### PR TITLE
Feature: support Discovery functionality `notifications/tools/list_changed`

### DIFF
--- a/examples/notifications_example.py
+++ b/examples/notifications_example.py
@@ -1,0 +1,49 @@
+"""
+This example shows how to test the different functionalities of MCPs using the MCP server.
+"""
+
+import asyncio
+
+from dotenv import load_dotenv
+from langchain_openai import ChatOpenAI
+
+from mcp_use import MCPAgent, MCPClient
+
+everything_server = {
+    "mcpServers": {
+        "everything": {
+            "command": "npx",
+            "args": ["-y", "@modelcontextprotocol/server-everything"],
+        }
+    }
+}
+
+
+async def main():
+    """Run the example using a configuration file."""
+    load_dotenv()
+    client = MCPClient(config=everything_server)
+    llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)
+    agent = MCPAgent(llm=llm, client=client, max_steps=5)
+
+    print("Initializing agent...")
+    print(f"Agent: {agent}")
+
+    result = await agent.run(
+        """
+        Hello, you are a tester, you have access to prompts, resources and tools.
+        Can you please test all the tools, prompts, and resources you have access to and return
+        the number of successful tests and the number of failed tests?
+        For each succesfful test also
+        return the return value of the tool. For each failed test, please return the error
+        message and the name of the feature that failed. For each resource,
+        can you please describe the content it returned? Also for promtps and tools.
+        Importantly, can you see the content of the images?
+        """,
+    )
+    print(f"\nResult: {result}")
+
+
+if __name__ == "__main__":
+    # Run the appropriate example
+    asyncio.run(main())

--- a/mcp_use/connectors/http.py
+++ b/mcp_use/connectors/http.py
@@ -5,7 +5,7 @@ This module provides a connector for communicating with MCP implementations
 through HTTP APIs with SSE for transport.
 """
 
-from mcp import ClientSession
+from mcp_use.sessions.mcp_use_client_session import McpUseClientSession
 
 from ..logging import logger
 from ..task_managers import SseConnectionManager
@@ -63,7 +63,12 @@ class HttpConnector(BaseConnector):
             read_stream, write_stream = await self._connection_manager.start()
 
             # Create the client session
-            self.client = ClientSession(read_stream, write_stream, sampling_callback=None)
+            self.client = McpUseClientSession(
+                read_stream,
+                write_stream,
+                sampling_callback=None,
+                message_handler=self._handle_client_message,
+            )
             await self.client.__aenter__()
 
             # Mark as connected

--- a/mcp_use/connectors/stdio.py
+++ b/mcp_use/connectors/stdio.py
@@ -7,7 +7,9 @@ through the standard input/output streams.
 
 import sys
 
-from mcp import ClientSession, StdioServerParameters
+from mcp import StdioServerParameters
+
+from mcp_use.sessions.mcp_use_client_session import McpUseClientSession
 
 from ..logging import logger
 from ..task_managers import StdioConnectionManager
@@ -60,8 +62,13 @@ class StdioConnector(BaseConnector):
             self._connection_manager = StdioConnectionManager(server_params, self.errlog)
             read_stream, write_stream = await self._connection_manager.start()
 
-            # Create the client session
-            self.client = ClientSession(read_stream, write_stream, sampling_callback=None)
+            # Create the client session with message handler
+            self.client = McpUseClientSession(
+                read_stream,
+                write_stream,
+                sampling_callback=None,
+                message_handler=self._handle_client_message,
+            )
             await self.client.__aenter__()
 
             # Mark as connected

--- a/mcp_use/sessions/mcp_use_client_session.py
+++ b/mcp_use/sessions/mcp_use_client_session.py
@@ -1,0 +1,125 @@
+import logging
+from typing import Any
+
+import mcp.types as types
+from mcp.client.session import ClientSession
+from mcp.shared.session import RequestResponder
+from mcp.types import JSONRPCNotification
+from pydantic import ValidationError
+
+# Define MessageType (reuse from client_session.py for consistency)
+MessageType = (
+    RequestResponder[types.ServerRequest, types.ClientResult]
+    | types.ServerNotification
+    | Exception
+    | JSONRPCNotification
+)
+
+
+class McpUseClientSession(ClientSession):
+    """
+    A patched version of ClientSession that gracefully handles unknown or non-standard
+    JSON-RPC notifications from the server.
+
+    Motivation:
+    -------------
+    The base ClientSession (and BaseSession) attempts to parse all incoming notifications
+    as known ServerNotification types using Pydantic. If the notification does not match
+    any known type (e.g., a server sends a custom notification like 'notifications/stderr'),
+    Pydantic raises a validation error and logs a warning, but does not forward the raw
+    notification to the client message handler.
+
+    This subclass overrides the _receive_loop method to catch validation errors when parsing
+    notifications. If validation fails, it forwards the raw JSONRPCNotification to the
+    message handler, allowing the client to handle or ignore unknown notifications as needed.
+    This prevents noisy Pydantic validation warnings and gives the client full visibility
+    into all notifications, even those not covered by the protocol schema.
+    """
+
+    async def _receive_loop(self) -> None:
+        """
+        Override the main receive loop to catch validation errors when parsing notifications.
+        If a notification cannot be parsed as a known type, forward the raw JSONRPCNotification
+        to the message handler instead of just logging a warning.
+        """
+        async with (
+            self._read_stream,
+            self._write_stream,
+        ):
+            async for message in self._read_stream:
+                if isinstance(message, Exception):
+                    await self._handle_incoming(message)
+                elif isinstance(message.message.root, types.JSONRPCRequest):
+                    validated_request = self._receive_request_type.model_validate(
+                        message.message.root.model_dump(
+                            by_alias=True, mode="json", exclude_none=True
+                        )
+                    )
+
+                    responder = RequestResponder(
+                        request_id=message.message.root.id,
+                        request_meta=validated_request.root.params.meta
+                        if validated_request.root.params
+                        else None,
+                        request=validated_request,
+                        session=self,
+                        on_complete=lambda r: self._in_flight.pop(r.request_id, None),
+                    )
+
+                    self._in_flight[responder.request_id] = responder
+                    await self._received_request(responder)
+
+                    if not responder._completed:  # type: ignore[reportPrivateUsage]
+                        await self._handle_incoming(responder)
+
+                elif isinstance(message.message.root, types.JSONRPCNotification):
+                    try:
+                        notification = self._receive_notification_type.model_validate(
+                            message.message.root.model_dump(
+                                by_alias=True, mode="json", exclude_none=True
+                            )
+                        )
+                        # Handle cancellation notifications if needed (optional)
+                        await self._received_notification(notification)
+                        await self._handle_incoming(notification)
+                    except Exception as e:
+                        # Instead of just logging, call your handler with the raw notification
+                        if self._message_handler:
+                            await self._message_handler(message.message.root)
+                        else:
+                            logging.warning(
+                                f"Failed to validate notification: {e}. "
+                                f"Message was: {message.message.root}"
+                            )
+                else:  # Response or error
+                    stream = self._response_streams.pop(message.message.root.id, None)
+                    if stream:
+                        await stream.send(message.message.root)
+                    else:
+                        await self._handle_incoming(
+                            RuntimeError(
+                                "Received response with an unknown " f"request ID: {message}"
+                            )
+                        )
+
+    async def _received_notification(self, notification: Any) -> None:
+        """
+        Override to ensure that if a notification is a raw JSONRPCNotification (not a known type),
+        it is still forwarded to the message handler.
+        """
+        try:
+            # Call parent notification handler first
+            await super()._received_notification(notification)
+
+        except (ValidationError, Exception):
+            # If the notification is a JSONRPCNotification, forward it to the message handler
+            if self._message_handler and isinstance(notification, JSONRPCNotification):
+                await self._message_handler(notification)
+
+    async def _handle_incoming(self, req: MessageType) -> None:
+        """
+        Override to ensure the message handler always receives the full MessageType union,
+        including raw JSONRPCNotification objects.
+        """
+        if self._message_handler:
+            await self._message_handler(req)

--- a/tests/unit/test_base_connector.py
+++ b/tests/unit/test_base_connector.py
@@ -1,0 +1,55 @@
+import unittest
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from mcp.types import JSONRPCNotification, Tool, ToolListChangedNotification
+
+from mcp_use.connectors.base import BaseConnector
+
+
+class DummyConnector(BaseConnector):
+    async def connect(self):
+        pass
+
+
+@patch("mcp_use.connectors.base.logger")
+class TestBaseConnectorToolDiscovery(IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.connector = DummyConnector()
+        self.connector.client = MagicMock()  # Simulate connected state
+
+    async def test_discovery_on_tool_list_changed_notification(self, mock_logger):
+        """
+        This test verifies that when the connector receives a ToolListChangedNotification
+        (with method="notifications/tools/list_changed"), it refreshes its tool list
+        by calling list_tools and updates its _tools cache accordingly. The test first
+        sets an initial tool list, then simulates a change in the available tools,
+        sends the notification, and checks that the connector's _tools is updated.
+        """
+        # Initial tools
+        mocked_tools1 = [Tool(name="tool1", description="desc1", inputSchema={})]
+        self.connector.list_tools = AsyncMock(return_value=mocked_tools1)
+
+        # Patch initialize to set up the initial tools
+        with patch.object(self.connector, "initialize", AsyncMock()):
+            await self.connector.initialize()
+            self.connector._tools = mocked_tools1  # Simulate initialize setting tools
+        self.assertEqual(self.connector._tools, mocked_tools1)
+
+        # Change tools to include a new tool
+        mocked_tools2 = [
+            Tool(name="tool1", description="desc1", inputSchema={}),
+            Tool(name="tool2", description="desc2", inputSchema={}),
+        ]
+        self.connector.list_tools = AsyncMock(return_value=mocked_tools2)
+
+        # Send notification to trigger discovery (notifications/tools/list_changed)
+        notification = ToolListChangedNotification(method="notifications/tools/list_changed")
+        await self.connector._handle_client_message(notification)
+
+        # Assert _tools is updated and contains both tools
+        self.assertEqual(self.connector._tools, mocked_tools2)
+        self.assertEqual(len(self.connector._tools), 2)
+        self.assertIn(mocked_tools2[0], self.connector._tools)
+        self.assertIn(mocked_tools2[1], self.connector._tools)


### PR DESCRIPTION
# Pull Request Description

## Changes

This PR introduces support for the Discovery functionality in the connector. The connector now listens for the notifications/tools/list_changed notification and refreshes its internal tool list accordingly. When a tool list change is detected, the connector calls list_tools and updates its _tools cache to reflect the current set of available tools.

## Documentation Updates

TODO: Add a usage/example section to the documentation to demonstrate how Discovery works in practice.

## Testing

Added and ran the unit test test_discovery_on_tool_list_changed_notification to verify that the connector correctly updates its tool list when a ToolListChangedNotification is received.
