### PR TITLE
Feature: Support for running MCP servers in a sandboxed cloud environment using E2B

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .[dev,anthropic,openai,search]
+          pip install .[dev,anthropic,openai,search,e2b]
       - name: Lint with ruff
         run: |
           ruff check .

--- a/docs/api-reference/introduction.mdx
+++ b/docs/api-reference/introduction.mdx
@@ -49,6 +49,60 @@ client = MCPClient.from_dict(config=config)
 | --------- | ---- | -------- | ---------------------------------------------- |
 | `config`  | dict | Yes      | Dictionary containing MCP server configuration |
 
+#### Sandboxed Execution
+
+Both `from_config_file` and `from_dict` methods support the `options` parameter for configuring client features, including sandboxed execution:
+
+```python
+from mcp_use import MCPClient
+from mcp_use.types.sandbox import SandboxOptions
+from mcp_use.types.clientoptions import ClientOptions
+
+# Define sandbox options
+sandbox_options: SandboxOptions = {
+    "api_key": "your_e2b_api_key",
+    "sandbox_template_id": "code-interpreter-v1"
+}
+
+# Create client options for sandboxed mode
+client_options: ClientOptions = {
+    "is_sandboxed": True,
+    "sandbox_options": sandbox_options
+}
+
+# Create client with sandboxed mode enabled
+client = MCPClient.from_config_file(
+    config_path="config.json",
+    options=client_options
+)
+```
+
+| Parameter | Type          | Required | Default | Description                                          |
+| --------- | ------------- | -------- | ------- | ---------------------------------------------------- |
+| `options` | ClientOptions | No       | {}      | Client configuration options, including sandbox mode |
+
+The `ClientOptions` type is a TypedDict with the following fields:
+
+| Field             | Type           | Required | Default | Description                                       |
+| ----------------- | -------------- | -------- | ------- | ------------------------------------------------- |
+| `is_sandboxed`    | bool           | No       | False   | Whether to run commands in a sandbox environment  |
+| `sandbox_options` | SandboxOptions | No       | None    | Configuration options for the sandbox environment |
+
+The `SandboxOptions` type supports the following options:
+
+| Option                 | Type | Required | Default               | Description                                                                              |
+| ---------------------- | ---- | -------- | --------------------- | ---------------------------------------------------------------------------------------- |
+| `api_key`              | str  | Yes      | None                  | E2B API key. Required - can be provided directly or via E2B_API_KEY environment variable |
+| `sandbox_template_id`  | str  | No       | "base"                | Template ID for the sandbox environment                                                  |
+| `supergateway_command` | str  | No       | "npx -y supergateway" | Command to run supergateway                                                              |
+
+**When to use sandboxed execution**:
+
+- When you want to run MCP servers without installing their dependencies locally
+- To ensure consistent execution environments across different systems
+- For improved security through isolation
+- To leverage cloud resources for resource-intensive MCP servers
+
 ### Core Methods
 
 #### create_session
@@ -133,22 +187,22 @@ agent = MCPAgent(
 )
 ```
 
-| Parameter                 | Type                | Required | Default | Description                                                  |
-| ------------------------- | ------------------- | -------- | ------- | ------------------------------------------------------------ |
-| `llm`                     | BaseLanguageModel   | Yes      | -       | Any LangChain-compatible language model                      |
-| `client`                  | MCPClient           | No       | None    | The MCPClient instance                                       |
-| `connectors`              | list[BaseConnector] | No       | None    | List of connectors if not using client                       |
-| `server_name`             | str                 | No       | None    | Name of the server to use                                    |
-| `max_steps`               | int                 | No       | 5       | Maximum number of steps the agent can take                   |
-| `auto_initialize`         | bool                | No       | False   | Whether to initialize automatically                          |
-| `memory_enabled`          | bool                | No       | True    | Whether to enable memory                                     |
-| `system_prompt`           | str                 | No       | None    | Custom system prompt                                         |
-| `system_prompt_template`  | str                 | No       | None    | Custom system prompt template                                |
-| `additional_instructions` | str                 | No       | None    | Additional instructions for the agent                        |
-| `session_options`         | dict                | No       | {}      | Additional options for session creation                      |
-| `output_parser`           | OutputParser        | No       | None    | Custom output parser for LLM responses                       |
+| Parameter                 | Type                | Required | Default | Description                                                                                                                                     |
+| ------------------------- | ------------------- | -------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `llm`                     | BaseLanguageModel   | Yes      | -       | Any LangChain-compatible language model                                                                                                         |
+| `client`                  | MCPClient           | No       | None    | The MCPClient instance                                                                                                                          |
+| `connectors`              | list[BaseConnector] | No       | None    | List of connectors if not using client                                                                                                          |
+| `server_name`             | str                 | No       | None    | Name of the server to use                                                                                                                       |
+| `max_steps`               | int                 | No       | 5       | Maximum number of steps the agent can take                                                                                                      |
+| `auto_initialize`         | bool                | No       | False   | Whether to initialize automatically                                                                                                             |
+| `memory_enabled`          | bool                | No       | True    | Whether to enable memory                                                                                                                        |
+| `system_prompt`           | str                 | No       | None    | Custom system prompt                                                                                                                            |
+| `system_prompt_template`  | str                 | No       | None    | Custom system prompt template                                                                                                                   |
+| `additional_instructions` | str                 | No       | None    | Additional instructions for the agent                                                                                                           |
+| `session_options`         | dict                | No       | {}      | Additional options for session creation                                                                                                         |
+| `output_parser`           | OutputParser        | No       | None    | Custom output parser for LLM responses                                                                                                          |
 | `use_server_manager`      | bool                | No       | False   | If `True`, enables automatic selection of the appropriate server based on the chosen tool when multiple servers are configured via `MCPClient`. |
-| `disallowed_tools`        | list[str]           | No       | None    | List of tool names that should not be available to the agent |
+| `disallowed_tools`        | list[str]           | No       | None    | List of tool names that should not be available to the agent                                                                                    |
 
 **When to use different parameters**:
 
@@ -459,3 +513,91 @@ This approach is useful when:
 - You want to limit the agent's capabilities for specific tasks
 - You're concerned about security implications of certain tools
 - You want to focus the agent on specific functionality
+
+### Sandboxed Execution with Multiple Servers
+
+Configure and use multiple sandboxed MCP servers:
+
+```python
+import os
+from dotenv import load_dotenv
+from mcp_use import MCPClient, MCPAgent
+from mcp_use.types.sandbox import SandboxOptions
+from langchain_anthropic import ChatAnthropic
+
+# Load environment variables
+load_dotenv()
+
+# Define sandbox options
+sandbox_options: SandboxOptions = {
+    "api_key": os.getenv("E2B_API_KEY"),
+    "sandbox_template_id": "code-interpreter-v1"
+}
+
+# Create client with multiple sandboxed servers
+client = MCPClient.from_dict(
+    {
+        "mcpServers": {
+            "browser": {
+                "command": "npx",
+                "args": ["@playwright/mcp@latest"]
+            },
+            "command": {
+                "command": "npx",
+                "args": ["-y", "@modelcontextprotocol/server-everything"]
+            }
+        }
+    },
+    is_sandboxed=True,
+    sandbox_options=sandbox_options
+)
+
+# Create agent with server manager enabled
+agent = MCPAgent(
+    llm=ChatAnthropic(model="claude-3-5-sonnet"),
+    client=client,
+    use_server_manager=True  # Automatically selects the appropriate server
+)
+
+# Run a task that will use tools from both servers
+result = await agent.run(
+    "Search for information about Python and then use the command line to check the latest version"
+)
+```
+
+This approach is useful when:
+
+- You need to use multiple MCP servers but don't want to install their dependencies locally
+- You want to ensure consistent execution environments for all servers
+- You need to leverage cloud resources for resource-intensive MCP servers
+
+## Error Handling
+
+mcp_use provides several exception types to handle different error scenarios:
+
+| Exception                | Description                       | When It Occurs                      |
+| ------------------------ | --------------------------------- | ----------------------------------- |
+| `MCPConnectionError`     | Connection to MCP server failed   | Network issues, server not running  |
+| `MCPAuthenticationError` | Authentication with server failed | Invalid credentials or tokens       |
+| `MCPTimeoutError`        | Operation timed out               | Server takes too long to respond    |
+| `MCPServerError`         | Server returned an error          | Internal server error               |
+| `MCPClientError`         | Client-side error                 | Invalid configuration or parameters |
+| `MCPError`               | Generic MCP-related error         | Any other MCP-related issue         |
+
+**Handling Strategies**:
+
+```python
+from mcp_use.exceptions import MCPConnectionError, MCPTimeoutError
+
+try:
+    result = await agent.run("Find information")
+except MCPConnectionError:
+    # Handle connection issues
+    print("Failed to connect to the MCP server")
+except MCPTimeoutError:
+    # Handle timeout issues
+    print("Operation timed out")
+except Exception as e:
+    # Handle other exceptions
+    print(f"An error occurred: {e}")
+```

--- a/docs/essentials/configuration.mdx
+++ b/docs/essentials/configuration.mdx
@@ -111,13 +111,99 @@ You can configure multiple MCP servers in a single configuration file, allowing 
     },
     "filesystem": {
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/home/pietro/projects/mcp-use/"]
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "/home/pietro/projects/mcp-use/"
+      ]
     }
   }
 }
 ```
 
 For a complete example of using multiple servers, see the [multi-server example](https://github.com/pietrozullo/mcp-use/blob/main/examples/multi_server_example.py) in our repository.
+
+## Sandboxed Execution
+
+mcp_use supports running MCP servers in a sandboxed cloud environment using E2B. This is useful when you want to run MCP servers without having to install their dependencies locally.
+
+### Installation
+
+To use sandboxed execution, you need to install the E2B dependency:
+
+```bash
+# Install mcp-use with E2B support
+pip install "mcp-use[e2b]"
+
+# Or install the dependency directly
+pip install e2b-code-interpreter
+```
+
+You'll also need an E2B API key. You can sign up at [e2b.dev](https://e2b.dev) to get your API key.
+
+### Configuration Example
+
+To enable sandboxed execution, use the `ClientOptions` parameter when creating the MCPClient:
+
+```python
+from mcp_use import MCPClient
+from mcp_use.types.sandbox import SandboxOptions
+from mcp_use.types.clientoptions import ClientOptions
+
+# Define sandbox options
+sandbox_options: SandboxOptions = {
+    "api_key": "your_e2b_api_key",  # Or use E2B_API_KEY environment variable
+    "sandbox_template_id": "code-interpreter-v1",
+    "supergateway_command": "npx -y supergateway"  # Optional, this is the default
+}
+
+# Create client options for sandboxed execution
+client_options: ClientOptions = {
+    "is_sandboxed": True,
+    "sandbox_options": sandbox_options
+}
+
+# Create client with sandboxed execution enabled
+client = MCPClient.from_dict(
+    {
+        "mcpServers": {
+            "command_line": {
+                "command": "npx",
+                "args": ["-y", "@modelcontextprotocol/server-everything"]
+            }
+        }
+    },
+    options=client_options
+)
+```
+
+### Available Sandbox Options
+
+The `SandboxOptions` type provides the following configuration options:
+
+| Option                 | Description                                                                              | Default               |
+| ---------------------- | ---------------------------------------------------------------------------------------- | --------------------- |
+| `api_key`              | E2B API key. Required - can be provided directly or via E2B_API_KEY environment variable | None                  |
+| `sandbox_template_id`  | Template ID for the sandbox environment                                                  | "base"                |
+| `supergateway_command` | Command to run supergateway                                                              | "npx -y supergateway" |
+
+### E2B API Key
+
+To use sandboxed execution, you need an E2B API key. You can provide it in two ways:
+
+1. Directly in the sandbox options:
+
+   ```python
+   sandbox_options = {"api_key": "your_e2b_api_key"}
+   ```
+
+2. Through the environment variable:
+   ```bash
+   # In your .env file or environment
+   E2B_API_KEY=your_e2b_api_key
+   ```
+
+For more details on connection types and sandbox configuration, see the [Connection Types](./connection-types) guide.
 
 ## Agent Configuration
 

--- a/docs/essentials/connection-types.mdx
+++ b/docs/essentials/connection-types.mdx
@@ -5,7 +5,7 @@ description: "Understanding the different connection types for MCP servers"
 
 # Connection Types for MCP Servers
 
-MCP servers can communicate with clients using different connection protocols, each with its own advantages and use cases. This guide explains the three primary connection types supported by mcp_use:
+MCP servers can communicate with clients using different connection protocols, each with its own advantages and use cases. This guide explains the primary connection types supported by mcp_use:
 
 ## Standard Input/Output (STDIO)
 
@@ -58,6 +58,66 @@ HTTP connections communicate with MCP servers over standard HTTP/HTTPS protocols
 }
 ```
 
+## Sandboxed Execution
+
+Sandboxed execution runs STDIO-based MCP servers in a cloud sandbox environment using E2B, rather than locally on your machine.
+
+### Installation
+
+To use sandboxed execution, you need to install the E2B dependency:
+
+```bash
+# Install mcp-use with E2B support
+pip install "mcp-use[e2b]"
+
+# Or install the dependency directly
+pip install e2b-code-interpreter
+```
+
+You'll also need an E2B API key. You can sign up at [e2b.dev](https://e2b.dev) to get your API key.
+
+### Characteristics:
+
+- **Cloud Execution**: The server runs in a secure cloud environment
+- **No Local Dependencies**: No need to install server dependencies locally
+- **Consistent Environment**: Same environment regardless of local setup
+- **Resource Isolation**: Server operations won't impact local system resources
+- **Secure Execution**: Sandbox provides isolation for security-sensitive operations
+
+### Configuration Example:
+
+```python
+from mcp_use import MCPClient
+from mcp_use.types.sandbox import SandboxOptions
+from mcp_use.types.clientoptions import ClientOptions
+
+# Define sandbox options
+sandbox_options: SandboxOptions = {
+    "api_key": "your_e2b_api_key",  # Or use E2B_API_KEY environment variable
+    "sandbox_template_id": "code-interpreter-v1"
+}
+
+# Create client options for sandboxed execution
+client_options: ClientOptions = {
+    "is_sandboxed": True,
+    "sandbox_options": sandbox_options
+}
+
+# Create client with sandboxed execution enabled
+client = MCPClient.from_dict(
+    {
+        "mcpServers": {
+            "sandboxed_server": {
+                "command": "npx",
+                "args": ["@my-mcp/server"],
+                "env": {}
+            }
+        }
+    },
+    options=client_options
+)
+```
+
 ## Choosing the Right Connection Type
 
 The choice of connection type depends on your specific use case:
@@ -65,6 +125,8 @@ The choice of connection type depends on your specific use case:
 1. **STDIO**: Best for local development, testing, and enhanced security scenarios where network exposure is a concern
 
 2. **HTTP**: Ideal for stateless operations, simple integrations, and when working with existing HTTP infrastructure
+
+3. **Sandboxed**: Best when you need to run MCP servers without installing their dependencies locally, or when you want consistent execution environments across different systems
 
 When configuring your mcp_use environment, you can specify the connection type in your configuration file as shown in the examples above.
 
@@ -74,14 +136,26 @@ Connection types are automatically inferred from your configuration file based o
 
 ```python
 from mcp_use import MCPClient
+from mcp_use.types.clientoptions import ClientOptions
 
 # The connection type is automatically inferred based on your config file
 client = MCPClient.from_config_file("config.json", server_name="my_server")
+
+# For sandboxed execution, use ClientOptions
+client_options: ClientOptions = {
+    "is_sandboxed": True,
+    "sandbox_options": {"api_key": "your_e2b_api_key"}
+}
+client = MCPClient.from_config_file(
+    "config.json",
+    options=client_options
+)
 ```
 
 For example:
 
-- If your configuration includes `command` and `args`, a STDIO connection will be used
+- If your configuration includes `command` and `args` and client_options has `"is_sandboxed": False` (default), a local STDIO connection will be used
+- If your configuration includes `command` and `args` and client_options has `"is_sandboxed": True`, a sandboxed execution connection will be used
 - If your configuration has a `url` starting with `http://` or `https://`, an HTTP connection will be used
 
 This automatic inference simplifies the configuration process and ensures the appropriate connection type is used without requiring explicit specification.

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -169,6 +169,79 @@ The adapter pattern makes it easy to:
 2. Filter or customize which tools are available
 3. Integrate with different agent frameworks
 
+## Sandboxed Execution
+
+MCP-Use supports running MCP servers in a sandboxed cloud environment using E2B. This allows you to run MCP servers without installing their dependencies locally.
+
+### Installation
+
+To use sandboxed execution, you need to install the E2B dependency:
+
+```bash
+# Install mcp-use with E2B support
+pip install "mcp-use[e2b]"
+
+# Or install the dependency directly
+pip install e2b-code-interpreter
+```
+
+You'll also need an E2B API key. You can sign up at [e2b.dev](https://e2b.dev) to get your API key.
+
+### Configuration
+
+To enable sandboxed execution, use the `ClientOptions` parameter when creating your `MCPClient`:
+
+```python
+import os
+from dotenv import load_dotenv
+from mcp_use import MCPClient
+from mcp_use.types.sandbox import SandboxOptions
+from mcp_use.types.clientoptions import ClientOptions
+
+# Load environment variables
+load_dotenv()
+
+# Define sandbox options
+sandbox_options: SandboxOptions = {
+    "api_key": os.getenv("E2B_API_KEY"),
+    "sandbox_template_id": "code-interpreter-v1"
+}
+
+# Create client options for sandboxed mode
+client_options: ClientOptions = {
+    "is_sandboxed": True,
+    "sandbox_options": sandbox_options
+}
+
+# Create client with sandboxed mode enabled
+client = MCPClient.from_dict(
+    {
+        "mcpServers": {
+            "everything": {
+                "command": "npx",
+                "args": ["-y", "@modelcontextprotocol/server-everything"]
+            }
+        }
+    },
+    options=client_options
+)
+```
+
+The `SandboxOptions` type provides the following configuration options:
+
+| Option                 | Description                                                                              | Default               |
+| ---------------------- | ---------------------------------------------------------------------------------------- | --------------------- |
+| `api_key`              | E2B API key. Required - can be provided directly or via E2B_API_KEY environment variable | None                  |
+| `sandbox_template_id`  | Template ID for the sandbox environment                                                  | "base"                |
+| `supergateway_command` | Command to run supergateway                                                              | "npx -y supergateway" |
+
+Sandboxed execution offers several benefits:
+
+- No need to install dependencies locally
+- Consistent execution environment
+- Isolation for security
+- Access to cloud resources
+
 ## Using Multiple Servers
 
 The `MCPClient` can be configured with multiple MCP servers, allowing your agent to access tools from different sources. This capability enables complex workflows spanning various domains (e.g., web browsing and API interaction).

--- a/examples/sandbox_everything.py
+++ b/examples/sandbox_everything.py
@@ -9,9 +9,12 @@ import os
 from dotenv import load_dotenv
 from langchain_openai import ChatOpenAI
 
+import mcp_use
 from mcp_use import MCPAgent, MCPClient
 from mcp_use.types.clientoptions import ClientOptions
 from mcp_use.types.sandbox import SandboxOptions
+
+mcp_use.set_debug(debug=1)
 
 # Server configuration (MCP standard compliant)
 sandboxed_server = {

--- a/examples/sandbox_everything.py
+++ b/examples/sandbox_everything.py
@@ -1,0 +1,66 @@
+"""
+This example shows how to test the different functionalities of MCPs using the MCP server from
+OpenAI in a sandboxed environment using E2B.
+"""
+
+import asyncio
+import os
+
+from dotenv import load_dotenv
+from langchain_openai import ChatOpenAI
+
+from mcp_use import MCPAgent, MCPClient
+from mcp_use.types.clientoptions import ClientOptions
+from mcp_use.types.sandbox import SandboxOptions
+
+# Server configuration (MCP standard compliant)
+sandboxed_server = {
+    "mcpServers": {
+        "everything": {
+            "command": "npx",
+            "args": ["-y", "@modelcontextprotocol/server-everything"],
+        }
+    }
+}
+
+
+async def main():
+    """Run the example using a sandboxed environment."""
+    # Load environment variables (needs E2B_API_KEY)
+    load_dotenv()
+
+    # Ensure E2B API key is available
+    if not os.getenv("E2B_API_KEY"):
+        raise ValueError("E2B_API_KEY environment variable is required")
+
+    # E2B sandbox options
+    sandbox_options: SandboxOptions = {
+        "api_key": os.getenv("E2B_API_KEY"),  # E2B API key to create the sandbox
+        "sandbox_template_id": "code-interpreter-v1",  # Use code interpreter template
+    }
+
+    client_options: ClientOptions = {"is_sandboxed": True, "sandbox_options": sandbox_options}
+
+    # Create client with sandboxed mode enabled and sandbox options
+    client = MCPClient(config=sandboxed_server, options=client_options)
+
+    # Create LLM and agent
+    llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)
+    agent = MCPAgent(llm=llm, client=client, max_steps=30)
+
+    try:
+        # Run the same test query
+        result = await agent.run(
+            """
+            Run echo "test" and then echo "second test" again and then add 1 + 1
+            """,
+            max_steps=30,
+        )
+        print(f"\nResult: {result}")
+    finally:
+        # Ensure we clean up resources properly
+        await client.close_all_sessions()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/mcp_use/connectors/__init__.py
+++ b/mcp_use/connectors/__init__.py
@@ -5,9 +5,16 @@ This module provides interfaces for connecting to MCP implementations
 through different transport mechanisms.
 """
 
-from .base import BaseConnector
-from .http import HttpConnector
-from .stdio import StdioConnector
-from .websocket import WebSocketConnector
+from .base import BaseConnector  # noqa: F401
+from .http import HttpConnector  # noqa: F401
+from .sandbox import SandboxConnector  # noqa: F401
+from .stdio import StdioConnector  # noqa: F401
+from .websocket import WebSocketConnector  # noqa: F401
 
-__all__ = ["BaseConnector", "StdioConnector", "WebSocketConnector", "HttpConnector"]
+__all__ = [
+    "BaseConnector",
+    "StdioConnector",
+    "HttpConnector",
+    "WebSocketConnector",
+    "SandboxConnector",
+]

--- a/mcp_use/connectors/sandbox.py
+++ b/mcp_use/connectors/sandbox.py
@@ -1,0 +1,297 @@
+"""
+Sandbox connector for MCP implementations.
+
+This module provides a connector for communicating with MCP implementations
+that are executed inside a sandbox environment (currently using E2B).
+"""
+
+import asyncio
+import os
+import sys
+import time
+
+import aiohttp
+from mcp import ClientSession
+
+from ..logging import logger
+from ..task_managers import SseConnectionManager
+
+# Import E2B SDK components (optional dependency)
+try:
+    logger.debug("Attempting to import e2b_code_interpreter...")
+    from e2b_code_interpreter import (
+        AsyncCommandHandle,
+        AsyncSandbox,
+        CommandHandle,
+        CommandResult,
+        OutputMessage,
+        Sandbox,
+    )
+
+    logger.debug("Successfully imported e2b_code_interpreter")
+except ImportError as e:
+    logger.error(f"Failed to import e2b_code_interpreter: {e}")
+    AsyncSandbox = None
+    OutputMessage = None
+    CommandResult = None
+    AsyncCommandHandle = None
+
+from ..types.sandbox import SandboxOptions
+from .base import BaseConnector
+
+
+class SandboxConnector(BaseConnector):
+    """Connector for MCP implementations running in a sandbox environment.
+
+    This connector runs a user-defined stdio command within a sandbox environment,
+    currently implemented using E2B, potentially wrapped by a utility like 'supergateway'
+    to expose its stdio.
+    """
+
+    def __init__(
+        self,
+        command: str,
+        args: list[str],
+        env: dict[str, str] | None = None,
+        e2b_options: SandboxOptions | None = None,
+        timeout: float = 5,
+        sse_read_timeout: float = 60 * 5,
+    ):
+        """Initialize a new sandbox connector.
+
+        Args:
+            command: The user's MCP server command to execute in the sandbox.
+            args: Command line arguments for the user's MCP server command.
+            env: Environment variables for the user's MCP server command.
+            e2b_options: Configuration options for the E2B sandbox environment.
+                        See SandboxOptions for available options and defaults.
+            timeout: Timeout for the sandbox process in seconds.
+            sse_read_timeout: Timeout for the SSE connection in seconds.
+        """
+        super().__init__()
+        if AsyncSandbox is None:
+            raise ImportError(
+                "E2B SDK (e2b-code-interpreter) not found. "
+                "Please install it with 'pip install mcp-use[e2b]' "
+                "(or 'pip install e2b-code-interpreter')."
+            )
+
+        self.user_command = command
+        self.user_args = args or []
+        self.user_env = env or {}
+
+        _e2b_options = e2b_options or {}
+
+        self.api_key = _e2b_options.get("api_key") or os.environ.get("E2B_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "E2B API key is required. Provide it via 'e2b_options.api_key' "
+                "or the E2B_API_KEY environment variable."
+            )
+
+        self.sandbox_template_id = _e2b_options.get("sandbox_template_id", "base")
+        self.supergateway_cmd_parts = _e2b_options.get(
+            "supergateway_command", "npx -y supergateway"
+        )
+
+        self.sandbox: Sandbox | None = None
+        self.process: CommandHandle | None = None
+        self.client: ClientSession | None = None
+        self.errlog = sys.stderr
+        self.base_url: str | None = None
+        self._connected = False
+        self._connection_manager: SseConnectionManager | None = None
+
+        # SSE connection parameters
+        self.headers = {}
+        self.timeout = timeout
+        self.sse_read_timeout = sse_read_timeout
+
+        self.stdout_lines: list[str] = []
+        self.stderr_lines: list[str] = []
+        self._server_ready = asyncio.Event()
+
+    def _handle_stdout(self, data: str) -> None:
+        """Handle stdout data from the sandbox process."""
+        self.stdout_lines.append(data)
+        logger.debug(f"[SANDBOX STDOUT] {data}", end="", flush=True)
+
+    def _handle_stderr(self, data: str) -> None:
+        """Handle stderr data from the sandbox process."""
+        self.stderr_lines.append(data)
+        logger.debug(f"[SANDBOX STDERR] {data}", file=self.errlog, end="", flush=True)
+
+    async def wait_for_server_response(self, base_url: str, timeout: int = 30) -> bool:
+        """Wait for the server to respond to HTTP requests.
+        Args:
+            base_url: The base URL to check for server readiness
+            timeout: Maximum time to wait in seconds
+        Returns:
+            True if server is responding, raises TimeoutError otherwise
+        """
+        print(f"Waiting for server at {base_url} to respond...")
+        sys.stdout.flush()
+
+        start_time = time.time()
+        ping_url = f"{base_url}/sse"
+
+        # Try to connect to the server
+        while time.time() - start_time < timeout:
+            try:
+                async with aiohttp.ClientSession() as session:
+                    try:
+                        # First try the endpoint
+                        async with session.get(ping_url, timeout=2) as response:
+                            if response.status == 200:
+                                elapsed = time.time() - start_time
+                                print(
+                                    f"Server is ready! "
+                                    f"SSE endpoint responded with 200 after {elapsed:.1f}s"
+                                )
+                                return True
+                    except Exception:
+                        # If sse endpoint doesn't work, try the base URL
+                        async with session.get(base_url, timeout=2) as response:
+                            if response.status < 500:  # Accept any non-server error
+                                elapsed = time.time() - start_time
+                                print(
+                                    f"Server is ready! Base URL responded with "
+                                    f"{response.status} after {elapsed:.1f}s"
+                                )
+                                return True
+            except Exception:
+                # Wait a bit before trying again
+                await asyncio.sleep(0.5)
+                continue
+
+            # If we get here, the request failed
+            await asyncio.sleep(0.5)
+
+            # Log status every 5 seconds
+            elapsed = time.time() - start_time
+            if int(elapsed) % 5 == 0:
+                print(f"Still waiting for server to respond... ({elapsed:.1f}s elapsed)")
+                sys.stdout.flush()
+
+        # If we get here, we timed out
+        raise TimeoutError(f"Timeout waiting for server to respond (waited {timeout} seconds)")
+
+    async def connect(self):
+        """Connect to the sandbox and start the MCP server."""
+
+        if self._connected:
+            logger.debug("Already connected to MCP implementation")
+            return
+
+        logger.debug("Connecting to MCP implementation in sandbox")
+
+        try:
+            # Create and start the sandbox
+            self.sandbox = Sandbox(
+                template=self.sandbox_template_id,
+                api_key=self.api_key,
+            )
+
+            # Get the host for the sandbox
+            host = self.sandbox.get_host(3000)
+            self.base_url = f"https://{host}".rstrip("/")
+
+            # Append command with args
+            command = f"{self.user_command} {' '.join(self.user_args)}"
+
+            # Construct the full command with supergateway
+            full_command = f'{self.supergateway_cmd_parts} \
+                --base-url {self.base_url} \
+                --port 3000 \
+                --cors \
+                --stdio "{command}"'
+
+            logger.debug(f"Full command: {full_command}")
+
+            # Start the process in the sandbox with our stdout/stderr handlers
+            self.process: CommandHandle = self.sandbox.commands.run(
+                full_command,
+                envs=self.user_env,
+                timeout=1000 * 60 * 10,  # 10 minutes timeout
+                background=True,
+                on_stdout=self._handle_stdout,
+                on_stderr=self._handle_stderr,
+            )
+
+            # Wait for the server to be ready
+            await self.wait_for_server_response(self.base_url, timeout=30)
+            logger.debug("Initializing connection manager...")
+
+            # Create the SSE connection URL
+            sse_url = f"{self.base_url}/sse"
+
+            # Create and start the connection manager
+            self._connection_manager = SseConnectionManager(
+                sse_url, self.headers, self.timeout, self.sse_read_timeout
+            )
+            read_stream, write_stream = await self._connection_manager.start()
+
+            # Create the client session
+            self.client = ClientSession(read_stream, write_stream, sampling_callback=None)
+            await self.client.__aenter__()
+
+            # Mark as connected
+            self._connected = True
+            logger.debug(
+                f"Successfully connected to MCP implementation via HTTP/SSE: {self.base_url}"
+            )
+
+        except Exception as e:
+            logger.error(f"Failed to connect to MCP implementation: {e}")
+
+            # Clean up any resources if connection failed
+            await self._cleanup_resources()
+
+            raise e
+
+    async def _cleanup_resources(self) -> None:
+        """Clean up all resources associated with this connector, including the sandbox.
+        This method extends the base implementation to also terminate the sandbox instance
+        and clean up any processes running in the sandbox.
+        """
+        logger.debug("Cleaning up sandbox resources")
+
+        # Terminate any running process
+        if self.process:
+            try:
+                logger.debug("Terminating sandbox process")
+                self.process.kill()
+            except Exception as e:
+                logger.warning(f"Error terminating sandbox process: {e}")
+            finally:
+                self.process = None
+
+        # Close the sandbox
+        if self.sandbox:
+            try:
+                logger.debug("Closing sandbox instance")
+                self.sandbox.kill()
+                logger.debug("Sandbox instance closed successfully")
+            except Exception as e:
+                logger.warning(f"Error closing sandbox: {e}")
+            finally:
+                self.sandbox = None
+
+        # Then call the parent method to clean up the rest
+        await super()._cleanup_resources()
+
+        # Clear any collected output
+        self.stdout_lines = []
+        self.stderr_lines = []
+        self.base_url = None
+
+    async def disconnect(self) -> None:
+        """Close the connection to the MCP implementation."""
+        if not self._connected:
+            logger.debug("Not connected to MCP implementation")
+            return
+
+        logger.debug("Disconnecting from MCP implementation")
+        await self._cleanup_resources()
+        self._connected = False
+        logger.debug("Disconnected from MCP implementation")

--- a/mcp_use/connectors/sandbox.py
+++ b/mcp_use/connectors/sandbox.py
@@ -20,21 +20,15 @@ from ..task_managers import SseConnectionManager
 try:
     logger.debug("Attempting to import e2b_code_interpreter...")
     from e2b_code_interpreter import (
-        AsyncCommandHandle,
-        AsyncSandbox,
         CommandHandle,
-        CommandResult,
-        OutputMessage,
         Sandbox,
     )
 
     logger.debug("Successfully imported e2b_code_interpreter")
 except ImportError as e:
-    logger.error(f"Failed to import e2b_code_interpreter: {e}")
-    AsyncSandbox = None
-    OutputMessage = None
-    CommandResult = None
-    AsyncCommandHandle = None
+    logger.debug(f"Failed to import e2b_code_interpreter: {e}")
+    CommandHandle = None
+    Sandbox = None
 
 from ..types.sandbox import SandboxOptions
 from .base import BaseConnector
@@ -69,7 +63,7 @@ class SandboxConnector(BaseConnector):
             sse_read_timeout: Timeout for the SSE connection in seconds.
         """
         super().__init__()
-        if AsyncSandbox is None:
+        if Sandbox is None:
             raise ImportError(
                 "E2B SDK (e2b-code-interpreter) not found. "
                 "Please install it with 'pip install mcp-use[e2b]' "
@@ -129,7 +123,7 @@ class SandboxConnector(BaseConnector):
         Returns:
             True if server is responding, raises TimeoutError otherwise
         """
-        print(f"Waiting for server at {base_url} to respond...")
+        logger.info(f"Waiting for server at {base_url} to respond...")
         sys.stdout.flush()
 
         start_time = time.time()
@@ -144,7 +138,7 @@ class SandboxConnector(BaseConnector):
                         async with session.get(ping_url, timeout=2) as response:
                             if response.status == 200:
                                 elapsed = time.time() - start_time
-                                print(
+                                logger.info(
                                     f"Server is ready! "
                                     f"SSE endpoint responded with 200 after {elapsed:.1f}s"
                                 )
@@ -154,7 +148,7 @@ class SandboxConnector(BaseConnector):
                         async with session.get(base_url, timeout=2) as response:
                             if response.status < 500:  # Accept any non-server error
                                 elapsed = time.time() - start_time
-                                print(
+                                logger.info(
                                     f"Server is ready! Base URL responded with "
                                     f"{response.status} after {elapsed:.1f}s"
                                 )
@@ -170,7 +164,7 @@ class SandboxConnector(BaseConnector):
             # Log status every 5 seconds
             elapsed = time.time() - start_time
             if int(elapsed) % 5 == 0:
-                print(f"Still waiting for server to respond... ({elapsed:.1f}s elapsed)")
+                logger.info(f"Still waiting for server to respond... ({elapsed:.1f}s elapsed)")
                 sys.stdout.flush()
 
         # If we get here, we timed out

--- a/mcp_use/connectors/utils.py
+++ b/mcp_use/connectors/utils.py
@@ -1,0 +1,13 @@
+from typing import Any
+
+
+def is_stdio_server(server_config: dict[str, Any]) -> bool:
+    """Check if the server configuration is for a stdio server.
+
+    Args:
+        server_config: The server configuration section
+
+    Returns:
+        True if the server is a stdio server, False otherwise
+    """
+    return "command" in server_config and "args" in server_config

--- a/mcp_use/types/clientoptions.py
+++ b/mcp_use/types/clientoptions.py
@@ -1,0 +1,23 @@
+"""
+Options for MCP client configuration.
+
+This module provides data classes and type definitions for configuring the MCP client.
+"""
+
+from typing import NotRequired, TypedDict
+
+from .sandbox import SandboxOptions
+
+
+class ClientOptions(TypedDict):
+    """Options for configuring the MCP client.
+
+    This class encapsulates all configuration options for the MCPClient,
+    making it easier to extend the API without breaking backward compatibility.
+    """
+
+    is_sandboxed: NotRequired[bool]
+    """Whether to use sandboxed execution mode for running MCP servers."""
+
+    sandbox_options: NotRequired[SandboxOptions]
+    """Options for sandbox configuration when is_sandboxed=True."""

--- a/mcp_use/types/sandbox.py
+++ b/mcp_use/types/sandbox.py
@@ -1,0 +1,23 @@
+"""Type definitions for sandbox-related configurations."""
+
+from typing import NotRequired, TypedDict
+
+
+class SandboxOptions(TypedDict):
+    """Configuration options for sandbox execution.
+
+    This type defines the configuration options available when running
+    MCP servers in a sandboxed environment (e.g., using E2B).
+    """
+
+    api_key: str
+    """Direct API key for sandbox provider (e.g., E2B API key).
+    If not provided, will use E2B_API_KEY environment variable."""
+
+    sandbox_template_id: NotRequired[str]
+    """Template ID for the sandbox environment.
+    Default: 'base'"""
+
+    supergateway_command: NotRequired[str]
+    """Command to run supergateway.
+    Default: 'npx -y supergateway'"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ openai = [
 search = [
     "fastembed>=0.0.1",
 ]
+e2b = [
+    "e2b-code-interpreter>=1.5.0",
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -13,7 +13,7 @@ select = [
 
 [lint.per-file-ignores]
 "__init__.py" = ["F401"]  # Unused imports
-"tests/**/*.py" = ["F811", "F401"]  # Redefinition in test files
+"tests/**/*.py" = ["F811", "F401", "B017"]  # Redefinition in test files
 "mcp_use/connectors/websocket.py" = ["C901"]  # Function too complex
 
 [lint.isort]

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -218,7 +218,7 @@ class TestMCPClientSessionManagement:
         await client.create_session("server1")
 
         # Verify behavior
-        mock_create_connector.assert_called_once_with({"url": "http://server1.com"})
+        mock_create_connector.assert_called_once_with({"url": "http://server1.com"}, options={})
         mock_session_class.assert_called_once_with(mock_connector)
         mock_session.initialize.assert_called_once()
 
@@ -271,7 +271,7 @@ class TestMCPClientSessionManagement:
         await client.create_session("server1", auto_initialize=False)
 
         # Verify behavior
-        mock_create_connector.assert_called_once_with({"url": "http://server1.com"})
+        mock_create_connector.assert_called_once_with({"url": "http://server1.com"}, options={})
         mock_session_class.assert_called_once_with(mock_connector)
         mock_session.initialize.assert_not_called()
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -9,7 +9,8 @@ import unittest
 from unittest.mock import patch
 
 from mcp_use.config import create_connector_from_config, load_config_file
-from mcp_use.connectors import HttpConnector, StdioConnector, WebSocketConnector
+from mcp_use.connectors import HttpConnector, SandboxConnector, StdioConnector, WebSocketConnector
+from mcp_use.types.clientoptions import ClientOptions
 
 
 class TestConfigLoading(unittest.TestCase):
@@ -59,6 +60,25 @@ class TestConnectorCreation(unittest.TestCase):
         )
         self.assertEqual(connector.auth_token, "test_token")
 
+    def test_create_http_connector_with_options(self):
+        """Test creating an HTTP connector with options."""
+        server_config = {
+            "url": "http://test.com",
+            "headers": {"Content-Type": "application/json"},
+            "auth_token": "test_token",
+        }
+        options: ClientOptions = {"is_sandboxed": False}
+
+        connector = create_connector_from_config(server_config, options)
+
+        self.assertIsInstance(connector, HttpConnector)
+        self.assertEqual(connector.base_url, "http://test.com")
+        self.assertEqual(
+            connector.headers,
+            {"Content-Type": "application/json", "Authorization": "Bearer test_token"},
+        )
+        self.assertEqual(connector.auth_token, "test_token")
+
     def test_create_http_connector_minimal(self):
         """Test creating an HTTP connector with minimal config."""
         server_config = {"url": "http://test.com"}
@@ -79,6 +99,25 @@ class TestConnectorCreation(unittest.TestCase):
         }
 
         connector = create_connector_from_config(server_config)
+
+        self.assertIsInstance(connector, WebSocketConnector)
+        self.assertEqual(connector.url, "ws://test.com")
+        self.assertEqual(
+            connector.headers,
+            {"Content-Type": "application/json", "Authorization": "Bearer test_token"},
+        )
+        self.assertEqual(connector.auth_token, "test_token")
+
+    def test_create_websocket_connector_with_options(self):
+        """Test creating a WebSocket connector with options."""
+        server_config = {
+            "ws_url": "ws://test.com",
+            "headers": {"Content-Type": "application/json"},
+            "auth_token": "test_token",
+        }
+        options: ClientOptions = {"is_sandboxed": False}
+
+        connector = create_connector_from_config(server_config, options)
 
         self.assertIsInstance(connector, WebSocketConnector)
         self.assertEqual(connector.url, "ws://test.com")
@@ -113,6 +152,45 @@ class TestConnectorCreation(unittest.TestCase):
         self.assertEqual(connector.command, "python")
         self.assertEqual(connector.args, ["-m", "mcp_server"])
         self.assertEqual(connector.env, {"DEBUG": "1"})
+
+    def test_create_stdio_connector_with_options(self):
+        """Test creating a stdio connector with options."""
+        server_config = {
+            "command": "python",
+            "args": ["-m", "mcp_server"],
+            "env": {"DEBUG": "1"},
+        }
+        options: ClientOptions = {"is_sandboxed": False}
+
+        connector = create_connector_from_config(server_config, options)
+
+        self.assertIsInstance(connector, StdioConnector)
+        self.assertEqual(connector.command, "python")
+        self.assertEqual(connector.args, ["-m", "mcp_server"])
+        self.assertEqual(connector.env, {"DEBUG": "1"})
+
+    def test_create_sandboxed_stdio_connector(self):
+        """Test creating a sandboxed stdio connector."""
+        server_config = {
+            "command": "python",
+            "args": ["-m", "mcp_server"],
+            "env": {"DEBUG": "1"},
+        }
+        options: ClientOptions = {
+            "is_sandboxed": True,
+            "sandbox_options": {"api_key": "test_key", "sandbox_template_id": "test_template"},
+        }
+
+        # Use patch to avoid the actual E2B SDK import check
+        with patch("mcp_use.connectors.sandbox.AsyncSandbox", create=True):
+            connector = create_connector_from_config(server_config, options)
+
+            self.assertIsInstance(connector, SandboxConnector)
+            self.assertEqual(connector.user_command, "python")
+            self.assertEqual(connector.user_args, ["-m", "mcp_server"])
+            self.assertEqual(connector.user_env, {"DEBUG": "1"})
+            self.assertEqual(connector.api_key, "test_key")
+            self.assertEqual(connector.sandbox_template_id, "test_template")
 
     def test_create_stdio_connector_minimal(self):
         """Test creating a stdio connector with minimal config."""

--- a/tests/unit/test_sandbox_connector.py
+++ b/tests/unit/test_sandbox_connector.py
@@ -1,0 +1,308 @@
+"""
+Unit tests for the SandboxConnector class.
+"""
+
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+
+# Use MagicMock instead of importing from mcp.types
+# from mcp.types import CallToolResult, Tool
+from mcp_use.connectors.sandbox import SandboxConnector
+from mcp_use.task_managers import SseConnectionManager
+from mcp_use.types.sandbox import SandboxOptions
+
+
+# Mock the sandbox module for tests
+class MockCommandHandle:
+    def __init__(self):
+        self.exit_code = 0
+        self.is_completed = True
+
+    def kill(self):
+        pass
+
+
+class MockSandbox:
+    def __init__(self, *args, **kwargs):
+        self.commands = MagicMock()
+        self.commands.run = MagicMock(return_value=MockCommandHandle())
+
+    def get_host(self, port):
+        return "test-host.sandbox.e2b.dev"
+
+    def kill(self):
+        pass
+
+
+@pytest.fixture(autouse=True)
+def mock_logger():
+    """Mock the logger to prevent errors during tests."""
+    with (
+        patch("mcp_use.connectors.base.logger") as mock_base_logger,
+        patch("mcp_use.connectors.sandbox.logger") as mock_sandbox_logger,
+    ):
+        # Set level attribute to an integer for comparison in the logger
+        mock_sandbox_logger.handlers = []
+        mock_base_logger.handlers = []
+        yield mock_sandbox_logger
+
+
+@pytest.fixture
+def mock_sandbox_modules():
+    """Mock the E2B sandbox modules."""
+    with (
+        patch("mcp_use.connectors.sandbox.Sandbox", MockSandbox),
+        patch("mcp_use.connectors.sandbox.CommandHandle", MockCommandHandle),
+    ):
+        yield
+
+
+@pytest.fixture
+def mock_os_environ():
+    """Fixture to mock os.environ."""
+    with patch.dict(os.environ, {"E2B_API_KEY": "test-api-key"}, clear=False):
+        yield
+
+
+class TestSandboxConnectorInitialization:
+    """Tests for SandboxConnector initialization."""
+
+    def test_init_with_api_key(self, mock_sandbox_modules):
+        """Test initialization with API key in sandbox options."""
+        sandbox_options = SandboxOptions(api_key="test-api-key")
+        connector = SandboxConnector("npx", ["test-command"], e2b_options=sandbox_options)
+
+        assert connector.api_key == "test-api-key"
+        assert connector.sandbox_template_id == "base"
+        assert connector.supergateway_cmd_parts == "npx -y supergateway"
+        assert connector.user_command == "npx"
+        assert connector.user_args == ["test-command"]
+        assert not connector._connected
+
+    def test_init_with_env_api_key(self, mock_sandbox_modules, mock_os_environ):
+        """Test initialization with API key from environment."""
+        connector = SandboxConnector("npx", ["test-command"])
+
+        assert connector.api_key == "test-api-key"
+        assert connector.sandbox_template_id == "base"
+        assert connector.user_command == "npx"
+        assert connector.user_args == ["test-command"]
+        assert not connector._connected
+
+    def test_init_missing_api_key(self, mock_sandbox_modules):
+        """Test initialization fails with missing API key."""
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(ValueError, match="E2B API key is required"):
+                SandboxConnector("npx", ["test-command"])
+
+    def test_init_with_custom_options(self, mock_sandbox_modules):
+        """Test initialization with custom sandbox options."""
+        sandbox_options = SandboxOptions(
+            api_key="test-api-key",
+            sandbox_template_id="custom-template",
+            supergateway_command="custom-gateway-command",
+        )
+        connector = SandboxConnector("npx", ["test-command"], e2b_options=sandbox_options)
+
+        assert connector.api_key == "test-api-key"
+        assert connector.sandbox_template_id == "custom-template"
+        assert connector.supergateway_cmd_parts == "custom-gateway-command"
+
+
+class TestSandboxConnectorConnection:
+    """Tests for SandboxConnector connection methods."""
+
+    @pytest.mark.asyncio
+    @patch("mcp_use.connectors.sandbox.SseConnectionManager")
+    @patch("mcp_use.connectors.sandbox.ClientSession")
+    async def test_connect(
+        self, mock_client_session, mock_connection_manager, mock_sandbox_modules
+    ):
+        """Test connecting to the MCP implementation in sandbox."""
+        # Setup mocks
+        mock_manager_instance = Mock(spec=SseConnectionManager)
+        mock_manager_instance.start = AsyncMock(return_value=("read_stream", "write_stream"))
+        mock_connection_manager.return_value = mock_manager_instance
+
+        mock_client_instance = Mock()
+        mock_client_instance.__aenter__ = AsyncMock()
+        mock_client_session.return_value = mock_client_instance
+
+        # Mock wait_for_server_response to avoid actual HTTP calls
+        with patch.object(
+            SandboxConnector, "wait_for_server_response", new_callable=AsyncMock, return_value=True
+        ):
+            # Create connector and connect
+            sandbox_options = SandboxOptions(api_key="test-api-key")
+            connector = SandboxConnector("npx", ["test-command"], e2b_options=sandbox_options)
+            await connector.connect()
+
+            # Verify sandbox creation
+            assert connector.sandbox is not None
+
+            # Verify connection manager creation and start
+            mock_connection_manager.assert_called_once()
+            mock_manager_instance.start.assert_called_once()
+
+            # Verify client session creation
+            mock_client_session.assert_called_once_with(
+                "read_stream", "write_stream", sampling_callback=None
+            )
+            mock_client_instance.__aenter__.assert_called_once()
+
+            # Verify state
+            assert connector._connected is True
+            assert connector.client == mock_client_instance
+            assert connector._connection_manager == mock_manager_instance
+            assert connector.base_url == "https://test-host.sandbox.e2b.dev"
+
+    @pytest.mark.asyncio
+    async def test_connect_already_connected(self, mock_sandbox_modules):
+        """Test connecting when already connected."""
+        sandbox_options = SandboxOptions(api_key="test-api-key")
+        connector = SandboxConnector("npx", ["test-command"], e2b_options=sandbox_options)
+        connector._connected = True
+
+        await connector.connect()
+
+        # Verify no connection established since already connected
+        assert connector._connection_manager is None
+        assert connector.client is None
+        assert connector.sandbox is None
+
+    @pytest.mark.asyncio
+    @patch("mcp_use.connectors.sandbox.logger")
+    @patch("mcp_use.connectors.sandbox.Sandbox")
+    async def test_connect_error(self, mock_sandbox_class, mock_logger, mock_sandbox_modules):
+        """Test connection error handling."""
+        # Setup mocks to raise an exception during sandbox creation
+        mock_sandbox_instance = MagicMock()
+        mock_sandbox_instance.get_host.side_effect = Exception("Sandbox creation error")
+        mock_sandbox_class.return_value = mock_sandbox_instance
+
+        # Create connector and attempt to connect
+        sandbox_options = SandboxOptions(api_key="test-api-key")
+        connector = SandboxConnector("npx", ["test-command"], e2b_options=sandbox_options)
+
+        # Mock cleanup to avoid errors during exception handling
+        connector._cleanup_resources = AsyncMock()
+
+        # Expect the exception to be re-raised
+        with pytest.raises(Exception):
+            await connector.connect()
+
+        # Verify resources were cleaned up
+        connector._cleanup_resources.assert_called_once()
+        assert connector._connected is False
+        assert connector.client is None
+
+    @pytest.mark.asyncio
+    async def test_disconnect(self, mock_sandbox_modules):
+        """Test disconnecting from MCP implementation."""
+        sandbox_options = SandboxOptions(api_key="test-api-key")
+        connector = SandboxConnector("npx", ["test-command"], e2b_options=sandbox_options)
+        connector._connected = True
+
+        # Mock the _cleanup_resources method to replace the actual method
+        connector._cleanup_resources = AsyncMock()
+
+        # Disconnect
+        await connector.disconnect()
+
+        # Verify _cleanup_resources was called
+        connector._cleanup_resources.assert_called_once()
+
+        # Verify state
+        assert connector._connected is False
+
+
+class TestSandboxConnectorCleanup:
+    """Tests for SandboxConnector cleanup methods."""
+
+    @pytest.mark.asyncio
+    async def test_cleanup_resources(self, mock_sandbox_modules):
+        """Test cleanup of all resources."""
+        # Create connector with resources to clean up
+        sandbox_options = SandboxOptions(api_key="test-api-key")
+        connector = SandboxConnector("npx", ["test-command"], e2b_options=sandbox_options)
+
+        # Set up mock resources
+        process_mock = MagicMock()
+        process_mock.kill = MagicMock()
+        connector.process = process_mock
+
+        sandbox_mock = MagicMock()
+        sandbox_mock.kill = MagicMock()
+        connector.sandbox = sandbox_mock
+
+        # Mock super()._cleanup_resources method
+        with patch(
+            "mcp_use.connectors.base.BaseConnector._cleanup_resources", new_callable=AsyncMock
+        ) as mock_super_cleanup:
+            # Call cleanup
+            await connector._cleanup_resources()
+
+            # Verify process was terminated
+            process_mock.kill.assert_called_once()
+
+            # Verify sandbox was closed
+            sandbox_mock.kill.assert_called_once()
+
+            # Verify parent cleanup was called
+            mock_super_cleanup.assert_called_once()
+
+            # Verify state changes
+            assert connector.sandbox is None
+            assert connector.process is None
+            assert connector.stdout_lines == []
+            assert connector.stderr_lines == []
+            assert connector.base_url is None
+
+    @pytest.mark.asyncio
+    @patch("mcp_use.connectors.sandbox.logger")
+    async def test_cleanup_resources_with_exceptions(self, mock_logger, mock_sandbox_modules):
+        """Test cleanup handles exceptions gracefully."""
+        # Create connector with resources to clean up
+        sandbox_options = SandboxOptions(api_key="test-api-key")
+        connector = SandboxConnector("npx", ["test-command"], e2b_options=sandbox_options)
+
+        # Set up mock resources that will raise exceptions
+        process_mock = MagicMock()
+        process_mock.kill = MagicMock(side_effect=Exception("Process kill error"))
+        connector.process = process_mock
+
+        sandbox_mock = MagicMock()
+        sandbox_mock.kill = MagicMock(side_effect=Exception("Sandbox kill error"))
+        connector.sandbox = sandbox_mock
+
+        # Configure logger to avoid test errors
+        mock_logger.warning = MagicMock()
+
+        # Mock super()._cleanup_resources method
+        with patch(
+            "mcp_use.connectors.base.BaseConnector._cleanup_resources", new_callable=AsyncMock
+        ) as mock_super_cleanup:
+            # Call cleanup
+            await connector._cleanup_resources()
+
+            # Verify process termination was attempted even though it errored
+            process_mock.kill.assert_called_once()
+
+            # Verify sandbox close was attempted even though it errored
+            sandbox_mock.kill.assert_called_once()
+
+            # Verify warnings were logged
+            assert mock_logger.warning.call_count == 2
+
+            # Verify parent cleanup was still called
+            mock_super_cleanup.assert_called_once()
+
+            # Verify state changes
+            assert connector.sandbox is None
+            assert connector.process is None
+            assert connector.stdout_lines == []
+            assert connector.stderr_lines == []
+            assert connector.base_url is None


### PR DESCRIPTION
# Pull Request Description

## Changes

This PR adds support for running MCP servers in a sandboxed cloud environment using E2B. The implementation allows users to run MCP servers without installing dependencies locally, making it easier to use tools with complex setups.

## Implementation Details

1. Added a new `SandboxConnector` class that creates and manages a sandboxed environment to run MCP servers
2. Implemented client configuration options via the new `ClientOptions` type to support sandboxed execution
3. Created dedicated type definitions (`SandboxOptions`) for configuring sandbox environments
4. Added E2B as an optional dependency that can be installed with `pip install "mcp-use[e2b]"`
5. Enhanced the `MCPClient` to support sandboxed execution through configuration options
6. Added a new example demonstrating how to use sandboxed execution with the "everything" MCP server
7. Updated documentation with details on sandboxed execution configuration and usage

## Example Usage (Before)

```python
# Previously, users had to install all dependencies locally
import asyncio
from langchain_openai import ChatOpenAI
from mcp_use import MCPAgent, MCPClient

async def main():
    # Create client with local server
    client = MCPClient.from_dict({
        "mcpServers": {
            "command_line": {
                "command": "npx",
                "args": ["-y", "@modelcontextprotocol/server-everything"]
            }
        }
    })
    
    # Create agent
    llm = ChatOpenAI(model="gpt-4o")
    agent = MCPAgent(llm=llm, client=client)
    
    # Run query
    result = await agent.run("Run echo 'hello world'")
    print(result)

asyncio.run(main())
```

## Example Usage (After)

```python
import asyncio
import os
from dotenv import load_dotenv
from langchain_openai import ChatOpenAI
from mcp_use import MCPAgent, MCPClient
from mcp_use.types.clientoptions import ClientOptions
from mcp_use.types.sandbox import SandboxOptions

async def main():
    # Load environment (needs E2B_API_KEY)
    load_dotenv()
    
    # Define sandbox options
    sandbox_options: SandboxOptions = {
        "api_key": os.getenv("E2B_API_KEY"),
        "sandbox_template_id": "code-interpreter-v1",
    }
    
    # Enable sandboxed execution
    client_options: ClientOptions = {
        "is_sandboxed": True, 
        "sandbox_options": sandbox_options
    }
    
    # Create client with sandboxed server
    client = MCPClient(
        config={
            "mcpServers": {
                "everything": {
                    "command": "npx",
                    "args": ["-y", "@modelcontextprotocol/server-everything"],
                }
            }
        },
        options=client_options
    )
    
    # Create agent and run query
    llm = ChatOpenAI(model="gpt-4o-mini")
    agent = MCPAgent(llm=llm, client=client)
    result = await agent.run("Run echo 'hello world'")
    print(result)
    
    # Don't forget to clean up resources
    await client.close_all_sessions()

asyncio.run(main())
```

## Documentation Updates

* Updated `README.md` with a new "Sandboxed Execution" section describing the feature and providing examples
* Added detailed documentation in `docs/essentials/configuration.mdx` explaining sandbox options and configuration
* Added a new section to `docs/essentials/connection-types.mdx` covering sandbox connections
* Updated API reference in `docs/api-reference/introduction.mdx`
* Updated `docs/quickstart.mdx` with information about the E2B optional dependency

## Testing

The changes include comprehensive testing:
- Added unit tests for the `SandboxConnector` in `tests/unit/test_sandbox_connector.py`
- Updated `test_client.py` to test sandboxed mode configuration
- Updated `test_config.py` to verify sandbox options are correctly processed
- Manual testing performed with the `sandbox_everything.py` example

## Backwards Compatibility

These changes are fully backwards compatible. Existing code that doesn't use sandboxed execution will continue to work unchanged. The sandboxed execution mode is entirely opt-in through the new `ClientOptions` parameter.

## Related Issues

Closes #42
