### PR TITLE
Feature/streamable http support

### DIFF
--- a/mcp_use/config.py
+++ b/mcp_use/config.py
@@ -72,6 +72,7 @@ def create_connector_from_config(
             base_url=server_config["url"],
             headers=server_config.get("headers", None),
             auth_token=server_config.get("auth_token", None),
+            use_streamable_http=server_config.get("use_streamable_http", False),
         )
 
     # WebSocket connector

--- a/mcp_use/connectors/http.py
+++ b/mcp_use/connectors/http.py
@@ -8,14 +8,14 @@ through HTTP APIs with SSE for transport.
 from mcp import ClientSession
 
 from ..logging import logger
-from ..task_managers import SseConnectionManager
+from ..task_managers import SseConnectionManager, StreamableHttpConnectionManager
 from .base import BaseConnector
 
 
 class HttpConnector(BaseConnector):
-    """Connector for MCP implementations using HTTP transport with SSE.
+    """Connector for MCP implementations using HTTP transport with SSE or streamable HTTP.
 
-    This connector uses HTTP/SSE to communicate with remote MCP implementations,
+    This connector uses HTTP/SSE or streamable HTTP to communicate with remote MCP implementations,
     using a connection manager to handle the proper lifecycle management.
     """
 
@@ -26,6 +26,7 @@ class HttpConnector(BaseConnector):
         headers: dict[str, str] | None = None,
         timeout: float = 5,
         sse_read_timeout: float = 60 * 5,
+        use_streamable_http: bool = False,
     ):
         """Initialize a new HTTP connector.
 
@@ -35,6 +36,7 @@ class HttpConnector(BaseConnector):
             headers: Optional additional headers.
             timeout: Timeout for HTTP operations in seconds.
             sse_read_timeout: Timeout for SSE read operations in seconds.
+            use_streamable_http: Whether to use streamable HTTP instead of SSE.
         """
         super().__init__()
         self.base_url = base_url.rstrip("/")
@@ -44,6 +46,7 @@ class HttpConnector(BaseConnector):
             self.headers["Authorization"] = f"Bearer {auth_token}"
         self.timeout = timeout
         self.sse_read_timeout = sse_read_timeout
+        self.use_streamable_http = use_streamable_http
 
     async def connect(self) -> None:
         """Establish a connection to the MCP implementation."""
@@ -51,15 +54,22 @@ class HttpConnector(BaseConnector):
             logger.debug("Already connected to MCP implementation")
             return
 
-        logger.debug(f"Connecting to MCP implementation via HTTP/SSE: {self.base_url}")
+        transport = "streamable HTTP" if self.use_streamable_http else "HTTP/SSE"
+        logger.debug(
+            f"Connecting to MCP implementation via {transport}: {self.base_url}",
+        )
         try:
-            # Create the SSE connection URL
-            sse_url = f"{self.base_url}"
-
             # Create and start the connection manager
-            self._connection_manager = SseConnectionManager(
-                sse_url, self.headers, self.timeout, self.sse_read_timeout
+            self._connection_manager = (
+                SseConnectionManager(
+                    self.base_url, self.headers, self.timeout, self.sse_read_timeout
+                )
+                if not self.use_streamable_http
+                else StreamableHttpConnectionManager(
+                    self.base_url, self.headers, self.timeout, self.sse_read_timeout
+                )
             )
+
             read_stream, write_stream = await self._connection_manager.start()
 
             # Create the client session
@@ -69,11 +79,11 @@ class HttpConnector(BaseConnector):
             # Mark as connected
             self._connected = True
             logger.debug(
-                f"Successfully connected to MCP implementation via HTTP/SSE: {self.base_url}"
+                f"Successfully connected to MCP implementation via {transport}: {self.base_url}"
             )
 
         except Exception as e:
-            logger.error(f"Failed to connect to MCP implementation via HTTP/SSE: {e}")
+            logger.error(f"Failed to connect to MCP implementation via {transport}: {e}")
 
             # Clean up any resources if connection failed
             await self._cleanup_resources()

--- a/mcp_use/task_managers/__init__.py
+++ b/mcp_use/task_managers/__init__.py
@@ -8,12 +8,13 @@ through different transport mechanisms.
 from .base import ConnectionManager
 from .sse import SseConnectionManager
 from .stdio import StdioConnectionManager
+from .streamable_http import StreamableHttpConnectionManager
 from .websocket import WebSocketConnectionManager
 
 __all__ = [
     "ConnectionManager",
-    "HttpConnectionManager",
     "StdioConnectionManager",
     "WebSocketConnectionManager",
     "SseConnectionManager",
+    "StreamableHttpConnectionManager",
 ]

--- a/mcp_use/task_managers/streamable_http.py
+++ b/mcp_use/task_managers/streamable_http.py
@@ -1,0 +1,79 @@
+"""
+Streamable HTTP connection management for MCP implementations.
+
+This module provides a connection manager for streamable HTTP-based MCP connections
+that ensures proper task isolation and resource cleanup.
+"""
+
+from typing import Any
+
+from mcp.client.streamable_http import streamablehttp_client
+
+from ..logging import logger
+from .base import ConnectionManager
+
+
+class StreamableHttpConnectionManager(ConnectionManager[tuple[Any, Any]]):
+    """Connection manager for streamable HTTP-based MCP connections.
+
+    This class handles the proper task isolation for HTTP streaming connections
+    to prevent the "cancel scope in different task" error. It runs the http_stream_client
+    in a dedicated task and manages its lifecycle.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        headers: dict[str, str] | None = None,
+        timeout: float = 5,
+        read_timeout: float = 60 * 5,
+    ):
+        """Initialize a new streamable HTTP connection manager.
+
+        Args:
+            url: The HTTP endpoint URL
+            headers: Optional HTTP headers
+            timeout: Timeout for HTTP operations in seconds
+            read_timeout: Timeout for HTTP read operations in seconds
+        """
+        super().__init__()
+        self.url = url
+        self.headers = headers or {}
+        self.timeout = timeout
+        self.read_timeout = read_timeout
+        self._http_ctx = None
+
+    async def _establish_connection(self) -> tuple[Any, Any]:
+        """Establish a streamable HTTP connection.
+
+        Returns:
+            A tuple of (read_stream, write_stream)
+
+        Raises:
+            Exception: If connection cannot be established.
+        """
+        # Create the context manager
+        self._http_ctx = streamablehttp_client(
+            url=self.url,
+            headers=self.headers,
+            timeout=self.timeout,
+            read_timeout=self.read_timeout,
+        )
+
+        # Enter the context manager
+        read_stream, write_stream = await self._http_ctx.__aenter__()
+
+        # Return the streams
+        return (read_stream, write_stream)
+
+    async def _close_connection(self) -> None:
+        """Close the streamable HTTP connection."""
+
+        if self._http_ctx:
+            # Exit the context manager
+            try:
+                await self._http_ctx.__aexit__(None, None, None)
+            except Exception as e:
+                logger.warning(f"Error closing streamable HTTP context: {e}")
+            finally:
+                self._http_ctx = None


### PR DESCRIPTION
# Pull Request Description

## Changes

Extends the `HttpConnector` to support both the older SSE and newer streamable HTTP transport. This defaults to the SSE transport for backwards compatibility.

These changes update the `HttpConnector` instead of making a new one since the SSE one is considered [deprecated](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http).

## Implementation Details

1. Introduce new streamable HTTP task manager
2. Extends the `HttpConnector` with a `use_streamable_http` flag that will switch what connection manager will be used.
3. Update configuration to pass down the flag

## Example Usage (Before)

```python
config = {"mcpServers": {"http": {"url": "http://localhost:8000/sse"}}}

# Create MCPClient from config file
client = MCPClient.from_dict(config)
```

## Example Usage (After)

```python
config = {"mcpServers": {"http": {"url": "http://localhost:8000/mcpunsecured", "use_streamable_http": True}}}

# Create MCPClient from config file
client = MCPClient.from_dict(config)
```

## Documentation Updates
N/A

## Testing
### Unit Tests
Added new unit tests to verify support of both SSE and streamable HTTP

### Manual Testing
1. Checked out [this](https://github.com/omarbenhamid/django-mcp-server/tree/main/examples/mcpexample) example MCP server that uses streamable http
2. Ran the following script:
```
import asyncio

from dotenv import load_dotenv
from langchain_openai import ChatOpenAI

from mcp_use import MCPAgent, MCPClient


async def main():
    """Run the example using a configuration file."""
    # Load environment variables
    load_dotenv()

    config = {"mcpServers": {"http": {"url": "http://localhost:8000/mcpunsecured", "use_streamable_http": True}}}

    # Create MCPClient from config file
    client = MCPClient.from_dict(config)

    # Create LLM
    llm = ChatOpenAI(model="gpt-4o")

    # Create agent with the client
    agent = MCPAgent(llm=llm, client=client, max_steps=5)

    # Run the query
    result = await agent.run(
        "How many robins are there?",
        max_steps=5,
    )
    print(f"\nResult: {result}")


if __name__ == "__main__":
    # Run the appropriate example
    asyncio.run(main())
```
5. Verified results 
    ![image](https://github.com/user-attachments/assets/10c2b3b0-9b5b-40ec-b978-fe004b92adce)


## Backwards Compatibility
They are

## Related Issues

Closes https://github.com/mcp-use/mcp-use/issues/70
