### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix some typos

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within pyproject.toml
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,12 @@ repos:
     -   id: check-added-large-files
     -   id: debug-statements
 
+-   repo: https://github.com/codespell-project/codespell
+    # Configuration for codespell is in .pre-commit-config.yaml
+    rev: v2.4.1
+    hooks:
+    -   id: codespell
+
 # Define configuration for the Python checks
 default_language_version:
     python: python3.11

--- a/README.md
+++ b/README.md
@@ -667,7 +667,7 @@ async def main():
 
     # Create a custom LangChain agent
     llm_with_tools = llm.bind_tools(tools)
-    result = await llm_with_tools.ainvoke("What tools do you have avilable ? ")
+    result = await llm_with_tools.ainvoke("What tools do you have available ? ")
     print(result)
 
 

--- a/docs/essentials/connection-types.mdx
+++ b/docs/essentials/connection-types.mdx
@@ -142,8 +142,8 @@ client = MCPClient.from_config_file(
 
 For example:
 
-- If your configuration includes `command` and `args` and sandbox parmater is False` (default), a local STDIO connection will be used
-- If your configuration includes `command` and `args` and sandbox parmater is True`, a sandboxed execution connection will be used
+- If your configuration includes `command` and `args` and sandbox parameter is False` (default), a local STDIO connection will be used
+- If your configuration includes `command` and `args` and sandbox parameter is True`, a sandboxed execution connection will be used
 - If your configuration has a `url` starting with `http://` or `https://`, an HTTP connection will be used
 
 This automatic inference simplifies the configuration process and ensures the appropriate connection type is used without requiring explicit specification.

--- a/examples/mcp_everything.py
+++ b/examples/mcp_everything.py
@@ -26,7 +26,7 @@ async def main():
 
     result = await agent.run(
         """
-        Hello, you are a tester can you please answer the follwing questions:
+        Hello, you are a tester can you please answer the following questions:
         - Which resources do you have access to?
         - Which prompts do you have access to?
         - Which tools do you have access to?

--- a/examples/multi_server_example.py
+++ b/examples/multi_server_example.py
@@ -56,7 +56,7 @@ async def run_multi_server_example():
     result = await agent.run(
         "Search for a nice place to stay in Barcelona on Airbnb, "
         "then use Google to find nearby restaurants and attractions."
-        "Write the result in the current directory in restarant.txt",
+        "Write the result in the current directory in restaurant.txt",
         max_steps=30,
     )
     print(result)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,3 +61,10 @@ build-backend = "hatchling.build"
 [tool.pytest.ini_options]
 asyncio_mode = "strict"
 asyncio_default_fixture_loop_scope = "function"
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git*,*.svg'
+check-hidden = true
+# ignore-regex = ''
+# ignore-words-list = ''


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.

TODOs
- [x] Potentially remove a dedicated CI, since there is pre-commit?  Note that CI does nice annotation on PR diff files on where and what typo detected
- [x] Remove TEMP demonstrating typo detection