### PR TITLE
Fix websocket error positional arguments, headers were missing (#118)

### DIFF
--- a/mcp_use/task_managers/websocket.py
+++ b/mcp_use/task_managers/websocket.py
@@ -22,14 +22,17 @@ class WebSocketConnectionManager(ConnectionManager[tuple[Any, Any]]):
     def __init__(
         self,
         url: str,
+        headers: dict[str, str] | None = None,
     ):
         """Initialize a new WebSocket connection manager.
 
         Args:
             url: The WebSocket URL to connect to
+            headers: Optional HTTP headers
         """
         super().__init__()
         self.url = url
+        self.headers = headers or {}
 
     async def _establish_connection(self) -> tuple[Any, Any]:
         """Establish a WebSocket connection.
@@ -42,6 +45,8 @@ class WebSocketConnectionManager(ConnectionManager[tuple[Any, Any]]):
         """
         logger.debug(f"Connecting to WebSocket: {self.url}")
         # Create the context manager
+        # Note: The current MCP websocket_client implementation doesn't support headers
+        # If headers need to be passed, this would need to be updated when MCP supports it
         self._ws_ctx = websocket_client(self.url)
 
         # Enter the context manager

--- a/tests/unit/test_websocket_connection_manager.py
+++ b/tests/unit/test_websocket_connection_manager.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Unit tests for WebSocketConnectionManager."""
+
+import pytest
+
+from mcp_use.task_managers.websocket import WebSocketConnectionManager
+
+
+class TestWebSocketConnectionManager:
+    """Test cases for WebSocketConnectionManager."""
+
+    def test_init_with_url_only(self):
+        """Test that WebSocketConnectionManager can be initialized with URL only."""
+        url = "ws://localhost:8080"
+        manager = WebSocketConnectionManager(url)
+
+        assert manager.url == url
+        assert manager.headers == {}
+
+    def test_init_with_url_and_headers(self):
+        """Test that WebSocketConnectionManager can be initialized with URL and headers."""
+        url = "ws://localhost:8080"
+        headers = {"Authorization": "Bearer token123", "User-Agent": "test-client"}
+        manager = WebSocketConnectionManager(url, headers)
+
+        assert manager.url == url
+        assert manager.headers == headers
+
+    def test_init_with_url_and_none_headers(self):
+        """Test that WebSocketConnectionManager handles None headers correctly."""
+        url = "ws://localhost:8080"
+        manager = WebSocketConnectionManager(url, None)
+
+        assert manager.url == url
+        assert manager.headers == {}
+
+    def test_init_with_empty_headers(self):
+        """Test that WebSocketConnectionManager handles empty headers correctly."""
+        url = "ws://localhost:8080"
+        headers = {}
+        manager = WebSocketConnectionManager(url, headers)
+
+        assert manager.url == url
+        assert manager.headers == headers
+
+    def test_headers_parameter_optional(self):
+        """Test that headers parameter is optional and defaults correctly."""
+        url = "ws://localhost:8080"
+
+        # Should work without headers parameter
+        manager1 = WebSocketConnectionManager(url)
+        assert manager1.headers == {}
+
+        # Should work with explicit None
+        manager2 = WebSocketConnectionManager(url, None)
+        assert manager2.headers == {}
+
+        # Should work with actual headers
+        headers = {"Content-Type": "application/json"}
+        manager3 = WebSocketConnectionManager(url, headers)
+        assert manager3.headers == headers
+
+    def test_fix_for_issue_118(self):
+        """Test that reproduces and verifies the fix for GitHub issue #118.
+
+        The original error was:
+        WebSocketConnectionManager.__init__() takes 2 positional arguments but 3 were given
+
+        This happened because WebSocketConnector was trying to pass headers to
+        WebSocketConnectionManager, but the constructor didn't accept headers.
+        """
+        url = "ws://example.com"
+        headers = {"Authorization": "Bearer test-token"}
+
+        # This should NOT raise "takes 2 positional arguments but 3 were given"
+        try:
+            manager = WebSocketConnectionManager(url, headers)
+            assert manager.url == url
+            assert manager.headers == headers
+        except TypeError as e:
+            pytest.fail(f"WebSocketConnectionManager failed to accept headers parameter: {e}")


### PR DESCRIPTION
# Pull Request Description

Problem: The `WebSocketConnectionManager.__init__()` method only accepts 2 positional arguments (self and url), but it's being called with 3 arguments (self, self.url, and self.headers).

## Changes

The WebSocketConnectionManager class needs to be updated to accept and handle headers.

## Testing

Describe how you tested these changes:

Add unit test `tests/unit/test_websocket_connection_manager.py`


## Related Issues

Closes #118 
