### PR TITLE
Create tool to connect servers from config pasted into query

### DIFF
--- a/examples/dynamic_server_management.py
+++ b/examples/dynamic_server_management.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Example demonstrating dynamic server management with MCPAgent.
+
+This example shows how an agent can dynamically add new MCP servers during execution
+and immediately use their tools.
+"""
+
+import asyncio
+import json
+
+from langchain_openai import ChatOpenAI
+
+from mcp_use import MCPClient
+from mcp_use.agents import MCPAgent
+from mcp_use.logging import logger
+
+
+async def main():
+    """Main function demonstrating dynamic server management."""
+
+    # Create an empty MCP client (no servers configured initially)
+    client = MCPClient()
+
+    # Initialize the LLM (you can use OpenAI or any LangChain-compatible LLM)
+    llm = ChatOpenAI(
+        model="gpt-4o-mini",
+        temperature=0.0,
+    )
+
+    # Create the MCPAgent with server manager enabled
+    agent = MCPAgent(
+        client=client,
+        llm=llm,
+        use_server_manager=True,
+    )
+
+    # Define the server configurations that the agent will be asked to add
+    server_config_playwright = {
+        "command": "npx",
+        "args": ["@playwright/mcp@latest"],
+        "env": {
+            "DISPLAY": ":1",
+        },
+    }
+    server_config_airbnb = {
+        "command": "npx",
+        "args": ["-y", "@openbnb/mcp-server-airbnb", "--ignore-robots-txt"],
+    }
+
+    # We'll pass the configs as JSON strings in the prompt
+    server_config_string_playwright = json.dumps(server_config_playwright, indent=2)
+    server_config_string_airbnb = json.dumps(server_config_airbnb, indent=2)
+
+    # Prepare a prompt that asks the agent to add two different servers and use them
+    prompt = f"""
+    I need to browse the web. To do this, please add and connect to a new MCP server for Playwright.
+    The server name is 'playwright' and its configuration is:
+    ```json
+    {server_config_string_playwright}
+    ```
+    Once the server is ready, navigate to https://github.com/mcp-use/mcp-use, give a star to the
+    project, and then provide a concise summary of the project's README.
+
+    Then, please add and connect to a new MCP server for Airbnb.
+    The server name is 'airbnb' and its configuration is:
+    ```json
+    {server_config_string_airbnb}
+    ```
+    and give me a house in the location of the company mcp-use.
+    """
+
+    try:
+        logger.info("Starting dynamic server management example...")
+
+        # Run the agent with the prompt
+        result = await agent.run(prompt)
+
+        print("\n=== Agent Response ===")
+        print(result)
+
+        # Display final server state
+        print("\n=== Final Server State ===")
+        server_names = client.get_server_names()
+        print(f"Total servers: {len(server_names)}")
+        for server_name in server_names:
+            try:
+                client.get_session(server_name)
+                print(f"  - {server_name}: connected")
+            except ValueError:
+                print(f"  - {server_name}: not connected")
+
+    finally:
+        # Clean up
+        await agent.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/mcp_use/managers/server_manager.py
+++ b/mcp_use/managers/server_manager.py
@@ -5,6 +5,7 @@ from mcp_use.logging import logger
 
 from ..adapters.base import BaseAdapter
 from .tools import (
+    AddMCPServerTool,
     ConnectServerTool,
     DisconnectServerTool,
     GetActiveServerTool,
@@ -32,7 +33,7 @@ class ServerManager:
         self.adapter = adapter
         self.active_server: str | None = None
         self.initialized_servers: dict[str, bool] = {}
-        self._server_tools: dict[str, list[BaseTool]] = {}
+        self.server_tools: dict[str, list[BaseTool]] = {}
 
     async def initialize(self) -> None:
         """Initialize the server manager and prepare server management tools."""
@@ -64,8 +65,8 @@ class ServerManager:
                     tools = await self.adapter._create_tools_from_connectors([connector])
 
                     # Check if this server's tools have changed
-                    if server_name not in self._server_tools or self._server_tools[server_name] != tools:
-                        self._server_tools[server_name] = tools  # Cache tools
+                    if server_name not in self.server_tools or self.server_tools[server_name] != tools:
+                        self.server_tools[server_name] = tools  # Cache tools
                         self.initialized_servers[server_name] = True  # Mark as initialized
                         logger.debug(f"Prefetched {len(tools)} tools for server '{server_name}'.")
                     else:
@@ -73,14 +74,57 @@ class ServerManager:
             except Exception as e:
                 logger.error(f"Error prefetching tools for server '{server_name}': {e}")
 
+    def log_state(self, context: str) -> None:
+        """Log the current state of all servers for debugging.
+
+        Args:
+            context: Context string for the log message
+        """
+        logger.debug(f"\n=== ServerManager State ({context}) ===")
+        server_names = self.client.get_server_names()
+
+        if not server_names:
+            logger.debug("No servers configured")
+            return
+
+        for server_name in server_names:
+            # Check connection status
+            try:
+                session = self.client.get_session(server_name)
+                connected = session is not None
+            except ValueError:
+                connected = False
+
+            # Get other status info
+            initialized = self.initialized_servers.get(server_name, False)
+            tool_count = len(self.server_tools.get(server_name, []))
+            is_active = server_name == self.active_server
+
+            status = []
+            if connected:
+                status.append("connected")
+            if initialized:
+                status.append("initialized")
+            if is_active:
+                status.append("ACTIVE")
+
+            logger.debug(f"  - {server_name}: {', '.join(status) if status else 'not connected'} ({tool_count} tools)")
+        logger.debug("==========================\n")
+
     @property
     def tools(self) -> list[BaseTool]:
-        """Get all server management tools.
+        """Get all available tools including server management and active server tools.
 
         Returns:
-            list of LangChain tools for server management
+            Combined list of management tools and active server tools
         """
-        return [
+        # Log current state for debugging
+        if logger.level <= 10:  # DEBUG level
+            self.log_state("tools getter")
+
+        # Base management tools
+        management_tools = [
+            AddMCPServerTool(self),
             ListServersTool(self),
             ConnectServerTool(self),
             GetActiveServerTool(self),
@@ -88,3 +132,10 @@ class ServerManager:
             SearchToolsTool(self),
             UseToolFromServerTool(self),
         ]
+
+        # If there's an active server, include its tools
+        if self.active_server and self.active_server in self.server_tools:
+            active_tools = self.server_tools[self.active_server]
+            return management_tools + active_tools
+
+        return management_tools

--- a/mcp_use/managers/tools/__init__.py
+++ b/mcp_use/managers/tools/__init__.py
@@ -1,3 +1,4 @@
+from .add_server import AddMCPServerTool
 from .base_tool import MCPServerTool
 from .connect_server import ConnectServerTool
 from .disconnect_server import DisconnectServerTool
@@ -8,6 +9,7 @@ from .use_tool import UseToolFromServerTool
 
 __all__ = [
     "MCPServerTool",
+    "AddMCPServerTool",
     "ListServersTool",
     "ConnectServerTool",
     "GetActiveServerTool",

--- a/mcp_use/managers/tools/add_server.py
+++ b/mcp_use/managers/tools/add_server.py
@@ -1,0 +1,93 @@
+"""Tool for dynamically adding MCP servers to the client."""
+
+import logging
+from typing import Any
+
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+
+class AddMCPServerToolSchema(BaseModel):
+    """Schema for add_mcp_server tool input."""
+
+    server_name: str = Field(description="Name for the new MCP server")
+    server_config: dict[str, Any] = Field(description="Server configuration including command, args, and env")
+    connect: bool = Field(
+        default=True,
+        description="Whether to immediately connect to the server after adding it",
+    )
+
+
+class AddMCPServerTool(StructuredTool):
+    """Tool that allows adding new MCP servers dynamically."""
+
+    name: str = "add_mcp_server"
+    description: str = "Adds a new MCP server to the client and connects to it, making its tools available."
+    args_schema: type[BaseModel] = AddMCPServerToolSchema
+
+    def __init__(self, server_manager):
+        """Initialize the tool with a reference to the ServerManager.
+
+        Args:
+            server_manager: The ServerManager instance to use
+        """
+        super().__init__(
+            name=self.name,
+            description=self.description,
+            func=self._run,
+            coroutine=self._arun,
+            args_schema=self.args_schema,
+        )
+        self.manager = server_manager
+
+    def _run(self, server_name: str, server_config: dict[str, Any], connect: bool = True) -> str:
+        """Synchronous version - not implemented as this is an async operation."""
+        raise NotImplementedError("This tool only supports async execution")
+
+    async def _arun(self, server_name: str, server_config: dict[str, Any], connect: bool = True) -> str:
+        """Add a new MCP server to the client and optionally connect to it.
+
+        Args:
+            server_name: Name for the new server
+            server_config: Server configuration dict
+            connect: Whether to immediately connect
+
+        Returns:
+            Success or error message
+        """
+        try:
+            # Add the server to the client
+            self.manager.client.add_server(server_name, server_config)
+
+            if connect:
+                logger.debug(f"Connecting to new server '{server_name}' and discovering tools")
+
+                # Create a session for the new server
+                session = await self.manager.client.create_session(server_name)
+
+                # Get the connector from the session
+                connector = session.connector
+
+                # Create tools from the connector using the adapter
+                tools = await self.manager.adapter.create_tools_from_connectors([connector])
+
+                # Update ServerManager's state
+                self.manager.server_tools[server_name] = tools
+                self.manager.initialized_servers[server_name] = True
+                self.manager.active_server = server_name
+
+                success_msg = (
+                    f"Successfully added and connected to server '{server_name}'. "
+                    f"'{server_name}' is now the active server with {len(tools)} tools available."
+                )
+                logger.info(success_msg)
+                return success_msg
+            else:
+                return f"Successfully added server '{server_name}' (not connected)"
+
+        except Exception as e:
+            error_msg = f"Failed to add server '{server_name}': {str(e)}"
+            logger.error(error_msg, exc_info=True)
+            return error_msg


### PR DESCRIPTION
# Pull Request Description

## Description

This pull request significantly enhances the `MCPAgent`'s dynamic server management capabilities. The agent can now **add and instantiate entirely new MCP servers at runtime**, based on configuration details provided directly in the user's prompt. This moves beyond simply switching between pre-configured servers, granting the agent true autonomy to expand its own toolset on-the-fly to meet the demands of a task.

The core of this change is the new `AddMCPServerTool`, which is provided to the agent when the `ServerManager` is active. This tool empowers the agent to:
1. Parse a server name and JSON configuration from the prompt.
2. Add the new server configuration to the `MCPClient`.
3. Establish a session with the newly defined server.
4. Discover the tools offered by that server.
5. Register the new tools and activate the server, making its capabilities immediately available for subsequent steps.

This PR also includes existing enhancements for observability and code structure that support this new feature.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] The title of my pull request follows the [conventional commits](https://www.conventionalcommits.org/) standard
- [x] Changes have been documented in the README/documentation (if applicable)

## Changes

- **Introduced `AddMCPServerTool`**: A new tool that allows the agent to add a new MCP server using a name and configuration string, typically extracted from a user's prompt.
- **Enhanced `ServerManager`**: The manager now includes the `AddMCPServerTool` in its toolset, enabling the agent to dynamically expand the list of available servers.

## Implementation Details

1.  **`AddMCPServerTool`**: This is the key component of the PR. It is a standard `BaseTool` that exposes the functionality of adding and connecting to a new server to the agent. It orchestrates calls to `client.add_server` and `client.create_session`.
2.  **`ServerManager`**: The manager's role is updated to provide this new tool to the agent. Its existing ability to manage active server tools ensures that once a server is added, its tools are immediately usable.

## Example Usage (Before)

```python
# Before, the agent could manage and switch between servers,
# but those servers had to be defined when the client was created.

from mcp_use import MCPClient
from mcp_use.agents import MCPAgent

# Servers had to be pre-configured. The agent could not add new ones.
client = MCPClient(servers={
    "playwright": {"command": "npx @playwright/mcp"},
    "airbnb": {"command": "npx -y @openbnb/mcp-server-airbnb"},
})

agent = MCPAgent(client=client, llm=llm, use_server_manager=True)

# The agent could be prompted to "connect to playwright" or "connect to airbnb",
# but could not create a new server, e.g., for "filesystem".
```

## Example Usage (After)

```python
#!/usr/bin/env python3
"""Example demonstrating adding new MCP servers directly from a prompt.

This example shows how an agent can dynamically add new MCP servers during execution
and immediately use their tools, based on configuration from a prompt.
"""

import asyncio
import json

from langchain_openai import ChatOpenAI

from mcp_use import MCPClient
from mcp_use.agents import MCPAgent
from mcp_use.logging import logger


async def main():
    """Main function demonstrating dynamic server management."""

    # Create an empty MCP client (no servers configured initially)
    client = MCPClient()

    # Initialize the LLM
    llm = ChatOpenAI(
        model="gpt-4o-mini",
        temperature=0.0,
    )

    # Create the MCPAgent with server manager enabled
    agent = MCPAgent(
        client=client,
        llm=llm,
        use_server_manager=True,
    )

    # Define the server configurations that the agent will be asked to add
    server_config_playwright = {
        "command": "npx",
        "args": ["@playwright/mcp@latest"],
        "env": {
            "DISPLAY": ":1",
        },
    }
    server_config_airbnb = {
        "command": "npx",
        "args": ["-y", "@openbnb/mcp-server-airbnb", "--ignore-robots-txt"],
    }

    # We'll pass the configs as JSON strings in the prompt
    server_config_string_playwright = json.dumps(server_config_playwright, indent=2)
    server_config_string_airbnb = json.dumps(server_config_airbnb, indent=2)

    # Prepare a prompt that asks the agent to add two different servers and use them
    prompt = f"""
    I need to browse the web. To do this, please add and connect to a new MCP server for Playwright.
    The server name is 'playwright' and its configuration is:
    ```json
    {server_config_string_playwright}
    ```
    Once the server is ready, navigate to https://github.com/mcp-use/mcp-use, give a star to the
    project, and then provide a concise summary of the project's README.

    Then, please add and connect to a new MCP server for Airbnb.
    The server name is 'airbnb' and its configuration is:
    ```json
    {server_config_string_airbnb}
    ```
    and give me a house in the location of the company mcp-use.
    """

    try:
        logger.info("Starting dynamic server management example...")

        # Run the agent with the prompt
        result = await agent.run(prompt)

        print("\n=== Agent Response ===")
        print(result)

        # Display final server state
        print("\n=== Final Server State ===")
        server_names = client.get_server_names()
        print(f"Total servers: {len(server_names)}")
        for server_name in server_names:
            try:
                client.get_session(server_name)
                print(f"  - {server_name}: connected")
            except ValueError:
                print(f"  - {server_name}: not connected")

    finally:
        # Clean up
        await agent.close()


if __name__ == "__main__":
    asyncio.run(main())
```

## Documentation Updates

- A new example, `examples/add_servers_from_prompt.py`, has been added to demonstrate the agent's ability to add servers from a prompt.

## Testing

- Manually tested using the `add_servers_from_prompt.py` example to confirm that the agent can parse configurations from the prompt, add multiple servers, and use their tools in sequence.

## Backwards Compatibility

These changes are fully backwards compatible. The feature is only active when `use_server_manager=True` is set on the `MCPAgent`. Agents without this flag will not have the `AddMCPServerTool` and will behave as before.

## Related Issues

Closes #
