### PR TITLE
fix: Renamed client to client session, fixed bug

### DIFF
--- a/mcp_use/connectors/base.py
+++ b/mcp_use/connectors/base.py
@@ -11,6 +11,7 @@ from typing import Any
 from mcp import ClientSession
 from mcp.shared.exceptions import McpError
 from mcp.types import CallToolResult, GetPromptResult, Prompt, ReadResourceResult, Resource, Tool
+from pydantic import AnyUrl
 
 from ..logging import logger
 from ..task_managers import ConnectionManager
@@ -287,7 +288,7 @@ class BaseConnector(ABC):
             logger.error(f"Error listing resources: {e}")
             return []
 
-    async def read_resource(self, uri: str) -> ReadResourceResult:
+    async def read_resource(self, uri: AnyUrl) -> ReadResourceResult:
         """Read a resource by URI."""
         await self._ensure_connected()
 

--- a/mcp_use/connectors/sandbox.py
+++ b/mcp_use/connectors/sandbox.py
@@ -65,9 +65,8 @@ class SandboxConnector(BaseConnector):
         super().__init__()
         if Sandbox is None:
             raise ImportError(
-                "E2B SDK (e2b-code-interpreter) not found. "
-                "Please install it with 'pip install mcp-use[e2b]' "
-                "(or 'pip install e2b-code-interpreter')."
+                "E2B SDK (e2b-code-interpreter) not found. Please install it with "
+                "'pip install mcp-use[e2b]' (or 'pip install e2b-code-interpreter')."
             )
 
         self.user_command = command
@@ -79,8 +78,8 @@ class SandboxConnector(BaseConnector):
         self.api_key = _e2b_options.get("api_key") or os.environ.get("E2B_API_KEY")
         if not self.api_key:
             raise ValueError(
-                "E2B API key is required. Provide it via 'sandbox_options.api_key' "
-                "or the E2B_API_KEY environment variable."
+                "E2B API key is required. Provide it via 'sandbox_options.api_key'"
+                " or the E2B_API_KEY environment variable."
             )
 
         self.sandbox_template_id = _e2b_options.get("sandbox_template_id", "base")
@@ -88,7 +87,7 @@ class SandboxConnector(BaseConnector):
 
         self.sandbox: Sandbox | None = None
         self.process: CommandHandle | None = None
-        self.client: ClientSession | None = None
+        self.client_session: ClientSession | None = None
         self.errlog = sys.stderr
         self.base_url: str | None = None
         self._connected = False
@@ -218,8 +217,8 @@ class SandboxConnector(BaseConnector):
             read_stream, write_stream = await self._connection_manager.start()
 
             # Create the client session
-            self.client = ClientSession(read_stream, write_stream, sampling_callback=None)
-            await self.client.__aenter__()
+            self.client_session = ClientSession(read_stream, write_stream, sampling_callback=None)
+            await self.client_session.__aenter__()
 
             # Mark as connected
             self._connected = True

--- a/tests/unit/test_sandbox_connector.py
+++ b/tests/unit/test_sandbox_connector.py
@@ -149,7 +149,7 @@ class TestSandboxConnectorConnection:
 
             # Verify state
             assert connector._connected is True
-            assert connector.client == mock_client_instance
+            assert connector.client_session == mock_client_instance
             assert connector._connection_manager == mock_manager_instance
             assert connector.base_url == "https://test-host.sandbox.e2b.dev"
 
@@ -164,7 +164,7 @@ class TestSandboxConnectorConnection:
 
         # Verify no connection established since already connected
         assert connector._connection_manager is None
-        assert connector.client is None
+        assert connector.client_session is None
         assert connector.sandbox is None
 
     @pytest.mark.asyncio
@@ -191,7 +191,7 @@ class TestSandboxConnectorConnection:
         # Verify resources were cleaned up
         connector._cleanup_resources.assert_called_once()
         assert connector._connected is False
-        assert connector.client is None
+        assert connector.client_session is None
 
     @pytest.mark.asyncio
     async def test_disconnect(self, mock_sandbox_modules):


### PR DESCRIPTION
The SanboxConnector was still using self.client not self.client_session for its client session, creating a bug. It is now fixed 