### PR TITLE
Add sampling to MCPClient constructors

### DIFF
--- a/mcp_use/client.py
+++ b/mcp_use/client.py
@@ -60,6 +60,7 @@ class MCPClient:
         config: dict[str, Any],
         sandbox: bool = False,
         sandbox_options: SandboxOptions | None = None,
+        sampling_callback: SamplingFnT | None = None,
     ) -> "MCPClient":
         """Create a MCPClient from a dictionary.
 
@@ -68,11 +69,15 @@ class MCPClient:
             sandbox: Whether to use sandboxed execution mode for running MCP servers.
             sandbox_options: Optional sandbox configuration options.
         """
-        return cls(config=config, sandbox=sandbox, sandbox_options=sandbox_options)
+        return cls(config=config, sandbox=sandbox, sandbox_options=sandbox_options, sampling_callback=sampling_callback)
 
     @classmethod
     def from_config_file(
-        cls, filepath: str, sandbox: bool = False, sandbox_options: SandboxOptions | None = None
+        cls,
+        filepath: str,
+        sandbox: bool = False,
+        sandbox_options: SandboxOptions | None = None,
+        sampling_callback: SamplingFnT | None = None,
     ) -> "MCPClient":
         """Create a MCPClient from a configuration file.
 
@@ -81,7 +86,12 @@ class MCPClient:
             sandbox: Whether to use sandboxed execution mode for running MCP servers.
             sandbox_options: Optional sandbox configuration options.
         """
-        return cls(config=load_config_file(filepath), sandbox=sandbox, sandbox_options=sandbox_options)
+        return cls(
+            config=load_config_file(filepath),
+            sandbox=sandbox,
+            sandbox_options=sandbox_options,
+            sampling_callback=sampling_callback,
+        )
 
     def add_server(
         self,


### PR DESCRIPTION
# Pull Request Description

## Changes

Added sampling_callback to MCPClient.from_config_file and MCPClient.from_dict

## Implementation Details

Kept this change very minor, just added the same sampling_callback to the constructor class functions

## Example Usage (Before)

MCPClient.from_config_file could not be used with Sampling

## Example Usage (After)

MCPClient.from_config_file(fname, sampling_callback=sampling_callback)


## Backwards Compatibility

Adding another kwarg so should be safe

## Related Issues
