### PR TITLE
Add direct tool call example and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,6 +633,47 @@ The `SandboxOptions` type provides configuration for the sandbox environment:
 - **Consistent environment**: Ensure consistent behavior across different systems
 - **Resource efficiency**: Offload resource-intensive tasks to cloud infrastructure
 
+# Direct Tool Calls (Without LLM)
+
+You can call MCP server tools directly without an LLM when you need programmatic control:
+
+```python
+import asyncio
+from mcp_use import MCPClient
+
+async def call_tool_example():
+    config = {
+        "mcpServers": {
+            "everything": {
+                "command": "npx",
+                "args": ["-y", "@modelcontextprotocol/server-everything"],
+            }
+        }
+    }
+
+    client = MCPClient.from_dict(config)
+
+    try:
+        await client.create_all_sessions()
+        session = client.get_session("everything")
+
+        # Call tool directly
+        result = await session.connector.call_tool(
+            name="add",
+            arguments={"a": 1, "b": 2}
+        )
+
+        print(f"Result: {result.content[0].text}")  # Output: 3
+
+    finally:
+        await client.close_all_sessions()
+
+if __name__ == "__main__":
+    asyncio.run(call_tool_example())
+```
+
+See the complete example: [examples/direct_tool_call.py](examples/direct_tool_call.py)
+
 # Build a Custom Agent:
 
 You can also build your own custom agent using the LangChain adapter:

--- a/docs/client/direct-tool-calls.mdx
+++ b/docs/client/direct-tool-calls.mdx
@@ -1,0 +1,233 @@
+---
+title: Direct Tool Calls
+description: Learn how to call MCP tools directly without using an LLM
+---
+
+# Direct Tool Calls
+
+MCP-Use allows you to call MCP server tools directly without needing an LLM or agent. This is useful when you want to use MCP servers as a simple interface to various tools and APIs, or when you need programmatic control over tool execution.
+
+## When to Use Direct Tool Calls
+
+Direct tool calls are appropriate when:
+
+- You know exactly which tool to call and with what parameters
+- You don't need an LLM to make decisions about tool selection
+- You want to integrate MCP tools into existing Python applications
+- You need deterministic, programmatic control over tool execution
+
+<Note>
+Direct tool calls will not work for tools that require sampling/completion, as these need an LLM to generate responses.
+</Note>
+
+## Basic Example
+
+Here's how to call tools directly using the MCPClient:
+
+```python
+import asyncio
+from mcp_use import MCPClient
+
+async def call_tool_example():
+    # Configure the MCP server
+    config = {
+        "mcpServers": {
+            "everything": {
+                "command": "npx",
+                "args": ["-y", "@modelcontextprotocol/server-everything"],
+            }
+        }
+    }
+
+    # Create client from configuration
+    client = MCPClient.from_dict(config)
+
+    try:
+        # Initialize all configured sessions
+        await client.create_all_sessions()
+
+        # Get the session for a specific server
+        session = client.get_session("everything")
+
+        # List available tools
+        tools = await session.connector.list_tools()
+        tool_names = [t.name for t in tools]
+        print(f"Available tools: {tool_names}")
+
+        # Call a specific tool with arguments
+        result = await session.connector.call_tool(
+            name="add",
+            arguments={"a": 1, "b": 2}
+        )
+
+        # Handle the result
+        if getattr(result, "isError", False):
+            print(f"Error: {result.content}")
+        else:
+            print(f"Tool result: {result.content}")
+            print(f"Text result: {result.content[0].text}")
+
+    finally:
+        # Clean up resources
+        await client.close_all_sessions()
+
+if __name__ == "__main__":
+    asyncio.run(call_tool_example())
+```
+
+## Working with Tool Results
+
+The `call_tool` method returns a `CallToolResult` object with the following attributes:
+
+- **`content`**: A list of `ContentBlock` objects containing the tool's output
+- **`structuredContent`**: A dictionary with the structured result (for non-sampling tools)
+- **`isError`**: Boolean indicating if the tool call encountered an error
+
+### Accessing Results
+
+```python
+# Call a tool
+result = await session.connector.call_tool(
+    name="get_weather",
+    arguments={"location": "San Francisco"}
+)
+
+# Check for errors
+if result.isError:
+    print(f"Tool error: {result.content}")
+else:
+    # Access text content
+    text_result = result.content[0].text
+    print(f"Weather: {text_result}")
+
+    # Access structured content if available
+    if hasattr(result, 'structuredContent'):
+        structured = result.structuredContent
+        print(f"Temperature: {structured.get('temperature')}")
+```
+
+## Multiple Server Example
+
+You can work with multiple MCP servers and call tools from each:
+
+```python
+import asyncio
+from mcp_use import MCPClient
+
+async def multi_server_example():
+    config = {
+        "mcpServers": {
+            "filesystem": {
+                "command": "npx",
+                "args": ["-y", "@modelcontextprotocol/server-filesystem"],
+                "env": {"FILE_PATH": "/tmp"}
+            },
+            "time": {
+                "command": "npx",
+                "args": ["-y", "@modelcontextprotocol/server-time"]
+            }
+        }
+    }
+
+    client = MCPClient.from_dict(config)
+
+    try:
+        await client.create_all_sessions()
+
+        # Call tool from filesystem server
+        fs_session = client.get_session("filesystem")
+        files = await fs_session.connector.call_tool(
+            name="list_files",
+            arguments={"path": "/tmp"}
+        )
+        print(f"Files: {files.content[0].text}")
+
+        # Call tool from time server
+        time_session = client.get_session("time")
+        current_time = await time_session.connector.call_tool(
+            name="get_current_time",
+            arguments={}
+        )
+        print(f"Current time: {current_time.content[0].text}")
+
+    finally:
+        await client.close_all_sessions()
+
+if __name__ == "__main__":
+    asyncio.run(multi_server_example())
+```
+
+## Discovering Available Tools
+
+Before calling tools, you may want to discover what's available:
+
+```python
+async def discover_tools():
+    client = MCPClient.from_dict(config)
+    await client.create_all_sessions()
+
+    try:
+        session = client.get_session("my_server")
+
+        # Get all tools
+        tools = await session.connector.list_tools()
+
+        for tool in tools:
+            print(f"Tool: {tool.name}")
+            print(f"  Description: {tool.description}")
+
+            # Print input schema if available
+            if hasattr(tool, 'inputSchema'):
+                print(f"  Parameters: {tool.inputSchema}")
+            print()
+
+    finally:
+        await client.close_all_sessions()
+```
+
+## Error Handling
+
+Always handle potential errors when making direct tool calls:
+
+```python
+async def safe_tool_call():
+    try:
+        result = await session.connector.call_tool(
+            name="some_tool",
+            arguments={"param": "value"}
+        )
+
+        if result.isError:
+            # Handle tool-specific errors
+            error_msg = result.content[0].text if result.content else "Unknown error"
+            print(f"Tool returned error: {error_msg}")
+            return None
+
+        return result.content[0].text
+
+    except Exception as e:
+        # Handle connection or other errors
+        print(f"Failed to call tool: {e}")
+        return None
+```
+
+## Limitations
+
+When using direct tool calls, be aware of these limitations:
+
+1. **No Sampling Support**: Tools that require sampling/completion (like text generation) won't work without an LLM
+2. **Manual Tool Selection**: You need to know which tool to call - there's no automatic selection
+3. **No Context Management**: Unlike agents, direct calls don't maintain conversation context
+4. **Parameter Validation**: You're responsible for providing correct parameters
+
+## Complete Example
+
+View the complete working example in the repository:
+
+[examples/direct_tool_call.py](https://github.com/pietrozullo/mcp-use/blob/main/examples/direct_tool_call.py)
+
+## Next Steps
+
+- Learn about [tool discovery](/client/tools) to explore available tools
+- Understand [connection types](/client/connection-types) for different server configurations
+- Explore [building custom agents](/advanced/building-custom-agents) for more complex use cases

--- a/examples/direct_tool_call.py
+++ b/examples/direct_tool_call.py
@@ -1,0 +1,59 @@
+"""
+Direct tool calling example using MCPClient.
+
+Notes:
+- This demonstrates calling tools directly without an LLM/agent.
+- This approach will not work for tools that require sampling.
+"""
+
+import asyncio
+
+from mcp_use import MCPClient
+
+config = {
+    "mcpServers": {
+        "everything": {
+            "command": "npx",
+            "args": ["-y", "@modelcontextprotocol/server-everything"],
+        }
+    }
+}
+
+
+async def call_tool_example() -> None:
+    client = MCPClient.from_dict(config)
+
+    try:
+        # Create and initialize sessions for configured servers
+        await client.create_all_sessions()
+
+        # Retrieve the session for the "everything" server (match the server name key in the config)
+        session = client.get_session("everything")
+
+        # List available tools
+        tools = await session.connector.list_tools()
+        tool_names = [t.name for t in tools]
+        print(f"Available tools: {tool_names}")
+
+        # Choose a tool to call (note: do not call sampling tools because they require an LLM to complete)
+        # In the example, we call the "add" tool from the "everything" server
+        # Result is a CallToolResult object
+        # - content is a list of ContentBlock objects
+        # - structuredContent is a dictionary of the structured result of the tool call (only for non-sampling tools)
+        # - isError is a boolean indicating if the tool call was successful
+        result_tool_add = await session.connector.call_tool(name="add", arguments={"a": 1, "b": 2})
+
+        # Handle and print the result
+        if getattr(result_tool_add, "isError", False):
+            print(f"Error: {result_tool_add.content}")
+        else:
+            print(f"Tool result: {result_tool_add.content}")
+            print(f"Text result: {result_tool_add.content[0].text}")
+
+    finally:
+        # Ensure we clean up resources properly
+        await client.close_all_sessions()
+
+
+if __name__ == "__main__":
+    asyncio.run(call_tool_example())


### PR DESCRIPTION
### Changes

  Added comprehensive documentation and examples for direct tool calling functionality in MCP-Use, allowing users to call MCP server tools
  programmatically without requiring an LLM or agent.

  Implementation Details

  1. Documentation Structure: Created new documentation page at docs/client/direct-tool-calls.mdx following the existing documentation format
  and style
  2. Content Organization: Structured the documentation with clear sections covering use cases, examples, error handling, and limitations
  3. Integration: Added a dedicated section in the main README.md to highlight this functionality alongside other core features
  4. Cross-referencing: Linked to the existing example file and related documentation pages

 ## Example Usage (Before)

  Users had to discover this functionality through code exploration
  No dedicated documentation existed for direct tool calling

  ## Example Usage (After)

  import asyncio
  from mcp_use import MCPClient

```
  async def call_tool_example():
      config = {
          "mcpServers": {
              "everything": {
                  "command": "npx",
                  "args": ["-y", "@modelcontextprotocol/server-everything"],
              }
          }
      }

      client = MCPClient.from_dict(config)

      try:
          await client.create_all_sessions()
          session = client.get_session("everything")

          # Call tool directly
          result = await session.connector.call_tool(
              name="add",
              arguments={"a": 1, "b": 2}
          )

          print(f"Result: {result.content[0].text}")  # Output: 3

      finally:
          await client.close_all_sessions()
```

##  Documentation Updates

  - README.md: Added new section "Direct Tool Calls (Without LLM)" with concise example and link to detailed documentation
  - docs/client/direct-tool-calls.mdx: Created comprehensive documentation covering:
    - When to use direct tool calls
    - Basic and advanced examples
    - Working with tool results and multiple servers
    - Tool discovery patterns
    - Error handling best practices
    - Limitations and caveats
    - Links to related documentation


## Backwards Compatibility

  These changes are fully backwards compatible. No existing functionality was modified - only documentation was added to make existing direct tool calling capabilities more discoverable and usable.

 ## Related Issues

Related to discussion: https://github.com/orgs/mcp-use/discussions/218

This addresses the need for better documentation around direct tool calling functionality that was already present in the codebase but not well-documented for users who want to use MCP servers without LLM integration.