### PR TITLE
feat: expose chat creation

### DIFF
--- a/mcp_use/agents/mcpagent.py
+++ b/mcp_use/agents/mcpagent.py
@@ -66,6 +66,7 @@ class MCPAgent:
         agent_id: str | None = None,
         api_key: str | None = None,
         base_url: str = "https://cloud.mcp-use.com",
+        chat_id: str | None = None,
         retry_on_error: bool = True,
         max_retries_per_step: int = 2,
     ):
@@ -91,7 +92,7 @@ class MCPAgent:
         """
         # Handle remote execution
         if agent_id is not None:
-            self._remote_agent = RemoteAgent(agent_id=agent_id, api_key=api_key, base_url=base_url)
+            self._remote_agent = RemoteAgent(agent_id=agent_id, api_key=api_key, base_url=base_url, chat_id=chat_id)
             self._is_remote = True
             return
 
@@ -772,7 +773,8 @@ class MCPAgent:
         """
         # Delegate to remote agent if in remote mode
         if self._is_remote and self._remote_agent:
-            return await self._remote_agent.run(query, max_steps, manage_connector, external_history, output_schema)
+            result = await self._remote_agent.run(query, max_steps, external_history, output_schema)
+            return result
 
         success = True
         start_time = time.time()

--- a/mcp_use/agents/remote.py
+++ b/mcp_use/agents/remote.py
@@ -5,6 +5,7 @@ Remote agent implementation for executing agents via API.
 import json
 import os
 from typing import Any, TypeVar
+from uuid import UUID
 
 import httpx
 from langchain.schema import BaseMessage
@@ -15,25 +16,52 @@ from ..logging import logger
 T = TypeVar("T", bound=BaseModel)
 
 # API endpoint constants
-API_CHATS_ENDPOINT = "/api/v1/chats"
+API_CHATS_ENDPOINT = "/api/v1/chats/get-or-create"
 API_CHAT_EXECUTE_ENDPOINT = "/api/v1/chats/{chat_id}/execute"
 API_CHAT_DELETE_ENDPOINT = "/api/v1/chats/{chat_id}"
+
+UUID_ERROR_MESSAGE = """A UUID is a 36 character string of the format xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx \n
+Example: 123e4567-e89b-12d3-a456-426614174000
+To generate a UUID, you can use the following command:
+import uuid
+
+# Generate a random UUID
+my_uuid = uuid.uuid4()
+print(my_uuid)
+"""
 
 
 class RemoteAgent:
     """Agent that executes remotely via API."""
 
-    def __init__(self, agent_id: str, api_key: str | None = None, base_url: str = "https://cloud.mcp-use.com"):
+    def __init__(
+        self,
+        agent_id: str,
+        chat_id: str | None = None,
+        api_key: str | None = None,
+        base_url: str = "https://cloud.mcp-use.com",
+    ):
         """Initialize remote agent.
 
         Args:
             agent_id: The ID of the remote agent to execute
+            chat_id: The ID of the chat session to use. If None, a new chat session will be created.
             api_key: API key for authentication. If None, will check MCP_USE_API_KEY env var
             base_url: Base URL for the remote API
         """
+
+        if chat_id is not None:
+            try:
+                chat_id = str(UUID(chat_id))
+            except ValueError as e:
+                raise ValueError(
+                    f"Invalid chat ID: {chat_id}, make sure to provide a valid UUID.\n{UUID_ERROR_MESSAGE}"
+                ) from e
+
         self.agent_id = agent_id
+        self.chat_id = chat_id
+        self._session_established = False
         self.base_url = base_url
-        self._chat_id = None  # Persistent chat session
 
         # Handle API key validation
         if api_key is None:
@@ -109,16 +137,10 @@ class RemoteAgent:
                 return output_schema.model_validate({"content": str(result_data)})
             raise
 
-    async def _create_chat_session(self, query: str) -> str:
-        """Create a persistent chat session for the agent.
-        Args:
-            query: The initial query (not used in title anymore)
-        Returns:
-            The chat ID of the created session
-        Raises:
-            RuntimeError: If chat creation fails
-        """
+    async def _upsert_chat_session(self) -> str:
+        """Create or resume a persistent chat session for the agent via upsert."""
         chat_payload = {
+            "id": self.chat_id,  # Include chat_id for resuming or None for creating
             "title": f"Remote Agent Session - {self.agent_id}",
             "agent_id": self.agent_id,
             "type": "agent_execution",
@@ -127,7 +149,7 @@ class RemoteAgent:
         headers = {"Content-Type": "application/json", "x-api-key": self.api_key}
         chat_url = f"{self.base_url}{API_CHATS_ENDPOINT}"
 
-        logger.info(f"📝 Creating chat session for agent {self.agent_id}")
+        logger.info(f"📝 Upserting chat session for agent {self.agent_id}")
 
         try:
             chat_response = await self._client.post(chat_url, json=chat_payload, headers=headers)
@@ -135,7 +157,11 @@ class RemoteAgent:
 
             chat_data = chat_response.json()
             chat_id = chat_data["id"]
-            logger.info(f"✅ Chat session created: {chat_id}")
+            if chat_response.status_code == 201:
+                logger.info(f"✅ New chat session created: {chat_id}")
+            else:
+                logger.info(f"✅ Resumed chat session: {chat_id}")
+
             return chat_id
 
         except httpx.HTTPStatusError as e:
@@ -156,7 +182,6 @@ class RemoteAgent:
         self,
         query: str,
         max_steps: int | None = None,
-        manage_connector: bool = True,
         external_history: list[BaseMessage] | None = None,
         output_schema: type[T] | None = None,
     ) -> str | T:
@@ -166,11 +191,13 @@ class RemoteAgent:
             query: The query to execute
             max_steps: Maximum number of steps (default: 10)
             manage_connector: Ignored for remote execution
-            external_history: Ignored for remote execution (not supported yet)
+        external_history: Ignored for remote execution (not supported yet)
             output_schema: Optional Pydantic model for structured output
 
         Returns:
-            The result from the remote agent execution (string or structured output)
+            A tuple containing:
+                - The result from the remote agent execution (string or structured output)
+                - The chat ID of the execution
         """
         if external_history is not None:
             logger.warning("External history is not yet supported for remote execution")
@@ -178,11 +205,14 @@ class RemoteAgent:
         try:
             logger.info(f"🌐 Executing query on remote agent {self.agent_id}")
 
-            # Step 1: Create a chat session for this agent (only if we don't have one)
-            if self._chat_id is None:
-                self._chat_id = await self._create_chat_session(query)
+            # Step 1: Ensure chat session exists on the backend by upserting.
+            # This happens once per agent instance.
+            if not self._session_established:
+                logger.info(f"🔧 Establishing chat session for agent {self.agent_id}")
+                self.chat_id = await self._upsert_chat_session()
+                self._session_established = True
 
-            chat_id = self._chat_id
+            chat_id = self.chat_id
 
             # Step 2: Execute the agent within the chat context
             execution_payload = {"query": query, "max_steps": max_steps or 10}


### PR DESCRIPTION
With this PR we give the possibility to the user of the library to:
1 - create a chat with a user defined ID, this is useful if they have their own DB of agent executions or chats
2 - resume a conversation or agent execution given a certain chat id. 

