### PR TITLE
feat: [WIP] pretty printer for agent run/stream 

### DIFF
--- a/mcp_use/output/__init__.py
+++ b/mcp_use/output/__init__.py
@@ -1,0 +1,14 @@
+"""
+Output formatting for MCP agent responses.
+"""
+
+from .types import AgentOutput, AgentOutputEvent, EventType
+from .formatter import format_output, format_stream
+
+__all__ = [
+    "AgentOutput",
+    "AgentOutputEvent",
+    "EventType",
+    "format_output",
+    "format_stream",
+]

--- a/mcp_use/output/config.py
+++ b/mcp_use/output/config.py
@@ -1,0 +1,44 @@
+"""
+Configuration for output formatting.
+
+This module provides configuration options for output formatting.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class OutputConfig:
+    """Configuration for output formatting."""
+
+    # Display options
+    markdown: bool = False
+    show_timing: bool = False
+    show_metadata: bool = False
+    show_steps: bool = True
+
+    # Formatting options
+    max_tool_input_length: int = 100
+    max_tool_result_length: int = 200
+    max_thinking_length: int = 300
+
+    # Color scheme
+    tool_call_color: str = "cyan"
+    tool_result_color: str = "green"
+    thinking_color: str = "yellow"
+    error_color: str = "red"
+    success_color: str = "green"
+
+    # Table styling
+    table_box_style: str = "ROUNDED"
+    table_border_color: str = "blue"
+
+    @classmethod
+    def from_dict(cls, config: dict) -> "OutputConfig":
+        """Create config from dictionary."""
+        pass
+
+    def to_dict(self) -> dict:
+        """Convert config to dictionary."""
+        pass

--- a/mcp_use/output/formatter.py
+++ b/mcp_use/output/formatter.py
@@ -1,0 +1,72 @@
+"""
+Output formatters for MCP agent responses.
+
+This module provides functions to format agent outputs
+using the rich library for terminal display.
+"""
+
+from collections.abc import AsyncIterable, Iterable
+from typing import Any, Union
+
+from .types import AgentOutput, AgentOutputEvent
+
+
+def format_output(
+    output: Union[AgentOutput, str, Any],
+    markdown: bool = False,
+    show_metadata: bool = False,
+    show_timing: bool = False,
+) -> None:
+    """
+    Format and display a single agent output.
+
+    Args:
+        output: The agent output to format
+        markdown: Whether to render string content as markdown
+        show_metadata: Whether to show metadata information
+        show_timing: Whether to show timing information
+    """
+    pass
+
+
+async def format_stream(
+    stream: Union[AsyncIterable[AgentOutputEvent], Iterable[AgentOutputEvent]],
+    markdown: bool = False,
+    show_steps: bool = True,
+    show_timing: bool = False,
+) -> None:
+    """
+    Format and display a stream of agent events with live updates.
+
+    Args:
+        stream: The stream of events to format
+        markdown: Whether to render string content as markdown
+        show_steps: Whether to show intermediate steps
+        show_timing: Whether to show timing information
+    """
+    pass
+
+
+def _format_tool_call(tool_name: str, tool_input: dict[str, Any]) -> str:
+    """Format a tool call for display."""
+    pass
+
+
+def _format_tool_result(tool_name: str, result: Any) -> str:
+    """Format a tool result for display."""
+    pass
+
+
+def _format_thinking(content: str, max_length: int = 300) -> str:
+    """Format agent thinking/reasoning for display."""
+    pass
+
+
+def _format_error(error: str) -> str:
+    """Format an error message for display."""
+    pass
+
+
+def _format_metadata(metadata: dict[str, Any]) -> str:
+    """Format metadata information for display."""
+    pass

--- a/mcp_use/output/integration.py
+++ b/mcp_use/output/integration.py
@@ -1,0 +1,126 @@
+"""
+Integration helpers for connecting output formatting with MCPAgent.
+
+This module provides helper functions and decorators to seamlessly
+integrate pretty printing into agent run() and stream() methods.
+"""
+
+from collections.abc import AsyncGenerator
+from typing import Any, Callable, Optional, TypeVar, Union
+
+from langchain_core.agents import AgentAction
+
+from .config import OutputConfig
+from .types import AgentOutput, AgentOutputEvent, EventType
+
+T = TypeVar("T")
+
+
+def create_output_from_result(
+    result: Union[str, Any],
+    execution_time_ms: Optional[int] = None,
+    steps_taken: Optional[int] = None,
+    tools_used: Optional[list[str]] = None,
+    metadata: Optional[dict[str, Any]] = None,
+) -> AgentOutput:
+    """
+    Create an AgentOutput from a result.
+
+    Args:
+        result: The result from agent execution
+        execution_time_ms: Execution time in milliseconds
+        steps_taken: Number of steps taken
+        tools_used: List of tool names used
+        metadata: Additional metadata
+
+    Returns:
+        AgentOutput instance
+    """
+    pass
+
+
+def create_event_from_step(
+    step: tuple[AgentAction, str],
+    event_type: EventType = EventType.TOOL_CALL_COMPLETED,
+) -> AgentOutputEvent:
+    """
+    Create an AgentOutputEvent from an agent step.
+
+    Args:
+        step: Tuple of (AgentAction, observation)
+        event_type: Type of event
+
+    Returns:
+        AgentOutputEvent instance
+    """
+    pass
+
+
+async def wrap_stream_with_formatting(
+    stream: AsyncGenerator[tuple[AgentAction, str] | str | T, None],
+    config: Optional[OutputConfig] = None,
+    auto_print: bool = True,
+) -> AsyncGenerator[tuple[AgentAction, str] | str | T, None]:
+    """
+    Wrap a stream to add automatic formatting.
+
+    This generator wraps the agent's stream and optionally prints
+    formatted output while still yielding the original items.
+
+    Args:
+        stream: The original stream from agent
+        config: Output configuration
+        auto_print: Whether to automatically print formatted output
+
+    Yields:
+        Original stream items
+    """
+    pass
+
+
+def format_and_print_result(
+    result: Union[str, Any],
+    config: Optional[OutputConfig] = None,
+) -> None:
+    """
+    Format and print a single result.
+
+    Args:
+        result: The result to format and print
+        config: Output configuration
+    """
+    pass
+
+
+class OutputCapture:
+    """
+    Context manager for capturing and formatting agent output.
+
+    This can be used to wrap agent execution and automatically
+    format the output.
+    """
+
+    def __init__(self, config: Optional[OutputConfig] = None):
+        """
+        Initialize output capture.
+
+        Args:
+            config: Output configuration
+        """
+        pass
+
+    async def __aenter__(self) -> "OutputCapture":
+        """Enter async context."""
+        pass
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        """Exit async context."""
+        pass
+
+    def capture_event(self, event: AgentOutputEvent) -> None:
+        """Capture an event."""
+        pass
+
+    def get_output(self) -> AgentOutput:
+        """Get the captured output."""
+        pass

--- a/mcp_use/output/printer.py
+++ b/mcp_use/output/printer.py
@@ -1,0 +1,110 @@
+"""
+Pretty printer using rich library.
+
+This module provides the core printing functionality using rich
+for terminal output with tables, colors, and live updates.
+"""
+
+from typing import Any, Optional
+
+from pydantic import BaseModel
+
+
+class OutputPrinter:
+    """Pretty printer for agent outputs using rich."""
+
+    def __init__(
+        self,
+        markdown: bool = False,
+        show_timing: bool = False,
+        show_metadata: bool = False,
+    ):
+        """
+        Initialize the output printer.
+
+        Args:
+            markdown: Whether to render markdown
+            show_timing: Whether to show timing information
+            show_metadata: Whether to show metadata
+        """
+        pass
+
+    def print_output(self, content: Any) -> None:
+        """Print a single output."""
+        pass
+
+    def print_tool_call(self, tool_name: str, tool_input: dict[str, Any]) -> None:
+        """Print a tool call."""
+        pass
+
+    def print_tool_result(self, tool_name: str, result: Any) -> None:
+        """Print a tool result."""
+        pass
+
+    def print_thinking(self, content: str) -> None:
+        """Print agent thinking/reasoning."""
+        pass
+
+    def print_error(self, error: str) -> None:
+        """Print an error message."""
+        pass
+
+    def _format_content(self, content: Any) -> Any:
+        """Format content for display based on type."""
+        pass
+
+    def _create_table(self, content: Any, title: Optional[str] = None) -> Any:
+        """Create a rich table for displaying content."""
+        pass
+
+
+class StreamPrinter:
+    """Pretty printer for streaming agent outputs with live updates."""
+
+    def __init__(
+        self,
+        markdown: bool = False,
+        show_timing: bool = False,
+        show_steps: bool = True,
+    ):
+        """
+        Initialize the stream printer.
+
+        Args:
+            markdown: Whether to render markdown
+            show_timing: Whether to show timing information
+            show_steps: Whether to show intermediate steps
+        """
+        pass
+
+    async def start(self) -> None:
+        """Start the live display."""
+        pass
+
+    async def update_content(self, content: str) -> None:
+        """Update the streaming content."""
+        pass
+
+    async def add_tool_call(self, tool_name: str, tool_input: dict[str, Any]) -> None:
+        """Add a tool call to the display."""
+        pass
+
+    async def add_tool_result(self, tool_name: str, result: Any) -> None:
+        """Add a tool result to the display."""
+        pass
+
+    async def add_thinking(self, content: str) -> None:
+        """Add thinking/reasoning to the display."""
+        pass
+
+    async def finish(self, final_content: Any) -> None:
+        """Finish the live display with final content."""
+        pass
+
+    async def error(self, error: str) -> None:
+        """Display an error and stop."""
+        pass
+
+    def _build_display(self) -> Any:
+        """Build the current display content."""
+        pass

--- a/mcp_use/output/types.py
+++ b/mcp_use/output/types.py
@@ -1,0 +1,61 @@
+"""
+Output types for MCP agent responses.
+
+This module defines the data structures for agent outputs and events.
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum
+from time import time
+from typing import Any, Optional
+
+from pydantic import BaseModel
+
+
+class EventType(str, Enum):
+    """Types of events that can occur during agent execution."""
+
+    AGENT_STARTED = "agent_started"
+    AGENT_THINKING = "agent_thinking"
+    TOOL_CALL_STARTED = "tool_call_started"
+    TOOL_CALL_COMPLETED = "tool_call_completed"
+    AGENT_RESPONSE = "agent_response"
+    AGENT_COMPLETED = "agent_completed"
+    AGENT_ERROR = "agent_error"
+
+
+@dataclass
+class AgentOutputEvent:
+    """Represents an event during agent execution."""
+
+    event_type: EventType
+    timestamp: int = field(default_factory=lambda: int(time()))
+    content: Optional[Any] = None
+    metadata: Optional[dict[str, Any]] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert event to dictionary."""
+        pass
+
+
+@dataclass
+class AgentOutput:
+    """Represents the final output from an agent execution."""
+
+    content: Optional[Any] = None
+    content_type: str = "str"
+    metadata: Optional[dict[str, Any]] = None
+    events: Optional[list[AgentOutputEvent]] = None
+    execution_time_ms: Optional[int] = None
+    steps_taken: Optional[int] = None
+    tools_used: Optional[list[str]] = None
+    success: bool = True
+    error: Optional[str] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert output to dictionary."""
+        pass
+
+    def get_content_as_string(self, **kwargs) -> str:
+        """Get content as formatted string."""
+        pass

--- a/mcp_use/utils/timer.py
+++ b/mcp_use/utils/timer.py
@@ -1,0 +1,41 @@
+"""
+Timer utility for tracking execution time.
+"""
+
+from time import perf_counter
+from typing import Optional
+
+
+class Timer:
+    """Simple timer for tracking execution time."""
+
+    def __init__(self):
+        """Initialize a new timer."""
+        self.start_time: Optional[float] = None
+        self.end_time: Optional[float] = None
+        self.elapsed_time: Optional[float] = None
+
+    @property
+    def elapsed(self) -> float:
+        """Get the elapsed time in seconds."""
+        pass
+
+    def start(self) -> float:
+        """Start the timer."""
+        pass
+
+    def stop(self) -> float:
+        """Stop the timer."""
+        pass
+
+    def __enter__(self) -> "Timer":
+        """Enter context manager."""
+        pass
+
+    def __exit__(self, *args) -> None:
+        """Exit context manager."""
+        pass
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert timer to dictionary."""
+        pass


### PR DESCRIPTION
# Pull Request Description

## Changes

The Implementation includes visually appealing output formatting for agent responses (`run()` or `stream()`) using the `rich` library.

## Implementation Details

```
┌─────────────────────────────────────────────────────────────┐
│                      MCPAgent                               │
│                    (agents/mcpagent.py)                     │
└────────────┬────────────────────────────────────────────────┘
             │
             │ uses
             │
┌────────────▼────────────────────────────────────────────────┐
│                  Integration Layer                          │
│                (output/integration.py)                      │
│                                                             │
│  - wrap_stream_with_formatting()                           │
│  - format_and_print_result()                               │
│  - create_output_from_result()                             │
└────────────┬────────────────────────────────────────────────┘
             │
             │ uses
             │
┌────────────▼────────────────────────────────────────────────┐
│                    Formatter Layer                          │
│                 (output/formatter.py)                       │
│                                                             │
│  - format_output()                                         │
│  - format_stream()                                         │
│  - _format_* helpers                                       │
└──────┬─────────────────────────────────┬───────────────────┘
       │                                 │
       │ uses                            │ uses
       │                                 │
┌──────▼──────────────────┐   ┌─────────▼──────────────────┐
│   Printer Layer         │   │    Types Layer             │
│  (output/printer.py)    │   │  (output/types.py)         │
│                         │   │                            │
│  - OutputPrinter        │   │  - EventType               │
│  - StreamPrinter        │   │  - AgentOutputEvent        │
│                         │   │  - AgentOutput             │
└──────┬──────────────────┘   └────────────────────────────┘
       │
       │ uses
       │
┌──────▼──────────────────┐   ┌────────────────────────────┐
│   Rich Library          │   │   Configuration            │
│                         │   │  (output/config.py)        │
│  - Table                │   │                            │
│  - Console              │   │  - OutputConfig            │
│  - Live                 │   │                            │
│  - Markdown             │   └────────────────────────────┘
│  - JSON                 │
│  - Status               │
└─────────────────────────┘
```

### Directory Tree

```
mcp_use/
├── output/                          # output formatting module
│   ├── __init__.py                 # Public API exports
│   ├── types.py                    # Data structures (EventType, AgentOutputEvent, AgentOutput)
│   ├── formatter.py                # High-level formatting functions
│   ├── printer.py                  # Rich-based printer classes
│   ├── config.py                   # Configuration options
│   └── integration.py              # MCPAgent integration helpers
│
├── utils/                           
│   └── timer.py                    # Timer utility for execution timing
│
└── agents/
   └── mcpagent.py                 # TO BE MODIFIED: Add output formatting integration
```

### Dependencies
`rich>=13.0.0` (to be added)

## Example Usage (Before)

```python
result = await agent.run("What's the weather?")
print(result)
# Output: "The weather in San Francisco is 68°F"
```

## Example Usage (After)

```python
result = await agent.run("What's the weather?")
# Terminal:
#
# ╭────────────────────────────────────────╮
# │ 🤖 Agent Execution                     │
# ├────────────────────────────────────────┤
# │                                        │
# │ 💭 Analyzing request...                │
# │                                        │
# │ 🔧 Tool: weather_api                   │
# │    Input: {"city": "San Francisco"}    │
# │                                        │
# │ 📄 Result: 68°F, partly cloudy         │
# │                                        │
# │ ✅ The weather in San Francisco is     │
# │    68°F with partly cloudy skies.      │
# │                                        │
# ├────────────────────────────────────────┤
# │ ⏱️  1.2s | 🔧 1 tool | 👣 2 steps      │
# ╰────────────────────────────────────────╯
```

## Documentation Updates

None

## Testing

Describe how you tested these changes:
- Unit tests added/modified
- Manual testing performed
- Edge cases considered

## Backwards Compatibility

These changes add a new optional output formatting layer without modifying any existing behaviour, which can be disabled with `auto_format_output=False` parameter