### PR TITLE
feat: Tools integrations for others SDKs [WIP]

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -84,6 +84,10 @@
             ]
           },
           {
+            "group": "Integrations",
+            "pages": ["integration/openai"]
+          },
+          {
             "group": "Agent Configuration",
             "pages": [
               "agent/agent-configuration",

--- a/docs/integration/openai.mdx
+++ b/docs/integration/openai.mdx
@@ -1,0 +1,106 @@
+---
+title: "OpenAI"
+description: "Use MCP-USE tools directly with the OpenAI SDK"
+icon: "cubes"
+---
+
+# Using MCP-USE with OpenAI
+
+The OpenAI adapter allows you to seamlessly integrate tools from any MCP server with the OpenAI Python SDK. This enables you to use `mcp-use` as a tool provider for your OpenAI-powered agents.
+
+## How it Works
+
+The `OpenAIMCPAdapter` converts tools from your active MCP servers into a format compatible with OpenAI's tool-calling feature. It also provides a mapping to execute these tools when requested by the OpenAI model.
+
+## Usage
+
+Here's how to use the adapter to provide tools to an OpenAI Chat Completion:
+
+<CodeGroup>
+  ```python
+  import asyncio
+
+  from dotenv import load_dotenv
+  from openai import OpenAI
+  
+  from mcp_use import MCPClient
+  from mcp_use.adapters import OpenAIMCPAdapter
+  
+  # This example demonstrates how to use our integration
+  # adapaters to use MCP tools and convert to the right format.
+  # In particularly, this example uses the OpenAIMCPAdapter.
+  
+  load_dotenv()
+  
+  
+  async def main():
+      config = {
+          "mcpServers": {
+              "airbnb": {"command": "npx", "args": ["-y", "@openbnb/mcp-server-airbnb", "--ignore-robots-txt"]}
+          }
+      }
+  
+      try:
+          client = MCPClient(config=config)
+  
+          # Creates the adapter for OpenAI's format
+          adapter = OpenAIMCPAdapter()
+  
+          # Convert tools from active connectors to the OpenAI's format
+          openai_tools = await adapter.create_tools(client)
+  
+          # Use tools with OpenAI's SDK (not agent in this case)
+          openai = OpenAI()
+          input_list = [{"role": "user", "content": "Search on Airbnb the cheapest hotel in Trapani for two nights."}]
+          response = openai.chat.completions.create(model="gpt-4o", messages=input_list, tools=openai_tools)
+  
+          response_message = response.choices[0].message
+          input_list.append(response_message)
+          if not response_message.tool_calls:
+              print("No tool call requested by the model")
+              print(response_message.content)
+              return
+  
+          for tool_call in response_message.tool_calls:
+              import json
+  
+              function_name = tool_call.function.name
+              arguments = json.loads(tool_call.function.arguments)
+  
+              # Use the adapter's map to get the correct connector
+              connector = adapter.tool_to_connector_map[function_name]
+  
+              print(f"Executing tool: {function_name}({arguments})")
+              tool_result = await connector.call_tool(name=function_name, arguments=arguments)
+  
+          # Handle and print the result
+          if getattr(tool_result, "isError", False):
+              print(f"Error: {tool_result.content}")
+              return
+  
+          input_list.append(
+              {"tool_call_id": tool_call.id, "role": "tool", "name": function_name, "content": tool_result.content}
+          )
+  
+          # Send the tool result back to the model
+          second_response = openai.chat.completions.create(model="gpt-4o", messages=input_list, tools=openai_tools)
+          final_message = second_response.choices[0].message
+          print("\n--- Final response from the model ---")
+          print(final_message.content)
+  
+      except Exception as e:
+          print(f"Error: {e}")
+  
+  
+  if __name__ == "__main__":
+      asyncio.run(main())
+  ```
+</CodeGroup>
+
+### Key Steps:
+1.  **Initialize `MCPClient`**: Set up your MCP servers as usual.
+2.  **Create `OpenAIMCPAdapter`**: Instantiate the adapter.
+3.  **Generate Tools**: Use `adapter.create_tools(client)` to get a list of OpenAI-compatible tools.
+4.  **Make API Call**: Pass the generated `openai_tools` to the `tools` parameter of `openai.chat.completions.create`.
+5.  **Execute Tool Calls**: When the model returns `tool_calls`, use the `adapter.tool_to_connector_map` to find the correct `connector` for each tool and execute it with `connector.call_tool()`.
+6.  **Return Results**: Send the tool execution results back to the model to get a final response.

--- a/examples/openai_integration_example.py
+++ b/examples/openai_integration_example.py
@@ -1,0 +1,76 @@
+import asyncio
+
+from dotenv import load_dotenv
+from openai import OpenAI
+
+from mcp_use import MCPClient
+from mcp_use.adapters import OpenAIMCPAdapter
+
+# This example demonstrates how to use our integration
+# adapaters to use MCP tools and convert to the right format.
+# In particularly, this example uses the OpenAIMCPAdapter.
+
+load_dotenv()
+
+
+async def main():
+    config = {
+        "mcpServers": {
+            "airbnb": {"command": "npx", "args": ["-y", "@openbnb/mcp-server-airbnb", "--ignore-robots-txt"]}
+        }
+    }
+
+    try:
+        client = MCPClient(config=config)
+
+        # Creates the adapter for OpenAI's format
+        adapter = OpenAIMCPAdapter()
+
+        # Convert tools from active connectors to the OpenAI's format
+        openai_tools = await adapter.create_tools(client)
+
+        # Use tools with OpenAI's SDK (not agent in this case)
+        openai = OpenAI()
+        input_list = [{"role": "user", "content": "Search on Airbnb the cheapest hotel in Trapani for two nights."}]
+        response = openai.chat.completions.create(model="gpt-4o", messages=input_list, tools=openai_tools)
+
+        response_message = response.choices[0].message
+        input_list.append(response_message)
+        if not response_message.tool_calls:
+            print("No tool call requested by the model")
+            print(response_message.content)
+            return
+
+        for tool_call in response_message.tool_calls:
+            import json
+
+            function_name = tool_call.function.name
+            arguments = json.loads(tool_call.function.arguments)
+
+            # Use the adapter's map to get the correct connector
+            connector = adapter.tool_to_connector_map[function_name]
+
+            print(f"Executing tool: {function_name}({arguments})")
+            tool_result = await connector.call_tool(name=function_name, arguments=arguments)
+
+        # Handle and print the result
+        if getattr(tool_result, "isError", False):
+            print(f"Error: {tool_result.content}")
+            return
+
+        input_list.append(
+            {"tool_call_id": tool_call.id, "role": "tool", "name": function_name, "content": tool_result.content}
+        )
+
+        # Send the tool result back to the model
+        second_response = openai.chat.completions.create(model="gpt-4o", messages=input_list, tools=openai_tools)
+        final_message = second_response.choices[0].message
+        print("\n--- Final response from the model ---")
+        print(final_message.content)
+
+    except Exception as e:
+        print(f"Error: {e}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/mcp_use/adapters/__init__.py
+++ b/mcp_use/adapters/__init__.py
@@ -6,5 +6,6 @@ This package provides adapters for converting MCP tools to different frameworks.
 
 from .base import BaseAdapter
 from .langchain_adapter import LangChainAdapter
+from .openai import OpenAIMCPAdapter
 
-__all__ = ["BaseAdapter", "LangChainAdapter"]
+__all__ = ["BaseAdapter", "LangChainAdapter", "OpenAIMCPAdapter"]

--- a/mcp_use/adapters/openai.py
+++ b/mcp_use/adapters/openai.py
@@ -1,0 +1,43 @@
+from typing import Any
+
+from mcp.types import Prompt, Resource, Tool
+
+from ..connectors.base import BaseConnector
+from .base import BaseAdapter
+
+
+class OpenAIMCPAdapter(BaseAdapter):
+    def __init__(self, disallowed_tools: list[str] | None = None) -> None:
+        """Initialize a new OpenAI adapter.
+
+        Args:
+            disallowed_tools: list of tool names that should not be available.
+        """
+        super().__init__(disallowed_tools)
+        self.tool_to_connector_map: dict[str, BaseConnector] = {}
+
+    def _convert_tool(self, mcp_tool: Tool, connector: BaseConnector) -> dict[str, Any]:
+        """Convert an MCP tool to the OpenAI tool format."""
+        self.tool_to_connector_map[mcp_tool.name] = connector
+
+        fixed_schema = self.fix_schema(mcp_tool.inputSchema)
+        return {
+            "type": "function",
+            "function": {
+                "name": mcp_tool.name,
+                "description": mcp_tool.description,
+                "parameters": fixed_schema,
+            },
+        }
+
+    def _convert_resource(self, mcp_resource: Resource, connector: BaseConnector) -> dict[str, Any]:
+        """Convert an MCP resource to a readable tool in OpenAI format."""
+        # This part is not implemented yet.
+        # You would create a tool that calls `connector.read_resource`.
+        return None
+
+    def _convert_prompt(self, mcp_prompt: Prompt, connector: BaseConnector) -> dict[str, Any]:
+        """Convert an MCP prompt to a usable tool in OpenAI format."""
+        # This part is not implemented yet.
+        # You would create a tool that calls `connector.get_prompt`.
+        return None


### PR DESCRIPTION
### Pull Request Description

This pull request introduces the first of our new integration adapters, allowing `mcp-use` to be used directly with other SDKs. This marks a significant step towards making `mcp-use` a universal tool provider that can plug into various LLM ecosystems beyond LangChain.

The initial part of this change is the `OpenAIMCPAdapter`, which handles the conversion of MCP tools into the format expected by OpenAI's tool-calling API. This allows developers to leverage the power of MCP servers while working directly with OpenAI's native tools.

### Key Changes:
*   **New `OpenAIMCPAdapter`**: Added `mcp_use/adapters/openai.py` to manage the conversion of MCP tools to the OpenAI format.
*   **Usage Example**: Included `examples/openai_integration_example.py` to demonstrate how to use the new adapter.
*   **Initial Documentation**: Created a basic documentation page at `docs/integration/openai.mdx`.

<details>
<summary><b>Usage Example (`examples/openai_integration_example.py`)</b></summary>

```python
import asyncio

from dotenv import load_dotenv
from openai import OpenAI

from mcp_use import MCPClient
from mcp_use.adapters import OpenAIMCPAdapter

# This example demonstrates how to use our integration
# adapaters to use MCP tools and convert to the right format.
# In particularly, this example uses the OpenAIMCPAdapter.

load_dotenv()


async def main():
    config = {
        "mcpServers": {
            "airbnb": {"command": "npx", "args": ["-y", "@openbnb/mcp-server-airbnb", "--ignore-robots-txt"]}
        }
    }

    try:
        client = MCPClient(config=config)

        # Creates the adapter for OpenAI's format
        adapter = OpenAIMCPAdapter()

        # Convert tools from active connectors to the OpenAI's format
        openai_tools = await adapter.create_tools(client)

        # Use tools with OpenAI's SDK (not agent in this case)
        openai = OpenAI()
        input_list = [{"role": "user", "content": "Search on Airbnb the cheapest hotel in Trapani for two nights."}]
        response = openai.chat.completions.create(model="gpt-4o", messages=input_list, tools=openai_tools)

        response_message = response.choices[0].message
        input_list.append(response_message)
        if not response_message.tool_calls:
            print("No tool call requested by the model")
            print(response_message.content)
            return

        for tool_call in response_message.tool_calls:
            import json

            function_name = tool_call.function.name
            arguments = json.loads(tool_call.function.arguments)

            # Use the adapter's map to get the correct connector
            connector = adapter.tool_to_connector_map[function_name]

            print(f"Executing tool: {function_name}({arguments})")
            tool_result = await connector.call_tool(name=function_name, arguments=arguments)

        # Handle and print the result
        if getattr(tool_result, "isError", False):
            print(f"Error: {tool_result.content}")
            return

        input_list.append(
            {"tool_call_id": tool_call.id, "role": "tool", "name": function_name, "content": tool_result.content}
        )

        # Send the tool result back to the model
        second_response = openai.chat.completions.create(model="gpt-4o", messages=input_list, tools=openai_tools)
        final_message = second_response.choices[0].message
        print("\n--- Final response from the model ---")
        print(final_message.content)

    except Exception as e:
        print(f"Error: {e}")


if __name__ == "__main__":
    asyncio.run(main())
```
</details>

### Future Integrations
This PR establishes a pattern that we will follow to create adapters for other major LLM providers. Work will begin shortly on similar integrations for:
*   Anthropic
*   Groq
*   Google Gemini

By providing these adapters, we aim to offer developers maximum flexibility in how they build their agents and applications with `mcp-use`.