### PR TITLE
fix: duplicate user message

### DIFF
--- a/mcp_use/agents/mcpagent.py
+++ b/mcp_use/agents/mcpagent.py
@@ -503,10 +503,6 @@ class MCPAgent:
             display_query = query[:50].replace("\n", " ") + "..." if len(query) > 50 else query.replace("\n", " ")
             logger.info(f"💬 Received query: '{display_query}'")
 
-            # Add the user query to conversation history if memory is enabled
-            if self.memory_enabled:
-                self.add_to_history(HumanMessage(content=query))
-
             # Use the provided history or the internal history
             history_to_use = external_history if external_history is not None else self._conversation_history
 


### PR DESCRIPTION
# Pull Request Description

## Changes

This pull request fixes a bug where the user query was duplicated in the system prompt when `memory_enabled=True` was set in the MCPAgent class.

## Example Usage (Before)

```python
agent = MCPAgent(llm=llm, client=client, memory_enabled=True)
await agent.run("What to eat today?")

# Terminal
{
  "prompts": [
    "System: You are a helpful AI assistant.\nYou have access to the following tools:\n\n\n\nUse these tools to help answer questions and complete tasks as needed.\nHuman: hi\nHuman: hi"
  ]
}
```

## Example Usage (After)

```python
agent = MCPAgent(llm=llm, client=client, memory_enabled=True)
await agent.run("What to eat today?")

# Terminal
{
  "prompts": [
    "System: You are a helpful AI assistant.\nYou have access to the following tools:\n\n\n\nUse these tools to help answer questions and complete tasks as needed.\nHuman: hi"
  ]
}
```

## Documentation Updates

None

## Testing

Describe how you tested these changes:
- Verified manually using debug logs with `mcp_use.set_debug(2)`

## Related Issues

Closes #109
