### PR TITLE
feat: interface for tool call management

### DIFF
--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -52,7 +52,7 @@ class TestLangChainAdapterToolCallIDManagement:
         mcp_tool.inputSchema = {"type": "object", "properties": {"arg1": {"type": "string"}}}
 
         tool = adapter._convert_tool(mcp_tool, connector)
-        
+
         result = await tool._arun(arg1="test_value")
 
         # Verify core functionality:
@@ -60,11 +60,13 @@ class TestLangChainAdapterToolCallIDManagement:
         agent._generate_tool_call_id.assert_called_once()
 
         # 2. ToolMessage was created with the ID
-        agent._create_tool_message.assert_called_once_with("call_abc12345", "[{'type': 'text', 'text': 'Tool execution result'}]")
-        
+        agent._create_tool_message.assert_called_once_with(
+            "call_abc12345", "[{'type': 'text', 'text': 'Tool execution result'}]"
+        )
+
         # 3. ToolMessage was added to conversation history
         agent.add_to_history.assert_called_once()
-        
+
         # 4. Tool execution returned correct result
         assert result == "[{'type': 'text', 'text': 'Tool execution result'}]"
 


### PR DESCRIPTION
# Pull Request Description

## Changes

This PR implements Tool Call Management to enable conversation reconstruction by generating unique tool_call_id values that link Assistant Messages with Tool Messages. The implementation adds minimal functionality to track tool calls without introducing persistent memory management.

Message chain flow:
```
HumanMessage: "What's 2 + 3?"
AIMessage: [tool_call_id: "t1", tool_calls: [{"name": "calculator", "args": {"x": 2, "y": 3}}]]
ToolMessage: [tool_call_id: "t1", content: "5"]
AIMessage: "The answer is 5"
```

## Implementation Details

- Added `_generate_tool_call_id()` method using UUID for unique ID generation
- Added `_create_tool_message()` helper method for ToolMessage creation
- Updated `_arun()` method to generate `tool_call_id` before execution and create `ToolMessage` after execution
- `ToolMessage` will now be recorded into the existing conversation history

## Example Usage (Before)

```python
history = agent.get_conversation_history()
# [HumanMessage, AIMessage]
```

## Example Usage (After)

```python
history = agent.get_conversation_history()
# [ToolMessage(tool_call_id="call_abc12345"), HumanMessage, AIMessage]
```

## Documentation Updates

None

## Testing

- added tests in test_agent for tool call ID management
- added tests in test_adapter for LangChainAdapter integration

Validates ID generation, ToolMessage creation, and conversation history integration

## Backwards Compatibility

All existing code continues to work without modification, existing conversation history methods are unchanged

## Related Issues

Closes #276
