### PR TITLE
feat: Add Morph MCP integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ This streaming interface is ideal for applications that require real-time update
 
 MCP-Use supports integration with various MCP servers. Below are detailed examples for each supported server.
 
-[Morph](https://morph.so) provides AI-powered code editing capabilities through MCP. The Fast Apply feature enables efficient code modifications with minimal context.
+[Morph](https://morphllm.com) provides AI-powered code editing capabilities through MCP. The Fast Apply feature enables efficient code modifications with minimal context.
 
 ```python
 import asyncio
@@ -292,7 +292,7 @@ Example configuration file (`examples/configs/morph_fast_apply.json`):
   "mcpServers": {
     "morph": {
       "command": "npx",
-      "args": ["-y", "@morph-labs/mcp-morph"],
+      "args": ["-y", "@morph-llm/morph-fast-apply"],
       "env": {
         "MORPH_API_KEY": "your-api-key-here",
         "ALL_TOOLS": "false"


### PR DESCRIPTION
Add Morph Fast Apply as a ready-to-use preset for mcp-use library. Morph provides fast, robust code edits through MCP.

Changes:
- Add config preset: examples/configs/morph_fast_apply.json
- Add agent example: examples/morph_fast_apply.py (with Claude)
- Add tools example: examples/morph_tools_langchain.py
- Add server docs: docs/servers/morph.mdx
- Add integration example to docs/api-reference/adapters.mdx
- Add test: tests/test_morph_detects_tools.py (skips if no API key)
- Update README.md with Morph preset reference

Key implementation details:
- Uses os.getenv() to properly pass MORPH_API_KEY to subprocess
- Safe-by-default with ALL_TOOLS=false (only exposes edit_file)
- Examples use ChatAnthropic (Claude) instead of OpenAI
- Test gracefully skips when MORPH_API_KEY not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)