### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,23 +450,7 @@ You can configure multiple servers in your configuration file:
 ```
 
 ## Usage
-
-The `MCPClient` class provides methods for managing connections to multiple servers. When creating an `MCPAgent`, you can provide an `MCPClient` configured with multiple servers.
-
-By default, the agent will have access to tools from all configured servers. If you need to target a specific server for a particular task, you can specify the `server_name` when calling the `agent.run()` method.
-
-```python
-# Example: Manually selecting a server for a specific task
-result = await agent.run(
-    "Search for Airbnb listings in Barcelona",
-    server_name="airbnb" # Explicitly use the airbnb server
-)
-
-result_google = await agent.run(
-    "Find restaurants near the first result using Google Search",
-    server_name="playwright" # Explicitly use the playwright server
-)
-```
+**There is no server_name argument in the run method.**
 
 ## Dynamic Server Selection (Server Manager)
 


### PR DESCRIPTION
# Pull Request: Fix documentation — remove `server_name` example (not supported)

## Summary of Changes

This PR corrects the documentation of the `MCPAgent.run(...)` method by removing or clarifying the example that uses a `server_name` argument. The current implementation does **not** support a `server_name` parameter, so the docs are misleading.  

Specifically:

- In `README.md` (or whichever doc file contains the example), the lines showing `agent.run(..., server_name="...")` are removed or replaced.
- A note is added clarifying that as of this version, `MCPAgent.run()` does not accept a `server_name` argument.
- If relevant, tests or examples referencing `server_name` are updated/removed.

## Implementation Details

1. Locate the documentation file(s) where the `server_name` usage is illustrated (e.g. `README.md`, `docs/usage.md`, or similar).  
2. Remove or replace the example code that passes `server_name` to `agent.run()`.  
3. Insert a short explanatory note in that section, such as:

   > _Note: the `server_name` parameter is not supported in the current version of `MCPAgent.run()` — the agent dynamically routes to servers based on tool selection._

4. Ensure the revised example uses only the supported arguments for `agent.run(...)` (e.g. `prompt`, `max_steps`, etc.).  
5. Update any references or commentary in the doc that imply `server_name` support (including in the introduction or “Usage” section).  
6. If there are auto-generated docs or docs build tools, ensure rebuilding / verifying them if needed.  
7. No new dependencies are required; this is purely a doc fix.

## Example Usage (Before)

```python
# The old (misleading) example in docs

result = await agent.run(
    "Search for Airbnb listings in Barcelona",
    server_name="airbnb"  # Explicitly use the airbnb server
)

result2 = await agent.run(
    "Find restaurants near the first result using Google Search",
    server_name="playwright"
)
