### PR TITLE
fix: python: docs: astream removed

### DIFF
--- a/docs/python/api-reference/mcp_use_agents_mcpagent.mdx
+++ b/docs/python/api-reference/mcp_use_agents_mcpagent.mdx
@@ -305,7 +305,7 @@ Asynchronous streaming interface.
 
         Example::
 
-            async for chunk in agent.astream("hello"):
+            async for chunk in agent.stream("hello"):
                 print(chunk, end="|", flush=True)
 
 

--- a/docs/python/development/telemetry.mdx
+++ b/docs/python/development/telemetry.mdx
@@ -20,7 +20,7 @@ MCP-use includes an **opt-out telemetry system** that helps us understand how th
 ## What We Collect
 
 ### Agent Execution Data
-When you use `MCPAgent.run()` or `MCPAgent.astream()`, we collect:
+When you use `MCPAgent.run()` or `MCPAgent.stream()`, we collect:
 
 - **Query and response content** (to understand use cases)
 - **Model provider and name** (e.g., "openai", "gpt-4")

--- a/docs/python/getting-started/quickstart.mdx
+++ b/docs/python/getting-started/quickstart.mdx
@@ -243,7 +243,7 @@ Stream agent responses as they're generated:
 
 <CodeGroup>
   ```python Python
-  async for chunk in agent.astream("your query here"):
+  async for chunk in agent.stream("your query here"):
       print(chunk, end="", flush=True)
   ```
 

--- a/libraries/python/mcp_use/agents/mcpagent.py
+++ b/libraries/python/mcp_use/agents/mcpagent.py
@@ -1051,7 +1051,7 @@ class MCPAgent:
 
         Example::
 
-            async for chunk in agent.astream("hello"):
+            async for chunk in agent.stream("hello"):
                 print(chunk, end="|", flush=True)
         """
         start_time = time.time()


### PR DESCRIPTION
This pull request updates the documentation and code examples to reflect a change in the method name for streaming agent responses. The method previously called `astream` has been renamed to `stream` throughout the documentation and in the `MCPAgent` Python class.

Method name update:

* Updated all usage examples in documentation files (`quickstart.mdx`, `mcp_use_agents_mcpagent.mdx`, and `telemetry.mdx`) to use `agent.stream()` instead of `agent.astream()`. [[1]](diffhunk://#diff-8983319116eafc799ed9c80673d8698ab1159197fcb3dd159dbeb273795b81f0L246-R246) [[2]](diffhunk://#diff-3da5811e9a1f39be02eb9c80fc004e56ceea3051cbe772edd832cb31ce8b53beL308-R308) [[3]](diffhunk://#diff-21468d6ec87772b77aed8970bb4713d0968a16eb8c0a913e4d8daef39108e109L23-R23)
* Changed the example in the `stream_events` method docstring in `mcpagent.py` to use `agent.stream()` for consistency with the new method name.