### PR TITLE
python: chore: locked langchain dependencies in pyproject.toml

### DIFF
--- a/libraries/python/pyproject.toml
+++ b/libraries/python/pyproject.toml
@@ -21,7 +21,8 @@ classifiers = [
 ]
 dependencies = [
     "mcp>=1.10.0",
-    "langchain>=0.1.0",
+    "langchain==0.3.27",
+    "langchain-core==0.3.79",
     "websockets>=15.0",
     "aiohttp>=3.9.0",
     "pydantic==2.11.10",


### PR DESCRIPTION
Langchain recent release https://docs.langchain.com/oss/python/releases/langchain-v1 broke the library.
Need to update and lock langchain to a older version. We are going to migrate either to the new version or away from langchain. 