### PR TITLE
chore(release): simplify canary reset process in TypeScript workflow

### DIFF
--- a/.github/workflows/typescript-release.yml
+++ b/.github/workflows/typescript-release.yml
@@ -153,7 +153,7 @@ jobs:
           
           echo "✅ Created consolidated GitHub release: $RELEASE_TITLE"
 
-      - name: Reset canary to main and re-enter prerelease
+      - name: Reset canary to main
         if: steps.check.outputs.should_publish == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -168,21 +168,8 @@ jobs:
           # Checkout canary and reset to main (clean slate with stable versions)
           git checkout canary
           git reset --hard origin/main
-          
-          echo "✅ Reset canary to match main"
-
-          # Re-enter prerelease mode on canary
-          cd libraries/typescript
-          pnpm changeset pre enter canary
-          
-          echo "✅ Re-entered prerelease mode on canary branch"
-
-          # Commit the prerelease mode change
-          cd ../..
-          git add .
-          git commit -m "chore: re-enter prerelease mode on canary after stable release"
 
           # Force push canary (since we did a reset)
           git push --force origin canary
 
-          echo "✅ Canary branch reset to main and re-entered prerelease mode"
+          echo "✅ Reset canary to main (canary workflow will auto-enter prerelease mode)"


### PR DESCRIPTION
- Updated the TypeScript release workflow to reset the canary branch to match the main branch without re-entering prerelease mode.
- Removed unnecessary steps related to prerelease mode, streamlining the workflow for better clarity and efficiency.
