### PR TITLE
Message ID inclusion to the conversation history

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -129,7 +129,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Fail if docs are outdated
-        if: steps.check_docs.outputs.docs_outdated == 'true' && github.event.pull_request.head.repo.full_name == github.repository
+        if: steps.check_docs.outputs.docs_outdated == 'true' && github.event.pull_request.head.repo.full_name == github.repository && github.event_name == 'pull_request' 
         run: |
           echo "Please update the API documentation and commit the changes."
           exit 1

--- a/libraries/python/mcp_use/agents/mcpagent.py
+++ b/libraries/python/mcp_use/agents/mcpagent.py
@@ -1037,7 +1037,11 @@ class MCPAgent:
                     for message in output:
                         if not isinstance(message, ToolAgentAction):
                             if self.message_id:
-                                message["id"] = self.message_id
+                                try:
+                                    message.id = self.message_id
+                                except (AttributeError, TypeError):
+                                    if isinstance(message, dict):
+                                        message["id"] = self.message_id
                             self.add_to_history(message)
             yield event
 


### PR DESCRIPTION
# Pull Request Description

## Changes

We are passing the Message Id variable into the conversation history to better identify the messages within the same session.

## Implementation Details

The BaseMessage of langchain has capabilities to accept the ID which we can use to identify the exact message incase we need to use it for training or feedback purposes


