### PR TITLE
Fix: client_info url property

### DIFF
--- a/libraries/python/mcp_use/client/connectors/base.py
+++ b/libraries/python/mcp_use/client/connectors/base.py
@@ -11,7 +11,12 @@ from datetime import timedelta
 from typing import Any
 
 from mcp import ClientSession, Implementation
-from mcp.client.session import ElicitationFnT, LoggingFnT, MessageHandlerFnT, SamplingFnT
+from mcp.client.session import (
+    ElicitationFnT,
+    LoggingFnT,
+    MessageHandlerFnT,
+    SamplingFnT,
+)
 from mcp.shared.exceptions import McpError
 from mcp.types import (
     CallToolResult,
@@ -76,7 +81,7 @@ class BaseConnector(ABC):
         return Implementation(
             name="mcp-use",
             version=mcp_use.__version__,
-            url="https://github.com/mcp-use/mcp-use",
+            websiteUrl="https://github.com/mcp-use/mcp-use",
         )
 
     async def _internal_message_handler(self, message: Any) -> None:
@@ -353,7 +358,10 @@ class BaseConnector(ABC):
 
     @telemetry("connector_call_tool")
     async def call_tool(
-        self, name: str, arguments: dict[str, Any], read_timeout_seconds: timedelta | None = None
+        self,
+        name: str,
+        arguments: dict[str, Any],
+        read_timeout_seconds: timedelta | None = None,
     ) -> CallToolResult:
         """Call an MCP tool with automatic reconnection handling.
 


### PR DESCRIPTION
There was an update on the client_info implementation that broke totally the functionality of the framework, previously was:
```python
return Implementation(
            name="mcp-use",
            version=mcp_use.__version__,
            url="https://github.com/mcp-use/mcp-use",
        )
```
Therefore, I updated it with new correct properties.