### PR TITLE
feat(python): enable negative logging level to suppress all logs

### DIFF
--- a/docs/python/advanced/logging.mdx
+++ b/docs/python/advanced/logging.mdx
@@ -62,9 +62,10 @@ Programmatic control is useful for debugging specific parts of your application 
 import mcp_use
 
 # Different debug levels
+mcp_use.set_debug(-1)  # Silent mode (no logs)
+mcp_use.set_debug(0)  # WARNING level only
 mcp_use.set_debug(1)  # INFO level
 mcp_use.set_debug(2)  # DEBUG level (full verbose output)
-mcp_use.set_debug(0)  # Turn off debug (WARNING level)
 ```
 </CodeGroup>
 
@@ -84,7 +85,15 @@ if os.getenv("ENVIRONMENT") == "development":
 
 ## Debug Levels
 
-<CardGroup cols={3}>
+<CardGroup cols={4}>
+  <Card title="Level -1 - Silent" icon="volume-xmark">
+    **No Output**
+
+    Suppresses all log messages from mcp-use
+
+    `DEBUG=-1` or `set_debug(-1)`
+  </Card>
+
   <Card title="Level 0 - Normal" icon="volume-off">
     **Minimal Output**
 

--- a/docs/python/development/logging.mdx
+++ b/docs/python/development/logging.mdx
@@ -62,9 +62,10 @@ Programmatic control is useful for debugging specific parts of your application 
 import mcp_use
 
 # Different debug levels
+mcp_use.set_debug(-1)  # Silent mode (no logs)
+mcp_use.set_debug(0)  # WARNING level only
 mcp_use.set_debug(1)  # INFO level
 mcp_use.set_debug(2)  # DEBUG level (full verbose output)
-mcp_use.set_debug(0)  # Turn off debug (WARNING level)
 ```
 </CodeGroup>
 
@@ -84,7 +85,15 @@ if os.getenv("ENVIRONMENT") == "development":
 
 ## Debug Levels
 
-<CardGroup cols={3}>
+<CardGroup cols={4}>
+  <Card title="Level -1 - Silent" icon="volume-xmark">
+    **No Output**
+
+    Suppresses all log messages from mcp-use
+
+    `DEBUG=-1` or `set_debug(-1)`
+  </Card>
+
   <Card title="Level 0 - Normal" icon="volume-off">
     **Minimal Output**
 

--- a/libraries/python/mcp_use/logging.py
+++ b/libraries/python/mcp_use/logging.py
@@ -59,7 +59,7 @@ class Logger:
 
         Args:
             level: Log level (default: DEBUG if MCP_USE_DEBUG is 2,
-            INFO if MCP_USE_DEBUG is 1,
+            INFO if MCP_USE_DEBUG is 1, CRITICAL+1 if MCP_USE_DEBUG < 0,
             otherwise WARNING)
             format_str: Log format string (default: DEFAULT_FORMAT)
             log_to_console: Whether to log to console (default: True)
@@ -73,6 +73,8 @@ class Logger:
                 level = logging.DEBUG
             elif MCP_USE_DEBUG == 1:
                 level = logging.INFO
+            elif MCP_USE_DEBUG < 0:
+                level = logging.CRITICAL + 1
             else:
                 level = logging.WARNING
         elif isinstance(level, str):
@@ -114,7 +116,7 @@ class Logger:
         """Set the debug flag and update the log level accordingly.
 
         Args:
-            debug_level: Debug level (0=off, 1=info, 2=debug)
+            debug_level: Debug level (-1=silent, 0=warning, 1=info, 2=debug)
         """
         global MCP_USE_DEBUG
         MCP_USE_DEBUG = debug_level
@@ -125,6 +127,9 @@ class Logger:
             langchain_set_debug(True)
         elif debug_level == 1:
             target_level = logging.INFO
+            langchain_set_debug(False)
+        elif debug_level < 0:
+            target_level = logging.CRITICAL + 1
             langchain_set_debug(False)
         else:
             target_level = logging.WARNING
@@ -151,6 +156,8 @@ if debug_env == "2":
     MCP_USE_DEBUG = 2
 elif debug_env == "1":
     MCP_USE_DEBUG = 1
+elif debug_env == "-1":
+    MCP_USE_DEBUG = -1
 
 # Configure default logger
 Logger.configure()


### PR DESCRIPTION
This pull request adds support for a new "silent" debug level to the `mcp_use` Python logging system, allowing users to suppress all log output. The documentation has been updated to reflect this new debug level, and the implementation now handles the `-1` level, setting the logger to a value above `CRITICAL` to ensure no logs are emitted.

**Logging system enhancements:**

* Added support for a silent debug level (`-1`) in the `set_debug` method and logger configuration, which sets the log level to `CRITICAL + 1` to suppress all output. [[1]](diffhunk://#diff-441e7d7eabbc5ac54e45e0a8408f6e68acdcfdf41600b14446729649e842d208R76-R77) [[2]](diffhunk://#diff-441e7d7eabbc5ac54e45e0a8408f6e68acdcfdf41600b14446729649e842d208R131-R133)
* Updated the environment variable handling to recognize `DEBUG=-1` and set the debug level accordingly.
* Improved docstrings and comments to document the new `-1` silent level in both the `configure` and `set_debug` methods. [[1]](diffhunk://#diff-441e7d7eabbc5ac54e45e0a8408f6e68acdcfdf41600b14446729649e842d208L62-R62) [[2]](diffhunk://#diff-441e7d7eabbc5ac54e45e0a8408f6e68acdcfdf41600b14446729649e842d208L117-R119)

**Documentation updates:**

* Updated code examples in `logging.mdx` files to show usage of the new silent mode and clarified the meaning of each debug level.
* Expanded the debug levels documentation UI to include a card for the silent mode, explaining its effect and usage.