### PR TITLE
Fix inspector button overflow

### DIFF
--- a/libraries/typescript/packages/inspector/src/client/components/LayoutHeader.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/LayoutHeader.tsx
@@ -75,10 +75,10 @@ export function LayoutHeader({
   };
 
   return (
-    <header className="w-full mx-auto">
-      <div className="flex items-center justify-between">
+    <header className="w-full mx-auto overflow-hidden">
+      <div className="flex items-center justify-between min-w-0">
         {/* Left side: Server dropdown + Tabs + Tunnel Badge */}
-        <div className="flex items-center space-x-6">
+        <div className="flex items-center space-x-6 min-w-0 flex-1">
           {/* Server Selection Dropdown */}
           <ServerDropdown
             connections={connections}
@@ -92,8 +92,9 @@ export function LayoutHeader({
             <Tabs
               value={activeTab}
               onValueChange={(tab) => onTabChange(tab as TabType)}
+              className="min-w-0 shrink"
             >
-              <TabsList>
+              <TabsList className="min-w-0">
                 {tabs.map((tab) => {
                   // Get count for the current tab
                   let count = 0;
@@ -219,7 +220,7 @@ export function LayoutHeader({
         </div>
 
         {/* Right side: Theme Toggle + Command Palette + Discord Button + Logo */}
-        <div className="flex items-center gap-4">
+        <div className="flex items-center gap-4 shrink-0">
           <Tooltip>
             <TooltipTrigger>
               <AnimatedThemeToggler className="p-2 hover:bg-zinc-200 dark:hover:bg-zinc-800 rounded-full transition-colors cursor-pointer" />


### PR DESCRIPTION
# Pull Request Description

## Changes

This PR resolves an issue where buttons and tabs in the `LayoutHeader` would overflow horizontally when the window width was reduced, leading to a broken UI. The fix utilizes flexbox properties to ensure elements shrink and wrap appropriately.

## Implementation Details

1.  **`LayoutHeader.tsx`**:
    *   Added `overflow-hidden` to the `<header>` element to prevent horizontal scrolling.
    *   Added `min-w-0` to the main flex container `div` to allow its children to shrink below their intrinsic content size.
    *   Added `min-w-0 flex-1` to the left-side container (ServerDropdown + Tabs + Tunnel Badge) to allow it to shrink and occupy available space.
    *   Added `shrink-0` to the right-side container (Theme Toggle + Command Palette + Github + Logo) to prevent these buttons from shrinking.
    *   Added `min-w-0 shrink` to the `Tabs` component and `min-w-0` to `TabsList` to ensure tabs can shrink properly when space is constrained.

## Example Usage (Before)

```python
# Refer to the image in the Linear issue for the "before" state.
# The issue describes a visual overflow, not a functional code change.
```

## Example Usage (After)

```python
# The "after" state is the visually corrected layout where buttons and tabs
# no longer overflow the header when the window is resized.
```

## Documentation Updates

No documentation files were updated.

## Testing

*   **Manual testing**: Verified by resizing the browser window to various widths, ensuring that the header elements (buttons, tabs, dropdowns) correctly adapt and do not overflow.

## Backwards Compatibility

These changes are purely related to UI styling and are fully backwards compatible. No user-facing API or functional changes were introduced.

## Related Issues

Closes #MCP-682

---
Linear Issue: [MCP-682](https://linear.app/mcp-use/issue/MCP-682/fix-inspector-button-overflow)

<a href="https://cursor.com/background-agent?bcId=bc-400c502a-aaec-40cf-920d-f886cb9e352c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-400c502a-aaec-40cf-920d-f886cb9e352c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

