### PR TITLE
Add task manager testing coverage

### DIFF
--- a/libraries/python/tests/unit/test_base_connection_manager.py
+++ b/libraries/python/tests/unit/test_base_connection_manager.py
@@ -1,0 +1,301 @@
+"""
+Unit tests for BaseConnectionManager (ConnectionManager).
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mcp_use.client.task_managers.base import ConnectionManager
+
+
+class MockConnectionManager(ConnectionManager[str]):
+    """Mock implementation of ConnectionManager for testing."""
+
+    def __init__(self, connection_result: str = "test_connection", should_fail: bool = False):
+        """Initialize mock connection manager.
+
+        Args:
+            connection_result: The connection object to return
+            should_fail: If True, raise an exception during connection
+        """
+        super().__init__()
+        self.connection_result = connection_result
+        self.should_fail = should_fail
+        self.establish_called = False
+        self.close_called = False
+
+    async def _establish_connection(self) -> str:
+        """Mock connection establishment."""
+        self.establish_called = True
+        if self.should_fail:
+            raise ConnectionError("Connection failed")
+        await asyncio.sleep(0.01)  # Simulate async work
+        return self.connection_result
+
+    async def _close_connection(self) -> None:
+        """Mock connection closure."""
+        self.close_called = True
+        await asyncio.sleep(0.01)  # Simulate async work
+
+
+class TestConnectionManagerInitialization:
+    """Tests for ConnectionManager initialization."""
+
+    def test_init(self):
+        """Test that ConnectionManager initializes correctly."""
+        manager = MockConnectionManager()
+
+        assert manager._ready_event is not None
+        assert manager._done_event is not None
+        assert manager._stop_event is not None
+        assert manager._exception is None
+        assert manager._connection is None
+        assert manager._task is None
+
+    def test_get_streams_before_connection(self):
+        """Test get_streams returns None before connection."""
+        manager = MockConnectionManager()
+        assert manager.get_streams() is None
+
+
+class TestConnectionManagerConnectionLifecycle:
+    """Tests for connection lifecycle management."""
+
+    @pytest.mark.asyncio
+    async def test_start_establishes_connection(self):
+        """Test that start() establishes a connection."""
+        manager = MockConnectionManager(connection_result="test_conn")
+
+        connection = await manager.start()
+
+        assert connection == "test_conn"
+        assert manager._connection == "test_conn"
+        assert manager.establish_called is True
+        assert manager._ready_event.is_set()
+        assert manager._task is not None
+
+    @pytest.mark.asyncio
+    async def test_start_raises_exception_on_failure(self):
+        """Test that start() raises exception when connection fails."""
+        manager = MockConnectionManager(should_fail=True)
+
+        with pytest.raises(ConnectionError, match="Connection failed"):
+            await manager.start()
+
+        assert manager.establish_called is True
+        assert manager._exception is not None
+        assert isinstance(manager._exception, ConnectionError)
+
+    @pytest.mark.asyncio
+    async def test_start_resets_state(self):
+        """Test that start() resets state properly."""
+        manager = MockConnectionManager()
+
+        # Set events manually to simulate previous state
+        manager._ready_event.set()
+        manager._done_event.set()
+        manager._exception = ValueError("Previous error")
+
+        await manager.start()
+
+        # State should be reset
+        assert manager._exception is None
+        assert manager._connection == "test_connection"
+
+    @pytest.mark.asyncio
+    async def test_stop_closes_connection(self):
+        """Test that stop() closes the connection."""
+        manager = MockConnectionManager()
+
+        await manager.start()
+        await manager.stop()
+
+        assert manager.close_called is True
+        assert manager._connection is None
+        assert manager._done_event.is_set()
+
+    @pytest.mark.asyncio
+    async def test_stop_waits_for_task_completion(self):
+        """Test that stop() waits for task to complete."""
+        manager = MockConnectionManager()
+
+        await manager.start()
+        task = manager._task
+
+        await manager.stop()
+
+        assert task.done() is True
+
+    @pytest.mark.asyncio
+    async def test_stop_handles_already_stopped(self):
+        """Test that stop() handles already stopped manager."""
+        manager = MockConnectionManager()
+
+        await manager.start()
+        await manager.stop()
+
+        # Stop again should not raise
+        await manager.stop()
+
+        assert manager.close_called is True
+
+    @pytest.mark.asyncio
+    async def test_stop_without_start(self):
+        """Test that stop() works even if start() was never called."""
+        manager = MockConnectionManager()
+
+        # Should not raise
+        await manager.stop()
+
+        assert manager._done_event.is_set()
+
+    @pytest.mark.asyncio
+    async def test_full_lifecycle(self):
+        """Test complete connection lifecycle: connect → use → disconnect."""
+        manager = MockConnectionManager(connection_result="my_connection")
+
+        # Connect
+        connection = await manager.start()
+        assert connection == "my_connection"
+        assert manager.get_streams() == "my_connection"
+
+        # Use connection
+        assert manager._connection is not None
+
+        # Disconnect
+        await manager.stop()
+        assert manager.get_streams() is None
+        assert manager.close_called is True
+
+
+class TestConnectionManagerErrorHandling:
+    """Tests for error handling."""
+
+    @pytest.mark.asyncio
+    async def test_connection_error_propagated(self):
+        """Test that connection errors are propagated."""
+        manager = MockConnectionManager(should_fail=True)
+
+        with pytest.raises(ConnectionError):
+            await manager.start()
+
+        assert manager._exception is not None
+
+    @pytest.mark.asyncio
+    async def test_close_error_logged_not_raised(self):
+        """Test that errors during close are logged but not raised."""
+        manager = MockConnectionManager()
+
+        # Override close to raise an error
+        async def failing_close():
+            raise RuntimeError("Close failed")
+
+        manager._close_connection = failing_close
+
+        await manager.start()
+
+        # Stop should not raise, even if close fails
+        with patch("mcp_use.client.task_managers.base.logger") as mock_logger:
+            await manager.stop()
+
+        # Error should be logged
+        mock_logger.warning.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_establish_error_stored(self):
+        """Test that establishment errors are stored."""
+        manager = MockConnectionManager(should_fail=True)
+
+        try:
+            await manager.start()
+        except ConnectionError:
+            pass
+
+        assert manager._exception is not None
+        assert isinstance(manager._exception, ConnectionError)
+
+
+class TestConnectionManagerTaskManagement:
+    """Tests for task management."""
+
+    @pytest.mark.asyncio
+    async def test_task_created_on_start(self):
+        """Test that a task is created when start() is called."""
+        manager = MockConnectionManager()
+
+        assert manager._task is None
+
+        await manager.start()
+
+        assert manager._task is not None
+        assert manager._task.get_name() == "MockConnectionManager_task"
+
+    @pytest.mark.asyncio
+    async def test_task_completes_on_stop(self):
+        """Test that task completes when stop() is called."""
+        manager = MockConnectionManager()
+
+        await manager.start()
+        task = manager._task
+
+        await manager.stop()
+
+        assert task.done() is True
+
+    @pytest.mark.asyncio
+    async def test_stop_event_signals_task(self):
+        """Test that stop event signals the task to stop."""
+        manager = MockConnectionManager()
+
+        await manager.start()
+
+        # Task should be waiting on stop_event
+        assert not manager._stop_event.is_set()
+
+        await manager.stop()
+
+        # Stop event should be set
+        assert manager._stop_event.is_set()
+
+
+class TestConnectionManagerConcurrency:
+    """Tests for concurrent operations."""
+
+    @pytest.mark.asyncio
+    async def test_multiple_starts_sequential(self):
+        """Test that multiple sequential starts work correctly."""
+        manager = MockConnectionManager()
+
+        conn1 = await manager.start()
+        await manager.stop()
+
+        conn2 = await manager.start()
+        await manager.stop()
+
+        assert conn1 == conn2 == "test_connection"
+        assert manager.establish_called is True
+
+    @pytest.mark.asyncio
+    async def test_get_streams_during_connection(self):
+        """Test get_streams() behavior during connection."""
+        manager = MockConnectionManager()
+
+        # Before start
+        assert manager.get_streams() is None
+
+        # During start (before ready)
+        start_task = asyncio.create_task(manager.start())
+
+        # Give it a moment to start establishing
+        await asyncio.sleep(0.005)
+
+        # Connection might not be ready yet
+        # After start completes
+        await start_task
+        assert manager.get_streams() == "test_connection"
+
+        # After stop
+        await manager.stop()
+        assert manager.get_streams() is None

--- a/libraries/python/tests/unit/test_sse_connection_manager.py
+++ b/libraries/python/tests/unit/test_sse_connection_manager.py
@@ -1,0 +1,248 @@
+"""
+Unit tests for SseConnectionManager.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import httpx
+import pytest
+
+from mcp_use.client.task_managers.sse import SseConnectionManager
+
+
+class TestSseConnectionManagerInitialization:
+    """Tests for SseConnectionManager initialization."""
+
+    def test_init_with_url_only(self):
+        """Test initialization with URL only."""
+        url = "http://localhost:8080/sse"
+        manager = SseConnectionManager(url)
+
+        assert manager.url == url
+        assert manager.headers == {}
+        assert manager.timeout == 5
+        assert manager.sse_read_timeout == 60 * 5
+        assert manager.auth is None
+        assert manager.httpx_client_factory is None
+        assert manager._sse_ctx is None
+
+    def test_init_with_all_parameters(self):
+        """Test initialization with all parameters."""
+        url = "http://localhost:8080/sse"
+        headers = {"Authorization": "Bearer token"}
+        timeout = 10.0
+        sse_read_timeout = 120.0
+        auth = httpx.BasicAuth("user", "pass")
+        client_factory = Mock()
+
+        manager = SseConnectionManager(
+            url=url,
+            headers=headers,
+            timeout=timeout,
+            sse_read_timeout=sse_read_timeout,
+            auth=auth,
+            httpx_client_factory=client_factory,
+        )
+
+        assert manager.url == url
+        assert manager.headers == headers
+        assert manager.timeout == timeout
+        assert manager.sse_read_timeout == sse_read_timeout
+        assert manager.auth == auth
+        assert manager.httpx_client_factory == client_factory
+
+    def test_init_with_none_headers(self):
+        """Test initialization with None headers."""
+        url = "http://localhost:8080/sse"
+        manager = SseConnectionManager(url, headers=None)
+
+        assert manager.headers == {}
+
+
+class TestSseConnectionManagerConnection:
+    """Tests for connection establishment and closure."""
+
+    @pytest.mark.asyncio
+    @patch("mcp_use.client.task_managers.sse.sse_client")
+    async def test_establish_connection_success(self, mock_sse_client):
+        """Test successful connection establishment."""
+        url = "http://localhost:8080/sse"
+        manager = SseConnectionManager(url)
+
+        # Mock the context manager
+        mock_ctx = MagicMock()
+        mock_read_stream = Mock()
+        mock_write_stream = Mock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=(mock_read_stream, mock_write_stream))
+        mock_sse_client.return_value = mock_ctx
+
+        connection = await manager._establish_connection()
+
+        assert connection == (mock_read_stream, mock_write_stream)
+        assert manager._sse_ctx == mock_ctx
+        mock_sse_client.assert_called_once_with(
+            url=url,
+            headers={},
+            timeout=5,
+            sse_read_timeout=60 * 5,
+            auth=None,
+            httpx_client_factory=None,
+        )
+        mock_ctx.__aenter__.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("mcp_use.client.task_managers.sse.sse_client")
+    async def test_establish_connection_with_all_params(self, mock_sse_client):
+        """Test connection establishment with all parameters."""
+        url = "http://localhost:8080/sse"
+        headers = {"Authorization": "Bearer token"}
+        timeout = 10.0
+        sse_read_timeout = 120.0
+        auth = httpx.BasicAuth("user", "pass")
+        client_factory = Mock()
+
+        manager = SseConnectionManager(
+            url=url,
+            headers=headers,
+            timeout=timeout,
+            sse_read_timeout=sse_read_timeout,
+            auth=auth,
+            httpx_client_factory=client_factory,
+        )
+
+        mock_ctx = MagicMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=(Mock(), Mock()))
+        mock_sse_client.return_value = mock_ctx
+
+        await manager._establish_connection()
+
+        mock_sse_client.assert_called_once_with(
+            url=url,
+            headers=headers,
+            timeout=timeout,
+            sse_read_timeout=sse_read_timeout,
+            auth=auth,
+            httpx_client_factory=client_factory,
+        )
+
+    @pytest.mark.asyncio
+    @patch("mcp_use.client.task_managers.sse.sse_client")
+    async def test_establish_connection_failure(self, mock_sse_client):
+        """Test connection establishment failure."""
+        url = "http://localhost:8080/sse"
+        manager = SseConnectionManager(url)
+
+        mock_ctx = MagicMock()
+        mock_ctx.__aenter__ = AsyncMock(side_effect=httpx.ConnectError("Connection failed"))
+        mock_sse_client.return_value = mock_ctx
+
+        with pytest.raises(httpx.ConnectError, match="Connection failed"):
+            await manager._establish_connection()
+
+    @pytest.mark.asyncio
+    @patch("mcp_use.client.task_managers.sse.sse_client")
+    async def test_close_connection_success(self, mock_sse_client):
+        """Test successful connection closure."""
+        url = "http://localhost:8080/sse"
+        manager = SseConnectionManager(url)
+
+        # Establish connection first
+        mock_ctx = MagicMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=(Mock(), Mock()))
+        mock_ctx.__aexit__ = AsyncMock()
+        mock_sse_client.return_value = mock_ctx
+
+        await manager._establish_connection()
+        await manager._close_connection()
+
+        mock_ctx.__aexit__.assert_called_once_with(None, None, None)
+        assert manager._sse_ctx is None
+
+    @pytest.mark.asyncio
+    @patch("mcp_use.client.task_managers.sse.sse_client")
+    @patch("mcp_use.client.task_managers.sse.logger")
+    async def test_close_connection_error_handling(self, mock_logger, mock_sse_client):
+        """Test that errors during close are handled gracefully."""
+        url = "http://localhost:8080/sse"
+        manager = SseConnectionManager(url)
+
+        # Establish connection first
+        mock_ctx = MagicMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=(Mock(), Mock()))
+        mock_ctx.__aexit__ = AsyncMock(side_effect=RuntimeError("Close error"))
+        mock_sse_client.return_value = mock_ctx
+
+        await manager._establish_connection()
+        await manager._close_connection()
+
+        # Error should be logged but not raised
+        mock_logger.warning.assert_called()
+        assert manager._sse_ctx is None
+
+    @pytest.mark.asyncio
+    @patch("mcp_use.client.task_managers.sse.sse_client")
+    async def test_close_without_connection(self, mock_sse_client):
+        """Test closing when no connection exists."""
+        url = "http://localhost:8080/sse"
+        manager = SseConnectionManager(url)
+
+        # Should not raise
+        await manager._close_connection()
+
+        assert manager._sse_ctx is None
+
+
+class TestSseConnectionManagerLifecycle:
+    """Tests for full connection lifecycle."""
+
+    @pytest.mark.asyncio
+    @patch("mcp_use.client.task_managers.sse.sse_client")
+    async def test_full_lifecycle(self, mock_sse_client):
+        """Test complete connection lifecycle."""
+        url = "http://localhost:8080/sse"
+        manager = SseConnectionManager(url)
+
+        # Mock the context manager
+        mock_ctx = MagicMock()
+        mock_read_stream = Mock()
+        mock_write_stream = Mock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=(mock_read_stream, mock_write_stream))
+        mock_ctx.__aexit__ = AsyncMock()
+        mock_sse_client.return_value = mock_ctx
+
+        # Start connection
+        connection = await manager.start()
+        assert connection == (mock_read_stream, mock_write_stream)
+        assert manager.get_streams() == (mock_read_stream, mock_write_stream)
+
+        # Stop connection
+        await manager.stop()
+        assert manager.get_streams() is None
+        mock_ctx.__aexit__.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("mcp_use.client.task_managers.sse.sse_client")
+    async def test_start_stop_multiple_times(self, mock_sse_client):
+        """Test starting and stopping multiple times."""
+        url = "http://localhost:8080/sse"
+        manager = SseConnectionManager(url)
+
+        mock_ctx1 = MagicMock()
+        mock_ctx1.__aenter__ = AsyncMock(return_value=(Mock(), Mock()))
+        mock_ctx1.__aexit__ = AsyncMock()
+
+        mock_ctx2 = MagicMock()
+        mock_ctx2.__aenter__ = AsyncMock(return_value=(Mock(), Mock()))
+        mock_ctx2.__aexit__ = AsyncMock()
+
+        mock_sse_client.side_effect = [mock_ctx1, mock_ctx2]
+
+        # First connection
+        await manager.start()
+        await manager.stop()
+
+        # Second connection
+        await manager.start()
+        await manager.stop()
+
+        assert mock_sse_client.call_count == 2

--- a/libraries/python/tests/unit/test_stdio_connection_manager.py
+++ b/libraries/python/tests/unit/test_stdio_connection_manager.py
@@ -1,0 +1,207 @@
+"""
+Unit tests for StdioConnectionManager.
+"""
+
+import sys
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+from mcp import StdioServerParameters
+
+from mcp_use.client.task_managers.stdio import StdioConnectionManager
+
+
+class TestStdioConnectionManagerInitialization:
+    """Tests for StdioConnectionManager initialization."""
+
+    def test_init_with_server_params(self):
+        """Test initialization with server parameters."""
+        server_params = StdioServerParameters(
+            command="test-command",
+            args=["--arg1", "--arg2"],
+        )
+        manager = StdioConnectionManager(server_params)
+
+        assert manager.server_params == server_params
+        assert manager.errlog == sys.stderr
+        assert manager._stdio_ctx is None
+
+    def test_init_with_custom_errlog(self):
+        """Test initialization with custom error log."""
+        server_params = StdioServerParameters(command="test-command")
+        custom_errlog = Mock()
+
+        manager = StdioConnectionManager(server_params, errlog=custom_errlog)
+
+        assert manager.errlog == custom_errlog
+
+    def test_init_defaults(self):
+        """Test initialization with default parameters."""
+        server_params = StdioServerParameters(command="test-command")
+
+        manager = StdioConnectionManager(server_params)
+
+        assert manager.errlog == sys.stderr
+
+
+class TestStdioConnectionManagerConnection:
+    """Tests for connection establishment and closure."""
+
+    @pytest.mark.asyncio
+    @patch("mcp_use.client.task_managers.stdio.stdio_client")
+    async def test_establish_connection_success(self, mock_stdio_client):
+        """Test successful connection establishment."""
+        server_params = StdioServerParameters(command="test-command")
+        manager = StdioConnectionManager(server_params)
+
+        # Mock the context manager
+        mock_ctx = MagicMock()
+        mock_read_stream = Mock()
+        mock_write_stream = Mock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=(mock_read_stream, mock_write_stream))
+        mock_stdio_client.return_value = mock_ctx
+
+        connection = await manager._establish_connection()
+
+        assert connection == (mock_read_stream, mock_write_stream)
+        assert manager._stdio_ctx == mock_ctx
+        mock_stdio_client.assert_called_once_with(server_params, sys.stderr)
+        mock_ctx.__aenter__.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("mcp_use.client.task_managers.stdio.stdio_client")
+    async def test_establish_connection_with_custom_errlog(self, mock_stdio_client):
+        """Test connection establishment with custom error log."""
+        server_params = StdioServerParameters(command="test-command")
+        custom_errlog = Mock()
+        manager = StdioConnectionManager(server_params, errlog=custom_errlog)
+
+        mock_ctx = MagicMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=(Mock(), Mock()))
+        mock_stdio_client.return_value = mock_ctx
+
+        await manager._establish_connection()
+
+        mock_stdio_client.assert_called_once_with(server_params, custom_errlog)
+
+    @pytest.mark.asyncio
+    @patch("mcp_use.client.task_managers.stdio.stdio_client")
+    async def test_establish_connection_failure(self, mock_stdio_client):
+        """Test connection establishment failure."""
+        server_params = StdioServerParameters(command="test-command")
+        manager = StdioConnectionManager(server_params)
+
+        mock_ctx = MagicMock()
+        mock_ctx.__aenter__ = AsyncMock(side_effect=OSError("Failed to start process"))
+        mock_stdio_client.return_value = mock_ctx
+
+        with pytest.raises(OSError, match="Failed to start process"):
+            await manager._establish_connection()
+
+    @pytest.mark.asyncio
+    @patch("mcp_use.client.task_managers.stdio.stdio_client")
+    async def test_close_connection_success(self, mock_stdio_client):
+        """Test successful connection closure."""
+        server_params = StdioServerParameters(command="test-command")
+        manager = StdioConnectionManager(server_params)
+
+        # Establish connection first
+        mock_ctx = MagicMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=(Mock(), Mock()))
+        mock_ctx.__aexit__ = AsyncMock()
+        mock_stdio_client.return_value = mock_ctx
+
+        await manager._establish_connection()
+        await manager._close_connection()
+
+        mock_ctx.__aexit__.assert_called_once_with(None, None, None)
+        assert manager._stdio_ctx is None
+
+    @pytest.mark.asyncio
+    @patch("mcp_use.client.task_managers.stdio.stdio_client")
+    @patch("mcp_use.client.task_managers.stdio.logger")
+    async def test_close_connection_error_handling(self, mock_logger, mock_stdio_client):
+        """Test that errors during close are handled gracefully."""
+        server_params = StdioServerParameters(command="test-command")
+        manager = StdioConnectionManager(server_params)
+
+        # Establish connection first
+        mock_ctx = MagicMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=(Mock(), Mock()))
+        mock_ctx.__aexit__ = AsyncMock(side_effect=RuntimeError("Close error"))
+        mock_stdio_client.return_value = mock_ctx
+
+        await manager._establish_connection()
+        await manager._close_connection()
+
+        # Error should be logged but not raised
+        mock_logger.warning.assert_called()
+        assert manager._stdio_ctx is None
+
+    @pytest.mark.asyncio
+    @patch("mcp_use.client.task_managers.stdio.stdio_client")
+    async def test_close_without_connection(self, mock_stdio_client):
+        """Test closing when no connection exists."""
+        server_params = StdioServerParameters(command="test-command")
+        manager = StdioConnectionManager(server_params)
+
+        # Should not raise
+        await manager._close_connection()
+
+        assert manager._stdio_ctx is None
+
+
+class TestStdioConnectionManagerLifecycle:
+    """Tests for full connection lifecycle."""
+
+    @pytest.mark.asyncio
+    @patch("mcp_use.client.task_managers.stdio.stdio_client")
+    async def test_full_lifecycle(self, mock_stdio_client):
+        """Test complete connection lifecycle."""
+        server_params = StdioServerParameters(command="test-command")
+        manager = StdioConnectionManager(server_params)
+
+        # Mock the context manager
+        mock_ctx = MagicMock()
+        mock_read_stream = Mock()
+        mock_write_stream = Mock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=(mock_read_stream, mock_write_stream))
+        mock_ctx.__aexit__ = AsyncMock()
+        mock_stdio_client.return_value = mock_ctx
+
+        # Start connection
+        connection = await manager.start()
+        assert connection == (mock_read_stream, mock_write_stream)
+        assert manager.get_streams() == (mock_read_stream, mock_write_stream)
+
+        # Stop connection
+        await manager.stop()
+        assert manager.get_streams() is None
+        mock_ctx.__aexit__.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("mcp_use.client.task_managers.stdio.stdio_client")
+    async def test_start_stop_multiple_times(self, mock_stdio_client):
+        """Test starting and stopping multiple times."""
+        server_params = StdioServerParameters(command="test-command")
+        manager = StdioConnectionManager(server_params)
+
+        mock_ctx1 = MagicMock()
+        mock_ctx1.__aenter__ = AsyncMock(return_value=(Mock(), Mock()))
+        mock_ctx1.__aexit__ = AsyncMock()
+
+        mock_ctx2 = MagicMock()
+        mock_ctx2.__aenter__ = AsyncMock(return_value=(Mock(), Mock()))
+        mock_ctx2.__aexit__ = AsyncMock()
+
+        mock_stdio_client.side_effect = [mock_ctx1, mock_ctx2]
+
+        # First connection
+        await manager.start()
+        await manager.stop()
+
+        # Second connection
+        await manager.start()
+        await manager.stop()
+
+        assert mock_stdio_client.call_count == 2

--- a/libraries/python/tests/unit/test_streamable_http_connection_manager.py
+++ b/libraries/python/tests/unit/test_streamable_http_connection_manager.py
@@ -1,0 +1,251 @@
+"""
+Unit tests for StreamableHttpConnectionManager.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import httpx
+import pytest
+
+from mcp_use.client.task_managers.streamable_http import StreamableHttpConnectionManager
+
+
+class TestStreamableHttpConnectionManagerInitialization:
+    """Tests for StreamableHttpConnectionManager initialization."""
+
+    def test_init_with_url_only(self):
+        """Test initialization with URL only."""
+        url = "http://localhost:8080/api"
+        manager = StreamableHttpConnectionManager(url)
+
+        assert manager.url == url
+        assert manager.headers == {}
+        assert manager.timeout.total_seconds() == 5
+        assert manager.read_timeout.total_seconds() == 60 * 5
+        assert manager.auth is None
+        assert manager.httpx_client_factory is None
+        assert manager._http_ctx is None
+
+    def test_init_with_all_parameters(self):
+        """Test initialization with all parameters."""
+        url = "http://localhost:8080/api"
+        headers = {"Authorization": "Bearer token"}
+        timeout = 10.0
+        read_timeout = 120.0
+        auth = httpx.BasicAuth("user", "pass")
+        client_factory = Mock()
+
+        manager = StreamableHttpConnectionManager(
+            url=url,
+            headers=headers,
+            timeout=timeout,
+            read_timeout=read_timeout,
+            auth=auth,
+            httpx_client_factory=client_factory,
+        )
+
+        assert manager.url == url
+        assert manager.headers == headers
+        assert manager.timeout.total_seconds() == timeout
+        assert manager.read_timeout.total_seconds() == read_timeout
+        assert manager.auth == auth
+        assert manager.httpx_client_factory == client_factory
+
+    def test_init_with_none_headers(self):
+        """Test initialization with None headers."""
+        url = "http://localhost:8080/api"
+        manager = StreamableHttpConnectionManager(url, headers=None)
+
+        assert manager.headers == {}
+
+
+class TestStreamableHttpConnectionManagerConnection:
+    """Tests for connection establishment and closure."""
+
+    @pytest.mark.asyncio
+    @patch("mcp_use.client.task_managers.streamable_http.streamablehttp_client")
+    async def test_establish_connection_success(self, mock_http_client):
+        """Test successful connection establishment."""
+        url = "http://localhost:8080/api"
+        manager = StreamableHttpConnectionManager(url)
+
+        # Mock the context manager
+        mock_ctx = MagicMock()
+        mock_read_stream = Mock()
+        mock_write_stream = Mock()
+        mock_session_id_callback = Mock()
+        mock_ctx.__aenter__ = AsyncMock(
+            return_value=(mock_read_stream, mock_write_stream, mock_session_id_callback)
+        )
+        mock_http_client.return_value = mock_ctx
+
+        connection = await manager._establish_connection()
+
+        assert connection == (mock_read_stream, mock_write_stream)
+        assert manager._http_ctx == mock_ctx
+        mock_http_client.assert_called_once_with(
+            url=url,
+            headers={},
+            timeout=manager.timeout,
+            sse_read_timeout=manager.read_timeout,
+            auth=None,
+            httpx_client_factory=None,
+        )
+        mock_ctx.__aenter__.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("mcp_use.client.task_managers.streamable_http.streamablehttp_client")
+    async def test_establish_connection_with_all_params(self, mock_http_client):
+        """Test connection establishment with all parameters."""
+        url = "http://localhost:8080/api"
+        headers = {"Authorization": "Bearer token"}
+        timeout = 10.0
+        read_timeout = 120.0
+        auth = httpx.BasicAuth("user", "pass")
+        client_factory = Mock()
+
+        manager = StreamableHttpConnectionManager(
+            url=url,
+            headers=headers,
+            timeout=timeout,
+            read_timeout=read_timeout,
+            auth=auth,
+            httpx_client_factory=client_factory,
+        )
+
+        mock_ctx = MagicMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=(Mock(), Mock(), Mock()))
+        mock_http_client.return_value = mock_ctx
+
+        await manager._establish_connection()
+
+        mock_http_client.assert_called_once_with(
+            url=url,
+            headers=headers,
+            timeout=manager.timeout,
+            sse_read_timeout=manager.read_timeout,
+            auth=auth,
+            httpx_client_factory=client_factory,
+        )
+
+    @pytest.mark.asyncio
+    @patch("mcp_use.client.task_managers.streamable_http.streamablehttp_client")
+    async def test_establish_connection_failure(self, mock_http_client):
+        """Test connection establishment failure."""
+        url = "http://localhost:8080/api"
+        manager = StreamableHttpConnectionManager(url)
+
+        mock_ctx = MagicMock()
+        mock_ctx.__aenter__ = AsyncMock(side_effect=httpx.ConnectError("Connection failed"))
+        mock_http_client.return_value = mock_ctx
+
+        with pytest.raises(httpx.ConnectError, match="Connection failed"):
+            await manager._establish_connection()
+
+    @pytest.mark.asyncio
+    @patch("mcp_use.client.task_managers.streamable_http.streamablehttp_client")
+    async def test_close_connection_success(self, mock_http_client):
+        """Test successful connection closure."""
+        url = "http://localhost:8080/api"
+        manager = StreamableHttpConnectionManager(url)
+
+        # Establish connection first
+        mock_ctx = MagicMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=(Mock(), Mock(), Mock()))
+        mock_ctx.__aexit__ = AsyncMock()
+        mock_http_client.return_value = mock_ctx
+
+        await manager._establish_connection()
+        await manager._close_connection()
+
+        mock_ctx.__aexit__.assert_called_once_with(None, None, None)
+        assert manager._http_ctx is None
+
+    @pytest.mark.asyncio
+    @patch("mcp_use.client.task_managers.streamable_http.streamablehttp_client")
+    @patch("mcp_use.client.task_managers.streamable_http.logger")
+    async def test_close_connection_error_handling(self, mock_logger, mock_http_client):
+        """Test that errors during close are handled gracefully."""
+        url = "http://localhost:8080/api"
+        manager = StreamableHttpConnectionManager(url)
+
+        # Establish connection first
+        mock_ctx = MagicMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=(Mock(), Mock(), Mock()))
+        mock_ctx.__aexit__ = AsyncMock(side_effect=RuntimeError("Close error"))
+        mock_http_client.return_value = mock_ctx
+
+        await manager._establish_connection()
+        await manager._close_connection()
+
+        # Error should be logged but not raised (uses debug level)
+        mock_logger.debug.assert_called()
+        assert manager._http_ctx is None
+
+    @pytest.mark.asyncio
+    @patch("mcp_use.client.task_managers.streamable_http.streamablehttp_client")
+    async def test_close_without_connection(self, mock_http_client):
+        """Test closing when no connection exists."""
+        url = "http://localhost:8080/api"
+        manager = StreamableHttpConnectionManager(url)
+
+        # Should not raise
+        await manager._close_connection()
+
+        assert manager._http_ctx is None
+
+
+class TestStreamableHttpConnectionManagerLifecycle:
+    """Tests for full connection lifecycle."""
+
+    @pytest.mark.asyncio
+    @patch("mcp_use.client.task_managers.streamable_http.streamablehttp_client")
+    async def test_full_lifecycle(self, mock_http_client):
+        """Test complete connection lifecycle."""
+        url = "http://localhost:8080/api"
+        manager = StreamableHttpConnectionManager(url)
+
+        # Mock the context manager
+        mock_ctx = MagicMock()
+        mock_read_stream = Mock()
+        mock_write_stream = Mock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=(mock_read_stream, mock_write_stream, Mock()))
+        mock_ctx.__aexit__ = AsyncMock()
+        mock_http_client.return_value = mock_ctx
+
+        # Start connection
+        connection = await manager.start()
+        assert connection == (mock_read_stream, mock_write_stream)
+        assert manager.get_streams() == (mock_read_stream, mock_write_stream)
+
+        # Stop connection
+        await manager.stop()
+        assert manager.get_streams() is None
+        mock_ctx.__aexit__.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("mcp_use.client.task_managers.streamable_http.streamablehttp_client")
+    async def test_start_stop_multiple_times(self, mock_http_client):
+        """Test starting and stopping multiple times."""
+        url = "http://localhost:8080/api"
+        manager = StreamableHttpConnectionManager(url)
+
+        mock_ctx1 = MagicMock()
+        mock_ctx1.__aenter__ = AsyncMock(return_value=(Mock(), Mock(), Mock()))
+        mock_ctx1.__aexit__ = AsyncMock()
+
+        mock_ctx2 = MagicMock()
+        mock_ctx2.__aenter__ = AsyncMock(return_value=(Mock(), Mock(), Mock()))
+        mock_ctx2.__aexit__ = AsyncMock()
+
+        mock_http_client.side_effect = [mock_ctx1, mock_ctx2]
+
+        # First connection
+        await manager.start()
+        await manager.stop()
+
+        # Second connection
+        await manager.start()
+        await manager.stop()
+
+        assert mock_http_client.call_count == 2


### PR DESCRIPTION
# Pull Request Description

## Changes

This PR introduces comprehensive unit test coverage for all `ConnectionManager` types, including the abstract base class and its concrete implementations: `StdioConnectionManager`, `SseConnectionManager`, `WebSocketConnectionManager`, and `StreamableHttpConnectionManager`.

## Implementation Details

1.  **New Test Files**: Created `test_base_connection_manager.py`, `test_stdio_connection_manager.py`, `test_sse_connection_manager.py`, and `test_streamable_http_connection_manager.py`.
2.  **Updated Test File**: Expanded `test_websocket_connection_manager.py` with new tests and corrected an import path.
3.  **Coverage**: Tests cover connection initialization, establishment, closure, full connection lifecycle (start → use → stop), and error handling scenarios for each manager.
4.  **Mocking**: Utilizes `unittest.mock` to isolate the task managers and simulate external dependencies like client factories and network operations.
5.  **Test Framework**: All tests are written using `pytest` with `asyncio` support.

## Example Usage (Before)

```python
# N/A - This PR adds tests, it does not change API usage.
```

## Example Usage (After)

```python
# N/A - This PR adds tests, it does not change API usage.
```

## Documentation Updates

*   No explicit documentation files were updated as part of this change.

## Testing

The following testing was performed:

*   **Unit tests added**: New unit tests were created for `BaseConnectionManager`, `StdioConnectionManager`, `SseConnectionManager`, `WebSocketConnectionManager`, and `StreamableHttpConnectionManager`.
*   **Manual testing performed**: All new and modified test files were run using `pytest` to ensure they pass and no new errors were introduced. Python syntax validation was also performed.
*   **Edge cases considered**: Tests include scenarios for successful connections, connection failures, graceful handling of errors during connection closure, and attempting to close a connection when none is active. The full connection lifecycle (start, get streams, stop) and multiple sequential start/stop cycles were also tested.
*   **Integration Tests**: The issue's requirement for integration tests is covered by existing transport integration tests (e.g., `test_stdio.py`, `test_sse.py`, `test_streamable_http.py`), which validate the full stack including the task managers.

## Backwards Compatibility

These changes are fully backwards compatible as they only add new test files and update an existing test file. No changes were made to the production code or public APIs.

## Related Issues

Closes #MCP-905

---
Linear Issue: [MCP-905](https://linear.app/mcp-use/issue/MCP-905/add-task-manager-testing-coverage)

<a href="https://cursor.com/background-agent?bcId=bc-d76bbb6f-04d1-4219-918a-b035ae155d2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d76bbb6f-04d1-4219-918a-b035ae155d2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

