### PR TITLE
Bug: Deprecation Version Mismatch

### DIFF
--- a/libraries/python/mcp_use/adapters/__init__.py
+++ b/libraries/python/mcp_use/adapters/__init__.py
@@ -7,7 +7,7 @@ from mcp_use.agents.adapters import BaseAdapter as _BaseAdapter
 from mcp_use.agents.adapters import LangChainAdapter as _LangChainAdapter
 
 warnings.warn(
-    "mcp_use.adapters is deprecated. Use mcp_use.agents.adapters. This import will be removed in version 1.4.0",
+    "mcp_use.adapters is deprecated. Use mcp_use.agents.adapters. This import will be removed in version 2.0.0",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/libraries/python/mcp_use/adapters/base.py
+++ b/libraries/python/mcp_use/adapters/base.py
@@ -7,7 +7,7 @@ from mcp_use.agents.adapters.base import BaseAdapter as _BaseAdapter
 
 warnings.warn(
     "mcp_use.adapters.base is deprecated. Use mcp_use.agents.adapters.base. "
-    "This import will be removed in version 1.4.0",
+    "This import will be removed in version 2.0.0",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/libraries/python/mcp_use/adapters/langchain_adapter.py
+++ b/libraries/python/mcp_use/adapters/langchain_adapter.py
@@ -8,7 +8,7 @@ from mcp_use.agents.adapters.langchain_adapter import LangChainAdapter as _LangC
 warnings.warn(
     "mcp_use.adapters.langchain_adapter is deprecated. "
     "Use mcp_use.agents.adapters.langchain_adapter. "
-    "This import will be removed in version 1.4.0",
+    "This import will be removed in version 2.0.0",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/libraries/python/mcp_use/auth/__init__.py
+++ b/libraries/python/mcp_use/auth/__init__.py
@@ -7,7 +7,7 @@ from mcp_use.client.auth import BearerAuth as _BearerAuth
 from mcp_use.client.auth import OAuth as _OAuth
 
 warnings.warn(
-    "mcp_use.auth is deprecated. Use mcp_use.client.auth. This import will be removed in version 1.4.0",
+    "mcp_use.auth is deprecated. Use mcp_use.client.auth. This import will be removed in version 2.0.0",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/libraries/python/mcp_use/auth/bearer.py
+++ b/libraries/python/mcp_use/auth/bearer.py
@@ -6,7 +6,7 @@ from typing_extensions import deprecated
 from mcp_use.client.auth.bearer import BearerAuth as _BearerAuth
 
 warnings.warn(
-    "mcp_use.auth.bearer is deprecated. Use mcp_use.client.auth.bearer. This import will be removed in version 1.4.0",
+    "mcp_use.auth.bearer is deprecated. Use mcp_use.client.auth.bearer. This import will be removed in version 2.0.0",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/libraries/python/mcp_use/auth/oauth.py
+++ b/libraries/python/mcp_use/auth/oauth.py
@@ -6,7 +6,7 @@ from typing_extensions import deprecated
 from mcp_use.client.auth.oauth import OAuth as _OAuth
 
 warnings.warn(
-    "mcp_use.auth.oauth is deprecated. Use mcp_use.client.auth.oauth. This import will be removed in version 1.4.0",
+    "mcp_use.auth.oauth is deprecated. Use mcp_use.client.auth.oauth. This import will be removed in version 2.0.0",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/libraries/python/mcp_use/auth/oauth_callback.py
+++ b/libraries/python/mcp_use/auth/oauth_callback.py
@@ -9,7 +9,7 @@ from mcp_use.client.auth.oauth_callback import OAuthCallbackServer as _OAuthCall
 warnings.warn(
     "mcp_use.auth.oauth_callback is deprecated. "
     "Use mcp_use.client.auth.oauth_callback. "
-    "This import will be removed in version 1.4.0",
+    "This import will be removed in version 2.0.0",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/libraries/python/mcp_use/client.py
+++ b/libraries/python/mcp_use/client.py
@@ -8,7 +8,7 @@ from mcp_use.client.client import MCPClient as _MCPClient
 warnings.warn(
     "mcp_use.client.MCPClient is deprecated. "
     "Use mcp_use.client.client.MCPClient. "
-    "This import will be removed in version 1.4.0",
+    "This import will be removed in version 2.0.0",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/libraries/python/mcp_use/config.py
+++ b/libraries/python/mcp_use/config.py
@@ -11,7 +11,7 @@ from mcp_use.client.config import (
 )
 
 warnings.warn(
-    "mcp_use.config is deprecated. Use mcp_use.client.config. This import will be removed in version 1.4.0",
+    "mcp_use.config is deprecated. Use mcp_use.client.config. This import will be removed in version 2.0.0",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/libraries/python/mcp_use/connectors/__init__.py
+++ b/libraries/python/mcp_use/connectors/__init__.py
@@ -20,7 +20,7 @@ from mcp_use.client.connectors import (
 )
 
 warnings.warn(
-    "mcp_use.connectors is deprecated. Use mcp_use.client.connectors. This import will be removed in version 1.4.0",
+    "mcp_use.connectors is deprecated. Use mcp_use.client.connectors. This import will be removed in version 2.0.0",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/libraries/python/mcp_use/connectors/base.py
+++ b/libraries/python/mcp_use/connectors/base.py
@@ -8,7 +8,7 @@ from mcp_use.client.connectors.base import BaseConnector as _BaseConnector
 warnings.warn(
     "mcp_use.connectors.base is deprecated. "
     "Use mcp_use.client.connectors.base. "
-    "This import will be removed in version 1.4.0",
+    "This import will be removed in version 2.0.0",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/libraries/python/mcp_use/connectors/http.py
+++ b/libraries/python/mcp_use/connectors/http.py
@@ -8,7 +8,7 @@ from mcp_use.client.connectors.http import HttpConnector as _HttpConnector
 warnings.warn(
     "mcp_use.connectors.http is deprecated. "
     "Use mcp_use.client.connectors.http. "
-    "This import will be removed in version 1.4.0",
+    "This import will be removed in version 2.0.0",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/libraries/python/mcp_use/connectors/sandbox.py
+++ b/libraries/python/mcp_use/connectors/sandbox.py
@@ -8,7 +8,7 @@ from mcp_use.client.connectors.sandbox import SandboxConnector as _SandboxConnec
 warnings.warn(
     "mcp_use.connectors.sandbox is deprecated. "
     "Use mcp_use.client.connectors.sandbox. "
-    "This import will be removed in version 1.4.0",
+    "This import will be removed in version 2.0.0",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/libraries/python/mcp_use/connectors/stdio.py
+++ b/libraries/python/mcp_use/connectors/stdio.py
@@ -8,7 +8,7 @@ from mcp_use.client.connectors.stdio import StdioConnector as _StdioConnector
 warnings.warn(
     "mcp_use.connectors.stdio is deprecated. "
     "Use mcp_use.client.connectors.stdio. "
-    "This import will be removed in version 1.4.0",
+    "This import will be removed in version 2.0.0",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/libraries/python/mcp_use/connectors/utils.py
+++ b/libraries/python/mcp_use/connectors/utils.py
@@ -9,7 +9,7 @@ from mcp_use.client.connectors.utils import is_stdio_server as _is_stdio_server
 warnings.warn(
     "mcp_use.connectors.utils is deprecated. "
     "Use mcp_use.client.connectors.utils. "
-    "This import will be removed in version 1.4.0",
+    "This import will be removed in version 2.0.0",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/libraries/python/mcp_use/connectors/websocket.py
+++ b/libraries/python/mcp_use/connectors/websocket.py
@@ -8,7 +8,7 @@ from mcp_use.client.connectors.websocket import WebSocketConnector as _WebSocket
 warnings.warn(
     "mcp_use.connectors.websocket is deprecated. "
     "Use mcp_use.client.connectors.websocket. "
-    "This import will be removed in version 1.4.0",
+    "This import will be removed in version 2.0.0",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/libraries/python/mcp_use/exceptions.py
+++ b/libraries/python/mcp_use/exceptions.py
@@ -20,7 +20,7 @@ from mcp_use.client.exceptions import (
 )
 
 warnings.warn(
-    "mcp_use.exceptions is deprecated. Use mcp_use.client.exceptions. This import will be removed in version 1.4.0",
+    "mcp_use.exceptions is deprecated. Use mcp_use.client.exceptions. This import will be removed in version 2.0.0",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/libraries/python/mcp_use/managers/__init__.py
+++ b/libraries/python/mcp_use/managers/__init__.py
@@ -24,7 +24,7 @@ from mcp_use.agents.managers.tools import (
 )
 
 warnings.warn(
-    "mcp_use.managers is deprecated. Use mcp_use.agents.managers. This import will be removed in version 1.4.0",
+    "mcp_use.managers is deprecated. Use mcp_use.agents.managers. This import will be removed in version 2.0.0",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/libraries/python/mcp_use/managers/base.py
+++ b/libraries/python/mcp_use/managers/base.py
@@ -8,7 +8,7 @@ from mcp_use.agents.managers.base import BaseServerManager as _BaseServerManager
 warnings.warn(
     "mcp_use.managers.base is deprecated. "
     "Use mcp_use.agents.managers.base. "
-    "This import will be removed in version 1.4.0",
+    "This import will be removed in version 2.0.0",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/libraries/python/mcp_use/managers/server_manager.py
+++ b/libraries/python/mcp_use/managers/server_manager.py
@@ -8,7 +8,7 @@ from mcp_use.agents.managers.server_manager import ServerManager as _ServerManag
 warnings.warn(
     "mcp_use.managers.server_manager is deprecated. "
     "Use mcp_use.agents.managers.server_manager. "
-    "This import will be removed in version 1.4.0",
+    "This import will be removed in version 2.0.0",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/libraries/python/mcp_use/middleware/__init__.py
+++ b/libraries/python/mcp_use/middleware/__init__.py
@@ -38,7 +38,7 @@ from mcp_use.client.middleware import (
 )
 
 warnings.warn(
-    "mcp_use.middleware is deprecated. Use mcp_use.client.middleware. This import will be removed in version 1.4.0",
+    "mcp_use.middleware is deprecated. Use mcp_use.client.middleware. This import will be removed in version 2.0.0",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/libraries/python/mcp_use/middleware/logging.py
+++ b/libraries/python/mcp_use/middleware/logging.py
@@ -8,7 +8,7 @@ from mcp_use.client.middleware.logging import default_logging_middleware as _def
 warnings.warn(
     "mcp_use.middleware.logging is deprecated. "
     "Use mcp_use.client.middleware.logging. "
-    "This import will be removed in version 1.4.0",
+    "This import will be removed in version 2.0.0",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/libraries/python/mcp_use/middleware/metrics.py
+++ b/libraries/python/mcp_use/middleware/metrics.py
@@ -19,7 +19,7 @@ from mcp_use.client.middleware.metrics import (
 warnings.warn(
     "mcp_use.middleware.metrics is deprecated. "
     "Use mcp_use.client.middleware.metrics. "
-    "This import will be removed in version 1.4.0",
+    "This import will be removed in version 2.0.0",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/libraries/python/mcp_use/middleware/middleware.py
+++ b/libraries/python/mcp_use/middleware/middleware.py
@@ -25,7 +25,7 @@ from mcp_use.client.middleware.middleware import (
 warnings.warn(
     "mcp_use.middleware.middleware is deprecated. "
     "Use mcp_use.client.middleware.middleware. "
-    "This import will be removed in version 1.4.0",
+    "This import will be removed in version 2.0.0",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/libraries/python/mcp_use/session.py
+++ b/libraries/python/mcp_use/session.py
@@ -8,7 +8,7 @@ from mcp_use.client.session import MCPSession as _MCPSession
 warnings.warn(
     "mcp_use.session.MCPSession is deprecated. "
     "Use mcp_use.client.session.MCPSession. "
-    "This import will be removed in version 1.4.0",
+    "This import will be removed in version 2.0.0",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/libraries/python/mcp_use/task_managers/__init__.py
+++ b/libraries/python/mcp_use/task_managers/__init__.py
@@ -22,7 +22,7 @@ from mcp_use.client.task_managers import (
 warnings.warn(
     "mcp_use.task_managers is deprecated. "
     "Use mcp_use.client.task_managers. "
-    "This import will be removed in version 1.4.0",
+    "This import will be removed in version 2.0.0",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/libraries/python/mcp_use/task_managers/base.py
+++ b/libraries/python/mcp_use/task_managers/base.py
@@ -8,7 +8,7 @@ from mcp_use.client.task_managers.base import ConnectionManager as _ConnectionMa
 warnings.warn(
     "mcp_use.task_managers.base is deprecated. "
     "Use mcp_use.client.task_managers.base. "
-    "This import will be removed in version 1.4.0",
+    "This import will be removed in version 2.0.0",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/libraries/python/mcp_use/task_managers/sse.py
+++ b/libraries/python/mcp_use/task_managers/sse.py
@@ -8,7 +8,7 @@ from mcp_use.client.task_managers.sse import SseConnectionManager as _SseConnect
 warnings.warn(
     "mcp_use.task_managers.sse is deprecated. "
     "Use mcp_use.client.task_managers.sse. "
-    "This import will be removed in version 1.4.0",
+    "This import will be removed in version 2.0.0",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/libraries/python/mcp_use/task_managers/stdio.py
+++ b/libraries/python/mcp_use/task_managers/stdio.py
@@ -8,7 +8,7 @@ from mcp_use.client.task_managers.stdio import StdioConnectionManager as _StdioC
 warnings.warn(
     "mcp_use.task_managers.stdio is deprecated. "
     "Use mcp_use.client.task_managers.stdio. "
-    "This import will be removed in version 1.4.0",
+    "This import will be removed in version 2.0.0",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/libraries/python/mcp_use/task_managers/streamable_http.py
+++ b/libraries/python/mcp_use/task_managers/streamable_http.py
@@ -10,7 +10,7 @@ from mcp_use.client.task_managers.streamable_http import (
 warnings.warn(
     "mcp_use.task_managers.streamable_http is deprecated. "
     "Use mcp_use.client.task_managers.streamable_http. "
-    "This import will be removed in version 1.4.0",
+    "This import will be removed in version 2.0.0",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/libraries/python/mcp_use/task_managers/websocket.py
+++ b/libraries/python/mcp_use/task_managers/websocket.py
@@ -8,7 +8,7 @@ from mcp_use.client.task_managers.websocket import WebSocketConnectionManager as
 warnings.warn(
     "mcp_use.task_managers.websocket is deprecated. "
     "Use mcp_use.client.task_managers.websocket. "
-    "This import will be removed in version 1.4.0",
+    "This import will be removed in version 2.0.0",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/libraries/python/mcp_use/types/sandbox.py
+++ b/libraries/python/mcp_use/types/sandbox.py
@@ -8,7 +8,7 @@ from mcp_use.client.connectors.sandbox import SandboxOptions as _SandboxOptions
 warnings.warn(
     "mcp_use.types.sandbox is deprecated. "
     "Use mcp_use.client.connectors.sandbox. "
-    "This import will be removed in version 1.4.0",
+    "This import will be removed in version 2.0.0",
     DeprecationWarning,
     stacklevel=2,
 )


### PR DESCRIPTION
# Pull Request Description

## Changes

Fixed deprecation version mismatch across the Python codebase. Updated all deprecation warnings that incorrectly referenced version 1.4.0 (which has already passed) to reference version 2.0.0, providing users with accurate migration timelines and maintaining proper semantic versioning practices.

**Impact:** 32 files updated across all deprecated modules (client, config, session, exceptions, connectors, middleware, managers, task_managers, auth, adapters, and types).

## Implementation Details

1. **Systematic Update Approach:** Used pattern matching to find all instances of `"version 1.4.0"` in deprecation warning messages and replaced them with `"version 2.0.0"`

2. **Files Updated by Category:**
   - **Core Modules (4 files):** `client.py`, `config.py`, `session.py`, `exceptions.py`
   - **Connectors (7 files):** All connector modules and utilities
   - **Middleware (4 files):** All middleware-related modules
   - **Managers (3 files):** Server manager and base classes
   - **Task Managers (6 files):** All connection manager implementations
   - **Auth (4 files):** Authentication modules (OAuth, Bearer)
   - **Adapters (3 files):** Adapter base and LangChain adapter
   - **Types (1 file):** Sandbox types

3. **Code Organization:** All changes maintain the existing deprecation warning structure and only update the version reference string. No functional changes were made.

4. **Dependencies:** No dependencies were added or modified. This is a pure maintenance fix.

## Example Usage (Before)

```python
# Before: Deprecation warning showed incorrect version
from mcp_use.client import MCPClient
# DeprecationWarning: mcp_use.client.MCPClient is deprecated. 
# Use mcp_use.client.client.MCPClient. 
# This import will be removed in version 1.4.0  ❌ (Already passed!)

from mcp_use.config import load_config_file
# DeprecationWarning: mcp_use.config is deprecated. 
# Use mcp_use.client.config. 
# This import will be removed in version 1.4.0  ❌ (Confusing - version already released)
```

## Example Usage (After)

```python
# After: Deprecation warning shows correct future version
from mcp_use.client import MCPClient
# DeprecationWarning: mcp_use.client.MCPClient is deprecated. 
# Use mcp_use.client.client.MCPClient. 
# This import will be removed in version 2.0.0  ✅ (Clear migration timeline)

from mcp_use.config import load_config_file
# DeprecationWarning: mcp_use.config is deprecated. 
# Use mcp_use.client.config. 
# This import will be removed in version 2.0.0  ✅ (Accurate version reference)
```

## Documentation Updates

**No documentation files were updated in this PR.** However, the existing migration guide in `docs/python/changelog/1_3_13.mdx` already documents the deprecations and migration paths. The guide mentions "future versions," which now correctly refers to version 2.0.0.

**Recommendation for follow-up:** Consider updating the migration guide to explicitly mention version 2.0.0 as the removal target in a future PR.

## Testing

**Verification performed:**

1. **Pattern Matching Verification:**
   - Confirmed 0 instances of `"1.4.0"` remain in the codebase
   - Verified 32 instances of `"2.0.0"` were added (one per file)

2. **Code Quality Checks:**
   - Ran linter: No linting errors introduced
   - All files maintain consistent formatting
   - No functional code changes, only deprecation message strings

3. **Manual Review:**
   - Spot-checked multiple files across different modules
   - Verified warning messages are complete and properly formatted
   - Confirmed all deprecated imports still function correctly

4. **Edge Cases Considered:**
   - All deprecation warnings follow the same pattern
   - No breaking changes to warning structure
   - Backward compatibility fully maintained

## Backwards Compatibility

**Fully backwards compatible**

These changes are 100% backwards compatible:

- **No functional changes:** Only deprecation warning message strings were updated
- **No API changes:** All deprecated imports continue to work exactly as before
- **No breaking changes:** Existing code using deprecated imports will continue to function
- **Clearer messaging:** Users now receive accurate information about when deprecated code will be removed

**User Impact:**
- Users will see updated deprecation warnings with correct version references
- No code changes required from users
- The migration timeline is now clear: deprecated code will be removed in version 2.0.0

**Migration Path:**
Users should migrate from deprecated imports to new import paths before version 2.0.0. The migration guide in `docs/python/changelog/1_3_13.mdx` provides detailed instructions for all deprecated imports.

## Related Issues

Closes #537 

**Issue Summary:**
- **Priority:** High
- **Type:** Bug / Maintenance
- **Labels:** `bug`, `maintenance`, `python`
- **Problem:** Deprecation warnings referenced version 1.4.0 for removal, but current version is 1.5.0, creating confusion about migration timelines
- **Solution:** Updated all deprecation warnings to reference version 2.0.0 (next major version)

---

## Additional Notes

- **Current Version:** 1.5.0 (as per `pyproject.toml`)
- **Target Removal Version:** 2.0.0 (following semantic versioning best practices)
- **Files Changed:** 32 files
- **Lines Changed:** 32 lines (one deprecation message per file)
- **Risk Level:** Low (string-only changes, no functional impact)

