### PR TITLE
chore(typescript): update package references to mcp-use/modelcontextp…

### DIFF
--- a/libraries/typescript/.changeset/metal-eagles-accept.md
+++ b/libraries/typescript/.changeset/metal-eagles-accept.md
@@ -1,0 +1,6 @@
+---
+"@mcp-use/inspector": patch
+"mcp-use": patch
+---
+
+chore: replace official sdk with fork in imports

--- a/libraries/typescript/package.json
+++ b/libraries/typescript/package.json
@@ -59,7 +59,7 @@
       "eslint --fix"
     ]
   },
-  "packageManager": "pnpm@10.6.1",
+  "packageManager": "pnpm@10.24.0+sha512.01ff8ae71b4419903b65c60fb2dc9d34cf8bb6e06d03bde112ef38f7a34d6904c424ba66bea5cdcf12890230bf39f9580473140ed9c946fef328b6e5238a345a",
   "pnpm": {
     "patchedDependencies": {},
     "overrides": {

--- a/libraries/typescript/packages/inspector/package.json
+++ b/libraries/typescript/packages/inspector/package.json
@@ -72,7 +72,7 @@
     "@langchain/google-genai": "^2.0.0",
     "@langchain/openai": "^1.1.3",
     "@mcp-ui/client": "^5.16.0",
-    "@modelcontextprotocol/sdk": "git+https://github.com/mcp-use/mcp-ts-sdk-fork.git#v1.24.3-mcp-use.1",
+    "@mcp-use/modelcontextprotocol-sdk": "1.24.3-mcp-use.1",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/libraries/typescript/packages/inspector/src/client/components/CommandPalette.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/CommandPalette.tsx
@@ -2,7 +2,7 @@ import type {
   Prompt,
   Resource,
   Tool,
-} from "@modelcontextprotocol/sdk/types.js";
+} from "@mcp-use/modelcontextprotocol-sdk/types.js";
 import type { SavedRequest } from "./tools";
 import { Command } from "cmdk";
 import {

--- a/libraries/typescript/packages/inspector/src/client/components/ElicitationTab.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ElicitationTab.tsx
@@ -1,4 +1,4 @@
-import type { ElicitResult } from "@modelcontextprotocol/sdk/types.js";
+import type { ElicitResult } from "@mcp-use/modelcontextprotocol-sdk/types.js";
 import type { PendingElicitationRequest } from "@/client/types/elicitation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { CheckSquare } from "lucide-react";

--- a/libraries/typescript/packages/inspector/src/client/components/McpUIRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/McpUIRenderer.tsx
@@ -1,4 +1,4 @@
-import type { Resource } from "@modelcontextprotocol/sdk/types.js";
+import type { Resource } from "@mcp-use/modelcontextprotocol-sdk/types.js";
 import {
   basicComponentLibrary,
   remoteButtonDefinition,

--- a/libraries/typescript/packages/inspector/src/client/components/PromptsTab.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/PromptsTab.tsx
@@ -1,4 +1,4 @@
-import type { Prompt } from "@modelcontextprotocol/sdk/types.js";
+import type { Prompt } from "@mcp-use/modelcontextprotocol-sdk/types.js";
 import type { PromptResult, SavedPrompt } from "./prompts";
 import {
   useCallback,

--- a/libraries/typescript/packages/inspector/src/client/components/ResourcesTab.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ResourcesTab.tsx
@@ -1,4 +1,4 @@
-import type { Resource } from "@modelcontextprotocol/sdk/types.js";
+import type { Resource } from "@mcp-use/modelcontextprotocol-sdk/types.js";
 import {
   useCallback,
   useEffect,

--- a/libraries/typescript/packages/inspector/src/client/components/SamplingTab.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/SamplingTab.tsx
@@ -1,4 +1,4 @@
-import type { CreateMessageResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CreateMessageResult } from "@mcp-use/modelcontextprotocol-sdk/types.js";
 import type { PendingSamplingRequest } from "@/client/types/sampling";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Hash } from "lucide-react";

--- a/libraries/typescript/packages/inspector/src/client/components/ToolsTab.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ToolsTab.tsx
@@ -1,4 +1,4 @@
-import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { Tool } from "@mcp-use/modelcontextprotocol-sdk/types.js";
 import {
   useCallback,
   useEffect,

--- a/libraries/typescript/packages/inspector/src/client/components/elicitation/ElicitationRequestDisplay.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/elicitation/ElicitationRequestDisplay.tsx
@@ -4,7 +4,7 @@ import { Input } from "@/client/components/ui/input";
 import { Label } from "@/client/components/ui/label";
 import { Textarea } from "@/client/components/ui/textarea";
 import { Checkbox } from "@/client/components/ui/checkbox";
-import type { ElicitResult } from "@modelcontextprotocol/sdk/types.js";
+import type { ElicitResult } from "@mcp-use/modelcontextprotocol-sdk/types.js";
 import type { PendingElicitationRequest } from "@/client/types/elicitation";
 import { JSONDisplay } from "@/client/components/shared/JSONDisplay";
 import { toast } from "sonner";

--- a/libraries/typescript/packages/inspector/src/client/components/prompts/PromptExecutionPanel.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/prompts/PromptExecutionPanel.tsx
@@ -1,4 +1,4 @@
-import type { Prompt } from "@modelcontextprotocol/sdk/types.js";
+import type { Prompt } from "@mcp-use/modelcontextprotocol-sdk/types.js";
 import { Play, Save } from "lucide-react";
 import { useEffect } from "react";
 import { Button } from "@/client/components/ui/button";

--- a/libraries/typescript/packages/inspector/src/client/components/prompts/PromptInputForm.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/prompts/PromptInputForm.tsx
@@ -1,4 +1,4 @@
-import type { Prompt } from "@modelcontextprotocol/sdk/types.js";
+import type { Prompt } from "@mcp-use/modelcontextprotocol-sdk/types.js";
 import { Input } from "@/client/components/ui/input";
 import { Label } from "@/client/components/ui/label";
 import { Textarea } from "@/client/components/ui/textarea";

--- a/libraries/typescript/packages/inspector/src/client/components/prompts/PromptResultDisplay.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/prompts/PromptResultDisplay.tsx
@@ -2,7 +2,7 @@ import { Check, Clock, Copy, Zap } from "lucide-react";
 import { Button } from "@/client/components/ui/button";
 import { NotFound } from "../ui/not-found";
 import { JSONDisplay } from "../shared/JSONDisplay";
-import type { GetPromptResult } from "@modelcontextprotocol/sdk/types.js";
+import type { GetPromptResult } from "@mcp-use/modelcontextprotocol-sdk/types.js";
 
 export interface PromptResult {
   promptName: string;

--- a/libraries/typescript/packages/inspector/src/client/components/prompts/PromptsList.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/prompts/PromptsList.tsx
@@ -1,4 +1,4 @@
-import type { Prompt } from "@modelcontextprotocol/sdk/types.js";
+import type { Prompt } from "@mcp-use/modelcontextprotocol-sdk/types.js";
 import { MessageSquare } from "lucide-react";
 import { ListItem } from "@/client/components/shared";
 import { Badge } from "@/client/components/ui/badge";

--- a/libraries/typescript/packages/inspector/src/client/components/resources/ResourceResultDisplay.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/resources/ResourceResultDisplay.tsx
@@ -14,7 +14,7 @@ import { isMcpUIResource, McpUIRenderer } from "../McpUIRenderer";
 import { OpenAIComponentRenderer } from "../OpenAIComponentRenderer";
 import { Spinner } from "../ui/spinner";
 import { JSONDisplay } from "../shared/JSONDisplay";
-import type { ReadResourceResult } from "@modelcontextprotocol/sdk/types.js";
+import type { ReadResourceResult } from "@mcp-use/modelcontextprotocol-sdk/types.js";
 
 export interface ResourceResult {
   uri: string;

--- a/libraries/typescript/packages/inspector/src/client/components/resources/ResourcesList.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/resources/ResourcesList.tsx
@@ -1,4 +1,4 @@
-import type { Resource } from "@modelcontextprotocol/sdk/types.js";
+import type { Resource } from "@mcp-use/modelcontextprotocol-sdk/types.js";
 import {
   Database,
   File,

--- a/libraries/typescript/packages/inspector/src/client/components/sampling/SamplingRequestDisplay.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/sampling/SamplingRequestDisplay.tsx
@@ -10,8 +10,8 @@ import {
   SelectValue,
 } from "@/client/components/ui/select";
 import { Textarea } from "@/client/components/ui/textarea";
-import { CreateMessageResultSchema } from "@modelcontextprotocol/sdk/types.js";
-import type { CreateMessageResult } from "@modelcontextprotocol/sdk/types.js";
+import { CreateMessageResultSchema } from "@mcp-use/modelcontextprotocol-sdk/types.js";
+import type { CreateMessageResult } from "@mcp-use/modelcontextprotocol-sdk/types.js";
 import type { PendingSamplingRequest } from "@/client/types/sampling";
 import type { LLMConfig } from "../chat/types";
 import { JSONDisplay } from "@/client/components/shared/JSONDisplay";

--- a/libraries/typescript/packages/inspector/src/client/components/sampling/SamplingRequestToast.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/sampling/SamplingRequestToast.tsx
@@ -1,4 +1,4 @@
-import type { CreateMessageResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CreateMessageResult } from "@mcp-use/modelcontextprotocol-sdk/types.js";
 import { DEFAULT_SAMPLING_RESPONSE } from "@/client/types/sampling";
 
 interface SamplingRequestToastProps {

--- a/libraries/typescript/packages/inspector/src/client/components/sampling/useSamplingLLM.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/sampling/useSamplingLLM.ts
@@ -3,7 +3,7 @@ import type { LLMConfig } from "../chat/types";
 import type {
   CreateMessageRequest,
   CreateMessageResult,
-} from "@modelcontextprotocol/sdk/types.js";
+} from "@mcp-use/modelcontextprotocol-sdk/types.js";
 
 interface UseSamplingLLMProps {
   llmConfig: LLMConfig | null;

--- a/libraries/typescript/packages/inspector/src/client/components/tools/ToolExecutionPanel.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/tools/ToolExecutionPanel.tsx
@@ -1,4 +1,4 @@
-import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { Tool } from "@mcp-use/modelcontextprotocol-sdk/types.js";
 import { Play, Save, X, Code } from "lucide-react";
 import { Button } from "@/client/components/ui/button";
 import { Spinner } from "@/client/components/ui/spinner";

--- a/libraries/typescript/packages/inspector/src/client/components/tools/ToolInputForm.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/tools/ToolInputForm.tsx
@@ -8,7 +8,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/client/components/ui/select";
-import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { Tool } from "@mcp-use/modelcontextprotocol-sdk/types.js";
 
 interface ToolInputFormProps {
   selectedTool: Tool;

--- a/libraries/typescript/packages/inspector/src/client/components/tools/ToolResultDisplay.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/tools/ToolResultDisplay.tsx
@@ -64,7 +64,7 @@ function getRelativeTime(timestamp: number): string {
 // Helper function to extract error message from result with isError: true
 function extractErrorMessage(
   result:
-    | import("@modelcontextprotocol/sdk/types.js").CallToolResult
+    | import("@mcp-use/modelcontextprotocol-sdk/types.js").CallToolResult
     | { error?: string; isError?: boolean }
 ): string | null {
   if (!result?.isError) {

--- a/libraries/typescript/packages/inspector/src/client/components/tools/ToolsList.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/tools/ToolsList.tsx
@@ -1,4 +1,4 @@
-import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { Tool } from "@mcp-use/modelcontextprotocol-sdk/types.js";
 import { Wrench } from "lucide-react";
 import { ListItem } from "@/client/components/shared";
 import { Badge } from "@/client/components/ui/badge";

--- a/libraries/typescript/packages/inspector/src/client/context/McpContext.tsx
+++ b/libraries/typescript/packages/inspector/src/client/context/McpContext.tsx
@@ -13,7 +13,7 @@ import {
 import type {
   CreateMessageResult,
   ElicitResult,
-} from "@modelcontextprotocol/sdk/types.js";
+} from "@mcp-use/modelcontextprotocol-sdk/types.js";
 import type { PendingSamplingRequest } from "@/client/types/sampling";
 import type { PendingElicitationRequest } from "@/client/types/elicitation";
 import { SamplingRequestToast } from "@/client/components/sampling/SamplingRequestToast";

--- a/libraries/typescript/packages/inspector/src/client/transport-wrapper-browser.ts
+++ b/libraries/typescript/packages/inspector/src/client/transport-wrapper-browser.ts
@@ -1,9 +1,9 @@
-import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import type { Transport } from "@mcp-use/modelcontextprotocol-sdk/shared/transport.js";
 import type {
   JSONRPCMessage,
   MessageExtraInfo,
-} from "@modelcontextprotocol/sdk/types.js";
-import type { TransportSendOptions } from "@modelcontextprotocol/sdk/shared/transport.js";
+} from "@mcp-use/modelcontextprotocol-sdk/types.js";
+import type { TransportSendOptions } from "@mcp-use/modelcontextprotocol-sdk/shared/transport.js";
 import { browserRpcLogBus } from "./rpc-log-bus-browser.js";
 
 /**

--- a/libraries/typescript/packages/inspector/src/client/types/elicitation.ts
+++ b/libraries/typescript/packages/inspector/src/client/types/elicitation.ts
@@ -2,7 +2,7 @@ import type {
   ElicitRequestFormParams,
   ElicitRequestURLParams,
   ElicitResult,
-} from "@modelcontextprotocol/sdk/types.js";
+} from "@mcp-use/modelcontextprotocol-sdk/types.js";
 
 export interface PendingElicitationRequest {
   id: string;

--- a/libraries/typescript/packages/inspector/src/client/types/sampling.ts
+++ b/libraries/typescript/packages/inspector/src/client/types/sampling.ts
@@ -1,7 +1,7 @@
 import type {
   CreateMessageRequest,
   CreateMessageResult,
-} from "@modelcontextprotocol/sdk/types.js";
+} from "@mcp-use/modelcontextprotocol-sdk/types.js";
 
 export interface PendingSamplingRequest {
   id: string;

--- a/libraries/typescript/packages/inspector/src/server/transport-wrapper.ts
+++ b/libraries/typescript/packages/inspector/src/server/transport-wrapper.ts
@@ -1,9 +1,9 @@
-import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import type { Transport } from "@mcp-use/modelcontextprotocol-sdk/shared/transport.js";
 import type {
   JSONRPCMessage,
   MessageExtraInfo,
-} from "@modelcontextprotocol/sdk/types.js";
-import type { TransportSendOptions } from "@modelcontextprotocol/sdk/shared/transport.js";
+} from "@mcp-use/modelcontextprotocol-sdk/types.js";
+import type { TransportSendOptions } from "@mcp-use/modelcontextprotocol-sdk/shared/transport.js";
 import { rpcLogBus } from "./rpc-log-bus.js";
 
 /**

--- a/libraries/typescript/packages/mcp-use/examples/client/sampling-client.ts
+++ b/libraries/typescript/packages/mcp-use/examples/client/sampling-client.ts
@@ -12,7 +12,7 @@
  */
 
 import { MCPClient } from "mcp-use";
-import type { CreateMessageRequest } from "@modelcontextprotocol/sdk/types.js";
+import type { CreateMessageRequest } from "@mcp-use/modelcontextprotocol-sdk/types.js";
 
 // Mock LLM function - replace this with your actual LLM integration
 async function mockLLM(prompt: string): Promise<string> {
@@ -55,7 +55,9 @@ async function mockLLM(prompt: string): Promise<string> {
 // Create sampling callback
 async function samplingCallback(
   params: CreateMessageRequest["params"]
-): Promise<import("@modelcontextprotocol/sdk/types.js").CreateMessageResult> {
+): Promise<
+  import("@mcp-use/modelcontextprotocol-sdk/types.js").CreateMessageResult
+> {
   console.log("📥 Received sampling request:");
   console.log("   Messages:", params.messages.length);
   console.log("   Model preferences:", params.modelPreferences);

--- a/libraries/typescript/packages/mcp-use/examples/server/elicitation/test-client.ts
+++ b/libraries/typescript/packages/mcp-use/examples/server/elicitation/test-client.ts
@@ -2,14 +2,14 @@
  * Simple test client to verify elicitation implementation
  */
 
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { Client } from "@mcp-use/modelcontextprotocol-sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@mcp-use/modelcontextprotocol-sdk/client/streamableHttp.js";
 import {
   ElicitRequestSchema,
   type ElicitRequestFormParams,
   type ElicitRequestURLParams,
   type ElicitResult,
-} from "@modelcontextprotocol/sdk/types.js";
+} from "@mcp-use/modelcontextprotocol-sdk/types.js";
 
 const SERVER_URL = "http://localhost:3002/mcp";
 

--- a/libraries/typescript/packages/mcp-use/examples/server/elicitation/test-validation.ts
+++ b/libraries/typescript/packages/mcp-use/examples/server/elicitation/test-validation.ts
@@ -3,12 +3,12 @@
  * Tests server-side validation of returned data against Zod schemas
  */
 
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { Client } from "@mcp-use/modelcontextprotocol-sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@mcp-use/modelcontextprotocol-sdk/client/streamableHttp.js";
 import {
   ElicitRequestSchema,
   type ElicitResult,
-} from "@modelcontextprotocol/sdk/types.js";
+} from "@mcp-use/modelcontextprotocol-sdk/types.js";
 
 const SERVER_URL = "http://localhost:3002/mcp";
 

--- a/libraries/typescript/packages/mcp-use/index.ts
+++ b/libraries/typescript/packages/mcp-use/index.ts
@@ -27,7 +27,7 @@ import {
   type Root,
   type Tool,
 } from "./src/session.js";
-import type { CreateMessageRequest } from "@modelcontextprotocol/sdk/types.js";
+import type { CreateMessageRequest } from "@mcp-use/modelcontextprotocol-sdk/types.js";
 
 export { BaseAdapter, LangChainAdapter } from "./src/adapters/index.js";
 // Export AI SDK utilities
@@ -132,7 +132,7 @@ export {
 export type {
   CreateMessageRequest,
   CreateMessageResult,
-} from "@modelcontextprotocol/sdk/types.js";
+} from "@mcp-use/modelcontextprotocol-sdk/types.js";
 
 /**
  * Type alias for the params property of CreateMessageRequest.

--- a/libraries/typescript/packages/mcp-use/package.json
+++ b/libraries/typescript/packages/mcp-use/package.json
@@ -161,7 +161,7 @@
     "@mcp-ui/server": "^5.15.0",
     "@mcp-use/cli": "workspace:*",
     "@mcp-use/inspector": "workspace:*",
-    "@modelcontextprotocol/sdk": "git+https://github.com/mcp-use/mcp-ts-sdk-fork.git#v1.24.3-mcp-use.1",
+    "@mcp-use/modelcontextprotocol-sdk": "1.24.3-mcp-use.1",
     "express": "^5.2.0",
     "hono": "^4.10.7",
     "jose": "^6.1.2",

--- a/libraries/typescript/packages/mcp-use/src/adapters/langchain_adapter.ts
+++ b/libraries/typescript/packages/mcp-use/src/adapters/langchain_adapter.ts
@@ -3,7 +3,7 @@ import type { StructuredToolInterface } from "@langchain/core/tools";
 import type {
   CallToolResult,
   Tool as MCPTool,
-} from "@modelcontextprotocol/sdk/types.js";
+} from "@mcp-use/modelcontextprotocol-sdk/types.js";
 import type { ZodTypeAny } from "zod";
 import type { BaseConnector } from "../connectors/base.js";
 

--- a/libraries/typescript/packages/mcp-use/src/auth/browser-provider.ts
+++ b/libraries/typescript/packages/mcp-use/src/auth/browser-provider.ts
@@ -3,8 +3,8 @@ import type {
   OAuthClientInformation,
   OAuthTokens,
   OAuthClientMetadata,
-} from "@modelcontextprotocol/sdk/shared/auth.js";
-import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
+} from "@mcp-use/modelcontextprotocol-sdk/shared/auth.js";
+import type { OAuthClientProvider } from "@mcp-use/modelcontextprotocol-sdk/client/auth.js";
 import { sanitizeUrl } from "../utils/url-sanitize.js";
 // Assuming StoredState is defined in ./types.js and includes fields for provider options
 import type { StoredState } from "./types.js"; // Adjust path if necessary

--- a/libraries/typescript/packages/mcp-use/src/auth/callback.ts
+++ b/libraries/typescript/packages/mcp-use/src/auth/callback.ts
@@ -1,5 +1,5 @@
 // callback.ts
-import { auth } from "@modelcontextprotocol/sdk/client/auth.js";
+import { auth } from "@mcp-use/modelcontextprotocol-sdk/client/auth.js";
 import { BrowserOAuthClientProvider } from "./browser-provider.js"; // Adjust path
 import type { StoredState } from "./types.js"; // Adjust path, ensure definition includes providerOptions
 

--- a/libraries/typescript/packages/mcp-use/src/auth/types.ts
+++ b/libraries/typescript/packages/mcp-use/src/auth/types.ts
@@ -1,4 +1,4 @@
-import type { OAuthMetadata } from "@modelcontextprotocol/sdk/shared/auth.js";
+import type { OAuthMetadata } from "@mcp-use/modelcontextprotocol-sdk/shared/auth.js";
 
 /**
  * Internal type for storing OAuth state in localStorage during the OAuth flow.

--- a/libraries/typescript/packages/mcp-use/src/browser.ts
+++ b/libraries/typescript/packages/mcp-use/src/browser.ts
@@ -48,4 +48,4 @@ export type {
   OAuthClientInformation,
   OAuthMetadata,
   OAuthTokens,
-} from "@modelcontextprotocol/sdk/shared/auth.js";
+} from "@mcp-use/modelcontextprotocol-sdk/shared/auth.js";

--- a/libraries/typescript/packages/mcp-use/src/client.ts
+++ b/libraries/typescript/packages/mcp-use/src/client.ts
@@ -6,7 +6,7 @@ import type {
   ElicitRequestFormParams,
   ElicitRequestURLParams,
   ElicitResult,
-} from "@modelcontextprotocol/sdk/types.js";
+} from "@mcp-use/modelcontextprotocol-sdk/types.js";
 import { BaseMCPClient } from "./client/base.js";
 import type { ExecutionResult } from "./client/codeExecutor.js";
 import {

--- a/libraries/typescript/packages/mcp-use/src/client/connectors/codeMode.ts
+++ b/libraries/typescript/packages/mcp-use/src/client/connectors/codeMode.ts
@@ -1,4 +1,7 @@
-import type { CallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
+import type {
+  CallToolResult,
+  Tool,
+} from "@mcp-use/modelcontextprotocol-sdk/types.js";
 import type { MCPClient } from "../../client.js";
 import { BaseConnector } from "../../connectors/base.js";
 

--- a/libraries/typescript/packages/mcp-use/src/client/executors/base.ts
+++ b/libraries/typescript/packages/mcp-use/src/client/executors/base.ts
@@ -1,4 +1,4 @@
-import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { Tool } from "@mcp-use/modelcontextprotocol-sdk/types.js";
 import type { MCPClient } from "../../client.js";
 import { logger } from "../../logging.js";
 

--- a/libraries/typescript/packages/mcp-use/src/client/executors/e2b.ts
+++ b/libraries/typescript/packages/mcp-use/src/client/executors/e2b.ts
@@ -1,4 +1,4 @@
-import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { Tool } from "@mcp-use/modelcontextprotocol-sdk/types.js";
 import type { E2BExecutorOptions, MCPClient } from "../../client.js";
 import { logger } from "../../logging.js";
 import { BaseCodeExecutor, type ExecutionResult } from "./base.js";

--- a/libraries/typescript/packages/mcp-use/src/connectors/base.ts
+++ b/libraries/typescript/packages/mcp-use/src/connectors/base.ts
@@ -1,13 +1,13 @@
 import type {
   Client,
   ClientOptions,
-} from "@modelcontextprotocol/sdk/client/index.js";
-import type { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js";
+} from "@mcp-use/modelcontextprotocol-sdk/client/index.js";
+import type { RequestOptions } from "@mcp-use/modelcontextprotocol-sdk/shared/protocol.js";
 import {
   ListRootsRequestSchema,
   CreateMessageRequestSchema,
   ElicitRequestSchema,
-} from "@modelcontextprotocol/sdk/types.js";
+} from "@mcp-use/modelcontextprotocol-sdk/types.js";
 import type {
   CallToolResult,
   CreateMessageRequest,
@@ -18,7 +18,7 @@ import type {
   Notification,
   Root,
   Tool,
-} from "@modelcontextprotocol/sdk/types.js";
+} from "@mcp-use/modelcontextprotocol-sdk/types.js";
 import type { ConnectionManager } from "../task_managers/base.js";
 import { logger } from "../logging.js";
 
@@ -236,7 +236,7 @@ export abstract class BaseConnector {
     // Handle roots/list requests from the server
     this.client.setRequestHandler(
       ListRootsRequestSchema,
-      async (_request, _extra) => {
+      async (_request: unknown, _extra: unknown) => {
         logger.debug(
           `Server requested roots list, returning ${this.rootsCache.length} root(s)`
         );
@@ -263,7 +263,7 @@ export abstract class BaseConnector {
     // Handle sampling/createMessage requests from the server
     this.client.setRequestHandler(
       CreateMessageRequestSchema,
-      async (request, _extra) => {
+      async (request: CreateMessageRequest, _extra: unknown) => {
         logger.debug("Server requested sampling, forwarding to callback");
         return await this.opts.samplingCallback!(request.params);
       }
@@ -293,7 +293,10 @@ export abstract class BaseConnector {
     // Handle elicitation/create requests from the server
     this.client.setRequestHandler(
       ElicitRequestSchema,
-      async (request, _extra) => {
+      async (
+        request: { params: ElicitRequestFormParams | ElicitRequestURLParams },
+        _extra: unknown
+      ) => {
         logger.debug("Server requested elicitation, forwarding to callback");
         return await this.opts.elicitationCallback!(request.params);
       }
@@ -460,7 +463,8 @@ export abstract class BaseConnector {
       let cursor: string | undefined = undefined;
 
       do {
-        const result = await this.client.listResources({ cursor }, options);
+        const result: { resources?: any[]; nextCursor?: string } =
+          await this.client.listResources({ cursor }, options);
         allResources.push(...(result.resources || []));
         cursor = result.nextCursor;
       } while (cursor);

--- a/libraries/typescript/packages/mcp-use/src/connectors/http.ts
+++ b/libraries/typescript/packages/mcp-use/src/connectors/http.ts
@@ -1,8 +1,8 @@
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { Client } from "@mcp-use/modelcontextprotocol-sdk/client/index.js";
 import {
   StreamableHTTPClientTransport,
   StreamableHTTPError,
-} from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+} from "@mcp-use/modelcontextprotocol-sdk/client/streamableHttp.js";
 import { logger } from "../logging.js";
 import { SseConnectionManager } from "../task_managers/sse.js";
 import type { ConnectorInitOptions } from "./base.js";
@@ -69,24 +69,32 @@ export class HttpConnector extends BaseConnector {
       logger.info("🔄 Attempting streamable HTTP transport...");
       await this.connectWithStreamableHttp(baseUrl);
       logger.info("✅ Successfully connected via streamable HTTP");
-    } catch (err) {
+    } catch (err: unknown) {
       // Check if this is a 4xx error that indicates we should try SSE fallback
       let fallbackReason = "Unknown error";
       let is401Error = false;
 
       if (err instanceof StreamableHTTPError) {
-        is401Error = err.code === 401;
+        // TypeScript type narrowing - check properties exist
+        const streamableErr = err as StreamableHTTPError & {
+          code: number;
+          message: string;
+        };
+        is401Error = streamableErr.code === 401;
 
         // Check for "Missing session ID" error (HTTP 400 from FastMCP)
-        if (err.code === 400 && err.message.includes("Missing session ID")) {
+        if (
+          streamableErr.code === 400 &&
+          streamableErr.message.includes("Missing session ID")
+        ) {
           fallbackReason =
             "Server requires session ID (FastMCP compatibility) - using SSE transport";
           logger.warn(`⚠️  ${fallbackReason}`);
-        } else if (err.code === 404 || err.code === 405) {
-          fallbackReason = `Server returned ${err.code} - server likely doesn't support streamable HTTP`;
+        } else if (streamableErr.code === 404 || streamableErr.code === 405) {
+          fallbackReason = `Server returned ${streamableErr.code} - server likely doesn't support streamable HTTP`;
           logger.debug(fallbackReason);
         } else {
-          fallbackReason = `Server returned ${err.code}: ${err.message}`;
+          fallbackReason = `Server returned ${streamableErr.code}: ${streamableErr.message}`;
           logger.debug(fallbackReason);
         }
       } else if (err instanceof Error) {

--- a/libraries/typescript/packages/mcp-use/src/connectors/stdio.ts
+++ b/libraries/typescript/packages/mcp-use/src/connectors/stdio.ts
@@ -1,9 +1,9 @@
-import type { StdioServerParameters } from "@modelcontextprotocol/sdk/client/stdio.js";
+import type { StdioServerParameters } from "@mcp-use/modelcontextprotocol-sdk/client/stdio.js";
 import type { Writable } from "node:stream";
 
 import type { ConnectorInitOptions } from "./base.js";
 import process from "node:process";
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { Client } from "@mcp-use/modelcontextprotocol-sdk/client/index.js";
 
 import { logger } from "../logging.js";
 import { StdioConnectionManager } from "../task_managers/stdio.js";

--- a/libraries/typescript/packages/mcp-use/src/connectors/websocket.ts
+++ b/libraries/typescript/packages/mcp-use/src/connectors/websocket.ts
@@ -2,7 +2,7 @@ import type {
   CallToolResult,
   ReadResourceResult,
   Tool,
-} from "@modelcontextprotocol/sdk/types.js";
+} from "@mcp-use/modelcontextprotocol-sdk/types.js";
 import { generateUUID } from "../server/utils/runtime.js";
 import { logger } from "../logging.js";
 import { WebSocketConnectionManager } from "../task_managers/websocket.js";

--- a/libraries/typescript/packages/mcp-use/src/react/index.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/index.ts
@@ -15,7 +15,7 @@ export type {
   Resource,
   ResourceTemplate,
   Tool,
-} from "@modelcontextprotocol/sdk/types.js";
+} from "@mcp-use/modelcontextprotocol-sdk/types.js";
 
 // Export OpenAI Apps SDK widget hooks and types
 export { ErrorBoundary } from "./ErrorBoundary.js";

--- a/libraries/typescript/packages/mcp-use/src/react/types.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/types.ts
@@ -9,7 +9,7 @@ import type {
   Resource,
   ResourceTemplate,
   Tool,
-} from "@modelcontextprotocol/sdk/types.js";
+} from "@mcp-use/modelcontextprotocol-sdk/types.js";
 import type { BrowserMCPClient } from "../client/browser.js";
 
 export type UseMcpOptions = {

--- a/libraries/typescript/packages/mcp-use/src/react/useMcp.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/useMcp.ts
@@ -4,7 +4,7 @@ import type {
   Resource,
   ResourceTemplate,
   Tool,
-} from "@modelcontextprotocol/sdk/types.js";
+} from "@mcp-use/modelcontextprotocol-sdk/types.js";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { sanitizeUrl } from "../utils/url-sanitize.js";
 import { BrowserMCPClient } from "../client/browser.js";
@@ -385,7 +385,7 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
             // This happens because 401 occurs before OAuth flow starts
             try {
               const { auth } =
-                await import("@modelcontextprotocol/sdk/client/auth.js");
+                await import("@mcp-use/modelcontextprotocol-sdk/client/auth.js");
               const baseUrl = new URL(url).origin;
 
               // Trigger auth to generate the URL, but it will be blocked by preventAutoAuth
@@ -658,19 +658,19 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
         // Generate a fresh authorization URL and redirect immediately
         // We need to manually trigger what the SDK would do
         const { auth } =
-          await import("@modelcontextprotocol/sdk/client/auth.js");
+          await import("@mcp-use/modelcontextprotocol-sdk/client/auth.js");
 
         // This will trigger the OAuth flow with the new provider
         // The provider will redirect/popup automatically since preventAutoAuth is false
         const baseUrl = new URL(url).origin;
         auth(freshAuthProvider, {
           serverUrl: baseUrl,
-        }).catch((err) => {
+        }).catch((err: unknown) => {
           // This is expected to "fail" with redirect - the auth flow continues in the popup/redirect
           addLog(
             "info",
             "OAuth flow initiated:",
-            err?.message || "Redirecting..."
+            err instanceof Error ? err.message : "Redirecting..."
           );
         });
       } catch (authError) {

--- a/libraries/typescript/packages/mcp-use/src/server/endpoints/mount-mcp.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/endpoints/mount-mcp.ts
@@ -20,7 +20,7 @@ import { generateUUID } from "../utils/runtime.js";
 export async function mountMcp(
   app: HonoType,
   mcpServerInstance: {
-    getServerForSession: () => import("@modelcontextprotocol/sdk/server/mcp.js").McpServer;
+    getServerForSession: () => import("@mcp-use/modelcontextprotocol-sdk/server/mcp.js").McpServer;
     cleanupSessionSubscriptions?: (sessionId: string) => void;
   }, // The McpServer instance with getServerForSession() method
   sessions: Map<string, SessionData>,
@@ -28,7 +28,7 @@ export async function mountMcp(
   isProductionMode: boolean
 ): Promise<{ mcpMounted: boolean; idleCleanupInterval?: NodeJS.Timeout }> {
   const { FetchStreamableHTTPServerTransport } =
-    await import("@modelcontextprotocol/sdk/experimental/fetch-streamable-http/index.js");
+    await import("@mcp-use/modelcontextprotocol-sdk/experimental/fetch-streamable-http/index.js");
 
   const idleTimeoutMs = config.sessionIdleTimeoutMs ?? 300000; // Default: 5 minutes
 

--- a/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
@@ -1,12 +1,15 @@
 import {
   McpServer as OfficialMcpServer,
   ResourceTemplate,
-} from "@modelcontextprotocol/sdk/server/mcp.js";
+} from "@mcp-use/modelcontextprotocol-sdk/server/mcp.js";
 import type {
   CreateMessageRequest,
   CreateMessageResult,
-} from "@modelcontextprotocol/sdk/types.js";
-import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
+} from "@mcp-use/modelcontextprotocol-sdk/types.js";
+import {
+  McpError,
+  ErrorCode,
+} from "@mcp-use/modelcontextprotocol-sdk/types.js";
 import type { Hono as HonoType } from "hono";
 import { z } from "zod";
 
@@ -86,7 +89,7 @@ import type {
 
 class MCPServerClass<HasOAuth extends boolean = false> {
   /**
-   * Native MCP server instance from @modelcontextprotocol/sdk
+   * Native MCP server instance from @mcp-use/modelcontextprotocol-sdk
    * Exposed publicly for advanced use cases
    */
   public readonly nativeServer: OfficialMcpServer;

--- a/libraries/typescript/packages/mcp-use/src/server/prompts/conversion.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/prompts/conversion.ts
@@ -2,7 +2,7 @@ import type {
   CallToolResult,
   GetPromptResult,
   PromptMessage,
-} from "@modelcontextprotocol/sdk/types.js";
+} from "@mcp-use/modelcontextprotocol-sdk/types.js";
 
 /**
  * Check if a result is a GetPromptResult (has 'messages' array)

--- a/libraries/typescript/packages/mcp-use/src/server/prompts/index.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/prompts/index.ts
@@ -2,7 +2,7 @@ import type { z } from "zod";
 import type {
   GetPromptResult,
   CallToolResult,
-} from "@modelcontextprotocol/sdk/types.js";
+} from "@mcp-use/modelcontextprotocol-sdk/types.js";
 import type {
   PromptDefinition,
   PromptDefinitionWithoutCallback,

--- a/libraries/typescript/packages/mcp-use/src/server/resources/conversion.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/resources/conversion.ts
@@ -2,7 +2,7 @@ import type {
   CallToolResult,
   ReadResourceResult,
   ResourceContents,
-} from "@modelcontextprotocol/sdk/types.js";
+} from "@mcp-use/modelcontextprotocol-sdk/types.js";
 
 /**
  * Check if a result is a ReadResourceResult (has 'contents' array)

--- a/libraries/typescript/packages/mcp-use/src/server/resources/index.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/resources/index.ts
@@ -9,11 +9,11 @@ import type {
   ResourceTemplateDefinition,
   EnhancedResourceContext,
 } from "../types/index.js";
-import { ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ResourceTemplate } from "@mcp-use/modelcontextprotocol-sdk/server/mcp.js";
 import type {
   ReadResourceResult,
   CallToolResult,
-} from "@modelcontextprotocol/sdk/types.js";
+} from "@mcp-use/modelcontextprotocol-sdk/types.js";
 import type { TypedCallToolResult } from "../utils/response-helpers.js";
 import { convertToolResultToResourceResult } from "./conversion.js";
 

--- a/libraries/typescript/packages/mcp-use/src/server/resources/subscriptions.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/resources/subscriptions.ts
@@ -5,11 +5,11 @@
  * Implements the MCP resources/subscribe and resources/unsubscribe protocol.
  */
 
-import type { McpServer as OfficialMcpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer as OfficialMcpServer } from "@mcp-use/modelcontextprotocol-sdk/server/mcp.js";
 import {
   SubscribeRequestSchema,
   UnsubscribeRequestSchema,
-} from "@modelcontextprotocol/sdk/types.js";
+} from "@mcp-use/modelcontextprotocol-sdk/types.js";
 import type { SessionData } from "../sessions/index.js";
 import { getRequestContext } from "../context-storage.js";
 

--- a/libraries/typescript/packages/mcp-use/src/server/sessions/session-manager.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/sessions/session-manager.ts
@@ -6,8 +6,8 @@
  */
 
 import type { Context } from "hono";
-import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { Transport } from "@mcp-use/modelcontextprotocol-sdk/shared/transport.js";
+import type { McpServer } from "@mcp-use/modelcontextprotocol-sdk/server/mcp.js";
 
 /**
  * Session data stored for each active MCP session

--- a/libraries/typescript/packages/mcp-use/src/server/tools/tool-execution-helpers.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/tools/tool-execution-helpers.ts
@@ -14,8 +14,8 @@ import type {
   ElicitRequestURLParams,
   ElicitResult,
   ElicitRequest,
-} from "@modelcontextprotocol/sdk/types.js";
-import { toJsonSchemaCompat } from "@modelcontextprotocol/sdk/server/zod-json-schema-compat.js";
+} from "@mcp-use/modelcontextprotocol-sdk/types.js";
+import { toJsonSchemaCompat } from "@mcp-use/modelcontextprotocol-sdk/server/zod-json-schema-compat.js";
 import { ElicitationValidationError } from "../../errors.js";
 import { generateUUID } from "../utils/runtime.js";
 import type {

--- a/libraries/typescript/packages/mcp-use/src/server/tools/tool-registration.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/tools/tool-registration.ts
@@ -12,7 +12,7 @@ import type {
   ElicitResult,
   CallToolResult,
   ElicitRequest,
-} from "@modelcontextprotocol/sdk/types.js";
+} from "@mcp-use/modelcontextprotocol-sdk/types.js";
 import { runWithContext, getRequestContext } from "../context-storage.js";
 import type {
   ToolDefinition,

--- a/libraries/typescript/packages/mcp-use/src/server/types/prompt.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/types/prompt.ts
@@ -1,7 +1,7 @@
 import type {
   GetPromptResult,
   CallToolResult,
-} from "@modelcontextprotocol/sdk/types.js";
+} from "@mcp-use/modelcontextprotocol-sdk/types.js";
 import type { InputDefinition, OptionalizeUndefinedFields } from "./common.js";
 import type { z } from "zod";
 import type { TypedCallToolResult } from "../utils/response-helpers.js";

--- a/libraries/typescript/packages/mcp-use/src/server/types/resource.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/types/resource.ts
@@ -1,7 +1,7 @@
 import type {
   ReadResourceResult,
   CallToolResult,
-} from "@modelcontextprotocol/sdk/types.js";
+} from "@mcp-use/modelcontextprotocol-sdk/types.js";
 import type { ResourceAnnotations } from "./common.js";
 import type { ToolAnnotations } from "./tool.js";
 import type { AdaptersConfig } from "@mcp-ui/server";

--- a/libraries/typescript/packages/mcp-use/src/server/types/tool-context.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/types/tool-context.ts
@@ -9,7 +9,7 @@ import type {
   CreateMessageRequest,
   CreateMessageResult,
   ElicitResult,
-} from "@modelcontextprotocol/sdk/types.js";
+} from "@mcp-use/modelcontextprotocol-sdk/types.js";
 import type { z } from "zod";
 
 /**

--- a/libraries/typescript/packages/mcp-use/src/server/types/tool.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/types/tool.ts
@@ -1,5 +1,5 @@
 import type { InputDefinition } from "./common.js";
-import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+import type { ToolAnnotations } from "@mcp-use/modelcontextprotocol-sdk/types.js";
 import type { ToolContext } from "./tool-context.js";
 import type { McpContext } from "./context.js";
 import type { z } from "zod";

--- a/libraries/typescript/packages/mcp-use/src/server/utils/response-helpers.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/utils/response-helpers.ts
@@ -1,4 +1,4 @@
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@mcp-use/modelcontextprotocol-sdk/types.js";
 import { fsHelpers, isDeno } from "./runtime.js";
 
 /**

--- a/libraries/typescript/packages/mcp-use/src/session.ts
+++ b/libraries/typescript/packages/mcp-use/src/session.ts
@@ -3,8 +3,8 @@ import type {
   Notification,
   Root,
   Tool,
-} from "@modelcontextprotocol/sdk/types.js";
-import type { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js";
+} from "@mcp-use/modelcontextprotocol-sdk/types.js";
+import type { RequestOptions } from "@mcp-use/modelcontextprotocol-sdk/shared/protocol.js";
 import type { BaseConnector, NotificationHandler } from "./connectors/base.js";
 
 export class MCPSession {

--- a/libraries/typescript/packages/mcp-use/src/task_managers/sse.ts
+++ b/libraries/typescript/packages/mcp-use/src/task_managers/sse.ts
@@ -1,5 +1,5 @@
-import type { SSEClientTransportOptions } from "@modelcontextprotocol/sdk/client/sse.js";
-import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+import type { SSEClientTransportOptions } from "@mcp-use/modelcontextprotocol-sdk/client/sse.js";
+import { SSEClientTransport } from "@mcp-use/modelcontextprotocol-sdk/client/sse.js";
 import { logger } from "../logging.js";
 import { ConnectionManager } from "./base.js";
 

--- a/libraries/typescript/packages/mcp-use/src/task_managers/stdio.ts
+++ b/libraries/typescript/packages/mcp-use/src/task_managers/stdio.ts
@@ -1,6 +1,6 @@
-import type { StdioServerParameters } from "@modelcontextprotocol/sdk/client/stdio.js";
+import type { StdioServerParameters } from "@mcp-use/modelcontextprotocol-sdk/client/stdio.js";
 import type { Writable } from "node:stream";
-import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { StdioClientTransport } from "@mcp-use/modelcontextprotocol-sdk/client/stdio.js";
 import { logger } from "../logging.js";
 import { ConnectionManager } from "./base.js";
 

--- a/libraries/typescript/packages/mcp-use/src/task_managers/streamable_http.ts
+++ b/libraries/typescript/packages/mcp-use/src/task_managers/streamable_http.ts
@@ -1,5 +1,5 @@
-import type { StreamableHTTPClientTransportOptions } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { StreamableHTTPClientTransportOptions } from "@mcp-use/modelcontextprotocol-sdk/client/streamableHttp.js";
+import { StreamableHTTPClientTransport } from "@mcp-use/modelcontextprotocol-sdk/client/streamableHttp.js";
 import { logger } from "../logging.js";
 import { ConnectionManager } from "./base.js";
 

--- a/libraries/typescript/packages/mcp-use/tests/deno/deno.json
+++ b/libraries/typescript/packages/mcp-use/tests/deno/deno.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "@modelcontextprotocol/sdk": "https://raw.githubusercontent.com/mcp-use/mcp-ts-sdk-fork/v1.24.3-mcp-use.1/src/index.ts",
+    "@modelcontextprotocol/sdk": "npm:@mcp-use/modelcontextprotocol-sdk@^1.24.3-mcp-use.1",
     "mcp-use/server": "npm:mcp-use/server"
   },
   "compilerOptions": {

--- a/libraries/typescript/packages/mcp-use/tests/integration/elicitation.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/integration/elicitation.test.ts
@@ -5,16 +5,16 @@
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { z } from "zod";
-import { toJsonSchemaCompat } from "@modelcontextprotocol/sdk/server/zod-json-schema-compat.js";
+import { toJsonSchemaCompat } from "@mcp-use/modelcontextprotocol-sdk/server/zod-json-schema-compat.js";
 import { MCPServer } from "../../src/server/index.js";
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { Client } from "@mcp-use/modelcontextprotocol-sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@mcp-use/modelcontextprotocol-sdk/client/streamableHttp.js";
 import type {
   ElicitRequestFormParams,
   ElicitRequestURLParams,
   ElicitResult,
-} from "@modelcontextprotocol/sdk/types.js";
-import { ElicitRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+} from "@mcp-use/modelcontextprotocol-sdk/types.js";
+import { ElicitRequestSchema } from "@mcp-use/modelcontextprotocol-sdk/types.js";
 
 describe("Elicitation Integration Tests", () => {
   let server: any;

--- a/libraries/typescript/packages/mcp-use/tests/integration/widget-helper.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/integration/widget-helper.test.ts
@@ -3,8 +3,8 @@ import { z } from "zod";
 import { MCPServer } from "../../src/server/index.js";
 import { widget } from "../../src/server/utils/response-helpers.js";
 import type { WidgetMetadata } from "../../src/server/types/widget.js";
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { Client } from "@mcp-use/modelcontextprotocol-sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@mcp-use/modelcontextprotocol-sdk/client/streamableHttp.js";
 
 describe("Widget Helper Integration Tests", () => {
   let server: any;

--- a/libraries/typescript/packages/mcp-use/tests/servers/simple_server.ts
+++ b/libraries/typescript/packages/mcp-use/tests/servers/simple_server.ts
@@ -5,12 +5,12 @@
  * Used for integration testing
  */
 
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { Server } from "@mcp-use/modelcontextprotocol-sdk/server/index.js";
+import { StdioServerTransport } from "@mcp-use/modelcontextprotocol-sdk/server/stdio.js";
 import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
-} from "@modelcontextprotocol/sdk/types.js";
+} from "@mcp-use/modelcontextprotocol-sdk/types.js";
 
 // Create server instance
 const server = new Server(

--- a/libraries/typescript/packages/mcp-use/tsup.config.ts
+++ b/libraries/typescript/packages/mcp-use/tsup.config.ts
@@ -16,6 +16,9 @@ export default defineConfig({
   keepNames: true,
   dts: false, // We run tsc separately for declarations
   external: [
+    // Keep MCP SDK external (peer dependency)
+    "@modelcontextprotocol/sdk",
+    "@mcp-use/modelcontextprotocol-sdk",
     // Keep Tailwind CSS and its dependencies external (native modules)
     "tailwindcss",
     "@tailwindcss/vite",

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -378,9 +378,9 @@ importers:
       '@mcp-ui/client':
         specifier: ^5.16.0
         version: 5.17.1(@cfworker/json-schema@4.1.1)(@preact/signals-core@1.12.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(zod@4.1.13)
-      '@modelcontextprotocol/sdk':
-        specifier: git+https://github.com/mcp-use/mcp-ts-sdk-fork.git#v1.24.3-mcp-use.1
-        version: https://codeload.github.com/mcp-use/mcp-ts-sdk-fork/tar.gz/d549cacdb44f56a77f126984c53ace885c002ce6(@cfworker/json-schema@4.1.1)(zod@4.1.13)
+      '@mcp-use/modelcontextprotocol-sdk':
+        specifier: 1.24.3-mcp-use.1
+        version: 1.24.3-mcp-use.1(@cfworker/json-schema@4.1.1)(zod@4.1.13)
       '@radix-ui/react-alert-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -556,9 +556,9 @@ importers:
       '@mcp-use/inspector':
         specifier: workspace:*
         version: link:../inspector
-      '@modelcontextprotocol/sdk':
-        specifier: git+https://github.com/mcp-use/mcp-ts-sdk-fork.git#v1.24.3-mcp-use.1
-        version: https://codeload.github.com/mcp-use/mcp-ts-sdk-fork/tar.gz/d549cacdb44f56a77f126984c53ace885c002ce6(@cfworker/json-schema@4.1.1)(zod@4.1.13)
+      '@mcp-use/modelcontextprotocol-sdk':
+        specifier: 1.24.3-mcp-use.1
+        version: 1.24.3-mcp-use.1(@cfworker/json-schema@4.1.1)(zod@4.1.13)
       express:
         specifier: ^5.2.0
         version: 5.2.1
@@ -917,6 +917,70 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+
+  test_app:
+    dependencies:
+      '@openai/apps-sdk-ui':
+        specifier: ^0.2.0
+        version: 0.2.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(immer@11.0.1)(react-dom@19.2.0(react@19.2.0))(react-is@18.3.1)(react@19.2.0)(redux@5.0.1)(tailwindcss@4.1.17)(use-sync-external-store@1.6.0(react@19.2.0))
+      '@tanstack/react-query':
+        specifier: ^5.90.11
+        version: 5.90.11(react@19.2.0)
+      cors:
+        specifier: ^2.8.5
+        version: 2.8.5
+      express:
+        specifier: ^5.2.0
+        version: 5.2.1
+      mcp-use:
+        specifier: workspace:*
+        version: link:../packages/mcp-use
+      node-mocks-http:
+        specifier: ^1.17.2
+        version: 1.17.2(@types/express@5.0.5)(@types/node@24.10.1)
+      react:
+        specifier: ^19.2.0
+        version: 19.2.0
+      react-dom:
+        specifier: ^19.2.0
+        version: 19.2.0(react@19.2.0)
+      react-router:
+        specifier: ^7.9.6
+        version: 7.9.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-router-dom:
+        specifier: ^7.9.6
+        version: 7.9.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      tailwindcss:
+        specifier: ^4.1.17
+        version: 4.1.17
+      zod:
+        specifier: ^4.1.13
+        version: 4.1.13
+    devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.1.17
+        version: 4.1.17(vite@7.2.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))
+      '@types/node':
+        specifier: ^24.10.1
+        version: 24.10.1
+      '@types/react':
+        specifier: ^19.2.7
+        version: 19.2.7
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.7)
+      '@vitejs/plugin-react':
+        specifier: ^5.1.1
+        version: 5.1.1(vite@7.2.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: '>=5.4.21'
+        version: 7.2.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)
 
 packages:
 
@@ -1629,8 +1693,8 @@ packages:
   '@mcp-ui/server@5.16.1':
     resolution: {integrity: sha512-/kK6pTFunWGyyS8j4Kt61o8oSsdqbgQTimYXMkF/2sFp3XwIFEBzjrBP4BzzLwBYzu7YCDHYff60AC6uUZHqQw==}
 
-  '@modelcontextprotocol/sdk@1.23.0':
-    resolution: {integrity: sha512-MCGd4K9aZKvuSqdoBkdMvZNcYXCkZRYVs/Gh92mdV5IHbctX9H9uIvd4X93+9g8tBbXv08sxc/QHXTzf8y65bA==}
+  '@mcp-use/modelcontextprotocol-sdk@1.24.3-mcp-use.1':
+    resolution: {integrity: sha512-ozSrHKUgbZYHkwuXpr7YQ3NayUswVhKfCHjHaUR/tZpUHANWQ5zFwWxn/JEstaiojxXrMkaa8g9orOcLClHWwg==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -1639,9 +1703,8 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
-  '@modelcontextprotocol/sdk@https://codeload.github.com/mcp-use/mcp-ts-sdk-fork/tar.gz/d549cacdb44f56a77f126984c53ace885c002ce6':
-    resolution: {tarball: https://codeload.github.com/mcp-use/mcp-ts-sdk-fork/tar.gz/d549cacdb44f56a77f126984c53ace885c002ce6}
-    version: 1.24.3-mcp-use.1
+  '@modelcontextprotocol/sdk@1.23.0':
+    resolution: {integrity: sha512-MCGd4K9aZKvuSqdoBkdMvZNcYXCkZRYVs/Gh92mdV5IHbctX9H9uIvd4X93+9g8tBbXv08sxc/QHXTzf8y65bA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -8110,27 +8173,7 @@ snapshots:
       - supports-color
       - zod
 
-  '@modelcontextprotocol/sdk@1.23.0(@cfworker/json-schema@4.1.1)(zod@4.1.13)':
-    dependencies:
-      ajv: 8.17.1
-      ajv-formats: 3.0.1(ajv@8.17.1)
-      content-type: 1.0.5
-      cors: 2.8.5
-      cross-spawn: 7.0.6
-      eventsource: 3.0.7
-      eventsource-parser: 3.0.6
-      express: 5.2.1
-      express-rate-limit: 7.5.1(express@5.2.1)
-      pkce-challenge: 5.0.0
-      raw-body: 3.0.1
-      zod: 4.1.13
-      zod-to-json-schema: 3.25.0(zod@4.1.13)
-    optionalDependencies:
-      '@cfworker/json-schema': 4.1.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@modelcontextprotocol/sdk@https://codeload.github.com/mcp-use/mcp-ts-sdk-fork/tar.gz/d549cacdb44f56a77f126984c53ace885c002ce6(@cfworker/json-schema@4.1.1)(zod@4.1.13)':
+  '@mcp-use/modelcontextprotocol-sdk@1.24.3-mcp-use.1(@cfworker/json-schema@4.1.1)(zod@4.1.13)':
     dependencies:
       ajv: 8.17.1
       ajv-formats: 3.0.1(ajv@8.17.1)
@@ -8145,6 +8188,26 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.0
       raw-body: 3.0.2
+      zod: 4.1.13
+      zod-to-json-schema: 3.25.0(zod@4.1.13)
+    optionalDependencies:
+      '@cfworker/json-schema': 4.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.23.0(@cfworker/json-schema@4.1.1)(zod@4.1.13)':
+    dependencies:
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      content-type: 1.0.5
+      cors: 2.8.5
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 7.5.1(express@5.2.1)
+      pkce-challenge: 5.0.0
+      raw-body: 3.0.1
       zod: 4.1.13
       zod-to-json-schema: 3.25.0(zod@4.1.13)
     optionalDependencies:


### PR DESCRIPTION
…rotocol-sdk

- Changed all instances of @modelcontextprotocol/sdk to @mcp-use/modelcontextprotocol-sdk across various files.
- Updated package.json files to reflect the new package versioning and structure.
- Enhanced import paths in multiple components and utilities to ensure compatibility with the new SDK structure.
- Added new dependencies and updated existing ones in the pnpm-lock.yaml file for consistency.
