### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sync-inspector.yml
+++ b/.github/workflows/sync-inspector.yml
@@ -1,5 +1,8 @@
 name: Sync inspector subfolder to mcp-use/inspector
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/mcp-use/mcp-use/security/code-scanning/4](https://github.com/mcp-use/mcp-use/security/code-scanning/4)

The best fix is to add a `permissions` block at the workflow level (root), before `jobs:`, specifying only the minimal privileges needed for the workflow. By default, for workflows that clone/push using a personal access token (in this case, `INSPECTOR_MIRROR_TOKEN`), only `contents: read` is typically required for `GITHUB_TOKEN` usage, as all actual write operations are performed using the PAT. Thus, add:

```yaml
permissions:
  contents: read
```

directly under the workflow name and before `on:` or `jobs:`. If in future you want certain jobs to have more (such as `issues: write` or `pull-requests: write`), you can scope those more specifically, but for this workflow, minimal is best.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
