### PR TITLE
chore: update package versions and dependencies

### DIFF
--- a/libraries/typescript/packages/cli/CHANGELOG.md
+++ b/libraries/typescript/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @mcp-use/cli
 
+## 2.5.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @mcp-use/inspector@0.12.2
+  - mcp-use@1.10.2
+
 ## 2.5.1
 
 ### Patch Changes

--- a/libraries/typescript/packages/cli/package.json
+++ b/libraries/typescript/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-use/cli",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "The mcp-use CLI is a tool for building and deploying MCP servers with support for ChatGPT Apps, Code Mode, OAuth, Notifications, Sampling, Observability and more.",
   "author": "mcp-use, Inc.",
   "license": "MIT",

--- a/libraries/typescript/packages/inspector/CHANGELOG.md
+++ b/libraries/typescript/packages/inspector/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @mcp-use/inspector
 
+## 0.12.2
+
+### Patch Changes
+
+- fix: update zod error
+- Updated dependencies
+  - mcp-use@1.10.2
+
 ## 0.12.1
 
 ### Patch Changes

--- a/libraries/typescript/packages/inspector/package.json
+++ b/libraries/typescript/packages/inspector/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-use/inspector",
   "type": "module",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "MCP Inspector - A tool for inspecting and debugging MCP servers",
   "author": "",
   "license": "MIT",
@@ -72,7 +72,7 @@
     "@langchain/google-genai": "^2.0.0",
     "@langchain/openai": "^1.1.3",
     "@mcp-ui/client": "^5.16.0",
-    "@mcp-use/modelcontextprotocol-sdk": "1.24.3-mcp-use.2",
+    "@mcp-use/modelcontextprotocol-sdk": "1.24.3-mcp-use.3",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/libraries/typescript/packages/mcp-use/CHANGELOG.md
+++ b/libraries/typescript/packages/mcp-use/CHANGELOG.md
@@ -1,5 +1,14 @@
 # mcp-use
 
+## 1.10.2
+
+### Patch Changes
+
+- fix: update zod error
+- Updated dependencies
+  - @mcp-use/inspector@0.12.2
+  - @mcp-use/cli@2.5.2
+
 ## 1.10.1
 
 ### Patch Changes

--- a/libraries/typescript/packages/mcp-use/package.json
+++ b/libraries/typescript/packages/mcp-use/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-use",
   "type": "module",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "packageManager": "pnpm@10.6.1",
   "description": "Opinionated MCP Framework for TypeScript (@modelcontextprotocol/sdk compatible) - Build MCP Agents, Clients and Servers with support for ChatGPT Apps, Code Mode, OAuth, Notifications, Sampling, Observability and more.",
   "author": "mcp-use, Inc.",
@@ -162,7 +162,7 @@
     "@mcp-ui/server": "^5.15.0",
     "@mcp-use/cli": "workspace:*",
     "@mcp-use/inspector": "workspace:*",
-    "@mcp-use/modelcontextprotocol-sdk": "1.24.3-mcp-use.2",
+    "@mcp-use/modelcontextprotocol-sdk": "1.24.3-mcp-use.3",
     "express": "^5.2.0",
     "hono": "^4.10.7",
     "jose": "^6.1.2",

--- a/libraries/typescript/packages/mcp-use/tests/deno/deno.json
+++ b/libraries/typescript/packages/mcp-use/tests/deno/deno.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "@modelcontextprotocol/sdk": "npm:@mcp-use/modelcontextprotocol-sdk@^1.24.3-mcp-use.2",
+    "@modelcontextprotocol/sdk": "npm:@mcp-use/modelcontextprotocol-sdk@^1.24.3-mcp-use.3",
     "mcp-use/server": "npm:mcp-use/server"
   },
   "compilerOptions": {

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -379,8 +379,8 @@ importers:
         specifier: ^5.16.0
         version: 5.17.1(@cfworker/json-schema@4.1.1)(@preact/signals-core@1.12.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(zod@4.1.13)
       '@mcp-use/modelcontextprotocol-sdk':
-        specifier: 1.24.3-mcp-use.2
-        version: 1.24.3-mcp-use.2(@cfworker/json-schema@4.1.1)(zod@4.1.13)
+        specifier: 1.24.3-mcp-use.3
+        version: 1.24.3-mcp-use.3(@cfworker/json-schema@4.1.1)(zod@4.1.13)
       '@radix-ui/react-alert-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -557,8 +557,8 @@ importers:
         specifier: workspace:*
         version: link:../inspector
       '@mcp-use/modelcontextprotocol-sdk':
-        specifier: 1.24.3-mcp-use.2
-        version: 1.24.3-mcp-use.2(@cfworker/json-schema@4.1.1)(zod@4.1.13)
+        specifier: 1.24.3-mcp-use.3
+        version: 1.24.3-mcp-use.3(@cfworker/json-schema@4.1.1)(zod@4.1.13)
       express:
         specifier: ^5.2.0
         version: 5.2.1
@@ -1696,8 +1696,8 @@ packages:
   '@mcp-ui/server@5.16.1':
     resolution: {integrity: sha512-/kK6pTFunWGyyS8j4Kt61o8oSsdqbgQTimYXMkF/2sFp3XwIFEBzjrBP4BzzLwBYzu7YCDHYff60AC6uUZHqQw==}
 
-  '@mcp-use/modelcontextprotocol-sdk@1.24.3-mcp-use.2':
-    resolution: {integrity: sha512-jRZbUeDWW7cy01qaLOArc/MSxs6U+RBxExpgyau6f8YqrQnD5jHmWK8OEhxahab25aOk62oLwIWjqRNhZ2NdSw==}
+  '@mcp-use/modelcontextprotocol-sdk@1.24.3-mcp-use.3':
+    resolution: {integrity: sha512-ihiuSp/jsfEFGXTNMtwKxBoQErPTqecmkEf74dNjVW3n8tI3ohTavQdluasIKMlm0jUt3a6fI7u49pGL1bIBYA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -8190,7 +8190,7 @@ snapshots:
       - supports-color
       - zod
 
-  '@mcp-use/modelcontextprotocol-sdk@1.24.3-mcp-use.2(@cfworker/json-schema@4.1.1)(zod@4.1.13)':
+  '@mcp-use/modelcontextprotocol-sdk@1.24.3-mcp-use.3(@cfworker/json-schema@4.1.1)(zod@4.1.13)':
     dependencies:
       ajv: 8.17.1
       ajv-formats: 3.0.1(ajv@8.17.1)


### PR DESCRIPTION
- Bumped version of @mcp-use/cli to 2.5.2 and @mcp-use/inspector to 0.12.2.
- Updated @mcp-use/modelcontextprotocol-sdk from 1.24.3-mcp-use.2 to 1.24.3-mcp-use.3 across multiple package.json files and pnpm-lock.yaml.
- Enhanced changelogs for @mcp-use/cli and @mcp-use/inspector to reflect dependency updates and fixes.
