### PR TITLE
feat(inspector): enhance Vite configuration and add path parsing utility

### DIFF
--- a/libraries/typescript/packages/inspector/src/client/components/OpenAIComponentRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/OpenAIComponentRenderer.tsx
@@ -154,7 +154,7 @@ function OpenAIComponentRendererBase({
 
         if (computedUseDevMode && widgetName && serverBaseUrl) {
           const devServerBaseUrl = new URL(serverBaseUrl).origin;
-          const devWidgetUrl = `${devServerBaseUrl}/mcp-use/widgets/${widgetName}?${urlParams.toString()}`;
+          const devWidgetUrl = `${devServerBaseUrl}/mcp-use/widgets/${widgetName}`;
           widgetDataToStore.devWidgetUrl = devWidgetUrl;
           widgetDataToStore.devServerBaseUrl = devServerBaseUrl;
         }
@@ -182,11 +182,11 @@ function OpenAIComponentRendererBase({
 
         if (computedUseDevMode && widgetName && serverBaseUrl) {
           // Use proxy URL for dev widgets (same-origin, supports HMR)
-          const proxyUrl = `/inspector/api/dev-widget/${toolId}?${urlParams.toString()}`;
+          const proxyUrl = `/inspector/api/dev-widget/${toolId}`;
           setWidgetUrl(proxyUrl);
           setIsSameOrigin(true); // Proxy makes it same-origin
         } else {
-          const prodUrl = `/inspector/api/resources/widget/${toolId}?${urlParams.toString()}`;
+          const prodUrl = `/inspector/api/resources/widget/${toolId}`;
           setWidgetUrl(prodUrl);
           // Relative URLs are always same-origin
           setIsSameOrigin(true);

--- a/libraries/typescript/packages/inspector/src/client/stubs/fs-promises.js
+++ b/libraries/typescript/packages/inspector/src/client/stubs/fs-promises.js
@@ -1,0 +1,63 @@
+// Browser stub for fs/promises module
+// This stub is used when building for the browser to avoid bundling Node.js-specific code
+
+export async function readFile() {
+  throw new Error(
+    "fs.promises.readFile is not available in browser environment"
+  );
+}
+
+export async function writeFile() {
+  throw new Error(
+    "fs.promises.writeFile is not available in browser environment"
+  );
+}
+
+export async function mkdir() {
+  throw new Error("fs.promises.mkdir is not available in browser environment");
+}
+
+export async function readdir() {
+  throw new Error(
+    "fs.promises.readdir is not available in browser environment"
+  );
+}
+
+export async function stat() {
+  throw new Error("fs.promises.stat is not available in browser environment");
+}
+
+export async function unlink() {
+  throw new Error("fs.promises.unlink is not available in browser environment");
+}
+
+export async function rmdir() {
+  throw new Error("fs.promises.rmdir is not available in browser environment");
+}
+
+export async function access() {
+  throw new Error("fs.promises.access is not available in browser environment");
+}
+
+export async function copyFile() {
+  throw new Error(
+    "fs.promises.copyFile is not available in browser environment"
+  );
+}
+
+export async function rename() {
+  throw new Error("fs.promises.rename is not available in browser environment");
+}
+
+export default {
+  readFile,
+  writeFile,
+  mkdir,
+  readdir,
+  stat,
+  unlink,
+  rmdir,
+  access,
+  copyFile,
+  rename,
+};

--- a/libraries/typescript/packages/inspector/src/client/stubs/fs.js
+++ b/libraries/typescript/packages/inspector/src/client/stubs/fs.js
@@ -1,0 +1,55 @@
+// Browser stub for fs module
+// This stub is used when building for the browser to avoid bundling Node.js-specific code
+
+export function readFileSync() {
+  throw new Error("fs.readFileSync is not available in browser environment");
+}
+
+export function writeFileSync() {
+  throw new Error("fs.writeFileSync is not available in browser environment");
+}
+
+export function existsSync() {
+  return false;
+}
+
+export function readFile() {
+  throw new Error("fs.readFile is not available in browser environment");
+}
+
+export function writeFile() {
+  throw new Error("fs.writeFile is not available in browser environment");
+}
+
+export function mkdir() {
+  throw new Error("fs.mkdir is not available in browser environment");
+}
+
+export function readdir() {
+  throw new Error("fs.readdir is not available in browser environment");
+}
+
+export function stat() {
+  throw new Error("fs.stat is not available in browser environment");
+}
+
+export function unlink() {
+  throw new Error("fs.unlink is not available in browser environment");
+}
+
+export function rmdir() {
+  throw new Error("fs.rmdir is not available in browser environment");
+}
+
+export default {
+  readFileSync,
+  writeFileSync,
+  existsSync,
+  readFile,
+  writeFile,
+  mkdir,
+  readdir,
+  stat,
+  unlink,
+  rmdir,
+};

--- a/libraries/typescript/packages/inspector/src/client/stubs/path.js
+++ b/libraries/typescript/packages/inspector/src/client/stubs/path.js
@@ -44,6 +44,23 @@ export function isAbsolute(filepath) {
   return filepath.startsWith("/");
 }
 
+export function parse(filepath) {
+  // Parse a path string into an object with root, dir, base, ext, and name
+  const root = filepath.startsWith("/") ? "/" : "";
+  const dir = dirname(filepath);
+  const base = basename(filepath);
+  const ext = extname(filepath);
+  const name = ext ? base.slice(0, -ext.length) : base;
+
+  return {
+    root,
+    dir,
+    base,
+    ext,
+    name,
+  };
+}
+
 export const sep = "/";
 export const delimiter = ":";
 
@@ -55,6 +72,7 @@ export default {
   extname,
   normalize,
   isAbsolute,
+  parse,
   sep,
   delimiter,
 };

--- a/libraries/typescript/packages/inspector/vite.config.ts
+++ b/libraries/typescript/packages/inspector/vite.config.ts
@@ -66,6 +66,17 @@ export default defineConfig({
       util: path.resolve(__dirname, "./src/client/stubs/util.js"),
       path: path.resolve(__dirname, "./src/client/stubs/path.js"),
       process: path.resolve(__dirname, "./src/client/stubs/process.js"),
+      // More specific aliases must come first
+      "node:fs/promises": path.resolve(
+        __dirname,
+        "./src/client/stubs/fs-promises.js"
+      ),
+      "fs/promises": path.resolve(
+        __dirname,
+        "./src/client/stubs/fs-promises.js"
+      ),
+      "node:fs": path.resolve(__dirname, "./src/client/stubs/fs.js"),
+      fs: path.resolve(__dirname, "./src/client/stubs/fs.js"),
       "node:async_hooks": path.resolve(
         __dirname,
         "./src/client/stubs/async_hooks.js"
@@ -84,12 +95,12 @@ export default defineConfig({
     global: "globalThis",
   },
   optimizeDeps: {
-    include: [
-      "mcp-use/react",
-      "react-syntax-highlighter",
-      "refractor/lib/core",
-    ],
-    exclude: ["posthog-node"], // Exclude Node.js-only packages
+    include: ["mcp-use/react", "react-syntax-highlighter"],
+    exclude: [
+      "posthog-node",
+      "tar", // Node.js file system package
+      "path-scurry", // Node.js path utilities
+    ], // Exclude Node.js-only packages
   },
   ssr: {
     noExternal: ["react-syntax-highlighter", "refractor"],


### PR DESCRIPTION
- Updated Vite configuration to include more specific aliases for Node.js modules, improving compatibility with browser builds.
- Modified widget URL construction in OpenAIComponentRenderer to remove unnecessary query parameters.
- Added a new `parse` function to the path stub, enabling path string parsing into an object with root, dir, base, ext, and name properties.
- Excluded additional Node.js-only packages from the build process to streamline dependencies.
