### PR TITLE
Potential fix for code scanning alert no. 46: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/discord-release-notify.yml
+++ b/.github/workflows/discord-release-notify.yml
@@ -2,6 +2,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   github-releases-to-discord:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/mcp-use/mcp-use/security/code-scanning/46](https://github.com/mcp-use/mcp-use/security/code-scanning/46)

To remedy the detected issue, explicitly set the `permissions` key in the workflow to ensure the `GITHUB_TOKEN` has only the minimal permissions necessary. According to GitHub documentation and CodeQL suggestions for this error, specifying `permissions: contents: read` at the root level (top of the workflow file, under the workflow name and above `jobs:`) ensures jobs will not have read-write or unnecessary access. This must be added as a new block after the trigger (`on:`) section and before `jobs:` in the `.github/workflows/discord-release-notify.yml` file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
