### PR TITLE
Potential fix for code scanning alert no. 23: Incomplete URL substring sanitization

### DIFF
--- a/libraries/typescript/packages/cli/src/utils/git.ts
+++ b/libraries/typescript/packages/cli/src/utils/git.ts
@@ -138,5 +138,18 @@ export async function getGitInfo(
  * Check if remote is a GitHub URL
  */
 export function isGitHubUrl(url: string): boolean {
-  return url.includes("github.com");
+  try {
+    // Handle HTTP(S) URLs
+    const parsedUrl = new URL(url);
+    return parsedUrl.hostname === "github.com" || parsedUrl.hostname === "www.github.com";
+  } catch {
+    // Handle SSH/shortened git URLs: git@github.com:user/repo.git
+    // Extract the host before the ":" or "/" (if git@host:repo or git@host/repo)
+    const sshMatch = url.match(/^git@([^:/]+)[:/]/);
+    if (sshMatch) {
+      const host = sshMatch[1];
+      return host === "github.com" || host === "www.github.com";
+    }
+  }
+  return false;
 }


### PR DESCRIPTION
Potential fix for [https://github.com/mcp-use/mcp-use/security/code-scanning/23](https://github.com/mcp-use/mcp-use/security/code-scanning/23)

The best way to fix this issue is to properly parse the input URL, extract its hostname, and then perform a strict check that the hostname exactly matches `'github.com'` or one of a well-defined list of GitHub-related hostnames (such as `'www.github.com'` or perhaps subdomains, if legitimate). This avoids the dangers of substring matching. In Node.js/TypeScript, this can be achieved by using the built-in `URL` class which provides a straightforward way to extract the hostname from the URL. If the input might be a scp-like SSH URL (e.g., `git@github.com:user/repo.git`), we may want to handle that format separately since it is not valid for the `URL` constructor — but, based on the information given, we will focus the fix on proper URLs first, as well as SSH URLs in a limited fashion if necessary (see below).

To implement the fix:
- Edit the `isGitHubUrl` function in the file shown.
- Replace the substring match with host-based checks using the `URL` constructor for HTTP(S) URLs.
- Optionally, handle scp-style SSH URLs by regex extraction of the host part.
- Do not change the API or existing imports.

No new dependencies are needed, since the `URL` class is standard in Node.js.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
