### PR TITLE
refactor(docs): streamline API reference structure by removing deprec…

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -236,14 +236,6 @@
             "icon": "terminal",
             "groups": [
               {
-                "group": "Adapters",
-                "icon": "plug-2",
-                "pages": [
-                  "python/api-reference/mcp_use_adapters_base",
-                  "python/api-reference/mcp_use_adapters_langchain_adapter"
-                ]
-              },
-              {
                 "group": "Agents",
                 "icon": "code",
                 "pages": [
@@ -253,6 +245,7 @@
                     "pages": [
                       "python/api-reference/mcp_use_agents_adapters_anthropic",
                       "python/api-reference/mcp_use_agents_adapters_base",
+                      "python/api-reference/mcp_use_agents_adapters_google",
                       "python/api-reference/mcp_use_agents_adapters_langchain_adapter",
                       "python/api-reference/mcp_use_agents_adapters_openai"
                     ]
@@ -293,15 +286,6 @@
                     ]
                   },
                   "python/api-reference/mcp_use_agents_remote"
-                ]
-              },
-              {
-                "group": "Auth",
-                "icon": "key",
-                "pages": [
-                  "python/api-reference/mcp_use_auth_bearer",
-                  "python/api-reference/mcp_use_auth_oauth",
-                  "python/api-reference/mcp_use_auth_oauth_callback"
                 ]
               },
               {
@@ -359,26 +343,11 @@
                 ]
               },
               {
-                "group": "Connectors",
-                "icon": "cable",
-                "pages": [
-                  "python/api-reference/mcp_use_connectors_base",
-                  "python/api-reference/mcp_use_connectors_http",
-                  "python/api-reference/mcp_use_connectors_sandbox",
-                  "python/api-reference/mcp_use_connectors_stdio",
-                  "python/api-reference/mcp_use_connectors_utils",
-                  "python/api-reference/mcp_use_connectors_websocket"
-                ]
-              },
-              {
                 "group": "Core",
                 "icon": "package",
                 "pages": [
                   "python/api-reference/mcp_use_client",
-                  "python/api-reference/mcp_use_config",
-                  "python/api-reference/mcp_use_exceptions",
                   "python/api-reference/mcp_use_logging",
-                  "python/api-reference/mcp_use_session",
                   "python/api-reference/mcp_use_utils"
                 ]
               },
@@ -387,35 +356,6 @@
                 "icon": "triangle-alert",
                 "pages": [
                   "python/api-reference/mcp_use_errors_error_formatting"
-                ]
-              },
-              {
-                "group": "Managers",
-                "icon": "users",
-                "pages": [
-                  "python/api-reference/mcp_use_managers_base",
-                  "python/api-reference/mcp_use_managers_server_manager",
-                  {
-                    "group": "Tools",
-                    "icon": "tool",
-                    "pages": [
-                      "python/api-reference/mcp_use_managers_tools_base_tool",
-                      "python/api-reference/mcp_use_managers_tools_connect_server",
-                      "python/api-reference/mcp_use_managers_tools_disconnect_server",
-                      "python/api-reference/mcp_use_managers_tools_get_active_server",
-                      "python/api-reference/mcp_use_managers_tools_list_servers_tool",
-                      "python/api-reference/mcp_use_managers_tools_search_tools"
-                    ]
-                  }
-                ]
-              },
-              {
-                "group": "Middleware",
-                "icon": "layers",
-                "pages": [
-                  "python/api-reference/mcp_use_middleware_logging",
-                  "python/api-reference/mcp_use_middleware_metrics",
-                  "python/api-reference/mcp_use_middleware_middleware"
                 ]
               },
               {
@@ -450,24 +390,6 @@
                       "python/api-reference/mcp_use_server_utils_utils"
                     ]
                   }
-                ]
-              },
-              {
-                "group": "Task Managers",
-                "icon": "command",
-                "pages": [
-                  "python/api-reference/mcp_use_task_managers_base",
-                  "python/api-reference/mcp_use_task_managers_sse",
-                  "python/api-reference/mcp_use_task_managers_stdio",
-                  "python/api-reference/mcp_use_task_managers_streamable_http",
-                  "python/api-reference/mcp_use_task_managers_websocket"
-                ]
-              },
-              {
-                "group": "Types",
-                "icon": "type",
-                "pages": [
-                  "python/api-reference/mcp_use_types_sandbox"
                 ]
               }
             ]


### PR DESCRIPTION

- Removed outdated groups such as "Adapters," "Auth," "Connectors," "Managers," "Middleware," "Task Managers," and "Types" from the documentation structure.
- Added a new page for Google adapters to the "Agents" group for improved resource accessibility.
- Updated the overall organization of the API reference to enhance clarity and navigation for users.
