### PR TITLE
Change debug flag to run_debug in server example

### DIFF
--- a/docs/python/server/index.mdx
+++ b/docs/python/server/index.mdx
@@ -179,7 +179,7 @@ server.run(transport="streamable-http", host="0.0.0.0", port=8000)
 Enable debug mode for development features:
 
 ```python
-server = MCPServer(name="My Server", run_debug=True)
+server = MCPServer(name="My Server", debug=True)
 ```
 
 Debug mode provides:

--- a/docs/python/server/prompts.mdx
+++ b/docs/python/server/prompts.mdx
@@ -195,7 +195,7 @@ async def daily_prompt(context: Context) -> str:
     return f"{greeting}! What would you like to work on?"
 
 if __name__ == "__main__":
-    server.run(transport="streamable-http", debug=True)
+    server.run(transport="streamable-http", run_debug=True)
 ```
 
 ## Prompts vs Tools vs Resources

--- a/docs/python/server/resources.mdx
+++ b/docs/python/server/resources.mdx
@@ -205,7 +205,7 @@ def current_time() -> str:
     return datetime.now().isoformat()
 
 if __name__ == "__main__":
-    server.run(transport="streamable-http", debug=True)
+    server.run(transport="streamable-http", run_debug=True)
 ```
 
 ## Resources vs Tools

--- a/docs/python/server/router.mdx
+++ b/docs/python/server/router.mdx
@@ -280,7 +280,7 @@ server.include_router(db_router, prefix="db")
 server.include_router(files_router, prefix="fs")
 
 if __name__ == "__main__":
-    server.run(transport="streamable-http", debug=True)
+    server.run(transport="streamable-http", run_debug=True)
 ```
 
 Output:

--- a/docs/python/server/running.mdx
+++ b/docs/python/server/running.mdx
@@ -41,7 +41,7 @@ server.run(
     host="127.0.0.1",
     port=8000,
     reload=False,
-    debug=False
+    run_debug=False
 )
 ```
 
@@ -56,7 +56,7 @@ server = MCPServer(name="My Server", debug=True)
 # - /openmcp.json endpoint
 # - /docs endpoint
 # - Enhanced logging
-server.run(transport="streamable-http", debug=True)
+server.run(transport="streamable-http", run_debug=True)
 ```
 
 ## Auto-reload
@@ -75,7 +75,7 @@ server.run(
     host="0.0.0.0",
     port=8000,
     reload=False,
-    debug=False
+    run_debug=False
 )
 ```
 

--- a/docs/python/server/tools.mdx
+++ b/docs/python/server/tools.mdx
@@ -183,5 +183,5 @@ async def batch_calculate(
     return results
 
 if __name__ == "__main__":
-    server.run(transport="streamable-http", debug=True)
+    server.run(transport="streamable-http", run_debug=True)
 ```


### PR DESCRIPTION
# Pull Request Description

## Changes

Fixes the python server example so that the code will run properly. `debug` is not the correct name of the parameter, `run_debug` is. 

## Implementation Details

1. Simple string change

## Example Usage (Before)

n/a

## Documentation Updates

* This is a documentation update

## Testing

n/a

## Backwards Compatibility

n/a

## Related Issues

n/a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Python server documentation and examples to reflect the updated debugging parameter name used in server configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->