### PR TITLE
Docs changelog 404 fix

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -657,6 +657,10 @@
     {
       "source": "/typescript/getting-started",
       "destination": "/typescript/getting-started/quickstart"
+    },
+    {
+      "source": "/changelog",
+      "destination": "/python/changelog/changelog"
     }
   ],
   "logo": {


### PR DESCRIPTION
# Pull Request Description

## Changes

This PR introduces a redirect for the `/changelog` route to resolve a 404 error on the documentation site.

## Implementation Details

1.  Added a new redirect rule in `docs/docs.json`.
2.  The redirect maps `/changelog` to `/python/changelog/changelog`.
3.  This aligns with Mintlify's routing configuration for redirects.

## Example Usage (Before)

```
# Navigating to https://docs.mcp-use.com/changelog resulted in a 404 error.
```

## Example Usage (After)

```
# Navigating to https://docs.mcp-use.com/changelog now redirects to https://docs.mcp-use.com/python/changelog/changelog.
```

## Documentation Updates

*   `docs/docs.json`: Added a new redirect entry to resolve the missing changelog page.

## Testing

-   Manually verified the redirect configuration in `docs.json`.
-   Confirmed that the new configuration follows existing patterns and does not introduce linter errors.
-   The change directly addresses the 404 by providing a valid destination for the `/changelog` path.

## Backwards Compatibility

These changes are fully backwards compatible. They fix a previously broken link (404) by adding a redirect, improving user experience without altering existing functionality.

## Related Issues

Closes #MCP-735

---
Linear Issue: [MCP-735](https://linear.app/mcp-use/issue/MCP-735/fix-docs-changelog-page-404)

<a href="https://cursor.com/background-agent?bcId=bc-d7b648ee-d26a-4847-8f39-9f0abb8a85a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d7b648ee-d26a-4847-8f39-9f0abb8a85a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

