### PR TITLE
fix: 🐛 Fix the return type of the stream_events function

### DIFF
--- a/libraries/python/mcp_use/agents/mcpagent.py
+++ b/libraries/python/mcp_use/agents/mcpagent.py
@@ -1040,7 +1040,6 @@ class MCPAgent:
         start_time = time.time()
         success = False
         chunk_count = 0
-        total_response_length = 0
         human_query = self._ensure_human_message(query)
 
         try:
@@ -1052,8 +1051,6 @@ class MCPAgent:
             ):
                 log_agent_stream(chunk, pretty_print=self.pretty_print)
                 chunk_count += 1
-                if isinstance(chunk, str):
-                    total_response_length += len(chunk)
                 yield chunk
             success = True
         finally:
@@ -1068,7 +1065,7 @@ class MCPAgent:
                 max_steps_used=max_steps,
                 manage_connector=manage_connector,
                 external_history_used=external_history is not None,
-                response=f"[STREAMED RESPONSE - {total_response_length} chars]",
+                response="[STREAMED RESPONSE]",
                 error_type=None if success else "streaming_error",
             )
 


### PR DESCRIPTION
# Pull Request Description

## Changes

Fix the return type of the stream_events function

## Implementation Details

It merely corrects the return type of the function.

```python
async for chunk in agent.stream_events("hello"):
        print(chunk)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streaming now emits structured event objects instead of plain text, enabling richer client-side handling.
  * Documentation and examples updated to show the new event format.

* **Bug Fixes / Behavior Changes**
  * Final streamed output simplified to a standard placeholder display.
  * Logs/telemetry updated to reflect the new streamed representation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->