### PR TITLE
fix: directory separator on windows platform causing widgets build fail

### DIFF
--- a/libraries/typescript/.changeset/fix-windows-path-separator.md
+++ b/libraries/typescript/.changeset/fix-windows-path-separator.md
@@ -1,0 +1,6 @@
+---
+"@mcp-use/cli": patch
+---
+
+fix: directory separator on Windows platform causing widgets build fail. Normalize Windows backslash path separators to forward slashes when building widget entry paths to ensure cross-platform compatibility.
+

--- a/libraries/typescript/packages/cli/src/index.ts
+++ b/libraries/typescript/packages/cli/src/index.ts
@@ -327,8 +327,7 @@ async function buildWidgets(
 
   for (const entry of entries) {
     const widgetName = entry.name;
-    const entryPath = entry.path
-      .replace(/\\/g, "/");
+    const entryPath = entry.path.replace(/\\/g, "/");
 
     console.log(chalk.gray(`  - Building ${widgetName}...`));
 


### PR DESCRIPTION
# Pull Request Description

## Changes

Fix the path written into entry.tsx files on windows platform.

## Implementation Details

Replace backslashes (\) with slashes (/)
```javascript
const entryPath = entry.path
  .replace(/\\/g, "/");
```

## Testing

Example project builds without error
```bash
npx create-mcp-use-app my-mcp-server
cd my-mcp-server
npm install
npm run build

> my-mcp-server@1.0.0 build
> mcp-use build

mcp-use v2.8.0
Building 2 widget(s)...
  - Building display-weather...
vite v7.3.0 building client environment for production...
✓ 349 modules transformed.
../../dist/resources/widgets/display-weather/index.html                   0.47 kB │ gzip:   0.29 kB
../../dist/resources/widgets/display-weather/assets/index-BxvsZANx.css  109.19 kB │ gzip:  18.35 kB
../../dist/resources/widgets/display-weather/assets/module-I01BGOgk.js  170.19 kB │ gzip:  56.27 kB
../../dist/resources/widgets/display-weather/assets/index-uWXJWB0V.js   186.89 kB │ gzip:  61.51 kB
../../dist/resources/widgets/display-weather/assets/index-DvN1tn-R.js   770.86 kB │ gzip: 225.42 kB

(!) Some chunks are larger than 500 kB after minification. Consider:
- Using dynamic import() to code-split the application
- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
✓ built in 3.46s
    ✓ Built display-weather
  - Building kanban-board...
vite v7.3.0 building client environment for production...
✓ 29 modules transformed.
../../dist/resources/widgets/kanban-board/index.html                   0.47 kB │ gzip:   0.29 kB
../../dist/resources/widgets/kanban-board/assets/index--LCcLYdF.css   22.42 kB │ gzip:   4.67 kB
../../dist/resources/widgets/kanban-board/assets/index-DZGzS75t.js   398.89 kB │ gzip: 118.71 kB
✓ built in 1.19s
    ✓ Built kanban-board
Building TypeScript...
✓ TypeScript build complete!
(node:16684) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
(Use `node --trace-deprecation ...` to show where the warning was created)
✓ Build manifest created

✓ Build complete!
  2 widget(s) built
```

## Related Issues

Backslashes in Windows path form escape characters in the generated entry.tsx files, causing the widgets build to fail.
```bash
npx create-mcp-use-app my-mcp-server
cd my-mcp-server
npm install
npm run build

> my-mcp-server@1.0.0 build
> mcp-use build

mcp-use v2.8.0
Building 2 widget(s)...
  - Building display-weather...
vite v7.3.0 building client environment for production...
✓ 2 modules transformed.
✗ Build failed in 46ms
esourcesdisplay-weather.tsx" from "[Projects]/my-mcp-server/.mcp-use/display-weather/entry.tsx".e-app
This is most likely unintended because it can break your application at runtime.
If you do want to externalize this module explicitly add it to
`build.rollupOptions.external`
    at viteLog (file:///[Projects]/my-mcp-server/node_modules/vite/dist/node/chunks/config.js:33634:57)
    at file:///[Projects]/my-mcp-server/node_modules/vite/dist/node/chunks/config.js:33668:73
    at onwarn (file:///[Projects]/my-mcp-server/node_modules/@vitejs/plugin-react/dist/index.js:76:7)
    at file:///[Projects]/my-mcp-server/node_modules/vite/dist/node/chunks/config.js:33668:28
    at onRollupLog (file:///[Projects]/my-mcp-server/node_modules/vite/dist/node/chunks/config.js:33663:63)
    at onLog (file:///[Projects]/my-mcp-server/node_modules/vite/dist/node/chunks/config.js:33466:4)
    at file:///[Projects]/my-mcp-server/node_modules/rollup/dist/es/shared/node-entry.js:21081:32
    at Object.logger [as onLog] (file:///[Projects]/my-mcp-server/node_modules/rollup/dist/es/shared/node-entry.js:22968:9)
    at ModuleLoader.handleInvalidResolvedId (file:///[Projects]/my-mcp-server/node_modules/rollup/dist/es/shared/node-entry.js:21712:26)
    at file:///[Projects]/my-mcp-server/node_modules/rollup/dist/es/shared/node-entry.js:21670:26 {
  watchFiles: [
    '[Projects]/my-mcp-server/.mcp-use/display-weather/index.html',
    '[Projects]/my-mcp-server/.mcp-use/display-weather/entry.tsx'
  ]
}
  - Building kanban-board...
transforming (4) ..\..\node_modules\react\cjs\react.development.jsvite v7.3.0 building client environment for production...
✓ 2 modules transformed.
✗ Build failed in 9ms
esourceskanban-board.tsx" from "[Projects]/my-mcp-server/.mcp-use/kanban-board/entry.tsx".-use-app
This is most likely unintended because it can break your application at runtime.
If you do want to externalize this module explicitly add it to
`build.rollupOptions.external`
    at viteLog (file:///[Projects]/my-mcp-server/node_modules/vite/dist/node/chunks/config.js:33634:57)
    at file:///[Projects]/my-mcp-server/node_modules/vite/dist/node/chunks/config.js:33668:73
    at onwarn (file:///[Projects]/my-mcp-server/node_modules/@vitejs/plugin-react/dist/index.js:76:7)
    at file:///[Projects]/my-mcp-server/node_modules/vite/dist/node/chunks/config.js:33668:28
    at onRollupLog (file:///[Projects]/my-mcp-server/node_modules/vite/dist/node/chunks/config.js:33663:63)
    at onLog (file:///[Projects]/my-mcp-server/node_modules/vite/dist/node/chunks/config.js:33466:4)
    at file:///[Projects]/my-mcp-server/node_modules/rollup/dist/es/shared/node-entry.js:21081:32
    at Object.logger [as onLog] (file:///[Projects]/my-mcp-server/node_modules/rollup/dist/es/shared/node-entry.js:22968:9)
    at ModuleLoader.handleInvalidResolvedId (file:///[Projects]/my-mcp-server/node_modules/rollup/dist/es/shared/node-entry.js:21712:26)
    at file:///[Projects]/my-mcp-server/node_modules/rollup/dist/es/shared/node-entry.js:21670:26 {
  watchFiles: [
    '[Projects]/my-mcp-server/.mcp-use/kanban-board/index.html',
    '[Projects]/my-mcp-server/.mcp-use/kanban-board/entry.tsx'
  ]
}
Building TypeScript...
✓ TypeScript build complete!
(node:8204) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
(Use `node --trace-deprecation ...` to show where the warning was created)
✓ Build manifest created

✓ Build complete!
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed critical path normalization issue in widget imports to ensure cross-platform consistency. Windows directory backslashes are now automatically converted to forward slashes during the widget build and import process, effectively preventing import failures on Windows systems while maintaining full compatibility with all other operating systems and development environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->