### PR TITLE
feat(create-mcp-use-app): enhance template selection logic and improve default handling

### DIFF
--- a/libraries/typescript/.changeset/respect-template-flag-interactive-mode.md
+++ b/libraries/typescript/.changeset/respect-template-flag-interactive-mode.md
@@ -1,0 +1,6 @@
+---
+"create-mcp-use-app": patch
+---
+
+fix: respect --template flag in interactive mode. Previously, when no project name was provided as a positional argument, the CLI would always prompt for template selection even if --template was explicitly provided via the command line flag. The tool now correctly uses the --template value when provided, only prompting for template selection when the flag is not specified.
+

--- a/libraries/typescript/packages/create-mcp-use-app/src/index.tsx
+++ b/libraries/typescript/packages/create-mcp-use-app/src/index.tsx
@@ -2,7 +2,7 @@
 
 import chalk from "chalk";
 import { Command } from "commander";
-import { render } from "ink";
+import { Box, render, Text } from "ink";
 import SelectInput from "ink-select-input";
 import TextInput from "ink-text-input";
 import { execSync, spawn, spawnSync } from "node:child_process";
@@ -16,12 +16,11 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { tmpdir } from "node:os";
 import ora from "ora";
 import React, { useState } from "react";
-import { Box, Text } from "ink";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -366,8 +365,7 @@ program
   .argument("[project-name]", "Name of the MCP server project")
   .option(
     "-t, --template <template>",
-    "Template to use (starter, mcp-ui, apps-sdk) or GitHub repo URL (owner/repo or https://github.com/owner/repo)",
-    "starter"
+    "Template to use (starter, mcp-ui, apps-sdk) or GitHub repo URL (owner/repo or https://github.com/owner/repo)"
   )
   .option("--list-templates", "List all available templates")
   .option("--install", "Install dependencies after creating project")
@@ -381,7 +379,7 @@ program
     async (
       projectName: string | undefined,
       options: {
-        template: string;
+        template?: string;
         listTemplates?: boolean;
         install?: boolean;
         git: boolean;
@@ -421,8 +419,15 @@ program
           projectName = await promptForProjectName();
           console.log("");
 
-          // Prompt for template selection in interactive mode
-          selectedTemplate = await promptForTemplate();
+          // Only prompt for template if one wasn't provided via --template flag
+          if (!options.template) {
+            selectedTemplate = await promptForTemplate();
+          }
+        }
+
+        // Set default template if still not selected
+        if (!selectedTemplate) {
+          selectedTemplate = "starter";
         }
 
         // Validate project name

--- a/libraries/typescript/packages/inspector/CHANGELOG.md
+++ b/libraries/typescript/packages/inspector/CHANGELOG.md
@@ -10,7 +10,6 @@
 
 ### Patch Changes
 
-- 1674a02: Updated dependency `@modelcontextprotocol/sdk` to `^1.25.2`.
 - 1674a02: Updated dependency `@modelcontextprotocol/sdk` from `1.25.1` to `1.25.2`. This update includes a fix for ReDoS vulnerability in UriTemplate regex patterns.
 - Updated dependencies [1674a02]
 - Updated dependencies [1674a02]

--- a/libraries/typescript/packages/mcp-use/CHANGELOG.md
+++ b/libraries/typescript/packages/mcp-use/CHANGELOG.md
@@ -12,7 +12,6 @@
 
 ### Patch Changes
 
-- 1674a02: Updated dependency `@modelcontextprotocol/sdk` to `^1.25.2`.
 - 1674a02: Updated dependency `@modelcontextprotocol/sdk` from `1.25.1` to `1.25.2`. This update includes a fix for ReDoS vulnerability in UriTemplate regex patterns.
 - Updated dependencies [1674a02]
 - Updated dependencies [1674a02]


### PR DESCRIPTION
- Updated the template selection process to only prompt for a template if one isn't provided via the --template flag.
- Set a default template of "starter" if no selection is made, ensuring a smoother user experience.
- Refactored imports to include necessary components from the 'ink' library for better UI rendering.

This change improves the usability of the create-mcp-use-app tool by streamlining the project setup process.

# Pull Request Description

## Changes

Describe the changes introduced by this PR in a concise manner.

## Implementation Details

1. List the specific implementation details
2. Include code organization, architectural decisions
3. Note any dependencies that were added or modified

## Example Usage (Before)

```python
# Include example code showing how things worked before (if applicable)
```

## Example Usage (After)

```python
# Include example code showing how things work after your changes
```

## Documentation Updates

* List any documentation files that were updated
* Explain what was changed in each file

## Testing

Describe how you tested these changes:
- Unit tests added/modified
- Manual testing performed
- Edge cases considered

## Backwards Compatibility

Explain whether these changes are backwards compatible. If not, describe what users will need to do to adapt to these changes.

## Related Issues

Closes #[issue_number]
