### PR TITLE
fix(python/server): update inspector CDN path and add error fallback

### DIFF
--- a/libraries/python/mcp_use/server/utils/inspector.py
+++ b/libraries/python/mcp_use/server/utils/inspector.py
@@ -1,6 +1,10 @@
+import logging
+
 import httpx
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, RedirectResponse
+
+logger = logging.getLogger(__name__)
 
 CDN_BASE_URL = "https://unpkg.com/@mcp-use/inspector@latest/dist/web"
 INDEX_URL = f"{CDN_BASE_URL}/index.html"
@@ -26,8 +30,12 @@ async def _inspector_index(request: Request, mcp_path: str = "/mcp"):
             response = await client.get(INDEX_URL, follow_redirects=True)
             if response.status_code == 200:
                 return HTMLResponse(response.text)
-    except Exception:
-        pass
+            else:
+                logger.warning(
+                    f"Failed to fetch inspector from CDN: {INDEX_URL} returned status {response.status_code}"
+                )
+    except Exception as e:
+        logger.exception(f"Failed to fetch inspector from CDN: {INDEX_URL} - {e}")
 
     # CDN failed - return error page (no redirect to avoid loop)
     return HTMLResponse(
@@ -42,7 +50,7 @@ async def _inspector_index(request: Request, mcp_path: str = "/mcp"):
         </body>
         </html>
         """,
-        status_code=503
+        status_code=503,
     )
 
 
@@ -54,8 +62,14 @@ async def _inspector_static(request: Request):
         async with httpx.AsyncClient(timeout=10.0) as client:
             response = await client.get(cdn_url, follow_redirects=True)
             if response.status_code == 200:
-                return HTMLResponse(content=response.content, media_type=response.headers.get("Content-Type", "text/plain"))
-    except Exception:
-        pass
+                return HTMLResponse(
+                    content=response.content, media_type=response.headers.get("Content-Type", "text/plain")
+                )
+            else:
+                logger.warning(
+                    f"Failed to fetch static file from CDN: {cdn_url} returned status {response.status_code}"
+                )
+    except Exception as e:
+        logger.exception(f"Failed to fetch static file from CDN: {cdn_url} - {e}")
 
     return HTMLResponse("File not found", status_code=404)


### PR DESCRIPTION
- Change CDN path from /dist/client to /dist/web
- Add error page fallback when CDN fails to prevent redirect loops


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Shows a 503 error page when the CDN is unavailable instead of redirecting.
  * Enforces 10‑second timeouts for inspector HTTP requests and requires static CDN responses to be 200 OK.

* **Chore**
  * Updated the inspector CDN base path to a different distribution location.

* **Behavior**
  * Keeps existing autoconnect redirect behavior where applicable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->