### PR TITLE
fix(mount-mcp): enforce JSON responses in stateless mode for edge run…

### DIFF
--- a/libraries/typescript/.changeset/fancy-stars-clap.md
+++ b/libraries/typescript/.changeset/fancy-stars-clap.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+fix: enable json response in stateless mode

--- a/libraries/typescript/packages/mcp-use/src/server/endpoints/mount-mcp.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/endpoints/mount-mcp.ts
@@ -101,9 +101,10 @@ export async function mountMcp(
       const server = mcpServerInstance.getServerForSession();
       const transport = new WebStandardStreamableHTTPServerTransport({
         sessionIdGenerator: undefined, // No session tracking
-        // Enable plain JSON responses ONLY if client doesn't support SSE
-        // This allows k6/curl to work while maintaining SSE format for compatible clients
-        enableJsonResponse: !clientSupportsSSE,
+        // IMPORTANT: Always use JSON responses in stateless mode
+        // Edge runtimes (Deno, Cloudflare Workers, Supabase) cannot maintain long-lived SSE streams
+        // Even if client supports SSE, we must use request-response JSON in stateless environments
+        enableJsonResponse: true,
       });
 
       try {


### PR DESCRIPTION

Updated the `mountMcp` function to always enable JSON responses, ensuring compatibility with stateless environments like Deno and Cloudflare Workers. This change addresses issues with maintaining long-lived SSE streams and improves the reliability of the API in various deployment scenarios.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled JSON responses in stateless mode to improve compatibility with edge runtime environments that cannot maintain long-lived streaming connections.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->