### PR TITLE
chore(ci): disable telemetry in conformance tests

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -106,6 +106,8 @@ jobs:
 
       - name: Run conformance tests
         uses: mcp-use/mcp-conformance-action@v1
+        env:
+          MCP_USE_ANONYMIZED_TELEMETRY: false
         with:
           mode: test
           servers: ${{ steps.build-servers.outputs.servers }}


### PR DESCRIPTION
## Changes
Add `MCP_USE_ANONYMIZED_TELEMETRY=false` environment variable to the conformance test workflow to prevent telemetry tracking during CI runs.

## Implementation Details
1. Added `env` block to the "Run conformance tests" step in `.github/workflows/conformance.yml`
2. Set `MCP_USE_ANONYMIZED_TELEMETRY: false` to disable telemetry for both Python and TypeScript conformance tests

## Testing
- Environment variable is inherited by all child processes spawned by the conformance action
- Both Python and TypeScript servers will have telemetry disabled

## Related Issues
Closes MCP-1152

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated conformance testing workflow configuration to refine test environment settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->