### PR TITLE
refactor(cli): skip git initialization during project setup to improve performance

### DIFF
--- a/libraries/typescript/.changeset/pretty-meals-happen.md
+++ b/libraries/typescript/.changeset/pretty-meals-happen.md
@@ -1,0 +1,6 @@
+---
+"create-mcp-use-app": patch
+---
+
+Fix .gitignore file not being created in generated projects.
+Fix long initialization due to wrong git initialization


### PR DESCRIPTION
- Removed automatic git repository initialization to avoid delays when scanning node_modules. Users are advised to run `git init` manually when ready.
- Updated the installation command output to only display if the install option is not set, enhancing clarity for users.

# Pull Request Description

## Changes

Describe the changes introduced by this PR in a concise manner.

## Implementation Details

1. List the specific implementation details
2. Include code organization, architectural decisions
3. Note any dependencies that were added or modified

## Example Usage (Before)

```python
# Include example code showing how things worked before (if applicable)
```

## Example Usage (After)

```python
# Include example code showing how things work after your changes
```

## Documentation Updates

* List any documentation files that were updated
* Explain what was changed in each file

## Testing

Describe how you tested these changes:
- Unit tests added/modified
- Manual testing performed
- Edge cases considered

## Backwards Compatibility

Explain whether these changes are backwards compatible. If not, describe what users will need to do to adapt to these changes.

## Related Issues

Closes #[issue_number]
