### PR TITLE
feat(inspector): add copy functionality for RPC messages in Prompts, Resources, and Tools tabs

### DIFF
--- a/libraries/typescript/.changeset/fine-pears-move.md
+++ b/libraries/typescript/.changeset/fine-pears-move.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+feat(inspector): add copy functionality for RPC messages in Prompts, Resources, and Tools tabs

--- a/libraries/typescript/packages/inspector/src/client/components/PromptsTab.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/PromptsTab.tsx
@@ -9,7 +9,7 @@ import { useInspector } from "@/client/context/InspectorContext";
 import { MCPPromptCallEvent, Telemetry } from "@/client/telemetry";
 import type { Prompt } from "@modelcontextprotocol/sdk/types.js";
 import { AnimatePresence, motion } from "framer-motion";
-import { ChevronDown, ChevronLeft, Trash2 } from "lucide-react";
+import { ChevronDown, ChevronLeft, Copy, Trash2 } from "lucide-react";
 import {
   useCallback,
   useEffect,
@@ -90,6 +90,7 @@ export function PromptsTab({
   const [isMaximized, setIsMaximized] = useState(false);
   const rpcPanelRef = useRef<ImperativePanelHandle>(null);
   const clearRpcMessagesRef = useRef<(() => Promise<void>) | null>(null);
+  const exportRpcMessagesRef = useRef<(() => Promise<void>) | null>(null);
   const leftPanelRef = useRef<ImperativePanelHandle>(null);
   const topPanelRef = useRef<ImperativePanelHandle>(null);
 
@@ -741,30 +742,47 @@ export function PromptsTab({
                 }
               }}
             >
-              <div className="flex items-center gap-2">
-                <h3 className="text-sm font-medium">RPC Messages</h3>
-                {rpcMessageCount > 0 && (
-                  <Badge
-                    variant="secondary"
-                    className="bg-zinc-500/20 text-zinc-600 dark:text-zinc-400 border-transparent"
-                  >
-                    {rpcMessageCount}
-                  </Badge>
-                )}
+              <div className="flex items-center justify-between gap-2 flex-1">
+                <div className="flex items-center gap-2">
+                  <h3 className="text-sm font-medium">RPC Messages</h3>
+                  {rpcMessageCount > 0 && (
+                    <Badge
+                      variant="secondary"
+                      className="bg-zinc-500/20 text-zinc-600 dark:text-zinc-400 border-transparent"
+                    >
+                      {rpcMessageCount}
+                    </Badge>
+                  )}
+                </div>
                 {rpcMessageCount > 0 && !rpcPanelCollapsed && (
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      clearRpcMessagesRef.current?.();
-                    }}
-                    className="h-6 w-6 p-0"
-                    title="Clear all messages"
-                  >
-                    <Trash2 className="h-3.5 w-3.5" />
-                  </Button>
+                  <div className="flex items-center gap-1">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        exportRpcMessagesRef.current?.();
+                      }}
+                      className="h-6 w-6 p-0"
+                      title="Copy all messages to clipboard"
+                    >
+                      <Copy className="h-3.5 w-3.5" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        clearRpcMessagesRef.current?.();
+                      }}
+                      className="h-6 w-6 p-0"
+                      title="Clear all messages"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </Button>
+                  </div>
                 )}
               </div>
               <ChevronDown
@@ -780,6 +798,7 @@ export function PromptsTab({
                 serverIds={[serverId]}
                 onCountChange={setRpcMessageCount}
                 onClearRef={clearRpcMessagesRef}
+                onExportRef={exportRpcMessagesRef}
               />
             </div>
           </ResizablePanel>

--- a/libraries/typescript/packages/inspector/src/client/components/ResourcesTab.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ResourcesTab.tsx
@@ -9,7 +9,7 @@ import { useInspector } from "@/client/context/InspectorContext";
 import { MCPResourceReadEvent, Telemetry } from "@/client/telemetry";
 import type { Resource } from "@modelcontextprotocol/sdk/types.js";
 import { AnimatePresence, motion } from "framer-motion";
-import { ChevronDown, ChevronLeft, Trash2 } from "lucide-react";
+import { ChevronDown, ChevronLeft, Copy, Trash2 } from "lucide-react";
 import {
   useCallback,
   useEffect,
@@ -79,6 +79,7 @@ export function ResourcesTab({
   const [rpcPanelCollapsed, setRpcPanelCollapsed] = useState(true);
   const rpcPanelRef = useRef<ImperativePanelHandle>(null);
   const clearRpcMessagesRef = useRef<(() => Promise<void>) | null>(null);
+  const exportRpcMessagesRef = useRef<(() => Promise<void>) | null>(null);
 
   // Detect mobile screen size
   useEffect(() => {
@@ -524,30 +525,47 @@ export function ResourcesTab({
                 }
               }}
             >
-              <div className="flex items-center gap-2">
-                <h3 className="text-sm font-medium">RPC Messages</h3>
-                {rpcMessageCount > 0 && (
-                  <Badge
-                    variant="secondary"
-                    className="bg-zinc-500/20 text-zinc-600 dark:text-zinc-400 border-transparent"
-                  >
-                    {rpcMessageCount}
-                  </Badge>
-                )}
+              <div className="flex items-center justify-between gap-2 flex-1">
+                <div className="flex items-center gap-2">
+                  <h3 className="text-sm font-medium">RPC Messages</h3>
+                  {rpcMessageCount > 0 && (
+                    <Badge
+                      variant="secondary"
+                      className="bg-zinc-500/20 text-zinc-600 dark:text-zinc-400 border-transparent"
+                    >
+                      {rpcMessageCount}
+                    </Badge>
+                  )}
+                </div>
                 {rpcMessageCount > 0 && !rpcPanelCollapsed && (
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      clearRpcMessagesRef.current?.();
-                    }}
-                    className="h-6 w-6 p-0"
-                    title="Clear all messages"
-                  >
-                    <Trash2 className="h-3.5 w-3.5" />
-                  </Button>
+                  <div className="flex items-center gap-1">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        exportRpcMessagesRef.current?.();
+                      }}
+                      className="h-6 w-6 p-0"
+                      title="Copy all messages to clipboard"
+                    >
+                      <Copy className="h-3.5 w-3.5" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        clearRpcMessagesRef.current?.();
+                      }}
+                      className="h-6 w-6 p-0"
+                      title="Clear all messages"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </Button>
+                  </div>
                 )}
               </div>
               <ChevronDown
@@ -563,6 +581,7 @@ export function ResourcesTab({
                 serverIds={[serverId]}
                 onCountChange={setRpcMessageCount}
                 onClearRef={clearRpcMessagesRef}
+                onExportRef={exportRpcMessagesRef}
               />
             </div>
           </ResizablePanel>

--- a/libraries/typescript/packages/inspector/src/client/components/ToolsTab.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ToolsTab.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@/client/components/ui/button";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { AnimatePresence, motion } from "framer-motion";
-import { ChevronDown, ChevronLeft, Trash2 } from "lucide-react";
+import { ChevronDown, ChevronLeft, Copy, Trash2 } from "lucide-react";
 import {
   useCallback,
   useEffect,
@@ -117,6 +117,7 @@ export function ToolsTab({
   const bottomPanelRef = useRef<any>(null);
   const rpcPanelRef = useRef<ImperativePanelHandle>(null);
   const clearRpcMessagesRef = useRef<(() => Promise<void>) | null>(null);
+  const exportRpcMessagesRef = useRef<(() => Promise<void>) | null>(null);
 
   // Detect mobile screen size
   useEffect(() => {
@@ -983,30 +984,47 @@ export function ToolsTab({
                 }
               }}
             >
-              <div className="flex items-center gap-2">
-                <h3 className="text-sm font-medium">RPC Messages</h3>
-                {rpcMessageCount > 0 && (
-                  <Badge
-                    variant="secondary"
-                    className="bg-zinc-500/20 text-zinc-600 dark:text-zinc-400 border-transparent"
-                  >
-                    {rpcMessageCount}
-                  </Badge>
-                )}
+              <div className="flex items-center justify-between gap-2 flex-1">
+                <div className="flex items-center gap-2">
+                  <h3 className="text-sm font-medium">RPC Messages</h3>
+                  {rpcMessageCount > 0 && (
+                    <Badge
+                      variant="secondary"
+                      className="bg-zinc-500/20 text-zinc-600 dark:text-zinc-400 border-transparent"
+                    >
+                      {rpcMessageCount}
+                    </Badge>
+                  )}
+                </div>
                 {rpcMessageCount > 0 && !rpcPanelCollapsed && (
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      clearRpcMessagesRef.current?.();
-                    }}
-                    className="h-6 w-6 p-0"
-                    title="Clear all messages"
-                  >
-                    <Trash2 className="h-3.5 w-3.5" />
-                  </Button>
+                  <div className="flex items-center gap-1">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        exportRpcMessagesRef.current?.();
+                      }}
+                      className="h-6 w-6 p-0"
+                      title="Copy all messages to clipboard"
+                    >
+                      <Copy className="h-3.5 w-3.5" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        clearRpcMessagesRef.current?.();
+                      }}
+                      className="h-6 w-6 p-0"
+                      title="Clear all messages"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </Button>
+                  </div>
                 )}
               </div>
               <ChevronDown
@@ -1022,6 +1040,7 @@ export function ToolsTab({
                 serverIds={[serverId]}
                 onCountChange={setRpcMessageCount}
                 onClearRef={clearRpcMessagesRef}
+                onExportRef={exportRpcMessagesRef}
               />
             </div>
           </ResizablePanel>


### PR DESCRIPTION
- Introduced a new "Copy" button to allow users to copy all RPC messages to the clipboard in the PromptsTab, ResourcesTab, and ToolsTab components.
- Updated the JsonRpcLoggerView to include a button for copying individual message payloads.
- Enhanced the user interface for better message management, including the addition of export functionality.
