### PR TITLE
refactor(cli): streamline widget building process with parallel execution

### DIFF
--- a/libraries/typescript/.changeset/slick-cobras-type.md
+++ b/libraries/typescript/.changeset/slick-cobras-type.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/cli": patch
+---
+
+refactor(cli): streamline widget building process with parallel execution


### PR DESCRIPTION
- Introduced a helper function to build individual widgets, improving code organization and readability.
- Implemented parallel execution for building widgets, enhancing performance.
- Filtered out failed builds to ensure only successful widget metadata is returned.
