### PR TITLE
refactor(inspector): conditionally add temperature to llmOptions in usePropsLLM hook

### DIFF
--- a/libraries/typescript/.changeset/pink-ads-rescue.md
+++ b/libraries/typescript/.changeset/pink-ads-rescue.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+fix: openai does not support temperature

--- a/libraries/typescript/packages/inspector/src/client/hooks/usePropsLLM.ts
+++ b/libraries/typescript/packages/inspector/src/client/hooks/usePropsLLM.ts
@@ -162,8 +162,12 @@ Based on this information, suggest 3-5 common customizable properties like theme
         const llmOptions: any = {
           model: llmConfig.model,
           apiKey: llmConfig.apiKey,
-          temperature: llmConfig.temperature ?? 0.7,
         };
+
+        // Only add temperature if explicitly configured to avoid model-specific issues
+        if (llmConfig.temperature !== undefined) {
+          llmOptions.temperature = llmConfig.temperature;
+        }
 
         if (llmConfig.provider === "openai") {
           const { ChatOpenAI } = await import("@langchain/openai");


### PR DESCRIPTION
This update modifies the usePropsLLM hook to only include the temperature setting in llmOptions if it is explicitly configured in llmConfig. This change aims to prevent model-specific issues related to temperature settings, enhancing the flexibility and reliability of the configuration.
