### PR TITLE
fix(docs): update sessionIdleTimeoutMs default value in documentation and code

### DIFF
--- a/docs/typescript/server/api-reference.mdx
+++ b/docs/typescript/server/api-reference.mdx
@@ -104,7 +104,7 @@ interface ServerConfig {
   host?: string             // Hostname for widget URLs and server endpoints (defaults to 'localhost')
   baseUrl?: string          // Full base URL (e.g., 'https://myserver.com') - overrides host:port for widget URLs
   allowedOrigins?: string[] // Allowed origins for DNS rebinding protection
-  sessionIdleTimeoutMs?: number     // Idle timeout for sessions in milliseconds (default: 300000 = 5 minutes)
+  sessionIdleTimeoutMs?: number     // Idle timeout for sessions in milliseconds (default: 86400000 = 1 day)
   autoCreateSessionOnInvalidId?: boolean // @deprecated Will be removed in a future version. Use sessionStore for persistent sessions.
 }
 ```

--- a/docs/typescript/server/configuration.mdx
+++ b/docs/typescript/server/configuration.mdx
@@ -36,7 +36,7 @@ const server = new MCPServer({
   allowedOrigins: process.env.NODE_ENV === 'production' 
     ? ['https://myapp.com']      // Production: explicit origins
     : undefined,                 // Development: allows all origins
-  sessionIdleTimeoutMs: 300000,  // Session idle timeout (default: 5 minutes)
+  sessionIdleTimeoutMs: 86400000,  // Session idle timeout (default: 1 day)
   autoCreateSessionOnInvalidId: true  // Auto-create session on invalid ID (default: true, compatible with ChatGPT)
 })
 ```
@@ -329,7 +329,7 @@ The server manages client sessions to maintain state across multiple requests. S
 
 **Session Configuration Options:**
 
-- **`sessionIdleTimeoutMs`**: Controls how long a session remains active when idle (default: 5 minutes)
+- **`sessionIdleTimeoutMs`**: Controls how long a session remains active when idle (default: 1 day)
 - **`autoCreateSessionOnInvalidId`**: Controls behavior when a client sends a request with an invalid or expired session ID
 
 **Session Reconnection Behavior:**
@@ -379,7 +379,7 @@ const specCompliantServer = new MCPServer({
 const server = new MCPServer({
   name: 'my-server',
   version: '1.0.0',
-  sessionIdleTimeoutMs: 300000,  // 5 minutes
+  sessionIdleTimeoutMs: 3600000,  // 1 hour (default is 1 day)
   autoCreateSessionOnInvalidId: true  // Auto-create on invalid session
 })
 

--- a/docs/typescript/server/session-management.mdx
+++ b/docs/typescript/server/session-management.mdx
@@ -45,7 +45,7 @@ sequenceDiagram
 Sessions can end in several ways:
 
 - **Client closes**: Client sends DELETE request to `/mcp`
-- **Idle timeout**: Session expires after inactivity (default: 5 minutes)
+- **Idle timeout**: Session expires after inactivity (default: 1 day)
 - **Server restart**: In-memory sessions are lost (see [Storage Providers](/typescript/server/session-management/memory-storage))
 
 ### 4. Session Not Found (404)
@@ -167,7 +167,7 @@ Configure how long sessions remain active without requests:
 const server = new MCPServer({
   name: 'my-server',
   version: '1.0.0',
-  sessionIdleTimeoutMs: 600000  // 10 minutes (default: 5 minutes)
+  sessionIdleTimeoutMs: 3600000  // 1 hour (default: 1 day)
 });
 ```
 

--- a/libraries/typescript/.changeset/tender-facts-flash.md
+++ b/libraries/typescript/.changeset/tender-facts-flash.md
@@ -1,0 +1,13 @@
+---
+"@mcp-use/inspector": patch
+"mcp-use": patch
+---
+
+fix: improve widget rendering and session management
+
+- Fix widget iframe reload by adding timestamp query parameter to force refresh when widget data changes
+- Add retry logic with exponential backoff for dev widget fetching to handle Vite dev server cold starts
+- Fix default session idle timeout from 5 minutes to 1 day to prevent premature session expiration
+- Fix session lastAccessedAt tracking to update both persistent store and in-memory map
+- Fix _meta merging to preserve existing fields (e.g., openai/outputTemplate) when updating tools and widgets
+- Add support for frame_domains and redirect_domains in widget CSP metadata

--- a/libraries/typescript/packages/inspector/src/client/components/OpenAIComponentRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/OpenAIComponentRenderer.tsx
@@ -253,11 +253,13 @@ function OpenAIComponentRendererBase({
 
         if (computedUseDevMode && widgetName && currentServerBaseUrl) {
           // Use proxy URL for dev widgets (same-origin, supports HMR)
-          const proxyUrl = `/inspector/api/dev-widget/${toolId}`;
+          // Add timestamp to force iframe reload when widget data changes (e.g., props)
+          const proxyUrl = `/inspector/api/dev-widget/${toolId}?t=${Date.now()}`;
           setWidgetUrl(proxyUrl);
           setIsSameOrigin(true); // Proxy makes it same-origin
         } else {
-          const prodUrl = `/inspector/api/resources/widget/${toolId}`;
+          // Add timestamp to force iframe reload when widget data changes (e.g., props)
+          const prodUrl = `/inspector/api/resources/widget/${toolId}?t=${Date.now()}`;
           setWidgetUrl(prodUrl);
           // Relative URLs are always same-origin
           setIsSameOrigin(true);

--- a/libraries/typescript/packages/inspector/src/server/shared-routes.ts
+++ b/libraries/typescript/packages/inspector/src/server/shared-routes.ts
@@ -16,6 +16,85 @@ import { formatErrorResponse } from "./utils.js";
 // For now, this is a placeholder that will be implemented when WebSocket support is added
 
 /**
+ * Fetch with retry logic and exponential backoff for handling cold starts
+ *
+ * Retries fetch requests that fail due to connection timeouts or refused connections,
+ * which commonly occur when the Vite dev server is still initializing.
+ *
+ * @param url - The URL to fetch
+ * @param options - Fetch options
+ * @param maxRetries - Maximum number of retry attempts (default: 3)
+ * @param initialDelay - Initial delay in milliseconds before first retry (default: 500ms)
+ * @returns The successful response
+ * @throws The final error if all retries fail
+ */
+async function fetchWithRetry(
+  url: string,
+  options?: RequestInit,
+  maxRetries = 3,
+  initialDelay = 500
+): Promise<Response> {
+  let lastError: Error | unknown;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      const response = await fetch(url, options);
+
+      // If successful, return immediately
+      if (response.ok || response.status < 500) {
+        return response;
+      }
+
+      // For 5xx errors, treat as retriable
+      lastError = new Error(
+        `Server error: ${response.status} ${response.statusText}`
+      );
+    } catch (error) {
+      lastError = error;
+
+      // Check if this is a retriable error (connection timeout or refused)
+      const isRetriable =
+        error instanceof Error &&
+        (error.message.includes("ETIMEDOUT") ||
+          error.message.includes("ECONNREFUSED") ||
+          error.message.includes("fetch failed") ||
+          error.message.includes("Failed to fetch"));
+
+      // If not retriable or this was the last attempt, throw immediately
+      if (!isRetriable || attempt === maxRetries) {
+        throw error;
+      }
+
+      // Calculate delay with exponential backoff
+      const delay = initialDelay * Math.pow(2, attempt);
+
+      // Log retry attempt (only on first retry to avoid spam)
+      if (attempt === 0) {
+        console.log(
+          `[Dev Widget Proxy] Dev server not ready, retrying in ${delay}ms... (attempt ${attempt + 1}/${maxRetries + 1})`
+        );
+      }
+
+      // Wait before retrying
+      await new Promise((resolve) => setTimeout(resolve, delay));
+      continue;
+    }
+
+    // For 5xx errors, retry with backoff
+    if (attempt < maxRetries) {
+      const delay = initialDelay * Math.pow(2, attempt);
+      console.log(
+        `[Dev Widget Proxy] Server error, retrying in ${delay}ms... (attempt ${attempt + 1}/${maxRetries + 1})`
+      );
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+
+  // All retries exhausted
+  throw lastError;
+}
+
+/**
  * Register inspector-specific routes (proxy, chat, config, widget rendering)
  */
 export function registerInspectorRoutes(
@@ -182,8 +261,8 @@ export function registerInspectorRoutes(
         );
       }
 
-      // Fetch HTML from dev server
-      const response = await fetch(widgetData.devWidgetUrl);
+      // Fetch HTML from dev server with retry logic for cold starts
+      const response = await fetchWithRetry(widgetData.devWidgetUrl);
       if (!response.ok) {
         const status = response.status as 400 | 404 | 500 | 502 | 503;
         return c.html(

--- a/libraries/typescript/packages/mcp-use/src/server/README.md
+++ b/libraries/typescript/packages/mcp-use/src/server/README.md
@@ -94,7 +94,7 @@ Creates a new MCP server instance using the class constructor (recommended).
   - `host` (string, optional): Hostname for widget URLs (default: 'localhost')
   - `baseUrl` (string, optional): Full base URL (overrides host:port)
   - `allowedOrigins` (string[], optional): Allowed origins for DNS rebinding protection
-  - `sessionIdleTimeoutMs` (number, optional): Idle timeout for sessions (default: 300000)
+  - `sessionIdleTimeoutMs` (number, optional): Idle timeout for sessions (default: 86400000)
   - `oauth` (OAuthProvider, optional): OAuth authentication configuration
 
 **Returns:** `MCPServer` instance

--- a/libraries/typescript/packages/mcp-use/src/server/endpoints/mount-mcp.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/endpoints/mount-mcp.ts
@@ -40,7 +40,7 @@ export async function mountMcp(
   const { WebStandardStreamableHTTPServerTransport } =
     await import("@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js");
 
-  const idleTimeoutMs = config.sessionIdleTimeoutMs ?? 300000; // Default: 5 minutes
+  const idleTimeoutMs = config.sessionIdleTimeoutMs ?? 86400000; // Default: 1 day
 
   // Initialize session store (pluggable - can be Redis, Postgres, etc.)
   // Stores ONLY serializable metadata (client capabilities, log level, timestamps)
@@ -152,6 +152,11 @@ export async function mountMcp(
           if (session) {
             session.lastAccessedAt = Date.now();
             await sessionStore.set(sessionId, session);
+          }
+          // Also update in-memory sessions map for idle cleanup
+          const sessionData = sessions.get(sessionId);
+          if (sessionData) {
+            sessionData.lastAccessedAt = Date.now();
           }
         }
         return new Response(null, { status: 200 });

--- a/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
@@ -633,7 +633,11 @@ class MCPServerClass<HasOAuth extends boolean = false> {
         registration.config.description = updates.description;
       }
       if (updates._meta !== undefined) {
-        registration.config._meta = updates._meta;
+        // Merge _meta to preserve existing fields like openai/outputTemplate
+        registration.config._meta = {
+          ...registration.config._meta,
+          ...updates._meta,
+        };
       }
       if ("schema" in updates) {
         registration.config.schema = updates.schema as any;
@@ -650,7 +654,11 @@ class MCPServerClass<HasOAuth extends boolean = false> {
           toolEntry.description = updates.description;
         }
         if (updates._meta !== undefined) {
-          toolEntry._meta = updates._meta;
+          // Merge _meta to preserve existing fields like openai/outputTemplate
+          toolEntry._meta = {
+            ...toolEntry._meta,
+            ...updates._meta,
+          };
         }
         if ("schema" in updates) {
           if (inputSchema !== undefined) {
@@ -1483,7 +1491,7 @@ class MCPServerClass<HasOAuth extends boolean = false> {
    * @param config.favicon - Optional favicon URL
    * @param config.oauth - Optional OAuth provider configuration
    * @param config.stateless - Whether to use stateless mode (auto-detected for Deno)
-   * @param config.sessionIdleTimeoutMs - Session idle timeout (default: 300000 = 5 min)
+   * @param config.sessionIdleTimeoutMs - Session idle timeout (default: 86400000 = 1 day)
    * @param config.allowedOrigins - Allowed CORS origins (see {@link ServerConfig.allowedOrigins})
    *
    * @returns Proxied server instance supporting both MCP and Hono methods
@@ -3083,7 +3091,7 @@ export const MCPServer: MCPServerConstructor = MCPServerClass as any;
  *   - **Development mode** (NODE_ENV !== "production"): If not set, all origins are allowed
  *   - **Production mode** (NODE_ENV === "production"): Only uses explicitly configured origins
  *   - See {@link ServerConfig.allowedOrigins} for detailed documentation
- * @param config.sessionIdleTimeoutMs - Idle timeout for sessions in milliseconds (default: 300000 = 5 minutes)
+ * @param config.sessionIdleTimeoutMs - Idle timeout for sessions in milliseconds (default: 86400000 = 1 day)
  * @returns McpServerInstance with both MCP and Hono methods
  *
  * @example

--- a/libraries/typescript/packages/mcp-use/src/server/types/common.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/types/common.ts
@@ -73,7 +73,7 @@ export interface ServerConfig {
    * ```
    */
   allowedOrigins?: string[];
-  sessionIdleTimeoutMs?: number; // Idle timeout for sessions in milliseconds (default: 300000 = 5 minutes)
+  sessionIdleTimeoutMs?: number; // Idle timeout for sessions in milliseconds (default: 86400000 = 1 day)
   /**
    * @deprecated This option is deprecated and will be removed in a future version.
    *

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/widget-helpers.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/widget-helpers.ts
@@ -480,6 +480,24 @@ export function createWidgetRegistration(
           ...(((metadata.appsSdkMetadata as any)?.["openai/widgetCSP"]
             ?.resource_domains as string[]) || []),
         ],
+        // frame_domains for iframe embeds (optional per OpenAI spec)
+        ...((metadata.appsSdkMetadata as any)?.["openai/widgetCSP"]
+          ?.frame_domains
+          ? {
+              frame_domains: (metadata.appsSdkMetadata as any)?.[
+                "openai/widgetCSP"
+              ]?.frame_domains as string[],
+            }
+          : {}),
+        // redirect_domains for openExternal redirects (optional per OpenAI spec)
+        ...((metadata.appsSdkMetadata as any)?.["openai/widgetCSP"]
+          ?.redirect_domains
+          ? {
+              redirect_domains: (metadata.appsSdkMetadata as any)?.[
+                "openai/widgetCSP"
+              ]?.redirect_domains as string[],
+            }
+          : {}),
       },
     },
   };


### PR DESCRIPTION
- Updated the default value of `sessionIdleTimeoutMs` from 5 minutes (300000 ms) to 1 day (86400000 ms) across various documentation files and code implementations.
- Adjusted related comments and descriptions to reflect the new default session timeout duration for better clarity and consistency.
