### PR TITLE
fix(python): propagate verify parameter to HTTPConnector

### DIFF
--- a/libraries/python/mcp_use/client/client.py
+++ b/libraries/python/mcp_use/client/client.py
@@ -312,6 +312,7 @@ class MCPClient:
             message_handler=self.message_handler,
             logging_callback=self.logging_callback,
             middleware=self.middleware,
+            verify=self.verify,
             roots=self.roots,
             list_roots_callback=self.list_roots_callback,
         )

--- a/libraries/python/tests/unit/test_client.py
+++ b/libraries/python/tests/unit/test_client.py
@@ -229,6 +229,7 @@ class TestMCPClientSessionManagement:
             message_handler=None,
             logging_callback=None,
             middleware=[default_logging_middleware],
+            verify=True,
             roots=None,
             list_roots_callback=None,
         )
@@ -290,6 +291,7 @@ class TestMCPClientSessionManagement:
             message_handler=None,
             logging_callback=None,
             middleware=[default_logging_middleware],
+            verify=True,
             roots=None,
             list_roots_callback=None,
         )
@@ -484,6 +486,7 @@ class TestMCPClientSessionManagement:
             message_handler=None,
             logging_callback=None,
             middleware=[default_logging_middleware],
+            verify=True,
             roots=None,
             list_roots_callback=None,
         )
@@ -496,6 +499,7 @@ class TestMCPClientSessionManagement:
             message_handler=None,
             logging_callback=None,
             middleware=[default_logging_middleware],
+            verify=True,
             roots=None,
             list_roots_callback=None,
         )
@@ -557,6 +561,7 @@ class TestMCPClientSessionManagement:
             message_handler=None,
             logging_callback=None,
             middleware=[default_logging_middleware],
+            verify=True,
             roots=None,
             list_roots_callback=None,
         )


### PR DESCRIPTION
## Summary
- Fix the `verify` parameter not being propagated from `MCPClient` to `HTTPConnector` when creating sessions

## Implementation Details
1. Added `verify=self.verify` to the `create_connector_from_config` call in `MCPClient.create_session`
2. Updated test assertions to expect the `verify` parameter

## Testing
- All unit tests pass
- The fix ensures `verify=False` properly disables SSL certificate verification for HTTP-based MCP servers

## Backwards Compatibility
This is a bug fix with no breaking changes. The `verify` parameter already existed on `MCPClient` but was not being used.

## Related Issues
Closes #913