### PR TITLE
feat(inspector, mcp-use): enhance request origin handling and security headers

### DIFF
--- a/libraries/typescript/.changeset/dynamic-csp-origins.md
+++ b/libraries/typescript/.changeset/dynamic-csp-origins.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": minor
+---
+
+Add dynamic CSP domain injection for widgets: the request origin (from X-Forwarded-Host or Host header) is now automatically added to connectDomains and resourceDomains in tool metadata at tools/list time. This enables widgets to work correctly when accessed through proxies like ngrok, Cloudflare tunnels, or other reverse proxies.

--- a/libraries/typescript/packages/inspector/src/server/shared-routes.ts
+++ b/libraries/typescript/packages/inspector/src/server/shared-routes.ts
@@ -1,9 +1,11 @@
 import type { Hono } from "hono";
 import { mountMcpProxy, mountOAuthProxy } from "mcp-use/server";
+import { registerMcpAppsRoutes } from "./routes/mcp-apps.js";
 import { rpcLogBus, type RpcLogEvent } from "./rpc-log-bus.js";
 import {
   generateWidgetContainerHtml,
   generateWidgetContentHtml,
+  getRequestOrigin,
   getWidgetData,
   getWidgetSecurityHeaders,
   handleChatRequest,
@@ -11,7 +13,6 @@ import {
   storeWidgetData,
 } from "./shared-utils-browser.js";
 import { formatErrorResponse } from "./utils.js";
-import { registerMcpAppsRoutes } from "./routes/mcp-apps.js";
 
 // WebSocket proxy for Vite HMR - note: requires WebSocket library
 // For now, this is a placeholder that will be implemented when WebSocket support is added
@@ -236,8 +237,15 @@ export function registerInspectorRoutes(
         return c.html(`<html><body>Error: ${result.error}</body></html>`, 404);
       }
 
+      // Extract runtime origin from request headers (proxy-aware)
+      const requestOrigin = getRequestOrigin(c);
+
       // Set security headers with widget-specific CSP
-      const headers = getWidgetSecurityHeaders(widgetData.widgetCSP);
+      const headers = getWidgetSecurityHeaders(
+        widgetData.widgetCSP,
+        undefined,
+        requestOrigin
+      );
       Object.entries(headers).forEach(([key, value]) => {
         c.header(key, value);
       });
@@ -398,10 +406,14 @@ export function registerInspectorRoutes(
         );
       }
 
+      // Extract runtime origin from request headers (proxy-aware)
+      const requestOrigin = getRequestOrigin(c);
+
       // Set security headers
       const headers = getWidgetSecurityHeaders(
         widgetData.widgetCSP,
-        widgetData.devServerBaseUrl
+        widgetData.devServerBaseUrl,
+        requestOrigin
       );
       Object.entries(headers).forEach(([key, value]) => {
         c.header(key, value);

--- a/libraries/typescript/packages/inspector/src/server/shared-utils-browser.ts
+++ b/libraries/typescript/packages/inspector/src/server/shared-utils-browser.ts
@@ -1019,7 +1019,47 @@ export function transformMcpAppsCspToSnakeCase(mcpAppsCsp?: {
 }
 
 /**
+ * Minimal context interface for extracting request headers
+ */
+interface RequestContext {
+  req: {
+    url: string;
+    header: (name: string) => string | undefined;
+  };
+}
+
+/**
+ * Extract the request origin from headers (proxy-aware)
+ *
+ * Checks X-Forwarded-Host and X-Forwarded-Proto headers first (for proxied requests),
+ * then falls back to Host header and request URL protocol.
+ *
+ * @param c - Request context with url and header access
+ * @returns Request origin (e.g., "https://myapp.com") or null if unavailable
+ */
+export function getRequestOrigin(c: RequestContext): string | null {
+  const proto =
+    c.req.header("X-Forwarded-Proto") ||
+    c.req.header("X-Forwarded-Protocol") ||
+    new URL(c.req.url).protocol.replace(":", "");
+
+  const host =
+    c.req.header("X-Forwarded-Host") ||
+    c.req.header("Host") ||
+    new URL(c.req.url).host;
+
+  if (!host) return null;
+
+  return `${proto}://${host}`;
+}
+
+/**
  * Get security headers for widget content
+ *
+ * @param widgetCSP - Widget-specific CSP configuration
+ * @param devServerBaseUrl - Dev server base URL for HMR
+ * @param requestOrigin - Dynamic request origin from headers (e.g., "https://myapp.com")
+ * @returns Security headers including CSP
  */
 export function getWidgetSecurityHeaders(
   widgetCSP?: {
@@ -1027,7 +1067,8 @@ export function getWidgetSecurityHeaders(
     resource_domains?: string[];
     frame_domains?: string[];
   },
-  devServerBaseUrl?: string
+  devServerBaseUrl?: string,
+  requestOrigin?: string | null
 ): Record<string, string> {
   const trustedCdns = [
     "https://persistent.oaistatic.com",
@@ -1079,9 +1120,16 @@ export function getWidgetSecurityHeaders(
   }
 
   // Build connect-src with widget-specific domains
+  let connectDomains = widgetCSP?.connect_domains || [];
+
+  // Add runtime request origin to allowed domains (dynamic, proxy-aware)
+  if (requestOrigin && !connectDomains.includes(requestOrigin)) {
+    connectDomains = [...connectDomains, requestOrigin];
+  }
+
   let connectSrc = "'self' https: wss: ws:";
-  if (widgetCSP?.connect_domains && widgetCSP.connect_domains.length > 0) {
-    connectSrc = `'self' ${widgetCSP.connect_domains.join(" ")} https: wss: ws:`;
+  if (connectDomains.length > 0) {
+    connectSrc = `'self' ${connectDomains.join(" ")} https: wss: ws:`;
   }
 
   // Build frame-src for embedding iframes (e.g., Cal.com embed)

--- a/libraries/typescript/packages/inspector/src/server/shared-utils.ts
+++ b/libraries/typescript/packages/inspector/src/server/shared-utils.ts
@@ -885,7 +885,47 @@ export function generateWidgetContentHtml(widgetData: WidgetData): {
 }
 
 /**
+ * Minimal context interface for extracting request headers
+ */
+interface RequestContext {
+  req: {
+    url: string;
+    header: (name: string) => string | undefined;
+  };
+}
+
+/**
+ * Extract the request origin from headers (proxy-aware)
+ *
+ * Checks X-Forwarded-Host and X-Forwarded-Proto headers first (for proxied requests),
+ * then falls back to Host header and request URL protocol.
+ *
+ * @param c - Request context with url and header access
+ * @returns Request origin (e.g., "https://myapp.com") or null if unavailable
+ */
+export function getRequestOrigin(c: RequestContext): string | null {
+  const proto =
+    c.req.header("X-Forwarded-Proto") ||
+    c.req.header("X-Forwarded-Protocol") ||
+    new URL(c.req.url).protocol.replace(":", "");
+
+  const host =
+    c.req.header("X-Forwarded-Host") ||
+    c.req.header("Host") ||
+    new URL(c.req.url).host;
+
+  if (!host) return null;
+
+  return `${proto}://${host}`;
+}
+
+/**
  * Get security headers for widget content
+ *
+ * @param widgetCSP - Widget-specific CSP configuration
+ * @param devServerBaseUrl - Dev server base URL for HMR
+ * @param requestOrigin - Dynamic request origin from headers (e.g., "https://myapp.com")
+ * @returns Security headers including CSP
  */
 export function getWidgetSecurityHeaders(
   widgetCSP?: {
@@ -893,7 +933,8 @@ export function getWidgetSecurityHeaders(
     resource_domains?: string[];
     frame_domains?: string[];
   },
-  devServerBaseUrl?: string
+  devServerBaseUrl?: string,
+  requestOrigin?: string | null
 ): Record<string, string> {
   const trustedCdns = [
     "https://persistent.oaistatic.com",
@@ -945,9 +986,16 @@ export function getWidgetSecurityHeaders(
   }
 
   // Build connect-src with widget-specific domains
+  let connectDomains = widgetCSP?.connect_domains || [];
+
+  // Add runtime request origin to allowed domains (dynamic, proxy-aware)
+  if (requestOrigin && !connectDomains.includes(requestOrigin)) {
+    connectDomains = [...connectDomains, requestOrigin];
+  }
+
   let connectSrc = "'self' https: wss: ws:";
-  if (widgetCSP?.connect_domains && widgetCSP.connect_domains.length > 0) {
-    connectSrc = `'self' ${widgetCSP.connect_domains.join(" ")} https: wss: ws:`;
+  if (connectDomains.length > 0) {
+    connectSrc = `'self' ${connectDomains.join(" ")} https: wss: ws:`;
   }
 
   // Build frame-src for embedding iframes (e.g., Cal.com embed)

--- a/libraries/typescript/packages/mcp-use/src/server/utils/csp-helpers.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/utils/csp-helpers.ts
@@ -1,0 +1,183 @@
+/**
+ * CSP (Content Security Policy) helpers for dynamic domain injection
+ *
+ * These utilities enable lazy metadata evaluation by extracting the request origin
+ * from HTTP headers and injecting it into tool metadata's CSP configuration.
+ * This allows widgets to connect to dynamically determined origins (e.g., ngrok tunnels).
+ */
+
+/**
+ * Headers interface matching SDK's extra.requestInfo.headers structure
+ */
+interface RequestHeaders {
+  get?: (name: string) => string | null | undefined;
+  [key: string]: unknown;
+}
+
+/**
+ * Extract request origin from HTTP headers (proxy-aware)
+ *
+ * Checks for proxy headers (X-Forwarded-Proto, X-Forwarded-Host) first,
+ * then falls back to Host header.
+ *
+ * @param headers - Request headers from SDK's extra.requestInfo
+ * @returns Request origin (e.g., "https://myapp.ngrok.io") or null if unavailable
+ */
+export function getRequestOriginFromHeaders(
+  headers?: RequestHeaders
+): string | null {
+  if (!headers) return null;
+
+  // Helper to get header value (handles both get() method and direct access)
+  const getHeader = (name: string): string | undefined => {
+    if (typeof headers.get === "function") {
+      return headers.get(name) ?? undefined;
+    }
+    // Direct access for plain objects (case-insensitive)
+    const lowerName = name.toLowerCase();
+    for (const [key, value] of Object.entries(headers)) {
+      if (key.toLowerCase() === lowerName && typeof value === "string") {
+        return value;
+      }
+    }
+    return undefined;
+  };
+
+  const proto =
+    getHeader("X-Forwarded-Proto") ||
+    getHeader("X-Forwarded-Protocol") ||
+    "https"; // Default to https for security
+
+  const host =
+    getHeader("X-Forwarded-Host") || getHeader("Host") || getHeader("host");
+
+  if (!host) return null;
+
+  // Remove port from host if it's a standard port
+  const cleanHost = host.replace(/:443$|:80$/, "");
+
+  return `${proto}://${cleanHost}`;
+}
+
+/**
+ * CSP configuration within tool metadata
+ */
+interface ToolMetaCsp {
+  connectDomains?: string[];
+  resourceDomains?: string[];
+  baseUriDomains?: string[];
+}
+
+/**
+ * Widget UI metadata structure (MCP Apps protocol)
+ */
+interface ToolMetaUi {
+  csp?: ToolMetaCsp;
+  [key: string]: unknown;
+}
+
+/**
+ * Tool metadata structure
+ */
+interface ToolMeta {
+  ui?: ToolMetaUi;
+  "openai/widgetCSP"?: {
+    connect_domains?: string[];
+    resource_domains?: string[];
+    base_uri_domains?: string[];
+  };
+  [key: string]: unknown;
+}
+
+/**
+ * Inject dynamic request origin into tool metadata's CSP configuration
+ *
+ * Adds the origin to both protocols:
+ * - MCP Apps: `ui.csp.connectDomains` and `ui.csp.resourceDomains`
+ * - Apps SDK: `openai/widgetCSP.connect_domains` and `openai/widgetCSP.resource_domains`
+ *
+ * This enables lazy metadata evaluation where the actual request origin
+ * is injected at tools/list time rather than at registration time.
+ *
+ * @param meta - Original tool metadata
+ * @param requestOrigin - Dynamic request origin to inject
+ * @returns New metadata object with injected origin (or original if no changes needed)
+ */
+export function injectDynamicOriginIntoMeta(
+  meta: ToolMeta | undefined,
+  requestOrigin: string | null
+): ToolMeta | undefined {
+  if (!requestOrigin || !meta) return meta;
+
+  let needsUpdate = false;
+
+  // Check MCP Apps protocol (ui.csp)
+  const uiCsp = meta.ui?.csp;
+  if (uiCsp) {
+    if (!uiCsp.connectDomains?.includes(requestOrigin)) {
+      needsUpdate = true;
+    }
+    if (!uiCsp.resourceDomains?.includes(requestOrigin)) {
+      needsUpdate = true;
+    }
+  }
+
+  // Check Apps SDK protocol (openai/widgetCSP)
+  const widgetCSP = meta["openai/widgetCSP"];
+  if (widgetCSP) {
+    if (!widgetCSP.connect_domains?.includes(requestOrigin)) {
+      needsUpdate = true;
+    }
+    if (!widgetCSP.resource_domains?.includes(requestOrigin)) {
+      needsUpdate = true;
+    }
+  }
+
+  if (!needsUpdate) return meta;
+
+  // Create new metadata with injected origin
+  const newMeta: ToolMeta = { ...meta };
+
+  // Inject into MCP Apps protocol
+  if (meta.ui?.csp) {
+    newMeta.ui = {
+      ...meta.ui,
+      csp: {
+        ...meta.ui.csp,
+        connectDomains: meta.ui.csp.connectDomains?.includes(requestOrigin)
+          ? meta.ui.csp.connectDomains
+          : meta.ui.csp.connectDomains
+            ? [...meta.ui.csp.connectDomains, requestOrigin]
+            : [requestOrigin],
+        resourceDomains: meta.ui.csp.resourceDomains?.includes(requestOrigin)
+          ? meta.ui.csp.resourceDomains
+          : meta.ui.csp.resourceDomains
+            ? [...meta.ui.csp.resourceDomains, requestOrigin]
+            : [requestOrigin],
+      },
+    };
+  }
+
+  // Inject into Apps SDK protocol
+  if (meta["openai/widgetCSP"]) {
+    newMeta["openai/widgetCSP"] = {
+      ...meta["openai/widgetCSP"],
+      connect_domains: meta["openai/widgetCSP"].connect_domains?.includes(
+        requestOrigin
+      )
+        ? meta["openai/widgetCSP"].connect_domains
+        : meta["openai/widgetCSP"].connect_domains
+          ? [...meta["openai/widgetCSP"].connect_domains, requestOrigin]
+          : [requestOrigin],
+      resource_domains: meta["openai/widgetCSP"].resource_domains?.includes(
+        requestOrigin
+      )
+        ? meta["openai/widgetCSP"].resource_domains
+        : meta["openai/widgetCSP"].resource_domains
+          ? [...meta["openai/widgetCSP"].resource_domains, requestOrigin]
+          : [requestOrigin],
+    };
+  }
+
+  return newMeta;
+}

--- a/libraries/typescript/packages/mcp-use/src/server/utils/index.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/utils/index.ts
@@ -2,9 +2,10 @@
  * Server utility functions
  */
 
+export * from "./completion-helpers.js";
+export * from "./csp-helpers.js";
+export * from "./hono-proxy.js";
 export * from "./response-helpers.js";
 export * from "./runtime.js";
 export * from "./server-helpers.js";
 export * from "./server-lifecycle.js";
-export * from "./hono-proxy.js";
-export * from "./completion-helpers.js";


### PR DESCRIPTION
- Introduced `getRequestOrigin` function to extract the request origin from headers, supporting proxy-aware configurations.
- Updated `getWidgetSecurityHeaders` to include the dynamic request origin in CSP configurations, enhancing security for widget connections.
- Modified `registerInspectorRoutes` to utilize the new request origin handling, ensuring proper security headers are set based on the request context.
- Refactored UI resource registration to enrich widget definitions with server origin for improved asset loading and API connectivity.

These changes improve the security and flexibility of widget interactions within the inspector and MCP applications.
