### PR TITLE
feat(auth): support custom OAuth URLs configuration in HttpConnector

### DIFF
--- a/libraries/python/tests/integration/client/primitives/test_auth.py
+++ b/libraries/python/tests/integration/client/primitives/test_auth.py
@@ -105,6 +105,73 @@ async def test_oauth_provider(mock_callback_server_class, mock_webbrowser_open, 
 
 
 @pytest.mark.asyncio
+@patch("secrets.token_urlsafe")
+@patch("webbrowser.open")
+@patch("mcp_use.client.auth.oauth.OAuthCallbackServer")
+async def test_custom_oauth_urls(mock_callback_server_class, mock_webbrowser_open, mock_token_urlsafe, auth_server):
+    """Test OAuth with simplified custom URLs configuration (issue #864).
+
+    This tests the new flat configuration format that allows users to specify
+    custom OAuth URLs directly without the nested oauth_provider structure.
+    """
+    await clean_token()
+
+    # Mock the callback server
+    mock_callback_server = AsyncMock()
+    mock_callback_server.start.return_value = "http://127.0.0.1:8080/callback"
+    mock_callback_server.wait_for_code.return_value = MagicMock(
+        code="test_auth_code_12345", state="test_state_67890", error=None, error_description=None
+    )
+    mock_callback_server_class.return_value = mock_callback_server
+    mock_webbrowser_open.return_value = None
+
+    # Avoid CSRF error during testing
+    mock_token_urlsafe.return_value = "test_state_67890"
+
+    config = {
+        "mcpServers": {
+            "AuthServer": {
+                "url": f"{auth_server}/mcp",
+                "auth": {
+                    "authorization_url": "http://127.0.0.1:8081/oauth/authorize",
+                    "token_url": "http://127.0.0.1:8081/oauth/token",
+                    "registration_url": "http://127.0.0.1:8081/oauth/register",
+                    "issuer": "http://127.0.0.1:8081",
+                },
+            }
+        }
+    }
+    client = MCPClient(config)
+    try:
+        await client.create_all_sessions()
+        session = client.get_session("AuthServer")
+
+        assert session.connector._oauth is not None, "OAuth should be initialized"
+        assert session.connector._oauth._metadata is not None, "OAuth metadata should be set"
+        assert str(session.connector._oauth._metadata.issuer) == "http://127.0.0.1:8081/"
+        assert str(session.connector._oauth._metadata.authorization_endpoint) == "http://127.0.0.1:8081/oauth/authorize"
+        assert str(session.connector._oauth._metadata.registration_endpoint) == "http://127.0.0.1:8081/oauth/register"
+        assert str(session.connector._oauth._metadata.token_endpoint) == "http://127.0.0.1:8081/oauth/token"
+        assert "S256" in session.connector._oauth._metadata.code_challenge_methods_supported
+
+        mock_webbrowser_open.assert_called_once()
+        mock_callback_server_class.assert_called_once()
+        mock_callback_server.start.assert_called_once()
+        mock_callback_server.wait_for_code.assert_called_once()
+        assert session.connector._auth is not None
+
+        # Test that we can call protected tools
+        result = await session.call_tool(name="protected_tool", arguments={})
+        assert result.content[0].text == "Authenticated access granted!"
+
+        # Test that we can call regular tools
+        result = await session.call_tool(name="add", arguments={"a": 5, "b": 3})
+        assert result.content[0].text == "8"
+    finally:
+        await client.close_all_sessions()
+
+
+@pytest.mark.asyncio
 async def test_custom_client(auth_server):
     "Test that custom httpx.Auth objects works in auth field."
 


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

Check all that apply:
- [ ] TypeScript
- [x] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

This PR adds support for custom OAuth configuration URLs, allowing users to specify `authorization_url`, `token_url`, and `registration_url` directly in their server configuration. This enables support for MCP servers with non-standard OAuth implementations (like Zapier's server-specific URLs) without hardcoding vendor-specific logic.

## Implementation Details

1. **Modified `HttpConnector._set_auth()` method** to support three OAuth configuration modes:
   - Custom OAuth URLs (new): Direct specification of OAuth endpoints
   - OAuth Provider: Pre-configured provider with metadata (existing)
   - Auto-discovery: Standard OAuth discovery (existing)

2. **Added `skip_discovery` flag** to allow users to disable OAuth discovery entirely when using pre-authenticated server-specific URLs

3. **Maintained full backward compatibility** with all existing authentication methods (bearer tokens, OAuth provider, auto-discovery, custom httpx.Auth)

4. **No new dependencies** - implementation uses existing OAuth infrastructure

---

## Python Checklist

> Complete this section if your PR includes Python changes

### Pre-commit Checklist

Ensure all of the following have been completed:
- [x] Code formatted with `ruff format`
- [x] Linting passes with `ruff check`
- [x] Added or updated tests if needed
- [ ] Updated documentation if needed

---

## Example Usage (Before)

```python
# Users with non-standard OAuth servers had to use workarounds
# or wait for vendor-specific code to be added

# For Zapier's server-specific URLs, there was no clean solution
config = {
    "mcpServers": {
        "zapier": {
            "url": "https://mcp.zapier.com/api/mcp/s/XXXXXXXXX/mcp",
            # No way to configure custom OAuth URLs
        }
    }
}
```

## Example Usage (After)

```python
# Users can now specify custom OAuth URLs directly
config = {
    "mcpServers": {
        "zapier": {
            "url": "https://mcp.zapier.com/api/mcp/s/XXXXXXXXX/mcp",
            "auth": {
                "authorization_url": "https://custom.auth.url/authorize",
                "token_url": "https://custom.auth.url/token",
                "registration_url": "https://custom.auth.url/register",  # Optional
                "issuer": "https://custom.issuer.url",  # Optional
                "client_id": "my-client-id",  # Optional
                "client_secret": "my-client-secret",  # Optional
                "scope": "read write",  # Optional
            }
        }
    }
}

# Or skip OAuth discovery entirely for pre-authenticated URLs
config = {
    "mcpServers": {
        "zapier": {
            "url": "https://mcp.zapier.com/api/mcp/s/XXXXXXXXX/mcp",
            "auth": {
                "skip_discovery": True
            }
        }
    }
}
```

## Documentation Updates

* No documentation files updated in this PR (can be added in follow-up if needed)

## Testing

### Unit Tests
- Custom OAuth URLs create OAuth provider correctly
- Registration URL is passed through
- Client credentials are passed through
- Custom issuer can be specified
- Issuer defaults to base_url if not specified
- PKCE S256 is automatically included
- Both authorization_url and token_url are required (validation)
- skip_discovery without custom URLs disables OAuth
- Bearer token auth works independently
- Legacy oauth_provider format still works
- Standard auto-discovery format still works
- Custom callback_port is passed through

### Integration Tests (1 new test in `test_auth.py`)
- End-to-end OAuth flow with custom URLs

### Test Results
```bash
# Integration tests
pytest tests/integration/client/primitives/test_auth.py -v
# Result: 5/5 passed (including new test)
```

### Edge Cases Considered
- Missing required URLs (authorization_url or token_url)
- Optional parameters (registration_url, issuer, client credentials)
- Interaction with skip_discovery flag
- Backward compatibility with all existing auth formats

## Backwards Compatibility

**Fully backward compatible**

All existing authentication methods continue to work without any changes:
- Bearer token authentication (`auth: "token"`)
- OAuth with provider metadata (`auth: {"oauth_provider": {...}}`)
- OAuth auto-discovery (`auth: {"client_id": "...", "scope": "..."}`)
- Custom httpx.Auth objects

The new custom URL configuration is opt-in and only activates when `authorization_url` or `token_url` are present in the auth dict.

## Related Issues

Closes #864
