### PR TITLE
feat: add Depends() DI for MCP server tools

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -135,7 +135,8 @@
                       "python/server/sampling",
                       "python/server/elicitation",
                       "python/server/roots",
-                      "python/server/notifications"
+                      "python/server/notifications",
+                      "python/server/dependency-injection"
                     ]
                   },
                   {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -393,6 +393,7 @@
                     ]
                   },
                   "python/api-reference/mcp_use_server_context",
+                  "python/api-reference/mcp_use_server_dependencies",
                   {
                     "group": "Logging",
                     "icon": "logs",

--- a/docs/python/api-reference/mcp_use_server_dependencies.mdx
+++ b/docs/python/api-reference/mcp_use_server_dependencies.mdx
@@ -1,0 +1,71 @@
+---
+title: "Dependencies"
+description: "Dependencies API Documentation"
+icon: "code"
+github: "https://github.com/mcp-use/mcp-use/blob/main/libraries/python/mcp_use/server/dependencies.py"
+---
+
+import {RandomGradientBackground} from "/snippets/gradient.jsx"
+
+<Callout type="info" title="Source Code">
+View the source code for this module on GitHub: <a href='https://github.com/mcp-use/mcp-use/blob/main/libraries/python/mcp_use/server/dependencies.py' target='_blank' rel='noopener noreferrer'>https://github.com/mcp-use/mcp-use/blob/main/libraries/python/mcp_use/server/dependencies.py</a>
+</Callout>
+
+## Depends
+
+<div>
+<RandomGradientBackground className="rounded-lg p-4 w-full h-full rounded-full">
+<div className="text-black">
+<div className="text-black font-bold text-xl mb-2 mt-8"><code className="!text-black">class</code> Depends</div>
+
+Marks a parameter as an injected dependency.
+
+    Usage:
+        @server.tool()
+        def my_tool(query: str, db: Database = Depends(get_database)) -> str:
+            ...
+
+</div>
+</RandomGradientBackground>
+```python
+from mcp_use.server.dependencies import Depends
+```
+
+<Card type="info">
+### `method` __init__
+
+**Parameters**
+><ParamField body="dependency" type="Callable[..., Any]" required="True" >   Parameter value </ParamField>
+
+**Signature**
+```python wrap
+def __init__(dependency: Callable[..., Any]):
+```
+
+</Card>
+</div>
+
+
+## wrap_tool_with_dependencies
+<Card type="info">
+### `function` wrap_tool_with_dependencies
+
+Wrap a tool function so that Depends() parameters are resolved at call time
+    and excluded from the MCP tool schema.
+
+```python
+from mcp_use.server.dependencies import wrap_tool_with_dependencies
+```
+
+**Parameters**
+><ParamField body="fn" type="Callable[..., Any]" required="True" >   Parameter value </ParamField>
+
+**Returns**
+><ResponseField name="returns" type="Callable[..., Any]" />
+
+**Signature**
+```python wrap
+def wrap_tool_with_dependencies(fn: Callable[..., Any]):
+```
+
+</Card>

--- a/docs/python/server/dependency-injection.mdx
+++ b/docs/python/server/dependency-injection.mdx
@@ -1,0 +1,177 @@
+---
+title: "Dependency Injection"
+description: "Inject dependencies into MCP tools with Depends()"
+icon: "syringe"
+---
+
+`Depends()` lets you inject dependencies into your MCP tools, just like FastAPI. Dependencies are resolved at call time and hidden from the MCP tool schema, so clients never see them.
+
+## Quick Start
+
+```python
+from mcp_use.server import MCPServer
+from mcp_use.server.dependencies import Depends
+
+server = MCPServer(name="my-server")
+
+def get_api_key() -> str:
+    return "sk-secret-key"
+
+@server.tool()
+def call_api(query: str, api_key: str = Depends(get_api_key)) -> str:
+    """Call an external API."""
+    return f"Called API with query={query}, key={api_key}"
+```
+
+The client sees `call_api(query: str)` and the `api_key` parameter is resolved automatically and excluded from the schema.
+
+## How It Works
+
+1. You mark parameters with `Depends(callable)` as their default value
+2. When the tool is called, each dependency callable is invoked to produce the value
+3. The resolved values are injected into the function
+4. `Depends` parameters are stripped from the MCP tool schema, clients don't know they exist
+
+<Tip>
+This is useful for injecting database connections, configuration, authenticated clients, or any setup logic that shouldn't be exposed to the LLM.
+</Tip>
+
+## Dependency Types
+
+<Tabs>
+  <Tab title="Sync Function">
+    The simplest form, a plain function that returns a value:
+
+    ```python
+    def get_config() -> dict:
+        return {"model": "gpt-4", "temperature": 0.7}
+
+    @server.tool()
+    def generate(prompt: str, config: dict = Depends(get_config)) -> str:
+        """Generate text with config."""
+        return f"Generating with {config['model']}: {prompt}"
+    ```
+  </Tab>
+
+  <Tab title="Async Function">
+    For dependencies that need async I/O:
+
+    ```python
+    async def get_user() -> dict:
+        # e.g. fetch from database
+        return {"id": 1, "name": "Alice"}
+
+    @server.tool()
+    async def greet_user(message: str, user: dict = Depends(get_user)) -> str:
+        """Greet the current user."""
+        return f"Hello {user['name']}! {message}"
+    ```
+  </Tab>
+
+  <Tab title="Sync Generator">
+    Use a generator for setup/cleanup (like a context manager):
+
+    ```python
+    def get_db_connection():
+        conn = create_connection()
+        yield conn         # value injected into the tool
+        conn.close()       # cleanup runs after the tool returns
+
+    @server.tool()
+    def query_db(sql: str, db = Depends(get_db_connection)) -> str:
+        """Run a database query."""
+        return db.execute(sql)
+    ```
+  </Tab>
+
+  <Tab title="Async Generator">
+    Async setup/cleanup for async resources:
+
+    ```python
+    async def get_async_client():
+        client = await AsyncHTTPClient.create()
+        yield client
+        await client.close()
+
+    @server.tool()
+    async def fetch_data(url: str, client = Depends(get_async_client)) -> str:
+        """Fetch data from a URL."""
+        response = await client.get(url)
+        return response.text
+    ```
+  </Tab>
+</Tabs>
+
+<Note>
+Generator dependencies always run their cleanup code, even if the tool raises an exception. This ensures resources like database connections are properly released.
+</Note>
+
+## Multiple Dependencies
+
+A single tool can have multiple injected dependencies:
+
+```python
+def get_db():
+    conn = create_connection()
+    yield conn
+    conn.close()
+
+def get_settings() -> dict:
+    return {"max_results": 100, "timeout": 30}
+
+@server.tool()
+def search(
+    query: str,
+    db = Depends(get_db),
+    settings: dict = Depends(get_settings),
+) -> str:
+    """Search the database."""
+    results = db.execute(query, limit=settings["max_results"])
+    return str(results)
+```
+
+The client only sees `search(query: str)`. Both `db` and `settings` are resolved and injected automatically.
+
+## Real World Example
+
+A complete server using dependency injection for database access and configuration:
+
+```python
+import sqlite3
+from mcp_use.server import MCPServer
+from mcp_use.server.dependencies import Depends
+
+server = MCPServer(name="notes-server")
+
+def get_db():
+    conn = sqlite3.connect("notes.db")
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS notes (id INTEGER PRIMARY KEY, text TEXT)"
+    )
+    yield conn
+    conn.close()
+
+def get_config() -> dict:
+    return {"max_notes": 1000}
+
+@server.tool()
+def add_note(text: str, db: sqlite3.Connection = Depends(get_db)) -> str:
+    """Add a new note."""
+    db.execute("INSERT INTO notes (text) VALUES (?)", (text,))
+    db.commit()
+    return "Note added."
+
+@server.tool()
+def list_notes(
+    db: sqlite3.Connection = Depends(get_db),
+    config: dict = Depends(get_config),
+) -> str:
+    """List all notes."""
+    rows = db.execute(
+        "SELECT text FROM notes LIMIT ?", (config["max_notes"],)
+    ).fetchall()
+    return "\n".join(row[0] for row in rows)
+
+if __name__ == "__main__":
+    server.run()
+```

--- a/libraries/python/mcp_use/server/__init__.py
+++ b/libraries/python/mcp_use/server/__init__.py
@@ -1,4 +1,5 @@
 from .context import Context
+from .dependencies import Depends
 from .middleware import Middleware, TelemetryMiddleware
 from .router import MCPRouter
 from .server import MCPServer
@@ -11,6 +12,7 @@ __all__ = [
     "MCPRouter",
     "FastMCP",
     "Context",
+    "Depends",
     "Middleware",
     "TelemetryMiddleware",
 ]

--- a/libraries/python/mcp_use/server/dependencies.py
+++ b/libraries/python/mcp_use/server/dependencies.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import functools
+import inspect
+from collections.abc import Callable
+from typing import Any
+
+
+class Depends:
+    """Marks a parameter as an injected dependency.
+
+    Usage:
+        @server.tool()
+        def my_tool(query: str, db: Database = Depends(get_database)) -> str:
+            ...
+    """
+
+    def __init__(self, dependency: Callable[..., Any]) -> None:
+        self.dependency = dependency
+
+    def __repr__(self) -> str:
+        return f"Depends({self.dependency!r})"
+
+
+def wrap_tool_with_dependencies(fn: Callable[..., Any]) -> Callable[..., Any]:
+    """Wrap a tool function so that Depends() parameters are resolved at call time
+    and excluded from the MCP tool schema."""
+    sig = inspect.signature(fn)
+
+    # Find params with Depends defaults
+    depends_params: dict[str, Depends] = {}
+    regular_params: list[inspect.Parameter] = []
+
+    for name, param in sig.parameters.items():
+        if isinstance(param.default, Depends):
+            depends_params[name] = param.default
+        else:
+            regular_params.append(param)
+
+    if not depends_params:
+        return fn
+
+    # Build new signature without Depends params
+    new_sig = sig.replace(parameters=regular_params)
+
+    @functools.wraps(fn)
+    async def wrapper(*args: Any, **kwargs: Any) -> Any:
+        resolved: dict[str, Any] = {}
+        cleanup_generators: list[Any] = []
+        cleanup_async_generators: list[Any] = []
+
+        try:
+            # Resolve each dependency
+            for param_name, dep in depends_params.items():
+                result = dep.dependency()
+
+                # Handle async callables
+                if inspect.isawaitable(result):
+                    result = await result
+
+                # Handle sync generators (context manager pattern)
+                if inspect.isgenerator(result):
+                    value = next(result)
+                    resolved[param_name] = value
+                    cleanup_generators.append(result)
+
+                # Handle async generators (async context manager pattern)
+                elif inspect.isasyncgen(result):
+                    value = await result.__anext__()
+                    resolved[param_name] = value
+                    cleanup_async_generators.append(result)
+
+                else:
+                    resolved[param_name] = result
+
+            # Call original function with caller args + resolved deps
+            kwargs.update(resolved)
+            result = fn(*args, **kwargs)
+            if inspect.isawaitable(result):
+                result = await result
+            return result
+        finally:
+            # Cleanup sync generators
+            for gen in reversed(cleanup_generators):
+                try:
+                    next(gen)
+                except StopIteration:
+                    pass
+            # Cleanup async generators
+            for gen in reversed(cleanup_async_generators):
+                try:
+                    await gen.__anext__()
+                except StopAsyncIteration:
+                    pass
+
+    wrapper.__signature__ = new_sig  # type: ignore[attr-defined]
+    return wrapper

--- a/libraries/python/mcp_use/server/server.py
+++ b/libraries/python/mcp_use/server/server.py
@@ -24,6 +24,7 @@ from mcp.types import (
 # Import auth components
 from mcp_use.server.auth import AuthMiddleware, BearerAuthProvider
 from mcp_use.server.context import Context as MCPContext
+from mcp_use.server.dependencies import wrap_tool_with_dependencies
 from mcp_use.server.logging import MCPLoggingMiddleware
 from mcp_use.server.middleware import (
     Middleware,
@@ -141,6 +142,11 @@ class MCPServer(FastMCP):
         # Inject middleware in the ServerSession
         MiddlewareServerSession._middleware_manager = self.middleware_manager
         MiddlewareServerSession._transport_type = self._transport_type
+
+    def add_tool(self, fn: AnyFunction, **kwargs: Any) -> None:
+        """Override to resolve Depends() parameters before registration."""
+        wrapped = wrap_tool_with_dependencies(fn)
+        super().add_tool(wrapped, **kwargs)
 
     @property
     def debug(self) -> bool:

--- a/libraries/python/pyproject.toml
+++ b/libraries/python/pyproject.toml
@@ -79,7 +79,7 @@ select = [
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]  # Unused imports
-"tests/**/*.py" = ["F811", "F401", "B017"]  # Redefinition in test files
+"tests/**/*.py" = ["F811", "F401", "B017", "B008"]  # Redefinition in test files
 "mcp_use/connectors/websocket.py" = ["C901"]  # Function too complex
 
 [tool.ruff.lint.isort]

--- a/libraries/python/tests/unit/test_depends.py
+++ b/libraries/python/tests/unit/test_depends.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from mcp_use.server.dependencies import Depends, wrap_tool_with_dependencies
+
+def get_db():
+    return "db_connection"
+
+
+async def get_async_service():
+    return "async_service"
+
+
+def get_contextual_resource():
+    yield "contextual_resource"
+
+
+async def get_async_contextual():
+    yield "async_contextual"
+
+class TestDepends:
+    def test_depends_stores_callable(self):
+        dep = Depends(get_db)
+        assert dep.dependency is get_db
+
+    def test_depends_repr(self):
+        dep = Depends(get_db)
+        assert "get_db" in repr(dep)
+
+
+class TestWrapToolWithDependencies:
+    def test_no_depends_returns_original(self):
+        def my_tool(query: str) -> str:
+            return query
+
+        result = wrap_tool_with_dependencies(my_tool)
+        assert result is my_tool
+
+    def test_signature_excludes_depends_params(self):
+        def my_tool(query: str, db=Depends(get_db)) -> str:
+            return f"{query} {db}"
+
+        wrapped = wrap_tool_with_dependencies(my_tool)
+        sig = inspect.signature(wrapped)
+        assert "query" in sig.parameters
+        assert "db" not in sig.parameters
+
+    @pytest.mark.asyncio
+    async def test_sync_dependency(self):
+        def my_tool(query: str, db=Depends(get_db)) -> str:
+            return f"{query} {db}"
+
+        wrapped = wrap_tool_with_dependencies(my_tool)
+        result = await wrapped(query="hello")
+        assert result == "hello db_connection"
+
+    @pytest.mark.asyncio
+    async def test_async_dependency(self):
+        def my_tool(query: str, svc=Depends(get_async_service)) -> str:
+            return f"{query} {svc}"
+
+        wrapped = wrap_tool_with_dependencies(my_tool)
+        result = await wrapped(query="hello")
+        assert result == "hello async_service"
+
+    @pytest.mark.asyncio
+    async def test_sync_generator_dependency(self):
+        cleanup_called = False
+
+        def get_resource():
+            nonlocal cleanup_called
+            yield "resource_value"
+            cleanup_called = True
+
+        def my_tool(query: str, res=Depends(get_resource)) -> str:
+            return f"{query} {res}"
+
+        wrapped = wrap_tool_with_dependencies(my_tool)
+        result = await wrapped(query="hello")
+        assert result == "hello resource_value"
+        assert cleanup_called
+
+    @pytest.mark.asyncio
+    async def test_async_generator_dependency(self):
+        cleanup_called = False
+
+        async def get_resource():
+            nonlocal cleanup_called
+            yield "async_resource"
+            cleanup_called = True
+
+        def my_tool(query: str, res=Depends(get_resource)) -> str:
+            return f"{query} {res}"
+
+        wrapped = wrap_tool_with_dependencies(my_tool)
+        result = await wrapped(query="hello")
+        assert result == "hello async_resource"
+        assert cleanup_called
+
+    @pytest.mark.asyncio
+    async def test_multiple_dependencies(self):
+        def my_tool(query: str, db=Depends(get_db), svc=Depends(get_async_service)) -> str:
+            return f"{query} {db} {svc}"
+
+        wrapped = wrap_tool_with_dependencies(my_tool)
+        result = await wrapped(query="hello")
+        assert result == "hello db_connection async_service"
+
+    @pytest.mark.asyncio
+    async def test_async_tool_function(self):
+        async def my_tool(query: str, db=Depends(get_db)) -> str:
+            return f"{query} {db}"
+
+        wrapped = wrap_tool_with_dependencies(my_tool)
+        result = await wrapped(query="hello")
+        assert result == "hello db_connection"
+
+    def test_preserves_name_and_doc(self):
+        def my_tool(query: str, db=Depends(get_db)) -> str:
+            """My tool docstring."""
+            return f"{query} {db}"
+
+        wrapped = wrap_tool_with_dependencies(my_tool)
+        assert wrapped.__name__ == "my_tool"
+        assert wrapped.__doc__ == "My tool docstring."
+
+    @pytest.mark.asyncio
+    async def test_positional_args_work(self):
+        def my_tool(query: str, db=Depends(get_db)) -> str:
+            return f"{query} {db}"
+
+        wrapped = wrap_tool_with_dependencies(my_tool)
+        result = await wrapped("hello")
+        assert result == "hello db_connection"

--- a/libraries/python/tests/unit/test_depends.py
+++ b/libraries/python/tests/unit/test_depends.py
@@ -1,4 +1,3 @@
-# ruff: noqa: B008
 """Tests for Depends() dependency injection."""
 
 from __future__ import annotations

--- a/libraries/python/tests/unit/test_depends.py
+++ b/libraries/python/tests/unit/test_depends.py
@@ -1,3 +1,6 @@
+# ruff: noqa: B008
+"""Tests for Depends() dependency injection."""
+
 from __future__ import annotations
 
 import inspect
@@ -5,6 +8,7 @@ import inspect
 import pytest
 
 from mcp_use.server.dependencies import Depends, wrap_tool_with_dependencies
+
 
 def get_db():
     return "db_connection"
@@ -20,6 +24,7 @@ def get_contextual_resource():
 
 async def get_async_contextual():
     yield "async_contextual"
+
 
 class TestDepends:
     def test_depends_stores_callable(self):


### PR DESCRIPTION
## Changes
Add a FastAPI-style `Depends()` dependency injection mechanism for MCP server tools, allowing tool functions to declare injected dependencies that are resolved at call time and hidden from the MCP tool schema.

## Implementation Details
1. **`mcp_use/server/dependencies.py`** — `Depends` class and `wrap_tool_with_dependencies()` that inspects signatures, strips `Depends` params from the schema, and resolves them at call time
2. **`mcp_use/server/server.py`** — Override `add_tool()` on `MCPServer` to wrap functions, catching all registration paths (`@server.tool()`, `include_router()`, manual `add_tool()`)
3. **`mcp_use/server/__init__.py`** — Export `Depends` in public API

## Example Usage (Before)
```python
@server.tool()
def my_tool(query: str) -> str:
    token = require_auth()  # Manual call
    db = get_database()     # Manual call
    return f"User {token.claims.get('email')} searched for {query}"
```

## Example Usage (After)
```python
from mcp_use.server import Depends

@server.tool()
def my_tool(
    query: str,
    token: AccessToken = Depends(require_auth),
    db: Database = Depends(get_database),
) -> str:
    return f"User {token.claims.get('email')} searched for {query}"
```

## Testing
- 12 unit tests covering: sync/async/generator dependencies, schema exclusion, multiple deps, name/doc preservation, positional args

## Related Issues
Closes #870