### PR TITLE
fix(chat): enhance message conversion logic to handle empty content and attachments

### DIFF
--- a/libraries/typescript/.changeset/salty-rice-shine.md
+++ b/libraries/typescript/.changeset/salty-rice-shine.md
@@ -1,0 +1,9 @@
+---
+"@mcp-use/inspector": patch
+---
+
+fix(chat): enhance message conversion logic to handle empty content and attachments
+
+- Updated `convertMessagesToLangChain` to fall back on `m.parts` when `m.content` is empty, ensuring text is retrieved from streamed assistant messages.
+- Modified `useChatMessages` to prioritize `m.parts` for message content, improving message handling consistency.
+- Adjusted `handleChatRequestStream` to utilize `externalHistory` for better context management during agent interactions, preventing message duplication.

--- a/libraries/typescript/packages/inspector/src/client/components/chat/conversion.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/conversion.ts
@@ -50,7 +50,7 @@ export function convertMessagesToLangChain(
     }
 
     // Handle regular messages (text only)
-    const raw =
+    let raw =
       typeof m.content === "string"
         ? m.content
         : Array.isArray(m.content)
@@ -58,6 +58,16 @@ export function convertMessagesToLangChain(
               .map((x) => x?.text ?? "")
               .join("\n")
           : JSON.stringify(m.content ?? "");
+
+    // Fall back to parts when content is empty (streamed assistant messages
+    // store their text in parts, not content)
+    if (!raw.trim() && m.parts && m.parts.length > 0) {
+      raw = m.parts
+        .filter((p) => p.type === "text" && p.text)
+        .map((p) => p.text!)
+        .join("");
+    }
+
     const content = raw.trim() || "[no content]";
     return m.role === "user"
       ? new HumanMessage(content)

--- a/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessages.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessages.ts
@@ -104,7 +104,13 @@ export function useChatMessages({
             authConfig: authConfigWithTokens,
             messages: [...messages, ...userMessages].map((m) => ({
               role: m.role,
-              content: m.content,
+              content:
+                m.content ||
+                (m.parts
+                  ?.filter((p) => p.type === "text")
+                  .map((p) => p.text)
+                  .join("") ??
+                  ""),
               attachments: m.attachments,
             })),
           }),

--- a/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessagesClientSide.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessagesClientSide.ts
@@ -163,11 +163,11 @@ export function useChatMessagesClientSide({
         }
 
         // Stream events from agent
-        // Include the new user message with attachments in the external history
+        // Don't include the new userMessage here - streamEvents() appends it internally
+        // as new HumanMessage(query), so including it would cause duplication
         const externalHistory = convertMessagesToLangChain([
           ...messages,
           ...promptResultsMessages,
-          userMessage, // Include the new message with attachments
         ]);
 
         for await (const event of agentRef.current.streamEvents(


### PR DESCRIPTION
- Updated `convertMessagesToLangChain` to fall back on `m.parts` when `m.content` is empty, ensuring text is retrieved from streamed assistant messages.
- Modified `useChatMessages` to prioritize `m.parts` for message content, improving message handling consistency.
- Adjusted `handleChatRequestStream` to utilize `externalHistory` for better context management during agent interactions, preventing message duplication.
