### PR TITLE
fix(inspector): reset readiness state on widget URL change and enhance tool output handling

### DIFF
--- a/libraries/typescript/.changeset/wicked-adults-grow.md
+++ b/libraries/typescript/.changeset/wicked-adults-grow.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+fix(inspector): reset readiness state on widget URL change and enhance tool output handling

--- a/libraries/typescript/packages/inspector/src/client/components/OpenAIComponentRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/OpenAIComponentRenderer.tsx
@@ -90,6 +90,17 @@ function OpenAIComponentRendererBase({
   const [isReady, setIsReady] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [widgetUrl, setWidgetUrl] = useState<string | null>(null);
+
+  // Reset isReady when widgetUrl changes so the update effect re-fires
+  // after the new iframe loads. Without this, when storeAndSetUrl re-runs
+  // (e.g. after toolResult arrives) and creates a new widgetUrl, isReady
+  // stays true, setIsReady(true) in handleLoad is a no-op, and the
+  // toolResult update effect never re-triggers for the new iframe.
+  useEffect(() => {
+    if (widgetUrl) {
+      setIsReady(false);
+    }
+  }, [widgetUrl]);
   const [iframeHeight, setIframeHeight] = useState<number>(400);
   const lastMeasuredHeightRef = useRef<number>(0);
   const lastNotifiedHeightRef = useRef<number>(0);

--- a/libraries/typescript/packages/inspector/src/server/shared-utils.ts
+++ b/libraries/typescript/packages/inspector/src/server/shared-utils.ts
@@ -1021,6 +1021,18 @@ export function generateWidgetContentHtml(widgetData: WidgetData): {
               hasChanges = true;
             }
 
+            // Update toolOutput (allows widget to transition from isPending=true to isPending=false)
+            if (updates.toolOutput !== undefined) {
+              openaiAPI.toolOutput = updates.toolOutput;
+              hasChanges = true;
+            }
+
+            // Update toolResponseMetadata
+            if (updates.toolResponseMetadata !== undefined) {
+              openaiAPI.toolResponseMetadata = updates.toolResponseMetadata;
+              hasChanges = true;
+            }
+
             // Dispatch set_globals event to notify React components if any changes occurred
             if (hasChanges) {
               try {


### PR DESCRIPTION
- Added a useEffect hook in OpenAIComponentRenderer to reset the readiness state when the widget URL changes, ensuring proper re-triggering of updates for new iframes.
- Updated shared-utils to handle tool output and response metadata updates, improving the transition of widget states from pending to ready.
