### PR TITLE
feat(dns-rebinding): implement DNS rebinding protection and examples

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -543,11 +543,11 @@
               {
                 "group": "MCP Server",
                 "icon": "server",
-                "tag": "Beta",
                 "pages": [
                   "typescript/server/index",
                   "typescript/server/configuration",
                   "typescript/server/cli-reference",
+                  "typescript/server/examples",
                   {
                     "group": "Core Components",
                     "icon": "box",

--- a/docs/typescript/server/api-reference.mdx
+++ b/docs/typescript/server/api-reference.mdx
@@ -12,7 +12,7 @@ This document provides a complete reference for the `mcp-use/server` API, includ
 
 ### `MCPServer` Class
 
-Creates a new MCP server instance with Express integration.
+Creates a new MCP server instance with built-in HTTP routing and MCP transport support.
 
 ```typescript
 class MCPServer {
@@ -23,7 +23,7 @@ class MCPServer {
 **Parameters:**
 - `config` (ServerConfig) - Server configuration object (name is required in config)
 
-**Returns:** `McpServerInstance` - Server instance with both MCP and Express methods
+**Returns:** `McpServerInstance` - Server instance with MCP server methods plus route/middleware helpers
 
 **Example:**
 ```typescript
@@ -103,7 +103,16 @@ interface ServerConfig {
   favicon?: string          // Favicon path relative to public/ directory (e.g., 'favicon.ico')
   host?: string             // Hostname for widget URLs and server endpoints (defaults to 'localhost')
   baseUrl?: string          // Full base URL (e.g., 'https://myserver.com') - overrides host:port for widget URLs
-  allowedOrigins?: string[] // Allowed origins for DNS rebinding protection
+  cors?: {
+    // Hono CORS middleware options
+    origin?: string | string[] | ((origin: string, c: unknown) => string | null | Promise<string | null>)
+    allowMethods?: string[]
+    allowHeaders?: string[]
+    exposeHeaders?: string[]
+    maxAge?: number
+    credentials?: boolean
+  }
+  allowedOrigins?: string[] // Allowed origin values (normalized to hostnames for global Host validation)
   sessionIdleTimeoutMs?: number     // Idle timeout for sessions in milliseconds (default: 86400000 = 1 day)
   autoCreateSessionOnInvalidId?: boolean // @deprecated Will be removed in a future version. Use sessionStore for persistent sessions.
 }
@@ -111,26 +120,28 @@ interface ServerConfig {
 
 **`allowedOrigins` Configuration:**
 
-The `allowedOrigins` option controls DNS rebinding protection behavior:
+The `allowedOrigins` option controls DNS rebinding host validation:
 
-- **Development mode** (NODE_ENV !== "production"):
-  - If not set: All origins are allowed (DNS rebinding protection disabled)
-  - This enables direct browser connections from any origin for easier development
+- **Default behavior** (`allowedOrigins` not set):
+  - Host validation is disabled
+  - All `Host` values are accepted
 
-- **Production mode** (NODE_ENV === "production"):
-  - If not set: DNS rebinding protection is disabled (not recommended for production)
-  - If set to empty array: DNS rebinding protection is disabled
-  - If set with origins: DNS rebinding protection is enabled with those specific origins
+- **When `allowedOrigins` is set**:
+  - Values are normalized to hostnames and used as the Host allow list
+  - Validation applies across the whole server
+
+- **When `allowedOrigins` is empty**:
+  - Host validation remains disabled
 
 **Example:**
 ```typescript
-// Development: No need to set (allows all origins)
+// Default behavior: host validation disabled
 const server = new MCPServer({
   name: 'my-server',
   version: '1.0.0'
 })
 
-// Production: Explicitly set allowed origins
+// Production: explicit allow list
 const server = new MCPServer({
   name: 'my-server',
   version: '1.0.0',
@@ -140,7 +151,6 @@ const server = new MCPServer({
   ]
 })
 ```
-
 
 ## Core Server Methods
 
@@ -506,11 +516,11 @@ interface AppsSdkMetadata {
 }
 ```
 
-## Express Integration
+## HTTP Route Integration
 
-The server instance proxies all Express methods, allowing you to use Express functionality directly:
+The server instance supports adding custom HTTP routes and middleware alongside MCP endpoints.
 
-### Common Express Methods
+### Common Route Methods
 
 ```typescript
 // HTTP route handlers
@@ -523,41 +533,31 @@ server.patch(path, ...handlers)
 // Middleware
 server.use(...middleware)
 
-// Static files
-server.use('/static', express.static('public'))
-
-// Route parameters
-server.param(name, callback)
-
-// Settings
-server.set(setting, value)
-server.get(setting)
+// Route-scoped middleware
+server.use('/api/*', async (c, next) => {
+  await next()
+})
 ```
 
-### Example Express Usage
+### Route + Middleware Example
 
 ```typescript
-import express from 'express'
+import { MCPServer } from 'mcp-use/server'
 
-// Body parsing middleware
-server.use(express.json())
-server.use(express.urlencoded({ extended: true }))
+const server = new MCPServer({
+  name: 'my-server',
+  version: '1.0.0',
+})
 
 // Custom middleware
-server.use((req, res, next) => {
-  console.log(`${req.method} ${req.path}`)
-  next()
+server.use('/api/*', async (c, next) => {
+  console.log(`${c.req.method} ${c.req.path}`)
+  await next()
 })
 
 // API routes
-server.get('/api/status', (req, res) => {
-  res.json({ status: 'ok' })
-})
-
-// Error handling
-server.use((err, req, res, next) => {
-  console.error(err.stack)
-  res.status(500).send('Something broke!')
+server.get('/api/status', (c) => {
+  return c.json({ status: 'ok' })
 })
 ```
 

--- a/docs/typescript/server/configuration.mdx
+++ b/docs/typescript/server/configuration.mdx
@@ -36,6 +36,10 @@ const server = new MCPServer({
   allowedOrigins: process.env.NODE_ENV === 'production' 
     ? ['https://myapp.com']      // Production: explicit origins
     : undefined,                 // Development: allows all origins
+  cors: {
+    origin: ['https://myapp.com'],
+    credentials: true
+  },                             // Optional CORS override
   sessionIdleTimeoutMs: 86400000,  // Session idle timeout (default: 1 day)
   autoCreateSessionOnInvalidId: true  // Auto-create session on invalid ID (default: true, compatible with ChatGPT)
 })
@@ -121,104 +125,49 @@ if (config.features.enableInspector) {
 server.listen(config.server.port)
 ```
 
-## Express Middleware Configuration
+## Middleware Configuration
 
-### CORS Configuration
+`MCPServer` is Hono-based and supports `server.use(...)` for adding middleware to custom routes.
 
-Configure Cross-Origin Resource Sharing:
+### CORS Customization
+
+By default, CORS is permissive (`origin: "*"`) for developer ergonomics. Override with `server` config when needed.
 
 ```typescript
-import cors from 'cors'
-
-// Custom CORS configuration
-server.use(cors({
-  origin: (origin, callback) => {
-    const allowedOrigins = [
-      'http://localhost:3000',
-      'https://app.example.com'
-    ]
-
-    if (!origin || allowedOrigins.includes(origin)) {
-      callback(null, true)
-    } else {
-      callback(new Error('Not allowed by CORS'))
-    }
-  },
-  credentials: true,
-  methods: ['GET', 'POST', 'DELETE', 'OPTIONS'],
-  allowedHeaders: ['Content-Type', 'Authorization', 'mcp-protocol-version']
-}))
+const server = new MCPServer({
+  name: 'my-server',
+  version: '1.0.0',
+  cors: {
+    origin: ['https://app.example.com'],
+    allowMethods: ['GET', 'POST', 'DELETE', 'OPTIONS'],
+    allowHeaders: ['Content-Type', 'Authorization', 'mcp-protocol-version'],
+    exposeHeaders: ['mcp-session-id']
+  }
+})
 ```
 
-### Rate Limiting
-
-Implement rate limiting for API protection:
+### Route-Scoped Middleware
 
 ```typescript
-import rateLimit from 'express-rate-limit'
+import { MCPServer } from 'mcp-use/server'
 
-// General rate limiter
-const limiter = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 100, // Limit each IP to 100 requests per windowMs
-  message: 'Too many requests from this IP'
+const server = new MCPServer({
+  name: 'my-server',
+  version: '1.0.0',
 })
 
-// Apply to all routes
-server.use('/api/', limiter)
-
-// Stricter limit for specific endpoints
-const strictLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  max: 10
-})
-
-server.use('/api/expensive-operation', strictLimiter)
-```
-
-### Authentication Middleware
-
-Add authentication to your server:
-
-```typescript
-// Basic API key authentication
-function authenticateApiKey(req, res, next) {
-  const apiKey = req.headers['x-api-key']
-
+server.use('/api/admin/*', async (c, next) => {
+  const apiKey = c.req.header('x-api-key')
   if (!apiKey || apiKey !== process.env.API_KEY) {
-    return res.status(401).json({ error: 'Unauthorized' })
+    return c.json({ error: 'Unauthorized' }, 401)
   }
-
-  next()
-}
-
-// Apply to specific routes
-server.use('/api/admin', authenticateApiKey)
-
-// JWT authentication
-import jwt from 'jsonwebtoken'
-
-function authenticateJWT(req, res, next) {
-  const token = req.headers.authorization?.split(' ')[1]
-
-  if (!token) {
-    return res.status(401).json({ error: 'No token provided' })
-  }
-
-  try {
-    const decoded = jwt.verify(token, process.env.JWT_SECRET)
-    req.user = decoded
-    next()
-  } catch (error) {
-    return res.status(403).json({ error: 'Invalid token' })
-  }
-}
-
-// Protected routes
-server.get('/api/protected', authenticateJWT, (req, res) => {
-  res.json({ user: req.user })
+  await next()
 })
 ```
+
+### DNS Rebinding Configuration
+
+Use the `allowedOrigins` server config property as the single way to enable DNS rebinding protection.
 
 ### Logging Configuration
 
@@ -264,34 +213,34 @@ For comprehensive logging configuration and log level details, see the [Server L
 
 ### DNS Rebinding Protection
 
-The server supports DNS rebinding protection through the `allowedOrigins` configuration option. This is important for security when exposing MCP servers over HTTP.
+The server supports DNS rebinding protection via host-header validation. This applies globally across server routes when enabled.
 
 **Development vs Production Behavior:**
 
-- **Development mode** (NODE_ENV !== "production"):
-  - If `allowedOrigins` is not set: All origins are allowed (DNS rebinding protection disabled)
-  - This enables direct browser connections from any origin for easier development
-  - Perfect for local development with tools like the MCP Inspector
+- **Default behavior** (`allowedOrigins` not set):
+  - DNS rebinding host validation is disabled (same behavior as before)
+  - All `Host` values are accepted
 
-- **Production mode** (NODE_ENV === "production"):
-  - If `allowedOrigins` is not set: DNS rebinding protection is disabled (not recommended)
-  - If set to empty array: DNS rebinding protection is disabled
-  - If set with origins: DNS rebinding protection is enabled with those specific origins
-  - **Always explicitly set allowed origins in production**
+- **Custom `allowedOrigins` set**:
+  - Values are normalized to hostnames and used as the allow list for `Host` validation
+  - Protection applies to all routes, including inspector and static assets
+  - Use this for explicit production allow lists
+
+- **Empty list** (`allowedOrigins: []`):
+  - DNS rebinding host validation remains disabled
 
 **Example Configuration:**
 
 ```typescript
 import { MCPServer } from 'mcp-use/server'
 
-// Development: No configuration needed (allows all origins)
+// Default behavior: no host validation
 const devServer = new MCPServer({
   name: 'dev-server',
   version: '1.0.0'
 })
-// Works with direct browser connections, inspector, etc.
 
-// Production: Explicitly set allowed origins
+// Production: explicit allow list
 const prodServer = new MCPServer({
   name: 'prod-server',
   version: '1.0.0',
@@ -301,7 +250,7 @@ const prodServer = new MCPServer({
     'https://admin.myapp.com'
   ]
 })
-// Only allows connections from these specific origins
+// Host header must match one of the configured hostnames
 
 // Environment-based configuration
 const server = new MCPServer({
@@ -309,19 +258,19 @@ const server = new MCPServer({
   version: '1.0.0',
   allowedOrigins: process.env.NODE_ENV === 'production'
     ? process.env.ALLOWED_ORIGINS?.split(',') || []
-    : undefined // Development: allow all origins
+    : undefined
 })
 ```
 
 **Security Best Practices:**
 
-1. **Always set `allowedOrigins` in production** - Never leave it undefined in production environments
+1. **Set `allowedOrigins` in production** - Do not rely on the default permissive behavior for public deployments
 2. **Use environment variables** - Store allowed origins in environment variables, not in code
-3. **Be specific** - Only include origins that actually need access
-4. **Include protocol** - Always specify the full origin including protocol (http/https)
-5. **Test in production mode** - Test your server with `NODE_ENV=production` to ensure proper origin validation
+3. **Be specific** - Only include hosts that actually need access
+4. **Include protocol in config values** - `allowedOrigins` accepts full origin values and normalizes them to hostnames
+5. **Test with spoofed Host headers** - Verify invalid hosts are rejected before deployment
 
-**Note:** The server exposes MCP endpoints at both `/mcp` and `/sse` for compatibility. Both endpoints respect the same `allowedOrigins` configuration.
+**Note:** If `allowedOrigins` is configured, host validation applies to the entire server.
 
 ### Session Management
 

--- a/docs/typescript/server/examples.mdx
+++ b/docs/typescript/server/examples.mdx
@@ -8,6 +8,22 @@ icon: "code"
 
 This page provides complete, production-ready examples of MCP servers built with the `mcp-use/server` framework. Each example demonstrates different capabilities and best practices.
 
+## DNS Rebinding Protection Example
+
+Use the dedicated DNS rebinding example to understand default permissive behavior and explicit `allowedOrigins` protection.
+
+**Example location:** `libraries/typescript/packages/mcp-use/examples/server/features/dns-rebinding`
+
+**Run from package root:**
+
+```bash
+pnpm run example:server:dns-rebinding
+```
+
+This example also includes copy-paste `curl` commands to verify:
+- spoofed `Host` is rejected (`403`)
+- valid localhost `Host` is accepted (`2xx`)
+
 ## Weather Service Server
 
 A complete weather information server with tools, resources, and UI widgets.

--- a/libraries/typescript/.changeset/slimy-rockets-clean.md
+++ b/libraries/typescript/.changeset/slimy-rockets-clean.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": minor
+---
+
+feat(server): added DNS rebinding protection support and updated documentation

--- a/libraries/typescript/packages/mcp-use/examples/server/features/conformance/src/server.ts
+++ b/libraries/typescript/packages/mcp-use/examples/server/features/conformance/src/server.ts
@@ -23,12 +23,19 @@ import {
 } from "mcp-use/server";
 import { z } from "zod";
 
+const SERVER_PORT = process.env.PORT || "3000";
+
 // Create server instance
 const server = new MCPServer({
   name: "ConformanceTestServer",
   version: "1.0.0",
   description:
     "MCP Conformance Test Server implementing all supported features.",
+  // Keep DNS rebinding protection enabled for conformance runs.
+  allowedOrigins: [
+    `http://localhost:${SERVER_PORT}`,
+    `http://127.0.0.1:${SERVER_PORT}`,
+  ],
 });
 
 // 1x1 red PNG pixel as base64

--- a/libraries/typescript/packages/mcp-use/examples/server/features/dns-rebinding/package.json
+++ b/libraries/typescript/packages/mcp-use/examples/server/features/dns-rebinding/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "dns-rebinding-example",
+  "type": "module",
+  "version": "1.0.0",
+  "description": "MCP server example demonstrating DNS rebinding protection options",
+  "author": "",
+  "license": "MIT",
+  "keywords": [
+    "mcp",
+    "server",
+    "example",
+    "dns-rebinding",
+    "security"
+  ],
+  "main": "dist/src/server.js",
+  "scripts": {
+    "build": "mcp-use build",
+    "dev": "mcp-use dev",
+    "start": "mcp-use start"
+  },
+  "dependencies": {
+    "mcp-use": "workspace:*",
+    "zod": "4.3.5"
+  },
+  "devDependencies": {
+    "@types/node": "^25.0.2"
+  }
+}

--- a/libraries/typescript/packages/mcp-use/examples/server/features/dns-rebinding/src/server.ts
+++ b/libraries/typescript/packages/mcp-use/examples/server/features/dns-rebinding/src/server.ts
@@ -1,0 +1,68 @@
+/**
+ * DNS Rebinding Protection Example
+ *
+ * Run:
+ *   pnpm dev
+ *   # Optional: enable protection
+ *   # ALLOWED_ORIGINS=http://localhost:3000 pnpm dev
+ *
+ * Quick checks (from this directory):
+ *   # If ALLOWED_ORIGINS includes localhost: expected HTTP 403
+ *   curl -i -H "Host: evil.example.com" -H "Origin: http://evil.example.com" \
+ *     -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
+ *     -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"dns-example","version":"1.0.0"}}}' \
+ *     http://localhost:3000/mcp
+ *
+ *   # Expected: HTTP 2xx
+ *   curl -i -H "Host: localhost:3000" -H "Origin: http://localhost:3000" \
+ *     -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
+ *     -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"dns-example","version":"1.0.0"}}}' \
+ *     http://localhost:3000/mcp
+ */
+
+import { MCPServer, text } from "mcp-use/server";
+
+const resolvedAllowedOrigins = process.env.ALLOWED_ORIGINS?.split(",")
+  .map((value) => value.trim())
+  .filter(Boolean);
+
+// Default behavior:
+// - without allowedOrigins: no host validation (same as previous behavior)
+// - with allowedOrigins: Host header must match configured hostnames (global)
+const server = new MCPServer({
+  name: "dns-rebinding-example",
+  version: "1.0.0",
+  description:
+    "Example server showing localhost auto-protection and explicit allowedOrigins in production.",
+  allowedOrigins:
+    resolvedAllowedOrigins && resolvedAllowedOrigins.length > 0
+      ? resolvedAllowedOrigins
+      : undefined,
+});
+
+server.tool(
+  {
+    name: "dns_rebinding_status",
+    description: "Show current DNS rebinding protection configuration.",
+  },
+  async () =>
+    text(
+      JSON.stringify(
+        {
+          nodeEnv: process.env.NODE_ENV ?? "development",
+          hostValidation:
+            resolvedAllowedOrigins && resolvedAllowedOrigins.length > 0
+              ? "enabled"
+              : "disabled",
+          allowedOrigins:
+            resolvedAllowedOrigins && resolvedAllowedOrigins.length > 0
+              ? resolvedAllowedOrigins
+              : "not configured",
+        },
+        null,
+        2
+      )
+    )
+);
+
+await server.listen();

--- a/libraries/typescript/packages/mcp-use/package.json
+++ b/libraries/typescript/packages/mcp-use/package.json
@@ -148,6 +148,7 @@
     "example:server:notification": "tsx examples/typescript/server/features/notifications/src/server.ts",
     "example:client:notification": "tsx examples/typescript/client/communication/notification-client.ts",
     "example:notifications": "lsof -ti:3000 | xargs kill -9 2>/dev/null; tsx examples/typescript/server/features/notifications/src/server.ts & sleep 3 && tsx examples/typescript/client/communication/notification-client.ts",
+    "example:server:dns-rebinding": "pnpm --dir examples/server/features/dns-rebinding dev",
     "example:server:sampling": "tsx examples/typescript/server/features/sampling/src/server.ts",
     "example:client:sampling": "tsx examples/typescript/client/communication/sampling-client.ts",
     "example:server:elicitation": "tsx examples/typescript/server/features/elicitation/src/server.ts",
@@ -226,6 +227,7 @@
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7",
     "react": "^19.2.3",
+    "react-test-renderer": "^19.2.4",
     "tsx": "^4.21.0",
     "vitest": "^4.0.17"
   },

--- a/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
@@ -1998,7 +1998,8 @@ class MCPServerClass<HasOAuth extends boolean = false> {
    * @param config.oauth - Optional OAuth provider configuration
    * @param config.stateless - Whether to use stateless mode (auto-detected for Deno)
    * @param config.sessionIdleTimeoutMs - Session idle timeout (default: 86400000 = 1 day)
-   * @param config.allowedOrigins - Allowed CORS origins (see {@link ServerConfig.allowedOrigins})
+   * @param config.cors - Optional CORS configuration overrides
+   * @param config.allowedOrigins - Allowed origins for DNS rebinding host validation
    *
    * @returns Proxied server instance supporting both MCP and Hono methods
    *
@@ -2120,7 +2121,10 @@ class MCPServerClass<HasOAuth extends boolean = false> {
     );
 
     // Create and configure Hono app with default middleware
-    this.app = createHonoApp(requestLogger);
+    this.app = createHonoApp(requestLogger, {
+      cors: this.config.cors,
+      allowedOrigins: this.config.allowedOrigins,
+    });
 
     // Install the custom routes middleware FIRST (before any other routes).
     // This single middleware dispatches from the mutable _customRoutes map,
@@ -3770,9 +3774,9 @@ export const MCPServer: MCPServerConstructor = MCPServerClass as any;
  * @param config.description - Server description
  * @param config.host - Hostname for widget URLs and server endpoints (defaults to 'localhost')
  * @param config.baseUrl - Full base URL (e.g., 'https://myserver.com') - overrides host:port for widget URLs
- * @param config.allowedOrigins - Allowed origins for DNS rebinding protection
- *   - **Development mode** (NODE_ENV !== "production"): If not set, all origins are allowed
- *   - **Production mode** (NODE_ENV === "production"): Only uses explicitly configured origins
+ * @param config.allowedOrigins - Allowed origins for DNS rebinding host validation (global when configured)
+ *   - If not set: host validation is disabled
+ *   - If set: host validation is enabled for all routes
  *   - See {@link ServerConfig.allowedOrigins} for detailed documentation
  * @param config.sessionIdleTimeoutMs - Idle timeout for sessions in milliseconds (default: 86400000 = 1 day)
  * @returns McpServerInstance with both MCP and Hono methods

--- a/libraries/typescript/packages/mcp-use/src/server/middleware/host-validation.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/middleware/host-validation.ts
@@ -1,0 +1,64 @@
+/**
+ * Host Header Validation Middleware
+ *
+ * DNS rebinding protection middleware for Hono-based MCP servers.
+ */
+
+import type { Context, Next } from "hono";
+
+function createJsonRpcErrorResponse(c: Context, message: string): Response {
+  return c.json(
+    {
+      jsonrpc: "2.0",
+      error: {
+        code: -32000,
+        message,
+      },
+      id: null,
+    },
+    403
+  );
+}
+
+function parseHostnameFromHostHeader(hostHeader: string): string | null {
+  try {
+    // URL parsing strips port and handles IPv6 host notation.
+    return new URL(`http://${hostHeader}`).hostname;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Create middleware that validates the Host header against an allow list.
+ *
+ * @param allowedHostnames - Hostnames allowed to access protected endpoints
+ * @returns Hono middleware
+ */
+export function hostHeaderValidation(allowedHostnames: string[]) {
+  const normalizedAllowedHostnames = allowedHostnames.map((hostname) =>
+    hostname.toLowerCase()
+  );
+
+  return async (c: Context, next: Next) => {
+    const hostHeader = c.req.header("Host");
+
+    if (!hostHeader) {
+      return createJsonRpcErrorResponse(c, "Missing Host header");
+    }
+
+    const hostname = parseHostnameFromHostHeader(hostHeader);
+    if (!hostname) {
+      return createJsonRpcErrorResponse(
+        c,
+        `Invalid Host header: ${hostHeader}`
+      );
+    }
+
+    if (!normalizedAllowedHostnames.includes(hostname.toLowerCase())) {
+      return createJsonRpcErrorResponse(c, `Invalid Host: ${hostname}`);
+    }
+
+    await next();
+  };
+}

--- a/libraries/typescript/packages/mcp-use/src/server/types/common.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/types/common.ts
@@ -3,6 +3,7 @@
  */
 
 import type { OAuthProvider } from "../oauth/providers/types.js";
+import type { cors } from "hono/cors";
 import type { z } from "zod";
 
 /**
@@ -42,26 +43,40 @@ export interface ServerConfig {
   host?: string; // Hostname for widget URLs and server endpoints (defaults to 'localhost')
   baseUrl?: string; // Full base URL (e.g., 'https://myserver.com') - overrides host:port for widget URLs
   /**
-   * Allowed origins for DNS rebinding protection
+   * Custom CORS options for the server.
    *
-   * **Development mode** (NODE_ENV !== "production"):
-   * - If not set: All origins are allowed (DNS rebinding protection disabled)
-   * - This enables direct browser connections from any origin for easier development
-   *
-   * **Production mode** (NODE_ENV === "production"):
-   * - If not set: DNS rebinding protection is disabled (not recommended for production)
-   * - If set to empty array: DNS rebinding protection is disabled
-   * - If set with origins: DNS rebinding protection is enabled with those specific origins
+   * By default, mcp-use enables permissive CORS (`origin: "*"`) for development ergonomics.
+   * Set this to customize allowed origins, headers, methods, credentials, etc.
    *
    * @example
    * ```typescript
-   * // Development: No need to set (allows all origins)
+   * const server = new MCPServer({
+   *   name: 'my-server',
+   *   version: '1.0.0',
+   *   cors: {
+   *     origin: ['https://app.mycompany.com'],
+   *     allowMethods: ['GET', 'POST', 'OPTIONS'],
+   *   },
+   * });
+   * ```
+   */
+  cors?: Partial<Parameters<typeof cors>[0]>;
+  /**
+   * Allowed origins for DNS rebinding protection
+   *
+   * - If not set: DNS rebinding protection is disabled (all Host values accepted)
+   * - If set to empty array: DNS rebinding protection is disabled
+   * - If set with origins: Host validation is enabled globally for the server
+   *
+   * @example
+   * ```typescript
+   * // Default behavior (no host validation)
    * const server = new MCPServer({
    *   name: 'my-server',
    *   version: '1.0.0'
    * });
    *
-   * // Production: Explicitly set allowed origins
+   * // Explicit protection (applies to all routes)
    * const server = new MCPServer({
    *   name: 'my-server',
    *   version: '1.0.0',

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -629,6 +629,9 @@ importers:
       react:
         specifier: ^19.2.0
         version: 19.2.4
+      react-test-renderer:
+        specifier: ^19.2.4
+        version: 19.2.4(react@19.2.4)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -741,6 +744,19 @@ importers:
       vite:
         specifier: ^7.3.0
         version: 7.3.1(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+
+  packages/mcp-use/examples/server/features/dns-rebinding:
+    dependencies:
+      mcp-use:
+        specifier: workspace:*
+        version: link:../../../..
+      zod:
+        specifier: 4.3.5
+        version: 4.3.5
+    devDependencies:
+      '@types/node':
+        specifier: ^25.0.2
+        version: 25.2.0
 
   packages/mcp-use/examples/server/features/elicitation:
     dependencies:
@@ -6031,6 +6047,9 @@ packages:
     peerDependencies:
       react: ^19.2.0
 
+  react-is@19.2.4:
+    resolution: {integrity: sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==}
+
   react-markdown@9.1.0:
     resolution: {integrity: sha512-xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw==}
     peerDependencies:
@@ -6106,6 +6125,11 @@ packages:
   react-syntax-highlighter@16.1.0:
     resolution: {integrity: sha512-E40/hBiP5rCNwkeBN1vRP+xow1X0pndinO+z3h7HLsHyjztbyjfzNWNKuAsJj+7DLam9iT4AaaOZnueCU+Nplg==}
     engines: {node: '>= 16.20.2'}
+    peerDependencies:
+      react: ^19.2.0
+
+  react-test-renderer@19.2.4:
+    resolution: {integrity: sha512-Ttl5D7Rnmi6JGMUpri4UjB4BAN0FPs4yRDnu2XSsigCWOLm11o8GwRlVsh27ER+4WFqsGtrBuuv5zumUaRCmKw==}
     peerDependencies:
       react: ^19.2.0
 
@@ -12736,6 +12760,8 @@ snapshots:
       react: 19.2.4
       scheduler: 0.27.0
 
+  react-is@19.2.4: {}
+
   react-markdown@9.1.0(@types/react@19.2.10)(react@19.2.4):
     dependencies:
       '@types/hast': 3.0.4
@@ -12818,6 +12844,12 @@ snapshots:
       prismjs: 1.30.0
       react: 19.2.4
       refractor: 5.0.0
+
+  react-test-renderer@19.2.4(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-is: 19.2.4
+      scheduler: 0.27.0
 
   react@19.2.4: {}
 


### PR DESCRIPTION
- Added `allowedOrigins` configuration to the `MCPServer` for DNS rebinding protection, enabling host validation for specified origins.
- Updated documentation to clarify the behavior of `allowedOrigins` in development and production environments.
- Introduced a new example demonstrating DNS rebinding protection, including curl commands for testing.
- Enhanced server methods and middleware to support the new host validation feature.
- Refactored related documentation to improve clarity on middleware and configuration options.
