### PR TITLE
chore(python): format adapter files for ruff 0.15 + remove docs PR comment spam

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -79,45 +79,6 @@ jobs:
             echo "✅ API documentation is up to date"
           fi
 
-      - name: Comment on PR
-        if: steps.check_docs.outputs.docs_outdated == 'true' && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const comment = `## ❌ API Documentation Out of Date
-
-            The API documentation needs to be regenerated. Please run the following commands:
-
-            \`\`\`bash
-            cd docs
-            python generate_docs.py ../libraries/python/mcp_use python/api-reference docs.json
-            \`\`\`
-
-            Then commit the changes:
-
-            \`\`\`bash
-            git add docs/
-            git commit -m "docs: update API documentation"
-            \`\`\`
-
-            <details>
-            <summary>Modified files</summary>
-
-            \`\`\`
-            ${process.env.MODIFIED_FILES}
-            \`\`\`
-            </details>`;
-
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: comment
-            });
-        env:
-          MODIFIED_FILES: ${{ steps.check_docs.outputs.modified_files }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Fail if docs are outdated
         if: steps.check_docs.outputs.docs_outdated == 'true'
         run: |

--- a/libraries/python/mcp_use/agents/adapters/anthropic.py
+++ b/libraries/python/mcp_use/agents/adapters/anthropic.py
@@ -41,8 +41,8 @@ class AnthropicMCPAdapter(BaseAdapter[dict[str, Any]]):
         if mcp_tool.name in self.disallowed_tools:
             return None
 
-        self.tool_executors[mcp_tool.name] = (
-            lambda connector=connector, name=mcp_tool.name, **kwargs: connector.call_tool(name, kwargs)
+        self.tool_executors[mcp_tool.name] = lambda connector=connector, name=mcp_tool.name, **kwargs: (
+            connector.call_tool(name, kwargs)
         )
 
         fixed_schema = self.fix_schema(mcp_tool.inputSchema)
@@ -55,8 +55,8 @@ class AnthropicMCPAdapter(BaseAdapter[dict[str, Any]]):
         if tool_name in self.disallowed_tools:
             return None
 
-        self.tool_executors[tool_name] = (
-            lambda connector=connector, uri=mcp_resource.uri, **kwargs: connector.read_resource(uri)
+        self.tool_executors[tool_name] = lambda connector=connector, uri=mcp_resource.uri, **kwargs: (
+            connector.read_resource(uri)
         )
 
         return {
@@ -70,8 +70,8 @@ class AnthropicMCPAdapter(BaseAdapter[dict[str, Any]]):
         if mcp_prompt.name in self.disallowed_tools:
             return None
 
-        self.tool_executors[mcp_prompt.name] = (
-            lambda connector=connector, name=mcp_prompt.name, **kwargs: connector.get_prompt(name, kwargs)
+        self.tool_executors[mcp_prompt.name] = lambda connector=connector, name=mcp_prompt.name, **kwargs: (
+            connector.get_prompt(name, kwargs)
         )
 
         properties = {}

--- a/libraries/python/mcp_use/agents/adapters/google.py
+++ b/libraries/python/mcp_use/agents/adapters/google.py
@@ -48,8 +48,8 @@ class GoogleMCPAdapter(BaseAdapter[types.FunctionDeclaration]):
         if mcp_tool.name in self.disallowed_tools:
             return None
 
-        self.tool_executors[mcp_tool.name] = (
-            lambda connector=connector, name=mcp_tool.name, **kwargs: connector.call_tool(name, kwargs)
+        self.tool_executors[mcp_tool.name] = lambda connector=connector, name=mcp_tool.name, **kwargs: (
+            connector.call_tool(name, kwargs)
         )
 
         fixed_schema = self.fix_schema(mcp_tool.inputSchema)
@@ -65,8 +65,8 @@ class GoogleMCPAdapter(BaseAdapter[types.FunctionDeclaration]):
         if tool_name in self.disallowed_tools:
             return None
 
-        self.tool_executors[tool_name] = (
-            lambda connector=connector, uri=mcp_resource.uri, **kwargs: connector.read_resource(uri)
+        self.tool_executors[tool_name] = lambda connector=connector, uri=mcp_resource.uri, **kwargs: (
+            connector.read_resource(uri)
         )
 
         function_declaration = types.FunctionDeclaration(
@@ -81,8 +81,8 @@ class GoogleMCPAdapter(BaseAdapter[types.FunctionDeclaration]):
         if mcp_prompt.name in self.disallowed_tools:
             return None
 
-        self.tool_executors[mcp_prompt.name] = (
-            lambda connector=connector, name=mcp_prompt.name, **kwargs: connector.get_prompt(name, kwargs)
+        self.tool_executors[mcp_prompt.name] = lambda connector=connector, name=mcp_prompt.name, **kwargs: (
+            connector.get_prompt(name, kwargs)
         )
 
         properties = {}

--- a/libraries/python/mcp_use/agents/adapters/openai.py
+++ b/libraries/python/mcp_use/agents/adapters/openai.py
@@ -41,8 +41,8 @@ class OpenAIMCPAdapter(BaseAdapter[dict[str, Any]]):
         if mcp_tool.name in self.disallowed_tools:
             return None
 
-        self.tool_executors[mcp_tool.name] = (
-            lambda connector=connector, name=mcp_tool.name, **kwargs: connector.call_tool(name, kwargs)
+        self.tool_executors[mcp_tool.name] = lambda connector=connector, name=mcp_tool.name, **kwargs: (
+            connector.call_tool(name, kwargs)
         )
 
         fixed_schema = self.fix_schema(mcp_tool.inputSchema)
@@ -63,8 +63,8 @@ class OpenAIMCPAdapter(BaseAdapter[dict[str, Any]]):
         if tool_name in self.disallowed_tools:
             return None
 
-        self.tool_executors[tool_name] = (
-            lambda connector=connector, uri=mcp_resource.uri, **kwargs: connector.read_resource(uri)
+        self.tool_executors[tool_name] = lambda connector=connector, uri=mcp_resource.uri, **kwargs: (
+            connector.read_resource(uri)
         )
 
         mcp_resource_desc = mcp_resource.description
@@ -83,8 +83,8 @@ class OpenAIMCPAdapter(BaseAdapter[dict[str, Any]]):
         if mcp_prompt.name in self.disallowed_tools:
             return None
 
-        self.tool_executors[mcp_prompt.name] = (
-            lambda connector=connector, name=mcp_prompt.name, **kwargs: connector.get_prompt(name, kwargs)
+        self.tool_executors[mcp_prompt.name] = lambda connector=connector, name=mcp_prompt.name, **kwargs: (
+            connector.get_prompt(name, kwargs)
         )
 
         # Preparing JSON schema for prompt arguments


### PR DESCRIPTION
## Changes
- Format 3 adapter files to match ruff 0.15 (CI linter version)
- Remove the PR comment step from docs.yml that created a new comment on every push

No functional changes.