### PR TITLE
feat(python): conformance test infrastructure for server + client

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -17,10 +17,12 @@ on:
       - canary
     paths:
       - 'libraries/python/mcp_use/server/**'
+      - 'libraries/python/mcp_use/client/**'
       - 'libraries/python/pyproject.toml'
       - 'libraries/typescript/packages/mcp-use/src/server/**'
       - 'libraries/typescript/packages/mcp-use/package.json'
       - 'libraries/python/tests/integration/servers_for_testing/conformance_server.py'
+      - 'libraries/python/tests/integration/clients_for_testing/conformance_client.py'
       - 'libraries/typescript/packages/mcp-use/examples/server/features/conformance/**'
       - '.github/workflows/conformance.yml'
   pull_request:
@@ -29,10 +31,12 @@ on:
       - canary
     paths:
       - 'libraries/python/mcp_use/server/**'
+      - 'libraries/python/mcp_use/client/**'
       - 'libraries/python/pyproject.toml'
       - 'libraries/typescript/packages/mcp-use/src/server/**'
       - 'libraries/typescript/packages/mcp-use/package.json'
       - 'libraries/python/tests/integration/servers_for_testing/conformance_server.py'
+      - 'libraries/python/tests/integration/clients_for_testing/conformance_client.py'
       - 'libraries/typescript/packages/mcp-use/examples/server/features/conformance/**'
       - '.github/workflows/conformance.yml'
 
@@ -42,7 +46,7 @@ jobs:
   conformance-test:
     name: Run Conformance Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
 
     steps:
       - name: Checkout repository
@@ -68,7 +72,7 @@ jobs:
         with:
           version: 10
 
-      - name: Prepare Python server
+      - name: Prepare Python
         if: ${{ github.event_name != 'workflow_dispatch' || !inputs.typescript_only }}
         working-directory: libraries/python
         run: |
@@ -104,12 +108,24 @@ jobs:
           SERVERS+=']'
           echo "servers=$SERVERS" >> $GITHUB_OUTPUT
 
+      - name: Build client list
+        id: build-clients
+        run: |
+          CLIENTS='['
+          if [ "${{ github.event_name }}" != "workflow_dispatch" ] || [ "${{ inputs.typescript_only }}" != "true" ]; then
+            CLIENTS+='{"name":"python-client","command":".venv/bin/python tests/integration/clients_for_testing/conformance_client.py","working-directory":"libraries/python"}'
+          fi
+          CLIENTS+=']'
+          echo "clients=$CLIENTS" >> $GITHUB_OUTPUT
+
       - name: Run conformance tests
         uses: mcp-use/mcp-conformance-action@v1
         env:
           MCP_USE_ANONYMIZED_TELEMETRY: false
         with:
           mode: test
+          test-type: both
           servers: ${{ steps.build-servers.outputs.servers }}
+          clients: ${{ steps.build-clients.outputs.clients }}
           badge-gist-id: ${{ secrets.CONFORMANCE_GIST_ID }}
           badge-gist-token: ${{ secrets.GIST_SECRET }}

--- a/libraries/python/tests/integration/clients_for_testing/conformance_client.py
+++ b/libraries/python/tests/integration/clients_for_testing/conformance_client.py
@@ -1,0 +1,206 @@
+"""
+MCP Conformance Test Client (Python)
+
+A client that exercises all MCP protocol features for conformance testing.
+Uses MCPClient for all scenarios to validate the mcp-use client SDK.
+
+The conformance test framework starts a test server and passes its URL as argv[1].
+The scenario name is in the MCP_CONFORMANCE_SCENARIO env var.
+
+Usage: python conformance_client.py <server_url>
+"""
+
+import asyncio
+import os
+import sys
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+from mcp.client.auth import OAuthClientProvider
+from mcp.client.auth.oauth2 import OAuthClientMetadata
+from mcp.types import ElicitRequestParams, ElicitResult
+
+from mcp_use import MCPClient
+
+# =============================================================================
+# Headless OAuth provider for conformance test servers (auto-approve)
+# =============================================================================
+
+
+class InMemoryTokenStorage:
+    """Simple in-memory token storage for conformance tests."""
+
+    def __init__(self):
+        self._tokens = {}
+
+    async def get_tokens(self):
+        return self._tokens.get("default")
+
+    async def set_tokens(self, tokens):
+        self._tokens["default"] = tokens
+
+    async def get_client_info(self):
+        return self._tokens.get("client_info")
+
+    async def set_client_info(self, client_info):
+        self._tokens["client_info"] = client_info
+
+
+def create_headless_oauth_provider(server_url: str) -> OAuthClientProvider:
+    """Create an OAuthClientProvider that handles auth headlessly.
+
+    Conformance test servers auto-approve authorization requests, so the
+    redirect_handler follows the auth URL via httpx (instead of opening a browser)
+    and the callback_handler extracts the code from the redirect.
+
+    This is passed directly to MCPClient as an httpx.Auth instance.
+    """
+    auth_code_future: asyncio.Future | None = None
+
+    async def redirect_handler(authorization_url: str) -> None:
+        nonlocal auth_code_future
+        auth_code_future = asyncio.get_event_loop().create_future()
+
+        try:
+            async with httpx.AsyncClient(follow_redirects=False) as client:
+                response = await client.get(authorization_url)
+
+                if response.status_code in (301, 302, 303, 307, 308):
+                    redirect_url = str(response.headers["location"])
+                    parsed = urlparse(redirect_url)
+                    params = parse_qs(parsed.query)
+                    code = params.get("code", [None])[0]
+                    state = params.get("state", [None])[0]
+                    if code:
+                        auth_code_future.set_result((code, state))
+                        return
+
+            auth_code_future.set_exception(Exception("No auth code in redirect"))
+        except Exception as e:
+            if auth_code_future and not auth_code_future.done():
+                auth_code_future.set_exception(e)
+
+    async def callback_handler() -> tuple[str, str | None]:
+        if auth_code_future is None:
+            raise Exception("redirect_handler was not called")
+        return await auth_code_future
+
+    return OAuthClientProvider(
+        server_url=server_url,
+        client_metadata=OAuthClientMetadata(
+            client_name="mcp-use-conformance-client",
+            redirect_uris=["http://127.0.0.1:19823/callback"],
+            grant_types=["authorization_code", "refresh_token"],
+            response_types=["code"],
+            token_endpoint_auth_method="client_secret_post",
+        ),
+        storage=InMemoryTokenStorage(),
+        redirect_handler=redirect_handler,
+        callback_handler=callback_handler,
+        timeout=10.0,
+    )
+
+
+# =============================================================================
+# Elicitation callback
+# =============================================================================
+
+
+async def handle_elicitation(_ctx, params: ElicitRequestParams) -> ElicitResult:
+    """Accept elicitation requests, applying schema defaults from the server."""
+    content = {}
+    if hasattr(params, "requestedSchema") and params.requestedSchema:
+        schema = params.requestedSchema
+        properties = schema.get("properties", {}) if isinstance(schema, dict) else {}
+        for field_name, field_schema in properties.items():
+            if isinstance(field_schema, dict) and "default" in field_schema:
+                content[field_name] = field_schema["default"]
+    return ElicitResult(action="accept", content=content)
+
+
+# =============================================================================
+# Scenario handlers
+# =============================================================================
+
+
+async def run_initialize(_session):
+    """Just connect and initialize — the framework validates the handshake."""
+    pass
+
+
+async def run_tools_call(session):
+    """List tools and call each one."""
+    tools = await session.list_tools()
+    for tool in tools:
+        args = {}
+        schema = tool.inputSchema or {}
+        properties = schema.get("properties", {})
+        for param_name, param_schema in properties.items():
+            param_type = param_schema.get("type", "string")
+            if param_type in ("number", "integer"):
+                args[param_name] = 1
+            elif param_type == "boolean":
+                args[param_name] = True
+            else:
+                args[param_name] = "test"
+        try:
+            await session.call_tool(name=tool.name, arguments=args)
+        except Exception:
+            pass
+
+
+async def run_elicitation_defaults(session):
+    """Call elicitation tools — the framework checks that client returns defaults."""
+    tools = await session.list_tools()
+    for tool in tools:
+        if "elicit" not in (tool.name or "").lower():
+            continue
+        try:
+            await session.call_tool(name=tool.name, arguments={})
+        except Exception:
+            pass
+
+
+# =============================================================================
+# Main
+# =============================================================================
+
+
+async def main():
+    if len(sys.argv) < 2:
+        print("Usage: python conformance_client.py <server_url>", file=sys.stderr)
+        sys.exit(1)
+
+    server_url = sys.argv[1]
+    scenario = os.environ.get("MCP_CONFORMANCE_SCENARIO", "")
+
+    # Build config — auth scenarios pass a headless OAuthClientProvider as httpx.Auth
+    server_config: dict = {"url": server_url}
+    if scenario.startswith("auth/"):
+        server_config["auth"] = create_headless_oauth_provider(server_url)
+
+    config = {"mcpServers": {"test": server_config}}
+    client = MCPClient(config=config, elicitation_callback=handle_elicitation)
+
+    try:
+        await client.create_all_sessions()
+        session = client.get_session("test")
+
+        if scenario == "initialize":
+            await run_initialize(session)
+        elif scenario == "tools_call":
+            await run_tools_call(session)
+        elif scenario == "elicitation-sep1034-client-defaults":
+            await run_elicitation_defaults(session)
+        elif scenario == "sse-retry":
+            await asyncio.sleep(5)
+        elif scenario.startswith("auth/"):
+            pass  # The framework validates OAuth protocol exchanges
+        else:
+            await run_tools_call(session)
+    finally:
+        await client.close_all_sessions()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/libraries/python/tests/integration/servers_for_testing/conformance_server.py
+++ b/libraries/python/tests/integration/servers_for_testing/conformance_server.py
@@ -7,12 +7,16 @@ Run with: python conformance_server.py --transport streamable-http
 """
 
 import argparse
+import asyncio
 import base64
 import json
 from dataclasses import dataclass
 from typing import get_args
 
+from mcp.server.fastmcp.prompts.base import UserMessage
 from mcp.types import (
+    AudioContent,
+    Completion,
     EmbeddedResource,
     ImageContent,
     SamplingMessage,
@@ -28,7 +32,33 @@ mcp = MCPServer(
     name="ConformanceTestServer",
     version="1.0.0",
     instructions="MCP Conformance Test Server implementing all supported features.",
+    dns_rebinding_protection=True,
 )
+
+# =============================================================================
+# Override completion handler with custom completions for this server
+# (logging/setLevel, subscribe/unsubscribe are auto-registered by MCPServer)
+# =============================================================================
+
+
+@mcp.completion()
+async def handle_completion(ref, argument, context=None):
+    """Return completions for resource template parameters and prompt arguments."""
+    # Completions for resource template parameters
+    if hasattr(ref, "uri") and "template" in str(getattr(ref, "uri", "")):
+        if argument.name == "id":
+            values = [v for v in ["foo", "bar", "baz", "qux"] if v.startswith(argument.value)]
+            return Completion(values=values, total=len(values), hasMore=False)
+    # Completions for prompt arguments
+    if hasattr(ref, "name"):
+        if argument.name == "arg1":
+            values = [v for v in ["default1", "option1"] if v.startswith(argument.value)]
+            return Completion(values=values, total=len(values), hasMore=False)
+        if argument.name == "arg2":
+            values = [v for v in ["default2", "option2"] if v.startswith(argument.value)]
+            return Completion(values=values, total=len(values), hasMore=False)
+    return Completion(values=[], total=0, hasMore=False)
+
 
 # =============================================================================
 # TOOLS (exact names expected by conformance tests)
@@ -111,6 +141,9 @@ RED_PIXEL_PNG = base64.b64encode(
     )
 ).decode("ascii")
 
+# Minimal valid WAV file: 44-byte header + 1 sample (silence for 8-bit PCM)
+SILENT_WAV_BASE64 = "UklGRiYAAABXQVZFZm10IBAAAAABAAEAQB8AAAB9AAABAAgAZGF0YQIAAACA"
+
 
 # tools-call-simple-text
 @mcp.tool(name="test_simple_text")
@@ -119,14 +152,21 @@ def test_simple_text(message: str = "Hello, World!") -> str:
     return f"Echo: {message}"
 
 
-# tools-call-image - Return ImageContent directly
-@mcp.tool(name="test_image")
-async def test_image() -> ImageContent:
+# tools-call-image (conformance expects: test_image_content)
+@mcp.tool(name="test_image_content")
+async def test_image_content() -> ImageContent:
     """A tool that returns image content."""
     return ImageContent(type="image", data=RED_PIXEL_PNG, mimeType="image/png")
 
 
-# tools-call-embedded-resource - Return EmbeddedResource directly
+# tools-call-audio (conformance expects: test_audio_content)
+@mcp.tool(name="test_audio_content")
+async def test_audio_content() -> AudioContent:
+    """A tool that returns audio content."""
+    return AudioContent(type="audio", data=SILENT_WAV_BASE64, mimeType="audio/wav")
+
+
+# tools-call-embedded-resource
 @mcp.tool(name="test_embedded_resource")
 async def test_embedded_resource() -> EmbeddedResource:
     """A tool that returns an embedded resource."""
@@ -140,32 +180,40 @@ async def test_embedded_resource() -> EmbeddedResource:
     )
 
 
-# tools-call-mixed-content - Return list of content types
-@mcp.tool(name="test_mixed_content")
-async def test_mixed_content() -> list:
-    """A tool that returns mixed content (text + image)."""
+# tools-call-mixed-content (conformance expects: test_multiple_content_types)
+@mcp.tool(name="test_multiple_content_types")
+async def test_multiple_content_types() -> list:
+    """A tool that returns mixed content (text + image + resource)."""
     return [
-        TextContent(type="text", text="Here is some text content"),
+        TextContent(type="text", text="Multiple content types test:"),
         ImageContent(type="image", data=RED_PIXEL_PNG, mimeType="image/png"),
+        EmbeddedResource(
+            type="resource",
+            resource=TextResourceContents(
+                uri="test://mixed-content-resource",
+                mimeType="application/json",
+                text=json.dumps({"test": "data", "value": 123}),
+            ),
+        ),
     ]
 
 
-# tools-call-with-logging
-@mcp.tool(name="test_logging")
-async def test_logging(ctx: Context) -> str:
-    """A tool that emits log messages at various levels."""
-    await ctx.debug("Debug message from tool")
-    await ctx.info("Info message from tool")
-    await ctx.warning("Warning message from tool")
-    return "Logging completed"
+# tools-call-with-logging (conformance expects: test_tool_with_logging)
+@mcp.tool(name="test_tool_with_logging")
+async def test_tool_with_logging(ctx: Context) -> str:
+    """A tool that sends log messages during execution."""
+    await ctx.info("Tool execution started")
+    await asyncio.sleep(0.05)
+    await ctx.info("Tool processing data")
+    await asyncio.sleep(0.05)
+    await ctx.info("Tool execution completed")
+    return "Tool execution completed with logging"
 
 
 # tools-call-with-progress (steps is optional with default)
 @mcp.tool(name="test_tool_with_progress")
 async def test_tool_with_progress(ctx: Context, steps: int = 5) -> str:
     """A tool that reports progress."""
-    import asyncio
-
     for i in range(steps):
         await ctx.report_progress(progress=i + 1, total=steps)
         await asyncio.sleep(0.01)
@@ -200,6 +248,97 @@ async def test_elicitation(ctx: Context) -> str:
     elif result.action == "decline":
         return "User declined"
     return "Operation cancelled"
+
+
+# tools-call-elicitation-sep1034-defaults
+# Uses raw JSON Schema via session.elicit_form() because the upstream MCP SDK
+# validation rejects Literal types needed for enum fields
+@mcp.tool(name="test_elicitation_sep1034_defaults")
+async def test_elicitation_sep1034_defaults(ctx: Context) -> str:
+    """A tool that uses elicitation with default values for all primitive types (SEP-1034)."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string", "default": "John Doe"},
+            "age": {"type": "integer", "default": 30},
+            "score": {"type": "number", "default": 95.5},
+            "status": {
+                "type": "string",
+                "enum": ["active", "inactive", "pending"],
+                "default": "active",
+            },
+            "verified": {"type": "boolean", "default": True},
+        },
+    }
+    session = ctx.request_context.session
+    result = await session.elicit_form(
+        message="Please provide your information",
+        requestedSchema=schema,
+        related_request_id=ctx.request_id,
+    )
+    if result.action == "accept":
+        return f"Elicitation completed: action=accept, content={json.dumps(result.content)}"
+    elif result.action == "decline":
+        return "Elicitation completed: action=decline"
+    return "Elicitation completed: action=cancel"
+
+
+# tools-call-elicitation-sep1330-enums (requires raw JSON Schema for complex enum variants)
+@mcp.tool(name="test_elicitation_sep1330_enums")
+async def test_elicitation_sep1330_enums(ctx: Context) -> str:
+    """A tool that uses elicitation with all 5 SEP-1330 enum variants."""
+    # Build the exact JSON Schema the conformance test expects
+    schema = {
+        "type": "object",
+        "properties": {
+            "untitledSingle": {
+                "type": "string",
+                "enum": ["option1", "option2", "option3"],
+            },
+            "titledSingle": {
+                "type": "string",
+                "oneOf": [
+                    {"const": "value1", "title": "First Option"},
+                    {"const": "value2", "title": "Second Option"},
+                    {"const": "value3", "title": "Third Option"},
+                ],
+            },
+            "legacyEnum": {
+                "type": "string",
+                "enum": ["opt1", "opt2", "opt3"],
+                "enumNames": ["Option One", "Option Two", "Option Three"],
+            },
+            "untitledMulti": {
+                "type": "array",
+                "items": {
+                    "type": "string",
+                    "enum": ["option1", "option2", "option3"],
+                },
+            },
+            "titledMulti": {
+                "type": "array",
+                "items": {
+                    "anyOf": [
+                        {"const": "value1", "title": "First Choice"},
+                        {"const": "value2", "title": "Second Choice"},
+                        {"const": "value3", "title": "Third Choice"},
+                    ],
+                },
+            },
+        },
+    }
+    # Use low-level session.elicit_form() for raw JSON Schema
+    session = ctx.request_context.session
+    result = await session.elicit_form(
+        message="Please select your preferences",
+        requestedSchema=schema,
+        related_request_id=ctx.request_id,
+    )
+    if result.action == "accept":
+        return f"Elicitation completed: action=accept, content={json.dumps(result.content)}"
+    elif result.action == "decline":
+        return "Elicitation completed: action=decline"
+    return "Elicitation completed: action=cancel"
 
 
 # tools-call-error
@@ -240,9 +379,30 @@ def get_template_resource(id: str) -> str:
     return json.dumps({"id": id, "data": f"Data for {id}"})
 
 
+# resources-subscribe / resources-unsubscribe
+# Subscribe/unsubscribe are handled by MCPServer automatically.
+# notify_resource_updated broadcasts to all subscribed sessions.
+
+_subscribable_value = "Initial value"
+
+
+@mcp.resource(uri="test://subscribable", name="subscribable_resource", mime_type="text/plain")
+def get_subscribable_resource() -> str:
+    """A resource that supports subscriptions and can be updated."""
+    return _subscribable_value
+
+
+@mcp.tool(name="update_subscribable_resource")
+async def update_subscribable_resource(newValue: str = "Updated value") -> str:
+    """Update the subscribable resource and notify subscribers."""
+    global _subscribable_value
+    _subscribable_value = newValue
+    await mcp.notify_resource_updated("test://subscribable")
+    return f"Resource updated to: {newValue}"
+
+
 # =============================================================================
 # PROMPTS (exact names expected by conformance tests)
-# All parameters are optional with defaults for conformance tests
 # =============================================================================
 
 
@@ -253,26 +413,28 @@ def test_simple_prompt() -> str:
     return "This is a simple prompt without any arguments."
 
 
-# prompts-get-with-args (parameters optional with defaults)
+# prompts-get-with-args (conformance expects arg1/arg2, not topic/style)
 @mcp.prompt(name="test_prompt_with_arguments", description="A prompt that accepts arguments")
-def test_prompt_with_arguments(topic: str = "general", style: str = "formal") -> str:
-    """A prompt that generates content about a topic in a specific style."""
-    return f"Please write about {topic} in a {style} style."
+def test_prompt_with_arguments(arg1: str = "default1", arg2: str = "default2") -> str:
+    """A prompt that generates content with arguments."""
+    return f"Prompt with arguments: arg1='{arg1}', arg2='{arg2}'"
 
 
-# prompts-get-embedded-resource (resourceUri parameter for conformance test)
+# prompts-get-embedded-resource
 @mcp.prompt(name="test_prompt_with_embedded_resource", description="A prompt with embedded resource")
 def test_prompt_with_embedded_resource(resourceUri: str = "config://embedded") -> list:
     """A prompt that includes an embedded resource."""
     return [
-        TextContent(type="text", text="Here is the configuration:"),
-        EmbeddedResource(
-            type="resource",
-            resource=TextResourceContents(
-                uri=resourceUri,
-                mimeType="application/json",
-                text='{"setting": "value"}',
-            ),
+        UserMessage(content=TextContent(type="text", text="Here is the configuration:")),
+        UserMessage(
+            content=EmbeddedResource(
+                type="resource",
+                resource=TextResourceContents(
+                    uri=resourceUri,
+                    mimeType="application/json",
+                    text='{"setting": "value"}',
+                ),
+            )
         ),
     ]
 
@@ -282,8 +444,8 @@ def test_prompt_with_embedded_resource(resourceUri: str = "config://embedded") -
 def test_prompt_with_image() -> list:
     """A prompt that includes image content."""
     return [
-        TextContent(type="text", text="Here is a test image:"),
-        ImageContent(type="image", data=RED_PIXEL_PNG, mimeType="image/png"),
+        UserMessage(content=TextContent(type="text", text="Here is a test image:")),
+        UserMessage(content=ImageContent(type="image", data=RED_PIXEL_PNG, mimeType="image/png")),
     ]
 
 
@@ -309,10 +471,5 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     print(f"Starting MCP Conformance Test Server with transport: {args.transport}")
-    print("Tools: test_simple_text, test_image, test_embedded_resource, test_mixed_content,")
-    print("       test_logging, test_tool_with_progress, test_sampling, test_elicitation, test_error_handling")
-    print("Resources: test://static-text, test://static-binary, test://template/{id}/data")
-    print("Prompts: test_simple_prompt, test_prompt_with_arguments,")
-    print("         test_prompt_with_embedded_resource, test_prompt_with_image")
 
-    mcp.run(transport=args.transport, host="127.0.0.1", port=args.port)
+    mcp.run(transport=args.transport, port=args.port)

--- a/libraries/python/tests/integration/test_conformance.py
+++ b/libraries/python/tests/integration/test_conformance.py
@@ -1,0 +1,306 @@
+"""
+MCP Conformance Integration Tests
+
+Tests the mcp-use Python SDK against the official MCP conformance test suite.
+Starts the conformance server, then validates both server-side protocol compliance
+(via the external conformance runner) and client-side behavior (via MCPClient).
+"""
+
+import asyncio
+import socket
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from mcp.client.session import RequestContext
+from mcp.types import ElicitRequestParams, ElicitResult
+
+from mcp_use.client import MCPClient
+
+CONFORMANCE_SERVER_PATH = Path(__file__).parent / "servers_for_testing" / "conformance_server.py"
+CONFORMANCE_CLIENT_PATH = Path(__file__).parent / "clients_for_testing" / "conformance_client.py"
+SERVER_PORT = 8765  # Use a non-default port to avoid conflicts
+
+
+async def _wait_for_server(host: str, port: int, timeout: float = 10.0) -> None:
+    """Poll TCP port until the server is accepting connections."""
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        try:
+            sock = socket.create_connection((host, port), timeout=0.5)
+            sock.close()
+            return
+        except OSError:
+            await asyncio.sleep(0.2)
+    raise TimeoutError(f"Server on {host}:{port} did not start within {timeout}s")
+
+
+@pytest.fixture(scope="module")
+async def conformance_server():
+    """Start the conformance server as a subprocess."""
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            str(CONFORMANCE_SERVER_PATH),
+            "--transport",
+            "streamable-http",
+            "--port",
+            str(SERVER_PORT),
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        env={**__import__("os").environ, "MCP_USE_ANONYMIZED_TELEMETRY": "false"},
+    )
+
+    await _wait_for_server("127.0.0.1", SERVER_PORT)
+
+    yield f"http://127.0.0.1:{SERVER_PORT}"
+
+    if process.poll() is None:
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()
+
+
+# =============================================================================
+# Server conformance (external runner)
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_server_conformance_via_runner(conformance_server):
+    """Run the official MCP conformance test suite against our server.
+
+    This executes `npx @modelcontextprotocol/conformance server` and asserts
+    zero failures across all active scenarios.
+    """
+    result = subprocess.run(
+        [
+            "npx",
+            "@modelcontextprotocol/conformance",
+            "server",
+            "--url",
+            f"{conformance_server}/mcp",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+
+    # Parse the summary line: "Total: X passed, Y failed"
+    for line in result.stdout.splitlines():
+        if line.startswith("Total:"):
+            parts = line.split(",")
+            failed = int(parts[1].strip().split()[0])
+            assert failed == 0, f"Server conformance failures:\n{result.stdout}"
+            return
+
+    # If we didn't find the Total line, the runner may have crashed
+    pytest.fail(f"Could not parse conformance output:\nstdout: {result.stdout}\nstderr: {result.stderr}")
+
+
+@pytest.mark.asyncio
+async def test_client_conformance_via_runner():
+    """Run the official MCP conformance client tests against our MCPClient.
+
+    Tests core (non-auth) client scenarios: initialize, tools_call,
+    elicitation defaults, and SSE retry.
+    """
+    scenarios = ["initialize", "tools_call", "elicitation-sep1034-client-defaults", "sse-retry"]
+    failures = []
+
+    for scenario in scenarios:
+        result = subprocess.run(
+            [
+                "npx",
+                "@modelcontextprotocol/conformance",
+                "client",
+                "--command",
+                f"{sys.executable} {CONFORMANCE_CLIENT_PATH}",
+                "--scenario",
+                scenario,
+                "--timeout",
+                "30000",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env={**__import__("os").environ, "MCP_USE_ANONYMIZED_TELEMETRY": "false"},
+        )
+
+        if "FAILED" in result.stdout:
+            failures.append(f"{scenario}: {result.stdout}")
+
+    assert not failures, f"Client conformance failures:\n{''.join(failures)}"
+
+
+# =============================================================================
+# Client-side conformance (direct MCPClient tests against conformance server)
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_client_initialize(conformance_server):
+    """Client connects and initializes successfully."""
+    config = {"mcpServers": {"test": {"url": f"{conformance_server}/mcp"}}}
+    client = MCPClient(config=config)
+    try:
+        await client.create_all_sessions()
+        session = client.get_session("test")
+        assert session is not None
+        assert session.is_connected
+    finally:
+        await client.close_all_sessions()
+
+
+@pytest.mark.asyncio
+async def test_client_list_tools(conformance_server):
+    """Client lists all tools from the conformance server."""
+    config = {"mcpServers": {"test": {"url": f"{conformance_server}/mcp"}}}
+    client = MCPClient(config=config)
+    try:
+        await client.create_all_sessions()
+        session = client.get_session("test")
+        tools = await session.list_tools()
+        tool_names = {t.name for t in tools}
+
+        expected = {
+            "test_simple_text",
+            "test_image_content",
+            "test_audio_content",
+            "test_embedded_resource",
+            "test_multiple_content_types",
+            "test_tool_with_logging",
+            "test_tool_with_progress",
+            "test_sampling",
+            "test_elicitation",
+            "test_elicitation_sep1034_defaults",
+            "test_elicitation_sep1330_enums",
+            "test_error_handling",
+            "update_subscribable_resource",
+        }
+        assert expected.issubset(tool_names), f"Missing tools: {expected - tool_names}"
+    finally:
+        await client.close_all_sessions()
+
+
+@pytest.mark.asyncio
+async def test_client_call_simple_text_tool(conformance_server):
+    """Client calls a simple text tool and gets the correct response."""
+    config = {"mcpServers": {"test": {"url": f"{conformance_server}/mcp"}}}
+    client = MCPClient(config=config)
+    try:
+        await client.create_all_sessions()
+        session = client.get_session("test")
+        result = await session.call_tool("test_simple_text", {"message": "conformance"})
+        assert result.content[0].text == "Echo: conformance"
+    finally:
+        await client.close_all_sessions()
+
+
+@pytest.mark.asyncio
+async def test_client_list_resources(conformance_server):
+    """Client lists all resources from the conformance server."""
+    config = {"mcpServers": {"test": {"url": f"{conformance_server}/mcp"}}}
+    client = MCPClient(config=config)
+    try:
+        await client.create_all_sessions()
+        session = client.get_session("test")
+        resources = await session.list_resources()
+        resource_names = {r.name for r in resources}
+        assert "static_text" in resource_names
+        assert "static_binary" in resource_names
+        assert "subscribable_resource" in resource_names
+    finally:
+        await client.close_all_sessions()
+
+
+@pytest.mark.asyncio
+async def test_client_read_text_resource(conformance_server):
+    """Client reads a text resource."""
+    config = {"mcpServers": {"test": {"url": f"{conformance_server}/mcp"}}}
+    client = MCPClient(config=config)
+    try:
+        await client.create_all_sessions()
+        session = client.get_session("test")
+        result = await session.read_resource("test://static-text")
+        assert result.contents[0].text == "This is static text content"
+    finally:
+        await client.close_all_sessions()
+
+
+@pytest.mark.asyncio
+async def test_client_list_prompts(conformance_server):
+    """Client lists all prompts from the conformance server."""
+    config = {"mcpServers": {"test": {"url": f"{conformance_server}/mcp"}}}
+    client = MCPClient(config=config)
+    try:
+        await client.create_all_sessions()
+        session = client.get_session("test")
+        prompts = await session.list_prompts()
+        prompt_names = {p.name for p in prompts}
+        assert "test_simple_prompt" in prompt_names
+        assert "test_prompt_with_arguments" in prompt_names
+    finally:
+        await client.close_all_sessions()
+
+
+@pytest.mark.asyncio
+async def test_client_get_prompt(conformance_server):
+    """Client gets a prompt with arguments."""
+    config = {"mcpServers": {"test": {"url": f"{conformance_server}/mcp"}}}
+    client = MCPClient(config=config)
+    try:
+        await client.create_all_sessions()
+        session = client.get_session("test")
+        result = await session.get_prompt("test_prompt_with_arguments", arguments={"arg1": "hello", "arg2": "world"})
+        assert len(result.messages) > 0
+        assert "hello" in result.messages[0].content.text
+        assert "world" in result.messages[0].content.text
+    finally:
+        await client.close_all_sessions()
+
+
+async def _accept_elicitation(ctx: RequestContext, params: ElicitRequestParams) -> ElicitResult:
+    """Elicitation callback that applies schema defaults."""
+    content = {}
+    if hasattr(params, "requestedSchema") and params.requestedSchema:
+        schema = params.requestedSchema
+        properties = schema.get("properties", {}) if isinstance(schema, dict) else {}
+        for name, field_schema in properties.items():
+            if isinstance(field_schema, dict) and "default" in field_schema:
+                content[name] = field_schema["default"]
+    return ElicitResult(action="accept", content=content)
+
+
+@pytest.mark.asyncio
+async def test_client_elicitation(conformance_server):
+    """Client handles elicitation requests from the server."""
+    config = {"mcpServers": {"test": {"url": f"{conformance_server}/mcp"}}}
+    client = MCPClient(config=config, elicitation_callback=_accept_elicitation)
+    try:
+        await client.create_all_sessions()
+        session = client.get_session("test")
+        result = await session.call_tool("test_elicitation", {})
+        assert "Received:" in result.content[0].text
+        assert "Anonymous" in result.content[0].text
+    finally:
+        await client.close_all_sessions()
+
+
+@pytest.mark.asyncio
+async def test_client_error_handling(conformance_server):
+    """Client handles tool errors gracefully."""
+    config = {"mcpServers": {"test": {"url": f"{conformance_server}/mcp"}}}
+    client = MCPClient(config=config)
+    try:
+        await client.create_all_sessions()
+        session = client.get_session("test")
+        result = await session.call_tool("test_error_handling", {})
+        assert result.isError is True
+    finally:
+        await client.close_all_sessions()


### PR DESCRIPTION
## Summary
Add full MCP conformance testing for both server and client SDKs.

## Changes
- **Conformance server**: Updated tool/prompt/resource names, added audio content, SEP-1034/1330 elicitation, subscribable resources
- **Conformance client**: Headless OAuth via OAuthClientProvider passed as httpx.Auth to MCPClient
- **Integration test**: 11 tests covering external conformance runner + direct MCPClient tests
- **CI workflow**: `test-type: both` with separate `clients` input, path triggers for client code
- **TypeScript**: Added SEP-1330 enum elicitation tool to TS conformance server

## Results
- Python server: 30/30 (100%)
- Python client: 16/20 (80%) — 4 auth gaps in upstream MCP SDK
- TypeScript server: 29/30 (97%) — DNS rebinding

## Related Issues
Closes MCP-1371