### PR TITLE
feat(inspector): enhance elicitation support with SEP-1330 enum schema variants

### DIFF
--- a/docs/inspector/index.mdx
+++ b/docs/inspector/index.mdx
@@ -165,6 +165,27 @@ The Prompts tab shows pre-configured prompts from the MCP server. You can select
 
 Note: Linear MCP server doesn't provide any prompts, so this tab shows "No prompts available".
 
+### Elicitation Tab
+
+The Elicitation tab appears when a tool requests user input during execution.
+
+What you can do:
+
+- Review pending elicitation requests
+- Fill form fields generated from the server's schema
+- Accept, decline, or cancel requests
+- Jump back to tool results after response submission
+
+Supported schema patterns include all SEP-1330 enum variants:
+
+- Untitled single-select: `type: "string"` + `enum`
+- Titled single-select: `type: "string"` + `oneOf[{ const, title }]`
+- Legacy titled enum: `type: "string"` + `enum` + `enumNames`
+- Untitled multi-select: `type: "array"` + `items.enum`
+- Titled multi-select: `type: "array"` + `items.anyOf[{ const, title }]`
+
+These schemas render as dropdowns (single-select) or checkbox groups (multi-select), while submitted values always use the underlying enum/const values.
+
 # Chat Tab
 
 <Note>

--- a/docs/typescript/client/elicitation.mdx
+++ b/docs/typescript/client/elicitation.mdx
@@ -250,6 +250,43 @@ async function handleFormElicitation(
   solely on client-side validation.
 </Note>
 
+### Handling SEP-1330 Enum Schema Variants
+
+For form-mode elicitation, clients should support these enum schema shapes:
+
+| Variant | Schema Shape | Recommended UI |
+|---|---|---|
+| Untitled single-select | `type: "string"` + `enum` | Single-select dropdown |
+| Titled single-select | `type: "string"` + `oneOf[{ const, title }]` | Single-select dropdown with labels from `title` |
+| Legacy titled enum | `type: "string"` + `enum` + `enumNames` | Single-select dropdown using `enumNames` as labels |
+| Untitled multi-select | `type: "array"` + `items.enum` | Multi-select checkbox group |
+| Titled multi-select | `type: "array"` + `items.anyOf[{ const, title }]` | Multi-select checkbox group with labels from `title` |
+
+When returning accepted form values:
+
+- Single-select fields should return a string.
+- Multi-select fields should return an array of strings.
+- Use the `const`/`enum` values as submitted data, even when displaying a different label.
+
+```typescript
+function getChoices(field: Record<string, any>): Array<{ value: string; label: string }> {
+  if (Array.isArray(field.oneOf)) {
+    return field.oneOf
+      .filter((x) => typeof x?.const === "string")
+      .map((x) => ({ value: x.const, label: x.title ?? x.const }));
+  }
+
+  if (Array.isArray(field.enum)) {
+    return field.enum.map((value: string, i: number) => ({
+      value,
+      label: field.enumNames?.[i] ?? value,
+    }));
+  }
+
+  return [];
+}
+```
+
 ## URL Mode Elicitation
 
 URL mode directs users to external URLs for sensitive operations. **This mode MUST be used for:**

--- a/docs/typescript/server/elicitation.mdx
+++ b/docs/typescript/server/elicitation.mdx
@@ -181,6 +181,60 @@ const result = await ctx.elicit(
 // result.data will be: { theme: 'light', notifications: true }
 ```
 
+<Note>
+Default values (SEP-1034) and enum schema improvements (SEP-1330) are complementary. Use `.default()` for straightforward Zod-based forms, and use the verbose JSON Schema API when you need titled enum variants or multi-select enum arrays.
+</Note>
+
+#### SEP-1330 Enum Schema Patterns
+
+When you need advanced enum shapes like titled enums (`oneOf`/`anyOf`) or legacy `enumNames`, use the verbose API:
+
+```typescript
+import {
+  enumSchema,
+  legacyEnum,
+  titledEnum,
+  titledMultiEnum,
+  untitledEnum,
+  untitledMultiEnum,
+} from 'mcp-use/server';
+
+const result = await ctx.elicit({
+  message: 'Choose your options',
+  requestedSchema: enumSchema({
+    untitledSingle: untitledEnum(['option1', 'option2', 'option3']),
+    titledSingle: titledEnum([
+      { value: 'value1', title: 'First Option' },
+      { value: 'value2', title: 'Second Option' },
+      { value: 'value3', title: 'Third Option' },
+    ]),
+    legacyEnum: legacyEnum([
+      { value: 'opt1', name: 'Option One' },
+      { value: 'opt2', name: 'Option Two' },
+      { value: 'opt3', name: 'Option Three' },
+    ]),
+    untitledMulti: untitledMultiEnum(['option1', 'option2', 'option3']),
+    titledMulti: titledMultiEnum([
+      { value: 'value1', title: 'First Choice' },
+      { value: 'value2', title: 'Second Choice' },
+      { value: 'value3', title: 'Third Choice' },
+    ]),
+  }),
+});
+
+if (result.action === 'accept') {
+  return text(`Selected: ${JSON.stringify(result.data)}`);
+}
+```
+
+Supported SEP-1330 variants:
+
+- Untitled single-select: `type: "string" + enum`
+- Titled single-select: `type: "string" + oneOf[{ const, title }]`
+- Legacy titled enum: `type: "string" + enum + enumNames`
+- Untitled multi-select: `type: "array" + items.enum`
+- Titled multi-select: `type: "array" + items.anyOf[{ const, title }]`
+
 #### Example: Simple Contact Form
 
 ```typescript
@@ -401,6 +455,8 @@ This example includes:
 - Form mode with JSON schema validation
 - URL mode for OAuth-like flows
 - Conformance test tool
+- SEP-1330 conformance pattern via `test_elicitation_sep1330_enums` in the conformance feature server:
+  [examples/server/features/conformance/](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/features/conformance)
 - Working test client
 
 To run the example:

--- a/libraries/typescript/.changeset/new-times-yawn.md
+++ b/libraries/typescript/.changeset/new-times-yawn.md
@@ -1,0 +1,6 @@
+---
+"@mcp-use/inspector": minor
+"mcp-use": minor
+---
+
+feat(inspector): enhance elicitation support with SEP-1330 enum schema variants

--- a/libraries/typescript/packages/inspector/README.md
+++ b/libraries/typescript/packages/inspector/README.md
@@ -204,6 +204,30 @@ Test and manage pre-configured prompts:
 
 > **Note**: Not all servers provide prompts. If none are available, you'll see "No prompts available".
 
+### Elicitation Tab
+
+The Elicitation tab handles tool requests that require user input during execution.
+
+**Features:**
+
+- View pending elicitation requests in a dedicated queue
+- Fill and submit form-mode responses directly in the inspector
+- Accept, decline, or cancel requests
+- Jump back to tool results after responding
+
+**Supported field types:**
+
+- Text, number/integer, and boolean fields
+- Single-select enum dropdowns:
+  - `type: "string" + enum`
+  - `type: "string" + oneOf[{ const, title }]`
+  - `type: "string" + enum + enumNames` (legacy)
+- Multi-select enum groups:
+  - `type: "array" + items.enum`
+  - `type: "array" + items.anyOf[{ const, title }]`
+
+This aligns with SEP-1330 enum schema variants used by MCP conformance scenarios.
+
 ### Chat Tab
 
 The Chat tab provides an interactive interface to test the MCP server with an LLM using **BYOK (Bring Your Own Key)**.

--- a/libraries/typescript/packages/inspector/tests/e2e/README.md
+++ b/libraries/typescript/packages/inspector/tests/e2e/README.md
@@ -117,6 +117,22 @@ pnpm test:e2e:codegen
 
 Tests use the **real MCP conformance server** from `examples/server/features/conformance` instead of mocks.
 
+### Elicitation Tests
+
+`connection.test.ts` includes elicitation coverage for:
+
+- `test_elicitation`: baseline form-mode elicitation flow
+- `test_elicitation_sep1034_defaults`: default values for primitive fields
+- `test_elicitation_sep1330_enums`: all SEP-1330 enum schema variants
+
+The SEP-1330 test verifies inspector rendering and submission behavior for:
+
+- `string + enum` (untitled single-select)
+- `string + oneOf[{ const, title }]` (titled single-select)
+- `string + enum + enumNames` (legacy titled enum)
+- `array + items.enum` (untitled multi-select)
+- `array + items.anyOf[{ const, title }]` (titled multi-select)
+
 ## Writing Tests
 
 ### Best Practices

--- a/libraries/typescript/packages/inspector/tests/e2e/connection.test.ts
+++ b/libraries/typescript/packages/inspector/tests/e2e/connection.test.ts
@@ -651,6 +651,99 @@ test.describe("Inspector MCP Server Connections", () => {
     await expect(textContent).toContainText("John Doe");
   });
 
+  test("test_elicitation_sep1330_enums - should handle all enum schema variants", async ({
+    page,
+  }) => {
+    await page.getByTestId("tool-item-test_elicitation_sep1330_enums").click();
+    await expect(
+      page.getByTestId("tool-execution-execute-button")
+    ).toBeVisible();
+
+    await page.getByTestId("tool-execution-execute-button").click();
+
+    const viewDetailsButton = page.getByTestId(
+      "elicitation-toast-view-details"
+    );
+    await expect(viewDetailsButton).toBeVisible({ timeout: 5000 });
+    await viewDetailsButton.click();
+
+    await expect(page.getByTestId("elicitation-tab-header")).toBeVisible({
+      timeout: 3000,
+    });
+    await expect(page.getByTestId("elicitation-request-item-0")).toBeVisible();
+
+    // 1) Untitled single-select: string + enum
+    const untitledSingle = page.getByTestId("elicitation-field-untitledSingle");
+    await expect(untitledSingle).toBeVisible();
+    await untitledSingle.selectOption("option2");
+    await expect(untitledSingle).toHaveValue("option2");
+
+    // 2) Titled single-select: string + oneOf (const/title)
+    const titledSingle = page.getByTestId("elicitation-field-titledSingle");
+    await expect(titledSingle).toBeVisible();
+    await expect(titledSingle.locator("option")).toContainText([
+      "Select...",
+      "First Option",
+      "Second Option",
+      "Third Option",
+    ]);
+    await titledSingle.selectOption("value1");
+    await expect(titledSingle).toHaveValue("value1");
+
+    // 3) Legacy titled enum: string + enum + enumNames
+    const legacyEnum = page.getByTestId("elicitation-field-legacyEnum");
+    await expect(legacyEnum).toBeVisible();
+    await expect(legacyEnum.locator("option")).toContainText([
+      "Select...",
+      "Option One",
+      "Option Two",
+      "Option Three",
+    ]);
+    await legacyEnum.selectOption("opt1");
+    await expect(legacyEnum).toHaveValue("opt1");
+
+    // 4) Untitled multi-select: array + items.enum
+    const untitledMulti = page.getByTestId("elicitation-field-untitledMulti");
+    await expect(untitledMulti).toBeVisible();
+    await untitledMulti.getByLabel("option1").click();
+    await untitledMulti.getByLabel("option3").click();
+
+    // 5) Titled multi-select: array + items.anyOf (const/title)
+    const titledMulti = page.getByTestId("elicitation-field-titledMulti");
+    await expect(titledMulti).toBeVisible();
+    await titledMulti.getByLabel("First Choice").click();
+    await titledMulti.getByLabel("Third Choice").click();
+
+    await page.getByTestId("elicitation-accept-button").click();
+
+    const viewToolResultButton = page.getByTestId(
+      "elicitation-view-tool-result"
+    );
+    await expect(viewToolResultButton).toBeVisible({ timeout: 5000 });
+    await viewToolResultButton.click();
+
+    await expect(page.getByRole("heading", { name: "Tools" })).toBeVisible({
+      timeout: 3000,
+    });
+
+    const textContent = page.getByTestId("tool-execution-results-text-content");
+    await expect(textContent).toBeVisible({ timeout: 10000 });
+    await expect(textContent).toContainText(
+      "Elicitation completed: action=accept"
+    );
+
+    // Ensure selected enum values were submitted correctly.
+    await expect(textContent).toContainText('"untitledSingle":"option2"');
+    await expect(textContent).toContainText('"titledSingle":"value1"');
+    await expect(textContent).toContainText('"legacyEnum":"opt1"');
+    await expect(textContent).toContainText(
+      '"untitledMulti":["option1","option3"]'
+    );
+    await expect(textContent).toContainText(
+      '"titledMulti":["value1","value3"]'
+    );
+  });
+
   test("test_error_handling - should display error message", async ({
     page,
   }) => {

--- a/libraries/typescript/packages/mcp-use/examples/server/features/conformance/src/server.ts
+++ b/libraries/typescript/packages/mcp-use/examples/server/features/conformance/src/server.ts
@@ -12,13 +12,19 @@ import {
   audio,
   binary,
   completable,
+  enumSchema,
   error,
   image,
+  legacyEnum,
   MCPServer,
   mix,
   object,
   resource,
   text,
+  titledEnum,
+  titledMultiEnum,
+  untitledEnum,
+  untitledMultiEnum,
   widget,
 } from "mcp-use/server";
 import { z } from "zod";
@@ -218,6 +224,52 @@ server.tool(
           verified: z.boolean().default(true),
         })
       );
+
+      if (result.action === "accept") {
+        return text(
+          `Elicitation completed: action=accept, content=${JSON.stringify(result.data)}`
+        );
+      } else if (result.action === "decline") {
+        return text("Elicitation completed: action=decline");
+      }
+      return text("Elicitation completed: action=cancel");
+    } catch (err: any) {
+      return error(`Elicitation error: ${err.message || String(err)}`);
+    }
+  }
+);
+
+// tools-call-elicitation-sep1330-enums
+server.tool(
+  {
+    name: "test_elicitation_sep1330_enums",
+    description:
+      "A tool that uses elicitation with all 5 enum variants (SEP-1330)",
+  },
+  async (params, ctx) => {
+    try {
+      const result = await ctx.elicit({
+        message: "Please choose your options",
+        requestedSchema: enumSchema({
+          untitledSingle: untitledEnum(["option1", "option2", "option3"]),
+          titledSingle: titledEnum([
+            { value: "value1", title: "First Option" },
+            { value: "value2", title: "Second Option" },
+            { value: "value3", title: "Third Option" },
+          ]),
+          legacyEnum: legacyEnum([
+            { value: "opt1", name: "Option One" },
+            { value: "opt2", name: "Option Two" },
+            { value: "opt3", name: "Option Three" },
+          ]),
+          untitledMulti: untitledMultiEnum(["option1", "option2", "option3"]),
+          titledMulti: titledMultiEnum([
+            { value: "value1", title: "First Choice" },
+            { value: "value2", title: "Second Choice" },
+            { value: "value3", title: "Third Choice" },
+          ]),
+        }),
+      });
 
       if (result.action === "accept") {
         return text(

--- a/libraries/typescript/packages/mcp-use/examples/server/features/elicitation/README.md
+++ b/libraries/typescript/packages/mcp-use/examples/server/features/elicitation/README.md
@@ -8,6 +8,7 @@ This example demonstrates elicitation support in MCP, showing how servers can re
 🛡️ **Server-Side Validation**: Automatic Zod validation of returned data
 🎯 **Type Safety**: Full TypeScript type inference from Zod schemas
 📝 **Comprehensive Examples**: Form mode, URL mode, and validation demos
+📚 **SEP-1330 Patterns**: Reference enum schema patterns for advanced elicitation clients
 
 ## Elicitation Modes
 
@@ -50,6 +51,42 @@ const result = await ctx.elicit(
 );
 ```
 
+### SEP-1330 Enum Patterns
+
+For advanced enum schemas (titled options and multi-select), use the verbose form API:
+
+```typescript
+const result = await ctx.elicit({
+  message: "Choose options",
+  requestedSchema: {
+    type: "object",
+    properties: {
+      untitledSingle: { type: "string", enum: ["option1", "option2"] },
+      titledSingle: {
+        type: "string",
+        oneOf: [{ const: "v1", title: "First Option" }],
+      },
+      legacyEnum: {
+        type: "string",
+        enum: ["v1"],
+        enumNames: ["First Option"],
+      },
+      untitledMulti: {
+        type: "array",
+        items: { type: "string", enum: ["option1", "option2"] },
+      },
+      titledMulti: {
+        type: "array",
+        items: { anyOf: [{ const: "v1", title: "First Choice" }] },
+      },
+    },
+  },
+});
+```
+
+The full conformance implementation for SEP-1330 lives in:
+`examples/server/features/conformance/src/server.ts` via `test_elicitation_sep1330_enums`.
+
 ## Running the Server
 
 ```bash
@@ -65,6 +102,9 @@ The server will start on port 3000 by default.
 2. **test_elicitation** - Conformance test tool (matches MCP test suite)
 3. **authorize-service** - URL mode for OAuth-like flows
 4. **test-required-validation** - Demonstrates required field validation
+
+For expanded conformance coverage (including `test_elicitation_sep1034_defaults` and `test_elicitation_sep1330_enums`), see the conformance feature server at:
+`examples/server/features/conformance/src/server.ts`.
 
 ## Testing
 

--- a/libraries/typescript/packages/mcp-use/src/server/index.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/index.ts
@@ -53,6 +53,23 @@ export {
   type Completable,
   type CompletionContext,
 } from "./utils/completion-helpers.js";
+export {
+  enumSchema,
+  legacyEnum,
+  titledEnum,
+  titledMultiEnum,
+  untitledEnum,
+  untitledMultiEnum,
+  type ElicitationEnumFieldSchema,
+  type ElicitationEnumObjectSchema,
+  type EnumOption,
+  type LegacyEnumOption,
+  type LegacyEnumSchema,
+  type TitledEnumSchema,
+  type TitledMultiEnumSchema,
+  type UntitledEnumSchema,
+  type UntitledMultiEnumSchema,
+} from "./utils/elicitation-helpers.js";
 
 // OAuth utilities for authentication and authorization
 export {

--- a/libraries/typescript/packages/mcp-use/src/server/utils/elicitation-helpers.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/utils/elicitation-helpers.ts
@@ -1,0 +1,138 @@
+/**
+ * Elicitation schema helpers (SEP-1330)
+ *
+ * These helpers generate JSON Schema fragments for enum-style elicitation fields.
+ * They are intended for use with the verbose `ctx.elicit({ requestedSchema })` API.
+ */
+
+export interface EnumOption {
+  value: string;
+  title: string;
+}
+
+export interface LegacyEnumOption {
+  value: string;
+  name: string;
+}
+
+export interface UntitledEnumSchema {
+  type: "string";
+  enum: string[];
+}
+
+export interface TitledEnumSchema {
+  type: "string";
+  oneOf: Array<{ const: string; title: string }>;
+}
+
+export interface LegacyEnumSchema {
+  type: "string";
+  enum: string[];
+  enumNames: string[];
+}
+
+export interface UntitledMultiEnumSchema {
+  type: "array";
+  items: {
+    type: "string";
+    enum: string[];
+  };
+}
+
+export interface TitledMultiEnumSchema {
+  type: "array";
+  items: {
+    anyOf: Array<{ const: string; title: string }>;
+  };
+}
+
+export type ElicitationEnumFieldSchema =
+  | UntitledEnumSchema
+  | TitledEnumSchema
+  | LegacyEnumSchema
+  | UntitledMultiEnumSchema
+  | TitledMultiEnumSchema;
+
+export interface ElicitationEnumObjectSchema {
+  type: "object";
+  properties: Record<string, ElicitationEnumFieldSchema>;
+}
+
+/**
+ * Untitled single-select enum.
+ * Example: { type: "string", enum: ["a", "b"] }
+ */
+export function untitledEnum(values: string[]): UntitledEnumSchema {
+  return {
+    type: "string",
+    enum: [...values],
+  };
+}
+
+/**
+ * Titled single-select enum.
+ * Example: { type: "string", oneOf: [{ const: "a", title: "Option A" }] }
+ */
+export function titledEnum(options: EnumOption[]): TitledEnumSchema {
+  return {
+    type: "string",
+    oneOf: options.map((option) => ({
+      const: option.value,
+      title: option.title,
+    })),
+  };
+}
+
+/**
+ * Legacy titled enum (deprecated in SEP-1330 but still supported).
+ * Example: { type: "string", enum: ["a"], enumNames: ["Option A"] }
+ */
+export function legacyEnum(options: LegacyEnumOption[]): LegacyEnumSchema {
+  return {
+    type: "string",
+    enum: options.map((option) => option.value),
+    enumNames: options.map((option) => option.name),
+  };
+}
+
+/**
+ * Untitled multi-select enum.
+ * Example: { type: "array", items: { type: "string", enum: ["a", "b"] } }
+ */
+export function untitledMultiEnum(values: string[]): UntitledMultiEnumSchema {
+  return {
+    type: "array",
+    items: {
+      type: "string",
+      enum: [...values],
+    },
+  };
+}
+
+/**
+ * Titled multi-select enum.
+ * Example: { type: "array", items: { anyOf: [{ const: "a", title: "Option A" }] } }
+ */
+export function titledMultiEnum(options: EnumOption[]): TitledMultiEnumSchema {
+  return {
+    type: "array",
+    items: {
+      anyOf: options.map((option) => ({
+        const: option.value,
+        title: option.title,
+      })),
+    },
+  };
+}
+
+/**
+ * Build a top-level object schema for elicitation requestedSchema.
+ */
+export function enumSchema(
+  fields: Record<string, ElicitationEnumFieldSchema>
+): ElicitationEnumObjectSchema {
+  return {
+    type: "object",
+    properties: fields,
+  };
+}

--- a/libraries/typescript/packages/mcp-use/src/server/utils/index.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/utils/index.ts
@@ -8,3 +8,4 @@ export * from "./server-helpers.js";
 export * from "./server-lifecycle.js";
 export * from "./hono-proxy.js";
 export * from "./completion-helpers.js";
+export * from "./elicitation-helpers.js";


### PR DESCRIPTION
- Added detailed documentation for the Elicitation tab, outlining its features and supported schema patterns.
- Implemented handling for various SEP-1330 enum schema variants in the client and server, including single-select and multi-select options.
- Introduced new tests to validate the elicitation flow for all enum schema variants, ensuring correct rendering and submission behavior.
- Updated examples and README files to reflect the new elicitation capabilities and SEP-1330 patterns.
