### PR TITLE
fix(python): improve client conformance (pre-registration, CIMD, scope step-up)

### DIFF
--- a/libraries/python/tests/integration/clients_for_testing/conformance_client.py
+++ b/libraries/python/tests/integration/clients_for_testing/conformance_client.py
@@ -235,7 +235,8 @@ async def main():
         elif scenario == "sse-retry":
             await asyncio.sleep(5)
         elif scenario.startswith("auth/"):
-            pass  # The framework validates OAuth protocol exchanges
+            # Exercise the connection so scope step-up can trigger on 403
+            await run_tools_call(session)
         else:
             await run_tools_call(session)
     finally:


### PR DESCRIPTION
## Summary
Fix conformance client to pass 3 more auth scenarios. Client conformance: **16/20 → 19/20**.

## Fixes

1. **auth/pre-registration** — Parse `MCP_CONFORMANCE_CONTEXT` for pre-registered credentials and pre-populate token storage
2. **auth/basic-cimd** — Use the conformance test's expected CIMD URL (`conformance-test.local`)
3. **auth/scope-step-up** — Call tools after auth so the 403 → re-authorization flow actually triggers

All fixes are in the conformance client test harness only — no MCPClient SDK changes.

## Remaining failure

`sse-retry` (1/20) — transport-level SSE reconnection (Last-Event-ID header, retry timing). Requires upstream MCP SDK changes.

## Related Issues
Part of MCP-1371