### PR TITLE
fix(python): replace deprecated streamablehttp_client with streamable_http_client

### DIFF
--- a/docs/python/api-reference/mcp_use_client_task_managers_streamable_http.mdx
+++ b/docs/python/api-reference/mcp_use_client_task_managers_streamable_http.mdx
@@ -47,11 +47,11 @@ Initialize a new streamable HTTP connection manager.
 ><ParamField body="timeout" type="float" default="5" >   Timeout for HTTP operations in seconds </ParamField>
 ><ParamField body="read_timeout" type="float" default="300" >   Timeout for HTTP read operations in seconds </ParamField>
 ><ParamField body="auth" type="httpx.Auth | None" default="None" >   Optional httpx.Auth instance for authentication </ParamField>
-><ParamField body="httpx_client_factory" type="mcp.shared._httpx_utils.McpHttpClientFactory" default="<function create_mcp_http_client at 0x10b073380>" >   Custom HTTPX client factory for MCP </ParamField>
+><ParamField body="httpx_client_factory" type="mcp.shared._httpx_utils.McpHttpClientFactory | None" default="None" >   Custom HTTPX client factory for MCP </ParamField>
 
 **Signature**
 ```python wrap
-def __init__(url: str, headers: dict[str, str] | None = None, timeout: float = 5, read_timeout: float = 300, auth: httpx.Auth | None = None, httpx_client_factory: mcp.shared._httpx_utils.McpHttpClientFactory = <function create_mcp_http_client at 0x10b073380>):
+def __init__(url: str, headers: dict[str, str] | None = None, timeout: float = 5, read_timeout: float = 300, auth: httpx.Auth | None = None, httpx_client_factory: mcp.shared._httpx_utils.McpHttpClientFactory | None = None):
 ```
 
 </Card>

--- a/libraries/python/mcp_use/client/task_managers/streamable_http.py
+++ b/libraries/python/mcp_use/client/task_managers/streamable_http.py
@@ -31,7 +31,7 @@ class StreamableHttpConnectionManager(ConnectionManager[tuple[Any, Any]]):
         timeout: float = 5,
         read_timeout: float = 60 * 5,
         auth: httpx.Auth | None = None,
-        httpx_client_factory: McpHttpClientFactory = create_mcp_http_client,
+        httpx_client_factory: McpHttpClientFactory | None = None,
     ):
         """Initialize a new streamable HTTP connection manager.
 
@@ -66,7 +66,8 @@ class StreamableHttpConnectionManager(ConnectionManager[tuple[Any, Any]]):
         read_timeout_seconds = self.read_timeout.total_seconds()
 
         # Create the httpx client with auth, headers, and timeouts
-        self._http_client = self.httpx_client_factory(
+        factory = self.httpx_client_factory or create_mcp_http_client
+        self._http_client = factory(
             headers=self.headers,
             timeout=httpx.Timeout(timeout_seconds, read=read_timeout_seconds),
             auth=self.auth,


### PR DESCRIPTION
## Summary
Replace deprecated `streamablehttp_client` with the new `streamable_http_client` API from the MCP SDK.

## Changes
`libraries/python/mcp_use/client/task_managers/streamable_http.py`:
- Create `httpx.AsyncClient` with auth, headers, and timeouts via the factory
- Pass the client to `streamable_http_client(url, http_client=client)`
- Manage the httpx client lifecycle properly in `_close_connection`

## Why
The MCP SDK deprecated `streamablehttp_client` (camelCase) in favor of `streamable_http_client` (snake_case). The new API takes a pre-configured `httpx.AsyncClient` instead of individual params, which is cleaner and gives us direct control over the HTTP client.

## Testing
- `tests/integration/client/transports/test_streamable_http.py` — 1/1 pass
- `tests/integration/client/primitives/` — 19/19 pass

Closes MCP-1379