### PR TITLE
fix(python): achieve 100% client conformance (20/20) — fix sse-retry

### DIFF
--- a/libraries/python/tests/integration/clients_for_testing/conformance_client.py
+++ b/libraries/python/tests/integration/clients_for_testing/conformance_client.py
@@ -1,12 +1,55 @@
 """
 MCP Conformance Test Client (Python)
 
-A client that exercises all MCP protocol features for conformance testing.
-Uses MCPClient for all scenarios to validate the mcp-use client SDK.
+This script is the test subject for the official MCP client conformance suite.
+It validates that the mcp-use Python client SDK correctly implements the MCP
+protocol by exercising MCPClient against test servers started by the conformance
+framework.
 
-The conformance test framework starts a test server and passes its URL as argv[1].
-The scenario name is in the MCP_CONFORMANCE_SCENARIO env var.
-The MCP_CONFORMANCE_CONTEXT env var contains scenario-specific data (e.g., pre-registered creds).
+How it works:
+    The conformance framework (https://github.com/modelcontextprotocol/conformance)
+    starts a purpose-built test server for each scenario, then runs this script with:
+    - argv[1]: the test server's URL
+    - MCP_CONFORMANCE_SCENARIO: which scenario to run (e.g., "initialize", "auth/scope-step-up")
+    - MCP_CONFORMANCE_CONTEXT: JSON with scenario-specific data (e.g., pre-registered credentials)
+
+    The framework monitors all HTTP traffic between this client and its test server,
+    then validates that the protocol exchanges match the MCP specification.
+
+    Each scenario's expected behavior is defined in the conformance repo:
+    https://github.com/modelcontextprotocol/conformance/tree/main/src/scenarios/client
+
+Scenario reference:
+    Core scenarios:
+    - initialize: Just connect. The framework validates the handshake (protocol version,
+      client info, capabilities).
+    - tools_call: List tools, call each one. The test server exposes an add_numbers tool
+      and checks that the client invokes it correctly.
+    - elicitation-sep1034-client-defaults: The server requests elicitation with a schema
+      that has default values. The client must return those defaults.
+      Ref: https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1034
+    - sse-retry: The test server exposes a test_reconnection tool that closes the SSE
+      stream. The client must reconnect via GET with the Last-Event-ID header.
+      Ref: https://modelcontextprotocol.io/specification/2025-11-25/basic/transports
+
+    Auth scenarios (all start with "auth/"):
+    - Most auth scenarios: Connect with OAuth. The framework validates the full OAuth flow
+      (PRM discovery, auth server metadata, DCR or CIMD, authorization, token exchange).
+    - auth/basic-cimd: Server advertises client_id_metadata_document_supported=true.
+      Client must use a URL-based client_id instead of DCR. The conformance test expects
+      the specific URL "https://conformance-test.local/client-metadata.json".
+      Ref: https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#client-id-metadata-documents
+    - auth/scope-step-up: After initial auth with mcp:basic scope, calling tools/call
+      returns 403 insufficient_scope requiring mcp:write. Client must re-authorize.
+      The httpx auth flow handles this automatically — we just need to call tools.
+      Ref: https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#scope-challenge-handling
+    - auth/pre-registration: MCP_CONFORMANCE_CONTEXT provides {"client_id": "...",
+      "client_secret": "..."}. Client must use these instead of doing DCR.
+      Ref: https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#preregistration
+
+    For all auth scenarios, after authenticating we call tools to exercise the
+    connection — this is required for scope-step-up (triggers the 403 re-auth)
+    and validates that the token works for actual MCP operations.
 
 Usage: python conformance_client.py <server_url>
 """
@@ -29,8 +72,16 @@ REDIRECT_URI = "http://127.0.0.1:19823/callback"
 
 
 # =============================================================================
-# Headless OAuth provider for conformance test servers (auto-approve)
+# Headless OAuth provider for conformance test servers
 # =============================================================================
+#
+# The conformance test servers auto-approve authorization requests (no real
+# browser interaction needed). We replace the browser-based OAuth flow with
+# an httpx-based one that follows the authorization redirect programmatically.
+#
+# This is passed to MCPClient as an httpx.Auth instance via the server config's
+# "auth" key. The HttpConnector._set_auth() accepts httpx.Auth directly and
+# passes it to the httpx client used by the MCP transport.
 
 
 class InMemoryTokenStorage:
@@ -60,15 +111,25 @@ def create_headless_oauth_provider(
     client_secret: str | None = None,
     client_metadata_url: str | None = None,
 ) -> OAuthClientProvider:
-    """Create an OAuthClientProvider that handles auth headlessly.
+    """Create an OAuthClientProvider that completes OAuth flows without a browser.
 
-    Conformance test servers auto-approve authorization requests, so the
-    redirect_handler follows the auth URL via httpx (instead of opening a browser)
-    and the callback_handler extracts the code from the redirect.
+    The conformance test servers auto-approve authorization requests and redirect
+    back with the auth code. Instead of opening a browser, the redirect_handler
+    follows the authorization URL via httpx and captures the code from the redirect.
+
+    Args:
+        server_url: The MCP server URL being tested.
+        client_id: Pre-registered client ID (for auth/pre-registration scenario).
+            Sourced from MCP_CONFORMANCE_CONTEXT.
+        client_secret: Pre-registered client secret (for auth/pre-registration).
+            Sourced from MCP_CONFORMANCE_CONTEXT.
+        client_metadata_url: URL-based client ID for CIMD (for auth/basic-cimd).
+            The conformance test expects "https://conformance-test.local/client-metadata.json".
     """
     auth_code_future: asyncio.Future | None = None
 
     async def redirect_handler(authorization_url: str) -> None:
+        """Follow the authorization URL headlessly instead of opening a browser."""
         nonlocal auth_code_future
         loop = asyncio.get_running_loop()
         auth_code_future = loop.create_future()
@@ -93,13 +154,17 @@ def create_headless_oauth_provider(
                 auth_code_future.set_exception(e)
 
     async def callback_handler() -> tuple[str, str | None]:
+        """Return the auth code captured from the redirect."""
         if auth_code_future is None:
             raise Exception("redirect_handler was not called")
         return await auth_code_future
 
     storage = InMemoryTokenStorage()
 
-    # Pre-populate storage with client info for pre-registered clients
+    # For pre-registration scenarios: pre-populate storage with the credentials
+    # from MCP_CONFORMANCE_CONTEXT so the OAuthClientProvider skips DCR and uses
+    # them directly. Uses client_secret_basic auth method which is what the
+    # conformance test server expects.
     if client_id:
         storage._client_info = OAuthClientInformationFull(
             client_id=client_id,
@@ -121,6 +186,9 @@ def create_headless_oauth_provider(
         redirect_handler=redirect_handler,
         callback_handler=callback_handler,
         timeout=10.0,
+        # For CIMD: the OAuthClientProvider checks should_use_client_metadata_url()
+        # and uses this URL as client_id instead of doing DCR when the server
+        # advertises client_id_metadata_document_supported=true.
         client_metadata_url=client_metadata_url,
     )
 
@@ -131,7 +199,11 @@ def create_headless_oauth_provider(
 
 
 async def handle_elicitation(_ctx, params: ElicitRequestParams) -> ElicitResult:
-    """Accept elicitation requests, applying schema defaults from the server."""
+    """Accept elicitation requests, applying schema defaults from the server.
+
+    The elicitation-sep1034-client-defaults scenario sends a schema with default
+    values for each field. The client must return those defaults — not empty content.
+    """
     content = {}
     if hasattr(params, "requestedSchema") and params.requestedSchema:
         schema = params.requestedSchema
@@ -153,7 +225,12 @@ async def run_initialize(_session):
 
 
 async def run_tools_call(session):
-    """List tools and call each one."""
+    """List tools and call each one with auto-generated arguments.
+
+    The conformance test server exposes tools with known schemas. We generate
+    placeholder arguments based on the input schema types. Some tools may
+    intentionally error (e.g., test_error_handling) — we catch and ignore those.
+    """
     tools = await session.list_tools()
     for tool in tools:
         args = {}
@@ -174,7 +251,11 @@ async def run_tools_call(session):
 
 
 async def run_elicitation_defaults(session):
-    """Call elicitation tools — the framework checks that client returns defaults."""
+    """Call elicitation tools so the framework can validate default handling.
+
+    Only calls tools with "elicit" in the name — the conformance test checks
+    that our elicitation callback returns the schema defaults.
+    """
     tools = await session.list_tools()
     for tool in tools:
         if "elicit" not in (tool.name or "").lower():
@@ -203,11 +284,11 @@ async def main():
     # Build config — auth scenarios pass a headless OAuthClientProvider as httpx.Auth
     server_config: dict = {"url": server_url}
     if scenario.startswith("auth/"):
-        # Check for pre-registered credentials from conformance context
+        # Pre-registered credentials from MCP_CONFORMANCE_CONTEXT (auth/pre-registration)
         pre_client_id = context.get("client_id")
         pre_client_secret = context.get("client_secret")
 
-        # CIMD scenarios: use the conformance test's expected metadata URL as client_id
+        # CIMD URL for auth/basic-cimd — must match the conformance test's expected value
         client_metadata_url = None
         if scenario == "auth/basic-cimd":
             client_metadata_url = "https://conformance-test.local/client-metadata.json"
@@ -228,17 +309,37 @@ async def main():
 
         if scenario == "initialize":
             await run_initialize(session)
+
         elif scenario == "tools_call":
             await run_tools_call(session)
+
         elif scenario == "elicitation-sep1034-client-defaults":
             await run_elicitation_defaults(session)
+
         elif scenario == "sse-retry":
-            await asyncio.sleep(5)
+            # The test server exposes a test_reconnection tool that closes the SSE
+            # stream. We must call it so the MCP SDK transport can demonstrate proper
+            # reconnection behavior (reconnect via GET with Last-Event-ID header).
+            # Ref: https://github.com/modelcontextprotocol/conformance/blob/main/src/scenarios/client/sse-retry.ts
+            tools = await session.list_tools()
+            for tool in tools:
+                try:
+                    await session.call_tool(tool.name, {})
+                except Exception:
+                    pass
+            # Wait for the transport to reconnect after stream closure
+            await asyncio.sleep(3)
+
         elif scenario.startswith("auth/"):
-            # Exercise the connection so scope step-up can trigger on 403
+            # After authenticating, exercise the connection by calling tools.
+            # This is required for auth/scope-step-up: calling tools/call triggers
+            # a 403 insufficient_scope response, which httpx's OAuthClientProvider
+            # handles by re-authorizing with escalated scopes automatically.
             await run_tools_call(session)
+
         else:
             await run_tools_call(session)
+
     finally:
         await client.close_all_sessions()
 


### PR DESCRIPTION
## Summary
Fix the last failing client conformance scenario. **Python client: 20/20 (100%)**.

## Problem
The `sse-retry` scenario was failing because the conformance client just did `await asyncio.sleep(5)` instead of calling the `test_reconnection` tool that triggers SSE stream closure.

The MCP SDK transport already handles reconnection correctly:
- Tracks `Last-Event-ID` from SSE events
- Sends `Last-Event-ID` header on reconnection
- Respects the server's `retry` field for timing

We just weren't triggering the flow.

## Fix
Call all available tools (including `test_reconnection`) during the `sse-retry` scenario, then wait for the transport to reconnect.

## Results
All 20 client scenarios pass:
- 4/4 core (initialize, tools_call, elicitation, sse-retry)
- 16/16 auth (all metadata, CIMD, scope, token endpoint, pre-registration, backcompat scenarios)

## Related Issues
Part of MCP-1371