### PR TITLE
docs(python): update LangChain examples to use 1.0+ API

### DIFF
--- a/docs/python/agent/agent-configuration.mdx
+++ b/docs/python/agent/agent-configuration.mdx
@@ -249,9 +249,8 @@ If you want more control over how tools are created, you can work with the adapt
 
 ```python
 import asyncio
-from langchain_openai import ChatOpenAI
-from langchain.agents import AgentExecutor, create_tool_calling_agent
-from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+from langchain.agents import create_agent
+from langchain.chat_models import init_chat_model
 
 from mcp_use.client import MCPClient
 from mcp_use.adapters import LangChainAdapter
@@ -267,19 +266,18 @@ async def main():
     tools = await adapter.create_tools(client)
 
     # Use the tools with any LangChain agent
-    llm = ChatOpenAI(model="gpt-4o")
-    prompt = ChatPromptTemplate.from_messages([
-        ("system", "You are a helpful assistant with access to powerful tools."),
-        MessagesPlaceholder(variable_name="chat_history"),
-        ("human", "{input}"),
-        MessagesPlaceholder(variable_name="agent_scratchpad"),
-    ])
+    model = init_chat_model("gpt-4o", temperature=0.5)
 
-    agent = create_tool_calling_agent(llm=llm, tools=tools, prompt=prompt)
-    agent_executor = AgentExecutor(agent=agent, tools=tools, verbose=True)
+    agent = create_agent(
+        model=model,
+        tools=tools,
+        system_prompt="You are a helpful assistant with access to powerful tools.",
+    )
 
-    result = await agent_executor.ainvoke({"input": "Search for information about climate change"})
-    print(result["output"])
+    result = await agent.ainvoke(
+        {"messages": [{"role": "user", "content": "Search for information about climate change"}]}
+    )
+    print(result)
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/docs/python/agent/building-custom-agents.mdx
+++ b/docs/python/agent/building-custom-agents.mdx
@@ -41,9 +41,8 @@ Here's a simple example of creating a custom agent using the LangChain adapter:
 <CodeGroup>
 ```python Python
 import asyncio
-from langchain_openai import ChatOpenAI
-from langchain.agents import AgentExecutor, create_tool_calling_agent
-from langchain.prompts import ChatPromptTemplate, MessagesPlaceholder
+from langchain.agents import create_agent
+from langchain.chat_models import init_chat_model
 
 from mcp_use.client import MCPClient
 from mcp_use.adapters import LangChainAdapter
@@ -59,25 +58,20 @@ async def main():
     tools = await adapter.create_tools(client)
 
     # Initialize your language model
-    llm = ChatOpenAI(model="gpt-4o")
-
-    # Create a prompt template
-    prompt = ChatPromptTemplate.from_messages([
-        ("system", "You are a helpful assistant with access to powerful tools."),
-        MessagesPlaceholder(variable_name="chat_history"),
-        ("human", "{input}"),
-        MessagesPlaceholder(variable_name="agent_scratchpad"),
-    ])
+    model = init_chat_model("gpt-4o", temperature=0.5)
 
     # Create the agent
-    agent = create_tool_calling_agent(llm=llm, tools=tools, prompt=prompt)
-
-    # Create the agent executor
-    agent_executor = AgentExecutor(agent=agent, tools=tools, verbose=True)
+    agent = create_agent(
+        model=model,
+        tools=tools,
+        system_prompt="You are a helpful assistant with access to powerful tools.",
+    )
 
     # Run the agent
-    result = await agent_executor.ainvoke({"input": "What can you do?"})
-    print(result["output"])
+    result = await agent.ainvoke(
+        {"messages": [{"role": "user", "content": "What can you do?"}]}
+    )
+    print(result)
 
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
## Summary
- Update outdated LangChain code examples in agent docs to use the modern LangChain 1.0+ API
- Replace deprecated `AgentExecutor`/`create_tool_calling_agent` with `create_agent`/`init_chat_model`

## Implementation Details
1. **`docs/python/agent/building-custom-agents.mdx`** — replaced old LangChain imports and agent creation pattern
2. **`docs/python/agent/agent-configuration.mdx`** — same update in the "Working with Adapters Directly" section

Both now match the existing `docs/python/integration/langchain.mdx` page and `examples/langchain_integration_example.py`.

## Context
Users were hitting import errors (`cannot import AgentExecutor from langchain.agents`) because these docs referenced the pre-1.0 LangChain API, which is no longer available.

## Backwards Compatibility
Docs-only change, no code impact.