### PR TITLE
fix(typescript): error() return type compatibility with outputSchema

### DIFF
--- a/libraries/typescript/.changeset/shy-months-bow.md
+++ b/libraries/typescript/.changeset/shy-months-bow.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Fix error() return type to be compatible with tool callbacks that use outputSchema

--- a/libraries/typescript/packages/mcp-use/src/server/utils/response-helpers.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/utils/response-helpers.ts
@@ -340,7 +340,7 @@ export function resource(
  * })
  * ```
  */
-export function error(message: string): CallToolResult {
+export function error(message: string): TypedCallToolResult<never> {
   return {
     isError: true,
     content: [


### PR DESCRIPTION
# Pull Request Description
This PR fixes the `error()` helper return type so it's compatible with tool callbacks that have `outputSchema`.

## Language / Project Scope

Check all that apply:
- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Testing

- Manually tested the typescript build to check type inference in `libraries/typescript/packages/mcp-use/examples`

## Backwards Compatibility

No breaking changes