### PR TITLE
docs(typescript): replace Express patterns with Hono in server documentation

### DIFF
--- a/docs/typescript/blog/client_side.mdx
+++ b/docs/typescript/blog/client_side.mdx
@@ -154,10 +154,10 @@ When debugging an MCP server that requires authentication:
 
 ```typescript
 // Your MCP server
-server.use((req, res, next) => {
-  const apiKey = req.headers["authorization"];
-  if (!apiKey) return res.status(401).json({ error: "Unauthorized" });
-  next();
+server.use(async (c, next) => {
+  const apiKey = c.req.header("authorization");
+  if (!apiKey) return c.json({ error: "Unauthorized" }, 401);
+  await next();
 });
 ```
 

--- a/docs/typescript/server/configuration.mdx
+++ b/docs/typescript/server/configuration.mdx
@@ -426,35 +426,29 @@ const cache = new NodeCache({
 
 // Cache middleware
 function cacheMiddleware(key: string, ttl?: number) {
-  return (req, res, next) => {
-    const cacheKey = `${key}:${JSON.stringify(req.params)}:${JSON.stringify(req.query)}`
+  return async (c, next) => {
+    const url = new URL(c.req.url)
+    const cacheKey = `${key}:${url.pathname}:${url.search}`
     const cached = cache.get(cacheKey)
 
     if (cached) {
-      return res.json(cached)
+      return c.json(cached)
     }
 
-    // Store original json method
-    const originalJson = res.json.bind(res)
+    await next()
 
-    // Override json method to cache response
-    res.json = (data) => {
-      cache.set(cacheKey, data, ttl)
-      return originalJson(data)
-    }
-
-    next()
+    // Cache the response body
+    const body = await c.res.clone().json()
+    cache.set(cacheKey, body, ttl)
   }
 }
 
 // Use cache middleware
-server.get('/api/expensive',
-  cacheMiddleware('expensive-operation', 300),
-  async (req, res) => {
-    const result = await performExpensiveOperation()
-    res.json(result)
-  }
-)
+server.use('/api/expensive', cacheMiddleware('expensive-operation', 300))
+server.get('/api/expensive', async (c) => {
+  const result = await performExpensiveOperation()
+  return c.json(result)
+})
 ```
 
 ### Database Connection Pooling
@@ -660,7 +654,7 @@ spec:
 Implement comprehensive health checks:
 
 ```typescript
-server.get('/health', async (req, res) => {
+server.get('/health', async (c) => {
   const health = {
     status: 'healthy',
     timestamp: new Date().toISOString(),
@@ -690,7 +684,7 @@ server.get('/health', async (req, res) => {
 
   // Return appropriate status code
   const statusCode = health.status === 'healthy' ? 200 : 503
-  res.status(statusCode).json(health)
+  return c.json(health, statusCode)
 })
 ```
 
@@ -717,24 +711,19 @@ const httpRequestDuration = new promClient.Histogram({
 register.registerMetric(httpRequestDuration)
 
 // Middleware to track metrics
-server.use((req, res, next) => {
+server.use(async (c, next) => {
   const start = Date.now()
-
-  res.on('finish', () => {
-    const duration = (Date.now() - start) / 1000
-    httpRequestDuration
-      .labels(req.method, req.route?.path || 'unknown', res.statusCode.toString())
-      .observe(duration)
-  })
-
-  next()
+  await next()
+  const duration = (Date.now() - start) / 1000
+  httpRequestDuration
+    .labels(c.req.method, c.req.path, c.res.status.toString())
+    .observe(duration)
 })
 
 // Metrics endpoint
-server.get('/metrics', async (req, res) => {
-  res.set('Content-Type', register.contentType)
+server.get('/metrics', async (c) => {
   const metrics = await register.metrics()
-  res.end(metrics)
+  return c.text(metrics, 200, { 'Content-Type': register.contentType })
 })
 ```
 

--- a/docs/typescript/server/examples.mdx
+++ b/docs/typescript/server/examples.mdx
@@ -44,7 +44,6 @@ A complete weather information server with tools, resources, and UI widgets.
 
 ```typescript
 import { MCPServer } from 'mcp-use/server'
-import express from 'express'
 import axios from 'axios'
 
 // Types
@@ -280,28 +279,30 @@ server.uiResource({
 })
 
 // API endpoints for widget data
-server.get('/api/weather/:city', async (req, res) => {
+server.get('/api/weather/:city', async (c) => {
   try {
-    const weather = await weatherService.getCurrentWeather(req.params.city)
-    res.json(weather)
+    const city = c.req.param('city')
+    const weather = await weatherService.getCurrentWeather(city)
+    return c.json(weather)
   } catch (error) {
-    res.status(500).json({ error: error.message })
+    return c.json({ error: error.message }, 500)
   }
 })
 
-server.get('/api/forecast/:city', async (req, res) => {
-  const days = parseInt(req.query.days as string) || 3
+server.get('/api/forecast/:city', async (c) => {
+  const city = c.req.param('city')
+  const days = parseInt(c.req.query('days') || '3')
   try {
-    const forecast = await weatherService.getForecast(req.params.city, days)
-    res.json(forecast)
+    const forecast = await weatherService.getForecast(city, days)
+    return c.json(forecast)
   } catch (error) {
-    res.status(500).json({ error: error.message })
+    return c.json({ error: error.message }, 500)
   }
 })
 
 // Health check
-server.get('/health', (req, res) => {
-  res.json({
+server.get('/health', (c) => {
+  return c.json({
     status: 'healthy',
     service: 'weather-service',
     version: '2.0.0',
@@ -554,22 +555,22 @@ SELECT * FROM users LIMIT 10;
 })
 
 // API endpoint for query execution
-server.post('/api/query', async (req, res) => {
-  const { query } = req.body
+server.post('/api/query', async (c) => {
+  const { query } = await c.req.json()
 
   // Security: Only allow SELECT
   if (!query.trim().toLowerCase().startsWith('select')) {
-    return res.status(400).json({ error: 'Only SELECT queries allowed' })
+    return c.json({ error: 'Only SELECT queries allowed' }, 400)
   }
 
   try {
     const result = await pool.query(query)
-    res.json({
+    return c.json({
       rowCount: result.rowCount,
       rows: result.rows
     })
   } catch (error) {
-    res.status(500).json({ error: error.message })
+    return c.json({ error: error.message }, 500)
   }
 })
 

--- a/docs/typescript/server/index.mdx
+++ b/docs/typescript/server/index.mdx
@@ -205,12 +205,12 @@ When you run this server, it will be available at:
 
 ## Architecture Overview
 
-The mcp-use server framework is designed around a modular architecture that seamlessly integrates MCP protocol features with Express.js flexibility. Understanding this architecture helps you build powerful, production-ready MCP servers.
+The mcp-use server framework is designed around a modular architecture that seamlessly integrates MCP protocol features with Hono's flexibility. Understanding this architecture helps you build powerful, production-ready MCP servers.
 
 The framework is built on six fundamental components that work together:
 
 ### **Server Instance**
-The main `MCPServer` class created via `new MCPServer()`. It orchestrates all MCP functionality, manages the Express application, and handles client connections.
+The main `MCPServer` class created via `new MCPServer()`. It orchestrates all MCP functionality, manages the Hono application, and handles client connections.
 
 **Learn more**: See [Configuration](/typescript/server/configuration) for server setup options.
 
@@ -244,12 +244,12 @@ Rich, interactive React components that render in chat clients. Widgets are auto
 **Learn more**: [UI Widgets Guide →](/typescript/server/ui-widgets)
 
 ### **Custom Endpoints Integration**
-Full Express.js and Hono functionality for custom routes, middleware, authentication, static file serving, and more. The server instance is also an Express app.
+Full Hono functionality for custom routes, middleware, authentication, static file serving, and more. The server instance is also a Hono app.
 
 ```typescript
 // Add custom routes
-server.get('/api/mango', (req, res) => {
-  res.json({ fruit: 'mango' })
+server.get('/api/mango', (c) => {
+  return c.json({ fruit: 'mango' })
 })
 ```
 
@@ -271,8 +271,8 @@ class McpServer {
   
   listen(port?: number): Promise<void>
 
-  // Hono/Express proxy - all HTTP methods available
-  // Examples: get(), post(), use(), static(), route()
+  // Hono proxy - all HTTP methods available
+  // Examples: get(), post(), use(), route()
 }
 ```
 

--- a/libraries/typescript/packages/cli/README.md
+++ b/libraries/typescript/packages/cli/README.md
@@ -403,20 +403,20 @@ EXPOSE 3000
 CMD ["npm", "start"]
 ```
 
-### Integration with Existing Express Apps
+### Serving Built Widgets
 
-If you have an existing Express app, you can mount the built widgets:
+You can serve the built widgets from any Hono app using `serveStatic`:
 
 ```ts
-import express from "express";
-import path from "path";
+import { Hono } from "hono";
+import { serveStatic } from "hono/node-server/serve-static";
 
-const app = express();
+const app = new Hono();
 
 // Serve MCP widgets
 app.use(
-  "/widgets",
-  express.static(path.join(__dirname, "../dist/resources/mcp-use/widgets"))
+  "/widgets/*",
+  serveStatic({ root: "./dist/resources/mcp-use/widgets" })
 );
 
 // Your other routes...

--- a/libraries/typescript/packages/mcp-use/README.md
+++ b/libraries/typescript/packages/mcp-use/README.md
@@ -734,31 +734,24 @@ docker build -t my-mcp-server .
 docker run -p 3000:3000 my-mcp-server
 ```
 
-### Integration with Express
+### Custom Routes
 
-You can also integrate MCP server into existing Express applications:
+The MCPServer instance is a Hono app, so you can add custom routes directly:
 
 ```ts
-import express from "express";
-import { mountMCPServer } from "mcp-use/server";
+import { MCPServer } from "mcp-use/server";
 
-const app = express();
-
-// Your existing routes
-app.get("/api/health", (req, res) => res.send("OK"));
-
-// Mount MCP server
-const mcpServer = new MCPServer({
-  name: "integrated-server",
-  /* ... */
-});
-mountMCPServer(app, mcpServer, {
-  basePath: "/mcp-service", // Optional custom base path
+const server = new MCPServer({
+  name: "my-server",
+  version: "1.0.0",
 });
 
-app.listen(3000);
-// Inspector at: http://localhost:3000/mcp-service/inspector
-// MCP endpoint: http://localhost:3000/mcp-service/mcp
+// Add custom routes
+server.get("/api/health", (c) => c.text("OK"));
+
+await server.listen(3000);
+// MCP endpoint: http://localhost:3000/mcp
+// Inspector: http://localhost:3000/inspector
 ```
 
 ## 👥 Contributors


### PR DESCRIPTION
# Pull Request Description
This PR updates server documentation and READMEs to use Hono patterns instead of incorrect Express patterns (e.g., `(req, res)` → `(c)`, `res.json()` → `c.json()`).

## Language / Project Scope

Check all that apply:
- [x] TypeScript
- [ ] Python
- [x] Documentation only
- [ ] CI/CD or tooling
