### PR TITLE
Add plugin.yaml for agent discovery & registry

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -4,7 +4,7 @@
 
 name: mcp-use
 display_name: mcp-use
-version: "0.1.0"
+manifest_version: "1.0"
 description: >
   The easiest way to interact with MCP servers using custom agents.
   Connect any LLM to any MCP server with minimal setup — supports
@@ -43,9 +43,9 @@ runtime:
   language: python
   min_python: "3.10"
 
-discovery:
-  protocol: mcp
+protocols:
+  - mcp
   role: client
-  transport:
+transport:
     - stdio
     - sse

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,0 +1,51 @@
+# plugin.yaml — mcp-use Agent Plugin Manifest
+# This file makes mcp-use discoverable as an agent plugin.
+# Learn more: https://list.agenium.net/plugins
+
+name: mcp-use
+display_name: mcp-use
+version: "0.1.0"
+description: >
+  The easiest way to interact with MCP servers using custom agents.
+  Connect any LLM to any MCP server with minimal setup — supports
+  tool calling, multi-server connections, and autonomous agent workflows.
+
+author:
+  name: mcp-use
+  url: https://github.com/mcp-use
+
+repository: https://github.com/mcp-use/mcp-use
+license: MIT
+
+categories:
+  - mcp-clients
+  - agent-frameworks
+  - developer-tools
+
+tags:
+  - mcp
+  - model-context-protocol
+  - python
+  - langchain
+  - agent-orchestration
+  - llm-tools
+
+capabilities:
+  - mcp-client
+  - multi-server-connection
+  - tool-calling
+  - autonomous-agents
+
+install:
+  pip: mcp-use
+
+runtime:
+  language: python
+  min_python: "3.10"
+
+discovery:
+  protocol: mcp
+  role: client
+  transport:
+    - stdio
+    - sse


### PR DESCRIPTION
## What

Adds a `plugin.yaml` manifest file that describes mcp-use as a discoverable agent plugin.

## Why

The AI agent ecosystem needs a standard way for tools to declare themselves as discoverable plugins. A `plugin.yaml` at the repo root lets registries, package managers, and other agents automatically understand what mcp-use offers — its capabilities, install method, and protocol support.

**Think of it like:**
- `package.json` for npm
- `pyproject.toml` for Python
- `plugin.yaml` for agent tools

## What it includes

- **Metadata**: name, description, author, license
- **Capabilities**: MCP client, multi-server, tool calling, autonomous agents
- **Install info**: `pip install mcp-use`
- **Discovery**: protocol (MCP), role (client), transports (stdio/SSE)
- **Categories & tags**: for search and filtering

## Impact

- Zero code changes — just a metadata file
- No dependencies added
- Makes mcp-use easier to find in agent tool registries
- Standard format other MCP projects are also adopting

---

*Part of an effort to standardize agent plugin discovery across the ecosystem. [Learn more](https://list.agenium.net/plugins)*