### PR TITLE
feat(cli): add skills commands to cli with install command

### DIFF
--- a/docs/typescript/server/cli-reference.mdx
+++ b/docs/typescript/server/cli-reference.mdx
@@ -296,6 +296,55 @@ Removes authentication credentials from `~/.mcp-use/config.json`.
 
 ---
 
+### Skills Commands
+
+#### `skills add` - Install AI Agent Skills
+
+```bash
+mcp-use skills add [options]
+```
+
+Downloads the latest mcp-use skills from [github.com/mcp-use/mcp-use](https://github.com/mcp-use/mcp-use) and installs them into all agent preset directories.
+
+**What happens:**
+
+1. Downloads the latest skills from GitHub
+2. Installs them into all agent preset directories:
+   - `.cursor/skills/` (Cursor)
+   - `.claude/skills/` (Claude Code)
+   - `.agent/skills/` (Codex)
+
+**Options:**
+
+| Option              | Description       | Default           |
+| ------------------- | ----------------- | ----------------- |
+| `-p, --path <path>` | Project directory | Current directory |
+
+**Examples:**
+
+```bash
+# Install skills in current project
+mcp-use skills add
+
+# Install skills in a specific project
+mcp-use skills add -p ./my-server
+```
+
+#### `skills install` - Alias for `skills add`
+
+```bash
+mcp-use skills install [options]
+```
+
+Identical to `skills add`. Use whichever you prefer.
+
+<Tip>
+  Skills are also installed automatically when creating a new project with
+  `create-mcp-use-app` (unless `--no-skills` is passed).
+</Tip>
+
+---
+
 ## Build Artifacts & Generated Files
 
 The CLI generates several files during build, deployment, and development. Understanding these files helps with debugging and advanced configuration.

--- a/libraries/typescript/.changeset/chubby-emus-scream.md
+++ b/libraries/typescript/.changeset/chubby-emus-scream.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/cli": minor
+---
+
+Add mcp-use skills add and mcp-use skills install commands to the cli to install AI agent skills (Cursor, Claude Code, Codex) from the mcp-use repository

--- a/libraries/typescript/packages/cli/package.json
+++ b/libraries/typescript/packages/cli/package.json
@@ -61,10 +61,12 @@
     "tsx": "^4.21.0",
     "vite": "^7.3.1",
     "vite-plugin-singlefile": "^2.0.3",
+    "tar": "^7.4.3",
     "ws": "^8.19.0",
     "zod": "^4.2.0"
   },
   "devDependencies": {
+    "@types/tar": "^6.1.13",
     "@types/ws": "^8.18.1",
     "vitest": "^4.0.17"
   },

--- a/libraries/typescript/packages/cli/src/commands/skills.ts
+++ b/libraries/typescript/packages/cli/src/commands/skills.ts
@@ -1,0 +1,169 @@
+import chalk from "chalk";
+import { Command } from "commander";
+import { cpSync, existsSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { extract } from "tar";
+
+const REPO_OWNER = "mcp-use";
+const REPO_NAME = "mcp-use";
+const REPO_BRANCH = "main";
+
+const TELEMETRY_URL = "https://add-skill.vercel.sh/t";
+const SOURCE_REPO = `${REPO_OWNER}/${REPO_NAME}`;
+
+// Telemetry data defined in https://github.com/vercel-labs/skills/blob/main/src/telemetry.ts
+interface InstallTelemetryData {
+  event: "install";
+  source: string;
+  skills: string;
+  agents: string;
+  global?: "1";
+  skillFiles?: string;
+  sourceType?: string;
+}
+
+/** Type-safe enum for IDE/agent presets */
+type AgentPreset = "cursor" | "claude-code" | "codex";
+
+const AGENT_PRESET_FOLDERS: Record<AgentPreset, string> = {
+  cursor: ".cursor",
+  "claude-code": ".claude",
+  codex: ".agent",
+};
+
+const ALL_PRESETS: AgentPreset[] = ["cursor", "claude-code", "codex"];
+
+/**
+ * Send telemetry event for vercel skills.sh.
+ * Fire-and-forget -- never throws.
+ */
+function sendInstallTelemetryEvent(agents: string, skills: string): void {
+  const telemetryData: InstallTelemetryData = {
+    event: "install",
+    source: SOURCE_REPO,
+    skills,
+    agents,
+    sourceType: "github",
+  };
+  try {
+    const params = new URLSearchParams();
+    for (const [key, value] of Object.entries(telemetryData)) {
+      if (value !== undefined && value !== null) {
+        params.set(key, String(value));
+      }
+    }
+    fetch(`${TELEMETRY_URL}?${params.toString()}`).catch(() => {});
+  } catch {
+    // Silently fail - telemetry should never break the CLI
+  }
+}
+
+/**
+ * Download and extract skills from the mcp-use GitHub repository
+ * and install them into the project's agent preset directories
+ * (.cursor/skills, .claude/skills, .agent/skills).
+ */
+async function addSkillsToProject(projectPath: string): Promise<void> {
+  const tarballUrl = `https://codeload.github.com/${REPO_OWNER}/${REPO_NAME}/tar.gz/${REPO_BRANCH}`;
+  const tempDir = mkdtempSync(join(tmpdir(), "mcp-use-skills-"));
+
+  try {
+    const response = await fetch(tarballUrl);
+    if (!response.ok) {
+      throw new Error(`Failed to download tarball: ${response.statusText}`);
+    }
+
+    await pipeline(
+      Readable.fromWeb(response.body as any),
+      extract({
+        cwd: tempDir,
+        filter: (path) => path.includes("/skills/"),
+        strip: 1,
+      })
+    );
+
+    const skillsPath = join(tempDir, "skills");
+    if (!existsSync(skillsPath)) {
+      throw new Error("Skills folder not found in repository");
+    }
+
+    for (const preset of ALL_PRESETS) {
+      const folderName = AGENT_PRESET_FOLDERS[preset];
+      const outputPath = join(projectPath, folderName, "skills");
+      cpSync(skillsPath, outputPath, { recursive: true });
+    }
+
+    const skillNames = readdirSync(skillsPath, { withFileTypes: true })
+      .filter((dirent) => dirent.isDirectory())
+      .map((dirent) => dirent.name);
+
+    sendInstallTelemetryEvent(ALL_PRESETS.join(","), skillNames.join(","));
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+export function createSkillsCommand(): Command {
+  const skills = new Command("skills").description(
+    "Manage mcp-use AI agent skills"
+  );
+
+  const installAction = async (options: { path: string }) => {
+    const projectPath = resolve(options.path);
+
+    if (!existsSync(projectPath)) {
+      console.error(chalk.red(`Directory not found: ${projectPath}`));
+      process.exit(1);
+    }
+
+    console.log(chalk.cyan("📚 Installing mcp-use skills..."));
+    console.log(
+      chalk.gray(
+        "   Downloading from github.com/mcp-use/mcp-use → .cursor/skills, .claude/skills, .agent/skills"
+      )
+    );
+
+    try {
+      await addSkillsToProject(projectPath);
+      console.log(chalk.green("✅ Skills installed successfully!"));
+    } catch (error) {
+      console.error(chalk.red("❌ Failed to install skills."));
+      console.error(
+        chalk.yellow(
+          `   Error: ${error instanceof Error ? error.message : String(error)}`
+        )
+      );
+      console.error(
+        chalk.yellow(
+          "   You can also install manually: npx skills add mcp-use/mcp-use"
+        )
+      );
+      process.exit(1);
+    }
+  };
+
+  const pathOption = [
+    "-p, --path <path>",
+    "Path to project directory",
+    process.cwd(),
+  ] as const;
+
+  skills
+    .command("add")
+    .description(
+      "Install mcp-use skills for AI agents (Cursor, Claude Code, Codex)"
+    )
+    .option(...pathOption)
+    .action(installAction);
+
+  skills
+    .command("install")
+    .description("Install mcp-use skills for AI agents (alias for 'add')")
+    .option(...pathOption)
+    .action(installAction);
+
+  return skills;
+}

--- a/libraries/typescript/packages/cli/src/index.ts
+++ b/libraries/typescript/packages/cli/src/index.ts
@@ -14,6 +14,7 @@ import { loginCommand, logoutCommand, whoamiCommand } from "./commands/auth.js";
 import { createClientCommand } from "./commands/client.js";
 import { deployCommand } from "./commands/deploy.js";
 import { createDeploymentsCommand } from "./commands/deployments.js";
+import { createSkillsCommand } from "./commands/skills.js";
 
 const program = new Command();
 
@@ -1870,6 +1871,9 @@ program.addCommand(createClientCommand());
 
 // Deployments command
 program.addCommand(createDeploymentsCommand());
+
+// Skills command
+program.addCommand(createSkillsCommand());
 
 // Generate types command
 program

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -136,6 +136,9 @@ importers:
       react-router-dom:
         specifier: ^7.12.0
         version: 7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      tar:
+        specifier: ^7.4.3
+        version: 7.5.7
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -152,6 +155,9 @@ importers:
         specifier: 4.3.5
         version: 4.3.5
     devDependencies:
+      '@types/tar':
+        specifier: ^6.1.13
+        version: 6.1.13
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
@@ -6801,6 +6807,7 @@ packages:
   tar@7.5.7:
     resolution: {integrity: sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}


### PR DESCRIPTION
# Pull Request Description
This PR adds `mcp-use skills add` and `mcp-use skills install` commands to the CLI, allowing users to install AI agent skills (Cursor, Claude Code, Codex) from the mcp-use repository into their project.

## Language / Project Scope

Check all that apply:
- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

- Added `src/commands/skills.ts` with `addSkillsToProject` logic (downloads skills tarball from GitHub, extracts to `.cursor/skills`, `.claude/skills`, `.agent/skills`)
- Registered `mcp-use skills add` and `mcp-use skills install` as subcommands in `src/index.ts`
- Added `tar` dependency to `@mcp-use/cli`
- Updated `docs/typescript/server/cli-reference.mdx` with documentation for the new commands

## Testing

- Manually tested `mcp-use skills add` and `mcp-use skills install` via local CLI build

## Backwards Compatibility

No breaking changes — this is a new additive feature.