### PR TITLE
improvement(skills): add mcp server auth guidance to mcp-apps-builder skill

### DIFF
--- a/skills/mcp-apps-builder/SKILL.md
+++ b/skills/mcp-apps-builder/SKILL.md
@@ -46,6 +46,27 @@ Load these before diving into tools/resources/widgets sections.
 
 ---
 
+### 🔐 Adding Authentication?
+**When:** Protecting your server with OAuth (WorkOS, Supabase, or custom)
+
+- **[overview.md](references/authentication/overview.md)**
+  - When: First time adding auth, understanding `ctx.auth`, or choosing a provider
+  - Covers: `oauth` config, user context shape, provider comparison, common mistakes
+
+- **[workos.md](references/authentication/workos.md)**
+  - When: Using WorkOS AuthKit for authentication
+  - Covers: Setup, env vars, DCR vs pre-registered, roles/permissions, WorkOS API calls
+
+- **[supabase.md](references/authentication/supabase.md)**
+  - When: Using Supabase for authentication
+  - Covers: Setup, env vars, HS256 vs ES256, RLS-aware API calls
+
+- **[custom.md](references/authentication/custom.md)**
+  - When: Using any other identity provider (GitHub, Okta, Azure AD, Google, etc.)
+  - Covers: Custom verification, user info extraction, provider examples
+
+---
+
 ### 🔧 Building Server Backend (No UI)?
 **When:** Implementing MCP features (actions, data, templates). Read the specific file for the primitive you're building.
 
@@ -106,6 +127,9 @@ Load these before diving into tools/resources/widgets sections.
 ```
 What do you need to build?
 
+├─ OAuth / user authentication
+│  └─> authentication/overview.md → provider-specific guide
+│
 ├─ Simple backend action (no UI)
 │  └─> Use Tool: server/tools.md
 │

--- a/skills/mcp-apps-builder/references/authentication/custom.md
+++ b/skills/mcp-apps-builder/references/authentication/custom.md
@@ -1,0 +1,215 @@
+# Custom Authentication
+
+Setting up OAuth with any identity provider (GitHub, Okta, Azure AD, Google, etc.).
+
+---
+
+## Quick Start
+
+```typescript
+import { MCPServer, oauthCustomProvider, object } from "mcp-use/server";
+import { createRemoteJWKSet, jwtVerify } from "jose";
+
+const JWKS = createRemoteJWKSet(
+  new URL("https://login.example.com/.well-known/jwks.json")
+);
+
+const server = new MCPServer({
+  name: "my-server",
+  version: "1.0.0",
+  oauth: oauthCustomProvider({
+    issuer: "https://login.example.com",
+    jwksUrl: "https://login.example.com/.well-known/jwks.json",
+    authEndpoint: "https://login.example.com/oauth2/authorize",
+    tokenEndpoint: "https://login.example.com/oauth2/token",
+    verifyToken: async (token) => {
+      const result = await jwtVerify(token, JWKS, {
+        issuer: "https://login.example.com",
+      });
+      return result;
+    },
+  }),
+});
+
+server.tool(
+  { name: "whoami", description: "Get authenticated user info" },
+  async (_args, ctx) =>
+    object({
+      userId: ctx.auth.user.userId,
+      email: ctx.auth.user.email,
+    })
+);
+
+server.listen();
+```
+
+---
+
+## Configuration Options
+
+```typescript
+oauth: oauthCustomProvider({
+  issuer: "https://login.example.com",              // required
+  jwksUrl: "https://login.example.com/.well-known/jwks.json",  // required
+  authEndpoint: "https://login.example.com/authorize",          // required
+  tokenEndpoint: "https://login.example.com/token",             // required
+  verifyToken: async (token) => { ... },             // required
+  getUserInfo: (payload) => ({ ... }),                // optional
+  scopesSupported: ["openid", "profile", "email"],   // optional
+  grantTypesSupported: ["authorization_code", "refresh_token"], // optional
+})
+```
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `issuer` | `string` | Yes | OAuth issuer URL |
+| `jwksUrl` | `string` | Yes | JWKS endpoint for key discovery |
+| `authEndpoint` | `string` | Yes | Authorization endpoint |
+| `tokenEndpoint` | `string` | Yes | Token endpoint |
+| `verifyToken` | `(token: string) => Promise<{ payload }>` | Yes | Custom JWT verification function |
+| `getUserInfo` | `(payload) => UserInfo` | No | Custom user info extraction |
+| `scopesSupported` | `string[]` | No | Defaults to `["openid", "profile", "email"]` |
+| `grantTypesSupported` | `string[]` | No | Defaults to `["authorization_code", "refresh_token"]` |
+
+---
+
+## Token Verification
+
+You must provide a `verifyToken` function that validates the JWT and returns `{ payload }`:
+
+```typescript
+import { createRemoteJWKSet, jwtVerify } from "jose";
+
+const JWKS = createRemoteJWKSet(
+  new URL("https://login.example.com/.well-known/jwks.json")
+);
+
+verifyToken: async (token) => {
+  const result = await jwtVerify(token, JWKS, {
+    issuer: "https://login.example.com",
+    audience: "my-api",  // if your provider requires audience validation
+  });
+  return result;
+}
+```
+
+The `jose` library is already a dependency of mcp-use, so no additional install is needed.
+
+---
+
+## Custom User Info Extraction
+
+Without `getUserInfo`, the provider extracts standard OIDC claims automatically:
+
+| Field | Extracted From |
+|-------|---------------|
+| `userId` | `sub`, `user_id`, or `id` |
+| `email` | `email` |
+| `name` | `name` |
+| `username` | `username` or `preferred_username` |
+| `nickname` | `nickname` |
+| `picture` | `picture` or `avatar_url` |
+| `roles` | `roles` (if array) |
+| `permissions` | `permissions` (if array) |
+| `scopes` | Parsed from `scope` string |
+
+Override this if your provider uses non-standard claim names:
+
+```typescript
+getUserInfo: (payload) => ({
+  userId: payload.user_id as string,
+  email: payload.mail as string,
+  name: payload.display_name as string,
+  roles: (payload.groups as string[]) || [],
+})
+```
+
+---
+
+## Provider Examples
+
+### GitHub (via GitHub Apps)
+
+```typescript
+oauth: oauthCustomProvider({
+  issuer: "https://github.com",
+  jwksUrl: "https://token.actions.githubusercontent.com/.well-known/jwks",
+  authEndpoint: "https://github.com/login/oauth/authorize",
+  tokenEndpoint: "https://github.com/login/oauth/access_token",
+  verifyToken: async (token) => {
+    // GitHub tokens may need introspection rather than local JWT verification
+    const res = await fetch("https://api.github.com/user", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) throw new Error("Invalid token");
+    const user = await res.json();
+    return { payload: user };
+  },
+  getUserInfo: (payload) => ({
+    userId: String(payload.id),
+    email: payload.email as string,
+    name: payload.name as string,
+    username: payload.login as string,
+    picture: payload.avatar_url as string,
+  }),
+})
+```
+
+### Okta
+
+```typescript
+import { createRemoteJWKSet, jwtVerify } from "jose";
+
+const OKTA_DOMAIN = process.env.OKTA_DOMAIN; // e.g., "dev-123456.okta.com"
+const JWKS = createRemoteJWKSet(
+  new URL(`https://${OKTA_DOMAIN}/oauth2/default/v1/keys`)
+);
+
+oauth: oauthCustomProvider({
+  issuer: `https://${OKTA_DOMAIN}/oauth2/default`,
+  jwksUrl: `https://${OKTA_DOMAIN}/oauth2/default/v1/keys`,
+  authEndpoint: `https://${OKTA_DOMAIN}/oauth2/default/v1/authorize`,
+  tokenEndpoint: `https://${OKTA_DOMAIN}/oauth2/default/v1/token`,
+  verifyToken: async (token) =>
+    jwtVerify(token, JWKS, {
+      issuer: `https://${OKTA_DOMAIN}/oauth2/default`,
+    }),
+})
+```
+
+### Azure AD
+
+```typescript
+import { createRemoteJWKSet, jwtVerify } from "jose";
+
+const TENANT_ID = process.env.AZURE_TENANT_ID;
+const JWKS = createRemoteJWKSet(
+  new URL(`https://login.microsoftonline.com/${TENANT_ID}/discovery/v2.0/keys`)
+);
+
+oauth: oauthCustomProvider({
+  issuer: `https://login.microsoftonline.com/${TENANT_ID}/v2.0`,
+  jwksUrl: `https://login.microsoftonline.com/${TENANT_ID}/discovery/v2.0/keys`,
+  authEndpoint: `https://login.microsoftonline.com/${TENANT_ID}/oauth2/v2.0/authorize`,
+  tokenEndpoint: `https://login.microsoftonline.com/${TENANT_ID}/oauth2/v2.0/token`,
+  verifyToken: async (token) =>
+    jwtVerify(token, JWKS, {
+      issuer: `https://login.microsoftonline.com/${TENANT_ID}/v2.0`,
+    }),
+  getUserInfo: (payload) => ({
+    userId: payload.oid as string,
+    email: payload.preferred_username as string,
+    name: payload.name as string,
+    roles: (payload.roles as string[]) || [],
+  }),
+})
+```
+
+---
+
+## Next Steps
+
+- **Auth overview** → [overview.md](overview.md)
+- **WorkOS setup** → [workos.md](workos.md)
+- **Supabase setup** → [supabase.md](supabase.md)
+- **Build tools** → [../server/tools.md](../server/tools.md)

--- a/skills/mcp-apps-builder/references/authentication/overview.md
+++ b/skills/mcp-apps-builder/references/authentication/overview.md
@@ -1,0 +1,185 @@
+# Authentication
+
+Adding OAuth authentication to your MCP server.
+
+**Use for:** Protecting tools behind user authentication, accessing user identity in tool handlers, integrating with identity providers (WorkOS, Supabase, etc.)
+
+> **Recommended providers:** WorkOS and Supabase have been fully tested with the MCP Inspector and support Dynamic Client Registration (DCR) out of the box. Start with one of those if possible. The custom provider (`oauthCustomProvider`) works for any OIDC-compliant provider, but requires the provider to either support DCR or the user to supply a pre-registered `client_id` — most providers (e.g., Asana, Google, Okta) do not support DCR, which means the MCP Inspector cannot self-register and the OAuth flow will stall silently.
+
+---
+
+## How It Works
+
+Pass an OAuth provider to the `oauth` option on `MCPServer`. Everything else is automatic:
+
+```typescript
+import { MCPServer } from "mcp-use/server";
+
+const server = new MCPServer({
+  name: "my-server",
+  version: "1.0.0",
+  oauth: yourProvider(),  // see provider-specific guides
+});
+```
+
+This single property:
+- Protects all `/mcp/*` routes with bearer token authentication
+- Verifies JWTs using the provider's JWKS endpoint
+- Sets up OAuth discovery endpoints (`/.well-known/oauth-authorization-server`, `/.well-known/oauth-protected-resource`)
+- Sets up `/authorize` and `/token` proxy endpoints for browser clients
+- Populates `ctx.auth` in all tool/resource/prompt handlers
+
+---
+
+## Accessing User Context
+
+Every tool handler receives `ctx.auth` when OAuth is enabled:
+
+```typescript
+server.tool(
+  {
+    name: "get-profile",
+    description: "Get the authenticated user's profile",
+  },
+  async (_args, ctx) =>
+    object({
+      userId: ctx.auth.user.userId,
+      email: ctx.auth.user.email,
+      name: ctx.auth.user.name,
+    })
+);
+```
+
+### `ctx.auth` Shape
+
+```typescript
+ctx.auth.user            // UserInfo object (see below)
+ctx.auth.accessToken     // Raw bearer token string
+ctx.auth.scopes          // string[] — parsed from JWT `scope` claim
+ctx.auth.permissions     // string[] — parsed from JWT `permissions` claim
+ctx.auth.payload         // Raw JWT payload (all claims)
+```
+
+### `ctx.auth.user` (UserInfo)
+
+All providers populate these base fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `userId` | `string` | Unique user identifier (`sub` claim) |
+| `email` | `string?` | User's email |
+| `name` | `string?` | Display name |
+| `username` | `string?` | Username |
+| `nickname` | `string?` | Nickname |
+| `picture` | `string?` | Avatar URL |
+| `roles` | `string[]?` | User roles |
+| `permissions` | `string[]?` | User permissions |
+
+Providers may add extra fields (e.g., WorkOS adds `organization_id`, Supabase adds `aal`). Access them via `ctx.auth.user.organization_id` or `ctx.auth.payload` for raw claims.
+
+### `ctx.auth.payload` (Raw Claims)
+
+**Type:** `Record<string, unknown>` — all values are `unknown` and require explicit casts.
+
+This applies to **all providers** (WorkOS, Supabase, Auth0, Custom, etc.) since every provider's `verifyToken` returns `Record<string, unknown>`.
+
+**Prefer typed accessors** (`ctx.auth.user.*`, `ctx.auth.scopes`, `ctx.auth.permissions`) over raw payload access. If your provider has non-standard claims, map them into typed `ctx.auth.user` fields via the `getUserInfo` option rather than casting in every tool handler:
+
+```typescript
+// ✅ Preferred: map claims once in getUserInfo (custom provider example)
+oauth: oauthCustomProvider({
+  // ...endpoints and verifyToken...
+  getUserInfo: (payload) => ({
+    userId: payload.sub as string,
+    email: payload.mail as string,
+    name: payload.display_name as string,
+    roles: (payload.groups as string[]) || [],
+  }),
+})
+
+// Then access typed fields in tools:
+async (_args, ctx) => object({ email: ctx.auth.user.email })
+```
+
+```typescript
+// ❌ Avoid: casting raw payload in every tool handler
+async (_args, ctx) => {
+  const exp = ctx.auth.payload.exp as number;  // unknown → number cast needed
+  return object({ expiresAt: new Date(exp * 1000).toISOString() });
+}
+```
+
+If you must read raw claims (e.g., for debugging or provider-specific fields not in `UserInfo`), cast explicitly:
+
+```typescript
+const exp = ctx.auth.payload.exp as number | undefined;
+const iat = ctx.auth.payload.iat as number | undefined;
+const customField = ctx.auth.payload.my_field as string;
+```
+
+---
+
+## Zero-Config Setup
+
+All built-in providers support zero-config via environment variables. Call the factory with no arguments and it reads from `MCP_USE_OAUTH_*` env vars:
+
+```typescript
+oauth: oauthWorkOSProvider()    // reads MCP_USE_OAUTH_WORKOS_*
+oauth: oauthSupabaseProvider()  // reads MCP_USE_OAUTH_SUPABASE_*
+```
+
+Or pass config explicitly to override env vars. See each provider's guide for available options.
+
+---
+
+## Available Providers
+
+| Provider | Factory Function | Required Env Vars | Guide |
+|----------|-----------------|-------------------|-------|
+| **WorkOS** | `oauthWorkOSProvider()` | `MCP_USE_OAUTH_WORKOS_SUBDOMAIN` | [workos.md](workos.md) |
+| **Supabase** | `oauthSupabaseProvider()` | `MCP_USE_OAUTH_SUPABASE_PROJECT_ID` | [supabase.md](supabase.md) |
+| **Custom** | `oauthCustomProvider({...})` | None (all passed via config) | [custom.md](custom.md) |
+
+---
+
+## Making Authenticated API Calls
+
+Use `ctx.auth.accessToken` to call your provider's API on behalf of the user:
+
+```typescript
+server.tool(
+  { name: "fetch-data", description: "Fetch user data from API" },
+  async (_args, ctx) => {
+    const res = await fetch("https://api.example.com/me", {
+      headers: {
+        Authorization: `Bearer ${ctx.auth.accessToken}`,
+      },
+    });
+
+    if (!res.ok) {
+      return error(`API call failed: ${res.status}`);
+    }
+
+    return object(await res.json());
+  }
+);
+```
+
+---
+
+## Common Mistakes
+
+- **Wrong `ctx.auth` shape** — User info is nested: `ctx.auth.user.email`, not `ctx.auth.email`
+- **Hardcoding provider credentials** — Use env vars or pass config; never commit secrets
+- **Skipping JWT verification in production** — `verifyJwt: false` / `skipVerification: true` are for development only
+- **Throwing errors instead of returning `error()`** — Use the `error()` response helper for auth-related failures
+
+---
+
+## Next Steps
+
+- **WorkOS setup** → [workos.md](workos.md)
+- **Supabase setup** → [supabase.md](supabase.md)
+- **Custom provider** → [custom.md](custom.md)
+- **Build tools** → [../server/tools.md](../server/tools.md)
+- **See examples** → [../patterns/common-patterns.md](../patterns/common-patterns.md)

--- a/skills/mcp-apps-builder/references/authentication/supabase.md
+++ b/skills/mcp-apps-builder/references/authentication/supabase.md
@@ -1,0 +1,178 @@
+# Supabase Authentication
+
+Setting up OAuth with Supabase.
+
+**Learn more:** [Supabase MCP Authentication](https://supabase.com/docs/guides/auth/oauth-server/mcp-authentication)
+
+---
+
+## Quick Start
+
+```typescript
+import { MCPServer, oauthSupabaseProvider, object } from "mcp-use/server";
+
+const server = new MCPServer({
+  name: "my-server",
+  version: "1.0.0",
+  oauth: oauthSupabaseProvider(),
+});
+
+server.tool(
+  { name: "whoami", description: "Get authenticated user info" },
+  async (_args, ctx) =>
+    object({
+      userId: ctx.auth.user.userId,
+      email: ctx.auth.user.email,
+    })
+);
+
+server.listen();
+```
+
+With a `.env` file:
+
+```bash
+MCP_USE_OAUTH_SUPABASE_PROJECT_ID=your-project-id
+```
+
+JWT verification, OAuth discovery, and token proxying are handled automatically.
+
+---
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `MCP_USE_OAUTH_SUPABASE_PROJECT_ID` | Yes | Your Supabase project ID |
+| `MCP_USE_OAUTH_SUPABASE_JWT_SECRET` | No | JWT secret for HS256 token verification |
+
+> `NEXT_PUBLIC_SUPABASE_ANON_KEY` is not read by the SDK. It's a user-defined env var you'll need if your tools make Supabase REST API calls (see [Making Supabase API Calls](#making-supabase-api-calls)).
+
+### Finding Your Credentials
+
+- **Project ID**: Supabase Dashboard → **Project Settings** → **General** → Reference ID
+- **JWT Secret**: Supabase Dashboard → **Project Settings** → **JWT Settings** (Legacy section)
+- **Anon Key**: Supabase Dashboard → **Project Settings** → **API Keys**
+
+---
+
+## Configuration Options
+
+Zero-config (reads from env vars):
+
+```typescript
+oauth: oauthSupabaseProvider()
+```
+
+Explicit config (overrides env vars):
+
+```typescript
+oauth: oauthSupabaseProvider({
+  projectId: "my-project-id",
+  jwtSecret: process.env.SUPABASE_JWT_SECRET,
+  skipVerification: false,
+})
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `projectId` | `string` | env var | Supabase project ID |
+| `jwtSecret` | `string?` | env var | JWT secret for HS256 tokens |
+| `skipVerification` | `boolean?` | `false` | Skip JWT verification (development only) |
+
+---
+
+## JWT Signing: HS256 vs ES256
+
+Supabase supports two JWT signing algorithms:
+
+### ES256 (Newer Projects)
+
+Asymmetric signing using elliptic curve keys. Tokens are verified via Supabase's JWKS endpoint automatically. No `jwtSecret` needed.
+
+### HS256 (Legacy Projects)
+
+Symmetric signing using a shared secret. You must provide `MCP_USE_OAUTH_SUPABASE_JWT_SECRET` for verification.
+
+The provider auto-detects the algorithm from the token header. If your project uses HS256, make sure the JWT secret is configured. If it uses ES256, you can omit it.
+
+---
+
+## User Context
+
+Supabase populates these fields on `ctx.auth.user`:
+
+| Field | Type | Source |
+|-------|------|--------|
+| `userId` | `string` | `sub` or `user_id` claim |
+| `email` | `string?` | `email` claim |
+| `name` | `string?` | `user_metadata.name` or `user_metadata.full_name` |
+| `username` | `string?` | `user_metadata.username` |
+| `picture` | `string?` | `user_metadata.avatar_url` |
+| `roles` | `string[]` | `role` claim (e.g., `["authenticated"]`) |
+| `permissions` | `string[]` | Derived from AAL (e.g., `["aal:aal1"]`) |
+| `aal` | `string?` | Authentication Assurance Level |
+| `amr` | `array?` | Authentication Methods References |
+| `session_id` | `string?` | Supabase session ID |
+
+---
+
+## Making Supabase API Calls
+
+Use `ctx.auth.accessToken` as the bearer token for Supabase REST API calls. This ensures Row Level Security (RLS) policies apply to the authenticated user:
+
+```typescript
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+server.tool(
+  { name: "get-notes", description: "Fetch user's notes from Supabase" },
+  async (_args, ctx) => {
+    const projectId = process.env.MCP_USE_OAUTH_SUPABASE_PROJECT_ID;
+
+    if (!projectId || !SUPABASE_ANON_KEY) {
+      return error("Supabase credentials not configured");
+    }
+
+    const res = await fetch(
+      `https://${projectId}.supabase.co/rest/v1/notes`,
+      {
+        headers: {
+          Authorization: `Bearer ${ctx.auth.accessToken}`,
+          apikey: SUPABASE_ANON_KEY,
+        },
+      }
+    );
+
+    if (!res.ok) {
+      return error(`Supabase API failed: ${res.status}`);
+    }
+
+    return object(await res.json());
+  }
+);
+```
+
+**Key point:** The `Authorization` header uses the user's access token (for RLS), while the `apikey` header uses the anon key (for API access).
+
+---
+
+## Example `.env`
+
+```bash
+# Required: Supabase project ID (Dashboard → Project Settings → General)
+MCP_USE_OAUTH_SUPABASE_PROJECT_ID=your-project-id
+
+# Optional: JWT secret for HS256 verification (Dashboard → Project Settings → JWT Settings)
+MCP_USE_OAUTH_SUPABASE_JWT_SECRET=your-jwt-secret
+
+# Optional: Anon key for Supabase REST API calls (Dashboard → Project Settings → API Keys)
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+```
+
+---
+
+## Next Steps
+
+- **Auth overview** → [overview.md](overview.md)
+- **WorkOS setup** → [workos.md](workos.md)
+- **Build tools** → [../server/tools.md](../server/tools.md)

--- a/skills/mcp-apps-builder/references/authentication/workos.md
+++ b/skills/mcp-apps-builder/references/authentication/workos.md
@@ -1,0 +1,199 @@
+# WorkOS Authentication
+
+Setting up OAuth with WorkOS AuthKit.
+
+**Learn more:** [WorkOS MCP docs](https://workos.com/docs/authkit/mcp) · [WorkOS AuthKit](https://workos.com/docs/authkit)
+
+---
+
+## Quick Start
+
+```typescript
+import { MCPServer, oauthWorkOSProvider, object } from "mcp-use/server";
+
+const server = new MCPServer({
+  name: "my-server",
+  version: "1.0.0",
+  oauth: oauthWorkOSProvider(),
+});
+
+server.tool(
+  { name: "whoami", description: "Get authenticated user info" },
+  async (_args, ctx) =>
+    object({
+      userId: ctx.auth.user.userId,
+      email: ctx.auth.user.email,
+      name: ctx.auth.user.name,
+    })
+);
+
+server.listen();
+```
+
+With a `.env` file:
+
+```bash
+MCP_USE_OAUTH_WORKOS_SUBDOMAIN=your-subdomain
+```
+
+That's it. JWT verification, OAuth discovery, and token proxying are handled automatically.
+
+---
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `MCP_USE_OAUTH_WORKOS_SUBDOMAIN` | Yes | Your AuthKit subdomain (e.g., `my-company`) |
+| `MCP_USE_OAUTH_WORKOS_CLIENT_ID` | No | Pre-registered OAuth client ID. Omit for DCR mode |
+| `MCP_USE_OAUTH_WORKOS_API_KEY` | No | WorkOS API key for making WorkOS API calls |
+
+### Finding Your Subdomain
+
+WorkOS Dashboard → **Domains** tab → **AuthKit Domain**
+
+The subdomain is the part before `.authkit.app`. For example, if your AuthKit domain is `my-company.authkit.app`, the subdomain is `my-company`.
+
+---
+
+## Configuration Options
+
+Zero-config (reads from env vars):
+
+```typescript
+oauth: oauthWorkOSProvider()
+```
+
+Explicit config (overrides env vars):
+
+```typescript
+oauth: oauthWorkOSProvider({
+  subdomain: "my-company",
+  clientId: "client_01KB5DRXBDDY1VGCBKY108SKJW",  // optional
+  apiKey: "sk_test_...",                             // optional
+  verifyJwt: false,                                  // development only
+})
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `subdomain` | `string` | env var | AuthKit subdomain |
+| `clientId` | `string?` | env var | Pre-registered client ID. Omit for DCR |
+| `apiKey` | `string?` | env var | WorkOS API key |
+| `verifyJwt` | `boolean?` | `true` | Set `false` to skip JWT verification (development only) |
+
+---
+
+## Dynamic Client Registration (DCR)
+
+DCR lets MCP clients register themselves automatically with WorkOS. This is the recommended mode for MCP servers.
+
+> **Testing with the MCP Inspector:** Use DCR mode (do **not** set `MCP_USE_OAUTH_WORKOS_CLIENT_ID`). The Inspector relies on DCR to self-register — without it, the OAuth flow will stall because the Inspector has no pre-configured `client_id`.
+
+**Setup:**
+1. Don't set `MCP_USE_OAUTH_WORKOS_CLIENT_ID`
+2. Enable DCR in WorkOS Dashboard → **Connect** → **Configuration**
+
+MCP clients (like the Inspector) will register themselves on first connection.
+
+### Pre-registered Client (Alternative)
+
+If you need a specific OAuth client instead of DCR:
+
+1. Create an OAuth application in WorkOS Dashboard → **Connect** → **OAuth Applications**
+2. Set `MCP_USE_OAUTH_WORKOS_CLIENT_ID` to the client ID
+3. Configure redirect URIs in the dashboard to match your MCP client
+
+---
+
+## User Context
+
+WorkOS populates these fields on `ctx.auth.user`:
+
+| Field | Type | Source |
+|-------|------|--------|
+| `userId` | `string` | `sub` claim |
+| `email` | `string?` | `email` claim |
+| `name` | `string?` | `name` claim |
+| `username` | `string?` | `preferred_username` claim |
+| `picture` | `string?` | `picture` claim |
+| `roles` | `string[]` | `roles` claim |
+| `permissions` | `string[]` | `permissions` claim |
+| `scopes` | `string[]` | Parsed from `scope` claim |
+| `email_verified` | `boolean?` | `email_verified` claim |
+| `organization_id` | `string?` | `org_id` claim |
+| `sid` | `string?` | Session ID |
+
+### Role-Based Access
+
+```typescript
+server.tool(
+  { name: "admin-action", description: "Admin-only operation" },
+  async (_args, ctx) => {
+    if (!ctx.auth.user.roles?.includes("admin")) {
+      return error("Forbidden: admin role required");
+    }
+
+    // ... admin logic
+    return text("Done");
+  }
+);
+```
+
+---
+
+## Making WorkOS API Calls
+
+Use the WorkOS API key (not the user's access token) for WorkOS management API calls:
+
+```typescript
+const WORKOS_API_KEY = process.env.MCP_USE_OAUTH_WORKOS_API_KEY;
+
+server.tool(
+  { name: "get-workos-user", description: "Fetch user profile from WorkOS" },
+  async (_args, ctx) => {
+    if (!WORKOS_API_KEY) {
+      return error("WorkOS API key not configured");
+    }
+
+    const res = await fetch(
+      `https://api.workos.com/user_management/users/${ctx.auth.user.userId}`,
+      {
+        headers: {
+          Authorization: `Bearer ${WORKOS_API_KEY}`,
+          "Content-Type": "application/json",
+        },
+      }
+    );
+
+    if (!res.ok) {
+      return error(`WorkOS API failed: ${res.status} ${res.statusText}`);
+    }
+
+    return object(await res.json());
+  }
+);
+```
+
+---
+
+## Example `.env`
+
+```bash
+# Required: AuthKit subdomain (WorkOS Dashboard → Domains → AuthKit Domain)
+MCP_USE_OAUTH_WORKOS_SUBDOMAIN=my-company
+
+# Optional: Pre-registered OAuth client ID (omit for DCR mode)
+# MCP_USE_OAUTH_WORKOS_CLIENT_ID=client_01KB5DRXBDDY1VGCBKY108SKJW
+
+# Optional: WorkOS API key for management API calls
+MCP_USE_OAUTH_WORKOS_API_KEY=sk_test_...
+```
+
+---
+
+## Next Steps
+
+- **Auth overview** → [overview.md](overview.md)
+- **Supabase setup** → [supabase.md](supabase.md)
+- **Build tools** → [../server/tools.md](../server/tools.md)

--- a/skills/mcp-apps-builder/references/foundations/architecture.md
+++ b/skills/mcp-apps-builder/references/foundations/architecture.md
@@ -156,16 +156,20 @@ Understanding the flow of a request:
    ↓
 2. Hono middleware chain (server.app.use)
    ↓
-3. MCP protocol routing
+3. OAuth bearer auth (if `oauth` is configured — verifies JWT, populates ctx.auth)
    ↓
-4. Tool/Resource/Prompt handler
+4. MCP protocol routing
    ↓
-5. Response helpers (text, object, etc.)
+5. Tool/Resource/Prompt handler
    ↓
-6. MCP protocol response
+6. Response helpers (text, object, etc.)
    ↓
-7. HTTP Response
+7. MCP protocol response
+   ↓
+8. HTTP Response
 ```
+
+> When `oauth` is configured, unauthenticated requests to `/mcp/*` receive a `401` with a `WWW-Authenticate` header that tells MCP clients where to start the OAuth flow. See [../authentication/overview.md](../authentication/overview.md) for setup.
 
 ### Example Flow
 
@@ -224,20 +228,6 @@ server.use(async (c, next) => {
   await next();
   const duration = Date.now() - start;
   console.log(`${c.req.method} ${c.req.path} - ${duration}ms`);
-});
-```
-
-### Authentication Middleware
-
-```typescript
-server.use(async (c, next) => {
-  const apiKey = c.req.header('x-api-key');
-
-  if (!apiKey || apiKey !== process.env.API_KEY) {
-    return c.json({ error: "Unauthorized" }, 401);
-  }
-
-  await next();
 });
 ```
 


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope
Skills — `skills/mcp-apps-builder/`

## Changes

Add authentication reference docs to the mcp-apps-builder agent skill.

- New files: `references/authentication/overview.md`, `workos.md`, `supabase.md`, `custom.md`
- Updated `SKILL.md` with authentication navigation section and decision tree entry
- Updated `architecture.md` to include OAuth in the request flow and removed incorrect auth guidance

## Testing

- Cross-referenced all guidance against the actual codebase types and OAuth middleware
- Manually tested custom OAuth example with the MCP Inspector to validate documented behaviors (DCR requirements, payload typing, etc.)