### PR TITLE
fix: resolve local $ref pointers in fix_schema before jsonschema_to_pydantic

### DIFF
--- a/libraries/python/mcp_use/agents/adapters/base.py
+++ b/libraries/python/mcp_use/agents/adapters/base.py
@@ -4,6 +4,7 @@ Base adapter interface for MCP tools.
 This module provides the abstract base class that all MCP tool adapters should inherit from.
 """
 
+import copy
 from abc import ABC, abstractmethod
 from typing import Any, Generic, TypeVar
 
@@ -70,8 +71,15 @@ class BaseAdapter(Generic[T], ABC):
             # Fallback for unexpected types
             return str(tool_result)
 
-    def fix_schema(self, schema: Any) -> Any:
-        """Convert JSON Schema 'type': ['string', 'null'] to 'anyOf' format and fix enum handling.
+    def fix_schema(self, schema: Any, _root: Any = None, _resolving: frozenset[str] | None = None) -> Any:
+        """Convert JSON Schema to a form compatible with jsonschema_to_pydantic.
+
+        Performs three normalizations:
+        - Resolves local ``$ref`` pointers (e.g. ``#/properties/position``) that
+          ``jsonschema_to_pydantic`` cannot handle.  Refs targeting ``$defs`` or
+          ``definitions`` are left intact so that the library can resolve them itself.
+        - Converts ``"type": ["string", "null"]`` arrays to ``anyOf`` form.
+        - Adds ``"type": "string"`` to ``enum`` fields that lack an explicit type.
 
         Args:
             schema: The JSON schema to fix.
@@ -79,19 +87,45 @@ class BaseAdapter(Generic[T], ABC):
         Returns:
             The fixed JSON schema.
         """
+        if _root is None:
+            _root = schema
+        if _resolving is None:
+            _resolving = frozenset()
+
         if isinstance(schema, dict):
+            # Inline $ref pointers that jsonschema_to_pydantic cannot resolve.
+            # Refs targeting $defs / definitions are left intact for that library to handle.
+            if "$ref" in schema:
+                ref = schema["$ref"]
+                if isinstance(ref, str) and ref.startswith("#/"):
+                    parts = ref[2:].split("/")
+                    if parts and parts[0] not in ("$defs", "definitions") and ref not in _resolving:
+                        try:
+                            resolved = _root
+                            for part in parts:
+                                part = part.replace("~1", "/").replace("~0", "~")  # RFC 6901
+                                resolved = resolved[int(part) if isinstance(resolved, list) else part]
+                            resolved = copy.deepcopy(resolved)
+                            sibling_keys = {k: v for k, v in schema.items() if k != "$ref"}
+                            if sibling_keys and isinstance(resolved, dict):
+                                # Wrap in allOf so sibling constraints are combined without
+                                # overwriting any keyword already present in the resolved schema.
+                                resolved = {"allOf": [resolved, sibling_keys]}
+                            return self.fix_schema(resolved, _root, _resolving | {ref})
+                        except (KeyError, TypeError, IndexError, ValueError):
+                            pass
+
             if "type" in schema and isinstance(schema["type"], list):
                 schema["anyOf"] = [{"type": t} for t in schema["type"]]
-                del schema["type"]  # Remove 'type' and standardize to 'anyOf'
+                del schema["type"]
 
-            # Fix enum handling - ensure enum fields are properly typed as strings
             if "enum" in schema and "type" not in schema:
                 schema["type"] = "string"
 
             for key, value in schema.items():
-                schema[key] = self.fix_schema(value)  # Apply recursively
+                schema[key] = self.fix_schema(value, _root, _resolving)
         elif isinstance(schema, list):
-            return [self.fix_schema(item) for item in schema]
+            return [self.fix_schema(item, _root, _resolving) for item in schema]
         return schema
 
     async def _get_connectors(self, client: MCPClient) -> list[BaseConnector]:

--- a/libraries/python/mcp_use/agents/adapters/langchain_adapter.py
+++ b/libraries/python/mcp_use/agents/adapters/langchain_adapter.py
@@ -31,6 +31,50 @@ class _EmptyInput(BaseModel):
     pass
 
 
+def _resolve_ref(schema: Any, root_schema: Any, seen_refs: frozenset[str] = frozenset()) -> Any:
+    """Follow a local JSON Pointer $ref within root_schema (including $defs refs).
+
+    Unlike fix_schema, this resolves all #/ refs — including #/$defs — so that
+    _schema_allows_null can detect nullability through definition references.
+    """
+    if not isinstance(schema, dict):
+        return schema
+    ref = schema.get("$ref")
+    if not isinstance(ref, str) or not ref.startswith("#/") or ref in seen_refs:
+        return schema
+    try:
+        resolved: Any = root_schema
+        for part in ref[2:].split("/"):
+            part = part.replace("~1", "/").replace("~0", "~")  # RFC 6901
+            resolved = resolved[int(part) if isinstance(resolved, list) else part]
+    except (KeyError, TypeError, IndexError, ValueError):
+        return schema
+    return _resolve_ref(resolved, root_schema, seen_refs | {ref})
+
+
+def _schema_allows_null(schema: Any, root_schema: Any) -> bool:
+    """Return True if schema or any of its branches permit a null value."""
+    if not isinstance(schema, dict):
+        return False
+    resolved = _resolve_ref(schema, root_schema)
+    if resolved is not schema:
+        return _schema_allows_null(resolved, root_schema)
+    schema_type = schema.get("type")
+    if schema_type == "null":
+        return True
+    if isinstance(schema_type, list) and "null" in schema_type:
+        return True
+    for combinator in ("anyOf", "oneOf"):
+        options = schema.get(combinator)
+        if isinstance(options, list) and any(_schema_allows_null(option, root_schema) for option in options):
+            return True
+    # Be conservative for allOf: preserve null if any branch allows it.
+    all_of = schema.get("allOf")
+    if isinstance(all_of, list) and any(_schema_allows_null(option, root_schema) for option in all_of):
+        return True
+    return False
+
+
 class LangChainAdapter(BaseAdapter[BaseTool]):
     """Adapter for converting MCP tools to LangChain tools."""
 
@@ -69,57 +113,6 @@ class LangChainAdapter(BaseAdapter[BaseTool]):
         adapter_self = self
         fixed_input_schema = adapter_self.fix_schema(mcp_tool.inputSchema)
 
-        def _resolve_local_ref_schema(
-            schema: Any, root_schema: Any, seen_refs: frozenset[str] | None = None
-        ) -> Any:
-            if not isinstance(schema, dict):
-                return schema
-
-            if seen_refs is None:
-                seen_refs = frozenset()
-
-            ref = schema.get("$ref")
-            if not isinstance(ref, str) or not ref.startswith("#/") or ref in seen_refs:
-                return schema
-
-            try:
-                resolved: Any = root_schema
-                for part in ref[2:].split("/"):
-                    part = part.replace("~1", "/").replace("~0", "~")  # RFC 6901
-                    resolved = resolved[int(part) if isinstance(resolved, list) else part]
-            except (KeyError, TypeError, IndexError, ValueError):
-                return schema
-
-            return _resolve_local_ref_schema(resolved, root_schema, seen_refs | {ref})
-
-        def _schema_allows_null(schema: Any) -> bool:
-            if not isinstance(schema, dict):
-                return False
-
-            resolved_schema = _resolve_local_ref_schema(schema, fixed_input_schema)
-            if isinstance(resolved_schema, dict) and resolved_schema is not schema:
-                return _schema_allows_null(resolved_schema)
-
-            schema_type = schema.get("type")
-            if schema_type == "null":
-                return True
-            if isinstance(schema_type, list) and "null" in schema_type:
-                return True
-
-            for combinator in ("anyOf", "oneOf"):
-                options = schema.get(combinator)
-                if isinstance(options, list) and any(_schema_allows_null(option) for option in options):
-                    return True
-
-            # Be conservative when schemas are wrapped in allOf (e.g. a local $ref
-            # combined with metadata siblings): preserve explicit null if any branch
-            # explicitly allows it, rather than dropping a meaningful null.
-            all_of = schema.get("allOf")
-            if isinstance(all_of, list) and any(_schema_allows_null(option) for option in all_of):
-                return True
-
-            return False
-
         nullable_optional_fields: set[str] = set()
         if isinstance(fixed_input_schema, dict):
             required_fields = set(fixed_input_schema.get("required", []))
@@ -128,7 +121,7 @@ class LangChainAdapter(BaseAdapter[BaseTool]):
                 nullable_optional_fields = {
                     field_name
                     for field_name, field_schema in properties.items()
-                    if field_name not in required_fields and _schema_allows_null(field_schema)
+                    if field_name not in required_fields and _schema_allows_null(field_schema, fixed_input_schema)
                 }
 
         class McpToLangChainAdapter(BaseTool):

--- a/libraries/python/mcp_use/agents/adapters/langchain_adapter.py
+++ b/libraries/python/mcp_use/agents/adapters/langchain_adapter.py
@@ -12,7 +12,6 @@ from langchain_core.tools import BaseTool
 from mcp.types import (
     CallToolResult,
     Prompt,
-    ReadResourceRequestParams,
     Resource,
 )
 from mcp.types import (
@@ -24,6 +23,12 @@ from mcp_use.agents.adapters.base import BaseAdapter
 from mcp_use.client.connectors.base import BaseConnector
 from mcp_use.errors.error_formatting import format_error
 from mcp_use.logging import logger
+
+
+class _EmptyInput(BaseModel):
+    """Empty input schema for tools that take no arguments."""
+
+    pass
 
 
 class LangChainAdapter(BaseAdapter[BaseTool]):
@@ -62,13 +67,76 @@ class LangChainAdapter(BaseAdapter[BaseTool]):
 
         # This is a dynamic class creation, we need to work with the self reference
         adapter_self = self
+        fixed_input_schema = adapter_self.fix_schema(mcp_tool.inputSchema)
+
+        def _resolve_local_ref_schema(
+            schema: Any, root_schema: Any, seen_refs: frozenset[str] | None = None
+        ) -> Any:
+            if not isinstance(schema, dict):
+                return schema
+
+            if seen_refs is None:
+                seen_refs = frozenset()
+
+            ref = schema.get("$ref")
+            if not isinstance(ref, str) or not ref.startswith("#/") or ref in seen_refs:
+                return schema
+
+            try:
+                resolved: Any = root_schema
+                for part in ref[2:].split("/"):
+                    part = part.replace("~1", "/").replace("~0", "~")  # RFC 6901
+                    resolved = resolved[int(part) if isinstance(resolved, list) else part]
+            except (KeyError, TypeError, IndexError, ValueError):
+                return schema
+
+            return _resolve_local_ref_schema(resolved, root_schema, seen_refs | {ref})
+
+        def _schema_allows_null(schema: Any) -> bool:
+            if not isinstance(schema, dict):
+                return False
+
+            resolved_schema = _resolve_local_ref_schema(schema, fixed_input_schema)
+            if isinstance(resolved_schema, dict) and resolved_schema is not schema:
+                return _schema_allows_null(resolved_schema)
+
+            schema_type = schema.get("type")
+            if schema_type == "null":
+                return True
+            if isinstance(schema_type, list) and "null" in schema_type:
+                return True
+
+            for combinator in ("anyOf", "oneOf"):
+                options = schema.get(combinator)
+                if isinstance(options, list) and any(_schema_allows_null(option) for option in options):
+                    return True
+
+            # Be conservative when schemas are wrapped in allOf (e.g. a local $ref
+            # combined with metadata siblings): preserve explicit null if any branch
+            # explicitly allows it, rather than dropping a meaningful null.
+            all_of = schema.get("allOf")
+            if isinstance(all_of, list) and any(_schema_allows_null(option) for option in all_of):
+                return True
+
+            return False
+
+        nullable_optional_fields: set[str] = set()
+        if isinstance(fixed_input_schema, dict):
+            required_fields = set(fixed_input_schema.get("required", []))
+            properties = fixed_input_schema.get("properties", {})
+            if isinstance(properties, dict):
+                nullable_optional_fields = {
+                    field_name
+                    for field_name, field_schema in properties.items()
+                    if field_name not in required_fields and _schema_allows_null(field_schema)
+                }
 
         class McpToLangChainAdapter(BaseTool):
             name: str = mcp_tool.name or "NO NAME"
             description: str = mcp_tool.description or ""
             # Convert JSON schema to Pydantic model for argument validation
             args_schema: type[BaseModel] = jsonschema_to_pydantic(
-                adapter_self.fix_schema(mcp_tool.inputSchema)  # Apply schema conversion
+                fixed_input_schema  # Apply schema conversion
             )
             tool_connector: BaseConnector = connector  # Renamed variable to avoid name conflict
             handle_tool_error: bool = True
@@ -99,8 +167,21 @@ class LangChainAdapter(BaseAdapter[BaseTool]):
                 """
                 logger.debug(f'MCP tool: "{self.name}" received input: {kwargs}')
 
+                # Strip None values for optional fields so they are sent as
+                # absent rather than JSON null. Keep None when the MCP schema
+                # explicitly allows null or the field is required.
+                filtered_kwargs: dict[str, Any] = {}
+                for key, value in kwargs.items():
+                    if value is not None:
+                        filtered_kwargs[key] = value
+                        continue
+
+                    field_info = self.args_schema.model_fields.get(key)
+                    if (field_info and field_info.is_required()) or key in nullable_optional_fields:
+                        filtered_kwargs[key] = value
+
                 try:
-                    tool_result: CallToolResult = await self.tool_connector.call_tool(self.name, kwargs)
+                    tool_result: CallToolResult = await self.tool_connector.call_tool(self.name, filtered_kwargs)
                     try:
                         # Use the helper function to parse the result
                         return str(tool_result.content)
@@ -131,7 +212,7 @@ class LangChainAdapter(BaseAdapter[BaseTool]):
             description: str = (
                 mcp_resource.description or f"Return the content of the resource located at URI {mcp_resource.uri}."
             )
-            args_schema: type[BaseModel] = ReadResourceRequestParams
+            args_schema: type[BaseModel] = _EmptyInput
             tool_connector: BaseConnector = connector
             handle_tool_error: bool = True
 

--- a/libraries/python/tests/unit/test_schema_handling.py
+++ b/libraries/python/tests/unit/test_schema_handling.py
@@ -1,0 +1,357 @@
+"""
+Unit tests for fix_schema $ref resolution and LangChain adapter tool conversion.
+"""
+
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+from jsonschema_pydantic import jsonschema_to_pydantic
+from mcp.types import Resource
+from mcp.types import Tool as MCPTool
+from pydantic import AnyUrl
+
+from mcp_use.agents.adapters.langchain_adapter import LangChainAdapter
+
+
+class TestRefResolution(unittest.TestCase):
+    """Tests for JSON Schema local $ref pointer resolution in fix_schema."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.adapter = LangChainAdapter()
+
+    def test_resolves_property_ref(self):
+        """A $ref to another property is inlined and the $ref key is removed."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "position": {
+                    "type": "object",
+                    "properties": {
+                        "x": {"type": "number"},
+                        "y": {"type": "number"},
+                        "z": {"type": "number"},
+                    },
+                },
+                "rotation": {"$ref": "#/properties/position"},
+            },
+        }
+        fixed = self.adapter.fix_schema(schema)
+
+        rotation = fixed["properties"]["rotation"]
+        self.assertEqual(rotation["type"], "object")
+        self.assertIn("x", rotation["properties"])
+        self.assertNotIn("$ref", rotation)
+
+    def test_defs_refs_left_intact(self):
+        """$ref targeting $defs is left intact for jsonschema_to_pydantic to handle."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "rotation": {"$ref": "#/$defs/Vector3"},
+            },
+            "$defs": {
+                "Vector3": {
+                    "type": "object",
+                    "properties": {
+                        "x": {"type": "number"},
+                        "y": {"type": "number"},
+                        "z": {"type": "number"},
+                    },
+                }
+            },
+        }
+        fixed = self.adapter.fix_schema(schema)
+        self.assertEqual(fixed["properties"]["rotation"]["$ref"], "#/$defs/Vector3")
+
+    def test_definitions_refs_left_intact(self):
+        """$ref targeting definitions (draft-07 style) is left intact for jsonschema_to_pydantic to handle."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "item": {"$ref": "#/definitions/MyType"},
+            },
+            "definitions": {
+                "MyType": {"type": "string"},
+            },
+        }
+        fixed = self.adapter.fix_schema(schema)
+        self.assertEqual(fixed["properties"]["item"]["$ref"], "#/definitions/MyType")
+
+    def test_circular_ref_does_not_recurse_infinitely(self):
+        """A self-referencing $ref does not cause infinite recursion."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "self_ref": {"$ref": "#/properties/self_ref"},
+            },
+        }
+        fixed = self.adapter.fix_schema(schema)
+        self.assertIsInstance(fixed, dict)
+
+    def test_unresolvable_ref_left_intact(self):
+        """A $ref to a non-existent path is left as-is without raising."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "field": {"$ref": "#/nonexistent/path"},
+            },
+        }
+        fixed = self.adapter.fix_schema(schema)
+        self.assertEqual(fixed["properties"]["field"]["$ref"], "#/nonexistent/path")
+
+    def test_sibling_keys_combined_via_allof_on_resolution(self):
+        """Sibling keys alongside $ref are combined via allOf to avoid overwriting resolved constraints."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "position": {"type": "object", "properties": {"x": {"type": "number"}}},
+                "rotation": {"$ref": "#/properties/position", "description": "The rotation"},
+            },
+        }
+        fixed = self.adapter.fix_schema(schema)
+        rotation = fixed["properties"]["rotation"]
+        self.assertIn("allOf", rotation)
+        sub_schemas = rotation["allOf"]
+        self.assertTrue(any(s.get("type") == "object" for s in sub_schemas))
+        self.assertTrue(any(s.get("description") == "The rotation" for s in sub_schemas))
+
+    def test_property_ref_produces_valid_pydantic_model(self):
+        """A schema with inlined property $refs is accepted by jsonschema_to_pydantic.
+
+        Regression test for https://github.com/mcp-use/mcp-use/issues/964.
+        """
+        schema = {
+            "type": "object",
+            "properties": {
+                "position": {
+                    "type": "object",
+                    "properties": {
+                        "x": {"type": "number"},
+                        "y": {"type": "number"},
+                        "z": {"type": "number"},
+                    },
+                },
+                "rotation": {"$ref": "#/properties/position"},
+            },
+            "required": ["position", "rotation"],
+        }
+        fixed = self.adapter.fix_schema(schema)
+        model = jsonschema_to_pydantic(fixed)
+        self.assertIsNotNone(model)
+        self.assertIn("position", model.model_fields)
+        self.assertIn("rotation", model.model_fields)
+
+    def test_resolves_array_index_ref(self):
+        """A $ref with a numeric JSON Pointer segment traverses list nodes correctly."""
+        schema = {
+            "type": "object",
+            "allOf": [
+                {"properties": {"x": {"type": "number"}}},
+            ],
+            "properties": {
+                "alias": {"$ref": "#/allOf/0"},
+            },
+        }
+        fixed = self.adapter.fix_schema(schema)
+        alias = fixed["properties"]["alias"]
+        self.assertNotIn("$ref", alias)
+        self.assertIn("x", alias["properties"])
+
+    def test_json_pointer_rfc6901_escaping(self):
+        """JSON Pointer escape sequences (~0, ~1) are decoded per RFC 6901."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "my/prop": {"type": "string"},
+                "alias": {"$ref": "#/properties/my~1prop"},
+            },
+        }
+        fixed = self.adapter.fix_schema(schema)
+        self.assertEqual(fixed["properties"]["alias"]["type"], "string")
+        self.assertNotIn("$ref", fixed["properties"]["alias"])
+
+
+class TestNoneFilteringInToolCall(unittest.IsolatedAsyncioTestCase):
+    """Tests that None/null optional values are stripped before calling the MCP server."""
+
+    async def test_none_values_stripped_from_tool_call(self):
+        """Optional fields with None values should not be sent to the MCP server.
+
+        Regression test: MCP servers using Zod .optional() accept absent fields
+        but reject explicit null, so we must strip None values before the call.
+        """
+        adapter = LangChainAdapter()
+
+        # Schema mimicking add_asset_to_scene: assetPath required, others optional
+        schema = {
+            "type": "object",
+            "properties": {
+                "assetPath": {"type": "string"},
+                "guid": {"type": "string"},
+                "parentPath": {"type": "string"},
+                "parentId": {"type": "number"},
+            },
+            "required": ["assetPath"],
+        }
+
+        mock_connector = MagicMock()
+        mock_result = MagicMock()
+        mock_result.content = [MagicMock(text="ok")]
+        mock_connector.call_tool = AsyncMock(return_value=mock_result)
+
+        mcp_tool = MCPTool(name="add_asset_to_scene", description="test", inputSchema=schema)
+        lc_tool = adapter._convert_tool(mcp_tool, mock_connector)
+
+        # Simulate LangChain passing None for optional fields
+        await lc_tool._arun(assetPath="Prefabs/Cube.prefab", guid=None, parentPath=None, parentId=None)
+
+        # Verify only non-None values were forwarded
+        mock_connector.call_tool.assert_called_once()
+        actual_args = mock_connector.call_tool.call_args[0][1]
+        self.assertNotIn("guid", actual_args)
+        self.assertNotIn("parentPath", actual_args)
+        self.assertNotIn("parentId", actual_args)
+        self.assertEqual(actual_args["assetPath"], "Prefabs/Cube.prefab")
+
+    async def test_required_nullable_none_is_preserved(self):
+        """Required nullable fields should be forwarded as explicit null."""
+        adapter = LangChainAdapter()
+
+        schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "parentId": {"type": ["number", "null"]},
+            },
+            "required": ["name", "parentId"],
+        }
+
+        mock_connector = MagicMock()
+        mock_result = MagicMock()
+        mock_result.content = [MagicMock(text="ok")]
+        mock_connector.call_tool = AsyncMock(return_value=mock_result)
+
+        mcp_tool = MCPTool(name="set_parent", description="test", inputSchema=schema)
+        lc_tool = adapter._convert_tool(mcp_tool, mock_connector)
+
+        await lc_tool._arun(name="Cube", parentId=None)
+
+        mock_connector.call_tool.assert_called_once()
+        actual_args = mock_connector.call_tool.call_args[0][1]
+        self.assertIn("parentId", actual_args)
+        self.assertIsNone(actual_args["parentId"])
+        self.assertEqual(actual_args["name"], "Cube")
+
+    async def test_optional_nullable_none_is_preserved(self):
+        """Optional nullable fields should be forwarded as explicit null."""
+        adapter = LangChainAdapter()
+
+        schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "label": {"type": "string"},
+                "parentId": {"type": ["number", "null"]},
+            },
+            "required": ["name"],
+        }
+
+        mock_connector = MagicMock()
+        mock_result = MagicMock()
+        mock_result.content = [MagicMock(text="ok")]
+        mock_connector.call_tool = AsyncMock(return_value=mock_result)
+
+        mcp_tool = MCPTool(name="set_parent_optional", description="test", inputSchema=schema)
+        lc_tool = adapter._convert_tool(mcp_tool, mock_connector)
+
+        await lc_tool._arun(name="Cube", label=None, parentId=None)
+
+        mock_connector.call_tool.assert_called_once()
+        actual_args = mock_connector.call_tool.call_args[0][1]
+        self.assertNotIn("label", actual_args)
+        self.assertIn("parentId", actual_args)
+        self.assertIsNone(actual_args["parentId"])
+        self.assertEqual(actual_args["name"], "Cube")
+
+    async def test_optional_nullable_none_via_defs_ref_is_preserved(self):
+        """Optional nullable fields referenced via $defs should keep explicit null."""
+        adapter = LangChainAdapter()
+
+        schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "parentId": {"$ref": "#/$defs/NullableId"},
+                "label": {"type": "string"},
+            },
+            "required": ["name"],
+            "$defs": {
+                "NullableId": {
+                    "anyOf": [{"type": "number"}, {"type": "null"}],
+                }
+            },
+        }
+
+        mock_connector = MagicMock()
+        mock_result = MagicMock()
+        mock_result.content = [MagicMock(text="ok")]
+        mock_connector.call_tool = AsyncMock(return_value=mock_result)
+
+        mcp_tool = MCPTool(name="set_parent_optional_defs", description="test", inputSchema=schema)
+        lc_tool = adapter._convert_tool(mcp_tool, mock_connector)
+
+        await lc_tool._arun(name="Cube", label=None, parentId=None)
+
+        mock_connector.call_tool.assert_called_once()
+        actual_args = mock_connector.call_tool.call_args[0][1]
+        self.assertNotIn("label", actual_args)
+        self.assertIn("parentId", actual_args)
+        self.assertIsNone(actual_args["parentId"])
+        self.assertEqual(actual_args["name"], "Cube")
+
+
+class TestResourceToolSchema(unittest.IsolatedAsyncioTestCase):
+    """Tests that LangChain resource tools use an empty args schema."""
+
+    def test_resource_tool_has_empty_args_schema(self):
+        """Resource tools should not expose a uri parameter.
+
+        Regression test for #964: ReadResourceRequestParams leaked a uri field
+        that caused AnyUrl validation errors when the LLM passed a plain string.
+        """
+        adapter = LangChainAdapter()
+        mock_connector = MagicMock()
+
+        resource = Resource(uri=AnyUrl("file:///test/path"), name="test_resource", description="A test resource")
+        tool = adapter._convert_resource(resource, mock_connector)
+
+        # The schema should have no required fields and no uri property
+        schema = tool.args_schema.model_json_schema()
+        self.assertEqual(schema.get("properties", {}), {})
+        self.assertNotIn("uri", schema.get("properties", {}))
+
+    async def test_resource_tool_invocable_without_uri(self):
+        """Resource tool should be callable with no arguments.
+
+        Regression test for #964: passing uri as a kwarg would fail AnyUrl validation.
+        """
+        adapter = LangChainAdapter()
+
+        mock_connector = MagicMock()
+        mock_content = MagicMock()
+        mock_content.__str__ = lambda self: "resource content"
+        mock_result = MagicMock()
+        mock_result.contents = [mock_content]
+        mock_connector.read_resource = AsyncMock(return_value=mock_result)
+
+        resource = Resource(uri=AnyUrl("file:///test/path"), name="test_resource", description="A test resource")
+        tool = adapter._convert_resource(resource, mock_connector)
+
+        result = await tool._arun()
+        mock_connector.read_resource.assert_called_once_with(AnyUrl("file:///test/path"))
+        self.assertEqual(result, "resource content")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/libraries/python/tests/unit/test_schema_handling.py
+++ b/libraries/python/tests/unit/test_schema_handling.py
@@ -79,7 +79,7 @@ class TestRefResolution(unittest.TestCase):
         self.assertEqual(fixed["properties"]["item"]["$ref"], "#/definitions/MyType")
 
     def test_circular_ref_does_not_recurse_infinitely(self):
-        """A self-referencing $ref does not cause infinite recursion."""
+        """A self-referencing $ref does not cause infinite recursion and is left intact."""
         schema = {
             "type": "object",
             "properties": {
@@ -88,6 +88,8 @@ class TestRefResolution(unittest.TestCase):
         }
         fixed = self.adapter.fix_schema(schema)
         self.assertIsInstance(fixed, dict)
+        # The circular ref cannot be resolved, so it must be left as-is
+        self.assertIn("$ref", fixed["properties"]["self_ref"])
 
     def test_unresolvable_ref_left_intact(self):
         """A $ref to a non-existent path is left as-is without raising."""
@@ -115,6 +117,33 @@ class TestRefResolution(unittest.TestCase):
         sub_schemas = rotation["allOf"]
         self.assertTrue(any(s.get("type") == "object" for s in sub_schemas))
         self.assertTrue(any(s.get("description") == "The rotation" for s in sub_schemas))
+
+    def test_sibling_keys_allof_produces_valid_pydantic_model(self):
+        """A $ref with sibling keys (allOf merge) is accepted by jsonschema_to_pydantic.
+
+        Regression test: verifies the allOf structure produced for sibling-key $refs
+        does not prevent Pydantic model generation.
+        """
+        schema = {
+            "type": "object",
+            "properties": {
+                "position": {
+                    "type": "object",
+                    "properties": {
+                        "x": {"type": "number"},
+                        "y": {"type": "number"},
+                        "z": {"type": "number"},
+                    },
+                },
+                "rotation": {"$ref": "#/properties/position", "description": "The rotation"},
+            },
+            "required": ["position", "rotation"],
+        }
+        fixed = self.adapter.fix_schema(schema)
+        model = jsonschema_to_pydantic(fixed)
+        self.assertIsNotNone(model)
+        self.assertIn("position", model.model_fields)
+        self.assertIn("rotation", model.model_fields)
 
     def test_property_ref_produces_valid_pydantic_model(self):
         """A schema with inlined property $refs is accepted by jsonschema_to_pydantic.


### PR DESCRIPTION
## Changes

Three fixes for MCP server compatibility issues reported in #964:

1. **`$ref` resolution crash** — `jsonschema_to_pydantic` only resolves refs targeting `$defs`/`definitions`. Local refs like `#/properties/position` caused `KeyError` during tool initialization.
2. **`None` kwargs sent as JSON `null`** — Optional fields with `None` values were forwarded to MCP servers, which reject explicit `null` when using Zod `.optional()`.
3. **Resource-as-tool URI validation error** — The LangChain adapter used `ReadResourceRequestParams` as the args schema for resource tools, leaking a `uri` field to the LLM. This caused `AnyUrl` validation errors when the LLM passed a plain string instead of a valid URL.

## Implementation Details

### 1. Local `$ref` resolution in `fix_schema`
- Extended `BaseAdapter.fix_schema()` to resolve local `$ref` pointers via RFC 6901 JSON Pointer traversal before the schema reaches `jsonschema_to_pydantic`.
- `$defs`/`definitions` refs are left intact. Unresolvable refs fall through silently. A `frozenset` of in-progress refs prevents infinite recursion on self-referential schemas.
- When a `$ref` node has sibling keys, they are combined via `allOf` to avoid overwriting constraints.

### 2. Strip `None` values from tool kwargs
- Filter out `None` values before calling `connector.call_tool()`, so optional fields are sent as absent rather than JSON `null`.
- Nullability detection is handled by module-level `_resolve_ref` / `_schema_allows_null` helpers. Unlike `fix_schema`, these follow all `#/` refs including `#/$defs` so that nullability can be detected through definition references. Both functions are module-level (not per-call closures) to avoid object creation overhead and duplication.

### 3. Empty args schema for resource tools
- Replaced `ReadResourceRequestParams` with an empty `BaseModel` (`_EmptyInput`) as the `args_schema` for resource tools. The resource URI is already captured in a closure and used directly in `_arun()` — the LLM should never need to provide it.

## Example Usage (Before)

```python
# 1. Schema with $ref — agent init raised KeyError('position')
schema = {
    "type": "object",
    "properties": {
        "position": {"type": "object", "properties": {"x": ..., "y": ..., "z": ...}},
        "rotation": {"$ref": "#/properties/position"},   # ← crash
    },
}

# 2. Optional fields sent as null — MCP server rejected them
await connector.call_tool("add_asset", {"assetPath": "Cube.prefab", "guid": None})  # ← error

# 3. Resource tool exposed uri field — LLM passed invalid string
# Error: uri: Input should be a valid URL, relative URL without a base
```

## Example Usage (After)

```python
# 1. fix_schema() inlines the ref before jsonschema_to_pydantic sees it
fixed = adapter.fix_schema(schema)
model = jsonschema_to_pydantic(fixed)  # ✓ no KeyError

# 2. None values stripped — only non-None kwargs forwarded
await connector.call_tool("add_asset", {"assetPath": "Cube.prefab"})  # ✓

# 3. Resource tool has empty schema — no uri field exposed to LLM
tool.args_schema.model_json_schema()  # ✓ {"properties": {}, ...}
```

## Testing

- **`$ref` resolution** (10 tests): property ref inlining, `$defs`/`definitions` refs left intact, circular ref detection (with assertion the ref is preserved as-is), unresolvable ref fallback, sibling keys via `allOf`, end-to-end Pydantic model regression for sibling-key `allOf`, numeric JSON Pointer segments, RFC 6901 escape decoding, full Pydantic model regression test.
- **`None` filtering** (4 tests): non-None kwargs forwarded, required nullable fields preserved as `null`, optional nullable fields preserved as `null`, optional nullable via `$defs` ref preserved as `null`.
- **Resource tool schema** (2 tests): verifies empty args schema with no `uri` property, and that the tool is callable without arguments.
- All existing unit tests continue to pass.

## Backwards Compatibility

Non-breaking. The `fix_schema` internal parameters are `_`-prefixed with `None` defaults. The `ReadResourceRequestParams` import was only used in the LangChain adapter for this incorrect schema assignment — all other usages (middleware) have their own imports and are unaffected.

## Related Issues

Closes #964