### PR TITLE
feat(useMcp): expose health check and reconnection options

### DIFF
--- a/libraries/typescript/packages/mcp-use/src/client/browser.ts
+++ b/libraries/typescript/packages/mcp-use/src/client/browser.ts
@@ -71,6 +71,7 @@ export class BrowserMCPClient extends BaseMCPClient {
       preferSse,
       gatewayUrl,
       serverId,
+      reconnectionOptions,
     } = serverConfig;
 
     if (!url) {
@@ -105,6 +106,7 @@ export class BrowserMCPClient extends BaseMCPClient {
       clientInfo,
       gatewayUrl,
       serverId,
+      reconnectionOptions,
     };
 
     logger.debug(

--- a/libraries/typescript/packages/mcp-use/src/connectors/http.ts
+++ b/libraries/typescript/packages/mcp-use/src/connectors/http.ts
@@ -34,6 +34,12 @@ export interface HttpConnectorOptions extends ConnectorInitOptions {
   preferSse?: boolean; // Force SSE transport instead of trying streamable HTTP first
   disableSseFallback?: boolean; // Disable automatic fallback to SSE when streamable HTTP fails (default: false)
   gatewayUrl?: string; // Optional gateway URL to route requests through
+  reconnectionOptions?: {
+    maxReconnectionDelay?: number;
+    initialReconnectionDelay?: number;
+    reconnectionDelayGrowFactor?: number;
+    maxRetries?: number;
+  }; // SDK-level reconnection options for streamable HTTP transport
   serverId?: string; // Optional server ID for gateway observability
 }
 
@@ -300,7 +306,8 @@ export class HttpConnector extends BaseConnector {
             maxReconnectionDelay: 30000,
             initialReconnectionDelay: 1000,
             reconnectionDelayGrowFactor: 1.5,
-            maxRetries: 2, // Disable automatic reconnection - let higher-level logic handle it
+            maxRetries: 2,
+            ...this.opts.reconnectionOptions, // Allow user overrides
           },
           // Don't pass sessionId - let the SDK generate it automatically during connect()
         }

--- a/libraries/typescript/packages/mcp-use/src/react/types.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/types.ts
@@ -13,6 +13,21 @@ import type {
 import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
 import type { BrowserMCPClient } from "../client/browser.js";
 
+
+/**
+ * Configuration for SDK-level reconnection behavior on streamable HTTP transports.
+ */
+export type ReconnectionOptions = {
+  /** Maximum delay between reconnection attempts in ms (default: 30000) */
+  maxReconnectionDelay?: number;
+  /** Initial delay before first reconnection attempt in ms (default: 1000) */
+  initialReconnectionDelay?: number;
+  /** Multiplier applied to delay after each failed attempt (default: 1.5) */
+  reconnectionDelayGrowFactor?: number;
+  /** Maximum number of reconnection retries (default: 2) */
+  maxRetries?: number;
+};
+
 export type UseMcpOptions = {
   /** The /sse URL of your remote MCP server */
   url?: string;
@@ -111,6 +126,12 @@ export type UseMcpOptions = {
   autoRetry?: boolean | number;
   /** Auto reconnect if an established connection is lost, with delay in ms (default: 3000) */
   autoReconnect?: boolean | number;
+  /** Health check polling interval in ms when autoReconnect is enabled (default: 10000) */
+  healthCheckInterval?: number;
+  /** Time in ms without a successful health check before triggering reconnect (default: 30000) */
+  healthCheckTimeout?: number;
+  /** SDK-level reconnection options for streamable HTTP transport */
+  reconnectionOptions?: ReconnectionOptions;
   /** Popup window features string (dimensions and behavior) for OAuth */
   popupFeatures?: string;
   /**

--- a/libraries/typescript/packages/mcp-use/src/react/useMcp.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/useMcp.ts
@@ -93,6 +93,9 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
     logLevel: logLevelOption,
     autoRetry = false,
     autoReconnect = DEFAULT_RECONNECT_DELAY,
+    healthCheckInterval,
+    healthCheckTimeout,
+    reconnectionOptions,
     transportType = "auto",
     preventAutoAuth = true, // Default to true - require explicit user action for OAuth
     useRedirectFlow = false, // Default to false for backward compatibility (use popup)
@@ -626,6 +629,8 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
           clientInfo: mergedClientInfo,
           // Pass custom fetch if provided (e.g., OAuth retry fetch for scope-step-up)
           ...(customFetch && { fetch: customFetch }),
+          // Pass user-configurable reconnection options for streamable HTTP transport
+          ...(reconnectionOptions && { reconnectionOptions }),
         };
 
         // Add gateway URL if using proxy
@@ -790,6 +795,8 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
             addLog,
             connect,
             defaultReconnectDelay: DEFAULT_RECONNECT_DELAY,
+            healthCheckIntervalMs: healthCheckInterval,
+            healthCheckTimeoutMs: healthCheckTimeout,
           });
 
           // Store cleanup function for later


### PR DESCRIPTION
## Summary

Closes #985

The `useMcp` hook currently hardcodes the health check polling interval (10s), health check timeout (30s), and SDK-level reconnection options for streamable HTTP transports. This PR exposes these as configurable props so users can tune connection behavior for their deployment scenarios.

## Changes

### New `UseMcpOptions` props

| Prop | Type | Default | Description |
|------|------|---------|-------------|
| `healthCheckInterval` | `number` | `10000` | Health check polling interval in ms |
| `healthCheckTimeout` | `number` | `30000` | Time without successful health check before reconnect |
| `reconnectionOptions` | `ReconnectionOptions` | see below | SDK-level reconnection config |

### `ReconnectionOptions`

```ts
type ReconnectionOptions = {
  maxReconnectionDelay?: number;       // default: 30000
  initialReconnectionDelay?: number;   // default: 1000
  reconnectionDelayGrowFactor?: number; // default: 1.5
  maxRetries?: number;                 // default: 2
};
```

### Data flow

`useMcp` → `BrowserMCPClient` → `HttpConnector` (reconnection options)
`useMcp` → `startConnectionHealthMonitoring` (health check options)

## Usage

```tsx
const mcp = useMcp({
  url: "https://my-server.com/mcp",
  autoReconnect: true,
  healthCheckInterval: 30000,  // poll every 30s instead of 10s
  healthCheckTimeout: 60000,   // wait 60s before declaring dead
  reconnectionOptions: {
    initialReconnectionDelay: 2000,
    maxReconnectionDelay: 60000,
    maxRetries: 5,
  },
});
```

## Backward Compatibility

All new options are fully optional. Existing behavior is preserved with the same defaults — **no breaking changes**.

## Files Modified

- `src/react/types.ts` — Added `ReconnectionOptions` type, new props on `UseMcpOptions`
- `src/react/useMcp.ts` — Destructure and thread new options
- `src/client/browser.ts` — Pass `reconnectionOptions` to connector
- `src/connectors/http.ts` — Accept and spread `reconnectionOptions` over defaults