### PR TITLE
fix(docs): update all guidance on workos subdomain authkit

### DIFF
--- a/docs/typescript/server/authentication/providers/workos.mdx
+++ b/docs/typescript/server/authentication/providers/workos.mdx
@@ -55,7 +55,7 @@ await server.listen(3000)
 
 ```bash
 # .env
-MCP_USE_OAUTH_WORKOS_SUBDOMAIN=your-subdomain  # Required
+MCP_USE_OAUTH_WORKOS_SUBDOMAIN=your-company.authkit.app  # Required (full AuthKit domain)
 MCP_USE_OAUTH_WORKOS_API_KEY=sk_live_...       # Optional
 MCP_USE_OAUTH_WORKOS_CLIENT_ID=client_...      # Optional
 ```

--- a/libraries/typescript/packages/mcp-use/examples/server/oauth/workos/README.md
+++ b/libraries/typescript/packages/mcp-use/examples/server/oauth/workos/README.md
@@ -87,7 +87,7 @@ Create a `.env` file with these variables:
 
 ```bash
 # Your AuthKit subdomain - REQUIRED
-MCP_USE_OAUTH_WORKOS_SUBDOMAIN=imaginative-palm-54-staging
+MCP_USE_OAUTH_WORKOS_SUBDOMAIN=imaginative-palm-54-staging.authkit.app
 
 # Your pre-registered OAuth client ID - REQUIRED for this mode
 MCP_USE_OAUTH_WORKOS_CLIENT_ID=client_01KB5DRXBDDY1VGCBKY108SKJW
@@ -297,7 +297,7 @@ CMD ["npm", "start"]
 ```bash
 WORKOS_CLIENT_ID=client_...
 WORKOS_API_KEY=sk_live_...  # Use production key
-WORKOS_SUBDOMAIN=your-production-subdomain
+WORKOS_SUBDOMAIN=your-company.authkit.app
 NODE_ENV=production
 ```
 
@@ -357,7 +357,7 @@ NODE_ENV=production
 
 **Solutions**:
 
-- Verify your `MCP_USE_OAUTH_WORKOS_SUBDOMAIN` environment variable is correct (just the subdomain, not the full URL)
+- Verify your `MCP_USE_OAUTH_WORKOS_SUBDOMAIN` environment variable is the full AuthKit domain (e.g., `my-company.authkit.app`, not just `my-company`)
 - Check that your `WORKOS_API_KEY` is valid and not expired
 - Ensure the token is being sent in the `Authorization: Bearer <token>` header
 

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/providers.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/providers.ts
@@ -273,7 +273,7 @@ export function oauthKeycloakProvider(
  *   name: 'my-server',
  *   version: '1.0.0',
  *   oauth: oauthWorkOSProvider({
- *     subdomain: 'my-company'
+ *     subdomain: 'my-company.authkit.app'
  *   })
  * });
  * ```
@@ -284,7 +284,7 @@ export function oauthKeycloakProvider(
  *   name: 'my-server',
  *   version: '1.0.0',
  *   oauth: oauthWorkOSProvider({
- *     subdomain: 'my-company',
+ *     subdomain: 'my-company.authkit.app',
  *     clientId: 'client_01KB5DRXBDDY1VGCBKY108SKJW'
  *   })
  * });

--- a/skills/mcp-apps-builder/references/authentication/workos.md
+++ b/skills/mcp-apps-builder/references/authentication/workos.md
@@ -33,7 +33,7 @@ server.listen();
 With a `.env` file:
 
 ```bash
-MCP_USE_OAUTH_WORKOS_SUBDOMAIN=your-subdomain
+MCP_USE_OAUTH_WORKOS_SUBDOMAIN=your-company.authkit.app
 ```
 
 That's it. JWT verification, OAuth discovery, and token proxying are handled automatically.
@@ -44,7 +44,7 @@ That's it. JWT verification, OAuth discovery, and token proxying are handled aut
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `MCP_USE_OAUTH_WORKOS_SUBDOMAIN` | Yes | Your AuthKit subdomain (e.g., `my-company`) |
+| `MCP_USE_OAUTH_WORKOS_SUBDOMAIN` | Yes | Your full AuthKit domain (e.g., `my-company.authkit.app`) |
 | `MCP_USE_OAUTH_WORKOS_CLIENT_ID` | No | Pre-registered OAuth client ID. Omit for DCR mode |
 | `MCP_USE_OAUTH_WORKOS_API_KEY` | No | WorkOS API key for making WorkOS API calls |
 
@@ -52,7 +52,7 @@ That's it. JWT verification, OAuth discovery, and token proxying are handled aut
 
 WorkOS Dashboard → **Domains** tab → **AuthKit Domain**
 
-The subdomain is the part before `.authkit.app`. For example, if your AuthKit domain is `my-company.authkit.app`, the subdomain is `my-company`.
+Use the **full AuthKit domain** including `.authkit.app`. For example, if your AuthKit domain is `my-company.authkit.app`, set the value to `my-company.authkit.app` (not just `my-company`).
 
 ---
 
@@ -68,7 +68,7 @@ Explicit config (overrides env vars):
 
 ```typescript
 oauth: oauthWorkOSProvider({
-  subdomain: "my-company",
+  subdomain: "my-company.authkit.app",
   clientId: "client_01KB5DRXBDDY1VGCBKY108SKJW",  // optional
   apiKey: "sk_test_...",                             // optional
   verifyJwt: false,                                  // development only
@@ -77,7 +77,7 @@ oauth: oauthWorkOSProvider({
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `subdomain` | `string` | env var | AuthKit subdomain |
+| `subdomain` | `string` | env var | Full AuthKit domain (e.g., `my-company.authkit.app`) |
 | `clientId` | `string?` | env var | Pre-registered client ID. Omit for DCR |
 | `apiKey` | `string?` | env var | WorkOS API key |
 | `verifyJwt` | `boolean?` | `true` | Set `false` to skip JWT verification (development only) |
@@ -180,8 +180,8 @@ server.tool(
 ## Example `.env`
 
 ```bash
-# Required: AuthKit subdomain (WorkOS Dashboard → Domains → AuthKit Domain)
-MCP_USE_OAUTH_WORKOS_SUBDOMAIN=my-company
+# Required: Full AuthKit domain (WorkOS Dashboard → Domains → AuthKit Domain)
+MCP_USE_OAUTH_WORKOS_SUBDOMAIN=my-company.authkit.app
 
 # Optional: Pre-registered OAuth client ID (omit for DCR mode)
 # MCP_USE_OAUTH_WORKOS_CLIENT_ID=client_01KB5DRXBDDY1VGCBKY108SKJW


### PR DESCRIPTION
# Pull Request Description
This PR fixes incorrect WorkOS AuthKit subdomain instructions across docs, examples, and code comments to clarify that the full domain (e.g., my-company.authkit.app) is required, not just the subdomain prefix.

## Language / Project Scope

Check all that apply:
- [ ] TypeScript
- [ ] Python
- [x] Documentation only
- [ ] CI/CD or tooling
