### PR TITLE
chore(gitignore): update gitignore templates to include additional environment files and cache directories

### DIFF
--- a/libraries/typescript/.changeset/thirty-kiwis-cough.md
+++ b/libraries/typescript/.changeset/thirty-kiwis-cough.md
@@ -1,0 +1,5 @@
+---
+"create-mcp-use-app": patch
+---
+
+fix(templates): update gitignore

--- a/libraries/typescript/packages/create-mcp-use-app/src/templates/blank/gitignore
+++ b/libraries/typescript/packages/create-mcp-use-app/src/templates/blank/gitignore
@@ -1,26 +1,39 @@
 # Dependencies
 node_modules/
+.pnpm-store/
 
 # Build output
 dist/
 .mcp-use/
+.vite/
 
 # TypeScript
 *.tsbuildinfo
 
+# Testing
+coverage/
+
+# Linting
+.eslintcache
+
 # Environment
 .env
 .env.local
+.env.development.local
+.env.test.local
+.env.production.local
 
 # Logs
 *.log
 npm-debug.log*
+pnpm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
 # OS
 .DS_Store
 Thumbs.db
+*.pem
 
 # IDE
 .vscode/

--- a/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/gitignore
+++ b/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/gitignore
@@ -1,26 +1,39 @@
 # Dependencies
 node_modules/
+.pnpm-store/
 
 # Build output
 dist/
 .mcp-use/
+.vite/
 
 # TypeScript
 *.tsbuildinfo
 
+# Testing
+coverage/
+
+# Linting
+.eslintcache
+
 # Environment
 .env
 .env.local
+.env.development.local
+.env.test.local
+.env.production.local
 
 # Logs
 *.log
 npm-debug.log*
+pnpm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
 # OS
 .DS_Store
 Thumbs.db
+*.pem
 
 # IDE
 .vscode/

--- a/libraries/typescript/packages/create-mcp-use-app/src/templates/starter/gitignore
+++ b/libraries/typescript/packages/create-mcp-use-app/src/templates/starter/gitignore
@@ -1,26 +1,39 @@
 # Dependencies
 node_modules/
+.pnpm-store/
 
 # Build output
 dist/
 .mcp-use/
+.vite/
 
 # TypeScript
 *.tsbuildinfo
 
+# Testing
+coverage/
+
+# Linting
+.eslintcache
+
 # Environment
 .env
 .env.local
+.env.development.local
+.env.test.local
+.env.production.local
 
 # Logs
 *.log
 npm-debug.log*
+pnpm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
 # OS
 .DS_Store
 Thumbs.db
+*.pem
 
 # IDE
 .vscode/


### PR DESCRIPTION
- Added .pnpm-store/ and .vite/ to ignore build outputs and package manager caches.
- Included coverage/ for test results and .eslintcache for linting cache.
- Added new environment files: .env.development.local, .env.test.local, and .env.production.local.
- Updated log file patterns to include pnpm-debug.log* for consistency across package managers.
- Added *.pem to ignore private key files.
