### PR TITLE
feat(widget): enhance sendFollowUpMessage to support content block arrays

### DIFF
--- a/docs/typescript/server/mcp-apps.mdx
+++ b/docs/typescript/server/mcp-apps.mdx
@@ -248,12 +248,22 @@ Widgets can send messages to the conversation on behalf of the user using `sendF
 ```tsx
 const { sendFollowUpMessage } = useWidget();
 
+// String shorthand (most common)
 <button onClick={() => sendFollowUpMessage("Tell me more about mangoes")}>
+  Ask the AI
+</button>
+
+// Full content array — supports text, image, and resource blocks per SEP-1865
+<button onClick={() => sendFollowUpMessage([
+  { type: "text", text: "Tell me more about mangoes" },
+])}>
   Ask the AI
 </button>
 ```
 
-Per the MCP Apps specification, this maps to the `ui/message` JSON-RPC request. The host adds the message to the conversation and triggers the model to respond.
+Per the MCP Apps specification, this maps to the `ui/message` JSON-RPC request with `role: "user"` and a `content` array. The host adds the message to the conversation and triggers the model to respond.
+
+When running inside ChatGPT (Apps SDK), only the text content of the blocks is used since `window.openai.sendFollowUpMessage` accepts a plain string prompt.
 
 ## Host Context: Locale, Theme, and More
 

--- a/docs/typescript/server/widget-components/usewidget.mdx
+++ b/docs/typescript/server/widget-components/usewidget.mdx
@@ -96,7 +96,7 @@ useWidget<
 | Method                  | Signature                                                                    | Description                                                  |
 | ----------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------ |
 | `callTool`              | `(name: string, args: Record<string, unknown>) => Promise<CallToolResponse>` | Call a tool on the MCP server                                |
-| `sendFollowUpMessage`   | `(prompt: string) => Promise<void>`                                          | Send a follow-up message to the ChatGPT conversation         |
+| `sendFollowUpMessage`   | `(content: string \| MessageContentBlock[]) => Promise<void>`                | Send a follow-up message; string shorthand or full content block array (SEP-1865) |
 | `openExternal`          | `(href: string) => void`                                                     | Open an external URL in a new tab                            |
 | `requestDisplayMode`    | `(mode: DisplayMode) => Promise<{ mode: DisplayMode }>`                      | Request a different display mode                             |
 | `notifyIntrinsicHeight` | `(height: number) => Promise<void>`                                          | Notify OpenAI about intrinsic height changes for auto-sizing |
@@ -394,13 +394,21 @@ const handleSearch = async () => {
 
 ### 7. Follow-up Messages
 
-Send messages to the ChatGPT conversation:
+Send messages to the conversation. Accepts a plain string shorthand or a full content block array per the SEP-1865 `ui/message` spec:
 
 ```tsx
 const { sendFollowUpMessage } = useWidget();
 
+// String shorthand (most common)
 const handleRequestInfo = async () => {
   await sendFollowUpMessage("Show me more details about this product");
+};
+
+// Full content array (MCP Apps — supports text, image, resource blocks)
+const handleRichMessage = async () => {
+  await sendFollowUpMessage([
+    { type: "text", text: "Show me more details about this product" },
+  ]);
 };
 ```
 

--- a/libraries/typescript/.changeset/hungry-feet-mate.md
+++ b/libraries/typescript/.changeset/hungry-feet-mate.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": minor
+---
+
+feat(widgets): allow sendFollowUp to accept multiple mime types and not just text

--- a/libraries/typescript/packages/inspector/src/client/components/ChatTab.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ChatTab.tsx
@@ -645,7 +645,7 @@ export function ChatTab({
             serverId={connection.url}
             readResource={readResource}
             tools={connection.tools}
-            sendMessage={(msg) => sendMessage(msg, [])}
+            sendMessage={(msg, atts) => sendMessage(msg, [], atts)}
             serverBaseUrl={connection.url}
           />
         )}

--- a/libraries/typescript/packages/inspector/src/client/components/MCPAppsRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/MCPAppsRenderer.tsx
@@ -22,6 +22,7 @@ import type {
 } from "@modelcontextprotocol/sdk/types.js";
 import { X } from "lucide-react";
 import { useMcpClient } from "mcp-use/react";
+import type { MessageContentBlock } from "mcp-use/react";
 import {
   memo,
   useCallback,
@@ -103,7 +104,7 @@ interface MCPAppsRendererProps {
   partialToolInput?: Record<string, unknown>;
   resourceUri: string;
   readResource: (uri: string) => Promise<any>;
-  onSendFollowUp?: (text: string) => void;
+  onSendFollowUp?: (content: MessageContentBlock[]) => void;
   className?: string;
   displayMode?: DisplayMode;
   onDisplayModeChange?: (mode: DisplayMode) => void;
@@ -539,9 +540,8 @@ function MCPAppsRendererBase({
     };
 
     bridge.onmessage = async ({ content }) => {
-      const textContent = content.find((item) => item.type === "text")?.text;
-      if (textContent && onSendFollowUp) {
-        onSendFollowUp(textContent);
+      if (content.length > 0 && onSendFollowUp) {
+        onSendFollowUp(content as MessageContentBlock[]);
       }
       return {};
     };

--- a/libraries/typescript/packages/inspector/src/client/components/chat/MessageList.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/MessageList.tsx
@@ -1,5 +1,6 @@
 import { TextShimmer } from "@/client/components/ui/text-shimmer";
-import { memo, useEffect, useRef } from "react";
+import { memo, useCallback, useEffect, useRef } from "react";
+import type { MessageContentBlock } from "mcp-use/react";
 import { AssistantMessage } from "./AssistantMessage";
 import { ToolCallDisplay } from "./ToolCallDisplay";
 import { ToolResultRenderer } from "./ToolResultRenderer";
@@ -37,7 +38,10 @@ interface MessageListProps {
   serverId?: string;
   readResource?: (uri: string) => Promise<any>;
   tools?: any[];
-  sendMessage?: (message: string) => Promise<void>;
+  sendMessage?: (
+    message: string,
+    attachments?: MessageAttachment[]
+  ) => Promise<void>;
   /** When provided, passed to widget renderers to avoid useMcpClient() context lookup. */
   serverBaseUrl?: string;
 }
@@ -72,6 +76,32 @@ export const MessageList = memo(
       // mcp-ui requires result to detect, so don't pre-render for those
       return protocol !== null && protocol !== "mcp-ui";
     };
+
+    // Convert a ui/message content array to a text string + image attachments,
+    // then forward to sendMessage so the full message reaches the LLM.
+    const handleFollowUp = useCallback(
+      (content: MessageContentBlock[]) => {
+        const text = content
+          .filter(
+            (c): c is { type: "text"; text: string } =>
+              c.type === "text" && "text" in c
+          )
+          .map((c) => c.text)
+          .join("\n");
+        const images: MessageAttachment[] = content
+          .filter(
+            (c): c is { type: "image"; data: string; mimeType: string } =>
+              c.type === "image" && "data" in c && "mimeType" in c
+          )
+          .map((c) => ({
+            type: "image" as const,
+            data: c.data,
+            mimeType: c.mimeType,
+          }));
+        sendMessage?.(text, images.length > 0 ? images : undefined);
+      },
+      [sendMessage]
+    );
 
     // Scroll to bottom when messages change or streaming status changes
     useEffect(() => {
@@ -211,7 +241,7 @@ export const MessageList = memo(
                               toolMeta={getToolMeta(
                                 part.toolInvocation.toolName
                               )}
-                              onSendFollowUp={sendMessage}
+                              onSendFollowUp={handleFollowUp}
                               partialToolArgs={part.toolInvocation.partialArgs}
                               cancelled={
                                 part.toolInvocation.state === "error" &&
@@ -259,7 +289,7 @@ export const MessageList = memo(
                                   readResource={readResource}
                                   serverBaseUrl={serverBaseUrl}
                                   toolMeta={getToolMeta(toolCall.toolName)}
-                                  onSendFollowUp={sendMessage}
+                                  onSendFollowUp={handleFollowUp}
                                 />
                               )}
                             </div>

--- a/libraries/typescript/packages/inspector/src/client/components/chat/ToolResultRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/ToolResultRenderer.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import type { MessageContentBlock } from "mcp-use/react";
 import { useWidgetDebug } from "../../context/WidgetDebugContext";
 import {
   detectWidgetProtocol,
@@ -34,7 +35,7 @@ interface ToolResultRendererProps {
   serverId?: string;
   readResource?: (uri: string) => Promise<any>;
   toolMeta?: Record<string, any>;
-  onSendFollowUp?: (text: string) => void;
+  onSendFollowUp?: (content: MessageContentBlock[]) => void;
   /** When provided, passed to widget renderers to avoid useMcpClient() context lookup. */
   serverBaseUrl?: string;
   /** Partial/streaming tool arguments (forwarded to widget as partialToolInput) */

--- a/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessages.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessages.ts
@@ -39,10 +39,17 @@ export function useChatMessages({
   const abortControllerRef = useRef<AbortController | null>(null);
 
   const sendMessage = useCallback(
-    async (userInput: string, promptResults: PromptResult[]) => {
+    async (
+      userInput: string,
+      promptResults: PromptResult[],
+      extraAttachments?: MessageAttachment[]
+    ) => {
+      const allAttachments = [...attachments, ...(extraAttachments ?? [])];
       // Can send if there's text, prompt results, or attachments
       const hasContent =
-        userInput.trim() || promptResults.length > 0 || attachments.length > 0;
+        userInput.trim() ||
+        promptResults.length > 0 ||
+        allAttachments.length > 0;
       if (!hasContent || !llmConfig || !isConnected) {
         return;
       }
@@ -54,13 +61,13 @@ export function useChatMessages({
       // Don't create one when only using prompt results (they create their own messages)
       const userMessages: Message[] = [...promptResultsMessages];
 
-      if (userInput.trim() || attachments.length > 0) {
+      if (userInput.trim() || allAttachments.length > 0) {
         const userMessage: Message = {
           id: `user-${Date.now()}`,
           role: "user",
           content: userInput.trim(),
           timestamp: Date.now(),
-          attachments: attachments.length > 0 ? [...attachments] : undefined,
+          attachments: allAttachments.length > 0 ? allAttachments : undefined,
         };
         userMessages.push(userMessage);
       }

--- a/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessagesClientSide.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessagesClientSide.ts
@@ -43,10 +43,17 @@ export function useChatMessagesClientSide({
   const lastDisabledToolsRef = useRef<string>("");
 
   const sendMessage = useCallback(
-    async (userInput: string, promptResults: PromptResult[]) => {
+    async (
+      userInput: string,
+      promptResults: PromptResult[],
+      extraAttachments?: MessageAttachment[]
+    ) => {
+      const allAttachments = [...attachments, ...(extraAttachments ?? [])];
       // Can send if there's text, prompt results, or attachments
       const hasContent =
-        userInput.trim() || promptResults.length > 0 || attachments.length > 0;
+        userInput.trim() ||
+        promptResults.length > 0 ||
+        allAttachments.length > 0;
       if (!hasContent || !llmConfig || !isConnected) {
         return;
       }
@@ -60,13 +67,13 @@ export function useChatMessagesClientSide({
         role: "user",
         content: userInput.trim(),
         timestamp: Date.now(),
-        attachments: attachments.length > 0 ? [...attachments] : undefined,
+        attachments: allAttachments.length > 0 ? allAttachments : undefined,
       };
 
       // Only add user message to UI if there's actual user input or user-uploaded attachments
       // Don't show it when only using prompt results (they create their own messages)
       const userMessages: Message[] = [...promptResultsMessages];
-      if (userInput.trim() || attachments.length > 0) {
+      if (userInput.trim() || allAttachments.length > 0) {
         userMessages.push(userMessage);
       }
 
@@ -218,17 +225,25 @@ export function useChatMessagesClientSide({
           }
         }
 
-        // Stream events from agent
-        // Don't include the new userMessage here - streamEvents() appends it internally
-        // as new HumanMessage(query), so including it would cause duplication
+        // Stream events from agent.
+        // For text-only messages, streamEvents() appends userInput internally as a
+        // new HumanMessage(query), so we exclude userMessage from externalHistory to
+        // avoid duplication.
+        // For messages with image attachments, we must include the full multimodal
+        // userMessage in externalHistory so the LLM can see the images. In that case
+        // we pass "" as the query so streamEvents() doesn't add a duplicate plain-text
+        // message on top of the image-bearing message already in history.
+        const hasImageAttachments = (userMessage.attachments?.length ?? 0) > 0;
         const externalHistory = convertMessagesToLangChain([
           ...messages,
           ...promptResultsMessages,
           ...widgetContextMessages,
+          ...(hasImageAttachments ? [userMessage] : []),
         ]);
+        const effectiveInput = hasImageAttachments ? "" : userInput;
 
         for await (const event of agentRef.current.streamEvents(
-          userInput,
+          effectiveInput,
           10, // maxSteps
           false, // manageConnector - don't manage, already connected
           externalHistory, // externalHistory - keep history external to include prompt results AND new message

--- a/libraries/typescript/packages/inspector/src/client/components/tools/ToolResultDisplay.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/tools/ToolResultDisplay.tsx
@@ -23,6 +23,7 @@ import React, {
   useState,
 } from "react";
 import { toast } from "sonner";
+import type { MessageContentBlock } from "mcp-use/react";
 import { useWidgetDebug } from "../../context/WidgetDebugContext";
 import {
   detectWidgetProtocol,
@@ -479,12 +480,31 @@ export function ToolResultDisplay({
 
   // Memoize onSendFollowUp to prevent infinite re-render loop
   // This callback is used in MCPAppsRenderer's effect dependency array
-  const memoizedOnSendFollowUp = useCallback((text: string) => {
-    toast.info("Message received", {
-      description: text,
-      duration: 5000,
-    });
-  }, []);
+  const memoizedOnSendFollowUp = useCallback(
+    (content: MessageContentBlock[]) => {
+      const text = content
+        .filter(
+          (c): c is { type: "text"; text: string } =>
+            c.type === "text" && "text" in c
+        )
+        .map((c) => c.text)
+        .join("\n");
+      const imageCount = content.filter((c) => c.type === "image").length;
+      const resourceCount = content.filter((c) => c.type === "resource").length;
+      const extras = [
+        imageCount > 0 && `${imageCount} image${imageCount > 1 ? "s" : ""}`,
+        resourceCount > 0 &&
+          `${resourceCount} resource${resourceCount > 1 ? "s" : ""}`,
+      ]
+        .filter(Boolean)
+        .join(", ");
+      toast.info("Widget follow-up", {
+        description: [text, extras].filter(Boolean).join(" — "),
+        duration: 5000,
+      });
+    },
+    []
+  );
 
   // Get widget debug context for protocol selection
   const { playground } = useWidgetDebug();

--- a/libraries/typescript/packages/mcp-use/src/react/WIDGET_HOOKS.md
+++ b/libraries/typescript/packages/mcp-use/src/react/WIDGET_HOOKS.md
@@ -66,7 +66,7 @@ Main hook that provides access to all widget functionality.
   
   // Actions
   callTool: (name: string, args: Record<string, unknown>) => Promise<CallToolResponse>;
-  sendFollowUpMessage: (prompt: string) => Promise<void>;
+  sendFollowUpMessage: (content: string | MessageContentBlock[]) => Promise<void>;
   openExternal: (href: string) => void;
   requestDisplayMode: (mode: DisplayMode) => Promise<{ mode: DisplayMode }>;
   

--- a/libraries/typescript/packages/mcp-use/src/react/index.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/index.ts
@@ -41,6 +41,7 @@ export {
 export type {
   API,
   CallToolResponse,
+  MessageContentBlock,
   DeviceType,
   DisplayMode,
   OpenAiGlobals,

--- a/libraries/typescript/packages/mcp-use/src/react/mcp-apps-bridge.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/mcp-apps-bridge.ts
@@ -12,7 +12,11 @@ import {
   type JsonRpcResponse,
 } from "../server/utils/jsonrpc-helpers.js";
 import { MCP_APPS_BRIDGE_CONFIG } from "./constants.js";
-import type { DisplayMode, Theme } from "./widget-types.js";
+import type {
+  DisplayMode,
+  MessageContentBlock,
+  Theme,
+} from "./widget-types.js";
 
 // JSON-RPC message types (using imported types with compatible names)
 type JSONRPCRequest = JsonRpcRequest;
@@ -580,9 +584,12 @@ class McpAppsBridge {
   }
 
   /**
-   * Send a message to the conversation
+   * Send a message to the conversation.
+   * Accepts a single content block or an array of blocks per the SEP-1865 ui/message spec.
    */
-  async sendMessage(content: { type: string; text: string }): Promise<void> {
+  async sendMessage(
+    content: MessageContentBlock | MessageContentBlock[]
+  ): Promise<void> {
     const contentArray = Array.isArray(content) ? content : [content];
     await this.sendRequest("ui/message", {
       role: "user",

--- a/libraries/typescript/packages/mcp-use/src/react/useWidget.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/useWidget.ts
@@ -16,6 +16,7 @@ import { normalizeCallToolResponse } from "./widget-utils.js";
 import type {
   CallToolResponse,
   DisplayMode,
+  MessageContentBlock,
   OpenAiGlobals,
   SafeArea,
   SetGlobalsEvent,
@@ -530,16 +531,32 @@ export function useWidget<
   );
 
   const sendFollowUpMessage = useCallback(
-    async (prompt: string): Promise<void> => {
+    async (content: string | MessageContentBlock[]): Promise<void> => {
+      const contentArray: MessageContentBlock[] =
+        typeof content === "string"
+          ? [{ type: "text", text: content }]
+          : content;
+
       if (provider === "mcp-apps") {
         const bridge = getMcpAppsBridge();
-        await bridge.sendMessage({ type: "text", text: prompt });
+        await bridge.sendMessage(contentArray);
         return;
       }
 
       if (!window.openai?.sendFollowUpMessage) {
         throw new Error("window.openai.sendFollowUpMessage is not available");
       }
+      // window.openai only supports plain text; extract and join text blocks
+      const prompt =
+        typeof content === "string"
+          ? content
+          : contentArray
+              .filter(
+                (c): c is { type: "text"; text: string } =>
+                  c.type === "text" && "text" in c
+              )
+              .map((c) => c.text)
+              .join("\n");
       return window.openai.sendFollowUpMessage({ prompt });
     },
     [provider]

--- a/libraries/typescript/packages/mcp-use/src/react/widget-types.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/widget-types.ts
@@ -70,6 +70,18 @@ export type CallToolResponse = {
   _meta?: Record<string, unknown>;
 };
 
+/**
+ * A single content block for a user message, per the SEP-1865 `ui/message` spec.
+ *
+ * The `sendFollowUpMessage` action accepts either a plain string shorthand (automatically
+ * wrapped as a `text` block) or an explicit array of these blocks for richer content.
+ */
+export type MessageContentBlock =
+  | { type: "text"; text: string }
+  | { type: "image"; data: string; mimeType: string }
+  | { type: "resource"; resource: { uri: string; [key: string]: unknown } }
+  | { type: string; [key: string]: unknown };
+
 export interface OpenAiGlobals<
   ToolInput extends UnknownObject = UnknownObject,
   ToolOutput extends UnknownObject = UnknownObject,
@@ -360,7 +372,9 @@ interface UseWidgetResultBase<
    * user selects an item and you want the model to generate a contextual
    * response.
    */
-  sendFollowUpMessage: (prompt: string) => Promise<void>;
+  sendFollowUpMessage: (
+    content: string | MessageContentBlock[]
+  ) => Promise<void>;
 
   /**
    * Ask the host to open a URL in the user's default browser or a new tab.

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -1145,6 +1145,64 @@ importers:
         specifier: ^7.3.0
         version: 7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
 
+  test_app:
+    dependencies:
+      '@openai/apps-sdk-ui':
+        specifier: ^0.2.1
+        version: 0.2.1(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.0)
+      '@tanstack/react-query':
+        specifier: ^5.90.21
+        version: 5.90.21(react@19.2.4)
+      cors:
+        specifier: ^2.8.6
+        version: 2.8.6
+      express:
+        specifier: ^5.2.1
+        version: 5.2.1
+      mcp-use:
+        specifier: workspace:*
+        version: link:../packages/mcp-use
+      react:
+        specifier: ^19.2.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.0
+        version: 19.2.4(react@19.2.4)
+      react-router:
+        specifier: ^7.12.0
+        version: 7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      tailwindcss:
+        specifier: ^4.2.0
+        version: 4.2.0
+      zod:
+        specifier: 4.3.5
+        version: 4.3.5
+    devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.2.0
+        version: 4.2.0(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@types/node':
+        specifier: ^25.3.0
+        version: 25.3.0
+      '@types/react':
+        specifier: ^19.2.7
+        version: 19.2.10
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.10)
+      '@vitejs/plugin-react':
+        specifier: ^5.1.4
+        version: 5.1.4(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^7.3.0
+        version: 7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+
 packages:
 
   '@acemir/cssom@0.9.31':

--- a/skills/chatgpt-app-builder/references/components-api.md
+++ b/skills/chatgpt-app-builder/references/components-api.md
@@ -208,7 +208,7 @@ const {
 | `locale` | string | User locale (default: 'en') |
 | `timeZone` | string | IANA timezone identifier |
 | `callTool` | (name, args) => Promise | Call another MCP tool |
-| `sendFollowUpMessage` | (prompt) => Promise | Trigger LLM response |
+| `sendFollowUpMessage` | `(content: string \| MessageContentBlock[]) => Promise<void>` | Trigger LLM response; string shorthand or content block array |
 | `openExternal` | (href) => void | Open external URL |
 | `requestDisplayMode` | (mode) => Promise | Request display mode change |
 | `mcp_url` | string | MCP server base URL |
@@ -266,11 +266,20 @@ if (displayMode === "fullscreen") {
 ```tsx
 const { sendFollowUpMessage } = useWidget();
 
-// Trigger LLM to respond based on widget state
+// String shorthand (most common)
 <button onClick={() => sendFollowUpMessage("Analyze the selected items and recommend the best one")}>
   Get AI Recommendation
 </button>
+
+// Full content array — supports text, image, and resource blocks (MCP Apps / SEP-1865)
+<button onClick={() => sendFollowUpMessage([
+  { type: "text", text: "Analyze the selected items and recommend the best one" },
+])}>
+  Get AI Recommendation
+</button>
 ```
+
+When running inside ChatGPT (Apps SDK), only text blocks are used since the SDK accepts a plain string prompt.
 
 ### openExternal Usage
 

--- a/skills/chatgpt-app-builder/references/state-and-context.md
+++ b/skills/chatgpt-app-builder/references/state-and-context.md
@@ -145,7 +145,7 @@ function SearchWidget() {
 
 ## Triggering LLM Response: `sendFollowUpMessage`
 
-Trigger the LLM to respond from a widget interaction:
+Trigger the LLM to respond from a widget interaction. Accepts a plain string shorthand or a full content block array per the SEP-1865 `ui/message` spec:
 
 ```tsx
 import { useWidget } from "mcp-use/react";
@@ -154,11 +154,21 @@ function AnalyzeButton() {
   const { sendFollowUpMessage } = useWidget();
 
   return (
-    <button onClick={() => sendFollowUpMessage(
-      "Compare the top 3 results and recommend the best one based on price and reviews."
-    )}>
-      Ask AI to Analyze
-    </button>
+    <>
+      {/* String shorthand (most common) */}
+      <button onClick={() => sendFollowUpMessage(
+        "Compare the top 3 results and recommend the best one based on price and reviews."
+      )}>
+        Ask AI to Analyze
+      </button>
+
+      {/* Full content array — MCP Apps hosts support text, image, and resource blocks */}
+      <button onClick={() => sendFollowUpMessage([
+        { type: "text", text: "Compare the top 3 results and recommend the best one based on price and reviews." },
+      ])}>
+        Ask AI to Analyze (content array)
+      </button>
+    </>
   );
 }
 ```
@@ -167,6 +177,8 @@ Use this when:
 - User clicks "Find best option" and the LLM should reason about the data
 - User completes a selection and the LLM should provide recommendations
 - Widget needs the LLM to take action based on current state
+
+> **Note**: When running inside ChatGPT (Apps SDK), only text blocks are extracted and joined as a plain string prompt. Non-text blocks are ignored on that path.
 
 ## Opening External URLs: `openExternal`
 

--- a/skills/mcp-builder/references/widgets.md
+++ b/skills/mcp-builder/references/widgets.md
@@ -200,7 +200,7 @@ const {
 
   // Actions
   callTool,           // Call another MCP tool: callTool("tool-name", { args })
-  sendFollowUpMessage,// Trigger LLM response: sendFollowUpMessage("analyze this")
+  sendFollowUpMessage,// Trigger LLM response: sendFollowUpMessage("analyze this") or sendFollowUpMessage([{ type: "text", text: "..." }])
   openExternal,       // Open external URL: openExternal("https://example.com")
   requestDisplayMode, // Request mode change: requestDisplayMode("fullscreen")
   mcp_url,            // MCP server base URL for custom API requests
@@ -239,10 +239,20 @@ const handleRefresh = async () => {
 
 ### Triggering LLM Response
 
+Accepts a plain string shorthand or a full content block array per the SEP-1865 `ui/message` spec:
+
 ```tsx
 const { sendFollowUpMessage } = useWidget();
 
+// String shorthand (most common)
 <button onClick={() => sendFollowUpMessage("Compare the weather in these cities")}>
+  Ask AI to Compare
+</button>
+
+// Full content array (MCP Apps — supports text, image, resource blocks)
+<button onClick={() => sendFollowUpMessage([
+  { type: "text", text: "Compare the weather in these cities" },
+])}>
   Ask AI to Compare
 </button>
 ```


### PR DESCRIPTION
- Updated the `sendFollowUpMessage` method to accept both string shorthand and an array of `MessageContentBlock` objects, allowing for richer message content per the SEP-1865 `ui/message` specification.
- Modified documentation and examples across various files to reflect the new functionality, including usage of text, image, and resource blocks.
- Ensured compatibility with the ChatGPT Apps SDK, clarifying that only text blocks are utilized in that context.
