### PR TITLE
improvement(skills): add sendFollowUpMessage docs and replace callTool with useCallTool across mcp-apps-builder skill

### DIFF
--- a/skills/mcp-apps-builder/references/widgets/basics.md
+++ b/skills/mcp-apps-builder/references/widgets/basics.md
@@ -175,9 +175,10 @@ const {
   isPending,    // True while props are loading
   setState,     // Update widget state
   state,        // Current widget state
-  callTool      // Call MCP tools from widget
 } = useWidget();
 ```
+
+**To call tools from a widget**, use the dedicated `useCallTool()` hook — see [interactivity.md](interactivity.md).
 
 ### props
 Data passed from tool's `widget({ props })` response:

--- a/skills/mcp-apps-builder/references/widgets/state.md
+++ b/skills/mcp-apps-builder/references/widgets/state.md
@@ -600,8 +600,9 @@ const [filter, setFilter] = useState("all");
 
 ### ❌ Don't Call Tools for Filtering/Sorting
 ```typescript
-// ❌ Bad - Calling tool to filter
-<button onClick={() => callTool("filter-items", { category: "electronics" })}>
+// ❌ Bad - Using a tool call for client-side filtering
+const { callTool: filterItems } = useCallTool("filter-items");
+<button onClick={() => filterItems({ category: "electronics" })}>
   Filter
 </button>
 


### PR DESCRIPTION
# Pull Request Description

This PR adds `sendFollowUpMessage` documentation to the mcp-apps-builder skill and standardizes all widget examples to use `useCallTool()` instead of the lower-level `callTool` from `useWidget()`.

## Changes

### Added `sendFollowUpMessage` documentation
- New "Triggering LLM Responses" section in `interactivity.md` with standalone and combined (`useCallTool` + `sendFollowUpMessage`) examples
- Updated intro and best practices to cover both widget action methods

### Replaced `callTool` from `useWidget()` with `useCallTool()` across all skill files
`useCallTool()` provides type safety, built-in state management (`isPending`, `isError`, `data`), and side-effect callbacks — making `callTool` from `useWidget()` redundant in all static tool name cases.