### PR TITLE
feat(inspector): enhance logger middleware to filter noisy API endpoints

### DIFF
--- a/libraries/typescript/.changeset/quick-onions-train.md
+++ b/libraries/typescript/.changeset/quick-onions-train.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+feat(inspector): enhance logger middleware to filter noisy API endpoints

--- a/libraries/typescript/packages/inspector/src/server/server.ts
+++ b/libraries/typescript/packages/inspector/src/server/server.ts
@@ -18,8 +18,20 @@ app.use(
   })
 );
 
-// Apply logger middleware to API routes for request/response logging
-app.use("/inspector/api/*", logger());
+// Apply logger middleware to API routes for request/response logging.
+// Filter out noisy endpoints (telemetry, RPC stream/log) to reduce log spam.
+const noisyPaths = [
+  "/inspector/api/tel/",
+  "/inspector/api/rpc/stream",
+  "/inspector/api/rpc/log",
+];
+app.use(
+  "/inspector/api/*",
+  logger((message, ...rest) => {
+    if (noisyPaths.some((p) => message.includes(p))) return;
+    console.log(message, ...rest);
+  })
+);
 
 // Register all API routes
 registerInspectorRoutes(app);


### PR DESCRIPTION
- Updated logger middleware to filter out noisy endpoints (telemetry, RPC stream/log) to reduce log spam.
- Introduced a list of noisy paths and modified the logger function to skip logging for these paths, improving log clarity and relevance.
