### PR TITLE
docs(python): fix incorrect parameter name in quickstart server example

### DIFF
--- a/docs/python/getting-started/quickstart.mdx
+++ b/docs/python/getting-started/quickstart.mdx
@@ -174,7 +174,7 @@ from mcp_use import MCPServer
 server = MCPServer(
     name="my-server",
     version="1.0.0",
-    description="My custom MCP server"
+    instructions="A simple example server"
 )
 
 # Define a tool


### PR DESCRIPTION

# Pull Request Description
The python quickstart example used description as a parameter for MCPServer(), but the Python SDK's constructor expects instructions
## Language / Project Scope

Check all that apply:
- [ ] TypeScript
- [ ] Python
- [x] Documentation only
- [ ] CI/CD or tooling

## Changes

I was reading the python documentation and saw in the quickstart that the parameter used for the server example was description instead of instructions. 

## Example Usage (Before)

```
server = MCPServer(
    name="my-server",
    version="1.0.0",
    description="My custom MCP server"
)
```

## Example Usage (After)

```
server = MCPServer(
    name="my-server",
    version="1.0.0",
    instructions="A simple example server"
)
```

## Documentation Updates

I changed the docs/python/getting-started/quickstart.mdx file. 
