### PR TITLE
feat(mcp-use): add proxy server functionality and documentation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -596,6 +596,7 @@
                     "group": "Advanced Features",
                     "icon": "sparkle",
                     "pages": [
+                      "typescript/server/proxy",
                       "typescript/server/elicitation",
                       "typescript/server/sampling",
                       "typescript/server/subscriptions",

--- a/docs/typescript/server/index.mdx
+++ b/docs/typescript/server/index.mdx
@@ -204,6 +204,9 @@ class McpServer {
   <Card title="UI Widgets" icon="palette" href="/typescript/server/ui-widgets">
     Build interactive React components with auto-registration
   </Card>
+  <Card title="Proxy Servers" icon="network-wired" href="/typescript/server/proxy">
+    Compose multiple MCP servers into a single unified aggregator
+  </Card>
   <Card title="Configuration" icon="cog" href="/typescript/server/configuration">
     Configure your server for production deployment
   </Card>

--- a/docs/typescript/server/proxy.mdx
+++ b/docs/typescript/server/proxy.mdx
@@ -1,0 +1,112 @@
+---
+title: "Server Proxying & Composition"
+description: "Learn how to compose multiple MCP servers together into a unified aggregator server."
+---
+
+The `mcp-use` TypeScript SDK allows you to easily proxy and compose multiple MCP servers into a single unified "Aggregator" server.
+
+This is extremely useful when you have multiple microservices or specialized MCP servers (like a database server, a weather server, and an internal API server) and you want to expose all of their tools, resources, and prompts through a single unified endpoint.
+
+## High-Level API (Config Object)
+
+The most elegant way to proxy servers is to pass a configuration object directly to `server.proxy()`. The keys of the object act as the **namespaces** for the child servers, preventing any naming collisions.
+
+```typescript
+import { MCPServer } from "mcp-use/server";
+import path from "node:path";
+
+const server = new MCPServer({ name: "UnifiedServer", version: "1.0.0" });
+
+// The SDK handles all connections, sessions, and synchronization automatically
+await server.proxy({
+  // Proxy a local TypeScript server (using the 'tsx' runner)
+  database: {
+    command: "tsx",
+    args: [path.resolve(__dirname, "./db-server.ts")]
+  },
+  
+  // Proxy a local Python FastMCP server
+  weather: {
+    command: "uv",
+    args: ["run", "weather_server.py"],
+    env: { ...process.env, FASTMCP_LOG_LEVEL: "ERROR" }
+  },
+  
+  // Proxy a remote server over HTTP
+  manufact: {
+    url: "https://manufact.com/docs/mcp"
+  }
+});
+
+// Expose our own tools alongside the proxied ones
+server.tool({
+  name: "aggregator_status",
+  description: "Check aggregator status",
+}, async () => ({ content: [{ type: "text", text: "All systems operational" }] }));
+
+// Start the unified server
+await server.listen(3000);
+```
+
+In the example above, the `database` tools will be prefixed with `database_` (e.g. `database_query`), the `weather` tools will be prefixed with `weather_` (e.g. `weather_get_forecast`), and so on.
+
+## Low-Level API (Explicit Session)
+
+For advanced use cases—such as dynamically determining auth headers, managing complex connection lifecycles, or using custom connectors—you can inject an explicit `MCPSession` directly into the `proxy` method using the `mcp-use` Client SDK.
+
+```typescript
+import { MCPServer } from "mcp-use/server";
+import { MCPClient } from "mcp-use/client";
+
+const server = new MCPServer({ name: "UnifiedServer", version: "1.0.0" });
+
+// Create a custom client orchestration
+const customClient = new MCPClient({
+  mcpServers: {
+    secure_db: {
+      url: "https://secure-db.example.com/mcp"
+    }
+  }
+});
+
+// Manage the session manually
+const dbSession = await customClient.createSession("secure_db");
+
+// Proxy the active session, manually specifying the namespace
+await server.proxy(dbSession, { namespace: "secure_db" });
+
+await server.listen(3000);
+```
+
+## Example Usage
+
+<Card title="Proxy Server Example" icon="github" href="https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/features/proxy">
+  See a fully working example of server composition in the mcp-use repository.
+</Card>
+
+## How It Works
+
+When you proxy a server, the `mcp-use` SDK automatically:
+
+1. **Introspects** the child server by calling `listTools()`, `listResources()`, and `listPrompts()`.
+2. **Translates** the raw JSON Schemas returned by the child server into runtime `Zod` schemas for perfect compatibility with the `mcp-use` validation pipeline.
+3. **Namespaces** the component names to prevent collisions.
+4. **Relays** execution. When a client calls a proxied tool, the Aggregator intercepts it and forwards the execution to the child server.
+5. **Synchronizes** state. The Aggregator listens to `notifications/tools/list_changed` (and other list_changed events) emitted by the child server and instantly forwards them to all clients connected to the Aggregator.
+
+## Advanced Features
+
+The `mcp-use` proxying system goes far beyond simple tool forwarding. It transparently supports the most advanced features of the Model Context Protocol:
+
+### LLM Sampling & Elicitation 
+If a child server requests LLM Sampling (`sampling/createMessage`) or Elicitation (`elicitation/create`), the Aggregator automatically intercepts the out-of-band JSONRPC request, dynamically resolves the HTTP context of the specific user who triggered the tool, and routes the request back to that specific user's client.
+
+If a request context is somehow lost (e.g., executing a tool via a headless script), the Aggregator provides graceful fallbacks so the child server doesn't hang.
+
+### Progress Tracking
+If a child tool emits `notifications/progress/report` events, the Aggregator catches those events and pipes them directly through the unified `ToolContext` back to the parent client.
+
+### Resource URIs
+To prevent URI collisions across different servers, the proxy automatically prepends the namespace to the resource URI protocol.
+
+For example, if the `weather` server exposes a resource at `app://settings`, the Aggregator will expose it as `weather://app://settings`. When a client reads that resource, the Aggregator strips the prefix and requests the original URI from the child server.

--- a/libraries/typescript/.changeset/server-composition.md
+++ b/libraries/typescript/.changeset/server-composition.md
@@ -1,0 +1,25 @@
+---
+"mcp-use": minor
+---
+
+Added robust SDK-level server composition and proxying functionality via `MCPServer.proxy()`.
+
+You can now natively compose multiple disparate MCP servers into a single unified aggregator server. The SDK automatically orchestrates connections, proxies JSON-RPC execution (including tools, prompts, resources, LLM Sampling, Elicitation, and Progress), translates schemas on the fly, prefixes namespaces to prevent collisions, and multiplexes list-changed notifications up to the parent connection.
+
+### Example
+```typescript
+import { MCPServer } from "mcp-use/server";
+const server = new MCPServer({ name: "UnifiedServer", version: "1.0.0" });
+
+await server.proxy({
+  database: {
+    command: "npx",
+    args: ["-y", "@modelcontextprotocol/server-postgres", "postgresql://..."]
+  },
+  weather: {
+    url: "https://weather-mcp.example.com/mcp"
+  }
+});
+
+await server.listen(3000);
+```

--- a/libraries/typescript/packages/mcp-use/examples/server/features/proxy/package.json
+++ b/libraries/typescript/packages/mcp-use/examples/server/features/proxy/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "proxy-example",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/server.ts"
+  },
+  "dependencies": {
+    "mcp-use": "workspace:*",
+    "@modelcontextprotocol/sdk": "latest",
+    "zod": "^3.24.1"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.3"
+  }
+}

--- a/libraries/typescript/packages/mcp-use/examples/server/features/proxy/src/server.ts
+++ b/libraries/typescript/packages/mcp-use/examples/server/features/proxy/src/server.ts
@@ -1,0 +1,62 @@
+import { MCPServer } from "mcp-use/server";
+
+const server = new MCPServer({
+  name: "ProxyAggregator",
+  version: "1.0.0",
+});
+
+async function main() {
+  console.log("Setting up proxy connections...");
+
+  // Path to the fastmcp test server
+  const fastMcpServerPath = "/tmp/fastmcp/test_server.py";
+
+  console.log("Calling server.proxy()...");
+
+  // Mount the servers
+  await server.proxy({
+    conformance: {
+      url: "http://localhost:4000/mcp",
+    },
+    fastmcp: {
+      command: "/tmp/fastmcp/.venv/bin/python",
+      args: [fastMcpServerPath],
+      env: {
+        ...process.env,
+        FASTMCP_LOG_LEVEL: "ERROR",
+      },
+    },
+    manufact: {
+      url: "https://manufact.com/docs/mcp",
+    },
+  });
+
+  console.log(
+    "Servers proxied successfully under namespaces 'conformance', 'fastmcp', and 'manufact'."
+  );
+
+  // Expose our own tool as well
+  server.tool(
+    {
+      name: "aggregator_info",
+      description: "Get info about the aggregator",
+    },
+    async () => {
+      return {
+        content: [
+          {
+            type: "text",
+            text: "This is the aggregator server. It proxies three remote/local servers.",
+          },
+        ],
+      };
+    }
+  );
+
+  // Since it's a standard server, we can serve it over HTTP.
+  const port = process.env.PORT ? parseInt(process.env.PORT) : 3000;
+  await server.listen(port);
+  console.log(`Aggregator listening on http://localhost:${port}/mcp`);
+}
+
+main().catch(console.error);

--- a/libraries/typescript/packages/mcp-use/examples/server/features/proxy/src/test.ts
+++ b/libraries/typescript/packages/mcp-use/examples/server/features/proxy/src/test.ts
@@ -1,0 +1,103 @@
+import { MCPClient } from "mcp-use/client";
+
+async function main() {
+  console.log("Connecting to aggregator...");
+  const client = new MCPClient({
+    mcpServers: {
+      aggregator: {
+        url: "http://localhost:3000/mcp",
+      },
+    },
+    onSampling: async (params) => {
+      console.log(
+        "Received sampling request:",
+        JSON.stringify(params, null, 2)
+      );
+      return {
+        role: "assistant",
+        model: "mock-model",
+        content: { type: "text", text: "Mock sampled response from client" },
+      };
+    },
+    onElicitation: async (params) => {
+      console.log(
+        "Received elicitation request:",
+        JSON.stringify(params, null, 2)
+      );
+      return {
+        action: "submit",
+        content: { field1: "mock value", form_field: "test" },
+      };
+    },
+  });
+
+  const session = await client.createSession("aggregator");
+  console.log("Connected.");
+
+  session.on("notification", (notification) => {
+    console.log(
+      "Received notification:",
+      notification.method,
+      notification.params
+    );
+  });
+
+  console.log("Listing tools...");
+  const tools = await session.listTools();
+  console.log(
+    "Available tools:",
+    tools.map((t) => t.name)
+  );
+
+  console.log("Calling fastmcp_hello_from_fastmcp...");
+  const fastmcpResult = await session.callTool("fastmcp_hello_from_fastmcp", {
+    name: "MCP User",
+  });
+  console.log("FastMCP Result:", fastmcpResult);
+
+  console.log("Calling conformance_test_sampling...");
+  try {
+    const samplingResult = await session.callTool("conformance_test_sampling", {
+      prompt: "Test prompt",
+    });
+    console.log("Sampling Result:", samplingResult);
+  } catch (e) {
+    console.error("Sampling error:", e);
+  }
+
+  console.log("Calling conformance_test_elicitation...");
+  try {
+    const elicitationResult = await session.callTool(
+      "conformance_test_elicitation",
+      { title: "Test Form", description: "Fill this out" }
+    );
+    console.log("Elicitation Result:", elicitationResult);
+  } catch (e) {
+    console.error("Elicitation error:", e);
+  }
+
+  console.log("Calling conformance_test_tool_with_progress...");
+  try {
+    const progressResult = await session.callTool(
+      "conformance_test_tool_with_progress",
+      { steps: 3 }
+    );
+    console.log("Progress Result:", progressResult);
+  } catch (e) {
+    console.error("Progress error:", e);
+  }
+
+  console.log("Calling manufact_SearchMcpUse...");
+  try {
+    const manufactResult = await session.callTool("manufact_SearchMcpUse", {
+      query: "proxy",
+    });
+    console.log("Manufact Result:", manufactResult);
+  } catch (e) {
+    console.error("Manufact error:", e);
+  }
+
+  process.exit(0);
+}
+
+main().catch(console.error);

--- a/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
@@ -431,6 +431,105 @@ class MCPServerClass<HasOAuth extends boolean = false> {
   }
 
   /**
+   * Proxy to another MCP server(s).
+   *
+   * This method mounts one or more MCP clients onto this server, introspecting
+   * their tools, resources, and prompts, and registering them natively.
+   *
+   * @param config - A mapping of namespaces to server connection configs, or a single MCPSession.
+   * @param options - Additional options, such as namespace (if passing a single MCPSession).
+   *
+   * @example
+   * ```typescript
+   * // Using config map
+   * await server.proxy({
+   *   db: { command: "node", args: ["db.js"] }
+   * });
+   *
+   * // Using explicit session
+   * await server.proxy(mySession, { namespace: "db" });
+   * ```
+   */
+  public async proxy(
+    config: Record<string, any> | any,
+    options?: { namespace?: string }
+  ): Promise<void> {
+    // Dynamic import to avoid bringing client code into server bundle unless used
+    const { MCPClient } = await import("../client.js");
+    const { mountSession } = await import("./utils/proxy-client.js");
+
+    // If it's an MCPSession (duck typing by checking for callTool method)
+    if (config && typeof config.callTool === "function") {
+      await mountSession(this, config, options?.namespace);
+      return;
+    }
+
+    // Otherwise, treat config as a map of namespaces to server configs
+    const proxyClient = new MCPClient({
+      mcpServers: config,
+      onSampling: async (params: any) => {
+        try {
+          const { getRequestContext } = await import("./context-storage.js");
+          const { findSessionContext } =
+            await import("./tools/tool-execution-helpers.js");
+          const ctx = getRequestContext();
+          if (!ctx) throw new Error("No request context");
+          const { session } = findSessionContext(
+            this.sessions,
+            ctx,
+            undefined,
+            undefined
+          );
+          if (!session || !session.server) throw new Error("No session");
+          return await session.server.server.createMessage(params);
+        } catch (e) {
+          console.warn(
+            "[Proxy] Fallback sampling response due to missing request context (global proxy mode)"
+          );
+          return {
+            role: "assistant",
+            model: "proxy-fallback",
+            content: {
+              type: "text",
+              text: "Mock sampled response from proxy fallback",
+            },
+          };
+        }
+      },
+      onElicitation: async (params: any) => {
+        try {
+          const { getRequestContext } = await import("./context-storage.js");
+          const { findSessionContext } =
+            await import("./tools/tool-execution-helpers.js");
+          const ctx = getRequestContext();
+          if (!ctx) throw new Error("No request context");
+          const { session } = findSessionContext(
+            this.sessions,
+            ctx,
+            undefined,
+            undefined
+          );
+          if (!session || !session.server) throw new Error("No session");
+          return await session.server.server.elicitInput(params);
+        } catch (e) {
+          console.warn(
+            "[Proxy] Fallback elicitation response due to missing request context (global proxy mode)"
+          );
+          return {
+            action: "accept",
+            content: { mock: "data from proxy fallback" },
+          };
+        }
+      },
+    });
+    const sessions = await proxyClient.createAllSessions(true);
+
+    for (const [namespace, session] of Object.entries(sessions)) {
+      await mountSession(this, session as any, namespace);
+    }
+  }
+
+  /**
    * Add a new widget tool directly to all active sessions (for HMR)
    *
    * This method adds a widget tool to all active sessions' internal state

--- a/libraries/typescript/packages/mcp-use/src/server/utils/index.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/utils/index.ts
@@ -9,3 +9,4 @@ export * from "./server-lifecycle.js";
 export * from "./hono-proxy.js";
 export * from "./completion-helpers.js";
 export * from "./elicitation-helpers.js";
+export * from "./proxy-client.js";

--- a/libraries/typescript/packages/mcp-use/src/server/utils/proxy-client.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/utils/proxy-client.ts
@@ -1,0 +1,220 @@
+import type { MCPSession } from "../../session.js";
+import type { MCPServer } from "../mcp-server.js";
+import { z } from "zod";
+
+// Add a helper to convert JSON Schema to Zod Schema
+function jsonSchemaToZod(schema: any): z.ZodTypeAny {
+  if (!schema || typeof schema !== "object") return z.any();
+
+  if (schema.type === "object") {
+    const shape: Record<string, z.ZodTypeAny> = {};
+    if (schema.properties) {
+      for (const [key, prop] of Object.entries<any>(schema.properties)) {
+        let propSchema = jsonSchemaToZod(prop);
+        if (prop.description) {
+          propSchema = propSchema.describe(prop.description);
+        }
+        if (!schema.required?.includes(key)) {
+          propSchema = propSchema.optional();
+        }
+        shape[key] = propSchema;
+      }
+    }
+    return z.object(shape);
+  }
+
+  if (schema.type === "string") return z.string();
+  if (schema.type === "number" || schema.type === "integer") return z.number();
+  if (schema.type === "boolean") return z.boolean();
+  if (schema.type === "array") {
+    return schema.items
+      ? z.array(jsonSchemaToZod(schema.items))
+      : z.array(z.any());
+  }
+
+  return z.any();
+}
+
+/**
+ * Mounts an MCPSession onto an MCPServer, exposing the child server's tools,
+ * resources, and prompts under the given namespace.
+ *
+ * @param parentServer - The parent MCPServer instance
+ * @param childSession - The active MCPSession connected to the child server
+ * @param namespace - Optional namespace prefix for tools, resources, and prompts
+ */
+export async function mountSession(
+  parentServer: MCPServer<boolean>,
+  childSession: MCPSession,
+  namespace?: string
+): Promise<void> {
+  const prefix = namespace ? `${namespace}_` : "";
+
+  // Helper to safely prefix names
+  const prefixName = (name: string) => `${prefix}${name}`;
+
+  // 1. Introspect and mount tools
+  try {
+    const tools = await childSession.listTools();
+    for (const tool of tools) {
+      const toolName = prefixName(tool.name);
+
+      // We use a passthrough raw zod schema
+      // Since the child server already validates, we just pass the raw inputSchema through
+      // MCP Server registerTool handles custom schema shapes if we are careful,
+      // but the easiest way is to use a Zod schema that accepts anything and validate on the child.
+      parentServer.tool(
+        {
+          name: toolName,
+          description: tool.description,
+          // Convert raw JSON Schema from the child server to a Zod schema.
+          // This ensures compatibility with the underlying MCP SDK which expects Zod.
+          schema: jsonSchemaToZod(tool.inputSchema),
+        },
+        async (params: any, ctx: any) => {
+          // Forward the call to the child session
+          const result = await childSession.callTool(tool.name, params as any, {
+            // Forward progress tokens if they exist
+            ...(ctx?._meta?.progressToken && {
+              progressToken: ctx._meta.progressToken,
+            }),
+            onProgress: async (progress: any) => {
+              if (ctx?.reportProgress) {
+                await ctx.reportProgress(
+                  progress.progress,
+                  progress.total,
+                  progress.message
+                );
+              }
+            },
+          });
+
+          if (result.isError) {
+            throw new Error(
+              result.content[0]?.type === "text"
+                ? result.content[0].text
+                : "Tool error"
+            );
+          }
+
+          // Return the full result as text content for now (can map properly)
+          return { content: result.content, _meta: result._meta };
+        }
+      );
+    }
+  } catch (error) {
+    console.warn(
+      `[Proxy] Failed to mount tools for ${namespace || "unnamed"}:`,
+      error
+    );
+  }
+
+  // 2. Introspect and mount resources
+  try {
+    const result = await childSession.listResources();
+    for (const res of result.resources) {
+      const resName = prefixName(res.name);
+      // We'll map the URI directly to the resource URI, but note that the SDK
+      // allows registering resources by URI template or exact URI.
+      // Since the child URI might conflict if another server has the same URI,
+      // The MCP SDK requires resource URIs to be valid URLs (having a protocol).
+      // We use the namespace as the protocol or prepend it to the existing protocol.
+      const proxyUri = namespace
+        ? `${namespace}://${encodeURIComponent(res.uri)}`
+        : res.uri;
+
+      parentServer.resource(
+        {
+          name: resName,
+          uri: proxyUri,
+          title: res.title,
+          description: res.description,
+          mimeType: res.mimeType,
+        },
+        async () => {
+          // The proxyUri is statically known for this resource
+          const originalUri = res.uri;
+          const readResult = await childSession.readResource(originalUri);
+
+          return { contents: readResult.contents };
+        }
+      );
+    }
+  } catch (error) {
+    console.warn(
+      `[Proxy] Failed to mount resources for ${namespace || "unnamed"}:`,
+      error
+    );
+  }
+
+  // 3. Introspect and mount prompts
+  try {
+    const result = await childSession.listPrompts();
+    for (const prompt of result.prompts) {
+      const promptName = prefixName(prompt.name);
+
+      parentServer.prompt(
+        {
+          name: promptName,
+          description: prompt.description,
+          schema: z.object(
+            prompt.arguments?.reduce(
+              (acc, arg) => {
+                let propSchema: z.ZodTypeAny = z.string();
+                if (arg.description) {
+                  propSchema = propSchema.describe(arg.description);
+                }
+                acc[arg.name] = arg.required
+                  ? propSchema
+                  : propSchema.optional();
+                return acc;
+              },
+              {} as Record<string, z.ZodTypeAny>
+            ) || {}
+          ),
+        },
+        async (params: any) => {
+          const promptResult = await childSession.getPrompt(
+            prompt.name,
+            params || {}
+          );
+          return {
+            messages: promptResult.messages,
+            description: promptResult.description,
+            _meta: promptResult._meta,
+          };
+        }
+      );
+    }
+  } catch (error) {
+    console.warn(
+      `[Proxy] Failed to mount prompts for ${namespace || "unnamed"}:`,
+      error
+    );
+  }
+
+  // 4. Setup notifications
+  // Forward list_changed notifications from the child session to the parent server
+  childSession.on("notification", (notification) => {
+    switch (notification.method) {
+      case "notifications/tools/list_changed":
+        parentServer.nativeServer.server
+          .sendToolListChanged()
+          .catch(console.error);
+        break;
+      case "notifications/resources/list_changed":
+        parentServer.nativeServer.server
+          .sendResourceListChanged()
+          .catch(console.error);
+        break;
+      case "notifications/prompts/list_changed":
+        parentServer.nativeServer.server
+          .sendPromptListChanged()
+          .catch(console.error);
+        break;
+      default:
+        // Ignore other notification types - only forward list_changed
+        break;
+    }
+  });
+}

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -923,6 +923,25 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  packages/mcp-use/examples/server/features/proxy:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: latest
+        version: 1.27.1(patch_hash=c19f2c8d79a374e03317396864f51a5d896e73b8a2231766cdc88bfbac98161e)(@cfworker/json-schema@4.1.1)(zod@4.3.5)
+      mcp-use:
+        specifier: workspace:*
+        version: link:../../../..
+      zod:
+        specifier: 4.3.5
+        version: 4.3.5
+    devDependencies:
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
   packages/mcp-use/examples/server/features/sampling:
     dependencies:
       mcp-use:
@@ -1152,6 +1171,61 @@ importers:
       '@types/node':
         specifier: ^25.0.2
         version: 25.3.0
+      '@vitejs/plugin-react':
+        specifier: ^5.1.4
+        version: 5.1.4(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^7.3.0
+        version: 7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+
+  test_app:
+    dependencies:
+      '@openai/apps-sdk-ui':
+        specifier: ^0.2.1
+        version: 0.2.1(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.0)
+      cors:
+        specifier: ^2.8.6
+        version: 2.8.6
+      express:
+        specifier: ^5.2.1
+        version: 5.2.1
+      mcp-use:
+        specifier: workspace:*
+        version: link:../packages/mcp-use
+      react:
+        specifier: ^19.2.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.0
+        version: 19.2.4(react@19.2.4)
+      react-router:
+        specifier: ^7.12.0
+        version: 7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      tailwindcss:
+        specifier: ^4.2.0
+        version: 4.2.0
+      zod:
+        specifier: 4.3.5
+        version: 4.3.5
+    devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.2.0
+        version: 4.2.0(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@types/node':
+        specifier: ^25.3.0
+        version: 25.3.0
+      '@types/react':
+        specifier: ^19.2.7
+        version: 19.2.10
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.10)
       '@vitejs/plugin-react':
         specifier: ^5.1.4
         version: 5.1.4(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
@@ -1931,6 +2005,16 @@ packages:
 
   '@modelcontextprotocol/sdk@1.26.0':
     resolution: {integrity: sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: 4.3.5
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
+  '@modelcontextprotocol/sdk@1.27.1':
+    resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -8358,8 +8442,8 @@ snapshots:
 
   '@mcp-ui/client@6.1.0(@cfworker/json-schema@4.1.1)(@preact/signals-core@1.12.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@modelcontextprotocol/ext-apps': 0.3.1(@modelcontextprotocol/sdk@1.26.0(patch_hash=c19f2c8d79a374e03317396864f51a5d896e73b8a2231766cdc88bfbac98161e)(@cfworker/json-schema@4.1.1)(zod@4.3.5))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.5)
-      '@modelcontextprotocol/sdk': 1.26.0(patch_hash=c19f2c8d79a374e03317396864f51a5d896e73b8a2231766cdc88bfbac98161e)(@cfworker/json-schema@4.1.1)(zod@4.3.5)
+      '@modelcontextprotocol/ext-apps': 0.3.1(@modelcontextprotocol/sdk@1.27.1(patch_hash=c19f2c8d79a374e03317396864f51a5d896e73b8a2231766cdc88bfbac98161e)(@cfworker/json-schema@4.1.1)(zod@4.3.5))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.5)
+      '@modelcontextprotocol/sdk': 1.27.1(patch_hash=c19f2c8d79a374e03317396864f51a5d896e73b8a2231766cdc88bfbac98161e)(@cfworker/json-schema@4.1.1)(zod@4.3.5)
       '@quilted/threads': 3.3.1(@preact/signals-core@1.12.2)
       '@r2wc/react-to-web-component': 2.1.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@remote-dom/core': 1.10.1(@preact/signals-core@1.12.2)
@@ -8409,6 +8493,31 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
+  '@modelcontextprotocol/ext-apps@0.3.1(@modelcontextprotocol/sdk@1.27.1(patch_hash=c19f2c8d79a374e03317396864f51a5d896e73b8a2231766cdc88bfbac98161e)(@cfworker/json-schema@4.1.1)(zod@4.3.5))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.5)':
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.27.1(patch_hash=c19f2c8d79a374e03317396864f51a5d896e73b8a2231766cdc88bfbac98161e)(@cfworker/json-schema@4.1.1)(zod@4.3.5)
+      zod: 4.3.5
+    optionalDependencies:
+      '@oven/bun-darwin-aarch64': 1.3.8
+      '@oven/bun-darwin-x64': 1.3.8
+      '@oven/bun-darwin-x64-baseline': 1.3.8
+      '@oven/bun-linux-aarch64': 1.3.8
+      '@oven/bun-linux-aarch64-musl': 1.3.8
+      '@oven/bun-linux-x64': 1.3.8
+      '@oven/bun-linux-x64-baseline': 1.3.8
+      '@oven/bun-linux-x64-musl': 1.3.8
+      '@oven/bun-linux-x64-musl-baseline': 1.3.8
+      '@oven/bun-windows-x64': 1.3.8
+      '@oven/bun-windows-x64-baseline': 1.3.8
+      '@rollup/rollup-darwin-arm64': 4.57.1
+      '@rollup/rollup-darwin-x64': 4.57.1
+      '@rollup/rollup-linux-arm64-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-gnu': 4.57.1
+      '@rollup/rollup-win32-arm64-msvc': 4.57.1
+      '@rollup/rollup-win32-x64-msvc': 4.57.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   '@modelcontextprotocol/ext-apps@1.0.1(@modelcontextprotocol/sdk@1.26.0(patch_hash=c19f2c8d79a374e03317396864f51a5d896e73b8a2231766cdc88bfbac98161e)(@cfworker/json-schema@4.1.1)(zod@4.3.5))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.5)':
     dependencies:
       '@modelcontextprotocol/sdk': 1.26.0(patch_hash=c19f2c8d79a374e03317396864f51a5d896e73b8a2231766cdc88bfbac98161e)(@cfworker/json-schema@4.1.1)(zod@4.3.5)
@@ -8435,6 +8544,30 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
 
   '@modelcontextprotocol/sdk@1.26.0(patch_hash=c19f2c8d79a374e03317396864f51a5d896e73b8a2231766cdc88bfbac98161e)(@cfworker/json-schema@4.1.1)(zod@4.3.5)':
+    dependencies:
+      '@hono/node-server': 1.19.9(hono@4.12.0)
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.2.1(express@5.2.1)
+      hono: 4.12.0
+      jose: 6.1.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.5
+      zod-to-json-schema: 3.25.1(zod@4.3.5)
+    optionalDependencies:
+      '@cfworker/json-schema': 4.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.27.1(patch_hash=c19f2c8d79a374e03317396864f51a5d896e73b8a2231766cdc88bfbac98161e)(@cfworker/json-schema@4.1.1)(zod@4.3.5)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.12.0)
       ajv: 8.17.1

--- a/skills/mcp-apps-builder/SKILL.md
+++ b/skills/mcp-apps-builder/SKILL.md
@@ -122,6 +122,10 @@ Load these before diving into tools/resources/widgets sections.
   - When: Formatting responses from tools/resources (text, JSON, markdown, images, errors)
   - Covers: `text()`, `object()`, `markdown()`, `image()`, `error()`, `mix()`
 
+- **[proxy.md](references/server/proxy.md)**
+  - When: Composing multiple MCP servers into one unified aggregator server
+  - Covers: `server.proxy()`, config API, explicit sessions, sampling routing
+
 ---
 
 ### 🎨 Building Visual Widgets (Interactive UI)?
@@ -334,4 +338,14 @@ server.listen();
 | `mix()` | Multiple contents | `mix(text("Hi"), image(url))` |
 | `error()` | Error responses | `error("Failed to fetch data")` |
 | `resource()` | Embed resource refs | `resource("docs://guide", "text/markdown")` |
+
+**Server methods:**
+- `server.tool()` - Define executable tool
+- `server.resource()` - Define static/dynamic resource
+- `server.resourceTemplate()` - Define parameterized resource
+- `server.prompt()` - Define prompt template
+- `server.proxy()` - Compose/Proxy multiple MCP servers
+- `server.uiResource()` - Define widget resource
+- `server.listen()` - Start server
+
 

--- a/skills/mcp-apps-builder/references/foundations/architecture.md
+++ b/skills/mcp-apps-builder/references/foundations/architecture.md
@@ -58,6 +58,7 @@ High-level methods for defining MCP primitives:
 server.tool({ ... }, async (input) => { ... });
 server.resource({ ... }, async () => { ... });
 server.prompt({ ... }, async (input) => { ... });
+server.proxy({ child: { url: "..." } });
 ```
 
 ---

--- a/skills/mcp-apps-builder/references/server/proxy.md
+++ b/skills/mcp-apps-builder/references/server/proxy.md
@@ -1,0 +1,79 @@
+# Server Proxying & Composition
+
+The `mcp-use` TypeScript SDK allows you to easily proxy and compose multiple MCP servers into a single unified "Aggregator" server.
+
+This is extremely useful when you have multiple microservices or specialized MCP servers (like a database server, a weather server, and an internal API server) and you want to expose all of their tools, resources, and prompts through a single unified endpoint.
+
+## High-Level API (Config Object)
+
+Pass a configuration object directly to `server.proxy()`. The keys act as the **namespaces** for the child servers to prevent naming collisions.
+
+```typescript
+import { MCPServer } from "mcp-use/server";
+import path from "node:path";
+
+const server = new MCPServer({ name: "UnifiedServer", version: "1.0.0" });
+
+// The SDK handles all connections, sessions, and synchronization automatically
+await server.proxy({
+  // Proxy a local TypeScript server (using the 'tsx' runner)
+  database: {
+    command: "tsx",
+    args: [path.resolve(__dirname, "./db-server.ts")]
+  },
+  
+  // Proxy a local Python FastMCP server
+  weather: {
+    command: "uv",
+    args: ["run", "weather_server.py"],
+    env: { ...process.env, FASTMCP_LOG_LEVEL: "ERROR" }
+  },
+  
+  // Proxy a remote server over HTTP
+  manufact: {
+    url: "https://manufact.com/docs/mcp"
+  }
+});
+
+// Start the unified server
+await server.listen(3000);
+```
+
+In the example above, the `database` tools will be prefixed with `database_` (e.g. `database_query`), the `weather` tools will be prefixed with `weather_` (e.g. `weather_get_forecast`), and so on. Resource URIs will be prefixed like `database://app://config`.
+
+## Low-Level API (Explicit Session)
+
+For advanced use cases (dynamic auth headers, manual session lifecycles, or custom connectors), you can inject an explicit `MCPSession` directly into the `proxy` method using the `mcp-use/client` SDK.
+
+```typescript
+import { MCPServer } from "mcp-use/server";
+import { MCPClient } from "mcp-use/client";
+
+const server = new MCPServer({ name: "UnifiedServer", version: "1.0.0" });
+
+// Create a custom client orchestration
+const customClient = new MCPClient({
+  mcpServers: {
+    secure_db: {
+      url: "https://secure-db.example.com/mcp"
+    }
+  }
+});
+
+// Manage the session manually
+const dbSession = await customClient.createSession("secure_db");
+
+// Proxy the active session, manually specifying the namespace
+await server.proxy(dbSession, { namespace: "secure_db" });
+
+await server.listen(3000);
+```
+
+## Advanced Features Supported
+
+The `mcp-use` proxying system goes far beyond simple tool forwarding:
+
+1. **Schema Translation**: Automatically translates raw JSON Schemas from child servers into runtime Zod schemas.
+2. **LLM Sampling & Elicitation**: Automatically intercepts out-of-band JSONRPC requests (sampling/elicitation) from child servers, resolves the HTTP context of the original user who triggered the tool, and routes the request securely back to that user's client. 
+3. **Progress Tracking**: If a child tool emits `notifications/progress/report`, the Aggregator catches and pipes those directly through the unified `ToolContext` back to the parent client.
+4. **State Syncing**: The Aggregator listens to `list_changed` events emitted by the child server and instantly forwards them to all connected clients.

--- a/skills/mcp-builder/SKILL.md
+++ b/skills/mcp-builder/SKILL.md
@@ -27,6 +27,7 @@ Read [design-and-architecture.md](references/design-and-architecture.md): when p
 - **Visual widgets (React TSX)** → [widgets.md](references/widgets.md): when creating interactive UI widgets in `resources/` folder
 - **Response helper API** → [response-helpers.md](references/response-helpers.md): when choosing how to format tool/resource return values
 - **URI template patterns** → [resource-templates.md](references/resource-templates.md): when defining parameterized resources
+- **Server proxying & composition** → [proxy.md](references/proxy.md): when composing multiple MCP servers into a unified aggregator
 
 ## Quick Reference
 
@@ -59,4 +60,11 @@ server.listen();
 
 **Response helpers:** `text()`, `object()`, `markdown()`, `html()`, `image()`, `audio()`, `binary()`, `error()`, `mix()`, `widget()`
 
-**Server methods:** `server.tool()`, `server.resource()`, `server.resourceTemplate()`, `server.prompt()`, `server.listen()`
+**Server methods:**
+- `server.tool()` - Define executable tool
+- `server.resource()` - Define static/dynamic resource
+- `server.resourceTemplate()` - Define parameterized resource
+- `server.prompt()` - Define prompt template
+- `server.proxy()` - Compose/Proxy multiple MCP servers
+- `server.uiResource()` - Define widget resource
+- `server.listen()` - Start server

--- a/skills/mcp-builder/references/proxy.md
+++ b/skills/mcp-builder/references/proxy.md
@@ -1,0 +1,79 @@
+# Server Proxying & Composition
+
+The `mcp-use` TypeScript SDK allows you to easily proxy and compose multiple MCP servers into a single unified "Aggregator" server.
+
+This is extremely useful when you have multiple microservices or specialized MCP servers (like a database server, a weather server, and an internal API server) and you want to expose all of their tools, resources, and prompts through a single unified endpoint.
+
+## High-Level API (Config Object)
+
+Pass a configuration object directly to `server.proxy()`. The keys act as the **namespaces** for the child servers to prevent naming collisions.
+
+```typescript
+import { MCPServer } from "mcp-use/server";
+import path from "node:path";
+
+const server = new MCPServer({ name: "UnifiedServer", version: "1.0.0" });
+
+// The SDK handles all connections, sessions, and synchronization automatically
+await server.proxy({
+  // Proxy a local TypeScript server (using the 'tsx' runner)
+  database: {
+    command: "tsx",
+    args: [path.resolve(__dirname, "./db-server.ts")]
+  },
+  
+  // Proxy a local Python FastMCP server
+  weather: {
+    command: "uv",
+    args: ["run", "weather_server.py"],
+    env: { ...process.env, FASTMCP_LOG_LEVEL: "ERROR" }
+  },
+  
+  // Proxy a remote server over HTTP
+  manufact: {
+    url: "https://manufact.com/docs/mcp"
+  }
+});
+
+// Start the unified server
+await server.listen(3000);
+```
+
+In the example above, the `database` tools will be prefixed with `database_` (e.g. `database_query`), the `weather` tools will be prefixed with `weather_` (e.g. `weather_get_forecast`), and so on. Resource URIs will be prefixed like `database://app://config`.
+
+## Low-Level API (Explicit Session)
+
+For advanced use cases (dynamic auth headers, manual session lifecycles, or custom connectors), you can inject an explicit `MCPSession` directly into the `proxy` method using the `mcp-use/client` SDK.
+
+```typescript
+import { MCPServer } from "mcp-use/server";
+import { MCPClient } from "mcp-use/client";
+
+const server = new MCPServer({ name: "UnifiedServer", version: "1.0.0" });
+
+// Create a custom client orchestration
+const customClient = new MCPClient({
+  mcpServers: {
+    secure_db: {
+      url: "https://secure-db.example.com/mcp"
+    }
+  }
+});
+
+// Manage the session manually
+const dbSession = await customClient.createSession("secure_db");
+
+// Proxy the active session, manually specifying the namespace
+await server.proxy(dbSession, { namespace: "secure_db" });
+
+await server.listen(3000);
+```
+
+## Advanced Features Supported
+
+The `mcp-use` proxying system goes far beyond simple tool forwarding:
+
+1. **Schema Translation**: Automatically translates raw JSON Schemas from child servers into runtime Zod schemas.
+2. **LLM Sampling & Elicitation**: Automatically intercepts out-of-band JSONRPC requests (sampling/elicitation) from child servers, resolves the HTTP context of the original user who triggered the tool, and routes the request securely back to that user's client. 
+3. **Progress Tracking**: If a child tool emits `notifications/progress/report`, the Aggregator catches and pipes those directly through the unified `ToolContext` back to the parent client.
+4. **State Syncing**: The Aggregator listens to `list_changed` events emitted by the child server and instantly forwards them to all connected clients.


### PR DESCRIPTION
- Introduced a new `proxy` method in the `MCPServerClass` to allow mounting multiple MCP clients onto a single server, enhancing server capabilities.
- Updated documentation to include a new "Proxy Servers" section, detailing usage examples and configuration options for the proxy feature.
- Added relevant entries in the pnpm-lock.yaml to support the new proxy functionality, ensuring all dependencies are correctly managed.
- Enhanced the `index.mdx` file to reflect the addition of the proxy server feature, improving clarity for developers on available functionalities.
