### PR TITLE
fix(python): use WeakSet for resource subscriptions to prevent memory leak

### DIFF
--- a/libraries/python/mcp_use/server/server.py
+++ b/libraries/python/mcp_use/server/server.py
@@ -4,6 +4,7 @@ import inspect
 import logging
 import os
 import time
+import weakref
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, cast
 
@@ -305,13 +306,16 @@ class MCPServer(FastMCP):
             self._client_log_level = str(level)
 
         # resources/subscribe + unsubscribe — track per-URI subscriptions
-        self._resource_subscriptions: dict[str, set[int]] = {}  # uri -> set of session ids
+        # Uses WeakSet so that subscriptions are automatically cleaned up when
+        # a client disconnects and its session object is garbage-collected,
+        # preventing the memory leak described in GitHub issue #1092.
+        self._resource_subscriptions: dict[str, weakref.WeakSet] = {}  # uri -> WeakSet of sessions
 
         @self._mcp_server.subscribe_resource()
         async def _handle_subscribe(uri: Any) -> None:
             session = self._current_session()
             if session:
-                self._resource_subscriptions.setdefault(str(uri), set()).add(id(session))
+                self._resource_subscriptions.setdefault(str(uri), weakref.WeakSet()).add(session)
 
         @self._mcp_server.unsubscribe_resource()
         async def _handle_unsubscribe(uri: Any) -> None:
@@ -319,7 +323,7 @@ class MCPServer(FastMCP):
             if session:
                 subscribers = self._resource_subscriptions.get(str(uri))
                 if subscribers:
-                    subscribers.discard(id(session))
+                    subscribers.discard(session)
                     if not subscribers:
                         del self._resource_subscriptions[str(uri)]
 
@@ -352,14 +356,17 @@ class MCPServer(FastMCP):
         """
         subscribers = self._resource_subscriptions.get(uri)
         if not subscribers:
+            # Clean up empty entry left behind after all sessions were GC'd
+            self._resource_subscriptions.pop(uri, None)
             return
 
-        for session in list(MiddlewareServerSession._active_sessions):
-            if id(session) in subscribers:
-                try:
-                    await session.send_resource_updated(uri=uri)
-                except Exception:
-                    pass  # Session may have disconnected
+        # Iterate a snapshot; the WeakSet may shrink during iteration
+        # if sessions are garbage-collected concurrently.
+        for session in list(subscribers):
+            try:
+                await session.send_resource_updated(uri=uri)
+            except Exception:
+                pass  # Session may have disconnected
 
     def streamable_http_app(self):
         """Override to add our custom middleware."""

--- a/libraries/python/tests/unit/server/test_subscription_cleanup.py
+++ b/libraries/python/tests/unit/server/test_subscription_cleanup.py
@@ -1,0 +1,119 @@
+"""Unit tests for resource subscription cleanup on client disconnect.
+
+Verifies the fix for GitHub issue #1092: when a client disconnects without
+explicitly unsubscribing, weak references ensure the subscription entries
+are automatically cleaned up by the garbage collector.
+"""
+
+import gc
+import weakref
+
+import pytest
+
+from mcp_use.server import MCPServer
+
+
+class FakeSession:
+    """Minimal session-like object that supports weak references."""
+
+    def __init__(self):
+        self.notified_uris: list[str] = []
+
+    async def send_resource_updated(self, uri: str) -> None:
+        self.notified_uris.append(uri)
+
+
+@pytest.mark.asyncio
+async def test_subscription_cleanup_after_session_gc():
+    """Subscriptions are removed when a session is garbage-collected.
+
+    Simulates a client that subscribes to a resource and then disconnects
+    abruptly (no unsubscribe). After GC, the subscription set should be empty.
+    """
+    server = MCPServer(name="test")
+    uri = "data://test-resource"
+
+    session = FakeSession()
+    weak = weakref.ref(session)
+
+    # Manually add subscription (simulates the subscribe handler)
+    server._resource_subscriptions.setdefault(uri, weakref.WeakSet()).add(session)
+    assert len(server._resource_subscriptions[uri]) == 1
+
+    # Simulate abrupt disconnect: drop all strong references
+    del session
+    gc.collect()
+
+    # Session should be dead
+    assert weak() is None
+
+    # Subscription set should now be empty
+    assert len(server._resource_subscriptions.get(uri, weakref.WeakSet())) == 0
+
+
+@pytest.mark.asyncio
+async def test_notify_skips_gc_collected_sessions():
+    """notify_resource_updated works correctly when sessions have been GC'd."""
+    server = MCPServer(name="test")
+    uri = "data://test-resource"
+
+    live_session = FakeSession()
+    dead_session = FakeSession()
+
+    subs = weakref.WeakSet()
+    subs.add(live_session)
+    subs.add(dead_session)
+    server._resource_subscriptions[uri] = subs
+
+    # Kill one session
+    del dead_session
+    gc.collect()
+
+    # Only the live session should be notified
+    await server.notify_resource_updated(uri)
+    assert live_session.notified_uris == [uri]
+
+
+@pytest.mark.asyncio
+async def test_notify_does_not_crash_when_all_sessions_gone():
+    """notify_resource_updated is safe to call after all subscribers are GC'd."""
+    server = MCPServer(name="test")
+    uri = "data://test-resource"
+
+    session = FakeSession()
+    server._resource_subscriptions.setdefault(uri, weakref.WeakSet()).add(session)
+
+    del session
+    gc.collect()
+
+    # Should complete without errors
+    await server.notify_resource_updated(uri)
+
+    # The empty dict entry should also be cleaned up
+    assert uri not in server._resource_subscriptions
+
+
+@pytest.mark.asyncio
+async def test_multiple_uris_independent_cleanup():
+    """Sessions subscribed to different URIs are cleaned up independently."""
+    server = MCPServer(name="test")
+
+    session_a = FakeSession()
+    session_b = FakeSession()
+
+    server._resource_subscriptions.setdefault("uri://a", weakref.WeakSet()).add(session_a)
+    server._resource_subscriptions.setdefault("uri://a", weakref.WeakSet()).add(session_b)
+    server._resource_subscriptions.setdefault("uri://b", weakref.WeakSet()).add(session_b)
+
+    # Drop session_a only
+    del session_a
+    gc.collect()
+
+    # uri://a should still have session_b
+    assert len(server._resource_subscriptions["uri://a"]) == 1
+    # uri://b is unaffected
+    assert len(server._resource_subscriptions["uri://b"]) == 1
+
+    # Notify uri://a — only session_b should receive it
+    await server.notify_resource_updated("uri://a")
+    assert session_b.notified_uris == ["uri://a"]


### PR DESCRIPTION
## Summary
Fixes #1092 — supersedes #1093 with additional improvements and tests.

Resource subscriptions previously tracked sessions by storing `id(session)` integers in plain `set[int]`. When clients disconnected without explicitly unsubscribing (crash, network drop, SIGKILL), these integer IDs accumulated indefinitely — a slow memory leak that also degraded `notify_resource_updated()` broadcast performance over time.

## Changes

1. **Replace `dict[str, set[int]]` with `dict[str, weakref.WeakSet]`** for `_resource_subscriptions`
   - Store weak references to session objects directly instead of `id(session)` integers
   - When a session is garbage-collected after disconnect, its entry is automatically removed from all subscription sets

2. **Simplify `notify_resource_updated()`** to iterate the `WeakSet` directly instead of scanning all active sessions and checking membership by id — O(subscribers) instead of O(all_sessions)

3. **Clean up empty dict entries** after all sessions for a URI are GC'd, preventing stale keys from accumulating (improvement over #1093)

4. **Add unit tests** for GC-driven subscription cleanup (missing from #1093):
   - `test_subscription_cleanup_after_session_gc` — core fix validation
   - `test_notify_skips_gc_collected_sessions` — selective notification
   - `test_notify_does_not_crash_when_all_sessions_gone` — resilience + dict cleanup
   - `test_multiple_uris_independent_cleanup` — per-session/per-URI independence

## Why WeakSet works here

`MiddlewareServerSession._active_sessions` is already a `weakref.WeakSet`, so session objects are designed to be weakly referenceable (no `__slots__` in `ServerSession` or `BaseSession`). The `AsyncExitStack` in `lowlevel.Server.run()` holds the strong reference during the connection — when it unwinds on disconnect, the session becomes GC-eligible and both WeakSets clean up automatically.

## Backwards Compatibility

- `subscribe()` / `unsubscribe()` API unchanged
- `notify_resource_updated()` API unchanged
- MCP spec (2025-11-25) compliant — the spec defines subscribe/unsubscribe protocol messages but is silent on internal cleanup, so this is an implementation detail

## Testing

- 4 new unit tests pass
- All 65 existing server unit tests pass
- `WeakSet` supports the same `add()` / `discard()` / iteration interface as `set`