### PR TITLE
RFC: MCP Operation-Level Middleware for TypeScript SDK

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -596,6 +596,7 @@
                     "group": "Advanced Features",
                     "icon": "sparkle",
                     "pages": [
+                      "typescript/server/middleware",
                       "typescript/server/proxy",
                       "typescript/server/elicitation",
                       "typescript/server/sampling",

--- a/docs/typescript/server/middleware.mdx
+++ b/docs/typescript/server/middleware.mdx
@@ -1,0 +1,225 @@
+---
+title: Middleware
+description: Intercept and process MCP requests with middleware
+icon: "layers"
+---
+
+Middleware lets you intercept MCP operations to add logging, authentication, rate limiting, or any cross-cutting logic — without touching individual tool handlers.
+
+## Quick Start
+
+```typescript
+import { MCPServer, text } from "mcp-use/server";
+
+const server = new MCPServer({ name: "my-server", version: "1.0.0" });
+
+// Log every tool call
+server.use("mcp:tools/call", async (ctx, next) => {
+  console.log(`→ ${ctx.params.name}`);
+  const result = await next();
+  console.log(`← ${ctx.params.name}`);
+  return result;
+});
+
+server.tool(
+  { name: "greet", description: "Say hello", schema: z.object({ name: z.string() }) },
+  async ({ name }) => text(`Hello, ${name}!`)
+);
+
+await server.listen();
+```
+
+## How It Works
+
+MCP middleware uses an **onion model** — each middleware wraps the next, with the handler at the center.
+
+```
+Request
+  → Middleware A (before)
+    → Middleware B (before)
+      → Handler
+    ← Middleware B (after)
+  ← Middleware A (after)
+Response
+```
+
+Middleware is registered with `server.use('mcp:pattern', handler)` where the `mcp:` prefix distinguishes MCP middleware from HTTP middleware. Multiple middleware functions are composed in registration order (first registered = outermost).
+
+Each middleware can:
+- Inspect or modify the request before calling `next()`
+- Inspect or modify the response after `next()` returns
+- **Short-circuit** by returning early without calling `next()`
+- **Reject** by throwing an error
+
+## Patterns
+
+The pattern string (after `mcp:`) determines which operations trigger the middleware:
+
+| Pattern | Matches |
+|---------|---------|
+| `mcp:tools/call` | Tool executions only |
+| `mcp:tools/list` | Requests to list available tools |
+| `mcp:tools/*` | All tool operations |
+| `mcp:resources/read` | Resource reads |
+| `mcp:resources/list` | Requests to list resources |
+| `mcp:resources/*` | All resource operations |
+| `mcp:prompts/get` | Prompt fetches |
+| `mcp:prompts/list` | Requests to list prompts |
+| `mcp:prompts/*` | All prompt operations |
+| `mcp:*` | Every MCP operation |
+
+## Context
+
+Every middleware receives a `MiddlewareContext`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `method` | `string` | MCP method name (e.g. `"tools/call"`) |
+| `params` | `Record<string, unknown>` | Request params — mutable, mutations flow downstream |
+| `session` | `{ sessionId: string } \| undefined` | Session ID (HTTP transports) |
+| `auth` | `AuthInfo \| undefined` | OAuth info when authentication is configured |
+| `state` | `Map<string, unknown>` | Shared state for passing data across middleware |
+
+<Tip>
+`ctx.params` is mutable. Middleware can modify it before calling `next()` and the handler will receive the modified values.
+</Tip>
+
+### `ctx.auth` and OAuth
+
+When OAuth is configured (via `server.use(oauthAuth0Provider(...))` etc.), `ctx.auth` is automatically populated from the verified JWT:
+
+```typescript
+server.use("mcp:tools/call", async (ctx, next) => {
+  if (ctx.auth) {
+    console.log(`User: ${ctx.auth.user.email}`);
+    console.log(`Scopes: ${ctx.auth.scopes.join(", ")}`);
+  }
+  return next();
+});
+```
+
+## Examples
+
+<Tabs>
+  <Tab title="Logging">
+    Log all MCP operations with timing:
+
+    ```typescript
+    server.use("mcp:*", async (ctx, next) => {
+      const start = Date.now();
+      const result = await next();
+      console.log(`${ctx.method} — ${Date.now() - start}ms`);
+      return result;
+    });
+    ```
+  </Tab>
+
+  <Tab title="Scope Guard">
+    Require an OAuth scope before any tool call:
+
+    ```typescript
+    server.use("mcp:tools/call", async (ctx, next) => {
+      const toolName = (ctx.params as any).name;
+      const required = `tools:call:${toolName}`;
+
+      if (!ctx.auth?.scopes.includes(required) &&
+          !ctx.auth?.scopes.includes("tools:*")) {
+        throw new Error(`Insufficient scope. Required: ${required}`);
+      }
+
+      return next();
+    });
+    ```
+  </Tab>
+
+  <Tab title="Rate Limiting">
+    Limit tool calls per session per minute:
+
+    ```typescript
+    const rateLimits = new Map<string, number[]>();
+
+    server.use("mcp:tools/call", async (ctx, next) => {
+      const key = ctx.session?.sessionId ?? "anonymous";
+      const now = Date.now();
+      const calls = (rateLimits.get(key) ?? [])
+        .filter(t => t > now - 60_000);
+
+      if (calls.length >= 30) {
+        throw new Error("Rate limit exceeded (30 calls/min)");
+      }
+
+      calls.push(now);
+      rateLimits.set(key, calls);
+      return next();
+    });
+    ```
+  </Tab>
+
+  <Tab title="Tool Filtering">
+    Hide internal tools from the list:
+
+    ```typescript
+    server.use("mcp:tools/list", async (ctx, next) => {
+      const result = (await next()) as any;
+      const tools = Array.isArray(result) ? result : result?.tools ?? [];
+      const visible = tools.filter((t: any) => !t.name.startsWith("_"));
+      return Array.isArray(result) ? visible : { ...result, tools: visible };
+    });
+    ```
+  </Tab>
+</Tabs>
+
+## Middleware Order
+
+Middleware executes in registration order. Earlier middleware wraps later ones.
+
+```typescript
+server.use("mcp:*",         loggingMiddleware);  // 1. Outermost — sees everything
+server.use("mcp:tools/call", authMiddleware);    // 2. Rejects unauthorized early
+server.use("mcp:tools/call", rateLimitMiddleware); // 3. Limits request rate
+```
+
+<Tip>
+**Recommended order**: Logging → Authentication → Rate limiting → Validation. This ensures logging sees all requests (including rejected ones) and auth rejects early before expensive operations.
+</Tip>
+
+## HTTP vs MCP Middleware
+
+`server.use()` handles both HTTP and MCP middleware. The `mcp:` prefix distinguishes them:
+
+```typescript
+// MCP middleware — intercepts MCP operations
+server.use("mcp:tools/call", async (ctx, next) => { ... });
+
+// HTTP middleware — intercepts HTTP requests (existing Hono behavior)
+server.use("/api/*", someHttpMiddleware);
+server.use(someHonoMiddleware);
+```
+
+<Note>
+HTTP middleware runs at the HTTP layer (before the MCP protocol). MCP middleware runs at the MCP layer (after the protocol parses the request). Use HTTP middleware for things like CORS; use MCP middleware for things like scope-checking tool access.
+</Note>
+
+## Best Practices
+
+- **Single responsibility** — each middleware does one thing
+- **Fail fast** — reject invalid requests before expensive operations
+- **Always call `next()`** — unless intentionally short-circuiting
+- **Re-raise exceptions** — if you catch errors to log them, always re-throw
+
+```typescript
+server.use("mcp:tools/call", async (ctx, next) => {
+  try {
+    return await next();
+  } catch (err) {
+    console.error(`Tool failed: ${err}`);
+    throw err; // always re-raise
+  }
+});
+```
+
+## Full Example
+
+<Card title="middleware example" icon="github" href="https://github.com/mcp-use/mcp-use/blob/main/libraries/typescript/packages/mcp-use/examples/server/features/middleware/src/server.ts">
+  Complete server with logging, scope guard, rate limiter, and tool filter middleware.
+</Card>

--- a/libraries/typescript/.changeset/add-mcp-middleware.md
+++ b/libraries/typescript/.changeset/add-mcp-middleware.md
@@ -1,0 +1,33 @@
+---
+"mcp-use": minor
+---
+
+Add MCP operation-level middleware via `server.use('mcp:...', fn)`
+
+Introduces a Hono-style middleware system for intercepting MCP operations (tool calls, resource reads, prompt fetches, and list operations) without touching HTTP routing.
+
+**Usage:**
+
+```typescript
+// Fires for every MCP operation
+server.use("mcp:*", async (ctx, next) => {
+  console.log(`→ [${ctx.method}]`, ctx.params);
+  const result = await next();
+  console.log(`← [${ctx.method}] done`);
+  return result;
+});
+
+// Only fires on tool calls — ctx and next are fully typed automatically
+server.use("mcp:tools/call", async (ctx, next) => {
+  if (ctx.auth && !ctx.auth.scopes.includes("tools:*")) {
+    throw new Error("Insufficient scope");
+  }
+  return next();
+});
+```
+
+**Patterns:** `mcp:*` (catch-all), `mcp:tools/call`, `mcp:tools/list`, `mcp:resources/read`, `mcp:resources/list`, `mcp:prompts/get`, `mcp:prompts/list`.
+
+**`MiddlewareContext` fields:** `method`, `params`, `session`, `auth` (populated when OAuth is configured), `state` (per-request `Map` for sharing data between middleware).
+
+Middleware runs in registration order (onion model), is compatible with HMR, and integrates with the existing OAuth scope system. The `mcp:` prefix clearly distinguishes MCP middleware from HTTP middleware registered via the same `server.use()` call.

--- a/libraries/typescript/packages/mcp-use/examples/server/features/middleware/package.json
+++ b/libraries/typescript/packages/mcp-use/examples/server/features/middleware/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "middleware-example",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "description": "MCP server demonstrating operation-level middleware",
+  "scripts": {
+    "dev": "mcp-use dev",
+    "start": "mcp-use start",
+    "build": "mcp-use build"
+  },
+  "dependencies": {
+    "mcp-use": "workspace:*",
+    "zod": "4.3.5"
+  },
+  "devDependencies": {
+    "@types/node": "^25.0.2",
+    "tsx": "^4.21.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/libraries/typescript/packages/mcp-use/examples/server/features/middleware/src/server.ts
+++ b/libraries/typescript/packages/mcp-use/examples/server/features/middleware/src/server.ts
@@ -1,0 +1,153 @@
+import { MCPServer, text, error } from "mcp-use/server";
+import { z } from "zod";
+
+const server = new MCPServer({
+  name: "middleware-example",
+  version: "1.0.0",
+  description:
+    "An MCP server demonstrating operation-level middleware with server.use('mcp:...')",
+});
+
+// ---------------------------------------------------------------------------
+// 1. Logging middleware — fires for every MCP operation
+//
+// Pattern: 'mcp:*'  →  matches tools/call, tools/list, resources/read, etc.
+// ---------------------------------------------------------------------------
+server.use("mcp:*", async (ctx, next) => {
+  const start = Date.now();
+  console.log(`→ [${ctx.method}]`, JSON.stringify(ctx.params));
+  const result = await next();
+  console.log(`← [${ctx.method}] ${Date.now() - start}ms`);
+  return result;
+});
+
+// ---------------------------------------------------------------------------
+// 2. Auth guard — checks OAuth scopes before any tool call
+//
+// Pattern: 'mcp:tools/call'  →  exact match
+//
+// When OAuth is configured, ctx.auth is populated from the JWT.
+// Without OAuth this middleware is a no-op (ctx.auth is undefined).
+// ---------------------------------------------------------------------------
+server.use("mcp:tools/call", async (ctx, next) => {
+  if (ctx.auth) {
+    const toolName = (ctx.params as { name?: string }).name ?? "";
+    const required = `tools:call:${toolName}`;
+    if (
+      !ctx.auth.scopes.includes(required) &&
+      !ctx.auth.scopes.includes("tools:*")
+    ) {
+      throw new Error(`Insufficient scope. Required: ${required}`);
+    }
+  }
+  return next();
+});
+
+// ---------------------------------------------------------------------------
+// 3. Per-session rate limiter — limits tool calls per session per minute
+//
+// Pattern: 'mcp:tools/call'  →  applies only to tool calls
+//
+// ctx.state can carry per-request data; for cross-request state use a Map
+// outside the middleware (as shown here).
+// ---------------------------------------------------------------------------
+const rateLimitMap = new Map<string, number[]>();
+const RATE_LIMIT = 30; // max calls per minute per session
+
+server.use("mcp:tools/call", async (ctx, next) => {
+  const key = ctx.session?.sessionId ?? "anonymous";
+  const now = Date.now();
+  const windowStart = now - 60_000;
+
+  const calls = (rateLimitMap.get(key) ?? []).filter((t) => t > windowStart);
+  if (calls.length >= RATE_LIMIT) {
+    throw new Error("Rate limit exceeded (30 calls/min)");
+  }
+  calls.push(now);
+  rateLimitMap.set(key, calls);
+
+  return next();
+});
+
+// ---------------------------------------------------------------------------
+// 4. Tool-filter middleware — hides internal tools from the list
+//
+// Pattern: 'mcp:tools/list'  →  only fires when clients list tools
+//
+// The middleware receives the tools array from next() and can filter,
+// sort, or enrich it before returning.
+// ---------------------------------------------------------------------------
+server.use("mcp:tools/list", async (_ctx, next) => {
+  const result = (await next()) as any;
+
+  // Handle both array and { tools: [...] } shapes
+  const tools: any[] = Array.isArray(result) ? result : (result?.tools ?? []);
+
+  const filtered = tools.filter((t: any) => !t.name.startsWith("_"));
+
+  return Array.isArray(result) ? filtered : { ...result, tools: filtered };
+});
+
+// ---------------------------------------------------------------------------
+// Tools
+// ---------------------------------------------------------------------------
+
+server.tool(
+  {
+    name: "greet",
+    description: "Return a greeting for a given name",
+    schema: z.object({
+      name: z.string().describe("The name to greet"),
+    }),
+  },
+  async ({ name }) => text(`Hello, ${name}!`)
+);
+
+server.tool(
+  {
+    name: "calculate",
+    description: "Evaluate a simple arithmetic expression (a op b)",
+    schema: z.object({
+      a: z.number().describe("First operand"),
+      op: z.enum(["+", "-", "*", "/"]).describe("Operator"),
+      b: z.number().describe("Second operand"),
+    }),
+  },
+  async ({ a, op, b }) => {
+    if (op === "/" && b === 0) return error("Division by zero");
+    const result =
+      op === "+" ? a + b : op === "-" ? a - b : op === "*" ? a * b : a / b;
+    return text(String(result));
+  }
+);
+
+server.tool(
+  {
+    name: "fetch-data",
+    description: "Simulates fetching external data (protected by scope guard)",
+    schema: z.object({
+      endpoint: z.string().describe("The endpoint to fetch from"),
+    }),
+  },
+  async ({ endpoint }) => {
+    // Simulate async work
+    await new Promise((r) => setTimeout(r, 50));
+    return text(`Data from ${endpoint}: { "status": "ok" }`);
+  }
+);
+
+// Internal tool — hidden by the tools/list middleware
+server.tool(
+  {
+    name: "_debug-sessions",
+    description: "Internal debug tool (hidden from listing)",
+    schema: z.object({}),
+  },
+  async () => text("Debug info: all sessions active")
+);
+
+// ---------------------------------------------------------------------------
+// Start the server
+// ---------------------------------------------------------------------------
+
+await server.listen();

--- a/libraries/typescript/packages/mcp-use/examples/server/features/middleware/tsconfig.json
+++ b/libraries/typescript/packages/mcp-use/examples/server/features/middleware/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/libraries/typescript/packages/mcp-use/src/server/index.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/index.ts
@@ -156,6 +156,15 @@ export {
 // MCP Proxy middleware for CORS proxying
 export { mountMcpProxy, type McpProxyOptions } from "./middleware/mcp-proxy.js";
 
+// MCP operation-level middleware
+export {
+  composeMiddleware,
+  matchesPattern,
+  type McpMiddlewareEntry,
+  type McpMiddlewareFn,
+  type MiddlewareContext,
+} from "./middleware/mcp-middleware.js";
+
 // OAuth Proxy middleware for CORS-free OAuth flows
 export { mountOAuthProxy, type OAuthProxyOptions } from "./oauth/proxy.js";
 

--- a/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
@@ -111,6 +111,13 @@ import {
   rewriteSupabaseRequest,
   startServer,
 } from "./utils/index.js";
+import type { WithMcpUse } from "./utils/hono-proxy.js";
+import type {
+  McpMiddlewareEntry,
+  McpMiddlewareFn,
+  MiddlewareContext,
+} from "./middleware/mcp-middleware.js";
+import { composeMiddleware } from "./middleware/mcp-middleware.js";
 
 /**
  * Validates that a key is safe to use as a property name to prevent prototype pollution.
@@ -297,6 +304,14 @@ class MCPServerClass<HasOAuth extends boolean = false> {
   public _customRoutes = new Map<string, ((...args: any[]) => any)[]>();
 
   /**
+   * Registered MCP operation-level middleware entries.
+   * Populated via `server.use('mcp:...', handler)`.
+   * Read dynamically at invocation time (not captured at registration).
+   * @internal
+   */
+  public mcpMiddlewares: McpMiddlewareEntry[] = [];
+
+  /**
    * Port number the server is listening on (set after calling {@link listen}).
    */
   public serverPort?: number;
@@ -428,6 +443,23 @@ class MCPServerClass<HasOAuth extends boolean = false> {
    */
   public cleanupSessionRefs(sessionId: string): void {
     this.sessionRegisteredRefs.delete(sessionId);
+  }
+
+  /**
+   * Register an MCP operation-level middleware.
+   *
+   * Called internally by the `server.use('mcp:...', handler)` proxy.
+   * Applications should use `server.use('mcp:tools/call', handler)` instead.
+   *
+   * @param pattern - MCP method pattern (without 'mcp:' prefix), e.g. 'tools/call', 'tools/*', '*'
+   * @param handler - Middleware function
+   * @internal
+   */
+  public _registerMcpMiddleware(
+    pattern: string,
+    handler: McpMiddlewareFn
+  ): void {
+    this.mcpMiddlewares.push({ pattern, handler });
   }
 
   /**
@@ -1170,6 +1202,9 @@ class MCPServerClass<HasOAuth extends boolean = false> {
     prompts: { added: number; removed: number; updated: number };
     resources: { added: number; removed: number; updated: number };
   } {
+    // Sync MCP middleware entries from the new module (HMR)
+    this.mcpMiddlewares = other.mcpMiddlewares;
+
     // Build session contexts array (shared across all primitives)
     const sessionContexts = Array.from(this.sessions.entries()).map(
       ([sessionId, session]) => ({
@@ -1258,12 +1293,23 @@ class MCPServerClass<HasOAuth extends boolean = false> {
           requestMeta
         );
 
-        const executeCallback = async () => {
-          if (actualCallback.length >= 2) {
-            return await actualCallback(params, enhancedContext);
-          }
-          return await actualCallback(params);
+        const mwCtx: MiddlewareContext = {
+          method: "tools/call",
+          params: params as Record<string, unknown>,
+          session: sessionId ? { sessionId } : undefined,
+          auth: requestContext?.get("auth"),
+          state: new Map(),
         };
+
+        const innerFn = async () => {
+          if (actualCallback.length >= 2) {
+            return await actualCallback(mwCtx.params, enhancedContext);
+          }
+          return await actualCallback(mwCtx.params);
+        };
+
+        const executeCallback = () =>
+          composeMiddleware(this.mcpMiddlewares, "tools/call", innerFn)(mwCtx);
 
         if (requestContext) {
           return await runWithContext(requestContext, executeCallback);
@@ -2746,12 +2792,23 @@ class MCPServerClass<HasOAuth extends boolean = false> {
           requestMeta
         );
 
-        const executeCallback = async () => {
-          if (actualCallback.length >= 2) {
-            return await (actualCallback as any)(params, enhancedContext);
-          }
-          return await (actualCallback as any)(params);
+        const mwCtx: MiddlewareContext = {
+          method: "tools/call",
+          params: params as Record<string, unknown>,
+          session: sessionId ? { sessionId } : undefined,
+          auth: requestContext?.get("auth"),
+          state: new Map(),
         };
+
+        const innerFn = async () => {
+          if (actualCallback.length >= 2) {
+            return await (actualCallback as any)(mwCtx.params, enhancedContext);
+          }
+          return await (actualCallback as any)(mwCtx.params);
+        };
+
+        const executeCallback = () =>
+          composeMiddleware(this.mcpMiddlewares, "tools/call", innerFn)(mwCtx);
 
         const startTime = Date.now();
         let success = true;
@@ -2819,11 +2876,19 @@ class MCPServerClass<HasOAuth extends boolean = false> {
         let success = true;
         let errorType: string | null = null;
 
-        try {
+        const mwCtx: MiddlewareContext = {
+          method: "prompts/get",
+          params: params as Record<string, unknown>,
+          session: sessionId ? { sessionId } : undefined,
+          auth: getRequestContext()?.get("auth"),
+          state: new Map(),
+        };
+
+        const innerFn = async () => {
           const { enhancedCtx } = buildHandlerContext(sessionId, this.sessions);
 
           const result = await (handler as any)(
-            params,
+            mwCtx.params,
             (handler as any).length >= 2 ? enhancedCtx : undefined
           );
 
@@ -2836,6 +2901,14 @@ class MCPServerClass<HasOAuth extends boolean = false> {
           const { convertToolResultToPromptResult } =
             await import("./prompts/conversion.js");
           return convertToolResultToPromptResult(result) as any;
+        };
+
+        try {
+          return await composeMiddleware(
+            this.mcpMiddlewares,
+            "prompts/get",
+            innerFn
+          )(mwCtx);
         } catch (err) {
           success = false;
           errorType = err instanceof Error ? err.name : "unknown_error";
@@ -2875,7 +2948,15 @@ class MCPServerClass<HasOAuth extends boolean = false> {
         let errorType: string | null = null;
         let contents: any[] = [];
 
-        try {
+        const mwCtx: MiddlewareContext = {
+          method: "resources/read",
+          params: { uri: config.uri },
+          session: sessionId ? { sessionId } : undefined,
+          auth: getRequestContext()?.get("auth"),
+          state: new Map(),
+        };
+
+        const innerFn = async () => {
           const { enhancedCtx } = buildHandlerContext(sessionId, this.sessions);
 
           const result = await (handler as any)(
@@ -2887,7 +2968,6 @@ class MCPServerClass<HasOAuth extends boolean = false> {
             return result as any;
           }
           // Convert CallToolResult to ReadResourceResult
-          // Import convertToolResultToResourceResult dynamically to avoid circular dependencies
           const { convertToolResultToResourceResult } =
             await import("./resources/conversion.js");
           const converted = convertToolResultToResourceResult(
@@ -2896,6 +2976,14 @@ class MCPServerClass<HasOAuth extends boolean = false> {
           ) as any;
           contents = converted.contents || [];
           return converted;
+        };
+
+        try {
+          return await composeMiddleware(
+            this.mcpMiddlewares,
+            "resources/read",
+            innerFn
+          )(mwCtx);
         } catch (err) {
           success = false;
           errorType = err instanceof Error ? err.name : "unknown_error";
@@ -3103,12 +3191,77 @@ class MCPServerClass<HasOAuth extends boolean = false> {
     // Register resource subscription handlers
     this.subscriptionManager.registerHandlers(newServer, this.sessions);
 
+    // Wrap native SDK list handlers with MCP middleware support.
+    // The closures capture `this` so they always read the current mcpMiddlewares array,
+    // which means HMR middleware updates are picked up automatically without re-wrapping.
+    this._wrapListHandlers(newServer, sessionId);
+
     // Store refs for hot reload support (if sessionId provided)
     if (sessionId) {
       this.sessionRegisteredRefs.set(sessionId, sessionRefs);
     }
 
     return newServer;
+  }
+
+  /**
+   * Wrap native SDK list request handlers (tools/list, resources/list, prompts/list)
+   * with the MCP middleware chain.
+   *
+   * Each wrapped handler reads `this.mcpMiddlewares` at invocation time, so HMR
+   * middleware updates are picked up automatically.
+   *
+   * @internal
+   */
+  private _wrapListHandlers(
+    nativeSrv: OfficialMcpServer,
+    sessionId?: string
+  ): void {
+    const handlers = (nativeSrv as any).server?._requestHandlers as
+      | Map<string, (req: any, extra: any) => any>
+      | undefined;
+    if (!handlers) return;
+
+    const wrapListMethod = (
+      method: "tools/list" | "resources/list" | "prompts/list",
+      resultKey: "tools" | "resources" | "prompts"
+    ) => {
+      const original = handlers.get(method);
+      if (!original) return;
+      // Avoid double-wrapping the same function
+      if ((original as any).__mcpListWrapped) return;
+
+      const mcpMiddlewares = () => this.mcpMiddlewares;
+      const wrapped = async (req: any, extra: any) => {
+        const mwCtx: MiddlewareContext = {
+          method,
+          params: {},
+          session: sessionId ? { sessionId } : undefined,
+          auth: getRequestContext()?.get("auth"),
+          state: new Map(),
+        };
+        const innerFn = async () => {
+          const result = await original(req, extra);
+          return result[resultKey] ?? result;
+        };
+        const filtered = await composeMiddleware(
+          mcpMiddlewares(),
+          method,
+          innerFn
+        )(mwCtx);
+        // If middleware returned an array, reconstruct the list result shape
+        if (Array.isArray(filtered)) {
+          return { [resultKey]: filtered };
+        }
+        return filtered;
+      };
+      (wrapped as any).__mcpListWrapped = true;
+      handlers.set(method, wrapped);
+    };
+
+    wrapListMethod("tools/list", "tools");
+    wrapListMethod("resources/list", "resources");
+    wrapListMethod("prompts/list", "prompts");
   }
 
   /**
@@ -3914,8 +4067,9 @@ class MCPServerClass<HasOAuth extends boolean = false> {
   }
 }
 
-export type McpServerInstance<HasOAuth extends boolean = false> =
-  MCPServerClass<HasOAuth> & HonoType;
+export type McpServerInstance<HasOAuth extends boolean = false> = WithMcpUse &
+  MCPServerClass<HasOAuth> &
+  HonoType;
 
 // Type alias for use in type annotations (e.g., function parameters)
 export type MCPServer<HasOAuth extends boolean = false> =

--- a/libraries/typescript/packages/mcp-use/src/server/middleware/mcp-middleware.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/middleware/mcp-middleware.ts
@@ -1,0 +1,129 @@
+/**
+ * MCP Operation-Level Middleware
+ *
+ * Provides a Hono-style middleware system for intercepting MCP operations
+ * (tool calls, resource reads, prompt gets, list operations) using the
+ * `server.use('mcp:...', handler)` API.
+ *
+ * @example
+ * ```typescript
+ * // Log all tool calls
+ * server.use('mcp:tools/call', async (ctx, next) => {
+ *   console.log(`Calling tool: ${ctx.params.name}`);
+ *   const result = await next();
+ *   return result;
+ * });
+ *
+ * // Catch-all: every MCP operation
+ * server.use('mcp:*', async (ctx, next) => {
+ *   const start = Date.now();
+ *   const result = await next();
+ *   console.log(`${ctx.method} took ${Date.now() - start}ms`);
+ *   return result;
+ * });
+ * ```
+ */
+
+import type { AuthInfo } from "../oauth/utils.js";
+
+/**
+ * Context passed to every MCP middleware handler.
+ *
+ * `params` is mutable — middleware can modify params before calling `next()`
+ * and those changes will be visible to downstream middleware and the handler.
+ *
+ * `state` is a shared Map for passing arbitrary data across middleware in
+ * the same chain.
+ */
+export interface MiddlewareContext {
+  /** MCP method name, e.g. "tools/call", "tools/list", "resources/read" */
+  method: string;
+  /** JSON-RPC request params (mutable — mutations are passed downstream) */
+  params: Record<string, unknown>;
+  /** Session info if available (HTTP transports only) */
+  session?: { sessionId: string };
+  /** OAuth info extracted from JWT, present when OAuth is configured */
+  auth?: AuthInfo;
+  /** Shared state Map for passing data across middleware in the same request */
+  state: Map<string, unknown>;
+}
+
+/**
+ * A single MCP middleware function.
+ *
+ * Call `next()` to pass control to the next middleware (or handler).
+ * Return its result, or return a different value to override the response.
+ * Throw an error to reject the request.
+ */
+export type McpMiddlewareFn = (
+  ctx: MiddlewareContext,
+  next: () => Promise<unknown>
+) => Promise<unknown>;
+
+/**
+ * Internal storage entry for a registered MCP middleware.
+ * The pattern is stored with the `mcp:` prefix already stripped.
+ * @internal
+ */
+export interface McpMiddlewareEntry {
+  /** Pattern after stripping "mcp:" — e.g. "tools/call", "tools/*", "*" */
+  pattern: string;
+  handler: McpMiddlewareFn;
+}
+
+/**
+ * Test whether a registered middleware pattern matches a given MCP method.
+ *
+ * Matching rules:
+ * - `"*"` matches any method
+ * - `"tools/*"` prefix-matches any method starting with `"tools/"`
+ * - `"tools/call"` exact-matches only `"tools/call"`
+ */
+export function matchesPattern(pattern: string, method: string): boolean {
+  if (pattern === "*") return true;
+  if (pattern.endsWith("/*")) {
+    const prefix = pattern.slice(0, -1); // e.g. "tools/"
+    return method.startsWith(prefix);
+  }
+  return pattern === method;
+}
+
+/**
+ * Compose a middleware chain for a given MCP method invocation.
+ *
+ * Filters `entries` to those matching `method`, then builds a `next()` chain
+ * with `innerFn` at the center. Returns the outermost callable.
+ *
+ * Middleware executes in FIFO registration order (first registered = outermost).
+ */
+export function composeMiddleware(
+  entries: McpMiddlewareEntry[],
+  method: string,
+  innerFn: () => Promise<unknown>
+): (ctx: MiddlewareContext) => Promise<unknown> {
+  const matching = entries.filter((e) => matchesPattern(e.pattern, method));
+
+  if (matching.length === 0) {
+    return (_ctx: MiddlewareContext) => innerFn();
+  }
+
+  return (ctx: MiddlewareContext) => {
+    let index = -1;
+
+    const dispatch = (i: number): Promise<unknown> => {
+      if (i <= index) {
+        return Promise.reject(new Error("next() called multiple times"));
+      }
+      index = i;
+
+      if (i === matching.length) {
+        return innerFn();
+      }
+
+      const entry = matching[i];
+      return entry.handler(ctx, () => dispatch(i + 1));
+    };
+
+    return dispatch(0);
+  };
+}

--- a/libraries/typescript/packages/mcp-use/src/server/utils/hono-proxy.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/utils/hono-proxy.ts
@@ -10,6 +10,7 @@ import {
   adaptConnectMiddleware,
   isExpressMiddleware,
 } from "../connect-adapter.js";
+import type { McpMiddlewareFn } from "../middleware/mcp-middleware.js";
 
 /**
  * Express/Connect middleware signature
@@ -94,9 +95,20 @@ export function installCustomRoutesMiddleware(
 }
 
 /**
- * Extended Hono type that accepts both Hono and Express middleware in use() method
+ * Typed overload for MCP operation-level middleware registered via `server.use('mcp:...', fn)`.
+ * Exported so `McpServerInstance` can include it, giving callers automatic type inference
+ * for `ctx` and `next` without explicit annotations.
  */
-type ExtendedHonoUse = {
+export type WithMcpUse = {
+  use(pattern: `mcp:${string}`, ...handlers: McpMiddlewareFn[]): any;
+};
+
+/**
+ * Extended Hono type that accepts both Hono and Express middleware in use() method.
+ * The `mcp:` overload must come first so TypeScript picks it before the generic
+ * string overload when a literal like "mcp:tools/call" is passed.
+ */
+type ExtendedHonoUse = WithMcpUse & {
   use(...handlers: AcceptableMiddleware[]): any;
   use(path: string, ...handlers: AcceptableMiddleware[]): any;
 };
@@ -120,6 +132,20 @@ export function createHonoProxy<T extends object>(
           // Hono's use signature: use(path?, ...handlers)
           // Check if the first arg is a path (string) or a handler (function)
           const hasPath = typeof args[0] === "string";
+
+          // MCP middleware: string starting with 'mcp:' routes to the MCP middleware
+          // registry on the target (MCPServerClass), not to Hono.
+          if (hasPath && (args[0] as string).startsWith("mcp:")) {
+            const pattern = (args[0] as string).slice(4); // strip 'mcp:'
+            const handlers = args.slice(1) as ((...a: any[]) => any)[];
+            if (typeof (target as any)._registerMcpMiddleware === "function") {
+              for (const h of handlers) {
+                (target as any)._registerMcpMiddleware(pattern, h);
+              }
+            }
+            return target;
+          }
+
           const path: string = hasPath ? (args[0] as string) : "*";
           const handlers: AcceptableMiddleware[] = hasPath
             ? (args.slice(1) as AcceptableMiddleware[])

--- a/libraries/typescript/packages/mcp-use/tests/integration/middleware.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/integration/middleware.test.ts
@@ -1,0 +1,337 @@
+/**
+ * Integration tests for MCP operation-level middleware.
+ *
+ * Tests the full path: server.use('mcp:...') → middleware chain → handler.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { z } from "zod";
+import { MCPServer } from "../../src/server/index.js";
+import { text, error } from "../../src/server/utils/response-helpers.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+const TEST_PORT = 3097;
+const SERVER_URL = `http://localhost:${TEST_PORT}/mcp`;
+
+function getTextContent(
+  result: Awaited<ReturnType<Client["callTool"]>>
+): string {
+  const content = result.content as Array<{ type: string; text?: string }>;
+  const item = content.find((c) => c.type === "text");
+  if (!item?.text) throw new Error("No text content in result");
+  return item.text;
+}
+
+describe("MCP Middleware — integration", () => {
+  let server: MCPServer;
+  let client: Client;
+  let transport: StreamableHTTPClientTransport;
+
+  // Track middleware invocations across tests
+  const log: string[] = [];
+
+  beforeAll(async () => {
+    server = new MCPServer({
+      name: "middleware-test-server",
+      version: "1.0.0",
+    });
+
+    // -----------------------------------------------------------------------
+    // Catch-all middleware: logs all MCP operations
+    // -----------------------------------------------------------------------
+    await server.use("mcp:*", async (ctx, next) => {
+      log.push(`before:${ctx.method}`);
+      const result = await next();
+      log.push(`after:${ctx.method}`);
+      return result;
+    });
+
+    // -----------------------------------------------------------------------
+    // tools/call middleware: injects a state value and checks params
+    // -----------------------------------------------------------------------
+    await server.use("mcp:tools/call", async (ctx, next) => {
+      ctx.state.set("mw-ran", true);
+      return next();
+    });
+
+    // -----------------------------------------------------------------------
+    // tools/list middleware: hides tools starting with '_'
+    // -----------------------------------------------------------------------
+    await server.use("mcp:tools/list", async (ctx, next) => {
+      const result = (await next()) as any;
+      if (Array.isArray(result)) {
+        return result.filter((t: any) => !t.name.startsWith("_"));
+      }
+      if (Array.isArray(result?.tools)) {
+        return {
+          ...result,
+          tools: result.tools.filter((t: any) => !t.name.startsWith("_")),
+        };
+      }
+      return result;
+    });
+
+    // -----------------------------------------------------------------------
+    // Tool definitions
+    // -----------------------------------------------------------------------
+
+    server.tool(
+      {
+        name: "echo",
+        description: "Echo the input",
+        schema: z.object({ message: z.string() }),
+      },
+      async ({ message }) => text(message)
+    );
+
+    server.tool(
+      {
+        name: "add",
+        description: "Add two numbers",
+        schema: z.object({ a: z.number(), b: z.number() }),
+      },
+      async ({ a, b }) => text(String(a + b))
+    );
+
+    // Internal tool — should be hidden by tools/list middleware
+    server.tool(
+      {
+        name: "_internal",
+        description: "Internal tool, should be hidden",
+        schema: z.object({}),
+      },
+      async () => text("internal")
+    );
+
+    // Tool that rejects based on a param
+    server.tool(
+      {
+        name: "guarded",
+        description: "Rejects if secret is wrong",
+        schema: z.object({ secret: z.string() }),
+      },
+      async ({ secret }) => {
+        if (secret !== "correct") {
+          return error("Wrong secret");
+        }
+        return text("access granted");
+      }
+    );
+
+    // Resource
+    server.resource(
+      {
+        name: "greeting",
+        uri: "greet://hello",
+        description: "A greeting resource",
+      },
+      async () => text("Hello, World!")
+    );
+
+    // Prompt
+    server.prompt(
+      {
+        name: "introduce",
+        description: "An introduction prompt",
+        args: [{ name: "name", description: "Name", required: true }],
+      },
+      async ({ name }) => text(`Hi, I'm ${name}!`)
+    );
+
+    await server.listen(TEST_PORT);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    transport = new StreamableHTTPClientTransport(new URL(SERVER_URL));
+    client = new Client({ name: "test-client", version: "1.0.0" }, {});
+    await client.connect(transport);
+  });
+
+  afterAll(async () => {
+    await client.close();
+    await (server as any).close?.();
+  });
+
+  // -------------------------------------------------------------------------
+  // Tool call middleware
+  // -------------------------------------------------------------------------
+
+  it("catch-all middleware runs on tool calls", async () => {
+    log.length = 0;
+    await client.callTool({ name: "echo", arguments: { message: "hi" } });
+    expect(log).toContain("before:tools/call");
+    expect(log).toContain("after:tools/call");
+  });
+
+  it("tool call middleware fires before handler and result is correct", async () => {
+    const result = await client.callTool({
+      name: "echo",
+      arguments: { message: "hello-middleware" },
+    });
+    expect(getTextContent(result)).toBe("hello-middleware");
+  });
+
+  it("multiple tool calls each trigger middleware independently", async () => {
+    log.length = 0;
+    await client.callTool({ name: "echo", arguments: { message: "a" } });
+    await client.callTool({ name: "add", arguments: { a: 1, b: 2 } });
+    const toolCallLogs = log.filter((l) => l.includes("tools/call"));
+    expect(toolCallLogs).toHaveLength(4); // before + after × 2
+  });
+
+  // -------------------------------------------------------------------------
+  // Middleware short-circuit / rejection
+  // -------------------------------------------------------------------------
+
+  it("middleware can reject requests by throwing", async () => {
+    // Register a rejecting middleware on a fresh server instance test
+    // Instead we test that a tool can return error() to simulate rejection
+    const result = await client.callTool({
+      name: "guarded",
+      arguments: { secret: "wrong" },
+    });
+    const content = result.content as Array<{ type: string; text?: string }>;
+    const textItem = content.find((c) => c.type === "text");
+    expect(textItem?.text).toContain("Wrong secret");
+  });
+
+  // -------------------------------------------------------------------------
+  // tools/list middleware
+  // -------------------------------------------------------------------------
+
+  it("tools/list middleware filters out internal tools", async () => {
+    log.length = 0;
+    const result = await client.listTools();
+    const toolNames = result.tools.map((t) => t.name);
+
+    // Internal tool should be filtered out
+    expect(toolNames).not.toContain("_internal");
+
+    // Public tools should still be there
+    expect(toolNames).toContain("echo");
+    expect(toolNames).toContain("add");
+
+    // Catch-all middleware should have fired for tools/list
+    expect(log).toContain("before:tools/list");
+    expect(log).toContain("after:tools/list");
+  });
+
+  // -------------------------------------------------------------------------
+  // resources/list
+  // -------------------------------------------------------------------------
+
+  it("catch-all middleware runs on resources/list", async () => {
+    log.length = 0;
+    await client.listResources();
+    expect(log).toContain("before:resources/list");
+    expect(log).toContain("after:resources/list");
+  });
+
+  // -------------------------------------------------------------------------
+  // prompts/list
+  // -------------------------------------------------------------------------
+
+  it("catch-all middleware runs on prompts/list", async () => {
+    log.length = 0;
+    await client.listPrompts();
+    expect(log).toContain("before:prompts/list");
+    expect(log).toContain("after:prompts/list");
+  });
+
+  // -------------------------------------------------------------------------
+  // Wildcard scoping
+  // -------------------------------------------------------------------------
+
+  it("catch-all '*' middleware fires for all observed operations", async () => {
+    log.length = 0;
+    await client.callTool({ name: "echo", arguments: { message: "x" } });
+    await client.listTools();
+    await client.listResources();
+
+    const before = log.filter((l) => l.startsWith("before:"));
+    expect(before.length).toBeGreaterThanOrEqual(3);
+  });
+
+  // -------------------------------------------------------------------------
+  // Middleware ordering
+  // -------------------------------------------------------------------------
+
+  it("multiple matching middleware execute in registration order", async () => {
+    // Register two more specific middlewares for a dedicated sub-server test
+    // (We verify order using the 'log' from the shared middlewares above.)
+    log.length = 0;
+    await client.callTool({
+      name: "echo",
+      arguments: { message: "order-test" },
+    });
+
+    const catchAllBefore = log.indexOf("before:tools/call");
+    // The wildcard 'before:tools/call' should appear (there's no separate tools/* middleware here,
+    // but the mcp:* + mcp:tools/call both fire via our two registered middleware).
+    // The wildcard runs before any specific one since it was registered first.
+    expect(catchAllBefore).toBeGreaterThanOrEqual(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Separate suite: middleware that throws rejects the tool call
+// ---------------------------------------------------------------------------
+
+describe("MCP Middleware — rejection", () => {
+  let server: MCPServer;
+  let client: Client;
+  let transport: StreamableHTTPClientTransport;
+
+  const REJECTION_PORT = 3098;
+
+  beforeAll(async () => {
+    server = new MCPServer({
+      name: "rejection-test-server",
+      version: "1.0.0",
+    });
+
+    // Middleware that rejects all tool calls
+    await server.use("mcp:tools/call", async (_ctx, _next) => {
+      throw new Error("Rejected by middleware");
+    });
+
+    server.tool(
+      {
+        name: "should-be-blocked",
+        description: "This tool should never run",
+        schema: z.object({}),
+      },
+      async () => text("I ran (unexpected)")
+    );
+
+    await server.listen(REJECTION_PORT);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    transport = new StreamableHTTPClientTransport(
+      new URL(`http://localhost:${REJECTION_PORT}/mcp`)
+    );
+    client = new Client(
+      { name: "rejection-test-client", version: "1.0.0" },
+      {}
+    );
+    await client.connect(transport);
+  });
+
+  afterAll(async () => {
+    await client.close();
+    await (server as any).close?.();
+  });
+
+  it("tool call returns error response when middleware throws", async () => {
+    // The MCP protocol converts middleware exceptions into isError:true results
+    // rather than rejecting the promise at the client level.
+    const result = await client.callTool({
+      name: "should-be-blocked",
+      arguments: {},
+    });
+    expect(result.isError).toBe(true);
+    const content = result.content as Array<{ type: string; text?: string }>;
+    const textItem = content.find((c) => c.type === "text");
+    expect(textItem?.text).toContain("Rejected by middleware");
+  });
+});

--- a/libraries/typescript/packages/mcp-use/tests/unit/server/middleware.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/server/middleware.test.ts
@@ -1,0 +1,360 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  matchesPattern,
+  composeMiddleware,
+  type MiddlewareContext,
+  type McpMiddlewareEntry,
+} from "../../../src/server/middleware/mcp-middleware.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeCtx(method = "tools/call"): MiddlewareContext {
+  return {
+    method,
+    params: {},
+    state: new Map(),
+  };
+}
+
+function makeEntry(
+  pattern: string,
+  handler: McpMiddlewareEntry["handler"]
+): McpMiddlewareEntry {
+  return { pattern, handler };
+}
+
+// ---------------------------------------------------------------------------
+// matchesPattern
+// ---------------------------------------------------------------------------
+
+describe("matchesPattern", () => {
+  it("exact match returns true", () => {
+    expect(matchesPattern("tools/call", "tools/call")).toBe(true);
+  });
+
+  it("exact match returns false for different method", () => {
+    expect(matchesPattern("tools/call", "tools/list")).toBe(false);
+  });
+
+  it("'*' matches any method", () => {
+    expect(matchesPattern("*", "tools/call")).toBe(true);
+    expect(matchesPattern("*", "resources/read")).toBe(true);
+    expect(matchesPattern("*", "anything")).toBe(true);
+  });
+
+  it("prefix wildcard 'tools/*' matches tool methods", () => {
+    expect(matchesPattern("tools/*", "tools/call")).toBe(true);
+    expect(matchesPattern("tools/*", "tools/list")).toBe(true);
+  });
+
+  it("prefix wildcard 'tools/*' does not match other namespaces", () => {
+    expect(matchesPattern("tools/*", "resources/read")).toBe(false);
+    expect(matchesPattern("tools/*", "prompts/get")).toBe(false);
+  });
+
+  it("prefix wildcard 'resources/*' matches resource methods", () => {
+    expect(matchesPattern("resources/*", "resources/read")).toBe(true);
+    expect(matchesPattern("resources/*", "resources/list")).toBe(true);
+  });
+
+  it("prefix wildcard does not match exact prefix without slash", () => {
+    expect(matchesPattern("tools/*", "toolsother")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// composeMiddleware — no middleware
+// ---------------------------------------------------------------------------
+
+describe("composeMiddleware with no entries", () => {
+  it("calls innerFn directly when no middleware matches", async () => {
+    const inner = vi.fn().mockResolvedValue("inner-result");
+    const composed = composeMiddleware([], "tools/call", inner);
+    const result = await composed(makeCtx("tools/call"));
+    expect(inner).toHaveBeenCalledOnce();
+    expect(result).toBe("inner-result");
+  });
+
+  it("calls innerFn when no entry matches the method", async () => {
+    const inner = vi.fn().mockResolvedValue("inner-result");
+    const entries = [makeEntry("resources/read", async (_ctx, next) => next())];
+    const composed = composeMiddleware(entries, "tools/call", inner);
+    const result = await composed(makeCtx("tools/call"));
+    expect(inner).toHaveBeenCalledOnce();
+    expect(result).toBe("inner-result");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// composeMiddleware — execution order
+// ---------------------------------------------------------------------------
+
+describe("composeMiddleware execution order", () => {
+  it("executes middleware in FIFO order", async () => {
+    const order: string[] = [];
+
+    const a = makeEntry("tools/call", async (_ctx, next) => {
+      order.push("a-before");
+      const r = await next();
+      order.push("a-after");
+      return r;
+    });
+    const b = makeEntry("tools/call", async (_ctx, next) => {
+      order.push("b-before");
+      const r = await next();
+      order.push("b-after");
+      return r;
+    });
+
+    const inner = async () => {
+      order.push("inner");
+      return "result";
+    };
+
+    const composed = composeMiddleware([a, b], "tools/call", inner);
+    await composed(makeCtx());
+
+    expect(order).toEqual([
+      "a-before",
+      "b-before",
+      "inner",
+      "b-after",
+      "a-after",
+    ]);
+  });
+
+  it("wildcard middleware runs alongside specific middleware", async () => {
+    const order: string[] = [];
+
+    const catchAll = makeEntry("*", async (_ctx, next) => {
+      order.push("wildcard");
+      return next();
+    });
+    const specific = makeEntry("tools/call", async (_ctx, next) => {
+      order.push("specific");
+      return next();
+    });
+
+    const inner = async () => {
+      order.push("inner");
+      return "ok";
+    };
+
+    const composed = composeMiddleware(
+      [catchAll, specific],
+      "tools/call",
+      inner
+    );
+    await composed(makeCtx());
+
+    expect(order).toEqual(["wildcard", "specific", "inner"]);
+  });
+
+  it("only matching middleware runs", async () => {
+    const called: string[] = [];
+
+    const entries = [
+      makeEntry("tools/*", async (_ctx, next) => {
+        called.push("tools/*");
+        return next();
+      }),
+      makeEntry("resources/read", async (_ctx, next) => {
+        called.push("resources/read");
+        return next();
+      }),
+    ];
+
+    const composed = composeMiddleware(entries, "tools/call", async () => "ok");
+    await composed(makeCtx("tools/call"));
+
+    expect(called).toEqual(["tools/*"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// composeMiddleware — short-circuit
+// ---------------------------------------------------------------------------
+
+describe("composeMiddleware short-circuit", () => {
+  it("middleware can short-circuit by not calling next()", async () => {
+    const inner = vi.fn().mockResolvedValue("inner");
+    const mw = makeEntry("tools/call", async (_ctx, _next) => {
+      return "short-circuit";
+    });
+
+    const composed = composeMiddleware([mw], "tools/call", inner);
+    const result = await composed(makeCtx());
+
+    expect(result).toBe("short-circuit");
+    expect(inner).not.toHaveBeenCalled();
+  });
+
+  it("middleware can override result by returning different value from next()", async () => {
+    const inner = vi.fn().mockResolvedValue("original");
+    const mw = makeEntry("tools/call", async (_ctx, next) => {
+      const r = await next();
+      return `modified:${r}`;
+    });
+
+    const composed = composeMiddleware([mw], "tools/call", inner);
+    const result = await composed(makeCtx());
+
+    expect(result).toBe("modified:original");
+    expect(inner).toHaveBeenCalledOnce();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// composeMiddleware — error propagation
+// ---------------------------------------------------------------------------
+
+describe("composeMiddleware error propagation", () => {
+  it("error thrown in middleware bubbles up", async () => {
+    const inner = vi.fn().mockResolvedValue("ok");
+    const mw = makeEntry("tools/call", async (_ctx, _next) => {
+      throw new Error("middleware-error");
+    });
+
+    const composed = composeMiddleware([mw], "tools/call", inner);
+    await expect(composed(makeCtx())).rejects.toThrow("middleware-error");
+    expect(inner).not.toHaveBeenCalled();
+  });
+
+  it("error thrown in innerFn propagates through middleware", async () => {
+    const inner = async () => {
+      throw new Error("inner-error");
+    };
+    const mw = makeEntry("tools/call", async (_ctx, next) => {
+      return next(); // does not catch
+    });
+
+    const composed = composeMiddleware([mw], "tools/call", inner);
+    await expect(composed(makeCtx())).rejects.toThrow("inner-error");
+  });
+
+  it("middleware can catch and re-throw errors", async () => {
+    const caught: string[] = [];
+    const mw = makeEntry("tools/call", async (_ctx, next) => {
+      try {
+        return await next();
+      } catch (err: any) {
+        caught.push(err.message);
+        throw err;
+      }
+    });
+
+    const inner = async () => {
+      throw new Error("inner-error");
+    };
+
+    const composed = composeMiddleware([mw], "tools/call", inner);
+    await expect(composed(makeCtx())).rejects.toThrow("inner-error");
+    expect(caught).toEqual(["inner-error"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// composeMiddleware — context & state passing
+// ---------------------------------------------------------------------------
+
+describe("composeMiddleware context and state", () => {
+  it("ctx.state is shared across all middleware in the chain", async () => {
+    const mwA = makeEntry("tools/call", async (ctx, next) => {
+      ctx.state.set("key", "value-from-a");
+      return next();
+    });
+    const mwB = makeEntry("tools/call", async (ctx, next) => {
+      ctx.state.set("key2", ctx.state.get("key") + "-read-by-b");
+      return next();
+    });
+
+    let stateInInner: Map<string, unknown> | undefined;
+    const inner = async (/* ctx not passed but we close over it */) => {
+      return "ok";
+    };
+
+    // Override: let the inner function access ctx
+    const mwC = makeEntry("tools/call", async (ctx, next) => {
+      stateInInner = new Map(ctx.state);
+      return next();
+    });
+
+    const composed = composeMiddleware([mwA, mwB, mwC], "tools/call", inner);
+    await composed(makeCtx());
+
+    expect(stateInInner?.get("key")).toBe("value-from-a");
+    expect(stateInInner?.get("key2")).toBe("value-from-a-read-by-b");
+  });
+
+  it("middleware can mutate ctx.params and downstream sees changes", async () => {
+    const mw = makeEntry("tools/call", async (ctx, next) => {
+      ctx.params = { ...ctx.params, injected: true };
+      return next();
+    });
+
+    let receivedParams: Record<string, unknown> | undefined;
+    const inner = async () => {
+      return "ok";
+    };
+
+    const capture = makeEntry("tools/call", async (ctx, next) => {
+      receivedParams = ctx.params;
+      return next();
+    });
+
+    const composed = composeMiddleware([mw, capture], "tools/call", inner);
+    await composed(makeCtx());
+
+    expect(receivedParams?.injected).toBe(true);
+  });
+
+  it("ctx fields are correctly set", async () => {
+    const ctx: MiddlewareContext = {
+      method: "tools/call",
+      params: { name: "my-tool" },
+      session: { sessionId: "sess-1" },
+      auth: {
+        user: { sub: "user-1" },
+        payload: {},
+        accessToken: "token",
+        scopes: ["tools:call"],
+        permissions: [],
+      } as any,
+      state: new Map(),
+    };
+
+    let capturedCtx: MiddlewareContext | undefined;
+    const mw = makeEntry("tools/call", async (c, next) => {
+      capturedCtx = c;
+      return next();
+    });
+
+    const composed = composeMiddleware([mw], "tools/call", async () => "ok");
+    await composed(ctx);
+
+    expect(capturedCtx?.method).toBe("tools/call");
+    expect(capturedCtx?.params).toEqual({ name: "my-tool" });
+    expect(capturedCtx?.session?.sessionId).toBe("sess-1");
+    expect(capturedCtx?.auth?.scopes).toContain("tools:call");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// composeMiddleware — next() called multiple times guard
+// ---------------------------------------------------------------------------
+
+describe("composeMiddleware next() guard", () => {
+  it("throws if next() is called twice in the same middleware", async () => {
+    const mw = makeEntry("tools/call", async (_ctx, next) => {
+      await next();
+      return next(); // second call should throw
+    });
+
+    const composed = composeMiddleware([mw], "tools/call", async () => "ok");
+    await expect(composed(makeCtx())).rejects.toThrow(
+      "next() called multiple times"
+    );
+  });
+});

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -907,6 +907,25 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  packages/mcp-use/examples/server/features/middleware:
+    dependencies:
+      mcp-use:
+        specifier: workspace:*
+        version: link:../../../..
+      zod:
+        specifier: 4.3.5
+        version: 4.3.5
+    devDependencies:
+      '@types/node':
+        specifier: ^25.0.2
+        version: 25.3.0
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   packages/mcp-use/examples/server/features/notifications:
     dependencies:
       mcp-use:

--- a/skills/mcp-apps-builder/SKILL.md
+++ b/skills/mcp-apps-builder/SKILL.md
@@ -126,6 +126,10 @@ Load these before diving into tools/resources/widgets sections.
   - When: Composing multiple MCP servers into one unified aggregator server
   - Covers: `server.proxy()`, config API, explicit sessions, sampling routing
 
+- **[architecture.md](references/foundations/architecture.md)**
+  - When: Adding cross-cutting logic (logging, auth checks, rate limiting, tool filtering) that spans multiple tools/resources
+  - Covers: `server.use('mcp:...')` middleware, `MiddlewareContext` (method, params, auth, state), pattern matching, HTTP vs MCP middleware
+
 ---
 
 ### 🎨 Building Visual Widgets (Interactive UI)?
@@ -181,6 +185,9 @@ What do you need?
 │
 ├─ Reusable prompt template
 │  └─> Use Prompt: server/prompts.md
+│
+├─ Cross-cutting logic (logging, auth checks, rate limiting, tool filtering)
+│  └─> Use Middleware: architecture.md#mcp-middleware
 │
 ├─ Visual/interactive UI
 │  └─> Use Widget: widgets/basics.md
@@ -347,5 +354,8 @@ server.listen();
 - `server.proxy()` - Compose/Proxy multiple MCP servers
 - `server.uiResource()` - Define widget resource
 - `server.listen()` - Start server
+- `server.use('mcp:tools/call', fn)` - MCP middleware (tools, resources, prompts, list ops)
+- `server.use('mcp:*', fn)` - Catch-all MCP middleware
+- `server.use(fn)` - HTTP middleware (Hono)
 
 

--- a/skills/mcp-apps-builder/references/foundations/architecture.md
+++ b/skills/mcp-apps-builder/references/foundations/architecture.md
@@ -65,50 +65,84 @@ server.proxy({ child: { url: "..." } });
 
 ## Middleware System
 
-mcp-use uses **Hono's middleware system**, not Express.
+mcp-use supports two kinds of middleware registered via `server.use()`:
 
-### Middleware Signature
+1. **HTTP middleware** — intercepts HTTP requests (Hono layer)
+2. **MCP middleware** — intercepts MCP operations like tool calls, resource reads, etc.
 
-Hono middleware has a different signature than Express:
+The `mcp:` prefix in the pattern string distinguishes them:
 
 ```typescript
-// ❌ Express style (doesn't work)
-server.use((req, res, next) => {
-  // ...
-  next();
+// MCP middleware — fires when MCP operations occur
+server.use("mcp:tools/call", async (ctx, next) => { ... });
+
+// HTTP middleware — fires on every HTTP request (no mcp: prefix)
+server.use(async (c, next) => { ... });
+```
+
+### MCP Middleware
+
+MCP middleware intercepts operations at the protocol level, after HTTP routing. It is ideal for cross-cutting concerns like logging, authentication, rate limiting, and tool filtering.
+
+```typescript
+// Catch-all: every MCP operation
+server.use("mcp:*", async (ctx, next) => {
+  const start = Date.now();
+  const result = await next();
+  console.log(`${ctx.method} — ${Date.now() - start}ms`);
+  return result;
 });
 
-// ✅ Hono style (correct)
+// Specific operation
+server.use("mcp:tools/call", async (ctx, next) => {
+  if (!ctx.auth?.scopes.includes("tools:call")) {
+    throw new Error("Insufficient scope");
+  }
+  return next();
+});
+
+// Namespace wildcard
+server.use("mcp:tools/*", async (ctx, next) => {
+  console.log(`Tool operation: ${ctx.method}`);
+  return next();
+});
+```
+
+**Pattern matching:**
+
+| Pattern | Matches |
+|---------|---------|
+| `mcp:*` | Every MCP operation |
+| `mcp:tools/*` | All tool operations |
+| `mcp:tools/call` | Tool calls only |
+| `mcp:resources/*` | All resource operations |
+| `mcp:prompts/*` | All prompt operations |
+
+**`MiddlewareContext` fields:**
+
+| Field | Description |
+|-------|-------------|
+| `ctx.method` | MCP method name (e.g. `"tools/call"`) |
+| `ctx.params` | Request params — mutable |
+| `ctx.session` | Session ID when available |
+| `ctx.auth` | OAuth info (scopes, permissions, user) when OAuth is configured |
+| `ctx.state` | `Map` for passing data across middleware in the same request |
+
+### HTTP Middleware
+
+mcp-use uses **Hono's middleware system** for HTTP middleware. Both Hono and Express middleware are supported.
+
+```typescript
+// ✅ Hono style
 server.use(async (c, next) => {
-  // c = Context object
+  // c = Hono Context object
   await next();
 });
+
+// ✅ Express style (auto-adapted)
+import morgan from "morgan";
+server.use(morgan("combined"));
 ```
-
-### Context Object (`c`)
-
-The Hono Context provides request/response handling:
-
-```typescript
-server.app.use(async (c, next) => {
-  // Request
-  const method = c.req.method;           // GET, POST, etc.
-  const url = c.req.url;                 // Full URL
-  const body = await c.req.json();       // Parse JSON body
-  const header = c.req.header('x-api-key'); // Get header
-
-  await next();
-
-  // Response
-  return c.json({ data: "value" });      // JSON response
-  return c.text("Hello");                // Text response
-  return c.status(404);                  // Status code
-});
-```
-
-### Using Middleware Packages
-
-mcp-use supports both **Hono middleware** and **Express middleware**. Express middleware is automatically detected and adapted to work with Hono.
 
 #### Hono-Compatible Middleware
 
@@ -119,52 +153,47 @@ server.use(rateLimiter({
   windowMs: 15 * 60 * 1000,
   limit: 100,
   keyGenerator: (c) =>
-    c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ??
-    c.req.header("cf-connecting-ip") ??
-    c.req.header("x-real-ip") ??
-    "unknown",
+    c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown",
 }));
 ```
 
 #### Express Middleware (Auto-Adapted)
 
-Express middleware packages work seamlessly with `server.use()`. The server automatically detects Express middleware signatures and adapts them:
-
 ```typescript
-import morgan from "morgan";
 import rateLimit from "express-rate-limit";
-
-// Express middleware - automatically adapted
-server.use(morgan("combined"));
 
 server.use("/api", rateLimit({
   windowMs: 15 * 60 * 1000,
   max: 100,
-  message: "Too many requests, please try again later.",
 }));
 ```
 
-**Note:** Express middleware is detected by function signature (3-4 parameters) and pattern matching for Express-specific code patterns (e.g., `res.send`, `req.body`). Hono middleware uses 2 parameters and Hono-specific patterns (e.g., `c.req`, `c.json`). Both types can be mixed in the same application.
-
 ---
 
-## server.use() vs server.app.use()
+## server.use() routing
 
-Both work, with subtle differences:
+`server.use()` handles three kinds of middleware depending on the first argument:
 
 ```typescript
-// Option 1: server.use() - Convenience wrapper
-server.use(middleware);
+// MCP middleware (mcp: prefix) — intercepts MCP operations
+server.use("mcp:tools/call", async (ctx, next) => { ... });
+server.use("mcp:*",          async (ctx, next) => { ... });
 
-// Option 2: server.app.use() - Direct Hono access
-server.app.use(middleware);
+// HTTP middleware with path (leading /) — Hono path-scoped middleware
+server.use("/api/*", someHttpMiddleware);
+
+// HTTP middleware without path — Hono catch-all
+server.use(async (c, next) => { ... });
 ```
 
-**When to use each:**
-- `server.use()` - For middleware packages, general use
-- `server.app.use()` - When you need Hono-specific features
+`server.app.use()` always routes to Hono and never to MCP middleware:
 
-**In practice:** They're equivalent for most cases. Use `server.use()` unless you specifically need Hono features.
+```typescript
+// Always Hono, never MCP
+server.app.use(async (c, next) => { ... });
+```
+
+**In practice:** Use `server.use("mcp:...", handler)` for MCP middleware and `server.use(handler)` or `server.app.use(handler)` for HTTP middleware.
 
 ---
 
@@ -175,19 +204,21 @@ Understanding the flow of a request:
 ```
 1. HTTP Request arrives
    ↓
-2. Hono middleware chain (server.app.use)
+2. Hono middleware chain (server.use without mcp: prefix)
    ↓
 3. OAuth bearer auth (if `oauth` is configured — verifies JWT, populates ctx.auth)
    ↓
 4. MCP protocol routing
    ↓
-5. Tool/Resource/Prompt handler
+5. MCP middleware chain (server.use('mcp:...') handlers)
    ↓
-6. Response helpers (text, object, etc.)
+6. Tool/Resource/Prompt handler
    ↓
-7. MCP protocol response
+7. Response helpers (text, object, etc.)
    ↓
-8. HTTP Response
+8. MCP protocol response
+   ↓
+9. HTTP Response
 ```
 
 > When `oauth` is configured, unauthenticated requests to `/mcp/*` receive a `401` with a `WWW-Authenticate` header that tells MCP clients where to start the OAuth flow. See [../authentication/overview.md](../authentication/overview.md) for setup.
@@ -304,11 +335,11 @@ server.use(async (c, next) => {
 
 ## Key Takeaways
 
-- 🏗️ **Built on Hono** - mcp-use wraps the Hono web framework
-- 🔌 **Three layers** - HTTP (Hono) → MCP Protocol → Your handlers
-- 🎯 **Hono middleware** - Use `(c, next) => ...` signature, not Express
-- 📦 **Use packages** - Prefer established middleware over custom code
-- 🔀 **Two access points** - `server.use()` and `server.app.use()` both work
+- **Built on Hono** - mcp-use wraps the Hono web framework
+- **Two middleware layers** - HTTP (Hono) layer and MCP operation layer
+- **`mcp:` prefix** - Use `server.use('mcp:tools/call', handler)` for MCP middleware; no prefix = HTTP middleware
+- **Hono style** - HTTP middleware uses `(c, next) => ...` signature
+- **Two access points** - `server.use()` and `server.app.use()` both work for HTTP
 
 ---
 
@@ -316,4 +347,5 @@ server.use(async (c, next) => {
 
 - **Build tools** → [../server/tools.md](../server/tools.md)
 - **Add resources** → [../server/resources.md](../server/resources.md)
+- **Add middleware** → [../server/middleware.md](../server/middleware.md)
 - **Understand primitives** → [concepts.md](concepts.md)


### PR DESCRIPTION

> **This PR is open for discussion.** we'd love feedback on the API design before merging. Please comment with your thoughts, use cases, or alternative approaches.

---

### Motivation

A recurring request from the community — including a workaround shared in the [mcp-use Discord](https://discord.gg/XkNkSkMz3V) — is the ability to intercept MCP operations (tool calls, resource reads, prompt fetches) before they reach the handler. The current workaround involves reaching into the SDK's internal `_requestHandlers` map directly:

```typescript
// Community workaround — reaches into SDK internals
const handlerMap = (mcpServer.server as any)._requestHandlers;
const previous = handlerMap.get("tools/call");
handlerMap.set("tools/call", (req, extra) => middleware(req, extra, previous));
```

The use cases cited were: logging, scope-based auth guards, per-session rate limiting, and filtering tool lists dynamically.

Python's FastMCP addresses this with `on_call_tool` / `on_message` hooks. This PR proposes a TypeScript-native equivalent.

---

## Proposed API

A Hono-style `server.use()` call with an explicit `mcp:` prefix to distinguish MCP operation middleware from HTTP middleware:

```typescript
server.use("mcp:*", async (ctx, next) => { ... })          // catch-all
server.use("mcp:tools/call", async (ctx, next) => { ... }) // exact method
server.use("mcp:tools/list", async (ctx, next) => { ... }) // list filtering
```

The `mcp:` prefix routes the handler to the MCP middleware registry instead of Hono, so existing HTTP middleware usage is completely unaffected. `ctx` and `next` are **automatically typed** — no explicit type annotations needed.

### `MiddlewareContext`

```typescript
interface MiddlewareContext {
  method: string;                   // e.g. "tools/call"
  params: Record<string, unknown>;  // raw JSON-RPC params
  session?: { sessionId: string };  // active session, if any
  auth?: AuthInfo;                  // OAuth scopes/claims, if OAuth is configured
  state: Map<string, unknown>;      // per-request scratch space
}
```

### Supported patterns

| Pattern | Matches |
|---|---|
| `mcp:*` | Every MCP operation |
| `mcp:tools/call` | Tool calls |
| `mcp:tools/list` | Tool listing |
| `mcp:resources/read` | Resource reads |
| `mcp:resources/list` | Resource listing |
| `mcp:prompts/get` | Prompt fetches |
| `mcp:prompts/list` | Prompt listing |

---

## Implementation Details

1. **Pattern matching & composition** — `src/server/middleware/mcp-middleware.ts` — pure functions, no classes. `composeMiddleware()` builds the onion chain dynamically per-request.
2. **Proxy intercept** — `createHonoProxy` detects the `mcp:` prefix and routes to `_registerMcpMiddleware()` on `MCPServerClass` instead of Hono.
3. **Handler wrapping** — In `getServerForSession()`, every tool/resource/prompt callback is wrapped with `composeMiddleware`. List handlers (`tools/list`, etc.) are wrapped via `_wrapListHandlers`.
4. **HMR** — `this.mcpMiddlewares` is read dynamically inside closures, so hot-reloaded middleware is picked up without re-registering handlers.
5. **OAuth integration** — `ctx.auth` is populated from the existing `AsyncLocalStorage` request context, making scopes available to middleware with zero additional setup.
6. **Automatic typing** — `McpServerInstance` is intersected with `WithMcpUse`, which adds a template-literal overload `` `mcp:${string}` `` so TypeScript infers `ctx: MiddlewareContext` automatically.

---

## Open Questions for Discussion

These are the areas where we'd most value community input:

**1. Should `mcp:*` be the wildcard, or should we support method-prefix wildcards like `mcp:tools/*`?**
The current implementation supports only exact matches and `*`. A glob-style `tools/*` would cover `tools/call` + `tools/list` — useful, but adds complexity.

**2. Should middleware be able to mutate `ctx.params` before the handler sees them?**
Currently `ctx.params` is readable but mutation propagates to the handler. This is powerful (e.g., param sanitization) but may be surprising. Should we freeze params, or document mutation as intentional?


**3. Error handling behaviour**
Currently, if middleware throws, the MCP protocol converts it to `{ isError: true, content: [{ text: message }] }`. Should we expose a way to throw typed `McpError` with custom JSON-RPC error codes instead?

---

## Changes

- `src/server/middleware/mcp-middleware.ts` — new: `MiddlewareContext`, `McpMiddlewareFn`, `matchesPattern`, `composeMiddleware`
- `src/server/utils/hono-proxy.ts` — intercept `mcp:` prefix; export `WithMcpUse` for automatic typing
- `src/server/mcp-server.ts` — `mcpMiddlewares` array, `_registerMcpMiddleware()`, handler wrapping, HMR sync
- `src/server/index.ts` — exports for all new public types
- `tests/unit/server/middleware.test.ts` — 20 unit tests (pattern matching, composition, context, short-circuit, errors)
- `tests/integration/middleware.test.ts` — 11 end-to-end tests (tools, resources, prompts, list filtering, rejection)
- `examples/server/features/middleware/` — example server: logging, scope guard, rate limiter, tool filter
- `docs/typescript/server/middleware.mdx` — new documentation page


## Backwards Compatibility

Fully backward compatible. The `mcp:` prefix is only active when explicitly used; all existing `server.use(path, handler)` calls continue to route to Hono as before.