### PR TITLE
feat(deploy): add --root-dir option for monorepo support

### DIFF
--- a/libraries/typescript/.changeset/humble-facts-swim.md
+++ b/libraries/typescript/.changeset/humble-facts-swim.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/cli": minor
+---
+
+feat(deploy): add --root-dir option for monorepo support

--- a/libraries/typescript/packages/cli/src/commands/deploy.ts
+++ b/libraries/typescript/packages/cli/src/commands/deploy.ts
@@ -179,6 +179,7 @@ interface DeployOptions {
   new?: boolean;
   env?: string[];
   envFile?: string;
+  rootDir?: string;
 }
 
 /**
@@ -826,8 +827,25 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
 
     console.log(chalk.cyan.bold("🚀 Deploying to Manufact cloud...\n"));
 
+    // Resolve project directory (subfolder support for monorepos)
+    const projectDir = options.rootDir
+      ? path.resolve(cwd, options.rootDir)
+      : cwd;
+
+    if (options.rootDir) {
+      try {
+        await fs.access(projectDir);
+      } catch {
+        console.log(
+          chalk.red(`✗ Root directory not found: ${options.rootDir}`)
+        );
+        process.exit(1);
+      }
+      console.log(chalk.gray(`  Root dir:   `) + chalk.cyan(options.rootDir));
+    }
+
     // Check if this is an MCP project
-    const isMcp = await isMcpProject(cwd);
+    const isMcp = await isMcpProject(projectDir);
     if (!isMcp) {
       console.log(
         chalk.yellow(
@@ -938,12 +956,12 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
       process.exit(0);
     }
 
-    // Detect project settings
-    const projectName = options.name || (await getProjectName(cwd));
-    const runtime = options.runtime || (await detectRuntime(cwd));
+    // Detect project settings (use projectDir for subfolder-aware detection)
+    const projectName = options.name || (await getProjectName(projectDir));
+    const runtime = options.runtime || (await detectRuntime(projectDir));
     const port = options.port || 3000;
-    const buildCommand = await detectBuildCommand(cwd);
-    const startCommand = await detectStartCommand(cwd);
+    const buildCommand = await detectBuildCommand(projectDir);
+    const startCommand = await detectStartCommand(projectDir);
 
     // Build environment variables
     const envVars = await buildEnvVars(options);
@@ -953,6 +971,11 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
     console.log(chalk.gray(`  Name:          `) + chalk.cyan(projectName));
     console.log(chalk.gray(`  Runtime:       `) + chalk.cyan(runtime));
     console.log(chalk.gray(`  Port:          `) + chalk.cyan(port));
+    if (options.rootDir) {
+      console.log(
+        chalk.gray(`  Root dir:      `) + chalk.cyan(options.rootDir)
+      );
+    }
     if (buildCommand) {
       console.log(chalk.gray(`  Build command: `) + chalk.cyan(buildCommand));
     }
@@ -1112,6 +1135,7 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
             startCommand,
             ...(options.port !== undefined ? { port: options.port } : {}),
             env: Object.keys(envVars).length > 0 ? envVars : undefined,
+            rootDir: options.rootDir || undefined,
           };
 
           // Redeploy
@@ -1167,6 +1191,7 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
         type: "github",
         repo: `${gitInfo.owner}/${gitInfo.repo}`,
         branch: gitInfo.branch || "main",
+        rootDir: options.rootDir || undefined,
         runtime,
         port,
         buildCommand,

--- a/libraries/typescript/packages/cli/src/index.ts
+++ b/libraries/typescript/packages/cli/src/index.ts
@@ -2004,6 +2004,10 @@ program
     "Environment variables (can be used multiple times)"
   )
   .option("--env-file <path>", "Path to .env file with environment variables")
+  .option(
+    "--root-dir <path>",
+    "Root directory within repo to deploy from (for monorepos)"
+  )
   .action(async (options) => {
     await deployCommand({
       open: options.open,
@@ -2013,6 +2017,7 @@ program
       new: options.new,
       env: options.env,
       envFile: options.envFile,
+      rootDir: options.rootDir,
     });
   });
 

--- a/libraries/typescript/packages/cli/src/utils/api.ts
+++ b/libraries/typescript/packages/cli/src/utils/api.ts
@@ -19,6 +19,7 @@ export interface GitHubSource {
   type: "github";
   repo: string;
   branch?: string;
+  rootDir?: string;
   startCommand?: string;
   runtime?: "node" | "python";
   port?: number;
@@ -84,6 +85,7 @@ export interface RedeploymentConfig {
   startCommand?: string;
   port?: number;
   env?: Record<string, string>;
+  rootDir?: string;
 }
 
 export interface DeploymentListResponse {


### PR DESCRIPTION
- Introduced a new command-line option `--root-dir` to specify the root directory for deployments in monorepos.
- Updated the `deployCommand` to handle the new `rootDir` option, ensuring proper directory resolution and validation.
- Enhanced logging to display the specified root directory during deployment, improving user feedback and clarity.
