### PR TITLE
fix(docs): correct Twitter/X URL to @manufact

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -743,7 +743,7 @@
       {
         "label": "",
         "icon": "x-twitter",
-        "href": "https://x.com/mcpuse"
+        "href": "https://x.com/manufact"
       }
     ],
     "primary": {
@@ -754,7 +754,7 @@
   },
   "footer": {
     "socials": {
-      "x": "https://x.com/mcp_use",
+      "x": "https://x.com/manufact",
       "linkedin": "https://www.linkedin.com/company/mcp-use",
       "github": "https://github.com/mcp-use",
       "discord": "https://discord.gg/XkNkSkMz3V"

--- a/docs/home/mcp101.mdx
+++ b/docs/home/mcp101.mdx
@@ -400,7 +400,7 @@ Backed by significant adoption, with over 150,000 SDK downloads and trusted by o
 ### Socials
 
 - LinkedIn: [https://www.linkedin.com/company/mcp-use](https://www.linkedin.com/company/mcp-use)
-- X: [https://x.com/mcpuse](https://x.com/mcpuse)
+- X: [https://x.com/manufact](https://x.com/manufact)
 - Discord: [https://discord.gg/XkNkSkMz3V](https://discord.gg/XkNkSkMz3V)
 
 ### Founders


### PR DESCRIPTION


https://github.com/user-attachments/assets/fc4971b1-b318-43e8-8ae1-fe20b5da6730


## Changes

This PR fixes incorrect X (Twitter) links in the documentation and site configuration.

The previous links pointed to outdated or incorrect handles. These have been updated to the correct X account.

---

## Implementation Details

1
No dependencies or architectural changes were introduced.

---

## Documentation Updates

Files updated:

- `docs.json`
  - Updated the X link in the footer socials section.

- `mcp101.mdx`
  - Updated the X link in the **Socials** section.

---

## Testing

Manual verification performed:

1. Ran the documentation site locally:
