### PR TITLE
ci: skip unused language in conformance tests based on changed files

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -89,6 +89,7 @@ jobs:
   conformance-test:
     name: Run Conformance Tests
     needs: detect-changes
+    if: needs.detect-changes.outputs.python == 'true' || needs.detect-changes.outputs.typescript == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
 


### PR DESCRIPTION
## Summary
- Python-only PRs now skip TypeScript setup/build/tests in MCP conformance workflow (and vice versa)
- Saves several minutes of CI time per run when only one language is affected

## Implementation Details
1. Added `detect-changes` job using `dorny/paths-filter` (same pattern as `ci.yml`)
2. Outputs `python` and `typescript` booleans based on which paths changed
3. All setup steps, prep steps, and server/client list builders now use these outputs as conditionals
4. `workflow_dispatch` still respects the existing `python_only`/`typescript_only` manual inputs
5. Changes to `conformance.yml` itself triggers both languages (safety net)

## How it works

| Trigger | Python changes only | TypeScript changes only | Both changed |
|---------|:--:|:--:|:--:|
| Push/PR | Python tests only | TypeScript tests only | Both |
| Manual (`python_only`) | Python tests only | — | — |
| Manual (`typescript_only`) | — | TypeScript tests only | — |

## Backwards Compatibility
Non-breaking. Manual dispatch inputs work exactly as before. The only change is that push/PR triggers now auto-detect instead of always running both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)