### PR TITLE
Refactor clipboard operations across components to use a centralized `copyToClipboard` utility

### DIFF
--- a/libraries/typescript/.changeset/shy-pets-kneel.md
+++ b/libraries/typescript/.changeset/shy-pets-kneel.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Refactor clipboard operations across components to use a centralized `copyToClipboard` utility

--- a/libraries/typescript/packages/inspector/src/client/components/AddToClientDropdown.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/AddToClientDropdown.tsx
@@ -23,6 +23,7 @@ import {
   generateVSCodeInsidersDeepLink,
   getEnvVarInstructions,
 } from "@/client/utils/mcpClientUtils";
+import { copyToClipboard } from "@/client/utils/clipboard";
 import { Check, ChevronDown, Copy, Plus } from "lucide-react";
 import { useState } from "react";
 import { VSCodeIcon } from "./ui/client-icons";
@@ -161,7 +162,7 @@ export function AddToClientDropdown({
 
   const handleCopy = async (text: string) => {
     try {
-      await navigator.clipboard.writeText(text);
+      await copyToClipboard(text);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch (error) {

--- a/libraries/typescript/packages/inspector/src/client/components/CommandPalette.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/CommandPalette.tsx
@@ -28,6 +28,7 @@ import {
   generateVSCodeDeepLink,
   generateVSCodeInsidersDeepLink,
 } from "@/client/utils/mcpClientUtils";
+import { copyToClipboard } from "@/client/utils/clipboard";
 import { toast } from "sonner";
 import { McpUseLogo } from "./McpUseLogo";
 import { ServerIcon } from "./ServerIcon";
@@ -161,7 +162,7 @@ export function CommandPalette({
               serverName,
               serverHeaders
             );
-            navigator.clipboard.writeText(command);
+            copyToClipboard(command);
             toast.success("Command copied to clipboard");
             onOpenChange(false);
           },
@@ -236,7 +237,7 @@ export function CommandPalette({
               serverName,
               serverHeaders
             );
-            navigator.clipboard.writeText(command);
+            copyToClipboard(command);
             toast.success("Command copied to clipboard");
             onOpenChange(false);
           },
@@ -253,7 +254,7 @@ export function CommandPalette({
               serverName,
               serverHeaders
             );
-            navigator.clipboard.writeText(config);
+            copyToClipboard(config);
             toast.success("Config copied to clipboard");
             onOpenChange(false);
           },

--- a/libraries/typescript/packages/inspector/src/client/components/ConnectionSettingsForm.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ConnectionSettingsForm.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/client/components/ui/select";
 import { Switch } from "@/client/components/ui/switch";
 import { cn } from "@/client/lib/utils";
+import { copyToClipboard } from "@/client/utils/clipboard";
 import { Cog, Copy, FileText, Shield } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -173,7 +174,7 @@ export function ConnectionSettingsForm({
     };
 
     try {
-      await navigator.clipboard.writeText(JSON.stringify(config, null, 2));
+      await copyToClipboard(JSON.stringify(config, null, 2));
       toast.success("Configuration copied to clipboard");
     } catch {
       toast.error("Failed to copy configuration to clipboard");

--- a/libraries/typescript/packages/inspector/src/client/components/ElicitationTab.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ElicitationTab.tsx
@@ -13,6 +13,7 @@ import {
   ElicitationRequestDisplay,
 } from "./elicitation";
 import { useInspector } from "@/client/context/InspectorContext";
+import { copyToClipboard } from "@/client/utils/clipboard";
 import { formatRelativeTime } from "@/client/utils/time";
 
 interface ElicitationTabProps {
@@ -277,7 +278,7 @@ export function ElicitationTab({
   const handleCopy = useCallback(async () => {
     if (!selectedRequest) return;
     try {
-      await navigator.clipboard.writeText(
+      await copyToClipboard(
         JSON.stringify(
           {
             id: selectedRequest.id,

--- a/libraries/typescript/packages/inspector/src/client/components/IframeConsole.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/IframeConsole.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@/client/lib/utils";
+import { copyToClipboard } from "@/client/utils/clipboard";
 import {
   ChevronDown,
   ChevronRight,
@@ -98,7 +99,7 @@ function LogEntry({ log }: { log: ConsoleLogEntry }) {
     e.stopPropagation();
     try {
       const text = log.args.map(formatArg).join("\n");
-      await navigator.clipboard.writeText(text);
+      await copyToClipboard(text);
       toast.success("Copied to clipboard");
     } catch {
       toast.error("Failed to copy");
@@ -362,7 +363,7 @@ export function IframeConsole({
         })
         .join("\n\n");
 
-      await navigator.clipboard.writeText(formattedLogs);
+      await copyToClipboard(formattedLogs);
       toast.success(`Copied ${filteredLogs.length} logs to clipboard`);
     } catch {
       toast.error("Failed to copy logs to clipboard");

--- a/libraries/typescript/packages/inspector/src/client/components/InspectorDashboard.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/InspectorDashboard.tsx
@@ -25,6 +25,7 @@ import {
 } from "lucide-react";
 import { useMcpClient, type McpServerOptions } from "mcp-use/react";
 import React, { useCallback, useEffect, useRef, useState } from "react";
+import { copyToClipboard } from "@/client/utils/clipboard";
 import { useLocation, useNavigate } from "react-router";
 import { toast } from "sonner";
 import { ConnectionSettingsForm } from "./ConnectionSettingsForm";
@@ -330,7 +331,7 @@ export function InspectorDashboard() {
 
   const handleCopyError = async (errorMessage: string) => {
     try {
-      await navigator.clipboard.writeText(errorMessage);
+      await copyToClipboard(errorMessage);
       toast.success("Error message copied to clipboard");
     } catch {
       toast.error("Failed to copy error message");
@@ -391,7 +392,7 @@ export function InspectorDashboard() {
         oauth: connection.oauth,
       };
 
-      await navigator.clipboard.writeText(JSON.stringify(config, null, 2));
+      await copyToClipboard(JSON.stringify(config, null, 2));
       toast.success("Connection configuration copied to clipboard");
     } catch {
       toast.error("Failed to copy connection configuration");
@@ -667,10 +668,14 @@ export function InspectorDashboard() {
                           <TooltipTrigger asChild>
                             <button
                               type="button"
-                              onClick={(e) => {
+                              onClick={async (e) => {
                                 e.stopPropagation();
-                                navigator.clipboard.writeText(connection.url);
-                                toast.success("URL copied to clipboard");
+                                try {
+                                  await copyToClipboard(connection.url);
+                                  toast.success("URL copied to clipboard");
+                                } catch {
+                                  toast.error("Failed to copy URL");
+                                }
                               }}
                               className="opacity-0 group-hover:opacity-100 transition-opacity p-1 hover:bg-white/10 rounded"
                               title="Copy URL"

--- a/libraries/typescript/packages/inspector/src/client/components/LayoutHeader.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/LayoutHeader.tsx
@@ -34,6 +34,7 @@ import {
 import type { McpServer } from "mcp-use/react";
 import { useState } from "react";
 import { toast } from "sonner";
+import { copyToClipboard } from "@/client/utils/clipboard";
 import { AddToClientDropdown } from "./AddToClientDropdown";
 import LogoAnimated from "./LogoAnimated";
 import { SdkIntegrationModal } from "./SdkIntegrationModal";
@@ -175,7 +176,7 @@ export function LayoutHeader({
     if (!tunnelUrl) return;
 
     try {
-      await navigator.clipboard.writeText(`${tunnelUrl}/mcp`);
+      await copyToClipboard(`${tunnelUrl}/mcp`);
       setCopied(true);
       toast.success("Tunnel URL copied to clipboard");
       setTimeout(() => setCopied(false), 2000);

--- a/libraries/typescript/packages/inspector/src/client/components/MCPAppsDebugControls.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/MCPAppsDebugControls.tsx
@@ -28,6 +28,7 @@ import {
 } from "../context/WidgetDebugContext";
 import { useResourceProps, type PropPreset } from "../hooks/useResourceProps";
 import type { LLMConfig } from "./chat/types";
+import { copyToClipboard } from "@/client/utils/clipboard";
 import { IframeConsole } from "./IframeConsole";
 import { PropsConfigDialog } from "./resources/PropsConfigDialog";
 import { JSONDisplay } from "./shared/JSONDisplay";
@@ -783,10 +784,14 @@ export function MCPAppsDebugControls({
                       variant="ghost"
                       size="sm"
                       className="h-7 w-7 p-0 shrink-0"
-                      onClick={(e) => {
+                      onClick={async (e) => {
                         e.stopPropagation();
-                        navigator.clipboard.writeText(effectivePolicy);
-                        toast.success("Policy copied to clipboard");
+                        try {
+                          await copyToClipboard(effectivePolicy);
+                          toast.success("Policy copied to clipboard");
+                        } catch {
+                          toast.error("Failed to copy");
+                        }
                       }}
                       aria-label="Copy policy"
                     >
@@ -834,10 +839,14 @@ export function MCPAppsDebugControls({
                       variant="ghost"
                       size="sm"
                       className="h-7 w-7 p-0 shrink-0 text-amber-600 dark:text-amber-400 hover:bg-amber-200/50 dark:hover:bg-amber-800/30"
-                      onClick={(e) => {
+                      onClick={async (e) => {
                         e.stopPropagation();
-                        navigator.clipboard.writeText(agentPrompt);
-                        toast.success("Prompt copied to clipboard");
+                        try {
+                          await copyToClipboard(agentPrompt);
+                          toast.success("Prompt copied to clipboard");
+                        } catch {
+                          toast.error("Failed to copy");
+                        }
                       }}
                       aria-label="Copy prompt for agents"
                     >

--- a/libraries/typescript/packages/inspector/src/client/components/NotificationsTab.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/NotificationsTab.tsx
@@ -15,6 +15,7 @@ import {
   NotificationResultDisplay,
   type NotificationResult,
 } from "./notifications";
+import { copyToClipboard } from "@/client/utils/clipboard";
 import { formatRelativeTime } from "@/client/utils/time";
 
 interface NotificationsTabProps {
@@ -196,7 +197,7 @@ export function NotificationsTab({
   const handleCopy = useCallback(async () => {
     if (!selectedNotification) return;
     try {
-      await navigator.clipboard.writeText(
+      await copyToClipboard(
         JSON.stringify(
           {
             method: selectedNotification.method,

--- a/libraries/typescript/packages/inspector/src/client/components/PromptsTab.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/PromptsTab.tsx
@@ -25,6 +25,7 @@ import {
   SavedPromptsList,
 } from "./prompts";
 import { useMCPPrompts } from "../hooks/useMCPPrompts";
+import { copyToClipboard } from "@/client/utils/clipboard";
 import { RpcPanel } from "./shared";
 
 export interface PromptsTabRef {
@@ -329,7 +330,7 @@ export function PromptsTab({
 
   const handleCopyResult = useCallback(async (index: number, result: any) => {
     try {
-      await navigator.clipboard.writeText(JSON.stringify(result, null, 2));
+      await copyToClipboard(JSON.stringify(result, null, 2));
       setCopiedResult(index);
       setTimeout(() => setCopiedResult(null), 2000);
     } catch (error) {

--- a/libraries/typescript/packages/inspector/src/client/components/ResourcesTab.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ResourcesTab.tsx
@@ -25,6 +25,7 @@ import {
 } from "./resources";
 import { RpcPanel } from "./shared";
 import { useConfig } from "./chat/useConfig";
+import { copyToClipboard } from "@/client/utils/clipboard";
 
 export interface ResourcesTabRef {
   focusSearch: () => void;
@@ -331,9 +332,7 @@ export function ResourcesTab({
   const handleCopy = useCallback(async () => {
     if (!currentResult) return;
     try {
-      await navigator.clipboard.writeText(
-        JSON.stringify(currentResult.result, null, 2)
-      );
+      await copyToClipboard(JSON.stringify(currentResult.result, null, 2));
       setIsCopied(true);
       setTimeout(() => setIsCopied(false), 2000);
     } catch (error) {

--- a/libraries/typescript/packages/inspector/src/client/components/SamplingTab.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/SamplingTab.tsx
@@ -13,6 +13,7 @@ import {
   SamplingRequestDisplay,
 } from "./sampling";
 import { useInspector } from "@/client/context/InspectorContext";
+import { copyToClipboard } from "@/client/utils/clipboard";
 import { formatRelativeTime } from "@/client/utils/time";
 import { useConfig } from "./chat/useConfig";
 
@@ -268,7 +269,7 @@ export function SamplingTab({
   const handleCopy = useCallback(async () => {
     if (!selectedRequest) return;
     try {
-      await navigator.clipboard.writeText(
+      await copyToClipboard(
         JSON.stringify(
           {
             id: selectedRequest.id,

--- a/libraries/typescript/packages/inspector/src/client/components/SdkIntegrationModal.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/SdkIntegrationModal.tsx
@@ -13,6 +13,7 @@ import {
   generatePythonSDKCode,
   generateTypeScriptSDKCode,
 } from "@/client/utils/mcpClientUtils";
+import { copyToClipboard } from "@/client/utils/clipboard";
 import { Button } from "./ui/button";
 
 interface SdkIntegrationModalProps {
@@ -55,7 +56,7 @@ export function SdkIntegrationModal({
       : generatePythonSDKCode(serverUrl, serverName, serverId, headers);
 
   const handleCopy = async () => {
-    await navigator.clipboard.writeText(code);
+    await copyToClipboard(code);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };

--- a/libraries/typescript/packages/inspector/src/client/components/ServerCapabilitiesModal.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ServerCapabilitiesModal.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/client/components/ui/dialog";
 import type { McpServer } from "mcp-use/react";
 import { Copy } from "lucide-react";
+import { copyToClipboard } from "@/client/utils/clipboard";
 import { toast } from "sonner";
 import { Button } from "./ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
@@ -37,9 +38,9 @@ export function ServerCapabilitiesModal({
 
   const capabilities = connection.capabilities || {};
 
-  const copyUrl = () => {
+  const copyUrl = async () => {
     if (connection.url) {
-      navigator.clipboard.writeText(connection.url);
+      await copyToClipboard(connection.url);
       toast.success("URL copied");
     }
   };

--- a/libraries/typescript/packages/inspector/src/client/components/ToolsTab.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ToolsTab.tsx
@@ -48,6 +48,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/client/components/ui/alert-dialog";
+import { copyToClipboard } from "@/client/utils/clipboard";
 
 export interface ToolsTabRef {
   focusSearch: () => void;
@@ -901,7 +902,7 @@ export function ToolsTab({
 
   const handleCopyResult = useCallback(async (index: number, text: string) => {
     try {
-      await navigator.clipboard.writeText(text);
+      await copyToClipboard(text);
       setCopiedResult(index);
       setTimeout(() => setCopiedResult(null), 2000);
     } catch (error) {

--- a/libraries/typescript/packages/inspector/src/client/components/chat/AssistantMessage.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/AssistantMessage.tsx
@@ -1,6 +1,7 @@
 import { Check, Copy } from "lucide-react";
 import { useState } from "react";
 import { MarkdownRenderer } from "@/client/components/shared/MarkdownRenderer";
+import { copyToClipboard } from "@/client/utils/clipboard";
 
 /**
  * Button that copies the provided text to the clipboard and shows a brief visual confirmation.
@@ -12,7 +13,7 @@ function CopyButton({ text }: { text: string }) {
   const [isCopied, setIsCopied] = useState(false);
 
   const handleCopy = async () => {
-    await navigator.clipboard.writeText(text);
+    await copyToClipboard(text);
     setIsCopied(true);
     setTimeout(() => setIsCopied(false), 2000);
   };

--- a/libraries/typescript/packages/inspector/src/client/components/chat/ToolCallDisplay.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/ToolCallDisplay.tsx
@@ -1,5 +1,4 @@
 import { Check, Copy, Loader2, Wrench, X } from "lucide-react";
-import { useState } from "react";
 import { Button } from "@/client/components/ui/button";
 import {
   Sheet,
@@ -10,8 +9,9 @@ import {
   SheetTrigger,
 } from "@/client/components/ui/sheet";
 import { cn } from "@/client/lib/utils";
-import { JSONDisplay } from "../shared/JSONDisplay";
+import { copyToClipboard } from "@/client/utils/clipboard";
 import { analyzeJSON } from "@/client/utils/jsonUtils";
+import { JSONDisplay } from "../shared/JSONDisplay";
 
 interface ToolCallDisplayProps {
   toolName: string;
@@ -28,7 +28,6 @@ export function ToolCallDisplay({
   state = "result",
   partialArgs,
 }: ToolCallDisplayProps) {
-  const [_copied, setCopied] = useState(false);
   const displayArgs = state === "call" && partialArgs ? partialArgs : args;
 
   const getStatusIcon = () => {
@@ -61,12 +60,6 @@ export function ToolCallDisplay({
       default:
         return " bg-emerald-500/20 dark:bg-emerald-500/20";
     }
-  };
-
-  const copyToClipboard = (text: string) => {
-    navigator.clipboard.writeText(text);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
   };
 
   const formatContent = (content: any): string => {

--- a/libraries/typescript/packages/inspector/src/client/components/logging/JsonRpcLoggerView.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/logging/JsonRpcLoggerView.tsx
@@ -15,6 +15,7 @@ import {
 } from "mcp-use/react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
+import { copyToClipboard } from "@/client/utils/clipboard";
 
 interface RenderableRpcItem {
   id: string;
@@ -77,10 +78,10 @@ export function JsonRpcLoggerView({
     }
   };
 
-  const copyToClipboard = async (payload: unknown) => {
+  const copyMessageToClipboard = async (payload: unknown) => {
     try {
       const jsonString = JSON.stringify(payload, null, 2);
-      await navigator.clipboard.writeText(jsonString);
+      await copyToClipboard(jsonString);
       toast.success("Message copied to clipboard");
     } catch (error) {
       console.error("Failed to copy message:", error);
@@ -91,7 +92,7 @@ export function JsonRpcLoggerView({
   const exportAllMessages = async () => {
     try {
       const jsonString = JSON.stringify(filteredItems, null, 2);
-      await navigator.clipboard.writeText(jsonString);
+      await copyToClipboard(jsonString);
       toast.success(
         `All messages copied to clipboard (${filteredItems.length})`
       );
@@ -320,7 +321,7 @@ export function JsonRpcLoggerView({
                           size="sm"
                           onClick={(e) => {
                             e.stopPropagation();
-                            copyToClipboard(it.payload);
+                            copyMessageToClipboard(it.payload);
                           }}
                           className="h-6 px-2"
                           title="Copy message to clipboard"

--- a/libraries/typescript/packages/inspector/src/client/components/prompts/PromptMessageCard.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/prompts/PromptMessageCard.tsx
@@ -1,6 +1,7 @@
 import { Check, Copy } from "lucide-react";
 import { useState } from "react";
 import { Badge } from "@/client/components/ui/badge";
+import { copyToClipboard } from "@/client/utils/clipboard";
 import { MarkdownRenderer } from "@/client/components/shared/MarkdownRenderer";
 import { Button } from "@/client/components/ui/button";
 
@@ -103,7 +104,7 @@ export function PromptMessageCard({ message, index }: PromptMessageCardProps) {
 
   const handleCopy = async () => {
     const text = extractTextFromContent(message.content);
-    await navigator.clipboard.writeText(text);
+    await copyToClipboard(text);
     setIsCopied(true);
     setTimeout(() => setIsCopied(false), 2000);
   };

--- a/libraries/typescript/packages/inspector/src/client/components/shared/MarkdownRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/shared/MarkdownRenderer.tsx
@@ -1,5 +1,6 @@
 import { Check, Copy } from "lucide-react";
 import Markdown from "markdown-to-jsx";
+import { copyToClipboard } from "@/client/utils/clipboard";
 import { useState } from "react";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { usePrismTheme } from "@/client/hooks/usePrismTheme";
@@ -49,7 +50,7 @@ function CodeBlock({
   const codeContent = String(children).trim();
 
   const handleCopy = async () => {
-    await navigator.clipboard.writeText(codeContent);
+    await copyToClipboard(codeContent);
     setIsCopied(true);
     setTimeout(() => setIsCopied(false), 2000);
   };

--- a/libraries/typescript/packages/inspector/src/client/components/tools/ToolExecutionPanel.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/tools/ToolExecutionPanel.tsx
@@ -23,6 +23,7 @@ import {
   X,
 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
+import { copyToClipboard } from "@/client/utils/clipboard";
 import { JSONDisplay } from "../shared/JSONDisplay";
 import { ToolInputForm } from "./ToolInputForm";
 
@@ -84,21 +85,28 @@ export function ToolExecutionPanel({
   }, [selectedTool?.description]);
 
   // Copy metadata to clipboard
-  const copyMetadataToClipboard = () => {
+  const copyMetadataToClipboard = async () => {
     if (!selectedTool) return;
-    // Copy the full tool definition instead of cherry-picking fields
-    navigator.clipboard.writeText(JSON.stringify(selectedTool, null, 2));
-    setCopiedMetadata(true);
-    setTimeout(() => setCopiedMetadata(false), 2000);
+    try {
+      await copyToClipboard(JSON.stringify(selectedTool, null, 2));
+      setCopiedMetadata(true);
+      setTimeout(() => setCopiedMetadata(false), 2000);
+    } catch {
+      // Silently fail - no toast in this component
+    }
   };
 
   // Copy payload to clipboard (use payloadToSend when provided - reflects what will actually be sent)
-  const copyPayloadToClipboard = () => {
+  const copyPayloadToClipboard = async () => {
     if (!selectedTool) return;
-    const payload = payloadToSend ?? toolArgs;
-    navigator.clipboard.writeText(JSON.stringify(payload, null, 2));
-    setCopiedPayload(true);
-    setTimeout(() => setCopiedPayload(false), 2000);
+    try {
+      const payload = payloadToSend ?? toolArgs;
+      await copyToClipboard(JSON.stringify(payload, null, 2));
+      setCopiedPayload(true);
+      setTimeout(() => setCopiedPayload(false), 2000);
+    } catch {
+      // Silently fail - no toast in this component
+    }
   };
 
   // Handle Cmd/Ctrl + Enter keyboard shortcut

--- a/libraries/typescript/packages/inspector/src/client/utils/clipboard.ts
+++ b/libraries/typescript/packages/inspector/src/client/utils/clipboard.ts
@@ -1,0 +1,20 @@
+/**
+ * Copy text to clipboard with fallback for non-secure contexts (HTTP, iframes).
+ * Uses navigator.clipboard when available, otherwise document.execCommand('copy').
+ */
+export async function copyToClipboard(text: string): Promise<void> {
+  if (navigator.clipboard?.writeText) {
+    return navigator.clipboard.writeText(text);
+  }
+  // Fallback for non-secure contexts (HTTP, iframes without clipboard permission)
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.style.cssText = "position:fixed;top:-9999px;left:-9999px;opacity:0";
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+  if (!document.execCommand("copy")) {
+    throw new Error("execCommand copy failed");
+  }
+  document.body.removeChild(textarea);
+}

--- a/libraries/typescript/packages/inspector/src/client/utils/index.ts
+++ b/libraries/typescript/packages/inspector/src/client/utils/index.ts
@@ -2,4 +2,5 @@
  * Utility functions for MCP client configurations
  */
 
+export * from "./clipboard.js";
 export * from "./mcpClientUtils.js";


### PR DESCRIPTION
- Replaced direct calls to `navigator.clipboard.writeText` with the new `copyToClipboard` function in multiple components, enhancing code consistency and maintainability.
- Updated components including `AddToClientDropdown`, `CommandPalette`, `ConnectionSettingsForm`, and others to utilize the new utility for clipboard operations.
- This change improves error handling and reduces redundancy in clipboard-related code.
