### PR TITLE
feat(python): add MCPServer mount support for external connectors

### DIFF
--- a/libraries/python/mcp_use/server/runner.py
+++ b/libraries/python/mcp_use/server/runner.py
@@ -3,6 +3,7 @@
 import logging
 import socket
 import sys
+from collections.abc import Awaitable, Callable
 from functools import partial
 from typing import TYPE_CHECKING, get_args
 
@@ -46,6 +47,14 @@ class ServerRunner:
     def __init__(self, server: "MCPServer"):
         self.server = server
 
+    async def _run_with_mounted_connectors(self, serve_fn: Callable[[], Awaitable[None]]) -> None:
+        """Run a server transport while mounted connectors are connected."""
+        try:
+            await self.server._connect_mounted_connectors()
+            await serve_fn()
+        finally:
+            await self.server._disconnect_mounted_connectors()
+
     async def serve_starlette_app(
         self,
         starlette_app: Starlette,
@@ -81,13 +90,26 @@ class ServerRunner:
 
     async def run_streamable_http_async(self, host: str = "127.0.0.1", port: int = 8000, reload: bool = False) -> None:
         """Run the server using StreamableHTTP transport."""
-        starlette_app = self.server.streamable_http_app()
-        await self.serve_starlette_app(starlette_app, host, port, "streamable-http", reload)
+
+        async def serve() -> None:
+            starlette_app = self.server.streamable_http_app()
+            await self.serve_starlette_app(starlette_app, host, port, "streamable-http", reload)
+
+        await self._run_with_mounted_connectors(serve)
 
     async def run_sse_async(self, host: str = "127.0.0.1", port: int = 8000, reload: bool = False) -> None:
         """Run the server using SSE transport."""
-        starlette_app = self.server.sse_app(self.server.mcp_path)
-        await self.serve_starlette_app(starlette_app, host, port, "sse", reload)
+
+        async def serve() -> None:
+            starlette_app = self.server.sse_app(self.server.mcp_path)
+            await self.serve_starlette_app(starlette_app, host, port, "sse", reload)
+
+        await self._run_with_mounted_connectors(serve)
+
+    async def run_stdio_async(self) -> None:
+        """Run the server using stdio transport with mounted connector lifecycle."""
+
+        await self._run_with_mounted_connectors(self.server.run_stdio_async)
 
     def run(
         self,
@@ -111,7 +133,7 @@ class ServerRunner:
         try:
             match transport:
                 case "stdio":
-                    anyio.run(self.server.run_stdio_async)
+                    anyio.run(self.run_stdio_async)
                 case "streamable-http":
                     anyio.run(partial(self.run_streamable_http_async, host=host, port=port, reload=reload))
                 case "sse":

--- a/libraries/python/mcp_use/server/server.py
+++ b/libraries/python/mcp_use/server/server.py
@@ -14,6 +14,7 @@ from mcp.server.fastmcp import FastMCP
 from mcp.types import (
     AnyFunction,
     CallToolRequest,
+    CallToolResult,
     CompleteRequest,
     Completion,
     GetPromptRequest,
@@ -21,10 +22,12 @@ from mcp.types import (
     ListPromptsRequest,
     ListResourcesRequest,
     ListToolsRequest,
+    ListToolsResult,
     ReadResourceRequest,
     ServerResult,
     SetLevelRequest,
     SubscribeRequest,
+    Tool,
     UnsubscribeRequest,
 )
 
@@ -54,6 +57,7 @@ lowlevel.ServerSession = MiddlewareServerSession
 if TYPE_CHECKING:
     from mcp.server.session import ServerSession
 
+    from mcp_use.client.connectors.base import BaseConnector
     from mcp_use.server.router import MCPRouter
 
 
@@ -147,6 +151,12 @@ class MCPServer(FastMCP):
         self.pretty_print_jsonrpc = pretty_print_jsonrpc
         self.mcp_logs_only = mcp_logs_only
         self._transport_type: TransportType = "streamable-http"
+        self._mounted_connectors: list[tuple[str, BaseConnector]] = []
+        self._mounted_tool_map: dict[str, tuple[BaseConnector, str]] = {}
+        self._mounted_tools_cache: list[Tool] = []
+        self._mounted_tool_cache_built = False
+        self._middleware_handlers_wrapped = False
+        self._mount_handlers_wrapped = False
 
         self.middleware_manager = MiddlewareManager()
         self.middleware_manager.add_middleware(TelemetryMiddleware())
@@ -318,6 +328,73 @@ class MCPServer(FastMCP):
                 description=prompt.description,
             )(prompt.fn)
 
+    def mount(self, connector: BaseConnector, prefix: str) -> None:
+        """Mount an external connector's tools on this server."""
+        normalized_prefix = prefix.strip()
+        if not normalized_prefix:
+            raise ValueError("Mounted connector prefix must be non-empty")
+
+        if any(existing_prefix == normalized_prefix for existing_prefix, _ in self._mounted_connectors):
+            raise ValueError(f"Mounted connector prefix '{normalized_prefix}' is already registered")
+
+        self._mounted_connectors.append((normalized_prefix, connector))
+        self._mounted_tool_cache_built = False
+
+    async def _connect_mounted_connectors(self) -> None:
+        """Connect mounted connectors and build the cached prefixed tool map."""
+        if not self._mounted_connectors:
+            return
+
+        for _, connector in self._mounted_connectors:
+            await connector.connect()
+            await connector.initialize()
+
+        await self._build_mounted_tool_cache()
+
+    async def _disconnect_mounted_connectors(self) -> None:
+        """Disconnect mounted connectors and clear cached mounted tools."""
+        for _, connector in reversed(self._mounted_connectors):
+            try:
+                await connector.disconnect()
+            except Exception as exc:
+                logger.warning("Error disconnecting mounted connector %s: %s", connector.public_identifier, exc)
+
+        self._mounted_tool_map.clear()
+        self._mounted_tools_cache = []
+        self._mounted_tool_cache_built = False
+
+    async def _build_mounted_tool_cache(self) -> None:
+        """Build prefixed tool metadata for all mounted connectors."""
+        mounted_tool_map: dict[str, tuple[BaseConnector, str]] = {}
+        mounted_tools_cache: list[Tool] = []
+
+        for prefix, connector in self._mounted_connectors:
+            tools = await connector.list_tools()
+            for tool in tools:
+                prefixed_name = f"{prefix}_{tool.name}"
+                mounted_tool_map[prefixed_name] = (connector, tool.name)
+                mounted_tools_cache.append(tool.model_copy(update={"name": prefixed_name}))
+
+        self._mounted_tool_map = mounted_tool_map
+        self._mounted_tools_cache = mounted_tools_cache
+        self._mounted_tool_cache_built = True
+
+    async def _ensure_mounted_tool_cache(self) -> None:
+        """Build mounted tool metadata once before serving lookups."""
+        if self._mounted_connectors and not self._mounted_tool_cache_built:
+            await self._build_mounted_tool_cache()
+
+    async def call_tool(self, name: str, arguments: dict[str, Any] | None = None) -> CallToolResult:
+        """Call a mounted tool by its prefixed name."""
+        await self._ensure_mounted_tool_cache()
+
+        mounted_tool = self._mounted_tool_map.get(name)
+        if mounted_tool is None:
+            raise ValueError(f"Unknown mounted tool: {name}")
+
+        connector, original_name = mounted_tool
+        return await connector.call_tool(original_name, arguments or {})
+
     def _apply_dns_rebinding_protection(self, host: str) -> None:
         """Configure transport security to reject non-localhost Host/Origin headers."""
         from mcp.server.transport_security import TransportSecuritySettings
@@ -450,6 +527,9 @@ class MCPServer(FastMCP):
         return app
 
     def _wrap_handlers_with_middleware(self) -> None:
+        if self._middleware_handlers_wrapped:
+            return
+
         handlers = self._mcp_server.request_handlers
 
         if self.debug_level >= 1:
@@ -490,6 +570,51 @@ class MCPServer(FastMCP):
         wrap_request(SubscribeRequest, "resources/subscribe")
         wrap_request(UnsubscribeRequest, "resources/unsubscribe")
         wrap_request(CompleteRequest, "completion/complete")
+        self._middleware_handlers_wrapped = True
+
+    def _wrap_handlers_for_mounts(self) -> None:
+        if self._mount_handlers_wrapped:
+            return
+
+        handlers = self._mcp_server.request_handlers
+
+        if CallToolRequest in handlers:
+            original_call_tool = handlers[CallToolRequest]
+
+            async def wrapped_call_tool(request: Any) -> ServerResult:
+                tool_name = request.params.name
+                await self._ensure_mounted_tool_cache()
+
+                mounted_tool = self._mounted_tool_map.get(tool_name)
+                if mounted_tool is None:
+                    return await original_call_tool(request)
+
+                connector, original_name = mounted_tool
+                result = await connector.call_tool(original_name, request.params.arguments or {})
+                return ServerResult(result)
+
+            handlers[CallToolRequest] = wrapped_call_tool
+
+        if ListToolsRequest in handlers:
+            original_list_tools = handlers[ListToolsRequest]
+
+            async def wrapped_list_tools(request: Any) -> ServerResult:
+                result = await original_list_tools(request)
+
+                if not self._mounted_tools_cache:
+                    return result
+
+                tools_result = getattr(result, "root", result)
+                if not isinstance(tools_result, ListToolsResult):
+                    return result
+
+                merged_tools = [*tools_result.tools, *self._mounted_tools_cache]
+                merged_result = tools_result.model_copy(update={"tools": merged_tools})
+                return ServerResult(merged_result)
+
+            handlers[ListToolsRequest] = wrapped_list_tools
+
+        self._mount_handlers_wrapped = True
 
     def run(  # type: ignore[override]
         self,
@@ -535,6 +660,7 @@ class MCPServer(FastMCP):
         self._transport_type = transport
         track_server_run_from_server(self, transport, final_host, final_port, _telemetry)
 
+        self._wrap_handlers_for_mounts()
         self._wrap_handlers_with_middleware()
 
         runner = ServerRunner(self)

--- a/libraries/python/mcp_use/server/server.py
+++ b/libraries/python/mcp_use/server/server.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import asyncio
 import inspect
 import logging
 import os
+import re
 import time
 import weakref
 from datetime import UTC, datetime
@@ -74,6 +76,11 @@ def _normalize_inspector_path(path: str) -> str:
     if normalized.endswith("/inspector"):
         return normalized
     return f"{normalized}/inspector"
+
+
+def _sanitize_for_tool_name_component(name: str) -> str:
+    """Sanitize a mounted tool name component to a provider-compatible shape."""
+    return re.sub(r"[^a-zA-Z0-9_]+", "_", name).strip("_")[:64]
 
 
 class MCPServer(FastMCP):
@@ -168,6 +175,7 @@ class MCPServer(FastMCP):
         self._mounted_tool_map: dict[str, tuple[BaseConnector, str]] = {}
         self._mounted_tools_cache: list[Tool] = []
         self._mounted_tool_cache_built = False
+        self._mounted_tool_cache_lock = asyncio.Lock()
         self._middleware_handlers_wrapped = False
         self._mount_handlers_wrapped = False
 
@@ -350,11 +358,16 @@ class MCPServer(FastMCP):
         normalized_prefix = prefix.strip()
         if not normalized_prefix:
             raise ValueError("Mounted connector prefix must be non-empty")
+        normalized_prefix = _sanitize_for_tool_name_component(normalized_prefix)
+        if not normalized_prefix:
+            raise ValueError("Mounted connector prefix must contain at least one letter or number")
 
         if any(existing_prefix == normalized_prefix for existing_prefix, _ in self._mounted_connectors):
             raise ValueError(f"Mounted connector prefix '{normalized_prefix}' is already registered")
 
         self._mounted_connectors.append((normalized_prefix, connector))
+        self._mounted_tool_map.clear()
+        self._mounted_tools_cache = []
         self._mounted_tool_cache_built = False
 
     async def _connect_mounted_connectors(self) -> None:
@@ -398,8 +411,12 @@ class MCPServer(FastMCP):
 
     async def _ensure_mounted_tool_cache(self) -> None:
         """Build mounted tool metadata once before serving lookups."""
-        if self._mounted_connectors and not self._mounted_tool_cache_built:
-            await self._build_mounted_tool_cache()
+        if not self._mounted_connectors or self._mounted_tool_cache_built:
+            return
+
+        async with self._mounted_tool_cache_lock:
+            if self._mounted_connectors and not self._mounted_tool_cache_built:
+                await self._build_mounted_tool_cache()
 
     async def call_tool(self, name: str, arguments: dict[str, Any] | None = None) -> CallToolResult:
         """Call a mounted tool by its prefixed name."""
@@ -617,6 +634,7 @@ class MCPServer(FastMCP):
 
             async def wrapped_list_tools(request: Any) -> ServerResult:
                 result = await original_list_tools(request)
+                await self._ensure_mounted_tool_cache()
 
                 if not self._mounted_tools_cache:
                     return result

--- a/libraries/python/tests/unit/server/test_mount.py
+++ b/libraries/python/tests/unit/server/test_mount.py
@@ -1,5 +1,6 @@
 """Unit tests for mounted connector support on MCPServer."""
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
@@ -55,12 +56,61 @@ class TestMountRegistration:
 
         assert server._mounted_connectors == [("browser", connector)]
 
+    def test_mount_strips_surrounding_whitespace_from_prefix(self):
+        server = MCPServer(name="test")
+        connector = _make_connector(["click"])
+
+        server.mount(connector, prefix=" browser ")
+
+        assert server._mounted_connectors == [("browser", connector)]
+
+    @pytest.mark.parametrize(
+        ("prefix", "expected_prefix"),
+        [
+            ("browser-tools", "browser_tools"),
+            ("browser tools", "browser_tools"),
+            ("browser.tools", "browser_tools"),
+            ("_browser", "browser"),
+            ("browser_", "browser"),
+            ("__browser__", "browser"),
+        ],
+    )
+    def test_mount_sanitizes_prefixes_to_provider_compatible_tool_names(self, prefix: str, expected_prefix: str):
+        server = MCPServer(name="test")
+        connector = _make_connector(["click"])
+
+        server.mount(connector, prefix=prefix)
+
+        assert server._mounted_connectors == [(expected_prefix, connector)]
+
     def test_mount_rejects_empty_prefix(self):
         server = MCPServer(name="test")
         connector = _make_connector(["click"])
 
         with pytest.raises(ValueError, match="non-empty"):
             server.mount(connector, prefix=" ")
+
+    def test_mount_rejects_prefixes_that_sanitize_to_empty(self):
+        server = MCPServer(name="test")
+        connector = _make_connector(["click"])
+
+        with pytest.raises(ValueError, match="at least one letter or number"):
+            server.mount(connector, prefix="---")
+
+    def test_mount_truncates_prefixes_longer_than_64_characters(self):
+        server = MCPServer(name="test")
+        connector = _make_connector(["click"])
+
+        server.mount(connector, prefix="a" * 65)
+
+        assert server._mounted_connectors == [("a" * 64, connector)]
+
+    def test_mount_rejects_duplicate_prefix_after_sanitization(self):
+        server = MCPServer(name="test")
+        server.mount(_make_connector(["click"]), prefix="browser-tools")
+
+        with pytest.raises(ValueError, match="already registered"):
+            server.mount(_make_connector(["navigate"]), prefix="browser_tools")
 
     def test_mount_rejects_duplicate_prefix(self):
         server = MCPServer(name="test")
@@ -112,6 +162,24 @@ class TestMountedConnectorLifecycle:
         assert server._mounted_tools_cache == []
         assert server._mounted_tool_map == {}
 
+    @pytest.mark.asyncio
+    async def test_mount_invalidates_existing_mounted_tool_cache(self):
+        server = MCPServer(name="test")
+        browser = _make_connector(["click"])
+        server.mount(browser, prefix="browser")
+
+        await server._build_mounted_tool_cache()
+
+        assert [tool.name for tool in server._mounted_tools_cache] == ["browser_click"]
+        assert server._mounted_tool_map == {"browser_click": (browser, "click")}
+        assert server._mounted_tool_cache_built is True
+
+        server.mount(_make_connector(["read_file"]), prefix="fs")
+
+        assert server._mounted_tools_cache == []
+        assert server._mounted_tool_map == {}
+        assert server._mounted_tool_cache_built is False
+
 
 class TestMountedHandlerWrapping:
     @pytest.mark.asyncio
@@ -134,6 +202,37 @@ class TestMountedHandlerWrapping:
         tools_result = _unwrap_server_result(result)
 
         assert [tool.name for tool in tools_result.tools] == ["local_tool", "browser_click"]
+
+    @pytest.mark.asyncio
+    async def test_wrap_handlers_rebuilds_mounted_tools_after_cache_invalidation(self):
+        server = MCPServer(name="test")
+        browser = _make_connector(["click"])
+        server.mount(browser, prefix="browser")
+        await server._build_mounted_tool_cache()
+        browser.list_tools.reset_mock()
+
+        filesystem = _make_connector(["read_file"])
+        server.mount(filesystem, prefix="fs")
+
+        native_result = ListToolsResult(tools=[_make_tool("local_tool")])
+
+        async def native_list_tools(_request):
+            return ServerResult(native_result)
+
+        server._mcp_server.request_handlers[ListToolsRequest] = native_list_tools
+
+        server._wrap_handlers_for_mounts()
+        wrapped = server._mcp_server.request_handlers[ListToolsRequest]
+        result = await wrapped(Mock())
+        tools_result = _unwrap_server_result(result)
+
+        assert [tool.name for tool in tools_result.tools] == [
+            "local_tool",
+            "browser_click",
+            "fs_read_file",
+        ]
+        browser.list_tools.assert_awaited_once()
+        filesystem.list_tools.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_wrap_handlers_routes_call_tool(self):
@@ -211,6 +310,28 @@ class TestMountedServerCallTool:
 
         with pytest.raises(ValueError, match="Unknown mounted tool"):
             await server.call_tool("browser_missing", {})
+
+    @pytest.mark.asyncio
+    async def test_ensure_mounted_tool_cache_builds_once_when_called_concurrently(self):
+        server = MCPServer(name="test")
+        server.mount(_make_connector(["click"]), prefix="browser")
+
+        build_mock = AsyncMock()
+
+        async def fake_build() -> None:
+            await asyncio.sleep(0)
+            server._mounted_tool_cache_built = True
+
+        build_mock.side_effect = fake_build
+        server._build_mounted_tool_cache = build_mock
+
+        await asyncio.gather(
+            server._ensure_mounted_tool_cache(),
+            server._ensure_mounted_tool_cache(),
+        )
+
+        assert build_mock.await_count == 1
+        assert server._mounted_tool_cache_built is True
 
 
 class TestServerRunnerMountedLifecycle:

--- a/libraries/python/tests/unit/server/test_mount.py
+++ b/libraries/python/tests/unit/server/test_mount.py
@@ -1,0 +1,243 @@
+"""Unit tests for mounted connector support on MCPServer."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from mcp.types import (
+    CallToolRequest,
+    CallToolResult,
+    ListToolsRequest,
+    ListToolsResult,
+    ServerResult,
+    TextContent,
+    Tool,
+)
+
+from mcp_use.client.connectors.base import BaseConnector
+from mcp_use.server import MCPServer
+from mcp_use.server.runner import ServerRunner
+
+
+def _make_tool(name: str) -> Tool:
+    return Tool(
+        name=name,
+        description=f"{name} description",
+        inputSchema={"type": "object", "properties": {}},
+    )
+
+
+def _make_call_tool_result(text: str) -> CallToolResult:
+    return CallToolResult(content=[TextContent(type="text", text=text)])
+
+
+def _unwrap_server_result(result):
+    return getattr(result, "root", result)
+
+
+def _make_connector(tool_names: list[str], tool_result: CallToolResult | None = None) -> Mock:
+    connector = Mock(spec=BaseConnector)
+    connector.connect = AsyncMock()
+    connector.initialize = AsyncMock()
+    connector.disconnect = AsyncMock()
+    connector.list_tools = AsyncMock(return_value=[_make_tool(name) for name in tool_names])
+    connector.call_tool = AsyncMock(return_value=tool_result or _make_call_tool_result("mounted"))
+    connector.public_identifier = "mock://connector"
+    return connector
+
+
+class TestMountRegistration:
+    def test_mount_stores_connector(self):
+        server = MCPServer(name="test")
+        connector = _make_connector(["click"])
+
+        server.mount(connector, prefix="browser")
+
+        assert server._mounted_connectors == [("browser", connector)]
+
+    def test_mount_rejects_empty_prefix(self):
+        server = MCPServer(name="test")
+        connector = _make_connector(["click"])
+
+        with pytest.raises(ValueError, match="non-empty"):
+            server.mount(connector, prefix=" ")
+
+    def test_mount_rejects_duplicate_prefix(self):
+        server = MCPServer(name="test")
+        server.mount(_make_connector(["click"]), prefix="browser")
+
+        with pytest.raises(ValueError, match="already registered"):
+            server.mount(_make_connector(["navigate"]), prefix="browser")
+
+
+class TestMountedConnectorLifecycle:
+    @pytest.mark.asyncio
+    async def test_connect_mounted_connectors_builds_prefixed_tool_cache(self):
+        server = MCPServer(name="test")
+        browser = _make_connector(["click", "navigate"])
+        filesystem = _make_connector(["read_file"])
+        server.mount(browser, prefix="browser")
+        server.mount(filesystem, prefix="fs")
+
+        await server._connect_mounted_connectors()
+
+        browser.connect.assert_called_once()
+        browser.initialize.assert_called_once()
+        filesystem.connect.assert_called_once()
+        filesystem.initialize.assert_called_once()
+        assert sorted(tool.name for tool in server._mounted_tools_cache) == [
+            "browser_click",
+            "browser_navigate",
+            "fs_read_file",
+        ]
+        assert server._mounted_tool_map["browser_click"] == (browser, "click")
+        assert server._mounted_tool_map["fs_read_file"] == (filesystem, "read_file")
+
+    @pytest.mark.asyncio
+    async def test_disconnect_mounted_connectors_disconnects_in_reverse_and_clears_cache(self):
+        server = MCPServer(name="test")
+        first = _make_connector(["click"])
+        second = _make_connector(["navigate"])
+        call_order: list[str] = []
+        first.disconnect.side_effect = lambda: call_order.append("first")
+        second.disconnect.side_effect = lambda: call_order.append("second")
+        server.mount(first, prefix="browser")
+        server.mount(second, prefix="fs")
+        server._mounted_tools_cache = [_make_tool("browser_click")]
+        server._mounted_tool_map = {"browser_click": (first, "click")}
+
+        await server._disconnect_mounted_connectors()
+
+        assert call_order == ["second", "first"]
+        assert server._mounted_tools_cache == []
+        assert server._mounted_tool_map == {}
+
+
+class TestMountedHandlerWrapping:
+    @pytest.mark.asyncio
+    async def test_wrap_handlers_lists_mounted_tools(self):
+        server = MCPServer(name="test")
+        connector = _make_connector(["click"])
+        server.mount(connector, prefix="browser")
+        await server._connect_mounted_connectors()
+
+        native_result = ListToolsResult(tools=[_make_tool("local_tool")])
+
+        async def native_list_tools(_request):
+            return ServerResult(native_result)
+
+        server._mcp_server.request_handlers[ListToolsRequest] = native_list_tools
+
+        server._wrap_handlers_for_mounts()
+        wrapped = server._mcp_server.request_handlers[ListToolsRequest]
+        result = await wrapped(Mock())
+        tools_result = _unwrap_server_result(result)
+
+        assert [tool.name for tool in tools_result.tools] == ["local_tool", "browser_click"]
+
+    @pytest.mark.asyncio
+    async def test_wrap_handlers_routes_call_tool(self):
+        server = MCPServer(name="test")
+        mounted_result = _make_call_tool_result("mounted result")
+        connector = _make_connector(["click"], tool_result=mounted_result)
+        server.mount(connector, prefix="browser")
+        await server._connect_mounted_connectors()
+
+        native_handler = AsyncMock()
+        server._mcp_server.request_handlers[CallToolRequest] = native_handler
+
+        server._wrap_handlers_for_mounts()
+        wrapped = server._mcp_server.request_handlers[CallToolRequest]
+        request = SimpleNamespace(params=SimpleNamespace(name="browser_click", arguments={"selector": "#submit"}))
+
+        result = await wrapped(request)
+
+        connector.call_tool.assert_awaited_once_with("click", {"selector": "#submit"})
+        native_handler.assert_not_called()
+        call_result = _unwrap_server_result(result)
+        assert call_result.content[0].text == "mounted result"
+
+    @pytest.mark.asyncio
+    async def test_wrap_handlers_routes_native_call_tool_when_name_is_not_mounted(self):
+        server = MCPServer(name="test")
+        native_result = _make_call_tool_result("native result")
+
+        async def native_call_tool(_request):
+            return ServerResult(native_result)
+
+        server._mcp_server.request_handlers[CallToolRequest] = native_call_tool
+
+        server._wrap_handlers_for_mounts()
+        wrapped = server._mcp_server.request_handlers[CallToolRequest]
+        request = SimpleNamespace(params=SimpleNamespace(name="local_tool", arguments={"value": 1}))
+
+        result = await wrapped(request)
+
+        call_result = _unwrap_server_result(result)
+        assert call_result.content[0].text == "native result"
+
+
+class TestMountedServerCallTool:
+    @pytest.mark.asyncio
+    async def test_call_tool_routes_to_mounted_connector(self):
+        server = MCPServer(name="test")
+        mounted_result = _make_call_tool_result("mounted result")
+        connector = _make_connector(["click"], tool_result=mounted_result)
+        server.mount(connector, prefix="browser")
+
+        result = await server.call_tool("browser_click", {"selector": "#submit"})
+
+        connector.list_tools.assert_awaited_once()
+        connector.call_tool.assert_awaited_once_with("click", {"selector": "#submit"})
+        assert result.content[0].text == "mounted result"
+
+    @pytest.mark.asyncio
+    async def test_call_tool_unknown_does_not_rebuild_initialized_cache(self):
+        server = MCPServer(name="test")
+        connector = _make_connector(["click"])
+        server.mount(connector, prefix="browser")
+
+        await server._build_mounted_tool_cache()
+        connector.list_tools.reset_mock()
+
+        with pytest.raises(ValueError, match="Unknown mounted tool"):
+            await server.call_tool("browser_missing", {})
+
+        connector.list_tools.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_call_tool_unknown_raises(self):
+        server = MCPServer(name="test")
+
+        with pytest.raises(ValueError, match="Unknown mounted tool"):
+            await server.call_tool("browser_missing", {})
+
+
+class TestServerRunnerMountedLifecycle:
+    @pytest.mark.asyncio
+    async def test_run_with_mounted_connectors_wraps_serve_function(self):
+        server = MCPServer(name="test")
+        server._connect_mounted_connectors = AsyncMock()
+        server._disconnect_mounted_connectors = AsyncMock()
+        runner = ServerRunner(server)
+        serve = AsyncMock()
+
+        await runner._run_with_mounted_connectors(serve)
+
+        server._connect_mounted_connectors.assert_awaited_once()
+        serve.assert_awaited_once()
+        server._disconnect_mounted_connectors.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_run_with_mounted_connectors_disconnects_after_startup_error(self):
+        server = MCPServer(name="test")
+        server._connect_mounted_connectors = AsyncMock(side_effect=RuntimeError("connect failed"))
+        server._disconnect_mounted_connectors = AsyncMock()
+        runner = ServerRunner(server)
+        serve = AsyncMock()
+
+        with pytest.raises(RuntimeError, match="connect failed"):
+            await runner._run_with_mounted_connectors(serve)
+
+        serve.assert_not_called()
+        server._disconnect_mounted_connectors.assert_awaited_once()


### PR DESCRIPTION
# Pull Request Description

Adds `MCPServer.mount()` support for composing local server tools with tools from external MCP connectors. Mounted tools are exposed with prefixes through `tools/list`, routed through `tools/call`, and available for internal orchestration through `server.call_tool(...)`.


## Language / Project Scope

Check all that apply:
- [ ] TypeScript
- [x] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

Adds `MCPServer.mount()` support for composing local server tools with remote tools from external MCP connectors.

## Implementation Details

1. Added mounted connector registration to `MCPServer` with required prefix validation and duplicate-prefix checks.
2. Added mounted connector lifecycle handling so mounted connectors connect and initialize at server startup, build a cached prefixed tool map/tool list, and disconnect on shutdown.
3. Added a cached mounted tool map for routing prefixed tool names to `(connector, original_tool_name)` and a mounted tool cache for `tools/list` responses.
4. Used `model_copy(update={"name": prefixed_name})` when building mounted tool metadata so the server can expose prefixed tool names without mutating the original upstream `Tool` objects returned by the connector.
5. Wrapped `ListToolsRequest` handling to merge native server tools with mounted connector tools.
6. Wrapped `CallToolRequest` handling to resolve prefixed mounted tool names back to the correct connector and original upstream tool name.
7. Added `server.call_tool(...)` support for mounted tools only, matching the issue’s composition example.
8. Added a shared runner helper to wrap stdio and HTTP server execution with mounted connector startup/shutdown logic, avoiding duplicate lifecycle code across transports.
9. Added unit coverage for mount registration, lifecycle behavior, tool listing, tool routing, mounted internal calls, cache behavior, and runner cleanup.
10. No dependencies were added or changed.

---

## TypeScript Checklist

> Complete this section if your PR includes TypeScript changes

### Packages Modified

Check all packages that were modified:
- [ ] `docs`
- [ ] `tests`
- [ ] `cli`
- [ ] `create-mcp-use-app`
- [ ] `mcp-use` (server)
- [ ] `mcp-use` (client)
- [ ] `inspector`

### Pre-commit Checklist

Ensure all of the following have been completed:
- [ ] Ran `pnpm lint:fix` to auto-fix linting issues
- [ ] Ran `pnpm format` to format code with Prettier
- [ ] Ran `pnpm build` and build succeeds without errors
- [ ] Ran `pnpm changeset` to create a changeset (if this PR includes user-facing changes)
- [ ] Added or updated tests if needed
- [ ] Updated documentation in `docs/` folder if needed

---

## Python Checklist

> Complete this section if your PR includes Python changes

### Pre-commit Checklist

Ensure all of the following have been completed:
- [x] Code formatted with `ruff format`
- [x] Linting passes with `ruff check`
- [x] Added or updated tests if needed
- [ ] Updated documentation if needed

---

## Example Usage (Before)

```python
from mcp_use import MCPServer, StdioConnector

server = MCPServer(name="composed-tools")

@server.tool()
def my_local_tool(query: str) -> str:
    return f"Local result for {query}"

playwright = StdioConnector(name="playwright", command="npx", args=["@playwright/mcp"])
filesystem = StdioConnector(
    name="filesystem",
    command="npx",
    args=["@modelcontextprotocol/server-filesystem"],
)

# No generic server-side mounting support.
# External MCP tools had to be managed directly through connector objects.
await playwright.connect()
await playwright.initialize()
await filesystem.connect()
await filesystem.initialize()

await playwright.call_tool("navigate", {"url": "https://example.com"})
await filesystem.call_tool("write_file", {"path": "/tmp/out.txt", "content": "hello"})
```

## Example Usage (After)

```python
from mcp_use import MCPServer, StdioConnector, HttpConnector

server = MCPServer(name="composed-tools")

@server.tool()
def my_local_tool(query: str) -> str:
    return f"Local result for {query}"

playwright = StdioConnector(name="playwright", command="npx", args=["@playwright/mcp"])
filesystem = StdioConnector(
    name="filesystem",
    command="npx",
    args=["@modelcontextprotocol/server-filesystem"],
)

server.mount(playwright, prefix="browser")
server.mount(filesystem, prefix="fs")

@server.tool()
async def screenshot_and_save(url: str, filepath: str) -> str:
    await server.call_tool("browser_navigate", {"url": url})
    screenshot = await server.call_tool("browser_screenshot", {})
    await server.call_tool("fs_write_file", {"path": filepath, "content": screenshot["data"]})
    return f"Screenshot saved to {filepath}"

server.run(transport="http", port=8080)
```

## Documentation Updates

* No documentation files were updated.
* This change is covered by new unit tests.

## Testing

Describe how you tested these changes:
- Added `tests/unit/server/test_mount.py`
- Ran `pytest -vv tests/unit/server/test_mount.py`
- Ran `pytest -vv tests/unit/server`
- Ran `ruff check .`
- Ran `ruff format --check .`

Verified:
- mount registration
- empty/duplicate prefix validation
- mounted connector startup/shutdown lifecycle
- mounted tool exposure through `tools/list`
- mounted tool routing through `tools/call`
- mounted internal orchestration through `server.call_tool(...)`
- no repeated mounted tool cache rebuild for unknown mounted names after initialization

## Backwards Compatibility

These changes are backwards compatible.
- Existing local `MCPServer` tool behavior is unchanged.
- Mounted connector support is opt-in through `server.mount(...).`
- Existing connector APIs are unchanged.

## Related Issues

Closes #951 
