### PR TITLE
fix(cli): use serverFileUrl instead of serverFilePath in tsImport call

### DIFF
--- a/libraries/typescript/packages/cli/src/index.ts
+++ b/libraries/typescript/packages/cli/src/index.ts
@@ -342,8 +342,10 @@ async function generateToolRegistryTypesForServer(
     (globalThis as any).__mcpUseHmrMode = true;
     (globalThis as any).__mcpUseLastServer = undefined;
 
+    const { pathToFileURL: pathToFileURL2 } = await import("node:url");
+    const serverFileUrl2 = pathToFileURL2(serverFile).href;
     const { tsImport } = await import("tsx/esm/api");
-    await tsImport(serverFile, {
+    await tsImport(serverFileUrl2, {
       parentURL: import.meta.url,
       tsconfig: path.join(projectPath, "tsconfig.json"),
     });


### PR DESCRIPTION
## Problem

mcp-use dev crashes on Windows with ERR_UNSUPPORTED_ESM_URL_SCHEME. On Windows, serverFilePath is an absolute path like C:\Projects\my-server\index.ts. Node's ESM loader interprets the drive letter c: as a URL scheme and throws.

Fixes #1171

## Solution

In the importServerModule helper, the tsImport branch passes serverFilePath, but serverFileUrl (already computed via pathToFileURL) is the correct argument. The else branch already uses serverFileUrl correctly.

Before:
await tsImport(`${serverFilePath}?t=${Date.now()}`, { ... })

After:
await tsImport(`${serverFileUrl}?t=${Date.now()}`, { ... })

serverFileUrl is already in scope as pathToFileURL(serverFilePath).href, producing the correct file:///C:/... format on Windows.

## Testing

The else branch (native import) already uses serverFileUrl and works on Windows. This fix applies the same pattern to the tsImport branch.