### PR TITLE
feat(python): add BasicAuth and APIKeyAuth classes

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -316,6 +316,8 @@
                     "group": "Auth",
                     "icon": "key",
                     "pages": [
+                      "python/api-reference/mcp_use_client_auth_api_key",
+                      "python/api-reference/mcp_use_client_auth_basic",
                       "python/api-reference/mcp_use_client_auth_bearer",
                       "python/api-reference/mcp_use_client_auth_oauth",
                       "python/api-reference/mcp_use_client_auth_oauth_callback"

--- a/docs/python/api-reference/mcp_use_client_auth_api_key.mdx
+++ b/docs/python/api-reference/mcp_use_client_auth_api_key.mdx
@@ -1,0 +1,55 @@
+---
+title: "Api Key"
+description: "API key authentication support API Documentation"
+icon: "code"
+github: "https://github.com/mcp-use/mcp-use/blob/main/libraries/python/mcp_use/client/auth/api_key.py"
+---
+
+import {RandomGradientBackground} from "/snippets/gradient.jsx"
+
+<Callout type="info" title="Source Code">
+View the source code for this module on GitHub: <a href='https://github.com/mcp-use/mcp-use/blob/main/libraries/python/mcp_use/client/auth/api_key.py' target='_blank' rel='noopener noreferrer'>https://github.com/mcp-use/mcp-use/blob/main/libraries/python/mcp_use/client/auth/api_key.py</a>
+</Callout>
+
+API key authentication support.
+
+## APIKeyAuth
+
+<div>
+<RandomGradientBackground className="rounded-lg p-4 w-full h-full rounded-full">
+<div className="text-black">
+<div className="text-black font-bold text-xl mb-2 mt-8"><code className="!text-black">class</code> APIKeyAuth</div>
+
+API key authentication for HTTP requests.
+
+    Supports sending the API key via a custom header or query parameter.
+    Exactly one of ``header`` or ``query_param`` must be provided.
+
+</div>
+</RandomGradientBackground>
+```python
+from mcp_use.client.auth.api_key import APIKeyAuth
+```
+
+<Card type="info">
+**Attributes**
+>
+<ParamField body="key" type="pydantic.types.SecretStr" required="True" >   String value </ParamField>
+<ParamField body="header" type="str | None" required="True" >   String value </ParamField>
+<ParamField body="query_param" type="str | None" required="True" >   Query string or input </ParamField>
+
+</Card>
+
+<Card type="info">
+### `method` __init__
+
+**Parameters**
+><ParamField body="data" required="True" >   Parameter value </ParamField>
+
+**Signature**
+```python wrap
+def __init__(data):
+```
+
+</Card>
+</div>

--- a/docs/python/api-reference/mcp_use_client_auth_basic.mdx
+++ b/docs/python/api-reference/mcp_use_client_auth_basic.mdx
@@ -1,0 +1,53 @@
+---
+title: "Basic"
+description: "HTTP Basic authentication support API Documentation"
+icon: "code"
+github: "https://github.com/mcp-use/mcp-use/blob/main/libraries/python/mcp_use/client/auth/basic.py"
+---
+
+import {RandomGradientBackground} from "/snippets/gradient.jsx"
+
+<Callout type="info" title="Source Code">
+View the source code for this module on GitHub: <a href='https://github.com/mcp-use/mcp-use/blob/main/libraries/python/mcp_use/client/auth/basic.py' target='_blank' rel='noopener noreferrer'>https://github.com/mcp-use/mcp-use/blob/main/libraries/python/mcp_use/client/auth/basic.py</a>
+</Callout>
+
+HTTP Basic authentication support.
+
+## BasicAuth
+
+<div>
+<RandomGradientBackground className="rounded-lg p-4 w-full h-full rounded-full">
+<div className="text-black">
+<div className="text-black font-bold text-xl mb-2 mt-8"><code className="!text-black">class</code> BasicAuth</div>
+
+HTTP Basic authentication for HTTP requests.
+
+    Encodes username:password as Base64 in the Authorization header.
+
+</div>
+</RandomGradientBackground>
+```python
+from mcp_use.client.auth.basic import BasicAuth
+```
+
+<Card type="info">
+**Attributes**
+>
+<ParamField body="username" type="str" required="True" >   Name identifier </ParamField>
+<ParamField body="password" type="pydantic.types.SecretStr" required="True" >   String value </ParamField>
+
+</Card>
+
+<Card type="info">
+### `method` __init__
+
+**Parameters**
+><ParamField body="data" required="True" >   Parameter value </ParamField>
+
+**Signature**
+```python wrap
+def __init__(data):
+```
+
+</Card>
+</div>

--- a/libraries/python/mcp_use/client/auth/__init__.py
+++ b/libraries/python/mcp_use/client/auth/__init__.py
@@ -1,6 +1,8 @@
 """Authentication support for MCP clients."""
 
+from .api_key import APIKeyAuth
+from .basic import BasicAuth
 from .bearer import BearerAuth
 from .oauth import OAuth
 
-__all__ = ["BearerAuth", "OAuth"]
+__all__ = ["APIKeyAuth", "BasicAuth", "BearerAuth", "OAuth"]

--- a/libraries/python/mcp_use/client/auth/api_key.py
+++ b/libraries/python/mcp_use/client/auth/api_key.py
@@ -1,0 +1,40 @@
+"""API key authentication support."""
+
+from collections.abc import Generator
+
+import httpx
+from pydantic import BaseModel, SecretStr, model_validator
+
+from mcp_use.telemetry.telemetry import telemetry
+
+
+class APIKeyAuth(httpx.Auth, BaseModel):
+    """API key authentication for HTTP requests.
+
+    Supports sending the API key via a custom header or query parameter.
+    Exactly one of ``header`` or ``query_param`` must be provided.
+    """
+
+    key: SecretStr
+    header: str | None = None
+    query_param: str | None = None
+
+    def __init__(self, **data):
+        super().__init__(**data)
+
+    @model_validator(mode="after")
+    def _validate_location(self) -> "APIKeyAuth":
+        if not self.header and not self.query_param:
+            raise ValueError("Either 'header' or 'query_param' must be provided")
+        if self.header and self.query_param:
+            raise ValueError("Only one of 'header' or 'query_param' can be provided, not both")
+        return self
+
+    @telemetry("auth_api_key")
+    def auth_flow(self, request: httpx.Request) -> Generator[httpx.Request, httpx.Response, None]:
+        """Apply API key authentication to the request."""
+        if self.header:
+            request.headers[self.header] = self.key.get_secret_value()
+        elif self.query_param:
+            request.url = request.url.copy_merge_params({self.query_param: self.key.get_secret_value()})
+        yield request

--- a/libraries/python/mcp_use/client/auth/basic.py
+++ b/libraries/python/mcp_use/client/auth/basic.py
@@ -1,0 +1,30 @@
+"""HTTP Basic authentication support."""
+
+import base64
+from collections.abc import Generator
+
+import httpx
+from pydantic import BaseModel, SecretStr
+
+from mcp_use.telemetry.telemetry import telemetry
+
+
+class BasicAuth(httpx.Auth, BaseModel):
+    """HTTP Basic authentication for HTTP requests.
+
+    Encodes username:password as Base64 in the Authorization header.
+    """
+
+    username: str
+    password: SecretStr
+
+    def __init__(self, **data):
+        super().__init__(**data)
+
+    @telemetry("auth_basic")
+    def auth_flow(self, request: httpx.Request) -> Generator[httpx.Request, httpx.Response, None]:
+        """Apply HTTP Basic authentication to the request."""
+        credentials = f"{self.username}:{self.password.get_secret_value()}"
+        encoded = base64.b64encode(credentials.encode()).decode("ascii")
+        request.headers["Authorization"] = f"Basic {encoded}"
+        yield request

--- a/libraries/python/mcp_use/server/__init__.py
+++ b/libraries/python/mcp_use/server/__init__.py
@@ -1,3 +1,4 @@
+from .auth import AccessToken, AuthenticationError, BearerAuthProvider, get_access_token, require_auth
 from .context import Context
 from .middleware import Middleware, TelemetryMiddleware
 from .router import MCPRouter
@@ -13,4 +14,9 @@ __all__ = [
     "Context",
     "Middleware",
     "TelemetryMiddleware",
+    "AccessToken",
+    "AuthenticationError",
+    "BearerAuthProvider",
+    "get_access_token",
+    "require_auth",
 ]

--- a/libraries/python/tests/unit/test_api_key_auth.py
+++ b/libraries/python/tests/unit/test_api_key_auth.py
@@ -1,0 +1,65 @@
+"""Unit tests for APIKeyAuth."""
+
+import httpx
+import pytest
+
+from mcp_use.client.auth import APIKeyAuth
+
+
+class TestAPIKeyAuth:
+    """Tests for APIKeyAuth."""
+
+    def test_creates_with_header(self):
+        auth = APIKeyAuth(key="my-key", header="X-API-Key")
+        assert auth.key.get_secret_value() == "my-key"
+        assert auth.header == "X-API-Key"
+        assert auth.query_param is None
+
+    def test_creates_with_query_param(self):
+        auth = APIKeyAuth(key="my-key", query_param="api_key")
+        assert auth.query_param == "api_key"
+        assert auth.header is None
+
+    def test_is_httpx_auth(self):
+        auth = APIKeyAuth(key="my-key", header="X-API-Key")
+        assert isinstance(auth, httpx.Auth)
+
+    def test_rejects_no_location(self):
+        with pytest.raises(ValueError, match="Either 'header' or 'query_param' must be provided"):
+            APIKeyAuth(key="my-key")
+
+    def test_rejects_both_locations(self):
+        with pytest.raises(ValueError, match="Only one of"):
+            APIKeyAuth(key="my-key", header="X-API-Key", query_param="api_key")
+
+    def test_auth_flow_sets_header(self):
+        auth = APIKeyAuth(key="secret-key", header="X-API-Key")
+        request = httpx.Request("GET", "https://example.com")
+
+        flow = auth.auth_flow(request)
+        modified = next(flow)
+
+        assert modified.headers["X-API-Key"] == "secret-key"
+
+    def test_auth_flow_sets_query_param(self):
+        auth = APIKeyAuth(key="secret-key", query_param="api_key")
+        request = httpx.Request("GET", "https://example.com/path")
+
+        flow = auth.auth_flow(request)
+        modified = next(flow)
+
+        assert "api_key=secret-key" in str(modified.url)
+
+    def test_key_is_secret(self):
+        auth = APIKeyAuth(key="secret", header="X-API-Key")
+        dumped = auth.model_dump()
+        assert dumped["key"] != "secret"
+
+    def test_custom_header_name(self):
+        auth = APIKeyAuth(key="token-123", header="Authorization")
+        request = httpx.Request("GET", "https://example.com")
+
+        flow = auth.auth_flow(request)
+        modified = next(flow)
+
+        assert modified.headers["Authorization"] == "token-123"

--- a/libraries/python/tests/unit/test_basic_auth.py
+++ b/libraries/python/tests/unit/test_basic_auth.py
@@ -1,0 +1,47 @@
+"""Unit tests for BasicAuth."""
+
+import base64
+
+import httpx
+import pytest
+
+from mcp_use.client.auth import BasicAuth
+
+
+class TestBasicAuth:
+    """Tests for BasicAuth."""
+
+    def test_creates_with_credentials(self):
+        auth = BasicAuth(username="user", password="pass")
+        assert auth.username == "user"
+        assert auth.password.get_secret_value() == "pass"
+
+    def test_is_httpx_auth(self):
+        auth = BasicAuth(username="user", password="pass")
+        assert isinstance(auth, httpx.Auth)
+
+    def test_auth_flow_sets_header(self):
+        auth = BasicAuth(username="alice", password="s3cret")
+        request = httpx.Request("GET", "https://example.com")
+
+        flow = auth.auth_flow(request)
+        modified = next(flow)
+
+        expected = base64.b64encode(b"alice:s3cret").decode("ascii")
+        assert modified.headers["Authorization"] == f"Basic {expected}"
+
+    def test_password_is_secret(self):
+        auth = BasicAuth(username="user", password="secret")
+        dumped = auth.model_dump()
+        # SecretStr should mask the value in serialization
+        assert dumped["password"] != "secret"
+
+    def test_special_characters_in_credentials(self):
+        auth = BasicAuth(username="user@domain.com", password="p@ss:word!")
+        request = httpx.Request("GET", "https://example.com")
+
+        flow = auth.auth_flow(request)
+        modified = next(flow)
+
+        expected = base64.b64encode(b"user@domain.com:p@ss:word!").decode("ascii")
+        assert modified.headers["Authorization"] == f"Basic {expected}"


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

- [x] Python

## Changes

Add `BasicAuth` and `APIKeyAuth` typed auth classes to complete the auth strategy coverage from #944. `BearerAuth` and `OAuth` already exist; this adds the two missing types.

## Implementation Details

1. `BasicAuth` — encodes `username:password` as Base64 in the `Authorization` header
2. `APIKeyAuth` — sends an API key via a custom header or query parameter (exactly one must be specified)
3. Both follow the existing `BearerAuth` pattern: `httpx.Auth + pydantic.BaseModel`, `SecretStr` for secrets, `@telemetry` decorator
4. Re-exported `auth` types from `mcp_use.server` to fix imports used by test servers

---

## Example Usage (After)

```python
from mcp_use.client.auth import BasicAuth, APIKeyAuth
from mcp_use.client.connectors.http import HttpConnector

# HTTP Basic
connector = HttpConnector(
    base_url="https://mcp-server.example.com/mcp",
    auth=BasicAuth(username="user", password="pass"),
)

# API key in header
connector = HttpConnector(
    base_url="https://mcp-server.example.com/mcp",
    auth=APIKeyAuth(key="sk-...", header="X-API-Key"),
)

# API key in query parameter
connector = HttpConnector(
    base_url="https://mcp-server.example.com/mcp",
    auth=APIKeyAuth(key="sk-...", query_param="api_key"),
)
```

## Testing

- 14 unit tests added (5 for `BasicAuth`, 9 for `APIKeyAuth`)
- Manually tested against `bearer_auth_server.py` to verify auth headers are applied correctly
- Verified `ruff check` and `ruff format --check` pass

## Backwards Compatibility

Fully backward compatible. Additive only — no existing APIs were changed.

## Related Issues

Closes #944