### PR TITLE
fix(inspector): correct sandbox host for cloud-embedded pages

### DIFF
--- a/libraries/typescript/.changeset/fix-inspector-sandbox-host.md
+++ b/libraries/typescript/.changeset/fix-inspector-sandbox-host.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Fix sandbox host derivation for cloud-embedded inspector pages. Apex hosts (e.g. manufact.com) now correctly resolve to sandbox-inspector.{domain} instead of sandbox-{domain}.

--- a/libraries/typescript/packages/inspector/src/client/components/ui/SandboxedIframe.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ui/SandboxedIframe.tsx
@@ -121,15 +121,17 @@ export const SandboxedIframe = forwardRef<
     ) {
       sandboxHost = currentHost; // Keep same origin
     } else {
-      // Priority 3: Production - use convention: sandbox-{hostname}
-      // Special case: dev.{domain} -> sandbox-inspector.dev.{domain}
-      // (not sandbox-dev.{domain}) so the sandbox subdomain consistently
-      // includes "inspector"
+      // Priority 3: Production - preserve the inspector namespace when deriving
+      // the sandbox host. Cloud embeds run on apex hosts such as manufact.com,
+      // while direct inspector pages run on inspector.{domain}; both should
+      // resolve to sandbox-inspector.{domain}.
       if (currentHost.startsWith("dev.")) {
         const rest = currentHost.slice(4); // "dev.".length
         sandboxHost = `sandbox-inspector.dev.${rest}`;
-      } else {
+      } else if (currentHost.startsWith("inspector.")) {
         sandboxHost = `sandbox-${currentHost}`;
+      } else {
+        sandboxHost = `sandbox-inspector.${currentHost}`;
       }
     }
 


### PR DESCRIPTION
## Summary
- Fix sandbox host derivation for cloud-embedded inspector pages (e.g. apex hosts like `manufact.com`)
- Apex hosts now correctly resolve to `sandbox-inspector.{domain}` instead of `sandbox-{domain}`, preserving the inspector namespace
- Hosts already prefixed with `inspector.` continue to work as before (`sandbox-inspector.{domain}`)

## Test plan
- [ ] Verify sandbox iframe loads correctly on `inspector.{domain}` hosts
- [ ] Verify sandbox iframe loads correctly on apex hosts (cloud embeds)
- [ ] Verify `dev.` prefixed hosts still resolve to `sandbox-inspector.dev.{domain}`