### PR TITLE
chore: add .mcp.json for auto-discovery of docs MCP server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,6 +1,7 @@
 {
   "mcpServers": {
     "mcp-use-docs": {
+      "type": "http",
       "url": "https://manufact.com/docs/mcp"
     }
   }


### PR DESCRIPTION
# Pull Request Description

## Changes

Adds a `.mcp.json` file at the repo root so that Claude Code automatically connects to the mcp-use documentation MCP server (`https://manufact.com/docs/mcp`) when working in this repository.

This gives contributors instant access to the full mcp-use documentation from within their AI coding tools without any manual setup.

## Implementation Details

1. Created `.mcp.json` with the docs MCP server endpoint

## Backwards Compatibility

Fully backward compatible. `.mcp.json` is only read by Claude Code and has no effect on other tooling.