### PR TITLE
refactor(cli, mcp-use): update type generation functions to return success status

### DIFF
--- a/libraries/typescript/.changeset/fix-typegen-zod-v4.md
+++ b/libraries/typescript/.changeset/fix-typegen-zod-v4.md
@@ -1,0 +1,8 @@
+---
+"mcp-use": patch
+"@mcp-use/cli": patch
+---
+
+fix: TypeGen crash with Zod v4 enum schemas
+
+`zod-to-ts` assumed Zod v3 internal structure for `ZodEnum` (`_def.values`), which is `undefined` in Zod v4 where enum entries are stored as `_def.entries`. This caused `Cannot read properties of undefined (reading 'map')` during `mcp-use build` for any project using `z.enum()` with Zod v4. Added v4 fallback paths for `ZodEnum`, `ZodDiscriminatedUnion`, and null guards for `ZodUnion` and `ZodTuple`. Also fixed the CLI reporting success when type generation silently failed.

--- a/libraries/typescript/packages/cli/src/index.ts
+++ b/libraries/typescript/packages/cli/src/index.ts
@@ -326,7 +326,7 @@ async function findServerFile(projectPath: string): Promise<string> {
 async function generateToolRegistryTypesForServer(
   projectPath: string,
   serverFileRelative: string
-): Promise<void> {
+): Promise<boolean> {
   const serverFile = path.join(projectPath, serverFileRelative);
   const serverFileExists = await access(serverFile)
     .then(() => true)
@@ -365,7 +365,11 @@ async function generateToolRegistryTypesForServer(
       throw new Error("generateToolRegistryTypes not found in mcp-use package");
     }
 
-    await generateToolRegistryTypes(server.registrations.tools, projectPath);
+    const success = await generateToolRegistryTypes(
+      server.registrations.tools,
+      projectPath
+    );
+    return success;
   } finally {
     (globalThis as any).__mcpUseHmrMode = previousHmrMode ?? false;
   }
@@ -1127,8 +1131,19 @@ program
 
       if (sourceServerFile) {
         console.log(chalk.gray("Generating tool registry types..."));
-        await generateToolRegistryTypesForServer(projectPath, sourceServerFile);
-        console.log(chalk.green("✓ Tool registry types generated"));
+        const typeGenOk = await generateToolRegistryTypesForServer(
+          projectPath,
+          sourceServerFile
+        );
+        if (typeGenOk) {
+          console.log(chalk.green("✓ Tool registry types generated"));
+        } else {
+          console.log(
+            chalk.yellow(
+              "⚠ Tool registry type generation had errors (non-blocking)"
+            )
+          );
+        }
       }
 
       // Transpile TypeScript with esbuild (fast, no OOM on complex types).
@@ -2253,8 +2268,17 @@ program
 
     try {
       console.log(chalk.blue("Generating tool registry types..."));
-      await generateToolRegistryTypesForServer(projectPath, options.server);
-      console.log(chalk.green("✓ Tool registry types generated successfully"));
+      const success = await generateToolRegistryTypesForServer(
+        projectPath,
+        options.server
+      );
+      if (success) {
+        console.log(
+          chalk.green("✓ Tool registry types generated successfully")
+        );
+      } else {
+        console.log(chalk.yellow("⚠ Tool registry type generation had errors"));
+      }
       process.exit(0);
     } catch (error) {
       console.error(

--- a/libraries/typescript/packages/mcp-use/src/server/utils/tool-registry-generator.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/utils/tool-registry-generator.ts
@@ -20,10 +20,10 @@ const MCP_USE_DIR = ".mcp-use";
 export async function generateToolRegistryTypes(
   registrations: Map<string, { config: ToolDefinition; handler: ToolCallback }>,
   projectRoot: string = process.cwd()
-): Promise<void> {
+): Promise<boolean> {
   // Skip in production
   if (process.env.NODE_ENV === "production") {
-    return;
+    return true;
   }
 
   try {
@@ -96,11 +96,13 @@ export async function generateToolRegistryTypes(
         `[TypeGen] Generated ${TOOL_REGISTRY_FILENAME} with ${sortedTools.length} tool(s)`
       );
     }
+    return true;
   } catch (error) {
     // Don't crash the server if type generation fails
     console.warn(
       "[TypeGen] Failed to generate tool registry types:",
       error instanceof Error ? error.message : String(error)
     );
+    return false;
   }
 }

--- a/libraries/typescript/packages/mcp-use/src/server/utils/zod-to-ts.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/utils/zod-to-ts.ts
@@ -89,7 +89,12 @@ export function zodToTypeString(schema: z.ZodTypeAny): string {
     }
 
     case "ZodEnum": {
-      const values = def.values as string[];
+      const values = Array.isArray(def.values)
+        ? (def.values as string[])
+        : def.entries
+          ? Object.values(def.entries as Record<string, string>)
+          : undefined;
+      if (!values || values.length === 0) return "string";
       return values.map((v) => `"${v.replace(/"/g, '\\"')}"`).join(" | ");
     }
 
@@ -160,15 +165,17 @@ export function zodToTypeString(schema: z.ZodTypeAny): string {
     }
 
     case "ZodUnion": {
-      const options = def.options as z.ZodTypeAny[];
-      const typeStrings = options.map(zodToTypeString);
-      return typeStrings.join(" | ");
+      const options = def.options as z.ZodTypeAny[] | undefined;
+      if (!options) return "unknown";
+      return options.map(zodToTypeString).join(" | ");
     }
 
     case "ZodDiscriminatedUnion": {
-      const options = Array.from(def.optionsMap.values()) as z.ZodTypeAny[];
-      const typeStrings = options.map(zodToTypeString);
-      return typeStrings.join(" | ");
+      const options = def.optionsMap
+        ? (Array.from(def.optionsMap.values()) as z.ZodTypeAny[])
+        : (def.options as z.ZodTypeAny[] | undefined);
+      if (!options) return "unknown";
+      return options.map(zodToTypeString).join(" | ");
     }
 
     case "ZodIntersection": {
@@ -178,9 +185,9 @@ export function zodToTypeString(schema: z.ZodTypeAny): string {
     }
 
     case "ZodTuple": {
-      const items = def.items as z.ZodTypeAny[];
-      const typeStrings = items.map(zodToTypeString);
-      return `[${typeStrings.join(", ")}]`;
+      const items = def.items as z.ZodTypeAny[] | undefined;
+      if (!items) return "unknown[]";
+      return `[${items.map(zodToTypeString).join(", ")}]`;
     }
 
     case "ZodEffects": {


### PR DESCRIPTION
- Modified `generateToolRegistryTypesForServer` and `generateToolRegistryTypes` to return a boolean indicating success or failure instead of void.
- Updated CLI commands to handle and log success or error messages based on the type generation outcome.
- Enhanced error handling in type generation to prevent server crashes while providing feedback on failures.
