### PR TITLE
fix(python): preserve readable MCP tool result content in BaseAdapter

### DIFF
--- a/libraries/python/mcp_use/agents/adapters/base.py
+++ b/libraries/python/mcp_use/agents/adapters/base.py
@@ -7,7 +7,7 @@ This module provides the abstract base class that all MCP tool adapters should i
 from abc import ABC, abstractmethod
 from typing import Any, Generic, TypeVar
 
-from mcp.types import Prompt, Resource, Tool
+from mcp.types import Prompt, Resource, TextContent, Tool
 
 from mcp_use.client.client import MCPClient
 from mcp_use.client.connectors.base import BaseConnector
@@ -57,15 +57,18 @@ class BaseAdapter(Generic[T], ABC):
             A string representation of the result content.
         """
         if getattr(tool_result, "isError", False):
-            # Handle errors first
-            error_content = tool_result.content or "Unknown error"
-            return f"Error: {error_content}"
+            # Handle errors: extract text from content blocks
+            content = getattr(tool_result, "content", None)
+            if content:
+                error_text = self._format_content_list(content)
+                return f"Error: {error_text}" if error_text else "Error: Unknown error"
+            return "Error: Unknown error"
         elif hasattr(tool_result, "contents"):  # For Resources (ReadResourceResult)
             return "\n".join(c.decode() if isinstance(c, bytes) else str(c) for c in tool_result.contents)
         elif hasattr(tool_result, "messages"):  # For Prompts (GetPromptResult)
             return "\n".join(str(s) for s in tool_result.messages)
         elif hasattr(tool_result, "content"):  # For Tools (CallToolResult)
-            return str(tool_result.content)
+            return self._format_content_list(tool_result.content)
         else:
             # Fallback for unexpected types
             return str(tool_result)
@@ -341,3 +344,31 @@ class BaseAdapter(Generic[T], ABC):
                 logger.error(f"Error initializing connector: {e}")
                 return False
         return True
+
+    def _format_content_item(self, item: Any) -> str:
+        """Format a single MCP content item as a readable string."""
+        if isinstance(item, TextContent):
+            return item.text
+
+        mime_type = getattr(item, "mimeType", None)
+        if mime_type:
+            return f"[{mime_type} content]"
+
+        text = getattr(item, "text", None)
+        if text:
+            return text
+
+        return str(item)
+
+    def _format_content_list(self, content: list[Any]) -> str:
+        """Format a list of MCP content items as a readable string.
+
+        Args:
+            content: A list of MCP content items.
+
+        Returns:
+            A newline-joined string of formatted content.
+        """
+        if not content:
+            return ""
+        return "\n".join(self._format_content_item(item) for item in content)

--- a/libraries/python/tests/unit/test_base_adapter.py
+++ b/libraries/python/tests/unit/test_base_adapter.py
@@ -1,0 +1,130 @@
+"""Unit tests for BaseAdapter.parse_result() content handling."""
+
+from mcp.types import (
+    AudioContent,
+    CallToolResult,
+    ImageContent,
+    TextContent,
+)
+
+
+class TestBaseAdapterParseResult:
+    """Tests for BaseAdapter.parse_result()."""
+
+    def _create_adapter(self):
+        """Create a minimal concrete adapter for testing parse_result()."""
+        from mcp_use.agents.adapters.base import BaseAdapter
+
+        class MinimalAdapter(BaseAdapter[dict]):
+            framework = "test"
+
+            def _convert_tool(self, mcp_tool, connector):
+                return None
+
+            def _convert_resource(self, mcp_resource, connector):
+                return None
+
+            def _convert_prompt(self, mcp_prompt, connector):
+                return None
+
+        return MinimalAdapter()
+
+    def test_single_text_content_returns_plain_string(self):
+        """Single TextContent should return the plain text, not a repr string."""
+        adapter = self._create_adapter()
+        result = CallToolResult(
+            content=[TextContent(type="text", text="hello world")],
+        )
+
+        parsed = adapter.parse_result(result)
+
+        assert parsed == "hello world"
+        assert "TextContent" not in parsed
+
+    def test_multiple_text_content_returns_newline_joined_text(self):
+        """Multiple TextContent items should return newline-joined text."""
+        adapter = self._create_adapter()
+        result = CallToolResult(
+            content=[
+                TextContent(type="text", text="first line"),
+                TextContent(type="text", text="second line"),
+            ],
+        )
+
+        parsed = adapter.parse_result(result)
+
+        assert parsed == "first line\nsecond line"
+        assert "TextContent" not in parsed
+
+    def test_mixed_content_text_and_image_returns_readable_output(self):
+        """Mixed content with text and image should return text plus readable placeholder."""
+        adapter = self._create_adapter()
+        result = CallToolResult(
+            content=[
+                TextContent(type="text", text="Here is the image:"),
+                ImageContent(type="image", data="aGVsbG8=", mimeType="image/png"),
+            ],
+        )
+
+        parsed = adapter.parse_result(result)
+
+        assert "Here is the image:" in parsed
+        assert "TextContent(" not in parsed
+        assert "ImageContent(" not in parsed
+        # Should have some indication of the image
+        assert "image" in parsed.lower() or "png" in parsed.lower()
+
+    def test_image_only_content_returns_readable_placeholder(self):
+        """Image-only content should return a readable placeholder, not repr string."""
+        adapter = self._create_adapter()
+        result = CallToolResult(
+            content=[
+                ImageContent(type="image", data="aGVsbG8=", mimeType="image/png"),
+            ],
+        )
+
+        parsed = adapter.parse_result(result)
+
+        assert "ImageContent(" not in parsed
+        # Should indicate it's an image with mime type info
+        assert "image" in parsed.lower() or "png" in parsed.lower()
+
+    def test_audio_content_returns_readable_placeholder(self):
+        """Audio content should return a readable placeholder, not repr string."""
+        adapter = self._create_adapter()
+        result = CallToolResult(
+            content=[
+                AudioContent(type="audio", data="d29ybGQ=", mimeType="audio/mpeg"),
+            ],
+        )
+
+        parsed = adapter.parse_result(result)
+
+        assert "AudioContent(" not in parsed
+        # Should indicate it's audio with mime type info
+        assert "audio" in parsed.lower() or "mpeg" in parsed.lower()
+
+    def test_is_error_with_text_content_extracts_actual_text(self):
+        """isError=True with TextContent should return 'Error: <actual text>'."""
+        adapter = self._create_adapter()
+        result = CallToolResult(
+            content=[TextContent(type="text", text="Something went wrong")],
+            isError=True,
+        )
+
+        parsed = adapter.parse_result(result)
+
+        assert parsed == "Error: Something went wrong"
+        assert "TextContent(" not in parsed
+        assert "[TextContent" not in parsed
+
+    def test_empty_content_returns_empty_string(self):
+        """Empty content list should return empty string."""
+        adapter = self._create_adapter()
+        result = CallToolResult(
+            content=[],
+        )
+
+        parsed = adapter.parse_result(result)
+
+        assert parsed == ""


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

Check all that apply:
- [ ] TypeScript
- [x] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

This PR fixes lossy stringification in `BaseAdapter.parse_result()` for non-LangChain adapter and example flows.

Previously, tool results with MCP content blocks were converted with `str(tool_result.content)`, which produced Python repr strings such as `"[TextContent(...)]"` instead of readable content. This PR extracts text content properly, preserves readable placeholders for non-text content, and adds focused unit tests covering the intended behavior.

## Implementation Details

1. Updated `libraries/python/mcp_use/agents/adapters/base.py` so `BaseAdapter.parse_result()` no longer calls `str(tool_result.content)` for tool results.
2. Added private helper methods to format MCP content items and content lists into readable string output:
   - `TextContent` returns its text directly
   - content items with a `mimeType` render as readable placeholders like `[image/png content]`
   - multiple text blocks are joined with newlines
   - empty content returns an empty string
3. Updated the `isError=True` path to extract actual text from MCP content before prefixing with `"Error: "`, instead of stringifying the raw content list.
4. Added `libraries/python/tests/unit/test_base_adapter.py` with focused unit coverage for:
   - single text content
   - multiple text blocks
   - mixed text and image content
   - image-only content
   - audio-only content
   - error results with text content
   - empty content
5. No dependencies were added or modified.

---

## TypeScript Checklist

> Complete this section if your PR includes TypeScript changes

### Packages Modified

Check all packages that were modified:
- [ ] `docs`
- [ ] `tests`
- [ ] `cli`
- [ ] `create-mcp-use-app`
- [ ] `mcp-use` (server)
- [ ] `mcp-use` (client)
- [ ] `inspector`

### Pre-commit Checklist

Ensure all of the following have been completed:
- [ ] Ran `pnpm lint:fix` to auto-fix linting issues
- [ ] Ran `pnpm format` to format code with Prettier
- [ ] Ran `pnpm build` and build succeeds without errors
- [ ] Ran `pnpm changeset` to create a changeset (if this PR includes user-facing changes)
- [ ] Added or updated tests if needed
- [ ] Updated documentation in `docs/` folder if needed

---

## Python Checklist

> Complete this section if your PR includes Python changes

### Pre-commit Checklist

Ensure all of the following have been completed:
- [x] Code formatted with `ruff format`
- [x] Linting passes with `ruff check`
- [x] Added or updated tests if needed
- [ ] Updated documentation if needed

---

## Example Usage (Before)

```python
tool_result = CallToolResult(
    content=[TextContent(type="text", text="hello world")]
)

parsed = adapter.parse_result(tool_result)
print(parsed)

# Before:
# A Python repr-style string of the content list, for example:
# "[TextContent(type='text', text='hello world', ...)]"
````

## Example Usage (After)

```python
tool_result = CallToolResult(
    content=[TextContent(type="text", text="hello world")]
)

parsed = adapter.parse_result(tool_result)
print(parsed)

# After:
# "hello world"
```

## Documentation Updates

* No documentation files were updated
* This PR is a focused Python behavior and test changes

## Testing

Describe how you tested these changes:

* Added unit tests in `libraries/python/tests/unit/test_base_adapter.py`
* Verified targeted unit tests pass:

  * `pytest tests/unit/test_base_adapter.py -v`
  * `pytest tests/unit/test_langchain_adapter.py -v`
* Ran lint/format checks on touched Python files:

  * `ruff check`
  * `ruff format`
* Edge cases covered in tests:

  * empty content
  * multiple text blocks
  * mixed content with text and image
  * image-only and audio-only content
  * `isError=True` with text content

## Backwards Compatibility

These changes are backwards compatible.

`BaseAdapter.parse_result()` still returns `str`, so callers expecting string output do not need to change. The improvement is that non-LangChain flows now receive readable string output instead of Python repr strings when tool results contain MCP content blocks.

## Related Issues

Refs: #1197
