### PR TITLE
feat(inspector): implement tunnel management functionality

### DIFF
--- a/.github/workflows/inspector-e2e.yml
+++ b/.github/workflows/inspector-e2e.yml
@@ -109,7 +109,9 @@ jobs:
   inspector-e2e-tunnel:
     name: "Inspector E2E (tunnel)"
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || github.head_ref == 'canary'
+    # Disabled: set to false to skip without deleting the workflow. Re-enable by restoring:
+    # if: github.event_name == 'workflow_dispatch' || github.head_ref == 'canary'
+    if: false
     defaults:
       run:
         working-directory: libraries/typescript

--- a/libraries/typescript/.changeset/shy-webs-share.md
+++ b/libraries/typescript/.changeset/shy-webs-share.md
@@ -1,0 +1,7 @@
+---
+"@mcp-use/inspector": minor
+"mcp-use": minor
+"@mcp-use/cli": minor
+---
+
+feat(tunnel): added ability to start/stop the mcp-use dev tunnel from the inspector

--- a/libraries/typescript/packages/cli/src/index.ts
+++ b/libraries/typescript/packages/cli/src/index.ts
@@ -17,7 +17,6 @@ import { deployCommand } from "./commands/deploy.js";
 import { createDeploymentsCommand } from "./commands/deployments.js";
 import { createSkillsCommand } from "./commands/skills.js";
 import { notifyIfUpdateAvailable } from "./utils/update-check.js";
-
 const program = new Command();
 
 const packageContent = readFileSync(
@@ -230,12 +229,11 @@ async function startTunnel(
 
     proc.stdout?.on("data", (data) => {
       const text = data.toString();
-      // Filter out shutdown messages from tunnel package
       const isShutdownMessage =
         text.includes("Shutting down") || text.includes("🛑");
+      const isErrorMessage = text.includes("✖") || text.includes("Error:");
 
-      // Suppress tunnel output during shutdown or if it's a shutdown message
-      if (!isShuttingDown && !isShutdownMessage) {
+      if (!isShuttingDown && !isShutdownMessage && !isErrorMessage) {
         process.stdout.write(text);
       }
 
@@ -1294,6 +1292,7 @@ program
   .option("--tunnel", "Expose server through a tunnel")
   .action(async (options) => {
     try {
+      process.env.MCP_USE_CLI_DEV = "1";
       const projectPath = path.resolve(options.path);
       let port = parseInt(options.port, 10);
       const host = options.host;
@@ -1330,12 +1329,35 @@ program
               console.log(
                 chalk.gray(`Found existing subdomain: ${existingSubdomain}`)
               );
+              const apiBase =
+                process.env.MCP_USE_TUNNEL_API || "https://local.mcp-use.run";
+              try {
+                await fetch(`${apiBase}/api/tunnels/${existingSubdomain}`, {
+                  method: "DELETE",
+                });
+              } catch {
+                // Best-effort cleanup; ignore DELETE failures
+              }
             }
           } catch {
             // Manifest doesn't exist or is invalid, that's okay
           }
 
-          const tunnelInfo = await startTunnel(port, existingSubdomain);
+          let tunnelInfo: Awaited<ReturnType<typeof startTunnel>>;
+          try {
+            tunnelInfo = await startTunnel(port, existingSubdomain);
+          } catch (e) {
+            if (existingSubdomain) {
+              console.log(
+                chalk.yellow(
+                  `Subdomain "${existingSubdomain}" unavailable, requesting a new one…`
+                )
+              );
+              tunnelInfo = await startTunnel(port);
+            } else {
+              throw e;
+            }
+          }
           tunnelUrl = tunnelInfo.url;
           tunnelProcess = tunnelInfo.process;
           tunnelSubdomain = tunnelInfo.subdomain;
@@ -1385,7 +1407,6 @@ program
       } else if (!process.env.MCP_URL) {
         process.env.MCP_URL = mcpUrl;
       }
-
       if (!useHmr) {
         // Fallback: Use tsx watch (restarts process on changes)
         console.log(chalk.gray("HMR disabled, using tsx watch (full restart)"));
@@ -1709,7 +1730,7 @@ program
       }
 
       // Watch for file changes - watch .ts/.tsx files in project directory
-      const watcher = chokidar.watch(".", {
+      let watcher = chokidar.watch(".", {
         cwd: projectPath,
         ignored: (path: string, stats?: any) => {
           // Normalize path separators for cross-platform compatibility
@@ -1776,7 +1797,7 @@ program
       let reloadTimeout: NodeJS.Timeout | null = null;
       let isReloading = false;
 
-      watcher.on("change", async (filePath: string) => {
+      const hmrOnChange = async (filePath: string) => {
         // Only handle .ts and .tsx files (not .d.ts)
         if (
           (!filePath.endsWith(".ts") && !filePath.endsWith(".tsx")) ||
@@ -1885,7 +1906,208 @@ program
 
           isReloading = false;
         }, 100);
-      });
+      };
+      watcher.on("change", hmrOnChange);
+
+      // Expose project path so tunnel.ts can read the manifest for subdomain reuse
+      process.env.MCP_USE_PROJECT_PATH = projectPath;
+
+      // Expose in-process restart hook for the inspector tunnel toggle.
+      // Tears down the running server and re-sets up everything as if
+      // `mcp-use dev` was called with or without --tunnel.
+      (globalThis as any).__mcpUseDevRestart = async (withTunnel: boolean) => {
+        console.log(
+          chalk.yellow(
+            `\n[DEV] Restarting ${withTunnel ? "with" : "without"} tunnel…`
+          )
+        );
+
+        // Suppress noise from in-flight requests terminated during teardown
+        const origStderrWrite = process.stderr.write.bind(process.stderr);
+        const stderrFilter = (chunk: any, ...args: any[]) => {
+          const str =
+            typeof chunk === "string" ? chunk : (chunk?.toString?.() ?? "");
+          if (
+            str.includes("TypeError: terminated") ||
+            str.includes("SocketError") ||
+            str.includes("UND_ERR_SOCKET")
+          ) {
+            return true;
+          }
+          return origStderrWrite(chunk, ...args);
+        };
+        process.stderr.write = stderrFilter as typeof process.stderr.write;
+
+        // 1. Tear down
+        watcher.close();
+        if (tunnelProcess && typeof tunnelProcess.kill === "function") {
+          if (typeof (tunnelProcess as any).markShutdown === "function") {
+            (tunnelProcess as any).markShutdown();
+          }
+          const dyingProc = tunnelProcess;
+          tunnelProcess = undefined;
+          dyingProc.kill("SIGINT");
+          await new Promise<void>((resolve) => {
+            const timeout = setTimeout(() => {
+              try {
+                dyingProc.kill("SIGKILL");
+              } catch {
+                /* ignore */
+              }
+              resolve();
+            }, 5000);
+            dyingProc.on("exit", () => {
+              clearTimeout(timeout);
+              resolve();
+            });
+          });
+        }
+        if (tunnelSubdomain) {
+          const apiBase =
+            process.env.MCP_USE_API || "https://local.mcp-use.run";
+          try {
+            await fetch(`${apiBase}/api/tunnels/${tunnelSubdomain}`, {
+              method: "DELETE",
+            });
+          } catch {
+            /* ignore */
+          }
+          tunnelSubdomain = undefined;
+        }
+        if (runningServer && typeof runningServer.forceClose === "function") {
+          await runningServer.forceClose();
+        } else if (runningServer && typeof runningServer.close === "function") {
+          await runningServer.close();
+        }
+
+        // 2. Start tunnel if requested
+        tunnelUrl = undefined;
+        if (withTunnel) {
+          const manifestPath = path.join(projectPath, "dist", "mcp-use.json");
+          let existingSubdomain: string | undefined;
+          try {
+            const manifestContent = await readFile(manifestPath, "utf-8");
+            const manifest = JSON.parse(manifestContent);
+            existingSubdomain = manifest.tunnel?.subdomain;
+            if (existingSubdomain) {
+              const apiBase =
+                process.env.MCP_USE_API || "https://local.mcp-use.run";
+              try {
+                await fetch(`${apiBase}/api/tunnels/${existingSubdomain}`, {
+                  method: "DELETE",
+                });
+              } catch {
+                /* ignore */
+              }
+            }
+          } catch {
+            /* ignore */
+          }
+          let tunnelInfo: Awaited<ReturnType<typeof startTunnel>>;
+          try {
+            tunnelInfo = await startTunnel(port, existingSubdomain);
+          } catch {
+            if (existingSubdomain) {
+              console.log(
+                chalk.yellow(
+                  `Subdomain "${existingSubdomain}" unavailable, requesting a new one…`
+                )
+              );
+              tunnelInfo = await startTunnel(port);
+            } else {
+              throw new Error("Failed to start tunnel");
+            }
+          }
+          tunnelUrl = tunnelInfo.url;
+          tunnelProcess = tunnelInfo.process;
+          tunnelSubdomain = tunnelInfo.subdomain;
+          process.env.MCP_URL = tunnelUrl;
+
+          // Persist subdomain
+          try {
+            const mPath = path.join(projectPath, "dist", "mcp-use.json");
+            let manifest: any = {};
+            try {
+              manifest = JSON.parse(await readFile(mPath, "utf-8"));
+            } catch {
+              /* ignore */
+            }
+            if (!manifest.tunnel) manifest.tunnel = {};
+            manifest.tunnel.subdomain = tunnelSubdomain;
+            await mkdir(path.dirname(mPath), { recursive: true });
+            await writeFile(mPath, JSON.stringify(manifest, null, 2), "utf-8");
+          } catch {
+            /* ignore */
+          }
+        } else {
+          process.env.MCP_URL = `http://${host}:${port}`;
+        }
+
+        // 3. Re-import server module (HMR mode stays true so user's listen() is a no-op)
+        console.log(chalk.gray(`Loading server from ${serverFile}...`));
+        runningServer = await importServerModule();
+        if (!runningServer) {
+          console.error(
+            chalk.red("Error: Could not find MCPServer instance after restart.")
+          );
+          return;
+        }
+        // Temporarily disable HMR flag so our listen() actually starts the server
+        (globalThis as any).__mcpUseHmrMode = false;
+        await runningServer.listen(port);
+        (globalThis as any).__mcpUseHmrMode = true;
+
+        const browserHost = normalizeBrowserHost(host);
+        const mcpEndpoint = `http://${browserHost}:${port}/mcp`;
+        const autoConnectEndpoint = tunnelUrl
+          ? `${tunnelUrl}/mcp`
+          : mcpEndpoint;
+        console.log(chalk.green.bold(`✓ Restarted`));
+        console.log(chalk.whiteBright(`MCP:      ${mcpEndpoint}`));
+        if (tunnelUrl) {
+          console.log(chalk.whiteBright(`Tunnel:   ${tunnelUrl}/mcp`));
+        }
+        console.log(
+          chalk.whiteBright(
+            `Inspector: http://${browserHost}:${port}/inspector?autoConnect=${encodeURIComponent(autoConnectEndpoint)}`
+          )
+        );
+        console.log(chalk.gray(`Watching for changes...\n`));
+
+        // 4. Re-create watcher (reuses same config)
+        watcher = chokidar.watch(".", {
+          cwd: projectPath,
+          ignored: (p: string, stats?: any) => {
+            const np = p.replace(/\\/g, "/");
+            if (/(^|\/)\.[^/]/.test(np)) return true;
+            if (np.includes("/node_modules/") || np.endsWith("/node_modules"))
+              return true;
+            if (np.includes("/dist/") || np.endsWith("/dist")) return true;
+            if (np.includes("/resources/") || np.endsWith("/resources"))
+              return true;
+            if (stats?.isFile() && np.endsWith(".d.ts")) return true;
+            return false;
+          },
+          persistent: true,
+          ignoreInitial: true,
+          depth: 3,
+        });
+        watcher
+          .on("ready", () => console.log(chalk.gray(`[HMR] Watcher ready`)))
+          .on("error", (err: unknown) =>
+            console.error(
+              chalk.red(
+                `[HMR] Watcher error: ${err instanceof Error ? err.message : String(err)}`
+              )
+            )
+          )
+          .on("change", hmrOnChange);
+
+        // Restore stderr once the new server is stable
+        setTimeout(() => {
+          process.stderr.write = origStderrWrite;
+        }, 2000);
+      };
 
       // Handle cleanup
       let hmrCleanupInProgress = false;
@@ -1977,6 +2199,16 @@ program
               console.log(
                 chalk.gray(`Found existing subdomain: ${existingSubdomain}`)
               );
+              // Release the stale subdomain so the first attempt can reclaim it
+              const apiBase =
+                process.env.MCP_USE_API || "https://local.mcp-use.run";
+              try {
+                await fetch(`${apiBase}/api/tunnels/${existingSubdomain}`, {
+                  method: "DELETE",
+                });
+              } catch {
+                // Best-effort cleanup; ignore DELETE failures
+              }
             }
           } catch (error) {
             // Manifest doesn't exist or is invalid, that's okay
@@ -1987,7 +2219,21 @@ program
             );
           }
 
-          const tunnelInfo = await startTunnel(port, existingSubdomain);
+          let tunnelInfo: Awaited<ReturnType<typeof startTunnel>>;
+          try {
+            tunnelInfo = await startTunnel(port, existingSubdomain);
+          } catch (e) {
+            if (existingSubdomain) {
+              console.log(
+                chalk.yellow(
+                  `Subdomain "${existingSubdomain}" unavailable, requesting a new one…`
+                )
+              );
+              tunnelInfo = await startTunnel(port);
+            } else {
+              throw e;
+            }
+          }
           mcpUrl = tunnelInfo.url;
           tunnelProcess = tunnelInfo.process;
           const subdomain = tunnelInfo.subdomain;

--- a/libraries/typescript/packages/inspector/src/client/components/LayoutHeader.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/LayoutHeader.tsx
@@ -15,6 +15,7 @@ import type { TabType } from "@/client/context/InspectorContext";
 import { useInspector } from "@/client/context/InspectorContext";
 import { cn } from "@/client/lib/utils";
 import {
+  ArrowUpRight,
   Bell,
   Check,
   CheckSquare,
@@ -24,15 +25,19 @@ import {
   Command,
   Copy,
   FolderOpen,
+  ChevronsLeftRightEllipsis,
   Hash,
+  Loader2,
   MessageCircle,
   MessageSquare,
   Plus,
+  Square,
   Wrench,
-  Zap,
 } from "lucide-react";
+import { INSPECTOR_RECONNECT_STORAGE_KEY } from "@/client/hooks/useAutoConnect";
 import type { McpServer } from "mcp-use/react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+
 import { toast } from "sonner";
 import { copyToClipboard } from "@/client/utils/clipboard";
 import { AddToClientDropdown } from "./AddToClientDropdown";
@@ -126,6 +131,378 @@ function CollapseButton({
   );
 }
 
+function isLocalhostServerUrl(serverUrl: string): boolean {
+  try {
+    const u = new URL(serverUrl);
+    const h = u.hostname.toLowerCase();
+    return (
+      h === "localhost" || h === "127.0.0.1" || h === "::1" || h === "0.0.0.0"
+    );
+  } catch {
+    return false;
+  }
+}
+
+function isMcpUseTunnelUrl(serverUrl: string): boolean {
+  try {
+    return new URL(serverUrl).hostname.endsWith(".mcp-use.run");
+  } catch {
+    return false;
+  }
+}
+
+function tunnelOriginFromMcpUrl(mcpUrl: string | null): string | null {
+  if (!mcpUrl) return null;
+  try {
+    const u = new URL(mcpUrl);
+    if (u.protocol === "https:") {
+      return u.origin;
+    }
+  } catch {
+    /* ignore */
+  }
+  return null;
+}
+
+const TUNNEL_PHASE = {
+  starting: "Starting tunnel…",
+  stopping: "Stopping tunnel…",
+  reconnecting: "Reconnecting…",
+} as const;
+
+function TunnelBadge({
+  tunnelUrl,
+  isTunnelStarting,
+  setTunnelUrl,
+  setIsTunnelStarting,
+  copied,
+  setCopied,
+  handleCopy,
+}: {
+  tunnelUrl: string | null;
+  isTunnelStarting: boolean;
+  setTunnelUrl: (url: string | null) => void;
+  setIsTunnelStarting: (starting: boolean) => void;
+  copied: boolean;
+  setCopied: (copied: boolean) => void;
+  handleCopy: () => void;
+}) {
+  const [popoverOpen, setPopoverOpen] = useState(false);
+  const [devFromCli, setDevFromCli] = useState<boolean | null>(null);
+  const [waitTicks, setWaitTicks] = useState(0);
+  const [_, setTunnelPhaseMessage] = useState<string>(TUNNEL_PHASE.starting);
+
+  useEffect(() => {
+    if (!isTunnelStarting) {
+      setWaitTicks(20);
+      return;
+    }
+    setWaitTicks(20);
+    const id = setInterval(
+      () => setWaitTicks((t) => (t > 0 ? t - 1 : 0)),
+      1000
+    );
+    return () => clearInterval(id);
+  }, [isTunnelStarting]);
+
+  useEffect(() => {
+    if (!tunnelUrl) return;
+    setPopoverOpen(true);
+    // Clean up the query param if present
+    const p = new URLSearchParams(window.location.search);
+    if (p.has("openTunnelPopover")) {
+      p.delete("openTunnelPopover");
+      const qs = p.toString();
+      window.history.replaceState(
+        {},
+        "",
+        `${window.location.pathname}${qs ? `?${qs}` : ""}`
+      );
+    }
+  }, [tunnelUrl]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/inspector/api/dev/info");
+        if (!res.ok || cancelled) return;
+        const info = (await res.json()) as {
+          fromCli?: boolean;
+          tunnelUrl?: string | null;
+          mcpUrl?: string | null;
+        };
+        if (cancelled) return;
+        setDevFromCli(!!info.fromCli);
+        if (info.tunnelUrl) {
+          setTunnelUrl(new URL(info.tunnelUrl).origin);
+        } else {
+          const origin = tunnelOriginFromMcpUrl(info.mcpUrl ?? null);
+          if (origin) setTunnelUrl(origin);
+        }
+      } catch {
+        if (!cancelled) setDevFromCli(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [setTunnelUrl]);
+
+  /**
+   * Poll /inspector/api/dev/info until the new server is ready,
+   * then redirect the inspector to reconnect via sessionStorage.
+   */
+  const pollAndReconnect = async (expectTunnel: boolean) => {
+    const port = window.location.port || "3000";
+    const infoUrl = `http://localhost:${port}/inspector/api/dev/info`;
+    const deadline = Date.now() + 90_000;
+
+    setTunnelPhaseMessage(
+      expectTunnel ? "Restarting with tunnel…" : "Restarting…"
+    );
+
+    // Wait a moment for the old process to exit
+    await new Promise((r) => setTimeout(r, 1500));
+
+    while (Date.now() < deadline) {
+      try {
+        const r = await fetch(infoUrl, { cache: "no-store" });
+        if (r.ok) {
+          const info = (await r.json()) as {
+            mcpUrl?: string;
+            tunnelUrl?: string;
+          };
+          const hasTunnel = !!info.tunnelUrl;
+          if (hasTunnel === expectTunnel) {
+            const baseUrl =
+              info.tunnelUrl || info.mcpUrl || `http://localhost:${port}`;
+            const mcpEndpoint = baseUrl.replace(/\/+$/, "") + "/mcp";
+
+            if (info.tunnelUrl) {
+              setTunnelUrl(new URL(info.tunnelUrl).origin);
+            } else {
+              setTunnelUrl(null);
+            }
+
+            sessionStorage.setItem(
+              INSPECTOR_RECONNECT_STORAGE_KEY,
+              JSON.stringify({
+                url: mcpEndpoint,
+                name: "Local MCP Server",
+                transportType: "http",
+                connectionType: "Direct",
+              })
+            );
+            toast.success(
+              expectTunnel
+                ? "Tunnel ready — reconnecting…"
+                : "Tunnel stopped — reconnecting…"
+            );
+            setTunnelPhaseMessage(TUNNEL_PHASE.reconnecting);
+
+            const u = new URL(window.location.href);
+            u.searchParams.delete("server");
+            u.searchParams.delete("tunnelUrl");
+            u.searchParams.delete("autoConnect");
+            if (expectTunnel) u.searchParams.set("openTunnelPopover", "1");
+            window.location.assign(u.toString());
+            return;
+          }
+        }
+      } catch {
+        // Server not up yet — keep polling
+      }
+      await new Promise((r) => setTimeout(r, 1500));
+    }
+
+    toast.error("Timeout waiting for server to restart");
+    setIsTunnelStarting(false);
+  };
+
+  const handleStartTunnel = async () => {
+    if (devFromCli === false) {
+      toast.error(
+        "Start Tunnel requires `mcp-use dev` from your project directory."
+      );
+      return;
+    }
+    setTunnelPhaseMessage(TUNNEL_PHASE.starting);
+    setIsTunnelStarting(true);
+    try {
+      const res = await fetch("/inspector/api/dev/start-tunnel", {
+        method: "POST",
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        toast.error((data as any).error || "Failed to start tunnel");
+        setIsTunnelStarting(false);
+        return;
+      }
+      // Server is restarting — poll until the new instance with tunnel is up
+      await pollAndReconnect(true);
+    } catch {
+      toast.error("Failed to start tunnel");
+      setIsTunnelStarting(false);
+    }
+  };
+
+  const handleStopTunnel = async () => {
+    setTunnelPhaseMessage(TUNNEL_PHASE.stopping);
+    setIsTunnelStarting(true);
+    try {
+      const res = await fetch("/inspector/api/dev/stop-tunnel", {
+        method: "POST",
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        toast.error((data as any).error || "Failed to stop tunnel");
+        setIsTunnelStarting(false);
+        return;
+      }
+      setCopied(false);
+      setPopoverOpen(false);
+      // Server is restarting — poll until the new instance without tunnel is up
+      await pollAndReconnect(false);
+    } catch {
+      toast.error("Failed to stop tunnel");
+      setIsTunnelStarting(false);
+    }
+  };
+
+  if (isTunnelStarting) {
+    return (
+      <button
+        disabled
+        className="flex items-center gap-2 h-9 px-3 bg-zinc-100 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded-full opacity-75 cursor-wait"
+      >
+        <Loader2 className="size-4 text-zinc-500 dark:text-zinc-400 animate-spin" />
+        <span className="text-sm font-medium text-zinc-600 dark:text-zinc-300 hidden lg:inline">
+          Start Tunnel <span className="tabular-nums">{waitTicks}s</span>
+        </span>
+      </button>
+    );
+  }
+
+  if (!tunnelUrl) {
+    const canStart = devFromCli === true;
+    const loadingDev = devFromCli === null;
+    return (
+      <button
+        type="button"
+        onClick={handleStartTunnel}
+        disabled={!canStart || loadingDev}
+        title={
+          devFromCli === false
+            ? "Run `mcp-use dev` from your project to enable tunneling."
+            : loadingDev
+              ? "Checking dev server…"
+              : undefined
+        }
+        className={cn(
+          "flex items-center gap-2 h-9 px-3 border rounded-full transition-colors",
+          canStart && !loadingDev
+            ? "bg-zinc-100 dark:bg-zinc-800 border-zinc-200 dark:border-zinc-700 hover:bg-zinc-200 dark:hover:bg-zinc-700 cursor-pointer"
+            : "bg-zinc-100/60 dark:bg-zinc-800/60 border-zinc-200 dark:border-zinc-700 cursor-not-allowed opacity-70"
+        )}
+      >
+        {loadingDev ? (
+          <Loader2 className="size-4 text-zinc-500 dark:text-zinc-400 animate-spin" />
+        ) : (
+          <ChevronsLeftRightEllipsis className="size-4 text-zinc-500 dark:text-zinc-400" />
+        )}
+        <span className="text-sm font-medium text-zinc-600 dark:text-zinc-300 hidden lg:inline">
+          Start Tunnel
+        </span>
+      </button>
+    );
+  }
+
+  return (
+    <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
+      <PopoverTrigger asChild>
+        <button className="flex items-center gap-2 h-9 px-3 bg-gradient-to-r from-purple-500/10 to-pink-500/10 dark:from-purple-500/20 dark:to-pink-500/20 border border-purple-500/30 dark:border-purple-500/40 rounded-full hover:from-purple-500/20 hover:to-pink-500/20 dark:hover:from-purple-500/30 dark:hover:to-pink-500/30 transition-colors cursor-pointer">
+          <ChevronsLeftRightEllipsis className="size-4 text-purple-600 dark:text-purple-400" />
+          <span className="text-sm font-medium text-purple-700 dark:text-purple-300 hidden lg:inline">
+            Tunnel
+          </span>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-[calc(100vw-2rem)] sm:w-96 overflow-hidden"
+        align="end"
+      >
+        <div className="space-y-4">
+          <div>
+            <div className="flex items-center justify-between mb-3">
+              <h4 className="font-semibold text-sm">Tunnel URL</h4>
+              <a
+                href="https://manufact.com/docs/tunneling"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+              >
+                Docs
+                <ArrowUpRight className="size-3" />
+              </a>
+            </div>
+            <button
+              onClick={handleCopy}
+              className="-mx-4 px-4 py-3 bg-muted hover:bg-accent transition-colors cursor-pointer flex items-center gap-3 w-[calc(100%+2rem)]"
+            >
+              <code className="flex-1 text-[10px] font-mono truncate text-left">
+                {tunnelUrl}/mcp
+              </code>
+              {copied ? (
+                <Check className="size-3.5 text-green-600 shrink-0" />
+              ) : (
+                <Copy className="size-3.5 shrink-0 text-muted-foreground" />
+              )}
+            </button>
+          </div>
+
+          <div>
+            <h5 className="font-semibold text-sm mb-2">Use in ChatGPT</h5>
+            <ol className="space-y-2 text-xs text-muted-foreground">
+              <li className="flex gap-2">
+                <span className="font-semibold text-foreground">1.</span>
+                <span>
+                  Enable{" "}
+                  <span className="font-medium text-foreground">dev mode</span>{" "}
+                  from settings
+                </span>
+              </li>
+              <li className="flex gap-2">
+                <span className="font-semibold text-foreground">2.</span>
+                <span>
+                  In{" "}
+                  <span className="font-medium text-foreground">
+                    App & Connectors
+                  </span>{" "}
+                  click on{" "}
+                  <span className="font-medium text-foreground">create</span>
+                </span>
+              </li>
+              <li className="flex gap-2">
+                <span className="font-semibold text-foreground">3.</span>
+                <span>Use the tunnel URL in the input</span>
+              </li>
+            </ol>
+          </div>
+
+          <button
+            onClick={handleStopTunnel}
+            className="flex items-center gap-1.5 text-xs text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 transition-colors cursor-pointer"
+          >
+            <Square className="size-3 fill-current" />
+            Stop Tunnel
+          </button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
 /**
  * Renders the application header with server selector, tabs, tunnel badge, and global actions.
  *
@@ -154,8 +531,18 @@ export function LayoutHeader({
   onOpenConnectionOptions,
   embedded = false,
 }: LayoutHeaderProps) {
-  const { tunnelUrl, embeddedConfig } = useInspector();
-  const showTunnelBadge = selectedServer && tunnelUrl;
+  const {
+    tunnelUrl,
+    isTunnelStarting,
+    setTunnelUrl,
+    setIsTunnelStarting,
+    embeddedConfig,
+  } = useInspector();
+  const showTunnelBadge =
+    !!selectedServer &&
+    (isLocalhostServerUrl(selectedServer.url) ||
+      isMcpUseTunnelUrl(selectedServer.url) ||
+      !!tunnelUrl);
   const [copied, setCopied] = useState(false);
   const [tsSdkModalOpen, setTsSdkModalOpen] = useState(false);
   const [pySdkModalOpen, setPySdkModalOpen] = useState(false);
@@ -446,97 +833,23 @@ export function LayoutHeader({
               />
             </div>
           )}
-
-          {/* Tunnel Badge */}
-          {showTunnelBadge && (
-            <Popover>
-              <PopoverTrigger asChild>
-                <button className="flex items-center gap-2 px-3 py-1.5 bg-gradient-to-r from-purple-500/10 to-pink-500/10 dark:from-purple-500/20 dark:to-pink-500/20 border border-purple-500/30 dark:border-purple-500/40 rounded-full hover:from-purple-500/20 hover:to-pink-500/20 dark:hover:from-purple-500/30 dark:hover:to-pink-500/30 transition-colors cursor-pointer">
-                  <Zap className="size-4 text-purple-600 dark:text-purple-400 animate-pulse" />
-                  <span className="text-xs font-medium text-purple-700 dark:text-purple-300 hidden lg:inline">
-                    Tunnel
-                  </span>
-                </button>
-              </PopoverTrigger>
-              <PopoverContent
-                className="w-[calc(100vw-2rem)] sm:w-96"
-                align="start"
-              >
-                <div className="space-y-4">
-                  <div>
-                    <h4 className="font-semibold text-sm mb-2 flex items-center gap-2">
-                      <Zap className="size-4 text-purple-600 dark:text-purple-400" />
-                      Tunnel URL
-                    </h4>
-                    <div className="flex items-center gap-2 p-2 py-0 bg-muted rounded-full">
-                      <code className="flex-1 text-[10px] font-mono">
-                        {tunnelUrl}
-                        /mcp
-                      </code>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="h-7 px-2"
-                        onClick={handleCopy}
-                      >
-                        {copied ? (
-                          <Check className="size-3.5 text-green-600" />
-                        ) : (
-                          <Copy className="size-3.5" />
-                        )}
-                      </Button>
-                    </div>
-                  </div>
-
-                  <div>
-                    <h5 className="font-semibold text-sm mb-2">
-                      Use in ChatGPT
-                    </h5>
-                    <ol className="space-y-2 text-xs text-muted-foreground">
-                      <li className="flex gap-2">
-                        <span className="font-semibold text-foreground">
-                          1.
-                        </span>
-                        <span>
-                          Enable{" "}
-                          <span className="font-medium text-foreground">
-                            dev mode
-                          </span>{" "}
-                          from settings
-                        </span>
-                      </li>
-                      <li className="flex gap-2">
-                        <span className="font-semibold text-foreground">
-                          2.
-                        </span>
-                        <span>
-                          In{" "}
-                          <span className="font-medium text-foreground">
-                            App & Connectors
-                          </span>{" "}
-                          click on{" "}
-                          <span className="font-medium text-foreground">
-                            create
-                          </span>
-                        </span>
-                      </li>
-                      <li className="flex gap-2">
-                        <span className="font-semibold text-foreground">
-                          3.
-                        </span>
-                        <span>Use the tunnel URL in the input</span>
-                      </li>
-                    </ol>
-                  </div>
-                </div>
-              </PopoverContent>
-            </Popover>
-          )}
         </div>
 
-        {/* Right side: Add to Client + Theme Toggle + Command Palette + GitHub Button + Logo - Hidden in embedded mode */}
+        {/* Right side: Tunnel Badge + Add to Client + Theme Toggle + Command Palette + GitHub Button + Logo - Hidden in embedded mode */}
         {!embedded && (
           <div className="flex items-center gap-2 sm:gap-4 flex-shrink-0">
+            {/* Tunnel Badge */}
+            {showTunnelBadge && (
+              <TunnelBadge
+                tunnelUrl={tunnelUrl}
+                isTunnelStarting={isTunnelStarting}
+                setTunnelUrl={setTunnelUrl}
+                setIsTunnelStarting={setIsTunnelStarting}
+                copied={copied}
+                setCopied={setCopied}
+                handleCopy={handleCopy}
+              />
+            )}
             {selectedServer &&
               (() => {
                 // Extract display name the same way ServerDropdown does

--- a/libraries/typescript/packages/inspector/src/client/components/ThemeToggle.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ThemeToggle.tsx
@@ -24,7 +24,7 @@ export function ThemeToggle({ className }: ThemeToggleProps) {
 
   const getThemeIcon = () => {
     if (theme === "system") return <Monitor className="size-4" />;
-    if (theme === "light") return <SunDim className="size-4" />;
+    if (theme === "light") return <SunDim className="size-5" />;
     return <Moon className="size-4" />;
   };
 
@@ -99,7 +99,7 @@ export function ThemeToggle({ className }: ThemeToggleProps) {
             className="pl-2 pr-0 flex items-center gap-2 justify-end"
           >
             <span>Light</span>
-            <SunDim className="mr-2 h-4 w-4" />
+            <SunDim className="mr-2 size-5" />
           </DropdownMenuRadioItem>
           <DropdownMenuRadioItem
             value="dark"

--- a/libraries/typescript/packages/inspector/src/client/context/InspectorContext.tsx
+++ b/libraries/typescript/packages/inspector/src/client/context/InspectorContext.tsx
@@ -66,6 +66,7 @@ interface InspectorState {
   selectedSamplingRequestId: string | null;
   selectedElicitationRequestId: string | null;
   tunnelUrl: string | null;
+  isTunnelStarting: boolean;
   isEmbedded: boolean;
   embeddedConfig: EmbeddedConfig;
 }
@@ -79,6 +80,7 @@ interface InspectorContextType extends InspectorState {
   setSelectedSamplingRequestId: (requestId: string | null) => void;
   setSelectedElicitationRequestId: (requestId: string | null) => void;
   setTunnelUrl: (tunnelUrl: string | null) => void;
+  setIsTunnelStarting: (starting: boolean) => void;
   setEmbeddedMode: (isEmbedded: boolean, config?: EmbeddedConfig) => void;
   navigateToItem: (
     serverId: string,
@@ -112,6 +114,7 @@ export function InspectorProvider({ children }: { children: ReactNode }) {
     selectedSamplingRequestId: null,
     selectedElicitationRequestId: null,
     tunnelUrl: null,
+    isTunnelStarting: false,
     isEmbedded: false,
     embeddedConfig: {},
   });
@@ -157,6 +160,10 @@ export function InspectorProvider({ children }: { children: ReactNode }) {
     setState((prev) => ({ ...prev, tunnelUrl }));
   }, []);
 
+  const setIsTunnelStarting = useCallback((isTunnelStarting: boolean) => {
+    setState((prev) => ({ ...prev, isTunnelStarting }));
+  }, []);
+
   const setEmbeddedMode = useCallback(
     (isEmbedded: boolean, config: EmbeddedConfig = {}) => {
       setState((prev) => ({ ...prev, isEmbedded, embeddedConfig: config }));
@@ -184,7 +191,6 @@ export function InspectorProvider({ children }: { children: ReactNode }) {
           tab === "sampling" ? itemIdentifier || null : null,
         selectedElicitationRequestId:
           tab === "elicitation" ? itemIdentifier || null : null,
-        tunnelUrl: null,
       }));
     },
     []
@@ -211,6 +217,7 @@ export function InspectorProvider({ children }: { children: ReactNode }) {
     setSelectedSamplingRequestId,
     setSelectedElicitationRequestId,
     setTunnelUrl,
+    setIsTunnelStarting,
     setEmbeddedMode,
     navigateToItem,
     clearSelection,

--- a/libraries/typescript/packages/inspector/src/client/hooks/useAutoConnect.ts
+++ b/libraries/typescript/packages/inspector/src/client/hooks/useAutoConnect.ts
@@ -3,6 +3,9 @@ import { useCallback, useEffect, useState } from "react";
 import { useNavigate } from "react-router";
 import { toast } from "sonner";
 
+/** Survives full page reload; avoids fragile long JSON in query (was resolving to localhost + http). */
+export const INSPECTOR_RECONNECT_STORAGE_KEY = "__mcpUseInspectorReconnect";
+
 // Type alias for backward compatibility
 type MCPConnection = McpServer;
 
@@ -340,10 +343,13 @@ export function useAutoConnect({
           const urlParams = new URLSearchParams(window.location.search);
           const tunnelUrl = urlParams.get("tunnelUrl");
           const tab = urlParams.get("tab");
+          const openTunnelPopover = urlParams.get("openTunnelPopover");
           const params = new URLSearchParams();
           params.set("server", existing.id);
           if (tunnelUrl) params.set("tunnelUrl", tunnelUrl);
           if (tab) params.set("tab", tab);
+          if (openTunnelPopover)
+            params.set("openTunnelPopover", openTunnelPopover);
           navigate(`/?${params.toString()}`);
         } else {
           // Connection exists but not ready - track it for navigation when ready
@@ -372,9 +378,33 @@ export function useAutoConnect({
       return;
     }
 
+    const trySessionReconnect = (): boolean => {
+      if (typeof sessionStorage === "undefined") return false;
+      try {
+        const raw = sessionStorage.getItem(INSPECTOR_RECONNECT_STORAGE_KEY);
+        if (!raw) return false;
+        const parsed = JSON.parse(raw) as ConnectionConfig;
+        sessionStorage.removeItem(INSPECTOR_RECONNECT_STORAGE_KEY);
+        if (!parsed?.url || !parsed.transportType) return false;
+        handleAutoConnectConfig(parsed);
+        return true;
+      } catch {
+        try {
+          sessionStorage.removeItem(INSPECTOR_RECONNECT_STORAGE_KEY);
+        } catch {
+          /* ignore */
+        }
+        return false;
+      }
+    };
+
     // In embedded mode, we don't need to wait for storage to load
     // Proceed immediately with autoConnect
     if (embedded) {
+      if (trySessionReconnect()) {
+        setConfigLoaded(true);
+        return;
+      }
       const urlParams = new URLSearchParams(window.location.search);
       let queryAutoConnectParam = urlParams.get("autoConnect");
 
@@ -413,6 +443,11 @@ export function useAutoConnect({
       return;
     }
 
+    if (trySessionReconnect()) {
+      setConfigLoaded(true);
+      return;
+    }
+
     // Check for autoConnect query parameter first
     const urlParams = new URLSearchParams(window.location.search);
     let queryAutoConnectParam = urlParams.get("autoConnect");
@@ -429,7 +464,6 @@ export function useAutoConnect({
 
     if (queryAutoConnectParam) {
       const config = parseAutoConnectParam(queryAutoConnectParam);
-
       if (config) {
         handleAutoConnectConfig(config);
       }
@@ -474,10 +508,12 @@ export function useAutoConnect({
       const urlParams = new URLSearchParams(window.location.search);
       const tunnelUrl = urlParams.get("tunnelUrl");
       const tab = urlParams.get("tab");
+      const openTunnelPopover = urlParams.get("openTunnelPopover");
       const params = new URLSearchParams();
       params.set("server", connection.id);
       if (tunnelUrl) params.set("tunnelUrl", tunnelUrl);
       if (tab) params.set("tab", tab);
+      if (openTunnelPopover) params.set("openTunnelPopover", openTunnelPopover);
       navigate(`/?${params.toString()}`);
 
       setTimeout(() => {

--- a/libraries/typescript/packages/inspector/src/server/cli.ts
+++ b/libraries/typescript/packages/inspector/src/server/cli.ts
@@ -7,6 +7,7 @@ import { logger } from "hono/logger";
 import open from "open";
 import { registerInspectorRoutes } from "./shared-routes.js";
 import { registerStaticRoutes } from "./shared-static.js";
+import { setServerPort } from "./tunnel.js";
 import { findAvailablePort, isValidUrl } from "./utils.js";
 
 // Parse command line arguments
@@ -90,6 +91,7 @@ async function startServer() {
       fetch: app.fetch,
       port,
     });
+    setServerPort(port);
     console.log(`🚀 MCP Inspector running on http://localhost:${port}`);
     if (mcpUrl) {
       console.log(`📡 Auto-connecting to: ${mcpUrl}`);

--- a/libraries/typescript/packages/inspector/src/server/index.ts
+++ b/libraries/typescript/packages/inspector/src/server/index.ts
@@ -9,3 +9,6 @@ export { mountInspector } from "./middleware.js";
 
 // Export browser-compatible chat utilities for client-side usage
 export { handleChatRequest, handleChatRequestStream } from "./shared-utils.js";
+
+/** Used by @mcp-use/cli dev restart (inspector tunnel stop before re-exec) */
+export { stopTunnel, getTunnelStatus } from "./tunnel.js";

--- a/libraries/typescript/packages/inspector/src/server/middleware.ts
+++ b/libraries/typescript/packages/inspector/src/server/middleware.ts
@@ -29,6 +29,8 @@ export function mountInspector(
     devMode?: boolean;
     /** Override the sandbox origin for MCP Apps widgets (e.g., for production reverse proxies) */
     sandboxOrigin?: string | null;
+    /** Port the host app listens on (embedded inspector); required for tunnel start */
+    serverPort?: number;
   }
 ): void {
   // Find the built client files

--- a/libraries/typescript/packages/inspector/src/server/server.ts
+++ b/libraries/typescript/packages/inspector/src/server/server.ts
@@ -5,6 +5,7 @@ import { logger } from "hono/logger";
 import open from "open";
 import { registerInspectorRoutes } from "./shared-routes.js";
 import { registerStaticRoutesWithDevProxy } from "./shared-static.js";
+import { setServerPort } from "./tunnel.js";
 import { isPortAvailable, parsePortFromArgs, hasNoOpenFlag } from "./utils.js";
 
 const app = new Hono();
@@ -114,6 +115,8 @@ async function startServer() {
       fetch: app.fetch,
       port,
     });
+
+    setServerPort(port);
 
     if (isDev) {
       console.warn(

--- a/libraries/typescript/packages/inspector/src/server/shared-routes.ts
+++ b/libraries/typescript/packages/inspector/src/server/shared-routes.ts
@@ -11,6 +11,12 @@ import {
   handleChatRequestStream,
   storeWidgetData,
 } from "./shared-utils.js";
+import {
+  getTunnelStatus,
+  setServerPort,
+  startTunnel,
+  stopTunnel,
+} from "./tunnel.js";
 import { formatErrorResponse } from "./utils.js";
 
 /**
@@ -33,10 +39,20 @@ function getFrameAncestorsFromEnv(): string | undefined {
 /**
  * Register inspector-specific routes (proxy, chat, config, widget rendering)
  */
+export type InspectorRoutesConfig = {
+  autoConnectUrl?: string | null;
+  /** HTTP port the app listens on (embedded inspector); required for tunnel start */
+  serverPort?: number;
+};
+
 export function registerInspectorRoutes(
   app: Hono,
-  config?: { autoConnectUrl?: string | null }
+  config?: InspectorRoutesConfig
 ) {
+  if (typeof config?.serverPort === "number") {
+    setServerPort(config.serverPort);
+  }
+
   app.get("/inspector/health", (c) => {
     return c.json({ status: "ok", timestamp: new Date().toISOString() });
   });
@@ -407,5 +423,108 @@ export function registerInspectorRoutes(
         "Access-Control-Expose-Headers": "*",
       },
     });
+  });
+
+  // Tunnel management endpoints
+  app.get("/inspector/api/tunnel/status", (c) => {
+    const status = getTunnelStatus();
+    return c.json(status);
+  });
+
+  app.post("/inspector/api/tunnel/start", async (c) => {
+    try {
+      const result = await startTunnel();
+      return c.json(result);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to start tunnel";
+      return c.json({ error: message }, 500);
+    }
+  });
+
+  app.delete("/inspector/api/tunnel/stop", (c) => {
+    const stopped = stopTunnel();
+    return c.json({ stopped });
+  });
+
+  /** Public MCP URL and CLI dev session (set by `mcp-use dev` / MCP_URL) */
+  app.get("/inspector/api/dev/info", (c) => {
+    const mcpUrl = process.env.MCP_URL ?? null;
+    const portEnv = process.env.PORT;
+    const fromCli = process.env.MCP_USE_CLI_DEV === "1";
+    const tunnel = getTunnelStatus();
+    let portNum: number | null = null;
+    if (portEnv !== undefined) {
+      const n = parseInt(portEnv, 10);
+      if (!Number.isNaN(n)) portNum = n;
+    }
+    // Derive tunnelUrl from MCP_URL when the inspector tunnel module has none
+    let tunnelUrl = tunnel.url ?? null;
+    if (!tunnelUrl && mcpUrl) {
+      try {
+        const u = new URL(mcpUrl);
+        if (u.protocol === "https:") tunnelUrl = u.origin;
+      } catch {
+        /* ignore */
+      }
+    }
+    return c.json({
+      mcpUrl,
+      port: portNum,
+      fromCli,
+      tunnelUrl,
+    });
+  });
+
+  /**
+   * Restart the dev server with the tunnel enabled.
+   * Delegates to the CLI restart hook which re-spawns the process with --tunnel.
+   */
+  app.post("/inspector/api/dev/start-tunnel", (c) => {
+    const restart = (globalThis as any).__mcpUseDevRestart as
+      | ((withTunnel: boolean) => void)
+      | undefined;
+    if (!restart) {
+      return c.json(
+        { error: "Dev restart not available (not running via mcp-use dev)" },
+        500
+      );
+    }
+    setTimeout(() => restart(true), 200);
+    return c.json({ ok: true, restarting: true });
+  });
+
+  /** Restart the dev server without the tunnel. */
+  app.post("/inspector/api/dev/stop-tunnel", (c) => {
+    const restart = (globalThis as any).__mcpUseDevRestart as
+      | ((withTunnel: boolean) => void)
+      | undefined;
+    if (!restart) {
+      return c.json(
+        { error: "Dev restart not available (not running via mcp-use dev)" },
+        500
+      );
+    }
+    setTimeout(() => restart(false), 200);
+    return c.json({ ok: true, restarting: true });
+  });
+
+  // Legacy aliases
+  app.post("/inspector/api/dev/restart-with-tunnel", (c) => {
+    const restart = (globalThis as any).__mcpUseDevRestart as
+      | ((withTunnel: boolean) => void)
+      | undefined;
+    if (!restart) return c.json({ error: "Not available" }, 500);
+    setTimeout(() => restart(true), 200);
+    return c.json({ ok: true, restarting: true });
+  });
+
+  app.post("/inspector/api/dev/restart-without-tunnel", (c) => {
+    const restart = (globalThis as any).__mcpUseDevRestart as
+      | ((withTunnel: boolean) => void)
+      | undefined;
+    if (!restart) return c.json({ error: "Not available" }, 500);
+    setTimeout(() => restart(false), 200);
+    return c.json({ ok: true, restarting: true });
   });
 }

--- a/libraries/typescript/packages/inspector/src/server/tunnel.ts
+++ b/libraries/typescript/packages/inspector/src/server/tunnel.ts
@@ -1,0 +1,163 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const TUNNEL_URL_REGEX = /https?:\/\/([a-z0-9-]+\.[a-z0-9.-]+)/i;
+const SETUP_TIMEOUT_MS = 30_000;
+
+interface TunnelState {
+  url: string;
+  subdomain: string;
+  process: ChildProcess;
+}
+
+let serverPort: number | null = null;
+let activeTunnel: TunnelState | null = null;
+
+export function setServerPort(port: number) {
+  serverPort = port;
+}
+
+export function getTunnelStatus(): {
+  url: string | null;
+  subdomain: string | null;
+} {
+  if (!activeTunnel) {
+    return { url: null, subdomain: null };
+  }
+  return { url: activeTunnel.url, subdomain: activeTunnel.subdomain };
+}
+
+function readSubdomainFromManifest(): string | undefined {
+  const projectPath = process.env.MCP_USE_PROJECT_PATH || process.cwd();
+  try {
+    const raw = readFileSync(
+      join(projectPath, "dist", "mcp-use.json"),
+      "utf-8"
+    );
+    const manifest = JSON.parse(raw);
+    return manifest?.tunnel?.subdomain || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function startTunnel(
+  subdomain?: string
+): Promise<{ url: string; subdomain: string }> {
+  if (activeTunnel) {
+    return { url: activeTunnel.url, subdomain: activeTunnel.subdomain };
+  }
+
+  if (!serverPort) {
+    throw new Error("Server port not set. Cannot start tunnel.");
+  }
+
+  const resolvedSubdomain = subdomain ?? readSubdomainFromManifest();
+  const port = serverPort;
+
+  return new Promise((resolve, reject) => {
+    console.log(`[Tunnel] Starting tunnel for port ${port}...`);
+
+    const tunnelArgs = ["--yes", "@mcp-use/tunnel", String(port)];
+    if (resolvedSubdomain) {
+      tunnelArgs.push("--subdomain", resolvedSubdomain);
+      console.log(`[Tunnel] Reusing subdomain: ${resolvedSubdomain}`);
+    }
+    const proc = spawn("npx", tunnelArgs, {
+      stdio: ["ignore", "pipe", "pipe"],
+      shell: process.platform === "win32",
+    });
+
+    let resolved = false;
+
+    const setupTimeout = setTimeout(() => {
+      if (!resolved) {
+        resolved = true;
+        try {
+          proc.kill("SIGTERM");
+        } catch {
+          /* ignore */
+        }
+        reject(new Error("Tunnel setup timed out after 30s"));
+      }
+    }, SETUP_TIMEOUT_MS);
+
+    proc.stdout?.on("data", (data: Buffer) => {
+      const text = data.toString();
+      const isShutdownMessage =
+        text.includes("Shutting down") || text.includes("🛑");
+      if (!isShutdownMessage) {
+        process.stdout.write(`[Tunnel] ${text}`);
+      }
+
+      const urlMatch = text.match(TUNNEL_URL_REGEX);
+      if (urlMatch && !resolved) {
+        const url = urlMatch[0];
+        const fullDomain = urlMatch[1];
+        const subdomainMatch = fullDomain.match(/^([a-z0-9-]+)\./i);
+        const extractedSubdomain = subdomainMatch
+          ? subdomainMatch[1]
+          : fullDomain.split(".")[0];
+
+        resolved = true;
+        clearTimeout(setupTimeout);
+
+        activeTunnel = { url, subdomain: extractedSubdomain, process: proc };
+
+        proc.on("exit", () => {
+          if (activeTunnel?.process === proc) {
+            console.log("[Tunnel] Process exited, clearing state");
+            activeTunnel = null;
+          }
+        });
+
+        console.log(`[Tunnel] Established: ${url}`);
+        resolve({ url, subdomain: extractedSubdomain });
+      }
+    });
+
+    proc.stderr?.on("data", (data: Buffer) => {
+      const text = data.toString();
+      if (
+        !text.includes("INFO") &&
+        !text.includes("bore_cli") &&
+        !text.includes("Shutting down")
+      ) {
+        process.stderr.write(`[Tunnel] ${text}`);
+      }
+    });
+
+    proc.on("error", (error) => {
+      if (!resolved) {
+        resolved = true;
+        clearTimeout(setupTimeout);
+        reject(new Error(`Failed to start tunnel: ${error.message}`));
+      }
+    });
+
+    proc.on("exit", (code) => {
+      if (!resolved && code !== 0) {
+        resolved = true;
+        clearTimeout(setupTimeout);
+        reject(new Error(`Tunnel process exited with code ${code}`));
+      }
+    });
+  });
+}
+
+export function stopTunnel(): boolean {
+  if (!activeTunnel) {
+    return false;
+  }
+
+  try {
+    activeTunnel.process.kill("SIGTERM");
+  } catch {
+    /* ignore */
+  }
+
+  activeTunnel = null;
+  console.log("[Tunnel] Stopped");
+  return true;
+}

--- a/libraries/typescript/packages/mcp-use/src/server/inspector/mount.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/inspector/mount.ts
@@ -70,6 +70,7 @@ export async function mountInspectorUI(
       // This avoids requiring a sandbox-{hostname} subdomain that doesn't exist
       // behind reverse proxies (ngrok, E2B, etc.)
       devMode: !isProduction,
+      serverPort: typeof serverPort === "number" ? serverPort : undefined,
     });
     console.log(
       `[INSPECTOR] UI available at http://${serverHost}:${serverPort}/inspector`

--- a/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
@@ -321,6 +321,11 @@ class MCPServerClass<HasOAuth extends boolean = false> {
    */
   public serverHost: string;
 
+  /** @internal Closes the Node HTTP listener when {@link listen} was used */
+  private _httpServerClose?: () => Promise<void>;
+  /** @internal Force-closes all connections and stops listening immediately */
+  private _httpServerForceClose?: () => Promise<void>;
+
   /**
    * Full base URL for the server (e.g., "https://example.com").
    * Used for generating widget URLs and OAuth callbacks.
@@ -3898,9 +3903,43 @@ class MCPServerClass<HasOAuth extends boolean = false> {
     this._trackServerRun("http");
 
     // Start server using runtime-aware helper
-    await startServer(this.app, this.serverPort, this.serverHost, {
-      onDenoRequest: rewriteSupabaseRequest,
-    });
+    const httpHandle = await startServer(
+      this.app,
+      this.serverPort,
+      this.serverHost,
+      {
+        onDenoRequest: rewriteSupabaseRequest,
+      }
+    );
+    this._httpServerClose = httpHandle.close;
+    this._httpServerForceClose = httpHandle.forceClose;
+  }
+
+  /**
+   * Stops the HTTP listener started by {@link listen} (Node.js). No-op if not listening or on Deno no-op handle.
+   */
+  public async close(): Promise<void> {
+    if (this._httpServerClose) {
+      const close = this._httpServerClose;
+      this._httpServerClose = undefined;
+      this._httpServerForceClose = undefined;
+      await close();
+    }
+  }
+
+  /**
+   * Force-closes all connections and stops listening immediately.
+   * Unlike {@link close}, this doesn't wait for keep-alive connections to drain.
+   */
+  public async forceClose(): Promise<void> {
+    if (this._httpServerForceClose) {
+      const forceClose = this._httpServerForceClose;
+      this._httpServerClose = undefined;
+      this._httpServerForceClose = undefined;
+      await forceClose();
+    } else {
+      await this.close();
+    }
   }
 
   private _trackServerRun(transport: string): void {

--- a/libraries/typescript/packages/mcp-use/src/server/utils/server-lifecycle.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/utils/server-lifecycle.ts
@@ -101,6 +101,13 @@ export function rewriteSupabaseRequest(req: Request): Request {
   return req;
 }
 
+/** Handle to cleanly shut down the HTTP listener (Node) or no-op (Deno). */
+export type HttpServerHandle = {
+  close: () => Promise<void>;
+  /** Force-close all connections and stop listening immediately (Node 18.2+). */
+  forceClose: () => Promise<void>;
+};
+
 /**
  * Start the provided Hono application as an HTTP server for the current runtime.
  *
@@ -110,7 +117,7 @@ export function rewriteSupabaseRequest(req: Request): Request {
  * @param options - Optional runtime-specific hooks
  * @param options.onDenoRequest - Transform an incoming Deno `Request` before it is passed to the application
  * @param options.onDenoResponse - Transform a Deno `Response` before it is returned (if omitted, default CORS headers are applied)
- * @returns Nothing.
+ * @returns A handle whose {@link HttpServerHandle.close} stops the listener (Node); Deno returns a no-op close.
  */
 export async function startServer(
   app: HonoType,
@@ -120,7 +127,7 @@ export async function startServer(
     onDenoRequest?: (req: Request) => Request | Promise<Request>;
     onDenoResponse?: (res: Response) => Response | Promise<Response>;
   }
-): Promise<void> {
+): Promise<HttpServerHandle> {
   if (isDeno) {
     // Deno runtime
     const corsHeaders = getDenoCorsHeaders();
@@ -154,6 +161,10 @@ export async function startServer(
       }
     );
     console.log(`[SERVER] Listening`);
+    return {
+      close: async () => {},
+      forceClose: async () => {},
+    };
   } else {
     // Node.js runtime
     const { serve } = await import("@hono/node-server");
@@ -176,5 +187,20 @@ export async function startServer(
     if (wsProxySetup && server) {
       wsProxySetup(server);
     }
+
+    const nodeServer = server as import("node:http").Server;
+    return {
+      close: () =>
+        new Promise((resolve, reject) => {
+          nodeServer.close((err) => (err ? reject(err) : resolve()));
+        }),
+      forceClose: () =>
+        new Promise<void>((resolve) => {
+          if (typeof nodeServer.closeAllConnections === "function") {
+            nodeServer.closeAllConnections();
+          }
+          nodeServer.close(() => resolve());
+        }),
+    };
   }
 }


### PR DESCRIPTION
- Added API endpoints for starting, stopping, and checking the status of a tunnel.
- Integrated tunnel management into the Layout and LayoutHeader components, allowing users to start and stop tunnels directly from the UI.
- Updated context to manage tunnel state, including a loading state for starting the tunnel.
- Enhanced the user experience with visual feedback during tunnel operations and added instructions for using the tunnel URL in ChatGPT.

This feature improves the overall functionality of the inspector by enabling real-time tunnel management.
