### PR TITLE
feat(python): add Context.elicit_url() for URL mode elicitation

### DIFF
--- a/libraries/python/mcp_use/server/context.py
+++ b/libraries/python/mcp_use/server/context.py
@@ -1,12 +1,21 @@
 from __future__ import annotations
 
+import uuid
 from collections.abc import Sequence
 from dataclasses import MISSING, fields, is_dataclass
 from typing import Any, Literal, cast
 
 from mcp.server.elicitation import ElicitationResult, ElicitSchemaModelT
 from mcp.server.fastmcp import Context as FastMCPContext
-from mcp.types import CreateMessageResult, ListRootsResult, ModelPreferences, Root, SamplingMessage, TextContent
+from mcp.types import (
+    CreateMessageResult,
+    ElicitResult,
+    ListRootsResult,
+    ModelPreferences,
+    Root,
+    SamplingMessage,
+    TextContent,
+)
 from pydantic import BaseModel, Field, create_model
 from starlette.requests import Request
 
@@ -154,7 +163,33 @@ class Context(FastMCPContext):
         message: str,
         schema: type[ElicitSchemaModelT] | type[Any],
     ) -> ElicitationResult[ElicitSchemaModelT]:
-        """Support both Pydantic models and dataclasses for elicitation schemas."""
+        """Request structured user input via a form elicitation.
+
+        Supports both Pydantic models and dataclasses as schemas.
+
+        Args:
+            message: Human-readable prompt explaining what input is needed.
+            schema: A Pydantic model class or dataclass defining the form fields.
+
+        Returns:
+            An ``ElicitationResult`` with ``action`` ("accept", "decline", "cancel")
+            and typed ``data`` when accepted.
+
+        Example:
+            ```python
+            @dataclass
+            class ReleaseConfig:
+                version: str = "1.0.0"
+                environment: str = "staging"
+
+            @server.tool()
+            async def create_release(ctx: Context) -> str:
+                result = await ctx.elicit("Configure release", ReleaseConfig)
+                if result.action == "accept":
+                    return f"Releasing {result.data.version} to {result.data.environment}"
+                return "Cancelled"
+            ```
+        """
         _telemetry.track_server_context(context_type="elicit")
 
         schema_model, dataclass_schema = self._coerce_schema(schema)
@@ -164,6 +199,53 @@ class Context(FastMCPContext):
             result.data = dataclass_schema(**result.data.model_dump())
 
         return result
+
+    async def elicit_url(
+        self,
+        message: str,
+        url: str,
+        *,
+        elicitation_id: str | None = None,
+    ) -> ElicitResult:
+        """Redirect the user to an external URL for out-of-band interactions.
+
+        Use this for OAuth flows, credential collection, payment processing,
+        or any workflow that requires the user to interact with an external service.
+
+        Args:
+            message: Human-readable explanation of why the URL interaction is needed.
+            url: The URL the user should navigate to.
+            elicitation_id: Optional unique identifier for tracking. Auto-generated if omitted.
+
+        Returns:
+            An ``ElicitResult`` with ``action`` ("accept", "decline", "cancel").
+            URL mode never returns ``content``.
+
+        Example:
+            ```python
+            @server.tool()
+            async def authenticate(provider: str, ctx: Context) -> str:
+                result = await ctx.elicit_url(
+                    f"Sign in to {provider}",
+                    f"https://auth.example.com/login?provider={provider}",
+                )
+                if result.action == "accept":
+                    return "Authenticated!"
+                return "Authentication declined."
+            ```
+        """
+        _telemetry.track_server_context(context_type="elicit_url")
+
+        if elicitation_id is None:
+            elicitation_id = uuid.uuid4().hex
+
+        session = self.request_context.session
+        return await session.elicit_url(
+            message=message,
+            url=url,
+            elicitation_id=elicitation_id,
+            related_request_id=self.request_id,
+        )
 
     @staticmethod
     def _text_message(text: str) -> SamplingMessage:

--- a/libraries/python/tests/unit/server/test_context_elicit_url.py
+++ b/libraries/python/tests/unit/server/test_context_elicit_url.py
@@ -1,0 +1,109 @@
+"""
+Tests for Context.elicit_url() — URL mode elicitation.
+
+Verifies that the convenience method correctly delegates to
+session.elicit_url() with proper defaults and parameter forwarding.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from mcp.types import ElicitResult
+
+from mcp_use.server.context import Context
+
+
+class FakeMCPServer:
+    def __init__(self):
+        self._client_log_level = "debug"
+
+
+class FakeSession:
+    def __init__(self):
+        self.elicit_url = AsyncMock(return_value=ElicitResult(action="accept", content=None))
+
+
+class FakeRequestContext:
+    def __init__(self):
+        self.session = FakeSession()
+        self.request_id = "test-request-id"
+
+
+def make_context() -> Context:
+    server = FakeMCPServer()
+    request_context = FakeRequestContext()
+    return Context(request_context=request_context, fastmcp=server)
+
+
+@pytest.mark.asyncio
+async def test_elicit_url_delegates_to_session():
+    """elicit_url should call session.elicit_url with the correct args."""
+    ctx = make_context()
+
+    result = await ctx.elicit_url("Please sign in", "https://auth.example.com/login")
+
+    assert result.action == "accept"
+    ctx.request_context.session.elicit_url.assert_awaited_once()
+    call_kwargs = ctx.request_context.session.elicit_url.call_args.kwargs
+    assert call_kwargs["message"] == "Please sign in"
+    assert call_kwargs["url"] == "https://auth.example.com/login"
+    assert call_kwargs["related_request_id"] == "test-request-id"
+    # elicitation_id should be auto-generated (32 hex chars)
+    assert len(call_kwargs["elicitation_id"]) == 32
+
+
+@pytest.mark.asyncio
+async def test_elicit_url_custom_elicitation_id():
+    """A custom elicitation_id should be forwarded as-is."""
+    ctx = make_context()
+
+    await ctx.elicit_url("Sign in", "https://example.com", elicitation_id="my-custom-id")
+
+    call_kwargs = ctx.request_context.session.elicit_url.call_args.kwargs
+    assert call_kwargs["elicitation_id"] == "my-custom-id"
+
+
+@pytest.mark.asyncio
+async def test_elicit_url_decline():
+    """Should propagate decline action from session."""
+    ctx = make_context()
+    ctx.request_context.session.elicit_url.return_value = ElicitResult(action="decline", content=None)
+
+    result = await ctx.elicit_url("Sign in", "https://example.com")
+
+    assert result.action == "decline"
+
+
+@pytest.mark.asyncio
+async def test_elicit_url_cancel():
+    """Should propagate cancel action from session."""
+    ctx = make_context()
+    ctx.request_context.session.elicit_url.return_value = ElicitResult(action="cancel", content=None)
+
+    result = await ctx.elicit_url("Sign in", "https://example.com")
+
+    assert result.action == "cancel"
+
+
+@pytest.mark.asyncio
+async def test_elicit_url_tracks_telemetry():
+    """Should call telemetry with context_type='elicit_url'."""
+    ctx = make_context()
+
+    with patch("mcp_use.server.context._telemetry") as mock_telemetry:
+        await ctx.elicit_url("Sign in", "https://example.com")
+        mock_telemetry.track_server_context.assert_called_once_with(context_type="elicit_url")
+
+
+@pytest.mark.asyncio
+async def test_elicit_url_auto_generates_unique_ids():
+    """Each call should get a different auto-generated elicitation_id."""
+    ctx = make_context()
+
+    await ctx.elicit_url("Sign in", "https://example.com")
+    id1 = ctx.request_context.session.elicit_url.call_args.kwargs["elicitation_id"]
+
+    await ctx.elicit_url("Sign in again", "https://example.com")
+    id2 = ctx.request_context.session.elicit_url.call_args.kwargs["elicitation_id"]
+
+    assert id1 != id2


### PR DESCRIPTION
## Changes

Adds `Context.elicit_url(message, url)` to the Python server SDK, wrapping the MCP SDK's `session.elicit_url()` with a clean, high-level API that matches the existing `Context.elicit()` pattern for form mode.

## Implementation Details

1. **New method**: `Context.elicit_url(message, url, *, elicitation_id=None)` on the server `Context` class
2. Auto-generates `elicitation_id` (UUID hex) if not provided
3. Forwards `related_request_id` from context automatically
4. Tracks telemetry as `"elicit_url"`
5. Returns `ElicitResult` with `action` ("accept", "decline", "cancel") — URL mode never returns `content`

## Example Usage (Before)

```python
# Had to drop down to raw session API
session = context.request_context.session
result = await session.elicit_url(
    message="Please sign in",
    url="https://auth.example.com/login",
    elicitation_id=uuid.uuid4().hex,
    related_request_id=context.request_id,
)
```

## Example Usage (After)

```python
result = await context.elicit_url(
    "Please sign in",
    "https://auth.example.com/login",
)
if result.action == "accept":
    return "Authenticated!"
```

## Testing

- 6 unit tests covering:
  - Correct delegation to `session.elicit_url`
  - Custom `elicitation_id` forwarding
  - Decline/cancel action propagation
  - Telemetry tracking
  - Unique auto-generated IDs across calls
- All 305 existing tests still pass (`pytest tests/unit/`)

## Backwards Compatibility

Purely additive — no breaking changes. Existing `Context.elicit()` for form mode is unchanged.