### PR TITLE
fix(python): prevent double-close race in BaseConnector.disconnect()

### DIFF
--- a/libraries/python/mcp_use/client/connectors/base.py
+++ b/libraries/python/mcp_use/client/connectors/base.py
@@ -5,6 +5,7 @@ This module provides the base connector interface that all MCP connectors
 must implement.
 """
 
+import asyncio
 import warnings
 from abc import ABC, abstractmethod
 from datetime import timedelta
@@ -95,6 +96,9 @@ class BaseConnector(ABC):
         # Roots support - always advertise roots capability
         self._roots: list[Root] = roots or []
         self._user_list_roots_callback = list_roots_callback
+
+        # Lock to ensure concurrent disconnect() callers wait for cleanup
+        self._disconnect_lock = asyncio.Lock()
 
         # Set up middleware manager
         self.middleware_manager = MiddlewareManager()
@@ -193,14 +197,15 @@ class BaseConnector(ABC):
     @telemetry("connector_disconnect")
     async def disconnect(self) -> None:
         """Close the connection to the MCP implementation."""
-        if not self._connected:
-            logger.debug("Not connected to MCP implementation")
-            return
+        async with self._disconnect_lock:
+            if not self._connected:
+                logger.debug("Not connected to MCP implementation")
+                return
 
-        logger.debug("Disconnecting from MCP implementation")
-        self._connected = False
-        await self._cleanup_resources()
-        logger.debug("Disconnected from MCP implementation")
+            logger.debug("Disconnecting from MCP implementation")
+            self._connected = False
+            await self._cleanup_resources()
+            logger.debug("Disconnected from MCP implementation")
 
     async def _cleanup_resources(self) -> None:
         """Clean up all resources associated with this connector."""

--- a/libraries/python/mcp_use/client/connectors/base.py
+++ b/libraries/python/mcp_use/client/connectors/base.py
@@ -198,8 +198,8 @@ class BaseConnector(ABC):
             return
 
         logger.debug("Disconnecting from MCP implementation")
-        await self._cleanup_resources()
         self._connected = False
+        await self._cleanup_resources()
         logger.debug("Disconnected from MCP implementation")
 
     async def _cleanup_resources(self) -> None:

--- a/libraries/python/tests/unit/test_connector_double_close.py
+++ b/libraries/python/tests/unit/test_connector_double_close.py
@@ -54,6 +54,26 @@ class TestDoubleCloseGuard:
         assert cleanup_call_count == 1
 
     @pytest.mark.asyncio
+    async def test_concurrent_disconnect_waits_for_cleanup(self):
+        """A concurrent disconnect() caller must block until cleanup finishes."""
+        connector = StdioConnector()
+        connector._connected = True
+
+        cleanup_done = False
+
+        async def slow_cleanup():
+            nonlocal cleanup_done
+            await asyncio.sleep(0.05)
+            cleanup_done = True
+
+        connector._cleanup_resources = slow_cleanup
+
+        # Both calls should complete, and by the time they return cleanup must be done
+        await asyncio.gather(connector.disconnect(), connector.disconnect())
+
+        assert cleanup_done is True
+
+    @pytest.mark.asyncio
     async def test_disconnect_when_not_connected_is_noop(self):
         """disconnect() on a not-connected connector should not call cleanup."""
         connector = StdioConnector()

--- a/libraries/python/tests/unit/test_connector_double_close.py
+++ b/libraries/python/tests/unit/test_connector_double_close.py
@@ -1,0 +1,65 @@
+"""
+Unit tests for the double-close guard in BaseConnector.disconnect().
+
+Regression test for https://github.com/mcp-use/mcp-use/issues/1220
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from mcp_use.client.connectors.stdio import StdioConnector
+
+
+@pytest.fixture(autouse=True)
+def mock_logger():
+    """Mock the logger to prevent errors during tests."""
+    with patch("mcp_use.client.connectors.base.logger"):
+        yield
+
+
+class TestDoubleCloseGuard:
+    """Verify that disconnect() only cleans up resources once, even when called concurrently."""
+
+    @pytest.mark.asyncio
+    async def test_sequential_disconnect_calls_cleanup_once(self):
+        """Calling disconnect() twice sequentially should only clean up once."""
+        connector = StdioConnector()
+        connector._connected = True
+        connector._cleanup_resources = AsyncMock()
+
+        await connector.disconnect()
+        await connector.disconnect()
+
+        connector._cleanup_resources.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_concurrent_disconnect_calls_cleanup_once(self):
+        """Two concurrent disconnect() calls should only clean up once."""
+        connector = StdioConnector()
+        connector._connected = True
+
+        cleanup_call_count = 0
+
+        async def slow_cleanup():
+            nonlocal cleanup_call_count
+            cleanup_call_count += 1
+            await asyncio.sleep(0.05)
+
+        connector._cleanup_resources = slow_cleanup
+
+        await asyncio.gather(connector.disconnect(), connector.disconnect())
+
+        assert cleanup_call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_disconnect_when_not_connected_is_noop(self):
+        """disconnect() on a not-connected connector should not call cleanup."""
+        connector = StdioConnector()
+        connector._connected = False
+        connector._cleanup_resources = AsyncMock()
+
+        await connector.disconnect()
+
+        connector._cleanup_resources.assert_not_called()


### PR DESCRIPTION
## Changes
Fix `close_all_sessions()` closing each session twice, which raises `ValueError: I/O operation on closed pipe` on Windows and noisy tracebacks on Unix.

## Implementation Details
1. Moved `self._connected = False` **before** `await self._cleanup_resources()` in `BaseConnector.disconnect()` so the guard is effective for concurrent/re-entrant async calls
2. Both `close_all_sessions()` and `AsyncExitStack` teardown call `disconnect()` — previously both could pass the `if not self._connected` check before either set the flag

## Example Usage (Before)
```python
await client.close_all_sessions()
# ValueError: I/O operation on closed pipe (Windows)
# Exception ignored in: <function BaseEventLoop.__del__> (Unix)
```

## Example Usage (After)
```python
await client.close_all_sessions()
# Clean shutdown, no errors
```

## Documentation Updates
- No documentation changes needed

## Testing
- Added `tests/unit/test_connector_double_close.py` with 3 tests:
  - Sequential double-call only cleans up once
  - Concurrent double-call (`asyncio.gather`) only cleans up once
  - Disconnect when not connected is a no-op
- All 301 existing unit tests continue to pass

## Backwards Compatibility
Not a breaking change — this is a one-line reorder that fixes incorrect behavior.

## Related Issues
Closes #1220