### PR TITLE
feat(mcp-use): enhance middleware and type definitions

### DIFF
--- a/libraries/typescript/.changeset/typed-middleware-and-tool-fixes.md
+++ b/libraries/typescript/.changeset/typed-middleware-and-tool-fixes.md
@@ -1,0 +1,9 @@
+---
+"mcp-use": patch
+---
+
+Improve MCP middleware and tool typing ergonomics
+
+- **Typed MCP middleware context**: `server.use("mcp:tools/call", ...)` now narrows `ctx.params` to `{ name: string; arguments?: Record<string, unknown> }` instead of the generic `Record<string, unknown>`. Same for `mcp:resources/read` (typed `uri`) and `mcp:prompts/get` (typed `name` + `arguments`). Wildcard patterns (`mcp:*`) fall back to the base `MiddlewareContext`.
+- **`outputSchema` + response helpers compatibility**: Tools with `outputSchema` can now return `text()`, `mix()`, `markdown()`, and other content helpers without a type error. The callback return type is widened to `Promise<TypedCallToolResult<TOutput> | CallToolResult>`.
+- **Typed `resourceTemplate` params**: `server.resourceTemplate()` now accepts an optional `schema` field (Zod schema). When provided, the callback's `params` argument is narrowed to `z.infer<schema>` instead of `Record<string, any>`, matching how `server.tool()` works.

--- a/libraries/typescript/packages/mcp-use/src/server/index.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/index.ts
@@ -162,7 +162,12 @@ export {
   matchesPattern,
   type McpMiddlewareEntry,
   type McpMiddlewareFn,
+  type McpMiddlewareFnFor,
+  type McpMiddlewarePatternMap,
   type MiddlewareContext,
+  type ToolsCallMiddlewareContext,
+  type ResourcesReadMiddlewareContext,
+  type PromptsGetMiddlewareContext,
 } from "./middleware/mcp-middleware.js";
 
 // OAuth Proxy middleware for CORS-free OAuth flows

--- a/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
@@ -86,6 +86,7 @@ import type {
 import type {
   ReadResourceCallback,
   ReadResourceTemplateCallback,
+  InferTemplateParams,
   ResourceDefinition,
   ResourceTemplateDefinition,
   ResourceTemplateCallbacks,
@@ -2603,11 +2604,17 @@ class MCPServerClass<HasOAuth extends boolean = false> {
 
     this.resourceTemplate = ((
       templateDefinition:
-        | import("./types/index.js").ResourceTemplateDefinition<HasOAuth>
+        | import("./types/index.js").ResourceTemplateDefinition<HasOAuth, any>
         | import("./types/index.js").ResourceTemplateDefinitionWithoutCallback
-        | import("./types/index.js").FlatResourceTemplateDefinition<HasOAuth>
+        | import("./types/index.js").FlatResourceTemplateDefinition<
+            HasOAuth,
+            any
+          >
         | import("./types/index.js").FlatResourceTemplateDefinitionWithoutCallback,
-      callback?: import("./types/index.js").ReadResourceTemplateCallback<HasOAuth>
+      callback?: import("./types/index.js").ReadResourceTemplateCallback<
+        any,
+        HasOAuth
+      >
     ) => {
       const actualCallback =
         callback || (templateDefinition as any).readCallback;
@@ -3457,13 +3464,15 @@ class MCPServerClass<HasOAuth extends boolean = false> {
    * @see {@link ResourceTemplateDefinition} for all configuration options
    * @see {@link resource} for static resources
    */
-  public resourceTemplate!: (
-    templateDefinition:
-      | ResourceTemplateDefinition<HasOAuth>
+  public resourceTemplate!: <
+    T extends
+      | ResourceTemplateDefinition<HasOAuth, any>
       | import("./types/index.js").ResourceTemplateDefinitionWithoutCallback
-      | import("./types/index.js").FlatResourceTemplateDefinition<HasOAuth>
+      | import("./types/index.js").FlatResourceTemplateDefinition<HasOAuth, any>
       | import("./types/index.js").FlatResourceTemplateDefinitionWithoutCallback,
-    callback?: ReadResourceTemplateCallback<HasOAuth>
+  >(
+    templateDefinition: T,
+    callback?: ReadResourceTemplateCallback<InferTemplateParams<T>, HasOAuth>
   ) => this;
 
   /**

--- a/libraries/typescript/packages/mcp-use/src/server/middleware/mcp-middleware.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/middleware/mcp-middleware.ts
@@ -48,6 +48,67 @@ export interface MiddlewareContext {
   state: Map<string, unknown>;
 }
 
+/** Params shape for `tools/call` method */
+export interface ToolsCallParams {
+  name: string;
+  arguments?: Record<string, unknown>;
+  _meta?: Record<string, unknown>;
+}
+
+/** Params shape for `resources/read` method */
+export interface ResourcesReadParams {
+  uri: string;
+  _meta?: Record<string, unknown>;
+}
+
+/** Params shape for `prompts/get` method */
+export interface PromptsGetParams {
+  name: string;
+  arguments?: Record<string, string>;
+  _meta?: Record<string, unknown>;
+}
+
+/** Context with narrowed `params` for `tools/call` */
+export interface ToolsCallMiddlewareContext extends MiddlewareContext {
+  method: "tools/call";
+  params: ToolsCallParams & Record<string, unknown>;
+}
+
+/** Context with narrowed `params` for `resources/read` */
+export interface ResourcesReadMiddlewareContext extends MiddlewareContext {
+  method: "resources/read";
+  params: ResourcesReadParams & Record<string, unknown>;
+}
+
+/** Context with narrowed `params` for `prompts/get` */
+export interface PromptsGetMiddlewareContext extends MiddlewareContext {
+  method: "prompts/get";
+  params: PromptsGetParams & Record<string, unknown>;
+}
+
+/**
+ * Map from MCP middleware pattern strings to their narrowed context type.
+ * Used by `McpMiddlewareFnFor<P>` to infer the correct `ctx` parameter.
+ */
+export interface McpMiddlewarePatternMap {
+  "tools/call": ToolsCallMiddlewareContext;
+  "resources/read": ResourcesReadMiddlewareContext;
+  "prompts/get": PromptsGetMiddlewareContext;
+}
+
+/**
+ * A typed MCP middleware function whose `ctx` is narrowed based on the
+ * pattern string `P`. Falls back to the base `MiddlewareContext` for
+ * wildcard or unrecognized patterns.
+ */
+export type McpMiddlewareFnFor<P extends string> =
+  P extends keyof McpMiddlewarePatternMap
+    ? (
+        ctx: McpMiddlewarePatternMap[P],
+        next: () => Promise<unknown>
+      ) => Promise<unknown>
+    : McpMiddlewareFn;
+
 /**
  * A single MCP middleware function.
  *

--- a/libraries/typescript/packages/mcp-use/src/server/types/index.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/types/index.ts
@@ -27,6 +27,7 @@ export {
 export {
   ReadResourceCallback,
   ReadResourceTemplateCallback,
+  InferTemplateParams,
   ResourceTemplateConfig,
   ResourceTemplateDefinition,
   ResourceTemplateDefinitionWithoutCallback,

--- a/libraries/typescript/packages/mcp-use/src/server/types/resource.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/types/resource.ts
@@ -9,6 +9,7 @@ import type { AdaptersConfig } from "@mcp-ui/server";
 import type { TypedCallToolResult } from "../utils/response-helpers.js";
 import type { ClientCapabilityChecker, McpContext } from "./context.js";
 import type { UnifiedWidgetMetadata } from "../widgets/adapters/types.js";
+import type { z } from "zod";
 
 // UIResourceContent type from MCP-UI
 export type UIResourceContent = {
@@ -125,20 +126,34 @@ export type ReadResourceCallback<HasOAuth extends boolean = false> =
   ReadResourceCallbackBivariant<HasOAuth>["bivarianceHack"];
 
 /**
+ * Extract template params type from a resource template definition's schema.
+ * Mirrors InferToolInput from tool.ts.
+ */
+export type InferTemplateParams<T> = T extends { schema: infer S }
+  ? S extends z.ZodTypeAny
+    ? z.infer<S>
+    : Record<string, any>
+  : Record<string, any>;
+
+/**
  * Callback type for reading a resource template with parameters.
  * Supports both CallToolResult (from helpers) and ReadResourceResult (old API).
  *
  * Supports multiple callback signatures:
  * - `async () => ...` - No parameters
  * - `async (uri: URL) => ...` - Just URI (required)
- * - `async (uri: URL, params: Record<string, any>) => ...` - URI and parameters (both required)
- * - `async (uri: URL, params: Record<string, any>, ctx: EnhancedResourceContext) => ...` - All parameters (all required)
+ * - `async (uri: URL, params: TParams) => ...` - URI and parameters (both required)
+ * - `async (uri: URL, params: TParams, ctx: EnhancedResourceContext) => ...` - All parameters (all required)
  *
  * The implementation checks callback.length to determine which signature to use.
  *
+ * @template TParams - Type for URI template parameters (defaults to Record<string, any>)
  * @template HasOAuth - Whether OAuth is configured (affects ctx.auth availability)
  */
-export type ReadResourceTemplateCallback<HasOAuth extends boolean = false> =
+export type ReadResourceTemplateCallback<
+  TParams extends Record<string, any> = Record<string, any>,
+  HasOAuth extends boolean = false,
+> =
   | (() => Promise<
       CallToolResult | ReadResourceResult | TypedCallToolResult<any>
     >)
@@ -149,13 +164,13 @@ export type ReadResourceTemplateCallback<HasOAuth extends boolean = false> =
     >)
   | ((
       uri: URL,
-      params: Record<string, any>
+      params: TParams
     ) => Promise<
       CallToolResult | ReadResourceResult | TypedCallToolResult<any>
     >)
   | ((
       uri: URL,
-      params: Record<string, any>,
+      params: TParams,
       ctx: EnhancedResourceContext<HasOAuth>
     ) => Promise<
       CallToolResult | ReadResourceResult | TypedCallToolResult<any>
@@ -206,13 +221,23 @@ export interface ResourceTemplateConfig {
 /**
  * Resource template definition with readCallback (old API)
  */
-export interface ResourceTemplateDefinition<HasOAuth extends boolean = false> {
+export interface ResourceTemplateDefinition<
+  HasOAuth extends boolean = false,
+  TParams extends Record<string, any> = Record<string, any>,
+> {
   name: string;
   resourceTemplate: ResourceTemplateConfig;
   title?: string;
   description?: string;
   annotations?: ResourceAnnotations;
-  readCallback: ReadResourceTemplateCallback<HasOAuth>;
+  /**
+   * Optional Zod schema for URI template parameters. When provided, narrows
+   * the `params` argument in the callback to `z.infer<schema>`.
+   *
+   * @example z.object({ id: z.string() })
+   */
+  schema?: z.ZodTypeAny;
+  readCallback: ReadResourceTemplateCallback<TParams, HasOAuth>;
   _meta?: Record<string, unknown>;
 }
 
@@ -225,6 +250,13 @@ export interface ResourceTemplateDefinitionWithoutCallback {
   title?: string;
   description?: string;
   annotations?: ResourceAnnotations;
+  /**
+   * Optional Zod schema for URI template parameters. When provided, narrows
+   * the `params` argument in the callback to `z.infer<schema>`.
+   *
+   * @example z.object({ id: z.string() })
+   */
+  schema?: z.ZodTypeAny;
   _meta?: Record<string, unknown>;
 }
 
@@ -236,6 +268,7 @@ export interface ResourceTemplateDefinitionWithoutCallback {
  */
 export interface FlatResourceTemplateDefinition<
   HasOAuth extends boolean = false,
+  TParams extends Record<string, any> = Record<string, any>,
 > {
   /**
    * Unique identifier for the template.
@@ -269,8 +302,15 @@ export interface FlatResourceTemplateDefinition<
   mimeType?: string;
   /** Optional annotations for the resource */
   annotations?: ResourceAnnotations;
+  /**
+   * Optional Zod schema for URI template parameters. When provided, narrows
+   * the `params` argument in the readCallback to `z.infer<schema>`.
+   *
+   * @example z.object({ id: z.string() })
+   */
+  schema?: z.ZodTypeAny;
   /** Async callback function that returns the resource content */
-  readCallback: ReadResourceTemplateCallback<HasOAuth>;
+  readCallback: ReadResourceTemplateCallback<TParams, HasOAuth>;
   _meta?: Record<string, unknown>;
   /** Complete callback for the resource template */
   callbacks?: ResourceTemplateCallbacks;
@@ -315,6 +355,13 @@ export interface FlatResourceTemplateDefinitionWithoutCallback {
   mimeType?: string;
   /** Optional annotations for the resource */
   annotations?: ResourceAnnotations;
+  /**
+   * Optional Zod schema for URI template parameters. When provided, narrows
+   * the `params` argument in the callback to `z.infer<schema>`.
+   *
+   * @example z.object({ id: z.string() })
+   */
+  schema?: z.ZodTypeAny;
   _meta?: Record<string, unknown>;
   /** Complete callback for the resource template */
   callbacks?: ResourceTemplateCallbacks;

--- a/libraries/typescript/packages/mcp-use/src/server/types/tool.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/types/tool.ts
@@ -1,5 +1,8 @@
 import type { InputDefinition } from "./common.js";
-import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+import type {
+  CallToolResult,
+  ToolAnnotations,
+} from "@modelcontextprotocol/sdk/types.js";
 import type { ToolContext } from "./tool-context.js";
 import type { McpContext } from "./context.js";
 import type { z } from "zod";
@@ -73,11 +76,14 @@ interface ToolCallbackBivariant<
   TOutput extends Record<string, unknown>,
   HasOAuth extends boolean,
 > {
-  // Method signature enables bivariant checking for TInput parameter
+  // Method signature enables bivariant checking for TInput parameter.
+  // The union with CallToolResult allows response helpers like text(), mix(),
+  // and markdown() to be used even when outputSchema is defined — the SDK
+  // validates structuredContent at runtime only when it is present.
   bivarianceHack(
     params: TInput,
     ctx: EnhancedToolContext<HasOAuth>
-  ): Promise<TypedCallToolResult<TOutput>>;
+  ): Promise<TypedCallToolResult<TOutput> | CallToolResult>;
 }
 
 /**
@@ -136,7 +142,7 @@ export type ToolCallbackWithContext<
 > = (
   params: TInput,
   ctx: EnhancedToolContext<HasOAuth>
-) => Promise<TypedCallToolResult<TOutput>>;
+) => Promise<TypedCallToolResult<TOutput> | CallToolResult>;
 
 /**
  * Extract input type from a tool definition's schema.

--- a/libraries/typescript/packages/mcp-use/src/server/utils/hono-proxy.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/utils/hono-proxy.ts
@@ -10,7 +10,7 @@ import {
   adaptConnectMiddleware,
   isExpressMiddleware,
 } from "../connect-adapter.js";
-import type { McpMiddlewareFn } from "../middleware/mcp-middleware.js";
+import type { McpMiddlewareFnFor } from "../middleware/mcp-middleware.js";
 
 /**
  * Express/Connect middleware signature
@@ -95,12 +95,19 @@ export function installCustomRoutesMiddleware(
 }
 
 /**
- * Typed overload for MCP operation-level middleware registered via `server.use('mcp:...', fn)`.
+ * Typed overloads for MCP operation-level middleware registered via `server.use('mcp:...', fn)`.
  * Exported so `McpServerInstance` can include it, giving callers automatic type inference
  * for `ctx` and `next` without explicit annotations.
+ *
+ * Known patterns (`mcp:tools/call`, `mcp:resources/read`, `mcp:prompts/get`) narrow the
+ * `ctx.params` type so that `ctx.params.name`, `ctx.params.uri`, etc. are directly accessible
+ * without a manual cast.
  */
 export type WithMcpUse = {
-  use(pattern: `mcp:${string}`, ...handlers: McpMiddlewareFn[]): any;
+  use<P extends string>(
+    pattern: `mcp:${P}`,
+    ...handlers: McpMiddlewareFnFor<P>[]
+  ): any;
 };
 
 /**

--- a/skills/mcp-apps-builder/references/server/tools.md
+++ b/skills/mcp-apps-builder/references/server/tools.md
@@ -85,7 +85,7 @@ z.object({
 - Add validation: `.min()`, `.max()`, `.email()`, `.url()`
 - Use `z.enum()` for fixed sets of values (not `z.string()`)
 - Use `z.array()` for lists
-- Use `z.record()` for key-value maps
+- Use `z.record(z.string(), z.string())` for key-value maps (Zod v4 requires both key and value schemas)
 
 ---
 


### PR DESCRIPTION
- Added new types for middleware context and parameters, including `ToolsCallParams`, `ResourcesReadParams`, and `PromptsGetParams`.
- Introduced `McpMiddlewarePatternMap` and `McpMiddlewareFnFor` to improve type inference for middleware functions.
- Updated `ResourceTemplateDefinition` and related types to support optional Zod schemas for parameter validation.
- Enhanced `MCPServerClass` to utilize the new type definitions, ensuring better type safety and flexibility in middleware handling.
