### PR TITLE
feat: ErrorBoundary fallback/onError props + inspector & connector fixes

### DIFF
--- a/docs/typescript/server/api-reference.mdx
+++ b/docs/typescript/server/api-reference.mdx
@@ -746,12 +746,15 @@ See [WidgetControls documentation](./widget-components/widgetcontrols) for detai
 
 #### `ErrorBoundary`
 
-Error boundary component for graceful error handling.
+Error boundary component for graceful error handling. Supports custom fallback UI and error callbacks.
 
 ```typescript
 import { ErrorBoundary } from 'mcp-use/react';
 
-<ErrorBoundary>
+<ErrorBoundary
+  fallback={(error) => <div>Error: {error.message}</div>}
+  onError={(error) => console.error(error)}
+>
   {children}
 </ErrorBoundary>
 ```

--- a/docs/typescript/server/widget-components/errorboundary.mdx
+++ b/docs/typescript/server/widget-components/errorboundary.mdx
@@ -4,7 +4,7 @@ description: "Error boundary component for graceful error handling in widgets"
 icon: "bug"
 ---
 
-The `ErrorBoundary` component catches React errors anywhere in the child component tree, logs those errors, and displays a friendly fallback UI instead of crashing the entire widget.
+The `ErrorBoundary` component catches React errors anywhere in the child component tree, logs those errors, and displays a fallback UI instead of crashing the entire widget.
 
 ## Import
 
@@ -21,6 +21,8 @@ import { ErrorBoundary } from 'mcp-use/react';
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
 | `children` | `React.ReactNode` | **required** | The widget content to wrap |
+| `fallback` | `ReactNode \| (error: Error) => ReactNode` | Built-in error card | Custom UI to render when an error is caught |
+| `onError` | `(error: Error, errorInfo: React.ErrorInfo) => void` | — | Callback invoked when an error is caught |
 
 ## Basic Usage
 
@@ -34,6 +36,61 @@ function MyWidget() {
     </ErrorBoundary>
   );
 }
+```
+
+## Custom Fallback
+
+Pass a `fallback` prop to render your own error UI instead of the default red error card.
+
+### Static Fallback
+
+```tsx
+<ErrorBoundary fallback={<div>Something went wrong. Please try again.</div>}>
+  <MyWidget />
+</ErrorBoundary>
+```
+
+### Dynamic Fallback with Error Details
+
+Pass a function to receive the error object:
+
+```tsx
+<ErrorBoundary fallback={(error) => (
+  <div className="p-4 rounded bg-yellow-50 text-yellow-800">
+    <p className="font-bold">Oops!</p>
+    <p className="text-sm">{error.message}</p>
+  </div>
+)}>
+  <MyWidget />
+</ErrorBoundary>
+```
+
+## Error Callback
+
+Use `onError` to log errors to an analytics service or perform side effects:
+
+```tsx
+<ErrorBoundary
+  onError={(error, errorInfo) => {
+    analytics.track('widget_error', {
+      message: error.message,
+      stack: errorInfo.componentStack,
+    });
+  }}
+>
+  <MyWidget />
+</ErrorBoundary>
+```
+
+You can combine `fallback` and `onError`:
+
+```tsx
+<ErrorBoundary
+  fallback={<div>Something went wrong</div>}
+  onError={(error) => console.error('Widget crashed:', error)}
+>
+  <MyWidget />
+</ErrorBoundary>
 ```
 
 ## Automatic Inclusion
@@ -50,9 +107,9 @@ import { McpUseProvider } from 'mcp-use/react';
 
 The error boundary wraps your widget content as the innermost wrapper, ensuring all errors are caught.
 
-## Error Display
+## Default Error Display
 
-When an error occurs, the boundary displays:
+When no `fallback` is provided and an error occurs, the boundary displays:
 
 - A red-bordered error container
 - The error message in a readable format
@@ -62,16 +119,15 @@ The error UI is styled to be visible but not intrusive, allowing users to unders
 
 ## Error Logging
 
-Errors are automatically logged to the console with:
+Errors are always logged to the console with:
 
 - The error object
 - React error info (component stack, etc.)
 
-This helps with debugging during development.
+This happens regardless of whether `onError` is provided.
 
 
 ## Related Components
 
 - [`McpUseProvider`](./mcpuseprovider) - Includes ErrorBoundary automatically
 - [`useWidget`](./usewidget) - Widget hook for accessing props and actions
-

--- a/libraries/typescript/.changeset/error-boundary-fallback.md
+++ b/libraries/typescript/.changeset/error-boundary-fallback.md
@@ -1,0 +1,8 @@
+---
+"mcp-use": patch
+"@mcp-use/inspector": patch
+---
+
+Add `fallback` and `onError` props to ErrorBoundary
+
+The `ErrorBoundary` component now accepts an optional `fallback` prop (`ReactNode` or `(error: Error) => ReactNode`) for custom error UI, and an `onError` callback for error reporting. When no fallback is provided, the default red error card is shown (backward compatible).

--- a/libraries/typescript/packages/inspector/src/client/components/MCPAppsRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/MCPAppsRenderer.tsx
@@ -1142,7 +1142,7 @@ function MCPAppsRendererBase({
             </div>
           )}
           <div
-            className="relative w-full"
+            className="relative w-full h-full"
             style={{ maxWidth: iframeStyle.maxWidth }}
           >
             <div className="absolute -top-8 left-2 z-10 h-full">

--- a/libraries/typescript/packages/mcp-use/src/connectors/base.ts
+++ b/libraries/typescript/packages/mcp-use/src/connectors/base.ts
@@ -194,6 +194,16 @@ export abstract class BaseConnector {
   protected setupNotificationHandler(): void {
     if (!this.client) return;
 
+    const forwardToUserHandlers = async (notification: Notification) => {
+      for (const handler of this.notificationHandlers) {
+        try {
+          await handler(notification);
+        } catch (err) {
+          logger.error("Error in notification handler:", err);
+        }
+      }
+    };
+
     // Use fallbackNotificationHandler to catch all notifications
     this.client.fallbackNotificationHandler = async (
       notification: Notification
@@ -211,19 +221,33 @@ export abstract class BaseConnector {
           await this.onPromptsListChanged();
           break;
         default:
-          // Other notification methods are handled by user-registered handlers
           break;
       }
 
-      // Then call user-registered handlers
-      for (const handler of this.notificationHandlers) {
-        try {
-          await handler(notification);
-        } catch (err) {
-          logger.error("Error in notification handler:", err);
-        }
-      }
+      await forwardToUserHandlers(notification);
     };
+
+    // The SDK registers specific handlers for progress and cancelled notifications
+    // that bypass fallbackNotificationHandler entirely. Override them to also
+    // forward to user-registered handlers so they appear in notification UIs.
+    const client = this.client as any;
+    const handlersMap = client._notificationHandlers as Map<
+      string,
+      (notification: Notification) => Promise<void>
+    >;
+
+    for (const method of [
+      "notifications/progress",
+      "notifications/cancelled",
+    ]) {
+      const originalHandler = handlersMap.get(method);
+      if (originalHandler) {
+        handlersMap.set(method, async (notification: Notification) => {
+          await originalHandler(notification);
+          await forwardToUserHandlers(notification);
+        });
+      }
+    }
   }
 
   /**

--- a/libraries/typescript/packages/mcp-use/src/react/ErrorBoundary.tsx
+++ b/libraries/typescript/packages/mcp-use/src/react/ErrorBoundary.tsx
@@ -9,11 +9,19 @@ const logger = Logger.get("ErrorBoundary");
  * This component catches JavaScript errors anywhere in the child component tree,
  * logs those errors, and displays a fallback UI instead of crashing the entire app.
  */
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+  /** Custom fallback UI to render when an error is caught. Receives the error object. */
+  fallback?: React.ReactNode | ((error: Error) => React.ReactNode);
+  /** Callback invoked when an error is caught */
+  onError?: (error: Error, errorInfo: React.ErrorInfo) => void;
+}
+
 export class ErrorBoundary extends React.Component<
-  { children: React.ReactNode },
+  ErrorBoundaryProps,
   { hasError: boolean; error: Error | null }
 > {
-  constructor(props: { children: React.ReactNode }) {
+  constructor(props: ErrorBoundaryProps) {
     super(props);
     this.state = { hasError: false, error: null };
   }
@@ -24,15 +32,22 @@ export class ErrorBoundary extends React.Component<
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     logger.error("Widget Error:", error, errorInfo);
+    this.props.onError?.(error, errorInfo);
   }
 
   render() {
-    if (this.state.hasError) {
+    if (this.state.hasError && this.state.error) {
+      if (this.props.fallback !== undefined) {
+        return typeof this.props.fallback === "function"
+          ? this.props.fallback(this.state.error)
+          : this.props.fallback;
+      }
+
       return (
         <div className="p-4 border border-red-500 bg-red-50 text-red-900 rounded-md dark:bg-red-900/20 dark:text-red-100">
           <h3 className="font-bold mb-2">Widget Error</h3>
           <pre className="text-sm whitespace-pre-wrap">
-            {this.state.error?.message}
+            {this.state.error.message}
           </pre>
         </div>
       );


### PR DESCRIPTION
## Summary

- **ErrorBoundary**: Add `fallback` and `onError` props for custom error UI and error reporting
- **Inspector**: MCPAppsRenderer fix
- **Connectors**: base.ts improvements

## Changes

### `ErrorBoundary` component (`mcp-use/react`)
- New `fallback` prop: `ReactNode | ((error: Error) => ReactNode)` — custom UI when an error is caught
- New `onError` prop: `(error: Error, errorInfo: React.ErrorInfo) => void` — callback for error logging/analytics
- Fully backward compatible — default red error card renders when no `fallback` is provided

### Documentation
- Updated `docs/typescript/server/widget-components/errorboundary.mdx` with new props table, examples for static/dynamic fallback, error callback, and combined usage
- Updated `docs/typescript/server/api-reference.mdx` ErrorBoundary snippet

### Inspector
- MCPAppsRenderer fix

### Connectors
- base.ts improvements

## Test plan
- [ ] `pnpm build` passes
- [ ] Existing ErrorBoundary behavior unchanged when no props are passed
- [ ] Custom `fallback` renders when error occurs
- [ ] `onError` callback fires on error