### PR TITLE
feat(org): add organization management commands and enhance deployment options

### DIFF
--- a/libraries/typescript/.changeset/cli-organization-support.md
+++ b/libraries/typescript/.changeset/cli-organization-support.md
@@ -1,0 +1,12 @@
+---
+"@mcp-use/cli": minor
+---
+
+Add organization support to the CLI
+
+- `mcp-use org list` / `switch` / `current` commands to manage organizations
+- `mcp-use deploy --org <slug-or-id>` to deploy to a specific organization
+- Login flow now prompts for organization selection when the user belongs to multiple orgs
+- `whoami` displays the active organization
+- All API requests include `x-profile-id` header for org-scoped operations
+- Organization preference is persisted in `~/.mcp-use/config.json`

--- a/libraries/typescript/packages/cli/src/commands/auth.ts
+++ b/libraries/typescript/packages/cli/src/commands/auth.ts
@@ -12,8 +12,10 @@ import {
   getApiKey,
   getWebUrl,
   isLoggedIn,
+  readConfig,
   writeConfig,
 } from "../utils/config.js";
+import type { ProfileInfo } from "../utils/api.js";
 
 const LOGIN_TIMEOUT = 300000; // 5 minutes
 
@@ -302,6 +304,60 @@ async function startCallbackServer(
 }
 
 /**
+ * Prompt user to pick an organization from a numbered list.
+ * Returns the selected profile or null if selection fails.
+ */
+export async function promptOrgSelection(
+  profiles: ProfileInfo[],
+  defaultProfileId?: string | null
+): Promise<ProfileInfo | null> {
+  if (profiles.length === 0) return null;
+
+  if (profiles.length === 1) {
+    return profiles[0];
+  }
+
+  console.log(chalk.cyan.bold("\n🏢 Select an organization:\n"));
+
+  for (let i = 0; i < profiles.length; i++) {
+    const p = profiles[i];
+    const marker = p.id === defaultProfileId ? chalk.green(" (current)") : "";
+    const slug = p.slug ? chalk.gray(` (${p.slug})`) : "";
+    console.log(
+      `  ${chalk.white(`${i + 1}.`)} ${p.profile_name}${slug}${marker}`
+    );
+  }
+
+  const readline = await import("node:readline");
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  return new Promise((resolve) => {
+    const defaultIdx = defaultProfileId
+      ? profiles.findIndex((p) => p.id === defaultProfileId)
+      : 0;
+    const defaultDisplay = defaultIdx >= 0 ? defaultIdx + 1 : 1;
+
+    rl.question(
+      chalk.gray(`\nEnter number [${defaultDisplay}]: `),
+      (answer) => {
+        rl.close();
+        const trimmed = answer.trim();
+        const idx = trimmed === "" ? defaultIdx : parseInt(trimmed, 10) - 1;
+        if (idx >= 0 && idx < profiles.length) {
+          resolve(profiles[idx]);
+        } else {
+          console.log(chalk.yellow("Invalid selection, using default."));
+          resolve(profiles[defaultIdx >= 0 ? defaultIdx : 0]);
+        }
+      }
+    );
+  });
+}
+
+/**
  * Login command - opens browser for OAuth flow
  */
 export async function loginCommand(options?: {
@@ -383,7 +439,7 @@ export async function loginCommand(options?: {
 
     console.log(chalk.green.bold("\n✓ Successfully logged in!"));
 
-    // Show user info card (same as whoami)
+    // Show user info and select organization
     try {
       const api = await McpUseAPI.create();
       const authInfo = await api.testAuth();
@@ -396,6 +452,40 @@ export async function loginCommand(options?: {
       if (apiKey) {
         const masked = apiKey.substring(0, 6) + "...";
         console.log(chalk.white("API Key: ") + chalk.gray(masked));
+      }
+
+      // Organization selection
+      const profiles = authInfo.profiles ?? [];
+      if (profiles.length > 0) {
+        let selectedProfile: ProfileInfo | null = null;
+
+        if (profiles.length === 1) {
+          selectedProfile = profiles[0];
+        } else {
+          selectedProfile = await promptOrgSelection(
+            profiles,
+            authInfo.default_profile_id
+          );
+        }
+
+        if (selectedProfile) {
+          const config = await readConfig();
+          await writeConfig({
+            ...config,
+            profileId: selectedProfile.id,
+            profileName: selectedProfile.profile_name,
+            profileSlug: selectedProfile.slug ?? undefined,
+          });
+
+          const slug = selectedProfile.slug
+            ? chalk.gray(` (${selectedProfile.slug})`)
+            : "";
+          console.log(
+            chalk.white("Org:     ") +
+              chalk.cyan(selectedProfile.profile_name) +
+              slug
+          );
+        }
       }
     } catch (error) {
       // If fetching user info fails, just skip it
@@ -486,9 +576,38 @@ export async function whoamiCommand(): Promise<void> {
 
     const apiKey = await getApiKey();
     if (apiKey) {
-      // Show first 6 characters
       const masked = apiKey.substring(0, 6) + "...";
       console.log(chalk.white("API Key: ") + chalk.gray(masked));
+    }
+
+    // Show organization info
+    const config = await readConfig();
+    const profiles = authInfo.profiles ?? [];
+    if (profiles.length > 0) {
+      const activeProfile = profiles.find(
+        (p) => p.id === (config.profileId || authInfo.default_profile_id)
+      );
+
+      if (activeProfile) {
+        const slug = activeProfile.slug
+          ? chalk.gray(` (${activeProfile.slug})`)
+          : "";
+        console.log(
+          chalk.white("Org:     ") +
+            chalk.cyan(activeProfile.profile_name) +
+            slug
+        );
+      }
+
+      if (profiles.length > 1) {
+        console.log(
+          chalk.gray(
+            `\n  ${profiles.length} organizations available. Use ` +
+              chalk.white("npx mcp-use org list") +
+              " to see all."
+          )
+        );
+      }
     }
   } catch (error) {
     console.error(

--- a/libraries/typescript/packages/cli/src/commands/deploy.ts
+++ b/libraries/typescript/packages/cli/src/commands/deploy.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import open from "open";
 import type { CreateDeploymentRequest, Deployment } from "../utils/api.js";
 import { McpUseAPI } from "../utils/api.js";
-import { getWebUrl, isLoggedIn } from "../utils/config.js";
+import { getWebUrl, isLoggedIn, readConfig } from "../utils/config.js";
 import { getGitInfo, isGitHubUrl } from "../utils/git.js";
 import { getProjectLink, saveProjectLink } from "../utils/project-link.js";
 import { loginCommand } from "./auth.js";
@@ -180,6 +180,7 @@ interface DeployOptions {
   env?: string[];
   envFile?: string;
   rootDir?: string;
+  org?: string;
 }
 
 /**
@@ -487,14 +488,18 @@ async function displayDeploymentProgress(
       // Determine the MCP Server URL to display
       const mcpServerUrl = getMcpServerUrl(finalDeployment);
 
-      // Determine dashboard URL if server exists
-      // Uses /cloud/servers/[id] - frontend redirects to /cloud/[org-slug]/servers/[id]
+      // Determine dashboard URL with org slug for direct navigation
       let dashboardUrl: string | null = null;
       const webUrl = (await getWebUrl()).replace(/\/$/, "");
-      if (finalDeployment.serverSlug) {
-        dashboardUrl = `${webUrl}/cloud/servers/${finalDeployment.serverSlug}`;
-      } else if (finalDeployment.serverId) {
-        dashboardUrl = `${webUrl}/cloud/servers/${finalDeployment.serverId}`;
+      const config = await readConfig();
+      const orgSlug = config.profileSlug;
+      const serverRef = finalDeployment.serverSlug || finalDeployment.serverId;
+      if (serverRef) {
+        if (orgSlug) {
+          dashboardUrl = `${webUrl}/cloud/${orgSlug}/servers/${serverRef}`;
+        } else {
+          dashboardUrl = `${webUrl}/cloud/servers/${serverRef}`;
+        }
       }
 
       const inspectorUrl = `https://inspector.manufact.com/inspector?autoConnect=${encodeURIComponent(
@@ -997,6 +1002,39 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
     // Check if project is linked to an existing deployment
     const api = await McpUseAPI.create();
 
+    // Resolve --org flag: match by slug or ID against the user's profiles
+    if (options.org) {
+      try {
+        const authInfo = await api.testAuth();
+        const match = (authInfo.profiles ?? []).find(
+          (p) =>
+            p.slug === options.org ||
+            p.id === options.org ||
+            p.profile_name.toLowerCase() === options.org!.toLowerCase()
+        );
+        if (match) {
+          api.setProfileId(match.id);
+          const slug = match.slug ? chalk.gray(` (${match.slug})`) : "";
+          console.log(
+            chalk.gray("Organization: ") + chalk.cyan(match.profile_name) + slug
+          );
+        } else {
+          console.error(
+            chalk.red(
+              `✗ Organization "${options.org}" not found. Run ${chalk.white("npx mcp-use org list")} to see available organizations.`
+            )
+          );
+          process.exit(1);
+        }
+      } catch (error) {
+        console.error(
+          chalk.red("✗ Failed to resolve organization:"),
+          chalk.red(error instanceof Error ? error.message : "Unknown error")
+        );
+        process.exit(1);
+      }
+    }
+
     // Pre-flight GitHub connection and repo access check (REQUIRED for GitHub repos)
     let githubVerified = false;
     try {
@@ -1201,6 +1239,23 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
       healthCheckPath: "/healthz",
       serverId,
     };
+
+    // Show target organization if not already shown by --org flag
+    if (!options.org) {
+      try {
+        const config = await readConfig();
+        if (config.profileName) {
+          const slug = config.profileSlug
+            ? chalk.gray(` (${config.profileSlug})`)
+            : "";
+          console.log(
+            chalk.gray("Organization: ") + chalk.cyan(config.profileName) + slug
+          );
+        }
+      } catch {
+        // Non-fatal
+      }
+    }
 
     // Create deployment
     console.log(chalk.gray("Creating deployment..."));

--- a/libraries/typescript/packages/cli/src/commands/org.ts
+++ b/libraries/typescript/packages/cli/src/commands/org.ts
@@ -1,0 +1,164 @@
+import chalk from "chalk";
+import { McpUseAPI } from "../utils/api.js";
+import { isLoggedIn, readConfig, writeConfig } from "../utils/config.js";
+import { promptOrgSelection } from "./auth.js";
+
+async function ensureLoggedIn(): Promise<boolean> {
+  if (!(await isLoggedIn())) {
+    console.log(chalk.yellow("⚠️  You are not logged in."));
+    console.log(
+      chalk.gray("Run " + chalk.white("npx mcp-use login") + " to get started.")
+    );
+    return false;
+  }
+  return true;
+}
+
+/**
+ * List all organizations the user belongs to
+ */
+export async function orgListCommand(): Promise<void> {
+  try {
+    if (!(await ensureLoggedIn())) return;
+
+    const api = await McpUseAPI.create();
+    const authInfo = await api.testAuth();
+    const config = await readConfig();
+
+    const profiles = authInfo.profiles ?? [];
+    const activeId = config.profileId || authInfo.default_profile_id;
+
+    if (profiles.length === 0) {
+      console.log(chalk.yellow("No organizations found."));
+      return;
+    }
+
+    console.log(chalk.cyan.bold("🏢 Your organizations:\n"));
+
+    for (const p of profiles) {
+      const isActive = p.id === activeId;
+      const marker = isActive ? chalk.green(" ← active") : "";
+      const slug = p.slug ? chalk.gray(` (${p.slug})`) : "";
+      const role = chalk.gray(` [${p.role}]`);
+      const name = isActive
+        ? chalk.cyan.bold(p.profile_name)
+        : chalk.white(p.profile_name);
+      console.log(`  ${name}${slug}${role}${marker}`);
+    }
+
+    if (profiles.length > 1) {
+      console.log(
+        chalk.gray("\nSwitch with " + chalk.white("npx mcp-use org switch"))
+      );
+    }
+  } catch (error) {
+    console.error(
+      chalk.red.bold("\n✗ Failed to list organizations:"),
+      chalk.red(error instanceof Error ? error.message : "Unknown error")
+    );
+    process.exit(1);
+  }
+}
+
+/**
+ * Switch the active organization
+ */
+export async function orgSwitchCommand(): Promise<void> {
+  try {
+    if (!(await ensureLoggedIn())) return;
+
+    const api = await McpUseAPI.create();
+    const authInfo = await api.testAuth();
+    const config = await readConfig();
+    const profiles = authInfo.profiles ?? [];
+
+    if (profiles.length === 0) {
+      console.log(chalk.yellow("No organizations found."));
+      return;
+    }
+
+    if (profiles.length === 1) {
+      const p = profiles[0];
+      const slug = p.slug ? chalk.gray(` (${p.slug})`) : "";
+      console.log(
+        chalk.yellow(
+          `You only have one organization: ${chalk.cyan(p.profile_name)}${slug}`
+        )
+      );
+      return;
+    }
+
+    const activeId = config.profileId || authInfo.default_profile_id;
+    const selected = await promptOrgSelection(profiles, activeId);
+
+    if (!selected) {
+      console.log(chalk.yellow("No organization selected."));
+      return;
+    }
+
+    // Update local config
+    await writeConfig({
+      ...config,
+      profileId: selected.id,
+      profileName: selected.profile_name,
+      profileSlug: selected.slug ?? undefined,
+    });
+
+    // Sync to backend so the web dashboard reflects the same default
+    try {
+      await api.setDefaultProfile(selected.id);
+    } catch {
+      // Non-fatal: the local config is what matters for CLI operations
+    }
+
+    const slug = selected.slug ? chalk.gray(` (${selected.slug})`) : "";
+    console.log(
+      chalk.green.bold("\n✓ Switched to ") +
+        chalk.cyan.bold(selected.profile_name) +
+        slug
+    );
+  } catch (error) {
+    console.error(
+      chalk.red.bold("\n✗ Failed to switch organization:"),
+      chalk.red(error instanceof Error ? error.message : "Unknown error")
+    );
+    process.exit(1);
+  }
+}
+
+/**
+ * Show the currently active organization
+ */
+export async function orgCurrentCommand(): Promise<void> {
+  try {
+    if (!(await ensureLoggedIn())) return;
+
+    const config = await readConfig();
+
+    if (!config.profileId) {
+      console.log(
+        chalk.yellow(
+          "No organization selected. Run " +
+            chalk.white("npx mcp-use org switch") +
+            " to pick one."
+        )
+      );
+      return;
+    }
+
+    const slug = config.profileSlug
+      ? chalk.gray(` (${config.profileSlug})`)
+      : "";
+    console.log(
+      chalk.cyan.bold("🏢 Active organization: ") +
+        chalk.white(config.profileName || config.profileId) +
+        slug
+    );
+  } catch (error) {
+    console.error(
+      chalk.red.bold("\n✗ Failed to get organization:"),
+      chalk.red(error instanceof Error ? error.message : "Unknown error")
+    );
+    process.exit(1);
+  }
+}

--- a/libraries/typescript/packages/cli/src/index.ts
+++ b/libraries/typescript/packages/cli/src/index.ts
@@ -15,6 +15,11 @@ import { loginCommand, logoutCommand, whoamiCommand } from "./commands/auth.js";
 import { createClientCommand } from "./commands/client.js";
 import { deployCommand } from "./commands/deploy.js";
 import { createDeploymentsCommand } from "./commands/deployments.js";
+import {
+  orgCurrentCommand,
+  orgListCommand,
+  orgSwitchCommand,
+} from "./commands/org.js";
 import { createSkillsCommand } from "./commands/skills.js";
 import { notifyIfUpdateAvailable } from "./utils/update-check.js";
 const program = new Command();
@@ -2457,6 +2462,30 @@ program
     await whoamiCommand();
   });
 
+// Organization commands
+const orgCommand = program.command("org").description("Manage organizations");
+
+orgCommand
+  .command("list")
+  .description("List your organizations")
+  .action(async () => {
+    await orgListCommand();
+  });
+
+orgCommand
+  .command("switch")
+  .description("Switch the active organization")
+  .action(async () => {
+    await orgSwitchCommand();
+  });
+
+orgCommand
+  .command("current")
+  .description("Show the currently active organization")
+  .action(async () => {
+    await orgCurrentCommand();
+  });
+
 // Deployment command
 program
   .command("deploy")
@@ -2478,6 +2507,10 @@ program
     "--root-dir <path>",
     "Root directory within repo to deploy from (for monorepos)"
   )
+  .option(
+    "--org <slug-or-id>",
+    "Deploy to a specific organization (by slug or ID)"
+  )
   .action(async (options) => {
     await deployCommand({
       open: options.open,
@@ -2488,6 +2521,7 @@ program
       env: options.env,
       envFile: options.envFile,
       rootDir: options.rootDir,
+      org: options.org,
     });
   });
 

--- a/libraries/typescript/packages/cli/src/utils/api.ts
+++ b/libraries/typescript/packages/cli/src/utils/api.ts
@@ -1,4 +1,4 @@
-import { getApiKey, getApiUrl } from "./config.js";
+import { getApiKey, getApiUrl, getProfileId } from "./config.js";
 
 export interface APIKeyCreateRequest {
   name: string;
@@ -9,10 +9,19 @@ export interface APIKeyCreateResponse {
   name: string;
 }
 
+export interface ProfileInfo {
+  id: string;
+  profile_name: string;
+  slug: string | null;
+  role: string;
+}
+
 export interface AuthTestResponse {
   message: string;
   user_id: string;
   email: string;
+  profiles: ProfileInfo[];
+  default_profile_id: string | null;
 }
 
 export interface GitHubSource {
@@ -145,10 +154,12 @@ export interface GitHubReposResponse {
 export class McpUseAPI {
   private baseUrl: string;
   private apiKey: string | undefined;
+  private profileId: string | undefined;
 
-  constructor(baseUrl?: string, apiKey?: string) {
+  constructor(baseUrl?: string, apiKey?: string, profileId?: string) {
     this.baseUrl = baseUrl || "";
     this.apiKey = apiKey;
+    this.profileId = profileId;
   }
 
   /**
@@ -157,7 +168,15 @@ export class McpUseAPI {
   static async create(): Promise<McpUseAPI> {
     const baseUrl = await getApiUrl();
     const apiKey = await getApiKey();
-    return new McpUseAPI(baseUrl, apiKey ?? undefined);
+    const profileId = await getProfileId();
+    return new McpUseAPI(baseUrl, apiKey ?? undefined, profileId ?? undefined);
+  }
+
+  /**
+   * Override the profile ID for this API client instance (e.g. from --org flag)
+   */
+  setProfileId(profileId: string): void {
+    this.profileId = profileId;
   }
 
   /**
@@ -180,6 +199,10 @@ export class McpUseAPI {
 
     if (this.apiKey) {
       headers["x-api-key"] = this.apiKey;
+    }
+
+    if (this.profileId) {
+      headers["x-profile-id"] = this.profileId;
     }
 
     // Add timeout support (default 30 seconds)
@@ -246,6 +269,15 @@ export class McpUseAPI {
   }
 
   /**
+   * Set the user's default profile (organization) on the server
+   */
+  async setDefaultProfile(profileId: string): Promise<void> {
+    await this.request(`/profiles/${profileId}/set-default`, {
+      method: "POST",
+    });
+  }
+
+  /**
    * Create deployment
    */
   async createDeployment(
@@ -275,6 +307,9 @@ export class McpUseAPI {
 
     if (this.apiKey) {
       headers["x-api-key"] = this.apiKey;
+    }
+    if (this.profileId) {
+      headers["x-profile-id"] = this.profileId;
     }
 
     const response = await fetch(url, { headers });
@@ -378,6 +413,9 @@ export class McpUseAPI {
     if (this.apiKey) {
       headers["x-api-key"] = this.apiKey;
     }
+    if (this.profileId) {
+      headers["x-profile-id"] = this.profileId;
+    }
 
     const response = await fetch(url, {
       method: "POST",
@@ -459,6 +497,7 @@ export class McpUseAPI {
 
       const headers: Record<string, string> = {};
       if (this.apiKey) headers["x-api-key"] = this.apiKey;
+      if (this.profileId) headers["x-profile-id"] = this.profileId;
 
       const response = await fetch(
         `${this.baseUrl}/deployments/${deploymentId}/redeploy`,

--- a/libraries/typescript/packages/cli/src/utils/config.ts
+++ b/libraries/typescript/packages/cli/src/utils/config.ts
@@ -5,6 +5,9 @@ import path from "node:path";
 export interface McpConfig {
   apiKey?: string;
   apiUrl?: string;
+  profileId?: string;
+  profileName?: string;
+  profileSlug?: string;
 }
 
 const CONFIG_DIR = path.join(os.homedir(), ".mcp-use");
@@ -85,6 +88,14 @@ export async function getApiKey(): Promise<string | null> {
 export async function isLoggedIn(): Promise<boolean> {
   const apiKey = await getApiKey();
   return !!apiKey;
+}
+
+/**
+ * Get the stored profile (organization) ID from config
+ */
+export async function getProfileId(): Promise<string | null> {
+  const config = await readConfig();
+  return config.profileId || null;
 }
 
 /**


### PR DESCRIPTION
- Introduced new commands for managing organizations: `org list`, `org switch`, and `org current`.
- Enhanced the `deploy` command to accept an `--org` option for specifying the target organization.
- Implemented organization selection during login and updated user info display to include organization details.
- Added utility functions for prompting organization selection and retrieving stored profile information.
