### PR TITLE
feat(cli): add --yes option to skip confirmation prompts during deployment

### DIFF
--- a/libraries/typescript/.changeset/cli-deploy-yes-flag.md
+++ b/libraries/typescript/.changeset/cli-deploy-yes-flag.md
@@ -1,0 +1,9 @@
+---
+"@mcp-use/cli": patch
+---
+
+Add `-y` / `--yes` to `mcp-use deploy` for non-interactive runs
+
+- Skip confirmation prompts (MCP project, uncommitted changes, final deploy, GitHub connect/retry) when the flag is set
+- If not logged in and `--yes` is passed, exit with an error instructing users to run `mcp-use login` first (browser login cannot be automated)
+- With `--yes`, post-GitHub-setup “Press Enter” is replaced by polling connection status instead of blocking on stdin

--- a/libraries/typescript/packages/cli/src/commands/deploy.ts
+++ b/libraries/typescript/packages/cli/src/commands/deploy.ts
@@ -181,6 +181,8 @@ interface DeployOptions {
   envFile?: string;
   rootDir?: string;
   org?: string;
+  /** Skip interactive confirmation prompts (non-interactive / CI) */
+  yes?: boolean;
 }
 
 /**
@@ -363,7 +365,8 @@ function getMcpServerUrl(deployment: Deployment): string {
  */
 async function displayDeploymentProgress(
   api: McpUseAPI,
-  deployment: Deployment
+  deployment: Deployment,
+  progressOptions?: { yes?: boolean }
 ): Promise<void> {
   const frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
   let frameIndex = 0;
@@ -532,11 +535,20 @@ async function displayDeploymentProgress(
         // Check for GitHub access errors and offer to fix
         if (finalDeployment.error.includes("No GitHub installations found")) {
           console.log();
-          const retry = await promptGitHubInstallation(api, "not_connected");
+          const retry = await promptGitHubInstallation(
+            api,
+            "not_connected",
+            undefined,
+            { yes: progressOptions?.yes }
+          );
           if (retry) {
             console.log(chalk.cyan("\n🔄 Retrying deployment...\n"));
             const newDeployment = await api.redeployDeployment(deployment.id);
-            await displayDeploymentProgress(api, newDeployment);
+            await displayDeploymentProgress(
+              api,
+              newDeployment,
+              progressOptions
+            );
             return;
           }
         } else if (
@@ -558,12 +570,17 @@ async function displayDeploymentProgress(
           const retry = await promptGitHubInstallation(
             api,
             "no_access",
-            repoName
+            repoName,
+            { yes: progressOptions?.yes }
           );
           if (retry) {
             console.log(chalk.cyan("\n🔄 Retrying deployment...\n"));
             const newDeployment = await api.redeployDeployment(deployment.id);
-            await displayDeploymentProgress(api, newDeployment);
+            await displayDeploymentProgress(
+              api,
+              newDeployment,
+              progressOptions
+            );
             return;
           }
         }
@@ -632,14 +649,74 @@ async function checkRepoAccess(
   }
 }
 
+const GITHUB_SETUP_POLL_INTERVAL_MS = 2000;
+const GITHUB_SETUP_POLL_MAX_MS = 120_000;
+
+/**
+ * After opening the GitHub App URL, wait for the user to finish setup.
+ * In interactive mode, waits for Enter. With `yes`, polls connection/repo access.
+ */
+async function waitForGitHubSetupAfterBrowser(
+  api: McpUseAPI,
+  repoName: string | undefined,
+  yes: boolean
+): Promise<void> {
+  if (!yes) {
+    console.log(chalk.gray("Waiting for GitHub configuration..."));
+    await prompt(
+      chalk.white("Press Enter when you've completed the GitHub setup..."),
+      "y"
+    );
+    return;
+  }
+
+  console.log(
+    chalk.gray(
+      "Waiting for GitHub configuration (polling every 2s, up to 2 min)..."
+    )
+  );
+  const deadline = Date.now() + GITHUB_SETUP_POLL_MAX_MS;
+
+  while (Date.now() < deadline) {
+    try {
+      const status = await api.getGitHubConnectionStatus();
+      if (!status.is_connected) {
+        await new Promise((r) => setTimeout(r, GITHUB_SETUP_POLL_INTERVAL_MS));
+        continue;
+      }
+      if (repoName) {
+        const parts = repoName.split("/");
+        const owner = parts[0];
+        const repo = parts[1];
+        if (owner && repo && (await checkRepoAccess(api, owner, repo))) {
+          return;
+        }
+      } else {
+        return;
+      }
+    } catch {
+      // keep polling
+    }
+    await new Promise((r) => setTimeout(r, GITHUB_SETUP_POLL_INTERVAL_MS));
+  }
+
+  console.log(
+    chalk.yellow(
+      "⚠️  Timed out waiting for GitHub setup. Continuing with verification..."
+    )
+  );
+}
+
 /**
  * Prompt user to install/configure GitHub App with repo verification
  */
 async function promptGitHubInstallation(
   api: McpUseAPI,
   reason: "not_connected" | "no_access",
-  repoName?: string
+  repoName?: string,
+  opts?: { yes?: boolean }
 ): Promise<boolean> {
+  const yes = !!opts?.yes;
   console.log();
 
   if (reason === "not_connected") {
@@ -658,12 +735,14 @@ async function promptGitHubInstallation(
     );
   }
 
-  const shouldInstall = await prompt(
-    chalk.white(
-      `Would you like to ${reason === "not_connected" ? "connect" : "configure"} GitHub now? (Y/n): `
-    ),
-    "y"
-  );
+  const shouldInstall = yes
+    ? true
+    : await prompt(
+        chalk.white(
+          `Would you like to ${reason === "not_connected" ? "connect" : "configure"} GitHub now? (Y/n): `
+        ),
+        "y"
+      );
 
   if (!shouldInstall) {
     return false;
@@ -715,12 +794,7 @@ async function promptGitHubInstallation(
     // Open the browser
     await open(installUrl);
 
-    // Wait for user confirmation
-    console.log(chalk.gray("Waiting for GitHub configuration..."));
-    await prompt(
-      chalk.white("Press Enter when you've completed the GitHub setup..."),
-      "y"
-    );
+    await waitForGitHubSetupAfterBrowser(api, repoName, yes);
 
     // Verify connection (best effort)
     console.log(chalk.gray("Verifying GitHub connection..."));
@@ -794,6 +868,17 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
     // Check if logged in
     if (!(await isLoggedIn())) {
       console.log(chalk.red("✗ You are not logged in."));
+      if (options.yes) {
+        console.log(
+          chalk.gray(
+            "Run " +
+              chalk.white("npx mcp-use login") +
+              " first. Non-interactive deploy requires an existing session."
+          )
+        );
+        process.exit(1);
+      }
+
       const shouldLogin = await prompt(
         chalk.white("Would you like to login now? (Y/n): "),
         "y"
@@ -857,12 +942,14 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
           "⚠️  This doesn't appear to be an MCP server project (no mcp-use or @modelcontextprotocol/sdk dependency found)."
         )
       );
-      const shouldContinue = await prompt(
-        chalk.white("Continue anyway? (y/n): ")
-      );
-      if (!shouldContinue) {
-        console.log(chalk.gray("Deployment cancelled."));
-        process.exit(0);
+      if (!options.yes) {
+        const shouldContinue = await prompt(
+          chalk.white("Continue anyway? (y/n): ")
+        );
+        if (!shouldContinue) {
+          console.log(chalk.gray("Deployment cancelled."));
+          process.exit(0);
+        }
       }
       console.log();
     }
@@ -915,13 +1002,15 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
         )
       );
 
-      const shouldContinue = await prompt(
-        chalk.white("Continue with deployment from GitHub? (y/n): ")
-      );
+      if (!options.yes) {
+        const shouldContinue = await prompt(
+          chalk.white("Continue with deployment from GitHub? (y/n): ")
+        );
 
-      if (!shouldContinue) {
-        console.log(chalk.gray("Deployment cancelled."));
-        process.exit(0);
+        if (!shouldContinue) {
+          console.log(chalk.gray("Deployment cancelled."));
+          process.exit(0);
+        }
       }
       console.log();
     }
@@ -949,16 +1038,18 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
     console.log();
 
     // Confirm deployment
-    const shouldDeploy = await prompt(
-      chalk.white(
-        `Deploy from GitHub repository ${gitInfo.owner}/${gitInfo.repo}? (Y/n): `
-      ),
-      "y"
-    );
+    if (!options.yes) {
+      const shouldDeploy = await prompt(
+        chalk.white(
+          `Deploy from GitHub repository ${gitInfo.owner}/${gitInfo.repo}? (Y/n): `
+        ),
+        "y"
+      );
 
-    if (!shouldDeploy) {
-      console.log(chalk.gray("Deployment cancelled."));
-      process.exit(0);
+      if (!shouldDeploy) {
+        console.log(chalk.gray("Deployment cancelled."));
+        process.exit(0);
+      }
     }
 
     // Detect project settings (use projectDir for subfolder-aware detection)
@@ -1048,7 +1139,8 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
         const installed = await promptGitHubInstallation(
           api,
           "not_connected",
-          repoFullName
+          repoFullName,
+          { yes: options.yes }
         );
         if (!installed) {
           console.log(chalk.gray("Deployment cancelled."));
@@ -1087,7 +1179,8 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
           const configured = await promptGitHubInstallation(
             api,
             "no_access",
-            repoFullName
+            repoFullName,
+            { yes: options.yes }
           );
           if (!configured) {
             console.log(chalk.gray("Deployment cancelled."));
@@ -1189,7 +1282,9 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
           });
 
           // Display progress
-          await displayDeploymentProgress(api, deployment);
+          await displayDeploymentProgress(api, deployment, {
+            yes: options.yes,
+          });
 
           // Open in browser if requested
           if (options.open && deployment.domain) {
@@ -1279,7 +1374,7 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
     console.log(chalk.gray(`  Future deploys will reuse the same URL\n`));
 
     // Display progress
-    await displayDeploymentProgress(api, deployment);
+    await displayDeploymentProgress(api, deployment, { yes: options.yes });
 
     // Open in browser if requested
     if (options.open && deployment.domain) {

--- a/libraries/typescript/packages/cli/src/index.ts
+++ b/libraries/typescript/packages/cli/src/index.ts
@@ -2511,6 +2511,7 @@ program
     "--org <slug-or-id>",
     "Deploy to a specific organization (by slug or ID)"
   )
+  .option("-y, --yes", "Skip confirmation prompts")
   .action(async (options) => {
     await deployCommand({
       open: options.open,
@@ -2522,6 +2523,7 @@ program
       envFile: options.envFile,
       rootDir: options.rootDir,
       org: options.org,
+      yes: options.yes,
     });
   });
 


### PR DESCRIPTION
- Introduced a new `--yes` option to the deploy command, allowing users to bypass interactive confirmation prompts.
- Updated the deployment process to handle non-interactive scenarios, improving usability in CI environments.
- Enhanced related functions to respect the `yes` flag for GitHub setup and deployment confirmations.
