### PR TITLE
chore: clean up package dependencies in pnpm-lock.yaml and package.json files

### DIFF
--- a/libraries/typescript/.changeset/clean-template-deps.md
+++ b/libraries/typescript/.changeset/clean-template-deps.md
@@ -1,0 +1,9 @@
+---
+"create-mcp-use-app": patch
+---
+
+Clean up create-mcp-use-app template dependencies
+
+- Remove unused deps from blank and starter templates: @openai/apps-sdk-ui, @tanstack/react-query, cors, express
+- Remove build tool devDeps from all 3 templates (vite, @vitejs/plugin-react, @tailwindcss/vite) — these are provided by @mcp-use/cli
+- Remove cargo-culted overrides (sugarss, lodash) from all 3 templates — no longer needed, zero audit vulnerabilities without them

--- a/libraries/typescript/packages/create-mcp-use-app/src/templates/blank/package.json
+++ b/libraries/typescript/packages/create-mcp-use-app/src/templates/blank/package.json
@@ -20,10 +20,6 @@
     "deploy": "mcp-use deploy"
   },
   "dependencies": {
-    "@openai/apps-sdk-ui": "^0.2.1",
-    "@tanstack/react-query": "^5.90.21",
-    "cors": "^2.8.6",
-    "express": "^5.2.1",
     "mcp-use": "workspace:*",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
@@ -32,17 +28,10 @@
     "zod": "4.3.5"
   },
   "devDependencies": {
-    "@tailwindcss/vite": "^4.2.0",
     "@types/node": "^25.3.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react": "^6.0.0",
     "tsx": "^4.21.0",
-    "typescript": "^5.9.3",
-    "vite": "^8.0.0"
-  },
-  "overrides": {
-    "sugarss": "^5.0.1",
-    "lodash": "4.17.23"
+    "typescript": "^5.9.3"
   }
 }

--- a/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/package.json
+++ b/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/package.json
@@ -37,17 +37,10 @@
     "zod": "4.3.5"
   },
   "devDependencies": {
-    "@tailwindcss/vite": "^4.2.0",
     "@types/node": "^25.3.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react": "^6.0.0",
     "tsx": "^4.21.0",
-    "typescript": "^5.9.3",
-    "vite": "^8.0.0"
-  },
-  "overrides": {
-    "sugarss": "^5.0.1",
-    "lodash": "4.17.23"
+    "typescript": "^5.9.3"
   }
 }

--- a/libraries/typescript/packages/create-mcp-use-app/src/templates/starter/package.json
+++ b/libraries/typescript/packages/create-mcp-use-app/src/templates/starter/package.json
@@ -28,10 +28,6 @@
     "deploy": "mcp-use deploy"
   },
   "dependencies": {
-    "@openai/apps-sdk-ui": "^0.2.1",
-    "@tanstack/react-query": "^5.90.21",
-    "cors": "^2.8.6",
-    "express": "^5.2.1",
     "mcp-use": "workspace:*",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
@@ -40,17 +36,10 @@
     "zod": "4.3.5"
   },
   "devDependencies": {
-    "@tailwindcss/vite": "^4.2.0",
     "@types/node": "^25.3.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react": "^6.0.0",
     "tsx": "^4.21.0",
-    "typescript": "^5.9.3",
-    "vite": "^8.0.0"
-  },
-  "overrides": {
-    "sugarss": "^5.0.1",
-    "lodash": "4.17.23"
+    "typescript": "^5.9.3"
   }
 }

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -217,18 +217,6 @@ importers:
 
   packages/create-mcp-use-app/src/templates/blank:
     dependencies:
-      '@openai/apps-sdk-ui':
-        specifier: ^0.2.1
-        version: 0.2.1(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.0)
-      '@tanstack/react-query':
-        specifier: ^5.90.21
-        version: 5.90.21(react@19.2.4)
-      cors:
-        specifier: ^2.8.6
-        version: 2.8.6
-      express:
-        specifier: ^5.2.1
-        version: 5.2.1
       mcp-use:
         specifier: workspace:*
         version: link:../../../../mcp-use
@@ -248,9 +236,6 @@ importers:
         specifier: 4.3.5
         version: 4.3.5
     devDependencies:
-      '@tailwindcss/vite':
-        specifier: ^4.2.0
-        version: 4.2.0(vite@8.0.0(@types/node@25.3.0)(esbuild@0.27.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
       '@types/node':
         specifier: ^25.3.0
         version: 25.3.0
@@ -260,18 +245,12 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.10)
-      '@vitejs/plugin-react':
-        specifier: ^6.0.0
-        version: 6.0.1(vite@8.0.0(@types/node@25.3.0)(esbuild@0.27.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
-      vite:
-        specifier: ^8.0.0
-        version: 8.0.0(@types/node@25.3.0)(esbuild@0.27.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/create-mcp-use-app/src/templates/mcp-apps:
     dependencies:
@@ -297,9 +276,6 @@ importers:
         specifier: 4.3.5
         version: 4.3.5
     devDependencies:
-      '@tailwindcss/vite':
-        specifier: ^4.2.0
-        version: 4.2.0(vite@8.0.0(@types/node@25.3.0)(esbuild@0.27.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
       '@types/node':
         specifier: ^25.3.0
         version: 25.3.0
@@ -309,33 +285,15 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.10)
-      '@vitejs/plugin-react':
-        specifier: ^6.0.0
-        version: 6.0.1(vite@8.0.0(@types/node@25.3.0)(esbuild@0.27.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
-      vite:
-        specifier: ^8.0.0
-        version: 8.0.0(@types/node@25.3.0)(esbuild@0.27.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/create-mcp-use-app/src/templates/starter:
     dependencies:
-      '@openai/apps-sdk-ui':
-        specifier: ^0.2.1
-        version: 0.2.1(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.0)
-      '@tanstack/react-query':
-        specifier: ^5.90.21
-        version: 5.90.21(react@19.2.4)
-      cors:
-        specifier: ^2.8.6
-        version: 2.8.6
-      express:
-        specifier: ^5.2.1
-        version: 5.2.1
       mcp-use:
         specifier: workspace:*
         version: link:../../../../mcp-use
@@ -355,9 +313,6 @@ importers:
         specifier: 4.3.5
         version: 4.3.5
     devDependencies:
-      '@tailwindcss/vite':
-        specifier: ^4.2.0
-        version: 4.2.0(vite@8.0.0(@types/node@25.3.0)(esbuild@0.27.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
       '@types/node':
         specifier: ^25.3.0
         version: 25.3.0
@@ -367,18 +322,12 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.10)
-      '@vitejs/plugin-react':
-        specifier: ^6.0.0
-        version: 6.0.1(vite@8.0.0(@types/node@25.3.0)(esbuild@0.27.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
-      vite:
-        specifier: ^8.0.0
-        version: 8.0.0(@types/node@25.3.0)(esbuild@0.27.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/inspector:
     dependencies:
@@ -1320,6 +1269,55 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^5.1.4
         version: 5.1.4(vite@8.0.0(@types/node@25.3.0)(esbuild@0.27.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.0(@types/node@25.3.0)(esbuild@0.27.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+
+  test_app:
+    dependencies:
+      '@openai/apps-sdk-ui':
+        specifier: ^0.2.1
+        version: 0.2.1(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.0)
+      mcp-use:
+        specifier: workspace:*
+        version: link:../packages/mcp-use
+      react:
+        specifier: ^19.2.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.0
+        version: 19.2.4(react@19.2.4)
+      react-router:
+        specifier: ^7.12.0
+        version: 7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      tailwindcss:
+        specifier: ^4.2.0
+        version: 4.2.0
+      zod:
+        specifier: 4.3.5
+        version: 4.3.5
+    devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.2.0
+        version: 4.2.0(vite@8.0.0(@types/node@25.3.0)(esbuild@0.27.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@types/node':
+        specifier: ^25.3.0
+        version: 25.3.0
+      '@types/react':
+        specifier: ^19.2.7
+        version: 19.2.10
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.10)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.0
+        version: 6.0.1(vite@8.0.0(@types/node@25.3.0)(esbuild@0.27.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -3606,11 +3604,6 @@ packages:
 
   '@tanstack/react-query@5.90.20':
     resolution: {integrity: sha512-vXBxa+qeyveVO7OA0jX1z+DeyCA4JKnThKv411jd5SORpBKgkcVnYKCiBgECvADvniBX7tobwBmg01qq9JmMJw==}
-    peerDependencies:
-      react: ^19.2.0
-
-  '@tanstack/react-query@5.90.21':
-    resolution: {integrity: sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg==}
     peerDependencies:
       react: ^19.2.0
 
@@ -10219,11 +10212,6 @@ snapshots:
   '@tanstack/query-core@5.90.20': {}
 
   '@tanstack/react-query@5.90.20(react@19.2.4)':
-    dependencies:
-      '@tanstack/query-core': 5.90.20
-      react: 19.2.4
-
-  '@tanstack/react-query@5.90.21(react@19.2.4)':
     dependencies:
       '@tanstack/query-core': 5.90.20
       react: 19.2.4


### PR DESCRIPTION
- Removed unused dependencies from the `blank`, `mcp-apps`, and `starter` templates, including `@openai/apps-sdk-ui`, `@tanstack/react-query`, `cors`, `express`, and `@tailwindcss/vite`.
- Added a new `test_app` template with its own set of dependencies and devDependencies, including `react`, `react-dom`, and `tailwindcss`.
- Updated `package.json` files to reflect the removal of unnecessary dependencies while maintaining essential ones like `typescript` and `tsx`.
