### PR TITLE
chore: update @mcp-ui/client to version 7.0.0 and refactor MCP UI rendering components

### DIFF
--- a/libraries/typescript/.changeset/upgrade-mcp-ui-client-v7.md
+++ b/libraries/typescript/.changeset/upgrade-mcp-ui-client-v7.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": minor
+---
+
+Upgrade @mcp-ui/client from ^6.1.0 to ^7.0.0. Replace removed UIResourceRenderer with sandboxed iframes for legacy ui:// resources. Drop remote-dom support (removed upstream). MCP Apps rendering via MCPAppsRenderer is unaffected.

--- a/libraries/typescript/packages/inspector/package.json
+++ b/libraries/typescript/packages/inspector/package.json
@@ -93,7 +93,7 @@
     "@langchain/core": "^1.1.26",
     "@langchain/google-genai": "^2.1.19",
     "@langchain/openai": "^1.2.8",
-    "@mcp-ui/client": "^6.1.0",
+    "@mcp-ui/client": "^7.0.0",
     "@modelcontextprotocol/ext-apps": "^1.0.1",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/libraries/typescript/packages/inspector/src/client/components/McpUIRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/McpUIRenderer.tsx
@@ -1,12 +1,5 @@
 import type { Resource } from "@modelcontextprotocol/sdk/types.js";
-import {
-  basicComponentLibrary,
-  remoteButtonDefinition,
-  remoteImageDefinition,
-  remoteStackDefinition,
-  remoteTextDefinition,
-  UIResourceRenderer,
-} from "@mcp-ui/client";
+import { useMemo } from "react";
 
 interface McpUIRendererProps {
   resource: Resource;
@@ -24,6 +17,7 @@ export function isMcpUIResource(resource: any): boolean {
   const mimeType = resource.mimeType.toLowerCase();
   return (
     mimeType === "text/html" ||
+    mimeType === "text/html;profile=mcp-app" ||
     mimeType === "text/html+skybridge" ||
     mimeType === "text/uri-list" ||
     mimeType.startsWith("application/vnd.mcp-ui.remote-dom")
@@ -31,71 +25,37 @@ export function isMcpUIResource(resource: any): boolean {
 }
 
 /**
- * Helper function to convert MCP SDK Resource to MCP UI Resource format
+ * Component to render MCP UI resources via a sandboxed iframe.
+ * Legacy remote-dom content types are no longer rendered interactively
+ * (upstream @mcp-ui/client v7 dropped remote-dom support).
  */
-function convertToMcpUIResource(resource: Resource): any {
+export function McpUIRenderer({ resource, className }: McpUIRendererProps) {
   const r = resource as Resource & { text?: string; blob?: string };
-  return {
-    uri: resource.uri,
-    mimeType: resource.mimeType,
-    text: r.text,
-    blob: r.blob,
-  };
-}
 
-/**
- * Component to render MCP UI resources
- */
-export function McpUIRenderer({
-  resource,
-  onUIAction,
-  className,
-  customProps,
-}: McpUIRendererProps) {
-  const handleUIAction = async (action: any) => {
-    return onUIAction?.(action);
-  };
-
-  const uiResource = convertToMcpUIResource(resource);
-
-  // Merge custom props into the resource if provided
-  const resourceWithProps = customProps
-    ? {
-        ...uiResource,
-        // Add custom props as data attributes or in a way the UIResourceRenderer can access
-        customProps,
+  const html = useMemo(() => {
+    if (r.text) return r.text;
+    if (r.blob) {
+      try {
+        return atob(r.blob);
+      } catch {
+        return null;
       }
-    : uiResource;
+    }
+    return null;
+  }, [r.text, r.blob]);
+
+  if (!html) return null;
 
   return (
     <div className={className}>
-      <UIResourceRenderer
-        resource={resourceWithProps}
-        onUIAction={handleUIAction}
-        htmlProps={{
-          autoResizeIframe: { width: true, height: true },
-          style: {
-            width: "100%",
-            minHeight: "200px",
-          },
-          sandboxPermissions: "allow-scripts allow-forms allow-popups",
-          // Pass custom props as data attributes
-          ...(customProps
-            ? {
-                "data-mcp-props": JSON.stringify(customProps),
-              }
-            : {}),
-        }}
-        remoteDomProps={{
-          remoteElements: [
-            remoteTextDefinition,
-            remoteButtonDefinition,
-            remoteStackDefinition,
-            remoteImageDefinition,
-          ],
-          library: basicComponentLibrary,
-          // Pass custom props to remote-dom components if supported
-          ...(customProps ? { customProps } : {}),
+      <iframe
+        srcDoc={html}
+        sandbox="allow-scripts allow-forms allow-popups"
+        title={resource.uri ?? "MCP UI Resource"}
+        style={{
+          width: "100%",
+          minHeight: "200px",
+          border: "none",
         }}
       />
     </div>

--- a/libraries/typescript/packages/inspector/src/client/components/chat/MCPUIResource.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/MCPUIResource.tsx
@@ -1,5 +1,4 @@
-import { UIResourceRenderer } from "@mcp-ui/client";
-import { memo } from "react";
+import { memo, useMemo } from "react";
 
 interface MCPUIResourceProps {
   resource: {
@@ -11,49 +10,35 @@ interface MCPUIResourceProps {
 }
 
 export const MCPUIResource = memo(({ resource }: MCPUIResourceProps) => {
-  const handleUIAction = async (result: any) => {
-    // console.log('MCP-UI Action:', result)
-
-    if (result.type === "tool") {
-      // console.log(
-      //   `Tool action: ${result.payload.toolName}`,
-      //   result.payload.params,
-      // )
-    } else if (result.type === "prompt") {
-      // console.log('Prompt action:', result.payload.prompt)
-    } else if (result.type === "link") {
-      // console.log('Link action:', result.payload.url)
-      // Optionally open the link
-      if (result.payload.url) {
-        window.open(result.payload.url, "_blank");
-      }
-    } else if (result.type === "intent") {
-      // console.log('Intent action:', result.payload.intent)
-    } else if (result.type === "notify") {
-      // console.log('Notification:', result.payload.message)
-    }
-
-    return { status: "Action received" };
-  };
-
-  // Only render if this is a UI resource
   if (!resource.uri?.startsWith("ui://")) {
     return null;
   }
 
+  const html = useMemo(() => {
+    if (resource.text) return resource.text;
+    if (resource.blob) {
+      try {
+        return atob(resource.blob);
+      } catch {
+        return null;
+      }
+    }
+    return null;
+  }, [resource.text, resource.blob]);
+
+  if (!html) return null;
+
   return (
     <div className="my-4 p-0 border h-[350px] rounded-2xl border-zinc-200 overflow-hidden bg-card">
-      <UIResourceRenderer
-        resource={resource}
-        onUIAction={handleUIAction}
-        htmlProps={{
-          style: {
-            maxWidth: "100%",
-            height: "100%",
-            overflow: "auto",
-          },
-          autoResizeIframe: true,
-          sandboxPermissions: "allow-scripts allow-forms allow-popups",
+      <iframe
+        srcDoc={html}
+        sandbox="allow-scripts allow-forms allow-popups"
+        title={resource.uri ?? "MCP UI Resource"}
+        style={{
+          width: "100%",
+          height: "100%",
+          border: "none",
+          overflow: "auto",
         }}
       />
     </div>

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -398,8 +398,8 @@ importers:
         specifier: ^1.0.0
         version: 1.2.4(@langchain/core@1.1.18(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.17.0(ws@8.19.0)(zod@4.3.5)))(ws@8.19.0)
       '@mcp-ui/client':
-        specifier: ^6.1.0
-        version: 6.1.0(@cfworker/json-schema@4.1.1)(@preact/signals-core@1.12.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: ^7.0.0
+        version: 7.0.0(@cfworker/json-schema@4.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@modelcontextprotocol/ext-apps':
         specifier: ^1.0.1
         version: 1.0.1(@modelcontextprotocol/sdk@1.27.1(patch_hash=c19f2c8d79a374e03317396864f51a5d896e73b8a2231766cdc88bfbac98161e)(@cfworker/json-schema@4.1.1)(zod@4.3.5))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.5)
@@ -1330,6 +1330,55 @@ importers:
         specifier: ^8.0.0
         version: 8.0.0(@types/node@25.3.0)(esbuild@0.27.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
 
+  test_app:
+    dependencies:
+      '@openai/apps-sdk-ui':
+        specifier: ^0.2.1
+        version: 0.2.1(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.0)
+      mcp-use:
+        specifier: workspace:*
+        version: link:../packages/mcp-use
+      react:
+        specifier: ^19.2.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.0
+        version: 19.2.4(react@19.2.4)
+      react-router:
+        specifier: ^7.12.0
+        version: 7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      tailwindcss:
+        specifier: ^4.2.0
+        version: 4.2.0
+      zod:
+        specifier: 4.3.5
+        version: 4.3.5
+    devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.2.0
+        version: 4.2.0(vite@8.0.0(@types/node@25.3.0)(esbuild@0.27.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@types/node':
+        specifier: ^25.3.0
+        version: 25.3.0
+      '@types/react':
+        specifier: ^19.2.7
+        version: 19.2.10
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.10)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.0
+        version: 6.0.1(vite@8.0.0(@types/node@25.3.0)(esbuild@0.27.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.0(@types/node@25.3.0)(esbuild@0.27.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+
 packages:
 
   '@acemir/cssom@0.9.31':
@@ -2067,8 +2116,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mcp-ui/client@6.1.0':
-    resolution: {integrity: sha512-Wk/9uhu8xdOgHjiaEtAq2RbXn4WGstpFeJ6I71JCP7JC7MtvQB/qnEKDVGSbjwyLnIeZYMSILHf5E+57/YCftQ==}
+  '@mcp-ui/client@7.0.0':
+    resolution: {integrity: sha512-by2YqknAegCbOIjQzEVAjTjopfrbwc0DYycWpAt33qVGv5yx8pChPVmO4l5iILrpVnRUPAtmhguPSoTTL7w0qw==}
     peerDependencies:
       react: ^19.2.0
       react-dom: ^19.2.0
@@ -2091,6 +2140,20 @@ packages:
 
   '@modelcontextprotocol/ext-apps@1.0.1':
     resolution: {integrity: sha512-rAPzBbB5GNgYk216paQjGKUgbNXSy/yeR95c0ni6Y4uvhWI2AeF+ztEOqQFLBMQy/MPM+02pbVK1HaQmQjMwYQ==}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': '>=1.25.2'
+      react: ^19.2.0
+      react-dom: ^19.2.0
+      zod: 4.3.5
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
+  '@modelcontextprotocol/ext-apps@1.3.1':
+    resolution: {integrity: sha512-XchYFGrCEO9JOLo6575MF3LWBrHOH9nVt1sC3ZaDL/JSgd6uN37/48Bcn5K1AIPXPxpsuQuczF8J+b4HxiYJpA==}
+    engines: {node: '>=20'}
     peerDependencies:
       '@modelcontextprotocol/sdk': '>=1.25.2'
       react: ^19.2.0
@@ -2373,9 +2436,6 @@ packages:
   '@posthog/types@1.351.4':
     resolution: {integrity: sha512-PMrNdOGVIiUczixF+AkodxIigAr3OM2LMfs565uTPZaIUip7S+njoaZRoIT66VJJviWtbLtzJHR49YJtIRIiWQ==}
 
-  '@preact/signals-core@1.12.2':
-    resolution: {integrity: sha512-5Yf8h1Ke3SMHr15xl630KtwPTW4sYDFkkxS0vQ8UiQLWwZQnrF9IKaVG1mN5VcJz52EcWs2acsc/Npjha/7ysA==}
-
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
 
@@ -2405,28 +2465,6 @@ packages:
 
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
-
-  '@quilted/events@2.1.3':
-    resolution: {integrity: sha512-4fHaSLND8rmZ+tce9/4FNmG5UWTRpFtM54kOekf3tLON4ZLLnYzjjldELD35efd7+lT5+E3cdkacqc56d+kCrQ==}
-    engines: {node: '>=14.0.0'}
-
-  '@quilted/threads@3.3.1':
-    resolution: {integrity: sha512-0ASnjTH+hOu1Qwzi9NnsVcsbMhWVx8pEE8SXIHknqcc/1rXAU0QlKw9ARq0W43FAdzyVeuXeXtZN27ZC0iALKg==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      '@preact/signals-core': ^1.8.0
-    peerDependenciesMeta:
-      '@preact/signals-core':
-        optional: true
-
-  '@r2wc/core@1.3.0':
-    resolution: {integrity: sha512-aPBnND92Itl+SWWbWyyxdFFF0+RqKB6dptGHEdiPB8ZvnHWHlVzOfEvbEcyUYGtB6HBdsfkVuBiaGYyBFVTzVQ==}
-
-  '@r2wc/react-to-web-component@2.1.0':
-    resolution: {integrity: sha512-m/PzgUOEiL1HxmvfP5LgBLqB7sHeRj+d1QAeZklwS4OEI2HUU+xTpT3hhJipH5DQoFInDqDTfe0lNFFKcrqk4w==}
-    peerDependencies:
-      react: ^19.2.0
-      react-dom: ^19.2.0
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -3180,31 +3218,6 @@ packages:
     engines: {node: '>= 18'}
     peerDependencies:
       '@redis/client': ^5.10.0
-
-  '@remote-dom/core@1.10.1':
-    resolution: {integrity: sha512-MlbUOGuHjOrB7uOkaYkIoLUG8lDK8/H1D7MHnGkgqbG6jwjwQSlGPHhbwnD6HYWsTGpAPOP02Byd8wBt9U6TEw==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      '@preact/signals-core': ^1.3.0
-      preact: '*'
-    peerDependenciesMeta:
-      '@preact/signals-core':
-        optional: true
-      preact:
-        optional: true
-
-  '@remote-dom/polyfill@1.5.1':
-    resolution: {integrity: sha512-eaWdIVKZpNfbqspKkRQLVxiFv/7vIw8u0FVA5oy52YANFbO/WVT0GU+PQmRt/QUSijaB36HBAqx7stjo8HGpVQ==}
-    engines: {node: '>=14.0.0'}
-
-  '@remote-dom/react@1.2.2':
-    resolution: {integrity: sha512-PkvioODONTr1M0StGDYsR4Ssf5M0Rd4+IlWVvVoK3Zrw8nr7+5mJkgNofaj/z7i8Aep78L28PCW8/WduUt4unA==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      react: ^19.2.0
-    peerDependenciesMeta:
-      react:
-        optional: true
 
   '@rolldown/binding-android-arm64@1.0.0-rc.9':
     resolution: {integrity: sha512-lcJL0bN5hpgJfSIz/8PIf02irmyL43P+j1pTCfbD1DbLkmGRuFIA4DD3B3ZOvGqG0XiVvRznbKtN0COQVaKUTg==}
@@ -5438,9 +5451,6 @@ packages:
   hono@4.12.8:
     resolution: {integrity: sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==}
     engines: {node: '>=16.9.0'}
-
-  htm@3.1.1:
-    resolution: {integrity: sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ==}
 
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
@@ -8773,21 +8783,15 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mcp-ui/client@6.1.0(@cfworker/json-schema@4.1.1)(@preact/signals-core@1.12.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@mcp-ui/client@7.0.0(@cfworker/json-schema@4.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@modelcontextprotocol/ext-apps': 0.3.1(@modelcontextprotocol/sdk@1.27.1(patch_hash=c19f2c8d79a374e03317396864f51a5d896e73b8a2231766cdc88bfbac98161e)(@cfworker/json-schema@4.1.1)(zod@4.3.5))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.5)
+      '@modelcontextprotocol/ext-apps': 1.3.1(@modelcontextprotocol/sdk@1.27.1(patch_hash=c19f2c8d79a374e03317396864f51a5d896e73b8a2231766cdc88bfbac98161e)(@cfworker/json-schema@4.1.1)(zod@4.3.5))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.5)
       '@modelcontextprotocol/sdk': 1.27.1(patch_hash=c19f2c8d79a374e03317396864f51a5d896e73b8a2231766cdc88bfbac98161e)(@cfworker/json-schema@4.1.1)(zod@4.3.5)
-      '@quilted/threads': 3.3.1(@preact/signals-core@1.12.2)
-      '@r2wc/react-to-web-component': 2.1.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@remote-dom/core': 1.10.1(@preact/signals-core@1.12.2)
-      '@remote-dom/react': 1.2.2(@preact/signals-core@1.12.2)(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       zod: 4.3.5
     transitivePeerDependencies:
       - '@cfworker/json-schema'
-      - '@preact/signals-core'
-      - preact
       - supports-color
 
   '@mcp-ui/server@6.1.0(@cfworker/json-schema@4.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.5)':
@@ -8848,6 +8852,14 @@ snapshots:
       '@rollup/rollup-linux-x64-gnu': 4.57.1
       '@rollup/rollup-win32-arm64-msvc': 4.57.1
       '@rollup/rollup-win32-x64-msvc': 4.57.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
+  '@modelcontextprotocol/ext-apps@1.3.1(@modelcontextprotocol/sdk@1.27.1(patch_hash=c19f2c8d79a374e03317396864f51a5d896e73b8a2231766cdc88bfbac98161e)(@cfworker/json-schema@4.1.1)(zod@4.3.5))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.5)':
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.27.1(patch_hash=c19f2c8d79a374e03317396864f51a5d896e73b8a2231766cdc88bfbac98161e)(@cfworker/json-schema@4.1.1)(zod@4.3.5)
+      zod: 4.3.5
+    optionalDependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
@@ -9110,8 +9122,6 @@ snapshots:
 
   '@posthog/types@1.351.4': {}
 
-  '@preact/signals-core@1.12.2': {}
-
   '@protobufjs/aspromise@1.1.2': {}
 
   '@protobufjs/base64@1.1.2': {}
@@ -9134,24 +9144,6 @@ snapshots:
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.0': {}
-
-  '@quilted/events@2.1.3':
-    dependencies:
-      '@preact/signals-core': 1.12.2
-
-  '@quilted/threads@3.3.1(@preact/signals-core@1.12.2)':
-    dependencies:
-      '@quilted/events': 2.1.3
-    optionalDependencies:
-      '@preact/signals-core': 1.12.2
-
-  '@r2wc/core@1.3.0': {}
-
-  '@r2wc/react-to-web-component@2.1.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
-    dependencies:
-      '@r2wc/core': 1.3.0
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
 
   '@radix-ui/number@1.1.1': {}
 
@@ -9944,26 +9936,6 @@ snapshots:
   '@redis/time-series@5.10.0(@redis/client@5.10.0)':
     dependencies:
       '@redis/client': 5.10.0
-
-  '@remote-dom/core@1.10.1(@preact/signals-core@1.12.2)':
-    dependencies:
-      '@remote-dom/polyfill': 1.5.1
-      htm: 3.1.1
-    optionalDependencies:
-      '@preact/signals-core': 1.12.2
-
-  '@remote-dom/polyfill@1.5.1': {}
-
-  '@remote-dom/react@1.2.2(@preact/signals-core@1.12.2)(react@19.2.4)':
-    dependencies:
-      '@remote-dom/core': 1.10.1(@preact/signals-core@1.12.2)
-      '@types/react': 19.2.10
-      htm: 3.1.1
-    optionalDependencies:
-      react: 19.2.4
-    transitivePeerDependencies:
-      - '@preact/signals-core'
-      - preact
 
   '@rolldown/binding-android-arm64@1.0.0-rc.9':
     optional: true
@@ -12360,8 +12332,6 @@ snapshots:
   highlightjs-vue@1.0.0: {}
 
   hono@4.12.8: {}
-
-  htm@3.1.1: {}
 
   html-encoding-sniffer@6.0.0:
     dependencies:


### PR DESCRIPTION
- Updated the version of @mcp-ui/client from 6.1.0 to 7.0.0 in package.json and pnpm-lock.yaml.
- Refactored McpUIRenderer and MCPUIResource components to remove legacy remote-dom support, now rendering content via sandboxed iframes.
- Enhanced resource handling in MCPUIResource to ensure proper rendering of UI resources.
- Cleaned up unused imports and improved code readability.

