### PR TITLE
refactor(mcp-use): change _trackClientInit method visibility from private to protected

### DIFF
--- a/libraries/typescript/.changeset/wicked-candles-scream.md
+++ b/libraries/typescript/.changeset/wicked-candles-scream.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+chore: fix protected method in the mcpclient to avoid peer dep duplication

--- a/libraries/typescript/packages/mcp-use/src/client.ts
+++ b/libraries/typescript/packages/mcp-use/src/client.ts
@@ -380,7 +380,7 @@ export class MCPClient extends BaseMCPClient {
     this._trackClientInit();
   }
 
-  private _trackClientInit(): void {
+  protected _trackClientInit(): void {
     const servers = Object.keys(this.config.mcpServers ?? {});
     const hasSamplingCallback = !!(
       this._globalCallbacks.onSampling ?? this._globalCallbacks.samplingCallback

--- a/libraries/typescript/packages/mcp-use/src/client/browser.ts
+++ b/libraries/typescript/packages/mcp-use/src/client/browser.ts
@@ -30,7 +30,7 @@ export class BrowserMCPClient extends BaseMCPClient {
     this._trackClientInit();
   }
 
-  private _trackClientInit(): void {
+  protected _trackClientInit(): void {
     const servers = Object.keys(this.config.mcpServers ?? {});
 
     Tel.getInstance()


### PR DESCRIPTION
Updated the visibility of the _trackClientInit method in both MCPClient and BrowserMCPClient classes to protected, allowing for better extensibility in subclasses.
