### PR TITLE
Potential fix for code scanning alert no. 82: Reflected cross-site scripting

### DIFF
--- a/libraries/typescript/packages/inspector/tests/e2e/scripts/run-test-matrix.mjs
+++ b/libraries/typescript/packages/inspector/tests/e2e/scripts/run-test-matrix.mjs
@@ -120,7 +120,7 @@ function startLocalCdnServer(cdnDistDir) {
           : cdnDistDir + (process.platform === "win32" ? "\\" : "/");
       if (!file.startsWith(rootWithSep)) {
         res.writeHead(404);
-        res.end(`Not found: ${urlPath}`);
+        res.end(`Not found: ${escapeHtml(urlPath)}`);
         return;
       }
       try {


### PR DESCRIPTION
Potential fix for [https://github.com/mcp-use/mcp-use/security/code-scanning/82](https://github.com/mcp-use/mcp-use/security/code-scanning/82)

In general, to fix reflected XSS you must not write untrusted input directly to an HTTP response in a way that will be interpreted as HTML/JS. Instead, HTML‑escape or otherwise contextually encode the user input before including it in the response. This ensures any characters that could start tags or scripts are rendered harmless.

For this specific file, the best fix is to escape `urlPath` before interpolating it into the 404 error message at line 123, just like is already done at line 136. There is already an `escapeHtml` helper in use (`escapeHtml(urlPath)`), so we should reuse it for consistency. The change is localized: modify the string passed to `res.end` in the `!file.startsWith(rootWithSep)` branch to use `escapeHtml(urlPath)` instead of `urlPath`. No new imports or helpers are needed, assuming `escapeHtml` is already defined elsewhere in this file (it must be, since line 136 compiles).

Concretely:
- In `libraries/typescript/packages/inspector/tests/e2e/scripts/run-test-matrix.mjs`, within `startLocalCdnServer`, replace `res.end(\`Not found: ${urlPath}\`);` with `res.end(\`Not found: ${escapeHtml(urlPath)}\`);`.
- Leave all other logic, including the path traversal check and content-type mapping, unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
