### PR TITLE
Potential fix for code scanning alert no. 79: Incomplete string escaping or encoding

### DIFF
--- a/libraries/typescript/packages/mcp-use/src/server/utils/zod-to-ts.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/utils/zod-to-ts.ts
@@ -6,6 +6,15 @@
 import type { z } from "zod";
 
 /**
+ * Escape a string so it can be safely embedded in a double-quoted
+ * TypeScript string literal.
+ */
+function escapeTsStringLiteral(value: string): string {
+  // First escape backslashes, then double quotes.
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+/**
  * Convert a Zod schema to a TypeScript type string
  * @param schema - The Zod schema to convert
  * @returns TypeScript type string representation
@@ -77,7 +86,7 @@ export function zodToTypeString(schema: z.ZodTypeAny): string {
     case "ZodLiteral": {
       const value = def.value;
       if (typeof value === "string") {
-        return `"${value.replace(/"/g, '\\"')}"`;
+        return `"${escapeTsStringLiteral(value)}"`;
       }
       if (typeof value === "number") {
         return String(value);
@@ -95,7 +104,7 @@ export function zodToTypeString(schema: z.ZodTypeAny): string {
           ? Object.values(def.entries as Record<string, string>)
           : undefined;
       if (!values || values.length === 0) return "string";
-      return values.map((v) => `"${v.replace(/"/g, '\\"')}"`).join(" | ");
+      return values.map((v) => `"${escapeTsStringLiteral(v)}"`).join(" | ");
     }
 
     case "ZodNativeEnum": {


### PR DESCRIPTION
Potential fix for [https://github.com/mcp-use/mcp-use/security/code-scanning/79](https://github.com/mcp-use/mcp-use/security/code-scanning/79)

In general, when constructing string literals with custom escaping, you must escape both the delimiter character (here `"`) and the backslash `\` itself. Otherwise, sequences like `\"` or `\\` may not behave as intended in the resulting string literal. The safest approach is to implement a small, well-defined escaping function that first escapes backslashes, then escapes quotes, or to use a library function that correctly escapes JavaScript/TypeScript string literals.

For this specific file, we should centralize the escaping logic in a helper function, e.g. `escapeTsStringLiteral`, that takes a string and returns a version safe to embed in a double-quoted TypeScript string literal. The function should: (1) replace backslashes (`\`) with double backslashes (`\\`), then (2) replace double quotes (`"`) with `\"`. We then use this helper in both places that currently do manual `.replace(/"/g, '\\"')`: in the `ZodLiteral` case for string values (line 80) and in the `ZodEnum` case when mapping enum values (line 98). This preserves existing behavior for quotes while adding correct escaping for backslashes and avoids duplicating logic.

Concretely:
- In `libraries/typescript/packages/mcp-use/src/server/utils/zod-to-ts.ts`, add a small local function `escapeTsStringLiteral` near the top of the file (after imports and before `zodToTypeString`).
- Replace `value.replace(/"/g, '\\"')` with `escapeTsStringLiteral(value)` in the `"ZodLiteral"` case.
- Replace `v.replace(/"/g, '\\"')` with `escapeTsStringLiteral(v)` in the `"ZodEnum"` case.
No new external imports are necessary; we only use built-in `String.prototype.replace` with appropriate regular expressions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
