### PR TITLE
fix(main): keep traceback in main

### DIFF
--- a/libraries/python/examples/google_integration_example.py
+++ b/libraries/python/examples/google_integration_example.py
@@ -131,7 +131,7 @@ async def main():
         gemini.close()
     except Exception as e:
         print(f"Error: {e}")
-        raise e
+        raise
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The code around line 134 in libraries/python/examples/google_integration_example.py looked like it might have an issue. It re-raises the caught exception object and loses the cleaner traceback shape. this patch changes that to a plain raise so the original stack stays intact.

Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.