### PR TITLE
fix: update deprecated claude-3-5-sonnet-20241022 to claude-sonnet-4-6

### DIFF
--- a/docs/python/agent/llm-integration.mdx
+++ b/docs/python/agent/llm-integration.mdx
@@ -58,7 +58,7 @@ from mcp_use import MCPAgent, MCPClient
 
 # Initialize Claude model
 llm = ChatAnthropic(
-    model="claude-3-5-sonnet-20241022",
+    model="claude-sonnet-4-6",
     temperature=0.7,
     api_key="your-api-key"  # Or set ANTHROPIC_API_KEY env var
 )
@@ -182,7 +182,7 @@ llm = ChatOpenAI(
 
 # Anthropic with custom parameters
 llm = ChatAnthropic(
-    model="claude-3-5-sonnet-20241022",
+    model="claude-sonnet-4-6",
     temperature=0.7,
     max_tokens=4000,
     top_p=0.9
@@ -274,7 +274,7 @@ def get_model_for_task(task_type: str):
     if task_type == "complex_reasoning":
         return ChatOpenAI(model="gpt-4o", temperature=0.1)
     elif task_type == "creative":
-        return ChatAnthropic(model="claude-3-5-sonnet-20241022", temperature=0.8)
+        return ChatAnthropic(model="claude-sonnet-4-6", temperature=0.8)
     else:
         return ChatOpenAI(model="gpt-3.5-turbo", temperature=0.7)
 

--- a/docs/typescript/agent/llm-integration.mdx
+++ b/docs/typescript/agent/llm-integration.mdx
@@ -44,7 +44,7 @@ import { MCPAgent, MCPClient } from 'mcp-use'
 
 // Initialize Claude model
 const llm = new ChatAnthropic({
-  model: 'claude-3-5-sonnet-20241022',
+  model: 'claude-sonnet-4-6',
   temperature: 0.7,
   apiKey: process.env.ANTHROPIC_API_KEY  // Or set ANTHROPIC_API_KEY env var
 })

--- a/libraries/typescript/packages/mcp-use/src/agents/utils/llm_provider.ts
+++ b/libraries/typescript/packages/mcp-use/src/agents/utils/llm_provider.ts
@@ -31,7 +31,7 @@ const PROVIDER_CONFIG = {
     package: "@langchain/anthropic",
     className: "ChatAnthropic",
     envVars: ["ANTHROPIC_API_KEY"],
-    defaultModel: "claude-3-5-sonnet-20241022",
+    defaultModel: "claude-sonnet-4-6",
   },
   google: {
     package: "@langchain/google-genai",
@@ -51,7 +51,7 @@ const PROVIDER_CONFIG = {
  * Parse LLM string format: "provider/model"
  * Examples:
  *   - "openai/gpt-4" -> { provider: "openai", model: "gpt-4" }
- *   - "anthropic/claude-3-5-sonnet-20241022" -> { provider: "anthropic", model: "claude-3-5-sonnet-20241022" }
+ *   - "anthropic/claude-sonnet-4-6" -> { provider: "anthropic", model: "claude-sonnet-4-6" }
  *   - "google/gemini-pro" -> { provider: "google", model: "gemini-pro" }
  */
 export function parseLLMString(llmString: string): {
@@ -63,7 +63,7 @@ export function parseLLMString(llmString: string): {
   if (parts.length !== 2) {
     throw new Error(
       `Invalid LLM string format. Expected 'provider/model', got '${llmString}'. ` +
-        `Examples: 'openai/gpt-4', 'anthropic/claude-3-5-sonnet-20241022', 'google/gemini-pro', 'groq/llama-3.1-70b-versatile'`
+        `Examples: 'openai/gpt-4', 'anthropic/claude-sonnet-4-6', 'google/gemini-pro', 'groq/llama-3.1-70b-versatile'`
     );
   }
 
@@ -140,7 +140,7 @@ function getAPIKey(provider: LLMProvider, config?: LLMConfig): string {
  *
  * @example
  * ```typescript
- * const llm = await createLLMFromString('anthropic/claude-3-5-sonnet-20241022');
+ * const llm = await createLLMFromString('anthropic/claude-sonnet-4-6');
  * ```
  */
 export async function createLLMFromString(


### PR DESCRIPTION
## Summary
Model `claude-3-5-sonnet-20241022` was retired on October 28, 2025 per [Anthropic model deprecations](https://platform.claude.com/docs/en/about-claude/model-deprecations). This PR updates the default model and documentation examples to use `claude-sonnet-4-6` as recommended replacement.

## Changes
- `llm_provider.ts`: defaultModel updated from `claude-3-5-sonnet-20241022` to `claude-sonnet-4-6`
- `docs/typescript/agent/llm-integration.mdx`: model reference updated
- `docs/python/agent/llm-integration.mdx`: 3 occurrences updated (initialization, custom params, task function)
- `llm_provider.ts`: parseLLMString examples updated

Closes #1258