### PR TITLE
fix(python): add missing super().__init__() in WebSocketConnector

### DIFF
--- a/libraries/python/mcp_use/client/config.py
+++ b/libraries/python/mcp_use/client/config.py
@@ -137,6 +137,13 @@ def create_connector_from_config(
             url=server_config["ws_url"],
             headers=server_config.get("headers", None),
             auth=server_config.get("auth", {}),
+            sampling_callback=sampling_callback,
+            elicitation_callback=elicitation_callback,
+            message_handler=message_handler,
+            logging_callback=logging_callback,
+            middleware=middleware,
+            roots=roots,
+            list_roots_callback=list_roots_callback,
         )
 
     raise ValueError("Cannot determine connector type from config")

--- a/libraries/python/mcp_use/client/connectors/websocket.py
+++ b/libraries/python/mcp_use/client/connectors/websocket.py
@@ -11,11 +11,13 @@ import uuid
 from typing import Any
 
 import httpx
-from mcp.types import Tool
+from mcp.client.session import ElicitationFnT, ListRootsFnT, LoggingFnT, MessageHandlerFnT, SamplingFnT
+from mcp.types import Root, Tool
 from websockets import ClientConnection
 
 from mcp_use.client.connectors.base import BaseConnector
-from mcp_use.client.task_managers import ConnectionManager, WebSocketConnectionManager
+from mcp_use.client.middleware import Middleware
+from mcp_use.client.task_managers import WebSocketConnectionManager
 from mcp_use.logging import logger
 
 
@@ -31,6 +33,13 @@ class WebSocketConnector(BaseConnector):
         url: str,
         headers: dict[str, str] | None = None,
         auth: str | dict[str, Any] | httpx.Auth | None = None,
+        sampling_callback: SamplingFnT | None = None,
+        elicitation_callback: ElicitationFnT | None = None,
+        message_handler: MessageHandlerFnT | None = None,
+        logging_callback: LoggingFnT | None = None,
+        middleware: list[Middleware] | None = None,
+        roots: list[Root] | None = None,
+        list_roots_callback: ListRootsFnT | None = None,
     ):
         """Initialize a new WebSocket connector.
 
@@ -41,7 +50,23 @@ class WebSocketConnector(BaseConnector):
                 - A string token: Use Bearer token authentication
                 - A dict: Not supported for WebSocket (will log warning)
                 - An httpx.Auth object: Not supported for WebSocket (will log warning)
+            sampling_callback: Optional callback to handle sampling requests from servers.
+            elicitation_callback: Optional callback to handle elicitation requests from servers.
+            message_handler: Optional callback to handle messages from servers.
+            logging_callback: Optional callback to handle log messages from servers.
+            middleware: Optional list of middleware to apply to requests.
+            roots: Optional initial list of roots to advertise to the server.
+            list_roots_callback: Optional custom callback to handle roots/list requests.
         """
+        super().__init__(
+            sampling_callback=sampling_callback,
+            elicitation_callback=elicitation_callback,
+            message_handler=message_handler,
+            logging_callback=logging_callback,
+            middleware=middleware,
+            roots=roots,
+            list_roots_callback=list_roots_callback,
+        )
         self.url = url
         self.headers = headers or {}
 
@@ -54,11 +79,8 @@ class WebSocketConnector(BaseConnector):
                 logger.warning("WebSocket connector only supports bearer token authentication")
 
         self.ws: ClientConnection | None = None
-        self._connection_manager: ConnectionManager | None = None
         self._receiver_task: asyncio.Task | None = None
         self.pending_requests: dict[str, asyncio.Future] = {}
-        self._tools: list[Tool] | None = None
-        self._connected = False
 
     async def connect(self) -> None:
         """Establish a connection to the MCP implementation."""


### PR DESCRIPTION
## Language / Project Scope
- [x] Python

## Changes

`WebSocketConnector.__init__()` did not call `super().__init__()`, causing all `BaseConnector` attributes to be missing at runtime. This PR fixes the initialization and updates the config factory to forward callbacks to WebSocket connectors.

## Implementation Details

1. **`websocket.py`**: Added `super().__init__()` call with all 7 `BaseConnector` parameters (`sampling_callback`, `elicitation_callback`, `message_handler`, `logging_callback`, `middleware`, `roots`, `list_roots_callback`). Removed redundant local declarations of `_tools`, `_connected`, `_connection_manager` that are now inherited. Cleaned up unused `ConnectionManager` import.

2. **`config.py`**: Updated the WebSocket branch of `create_connector_from_config()` to forward all callback/middleware/roots parameters, matching the existing pattern for `StdioConnector`, `HttpConnector`, and `SandboxConnector`.

## Example Usage (Before)

```python
# WebSocketConnector was missing middleware_manager, sampling_callback,
# elicitation_callback, roots, etc. — any code path touching these
# attributes would raise AttributeError.
connector = WebSocketConnector(url="ws://localhost:8080")
connector.middleware_manager  # AttributeError!
```

## Example Usage (After)

```python
connector = WebSocketConnector(
    url="ws://localhost:8080",
    sampling_callback=my_callback,
    middleware=[my_middleware],
)
connector.middleware_manager  # works correctly
```

## Python Checklist
- [x] `ruff format` passes
- [x] `ruff check` passes
- [x] Existing tests pass (306/307, 1 pre-existing failure in sandbox test unrelated to this change)

## Testing

- `test_websocket_connection_manager.py`: 6/6 passed
- `test_client_capabilities.py`: 14/14 passed
- `test_config.py`: 15/16 passed (1 pre-existing failure: `test_create_sandboxed_stdio_connector` due to missing optional `e2b-code-interpreter` dependency)

## Backwards Compatibility

Fully backward compatible. All new constructor parameters have `None` defaults. Existing callers passing only `url`, `headers`, `auth` continue to work unchanged.