### PR TITLE
fix(python): fix ResourceTool data loss and GoogleMCPAdapter return type

### DIFF
--- a/libraries/python/mcp_use/agents/adapters/google.py
+++ b/libraries/python/mcp_use/agents/adapters/google.py
@@ -43,7 +43,7 @@ class GoogleMCPAdapter(BaseAdapter[types.FunctionDeclaration]):
         self.resources: list[types.FunctionDeclaration] = []
         self.prompts: list[types.FunctionDeclaration] = []
 
-    def _convert_tool(self, mcp_tool: Tool, connector: BaseConnector) -> types.FunctionDeclaration:
+    def _convert_tool(self, mcp_tool: Tool, connector: BaseConnector) -> types.FunctionDeclaration | None:
         """Convert an MCP tool to the Google tool format."""
         if mcp_tool.name in self.disallowed_tools:
             return None
@@ -58,7 +58,7 @@ class GoogleMCPAdapter(BaseAdapter[types.FunctionDeclaration]):
         )
         return function_declaration
 
-    def _convert_resource(self, mcp_resource: Resource, connector: BaseConnector) -> types.FunctionDeclaration:
+    def _convert_resource(self, mcp_resource: Resource, connector: BaseConnector) -> types.FunctionDeclaration | None:
         """Convert an MCP resource to a readable tool in Google format."""
         tool_name = _sanitize_for_tool_name(f"resource_{mcp_resource.name}")
 

--- a/libraries/python/mcp_use/agents/adapters/langchain_adapter.py
+++ b/libraries/python/mcp_use/agents/adapters/langchain_adapter.py
@@ -233,14 +233,18 @@ class LangChainAdapter(BaseAdapter[BaseTool]):
                 logger.debug(f'Resource tool: "{self.name}" called')
                 try:
                     result = await self.tool_connector.read_resource(mcp_resource.uri)
+                    decoded_parts = []
                     for content in result.contents:
-                        # Attempt to decode bytes if necessary
                         if isinstance(content, bytes):
-                            content_decoded = content.decode()
+                            decoded_parts.append(content.decode())
+                        elif hasattr(content, "text"):
+                            decoded_parts.append(content.text)
+                        elif hasattr(content, "blob"):
+                            decoded_parts.append(content.blob)
                         else:
-                            content_decoded = str(content)
+                            decoded_parts.append(str(content))
 
-                    return content_decoded
+                    return "\n".join(decoded_parts)
                 except Exception as e:
                     if self.handle_tool_error:
                         return format_error(e, tool=self.name)  # Format the error to make LLM understand it


### PR DESCRIPTION
## Language / Project Scope
- [x] Python

## Changes

Two adapter-layer bug fixes:

1. **`langchain_adapter.py`** — `ResourceTool._arun()` silently discarded all but the last content item from `read_resource()` results.
2. **`google.py`** — `_convert_tool()` and `_convert_resource()` return type annotations did not include `None`, despite returning `None` for disallowed tools.

## Implementation Details

1. **ResourceTool data loss fix**: The original code reassigned `content_decoded` inside a `for` loop but returned it outside the loop, so only the last item survived. Additionally, `str(content)` produced the Pydantic model repr (e.g., `uri=AnyUrl(...) mimeType=None text='...'`) instead of the actual content. Fixed by accumulating into a list, extracting `.text` / `.blob` attributes, and joining with `"\n"`.

2. **Google adapter type annotation fix**: `_convert_tool` and `_convert_resource` both returned `None` when a tool is in `disallowed_tools`, but their signatures declared `-> types.FunctionDeclaration` (non-optional). Changed to `-> types.FunctionDeclaration | None` to match the actual behavior, the base class `-> T | None` contract, and all other adapter implementations. Callers in `base.py` already guard with `if converted_tool:`.

## Example Usage (Before)

```python
# ResourceTool with multiple content items — data loss
result.contents = [TextResourceContents(text="part1"), TextResourceContents(text="part2")]
# _arun() returned: "uri=AnyUrl(...) text='part2'"  (only last item, as Pydantic repr)
```

## Example Usage (After)

```python
# _arun() now returns: "part1\npart2"  (all items, actual text content)
```

## Python Checklist
- [x] `ruff format` passes
- [x] `ruff check` passes
- [x] Existing tests pass

## Testing

- `test_langchain_adapter.py`: 4/4 passed
- Full unit suite: 306/307 passed (1 pre-existing failure unrelated to this change)

## Backwards Compatibility

- **ResourceTool**: The return value changes from a Pydantic repr string to the actual resource text. This is a behavioral improvement — no code could have meaningfully depended on the old repr format.
- **GoogleMCPAdapter**: Type annotation only — no runtime behavior change.