### PR TITLE
feat(python): add ToolAuthorizationMiddleware for per-tool access control

### DIFF
--- a/libraries/python/examples/authorization_middleware_example.py
+++ b/libraries/python/examples/authorization_middleware_example.py
@@ -4,10 +4,11 @@ Per-tool authorization middleware example.
 Demonstrates how to use ToolAuthorizationMiddleware to enforce fine-grained
 access control over which MCP tools an agent is allowed to invoke.
 
-Three patterns are shown:
-1. Allowlist — only the listed tools may be called.
+Four patterns are shown:
+1. Allowlist — only the listed tools may be called (and appear in tool list).
 2. Denylist — all tools except the listed ones may be called.
-3. Custom authorizer — delegate the decision to an async function (e.g. an
+3. Agent identity context — pass caller identity to the authorizer.
+4. Custom authorizer — delegate the decision to an async function (e.g. an
    external permission engine, OAuth token validation, etc.).
 """
 
@@ -16,8 +17,7 @@ import asyncio
 from dotenv import load_dotenv
 from langchain_openai import ChatOpenAI
 
-from mcp_use import MCPAgent, MCPClient
-from mcp_use.client.middleware import ToolAuthorizationMiddleware
+from mcp_use import MCPAgent, MCPClient, ToolAuthorizationMiddleware
 
 load_dotenv()
 
@@ -33,7 +33,8 @@ CONFIG = {
 
 
 # ---------------------------------------------------------------------------
-# Pattern 1: Allowlist — research agent can only search
+# Pattern 1: Allowlist — research agent can only navigate and snapshot
+# Denied tools are also hidden from the LLM's tool list.
 # ---------------------------------------------------------------------------
 async def run_research_agent():
     client = MCPClient(
@@ -61,25 +62,63 @@ async def run_content_agent():
 
 
 # ---------------------------------------------------------------------------
-# Pattern 3: Custom authorizer backed by an external permission engine
+# Pattern 3: Agent identity context + custom authorizer
+# The agent_context dict is forwarded to the authorizer so you can make
+# identity-aware decisions without coupling the middleware to a specific
+# auth system.
 # ---------------------------------------------------------------------------
-async def run_custom_auth_agent():
-    # Simulate an external permission check
-    PERMITTED = {"browser_navigate", "browser_snapshot"}
+async def run_identity_aware_agent():
+    PERMITTED_BY_ROLE = {
+        "admin": {"browser_navigate", "browser_snapshot", "browser_file_upload"},
+        "reader": {"browser_navigate", "browser_snapshot"},
+    }
 
-    async def my_authorizer(tool_name: str, arguments: dict) -> bool:
-        allowed = tool_name in PERMITTED
-        print(f"[auth] tool={tool_name!r} allowed={allowed}")
+    async def role_authorizer(tool_name: str, arguments: dict, agent_context: dict) -> bool:
+        role = agent_context.get("role", "reader")
+        allowed = tool_name in PERMITTED_BY_ROLE.get(role, set())
+        print(f"[auth] agent={agent_context.get('agent_id')!r} role={role!r} tool={tool_name!r} allowed={allowed}")
         return allowed
 
     client = MCPClient(
         config=CONFIG,
-        middleware=[ToolAuthorizationMiddleware(authorizer=my_authorizer)],
+        middleware=[
+            ToolAuthorizationMiddleware(
+                agent_context={"agent_id": "sub-agent-42", "role": "reader"},
+                authorizer=role_authorizer,
+            )
+        ],
     )
     llm = ChatOpenAI(model="gpt-4o-mini")
     agent = MCPAgent(llm=llm, client=client, max_steps=10)
     result = await agent.run("Navigate to https://example.com.")
-    print("Custom auth agent result:", result)
+    print("Identity-aware agent result:", result)
+
+
+# ---------------------------------------------------------------------------
+# Pattern 4: External permission engine
+# ---------------------------------------------------------------------------
+async def run_external_auth_agent():
+    PERMITTED = {"browser_navigate", "browser_snapshot"}
+
+    async def external_check(tool_name: str, arguments: dict, agent_context: dict) -> bool:
+        # Replace with a real HTTP call to your permission engine
+        token = agent_context.get("token")
+        print(f"[auth] Checking token={token!r} for tool={tool_name!r}")
+        return tool_name in PERMITTED
+
+    client = MCPClient(
+        config=CONFIG,
+        middleware=[
+            ToolAuthorizationMiddleware(
+                agent_context={"token": "Bearer eyJ..."},
+                authorizer=external_check,
+            )
+        ],
+    )
+    llm = ChatOpenAI(model="gpt-4o-mini")
+    agent = MCPAgent(llm=llm, client=client, max_steps=10)
+    result = await agent.run("Navigate to https://example.com.")
+    print("External auth agent result:", result)
 
 
 if __name__ == "__main__":

--- a/libraries/python/examples/authorization_middleware_example.py
+++ b/libraries/python/examples/authorization_middleware_example.py
@@ -1,0 +1,86 @@
+"""
+Per-tool authorization middleware example.
+
+Demonstrates how to use ToolAuthorizationMiddleware to enforce fine-grained
+access control over which MCP tools an agent is allowed to invoke.
+
+Three patterns are shown:
+1. Allowlist — only the listed tools may be called.
+2. Denylist — all tools except the listed ones may be called.
+3. Custom authorizer — delegate the decision to an async function (e.g. an
+   external permission engine, OAuth token validation, etc.).
+"""
+
+import asyncio
+
+from dotenv import load_dotenv
+from langchain_openai import ChatOpenAI
+
+from mcp_use import MCPAgent, MCPClient
+from mcp_use.client.middleware import ToolAuthorizationMiddleware
+
+load_dotenv()
+
+CONFIG = {
+    "mcpServers": {
+        "demo": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"],
+            "env": {"DISPLAY": ":1"},
+        }
+    }
+}
+
+
+# ---------------------------------------------------------------------------
+# Pattern 1: Allowlist — research agent can only search
+# ---------------------------------------------------------------------------
+async def run_research_agent():
+    client = MCPClient(
+        config=CONFIG,
+        middleware=[ToolAuthorizationMiddleware(allowed_tools=["browser_navigate", "browser_snapshot"])],
+    )
+    llm = ChatOpenAI(model="gpt-4o-mini")
+    agent = MCPAgent(llm=llm, client=client, max_steps=10)
+    result = await agent.run("Navigate to https://example.com and take a snapshot.")
+    print("Research agent result:", result)
+
+
+# ---------------------------------------------------------------------------
+# Pattern 2: Denylist — block only destructive tools
+# ---------------------------------------------------------------------------
+async def run_content_agent():
+    client = MCPClient(
+        config=CONFIG,
+        middleware=[ToolAuthorizationMiddleware(denied_tools=["browser_file_upload", "browser_close"])],
+    )
+    llm = ChatOpenAI(model="gpt-4o-mini")
+    agent = MCPAgent(llm=llm, client=client, max_steps=10)
+    result = await agent.run("Navigate to https://example.com and describe the page.")
+    print("Content agent result:", result)
+
+
+# ---------------------------------------------------------------------------
+# Pattern 3: Custom authorizer backed by an external permission engine
+# ---------------------------------------------------------------------------
+async def run_custom_auth_agent():
+    # Simulate an external permission check
+    PERMITTED = {"browser_navigate", "browser_snapshot"}
+
+    async def my_authorizer(tool_name: str, arguments: dict) -> bool:
+        allowed = tool_name in PERMITTED
+        print(f"[auth] tool={tool_name!r} allowed={allowed}")
+        return allowed
+
+    client = MCPClient(
+        config=CONFIG,
+        middleware=[ToolAuthorizationMiddleware(authorizer=my_authorizer)],
+    )
+    llm = ChatOpenAI(model="gpt-4o-mini")
+    agent = MCPAgent(llm=llm, client=client, max_steps=10)
+    result = await agent.run("Navigate to https://example.com.")
+    print("Custom auth agent result:", result)
+
+
+if __name__ == "__main__":
+    asyncio.run(run_research_agent())

--- a/libraries/python/mcp_use/__init__.py
+++ b/libraries/python/mcp_use/__init__.py
@@ -15,6 +15,7 @@ from .logging import MCP_USE_DEBUG, Logger, logger  # isort: skip
 from .agents import observability  # noqa: E402
 from .agents.mcpagent import MCPAgent
 from .client import MCPClient
+from .client.middleware import ToolAuthorizationMiddleware
 from .client.prompts import CODE_MODE_AGENT_PROMPT
 from .config import load_config_file
 from .connectors import BaseConnector, HttpConnector, StdioConnector, WebSocketConnector
@@ -26,6 +27,7 @@ __version__ = version("mcp-use")
 __all__ = [
     "MCPAgent",
     "MCPClient",
+    "ToolAuthorizationMiddleware",
     "MCPSession",
     "MCPServer",
     "BaseConnector",

--- a/libraries/python/mcp_use/client/middleware/__init__.py
+++ b/libraries/python/mcp_use/client/middleware/__init__.py
@@ -9,6 +9,9 @@ receive a request context and a call_next function, allowing them to process bot
 incoming requests and outgoing responses.
 """
 
+# Authorization middleware
+from .authorization import ToolAuthorizationMiddleware
+
 # Core middleware implementation
 # Default logging middleware
 from .logging import default_logging_middleware
@@ -32,6 +35,8 @@ from .middleware import (
 )
 
 __all__ = [
+    # Authorization middleware
+    "ToolAuthorizationMiddleware",
     # Core types and classes
     "MiddlewareContext",
     "MCPResponseContext",

--- a/libraries/python/mcp_use/client/middleware/authorization.py
+++ b/libraries/python/mcp_use/client/middleware/authorization.py
@@ -1,0 +1,106 @@
+"""
+Per-tool authorization middleware for MCP requests.
+
+This module provides a deny-first authorization middleware that intercepts
+tool calls before they reach the MCP server, enabling fine-grained access
+control over which tools an agent is permitted to invoke.
+"""
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from mcp.types import CallToolResult, TextContent
+
+from .middleware import Middleware, MiddlewareContext, NextFunctionT
+
+
+def _denied_result(tool_name: str) -> CallToolResult:
+    """Return a CallToolResult indicating the tool call was denied."""
+    return CallToolResult(
+        content=[TextContent(type="text", text=f"Tool '{tool_name}' is not authorized for this agent.")],
+        isError=True,
+    )
+
+
+class ToolAuthorizationMiddleware(Middleware):
+    """Deny-first per-tool authorization middleware.
+
+    Intercepts tool calls after the LLM decides to invoke a tool but before
+    the call reaches the MCP server. Evaluates the call against an allowlist,
+    denylist, and/or a custom async authorizer function.
+
+    Authorization order:
+      1. Denylist check — if the tool is in ``denied_tools``, deny immediately.
+      2. Allowlist check — if ``allowed_tools`` is set and the tool is not in
+         it, deny.
+      3. Custom authorizer — if provided and it returns ``False``, deny.
+      4. Otherwise, forward the call.
+
+    A denied call returns a :class:`mcp.types.CallToolResult` with
+    ``isError=True`` so the LLM can reason about the denial gracefully
+    instead of seeing an unexpected exception.
+
+    Args:
+        allowed_tools: Explicit allowlist of tool names. When provided, any
+            tool not on this list is denied. Pass ``None`` (default) to allow
+            all tools not blocked by other checks.
+        denied_tools: Explicit denylist of tool names. Takes precedence over
+            ``allowed_tools``. Defaults to no denials.
+        authorizer: Optional async callable with signature
+            ``(tool_name: str, arguments: dict) -> bool``. Return ``True``
+            to allow the call, ``False`` to deny it. Evaluated last, after
+            the allowlist/denylist checks pass.
+
+    Example::
+
+        # Research agent: only allowed to search
+        client = MCPClient(
+            config=config,
+            middleware=[ToolAuthorizationMiddleware(allowed_tools=["search_docs"])],
+        )
+
+        # Content agent: cannot touch destructive tools
+        client = MCPClient(
+            config=config,
+            middleware=[
+                ToolAuthorizationMiddleware(denied_tools=["delete_note", "deploy_prod"])
+            ],
+        )
+
+        # Custom authorizer backed by an external permission engine
+        async def my_authorizer(tool_name: str, arguments: dict) -> bool:
+            return await permission_engine.check(tool_name, arguments)
+
+        client = MCPClient(
+            config=config,
+            middleware=[ToolAuthorizationMiddleware(authorizer=my_authorizer)],
+        )
+    """
+
+    def __init__(
+        self,
+        allowed_tools: list[str] | None = None,
+        denied_tools: list[str] | None = None,
+        authorizer: Callable[[str, dict[str, Any]], Awaitable[bool]] | None = None,
+    ) -> None:
+        self._allowed: frozenset[str] | None = frozenset(allowed_tools) if allowed_tools is not None else None
+        self._denied: frozenset[str] = frozenset(denied_tools or [])
+        self._authorizer = authorizer
+
+    async def on_call_tool(self, context: MiddlewareContext[Any], call_next: NextFunctionT) -> CallToolResult:
+        tool_name: str = context.params.name
+        arguments: dict[str, Any] = context.params.arguments or {}
+
+        # 1. Denylist takes unconditional precedence.
+        if tool_name in self._denied:
+            return _denied_result(tool_name)
+
+        # 2. Allowlist: if set, only listed tools are permitted.
+        if self._allowed is not None and tool_name not in self._allowed:
+            return _denied_result(tool_name)
+
+        # 3. Custom authorizer for dynamic / external policy evaluation.
+        if self._authorizer is not None and not await self._authorizer(tool_name, arguments):
+            return _denied_result(tool_name)
+
+        return await call_next(context)

--- a/libraries/python/mcp_use/client/middleware/authorization.py
+++ b/libraries/python/mcp_use/client/middleware/authorization.py
@@ -119,13 +119,22 @@ class ToolAuthorizationMiddleware(Middleware):
         self._agent_context: dict[str, Any] = agent_context or {}
         self._authorizer: AuthorizerFn | None = authorizer
 
+    def _static_deny_reason(self, tool_name: str) -> str | None:
+        """Return the reason a tool is denied by static rules, or ``None`` if allowed.
+
+        This is the single source of truth for allowlist/denylist evaluation,
+        used by both :meth:`on_call_tool` (for logging) and
+        :meth:`on_list_tools` (for filtering).
+        """
+        if tool_name in self._denied:
+            return "denylist"
+        if self._allowed is not None and tool_name not in self._allowed:
+            return "not_in_allowlist"
+        return None
+
     def _is_tool_allowed_by_static_rules(self, tool_name: str) -> bool:
         """Check allowlist/denylist rules only (no async authorizer)."""
-        if tool_name in self._denied:
-            return False
-        if self._allowed is not None and tool_name not in self._allowed:
-            return False
-        return True
+        return self._static_deny_reason(tool_name) is None
 
     def _log_decision(self, context: MiddlewareContext[Any], decision: str, tool_name: str, reason: str) -> None:
         """Emit an audit log entry for an allow/deny decision."""
@@ -150,20 +159,17 @@ class ToolAuthorizationMiddleware(Middleware):
                 f"[{context.id}] {context.connection_id} ToolAuthorizationMiddleware "
                 f"filtered {removed} unauthorized tool(s) from list_tools"
             )
-        return ListToolsResult(tools=filtered)
+        result.tools = filtered
+        return result
 
     async def on_call_tool(self, context: MiddlewareContext[Any], call_next: NextFunctionT) -> CallToolResult:
         tool_name: str = context.params.name
         arguments: dict[str, Any] = context.params.arguments or {}
 
-        # 1. Denylist takes unconditional precedence.
-        if tool_name in self._denied:
-            self._log_decision(context, "DENIED", tool_name, "denylist")
-            return _denied_result(tool_name)
-
-        # 2. Allowlist: if set, only listed tools are permitted.
-        if self._allowed is not None and tool_name not in self._allowed:
-            self._log_decision(context, "DENIED", tool_name, "not_in_allowlist")
+        # 1. & 2. Static rules (denylist, then allowlist).
+        deny_reason = self._static_deny_reason(tool_name)
+        if deny_reason is not None:
+            self._log_decision(context, "DENIED", tool_name, deny_reason)
             return _denied_result(tool_name)
 
         # 3. Custom authorizer for dynamic / external policy evaluation.

--- a/libraries/python/mcp_use/client/middleware/authorization.py
+++ b/libraries/python/mcp_use/client/middleware/authorization.py
@@ -6,10 +6,13 @@ tool calls before they reach the MCP server, enabling fine-grained access
 control over which tools an agent is permitted to invoke.
 """
 
+import time
 from collections.abc import Awaitable, Callable
 from typing import Any
 
-from mcp.types import CallToolResult, TextContent
+from mcp.types import CallToolResult, ListToolsResult, TextContent
+
+from mcp_use.logging import logger
 
 from .middleware import Middleware, MiddlewareContext, NextFunctionT
 
@@ -26,15 +29,18 @@ class ToolAuthorizationMiddleware(Middleware):
     """Deny-first per-tool authorization middleware.
 
     Intercepts tool calls after the LLM decides to invoke a tool but before
-    the call reaches the MCP server. Evaluates the call against an allowlist,
-    denylist, and/or a custom async authorizer function.
+    the call reaches the MCP server. Also filters the tool list returned by
+    ``list_tools`` so that unauthorized tools are never visible to the LLM.
 
-    Authorization order:
+    Authorization order for tool calls:
       1. Denylist check — if the tool is in ``denied_tools``, deny immediately.
       2. Allowlist check — if ``allowed_tools`` is set and the tool is not in
          it, deny.
       3. Custom authorizer — if provided and it returns ``False``, deny.
       4. Otherwise, forward the call.
+
+    Every decision (allow or deny) is logged via the ``mcp_use`` logger so
+    an audit trail is always available.
 
     A denied call returns a :class:`mcp.types.CallToolResult` with
     ``isError=True`` so the LLM can reason about the denial gracefully
@@ -46,10 +52,14 @@ class ToolAuthorizationMiddleware(Middleware):
             all tools not blocked by other checks.
         denied_tools: Explicit denylist of tool names. Takes precedence over
             ``allowed_tools``. Defaults to no denials.
+        agent_context: Arbitrary identity/metadata dict (e.g. agent ID, OAuth
+            token, role) forwarded to the ``authorizer`` as its third argument.
+            Useful for building identity-aware permission checks without
+            coupling the middleware to a specific auth system.
         authorizer: Optional async callable with signature
-            ``(tool_name: str, arguments: dict) -> bool``. Return ``True``
-            to allow the call, ``False`` to deny it. Evaluated last, after
-            the allowlist/denylist checks pass.
+            ``(tool_name: str, arguments: dict, agent_context: dict) -> bool``.
+            Return ``True`` to allow the call, ``False`` to deny it. Evaluated
+            last, after the allowlist/denylist checks pass.
 
     Example::
 
@@ -67,13 +77,19 @@ class ToolAuthorizationMiddleware(Middleware):
             ],
         )
 
-        # Custom authorizer backed by an external permission engine
-        async def my_authorizer(tool_name: str, arguments: dict) -> bool:
-            return await permission_engine.check(tool_name, arguments)
+        # Identity-aware authorizer backed by an external permission engine
+        async def my_authorizer(tool_name: str, arguments: dict, agent_context: dict) -> bool:
+            token = agent_context.get("token")
+            return await permission_engine.check(token, tool_name, arguments)
 
         client = MCPClient(
             config=config,
-            middleware=[ToolAuthorizationMiddleware(authorizer=my_authorizer)],
+            middleware=[
+                ToolAuthorizationMiddleware(
+                    agent_context={"agent_id": "research-1", "token": "..."},
+                    authorizer=my_authorizer,
+                )
+            ],
         )
     """
 
@@ -81,26 +97,56 @@ class ToolAuthorizationMiddleware(Middleware):
         self,
         allowed_tools: list[str] | None = None,
         denied_tools: list[str] | None = None,
-        authorizer: Callable[[str, dict[str, Any]], Awaitable[bool]] | None = None,
+        agent_context: dict[str, Any] | None = None,
+        authorizer: Callable[[str, dict[str, Any], dict[str, Any]], Awaitable[bool]] | None = None,
     ) -> None:
         self._allowed: frozenset[str] | None = frozenset(allowed_tools) if allowed_tools is not None else None
         self._denied: frozenset[str] = frozenset(denied_tools or [])
+        self._agent_context: dict[str, Any] = agent_context or {}
         self._authorizer = authorizer
+
+    def _is_tool_allowed_by_static_rules(self, tool_name: str) -> bool:
+        """Check allowlist/denylist rules only (no async authorizer)."""
+        if tool_name in self._denied:
+            return False
+        if self._allowed is not None and tool_name not in self._allowed:
+            return False
+        return True
+
+    async def on_list_tools(self, context: MiddlewareContext[Any], call_next: NextFunctionT) -> ListToolsResult:
+        """Filter the tool list so denied tools are never visible to the LLM."""
+        result: ListToolsResult = await call_next(context)
+        if not result.tools:
+            return result
+
+        filtered = [tool for tool in result.tools if self._is_tool_allowed_by_static_rules(tool.name)]
+        removed = len(result.tools) - len(filtered)
+        if removed:
+            logger.debug(f"[ToolAuthorizationMiddleware] Filtered {removed} unauthorized tool(s) from list_tools")
+
+        return ListToolsResult(tools=filtered)
 
     async def on_call_tool(self, context: MiddlewareContext[Any], call_next: NextFunctionT) -> CallToolResult:
         tool_name: str = context.params.name
         arguments: dict[str, Any] = context.params.arguments or {}
+        timestamp = time.time()
 
         # 1. Denylist takes unconditional precedence.
         if tool_name in self._denied:
+            logger.info(f"[ToolAuthorizationMiddleware] DENIED tool='{tool_name}' reason=denylist ts={timestamp:.3f}")
             return _denied_result(tool_name)
 
         # 2. Allowlist: if set, only listed tools are permitted.
         if self._allowed is not None and tool_name not in self._allowed:
+            logger.info(
+                f"[ToolAuthorizationMiddleware] DENIED tool='{tool_name}' reason=not_in_allowlist ts={timestamp:.3f}"
+            )
             return _denied_result(tool_name)
 
         # 3. Custom authorizer for dynamic / external policy evaluation.
-        if self._authorizer is not None and not await self._authorizer(tool_name, arguments):
+        if self._authorizer is not None and not await self._authorizer(tool_name, arguments, self._agent_context):
+            logger.info(f"[ToolAuthorizationMiddleware] DENIED tool='{tool_name}' reason=authorizer ts={timestamp:.3f}")
             return _denied_result(tool_name)
 
+        logger.debug(f"[ToolAuthorizationMiddleware] ALLOWED tool='{tool_name}' ts={timestamp:.3f}")
         return await call_next(context)

--- a/libraries/python/mcp_use/client/middleware/authorization.py
+++ b/libraries/python/mcp_use/client/middleware/authorization.py
@@ -4,17 +4,31 @@ Per-tool authorization middleware for MCP requests.
 This module provides a deny-first authorization middleware that intercepts
 tool calls before they reach the MCP server, enabling fine-grained access
 control over which tools an agent is permitted to invoke.
+
+The middleware is fail-safe: any unexpected error while evaluating the
+custom authorizer results in a deny decision, never an allow.
 """
 
-import time
 from collections.abc import Awaitable, Callable
-from typing import Any
+from typing import Any, TypeAlias
 
 from mcp.types import CallToolResult, ListToolsResult, TextContent
 
 from mcp_use.logging import logger
 
 from .middleware import Middleware, MiddlewareContext, NextFunctionT
+
+#: Signature for a custom authorizer callable.
+#:
+#: Args:
+#:     tool_name: The name of the tool being invoked.
+#:     arguments: The arguments the LLM supplied for the call.
+#:     agent_context: Identity/metadata dict passed to the middleware at
+#:         construction time (e.g. agent ID, OAuth token, role).
+#:
+#: Returns:
+#:     ``True`` to allow the call, ``False`` to deny it.
+AuthorizerFn: TypeAlias = Callable[[str, dict[str, Any], dict[str, Any]], Awaitable[bool]]
 
 
 def _denied_result(tool_name: str) -> CallToolResult:
@@ -30,17 +44,25 @@ class ToolAuthorizationMiddleware(Middleware):
 
     Intercepts tool calls after the LLM decides to invoke a tool but before
     the call reaches the MCP server. Also filters the tool list returned by
-    ``list_tools`` so that unauthorized tools are never visible to the LLM.
+    ``list_tools`` so that statically-disallowed tools are never visible to
+    the LLM (the async ``authorizer`` is not consulted here because it may
+    need per-call arguments to decide).
 
     Authorization order for tool calls:
       1. Denylist check — if the tool is in ``denied_tools``, deny immediately.
       2. Allowlist check — if ``allowed_tools`` is set and the tool is not in
          it, deny.
-      3. Custom authorizer — if provided and it returns ``False``, deny.
+      3. Custom authorizer — if provided and it returns ``False`` (or raises),
+         deny.
       4. Otherwise, forward the call.
 
-    Every decision (allow or deny) is logged via the ``mcp_use`` logger so
-    an audit trail is always available.
+    Every decision (allow or deny) is logged via the ``mcp_use`` logger with
+    the request ID and connection ID so the audit trail can be correlated
+    with other middleware output.
+
+    This middleware is **fail-safe**: if the ``authorizer`` raises an
+    exception, the call is denied rather than allowed. Exceptions are
+    logged at error level so the root cause is visible.
 
     A denied call returns a :class:`mcp.types.CallToolResult` with
     ``isError=True`` so the LLM can reason about the denial gracefully
@@ -49,17 +71,16 @@ class ToolAuthorizationMiddleware(Middleware):
     Args:
         allowed_tools: Explicit allowlist of tool names. When provided, any
             tool not on this list is denied. Pass ``None`` (default) to allow
-            all tools not blocked by other checks.
+            all tools not blocked by other checks. An empty list denies
+            everything.
         denied_tools: Explicit denylist of tool names. Takes precedence over
             ``allowed_tools``. Defaults to no denials.
         agent_context: Arbitrary identity/metadata dict (e.g. agent ID, OAuth
             token, role) forwarded to the ``authorizer`` as its third argument.
             Useful for building identity-aware permission checks without
             coupling the middleware to a specific auth system.
-        authorizer: Optional async callable with signature
-            ``(tool_name: str, arguments: dict, agent_context: dict) -> bool``.
-            Return ``True`` to allow the call, ``False`` to deny it. Evaluated
-            last, after the allowlist/denylist checks pass.
+        authorizer: Optional async callable matching :data:`AuthorizerFn`.
+            Evaluated last, after the allowlist/denylist checks pass.
 
     Example::
 
@@ -69,18 +90,11 @@ class ToolAuthorizationMiddleware(Middleware):
             middleware=[ToolAuthorizationMiddleware(allowed_tools=["search_docs"])],
         )
 
-        # Content agent: cannot touch destructive tools
-        client = MCPClient(
-            config=config,
-            middleware=[
-                ToolAuthorizationMiddleware(denied_tools=["delete_note", "deploy_prod"])
-            ],
-        )
-
         # Identity-aware authorizer backed by an external permission engine
-        async def my_authorizer(tool_name: str, arguments: dict, agent_context: dict) -> bool:
-            token = agent_context.get("token")
-            return await permission_engine.check(token, tool_name, arguments)
+        async def my_authorizer(tool_name, arguments, agent_context):
+            return await permission_engine.check(
+                agent_context["token"], tool_name, arguments
+            )
 
         client = MCPClient(
             config=config,
@@ -98,12 +112,12 @@ class ToolAuthorizationMiddleware(Middleware):
         allowed_tools: list[str] | None = None,
         denied_tools: list[str] | None = None,
         agent_context: dict[str, Any] | None = None,
-        authorizer: Callable[[str, dict[str, Any], dict[str, Any]], Awaitable[bool]] | None = None,
+        authorizer: AuthorizerFn | None = None,
     ) -> None:
         self._allowed: frozenset[str] | None = frozenset(allowed_tools) if allowed_tools is not None else None
         self._denied: frozenset[str] = frozenset(denied_tools or [])
         self._agent_context: dict[str, Any] = agent_context or {}
-        self._authorizer = authorizer
+        self._authorizer: AuthorizerFn | None = authorizer
 
     def _is_tool_allowed_by_static_rules(self, tool_name: str) -> bool:
         """Check allowlist/denylist rules only (no async authorizer)."""
@@ -113,40 +127,60 @@ class ToolAuthorizationMiddleware(Middleware):
             return False
         return True
 
-    async def on_list_tools(self, context: MiddlewareContext[Any], call_next: NextFunctionT) -> ListToolsResult:
-        """Filter the tool list so denied tools are never visible to the LLM."""
-        result: ListToolsResult = await call_next(context)
-        if not result.tools:
-            return result
+    def _log_decision(self, context: MiddlewareContext[Any], decision: str, tool_name: str, reason: str) -> None:
+        """Emit an audit log entry for an allow/deny decision."""
+        level = logger.debug if decision == "ALLOWED" else logger.info
+        level(
+            f"[{context.id}] {context.connection_id} ToolAuthorizationMiddleware "
+            f"{decision} tool='{tool_name}' reason={reason}"
+        )
 
+    async def on_list_tools(self, context: MiddlewareContext[Any], call_next: NextFunctionT) -> ListToolsResult:
+        """Filter the tool list using static rules only.
+
+        The async ``authorizer`` is intentionally not consulted here because
+        it may need per-call arguments and side-effect-free evaluation is not
+        guaranteed.
+        """
+        result: ListToolsResult = await call_next(context)
         filtered = [tool for tool in result.tools if self._is_tool_allowed_by_static_rules(tool.name)]
         removed = len(result.tools) - len(filtered)
         if removed:
-            logger.debug(f"[ToolAuthorizationMiddleware] Filtered {removed} unauthorized tool(s) from list_tools")
-
+            logger.debug(
+                f"[{context.id}] {context.connection_id} ToolAuthorizationMiddleware "
+                f"filtered {removed} unauthorized tool(s) from list_tools"
+            )
         return ListToolsResult(tools=filtered)
 
     async def on_call_tool(self, context: MiddlewareContext[Any], call_next: NextFunctionT) -> CallToolResult:
         tool_name: str = context.params.name
         arguments: dict[str, Any] = context.params.arguments or {}
-        timestamp = time.time()
 
         # 1. Denylist takes unconditional precedence.
         if tool_name in self._denied:
-            logger.info(f"[ToolAuthorizationMiddleware] DENIED tool='{tool_name}' reason=denylist ts={timestamp:.3f}")
+            self._log_decision(context, "DENIED", tool_name, "denylist")
             return _denied_result(tool_name)
 
         # 2. Allowlist: if set, only listed tools are permitted.
         if self._allowed is not None and tool_name not in self._allowed:
-            logger.info(
-                f"[ToolAuthorizationMiddleware] DENIED tool='{tool_name}' reason=not_in_allowlist ts={timestamp:.3f}"
-            )
+            self._log_decision(context, "DENIED", tool_name, "not_in_allowlist")
             return _denied_result(tool_name)
 
         # 3. Custom authorizer for dynamic / external policy evaluation.
-        if self._authorizer is not None and not await self._authorizer(tool_name, arguments, self._agent_context):
-            logger.info(f"[ToolAuthorizationMiddleware] DENIED tool='{tool_name}' reason=authorizer ts={timestamp:.3f}")
-            return _denied_result(tool_name)
+        #    Fail-safe: any exception results in a deny, not an allow.
+        if self._authorizer is not None:
+            try:
+                allowed = await self._authorizer(tool_name, arguments, self._agent_context)
+            except Exception as exc:
+                logger.error(
+                    f"[{context.id}] {context.connection_id} ToolAuthorizationMiddleware "
+                    f"authorizer raised for tool='{tool_name}': {exc!r} — denying (fail-safe)"
+                )
+                return _denied_result(tool_name)
 
-        logger.debug(f"[ToolAuthorizationMiddleware] ALLOWED tool='{tool_name}' ts={timestamp:.3f}")
+            if not allowed:
+                self._log_decision(context, "DENIED", tool_name, "authorizer")
+                return _denied_result(tool_name)
+
+        self._log_decision(context, "ALLOWED", tool_name, "ok")
         return await call_next(context)

--- a/libraries/python/tests/unit/test_authorization_middleware.py
+++ b/libraries/python/tests/unit/test_authorization_middleware.py
@@ -1,0 +1,184 @@
+"""
+Unit tests for ToolAuthorizationMiddleware.
+"""
+
+import pytest
+from mcp.types import CallToolRequestParams, CallToolResult, TextContent
+
+from mcp_use.client.middleware.authorization import ToolAuthorizationMiddleware
+from mcp_use.client.middleware.middleware import MiddlewareContext
+
+
+def _make_context(tool_name: str, arguments: dict | None = None) -> MiddlewareContext:
+    params = CallToolRequestParams(name=tool_name, arguments=arguments or {})
+    return MiddlewareContext(
+        id="test-id",
+        method="tools/call",
+        params=params,
+        connection_id="conn-1",
+        timestamp=0.0,
+    )
+
+
+async def _allow_next(context: MiddlewareContext) -> CallToolResult:
+    """Simulates the next middleware/handler — always succeeds."""
+    return CallToolResult(
+        content=[TextContent(type="text", text="ok")],
+        isError=False,
+    )
+
+
+def _is_denied(result: CallToolResult) -> bool:
+    return result.isError is True
+
+
+class TestDenylist:
+    @pytest.mark.asyncio
+    async def test_denied_tool_is_blocked(self):
+        mw = ToolAuthorizationMiddleware(denied_tools=["delete_note"])
+        ctx = _make_context("delete_note")
+        result = await mw.on_call_tool(ctx, _allow_next)
+        assert _is_denied(result)
+        assert "delete_note" in result.content[0].text
+
+    @pytest.mark.asyncio
+    async def test_non_denied_tool_passes(self):
+        mw = ToolAuthorizationMiddleware(denied_tools=["delete_note"])
+        ctx = _make_context("search_docs")
+        result = await mw.on_call_tool(ctx, _allow_next)
+        assert not _is_denied(result)
+
+    @pytest.mark.asyncio
+    async def test_empty_denylist_blocks_nothing(self):
+        mw = ToolAuthorizationMiddleware(denied_tools=[])
+        ctx = _make_context("deploy_prod")
+        result = await mw.on_call_tool(ctx, _allow_next)
+        assert not _is_denied(result)
+
+
+class TestAllowlist:
+    @pytest.mark.asyncio
+    async def test_allowed_tool_passes(self):
+        mw = ToolAuthorizationMiddleware(allowed_tools=["search_docs"])
+        ctx = _make_context("search_docs")
+        result = await mw.on_call_tool(ctx, _allow_next)
+        assert not _is_denied(result)
+
+    @pytest.mark.asyncio
+    async def test_unlisted_tool_is_blocked(self):
+        mw = ToolAuthorizationMiddleware(allowed_tools=["search_docs"])
+        ctx = _make_context("save_note")
+        result = await mw.on_call_tool(ctx, _allow_next)
+        assert _is_denied(result)
+        assert "save_note" in result.content[0].text
+
+    @pytest.mark.asyncio
+    async def test_no_allowlist_allows_all(self):
+        mw = ToolAuthorizationMiddleware()
+        ctx = _make_context("any_tool")
+        result = await mw.on_call_tool(ctx, _allow_next)
+        assert not _is_denied(result)
+
+
+class TestDenylistOverridesAllowlist:
+    @pytest.mark.asyncio
+    async def test_denylist_takes_precedence_over_allowlist(self):
+        # tool is in both lists — denylist wins
+        mw = ToolAuthorizationMiddleware(
+            allowed_tools=["search_docs", "delete_note"],
+            denied_tools=["delete_note"],
+        )
+        ctx = _make_context("delete_note")
+        result = await mw.on_call_tool(ctx, _allow_next)
+        assert _is_denied(result)
+
+    @pytest.mark.asyncio
+    async def test_allowed_and_not_denied_passes(self):
+        mw = ToolAuthorizationMiddleware(
+            allowed_tools=["search_docs"],
+            denied_tools=["delete_note"],
+        )
+        ctx = _make_context("search_docs")
+        result = await mw.on_call_tool(ctx, _allow_next)
+        assert not _is_denied(result)
+
+
+class TestCustomAuthorizer:
+    @pytest.mark.asyncio
+    async def test_authorizer_returning_true_allows(self):
+        async def always_allow(tool_name: str, arguments: dict) -> bool:
+            return True
+
+        mw = ToolAuthorizationMiddleware(authorizer=always_allow)
+        result = await mw.on_call_tool(_make_context("deploy_prod"), _allow_next)
+        assert not _is_denied(result)
+
+    @pytest.mark.asyncio
+    async def test_authorizer_returning_false_denies(self):
+        async def always_deny(tool_name: str, arguments: dict) -> bool:
+            return False
+
+        mw = ToolAuthorizationMiddleware(authorizer=always_deny)
+        result = await mw.on_call_tool(_make_context("search_docs"), _allow_next)
+        assert _is_denied(result)
+
+    @pytest.mark.asyncio
+    async def test_authorizer_receives_tool_name_and_arguments(self):
+        received = {}
+
+        async def capture(tool_name: str, arguments: dict) -> bool:
+            received["tool_name"] = tool_name
+            received["arguments"] = arguments
+            return True
+
+        mw = ToolAuthorizationMiddleware(authorizer=capture)
+        await mw.on_call_tool(_make_context("search_docs", {"query": "hello"}), _allow_next)
+        assert received["tool_name"] == "search_docs"
+        assert received["arguments"] == {"query": "hello"}
+
+    @pytest.mark.asyncio
+    async def test_authorizer_not_called_when_denylist_blocks(self):
+        called = []
+
+        async def track(tool_name: str, arguments: dict) -> bool:
+            called.append(tool_name)
+            return True
+
+        mw = ToolAuthorizationMiddleware(denied_tools=["delete_note"], authorizer=track)
+        await mw.on_call_tool(_make_context("delete_note"), _allow_next)
+        assert called == [], "Authorizer should not be called when denylist blocks first"
+
+    @pytest.mark.asyncio
+    async def test_authorizer_not_called_when_allowlist_blocks(self):
+        called = []
+
+        async def track(tool_name: str, arguments: dict) -> bool:
+            called.append(tool_name)
+            return True
+
+        mw = ToolAuthorizationMiddleware(allowed_tools=["search_docs"], authorizer=track)
+        await mw.on_call_tool(_make_context("save_note"), _allow_next)
+        assert called == [], "Authorizer should not be called when allowlist blocks first"
+
+
+class TestNoneArguments:
+    @pytest.mark.asyncio
+    async def test_none_arguments_treated_as_empty_dict(self):
+        received = {}
+
+        async def capture(tool_name: str, arguments: dict) -> bool:
+            received["arguments"] = arguments
+            return True
+
+        # Simulate context where arguments is None
+        params = CallToolRequestParams(name="search_docs", arguments=None)
+        ctx = MiddlewareContext(
+            id="test-id",
+            method="tools/call",
+            params=params,
+            connection_id="conn-1",
+            timestamp=0.0,
+        )
+        mw = ToolAuthorizationMiddleware(authorizer=capture)
+        await mw.on_call_tool(ctx, _allow_next)
+        assert received["arguments"] == {}

--- a/libraries/python/tests/unit/test_authorization_middleware.py
+++ b/libraries/python/tests/unit/test_authorization_middleware.py
@@ -3,13 +3,13 @@ Unit tests for ToolAuthorizationMiddleware.
 """
 
 import pytest
-from mcp.types import CallToolRequestParams, CallToolResult, TextContent
+from mcp.types import CallToolRequestParams, CallToolResult, ListToolsResult, TextContent, Tool
 
 from mcp_use.client.middleware.authorization import ToolAuthorizationMiddleware
 from mcp_use.client.middleware.middleware import MiddlewareContext
 
 
-def _make_context(tool_name: str, arguments: dict | None = None) -> MiddlewareContext:
+def _make_call_context(tool_name: str, arguments: dict | None = None) -> MiddlewareContext:
     params = CallToolRequestParams(name=tool_name, arguments=arguments or {})
     return MiddlewareContext(
         id="test-id",
@@ -20,76 +20,97 @@ def _make_context(tool_name: str, arguments: dict | None = None) -> MiddlewareCo
     )
 
 
-async def _allow_next(context: MiddlewareContext) -> CallToolResult:
-    """Simulates the next middleware/handler — always succeeds."""
-    return CallToolResult(
-        content=[TextContent(type="text", text="ok")],
-        isError=False,
+def _make_list_context() -> MiddlewareContext:
+    return MiddlewareContext(
+        id="test-id",
+        method="tools/list",
+        params=None,
+        connection_id="conn-1",
+        timestamp=0.0,
     )
+
+
+def _tool(name: str) -> Tool:
+    return Tool(name=name, description=f"Tool {name}", inputSchema={"type": "object", "properties": {}})
+
+
+async def _allow_next(context: MiddlewareContext) -> CallToolResult:
+    """Simulates the next handler — always succeeds."""
+    return CallToolResult(content=[TextContent(type="text", text="ok")], isError=False)
+
+
+def _make_list_next(*tool_names: str):
+    """Returns a next-handler that produces a ListToolsResult with given tools."""
+
+    async def _next(context: MiddlewareContext) -> ListToolsResult:
+        return ListToolsResult(tools=[_tool(n) for n in tool_names])
+
+    return _next
 
 
 def _is_denied(result: CallToolResult) -> bool:
     return result.isError is True
 
 
+# ---------------------------------------------------------------------------
+# Denylist
+# ---------------------------------------------------------------------------
 class TestDenylist:
     @pytest.mark.asyncio
     async def test_denied_tool_is_blocked(self):
         mw = ToolAuthorizationMiddleware(denied_tools=["delete_note"])
-        ctx = _make_context("delete_note")
-        result = await mw.on_call_tool(ctx, _allow_next)
+        result = await mw.on_call_tool(_make_call_context("delete_note"), _allow_next)
         assert _is_denied(result)
         assert "delete_note" in result.content[0].text
 
     @pytest.mark.asyncio
     async def test_non_denied_tool_passes(self):
         mw = ToolAuthorizationMiddleware(denied_tools=["delete_note"])
-        ctx = _make_context("search_docs")
-        result = await mw.on_call_tool(ctx, _allow_next)
+        result = await mw.on_call_tool(_make_call_context("search_docs"), _allow_next)
         assert not _is_denied(result)
 
     @pytest.mark.asyncio
     async def test_empty_denylist_blocks_nothing(self):
         mw = ToolAuthorizationMiddleware(denied_tools=[])
-        ctx = _make_context("deploy_prod")
-        result = await mw.on_call_tool(ctx, _allow_next)
+        result = await mw.on_call_tool(_make_call_context("deploy_prod"), _allow_next)
         assert not _is_denied(result)
 
 
+# ---------------------------------------------------------------------------
+# Allowlist
+# ---------------------------------------------------------------------------
 class TestAllowlist:
     @pytest.mark.asyncio
     async def test_allowed_tool_passes(self):
         mw = ToolAuthorizationMiddleware(allowed_tools=["search_docs"])
-        ctx = _make_context("search_docs")
-        result = await mw.on_call_tool(ctx, _allow_next)
+        result = await mw.on_call_tool(_make_call_context("search_docs"), _allow_next)
         assert not _is_denied(result)
 
     @pytest.mark.asyncio
     async def test_unlisted_tool_is_blocked(self):
         mw = ToolAuthorizationMiddleware(allowed_tools=["search_docs"])
-        ctx = _make_context("save_note")
-        result = await mw.on_call_tool(ctx, _allow_next)
+        result = await mw.on_call_tool(_make_call_context("save_note"), _allow_next)
         assert _is_denied(result)
         assert "save_note" in result.content[0].text
 
     @pytest.mark.asyncio
     async def test_no_allowlist_allows_all(self):
         mw = ToolAuthorizationMiddleware()
-        ctx = _make_context("any_tool")
-        result = await mw.on_call_tool(ctx, _allow_next)
+        result = await mw.on_call_tool(_make_call_context("any_tool"), _allow_next)
         assert not _is_denied(result)
 
 
+# ---------------------------------------------------------------------------
+# Denylist takes precedence over allowlist
+# ---------------------------------------------------------------------------
 class TestDenylistOverridesAllowlist:
     @pytest.mark.asyncio
     async def test_denylist_takes_precedence_over_allowlist(self):
-        # tool is in both lists — denylist wins
         mw = ToolAuthorizationMiddleware(
             allowed_tools=["search_docs", "delete_note"],
             denied_tools=["delete_note"],
         )
-        ctx = _make_context("delete_note")
-        result = await mw.on_call_tool(ctx, _allow_next)
+        result = await mw.on_call_tool(_make_call_context("delete_note"), _allow_next)
         assert _is_denied(result)
 
     @pytest.mark.asyncio
@@ -98,41 +119,43 @@ class TestDenylistOverridesAllowlist:
             allowed_tools=["search_docs"],
             denied_tools=["delete_note"],
         )
-        ctx = _make_context("search_docs")
-        result = await mw.on_call_tool(ctx, _allow_next)
+        result = await mw.on_call_tool(_make_call_context("search_docs"), _allow_next)
         assert not _is_denied(result)
 
 
+# ---------------------------------------------------------------------------
+# Custom authorizer
+# ---------------------------------------------------------------------------
 class TestCustomAuthorizer:
     @pytest.mark.asyncio
     async def test_authorizer_returning_true_allows(self):
-        async def always_allow(tool_name: str, arguments: dict) -> bool:
+        async def always_allow(tool_name, arguments, agent_context) -> bool:
             return True
 
         mw = ToolAuthorizationMiddleware(authorizer=always_allow)
-        result = await mw.on_call_tool(_make_context("deploy_prod"), _allow_next)
+        result = await mw.on_call_tool(_make_call_context("deploy_prod"), _allow_next)
         assert not _is_denied(result)
 
     @pytest.mark.asyncio
     async def test_authorizer_returning_false_denies(self):
-        async def always_deny(tool_name: str, arguments: dict) -> bool:
+        async def always_deny(tool_name, arguments, agent_context) -> bool:
             return False
 
         mw = ToolAuthorizationMiddleware(authorizer=always_deny)
-        result = await mw.on_call_tool(_make_context("search_docs"), _allow_next)
+        result = await mw.on_call_tool(_make_call_context("search_docs"), _allow_next)
         assert _is_denied(result)
 
     @pytest.mark.asyncio
     async def test_authorizer_receives_tool_name_and_arguments(self):
         received = {}
 
-        async def capture(tool_name: str, arguments: dict) -> bool:
+        async def capture(tool_name, arguments, agent_context) -> bool:
             received["tool_name"] = tool_name
             received["arguments"] = arguments
             return True
 
         mw = ToolAuthorizationMiddleware(authorizer=capture)
-        await mw.on_call_tool(_make_context("search_docs", {"query": "hello"}), _allow_next)
+        await mw.on_call_tool(_make_call_context("search_docs", {"query": "hello"}), _allow_next)
         assert received["tool_name"] == "search_docs"
         assert received["arguments"] == {"query": "hello"}
 
@@ -140,37 +163,121 @@ class TestCustomAuthorizer:
     async def test_authorizer_not_called_when_denylist_blocks(self):
         called = []
 
-        async def track(tool_name: str, arguments: dict) -> bool:
+        async def track(tool_name, arguments, agent_context) -> bool:
             called.append(tool_name)
             return True
 
         mw = ToolAuthorizationMiddleware(denied_tools=["delete_note"], authorizer=track)
-        await mw.on_call_tool(_make_context("delete_note"), _allow_next)
+        await mw.on_call_tool(_make_call_context("delete_note"), _allow_next)
         assert called == [], "Authorizer should not be called when denylist blocks first"
 
     @pytest.mark.asyncio
     async def test_authorizer_not_called_when_allowlist_blocks(self):
         called = []
 
-        async def track(tool_name: str, arguments: dict) -> bool:
+        async def track(tool_name, arguments, agent_context) -> bool:
             called.append(tool_name)
             return True
 
         mw = ToolAuthorizationMiddleware(allowed_tools=["search_docs"], authorizer=track)
-        await mw.on_call_tool(_make_context("save_note"), _allow_next)
+        await mw.on_call_tool(_make_call_context("save_note"), _allow_next)
         assert called == [], "Authorizer should not be called when allowlist blocks first"
 
 
+# ---------------------------------------------------------------------------
+# Agent context forwarded to authorizer
+# ---------------------------------------------------------------------------
+class TestAgentContext:
+    @pytest.mark.asyncio
+    async def test_agent_context_forwarded_to_authorizer(self):
+        received = {}
+
+        async def capture(tool_name, arguments, agent_context) -> bool:
+            received["agent_context"] = agent_context
+            return True
+
+        mw = ToolAuthorizationMiddleware(
+            agent_context={"agent_id": "research-1", "token": "secret"},
+            authorizer=capture,
+        )
+        await mw.on_call_tool(_make_call_context("search_docs"), _allow_next)
+        assert received["agent_context"] == {"agent_id": "research-1", "token": "secret"}
+
+    @pytest.mark.asyncio
+    async def test_missing_agent_context_defaults_to_empty_dict(self):
+        received = {}
+
+        async def capture(tool_name, arguments, agent_context) -> bool:
+            received["agent_context"] = agent_context
+            return True
+
+        mw = ToolAuthorizationMiddleware(authorizer=capture)
+        await mw.on_call_tool(_make_call_context("search_docs"), _allow_next)
+        assert received["agent_context"] == {}
+
+    @pytest.mark.asyncio
+    async def test_agent_context_can_drive_deny_decision(self):
+        async def role_check(tool_name, arguments, agent_context) -> bool:
+            return "admin" in agent_context.get("roles", [])
+
+        mw_admin = ToolAuthorizationMiddleware(agent_context={"roles": ["admin"]}, authorizer=role_check)
+        mw_reader = ToolAuthorizationMiddleware(agent_context={"roles": ["reader"]}, authorizer=role_check)
+        assert not _is_denied(await mw_admin.on_call_tool(_make_call_context("deploy_prod"), _allow_next))
+        assert _is_denied(await mw_reader.on_call_tool(_make_call_context("deploy_prod"), _allow_next))
+
+
+# ---------------------------------------------------------------------------
+# on_list_tools filtering
+# ---------------------------------------------------------------------------
+class TestListToolsFiltering:
+    @pytest.mark.asyncio
+    async def test_denylist_removes_tools_from_list(self):
+        mw = ToolAuthorizationMiddleware(denied_tools=["delete_note", "deploy_prod"])
+        result = await mw.on_list_tools(
+            _make_list_context(),
+            _make_list_next("search_docs", "delete_note", "deploy_prod"),
+        )
+        names = [t.name for t in result.tools]
+        assert names == ["search_docs"]
+
+    @pytest.mark.asyncio
+    async def test_allowlist_removes_unlisted_tools_from_list(self):
+        mw = ToolAuthorizationMiddleware(allowed_tools=["search_docs", "save_note"])
+        result = await mw.on_list_tools(
+            _make_list_context(),
+            _make_list_next("search_docs", "save_note", "delete_note", "deploy_prod"),
+        )
+        names = [t.name for t in result.tools]
+        assert names == ["search_docs", "save_note"]
+
+    @pytest.mark.asyncio
+    async def test_no_rules_returns_all_tools(self):
+        mw = ToolAuthorizationMiddleware()
+        result = await mw.on_list_tools(
+            _make_list_context(),
+            _make_list_next("search_docs", "save_note", "delete_note"),
+        )
+        assert len(result.tools) == 3
+
+    @pytest.mark.asyncio
+    async def test_empty_tool_list_returned_as_is(self):
+        mw = ToolAuthorizationMiddleware(denied_tools=["delete_note"])
+        result = await mw.on_list_tools(_make_list_context(), _make_list_next())
+        assert result.tools == []
+
+
+# ---------------------------------------------------------------------------
+# None arguments edge case
+# ---------------------------------------------------------------------------
 class TestNoneArguments:
     @pytest.mark.asyncio
     async def test_none_arguments_treated_as_empty_dict(self):
         received = {}
 
-        async def capture(tool_name: str, arguments: dict) -> bool:
+        async def capture(tool_name, arguments, agent_context) -> bool:
             received["arguments"] = arguments
             return True
 
-        # Simulate context where arguments is None
         params = CallToolRequestParams(name="search_docs", arguments=None)
         ctx = MiddlewareContext(
             id="test-id",

--- a/libraries/python/tests/unit/test_authorization_middleware.py
+++ b/libraries/python/tests/unit/test_authorization_middleware.py
@@ -267,6 +267,72 @@ class TestListToolsFiltering:
 
 
 # ---------------------------------------------------------------------------
+# Fail-safe behavior
+# ---------------------------------------------------------------------------
+class TestFailSafe:
+    @pytest.mark.asyncio
+    async def test_authorizer_exception_denies_call(self):
+        async def boom(tool_name, arguments, agent_context) -> bool:
+            raise RuntimeError("permission engine unreachable")
+
+        mw = ToolAuthorizationMiddleware(authorizer=boom)
+        result = await mw.on_call_tool(_make_call_context("search_docs"), _allow_next)
+        assert _is_denied(result), "Authorizer exception must fail-safe to deny"
+        assert "search_docs" in result.content[0].text
+
+    @pytest.mark.asyncio
+    async def test_next_handler_not_called_when_authorizer_raises(self):
+        called = []
+
+        async def boom(tool_name, arguments, agent_context) -> bool:
+            raise RuntimeError("boom")
+
+        async def tracking_next(context) -> CallToolResult:
+            called.append(context.params.name)
+            return CallToolResult(content=[TextContent(type="text", text="ok")], isError=False)
+
+        mw = ToolAuthorizationMiddleware(authorizer=boom)
+        await mw.on_call_tool(_make_call_context("search_docs"), tracking_next)
+        assert called == [], "call_next must not execute when authorizer fails"
+
+
+# ---------------------------------------------------------------------------
+# Empty allowlist edge case
+# ---------------------------------------------------------------------------
+class TestEmptyAllowlist:
+    @pytest.mark.asyncio
+    async def test_empty_allowlist_denies_everything(self):
+        mw = ToolAuthorizationMiddleware(allowed_tools=[])
+        result = await mw.on_call_tool(_make_call_context("search_docs"), _allow_next)
+        assert _is_denied(result)
+
+    @pytest.mark.asyncio
+    async def test_empty_allowlist_filters_all_tools_from_list(self):
+        mw = ToolAuthorizationMiddleware(allowed_tools=[])
+        result = await mw.on_list_tools(_make_list_context(), _make_list_next("search_docs", "save_note"))
+        assert result.tools == []
+
+
+# ---------------------------------------------------------------------------
+# Authorizer is NOT consulted during list_tools (documented behavior)
+# ---------------------------------------------------------------------------
+class TestListToolsSkipsAuthorizer:
+    @pytest.mark.asyncio
+    async def test_authorizer_not_called_during_list_tools(self):
+        called = []
+
+        async def track(tool_name, arguments, agent_context) -> bool:
+            called.append(tool_name)
+            return False  # would deny if asked
+
+        mw = ToolAuthorizationMiddleware(authorizer=track)
+        result = await mw.on_list_tools(_make_list_context(), _make_list_next("search_docs", "save_note"))
+        assert called == []
+        # All tools remain because only static rules apply during list_tools
+        assert {t.name for t in result.tools} == {"search_docs", "save_note"}
+
+
+# ---------------------------------------------------------------------------
 # None arguments edge case
 # ---------------------------------------------------------------------------
 class TestNoneArguments:

--- a/libraries/python/tests/unit/test_authorization_middleware.py
+++ b/libraries/python/tests/unit/test_authorization_middleware.py
@@ -314,6 +314,24 @@ class TestEmptyAllowlist:
 
 
 # ---------------------------------------------------------------------------
+# Pagination and metadata are preserved through list_tools filtering
+# ---------------------------------------------------------------------------
+class TestListToolsPreservesPagination:
+    @pytest.mark.asyncio
+    async def test_next_cursor_preserved_through_filtering(self):
+        async def _next_with_cursor(context: MiddlewareContext) -> ListToolsResult:
+            return ListToolsResult(
+                tools=[_tool("search_docs"), _tool("delete_note")],
+                nextCursor="next-page-token",
+            )
+
+        mw = ToolAuthorizationMiddleware(denied_tools=["delete_note"])
+        result = await mw.on_list_tools(_make_list_context(), _next_with_cursor)
+        assert [t.name for t in result.tools] == ["search_docs"]
+        assert result.nextCursor == "next-page-token"
+
+
+# ---------------------------------------------------------------------------
 # Authorizer is NOT consulted during list_tools (documented behavior)
 # ---------------------------------------------------------------------------
 class TestListToolsSkipsAuthorizer:


### PR DESCRIPTION
## Language / Project Scope

- [x] Python

## Changes

Adds `ToolAuthorizationMiddleware` — a deny-first per-tool authorization middleware that intercepts tool calls after the LLM decides to invoke a tool but before the call reaches the MCP server. It supports an allowlist, a denylist, an arbitrary agent-identity context, and a custom async authorizer callable for integration with external permission engines. It also filters the tool list returned by `list_tools` so statically-denied tools are never visible to the LLM.

## Implementation Details

1. New module `libraries/python/mcp_use/client/middleware/authorization.py` hooks into the existing `Middleware.on_call_tool` and `Middleware.on_list_tools` extension points — no changes to the middleware pipeline itself.
2. Authorization order is **deny-first**: denylist → allowlist → custom `authorizer`. The denylist always takes precedence.
3. Denied calls return a `CallToolResult(isError=True)` with a human-readable message so the LLM can reason about the denial gracefully instead of seeing an unexpected exception.
4. **Fail-safe deny**: if the `authorizer` raises, the call is denied (never allowed) and the exception is logged at `error` level with full repr. Tests cover this path.
5. `on_list_tools` filters using **static rules only** (allow/deny lists). The async authorizer is intentionally not consulted here because it may need per-call arguments to decide and cannot be assumed side-effect-free. This behavior is documented in the class docstring and covered by a dedicated test.
6. Every allow/deny decision is logged through the existing `mcp_use` logger, including `context.id` and `context.connection_id`, so audit entries correlate with other middleware output.
7. `AuthorizerFn` type alias keeps the callable signature readable.
8. Exported from both `mcp_use.client.middleware` and the top-level `mcp_use` package.

## Python Checklist

- [x] Code formatted with `ruff format`
- [x] Linting passes with `ruff check`
- [x] Added or updated tests (26 new tests)
- [x] Updated examples (`examples/authorization_middleware_example.py`)

## Example Usage (Before)

```python
from mcp_use import MCPClient, MCPAgent

# No built-in way to restrict which tools an agent can invoke —
# the only option was to build separate MCP servers with tool subsets.
client = MCPClient(config=config)
agent = MCPAgent(llm=llm, client=client)
```

## Example Usage (After)

```python
from mcp_use import MCPClient, MCPAgent, ToolAuthorizationMiddleware

# Pattern 1 — allowlist: research agent can only search
client = MCPClient(
    config=config,
    middleware=[ToolAuthorizationMiddleware(allowed_tools=["search_docs"])],
)

# Pattern 2 — denylist: block destructive tools
client = MCPClient(
    config=config,
    middleware=[
        ToolAuthorizationMiddleware(denied_tools=["delete_note", "deploy_prod"])
    ],
)

# Pattern 3 — identity-aware custom authorizer backed by an external engine
async def my_authorizer(tool_name, arguments, agent_context):
    token = agent_context["token"]
    return await permission_engine.check(token, tool_name, arguments)

client = MCPClient(
    config=config,
    middleware=[
        ToolAuthorizationMiddleware(
            agent_context={"agent_id": "research-1", "token": "..."},
            authorizer=my_authorizer,
        )
    ],
)
```

Denied tools are also **hidden from the LLM's tool list** via `on_list_tools` filtering, so the agent never wastes inference steps trying to call something it cannot use.

## Documentation Updates

- `libraries/python/examples/authorization_middleware_example.py` — new example showing all four patterns (allowlist, denylist, identity-aware authorizer, external permission engine)
- Class docstring in `authorization.py` includes full usage examples, authorization order, fail-safe behavior, and the `on_list_tools` static-rules-only note
- No files under `docs/` were updated — there are no existing Python middleware docs to extend

## Testing

**26 unit tests** in `libraries/python/tests/unit/test_authorization_middleware.py`, all passing. Full `tests/unit/` suite runs clean (330 passed, 1 pre-existing unrelated failure on `test_create_sandboxed_stdio_connector` also fails on `main`).

Coverage:
- Denylist: blocks listed, passes non-listed, empty denylist is a no-op
- Allowlist: passes listed, blocks unlisted, `None` allows all, empty allowlist denies all
- Precedence: denylist beats allowlist
- Custom authorizer: allows on `True`, denies on `False`, receives tool name + arguments + agent_context, short-circuits correctly when denylist/allowlist blocks first
- **Fail-safe**: authorizer raising an exception denies the call and never invokes `call_next`
- Agent context: forwarded to authorizer, defaults to `{}`, can drive role-based deny decisions
- `on_list_tools`: denylist removes, allowlist removes, empty input handled, async authorizer **not** consulted during list filtering
- Edge case: `arguments=None` treated as `{}`

## Backwards Compatibility

**Fully backwards compatible.** This change is purely additive:
- New optional middleware class — not inserted into any default pipeline
- New import exported from `mcp_use.client.middleware` and the top-level `mcp_use` package; nothing removed or renamed
- No existing public API touched

Users who do not instantiate `ToolAuthorizationMiddleware` see zero behavior change.

## Related Issues

Closes #1257

## Notes for Reviewers

- The issue title mentions "for MCP servers" and the example in the body uses a server-style `@mcp.before_tool_call` decorator. mcp-use has a separate `ServerMiddleware` system in `mcp_use/server/middleware/` with its own context type. This PR implements the **client-side** complement per @stevenkozeniesky02's suggested approach in the issue thread — intercept after the LLM decides but before the call reaches the MCP server. A server-side `ToolAuthorizationServerMiddleware` would be a natural follow-up PR if the maintainers want symmetric coverage.
- Trust-score-based authorization and rate limits (discussed by @0xbrainkid and @stevenkozeniesky02 in the issue thread) are intentionally out of scope here — the `authorizer` callable is the extension point where those can be composed by users or added in follow-up PRs without touching this middleware.