### PR TITLE
feat(mcp-use): add telemetry support and update dependencies

### DIFF
--- a/libraries/typescript/.changeset/inspector-tel-fetch-subpath.md
+++ b/libraries/typescript/.changeset/inspector-tel-fetch-subpath.md
@@ -1,0 +1,6 @@
+---
+"mcp-use": patch
+"@mcp-use/inspector": patch
+---
+
+Fix embedded inspector failing when `langchain` is not installed: export `telFetch` from `mcp-use/telemetry/tel-fetch` so inspector server code does not load the root `mcp-use` entry (which eagerly pulls the agent graph). Log inspector mount failures in development or when `MCP_USE_DEBUG` is set.

--- a/libraries/typescript/packages/inspector/src/server/shared-routes.ts
+++ b/libraries/typescript/packages/inspector/src/server/shared-routes.ts
@@ -1,5 +1,5 @@
 import type { Hono } from "hono";
-import { telFetch } from "mcp-use";
+import { telFetch } from "mcp-use/telemetry/tel-fetch";
 import { mountMcpProxy, mountOAuthProxy } from "mcp-use/server";
 import { registerMcpAppsRoutes } from "./routes/mcp-apps.js";
 import { rpcLogBus, type RpcLogEvent } from "./rpc-log-bus.js";

--- a/libraries/typescript/packages/mcp-use/package.json
+++ b/libraries/typescript/packages/mcp-use/package.json
@@ -72,6 +72,11 @@
       "import": "./dist/src/server/index.js",
       "require": "./dist/src/server/index.cjs"
     },
+    "./telemetry/tel-fetch": {
+      "types": "./dist/src/telemetry/tel-fetch.d.ts",
+      "import": "./dist/src/telemetry/tel-fetch.js",
+      "require": "./dist/src/telemetry/tel-fetch.cjs"
+    },
     "./utils": {
       "types": "./dist/src/utils/index.d.ts",
       "import": "./dist/src/utils/index.js",

--- a/libraries/typescript/packages/mcp-use/src/server/inspector/mount.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/inspector/mount.ts
@@ -76,9 +76,13 @@ export async function mountInspectorUI(
       `[INSPECTOR] UI available at http://${serverHost}:${serverPort}/inspector`
     );
     return true;
-  } catch {
-    // Inspector package not installed, skip mounting silently
-    // This allows the server to work without the inspector in production
+  } catch (err) {
+    if (!isProduction || process.env.MCP_USE_DEBUG) {
+      console.warn(
+        "[INSPECTOR] Could not mount inspector UI:",
+        err instanceof Error ? err.message : err
+      );
+    }
     return false;
   }
 }

--- a/libraries/typescript/packages/mcp-use/tsup.config.ts
+++ b/libraries/typescript/packages/mcp-use/tsup.config.ts
@@ -75,6 +75,7 @@ export default defineConfig([
       "src/bin.ts",
       "src/client.ts",
       "src/server/index.ts",
+      "src/telemetry/tel-fetch.ts",
       "src/utils/index.ts",
       "src/client/prompts.ts",
     ],


### PR DESCRIPTION
- Introduced a new `tel-fetch` module under `mcp-use/telemetry` for enhanced telemetry functionality.
- Updated import paths in `shared-routes.ts` to reflect the new module structure.
- Added `test_app` configuration in `pnpm-lock.yaml` with necessary dependencies including React, TailwindCSS, and Zod.
- Updated `package.json` to include new telemetry module paths and adjusted `tsup.config.ts` to build the new module.
- Enhanced error handling in `mount.ts` to provide better logging during inspector UI mounting failures.
