### PR TITLE
feat(mcp-use): add telemetry support and update dependencies (#1307)

### DIFF
--- a/docs/inspector/changelog.mdx
+++ b/docs/inspector/changelog.mdx
@@ -6,6 +6,14 @@ rss: true
 tag: "New"
 ---
 
+<Update label="v1.0.1" description="April 2026">
+  ## Embedded inspector without LangChain
+  Patch release fixing server routes that imported `telFetch` from the root `mcp-use` package.
+
+- **Fix**: Import `telFetch` from `mcp-use/telemetry/tel-fetch` so shared routes do not load the root entry (which eagerly pulls the agent graph); resolves embedded inspector failures when `langchain` is not installed
+- **Update**: Updated mcp-use to v1.23.1
+</Update>
+
 <Update label="v1.0.0" description="April 2026">
   <Frame>
     <img src="https://mcp-use.com/api/og/release?v=1.0.0&title=Stream%20Protocol%2C%20Aliases%20%26%20Chat%20Tooling&date=2026-04&lang=inspector" alt="Release 1.0.0" />

--- a/docs/typescript/changelog/changelog.mdx
+++ b/docs/typescript/changelog/changelog.mdx
@@ -6,6 +6,17 @@ rss: true
 tag: "New"
 ---
 
+<Update label="v1.23.1" description="April 2026">
+  ## Embedded inspector without LangChain
+  Patch release fixing embedded inspector when the agent graph is not installed, and clearer diagnostics when mounting the inspector UI fails.
+
+- **Fix**: Export `telFetch` from `mcp-use/telemetry/tel-fetch` (tsup build) so inspector server code does not import the root `mcp-use` entry, which eagerly loads the agent stack — fixes embedded inspector when `langchain` is not installed
+- **Fix**: Log inspector UI mount failures in development or when `MCP_USE_DEBUG` is set (production remains quiet)
+- **Fix** (@mcp-use/inspector): `telFetch` import uses the telemetry subpath (see inspector changelog)
+- **Update**: Updated @mcp-use/inspector to v1.0.1
+- **Update**: Updated @mcp-use/cli to v2.21.4
+</Update>
+
 <Update label="v1.23.0" description="April 2026">
   <Frame>
     <img src="https://mcp-use.com/api/og/release?v=1.23.0&title=Better%20Auth%2C%20Server%20Metadata%20%26%20Inspector%201.0&date=2026-04&lang=typescript" alt="Release 1.23.0" />

--- a/libraries/typescript/.changeset/inspector-tel-fetch-subpath.md
+++ b/libraries/typescript/.changeset/inspector-tel-fetch-subpath.md
@@ -1,0 +1,6 @@
+---
+"mcp-use": patch
+"@mcp-use/inspector": patch
+---
+
+Fix embedded inspector failing when `langchain` is not installed: export `telFetch` from `mcp-use/telemetry/tel-fetch` so inspector server code does not load the root `mcp-use` entry (which eagerly pulls the agent graph). Log inspector mount failures in development or when `MCP_USE_DEBUG` is set.

--- a/libraries/typescript/.changeset/pre.json
+++ b/libraries/typescript/.changeset/pre.json
@@ -1,0 +1,11 @@
+{
+  "mode": "pre",
+  "tag": "canary",
+  "initialVersions": {
+    "@mcp-use/cli": "2.21.3",
+    "create-mcp-use-app": "0.14.8",
+    "@mcp-use/inspector": "1.0.0",
+    "mcp-use": "1.23.0"
+  },
+  "changesets": []
+}

--- a/libraries/typescript/.changeset/pre.json
+++ b/libraries/typescript/.changeset/pre.json
@@ -7,5 +7,7 @@
     "@mcp-use/inspector": "1.0.0",
     "mcp-use": "1.23.0"
   },
-  "changesets": []
+  "changesets": [
+    "inspector-tel-fetch-subpath"
+  ]
 }

--- a/libraries/typescript/packages/cli/CHANGELOG.md
+++ b/libraries/typescript/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @mcp-use/cli
 
+## 2.21.4-canary.0
+
+### Patch Changes
+
+- Updated dependencies [b3680f9]
+  - mcp-use@1.23.1-canary.0
+  - @mcp-use/inspector@1.0.1-canary.0
+
 ## 2.21.3
 
 ### Patch Changes

--- a/libraries/typescript/packages/cli/package.json
+++ b/libraries/typescript/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-use/cli",
   "type": "module",
-  "version": "2.21.3",
+  "version": "2.21.4-canary.0",
   "description": "The mcp-use CLI is a tool for building and deploying MCP servers with support for ChatGPT Apps, Code Mode, OAuth, Notifications, Sampling, Observability and more.",
   "author": "mcp-use, Inc.",
   "license": "MIT",

--- a/libraries/typescript/packages/inspector/CHANGELOG.md
+++ b/libraries/typescript/packages/inspector/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @mcp-use/inspector
 
+## 1.0.1-canary.0
+
+### Patch Changes
+
+- b3680f9: Fix embedded inspector failing when `langchain` is not installed: export `telFetch` from `mcp-use/telemetry/tel-fetch` so inspector server code does not load the root `mcp-use` entry (which eagerly pulls the agent graph). Log inspector mount failures in development or when `MCP_USE_DEBUG` is set.
+- Updated dependencies [b3680f9]
+  - mcp-use@1.23.1-canary.0
+
 ## 1.0.0
 
 ### Minor Changes

--- a/libraries/typescript/packages/inspector/package.json
+++ b/libraries/typescript/packages/inspector/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-use/inspector",
   "type": "module",
-  "version": "1.0.0",
+  "version": "1.0.1-canary.0",
   "description": "MCP Inspector - A tool for inspecting and debugging MCP servers",
   "author": "",
   "license": "MIT",
@@ -79,7 +79,7 @@
   },
   "peerDependencies": {
     "express": "^4.21.2 || ^5.0.0",
-    "mcp-use": ">=1.23.0",
+    "mcp-use": ">=1.23.1-canary.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
     "react-router": "^7.12.0"

--- a/libraries/typescript/packages/inspector/src/server/shared-routes.ts
+++ b/libraries/typescript/packages/inspector/src/server/shared-routes.ts
@@ -1,5 +1,5 @@
 import type { Hono } from "hono";
-import { telFetch } from "mcp-use";
+import { telFetch } from "mcp-use/telemetry/tel-fetch";
 import { mountMcpProxy, mountOAuthProxy } from "mcp-use/server";
 import { registerMcpAppsRoutes } from "./routes/mcp-apps.js";
 import { rpcLogBus, type RpcLogEvent } from "./rpc-log-bus.js";

--- a/libraries/typescript/packages/mcp-use/CHANGELOG.md
+++ b/libraries/typescript/packages/mcp-use/CHANGELOG.md
@@ -1,5 +1,14 @@
 # mcp-use
 
+## 1.23.1-canary.0
+
+### Patch Changes
+
+- b3680f9: Fix embedded inspector failing when `langchain` is not installed: export `telFetch` from `mcp-use/telemetry/tel-fetch` so inspector server code does not load the root `mcp-use` entry (which eagerly pulls the agent graph). Log inspector mount failures in development or when `MCP_USE_DEBUG` is set.
+- Updated dependencies [b3680f9]
+  - @mcp-use/inspector@1.0.1-canary.0
+  - @mcp-use/cli@2.21.4-canary.0
+
 ## 1.23.0
 
 ### Minor Changes

--- a/libraries/typescript/packages/mcp-use/package.json
+++ b/libraries/typescript/packages/mcp-use/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-use",
   "type": "module",
-  "version": "1.23.0",
+  "version": "1.23.1-canary.0",
   "packageManager": "pnpm@10.26.0+sha512.3b3f6c725ebe712506c0ab1ad4133cf86b1f4b687effce62a9b38b4d72e3954242e643190fc51fa1642949c735f403debd44f5cb0edd657abe63a8b6a7e1e402",
   "description": "Opinionated MCP Framework for TypeScript (@modelcontextprotocol/sdk compatible) - Build MCP Agents, Clients and Servers with support for ChatGPT Apps, Code Mode, OAuth, Notifications, Sampling, Observability and more.",
   "author": "mcp-use, Inc.",

--- a/libraries/typescript/packages/mcp-use/package.json
+++ b/libraries/typescript/packages/mcp-use/package.json
@@ -72,6 +72,11 @@
       "import": "./dist/src/server/index.js",
       "require": "./dist/src/server/index.cjs"
     },
+    "./telemetry/tel-fetch": {
+      "types": "./dist/src/telemetry/tel-fetch.d.ts",
+      "import": "./dist/src/telemetry/tel-fetch.js",
+      "require": "./dist/src/telemetry/tel-fetch.cjs"
+    },
     "./utils": {
       "types": "./dist/src/utils/index.d.ts",
       "import": "./dist/src/utils/index.js",

--- a/libraries/typescript/packages/mcp-use/src/server/inspector/mount.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/inspector/mount.ts
@@ -76,9 +76,13 @@ export async function mountInspectorUI(
       `[INSPECTOR] UI available at http://${serverHost}:${serverPort}/inspector`
     );
     return true;
-  } catch {
-    // Inspector package not installed, skip mounting silently
-    // This allows the server to work without the inspector in production
+  } catch (err) {
+    if (!isProduction || process.env.MCP_USE_DEBUG) {
+      console.warn(
+        "[INSPECTOR] Could not mount inspector UI:",
+        err instanceof Error ? err.message : err
+      );
+    }
     return false;
   }
 }

--- a/libraries/typescript/packages/mcp-use/tsup.config.ts
+++ b/libraries/typescript/packages/mcp-use/tsup.config.ts
@@ -75,6 +75,7 @@ export default defineConfig([
       "src/bin.ts",
       "src/client.ts",
       "src/server/index.ts",
+      "src/telemetry/tel-fetch.ts",
       "src/utils/index.ts",
       "src/client/prompts.ts",
     ],


### PR DESCRIPTION
Fix embedded inspector failing when `langchain` is not installed: export `telFetch` from `mcp-use/telemetry/tel-fetch` so inspector server code does not load the root `mcp-use` entry (which eagerly pulls the agent graph). Log inspector mount failures in development or when `MCP_USE_DEBUG` is set.