### PR TITLE
docs: reorder TypeScript SDK sidebar sections

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -491,60 +491,6 @@
                 ]
               },
               {
-                "group": "MCP Agent",
-                "icon": "brain",
-                "pages": [
-                  "typescript/agent/index",
-                  "typescript/agent/agent-configuration",
-                  {
-                    "group": "Core Concepts",
-                    "icon": "box",
-                    "pages": [
-                      "typescript/agent/llm-integration",
-                      "typescript/agent/memory-management",
-                      "typescript/agent/server-manager",
-                      "typescript/agent/structured-output",
-                      "typescript/agent/streaming"
-                    ]
-                  },
-                  "typescript/agent/observability"
-                ]
-              },
-              {
-                "group": "MCP Client",
-                "icon": "router",
-                "pages": [
-                  "typescript/client/index",
-                  "typescript/client/client-configuration",
-                  "typescript/client/environments",
-                  {
-                    "group": "Core Components",
-                    "icon": "box",
-                    "pages": [
-                      "typescript/client/tools",
-                      "typescript/client/resources",
-                      "typescript/client/prompts"
-                    ]
-                  },
-                  {
-                    "group": "Advanced Features",
-                    "icon": "sparkle",
-                    "pages": [
-                      "typescript/client/cli",
-                      "typescript/client/server-manager",
-                      "typescript/client/sampling",
-                      "typescript/client/elicitation",
-                      "typescript/client/completion",
-                      "typescript/client/notifications",
-                      "typescript/client/logging"
-                    ]
-                  },
-                  "typescript/client/authentication",
-                  "typescript/client/usemcp",
-                  "typescript/client/code-mode"
-                ]
-              },
-              {
                 "group": "MCP Server",
                 "icon": "server",
                 "pages": [
@@ -637,6 +583,60 @@
                       "typescript/server/deployment/google"
                     ]
                   }
+                ]
+              },
+              {
+                "group": "MCP Client",
+                "icon": "router",
+                "pages": [
+                  "typescript/client/index",
+                  "typescript/client/client-configuration",
+                  "typescript/client/environments",
+                  {
+                    "group": "Core Components",
+                    "icon": "box",
+                    "pages": [
+                      "typescript/client/tools",
+                      "typescript/client/resources",
+                      "typescript/client/prompts"
+                    ]
+                  },
+                  {
+                    "group": "Advanced Features",
+                    "icon": "sparkle",
+                    "pages": [
+                      "typescript/client/cli",
+                      "typescript/client/server-manager",
+                      "typescript/client/sampling",
+                      "typescript/client/elicitation",
+                      "typescript/client/completion",
+                      "typescript/client/notifications",
+                      "typescript/client/logging"
+                    ]
+                  },
+                  "typescript/client/authentication",
+                  "typescript/client/usemcp",
+                  "typescript/client/code-mode"
+                ]
+              },
+              {
+                "group": "MCP Agent",
+                "icon": "brain",
+                "pages": [
+                  "typescript/agent/index",
+                  "typescript/agent/agent-configuration",
+                  {
+                    "group": "Core Concepts",
+                    "icon": "box",
+                    "pages": [
+                      "typescript/agent/llm-integration",
+                      "typescript/agent/memory-management",
+                      "typescript/agent/server-manager",
+                      "typescript/agent/structured-output",
+                      "typescript/agent/streaming"
+                    ]
+                  },
+                  "typescript/agent/observability"
                 ]
               },
               {


### PR DESCRIPTION
Reorder the TypeScript SDK documentation sidebar to follow the sequence: MCP Server, MCP Client, MCP Agent.

This change reorganizes the navigation structure in `docs/docs.json` to present the documentation in a more logical order, with the Server section first, followed by Client, and then Agent sections.

<img width="264" height="810" alt="Screenshot 2026-04-10 at 10 19 27 AM" src="https://github.com/user-attachments/assets/cd3745bd-9293-42f0-bb06-84c845e5bc20" />
<img width="268" height="900" alt="image" src="https://github.com/user-attachments/assets/3f63ed5c-71c2-4cda-af12-7ea311869b5e" />
