### PR TITLE
Security: Untrusted HTML rendered into iframe `srcDoc` with script execution enabled

### DIFF
--- a/libraries/typescript/packages/inspector/src/client/components/chat/MCPUIResource.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/MCPUIResource.tsx
@@ -32,7 +32,7 @@ export const MCPUIResource = memo(({ resource }: MCPUIResourceProps) => {
     <div className="my-4 p-0 border h-[350px] rounded-2xl border-zinc-200 overflow-hidden bg-card">
       <iframe
         srcDoc={html}
-        sandbox="allow-scripts allow-forms allow-popups"
+        sandbox="allow-forms allow-popups"
         title={resource.uri ?? "MCP UI Resource"}
         style={{
           width: "100%",

--- a/libraries/typescript/packages/inspector/src/client/constants/iframe.ts
+++ b/libraries/typescript/packages/inspector/src/client/constants/iframe.ts
@@ -7,4 +7,4 @@
  * Used across all widget renderers for consistent security policy
  */
 export const IFRAME_SANDBOX_PERMISSIONS =
-  "allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox" as const;
+  "allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox" as const;


### PR DESCRIPTION
## Problem

The inspector renders `resource.text`/decoded `resource.blob` directly into an iframe via `srcDoc`. Because the iframe sandbox allows `allow-scripts`, attacker-controlled MCP resource content can execute JavaScript in the iframe context, trigger phishing flows, or abuse allowed popup/form capabilities. This is effectively a client-side code execution surface for untrusted server-provided content.

**Severity**: `high`
**File**: `libraries/typescript/packages/inspector/src/client/components/chat/MCPUIResource.tsx`

## Solution

Treat MCP UI resource HTML as untrusted. Sanitize HTML before rendering (e.g., strict allowlist sanitizer), remove `allow-scripts` unless absolutely required, and prefer rendering only trusted/signed UI resources. Consider adding a strict CSP inside rendered documents and disallow dangerous iframe capabilities by default.

## Changes

- `libraries/typescript/packages/inspector/src/client/components/chat/MCPUIResource.tsx` (modified)
- `libraries/typescript/packages/inspector/src/client/constants/iframe.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
