### PR TITLE
Security: Overly permissive iframe sandbox policy for widgets

### DIFF
--- a/libraries/typescript/packages/inspector/src/client/constants/iframe.ts
+++ b/libraries/typescript/packages/inspector/src/client/constants/iframe.ts
@@ -7,4 +7,4 @@
  * Used across all widget renderers for consistent security policy
  */
 export const IFRAME_SANDBOX_PERMISSIONS =
-  "allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox" as const;
+  "allow-scripts allow-forms allow-popups" as const;


### PR DESCRIPTION
## Problem

The shared iframe sandbox policy includes `allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox`. This combination significantly weakens isolation and can enable malicious widget content to run scripts, preserve origin semantics, and open unsandboxed popups. If untrusted or semi-trusted content is loaded, this increases XSS/phishing/exfiltration risk.

**Severity**: `high`
**File**: `libraries/typescript/packages/inspector/src/client/constants/iframe.ts`

## Solution

Use least-privilege sandbox defaults. Remove `allow-same-origin` and `allow-popups-to-escape-sandbox` unless strictly needed, and gate elevated permissions behind explicit trusted mode flags. Maintain separate policies for trusted vs untrusted widget sources.

## Changes

- `libraries/typescript/packages/inspector/src/client/constants/iframe.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
