### PR TITLE
fix(inspector): hide thinking indicator when assistant message has parts

### DIFF
--- a/libraries/typescript/.changeset/fix-inspector-thinking-indicator.md
+++ b/libraries/typescript/.changeset/fix-inspector-thinking-indicator.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Fix thinking indicator persisting after assistant stream completes

--- a/libraries/typescript/packages/inspector/src/client/components/chat/MessageList.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/MessageList.tsx
@@ -125,6 +125,12 @@ export const MessageList = memo(
 
         // If last message is from assistant but empty/minimal content, we're thinking
         if (lastMessage.role === "assistant") {
+          // Check parts array first — streaming delivers content via parts
+          // while content may remain "" until after the stream reader closes
+          if (lastMessage.parts && lastMessage.parts.length > 0) {
+            return false;
+          }
+
           const contentStr =
             typeof lastMessage.content === "string"
               ? lastMessage.content


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

Check all that apply:
- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

Fixes the thinking indicator persisting after the assistant stream completes in the inspector's `MessageList` component.

## Implementation Details

1. In the `isThinking` check inside `MessageList.tsx`, added an early return of `false` when the last assistant message has a non-empty `parts` array
2. No changes to streaming logic or state management — the fix is purely in the rendering heuristic

**Root Cause:** In the server-side streaming path (`useChatMessages`), content is delivered via `parts` while `message.content` stays `""` until after the stream reader fully exits. The `done` SSE event calls `finalizeParts()` which sets `content: ""`, but `setIsLoading(false)` only runs in the `finally` block after the reader loop closes. This created a window where:
- `isLoading` was still `true`
- `content` was `""`
- `isThinking` evaluated to `true`
- The "Thinking..." shimmer reappeared even though the response was complete

---

## TypeScript Checklist

> Complete this section if your PR includes TypeScript changes

### Packages Modified

Check all packages that were modified:
- [ ] `docs`
- [ ] `tests`
- [ ] `cli`
- [ ] `create-mcp-use-app`
- [ ] `mcp-use` (server)
- [ ] `mcp-use` (client)
- [x] `inspector`

### Pre-commit Checklist

Ensure all of the following have been completed:
- [x] Ran `pnpm lint:fix` to auto-fix linting issues
- [x] Ran `pnpm format` to format code with Prettier
- [x] Ran `pnpm build` and build succeeds without errors
- [x] Ran `pnpm changeset` to create a changeset (if this PR includes user-facing changes)
- [ ] Added or updated tests if needed
- [ ] Updated documentation in `docs/` folder if needed

---

## Example Usage (Before)

```
# N/A — visual bug fix with no API changes
```

## Example Usage (After)

```
# N/A — visual bug fix with no API changes
```

## Documentation Updates

No documentation updates required.

## Testing

- Build passes: `pnpm --filter @mcp-use/inspector build`
- Manual verification: thinking indicator disappears as soon as the first part arrives and does not reappear after the `done` event

## Backwards Compatibility

No breaking changes. Internal rendering logic only.

## Related Issues

Closes MCP-1649