### PR TITLE
fix(mcp-use): use catchall instead of z.record() to avoid propertyNames in Google provider

### DIFF
--- a/libraries/typescript/.changeset/fix-google-provider-record-schema.md
+++ b/libraries/typescript/.changeset/fix-google-provider-record-schema.md
@@ -1,0 +1,7 @@
+---
+"mcp-use": patch
+---
+
+Fix Google provider rejecting tool schemas with `propertyNames` keyword.
+
+`z.record()` causes `@langchain/core` to emit a `propertyNames` field in the JSON Schema output for constrained or enum key types, which Google's Generative AI API rejects. Switching to `z.object({}).catchall()` produces identical runtime behavior while serializing cleanly without `propertyNames`.

--- a/libraries/typescript/packages/mcp-use/src/utils/json-schema-to-zod/JSONSchemaToZod.ts
+++ b/libraries/typescript/packages/mcp-use/src/utils/json-schema-to-zod/JSONSchemaToZod.ts
@@ -667,16 +667,17 @@ export class JSONSchemaToZod {
     }
 
     // Handle pure record/map types: object with no named properties but with
-    // additionalProperties as a schema object. Use z.record() instead of
-    // z.object({}).catchall() because catchall doesn't roundtrip correctly
-    // through @langchain/core's toJsonSchema().
+    // additionalProperties as a schema object. Use z.object({}).catchall()
+    // rather than z.record() — catchall does not emit a `propertyNames` keyword
+    // when serialized via Zod's toJSONSchema(), whereas z.record() does.
+    // Google's Generative AI API rejects `propertyNames`, so this is the safe path.
     if (
       !schema.properties &&
       schema.additionalProperties &&
       typeof schema.additionalProperties === "object"
     ) {
       const valueSchema = this.parseSchema(schema.additionalProperties);
-      return z.record(z.string(), valueSchema);
+      return z.object({}).catchall(valueSchema);
     }
 
     // Create shape object for Zod


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

Fixes the Google provider in the chat inspector by switching from `z.record()` to `z.object({}).catchall()` when converting pure record/map JSON Schemas to Zod. This prevents `propertyNames` from appearing in the serialized JSON Schema output, which Google's Generative AI API rejects.

## Implementation Details

1. In `JSONSchemaToZod.parseObject()`, pure record/map types (schemas with `additionalProperties` but no named `properties`) were previously converted to `z.record(z.string(), valueSchema)`
2. When `@langchain/core` serializes `z.record()` to JSON Schema, it emits a `propertyNames` keyword for constrained or enum key types — Google's API rejects this with an error
3. `z.object({}).catchall(valueSchema)` is semantically equivalent at runtime but serializes cleanly to `{type: "object", additionalProperties: {...}}` with no `propertyNames` keyword
4. The old comment claiming `catchall` "doesn't roundtrip correctly through @langchain/core" was inaccurate — it was `z.record()` causing the problem, not `catchall`

---

## TypeScript Checklist

### Packages Modified

- [ ] `docs`
- [ ] `tests`
- [ ] `cli`
- [ ] `create-mcp-use-app`
- [x] `mcp-use` (server)
- [ ] `mcp-use` (client)
- [ ] `inspector`

### Pre-commit Checklist

- [ ] Ran `pnpm lint:fix` to auto-fix linting issues
- [ ] Ran `pnpm format` to format code with Prettier
- [ ] Ran `pnpm build` and build succeeds without errors
- [x] Ran `pnpm changeset` to create a changeset (if this PR includes user-facing changes)
- [ ] Added or updated tests if needed
- [ ] Updated documentation in `docs/` folder if needed

---

## Example Usage (Before)

When an MCP tool uses a record/map schema (e.g. `Record<string, string>`), calling it via the Google provider would fail:

```
Error: Schema with `propertyNames` is not supported by the Google Generative AI API
```

## Example Usage (After)

The same tool works correctly — the schema roundtrips to `{type: "object", additionalProperties: {type: "string"}}` with no `propertyNames`.

## Documentation Updates

None required — this is an internal implementation fix.

## Testing

- Existing e2e test `test_record_schema` in `packages/inspector/tests/e2e/connection.test.ts` validates the schema output
- The fix was verified by tracing `@langchain/core`'s `record.js` and `object.js` parsers directly: `catchall` routes through the object parser which emits only `additionalProperties`, while `z.record()` routes through the record parser which conditionally adds `propertyNames`

## Backwards Compatibility

Fully backwards compatible. The runtime behavior of `z.object({}).catchall()` is identical to `z.record()` for the pure map case — any object with string keys is accepted. Only the JSON Schema serialization output changes (removal of `propertyNames`).

## Related Issues

Closes MCP-1624