### PR TITLE
fix(inspector): use correct OAuth callback URL when mounted at /inspector

### DIFF
--- a/docs/inspector/connection-settings.mdx
+++ b/docs/inspector/connection-settings.mdx
@@ -82,7 +82,6 @@ The inspector supports OAuth 2.0 authentication for MCP servers that require it.
 2. Enter your OAuth credentials:
 
    - **Client ID**: Your OAuth application client ID
-   - **Redirect URL**: The callback URL (defaults to `/inspector/oauth/callback`)
    - **Scope**: Space-separated list of OAuth scopes
 
 3. Click **Save** to store the configuration
@@ -174,7 +173,6 @@ Export your connection configuration as JSON:
   "maxTotalTimeout": 60000,
   "oauth": {
     "clientId": "your-client-id",
-    "redirectUrl": "http://localhost:8080/inspector/oauth/callback",
     "scope": "read write"
   }
 }

--- a/docs/typescript/client/usemcp.mdx
+++ b/docs/typescript/client/usemcp.mdx
@@ -179,6 +179,12 @@ function ServerStatus({ serverId }) {
 
 ```typescript
 interface McpClientProviderProps {
+  // Default OAuth callback URL for all servers (can be overridden per-server via callbackUrl)
+  // Useful when your app is mounted at a sub-path — e.g. set to "/myapp/oauth/callback"
+  // so the OAuth redirect lands on the correct route.
+  // Defaults to /oauth/callback on the current origin.
+  defaultCallbackUrl?: string;
+
   // Default proxy configuration for all servers (can be overridden per-server)
   defaultProxyConfig?: {
     proxyAddress?: string;
@@ -347,7 +353,20 @@ addServer("linear", {
 
 ### OAuth Callback Page
 
-Create an OAuth callback route to handle OAuth redirects:
+Create an OAuth callback route to handle OAuth redirects.
+
+By default, `McpClientProvider` expects the callback at `/oauth/callback` on the current origin. If your app is mounted at a sub-path, set `defaultCallbackUrl` to match your actual route:
+
+```typescript
+// App mounted at /myapp — callback route is /myapp/oauth/callback
+<McpClientProvider
+  defaultCallbackUrl={`${window.location.origin}/myapp/oauth/callback`}
+>
+  <MyApp />
+</McpClientProvider>
+```
+
+Per-server `callbackUrl` in `addServer()` takes precedence over the provider default.
 
 ```typescript
 // app/oauth/callback/page.tsx (Next.js App Router)

--- a/libraries/typescript/.changeset/fix-inspector-oauth-callback.md
+++ b/libraries/typescript/.changeset/fix-inspector-oauth-callback.md
@@ -1,5 +1,5 @@
 ---
-"mcp-use": patch
+"mcp-use": minor
 "@mcp-use/inspector": patch
 ---
 

--- a/libraries/typescript/.changeset/fix-inspector-oauth-callback.md
+++ b/libraries/typescript/.changeset/fix-inspector-oauth-callback.md
@@ -1,0 +1,10 @@
+---
+"mcp-use": patch
+"@mcp-use/inspector": patch
+---
+
+Fix OAuth callback URL for inspector mounted at a sub-path
+
+**mcp-use:** Add `defaultCallbackUrl` prop to `McpClientProvider` so apps mounted at a sub-path (e.g. `/inspector`) can declare the correct OAuth redirect URL once at the provider level instead of passing it to every `addServer` call.
+
+**inspector:** Pass `defaultCallbackUrl` pointing to `/inspector/oauth/callback`, which is where the React Router (with `basename="/inspector"`) mounts the `OAuthCallback` component. Previously the callback URL defaulted to `/oauth/callback`, causing a blank screen after OAuth because the route was never matched. The "Redirect URL" field has been removed from the authentication dialog — it was never wired to the actual connection and could not be set to a path the inspector would handle.

--- a/libraries/typescript/packages/inspector/src/client/App.tsx
+++ b/libraries/typescript/packages/inspector/src/client/App.tsx
@@ -58,6 +58,7 @@ function App() {
         <McpClientProvider
           storageProvider={storageProvider}
           enableRpcLogging={true}
+          defaultCallbackUrl={`${window.location.origin}/inspector/oauth/callback`}
           defaultAutoProxyFallback={
             proxyAddress ? { enabled: true, proxyAddress } : false
           }

--- a/libraries/typescript/packages/inspector/src/client/components/ConnectionSettingsForm.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ConnectionSettingsForm.tsx
@@ -46,8 +46,6 @@ interface ConnectionSettingsFormProps {
   // OAuth fields
   clientId: string;
   setClientId: (value: string) => void;
-  redirectUrl: string;
-  setRedirectUrl: (value: string) => void;
   scope: string;
   setScope: (value: string) => void;
 
@@ -103,8 +101,6 @@ export function ConnectionSettingsForm({
   setProxyAddress,
   clientId,
   setClientId,
-  redirectUrl,
-  setRedirectUrl,
   scope,
   setScope,
   autoSwitch,
@@ -169,7 +165,6 @@ export function ConnectionSettingsForm({
         clientId || scope
           ? {
               clientId,
-              redirectUrl,
               scope,
             }
           : undefined,
@@ -261,7 +256,6 @@ export function ConnectionSettingsForm({
 
         if (config.oauth) {
           setClientId(config.oauth.clientId || "");
-          setRedirectUrl(config.oauth.redirectUrl || redirectUrl);
           setScope(config.oauth.scope || "");
         }
 
@@ -437,16 +431,6 @@ export function ConnectionSettingsForm({
                   placeholder="Client ID"
                   value={clientId}
                   onChange={(e) => setClientId(e.target.value)}
-                />
-              </div>
-
-              {/* Redirect URL */}
-              <div className="space-y-2">
-                <Label className="text-sm">Redirect URL</Label>
-                <Input
-                  data-testid="auth-dialog-redirect-url-input"
-                  value={redirectUrl}
-                  onChange={(e) => setRedirectUrl(e.target.value)}
                 />
               </div>
 

--- a/libraries/typescript/packages/inspector/src/client/components/InspectorDashboard.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/InspectorDashboard.tsx
@@ -241,11 +241,6 @@ export function InspectorDashboard() {
   );
   // OAuth fields
   const [clientId, setClientId] = useState("");
-  const [redirectUrl, setRedirectUrl] = useState(
-    typeof window !== "undefined"
-      ? new URL("/inspector/oauth/callback", window.location.origin).toString()
-      : "/inspector/oauth/callback"
-  );
   const [scope, setScope] = useState("");
 
   const connectFormGradientRef = useRef<HTMLDivElement>(null);
@@ -1101,8 +1096,6 @@ export function InspectorDashboard() {
             setProxyAddress={setProxyAddress}
             clientId={clientId}
             setClientId={setClientId}
-            redirectUrl={redirectUrl}
-            setRedirectUrl={setRedirectUrl}
             scope={scope}
             setScope={setScope}
             onConnect={handleAddConnection}

--- a/libraries/typescript/packages/inspector/src/client/components/ServerConnectionModal.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ServerConnectionModal.tsx
@@ -66,11 +66,6 @@ export function ServerConnectionModal({
   );
   // OAuth fields
   const [clientId, setClientId] = useState("");
-  const [redirectUrl, setRedirectUrl] = useState(
-    typeof window !== "undefined"
-      ? new URL("/inspector/oauth/callback", window.location.origin).toString()
-      : "/inspector/oauth/callback"
-  );
   const [scope, setScope] = useState("");
 
   // Prefill form when connection changes
@@ -236,8 +231,6 @@ export function ServerConnectionModal({
           setProxyAddress={setProxyAddress}
           clientId={clientId}
           setClientId={setClientId}
-          redirectUrl={redirectUrl}
-          setRedirectUrl={setRedirectUrl}
           scope={scope}
           setScope={setScope}
           onConnect={handleConnect}

--- a/libraries/typescript/packages/mcp-use/src/react/McpClientProvider.tsx
+++ b/libraries/typescript/packages/mcp-use/src/react/McpClientProvider.tsx
@@ -142,6 +142,7 @@ interface ServerConfig {
 interface McpServerWrapperProps {
   id: string;
   options: McpServerOptions;
+  defaultCallbackUrl?: string;
   defaultProxyConfig?: {
     proxyAddress?: string;
     headers?: Record<string, string>;
@@ -208,6 +209,7 @@ interface McpServerWrapperProps {
 function McpServerWrapper({
   id,
   options,
+  defaultCallbackUrl,
   defaultProxyConfig,
   defaultAutoProxyFallback,
   clientInfo: providerClientInfo,
@@ -244,6 +246,8 @@ function McpServerWrapper({
     // Server-specific options take precedence over defaults
     return {
       ...rest,
+      // Use server-specific callbackUrl if provided, otherwise use provider default
+      callbackUrl: rest.callbackUrl || defaultCallbackUrl,
       // Use server-specific proxyConfig if provided, otherwise use default
       proxyConfig: rest.proxyConfig || defaultProxyConfig,
       // Use server-specific autoProxyFallback if provided, otherwise use default
@@ -694,6 +698,15 @@ export interface McpClientProviderProps {
   mcpServers?: Record<string, McpServerOptions>;
 
   /**
+   * Default OAuth callback URL for all servers.
+   * Can be overridden per-server via the callbackUrl option in addServer().
+   * Useful when the app is mounted at a sub-path (e.g. /inspector) so the
+   * OAuth redirect lands on the correct route without requiring a server-side
+   * redirect shim.
+   */
+  defaultCallbackUrl?: string;
+
+  /**
    * Default proxy configuration for all servers
    * Can be overridden per-server in addServer() options
    */
@@ -855,6 +868,7 @@ export interface McpClientProviderProps {
 export function McpClientProvider({
   children,
   mcpServers,
+  defaultCallbackUrl,
   defaultProxyConfig,
   defaultAutoProxyFallback = true,
   clientInfo,
@@ -1356,6 +1370,7 @@ export function McpClientProvider({
           key={`${config.id}-v${(config.options as any)._updateVersion || 0}`}
           id={config.id}
           options={config.options}
+          defaultCallbackUrl={defaultCallbackUrl}
           defaultProxyConfig={defaultProxyConfig}
           defaultAutoProxyFallback={defaultAutoProxyFallback}
           clientInfo={clientInfoForWrapper}


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

- [x] TypeScript

## Changes

Fix OAuth callback URL mismatch when the inspector is mounted at `/inspector/`. The `BrowserOAuthClientProvider` was defaulting `redirect_uri` to `<origin>/oauth/callback`, but the React Router (with `basename="/inspector"`) only mounts `OAuthCallback` at `/inspector/oauth/callback` — so the OAuth flow would complete but land on an unmatched route, causing a blank screen.

## Implementation Details

1. **`mcp-use` — add `defaultCallbackUrl` to `McpClientProvider`**: New prop that threads down through `McpServerWrapper` into `useMcp` as a fallback when no per-server `callbackUrl` is set. Follows the same pattern as `defaultProxyConfig`.

2. **`inspector` — set `defaultCallbackUrl` in `App.tsx`**: Passes `${window.location.origin}/inspector/oauth/callback` to `McpClientProvider`. All `addServer` calls inherit it automatically — no per-connection wiring needed.

3. **`inspector` — remove "Redirect URL" field from auth dialog**: Removed `redirectUrl` state and UI from `ConnectionSettingsForm`, `InspectorDashboard`, and `ServerConnectionModal`. The field was never actually passed to the connection and couldn't be set to a path the inspector would handle.

---

## TypeScript Checklist

### Packages Modified

- [x] `mcp-use` (client)
- [x] `inspector`

### Pre-commit Checklist

- [x] Ran `pnpm lint:fix` to auto-fix linting issues
- [x] Ran `pnpm format` to format code with Prettier
- [x] Ran `pnpm build` and build succeeds without errors
- [x] Ran `pnpm changeset` to create a changeset
- [x] Added or updated tests if needed

---

## Example Usage (Before)

```tsx
// OAuth redirect landed on /oauth/callback
// React Router (basename="/inspector") had no route for this → blank screen
<McpClientProvider>
  ...
</McpClientProvider>
```

## Example Usage (After)

```tsx
// redirect_uri is now /inspector/oauth/callback, which React Router handles
<McpClientProvider
  defaultCallbackUrl={`${window.location.origin}/inspector/oauth/callback`}
>
  ...
</McpClientProvider>
```

## Testing

- Verified build passes with no type errors (`pnpm build`)
- Verified unit tests show no regressions — same 3 pre-existing failures on canary (agent-quick-start requires API key)
- `defaultCallbackUrl` follows the same plumbing pattern as `defaultProxyConfig`, which is well-tested

## Backwards Compatibility

Fully backwards compatible. `defaultCallbackUrl` is optional — existing `McpClientProvider` usage is unchanged. Per-server `callbackUrl` in `addServer()` still takes precedence.

## Related Issues

Fixes mounted inspector OAuth blank screen after redirect.