### PR TITLE
feat(widget): stream tool output into widget props

### DIFF
--- a/libraries/typescript/packages/inspector/src/client/App.tsx
+++ b/libraries/typescript/packages/inspector/src/client/App.tsx
@@ -85,7 +85,7 @@ function App() {
           }}
           onSamplingRequest={(
             request,
-            serverId,
+            _serverId,
             serverName,
             approve,
             reject
@@ -116,9 +116,9 @@ function App() {
           }}
           onElicitationRequest={(
             request,
-            serverId,
+            _serverId,
             serverName,
-            approve,
+            _approve,
             reject
           ) => {
             const mode = request.request.mode || "form";

--- a/libraries/typescript/packages/inspector/src/client/components/IframeConsole.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/IframeConsole.tsx
@@ -221,7 +221,7 @@ const levelFilterColors: Record<ConsoleLogEntry["level"], string> = {
 };
 
 export function IframeConsole({
-  iframeId,
+  iframeId: _iframeId,
   enabled = true,
 }: IframeConsoleProps) {
   // Load proxy toggle state from localStorage

--- a/libraries/typescript/packages/inspector/src/client/components/LayoutContent.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/LayoutContent.tsx
@@ -31,6 +31,21 @@ interface LayoutContentProps {
   children: ReactNode;
 }
 
+function normalizePromptArgs(
+  args?: Record<string, unknown>
+): Record<string, string> | undefined {
+  if (!args) {
+    return undefined;
+  }
+
+  return Object.fromEntries(
+    Object.entries(args).map(([k, v]) => [
+      k,
+      typeof v === "string" ? v : String(v ?? ""),
+    ])
+  ) as Record<string, string>;
+}
+
 export function LayoutContent({
   selectedServer,
   activeTab,
@@ -141,17 +156,7 @@ export function LayoutContent({
             ref={promptsSearchRef}
             prompts={selectedServer.prompts}
             callPrompt={(name, args) =>
-              selectedServer.getPrompt(
-                name,
-                args
-                  ? (Object.fromEntries(
-                      Object.entries(args).map(([k, v]) => [
-                        k,
-                        typeof v === "string" ? v : String(v ?? ""),
-                      ])
-                    ) as Record<string, string>)
-                  : undefined
-              )
+              selectedServer.getPrompt(name, normalizePromptArgs(args))
             }
             serverId={selectedServer.id}
             isConnected={selectedServer.state === "ready"}
@@ -189,7 +194,9 @@ export function LayoutContent({
             }
             prompts={selectedServer.prompts}
             serverId={selectedServer.id}
-            callPrompt={selectedServer.getPrompt}
+            callPrompt={(name, args) =>
+              selectedServer.getPrompt(name, normalizePromptArgs(args))
+            }
             readResource={selectedServer.readResource}
             useClientSide={!embeddedConfig.chatApiUrl}
             chatApiUrl={embeddedConfig.chatApiUrl}

--- a/libraries/typescript/packages/inspector/src/client/components/MCPAppsRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/MCPAppsRenderer.tsx
@@ -97,6 +97,7 @@ interface MCPAppsRendererProps {
   toolName: string;
   toolInput?: Record<string, unknown>;
   toolOutput?: unknown;
+  partialToolOutput?: Record<string, unknown> | null;
   toolMetadata?: Record<string, unknown>;
   invoking?: string;
   invoked?: string;
@@ -124,6 +125,7 @@ function MCPAppsRendererBase({
   toolName,
   toolInput,
   toolOutput,
+  partialToolOutput,
   toolMetadata,
   invoking,
   invoked,
@@ -831,6 +833,18 @@ function MCPAppsRendererBase({
     bridge.sendToolInputPartial({ arguments: partialToolInput });
   }, [initCount, partialToolInput]);
 
+  useEffect(() => {
+    if (initCount === 0 || !partialToolOutput) return;
+
+    sandboxRef.current?.postMessage({
+      jsonrpc: "2.0",
+      method: "ui/notifications/tool-result-partial",
+      params: {
+        structuredContent: partialToolOutput,
+      },
+    });
+  }, [initCount, partialToolOutput]);
+
   // Send tool input when ready. Re-send when toolCallId changes (re-execution)
   // or when customProps changes (user selects/creates preset with different props).
   useEffect(() => {
@@ -1205,6 +1219,7 @@ function mcpAppsRendererAreEqual(
   }
   if (prev.toolInput !== next.toolInput) return false;
   if (prev.toolOutput !== next.toolOutput) return false;
+  if (prev.partialToolOutput !== next.partialToolOutput) return false;
   if (prev.toolMetadata !== next.toolMetadata) return false;
   if (prev.partialToolInput !== next.partialToolInput) return false;
   if (prev.customProps !== next.customProps) return false;

--- a/libraries/typescript/packages/inspector/src/client/components/OpenAIComponentRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/OpenAIComponentRenderer.tsx
@@ -17,6 +17,7 @@ interface OpenAIComponentRendererProps {
   toolName: string;
   toolArgs: Record<string, unknown>;
   toolResult: any;
+  partialToolOutput?: Record<string, unknown> | null;
   serverId: string;
   readResource: (uri: string) => Promise<any>;
   className?: string;
@@ -52,6 +53,7 @@ type IframeGlobalUpdates = {
   };
   userAgent?: any;
   toolOutput?: any;
+  partialToolOutput?: any;
   toolResponseMetadata?: any;
 };
 
@@ -97,6 +99,7 @@ function OpenAIComponentRendererBase({
   toolName,
   toolArgs,
   toolResult,
+  partialToolOutput,
   serverId,
   readResource,
   className,
@@ -421,6 +424,8 @@ function OpenAIComponentRendererBase({
               iframeWindow.openai.userAgent = merged.userAgent;
             if (merged.toolOutput !== undefined)
               iframeWindow.openai.toolOutput = merged.toolOutput;
+            if (merged.partialToolOutput !== undefined)
+              iframeWindow.openai.partialToolOutput = merged.partialToolOutput;
             if (merged.toolResponseMetadata !== undefined)
               iframeWindow.openai.toolResponseMetadata =
                 merged.toolResponseMetadata;
@@ -488,6 +493,14 @@ function OpenAIComponentRendererBase({
       toolResponseMetadata: metadata,
     });
   }, [toolResult, isReady, updateIframeGlobals]);
+
+  useEffect(() => {
+    if (!isReady || !iframeRef.current?.contentWindow) return;
+
+    updateIframeGlobals({
+      partialToolOutput: partialToolOutput ?? null,
+    });
+  }, [partialToolOutput, isReady, updateIframeGlobals]);
 
   // Handle display mode changes with native Fullscreen API
   const handleDisplayModeChange = useCallback(
@@ -1184,6 +1197,7 @@ function openAIComponentRendererAreEqual(
     "serverId",
     "toolArgs",
     "toolResult",
+    "partialToolOutput",
     "readResource",
     "className",
   ] as const;

--- a/libraries/typescript/packages/inspector/src/client/components/ToolsTab.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ToolsTab.tsx
@@ -22,6 +22,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { useMcpClient } from "mcp-use/react";
 import { RpcPanel } from "./shared";
 import type { SavedRequest, ToolResult } from "./tools";
 import {
@@ -147,6 +148,12 @@ export function ToolsTab({
   });
   const [autoFilledFields, setAutoFilledFields] = useState<Set<string>>(
     new Set()
+  );
+  const lastWidgetPartialNotificationIdRef = useRef<string | null>(null);
+  const { servers } = useMcpClient();
+  const server = useMemo(
+    () => servers.find((candidate) => candidate.id === serverId),
+    [servers, serverId]
   );
 
   const leftPanelRef = usePanelRef();
@@ -320,6 +327,45 @@ export function ToolsTab({
   useEffect(() => {
     setFocusedIndex(-1);
   }, [searchQuery, activeTab]);
+
+  useEffect(() => {
+    const latestNotification = server?.notifications?.[0];
+    if (!latestNotification) {
+      return;
+    }
+
+    if (lastWidgetPartialNotificationIdRef.current === latestNotification.id) {
+      return;
+    }
+    lastWidgetPartialNotificationIdRef.current = latestNotification.id;
+
+    if (latestNotification.method !== "ui/notifications/tool-result-partial") {
+      return;
+    }
+
+    const structuredContent = latestNotification.params?.structuredContent;
+    if (!structuredContent || typeof structuredContent !== "object") {
+      return;
+    }
+
+    setResults((prev) => {
+      if (prev.length === 0) {
+        return prev;
+      }
+
+      const [first, ...rest] = prev;
+      if (first.result !== null) {
+        return prev;
+      }
+      return [
+        {
+          ...first,
+          partialToolOutput: structuredContent as Record<string, unknown>,
+        },
+        ...rest,
+      ];
+    });
+  }, [server?.notifications]);
 
   // Handle keyboard navigation
   useEffect(() => {
@@ -716,6 +762,7 @@ export function ToolsTab({
           toolName: selectedTool.name,
           args: parsedArgs,
           result: null, // No result yet
+          partialToolOutput: null,
           timestamp: startTime,
           duration: 0,
           toolMeta,
@@ -826,6 +873,7 @@ export function ToolsTab({
               ? {
                   ...r,
                   result,
+                  partialToolOutput: null,
                   duration,
                   appsSdkResource,
                   toolMeta: updatedToolMeta, // Include updated tool metadata for dual-protocol widget detection
@@ -840,6 +888,7 @@ export function ToolsTab({
             toolName: selectedTool.name,
             args: toolArgs,
             result,
+            partialToolOutput: null,
             timestamp: startTime,
             duration,
             toolMeta: updatedToolMeta,
@@ -874,6 +923,7 @@ export function ToolsTab({
         toolName: selectedTool.name,
         args: toolArgs,
         result: null,
+        partialToolOutput: null,
         error: error instanceof Error ? error.message : String(error),
         timestamp: startTime,
         duration,

--- a/libraries/typescript/packages/inspector/src/client/components/chat/MessageList.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/MessageList.tsx
@@ -21,6 +21,7 @@ interface Message {
       toolName: string;
       args: Record<string, unknown>;
       result?: any;
+      partialResult?: Record<string, unknown> | null;
       state?: "pending" | "streaming" | "result" | "error";
       partialArgs?: Record<string, unknown>;
     };
@@ -238,6 +239,9 @@ export const MessageList = memo(
                                 toolName={part.toolInvocation.toolName}
                                 toolArgs={part.toolInvocation.args}
                                 result={part.toolInvocation.result || null}
+                                partialToolOutput={
+                                  part.toolInvocation.partialResult
+                                }
                                 serverId={serverId}
                                 readResource={readResource}
                                 serverBaseUrl={serverBaseUrl}

--- a/libraries/typescript/packages/inspector/src/client/components/chat/ToolResultRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/ToolResultRenderer.tsx
@@ -32,6 +32,7 @@ interface ToolResultRendererProps {
   toolName: string;
   toolArgs: Record<string, unknown>;
   result: any;
+  partialToolOutput?: Record<string, unknown> | null;
   serverId?: string;
   readResource?: (uri: string) => Promise<any>;
   toolMeta?: Record<string, any>;
@@ -51,6 +52,7 @@ export function ToolResultRenderer({
   toolName,
   toolArgs,
   result,
+  partialToolOutput,
   serverId,
   readResource,
   toolMeta,
@@ -243,6 +245,7 @@ export function ToolResultRenderer({
             toolName={toolName}
             toolInput={memoizedToolArgs}
             toolOutput={memoizedResult}
+            partialToolOutput={partialToolOutput}
             toolMetadata={toolMeta}
             invoking={invokingText}
             invoked={invokedText}
@@ -262,6 +265,7 @@ export function ToolResultRenderer({
             toolName={toolName}
             toolArgs={memoizedToolArgs}
             toolResult={memoizedResult}
+            partialToolOutput={partialToolOutput}
             serverId={serverId}
             readResource={readResource}
             noWrapper={true}
@@ -286,6 +290,7 @@ export function ToolResultRenderer({
           toolName={toolName}
           toolInput={memoizedToolArgs}
           toolOutput={memoizedResult}
+          partialToolOutput={partialToolOutput}
           toolMetadata={toolMeta}
           invoking={invokingText}
           invoked={invokedText}
@@ -316,6 +321,7 @@ export function ToolResultRenderer({
         toolName={toolName}
         toolArgs={memoizedToolArgs}
         toolResult={memoizedResult}
+        partialToolOutput={partialToolOutput}
         serverId={serverId}
         readResource={readResource}
         noWrapper={true}

--- a/libraries/typescript/packages/inspector/src/client/components/chat/types.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/types.ts
@@ -19,6 +19,7 @@ export interface Message {
       toolName: string;
       args: Record<string, unknown>;
       result?: any;
+      partialResult?: Record<string, unknown> | null;
       state?: "pending" | "streaming" | "result" | "error";
       /** Best-effort parsed partial arguments while the LLM is still generating */
       partialArgs?: Record<string, unknown>;

--- a/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessagesClientSide.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessagesClientSide.ts
@@ -1,6 +1,6 @@
 import { MCPChatMessageEvent, Telemetry } from "@/client/telemetry";
 import type { McpServer } from "mcp-use/react";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { PromptResult } from "../../hooks/useMCPPrompts";
 import {
   convertMessagesToLangChain,
@@ -41,6 +41,66 @@ export function useChatMessagesClientSide({
   const agentRef = useRef<any>(null);
   const llmRef = useRef<any>(null);
   const lastDisabledToolsRef = useRef<string>("");
+  const lastWidgetPartialNotificationIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const latestNotification = connection.notifications?.[0];
+    if (!latestNotification) {
+      return;
+    }
+
+    if (lastWidgetPartialNotificationIdRef.current === latestNotification.id) {
+      return;
+    }
+    lastWidgetPartialNotificationIdRef.current = latestNotification.id;
+
+    if (latestNotification.method !== "ui/notifications/tool-result-partial") {
+      return;
+    }
+
+    const structuredContent = latestNotification.params?.structuredContent;
+    if (!structuredContent || typeof structuredContent !== "object") {
+      return;
+    }
+
+    setMessages((prev) =>
+      prev.map((message) => {
+        if (message.role !== "assistant" || !message.parts) {
+          return message;
+        }
+
+        let updated = false;
+        const nextParts = [...message.parts];
+        for (let i = nextParts.length - 1; i >= 0; i -= 1) {
+          const part = nextParts[i];
+          const toolInvocation = part.toolInvocation;
+          if (!toolInvocation) {
+            continue;
+          }
+
+          if (
+            toolInvocation.result !== undefined ||
+            (toolInvocation.state !== "pending" &&
+              toolInvocation.state !== "streaming")
+          ) {
+            continue;
+          }
+
+          nextParts[i] = {
+            ...part,
+            toolInvocation: {
+              ...toolInvocation,
+              partialResult: structuredContent as Record<string, unknown>,
+            },
+          };
+          updated = true;
+          break;
+        }
+
+        return updated ? { ...message, parts: nextParts } : message;
+      })
+    );
+  }, [connection.notifications]);
 
   const sendMessage = useCallback(
     async (
@@ -101,6 +161,7 @@ export function useChatMessagesClientSide({
             toolName: string;
             args: Record<string, unknown>;
             result?: any;
+            partialResult?: Record<string, unknown> | null;
             state?: "pending" | "streaming" | "result" | "error";
             partialArgs?: Record<string, unknown>;
           };
@@ -424,6 +485,7 @@ export function useChatMessagesClientSide({
                       toolInvocation: {
                         toolName: buffer.name,
                         args: {},
+                        partialResult: null,
                         state: "streaming",
                         partialArgs,
                       },
@@ -490,6 +552,7 @@ export function useChatMessagesClientSide({
                 toolInvocation: {
                   toolName: event.name || "unknown",
                   args,
+                  partialResult: null,
                   state: "pending",
                 },
               });
@@ -550,6 +613,7 @@ export function useChatMessagesClientSide({
 
               // Store the unwrapped result
               toolPart.toolInvocation.result = result;
+              toolPart.toolInvocation.partialResult = null;
               // Check if result indicates an error
               toolPart.toolInvocation.state = result?.isError
                 ? "error"

--- a/libraries/typescript/packages/inspector/src/client/components/prompts/PromptResultDisplay.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/prompts/PromptResultDisplay.tsx
@@ -99,11 +99,11 @@ function extractErrorMessage(
 export function PromptResultDisplay({
   results,
   copiedResult,
-  previewMode = true,
+  previewMode: _previewMode = true,
   onCopy,
   onDelete,
   onFullscreen,
-  onTogglePreview,
+  onTogglePreview: _onTogglePreview,
   onMaximize,
   isMaximized = false,
 }: PromptResultDisplayProps) {

--- a/libraries/typescript/packages/inspector/src/client/components/prompts/SavedPromptsList.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/prompts/SavedPromptsList.tsx
@@ -23,7 +23,7 @@ export function SavedPromptsList({
   savedPrompts,
   selectedPrompt,
   onLoadPrompt,
-  onDeletePrompt,
+  onDeletePrompt: _onDeletePrompt,
   focusedIndex,
 }: SavedPromptsListProps) {
   if (savedPrompts.length === 0) {

--- a/libraries/typescript/packages/inspector/src/client/components/sampling/useSamplingLLM.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/sampling/useSamplingLLM.ts
@@ -34,6 +34,7 @@ export function useSamplingLLM({ llmConfig }: UseSamplingLLMProps) {
       const maxTokens = params.maxTokens;
       const temperature = params.temperature;
       const _modelPreferences = params.modelPreferences;
+      void _modelPreferences;
 
       // Convert MCP messages to LangChain format
       const messages = params.messages || [];

--- a/libraries/typescript/packages/inspector/src/client/components/tools/ToolResultDisplay.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/tools/ToolResultDisplay.tsx
@@ -42,6 +42,7 @@ export interface ToolResult {
   toolName: string;
   args: Record<string, unknown>;
   result: any;
+  partialToolOutput?: Record<string, unknown> | null;
   error?: string;
   timestamp: number;
   duration?: number;
@@ -929,6 +930,7 @@ export function ToolResultDisplay({
                         toolName={result.toolName}
                         toolArgs={memoizedArgs}
                         toolResult={memoizedResult}
+                        partialToolOutput={result.partialToolOutput}
                         serverId={serverId}
                         readResource={memoizedReadResource}
                         className="w-full h-full relative p-4"
@@ -996,6 +998,7 @@ export function ToolResultDisplay({
                         toolName={result.toolName}
                         toolInput={memoizedArgs}
                         toolOutput={memoizedResult}
+                        partialToolOutput={result.partialToolOutput}
                         toolMetadata={result.toolMeta}
                         resourceUri={mcpAppsResourceUri}
                         readResource={memoizedReadResource}

--- a/libraries/typescript/packages/inspector/src/client/hooks/useAutoConnect.ts
+++ b/libraries/typescript/packages/inspector/src/client/hooks/useAutoConnect.ts
@@ -227,7 +227,7 @@ function parseAutoConnectParam(param: string): ConnectionConfig | null {
 export function useAutoConnect({
   connections,
   addConnection,
-  removeConnection,
+  removeConnection: _removeConnection,
   configLoaded: contextConfigLoaded,
   embedded = false,
 }: UseAutoConnectOptions): AutoConnectState {

--- a/libraries/typescript/packages/mcp-use/examples/server/features/streaming-props/index.ts
+++ b/libraries/typescript/packages/mcp-use/examples/server/features/streaming-props/index.ts
@@ -56,7 +56,7 @@ function buildCodeSnippet(language: string, description: string): string {
     "};",
     "",
     "function runTask(task: Task): string {",
-    "  return `Running: ${task.description}`;",
+    String.raw`  return \`Running: \${task.description}\`;`,
     "}",
     "",
     `const task: Task = { description: ${JSON.stringify(description)} };`,

--- a/libraries/typescript/packages/mcp-use/examples/server/features/streaming-props/index.ts
+++ b/libraries/typescript/packages/mcp-use/examples/server/features/streaming-props/index.ts
@@ -5,32 +5,64 @@ const server = new MCPServer({
   name: "streaming-props-example",
   version: "1.0.0",
   description:
-    "Example MCP server demonstrating streaming tool props to widgets. " +
-    "When an LLM generates complex tool arguments (code, JSON, etc.), " +
-    "the widget receives partial arguments in real-time via `partialToolInput` / `isStreaming`.",
+    "Example MCP server demonstrating tool-generated streaming widget props. " +
+    "The server streams partial structuredContent updates during tool execution " +
+    "before returning the final widget result.",
 });
 
 /**
  * STREAMING TOOL PROPS EXAMPLE
  *
- * This demonstrates the `partialToolInput` / `isStreaming` feature in useWidget.
+ * This demonstrates the `streamWidgetProps()` / `partialToolOutput` feature.
  *
- * When a host (like the MCP Inspector or an LLM client) sends
- * `ui/notifications/tool-input-partial` notifications as the LLM streams
- * tool arguments, the widget receives them in real-time and can render
- * a live preview of the incoming data.
+ * The tool itself progressively streams widget props while it is running.
+ * Each update is sent with `ctx.streamWidgetProps(...)`, which reaches the
+ * widget as `partialToolOutput` / `isOutputStreaming` in useWidget().
  *
  * The code-preview widget shows:
- * - A streaming indicator while `isStreaming` is true
- * - Live rendering of partially received code/text
- * - Final rendered state once complete args arrive
+ * - A streaming indicator while `isOutputStreaming` is true
+ * - Live rendering of partially generated code/text
+ * - Final rendered state once the tool returns
  *
  * To test in the Inspector:
  * 1. Run `mcp-use dev` in this directory
  * 2. Open the Inspector
  * 3. Call `generate-code` with a language and description
- * 4. The widget renders immediately and shows the code as it "streams in"
+ * 4. The widget renders immediately and shows the code as the tool streams it
  */
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function buildCodeSnippet(language: string, description: string): string {
+  if (language.toLowerCase() === "python") {
+    return [
+      "from dataclasses import dataclass",
+      "",
+      "@dataclass",
+      "class Task:",
+      "    description: str",
+      "",
+      "def run_task(task: Task) -> str:",
+      '    return f"Running: {task.description}"',
+      "",
+      `task = Task(description=${JSON.stringify(description)})`,
+      "print(run_task(task))",
+    ].join("\n");
+  }
+
+  return [
+    "type Task = {",
+    "  description: string;",
+    "};",
+    "",
+    "function runTask(task: Task): string {",
+    "  return `Running: ${task.description}`;",
+    "}",
+    "",
+    `const task: Task = { description: ${JSON.stringify(description)} };`,
+    "console.log(runTask(task));",
+  ].join("\n");
+}
 
 // Tool that generates code with a widget preview
 server.tool(
@@ -38,13 +70,12 @@ server.tool(
     name: "generate-code",
     description:
       "Generate a code snippet for the given description. " +
-      "The widget shows a live preview of the code as it streams in.",
+      "The widget shows a live preview as the tool streams partial output.",
     schema: z.object({
       language: z
         .string()
         .describe("Programming language (e.g. typescript, python, rust)"),
       description: z.string().describe("Description of the code to generate"),
-      code: z.string().describe("The generated code snippet"),
     }),
     widget: {
       name: "code-preview",
@@ -52,44 +83,28 @@ server.tool(
       invoked: "Code generated",
     },
   },
-  async ({ language, description, code }) => {
+  async ({ language, description }, ctx) => {
+    const finalCode = buildCodeSnippet(language, description);
+    const lines = finalCode.split("\n");
+
+    for (let i = 0; i < lines.length; i += 1) {
+      await ctx.streamWidgetProps({
+        language,
+        description,
+        code: lines.slice(0, i + 1).join("\n"),
+        generatedLines: i + 1,
+      });
+      await sleep(90);
+    }
+
     return widget({
       props: {
         language,
         description,
-        code,
+        code: finalCode,
+        generatedLines: lines.length,
       },
       message: `Generated ${language} code: ${description}`,
-    });
-  }
-);
-
-// Tool that generates a JSON document with streaming preview
-server.tool(
-  {
-    name: "generate-json",
-    description:
-      "Generate a JSON configuration or data structure. " +
-      "The widget shows a live preview of the JSON as it streams in.",
-    schema: z.object({
-      title: z.string().describe("Title of the JSON document"),
-      description: z.string().describe("Description of the JSON structure"),
-      content: z.string().describe("The JSON content as a string"),
-    }),
-    widget: {
-      name: "code-preview",
-      invoking: "Generating JSON...",
-      invoked: "JSON generated",
-    },
-  },
-  async ({ title, description, content }) => {
-    return widget({
-      props: {
-        language: "json",
-        description: `${title}: ${description}`,
-        code: content,
-      },
-      message: `Generated JSON: ${title}`,
     });
   }
 );
@@ -111,18 +126,15 @@ await server.listen();
 console.log(`
 Streaming Props Example Server Started!
 
-This server demonstrates the partialToolInput / isStreaming feature.
+This server demonstrates the partialToolOutput / isOutputStreaming feature.
 
 Tools:
-- generate-code: Generate code with live streaming preview widget
-- generate-json: Generate JSON with live streaming preview widget
+- generate-code: Generate code with live tool-output streaming preview widget
 - hello: Simple text tool (for comparison)
 
 How streaming props work:
-1. When the LLM starts generating tool arguments, the host sends
-   ui/notifications/tool-input-partial with the partial args parsed so far
-2. The widget receives these via useWidget()'s partialToolInput field
-3. isStreaming is true while partial args are arriving
-4. Once the full args arrive (tool-input notification), isStreaming becomes false
-   and toolInput contains the complete arguments
+1. The tool calls ctx.streamWidgetProps({ ...partial props... }) while it runs
+2. The host forwards ui/notifications/tool-result-partial to the widget
+3. The widget receives these via useWidget()'s partialToolOutput field
+4. isOutputStreaming stays true until the final tool result arrives
 `);

--- a/libraries/typescript/packages/mcp-use/examples/server/features/streaming-props/resources/code-preview/widget.tsx
+++ b/libraries/typescript/packages/mcp-use/examples/server/features/streaming-props/resources/code-preview/widget.tsx
@@ -24,13 +24,7 @@ export const widgetMetadata: WidgetMetadata = {
 type CodePreviewProps = z.infer<typeof propSchema>;
 
 const CodePreview: React.FC = () => {
-  const {
-    props,
-    isPending,
-    isOutputStreaming,
-    partialToolOutput,
-    theme,
-  } =
+  const { props, isPending, isOutputStreaming, partialToolOutput, theme } =
     useWidget<CodePreviewProps>();
 
   const isDark = theme === "dark";

--- a/libraries/typescript/packages/mcp-use/examples/server/features/streaming-props/resources/code-preview/widget.tsx
+++ b/libraries/typescript/packages/mcp-use/examples/server/features/streaming-props/resources/code-preview/widget.tsx
@@ -6,6 +6,7 @@ const propSchema = z.object({
   language: z.string().describe("Programming language"),
   description: z.string().describe("Description of the code"),
   code: z.string().describe("The code snippet"),
+  generatedLines: z.number().optional().describe("How many lines are ready"),
 });
 
 export const widgetMetadata: WidgetMetadata = {
@@ -23,7 +24,13 @@ export const widgetMetadata: WidgetMetadata = {
 type CodePreviewProps = z.infer<typeof propSchema>;
 
 const CodePreview: React.FC = () => {
-  const { props, isPending, isStreaming, partialToolInput, theme } =
+  const {
+    props,
+    isPending,
+    isOutputStreaming,
+    partialToolOutput,
+    theme,
+  } =
     useWidget<CodePreviewProps>();
 
   const isDark = theme === "dark";
@@ -31,19 +38,23 @@ const CodePreview: React.FC = () => {
   // Determine what to display based on streaming state
   const displayLanguage =
     props.language ||
-    (partialToolInput as Partial<CodePreviewProps> | null)?.language ||
+    (partialToolOutput as Partial<CodePreviewProps> | null)?.language ||
     "";
   const displayDescription =
     props.description ||
-    (partialToolInput as Partial<CodePreviewProps> | null)?.description ||
+    (partialToolOutput as Partial<CodePreviewProps> | null)?.description ||
     "";
   const displayCode =
     props.code ||
-    (partialToolInput as Partial<CodePreviewProps> | null)?.code ||
+    (partialToolOutput as Partial<CodePreviewProps> | null)?.code ||
     "";
+  const displayGeneratedLines =
+    props.generatedLines ||
+    (partialToolOutput as Partial<CodePreviewProps> | null)?.generatedLines ||
+    0;
 
   // Loading state - no data at all yet
-  if (isPending && !isStreaming) {
+  if (isPending && !isOutputStreaming) {
     return (
       <McpUseProvider autoSize>
         <div
@@ -109,7 +120,7 @@ const CodePreview: React.FC = () => {
           </div>
 
           {/* Streaming indicator */}
-          {isStreaming && (
+          {isOutputStreaming && (
             <div className="flex items-center gap-2">
               <div className="flex gap-1">
                 <div
@@ -140,7 +151,7 @@ const CodePreview: React.FC = () => {
           )}
 
           {/* Complete indicator */}
-          {!isStreaming && !isPending && (
+          {!isOutputStreaming && !isPending && (
             <span
               className={`text-xs ${isDark ? "text-gray-500" : "text-gray-400"}`}
             >
@@ -170,7 +181,7 @@ const CodePreview: React.FC = () => {
               )}
             </code>
             {/* Blinking cursor when streaming */}
-            {isStreaming && (
+            {isOutputStreaming && (
               <span
                 className={`inline-block w-2 h-4 ml-0.5 animate-pulse ${
                   isDark ? "bg-green-400" : "bg-green-500"
@@ -190,9 +201,10 @@ const CodePreview: React.FC = () => {
           }`}
         >
           <span>
-            isStreaming: {String(isStreaming)} | isPending: {String(isPending)}{" "}
-            | partialToolInput: {partialToolInput ? "present" : "null"} | code
-            length: {displayCode.length}
+            isOutputStreaming: {String(isOutputStreaming)} | isPending:{" "}
+            {String(isPending)} | partialToolOutput:{" "}
+            {partialToolOutput ? "present" : "null"} | lines ready:{" "}
+            {displayGeneratedLines} | code length: {displayCode.length}
           </span>
         </div>
       </div>

--- a/libraries/typescript/packages/mcp-use/src/react/mcp-apps-bridge.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/mcp-apps-bridge.ts
@@ -86,6 +86,10 @@ interface ToolResultNotification {
   _meta?: Record<string, unknown>;
 }
 
+interface ToolResultPartialNotification {
+  structuredContent?: Record<string, unknown>;
+}
+
 /**
  * Singleton bridge for MCP Apps postMessage communication
  */
@@ -102,6 +106,7 @@ class McpAppsBridge {
   // State
   private toolInput: Record<string, unknown> | null = null;
   private partialToolInput: Record<string, unknown> | null = null;
+  private partialToolOutput: Record<string, unknown> | null = null;
   private toolOutput: Record<string, unknown> | null = null;
   private toolResponseMetadata: Record<string, unknown> | null = null;
   private hostContext: HostContext | null = null;
@@ -117,6 +122,9 @@ class McpAppsBridge {
     (input: Record<string, unknown>) => void
   >();
   private toolResultHandlers = new Set<
+    (result: Record<string, unknown>) => void
+  >();
+  private toolResultPartialHandlers = new Set<
     (result: Record<string, unknown>) => void
   >();
   private hostContextHandlers = new Set<(context: HostContext) => void>();
@@ -327,6 +335,7 @@ class McpAppsBridge {
         const params = notification.params as unknown as ToolInputNotification;
         console.log("[MCP Apps Bridge] Tool input received:", params.arguments);
         this.toolInput = params.arguments;
+        this.partialToolOutput = null;
         this.toolInputHandlers.forEach((handler) => handler(params.arguments));
         break;
       }
@@ -351,7 +360,15 @@ class McpAppsBridge {
         this.toolOutput = output;
         this.toolResponseMetadata = meta;
         this.partialToolInput = null;
+        this.partialToolOutput = null;
         this.toolResultHandlers.forEach((handler) => handler(output));
+        break;
+      }
+      case "ui/notifications/tool-result-partial": {
+        const params = notification.params as ToolResultPartialNotification;
+        const output = params.structuredContent || {};
+        this.partialToolOutput = output;
+        this.toolResultPartialHandlers.forEach((handler) => handler(output));
         break;
       }
       case "ui/notifications/host-context-changed": {
@@ -539,6 +556,13 @@ class McpAppsBridge {
   }
 
   /**
+   * Get current partial tool output (structuredContent patch).
+   */
+  getPartialToolOutput(): Record<string, unknown> | null {
+    return this.partialToolOutput;
+  }
+
+  /**
    * Get tool response metadata (_meta from tool result)
    */
   getToolResponseMetadata(): Record<string, unknown> | null {
@@ -590,6 +614,16 @@ class McpAppsBridge {
   onToolResult(handler: (result: Record<string, unknown>) => void): () => void {
     this.toolResultHandlers.add(handler);
     return () => this.toolResultHandlers.delete(handler);
+  }
+
+  /**
+   * Subscribe to partial tool result changes.
+   */
+  onToolResultPartial(
+    handler: (result: Record<string, unknown>) => void
+  ): () => void {
+    this.toolResultPartialHandlers.add(handler);
+    return () => this.toolResultPartialHandlers.delete(handler);
   }
 
   /**

--- a/libraries/typescript/packages/mcp-use/src/react/useWidget.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/useWidget.ts
@@ -168,9 +168,8 @@ export function useWidget<
     string,
     unknown
   > | null>(null);
-  const [mcpAppsPartialToolOutput, setMcpAppsPartialToolOutput] = useState<
-    Record<string, unknown> | null
-  >(null);
+  const [mcpAppsPartialToolOutput, setMcpAppsPartialToolOutput] =
+    useState<Record<string, unknown> | null>(null);
   const [mcpAppsResponseMetadata, setMcpAppsResponseMetadata] = useState<Record<
     string,
     unknown
@@ -429,8 +428,10 @@ export function useWidget<
       openaiPartialToolOutput &&
       typeof openaiPartialToolOutput === "object"
     ) {
-      partialStructuredContent =
-        openaiPartialToolOutput as Record<string, unknown>;
+      partialStructuredContent = openaiPartialToolOutput as Record<
+        string,
+        unknown
+      >;
     } else if (provider === "mcp-apps" && mcpAppsToolOutput) {
       structuredContent = mcpAppsToolOutput as Record<string, unknown>;
     } else if (
@@ -438,8 +439,10 @@ export function useWidget<
       mcpAppsPartialToolOutput &&
       typeof mcpAppsPartialToolOutput === "object"
     ) {
-      partialStructuredContent =
-        mcpAppsPartialToolOutput as Record<string, unknown>;
+      partialStructuredContent = mcpAppsPartialToolOutput as Record<
+        string,
+        unknown
+      >;
     } else if (provider === "mcp-ui" && urlParams.toolOutput) {
       structuredContent = urlParams.toolOutput as Record<string, unknown>;
     }

--- a/libraries/typescript/packages/mcp-use/src/react/useWidget.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/useWidget.ts
@@ -89,7 +89,8 @@ function useOpenAiGlobal<K extends keyof OpenAiGlobals>(
  *    loaded in any SEP-1865-compliant host (e.g. Claude, Cursor) that is not
  *    ChatGPT. The hook connects via `ui/initialize` and listens for
  *    `ui/notifications/tool-input`, `ui/notifications/tool-input-partial`,
- *    `ui/notifications/tool-result`, and `ui/notifications/host-context-changed`.
+ *    `ui/notifications/tool-result`, `ui/notifications/tool-result-partial`,
+ *    and `ui/notifications/host-context-changed`.
  *
  * 3. **URL params fallback** (`mcpUseParams`) — used during local development
  *    (`mcp-use dev` inspector) where `toolInput` and `toolOutput` are injected
@@ -167,6 +168,9 @@ export function useWidget<
     string,
     unknown
   > | null>(null);
+  const [mcpAppsPartialToolOutput, setMcpAppsPartialToolOutput] = useState<
+    Record<string, unknown> | null
+  >(null);
   const [mcpAppsResponseMetadata, setMcpAppsResponseMetadata] = useState<Record<
     string,
     unknown
@@ -255,11 +259,13 @@ export function useWidget<
         const responseMeta = bridge.getToolResponseMetadata();
         const hostContext = bridge.getHostContext();
         const partialToolInput = bridge.getPartialToolInput();
+        const partialToolOutput = bridge.getPartialToolOutput();
 
         if (toolInput) setMcpAppsToolInput(toolInput);
         if (toolOutput) setMcpAppsToolOutput(toolOutput);
         if (responseMeta) setMcpAppsResponseMetadata(responseMeta);
         if (partialToolInput) setMcpAppsPartialToolInput(partialToolInput);
+        if (partialToolOutput) setMcpAppsPartialToolOutput(partialToolOutput);
         if (hostContext) setMcpAppsHostContext(hostContext);
 
         const hostInfo = bridge.getHostInfo();
@@ -284,6 +290,11 @@ export function useWidget<
       setMcpAppsToolOutput(result);
       setMcpAppsResponseMetadata(bridge.getToolResponseMetadata());
       setMcpAppsPartialToolInput(null);
+      setMcpAppsPartialToolOutput(null);
+    });
+
+    const unsubToolResultPartial = bridge.onToolResultPartial((result) => {
+      setMcpAppsPartialToolOutput(result);
     });
 
     const unsubHostContext = bridge.onHostContextChange((context) => {
@@ -295,6 +306,7 @@ export function useWidget<
       unsubToolInput();
       unsubToolInputPartial();
       unsubToolResult();
+      unsubToolResultPartial();
       unsubHostContext();
     };
   }, []);
@@ -332,6 +344,10 @@ export function useWidget<
     | undefined;
   const openaiToolOutput = useOpenAiGlobal("toolOutput") as
     | TOutput
+    | null
+    | undefined;
+  const openaiPartialToolOutput = useOpenAiGlobal("partialToolOutput") as
+    | Partial<TOutput>
     | null
     | undefined;
   const toolResponseMetadata = useOpenAiGlobal("toolResponseMetadata") as
@@ -380,6 +396,13 @@ export function useWidget<
     return urlParams.toolOutput as TOutput | null | undefined;
   }, [provider, openaiToolOutput, mcpAppsToolOutput, urlParams.toolOutput]);
 
+  const partialToolOutput = useMemo(() => {
+    if (provider === "openai") return openaiPartialToolOutput;
+    if (provider === "mcp-apps")
+      return mcpAppsPartialToolOutput as Partial<TOutput> | null | undefined;
+    return null;
+  }, [provider, openaiPartialToolOutput, mcpAppsPartialToolOutput]);
+
   // Props semantics:
   // - Widget exposed as tool: props = toolInput (args to the tool); when result arrives, props = structuredContent (tool can echo/override).
   // - Widget returned by another tool: props = structuredContent from that tool's result; toolInput = args to the parent tool.
@@ -393,6 +416,7 @@ export function useWidget<
     // full CallToolResult envelope { content, structuredContent, _meta } as toolOutput
     // instead of pre-extracting structuredContent. Detect and unwrap when needed.
     let structuredContent: Record<string, unknown> | undefined;
+    let partialStructuredContent: Record<string, unknown> | undefined;
     if (provider === "openai" && openaiToolOutput) {
       const raw = openaiToolOutput as Record<string, unknown>;
       if (raw.structuredContent && typeof raw.structuredContent === "object") {
@@ -400,20 +424,41 @@ export function useWidget<
       } else {
         structuredContent = raw;
       }
+    } else if (
+      provider === "openai" &&
+      openaiPartialToolOutput &&
+      typeof openaiPartialToolOutput === "object"
+    ) {
+      partialStructuredContent =
+        openaiPartialToolOutput as Record<string, unknown>;
     } else if (provider === "mcp-apps" && mcpAppsToolOutput) {
       structuredContent = mcpAppsToolOutput as Record<string, unknown>;
+    } else if (
+      provider === "mcp-apps" &&
+      mcpAppsPartialToolOutput &&
+      typeof mcpAppsPartialToolOutput === "object"
+    ) {
+      partialStructuredContent =
+        mcpAppsPartialToolOutput as Record<string, unknown>;
     } else if (provider === "mcp-ui" && urlParams.toolOutput) {
       structuredContent = urlParams.toolOutput as Record<string, unknown>;
     }
 
     // Base: toolInput (for exposed-as-tool) or defaultProps; overlay: structuredContent
-    const merged = { ...base, ...ti, ...(structuredContent || {}) } as TProps;
+    const merged = {
+      ...base,
+      ...ti,
+      ...(partialStructuredContent || {}),
+      ...(structuredContent || {}),
+    } as TProps;
     return merged;
   }, [
     provider,
     toolInput,
     openaiToolOutput,
+    openaiPartialToolOutput,
     mcpAppsToolOutput,
+    mcpAppsPartialToolOutput,
     urlParams.toolOutput,
     defaultProps,
   ]);
@@ -791,6 +836,14 @@ export function useWidget<
     return false;
   }, [provider, mcpAppsPartialToolInput]);
 
+  const isOutputStreaming = useMemo(() => {
+    return (
+      partialToolOutput !== null &&
+      partialToolOutput !== undefined &&
+      (toolOutput === null || toolOutput === undefined)
+    );
+  }, [partialToolOutput, toolOutput]);
+
   return {
     // Props and state (with defaults)
     props: widgetProps,
@@ -838,7 +891,9 @@ export function useWidget<
 
     // Streaming
     partialToolInput,
+    partialToolOutput: (partialToolOutput ?? null) as Partial<TOutput> | null,
     isStreaming,
+    isOutputStreaming,
 
     // Host identity (MCP Apps only)
     hostInfo: mcpAppsHostInfo ?? undefined,

--- a/libraries/typescript/packages/mcp-use/src/react/widget-types.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/widget-types.ts
@@ -106,6 +106,7 @@ export interface OpenAiGlobals<
   // state
   toolInput: ToolInput;
   toolOutput: ToolOutput | null;
+  partialToolOutput?: Partial<ToolOutput> | null;
   toolResponseMetadata: ToolResponseMetadata | null;
   widgetState: WidgetState | null;
 }
@@ -452,6 +453,14 @@ interface UseWidgetResultBase<
   partialToolInput: Partial<TToolInput> | null;
 
   /**
+   * Partial widget props streamed from inside the tool execution.
+   *
+   * Delivered via `ui/notifications/tool-result-partial` (SEP-1865) or an
+   * equivalent host update in Apps SDK-compatible inspector hosts.
+   */
+  partialToolOutput: Partial<TOutput> | null;
+
+  /**
    * Whether the LLM is currently streaming tool arguments.
    *
    * `true` while `partialToolInput` is non-null and the complete `toolInput`
@@ -465,6 +474,12 @@ interface UseWidgetResultBase<
    * @see partialToolInput
    */
   isStreaming: boolean;
+
+  /**
+   * `true` while the tool is streaming partial widget output and no final
+   * `tool-result` has been delivered yet.
+   */
+  isOutputStreaming: boolean;
 
   /**
    * Name and version of the MCP Apps host as reported during the

--- a/libraries/typescript/packages/mcp-use/src/server/tools/tool-execution-helpers.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/tools/tool-execution-helpers.ts
@@ -18,6 +18,7 @@ import type {
 import { toJsonSchemaCompat } from "@modelcontextprotocol/sdk/server/zod-json-schema-compat.js";
 import { ElicitationValidationError } from "../../errors.js";
 import { generateUUID } from "../utils/runtime.js";
+import { createNotification } from "../utils/jsonrpc-helpers.js";
 import type {
   SampleOptions,
   ElicitOptions,
@@ -872,7 +873,25 @@ function createSendNotificationMethod(
 
   return async (method: string, params?: Record<string, unknown>) => {
     const session = sessions.get(sessionId);
-    if (!session?.sendNotification) {
+    if (!session) {
+      return;
+    }
+
+    if (!session.sendNotification) {
+      if (session.transport?.send) {
+        try {
+          await session.transport.send(
+            createNotification(method, params || {})
+          );
+        } catch (error) {
+          console.error(
+            `[MCP] Error sending transport notification to session ${sessionId}:`,
+            error
+          );
+        }
+        return;
+      }
+
       console.warn(
         `[MCP] Cannot send notification to session ${sessionId} - no sendNotification function`
       );
@@ -972,6 +991,9 @@ export function createEnhancedContext(
   client: ReturnType<typeof createClientCapabilityChecker>;
   session: { id?: string };
   sendNotification: typeof sendNotification;
+  streamWidgetProps: (
+    structuredContent: Record<string, unknown>
+  ) => Promise<void>;
 } {
   const enhancedContext: any = baseContext
     ? extractContextData(baseContext)
@@ -1014,6 +1036,18 @@ export function createEnhancedContext(
   if (sendNotificationMethod) {
     enhancedContext.sendNotification = sendNotificationMethod;
   }
+
+  enhancedContext.streamWidgetProps = async (
+    structuredContent: Record<string, unknown>
+  ): Promise<void> => {
+    if (!sendNotificationMethod) {
+      return;
+    }
+
+    await sendNotificationMethod("ui/notifications/tool-result-partial", {
+      structuredContent,
+    });
+  };
 
   const sendNotificationToSessionMethod =
     createSendNotificationToSessionMethod(sessions);

--- a/libraries/typescript/packages/mcp-use/src/server/types/tool-context.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/types/tool-context.ts
@@ -504,6 +504,17 @@ export interface ToolContext {
   ) => Promise<void>;
 
   /**
+   * Stream partial widget props to the current session while the tool is running.
+   *
+   * This uses the standard `ui/notifications/tool-result-partial` channel so
+   * widget hosts can merge progressive `structuredContent` updates before the
+   * final tool result arrives.
+   */
+  streamWidgetProps: (
+    structuredContent: Record<string, unknown>
+  ) => Promise<void>;
+
+  /**
    * Send a notification to a specific session by ID
    *
    * This allows sending notifications to any connected session, not just the


### PR DESCRIPTION
## Summary
- add `ctx.streamWidgetProps(...)` to stream partial widget props during tool execution
- add `tool-result-partial` handling to `mcp-use/react` and surface `partialToolOutput` / `isOutputStreaming` in `useWidget()`
- wire inspector Tools and client-side Chat widget hosts to forward partial tool output
- convert the `streaming-props` example into a working MCP server demo for tool-side widget prop streaming
- fix streamable HTTP session notification fallback so partial widget notifications are delivered during tool calls

Closes #1296.

## Verification
- `pnpm --dir libraries/typescript/packages/mcp-use build`
- `pnpm --dir libraries/typescript/packages/inspector type-check`
- `pnpm --dir libraries/typescript/packages/inspector build:client`
- manually verified the example server by calling `generate-code` and observing 10 `ui/notifications/tool-result-partial` updates before the final tool result
