### PR TITLE
feat(inspector): navbar UX improvements, deploy button, settings menu, and tel

### DIFF
--- a/libraries/typescript/.changeset/inspector-ui-improvements.md
+++ b/libraries/typescript/.changeset/inspector-ui-improvements.md
@@ -1,0 +1,12 @@
+---
+"@mcp-use/inspector": minor
+---
+
+Inspector navbar UX improvements
+
+- Chat tab moved to first position, always shows label even when collapsed, with visual separator
+- Active tab label stays visible when navbar is collapsed (new `alwaysExpanded` prop on TabsTrigger)
+- Deploy button added linking to manufact.com/signup with inspector referrer
+- Tunnel button repositioned between Add to Client and Deploy, restyled with violet theme, now visible in mobile layout
+- Theme toggle, command palette, and GitHub consolidated into a settings dropdown menu
+- "Report a Bug" menu item added, pre-fills GitHub issue with inspector label

--- a/libraries/typescript/packages/inspector/src/client/components/AddToClientDropdown.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/AddToClientDropdown.tsx
@@ -1,3 +1,4 @@
+import { MCPAddToClientEvent, Telemetry } from "@/client/telemetry";
 import { Button } from "@/client/components/ui/button";
 import {
   Dialog,
@@ -102,7 +103,16 @@ export function AddToClientDropdown({
 
   const { url, name, headers } = serverConfig;
 
+  const trackAddToClient = (client: string) => {
+    try {
+      Telemetry.getInstance()
+        .capture(new MCPAddToClientEvent({ client }))
+        .catch(() => {});
+    } catch {}
+  };
+
   const handleCursorClick = () => {
+    trackAddToClient("cursor");
     try {
       const deepLink = generateCursorDeepLink(url, name, headers);
       window.location.href = deepLink;
@@ -114,6 +124,7 @@ export function AddToClientDropdown({
   };
 
   const handleVSCodeClick = () => {
+    trackAddToClient("vscode");
     try {
       const deepLink = generateVSCodeDeepLink(url, name, headers);
       window.location.href = deepLink;
@@ -125,6 +136,7 @@ export function AddToClientDropdown({
   };
 
   const handleVSCodeInsidersClick = () => {
+    trackAddToClient("vscode-insiders");
     try {
       const deepLink = generateVSCodeInsidersDeepLink(url, name, headers);
       window.location.href = deepLink;
@@ -136,6 +148,7 @@ export function AddToClientDropdown({
   };
 
   const handleClaudeDesktopClick = () => {
+    trackAddToClient("claude-desktop");
     try {
       downloadMcpbFile(url, name, headers);
       onSuccess?.("Claude Desktop");
@@ -146,16 +159,19 @@ export function AddToClientDropdown({
   };
 
   const handleClaudeCodeClick = () => {
+    trackAddToClient("claude-code");
     setSelectedClient("claude-code");
     setShowModal(true);
   };
 
   const handleGeminiCLIClick = () => {
+    trackAddToClient("gemini-cli");
     setSelectedClient("gemini-cli");
     setShowModal(true);
   };
 
   const handleCodexCLIClick = () => {
+    trackAddToClient("codex-cli");
     setSelectedClient("codex-cli");
     setShowModal(true);
   };

--- a/libraries/typescript/packages/inspector/src/client/components/AddToClientDropdown.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/AddToClientDropdown.tsx
@@ -108,7 +108,9 @@ export function AddToClientDropdown({
       Telemetry.getInstance()
         .capture(new MCPAddToClientEvent({ client }))
         .catch(() => {});
-    } catch {}
+    } catch {
+      // ignore telemetry errors
+    }
   };
 
   const handleCursorClick = () => {

--- a/libraries/typescript/packages/inspector/src/client/components/InspectorDashboard.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/InspectorDashboard.tsx
@@ -102,7 +102,9 @@ export function InspectorDashboard() {
               })
             )
             .catch(() => {});
-        } catch {}
+        } catch {
+          // ignore telemetry errors
+        }
       } else if (
         connection.state === "failed" &&
         reportedConnectionsRef.current.has(connection.id)
@@ -119,7 +121,9 @@ export function InspectorDashboard() {
         Telemetry.getInstance()
           .capture(new MCPServerRemovedEvent({ serverId: connectionId }))
           .catch(() => {});
-      } catch {}
+      } catch {
+        // ignore telemetry errors
+      }
       reportedConnectionsRef.current.delete(connectionId);
       removeConnection(connectionId);
     },

--- a/libraries/typescript/packages/inspector/src/client/components/InspectorDashboard.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/InspectorDashboard.tsx
@@ -14,7 +14,12 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/client/components/ui/tooltip";
-import { MCPServerAddedEvent, Telemetry } from "@/client/telemetry";
+import {
+  MCPServerAddedEvent,
+  MCPServerConnectionEvent,
+  MCPServerRemovedEvent,
+  Telemetry,
+} from "@/client/telemetry";
 import {
   CircleMinus,
   Copy,
@@ -74,6 +79,52 @@ export function InspectorDashboard() {
     updateServerMetadata,
     updateServer,
   } = useMcpClient();
+
+  // Track which server connections have been reported to telemetry (dedup)
+  const reportedConnectionsRef = useRef<Set<string>>(new Set());
+
+  // Track server connection state transitions for telemetry
+  useEffect(() => {
+    connections.forEach((connection) => {
+      if (
+        connection.state === "ready" &&
+        !reportedConnectionsRef.current.has(connection.id)
+      ) {
+        reportedConnectionsRef.current.add(connection.id);
+        try {
+          Telemetry.getInstance()
+            .capture(
+              new MCPServerConnectionEvent({
+                serverId: connection.id,
+                serverUrl: connection.url,
+                success: true,
+                connectionType: "http",
+              })
+            )
+            .catch(() => {});
+        } catch {}
+      } else if (
+        connection.state === "failed" &&
+        reportedConnectionsRef.current.has(connection.id)
+      ) {
+        reportedConnectionsRef.current.delete(connection.id);
+      }
+    });
+  }, [connections]);
+
+  // Wrapper to track server removal in telemetry
+  const handleRemoveConnection = useCallback(
+    (connectionId: string) => {
+      try {
+        Telemetry.getInstance()
+          .capture(new MCPServerRemovedEvent({ serverId: connectionId }))
+          .catch(() => {});
+      } catch {}
+      reportedConnectionsRef.current.delete(connectionId);
+      removeConnection(connectionId);
+    },
+    [removeConnection]
+  );
 
   // Track concurrent updates to prevent race conditions
   const [updatingConnections, setUpdatingConnections] = useState<Set<string>>(
@@ -412,7 +463,7 @@ export function InspectorDashboard() {
   const handleClearAllConnections = () => {
     // Remove all connections
     connections.forEach((connection) => {
-      removeConnection(connection.id);
+      handleRemoveConnection(connection.id);
     });
   };
 
@@ -856,7 +907,7 @@ export function InspectorDashboard() {
                             size="sm"
                             onClick={(e) =>
                               handleActionClick(e, () =>
-                                removeConnection(connection.id)
+                                handleRemoveConnection(connection.id)
                               )
                             }
                             className="h-8 w-8 p-0"
@@ -961,7 +1012,7 @@ export function InspectorDashboard() {
                           <DropdownMenuItem
                             onClick={(e) => {
                               e.stopPropagation();
-                              removeConnection(connection.id);
+                              handleRemoveConnection(connection.id);
                             }}
                             className="text-destructive focus:text-destructive"
                           >

--- a/libraries/typescript/packages/inspector/src/client/components/Layout.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/Layout.tsx
@@ -8,7 +8,12 @@ import {
 import { useAutoConnect } from "@/client/hooks/useAutoConnect";
 import { useKeyboardShortcuts } from "@/client/hooks/useKeyboardShortcuts";
 import { useSavedRequests } from "@/client/hooks/useSavedRequests";
-import { MCPCommandPaletteOpenEvent, Telemetry } from "@/client/telemetry";
+import {
+  MCPCommandPaletteOpenEvent,
+  MCPTabNavigationEvent,
+  MCPSessionDurationEvent,
+  Telemetry,
+} from "@/client/telemetry";
 import {
   getStoredConnectionConfig,
   isAliasOnlyConnectionUpdate,
@@ -173,9 +178,59 @@ export function Layout({ children }: LayoutProps) {
     }
   }, [location.search, setActiveTab]);
 
+  // Tab navigation telemetry
+  const previousTabRef = useRef<string | null>(null);
+
+  // Session duration tracking
+  const sessionStartRef = useRef<number>(Date.now());
+  const tabsVisitedRef = useRef<Set<string>>(new Set());
+  const toolsExecutedRef = useRef<number>(0);
+
+  useEffect(() => {
+    const handler = () => {
+      toolsExecutedRef.current++;
+    };
+    window.addEventListener("mcp-tool-executed", handler);
+    return () => window.removeEventListener("mcp-tool-executed", handler);
+  }, []);
+
+  useEffect(() => {
+    const handleBeforeUnload = () => {
+      try {
+        const durationSeconds = Math.round(
+          (Date.now() - sessionStartRef.current) / 1000
+        );
+        Telemetry.getInstance()
+          .capture(
+            new MCPSessionDurationEvent({
+              durationSeconds,
+              tabsVisited: tabsVisitedRef.current.size,
+              toolsExecuted: toolsExecutedRef.current,
+            })
+          )
+          .catch(() => {});
+      } catch {}
+    };
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, []);
+
   // Sync the URL ?tab= param whenever the active tab changes
   const handleTabChange = useCallback(
     (tab: TabType) => {
+      try {
+        Telemetry.getInstance()
+          .capture(
+            new MCPTabNavigationEvent({
+              tab,
+              previousTab: previousTabRef.current,
+            })
+          )
+          .catch(() => {});
+      } catch {}
+      previousTabRef.current = tab;
+      tabsVisitedRef.current.add(tab);
+
       setActiveTab(tab);
       const params = new URLSearchParams(location.search);
       params.set("tab", tab);

--- a/libraries/typescript/packages/inspector/src/client/components/Layout.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/Layout.tsx
@@ -209,7 +209,9 @@ export function Layout({ children }: LayoutProps) {
             })
           )
           .catch(() => {});
-      } catch {}
+      } catch {
+        // ignore telemetry errors
+      }
     };
     window.addEventListener("beforeunload", handleBeforeUnload);
     return () => window.removeEventListener("beforeunload", handleBeforeUnload);
@@ -227,7 +229,9 @@ export function Layout({ children }: LayoutProps) {
             })
           )
           .catch(() => {});
-      } catch {}
+      } catch {
+        // ignore telemetry errors
+      }
       previousTabRef.current = tab;
       tabsVisitedRef.current.add(tab);
 

--- a/libraries/typescript/packages/inspector/src/client/components/LayoutHeader.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/LayoutHeader.tsx
@@ -376,7 +376,9 @@ function TunnelBadge({
       Telemetry.getInstance()
         .capture(new MCPTunnelActionEvent({ action: "start", success }))
         .catch(() => {});
-    } catch {}
+    } catch {
+      // ignore telemetry errors
+    }
   };
 
   const handleStopTunnel = async () => {
@@ -412,7 +414,9 @@ function TunnelBadge({
           })
         )
         .catch(() => {});
-    } catch {}
+    } catch {
+      // ignore telemetry errors
+    }
   };
 
   if (isTunnelStarting) {
@@ -770,7 +774,9 @@ export function LayoutHeader({
                           })
                         )
                         .catch(() => {});
-                    } catch {}
+                    } catch {
+                      // ignore telemetry errors
+                    }
                   }}
                 >
                   <Rocket className="size-4" />
@@ -1109,7 +1115,9 @@ export function LayoutHeader({
                         })
                       )
                       .catch(() => {});
-                  } catch {}
+                  } catch {
+                    // ignore telemetry errors
+                  }
                 }}
               >
                 <Rocket className="size-4" />

--- a/libraries/typescript/packages/inspector/src/client/components/LayoutHeader.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/LayoutHeader.tsx
@@ -11,12 +11,25 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/client/components/ui/tooltip";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@/client/components/ui/dropdown-menu";
 import type { TabType } from "@/client/context/InspectorContext";
 import { useInspector } from "@/client/context/InspectorContext";
 import { cn } from "@/client/lib/utils";
 import {
   ArrowUpRight,
   Bell,
+  Bug,
   Check,
   CheckSquare,
   ChevronDown,
@@ -30,8 +43,13 @@ import {
   Loader2,
   MessageCircle,
   MessageSquare,
+  Monitor,
+  Moon,
   Plus,
+  Rocket,
+  Settings,
   Square,
+  SunDim,
   Wrench,
 } from "lucide-react";
 import { INSPECTOR_RECONNECT_STORAGE_KEY } from "@/client/hooks/useAutoConnect";
@@ -41,11 +59,16 @@ import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { getServerDisplayName } from "@/client/utils/serverNames";
 import { copyToClipboard } from "@/client/utils/clipboard";
+import { useTheme } from "@/client/context/ThemeContext";
+import {
+  MCPTunnelActionEvent,
+  MCPDeployClickEvent,
+  Telemetry,
+} from "@/client/telemetry";
 import { AddToClientDropdown } from "./AddToClientDropdown";
 import LogoAnimated from "./LogoAnimated";
 import { SdkIntegrationModal } from "./SdkIntegrationModal";
 import { ServerDropdown } from "./ServerDropdown";
-import { ThemeToggle } from "./ThemeToggle";
 
 // Type alias for backward compatibility
 type MCPConnection = McpServer;
@@ -62,14 +85,15 @@ interface LayoutHeaderProps {
 }
 
 const tabs = [
+  { id: "chat", label: "Chat", icon: MessageCircle, alwaysExpanded: true },
+  { id: "separator" },
   { id: "tools", label: "Tools", icon: Wrench },
   { id: "prompts", label: "Prompts", icon: MessageSquare },
   { id: "resources", label: "Resources", icon: FolderOpen },
   { id: "sampling", label: "Sampling", icon: Hash },
   { id: "elicitation", label: "Elicitation", icon: CheckSquare },
   { id: "notifications", label: "Notifications", icon: Bell },
-  { id: "chat", label: "Chat", icon: MessageCircle },
-];
+] as const;
 
 function getTabCount(tabId: string, server: MCPConnection): number {
   if (tabId === "tools") {
@@ -330,6 +354,7 @@ function TunnelBadge({
     }
     setTunnelPhaseMessage(TUNNEL_PHASE.starting);
     setIsTunnelStarting(true);
+    let success = false;
     try {
       const res = await fetch("/inspector/api/dev/start-tunnel", {
         method: "POST",
@@ -342,15 +367,22 @@ function TunnelBadge({
       }
       // Server is restarting — poll until the new instance with tunnel is up
       await pollAndReconnect(true);
+      success = true;
     } catch {
       toast.error("Failed to start tunnel");
       setIsTunnelStarting(false);
     }
+    try {
+      Telemetry.getInstance()
+        .capture(new MCPTunnelActionEvent({ action: "start", success }))
+        .catch(() => {});
+    } catch {}
   };
 
   const handleStopTunnel = async () => {
     setTunnelPhaseMessage(TUNNEL_PHASE.stopping);
     setIsTunnelStarting(true);
+    let success = false;
     try {
       const res = await fetch("/inspector/api/dev/stop-tunnel", {
         method: "POST",
@@ -365,20 +397,32 @@ function TunnelBadge({
       setPopoverOpen(false);
       // Server is restarting — poll until the new instance without tunnel is up
       await pollAndReconnect(false);
+      success = true;
     } catch {
       toast.error("Failed to stop tunnel");
       setIsTunnelStarting(false);
     }
+    try {
+      Telemetry.getInstance()
+        .capture(
+          new MCPTunnelActionEvent({
+            action: "stop",
+            success,
+            tunnelUrl: tunnelUrl,
+          })
+        )
+        .catch(() => {});
+    } catch {}
   };
 
   if (isTunnelStarting) {
     return (
       <button
         disabled
-        className="flex items-center gap-2 h-9 px-3 bg-zinc-100 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded-full opacity-75 cursor-wait"
+        className="flex items-center gap-2 h-9 px-3 bg-violet-50 dark:bg-violet-950/40 border border-violet-200 dark:border-violet-800 rounded-full opacity-75 cursor-wait"
       >
-        <Loader2 className="size-4 text-zinc-500 dark:text-zinc-400 animate-spin" />
-        <span className="text-sm font-medium text-zinc-600 dark:text-zinc-300 hidden lg:inline">
+        <Loader2 className="size-4 text-violet-500 dark:text-violet-400 animate-spin" />
+        <span className="text-sm font-medium text-violet-600 dark:text-violet-300 hidden lg:inline">
           Start Tunnel <span className="tabular-nums">{waitTicks}s</span>
         </span>
       </button>
@@ -403,16 +447,16 @@ function TunnelBadge({
         className={cn(
           "flex items-center gap-2 h-9 px-3 border rounded-full transition-colors",
           canStart && !loadingDev
-            ? "bg-zinc-100 dark:bg-zinc-800 border-zinc-200 dark:border-zinc-700 hover:bg-zinc-200 dark:hover:bg-zinc-700 cursor-pointer"
-            : "bg-zinc-100/60 dark:bg-zinc-800/60 border-zinc-200 dark:border-zinc-700 cursor-not-allowed opacity-70"
+            ? "bg-violet-50 dark:bg-violet-950/40 border-violet-200 dark:border-violet-800 hover:bg-violet-100 dark:hover:bg-violet-900/50 cursor-pointer"
+            : "bg-violet-50/60 dark:bg-violet-950/20 border-violet-200 dark:border-violet-800 cursor-not-allowed opacity-70"
         )}
       >
         {loadingDev ? (
-          <Loader2 className="size-4 text-zinc-500 dark:text-zinc-400 animate-spin" />
+          <Loader2 className="size-4 text-violet-500 dark:text-violet-400 animate-spin" />
         ) : (
-          <ChevronsLeftRightEllipsis className="size-4 text-zinc-500 dark:text-zinc-400" />
+          <ChevronsLeftRightEllipsis className="size-4 text-violet-500 dark:text-violet-400" />
         )}
-        <span className="text-sm font-medium text-zinc-600 dark:text-zinc-300 hidden lg:inline">
+        <span className="text-sm font-medium text-violet-600 dark:text-violet-300 hidden lg:inline">
           Start Tunnel
         </span>
       </button>
@@ -539,6 +583,7 @@ export function LayoutHeader({
     setIsTunnelStarting,
     embeddedConfig,
   } = useInspector();
+  const { theme, setTheme } = useTheme();
   const showTunnelBadge =
     !!selectedServer &&
     (isLocalhostServerUrl(selectedServer.url) ||
@@ -557,7 +602,11 @@ export function LayoutHeader({
 
   // Filter tabs based on visibleTabs config
   const filteredTabs = embeddedConfig.visibleTabs
-    ? tabs.filter((t) => embeddedConfig.visibleTabs!.includes(t.id as TabType))
+    ? tabs.filter(
+        (t) =>
+          t.id === "separator" ||
+          embeddedConfig.visibleTabs!.includes(t.id as TabType)
+      )
     : tabs;
 
   const handleCopy = async () => {
@@ -691,25 +740,110 @@ export function LayoutHeader({
                     </>
                   );
                 })()}
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button variant="ghost" size="sm" asChild>
+              {/* Tunnel Badge - Mobile */}
+              {showTunnelBadge && (
+                <TunnelBadge
+                  tunnelUrl={tunnelUrl}
+                  isTunnelStarting={isTunnelStarting}
+                  setTunnelUrl={setTunnelUrl}
+                  setIsTunnelStarting={setIsTunnelStarting}
+                  copied={copied}
+                  setCopied={setCopied}
+                  handleCopy={handleCopy}
+                />
+              )}
+              <Button
+                asChild
+                size="sm"
+                className="rounded-full bg-blue-600 hover:bg-blue-700 text-white px-3"
+              >
+                <a
+                  href="https://manufact.com/signup?ref=mcp-use-inspector"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={() => {
+                    try {
+                      Telemetry.getInstance()
+                        .capture(
+                          new MCPDeployClickEvent({
+                            referrer: "mcp-use-inspector",
+                          })
+                        )
+                        .catch(() => {});
+                    } catch {}
+                  }}
+                >
+                  <Rocket className="size-4" />
+                </a>
+              </Button>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="p-2 hover:bg-zinc-200 dark:hover:bg-zinc-800 rounded-full transition-colors"
+                    aria-label="Settings"
+                  >
+                    <Settings className="size-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-48">
+                  <DropdownMenuSub>
+                    <DropdownMenuSubTrigger>
+                      {theme === "light" ? (
+                        <SunDim className="size-4 mr-2" />
+                      ) : theme === "dark" ? (
+                        <Moon className="size-4 mr-2" />
+                      ) : (
+                        <Monitor className="size-4 mr-2" />
+                      )}
+                      Theme
+                    </DropdownMenuSubTrigger>
+                    <DropdownMenuSubContent>
+                      <DropdownMenuRadioGroup
+                        value={theme}
+                        onValueChange={(v) =>
+                          setTheme(v as "light" | "dark" | "system")
+                        }
+                      >
+                        <DropdownMenuRadioItem value="light">
+                          <SunDim className="size-4 mr-2" />
+                          Light
+                        </DropdownMenuRadioItem>
+                        <DropdownMenuRadioItem value="dark">
+                          <Moon className="size-4 mr-2" />
+                          Dark
+                        </DropdownMenuRadioItem>
+                        <DropdownMenuRadioItem value="system">
+                          <Monitor className="size-4 mr-2" />
+                          System
+                        </DropdownMenuRadioItem>
+                      </DropdownMenuRadioGroup>
+                    </DropdownMenuSubContent>
+                  </DropdownMenuSub>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem asChild>
                     <a
                       href="https://github.com/mcp-use/mcp-use"
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="p-2"
-                      aria-label="GitHub"
                     >
-                      <GithubIcon className="h-4 w-4" />
+                      <GithubIcon className="h-4 w-4 mr-2" />
+                      GitHub
                     </a>
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <p>Give us a star ⭐</p>
-                </TooltipContent>
-              </Tooltip>
-              <ThemeToggle />
+                  </DropdownMenuItem>
+                  <DropdownMenuItem asChild>
+                    <a
+                      href="https://github.com/mcp-use/mcp-use/issues/new?labels=inspector&template=bug_report.md&title=%5BInspector%5D+"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <Bug className="size-4 mr-2" />
+                      Report a Bug
+                    </a>
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
             </div>
           )}
         </div>
@@ -725,6 +859,14 @@ export function LayoutHeader({
             >
               <TabsList className="w-full justify-center">
                 {filteredTabs.map((tab) => {
+                  if (tab.id === "separator") {
+                    return (
+                      <div
+                        key="separator"
+                        className="h-5 w-px bg-zinc-300 dark:bg-zinc-600 mx-1 shrink-0"
+                      />
+                    );
+                  }
                   const count = getTabCount(tab.id, selectedServer);
                   const showDot = shouldShowDot(tab.id, count, collapsed);
 
@@ -735,6 +877,9 @@ export function LayoutHeader({
                       data-testid={`tab-${tab.id}`}
                       icon={tab.icon}
                       showDot={showDot}
+                      alwaysExpanded={
+                        "alwaysExpanded" in tab && tab.alwaysExpanded
+                      }
                       className={cn(
                         "[&>svg]:mr-0 flex-1 flex-row gap-2 relative",
                         collapsed && "pl-2"
@@ -787,6 +932,14 @@ export function LayoutHeader({
               >
                 <TabsList className="overflow-x-auto" collapsible>
                   {filteredTabs.map((tab) => {
+                    if (tab.id === "separator") {
+                      return (
+                        <div
+                          key="separator"
+                          className="h-5 w-px bg-zinc-300 dark:bg-zinc-600 mx-1 shrink-0"
+                        />
+                      );
+                    }
                     const count = getTabCount(tab.id, selectedServer);
                     const tooltipText =
                       count > 0 ? `${tab.label} (${count})` : tab.label;
@@ -794,10 +947,14 @@ export function LayoutHeader({
 
                     return (
                       <TabsTrigger
+                        key={tab.id}
                         value={tab.id}
                         data-testid={`tab-${tab.id}`}
                         icon={tab.icon}
                         showDot={showDot}
+                        alwaysExpanded={
+                          "alwaysExpanded" in tab && tab.alwaysExpanded
+                        }
                         className={cn(
                           "[&>svg]:mr-0 lg:[&>svg]:mr-2 relative",
                           collapsed && "pl-4"
@@ -835,18 +992,6 @@ export function LayoutHeader({
         {/* Right side: Tunnel Badge + Add to Client + Theme Toggle + Command Palette + GitHub Button + Logo - Hidden in embedded mode */}
         {!embedded && (
           <div className="flex items-center gap-2 sm:gap-4 flex-shrink-0">
-            {/* Tunnel Badge */}
-            {showTunnelBadge && (
-              <TunnelBadge
-                tunnelUrl={tunnelUrl}
-                isTunnelStarting={isTunnelStarting}
-                setTunnelUrl={setTunnelUrl}
-                setIsTunnelStarting={setIsTunnelStarting}
-                copied={copied}
-                setCopied={setCopied}
-                handleCopy={handleCopy}
-              />
-            )}
             {selectedServer &&
               (() => {
                 const displayName = getServerDisplayName(selectedServer);
@@ -935,43 +1080,120 @@ export function LayoutHeader({
                   </>
                 );
               })()}
-            <ThemeToggle />
-            <Tooltip>
-              <TooltipTrigger asChild>
+            {/* Tunnel Badge */}
+            {showTunnelBadge && (
+              <TunnelBadge
+                tunnelUrl={tunnelUrl}
+                isTunnelStarting={isTunnelStarting}
+                setTunnelUrl={setTunnelUrl}
+                setIsTunnelStarting={setIsTunnelStarting}
+                copied={copied}
+                setCopied={setCopied}
+                handleCopy={handleCopy}
+              />
+            )}
+            <Button
+              asChild
+              className="rounded-full bg-blue-600 hover:bg-blue-700 text-white px-4"
+            >
+              <a
+                href="https://manufact.com/signup?ref=mcp-use-inspector"
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => {
+                  try {
+                    Telemetry.getInstance()
+                      .capture(
+                        new MCPDeployClickEvent({
+                          referrer: "mcp-use-inspector",
+                        })
+                      )
+                      .catch(() => {});
+                  } catch {}
+                }}
+              >
+                <Rocket className="size-4" />
+                <span className="hidden sm:inline">Deploy</span>
+              </a>
+            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
                 <Button
                   variant="ghost"
-                  className="hover:bg-zinc-200 dark:hover:bg-zinc-800 rounded-full px-1 -mx-3 flex gap-1"
+                  size="sm"
+                  className="p-2 hover:bg-zinc-200 dark:hover:bg-zinc-800 rounded-full transition-colors"
+                  aria-label="Settings"
+                >
+                  <Settings className="size-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-48">
+                <DropdownMenuItem
                   onClick={onCommandPaletteOpen}
                   data-testid="command-palette-trigger-button"
                 >
-                  <Command className="size-4" />
-                  <span className="text-base font-mono hidden sm:inline">
-                    K
+                  <Command className="size-4 mr-2" />
+                  Command Palette
+                  <span className="ml-auto text-xs text-muted-foreground">
+                    {"\u2318"}K
                   </span>
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>
-                <p>Command Palette</p>
-              </TooltipContent>
-            </Tooltip>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button variant="ghost" size="sm" asChild>
+                </DropdownMenuItem>
+                <DropdownMenuSub>
+                  <DropdownMenuSubTrigger>
+                    {theme === "light" ? (
+                      <SunDim className="size-4 mr-2" />
+                    ) : theme === "dark" ? (
+                      <Moon className="size-4 mr-2" />
+                    ) : (
+                      <Monitor className="size-4 mr-2" />
+                    )}
+                    Theme
+                  </DropdownMenuSubTrigger>
+                  <DropdownMenuSubContent>
+                    <DropdownMenuRadioGroup
+                      value={theme}
+                      onValueChange={(v) =>
+                        setTheme(v as "light" | "dark" | "system")
+                      }
+                    >
+                      <DropdownMenuRadioItem value="light">
+                        <SunDim className="size-4 mr-2" />
+                        Light
+                      </DropdownMenuRadioItem>
+                      <DropdownMenuRadioItem value="dark">
+                        <Moon className="size-4 mr-2" />
+                        Dark
+                      </DropdownMenuRadioItem>
+                      <DropdownMenuRadioItem value="system">
+                        <Monitor className="size-4 mr-2" />
+                        System
+                      </DropdownMenuRadioItem>
+                    </DropdownMenuRadioGroup>
+                  </DropdownMenuSubContent>
+                </DropdownMenuSub>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem asChild>
                   <a
                     href="https://github.com/mcp-use/mcp-use"
-                    className="flex items-center gap-2"
                     target="_blank"
                     rel="noopener noreferrer"
                   >
-                    <GithubIcon className="h-4 w-4" />
-                    <span className="hidden xl:inline">Github</span>
+                    <GithubIcon className="h-4 w-4 mr-2" />
+                    GitHub
                   </a>
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>
-                <p>Give us a star ⭐</p>
-              </TooltipContent>
-            </Tooltip>
+                </DropdownMenuItem>
+                <DropdownMenuItem asChild>
+                  <a
+                    href="https://github.com/mcp-use/mcp-use/issues/new?labels=inspector&template=bug_report.md&title=%5BInspector%5D+"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <Bug className="size-4 mr-2" />
+                    Report a Bug
+                  </a>
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
 
             <LogoAnimated state="expanded" />
           </div>

--- a/libraries/typescript/packages/inspector/src/client/components/ToolsTab.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ToolsTab.tsx
@@ -758,6 +758,7 @@ export function ToolsTab({
         .catch(() => {
           // Silently fail - telemetry should not break the application
         });
+      window.dispatchEvent(new Event("mcp-tool-executed"));
 
       // Widget resource was already fetched before tool execution (if applicable)
       // Now we just need to update the result with tool output
@@ -865,6 +866,7 @@ export function ToolsTab({
         .catch(() => {
           // Silently fail - telemetry should not break the application
         });
+      window.dispatchEvent(new Event("mcp-tool-executed"));
 
       const toolMeta =
         (selectedTool as any)?._meta || (selectedTool as any)?.metadata;

--- a/libraries/typescript/packages/inspector/src/client/components/chat/useConfig.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/useConfig.ts
@@ -184,7 +184,9 @@ export function useConfig({ mcpServerUrl }: UseConfigProps) {
           })
         )
         .catch(() => {});
-    } catch {}
+    } catch {
+      // ignore telemetry errors
+    }
 
     setConfigDialogOpen(false);
   }, [

--- a/libraries/typescript/packages/inspector/src/client/components/chat/useConfig.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/useConfig.ts
@@ -1,3 +1,4 @@
+import { MCPChatConfiguredEvent, Telemetry } from "@/client/telemetry";
 import { useCallback, useEffect, useState } from "react";
 import type { AuthConfig, LLMConfig } from "./types";
 import { DEFAULT_MODELS } from "./types";
@@ -172,6 +173,18 @@ export function useConfig({ mcpServerUrl }: UseConfigProps) {
 
     // Dispatch custom event to notify other components
     window.dispatchEvent(new CustomEvent("llm-config-updated"));
+
+    // Track chat configuration (no API key)
+    try {
+      Telemetry.getInstance()
+        .capture(
+          new MCPChatConfiguredEvent({
+            provider: tempProvider,
+            model: tempModel,
+          })
+        )
+        .catch(() => {});
+    } catch {}
 
     setConfigDialogOpen(false);
   }, [

--- a/libraries/typescript/packages/inspector/src/client/components/ui/tabs.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ui/tabs.tsx
@@ -277,6 +277,8 @@ interface TabsTriggerProps {
   icon?: LucideIcon;
   title?: string;
   showDot?: boolean;
+  /** When true, the label stays visible even when the tab bar is collapsed */
+  alwaysExpanded?: boolean;
 }
 
 // conditional tooltip wrapper if collapsed
@@ -325,6 +327,7 @@ const TabsTrigger = React.forwardRef<
       icon: Icon,
       title: titleProp,
       showDot = false,
+      alwaysExpanded = false,
       ...props
     },
     ref
@@ -334,11 +337,17 @@ const TabsTrigger = React.forwardRef<
     const variant = tabsListContext?.variant || "default";
     const isActive = activeValue === value;
 
+    // A tab's label is visible when: not collapsed, or it's the active tab, or alwaysExpanded
+    const showLabel = !collapsed || isActive || alwaysExpanded;
+
     // Use title prop when provided (for collapsed mode tooltips)
-    const title = collapsed && titleProp ? titleProp : undefined;
+    const title = collapsed && !showLabel && titleProp ? titleProp : undefined;
 
     return (
-      <ConditionalTooltip title={titleProp as string} collapsed={collapsed}>
+      <ConditionalTooltip
+        title={titleProp as string}
+        collapsed={collapsed && !showLabel}
+      >
         <button
           ref={ref}
           disabled={disabled}
@@ -352,7 +361,6 @@ const TabsTrigger = React.forwardRef<
             "relative z-10 flex-1 inline-flex items-center justify-center whitespace-nowrap text-sm font-medium ring-offset-background transition-all duration-500 ease-in-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 cursor-pointer",
             variant === "default" && "py-2.5",
             variant === "default" && "rounded-md px-4",
-            // variant === "default" && collapsed && "rounded-md px-1.5 aspect-square",
             variant === "underline" &&
               "px-6 py-3 border-b-2 border-transparent",
             isActive && "text-foreground",
@@ -365,8 +373,8 @@ const TabsTrigger = React.forwardRef<
             <Icon
               className={cn(
                 "h-4 w-4 transition-all duration-500 ease-in-out",
-                !collapsed && "mr-2",
-                collapsed && "mr-0!"
+                showLabel && "mr-2",
+                !showLabel && "mr-0!"
               )}
             />
           )}
@@ -376,7 +384,7 @@ const TabsTrigger = React.forwardRef<
           <span
             className={cn(
               "transition-all duration-500 ease-in-out overflow-hidden",
-              collapsed ? "w-0 opacity-0" : "w-auto opacity-100"
+              showLabel ? "w-auto opacity-100" : "w-0 opacity-0"
             )}
           >
             {children}

--- a/libraries/typescript/packages/inspector/src/client/telemetry/events.ts
+++ b/libraries/typescript/packages/inspector/src/client/telemetry/events.ts
@@ -206,3 +206,105 @@ export class MCPToolSavedEvent implements BaseTelemetryEvent {
     };
   }
 }
+
+export interface MCPTunnelActionEventData {
+  action: "start" | "stop";
+  success: boolean;
+  tunnelUrl?: string | null;
+}
+
+export class MCPTunnelActionEvent implements BaseTelemetryEvent {
+  name = "mcp_tunnel_action";
+  properties: Record<string, any>;
+
+  constructor(data: MCPTunnelActionEventData) {
+    this.properties = {
+      action: data.action,
+      success: data.success,
+      tunnel_url: data.tunnelUrl,
+    };
+  }
+}
+
+export interface MCPDeployClickEventData {
+  referrer: string;
+}
+
+export class MCPDeployClickEvent implements BaseTelemetryEvent {
+  name = "mcp_deploy_click";
+  properties: Record<string, any>;
+
+  constructor(data: MCPDeployClickEventData) {
+    this.properties = {
+      referrer: data.referrer,
+    };
+  }
+}
+
+export interface MCPChatConfiguredEventData {
+  provider: string;
+  model: string;
+}
+
+export class MCPChatConfiguredEvent implements BaseTelemetryEvent {
+  name = "mcp_chat_configured";
+  properties: Record<string, any>;
+
+  constructor(data: MCPChatConfiguredEventData) {
+    this.properties = {
+      provider: data.provider,
+      model: data.model,
+    };
+  }
+}
+
+export interface MCPTabNavigationEventData {
+  tab: string;
+  previousTab: string | null;
+}
+
+export class MCPTabNavigationEvent implements BaseTelemetryEvent {
+  name = "mcp_tab_navigation";
+  properties: Record<string, any>;
+
+  constructor(data: MCPTabNavigationEventData) {
+    this.properties = {
+      tab: data.tab,
+      previous_tab: data.previousTab,
+    };
+  }
+}
+
+export interface MCPAddToClientEventData {
+  client: string;
+}
+
+export class MCPAddToClientEvent implements BaseTelemetryEvent {
+  name = "mcp_add_to_client";
+  properties: Record<string, any>;
+
+  constructor(data: MCPAddToClientEventData) {
+    this.properties = {
+      client: data.client,
+    };
+  }
+}
+
+export interface MCPSessionDurationEventData {
+  durationSeconds: number;
+  tabsVisited: number;
+  toolsExecuted: number;
+}
+
+export class MCPSessionDurationEvent implements BaseTelemetryEvent {
+  name = "mcp_session_duration";
+  properties: Record<string, any>;
+
+  constructor(data: MCPSessionDurationEventData) {
+    this.properties = {
+      duration_seconds: data.durationSeconds,
+      tabs_visited: data.tabsVisited,
+      tools_executed: data.toolsExecuted,
+    };
+  }
+}

--- a/libraries/typescript/packages/inspector/src/client/telemetry/telemetry.ts
+++ b/libraries/typescript/packages/inspector/src/client/telemetry/telemetry.ts
@@ -49,6 +49,28 @@ function getCacheKey(key: string): string {
   return `mcp_inspector_telemetry_${key}`;
 }
 
+export type InspectorMode = "standalone" | "embedded" | "cloud";
+
+/**
+ * Detect the inspector deployment mode from the runtime config injected by the
+ * server (see shared-static.ts's `injectRuntimeConfig`). Defaults to
+ * "standalone" when no mode has been injected (e.g. when the inspector dev
+ * server serves via the Vite proxy and no runtime scripts are present).
+ */
+function detectInspectorMode(): InspectorMode {
+  if (typeof window === "undefined") return "standalone";
+  const injected = (window as unknown as { __MCP_INSPECTOR_MODE__?: string })
+    .__MCP_INSPECTOR_MODE__;
+  if (
+    injected === "standalone" ||
+    injected === "embedded" ||
+    injected === "cloud"
+  ) {
+    return injected;
+  }
+  return "standalone";
+}
+
 /**
  * Check if localStorage is available and functional.
  * Node.js 25+ has an experimental localStorage that exists but doesn't implement methods properly.
@@ -72,6 +94,7 @@ export class Telemetry {
   private _posthogClient: TelemetryEventLogger | null = null;
   private _scarfClient: TelemetryEventLogger | null = null;
   private _source: string = "inspector";
+  private _mode: InspectorMode = "standalone";
 
   private constructor() {
     // Check if we're in a browser environment first
@@ -82,6 +105,10 @@ export class Telemetry {
 
     // Check for source from localStorage or default to 'inspector'
     this._source = this.getStoredSource() || "inspector";
+
+    // Deployment mode is injected by the server into window; fixed for the
+    // lifetime of the page, so we capture it once here.
+    this._mode = detectInspectorMode();
 
     if (telemetryDisabled) {
       this._posthogClient = null;
@@ -161,6 +188,14 @@ export class Telemetry {
    */
   getSource(): string {
     return this._source;
+  }
+
+  /**
+   * Get the inspector's deployment mode (standalone CLI, embedded in mcp-use,
+   * or cloud-hosted). Emitted with every telemetry event.
+   */
+  getMode(): InspectorMode {
+    return this._mode;
   }
 
   get userId(): string {
@@ -248,7 +283,7 @@ export class Telemetry {
     // Send to PostHog proxy
     if (this._posthogClient) {
       try {
-        // Add package version, language flag, source, and user_id to all events
+        // Add package version, language flag, source, mode, and user_id to all events
         const properties: Record<string, any> = {
           event: event.name,
           user_id: this.userId, // Include user_id for distinct_id
@@ -258,6 +293,7 @@ export class Telemetry {
             language: "typescript",
             source: this._source,
             package: "inspector",
+            mode: this._mode,
           },
         };
 
@@ -270,7 +306,7 @@ export class Telemetry {
     // Send to Scarf proxy
     if (this._scarfClient) {
       try {
-        // Add package version, user_id, language flag, and source to all events
+        // Add package version, user_id, language flag, source, and mode to all events
         const properties: Record<string, any> = {};
         properties.mcp_use_version = getPackageVersion();
         properties.user_id = this.userId;
@@ -278,6 +314,7 @@ export class Telemetry {
         properties.language = "typescript";
         properties.source = this._source;
         properties.package = "inspector";
+        properties.mode = this._mode;
 
         await this._scarfClient.logEvent(properties);
       } catch {
@@ -333,6 +370,7 @@ export class Telemetry {
         eventProperties.language = "typescript";
         eventProperties.source = this._source;
         eventProperties.package = "inspector";
+        eventProperties.mode = this._mode;
 
         await this._scarfClient.logEvent(eventProperties);
       }

--- a/libraries/typescript/packages/inspector/src/server/cli.ts
+++ b/libraries/typescript/packages/inspector/src/server/cli.ts
@@ -6,6 +6,7 @@ import { cors } from "hono/cors";
 import { logger } from "hono/logger";
 import open from "open";
 import { registerInspectorRoutes } from "./shared-routes.js";
+import type { InspectorMode } from "./shared-static.js";
 import { registerStaticRoutes } from "./shared-static.js";
 import { setServerPort } from "./tunnel.js";
 import { findAvailablePort, isValidUrl } from "./utils.js";
@@ -80,8 +81,17 @@ app.use("/inspector/api/proxy/*", logger());
 
 registerInspectorRoutes(app, { autoConnectUrl: mcpUrl });
 
+// Detect the deployment mode. The same CLI binary powers both local standalone
+// usage (`npx @mcp-use/inspector`) and the cloud-hosted Railway deployment at
+// inspector.mcpus.com — Railway sets RAILWAY_ENVIRONMENT_NAME, so we use that
+// as the primary cloud signal, with an explicit MCP_INSPECTOR_MODE override
+// for other hosted environments.
+const inspectorMode: InspectorMode =
+  (process.env.MCP_INSPECTOR_MODE as InspectorMode | undefined) ??
+  (process.env.RAILWAY_ENVIRONMENT_NAME ? "cloud" : "standalone");
+
 // Register static file serving (must be last as it includes catch-all route)
-registerStaticRoutes(app);
+registerStaticRoutes(app, undefined, { inspectorMode });
 
 // Start the server with automatic port selection
 async function startServer() {

--- a/libraries/typescript/packages/inspector/src/server/middleware.ts
+++ b/libraries/typescript/packages/inspector/src/server/middleware.ts
@@ -49,6 +49,7 @@ export function mountInspector(
   const runtimeConfig = {
     devMode: config?.devMode,
     sandboxOrigin: config?.sandboxOrigin,
+    inspectorMode: "embedded" as const,
   };
 
   // If it's already a Hono app, register routes directly

--- a/libraries/typescript/packages/inspector/src/server/shared-static.ts
+++ b/libraries/typescript/packages/inspector/src/server/shared-static.ts
@@ -28,6 +28,12 @@ const CDN_JS_URL = `${CDN_BASE}/inspector@${INSPECTOR_VERSION}.js`;
 const CDN_CSS_URL = `${CDN_BASE}/inspector@${INSPECTOR_VERSION}.css`;
 
 /**
+ * Inspector deployment mode. Identifies how the inspector is being served so the
+ * client can distinguish the three supported deployments.
+ */
+export type InspectorMode = "standalone" | "embedded" | "cloud";
+
+/**
  * Runtime configuration injected into the inspector HTML at serve time.
  */
 interface RuntimeConfig {
@@ -37,6 +43,8 @@ interface RuntimeConfig {
   sandboxOrigin?: string | null;
   /** Relative path to the MCP proxy (e.g. "/inspector/api/proxy"). When set, the client uses it for autoProxyFallback. Omit when the proxy is not available (e.g. Python server serving inspector). */
   proxyUrl?: string | null;
+  /** How the inspector is being served (standalone CLI, embedded in mcp-use, or cloud-hosted). Consumed by telemetry. */
+  inspectorMode?: InspectorMode;
 }
 
 /**
@@ -61,6 +69,12 @@ function injectRuntimeConfig(html: string, config?: RuntimeConfig): string {
   if (config.proxyUrl !== undefined) {
     scripts.push(
       `<script>window.__MCP_PROXY_URL__ = ${JSON.stringify(config.proxyUrl)};</script>`
+    );
+  }
+
+  if (config.inspectorMode) {
+    scripts.push(
+      `<script>window.__MCP_INSPECTOR_MODE__ = ${JSON.stringify(config.inspectorMode)};</script>`
     );
   }
 
@@ -91,6 +105,11 @@ function generateCdnShellHtml(config?: RuntimeConfig): string {
     if (config.proxyUrl !== undefined) {
       scripts.push(
         `<script>window.__MCP_PROXY_URL__ = ${JSON.stringify(config.proxyUrl)};</script>`
+      );
+    }
+    if (config.inspectorMode) {
+      scripts.push(
+        `<script>window.__MCP_INSPECTOR_MODE__ = ${JSON.stringify(config.inspectorMode)};</script>`
       );
     }
     return scripts.join("\n    ");


### PR DESCRIPTION
## Summary

- Improved inspector navbar with smart tab collapsing, Chat tab promoted to first position, and new Deploy/Tunnel buttons
- Consolidated theme toggle, command palette, and GitHub into a settings dropdown with a "Report a Bug" shortcut
- Added 6 new telemetry events and wired up 2 existing unused ones for better product analytics

## UI Changes

- **Chat tab** moved to first position with always-expanded label and visual separator
- **Active tab** label stays visible when navbar is collapsed (`alwaysExpanded` prop on `TabsTrigger`)
- **Deploy button** (blue, primary) linking to manufact.com/signup with `?ref=mcp-use-inspector`
- **Tunnel button** repositioned between Add to Client and Deploy, restyled with violet theme, now visible in mobile
- **Settings dropdown** consolidates: Command Palette (⌘K), Theme submenu (Light/Dark/System), GitHub, Report a Bug

## New Telemetry Events

| Event | Trigger | Properties |
|-------|---------|------------|
| `mcp_tunnel_action` | Tunnel start/stop | `action`, `success`, `tunnel_url` |
| `mcp_deploy_click` | Deploy button click | `referrer` |
| `mcp_chat_configured` | Chat API key setup | `provider`, `model` (no secrets) |
| `mcp_tab_navigation` | Tab switch | `tab`, `previous_tab` |
| `mcp_add_to_client` | Add to Client click | `client` |
| `mcp_session_duration` | Page unload | `duration_seconds`, `tabs_visited`, `tools_executed` |

Wired up 2 existing but previously uncaptured events: `mcp_server_connection` and `mcp_server_removed`.

## Testing

- Build: `cd libraries/typescript/packages/inspector && npm run build:client` ✅
- Verify events in browser Network tab → POST `/inspector/api/tel/posthog`
- Test: open inspector, switch tabs, click Deploy, configure chat, add to client, close tab

## Backwards Compatibility

Non-breaking. New telemetry events are additive. UI changes are visual only.