### PR TITLE
feat(inspector): inline elicitation requests in chat thread

### DIFF
--- a/libraries/typescript/.changeset/inline-elicitation-chat.md
+++ b/libraries/typescript/.changeset/inline-elicitation-chat.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": minor
+---
+
+Elicitation requests triggered from the Chat tab now appear inline in the chat thread instead of routing users to a separate Elicitation tab via a toast. When triggered from the Tools tab, the existing toast behaviour is preserved. The Elicitation tab remains available as a fallback/audit view.

--- a/libraries/typescript/packages/inspector/src/client/App.tsx
+++ b/libraries/typescript/packages/inspector/src/client/App.tsx
@@ -9,12 +9,28 @@ import {
   McpClientProvider,
   type McpServer,
 } from "mcp-use/react";
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { Route, BrowserRouter as Router, Routes } from "react-router";
 import { toast } from "sonner";
-import { InspectorProvider } from "./context/InspectorContext";
+import { InspectorProvider, useInspector } from "./context/InspectorContext";
 import { ThemeProvider } from "./context/ThemeContext";
 import { WidgetDebugProvider } from "./context/WidgetDebugContext";
+
+/**
+ * Syncs the active tab from InspectorContext into a ref readable by
+ * McpClientProvider callbacks defined outside the InspectorProvider tree.
+ */
+function InspectorTabSync({
+  activeTabRef,
+}: {
+  activeTabRef: React.MutableRefObject<string>;
+}) {
+  const { activeTab } = useInspector();
+  useEffect(() => {
+    activeTabRef.current = activeTab;
+  }, [activeTab, activeTabRef]);
+  return null;
+}
 
 /**
  * Root React component that configures application providers, routing, and toast-based handlers for sampling and elicitation requests in the inspector UI.
@@ -24,6 +40,8 @@ import { WidgetDebugProvider } from "./context/WidgetDebugContext";
  * @returns The app's React element tree.
  */
 function App() {
+  const activeTabRef = useRef<string>("tools");
+
   // Check if embedded mode is active from URL params
   const urlParams = new URLSearchParams(window.location.search);
   const isEmbedded = urlParams.get("embedded") === "true";
@@ -122,6 +140,11 @@ function App() {
             approve,
             reject
           ) => {
+            // When the chat tab is active, elicitation is rendered inline — no toast needed.
+            if (activeTabRef.current === "chat") {
+              return;
+            }
+
             const mode = request.request.mode || "form";
             const message = request.request.message;
             const url =
@@ -161,6 +184,7 @@ function App() {
           }}
         >
           <InspectorProvider>
+            <InspectorTabSync activeTabRef={activeTabRef} />
             <Router basename="/inspector">
               <Routes>
                 <Route path="/oauth/callback" element={<OAuthCallback />} />

--- a/libraries/typescript/packages/inspector/src/client/components/ChatTab.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ChatTab.tsx
@@ -884,6 +884,9 @@ export function ChatTab({
             tools={connection.tools}
             sendMessage={(msg, atts) => sendMessage(msg, [], atts)}
             serverBaseUrl={connection.url}
+            pendingElicitationRequests={connection.pendingElicitationRequests}
+            onApproveElicitation={connection.approveElicitation}
+            onRejectElicitation={connection.rejectElicitation}
           />
         )}
       </div>

--- a/libraries/typescript/packages/inspector/src/client/components/chat/InlineElicitationCard.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/InlineElicitationCard.tsx
@@ -1,0 +1,418 @@
+// libraries/typescript/packages/inspector/src/client/components/chat/InlineElicitationCard.tsx
+import { useState, useMemo, useEffect } from "react";
+import type { ElicitResult } from "@modelcontextprotocol/sdk/types.js";
+import type { PendingElicitationRequest } from "@/client/types/elicitation";
+import { Button } from "@/client/components/ui/button";
+import { Input } from "@/client/components/ui/input";
+import { Label } from "@/client/components/ui/label";
+import { Textarea } from "@/client/components/ui/textarea";
+import { Checkbox } from "@/client/components/ui/checkbox";
+import { Badge } from "@/client/components/ui/badge";
+import { ExternalLink } from "lucide-react";
+import { toast } from "sonner";
+
+interface InlineElicitationCardProps {
+  request: PendingElicitationRequest;
+  onApprove: (requestId: string, result: ElicitResult) => void;
+  onReject: (requestId: string, error?: string) => void;
+}
+
+interface EnumChoice {
+  const: string;
+  title?: string;
+}
+
+function isEnumChoice(value: unknown): value is EnumChoice {
+  if (!value || typeof value !== "object") return false;
+  const v = value as { const?: unknown; title?: unknown };
+  return (
+    typeof v.const === "string" &&
+    (v.title === undefined || typeof v.title === "string")
+  );
+}
+
+function getSingleSelectChoices(field: Record<string, any>): EnumChoice[] {
+  const oneOf = Array.isArray(field.oneOf) ? field.oneOf.filter(isEnumChoice) : [];
+  const anyOf = Array.isArray(field.anyOf) ? field.anyOf.filter(isEnumChoice) : [];
+  return oneOf.length > 0 ? oneOf : anyOf;
+}
+
+function getMultiSelectChoices(field: Record<string, any>): EnumChoice[] {
+  const items = field.items && typeof field.items === "object" ? field.items : {};
+  const anyOf = Array.isArray(items.anyOf) ? items.anyOf.filter(isEnumChoice) : [];
+  const oneOf = Array.isArray(items.oneOf) ? items.oneOf.filter(isEnumChoice) : [];
+  return anyOf.length > 0 ? anyOf : oneOf;
+}
+
+export function InlineElicitationCard({
+  request,
+  onApprove,
+  onReject,
+}: InlineElicitationCardProps) {
+  const [formData, setFormData] = useState<Record<string, any>>({});
+  const [urlCompleted, setUrlCompleted] = useState(false);
+  const [responded, setResponded] = useState(false);
+  const [responseLabel, setResponseLabel] = useState<string>("");
+
+  const mode = request.request.mode || "form";
+  const isFormMode = mode === "form";
+  const isUrlMode = mode === "url";
+
+  // Initialize form fields from schema defaults
+  useEffect(() => {
+    if (!isFormMode || !("requestedSchema" in request.request)) return;
+    const schema = request.request.requestedSchema;
+    const initial: Record<string, any> = {};
+    if (schema?.type === "object" && schema.properties) {
+      for (const [fieldName, fieldSchema] of Object.entries(schema.properties)) {
+        const field = fieldSchema as any;
+        if (field.default !== undefined) {
+          initial[fieldName] = field.default;
+        } else if (field.type === "array") {
+          initial[fieldName] = [];
+        } else if (field.type === "boolean") {
+          initial[fieldName] = false;
+        } else if (field.type === "number" || field.type === "integer") {
+          initial[fieldName] = 0;
+        } else {
+          initial[fieldName] = "";
+        }
+      }
+    }
+    setFormData(initial);
+  }, [request.id, isFormMode]);
+
+  const handleFieldChange = (fieldName: string, value: any) => {
+    setFormData((prev) => ({ ...prev, [fieldName]: value }));
+  };
+
+  const handleAccept = () => {
+    if (responded) return;
+    if (isFormMode) {
+      if ("requestedSchema" in request.request) {
+        const schema = request.request.requestedSchema;
+        if (schema?.required) {
+          const missing = (schema.required as string[]).filter(
+            (f) => formData[f] === undefined || formData[f] === "" || formData[f] === null
+          );
+          if (missing.length > 0) {
+            toast.error("Missing required fields", {
+              description: `Please fill in: ${missing.join(", ")}`,
+            });
+            return;
+          }
+        }
+      }
+      setResponded(true);
+      setResponseLabel("accepted");
+      onApprove(request.id, { action: "accept", content: formData });
+    } else if (isUrlMode) {
+      setResponded(true);
+      setResponseLabel("accepted");
+      onApprove(request.id, { action: "accept" });
+    }
+  };
+
+  const handleDecline = () => {
+    if (responded) return;
+    setResponded(true);
+    setResponseLabel("declined");
+    onApprove(request.id, { action: "decline" });
+  };
+
+  const handleCancel = () => {
+    if (responded) return;
+    setResponded(true);
+    setResponseLabel("cancelled");
+    onReject(request.id, "User cancelled elicitation request");
+  };
+
+  const renderFormFields = useMemo(() => {
+    if (!isFormMode || !("requestedSchema" in request.request)) return null;
+    const schema = request.request.requestedSchema;
+    if (!schema || schema.type !== "object" || !schema.properties) {
+      return (
+        <p className="text-sm text-muted-foreground">No form schema provided.</p>
+      );
+    }
+    const properties = schema.properties as Record<string, any>;
+    const required = (schema.required as string[]) || [];
+
+    return (
+      <div className="space-y-4">
+        {Object.entries(properties).map(([fieldName, fieldSchema]) => {
+          const field = fieldSchema as any;
+          const isRequired = required.includes(fieldName);
+          const fieldType = field.type || "string";
+          const fieldLabel = field.title || fieldName;
+          const fieldDescription = field.description;
+          const singleSelectChoices = getSingleSelectChoices(field);
+          const isSingleSelectChoiceField = singleSelectChoices.length > 0;
+          const isEnumField = Array.isArray(field.enum);
+          const isUntitledMultiSelectField =
+            fieldType === "array" && Array.isArray(field.items?.enum);
+          const multiSelectChoices = getMultiSelectChoices(field);
+          const isTitledMultiSelectField =
+            fieldType === "array" && multiSelectChoices.length > 0;
+          const selectedMultiValues = Array.isArray(formData[fieldName])
+            ? (formData[fieldName] as string[])
+            : [];
+
+          return (
+            <div key={fieldName} className="space-y-1.5">
+              {fieldType !== "boolean" && (
+                <Label htmlFor={`inline-field-${request.id}-${fieldName}`}>
+                  {fieldLabel}
+                  {isRequired && <span className="text-red-500 ml-1">*</span>}
+                </Label>
+              )}
+              {fieldDescription && (
+                <p className="text-xs text-muted-foreground">{fieldDescription}</p>
+              )}
+              {fieldType === "boolean" ? (
+                <div className="flex items-center space-x-2">
+                  <Checkbox
+                    id={`inline-field-${request.id}-${fieldName}`}
+                    data-testid={`inline-elicitation-field-${fieldName}`}
+                    checked={formData[fieldName] || false}
+                    onCheckedChange={(checked) => handleFieldChange(fieldName, checked)}
+                  />
+                  <Label
+                    htmlFor={`inline-field-${request.id}-${fieldName}`}
+                    className="text-sm font-normal cursor-pointer"
+                  >
+                    {fieldLabel}
+                    {isRequired && <span className="text-red-500 ml-1">*</span>}
+                  </Label>
+                </div>
+              ) : fieldType === "number" || fieldType === "integer" ? (
+                <Input
+                  id={`inline-field-${request.id}-${fieldName}`}
+                  data-testid={`inline-elicitation-field-${fieldName}`}
+                  type="number"
+                  value={formData[fieldName] ?? ""}
+                  onChange={(e) => {
+                    const parsed =
+                      fieldType === "integer"
+                        ? parseInt(e.target.value, 10)
+                        : parseFloat(e.target.value);
+                    handleFieldChange(fieldName, isNaN(parsed) ? "" : parsed);
+                  }}
+                  placeholder={field.default?.toString() || ""}
+                />
+              ) : isSingleSelectChoiceField ? (
+                <select
+                  id={`inline-field-${request.id}-${fieldName}`}
+                  data-testid={`inline-elicitation-field-${fieldName}`}
+                  value={formData[fieldName] || ""}
+                  onChange={(e) => handleFieldChange(fieldName, e.target.value)}
+                  className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                >
+                  <option value="">Select...</option>
+                  {singleSelectChoices.map((choice) => (
+                    <option key={choice.const} value={choice.const}>
+                      {choice.title || choice.const}
+                    </option>
+                  ))}
+                </select>
+              ) : isEnumField ? (
+                <select
+                  id={`inline-field-${request.id}-${fieldName}`}
+                  data-testid={`inline-elicitation-field-${fieldName}`}
+                  value={formData[fieldName] || ""}
+                  onChange={(e) => handleFieldChange(fieldName, e.target.value)}
+                  className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                >
+                  <option value="">Select...</option>
+                  {field.enum.map((option: string, index: number) => (
+                    <option key={option} value={option}>
+                      {field.enumNames?.[index] || option}
+                    </option>
+                  ))}
+                </select>
+              ) : isUntitledMultiSelectField ? (
+                <div
+                  className="space-y-2"
+                  data-testid={`inline-elicitation-field-${fieldName}`}
+                >
+                  {field.items.enum.map((option: string) => {
+                    const checkboxId = `inline-field-${request.id}-${fieldName}-${option}`;
+                    const checked = selectedMultiValues.includes(option);
+                    return (
+                      <div key={option} className="flex items-center space-x-2">
+                        <Checkbox
+                          id={checkboxId}
+                          checked={checked}
+                          onCheckedChange={(nextChecked) => {
+                            const updated = nextChecked
+                              ? [...selectedMultiValues, option]
+                              : selectedMultiValues.filter((v) => v !== option);
+                            handleFieldChange(fieldName, updated);
+                          }}
+                        />
+                        <Label htmlFor={checkboxId} className="text-sm font-normal cursor-pointer">
+                          {option}
+                        </Label>
+                      </div>
+                    );
+                  })}
+                </div>
+              ) : isTitledMultiSelectField ? (
+                <div
+                  className="space-y-2"
+                  data-testid={`inline-elicitation-field-${fieldName}`}
+                >
+                  {multiSelectChoices.map((choice) => {
+                    const checkboxId = `inline-field-${request.id}-${fieldName}-${choice.const}`;
+                    const checked = selectedMultiValues.includes(choice.const);
+                    return (
+                      <div key={choice.const} className="flex items-center space-x-2">
+                        <Checkbox
+                          id={checkboxId}
+                          checked={checked}
+                          onCheckedChange={(nextChecked) => {
+                            const updated = nextChecked
+                              ? [...selectedMultiValues, choice.const]
+                              : selectedMultiValues.filter((v) => v !== choice.const);
+                            handleFieldChange(fieldName, updated);
+                          }}
+                        />
+                        <Label htmlFor={checkboxId} className="text-sm font-normal cursor-pointer">
+                          {choice.title || choice.const}
+                        </Label>
+                      </div>
+                    );
+                  })}
+                </div>
+              ) : fieldType === "string" &&
+                (field.format === "textarea" || field.maxLength > 100) ? (
+                <Textarea
+                  id={`inline-field-${request.id}-${fieldName}`}
+                  data-testid={`inline-elicitation-field-${fieldName}`}
+                  value={formData[fieldName] || ""}
+                  onChange={(e) => handleFieldChange(fieldName, e.target.value)}
+                  placeholder={field.default || ""}
+                  rows={3}
+                />
+              ) : (
+                <Input
+                  id={`inline-field-${request.id}-${fieldName}`}
+                  data-testid={`inline-elicitation-field-${fieldName}`}
+                  type="text"
+                  value={formData[fieldName] || ""}
+                  onChange={(e) => handleFieldChange(fieldName, e.target.value)}
+                  placeholder={field.default || ""}
+                />
+              )}
+            </div>
+          );
+        })}
+      </div>
+    );
+  }, [request, formData, isFormMode]);
+
+  const urlModeUrl =
+    isUrlMode && "url" in request.request
+      ? (request.request as { url: string }).url
+      : null;
+
+  // Collapsed summary after responding
+  if (responded) {
+    return (
+      <div className="rounded-lg border border-dashed bg-muted/30 p-3 text-sm text-muted-foreground max-w-2xl">
+        Elicitation {responseLabel} — the tool will continue executing.
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border bg-card shadow-sm p-4 space-y-4 max-w-2xl">
+      {/* Header */}
+      <div className="flex items-center gap-2 flex-wrap">
+        <span className="font-medium text-sm text-card-foreground">
+          Elicitation Request
+        </span>
+        <Badge
+          variant="outline"
+          className={
+            isUrlMode
+              ? "bg-blue-500/10 text-blue-600 dark:text-blue-400 border-blue-500/30"
+              : "bg-green-500/10 text-green-600 dark:text-green-400 border-green-500/30"
+          }
+        >
+          {mode}
+        </Badge>
+        <span className="text-xs text-muted-foreground">{request.serverName}</span>
+      </div>
+
+      {/* Server message */}
+      <p className="text-sm text-card-foreground">{request.request.message}</p>
+
+      {/* URL mode */}
+      {isUrlMode && "url" in request.request && (
+        <div className="space-y-3">
+          <div className="flex items-center gap-2 p-2 bg-muted rounded border">
+            <code className="flex-1 text-xs font-mono break-all">
+              {urlModeUrl}
+            </code>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => {
+                window.open(urlModeUrl ?? "", "_blank");
+                setUrlCompleted(true);
+              }}
+            >
+              <ExternalLink className="h-3 w-3 mr-1" />
+              Open
+            </Button>
+          </div>
+          <div className="flex items-center space-x-2">
+            <Checkbox
+              id={`inline-url-done-${request.id}`}
+              checked={urlCompleted}
+              onCheckedChange={(c) => setUrlCompleted(!!c)}
+            />
+            <Label
+              htmlFor={`inline-url-done-${request.id}`}
+              className="text-sm font-normal cursor-pointer"
+            >
+              I have completed the required action
+            </Label>
+          </div>
+        </div>
+      )}
+
+      {/* Form mode */}
+      {isFormMode && renderFormFields}
+
+      {/* Actions */}
+      <div className="flex gap-2 pt-1">
+        <Button
+          size="sm"
+          onClick={handleAccept}
+          disabled={isUrlMode && !urlCompleted}
+          data-testid="inline-elicitation-accept"
+        >
+          Accept
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={handleDecline}
+          data-testid="inline-elicitation-decline"
+        >
+          Decline
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={handleCancel}
+          data-testid="inline-elicitation-cancel"
+        >
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/libraries/typescript/packages/inspector/src/client/components/chat/InlineElicitationCard.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/InlineElicitationCard.tsx
@@ -32,15 +32,24 @@ function isEnumChoice(value: unknown): value is EnumChoice {
 }
 
 function getSingleSelectChoices(field: Record<string, any>): EnumChoice[] {
-  const oneOf = Array.isArray(field.oneOf) ? field.oneOf.filter(isEnumChoice) : [];
-  const anyOf = Array.isArray(field.anyOf) ? field.anyOf.filter(isEnumChoice) : [];
+  const oneOf = Array.isArray(field.oneOf)
+    ? field.oneOf.filter(isEnumChoice)
+    : [];
+  const anyOf = Array.isArray(field.anyOf)
+    ? field.anyOf.filter(isEnumChoice)
+    : [];
   return oneOf.length > 0 ? oneOf : anyOf;
 }
 
 function getMultiSelectChoices(field: Record<string, any>): EnumChoice[] {
-  const items = field.items && typeof field.items === "object" ? field.items : {};
-  const anyOf = Array.isArray(items.anyOf) ? items.anyOf.filter(isEnumChoice) : [];
-  const oneOf = Array.isArray(items.oneOf) ? items.oneOf.filter(isEnumChoice) : [];
+  const items =
+    field.items && typeof field.items === "object" ? field.items : {};
+  const anyOf = Array.isArray(items.anyOf)
+    ? items.anyOf.filter(isEnumChoice)
+    : [];
+  const oneOf = Array.isArray(items.oneOf)
+    ? items.oneOf.filter(isEnumChoice)
+    : [];
   return anyOf.length > 0 ? anyOf : oneOf;
 }
 
@@ -64,7 +73,9 @@ export function InlineElicitationCard({
     const schema = request.request.requestedSchema;
     const initial: Record<string, any> = {};
     if (schema?.type === "object" && schema.properties) {
-      for (const [fieldName, fieldSchema] of Object.entries(schema.properties)) {
+      for (const [fieldName, fieldSchema] of Object.entries(
+        schema.properties
+      )) {
         const field = fieldSchema as any;
         if (field.default !== undefined) {
           initial[fieldName] = field.default;
@@ -93,7 +104,10 @@ export function InlineElicitationCard({
         const schema = request.request.requestedSchema;
         if (schema?.required) {
           const missing = (schema.required as string[]).filter(
-            (f) => formData[f] === undefined || formData[f] === "" || formData[f] === null
+            (f) =>
+              formData[f] === undefined ||
+              formData[f] === "" ||
+              formData[f] === null
           );
           if (missing.length > 0) {
             toast.error("Missing required fields", {
@@ -132,7 +146,9 @@ export function InlineElicitationCard({
     const schema = request.request.requestedSchema;
     if (!schema || schema.type !== "object" || !schema.properties) {
       return (
-        <p className="text-sm text-muted-foreground">No form schema provided.</p>
+        <p className="text-sm text-muted-foreground">
+          No form schema provided.
+        </p>
       );
     }
     const properties = schema.properties as Record<string, any>;
@@ -167,7 +183,9 @@ export function InlineElicitationCard({
                 </Label>
               )}
               {fieldDescription && (
-                <p className="text-xs text-muted-foreground">{fieldDescription}</p>
+                <p className="text-xs text-muted-foreground">
+                  {fieldDescription}
+                </p>
               )}
               {fieldType === "boolean" ? (
                 <div className="flex items-center space-x-2">
@@ -175,7 +193,9 @@ export function InlineElicitationCard({
                     id={`inline-field-${request.id}-${fieldName}`}
                     data-testid={`inline-elicitation-field-${fieldName}`}
                     checked={formData[fieldName] || false}
-                    onCheckedChange={(checked) => handleFieldChange(fieldName, checked)}
+                    onCheckedChange={(checked) =>
+                      handleFieldChange(fieldName, checked)
+                    }
                   />
                   <Label
                     htmlFor={`inline-field-${request.id}-${fieldName}`}
@@ -250,7 +270,10 @@ export function InlineElicitationCard({
                             handleFieldChange(fieldName, updated);
                           }}
                         />
-                        <Label htmlFor={checkboxId} className="text-sm font-normal cursor-pointer">
+                        <Label
+                          htmlFor={checkboxId}
+                          className="text-sm font-normal cursor-pointer"
+                        >
                           {option}
                         </Label>
                       </div>
@@ -266,18 +289,26 @@ export function InlineElicitationCard({
                     const checkboxId = `inline-field-${request.id}-${fieldName}-${choice.const}`;
                     const checked = selectedMultiValues.includes(choice.const);
                     return (
-                      <div key={choice.const} className="flex items-center space-x-2">
+                      <div
+                        key={choice.const}
+                        className="flex items-center space-x-2"
+                      >
                         <Checkbox
                           id={checkboxId}
                           checked={checked}
                           onCheckedChange={(nextChecked) => {
                             const updated = nextChecked
                               ? [...selectedMultiValues, choice.const]
-                              : selectedMultiValues.filter((v) => v !== choice.const);
+                              : selectedMultiValues.filter(
+                                  (v) => v !== choice.const
+                                );
                             handleFieldChange(fieldName, updated);
                           }}
                         />
-                        <Label htmlFor={checkboxId} className="text-sm font-normal cursor-pointer">
+                        <Label
+                          htmlFor={checkboxId}
+                          className="text-sm font-normal cursor-pointer"
+                        >
                           {choice.title || choice.const}
                         </Label>
                       </div>
@@ -342,7 +373,9 @@ export function InlineElicitationCard({
         >
           {mode}
         </Badge>
-        <span className="text-xs text-muted-foreground">{request.serverName}</span>
+        <span className="text-xs text-muted-foreground">
+          {request.serverName}
+        </span>
       </div>
 
       {/* Server message */}

--- a/libraries/typescript/packages/inspector/src/client/components/chat/InlineElicitationCard.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/InlineElicitationCard.tsx
@@ -1,15 +1,17 @@
 // libraries/typescript/packages/inspector/src/client/components/chat/InlineElicitationCard.tsx
-import { useState, useMemo, useEffect } from "react";
+import { useState } from "react";
 import type { ElicitResult } from "@modelcontextprotocol/sdk/types.js";
 import type { PendingElicitationRequest } from "@/client/types/elicitation";
 import { Button } from "@/client/components/ui/button";
-import { Input } from "@/client/components/ui/input";
 import { Label } from "@/client/components/ui/label";
-import { Textarea } from "@/client/components/ui/textarea";
 import { Checkbox } from "@/client/components/ui/checkbox";
 import { Badge } from "@/client/components/ui/badge";
 import { ExternalLink } from "lucide-react";
 import { toast } from "sonner";
+import {
+  ElicitationFormFields,
+  useElicitationForm,
+} from "@/client/components/elicitation/shared";
 
 interface InlineElicitationCardProps {
   request: PendingElicitationRequest;
@@ -17,105 +19,34 @@ interface InlineElicitationCardProps {
   onReject: (requestId: string, error?: string) => void;
 }
 
-interface EnumChoice {
-  const: string;
-  title?: string;
-}
-
-function isEnumChoice(value: unknown): value is EnumChoice {
-  if (!value || typeof value !== "object") return false;
-  const v = value as { const?: unknown; title?: unknown };
-  return (
-    typeof v.const === "string" &&
-    (v.title === undefined || typeof v.title === "string")
-  );
-}
-
-function getSingleSelectChoices(field: Record<string, any>): EnumChoice[] {
-  const oneOf = Array.isArray(field.oneOf)
-    ? field.oneOf.filter(isEnumChoice)
-    : [];
-  const anyOf = Array.isArray(field.anyOf)
-    ? field.anyOf.filter(isEnumChoice)
-    : [];
-  return oneOf.length > 0 ? oneOf : anyOf;
-}
-
-function getMultiSelectChoices(field: Record<string, any>): EnumChoice[] {
-  const items =
-    field.items && typeof field.items === "object" ? field.items : {};
-  const anyOf = Array.isArray(items.anyOf)
-    ? items.anyOf.filter(isEnumChoice)
-    : [];
-  const oneOf = Array.isArray(items.oneOf)
-    ? items.oneOf.filter(isEnumChoice)
-    : [];
-  return anyOf.length > 0 ? anyOf : oneOf;
-}
-
 export function InlineElicitationCard({
   request,
   onApprove,
   onReject,
 }: InlineElicitationCardProps) {
-  const [formData, setFormData] = useState<Record<string, any>>({});
-  const [urlCompleted, setUrlCompleted] = useState(false);
+  const {
+    formData,
+    setFieldValue,
+    getMissingRequiredFields,
+    urlCompleted,
+    setUrlCompleted,
+    mode,
+    isFormMode,
+    isUrlMode,
+  } = useElicitationForm(request);
+
   const [responded, setResponded] = useState(false);
   const [responseLabel, setResponseLabel] = useState<string>("");
-
-  const mode = request.request.mode || "form";
-  const isFormMode = mode === "form";
-  const isUrlMode = mode === "url";
-
-  // Initialize form fields from schema defaults
-  useEffect(() => {
-    if (!isFormMode || !("requestedSchema" in request.request)) return;
-    const schema = request.request.requestedSchema;
-    const initial: Record<string, any> = {};
-    if (schema?.type === "object" && schema.properties) {
-      for (const [fieldName, fieldSchema] of Object.entries(
-        schema.properties
-      )) {
-        const field = fieldSchema as any;
-        if (field.default !== undefined) {
-          initial[fieldName] = field.default;
-        } else if (field.type === "array") {
-          initial[fieldName] = [];
-        } else if (field.type === "boolean") {
-          initial[fieldName] = false;
-        } else if (field.type === "number" || field.type === "integer") {
-          initial[fieldName] = 0;
-        } else {
-          initial[fieldName] = "";
-        }
-      }
-    }
-    setFormData(initial);
-  }, [request.id, isFormMode]);
-
-  const handleFieldChange = (fieldName: string, value: any) => {
-    setFormData((prev) => ({ ...prev, [fieldName]: value }));
-  };
 
   const handleAccept = () => {
     if (responded) return;
     if (isFormMode) {
-      if ("requestedSchema" in request.request) {
-        const schema = request.request.requestedSchema;
-        if (schema?.required) {
-          const missing = (schema.required as string[]).filter(
-            (f) =>
-              formData[f] === undefined ||
-              formData[f] === "" ||
-              formData[f] === null
-          );
-          if (missing.length > 0) {
-            toast.error("Missing required fields", {
-              description: `Please fill in: ${missing.join(", ")}`,
-            });
-            return;
-          }
-        }
+      const missing = getMissingRequiredFields();
+      if (missing.length > 0) {
+        toast.error("Missing required fields", {
+          description: `Please fill in: ${missing.join(", ")}`,
+        });
+        return;
       }
       setResponded(true);
       setResponseLabel("accepted");
@@ -140,207 +71,6 @@ export function InlineElicitationCard({
     setResponseLabel("cancelled");
     onReject(request.id, "User cancelled elicitation request");
   };
-
-  const renderFormFields = useMemo(() => {
-    if (!isFormMode || !("requestedSchema" in request.request)) return null;
-    const schema = request.request.requestedSchema;
-    if (!schema || schema.type !== "object" || !schema.properties) {
-      return (
-        <p className="text-sm text-muted-foreground">
-          No form schema provided.
-        </p>
-      );
-    }
-    const properties = schema.properties as Record<string, any>;
-    const required = (schema.required as string[]) || [];
-
-    return (
-      <div className="space-y-4">
-        {Object.entries(properties).map(([fieldName, fieldSchema]) => {
-          const field = fieldSchema as any;
-          const isRequired = required.includes(fieldName);
-          const fieldType = field.type || "string";
-          const fieldLabel = field.title || fieldName;
-          const fieldDescription = field.description;
-          const singleSelectChoices = getSingleSelectChoices(field);
-          const isSingleSelectChoiceField = singleSelectChoices.length > 0;
-          const isEnumField = Array.isArray(field.enum);
-          const isUntitledMultiSelectField =
-            fieldType === "array" && Array.isArray(field.items?.enum);
-          const multiSelectChoices = getMultiSelectChoices(field);
-          const isTitledMultiSelectField =
-            fieldType === "array" && multiSelectChoices.length > 0;
-          const selectedMultiValues = Array.isArray(formData[fieldName])
-            ? (formData[fieldName] as string[])
-            : [];
-
-          return (
-            <div key={fieldName} className="space-y-1.5">
-              {fieldType !== "boolean" && (
-                <Label htmlFor={`inline-field-${request.id}-${fieldName}`}>
-                  {fieldLabel}
-                  {isRequired && <span className="text-red-500 ml-1">*</span>}
-                </Label>
-              )}
-              {fieldDescription && (
-                <p className="text-xs text-muted-foreground">
-                  {fieldDescription}
-                </p>
-              )}
-              {fieldType === "boolean" ? (
-                <div className="flex items-center space-x-2">
-                  <Checkbox
-                    id={`inline-field-${request.id}-${fieldName}`}
-                    data-testid={`inline-elicitation-field-${fieldName}`}
-                    checked={formData[fieldName] || false}
-                    onCheckedChange={(checked) =>
-                      handleFieldChange(fieldName, checked)
-                    }
-                  />
-                  <Label
-                    htmlFor={`inline-field-${request.id}-${fieldName}`}
-                    className="text-sm font-normal cursor-pointer"
-                  >
-                    {fieldLabel}
-                    {isRequired && <span className="text-red-500 ml-1">*</span>}
-                  </Label>
-                </div>
-              ) : fieldType === "number" || fieldType === "integer" ? (
-                <Input
-                  id={`inline-field-${request.id}-${fieldName}`}
-                  data-testid={`inline-elicitation-field-${fieldName}`}
-                  type="number"
-                  value={formData[fieldName] ?? ""}
-                  onChange={(e) => {
-                    const parsed =
-                      fieldType === "integer"
-                        ? parseInt(e.target.value, 10)
-                        : parseFloat(e.target.value);
-                    handleFieldChange(fieldName, isNaN(parsed) ? "" : parsed);
-                  }}
-                  placeholder={field.default?.toString() || ""}
-                />
-              ) : isSingleSelectChoiceField ? (
-                <select
-                  id={`inline-field-${request.id}-${fieldName}`}
-                  data-testid={`inline-elicitation-field-${fieldName}`}
-                  value={formData[fieldName] || ""}
-                  onChange={(e) => handleFieldChange(fieldName, e.target.value)}
-                  className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                >
-                  <option value="">Select...</option>
-                  {singleSelectChoices.map((choice) => (
-                    <option key={choice.const} value={choice.const}>
-                      {choice.title || choice.const}
-                    </option>
-                  ))}
-                </select>
-              ) : isEnumField ? (
-                <select
-                  id={`inline-field-${request.id}-${fieldName}`}
-                  data-testid={`inline-elicitation-field-${fieldName}`}
-                  value={formData[fieldName] || ""}
-                  onChange={(e) => handleFieldChange(fieldName, e.target.value)}
-                  className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                >
-                  <option value="">Select...</option>
-                  {field.enum.map((option: string, index: number) => (
-                    <option key={option} value={option}>
-                      {field.enumNames?.[index] || option}
-                    </option>
-                  ))}
-                </select>
-              ) : isUntitledMultiSelectField ? (
-                <div
-                  className="space-y-2"
-                  data-testid={`inline-elicitation-field-${fieldName}`}
-                >
-                  {field.items.enum.map((option: string) => {
-                    const checkboxId = `inline-field-${request.id}-${fieldName}-${option}`;
-                    const checked = selectedMultiValues.includes(option);
-                    return (
-                      <div key={option} className="flex items-center space-x-2">
-                        <Checkbox
-                          id={checkboxId}
-                          checked={checked}
-                          onCheckedChange={(nextChecked) => {
-                            const updated = nextChecked
-                              ? [...selectedMultiValues, option]
-                              : selectedMultiValues.filter((v) => v !== option);
-                            handleFieldChange(fieldName, updated);
-                          }}
-                        />
-                        <Label
-                          htmlFor={checkboxId}
-                          className="text-sm font-normal cursor-pointer"
-                        >
-                          {option}
-                        </Label>
-                      </div>
-                    );
-                  })}
-                </div>
-              ) : isTitledMultiSelectField ? (
-                <div
-                  className="space-y-2"
-                  data-testid={`inline-elicitation-field-${fieldName}`}
-                >
-                  {multiSelectChoices.map((choice) => {
-                    const checkboxId = `inline-field-${request.id}-${fieldName}-${choice.const}`;
-                    const checked = selectedMultiValues.includes(choice.const);
-                    return (
-                      <div
-                        key={choice.const}
-                        className="flex items-center space-x-2"
-                      >
-                        <Checkbox
-                          id={checkboxId}
-                          checked={checked}
-                          onCheckedChange={(nextChecked) => {
-                            const updated = nextChecked
-                              ? [...selectedMultiValues, choice.const]
-                              : selectedMultiValues.filter(
-                                  (v) => v !== choice.const
-                                );
-                            handleFieldChange(fieldName, updated);
-                          }}
-                        />
-                        <Label
-                          htmlFor={checkboxId}
-                          className="text-sm font-normal cursor-pointer"
-                        >
-                          {choice.title || choice.const}
-                        </Label>
-                      </div>
-                    );
-                  })}
-                </div>
-              ) : fieldType === "string" &&
-                (field.format === "textarea" || field.maxLength > 100) ? (
-                <Textarea
-                  id={`inline-field-${request.id}-${fieldName}`}
-                  data-testid={`inline-elicitation-field-${fieldName}`}
-                  value={formData[fieldName] || ""}
-                  onChange={(e) => handleFieldChange(fieldName, e.target.value)}
-                  placeholder={field.default || ""}
-                  rows={3}
-                />
-              ) : (
-                <Input
-                  id={`inline-field-${request.id}-${fieldName}`}
-                  data-testid={`inline-elicitation-field-${fieldName}`}
-                  type="text"
-                  value={formData[fieldName] || ""}
-                  onChange={(e) => handleFieldChange(fieldName, e.target.value)}
-                  placeholder={field.default || ""}
-                />
-              )}
-            </div>
-          );
-        })}
-      </div>
-    );
-  }, [request, formData, isFormMode]);
 
   const urlModeUrl =
     isUrlMode && "url" in request.request
@@ -417,7 +147,23 @@ export function InlineElicitationCard({
       )}
 
       {/* Form mode */}
-      {isFormMode && renderFormFields}
+      {isFormMode && (
+        <ElicitationFormFields
+          request={request}
+          formData={formData}
+          onFieldChange={setFieldValue}
+          idPrefix={`inline-field-${request.id}`}
+          testIdPrefix="inline-elicitation-field"
+          fieldContainerClassName="space-y-1.5"
+          textareaRows={3}
+          showOuterLabelForBoolean={false}
+          emptyFallback={
+            <p className="text-sm text-muted-foreground">
+              No form schema provided.
+            </p>
+          }
+        />
+      )}
 
       {/* Actions */}
       <div className="flex gap-2 pt-1">

--- a/libraries/typescript/packages/inspector/src/client/components/chat/MessageList.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/MessageList.tsx
@@ -7,6 +7,9 @@ import { ToolResultRenderer } from "./ToolResultRenderer";
 import { UserMessage } from "./UserMessage";
 import type { MessageAttachment } from "./types";
 import { detectWidgetProtocol } from "@/client/utils/widget-detection";
+import { InlineElicitationCard } from "./InlineElicitationCard";
+import type { PendingElicitationRequest } from "@/client/types/elicitation";
+import type { ElicitResult } from "@modelcontextprotocol/sdk/types.js";
 
 interface Message {
   id: string;
@@ -44,6 +47,12 @@ interface MessageListProps {
   ) => Promise<void>;
   /** When provided, passed to widget renderers to avoid useMcpClient() context lookup. */
   serverBaseUrl?: string;
+  /** Pending elicitation requests to render inline in the chat thread. */
+  pendingElicitationRequests?: PendingElicitationRequest[];
+  /** Handler called when the user accepts or declines an elicitation. */
+  onApproveElicitation?: (requestId: string, result: ElicitResult) => void;
+  /** Handler called when the user cancels an elicitation. */
+  onRejectElicitation?: (requestId: string, error?: string) => void;
 }
 
 export const MessageList = memo(
@@ -55,6 +64,9 @@ export const MessageList = memo(
     tools,
     sendMessage,
     serverBaseUrl,
+    pendingElicitationRequests,
+    onApproveElicitation,
+    onRejectElicitation,
   }: MessageListProps) => {
     const messagesEndRef = useRef<HTMLDivElement>(null);
 
@@ -319,6 +331,23 @@ export const MessageList = memo(
 
           return null;
         })}
+
+        {/* Inline elicitation cards — shown when a tool triggers elicitation during chat */}
+        {pendingElicitationRequests &&
+          pendingElicitationRequests.length > 0 &&
+          onApproveElicitation &&
+          onRejectElicitation && (
+            <div className="space-y-3">
+              {pendingElicitationRequests.map((req) => (
+                <InlineElicitationCard
+                  key={req.id}
+                  request={req}
+                  onApprove={onApproveElicitation}
+                  onReject={onRejectElicitation}
+                />
+              ))}
+            </div>
+          )}
 
         {/* Thinking indicator - only show when actually thinking, not streaming */}
         {isThinking && (

--- a/libraries/typescript/packages/inspector/src/client/components/elicitation/ElicitationRequestDisplay.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/elicitation/ElicitationRequestDisplay.tsx
@@ -1,8 +1,5 @@
-import { useState, useMemo, useEffect } from "react";
 import { Button } from "@/client/components/ui/button";
-import { Input } from "@/client/components/ui/input";
 import { Label } from "@/client/components/ui/label";
-import { Textarea } from "@/client/components/ui/textarea";
 import { Checkbox } from "@/client/components/ui/checkbox";
 import type { ElicitResult } from "@modelcontextprotocol/sdk/types.js";
 import type { PendingElicitationRequest } from "@/client/types/elicitation";
@@ -22,6 +19,10 @@ import {
   TooltipTrigger,
 } from "@/client/components/ui/tooltip";
 import { Badge } from "@/client/components/ui/badge";
+import {
+  ElicitationFormFields,
+  useElicitationForm,
+} from "./shared";
 
 interface ElicitationRequestDisplayProps {
   request: PendingElicitationRequest | null;
@@ -36,44 +37,6 @@ interface ElicitationRequestDisplayProps {
   onFullscreen: () => void;
 }
 
-interface EnumChoice {
-  const: string;
-  title?: string;
-}
-
-function isEnumChoice(value: unknown): value is EnumChoice {
-  if (!value || typeof value !== "object") return false;
-  const maybeChoice = value as { const?: unknown; title?: unknown };
-  return (
-    typeof maybeChoice.const === "string" &&
-    (maybeChoice.title === undefined || typeof maybeChoice.title === "string")
-  );
-}
-
-function getSingleSelectChoices(field: Record<string, any>): EnumChoice[] {
-  const oneOf = Array.isArray(field.oneOf)
-    ? field.oneOf.filter(isEnumChoice)
-    : [];
-  const anyOf = Array.isArray(field.anyOf)
-    ? field.anyOf.filter(isEnumChoice)
-    : [];
-
-  return oneOf.length > 0 ? oneOf : anyOf;
-}
-
-function getMultiSelectChoices(field: Record<string, any>): EnumChoice[] {
-  const items =
-    field.items && typeof field.items === "object" ? field.items : {};
-  const anyOf = Array.isArray(items.anyOf)
-    ? items.anyOf.filter(isEnumChoice)
-    : [];
-  const oneOf = Array.isArray(items.oneOf)
-    ? items.oneOf.filter(isEnumChoice)
-    : [];
-
-  return anyOf.length > 0 ? anyOf : oneOf;
-}
-
 export function ElicitationRequestDisplay({
   request,
   onApprove,
@@ -86,68 +49,27 @@ export function ElicitationRequestDisplay({
   onDownload,
   onFullscreen,
 }: ElicitationRequestDisplayProps) {
-  const [formData, setFormData] = useState<Record<string, any>>({});
-  const [urlCompleted, setUrlCompleted] = useState(false);
-
-  const mode = request?.request.mode || "form";
-  const isFormMode = mode === "form";
-  const isUrlMode = mode === "url";
-
-  // Reset form data when request changes
-  useEffect(() => {
-    if (request && isFormMode && "requestedSchema" in request.request) {
-      const schema = request.request.requestedSchema;
-      const initialData: Record<string, any> = {};
-
-      if (schema?.type === "object" && schema.properties) {
-        for (const [fieldName, fieldSchema] of Object.entries(
-          schema.properties
-        )) {
-          const field = fieldSchema as any;
-          // Set default values if available
-          if (field.default !== undefined) {
-            initialData[fieldName] = field.default;
-          } else if (field.type === "array") {
-            initialData[fieldName] = [];
-          } else if (field.type === "boolean") {
-            initialData[fieldName] = false;
-          } else if (field.type === "number" || field.type === "integer") {
-            initialData[fieldName] = 0;
-          } else {
-            initialData[fieldName] = "";
-          }
-        }
-      }
-      setFormData(initialData);
-    }
-    setUrlCompleted(false);
-  }, [request?.id, isFormMode]);
-
-  const handleFieldChange = (fieldName: string, value: any) => {
-    setFormData((prev) => ({ ...prev, [fieldName]: value }));
-  };
+  const {
+    formData,
+    setFieldValue,
+    getMissingRequiredFields,
+    urlCompleted,
+    setUrlCompleted,
+    mode,
+    isFormMode,
+    isUrlMode,
+  } = useElicitationForm(request);
 
   const handleAccept = () => {
     if (!request) return;
 
     if (isFormMode) {
-      // Validate required fields if schema is available
-      if ("requestedSchema" in request.request) {
-        const schema = request.request.requestedSchema;
-        if (schema?.required) {
-          const missingFields = schema.required.filter(
-            (field: string) =>
-              formData[field] === undefined ||
-              formData[field] === "" ||
-              formData[field] === null
-          );
-          if (missingFields.length > 0) {
-            toast.error("Missing required fields", {
-              description: `Please fill in: ${missingFields.join(", ")}`,
-            });
-            return;
-          }
-        }
+      const missingFields = getMissingRequiredFields();
+      if (missingFields.length > 0) {
+        toast.error("Missing required fields", {
+          description: `Please fill in: ${missingFields.join(", ")}`,
+        });
+        return;
       }
 
       onApprove(request.id, {
@@ -228,213 +150,6 @@ export function ElicitationRequestDisplay({
       setUrlCompleted(true);
     }
   };
-
-  const renderFormFields = useMemo(() => {
-    if (!request || !isFormMode || !("requestedSchema" in request.request))
-      return null;
-
-    const schema = request.request.requestedSchema;
-    if (!schema || schema.type !== "object" || !schema.properties) {
-      return (
-        <div className="text-sm text-gray-500 dark:text-gray-400">
-          No form schema available
-        </div>
-      );
-    }
-
-    const properties = schema.properties as Record<string, any>;
-    const required = (schema.required as string[]) || [];
-
-    return (
-      <div className="space-y-4">
-        {Object.entries(properties).map(([fieldName, fieldSchema]) => {
-          const field = fieldSchema as any;
-          const isRequired = required.includes(fieldName);
-          const fieldType = field.type || "string";
-          const fieldLabel = field.title || fieldName;
-          const fieldDescription = field.description;
-          const singleSelectChoices = getSingleSelectChoices(field);
-          const isSingleSelectChoiceField = singleSelectChoices.length > 0;
-          const isEnumField = Array.isArray(field.enum);
-          const isUntitledMultiSelectField =
-            fieldType === "array" && Array.isArray(field.items?.enum);
-          const multiSelectChoices = getMultiSelectChoices(field);
-          const isTitledMultiSelectField =
-            fieldType === "array" && multiSelectChoices.length > 0;
-          const selectedMultiValues = Array.isArray(formData[fieldName])
-            ? (formData[fieldName] as string[])
-            : [];
-
-          return (
-            <div key={fieldName} className="space-y-2">
-              <Label htmlFor={`field-${fieldName}`}>
-                {fieldLabel}
-                {isRequired && <span className="text-red-500 ml-1">*</span>}
-              </Label>
-              {fieldDescription && (
-                <p className="text-xs text-muted-foreground">
-                  {fieldDescription}
-                </p>
-              )}
-
-              {fieldType === "boolean" ? (
-                <div className="flex items-center space-x-2">
-                  <Checkbox
-                    id={`field-${fieldName}`}
-                    data-testid={`elicitation-field-${fieldName}`}
-                    checked={formData[fieldName] || false}
-                    onCheckedChange={(checked) =>
-                      handleFieldChange(fieldName, checked)
-                    }
-                  />
-                  <Label
-                    htmlFor={`field-${fieldName}`}
-                    className="text-sm font-normal cursor-pointer"
-                  >
-                    {field.title || fieldName}
-                  </Label>
-                </div>
-              ) : fieldType === "number" || fieldType === "integer" ? (
-                <Input
-                  id={`field-${fieldName}`}
-                  data-testid={`elicitation-field-${fieldName}`}
-                  type="number"
-                  value={formData[fieldName] || ""}
-                  onChange={(e) =>
-                    handleFieldChange(
-                      fieldName,
-                      fieldType === "integer"
-                        ? parseInt(e.target.value, 10)
-                        : parseFloat(e.target.value)
-                    )
-                  }
-                  placeholder={field.default?.toString() || ""}
-                />
-              ) : isSingleSelectChoiceField ? (
-                <select
-                  id={`field-${fieldName}`}
-                  data-testid={`elicitation-field-${fieldName}`}
-                  value={formData[fieldName] || ""}
-                  onChange={(e) => handleFieldChange(fieldName, e.target.value)}
-                  className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                >
-                  <option value="">Select...</option>
-                  {singleSelectChoices.map((choice) => (
-                    <option key={choice.const} value={choice.const}>
-                      {choice.title || choice.const}
-                    </option>
-                  ))}
-                </select>
-              ) : isEnumField ? (
-                <select
-                  id={`field-${fieldName}`}
-                  data-testid={`elicitation-field-${fieldName}`}
-                  value={formData[fieldName] || ""}
-                  onChange={(e) => handleFieldChange(fieldName, e.target.value)}
-                  className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                >
-                  <option value="">Select...</option>
-                  {field.enum.map((option: string, index: number) => (
-                    <option key={option} value={option}>
-                      {field.enumNames?.[index] || option}
-                    </option>
-                  ))}
-                </select>
-              ) : isUntitledMultiSelectField ? (
-                <div
-                  className="space-y-2"
-                  data-testid={`elicitation-field-${fieldName}`}
-                >
-                  {field.items.enum.map((option: string) => {
-                    const checkboxId = `field-${fieldName}-${option}`;
-                    const checked = selectedMultiValues.includes(option);
-
-                    return (
-                      <div key={option} className="flex items-center space-x-2">
-                        <Checkbox
-                          id={checkboxId}
-                          checked={checked}
-                          onCheckedChange={(nextChecked) => {
-                            const updatedValues = nextChecked
-                              ? [...selectedMultiValues, option]
-                              : selectedMultiValues.filter(
-                                  (value) => value !== option
-                                );
-                            handleFieldChange(fieldName, updatedValues);
-                          }}
-                        />
-                        <Label
-                          htmlFor={checkboxId}
-                          className="text-sm font-normal cursor-pointer"
-                        >
-                          {option}
-                        </Label>
-                      </div>
-                    );
-                  })}
-                </div>
-              ) : isTitledMultiSelectField ? (
-                <div
-                  className="space-y-2"
-                  data-testid={`elicitation-field-${fieldName}`}
-                >
-                  {multiSelectChoices.map((choice) => {
-                    const checkboxId = `field-${fieldName}-${choice.const}`;
-                    const checked = selectedMultiValues.includes(choice.const);
-
-                    return (
-                      <div
-                        key={choice.const}
-                        className="flex items-center space-x-2"
-                      >
-                        <Checkbox
-                          id={checkboxId}
-                          checked={checked}
-                          onCheckedChange={(nextChecked) => {
-                            const updatedValues = nextChecked
-                              ? [...selectedMultiValues, choice.const]
-                              : selectedMultiValues.filter(
-                                  (value) => value !== choice.const
-                                );
-                            handleFieldChange(fieldName, updatedValues);
-                          }}
-                        />
-                        <Label
-                          htmlFor={checkboxId}
-                          className="text-sm font-normal cursor-pointer"
-                        >
-                          {choice.title || choice.const}
-                        </Label>
-                      </div>
-                    );
-                  })}
-                </div>
-              ) : fieldType === "string" &&
-                (field.format === "textarea" || field.maxLength > 100) ? (
-                <Textarea
-                  id={`field-${fieldName}`}
-                  data-testid={`elicitation-field-${fieldName}`}
-                  value={formData[fieldName] || ""}
-                  onChange={(e) => handleFieldChange(fieldName, e.target.value)}
-                  placeholder={field.default || ""}
-                  rows={4}
-                />
-              ) : (
-                <Input
-                  id={`field-${fieldName}`}
-                  data-testid={`elicitation-field-${fieldName}`}
-                  type="text"
-                  value={formData[fieldName] || ""}
-                  onChange={(e) => handleFieldChange(fieldName, e.target.value)}
-                  placeholder={field.default || ""}
-                />
-              )}
-            </div>
-          );
-        })}
-      </div>
-    );
-  }, [request, formData, isFormMode]);
 
   if (!request) {
     return (
@@ -583,7 +298,18 @@ export function ElicitationRequestDisplay({
             <h4 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
               Form Data
             </h4>
-            {renderFormFields}
+            <ElicitationFormFields
+              request={request}
+              formData={formData}
+              onFieldChange={setFieldValue}
+              idPrefix="field"
+              testIdPrefix="elicitation-field"
+              emptyFallback={
+                <div className="text-sm text-gray-500 dark:text-gray-400">
+                  No form schema available
+                </div>
+              }
+            />
           </div>
         )}
 

--- a/libraries/typescript/packages/inspector/src/client/components/elicitation/ElicitationRequestDisplay.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/elicitation/ElicitationRequestDisplay.tsx
@@ -19,10 +19,7 @@ import {
   TooltipTrigger,
 } from "@/client/components/ui/tooltip";
 import { Badge } from "@/client/components/ui/badge";
-import {
-  ElicitationFormFields,
-  useElicitationForm,
-} from "./shared";
+import { ElicitationFormFields, useElicitationForm } from "./shared";
 
 interface ElicitationRequestDisplayProps {
   request: PendingElicitationRequest | null;

--- a/libraries/typescript/packages/inspector/src/client/components/elicitation/shared/ElicitationFormFields.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/elicitation/shared/ElicitationFormFields.tsx
@@ -4,10 +4,7 @@ import { Input } from "@/client/components/ui/input";
 import { Label } from "@/client/components/ui/label";
 import { Textarea } from "@/client/components/ui/textarea";
 import { Checkbox } from "@/client/components/ui/checkbox";
-import {
-  getMultiSelectChoices,
-  getSingleSelectChoices,
-} from "./schemaHelpers";
+import { getMultiSelectChoices, getSingleSelectChoices } from "./schemaHelpers";
 
 interface ElicitationFormFieldsProps {
   request: PendingElicitationRequest;
@@ -165,10 +162,7 @@ export function ElicitationFormFields({
                     const checkboxId = `${inputId}-${option}`;
                     const checked = selectedMultiValues.includes(option);
                     return (
-                      <div
-                        key={option}
-                        className="flex items-center space-x-2"
-                      >
+                      <div key={option} className="flex items-center space-x-2">
                         <Checkbox
                           id={checkboxId}
                           checked={checked}

--- a/libraries/typescript/packages/inspector/src/client/components/elicitation/shared/ElicitationFormFields.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/elicitation/shared/ElicitationFormFields.tsx
@@ -1,0 +1,264 @@
+import { useMemo } from "react";
+import type { PendingElicitationRequest } from "@/client/types/elicitation";
+import { Input } from "@/client/components/ui/input";
+import { Label } from "@/client/components/ui/label";
+import { Textarea } from "@/client/components/ui/textarea";
+import { Checkbox } from "@/client/components/ui/checkbox";
+import {
+  getMultiSelectChoices,
+  getSingleSelectChoices,
+} from "./schemaHelpers";
+
+interface ElicitationFormFieldsProps {
+  request: PendingElicitationRequest;
+  formData: Record<string, any>;
+  onFieldChange: (fieldName: string, value: any) => void;
+  /** Prefix used for DOM `id` attributes (e.g. `"field"` → `"field-{name}"`). */
+  idPrefix: string;
+  /** Prefix used for `data-testid` attributes (e.g. `"elicitation-field"`). */
+  testIdPrefix: string;
+  /** Class for the per-field vertical spacing. */
+  fieldContainerClassName?: string;
+  /** Row count for textarea fields. */
+  textareaRows?: number;
+  /** Whether to render the outer label above a boolean field (in addition to the checkbox-adjacent label). */
+  showOuterLabelForBoolean?: boolean;
+  /** Fallback rendered when the schema is missing or malformed. */
+  emptyFallback?: React.ReactNode;
+}
+
+export function ElicitationFormFields({
+  request,
+  formData,
+  onFieldChange,
+  idPrefix,
+  testIdPrefix,
+  fieldContainerClassName = "space-y-2",
+  textareaRows = 4,
+  showOuterLabelForBoolean = true,
+  emptyFallback,
+}: ElicitationFormFieldsProps) {
+  const rendered = useMemo(() => {
+    if (!("requestedSchema" in request.request)) return null;
+
+    const schema = request.request.requestedSchema;
+    if (!schema || schema.type !== "object" || !schema.properties) {
+      return (
+        emptyFallback ?? (
+          <p className="text-sm text-muted-foreground">
+            No form schema available
+          </p>
+        )
+      );
+    }
+
+    const properties = schema.properties as Record<string, any>;
+    const required = (schema.required as string[]) || [];
+
+    return (
+      <div className="space-y-4">
+        {Object.entries(properties).map(([fieldName, fieldSchema]) => {
+          const field = fieldSchema as any;
+          const isRequired = required.includes(fieldName);
+          const fieldType = field.type || "string";
+          const fieldLabel = field.title || fieldName;
+          const fieldDescription = field.description;
+          const singleSelectChoices = getSingleSelectChoices(field);
+          const isSingleSelectChoiceField = singleSelectChoices.length > 0;
+          const isEnumField = Array.isArray(field.enum);
+          const isUntitledMultiSelectField =
+            fieldType === "array" && Array.isArray(field.items?.enum);
+          const multiSelectChoices = getMultiSelectChoices(field);
+          const isTitledMultiSelectField =
+            fieldType === "array" && multiSelectChoices.length > 0;
+          const selectedMultiValues = Array.isArray(formData[fieldName])
+            ? (formData[fieldName] as string[])
+            : [];
+
+          const inputId = `${idPrefix}-${fieldName}`;
+          const testId = `${testIdPrefix}-${fieldName}`;
+          const showTopLabel =
+            fieldType !== "boolean" || showOuterLabelForBoolean;
+
+          return (
+            <div key={fieldName} className={fieldContainerClassName}>
+              {showTopLabel && (
+                <Label htmlFor={inputId}>
+                  {fieldLabel}
+                  {isRequired && <span className="text-red-500 ml-1">*</span>}
+                </Label>
+              )}
+              {fieldDescription && (
+                <p className="text-xs text-muted-foreground">
+                  {fieldDescription}
+                </p>
+              )}
+
+              {fieldType === "boolean" ? (
+                <div className="flex items-center space-x-2">
+                  <Checkbox
+                    id={inputId}
+                    data-testid={testId}
+                    checked={formData[fieldName] || false}
+                    onCheckedChange={(checked) =>
+                      onFieldChange(fieldName, checked)
+                    }
+                  />
+                  <Label
+                    htmlFor={inputId}
+                    className="text-sm font-normal cursor-pointer"
+                  >
+                    {fieldLabel}
+                    {!showOuterLabelForBoolean && isRequired && (
+                      <span className="text-red-500 ml-1">*</span>
+                    )}
+                  </Label>
+                </div>
+              ) : fieldType === "number" || fieldType === "integer" ? (
+                <Input
+                  id={inputId}
+                  data-testid={testId}
+                  type="number"
+                  value={formData[fieldName] ?? ""}
+                  onChange={(e) => {
+                    const parsed =
+                      fieldType === "integer"
+                        ? parseInt(e.target.value, 10)
+                        : parseFloat(e.target.value);
+                    onFieldChange(fieldName, isNaN(parsed) ? "" : parsed);
+                  }}
+                  placeholder={field.default?.toString() || ""}
+                />
+              ) : isSingleSelectChoiceField ? (
+                <select
+                  id={inputId}
+                  data-testid={testId}
+                  value={formData[fieldName] || ""}
+                  onChange={(e) => onFieldChange(fieldName, e.target.value)}
+                  className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                >
+                  <option value="">Select...</option>
+                  {singleSelectChoices.map((choice) => (
+                    <option key={choice.const} value={choice.const}>
+                      {choice.title || choice.const}
+                    </option>
+                  ))}
+                </select>
+              ) : isEnumField ? (
+                <select
+                  id={inputId}
+                  data-testid={testId}
+                  value={formData[fieldName] || ""}
+                  onChange={(e) => onFieldChange(fieldName, e.target.value)}
+                  className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                >
+                  <option value="">Select...</option>
+                  {field.enum.map((option: string, index: number) => (
+                    <option key={option} value={option}>
+                      {field.enumNames?.[index] || option}
+                    </option>
+                  ))}
+                </select>
+              ) : isUntitledMultiSelectField ? (
+                <div className="space-y-2" data-testid={testId}>
+                  {field.items.enum.map((option: string) => {
+                    const checkboxId = `${inputId}-${option}`;
+                    const checked = selectedMultiValues.includes(option);
+                    return (
+                      <div
+                        key={option}
+                        className="flex items-center space-x-2"
+                      >
+                        <Checkbox
+                          id={checkboxId}
+                          checked={checked}
+                          onCheckedChange={(nextChecked) => {
+                            const updated = nextChecked
+                              ? [...selectedMultiValues, option]
+                              : selectedMultiValues.filter(
+                                  (value) => value !== option
+                                );
+                            onFieldChange(fieldName, updated);
+                          }}
+                        />
+                        <Label
+                          htmlFor={checkboxId}
+                          className="text-sm font-normal cursor-pointer"
+                        >
+                          {option}
+                        </Label>
+                      </div>
+                    );
+                  })}
+                </div>
+              ) : isTitledMultiSelectField ? (
+                <div className="space-y-2" data-testid={testId}>
+                  {multiSelectChoices.map((choice) => {
+                    const checkboxId = `${inputId}-${choice.const}`;
+                    const checked = selectedMultiValues.includes(choice.const);
+                    return (
+                      <div
+                        key={choice.const}
+                        className="flex items-center space-x-2"
+                      >
+                        <Checkbox
+                          id={checkboxId}
+                          checked={checked}
+                          onCheckedChange={(nextChecked) => {
+                            const updated = nextChecked
+                              ? [...selectedMultiValues, choice.const]
+                              : selectedMultiValues.filter(
+                                  (value) => value !== choice.const
+                                );
+                            onFieldChange(fieldName, updated);
+                          }}
+                        />
+                        <Label
+                          htmlFor={checkboxId}
+                          className="text-sm font-normal cursor-pointer"
+                        >
+                          {choice.title || choice.const}
+                        </Label>
+                      </div>
+                    );
+                  })}
+                </div>
+              ) : fieldType === "string" &&
+                (field.format === "textarea" || field.maxLength > 100) ? (
+                <Textarea
+                  id={inputId}
+                  data-testid={testId}
+                  value={formData[fieldName] || ""}
+                  onChange={(e) => onFieldChange(fieldName, e.target.value)}
+                  placeholder={field.default || ""}
+                  rows={textareaRows}
+                />
+              ) : (
+                <Input
+                  id={inputId}
+                  data-testid={testId}
+                  type="text"
+                  value={formData[fieldName] || ""}
+                  onChange={(e) => onFieldChange(fieldName, e.target.value)}
+                  placeholder={field.default || ""}
+                />
+              )}
+            </div>
+          );
+        })}
+      </div>
+    );
+  }, [
+    request,
+    formData,
+    onFieldChange,
+    idPrefix,
+    testIdPrefix,
+    fieldContainerClassName,
+    textareaRows,
+    showOuterLabelForBoolean,
+    emptyFallback,
+  ]);
+
+  return <>{rendered}</>;
+}

--- a/libraries/typescript/packages/inspector/src/client/components/elicitation/shared/index.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/elicitation/shared/index.ts
@@ -1,0 +1,8 @@
+export { ElicitationFormFields } from "./ElicitationFormFields";
+export { useElicitationForm } from "./useElicitationForm";
+export {
+  getMultiSelectChoices,
+  getSingleSelectChoices,
+  isEnumChoice,
+} from "./schemaHelpers";
+export type { EnumChoice } from "./schemaHelpers";

--- a/libraries/typescript/packages/inspector/src/client/components/elicitation/shared/schemaHelpers.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/elicitation/shared/schemaHelpers.ts
@@ -1,0 +1,39 @@
+export interface EnumChoice {
+  const: string;
+  title?: string;
+}
+
+export function isEnumChoice(value: unknown): value is EnumChoice {
+  if (!value || typeof value !== "object") return false;
+  const maybeChoice = value as { const?: unknown; title?: unknown };
+  return (
+    typeof maybeChoice.const === "string" &&
+    (maybeChoice.title === undefined || typeof maybeChoice.title === "string")
+  );
+}
+
+export function getSingleSelectChoices(
+  field: Record<string, any>
+): EnumChoice[] {
+  const oneOf = Array.isArray(field.oneOf)
+    ? field.oneOf.filter(isEnumChoice)
+    : [];
+  const anyOf = Array.isArray(field.anyOf)
+    ? field.anyOf.filter(isEnumChoice)
+    : [];
+  return oneOf.length > 0 ? oneOf : anyOf;
+}
+
+export function getMultiSelectChoices(
+  field: Record<string, any>
+): EnumChoice[] {
+  const items =
+    field.items && typeof field.items === "object" ? field.items : {};
+  const anyOf = Array.isArray(items.anyOf)
+    ? items.anyOf.filter(isEnumChoice)
+    : [];
+  const oneOf = Array.isArray(items.oneOf)
+    ? items.oneOf.filter(isEnumChoice)
+    : [];
+  return anyOf.length > 0 ? anyOf : oneOf;
+}

--- a/libraries/typescript/packages/inspector/src/client/components/elicitation/shared/useElicitationForm.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/elicitation/shared/useElicitationForm.ts
@@ -1,0 +1,76 @@
+import { useCallback, useEffect, useState } from "react";
+import type { PendingElicitationRequest } from "@/client/types/elicitation";
+
+/**
+ * Shared state + lifecycle for elicitation form/url requests.
+ *
+ * Handles:
+ *  - Initializing `formData` from the request's JSON schema defaults.
+ *  - Resetting `urlCompleted` when the request changes.
+ *  - Validating required fields on submit.
+ *
+ * Used by both the full-panel (`ElicitationRequestDisplay`) and the
+ * inline chat card (`InlineElicitationCard`) variants.
+ */
+export function useElicitationForm(request: PendingElicitationRequest | null) {
+  const [formData, setFormData] = useState<Record<string, any>>({});
+  const [urlCompleted, setUrlCompleted] = useState(false);
+
+  const mode = request?.request.mode || "form";
+  const isFormMode = mode === "form";
+  const isUrlMode = mode === "url";
+
+  useEffect(() => {
+    if (request && isFormMode && "requestedSchema" in request.request) {
+      const schema = request.request.requestedSchema;
+      const initial: Record<string, any> = {};
+      if (schema?.type === "object" && schema.properties) {
+        for (const [fieldName, fieldSchema] of Object.entries(
+          schema.properties
+        )) {
+          const field = fieldSchema as any;
+          if (field.default !== undefined) {
+            initial[fieldName] = field.default;
+          } else if (field.type === "array") {
+            initial[fieldName] = [];
+          } else if (field.type === "boolean") {
+            initial[fieldName] = false;
+          } else if (field.type === "number" || field.type === "integer") {
+            initial[fieldName] = 0;
+          } else {
+            initial[fieldName] = "";
+          }
+        }
+      }
+      setFormData(initial);
+    }
+    setUrlCompleted(false);
+  }, [request?.id, isFormMode]);
+
+  const setFieldValue = useCallback((fieldName: string, value: any) => {
+    setFormData((prev) => ({ ...prev, [fieldName]: value }));
+  }, []);
+
+  const getMissingRequiredFields = useCallback((): string[] => {
+    if (!request || !isFormMode || !("requestedSchema" in request.request)) {
+      return [];
+    }
+    const schema = request.request.requestedSchema;
+    const required = (schema?.required as string[] | undefined) ?? [];
+    return required.filter(
+      (f) =>
+        formData[f] === undefined || formData[f] === "" || formData[f] === null
+    );
+  }, [request, formData, isFormMode]);
+
+  return {
+    formData,
+    setFieldValue,
+    getMissingRequiredFields,
+    urlCompleted,
+    setUrlCompleted,
+    mode,
+    isFormMode,
+    isUrlMode,
+  };
+}


### PR DESCRIPTION
# Pull Request Description

https://github.com/user-attachments/assets/e8507b67-cc02-4639-945b-0136046daed2

## Language / Project Scope

- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

Elicitation requests triggered from the Chat tab now appear inline in the chat thread instead of routing the user to a separate Elicitation tab via a toast notification. When elicitation is triggered from the Tools tab, the existing toast behaviour is preserved.

## Implementation Details

1. **New `InlineElicitationCard` component** (`packages/inspector/src/client/components/chat/InlineElicitationCard.tsx`) — compact card rendered inside the chat message list. Handles both `form` mode (all JSON Schema field types: text, number, boolean, single/multi-select, textarea) and `url` mode (URL + "I completed this" checkbox). Collapses to a one-line summary after the user responds (accepted / declined / cancelled).

2. **`MessageList` updated** — three optional props added (`pendingElicitationRequests`, `onApproveElicitation`, `onRejectElicitation`). Inline cards render below the last message and above the thinking indicator.

3. **`ChatTab` wired** — passes `connection.pendingElicitationRequests`, `connection.approveElicitation`, and `connection.rejectElicitation` (already present on the `McpServer` object) down to `MessageList`.

4. **`App.tsx` toast suppression** — added a small `InspectorTabSync` bridge component that syncs `activeTab` from `InspectorContext` into an `activeTabRef`. The `onElicitationRequest` callback returns early (no toast) when `activeTabRef.current === "chat"`. The Elicitation tab and toast both continue to work normally when triggered from non-chat tabs.

---

## TypeScript Checklist

### Packages Modified

- [ ] `docs`
- [ ] `tests`
- [ ] `cli`
- [ ] `create-mcp-use-app`
- [ ] `mcp-use` (server)
- [ ] `mcp-use` (client)
- [x] `inspector`

### Pre-commit Checklist

- [ ] Ran `pnpm lint:fix` to auto-fix linting issues
- [ ] Ran `pnpm format` to format code with Prettier
- [ ] Ran `pnpm build` and build succeeds without errors
- [ ] Ran `pnpm changeset` to create a changeset (if this PR includes user-facing changes)
- [ ] Added or updated tests if needed
- [ ] Updated documentation in `docs/` folder if needed

---

## Example Usage (Before)

User triggers an elicitation tool from the Chat tab → toast appears saying "go to the Elicitation tab" → user has to switch tabs, fill the form, and click Accept → switch back to chat to see the result.

## Example Usage (After)

User triggers an elicitation tool from the Chat tab → an inline card appears in the chat thread below the tool call → user fills the form and clicks Accept without leaving chat → the tool result appears immediately below.

## Documentation Updates

None required — this is an inspector UI change only.

## Testing

- Manual testing via `pnpm --filter @mcp-use/inspector dev` against the elicitation example server
- Verified inline card appears in chat thread with no toast when on Chat tab
- Verified toast still fires when elicitation is triggered from Tools tab
- Verified Elicitation tab still shows and handles the request as a fallback
- Verified Accept / Decline / Cancel all collapse the card correctly
- Verified URL mode shows the URL, Open button, and checkbox with Accept disabled until checked
- No regressions to existing message rendering, tool call display, or thinking indicator

## Backwards Compatibility

No breaking changes. All new `MessageList` props are optional. The Elicitation tab and toast are unchanged for non-chat contexts.

## Related Issues

Closes #1306 