### PR TITLE
fix(react): restore window.fetch interceptor when useMcp unmounts (Via Proxy → Direct)

### DIFF
--- a/libraries/typescript/.changeset/fix-proxy-fetch-interceptor-teardown.md
+++ b/libraries/typescript/.changeset/fix-proxy-fetch-interceptor-teardown.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Fix inspector "Protected resource does not match" error when switching from Via Proxy to Direct connection. The `window.fetch` interceptor installed by `BrowserOAuthClientProvider` is now correctly restored when `useMcp` unmounts, preventing the stale proxy interceptor from interfering with subsequent direct OAuth flows.

--- a/libraries/typescript/packages/mcp-use/src/react/useMcp.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/useMcp.ts
@@ -41,6 +41,7 @@ type UseMcpAuthProvider = OAuthClientProvider & {
   clearStorage?: () => number;
   getLastAttemptedAuthUrl?: () => string | null | undefined;
   installFetchInterceptor?: () => void;
+  restoreFetch?: () => void;
   serverUrl?: string;
 };
 
@@ -2020,6 +2021,10 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
     return () => {
       isMountedRef.current = false;
       addLog("debug", "useMcp unmounting, disconnecting.");
+
+      // Restore window.fetch if a proxy interceptor was installed.
+      // restoreFetch() is a no-op when no interceptor is active.
+      authProviderRef.current?.restoreFetch?.();
 
       // Clear OAuth state ONLY if we're in the middle of an OAuth flow
       // This prevents "code verifier not found" errors in StrictMode double-mounting

--- a/libraries/typescript/packages/mcp-use/tests/unit/react/useMcp-logLevel.test.tsx
+++ b/libraries/typescript/packages/mcp-use/tests/unit/react/useMcp-logLevel.test.tsx
@@ -283,17 +283,38 @@ describe("useMcp logLevel configuration", () => {
         create(<TestComponent1 />);
       });
 
-      const silentLogs = (console.log as any).mock.calls.length;
+      // Snapshot all console methods after the silent instance runs.
+      // Debug-level output routes to console.debug, not console.log, so we
+      // must track all relevant channels.
+      const callsAfterSilent = {
+        log: (console.log as any).mock.calls.length,
+        info: (console.info as any).mock.calls.length,
+        debug: (console.debug as any).mock.calls.length,
+        warn: (console.warn as any).mock.calls.length,
+      };
+
+      // Silent instance should produce no console output at all
+      expect(
+        callsAfterSilent.log +
+          callsAfterSilent.info +
+          callsAfterSilent.debug +
+          callsAfterSilent.warn
+      ).toBe(0);
 
       // Second instance: debug (different URL so different logger name)
       act(() => {
         create(<TestComponent2 />);
       });
 
-      const debugLogs = (console.log as any).mock.calls.length;
+      // Count only the new calls produced by the debug instance (delta, not cumulative)
+      const newCallsFromDebug =
+        (console.log as any).mock.calls.length -
+        callsAfterSilent.log +
+        ((console.info as any).mock.calls.length - callsAfterSilent.info) +
+        ((console.debug as any).mock.calls.length - callsAfterSilent.debug);
 
-      // The debug instance should log, silent shouldn't
-      expect(debugLogs).toBeGreaterThan(silentLogs);
+      // The debug instance should have produced at least one log entry
+      expect(newCallsFromDebug).toBeGreaterThan(0);
 
       // Both should have their own state
       expect(hookResult1.state).toBeDefined();

--- a/libraries/typescript/packages/mcp-use/tests/unit/react/useMcp-logLevel.test.tsx
+++ b/libraries/typescript/packages/mcp-use/tests/unit/react/useMcp-logLevel.test.tsx
@@ -1,3 +1,5 @@
+// @vitest-environment jsdom
+
 /**
  * Tests for logLevel configuration in useMcp hook
  *

--- a/libraries/typescript/packages/mcp-use/tests/unit/react/useMcp-proxyCleanup.test.tsx
+++ b/libraries/typescript/packages/mcp-use/tests/unit/react/useMcp-proxyCleanup.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+
+/**
+ * Tests that useMcp calls restoreFetch() on unmount to tear down any
+ * window.fetch interceptor installed by a proxy-mode OAuth provider.
+ *
+ * Related issue: MCP-1713 — Inspector: switching from "Via Proxy" → "Direct"
+ * fails with "Protected resource does not match" error because the stale
+ * interceptor from the proxy connection is never removed.
+ */
+
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, create } from "react-test-renderer";
+
+vi.mock("../../../src/client/browser.js", () => ({
+  // Use a regular function (not arrow) so it's constructable with `new`
+  BrowserMCPClient: vi.fn(function () {
+    return {
+      addServer: vi.fn().mockResolvedValue(undefined),
+      removeServer: vi.fn().mockResolvedValue(undefined),
+      getSession: vi.fn().mockReturnValue(null),
+      createSession: vi.fn().mockResolvedValue(undefined),
+      listSessions: vi.fn().mockReturnValue([]),
+    };
+  }),
+}));
+
+vi.mock("../../../src/auth/browser-provider.js", () => ({
+  createBrowserOAuthProvider: vi.fn(() => ({
+    provider: null,
+    oauthProxyUrl: undefined,
+  })),
+}));
+
+vi.mock("../../../src/telemetry/index.js", () => ({
+  Tel: {
+    getInstance: () => ({
+      trackUseMcpConnection: vi.fn().mockResolvedValue(undefined),
+    }),
+  },
+}));
+
+describe("useMcp proxy connection cleanup", () => {
+  let useMcp: any;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    const module = await import("../../../src/react/useMcp.js");
+    useMcp = module.useMcp;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls restoreFetch() on the auth provider when the hook unmounts", async () => {
+    const restoreFetch = vi.fn();
+    const mockAuthProvider = {
+      restoreFetch,
+      clearStorage: vi.fn().mockReturnValue(0),
+      serverUrl: "http://localhost:3001/mcp",
+    };
+
+    let renderer: ReturnType<typeof create>;
+
+    function TestComponent() {
+      useMcp({
+        url: "http://localhost:3001/mcp",
+        enabled: true,
+        authProvider: mockAuthProvider,
+      });
+      return null;
+    }
+
+    await act(async () => {
+      renderer = create(<TestComponent />);
+    });
+
+    expect(restoreFetch).not.toHaveBeenCalled();
+
+    await act(async () => {
+      renderer!.unmount();
+    });
+
+    expect(restoreFetch).toHaveBeenCalledOnce();
+  });
+
+  it("does not throw on unmount when no auth provider is set", async () => {
+    let renderer: ReturnType<typeof create>;
+
+    function TestComponent() {
+      useMcp({
+        url: "http://localhost:3001/mcp",
+        enabled: false, // skip connection so authProviderRef stays null
+      });
+      return null;
+    }
+
+    await act(async () => {
+      renderer = create(<TestComponent />);
+    });
+
+    await expect(
+      act(async () => {
+        renderer!.unmount();
+      })
+    ).resolves.not.toThrow();
+  });
+});

--- a/libraries/typescript/packages/mcp-use/vitest.config.ts
+++ b/libraries/typescript/packages/mcp-use/vitest.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
-    include: ["tests/**/*.test.ts"],
+    include: ["tests/**/*.test.ts", "tests/**/*.test.tsx"],
     exclude: ["node_modules/**", "dist/**", "tests/deno/**"],
     coverage: {
       provider: "v8",


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

When a user connects via **Via Proxy** in the inspector and then switches to **Direct** (without reloading), the direct connection fails with:

```
Protected resource http://localhost:3000/inspector/api/proxy does not match expected https://mcp.linear.app/mcp (or origin)
```

`BrowserOAuthClientProvider.restoreFetch()` existed to undo the `window.fetch` proxy interceptor, but was never called anywhere. This PR calls it in the `useMcp` `useEffect` cleanup so the interceptor is torn down whenever the hook unmounts.

## Implementation Details

1. Added `restoreFetch?: () => void` to the `UseMcpAuthProvider` interface in `useMcp.ts` so TypeScript recognises the method
2. Added `authProviderRef.current?.restoreFetch?.()` to the `useEffect` cleanup (before `disconnect()`) — runs on every unmount, is a no-op when no interceptor was installed
3. Added unit test `useMcp-proxyCleanup.test.tsx` verifying `restoreFetch()` is called on unmount
4. Added `tests/**/*.test.tsx` to the vitest `include` pattern (`.tsx` test files were silently excluded before) and added `// @vitest-environment jsdom` to both `.tsx` test files that exercise `useMcp` directly

---

## TypeScript Checklist

### Packages Modified

- [ ] `docs`
- [x] `tests`
- [ ] `cli`
- [ ] `create-mcp-use-app`
- [x] `mcp-use` (client)
- [ ] `mcp-use` (server)
- [ ] `inspector`

### Pre-commit Checklist

- [x] Ran `pnpm lint:fix` to auto-fix linting issues
- [x] Ran `pnpm format` to format code with Prettier
- [x] Ran `pnpm build` and build succeeds without errors
- [ ] Ran `pnpm changeset` to create a changeset (if this PR includes user-facing changes)
- [x] Added or updated tests if needed
- [ ] Updated documentation in `docs/` folder if needed

---

## Example Usage (Before)

```
// 1. Connect inspector via "Via Proxy" → succeeds
// 2. Switch to "Direct" → fails with:
//    Protected resource http://localhost:3000/inspector/api/proxy
//    does not match expected https://mcp.linear.app/mcp (or origin)
```

## Example Usage (After)

```
// 1. Connect inspector via "Via Proxy" → succeeds
// 2. Switch to "Direct" → succeeds (stale fetch interceptor is torn down on unmount)
```

## Documentation Updates

No documentation changes required.

## Testing

- Added `tests/unit/react/useMcp-proxyCleanup.test.tsx` with two tests:
  - Asserts `restoreFetch()` is called exactly once when the hook unmounts with a proxy auth provider set
  - Asserts unmount is safe when no auth provider is set (no-op path)
- Build passes: `pnpm build` ✓
- Lint and format pass: `pnpm lint && pnpm format:check` ✓
- Unit tests pass: `pnpm --filter mcp-use test:unit` (pre-existing failures in `docs/agent-quick-start.test.ts` require `OPENAI_API_KEY` and are unrelated)

## Backwards Compatibility

Non-breaking. `restoreFetch()` is already a no-op when no interceptor is installed (`if (this.originalFetch)` guard in `BrowserOAuthClientProvider`).

## Related Issues

Closes #1334