### PR TITLE
fix(create-mcp-use-app): switch template tsconfigs to NodeNext

### DIFF
--- a/libraries/typescript/.changeset/mcp-1733-esm-nodenext.md
+++ b/libraries/typescript/.changeset/mcp-1733-esm-nodenext.md
@@ -1,0 +1,7 @@
+---
+"create-mcp-use-app": patch
+---
+
+Switch template tsconfigs to `module: "NodeNext"` and `moduleResolution: "NodeNext"`.
+
+Scaffolded apps run under native Node ESM (`mcp-use start` spawns plain `node`), but the previous `bundler` resolution let TypeScript accept extensionless relative imports that Node then rejected with `ERR_MODULE_NOT_FOUND`. NodeNext makes TypeScript enforce the `.js` suffix at authoring and at `tsc --noEmit` during `mcp-use build`, so the mismatch surfaces at compile time instead of at server start.

--- a/libraries/typescript/packages/create-mcp-use-app/src/templates/blank/tsconfig.json
+++ b/libraries/typescript/packages/create-mcp-use-app/src/templates/blank/tsconfig.json
@@ -2,8 +2,8 @@
   "compilerOptions": {
     "target": "ES2022",
     "jsx": "react-jsx",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "allowJs": true,
     "strict": true,
     "outDir": "./dist",

--- a/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/resources/product-search-result/components/Accordion.tsx
+++ b/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/resources/product-search-result/components/Accordion.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { AccordionItem } from "./AccordionItem";
+import { AccordionItem } from "./AccordionItem.js";
 
 export interface AccordionItemData {
   question: string;

--- a/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/resources/product-search-result/components/AccordionItem.tsx
+++ b/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/resources/product-search-result/components/AccordionItem.tsx
@@ -1,6 +1,6 @@
 import { Animate } from "@openai/apps-sdk-ui/components/Transition";
 import React from "react";
-import type { AccordionItemProps } from "../types";
+import type { AccordionItemProps } from "../types.js";
 
 export const AccordionItem: React.FC<AccordionItemProps> = ({
   question,

--- a/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/resources/product-search-result/components/Carousel.tsx
+++ b/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/resources/product-search-result/components/Carousel.tsx
@@ -1,7 +1,7 @@
 import { Animate } from "@openai/apps-sdk-ui/components/Transition";
 import React, { useRef } from "react";
-import { CarouselItem } from "./CarouselItem";
-import { useCarouselAnimation } from "../hooks/useCarouselAnimation";
+import { CarouselItem } from "./CarouselItem.js";
+import { useCarouselAnimation } from "../hooks/useCarouselAnimation.js";
 
 interface CarouselProps {
   results: Array<{ fruit: string; color: string }>;

--- a/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/resources/product-search-result/widget.tsx
+++ b/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/resources/product-search-result/widget.tsx
@@ -9,11 +9,11 @@ import {
 import React, { useCallback } from "react";
 import { Link } from "react-router";
 import "../styles.css";
-import { Carousel } from "./components/Carousel";
-import { CarouselSkeleton } from "./components/CarouselSkeleton";
-import { Accordion } from "./components/Accordion";
-import type { ProductSearchResultProps } from "./types";
-import { propSchema } from "./types";
+import { Carousel } from "./components/Carousel.js";
+import { CarouselSkeleton } from "./components/CarouselSkeleton.js";
+import { Accordion } from "./components/Accordion.js";
+import type { ProductSearchResultProps } from "./types.js";
+import { propSchema } from "./types.js";
 import { Button } from "@openai/apps-sdk-ui/components/Button";
 import {
   Expand,

--- a/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/tsconfig.json
+++ b/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/tsconfig.json
@@ -2,8 +2,8 @@
   "compilerOptions": {
     "target": "ES2022",
     "jsx": "react-jsx",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "allowJs": true,
     "strict": true,
     "outDir": "./dist",

--- a/libraries/typescript/packages/create-mcp-use-app/src/templates/starter/tsconfig.json
+++ b/libraries/typescript/packages/create-mcp-use-app/src/templates/starter/tsconfig.json
@@ -2,8 +2,8 @@
   "compilerOptions": {
     "target": "ES2022",
     "jsx": "react-jsx",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "allowJs": true,
     "strict": true,
     "outDir": "./dist",


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

Check all that apply:
- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

Flip the `create-mcp-use-app` template tsconfigs from `module: "ESNext"` + `moduleResolution: "bundler"` to `module: "NodeNext"` + `moduleResolution: "NodeNext"` across all three templates (`blank`, `starter`, `mcp-apps`).

Scaffolded apps run under native Node ESM — `mcp-use start` spawns plain `node` on the esbuild output ([`libraries/typescript/packages/cli/src/index.ts:2348`](libraries/typescript/packages/cli/src/index.ts#L2348)), and `transpileWithEsbuild` runs with `bundle: false` + `format: "esm"` so it passes import specifiers through untouched ([`libraries/typescript/packages/cli/src/index.ts:1040`](libraries/typescript/packages/cli/src/index.ts#L1040)). The previous `bundler` resolution let TypeScript accept extensionless relative imports like `from "./qc-framework"` that Node then rejected with `ERR_MODULE_NOT_FOUND` once users split their server into multiple files. `mcp-use dev` masked the issue because it runs through `tsx`, whose resolver handles extensionless TS imports.

NodeNext makes TypeScript enforce `.js` suffixes at authoring time and at the `tsc --noEmit` pass already wired into `mcp-use build`, so the mismatch surfaces at compile time instead of at server start.

## Implementation Details

1. Updated `compilerOptions.module` from `"ESNext"` to `"NodeNext"` in all three template tsconfigs.
2. Updated `compilerOptions.moduleResolution` from `"bundler"` to `"NodeNext"` in the same files.
3. Left everything else (`target`, `jsx`, `paths`, `baseUrl`, includes) unchanged. Template source files have no relative imports today, so no source edits were needed. Widgets under `mcp-apps/resources/**` are compiled by Vite, not esbuild, so NodeNext here doesn't affect widget authoring.
4. Added a changeset for `create-mcp-use-app` (patch).

---

## TypeScript Checklist

### Packages Modified

- [ ] `docs`
- [ ] `tests`
- [ ] `cli`
- [x] `create-mcp-use-app`
- [ ] `mcp-use` (server)
- [ ] `mcp-use` (client)
- [ ] `inspector`

### Pre-commit Checklist

- [ ] Ran `pnpm lint:fix` to auto-fix linting issues
- [ ] Ran `pnpm format` to format code with Prettier
- [ ] Ran `pnpm build` and build succeeds without errors
- [x] Ran `pnpm changeset` to create a changeset (if this PR includes user-facing changes)
- [ ] Added or updated tests if needed
- [ ] Updated documentation in `docs/` folder if needed

---

## Example Usage (Before)

```jsonc
// templates/*/tsconfig.json
{
  "compilerOptions": {
    "module": "ESNext",
    "moduleResolution": "bundler",
    // ...
  }
}
```

```ts
// A user splits their server into ./qc-framework.ts and imports it from index.ts:
import { something } from "./qc-framework"; // TS happy, tsc --noEmit happy

// After `mcp-use build && mcp-use start`:
//   Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../dist/qc-framework'
//   imported from .../dist/index.js
//   Did you mean to import "./qc-framework.js"?
```

## Example Usage (After)

```jsonc
// templates/*/tsconfig.json
{
  "compilerOptions": {
    "module": "NodeNext",
    "moduleResolution": "NodeNext",
    // ...
  }
}
```

```ts
// Same code now fails at tsc --noEmit, before `mcp-use start` is ever invoked:
import { something } from "./qc-framework";
//                        ~~~~~~~~~~~~~~~~~
// Relative import paths need explicit file extensions in ECMAScript imports
// when '--moduleResolution' is 'node16' or 'nodenext'. Did you mean './qc-framework.js'?

// The correct form, which also matches Node's runtime resolution:
import { something } from "./qc-framework.js";
```

## Documentation Updates

None in this PR. The CLI README already shows `"moduleResolution": "bundler"` in one example snippet and could be refreshed as a follow-up, but that's cosmetic.

## Testing

- Manually inspected all three template `tsconfig.json` files after the edit to confirm the two option changes and no other drift.
- Verified no template source files currently use extensionless relative imports (grepped `templates/**/index.ts` and `templates/**/src/**`), so the switch is a no-op for the scaffolded starter code.
- Widgets under `mcp-apps/resources/**` are Vite-compiled; they keep `bundler`-style resolution via Vite's own config and are unaffected.
- Build pipeline: `mcp-use build` already runs `tsc --noEmit` after `transpileWithEsbuild`; NodeNext now turns the previously-silent extensionless-import case into a type-check error there.

Not yet run locally: `pnpm lint:fix`, `pnpm format`, `pnpm build`. Will run prior to merge.

## Backwards Compatibility

- **New projects scaffolded after this PR:** behavior-changing at authoring time only. TypeScript will flag extensionless relative imports; users must write `from "./foo.js"`. This matches the runtime Node ESM requirement and removes a latent footgun.
- **Existing scaffolded projects:** unaffected by this change — their tsconfigs stay as shipped. They'll continue to exhibit the original bug if they use extensionless imports. A separate follow-up (docs and/or a CLI-side import rewriter) can address those; intentionally out of scope here.