### PR TITLE
feat(server): dynamic `allowedOrigins` for multi-domain hosting + Host validation + widget CSP

### DIFF
--- a/docs/inspector/cli.mdx
+++ b/docs/inspector/cli.mdx
@@ -116,6 +116,8 @@ MCP_URL=https://my-tunnel.trycloudflare.com npx @mcp-use/cli dev
 
 <Tip>
 When using a reverse proxy, set `MCP_URL` to the public-facing URL. This ensures widget hot-reload (HMR) and asset loading work correctly through the proxy.
+
+For multi-domain or preview deployments (several public URLs pointing at the same server), use [`allowedOrigins`](/typescript/server/content-security-policy) in `MCPServer` config instead. Widget `<base>` and CSP are then computed per request.
 </Tip>
 
 ## Automatic Port Selection

--- a/docs/typescript/changelog/changelog.mdx
+++ b/docs/typescript/changelog/changelog.mdx
@@ -6,6 +6,18 @@ rss: true
 tag: "New"
 ---
 
+<Update label="v1.25.0" description="April 2026">
+  ## Dynamic `allowedOrigins` for multi-domain deployments
+  Minor release extending `allowedOrigins` from a static `string[]` to a dynamic allow-list that drives both DNS-rebinding Host validation and widget `<base>` / CSP per request.
+
+- **New**: `allowedOrigins` accepts an object form (`{ origins, provider, providerUrl, token, headers, webhookSecret, fallbackRevalidateSeconds }`) with wildcard support (`https://*.preview.example.com`), async provider callback, remote JSON provider URL honoring `Cache-Control` / `ETag` / `If-None-Match` / `stale-while-revalidate`, and an optional HMAC-signed push webhook at `POST /mcp-use/internal/origins/refresh`
+- **New**: Widget `<base>`, `window.__getFile`, `window.__mcpPublicUrl`, and CSP (`connect_domains` / `resource_domains` / `base_uri_domains`) are computed per-request from the allow-list when any `allowedOrigins` is set — unknown `Host` falls back to `baseUrl` / `MCP_URL`
+- **New**: Env vars `MCP_ALLOWED_ORIGINS`, `MCP_ALLOWED_ORIGINS_URL`, `MCP_ALLOWED_ORIGINS_TOKEN`, `MCP_ALLOWED_ORIGINS_WEBHOOK_SECRET`
+- **New**: Fail-closed cold start — when a provider is configured but the initial fetch fails AND no static origins are set, `/mcp` returns `503 origin allow-list unavailable` until the resolver recovers (no silent bypass of Host validation)
+- **Backwards-compatible**: `allowedOrigins: string[]` keeps today's hostname-level Host validation semantics; unset `allowedOrigins` keeps today's static `baseUrl`-only widgets
+- **Docs**: Rewritten [Content Security Policy](/typescript/server/content-security-policy) and [Configuration](/typescript/server/configuration) pages; new [dynamic-origins example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/ui/mcp-apps/dynamic-origins)
+</Update>
+
 <Update label="v1.24.0" description="April 2026">
   <Frame>
     <img src="https://mcp-use.com/api/og/release?v=1.24.0&title=OAuth%20scopes%2C%20telemetry%2C%20CLI%203%20%26%20device%20flow&date=2026-04&lang=typescript" alt="Release 1.24.0" />

--- a/docs/typescript/server/api-reference.mdx
+++ b/docs/typescript/server/api-reference.mdx
@@ -112,45 +112,72 @@ interface ServerConfig {
     maxAge?: number
     credentials?: boolean
   }
-  allowedOrigins?: string[] // Allowed origin values (normalized to hostnames for global Host validation)
+  allowedOrigins?: string[] | AllowedOriginsConfig // Drives DNS-rebinding Host validation AND dynamic widget base-URL / CSP
   sessionIdleTimeoutMs?: number     // Idle timeout for sessions in milliseconds (default: 86400000 = 1 day)
   autoCreateSessionOnInvalidId?: boolean // @deprecated Will be removed in a future version. Use sessionStore for persistent sessions.
+}
+
+interface AllowedOriginsConfig {
+  origins?: string[]
+  provider?: () => string[] | Promise<string[]>
+  providerUrl?: string
+  token?: string
+  headers?: Record<string, string>
+  webhookSecret?: string
+  fallbackRevalidateSeconds?: number // default 60s
 }
 ```
 
 **`allowedOrigins` Configuration:**
 
-The `allowedOrigins` option controls DNS rebinding host validation:
+Single option with two roles:
+- **DNS-rebinding host validation** — unknown `Host` → `403`.
+- **Dynamic widget hosting** — per request, widget `<base>`, asset URLs and CSP (`connect_domains`, `resource_domains`, `base_uri_domains`) use the incoming request's origin when it matches the allow-list.
 
-- **Default behavior** (`allowedOrigins` not set):
-  - Host validation is disabled
-  - All `Host` values are accepted
+Behavior summary:
 
-- **When `allowedOrigins` is set**:
-  - Values are normalized to hostnames and used as the Host allow list
-  - Validation applies across the whole server
+- Unset → no Host validation, widgets use the single static `baseUrl`.
+- `string[]` form → static allow-list with wildcard support (`"https://*.preview.example.com"`).
+- Object form → adds async provider, remote `providerUrl` with HTTP cache validators, and the optional HMAC push webhook at `POST /mcp-use/internal/origins/refresh`.
 
-- **When `allowedOrigins` is empty**:
-  - Host validation remains disabled
+Environment variables:
+
+- `MCP_ALLOWED_ORIGINS` — comma-separated list (merged with constructor `origins`).
+- `MCP_ALLOWED_ORIGINS_URL` — remote provider URL (merged with `providerUrl`).
+- `MCP_ALLOWED_ORIGINS_TOKEN` — Bearer token for the provider.
+- `MCP_ALLOWED_ORIGINS_WEBHOOK_SECRET` — enables the push webhook.
 
 **Example:**
 ```typescript
-// Default behavior: host validation disabled
-const server = new MCPServer({
-  name: 'my-server',
-  version: '1.0.0'
+// Default: no host validation
+const dev = new MCPServer({ name: 'dev', version: '1.0.0' })
+
+// Static multi-domain with wildcards
+const app = new MCPServer({
+  name: 'app',
+  version: '1.0.0',
+  baseUrl: process.env.MCP_URL,
+  allowedOrigins: [
+    'https://app.example.com',
+    'https://*.preview.example.com',
+  ],
 })
 
-// Production: explicit allow list
-const server = new MCPServer({
-  name: 'my-server',
+// Dynamic provider + webhook for instant invalidation
+const dynamic = new MCPServer({
+  name: 'dynamic',
   version: '1.0.0',
-  allowedOrigins: [
-    'https://myapp.com',
-    'https://app.myapp.com'
-  ]
+  baseUrl: process.env.MCP_URL,
+  allowedOrigins: {
+    origins: ['https://app.example.com'],
+    providerUrl: process.env.MCP_ALLOWED_ORIGINS_URL,
+    token: process.env.MCP_ALLOWED_ORIGINS_TOKEN,
+    webhookSecret: process.env.MCP_ALLOWED_ORIGINS_WEBHOOK_SECRET,
+  },
 })
 ```
+
+See [Content Security Policy](./content-security-policy) for the provider contract and webhook signature format.
 
 ## Core Server Methods
 

--- a/docs/typescript/server/configuration.mdx
+++ b/docs/typescript/server/configuration.mdx
@@ -44,8 +44,15 @@ const server = new MCPServer({
     allowMethods: ['GET', 'POST', 'OPTIONS'],
   },
 
-  // ── DNS Rebinding Protection ───────────────────────────────
-  allowedOrigins: ['https://myapp.com'],  // Enables Host header validation
+  // ── Allowed origins (Host validation + widget CSP) ─────────
+  // Plain array form (hostname-level Host validation, static CSP).
+  allowedOrigins: ['https://myapp.com', 'https://*.preview.myapp.com'],
+  // Or object form for async providers + HMAC webhook:
+  // allowedOrigins: {
+  //   origins: ['https://myapp.com'],
+  //   providerUrl: process.env.MCP_ALLOWED_ORIGINS_URL,
+  //   webhookSecret: process.env.MCP_ALLOWED_ORIGINS_WEBHOOK_SECRET,
+  // },
 
   // ── Transport ─────────────────────────────────────────────
   stateless: false,                     // See "Stateless Mode" below
@@ -341,43 +348,74 @@ MCP protocol routes (`/mcp`, `/mcp-use/widgets/*`, `/inspector`) are registered 
 
 ## Security Configuration
 
-### DNS Rebinding Protection
+### Allowed origins (Host validation + widget CSP)
 
-Use `allowedOrigins` to enable Host header validation and protect against DNS rebinding attacks.
+`allowedOrigins` is one option with two roles:
+
+1. **DNS-rebinding protection** — rejects requests with an unknown `Host` header (`403`).
+2. **Dynamic widget hosting** — when set, widget `<base>`, `window.__getFile`, `window.__mcpPublicUrl`, and CSP are computed per request from the allow-list so the same server can serve multiple domains.
 
 **Behavior:**
-- `allowedOrigins` not set (default) → no host validation, all `Host` values accepted
-- `allowedOrigins: []` → no host validation (same as not set)
-- `allowedOrigins: ['https://myapp.com']` → Host header must match one of the configured hostnames; applies globally to all routes
+
+- Not set (default) → no Host validation, widgets use the single static `baseUrl`.
+- `string[]` form → static allow-list; supports wildcards like `"https://*.preview.example.com"`. Matches one subdomain label (CSP host-source semantics).
+- Object form → adds async providers and an HMAC push webhook.
 
 ```typescript
-// Default: no host validation (development)
-const devServer = new MCPServer({
-  name: 'dev-server',
-  version: '1.0.0',
-})
-
-// Production: restrict to known hostnames
-const prodServer = new MCPServer({
-  name: 'prod-server',
-  version: '1.0.0',
-  allowedOrigins: [
-    'https://myapp.com',
-    'https://app.myapp.com',
-  ],
-})
-
-// Load from environment
+// Single-domain production deployment
 const server = new MCPServer({
-  name: 'my-server',
-  version: '1.0.0',
-  allowedOrigins: process.env.ALLOWED_ORIGINS?.split(','),
-})
+  name: "prod-server",
+  version: "1.0.0",
+  baseUrl: process.env.MCP_URL,
+  allowedOrigins: ["https://myapp.com", "https://app.myapp.com"],
+});
+
+// Multi-domain with wildcards
+const previewServer = new MCPServer({
+  name: "preview-server",
+  version: "1.0.0",
+  baseUrl: process.env.MCP_URL,
+  allowedOrigins: [
+    "https://app.example.com",
+    "https://*.preview.example.com", // matches pr-42.preview.example.com
+  ],
+});
+
+// Dynamic: remote provider + instant updates via webhook
+const dynamicServer = new MCPServer({
+  name: "dynamic-server",
+  version: "1.0.0",
+  baseUrl: process.env.MCP_URL,
+  allowedOrigins: {
+    origins: ["https://app.example.com"],
+    providerUrl: process.env.MCP_ALLOWED_ORIGINS_URL,
+    token: process.env.MCP_ALLOWED_ORIGINS_TOKEN,
+    webhookSecret: process.env.MCP_ALLOWED_ORIGINS_WEBHOOK_SECRET,
+  },
+});
 ```
 
+Environment variables:
+
+```env
+MCP_ALLOWED_ORIGINS=https://app.example.com,https://*.b.com
+MCP_ALLOWED_ORIGINS_URL=https://config.example.com/origins.json
+MCP_ALLOWED_ORIGINS_TOKEN=sk_...
+MCP_ALLOWED_ORIGINS_WEBHOOK_SECRET=whsec_...
+```
+
+`MCP_ALLOWED_ORIGINS_URL` is fetched with standard HTTP cache validators
+(`Cache-Control`, `ETag`, `If-None-Match`, `stale-while-revalidate`). See
+[Content Security Policy](./content-security-policy) for the provider
+contract and webhook format.
+
 <Tip>
-`allowedOrigins` accepts full URLs (e.g. `"https://myapp.com"`) and normalizes them to hostnames for validation.
+Entries accept full URLs (`"https://myapp.com"`) or hostnames (`"myapp.com"`). Wildcards match exactly one subdomain label and must include at least two suffix labels (`*.example.com` is accepted; `*.com` is not).
 </Tip>
+
+<Warning>
+When an object-form provider is configured but the initial fetch fails and no static `origins` are set, `/mcp` returns `503 origin allow-list unavailable` until the resolver recovers. This prevents silently disabling Host validation when the upstream is down at boot.
+</Warning>
 
 ### Session Timeout
 

--- a/docs/typescript/server/content-security-policy.mdx
+++ b/docs/typescript/server/content-security-policy.mdx
@@ -1,38 +1,141 @@
 ---
 title: "Content Security Policy"
-description: "Configure CSP for MCP Apps and ChatGPT Apps SDK widgets"
+description: "Configure CSP and multi-domain hosting for MCP Apps and ChatGPT Apps SDK widgets"
 icon: "shield"
 ---
 
 Content Security Policy (CSP) controls which domains your widgets can fetch from, load scripts/styles from, and embed. Widgets run in sandboxed iframes, so CSP must explicitly allow any external resources.
 
-## Automatic Configuration
+Since `mcp-use` v3.0, CSP and widget base URLs can be driven by a single
+dynamic allow-list via `allowedOrigins` — useful when the same server is
+reachable from multiple domains (preview deployments, canary, custom domains).
 
-When `baseUrl` is set (via `MCPServer` constructor or `MCP_URL` environment variable), mcp-use automatically configures CSP:
+## Automatic configuration
+
+When `baseUrl` is set (via `MCPServer` constructor or `MCP_URL` env var),
+mcp-use automatically configures CSP for that one origin. This is fine for
+single-domain deployments:
 
 ```typescript
 const server = new MCPServer({
   name: "my-server",
   version: "1.0.0",
-  baseUrl: process.env.MCP_URL, // Required for production
+  baseUrl: process.env.MCP_URL, // Single public URL
 });
 ```
 
-This ensures:
+CSP includes the server origin, widget `<base>` and asset URLs resolve to it,
+and everything works out of the box.
 
-- Widget URLs use the correct domain
-- CSP includes your server domain
-- Works behind proxies and custom domains
+## Multi-domain / dynamic origins
 
-The server origin is auto-injected into each widget's `connectDomains`, `resourceDomains`, and `baseUriDomains`—you don't need to add it manually.
+To serve the same MCP server from multiple domains (`app.example.com`,
+`preview-42.example.com`, etc.) use the object form of `allowedOrigins`.
+One option drives both DNS-rebinding Host validation and per-request widget
+`<base>` + CSP rewriting:
 
-## Per-Widget Configuration
+```typescript
+const server = new MCPServer({
+  name: "my-server",
+  version: "1.0.0",
+  baseUrl: process.env.MCP_URL, // Fallback when Host isn't allow-listed
+  allowedOrigins: {
+    origins: [
+      "https://app.example.com",
+      "https://*.preview.example.com", // wildcards: one label
+    ],
+    providerUrl: process.env.MCP_ALLOWED_ORIGINS_URL, // optional
+    token: process.env.MCP_ALLOWED_ORIGINS_TOKEN, // optional
+    webhookSecret: process.env.MCP_ALLOWED_ORIGINS_WEBHOOK_SECRET, // optional
+  },
+});
+```
 
-For widgets that need additional domains (APIs, CDNs, etc.), configure CSP in your widget metadata.
+Per request, mcp-use:
 
-### MCP Apps (all compatible clients, ChatGPT, Claude etc..)
+1. Validates the `Host` header against the allow-list. Unknown hosts → `403`.
+2. If matched, sets the widget `<base>`, `window.__getFile`,
+   `window.__mcpPublicUrl`, and CSP (`connect_domains`, `resource_domains`,
+   `base_uri_domains`) to the request's own origin, unioned with every
+   allow-list entry (wildcards passed through verbatim).
+3. If not matched but routed past Host validation (edge case), falls back to
+   `baseUrl`.
 
-With `type: "mcpApps"`, use camelCase in `metadata.csp`:
+### Static vs dynamic forms
+
+| Form | Host validation | Wildcards | Widget `<base>` | Widget CSP |
+| --- | --- | --- | --- | --- |
+| `allowedOrigins` unset | off | n/a | `baseUrl` | `baseUrl` + `CSP_URLS` + widget `metadata.csp` |
+| `allowedOrigins: string[]` | on | yes | Request origin if matched, else `baseUrl` | Same as dynamic: union |
+| `allowedOrigins: { … }` | on | yes | Same | Same |
+
+The object form additionally unlocks async providers, remote provider URL,
+and the HMAC push webhook.
+
+## Provider endpoint
+
+For lists you want to update without redeploying, point `providerUrl` at a
+JSON endpoint you control. mcp-use honors standard HTTP cache validators:
+
+```http
+GET /origins.json
+Authorization: Bearer <token>
+If-None-Match: "v42"
+```
+
+```http
+200 OK
+Cache-Control: public, max-age=10, stale-while-revalidate=60
+ETag: "v42"
+
+["https://app.example.com", "https://*.preview.example.com"]
+```
+
+- `max-age` / `s-maxage` controls how often the server revalidates.
+- `stale-while-revalidate` lets mcp-use serve the cached list while a
+  background refresh runs (zero added latency).
+- `ETag` / `Last-Modified` trigger conditional `304 Not Modified` responses,
+  keeping steady-state cost near zero.
+- 5xx / network failures are non-fatal: last-known-good list is kept and
+  retried per `Cache-Control`.
+- On cold start, if the provider fails AND no static `origins` are set,
+  /mcp returns `503 origin allow-list unavailable` — **fail-closed**.
+
+## Push webhook
+
+For instant invalidation (no need to wait for revalidation), set
+`webhookSecret` and POST to `/mcp-use/internal/origins/refresh` with an
+HMAC-signed body. Stripe-style:
+
+```http
+POST /mcp-use/internal/origins/refresh
+X-MCP-Signature: t=1734567890,v1=<hex hmac-sha256(secret, "<t>.<body>")>
+Content-Type: application/json
+
+{ "origins": ["https://app.example.com", "https://*.preview.example.com"] }
+```
+
+- Valid signature + inline `origins` → list is swapped in-memory, `204 No Content`.
+- Valid signature + empty body → cache is invalidated, next read refetches `providerUrl`.
+- Invalid signature → `401`.
+- Timestamp >5 minutes off → `401` (replay protection).
+
+## Environment variables
+
+```env
+MCP_URL=https://myserver.com                               # fallback baseUrl
+MCP_ALLOWED_ORIGINS=https://app.example.com,https://*.b.com # static list
+MCP_ALLOWED_ORIGINS_URL=https://config.example.com/origins.json
+MCP_ALLOWED_ORIGINS_TOKEN=sk_...                            # Authorization: Bearer
+MCP_ALLOWED_ORIGINS_WEBHOOK_SECRET=whsec_...                # enables webhook
+CSP_URLS=https://extra.example.com                          # legacy — appended to CSP
+```
+
+## Per-widget CSP (CDN, auth providers, analytics)
+
+`allowedOrigins` is about **where this server lives**. Origins your widget
+itself fetches from (CDNs, analytics, third-party APIs) go inline in the
+widget's `metadata.csp` just like before:
 
 ```typescript
 export const widgetMetadata: WidgetMetadata = {
@@ -42,15 +145,15 @@ export const widgetMetadata: WidgetMetadata = {
     csp: {
       connectDomains: ["https://api.weather.com"],
       resourceDomains: ["https://cdn.weather.com"],
-      baseUriDomains: ["https://myserver.com"],
-      frameDomains: ["https://trusted-embed.com"],
-      redirectDomains: ["https://oauth.provider.com"],
     },
   },
 };
 ```
 
-### Apps SDK Format (ChatGPT only - DEPRECATED)
+These entries are merged with whatever `allowedOrigins` resolves to at read
+time, so widgets "just work" across multiple domains.
+
+### Apps SDK (ChatGPT-only, deprecated)
 
 With `type: "appsSdk"`, use snake_case in `appsSdkMetadata["openai/widgetCSP"]`:
 
@@ -59,72 +162,55 @@ export const appsSdkMetadata = {
   "openai/widgetCSP": {
     connect_domains: ["https://api.weather.com"],
     resource_domains: ["https://cdn.weather.com"],
-    frame_domains: ["https://trusted-embed.com"],
-    redirect_domains: ["https://oauth.provider.com"],
   },
 };
 ```
 
-### Field Reference
+### Field reference
 
 | MCP Apps (camelCase) | Apps SDK (snake_case) | Description |
 | -------------------- | --------------------- | ----------- |
 | `connectDomains` | `connect_domains` | Domains for fetch, XHR, WebSocket |
 | `resourceDomains` | `resource_domains` | Domains for scripts, styles, images |
-| `baseUriDomains` | `base_uri_domains` | Domains for base URI (MCP Apps) |
+| `baseUriDomains` | `base_uri_domains` | Domains for `<base>` (MCP Apps) |
 | `frameDomains` | `frame_domains` | Domains for iframe embeds |
 | `redirectDomains` | `redirect_domains` | Domains for redirects (ChatGPT-specific) |
-| `scriptDirectives` | `script_directives` | Custom script CSP directives, not all clients support this (e.g. ChatGPT) |
-| `styleDirectives` | `style_directives` | Custom style CSP directives |
+| `scriptDirectives` | `script_directives` | Custom script directives (not all clients support this) |
+| `styleDirectives` | `style_directives` | Custom style directives |
 
 <Note>
-Your CSP domains are merged with your server's base URL automatically. For ChatGPT, OpenAI's required domains (`*.oaistatic.com`, etc.) are also added. For MCP Apps clients, only the domains you declare are used.
+mcp-use always adds the current allow-list (static + provider + effective request origin) to `connect_domains`, `resource_domains`, and `base_uri_domains`. For ChatGPT, OpenAI's required domains (`*.oaistatic.com`, etc.) are also added. You only need to list additional domains your widget talks to.
 </Note>
 
-## Environment Variables
+## Static (CDN) deployments
+
+When widget assets live on a CDN while the MCP server runs elsewhere, list
+both origins in `allowedOrigins` (or leave them in the widget's own
+`metadata.csp.resourceDomains`):
 
 ```env
-# Base URL — auto-included in widget CSP
-MCP_URL=https://myserver.com
-
-# Additional domains (comma-separated) — appended to widget CSP
-CSP_URLS=https://api.example.com,https://cdn.example.com
+MCP_URL=https://api.example.com
+MCP_ALLOWED_ORIGINS=https://api.example.com,https://cdn.example.com
 ```
-
-- **MCP_URL**: Base URL for widget assets and public files. Also used by the server to configure CSP.
-- **CSP_URLS**: (Optional) Additional domains to whitelist. Supports comma-separated list. Required for static deployments where widget assets are served from different domains.
-
-## Static Deployments
-
-When widgets are served from static storage (e.g., Supabase Storage) while the MCP server runs elsewhere, set:
-
-- **MCP_URL**: Where widget assets are stored
-- **MCP_SERVER_URL**: Where the MCP server runs (for API calls)
-- **CSP_URLS**: Domains for storage and API access (e.g., `https://YOUR_PROJECT.supabase.co`)
 
 See [Supabase deployment](./deployment/supabase) for a complete setup.
 
-<Tip>
-**Alternative**: Instead of the global `CSP_URLS` environment variable, configure CSP per-widget in `metadata.csp`
-</Tip>
+## Inspector debugging
 
-## Inspector Debugging
+The mcp-use Inspector provides a **CSP Mode Toggle**:
 
-The mcp-use Inspector provides a **CSP Mode Toggle** for testing:
-
-- **Permissive** — Relaxed CSP for debugging
-- **Widget-Declared** — Enforces the widget's declared CSP (production-like)
+- **Permissive** — relaxed CSP for debugging
+- **Widget-Declared** — enforces the widget's declared CSP (production-like)
 
 <Warning>
-CSP violations are logged in the console. Use Widget-Declared mode to catch CSP issues before production deployment.
+CSP violations are logged in the browser console. Use Widget-Declared mode
+before shipping to catch issues early.
 </Warning>
 
 See [Debugging ChatGPT Apps](/inspector/debugging-chatgpt-apps) for details.
 
+## Next steps
 
-## Next Steps
-
-- [MCP Apps](./mcp-apps) — Unified metadata format for both protocols
-- [ChatGPT Apps SDK](./ui-widgets) — Widget metadata and registration
-- [Supabase Deployment](./deployment/supabase) — Static deployment with CSP
-- [Debugging Widgets](/inspector/debugging-chatgpt-apps) — Test CSP in the Inspector
+- [MCP Apps](./mcp-apps) — unified metadata format for both protocols
+- [Configuration](./configuration) — every `MCPServer` option
+- [API reference](./api-reference) — `AllowedOriginsConfig` shape

--- a/docs/typescript/server/creating-mcp-apps-server.mdx
+++ b/docs/typescript/server/creating-mcp-apps-server.mdx
@@ -299,7 +299,9 @@ Create a `.env` file:
 ```env
 # Server port (default: 3000)
 PORT=3000
-# Production base URL; used for CSP and widget asset URLs — required for production
+# Production base URL; used for CSP and widget asset URLs — required for production.
+# For multi-domain deployments set `allowedOrigins` in MCPServer config instead of
+# relying on a single static MCP_URL. See docs/typescript/server/content-security-policy.
 MCP_URL=https://your-server.com
 # Environment mode (development | production)
 NODE_ENV=production

--- a/docs/typescript/server/deployment/supabase.mdx
+++ b/docs/typescript/server/deployment/supabase.mdx
@@ -336,7 +336,9 @@ supabase secrets set CSP_URLS="https://YOUR_PROJECT_REF.supabase.co" --project-r
 
 **Important**: Set these before deploying the function. If you set them after deployment, you must redeploy for the changes to take effect.
 
-**Alternative**: You can also configure CSP per-widget in your widget's `appsSdkMetadata['openai/widgetCSP']` instead of using the global `CSP_URLS` environment variable. See [Content Security Policy](../content-security-policy) or [UI Widgets](/typescript/server/ui-widgets#apps-sdk-metadata) for examples.
+**Multi-domain / preview deployments**: if your edge function is reachable from multiple public domains, set `allowedOrigins` on `MCPServer` (or `MCP_ALLOWED_ORIGINS` env var) instead of a single static `MCP_URL`. Widget CSP adapts per-request. See [Content Security Policy](../content-security-policy).
+
+**Alternative**: You can also configure CSP per-widget in your widget's `appsSdkMetadata['openai/widgetCSP']` or `metadata.csp` instead of using the global `CSP_URLS` environment variable. See [Content Security Policy](../content-security-policy) or [UI Widgets](/typescript/server/ui-widgets#apps-sdk-metadata) for examples.
 </Note>
 
 ### 9. Deploy the Function

--- a/docs/typescript/server/mcp-apps.mdx
+++ b/docs/typescript/server/mcp-apps.mdx
@@ -85,6 +85,10 @@ const server = new MCPServer({
   name: "my-server",
   version: "1.0.0",
   baseUrl: process.env.MCP_URL || "http://localhost:3000",
+  // Serve from multiple domains? Set `allowedOrigins` — widget CSP and
+  // asset URLs will be computed per-request. See
+  // [Content Security Policy](./content-security-policy).
+  // allowedOrigins: ["https://app.example.com", "https://*.preview.example.com"],
 });
 
 // Register a dual-protocol widget

--- a/docs/typescript/server/ui-widgets.mdx
+++ b/docs/typescript/server/ui-widgets.mdx
@@ -817,6 +817,10 @@ This ensures:
 Preferably set the variable at build time to have statically generated widget assets paths.
 If you don't set it at build time you must set it at runtime either by passing the `baseUrl` option to the `MCPServer` constructor or by setting the `MCP_URL` environment variable.
 
+<Tip>
+**Multi-domain / preview deployments**: if the same server is reachable from multiple domains (canary, preview URLs, custom domains), set [`allowedOrigins`](./configuration#allowed-origins-host-validation--widget-csp) instead of a single `baseUrl`. Widget `<base>`, asset paths, and CSP will be computed per request against the allow-list (wildcards supported, async providers + push webhook available). See [Content Security Policy](./content-security-policy).
+</Tip>
+
 ### Environment Variables
 
 ```env

--- a/libraries/typescript/.changeset/dynamic-allowed-origins.md
+++ b/libraries/typescript/.changeset/dynamic-allowed-origins.md
@@ -1,0 +1,16 @@
+---
+"mcp-use": minor
+---
+
+feat(server): dynamic `allowedOrigins` for multi-domain hosting + Host validation + widget CSP
+
+Extend the existing `allowedOrigins` option from a static `string[]` to `string[] | AllowedOriginsConfig`. A single `OriginResolver` now drives BOTH DNS-rebinding Host validation AND per-request widget `<base>` / asset URLs / CSP, so the same MCP server can serve multiple public domains (Vercel-style previews, canary, custom domains) without redeploying.
+
+- New object form: `{ origins, provider, providerUrl, token, headers, webhookSecret, fallbackRevalidateSeconds }`
+- Wildcard hostnames (`https://*.preview.example.com`) — one-label semantics, same as CSP host-source
+- Remote `providerUrl` with HTTP cache validators (`Cache-Control` / `ETag` / `If-None-Match` / `stale-while-revalidate`) and single-flight refresh
+- HMAC-signed push webhook at `POST /mcp-use/internal/origins/refresh` for instant invalidation (Stripe-style `X-MCP-Signature: t=...,v1=...`, 5-minute replay window)
+- New env vars: `MCP_ALLOWED_ORIGINS`, `MCP_ALLOWED_ORIGINS_URL`, `MCP_ALLOWED_ORIGINS_TOKEN`, `MCP_ALLOWED_ORIGINS_WEBHOOK_SECRET`
+- Per-request widget output: `<base>`, `window.__getFile`, `window.__mcpPublicUrl`, and CSP (`connect_domains` / `resource_domains` / `base_uri_domains`) are computed from the allow-list + effective request origin; unknown `Host` falls back to `baseUrl` / `MCP_URL`
+- Fail-closed cold start: if providers are configured but the initial fetch fails AND no static origins are set, `/mcp` returns `503 origin allow-list unavailable` until the resolver recovers — no silent bypass of Host validation
+- Backward compatible: `allowedOrigins: string[]` keeps today's semantics (hostname-level Host validation, static widget `baseUrl`). Unset `allowedOrigins` is unchanged.

--- a/libraries/typescript/.changeset/fix-proxy-fetch-interceptor-teardown.md
+++ b/libraries/typescript/.changeset/fix-proxy-fetch-interceptor-teardown.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Fix inspector "Protected resource does not match" error when switching from Via Proxy to Direct connection. The `window.fetch` interceptor installed by `BrowserOAuthClientProvider` is now correctly restored when `useMcp` unmounts, preventing the stale proxy interceptor from interfering with subsequent direct OAuth flows.

--- a/libraries/typescript/.changeset/inspector-ui-improvements.md
+++ b/libraries/typescript/.changeset/inspector-ui-improvements.md
@@ -1,0 +1,12 @@
+---
+"@mcp-use/inspector": minor
+---
+
+Inspector navbar UX improvements
+
+- Chat tab moved to first position, always shows label even when collapsed, with visual separator
+- Active tab label stays visible when navbar is collapsed (new `alwaysExpanded` prop on TabsTrigger)
+- Deploy button added linking to manufact.com/signup with inspector referrer
+- Tunnel button repositioned between Add to Client and Deploy, restyled with violet theme, now visible in mobile layout
+- Theme toggle, command palette, and GitHub consolidated into a settings dropdown menu
+- "Report a Bug" menu item added, pre-fills GitHub issue with inspector label

--- a/libraries/typescript/.changeset/late-lies-tan.md
+++ b/libraries/typescript/.changeset/late-lies-tan.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/cli": patch
+---
+
+refactor(cli): enhance deploy command with GitHub authorization handling

--- a/libraries/typescript/.changeset/pre.json
+++ b/libraries/typescript/.changeset/pre.json
@@ -1,0 +1,11 @@
+{
+  "mode": "pre",
+  "tag": "canary",
+  "initialVersions": {
+    "@mcp-use/cli": "3.0.0",
+    "create-mcp-use-app": "0.14.8",
+    "@mcp-use/inspector": "2.0.0",
+    "mcp-use": "1.24.0"
+  },
+  "changesets": []
+}

--- a/libraries/typescript/.changeset/pre.json
+++ b/libraries/typescript/.changeset/pre.json
@@ -7,5 +7,7 @@
     "@mcp-use/inspector": "2.0.0",
     "mcp-use": "1.24.0"
   },
-  "changesets": []
+  "changesets": [
+    "inspector-ui-improvements"
+  ]
 }

--- a/libraries/typescript/.changeset/pre.json
+++ b/libraries/typescript/.changeset/pre.json
@@ -8,6 +8,7 @@
     "mcp-use": "1.24.0"
   },
   "changesets": [
+    "fix-proxy-fetch-interceptor-teardown",
     "inspector-ui-improvements"
   ]
 }

--- a/libraries/typescript/.changeset/pre.json
+++ b/libraries/typescript/.changeset/pre.json
@@ -9,6 +9,7 @@
   },
   "changesets": [
     "fix-proxy-fetch-interceptor-teardown",
-    "inspector-ui-improvements"
+    "inspector-ui-improvements",
+    "late-lies-tan"
   ]
 }

--- a/libraries/typescript/packages/cli/CHANGELOG.md
+++ b/libraries/typescript/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @mcp-use/cli
 
+## 3.0.1-canary.0
+
+### Patch Changes
+
+- Updated dependencies [27bd31c]
+  - @mcp-use/inspector@2.1.0-canary.0
+  - mcp-use@1.24.1-canary.0
+
 ## 3.0.0
 
 ### Major Changes

--- a/libraries/typescript/packages/cli/CHANGELOG.md
+++ b/libraries/typescript/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @mcp-use/cli
 
+## 3.0.1-canary.2
+
+### Patch Changes
+
+- 744db4d: refactor(cli): enhance deploy command with GitHub authorization handling
+  - mcp-use@1.24.1-canary.2
+  - @mcp-use/inspector@2.1.0-canary.2
+
 ## 3.0.1-canary.1
 
 ### Patch Changes

--- a/libraries/typescript/packages/cli/CHANGELOG.md
+++ b/libraries/typescript/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @mcp-use/cli
 
+## 3.0.1-canary.1
+
+### Patch Changes
+
+- Updated dependencies [9fed740]
+  - mcp-use@1.24.1-canary.1
+  - @mcp-use/inspector@2.1.0-canary.1
+
 ## 3.0.1-canary.0
 
 ### Patch Changes

--- a/libraries/typescript/packages/cli/package.json
+++ b/libraries/typescript/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-use/cli",
   "type": "module",
-  "version": "3.0.1-canary.1",
+  "version": "3.0.1-canary.2",
   "description": "The mcp-use CLI is a tool for building and deploying MCP servers with support for ChatGPT Apps, Code Mode, OAuth, Notifications, Sampling, Observability and more.",
   "author": "mcp-use, Inc.",
   "license": "MIT",

--- a/libraries/typescript/packages/cli/package.json
+++ b/libraries/typescript/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-use/cli",
   "type": "module",
-  "version": "3.0.0",
+  "version": "3.0.1-canary.0",
   "description": "The mcp-use CLI is a tool for building and deploying MCP servers with support for ChatGPT Apps, Code Mode, OAuth, Notifications, Sampling, Observability and more.",
   "author": "mcp-use, Inc.",
   "license": "MIT",

--- a/libraries/typescript/packages/cli/package.json
+++ b/libraries/typescript/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-use/cli",
   "type": "module",
-  "version": "3.0.1-canary.0",
+  "version": "3.0.1-canary.1",
   "description": "The mcp-use CLI is a tool for building and deploying MCP servers with support for ChatGPT Apps, Code Mode, OAuth, Notifications, Sampling, Observability and more.",
   "author": "mcp-use, Inc.",
   "license": "MIT",

--- a/libraries/typescript/packages/cli/src/commands/deploy.ts
+++ b/libraries/typescript/packages/cli/src/commands/deploy.ts
@@ -3,7 +3,7 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import open from "open";
 import type { OrgInfo } from "../utils/api.js";
-import { McpUseAPI } from "../utils/api.js";
+import { McpUseAPI, GitHubAuthRequiredError } from "../utils/api.js";
 import {
   getWebUrl,
   isLoggedIn,
@@ -15,6 +15,7 @@ import {
   gitInit,
   gitAddRemoteAndPush,
   gitCommitAndPush,
+  hasUncommittedChanges,
   isGitHubUrl,
 } from "../utils/git.js";
 import { getMcpServerUrl } from "../utils/cloud-urls.js";
@@ -691,14 +692,11 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
       process.exit(1);
     }
 
-    // Default to first org-type installation, fallback to first
-    const defaultInstallation =
-      installations.find((i) => i.account_type === "Organization") ??
-      installations[0];
-    const installationDbId = defaultInstallation.id;
-    const githubInstallationId = defaultInstallation.installation_id;
-
     console.log(chalk.green("✓ GitHub connected\n"));
+
+    // Resolved later based on user selection or repo ownership.
+    let installationDbId: string | undefined;
+    let githubInstallationId: string | undefined;
 
     // ── Step 4: Project & Git ─────────────────────────────────────
     const projectDir = options.rootDir
@@ -801,54 +799,8 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
       }
 
       const repoInstallation = installations[selectedIdx];
-
-      // Personal accounts cannot create repos via GitHub App installation tokens.
-      if (repoInstallation.account_type !== "Organization") {
-        console.log(
-          chalk.yellow(
-            "\n⚠️  GitHub Apps cannot create repos on personal accounts.\n"
-          )
-        );
-        console.log(
-          chalk.white("To deploy from ") +
-            chalk.cyan(repoInstallation.account_login) +
-            chalk.white(", create a repository manually:\n")
-        );
-        console.log(
-          chalk.cyan("  1. ") +
-            chalk.white("Go to ") +
-            chalk.cyan("https://github.com/new")
-        );
-        console.log(
-          chalk.cyan("  2. ") +
-            chalk.white("Create a repository (any name, can be private)")
-        );
-        console.log(chalk.cyan("  3. ") + chalk.white("Add it as a remote:"));
-        console.log(chalk.gray("     git init && git remote add origin <url>"));
-        console.log(chalk.cyan("  4. ") + chalk.white("Push your code:"));
-        console.log(
-          chalk.gray(
-            "     git add . && git commit -m 'Initial commit' && git push -u origin main"
-          )
-        );
-        console.log(
-          chalk.cyan("  5. ") +
-            chalk.white("Grant the GitHub App access to the repo:")
-        );
-        const appName = await api.getGitHubAppName();
-        console.log(
-          chalk.gray(
-            `     https://github.com/apps/${appName}/installations/new`
-          )
-        );
-        console.log(
-          chalk.cyan("  6. ") +
-            chalk.white("Run ") +
-            chalk.cyan("mcp-use deploy") +
-            chalk.white(" again\n")
-        );
-        process.exit(0);
-      }
+      installationDbId = repoInstallation.id;
+      githubInstallationId = repoInstallation.installation_id;
 
       const repoName = options.yes
         ? projectName
@@ -861,20 +813,76 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
           `Creating repository on ${repoInstallation.account_login}...`
         )
       );
-      const repoResult = await api.createGitHubRepo({
-        installationId: repoInstallation.installation_id,
-        name: repoName,
-        private: true,
-        org: repoInstallation.account_login,
-      });
+
+      let repoResult: { fullName: string; cloneUrl: string; htmlUrl: string };
+      try {
+        repoResult = await api.createGitHubRepo({
+          installationId: repoInstallation.installation_id,
+          name: repoName,
+          private: true,
+          org: repoInstallation.account_login,
+        });
+      } catch (err) {
+        if (err instanceof GitHubAuthRequiredError) {
+          console.log(
+            chalk.yellow(
+              `\n  Personal accounts require a one-time GitHub authorization.\n`
+            )
+          );
+          try {
+            await open(err.authorizeUrl);
+            console.log(
+              chalk.gray("  Browser opened. Authorize and return here.\n")
+            );
+          } catch {
+            console.log(
+              chalk.gray(
+                `  Open this URL in your browser:\n  ${err.authorizeUrl}\n`
+              )
+            );
+          }
+          const readline = await import("node:readline");
+          await new Promise<void>((resolve) => {
+            const rl = readline.createInterface({
+              input: process.stdin,
+              output: process.stdout,
+            });
+            rl.question(
+              chalk.gray("  Press Enter after authorizing..."),
+              () => {
+                rl.close();
+                resolve();
+              }
+            );
+          });
+          console.log(chalk.gray("Retrying repository creation..."));
+          repoResult = await api.createGitHubRepo({
+            installationId: repoInstallation.installation_id,
+            name: repoName,
+            private: true,
+            org: repoInstallation.account_login,
+          });
+        } else {
+          throw err;
+        }
+      }
       console.log(chalk.green(`✓ Created ${chalk.cyan(repoResult.fullName)}`));
 
       if (!gitInfo.isGitRepo) {
+        await ensureGitignore(cwd);
         console.log(chalk.gray("Initializing git..."));
         await gitInit(cwd, "Initial commit");
         console.log(chalk.gray("Pushing to GitHub..."));
         await gitAddRemoteAndPush(cwd, repoResult.cloneUrl, "main");
       } else {
+        if (await hasUncommittedChanges(cwd)) {
+          console.log(
+            chalk.red(
+              "✗ You have uncommitted changes. Commit and push before deploying."
+            )
+          );
+          process.exit(1);
+        }
         console.log(chalk.gray("Adding remote and pushing..."));
         await gitAddRemoteAndPush(
           cwd,
@@ -899,23 +907,40 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
       repoFullName = `${gitInfo.owner}/${gitInfo.repo}`;
       branch = gitInfo.branch || "main";
 
-      // Check for uncommitted changes and offer to commit+push
+      // Resolve installation matching the repo owner
+      const ownerLower = gitInfo.owner!.toLowerCase();
+      const matchingInst =
+        installations.find(
+          (i) => i.account_login.toLowerCase() === ownerLower
+        ) ??
+        installations.find((i) => i.account_type === "Organization") ??
+        installations[0];
+      installationDbId = matchingInst.id;
+      githubInstallationId = matchingInst.installation_id;
+
+      // Check for uncommitted changes
       if (gitInfo.hasUncommittedChanges) {
-        console.log(chalk.yellow("⚠️  You have uncommitted changes.\n"));
-        if (!options.yes) {
-          const shouldCommit = await prompt(
-            chalk.white("Commit and push changes before deploying? (Y/n): "),
-            "y"
+        if (options.yes) {
+          console.log(
+            chalk.red(
+              "✗ You have uncommitted changes. Commit and push before deploying."
+            )
           );
-          if (shouldCommit) {
-            await ensureGitignore(cwd);
-            console.log(chalk.gray("Committing and pushing..."));
-            await gitCommitAndPush(cwd, "Deploy changes", branch);
-            gitInfo = await getGitInfo(cwd);
-            console.log(chalk.green("✓ Changes pushed\n"));
-          } else {
-            console.log(chalk.gray("Deploying from last pushed commit.\n"));
-          }
+          process.exit(1);
+        }
+        console.log(chalk.yellow("⚠️  You have uncommitted changes.\n"));
+        const shouldCommit = await prompt(
+          chalk.white("Commit and push changes before deploying? (Y/n): "),
+          "y"
+        );
+        if (shouldCommit) {
+          await ensureGitignore(cwd);
+          console.log(chalk.gray("Committing and pushing..."));
+          await gitCommitAndPush(cwd, "Deploy changes", branch);
+          gitInfo = await getGitInfo(cwd);
+          console.log(chalk.green("✓ Changes pushed\n"));
+        } else {
+          console.log(chalk.gray("Deploying from last pushed commit.\n"));
         }
       }
 
@@ -1092,6 +1117,15 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
 
     if (!serverId) {
       const orgId = await api.resolveOrganizationId();
+
+      if (!installationDbId) {
+        console.log(
+          chalk.red(
+            "✗ Could not determine GitHub installation for this repository."
+          )
+        );
+        process.exit(1);
+      }
 
       console.log(chalk.gray("Creating server and deployment..."));
       const serverResult = await api.createServer({

--- a/libraries/typescript/packages/cli/src/utils/api.ts
+++ b/libraries/typescript/packages/cli/src/utils/api.ts
@@ -1,5 +1,14 @@
 import { getApiKey, getApiUrl, getAuthBaseUrl, getOrgId } from "./config.js";
 
+export class GitHubAuthRequiredError extends Error {
+  readonly authorizeUrl: string;
+  constructor(message: string, authorizeUrl: string) {
+    super(message);
+    this.name = "GitHubAuthRequiredError";
+    this.authorizeUrl = authorizeUrl;
+  }
+}
+
 export interface OrgInfo {
   id: string;
   name: string;
@@ -245,8 +254,19 @@ export class McpUseAPI {
       }
 
       if (!response.ok) {
-        const error = await response.text();
-        throw new Error(`API request failed: ${response.status} ${error}`);
+        const errorText = await response.text();
+        try {
+          const parsed = JSON.parse(errorText);
+          if (parsed.code === "GITHUB_AUTH_REQUIRED" && parsed.authorizeUrl) {
+            throw new GitHubAuthRequiredError(
+              parsed.error || "GitHub authorization required",
+              parsed.authorizeUrl
+            );
+          }
+        } catch (e) {
+          if (e instanceof GitHubAuthRequiredError) throw e;
+        }
+        throw new Error(`API request failed: ${response.status} ${errorText}`);
       }
 
       return response.json() as Promise<T>;
@@ -526,5 +546,23 @@ export class McpUseAPI {
         org: opts.org,
       }),
     });
+  }
+
+  async getGitHubOAuthUrl(): Promise<{ url: string; state: string }> {
+    return this.request<{ url: string; state: string }>(
+      "/github/oauth/authorize"
+    );
+  }
+
+  async exchangeGitHubOAuthToken(
+    code: string
+  ): Promise<{ success: boolean; installationsUpdated: number }> {
+    return this.request<{ success: boolean; installationsUpdated: number }>(
+      "/github/oauth/token",
+      {
+        method: "POST",
+        body: JSON.stringify({ code }),
+      }
+    );
   }
 }

--- a/libraries/typescript/packages/inspector/CHANGELOG.md
+++ b/libraries/typescript/packages/inspector/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @mcp-use/inspector
 
+## 2.1.0-canary.2
+
+### Patch Changes
+
+- mcp-use@1.24.1-canary.2
+
 ## 2.1.0-canary.1
 
 ### Patch Changes

--- a/libraries/typescript/packages/inspector/CHANGELOG.md
+++ b/libraries/typescript/packages/inspector/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @mcp-use/inspector
 
+## 2.1.0-canary.1
+
+### Patch Changes
+
+- Updated dependencies [9fed740]
+  - mcp-use@1.24.1-canary.1
+
 ## 2.1.0-canary.0
 
 ### Minor Changes

--- a/libraries/typescript/packages/inspector/CHANGELOG.md
+++ b/libraries/typescript/packages/inspector/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @mcp-use/inspector
 
+## 2.1.0-canary.0
+
+### Minor Changes
+
+- 27bd31c: Inspector navbar UX improvements
+  - Chat tab moved to first position, always shows label even when collapsed, with visual separator
+  - Active tab label stays visible when navbar is collapsed (new `alwaysExpanded` prop on TabsTrigger)
+  - Deploy button added linking to manufact.com/signup with inspector referrer
+  - Tunnel button repositioned between Add to Client and Deploy, restyled with violet theme, now visible in mobile layout
+  - Theme toggle, command palette, and GitHub consolidated into a settings dropdown menu
+  - "Report a Bug" menu item added, pre-fills GitHub issue with inspector label
+
+### Patch Changes
+
+- mcp-use@1.24.1-canary.0
+
 ## 2.0.0
 
 ### Patch Changes

--- a/libraries/typescript/packages/inspector/package.json
+++ b/libraries/typescript/packages/inspector/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-use/inspector",
   "type": "module",
-  "version": "2.1.0-canary.1",
+  "version": "2.1.0-canary.2",
   "description": "MCP Inspector - A tool for inspecting and debugging MCP servers",
   "author": "",
   "license": "MIT",
@@ -79,7 +79,7 @@
   },
   "peerDependencies": {
     "express": "^4.21.2 || ^5.0.0",
-    "mcp-use": ">=1.24.1-canary.1",
+    "mcp-use": ">=1.24.1-canary.2",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
     "react-router": "^7.12.0"

--- a/libraries/typescript/packages/inspector/package.json
+++ b/libraries/typescript/packages/inspector/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-use/inspector",
   "type": "module",
-  "version": "2.0.0",
+  "version": "2.1.0-canary.0",
   "description": "MCP Inspector - A tool for inspecting and debugging MCP servers",
   "author": "",
   "license": "MIT",
@@ -79,7 +79,7 @@
   },
   "peerDependencies": {
     "express": "^4.21.2 || ^5.0.0",
-    "mcp-use": ">=1.24.0",
+    "mcp-use": ">=1.24.1-canary.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
     "react-router": "^7.12.0"

--- a/libraries/typescript/packages/inspector/package.json
+++ b/libraries/typescript/packages/inspector/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-use/inspector",
   "type": "module",
-  "version": "2.1.0-canary.0",
+  "version": "2.1.0-canary.1",
   "description": "MCP Inspector - A tool for inspecting and debugging MCP servers",
   "author": "",
   "license": "MIT",
@@ -79,7 +79,7 @@
   },
   "peerDependencies": {
     "express": "^4.21.2 || ^5.0.0",
-    "mcp-use": ">=1.24.1-canary.0",
+    "mcp-use": ">=1.24.1-canary.1",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
     "react-router": "^7.12.0"

--- a/libraries/typescript/packages/inspector/src/client/components/AddToClientDropdown.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/AddToClientDropdown.tsx
@@ -1,3 +1,4 @@
+import { MCPAddToClientEvent, Telemetry } from "@/client/telemetry";
 import { Button } from "@/client/components/ui/button";
 import {
   Dialog,
@@ -102,7 +103,16 @@ export function AddToClientDropdown({
 
   const { url, name, headers } = serverConfig;
 
+  const trackAddToClient = (client: string) => {
+    try {
+      Telemetry.getInstance()
+        .capture(new MCPAddToClientEvent({ client }))
+        .catch(() => {});
+    } catch {}
+  };
+
   const handleCursorClick = () => {
+    trackAddToClient("cursor");
     try {
       const deepLink = generateCursorDeepLink(url, name, headers);
       window.location.href = deepLink;
@@ -114,6 +124,7 @@ export function AddToClientDropdown({
   };
 
   const handleVSCodeClick = () => {
+    trackAddToClient("vscode");
     try {
       const deepLink = generateVSCodeDeepLink(url, name, headers);
       window.location.href = deepLink;
@@ -125,6 +136,7 @@ export function AddToClientDropdown({
   };
 
   const handleVSCodeInsidersClick = () => {
+    trackAddToClient("vscode-insiders");
     try {
       const deepLink = generateVSCodeInsidersDeepLink(url, name, headers);
       window.location.href = deepLink;
@@ -136,6 +148,7 @@ export function AddToClientDropdown({
   };
 
   const handleClaudeDesktopClick = () => {
+    trackAddToClient("claude-desktop");
     try {
       downloadMcpbFile(url, name, headers);
       onSuccess?.("Claude Desktop");
@@ -146,16 +159,19 @@ export function AddToClientDropdown({
   };
 
   const handleClaudeCodeClick = () => {
+    trackAddToClient("claude-code");
     setSelectedClient("claude-code");
     setShowModal(true);
   };
 
   const handleGeminiCLIClick = () => {
+    trackAddToClient("gemini-cli");
     setSelectedClient("gemini-cli");
     setShowModal(true);
   };
 
   const handleCodexCLIClick = () => {
+    trackAddToClient("codex-cli");
     setSelectedClient("codex-cli");
     setShowModal(true);
   };

--- a/libraries/typescript/packages/inspector/src/client/components/AddToClientDropdown.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/AddToClientDropdown.tsx
@@ -108,7 +108,9 @@ export function AddToClientDropdown({
       Telemetry.getInstance()
         .capture(new MCPAddToClientEvent({ client }))
         .catch(() => {});
-    } catch {}
+    } catch {
+      // ignore telemetry errors
+    }
   };
 
   const handleCursorClick = () => {

--- a/libraries/typescript/packages/inspector/src/client/components/InspectorDashboard.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/InspectorDashboard.tsx
@@ -102,7 +102,9 @@ export function InspectorDashboard() {
               })
             )
             .catch(() => {});
-        } catch {}
+        } catch {
+          // ignore telemetry errors
+        }
       } else if (
         connection.state === "failed" &&
         reportedConnectionsRef.current.has(connection.id)
@@ -119,7 +121,9 @@ export function InspectorDashboard() {
         Telemetry.getInstance()
           .capture(new MCPServerRemovedEvent({ serverId: connectionId }))
           .catch(() => {});
-      } catch {}
+      } catch {
+        // ignore telemetry errors
+      }
       reportedConnectionsRef.current.delete(connectionId);
       removeConnection(connectionId);
     },

--- a/libraries/typescript/packages/inspector/src/client/components/InspectorDashboard.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/InspectorDashboard.tsx
@@ -14,7 +14,12 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/client/components/ui/tooltip";
-import { MCPServerAddedEvent, Telemetry } from "@/client/telemetry";
+import {
+  MCPServerAddedEvent,
+  MCPServerConnectionEvent,
+  MCPServerRemovedEvent,
+  Telemetry,
+} from "@/client/telemetry";
 import {
   CircleMinus,
   Copy,
@@ -74,6 +79,52 @@ export function InspectorDashboard() {
     updateServerMetadata,
     updateServer,
   } = useMcpClient();
+
+  // Track which server connections have been reported to telemetry (dedup)
+  const reportedConnectionsRef = useRef<Set<string>>(new Set());
+
+  // Track server connection state transitions for telemetry
+  useEffect(() => {
+    connections.forEach((connection) => {
+      if (
+        connection.state === "ready" &&
+        !reportedConnectionsRef.current.has(connection.id)
+      ) {
+        reportedConnectionsRef.current.add(connection.id);
+        try {
+          Telemetry.getInstance()
+            .capture(
+              new MCPServerConnectionEvent({
+                serverId: connection.id,
+                serverUrl: connection.url,
+                success: true,
+                connectionType: "http",
+              })
+            )
+            .catch(() => {});
+        } catch {}
+      } else if (
+        connection.state === "failed" &&
+        reportedConnectionsRef.current.has(connection.id)
+      ) {
+        reportedConnectionsRef.current.delete(connection.id);
+      }
+    });
+  }, [connections]);
+
+  // Wrapper to track server removal in telemetry
+  const handleRemoveConnection = useCallback(
+    (connectionId: string) => {
+      try {
+        Telemetry.getInstance()
+          .capture(new MCPServerRemovedEvent({ serverId: connectionId }))
+          .catch(() => {});
+      } catch {}
+      reportedConnectionsRef.current.delete(connectionId);
+      removeConnection(connectionId);
+    },
+    [removeConnection]
+  );
 
   // Track concurrent updates to prevent race conditions
   const [updatingConnections, setUpdatingConnections] = useState<Set<string>>(
@@ -412,7 +463,7 @@ export function InspectorDashboard() {
   const handleClearAllConnections = () => {
     // Remove all connections
     connections.forEach((connection) => {
-      removeConnection(connection.id);
+      handleRemoveConnection(connection.id);
     });
   };
 
@@ -856,7 +907,7 @@ export function InspectorDashboard() {
                             size="sm"
                             onClick={(e) =>
                               handleActionClick(e, () =>
-                                removeConnection(connection.id)
+                                handleRemoveConnection(connection.id)
                               )
                             }
                             className="h-8 w-8 p-0"
@@ -961,7 +1012,7 @@ export function InspectorDashboard() {
                           <DropdownMenuItem
                             onClick={(e) => {
                               e.stopPropagation();
-                              removeConnection(connection.id);
+                              handleRemoveConnection(connection.id);
                             }}
                             className="text-destructive focus:text-destructive"
                           >

--- a/libraries/typescript/packages/inspector/src/client/components/Layout.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/Layout.tsx
@@ -8,7 +8,12 @@ import {
 import { useAutoConnect } from "@/client/hooks/useAutoConnect";
 import { useKeyboardShortcuts } from "@/client/hooks/useKeyboardShortcuts";
 import { useSavedRequests } from "@/client/hooks/useSavedRequests";
-import { MCPCommandPaletteOpenEvent, Telemetry } from "@/client/telemetry";
+import {
+  MCPCommandPaletteOpenEvent,
+  MCPTabNavigationEvent,
+  MCPSessionDurationEvent,
+  Telemetry,
+} from "@/client/telemetry";
 import {
   getStoredConnectionConfig,
   isAliasOnlyConnectionUpdate,
@@ -173,9 +178,59 @@ export function Layout({ children }: LayoutProps) {
     }
   }, [location.search, setActiveTab]);
 
+  // Tab navigation telemetry
+  const previousTabRef = useRef<string | null>(null);
+
+  // Session duration tracking
+  const sessionStartRef = useRef<number>(Date.now());
+  const tabsVisitedRef = useRef<Set<string>>(new Set());
+  const toolsExecutedRef = useRef<number>(0);
+
+  useEffect(() => {
+    const handler = () => {
+      toolsExecutedRef.current++;
+    };
+    window.addEventListener("mcp-tool-executed", handler);
+    return () => window.removeEventListener("mcp-tool-executed", handler);
+  }, []);
+
+  useEffect(() => {
+    const handleBeforeUnload = () => {
+      try {
+        const durationSeconds = Math.round(
+          (Date.now() - sessionStartRef.current) / 1000
+        );
+        Telemetry.getInstance()
+          .capture(
+            new MCPSessionDurationEvent({
+              durationSeconds,
+              tabsVisited: tabsVisitedRef.current.size,
+              toolsExecuted: toolsExecutedRef.current,
+            })
+          )
+          .catch(() => {});
+      } catch {}
+    };
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, []);
+
   // Sync the URL ?tab= param whenever the active tab changes
   const handleTabChange = useCallback(
     (tab: TabType) => {
+      try {
+        Telemetry.getInstance()
+          .capture(
+            new MCPTabNavigationEvent({
+              tab,
+              previousTab: previousTabRef.current,
+            })
+          )
+          .catch(() => {});
+      } catch {}
+      previousTabRef.current = tab;
+      tabsVisitedRef.current.add(tab);
+
       setActiveTab(tab);
       const params = new URLSearchParams(location.search);
       params.set("tab", tab);

--- a/libraries/typescript/packages/inspector/src/client/components/Layout.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/Layout.tsx
@@ -209,7 +209,9 @@ export function Layout({ children }: LayoutProps) {
             })
           )
           .catch(() => {});
-      } catch {}
+      } catch {
+        // ignore telemetry errors
+      }
     };
     window.addEventListener("beforeunload", handleBeforeUnload);
     return () => window.removeEventListener("beforeunload", handleBeforeUnload);
@@ -227,7 +229,9 @@ export function Layout({ children }: LayoutProps) {
             })
           )
           .catch(() => {});
-      } catch {}
+      } catch {
+        // ignore telemetry errors
+      }
       previousTabRef.current = tab;
       tabsVisitedRef.current.add(tab);
 

--- a/libraries/typescript/packages/inspector/src/client/components/LayoutHeader.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/LayoutHeader.tsx
@@ -376,7 +376,9 @@ function TunnelBadge({
       Telemetry.getInstance()
         .capture(new MCPTunnelActionEvent({ action: "start", success }))
         .catch(() => {});
-    } catch {}
+    } catch {
+      // ignore telemetry errors
+    }
   };
 
   const handleStopTunnel = async () => {
@@ -412,7 +414,9 @@ function TunnelBadge({
           })
         )
         .catch(() => {});
-    } catch {}
+    } catch {
+      // ignore telemetry errors
+    }
   };
 
   if (isTunnelStarting) {
@@ -770,7 +774,9 @@ export function LayoutHeader({
                           })
                         )
                         .catch(() => {});
-                    } catch {}
+                    } catch {
+                      // ignore telemetry errors
+                    }
                   }}
                 >
                   <Rocket className="size-4" />
@@ -1109,7 +1115,9 @@ export function LayoutHeader({
                         })
                       )
                       .catch(() => {});
-                  } catch {}
+                  } catch {
+                    // ignore telemetry errors
+                  }
                 }}
               >
                 <Rocket className="size-4" />

--- a/libraries/typescript/packages/inspector/src/client/components/LayoutHeader.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/LayoutHeader.tsx
@@ -11,12 +11,25 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/client/components/ui/tooltip";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@/client/components/ui/dropdown-menu";
 import type { TabType } from "@/client/context/InspectorContext";
 import { useInspector } from "@/client/context/InspectorContext";
 import { cn } from "@/client/lib/utils";
 import {
   ArrowUpRight,
   Bell,
+  Bug,
   Check,
   CheckSquare,
   ChevronDown,
@@ -30,8 +43,13 @@ import {
   Loader2,
   MessageCircle,
   MessageSquare,
+  Monitor,
+  Moon,
   Plus,
+  Rocket,
+  Settings,
   Square,
+  SunDim,
   Wrench,
 } from "lucide-react";
 import { INSPECTOR_RECONNECT_STORAGE_KEY } from "@/client/hooks/useAutoConnect";
@@ -41,11 +59,16 @@ import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { getServerDisplayName } from "@/client/utils/serverNames";
 import { copyToClipboard } from "@/client/utils/clipboard";
+import { useTheme } from "@/client/context/ThemeContext";
+import {
+  MCPTunnelActionEvent,
+  MCPDeployClickEvent,
+  Telemetry,
+} from "@/client/telemetry";
 import { AddToClientDropdown } from "./AddToClientDropdown";
 import LogoAnimated from "./LogoAnimated";
 import { SdkIntegrationModal } from "./SdkIntegrationModal";
 import { ServerDropdown } from "./ServerDropdown";
-import { ThemeToggle } from "./ThemeToggle";
 
 // Type alias for backward compatibility
 type MCPConnection = McpServer;
@@ -62,14 +85,15 @@ interface LayoutHeaderProps {
 }
 
 const tabs = [
+  { id: "chat", label: "Chat", icon: MessageCircle, alwaysExpanded: true },
+  { id: "separator" },
   { id: "tools", label: "Tools", icon: Wrench },
   { id: "prompts", label: "Prompts", icon: MessageSquare },
   { id: "resources", label: "Resources", icon: FolderOpen },
   { id: "sampling", label: "Sampling", icon: Hash },
   { id: "elicitation", label: "Elicitation", icon: CheckSquare },
   { id: "notifications", label: "Notifications", icon: Bell },
-  { id: "chat", label: "Chat", icon: MessageCircle },
-];
+] as const;
 
 function getTabCount(tabId: string, server: MCPConnection): number {
   if (tabId === "tools") {
@@ -330,6 +354,7 @@ function TunnelBadge({
     }
     setTunnelPhaseMessage(TUNNEL_PHASE.starting);
     setIsTunnelStarting(true);
+    let success = false;
     try {
       const res = await fetch("/inspector/api/dev/start-tunnel", {
         method: "POST",
@@ -342,15 +367,22 @@ function TunnelBadge({
       }
       // Server is restarting — poll until the new instance with tunnel is up
       await pollAndReconnect(true);
+      success = true;
     } catch {
       toast.error("Failed to start tunnel");
       setIsTunnelStarting(false);
     }
+    try {
+      Telemetry.getInstance()
+        .capture(new MCPTunnelActionEvent({ action: "start", success }))
+        .catch(() => {});
+    } catch {}
   };
 
   const handleStopTunnel = async () => {
     setTunnelPhaseMessage(TUNNEL_PHASE.stopping);
     setIsTunnelStarting(true);
+    let success = false;
     try {
       const res = await fetch("/inspector/api/dev/stop-tunnel", {
         method: "POST",
@@ -365,20 +397,32 @@ function TunnelBadge({
       setPopoverOpen(false);
       // Server is restarting — poll until the new instance without tunnel is up
       await pollAndReconnect(false);
+      success = true;
     } catch {
       toast.error("Failed to stop tunnel");
       setIsTunnelStarting(false);
     }
+    try {
+      Telemetry.getInstance()
+        .capture(
+          new MCPTunnelActionEvent({
+            action: "stop",
+            success,
+            tunnelUrl: tunnelUrl,
+          })
+        )
+        .catch(() => {});
+    } catch {}
   };
 
   if (isTunnelStarting) {
     return (
       <button
         disabled
-        className="flex items-center gap-2 h-9 px-3 bg-zinc-100 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded-full opacity-75 cursor-wait"
+        className="flex items-center gap-2 h-9 px-3 bg-violet-50 dark:bg-violet-950/40 border border-violet-200 dark:border-violet-800 rounded-full opacity-75 cursor-wait"
       >
-        <Loader2 className="size-4 text-zinc-500 dark:text-zinc-400 animate-spin" />
-        <span className="text-sm font-medium text-zinc-600 dark:text-zinc-300 hidden lg:inline">
+        <Loader2 className="size-4 text-violet-500 dark:text-violet-400 animate-spin" />
+        <span className="text-sm font-medium text-violet-600 dark:text-violet-300 hidden lg:inline">
           Start Tunnel <span className="tabular-nums">{waitTicks}s</span>
         </span>
       </button>
@@ -403,16 +447,16 @@ function TunnelBadge({
         className={cn(
           "flex items-center gap-2 h-9 px-3 border rounded-full transition-colors",
           canStart && !loadingDev
-            ? "bg-zinc-100 dark:bg-zinc-800 border-zinc-200 dark:border-zinc-700 hover:bg-zinc-200 dark:hover:bg-zinc-700 cursor-pointer"
-            : "bg-zinc-100/60 dark:bg-zinc-800/60 border-zinc-200 dark:border-zinc-700 cursor-not-allowed opacity-70"
+            ? "bg-violet-50 dark:bg-violet-950/40 border-violet-200 dark:border-violet-800 hover:bg-violet-100 dark:hover:bg-violet-900/50 cursor-pointer"
+            : "bg-violet-50/60 dark:bg-violet-950/20 border-violet-200 dark:border-violet-800 cursor-not-allowed opacity-70"
         )}
       >
         {loadingDev ? (
-          <Loader2 className="size-4 text-zinc-500 dark:text-zinc-400 animate-spin" />
+          <Loader2 className="size-4 text-violet-500 dark:text-violet-400 animate-spin" />
         ) : (
-          <ChevronsLeftRightEllipsis className="size-4 text-zinc-500 dark:text-zinc-400" />
+          <ChevronsLeftRightEllipsis className="size-4 text-violet-500 dark:text-violet-400" />
         )}
-        <span className="text-sm font-medium text-zinc-600 dark:text-zinc-300 hidden lg:inline">
+        <span className="text-sm font-medium text-violet-600 dark:text-violet-300 hidden lg:inline">
           Start Tunnel
         </span>
       </button>
@@ -539,6 +583,7 @@ export function LayoutHeader({
     setIsTunnelStarting,
     embeddedConfig,
   } = useInspector();
+  const { theme, setTheme } = useTheme();
   const showTunnelBadge =
     !!selectedServer &&
     (isLocalhostServerUrl(selectedServer.url) ||
@@ -557,7 +602,11 @@ export function LayoutHeader({
 
   // Filter tabs based on visibleTabs config
   const filteredTabs = embeddedConfig.visibleTabs
-    ? tabs.filter((t) => embeddedConfig.visibleTabs!.includes(t.id as TabType))
+    ? tabs.filter(
+        (t) =>
+          t.id === "separator" ||
+          embeddedConfig.visibleTabs!.includes(t.id as TabType)
+      )
     : tabs;
 
   const handleCopy = async () => {
@@ -691,25 +740,110 @@ export function LayoutHeader({
                     </>
                   );
                 })()}
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button variant="ghost" size="sm" asChild>
+              {/* Tunnel Badge - Mobile */}
+              {showTunnelBadge && (
+                <TunnelBadge
+                  tunnelUrl={tunnelUrl}
+                  isTunnelStarting={isTunnelStarting}
+                  setTunnelUrl={setTunnelUrl}
+                  setIsTunnelStarting={setIsTunnelStarting}
+                  copied={copied}
+                  setCopied={setCopied}
+                  handleCopy={handleCopy}
+                />
+              )}
+              <Button
+                asChild
+                size="sm"
+                className="rounded-full bg-blue-600 hover:bg-blue-700 text-white px-3"
+              >
+                <a
+                  href="https://manufact.com/signup?ref=mcp-use-inspector"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={() => {
+                    try {
+                      Telemetry.getInstance()
+                        .capture(
+                          new MCPDeployClickEvent({
+                            referrer: "mcp-use-inspector",
+                          })
+                        )
+                        .catch(() => {});
+                    } catch {}
+                  }}
+                >
+                  <Rocket className="size-4" />
+                </a>
+              </Button>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="p-2 hover:bg-zinc-200 dark:hover:bg-zinc-800 rounded-full transition-colors"
+                    aria-label="Settings"
+                  >
+                    <Settings className="size-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-48">
+                  <DropdownMenuSub>
+                    <DropdownMenuSubTrigger>
+                      {theme === "light" ? (
+                        <SunDim className="size-4 mr-2" />
+                      ) : theme === "dark" ? (
+                        <Moon className="size-4 mr-2" />
+                      ) : (
+                        <Monitor className="size-4 mr-2" />
+                      )}
+                      Theme
+                    </DropdownMenuSubTrigger>
+                    <DropdownMenuSubContent>
+                      <DropdownMenuRadioGroup
+                        value={theme}
+                        onValueChange={(v) =>
+                          setTheme(v as "light" | "dark" | "system")
+                        }
+                      >
+                        <DropdownMenuRadioItem value="light">
+                          <SunDim className="size-4 mr-2" />
+                          Light
+                        </DropdownMenuRadioItem>
+                        <DropdownMenuRadioItem value="dark">
+                          <Moon className="size-4 mr-2" />
+                          Dark
+                        </DropdownMenuRadioItem>
+                        <DropdownMenuRadioItem value="system">
+                          <Monitor className="size-4 mr-2" />
+                          System
+                        </DropdownMenuRadioItem>
+                      </DropdownMenuRadioGroup>
+                    </DropdownMenuSubContent>
+                  </DropdownMenuSub>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem asChild>
                     <a
                       href="https://github.com/mcp-use/mcp-use"
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="p-2"
-                      aria-label="GitHub"
                     >
-                      <GithubIcon className="h-4 w-4" />
+                      <GithubIcon className="h-4 w-4 mr-2" />
+                      GitHub
                     </a>
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <p>Give us a star ⭐</p>
-                </TooltipContent>
-              </Tooltip>
-              <ThemeToggle />
+                  </DropdownMenuItem>
+                  <DropdownMenuItem asChild>
+                    <a
+                      href="https://github.com/mcp-use/mcp-use/issues/new?labels=inspector&template=bug_report.md&title=%5BInspector%5D+"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <Bug className="size-4 mr-2" />
+                      Report a Bug
+                    </a>
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
             </div>
           )}
         </div>
@@ -725,6 +859,14 @@ export function LayoutHeader({
             >
               <TabsList className="w-full justify-center">
                 {filteredTabs.map((tab) => {
+                  if (tab.id === "separator") {
+                    return (
+                      <div
+                        key="separator"
+                        className="h-5 w-px bg-zinc-300 dark:bg-zinc-600 mx-1 shrink-0"
+                      />
+                    );
+                  }
                   const count = getTabCount(tab.id, selectedServer);
                   const showDot = shouldShowDot(tab.id, count, collapsed);
 
@@ -735,6 +877,9 @@ export function LayoutHeader({
                       data-testid={`tab-${tab.id}`}
                       icon={tab.icon}
                       showDot={showDot}
+                      alwaysExpanded={
+                        "alwaysExpanded" in tab && tab.alwaysExpanded
+                      }
                       className={cn(
                         "[&>svg]:mr-0 flex-1 flex-row gap-2 relative",
                         collapsed && "pl-2"
@@ -787,6 +932,14 @@ export function LayoutHeader({
               >
                 <TabsList className="overflow-x-auto" collapsible>
                   {filteredTabs.map((tab) => {
+                    if (tab.id === "separator") {
+                      return (
+                        <div
+                          key="separator"
+                          className="h-5 w-px bg-zinc-300 dark:bg-zinc-600 mx-1 shrink-0"
+                        />
+                      );
+                    }
                     const count = getTabCount(tab.id, selectedServer);
                     const tooltipText =
                       count > 0 ? `${tab.label} (${count})` : tab.label;
@@ -794,10 +947,14 @@ export function LayoutHeader({
 
                     return (
                       <TabsTrigger
+                        key={tab.id}
                         value={tab.id}
                         data-testid={`tab-${tab.id}`}
                         icon={tab.icon}
                         showDot={showDot}
+                        alwaysExpanded={
+                          "alwaysExpanded" in tab && tab.alwaysExpanded
+                        }
                         className={cn(
                           "[&>svg]:mr-0 lg:[&>svg]:mr-2 relative",
                           collapsed && "pl-4"
@@ -835,18 +992,6 @@ export function LayoutHeader({
         {/* Right side: Tunnel Badge + Add to Client + Theme Toggle + Command Palette + GitHub Button + Logo - Hidden in embedded mode */}
         {!embedded && (
           <div className="flex items-center gap-2 sm:gap-4 flex-shrink-0">
-            {/* Tunnel Badge */}
-            {showTunnelBadge && (
-              <TunnelBadge
-                tunnelUrl={tunnelUrl}
-                isTunnelStarting={isTunnelStarting}
-                setTunnelUrl={setTunnelUrl}
-                setIsTunnelStarting={setIsTunnelStarting}
-                copied={copied}
-                setCopied={setCopied}
-                handleCopy={handleCopy}
-              />
-            )}
             {selectedServer &&
               (() => {
                 const displayName = getServerDisplayName(selectedServer);
@@ -935,43 +1080,120 @@ export function LayoutHeader({
                   </>
                 );
               })()}
-            <ThemeToggle />
-            <Tooltip>
-              <TooltipTrigger asChild>
+            {/* Tunnel Badge */}
+            {showTunnelBadge && (
+              <TunnelBadge
+                tunnelUrl={tunnelUrl}
+                isTunnelStarting={isTunnelStarting}
+                setTunnelUrl={setTunnelUrl}
+                setIsTunnelStarting={setIsTunnelStarting}
+                copied={copied}
+                setCopied={setCopied}
+                handleCopy={handleCopy}
+              />
+            )}
+            <Button
+              asChild
+              className="rounded-full bg-blue-600 hover:bg-blue-700 text-white px-4"
+            >
+              <a
+                href="https://manufact.com/signup?ref=mcp-use-inspector"
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => {
+                  try {
+                    Telemetry.getInstance()
+                      .capture(
+                        new MCPDeployClickEvent({
+                          referrer: "mcp-use-inspector",
+                        })
+                      )
+                      .catch(() => {});
+                  } catch {}
+                }}
+              >
+                <Rocket className="size-4" />
+                <span className="hidden sm:inline">Deploy</span>
+              </a>
+            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
                 <Button
                   variant="ghost"
-                  className="hover:bg-zinc-200 dark:hover:bg-zinc-800 rounded-full px-1 -mx-3 flex gap-1"
+                  size="sm"
+                  className="p-2 hover:bg-zinc-200 dark:hover:bg-zinc-800 rounded-full transition-colors"
+                  aria-label="Settings"
+                >
+                  <Settings className="size-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-48">
+                <DropdownMenuItem
                   onClick={onCommandPaletteOpen}
                   data-testid="command-palette-trigger-button"
                 >
-                  <Command className="size-4" />
-                  <span className="text-base font-mono hidden sm:inline">
-                    K
+                  <Command className="size-4 mr-2" />
+                  Command Palette
+                  <span className="ml-auto text-xs text-muted-foreground">
+                    {"\u2318"}K
                   </span>
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>
-                <p>Command Palette</p>
-              </TooltipContent>
-            </Tooltip>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button variant="ghost" size="sm" asChild>
+                </DropdownMenuItem>
+                <DropdownMenuSub>
+                  <DropdownMenuSubTrigger>
+                    {theme === "light" ? (
+                      <SunDim className="size-4 mr-2" />
+                    ) : theme === "dark" ? (
+                      <Moon className="size-4 mr-2" />
+                    ) : (
+                      <Monitor className="size-4 mr-2" />
+                    )}
+                    Theme
+                  </DropdownMenuSubTrigger>
+                  <DropdownMenuSubContent>
+                    <DropdownMenuRadioGroup
+                      value={theme}
+                      onValueChange={(v) =>
+                        setTheme(v as "light" | "dark" | "system")
+                      }
+                    >
+                      <DropdownMenuRadioItem value="light">
+                        <SunDim className="size-4 mr-2" />
+                        Light
+                      </DropdownMenuRadioItem>
+                      <DropdownMenuRadioItem value="dark">
+                        <Moon className="size-4 mr-2" />
+                        Dark
+                      </DropdownMenuRadioItem>
+                      <DropdownMenuRadioItem value="system">
+                        <Monitor className="size-4 mr-2" />
+                        System
+                      </DropdownMenuRadioItem>
+                    </DropdownMenuRadioGroup>
+                  </DropdownMenuSubContent>
+                </DropdownMenuSub>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem asChild>
                   <a
                     href="https://github.com/mcp-use/mcp-use"
-                    className="flex items-center gap-2"
                     target="_blank"
                     rel="noopener noreferrer"
                   >
-                    <GithubIcon className="h-4 w-4" />
-                    <span className="hidden xl:inline">Github</span>
+                    <GithubIcon className="h-4 w-4 mr-2" />
+                    GitHub
                   </a>
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>
-                <p>Give us a star ⭐</p>
-              </TooltipContent>
-            </Tooltip>
+                </DropdownMenuItem>
+                <DropdownMenuItem asChild>
+                  <a
+                    href="https://github.com/mcp-use/mcp-use/issues/new?labels=inspector&template=bug_report.md&title=%5BInspector%5D+"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <Bug className="size-4 mr-2" />
+                    Report a Bug
+                  </a>
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
 
             <LogoAnimated state="expanded" />
           </div>

--- a/libraries/typescript/packages/inspector/src/client/components/ToolsTab.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ToolsTab.tsx
@@ -758,6 +758,7 @@ export function ToolsTab({
         .catch(() => {
           // Silently fail - telemetry should not break the application
         });
+      window.dispatchEvent(new Event("mcp-tool-executed"));
 
       // Widget resource was already fetched before tool execution (if applicable)
       // Now we just need to update the result with tool output
@@ -865,6 +866,7 @@ export function ToolsTab({
         .catch(() => {
           // Silently fail - telemetry should not break the application
         });
+      window.dispatchEvent(new Event("mcp-tool-executed"));
 
       const toolMeta =
         (selectedTool as any)?._meta || (selectedTool as any)?.metadata;

--- a/libraries/typescript/packages/inspector/src/client/components/chat/useConfig.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/useConfig.ts
@@ -184,7 +184,9 @@ export function useConfig({ mcpServerUrl }: UseConfigProps) {
           })
         )
         .catch(() => {});
-    } catch {}
+    } catch {
+      // ignore telemetry errors
+    }
 
     setConfigDialogOpen(false);
   }, [

--- a/libraries/typescript/packages/inspector/src/client/components/chat/useConfig.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/useConfig.ts
@@ -1,3 +1,4 @@
+import { MCPChatConfiguredEvent, Telemetry } from "@/client/telemetry";
 import { useCallback, useEffect, useState } from "react";
 import type { AuthConfig, LLMConfig } from "./types";
 import { DEFAULT_MODELS } from "./types";
@@ -172,6 +173,18 @@ export function useConfig({ mcpServerUrl }: UseConfigProps) {
 
     // Dispatch custom event to notify other components
     window.dispatchEvent(new CustomEvent("llm-config-updated"));
+
+    // Track chat configuration (no API key)
+    try {
+      Telemetry.getInstance()
+        .capture(
+          new MCPChatConfiguredEvent({
+            provider: tempProvider,
+            model: tempModel,
+          })
+        )
+        .catch(() => {});
+    } catch {}
 
     setConfigDialogOpen(false);
   }, [

--- a/libraries/typescript/packages/inspector/src/client/components/ui/tabs.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ui/tabs.tsx
@@ -277,6 +277,8 @@ interface TabsTriggerProps {
   icon?: LucideIcon;
   title?: string;
   showDot?: boolean;
+  /** When true, the label stays visible even when the tab bar is collapsed */
+  alwaysExpanded?: boolean;
 }
 
 // conditional tooltip wrapper if collapsed
@@ -325,6 +327,7 @@ const TabsTrigger = React.forwardRef<
       icon: Icon,
       title: titleProp,
       showDot = false,
+      alwaysExpanded = false,
       ...props
     },
     ref
@@ -334,11 +337,17 @@ const TabsTrigger = React.forwardRef<
     const variant = tabsListContext?.variant || "default";
     const isActive = activeValue === value;
 
+    // A tab's label is visible when: not collapsed, or it's the active tab, or alwaysExpanded
+    const showLabel = !collapsed || isActive || alwaysExpanded;
+
     // Use title prop when provided (for collapsed mode tooltips)
-    const title = collapsed && titleProp ? titleProp : undefined;
+    const title = collapsed && !showLabel && titleProp ? titleProp : undefined;
 
     return (
-      <ConditionalTooltip title={titleProp as string} collapsed={collapsed}>
+      <ConditionalTooltip
+        title={titleProp as string}
+        collapsed={collapsed && !showLabel}
+      >
         <button
           ref={ref}
           disabled={disabled}
@@ -352,7 +361,6 @@ const TabsTrigger = React.forwardRef<
             "relative z-10 flex-1 inline-flex items-center justify-center whitespace-nowrap text-sm font-medium ring-offset-background transition-all duration-500 ease-in-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 cursor-pointer",
             variant === "default" && "py-2.5",
             variant === "default" && "rounded-md px-4",
-            // variant === "default" && collapsed && "rounded-md px-1.5 aspect-square",
             variant === "underline" &&
               "px-6 py-3 border-b-2 border-transparent",
             isActive && "text-foreground",
@@ -365,8 +373,8 @@ const TabsTrigger = React.forwardRef<
             <Icon
               className={cn(
                 "h-4 w-4 transition-all duration-500 ease-in-out",
-                !collapsed && "mr-2",
-                collapsed && "mr-0!"
+                showLabel && "mr-2",
+                !showLabel && "mr-0!"
               )}
             />
           )}
@@ -376,7 +384,7 @@ const TabsTrigger = React.forwardRef<
           <span
             className={cn(
               "transition-all duration-500 ease-in-out overflow-hidden",
-              collapsed ? "w-0 opacity-0" : "w-auto opacity-100"
+              showLabel ? "w-auto opacity-100" : "w-0 opacity-0"
             )}
           >
             {children}

--- a/libraries/typescript/packages/inspector/src/client/telemetry/events.ts
+++ b/libraries/typescript/packages/inspector/src/client/telemetry/events.ts
@@ -206,3 +206,105 @@ export class MCPToolSavedEvent implements BaseTelemetryEvent {
     };
   }
 }
+
+export interface MCPTunnelActionEventData {
+  action: "start" | "stop";
+  success: boolean;
+  tunnelUrl?: string | null;
+}
+
+export class MCPTunnelActionEvent implements BaseTelemetryEvent {
+  name = "mcp_tunnel_action";
+  properties: Record<string, any>;
+
+  constructor(data: MCPTunnelActionEventData) {
+    this.properties = {
+      action: data.action,
+      success: data.success,
+      tunnel_url: data.tunnelUrl,
+    };
+  }
+}
+
+export interface MCPDeployClickEventData {
+  referrer: string;
+}
+
+export class MCPDeployClickEvent implements BaseTelemetryEvent {
+  name = "mcp_deploy_click";
+  properties: Record<string, any>;
+
+  constructor(data: MCPDeployClickEventData) {
+    this.properties = {
+      referrer: data.referrer,
+    };
+  }
+}
+
+export interface MCPChatConfiguredEventData {
+  provider: string;
+  model: string;
+}
+
+export class MCPChatConfiguredEvent implements BaseTelemetryEvent {
+  name = "mcp_chat_configured";
+  properties: Record<string, any>;
+
+  constructor(data: MCPChatConfiguredEventData) {
+    this.properties = {
+      provider: data.provider,
+      model: data.model,
+    };
+  }
+}
+
+export interface MCPTabNavigationEventData {
+  tab: string;
+  previousTab: string | null;
+}
+
+export class MCPTabNavigationEvent implements BaseTelemetryEvent {
+  name = "mcp_tab_navigation";
+  properties: Record<string, any>;
+
+  constructor(data: MCPTabNavigationEventData) {
+    this.properties = {
+      tab: data.tab,
+      previous_tab: data.previousTab,
+    };
+  }
+}
+
+export interface MCPAddToClientEventData {
+  client: string;
+}
+
+export class MCPAddToClientEvent implements BaseTelemetryEvent {
+  name = "mcp_add_to_client";
+  properties: Record<string, any>;
+
+  constructor(data: MCPAddToClientEventData) {
+    this.properties = {
+      client: data.client,
+    };
+  }
+}
+
+export interface MCPSessionDurationEventData {
+  durationSeconds: number;
+  tabsVisited: number;
+  toolsExecuted: number;
+}
+
+export class MCPSessionDurationEvent implements BaseTelemetryEvent {
+  name = "mcp_session_duration";
+  properties: Record<string, any>;
+
+  constructor(data: MCPSessionDurationEventData) {
+    this.properties = {
+      duration_seconds: data.durationSeconds,
+      tabs_visited: data.tabsVisited,
+      tools_executed: data.toolsExecuted,
+    };
+  }
+}

--- a/libraries/typescript/packages/inspector/src/client/telemetry/telemetry.ts
+++ b/libraries/typescript/packages/inspector/src/client/telemetry/telemetry.ts
@@ -49,6 +49,28 @@ function getCacheKey(key: string): string {
   return `mcp_inspector_telemetry_${key}`;
 }
 
+export type InspectorMode = "standalone" | "embedded" | "cloud";
+
+/**
+ * Detect the inspector deployment mode from the runtime config injected by the
+ * server (see shared-static.ts's `injectRuntimeConfig`). Defaults to
+ * "standalone" when no mode has been injected (e.g. when the inspector dev
+ * server serves via the Vite proxy and no runtime scripts are present).
+ */
+function detectInspectorMode(): InspectorMode {
+  if (typeof window === "undefined") return "standalone";
+  const injected = (window as unknown as { __MCP_INSPECTOR_MODE__?: string })
+    .__MCP_INSPECTOR_MODE__;
+  if (
+    injected === "standalone" ||
+    injected === "embedded" ||
+    injected === "cloud"
+  ) {
+    return injected;
+  }
+  return "standalone";
+}
+
 /**
  * Check if localStorage is available and functional.
  * Node.js 25+ has an experimental localStorage that exists but doesn't implement methods properly.
@@ -72,6 +94,7 @@ export class Telemetry {
   private _posthogClient: TelemetryEventLogger | null = null;
   private _scarfClient: TelemetryEventLogger | null = null;
   private _source: string = "inspector";
+  private _mode: InspectorMode = "standalone";
 
   private constructor() {
     // Check if we're in a browser environment first
@@ -82,6 +105,10 @@ export class Telemetry {
 
     // Check for source from localStorage or default to 'inspector'
     this._source = this.getStoredSource() || "inspector";
+
+    // Deployment mode is injected by the server into window; fixed for the
+    // lifetime of the page, so we capture it once here.
+    this._mode = detectInspectorMode();
 
     if (telemetryDisabled) {
       this._posthogClient = null;
@@ -161,6 +188,14 @@ export class Telemetry {
    */
   getSource(): string {
     return this._source;
+  }
+
+  /**
+   * Get the inspector's deployment mode (standalone CLI, embedded in mcp-use,
+   * or cloud-hosted). Emitted with every telemetry event.
+   */
+  getMode(): InspectorMode {
+    return this._mode;
   }
 
   get userId(): string {
@@ -248,7 +283,7 @@ export class Telemetry {
     // Send to PostHog proxy
     if (this._posthogClient) {
       try {
-        // Add package version, language flag, source, and user_id to all events
+        // Add package version, language flag, source, mode, and user_id to all events
         const properties: Record<string, any> = {
           event: event.name,
           user_id: this.userId, // Include user_id for distinct_id
@@ -258,6 +293,7 @@ export class Telemetry {
             language: "typescript",
             source: this._source,
             package: "inspector",
+            mode: this._mode,
           },
         };
 
@@ -270,7 +306,7 @@ export class Telemetry {
     // Send to Scarf proxy
     if (this._scarfClient) {
       try {
-        // Add package version, user_id, language flag, and source to all events
+        // Add package version, user_id, language flag, source, and mode to all events
         const properties: Record<string, any> = {};
         properties.mcp_use_version = getPackageVersion();
         properties.user_id = this.userId;
@@ -278,6 +314,7 @@ export class Telemetry {
         properties.language = "typescript";
         properties.source = this._source;
         properties.package = "inspector";
+        properties.mode = this._mode;
 
         await this._scarfClient.logEvent(properties);
       } catch {
@@ -333,6 +370,7 @@ export class Telemetry {
         eventProperties.language = "typescript";
         eventProperties.source = this._source;
         eventProperties.package = "inspector";
+        eventProperties.mode = this._mode;
 
         await this._scarfClient.logEvent(eventProperties);
       }

--- a/libraries/typescript/packages/inspector/src/server/cli.ts
+++ b/libraries/typescript/packages/inspector/src/server/cli.ts
@@ -6,6 +6,7 @@ import { cors } from "hono/cors";
 import { logger } from "hono/logger";
 import open from "open";
 import { registerInspectorRoutes } from "./shared-routes.js";
+import type { InspectorMode } from "./shared-static.js";
 import { registerStaticRoutes } from "./shared-static.js";
 import { setServerPort } from "./tunnel.js";
 import { findAvailablePort, isValidUrl } from "./utils.js";
@@ -80,8 +81,17 @@ app.use("/inspector/api/proxy/*", logger());
 
 registerInspectorRoutes(app, { autoConnectUrl: mcpUrl });
 
+// Detect the deployment mode. The same CLI binary powers both local standalone
+// usage (`npx @mcp-use/inspector`) and the cloud-hosted Railway deployment at
+// inspector.mcpus.com — Railway sets RAILWAY_ENVIRONMENT_NAME, so we use that
+// as the primary cloud signal, with an explicit MCP_INSPECTOR_MODE override
+// for other hosted environments.
+const inspectorMode: InspectorMode =
+  (process.env.MCP_INSPECTOR_MODE as InspectorMode | undefined) ??
+  (process.env.RAILWAY_ENVIRONMENT_NAME ? "cloud" : "standalone");
+
 // Register static file serving (must be last as it includes catch-all route)
-registerStaticRoutes(app);
+registerStaticRoutes(app, undefined, { inspectorMode });
 
 // Start the server with automatic port selection
 async function startServer() {

--- a/libraries/typescript/packages/inspector/src/server/middleware.ts
+++ b/libraries/typescript/packages/inspector/src/server/middleware.ts
@@ -49,6 +49,7 @@ export function mountInspector(
   const runtimeConfig = {
     devMode: config?.devMode,
     sandboxOrigin: config?.sandboxOrigin,
+    inspectorMode: "embedded" as const,
   };
 
   // If it's already a Hono app, register routes directly

--- a/libraries/typescript/packages/inspector/src/server/shared-static.ts
+++ b/libraries/typescript/packages/inspector/src/server/shared-static.ts
@@ -28,6 +28,12 @@ const CDN_JS_URL = `${CDN_BASE}/inspector@${INSPECTOR_VERSION}.js`;
 const CDN_CSS_URL = `${CDN_BASE}/inspector@${INSPECTOR_VERSION}.css`;
 
 /**
+ * Inspector deployment mode. Identifies how the inspector is being served so the
+ * client can distinguish the three supported deployments.
+ */
+export type InspectorMode = "standalone" | "embedded" | "cloud";
+
+/**
  * Runtime configuration injected into the inspector HTML at serve time.
  */
 interface RuntimeConfig {
@@ -37,6 +43,8 @@ interface RuntimeConfig {
   sandboxOrigin?: string | null;
   /** Relative path to the MCP proxy (e.g. "/inspector/api/proxy"). When set, the client uses it for autoProxyFallback. Omit when the proxy is not available (e.g. Python server serving inspector). */
   proxyUrl?: string | null;
+  /** How the inspector is being served (standalone CLI, embedded in mcp-use, or cloud-hosted). Consumed by telemetry. */
+  inspectorMode?: InspectorMode;
 }
 
 /**
@@ -61,6 +69,12 @@ function injectRuntimeConfig(html: string, config?: RuntimeConfig): string {
   if (config.proxyUrl !== undefined) {
     scripts.push(
       `<script>window.__MCP_PROXY_URL__ = ${JSON.stringify(config.proxyUrl)};</script>`
+    );
+  }
+
+  if (config.inspectorMode) {
+    scripts.push(
+      `<script>window.__MCP_INSPECTOR_MODE__ = ${JSON.stringify(config.inspectorMode)};</script>`
     );
   }
 
@@ -91,6 +105,11 @@ function generateCdnShellHtml(config?: RuntimeConfig): string {
     if (config.proxyUrl !== undefined) {
       scripts.push(
         `<script>window.__MCP_PROXY_URL__ = ${JSON.stringify(config.proxyUrl)};</script>`
+      );
+    }
+    if (config.inspectorMode) {
+      scripts.push(
+        `<script>window.__MCP_INSPECTOR_MODE__ = ${JSON.stringify(config.inspectorMode)};</script>`
       );
     }
     return scripts.join("\n    ");

--- a/libraries/typescript/packages/mcp-use/CHANGELOG.md
+++ b/libraries/typescript/packages/mcp-use/CHANGELOG.md
@@ -1,5 +1,13 @@
 # mcp-use
 
+## 1.24.1-canary.2
+
+### Patch Changes
+
+- Updated dependencies [744db4d]
+  - @mcp-use/cli@3.0.1-canary.2
+  - @mcp-use/inspector@2.1.0-canary.2
+
 ## 1.24.1-canary.1
 
 ### Patch Changes

--- a/libraries/typescript/packages/mcp-use/CHANGELOG.md
+++ b/libraries/typescript/packages/mcp-use/CHANGELOG.md
@@ -1,5 +1,13 @@
 # mcp-use
 
+## 1.24.1-canary.0
+
+### Patch Changes
+
+- Updated dependencies [27bd31c]
+  - @mcp-use/inspector@2.1.0-canary.0
+  - @mcp-use/cli@3.0.1-canary.0
+
 ## 1.24.0
 
 ### Minor Changes

--- a/libraries/typescript/packages/mcp-use/CHANGELOG.md
+++ b/libraries/typescript/packages/mcp-use/CHANGELOG.md
@@ -1,5 +1,13 @@
 # mcp-use
 
+## 1.24.1-canary.1
+
+### Patch Changes
+
+- 9fed740: Fix inspector "Protected resource does not match" error when switching from Via Proxy to Direct connection. The `window.fetch` interceptor installed by `BrowserOAuthClientProvider` is now correctly restored when `useMcp` unmounts, preventing the stale proxy interceptor from interfering with subsequent direct OAuth flows.
+  - @mcp-use/cli@3.0.1-canary.1
+  - @mcp-use/inspector@2.1.0-canary.1
+
 ## 1.24.1-canary.0
 
 ### Patch Changes

--- a/libraries/typescript/packages/mcp-use/examples/server/ui/mcp-apps/dynamic-origins/README.md
+++ b/libraries/typescript/packages/mcp-use/examples/server/ui/mcp-apps/dynamic-origins/README.md
@@ -1,0 +1,36 @@
+# Dynamic origins example
+
+End-to-end demonstration of the `allowedOrigins` object form:
+
+- Static literal + wildcard
+- Async `provider` callback
+- Remote `providerUrl` with HTTP cache validators
+- HMAC-signed push webhook at `POST /mcp-use/internal/origins/refresh`
+
+## Run
+
+```bash
+pnpm tsx examples/server/ui/mcp-apps/dynamic-origins/index.ts
+```
+
+This starts two HTTP servers:
+
+- MCP server on `http://localhost:3400`
+- Mock provider on `http://localhost:3401/origins.json` (serves JSON with
+  `Cache-Control: public, max-age=10, stale-while-revalidate=60` and an
+  `ETag`)
+
+Watch the mock provider logs for `200 OK` on cold start and `304 Not Modified`
+on subsequent revalidations — proof the conditional GET is working.
+
+## What to expect
+
+| Scenario | How | Outcome |
+| --- | --- | --- |
+| Localhost request | `curl http://localhost:3400/mcp` | Host matches, `<base>` = `http://localhost:3400`, CSP includes everything |
+| Wildcard preview | `-H 'Host: pr-42.preview.example.com'` | Host matches the wildcard, `<base>` = `https://pr-42.preview.example.com` |
+| Unknown host | `-H 'Host: evil.com'` | 403 from the Host validator — and if the request ever reached the widget reader, CSP would fall back to `baseUrl` |
+| Webhook push | `POST /mcp-use/internal/origins/refresh` with valid HMAC + new origins | `204`, new list is applied immediately. Next `resources/read` reflects the change |
+| Webhook replay / bad sig | Change `v1=...` or use a timestamp from 10 min ago | `401` |
+
+See the startup banner printed by `index.ts` for copy-pasteable `curl` recipes.

--- a/libraries/typescript/packages/mcp-use/examples/server/ui/mcp-apps/dynamic-origins/index.ts
+++ b/libraries/typescript/packages/mcp-use/examples/server/ui/mcp-apps/dynamic-origins/index.ts
@@ -1,0 +1,169 @@
+/**
+ * Dynamic origins example
+ *
+ * Demonstrates every `allowedOrigins` source working together:
+ *
+ *   - Static literals and wildcards
+ *   - Async provider callback
+ *   - Remote providerUrl (backed by an in-process mock provider with
+ *     Cache-Control + ETag so conditional GETs (304 Not Modified) are visible
+ *     in the logs)
+ *   - HMAC-signed push webhook for instant updates
+ *
+ * Boot:
+ *
+ *   pnpm tsx examples/server/ui/mcp-apps/dynamic-origins/index.ts
+ *
+ * Then exercise the scenarios (see the companion README.md in this folder).
+ */
+
+import { createHmac } from "node:crypto";
+import { createServer } from "node:http";
+import { MCPServer } from "mcp-use/server";
+
+const SERVER_PORT = Number(process.env.PORT ?? 3400);
+const PROVIDER_PORT = Number(process.env.PROVIDER_PORT ?? 3401);
+const WEBHOOK_SECRET =
+  process.env.MCP_ALLOWED_ORIGINS_WEBHOOK_SECRET ?? "whsec_demo_secret";
+const PROVIDER_URL = `http://localhost:${PROVIDER_PORT}/origins.json`;
+
+/**
+ * In-process mock provider. Serves a JSON list with standard HTTP validators.
+ * Flip PROVIDER_LIST below at runtime (e.g. via kill/restart) to simulate
+ * upstream changes. Revalidations will 304 until the ETag changes.
+ */
+const PROVIDER_LIST: string[] = [
+  "https://canary.example.com",
+  "https://*.staging.example.com",
+];
+const PROVIDER_ETAG = `"v${Date.now()}"`;
+
+const providerHttp = createServer((req, res) => {
+  if (!req.url?.startsWith("/origins.json")) {
+    res.statusCode = 404;
+    res.end();
+    return;
+  }
+  const ifNoneMatch = req.headers["if-none-match"];
+  if (ifNoneMatch && ifNoneMatch === PROVIDER_ETAG) {
+    res.statusCode = 304;
+    res.setHeader("ETag", PROVIDER_ETAG);
+    res.setHeader(
+      "Cache-Control",
+      "public, max-age=10, stale-while-revalidate=60"
+    );
+    res.end();
+    console.log(`[mock-provider] 304 Not Modified (ETag ${PROVIDER_ETAG})`);
+    return;
+  }
+  const body = JSON.stringify(PROVIDER_LIST);
+  res.statusCode = 200;
+  res.setHeader("Content-Type", "application/json");
+  res.setHeader("ETag", PROVIDER_ETAG);
+  res.setHeader(
+    "Cache-Control",
+    "public, max-age=10, stale-while-revalidate=60"
+  );
+  res.end(body);
+  console.log(
+    `[mock-provider] 200 OK (${PROVIDER_LIST.length} origins, ETag ${PROVIDER_ETAG})`
+  );
+});
+
+providerHttp.listen(PROVIDER_PORT, () => {
+  console.log(`[mock-provider] listening on ${PROVIDER_URL}`);
+});
+
+const server = new MCPServer({
+  name: "dynamic-origins-example",
+  version: "1.0.0",
+  description:
+    "Demonstrates dynamic allowedOrigins (static + wildcards + callback + providerUrl + webhook)",
+  baseUrl: `http://localhost:${SERVER_PORT}`,
+  allowedOrigins: {
+    origins: [
+      `http://localhost:${SERVER_PORT}`,
+      "https://app.example.com",
+      "https://*.preview.example.com",
+    ],
+    provider: async () => {
+      // Any extra dynamic origins your app wants to inject at boot or on
+      // revalidation. Useful for custom business logic (e.g. reading from a
+      // database of tenants).
+      return ["https://tenant-dynamic.example.com"];
+    },
+    providerUrl: PROVIDER_URL,
+    fallbackRevalidateSeconds: 15,
+    webhookSecret: WEBHOOK_SECRET,
+  },
+});
+
+// Minimal programmatic widget — exercises CSP union but no HTML rewriting.
+server.uiResource({
+  type: "mcpApps",
+  name: "origin-probe",
+  title: "Origin Probe",
+  description:
+    "Minimal widget that renders the CSP/base-URL computed for each request. Compare resources/read with different Host headers to see the dynamic behaviour.",
+  htmlTemplate: `<!doctype html>
+<html>
+  <head><meta charset="utf-8" /></head>
+  <body>
+    <h1>Origin Probe</h1>
+    <p>This widget's CSP adapts to the allow-listed origin that matches the incoming request.</p>
+  </body>
+</html>`,
+  metadata: {
+    description: "Dynamic origin probe",
+  },
+  exposeAsTool: true,
+});
+
+await server.listen(SERVER_PORT);
+
+console.log(`
+Dynamic origins example is running.
+
+Static sources configured:
+  - http://localhost:${SERVER_PORT}
+  - https://app.example.com
+  - https://*.preview.example.com
+Provider callback returns:
+  - https://tenant-dynamic.example.com
+providerUrl ${PROVIDER_URL} currently returns:
+  ${PROVIDER_LIST.join("\n  ")}
+
+Webhook:
+  POST /mcp-use/internal/origins/refresh
+  HMAC secret: ${WEBHOOK_SECRET}
+
+Quick curl recipes:
+
+  # 1) Resources/read as localhost (allowed)
+  SESSION=$(curl -s -D - -X POST http://localhost:${SERVER_PORT}/mcp \\
+    -H 'Accept: application/json, text/event-stream' \\
+    -H 'Content-Type: application/json' \\
+    -d '{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"capabilities":{},"clientInfo":{"name":"curl","version":"0"},"protocolVersion":"2025-11-25"}}' | awk '/mcp-session-id:/ {print $2}' | tr -d '\\r')
+
+  curl -s -X POST http://localhost:${SERVER_PORT}/mcp \\
+    -H 'Accept: application/json, text/event-stream' \\
+    -H 'Content-Type: application/json' \\
+    -H "mcp-session-id: $SESSION" \\
+    -d '{"jsonrpc":"2.0","id":1,"method":"resources/read","params":{"uri":"ui://widget/origin-probe.html"}}'
+
+  # 2) Rejected host -> 403 DNS rebinding
+  curl -i -X POST http://localhost:${SERVER_PORT}/mcp \\
+    -H 'Host: evil.example.com' \\
+    -H 'Accept: application/json, text/event-stream' \\
+    -H 'Content-Type: application/json' \\
+    -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
+
+  # 3) Webhook -> instant invalidation with inline origins
+  TS=$(date +%s)
+  BODY='{"origins":["https://hotpatched.example.com"]}'
+  SIG=$(printf '%s.%s' "$TS" "$BODY" | openssl dgst -sha256 -hmac "${WEBHOOK_SECRET}" -hex | awk '{print $2}')
+  curl -i -X POST http://localhost:${SERVER_PORT}/mcp-use/internal/origins/refresh \\
+    -H "X-MCP-Signature: t=$TS,v1=$SIG" \\
+    -H 'Content-Type: application/json' \\
+    -d "$BODY"
+`);

--- a/libraries/typescript/packages/mcp-use/package.json
+++ b/libraries/typescript/packages/mcp-use/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-use",
   "type": "module",
-  "version": "1.24.1-canary.0",
+  "version": "1.24.1-canary.1",
   "packageManager": "pnpm@10.26.0+sha512.3b3f6c725ebe712506c0ab1ad4133cf86b1f4b687effce62a9b38b4d72e3954242e643190fc51fa1642949c735f403debd44f5cb0edd657abe63a8b6a7e1e402",
   "description": "Opinionated MCP Framework for TypeScript (@modelcontextprotocol/sdk compatible) - Build MCP Agents, Clients and Servers with support for ChatGPT Apps, Code Mode, OAuth, Notifications, Sampling, Observability and more.",
   "author": "mcp-use, Inc.",

--- a/libraries/typescript/packages/mcp-use/package.json
+++ b/libraries/typescript/packages/mcp-use/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-use",
   "type": "module",
-  "version": "1.24.1-canary.1",
+  "version": "1.24.1-canary.2",
   "packageManager": "pnpm@10.26.0+sha512.3b3f6c725ebe712506c0ab1ad4133cf86b1f4b687effce62a9b38b4d72e3954242e643190fc51fa1642949c735f403debd44f5cb0edd657abe63a8b6a7e1e402",
   "description": "Opinionated MCP Framework for TypeScript (@modelcontextprotocol/sdk compatible) - Build MCP Agents, Clients and Servers with support for ChatGPT Apps, Code Mode, OAuth, Notifications, Sampling, Observability and more.",
   "author": "mcp-use, Inc.",

--- a/libraries/typescript/packages/mcp-use/package.json
+++ b/libraries/typescript/packages/mcp-use/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-use",
   "type": "module",
-  "version": "1.24.0",
+  "version": "1.24.1-canary.0",
   "packageManager": "pnpm@10.26.0+sha512.3b3f6c725ebe712506c0ab1ad4133cf86b1f4b687effce62a9b38b4d72e3954242e643190fc51fa1642949c735f403debd44f5cb0edd657abe63a8b6a7e1e402",
   "description": "Opinionated MCP Framework for TypeScript (@modelcontextprotocol/sdk compatible) - Build MCP Agents, Clients and Servers with support for ChatGPT Apps, Code Mode, OAuth, Notifications, Sampling, Observability and more.",
   "author": "mcp-use, Inc.",

--- a/libraries/typescript/packages/mcp-use/src/react/useMcp.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/useMcp.ts
@@ -41,6 +41,7 @@ type UseMcpAuthProvider = OAuthClientProvider & {
   clearStorage?: () => number;
   getLastAttemptedAuthUrl?: () => string | null | undefined;
   installFetchInterceptor?: () => void;
+  restoreFetch?: () => void;
   serverUrl?: string;
 };
 
@@ -2020,6 +2021,10 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
     return () => {
       isMountedRef.current = false;
       addLog("debug", "useMcp unmounting, disconnecting.");
+
+      // Restore window.fetch if a proxy interceptor was installed.
+      // restoreFetch() is a no-op when no interceptor is active.
+      authProviderRef.current?.restoreFetch?.();
 
       // Clear OAuth state ONLY if we're in the middle of an OAuth flow
       // This prevents "code verifier not found" errors in StrictMode double-mounting

--- a/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
@@ -108,6 +108,7 @@ import {
   isDeno,
   isProductionMode as isProductionModeHelper,
   logRegisteredItems as logRegisteredItemsHelper,
+  OriginResolver,
   parseTemplateUri as parseTemplateUriHelper,
   rewriteSupabaseRequest,
   startServer,
@@ -332,6 +333,14 @@ class MCPServerClass<HasOAuth extends boolean = false> {
    * Used for generating widget URLs and OAuth callbacks.
    */
   public serverBaseUrl?: string;
+
+  /**
+   * Resolver backing `allowedOrigins`. Provides Host validation and the
+   * per-request base URL / CSP allow-list for widget output. Always
+   * instantiated; when `allowedOrigins` is not configured the resolver
+   * simply reports `isEnabled() === false` and the middleware short-circuits.
+   */
+  public originResolver!: OriginResolver;
 
   /**
    * Optional favicon URL to display in inspector and documentation.
@@ -2368,6 +2377,14 @@ class MCPServerClass<HasOAuth extends boolean = false> {
     this.serverHost = config.host || "localhost";
     this.serverBaseUrl = config.baseUrl;
 
+    // Build the origin resolver. Always instantiated so middleware + widgets
+    // have a stable handle; when allowedOrigins is unset, the resolver is a
+    // no-op (isEnabled() === false). Fallback origin is refined in listen()
+    // once MCP_URL / host:port is known.
+    this.originResolver = new OriginResolver(config.allowedOrigins, {
+      fallbackOrigin: config.baseUrl ?? null,
+    });
+
     // Auto-select favicon from icons array if not explicitly provided
     if (config.favicon) {
       this.favicon = config.favicon;
@@ -2421,7 +2438,7 @@ class MCPServerClass<HasOAuth extends boolean = false> {
     // Create and configure Hono app with default middleware
     this.app = createHonoApp(requestLogger, {
       cors: this.config.cors,
-      allowedOrigins: this.config.allowedOrigins,
+      originResolver: this.originResolver,
     });
 
     // Install the custom routes middleware FIRST (before any other routes).
@@ -3716,6 +3733,33 @@ class MCPServerClass<HasOAuth extends boolean = false> {
   }
 
   /**
+   * Mount the HMAC-signed origins-refresh webhook. Only mounted when the
+   * resolver was configured with a `webhookSecret` (or the
+   * `MCP_ALLOWED_ORIGINS_WEBHOOK_SECRET` env var is set).
+   *
+   * @internal
+   */
+  private mountOriginsWebhook(): void {
+    if (!this.originResolver.hasWebhook()) return;
+
+    this.app.post(OriginResolver.WEBHOOK_PATH, async (c) => {
+      const rawBody = await c.req.text();
+      const signatureHeader = c.req.header("x-mcp-signature") ?? null;
+      const result = await this.originResolver.handleWebhook({
+        rawBody,
+        signatureHeader,
+      });
+      if (result.status === 204) {
+        return new Response(null, { status: 204 });
+      }
+      return new Response(result.body ?? "", { status: result.status });
+    });
+    console.log(
+      `[OriginResolver] webhook mounted at ${OriginResolver.WEBHOOK_PATH}`
+    );
+  }
+
+  /**
    * Starts the HTTP server and begins listening for connections.
    *
    * This method is the primary way to run an MCP server as a standalone HTTP service.
@@ -3888,6 +3932,15 @@ class MCPServerClass<HasOAuth extends boolean = false> {
       this.serverPort
     );
 
+    // Refine the resolver's fallback origin now that MCP_URL / host:port has
+    // been resolved, then run the initial provider fetch. For static
+    // `allowedOrigins: string[]` this is a no-op; for the dynamic object form
+    // it awaits the first fetch with a 5-second timeout and populates the
+    // last-known-good list before any /mcp request is served.
+    this.originResolver.setFallbackOrigin(this.serverBaseUrl ?? null);
+    await this.originResolver.init();
+    this.mountOriginsWebhook();
+
     // Setup OAuth before mounting widgets/MCP (if configured)
     if (this.oauthProvider && !this.oauthSetupState.complete) {
       await setupOAuthForServer(
@@ -4010,6 +4063,12 @@ class MCPServerClass<HasOAuth extends boolean = false> {
   async getHandler(options?: {
     provider?: "supabase" | "cloudflare" | "deno-deploy";
   }): Promise<(req: Request) => Promise<Response>> {
+    // Refine fallback origin + initialize the resolver for the serverless
+    // path too (listen() normally does this).
+    this.originResolver.setFallbackOrigin(this.serverBaseUrl ?? null);
+    await this.originResolver.init();
+    this.mountOriginsWebhook();
+
     // Setup OAuth before mounting widgets/MCP (if configured)
     if (this.oauthProvider && !this.oauthSetupState.complete) {
       await setupOAuthForServer(

--- a/libraries/typescript/packages/mcp-use/src/server/middleware/host-validation.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/middleware/host-validation.ts
@@ -1,12 +1,30 @@
 /**
  * Host Header Validation Middleware
  *
- * DNS rebinding protection middleware for Hono-based MCP servers.
+ * DNS rebinding protection for Hono-based MCP servers. Backed by an
+ * `OriginResolver` that may be static (plain `string[]` form of
+ * `allowedOrigins`) or dynamic (object form with wildcards / provider /
+ * webhook). The resolver is always consulted synchronously — it caches
+ * last-known-good — so this middleware adds essentially zero per-request
+ * overhead.
+ *
+ * Security posture:
+ *   - Unknown Host → 403 (DNS rebinding protection).
+ *   - Cold-start failure (dynamic resolver configured, initial fetch failed,
+ *     no static fallback) → 503. We FAIL CLOSED rather than silently accept
+ *     every Host when the provider is down at boot.
+ *   - Host validation uses only the `Host` header, never
+ *     `X-Forwarded-Host`, to prevent header injection.
  */
 
 import type { Context, Next } from "hono";
+import type { OriginResolver } from "../utils/origin-resolver.js";
 
-function createJsonRpcErrorResponse(c: Context, message: string): Response {
+function createJsonRpcErrorResponse(
+  c: Context,
+  status: number,
+  message: string
+): Response {
   return c.json(
     {
       jsonrpc: "2.0",
@@ -16,13 +34,12 @@ function createJsonRpcErrorResponse(c: Context, message: string): Response {
       },
       id: null,
     },
-    403
+    status as 403 | 503
   );
 }
 
 function parseHostnameFromHostHeader(hostHeader: string): string | null {
   try {
-    // URL parsing strips port and handles IPv6 host notation.
     return new URL(`http://${hostHeader}`).hostname;
   } catch {
     return null;
@@ -30,33 +47,41 @@ function parseHostnameFromHostHeader(hostHeader: string): string | null {
 }
 
 /**
- * Create middleware that validates the Host header against an allow list.
+ * Create middleware that validates the Host header against the resolver's
+ * current allow-list (static + last-known-good from any dynamic provider).
  *
- * @param allowedHostnames - Hostnames allowed to access protected endpoints
- * @returns Hono middleware
+ * Returns `null` when validation should be skipped entirely (e.g. the user
+ * didn't configure `allowedOrigins` at all) so callers can avoid paying the
+ * per-request middleware cost on servers that don't use Host validation.
  */
-export function hostHeaderValidation(allowedHostnames: string[]) {
-  const normalizedAllowedHostnames = allowedHostnames.map((hostname) =>
-    hostname.toLowerCase()
-  );
-
+export function hostHeaderValidation(resolver: OriginResolver) {
   return async (c: Context, next: Next) => {
-    const hostHeader = c.req.header("Host");
+    // Cold-start failure: dynamic providers were configured but we never
+    // got a single good list. Fail closed rather than accept any Host.
+    if (resolver.isColdStartFailure()) {
+      return createJsonRpcErrorResponse(
+        c,
+        503,
+        "Origin allow-list unavailable"
+      );
+    }
 
+    const hostHeader = c.req.header("Host");
     if (!hostHeader) {
-      return createJsonRpcErrorResponse(c, "Missing Host header");
+      return createJsonRpcErrorResponse(c, 403, "Missing Host header");
     }
 
     const hostname = parseHostnameFromHostHeader(hostHeader);
     if (!hostname) {
       return createJsonRpcErrorResponse(
         c,
+        403,
         `Invalid Host header: ${hostHeader}`
       );
     }
 
-    if (!normalizedAllowedHostnames.includes(hostname.toLowerCase())) {
-      return createJsonRpcErrorResponse(c, `Invalid Host: ${hostname}`);
+    if (!resolver.matchesHostname(hostname)) {
+      return createJsonRpcErrorResponse(c, 403, `Invalid Host: ${hostname}`);
     }
 
     await next();

--- a/libraries/typescript/packages/mcp-use/src/server/types/common.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/types/common.ts
@@ -5,6 +5,9 @@
 import type { OAuthProvider } from "../oauth/providers/types.js";
 import type { cors } from "hono/cors";
 import type { z } from "zod";
+import type { AllowedOriginsConfig } from "../utils/origin-resolver.js";
+
+export type { AllowedOriginsConfig } from "../utils/origin-resolver.js";
 
 /**
  * Converts Zod optional fields to TypeScript optional properties.
@@ -92,32 +95,61 @@ export interface ServerConfig {
    */
   cors?: Partial<Parameters<typeof cors>[0]>;
   /**
-   * Allowed origins for DNS rebinding protection
+   * Allowed origins for the server.
    *
-   * - If not set: DNS rebinding protection is disabled (all Host values accepted)
-   * - If set to empty array: DNS rebinding protection is disabled
-   * - If set with origins: Host validation is enabled globally for the server
+   * One option, two roles:
+   *
+   * 1. **DNS-rebinding protection (Host validation)** — requests whose `Host`
+   *    header doesn't match the allow-list are rejected with 403.
+   * 2. **Widget hosting origins** — when the object form is used, widget
+   *    `<base>`, `window.__getFile`, `window.__mcpPublicUrl`, and CSP
+   *    (`connect_domains`, `resource_domains`, `base_uri_domains`) are
+   *    computed per-request from the allow-list instead of being baked to
+   *    the single static `baseUrl` / `MCP_URL`.
+   *
+   * Accepts two shapes:
+   *
+   * - `string[]` — static list; fully backward-compatible with earlier versions
+   *   (hostname-level Host validation only, no widget CSP expansion).
+   * - {@link AllowedOriginsConfig} — unlocks wildcard hostnames (e.g.
+   *   `"https://*.preview.example.com"`), dynamic provider callback / URL
+   *   with HTTP cache-validator semantics, and an optional HMAC push
+   *   webhook for instant invalidation. In this mode widget output is
+   *   per-request: the request's origin is used when allow-listed, otherwise
+   *   the static fallback (`baseUrl` / `MCP_URL`) is used. Widget CSP
+   *   includes the union of allow-listed origins.
    *
    * @example
    * ```typescript
-   * // Default behavior (no host validation)
-   * const server = new MCPServer({
-   *   name: 'my-server',
-   *   version: '1.0.0'
-   * });
+   * // Default behavior (no Host validation, static widget baseUrl)
+   * const server = new MCPServer({ name: 'my-server', version: '1.0.0' });
    *
-   * // Explicit protection (applies to all routes)
+   * // Static form (hostname-level Host validation, unchanged behavior)
    * const server = new MCPServer({
    *   name: 'my-server',
    *   version: '1.0.0',
-   *   allowedOrigins: [
-   *     'https://myapp.com',
-   *     'https://app.myapp.com'
-   *   ]
+   *   allowedOrigins: ['https://myapp.com', 'https://app.myapp.com'],
+   * });
+   *
+   * // Dynamic form (wildcards + remote provider + webhook)
+   * const server = new MCPServer({
+   *   name: 'my-server',
+   *   version: '1.0.0',
+   *   allowedOrigins: {
+   *     origins: [
+   *       'https://app.example.com',
+   *       'https://*.preview.example.com',
+   *     ],
+   *     providerUrl: process.env.MCP_ALLOWED_ORIGINS_URL,
+   *     token: process.env.MCP_ALLOWED_ORIGINS_TOKEN,
+   *     webhookSecret: process.env.MCP_ALLOWED_ORIGINS_WEBHOOK_SECRET,
+   *   },
    * });
    * ```
+   *
+   * @see {@link AllowedOriginsConfig}
    */
-  allowedOrigins?: string[];
+  allowedOrigins?: string[] | AllowedOriginsConfig;
   sessionIdleTimeoutMs?: number; // Idle timeout for sessions in milliseconds (default: 86400000 = 1 day)
   /**
    * @deprecated This option is deprecated and will be removed in a future version.

--- a/libraries/typescript/packages/mcp-use/src/server/types/index.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/types/index.ts
@@ -5,6 +5,7 @@
 // Common types
 export {
   ServerConfig,
+  AllowedOriginsConfig,
   InputDefinition,
   ResourceAnnotations,
   OptionalizeUndefinedFields,

--- a/libraries/typescript/packages/mcp-use/src/server/utils/index.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/utils/index.ts
@@ -10,3 +10,4 @@ export * from "./hono-proxy.js";
 export * from "./completion-helpers.js";
 export * from "./elicitation-helpers.js";
 export * from "./proxy-client.js";
+export * from "./origin-resolver.js";

--- a/libraries/typescript/packages/mcp-use/src/server/utils/origin-resolver.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/utils/origin-resolver.ts
@@ -1,0 +1,886 @@
+/**
+ * OriginResolver
+ *
+ * Single source of truth for "which origins is this MCP server reachable from?".
+ * Drives both:
+ *   - Host validation middleware (DNS-rebinding protection)
+ *   - Widget <base> / window.__getFile / window.__mcpPublicUrl rewriting at read time
+ *   - Widget CSP `connect_domains` / `resource_domains` / `base_uri_domains`
+ *
+ * Sources (all merged, deduplicated):
+ *   - Constructor `origins: string[]`
+ *   - `MCP_ALLOWED_ORIGINS` env var (comma-separated)
+ *   - `provider: () => string[] | Promise<string[]>` callback
+ *   - `providerUrl: string` HTTP endpoint returning JSON `string[]`
+ *
+ * Provider freshness is driven by the HTTP layer:
+ *   - `Cache-Control: max-age` / `s-maxage` / `stale-while-revalidate`
+ *   - `ETag` / `Last-Modified` with conditional GET
+ *   - Single-flight background refresh (SWR)
+ *
+ * Optional HMAC-signed push webhook allows instant invalidation
+ * (`POST /mcp-use/internal/origins/refresh` — mounted in mcp-server.ts).
+ *
+ * Wildcard semantics: `*.example.com` matches exactly one label
+ * (`a.example.com` yes, `a.b.example.com` no, `example.com` no). Same as
+ * CSP host-source semantics. Bare `*` is rejected at parse time.
+ */
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { getEnv } from "./runtime.js";
+
+/**
+ * Object-form configuration for `allowedOrigins`.
+ *
+ * Used when the caller needs wildcards, dynamic providers, or the HMAC
+ * push webhook. Plain `string[]` is still accepted by `MCPServer` for
+ * fully backward-compatible static host validation.
+ */
+export interface AllowedOriginsConfig {
+  /** Static allow-list entries. Supports exact origins and wildcard hostnames. */
+  origins?: string[];
+  /** Sync or async callback returning origins. Runs alongside providerUrl. */
+  provider?: () => string[] | Promise<string[]>;
+  /** HTTP endpoint returning JSON `string[]`. Honors Cache-Control / ETag. */
+  providerUrl?: string;
+  /** Bearer token sent to providerUrl as `Authorization: Bearer <token>`. */
+  token?: string;
+  /** Extra headers sent to providerUrl (e.g. tenant IDs). */
+  headers?: Record<string, string>;
+  /** Shared secret for the HMAC push webhook. Webhook is NOT mounted without this. */
+  webhookSecret?: string;
+  /** Seconds to wait before revalidating when provider sends no Cache-Control. Default 60. */
+  fallbackRevalidateSeconds?: number;
+}
+
+/**
+ * Parsed allow-list entry used for matching both Host headers and full origins.
+ */
+export interface OriginMatcher {
+  raw: string;
+  /** Scheme if the entry included one (e.g. "https"), otherwise undefined. */
+  scheme?: string;
+  /** Either "literal" or "wildcard". Wildcards match exactly one subdomain label. */
+  kind: "literal" | "wildcard";
+  /** Lowercase hostname. For wildcards, this is the full pattern (e.g. "*.example.com"). */
+  hostname: string;
+  /** Optional port (e.g. "3000"). */
+  port?: string;
+}
+
+const WEBHOOK_PATH = "/mcp-use/internal/origins/refresh";
+const WEBHOOK_REPLAY_WINDOW_SECONDS = 5 * 60;
+const DEFAULT_FALLBACK_REVALIDATE_SECONDS = 60;
+const INITIAL_FETCH_TIMEOUT_MS = 5000;
+
+type ParsedCacheControl = {
+  maxAgeSeconds?: number;
+  staleWhileRevalidateSeconds?: number;
+  noStore: boolean;
+  noCache: boolean;
+  mustRevalidate: boolean;
+};
+
+function parseCacheControl(
+  header: string | null | undefined
+): ParsedCacheControl {
+  const result: ParsedCacheControl = {
+    noStore: false,
+    noCache: false,
+    mustRevalidate: false,
+  };
+  if (!header) return result;
+  for (const rawDirective of header.split(",")) {
+    const directive = rawDirective.trim().toLowerCase();
+    if (directive === "no-store") result.noStore = true;
+    else if (directive === "no-cache") result.noCache = true;
+    else if (directive === "must-revalidate") result.mustRevalidate = true;
+    else if (directive.startsWith("s-maxage=")) {
+      const n = Number(directive.slice("s-maxage=".length));
+      if (Number.isFinite(n) && n >= 0) result.maxAgeSeconds = n;
+    } else if (directive.startsWith("max-age=")) {
+      if (result.maxAgeSeconds === undefined) {
+        const n = Number(directive.slice("max-age=".length));
+        if (Number.isFinite(n) && n >= 0) result.maxAgeSeconds = n;
+      }
+    } else if (directive.startsWith("stale-while-revalidate=")) {
+      const n = Number(directive.slice("stale-while-revalidate=".length));
+      if (Number.isFinite(n) && n >= 0) result.staleWhileRevalidateSeconds = n;
+    }
+  }
+  return result;
+}
+
+/**
+ * Parse one allow-list entry into a matcher.
+ *
+ * Accepts:
+ *   - "https://app.example.com"
+ *   - "http://localhost:3000"
+ *   - "*.preview.example.com"        (implicit https)
+ *   - "https://*.preview.example.com"
+ *   - "app.example.com"              (hostname only, any scheme)
+ *
+ * Rejects:
+ *   - "*"                             (too broad)
+ *   - "**.example.com"                (only one wildcard label allowed)
+ *   - "*.co" / "*.com"                (TLD-only wildcards — still reject bare-TLD to reduce foot-guns)
+ *   - invalid URLs
+ */
+export function parseAllowedOrigin(entry: string): OriginMatcher | null {
+  const trimmed = entry.trim();
+  if (!trimmed) return null;
+  if (trimmed === "*") {
+    console.warn(
+      `[OriginResolver] rejected bare "*" entry (too broad); use a specific hostname or wildcard like "*.example.com"`
+    );
+    return null;
+  }
+
+  // Pre-strip scheme for our own parsing — URL parser rejects wildcards in host.
+  const schemeMatch = trimmed.match(/^([a-z][a-z0-9+.-]*):\/\//i);
+  let scheme: string | undefined;
+  let rest = trimmed;
+  if (schemeMatch) {
+    scheme = schemeMatch[1].toLowerCase();
+    rest = trimmed.slice(schemeMatch[0].length);
+  }
+
+  // Strip path/query if someone pasted a full URL with a path.
+  const slashIdx = rest.indexOf("/");
+  if (slashIdx >= 0) rest = rest.slice(0, slashIdx);
+
+  // Split host:port (IPv6 not supported here — allow-list entries are hostnames).
+  let host = rest;
+  let port: string | undefined;
+  const portIdx = rest.lastIndexOf(":");
+  if (portIdx > 0 && !rest.slice(portIdx + 1).match(/[^0-9]/)) {
+    host = rest.slice(0, portIdx);
+    port = rest.slice(portIdx + 1);
+  }
+
+  host = host.toLowerCase();
+  if (!host) return null;
+
+  const wildcardCount = (host.match(/\*/g) ?? []).length;
+  if (wildcardCount === 0) {
+    return {
+      raw: trimmed,
+      scheme,
+      kind: "literal",
+      hostname: host,
+      port,
+    };
+  }
+
+  if (wildcardCount > 1 || !host.startsWith("*.")) {
+    console.warn(
+      `[OriginResolver] rejected wildcard entry "${trimmed}" — only one leading "*." label is allowed`
+    );
+    return null;
+  }
+
+  // Require at least two more labels (e.g. "*.example.com" OK, "*.com" rejected).
+  const rest2 = host.slice(2);
+  if (!rest2.includes(".")) {
+    console.warn(
+      `[OriginResolver] rejected wildcard entry "${trimmed}" — suffix must include at least two labels (e.g. "*.example.com")`
+    );
+    return null;
+  }
+
+  return {
+    raw: trimmed,
+    scheme,
+    kind: "wildcard",
+    hostname: host,
+    port,
+  };
+}
+
+function matcherMatchesHostname(m: OriginMatcher, hostname: string): boolean {
+  const h = hostname.toLowerCase();
+  if (m.kind === "literal") return m.hostname === h;
+  // Wildcard: "*.example.com" matches exactly one label.
+  const suffix = m.hostname.slice(1); // ".example.com"
+  if (!h.endsWith(suffix)) return false;
+  const prefix = h.slice(0, h.length - suffix.length);
+  if (prefix.length === 0) return false; // bare "example.com" shouldn't match "*.example.com"
+  if (prefix.includes(".")) return false; // only one label allowed
+  return true;
+}
+
+function matcherMatchesOrigin(
+  m: OriginMatcher,
+  origin: { scheme: string; hostname: string; port?: string }
+): boolean {
+  if (m.scheme && m.scheme !== origin.scheme) return false;
+  if (m.port && m.port !== (origin.port ?? "")) return false;
+  return matcherMatchesHostname(m, origin.hostname);
+}
+
+function splitEnvList(value: string | undefined): string[] {
+  if (!value) return [];
+  return value
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function parseOriginFromString(raw: string | undefined): {
+  scheme: string;
+  hostname: string;
+  port?: string;
+} | null {
+  if (!raw) return null;
+  try {
+    const url = new URL(raw);
+    return {
+      scheme: url.protocol.replace(/:$/, "").toLowerCase(),
+      hostname: url.hostname.toLowerCase(),
+      port: url.port || undefined,
+    };
+  } catch {
+    // Not a full URL — try treating as host[:port]
+    const trimmed = raw.trim();
+    if (!trimmed) return null;
+    const portIdx = trimmed.lastIndexOf(":");
+    if (portIdx > 0 && !trimmed.slice(portIdx + 1).match(/[^0-9]/)) {
+      return {
+        scheme: "http",
+        hostname: trimmed.slice(0, portIdx).toLowerCase(),
+        port: trimmed.slice(portIdx + 1),
+      };
+    }
+    return {
+      scheme: "http",
+      hostname: trimmed.toLowerCase(),
+    };
+  }
+}
+
+/**
+ * Split a hostname string (e.g. from a Host header) into hostname + optional port.
+ */
+function splitHostHeader(
+  hostHeader: string
+): { hostname: string; port?: string } | null {
+  const trimmed = hostHeader.trim();
+  if (!trimmed) return null;
+  // IPv6 in brackets — not allowed in allow-list entries either.
+  if (trimmed.startsWith("[")) {
+    const closing = trimmed.indexOf("]");
+    if (closing < 0) return null;
+    const host = trimmed.slice(1, closing);
+    const portPart = trimmed.slice(closing + 1);
+    const port =
+      portPart.startsWith(":") && /^:[0-9]+$/.test(portPart)
+        ? portPart.slice(1)
+        : undefined;
+    return { hostname: host.toLowerCase(), port };
+  }
+  const idx = trimmed.lastIndexOf(":");
+  if (idx > 0 && !trimmed.slice(idx + 1).match(/[^0-9]/)) {
+    return {
+      hostname: trimmed.slice(0, idx).toLowerCase(),
+      port: trimmed.slice(idx + 1),
+    };
+  }
+  return { hostname: trimmed.toLowerCase() };
+}
+
+/**
+ * Structural result used by the host validation middleware and widget read path.
+ */
+export interface ResolveResult {
+  /** The origin we'll use for widget <base> / CSP. Always set. */
+  origin: string;
+  /** True if the request's Host matched the allow-list. */
+  isAllowed: boolean;
+  /** Hostname of the incoming request (lowercased), or null if missing. */
+  requestHostname: string | null;
+}
+
+/**
+ * Public API of the resolver consumed by middleware, widgets, and the webhook handler.
+ */
+export class OriginResolver {
+  private readonly staticMatchers: OriginMatcher[] = [];
+  private readonly staticOriginStrings: string[] = [];
+  private readonly providerMatchers: OriginMatcher[] = [];
+  private providerOriginStrings: string[] = [];
+
+  private readonly config: AllowedOriginsConfig;
+  private readonly providerUrl: string | undefined;
+  private readonly token: string | undefined;
+  private readonly webhookSecret: string | undefined;
+  private readonly extraHeaders: Record<string, string>;
+  private readonly fallbackRevalidateSeconds: number;
+  /** If true, the user configured at least a static list or provider. */
+  private readonly enabled: boolean;
+  /** If true, the user configured a dynamic source (provider / providerUrl / webhook). */
+  private readonly dynamic: boolean;
+  /**
+   * Fallback origin used for widget output when the request Host is not
+   * allow-listed (typically the configured baseUrl / MCP_URL / host:port).
+   */
+  private fallbackOrigin: string | null = null;
+
+  // HTTP cache state for providerUrl.
+  private lastETag: string | undefined;
+  private lastModified: string | undefined;
+  private cacheExpiresAtMs = 0;
+  private staleUntilMs = 0;
+  private inFlightRefresh: Promise<void> | null = null;
+  private hasInitialFetch = false;
+  private initialFetchFailed = false;
+  private lastProviderError: Error | null = null;
+  private lastLoggedFailureAtMs = 0;
+
+  constructor(
+    rawConfig: string[] | AllowedOriginsConfig | undefined,
+    opts: { fallbackOrigin?: string | null } = {}
+  ) {
+    const envOrigins = splitEnvList(getEnv("MCP_ALLOWED_ORIGINS"));
+    const envProviderUrl = getEnv("MCP_ALLOWED_ORIGINS_URL");
+    const envToken = getEnv("MCP_ALLOWED_ORIGINS_TOKEN");
+    const envWebhookSecret = getEnv("MCP_ALLOWED_ORIGINS_WEBHOOK_SECRET");
+
+    if (rawConfig === undefined) {
+      this.config = {};
+    } else if (Array.isArray(rawConfig)) {
+      this.config = { origins: rawConfig };
+    } else {
+      this.config = rawConfig;
+    }
+
+    this.providerUrl = this.config.providerUrl ?? envProviderUrl;
+    this.token = this.config.token ?? envToken;
+    this.webhookSecret = this.config.webhookSecret ?? envWebhookSecret;
+    this.extraHeaders = this.config.headers ?? {};
+    this.fallbackRevalidateSeconds =
+      this.config.fallbackRevalidateSeconds ??
+      DEFAULT_FALLBACK_REVALIDATE_SECONDS;
+    this.fallbackOrigin = opts.fallbackOrigin ?? null;
+
+    const staticOrigins = [...(this.config.origins ?? []), ...envOrigins];
+
+    for (const entry of staticOrigins) {
+      const m = parseAllowedOrigin(entry);
+      if (m) {
+        this.staticMatchers.push(m);
+        this.staticOriginStrings.push(entry.trim());
+      }
+    }
+
+    const hasProvider = Boolean(this.config.provider || this.providerUrl);
+    this.dynamic = Boolean(
+      hasProvider ||
+      (rawConfig !== undefined &&
+        !Array.isArray(rawConfig) &&
+        this.webhookSecret)
+    );
+    this.enabled =
+      this.staticMatchers.length > 0 ||
+      hasProvider ||
+      Boolean(this.webhookSecret);
+  }
+
+  /**
+   * Update the fallback origin used when the request Host isn't allow-listed.
+   * Called by MCPServer.listen() after MCP_URL / host:port is finalized.
+   */
+  setFallbackOrigin(origin: string | null): void {
+    this.fallbackOrigin = origin;
+  }
+
+  getFallbackOrigin(): string | null {
+    return this.fallbackOrigin;
+  }
+
+  /** Whether any allow-list mechanism is active. */
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  /** Whether a dynamic source (provider / providerUrl / webhook) is configured. */
+  isDynamic(): boolean {
+    return this.dynamic;
+  }
+
+  /** Whether a push webhook is enabled (webhookSecret set). */
+  hasWebhook(): boolean {
+    return Boolean(this.webhookSecret);
+  }
+
+  /** Path where the resolver mounts its webhook (constant). */
+  static readonly WEBHOOK_PATH = WEBHOOK_PATH;
+
+  /**
+   * Run the initial provider fetch (best-effort, time-boxed).
+   *
+   * After this resolves, `getMatchersSync()` returns the most complete
+   * allow-list we can produce at cold start. Providers that fail to
+   * respond within the timeout are logged; the server will continue with
+   * just the static list (plus any subsequent successful refreshes).
+   *
+   * Safe to call on servers with no dynamic sources — it's a no-op then.
+   */
+  async init(timeoutMs: number = INITIAL_FETCH_TIMEOUT_MS): Promise<void> {
+    if (!this.dynamic) return;
+    try {
+      await this.refreshOnce({ timeoutMs });
+    } catch (err) {
+      this.initialFetchFailed = true;
+      this.lastProviderError = err as Error;
+      console.warn(
+        `[OriginResolver] initial provider fetch failed: ${(err as Error).message}; continuing with ${this.staticMatchers.length} static entries`
+      );
+    } finally {
+      this.hasInitialFetch = true;
+    }
+  }
+
+  /**
+   * True if we have *nothing* to enforce with (fail-closed path for Host
+   * validation on cold start). Only possible when a provider was configured
+   * but failed AND no static origins were provided.
+   */
+  isColdStartFailure(): boolean {
+    if (!this.dynamic) return false;
+    if (this.staticMatchers.length > 0) return false;
+    if (this.providerMatchers.length > 0) return false;
+    return this.hasInitialFetch && this.initialFetchFailed;
+  }
+
+  /**
+   * Return all matchers currently active (static + last-known-good provider).
+   * Never blocks, never throws. Safe to call from hot paths (middleware).
+   */
+  getMatchersSync(): OriginMatcher[] {
+    if (this.providerMatchers.length === 0) return this.staticMatchers;
+    if (this.staticMatchers.length === 0) return this.providerMatchers;
+    return [...this.staticMatchers, ...this.providerMatchers];
+  }
+
+  /**
+   * Return the union of origin strings as currently known, preserving
+   * wildcard patterns (e.g. `"https://*.example.com"`) as written. Used
+   * to populate widget CSP arrays.
+   */
+  getAllowedOriginStringsSync(): string[] {
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const s of this.staticOriginStrings) {
+      if (!seen.has(s)) {
+        seen.add(s);
+        out.push(s);
+      }
+    }
+    for (const s of this.providerOriginStrings) {
+      if (!seen.has(s)) {
+        seen.add(s);
+        out.push(s);
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Return just the hostnames (lowercased, wildcard patterns preserved) for
+   * use by the host-validation middleware.
+   */
+  getAllowedHostnamesSync(): string[] {
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const m of this.getMatchersSync()) {
+      if (!seen.has(m.hostname)) {
+        seen.add(m.hostname);
+        out.push(m.hostname);
+      }
+    }
+    return out;
+  }
+
+  matchesHostname(hostname: string): boolean {
+    for (const m of this.getMatchersSync()) {
+      if (matcherMatchesHostname(m, hostname)) return true;
+    }
+    return false;
+  }
+
+  /**
+   * Does any matcher match this full origin (scheme + host + optional port)?
+   */
+  matchesOrigin(originString: string): boolean {
+    const parsed = parseOriginFromString(originString);
+    if (!parsed) return false;
+    for (const m of this.getMatchersSync()) {
+      if (matcherMatchesOrigin(m, parsed)) return true;
+    }
+    return false;
+  }
+
+  /**
+   * Resolve the effective origin to use for a given Request, consulting the
+   * Host header (NOT X-Forwarded-Host — that bypass is reserved for a future
+   * trustedProxies option).
+   */
+  resolveRequest(req: {
+    headers: { get(name: string): string | null };
+    url?: string;
+  }): ResolveResult {
+    const hostHeader = req.headers.get("host") || req.headers.get("Host");
+    let requestHostname: string | null = null;
+    let requestPort: string | undefined;
+    if (hostHeader) {
+      const parts = splitHostHeader(hostHeader);
+      if (parts) {
+        requestHostname = parts.hostname;
+        requestPort = parts.port;
+      }
+    }
+
+    if (!requestHostname) {
+      return {
+        origin: this.fallbackOrigin ?? "",
+        isAllowed: false,
+        requestHostname: null,
+      };
+    }
+
+    // Derive scheme from the request URL when possible, else fall back to
+    // the fallback origin's scheme (or http).
+    let scheme = "http";
+    if (req.url) {
+      try {
+        scheme = new URL(req.url).protocol.replace(/:$/, "").toLowerCase();
+      } catch {
+        // ignore
+      }
+    }
+    if (scheme === "http" && this.fallbackOrigin) {
+      try {
+        scheme = new URL(this.fallbackOrigin).protocol
+          .replace(/:$/, "")
+          .toLowerCase();
+      } catch {
+        // ignore
+      }
+    }
+
+    const candidate = {
+      scheme,
+      hostname: requestHostname,
+      port: requestPort,
+    };
+
+    let isAllowed = false;
+    for (const m of this.getMatchersSync()) {
+      if (matcherMatchesOrigin(m, candidate)) {
+        isAllowed = true;
+        break;
+      }
+    }
+
+    if (!isAllowed) {
+      // Fallback origin is always implicitly allowed for widget output.
+      return {
+        origin: this.fallbackOrigin ?? "",
+        isAllowed: false,
+        requestHostname,
+      };
+    }
+
+    const originOut = candidate.port
+      ? `${scheme}://${requestHostname}:${candidate.port}`
+      : `${scheme}://${requestHostname}`;
+
+    return {
+      origin: originOut,
+      isAllowed: true,
+      requestHostname,
+    };
+  }
+
+  /**
+   * Refresh the provider list if stale. Called opportunistically by the
+   * widget read path (and by the webhook handler in "revalidate" mode).
+   * Non-blocking — returns the current in-flight refresh if any, else
+   * kicks off a new one (single-flight).
+   */
+  refreshIfStale(): Promise<void> {
+    if (!this.dynamic) return Promise.resolve();
+    const now = Date.now();
+    if (now < this.cacheExpiresAtMs) return Promise.resolve();
+    if (this.inFlightRefresh) return this.inFlightRefresh;
+    this.inFlightRefresh = this.refreshOnce().finally(() => {
+      this.inFlightRefresh = null;
+    });
+    // Fire-and-forget from the caller's perspective; don't let background
+    // refresh reject promises bubble up.
+    this.inFlightRefresh.catch(() => {});
+    return this.inFlightRefresh;
+  }
+
+  /**
+   * Force-invalidate the cache and trigger a refresh. Used by the webhook
+   * handler when the payload doesn't carry an inline origins list.
+   */
+  invalidateAndRefresh(): Promise<void> {
+    this.cacheExpiresAtMs = 0;
+    this.staleUntilMs = 0;
+    return this.refreshIfStale();
+  }
+
+  /**
+   * Replace the provider list in-memory (used by the webhook when the
+   * payload carries an inline origins list — no outbound fetch needed).
+   */
+  applyInlineOrigins(origins: string[]): void {
+    const matchers: OriginMatcher[] = [];
+    const strings: string[] = [];
+    for (const entry of origins) {
+      const m = parseAllowedOrigin(entry);
+      if (m) {
+        matchers.push(m);
+        strings.push(entry.trim());
+      }
+    }
+    this.providerMatchers.length = 0;
+    this.providerMatchers.push(...matchers);
+    this.providerOriginStrings = strings;
+    // Treat inline updates as "fresh" for the full fallback window so we
+    // don't immediately refetch on the next request.
+    const now = Date.now();
+    this.cacheExpiresAtMs = now + this.fallbackRevalidateSeconds * 1000;
+    this.staleUntilMs = this.cacheExpiresAtMs;
+    this.hasInitialFetch = true;
+    this.initialFetchFailed = false;
+  }
+
+  /**
+   * Internal refresh: runs provider callback + providerUrl, merges, updates
+   * last-known-good + cache expiry.
+   */
+  private async refreshOnce(opts: { timeoutMs?: number } = {}): Promise<void> {
+    const timeoutMs = opts.timeoutMs;
+    const tasks: Array<Promise<string[]>> = [];
+    if (this.config.provider) {
+      tasks.push(
+        Promise.resolve()
+          .then(() => this.config.provider!())
+          .then((v) => (Array.isArray(v) ? v : []))
+      );
+    }
+    if (this.providerUrl) {
+      tasks.push(this.fetchProviderUrl(timeoutMs));
+    }
+
+    if (tasks.length === 0) {
+      return;
+    }
+
+    const results = await Promise.allSettled(tasks);
+
+    const merged: string[] = [];
+    let anyFailed = false;
+    let anySuccess = false;
+    for (const r of results) {
+      if (r.status === "fulfilled") {
+        anySuccess = true;
+        for (const entry of r.value) merged.push(entry);
+      } else {
+        anyFailed = true;
+        this.logProviderFailure(r.reason as Error);
+      }
+    }
+
+    // Only update last-known-good when we got SOMETHING.
+    if (anySuccess) {
+      const matchers: OriginMatcher[] = [];
+      const strings: string[] = [];
+      const seen = new Set<string>();
+      for (const entry of merged) {
+        const trimmed = entry.trim();
+        if (!trimmed || seen.has(trimmed)) continue;
+        const m = parseAllowedOrigin(trimmed);
+        if (m) {
+          matchers.push(m);
+          strings.push(trimmed);
+          seen.add(trimmed);
+        }
+      }
+      this.providerMatchers.length = 0;
+      this.providerMatchers.push(...matchers);
+      this.providerOriginStrings = strings;
+    }
+
+    if (anyFailed && !anySuccess) {
+      // Bubble up for init() to record cold-start failure; background
+      // refresh swallows it (we've already logged).
+      if (!this.hasInitialFetch) {
+        throw (
+          results.find((r) => r.status === "rejected")?.reason ??
+          new Error("provider failed")
+        );
+      }
+    }
+  }
+
+  private logProviderFailure(err: Error): void {
+    this.lastProviderError = err;
+    const now = Date.now();
+    if (now - this.lastLoggedFailureAtMs > 60_000) {
+      this.lastLoggedFailureAtMs = now;
+      console.warn(`[OriginResolver] provider refresh failed: ${err.message}`);
+    }
+  }
+
+  /**
+   * Conditional GET against providerUrl. Updates ETag/Last-Modified/cache
+   * expiry from response headers. Returns the parsed list on 200; on 304,
+   * resolves with the current `providerOriginStrings` (caller merges).
+   */
+  private async fetchProviderUrl(timeoutMs?: number): Promise<string[]> {
+    if (!this.providerUrl) return [];
+    const headers: Record<string, string> = {
+      Accept: "application/json",
+      ...this.extraHeaders,
+    };
+    if (this.token) headers.Authorization = `Bearer ${this.token}`;
+    if (this.lastETag) headers["If-None-Match"] = this.lastETag;
+    if (this.lastModified) headers["If-Modified-Since"] = this.lastModified;
+
+    const controller = new AbortController();
+    const timer = timeoutMs
+      ? setTimeout(() => controller.abort(), timeoutMs)
+      : null;
+
+    let res: Response;
+    try {
+      res = await fetch(this.providerUrl, {
+        method: "GET",
+        headers,
+        signal: controller.signal,
+      });
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+
+    const now = Date.now();
+    const cc = parseCacheControl(res.headers.get("cache-control"));
+    const maxAgeSec = cc.maxAgeSeconds ?? this.fallbackRevalidateSeconds;
+    const swrSec = cc.staleWhileRevalidateSeconds ?? 0;
+
+    if (cc.noStore) {
+      this.cacheExpiresAtMs = 0;
+      this.staleUntilMs = 0;
+    } else {
+      this.cacheExpiresAtMs = cc.noCache ? 0 : now + maxAgeSec * 1000;
+      this.staleUntilMs = this.cacheExpiresAtMs + swrSec * 1000;
+    }
+
+    if (res.status === 304) {
+      // Keep last-known-good; nothing to merge.
+      return this.providerOriginStrings;
+    }
+    if (!res.ok) {
+      throw new Error(
+        `providerUrl ${this.providerUrl} returned ${res.status} ${res.statusText}`
+      );
+    }
+
+    const etag = res.headers.get("etag");
+    const lastModified = res.headers.get("last-modified");
+    if (etag) this.lastETag = etag;
+    if (lastModified) this.lastModified = lastModified;
+
+    const json = (await res.json()) as unknown;
+    if (!Array.isArray(json)) {
+      throw new Error(
+        `providerUrl ${this.providerUrl} did not return a JSON array`
+      );
+    }
+    const out: string[] = [];
+    for (const v of json) {
+      if (typeof v === "string") out.push(v);
+    }
+    return out;
+  }
+
+  /**
+   * Verify an incoming webhook request. The caller (mcp-server.ts) wires
+   * this to `POST /mcp-use/internal/origins/refresh`. Returns a shape
+   * the route handler turns into the HTTP response.
+   */
+  async handleWebhook(opts: {
+    signatureHeader: string | null;
+    rawBody: string;
+    now?: number;
+  }): Promise<{ status: number; body?: string }> {
+    if (!this.webhookSecret) {
+      return { status: 404, body: "webhook disabled" };
+    }
+    const nowSec = Math.floor((opts.now ?? Date.now()) / 1000);
+    const sig = opts.signatureHeader?.trim();
+    if (!sig) return { status: 401, body: "missing signature" };
+
+    const parts = Object.fromEntries(
+      sig.split(",").map((p) => {
+        const idx = p.indexOf("=");
+        if (idx < 0) return [p.trim(), ""];
+        return [p.slice(0, idx).trim(), p.slice(idx + 1).trim()];
+      })
+    ) as Record<string, string>;
+
+    const tStr = parts["t"];
+    const v1 = parts["v1"];
+    if (!tStr || !v1) return { status: 401, body: "malformed signature" };
+
+    const t = Number(tStr);
+    if (!Number.isFinite(t))
+      return { status: 401, body: "malformed timestamp" };
+    if (Math.abs(nowSec - t) > WEBHOOK_REPLAY_WINDOW_SECONDS) {
+      return { status: 401, body: "stale signature" };
+    }
+
+    const expected = createHmac("sha256", this.webhookSecret)
+      .update(`${tStr}.${opts.rawBody}`)
+      .digest("hex");
+    const expectedBuf = Buffer.from(expected, "utf8");
+    const providedBuf = Buffer.from(v1, "utf8");
+    if (
+      expectedBuf.length !== providedBuf.length ||
+      !timingSafeEqual(expectedBuf, providedBuf)
+    ) {
+      return { status: 401, body: "signature mismatch" };
+    }
+
+    // Signature OK. Parse body — empty body == "invalidate + refetch".
+    if (opts.rawBody.trim().length > 0) {
+      let payload: unknown;
+      try {
+        payload = JSON.parse(opts.rawBody);
+      } catch {
+        return { status: 400, body: "invalid JSON body" };
+      }
+      const origins =
+        payload && typeof payload === "object" && payload !== null
+          ? (payload as { origins?: unknown }).origins
+          : undefined;
+      if (Array.isArray(origins)) {
+        const list: string[] = [];
+        for (const v of origins) if (typeof v === "string") list.push(v);
+        this.applyInlineOrigins(list);
+        return { status: 204 };
+      }
+    }
+
+    // No inline origins — invalidate cache so the next read triggers a refetch.
+    await this.invalidateAndRefresh();
+    return { status: 204 };
+  }
+}
+
+export { parseCacheControl, matcherMatchesHostname, matcherMatchesOrigin };

--- a/libraries/typescript/packages/mcp-use/src/server/utils/server-helpers.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/utils/server-helpers.ts
@@ -7,6 +7,7 @@
 import { Hono, type Hono as HonoType } from "hono";
 import { cors } from "hono/cors";
 import { hostHeaderValidation } from "../middleware/host-validation.js";
+import type { OriginResolver, ResolveResult } from "./origin-resolver.js";
 import { getEnv } from "./runtime.js";
 
 /**
@@ -35,43 +36,18 @@ export function getDefaultCorsOptions(): Parameters<typeof cors>[0] {
 /**
  * Create and configure a new Hono app instance with default middleware
  *
- * Sets up CORS and request logging middleware for the MCP server.
+ * Sets up CORS and request logging middleware for the MCP server. When an
+ * `originResolver` is provided AND the user actually configured
+ * `allowedOrigins`, Host validation middleware is installed globally.
  *
  * @param requestLogger - Request logging middleware function
+ * @param options.originResolver - Resolver driving Host validation
+ * @param options.cors - Custom CORS options
  * @returns Configured Hono app instance
  */
 interface CreateHonoAppOptions {
-  allowedOrigins?: string[];
+  originResolver?: OriginResolver;
   cors?: Partial<Parameters<typeof cors>[0]>;
-}
-
-function parseAllowedHostname(value: string): string | null {
-  const trimmedValue = value.trim();
-  if (!trimmedValue) {
-    return null;
-  }
-
-  try {
-    return new URL(trimmedValue).hostname.toLowerCase();
-  } catch {
-    try {
-      return new URL(`http://${trimmedValue}`).hostname.toLowerCase();
-    } catch {
-      return null;
-    }
-  }
-}
-
-function getAllowedHostnames(allowedOrigins?: string[]): string[] {
-  if (!allowedOrigins || allowedOrigins.length === 0) {
-    return [];
-  }
-
-  const hostnames = allowedOrigins
-    .map((origin) => parseAllowedHostname(origin))
-    .filter((hostname): hostname is string => Boolean(hostname));
-
-  return [...new Set(hostnames)];
 }
 
 export function createHonoApp(
@@ -80,10 +56,10 @@ export function createHonoApp(
 ): HonoType {
   const app = new Hono();
 
-  const allowedHostnames = getAllowedHostnames(options.allowedOrigins);
-
-  if (allowedHostnames.length > 0) {
-    app.use("*", hostHeaderValidation(allowedHostnames));
+  // Only enable Host validation when the user actually configured
+  // `allowedOrigins`. Resolvers built from an empty/absent config are no-ops.
+  if (options.originResolver && options.originResolver.isEnabled()) {
+    app.use("*", hostHeaderValidation(options.originResolver));
   }
 
   // Enable CORS by default, with optional config overrides
@@ -166,7 +142,6 @@ export function getServerBaseUrl(
 export function getCSPUrls(): string[] {
   const cspUrlsEnv = getEnv("CSP_URLS");
   if (!cspUrlsEnv) {
-    console.log("[CSP] No CSP_URLS environment variable found");
     return [];
   }
 
@@ -176,8 +151,41 @@ export function getCSPUrls(): string[] {
     .map((url) => url.trim())
     .filter((url) => url.length > 0);
 
-  console.log("[CSP] Parsed CSP URLs:", urls);
   return urls;
+}
+
+/**
+ * Resolve the effective base URL + allow-list for a given request using
+ * the optional `OriginResolver`. When no resolver is configured (or the
+ * request Host isn't allow-listed), falls back to the static `baseUrl`.
+ *
+ * Designed for use inside widget read callbacks via `getRequestContext()`.
+ *
+ * @param req - Incoming request (Web `Request` or Hono-compatible object)
+ * @param resolver - Optional OriginResolver; when absent, always uses fallback
+ * @param fallback - Fallback base URL (typically the configured baseUrl)
+ * @returns Resolved origin and whether the request Host was allow-listed
+ */
+export function resolveBaseUrlForRequest(
+  req:
+    | { headers: { get(name: string): string | null }; url?: string }
+    | undefined,
+  resolver: OriginResolver | undefined,
+  fallback: string | null | undefined
+): ResolveResult {
+  if (!resolver || !resolver.isEnabled() || !req) {
+    return {
+      origin: fallback ?? "",
+      isAllowed: false,
+      requestHostname: null,
+    };
+  }
+
+  const result = resolver.resolveRequest(req);
+  if (!result.isAllowed && !result.origin && fallback) {
+    return { ...result, origin: fallback };
+  }
+  return result;
 }
 
 /**

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/ui-resource-registration.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/ui-resource-registration.ts
@@ -16,8 +16,11 @@ import type {
   ToolDefinition,
   UIResourceDefinition,
 } from "../types/index.js";
+import { getRequestContext } from "../context-storage.js";
+import type { OriginResolver } from "../utils/origin-resolver.js";
 import {
   applyDefaultProps,
+  augmentDefinitionForRequest,
   convertPropsToInputs,
   createWidgetUIResource,
   generateWidgetUri,
@@ -42,6 +45,8 @@ export interface UIResourceServer {
   readonly serverHost: string;
   readonly serverPort?: number;
   readonly serverBaseUrl?: string;
+  /** Resolver used to make widget <base> / CSP dynamic per request. Optional. */
+  readonly originResolver?: OriginResolver;
   /** Storage for widget definitions, used to inject metadata into tool responses */
   widgetDefinitions: Map<string, Record<string, unknown>>;
   /** Registrations storage for checking existing registrations (for HMR updates) */
@@ -190,17 +195,22 @@ export function uiResourceRegistration<T extends UIResourceServer>(
   // Only store what's needed to build protocol metadata at tool-call time:
   // - widgetType: to decide mcpApps vs appsSdk code path
   // - metadata: CSP/domain config needed by protocol adapters
-  // No mcp-use/* keys are stored — they don't belong on the wire.
+  // - mcp-use/rawHtml: unprocessed HTML preserved for per-request re-processing
+  //   when the origin resolver is in dynamic mode. Null-safe (may be undefined
+  //   for programmatic widgets that didn't go through processWidgetHtml).
+  // No mcp-use/* keys are surfaced on the wire.
   if (
     enrichedDefinition.type === "appsSdk" ||
     enrichedDefinition.type === "mcpApps"
   ) {
+    const rawHtml = (enrichedDefinition._meta as any)?.["mcp-use/rawHtml"];
     server.widgetDefinitions.set(enrichedDefinition.name, {
       widgetType: enrichedDefinition.type,
       metadata:
         enrichedDefinition.type === "mcpApps"
           ? enrichedDefinition.metadata
           : undefined,
+      "mcp-use/rawHtml": typeof rawHtml === "string" ? rawHtml : undefined,
     } as Record<string, unknown>);
 
     // Update any existing tools that reference this widget
@@ -315,8 +325,46 @@ export function uiResourceRegistration<T extends UIResourceServer>(
     return (full as UIResourceDefinition) ?? enrichedDefinition;
   };
 
+  /**
+   * When the origin resolver is enabled, clone the definition and re-process
+   * HTML + CSP for the current request. When it isn't, fall through with the
+   * definition as-registered (zero per-request overhead = today's behavior).
+   */
+  const buildRequestScopedDefinition = (
+    def: UIResourceDefinition
+  ): UIResourceDefinition => {
+    const resolver = server.originResolver;
+    // Any `allowedOrigins` form activates per-request widget resolution:
+    // the resolver becomes the single source of truth for Host validation
+    // AND widget <base>/CSP. When unset, the resolver reports !isEnabled()
+    // and we fall through unchanged (zero per-request overhead = today).
+    if (!resolver || !resolver.isEnabled()) return def;
+    const ctx = getRequestContext();
+    const req = ctx?.req.raw;
+    if (!req) return def;
+
+    const stored = server.widgetDefinitions.get(def.name) as
+      | Record<string, unknown>
+      | undefined;
+    const rawHtml =
+      (stored?.["mcp-use/rawHtml"] as string | undefined) ?? undefined;
+
+    // Fire-and-forget background refresh if the resolver's cache is stale.
+    resolver.refreshIfStale();
+
+    return augmentDefinitionForRequest({
+      definition: def,
+      request: req,
+      resolver,
+      rawHtml,
+      fallbackBaseUrl: server.serverBaseUrl,
+      serverHost: server.serverHost,
+      serverPort: server.serverPort || 3000,
+    });
+  };
+
   const resourceReadCallback = async () => {
-    const latestDef = getLatestDefinition();
+    const latestDef = buildRequestScopedDefinition(getLatestDefinition());
     const params =
       latestDef.type === "externalUrl"
         ? applyDefaultProps(latestDef.props)
@@ -339,7 +387,7 @@ export function uiResourceRegistration<T extends UIResourceServer>(
     uri: URL,
     _params: Record<string, string>
   ) => {
-    const latestDef = getLatestDefinition();
+    const latestDef = buildRequestScopedDefinition(getLatestDefinition());
     const uiResource = await createWidgetUIResource(
       latestDef,
       {},

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/widget-helpers.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/widget-helpers.ts
@@ -13,6 +13,7 @@ import type {
   WidgetProps,
 } from "../types/index.js";
 import { fsHelpers, getCwd, isDeno, pathHelpers } from "../utils/runtime.js";
+import type { OriginResolver } from "../utils/origin-resolver.js";
 import {
   createUIResourceFromDefinition,
   type UrlConfig,
@@ -716,16 +717,28 @@ export async function registerWidgetFromTemplate(
   isDev: boolean = false
 ): Promise<void> {
   // Read and process HTML template
-  let html = await readWidgetHtml(htmlPath, widgetName);
-  if (!html) {
+  const rawHtml = await readWidgetHtml(htmlPath, widgetName);
+  if (!rawHtml) {
     return; // readWidgetHtml already logged the error
   }
 
   // Process HTML with base URL injection and path conversion
-  html = processWidgetHtml(html, widgetName, serverConfig.serverBaseUrl);
+  const html = processWidgetHtml(
+    rawHtml,
+    widgetName,
+    serverConfig.serverBaseUrl
+  );
 
-  // Ensure metadata has proper fallbacks
+  // Ensure metadata has proper fallbacks; propagate raw HTML via _meta so that
+  // the dynamic origin resolver can re-process it at resources/read time with
+  // the current request's effective origin.
   const processedMetadata = ensureWidgetMetadata(metadata, widgetName);
+  const existingMeta =
+    (processedMetadata._meta as Record<string, unknown>) || {};
+  processedMetadata._meta = {
+    ...existingMeta,
+    "mcp-use/rawHtml": rawHtml,
+  };
 
   // Create and register the widget
   const widgetRegistration = createWidgetRegistration(
@@ -831,4 +844,138 @@ export function setupFaviconRoute(
       return c.notFound();
     }
   });
+}
+
+/**
+ * Request-scoped clone of a widget definition used when the origin resolver
+ * is active. Re-processes HTML with the effective base URL for the incoming
+ * request and extends every CSP array with the union of:
+ *
+ *   - the effective request origin (request Host if allow-listed, else fallback),
+ *   - every currently-known allow-listed origin (static + provider, wildcards preserved).
+ *
+ * This is a no-op in static mode — the caller in `ui-resource-registration.ts`
+ * guards on `resolver.isEnabled()`.
+ */
+export function augmentDefinitionForRequest(opts: {
+  definition: UIResourceDefinition;
+  request: { headers: { get(name: string): string | null }; url?: string };
+  resolver: OriginResolver;
+  rawHtml?: string;
+  fallbackBaseUrl?: string;
+  serverHost: string;
+  serverPort: number | string;
+}): UIResourceDefinition {
+  const { definition, request, resolver, rawHtml } = opts;
+  const resolved = resolver.resolveRequest(request);
+  const effectiveBase =
+    resolved.origin ||
+    opts.fallbackBaseUrl ||
+    `http://${opts.serverHost}:${opts.serverPort}`;
+
+  const allowList = resolver.getAllowedOriginStringsSync();
+
+  // Build the union (dedupe, preserve wildcards). Effective base always first
+  // so clients that inspect CSP get a predictable primary origin.
+  const unionSet = new Set<string>();
+  const union: string[] = [];
+  const push = (v: string | undefined | null) => {
+    if (!v) return;
+    const trimmed = v.trim();
+    if (!trimmed || unionSet.has(trimmed)) return;
+    unionSet.add(trimmed);
+    union.push(trimmed);
+  };
+  push(effectiveBase);
+  for (const origin of allowList) push(origin);
+
+  // Clone with re-processed HTML when the underlying widget was authored via
+  // processWidgetHtml (raw HTML available). Programmatic `htmlTemplate` widgets
+  // pass through unchanged.
+  const cloned: UIResourceDefinition = {
+    ...definition,
+  } as UIResourceDefinition;
+  if (
+    (definition.type === "appsSdk" || definition.type === "mcpApps") &&
+    rawHtml
+  ) {
+    (cloned as { htmlTemplate: string }).htmlTemplate = processWidgetHtml(
+      rawHtml,
+      definition.name,
+      effectiveBase
+    );
+  }
+
+  if (definition.type === "appsSdk" || definition.type === "mcpApps") {
+    const appsSdkMeta =
+      "appsSdkMetadata" in definition ? definition.appsSdkMetadata : undefined;
+    const existingWidgetCSP =
+      (appsSdkMeta as any)?.["openai/widgetCSP"] ?? undefined;
+
+    const mergedWidgetCSP: Record<string, string[] | undefined> = {
+      connect_domains: mergeCspArray(existingWidgetCSP?.connect_domains, union),
+      resource_domains: mergeCspArray(
+        existingWidgetCSP?.resource_domains,
+        union
+      ),
+      base_uri_domains: mergeCspArray(
+        existingWidgetCSP?.base_uri_domains,
+        union
+      ),
+    };
+    if (existingWidgetCSP?.frame_domains)
+      mergedWidgetCSP.frame_domains = existingWidgetCSP.frame_domains;
+    if (existingWidgetCSP?.redirect_domains)
+      mergedWidgetCSP.redirect_domains = existingWidgetCSP.redirect_domains;
+
+    (cloned as any).appsSdkMetadata = {
+      ...(appsSdkMeta as Record<string, unknown> | undefined),
+      "openai/widgetCSP": mergedWidgetCSP,
+    };
+  }
+
+  if (definition.type === "mcpApps") {
+    const existingMetadata =
+      "metadata" in definition ? definition.metadata : undefined;
+    const existingCsp = (existingMetadata as any)?.csp ?? undefined;
+    const mergedCsp = {
+      ...(existingCsp || {}),
+      resourceDomains: mergeCspArray(existingCsp?.resourceDomains, union),
+      connectDomains: mergeCspArray(existingCsp?.connectDomains, union),
+      baseUriDomains: mergeCspArray(existingCsp?.baseUriDomains, union),
+    };
+    (cloned as any).metadata = {
+      ...(existingMetadata as Record<string, unknown> | undefined),
+      csp: mergedCsp,
+    };
+  }
+
+  return cloned;
+}
+
+/**
+ * Merge an existing CSP array with new entries, deduping exact string matches
+ * while preserving order (existing entries first, then new).
+ */
+function mergeCspArray(
+  existing: string[] | undefined,
+  additions: string[]
+): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  if (existing) {
+    for (const v of existing) {
+      if (!seen.has(v)) {
+        seen.add(v);
+        out.push(v);
+      }
+    }
+  }
+  for (const v of additions) {
+    if (!seen.has(v)) {
+      seen.add(v);
+      out.push(v);
+    }
+  }
+  return out;
 }

--- a/libraries/typescript/packages/mcp-use/tests/integration/dynamic-origins.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/integration/dynamic-origins.test.ts
@@ -1,0 +1,173 @@
+import { createHmac } from "node:crypto";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { MCPServer } from "../../src/server/index.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+describe("Dynamic origins integration", () => {
+  let server: any;
+  let client: Client;
+  let transport: StreamableHTTPClientTransport;
+  const PORT = 3197;
+  const BASE = `http://localhost:${PORT}`;
+  const MCP_URL = `${BASE}/mcp`;
+  const WEBHOOK_SECRET = "whsec_test_integration";
+
+  beforeAll(async () => {
+    server = new MCPServer({
+      name: "dynamic-origins-test",
+      version: "1.0.0",
+      baseUrl: BASE,
+      allowedOrigins: {
+        origins: [
+          `http://localhost:${PORT}`,
+          "https://app.example.com",
+          "https://*.preview.example.com",
+        ],
+        webhookSecret: WEBHOOK_SECRET,
+      },
+    });
+
+    // Programmatic widget — no raw HTML, so CSP union is what we assert.
+    server.uiResource({
+      type: "mcpApps",
+      name: "origin-probe",
+      title: "Origin Probe",
+      description: "Minimal widget for testing dynamic origin/CSP",
+      htmlTemplate: "<html><body>probe</body></html>",
+      metadata: {
+        description: "Minimal widget",
+      },
+    });
+
+    await server.listen(PORT);
+
+    client = new Client(
+      { name: "origins-test-client", version: "1.0.0" },
+      { capabilities: {} }
+    );
+    transport = new StreamableHTTPClientTransport(new URL(MCP_URL), {
+      // localhost is allow-listed, so this connects fine.
+    });
+    await client.connect(transport);
+  }, 30_000);
+
+  afterAll(async () => {
+    await client?.close();
+    await transport?.close();
+    await server?.close?.();
+  }, 10_000);
+
+  it("allow-listed Host results in that origin being in widget CSP", async () => {
+    const result = await client.readResource({
+      uri: "ui://widget/origin-probe.html",
+    });
+    const contents = (result as any).contents ?? [];
+    expect(contents.length).toBeGreaterThan(0);
+    const csp =
+      (contents[0]?._meta?.ui?.csp as Record<string, string[]> | undefined) ||
+      undefined;
+    expect(csp).toBeDefined();
+    const flattened = [
+      ...(csp!.resourceDomains ?? []),
+      ...(csp!.connectDomains ?? []),
+      ...(csp!.baseUriDomains ?? []),
+    ];
+    // Localhost-on-the-configured-port is allow-listed, so it shows up.
+    expect(flattened).toContain(`http://localhost:${PORT}`);
+    // The full allow-list is unioned into CSP.
+    expect(flattened).toContain("https://app.example.com");
+    expect(flattened).toContain("https://*.preview.example.com");
+  });
+
+  it("rejects /mcp with a non-allow-listed Host (403)", async () => {
+    const res = await server.app.request("http://localhost/mcp", {
+      method: "POST",
+      headers: {
+        Host: "evil.example.com",
+        Accept: "application/json, text/event-stream",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+        params: {},
+      }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("webhook accepts valid HMAC and 401s on bad signature or stale timestamp", async () => {
+    const body = JSON.stringify({
+      origins: ["https://added.example.com"],
+    });
+    const t = Math.floor(Date.now() / 1000);
+    const v1 = createHmac("sha256", WEBHOOK_SECRET)
+      .update(`${t}.${body}`)
+      .digest("hex");
+
+    const ok = await server.app.request(
+      "http://localhost/mcp-use/internal/origins/refresh",
+      {
+        method: "POST",
+        headers: {
+          Host: `localhost:${PORT}`,
+          "Content-Type": "application/json",
+          "X-MCP-Signature": `t=${t},v1=${v1}`,
+        },
+        body,
+      }
+    );
+    expect(ok.status).toBe(204);
+
+    // Next read should reflect the pushed origin.
+    const after = await client.readResource({
+      uri: "ui://widget/origin-probe.html",
+    });
+    const csp = (after as any).contents?.[0]?._meta?.ui?.csp as Record<
+      string,
+      string[]
+    >;
+    const all = [
+      ...(csp?.resourceDomains ?? []),
+      ...(csp?.connectDomains ?? []),
+      ...(csp?.baseUriDomains ?? []),
+    ];
+    expect(all).toContain("https://added.example.com");
+
+    // Bad signature.
+    const bad = await server.app.request(
+      "http://localhost/mcp-use/internal/origins/refresh",
+      {
+        method: "POST",
+        headers: {
+          Host: `localhost:${PORT}`,
+          "Content-Type": "application/json",
+          "X-MCP-Signature": `t=${t},v1=deadbeef`,
+        },
+        body,
+      }
+    );
+    expect(bad.status).toBe(401);
+
+    // Stale timestamp.
+    const staleT = t - 10 * 60;
+    const staleSig = createHmac("sha256", WEBHOOK_SECRET)
+      .update(`${staleT}.${body}`)
+      .digest("hex");
+    const stale = await server.app.request(
+      "http://localhost/mcp-use/internal/origins/refresh",
+      {
+        method: "POST",
+        headers: {
+          Host: `localhost:${PORT}`,
+          "Content-Type": "application/json",
+          "X-MCP-Signature": `t=${staleT},v1=${staleSig}`,
+        },
+        body,
+      }
+    );
+    expect(stale.status).toBe(401);
+  });
+});

--- a/libraries/typescript/packages/mcp-use/tests/unit/react/useMcp-logLevel.test.tsx
+++ b/libraries/typescript/packages/mcp-use/tests/unit/react/useMcp-logLevel.test.tsx
@@ -1,3 +1,5 @@
+// @vitest-environment jsdom
+
 /**
  * Tests for logLevel configuration in useMcp hook
  *
@@ -281,17 +283,38 @@ describe("useMcp logLevel configuration", () => {
         create(<TestComponent1 />);
       });
 
-      const silentLogs = (console.log as any).mock.calls.length;
+      // Snapshot all console methods after the silent instance runs.
+      // Debug-level output routes to console.debug, not console.log, so we
+      // must track all relevant channels.
+      const callsAfterSilent = {
+        log: (console.log as any).mock.calls.length,
+        info: (console.info as any).mock.calls.length,
+        debug: (console.debug as any).mock.calls.length,
+        warn: (console.warn as any).mock.calls.length,
+      };
+
+      // Silent instance should produce no console output at all
+      expect(
+        callsAfterSilent.log +
+          callsAfterSilent.info +
+          callsAfterSilent.debug +
+          callsAfterSilent.warn
+      ).toBe(0);
 
       // Second instance: debug (different URL so different logger name)
       act(() => {
         create(<TestComponent2 />);
       });
 
-      const debugLogs = (console.log as any).mock.calls.length;
+      // Count only the new calls produced by the debug instance (delta, not cumulative)
+      const newCallsFromDebug =
+        (console.log as any).mock.calls.length -
+        callsAfterSilent.log +
+        ((console.info as any).mock.calls.length - callsAfterSilent.info) +
+        ((console.debug as any).mock.calls.length - callsAfterSilent.debug);
 
-      // The debug instance should log, silent shouldn't
-      expect(debugLogs).toBeGreaterThan(silentLogs);
+      // The debug instance should have produced at least one log entry
+      expect(newCallsFromDebug).toBeGreaterThan(0);
 
       // Both should have their own state
       expect(hookResult1.state).toBeDefined();

--- a/libraries/typescript/packages/mcp-use/tests/unit/react/useMcp-proxyCleanup.test.tsx
+++ b/libraries/typescript/packages/mcp-use/tests/unit/react/useMcp-proxyCleanup.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+
+/**
+ * Tests that useMcp calls restoreFetch() on unmount to tear down any
+ * window.fetch interceptor installed by a proxy-mode OAuth provider.
+ *
+ * Related issue: MCP-1713 — Inspector: switching from "Via Proxy" → "Direct"
+ * fails with "Protected resource does not match" error because the stale
+ * interceptor from the proxy connection is never removed.
+ */
+
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, create } from "react-test-renderer";
+
+vi.mock("../../../src/client/browser.js", () => ({
+  // Use a regular function (not arrow) so it's constructable with `new`
+  BrowserMCPClient: vi.fn(function () {
+    return {
+      addServer: vi.fn().mockResolvedValue(undefined),
+      removeServer: vi.fn().mockResolvedValue(undefined),
+      getSession: vi.fn().mockReturnValue(null),
+      createSession: vi.fn().mockResolvedValue(undefined),
+      listSessions: vi.fn().mockReturnValue([]),
+    };
+  }),
+}));
+
+vi.mock("../../../src/auth/browser-provider.js", () => ({
+  createBrowserOAuthProvider: vi.fn(() => ({
+    provider: null,
+    oauthProxyUrl: undefined,
+  })),
+}));
+
+vi.mock("../../../src/telemetry/index.js", () => ({
+  Tel: {
+    getInstance: () => ({
+      trackUseMcpConnection: vi.fn().mockResolvedValue(undefined),
+    }),
+  },
+}));
+
+describe("useMcp proxy connection cleanup", () => {
+  let useMcp: any;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    const module = await import("../../../src/react/useMcp.js");
+    useMcp = module.useMcp;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls restoreFetch() on the auth provider when the hook unmounts", async () => {
+    const restoreFetch = vi.fn();
+    const mockAuthProvider = {
+      restoreFetch,
+      clearStorage: vi.fn().mockReturnValue(0),
+      serverUrl: "http://localhost:3001/mcp",
+    };
+
+    let renderer: ReturnType<typeof create>;
+
+    function TestComponent() {
+      useMcp({
+        url: "http://localhost:3001/mcp",
+        enabled: true,
+        authProvider: mockAuthProvider,
+      });
+      return null;
+    }
+
+    await act(async () => {
+      renderer = create(<TestComponent />);
+    });
+
+    expect(restoreFetch).not.toHaveBeenCalled();
+
+    await act(async () => {
+      renderer!.unmount();
+    });
+
+    expect(restoreFetch).toHaveBeenCalledOnce();
+  });
+
+  it("does not throw on unmount when no auth provider is set", async () => {
+    let renderer: ReturnType<typeof create>;
+
+    function TestComponent() {
+      useMcp({
+        url: "http://localhost:3001/mcp",
+        enabled: false, // skip connection so authProviderRef stays null
+      });
+      return null;
+    }
+
+    await act(async () => {
+      renderer = create(<TestComponent />);
+    });
+
+    await expect(
+      act(async () => {
+        renderer!.unmount();
+      })
+    ).resolves.not.toThrow();
+  });
+});

--- a/libraries/typescript/packages/mcp-use/tests/unit/server/origin-resolver.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/server/origin-resolver.test.ts
@@ -1,0 +1,385 @@
+import { createHmac } from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  OriginResolver,
+  parseAllowedOrigin,
+  matcherMatchesHostname,
+  parseCacheControl,
+} from "../../../src/server/utils/origin-resolver.js";
+
+const ENV_KEYS = [
+  "MCP_ALLOWED_ORIGINS",
+  "MCP_ALLOWED_ORIGINS_URL",
+  "MCP_ALLOWED_ORIGINS_TOKEN",
+  "MCP_ALLOWED_ORIGINS_WEBHOOK_SECRET",
+] as const;
+
+function clearEnv() {
+  for (const k of ENV_KEYS) delete process.env[k];
+}
+
+function makeRequest(host: string, url = `http://${host}/mcp`): Request {
+  return new Request(url, { headers: { Host: host } });
+}
+
+describe("parseAllowedOrigin", () => {
+  it("parses literal origins with scheme", () => {
+    const m = parseAllowedOrigin("https://app.example.com");
+    expect(m).toMatchObject({
+      kind: "literal",
+      hostname: "app.example.com",
+      scheme: "https",
+    });
+  });
+
+  it("parses literal hostnames without scheme", () => {
+    const m = parseAllowedOrigin("app.example.com");
+    expect(m).toMatchObject({
+      kind: "literal",
+      hostname: "app.example.com",
+      scheme: undefined,
+    });
+  });
+
+  it("parses wildcard origins", () => {
+    const m = parseAllowedOrigin("https://*.preview.example.com");
+    expect(m).toMatchObject({
+      kind: "wildcard",
+      hostname: "*.preview.example.com",
+      scheme: "https",
+    });
+  });
+
+  it("rejects bare *", () => {
+    expect(parseAllowedOrigin("*")).toBeNull();
+  });
+
+  it("rejects multiple wildcards", () => {
+    expect(parseAllowedOrigin("*.*.example.com")).toBeNull();
+  });
+
+  it("rejects wildcards with single-label suffix", () => {
+    // "*.com" is a TLD-only wildcard — rejected to prevent foot-guns.
+    expect(parseAllowedOrigin("*.com")).toBeNull();
+  });
+});
+
+describe("matcherMatchesHostname", () => {
+  it("literal matcher matches exact hostname (case-insensitive)", () => {
+    const m = parseAllowedOrigin("https://App.Example.COM")!;
+    expect(matcherMatchesHostname(m, "app.example.com")).toBe(true);
+    expect(matcherMatchesHostname(m, "other.example.com")).toBe(false);
+  });
+
+  it("wildcard matches exactly one label", () => {
+    const m = parseAllowedOrigin("https://*.example.com")!;
+    expect(matcherMatchesHostname(m, "a.example.com")).toBe(true);
+    expect(matcherMatchesHostname(m, "foo.example.com")).toBe(true);
+    // Two labels rejected.
+    expect(matcherMatchesHostname(m, "a.b.example.com")).toBe(false);
+    // Bare apex rejected.
+    expect(matcherMatchesHostname(m, "example.com")).toBe(false);
+    // Totally different domain rejected.
+    expect(matcherMatchesHostname(m, "evil.com")).toBe(false);
+  });
+});
+
+describe("parseCacheControl", () => {
+  it("parses max-age and stale-while-revalidate", () => {
+    const cc = parseCacheControl(
+      "public, max-age=10, stale-while-revalidate=60"
+    );
+    expect(cc.maxAgeSeconds).toBe(10);
+    expect(cc.staleWhileRevalidateSeconds).toBe(60);
+    expect(cc.noStore).toBe(false);
+  });
+
+  it("s-maxage wins over max-age", () => {
+    const cc = parseCacheControl("max-age=10, s-maxage=30");
+    expect(cc.maxAgeSeconds).toBe(30);
+  });
+
+  it("handles no-store / no-cache / must-revalidate", () => {
+    const cc = parseCacheControl("no-cache, no-store, must-revalidate");
+    expect(cc.noStore).toBe(true);
+    expect(cc.noCache).toBe(true);
+    expect(cc.mustRevalidate).toBe(true);
+  });
+});
+
+describe("OriginResolver — static sources", () => {
+  beforeEach(() => clearEnv());
+  afterEach(() => clearEnv());
+
+  it("reports disabled when nothing is configured", () => {
+    const r = new OriginResolver(undefined);
+    expect(r.isEnabled()).toBe(false);
+    expect(r.getMatchersSync()).toHaveLength(0);
+  });
+
+  it("enables with a plain string[] list", () => {
+    const r = new OriginResolver(["https://a.com", "https://*.b.com"]);
+    expect(r.isEnabled()).toBe(true);
+    expect(r.isDynamic()).toBe(false);
+    expect(r.matchesHostname("a.com")).toBe(true);
+    expect(r.matchesHostname("x.b.com")).toBe(true);
+    expect(r.matchesHostname("evil.com")).toBe(false);
+  });
+
+  it("merges MCP_ALLOWED_ORIGINS env var with constructor list", () => {
+    process.env.MCP_ALLOWED_ORIGINS = "https://c.com, https://d.com";
+    const r = new OriginResolver(["https://a.com"]);
+    expect(r.matchesHostname("a.com")).toBe(true);
+    expect(r.matchesHostname("c.com")).toBe(true);
+    expect(r.matchesHostname("d.com")).toBe(true);
+  });
+
+  it("dedupes origin strings", () => {
+    const r = new OriginResolver([
+      "https://a.com",
+      "https://a.com",
+      "https://b.com",
+    ]);
+    expect(r.getAllowedOriginStringsSync()).toEqual([
+      "https://a.com",
+      "https://b.com",
+    ]);
+  });
+
+  it("treats webhookSecret as opting into dynamic mode", () => {
+    const r = new OriginResolver({
+      origins: ["https://a.com"],
+      webhookSecret: "whsec",
+    });
+    expect(r.isEnabled()).toBe(true);
+    expect(r.isDynamic()).toBe(true);
+    expect(r.hasWebhook()).toBe(true);
+  });
+});
+
+describe("OriginResolver — resolveRequest", () => {
+  it("returns fallback origin when resolver is disabled", () => {
+    const r = new OriginResolver(undefined, {
+      fallbackOrigin: "http://localhost:3000",
+    });
+    const result = r.resolveRequest(makeRequest("anything.com"));
+    expect(result.isAllowed).toBe(false);
+    expect(result.origin).toBe("http://localhost:3000");
+  });
+
+  it("returns request origin when Host is allow-listed", () => {
+    const r = new OriginResolver(["https://app.example.com"], {
+      fallbackOrigin: "http://localhost:3000",
+    });
+    const req = new Request("https://app.example.com/mcp", {
+      headers: { Host: "app.example.com" },
+    });
+    const result = r.resolveRequest(req);
+    expect(result.isAllowed).toBe(true);
+    expect(result.origin).toBe("https://app.example.com");
+  });
+
+  it("matches wildcard Host", () => {
+    const r = new OriginResolver(["https://*.preview.example.com"], {
+      fallbackOrigin: "http://localhost:3000",
+    });
+    const req = new Request("https://pr-42.preview.example.com/mcp", {
+      headers: { Host: "pr-42.preview.example.com" },
+    });
+    const result = r.resolveRequest(req);
+    expect(result.isAllowed).toBe(true);
+    expect(result.origin).toBe("https://pr-42.preview.example.com");
+  });
+
+  it("falls back when Host not allow-listed", () => {
+    const r = new OriginResolver(["https://app.example.com"], {
+      fallbackOrigin: "http://localhost:3000",
+    });
+    const result = r.resolveRequest(makeRequest("evil.com"));
+    expect(result.isAllowed).toBe(false);
+    expect(result.origin).toBe("http://localhost:3000");
+  });
+});
+
+describe("OriginResolver — providerUrl with HTTP validators", () => {
+  const originalFetch = globalThis.fetch;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    clearEnv();
+    fetchMock = vi.fn();
+    // @ts-expect-error override global for test
+    globalThis.fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("fetches once and honors 304 Not Modified on revalidation", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(["https://provider-origin.example.com"]), {
+          status: 200,
+          headers: {
+            ETag: '"v1"',
+            "Cache-Control": "public, max-age=0",
+            "Content-Type": "application/json",
+          },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 304,
+          headers: { ETag: '"v1"' },
+        })
+      );
+
+    const r = new OriginResolver({
+      origins: ["https://static.example.com"],
+      providerUrl: "https://config.example/origins.json",
+    });
+
+    await r.init();
+    expect(r.matchesHostname("provider-origin.example.com")).toBe(true);
+    expect(r.matchesHostname("static.example.com")).toBe(true);
+
+    // Trigger revalidation (cache expired, so refreshIfStale kicks off).
+    await r.refreshIfStale();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    // Assert If-None-Match was sent on the 2nd call.
+    const secondCall = fetchMock.mock.calls[1];
+    const sentHeaders = secondCall[1]?.headers as Record<string, string>;
+    expect(sentHeaders["If-None-Match"]).toBe('"v1"');
+
+    // List is still present after 304.
+    expect(r.matchesHostname("provider-origin.example.com")).toBe(true);
+  });
+
+  it("keeps last-known-good list when provider fails after initial success", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(["https://dyn.example.com"]), {
+          status: 200,
+          headers: {
+            ETag: '"v1"',
+            "Cache-Control": "public, max-age=0",
+            "Content-Type": "application/json",
+          },
+        })
+      )
+      .mockRejectedValueOnce(new Error("network down"));
+
+    const r = new OriginResolver({
+      providerUrl: "https://config.example/origins.json",
+    });
+    await r.init();
+    expect(r.matchesHostname("dyn.example.com")).toBe(true);
+
+    await r.refreshIfStale();
+    // After the failure, the list is still present.
+    expect(r.matchesHostname("dyn.example.com")).toBe(true);
+    expect(r.isColdStartFailure()).toBe(false);
+    warn.mockRestore();
+  });
+
+  it("marks cold-start failure when initial fetch fails and no static list", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    fetchMock.mockRejectedValueOnce(new Error("provider unreachable"));
+
+    const r = new OriginResolver({
+      providerUrl: "https://config.example/origins.json",
+    });
+    await r.init();
+    expect(r.isColdStartFailure()).toBe(true);
+    warn.mockRestore();
+  });
+
+  it("single-flight: concurrent refreshes share one in-flight fetch", async () => {
+    let resolveFirst!: (res: Response) => void;
+    const firstPromise = new Promise<Response>((resolve) => {
+      resolveFirst = resolve;
+    });
+    fetchMock.mockReturnValueOnce(firstPromise);
+
+    const r = new OriginResolver({
+      providerUrl: "https://config.example/origins.json",
+    });
+    const p1 = r.refreshIfStale();
+    const p2 = r.refreshIfStale();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    resolveFirst(
+      new Response(JSON.stringify(["https://a.example.com"]), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    await Promise.all([p1, p2]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(r.matchesHostname("a.example.com")).toBe(true);
+  });
+});
+
+describe("OriginResolver — webhook HMAC", () => {
+  beforeEach(() => clearEnv());
+
+  function sign(secret: string, t: number, body: string): string {
+    return createHmac("sha256", secret).update(`${t}.${body}`).digest("hex");
+  }
+
+  it("accepts valid HMAC and swaps in inline origins", async () => {
+    const r = new OriginResolver({
+      origins: ["https://a.com"],
+      webhookSecret: "whsec_test",
+    });
+    const body = JSON.stringify({ origins: ["https://added.example.com"] });
+    const t = Math.floor(Date.now() / 1000);
+    const v1 = sign("whsec_test", t, body);
+
+    const result = await r.handleWebhook({
+      signatureHeader: `t=${t},v1=${v1}`,
+      rawBody: body,
+    });
+
+    expect(result.status).toBe(204);
+    expect(r.matchesHostname("added.example.com")).toBe(true);
+    expect(r.matchesHostname("a.com")).toBe(true); // static still present
+  });
+
+  it("rejects bad signature with 401", async () => {
+    const r = new OriginResolver({
+      webhookSecret: "whsec_test",
+    });
+    const result = await r.handleWebhook({
+      signatureHeader: "t=1,v1=deadbeef",
+      rawBody: "{}",
+    });
+    expect(result.status).toBe(401);
+  });
+
+  it("rejects stale timestamp with 401", async () => {
+    const r = new OriginResolver({ webhookSecret: "whsec_test" });
+    const staleT = Math.floor(Date.now() / 1000) - 10 * 60; // 10 min old
+    const body = "{}";
+    const v1 = sign("whsec_test", staleT, body);
+    const result = await r.handleWebhook({
+      signatureHeader: `t=${staleT},v1=${v1}`,
+      rawBody: body,
+    });
+    expect(result.status).toBe(401);
+    expect(result.body).toContain("stale");
+  });
+
+  it("returns 404 when webhook is not configured", async () => {
+    const r = new OriginResolver({ origins: ["https://a.com"] });
+    const result = await r.handleWebhook({
+      signatureHeader: "t=1,v1=x",
+      rawBody: "",
+    });
+    expect(result.status).toBe(404);
+  });
+});

--- a/libraries/typescript/packages/mcp-use/tests/unit/server/widget-dynamic-origin.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/server/widget-dynamic-origin.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+import {
+  augmentDefinitionForRequest,
+  processWidgetHtml,
+} from "../../../src/server/widgets/widget-helpers.js";
+import { OriginResolver } from "../../../src/server/utils/origin-resolver.js";
+import type { UIResourceDefinition } from "../../../src/server/types/index.js";
+
+function fakeRequest(host: string, url = `https://${host}/mcp`) {
+  return new Request(url, { headers: { Host: host } });
+}
+
+describe("processWidgetHtml", () => {
+  it("injects <base> and window.__getFile for the given origin", () => {
+    const raw = `<!doctype html><html><head></head><body></body></html>`;
+    const out = processWidgetHtml(raw, "my-widget", "https://app.example.com");
+    expect(out).toContain('<base href="https://app.example.com" />');
+    expect(out).toContain(
+      `window.__getFile = (filename) => { return "https://app.example.com/mcp-use/widgets/my-widget/"+filename }`
+    );
+    expect(out).toContain(
+      `window.__mcpPublicUrl = "https://app.example.com/mcp-use/public"`
+    );
+  });
+
+  it("rewrites absolute widget asset URLs", () => {
+    const raw = `<html><head><script src="/mcp-use/widgets/my-widget/index.js"></script></head><body></body></html>`;
+    const out = processWidgetHtml(raw, "my-widget", "https://app.example.com");
+    expect(out).toContain(
+      'src="https://app.example.com/mcp-use/widgets/my-widget/index.js"'
+    );
+  });
+});
+
+describe("augmentDefinitionForRequest", () => {
+  const staticDef: UIResourceDefinition = {
+    type: "mcpApps",
+    name: "weather",
+    title: "Weather",
+    description: "Show weather",
+    htmlTemplate: "<html><head></head><body>weather</body></html>",
+    metadata: {
+      description: "Show weather",
+      csp: {
+        resourceDomains: ["https://cdn.example.com"],
+        connectDomains: [],
+        baseUriDomains: [],
+      },
+    },
+  };
+
+  it("rewrites <base> per-request when raw HTML is available", () => {
+    const resolver = new OriginResolver(["https://app.example.com"], {
+      fallbackOrigin: "http://localhost:3000",
+    });
+    const req = fakeRequest("app.example.com");
+    const raw = `<html><head></head><body>hi</body></html>`;
+
+    const out = augmentDefinitionForRequest({
+      definition: staticDef,
+      request: req,
+      resolver,
+      rawHtml: raw,
+      fallbackBaseUrl: "http://localhost:3000",
+      serverHost: "localhost",
+      serverPort: 3000,
+    });
+
+    expect((out as any).htmlTemplate).toContain(
+      '<base href="https://app.example.com" />'
+    );
+  });
+
+  it("falls back to baseUrl when Host is not allow-listed", () => {
+    const resolver = new OriginResolver(["https://app.example.com"], {
+      fallbackOrigin: "http://localhost:3000",
+    });
+    const req = fakeRequest("evil.com");
+    const raw = `<html><head></head><body></body></html>`;
+
+    const out = augmentDefinitionForRequest({
+      definition: staticDef,
+      request: req,
+      resolver,
+      rawHtml: raw,
+      fallbackBaseUrl: "http://localhost:3000",
+      serverHost: "localhost",
+      serverPort: 3000,
+    });
+
+    const html = (out as any).htmlTemplate as string;
+    expect(html).toContain('<base href="http://localhost:3000" />');
+    expect(html).not.toContain("evil.com");
+  });
+
+  it("unions allow-list into metadata.csp for mcpApps", () => {
+    const resolver = new OriginResolver(
+      ["https://app.example.com", "https://*.preview.example.com"],
+      { fallbackOrigin: "http://localhost:3000" }
+    );
+    const req = fakeRequest("pr-42.preview.example.com");
+
+    const out = augmentDefinitionForRequest({
+      definition: staticDef,
+      request: req,
+      resolver,
+      fallbackBaseUrl: "http://localhost:3000",
+      serverHost: "localhost",
+      serverPort: 3000,
+    });
+
+    const csp = (out as any).metadata.csp;
+    // Widget-declared entry retained.
+    expect(csp.resourceDomains).toContain("https://cdn.example.com");
+    // Effective request origin added.
+    expect(csp.resourceDomains).toContain("https://pr-42.preview.example.com");
+    // Wildcard pattern passed through as-is.
+    expect(csp.resourceDomains).toContain("https://*.preview.example.com");
+    // connectDomains / baseUriDomains populated with same union.
+    expect(csp.connectDomains).toContain("https://pr-42.preview.example.com");
+    expect(csp.baseUriDomains).toContain("https://pr-42.preview.example.com");
+  });
+
+  it("populates appsSdkMetadata widgetCSP for appsSdk widgets", () => {
+    const appsSdkDef: UIResourceDefinition = {
+      type: "appsSdk",
+      name: "appsdk-widget",
+      title: "AppsSDK",
+      description: "SDK widget",
+      htmlTemplate: "<html></html>",
+      appsSdkMetadata: {
+        "openai/widgetCSP": {
+          connect_domains: [],
+          resource_domains: ["https://*.oaistatic.com"],
+        },
+      },
+    };
+
+    const resolver = new OriginResolver(["https://app.example.com"], {
+      fallbackOrigin: "http://localhost:3000",
+    });
+    const req = fakeRequest("app.example.com");
+
+    const out = augmentDefinitionForRequest({
+      definition: appsSdkDef,
+      request: req,
+      resolver,
+      fallbackBaseUrl: "http://localhost:3000",
+      serverHost: "localhost",
+      serverPort: 3000,
+    });
+
+    const csp = (out as any).appsSdkMetadata["openai/widgetCSP"];
+    expect(csp.resource_domains).toContain("https://*.oaistatic.com");
+    expect(csp.resource_domains).toContain("https://app.example.com");
+    expect(csp.connect_domains).toContain("https://app.example.com");
+    expect(csp.base_uri_domains).toContain("https://app.example.com");
+  });
+
+  it("is a structural clone — does not mutate the input definition", () => {
+    const resolver = new OriginResolver(["https://app.example.com"], {
+      fallbackOrigin: "http://localhost:3000",
+    });
+    const before = JSON.parse(JSON.stringify(staticDef));
+    const out = augmentDefinitionForRequest({
+      definition: staticDef,
+      request: fakeRequest("app.example.com"),
+      resolver,
+      fallbackBaseUrl: "http://localhost:3000",
+      serverHost: "localhost",
+      serverPort: 3000,
+    });
+    expect(staticDef).toEqual(before);
+    expect(out).not.toBe(staticDef);
+  });
+});

--- a/libraries/typescript/packages/mcp-use/vitest.config.ts
+++ b/libraries/typescript/packages/mcp-use/vitest.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
-    include: ["tests/**/*.test.ts"],
+    include: ["tests/**/*.test.ts", "tests/**/*.test.tsx"],
     exclude: ["node_modules/**", "dist/**", "tests/deno/**"],
     coverage: {
       provider: "v8",

--- a/skills/chatgpt-app-builder/SKILL.md
+++ b/skills/chatgpt-app-builder/SKILL.md
@@ -32,7 +32,7 @@ The app is consumed by **two users at once**: the **human** and the **ChatGPT LL
 - **Widget state and LLM context** → [state-and-context.md](references/state-and-context.md): when persisting state, triggering LLM from widget, managing ephemeral vs persistent data
 - **Display modes, theme, layout** → [ui-guidelines.md](references/ui-guidelines.md): when adapting to inline/fullscreen/PiP, handling theme, device, locale
 - **Component API** → [components-api.md](references/components-api.md): when using McpUseProvider, Image, ErrorBoundary, useWidget
-- **CSP and metadata** → [csp-and-metadata.md](references/csp-and-metadata.md): when configuring external domains, dual-protocol metadata
+- **CSP and metadata** → [csp-and-metadata.md](references/csp-and-metadata.md): when configuring external domains, dual-protocol metadata, **multi-domain deployments (Vercel previews, canary) via `allowedOrigins`**
 - **Advanced patterns** → [widget-patterns.md](references/widget-patterns.md): when building complex widgets with tool calls, state, theming
 
 ## Quick Reference

--- a/skills/chatgpt-app-builder/references/csp-and-metadata.md
+++ b/skills/chatgpt-app-builder/references/csp-and-metadata.md
@@ -46,30 +46,59 @@ export const widgetMetadata: WidgetMetadata = {
 
 ### Security Best Practices
 
-1. **Specify exact domains**: `https://api.weather.com` (not wildcards)
-2. **Avoid wildcards**: `https://*.weather.com` is less secure
-3. **Never use `'unsafe-eval'`** unless absolutely necessary
-4. **Test CSP in development** before deploying
-5. **Use HTTPS** for all resources
+1. **Prefer exact domains** for third-party APIs (`https://api.weather.com`).
+2. **Use wildcards deliberately** (`https://*.weather.com`) — mcp-use supports them for one subdomain label, matching CSP host-source semantics.
+3. **Never use `'unsafe-eval'`** unless absolutely necessary.
+4. **Test CSP in development** before deploying (Inspector → Widget-Declared mode).
+5. **Use HTTPS** for all resources.
+
+### Hosting the server on multiple domains (Vercel-style, previews, canary)
+
+When the same MCP server is reachable from multiple public URLs (preview deploys, custom domains), don't hardcode a single `baseUrl` — configure `allowedOrigins` on `MCPServer`. A single option drives both DNS-rebinding Host validation AND widget `<base>` + CSP per request:
+
+```typescript
+const server = new MCPServer({
+  name: "my-server",
+  version: "1.0.0",
+  baseUrl: process.env.MCP_URL,
+  allowedOrigins: [
+    "https://app.example.com",
+    "https://*.preview.example.com", // all preview URLs for this repo
+  ],
+});
+```
+
+For remote-managed allow-lists, use the object form with `providerUrl` (honors `Cache-Control` / `ETag` / `stale-while-revalidate`) and an HMAC-signed push webhook for instant updates:
+
+```typescript
+allowedOrigins: {
+  origins: ["https://app.example.com"],
+  providerUrl: process.env.MCP_ALLOWED_ORIGINS_URL,
+  token: process.env.MCP_ALLOWED_ORIGINS_TOKEN,
+  webhookSecret: process.env.MCP_ALLOWED_ORIGINS_WEBHOOK_SECRET,
+}
+```
+
+See `docs/typescript/server/content-security-policy.mdx` for the full provider contract.
 
 ### Troubleshooting CSP Errors
 
 **Problem:** Widget loads but assets fail
 
 **Solutions:**
-1. Check browser console for CSP violation messages
-2. Add missing domains to CSP:
+1. Check browser console for CSP violation messages.
+2. Add missing third-party domains to the widget's CSP:
    ```typescript
    metadata: {
      csp: {
-       connectDomains: ['https://api.example.com'], // Add missing API
-       resourceDomains: ['https://cdn.example.com'], // Add missing CDN
+       connectDomains: ['https://api.example.com'], // third-party API
+       resourceDomains: ['https://cdn.example.com'], // third-party CDN
      }
    }
    ```
-3. Use exact domains - avoid wildcards in production
-4. Test in Inspector before deploying
-5. Set `CSP_URLS` environment variable for additional domains
+3. If the MCP server is reachable under multiple domains, add them to `allowedOrigins` on `MCPServer` so widget `<base>` and CSP track the incoming request.
+4. Test in Inspector's Widget-Declared CSP mode before deploying.
+5. `CSP_URLS` env var still works for additional static entries (legacy).
 
 ## Metadata Configuration
 

--- a/skills/chatgpt-app-builder/references/server-and-widgets.md
+++ b/skills/chatgpt-app-builder/references/server-and-widgets.md
@@ -27,6 +27,10 @@ const server = new MCPServer({
   name: "my-app",
   version: "1.0.0",
   baseUrl: process.env.MCP_URL || "http://localhost:3000",
+  // For multi-domain deployments (Vercel previews, custom domains) list the
+  // public origins in `allowedOrigins` — widget CSP and asset URLs adapt
+  // per-request. See `references/csp-and-metadata.md`.
+  // allowedOrigins: ["https://app.example.com", "https://*.preview.example.com"],
 });
 
 server.tool(

--- a/skills/mcp-apps-builder/SKILL.md
+++ b/skills/mcp-apps-builder/SKILL.md
@@ -143,6 +143,8 @@ Load these before diving into tools/resources/widgets sections.
   - When: Creating your first widget or adding UI to an existing tool
   - Covers: Widget setup, `useWidget()` hook, `isPending` checks, props handling
 
+**Multi-domain / preview deployments** — when the same server is reachable from several public URLs (Vercel previews, custom domains, canary), set `allowedOrigins` on `MCPServer` (supports wildcards and dynamic providers with an HMAC webhook). Widget `<base>`, asset paths, and CSP then adapt per request. See [csp-and-metadata.md](../chatgpt-app-builder/references/csp-and-metadata.md) and `docs/typescript/server/content-security-policy`.
+
 - **[state.md](references/widgets/state.md)**
   - When: Managing UI state (selections, filters, tabs) within widgets
   - Covers: `useState`, `setState`, state persistence, when to use tool vs widget state

--- a/skills/mcp-apps-builder/references/foundations/quickstart.md
+++ b/skills/mcp-apps-builder/references/foundations/quickstart.md
@@ -100,7 +100,12 @@ const server = new MCPServer({
   name: "my-server",
   title: "My Server",
   version: "1.0.0",
-  baseUrl: process.env.MCP_URL || "http://localhost:3000"
+  baseUrl: process.env.MCP_URL || "http://localhost:3000",
+  // Multi-domain? Uncomment and list the public origins this server is
+  // reachable from. Widget <base>, asset paths and CSP are then computed
+  // per-request. Wildcards (https://*.preview.example.com) are supported.
+  // See `skills/chatgpt-app-builder/references/csp-and-metadata.md`.
+  // allowedOrigins: ["https://app.example.com", "https://*.preview.example.com"],
 });
 
 // Add this tool

--- a/skills/mcp-apps-builder/references/widgets/basics.md
+++ b/skills/mcp-apps-builder/references/widgets/basics.md
@@ -158,6 +158,10 @@ export const widgetMetadata: WidgetMetadata = {
   metadata: {
     invoking: "Fetching weather...", // Shimmer text while tool runs
     invoked: "Weather loaded",       // Static text when complete
+    // Third-party origins your widget fetches from belong here.
+    // The MCP server's own origin(s) are added automatically at read time
+    // from the server's `allowedOrigins` / `baseUrl` configuration — you
+    // don't need to list them in `metadata.csp`.
     csp: { connectDomains: ["https://api.weather.com"] },
   },
 };

--- a/skills/mcp-builder/references/widgets.md
+++ b/skills/mcp-builder/references/widgets.md
@@ -90,6 +90,9 @@ const server = new MCPServer({
   name: "weather-server",
   version: "1.0.0",
   baseUrl: process.env.MCP_URL || "http://localhost:3000",
+  // Serving from multiple domains? List them in `allowedOrigins` — widget
+  // CSP + `<base>` adapt per request. Wildcards supported:
+  //   allowedOrigins: ["https://*.preview.example.com"],
 });
 
 server.tool(


### PR DESCRIPTION
## Language / Project Scope

- [x] TypeScript
- [x] Documentation only (partial — skills & docs also updated)

## Why

`MCPServer` today resolves its public URL exactly once (`baseUrl` → `MCP_URL` → `host:port`) and bakes it into:

- widget HTML (`<base>`, `window.__getFile`, `window.__mcpPublicUrl`, rewritten asset URLs)
- widget CSP (`connect_domains`, `resource_domains`, `base_uri_domains`)

Separately, `allowedOrigins: string[]` gated DNS-rebinding Host validation.

Both knobs answer the **same question** — "which origins is this server reachable from?" — but they didn't talk to each other, didn't support wildcards, and couldn't be updated without redeploying. If you wanted to serve the same server from `app.example.com`, `preview-42.example.com`, and a custom domain, you had to redeploy every time the list changed.

This PR consolidates them behind a single `allowedOrigins` option that now also drives **per-request** widget output, so the same server works across any number of domains — Vercel-style previews, canary, custom domains — with zero redeploys.

## How

- **One `OriginResolver`** is the single source of truth for both Host validation and widget reads.
- `allowedOrigins` accepts `string[]` (today's form, fully preserved) **or** an `AllowedOriginsConfig` object with:
  - Wildcard hostnames (`https://*.preview.example.com`) — one-label matching, same as CSP host-source.
  - `provider: () => string[] | Promise<string[]>` for dynamic lists.
  - `providerUrl` for remote JSON, fetched with HTTP cache validators: `Cache-Control` / `s-maxage` / `stale-while-revalidate` / `ETag` / `If-None-Match`. Conditional 304s keep steady-state cost ~0. Single-flight SWR means one in-flight refresh at a time.
  - `token` → `Authorization: Bearer`, plus arbitrary `headers`.
  - `webhookSecret` enables a push webhook at `POST /mcp-use/internal/origins/refresh` — HMAC-SHA256 with Stripe-style `X-MCP-Signature: t=...,v1=...` and a 5-minute replay window. Inline `origins` in the body swap the list instantly (no follow-up fetch).
- **Per-request widget output** uses the existing `AsyncLocalStorage` request context to:
  1. resolve the request's effective origin (if allow-listed),
  2. re-process the widget HTML with that origin (`<base>`, asset paths, `__getFile`/`__mcpPublicUrl`),
  3. union the full allow-list into `connect_domains` / `resource_domains` / `base_uri_domains` for both `mcpApps` and `appsSdk` widgets.
  Unknown `Host` → fall back to `baseUrl` / `MCP_URL`. Raw HTML is preserved in `_meta["mcp-use/rawHtml"]` so the read callback can re-process it.
- **Fail-closed cold start**: when providers are configured but the initial fetch fails AND there's no static fallback, `/mcp` returns `503 origin allow-list unavailable`. Prevents silently disabling Host validation when an upstream is down at boot.
- **Backward compat**: `allowedOrigins: string[]` keeps today's hostname-level Host validation and static widget `baseUrl`. Unset `allowedOrigins` is identical to today — zero per-request overhead.

## Example usage (before)

```ts
const server = new MCPServer({
  name: "my-server",
  version: "1.0.0",
  baseUrl: process.env.MCP_URL, // static, one domain only
  allowedOrigins: ["https://myapp.com"], // hostname-level host validation only
});
```

Moving to a preview URL required redeploying with a new `MCP_URL`.

## Example usage (after)

```ts
// Static list + wildcards
new MCPServer({
  name: "my-server",
  version: "1.0.0",
  baseUrl: process.env.MCP_URL,
  allowedOrigins: [
    "https://app.example.com",
    "https://*.preview.example.com", // all preview URLs just work
  ],
});

// Dynamic: remote list + instant updates via webhook
new MCPServer({
  name: "my-server",
  version: "1.0.0",
  baseUrl: process.env.MCP_URL,
  allowedOrigins: {
    origins: ["https://app.example.com"],
    providerUrl: process.env.MCP_ALLOWED_ORIGINS_URL,
    token: process.env.MCP_ALLOWED_ORIGINS_TOKEN,
    webhookSecret: process.env.MCP_ALLOWED_ORIGINS_WEBHOOK_SECRET,
  },
});
```

Env-var equivalents:

```env
MCP_ALLOWED_ORIGINS=https://app.example.com,https://*.preview.example.com
MCP_ALLOWED_ORIGINS_URL=https://config.example.com/origins.json
MCP_ALLOWED_ORIGINS_TOKEN=sk_...
MCP_ALLOWED_ORIGINS_WEBHOOK_SECRET=whsec_...
```

## Files changed

**Core:**
- `src/server/utils/origin-resolver.ts` (new) — `OriginResolver` class, HTTP validators, SWR, webhook HMAC
- `src/server/types/common.ts` — `allowedOrigins?: string[] | AllowedOriginsConfig`, re-export `AllowedOriginsConfig`
- `src/server/middleware/host-validation.ts` — resolver-backed middleware with fail-closed 503 path
- `src/server/utils/server-helpers.ts` — `createHonoApp` wired to resolver; new `resolveBaseUrlForRequest`
- `src/server/mcp-server.ts` — constructor builds resolver, `listen()` / `getHandler()` run init + mount webhook
- `src/server/widgets/ui-resource-registration.ts` — read callbacks consult resolver + request context
- `src/server/widgets/widget-helpers.ts` — `augmentDefinitionForRequest` helper, raw-HTML preservation

**Tests:**
- `tests/unit/server/origin-resolver.test.ts` (28 tests) — parsing, wildcard semantics, conditional GET / 304, single-flight SWR, last-known-good on failure, webhook HMAC + replay
- `tests/unit/server/widget-dynamic-origin.test.ts` (7 tests) — per-request `<base>` rewrite and CSP union for `mcpApps` + `appsSdk`
- `tests/integration/dynamic-origins.test.ts` (3 tests) — end-to-end through real `MCPServer` + MCP client + webhook

**Docs:**
- Rewrote `docs/typescript/server/content-security-policy.mdx`
- Updated `configuration.mdx`, `api-reference.mdx`, `mcp-apps.mdx`, `ui-widgets.mdx`, `creating-mcp-apps-server.mdx`, `deployment/supabase.mdx`, `inspector/cli.mdx`
- Added changelog entry in `docs/typescript/changelog/changelog.mdx`

**Skills:**
- `skills/chatgpt-app-builder/references/csp-and-metadata.md`, `server-and-widgets.md`, `SKILL.md`
- `skills/mcp-apps-builder/references/widgets/basics.md`, `foundations/quickstart.md`, `SKILL.md`
- `skills/mcp-builder/references/widgets.md`

**Example:**
- `examples/server/ui/mcp-apps/dynamic-origins/{index.ts,README.md}` — runnable demo with in-process mock provider that serves `Cache-Control: max-age=10, stale-while-revalidate=60` + `ETag`.

**Changeset:** `libraries/typescript/.changeset/dynamic-allowed-origins.md` (minor bump for `mcp-use`).

## Testing

### Automated

- `pnpm --filter mcp-use test:unit` → **398 passed, 2 skipped**
- `pnpm --filter mcp-use test` (inc. new integration test) → **all passing**
- `pnpm build` → all packages build clean
- `pnpm lint` → clean
- `pnpm format:check` → clean

### Manual smoke test (new example)

```bash
cd libraries/typescript/packages/mcp-use
PORT=3490 PROVIDER_PORT=3491 pnpm tsx examples/server/ui/mcp-apps/dynamic-origins/index.ts
```

Then:

| Scenario | Observed |
| --- | --- |
| `resources/read` on allow-listed localhost | CSP contains `http://localhost:3490`, `https://app.example.com`, `https://*.preview.example.com`, `https://tenant-dynamic.example.com` (provider callback), `https://canary.example.com`, `https://*.staging.example.com` (providerUrl) |
| Request with `Host: evil.example.com` | `403` |
| Valid HMAC webhook with `{"origins": ["https://hotpatched.example.com"]}` | `204`, next `resources/read` CSP contains `hotpatched.example.com` |
| Bad HMAC signature | `401` |
| Timestamp 10 minutes old | `401` |
| Mock provider revalidation | First request `200 OK` with `ETag: "v..."`, subsequent with matching `If-None-Match` → `304 Not Modified` |

## Backwards compatibility

Non-breaking. Three modes:

- `allowedOrigins` unset → **identical to today** (no Host validation, static widget `baseUrl`, zero per-request overhead).
- `allowedOrigins: string[]` → DNS-rebinding Host validation as today; **now also** drives widget `<base>` / CSP per request (widget output adapts to the allow-listed request origin instead of always using `baseUrl`). Wildcards are newly supported in this form.
- `allowedOrigins: { … }` → opts into async providers + webhook on top of everything above.

No public API signatures broke; `hostHeaderValidation()` signature changed internally but isn't exported.

## Related

- Unblocks multi-domain deployments where a single MCP server backs several public URLs (preview environments, canary, regional domains).


Made with [Cursor](https://cursor.com)