### PR TITLE
fix(cli): surface git failures during deploy and normalize main

### DIFF
--- a/libraries/typescript/.changeset/fix-deploy-github-init-push.md
+++ b/libraries/typescript/.changeset/fix-deploy-github-init-push.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/cli": patch
+---
+
+Deploy: `git init` / `commit` / `push` no longer fail silently—mutating git commands throw with stderr, the first branch is normalized to `main` before push, and `git rev-parse HEAD` verifies a commit exists. `mcp-use deploy` catches these errors and prints hints for missing `user.name`/`user.email` and for rejected/non-fast-forward pushes. Commit messages are shell-quoted.

--- a/libraries/typescript/packages/cli/src/commands/deploy.ts
+++ b/libraries/typescript/packages/cli/src/commands/deploy.ts
@@ -894,9 +894,7 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
         }
       } catch (err) {
         if (err instanceof GitCommandError) {
-          console.log(
-            chalk.red(`\n✗ Git step failed: \`${err.command}\``)
-          );
+          console.log(chalk.red(`\n✗ Git step failed: \`${err.command}\``));
           const stderrTrimmed = (err.stderr || err.stdout).trim();
           if (stderrTrimmed) {
             console.log(chalk.gray(stderrTrimmed));
@@ -910,7 +908,9 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
                   `    git -C ${JSON.stringify(cwd)} config user.name  "Your Name"`
               )
             );
-          } else if (/non-fast-forward|rejected|unrelated histories/i.test(err.stderr)) {
+          } else if (
+            /non-fast-forward|rejected|unrelated histories/i.test(err.stderr)
+          ) {
             console.log(
               chalk.yellow(
                 "\n  The remote branch already has commits. Either delete the empty GitHub repo and retry, " +

--- a/libraries/typescript/packages/cli/src/commands/deploy.ts
+++ b/libraries/typescript/packages/cli/src/commands/deploy.ts
@@ -15,6 +15,7 @@ import {
   gitInit,
   gitAddRemoteAndPush,
   gitCommitAndPush,
+  GitCommandError,
   hasUncommittedChanges,
   isGitHubUrl,
 } from "../utils/git.js";
@@ -868,27 +869,60 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
       }
       console.log(chalk.green(`✓ Created ${chalk.cyan(repoResult.fullName)}`));
 
-      if (!gitInfo.isGitRepo) {
-        await ensureGitignore(cwd);
-        console.log(chalk.gray("Initializing git..."));
-        await gitInit(cwd, "Initial commit");
-        console.log(chalk.gray("Pushing to GitHub..."));
-        await gitAddRemoteAndPush(cwd, repoResult.cloneUrl, "main");
-      } else {
-        if (await hasUncommittedChanges(cwd)) {
-          console.log(
-            chalk.red(
-              "✗ You have uncommitted changes. Commit and push before deploying."
-            )
+      try {
+        if (!gitInfo.isGitRepo) {
+          await ensureGitignore(cwd);
+          console.log(chalk.gray("Initializing git..."));
+          await gitInit(cwd, "Initial commit");
+          console.log(chalk.gray("Pushing to GitHub..."));
+          await gitAddRemoteAndPush(cwd, repoResult.cloneUrl, "main");
+        } else {
+          if (await hasUncommittedChanges(cwd)) {
+            console.log(
+              chalk.red(
+                "✗ You have uncommitted changes. Commit and push before deploying."
+              )
+            );
+            process.exit(1);
+          }
+          console.log(chalk.gray("Adding remote and pushing..."));
+          await gitAddRemoteAndPush(
+            cwd,
+            repoResult.cloneUrl,
+            gitInfo.branch || "main"
           );
+        }
+      } catch (err) {
+        if (err instanceof GitCommandError) {
+          console.log(
+            chalk.red(`\n✗ Git step failed: \`${err.command}\``)
+          );
+          const stderrTrimmed = (err.stderr || err.stdout).trim();
+          if (stderrTrimmed) {
+            console.log(chalk.gray(stderrTrimmed));
+          }
+          // Actionable hint for the most common failure: missing identity.
+          if (/tell me who you are|user\.email|user\.name/i.test(err.stderr)) {
+            console.log(
+              chalk.yellow(
+                "\n  Set your git identity for this project and retry:\n" +
+                  `    git -C ${JSON.stringify(cwd)} config user.email "you@example.com"\n` +
+                  `    git -C ${JSON.stringify(cwd)} config user.name  "Your Name"`
+              )
+            );
+          } else if (/non-fast-forward|rejected|unrelated histories/i.test(err.stderr)) {
+            console.log(
+              chalk.yellow(
+                "\n  The remote branch already has commits. Either delete the empty GitHub repo and retry, " +
+                  "or reconcile manually:\n" +
+                  "    git pull --rebase origin main --allow-unrelated-histories\n" +
+                  "    git push -u origin main"
+              )
+            );
+          }
           process.exit(1);
         }
-        console.log(chalk.gray("Adding remote and pushing..."));
-        await gitAddRemoteAndPush(
-          cwd,
-          repoResult.cloneUrl,
-          gitInfo.branch || "main"
-        );
+        throw err;
       }
 
       console.log(chalk.green("✓ Code pushed to GitHub\n"));

--- a/libraries/typescript/packages/cli/src/utils/git.ts
+++ b/libraries/typescript/packages/cli/src/utils/git.ts
@@ -15,7 +15,11 @@ export interface GitInfo {
 }
 
 /**
- * Execute git command
+ * Read-only git probe. Swallows errors and returns `null` so callers can treat
+ * "command failed" identically to "empty output" (e.g. not a repo, no remote).
+ *
+ * DO NOT use this for state-mutating commands (init/add/commit/push/remote add).
+ * Use `gitCommandOrThrow` instead so failures surface to the user.
  */
 async function gitCommand(
   command: string,
@@ -26,6 +30,60 @@ async function gitCommand(
     return stdout.trim();
   } catch (error) {
     return null;
+  }
+}
+
+/**
+ * Error thrown by `gitCommandOrThrow` when a git command exits non-zero.
+ * Carries the command string plus captured stderr/stdout for actionable errors.
+ */
+export class GitCommandError extends Error {
+  readonly command: string;
+  readonly stderr: string;
+  readonly stdout: string;
+  readonly exitCode: number | null;
+
+  constructor(opts: {
+    command: string;
+    stderr: string;
+    stdout: string;
+    exitCode: number | null;
+  }) {
+    const trimmed = opts.stderr.trim() || opts.stdout.trim() || "unknown error";
+    super(`git command failed: \`${opts.command}\`\n${trimmed}`);
+    this.name = "GitCommandError";
+    this.command = opts.command;
+    this.stderr = opts.stderr;
+    this.stdout = opts.stdout;
+    this.exitCode = opts.exitCode;
+  }
+}
+
+/**
+ * Execute a git command that MUST succeed. On non-zero exit, throws
+ * `GitCommandError` with captured stderr so the caller can show actionable
+ * errors instead of silently continuing.
+ */
+async function gitCommandOrThrow(
+  command: string,
+  cwd: string = process.cwd()
+): Promise<string> {
+  try {
+    const { stdout } = await execAsync(command, { cwd });
+    return stdout.trim();
+  } catch (error) {
+    const e = error as {
+      stderr?: string;
+      stdout?: string;
+      code?: number | null;
+      message?: string;
+    };
+    throw new GitCommandError({
+      command,
+      stderr: (e.stderr ?? "").toString(),
+      stdout: (e.stdout ?? "").toString(),
+      exitCode: typeof e.code === "number" ? e.code : null,
+    });
   }
 }
 
@@ -148,40 +206,57 @@ export async function getGitInfo(
 }
 
 /**
- * Initialize a git repo, add all files, and commit.
+ * Escape a commit message for safe inclusion in a shell-quoted `git commit -m`.
+ * Double quotes are handled by escaping `"` and `\` and wrapping in `"..."`.
+ */
+function shellQuote(message: string): string {
+  return `"${message.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+/**
+ * Initialize a git repo, add all files, commit, and normalize branch to `main`.
+ *
+ * Throws `GitCommandError` (typed Error) on any failure so callers can surface
+ * the real stderr instead of silently continuing (previous behavior left the
+ * repo in a half-baked state and the CLI still printed "Code pushed").
  */
 export async function gitInit(
   cwd: string,
   message: string = "Initial commit"
 ): Promise<void> {
-  await gitCommand("git init", cwd);
-  await gitCommand("git add .", cwd);
-  await gitCommand(`git commit -m "${message}"`, cwd);
+  await gitCommandOrThrow("git init", cwd);
+  await gitCommandOrThrow("git add .", cwd);
+  await gitCommandOrThrow(`git commit -m ${shellQuote(message)}`, cwd);
+  // Normalize branch name so a subsequent `git push -u origin main` always
+  // matches, regardless of the user's `init.defaultBranch` config.
+  await gitCommandOrThrow("git branch -M main", cwd);
+  // Guard: commit must exist before we try to push.
+  await gitCommandOrThrow("git rev-parse HEAD", cwd);
 }
 
 /**
- * Add a remote and push to it.
+ * Add a remote and push to it. Throws `GitCommandError` on failure.
  */
 export async function gitAddRemoteAndPush(
   cwd: string,
   cloneUrl: string,
   branch: string = "main"
 ): Promise<void> {
-  await gitCommand(`git remote add origin ${cloneUrl}`, cwd);
-  await gitCommand(`git push -u origin ${branch}`, cwd);
+  await gitCommandOrThrow(`git remote add origin ${cloneUrl}`, cwd);
+  await gitCommandOrThrow(`git push -u origin ${branch}`, cwd);
 }
 
 /**
- * Commit all changes and push.
+ * Commit all changes and push. Throws `GitCommandError` on failure.
  */
 export async function gitCommitAndPush(
   cwd: string,
   message: string,
   branch: string = "main"
 ): Promise<void> {
-  await gitCommand("git add .", cwd);
-  await gitCommand(`git commit -m "${message}"`, cwd);
-  await gitCommand(`git push origin ${branch}`, cwd);
+  await gitCommandOrThrow("git add .", cwd);
+  await gitCommandOrThrow(`git commit -m ${shellQuote(message)}`, cwd);
+  await gitCommandOrThrow(`git push origin ${branch}`, cwd);
 }
 
 /**


### PR DESCRIPTION
Improves the **`mcp-use deploy`** path when the CLI runs **`git init`**, **`git commit`**, and **`git push`**: git failures are no longer swallowed, the first branch is aligned to **`main`** before push, and users get actionable errors instead of a misleading **“✓ Code pushed”**.

### Problem

- **`gitCommand`** treated every failed **`exec`** as `null`, so **`git commit`** / **`git push`** could fail while **`gitInit`**, **`gitAddRemoteAndPush`**, and **`gitCommitAndPush`** still returned successfully.
- **`deploy`** always printed success after those calls even when nothing reached GitHub.
- **`git push -u origin main`** could fail if the local default branch was **`master`** (mismatch with hardcoded **`main`**).
- Commit messages were interpolated into the shell string without escaping (fragile for quotes in messages).

---

### Changes

**[`libraries/typescript/packages/cli/src/utils/git.ts`](libraries/typescript/packages/cli/src/utils/git.ts)**

- Add **`GitCommandError`** and **`gitCommandOrThrow`** for mutating git steps; keep the existing **`gitCommand`** only for read-only probes (`rev-parse`, `status`, etc.).
- **`gitInit`**: after commit, run **`git branch -M main`**, then **`git rev-parse HEAD`** before any push.
- Use **`shellQuote`** for **`git commit -m`**.
- **`gitAddRemoteAndPush`** / **`gitCommitAndPush`**: use **`gitCommandOrThrow`**.

**[`libraries/typescript/packages/cli/src/commands/deploy.ts`](libraries/typescript/packages/cli/src/commands/deploy.ts)**

- Wrap the “initialize git + push” block in **try/catch** for **`GitCommandError`**: print failing command + stderr, hints for **missing `user.name` / `user.email`** and for **rejected / non-fast-forward** pushes, then **`process.exit(1)`**.
