### PR TITLE
fix(inspector): preserve URL path in OAuth authorize redirect

### DIFF
--- a/libraries/typescript/.changeset/fix-oauth-basepath-url.md
+++ b/libraries/typescript/.changeset/fix-oauth-basepath-url.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Fix OAuth authorize redirect stripping URL path when auth server uses basePath. The `authenticate()` function now preserves the pathname component (e.g. `/api/auth`) instead of reducing the URL to just the origin.

--- a/libraries/typescript/packages/mcp-use/src/react/useMcp.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/useMcp.ts
@@ -1404,7 +1404,8 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
             "info",
             "Using provided authProvider for manual authentication"
           );
-          const baseUrl = new URL(url).origin;
+          const parsedUrl = new URL(url);
+          const baseUrl = parsedUrl.origin + parsedUrl.pathname.replace(/\/+$/, "");
           await auth(authProviderRef.current, {
             serverUrl: baseUrl,
           });
@@ -1453,7 +1454,8 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
         // Generate a fresh authorization URL and redirect immediately
         // This will trigger the OAuth flow with the new provider
         // The provider will redirect/popup automatically since preventAutoAuth is false
-        const baseUrl = new URL(url).origin;
+        const parsedUrl = new URL(url);
+        const baseUrl = parsedUrl.origin + parsedUrl.pathname.replace(/\/+$/, "");
         try {
           await auth(freshAuthProvider, {
             serverUrl: baseUrl,

--- a/libraries/typescript/packages/mcp-use/src/react/useMcp.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/useMcp.ts
@@ -1405,7 +1405,8 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
             "Using provided authProvider for manual authentication"
           );
           const parsedUrl = new URL(url);
-          const baseUrl = parsedUrl.origin + parsedUrl.pathname.replace(/\/+$/, "");
+          const baseUrl =
+            parsedUrl.origin + parsedUrl.pathname.replace(/\/+$/, "");
           await auth(authProviderRef.current, {
             serverUrl: baseUrl,
           });
@@ -1455,7 +1456,8 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
         // This will trigger the OAuth flow with the new provider
         // The provider will redirect/popup automatically since preventAutoAuth is false
         const parsedUrl = new URL(url);
-        const baseUrl = parsedUrl.origin + parsedUrl.pathname.replace(/\/+$/, "");
+        const baseUrl =
+          parsedUrl.origin + parsedUrl.pathname.replace(/\/+$/, "");
         try {
           await auth(freshAuthProvider, {
             serverUrl: baseUrl,


### PR DESCRIPTION
## Summary

When an OAuth provider uses a `basePath` (e.g. `/api/auth`), the `authenticate()` function in `useMcp.ts` strips the URL to just the origin via `new URL(url).origin`. This causes the authorization redirect to go to the wrong URL (e.g. `http://localhost:8000/authorize` instead of `http://localhost:8000/api/auth/oauth2/authorize`), resulting in a 404.

## Changes

Preserve the pathname component when constructing `baseUrl` for the `auth()` call, in both the `providedAuthProvider` path (line ~1407) and the fresh auth provider path (line ~1457):

```ts
// Before
const baseUrl = new URL(url).origin;

// After
const parsedUrl = new URL(url);
const baseUrl = parsedUrl.origin + parsedUrl.pathname.replace(/\/+$/, "");
```

The trailing slash is stripped to avoid double-slash issues when the SDK appends paths like `/oauth2/authorize`.

## Testing

- Verified the fix correctly preserves paths like `/api/auth` while still stripping trailing slashes
- URLs without a path (e.g. `http://localhost:8000`) produce the same result as before (`http://localhost:8000`)

Closes #1333