### PR TITLE
feat(react): add colorScheme prop to McpUseProvider and ThemeProvider

### DIFF
--- a/libraries/typescript/.changeset/fix-theme-provider-color-scheme-transparency.md
+++ b/libraries/typescript/.changeset/fix-theme-provider-color-scheme-transparency.md
@@ -1,0 +1,11 @@
+---
+"mcp-use": patch
+---
+
+ThemeProvider: gate color-scheme on opt-in prop to fix transparent iframe backgrounds.
+
+Setting `color-scheme` to an explicit value ("dark"/"light") on the iframe document root causes browsers to paint an opaque canvas behind the iframe when the widget and host documents use different schemes, making `background-color: transparent` ineffective.
+
+`McpUseProvider` now accepts a `colorScheme?: boolean` prop (default `false`). When `false`, `ThemeProvider` clears any previously set `color-scheme` inline style, preserving iframe transparency. When `true`, the previous behavior is restored (useful for widgets that need native dark scrollbars or CSS `light-dark()`).
+
+Theme class (`dark`/`light`) and `data-theme` attribute are unaffected.

--- a/libraries/typescript/packages/mcp-use/src/react/McpUseProvider.tsx
+++ b/libraries/typescript/packages/mcp-use/src/react/McpUseProvider.tsx
@@ -36,6 +36,17 @@ interface McpUseProviderProps {
    * @default false
    */
   autoSize?: boolean;
+  /**
+   * Set color-scheme on the document root to match the active theme.
+   * Enables native dark scrollbars and CSS light-dark() function.
+   *
+   * Leave disabled (default) when you want a transparent iframe background.
+   * Setting color-scheme to an explicit value ("dark"/"light") causes browsers
+   * to paint an opaque canvas behind iframes when the widget and host documents
+   * use different schemes, making background-color: transparent ineffective.
+   * @default false
+   */
+  colorScheme?: boolean;
 }
 
 /**
@@ -62,6 +73,7 @@ export function McpUseProvider({
   debugger: enableDebugger = false,
   viewControls = false,
   autoSize = true,
+  colorScheme = false,
 }: McpUseProviderProps) {
   const [containerElement, setContainerElement] =
     useState<HTMLDivElement | null>(null);
@@ -209,7 +221,7 @@ export function McpUseProvider({
   }
 
   // ThemeProvider wraps WidgetControls
-  content = <ThemeProvider>{content}</ThemeProvider>;
+  content = <ThemeProvider colorScheme={colorScheme}>{content}</ThemeProvider>;
 
   // Wrap in container div for auto-sizing if enabled
   if (autoSize) {

--- a/libraries/typescript/packages/mcp-use/src/react/ThemeProvider.tsx
+++ b/libraries/typescript/packages/mcp-use/src/react/ThemeProvider.tsx
@@ -8,11 +8,15 @@ import { useWidget } from "./useWidget.js";
  * 1. useWidget theme (from OpenAI Apps SDK)
  * 2. System preference (prefers-color-scheme: dark)
  *
- * Sets the "dark" class on document.documentElement when dark mode is active
+ * Sets the "dark" class and data-theme attribute on document.documentElement.
+ * color-scheme is only set when the colorScheme prop is true — setting it to an
+ * explicit value causes browsers to paint an opaque canvas behind iframes when
+ * the widget and host documents use different schemes.
  */
-export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({
-  children,
-}) => {
+export const ThemeProvider: React.FC<{
+  children: React.ReactNode;
+  colorScheme?: boolean;
+}> = ({ children, colorScheme = false }) => {
   const { theme, isAvailable } = useWidget();
   const [systemPreference, setSystemPreference] = useState<"light" | "dark">(
     () => {
@@ -40,8 +44,8 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({
   const effectiveTheme = isAvailable ? theme : systemPreference;
 
   // Apply theme synchronously before browser paint to prevent flash
-  // Sets both CSS class (for Tailwind dark mode) and data-theme attribute
-  // (for OpenAI Apps SDK UI design tokens)
+  // Sets CSS class (for Tailwind dark mode) and data-theme attribute
+  // (for OpenAI Apps SDK UI design tokens).
   useLayoutEffect(() => {
     if (typeof document === "undefined") return;
 
@@ -57,9 +61,16 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({
       effectiveTheme === "dark" ? "dark" : "light"
     );
 
-    // Set color-scheme for CSS light-dark() function
-    root.style.colorScheme = effectiveTheme === "dark" ? "dark" : "light";
-  }, [effectiveTheme]);
+    // Only set color-scheme when explicitly opted in via the colorScheme prop.
+    // Setting it to "dark"/"light" triggers browsers to paint an opaque canvas
+    // behind iframes when the widget scheme differs from the host scheme, which
+    // makes background-color: transparent ineffective.
+    if (colorScheme) {
+      root.style.colorScheme = effectiveTheme === "dark" ? "dark" : "light";
+    } else {
+      root.style.colorScheme = "";
+    }
+  }, [effectiveTheme, colorScheme]);
 
   return <>{children}</>;
 };


### PR DESCRIPTION
- Introduced a new `colorScheme` prop in `McpUseProvider` to control the document's color scheme based on the active theme.
- Updated `ThemeProvider` to apply the color scheme only when the `colorScheme` prop is enabled, preventing issues with iframe backgrounds when themes differ.
- Enhanced documentation for both components to clarify the behavior and default values of the new prop.
