### PR TITLE
fix: replace broken doc hosts with canonical mcp-use.com/docs URLs

### DIFF
--- a/libraries/python/DEPENDENCY_POLICY.md
+++ b/libraries/python/DEPENDENCY_POLICY.md
@@ -36,7 +36,7 @@ The `mcp` package is our core dependency — it provides the MCP protocol implem
 
 When a dependency update requires user action:
 
-1. The change is documented in the [changelog](https://docs.mcp-use.io/python/changelog/changelog)
+1. The change is documented in the [changelog](https://mcp-use.com/docs/python/changelog/changelog)
 2. A migration guide is provided if the change affects the public API
 3. The minimum version bump is noted in the release notes
 

--- a/skills/mcp-apps-builder/references/authentication/better-auth.md
+++ b/skills/mcp-apps-builder/references/authentication/better-auth.md
@@ -86,7 +86,7 @@ The server needs three things beyond the standard `MCPServer` setup:
 2. Mount OAuth discovery endpoints with CORS headers (required for browser clients)
 3. Mount login and consent pages
 
-See the [GitHub example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/better-auth) or the [docs](https://mcp-use.dev/docs/typescript/server/authentication/providers/better-auth) for the full server.ts code. The key parts:
+See the [GitHub example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/better-auth) or the [docs](https://mcp-use.com/docs/typescript/server/authentication/providers/better-auth) for the full server.ts code. The key parts:
 
 ```typescript
 import { MCPServer, oauthBetterAuthProvider } from "mcp-use/server";


### PR DESCRIPTION
## Summary

- `docs.mcp-use.io/python/changelog/changelog` was timing out in the link checker → replaced with `mcp-use.com/docs/python/changelog/changelog`
- `mcp-use.dev/docs/typescript/.../better-auth` was causing HTTP/2 protocol errors → replaced with `mcp-use.com/docs/typescript/server/authentication/providers/better-auth`

Both point to the same content, and `mcp-use.com/docs` is already the canonical host used across the rest of the monorepo.

## Test plan

- [ ] Run link checker on `libraries/python/DEPENDENCY_POLICY.md` — should resolve without timeout
- [ ] Run link checker on `skills/mcp-apps-builder/references/authentication/better-auth.md` — should resolve without HTTP/2 error

Made with [Cursor](https://cursor.com)