### PR TITLE
docs: update chatgpt-apps-flow guide

### DIFF
--- a/docs/guides/chatgpt-apps-flow.mdx
+++ b/docs/guides/chatgpt-apps-flow.mdx
@@ -4,9 +4,9 @@ description: "Understanding ChatGPT widget flows and how mcp-use simplifies widg
 icon: "openai"
 ---
 
-<Warning>
-**Apps SDK is deprecated**: ChatGPT now supports **MCP Apps**. For new projects, use [Creating MCP Apps Server](/typescript/server/creating-mcp-apps-server) to build widgets that work with both ChatGPT and MCP Apps clients.
-</Warning>
+<Info>
+ChatGPT now supports **MCP Apps**. For new projects, use [Creating MCP Apps Server](/typescript/server/creating-mcp-apps-server) to build widgets that work with both ChatGPT and MCP Apps clients.
+</Info>
 
 # Building ChatGPT Apps with Widgets
 
@@ -31,7 +31,7 @@ Widgets transform static responses into interactive experiences:
 - Persist state across conversations
 - Call MCP tools directly from the UI
 
-However, building widgets with the official OpenAI Apps SDK involves significant manual setup: configuring build tools, managing React mounting, implementing custom state hooks, and handling Content Security Policy (CSP) configurations.
+However, building widgets with the official OpenAI Apps SDK involves manual setup: configuring build tools, managing React mounting, implementing custom state hooks, and handling Content Security Policy (CSP) configurations.
 
 **mcp-use simplifies this entire process** by providing:
 
@@ -242,7 +242,7 @@ async def get_weather(city: str):
     }
 ```
 
-As you can see, the official approach requires significant boilerplate and manual configuration at every step.
+As you can see, the official approach requires boilerplate and manual configuration at every step.
 
 ## The mcp-use Simplified Approach
 


### PR DESCRIPTION
## Language / Project Scope

- [x] Documentation only

## Summary

Adapts the ChatGPT Apps flow guide (`docs/guides/chatgpt-apps-flow.mdx`) to better reflect the current state of ChatGPT app integrations:

- Replaced the "Apps SDK is deprecated" warning with an informational note. ChatGPT now supports both MCP Apps and the Apps SDK, and the Apps SDK still has features not yet in the open-source spec — so framing it as deprecated is inaccurate. Kept the "ChatGPT now supports MCP Apps" line and switched the callout from `<Warning>` to `<Info>`.
- Dropped the "significant" qualifier in the two places it appeared so the copy emphasizes mcp-use's benefits rather than the complexity of the manual Apps SDK steps.

## Documentation Updates

- `docs/guides/chatgpt-apps-flow.mdx` — copy-only changes, no structural or anchor changes.

## Testing

Docs-only; no code paths affected.

## Backwards Compatibility

Fully compatible.