### PR TITLE
Enhance chat configuration handling in Inspector

### DIFF
--- a/libraries/typescript/.changeset/hosted-chat-runtime-config.md
+++ b/libraries/typescript/.changeset/hosted-chat-runtime-config.md
@@ -1,0 +1,11 @@
+---
+"@mcp-use/inspector": patch
+---
+
+feat(inspector): configure hosted chat URL at runtime via `MANUFACT_CHAT_URL`
+
+The hosted chat endpoint (`chatApiUrl`) previously had to be baked into the client bundle at `vite build` time via `VITE_MANUFACT_CHAT_URL`. This prevented the same pre-built npm tarball from being configured per deploy (Railway, CDN, self-hosted) without a rebuild.
+
+The inspector server now reads `MANUFACT_CHAT_URL` at runtime and injects `window.__MANUFACT_CHAT_URL__` into the served HTML. `InspectorProvider` prefers the runtime value and falls back to `VITE_MANUFACT_CHAT_URL` for local Vite dev, so existing build-time flows keep working.
+
+Also drops `noopener` from the LoginModal OAuth popup and redirects the OAuth `callbackURL` to a new `/inspector/oauth-popup-closed.html` page so the popup self-closes cleanly instead of briefly loading the full inspector inside it.

--- a/libraries/typescript/packages/inspector/src/client/context/InspectorContext.tsx
+++ b/libraries/typescript/packages/inspector/src/client/context/InspectorContext.tsx
@@ -151,14 +151,22 @@ const InspectorContext = createContext<InspectorContextType | undefined>(
  * @returns A context provider element that supplies inspector state and mutator functions to its children
  */
 export function InspectorProvider({ children }: { children: ReactNode }) {
-  // Seed chat config from build-time env var so the hosted inspector
-  // (inspector.manufact.com) uses the Manufact Claude API automatically.
-  const hostedChatUrl = (
-    typeof import.meta !== "undefined"
+  // Seed chat config so the hosted inspector (inspector.manufact.com, Railway
+  // deploy, etc.) uses the Manufact Claude API automatically. Read from:
+  //   1. `window.__MANUFACT_CHAT_URL__` — runtime, injected by the inspector
+  //      server from `MANUFACT_CHAT_URL` env var. This is the preferred path
+  //      so a single pre-built npm tarball can be configured at deploy time.
+  //   2. `VITE_MANUFACT_CHAT_URL` — build-time Vite env, for local dev builds
+  //      where you rebuild the client anyway.
+  const hostedChatUrl =
+    (typeof window !== "undefined"
+      ? (window as Window & { __MANUFACT_CHAT_URL__?: string })
+          .__MANUFACT_CHAT_URL__
+      : undefined) ??
+    ((typeof import.meta !== "undefined"
       ? (import.meta as unknown as Record<string, Record<string, string>>).env
           ?.VITE_MANUFACT_CHAT_URL
-      : undefined
-  ) as string | undefined;
+      : undefined) as string | undefined);
 
   const [state, setState] = useState<InspectorState>({
     selectedServerId: null,

--- a/libraries/typescript/packages/inspector/src/server/cli.ts
+++ b/libraries/typescript/packages/inspector/src/server/cli.ts
@@ -90,8 +90,13 @@ const inspectorMode: InspectorMode =
   (process.env.MCP_INSPECTOR_MODE as InspectorMode | undefined) ??
   (process.env.RAILWAY_ENVIRONMENT_NAME ? "cloud" : "standalone");
 
-// Register static file serving (must be last as it includes catch-all route)
-registerStaticRoutes(app, undefined, { inspectorMode });
+// Register static file serving (must be last as it includes catch-all route).
+// Runtime env vars here override what was baked in at `vite build` time — this
+// lets a single pre-built npm tarball be configured per deploy.
+registerStaticRoutes(app, undefined, {
+  inspectorMode,
+  manufactChatUrl: process.env.MANUFACT_CHAT_URL,
+});
 
 // Start the server with automatic port selection
 async function startServer() {

--- a/libraries/typescript/packages/inspector/src/server/shared-static.ts
+++ b/libraries/typescript/packages/inspector/src/server/shared-static.ts
@@ -45,6 +45,16 @@ interface RuntimeConfig {
   proxyUrl?: string | null;
   /** How the inspector is being served (standalone CLI, embedded in mcp-use, or cloud-hosted). Consumed by telemetry. */
   inspectorMode?: InspectorMode;
+  /**
+   * Full URL of the Manufact hosted chat stream endpoint
+   * (e.g. `https://manufact.com/api/v1/inspector/chat/stream`). When set, the
+   * client switches the Chat tab to hosted mode: uses this endpoint with
+   * `credentials: "include"` and shows the free-tier banner / login modal.
+   *
+   * Prefer this over the build-time `VITE_MANUFACT_CHAT_URL` so a single
+   * pre-built npm tarball can be configured at deploy time.
+   */
+  manufactChatUrl?: string | null;
 }
 
 /**
@@ -75,6 +85,12 @@ function injectRuntimeConfig(html: string, config?: RuntimeConfig): string {
   if (config.inspectorMode) {
     scripts.push(
       `<script>window.__MCP_INSPECTOR_MODE__ = ${JSON.stringify(config.inspectorMode)};</script>`
+    );
+  }
+
+  if (config.manufactChatUrl) {
+    scripts.push(
+      `<script>window.__MANUFACT_CHAT_URL__ = ${JSON.stringify(config.manufactChatUrl)};</script>`
     );
   }
 
@@ -110,6 +126,11 @@ function generateCdnShellHtml(config?: RuntimeConfig): string {
     if (config.inspectorMode) {
       scripts.push(
         `<script>window.__MCP_INSPECTOR_MODE__ = ${JSON.stringify(config.inspectorMode)};</script>`
+      );
+    }
+    if (config.manufactChatUrl) {
+      scripts.push(
+        `<script>window.__MANUFACT_CHAT_URL__ = ${JSON.stringify(config.manufactChatUrl)};</script>`
       );
     }
     return scripts.join("\n    ");
@@ -316,7 +337,8 @@ export function registerStaticRoutes(
  */
 export function registerStaticRoutesWithDevProxy(
   app: Hono,
-  clientDistPath?: string
+  clientDistPath?: string,
+  runtimeConfig?: RuntimeConfig
 ) {
   const distPath = clientDistPath || getClientDistPath();
   const isDev =
@@ -371,6 +393,6 @@ export function registerStaticRoutesWithDevProxy(
       `);
     });
   } else {
-    registerStaticRoutes(app, distPath);
+    registerStaticRoutes(app, distPath, runtimeConfig);
   }
 }


### PR DESCRIPTION
- Updated `InspectorContext` to improve chat URL configuration, allowing for runtime and build-time environment variable support.
- Modified `registerStaticRoutes` to accept a new `manufactChatUrl` parameter, enabling dynamic chat endpoint configuration.
- Enhanced `RuntimeConfig` interface to include `manufactChatUrl`, facilitating better integration of hosted chat features.

These changes streamline the setup for the hosted inspector and improve flexibility for deployment configurations.
