### PR TITLE
fix(inspector): honor MANUFACT_CHAT_URL in standalone server entrypoint

### DIFF
--- a/libraries/typescript/.changeset/fix-server-manufact-chat-url-parity.md
+++ b/libraries/typescript/.changeset/fix-server-manufact-chat-url-parity.md
@@ -1,0 +1,9 @@
+---
+"@mcp-use/inspector": patch
+---
+
+fix(inspector): read `MANUFACT_CHAT_URL` in the standalone server entrypoint
+
+The runtime hosted-chat URL injection was wired up in `cli.ts` (used by the published `mcp-inspect` bin and by Railway) but the same plumbing in `server.ts` (used by `pnpm start` / the dev server) was dropped during a merge. As a result, running the inspector via `node dist/server/server.js` with `MANUFACT_CHAT_URL` set did not inject `window.__MANUFACT_CHAT_URL__` into the served HTML.
+
+This change restores parity between the two entrypoints so both honour the env var at process start.

--- a/libraries/typescript/packages/inspector/src/server/server.ts
+++ b/libraries/typescript/packages/inspector/src/server/server.ts
@@ -67,8 +67,12 @@ app.get("/inspector/oauth-popup-closed.html", (c) =>
   c.html(OAUTH_POPUP_CLOSED_HTML)
 );
 
-// Register static file serving with dev proxy support (must be last as it includes catch-all route)
-registerStaticRoutesWithDevProxy(app);
+// Register static file serving with dev proxy support (must be last as it includes catch-all route).
+// `MANUFACT_CHAT_URL` is read at runtime so the hosted-chat URL can be set on
+// the deploy environment (Railway, etc.) without rebuilding the npm package.
+registerStaticRoutesWithDevProxy(app, undefined, {
+  manufactChatUrl: process.env.MANUFACT_CHAT_URL,
+});
 
 /**
  * Start the MCP Inspector HTTP server and return its listening port and fetch handler.


### PR DESCRIPTION
## Summary

- Re-adds the runtime `MANUFACT_CHAT_URL` plumbing to `dist/server/server.js` (the `pnpm start` / dev server entrypoint). The same plumbing already exists in `cli.ts` (what the published `mcp-inspect` bin and Railway run) but got dropped from `server.ts` during the merge of #1368.
- Result: both server entrypoints now inject `window.__MANUFACT_CHAT_URL__` into the served HTML when the env var is set, so hosted chat can be enabled without rebuilding the npm package.
- Includes changeset for a `@mcp-use/inspector` patch bump.

## Test plan

- [x] `pnpm build:server` succeeds.
- [x] `MANUFACT_CHAT_URL=https://example.com/api/v1/inspector/chat/stream node dist/server/server.js --port 3005` → `curl -s http://localhost:3005/inspector | grep __MANUFACT_CHAT_URL__` now returns the script tag (was empty before the fix).
- [x] `node dist/cli.js` path verified unchanged — still injects correctly.
- [x] `pnpm exec eslint --fix src/server/server.ts` → no warnings.
- [x] `pnpm exec prettier --check` on touched files → all pass.

Made with [Cursor](https://cursor.com)