### PR TITLE
feat(cli): add ORG column to deployments list

### DIFF
--- a/libraries/typescript/.changeset/deployments-list-org-column.md
+++ b/libraries/typescript/.changeset/deployments-list-org-column.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/cli": minor
+---
+
+Add ORG column to `deployments list` output so users can see which organization each deployment belongs to.

--- a/libraries/typescript/packages/cli/src/commands/deployments.ts
+++ b/libraries/typescript/packages/cli/src/commands/deployments.ts
@@ -53,7 +53,35 @@ async function listDeploymentsCommand(): Promise<void> {
     }
 
     const api = await McpUseAPI.create();
-    const deployments = await api.listDeployments();
+    const [deployments, authResult] = await Promise.all([
+      api.listDeployments(),
+      api.testAuth(),
+    ]);
+
+    const orgMap = new Map(authResult.orgs.map((o) => [o.id, o.name]));
+
+    const uniqueServerIds = [
+      ...new Set(
+        deployments
+          .map((d) => d.serverId)
+          .filter((id): id is string => id != null)
+      ),
+    ];
+
+    const serverResults = await Promise.allSettled(
+      uniqueServerIds.map((id) => api.getServer(id))
+    );
+
+    const serverOrgMap = new Map<string, string>();
+    for (let i = 0; i < uniqueServerIds.length; i++) {
+      const result = serverResults[i];
+      if (result.status === "fulfilled") {
+        const orgName =
+          orgMap.get(result.value.organizationId) ??
+          result.value.organizationId.substring(0, 19);
+        serverOrgMap.set(uniqueServerIds[i], orgName);
+      }
+    }
 
     const sortedDeployments = [...deployments].sort(
       (a, b) =>
@@ -76,21 +104,25 @@ async function listDeploymentsCommand(): Promise<void> {
 
     console.log(
       chalk.white.bold(
-        `${"ID".padEnd(40)} ${"NAME".padEnd(25)} ${"STATUS".padEnd(12)} ${"MCP URL".padEnd(45)} ${"CREATED"}`
+        `${"ID".padEnd(40)} ${"NAME".padEnd(25)} ${"ORG".padEnd(20)} ${"STATUS".padEnd(12)} ${"MCP URL".padEnd(45)} ${"CREATED"}`
       )
     );
-    console.log(chalk.gray("─".repeat(140)));
+    console.log(chalk.gray("─".repeat(155)));
 
     for (const deployment of sortedDeployments) {
       const id = formatId(deployment.id).padEnd(40);
       const name = deployment.name.substring(0, 24).padEnd(25);
+      const orgName = deployment.serverId
+        ? (serverOrgMap.get(deployment.serverId) ?? "-")
+        : "-";
+      const org = orgName.substring(0, 19).padEnd(20);
       const statusColor = getStatusColor(deployment.status);
       const status = statusColor(deployment.status.padEnd(12));
       const mcpUrl = (deployment.mcpUrl || "-").substring(0, 44).padEnd(45);
       const created = formatRelativeTime(deployment.createdAt);
 
       console.log(
-        `${chalk.gray(id)} ${name} ${status} ${chalk.cyan(mcpUrl)} ${chalk.gray(created)}`
+        `${chalk.gray(id)} ${name} ${chalk.magenta(org)} ${status} ${chalk.cyan(mcpUrl)} ${chalk.gray(created)}`
       );
     }
 


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

Adds an **ORG** column to `npx mcp-use deployments list` so users with multiple organizations can immediately see which org each deployment belongs to.

## Implementation Details

1. In `listDeploymentsCommand()`, fetches `listDeployments()` and `testAuth()` in parallel — `testAuth()` already returns all orgs the user belongs to (id + name)
2. Collects unique `serverId`s across all returned deployments (deduplicated), then fetches those servers in parallel via `Promise.allSettled` — typically far fewer calls than deployments
3. Joins `server.organizationId` → org name via the map built from `testAuth()`, storing the result in a `serverId → orgName` lookup
4. Adds ORG column (magenta, 20 chars) between NAME and STATUS in the table; deployments with no `serverId` or a failed server fetch show `-`

---

## TypeScript Checklist

### Packages Modified

- [x] `cli`

### Pre-commit Checklist

- [x] Ran `pnpm build` and build succeeds without errors
- [ ] Ran `pnpm changeset` to create a changeset (if this PR includes user-facing changes)

---

## Example Usage (Before)

```
📦 Deployments (15)

ID                                       NAME                      STATUS       MCP URL                                        CREATED
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
e8fb897a-62e5-433b-be34-6903ed2d1e42     Deployment #5             running      https://plain-water-yeta3.run.mcp-use.com/mc   1 day ago
2fsfml61fjzy                             Deployment - testing-man  running      https://bitter-bird-9xii3.run.mcp-use.com/mc   1 week ago
```

## Example Usage (After)

```
📦 Deployments (15)

ID                                       NAME                      ORG                  STATUS       MCP URL                                        CREATED
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
e8fb897a-62e5-433b-be34-6903ed2d1e42     Deployment #5             i am andrew          running      https://plain-water-yeta3.run.mcp-use.com/mc   1 day ago
2fsfml61fjzy                             Deployment - testing-man  testing-ord-2        running      https://bitter-bird-9xii3.run.mcp-use.com/mc   1 week ago
```

## Testing

- Manually ran `node packages/cli/dist/index.js deployments list` and confirmed ORG column appears with correct org names per deployment
- Verified deployments across multiple orgs show distinct org names
- Build passes with no TypeScript errors

## Backwards Compatibility

Display-only change. No API or interface changes.

## Related Issues

Closes #1673