### PR TITLE
feat(cli): add --org flag to login for non-interactive org selection

### DIFF
--- a/docs/typescript/server/cli-reference.mdx
+++ b/docs/typescript/server/cli-reference.mdx
@@ -241,11 +241,17 @@ mcp-use login
 
 Starts an OAuth-style device code flow to authenticate with [Manufact Cloud](https://manufact.com). Opens a browser window to complete authentication.
 
+**Options:**
+
+- `--api-key <key>` — Skip the browser flow and save an API key directly. Intended for CI/CD.
+- `--org <slug|id|name>` — Pick an organization up-front and skip the post-login prompt. Use this when running in agent harnesses or non-TTY environments where the interactive selection cannot be answered.
+
 **What happens:**
 
 1. CLI generates a device code
 2. Opens browser to authentication page
 3. Stores session token in `~/.mcp-use/config.json`
+4. If you have more than one organization and `--org` was not supplied, CLI prompts you to pick one. Without a TTY, the command fails with a message pointing at `--org` rather than hanging.
 
 #### `whoami` - Check Authentication Status
 

--- a/libraries/typescript/.changeset/login-org-flag.md
+++ b/libraries/typescript/.changeset/login-org-flag.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/cli": minor
+---
+
+`mcp-use login`: add `--org <slug|id|name>` flag for non-interactive org selection. Previously, when a user had multiple organizations, login would prompt on stdin after the browser auth completed — leaving agent harnesses blocked because they cannot write to the running process's stdin. With `--org`, login picks the org up-front and skips the prompt. If login is run without a TTY and no `--org` is supplied, it now fails fast with a message pointing at the flag rather than hanging. Matches the resolver already used by `mcp-use deploy --org`.

--- a/libraries/typescript/packages/cli/README.md
+++ b/libraries/typescript/packages/cli/README.md
@@ -125,6 +125,9 @@ Deploy your MCP server to production via [manufact.com](https://manufact.com):
 # Login to Manufact cloud
 mcp-use login
 
+# Non-interactive login (for agents / CI) — picks an org without prompting
+mcp-use login --org <slug|id|name>
+
 # Check authentication status
 mcp-use whoami
 

--- a/libraries/typescript/packages/cli/src/commands/auth.ts
+++ b/libraries/typescript/packages/cli/src/commands/auth.ts
@@ -105,7 +105,7 @@ async function pollForDeviceToken(
 
 /**
  * Resolve an org identifier (slug, id, or case-insensitive name) against a list.
- * Returns null if no match. Pure function — safe to unit test.
+ * Returns null if no match.
  */
 export function resolveOrgFromOption(
   orgs: OrgInfo[],

--- a/libraries/typescript/packages/cli/src/commands/auth.ts
+++ b/libraries/typescript/packages/cli/src/commands/auth.ts
@@ -104,6 +104,27 @@ async function pollForDeviceToken(
 }
 
 /**
+ * Resolve an org identifier (slug, id, or case-insensitive name) against a list.
+ * Returns null if no match. Pure function — safe to unit test.
+ */
+export function resolveOrgFromOption(
+  orgs: OrgInfo[],
+  identifier: string
+): OrgInfo | null {
+  const needle = identifier.trim();
+  if (!needle) return null;
+  const lower = needle.toLowerCase();
+  return (
+    orgs.find(
+      (o) =>
+        o.slug === needle ||
+        o.id === needle ||
+        o.name.toLowerCase() === lower
+    ) ?? null
+  );
+}
+
+/**
  * Prompt user to pick an organization from a numbered list.
  */
 export async function promptOrgSelection(
@@ -160,6 +181,7 @@ export async function promptOrgSelection(
 export async function loginCommand(options?: {
   silent?: boolean;
   apiKey?: string;
+  org?: string;
 }): Promise<void> {
   try {
     const directKey = options?.apiKey || process.env.MCP_USE_API_KEY;
@@ -256,8 +278,19 @@ export async function loginCommand(options?: {
       if (orgs.length > 0) {
         let selectedOrg: OrgInfo | null = null;
 
-        if (orgs.length === 1) {
+        if (options?.org) {
+          selectedOrg = resolveOrgFromOption(orgs, options.org);
+          if (!selectedOrg) {
+            throw new Error(
+              `Organization "${options.org}" not found. Run 'npx mcp-use org list' after logging in to see available organizations.`
+            );
+          }
+        } else if (orgs.length === 1) {
           selectedOrg = orgs[0];
+        } else if (!process.stdin.isTTY) {
+          throw new Error(
+            "Multiple organizations available and no TTY for interactive selection. Re-run with --org <slug|id|name> to pick one non-interactively."
+          );
         } else {
           selectedOrg = await promptOrgSelection(orgs, authInfo.default_org_id);
         }

--- a/libraries/typescript/packages/cli/src/commands/auth.ts
+++ b/libraries/typescript/packages/cli/src/commands/auth.ts
@@ -117,9 +117,7 @@ export function resolveOrgFromOption(
   return (
     orgs.find(
       (o) =>
-        o.slug === needle ||
-        o.id === needle ||
-        o.name.toLowerCase() === lower
+        o.slug === needle || o.id === needle || o.name.toLowerCase() === lower
     ) ?? null
   );
 }

--- a/libraries/typescript/packages/cli/src/commands/auth.ts
+++ b/libraries/typescript/packages/cli/src/commands/auth.ts
@@ -9,7 +9,7 @@ import {
   readConfig,
   writeConfig,
 } from "../utils/config.js";
-import type { OrgInfo } from "../utils/api.js";
+import type { AuthTestResponse, OrgInfo } from "../utils/api.js";
 
 const DEVICE_CLIENT_ID = "mcp-use-cli";
 const DEVICE_POLL_TIMEOUT = 1800000; // 30 minutes
@@ -258,10 +258,19 @@ export async function loginCommand(options?: {
 
     console.log(chalk.green.bold("\n✓ Successfully logged in!"));
 
+    let authInfo: AuthTestResponse | null = null;
     try {
       const freshApi = await McpUseAPI.create();
-      const authInfo = await freshApi.testAuth();
+      authInfo = await freshApi.testAuth();
+    } catch {
+      console.log(
+        chalk.gray(
+          `\n  Your API key has been saved to ${chalk.white("~/.mcp-use/config.json")}`
+        )
+      );
+    }
 
+    if (authInfo) {
       console.log(chalk.cyan.bold("\nCurrent user:\n"));
       console.log(chalk.white("  Email:   ") + chalk.cyan(authInfo.email));
       console.log(chalk.white("  User ID: ") + chalk.gray(authInfo.user_id));
@@ -310,12 +319,6 @@ export async function loginCommand(options?: {
           );
         }
       }
-    } catch {
-      console.log(
-        chalk.gray(
-          `\n  Your API key has been saved to ${chalk.white("~/.mcp-use/config.json")}`
-        )
-      );
     }
 
     console.log(

--- a/libraries/typescript/packages/cli/src/commands/deploy.ts
+++ b/libraries/typescript/packages/cli/src/commands/deploy.ts
@@ -25,7 +25,11 @@ import {
 } from "../utils/git.js";
 import { getMcpServerUrl } from "../utils/cloud-urls.js";
 import { getProjectLink, saveProjectLink } from "../utils/project-link.js";
-import { loginCommand, promptOrgSelection } from "./auth.js";
+import {
+  loginCommand,
+  promptOrgSelection,
+  resolveOrgFromOption,
+} from "./auth.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -693,12 +697,7 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
 
     if (options.org) {
       const authInfo = await api.testAuth();
-      const match = (authInfo.orgs ?? []).find(
-        (o) =>
-          o.slug === options.org ||
-          o.id === options.org ||
-          o.name.toLowerCase() === options.org!.toLowerCase()
-      );
+      const match = resolveOrgFromOption(authInfo.orgs ?? [], options.org);
       if (match) {
         api.setOrgId(match.id);
         resolvedOrgId = match.id;

--- a/libraries/typescript/packages/cli/src/commands/servers.ts
+++ b/libraries/typescript/packages/cli/src/commands/servers.ts
@@ -4,6 +4,7 @@ import { McpUseAPI } from "../utils/api.js";
 import { getMcpServerUrlForCloudServer } from "../utils/cloud-urls.js";
 import { getWebUrl, isLoggedIn, readConfig } from "../utils/config.js";
 import { formatRelativeTime } from "../utils/format.js";
+import { resolveOrgFromOption } from "./auth.js";
 import { createEnvCommand } from "./env.js";
 
 async function prompt(question: string): Promise<boolean> {
@@ -37,12 +38,7 @@ function pickStr(obj: unknown, key: string): string {
 async function applyOrgOption(api: McpUseAPI, org?: string): Promise<void> {
   if (!org) return;
   const authInfo = await api.testAuth();
-  const match = (authInfo.orgs ?? []).find(
-    (o) =>
-      o.slug === org ||
-      o.id === org ||
-      o.name.toLowerCase() === org.toLowerCase()
-  );
+  const match = resolveOrgFromOption(authInfo.orgs ?? [], org);
   if (!match) {
     console.error(
       chalk.red(

--- a/libraries/typescript/packages/cli/src/index.ts
+++ b/libraries/typescript/packages/cli/src/index.ts
@@ -2441,9 +2441,10 @@ program
     "--api-key <key>",
     "Login with an API key directly (non-interactive, for CI/CD)"
   )
-  .action(async (opts: { apiKey?: string }) => {
+  .option("--org <slug|id|name>", "Select an organization non-interactively")
+  .action(async (opts: { apiKey?: string; org?: string }) => {
     try {
-      await loginCommand({ apiKey: opts.apiKey });
+      await loginCommand({ apiKey: opts.apiKey, org: opts.org });
       process.exit(0);
     } catch (error) {
       console.error(

--- a/libraries/typescript/packages/cli/tests/auth.test.ts
+++ b/libraries/typescript/packages/cli/tests/auth.test.ts
@@ -54,8 +54,7 @@ describe("resolveOrgFromOption", () => {
     expect(resolveOrgFromOption([], "anything")).toBeNull();
   });
 
-  it("does not match a null slug when given an empty-ish value", () => {
-    // Regression guard: an org with slug=null must not be selected by accident.
+  it("does not coerce the literal string 'null' to match a null slug", () => {
     expect(resolveOrgFromOption(orgs, "null")).toBeNull();
   });
 

--- a/libraries/typescript/packages/cli/tests/auth.test.ts
+++ b/libraries/typescript/packages/cli/tests/auth.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { resolveOrgFromOption } from "../src/commands/auth.js";
+import type { OrgInfo } from "../src/utils/api.js";
+
+const orgs: OrgInfo[] = [
+  {
+    id: "default-profile-45e7bb29",
+    name: "Pietro",
+    slug: "pietro-personal",
+    role: "owner",
+  },
+  {
+    id: "primary-3747c0f6",
+    name: "Manufact Demo Org",
+    slug: "manufact-demo",
+    role: "admin",
+  },
+  {
+    id: "profile-no-slug",
+    name: "Legacy Org",
+    slug: null,
+    role: "member",
+  },
+];
+
+describe("resolveOrgFromOption", () => {
+  it("matches by slug", () => {
+    expect(resolveOrgFromOption(orgs, "manufact-demo")).toBe(orgs[1]);
+  });
+
+  it("matches by id", () => {
+    expect(resolveOrgFromOption(orgs, "primary-3747c0f6")).toBe(orgs[1]);
+  });
+
+  it("matches by name case-insensitively", () => {
+    expect(resolveOrgFromOption(orgs, "manufact demo org")).toBe(orgs[1]);
+    expect(resolveOrgFromOption(orgs, "MANUFACT DEMO ORG")).toBe(orgs[1]);
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(resolveOrgFromOption(orgs, "  manufact-demo  ")).toBe(orgs[1]);
+  });
+
+  it("returns null when no org matches", () => {
+    expect(resolveOrgFromOption(orgs, "does-not-exist")).toBeNull();
+  });
+
+  it("returns null for an empty string", () => {
+    expect(resolveOrgFromOption(orgs, "")).toBeNull();
+    expect(resolveOrgFromOption(orgs, "   ")).toBeNull();
+  });
+
+  it("returns null when the org list is empty", () => {
+    expect(resolveOrgFromOption([], "anything")).toBeNull();
+  });
+
+  it("does not match a null slug when given an empty-ish value", () => {
+    // Regression guard: an org with slug=null must not be selected by accident.
+    expect(resolveOrgFromOption(orgs, "null")).toBeNull();
+  });
+
+  it("matches an org whose slug is null by id or name", () => {
+    expect(resolveOrgFromOption(orgs, "profile-no-slug")).toBe(orgs[2]);
+    expect(resolveOrgFromOption(orgs, "Legacy Org")).toBe(orgs[2]);
+  });
+
+  it("returns the first match when identifiers collide across orgs", () => {
+    const collision: OrgInfo[] = [
+      { id: "shared-key", name: "First", slug: "first-slug", role: "owner" },
+      { id: "other", name: "Second", slug: "shared-key", role: "admin" },
+    ];
+    expect(resolveOrgFromOption(collision, "shared-key")).toBe(collision[0]);
+  });
+});

--- a/libraries/typescript/packages/cli/tests/auth.test.ts
+++ b/libraries/typescript/packages/cli/tests/auth.test.ts
@@ -5,8 +5,8 @@ import type { OrgInfo } from "../src/utils/api.js";
 const orgs: OrgInfo[] = [
   {
     id: "default-profile-45e7bb29",
-    name: "Pietro",
-    slug: "pietro-personal",
+    name: "Personal",
+    slug: "personal",
     role: "owner",
   },
   {


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

`mcp-use login` previously prompted on stdin to pick an organization when the user belonged to more than one. Agent harnesses (Claude Code, Cursor, etc.) can't write to a running process's stdin, so login would hang indefinitely after the browser flow completed.

This PR adds a `--org <slug|id|name>` flag to `mcp-use login` that picks the org up-front and skips the post-login prompt. When login runs without a TTY and no `--org` is supplied, it now fails fast with a message pointing at the flag instead of hanging.

## Implementation Details

1. New `resolveOrgFromOption(orgs, identifier)` helper in `packages/cli/src/commands/auth.ts` — pure function that matches an identifier against `slug` / `id` / case-insensitive `name`. Trims whitespace and rejects empty strings.
2. `loginCommand` accepts a new `org?: string` option. Resolution priority: `--org` (errors if not found) → single org (auto-select) → no TTY (error) → interactive prompt.
3. CLI registration in `packages/cli/src/index.ts` wires `--org <slug|id|name>` through to `loginCommand`.
4. **Dedupe pass:** `applyOrgOption` in `commands/servers.ts` and the inline `--org` block in `commands/deploy.ts` now both call `resolveOrgFromOption` instead of duplicating the slug/id/name match. Three copies → one.
5. Unit tests cover slug/id/name match, case-insensitivity, whitespace trim, empty string, empty list, null-slug handling, and the literal string `"null"` not coercing to a `null` slug.

---

## TypeScript Checklist

### Packages Modified

- [x] `docs`
- [ ] `tests`
- [x] `cli`
- [ ] `create-mcp-use-app`
- [ ] `mcp-use` (server)
- [ ] `mcp-use` (client)
- [ ] `inspector`

### Pre-commit Checklist

- [x] Ran `pnpm lint:fix` to auto-fix linting issues
- [x] Ran `pnpm format` to format code with Prettier
- [x] Ran `pnpm build` and build succeeds without errors
- [x] Ran `pnpm changeset` to create a changeset (if this PR includes user-facing changes)
- [x] Added or updated tests if needed
- [x] Updated documentation in `docs/` folder if needed

---

## Example Usage (Before)

```bash
# In an agent harness (no TTY) with multiple orgs — hangs forever after browser auth
mcp-use login
# (browser opens, auth completes, then process hangs on org selection prompt)
```

## Example Usage (After)

```bash
# Interactive: same behavior as before — prompts to pick an org
mcp-use login

# Non-interactive: pick the org up-front, no prompt
mcp-use login --org manufact-demo
mcp-use login --org primary-3747c0f6           # by id
mcp-use login --org "Manufact Demo Org"        # by name (case-insensitive)

# No TTY, no --org, multiple orgs available — fails fast with actionable message
mcp-use login
# Error: Multiple organizations available and no TTY for interactive selection.
#        Re-run with --org <slug|id|name> to pick one non-interactively.
```

## Documentation Updates

* `docs/typescript/server/cli-reference.mdx` — documented the new `--org` flag and the no-TTY failure mode.
* `libraries/typescript/packages/cli/README.md` — added the non-interactive login example.
* `libraries/typescript/.changeset/login-org-flag.md` — minor bump for `@mcp-use/cli`.

## Testing

- Unit tests added in `packages/cli/tests/auth.test.ts` (10 tests covering `resolveOrgFromOption`).
- Full CLI test suite passes (147/147).
- `pnpm --filter @mcp-use/cli build` succeeds.
- Edge cases covered: empty identifier, empty org list, whitespace trim, case-insensitive name match, null `slug` field, identifier collisions across orgs.

## Backwards Compatibility

Fully backwards compatible. `--org` is opt-in; existing interactive `mcp-use login` flow is unchanged. The new no-TTY error only triggers in a scenario that previously hung indefinitely, so no working invocation is broken.