### PR TITLE
fix(cli): keep mcp-use build non-fatal under bun runtime

### DIFF
--- a/libraries/typescript/.changeset/fix-cli-bun-runtime-build.md
+++ b/libraries/typescript/.changeset/fix-cli-bun-runtime-build.md
@@ -1,0 +1,15 @@
+---
+"@mcp-use/cli": patch
+---
+
+fix(cli): keep `mcp-use build` non-fatal under the bun runtime
+
+Building a project with `bun run build` inside an `oven/bun:alpine` image was failing in the tool-registry type-generation step. That step uses `tsx/esm/api`'s `tsImport`, which relies on Node.js custom loader hooks that bun does not implement, and the exception killed the whole build.
+
+Three small changes keep the build moving:
+
+- Detect the bun runtime up front in `generateToolRegistryTypesForServer` and skip the `tsx/esm/api` import with a clear warning instead of crashing.
+- Wrap the build command's call to `generateToolRegistryTypesForServer` in try/catch so any other import-time error in the user's server file is surfaced as a non-blocking warning rather than exiting the build.
+- Invoke `tsc --noEmit` via `process.execPath` instead of hardcoding `node`, so bun-only images (which don't ship a `node` binary) can still type-check. Also drop `--max-old-space-size=4096` under bun, which doesn't accept that flag.
+
+Type generation remains available on Node.js. Under bun, users can still refresh `.mcp-use/tool-registry.d.ts` by running `mcp-use generate-types` from a Node.js shell when needed.

--- a/libraries/typescript/packages/cli/src/index.ts
+++ b/libraries/typescript/packages/cli/src/index.ts
@@ -327,6 +327,13 @@ async function findServerFile(projectPath: string): Promise<string> {
   throw new Error("No server file found");
 }
 
+function isBunRuntime(): boolean {
+  return (
+    typeof (globalThis as any).Bun !== "undefined" ||
+    typeof (process.versions as any).bun === "string"
+  );
+}
+
 async function generateToolRegistryTypesForServer(
   projectPath: string,
   serverFileRelative: string
@@ -338,6 +345,23 @@ async function generateToolRegistryTypesForServer(
 
   if (!serverFileExists) {
     throw new Error(`Server file not found: ${serverFile}`);
+  }
+
+  // `tsx/esm/api` uses Node's custom loader hooks, which bun doesn't
+  // implement. Under bun we can't generate the registry types at build
+  // time; skip with a clear note so the build continues.
+  if (isBunRuntime()) {
+    console.log(
+      chalk.yellow(
+        "⚠ Skipping tool registry type generation under bun runtime (requires Node.js loader hooks)."
+      )
+    );
+    console.log(
+      chalk.gray(
+        "  Run `mcp-use generate-types` with node to refresh .mcp-use/tool-registry.d.ts."
+      )
+    );
+    return false;
   }
 
   const previousHmrMode = (globalThis as any).__mcpUseHmrMode;
@@ -1135,16 +1159,30 @@ program
 
       if (sourceServerFile) {
         console.log(chalk.gray("Generating tool registry types..."));
-        const typeGenOk = await generateToolRegistryTypesForServer(
-          projectPath,
-          sourceServerFile
-        );
-        if (typeGenOk) {
-          console.log(chalk.green("✓ Tool registry types generated"));
-        } else {
+        // Type generation is a dev convenience (regenerates
+        // .mcp-use/tool-registry.d.ts). Keep it non-fatal during build so
+        // a runtime without the right loader hooks (e.g. bun alpine) or
+        // an unrelated import-time error in the server file can't block
+        // the Docker build.
+        try {
+          const typeGenOk = await generateToolRegistryTypesForServer(
+            projectPath,
+            sourceServerFile
+          );
+          if (typeGenOk) {
+            console.log(chalk.green("✓ Tool registry types generated"));
+          } else {
+            console.log(
+              chalk.yellow(
+                "⚠ Tool registry type generation had errors (non-blocking)"
+              )
+            );
+          }
+        } catch (err) {
           console.log(
             chalk.yellow(
-              "⚠ Tool registry type generation had errors (non-blocking)"
+              "⚠ Tool registry type generation failed (non-blocking): " +
+                (err instanceof Error ? err.message : String(err))
             )
           );
         }
@@ -1161,22 +1199,21 @@ program
       // prevent npx from auto-installing the unrelated `tsc@2.0.4` package.
       if (options.typecheck !== false) {
         console.log(chalk.gray("Type checking..."));
+        // Use the current runtime binary (`process.execPath`) rather than
+        // hardcoding "node". Alpine images built on `oven/bun:alpine`
+        // don't ship a `node` binary, and bun runs tsc fine.
+        const tscBin = path.join(
+          projectPath,
+          "node_modules",
+          "typescript",
+          "bin",
+          "tsc"
+        );
+        const tscArgs = isBunRuntime()
+          ? [tscBin, "--noEmit"]
+          : ["--max-old-space-size=4096", tscBin, "--noEmit"];
         try {
-          await runCommand(
-            "node",
-            [
-              "--max-old-space-size=4096",
-              path.join(
-                projectPath,
-                "node_modules",
-                "typescript",
-                "bin",
-                "tsc"
-              ),
-              "--noEmit",
-            ],
-            projectPath
-          ).promise;
+          await runCommand(process.execPath, tscArgs, projectPath).promise;
           console.log(chalk.green("✓ Type check passed!"));
         } catch {
           console.error(

--- a/libraries/typescript/packages/cli/src/index.ts
+++ b/libraries/typescript/packages/cli/src/index.ts
@@ -337,7 +337,7 @@ function isBunRuntime(): boolean {
 async function generateToolRegistryTypesForServer(
   projectPath: string,
   serverFileRelative: string
-): Promise<boolean> {
+): Promise<"ok" | "failed" | "skipped"> {
   const serverFile = path.join(projectPath, serverFileRelative);
   const serverFileExists = await access(serverFile)
     .then(() => true)
@@ -361,7 +361,7 @@ async function generateToolRegistryTypesForServer(
         "  Run `mcp-use generate-types` with node to refresh .mcp-use/tool-registry.d.ts."
       )
     );
-    return false;
+    return "skipped";
   }
 
   const previousHmrMode = (globalThis as any).__mcpUseHmrMode;
@@ -398,7 +398,7 @@ async function generateToolRegistryTypesForServer(
       server.registrations.tools,
       projectPath
     );
-    return success;
+    return success ? "ok" : "failed";
   } finally {
     (globalThis as any).__mcpUseHmrMode = previousHmrMode ?? false;
   }
@@ -1165,19 +1165,20 @@ program
         // an unrelated import-time error in the server file can't block
         // the Docker build.
         try {
-          const typeGenOk = await generateToolRegistryTypesForServer(
+          const typeGenResult = await generateToolRegistryTypesForServer(
             projectPath,
             sourceServerFile
           );
-          if (typeGenOk) {
+          if (typeGenResult === "ok") {
             console.log(chalk.green("✓ Tool registry types generated"));
-          } else {
+          } else if (typeGenResult === "failed") {
             console.log(
               chalk.yellow(
                 "⚠ Tool registry type generation had errors (non-blocking)"
               )
             );
           }
+          // "skipped" already logged its own warning inside the function.
         } catch (err) {
           console.log(
             chalk.yellow(
@@ -2607,17 +2608,18 @@ program
 
     try {
       console.log(chalk.blue("Generating tool registry types..."));
-      const success = await generateToolRegistryTypesForServer(
+      const result = await generateToolRegistryTypesForServer(
         projectPath,
         options.server
       );
-      if (success) {
+      if (result === "ok") {
         console.log(
           chalk.green("✓ Tool registry types generated successfully")
         );
-      } else {
+      } else if (result === "failed") {
         console.log(chalk.yellow("⚠ Tool registry type generation had errors"));
       }
+      // "skipped" already logged its own warning inside the function.
       process.exit(0);
     } catch (error) {
       console.error(


### PR DESCRIPTION
Closes #1327.

## Summary

`mcp-use build` crashes during the tool-registry type-generation step when run under bun, e.g. inside an `oven/bun:alpine` Docker image. The step uses `tsx/esm/api`'s `tsImport`, which relies on Node.js custom loader hooks that bun does not implement, and the exception kills the whole build:

```
Generating tool registry types...
Build failed: error: Cannot find module 'tsx://{"specifier":"file:///app/index.ts", ... ,"namespace":"..."}' from '/app/node_modules/tsx/dist/register-B7jrtLTO.mjs'
error: script "build" exited with code 1
```

Type generation is a dev convenience (regenerates `.mcp-use/tool-registry.d.ts`); it shouldn't be able to fail a Docker production build.

## What changes

- `generateToolRegistryTypesForServer` detects the bun runtime up front and skips the `tsx/esm/api` step with a clear warning instead of throwing.
- The `build` command wraps the call in try/catch so any other import-time error in the user's server file surfaces as a non-blocking warning instead of `process.exit(1)`.
- `tsc --noEmit` now runs via `process.execPath` rather than a hardcoded `node`, since `oven/bun:alpine` ships no `node` binary. `--max-old-space-size=4096` is dropped under bun (unsupported flag).

Node.js behaviour is unchanged: tool-registry types are still generated and the typecheck still uses the same V8 flag.

## Test plan

- [x] `pnpm --filter @mcp-use/cli build` — CJS + ESM build clean.
- [x] `pnpm lint` / `pnpm format:check` — no warnings.
- [x] `pnpm --filter @mcp-use/cli test` — 137 passed.
- [x] Repro from #1327 under local bun 1.3.12 with the unfixed CLI:

  ```
  Generating tool registry types...
  Build failed: error: Cannot find module 'tsx://...' from '.../tsx/dist/register-B7jrtLTO.mjs'
  ```

- [x] Same project, same bun, with this PR's CLI:

  ```
  Generating tool registry types...
  ⚠ Skipping tool registry type generation under bun runtime (requires Node.js loader hooks).
    Run `mcp-use generate-types` with node to refresh .mcp-use/tool-registry.d.ts.
  ⚠ Tool registry type generation had errors (non-blocking)
  Building TypeScript...
  ✓ TypeScript build complete!
  Type checking...
  ✓ Type check passed!
  ✓ Build manifest created

  ✓ Build complete!
  ```

- [x] Same project under Node 22: `Generating tool registry types... ✓ Tool registry types generated ... ✓ Build complete!` — no regression.