### PR TITLE
fix(cli): validate token on login and unify 401 handling

### DIFF
--- a/libraries/typescript/.changeset/cli-validate-token-on-login.md
+++ b/libraries/typescript/.changeset/cli-validate-token-on-login.md
@@ -1,0 +1,7 @@
+---
+"@mcp-use/cli": patch
+---
+
+`mcp-use login` now validates the stored API key against the backend before short-circuiting with "You are already logged in." If the key is expired or revoked, login detects the 401, clears the stale config, and drops into the device-auth flow automatically. Network or other non-401 errors preserve the old "already logged in" behavior so users don't get bounced into re-auth just because they're offline.
+
+Every command that hits the authenticated API (`whoami`, `org`, `servers`, `deployments`, `env`) now funnels errors through a shared `handleCommandError` helper. On a 401 the user sees a friendly "session expired — run `npx mcp-use login` to re-authenticate" hint instead of a raw `API request failed: 401 …` dump. The `deploy` command's existing richer re-auth flow is unchanged.

--- a/libraries/typescript/packages/cli/src/commands/auth.ts
+++ b/libraries/typescript/packages/cli/src/commands/auth.ts
@@ -1,6 +1,6 @@
 import chalk from "chalk";
 import open from "open";
-import { McpUseAPI } from "../utils/api.js";
+import { ApiUnauthorizedError, McpUseAPI } from "../utils/api.js";
 import {
   deleteConfig,
   getApiKey,
@@ -9,6 +9,7 @@ import {
   readConfig,
   writeConfig,
 } from "../utils/config.js";
+import { handleCommandError } from "../utils/errors.js";
 import type { OrgInfo } from "../utils/api.js";
 
 const DEVICE_CLIENT_ID = "mcp-use-cli";
@@ -183,14 +184,36 @@ export async function loginCommand(options?: {
     }
 
     if (await isLoggedIn()) {
-      if (!options?.silent) {
-        console.log(
-          chalk.yellow(
-            "You are already logged in. Run 'npx mcp-use logout' first if you want to login with a different account."
-          )
-        );
+      const alreadyLoggedInMessage =
+        "You are already logged in. Run 'npx mcp-use logout' first if you want to login with a different account.";
+      try {
+        const existingApi = await McpUseAPI.create();
+        await existingApi.testAuth();
+        if (!options?.silent) {
+          console.log(chalk.yellow(alreadyLoggedInMessage));
+        }
+        return;
+      } catch (e) {
+        if (e instanceof ApiUnauthorizedError) {
+          // Stored key is invalid/expired — clear it and re-auth.
+          if (!options?.silent) {
+            console.log(
+              chalk.yellow(
+                "⚠️  Stored credentials are invalid or expired. Re-authenticating..."
+              )
+            );
+          }
+          await deleteConfig();
+          // fall through to device-code flow below
+        } else {
+          // Network/other error: don't force the user through re-auth when we
+          // can't actually verify the stored key is bad.
+          if (!options?.silent) {
+            console.log(chalk.yellow(alreadyLoggedInMessage));
+          }
+          return;
+        }
       }
-      return;
     }
 
     console.log(chalk.cyan.bold("Logging in to mcp-use cloud...\n"));
@@ -384,20 +407,7 @@ export async function whoamiCommand(): Promise<void> {
         );
       }
     }
-  } catch (error: any) {
-    if (error?.status === 401) {
-      console.error(
-        chalk.red("\nYour session has expired or your API key is invalid.")
-      );
-      console.log(
-        chalk.gray(`Run ${chalk.white("mcp-use login")} to re-authenticate.\n`)
-      );
-    } else {
-      console.error(
-        chalk.red.bold("\n✗ Failed to get user info:"),
-        chalk.red(error instanceof Error ? error.message : "Unknown error")
-      );
-    }
-    process.exit(1);
+  } catch (error) {
+    handleCommandError(error, "Failed to get user info");
   }
 }

--- a/libraries/typescript/packages/cli/src/commands/auth.ts
+++ b/libraries/typescript/packages/cli/src/commands/auth.ts
@@ -184,36 +184,37 @@ export async function loginCommand(options?: {
     }
 
     if (await isLoggedIn()) {
-      const alreadyLoggedInMessage =
-        "You are already logged in. Run 'npx mcp-use logout' first if you want to login with a different account.";
+      let needsReauth = false;
       try {
-        const existingApi = await McpUseAPI.create();
-        await existingApi.testAuth();
-        if (!options?.silent) {
-          console.log(chalk.yellow(alreadyLoggedInMessage));
-        }
-        return;
+        await (await McpUseAPI.create()).testAuth();
       } catch (e) {
+        // Only a 401 means the stored key is actually bad. Network/disk
+        // errors get the benefit of the doubt so offline users aren't
+        // bounced into re-auth when we can't verify.
         if (e instanceof ApiUnauthorizedError) {
-          // Stored key is invalid/expired — clear it and re-auth.
-          if (!options?.silent) {
-            console.log(
-              chalk.yellow(
-                "⚠️  Stored credentials are invalid or expired. Re-authenticating..."
-              )
-            );
-          }
-          await deleteConfig();
-          // fall through to device-code flow below
-        } else {
-          // Network/other error: don't force the user through re-auth when we
-          // can't actually verify the stored key is bad.
-          if (!options?.silent) {
-            console.log(chalk.yellow(alreadyLoggedInMessage));
-          }
-          return;
+          needsReauth = true;
         }
       }
+
+      if (!needsReauth) {
+        if (!options?.silent) {
+          console.log(
+            chalk.yellow(
+              "You are already logged in. Run 'npx mcp-use logout' first if you want to login with a different account."
+            )
+          );
+        }
+        return;
+      }
+
+      if (!options?.silent) {
+        console.log(
+          chalk.yellow(
+            "⚠️  Stored credentials are invalid or expired. Re-authenticating..."
+          )
+        );
+      }
+      await deleteConfig();
     }
 
     console.log(chalk.cyan.bold("Logging in to mcp-use cloud...\n"));

--- a/libraries/typescript/packages/cli/src/commands/deployments.ts
+++ b/libraries/typescript/packages/cli/src/commands/deployments.ts
@@ -3,6 +3,7 @@ import { Command } from "commander";
 import { McpUseAPI } from "../utils/api.js";
 import { getMcpServerUrl } from "../utils/cloud-urls.js";
 import { isLoggedIn } from "../utils/config.js";
+import { handleCommandError } from "../utils/errors.js";
 import { formatRelativeTime } from "../utils/format.js";
 
 async function prompt(question: string): Promise<boolean> {
@@ -96,11 +97,7 @@ async function listDeploymentsCommand(): Promise<void> {
 
     console.log();
   } catch (error) {
-    console.error(
-      chalk.red.bold("\n✗ Failed to list deployments:"),
-      chalk.red(error instanceof Error ? error.message : "Unknown error")
-    );
-    process.exit(1);
+    handleCommandError(error, "Failed to list deployments");
   }
 }
 
@@ -178,11 +175,7 @@ async function getDeploymentCommand(deploymentId: string): Promise<void> {
 
     console.log();
   } catch (error) {
-    console.error(
-      chalk.red.bold("\n✗ Failed to get deployment:"),
-      chalk.red(error instanceof Error ? error.message : "Unknown error")
-    );
-    process.exit(1);
+    handleCommandError(error, "Failed to get deployment");
   }
 }
 
@@ -276,11 +269,7 @@ async function restartDeploymentCommand(
 
     console.log();
   } catch (error) {
-    console.error(
-      chalk.red.bold("\n✗ Failed to restart deployment:"),
-      chalk.red(error instanceof Error ? error.message : "Unknown error")
-    );
-    process.exit(1);
+    handleCommandError(error, "Failed to restart deployment");
   }
 }
 
@@ -328,11 +317,7 @@ async function deleteDeploymentCommand(
       chalk.green.bold(`\n✓ Deployment deleted: ${deployment.name}\n`)
     );
   } catch (error) {
-    console.error(
-      chalk.red.bold("\n✗ Failed to delete deployment:"),
-      chalk.red(error instanceof Error ? error.message : "Unknown error")
-    );
-    process.exit(1);
+    handleCommandError(error, "Failed to delete deployment");
   }
 }
 
@@ -459,11 +444,7 @@ async function logsCommand(
 
     console.log();
   } catch (error) {
-    console.error(
-      chalk.red.bold("\n✗ Failed to get logs:"),
-      chalk.red(error instanceof Error ? error.message : "Unknown error")
-    );
-    process.exit(1);
+    handleCommandError(error, "Failed to get logs");
   }
 }
 
@@ -484,11 +465,7 @@ async function stopDeploymentCommand(deploymentId: string): Promise<void> {
 
     console.log(chalk.green.bold(`\n✓ Deployment stopped\n`));
   } catch (error) {
-    console.error(
-      chalk.red.bold("\n✗ Failed to stop deployment:"),
-      chalk.red(error instanceof Error ? error.message : "Unknown error")
-    );
-    process.exit(1);
+    handleCommandError(error, "Failed to stop deployment");
   }
 }
 
@@ -510,11 +487,7 @@ async function startDeploymentCommand(deploymentId: string): Promise<void> {
       )
     );
   } catch (error) {
-    console.error(
-      chalk.red.bold("\n✗ Failed to start deployment:"),
-      chalk.red(error instanceof Error ? error.message : "Unknown error")
-    );
-    process.exit(1);
+    handleCommandError(error, "Failed to start deployment");
   }
 }
 

--- a/libraries/typescript/packages/cli/src/commands/env.ts
+++ b/libraries/typescript/packages/cli/src/commands/env.ts
@@ -3,6 +3,7 @@ import { Command } from "commander";
 import type { EnvEnvironment, EnvVariable } from "../utils/api.js";
 import { McpUseAPI } from "../utils/api.js";
 import { isLoggedIn } from "../utils/config.js";
+import { handleCommandError } from "../utils/errors.js";
 
 const ALL_ENVS: EnvEnvironment[] = ["production", "preview", "development"];
 
@@ -67,22 +68,26 @@ async function listEnvCommand(options: {
   server: string;
   showValues?: boolean;
 }): Promise<void> {
-  await requireLogin();
+  try {
+    await requireLogin();
 
-  const api = await McpUseAPI.create();
-  const vars = await api.listEnvVariables(options.server);
+    const api = await McpUseAPI.create();
+    const vars = await api.listEnvVariables(options.server);
 
-  if (vars.length === 0) {
-    console.log(
-      chalk.yellow("\nNo environment variables set for this server.\n")
-    );
-    return;
-  }
+    if (vars.length === 0) {
+      console.log(
+        chalk.yellow("\nNo environment variables set for this server.\n")
+      );
+      return;
+    }
 
-  console.log(chalk.cyan.bold(`\nEnvironment Variables (${vars.length})\n`));
-  for (const v of vars) {
-    printEnvVar(v, options.showValues);
-    console.log();
+    console.log(chalk.cyan.bold(`\nEnvironment Variables (${vars.length})\n`));
+    for (const v of vars) {
+      printEnvVar(v, options.showValues);
+      console.log();
+    }
+  } catch (error) {
+    handleCommandError(error, "Failed to list environment variables");
   }
 }
 
@@ -90,87 +95,101 @@ async function addEnvCommand(
   assignment: string,
   options: { server: string; env?: string; sensitive?: boolean }
 ): Promise<void> {
-  await requireLogin();
+  try {
+    await requireLogin();
 
-  const eqIdx = assignment.indexOf("=");
-  if (eqIdx === -1) {
-    console.error(
-      chalk.red(
-        "✗ Expected KEY=VALUE format, e.g. mcp-use servers env add API_KEY=abc123"
-      )
+    const eqIdx = assignment.indexOf("=");
+    if (eqIdx === -1) {
+      console.error(
+        chalk.red(
+          "✗ Expected KEY=VALUE format, e.g. mcp-use servers env add API_KEY=abc123"
+        )
+      );
+      process.exit(1);
+    }
+
+    const key = assignment.substring(0, eqIdx).trim();
+    const value = assignment.substring(eqIdx + 1);
+
+    if (!key) {
+      console.error(chalk.red("✗ Key must not be empty."));
+      process.exit(1);
+    }
+
+    const environments = options.env
+      ? parseEnvironments(options.env)
+      : ALL_ENVS;
+
+    const api = await McpUseAPI.create();
+    const created = await api.createEnvVariable(options.server, {
+      key,
+      value,
+      environments,
+      sensitive: options.sensitive ?? false,
+    });
+
+    console.log(
+      chalk.green(`\n✓ Environment variable "${created.key}" added.\n`)
     );
-    process.exit(1);
+    printEnvVar(created, true);
+    console.log();
+  } catch (error) {
+    handleCommandError(error, "Failed to add environment variable");
   }
-
-  const key = assignment.substring(0, eqIdx).trim();
-  const value = assignment.substring(eqIdx + 1);
-
-  if (!key) {
-    console.error(chalk.red("✗ Key must not be empty."));
-    process.exit(1);
-  }
-
-  const environments = options.env ? parseEnvironments(options.env) : ALL_ENVS;
-
-  const api = await McpUseAPI.create();
-  const created = await api.createEnvVariable(options.server, {
-    key,
-    value,
-    environments,
-    sensitive: options.sensitive ?? false,
-  });
-
-  console.log(
-    chalk.green(`\n✓ Environment variable "${created.key}" added.\n`)
-  );
-  printEnvVar(created, true);
-  console.log();
 }
 
 async function updateEnvCommand(
   varId: string,
   options: { server: string; value?: string; env?: string; sensitive?: boolean }
 ): Promise<void> {
-  await requireLogin();
+  try {
+    await requireLogin();
 
-  if (!options.value && !options.env && options.sensitive === undefined) {
-    console.error(
-      chalk.red(
-        "✗ Nothing to update. Provide at least one of --value, --env, --sensitive."
-      )
+    if (!options.value && !options.env && options.sensitive === undefined) {
+      console.error(
+        chalk.red(
+          "✗ Nothing to update. Provide at least one of --value, --env, --sensitive."
+        )
+      );
+      process.exit(1);
+    }
+
+    const body: {
+      value?: string;
+      environments?: EnvEnvironment[];
+      sensitive?: boolean;
+    } = {};
+    if (options.value !== undefined) body.value = options.value;
+    if (options.env) body.environments = parseEnvironments(options.env);
+    if (options.sensitive !== undefined) body.sensitive = options.sensitive;
+
+    const api = await McpUseAPI.create();
+    const updated = await api.updateEnvVariable(options.server, varId, body);
+
+    console.log(
+      chalk.green(`\n✓ Environment variable "${updated.key}" updated.\n`)
     );
-    process.exit(1);
+    printEnvVar(updated, !!options.value);
+    console.log();
+  } catch (error) {
+    handleCommandError(error, "Failed to update environment variable");
   }
-
-  const body: {
-    value?: string;
-    environments?: EnvEnvironment[];
-    sensitive?: boolean;
-  } = {};
-  if (options.value !== undefined) body.value = options.value;
-  if (options.env) body.environments = parseEnvironments(options.env);
-  if (options.sensitive !== undefined) body.sensitive = options.sensitive;
-
-  const api = await McpUseAPI.create();
-  const updated = await api.updateEnvVariable(options.server, varId, body);
-
-  console.log(
-    chalk.green(`\n✓ Environment variable "${updated.key}" updated.\n`)
-  );
-  printEnvVar(updated, !!options.value);
-  console.log();
 }
 
 async function removeEnvCommand(
   varId: string,
   options: { server: string }
 ): Promise<void> {
-  await requireLogin();
+  try {
+    await requireLogin();
 
-  const api = await McpUseAPI.create();
-  await api.deleteEnvVariable(options.server, varId);
+    const api = await McpUseAPI.create();
+    await api.deleteEnvVariable(options.server, varId);
 
-  console.log(chalk.green(`\n✓ Environment variable ${varId} removed.\n`));
+    console.log(chalk.green(`\n✓ Environment variable ${varId} removed.\n`));
+  } catch (error) {
+    handleCommandError(error, "Failed to remove environment variable");
+  }
 }
 
 export function createEnvCommand(): Command {

--- a/libraries/typescript/packages/cli/src/commands/org.ts
+++ b/libraries/typescript/packages/cli/src/commands/org.ts
@@ -1,6 +1,7 @@
 import chalk from "chalk";
 import { McpUseAPI } from "../utils/api.js";
 import { isLoggedIn, readConfig, writeConfig } from "../utils/config.js";
+import { handleCommandError } from "../utils/errors.js";
 import { promptOrgSelection } from "./auth.js";
 
 async function ensureLoggedIn(): Promise<boolean> {
@@ -50,11 +51,7 @@ export async function orgListCommand(): Promise<void> {
       );
     }
   } catch (error) {
-    console.error(
-      chalk.red.bold("\n✗ Failed to list organizations:"),
-      chalk.red(error instanceof Error ? error.message : "Unknown error")
-    );
-    process.exit(1);
+    handleCommandError(error, "Failed to list organizations");
   }
 }
 
@@ -114,11 +111,7 @@ export async function orgSwitchCommand(): Promise<void> {
         slug
     );
   } catch (error) {
-    console.error(
-      chalk.red.bold("\n✗ Failed to switch organization:"),
-      chalk.red(error instanceof Error ? error.message : "Unknown error")
-    );
-    process.exit(1);
+    handleCommandError(error, "Failed to switch organization");
   }
 }
 
@@ -149,10 +142,6 @@ export async function orgCurrentCommand(): Promise<void> {
         slug
     );
   } catch (error) {
-    console.error(
-      chalk.red.bold("\n✗ Failed to get organization:"),
-      chalk.red(error instanceof Error ? error.message : "Unknown error")
-    );
-    process.exit(1);
+    handleCommandError(error, "Failed to get organization");
   }
 }

--- a/libraries/typescript/packages/cli/src/commands/servers.ts
+++ b/libraries/typescript/packages/cli/src/commands/servers.ts
@@ -3,6 +3,7 @@ import { Command } from "commander";
 import { McpUseAPI } from "../utils/api.js";
 import { getMcpServerUrlForCloudServer } from "../utils/cloud-urls.js";
 import { getWebUrl, isLoggedIn, readConfig } from "../utils/config.js";
+import { handleCommandError } from "../utils/errors.js";
 import { formatRelativeTime } from "../utils/format.js";
 import { createEnvCommand } from "./env.js";
 
@@ -137,11 +138,7 @@ async function listServersCommand(options: {
 
     console.log();
   } catch (error) {
-    console.error(
-      chalk.red.bold("\n✗ Failed to list servers:"),
-      chalk.red(error instanceof Error ? error.message : "Unknown error")
-    );
-    process.exit(1);
+    handleCommandError(error, "Failed to list servers");
   }
 }
 
@@ -261,11 +258,7 @@ async function getServerCommand(idOrSlug: string, options: { org?: string }) {
 
     console.log();
   } catch (error) {
-    console.error(
-      chalk.red.bold("\n✗ Failed to get server:"),
-      chalk.red(error instanceof Error ? error.message : "Unknown error")
-    );
-    process.exit(1);
+    handleCommandError(error, "Failed to get server");
   }
 }
 
@@ -324,11 +317,7 @@ async function deleteServerCommand(
       )
     );
   } catch (error) {
-    console.error(
-      chalk.red.bold("\n✗ Failed to delete server:"),
-      chalk.red(error instanceof Error ? error.message : "Unknown error")
-    );
-    process.exit(1);
+    handleCommandError(error, "Failed to delete server");
   }
 }
 

--- a/libraries/typescript/packages/cli/src/utils/errors.ts
+++ b/libraries/typescript/packages/cli/src/utils/errors.ts
@@ -2,8 +2,8 @@ import chalk from "chalk";
 import { ApiUnauthorizedError } from "./api.js";
 
 /**
- * Print a friendly error and exit. Treats `ApiUnauthorizedError` (401) as a
- * "please re-authenticate" hint instead of surfacing the raw API response.
+ * Treats `ApiUnauthorizedError` (401) as a "please re-authenticate" hint
+ * instead of surfacing the raw API response.
  */
 export function handleCommandError(error: unknown, context: string): never {
   if (error instanceof ApiUnauthorizedError) {

--- a/libraries/typescript/packages/cli/src/utils/errors.ts
+++ b/libraries/typescript/packages/cli/src/utils/errors.ts
@@ -1,0 +1,25 @@
+import chalk from "chalk";
+import { ApiUnauthorizedError } from "./api.js";
+
+/**
+ * Print a friendly error and exit. Treats `ApiUnauthorizedError` (401) as a
+ * "please re-authenticate" hint instead of surfacing the raw API response.
+ */
+export function handleCommandError(error: unknown, context: string): never {
+  if (error instanceof ApiUnauthorizedError) {
+    console.error(
+      chalk.red("\n✗ Your session has expired or your API key is invalid.")
+    );
+    console.log(
+      chalk.gray(
+        `Run ${chalk.white("npx mcp-use login")} to re-authenticate.\n`
+      )
+    );
+    process.exit(1);
+  }
+  console.error(
+    chalk.red.bold(`\n✗ ${context}:`),
+    chalk.red(error instanceof Error ? error.message : "Unknown error")
+  );
+  process.exit(1);
+}

--- a/libraries/typescript/packages/cli/src/utils/errors.ts
+++ b/libraries/typescript/packages/cli/src/utils/errors.ts
@@ -10,7 +10,7 @@ export function handleCommandError(error: unknown, context: string): never {
     console.error(
       chalk.red("\n✗ Your session has expired or your API key is invalid.")
     );
-    console.log(
+    console.error(
       chalk.gray(
         `Run ${chalk.white("npx mcp-use login")} to re-authenticate.\n`
       )

--- a/libraries/typescript/packages/cli/tests/deployments.test.ts
+++ b/libraries/typescript/packages/cli/tests/deployments.test.ts
@@ -24,6 +24,15 @@ vi.mock("../src/utils/api.js", () => {
         return mockApiInstance;
       }
     },
+    ApiUnauthorizedError: class ApiUnauthorizedError extends Error {
+      readonly status = 401 as const;
+      constructor(
+        message = "Your session has expired or your API key is invalid."
+      ) {
+        super(message);
+        this.name = "ApiUnauthorizedError";
+      }
+    },
   };
 });
 

--- a/libraries/typescript/packages/cli/tests/errors.test.ts
+++ b/libraries/typescript/packages/cli/tests/errors.test.ts
@@ -2,21 +2,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiUnauthorizedError } from "../src/utils/api.js";
 import { handleCommandError } from "../src/utils/errors.js";
 
-// Mock chalk so output is plain strings. Use a Proxy so arbitrary chain
-// accesses (chalk.red.bold.white, etc.) resolve without blowing the stack.
+// Mock chalk so output is plain strings. Covers the exact chains used by
+// handleCommandError (chalk.red, chalk.red.bold, chalk.gray, chalk.white).
 vi.mock("chalk", () => {
-  const makeChain = (): any => {
-    const fn = (s: string) => s;
-    return new Proxy(fn, {
-      get: (target, prop) => {
-        if (prop === "apply" || prop === "call" || prop === "bind") {
-          return (target as any)[prop].bind(target);
-        }
-        return makeChain();
-      },
-    });
-  };
-  return { default: makeChain() };
+  const id = (s: string) => s;
+  const red: any = Object.assign((s: string) => s, { bold: id });
+  return { default: { red, gray: id, white: id } };
 });
 
 describe("handleCommandError", () => {

--- a/libraries/typescript/packages/cli/tests/errors.test.ts
+++ b/libraries/typescript/packages/cli/tests/errors.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiUnauthorizedError } from "../src/utils/api.js";
+import { handleCommandError } from "../src/utils/errors.js";
+
+// Mock chalk so output is plain strings. Use a Proxy so arbitrary chain
+// accesses (chalk.red.bold.white, etc.) resolve without blowing the stack.
+vi.mock("chalk", () => {
+  const makeChain = (): any => {
+    const fn = (s: string) => s;
+    return new Proxy(fn, {
+      get: (target, prop) => {
+        if (prop === "apply" || prop === "call" || prop === "bind") {
+          return (target as any)[prop].bind(target);
+        }
+        return makeChain();
+      },
+    });
+  };
+  return { default: makeChain() };
+});
+
+describe("handleCommandError", () => {
+  let consoleLog: string[];
+  let consoleErr: string[];
+  let originalLog: typeof console.log;
+  let originalError: typeof console.error;
+  let originalExit: typeof process.exit;
+
+  beforeEach(() => {
+    consoleLog = [];
+    consoleErr = [];
+    originalLog = console.log;
+    originalError = console.error;
+    originalExit = process.exit;
+
+    console.log = vi.fn((...args) => {
+      consoleLog.push(args.join(" "));
+    });
+    console.error = vi.fn((...args) => {
+      consoleErr.push(args.join(" "));
+    });
+    // Throw instead of exiting so control flow stops at the first
+    // `process.exit(...)` (and test assertions can still run).
+    process.exit = vi.fn((code?: number) => {
+      throw new Error(`__process_exit__${code ?? 0}`);
+    }) as unknown as typeof process.exit;
+  });
+
+  afterEach(() => {
+    console.log = originalLog;
+    console.error = originalError;
+    process.exit = originalExit;
+  });
+
+  it("prints the re-auth hint for ApiUnauthorizedError and exits 1", () => {
+    expect(() =>
+      handleCommandError(new ApiUnauthorizedError(), "Failed to list servers")
+    ).toThrow("__process_exit__1");
+
+    expect(consoleErr.join("\n")).toContain(
+      "Your session has expired or your API key is invalid."
+    );
+    expect(consoleLog.join("\n")).toContain("npx mcp-use login");
+    expect(consoleLog.join("\n")).toContain("re-authenticate");
+    // Should NOT show the generic "Failed to list servers" label for 401s.
+    expect(consoleErr.join("\n")).not.toContain("Failed to list servers");
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("prints the context label for non-401 errors and exits 1", () => {
+    expect(() =>
+      handleCommandError(
+        new Error("connection refused"),
+        "Failed to list servers"
+      )
+    ).toThrow("__process_exit__1");
+
+    expect(consoleErr.join("\n")).toContain("Failed to list servers");
+    expect(consoleErr.join("\n")).toContain("connection refused");
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("handles non-Error thrown values", () => {
+    expect(() => handleCommandError("oops", "Failed to do thing")).toThrow(
+      "__process_exit__1"
+    );
+
+    expect(consoleErr.join("\n")).toContain("Failed to do thing");
+    expect(consoleErr.join("\n")).toContain("Unknown error");
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/libraries/typescript/packages/cli/tests/errors.test.ts
+++ b/libraries/typescript/packages/cli/tests/errors.test.ts
@@ -51,8 +51,8 @@ describe("handleCommandError", () => {
     expect(consoleErr.join("\n")).toContain(
       "Your session has expired or your API key is invalid."
     );
-    expect(consoleLog.join("\n")).toContain("npx mcp-use login");
-    expect(consoleLog.join("\n")).toContain("re-authenticate");
+    expect(consoleErr.join("\n")).toContain("npx mcp-use login");
+    expect(consoleErr.join("\n")).toContain("re-authenticate");
     // Should NOT show the generic "Failed to list servers" label for 401s.
     expect(consoleErr.join("\n")).not.toContain("Failed to list servers");
     expect(process.exit).toHaveBeenCalledWith(1);


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

Check all that apply:
- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

`mcp-use login` short-circuited on file presence alone, so a revoked or expired API key still produced "You are already logged in" and subsequent commands blew up with a raw 401 dump. Login now validates the stored key against the backend after the `isLoggedIn()` check — on a 401 it clears the stale config and falls into the device-auth flow; network/other errors preserve the old "already logged in" message so offline users aren't forced through re-auth.

A new `handleCommandError(error, context)` helper in `utils/errors.ts` converts `ApiUnauthorizedError` into a friendly "session expired — run `npx mcp-use login`" hint. Wired through `whoami`, `org`, `servers`, `deployments`, and `env` (which previously had no try/catch at all, so errors leaked as stack traces). `deploy`'s richer `promptReauthenticateOn401` flow is untouched.

## Implementation Details

1. `src/commands/auth.ts` — `loginCommand` now calls `testAuth()` after `isLoggedIn()`. Re-auth flow uses an explicit `needsReauth` boolean so the control flow reads top-to-bottom (no implicit fall-through). `whoamiCommand` routes through the shared helper.
2. `src/utils/errors.ts` (new) — `handleCommandError(error, context)`. 401 → re-auth hint; everything else → `✗ <context>: <message>`. Always exits 1.
3. `src/commands/{deployments,org,servers,env}.ts` — catch blocks call `handleCommandError`. `env` previously had no error handling at all; each subcommand now wraps in try/catch.
4. No public API changes. `deploy` flow is unchanged.

---

## TypeScript Checklist

### Packages Modified

- [ ] `docs`
- [ ] `tests`
- [x] `cli`
- [ ] `create-mcp-use-app`
- [ ] `mcp-use` (server)
- [ ] `mcp-use` (client)
- [ ] `inspector`

### Pre-commit Checklist

- [x] Ran `pnpm lint:fix` to auto-fix linting issues
- [x] Ran `pnpm format` to format code with Prettier
- [x] Ran `pnpm build` and build succeeds without errors
- [x] Ran `pnpm changeset` to create a changeset (if this PR includes user-facing changes)
- [x] Added or updated tests if needed
- [ ] Updated documentation in `docs/` folder if needed

---

## Example Usage (Before)

```bash
$ mcp-use login           # stored key was revoked server-side
You are already logged in. Run 'npx mcp-use logout' first if you want to login with a different account.

$ mcp-use whoami
Error: API request failed: 401 {"detail":"Invalid API key"}
    at McpUseAPI.request (.../api.js:123:15)
    ...stack trace...
```

## Example Usage (After)

```bash
$ mcp-use login           # stored key was revoked server-side
⚠️  Stored credentials are invalid or expired. Re-authenticating...
Logging in to mcp-use cloud...
[device-code flow proceeds]

$ mcp-use whoami          # any command, when key is bad
✗ Your session has expired or your API key is invalid.
Run npx mcp-use login to re-authenticate.
```

## Documentation Updates

* None — behavior change is surfaced via in-CLI messages and the changeset.

## Testing

- New `tests/errors.test.ts` covers `handleCommandError` for 401, generic Error, and non-Error thrown values
- `tests/deployments.test.ts` mock updated to export `ApiUnauthorizedError`
- Full CLI test suite passes (140 tests, 6 skipped)
- Manual: verified login behavior with a deliberately invalidated key (re-auth triggers); verified offline behavior preserves "already logged in"

## Backwards Compatibility

Backwards compatible. The change is in error-handling output and in `login`'s short-circuit logic; no API or command surface changes. The only user-visible behavior shift is that `login` will now drop into device-auth instead of declaring "already logged in" when the stored key is actually invalid — which is the intended fix.

## Related Issues

N/A