### PR TITLE
docs: fix integration adapter imports and update Anthropic model

### DIFF
--- a/docs/python/integration/anthropic.mdx
+++ b/docs/python/integration/anthropic.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Anthropic"
 description: "Use mcp-use tools, resources, and prompts directly with the Anthropic SDK"
-tag: "New"
 icon: "/images/anthropic.svg"
 ---
 
@@ -51,7 +50,7 @@ uv pip install anthropic
         Next, instantiate the `AnthropicMCPAdapter`. This adapter will be responsible for converting MCP constructs into a format Anthropic can understand.
 
         ```python
-        from mcp_use.adapters import AnthropicMCPAdapter
+        from mcp_use.agents.adapters import AnthropicMCPAdapter
 
         # Creates the adapter for Anthropic's format
         adapter = AnthropicMCPAdapter()
@@ -100,7 +99,7 @@ uv pip install anthropic
         ]
 
         response = anthropic.messages.create(
-            model="claude-3-opus-20240229",
+            model="claude-opus-4-7",
             messages=messages,
             tools=anthropic_tools,
             max_tokens=1024
@@ -166,7 +165,7 @@ uv pip install anthropic
             )
             # Get final response
             final_response = anthropic.messages.create(
-                model="claude-3-opus-20240229", max_tokens=1024, tools=anthropic_tools, messages=messages
+                model="claude-opus-4-7", max_tokens=1024, tools=anthropic_tools, messages=messages
             )
             print("\n--- Final response from the model ---")
             print(final_response.content[0].text)
@@ -186,7 +185,7 @@ from anthropic import Anthropic
 from dotenv import load_dotenv
 
 from mcp_use import MCPClient
-from mcp_use.adapters import AnthropicMCPAdapter
+from mcp_use.agents.adapters import AnthropicMCPAdapter
 
 # This example demonstrates how to use our integration
 # adapters to use MCP tools and convert to the right format.
@@ -221,7 +220,7 @@ async def main():
         # Initial request
         messages = [{"role": "user", "content": "Please could you give me the assistant prompt? My name is vincenzo"}]
         response = anthropic.messages.create(
-            model="claude-3-opus-20240229", tools=anthropic_tools, max_tokens=1024, messages=messages
+            model="claude-opus-4-7", tools=anthropic_tools, max_tokens=1024, messages=messages
         )
         messages.append({"role": response.role, "content": response.content})
 
@@ -273,7 +272,7 @@ async def main():
                 )
                 # Get final response
                 final_response = anthropic.messages.create(
-                    model="claude-3-opus-20240229", max_tokens=1024, tools=anthropic_tools, messages=messages
+                    model="claude-opus-4-7", max_tokens=1024, tools=anthropic_tools, messages=messages
                 )
                 print("\n--- Final response from the model ---")
                 print(final_response.content[0].text)

--- a/docs/python/integration/google.mdx
+++ b/docs/python/integration/google.mdx
@@ -49,7 +49,7 @@ uv pip install google-genai
         Next, instantiate the `GoogleMCPAdapter`. This adapter will be responsible for converting MCP constructs into a format Google can understand.
 
         ```python
-        from mcp_use.adapters import GoogleMCPAdapter
+        from mcp_use.agents.adapters import GoogleMCPAdapter
 
         # Creates the adapter for Google's format
         adapter = GoogleMCPAdapter()
@@ -208,7 +208,7 @@ from google import genai
 from google.genai import types
 
 from mcp_use import MCPClient
-from mcp_use.adapters import GoogleMCPAdapter
+from mcp_use.agents.adapters import GoogleMCPAdapter
 
 # This example demonstrates how to use our integration
 # adapters to use MCP tools and convert to the right format.

--- a/docs/python/integration/openai.mdx
+++ b/docs/python/integration/openai.mdx
@@ -51,7 +51,7 @@ uv pip install openai
         Next, instantiate the `OpenAIMCPAdapter`. This adapter will be responsible for converting MCP constructs into a format OpenAI can understand.
 
         ```python
-        from mcp_use.adapters import OpenAIMCPAdapter
+        from mcp_use.agents.adapters import OpenAIMCPAdapter
 
         # Creates the adapter for OpenAI's format
         adapter = OpenAIMCPAdapter()
@@ -181,7 +181,7 @@ from dotenv import load_dotenv
 from openai import OpenAI
 
 from mcp_use import MCPClient
-from mcp_use.adapters import OpenAIMCPAdapter
+from mcp_use.agents.adapters import OpenAIMCPAdapter
 
 # This example demonstrates how to use our integration
 # adapters to use MCP tools and convert to the right format.


### PR DESCRIPTION
## Changes
Fix broken imports and outdated model in the Python integration docs.

## Implementation Details
1. `docs/python/integration/openai.mdx`, `anthropic.mdx`, `google.mdx`: swap `from mcp_use.adapters import …` → `from mcp_use.agents.adapters import …`. The top-level `mcp_use.adapters` is a deprecation shim that only re-exports `BaseAdapter` and `LangChainAdapter`, so the previous snippets crashed on import.
2. `anthropic.mdx`: bump all `claude-3-opus-20240229` references to `claude-opus-4-7`.
3. `anthropic.mdx`: remove the stale `tag: "New"` frontmatter entry.

## Testing
Docs-only change. Verified the target module path exists and exports `OpenAIMCPAdapter`, `AnthropicMCPAdapter`, `GoogleMCPAdapter` in `libraries/python/mcp_use/agents/adapters/__init__.py`.

## Backwards Compatibility
No code changes; docs now match the supported import path.