### PR TITLE
fix(inspector): OAuth flow no longer leaves two tabs open (#1384)

### DIFF
--- a/libraries/typescript/.changeset/fix-oauth-double-tab-1384.md
+++ b/libraries/typescript/.changeset/fix-oauth-double-tab-1384.md
@@ -1,0 +1,11 @@
+---
+"@mcp-use/inspector": patch
+---
+
+fix(inspector): OAuth flow no longer leaves two tabs open (#1384)
+
+Previously, connecting to an OAuth-protected MCP server from the inspector opened the authorization page in a new tab, and after the user authorized the app the callback redirected back to the inspector inside that second tab — leaving the user with two inspector tabs.
+
+The inspector now uses the same-tab redirect flow (`useRedirectFlow: true`) combined with `preventAutoAuth: true`, so the OAuth authorization page opens in the current tab and the callback navigates the same tab back to the original inspector URL. The user ends up with a single tab.
+
+The `Authenticate` anchor no longer sets `target="_blank"` / `rel="noopener noreferrer"` — clicking it now navigates the current tab directly to the stored auth URL. All connection entry points in the inspector (`handleAddConnection`, the `Layout` adapter, and the `InspectorDashboard` adapter used by `handleUpdateConnection` on URL edits, as well as `useAutoConnect`) propagate the same flags so the single-tab behavior is consistent across manual connect, URL edits, and auto-connect from shared config.

--- a/libraries/typescript/packages/inspector/src/client/components/InspectorDashboard.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/InspectorDashboard.tsx
@@ -155,7 +155,7 @@ export function InspectorDashboard() {
         proxyConfig,
         transportType,
         preventAutoAuth: true,
-        useRedirectFlow: true, // Same-tab OAuth flow (issue #1384)
+        useRedirectFlow: true,
       });
     },
     [addServer]
@@ -416,7 +416,7 @@ export function InspectorDashboard() {
       name: alias.trim() || normalizedUrl,
       transportType: "http",
       preventAutoAuth: true, // Prevent auto OAuth popup - user must click "Authenticate" button
-      useRedirectFlow: true, // Use full-page same-tab redirect so OAuth callback returns to this tab (issue #1384)
+      useRedirectFlow: true,
       clientOptions: {
         capabilities: {
           extensions: {

--- a/libraries/typescript/packages/inspector/src/client/components/InspectorDashboard.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/InspectorDashboard.tsx
@@ -154,6 +154,8 @@ export function InspectorDashboard() {
         name,
         proxyConfig,
         transportType,
+        preventAutoAuth: true,
+        useRedirectFlow: true, // Same-tab OAuth flow (issue #1384)
       });
     },
     [addServer]
@@ -414,6 +416,7 @@ export function InspectorDashboard() {
       name: alias.trim() || normalizedUrl,
       transportType: "http",
       preventAutoAuth: true, // Prevent auto OAuth popup - user must click "Authenticate" button
+      useRedirectFlow: true, // Use full-page same-tab redirect so OAuth callback returns to this tab (issue #1384)
       clientOptions: {
         capabilities: {
           extensions: {
@@ -1050,8 +1053,6 @@ export function InspectorDashboard() {
                         >
                           <a
                             href={connection.authUrl}
-                            target="_blank"
-                            rel="noopener noreferrer"
                             onClick={(e) => e.stopPropagation()}
                           >
                             Authenticate

--- a/libraries/typescript/packages/inspector/src/client/components/Layout.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/Layout.tsx
@@ -69,6 +69,7 @@ export function Layout({ children }: LayoutProps) {
         proxyConfig,
         transportType,
         preventAutoAuth: true,
+        useRedirectFlow: true, // Same-tab OAuth flow (issue #1384)
         clientOptions: {
           capabilities: {
             extensions: {

--- a/libraries/typescript/packages/inspector/src/client/components/Layout.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/Layout.tsx
@@ -69,7 +69,7 @@ export function Layout({ children }: LayoutProps) {
         proxyConfig,
         transportType,
         preventAutoAuth: true,
-        useRedirectFlow: true, // Same-tab OAuth flow (issue #1384)
+        useRedirectFlow: true,
         clientOptions: {
           capabilities: {
             extensions: {


### PR DESCRIPTION
## Summary
- Inspector OAuth flow now stays in a single tab from start to finish.
- `Authenticate` anchor no longer sets `target="_blank"` — clicking it performs a same-tab navigation to the stored auth URL.
- All server-add paths (`handleAddConnection`, `Layout` adapter, `InspectorDashboard` adapter used by URL edits and `useAutoConnect`) set `useRedirectFlow: true` + `preventAutoAuth: true`, so the stored OAuth state records `flowType: "redirect"` and the callback routes the current tab back to `returnUrl`.

Closes #1384.

## Root cause
The inspector opened the OAuth authorization page in a new tab (`target="_blank"` on the Authenticate anchor). After the auth server redirected to the callback URL, modern browsers (COOP) stripped `window.opener` in the new tab, so `onMcpAuthorization` could not detect the popup and fell through to the `returnUrl` fallback — navigating the new tab to the inspector. Result: two inspector tabs.

The library primitives (`redirectToAuthorization`, `onMcpAuthorization`, `flowType`) already worked correctly — they just weren't being used by the inspector.

## Implementation details
- `packages/inspector/src/client/components/InspectorDashboard.tsx`
  - Drop `target="_blank"` / `rel="noopener noreferrer"` on the Authenticate anchor.
  - Add `useRedirectFlow: true` to `handleAddConnection`'s `McpServerOptions`.
  - Propagate `preventAutoAuth: true` + `useRedirectFlow: true` through the `addConnection` adapter used by `handleUpdateConnection` on URL edits.
- `packages/inspector/src/client/components/Layout.tsx`
  - Propagate `useRedirectFlow: true` through the `addConnection` adapter used by `useAutoConnect` and shared-config imports.
- `.changeset/fix-oauth-double-tab-1384.md` — patch bump for `@mcp-use/inspector`.

## Example usage
**Before:** user clicks Authenticate → new tab opens → after OAuth, user has two inspector tabs.
**After:** user clicks Authenticate → current tab navigates to auth server → after OAuth, same tab lands back on `/inspector`. One tab total.

## Test plan
- [x] `pnpm --filter @mcp-use/inspector build` — CDN + CLI bundles green
- [x] `pnpm lint --quiet` — clean
- [x] `pnpm format:check` — clean
- [ ] Manual smoke test against a real OAuth-protected MCP server

## Backwards compatibility
Non-breaking. The library's `useRedirectFlow` default remains `false` for existing SDK consumers — only the inspector's own server-add sites opt in. Popup flow is still fully supported by the library for non-inspector consumers.

## Related issues
Closes #1384