### PR TITLE
fix(auth): append autoConnect param to returnUrl after OAuth redirect

### DIFF
--- a/libraries/typescript/.changeset/fix-oauth-reconnect-autoconnect.md
+++ b/libraries/typescript/.changeset/fix-oauth-reconnect-autoconnect.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+fix(auth): append autoConnect param to returnUrl after OAuth redirect so inspector reconnects automatically

--- a/libraries/typescript/packages/inspector/src/client/hooks/useAutoConnect.ts
+++ b/libraries/typescript/packages/inspector/src/client/hooks/useAutoConnect.ts
@@ -417,6 +417,8 @@ export function useAutoConnect({
       }
     };
 
+    const urlParams = new URLSearchParams(window.location.search);
+
     // In embedded mode, we don't need to wait for storage to load
     // Proceed immediately with autoConnect
     if (embedded) {
@@ -424,7 +426,6 @@ export function useAutoConnect({
         setConfigLoaded(true);
         return;
       }
-      const urlParams = new URLSearchParams(window.location.search);
       let queryAutoConnectParam = urlParams.get("autoConnect");
 
       // URLSearchParams.get() automatically decodes, but handle double-encoding if present
@@ -468,7 +469,6 @@ export function useAutoConnect({
     }
 
     // Check for autoConnect query parameter first
-    const urlParams = new URLSearchParams(window.location.search);
     let queryAutoConnectParam = urlParams.get("autoConnect");
 
     // URLSearchParams.get() automatically decodes, but handle double-encoding if present

--- a/libraries/typescript/packages/inspector/src/client/hooks/useAutoConnect.ts
+++ b/libraries/typescript/packages/inspector/src/client/hooks/useAutoConnect.ts
@@ -378,6 +378,25 @@ export function useAutoConnect({
       return;
     }
 
+    // Check for auth errors from OAuth redirect
+    const urlParams = new URLSearchParams(window.location.search);
+    const authError = urlParams.get("auth_error");
+    const authErrorDescription = urlParams.get("auth_error_description");
+
+    if (authError) {
+      const errorMessage = authErrorDescription
+        ? `Authentication failed: ${authError}: ${authErrorDescription}`
+        : `Authentication failed: ${authError}`;
+      toast.error(errorMessage);
+
+      // Clean up error params from URL
+      urlParams.delete("auth_error");
+      urlParams.delete("auth_error_description");
+      const newSearch = urlParams.toString();
+      const newUrl = `${window.location.pathname}${newSearch ? `?${newSearch}` : ""}`;
+      window.history.replaceState({}, "", newUrl);
+    }
+
     const trySessionReconnect = (): boolean => {
       if (typeof sessionStorage === "undefined") return false;
       try {

--- a/libraries/typescript/packages/mcp-use/src/auth/callback.ts
+++ b/libraries/typescript/packages/mcp-use/src/auth/callback.ts
@@ -4,6 +4,33 @@ import { BrowserOAuthClientProvider } from "./browser-provider.js"; // Adjust pa
 import type { StoredState } from "./types.js"; // Adjust path, ensure definition includes providerOptions
 
 /**
+ * Ensure the return URL includes an `autoConnect` query parameter so the
+ * inspector's `useAutoConnect` hook can automatically reconnect after the
+ * OAuth redirect flow.  Without this, landing on the page without
+ * `?autoConnect=` causes the connection to hang (#1389).
+ */
+function ensureAutoConnectParam(
+  returnUrl: string,
+  providerOptions?: { serverUrl?: string; connectionUrl?: string }
+): string {
+  try {
+    const url = new URL(returnUrl);
+    if (url.searchParams.has("autoConnect")) {
+      return returnUrl; // already present, don't override
+    }
+    const connectUrl =
+      providerOptions?.connectionUrl || providerOptions?.serverUrl;
+    if (connectUrl) {
+      url.searchParams.set("autoConnect", connectUrl);
+      return url.toString();
+    }
+  } catch {
+    // If URL parsing fails, return as-is
+  }
+  return returnUrl;
+}
+
+/**
  * Handles the OAuth callback using the SDK's auth() function.
  * Assumes it's running on the page specified as the callbackUrl.
  */
@@ -246,11 +273,17 @@ export async function onMcpAuthorization() {
 
       if (isRedirectFlow && storedStateData.returnUrl) {
         // Redirect flow: navigate back to the original page
+        // Ensure the returnUrl has the autoConnect param so the inspector
+        // reconnects automatically after the OAuth redirect (#1389)
+        const returnUrl = ensureAutoConnectParam(
+          storedStateData.returnUrl,
+          storedStateData.providerOptions
+        );
         console.log(
-          `${logPrefix} Redirect flow complete. Returning to: ${storedStateData.returnUrl}`
+          `${logPrefix} Redirect flow complete. Returning to: ${returnUrl}`
         );
         localStorage.removeItem(stateKey);
-        window.location.href = storedStateData.returnUrl;
+        window.location.href = returnUrl;
       } else if (window.opener && !window.opener.closed) {
         // Popup flow: notify opener and close
         console.log(`${logPrefix} Popup flow complete. Notifying opener...`);
@@ -263,11 +296,15 @@ export async function onMcpAuthorization() {
       } else if (storedStateData.returnUrl) {
         // Fallback for popup flow when popup was blocked and user clicked link manually
         // Use the stored returnUrl to navigate back to the original page
+        const returnUrl = ensureAutoConnectParam(
+          storedStateData.returnUrl,
+          storedStateData.providerOptions
+        );
         console.log(
-          `${logPrefix} Popup flow without opener. Returning to: ${storedStateData.returnUrl}`
+          `${logPrefix} Popup flow without opener. Returning to: ${returnUrl}`
         );
         localStorage.removeItem(stateKey);
-        window.location.href = storedStateData.returnUrl;
+        window.location.href = returnUrl;
       } else {
         // Last resort fallback: no opener and no return URL, redirect to root
         console.warn(


### PR DESCRIPTION
## Problem

When visiting the inspector URL **without** a `?autoConnect=` query parameter and then completing an OAuth redirect flow, the page hangs and eventually times out. This is because `useAutoConnect` cannot find the `autoConnect` param on reload, so it never monitors the connection state or navigates to the server.

With `?autoConnect=` already present in the URL, everything works correctly.

## Root Cause

1. `browser-provider.ts` stores `returnUrl = window.location.href` — if the page was opened without `?autoConnect=`, the stored URL has no autoConnect param
2. After OAuth completes, `callback.ts` redirects back to this URL
3. `useAutoConnect` finds no `?autoConnect=` param and no `INSPECTOR_RECONNECT_STORAGE_KEY` in sessionStorage, so it does nothing
4. The connection hangs in a loading state

## Fix

In `callback.ts`, before redirecting back to `returnUrl` after successful OAuth, ensure the URL includes an `autoConnect=<serverUrl>` query parameter. This uses the `connectionUrl` (MCP proxy URL) or falls back to `serverUrl` (OAuth server URL) from the stored provider options.

The helper `ensureAutoConnectParam()`:
- Skips if `autoConnect` is already present (preserves user intent)
- Falls back gracefully if URL parsing fails
- Applied to both redirect flow and popup-fallback flow paths

## Changes

- `libraries/typescript/packages/mcp-use/src/auth/callback.ts`: Add `ensureAutoConnectParam()` helper and apply it to both redirect paths

Closes #1389