### PR TITLE
docs(inspector): document --no-open CLI flag

### DIFF
--- a/docs/inspector/cli.mdx
+++ b/docs/inspector/cli.mdx
@@ -50,6 +50,20 @@ npx @mcp-use/inspector --port 9000
 
 **Port Range:** Must be between 1 and 65535
 
+### `--no-open`
+
+Prevent the inspector from automatically opening a browser tab when it starts. Useful in CI/CD pipelines, headless environments, or when you prefer to open the URL manually.
+
+```bash
+npx @mcp-use/inspector --no-open
+```
+
+You can combine it with other flags:
+
+```bash
+npx @mcp-use/inspector --url http://localhost:3000/mcp --port 9000 --no-open
+```
+
 ### `--help, -h`
 
 Display help information and available options.
@@ -157,7 +171,7 @@ npx @mcp-use/inspector --url localhost:3000/mcp
 
 ### Browser Doesn't Open
 
-If the browser doesn't open automatically, check the terminal output for the inspector URL and open it manually.
+If the browser doesn't open automatically, check the terminal output for the inspector URL and open it manually. If you passed `--no-open`, this is expected behavior.
 
 ## Related Documentation
 


### PR DESCRIPTION
## Changes
Documents the `--no-open` CLI flag for the MCP Inspector, which suppresses auto-opening a browser tab on startup.

## Implementation Details
1. Added a `--no-open` section to `docs/inspector/cli.mdx` under Command Options, between `--port` and `--help`
2. Updated the "Browser Doesn't Open" troubleshooting entry to note that `--no-open` makes this expected behavior

## Backwards Compatibility
Docs-only change. No code changes.

## Related Issues
Closes #1813