### PR TITLE
fix(react): useWidget stays pending until real props arrive

### DIFF
--- a/libraries/typescript/.changeset/fix-useWidget-pending-1753.md
+++ b/libraries/typescript/.changeset/fix-useWidget-pending-1753.md
@@ -1,0 +1,10 @@
+---
+"mcp-use": patch
+---
+
+fix(react): `useWidget` no longer flips `isPending` to `false` before real props arrive (#1753)
+
+Two pre-render paths in `useWidget` were causing widgets to render with empty props, which crashed any widget that destructured required fields (e.g. `markers.length`, `results.length`, `center.lat`) after the `isPending` guard.
+
+- **ChatGPT Apps provider** — `isPending` compared `openaiToolOutput === null && toolResponseMetadata === null`, but `useOpenAiGlobal` returns `undefined` before the host has populated the key. `undefined === null` is `false`, so `isPending` was `false` on the very first render. Now uses loose `== null` so `undefined` is treated the same as `null`.
+- **mcp-ui URL-params fallback** — the fallback `urlParams` memo defaulted to `{ toolInput: {}, toolOutput: {}, toolId: "" }`, so the subsequent `toolOutput === null || toolOutput === undefined` check never triggered during standalone (non-iframe) dev. The memo now distinguishes "no `mcpUseParams` supplied" from "tool completed with empty object" via a `hasMcpUseParams` flag, and `isPending` stays `true` until params actually arrive.

--- a/libraries/typescript/packages/mcp-use/src/react/useWidget.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/useWidget.ts
@@ -316,9 +316,9 @@ export function useWidget<
     hasMcpUseParams: boolean;
   } => {
     // check if it has mcpUseParams
-    const sp = new URLSearchParams(searchString);
-    if (sp.has("mcpUseParams")) {
-      const parsed = JSON.parse(sp.get("mcpUseParams") as string) as {
+    const searchParams = new URLSearchParams(searchString);
+    if (searchParams.has("mcpUseParams")) {
+      const parsed = JSON.parse(searchParams.get("mcpUseParams") as string) as {
         toolInput: TProps;
         toolOutput: TOutput;
         toolId: string;

--- a/libraries/typescript/packages/mcp-use/src/react/useWidget.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/useWidget.ts
@@ -309,20 +309,27 @@ export function useWidget<
   const searchString =
     typeof window !== "undefined" ? window.location.search : "";
 
-  const urlParams = useMemo(() => {
+  const urlParams = useMemo((): {
+    toolInput: TProps | undefined;
+    toolOutput: TOutput | undefined;
+    toolId: string;
+    hasMcpUseParams: boolean;
+  } => {
     // check if it has mcpUseParams
-    const urlParams = new URLSearchParams(searchString);
-    if (urlParams.has("mcpUseParams")) {
-      return JSON.parse(urlParams.get("mcpUseParams") as string) as {
+    const sp = new URLSearchParams(searchString);
+    if (sp.has("mcpUseParams")) {
+      const parsed = JSON.parse(sp.get("mcpUseParams") as string) as {
         toolInput: TProps;
         toolOutput: TOutput;
         toolId: string;
       };
+      return { ...parsed, hasMcpUseParams: true };
     }
     return {
-      toolInput: {} as TProps,
-      toolOutput: {} as TOutput,
+      toolInput: undefined,
+      toolOutput: undefined,
       toolId: "",
+      hasMcpUseParams: false,
     };
   }, [searchString]);
 
@@ -738,7 +745,9 @@ export function useWidget<
       // Tool is pending until the host delivers either toolOutput (structuredContent)
       // or toolResponseMetadata (_meta). Checking both mirrors how MCP Apps works and
       // avoids staying stuck when the server omits _meta from the tool result.
-      return openaiToolOutput === null && toolResponseMetadata === null;
+      // `useOpenAiGlobal` returns `undefined` before the host has populated the key,
+      // so treat `undefined` the same as `null` here.
+      return openaiToolOutput == null && toolResponseMetadata == null;
     }
     if (provider === "mcp-apps") {
       // In MCP Apps, widget is pending until we receive tool-result notification
@@ -757,7 +766,12 @@ export function useWidget<
       ) {
         return true;
       }
-      return toolOutput === null || toolOutput === undefined;
+      // Standalone (non-iframe) without `mcpUseParams` has no way to deliver a
+      // tool result — stay pending rather than rendering with empty props.
+      if (!urlParams.hasMcpUseParams) {
+        return true;
+      }
+      return toolOutput == null;
     }
     return false;
   }, [
@@ -767,6 +781,7 @@ export function useWidget<
     mcpAppsToolOutput,
     toolOutput,
     urlParams.toolId,
+    urlParams.hasMcpUseParams,
   ]);
 
   // Partial/streaming tool input (available during LLM argument generation)

--- a/libraries/typescript/packages/mcp-use/tests/useWidget.test.tsx
+++ b/libraries/typescript/packages/mcp-use/tests/useWidget.test.tsx
@@ -4,7 +4,9 @@ import TestRenderer, { act } from "react-test-renderer";
 import { beforeEach, describe, expect, it } from "vitest";
 import { useWidget } from "../src/react/useWidget";
 
-type HookResult = ReturnType<typeof useWidget<Record<string, unknown>, unknown>>;
+type HookResult = ReturnType<
+  typeof useWidget<Record<string, unknown>, unknown>
+>;
 
 // Tiny harness that renders nothing visible but captures the hook's return value
 // on every render so tests can assert against it.
@@ -18,9 +20,7 @@ function renderHook() {
   let latest: HookResult | undefined;
   let renderer: TestRenderer.ReactTestRenderer | undefined;
   act(() => {
-    renderer = TestRenderer.create(
-      <Harness onResult={(r) => (latest = r)} />
-    );
+    renderer = TestRenderer.create(<Harness onResult={(r) => (latest = r)} />);
   });
   return {
     get result() {

--- a/libraries/typescript/packages/mcp-use/tests/useWidget.test.tsx
+++ b/libraries/typescript/packages/mcp-use/tests/useWidget.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+import React from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useWidget } from "../src/react/useWidget";
+
+type HookResult = ReturnType<typeof useWidget<Record<string, unknown>, unknown>>;
+
+// Tiny harness that renders nothing visible but captures the hook's return value
+// on every render so tests can assert against it.
+function Harness({ onResult }: { onResult: (r: HookResult) => void }) {
+  const result = useWidget();
+  onResult(result);
+  return null;
+}
+
+function renderHook() {
+  let latest: HookResult | undefined;
+  let renderer: TestRenderer.ReactTestRenderer | undefined;
+  act(() => {
+    renderer = TestRenderer.create(
+      <Harness onResult={(r) => (latest = r)} />
+    );
+  });
+  return {
+    get result() {
+      if (!latest) throw new Error("hook did not render");
+      return latest;
+    },
+    unmount: () => renderer?.unmount(),
+  };
+}
+
+function resetWindow() {
+  // Clear any openai global that a prior test set.
+  delete (window as unknown as { openai?: unknown }).openai;
+  // Reset the URL to have no search string.
+  window.history.replaceState(null, "", "/");
+}
+
+describe("useWidget isPending — openai provider", () => {
+  beforeEach(() => {
+    resetWindow();
+  });
+
+  it("stays pending when window.openai.toolOutput is undefined", () => {
+    // Host has wired up `window.openai` but hasn't delivered tool output yet.
+    // Previously useOpenAiGlobal's `undefined === null` check failed, flipping
+    // isPending to false on the very first render.
+    (window as unknown as { openai: Record<string, unknown> }).openai = {};
+    const hook = renderHook();
+    expect(hook.result.isPending).toBe(true);
+    hook.unmount();
+  });
+
+  it("stays pending when only toolOutput is populated but metadata is not", () => {
+    (window as unknown as { openai: Record<string, unknown> }).openai = {
+      toolOutput: { hello: "world" },
+    };
+    const hook = renderHook();
+    // isPending flips as soon as either toolOutput OR toolResponseMetadata arrives
+    expect(hook.result.isPending).toBe(false);
+    hook.unmount();
+  });
+
+  it("stays pending when only metadata is populated but toolOutput is not", () => {
+    (window as unknown as { openai: Record<string, unknown> }).openai = {
+      toolResponseMetadata: { _meta: "x" },
+    };
+    const hook = renderHook();
+    expect(hook.result.isPending).toBe(false);
+    hook.unmount();
+  });
+});
+
+describe("useWidget isPending — mcp-ui url-params fallback", () => {
+  beforeEach(() => {
+    resetWindow();
+  });
+
+  it("stays pending when running standalone without mcpUseParams", () => {
+    // No iframe, no `mcpUseParams` — previously the empty-object default made
+    // isPending read false and widgets rendered with empty props.
+    const hook = renderHook();
+    expect(hook.result.isPending).toBe(true);
+    hook.unmount();
+  });
+
+  it("resolves when mcpUseParams supplies toolOutput", () => {
+    const params = encodeURIComponent(
+      JSON.stringify({
+        toolInput: {},
+        toolOutput: { foo: "bar" },
+        toolId: "tool-1",
+      })
+    );
+    window.history.replaceState(null, "", `/?mcpUseParams=${params}`);
+    const hook = renderHook();
+    expect(hook.result.isPending).toBe(false);
+    hook.unmount();
+  });
+});


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

Two pre-render paths in `useWidget` were flipping `isPending` to `false` before any tool data had arrived, so widgets rendered with empty props and crashed when they destructured required nested fields (e.g. `markers.length`, `results.length`, `center.lat`). Concretely this broke the `mcp-use/mcp-maps-explorer` and `mcp-use/mcp-recipe-finder` template repos.

## Implementation Details

1. **ChatGPT Apps provider (`useWidget.ts` line ~741).** `isPending` compared `openaiToolOutput === null && toolResponseMetadata === null`, but `useOpenAiGlobal` returns `undefined` before the host has populated the key (not `null`). `undefined === null` is `false`, so `isPending` was `false` on the very first render. Switched to loose `== null` so `undefined` counts the same as `null`.

2. **mcp-ui URL-params fallback (`useWidget.ts` lines ~312–327, ~760).** The fallback `urlParams` memo defaulted to `{ toolInput: {}, toolOutput: {}, toolId: "" }`, and the subsequent `toolOutput === null || toolOutput === undefined` check never fired against the empty-object default. The memo now returns `{ toolInput: undefined, toolOutput: undefined, toolId: "", hasMcpUseParams: false }` when `mcpUseParams` is absent, and `isPending` gates on `!hasMcpUseParams || toolOutput == null`.

3. No changes to the `widgetProps` merge or to consumers — with `isPending` fixed, widgets bail via their existing loading guard before reaching the destructure.

4. No new runtime dependencies. Tests use `react-test-renderer` (already a dev dep) with vitest's `// @vitest-environment jsdom` header.

---

## TypeScript Checklist

### Packages Modified

- [ ] `docs`
- [ ] `tests`
- [ ] `cli`
- [ ] `create-mcp-use-app`
- [x] `mcp-use` (server)
- [x] `mcp-use` (client)
- [ ] `inspector`

(Note: the change lives in `src/react/` which is shipped from the `mcp-use` package — checking both server/client boxes since the bug affects any widget consuming this hook.)

### Pre-commit Checklist

- [x] Ran `pnpm lint:fix` to auto-fix linting issues (eslint clean on changed files)
- [x] Ran `pnpm format` to format code with Prettier
- [x] Ran `pnpm build` and build succeeds without errors
- [x] Ran `pnpm changeset` to create a changeset (`.changeset/fix-useWidget-pending-1753.md`, patch bump on `mcp-use`)
- [x] Added or updated tests if needed (`tests/useWidget.test.tsx`, 5 new cases)
- [ ] Updated documentation in `docs/` folder if needed — no user-facing API change, just a bug fix

---

## Python Checklist

> N/A — TypeScript-only change.

---

## Example Usage (Before)

```tsx
// Standard template widget, e.g. mcp-use/mcp-maps-explorer
const MapView = () => {
  const { props, isPending } = useWidget<MapViewProps>();
  if (isPending) return <Loading />;

  const { markers } = props;
  // ❌ TypeError: Cannot read properties of undefined (reading 'length')
  //    because isPending flipped to false before markers arrived
  return <div>{markers.length} markers</div>;
};
```

## Example Usage (After)

```tsx
// Same code — now works because isPending stays true until
// the host actually delivers tool data.
const MapView = () => {
  const { props, isPending } = useWidget<MapViewProps>();
  if (isPending) return <Loading />;

  const { markers } = props; // ✅ populated
  return <div>{markers.length} markers</div>;
};
```

## Documentation Updates

None. No public API shape changed.

## Testing

- **New unit tests** (`tests/useWidget.test.tsx`) — 5 cases covering both regressions:
  - openai provider: `isPending === true` when `window.openai.toolOutput` and `toolResponseMetadata` are `undefined`.
  - openai provider: `isPending` flips `false` once either `toolOutput` or `toolResponseMetadata` is populated.
  - mcp-ui provider: `isPending === true` when standalone without `mcpUseParams` in the URL.
  - mcp-ui provider: `isPending === false` once `mcpUseParams` is present.
- **Full unit suite** (`pnpm --filter mcp-use test:unit`) passes: 474 pre-existing + 5 new. The 3 unrelated failures in `tests/docs/agent-quick-start.test.ts` require `OPENAI_API_KEY` and are pre-existing.
- **Downstream build** (`pnpm --filter @mcp-use/inspector build`) passes, confirming no breakage in consumers of `mcp-use/react`.
- **Manual** — smoke-installed the locally packed `mcp-use` tarball into `mcp-use/mcp-maps-explorer` and `mcp-use/mcp-recipe-finder` (the two templates MCP-1753 calls out); install succeeds against the new shape.
- **Not covered** — full host-level E2E inside ChatGPT/Claude. The unit tests replicate the exact race the RCA identified; a separate version-bump PR on each template repo is the final step once this publishes.

## Backwards Compatibility

Backwards compatible. No public API changed. The `useWidget` return shape is unchanged; `urlParams` is internal to the hook. Widget authors who had added manual workarounds (e.g. `markers = []` defaults in destructuring) will continue to work — their defaults will simply never fire now, because `isPending` correctly gates the destructure.

## Related Issues

Closes MCP-1753