### PR TITLE
fix(inspector): hide free-tier upgrade UI when host app embeds ChatTab

### DIFF
--- a/libraries/typescript/.changeset/fix-chat-free-tier-leak-1903.md
+++ b/libraries/typescript/.changeset/fix-chat-free-tier-leak-1903.md
@@ -1,0 +1,11 @@
+---
+"@mcp-use/inspector": patch
+---
+
+fix(inspector): hide Manufact free-tier "Model & usage" dialog when host app embeds `ChatTab` with its own session (MCP-1903)
+
+The cloud dashboard chat was leaking the hosted inspector's free-tier sign-in / bring-your-own-key modal (plus the "anthropic/server-managed" model badge) even though it passed `hideModelBadge={true}` and already had its own authenticated session and model selector.
+
+`ChatTab` was auto-deriving `freeTierInfo` from `isManaged` (i.e., the mere presence of `managedLlmConfig`), and both the badge and `ConfigurationDialog` treated `freeTierInfo` as an override that forces the UI back on regardless of `hideModelBadge` / `hideConfigButton`.
+
+Free-tier upgrade UI is now opt-in via a new `enableFreeTierUpgrade?: boolean` prop on `ChatTab` (default `false`), plumbed through `EmbeddedConfig.chatEnableFreeTierUpgrade`. The hosted inspector (`inspector.manufact.com`) auto-seeds it to `true`; host apps that embed `ChatTab` directly (e.g. the cloud dashboard) leave it off and their hide-\* props are respected.

--- a/libraries/typescript/packages/inspector/src/client/components/ChatTab.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ChatTab.tsx
@@ -57,6 +57,8 @@ export interface ChatTabProps {
   /** Externally-managed LLM config. When provided, bypasses localStorage-based config
    *  and hides the API key configuration UI. Useful for host apps that provide their own backend. */
   managedLlmConfig?: import("./chat/types").LLMConfig;
+  /** Opt in to the Manufact free-tier sign-in / upgrade UI. Default: false. */
+  enableFreeTierUpgrade?: boolean;
   /** Label for the clear/new-chat button. Default: "New Chat". */
   clearButtonLabel?: string;
   /** When true, hides the "Chat" title in the header. Default: false. */
@@ -116,6 +118,7 @@ export function ChatTab({
   waitForChatApiUrl,
   initialMessages,
   managedLlmConfig,
+  enableFreeTierUpgrade = false,
   clearButtonLabel,
   hideTitle,
   hideModelBadge,
@@ -265,10 +268,10 @@ export function ChatTab({
     setShowLoginModal(true);
   }, [setConfigDialogOpen]);
 
-  // Free-tier info is shown whenever the chat is in hosted-managed mode.
-  const freeTierInfo = isManaged
-    ? { onLoginClick: handleOpenLogin }
-    : undefined;
+  const freeTierInfo =
+    isManaged && enableFreeTierUpgrade
+      ? { onLoginClick: handleOpenLogin }
+      : undefined;
 
   const {
     filteredPrompts,

--- a/libraries/typescript/packages/inspector/src/client/components/LayoutContent.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/LayoutContent.tsx
@@ -75,6 +75,7 @@ export function LayoutContent({
             apiKey: "server-managed",
           }
         }
+        enableFreeTierUpgrade={embeddedConfig.chatEnableFreeTierUpgrade}
         hideTitle={embeddedConfig.chatHideTitle}
         hideModelBadge={embeddedConfig.chatHideModelBadge ?? true}
         hideServerUrl={embeddedConfig.chatHideServerUrl ?? true}
@@ -218,6 +219,7 @@ export function LayoutContent({
                   }
                 : undefined)
             }
+            enableFreeTierUpgrade={embeddedConfig.chatEnableFreeTierUpgrade}
             hideTitle={embeddedConfig.chatHideTitle}
             hideModelBadge={
               embeddedConfig.chatHideModelBadge ?? !!embeddedConfig.chatApiUrl

--- a/libraries/typescript/packages/inspector/src/client/context/InspectorContext.tsx
+++ b/libraries/typescript/packages/inspector/src/client/context/InspectorContext.tsx
@@ -70,6 +70,8 @@ export interface EmbeddedConfig {
   chatCredentials?: RequestCredentials;
   /** Externally-managed LLM config passed to ChatTab (bypasses config UI) */
   managedLlmConfig?: LLMConfig;
+  /** Opt in to the Manufact free-tier sign-in / upgrade UI in the chat. */
+  chatEnableFreeTierUpgrade?: boolean;
   // --- Chat UI customization ---
   /** Hide the "Chat" title in the header */
   chatHideTitle?: boolean;
@@ -186,6 +188,7 @@ export function InspectorProvider({ children }: { children: ReactNode }) {
           // Include cookies so the backend can recognise authenticated users
           // (session cookie shared across subdomains via COOKIE_DOMAIN).
           chatCredentials: "include" as RequestCredentials,
+          chatEnableFreeTierUpgrade: true,
         }
       : {},
   });


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

Check all that apply:
- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

`ChatTab` was auto-deriving the Manufact free-tier "Model & usage" dialog (and the accompanying `anthropic/server-managed` model badge below the input) from the mere presence of `managedLlmConfig`. Host apps that embed `ChatTab` with their own authenticated session and their own model selector — e.g. the cloud dashboard — pass `managedLlmConfig` purely to satisfy the "have an llmConfig" gate, and pass `hideModelBadge={true}` / `hideConfigButton={true}` to suppress the inspector's model UI. But both the badge and the `ConfigurationDialog` treated `freeTierInfo` as an override that forced the UI back on, so the "Manufact free tier / Sign in / bring your own API key" modal leaked into the cloud chat.

Free-tier upgrade UI is now **opt-in** via a new `enableFreeTierUpgrade` prop on `ChatTab` (default `false`), plumbed through `EmbeddedConfig.chatEnableFreeTierUpgrade`. The hosted inspector auto-seeds the flag to `true` when it auto-configures `chatApiUrl`. Host apps embedding `ChatTab` directly leave the flag off, and their `hideModelBadge` / `hideConfigButton` settings are respected.

## Implementation Details

1. **`ChatTab.tsx`** — added `enableFreeTierUpgrade?: boolean` to `ChatTabProps` (default `false`). Changed `freeTierInfo` computation from `isManaged ? ... : undefined` to `isManaged && enableFreeTierUpgrade ? ... : undefined`. `isManaged` alone now only controls internal client-side vs server-side chat routing and config-dialog behavior — not the branded upgrade UI.
2. **`InspectorContext.tsx`** — added `chatEnableFreeTierUpgrade?: boolean` to `EmbeddedConfig`. The hosted inspector (`InspectorProvider`) auto-seeds it to `true` alongside the existing `chatApiUrl` seeding, preserving existing hosted-inspector behavior.
3. **`LayoutContent.tsx`** — both `<ChatTab>` render sites now pass `enableFreeTierUpgrade={embeddedConfig.chatEnableFreeTierUpgrade}`.

No changes to `ChatHeader` / `ChatLandingForm` / `ConfigurationDialog` — the existing `freeTierInfo`-driven conditionals remain intact and correctly route on the new gated value.

---

## TypeScript Checklist

### Packages Modified

- [x] `inspector`

### Pre-commit Checklist

- [x] Ran `pnpm lint:fix` to auto-fix linting issues
- [x] Ran `pnpm format` to format code with Prettier
- [x] Ran `pnpm build` and build succeeds without errors
- [x] Ran `pnpm changeset` to create a changeset
- [ ] Added or updated tests if needed (see Testing)
- [ ] Updated documentation in `docs/` folder if needed (no user-facing docs cover the free-tier UI)

---

## Example Usage (Before)

Host app (e.g. cloud dashboard) embedded `ChatTab` like this and still saw the Manufact free-tier modal when clicking the model badge:

```tsx
<ChatTab
  useClientSide={false}
  chatApiUrl={chatApiUrl}
  managedLlmConfig={{
    provider: "anthropic",
    model: "server-managed",
    apiKey: "server-managed",
  }}
  hideModelBadge={true}
  hideClearButton={true}
  // ... no way to suppress the free-tier upgrade UI
/>
```

## Example Usage (After)

Default behavior is now correct — no extra prop needed for host apps:

```tsx
<ChatTab
  useClientSide={false}
  chatApiUrl={chatApiUrl}
  managedLlmConfig={{
    provider: "anthropic",
    model: "server-managed",
    apiKey: "server-managed",
  }}
  hideModelBadge={true}
  hideClearButton={true}
  // free-tier UI stays hidden; host app's own model selector wins
/>
```

Callers that actually want the Manufact free-tier upgrade flow (i.e. the hosted inspector) opt in explicitly:

```tsx
<ChatTab
  useClientSide={false}
  chatApiUrl={chatApiUrl}
  managedLlmConfig={stubConfig}
  enableFreeTierUpgrade
/>
```

Or via embedded config:

```ts
const embeddedConfig: EmbeddedConfig = {
  chatApiUrl,
  chatStreamProtocol: "data-stream",
  chatCredentials: "include",
  chatEnableFreeTierUpgrade: true,
};
```

## Documentation Updates

None — the free-tier upgrade UI isn't covered in public docs.

## Testing

- Typechecked `@mcp-use/inspector` via `tsc --noEmit`; no errors introduced.
- Formatted and linted the three touched files.
- No new unit tests: the inspector only has Playwright E2E tests, and this is a conditional-rendering change behind props not exercised in the existing `chat.test.ts` flows. A follow-up E2E that renders `ChatTab` with `managedLlmConfig` + no `enableFreeTierUpgrade` and asserts the model badge / "Model & usage" dialog are absent would be the right shape.
- Manual verification to perform in reviewers' browsers:
  - Hosted inspector (`inspector.manufact.com`): model badge + "Model & usage" modal still present.
  - Cloud dashboard server Chat tab: model badge and modal gone; cloud's own model selector in the header remains.

## Backwards Compatibility

Backwards compatible for the hosted inspector — `InspectorProvider` auto-seeds `chatEnableFreeTierUpgrade: true` so `inspector.manufact.com` behavior is unchanged.

Behavior **change** for third-party embedders who were relying on the previously-automatic free-tier UI: they now need to pass `enableFreeTierUpgrade` (prop) or `chatEnableFreeTierUpgrade: true` (embedded config) explicitly. This is the intended fix — the free-tier UI is Manufact-branded and should not appear automatically in unrelated embeds.

## Related Issues

N/A