### PR TITLE
fix(inspector): persist connection config in sessionStorage before OAuth redirect

### DIFF
--- a/libraries/typescript/.changeset/oauth-reconnect-session-storage.md
+++ b/libraries/typescript/.changeset/oauth-reconnect-session-storage.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+fix(inspector): store connection config in sessionStorage before OAuth redirect so auto-reconnect works without ?autoConnect param

--- a/libraries/typescript/packages/inspector/src/client/components/InspectorDashboard.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/InspectorDashboard.tsx
@@ -49,6 +49,7 @@ import {
 } from "@/client/utils/serverNames";
 import { useLocation, useNavigate } from "react-router";
 import { toast } from "sonner";
+import { INSPECTOR_RECONNECT_STORAGE_KEY } from "@/client/hooks/useAutoConnect";
 import { ConnectionSettingsForm } from "./ConnectionSettingsForm";
 import type { CustomHeader } from "./CustomHeadersEditor";
 import { ServerCapabilitiesModal } from "./ServerCapabilitiesModal";
@@ -1053,7 +1054,28 @@ export function InspectorDashboard() {
                         >
                           <a
                             href={connection.authUrl}
-                            onClick={(e) => e.stopPropagation()}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              // Store connection config so trySessionReconnect() can
+                              // resume after an OAuth redirect (when ?autoConnect is absent).
+                              try {
+                                sessionStorage.setItem(
+                                  INSPECTOR_RECONNECT_STORAGE_KEY,
+                                  JSON.stringify({
+                                    url: connection.url,
+                                    name:
+                                      connection.name ||
+                                      "Auto-connected Server",
+                                    transportType:
+                                      (connection as any).transportType ||
+                                      "http",
+                                    connectionType: "Direct",
+                                  })
+                                );
+                              } catch {
+                                /* sessionStorage unavailable — best-effort */
+                              }
+                            }}
                           >
                             Authenticate
                           </a>


### PR DESCRIPTION
## Problem

When completing an OAuth flow without `?autoConnect` in the URL, the inspector hangs trying to connect and eventually times out (#1389).

### Root cause

1. OAuth starts → `browser-provider.ts` stores `returnUrl = window.location.href` (no `autoConnect` param)
2. OAuth completes → callback redirects back to `returnUrl` (bare `/inspector`)
3. On reload → `useAutoConnect` finds no `?autoConnect` param, `sessionStorage` has no `INSPECTOR_RECONNECT_STORAGE_KEY` → does nothing
4. The connection is restored from localStorage but never tracked by `useAutoConnect`, so it hangs

## Fix

When the user clicks the **Authenticate** button, store the pending connection config in `sessionStorage` under `INSPECTOR_RECONNECT_STORAGE_KEY` — the same key already consumed by `trySessionReconnect()` in `useAutoConnect`. After the OAuth callback redirects back, the hook picks up the stored config and resumes the connection automatically.

This follows the same pattern the tunnel-restart reconnect flow uses in `LayoutHeader.tsx`.

### Changes

- **`InspectorDashboard.tsx`**: Import `INSPECTOR_RECONNECT_STORAGE_KEY` and write connection config to `sessionStorage` on Authenticate button click

Inspector-only change; no library code modified.

Closes #1389