### PR TITLE
fix(inspector): stop MCP App widget from overlaying chat header

### DIFF
--- a/libraries/typescript/.changeset/mcp-1741-widget-overlays-the-header.md
+++ b/libraries/typescript/.changeset/mcp-1741-widget-overlays-the-header.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Fix MCP App widget overlaying the chat header. Removed the explicit `z-20`/`z-10` stacking context from the sandboxed iframe wrappers in `MCPAppsRenderer` and `OpenAIComponentRenderer` so widgets scroll beneath the chat header instead of painting over it.

--- a/libraries/typescript/packages/inspector/src/client/components/MCPAppsRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/MCPAppsRenderer.tsx
@@ -1175,7 +1175,7 @@ function MCPAppsRendererBase({
                 displayMode === "fullscreen" && "w-full h-full rounded-none",
                 displayMode === "pip" && "w-full h-full",
                 displayMode !== "fullscreen" && prefersBorder && "rounded-lg",
-                "overflow-hidden relative z-20",
+                "overflow-hidden",
                 prefersBorder && "border border-zinc-200 dark:border-zinc-700"
               )}
               style={iframeStyle}

--- a/libraries/typescript/packages/inspector/src/client/components/OpenAIComponentRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/OpenAIComponentRenderer.tsx
@@ -1128,7 +1128,7 @@ function OpenAIComponentRendererBase({
 
         <div
           className={cn(
-            "flex-1 w-full flex justify-center items-center relative z-10",
+            "flex-1 w-full flex justify-center items-center relative",
             displayMode === "fullscreen" && "pt-14",
             centerVertically && "items-center",
             displayMode === "inline" && (invoking || invoked) && "pt-8"


### PR DESCRIPTION
# Pull Request Description
Before:
<img width="1258" height="285" alt="image" src="https://github.com/user-attachments/assets/fe8b5ffb-d524-44eb-ab11-ca8bdbde5638" />

After:
<img width="1258" height="285" alt="image" src="https://github.com/user-attachments/assets/182bba14-e727-4e14-b290-b70c7e4c0e84" />

## Language / Project Scope

Check all that apply:
- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

The MCP App widget was painting on top of the chat header when scrolling, making the "Chat" title, model badge, "Export", and "New Chat" controls unreachable. Dropped the explicit z-index classes on the sandboxed iframe wrappers so widgets stack beneath the header.

## Implementation Details

1. `MCPAppsRenderer.tsx` — removed `relative z-20` from the `SandboxedIframe` className. The `z-20` stacking context was added in a prior loading-state refactor but wasn't required: the spinner overlay already paints above the iframe through DOM/positioning order.
2. `OpenAIComponentRenderer.tsx` — removed `z-10` from the inner flex container (kept `relative` for the absolute-positioned status label child). The previous `z-10` tied with `ChatHeader`'s own `z-10` and won via DOM order.
3. Added a patch changeset for `@mcp-use/inspector`.

---

## TypeScript Checklist

### Packages Modified

- [ ] `docs`
- [ ] `tests`
- [ ] `cli`
- [ ] `create-mcp-use-app`
- [ ] `mcp-use` (server)
- [ ] `mcp-use` (client)
- [x] `inspector`

### Pre-commit Checklist

- [x] Ran `pnpm lint:fix` to auto-fix linting issues
- [x] Ran `pnpm format` to format code with Prettier
- [x] Ran typecheck (`tsc --noEmit -p tsconfig.client.json`) — clean
- [x] Ran `pnpm changeset` to create a changeset
- [ ] Added or updated tests if needed
- [ ] Updated documentation in `docs/` folder if needed

---

## Example Usage (Before)

```
When the chat scrolls past an MCP App widget, the widget is rendered on top of
the ChatHeader ("Chat" title, model badge, Export, New Chat buttons), making
those controls visually obscured and click-blocked.
```

## Example Usage (After)

```
Widget scrolls beneath the ChatHeader as expected. Header controls remain
fully visible and clickable.
```

## Documentation Updates

* None — internal stacking-context fix, no public API change.

## Testing

- Typecheck passes (`tsc --noEmit -p tsconfig.client.json`).
- Formatter/lint clean on both touched files.
- Manual visual verification: widget no longer overlays the chat header when scrolling.
- Spinner/skeleton overlays still render above the iframe during load (verified via DOM-order stacking).

## Backwards Compatibility

Fully backwards compatible — CSS-only change inside widget renderers.