### PR TITLE
feat(server): enrich MCP request logs with target, args, outcome, and duration

### DIFF
--- a/docs/typescript/server/configuration.mdx
+++ b/docs/typescript/server/configuration.mdx
@@ -76,7 +76,8 @@ The server reads the following environment variables at runtime:
 | `HOST` | Bind hostname | `localhost` |
 | `MCP_URL` | Full public base URL (for widget/asset URLs) | `http://{HOST}:{PORT}` |
 | `NODE_ENV` | `production` disables dev features (inspector, type generation) | — |
-| `DEBUG` | Enables verbose debug logging | — |
+| `DEBUG` | Logger verbosity (`1` = info logs, `2` = debug logs) | — |
+| `MCP_LOG_LEVEL` | Per-request log verbosity for `POST /mcp` (`info` \| `debug` \| `trace`) | `info` |
 | `CSP_URLS` | Comma-separated extra URLs added to widget CSP `resource_domains` | — |
 
 **OAuth providers** also read zero-config env vars — see the OAuth docs for the full list.

--- a/docs/typescript/server/configuration.mdx
+++ b/docs/typescript/server/configuration.mdx
@@ -76,7 +76,6 @@ The server reads the following environment variables at runtime:
 | `HOST` | Bind hostname | `localhost` |
 | `MCP_URL` | Full public base URL (for widget/asset URLs) | `http://{HOST}:{PORT}` |
 | `NODE_ENV` | `production` disables dev features (inspector, type generation) | — |
-| `DEBUG` | Logger verbosity (`1` = info logs, `2` = debug logs) | — |
 | `MCP_LOG_LEVEL` | Per-request log verbosity for `POST /mcp` (`info` \| `debug` \| `trace`) | `info` |
 | `CSP_URLS` | Comma-separated extra URLs added to widget CSP `resource_domains` | — |
 

--- a/docs/typescript/server/logging.mdx
+++ b/docs/typescript/server/logging.mdx
@@ -48,43 +48,25 @@ DEBUG=1 node server.js
 
 ### Verbose Debug Mode
 
-Enable debug-level Logger output:
+Raise the [built-in `Logger`](#built-in-logging-system) to `debug` for detailed lifecycle messages:
 
 ```bash
 DEBUG=2 node server.js
 ```
 
-This raises the [built-in `Logger`](#built-in-logging-system) to `debug`, surfacing detailed lifecycle messages.
-
-<Note>
-  Full JSON-RPC request/response body dumps for `POST /mcp` are now controlled
-  separately by `MCP_LOG_LEVEL=trace` — see [Per-Request Log Verbosity](#per-request-log-verbosity) below.
-</Note>
-
 ## Per-Request Log Verbosity
 
-The Hono middleware that logs every `POST /mcp` request emits a one-line summary by default. Verbosity is controlled by the `MCP_LOG_LEVEL` environment variable:
+`MCP_LOG_LEVEL` controls how much detail the `POST /mcp` request log line includes:
 
 | Level | Includes |
 | --- | --- |
-| `info` (default) | Target (tool/resource/prompt name or client info), session id, outcome (`OK` / `ERROR <code> <msg>` / `HTTP <code>`), duration |
+| `info` (default) | Target, session id, outcome, duration |
 | `debug` | `info` + inline `args={...}` for `tools/call` and `prompts/get` |
 | `trace` | `debug` + full request/response header & body dump |
 
-Args are hidden by default because they may carry PII or secrets — opt in with `MCP_LOG_LEVEL=debug` when you actively need them.
+Args are hidden at `info` because they can carry PII or secrets — opt in with `debug` when you need them.
 
-```bash
-# Default — no args, no body dump
-node server.js
-
-# Show inline args
-MCP_LOG_LEVEL=debug node server.js
-
-# Show full JSON-RPC request/response bodies
-MCP_LOG_LEVEL=trace node server.js
-```
-
-**Example output (default, `info`):**
+**`info` (default):**
 
 ```
 [12:34:56.789] POST /mcp [initialize: Claude/0.8.3] → session=abc12de OK (12ms)
@@ -92,7 +74,7 @@ MCP_LOG_LEVEL=trace node server.js
 [12:34:57.540] sess=abc12de POST /mcp [tools/call: fetch_url] ERROR -32603 Invalid API key (1203ms)
 ```
 
-**Example output (`debug`):**
+**`debug`:**
 
 ```
 [12:34:57.102] sess=abc12de POST /mcp [tools/call: create_invoice] args={"amount":100,"currency":"USD"} OK (87ms)
@@ -100,11 +82,6 @@ MCP_LOG_LEVEL=trace node server.js
 ```
 
 `trace` additionally prints the full request/response headers and bodies after each line.
-
-<Warning>
-  Prior versions surfaced the body dump whenever `DEBUG` was truthy. The body
-  dump now requires `MCP_LOG_LEVEL=trace` — `DEBUG` alone no longer enables it.
-</Warning>
 
 ## Built-in Logging System
 

--- a/docs/typescript/server/logging.mdx
+++ b/docs/typescript/server/logging.mdx
@@ -6,54 +6,6 @@ icon: "scroll-text"
 
 mcp-use provides comprehensive logging for MCP servers, making it easy to understand server activity, debug issues, and monitor production deployments.
 
-## Log Levels
-
-The server provides different logging levels through environment variables:
-
-### Production Mode (Default)
-
-Clean, informative logs showing MCP operations:
-
-```bash
-node server.js
-```
-
-**Output:**
-
-```
-[MCP] Server mounted at /mcp (Streamable HTTP Transport)
-[MCP] Session initialized: abc123
-[MCP] tools/call:analyze-sentiment completed in 234ms
-[MCP] Session closed: abc123
-```
-
-### Debug Mode
-
-Enable debug mode for development and troubleshooting:
-
-```bash
-DEBUG=1 node server.js
-```
-
-**Output:**
-
-```
-[MCP] Server initialized: my-server v1.0.0
-[MCP] Registered tool: analyze-sentiment
-[MCP] Registered resource: config://app-settings
-[MCP] Session initialized: abc123
-[MCP] tools/call:analyze-sentiment started
-[MCP] tools/call:analyze-sentiment completed in 234ms
-```
-
-### Verbose Debug Mode
-
-Raise the [built-in `Logger`](#built-in-logging-system) to `debug` for detailed lifecycle messages:
-
-```bash
-DEBUG=2 node server.js
-```
-
 ## Per-Request Log Verbosity
 
 `MCP_LOG_LEVEL` controls how much detail the `POST /mcp` request log line includes:

--- a/docs/typescript/server/logging.mdx
+++ b/docs/typescript/server/logging.mdx
@@ -48,34 +48,63 @@ DEBUG=1 node server.js
 
 ### Verbose Debug Mode
 
-Full request/response logging with JSON-RPC details:
+Enable debug-level Logger output:
 
 ```bash
 DEBUG=2 node server.js
 ```
 
-**Output:**
+This raises the [built-in `Logger`](#built-in-logging-system) to `debug`, surfacing detailed lifecycle messages.
+
+<Note>
+  Full JSON-RPC request/response body dumps for `POST /mcp` are now controlled
+  separately by `MCP_LOG_LEVEL=trace` — see [Per-Request Log Verbosity](#per-request-log-verbosity) below.
+</Note>
+
+## Per-Request Log Verbosity
+
+The Hono middleware that logs every `POST /mcp` request emits a one-line summary by default. Verbosity is controlled by the `MCP_LOG_LEVEL` environment variable:
+
+| Level | Includes |
+| --- | --- |
+| `info` (default) | Target (tool/resource/prompt name or client info), session id, outcome (`OK` / `ERROR <code> <msg>` / `HTTP <code>`), duration |
+| `debug` | `info` + inline `args={...}` for `tools/call` and `prompts/get` |
+| `trace` | `debug` + full request/response header & body dump |
+
+Args are hidden by default because they may carry PII or secrets — opt in with `MCP_LOG_LEVEL=debug` when you actively need them.
+
+```bash
+# Default — no args, no body dump
+node server.js
+
+# Show inline args
+MCP_LOG_LEVEL=debug node server.js
+
+# Show full JSON-RPC request/response bodies
+MCP_LOG_LEVEL=trace node server.js
+```
+
+**Example output (default, `info`):**
 
 ```
-[MCP] Session initialized: abc123
-[MCP] → Request: {
-  "jsonrpc": "2.0",
-  "id": 1,
-  "method": "tools/call",
-  "params": {
-    "name": "analyze-sentiment",
-    "arguments": { "text": "I love this!" }
-  }
-}
-[MCP] tools/call:analyze-sentiment completed in 234ms
-[MCP] ← Response: {
-  "jsonrpc": "2.0",
-  "id": 1,
-  "result": {
-    "content": [{ "type": "text", "text": "Sentiment: positive" }]
-  }
-}
+[12:34:56.789] POST /mcp [initialize: Claude/0.8.3] → session=abc12de OK (12ms)
+[12:34:57.102] sess=abc12de POST /mcp [tools/call: create_invoice] OK (87ms)
+[12:34:57.540] sess=abc12de POST /mcp [tools/call: fetch_url] ERROR -32603 Invalid API key (1203ms)
 ```
+
+**Example output (`debug`):**
+
+```
+[12:34:57.102] sess=abc12de POST /mcp [tools/call: create_invoice] args={"amount":100,"currency":"USD"} OK (87ms)
+[12:34:57.540] sess=abc12de POST /mcp [tools/call: fetch_url] args={"url":"https://…"} ERROR -32603 Invalid API key (1203ms)
+```
+
+`trace` additionally prints the full request/response headers and bodies after each line.
+
+<Warning>
+  Prior versions surfaced the body dump whenever `DEBUG` was truthy. The body
+  dump now requires `MCP_LOG_LEVEL=trace` — `DEBUG` alone no longer enables it.
+</Warning>
 
 ## Built-in Logging System
 

--- a/libraries/typescript/.changeset/improve-mcp-server-request-logs.md
+++ b/libraries/typescript/.changeset/improve-mcp-server-request-logs.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Improve MCP server request logs: show the JSON-RPC target (tool/resource/prompt name, or client info for initialize) inside the bracket, inline arguments for `tools/call` and `prompts/get`, session id correlation prefix, JSON-RPC error code and message for failed calls, and request duration. The outcome (`OK` / `ERROR <code> <msg>` / `HTTP <code>`) now reflects the actual RPC result instead of just the HTTP status, so failing tool calls no longer appear as `200`.

--- a/libraries/typescript/.changeset/improve-mcp-server-request-logs.md
+++ b/libraries/typescript/.changeset/improve-mcp-server-request-logs.md
@@ -2,4 +2,11 @@
 "mcp-use": patch
 ---
 
-Improve MCP server request logs: show the JSON-RPC target (tool/resource/prompt name, or client info for initialize) inside the bracket, inline arguments for `tools/call` and `prompts/get`, session id correlation prefix, JSON-RPC error code and message for failed calls, and request duration. The outcome (`OK` / `ERROR <code> <msg>` / `HTTP <code>`) now reflects the actual RPC result instead of just the HTTP status, so failing tool calls no longer appear as `200`.
+Improve MCP server request logs: show the JSON-RPC target (tool/resource/prompt name, or client info for initialize) inside the bracket, session id correlation prefix, JSON-RPC error code and message for failed calls, and request duration. The outcome (`OK` / `ERROR <code> <msg>` / `HTTP <code>`) now reflects the actual RPC result instead of just the HTTP status, so failing tool calls no longer appear as `200`.
+
+Verbosity is tiered via the new `MCP_LOG_LEVEL` env var (`info` | `debug` | `trace`):
+- `info` (default) — target, outcome, duration. Args are hidden by default since they can carry PII or secrets.
+- `debug` — adds inline arguments for `tools/call` and `prompts/get`.
+- `trace` — adds the verbose request/response header & body dump.
+
+The previous `DEBUG=1` env var no longer controls the request logger; set `MCP_LOG_LEVEL=trace` instead to get the verbose body dump.

--- a/libraries/typescript/.changeset/improve-mcp-server-request-logs.md
+++ b/libraries/typescript/.changeset/improve-mcp-server-request-logs.md
@@ -8,5 +8,3 @@ Verbosity is tiered via the new `MCP_LOG_LEVEL` env var (`info` | `debug` | `tra
 - `info` (default) — target, outcome, duration. Args are hidden by default since they can carry PII or secrets.
 - `debug` — adds inline arguments for `tools/call` and `prompts/get`.
 - `trace` — adds the verbose request/response header & body dump.
-
-The previous `DEBUG=1` env var no longer controls the request logger; set `MCP_LOG_LEVEL=trace` instead to get the verbose body dump.

--- a/libraries/typescript/packages/mcp-use/src/server/logging.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/logging.ts
@@ -433,7 +433,8 @@ export async function requestLogger(c: Context, next: Next): Promise<void> {
     const tail = ` ${renderOutcome(outcome)} ${chalk.dim(`(${durationMs}ms)`)}`;
     const argsPart = args !== null ? ` args=${args}` : "";
     const argsOnNewLine =
-      args !== null && visibleLength(head + argsPart + tail) > MAX_INLINE_LENGTH;
+      args !== null &&
+      visibleLength(head + argsPart + tail) > MAX_INLINE_LENGTH;
 
     if (argsOnNewLine) {
       line = `${head}${tail}\n    args=${args}`;

--- a/libraries/typescript/packages/mcp-use/src/server/logging.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/logging.ts
@@ -13,6 +13,8 @@ const MAX_ARGS_TOTAL_LENGTH = 2000;
 const MAX_TRACE_STRING_LENGTH = 100;
 /** Stop descending into nested args past this depth. */
 const MAX_ARG_DEPTH = 3;
+/** Cap how many bytes of a POST /mcp response we peek for outcome detection. JSON-RPC error envelopes are tiny; large tool results are truncated and treated as `OK`. */
+const MAX_RESPONSE_PEEK_BYTES = 64 * 1024;
 
 /**
  * Verbosity tier for the request logger:
@@ -23,13 +25,28 @@ const MAX_ARG_DEPTH = 3;
 export type LogLevel = "info" | "debug" | "trace";
 
 /**
- * Resolve the effective log level from environment via `MCP_LOG_LEVEL`
- * (`info` | `debug` | `trace`, case-insensitive). Unset or unrecognized → `info`.
+ * Resolve the effective log level from environment.
+ *
+ * Primary control is `MCP_LOG_LEVEL` (`info` | `debug` | `trace`, case-insensitive).
+ * As a legacy fallback, a truthy `DEBUG` env var maps to `trace` so existing setups
+ * that relied on `DEBUG=1` for the verbose body dump keep working. `MCP_LOG_LEVEL`
+ * always wins when set; new docs and examples should reference it.
+ *
+ * Unset / unrecognized → `info`.
  */
 export function getLogLevel(): LogLevel {
   const explicit = getEnv("MCP_LOG_LEVEL")?.toLowerCase();
   if (explicit === "info" || explicit === "debug" || explicit === "trace") {
     return explicit;
+  }
+  const debug = getEnv("DEBUG");
+  if (
+    debug !== undefined &&
+    debug !== "" &&
+    debug !== "0" &&
+    debug.toLowerCase() !== "false"
+  ) {
+    return "trace";
   }
   return "info";
 }
@@ -237,6 +254,47 @@ function renderOutcome(outcome: Outcome): string {
   }
 }
 
+/**
+ * Read up to `maxBytes` from a Response body, then cancel the stream. The returned
+ * text may be a UTF-8-decoded prefix of the full body; callers must tolerate
+ * truncated JSON (in which case `detectOutcome` falls back to `ok`). Reading from a
+ * cloned response is required so the original body remains intact for the client.
+ */
+async function peekResponseText(
+  response: Response,
+  maxBytes: number
+): Promise<string | null> {
+  if (!response.body) return null;
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (total < maxBytes) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+      total += value.length;
+    }
+  } finally {
+    reader.cancel().catch(() => {});
+  }
+  if (total === 0) return null;
+  const out = new Uint8Array(Math.min(total, maxBytes));
+  let offset = 0;
+  for (const chunk of chunks) {
+    if (offset >= out.length) break;
+    const space = out.length - offset;
+    if (chunk.length <= space) {
+      out.set(chunk, offset);
+      offset += chunk.length;
+    } else {
+      out.set(chunk.subarray(0, space), offset);
+      offset = out.length;
+    }
+  }
+  return new TextDecoder().decode(out);
+}
+
 function colorHttpStatus(statusCode: number): string {
   const text = String(statusCode);
   if (statusCode >= 200 && statusCode < 300) return chalk.green(text);
@@ -292,7 +350,11 @@ export async function requestLogger(c: Context, next: Next): Promise<void> {
     return;
   }
 
-  // Get request body for logging
+  // Get request body for logging.
+  // Parsing is gated to POST /mcp (where we need it for the line composition) and
+  // trace mode (where the body dump applies to all routes). Other POST/PUT/PATCH
+  // requests skip the parse so we don't double-buffer their bodies on every request.
+  const isMcpPost = method === "POST" && pathname === "/mcp";
   let requestBody: any = null;
   let requestHeaders: Record<string, string> = {};
 
@@ -304,8 +366,7 @@ export async function requestLogger(c: Context, next: Next): Promise<void> {
     }
   }
 
-  // Get request body (for MCP method logging or full debug logging)
-  if (method !== "GET" && method !== "HEAD") {
+  if ((isMcpPost || traceMode) && method !== "GET" && method !== "HEAD") {
     try {
       // Clone the request to avoid consuming the original body stream
       const clonedRequest = c.req.raw.clone();
@@ -323,15 +384,15 @@ export async function requestLogger(c: Context, next: Next): Promise<void> {
   const durationMs = Math.round(performance.now() - startMs);
 
   const statusCode = c.res.status;
-  const isMcpPost = method === "POST" && pathname === "/mcp";
 
   // Peek response body for outcome detection (POST /mcp only — always JSON, never SSE).
-  // Safe to .text() because GET /mcp (SSE) is already filtered out above.
+  // Capped at MAX_RESPONSE_PEEK_BYTES so a multi-MB tool result doesn't get fully
+  // buffered just to inspect `result.isError`; truncated JSON falls through to `ok`.
   let responseText: string | null = null;
   if (isMcpPost) {
     try {
       const cloned = c.res.clone();
-      responseText = await cloned.text().catch(() => null);
+      responseText = await peekResponseText(cloned, MAX_RESPONSE_PEEK_BYTES);
     } catch {
       // Ignore; outcome falls back to OK / HTTP status.
     }

--- a/libraries/typescript/packages/mcp-use/src/server/logging.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/logging.ts
@@ -185,30 +185,58 @@ export function detectOutcome(
     return { kind: "http", status: statusCode };
   }
   if (!responseText) return { kind: "ok" };
-  let body: any;
-  try {
-    body = JSON.parse(responseText);
-  } catch {
-    return { kind: "ok" };
-  }
-  // JSON-RPC batch responses come back as arrays; the first error wins for display.
-  const items = Array.isArray(body) ? body : [body];
-  for (const item of items) {
+  // First error wins for display across batch/SSE responses.
+  for (const item of parseJsonRpcPayloads(responseText)) {
     if (!item || typeof item !== "object") continue;
-    if (item.error && typeof item.error === "object") {
+    const env = item as { error?: any; result?: any };
+    if (env.error && typeof env.error === "object") {
       return {
         kind: "rpc-error",
-        code: typeof item.error.code === "number" ? item.error.code : null,
-        message: truncateMessage(String(item.error.message ?? "unknown error")),
+        code: typeof env.error.code === "number" ? env.error.code : null,
+        message: truncateMessage(String(env.error.message ?? "unknown error")),
       };
     }
-    const result = item.result;
+    const result = env.result;
     if (result && typeof result === "object" && result.isError === true) {
       const msg = extractToolErrorMessage(result) ?? "tool reported error";
       return { kind: "rpc-error", code: null, message: truncateMessage(msg) };
     }
   }
   return { kind: "ok" };
+}
+
+/**
+ * Parse a POST /mcp response body into JSON-RPC envelopes. Handles three shapes:
+ * - Plain JSON object (`{...}`) — when the client sent `Accept: application/json`.
+ * - JSON-RPC batch array (`[{...}, ...]`).
+ * - SSE event stream (`event: message\ndata: {...}\n\n`) — the default when
+ *   clients accept `text/event-stream`, which official MCP clients do.
+ *
+ * Returns an empty array when nothing parseable is found; callers should fall
+ * through to `ok` in that case.
+ */
+function parseJsonRpcPayloads(text: string): unknown[] {
+  const trimmed = text.trimStart();
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+    try {
+      const parsed = JSON.parse(text);
+      return Array.isArray(parsed) ? parsed : [parsed];
+    } catch {
+      return [];
+    }
+  }
+  const out: unknown[] = [];
+  for (const line of text.split(/\r?\n/)) {
+    if (!line.startsWith("data:")) continue;
+    const payload = line.slice(5).trimStart();
+    if (!payload) continue;
+    try {
+      out.push(JSON.parse(payload));
+    } catch {
+      // Ignore malformed data lines — partial frames or non-JSON keepalives.
+    }
+  }
+  return out;
 }
 
 function extractToolErrorMessage(result: any): string | null {

--- a/libraries/typescript/packages/mcp-use/src/server/logging.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/logging.ts
@@ -1,6 +1,16 @@
+import chalk from "chalk";
 import type { Context, Next } from "hono";
 
 import { getEnv } from "./utils/runtime.js";
+
+/** If the rendered line would exceed this many plain characters, spill args to an indented second line. */
+const MAX_INLINE_LENGTH = 160;
+/** Cap error messages so a huge error body can't blow up the log line. */
+const MAX_ERROR_MESSAGE_LENGTH = 200;
+/** Truncate individual string values inside rendered args. */
+const MAX_ARG_STRING_LENGTH = 100;
+/** Stop descending into nested args past this depth. */
+const MAX_ARG_DEPTH = 3;
 
 /**
  * Check if DEBUG mode is enabled via environment variable
@@ -16,12 +26,12 @@ function isDebugMode(): boolean {
 }
 
 /**
- * Format an object for logging (pretty-print JSON)
+ * Format an object for pretty-printed JSON logging (used by DEBUG-mode body dumps).
  */
 function formatForLogging(obj: any): string {
   function truncate(val: any): any {
-    if (typeof val === "string" && val.length > 100) {
-      return val.slice(0, 100) + "...";
+    if (typeof val === "string" && val.length > MAX_ARG_STRING_LENGTH) {
+      return val.slice(0, MAX_ARG_STRING_LENGTH) + "...";
     } else if (Array.isArray(val)) {
       return val.map(truncate);
     } else if (val && typeof val === "object") {
@@ -43,10 +53,192 @@ function formatForLogging(obj: any): string {
 }
 
 /**
- * Middleware that logs incoming HTTP requests with a timestamp, color-coded status code, and optional debug details.
+ * Deeply truncate long strings and cap recursion for compact single-line arg rendering.
+ */
+function truncateCompact(val: any, depth = 0): any {
+  if (typeof val === "string" && val.length > MAX_ARG_STRING_LENGTH) {
+    return val.slice(0, MAX_ARG_STRING_LENGTH) + "...";
+  }
+  if (depth >= MAX_ARG_DEPTH) {
+    if (Array.isArray(val)) return val.length === 0 ? [] : ["..."];
+    if (val && typeof val === "object") return "{...}";
+    return val;
+  }
+  if (Array.isArray(val)) return val.map((v) => truncateCompact(v, depth + 1));
+  if (val && typeof val === "object") {
+    const result: Record<string, any> = {};
+    for (const key in val) {
+      if (Object.prototype.hasOwnProperty.call(val, key)) {
+        result[key] = truncateCompact(val[key], depth + 1);
+      }
+    }
+    return result;
+  }
+  return val;
+}
+
+/**
+ * Extract a human-readable target from a parsed JSON-RPC request body:
+ * tool name for `tools/call`, resource URI for `resources/read`, client name/version
+ * for `initialize`, etc. Returns null when the method has no natural target.
+ */
+export function extractTarget(body: any): string | null {
+  if (!body || typeof body !== "object") return null;
+  const method: unknown = body.method;
+  if (typeof method !== "string") return null;
+  const params = body.params;
+  switch (method) {
+    case "initialize": {
+      const info = params?.clientInfo;
+      if (!info || typeof info !== "object") return null;
+      const name = typeof info.name === "string" ? info.name : null;
+      const version = typeof info.version === "string" ? info.version : null;
+      if (name && version) return `${name}/${version}`;
+      return name ?? version;
+    }
+    case "tools/call":
+    case "prompts/get":
+      return typeof params?.name === "string" ? params.name : null;
+    case "resources/read":
+    case "resources/subscribe":
+    case "resources/unsubscribe":
+      return typeof params?.uri === "string" ? params.uri : null;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Render `params.arguments` as compact single-line JSON for `tools/call` / `prompts/get`.
+ * Returns null for other methods, missing/empty arguments, or non-serializable values.
+ */
+export function renderArgs(body: any): string | null {
+  if (!body || typeof body !== "object") return null;
+  if (body.method !== "tools/call" && body.method !== "prompts/get")
+    return null;
+  const args = body.params?.arguments;
+  if (args === undefined || args === null) return null;
+  if (typeof args !== "object") return null;
+  if (
+    Array.isArray(args) ? args.length === 0 : Object.keys(args).length === 0
+  ) {
+    return null;
+  }
+  try {
+    return JSON.stringify(truncateCompact(args));
+  } catch {
+    return null;
+  }
+}
+
+export type Outcome =
+  | { kind: "ok" }
+  | { kind: "rpc-error"; code: number | null; message: string }
+  | { kind: "http"; status: number };
+
+/**
+ * Decide whether a POST /mcp request succeeded, returned a JSON-RPC error, reported
+ * a tool-level error (`result.isError`), or failed at the HTTP layer.
+ */
+export function detectOutcome(
+  statusCode: number,
+  responseText: string | null
+): Outcome {
+  if (statusCode < 200 || statusCode >= 300) {
+    return { kind: "http", status: statusCode };
+  }
+  if (!responseText) return { kind: "ok" };
+  let body: any;
+  try {
+    body = JSON.parse(responseText);
+  } catch {
+    return { kind: "ok" };
+  }
+  // JSON-RPC batch responses come back as arrays; the first error wins for display.
+  const items = Array.isArray(body) ? body : [body];
+  for (const item of items) {
+    if (!item || typeof item !== "object") continue;
+    if (item.error && typeof item.error === "object") {
+      return {
+        kind: "rpc-error",
+        code: typeof item.error.code === "number" ? item.error.code : null,
+        message: truncateMessage(String(item.error.message ?? "unknown error")),
+      };
+    }
+    const result = item.result;
+    if (result && typeof result === "object" && result.isError === true) {
+      const msg = extractToolErrorMessage(result) ?? "tool reported error";
+      return { kind: "rpc-error", code: null, message: truncateMessage(msg) };
+    }
+  }
+  return { kind: "ok" };
+}
+
+function extractToolErrorMessage(result: any): string | null {
+  const content = result?.content;
+  if (!Array.isArray(content)) return null;
+  for (const item of content) {
+    if (item && typeof item === "object" && typeof item.text === "string") {
+      return item.text;
+    }
+  }
+  return null;
+}
+
+function truncateMessage(msg: string): string {
+  return msg.length > MAX_ERROR_MESSAGE_LENGTH
+    ? msg.slice(0, MAX_ERROR_MESSAGE_LENGTH) + "..."
+    : msg;
+}
+
+function plainOutcome(outcome: Outcome): string {
+  switch (outcome.kind) {
+    case "ok":
+      return "OK";
+    case "rpc-error":
+      return `ERROR${outcome.code !== null ? ` ${outcome.code}` : ""} ${outcome.message}`;
+    case "http":
+      return `HTTP ${outcome.status}`;
+    default:
+      return "";
+  }
+}
+
+function renderOutcome(outcome: Outcome): string {
+  switch (outcome.kind) {
+    case "ok":
+      return chalk.green("OK");
+    case "rpc-error": {
+      const codePart = outcome.code !== null ? ` ${outcome.code}` : "";
+      return chalk.red(`ERROR${codePart} ${outcome.message}`);
+    }
+    case "http": {
+      const text = `HTTP ${outcome.status}`;
+      if (outcome.status >= 500) return chalk.magenta(text);
+      if (outcome.status >= 300 && outcome.status < 400)
+        return chalk.yellow(text);
+      return chalk.red(text);
+    }
+    default:
+      return "";
+  }
+}
+
+function colorHttpStatus(statusCode: number): string {
+  const text = String(statusCode);
+  if (statusCode >= 200 && statusCode < 300) return chalk.green(text);
+  if (statusCode >= 300 && statusCode < 400) return chalk.yellow(text);
+  if (statusCode >= 400 && statusCode < 500) return chalk.red(text);
+  if (statusCode >= 500) return chalk.magenta(text);
+  return text;
+}
+
+/**
+ * Middleware that logs incoming HTTP requests with a timestamp, color-coded outcome,
+ * duration, and (for POST /mcp) the JSON-RPC method + target + args + RPC-level error.
  *
- * Skips logging for inspector telemetry and RPC endpoints under /inspector/api/tel/, /inspector/api/rpc/stream, and /inspector/api/rpc/log.
- * For POST requests to /mcp, includes the MCP method name when present. When DEBUG is enabled, logs request headers/body and response headers/body.
+ * Skips logging for inspector telemetry, inspector UI/assets, and SSE endpoints.
+ * When DEBUG is enabled, also logs request headers/body and response headers/body.
  *
  * @param c - Hono context for the current request/response
  * @param next - Next middleware function to invoke
@@ -109,46 +301,109 @@ export async function requestLogger(c: Context, next: Next): Promise<void> {
     }
   }
 
+  const startMs = performance.now();
   await next();
+  const durationMs = Math.round(performance.now() - startMs);
 
-  // Get status code from response
   const statusCode = c.res.status;
-  let statusColor = "";
+  const isMcpPost = method === "POST" && url.includes("/mcp");
 
-  if (statusCode >= 200 && statusCode < 300) {
-    statusColor = "\x1b[32m"; // Green for 2xx
-  } else if (statusCode >= 300 && statusCode < 400) {
-    statusColor = "\x1b[33m"; // Yellow for 3xx
-  } else if (statusCode >= 400 && statusCode < 500) {
-    statusColor = "\x1b[31m"; // Red for 4xx
-  } else if (statusCode >= 500) {
-    statusColor = "\x1b[35m"; // Magenta for 5xx
+  // Peek response body for outcome detection (POST /mcp only — always JSON, never SSE).
+  // Safe to .text() because GET /mcp (SSE) is already filtered out above.
+  let responseText: string | null = null;
+  if (isMcpPost) {
+    try {
+      const cloned = c.res.clone();
+      responseText = await cloned.text().catch(() => null);
+    } catch {
+      // Ignore; outcome falls back to OK / HTTP status.
+    }
   }
 
-  // Add MCP method info for POST requests to /mcp
-  let logMessage = `[${timestamp}] ${method} \x1b[1m${new URL(url).pathname}\x1b[0m`;
-  if (method === "POST" && url.includes("/mcp") && requestBody?.method) {
-    logMessage += ` \x1b[1m[${requestBody.method}]\x1b[0m`;
-  }
-  logMessage += ` ${statusColor}${statusCode}\x1b[0m`;
+  // mcp-session-id lives in the request header for established sessions and in the
+  // response header on the initialize round-trip.
+  const sessionId =
+    c.req.header("mcp-session-id") ??
+    c.res.headers.get("mcp-session-id") ??
+    null;
+  const sessionTag = sessionId ? sessionId.slice(0, 7) : null;
 
-  console.log(logMessage);
+  let line: string;
+
+  if (isMcpPost && requestBody && typeof requestBody === "object") {
+    const rpcMethod: string | undefined =
+      typeof (requestBody as any).method === "string"
+        ? (requestBody as any).method
+        : undefined;
+    const target = extractTarget(requestBody);
+    const args = renderArgs(requestBody);
+    const outcome = detectOutcome(statusCode, responseText);
+
+    const showSessionPrefix = sessionTag !== null && rpcMethod !== "initialize";
+    const showSessionSuffix = sessionTag !== null && rpcMethod === "initialize";
+
+    // Plain (color-free) parts — used to decide whether args spill to a second line.
+    const sessionPrefixPlain = showSessionPrefix ? `sess=${sessionTag} ` : "";
+    const bracketPlain = rpcMethod
+      ? target
+        ? ` [${rpcMethod}: ${target}]`
+        : ` [${rpcMethod}]`
+      : "";
+    const sessionSuffixPlain = showSessionSuffix
+      ? ` → session=${sessionTag}`
+      : "";
+    const headPlain = `[${timestamp}] ${sessionPrefixPlain}${method} ${pathname}${bracketPlain}${sessionSuffixPlain}`;
+    const argsPlain = args ? ` args=${args}` : "";
+    const tailPlain = ` ${plainOutcome(outcome)} (${durationMs}ms)`;
+    const argsOnNewLine =
+      args !== null &&
+      headPlain.length + argsPlain.length + tailPlain.length >
+        MAX_INLINE_LENGTH;
+
+    // Rendered (colored) parts.
+    const sessionPrefixRendered = showSessionPrefix
+      ? chalk.dim(`sess=${sessionTag}`) + " "
+      : "";
+    const bracketRendered = rpcMethod
+      ? target
+        ? " " + chalk.bold(`[${rpcMethod}: ${target}]`)
+        : " " + chalk.bold(`[${rpcMethod}]`)
+      : "";
+    const sessionSuffixRendered = showSessionSuffix
+      ? " " + chalk.dim(`→ session=${sessionTag}`)
+      : "";
+    const head = `[${timestamp}] ${sessionPrefixRendered}${method} ${chalk.bold(pathname)}${bracketRendered}${sessionSuffixRendered}`;
+    const outcomeRendered = renderOutcome(outcome);
+    const durationRendered = chalk.dim(`(${durationMs}ms)`);
+
+    if (args !== null && argsOnNewLine) {
+      line = `${head} ${outcomeRendered} ${durationRendered}\n    args: ${args}`;
+    } else if (args !== null) {
+      line = `${head} args=${args} ${outcomeRendered} ${durationRendered}`;
+    } else {
+      line = `${head} ${outcomeRendered} ${durationRendered}`;
+    }
+  } else {
+    line = `[${timestamp}] ${method} ${chalk.bold(pathname)} ${colorHttpStatus(statusCode)} ${chalk.dim(`(${durationMs}ms)`)}`;
+  }
+
+  console.log(line);
 
   // Debug mode: log detailed request/response information
   if (debugMode) {
-    console.log("\n\x1b[36m" + "=".repeat(80) + "\x1b[0m");
-    console.log("\x1b[1m\x1b[36m[DEBUG] Request Details\x1b[0m");
-    console.log("\x1b[36m" + "-".repeat(80) + "\x1b[0m");
+    console.log("\n" + chalk.cyan("=".repeat(80)));
+    console.log(chalk.bold.cyan("[DEBUG] Request Details"));
+    console.log(chalk.cyan("-".repeat(80)));
 
     // Request headers
     if (Object.keys(requestHeaders).length > 0) {
-      console.log("\x1b[33mRequest Headers:\x1b[0m");
+      console.log(chalk.yellow("Request Headers:"));
       console.log(formatForLogging(requestHeaders));
     }
 
     // Request body
     if (requestBody !== null) {
-      console.log("\x1b[33mRequest Body:\x1b[0m");
+      console.log(chalk.yellow("Request Body:"));
       if (typeof requestBody === "string") {
         console.log(requestBody);
       } else {
@@ -162,7 +417,7 @@ export async function requestLogger(c: Context, next: Next): Promise<void> {
       responseHeaders[key] = value;
     });
     if (Object.keys(responseHeaders).length > 0) {
-      console.log("\x1b[33mResponse Headers:\x1b[0m");
+      console.log(chalk.yellow("Response Headers:"));
       console.log(formatForLogging(responseHeaders));
     }
 
@@ -177,7 +432,7 @@ export async function requestLogger(c: Context, next: Next): Promise<void> {
           const responseBody = await clonedResponse.text().catch(() => null);
 
           if (responseBody !== null && responseBody.length > 0) {
-            console.log("\x1b[33mResponse Body:\x1b[0m");
+            console.log(chalk.yellow("Response Body:"));
             // Try to parse as JSON for pretty printing
             try {
               const jsonBody = JSON.parse(responseBody);
@@ -195,20 +450,22 @@ export async function requestLogger(c: Context, next: Next): Promise<void> {
               }
             }
           } else {
-            console.log("\x1b[33mResponse Body:\x1b[0m (empty)");
+            console.log(chalk.yellow("Response Body:") + " (empty)");
           }
         } catch (cloneError) {
           // If cloning fails (e.g., response already consumed), log that
-          console.log("\x1b[33mResponse Body:\x1b[0m (unable to clone/read)");
+          console.log(
+            chalk.yellow("Response Body:") + " (unable to clone/read)"
+          );
         }
       } else {
-        console.log("\x1b[33mResponse Body:\x1b[0m (no body)");
+        console.log(chalk.yellow("Response Body:") + " (no body)");
       }
     } catch (error) {
       // If we can't read the response body, log that
-      console.log("\x1b[33mResponse Body:\x1b[0m (unable to read)");
+      console.log(chalk.yellow("Response Body:") + " (unable to read)");
     }
 
-    console.log("\x1b[36m" + "=".repeat(80) + "\x1b[0m\n");
+    console.log(chalk.cyan("=".repeat(80)) + "\n");
   }
 }

--- a/libraries/typescript/packages/mcp-use/src/server/logging.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/logging.ts
@@ -15,6 +15,13 @@ const MAX_TRACE_STRING_LENGTH = 100;
 const MAX_ARG_DEPTH = 3;
 /** Cap how many bytes of a POST /mcp response we peek for outcome detection. JSON-RPC error envelopes are tiny; large tool results are truncated and treated as `OK`. */
 const MAX_RESPONSE_PEEK_BYTES = 64 * 1024;
+/** Cap raw (non-JSON) trace-mode response body output. */
+const MAX_TRACE_BODY_LENGTH = 10000;
+
+const ANSI_PATTERN = /\x1B\[[0-9;]*m/g;
+function visibleLength(s: string): number {
+  return s.replace(ANSI_PATTERN, "").length;
+}
 
 /**
  * Verbosity tier for the request logger:
@@ -221,19 +228,6 @@ function truncateMessage(msg: string): string {
     : msg;
 }
 
-function plainOutcome(outcome: Outcome): string {
-  switch (outcome.kind) {
-    case "ok":
-      return "OK";
-    case "rpc-error":
-      return `ERROR${outcome.code !== null ? ` ${outcome.code}` : ""} ${outcome.message}`;
-    case "http":
-      return `HTTP ${outcome.status}`;
-    default:
-      return "";
-  }
-}
-
 function renderOutcome(outcome: Outcome): string {
   switch (outcome.kind) {
     case "ok":
@@ -249,8 +243,6 @@ function renderOutcome(outcome: Outcome): string {
         return chalk.yellow(text);
       return chalk.red(text);
     }
-    default:
-      return "";
   }
 }
 
@@ -319,13 +311,12 @@ function colorHttpStatus(statusCode: number): string {
 export async function requestLogger(c: Context, next: Next): Promise<void> {
   const timestamp = new Date().toISOString().substring(11, 23);
   const method = c.req.method;
-  const url = c.req.url;
   const logLevel = getLogLevel();
   const showArgs = logLevel === "debug" || logLevel === "trace";
   const traceMode = logLevel === "trace";
 
   // Filter out noisy endpoints that create log spam
-  const pathname = new URL(url).pathname;
+  const pathname = c.req.path;
   const noisyPaths = [
     "/inspector/api/tel/", // Telemetry endpoints (posthog, scarf)
     "/inspector/api/rpc/stream", // RPC stream (SSE)
@@ -359,7 +350,6 @@ export async function requestLogger(c: Context, next: Next): Promise<void> {
   let requestHeaders: Record<string, string> = {};
 
   if (traceMode) {
-    // Log request headers - c.req.header() without args returns all headers
     const allHeaders = c.req.header();
     if (allHeaders) {
       requestHeaders = allHeaders;
@@ -367,15 +357,19 @@ export async function requestLogger(c: Context, next: Next): Promise<void> {
   }
 
   if ((isMcpPost || traceMode) && method !== "GET" && method !== "HEAD") {
-    try {
-      // Clone the request to avoid consuming the original body stream
-      const clonedRequest = c.req.raw.clone();
-      requestBody = await clonedRequest.json().catch(() => {
-        // If JSON parsing fails, try to get as text
-        return clonedRequest.text().catch(() => null);
-      });
-    } catch {
-      // Ignore errors
+    // Read text first so a failed JSON.parse can fall back to the raw string —
+    // calling .json() then .text() on the same clone fails because .json()
+    // consumes the body stream even when parsing throws.
+    const text = await c.req.raw
+      .clone()
+      .text()
+      .catch(() => null);
+    if (text !== null && text.length > 0) {
+      try {
+        requestBody = JSON.parse(text);
+      } catch {
+        requestBody = text;
+      }
     }
   }
 
@@ -385,14 +379,18 @@ export async function requestLogger(c: Context, next: Next): Promise<void> {
 
   const statusCode = c.res.status;
 
-  // Peek response body for outcome detection (POST /mcp only — always JSON, never SSE).
-  // Capped at MAX_RESPONSE_PEEK_BYTES so a multi-MB tool result doesn't get fully
-  // buffered just to inspect `result.isError`; truncated JSON falls through to `ok`.
+  // Read response body for outcome detection (POST /mcp only — always JSON, never SSE).
+  // In info/debug mode, cap at MAX_RESPONSE_PEEK_BYTES so a multi-MB tool result
+  // doesn't get fully buffered just to inspect `result.isError`; truncated JSON falls
+  // through to `ok`. In trace mode we read the full body once and reuse it for the
+  // body dump below, avoiding a second clone.
   let responseText: string | null = null;
   if (isMcpPost) {
     try {
       const cloned = c.res.clone();
-      responseText = await peekResponseText(cloned, MAX_RESPONSE_PEEK_BYTES);
+      responseText = traceMode
+        ? await cloned.text().catch(() => null)
+        : await peekResponseText(cloned, MAX_RESPONSE_PEEK_BYTES);
     } catch {
       // Ignore; outcome falls back to OK / HTTP status.
     }
@@ -420,46 +418,27 @@ export async function requestLogger(c: Context, next: Next): Promise<void> {
     const showSessionPrefix = sessionTag !== null && rpcMethod !== "initialize";
     const showSessionSuffix = sessionTag !== null && rpcMethod === "initialize";
 
-    // Plain (color-free) parts — used to decide whether args spill to a second line.
-    const sessionPrefixPlain = showSessionPrefix ? `sess=${sessionTag} ` : "";
-    const bracketPlain = rpcMethod
-      ? target
-        ? ` [${rpcMethod}: ${target}]`
-        : ` [${rpcMethod}]`
-      : "";
-    const sessionSuffixPlain = showSessionSuffix
-      ? ` → session=${sessionTag}`
-      : "";
-    const headPlain = `[${timestamp}] ${sessionPrefixPlain}${method} ${pathname}${bracketPlain}${sessionSuffixPlain}`;
-    const argsPlain = args ? ` args=${args}` : "";
-    const tailPlain = ` ${plainOutcome(outcome)} (${durationMs}ms)`;
-    const argsOnNewLine =
-      args !== null &&
-      headPlain.length + argsPlain.length + tailPlain.length >
-        MAX_INLINE_LENGTH;
-
-    // Rendered (colored) parts.
-    const sessionPrefixRendered = showSessionPrefix
+    const sessionPrefix = showSessionPrefix
       ? chalk.dim(`sess=${sessionTag}`) + " "
       : "";
-    const bracketRendered = rpcMethod
+    const bracket = rpcMethod
       ? target
         ? " " + chalk.bold(`[${rpcMethod}: ${target}]`)
         : " " + chalk.bold(`[${rpcMethod}]`)
       : "";
-    const sessionSuffixRendered = showSessionSuffix
+    const sessionSuffix = showSessionSuffix
       ? " " + chalk.dim(`→ session=${sessionTag}`)
       : "";
-    const head = `[${timestamp}] ${sessionPrefixRendered}${method} ${chalk.bold(pathname)}${bracketRendered}${sessionSuffixRendered}`;
-    const outcomeRendered = renderOutcome(outcome);
-    const durationRendered = chalk.dim(`(${durationMs}ms)`);
+    const head = `[${timestamp}] ${sessionPrefix}${method} ${chalk.bold(pathname)}${bracket}${sessionSuffix}`;
+    const tail = ` ${renderOutcome(outcome)} ${chalk.dim(`(${durationMs}ms)`)}`;
+    const argsPart = args !== null ? ` args=${args}` : "";
+    const argsOnNewLine =
+      args !== null && visibleLength(head + argsPart + tail) > MAX_INLINE_LENGTH;
 
-    if (args !== null && argsOnNewLine) {
-      line = `${head} ${outcomeRendered} ${durationRendered}\n    args=${args}`;
-    } else if (args !== null) {
-      line = `${head} args=${args} ${outcomeRendered} ${durationRendered}`;
+    if (argsOnNewLine) {
+      line = `${head}${tail}\n    args=${args}`;
     } else {
-      line = `${head} ${outcomeRendered} ${durationRendered}`;
+      line = `${head}${argsPart}${tail}`;
     }
   } else {
     line = `[${timestamp}] ${method} ${chalk.bold(pathname)} ${colorHttpStatus(statusCode)} ${chalk.dim(`(${durationMs}ms)`)}`;
@@ -467,29 +446,25 @@ export async function requestLogger(c: Context, next: Next): Promise<void> {
 
   console.log(line);
 
-  // Trace mode: log detailed request/response information
   if (traceMode) {
     console.log("\n" + chalk.cyan("=".repeat(80)));
     console.log(chalk.bold.cyan("[TRACE] Request Details"));
     console.log(chalk.cyan("-".repeat(80)));
 
-    // Request headers
     if (Object.keys(requestHeaders).length > 0) {
       console.log(chalk.yellow("Request Headers:"));
       console.log(formatForLogging(requestHeaders));
     }
 
-    // Request body
     if (requestBody !== null) {
       console.log(chalk.yellow("Request Body:"));
-      if (typeof requestBody === "string") {
-        console.log(requestBody);
-      } else {
-        console.log(formatForLogging(requestBody));
-      }
+      console.log(
+        typeof requestBody === "string"
+          ? requestBody
+          : formatForLogging(requestBody)
+      );
     }
 
-    // Response headers
     const responseHeaders: Record<string, string> = {};
     c.res.headers.forEach((value, key) => {
       responseHeaders[key] = value;
@@ -499,49 +474,31 @@ export async function requestLogger(c: Context, next: Next): Promise<void> {
       console.log(formatForLogging(responseHeaders));
     }
 
-    // Response body
-    try {
-      // Check if response has a body and can be cloned
-      // Clone the response to read the body without consuming the original stream
-      // This ensures the original response remains intact for the client
-      if (c.res.body !== null && c.res.body !== undefined) {
-        try {
-          const clonedResponse = c.res.clone();
-          const responseBody = await clonedResponse.text().catch(() => null);
-
-          if (responseBody !== null && responseBody.length > 0) {
-            console.log(chalk.yellow("Response Body:"));
-            // Try to parse as JSON for pretty printing
-            try {
-              const jsonBody = JSON.parse(responseBody);
-              console.log(formatForLogging(jsonBody));
-            } catch {
-              // Not JSON, print as text (truncate if too long)
-              const maxLength = 10000;
-              if (responseBody.length > maxLength) {
-                console.log(
-                  responseBody.substring(0, maxLength) +
-                    `\n... (truncated, ${responseBody.length - maxLength} more characters)`
-                );
-              } else {
-                console.log(responseBody);
-              }
-            }
-          } else {
-            console.log(chalk.yellow("Response Body:") + " (empty)");
-          }
-        } catch (cloneError) {
-          // If cloning fails (e.g., response already consumed), log that
+    // Reuse the response text already read above for MCP routes; for other
+    // traced routes, clone and read the body now.
+    let traceBody: string | null = responseText;
+    if (traceBody === null && c.res.body) {
+      traceBody = await c.res
+        .clone()
+        .text()
+        .catch(() => null);
+    }
+    console.log(chalk.yellow("Response Body:"));
+    if (traceBody === null || traceBody.length === 0) {
+      console.log("(empty)");
+    } else {
+      try {
+        console.log(formatForLogging(JSON.parse(traceBody)));
+      } catch {
+        if (traceBody.length > MAX_TRACE_BODY_LENGTH) {
           console.log(
-            chalk.yellow("Response Body:") + " (unable to clone/read)"
+            traceBody.slice(0, MAX_TRACE_BODY_LENGTH) +
+              `\n... (truncated, ${traceBody.length - MAX_TRACE_BODY_LENGTH} more characters)`
           );
+        } else {
+          console.log(traceBody);
         }
-      } else {
-        console.log(chalk.yellow("Response Body:") + " (no body)");
       }
-    } catch (error) {
-      // If we can't read the response body, log that
-      console.log(chalk.yellow("Response Body:") + " (unable to read)");
     }
 
     console.log(chalk.cyan("=".repeat(80)) + "\n");

--- a/libraries/typescript/packages/mcp-use/src/server/logging.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/logging.ts
@@ -7,8 +7,10 @@ import { getEnv } from "./utils/runtime.js";
 const MAX_INLINE_LENGTH = 160;
 /** Cap error messages so a huge error body can't blow up the log line. */
 const MAX_ERROR_MESSAGE_LENGTH = 200;
-/** Truncate individual string values inside rendered args. */
-const MAX_ARG_STRING_LENGTH = 100;
+/** Cap the full rendered args JSON so one huge payload can't blow up the log line. */
+const MAX_ARGS_TOTAL_LENGTH = 2000;
+/** Truncate individual long strings in DEBUG-mode body dumps. */
+const MAX_DEBUG_STRING_LENGTH = 100;
 /** Stop descending into nested args past this depth. */
 const MAX_ARG_DEPTH = 3;
 
@@ -30,8 +32,8 @@ function isDebugMode(): boolean {
  */
 function formatForLogging(obj: any): string {
   function truncate(val: any): any {
-    if (typeof val === "string" && val.length > MAX_ARG_STRING_LENGTH) {
-      return val.slice(0, MAX_ARG_STRING_LENGTH) + "...";
+    if (typeof val === "string" && val.length > MAX_DEBUG_STRING_LENGTH) {
+      return val.slice(0, MAX_DEBUG_STRING_LENGTH) + "...";
     } else if (Array.isArray(val)) {
       return val.map(truncate);
     } else if (val && typeof val === "object") {
@@ -53,23 +55,22 @@ function formatForLogging(obj: any): string {
 }
 
 /**
- * Deeply truncate long strings and cap recursion for compact single-line arg rendering.
+ * Cap recursion depth for compact single-line arg rendering. Individual string values
+ * are left intact — total output length is capped in `renderArgs` instead, so short
+ * values (URLs, ids, messages) print whole and only genuinely huge payloads get clipped.
  */
-function truncateCompact(val: any, depth = 0): any {
-  if (typeof val === "string" && val.length > MAX_ARG_STRING_LENGTH) {
-    return val.slice(0, MAX_ARG_STRING_LENGTH) + "...";
-  }
+function capDepth(val: any, depth = 0): any {
   if (depth >= MAX_ARG_DEPTH) {
     if (Array.isArray(val)) return val.length === 0 ? [] : ["..."];
     if (val && typeof val === "object") return "{...}";
     return val;
   }
-  if (Array.isArray(val)) return val.map((v) => truncateCompact(v, depth + 1));
+  if (Array.isArray(val)) return val.map((v) => capDepth(v, depth + 1));
   if (val && typeof val === "object") {
     const result: Record<string, any> = {};
     for (const key in val) {
       if (Object.prototype.hasOwnProperty.call(val, key)) {
-        result[key] = truncateCompact(val[key], depth + 1);
+        result[key] = capDepth(val[key], depth + 1);
       }
     }
     return result;
@@ -124,11 +125,16 @@ export function renderArgs(body: any): string | null {
   ) {
     return null;
   }
+  let rendered: string;
   try {
-    return JSON.stringify(truncateCompact(args));
+    rendered = JSON.stringify(capDepth(args));
   } catch {
     return null;
   }
+  if (rendered.length > MAX_ARGS_TOTAL_LENGTH) {
+    return rendered.slice(0, MAX_ARGS_TOTAL_LENGTH) + "...<truncated>";
+  }
+  return rendered;
 }
 
 export type Outcome =
@@ -306,7 +312,7 @@ export async function requestLogger(c: Context, next: Next): Promise<void> {
   const durationMs = Math.round(performance.now() - startMs);
 
   const statusCode = c.res.status;
-  const isMcpPost = method === "POST" && url.includes("/mcp");
+  const isMcpPost = method === "POST" && pathname === "/mcp";
 
   // Peek response body for outcome detection (POST /mcp only — always JSON, never SSE).
   // Safe to .text() because GET /mcp (SSE) is already filtered out above.
@@ -377,7 +383,7 @@ export async function requestLogger(c: Context, next: Next): Promise<void> {
     const durationRendered = chalk.dim(`(${durationMs}ms)`);
 
     if (args !== null && argsOnNewLine) {
-      line = `${head} ${outcomeRendered} ${durationRendered}\n    args: ${args}`;
+      line = `${head} ${outcomeRendered} ${durationRendered}\n    args=${args}`;
     } else if (args !== null) {
       line = `${head} args=${args} ${outcomeRendered} ${durationRendered}`;
     } else {

--- a/libraries/typescript/packages/mcp-use/src/server/logging.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/logging.ts
@@ -9,31 +9,38 @@ const MAX_INLINE_LENGTH = 160;
 const MAX_ERROR_MESSAGE_LENGTH = 200;
 /** Cap the full rendered args JSON so one huge payload can't blow up the log line. */
 const MAX_ARGS_TOTAL_LENGTH = 2000;
-/** Truncate individual long strings in DEBUG-mode body dumps. */
-const MAX_DEBUG_STRING_LENGTH = 100;
+/** Truncate individual long strings in trace-mode body dumps. */
+const MAX_TRACE_STRING_LENGTH = 100;
 /** Stop descending into nested args past this depth. */
 const MAX_ARG_DEPTH = 3;
 
 /**
- * Check if DEBUG mode is enabled via environment variable
+ * Verbosity tier for the request logger:
+ * - `info`  — target, outcome, duration. Default. Hides args (which can carry PII/secrets).
+ * - `debug` — `info` + inline args for `tools/call` and `prompts/get`.
+ * - `trace` — `debug` + the verbose request/response header & body dump.
  */
-function isDebugMode(): boolean {
-  const debugEnv = getEnv("DEBUG");
-  return (
-    debugEnv !== undefined &&
-    debugEnv !== "" &&
-    debugEnv !== "0" &&
-    debugEnv.toLowerCase() !== "false"
-  );
+export type LogLevel = "info" | "debug" | "trace";
+
+/**
+ * Resolve the effective log level from environment via `MCP_LOG_LEVEL`
+ * (`info` | `debug` | `trace`, case-insensitive). Unset or unrecognized → `info`.
+ */
+export function getLogLevel(): LogLevel {
+  const explicit = getEnv("MCP_LOG_LEVEL")?.toLowerCase();
+  if (explicit === "info" || explicit === "debug" || explicit === "trace") {
+    return explicit;
+  }
+  return "info";
 }
 
 /**
- * Format an object for pretty-printed JSON logging (used by DEBUG-mode body dumps).
+ * Format an object for pretty-printed JSON logging (used by trace-mode body dumps).
  */
 function formatForLogging(obj: any): string {
   function truncate(val: any): any {
-    if (typeof val === "string" && val.length > MAX_DEBUG_STRING_LENGTH) {
-      return val.slice(0, MAX_DEBUG_STRING_LENGTH) + "...";
+    if (typeof val === "string" && val.length > MAX_TRACE_STRING_LENGTH) {
+      return val.slice(0, MAX_TRACE_STRING_LENGTH) + "...";
     } else if (Array.isArray(val)) {
       return val.map(truncate);
     } else if (val && typeof val === "object") {
@@ -241,10 +248,12 @@ function colorHttpStatus(statusCode: number): string {
 
 /**
  * Middleware that logs incoming HTTP requests with a timestamp, color-coded outcome,
- * duration, and (for POST /mcp) the JSON-RPC method + target + args + RPC-level error.
+ * duration, and (for POST /mcp) the JSON-RPC method + target + RPC-level error.
+ *
+ * Verbosity is controlled by `MCP_LOG_LEVEL` (or legacy `DEBUG`); see {@link getLogLevel}.
+ * `debug` adds inline args; `trace` also dumps full request/response headers + bodies.
  *
  * Skips logging for inspector telemetry, inspector UI/assets, and SSE endpoints.
- * When DEBUG is enabled, also logs request headers/body and response headers/body.
  *
  * @param c - Hono context for the current request/response
  * @param next - Next middleware function to invoke
@@ -253,7 +262,9 @@ export async function requestLogger(c: Context, next: Next): Promise<void> {
   const timestamp = new Date().toISOString().substring(11, 23);
   const method = c.req.method;
   const url = c.req.url;
-  const debugMode = isDebugMode();
+  const logLevel = getLogLevel();
+  const showArgs = logLevel === "debug" || logLevel === "trace";
+  const traceMode = logLevel === "trace";
 
   // Filter out noisy endpoints that create log spam
   const pathname = new URL(url).pathname;
@@ -285,7 +296,7 @@ export async function requestLogger(c: Context, next: Next): Promise<void> {
   let requestBody: any = null;
   let requestHeaders: Record<string, string> = {};
 
-  if (debugMode) {
+  if (traceMode) {
     // Log request headers - c.req.header() without args returns all headers
     const allHeaders = c.req.header();
     if (allHeaders) {
@@ -342,7 +353,7 @@ export async function requestLogger(c: Context, next: Next): Promise<void> {
         ? (requestBody as any).method
         : undefined;
     const target = extractTarget(requestBody);
-    const args = renderArgs(requestBody);
+    const args = showArgs ? renderArgs(requestBody) : null;
     const outcome = detectOutcome(statusCode, responseText);
 
     const showSessionPrefix = sessionTag !== null && rpcMethod !== "initialize";
@@ -395,10 +406,10 @@ export async function requestLogger(c: Context, next: Next): Promise<void> {
 
   console.log(line);
 
-  // Debug mode: log detailed request/response information
-  if (debugMode) {
+  // Trace mode: log detailed request/response information
+  if (traceMode) {
     console.log("\n" + chalk.cyan("=".repeat(80)));
-    console.log(chalk.bold.cyan("[DEBUG] Request Details"));
+    console.log(chalk.bold.cyan("[TRACE] Request Details"));
     console.log(chalk.cyan("-".repeat(80)));
 
     // Request headers

--- a/libraries/typescript/packages/mcp-use/tests/server-logging.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/server-logging.test.ts
@@ -242,6 +242,63 @@ describe("detectOutcome", () => {
     });
   });
 
+  it("detects ok in an SSE-wrapped response", () => {
+    const sse =
+      "event: message\n" +
+      `data: ${JSON.stringify({ jsonrpc: "2.0", id: 1, result: { ok: true } })}\n\n`;
+    expect(detectOutcome(200, sse)).toEqual<Outcome>({ kind: "ok" });
+  });
+
+  it("detects rpc-error in an SSE-wrapped response", () => {
+    const sse =
+      "event: message\n" +
+      `data: ${JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        error: { code: -32603, message: "boom" },
+      })}\n\n`;
+    expect(detectOutcome(200, sse)).toEqual<Outcome>({
+      kind: "rpc-error",
+      code: -32603,
+      message: "boom",
+    });
+  });
+
+  it("detects tool-level isError in an SSE-wrapped response", () => {
+    const sse =
+      "event: message\n" +
+      `data: ${JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        result: {
+          isError: true,
+          content: [{ type: "text", text: "cannot divide by zero" }],
+        },
+      })}\n\n`;
+    expect(detectOutcome(200, sse)).toEqual<Outcome>({
+      kind: "rpc-error",
+      code: null,
+      message: "cannot divide by zero",
+    });
+  });
+
+  it("scans multiple SSE events and surfaces the first error", () => {
+    const sse =
+      "event: message\n" +
+      `data: ${JSON.stringify({ jsonrpc: "2.0", id: 1, result: { ok: true } })}\n\n` +
+      "event: message\n" +
+      `data: ${JSON.stringify({
+        jsonrpc: "2.0",
+        id: 2,
+        error: { code: -32000, message: "later failure" },
+      })}\n\n`;
+    expect(detectOutcome(200, sse)).toEqual<Outcome>({
+      kind: "rpc-error",
+      code: -32000,
+      message: "later failure",
+    });
+  });
+
   it("truncates very long error messages", () => {
     const longMsg = "a".repeat(500);
     const outcome = detectOutcome(

--- a/libraries/typescript/packages/mcp-use/tests/server-logging.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/server-logging.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
   detectOutcome,
   extractTarget,
+  getLogLevel,
   renderArgs,
   type Outcome,
 } from "../src/server/logging.js";
@@ -255,6 +256,60 @@ describe("detectOutcome", () => {
     if (outcome.kind === "rpc-error") {
       expect(outcome.message.length).toBeLessThanOrEqual(204);
       expect(outcome.message.endsWith("...")).toBe(true);
+    }
+  });
+});
+
+describe("getLogLevel", () => {
+  const ENV_KEYS = ["MCP_LOG_LEVEL", "DEBUG"];
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) saved[k] = process.env[k];
+    for (const k of ENV_KEYS) delete process.env[k];
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it("defaults to info when no env vars are set", () => {
+    expect(getLogLevel()).toBe("info");
+  });
+
+  it("respects explicit MCP_LOG_LEVEL=info", () => {
+    process.env.MCP_LOG_LEVEL = "info";
+    expect(getLogLevel()).toBe("info");
+  });
+
+  it("respects explicit MCP_LOG_LEVEL=debug", () => {
+    process.env.MCP_LOG_LEVEL = "debug";
+    expect(getLogLevel()).toBe("debug");
+  });
+
+  it("respects explicit MCP_LOG_LEVEL=trace", () => {
+    process.env.MCP_LOG_LEVEL = "trace";
+    expect(getLogLevel()).toBe("trace");
+  });
+
+  it("is case-insensitive for MCP_LOG_LEVEL", () => {
+    process.env.MCP_LOG_LEVEL = "DEBUG";
+    expect(getLogLevel()).toBe("debug");
+  });
+
+  it("falls back to info when MCP_LOG_LEVEL is unrecognized", () => {
+    process.env.MCP_LOG_LEVEL = "verbose";
+    expect(getLogLevel()).toBe("info");
+  });
+
+  it("DEBUG env var has no effect on log level", () => {
+    // DEBUG is no longer a control for the request logger; only MCP_LOG_LEVEL is.
+    for (const v of ["1", "true", "trace", "debug"]) {
+      process.env.DEBUG = v;
+      expect(getLogLevel()).toBe("info");
     }
   });
 });

--- a/libraries/typescript/packages/mcp-use/tests/server-logging.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/server-logging.test.ts
@@ -124,15 +124,27 @@ describe("renderArgs", () => {
     expect(renderArgs({ method: "tools/list" })).toBe(null);
   });
 
-  it("truncates string values over 100 characters", () => {
-    const long = "x".repeat(250);
+  it("preserves long string values up to the total-length cap", () => {
+    // A 300-char URL-like value should print intact — no per-string truncation.
+    const url = "https://example.com/" + "a".repeat(300);
     const out = renderArgs({
       method: "tools/call",
-      params: { name: "t", arguments: { blob: long } },
+      params: { name: "t", arguments: { url } },
     });
-    expect(out).toContain("xxx...");
-    // 100 x's + "..." + quotes + key wrapper
-    expect(out!.length).toBeLessThan(long.length + 20);
+    expect(out).toContain(url);
+    expect(out).not.toContain("...<truncated>");
+  });
+
+  it("caps the overall rendered args length", () => {
+    const huge = "x".repeat(5000);
+    const out = renderArgs({
+      method: "tools/call",
+      params: { name: "t", arguments: { blob: huge } },
+    });
+    expect(out).not.toBeNull();
+    expect(out!.endsWith("...<truncated>")).toBe(true);
+    // Cap is 2000 chars + suffix.
+    expect(out!.length).toBeLessThanOrEqual(2000 + "...<truncated>".length);
   });
 
   it("caps nested-object depth", () => {

--- a/libraries/typescript/packages/mcp-use/tests/server-logging.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/server-logging.test.ts
@@ -305,11 +305,26 @@ describe("getLogLevel", () => {
     expect(getLogLevel()).toBe("info");
   });
 
-  it("DEBUG env var has no effect on log level", () => {
-    // DEBUG is no longer a control for the request logger; only MCP_LOG_LEVEL is.
-    for (const v of ["1", "true", "trace", "debug"]) {
+  it("falls back to trace when DEBUG is truthy and MCP_LOG_LEVEL is unset", () => {
+    for (const v of ["1", "true", "yes", "trace"]) {
+      process.env.DEBUG = v;
+      expect(getLogLevel()).toBe("trace");
+    }
+  });
+
+  it("treats falsy DEBUG values as unset", () => {
+    for (const v of ["", "0", "false", "FALSE"]) {
       process.env.DEBUG = v;
       expect(getLogLevel()).toBe("info");
     }
+  });
+
+  it("MCP_LOG_LEVEL takes precedence over DEBUG", () => {
+    process.env.DEBUG = "1";
+    process.env.MCP_LOG_LEVEL = "info";
+    expect(getLogLevel()).toBe("info");
+
+    process.env.MCP_LOG_LEVEL = "debug";
+    expect(getLogLevel()).toBe("debug");
   });
 });

--- a/libraries/typescript/packages/mcp-use/tests/server-logging.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/server-logging.test.ts
@@ -1,12 +1,17 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Hono } from "hono";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   detectOutcome,
   extractTarget,
   getLogLevel,
   renderArgs,
+  requestLogger,
   type Outcome,
 } from "../src/server/logging.js";
+
+const ANSI_PATTERN = /\x1B\[[0-9;]*m/g;
+const stripAnsi = (s: string) => s.replace(ANSI_PATTERN, "");
 
 describe("extractTarget", () => {
   it("returns client name/version for initialize", () => {
@@ -383,5 +388,334 @@ describe("getLogLevel", () => {
 
     process.env.MCP_LOG_LEVEL = "debug";
     expect(getLogLevel()).toBe("debug");
+  });
+});
+
+describe("requestLogger middleware", () => {
+  const ENV_KEYS = ["MCP_LOG_LEVEL", "DEBUG"];
+  const saved: Record<string, string | undefined> = {};
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) saved[k] = process.env[k];
+    for (const k of ENV_KEYS) delete process.env[k];
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  function loggedLines(): string[] {
+    return logSpy.mock.calls.map((args) =>
+      args.map((a) => (typeof a === "string" ? a : String(a))).join(" ")
+    );
+  }
+
+  function firstPlainLine(): string {
+    const lines = loggedLines();
+    expect(lines.length).toBeGreaterThan(0);
+    return stripAnsi(lines[0]!);
+  }
+
+  function buildApp(handler: () => Response | Promise<Response>): Hono {
+    const app = new Hono();
+    app.use(requestLogger);
+    app.all("*", () => handler());
+    return app;
+  }
+
+  function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      ...init,
+      headers: {
+        "content-type": "application/json",
+        ...((init.headers as Record<string, string> | undefined) ?? {}),
+      },
+    });
+  }
+
+  function postMcp(
+    app: Hono,
+    body: unknown,
+    headers: Record<string, string> = {}
+  ): Promise<Response> {
+    return app.request("/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json", ...headers },
+      body: JSON.stringify(body),
+    });
+  }
+
+  it("uses → session= suffix on initialize, with target and OK outcome", async () => {
+    const sessionId = "session-abcdef-1234-uuid";
+    const app = buildApp(() =>
+      jsonResponse(
+        { jsonrpc: "2.0", id: 1, result: {} },
+        { headers: { "mcp-session-id": sessionId } }
+      )
+    );
+    await postMcp(app, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { clientInfo: { name: "Claude", version: "0.8.3" } },
+    });
+
+    const line = firstPlainLine();
+    expect(line).toContain("[initialize: Claude/0.8.3]");
+    expect(line).toContain(`→ session=${sessionId.slice(0, 7)}`);
+    expect(line).not.toMatch(/sess=/);
+    expect(line).toContain("OK");
+    expect(line).toMatch(/\(\d+ms\)/);
+  });
+
+  it("uses sess= prefix for established-session requests and renders the target", async () => {
+    const sessionId = "abcdef1-rest";
+    const app = buildApp(() =>
+      jsonResponse({ jsonrpc: "2.0", id: 2, result: { ok: true } })
+    );
+    await postMcp(
+      app,
+      {
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: { name: "greet", arguments: { name: "Alice" } },
+      },
+      { "mcp-session-id": sessionId }
+    );
+
+    const line = firstPlainLine();
+    expect(line).toContain(`sess=${sessionId.slice(0, 7)}`);
+    expect(line).toContain("[tools/call: greet]");
+    expect(line).toContain("OK");
+    // info default — args are hidden
+    expect(line).not.toContain("args=");
+    // suffix only on initialize
+    expect(line).not.toContain("→ session=");
+  });
+
+  it("renders ERROR <code> <message> for JSON-RPC errors", async () => {
+    const app = buildApp(() =>
+      jsonResponse({
+        jsonrpc: "2.0",
+        id: 1,
+        error: { code: -32603, message: "Invalid API key" },
+      })
+    );
+    await postMcp(app, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name: "fetch_url", arguments: { url: "https://x" } },
+    });
+
+    const line = firstPlainLine();
+    expect(line).toContain("[tools/call: fetch_url]");
+    expect(line).toContain("ERROR -32603 Invalid API key");
+  });
+
+  it("detects tool-level isError responses with extracted message", async () => {
+    const app = buildApp(() =>
+      jsonResponse({
+        jsonrpc: "2.0",
+        id: 1,
+        result: {
+          isError: true,
+          content: [{ type: "text", text: "cannot divide by zero" }],
+        },
+      })
+    );
+    await postMcp(app, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name: "divide", arguments: { a: 1, b: 0 } },
+    });
+
+    const line = firstPlainLine();
+    expect(line).toContain("[tools/call: divide]");
+    expect(line).toContain("ERROR cannot divide by zero");
+  });
+
+  it("detects rpc-error in SSE-wrapped responses", async () => {
+    const sse =
+      "event: message\n" +
+      `data: ${JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        error: { code: -32000, message: "boom" },
+      })}\n\n`;
+    const app = buildApp(
+      () =>
+        new Response(sse, {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        })
+    );
+    await postMcp(app, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name: "x" },
+    });
+
+    const line = firstPlainLine();
+    expect(line).toContain("ERROR -32000 boom");
+  });
+
+  it("renders HTTP <status> for non-2xx /mcp responses", async () => {
+    const app = buildApp(
+      () => new Response("Bad Request", { status: 400 })
+    );
+    await postMcp(app, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name: "x" },
+    });
+
+    const line = firstPlainLine();
+    expect(line).toContain("[tools/call: x]");
+    expect(line).toContain("HTTP 400");
+  });
+
+  it("includes inline args= at MCP_LOG_LEVEL=debug", async () => {
+    process.env.MCP_LOG_LEVEL = "debug";
+    const app = buildApp(() =>
+      jsonResponse({ jsonrpc: "2.0", id: 1, result: { ok: true } })
+    );
+    await postMcp(app, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name: "greet", arguments: { name: "Alice", formal: true } },
+    });
+
+    const line = firstPlainLine();
+    expect(line).toContain('args={"name":"Alice","formal":true}');
+  });
+
+  it("spills args to a second indented line when the line exceeds 160 chars", async () => {
+    process.env.MCP_LOG_LEVEL = "debug";
+    const longUrl = "https://example.com/" + "a".repeat(200);
+    const app = buildApp(() =>
+      jsonResponse({ jsonrpc: "2.0", id: 1, result: { ok: true } })
+    );
+    await postMcp(app, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name: "fetch", arguments: { url: longUrl } },
+    });
+
+    const line = stripAnsi(loggedLines()[0]!);
+    expect(line).toContain("\n    args=");
+    expect(line).toContain(longUrl);
+  });
+
+  it("prints the trace dump at MCP_LOG_LEVEL=trace", async () => {
+    process.env.MCP_LOG_LEVEL = "trace";
+    const app = buildApp(() =>
+      jsonResponse({ jsonrpc: "2.0", id: 1, result: { tools: [] } })
+    );
+    await postMcp(app, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/list",
+    });
+
+    const all = loggedLines().map(stripAnsi).join("\n");
+    expect(all).toContain("[TRACE] Request Details");
+    expect(all).toContain("Request Headers:");
+    expect(all).toContain("Request Body:");
+    expect(all).toContain("Response Body:");
+    expect(all).toContain("=".repeat(80));
+  });
+
+  it("falls back to trace when DEBUG is truthy and MCP_LOG_LEVEL is unset", async () => {
+    process.env.DEBUG = "1";
+    const app = buildApp(() =>
+      jsonResponse({ jsonrpc: "2.0", id: 1, result: { ok: true } })
+    );
+    await postMcp(app, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/list",
+    });
+
+    const all = loggedLines().map(stripAnsi).join("\n");
+    expect(all).toContain("[TRACE] Request Details");
+  });
+
+  it("renders a generic line for non-MCP routes", async () => {
+    const app = buildApp(
+      () =>
+        new Response("ok", {
+          status: 200,
+          headers: { "content-type": "text/plain" },
+        })
+    );
+    await app.request("/health", { method: "GET" });
+
+    const line = firstPlainLine();
+    expect(line).toMatch(/^\[\d{2}:\d{2}:\d{2}\.\d{3}\] GET \/health 200 \(\d+ms\)$/);
+  });
+
+  it("skips logging for GET /mcp", async () => {
+    const app = buildApp(() => new Response("", { status: 200 }));
+    const res = await app.request("/mcp", { method: "GET" });
+    expect(res.status).toBe(200);
+    expect(logSpy.mock.calls).toHaveLength(0);
+  });
+
+  it("skips logging for inspector telemetry endpoints", async () => {
+    const app = buildApp(() => new Response("", { status: 200 }));
+    await app.request("/inspector/api/tel/posthog", { method: "POST" });
+    expect(logSpy.mock.calls).toHaveLength(0);
+  });
+
+  it("does not consume the request body — handler still sees it", async () => {
+    const captured: { body?: unknown } = {};
+    const app = new Hono();
+    app.use(requestLogger);
+    app.post("/mcp", async (c) => {
+      captured.body = await c.req.json();
+      return jsonResponse({ jsonrpc: "2.0", id: 1, result: { ok: true } });
+    });
+
+    const requestBody = {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name: "x", arguments: { a: 1 } },
+    };
+    await postMcp(app, requestBody);
+
+    expect(captured.body).toEqual(requestBody);
+    expect(firstPlainLine()).toContain("[tools/call: x]");
+  });
+
+  it("does not consume the response body — caller still reads it", async () => {
+    const responsePayload = {
+      jsonrpc: "2.0",
+      id: 1,
+      result: { greeting: "hello" },
+    };
+    const app = buildApp(() => jsonResponse(responsePayload));
+    const res = await postMcp(app, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name: "greet" },
+    });
+
+    await expect(res.json()).resolves.toEqual(responsePayload);
   });
 });

--- a/libraries/typescript/packages/mcp-use/tests/server-logging.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/server-logging.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  detectOutcome,
+  extractTarget,
+  renderArgs,
+  type Outcome,
+} from "../src/server/logging.js";
+
+describe("extractTarget", () => {
+  it("returns client name/version for initialize", () => {
+    expect(
+      extractTarget({
+        method: "initialize",
+        params: { clientInfo: { name: "Claude", version: "0.8.3" } },
+      })
+    ).toBe("Claude/0.8.3");
+  });
+
+  it("returns only name when version missing on initialize", () => {
+    expect(
+      extractTarget({
+        method: "initialize",
+        params: { clientInfo: { name: "Claude" } },
+      })
+    ).toBe("Claude");
+  });
+
+  it("returns null for initialize with no clientInfo", () => {
+    expect(extractTarget({ method: "initialize", params: {} })).toBe(null);
+  });
+
+  it("returns tool name for tools/call", () => {
+    expect(
+      extractTarget({
+        method: "tools/call",
+        params: { name: "create_invoice", arguments: { amount: 100 } },
+      })
+    ).toBe("create_invoice");
+  });
+
+  it("returns prompt name for prompts/get", () => {
+    expect(
+      extractTarget({ method: "prompts/get", params: { name: "summarize" } })
+    ).toBe("summarize");
+  });
+
+  it("returns URI for resources/read", () => {
+    expect(
+      extractTarget({
+        method: "resources/read",
+        params: { uri: "file:///a/b.txt" },
+      })
+    ).toBe("file:///a/b.txt");
+  });
+
+  it("returns URI for resources/subscribe", () => {
+    expect(
+      extractTarget({
+        method: "resources/subscribe",
+        params: { uri: "mcp://thing" },
+      })
+    ).toBe("mcp://thing");
+  });
+
+  it("returns null for methods without a natural target", () => {
+    expect(extractTarget({ method: "tools/list" })).toBe(null);
+    expect(extractTarget({ method: "resources/list" })).toBe(null);
+    expect(extractTarget({ method: "ping" })).toBe(null);
+  });
+
+  it("returns null for malformed input", () => {
+    expect(extractTarget(null)).toBe(null);
+    expect(extractTarget("not an object")).toBe(null);
+    expect(extractTarget({})).toBe(null);
+    expect(extractTarget({ method: 42 })).toBe(null);
+  });
+});
+
+describe("renderArgs", () => {
+  it("renders compact single-line JSON for tools/call arguments", () => {
+    expect(
+      renderArgs({
+        method: "tools/call",
+        params: {
+          name: "create_invoice",
+          arguments: { amount: 100, currency: "USD" },
+        },
+      })
+    ).toBe('{"amount":100,"currency":"USD"}');
+  });
+
+  it("renders prompts/get arguments", () => {
+    expect(
+      renderArgs({
+        method: "prompts/get",
+        params: { name: "summarize", arguments: { topic: "q3" } },
+      })
+    ).toBe('{"topic":"q3"}');
+  });
+
+  it("returns null when arguments object is empty", () => {
+    expect(
+      renderArgs({
+        method: "tools/call",
+        params: { name: "t", arguments: {} },
+      })
+    ).toBe(null);
+  });
+
+  it("returns null when arguments are missing", () => {
+    expect(renderArgs({ method: "tools/call", params: { name: "t" } })).toBe(
+      null
+    );
+  });
+
+  it("returns null for methods other than tools/call or prompts/get", () => {
+    expect(
+      renderArgs({
+        method: "resources/read",
+        params: { uri: "file:///x" },
+      })
+    ).toBe(null);
+    expect(renderArgs({ method: "tools/list" })).toBe(null);
+  });
+
+  it("truncates string values over 100 characters", () => {
+    const long = "x".repeat(250);
+    const out = renderArgs({
+      method: "tools/call",
+      params: { name: "t", arguments: { blob: long } },
+    });
+    expect(out).toContain("xxx...");
+    // 100 x's + "..." + quotes + key wrapper
+    expect(out!.length).toBeLessThan(long.length + 20);
+  });
+
+  it("caps nested-object depth", () => {
+    const deep: any = { a: { b: { c: { d: { e: "bottom" } } } } };
+    const out = renderArgs({
+      method: "tools/call",
+      params: { name: "t", arguments: deep },
+    });
+    expect(out).toContain("{...}");
+  });
+});
+
+describe("detectOutcome", () => {
+  it("returns ok for 2xx with a result body", () => {
+    const outcome = detectOutcome(
+      200,
+      JSON.stringify({ jsonrpc: "2.0", id: 1, result: { ok: true } })
+    );
+    expect(outcome).toEqual<Outcome>({ kind: "ok" });
+  });
+
+  it("returns rpc-error when the body carries a JSON-RPC error", () => {
+    const outcome = detectOutcome(
+      200,
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        error: { code: -32603, message: "Invalid API key" },
+      })
+    );
+    expect(outcome).toEqual<Outcome>({
+      kind: "rpc-error",
+      code: -32603,
+      message: "Invalid API key",
+    });
+  });
+
+  it("returns rpc-error for tool-level isError with extracted text", () => {
+    const outcome = detectOutcome(
+      200,
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        result: {
+          isError: true,
+          content: [{ type: "text", text: "tool blew up: bad input" }],
+        },
+      })
+    );
+    expect(outcome).toEqual<Outcome>({
+      kind: "rpc-error",
+      code: null,
+      message: "tool blew up: bad input",
+    });
+  });
+
+  it("returns http for non-2xx status codes", () => {
+    expect(detectOutcome(400, null)).toEqual<Outcome>({
+      kind: "http",
+      status: 400,
+    });
+    expect(detectOutcome(500, "oops")).toEqual<Outcome>({
+      kind: "http",
+      status: 500,
+    });
+  });
+
+  it("treats non-JSON 2xx bodies as ok", () => {
+    expect(detectOutcome(200, "not json at all")).toEqual<Outcome>({
+      kind: "ok",
+    });
+  });
+
+  it("treats empty 2xx bodies as ok", () => {
+    expect(detectOutcome(200, null)).toEqual<Outcome>({ kind: "ok" });
+  });
+
+  it("finds the first error in a JSON-RPC batch response", () => {
+    const outcome = detectOutcome(
+      200,
+      JSON.stringify([
+        { jsonrpc: "2.0", id: 1, result: { ok: true } },
+        {
+          jsonrpc: "2.0",
+          id: 2,
+          error: { code: -32000, message: "batch member failed" },
+        },
+      ])
+    );
+    expect(outcome).toEqual<Outcome>({
+      kind: "rpc-error",
+      code: -32000,
+      message: "batch member failed",
+    });
+  });
+
+  it("truncates very long error messages", () => {
+    const longMsg = "a".repeat(500);
+    const outcome = detectOutcome(
+      200,
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        error: { code: -32000, message: longMsg },
+      })
+    );
+    expect(outcome.kind).toBe("rpc-error");
+    if (outcome.kind === "rpc-error") {
+      expect(outcome.message.length).toBeLessThanOrEqual(204);
+      expect(outcome.message.endsWith("...")).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
<img width="1594" height="514" alt="image" src="https://github.com/user-attachments/assets/f3cdf744-041b-4e41-91ea-3d8dc56f4ac2" />


# Pull Request Description

## Language / Project Scope

Check all that apply:
- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

The one-line request log for `POST /mcp` used to read `[12:34:56.789] POST /mcp [initialize] 200` — opaque enough that when a customer hit an auth failure on a tool call, the logs didn't reveal which tool, which client, or even that the call failed (MCP/JSON-RPC returns HTTP 200 on RPC errors).

This PR enriches the one-line request log the Hono middleware emits and introduces a tiered verbosity control via a new `MCP_LOG_LEVEL` env var:

- **Target in the bracket** — `[tools/call: create_invoice]`, `[resources/read: file:///a/b.txt]`, `[prompts/get: summarize]`, `[initialize: Claude/0.8.3]`.
- **Session-id prefix** `sess=<first-7>` on every `/mcp` line for correlation; `initialize` instead shows `→ session=<first-7>` after the bracket since it's the line that creates the session.
- **Outcome replaces HTTP status** for POST /mcp: `OK` (green), `ERROR <code> <msg>` (red) for JSON-RPC errors or `result.isError`, or `HTTP <code>` for HTTP-layer failures. JSON-RPC errors no longer appear as `200`. Detection works against both plain JSON responses and SSE-wrapped (`event: message\ndata: {…}`) responses, which is what real MCP clients receive.
- **Duration** appended as `(<ms>ms)`.
- **Tiered verbosity via `MCP_LOG_LEVEL`** (`info` | `debug` | `trace`, case-insensitive):
  - `info` (default) — target, outcome, duration. Args are hidden because they can carry PII or secrets.
  - `debug` — adds inline `args={...}` for `tools/call` and `prompts/get` (compact JSON, deeply truncated, spills to an indented second line past 160 chars).
  - `trace` — adds the verbose request/response header & body dump.
- **`DEBUG`** is kept as a legacy fallback: a truthy `DEBUG` maps to `trace` so existing setups keep working. `MCP_LOG_LEVEL` always wins when set; new docs and examples should reference `MCP_LOG_LEVEL`.

## Implementation Details

1. All code changes live in `libraries/typescript/packages/mcp-use/src/server/logging.ts`. The middleware was the only file touched, since the necessary data (request body, response body, session header) was already accessible post-`next()` — it just wasn't surfaced.
2. Pure helpers extracted and exported for testing:
   - `getLogLevel()` — reads `MCP_LOG_LEVEL` (case-insensitive); falls back to `trace` on truthy `DEBUG`; otherwise `info`.
   - `extractTarget(body)` — maps JSON-RPC method to its display target.
   - `renderArgs(body)` — compact single-line JSON for `tools/call`/`prompts/get` arguments with per-depth and total-length truncation.
   - `detectOutcome(statusCode, responseText)` — classifies a response as `ok`, `rpc-error`, or `http`. Parses both raw JSON and SSE event-stream bodies (single + batch).
3. Args rendering is gated on `logLevel !== 'info'`; the verbose body dump is gated on `logLevel === 'trace'` (the path that previously ran when `DEBUG` was truthy).
4. Color output migrated from raw ANSI escapes to `chalk` (already declared in `package.json` but previously unused in `src/`), which gives us `NO_COLOR`/TTY handling for free.
5. Response-body peeking on POST /mcp is bounded: 64 KB cap on `info`/`debug`, full read on `trace` for the body dump. The cloned `Response` is read with a streaming reader and cancelled, so the original body remains intact for the client.

---

## TypeScript Checklist

### Packages Modified

- [x] `mcp-use` (server)

### Pre-commit Checklist

- [x] Ran `pnpm lint:fix` to auto-fix linting issues
- [x] Ran `pnpm format` to format code with Prettier
- [x] Ran `pnpm build` and build succeeds without errors
- [x] Ran `pnpm changeset` to create a changeset (if this PR includes user-facing changes)
- [x] Added or updated tests if needed
- [x] Updated documentation in `docs/` folder

---

## Example Usage (Before)

```
[12:34:56.789] POST /mcp [initialize] 200
[12:34:57.102] POST /mcp [tools/call] 200
[12:34:57.540] POST /mcp [tools/call] 200
[12:34:57.701] POST /mcp [resources/read] 200
```

## Example Usage (After)

Captured against a small demo server (`greet` succeeds, `divide` throws on `b=0`, `does-not-exist` is unknown).

### `MCP_LOG_LEVEL=info` (default)

<!-- screenshot: info level -->

```
[19:44:56.927] POST /mcp [initialize: log-demo/0.1.0] → session=92c4e0b OK (1ms)
[19:44:56.935] sess=92c4e0b POST /mcp [notifications/initialized] OK (1ms)
[19:44:56.943] sess=92c4e0b POST /mcp [tools/list] OK (1ms)
[19:44:56.950] sess=92c4e0b POST /mcp [tools/call: greet] OK (1ms)
[19:44:56.958] sess=92c4e0b POST /mcp [tools/call: divide] ERROR cannot divide by zero (0ms)
[19:44:56.965] sess=92c4e0b POST /mcp [tools/call: does-not-exist] ERROR MCP error -32602: Tool does-not-exist not found (0ms)
```

### `MCP_LOG_LEVEL=debug` — adds inline `args=…`

<!-- screenshot: debug level -->

```
[19:44:57.893] POST /mcp [initialize: log-demo/0.1.0] → session=f93f8b1 OK (1ms)
[19:44:57.902] sess=f93f8b1 POST /mcp [notifications/initialized] OK (1ms)
[19:44:57.910] sess=f93f8b1 POST /mcp [tools/list] OK (1ms)
[19:44:57.918] sess=f93f8b1 POST /mcp [tools/call: greet] args={"name":"Andrew","formal":true} OK (1ms)
[19:44:57.926] sess=f93f8b1 POST /mcp [tools/call: divide] args={"a":10,"b":0} ERROR cannot divide by zero (0ms)
[19:44:57.934] sess=f93f8b1 POST /mcp [tools/call: does-not-exist] ERROR MCP error -32602: Tool does-not-exist not found (0ms)
```

### `MCP_LOG_LEVEL=trace` — adds full request/response header & body dump per call

<!-- screenshot: trace level -->

```
[19:44:58.883] sess=f5dc0f6 POST /mcp [tools/call: greet] args={"name":"Andrew","formal":true} OK (1ms)

================================================================================
[TRACE] Request Details
--------------------------------------------------------------------------------
Request Headers:
{
  "accept": "application/json, text/event-stream",
  "content-length": "116",
  "content-type": "application/json",
  "host": "127.0.0.1:3403",
  "mcp-session-id": "f5dc0f63-fcd2-47fa-bf5b-e99e73e707ad",
  "user-agent": "curl/8.7.1"
}
Request Body:
{
  "jsonrpc": "2.0",
  "id": 3,
  "method": "tools/call",
  "params": {
    "name": "greet",
    "arguments": { "name": "Andrew", "formal": true }
  }
}
Response Headers:
{
  "access-control-allow-origin": "*",
  "access-control-expose-headers": "mcp-session-id",
  "cache-control": "no-cache",
  "connection": "keep-alive",
  "content-type": "text/event-stream",
  "mcp-session-id": "f5dc0f63-fcd2-47fa-bf5b-e99e73e707ad"
}
Response Body:
event: message
data: {"result":{"_meta":{"mimeType":"text/plain"},"content":[{"type":"text","text":"Good day, Andrew."}]},"jsonrpc":"2.0","id":3}

================================================================================
```

## Documentation Updates

- `docs/typescript/server/logging.mdx` — added a **Per-Request Log Verbosity** section covering the `info` / `debug` / `trace` tiers and corrected the prior `DEBUG=2` example, which mixed the SimpleConsoleLogger debug level with a body dump that's now under `MCP_LOG_LEVEL=trace`.
- `docs/typescript/server/configuration.mdx` — added `MCP_LOG_LEVEL` to the environment-variables table and clarified what `DEBUG` actually controls (Logger verbosity).

## Testing

- **Unit tests** in `libraries/typescript/packages/mcp-use/tests/server-logging.test.ts` (38 tests) covering:
  - `getLogLevel`: defaults, each tier, case-insensitivity, fallback for unrecognized values, `DEBUG` legacy fallback, and that `MCP_LOG_LEVEL` wins over `DEBUG`.
  - `extractTarget`: all supported methods, fallback when fields are missing, malformed input.
  - `renderArgs`: happy paths for `tools/call` and `prompts/get`, empty / missing / non-object arguments, total-length cap, nested-depth cap.
  - `detectOutcome`: 2xx with result, 2xx with JSON-RPC error, tool `isError`, non-2xx, non-JSON body, empty body, batch responses, long-message truncation, and SSE-wrapped responses (single + multi-event).
- **Manual**: start a dev server, connect with an MCP client, call a tool (including one that errors), read a resource, and verify the new log shape. Set `MCP_LOG_LEVEL=debug` to see args, `MCP_LOG_LEVEL=trace` for the verbose body dump.

## Backwards Compatibility

- Code-level: `requestLogger` is an internal middleware, not re-exported from any public entrypoint.
- Behavioral: the log line format is changing (anyone grepping for `POST /mcp [<method>] 200` exactly will need to update). `DEBUG=1` still works as a legacy fallback (maps to `trace`), but new setups should prefer `MCP_LOG_LEVEL=trace`.
- Marked as a patch bump in the changeset since no consumer API changes.

## Related Issues

Closes [MCP-1569](https://linear.app/manufact/issue/MCP-1569/improve-typescript-mcp-server-logs)
