### PR TITLE
docs: add SECURITY.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,9 @@ main();
 
 ---
 
+## Security
+See [SECURITY.md](https://github.com/mcp-use/mcp-use/blob/main/SECURITY.md)
+
 ## Community & Support
 
 - **Discord**: [Join our community](https://discord.gg/XkNkSkMz3V)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@ If you discover a security vulnerability in mcp-use, please report it responsibl
 ### How to Report
 
 1. **GitHub Security Advisories**: Use [GitHub's private vulnerability reporting](https://github.com/mcp-use/mcp-use/security/advisories/new)
-2. **Email**: Send details to the maintainers
+2. **Email**: security@manufact.com
 
 ### What to Include
 
@@ -24,16 +24,12 @@ If you discover a security vulnerability in mcp-use, please report it responsibl
 - **Assessment**: Within 1 week
 - **Fix**: Depends on severity
 
-## Supported Versions
-
-| Version | Supported |
-|---------|:---------:|
-| Latest  | ✅        |
+## Manufact Cloud Security
+For anything related to Manufact Cloud please report any findings at security@manufact.com
 
 ## Security Best Practices for MCP Users
 
 1. **Review server permissions** before connecting to any MCP server
 2. **Use environment variables** for secrets — never hardcode them
 3. **Limit server access** to only required tools and resources
-4. **Monitor server activity** for unexpected behavior
-5. **Keep dependencies updated** to patch known vulnerabilities
+4. **Keep dependencies updated** to patch known vulnerabilities

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in mcp-use, please report it responsibly.
+
+**Do NOT open a public GitHub issue for security vulnerabilities.**
+
+### How to Report
+
+1. **GitHub Security Advisories**: Use [GitHub's private vulnerability reporting](https://github.com/mcp-use/mcp-use/security/advisories/new)
+2. **Email**: Send details to the maintainers
+
+### What to Include
+
+- Description of the vulnerability
+- Steps to reproduce
+- Impact assessment
+- Suggested fix (if any)
+
+### Response Timeline
+
+- **Acknowledgment**: Within 48 hours
+- **Assessment**: Within 1 week
+- **Fix**: Depends on severity
+
+## Supported Versions
+
+| Version | Supported |
+|---------|:---------:|
+| Latest  | ✅        |
+
+## Security Best Practices for MCP Users
+
+1. **Review server permissions** before connecting to any MCP server
+2. **Use environment variables** for secrets — never hardcode them
+3. **Limit server access** to only required tools and resources
+4. **Monitor server activity** for unexpected behavior
+5. **Keep dependencies updated** to patch known vulnerabilities


### PR DESCRIPTION
Add a security policy document to help users report vulnerabilities responsibly.

## Changes
- Add `SECURITY.md` with:
  - Responsible disclosure guidelines
  - Reporting channels (GitHub Security Advisories + email)
  - Response timeline expectations
  - Security best practices for MCP users

## Why
This repository (9.8K+ stars) currently has no security policy. A `SECURITY.md` helps security researchers know how to report vulnerabilities privately instead of opening public issues.