### PR TITLE
fix(python): set _connected before awaiting cleanup in disconnect

### DIFF
--- a/libraries/python/mcp_use/client/connectors/base.py
+++ b/libraries/python/mcp_use/client/connectors/base.py
@@ -197,9 +197,15 @@ class BaseConnector(ABC):
             logger.debug("Not connected to MCP implementation")
             return
 
+        # Mark as disconnected before awaiting cleanup so that any re-entrant
+        # call (e.g. an AsyncExitStack teardown firing while _cleanup_resources
+        # is suspended) sees _connected == False and returns early instead of
+        # tearing down the same resources twice. The second teardown is what
+        # raises ``ValueError: I/O operation on closed pipe`` on Windows.
+        self._connected = False
+
         logger.debug("Disconnecting from MCP implementation")
         await self._cleanup_resources()
-        self._connected = False
         logger.debug("Disconnected from MCP implementation")
 
     async def _cleanup_resources(self) -> None:

--- a/libraries/python/tests/unit/test_http_connector.py
+++ b/libraries/python/tests/unit/test_http_connector.py
@@ -298,6 +298,48 @@ class TestHttpConnectorConnection(IsolatedAsyncioTestCase):
         self.assertIsNone(self.connector._connection_manager)
         self.assertFalse(self.connector._connected)
 
+    async def test_disconnect_called_twice_runs_cleanup_once(self, _):
+        """Calling disconnect twice in a row must clean up resources only once."""
+        self.connector._connected = True
+        self.connector._connection_manager = self.mock_cm
+        self.connector._cleanup_resources = AsyncMock()
+
+        await self.connector.disconnect()
+        await self.connector.disconnect()
+
+        self.connector._cleanup_resources.assert_called_once()
+        self.assertFalse(self.connector._connected)
+
+    async def test_disconnect_reentrant_call_skips_second_cleanup(self, _):
+        """A re-entrant disconnect during ``_cleanup_resources`` must not run cleanup twice.
+
+        Reproduces the scenario from issue #1220: while the first
+        ``disconnect`` is awaiting ``_cleanup_resources``, an
+        ``AsyncExitStack`` teardown (or another caller) invokes
+        ``disconnect`` again. The guard at the top of ``disconnect`` must
+        already see ``_connected == False`` so the second call returns
+        early instead of re-running cleanup against already-closed
+        resources.
+        """
+        self.connector._connected = True
+        self.connector._connection_manager = self.mock_cm
+
+        cleanup_call_count = 0
+
+        async def reentrant_cleanup():
+            nonlocal cleanup_call_count
+            cleanup_call_count += 1
+            # Simulate a concurrent/re-entrant disconnect firing while we
+            # are still inside the first call's cleanup await.
+            await self.connector.disconnect()
+
+        self.connector._cleanup_resources = reentrant_cleanup
+
+        await self.connector.disconnect()
+
+        self.assertEqual(cleanup_call_count, 1)
+        self.assertFalse(self.connector._connected)
+
 
 @patch("mcp_use.client.connectors.base.logger")
 class TestHttpConnectorOperations(IsolatedAsyncioTestCase):


### PR DESCRIPTION
## Language / Project Scope

Check all that apply:
- [ ] TypeScript
- [x] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

Fixes a re-entrance bug in `BaseConnector.disconnect()` that caused each MCP session to be torn down twice — visible as `ValueError: I/O operation on closed pipe` on Windows and as a noisy `RuntimeError: Event loop is closed` traceback on Unix when calling `MCPClient.close_all_sessions()`.

The `_connected` guard at the top of `disconnect()` was set to `False` *after* `await self._cleanup_resources()`, not before. Any re-entrant caller (e.g. an `AsyncExitStack` teardown firing while the first call was suspended inside `_cleanup_resources()`) saw `self._connected` still `True`, fell through the guard, and ran cleanup against already-closed transports.

## Implementation Details

1. **`libraries/python/mcp_use/client/connectors/base.py`** — In `BaseConnector.disconnect()`, move `self._connected = False` to **before** `await self._cleanup_resources()`. The early-return guard now becomes effective the moment cleanup starts, so any concurrent or re-entrant `disconnect()` call returns immediately instead of double-tearing-down the same transport. Added a short comment explaining the ordering requirement so a future refactor doesn't move it back.
2. **`libraries/python/tests/unit/test_http_connector.py`** — Added two regression tests on `HttpConnector` (which exercises the inherited `BaseConnector.disconnect()`):
   - `test_disconnect_called_twice_runs_cleanup_once` — sequential idempotency: two back-to-back `disconnect()` calls invoke `_cleanup_resources` exactly once.
   - `test_disconnect_reentrant_call_skips_second_cleanup` — reproduces the exact scenario from #1220 by injecting a `_cleanup_resources` that re-enters `disconnect()` while still suspended in the original call. Without the fix this test recurses until `RecursionError`; with the fix it cleanly observes a single cleanup call and `_connected == False`.
3. No new dependencies, no public API changes, no behavioural change for the single-call path.

---

## Python Checklist

### Pre-commit Checklist

- [x] Code formatted with `ruff format` (no diff)
- [x] Linting passes with `ruff check` (no issues)
- [x] Added or updated tests if needed (2 new regression tests)
- [x] Updated documentation if needed (no public API change — none required)

---

## Example Usage (Before)

```python
# Reproducer from the issue
import asyncio
from mcp_use import MCPClient

async def main():
    client = MCPClient.from_dict({
        "mcpServers": {
            "calculator": {
                "command": "npx",
                "args": ["-y", "@modelcontextprotocol/server-everything"],
            }
        }
    })
    await client.create_all_sessions()
    session = client.get_session("calculator")
    await session.call_tool(name="add", arguments={"a": 1, "b": 2})
    await client.close_all_sessions()  # double-close triggered here

asyncio.run(main())
```

Output on Windows 11 (mcp-use 1.6.0):
```
DEBUG - Closing session for server 'calculator'
DEBUG - Closing session for server 'calculator'
ValueError: I/O operation on closed pipe
  File "...\asyncio\windows_utils.py", line 102, in fileno
    raise ValueError("I/O operation on closed pipe")
```

Output on Ubuntu 22.04:
```
Exception ignored in: <function BaseEventLoop.__del__ at 0x...>
RuntimeError: Event loop is closed
```

## Example Usage (After)

Same script. Clean shutdown on both platforms — no traceback, no `ValueError`, no `RuntimeError`. Each connector's `_cleanup_resources()` runs exactly once even when the disconnect path is invoked re-entrantly.

## Documentation Updates

None required — this is a pure bugfix on internal teardown ordering. Public API, docstrings, and examples are unchanged.

## Testing

- **Unit tests added** (`libraries/python/tests/unit/test_http_connector.py`):
  - `test_disconnect_called_twice_runs_cleanup_once` — verifies idempotency on repeated calls.
  - `test_disconnect_reentrant_call_skips_second_cleanup` — directly reproduces the #1220 scenario; fails with `RecursionError` on `main`, passes with this fix.
- **Full unit suite**: `pytest tests/unit` → 307 passed (305 baseline + 2 new), 0 failures.
- **Lint/format**: `ruff check` clean, `ruff format --check` clean on both touched files.
- **Manual verification**: confirmed the reproducer from the issue body runs to completion without traceback after the fix.
- **Edge cases covered**: not-connected state still no-ops; sequential repeated calls only run cleanup once; re-entrant calls during cleanup don't recurse.

## Backwards Compatibility

Fully backwards compatible. The change is internal to `BaseConnector.disconnect()` — same public signature, same observable behaviour for any caller that wasn't already racing or re-entering teardown. Callers that previously crashed (or silently logged a traceback) on `close_all_sessions()` will now shut down cleanly with no other behaviour change.

## Related Issues

Closes #1220
