### PR TITLE
fix(cli): allow "." as project name to init in current directory

### DIFF
--- a/libraries/typescript/.changeset/fix-create-app-dot-directory.md
+++ b/libraries/typescript/.changeset/fix-create-app-dot-directory.md
@@ -1,0 +1,10 @@
+---
+"create-mcp-use-app": patch
+---
+
+fix(cli): allow `.` as project name to initialize in current directory
+
+When running `npx create-mcp-use-app .` in an empty directory, the CLI now
+correctly initializes the project in the current directory instead of erroring
+with "Directory already exists". Uses the directory name for `package.json` name
+and display output. Errors if the directory is not empty.

--- a/libraries/typescript/packages/create-mcp-use-app/src/__tests__/dot-directory.test.ts
+++ b/libraries/typescript/packages/create-mcp-use-app/src/__tests__/dot-directory.test.ts
@@ -1,5 +1,21 @@
-import { describe, it, expect } from "vitest";
-import { sanitizePackageName, isSafeEntry } from "../utils.js";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  deriveProjectInfo,
+  findUnsafeEntries,
+  isSafeEntry,
+  sanitizePackageName,
+  updateIndexTs,
+  updatePackageJson,
+} from "../utils.js";
 
 describe("sanitizePackageName", () => {
   it("lowercases uppercase names", () => {
@@ -35,7 +51,6 @@ describe("sanitizePackageName", () => {
   });
 
   it("handles typical basename from cwd", () => {
-    // e.g., basename of /home/user/My Project Dir
     expect(sanitizePackageName("My Project Dir")).toBe("my-project-dir");
   });
 
@@ -44,65 +59,155 @@ describe("sanitizePackageName", () => {
     expect(sanitizePackageName("my_app")).toBe("my_app");
     expect(sanitizePackageName("myapp123")).toBe("myapp123");
   });
+
+  it("strips characters that would break a TS string literal", () => {
+    // The contract is "safe to embed inside a double-quoted TS string literal".
+    // Asserting that property keeps the test resilient to regex-order tweaks.
+    for (const raw of ['proj "copy"', "proj\\foo", "proj\nfoo"]) {
+      const out = sanitizePackageName(raw);
+      expect(out).toMatch(/^[a-z0-9_.-]+$/);
+      expect(out).not.toContain('"');
+      expect(out).not.toContain("\\");
+      expect(out).not.toContain("\n");
+    }
+  });
 });
 
 describe("isSafeEntry", () => {
-  it("recognizes git artifacts as safe", () => {
-    expect(isSafeEntry(".git")).toBe(true);
-    expect(isSafeEntry(".gitignore")).toBe(true);
-    expect(isSafeEntry(".gitattributes")).toBe(true);
-    expect(isSafeEntry(".gitlab-ci.yml")).toBe(true);
+  // Spot-check; exhaustive enumeration would just re-test the contents of
+  // SAFE_DIR_ENTRIES, which is data, not behavior.
+  it("recognizes representative safe entries", () => {
+    for (const name of [".git", ".vscode", ".DS_Store", "LICENSE"]) {
+      expect(isSafeEntry(name)).toBe(true);
+    }
   });
 
-  it("recognizes mercurial artifacts as safe", () => {
-    expect(isSafeEntry(".hg")).toBe(true);
-    expect(isSafeEntry(".hgcheck")).toBe(true);
-    expect(isSafeEntry(".hgignore")).toBe(true);
-  });
-
-  it("recognizes editor and AI tool directories as safe", () => {
-    expect(isSafeEntry(".idea")).toBe(true);
-    expect(isSafeEntry(".vscode")).toBe(true);
-    expect(isSafeEntry(".zed")).toBe(true);
-    expect(isSafeEntry(".claude")).toBe(true);
-    expect(isSafeEntry(".cursor")).toBe(true);
-  });
-
-  it("recognizes OS-generated files as safe", () => {
-    expect(isSafeEntry(".DS_Store")).toBe(true);
-    expect(isSafeEntry("Thumbs.db")).toBe(true);
-  });
-
-  it("recognizes CI / package manager artifacts as safe", () => {
-    expect(isSafeEntry(".travis.yml")).toBe(true);
-    expect(isSafeEntry(".npmignore")).toBe(true);
-    expect(isSafeEntry("yarnrc.yml")).toBe(true);
-    expect(isSafeEntry(".yarn")).toBe(true);
-    expect(isSafeEntry("npm-debug.log")).toBe(true);
-    expect(isSafeEntry("yarn-debug.log")).toBe(true);
-    expect(isSafeEntry("yarn-error.log")).toBe(true);
-  });
-
-  it("recognizes docs artifacts as safe", () => {
-    expect(isSafeEntry("LICENSE")).toBe(true);
-    expect(isSafeEntry("docs")).toBe(true);
-    expect(isSafeEntry("mkdocs.yml")).toBe(true);
-  });
-
-  it("rejects project files as unsafe", () => {
-    expect(isSafeEntry("package.json")).toBe(false);
-    expect(isSafeEntry("index.ts")).toBe(false);
-    expect(isSafeEntry("node_modules")).toBe(false);
-    expect(isSafeEntry("src")).toBe(false);
-  });
-
-  it("rejects README (not on the allow list)", () => {
-    expect(isSafeEntry("README")).toBe(false);
+  it("rejects project files (would clash with the template)", () => {
+    for (const name of ["package.json", "index.ts", "node_modules", "src"]) {
+      expect(isSafeEntry(name)).toBe(false);
+    }
+    // README is intentionally not on the allow list.
     expect(isSafeEntry("README.md")).toBe(false);
   });
 
   it("is case-sensitive", () => {
     expect(isSafeEntry("license")).toBe(false);
     expect(isSafeEntry(".DS_STORE")).toBe(false);
+  });
+});
+
+describe("findUnsafeEntries (real tmpdirs)", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "create-mcp-use-app-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns [] for an empty directory", () => {
+    expect(findUnsafeEntries(dir)).toEqual([]);
+  });
+
+  it("returns [] when only safe entries are present", () => {
+    mkdirSync(join(dir, ".git"));
+    writeFileSync(join(dir, ".gitignore"), "");
+    writeFileSync(join(dir, "LICENSE"), "MIT");
+    writeFileSync(join(dir, ".DS_Store"), "");
+    expect(findUnsafeEntries(dir)).toEqual([]);
+  });
+
+  it("returns unsafe entries sorted, alongside safe ones", () => {
+    mkdirSync(join(dir, ".git"));
+    writeFileSync(join(dir, "package.json"), "{}");
+    writeFileSync(join(dir, "README.md"), "");
+    mkdirSync(join(dir, "src"));
+    expect(findUnsafeEntries(dir)).toEqual([
+      "README.md",
+      "package.json",
+      "src",
+    ]);
+  });
+});
+
+describe("deriveProjectInfo", () => {
+  it("treats '.' as use-current-directory", () => {
+    const info = deriveProjectInfo(".", "/tmp/My Project");
+    expect(info.useCurrentDir).toBe(true);
+    expect(info.projectPath).toBe("/tmp/My Project");
+    expect(info.displayName).toBe("My Project");
+    // Sanitized so package.json + index.ts string literal stay valid
+    expect(info.packageName).toBe("my-project");
+  });
+
+  it("treats a normal name as a subdirectory", () => {
+    const info = deriveProjectInfo("my-app", "/tmp");
+    expect(info.useCurrentDir).toBe(false);
+    expect(info.projectPath).toBe("/tmp/my-app");
+    expect(info.displayName).toBe("my-app");
+    expect(info.packageName).toBe("my-app");
+  });
+});
+
+// End-to-end: simulates the actual file-mutation step the CLI runs against a
+// scratch directory shaped like a copied template. Verifies that the value
+// flowed into both files is npm-safe and produces a parseable index.ts.
+describe("template file updates against a tmpdir fixture", () => {
+  let dir: string;
+
+  const writeFixture = () => {
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify({ name: "placeholder", description: "" }, null, 2)
+    );
+    writeFileSync(
+      join(dir, "index.ts"),
+      `export const server = {\n  name: "{{PROJECT_NAME}}",\n  title: "{{PROJECT_NAME}}",\n};\n`
+    );
+  };
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "create-mcp-use-app-fixture-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("'.' end-to-end: derives info, writes package.json + index.ts with the sanitized name", () => {
+    const info = deriveProjectInfo(".", "/scratch/My App!");
+    expect(info.packageName).toBe("my-app");
+
+    writeFixture();
+    updatePackageJson(dir, info.packageName);
+    updateIndexTs(dir, info.packageName);
+
+    const pkg = JSON.parse(readFileSync(join(dir, "package.json"), "utf-8"));
+    expect(pkg.name).toBe("my-app");
+    expect(pkg.description).toBe("MCP server: my-app");
+
+    const indexContent = readFileSync(join(dir, "index.ts"), "utf-8");
+    expect(indexContent).toContain('name: "my-app"');
+    expect(indexContent).toContain('title: "my-app"');
+    expect(indexContent).not.toContain("{{PROJECT_NAME}}");
+  });
+
+  it("regression: a basename with quotes flows the sanitized name into index.ts (not the raw one)", () => {
+    // Before the fix, updateIndexTs received the raw displayName, so a cwd
+    // basename like 'My "App"' produced index.ts content `name: "My "App""` —
+    // invalid TypeScript. The sanitized packageName must be used instead.
+    const info = deriveProjectInfo(".", '/scratch/My "App"');
+    expect(info.displayName).toBe('My "App"');
+    expect(info.packageName).not.toContain('"');
+
+    writeFixture();
+    updateIndexTs(dir, info.packageName);
+
+    const indexContent = readFileSync(join(dir, "index.ts"), "utf-8");
+    const match = indexContent.match(/name: "([^"]+)"/);
+    expect(match).not.toBeNull();
+    expect(match![1]).toBe(info.packageName);
   });
 });

--- a/libraries/typescript/packages/create-mcp-use-app/src/__tests__/dot-directory.test.ts
+++ b/libraries/typescript/packages/create-mcp-use-app/src/__tests__/dot-directory.test.ts
@@ -47,35 +47,46 @@ describe("sanitizePackageName", () => {
 });
 
 describe("isSafeEntry", () => {
-  it("recognizes .git as safe", () => {
+  it("recognizes git artifacts as safe", () => {
     expect(isSafeEntry(".git")).toBe(true);
-  });
-
-  it("recognizes .gitignore as safe", () => {
     expect(isSafeEntry(".gitignore")).toBe(true);
+    expect(isSafeEntry(".gitattributes")).toBe(true);
+    expect(isSafeEntry(".gitlab-ci.yml")).toBe(true);
   });
 
-  it("recognizes LICENSE as safe", () => {
-    expect(isSafeEntry("LICENSE")).toBe(true);
+  it("recognizes mercurial artifacts as safe", () => {
+    expect(isSafeEntry(".hg")).toBe(true);
+    expect(isSafeEntry(".hgcheck")).toBe(true);
+    expect(isSafeEntry(".hgignore")).toBe(true);
   });
 
-  it("recognizes README and README.md as safe", () => {
-    expect(isSafeEntry("README")).toBe(true);
-    expect(isSafeEntry("README.md")).toBe(true);
-    expect(isSafeEntry("README.txt")).toBe(true);
-  });
-
-  it("recognizes .DS_Store as safe", () => {
-    expect(isSafeEntry(".DS_Store")).toBe(true);
-  });
-
-  it("recognizes IDE directories as safe", () => {
+  it("recognizes editor and AI tool directories as safe", () => {
     expect(isSafeEntry(".idea")).toBe(true);
     expect(isSafeEntry(".vscode")).toBe(true);
+    expect(isSafeEntry(".zed")).toBe(true);
+    expect(isSafeEntry(".claude")).toBe(true);
+    expect(isSafeEntry(".cursor")).toBe(true);
   });
 
-  it("recognizes Thumbs.db as safe", () => {
+  it("recognizes OS-generated files as safe", () => {
+    expect(isSafeEntry(".DS_Store")).toBe(true);
     expect(isSafeEntry("Thumbs.db")).toBe(true);
+  });
+
+  it("recognizes CI / package manager artifacts as safe", () => {
+    expect(isSafeEntry(".travis.yml")).toBe(true);
+    expect(isSafeEntry(".npmignore")).toBe(true);
+    expect(isSafeEntry("yarnrc.yml")).toBe(true);
+    expect(isSafeEntry(".yarn")).toBe(true);
+    expect(isSafeEntry("npm-debug.log")).toBe(true);
+    expect(isSafeEntry("yarn-debug.log")).toBe(true);
+    expect(isSafeEntry("yarn-error.log")).toBe(true);
+  });
+
+  it("recognizes docs artifacts as safe", () => {
+    expect(isSafeEntry("LICENSE")).toBe(true);
+    expect(isSafeEntry("docs")).toBe(true);
+    expect(isSafeEntry("mkdocs.yml")).toBe(true);
   });
 
   it("rejects project files as unsafe", () => {
@@ -83,5 +94,15 @@ describe("isSafeEntry", () => {
     expect(isSafeEntry("index.ts")).toBe(false);
     expect(isSafeEntry("node_modules")).toBe(false);
     expect(isSafeEntry("src")).toBe(false);
+  });
+
+  it("rejects README (not on the allow list)", () => {
+    expect(isSafeEntry("README")).toBe(false);
+    expect(isSafeEntry("README.md")).toBe(false);
+  });
+
+  it("is case-sensitive", () => {
+    expect(isSafeEntry("license")).toBe(false);
+    expect(isSafeEntry(".DS_STORE")).toBe(false);
   });
 });

--- a/libraries/typescript/packages/create-mcp-use-app/src/__tests__/dot-directory.test.ts
+++ b/libraries/typescript/packages/create-mcp-use-app/src/__tests__/dot-directory.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { sanitizePackageName, isSafeEntry } from "../utils.js";
+
+describe("sanitizePackageName", () => {
+  it("lowercases uppercase names", () => {
+    expect(sanitizePackageName("My-Project")).toBe("my-project");
+  });
+
+  it("replaces spaces with hyphens", () => {
+    expect(sanitizePackageName("my cool project")).toBe("my-cool-project");
+  });
+
+  it("replaces special characters with hyphens", () => {
+    expect(sanitizePackageName("my@project!name")).toBe("my-project-name");
+  });
+
+  it("trims leading dots and dashes", () => {
+    expect(sanitizePackageName("..my-project")).toBe("my-project");
+    expect(sanitizePackageName("--my-project")).toBe("my-project");
+    expect(sanitizePackageName(".-my-project")).toBe("my-project");
+  });
+
+  it("trims trailing dots and dashes", () => {
+    expect(sanitizePackageName("my-project..")).toBe("my-project");
+    expect(sanitizePackageName("my-project--")).toBe("my-project");
+  });
+
+  it("preserves valid npm name characters", () => {
+    expect(sanitizePackageName("my-project_v1.0")).toBe("my-project_v1.0");
+  });
+
+  it("returns fallback for names that become empty", () => {
+    expect(sanitizePackageName("...")).toBe("my-app");
+    expect(sanitizePackageName("@@@")).toBe("my-app");
+  });
+
+  it("handles typical basename from cwd", () => {
+    // e.g., basename of /home/user/My Project Dir
+    expect(sanitizePackageName("My Project Dir")).toBe("my-project-dir");
+  });
+
+  it("handles already-valid names unchanged", () => {
+    expect(sanitizePackageName("my-app")).toBe("my-app");
+    expect(sanitizePackageName("my_app")).toBe("my_app");
+    expect(sanitizePackageName("myapp123")).toBe("myapp123");
+  });
+});
+
+describe("isSafeEntry", () => {
+  it("recognizes .git as safe", () => {
+    expect(isSafeEntry(".git")).toBe(true);
+  });
+
+  it("recognizes .gitignore as safe", () => {
+    expect(isSafeEntry(".gitignore")).toBe(true);
+  });
+
+  it("recognizes LICENSE as safe", () => {
+    expect(isSafeEntry("LICENSE")).toBe(true);
+  });
+
+  it("recognizes README and README.md as safe", () => {
+    expect(isSafeEntry("README")).toBe(true);
+    expect(isSafeEntry("README.md")).toBe(true);
+    expect(isSafeEntry("README.txt")).toBe(true);
+  });
+
+  it("recognizes .DS_Store as safe", () => {
+    expect(isSafeEntry(".DS_Store")).toBe(true);
+  });
+
+  it("recognizes IDE directories as safe", () => {
+    expect(isSafeEntry(".idea")).toBe(true);
+    expect(isSafeEntry(".vscode")).toBe(true);
+  });
+
+  it("recognizes Thumbs.db as safe", () => {
+    expect(isSafeEntry("Thumbs.db")).toBe(true);
+  });
+
+  it("rejects project files as unsafe", () => {
+    expect(isSafeEntry("package.json")).toBe(false);
+    expect(isSafeEntry("index.ts")).toBe(false);
+    expect(isSafeEntry("node_modules")).toBe(false);
+    expect(isSafeEntry("src")).toBe(false);
+  });
+});

--- a/libraries/typescript/packages/create-mcp-use-app/src/index.tsx
+++ b/libraries/typescript/packages/create-mcp-use-app/src/index.tsx
@@ -27,8 +27,6 @@ import React, { useState } from "react";
 import { extract } from "tar";
 import { isSafeEntry, sanitizePackageName } from "./utils.js";
 
-export { sanitizePackageName } from "./utils.js";
-
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
@@ -561,15 +559,22 @@ program
           : sanitizedProjectName;
 
         if (useCurrentDir) {
-          // Allow "." when the directory contains only safe entries
-          // (.git, .gitignore, LICENSE, README*, .DS_Store, .idea, .vscode, Thumbs.db)
+          // Allow "." when the directory contains only safe entries (see SAFE_DIR_ENTRIES)
           const entries = readdirSync(projectPath);
           const unsafeEntries = entries.filter((entry) => !isSafeEntry(entry));
           if (unsafeEntries.length > 0) {
-            console.error(chalk.red("❌ Current directory is not empty!"));
+            console.error(
+              chalk.red(
+                "❌ Cannot initialize here — these entries would clash with the template:"
+              )
+            );
+            for (const entry of unsafeEntries.sort()) {
+              console.error(chalk.red(`   • ${entry}`));
+            }
+            console.error("");
             console.error(
               chalk.yellow(
-                '   Use "." only in an empty directory (or one with only .git, LICENSE, README, etc.), or provide a project name'
+                "   Remove these files, or pass a project name to scaffold into a new subdirectory instead."
               )
             );
             process.exit(1);
@@ -826,8 +831,6 @@ program
         console.log(chalk.bold("🚀 To get started:"));
         if (!useCurrentDir) {
           console.log(chalk.cyan(`   cd ${displayName}`));
-        } else {
-          console.log(chalk.gray("   # already in the project directory"));
         }
         if (!shouldInstall) {
           console.log(
@@ -1349,8 +1352,12 @@ function ProjectNameInput({ onSubmit }: { onSubmit: (name: string) => void }) {
       const entries = readdirSync(process.cwd());
       const unsafeEntries = entries.filter((entry) => !isSafeEntry(entry));
       if (unsafeEntries.length > 0) {
+        const list = unsafeEntries
+          .sort()
+          .map((entry) => `   • ${entry}`)
+          .join("\n");
         setError(
-          'Current directory is not empty. Use "." only in a directory with no project files (safe: .git, LICENSE, README, etc.).'
+          `Cannot initialize here — these entries would clash with the template:\n${list}\n\nRemove these files, or pick a project name to scaffold into a subdirectory.`
         );
         return;
       }

--- a/libraries/typescript/packages/create-mcp-use-app/src/index.tsx
+++ b/libraries/typescript/packages/create-mcp-use-app/src/index.tsx
@@ -25,6 +25,9 @@ import { fileURLToPath } from "node:url";
 import ora from "ora";
 import React, { useState } from "react";
 import { extract } from "tar";
+import { isSafeEntry, sanitizePackageName } from "./utils.js";
+
+export { sanitizePackageName } from "./utils.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -552,18 +555,21 @@ program
         const projectPath = useCurrentDir
           ? process.cwd()
           : resolve(process.cwd(), sanitizedProjectName);
+        // Raw basename for user-facing display; sanitized version for package.json
         const displayName = useCurrentDir
           ? basename(process.cwd())
           : sanitizedProjectName;
 
         if (useCurrentDir) {
-          // Allow "." only when the current directory is empty
+          // Allow "." when the directory contains only safe entries
+          // (.git, .gitignore, LICENSE, README*, .DS_Store, .idea, .vscode, Thumbs.db)
           const entries = readdirSync(projectPath);
-          if (entries.length > 0) {
+          const unsafeEntries = entries.filter((entry) => !isSafeEntry(entry));
+          if (unsafeEntries.length > 0) {
             console.error(chalk.red("❌ Current directory is not empty!"));
             console.error(
               chalk.yellow(
-                '   Use "." only in an empty directory, or provide a project name'
+                '   Use "." only in an empty directory (or one with only .git, LICENSE, README, etc.), or provide a project name'
               )
             );
             process.exit(1);
@@ -643,8 +649,11 @@ program
           options.canary
         );
 
-        // Update package.json with project name
-        updatePackageJson(projectPath, displayName);
+        // Update package.json with project name (sanitized for npm validity)
+        const packageName = useCurrentDir
+          ? sanitizePackageName(displayName)
+          : displayName;
+        updatePackageJson(projectPath, packageName);
 
         // Update index.ts with project name
         updateIndexTs(projectPath, displayName);
@@ -815,7 +824,11 @@ program
         }
         console.log("");
         console.log(chalk.bold("🚀 To get started:"));
-        console.log(chalk.cyan(`   cd ${useCurrentDir ? "." : displayName}`));
+        if (!useCurrentDir) {
+          console.log(chalk.cyan(`   cd ${displayName}`));
+        } else {
+          console.log(chalk.gray("   # already in the project directory"));
+        }
         if (!shouldInstall) {
           console.log(
             chalk.cyan(`   ${getInstallCommand(usedPackageManager)}`)
@@ -1332,11 +1345,12 @@ function ProjectNameInput({ onSubmit }: { onSubmit: (name: string) => void }) {
       return;
     }
     if (trimmed === ".") {
-      // Allow "." — use current directory if it's empty
+      // Allow "." — use current directory if it contains only safe entries
       const entries = readdirSync(process.cwd());
-      if (entries.length > 0) {
+      const unsafeEntries = entries.filter((entry) => !isSafeEntry(entry));
+      if (unsafeEntries.length > 0) {
         setError(
-          'Current directory is not empty. Use "." only in an empty directory.'
+          'Current directory is not empty. Use "." only in a directory with no project files (safe: .git, LICENSE, README, etc.).'
         );
         return;
       }

--- a/libraries/typescript/packages/create-mcp-use-app/src/index.tsx
+++ b/libraries/typescript/packages/create-mcp-use-app/src/index.tsx
@@ -560,11 +560,7 @@ program
           // Allow "." only when the current directory is empty
           const entries = readdirSync(projectPath);
           if (entries.length > 0) {
-            console.error(
-              chalk.red(
-                "❌ Current directory is not empty!"
-              )
-            );
+            console.error(chalk.red("❌ Current directory is not empty!"));
             console.error(
               chalk.yellow(
                 '   Use "." only in an empty directory, or provide a project name'
@@ -630,9 +626,7 @@ program
           mkdirSync(projectPath, { recursive: true });
         }
 
-        console.log(
-          chalk.cyan(`🚀 Creating MCP server "${displayName}"...`)
-        );
+        console.log(chalk.cyan(`🚀 Creating MCP server "${displayName}"...`));
 
         // Validate template name
         const validatedTemplate = validateTemplateName(selectedTemplate);

--- a/libraries/typescript/packages/create-mcp-use-app/src/index.tsx
+++ b/libraries/typescript/packages/create-mcp-use-app/src/index.tsx
@@ -18,7 +18,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { fileURLToPath } from "node:url";
@@ -547,61 +547,92 @@ program
           process.exit(1);
         }
 
-        // Security: Validate project name doesn't contain path traversal
-        if (
-          sanitizedProjectName.includes("..") ||
-          sanitizedProjectName.includes("/") ||
-          sanitizedProjectName.includes("\\")
-        ) {
-          console.error(
-            chalk.red('❌ Project name cannot contain path separators or ".."')
-          );
-          console.error(
-            chalk.yellow('   Use simple names like "my-mcp-server"')
-          );
-          process.exit(1);
-        }
+        // Handle "." — use current directory
+        const useCurrentDir = sanitizedProjectName === ".";
+        const projectPath = useCurrentDir
+          ? process.cwd()
+          : resolve(process.cwd(), sanitizedProjectName);
+        const displayName = useCurrentDir
+          ? basename(process.cwd())
+          : sanitizedProjectName;
 
-        // Validate against common protected directory names
-        const protectedNames = [
-          "node_modules",
-          ".git",
-          ".env",
-          "package.json",
-          "src",
-          "dist",
-        ];
-        if (protectedNames.includes(sanitizedProjectName.toLowerCase())) {
-          console.error(
-            chalk.red(`❌ Cannot use protected name "${sanitizedProjectName}"`)
-          );
-          console.error(
-            chalk.yellow("   Please choose a different project name")
-          );
-          process.exit(1);
+        if (useCurrentDir) {
+          // Allow "." only when the current directory is empty
+          const entries = readdirSync(projectPath);
+          if (entries.length > 0) {
+            console.error(
+              chalk.red(
+                "❌ Current directory is not empty!"
+              )
+            );
+            console.error(
+              chalk.yellow(
+                '   Use "." only in an empty directory, or provide a project name'
+              )
+            );
+            process.exit(1);
+          }
+        } else {
+          // Security: Validate project name doesn't contain path traversal
+          if (
+            sanitizedProjectName.includes("..") ||
+            sanitizedProjectName.includes("/") ||
+            sanitizedProjectName.includes("\\")
+          ) {
+            console.error(
+              chalk.red(
+                '❌ Project name cannot contain path separators or ".."'
+              )
+            );
+            console.error(
+              chalk.yellow('   Use simple names like "my-mcp-server"')
+            );
+            process.exit(1);
+          }
+
+          // Validate against common protected directory names
+          const protectedNames = [
+            "node_modules",
+            ".git",
+            ".env",
+            "package.json",
+            "src",
+            "dist",
+          ];
+          if (protectedNames.includes(sanitizedProjectName.toLowerCase())) {
+            console.error(
+              chalk.red(
+                `❌ Cannot use protected name "${sanitizedProjectName}"`
+              )
+            );
+            console.error(
+              chalk.yellow("   Please choose a different project name")
+            );
+            process.exit(1);
+          }
+
+          // Check if directory already exists
+          if (existsSync(projectPath)) {
+            console.error(
+              chalk.red(
+                `❌ Directory "${sanitizedProjectName}" already exists!`
+              )
+            );
+            console.error(
+              chalk.yellow(
+                "   Please choose a different name or remove the existing directory"
+              )
+            );
+            process.exit(1);
+          }
+
+          // Create project directory
+          mkdirSync(projectPath, { recursive: true });
         }
 
         console.log(
-          chalk.cyan(`🚀 Creating MCP server "${sanitizedProjectName}"...`)
+          chalk.cyan(`🚀 Creating MCP server "${displayName}"...`)
         );
-
-        const projectPath = resolve(process.cwd(), sanitizedProjectName);
-
-        // Check if directory already exists
-        if (existsSync(projectPath)) {
-          console.error(
-            chalk.red(`❌ Directory "${sanitizedProjectName}" already exists!`)
-          );
-          console.error(
-            chalk.yellow(
-              "   Please choose a different name or remove the existing directory"
-            )
-          );
-          process.exit(1);
-        }
-
-        // Create project directory
-        mkdirSync(projectPath, { recursive: true });
 
         // Validate template name
         const validatedTemplate = validateTemplateName(selectedTemplate);
@@ -619,10 +650,10 @@ program
         );
 
         // Update package.json with project name
-        updatePackageJson(projectPath, sanitizedProjectName);
+        updatePackageJson(projectPath, displayName);
 
         // Update index.ts with project name
-        updateIndexTs(projectPath, sanitizedProjectName);
+        updateIndexTs(projectPath, displayName);
 
         // Non-interactive defaults when template is specified via flag
         // Enables usage in CI/tests without blocking prompts
@@ -753,7 +784,7 @@ program
         }
         console.log("");
         console.log(chalk.bold("📁 Project structure:"));
-        console.log(`   ${sanitizedProjectName}/`);
+        console.log(`   ${useCurrentDir ? "." : displayName}/`);
         if (skillsInstalled) {
           console.log("   ├── .agent/skills/");
           console.log("   ├── .claude/skills/");
@@ -790,7 +821,7 @@ program
         }
         console.log("");
         console.log(chalk.bold("🚀 To get started:"));
-        console.log(chalk.cyan(`   cd ${sanitizedProjectName}`));
+        console.log(chalk.cyan(`   cd ${useCurrentDir ? "." : displayName}`));
         if (!shouldInstall) {
           console.log(
             chalk.cyan(`   ${getInstallCommand(usedPackageManager)}`)
@@ -1306,17 +1337,28 @@ function ProjectNameInput({ onSubmit }: { onSubmit: (name: string) => void }) {
       setError("Project name is required");
       return;
     }
-    if (!/^[a-zA-Z0-9-_]+$/.test(trimmed)) {
-      setError(
-        "Project name can only contain letters, numbers, hyphens, and underscores"
-      );
-      return;
-    }
-    if (existsSync(join(process.cwd(), trimmed))) {
-      setError(
-        `Directory "${trimmed}" already exists! Please choose a different name.`
-      );
-      return;
+    if (trimmed === ".") {
+      // Allow "." — use current directory if it's empty
+      const entries = readdirSync(process.cwd());
+      if (entries.length > 0) {
+        setError(
+          'Current directory is not empty. Use "." only in an empty directory.'
+        );
+        return;
+      }
+    } else {
+      if (!/^[a-zA-Z0-9-_]+$/.test(trimmed)) {
+        setError(
+          "Project name can only contain letters, numbers, hyphens, and underscores"
+        );
+        return;
+      }
+      if (existsSync(join(process.cwd(), trimmed))) {
+        setError(
+          `Directory "${trimmed}" already exists! Please choose a different name.`
+        );
+        return;
+      }
     }
 
     onSubmit(trimmed);

--- a/libraries/typescript/packages/create-mcp-use-app/src/index.tsx
+++ b/libraries/typescript/packages/create-mcp-use-app/src/index.tsx
@@ -18,14 +18,19 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { basename, dirname, join, resolve } from "node:path";
+import { dirname, join } from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { fileURLToPath } from "node:url";
 import ora from "ora";
 import React, { useState } from "react";
 import { extract } from "tar";
-import { isSafeEntry, sanitizePackageName } from "./utils.js";
+import {
+  deriveProjectInfo,
+  findUnsafeEntries,
+  updateIndexTs,
+  updatePackageJson,
+} from "./utils.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -541,34 +546,24 @@ program
           selectedTemplate = "starter";
         }
 
-        // Validate project name
-        const sanitizedProjectName = projectName!.trim();
-        if (!sanitizedProjectName) {
+        const trimmedProjectName = projectName!.trim();
+        if (!trimmedProjectName) {
           console.error(chalk.red("❌ Project name cannot be empty"));
           process.exit(1);
         }
 
-        // Handle "." — use current directory
-        const useCurrentDir = sanitizedProjectName === ".";
-        const projectPath = useCurrentDir
-          ? process.cwd()
-          : resolve(process.cwd(), sanitizedProjectName);
-        // Raw basename for user-facing display; sanitized version for package.json
-        const displayName = useCurrentDir
-          ? basename(process.cwd())
-          : sanitizedProjectName;
+        const { useCurrentDir, projectPath, displayName, packageName } =
+          deriveProjectInfo(trimmedProjectName, process.cwd());
 
         if (useCurrentDir) {
-          // Allow "." when the directory contains only safe entries (see SAFE_DIR_ENTRIES)
-          const entries = readdirSync(projectPath);
-          const unsafeEntries = entries.filter((entry) => !isSafeEntry(entry));
+          const unsafeEntries = findUnsafeEntries(projectPath);
           if (unsafeEntries.length > 0) {
             console.error(
               chalk.red(
                 "❌ Cannot initialize here — these entries would clash with the template:"
               )
             );
-            for (const entry of unsafeEntries.sort()) {
+            for (const entry of unsafeEntries) {
               console.error(chalk.red(`   • ${entry}`));
             }
             console.error("");
@@ -582,9 +577,9 @@ program
         } else {
           // Security: Validate project name doesn't contain path traversal
           if (
-            sanitizedProjectName.includes("..") ||
-            sanitizedProjectName.includes("/") ||
-            sanitizedProjectName.includes("\\")
+            trimmedProjectName.includes("..") ||
+            trimmedProjectName.includes("/") ||
+            trimmedProjectName.includes("\\")
           ) {
             console.error(
               chalk.red(
@@ -606,11 +601,9 @@ program
             "src",
             "dist",
           ];
-          if (protectedNames.includes(sanitizedProjectName.toLowerCase())) {
+          if (protectedNames.includes(trimmedProjectName.toLowerCase())) {
             console.error(
-              chalk.red(
-                `❌ Cannot use protected name "${sanitizedProjectName}"`
-              )
+              chalk.red(`❌ Cannot use protected name "${trimmedProjectName}"`)
             );
             console.error(
               chalk.yellow("   Please choose a different project name")
@@ -621,9 +614,7 @@ program
           // Check if directory already exists
           if (existsSync(projectPath)) {
             console.error(
-              chalk.red(
-                `❌ Directory "${sanitizedProjectName}" already exists!`
-              )
+              chalk.red(`❌ Directory "${trimmedProjectName}" already exists!`)
             );
             console.error(
               chalk.yellow(
@@ -654,14 +645,10 @@ program
           options.canary
         );
 
-        // Update package.json with project name (sanitized for npm validity)
-        const packageName = useCurrentDir
-          ? sanitizePackageName(displayName)
-          : displayName;
+        // Templates inline {{PROJECT_NAME}} inside double-quoted string literals,
+        // so both files use the npm-safe packageName, not the raw displayName.
         updatePackageJson(projectPath, packageName);
-
-        // Update index.ts with project name
-        updateIndexTs(projectPath, displayName);
+        updateIndexTs(projectPath, packageName);
 
         // Non-interactive defaults when template is specified via flag
         // Enables usage in CI/tests without blocking prompts
@@ -1218,31 +1205,6 @@ function copyDirectoryWithProcessing(
   }
 }
 
-function updatePackageJson(projectPath: string, projectName: string) {
-  const packageJsonPath = join(projectPath, "package.json");
-  const packageJsonContent = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
-
-  packageJsonContent.name = projectName;
-  packageJsonContent.description = `MCP server: ${projectName}`;
-
-  writeFileSync(packageJsonPath, JSON.stringify(packageJsonContent, null, 2));
-}
-
-function updateIndexTs(projectPath: string, projectName: string) {
-  const indexPath = join(projectPath, "index.ts");
-
-  if (!existsSync(indexPath)) {
-    return; // index.ts doesn't exist, skip
-  }
-
-  let content = readFileSync(indexPath, "utf-8");
-
-  // Replace {{PROJECT_NAME}} placeholders with actual project name
-  content = content.replace(/\{\{PROJECT_NAME\}\}/g, projectName);
-
-  writeFileSync(indexPath, content);
-}
-
 // Ink component for install dependencies prompt (Y/n)
 function InstallPrompt({
   packageManager,
@@ -1348,14 +1310,9 @@ function ProjectNameInput({ onSubmit }: { onSubmit: (name: string) => void }) {
       return;
     }
     if (trimmed === ".") {
-      // Allow "." — use current directory if it contains only safe entries
-      const entries = readdirSync(process.cwd());
-      const unsafeEntries = entries.filter((entry) => !isSafeEntry(entry));
+      const unsafeEntries = findUnsafeEntries(process.cwd());
       if (unsafeEntries.length > 0) {
-        const list = unsafeEntries
-          .sort()
-          .map((entry) => `   • ${entry}`)
-          .join("\n");
+        const list = unsafeEntries.map((entry) => `   • ${entry}`).join("\n");
         setError(
           `Cannot initialize here — these entries would clash with the template:\n${list}\n\nRemove these files, or pick a project name to scaffold into a subdirectory.`
         );

--- a/libraries/typescript/packages/create-mcp-use-app/src/utils.ts
+++ b/libraries/typescript/packages/create-mcp-use-app/src/utils.ts
@@ -1,0 +1,35 @@
+// Utility functions for create-mcp-use-app
+// Extracted to allow testing without heavy UI/CLI dependencies
+
+// Known safe entries that may exist in a directory without considering it "non-empty"
+// Mirrors create-next-app behavior for common init artifacts
+export const SAFE_DIR_ENTRIES = new Set([
+  ".git",
+  ".gitignore",
+  ".DS_Store",
+  ".idea",
+  ".vscode",
+  "LICENSE",
+  "Thumbs.db",
+]);
+
+export function isSafeEntry(name: string): boolean {
+  if (SAFE_DIR_ENTRIES.has(name)) return true;
+  // README with any extension (README, README.md, README.txt, etc.)
+  if (/^README(\.[a-z]+)?$/i.test(name)) return true;
+  return false;
+}
+
+// Sanitize a raw directory name into a valid npm package name
+export function sanitizePackageName(raw: string): string {
+  return (
+    raw
+      .toLowerCase()
+      // Replace any character that isn't [a-z0-9_.-] with a hyphen
+      .replace(/[^a-z0-9_.-]/g, "-")
+      // Trim leading dots and dashes (npm disallows them)
+      .replace(/^[.-]+/, "")
+      // Trim trailing dots and dashes for cleanliness
+      .replace(/[.-]+$/, "") || "my-app"
+  ); // fallback if everything was stripped
+}

--- a/libraries/typescript/packages/create-mcp-use-app/src/utils.ts
+++ b/libraries/typescript/packages/create-mcp-use-app/src/utils.ts
@@ -1,5 +1,9 @@
 // Utility functions for create-mcp-use-app
-// Extracted to allow testing without heavy UI/CLI dependencies
+// Extracted to allow testing without heavy UI/CLI dependencies (index.tsx
+// runs commander on import, so its inner functions can't be imported in tests).
+
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { basename, join, resolve } from "node:path";
 
 // Known safe entries that may exist in a directory without considering it "non-empty"
 // Mirrors create-next-app behavior for common init artifacts
@@ -34,16 +38,75 @@ export function isSafeEntry(name: string): boolean {
   return SAFE_DIR_ENTRIES.has(name);
 }
 
-// Sanitize a raw directory name into a valid npm package name
+// Returns the entries in `dir` that would clash with the template, sorted.
+// An empty result means it's safe to scaffold into `dir`.
+export function findUnsafeEntries(dir: string): string[] {
+  return readdirSync(dir)
+    .filter((entry) => !isSafeEntry(entry))
+    .sort();
+}
+
+// Sanitize a raw directory name into a valid npm package name.
+// npm names must be lowercase and may not contain spaces, most special chars,
+// or leading dots/dashes.
 export function sanitizePackageName(raw: string): string {
   return (
     raw
       .toLowerCase()
-      // Replace any character that isn't [a-z0-9_.-] with a hyphen
       .replace(/[^a-z0-9_.-]/g, "-")
-      // Trim leading dots and dashes (npm disallows them)
       .replace(/^[.-]+/, "")
-      // Trim trailing dots and dashes for cleanliness
       .replace(/[.-]+$/, "") || "my-app"
-  ); // fallback if everything was stripped
+  );
+}
+
+// Resolves what to scaffold given a raw user-supplied name.
+// `displayName` is the human-facing label (kept pretty when possible);
+// `packageName` is the npm-safe identifier flowed into package.json AND
+// any template files that embed it as a string literal (e.g. index.ts).
+export type ProjectInfo = {
+  useCurrentDir: boolean;
+  projectPath: string;
+  displayName: string;
+  packageName: string;
+};
+
+export function deriveProjectInfo(rawName: string, cwd: string): ProjectInfo {
+  const name = rawName.trim();
+  if (name === ".") {
+    const displayName = basename(cwd);
+    return {
+      useCurrentDir: true,
+      projectPath: cwd,
+      displayName,
+      packageName: sanitizePackageName(displayName),
+    };
+  }
+  return {
+    useCurrentDir: false,
+    projectPath: resolve(cwd, name),
+    displayName: name,
+    packageName: name,
+  };
+}
+
+export function updatePackageJson(projectPath: string, projectName: string) {
+  const packageJsonPath = join(projectPath, "package.json");
+  const packageJsonContent = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
+
+  packageJsonContent.name = projectName;
+  packageJsonContent.description = `MCP server: ${projectName}`;
+
+  writeFileSync(packageJsonPath, JSON.stringify(packageJsonContent, null, 2));
+}
+
+export function updateIndexTs(projectPath: string, projectName: string) {
+  const indexPath = join(projectPath, "index.ts");
+
+  if (!existsSync(indexPath)) {
+    return;
+  }
+
+  let content = readFileSync(indexPath, "utf-8");
+  content = content.replace(/\{\{PROJECT_NAME\}\}/g, projectName);
+  writeFileSync(indexPath, content);
 }

--- a/libraries/typescript/packages/create-mcp-use-app/src/utils.ts
+++ b/libraries/typescript/packages/create-mcp-use-app/src/utils.ts
@@ -4,20 +4,34 @@
 // Known safe entries that may exist in a directory without considering it "non-empty"
 // Mirrors create-next-app behavior for common init artifacts
 export const SAFE_DIR_ENTRIES = new Set([
-  ".git",
-  ".gitignore",
+  ".claude",
+  ".cursor",
   ".DS_Store",
+  ".git",
+  ".gitattributes",
+  ".gitignore",
+  ".gitlab-ci.yml",
+  ".hg",
+  ".hgcheck",
+  ".hgignore",
   ".idea",
+  ".npmignore",
+  ".travis.yml",
   ".vscode",
+  ".zed",
   "LICENSE",
   "Thumbs.db",
+  "docs",
+  "mkdocs.yml",
+  "npm-debug.log",
+  "yarn-debug.log",
+  "yarn-error.log",
+  "yarnrc.yml",
+  ".yarn",
 ]);
 
 export function isSafeEntry(name: string): boolean {
-  if (SAFE_DIR_ENTRIES.has(name)) return true;
-  // README with any extension (README, README.md, README.txt, etc.)
-  if (/^README(\.[a-z]+)?$/i.test(name)) return true;
-  return false;
+  return SAFE_DIR_ENTRIES.has(name);
 }
 
 // Sanitize a raw directory name into a valid npm package name


### PR DESCRIPTION
## Summary

When running `npx create-mcp-use-app .` in an empty directory, the CLI errors with "Directory already exists" instead of initializing the project in the current directory. This is unexpected behavior — users expect `.` to mean "use the current directory", consistent with `create-next-app`, `create-vite`, and similar scaffolding tools.

Closes #1406

## Changes

**Non-interactive CLI path (`program.action`):**
- Detect `.` as project name → resolve `projectPath` to `process.cwd()`
- Use `basename(cwd)` as `displayName` for `package.json` name and display output
- Check directory is empty before proceeding (error with clear message if not)
- Skip `mkdirSync` since the directory already exists
- Move all validation (path traversal, protected names, exists check) into `else` branch so `.` bypasses them

**Interactive input (`ProjectNameInput` component):**
- Allow `.` to pass the character regex validation
- Check directory is empty, show validation error if not

## Testing

- Verified code paths: `.` in empty dir → uses cwd, derives name from `basename(cwd)`
- Verified code paths: `.` in non-empty dir → clear error message
- Verified: normal project names (e.g., `my-app`) → unchanged behavior
- Verified: `package.json` and `index.ts` get the correct derived name

🤖 **Disclosure:** This PR was authored by [Kagura](https://github.com/kagura-agent), an AI agent. Open source contribution is one of the things I do — you can see my work history [here](https://github.com/kagura-agent/github-contribution). If you'd prefer not to receive AI-authored PRs, just let me know and I'll stop — no hard feelings.