### PR TITLE
docs(python): clarify how MCPServer surfaces tool validation errors (#1156)

### DIFF
--- a/docs/python/server/tools.mdx
+++ b/docs/python/server/tools.mdx
@@ -300,3 +300,83 @@ def divide(
         raise ValueError("Cannot divide by zero")
     return a / b
 ```
+
+### How errors reach the client
+
+Whether the failure is a tool-raised exception or a Pydantic validation error
+on the arguments, `MCPServer` always returns a regular MCP response — **not** a
+JSON-RPC transport error. The response is a `CallToolResult` with `isError`
+set to `true` and a single `TextContent` block whose text follows the pattern
+`"Error executing tool {name}: {message}"`.
+
+```json
+{
+  "isError": true,
+  "content": [
+    { "type": "text", "text": "Error executing tool divide: Cannot divide by zero" }
+  ]
+}
+```
+
+This means an LLM client always sees the failure as tool output it can read
+and react to (for example by retrying with corrected arguments), rather than
+as a connection-level error that aborts the call.
+
+### Argument validation errors
+
+When a client invokes a tool with arguments that don't match the tool's
+`inputSchema` — a missing required field, a wrong type, an unexpected enum
+value — Pydantic raises `ValidationError` **before your tool function runs**.
+`MCPServer` catches the `ValidationError`, wraps it with the same
+`"Error executing tool {name}: ..."` prefix, and returns it as an
+`isError: true` response.
+
+For example, calling the `search` tool below with no arguments:
+
+```python
+@server.tool()
+def search(
+    query: Annotated[str, Field(description="The search query")],
+) -> list[str]:
+    """Search the index."""
+    return [...]
+```
+
+Produces this `CallToolResult`:
+
+```text
+isError: true
+content[0].text:
+  Error executing tool search: 1 validation error for searchArguments
+  query
+    Field required [type=missing, input_value={}, input_type=dict]
+      For further information visit https://errors.pydantic.dev/2.13/v/missing
+```
+
+The full Pydantic error message — including field name, error type, and the
+input value — is preserved verbatim after the prefix, so the client (or the
+LLM driving it) has enough context to correct the call.
+
+<Note>
+Argument validation errors and exceptions raised inside your tool function
+are surfaced through the **same** path: both end up as
+`CallToolResult(isError=true)` with the `"Error executing tool {name}: ..."`
+prefix. The client cannot distinguish them at the protocol level — only by
+inspecting the message body.
+</Note>
+
+### Pairing with the agent-side `tool_error_middleware`
+
+On the client/agent side, mcp-use ships a built-in
+[`tool_error_middleware`](/docs/python/agent/agent-configuration) that catches
+these `isError: true` responses and feeds the error message back to the LLM so
+it can retry the tool call with corrected arguments. The server-side behavior
+documented above is what makes that retry loop work — because the validation
+failure is encoded as tool output (not a transport error), the agent
+middleware can inspect it, format it, and hand it back to the model on the
+next turn.
+
+If you build a custom client without that middleware, treat any
+`CallToolResult` with `isError: true` as a tool-level failure: read
+`content[0].text` for the human-readable message, and either surface it to
+the user or feed it back to your LLM yourself.


### PR DESCRIPTION
## Language / Project Scope

Check all that apply:
- [ ] TypeScript
- [ ] Python
- [x] Documentation only
- [ ] CI/CD or tooling

## Changes

Closes the documentation gap raised in #1156. The Python server's `tools.mdx` previously had a brief "Error Handling" section covering tool-raised exceptions but never documented what happens when a client calls a tool with arguments that don't match its `inputSchema` — i.e. the case where Pydantic raises `ValidationError` *before* the tool function executes.

This PR adds three subsections under "Error Handling" that document the actual, verified behavior:

1. **How errors reach the client** — explains that all tool failures (raised exceptions and validation errors alike) are returned as `CallToolResult(isError=true)` with content prefixed `"Error executing tool {name}: ..."`, never as JSON-RPC transport errors. Includes the JSON shape of the response.
2. **Argument validation errors** — documents the Pydantic `ValidationError` path specifically, with a worked example showing the exact `content[0].text` returned for a missing required field (field name, error type, input value all preserved).
3. **Pairing with the agent-side `tool_error_middleware`** — links the server-side behavior to the client-side retry loop already documented under agent configuration, so readers understand why this protocol contract matters.

## Implementation Details

1. **`docs/python/server/tools.mdx`** — appended three subsections to the existing `## Error Handling` section. No existing content was modified; the original "raise to fail" example still leads the section as the simplest case, and the new content fills in the protocol-level details that follow.
2. Empirically verified the documented behavior against the upstream `mcp` package before writing — both Pydantic `ValidationError` (missing arg, wrong type) and tool-raised `ValueError` go through `FastMCP.Tool.run()` → `ToolError(f"Error executing tool {name}: {e}")` → lowlevel server's `_make_error_result(...)`, all producing `CallToolResult(isError=true)` with the same prefix. So the docs match what `MCPServer` (which extends `FastMCP`) actually does today.
3. No new dependencies, no behavioural change, no API surface touched.

---

## Python Checklist

### Pre-commit Checklist

- [x] Code formatted with `ruff format` (N/A — docs only, no Python files changed)
- [x] Linting passes with `ruff check` (N/A — docs only)
- [x] Added or updated tests if needed (N/A — docs only)
- [x] Updated documentation if needed (this PR *is* the documentation update)

---

## Example Usage (Before)

The old "Error Handling" section only covered the tool-raised exception case:

```python
@server.tool()
def divide(a: float, b: float) -> float:
    if b == 0:
        raise ValueError("Cannot divide by zero")
    return a / b
```

Readers had no documented answer for any of the questions raised in #1156:
- Does `MCPServer` catch Pydantic `ValidationError` before the tool runs and return it as `isError: true`?
- Or does it bubble up as a transport-level error?
- Is the error message formatted in a specific way?
- How does it interact with the agent-side `tool_error_middleware`?

## Example Usage (After)

A reader can now find authoritative answers in `docs/python/server/tools.mdx`:

> When a client invokes a tool with arguments that don't match the tool's `inputSchema` — a missing required field, a wrong type, an unexpected enum value — Pydantic raises `ValidationError` **before your tool function runs**. `MCPServer` catches the `ValidationError`, wraps it with the same `"Error executing tool {name}: ..."` prefix, and returns it as an `isError: true` response.

…together with the JSON shape, a worked `search(query: str)` example showing the exact `content[0].text` produced for a missing-arg call, and a note explaining why this is what makes the agent-side retry middleware work.

## Documentation Updates

- `docs/python/server/tools.mdx` — added three subsections under `## Error Handling`:
  - "How errors reach the client" (the general protocol contract)
  - "Argument validation errors" (the Pydantic-specific case the issue asked about)
  - "Pairing with the agent-side `tool_error_middleware`" (cross-reference to the retry path)

## Testing

Documentation-only change, but the technical claims were verified empirically:

- Wrote a script that registers tools on `MCPServer`, invokes the lowlevel server's `CallToolRequest` handler with (a) a missing required arg, (b) a wrong-typed arg, (c) a tool that raises `ValueError`. All three produced `CallToolResult(isError=true)` with the documented `"Error executing tool {name}: ..."` prefix and full Pydantic error text preserved. The doc text matches what the script observed.
- Source-checked: `mcp.server.fastmcp.tools.base.Tool.run` (line 117) wraps any exception as `ToolError(f"Error executing tool {self.name}: {e}")`, and `mcp.server.lowlevel.server.call_tool` (line 583) converts that `ToolError` into `CallToolResult(isError=true)` via `_make_error_result(str(e))`. `mcp_use.server.MCPServer` extends `FastMCP`, so it inherits this exact path.
- Mintlify renders fine: only standard markdown plus the existing `<Note>` component already used elsewhere in this file. No new components introduced.

## Backwards Compatibility

Fully backwards compatible. Documentation-only change, no code modified, no public API touched.

## Related Issues

Closes #1156
