### PR TITLE
fix(inspector): detect Hono via duck-typing, not instanceof

### DIFF
--- a/libraries/typescript/.changeset/fix-inspector-hono-duck-type.md
+++ b/libraries/typescript/.changeset/fix-inspector-hono-duck-type.md
@@ -4,7 +4,7 @@
 
 fix(inspector): detect Hono via duck-typing, not `instanceof`
 
-`mountInspector(app)` chose between a fast Hono-direct path and a slower Express-compat bridge based on `app instanceof Hono`. That check is unreliable across a published library boundary: when this package and the host (e.g. `mcp-use`) resolve different `Hono` constructors — common in monorepos where workspace deps hoist their own `hono`, when Node loads Hono's dual CJS+ESM builds from the same on-disk copy as two separate module records, or under bundler dedup — `instanceof` returns false even for a real Hono app. The Express bridge then runs against a Hono `Context` and crashes on every request trying to read `req.headers.host`:
+`mountInspector(app)` chose between a fast Hono-direct path and a slower Express-compat bridge based on `app instanceof Hono`. That check is unreliable across a published library boundary. When this package and the host (e.g. `mcp-use`) resolve different `Hono` constructors (common in monorepos where workspace deps hoist their own `hono`, when Node loads Hono's dual CJS+ESM builds from the same on-disk copy as two separate module records, or under bundler dedup), `instanceof` returns false even for a real Hono app. The Express bridge then runs against a Hono `Context` and crashes on every request trying to read `req.headers.host`:
 
 ```
 TypeError: Cannot read properties of undefined (reading 'host')

--- a/libraries/typescript/.changeset/fix-inspector-hono-duck-type.md
+++ b/libraries/typescript/.changeset/fix-inspector-hono-duck-type.md
@@ -1,0 +1,14 @@
+---
+"@mcp-use/inspector": patch
+---
+
+fix(inspector): detect Hono via duck-typing, not `instanceof`
+
+`mountInspector(app)` chose between a fast Hono-direct path and a slower Express-compat bridge based on `app instanceof Hono`. That check is unreliable across a published library boundary: when this package and the host (e.g. `mcp-use`) resolve different `Hono` constructors — common in monorepos where workspace deps hoist their own `hono`, when Node loads Hono's dual CJS+ESM builds from the same on-disk copy as two separate module records, or under bundler dedup — `instanceof` returns false even for a real Hono app. The Express bridge then runs against a Hono `Context` and crashes on every request trying to read `req.headers.host`:
+
+```
+TypeError: Cannot read properties of undefined (reading 'host')
+    at .../@mcp-use/inspector/dist/server/chunk-*.js (mountInspector Express bridge)
+```
+
+Switch to a duck-type check: Hono apps expose `.fetch(Request) => Response`; Express apps don't. The check is unambiguous for the documented input set and works regardless of which physical Hono module produced the app. Surfaces immediately in the new Next.js drop-in flow (`--mcp-dir`) because Next.js apps almost always pull in a second `hono` through other deps, but the underlying problem applies any time the host and inspector resolve Hono through different module records.

--- a/libraries/typescript/packages/inspector/src/server/middleware.ts
+++ b/libraries/typescript/packages/inspector/src/server/middleware.ts
@@ -61,11 +61,9 @@ export function mountInspector(
   // copy loaded twice by Node, or bundler dedup quirks), `instanceof`
   // returns false even for a real Hono app, and the Express-compat path
   // below runs against a Hono `Context`, crashing on `req.headers.host`.
-  // Express apps don't expose `.fetch`, so this check is unambiguous in
-  // practice for the documented input set.
-  const looksLikeHono =
-    app instanceof Hono || typeof (app as any)?.fetch === "function";
-  if (looksLikeHono) {
+  // Every Hono instance exposes `.fetch`, and Express apps don't, so the
+  // duck-type check alone covers both shapes unambiguously.
+  if (typeof (app as any)?.fetch === "function") {
     registerInspectorRoutes(app as Hono, config);
     registerStaticRoutes(app as Hono, clientDistPath, runtimeConfig);
     return;

--- a/libraries/typescript/packages/inspector/src/server/middleware.ts
+++ b/libraries/typescript/packages/inspector/src/server/middleware.ts
@@ -56,9 +56,9 @@ export function mountInspector(
   //
   // Detect Hono via its `.fetch(Request) => Response` method rather than
   // `app instanceof Hono`. When this package and the host (e.g. `mcp-use`)
-  // resolve different `Hono` constructors — multiple `hono` copies hoisted
+  // resolve different `Hono` constructors (multiple `hono` copies hoisted
   // across a monorepo, the dual CJS/ESM builds shipped from a single on-disk
-  // copy loaded twice by Node, or bundler dedup quirks — `instanceof`
+  // copy loaded twice by Node, or bundler dedup quirks), `instanceof`
   // returns false even for a real Hono app, and the Express-compat path
   // below runs against a Hono `Context`, crashing on `req.headers.host`.
   // Express apps don't expose `.fetch`, so this check is unambiguous in

--- a/libraries/typescript/packages/inspector/src/server/middleware.ts
+++ b/libraries/typescript/packages/inspector/src/server/middleware.ts
@@ -63,9 +63,9 @@ export function mountInspector(
   // below runs against a Hono `Context`, crashing on `req.headers.host`.
   // Every Hono instance exposes `.fetch`, and Express apps don't, so the
   // duck-type check alone covers both shapes unambiguously.
-  if (typeof (app as any)?.fetch === "function") {
-    registerInspectorRoutes(app as Hono, config);
-    registerStaticRoutes(app as Hono, clientDistPath, runtimeConfig);
+  if (isHonoApp(app)) {
+    registerInspectorRoutes(app, config);
+    registerStaticRoutes(app, clientDistPath, runtimeConfig);
     return;
   }
 
@@ -117,4 +117,8 @@ export function mountInspector(
       })
       .catch(next);
   });
+}
+
+function isHonoApp(app: Express | Hono): app is Hono {
+  return typeof (app as { fetch?: unknown }).fetch === "function";
 }

--- a/libraries/typescript/packages/inspector/src/server/middleware.ts
+++ b/libraries/typescript/packages/inspector/src/server/middleware.ts
@@ -52,10 +52,22 @@ export function mountInspector(
     inspectorMode: "embedded" as const,
   };
 
-  // If it's already a Hono app, register routes directly
-  if (app instanceof Hono) {
-    registerInspectorRoutes(app, config);
-    registerStaticRoutes(app, clientDistPath, runtimeConfig);
+  // If it's already a Hono app, register routes directly.
+  //
+  // Detect Hono via its `.fetch(Request) => Response` method rather than
+  // `app instanceof Hono`. When this package and the host (e.g. `mcp-use`)
+  // resolve different `Hono` constructors — multiple `hono` copies hoisted
+  // across a monorepo, the dual CJS/ESM builds shipped from a single on-disk
+  // copy loaded twice by Node, or bundler dedup quirks — `instanceof`
+  // returns false even for a real Hono app, and the Express-compat path
+  // below runs against a Hono `Context`, crashing on `req.headers.host`.
+  // Express apps don't expose `.fetch`, so this check is unambiguous in
+  // practice for the documented input set.
+  const looksLikeHono =
+    app instanceof Hono || typeof (app as any)?.fetch === "function";
+  if (looksLikeHono) {
+    registerInspectorRoutes(app as Hono, config);
+    registerStaticRoutes(app as Hono, clientDistPath, runtimeConfig);
     return;
   }
 


### PR DESCRIPTION
## Summary

`mountInspector(app)` chose between a fast Hono-direct path and a slower Express-compat bridge based on `app instanceof Hono`. That check is unreliable across a published library boundary. When this package and the host (e.g. `mcp-use`) resolve different `Hono` constructors, `instanceof` returns false even for a real Hono app, and the Express bridge runs against a Hono `Context` and crashes on every request trying to read `req.headers.host`.

```
TypeError: Cannot read properties of undefined (reading 'host')
    at .../@mcp-use/inspector/dist/server/chunk-*.js (mountInspector Express bridge)
```

This trips on at least three configurations:

- **Monorepo hoisting**: workspace packages or transitive deps (`@hono/node-server`, etc.) resolve their own copy of `hono`.
- **CJS / ESM dual instantiation**: Hono ships both builds, and Node loads them as separate module records, so a CJS host and an ESM consumer end up with two distinct `Hono` constructors even from a single on-disk copy. This is the [dual-package hazard](https://nodejs.org/api/packages.html#dual-package-hazard).
- **Bundler dedup**: bundled artifacts can carry their own Hono copy.

Surfaces immediately in the new Next.js drop-in flow (`--mcp-dir`) because Next.js apps almost always pull in a second `hono` through other deps, but the underlying issue applies whenever host and inspector resolve Hono through different module records.

## Fix

Switch to duck-typing on a stable public method. Hono apps expose `.fetch(Request) => Response`; Express apps don't. The check is unambiguous for the documented input set and works regardless of which physical `hono` module produced the app.

```ts
const looksLikeHono =
  app instanceof Hono || typeof (app as any)?.fetch === "function";
if (looksLikeHono) {
  registerInspectorRoutes(app as Hono, config);
  registerStaticRoutes(app as Hono, clientDistPath, runtimeConfig);
  return;
}
```

## History

This fix originally landed on the `feat/cli-nextjs-drop-in` branch as commit `3ab18e32` on 2026-04-15, but was reverted on 2026-04-17 by `10aeca4a` ("chore: scope PR to next-js drop-in only") before PR #1332 was merged into `canary`. So the change has lived in git history but isn't present on `main`, `canary`, or any published `@mcp-use/inspector` (3.0.0 stable and 3.0.1-canary.x both still ship `if (app instanceof Hono)`). This PR re-lands it as its own scoped change with a changeset.

Tracked in MCP-1917.

## Test plan

- [ ] `next-js-mcp-app-template` against this build: `npm run mcp:dev`, hit any endpoint, confirm no `TypeError: ... reading 'host'` and the inspector UI loads at `/inspector`.
- [ ] Existing Express-bridge consumers still route through the bridge (`app.fetch` undefined falls through to the bridge, unchanged).
- [ ] Hono-direct consumers continue to register routes directly.