### PR TITLE
fix(oauth): Make Supabase OAuth docs more clear

### DIFF
--- a/docs/typescript/server/authentication/providers/supabase.mdx
+++ b/docs/typescript/server/authentication/providers/supabase.mdx
@@ -4,54 +4,47 @@ description: "Configure Supabase OAuth 2.1 server authentication for your MCP se
 icon: "/images/icons/supabase.svg"
 ---
 
-Supabase's [OAuth 2.1 server](https://supabase.com/docs/guides/auth/oauth-server/getting-started) hosts `/authorize`, `/token`, `/register`, and `.well-known` discovery on your Supabase project — the MCP server only verifies the resulting JWTs. **You host the consent UI**: Supabase redirects the browser to a URL you configure, and your route uses the Supabase JS SDK to load the authorization details, render sign-in + consent, and submit the decision back to Supabase.
+Use [Supabase's OAuth 2.1 server](https://supabase.com/docs/guides/auth/oauth-server/getting-started) to sign users into your MCP server. Supabase handles the OAuth flow and issues the tokens; your server verifies them and you host the consent page.
 
-<Note>
-  This provider targets Supabase's OAuth 2.1 server (see [MCP authentication guide](https://supabase.com/docs/guides/auth/oauth-server/mcp-authentication)). It's a different feature than Supabase Auth's social logins — enable it explicitly in the dashboard under **Authentication → OAuth Server**.
-</Note>
+## Prerequisites
+
+Before your MCP server will work, configure these in the [Supabase Dashboard](https://app.supabase.com/):
+
+<Steps>
+  <Step title="Enable the OAuth 2.1 server">
+    **Authentication → Sign In / Providers → OAuth Server** → toggle on. Also toggle **Allow Dynamic OAuth Apps** so MCP clients can self-register.
+  </Step>
+  <Step title="Set the consent screen URL">
+    Point it at the route your MCP server will host, e.g. `http://localhost:3000/auth/consent`. Supabase redirects the browser here with `?authorization_id=<uuid>` after `/authorize`.
+  </Step>
+  <Step title="Enable a sign-in method">
+    Users must be signed in before they can consent. Pick one under **Authentication → Sign In / Providers**:
+    - **Anonymous sign-ins** — one-click guest sessions, ideal for demos
+    - **Email + password**, **magic links**, or **OAuth providers** (Google, GitHub, etc.) — for real apps
+  </Step>
+  <Step title="Copy your keys">
+    From **Project Settings**:
+    - **Project ID** (General)
+    - **Publishable key** — `sb_publishable_...` (API Keys). Used by *your* consent route and by tools that call Supabase — not by the provider itself.
+  </Step>
+</Steps>
 
 ## Host the consent UI
 
-Supabase redirects the browser to the consent screen URL you configure in the dashboard (e.g. `/auth/consent?authorization_id=<uuid>`). Your route signs the user in, loads the authorization details with the Supabase JS SDK, and submits the approve/deny decision back to Supabase — mcp-use is not involved in this step.
+Supabase redirects the browser to the consent screen URL you configured above. Your route signs the user in, loads the authorization details with the Supabase JS SDK, and submits the approve/deny decision back to Supabase — mcp-use is not involved in this step.
 
-Follow Supabase's [OAuth Server — Getting Started guide](https://supabase.com/docs/guides/auth/oauth-server/getting-started) for the canonical implementation. For a wired-up reference, see the [runnable mcp-use + Supabase example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/supabase).
+Don't want to build it from scratch? Start from the [mcp-oauth-supabase-template](https://github.com/mcp-use/mcp-oauth-supabase-template) — it has sign-in, consent, and approve/deny already wired up. Or follow Supabase's [OAuth Server — Getting Started guide](https://supabase.com/docs/guides/auth/oauth-server/getting-started) to roll your own.
 
-## Setup
-
-### 1. Create a Supabase project
-
-Go to the [Supabase Dashboard](https://app.supabase.com/) and create or select a project. Copy the **Project ID** from **Project Settings → General**.
-
-### 2. Enable the OAuth Server
-
-In **Authentication → OAuth Server**, enable the OAuth 2.1 server and set the **consent screen URL** to the route your MCP server will host:
-
-```
-http://localhost:3000/auth/consent
-```
-
-Supabase will redirect users here with `?authorization_id=<uuid>` after `/authorize`.
-
-### 3. Enable a sign-in method
-
-Users must be signed in before they can consent. Pick one in **Authentication → Sign In / Providers**:
-
-- **Anonymous sign-ins** — one-click guest sessions, ideal for demos
-- **Email + password**, **magic links**, or **OAuth providers** (Google, GitHub, etc.) — for real apps
-
-### 4. Environment variables
+## Environment variables
 
 ```bash
+# Required — read by oauthSupabaseProvider()
 MCP_USE_OAUTH_SUPABASE_PROJECT_ID=your-project-id
 
-# Publishable key (sb_publishable_...) from Project Settings → API Keys.
-# Used by the consent UI and by tools calling Supabase REST/APIs.
+# Used by your consent UI and by tools calling Supabase REST/APIs.
+# Not read by oauthSupabaseProvider() itself.
 MCP_USE_OAUTH_SUPABASE_PUBLISHABLE_KEY=sb_publishable_...
 ```
-
-<Note>
-  New Supabase projects issue `sb_publishable_...` keys. If your project still uses the legacy `anon` JWT key, it will continue to work here — but prefer publishable keys going forward.
-</Note>
 
 ## Configure the MCP server
 
@@ -134,7 +127,7 @@ server.tool(
 
 ## Resources
 
-- [Runnable mcp-use + Supabase example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/supabase)
+- [mcp-oauth-supabase-template](https://github.com/mcp-use/mcp-oauth-supabase-template) — starter template with the consent UI already wired up
 - [Supabase OAuth Server — Getting Started](https://supabase.com/docs/guides/auth/oauth-server/getting-started)
 - [Supabase OAuth Server — MCP Authentication](https://supabase.com/docs/guides/auth/oauth-server/mcp-authentication)
 - [Row Level Security](https://supabase.com/docs/guides/auth/row-level-security)

--- a/libraries/typescript/.changeset/supabase-oauth-2-1-endpoints.md
+++ b/libraries/typescript/.changeset/supabase-oauth-2-1-endpoints.md
@@ -1,0 +1,9 @@
+---
+"mcp-use": patch
+---
+
+Fix Supabase OAuth provider to use OAuth 2.1 server endpoints
+
+`SupabaseOAuthProvider.getAuthEndpoint()` and `getTokenEndpoint()` now return `/auth/v1/oauth/authorize` and `/auth/v1/oauth/token` — the OAuth 2.1 server paths — instead of the legacy `/auth/v1/authorize` and `/auth/v1/token`. Metadata discovery and JWT verification were already correct, so most DCR-direct clients weren't affected, but any code path that consulted the provider's endpoint getters was pointed at the wrong URLs.
+
+Also clarifies the Supabase provider docs: adds a `<Steps>` prerequisites block (enable OAuth Server, allow dynamic OAuth apps, set consent URL, pick a sign-in method) and notes that `MCP_USE_OAUTH_SUPABASE_PUBLISHABLE_KEY` is used by your consent UI and Supabase SDK calls — the provider itself only needs the project ID.

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/providers/supabase.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/providers/supabase.ts
@@ -109,11 +109,11 @@ export class SupabaseOAuthProvider implements OAuthProvider {
   }
 
   getAuthEndpoint(): string {
-    return `${this.supabaseAuthUrl}/authorize`;
+    return `${this.supabaseAuthUrl}/oauth/authorize`;
   }
 
   getTokenEndpoint(): string {
-    return `${this.supabaseAuthUrl}/token`;
+    return `${this.supabaseAuthUrl}/oauth/token`;
   }
 
   getScopesSupported(): string[] {


### PR DESCRIPTION
## Language / Project Scope

Check all that apply:
- [x] TypeScript
- [ ] Python
- [x] Documentation only
- [ ] CI/CD or tooling

## Changes

`SupabaseOAuthProvider.getAuthEndpoint()` and `getTokenEndpoint()` were returning the legacy Supabase Auth paths (`/auth/v1/authorize`, `/auth/v1/token`) instead of the OAuth 2.1 server paths (`/auth/v1/oauth/authorize`, `/auth/v1/oauth/token`). Discovery metadata and JWT verification were already correct, so DCR-direct clients weren't broken — but anything that consulted the provider's endpoint getters was being pointed at URLs that don't serve the OAuth 2.1 server.

The Supabase provider docs were also out of sync with what the code actually requires, so they've been restructured.

## Implementation Details

1. `libraries/typescript/packages/mcp-use/src/server/oauth/providers/supabase.ts` — `getAuthEndpoint()` now returns `${supabaseAuthUrl}/oauth/authorize` and `getTokenEndpoint()` returns `${supabaseAuthUrl}/oauth/token`.
2. `docs/typescript/server/authentication/providers/supabase.mdx` — replaced the numbered "Setup" subsections with a `<Steps>`-based **Prerequisites** block (enable OAuth Server, allow Dynamic OAuth Apps, set consent URL, pick a sign-in method, copy keys); clarified that `MCP_USE_OAUTH_SUPABASE_PUBLISHABLE_KEY` is consumed by the consent UI / Supabase SDK calls and not by `oauthSupabaseProvider()` itself; swapped the in-repo example link for the standalone [`mcp-oauth-supabase-template`](https://github.com/mcp-use/mcp-oauth-supabase-template) starter.
3. Added a `mcp-use` patch changeset.

---

## TypeScript Checklist

### Packages Modified

- [x] `docs`
- [ ] `tests`
- [ ] `cli`
- [ ] `create-mcp-use-app`
- [x] `mcp-use` (server)
- [ ] `mcp-use` (client)
- [ ] `inspector`

### Pre-commit Checklist

- [ ] Ran `pnpm lint:fix` to auto-fix linting issues
- [ ] Ran `pnpm format` to format code with Prettier
- [ ] Ran `pnpm build` and build succeeds without errors
- [x] Ran `pnpm changeset` to create a changeset (if this PR includes user-facing changes)
- [ ] Added or updated tests if needed
- [x] Updated documentation in `docs/` folder if needed

---

## Example Usage (Before)

```ts
// SupabaseOAuthProvider returned the legacy Supabase Auth paths
provider.getAuthEndpoint();
// → https://<project>.supabase.co/auth/v1/authorize  (not the OAuth 2.1 server)
provider.getTokenEndpoint();
// → https://<project>.supabase.co/auth/v1/token      (not the OAuth 2.1 server)
```

## Example Usage (After)

```ts
provider.getAuthEndpoint();
// → https://<project>.supabase.co/auth/v1/oauth/authorize
provider.getTokenEndpoint();
// → https://<project>.supabase.co/auth/v1/oauth/token
```

## Documentation Updates

* `docs/typescript/server/authentication/providers/supabase.mdx` — restructured around a `<Steps>` prerequisites block, clarified env-var ownership (`MCP_USE_OAUTH_SUPABASE_PUBLISHABLE_KEY` is consumed by the consent UI, not the provider), and replaced the in-repo example link with the [`mcp-oauth-supabase-template`](https://github.com/mcp-use/mcp-oauth-supabase-template) starter repo.

## Testing

- Verified the new endpoint strings match Supabase's OAuth 2.1 server paths documented at https://supabase.com/docs/guides/auth/oauth-server/getting-started.
- No behavior change for clients that only consume discovery metadata or JWT verification — both paths were already correct.

## Backwards Compatibility

Backwards compatible for the typical DCR-direct flow (discovery metadata and JWT verification were unchanged). Code paths that called `getAuthEndpoint()` / `getTokenEndpoint()` directly were broken before this change and are fixed by it — no migration required.

## Related Issues

MCP-1931