### PR TITLE
fix(ci): skip test-result comment job on fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,7 +251,9 @@ jobs:
 
   python-transport-tests-report:
     needs: python-transport-tests
-    if: always() && github.event_name == 'pull_request' && needs.python-transport-tests.result != 'skipped'
+    # Fork PRs get a read-only GITHUB_TOKEN even with the permissions block above,
+    # so createComment 403s. Skip on forks; head_repo == base_repo means same-repo branch.
+    if: always() && github.event_name == 'pull_request' && needs.python-transport-tests.result != 'skipped' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -416,7 +418,8 @@ jobs:
 
   python-primitive-tests-report:
     needs: python-primitive-tests
-    if: always() && github.event_name == 'pull_request' && needs.python-primitive-tests.result != 'skipped'
+    # See python-transport-tests-report: skip on forks to avoid the read-only-token 403.
+    if: always() && github.event_name == 'pull_request' && needs.python-primitive-tests.result != 'skipped' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
## Problem

`python-transport-tests-report` and `python-primitive-tests-report` post a summary comment to the PR via `github-script` `issues.createComment`. The job declares `permissions: pull-requests: write`, but on `pull_request` runs originating from a fork, GitHub forces the `GITHUB_TOKEN` to read-only regardless of the permissions block (security guarantee for fork code).

Result: every fork PR that touches python sees both report jobs fail red with `403 Resource not accessible by integration`, even when every test in `python-primitive/*` and `python-transport/*` actually passed.

Example run on PR #1421 (`fix/disconnect-reentrant-race-ws-sandbox-subclasses`): 33 of 35 jobs green, 2 red, both red are the report jobs trying to `POST /repos/mcp-use/mcp-use/issues/1421/comments`. Tests themselves report `✅ All transport tests passed!` and `✅ All primitive tests passed!` in the failed step's body before the createComment call 403s.

## Fix

Gate both report jobs on `github.event.pull_request.head.repo.full_name == github.repository`. They run as before for same-repo branch PRs (where the permissions block is honored and `createComment` succeeds). They skip cleanly on fork PRs, so the rollup status is no longer red for a permissions issue the contributor cannot fix.

The actual test results remain visible:
- in each `python-primitive/*` and `python-transport/*` job log
- in the job summary tables (parsed and rendered before the failed createComment)
- in artifacts uploaded by the parent test jobs

## Why not `pull_request_target` or `workflow_run`

`pull_request_target` would grant write tokens to fork-PR runs but is unsafe to mix with code that executes from the PR head. `workflow_run` would post the comment from a base-repo workflow with full token, but requires splitting the comment-rendering logic into a new workflow file plus an artifact carrying the PR number — bigger refactor than the bug calls for. This PR is the narrow fix; the workflow_run pattern is a fine follow-up if maintainers want fork PRs to receive the comment.

## Test plan

- [ ] Same-repo branch PR continues to receive both summary comments (no behavior change).
- [ ] Fork PR rollup is green when all tests pass; the two report jobs show as `Skipped` rather than `Failed`.
- [ ] No change to test execution: `python-primitive/*` and `python-transport/*` still run and gate the rollup.