### PR TITLE
fix(widgets): pre-warm Vite entries before registration to prevent first-render 504s

### DIFF
--- a/libraries/typescript/.changeset/fix-widget-dev-deps-504.md
+++ b/libraries/typescript/.changeset/fix-widget-dev-deps-504.md
@@ -1,0 +1,9 @@
+---
+"mcp-use": patch
+---
+
+fix(widgets): pre-warm widget Vite entries before registration to prevent first-render `/.vite/deps/*` 504s
+
+When a widget is registered (initial boot, watcher add-file, or watcher add-folder), `mount-widgets-dev` now calls `viteServer.warmupRequest()` followed by `viteServer.waitForRequestsIdle()` for the widget's `entry.tsx` before exposing it to the inspector. This forces Vite's `depsOptimizer` to finish pre-bundling and stabilise its dependency hash before the browser starts requesting `/.vite/deps/*` modules.
+
+Previously, the inspector iframe could fetch optimized dependencies (e.g. `mcp-use_react.js`) with a stale Vite hash while `depsOptimizer` was still re-bundling, which surfaced as `504 Gateway Timeout` errors and a blank widget on first interaction in Vibe-created sandboxes. Each widget is warmed at most once per dev-server lifetime; failures fall back to a warning so registration never blocks.

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/mount-widgets-dev.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/mount-widgets-dev.ts
@@ -381,9 +381,13 @@ if (container && Component) {
   };
 
   // Create a plugin to ensure Vite watches the resources directory for HMR
-  let warmWidgetEntry:
-    | ((slugifiedName: string, reason: string) => Promise<void>)
-    | undefined;
+  const warmWidgetEntry: {
+    current: (slugifiedName: string, reason: string) => Promise<void>;
+  } = {
+    current: async () => {
+      // No-op until Vite server is fully initialised.
+    },
+  };
   const watchResourcesPlugin = {
     name: "watch-resources",
     configureServer(server: any) {
@@ -865,7 +869,7 @@ if (container && Component) {
 
               // Create temp files and register widget
               await createWidgetTempFiles(widgetName, filePath);
-              await warmWidgetEntry?.(widgetName, "watch-add-file");
+              await warmWidgetEntry.current(widgetName, "watch-add-file");
               await extractAndRegisterWidget(widgetName, filePath);
 
               console.log(`[WIDGETS] New widget added: ${widgetName}`);
@@ -907,7 +911,7 @@ if (container && Component) {
 
                 // Create temp files and register widget
                 await createWidgetTempFiles(widgetName, filePath);
-                await warmWidgetEntry?.(widgetName, "watch-add-folder");
+                await warmWidgetEntry.current(widgetName, "watch-add-folder");
                 await extractAndRegisterWidget(widgetName, filePath);
 
                 console.log(`[WIDGETS] New widget added: ${widgetName}`);
@@ -1256,7 +1260,7 @@ export default PostHog;
   // and can fetch optimized deps with a stale hash, manifesting as 504s on
   // `/.vite/deps/*` requests on first widget render.
   const warmedWidgetEntries = new Set<string>();
-  warmWidgetEntry = async (widgetName: string, _reason: string) => {
+  warmWidgetEntry.current = async (widgetName: string, _reason: string) => {
     const slugifiedName = slugifyWidgetName(widgetName);
     const entryUrl = `/${slugifiedName}/entry.tsx`;
     if (warmedWidgetEntries.has(entryUrl)) return;
@@ -1487,7 +1491,7 @@ export default PostHog;
 
     // Use the extracted helper to register the widget
     const slugifiedName = slugifyWidgetName(widget.name);
-    await warmWidgetEntry?.(widget.name, "initial-registration");
+    await warmWidgetEntry.current(widget.name, "initial-registration");
     await registerWidgetFromTemplate(
       widget.name,
       pathHelpers.join(tempDir, slugifiedName, "index.html"),

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/mount-widgets-dev.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/mount-widgets-dev.ts
@@ -381,6 +381,9 @@ if (container && Component) {
   };
 
   // Create a plugin to ensure Vite watches the resources directory for HMR
+  let warmWidgetEntry:
+    | ((slugifiedName: string, reason: string) => Promise<void>)
+    | undefined;
   const watchResourcesPlugin = {
     name: "watch-resources",
     configureServer(server: any) {
@@ -862,6 +865,7 @@ if (container && Component) {
 
               // Create temp files and register widget
               await createWidgetTempFiles(widgetName, filePath);
+              await warmWidgetEntry?.(widgetName, "watch-add-file");
               await extractAndRegisterWidget(widgetName, filePath);
 
               console.log(`[WIDGETS] New widget added: ${widgetName}`);
@@ -903,6 +907,7 @@ if (container && Component) {
 
                 // Create temp files and register widget
                 await createWidgetTempFiles(widgetName, filePath);
+                await warmWidgetEntry?.(widgetName, "watch-add-folder");
                 await extractAndRegisterWidget(widgetName, filePath);
 
                 console.log(`[WIDGETS] New widget added: ${widgetName}`);
@@ -1246,6 +1251,31 @@ export default PostHog;
     },
   });
 
+  // Pre-bundle a widget's dependencies via Vite's optimizer before the inspector
+  // requests its assets. Without this, the browser races against `depsOptimizer`
+  // and can fetch optimized deps with a stale hash, manifesting as 504s on
+  // `/.vite/deps/*` requests on first widget render.
+  const warmedWidgetEntries = new Set<string>();
+  warmWidgetEntry = async (widgetName: string, _reason: string) => {
+    const slugifiedName = slugifyWidgetName(widgetName);
+    const entryUrl = `/${slugifiedName}/entry.tsx`;
+    if (warmedWidgetEntries.has(entryUrl)) return;
+
+    try {
+      if (typeof viteServer.warmupRequest === "function") {
+        await viteServer.warmupRequest(entryUrl);
+      } else {
+        await viteServer.transformRequest(entryUrl);
+      }
+      if (typeof viteServer.waitForRequestsIdle === "function") {
+        await viteServer.waitForRequestsIdle(entryUrl);
+      }
+      warmedWidgetEntries.add(entryUrl);
+    } catch (error) {
+      console.warn(`[WIDGETS] Failed to warm widget entry ${entryUrl}:`, error);
+    }
+  };
+
   // Set up WebSocket proxy for Vite HMR through the main HTTP server.
   // In middleware mode, Vite creates its own WebSocket on a random port (e.g., 24678).
   // Reverse proxies (ngrok, E2B) only forward traffic on the main port.
@@ -1457,6 +1487,7 @@ export default PostHog;
 
     // Use the extracted helper to register the widget
     const slugifiedName = slugifyWidgetName(widget.name);
+    await warmWidgetEntry?.(widget.name, "initial-registration");
     await registerWidgetFromTemplate(
       widget.name,
       pathHelpers.join(tempDir, slugifiedName, "index.html"),


### PR DESCRIPTION
When a widget is registered (initial boot, watcher add-file, or watcher
add-folder), `mount-widgets-dev` now calls `viteServer.warmupRequest()`
followed by `viteServer.waitForRequestsIdle()` for the widget's
`entry.tsx` before exposing it to the inspector. This forces Vite's
`depsOptimizer` to finish pre-bundling and stabilise its dependency
hash before the browser starts requesting `/.vite/deps/*` modules.

Previously the inspector iframe could fetch optimized dependencies
(e.g. `mcp-use_react.js`) with a stale Vite hash while `depsOptimizer`
was still re-bundling, surfacing as `504 Gateway Timeout` errors and a
blank widget on first interaction in Vibe-created sandboxes. Each
widget is warmed at most once per dev-server lifetime; failures fall
back to a warning so registration never blocks.
