### PR TITLE
fix(widgets): pre-warm Vite entries before registration to prevent fi…

### DIFF
--- a/docs/inspector/changelog.mdx
+++ b/docs/inspector/changelog.mdx
@@ -6,6 +6,14 @@ rss: true
 tag: "New"
 ---
 
+<Update label="v3.0.2" description="April 2026">
+  ## E2E alignment for Settings dropdown
+  Patch release updating Playwright coverage for the command palette Settings entry after the navbar refactor; paired with `mcp-use` v1.25.2.
+
+- **Fix**: Command palette e2e test targets the Settings option via the dropdown trigger introduced in the inspector settings UX (`#1428`)
+- **Update**: Updated mcp-use to v1.25.2
+</Update>
+
 <Update label="v3.0.1" description="April 2026">
   ## OAuth single-tab flow, embed fixes & Hono detection
   Patch release fixing OAuth redirect flows, embedded `ChatTab` UI leaks, and Hono duck-type detection in `mountInspector`; paired with `mcp-use` v1.25.1.

--- a/docs/typescript/changelog/changelog.mdx
+++ b/docs/typescript/changelog/changelog.mdx
@@ -6,6 +6,18 @@ rss: true
 tag: "New"
 ---
 
+<Update label="v1.25.2" description="April 2026">
+  ## Debug log tiers & widget dev first render
+  Patch release adding tiered `MCP_DEBUG_LEVEL` logging for MCP servers, pre-warming Vite widget entries in dev to avoid first-render 504s, and Inspector 3.0.2 (see inspector changelog).
+
+- **New**: `MCP_DEBUG_LEVEL` environment variable on MCP servers — `info` (default), `debug`, or `trace` — tiered framework logging with clearer precedence than legacy truthy `DEBUG` (`#1430`)
+- **Fix**: Widget dev server pre-warms Vite entries before tool registration so the first widget render does not time out with HTTP 504 (`#1425`)
+- **Fix** (@mcp-use/inspector): Command palette e2e tests updated for the Settings dropdown trigger (`#1428`) (see inspector changelog)
+- **Update**: Updated @mcp-use/inspector to v3.0.2
+- **Update**: Updated @mcp-use/cli to v3.1.2
+- **Update**: Updated create-mcp-use-app to v0.14.10
+</Update>
+
 <Update label="v1.25.1" description="April 2026">
   ## OAuth error handling, Supabase endpoints & CLI bundling
   Patch release fixing OAuth error redirects, Supabase OAuth 2.1 endpoints, CLI bundling for Node ESM, bun build compatibility, `create-mcp-use-app` dot-directory init, and Inspector 3.0.1 (see inspector changelog).

--- a/docs/typescript/server/configuration.mdx
+++ b/docs/typescript/server/configuration.mdx
@@ -76,7 +76,7 @@ The server reads the following environment variables at runtime:
 | `HOST` | Bind hostname | `localhost` |
 | `MCP_URL` | Full public base URL (for widget/asset URLs) | `http://{HOST}:{PORT}` |
 | `NODE_ENV` | `production` disables dev features (inspector, type generation) | — |
-| `DEBUG` | Enables verbose debug logging | — |
+| `MCP_DEBUG_LEVEL` | Request log verbosity: `info`, `debug`, or `trace` | `info` |
 | `CSP_URLS` | Comma-separated extra URLs added to widget CSP `resource_domains` | — |
 
 **OAuth providers** also read zero-config env vars — see the OAuth docs for the full list.

--- a/docs/typescript/server/logging.mdx
+++ b/docs/typescript/server/logging.mdx
@@ -8,11 +8,11 @@ mcp-use provides comprehensive logging for MCP servers, making it easy to unders
 
 ## Log Levels
 
-The server provides different logging levels through environment variables:
+HTTP request logging is controlled by the `MCP_DEBUG_LEVEL` environment variable, which has three levels: `info` (default), `debug`, and `trace`.
 
-### Production Mode (Default)
+### Info (Default)
 
-Clean, informative logs showing MCP operations:
+One compact line per request — session, client, the MCP method, and the outcome:
 
 ```bash
 node server.js
@@ -21,60 +21,35 @@ node server.js
 **Output:**
 
 ```
-[MCP] Server mounted at /mcp (Streamable HTTP Transport)
-[MCP] Session initialized: abc123
-[MCP] tools/call:analyze-sentiment completed in 234ms
-[MCP] Session closed: abc123
+[19:44:56.927] POST /mcp [initialize: my-client/0.1.0] → session=92c4e0b OK (1ms)
+[19:44:56.935] sess=92c4e0b POST /mcp [notifications/initialized] OK (1ms)
+[19:44:56.943] sess=92c4e0b POST /mcp [tools/list] OK (1ms)
+[19:44:56.950] sess=92c4e0b POST /mcp [tools/call: greet] OK (1ms)
+[19:44:56.958] sess=92c4e0b POST /mcp [tools/call: divide] ERROR cannot divide by zero (0ms)
+[19:44:56.965] sess=92c4e0b POST /mcp [tools/call: does-not-exist] ERROR MCP error -32602: Tool does-not-exist not found (0ms)
 ```
 
-### Debug Mode
+### Debug
 
-Enable debug mode for development and troubleshooting:
+Same as `info` but appends inline `args=<json>` for `tools/call` requests:
 
 ```bash
-DEBUG=1 node server.js
+MCP_DEBUG_LEVEL=debug node server.js
 ```
 
 **Output:**
 
 ```
-[MCP] Server initialized: my-server v1.0.0
-[MCP] Registered tool: analyze-sentiment
-[MCP] Registered resource: config://app-settings
-[MCP] Session initialized: abc123
-[MCP] tools/call:analyze-sentiment started
-[MCP] tools/call:analyze-sentiment completed in 234ms
+[19:44:57.918] sess=f93f8b1 POST /mcp [tools/call: greet] args={"name":"Andrew","formal":true} OK (1ms)
+[19:44:57.926] sess=f93f8b1 POST /mcp [tools/call: divide] args={"a":10,"b":0} ERROR cannot divide by zero (0ms)
 ```
 
-### Verbose Debug Mode
+### Trace
 
-Full request/response logging with JSON-RPC details:
+Full request and response dump (headers and bodies) following the summary line — useful for protocol-level debugging:
 
 ```bash
-DEBUG=2 node server.js
-```
-
-**Output:**
-
-```
-[MCP] Session initialized: abc123
-[MCP] → Request: {
-  "jsonrpc": "2.0",
-  "id": 1,
-  "method": "tools/call",
-  "params": {
-    "name": "analyze-sentiment",
-    "arguments": { "text": "I love this!" }
-  }
-}
-[MCP] tools/call:analyze-sentiment completed in 234ms
-[MCP] ← Response: {
-  "jsonrpc": "2.0",
-  "id": 1,
-  "result": {
-    "content": [{ "type": "text", "text": "Sentiment: positive" }]
-  }
-}
+MCP_DEBUG_LEVEL=trace node server.js
 ```
 
 ## Built-in Logging System

--- a/libraries/typescript/.changeset/fix-widget-dev-deps-504.md
+++ b/libraries/typescript/.changeset/fix-widget-dev-deps-504.md
@@ -1,0 +1,9 @@
+---
+"mcp-use": patch
+---
+
+fix(widgets): pre-warm widget Vite entries before registration to prevent first-render `/.vite/deps/*` 504s
+
+When a widget is registered (initial boot, watcher add-file, or watcher add-folder), `mount-widgets-dev` now calls `viteServer.warmupRequest()` followed by `viteServer.waitForRequestsIdle()` for the widget's `entry.tsx` before exposing it to the inspector. This forces Vite's `depsOptimizer` to finish pre-bundling and stabilise its dependency hash before the browser starts requesting `/.vite/deps/*` modules.
+
+Previously, the inspector iframe could fetch optimized dependencies (e.g. `mcp-use_react.js`) with a stale Vite hash while `depsOptimizer` was still re-bundling, which surfaced as `504 Gateway Timeout` errors and a blank widget on first interaction in Vibe-created sandboxes. Each widget is warmed at most once per dev-server lifetime; failures fall back to a warning so registration never blocks.

--- a/libraries/typescript/.changeset/mcp-debug-level.md
+++ b/libraries/typescript/.changeset/mcp-debug-level.md
@@ -1,0 +1,14 @@
+---
+"mcp-use": minor
+---
+
+feat(server): add `MCP_DEBUG_LEVEL` env var with `info` / `debug` / `trace` levels for HTTP request logs
+
+Replaces the previous all-or-nothing `DEBUG=1` behavior with three explicit verbosity levels:
+
+- `info` (default): one compact line per request, e.g.
+  `[19:44:56] POST /mcp [tools/call: greet] OK (1ms)`. Initialize lines now include the client `name/version` and the new short session id (`→ session=92c4e0b`); subsequent requests are prefixed with `sess=<short>`. JSON-RPC and tool errors are extracted from the response body and shown inline (`ERROR cannot divide by zero`).
+- `debug`: same as `info` plus inline `args=<json>` for `tools/call`.
+- `trace`: identical to the legacy `DEBUG=1` output (full request/response headers and bodies).
+
+`DEBUG=1` (or any truthy `DEBUG` value) continues to work and maps to `trace`. Internal "Session initialized"/"Session closed" log lines are now suppressed at `info` level, since the per-request log line already conveys that information.

--- a/libraries/typescript/.changeset/pre.json
+++ b/libraries/typescript/.changeset/pre.json
@@ -7,5 +7,7 @@
     "@mcp-use/inspector": "3.0.1",
     "mcp-use": "1.25.1"
   },
-  "changesets": []
+  "changesets": [
+    "fix-widget-dev-deps-504"
+  ]
 }

--- a/libraries/typescript/.changeset/pre.json
+++ b/libraries/typescript/.changeset/pre.json
@@ -1,0 +1,11 @@
+{
+  "mode": "pre",
+  "tag": "canary",
+  "initialVersions": {
+    "@mcp-use/cli": "3.1.1",
+    "create-mcp-use-app": "0.14.10",
+    "@mcp-use/inspector": "3.0.1",
+    "mcp-use": "1.25.1"
+  },
+  "changesets": []
+}

--- a/libraries/typescript/.changeset/pre.json
+++ b/libraries/typescript/.changeset/pre.json
@@ -8,6 +8,7 @@
     "mcp-use": "1.25.1"
   },
   "changesets": [
-    "fix-widget-dev-deps-504"
+    "fix-widget-dev-deps-504",
+    "mcp-debug-level"
   ]
 }

--- a/libraries/typescript/packages/cli/CHANGELOG.md
+++ b/libraries/typescript/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @mcp-use/cli
 
+## 3.1.2-canary.0
+
+### Patch Changes
+
+- Updated dependencies [2636f32]
+  - mcp-use@1.25.2-canary.0
+  - @mcp-use/inspector@3.0.2-canary.0
+
 ## 3.1.1
 
 ### Patch Changes

--- a/libraries/typescript/packages/cli/CHANGELOG.md
+++ b/libraries/typescript/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @mcp-use/cli
 
+## 3.1.2-canary.1
+
+### Patch Changes
+
+- Updated dependencies [1b70559]
+  - mcp-use@1.26.0-canary.1
+  - @mcp-use/inspector@4.0.0-canary.1
+
 ## 3.1.2-canary.0
 
 ### Patch Changes

--- a/libraries/typescript/packages/cli/package.json
+++ b/libraries/typescript/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-use/cli",
   "type": "module",
-  "version": "3.1.2-canary.0",
+  "version": "3.1.2-canary.1",
   "description": "The mcp-use CLI is a tool for building and deploying MCP servers with support for ChatGPT Apps, Code Mode, OAuth, Notifications, Sampling, Observability and more.",
   "author": "mcp-use, Inc.",
   "license": "MIT",

--- a/libraries/typescript/packages/cli/package.json
+++ b/libraries/typescript/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-use/cli",
   "type": "module",
-  "version": "3.1.1",
+  "version": "3.1.2-canary.0",
   "description": "The mcp-use CLI is a tool for building and deploying MCP servers with support for ChatGPT Apps, Code Mode, OAuth, Notifications, Sampling, Observability and more.",
   "author": "mcp-use, Inc.",
   "license": "MIT",

--- a/libraries/typescript/packages/inspector/CHANGELOG.md
+++ b/libraries/typescript/packages/inspector/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @mcp-use/inspector
 
+## 3.0.2-canary.0
+
+### Patch Changes
+
+- Updated dependencies [2636f32]
+  - mcp-use@1.25.2-canary.0
+
 ## 3.0.1
 
 ### Patch Changes

--- a/libraries/typescript/packages/inspector/CHANGELOG.md
+++ b/libraries/typescript/packages/inspector/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @mcp-use/inspector
 
+## 4.0.0-canary.1
+
+### Patch Changes
+
+- Updated dependencies [1b70559]
+  - mcp-use@1.26.0-canary.1
+
 ## 3.0.2-canary.0
 
 ### Patch Changes

--- a/libraries/typescript/packages/inspector/package.json
+++ b/libraries/typescript/packages/inspector/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-use/inspector",
   "type": "module",
-  "version": "3.0.1",
+  "version": "3.0.2-canary.0",
   "description": "MCP Inspector - A tool for inspecting and debugging MCP servers",
   "author": "",
   "license": "MIT",
@@ -79,7 +79,7 @@
   },
   "peerDependencies": {
     "express": "^4.21.2 || ^5.0.0",
-    "mcp-use": ">=1.25.1-canary.0",
+    "mcp-use": ">=1.25.2-canary.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
     "react-router": "^7.12.0"

--- a/libraries/typescript/packages/inspector/package.json
+++ b/libraries/typescript/packages/inspector/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-use/inspector",
   "type": "module",
-  "version": "3.0.2-canary.0",
+  "version": "4.0.0-canary.1",
   "description": "MCP Inspector - A tool for inspecting and debugging MCP servers",
   "author": "",
   "license": "MIT",
@@ -79,7 +79,7 @@
   },
   "peerDependencies": {
     "express": "^4.21.2 || ^5.0.0",
-    "mcp-use": ">=1.25.2-canary.0",
+    "mcp-use": ">=1.26.0-canary.1",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
     "react-router": "^7.12.0"

--- a/libraries/typescript/packages/inspector/tests/e2e/command-palette.test.ts
+++ b/libraries/typescript/packages/inspector/tests/e2e/command-palette.test.ts
@@ -45,7 +45,10 @@ test.describe("Inspector Command Palette Tests", () => {
   });
 
   test("should open command palette with button click", async () => {
-    // Click the Cmd+K button in header
+    // Open the Settings dropdown (command palette trigger moved there)
+    await page.getByRole("button", { name: "Settings", exact: true }).click();
+
+    // Click the Command Palette menu item
     await page.getByTestId("command-palette-trigger-button").click();
 
     // Verify command palette dialog opens

--- a/libraries/typescript/packages/mcp-use/CHANGELOG.md
+++ b/libraries/typescript/packages/mcp-use/CHANGELOG.md
@@ -1,5 +1,17 @@
 # mcp-use
 
+## 1.25.2-canary.0
+
+### Patch Changes
+
+- 2636f32: fix(widgets): pre-warm widget Vite entries before registration to prevent first-render `/.vite/deps/*` 504s
+
+  When a widget is registered (initial boot, watcher add-file, or watcher add-folder), `mount-widgets-dev` now calls `viteServer.warmupRequest()` followed by `viteServer.waitForRequestsIdle()` for the widget's `entry.tsx` before exposing it to the inspector. This forces Vite's `depsOptimizer` to finish pre-bundling and stabilise its dependency hash before the browser starts requesting `/.vite/deps/*` modules.
+
+  Previously, the inspector iframe could fetch optimized dependencies (e.g. `mcp-use_react.js`) with a stale Vite hash while `depsOptimizer` was still re-bundling, which surfaced as `504 Gateway Timeout` errors and a blank widget on first interaction in Vibe-created sandboxes. Each widget is warmed at most once per dev-server lifetime; failures fall back to a warning so registration never blocks.
+  - @mcp-use/cli@3.1.2-canary.0
+  - @mcp-use/inspector@3.0.2-canary.0
+
 ## 1.25.1
 
 ### Patch Changes

--- a/libraries/typescript/packages/mcp-use/CHANGELOG.md
+++ b/libraries/typescript/packages/mcp-use/CHANGELOG.md
@@ -1,5 +1,24 @@
 # mcp-use
 
+## 1.26.0-canary.1
+
+### Minor Changes
+
+- 1b70559: feat(server): add `MCP_DEBUG_LEVEL` env var with `info` / `debug` / `trace` levels for HTTP request logs
+
+  Replaces the previous all-or-nothing `DEBUG=1` behavior with three explicit verbosity levels:
+  - `info` (default): one compact line per request, e.g.
+    `[19:44:56] POST /mcp [tools/call: greet] OK (1ms)`. Initialize lines now include the client `name/version` and the new short session id (`→ session=92c4e0b`); subsequent requests are prefixed with `sess=<short>`. JSON-RPC and tool errors are extracted from the response body and shown inline (`ERROR cannot divide by zero`).
+  - `debug`: same as `info` plus inline `args=<json>` for `tools/call`.
+  - `trace`: identical to the legacy `DEBUG=1` output (full request/response headers and bodies).
+
+  `DEBUG=1` (or any truthy `DEBUG` value) continues to work and maps to `trace`. Internal "Session initialized"/"Session closed" log lines are now suppressed at `info` level, since the per-request log line already conveys that information.
+
+### Patch Changes
+
+- @mcp-use/cli@3.1.2-canary.1
+- @mcp-use/inspector@4.0.0-canary.1
+
 ## 1.25.2-canary.0
 
 ### Patch Changes

--- a/libraries/typescript/packages/mcp-use/package.json
+++ b/libraries/typescript/packages/mcp-use/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-use",
   "type": "module",
-  "version": "1.25.2-canary.0",
+  "version": "1.26.0-canary.1",
   "packageManager": "pnpm@10.26.0+sha512.3b3f6c725ebe712506c0ab1ad4133cf86b1f4b687effce62a9b38b4d72e3954242e643190fc51fa1642949c735f403debd44f5cb0edd657abe63a8b6a7e1e402",
   "description": "Opinionated MCP Framework for TypeScript (@modelcontextprotocol/sdk compatible) - Build MCP Agents, Clients and Servers with support for ChatGPT Apps, Code Mode, OAuth, Notifications, Sampling, Observability and more.",
   "author": "mcp-use, Inc.",

--- a/libraries/typescript/packages/mcp-use/package.json
+++ b/libraries/typescript/packages/mcp-use/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-use",
   "type": "module",
-  "version": "1.25.1",
+  "version": "1.25.2-canary.0",
   "packageManager": "pnpm@10.26.0+sha512.3b3f6c725ebe712506c0ab1ad4133cf86b1f4b687effce62a9b38b4d72e3954242e643190fc51fa1642949c735f403debd44f5cb0edd657abe63a8b6a7e1e402",
   "description": "Opinionated MCP Framework for TypeScript (@modelcontextprotocol/sdk compatible) - Build MCP Agents, Clients and Servers with support for ChatGPT Apps, Code Mode, OAuth, Notifications, Sampling, Observability and more.",
   "author": "mcp-use, Inc.",

--- a/libraries/typescript/packages/mcp-use/src/server/endpoints/mount-mcp.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/endpoints/mount-mcp.ts
@@ -22,6 +22,7 @@ import {
   isJsonRpcResponse,
 } from "../utils/jsonrpc-helpers.js";
 import { runWithContext } from "../context-storage.js";
+import { getDebugLevel } from "../logging.js";
 import { generateUUID } from "../utils/runtime.js";
 
 // ---------------------------------------------------------------------------
@@ -401,11 +402,15 @@ export async function mountMcp(
           sessionIdGenerator: () => sessionId,
 
           onsessioninitialized: async (sid: string) => {
-            console.log(`[MCP] Session re-initialized: ${sid}`);
+            if (getDebugLevel() !== "info") {
+              console.log(`[MCP] Session re-initialized: ${sid}`);
+            }
           },
 
           onsessionclosed: async (sid: string) => {
-            console.log(`[MCP] Session closed: ${sid}`);
+            if (getDebugLevel() !== "info") {
+              console.log(`[MCP] Session closed: ${sid}`);
+            }
             transports.delete(sid);
             await streamManager.delete(sid);
             await sessionStore.delete(sid);
@@ -513,7 +518,9 @@ export async function mountMcp(
         sessionIdGenerator: () => newSessionId,
 
         onsessioninitialized: async (sid: string) => {
-          console.log(`[MCP] Session initialized: ${sid}`);
+          if (getDebugLevel() !== "info") {
+            console.log(`[MCP] Session initialized: ${sid}`);
+          }
           transports.set(sid, transport);
 
           // Store full session data in memory (includes transport, server, context)
@@ -550,13 +557,7 @@ export async function mountMcp(
               metadata.protocolVersion = String(protocolVersion);
               await sessionStore.set(sid, metadata);
 
-              const debugEnv = process.env.DEBUG;
-              const isDebug =
-                debugEnv != null &&
-                debugEnv !== "" &&
-                debugEnv !== "0" &&
-                debugEnv.toLowerCase() !== "false";
-              if (isDebug) {
+              if (getDebugLevel() !== "info") {
                 console.log(
                   `[MCP] Captured client capabilities for session ${sid}:`,
                   clientCapabilities ? Object.keys(clientCapabilities) : "none"
@@ -586,7 +587,9 @@ export async function mountMcp(
         },
 
         onsessionclosed: async (sid: string) => {
-          console.log(`[MCP] Session closed: ${sid}`);
+          if (getDebugLevel() !== "info") {
+            console.log(`[MCP] Session closed: ${sid}`);
+          }
           transports.delete(sid);
 
           // Clean up stream manager

--- a/libraries/typescript/packages/mcp-use/src/server/logging.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/logging.ts
@@ -1,22 +1,40 @@
+import chalk from "chalk";
 import type { Context, Next } from "hono";
 
 import { getEnv } from "./utils/runtime.js";
 
 /**
- * Check if DEBUG mode is enabled via environment variable
+ * Server-side debug verbosity for MCP request logging.
+ *
+ * - `info`: one compact line per request (default)
+ * - `debug`: adds `args=<json>` for `tools/call` requests
+ * - `trace`: includes full request/response headers and bodies (legacy DEBUG=1)
  */
-function isDebugMode(): boolean {
+export type McpDebugLevel = "info" | "debug" | "trace";
+
+/**
+ * Resolve the active debug level from environment variables.
+ *
+ * Precedence: `MCP_DEBUG_LEVEL` (info|debug|trace) > legacy `DEBUG` (any truthy → trace).
+ */
+export function getDebugLevel(): McpDebugLevel {
+  const explicit = getEnv("MCP_DEBUG_LEVEL")?.trim().toLowerCase();
+  if (explicit === "info" || explicit === "debug" || explicit === "trace") {
+    return explicit;
+  }
+
+  // Backward compatibility: DEBUG=1 (or any non-falsy value) maps to `trace`.
   const debugEnv = getEnv("DEBUG");
-  return (
+  const debugEnabled =
     debugEnv !== undefined &&
     debugEnv !== "" &&
     debugEnv !== "0" &&
-    debugEnv.toLowerCase() !== "false"
-  );
+    debugEnv.toLowerCase() !== "false";
+  return debugEnabled ? "trace" : "info";
 }
 
 /**
- * Format an object for logging (pretty-print JSON)
+ * Format an object for logging (pretty-print JSON, truncating long strings).
  */
 function formatForLogging(obj: any): string {
   function truncate(val: any): any {
@@ -43,38 +61,118 @@ function formatForLogging(obj: any): string {
 }
 
 /**
- * Middleware that logs incoming HTTP requests with a timestamp, color-coded status code, and optional debug details.
+ * Compact JSON.stringify for inline `args=` output. Falls back to `String(v)`
+ * if the value is not serializable.
+ */
+function inlineJson(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+/**
+ * Short session ID used in log lines (matches example format `92c4e0b`).
+ */
+function shortSessionId(sid: string | null | undefined): string | null {
+  if (!sid) return null;
+  return sid.replace(/-/g, "").slice(0, 7);
+}
+
+/**
+ * Try to extract a JSON-RPC error from the response body. Returns the first
+ * error message found, or `null` if none.
  *
- * Skips logging for inspector telemetry and RPC endpoints under /inspector/api/tel/, /inspector/api/rpc/stream, and /inspector/api/rpc/log.
- * For POST requests to /mcp, includes the MCP method name when present. When DEBUG is enabled, logs request headers/body and response headers/body.
+ * Recognized errors:
+ *  - JSON-RPC error envelope: `{ error: { message } }`
+ *  - Tool call errors:        `{ result: { isError: true, content: [{ text }] } }`
  *
- * @param c - Hono context for the current request/response
- * @param next - Next middleware function to invoke
+ * Handles both `application/json` and `text/event-stream` (SSE) payloads,
+ * and JSON-RPC batches (arrays of messages).
+ */
+async function extractResponseError(res: Response): Promise<string | null> {
+  if (!res.body) return null;
+
+  let text: string;
+  try {
+    text = await res.clone().text();
+  } catch {
+    return null;
+  }
+  if (!text) return null;
+
+  // Collect candidate JSON payloads. SSE responses are framed as
+  // `event: message\ndata: <json>\n\n` — extract each `data:` line.
+  const isSse = (res.headers.get("content-type") || "").includes(
+    "text/event-stream"
+  );
+  const payloads: unknown[] = [];
+  const tryParse = (raw: string) => {
+    try {
+      payloads.push(JSON.parse(raw));
+    } catch {
+      // not JSON — skip
+    }
+  };
+  if (isSse) {
+    for (const line of text.split(/\r?\n/)) {
+      if (line.startsWith("data:")) {
+        const data = line.slice(5).trim();
+        if (data) tryParse(data);
+      }
+    }
+  } else {
+    tryParse(text);
+  }
+
+  for (const payload of payloads) {
+    for (const msg of Array.isArray(payload) ? payload : [payload]) {
+      if (!msg || typeof msg !== "object") continue;
+      const m = msg as any;
+      if (typeof m.error?.message === "string") return m.error.message;
+      if (m.result?.isError === true) {
+        const textBlock = Array.isArray(m.result.content)
+          ? m.result.content.find(
+              (b: any) => b?.type === "text" && typeof b.text === "string"
+            )
+          : null;
+        return textBlock ? String(textBlock.text) : "tool error";
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Middleware that logs incoming HTTP requests in a compact format controlled
+ * by `MCP_DEBUG_LEVEL` (or legacy `DEBUG`). See {@link getDebugLevel}.
+ *
+ * Skips logging for inspector telemetry/RPC endpoints, dev widget assets, and
+ * polling GETs against `/mcp` and `/inspector/api/*`.
  */
 export async function requestLogger(c: Context, next: Next): Promise<void> {
+  const startedAt = Date.now();
   const timestamp = new Date().toISOString().substring(11, 23);
   const method = c.req.method;
   const url = c.req.url;
-  const debugMode = isDebugMode();
+  const level = getDebugLevel();
 
-  // Filter out noisy endpoints that create log spam
   const pathname = new URL(url).pathname;
   const noisyPaths = [
-    "/inspector/api/tel/", // Telemetry endpoints (posthog, scarf)
-    "/inspector/api/rpc/stream", // RPC stream (SSE)
-    "/inspector/api/rpc/log", // RPC log endpoint
-    "/inspector", // Inspector UI and static assets
-    "/mcp-use/widgets/", // Dev widget Vite proxy and assets
-    "/mcp-use/public/", // Public static files
+    "/inspector/api/tel/",
+    "/inspector/api/rpc/stream",
+    "/inspector/api/rpc/log",
+    "/inspector",
+    "/mcp-use/widgets/",
+    "/mcp-use/public/",
   ];
-  // Also skip GET /mcp (SSE/health) and GET /inspector/api/* (API polling, dev-widget, etc.)
   const isNoisyGet =
     method === "GET" &&
     (pathname === "/mcp" ||
       pathname.startsWith("/inspector/api/") ||
       pathname.startsWith("/mcp-use/"));
 
-  // Skip logging for noisy paths and noisy GETs but still process the request
   if (
     noisyPaths.some((noisyPath) => pathname.startsWith(noisyPath)) ||
     isNoisyGet
@@ -83,132 +181,176 @@ export async function requestLogger(c: Context, next: Next): Promise<void> {
     return;
   }
 
-  // Get request body for logging
+  // Capture request body up front so we can extract MCP method/params.
   let requestBody: any = null;
   let requestHeaders: Record<string, string> = {};
 
-  if (debugMode) {
-    // Log request headers - c.req.header() without args returns all headers
+  if (level === "trace") {
     const allHeaders = c.req.header();
-    if (allHeaders) {
-      requestHeaders = allHeaders;
-    }
+    if (allHeaders) requestHeaders = allHeaders;
   }
 
-  // Get request body (for MCP method logging or full debug logging)
   if (method !== "GET" && method !== "HEAD") {
     try {
-      // Clone the request to avoid consuming the original body stream
       const clonedRequest = c.req.raw.clone();
       requestBody = await clonedRequest.json().catch(() => {
-        // If JSON parsing fails, try to get as text
         return clonedRequest.text().catch(() => null);
       });
     } catch {
-      // Ignore errors
+      // ignore — body is optional for the log line
     }
   }
 
   await next();
 
-  // Get status code from response
+  const durationMs = Date.now() - startedAt;
   const statusCode = c.res.status;
-  let statusColor = "";
 
-  if (statusCode >= 200 && statusCode < 300) {
-    statusColor = "\x1b[32m"; // Green for 2xx
-  } else if (statusCode >= 300 && statusCode < 400) {
-    statusColor = "\x1b[33m"; // Yellow for 3xx
-  } else if (statusCode >= 400 && statusCode < 500) {
-    statusColor = "\x1b[31m"; // Red for 4xx
-  } else if (statusCode >= 500) {
-    statusColor = "\x1b[35m"; // Magenta for 5xx
-  }
+  // Session ID: incoming header for established sessions, response header for
+  // initialize requests (the SDK transport stamps it on the response).
+  const incomingSid = c.req.header("mcp-session-id");
+  const responseSid = c.res.headers.get("mcp-session-id");
+  const mcpMethod: string | undefined = requestBody?.method;
+  const isInitialize = mcpMethod === "initialize";
 
-  // Add MCP method info for POST requests to /mcp
-  let logMessage = `[${timestamp}] ${method} \x1b[1m${new URL(url).pathname}\x1b[0m`;
-  if (method === "POST" && url.includes("/mcp") && requestBody?.method) {
-    logMessage += ` \x1b[1m[${requestBody.method}]\x1b[0m`;
-  }
-  logMessage += ` ${statusColor}${statusCode}\x1b[0m`;
+  // Build the line. Colors mirror typical access-log palettes: timestamps,
+  // session ids, args and durations are dimmed; method/path/MCP-method are
+  // bold; outcome is green (OK) or red (ERROR).
+  const parts: string[] = [chalk.gray(`[${timestamp}]`)];
 
-  console.log(logMessage);
+  const sessPrefix = !isInitialize ? shortSessionId(incomingSid) : null;
+  if (sessPrefix) parts.push(chalk.gray(`sess=${sessPrefix}`));
 
-  // Debug mode: log detailed request/response information
-  if (debugMode) {
-    console.log("\n\x1b[36m" + "=".repeat(80) + "\x1b[0m");
-    console.log("\x1b[1m\x1b[36m[DEBUG] Request Details\x1b[0m");
-    console.log("\x1b[36m" + "-".repeat(80) + "\x1b[0m");
+  parts.push(method);
+  parts.push(chalk.bold(pathname));
 
-    // Request headers
-    if (Object.keys(requestHeaders).length > 0) {
-      console.log("\x1b[33mRequest Headers:\x1b[0m");
-      console.log(formatForLogging(requestHeaders));
-    }
-
-    // Request body
-    if (requestBody !== null) {
-      console.log("\x1b[33mRequest Body:\x1b[0m");
-      if (typeof requestBody === "string") {
-        console.log(requestBody);
-      } else {
-        console.log(formatForLogging(requestBody));
-      }
-    }
-
-    // Response headers
-    const responseHeaders: Record<string, string> = {};
-    c.res.headers.forEach((value, key) => {
-      responseHeaders[key] = value;
-    });
-    if (Object.keys(responseHeaders).length > 0) {
-      console.log("\x1b[33mResponse Headers:\x1b[0m");
-      console.log(formatForLogging(responseHeaders));
-    }
-
-    // Response body
-    try {
-      // Check if response has a body and can be cloned
-      // Clone the response to read the body without consuming the original stream
-      // This ensures the original response remains intact for the client
-      if (c.res.body !== null && c.res.body !== undefined) {
-        try {
-          const clonedResponse = c.res.clone();
-          const responseBody = await clonedResponse.text().catch(() => null);
-
-          if (responseBody !== null && responseBody.length > 0) {
-            console.log("\x1b[33mResponse Body:\x1b[0m");
-            // Try to parse as JSON for pretty printing
-            try {
-              const jsonBody = JSON.parse(responseBody);
-              console.log(formatForLogging(jsonBody));
-            } catch {
-              // Not JSON, print as text (truncate if too long)
-              const maxLength = 10000;
-              if (responseBody.length > maxLength) {
-                console.log(
-                  responseBody.substring(0, maxLength) +
-                    `\n... (truncated, ${responseBody.length - maxLength} more characters)`
-                );
-              } else {
-                console.log(responseBody);
-              }
-            }
-          } else {
-            console.log("\x1b[33mResponse Body:\x1b[0m (empty)");
-          }
-        } catch (cloneError) {
-          // If cloning fails (e.g., response already consumed), log that
-          console.log("\x1b[33mResponse Body:\x1b[0m (unable to clone/read)");
+  if (mcpMethod) {
+    if (isInitialize) {
+      const ci = requestBody?.params?.clientInfo;
+      const label =
+        ci?.name && ci?.version
+          ? `: ${ci.name}/${ci.version}`
+          : ci?.name
+            ? `: ${ci.name}`
+            : "";
+      parts.push(chalk.bold(`[initialize${label}]`));
+    } else if (mcpMethod === "tools/call") {
+      const toolName = requestBody?.params?.name ?? "?";
+      let segment = chalk.bold(`[tools/call: ${toolName}]`);
+      if (level !== "info") {
+        const args = requestBody?.params?.arguments;
+        if (args !== undefined) {
+          segment += ` args=${inlineJson(args)}`;
         }
-      } else {
-        console.log("\x1b[33mResponse Body:\x1b[0m (no body)");
       }
-    } catch (error) {
-      // If we can't read the response body, log that
-      console.log("\x1b[33mResponse Body:\x1b[0m (unable to read)");
+      parts.push(segment);
+    } else if (mcpMethod === "resources/read") {
+      const uri = requestBody?.params?.uri ?? "?";
+      parts.push(chalk.bold(`[resources/read: ${uri}]`));
+    } else if (mcpMethod === "prompts/get") {
+      const promptName = requestBody?.params?.name ?? "?";
+      parts.push(chalk.bold(`[prompts/get: ${promptName}]`));
+    } else {
+      parts.push(chalk.bold(`[${mcpMethod}]`));
     }
-
-    console.log("\x1b[36m" + "=".repeat(80) + "\x1b[0m\n");
   }
+
+  if (isInitialize && responseSid) {
+    parts.push(chalk.gray(`→ session=${shortSessionId(responseSid)}`));
+  }
+
+  // Outcome:
+  //  - MCP requests: OK / ERROR <message> based on JSON-RPC error parsing.
+  //  - Plain HTTP (HEAD, etc.): the raw status code, colored by class.
+  let outcomePart: string;
+  const errMsg = await extractResponseError(c.res);
+  if (errMsg) {
+    outcomePart = chalk.red(`ERROR ${errMsg}`);
+  } else if (mcpMethod) {
+    outcomePart =
+      statusCode >= 400
+        ? chalk.red(`ERROR (HTTP ${statusCode})`)
+        : chalk.green("OK");
+  } else {
+    outcomePart =
+      statusCode >= 500
+        ? chalk.magenta(String(statusCode))
+        : statusCode >= 400
+          ? chalk.red(String(statusCode))
+          : statusCode >= 300
+            ? chalk.yellow(String(statusCode))
+            : chalk.green(String(statusCode));
+  }
+  parts.push(outcomePart);
+  parts.push(chalk.gray(`(${durationMs}ms)`));
+
+  console.log(parts.join(" "));
+
+  // Trace mode preserves the legacy DEBUG=1 behavior: detailed request and
+  // response dumps follow the summary line.
+  if (level !== "trace") return;
+
+  console.log("\n" + chalk.cyan("=".repeat(80)));
+  console.log(chalk.bold.cyan("[TRACE] Request Details"));
+  console.log(chalk.cyan("-".repeat(80)));
+
+  if (Object.keys(requestHeaders).length > 0) {
+    console.log(chalk.yellow("Request Headers:"));
+    console.log(formatForLogging(requestHeaders));
+  }
+
+  if (requestBody !== null) {
+    console.log(chalk.yellow("Request Body:"));
+    if (typeof requestBody === "string") {
+      console.log(requestBody);
+    } else {
+      console.log(formatForLogging(requestBody));
+    }
+  }
+
+  const responseHeaders: Record<string, string> = {};
+  c.res.headers.forEach((value, key) => {
+    responseHeaders[key] = value;
+  });
+  if (Object.keys(responseHeaders).length > 0) {
+    console.log(chalk.yellow("Response Headers:"));
+    console.log(formatForLogging(responseHeaders));
+  }
+
+  try {
+    if (c.res.body !== null && c.res.body !== undefined) {
+      try {
+        const clonedResponse = c.res.clone();
+        const responseBody = await clonedResponse.text().catch(() => null);
+
+        if (responseBody !== null && responseBody.length > 0) {
+          console.log(chalk.yellow("Response Body:"));
+          try {
+            const jsonBody = JSON.parse(responseBody);
+            console.log(formatForLogging(jsonBody));
+          } catch {
+            const maxLength = 10000;
+            if (responseBody.length > maxLength) {
+              console.log(
+                responseBody.substring(0, maxLength) +
+                  `\n... (truncated, ${responseBody.length - maxLength} more characters)`
+              );
+            } else {
+              console.log(responseBody);
+            }
+          }
+        } else {
+          console.log(chalk.yellow("Response Body:") + " (empty)");
+        }
+      } catch {
+        console.log(chalk.yellow("Response Body:") + " (unable to clone/read)");
+      }
+    } else {
+      console.log(chalk.yellow("Response Body:") + " (no body)");
+    }
+  } catch {
+    console.log(chalk.yellow("Response Body:") + " (unable to read)");
+  }
+
+  console.log(chalk.cyan("=".repeat(80)) + "\n");
 }

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/mount-widgets-dev.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/mount-widgets-dev.ts
@@ -381,6 +381,13 @@ if (container && Component) {
   };
 
   // Create a plugin to ensure Vite watches the resources directory for HMR
+  const warmWidgetEntry: {
+    current: (slugifiedName: string, reason: string) => Promise<void>;
+  } = {
+    current: async () => {
+      // No-op until Vite server is fully initialised.
+    },
+  };
   const watchResourcesPlugin = {
     name: "watch-resources",
     configureServer(server: any) {
@@ -862,6 +869,7 @@ if (container && Component) {
 
               // Create temp files and register widget
               await createWidgetTempFiles(widgetName, filePath);
+              await warmWidgetEntry.current(widgetName, "watch-add-file");
               await extractAndRegisterWidget(widgetName, filePath);
 
               console.log(`[WIDGETS] New widget added: ${widgetName}`);
@@ -903,6 +911,7 @@ if (container && Component) {
 
                 // Create temp files and register widget
                 await createWidgetTempFiles(widgetName, filePath);
+                await warmWidgetEntry.current(widgetName, "watch-add-folder");
                 await extractAndRegisterWidget(widgetName, filePath);
 
                 console.log(`[WIDGETS] New widget added: ${widgetName}`);
@@ -1246,6 +1255,31 @@ export default PostHog;
     },
   });
 
+  // Pre-bundle a widget's dependencies via Vite's optimizer before the inspector
+  // requests its assets. Without this, the browser races against `depsOptimizer`
+  // and can fetch optimized deps with a stale hash, manifesting as 504s on
+  // `/.vite/deps/*` requests on first widget render.
+  const warmedWidgetEntries = new Set<string>();
+  warmWidgetEntry.current = async (widgetName: string, _reason: string) => {
+    const slugifiedName = slugifyWidgetName(widgetName);
+    const entryUrl = `/${slugifiedName}/entry.tsx`;
+    if (warmedWidgetEntries.has(entryUrl)) return;
+
+    try {
+      if (typeof viteServer.warmupRequest === "function") {
+        await viteServer.warmupRequest(entryUrl);
+      } else {
+        await viteServer.transformRequest(entryUrl);
+      }
+      if (typeof viteServer.waitForRequestsIdle === "function") {
+        await viteServer.waitForRequestsIdle(entryUrl);
+      }
+      warmedWidgetEntries.add(entryUrl);
+    } catch (error) {
+      console.warn(`[WIDGETS] Failed to warm widget entry ${entryUrl}:`, error);
+    }
+  };
+
   // Set up WebSocket proxy for Vite HMR through the main HTTP server.
   // In middleware mode, Vite creates its own WebSocket on a random port (e.g., 24678).
   // Reverse proxies (ngrok, E2B) only forward traffic on the main port.
@@ -1457,6 +1491,7 @@ export default PostHog;
 
     // Use the extracted helper to register the widget
     const slugifiedName = slugifyWidgetName(widget.name);
+    await warmWidgetEntry.current(widget.name, "initial-registration");
     await registerWidgetFromTemplate(
       widget.name,
       pathHelpers.join(tempDir, slugifiedName, "index.html"),

--- a/libraries/typescript/packages/mcp-use/tests/unit/server/logging.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/server/logging.test.ts
@@ -1,0 +1,449 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Context, Next } from "hono";
+
+import { getDebugLevel, requestLogger } from "../../../src/server/logging.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface MockOptions {
+  method?: string;
+  url?: string;
+  requestHeaders?: Record<string, string>;
+  requestBody?: unknown;
+  responseStatus?: number;
+  responseHeaders?: Record<string, string>;
+  responseBody?: string | null;
+  responseContentType?: string;
+}
+
+function makeContext(opts: MockOptions = {}): {
+  ctx: Context;
+  next: Next;
+  // Captured for assertions:
+  state: { lastResponse: Response };
+} {
+  const method = opts.method ?? "POST";
+  const url = opts.url ?? "http://localhost:3000/mcp";
+  const headers = new Headers(opts.requestHeaders ?? {});
+
+  const requestInit: RequestInit = {
+    method,
+    headers,
+  };
+  if (opts.requestBody !== undefined && method !== "GET" && method !== "HEAD") {
+    requestInit.body =
+      typeof opts.requestBody === "string"
+        ? opts.requestBody
+        : JSON.stringify(opts.requestBody);
+    if (!headers.has("content-type")) {
+      headers.set("content-type", "application/json");
+    }
+  }
+
+  const rawRequest = new Request(url, requestInit);
+
+  const responseHeaders = new Headers(opts.responseHeaders ?? {});
+  if (opts.responseContentType && !responseHeaders.has("content-type")) {
+    responseHeaders.set("content-type", opts.responseContentType);
+  }
+  const response = new Response(opts.responseBody ?? null, {
+    status: opts.responseStatus ?? 200,
+    headers: responseHeaders,
+  });
+
+  const state = { lastResponse: response };
+
+  // Minimal Hono Context shim covering what requestLogger reads.
+  const ctx = {
+    req: {
+      raw: rawRequest,
+      method,
+      url,
+      header(name?: string): any {
+        if (name === undefined) {
+          const all: Record<string, string> = {};
+          headers.forEach((v, k) => {
+            all[k] = v;
+          });
+          return all;
+        }
+        return headers.get(name) ?? undefined;
+      },
+      path: new URL(url).pathname,
+    },
+    get res(): Response {
+      return state.lastResponse;
+    },
+  } as unknown as Context;
+
+  const next: Next = async () => {
+    // Replace the response inside next() to simulate a downstream handler.
+    state.lastResponse = response;
+  };
+
+  return { ctx, next, state };
+}
+
+// ---------------------------------------------------------------------------
+// getDebugLevel
+// ---------------------------------------------------------------------------
+
+describe("getDebugLevel", () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("defaults to info when no env vars are set", () => {
+    delete process.env.MCP_DEBUG_LEVEL;
+    delete process.env.DEBUG;
+    expect(getDebugLevel()).toBe("info");
+  });
+
+  it("respects MCP_DEBUG_LEVEL=debug", () => {
+    process.env.MCP_DEBUG_LEVEL = "debug";
+    expect(getDebugLevel()).toBe("debug");
+  });
+
+  it("respects MCP_DEBUG_LEVEL=trace", () => {
+    process.env.MCP_DEBUG_LEVEL = "trace";
+    expect(getDebugLevel()).toBe("trace");
+  });
+
+  it("normalizes case and whitespace", () => {
+    process.env.MCP_DEBUG_LEVEL = "  TRACE  ";
+    expect(getDebugLevel()).toBe("trace");
+  });
+
+  it("falls back to info for unknown MCP_DEBUG_LEVEL values", () => {
+    process.env.MCP_DEBUG_LEVEL = "verbose";
+    delete process.env.DEBUG;
+    expect(getDebugLevel()).toBe("info");
+  });
+
+  it("maps legacy DEBUG=1 to trace", () => {
+    delete process.env.MCP_DEBUG_LEVEL;
+    process.env.DEBUG = "1";
+    expect(getDebugLevel()).toBe("trace");
+  });
+
+  it("maps legacy DEBUG=true to trace", () => {
+    delete process.env.MCP_DEBUG_LEVEL;
+    process.env.DEBUG = "true";
+    expect(getDebugLevel()).toBe("trace");
+  });
+
+  it("treats DEBUG=0 as disabled", () => {
+    delete process.env.MCP_DEBUG_LEVEL;
+    process.env.DEBUG = "0";
+    expect(getDebugLevel()).toBe("info");
+  });
+
+  it("treats DEBUG=false as disabled", () => {
+    delete process.env.MCP_DEBUG_LEVEL;
+    process.env.DEBUG = "false";
+    expect(getDebugLevel()).toBe("info");
+  });
+
+  it("MCP_DEBUG_LEVEL takes precedence over DEBUG", () => {
+    process.env.MCP_DEBUG_LEVEL = "info";
+    process.env.DEBUG = "1";
+    expect(getDebugLevel()).toBe("info");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// requestLogger
+// ---------------------------------------------------------------------------
+
+describe("requestLogger", () => {
+  const originalEnv = { ...process.env };
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    process.env = { ...originalEnv };
+  });
+
+  function logLines(): string[] {
+    return logSpy.mock.calls.map((c) => String(c[0]));
+  }
+
+  it("emits info-level line for initialize with client info and new session id", async () => {
+    process.env.MCP_DEBUG_LEVEL = "info";
+    const sid = "92c4e0b1-1234-5678-9abc-def012345678";
+    const { ctx, next } = makeContext({
+      method: "POST",
+      url: "http://localhost:3000/mcp",
+      requestBody: {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: { clientInfo: { name: "log-demo", version: "0.1.0" } },
+      },
+      responseStatus: 200,
+      responseHeaders: { "mcp-session-id": sid },
+      responseContentType: "application/json",
+      responseBody: JSON.stringify({ jsonrpc: "2.0", id: 1, result: {} }),
+    });
+
+    await requestLogger(ctx, next);
+
+    const line = logLines()[0];
+    expect(line).toContain("POST");
+    expect(line).toContain("/mcp");
+    expect(line).toContain("[initialize: log-demo/0.1.0]");
+    expect(line).toContain("→ session=92c4e0b");
+    expect(line).toContain("OK");
+    expect(line).toMatch(/\(\d+ms\)/);
+    // Initialize lines must NOT carry an incoming sess= prefix.
+    expect(line).not.toMatch(/sess=\S+ POST/);
+  });
+
+  it("prefixes non-initialize requests with sess=<short>", async () => {
+    process.env.MCP_DEBUG_LEVEL = "info";
+    const sid = "92c4e0b1-1234-5678-9abc-def012345678";
+    const { ctx, next } = makeContext({
+      requestHeaders: { "mcp-session-id": sid },
+      requestBody: { jsonrpc: "2.0", id: 2, method: "tools/list" },
+      responseStatus: 200,
+      responseContentType: "application/json",
+      responseBody: JSON.stringify({ jsonrpc: "2.0", id: 2, result: {} }),
+    });
+
+    await requestLogger(ctx, next);
+
+    const line = logLines()[0];
+    expect(line).toContain("sess=92c4e0b");
+    expect(line).toContain("[tools/list]");
+    expect(line).toContain("OK");
+  });
+
+  it("at info level, tools/call shows tool name but no args", async () => {
+    process.env.MCP_DEBUG_LEVEL = "info";
+    const { ctx, next } = makeContext({
+      requestHeaders: { "mcp-session-id": "abcdefg" },
+      requestBody: {
+        jsonrpc: "2.0",
+        id: 3,
+        method: "tools/call",
+        params: { name: "greet", arguments: { name: "Andrew", formal: true } },
+      },
+      responseStatus: 200,
+      responseContentType: "application/json",
+      responseBody: JSON.stringify({ jsonrpc: "2.0", id: 3, result: {} }),
+    });
+
+    await requestLogger(ctx, next);
+
+    const line = logLines()[0];
+    expect(line).toContain("[tools/call: greet]");
+    expect(line).not.toContain("args=");
+  });
+
+  it("at debug level, tools/call appends args=<json>", async () => {
+    process.env.MCP_DEBUG_LEVEL = "debug";
+    const { ctx, next } = makeContext({
+      requestHeaders: { "mcp-session-id": "abcdefg" },
+      requestBody: {
+        jsonrpc: "2.0",
+        id: 4,
+        method: "tools/call",
+        params: { name: "greet", arguments: { name: "Andrew", formal: true } },
+      },
+      responseStatus: 200,
+      responseContentType: "application/json",
+      responseBody: JSON.stringify({ jsonrpc: "2.0", id: 4, result: {} }),
+    });
+
+    await requestLogger(ctx, next);
+
+    const line = logLines()[0];
+    expect(line).toContain("[tools/call: greet]");
+    expect(line).toContain('args={"name":"Andrew","formal":true}');
+  });
+
+  it("resources/read shows the resource URI", async () => {
+    process.env.MCP_DEBUG_LEVEL = "info";
+    const { ctx, next } = makeContext({
+      requestHeaders: { "mcp-session-id": "abcdefg" },
+      requestBody: {
+        jsonrpc: "2.0",
+        id: 10,
+        method: "resources/read",
+        params: { uri: "ui://widget/weather-display.html" },
+      },
+      responseStatus: 200,
+      responseContentType: "application/json",
+      responseBody: JSON.stringify({ jsonrpc: "2.0", id: 10, result: {} }),
+    });
+
+    await requestLogger(ctx, next);
+
+    const line = logLines()[0];
+    expect(line).toContain(
+      "[resources/read: ui://widget/weather-display.html]"
+    );
+    expect(line).toContain("OK");
+  });
+
+  it("prompts/get shows the prompt name", async () => {
+    process.env.MCP_DEBUG_LEVEL = "info";
+    const { ctx, next } = makeContext({
+      requestHeaders: { "mcp-session-id": "abcdefg" },
+      requestBody: {
+        jsonrpc: "2.0",
+        id: 11,
+        method: "prompts/get",
+        params: { name: "summarize" },
+      },
+      responseStatus: 200,
+      responseContentType: "application/json",
+      responseBody: JSON.stringify({ jsonrpc: "2.0", id: 11, result: {} }),
+    });
+
+    await requestLogger(ctx, next);
+
+    const line = logLines()[0];
+    expect(line).toContain("[prompts/get: summarize]");
+    expect(line).toContain("OK");
+  });
+
+  it("extracts JSON-RPC error message from response body", async () => {
+    process.env.MCP_DEBUG_LEVEL = "info";
+    const { ctx, next } = makeContext({
+      requestHeaders: { "mcp-session-id": "abcdefg" },
+      requestBody: {
+        jsonrpc: "2.0",
+        id: 5,
+        method: "tools/call",
+        params: { name: "does-not-exist" },
+      },
+      responseStatus: 200,
+      responseContentType: "application/json",
+      responseBody: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 5,
+        error: {
+          code: -32602,
+          message: "MCP error -32602: Tool does-not-exist not found",
+        },
+      }),
+    });
+
+    await requestLogger(ctx, next);
+
+    const line = logLines()[0];
+    expect(line).toContain(
+      "ERROR MCP error -32602: Tool does-not-exist not found"
+    );
+  });
+
+  it("extracts tool error text from result.isError responses", async () => {
+    process.env.MCP_DEBUG_LEVEL = "info";
+    const { ctx, next } = makeContext({
+      requestHeaders: { "mcp-session-id": "abcdefg" },
+      requestBody: {
+        jsonrpc: "2.0",
+        id: 6,
+        method: "tools/call",
+        params: { name: "divide", arguments: { a: 10, b: 0 } },
+      },
+      responseStatus: 200,
+      responseContentType: "application/json",
+      responseBody: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 6,
+        result: {
+          isError: true,
+          content: [{ type: "text", text: "cannot divide by zero" }],
+        },
+      }),
+    });
+
+    await requestLogger(ctx, next);
+
+    const line = logLines()[0];
+    expect(line).toContain("ERROR cannot divide by zero");
+  });
+
+  it("parses errors from text/event-stream (SSE) responses", async () => {
+    process.env.MCP_DEBUG_LEVEL = "info";
+    const sseBody =
+      `event: message\n` +
+      `data: ${JSON.stringify({
+        jsonrpc: "2.0",
+        id: 7,
+        error: { code: -32601, message: "Method not found" },
+      })}\n\n`;
+
+    const { ctx, next } = makeContext({
+      requestHeaders: { "mcp-session-id": "abcdefg" },
+      requestBody: { jsonrpc: "2.0", id: 7, method: "tools/list" },
+      responseStatus: 200,
+      responseContentType: "text/event-stream",
+      responseBody: sseBody,
+    });
+
+    await requestLogger(ctx, next);
+
+    const line = logLines()[0];
+    expect(line).toContain("ERROR Method not found");
+  });
+
+  it("skips noisy paths (no log line emitted)", async () => {
+    process.env.MCP_DEBUG_LEVEL = "info";
+    const { ctx, next } = makeContext({
+      method: "POST",
+      url: "http://localhost:3000/inspector/api/tel/event",
+      responseStatus: 200,
+    });
+
+    await requestLogger(ctx, next);
+    expect(logLines()).toHaveLength(0);
+  });
+
+  it("trace level emits the summary line plus a detailed dump", async () => {
+    process.env.MCP_DEBUG_LEVEL = "trace";
+    const { ctx, next } = makeContext({
+      requestHeaders: { "mcp-session-id": "abcdefg" },
+      requestBody: { jsonrpc: "2.0", id: 8, method: "tools/list" },
+      responseStatus: 200,
+      responseContentType: "application/json",
+      responseBody: JSON.stringify({ jsonrpc: "2.0", id: 8, result: {} }),
+    });
+
+    await requestLogger(ctx, next);
+
+    const lines = logLines();
+    // Summary line first, then a multi-line trace dump
+    expect(lines[0]).toContain("[tools/list]");
+    expect(lines.some((l) => l.includes("TRACE"))).toBe(true);
+    expect(lines.some((l) => l.includes("Request Body"))).toBe(true);
+    expect(lines.some((l) => l.includes("Response Body"))).toBe(true);
+  });
+
+  it("DEBUG=1 acts as trace (backward compatibility)", async () => {
+    delete process.env.MCP_DEBUG_LEVEL;
+    process.env.DEBUG = "1";
+    const { ctx, next } = makeContext({
+      requestHeaders: { "mcp-session-id": "abcdefg" },
+      requestBody: { jsonrpc: "2.0", id: 9, method: "tools/list" },
+      responseStatus: 200,
+      responseContentType: "application/json",
+      responseBody: JSON.stringify({ jsonrpc: "2.0", id: 9, result: {} }),
+    });
+
+    await requestLogger(ctx, next);
+
+    const lines = logLines();
+    expect(lines.some((l) => l.includes("TRACE"))).toBe(true);
+  });
+});


### PR DESCRIPTION
…rst-render 504s (#1425)

* fix(widgets): pre-warm Vite entries before registration to prevent first-render 504s

When a widget is registered (initial boot, watcher add-file, or watcher add-folder), `mount-widgets-dev` now calls `viteServer.warmupRequest()` followed by `viteServer.waitForRequestsIdle()` for the widget's `entry.tsx` before exposing it to the inspector. This forces Vite's `depsOptimizer` to finish pre-bundling and stabilise its dependency hash before the browser starts requesting `/.vite/deps/*` modules.

Previously the inspector iframe could fetch optimized dependencies (e.g. `mcp-use_react.js`) with a stale Vite hash while `depsOptimizer` was still re-bundling, surfacing as `504 Gateway Timeout` errors and a blank widget on first interaction in Vibe-created sandboxes. Each widget is warmed at most once per dev-server lifetime; failures fall back to a warning so registration never blocks.
