### PR TITLE
fix(inspector): update command-palette e2e test for new Settings dropdown trigger

### DIFF
--- a/libraries/typescript/.changeset/fix-inspector-command-palette-e2e-test.md
+++ b/libraries/typescript/.changeset/fix-inspector-command-palette-e2e-test.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Fix command-palette e2e test broken by Settings dropdown header change

--- a/libraries/typescript/.changeset/fix-inspector-command-palette-e2e-test.md
+++ b/libraries/typescript/.changeset/fix-inspector-command-palette-e2e-test.md
@@ -1,5 +1,0 @@
----
-"@mcp-use/inspector": patch
----
-
-Fix command-palette e2e test broken by Settings dropdown header change

--- a/libraries/typescript/packages/inspector/tests/e2e/command-palette.test.ts
+++ b/libraries/typescript/packages/inspector/tests/e2e/command-palette.test.ts
@@ -45,7 +45,10 @@ test.describe("Inspector Command Palette Tests", () => {
   });
 
   test("should open command palette with button click", async () => {
-    // Click the Cmd+K button in header
+    // Open the Settings dropdown (command palette trigger moved there)
+    await page.getByRole("button", { name: "Settings", exact: true }).click();
+
+    // Click the Command Palette menu item
     await page.getByTestId("command-palette-trigger-button").click();
 
     // Verify command palette dialog opens


### PR DESCRIPTION
## Language / Project Scope

- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

The `command-palette.test.ts` e2e test was broken by a recent PR that moved the command palette trigger button from a standalone button in the inspector header into a Settings gear icon dropdown menu. This PR updates the test to reflect the new UI structure.

## Implementation Details

1. Added a step to open the Settings dropdown before clicking the command palette trigger item
2. Added `exact: true` to the `getByRole("button", { name: "Settings" })` selector to disambiguate from the "Edit connection settings" button that also exists on the page

---

## TypeScript Checklist

### Packages Modified

- [ ] `docs`
- [x] `tests`
- [ ] `cli`
- [ ] `create-mcp-use-app`
- [ ] `mcp-use` (server)
- [ ] `mcp-use` (client)
- [x] `inspector`

### Pre-commit Checklist

- [x] Ran `pnpm lint:fix` to auto-fix linting issues
- [x] Ran `pnpm format` to format code with Prettier
- [x] Ran `pnpm build` and build succeeds without errors
- [ ] Ran `pnpm changeset` to create a changeset (test-only change, no user-facing changes)
- [x] Added or updated tests if needed
- [ ] Updated documentation in `docs/` folder if needed

---

## Example Usage (Before)

The failing test tried to click the command palette trigger directly without first opening the Settings dropdown:

```typescript
test("should open command palette with button click", async () => {
  // Click the Cmd+K button in header
  await page.getByTestId("command-palette-trigger-button").click();
  // ...
});
```

## Example Usage (After)

The fixed test opens the Settings dropdown first, then clicks the trigger:

```typescript
test("should open command palette with button click", async () => {
  // Open the Settings dropdown (command palette trigger moved there)
  await page.getByRole("button", { name: "Settings", exact: true }).click();

  // Click the Command Palette menu item
  await page.getByTestId("command-palette-trigger-button").click();
  // ...
});
```

## Documentation Updates

No documentation changes needed.

## Testing

- All 6 command-palette e2e tests now pass in mix mode (`pnpm test:e2e:mix tests/e2e/command-palette.test.ts`)
- Verified locally: 6 passed (5.5s)

## Backwards Compatibility

Test-only change. No user-facing API changes.

## Related Issues

Closes #1730