### PR TITLE
fix(cli): propagate --env/--env-file to server on deploy redeploys

### DIFF
--- a/libraries/typescript/.changeset/fix-deploy-env-propagation.md
+++ b/libraries/typescript/.changeset/fix-deploy-env-propagation.md
@@ -1,0 +1,18 @@
+---
+"@mcp-use/cli": patch
+---
+
+fix(cli): propagate `--env`/`--env-file` to the server on `mcp-use deploy` redeploys
+
+`mcp-use deploy --env KEY=VAL` previously only forwarded env vars when the
+deploy created a new server: the values rode along on the `createServer`
+request body. On redeploys (an existing linked server, or a previously failed
+deployment), the CLI parsed the flags, displayed them in the configuration
+preview, and then silently dropped them — `createDeployment` was called
+without ever touching the server's env vars.
+
+The deploy command now upserts each `--env`/`--env-file` entry against the
+server's env-variables API before triggering the deployment: keys that exist
+get a `PATCH` with the new value, new keys get a `POST`. Keys not present in
+the supplied set are left untouched (clearing still requires
+`mcp-use servers env rm`).

--- a/libraries/typescript/packages/cli/src/commands/deploy.ts
+++ b/libraries/typescript/packages/cli/src/commands/deploy.ts
@@ -102,6 +102,44 @@ function parseEnvVar(envStr: string): { key: string; value: string } {
   return { key, value };
 }
 
+/**
+ * Upsert env vars onto an existing server via the env-variables API.
+ *
+ * The `--env`/`--env-file` flags are only honored on initial server creation
+ * (where `env` rides on the createServer body). On redeploys we have to call
+ * the dedicated env-variables endpoints, otherwise the values are silently
+ * dropped. Existing keys are updated; new keys are created. Keys not in the
+ * supplied set are left alone — clearing requires `mcp-use servers env rm`.
+ */
+export async function syncEnvVarsToServer(
+  api: McpUseAPI,
+  serverId: string,
+  envVars: Record<string, string>
+): Promise<{ created: number; updated: number }> {
+  const entries = Object.entries(envVars);
+  if (entries.length === 0) return { created: 0, updated: 0 };
+
+  const existing = await api.listEnvVariables(serverId);
+  const byKey = new Map(existing.map((v) => [v.key, v]));
+
+  const results = await Promise.all(
+    entries.map(async ([key, value]) => {
+      const found = byKey.get(key);
+      if (found) {
+        await api.updateEnvVariable(serverId, found.id, { value });
+        return "updated" as const;
+      }
+      await api.createEnvVariable(serverId, { key, value });
+      return "created" as const;
+    })
+  );
+
+  return {
+    created: results.filter((r) => r === "created").length,
+    updated: results.filter((r) => r === "updated").length,
+  };
+}
+
 async function buildEnvVars(
   options: DeployOptions
 ): Promise<Record<string, string>> {
@@ -1238,6 +1276,20 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
           console.log(chalk.gray(`  Redeploying to maintain the same URL...`));
           console.log(chalk.cyan(`  URL: ${getMcpServerUrl(existingDep)}\n`));
 
+          if (Object.keys(envVars).length > 0) {
+            const synced = await syncEnvVarsToServer(api, serverId, envVars);
+            console.log(
+              chalk.green(
+                `✓ Synced ${synced.created + synced.updated} environment variable(s)` +
+                  (synced.created || synced.updated
+                    ? chalk.gray(
+                        ` (${synced.created} created, ${synced.updated} updated)`
+                      )
+                    : "")
+              )
+            );
+          }
+
           const newDep = await api.createDeployment({
             serverId,
             branch,
@@ -1281,6 +1333,19 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
     let deploymentId: string | undefined;
 
     if (serverId) {
+      if (Object.keys(envVars).length > 0) {
+        const synced = await syncEnvVarsToServer(api, serverId, envVars);
+        console.log(
+          chalk.green(
+            `✓ Synced ${synced.created + synced.updated} environment variable(s)` +
+              (synced.created || synced.updated
+                ? chalk.gray(
+                    ` (${synced.created} created, ${synced.updated} updated)`
+                  )
+                : "")
+          )
+        );
+      }
       console.log(chalk.gray("Creating deployment..."));
       try {
         const result = await api.createDeployment({

--- a/libraries/typescript/packages/cli/tests/deployments.test.ts
+++ b/libraries/typescript/packages/cli/tests/deployments.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { Deployment } from "../src/utils/api.js";
+import type { Deployment, EnvVariable } from "../src/utils/api.js";
 
 // Create a mock API instance
 const mockApiInstance = {
@@ -11,6 +11,10 @@ const mockApiInstance = {
   getDeploymentLogs: vi.fn(),
   getDeploymentBuildLogs: vi.fn(),
   streamDeploymentLogs: vi.fn(),
+  listEnvVariables: vi.fn(),
+  createEnvVariable: vi.fn(),
+  updateEnvVariable: vi.fn(),
+  deleteEnvVariable: vi.fn(),
 };
 
 // Mock the entire api module
@@ -45,24 +49,20 @@ vi.mock("../src/utils/config.js", () => {
   };
 });
 
-// Mock chalk to avoid color codes in tests
+// Mock chalk to avoid color codes in tests. Uses a Proxy so any chained
+// property access (chalk.red.bold, chalk.gray, etc.) returns a function that
+// just echoes its input — without eagerly building an infinite tree.
 vi.mock("chalk", () => {
-  const createChain = () => {
-    const fn = (str: string) => str;
-    fn.bold = createChain();
-    fn.red = createChain();
-    fn.green = createChain();
-    fn.yellow = createChain();
-    fn.cyan = createChain();
-    fn.gray = createChain();
-    fn.white = createChain();
-    fn.whiteBright = createChain();
-    return fn;
-  };
-
-  return {
-    default: createChain(),
-  };
+  const passthrough: any = new Proxy(
+    function passthrough(s: string) {
+      return s;
+    },
+    {
+      get: () => passthrough,
+      apply: (_t, _this, args) => args[0],
+    }
+  );
+  return { default: passthrough };
 });
 
 // Mock readline for prompts
@@ -782,6 +782,148 @@ describe("Error Handling", () => {
       : apiError;
 
     expect(userMessage).toBe("Deployment not found");
+  });
+});
+
+describe("syncEnvVarsToServer", () => {
+  const SERVER_ID = "srv_abc";
+
+  function makeExisting(overrides: Partial<EnvVariable> = {}): EnvVariable {
+    return {
+      id: "env_existing",
+      serverId: SERVER_ID,
+      key: "EXISTING",
+      value: "old",
+      environments: ["production", "preview", "development"],
+      sensitive: false,
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-01T00:00:00Z",
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns zero counts when no env vars are provided", async () => {
+    const { syncEnvVarsToServer } = await import("../src/commands/deploy.js");
+
+    const result = await syncEnvVarsToServer(
+      mockApiInstance as any,
+      SERVER_ID,
+      {}
+    );
+
+    expect(result).toEqual({ created: 0, updated: 0 });
+    expect(mockApiInstance.listEnvVariables).not.toHaveBeenCalled();
+    expect(mockApiInstance.createEnvVariable).not.toHaveBeenCalled();
+    expect(mockApiInstance.updateEnvVariable).not.toHaveBeenCalled();
+  });
+
+  it("creates env variables that don't exist on the server", async () => {
+    const { syncEnvVarsToServer } = await import("../src/commands/deploy.js");
+    mockApiInstance.listEnvVariables.mockResolvedValue([]);
+    mockApiInstance.createEnvVariable.mockResolvedValue(makeExisting());
+
+    const result = await syncEnvVarsToServer(
+      mockApiInstance as any,
+      SERVER_ID,
+      { API_KEY: "abc", DATABASE_URL: "postgres://x" }
+    );
+
+    expect(mockApiInstance.listEnvVariables).toHaveBeenCalledWith(SERVER_ID);
+    expect(mockApiInstance.createEnvVariable).toHaveBeenCalledTimes(2);
+    expect(mockApiInstance.createEnvVariable).toHaveBeenCalledWith(SERVER_ID, {
+      key: "API_KEY",
+      value: "abc",
+    });
+    expect(mockApiInstance.createEnvVariable).toHaveBeenCalledWith(SERVER_ID, {
+      key: "DATABASE_URL",
+      value: "postgres://x",
+    });
+    expect(mockApiInstance.updateEnvVariable).not.toHaveBeenCalled();
+    expect(result).toEqual({ created: 2, updated: 0 });
+  });
+
+  it("updates env variables that already exist on the server", async () => {
+    const { syncEnvVarsToServer } = await import("../src/commands/deploy.js");
+    mockApiInstance.listEnvVariables.mockResolvedValue([
+      makeExisting({ id: "env_1", key: "API_KEY", value: "old" }),
+    ]);
+    mockApiInstance.updateEnvVariable.mockResolvedValue(makeExisting());
+
+    const result = await syncEnvVarsToServer(
+      mockApiInstance as any,
+      SERVER_ID,
+      { API_KEY: "new" }
+    );
+
+    expect(mockApiInstance.updateEnvVariable).toHaveBeenCalledWith(
+      SERVER_ID,
+      "env_1",
+      { value: "new" }
+    );
+    expect(mockApiInstance.createEnvVariable).not.toHaveBeenCalled();
+    expect(result).toEqual({ created: 0, updated: 1 });
+  });
+
+  it("mixes creates and updates in a single sync", async () => {
+    const { syncEnvVarsToServer } = await import("../src/commands/deploy.js");
+    mockApiInstance.listEnvVariables.mockResolvedValue([
+      makeExisting({ id: "env_1", key: "API_KEY", value: "old" }),
+    ]);
+    mockApiInstance.createEnvVariable.mockResolvedValue(makeExisting());
+    mockApiInstance.updateEnvVariable.mockResolvedValue(makeExisting());
+
+    const result = await syncEnvVarsToServer(
+      mockApiInstance as any,
+      SERVER_ID,
+      { API_KEY: "new", BRAND_NEW: "value" }
+    );
+
+    expect(mockApiInstance.updateEnvVariable).toHaveBeenCalledWith(
+      SERVER_ID,
+      "env_1",
+      { value: "new" }
+    );
+    expect(mockApiInstance.createEnvVariable).toHaveBeenCalledWith(SERVER_ID, {
+      key: "BRAND_NEW",
+      value: "value",
+    });
+    expect(result).toEqual({ created: 1, updated: 1 });
+  });
+
+  it("does not delete or modify keys that aren't in the supplied set", async () => {
+    const { syncEnvVarsToServer } = await import("../src/commands/deploy.js");
+    mockApiInstance.listEnvVariables.mockResolvedValue([
+      makeExisting({ id: "env_1", key: "API_KEY", value: "old" }),
+      makeExisting({ id: "env_2", key: "UNTOUCHED", value: "stay" }),
+    ]);
+    mockApiInstance.updateEnvVariable.mockResolvedValue(makeExisting());
+
+    await syncEnvVarsToServer(mockApiInstance as any, SERVER_ID, {
+      API_KEY: "new",
+    });
+
+    expect(mockApiInstance.updateEnvVariable).toHaveBeenCalledTimes(1);
+    expect(mockApiInstance.updateEnvVariable).toHaveBeenCalledWith(
+      SERVER_ID,
+      "env_1",
+      { value: "new" }
+    );
+    expect(mockApiInstance.deleteEnvVariable).not.toHaveBeenCalled();
+  });
+
+  it("propagates API errors so the caller can fail the deploy", async () => {
+    const { syncEnvVarsToServer } = await import("../src/commands/deploy.js");
+    mockApiInstance.listEnvVariables.mockRejectedValue(
+      new Error("API request failed: 500")
+    );
+
+    await expect(
+      syncEnvVarsToServer(mockApiInstance as any, SERVER_ID, { K: "v" })
+    ).rejects.toThrow("500");
   });
 });
 


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

`mcp-use deploy --env KEY=VAL` (and `--env-file`) silently dropped the env vars on every redeploy. The CLI parsed them, showed them in the deployment preview, then called `api.createDeployment(...)` without ever touching the server's env vars. Only the *initial* server-creation path actually forwarded env vars (they ride on the `createServer` request body).

This PR makes the deploy command upsert env vars against the dedicated `/api/v1/servers/{id}/env-variables` endpoints before triggering the deployment, so redeploys finally honor `--env`/`--env-file`.

## Implementation Details

1. New exported helper `syncEnvVarsToServer(api, serverId, envVars)` in `packages/cli/src/commands/deploy.ts`. It calls `listEnvVariables`, then in parallel issues `PATCH` (`updateEnvVariable`) for keys that already exist on the server and `POST` (`createEnvVariable`) for new ones. Returns `{ created, updated }` counts for status output.
2. Wired `syncEnvVarsToServer` into both redeploy code paths in `deployCommand`:
   - The "Found linked server" branch (linked deployment, status not failed).
   - The fallback `if (serverId)` branch (e.g., previously failed deployment, server still exists).
3. Keys *not* in the supplied set are left alone — clearing a variable still requires `mcp-use servers env rm`. This matches the existing one-off `servers env` UX and avoids destructive surprises.
4. The new-server (`createServer`) path is unchanged: env still rides on the request body.

## TypeScript Checklist

### Packages Modified
- [ ] `docs`
- [ ] `tests`
- [x] `cli`
- [ ] `create-mcp-use-app`
- [ ] `mcp-use` (server)
- [ ] `mcp-use` (client)
- [ ] `inspector`

### Pre-commit Checklist
- [x] Ran `pnpm lint` (clean)
- [x] Ran `pnpm format:check` (clean)
- [x] Ran `pnpm build` (clean)
- [x] Ran `pnpm changeset` — added `.changeset/fix-deploy-env-propagation.md` (`@mcp-use/cli` patch)
- [x] Added tests for the new helper
- [ ] Updated documentation in `docs/` folder if needed (no doc-visible API changes)

## Example Usage (Before)

```bash
# First deploy — env propagates because it rides on createServer
$ mcp-use deploy --env API_KEY=abc123
✓ Server created, deployment running
$ mcp-use servers env list --server <id>
  API_KEY = abc123

# Redeploy with a new env value — silently dropped
$ mcp-use deploy --env API_KEY=updated-value
Deployment configuration:
  Environment:   1 variable(s)    ← preview lies
✓ Found linked server
  Redeploying to maintain the same URL...
✓ Deployment created

$ mcp-use servers env list --server <id>
  API_KEY = abc123                ← still the old value
```

## Example Usage (After)

```bash
$ mcp-use deploy --env API_KEY=updated-value --env NEW_FLAG=on
Deployment configuration:
  Environment:   2 variable(s)
✓ Found linked server
  Redeploying to maintain the same URL...
✓ Synced 2 environment variable(s) (1 created, 1 updated)
✓ Deployment created

$ mcp-use servers env list --server <id>
  API_KEY  = updated-value
  NEW_FLAG = on
```

## Documentation Updates

None required — `--env` / `--env-file` flags are unchanged in shape. The behavior change is "they now actually work on redeploys."

## Testing

**Unit tests** (added in `packages/cli/tests/deployments.test.ts` — 6 new cases under `syncEnvVarsToServer`):

- returns zero counts when no env vars are provided (and skips the API entirely)
- creates env variables that don't exist on the server
- updates env variables that already exist on the server
- mixes creates and updates in a single sync
- does not delete or modify keys that aren't in the supplied set
- propagates API errors so the caller can fail the deploy

`pnpm --filter @mcp-use/cli exec vitest run tests/deployments.test.ts` → 58/58 pass (52 existing + 6 new). The 10 pre-existing failures elsewhere in the CLI test suite (`cli-integration` build/import-resolution) reproduce on a clean `canary` checkout and are unrelated.

**Manual validation context:** the env-variables REST endpoints (POST/PATCH/DELETE) on `cloud.dev.manufact.com` were independently validated against server `f8c93a6e-8f2c-486a-aac9-adcd299f7fbb` via `mcp-use servers env add/update/remove` — all exited 0. Those are the exact endpoints `syncEnvVarsToServer` calls, so the underlying transport is known-good; this PR fixes the missing wire-up between `deploy` and those endpoints.

**Side fix:** the existing `chalk` mock in `tests/deployments.test.ts` had an infinite-recursion bug in its factory (`createChain` calling itself eagerly for each property). It only manifested once a test imported a module that actually consumed `chalk` at import time. Replaced with a Proxy-based passthrough mock.

## Backwards Compatibility

Backwards compatible. The CLI flags are unchanged; redeploys that previously silently no-op'd on env vars now do what users already expected. Existing keys not mentioned in `--env` are still left untouched (no surprise deletions).

## Related Issues

Closes MCP-1995