### PR TITLE
feat(inspector): support custom base URL for OpenAI-compatible providers

### DIFF
--- a/libraries/typescript/.changeset/inspector-openai-base-url.md
+++ b/libraries/typescript/.changeset/inspector-openai-base-url.md
@@ -1,5 +1,5 @@
 ---
-"@mcp-use/inspector": patch
+"@mcp-use/inspector": minor
 ---
 
 Add "OpenAI Compatible" provider option to the inspector chat configuration.

--- a/libraries/typescript/.changeset/inspector-openai-base-url.md
+++ b/libraries/typescript/.changeset/inspector-openai-base-url.md
@@ -1,0 +1,7 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Add configurable Base URL support for OpenAI-compatible providers in the inspector chat.
+
+The OpenAI provider now accepts an optional `baseUrl` field, allowing users to point the inspector chat at any OpenAI-compatible API (e.g. LM Studio at `http://localhost:1234/v1`, OpenRouter at `https://openrouter.ai/api/v1`). When left blank the default OpenAI endpoint (`https://api.openai.com/v1`) is used.

--- a/libraries/typescript/.changeset/inspector-openai-base-url.md
+++ b/libraries/typescript/.changeset/inspector-openai-base-url.md
@@ -2,6 +2,6 @@
 "@mcp-use/inspector": patch
 ---
 
-Add configurable Base URL support for OpenAI-compatible providers in the inspector chat.
+Add "OpenAI Compatible" provider option to the inspector chat configuration.
 
-The OpenAI provider now accepts an optional `baseUrl` field, allowing users to point the inspector chat at any OpenAI-compatible API (e.g. LM Studio at `http://localhost:1234/v1`, OpenRouter at `https://openrouter.ai/api/v1`). When left blank the default OpenAI endpoint (`https://api.openai.com/v1`) is used.
+A new "OpenAI Compatible" entry in the provider dropdown lets users point the inspector chat at any OpenAI-compatible API (e.g. LM Studio, Ollama, OpenRouter). Selecting it exposes a required Base URL field and an optional API key. The standard OpenAI provider is unchanged.

--- a/libraries/typescript/packages/inspector/src/client/components/ChatTab.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ChatTab.tsx
@@ -168,6 +168,8 @@ export function ChatTab({
     setTempApiKey,
     tempModel,
     setTempModel,
+    tempBaseUrl,
+    setTempBaseUrl,
     saveLLMConfig,
     clearConfig,
   } = useConfig({ mcpServerUrl: connection.url });
@@ -1024,9 +1026,11 @@ export function ChatTab({
             tempProvider={tempProvider}
             tempModel={tempModel}
             tempApiKey={tempApiKey}
+            tempBaseUrl={tempBaseUrl}
             onProviderChange={setTempProvider}
             onModelChange={setTempModel}
             onApiKeyChange={setTempApiKey}
+            onBaseUrlChange={setTempBaseUrl}
             onSave={saveLLMConfig}
             onClear={handleClearConfig}
             showClearButton={!isManaged}
@@ -1091,9 +1095,11 @@ export function ChatTab({
         tempProvider={tempProvider}
         tempModel={tempModel}
         tempApiKey={tempApiKey}
+        tempBaseUrl={tempBaseUrl}
         onProviderChange={setTempProvider}
         onModelChange={setTempModel}
         onApiKeyChange={setTempApiKey}
+        onBaseUrlChange={setTempBaseUrl}
         onSaveConfig={saveLLMConfig}
         onClearConfig={handleClearConfig}
         hideConfigButton={

--- a/libraries/typescript/packages/inspector/src/client/components/chat/ChatHeader.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/ChatHeader.tsx
@@ -28,9 +28,11 @@ interface ChatHeaderProps {
   tempProvider: "openai" | "anthropic" | "google";
   tempModel: string;
   tempApiKey: string;
+  tempBaseUrl?: string;
   onProviderChange: (provider: "openai" | "anthropic" | "google") => void;
   onModelChange: (model: string) => void;
   onApiKeyChange: (apiKey: string) => void;
+  onBaseUrlChange?: (baseUrl: string) => void;
   onSaveConfig: () => void;
   onClearConfig: () => void;
   /** When true, hides the API key config badge/button and dialog. */
@@ -67,9 +69,11 @@ export function ChatHeader({
   tempProvider,
   tempModel,
   tempApiKey,
+  tempBaseUrl,
   onProviderChange,
   onModelChange,
   onApiKeyChange,
+  onBaseUrlChange,
   onSaveConfig,
   onClearConfig,
   hideConfigButton,
@@ -180,7 +184,7 @@ export function ChatHeader({
               </DropdownMenu>
             )}
 
-            <div className="w-[1px] h-4 bg-border mx-1" />
+            <div className="w-px h-4 bg-border mx-1" />
 
             <Tooltip>
               <TooltipTrigger asChild>
@@ -219,9 +223,11 @@ export function ChatHeader({
             tempProvider={tempProvider}
             tempModel={tempModel}
             tempApiKey={tempApiKey}
+            tempBaseUrl={tempBaseUrl}
             onProviderChange={onProviderChange}
             onModelChange={onModelChange}
             onApiKeyChange={onApiKeyChange}
+            onBaseUrlChange={onBaseUrlChange}
             onSave={onSaveConfig}
             onClear={onClearConfig}
             showClearButton={!!llmConfig && !freeTierInfo}

--- a/libraries/typescript/packages/inspector/src/client/components/chat/ChatHeader.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/ChatHeader.tsx
@@ -1,4 +1,3 @@
-import { resolveProvider } from "@/llm/types";
 import type { LLMConfig } from "./types";
 
 import { Badge } from "@/client/components/ui/badge";
@@ -102,11 +101,13 @@ export function ChatHeader({
                 className="hidden sm:flex ml-2 pl-1 font-mono text-[11px] cursor-pointer hover:bg-secondary/80 transition-colors"
                 onClick={() => onConfigDialogOpenChange(true)}
               >
-                <img
-                  src={`https://inspector-cdn.mcp-use.com/providers/${resolveProvider(llmConfig.provider)}.png`}
-                  alt={llmConfig.provider}
-                  className="w-4 h-4 mr-0"
-                />
+                {llmConfig.provider !== "openai-compatible" && (
+                  <img
+                    src={`https://inspector-cdn.mcp-use.com/providers/${llmConfig.provider}.png`}
+                    alt={llmConfig.provider}
+                    className="w-4 h-4 mr-0"
+                  />
+                )}
                 {llmConfig.provider}/{llmConfig.model}
               </Badge>
             </TooltipTrigger>
@@ -129,11 +130,13 @@ export function ChatHeader({
                 className="p-2 sm:hidden"
                 onClick={() => onConfigDialogOpenChange(true)}
               >
-                <img
-                  src={`https://inspector-cdn.mcp-use.com/providers/${resolveProvider(llmConfig.provider)}.png`}
-                  alt={llmConfig.provider}
-                  className="w-4 h-4"
-                />
+                {llmConfig.provider !== "openai-compatible" && (
+                  <img
+                    src={`https://inspector-cdn.mcp-use.com/providers/${llmConfig.provider}.png`}
+                    alt={llmConfig.provider}
+                    className="w-4 h-4"
+                  />
+                )}
               </Button>
             </TooltipTrigger>
             <TooltipContent>

--- a/libraries/typescript/packages/inspector/src/client/components/chat/ChatHeader.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/ChatHeader.tsx
@@ -1,3 +1,4 @@
+import { resolveProvider } from "@/llm/types";
 import type { LLMConfig } from "./types";
 
 import { Badge } from "@/client/components/ui/badge";
@@ -25,11 +26,13 @@ interface ChatHeaderProps {
   onCopyChat?: () => void;
   onExportChat?: (format: "json" | "markdown") => void;
   // Configuration props
-  tempProvider: "openai" | "anthropic" | "google";
+  tempProvider: "openai" | "openai-compatible" | "anthropic" | "google";
   tempModel: string;
   tempApiKey: string;
   tempBaseUrl?: string;
-  onProviderChange: (provider: "openai" | "anthropic" | "google") => void;
+  onProviderChange: (
+    provider: "openai" | "openai-compatible" | "anthropic" | "google"
+  ) => void;
   onModelChange: (model: string) => void;
   onApiKeyChange: (apiKey: string) => void;
   onBaseUrlChange?: (baseUrl: string) => void;
@@ -100,7 +103,7 @@ export function ChatHeader({
                 onClick={() => onConfigDialogOpenChange(true)}
               >
                 <img
-                  src={`https://inspector-cdn.mcp-use.com/providers/${llmConfig.provider}.png`}
+                  src={`https://inspector-cdn.mcp-use.com/providers/${resolveProvider(llmConfig.provider)}.png`}
                   alt={llmConfig.provider}
                   className="w-4 h-4 mr-0"
                 />
@@ -127,7 +130,7 @@ export function ChatHeader({
                 onClick={() => onConfigDialogOpenChange(true)}
               >
                 <img
-                  src={`https://inspector-cdn.mcp-use.com/providers/${llmConfig.provider}.png`}
+                  src={`https://inspector-cdn.mcp-use.com/providers/${resolveProvider(llmConfig.provider)}.png`}
                   alt={llmConfig.provider}
                   className="w-4 h-4"
                 />

--- a/libraries/typescript/packages/inspector/src/client/components/chat/ChatLandingForm.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/ChatLandingForm.tsx
@@ -1,5 +1,4 @@
 import { AuroraBackground } from "@/client/components/ui/aurora-background";
-import { resolveProvider } from "@/llm/types";
 import { Badge } from "@/client/components/ui/badge";
 import { BlurFade } from "@/client/components/ui/blur-fade";
 import { Button } from "@/client/components/ui/button";
@@ -199,11 +198,13 @@ export function ChatLandingForm({
                     className="pl-1 font-mono text-[11px] cursor-pointer hover:bg-secondary/80 transition-colors"
                     onClick={() => onConfigDialogOpenChange(true)}
                   >
-                    <img
-                      src={`https://inspector-cdn.mcp-use.com/providers/${resolveProvider(llmConfig.provider)}.png`}
-                      alt={llmConfig.provider}
-                      className="w-4 h-4 mr-0 rounded-full"
-                    />
+                    {llmConfig.provider !== "openai-compatible" && (
+                      <img
+                        src={`https://inspector-cdn.mcp-use.com/providers/${llmConfig.provider}.png`}
+                        alt={llmConfig.provider}
+                        className="w-4 h-4 mr-0 rounded-full"
+                      />
+                    )}
                     {llmConfig.provider}/{llmConfig.model}
                   </Badge>
                 </TooltipTrigger>

--- a/libraries/typescript/packages/inspector/src/client/components/chat/ChatLandingForm.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/ChatLandingForm.tsx
@@ -1,4 +1,5 @@
 import { AuroraBackground } from "@/client/components/ui/aurora-background";
+import { resolveProvider } from "@/llm/types";
 import { Badge } from "@/client/components/ui/badge";
 import { BlurFade } from "@/client/components/ui/blur-fade";
 import { Button } from "@/client/components/ui/button";
@@ -199,7 +200,7 @@ export function ChatLandingForm({
                     onClick={() => onConfigDialogOpenChange(true)}
                   >
                     <img
-                      src={`https://inspector-cdn.mcp-use.com/providers/${llmConfig.provider}.png`}
+                      src={`https://inspector-cdn.mcp-use.com/providers/${resolveProvider(llmConfig.provider)}.png`}
                       alt={llmConfig.provider}
                       className="w-4 h-4 mr-0 rounded-full"
                     />

--- a/libraries/typescript/packages/inspector/src/client/components/chat/ConfigurationDialog.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/ConfigurationDialog.tsx
@@ -127,9 +127,20 @@ async function fetchOpenAICompatibleModels(
   baseUrl: string,
   apiKey: string
 ): Promise<ModelOption[]> {
-  const response = await fetch(`${baseUrl}/models`, {
-    headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : undefined,
-  });
+  const stripped = baseUrl.replace(/\/+$/, "");
+  const headers: Record<string, string> = {};
+  if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+
+  let response: Response;
+  try {
+    response = await fetch(`${stripped}/models`, { headers });
+  } catch {
+    // fetch() rejects with a generic TypeError when CORS blocks the response,
+    // when the server is unreachable, or on mixed-content.
+    throw new Error(
+      "Failed to reach the server. Check the URL is correct and that CORS is enabled on the server."
+    );
+  }
 
   if (!response.ok) {
     throw new Error(`Failed to fetch models: ${response.statusText}`);
@@ -137,10 +148,15 @@ async function fetchOpenAICompatibleModels(
 
   const contentType = response.headers.get("content-type") ?? "";
   if (!contentType.includes("application/json")) {
-    throw new Error("Invalid URL");
+    throw new Error("Invalid URL — response was not JSON");
   }
 
   const data = await response.json();
+  if (!Array.isArray(data?.data)) {
+    throw new Error(
+      "Unexpected response format — expected { data: [...] } from the OpenAI-compatible endpoint"
+    );
+  }
   return data.data.map((model: { id: string }) => ({ id: model.id }));
 }
 
@@ -354,16 +370,6 @@ export function ConfigurationDialog({
                     <span>OpenAI</span>
                   </div>
                 </SelectItem>
-                <SelectItem value="openai-compatible">
-                  <div className="flex items-center gap-2">
-                    <img
-                      src={getProviderIcon("openai")}
-                      alt="OpenAI Compatible"
-                      className="w-4 h-4"
-                    />
-                    <span>OpenAI Compatible</span>
-                  </div>
-                </SelectItem>
                 <SelectItem value="anthropic">
                   <div className="flex items-center gap-2">
                     <img
@@ -382,6 +388,11 @@ export function ConfigurationDialog({
                       className="w-4 h-4"
                     />
                     <span>Google</span>
+                  </div>
+                </SelectItem>
+                <SelectItem value="openai-compatible">
+                  <div className="flex items-center gap-2">
+                    <span>OpenAI Compatible</span>
                   </div>
                 </SelectItem>
               </SelectContent>
@@ -432,8 +443,8 @@ export function ConfigurationDialog({
                 data-testid="chat-config-base-url-input"
               />
               <p className="text-xs text-muted-foreground">
-                Base URL of your OpenAI-compatible API (e.g. LM Studio, Ollama,
-                OpenRouter).
+                Base URL of your OpenAI-compatible API. Local servers must
+                have CORS enabled.
               </p>
             </div>
           )}

--- a/libraries/typescript/packages/inspector/src/client/components/chat/ConfigurationDialog.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/ConfigurationDialog.tsx
@@ -100,9 +100,11 @@ interface ConfigurationDialogProps {
   tempProvider: "openai" | "anthropic" | "google";
   tempModel: string;
   tempApiKey: string;
+  tempBaseUrl?: string;
   onProviderChange: (provider: "openai" | "anthropic" | "google") => void;
   onModelChange: (model: string) => void;
   onApiKeyChange: (apiKey: string) => void;
+  onBaseUrlChange?: (baseUrl: string) => void;
   onSave: () => void;
   onClear?: () => void;
   showClearButton?: boolean;
@@ -119,8 +121,12 @@ interface ConfigurationDialogProps {
   };
 }
 
-async function fetchOpenAIModels(apiKey: string): Promise<ModelOption[]> {
-  const response = await fetch("https://api.openai.com/v1/models", {
+async function fetchOpenAIModels(
+  apiKey: string,
+  baseUrl?: string
+): Promise<ModelOption[]> {
+  const origin = baseUrl ?? "https://api.openai.com/v1";
+  const response = await fetch(`${origin}/models`, {
     headers: {
       Authorization: `Bearer ${apiKey}`,
     },
@@ -180,9 +186,11 @@ export function ConfigurationDialog({
   tempProvider,
   tempModel,
   tempApiKey,
+  tempBaseUrl = "",
   onProviderChange,
   onModelChange,
   onApiKeyChange,
+  onBaseUrlChange,
   onSave,
   onClear,
   showClearButton = false,
@@ -204,8 +212,14 @@ export function ConfigurationDialog({
     }
 
     const loadModels = async () => {
+      // Cache key includes baseUrl so different endpoints get separate caches
+      const cacheKey =
+        tempProvider === "openai" && tempBaseUrl.trim()
+          ? `${tempProvider}:${tempBaseUrl.trim()}`
+          : tempProvider;
+
       // Check cache first
-      const cachedModels = getCachedModels(tempProvider);
+      const cachedModels = getCachedModels(cacheKey);
       if (cachedModels) {
         setModels(cachedModels);
         setModelError(null);
@@ -219,7 +233,10 @@ export function ConfigurationDialog({
       try {
         let fetchedModels: ModelOption[] = [];
         if (tempProvider === "openai") {
-          fetchedModels = await fetchOpenAIModels(tempApiKey);
+          fetchedModels = await fetchOpenAIModels(
+            tempApiKey,
+            tempBaseUrl.trim() || undefined
+          );
         } else if (tempProvider === "anthropic") {
           fetchedModels = await fetchAnthropicModels(tempApiKey);
         } else if (tempProvider === "google") {
@@ -227,7 +244,7 @@ export function ConfigurationDialog({
         }
 
         // Cache the fetched models
-        setModelsCache(tempProvider, fetchedModels);
+        setModelsCache(cacheKey, fetchedModels);
         setModels(fetchedModels);
       } catch (error) {
         setModelError(
@@ -244,7 +261,7 @@ export function ConfigurationDialog({
     // Debounce the API call
     const timeoutId = setTimeout(loadModels, 500);
     return () => clearTimeout(timeoutId);
-  }, [tempApiKey, tempProvider, open]);
+  }, [tempApiKey, tempProvider, tempBaseUrl, open]);
 
   // Reset model when provider changes
   useEffect(() => {
@@ -366,6 +383,22 @@ export function ConfigurationDialog({
               Your API key is stored locally and never sent to our servers
             </p>
           </div>
+
+          {tempProvider === "openai" && (
+            <div className="space-y-2">
+              <Label>Base URL</Label>
+              <Input
+                value={tempBaseUrl}
+                onChange={(e) => onBaseUrlChange?.(e.target.value)}
+                placeholder="https://api.openai.com/v1 (default)"
+                data-testid="chat-config-base-url-input"
+              />
+              <p className="text-xs text-muted-foreground">
+                Override for OpenAI-compatible providers (e.g. LM Studio,
+                OpenRouter). Leave blank to use the default OpenAI endpoint.
+              </p>
+            </div>
+          )}
 
           {tempApiKey.trim() && (
             <div className="space-y-2">

--- a/libraries/typescript/packages/inspector/src/client/components/chat/ConfigurationDialog.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/ConfigurationDialog.tsx
@@ -97,11 +97,13 @@ function getCachedModels(provider: string): ModelOption[] | null {
 interface ConfigurationDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  tempProvider: "openai" | "anthropic" | "google";
+  tempProvider: "openai" | "openai-compatible" | "anthropic" | "google";
   tempModel: string;
   tempApiKey: string;
   tempBaseUrl?: string;
-  onProviderChange: (provider: "openai" | "anthropic" | "google") => void;
+  onProviderChange: (
+    provider: "openai" | "openai-compatible" | "anthropic" | "google"
+  ) => void;
   onModelChange: (model: string) => void;
   onApiKeyChange: (apiKey: string) => void;
   onBaseUrlChange?: (baseUrl: string) => void;
@@ -121,12 +123,29 @@ interface ConfigurationDialogProps {
   };
 }
 
-async function fetchOpenAIModels(
-  apiKey: string,
-  baseUrl?: string
+async function fetchOpenAICompatibleModels(
+  baseUrl: string,
+  apiKey: string
 ): Promise<ModelOption[]> {
-  const origin = baseUrl ?? "https://api.openai.com/v1";
-  const response = await fetch(`${origin}/models`, {
+  const response = await fetch(`${baseUrl}/models`, {
+    headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : undefined,
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch models: ${response.statusText}`);
+  }
+
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!contentType.includes("application/json")) {
+    throw new Error("Invalid URL");
+  }
+
+  const data = await response.json();
+  return data.data.map((model: { id: string }) => ({ id: model.id }));
+}
+
+async function fetchOpenAIModels(apiKey: string): Promise<ModelOption[]> {
+  const response = await fetch("https://api.openai.com/v1/models", {
     headers: {
       Authorization: `Bearer ${apiKey}`,
     },
@@ -203,19 +222,22 @@ export function ConfigurationDialog({
   const [comboboxOpen, setComboboxOpen] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
 
-  // Fetch models when API key is set and provider is selected
+  // Fetch models when API key / base URL is set and provider is selected
   useEffect(() => {
-    if (!open || !tempApiKey.trim() || !tempProvider) {
+    const hasCredential =
+      tempProvider === "openai-compatible"
+        ? !!tempBaseUrl.trim()
+        : !!tempApiKey.trim();
+    if (!open || !hasCredential) {
       setModels([]);
       setModelError(null);
       return;
     }
 
     const loadModels = async () => {
-      // Cache key includes baseUrl so different endpoints get separate caches
       const cacheKey =
-        tempProvider === "openai" && tempBaseUrl.trim()
-          ? `${tempProvider}:${tempBaseUrl.trim()}`
+        tempProvider === "openai-compatible"
+          ? `${tempProvider}:${tempBaseUrl}`
           : tempProvider;
 
       // Check cache first
@@ -232,11 +254,13 @@ export function ConfigurationDialog({
 
       try {
         let fetchedModels: ModelOption[] = [];
-        if (tempProvider === "openai") {
-          fetchedModels = await fetchOpenAIModels(
-            tempApiKey,
-            tempBaseUrl.trim() || undefined
+        if (tempProvider === "openai-compatible") {
+          fetchedModels = await fetchOpenAICompatibleModels(
+            tempBaseUrl,
+            tempApiKey
           );
+        } else if (tempProvider === "openai") {
+          fetchedModels = await fetchOpenAIModels(tempApiKey);
         } else if (tempProvider === "anthropic") {
           fetchedModels = await fetchAnthropicModels(tempApiKey);
         } else if (tempProvider === "google") {
@@ -330,6 +354,16 @@ export function ConfigurationDialog({
                     <span>OpenAI</span>
                   </div>
                 </SelectItem>
+                <SelectItem value="openai-compatible">
+                  <div className="flex items-center gap-2">
+                    <img
+                      src={getProviderIcon("openai")}
+                      alt="OpenAI Compatible"
+                      className="w-4 h-4"
+                    />
+                    <span>OpenAI Compatible</span>
+                  </div>
+                </SelectItem>
                 <SelectItem value="anthropic">
                   <div className="flex items-center gap-2">
                     <img
@@ -361,7 +395,11 @@ export function ConfigurationDialog({
                 type={showPassword ? "text" : "password"}
                 value={tempApiKey}
                 onChange={(e) => onApiKeyChange(e.target.value)}
-                placeholder="Enter your API key"
+                placeholder={
+                  tempProvider === "openai-compatible"
+                    ? "Enter your API key (optional)"
+                    : "Enter your API key"
+                }
                 className="pr-10"
                 data-testid="chat-config-api-key-input"
               />
@@ -384,23 +422,25 @@ export function ConfigurationDialog({
             </p>
           </div>
 
-          {tempProvider === "openai" && (
+          {tempProvider === "openai-compatible" && (
             <div className="space-y-2">
               <Label>Base URL</Label>
               <Input
                 value={tempBaseUrl}
                 onChange={(e) => onBaseUrlChange?.(e.target.value)}
-                placeholder="https://api.openai.com/v1 (default)"
+                placeholder="http://localhost:11434/v1"
                 data-testid="chat-config-base-url-input"
               />
               <p className="text-xs text-muted-foreground">
-                Override for OpenAI-compatible providers (e.g. LM Studio,
-                OpenRouter). Leave blank to use the default OpenAI endpoint.
+                Base URL of your OpenAI-compatible API (e.g. LM Studio, Ollama,
+                OpenRouter).
               </p>
             </div>
           )}
 
-          {tempApiKey.trim() && (
+          {(tempProvider === "openai-compatible"
+            ? !!tempBaseUrl.trim()
+            : !!tempApiKey.trim()) && (
             <div className="space-y-2">
               <Label>Model</Label>
               {isLoadingModels ? (
@@ -489,7 +529,9 @@ export function ConfigurationDialog({
             <Button
               onClick={onSave}
               disabled={
-                !tempApiKey.trim() || (!!tempApiKey.trim() && !tempModel.trim())
+                tempProvider === "openai-compatible"
+                  ? !tempBaseUrl.trim() || !tempModel.trim()
+                  : !tempApiKey.trim() || !tempModel.trim()
               }
               className={showClearButton ? "ml-auto" : ""}
               data-testid="chat-config-save-button"

--- a/libraries/typescript/packages/inspector/src/client/components/chat/ConfigurationDialog.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/ConfigurationDialog.tsx
@@ -443,8 +443,8 @@ export function ConfigurationDialog({
                 data-testid="chat-config-base-url-input"
               />
               <p className="text-xs text-muted-foreground">
-                Base URL of your OpenAI-compatible API. Local servers must
-                have CORS enabled.
+                Base URL of your OpenAI-compatible API. Local servers must have
+                CORS enabled.
               </p>
             </div>
           )}

--- a/libraries/typescript/packages/inspector/src/client/components/chat/types.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/types.ts
@@ -32,7 +32,7 @@ export interface Message {
 }
 
 export interface LLMConfig {
-  provider: "openai" | "anthropic" | "google";
+  provider: "openai" | "openai-compatible" | "anthropic" | "google";
   apiKey: string;
   model: string;
   temperature?: number;
@@ -71,6 +71,7 @@ export type StreamProtocol = "sse" | "data-stream";
 
 export const DEFAULT_MODELS = {
   openai: "gpt-4o",
+  "openai-compatible": "",
   anthropic: "claude-haiku-4-5-20251001",
   google: "gemini-2.5-flash",
 };

--- a/libraries/typescript/packages/inspector/src/client/components/chat/types.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/types.ts
@@ -36,6 +36,7 @@ export interface LLMConfig {
   apiKey: string;
   model: string;
   temperature?: number;
+  baseUrl?: string;
 }
 
 export interface AuthConfig {

--- a/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessagesClientSide.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessagesClientSide.ts
@@ -272,6 +272,7 @@ export function useChatMessagesClientSide({
             model: llmConfig.model,
             apiKey: llmConfig.apiKey,
             temperature: llmConfig.temperature,
+            baseUrl: llmConfig.baseUrl,
           },
           messages: providerMessages,
           tools: toolList,

--- a/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessagesClientSide.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessagesClientSide.ts
@@ -1,5 +1,6 @@
 import { MCPChatMessageEvent, Telemetry } from "@/client/telemetry";
 import { runToolLoop } from "@/llm/toolLoop";
+import { resolveProvider } from "@/llm/types";
 import type { ProviderTool } from "@/llm/types";
 import type { McpServer } from "mcp-use/react";
 import { useCallback, useRef, useState } from "react";
@@ -268,7 +269,7 @@ export function useChatMessagesClientSide({
 
         for await (const ev of runToolLoop({
           config: {
-            provider: llmConfig.provider,
+            provider: resolveProvider(llmConfig.provider),
             model: llmConfig.model,
             apiKey: llmConfig.apiKey,
             temperature: llmConfig.temperature,

--- a/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessagesClientSide.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessagesClientSide.ts
@@ -1,6 +1,5 @@
 import { MCPChatMessageEvent, Telemetry } from "@/client/telemetry";
 import { runToolLoop } from "@/llm/toolLoop";
-import { resolveProvider } from "@/llm/types";
 import type { ProviderTool } from "@/llm/types";
 import type { McpServer } from "mcp-use/react";
 import { useCallback, useRef, useState } from "react";
@@ -269,7 +268,7 @@ export function useChatMessagesClientSide({
 
         for await (const ev of runToolLoop({
           config: {
-            provider: resolveProvider(llmConfig.provider),
+            provider: llmConfig.provider,
             model: llmConfig.model,
             apiKey: llmConfig.apiKey,
             temperature: llmConfig.temperature,

--- a/libraries/typescript/packages/inspector/src/client/components/chat/useConfig.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/useConfig.ts
@@ -15,7 +15,7 @@ export function useConfig({ mcpServerUrl }: UseConfigProps) {
 
   // LLM Config form state
   const [tempProvider, setTempProvider] = useState<
-    "openai" | "anthropic" | "google"
+    "openai" | "openai-compatible" | "anthropic" | "google"
   >("openai");
   const [tempApiKey, setTempApiKey] = useState("");
   const [tempModel, setTempModel] = useState(DEFAULT_MODELS.openai);
@@ -129,14 +129,16 @@ export function useConfig({ mcpServerUrl }: UseConfigProps) {
 
   // Update model and load API key when provider changes
   useEffect(() => {
-    setTempModel(DEFAULT_MODELS[tempProvider]);
-    // Load API key for the selected provider
+    if (tempProvider !== "openai-compatible") {
+      setTempModel(DEFAULT_MODELS[tempProvider]);
+      setTempBaseUrl("");
+    }
     const apiKeys = getApiKeys();
     setTempApiKey(apiKeys[tempProvider] || "");
   }, [tempProvider, getApiKeys]);
 
   const saveLLMConfig = useCallback(() => {
-    if (!tempApiKey.trim()) {
+    if (tempProvider === "openai-compatible" ? !tempBaseUrl.trim() : !tempApiKey.trim()) {
       return;
     }
 
@@ -149,7 +151,7 @@ export function useConfig({ mcpServerUrl }: UseConfigProps) {
       provider: tempProvider,
       apiKey: tempApiKey,
       model: tempModel,
-      ...(tempProvider === "openai" &&
+      ...(tempProvider === "openai-compatible" &&
         tempBaseUrl.trim() && { baseUrl: tempBaseUrl.trim() }),
     };
 
@@ -214,6 +216,7 @@ export function useConfig({ mcpServerUrl }: UseConfigProps) {
     delete apiKeys[tempProvider];
     saveApiKeys(apiKeys);
     setTempApiKey("");
+    setTempBaseUrl("");
     setTempUsername("");
     setTempPassword("");
     setTempToken("");

--- a/libraries/typescript/packages/inspector/src/client/components/chat/useConfig.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/useConfig.ts
@@ -19,6 +19,7 @@ export function useConfig({ mcpServerUrl }: UseConfigProps) {
   >("openai");
   const [tempApiKey, setTempApiKey] = useState("");
   const [tempModel, setTempModel] = useState(DEFAULT_MODELS.openai);
+  const [tempBaseUrl, setTempBaseUrl] = useState("");
 
   // Load API keys per provider from localStorage
   const getApiKeys = useCallback((): Record<string, string> => {
@@ -60,6 +61,7 @@ export function useConfig({ mcpServerUrl }: UseConfigProps) {
           // Load API key for the provider from provider-specific storage
           setTempApiKey(apiKeys[config.provider] || config.apiKey || "");
           setTempModel(config.model);
+          setTempBaseUrl(config.baseUrl ?? "");
         } catch (error) {
           console.error("Failed to load LLM config:", error);
         }
@@ -147,6 +149,8 @@ export function useConfig({ mcpServerUrl }: UseConfigProps) {
       provider: tempProvider,
       apiKey: tempApiKey,
       model: tempModel,
+      ...(tempProvider === "openai" &&
+        tempBaseUrl.trim() && { baseUrl: tempBaseUrl.trim() }),
     };
 
     const newAuthConfig: AuthConfig = {
@@ -193,6 +197,7 @@ export function useConfig({ mcpServerUrl }: UseConfigProps) {
     tempProvider,
     tempApiKey,
     tempModel,
+    tempBaseUrl,
     tempAuthType,
     tempUsername,
     tempPassword,
@@ -228,6 +233,8 @@ export function useConfig({ mcpServerUrl }: UseConfigProps) {
     setTempApiKey,
     tempModel,
     setTempModel,
+    tempBaseUrl,
+    setTempBaseUrl,
     tempAuthType,
     saveLLMConfig,
     clearConfig,

--- a/libraries/typescript/packages/inspector/src/client/components/chat/useConfig.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/useConfig.ts
@@ -40,6 +40,25 @@ export function useConfig({ mcpServerUrl }: UseConfigProps) {
     localStorage.setItem("mcp-inspector-api-keys", JSON.stringify(apiKeys));
   }, []);
 
+  // Load base URLs per provider from localStorage (currently only used by openai-compatible)
+  const getBaseUrls = useCallback((): Record<string, string> => {
+    const saved = localStorage.getItem("mcp-inspector-base-urls");
+    if (saved) {
+      try {
+        return JSON.parse(saved);
+      } catch (error) {
+        console.error("Failed to load base URLs:", error);
+        return {};
+      }
+    }
+    return {};
+  }, []);
+
+  // Save base URLs per provider to localStorage
+  const saveBaseUrls = useCallback((baseUrls: Record<string, string>) => {
+    localStorage.setItem("mcp-inspector-base-urls", JSON.stringify(baseUrls));
+  }, []);
+
   // Auth Config form state
   const [tempAuthType, setTempAuthType] = useState<
     "none" | "basic" | "bearer" | "oauth"
@@ -53,6 +72,7 @@ export function useConfig({ mcpServerUrl }: UseConfigProps) {
     const loadConfig = () => {
       const saved = localStorage.getItem("mcp-inspector-llm-config");
       const apiKeys = getApiKeys();
+      const baseUrls = getBaseUrls();
       if (saved) {
         try {
           const config = JSON.parse(saved);
@@ -61,7 +81,9 @@ export function useConfig({ mcpServerUrl }: UseConfigProps) {
           // Load API key for the provider from provider-specific storage
           setTempApiKey(apiKeys[config.provider] || config.apiKey || "");
           setTempModel(config.model);
-          setTempBaseUrl(config.baseUrl ?? "");
+          setTempBaseUrl(
+            baseUrls[config.provider] ?? config.baseUrl ?? ""
+          );
         } catch (error) {
           console.error("Failed to load LLM config:", error);
         }
@@ -80,7 +102,8 @@ export function useConfig({ mcpServerUrl }: UseConfigProps) {
     const handleStorageChange = (e: StorageEvent) => {
       if (
         e.key === "mcp-inspector-llm-config" ||
-        e.key === "mcp-inspector-api-keys"
+        e.key === "mcp-inspector-api-keys" ||
+        e.key === "mcp-inspector-base-urls"
       ) {
         loadConfig();
       }
@@ -92,7 +115,7 @@ export function useConfig({ mcpServerUrl }: UseConfigProps) {
       window.removeEventListener("llm-config-updated", handleConfigUpdate);
       window.removeEventListener("storage", handleStorageChange);
     };
-  }, [getApiKeys]);
+  }, [getApiKeys, getBaseUrls]);
 
   // Load auth config from localStorage on mount
   useEffect(() => {
@@ -127,15 +150,18 @@ export function useConfig({ mcpServerUrl }: UseConfigProps) {
     }
   }, [mcpServerUrl]);
 
-  // Update model and load API key when provider changes
+  // Update model and load API key / base URL when provider changes
   useEffect(() => {
-    if (tempProvider !== "openai-compatible") {
+    if (tempProvider === "openai-compatible") {
+      const baseUrls = getBaseUrls();
+      setTempBaseUrl(baseUrls[tempProvider] || "");
+    } else {
       setTempModel(DEFAULT_MODELS[tempProvider]);
       setTempBaseUrl("");
     }
     const apiKeys = getApiKeys();
     setTempApiKey(apiKeys[tempProvider] || "");
-  }, [tempProvider, getApiKeys]);
+  }, [tempProvider, getApiKeys, getBaseUrls]);
 
   const saveLLMConfig = useCallback(() => {
     if (tempProvider === "openai-compatible" ? !tempBaseUrl.trim() : !tempApiKey.trim()) {
@@ -146,6 +172,13 @@ export function useConfig({ mcpServerUrl }: UseConfigProps) {
     const apiKeys = getApiKeys();
     apiKeys[tempProvider] = tempApiKey;
     saveApiKeys(apiKeys);
+
+    // Save base URL for the current provider (currently only openai-compatible)
+    if (tempProvider === "openai-compatible" && tempBaseUrl.trim()) {
+      const baseUrls = getBaseUrls();
+      baseUrls[tempProvider] = tempBaseUrl.trim();
+      saveBaseUrls(baseUrls);
+    }
 
     const newLlmConfig: LLMConfig = {
       provider: tempProvider,
@@ -206,6 +239,8 @@ export function useConfig({ mcpServerUrl }: UseConfigProps) {
     tempToken,
     getApiKeys,
     saveApiKeys,
+    getBaseUrls,
+    saveBaseUrls,
   ]);
 
   const clearConfig = useCallback(() => {
@@ -215,6 +250,10 @@ export function useConfig({ mcpServerUrl }: UseConfigProps) {
     const apiKeys = getApiKeys();
     delete apiKeys[tempProvider];
     saveApiKeys(apiKeys);
+    // Clear stored base URL for current provider only
+    const baseUrls = getBaseUrls();
+    delete baseUrls[tempProvider];
+    saveBaseUrls(baseUrls);
     setTempApiKey("");
     setTempBaseUrl("");
     setTempUsername("");
@@ -223,7 +262,7 @@ export function useConfig({ mcpServerUrl }: UseConfigProps) {
     setTempAuthType("none");
     localStorage.removeItem("mcp-inspector-llm-config");
     localStorage.removeItem("mcp-inspector-auth-config");
-  }, [tempProvider, getApiKeys, saveApiKeys]);
+  }, [tempProvider, getApiKeys, saveApiKeys, getBaseUrls, saveBaseUrls]);
 
   return {
     llmConfig,

--- a/libraries/typescript/packages/inspector/src/client/components/chat/useConfig.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/useConfig.ts
@@ -81,9 +81,7 @@ export function useConfig({ mcpServerUrl }: UseConfigProps) {
           // Load API key for the provider from provider-specific storage
           setTempApiKey(apiKeys[config.provider] || config.apiKey || "");
           setTempModel(config.model);
-          setTempBaseUrl(
-            baseUrls[config.provider] ?? config.baseUrl ?? ""
-          );
+          setTempBaseUrl(baseUrls[config.provider] ?? config.baseUrl ?? "");
         } catch (error) {
           console.error("Failed to load LLM config:", error);
         }
@@ -164,7 +162,11 @@ export function useConfig({ mcpServerUrl }: UseConfigProps) {
   }, [tempProvider, getApiKeys, getBaseUrls]);
 
   const saveLLMConfig = useCallback(() => {
-    if (tempProvider === "openai-compatible" ? !tempBaseUrl.trim() : !tempApiKey.trim()) {
+    if (
+      tempProvider === "openai-compatible"
+        ? !tempBaseUrl.trim()
+        : !tempApiKey.trim()
+    ) {
       return;
     }
 

--- a/libraries/typescript/packages/inspector/src/client/components/sampling/useSamplingLLM.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/sampling/useSamplingLLM.ts
@@ -60,6 +60,7 @@ export function useSamplingLLM({ llmConfig }: UseSamplingLLMProps) {
           apiKey: llmConfig.apiKey,
           temperature: temperature ?? llmConfig.temperature,
           maxTokens,
+          baseUrl: llmConfig.baseUrl,
         },
         messages: providerMessages,
       });

--- a/libraries/typescript/packages/inspector/src/client/components/sampling/useSamplingLLM.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/sampling/useSamplingLLM.ts
@@ -1,5 +1,4 @@
 import { chat } from "@/llm/providers";
-import { resolveProvider } from "@/llm/types";
 import type { ProviderMessage } from "@/llm/types";
 import type {
   CreateMessageRequest,
@@ -56,7 +55,7 @@ export function useSamplingLLM({ llmConfig }: UseSamplingLLMProps) {
 
       const { text } = await chat({
         config: {
-            provider: resolveProvider(llmConfig.provider),
+          provider: llmConfig.provider,
           model: llmConfig.model,
           apiKey: llmConfig.apiKey,
           temperature: temperature ?? llmConfig.temperature,

--- a/libraries/typescript/packages/inspector/src/client/components/sampling/useSamplingLLM.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/sampling/useSamplingLLM.ts
@@ -1,4 +1,5 @@
 import { chat } from "@/llm/providers";
+import { resolveProvider } from "@/llm/types";
 import type { ProviderMessage } from "@/llm/types";
 import type {
   CreateMessageRequest,
@@ -55,7 +56,7 @@ export function useSamplingLLM({ llmConfig }: UseSamplingLLMProps) {
 
       const { text } = await chat({
         config: {
-          provider: llmConfig.provider,
+            provider: resolveProvider(llmConfig.provider),
           model: llmConfig.model,
           apiKey: llmConfig.apiKey,
           temperature: temperature ?? llmConfig.temperature,

--- a/libraries/typescript/packages/inspector/src/client/hooks/usePropsLLM.ts
+++ b/libraries/typescript/packages/inspector/src/client/hooks/usePropsLLM.ts
@@ -103,6 +103,7 @@ Example: {"query": "example search term", "results": [{"fruit": "Apple", "color"
             model: llmConfig.model,
             apiKey: llmConfig.apiKey,
             temperature: llmConfig.temperature,
+            baseUrl: llmConfig.baseUrl,
           },
           messages,
         });
@@ -157,6 +158,7 @@ Based on this information, suggest 3-5 common customizable properties like theme
           model: llmConfig.model,
           apiKey: llmConfig.apiKey,
           temperature: llmConfig.temperature,
+          baseUrl: llmConfig.baseUrl,
         },
         messages,
       });

--- a/libraries/typescript/packages/inspector/src/client/hooks/usePropsLLM.ts
+++ b/libraries/typescript/packages/inspector/src/client/hooks/usePropsLLM.ts
@@ -1,5 +1,4 @@
 import { chat } from "@/llm/providers";
-import { resolveProvider } from "@/llm/types";
 import type { ProviderMessage } from "@/llm/types";
 import type { Resource } from "@modelcontextprotocol/sdk/types.js";
 import { useCallback } from "react";
@@ -100,7 +99,7 @@ Example: {"query": "example search term", "results": [{"fruit": "Apple", "color"
         ];
         const { text } = await chat({
           config: {
-            provider: resolveProvider(llmConfig.provider),
+            provider: llmConfig.provider,
             model: llmConfig.model,
             apiKey: llmConfig.apiKey,
             temperature: llmConfig.temperature,
@@ -155,7 +154,7 @@ Based on this information, suggest 3-5 common customizable properties like theme
       ];
       const { text } = await chat({
         config: {
-          provider: resolveProvider(llmConfig.provider),
+          provider: llmConfig.provider,
           model: llmConfig.model,
           apiKey: llmConfig.apiKey,
           temperature: llmConfig.temperature,

--- a/libraries/typescript/packages/inspector/src/client/hooks/usePropsLLM.ts
+++ b/libraries/typescript/packages/inspector/src/client/hooks/usePropsLLM.ts
@@ -1,4 +1,5 @@
 import { chat } from "@/llm/providers";
+import { resolveProvider } from "@/llm/types";
 import type { ProviderMessage } from "@/llm/types";
 import type { Resource } from "@modelcontextprotocol/sdk/types.js";
 import { useCallback } from "react";
@@ -99,7 +100,7 @@ Example: {"query": "example search term", "results": [{"fruit": "Apple", "color"
         ];
         const { text } = await chat({
           config: {
-            provider: llmConfig.provider,
+            provider: resolveProvider(llmConfig.provider),
             model: llmConfig.model,
             apiKey: llmConfig.apiKey,
             temperature: llmConfig.temperature,
@@ -154,7 +155,7 @@ Based on this information, suggest 3-5 common customizable properties like theme
       ];
       const { text } = await chat({
         config: {
-          provider: llmConfig.provider,
+          provider: resolveProvider(llmConfig.provider),
           model: llmConfig.model,
           apiKey: llmConfig.apiKey,
           temperature: llmConfig.temperature,

--- a/libraries/typescript/packages/inspector/src/client/telemetry/events.ts
+++ b/libraries/typescript/packages/inspector/src/client/telemetry/events.ts
@@ -110,7 +110,7 @@ export class MCPServerConnectionEvent implements BaseTelemetryEvent {
 
 export interface MCPChatMessageEventData {
   serverId?: string;
-  provider: "openai" | "anthropic" | "google";
+  provider: "openai" | "openai-compatible" | "anthropic" | "google";
   model: string;
   messageCount: number;
   toolCallsCount?: number;

--- a/libraries/typescript/packages/inspector/src/llm/providers/index.ts
+++ b/libraries/typescript/packages/inspector/src/llm/providers/index.ts
@@ -25,6 +25,7 @@ export function streamChat(
 ): AsyncGenerator<LlmStreamEvent, void, unknown> {
   switch (params.config.provider) {
     case "openai":
+    case "openai-compatible":
       return openai.streamChat(params);
     case "anthropic":
       return anthropic.streamChat(params);
@@ -38,6 +39,7 @@ export function streamChat(
 export function chat(params: ChatParams): Promise<ChatResult> {
   switch (params.config.provider) {
     case "openai":
+    case "openai-compatible":
       return openai.chat(params);
     case "anthropic":
       return anthropic.chat(params);

--- a/libraries/typescript/packages/inspector/src/llm/providers/openai.ts
+++ b/libraries/typescript/packages/inspector/src/llm/providers/openai.ts
@@ -15,7 +15,7 @@ interface ChatParams {
   signal?: AbortSignal;
 }
 
-const DEFAULT_ENDPOINT = "https://api.openai.com/v1/chat/completions";
+const OPENAI_BASE_URL = "https://api.openai.com/v1";
 
 function toOpenAIContent(content: string | ContentPart[]): unknown {
   if (typeof content === "string") return content;
@@ -86,7 +86,8 @@ export async function* streamChat(
     }));
   }
 
-  const res = await fetch(DEFAULT_ENDPOINT, {
+  const endpoint = `${config.baseUrl ?? OPENAI_BASE_URL}/chat/completions`;
+  const res = await fetch(endpoint, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -209,7 +210,8 @@ export async function chat(params: ChatParams): Promise<{
       },
     }));
   }
-  const res = await fetch(DEFAULT_ENDPOINT, {
+  const endpoint = `${config.baseUrl ?? OPENAI_BASE_URL}/chat/completions`;
+  const res = await fetch(endpoint, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/libraries/typescript/packages/inspector/src/llm/providers/openai.ts
+++ b/libraries/typescript/packages/inspector/src/llm/providers/openai.ts
@@ -17,6 +17,21 @@ interface ChatParams {
 
 const OPENAI_BASE_URL = "https://api.openai.com/v1";
 
+function buildEndpoint(config: ProviderConfig, path: string): string {
+  const base = (config.baseUrl ?? OPENAI_BASE_URL).replace(/\/+$/, "");
+  return `${base}${path}`;
+}
+
+function buildHeaders(config: ProviderConfig): Record<string, string> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (config.apiKey) {
+    headers.Authorization = `Bearer ${config.apiKey}`;
+  }
+  return headers;
+}
+
 function toOpenAIContent(content: string | ContentPart[]): unknown {
   if (typeof content === "string") return content;
   return content.map((p) => {
@@ -86,13 +101,10 @@ export async function* streamChat(
     }));
   }
 
-  const endpoint = `${config.baseUrl ?? OPENAI_BASE_URL}/chat/completions`;
+  const endpoint = buildEndpoint(config, "/chat/completions");
   const res = await fetch(endpoint, {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${config.apiKey}`,
-    },
+    headers: buildHeaders(config),
     body: JSON.stringify(body),
     signal,
   });
@@ -210,13 +222,10 @@ export async function chat(params: ChatParams): Promise<{
       },
     }));
   }
-  const endpoint = `${config.baseUrl ?? OPENAI_BASE_URL}/chat/completions`;
+  const endpoint = buildEndpoint(config, "/chat/completions");
   const res = await fetch(endpoint, {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${config.apiKey}`,
-    },
+    headers: buildHeaders(config),
     body: JSON.stringify(body),
     signal,
   });

--- a/libraries/typescript/packages/inspector/src/llm/types.ts
+++ b/libraries/typescript/packages/inspector/src/llm/types.ts
@@ -16,6 +16,7 @@ export interface ProviderConfig {
   apiKey: string;
   temperature?: number;
   maxTokens?: number;
+  baseUrl?: string;
 }
 
 export interface ImageContentPart {

--- a/libraries/typescript/packages/inspector/src/llm/types.ts
+++ b/libraries/typescript/packages/inspector/src/llm/types.ts
@@ -8,13 +8,11 @@
  * langchain to bundle their apps.
  */
 
-export type ProviderName = "openai" | "anthropic" | "google";
-
-/** Maps UI-level provider names (including aliases like "openai-compatible") to the underlying LLM provider. */
-export function resolveProvider(provider: string): ProviderName {
-  if (provider === "openai-compatible") return "openai";
-  return provider as ProviderName;
-}
+export type ProviderName =
+  | "openai"
+  | "openai-compatible"
+  | "anthropic"
+  | "google";
 
 export interface ProviderConfig {
   provider: ProviderName;

--- a/libraries/typescript/packages/inspector/src/llm/types.ts
+++ b/libraries/typescript/packages/inspector/src/llm/types.ts
@@ -10,6 +10,12 @@
 
 export type ProviderName = "openai" | "anthropic" | "google";
 
+/** Maps UI-level provider names (including aliases like "openai-compatible") to the underlying LLM provider. */
+export function resolveProvider(provider: string): ProviderName {
+  if (provider === "openai-compatible") return "openai";
+  return provider as ProviderName;
+}
+
 export interface ProviderConfig {
   provider: ProviderName;
   model: string;

--- a/libraries/typescript/packages/inspector/src/server/shared-utils.ts
+++ b/libraries/typescript/packages/inspector/src/server/shared-utils.ts
@@ -12,6 +12,7 @@ interface LLMConfig {
   model: string;
   apiKey: string;
   temperature?: number;
+  baseUrl?: string;
 }
 
 interface OAuthTokens {
@@ -182,6 +183,7 @@ export async function* handleChatRequestStream(requestBody: {
         model: llmConfig.model,
         apiKey: llmConfig.apiKey,
         temperature: llmConfig.temperature,
+        baseUrl: llmConfig.baseUrl,
       },
       messages: providerMessages,
       tools,
@@ -342,6 +344,7 @@ export async function handleChatRequest(requestBody: {
         model: llmConfig.model,
         apiKey: llmConfig.apiKey,
         temperature: llmConfig.temperature,
+        baseUrl: llmConfig.baseUrl,
       },
       messages: providerMessages,
       tools,

--- a/libraries/typescript/packages/inspector/src/server/shared-utils.ts
+++ b/libraries/typescript/packages/inspector/src/server/shared-utils.ts
@@ -5,10 +5,11 @@
 
 import { convertMessagesToProvider } from "../llm/messageFormat";
 import { runToolLoop, runToolLoopNonStreaming } from "../llm/toolLoop";
+import { resolveProvider } from "../llm/types";
 import type { ProviderMessage, ProviderTool } from "../llm/types";
 
 interface LLMConfig {
-  provider: "openai" | "anthropic" | "google";
+  provider: "openai" | "openai-compatible" | "anthropic" | "google";
   model: string;
   apiKey: string;
   temperature?: number;
@@ -179,7 +180,7 @@ export async function* handleChatRequestStream(requestBody: {
 
     for await (const ev of runToolLoop({
       config: {
-        provider: llmConfig.provider,
+        provider: resolveProvider(llmConfig.provider),
         model: llmConfig.model,
         apiKey: llmConfig.apiKey,
         temperature: llmConfig.temperature,
@@ -340,7 +341,7 @@ export async function handleChatRequest(requestBody: {
 
     const { content, toolCalls } = await runToolLoopNonStreaming({
       config: {
-        provider: llmConfig.provider,
+        provider: resolveProvider(llmConfig.provider),
         model: llmConfig.model,
         apiKey: llmConfig.apiKey,
         temperature: llmConfig.temperature,

--- a/libraries/typescript/packages/inspector/src/server/shared-utils.ts
+++ b/libraries/typescript/packages/inspector/src/server/shared-utils.ts
@@ -5,7 +5,6 @@
 
 import { convertMessagesToProvider } from "../llm/messageFormat";
 import { runToolLoop, runToolLoopNonStreaming } from "../llm/toolLoop";
-import { resolveProvider } from "../llm/types";
 import type { ProviderMessage, ProviderTool } from "../llm/types";
 
 interface LLMConfig {
@@ -180,7 +179,7 @@ export async function* handleChatRequestStream(requestBody: {
 
     for await (const ev of runToolLoop({
       config: {
-        provider: resolveProvider(llmConfig.provider),
+        provider: llmConfig.provider,
         model: llmConfig.model,
         apiKey: llmConfig.apiKey,
         temperature: llmConfig.temperature,
@@ -341,7 +340,7 @@ export async function handleChatRequest(requestBody: {
 
     const { content, toolCalls } = await runToolLoopNonStreaming({
       config: {
-        provider: resolveProvider(llmConfig.provider),
+        provider: llmConfig.provider,
         model: llmConfig.model,
         apiKey: llmConfig.apiKey,
         temperature: llmConfig.temperature,


### PR DESCRIPTION
## Language / Project Scope

- [x] TypeScript

## Changes

Adds a **Base URL** field to the inspector's LLM configuration dialog, allowing OpenAI-compatible providers (LM Studio, OpenRouter, Ollama, etc.) to be used by pointing the inspector at a custom API endpoint.

## Implementation Details

1. Added `baseUrl?: string` to `ProviderConfig` (`llm/types.ts`) and `LLMConfig` (`chat/types.ts`)
2. Replaced hardcoded `DEFAULT_ENDPOINT` in `openai.ts` with `OPENAI_BASE_URL = "https://api.openai.com/v1"`; endpoint is now built as `` `${config.baseUrl ?? OPENAI_BASE_URL}/chat/completions` `` — callers supply a full base URL including `/v1`, no double-path segment
3. Forwarded `baseUrl` from `LLMConfig` → `ProviderConfig` at all four call sites: `useChatMessagesClientSide`, `usePropsLLM` (×2), `useSamplingLLM`, and server-side `shared-utils`
4. Added `tempBaseUrl`/`setTempBaseUrl` state in `useConfig`; restored from localStorage on load; only saved when `tempProvider === "openai"` to avoid polluting Anthropic/Google configs
5. Added Base URL `<Input>` in `ConfigurationDialog` (visible only for OpenAI provider); `fetchOpenAIModels` accepts a custom base URL; model list cache key namespaced by base URL
6. Wired `tempBaseUrl`/`onBaseUrlChange` through `ChatTab` → `ChatHeader` → `ConfigurationDialog` (both the header dialog and the landing-form dialog)

---

## TypeScript Checklist

### Packages Modified

- [x] `inspector`

### Pre-commit Checklist

- [x] Ran `pnpm lint:fix` to auto-fix linting issues
- [x] Ran `pnpm format` to format code with Prettier
- [x] Ran `pnpm build` and build succeeds without errors
- [x] Ran `pnpm changeset` to create a changeset (if this PR includes user-facing changes)
- [ ] Added or updated tests if needed
- [ ] Updated documentation in `docs/` folder if needed

---

## Example Usage (Before)

```ts
// OpenAI provider was hardcoded to api.openai.com — no way to point
// the inspector at LM Studio, OpenRouter, or any other compatible endpoint
```

## Example Usage (After)

1. Open the inspector chat config dialog
2. Select "OpenAI" as provider
3. Enter your API key
4. Set Base URL to e.g. http://localhost:1234/v1 (LM Studio)
   or https://openrouter.ai/api/v1 (OpenRouter)
5. Leave blank to use the default OpenAI endpoint


## Testing
- Manual testing: verified Base URL field appears for OpenAI, hidden for Anthropic/Google
- Verified value persists to localStorage and restores correctly on page reload
- Verified models are fetched from the custom endpoint (/models appended, no double /v1)
- Verified switching provider away and back does not wipe the saved base URL
- Verified saving with Anthropic/Google selected does not persist `baseUrl` into those configs

## Backwards Compatibility
- Fully backwards compatible. `baseUrl` is optional throughout — leaving it blank uses the default https://api.openai.com/v1 endpoint, identical to previous behavior.

## Related Issues
- Closes #1435