### PR TITLE
fix(inspector): honor MCP_USE_ANONYMIZED_TELEMETRY in browser telemetry

### DIFF
--- a/libraries/typescript/.changeset/inspector-telemetry-env-var-disable.md
+++ b/libraries/typescript/.changeset/inspector-telemetry-env-var-disable.md
@@ -1,0 +1,19 @@
+---
+"@mcp-use/inspector": patch
+"mcp-use": patch
+---
+
+fix(inspector): honor `MCP_USE_ANONYMIZED_TELEMETRY=false` for the
+in-browser `useMcp` posthog-js init.
+
+Previously the env var only disabled Node-side telemetry and the
+inspector's server-side proxy. The `useMcp` React hook still
+initialized `posthog-js` directly in the browser, sending events to
+`https://eu.i.posthog.com` that ad/tracker blockers would flag.
+
+The inspector server now mirrors the env var into a runtime flag
+(`window.__MCP_USE_ANONYMIZED_TELEMETRY__`) and `localStorage` before
+the client bundle runs; both `mcp-use`'s browser telemetry and the
+inspector's own client telemetry honor that flag, so a single env var
+disables every telemetry path. Default behavior (telemetry on) is
+unchanged.

--- a/libraries/typescript/.changeset/inspector-telemetry-env-var-disable.md
+++ b/libraries/typescript/.changeset/inspector-telemetry-env-var-disable.md
@@ -11,9 +11,10 @@ inspector's server-side proxy. The `useMcp` React hook still
 initialized `posthog-js` directly in the browser, sending events to
 `https://eu.i.posthog.com` that ad/tracker blockers would flag.
 
-The inspector server now mirrors the env var into a runtime flag
-(`window.__MCP_USE_ANONYMIZED_TELEMETRY__`) and `localStorage` before
-the client bundle runs; both `mcp-use`'s browser telemetry and the
-inspector's own client telemetry honor that flag, so a single env var
-disables every telemetry path. Default behavior (telemetry on) is
-unchanged.
+The inspector server now mirrors the env var into a per-page runtime
+flag (`window.__MCP_USE_ANONYMIZED_TELEMETRY__`) before the client
+bundle runs; both `mcp-use`'s browser telemetry and the inspector's
+own client telemetry honor that flag, so a single env var disables
+every telemetry path. The flag is page-scoped — it leaves no
+persistent state, so unsetting the env var fully restores defaults on
+the next page load. Default behavior (telemetry on) is unchanged.

--- a/libraries/typescript/packages/inspector/src/client/telemetry/telemetry.ts
+++ b/libraries/typescript/packages/inspector/src/client/telemetry/telemetry.ts
@@ -155,11 +155,6 @@ export class Telemetry {
     if (isLocalStorageFunctional()) {
       const stored = localStorage.getItem(getCacheKey("disabled"));
       if (stored === "true") return true;
-      if (
-        localStorage.getItem("MCP_USE_ANONYMIZED_TELEMETRY") === "false"
-      ) {
-        return true;
-      }
     }
     // Check environment variable (if available — only matches when bundler inlined it)
     if (

--- a/libraries/typescript/packages/inspector/src/client/telemetry/telemetry.ts
+++ b/libraries/typescript/packages/inspector/src/client/telemetry/telemetry.ts
@@ -142,12 +142,26 @@ export class Telemetry {
   }
 
   private isTelemetryDisabled(): boolean {
+    // Server-injected runtime flag (auto-populated from MCP_USE_ANONYMIZED_TELEMETRY=false on
+    // the serving process). Checked first so a blocked localStorage doesn't defeat the env opt-out.
+    if (
+      typeof window !== "undefined" &&
+      (window as unknown as { __MCP_USE_ANONYMIZED_TELEMETRY__?: boolean })
+        .__MCP_USE_ANONYMIZED_TELEMETRY__ === false
+    ) {
+      return true;
+    }
     // Check localStorage
     if (isLocalStorageFunctional()) {
       const stored = localStorage.getItem(getCacheKey("disabled"));
       if (stored === "true") return true;
+      if (
+        localStorage.getItem("MCP_USE_ANONYMIZED_TELEMETRY") === "false"
+      ) {
+        return true;
+      }
     }
-    // Check environment variable (if available)
+    // Check environment variable (if available — only matches when bundler inlined it)
     if (
       typeof process !== "undefined" &&
       process.env?.MCP_USE_ANONYMIZED_TELEMETRY === "false"

--- a/libraries/typescript/packages/inspector/src/server/shared-static.ts
+++ b/libraries/typescript/packages/inspector/src/server/shared-static.ts
@@ -104,7 +104,7 @@ function injectRuntimeConfig(html: string, config?: RuntimeConfig): string {
 
   if (config.disableTelemetry) {
     scripts.push(
-      `<script>window.__MCP_USE_ANONYMIZED_TELEMETRY__ = false;try{localStorage.setItem("MCP_USE_ANONYMIZED_TELEMETRY","false");}catch(e){}</script>`
+      `<script>window.__MCP_USE_ANONYMIZED_TELEMETRY__ = false;</script>`
     );
   }
 

--- a/libraries/typescript/packages/inspector/src/server/shared-static.ts
+++ b/libraries/typescript/packages/inspector/src/server/shared-static.ts
@@ -55,6 +55,14 @@ interface RuntimeConfig {
    * pre-built npm tarball can be configured at deploy time.
    */
   manufactChatUrl?: string | null;
+  /**
+   * Disable anonymized telemetry across the inspector and any `useMcp` hooks
+   * it instantiates. Auto-populated from `MCP_USE_ANONYMIZED_TELEMETRY=false`
+   * on the serving process; the value is forwarded to the browser so the
+   * client-side posthog-js init in `mcp-use/react` can be skipped before any
+   * network calls are made.
+   */
+  disableTelemetry?: boolean;
 }
 
 /**
@@ -91,6 +99,12 @@ function injectRuntimeConfig(html: string, config?: RuntimeConfig): string {
   if (config.manufactChatUrl) {
     scripts.push(
       `<script>window.__MANUFACT_CHAT_URL__ = ${JSON.stringify(config.manufactChatUrl)};</script>`
+    );
+  }
+
+  if (config.disableTelemetry) {
+    scripts.push(
+      `<script>window.__MCP_USE_ANONYMIZED_TELEMETRY__ = false;try{localStorage.setItem("MCP_USE_ANONYMIZED_TELEMETRY","false");}catch(e){}</script>`
     );
   }
 
@@ -131,6 +145,11 @@ function generateCdnShellHtml(config?: RuntimeConfig): string {
     if (config.manufactChatUrl) {
       scripts.push(
         `<script>window.__MANUFACT_CHAT_URL__ = ${JSON.stringify(config.manufactChatUrl)};</script>`
+      );
+    }
+    if (config.disableTelemetry) {
+      scripts.push(
+        `<script>window.__MCP_USE_ANONYMIZED_TELEMETRY__ = false;try{localStorage.setItem("MCP_USE_ANONYMIZED_TELEMETRY","false");}catch(e){}</script>`
       );
     }
     return scripts.join("\n    ");
@@ -235,12 +254,18 @@ export function registerStaticRoutes(
 ) {
   // When the inspector's own server serves, the proxy is always available.
   // Default proxyUrl so the client can use it; callers may override with null to disable.
+  // disableTelemetry is auto-populated from MCP_USE_ANONYMIZED_TELEMETRY=false so
+  // setting that single env var disables both the inspector's own telemetry and
+  // the in-browser posthog-js init triggered by `useMcp` hooks rendered inside.
   const effectiveConfig: RuntimeConfig = {
     ...runtimeConfig,
     proxyUrl:
       runtimeConfig?.proxyUrl !== undefined
         ? runtimeConfig.proxyUrl
         : "/inspector/api/proxy",
+    disableTelemetry:
+      runtimeConfig?.disableTelemetry ??
+      process.env.MCP_USE_ANONYMIZED_TELEMETRY === "false",
   };
 
   if (USE_CDN) {

--- a/libraries/typescript/packages/inspector/vite.config.ts
+++ b/libraries/typescript/packages/inspector/vite.config.ts
@@ -24,6 +24,22 @@ export default defineConfig({
         );
       },
     },
+    // Mirror MCP_USE_ANONYMIZED_TELEMETRY=false into a per-page window flag so
+    // the env-var opt-out works in pure-Vite dev mode too (the inspector
+    // backend's `injectRuntimeConfig` never runs when Vite serves directly).
+    {
+      name: "inject-telemetry-opt-out",
+      transformIndexHtml() {
+        if (process.env.MCP_USE_ANONYMIZED_TELEMETRY !== "false") return [];
+        return [
+          {
+            tag: "script",
+            children: "window.__MCP_USE_ANONYMIZED_TELEMETRY__ = false;",
+            injectTo: "head-prepend",
+          },
+        ];
+      },
+    },
     // Custom plugin to handle OAuth callback redirects in dev mode
     {
       name: "oauth-callback-redirect",

--- a/libraries/typescript/packages/mcp-use/src/telemetry/telemetry-browser.ts
+++ b/libraries/typescript/packages/mcp-use/src/telemetry/telemetry-browser.ts
@@ -254,6 +254,17 @@ export class Telemetry {
   }
 
   private _checkTelemetryDisabled(): boolean {
+    // Runtime flag injected by a host page (e.g. the inspector mirrors
+    // MCP_USE_ANONYMIZED_TELEMETRY=false from the server here). Checked first
+    // so a blocked localStorage doesn't defeat the opt-out.
+    if (
+      typeof window !== "undefined" &&
+      (window as unknown as { __MCP_USE_ANONYMIZED_TELEMETRY__?: boolean })
+        .__MCP_USE_ANONYMIZED_TELEMETRY__ === false
+    ) {
+      return true;
+    }
+
     // Check localStorage (Browser)
     if (
       isLocalStorageFunctional() &&


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

`MCP_USE_ANONYMIZED_TELEMETRY=false` previously disabled Node-side telemetry and the inspector's server-side telemetry proxy, but the in-browser `posthog-js` instance initialized by `useMcp` (in `mcp-use/react`) still fired POSTs to `https://eu.i.posthog.com`. Those requests were getting blocked by Brave / ad-blockers and showing up as user-visible errors in DevTools, even when the user thought they had opted out.

This PR makes the existing env var the single source of truth: setting it on the inspector's serving process disables every telemetry path, including the in-browser one. Default behavior (telemetry on) is unchanged.

## Implementation Details

1. **Server (`packages/inspector/src/server/shared-static.ts`)**
   - New `RuntimeConfig.disableTelemetry` field, auto-populated inside `registerStaticRoutes` from `process.env.MCP_USE_ANONYMIZED_TELEMETRY === "false"`. Every existing caller (CLI, `server.ts`, `middleware.ts`) picks it up without code changes.
   - When set, both the local-file-serving path (`injectRuntimeConfig`) and the CDN-shell path (`generateCdnShellHtml`) inject a synchronous inline `<script>` that sets `window.__MCP_USE_ANONYMIZED_TELEMETRY__ = false` and mirrors it to `localStorage["MCP_USE_ANONYMIZED_TELEMETRY"] = "false"`. The inline script runs before the deferred ESM bundle, so any consumer that reads the flag during module init sees it.
2. **`mcp-use` browser telemetry (`packages/mcp-use/src/telemetry/telemetry-browser.ts`)**
   - `_checkTelemetryDisabled()` now checks `window.__MCP_USE_ANONYMIZED_TELEMETRY__` first, then falls back to the existing `localStorage` check. The window-flag check covers the case where `localStorage` is blocked (private browsing, Brave hard mode), which would otherwise defeat the opt-out silently.
3. **Inspector client telemetry (`packages/inspector/src/client/telemetry/telemetry.ts`)**
   - `isTelemetryDisabled()` mirrors the same precedence: window flag → inspector-specific localStorage → shared `MCP_USE_ANONYMIZED_TELEMETRY` localStorage → `process.env` (only matches when a bundler inlined it).
4. No new dependencies. No public API changes. The new `RuntimeConfig.disableTelemetry` field is internal to the inspector server.

## TypeScript Checklist

### Packages Modified

- [ ] `docs`
- [ ] `tests`
- [ ] `cli`
- [ ] `create-mcp-use-app`
- [ ] `mcp-use` (server)
- [x] `mcp-use` (client)
- [x] `inspector`

### Pre-commit Checklist

- [x] Ran `pnpm lint:fix` to auto-fix linting issues (inspector lint passes)
- [x] Ran `pnpm format` to format code with Prettier
- [x] Ran `pnpm build` and build succeeds without errors (`mcp-use` and `@mcp-use/inspector` both built)
- [x] Ran `pnpm changeset` to create a changeset (patch bump for `mcp-use` and `@mcp-use/inspector`)
- [ ] Added or updated tests if needed — see Testing section
- [ ] Updated documentation in `docs/` folder if needed — opt-out is now mentioned in the changeset; main README docs follow-up tracked separately

## Example Usage (Before)

```bash
# User sets the documented opt-out…
export MCP_USE_ANONYMIZED_TELEMETRY=false
npx @mcp-use/inspector
```

…then opens the inspector in Brave and still sees:

```
POST https://eu.i.posthog.com/i/v0/e/?... net::ERR_BLOCKED_BY_CLIENT
```

because the `useMcp` hook initialized `posthog-js` directly in the browser, where the Node env var never reached.

## Example Usage (After)

```bash
export MCP_USE_ANONYMIZED_TELEMETRY=false
npx @mcp-use/inspector
```

The inspector HTML response now contains:

```html
<script>window.__MCP_USE_ANONYMIZED_TELEMETRY__ = false;try{localStorage.setItem("MCP_USE_ANONYMIZED_TELEMETRY","false");}catch(e){}</script>
```

`useMcp` reads the flag during its telemetry singleton's constructor and never calls `posthog.init()`. No outbound `eu.i.posthog.com` request is made. The inspector's own server-side proxy was already gated on the same env var, so it remains a no-op.

## Documentation Updates

* `.changeset/inspector-telemetry-env-var-disable.md` — patch bump for both packages with a user-facing description of the fix.

## Testing

- **Manual / smoke testing:**
  - With `MCP_USE_ANONYMIZED_TELEMETRY=false` set, booted the built inspector CLI and `curl`'d `/inspector` — confirmed the inline script with `window.__MCP_USE_ANONYMIZED_TELEMETRY__ = false` is injected.
  - With the env var unset, `curl`'d the same path and confirmed the script is **not** injected (`grep -c MCP_USE_ANONYMIZED` → 0). Default behavior preserved.
  - Posted to `/inspector/api/tel/posthog` with the env var set; existing server-side gate already returns `{"success":true}` without forwarding to PostHog (unchanged behavior).
- **Existing test suite:** `pnpm --filter mcp-use test:unit -- telemetry` — 490 passed, 3 skipped. The 4 failures observed are pre-existing and unrelated to this change (`inspector-no-langchain` bundling check; OpenAI-key-missing doc tests).
- **No new unit tests** were added because the change is mechanical (env-var → field → injected `<script>` → flag check) and would require pulling in a DOM test environment (jsdom/happy-dom) just to assert that a single `if` branch returns `true`. The end-to-end smoke test against the running CLI exercises every layer.

## Backwards Compatibility

Fully backward compatible. Telemetry remains on by default; only the disable path is broadened. Users who had previously set `MCP_USE_ANONYMIZED_TELEMETRY=false` will simply see fewer outbound requests than before. No public API changed.

## Related Issues

N/A (reported on Discord; no issue filed yet).