### PR TITLE
refactor(auth): extract OAuthSessionStore from BrowserOAuthClientProvider

### DIFF
--- a/libraries/typescript/.changeset/oauth-session-store-extract.md
+++ b/libraries/typescript/.changeset/oauth-session-store-extract.md
@@ -1,0 +1,13 @@
+---
+"mcp-use": patch
+---
+
+refactor(auth): extract `OAuthSessionStore` helper from `BrowserOAuthClientProvider`
+
+Pulls token storage, JWT-expiry-driven refresh (with deduplication),
+client-info validation, code-verifier handling, key hashing, and generic
+authorization-state persistence into a new platform-neutral
+`OAuthSessionStore` helper parameterized over a `KVStore`. The browser
+provider now holds an `OAuthSessionStore` and delegates the SDK
+`OAuthClientProvider` interface methods to it. No behavior change —
+this prepares the ground for a future Node/CLI OAuth provider.

--- a/libraries/typescript/packages/mcp-use/src/auth/browser-provider.ts
+++ b/libraries/typescript/packages/mcp-use/src/auth/browser-provider.ts
@@ -1,19 +1,14 @@
 // browser-provider.ts
 import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
-import {
-  discoverOAuthProtectedResourceMetadata,
-  discoverAuthorizationServerMetadata,
-  refreshAuthorization,
-} from "@modelcontextprotocol/sdk/client/auth.js";
 import type {
   OAuthClientInformation,
   OAuthClientMetadata,
   OAuthTokens,
 } from "@modelcontextprotocol/sdk/shared/auth.js";
-import type { AuthorizationServerMetadata } from "@modelcontextprotocol/sdk/shared/auth.js";
 import { sanitizeUrl } from "../utils/url-sanitize.js";
-// Assuming StoredState is defined in ./types.js and includes fields for provider options
-import type { StoredState } from "./types.js"; // Adjust path if necessary
+import { LocalStorageKVStore } from "./kv-store.js";
+import { OAuthSessionStore } from "./oauth-session-store.js";
+import type { StoredState } from "./types.js";
 
 /**
  * Serialize request body for proxying
@@ -27,29 +22,48 @@ async function serializeBody(body: BodyInit): Promise<any> {
   return body;
 }
 
+export interface BrowserOAuthOptions {
+  storageKeyPrefix?: string;
+  clientName?: string;
+  clientUri?: string;
+  logoUri?: string;
+  callbackUrl?: string;
+  preventAutoAuth?: boolean;
+  useRedirectFlow?: boolean;
+  oauthProxyUrl?: string;
+  /** MCP proxy URL that client connected to (for resource field rewriting) */
+  connectionUrl?: string;
+  /**
+   * Pre-registered OAuth client information. When set, the SDK skips
+   * Dynamic Client Registration and uses this client_id directly.
+   * Required for proxy-mode auth servers (e.g. Slack, WorkOS proxy)
+   * that strip `registration_endpoint` from metadata.
+   */
+  staticClientInfo?: OAuthClientInformation;
+  /** OAuth scope string forwarded to the SDK via clientMetadata.scope. */
+  scope?: string;
+  onPopupWindow?: (
+    url: string,
+    features: string,
+    window: globalThis.Window | null
+  ) => void;
+}
+
 /**
  * Browser-compatible OAuth client provider for MCP using localStorage.
  */
 export class BrowserOAuthClientProvider implements OAuthClientProvider {
   readonly serverUrl: string;
-  readonly storageKeyPrefix: string;
-  readonly serverUrlHash: string;
-  readonly clientName: string;
-  readonly clientUri: string;
-  readonly logoUri: string;
-  readonly callbackUrl: string;
-  readonly scope?: string;
   readonly staticClientInfo?: OAuthClientInformation;
+  private session: OAuthSessionStore;
+
+  // Browser-only state
   private preventAutoAuth?: boolean;
   private useRedirectFlow?: boolean;
   private oauthProxyUrl?: string;
-  private connectionUrl?: string; // MCP proxy URL that client connected to
+  private connectionUrl?: string;
   private originalFetch?: typeof fetch;
-  private pendingCodeVerifier: string | null = null;
   private _lastOriginalResource: string | null = null;
-  private _cachedAuthServerUrl: string | null = null;
-  private _cachedMetadata: AuthorizationServerMetadata | null = null;
-  private _refreshPromise: Promise<OAuthTokens | null> | null = null;
   readonly onPopupWindow:
     | ((
         url: string,
@@ -58,55 +72,53 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
       ) => void)
     | undefined;
 
-  constructor(
-    serverUrl: string,
-    options: {
-      storageKeyPrefix?: string;
-      clientName?: string;
-      clientUri?: string;
-      logoUri?: string;
-      callbackUrl?: string;
-      preventAutoAuth?: boolean;
-      useRedirectFlow?: boolean;
-      oauthProxyUrl?: string;
-      connectionUrl?: string; // MCP proxy URL that client connected to (for resource field rewriting)
-      /**
-       * Pre-registered OAuth client information. When set, the SDK skips
-       * Dynamic Client Registration and uses this client_id directly.
-       * Required for proxy-mode auth servers (e.g. Slack, WorkOS proxy)
-       * that strip `registration_endpoint` from metadata.
-       */
-      staticClientInfo?: OAuthClientInformation;
-      /** OAuth scope string forwarded to the SDK via clientMetadata.scope. */
-      scope?: string;
-      onPopupWindow?: (
-        url: string,
-        features: string,
-        window: globalThis.Window | null
-      ) => void;
-    } = {}
-  ) {
+  constructor(serverUrl: string, options: BrowserOAuthOptions = {}) {
     this.serverUrl = serverUrl;
-    this.storageKeyPrefix = options.storageKeyPrefix || "mcp:auth";
-    this.serverUrlHash = this.hashString(serverUrl);
-    this.clientName = options.clientName || "mcp-use";
-    this.clientUri =
-      options.clientUri ||
-      (typeof window !== "undefined" ? window.location.origin : "");
-    this.logoUri = options.logoUri || "https://mcp-use.com/logo.png";
-    this.callbackUrl = sanitizeUrl(
-      options.callbackUrl ||
-        (typeof window !== "undefined"
-          ? new URL("/oauth/callback", window.location.origin).toString()
-          : "/oauth/callback")
+    this.session = new OAuthSessionStore(
+      serverUrl,
+      options,
+      new LocalStorageKVStore()
     );
     this.preventAutoAuth = options.preventAutoAuth;
     this.useRedirectFlow = options.useRedirectFlow;
     this.oauthProxyUrl = options.oauthProxyUrl;
     this.connectionUrl = options.connectionUrl;
     this.staticClientInfo = options.staticClientInfo;
-    this.scope = options.scope;
     this.onPopupWindow = options.onPopupWindow;
+  }
+
+  // --- Identity / key fields exposed for callback handling ---
+
+  get storageKeyPrefix(): string {
+    return this.session.storageKeyPrefix;
+  }
+
+  get serverUrlHash(): string {
+    return this.session.serverUrlHash;
+  }
+
+  get clientName(): string {
+    return this.session.clientName;
+  }
+
+  get clientUri(): string {
+    return this.session.clientUri;
+  }
+
+  get logoUri(): string {
+    return this.session.logoUri;
+  }
+
+  get callbackUrl(): string {
+    return this.session.callbackUrl;
+  }
+
+  get scope(): string | undefined {
+    return this.session.scope;
+  }
+
+  getKey(keySuffix: string): string {
+    return this.session.getKey(keySuffix);
   }
 
   /**
@@ -277,23 +289,22 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
     }
   }
 
-  // --- SDK Interface Methods ---
+  // --- SDK Interface Methods (delegated) ---
 
   get redirectUrl(): string {
-    return sanitizeUrl(this.callbackUrl);
+    return this.session.redirectUrl;
   }
 
   get clientMetadata(): OAuthClientMetadata {
-    return {
-      redirect_uris: [this.redirectUrl],
-      token_endpoint_auth_method: "none", // Public client
-      grant_types: ["authorization_code", "refresh_token"],
-      response_types: ["code"],
-      client_name: this.clientName,
-      client_uri: this.clientUri,
-      logo_uri: this.logoUri,
-      ...(this.scope ? { scope: this.scope } : {}),
-    };
+    return this.session.clientMetadata;
+  }
+
+  tokens(): Promise<OAuthTokens | undefined> {
+    return this.session.tokens();
+  }
+
+  saveTokens(tokens: OAuthTokens): Promise<void> {
+    return this.session.saveTokens(tokens);
   }
 
   async clientInformation(): Promise<OAuthClientInformation | undefined> {
@@ -302,280 +313,63 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
     // bypasses any stored DCR result so a stale localStorage entry can't
     // shadow the configured client_id.
     if (this.staticClientInfo) return this.staticClientInfo;
-    const key = this.getKey("client_info");
-    const data = localStorage.getItem(key);
-    if (!data) return undefined;
-    try {
-      // TODO: Add validation using a schema
-      const clientInfo = JSON.parse(data) as OAuthClientInformation & {
-        redirect_uris?: string[];
-      };
-      const storedRedirectUris = Array.isArray(clientInfo.redirect_uris)
-        ? clientInfo.redirect_uris
-        : [];
-      // length === 0 means the server didn't include redirect_uris in the
-      // registration response — skip the check rather than invalidating valid creds.
-      const hasMatchingRedirect =
-        storedRedirectUris.length === 0 ||
-        storedRedirectUris.includes(this.redirectUrl);
-
-      if (!hasMatchingRedirect) {
-        console.info(
-          `[${this.storageKeyPrefix}] Invalidating cached OAuth client info due to redirect URI mismatch.`
-        );
-        localStorage.removeItem(key);
-        localStorage.removeItem(this.getKey("tokens"));
-        localStorage.removeItem(this.getKey("last_auth_url"));
-        return undefined;
-      }
-
-      return clientInfo;
-    } catch (e) {
-      console.warn(
-        `[${this.storageKeyPrefix}] Failed to parse client information:`,
-        e
-      );
-      localStorage.removeItem(key);
-      return undefined;
-    }
+    return this.session.clientInformation();
   }
 
-  // NOTE: The SDK's auth() function uses this if dynamic registration is needed.
-  // Ensure your OAuthClientInformationFull matches the expected structure if DCR is used.
   async saveClientInformation(
-    clientInformation: OAuthClientInformation /* | OAuthClientInformationFull */
+    clientInformation: OAuthClientInformation
   ): Promise<void> {
     // When a pre-registered client_id is configured, never persist DCR results
     // — the static client_id is the source of truth.
     if (this.staticClientInfo) return;
-    const key = this.getKey("client_info");
-    // Cast needed if handling OAuthClientInformationFull specifically
-    localStorage.setItem(key, JSON.stringify(clientInformation));
+    return this.session.saveClientInformation(clientInformation);
   }
 
-  async tokens(): Promise<OAuthTokens | undefined> {
-    const key = this.getKey("tokens");
-    const data = localStorage.getItem(key);
-    if (!data) return undefined;
-    try {
-      const tokens = JSON.parse(data) as OAuthTokens;
-      if (tokens.access_token && tokens.refresh_token) {
-        try {
-          const payload = JSON.parse(atob(tokens.access_token.split(".")[1]));
-          if (payload.exp && Date.now() >= (payload.exp - 30) * 1000) {
-            console.log("[tokens] Access token expiring soon, refreshing...");
-            const refreshed = await this._dedupedRefresh(tokens);
-            if (refreshed) {
-              console.log("[tokens] Refreshed successfully");
-              return refreshed;
-            }
-          }
-        } catch {
-          // Can't decode JWT, return as-is
-        }
-      }
-      return tokens;
-    } catch (e) {
-      console.warn(`[${this.storageKeyPrefix}] Failed to parse tokens:`, e);
-      localStorage.removeItem(key);
-      return undefined;
-    }
+  codeVerifier(): Promise<string> {
+    return this.session.codeVerifier();
   }
 
-  async saveTokens(tokens: OAuthTokens): Promise<void> {
-    const key = this.getKey("tokens");
-    localStorage.setItem(key, JSON.stringify(tokens));
-    // Clean up code verifier and last auth URL after successful token save
-    localStorage.removeItem(this.getKey("code_verifier"));
-    localStorage.removeItem(this.getKey("last_auth_url"));
-    this.pendingCodeVerifier = null;
+  saveCodeVerifier(codeVerifier: string): Promise<void> {
+    return this.session.saveCodeVerifier(codeVerifier);
   }
 
-  private async _refresh(tokens: OAuthTokens): Promise<OAuthTokens | null> {
-    try {
-      if (!this._cachedAuthServerUrl || !this._cachedMetadata) {
-        const resourceMetadata = await discoverOAuthProtectedResourceMetadata(
-          this.serverUrl
-        );
-        const authServerUrl = resourceMetadata.authorization_servers?.[0];
-        if (!authServerUrl) return null;
-        const metadata =
-          await discoverAuthorizationServerMetadata(authServerUrl);
-        if (!metadata) return null;
-        this._cachedAuthServerUrl = authServerUrl;
-        this._cachedMetadata = metadata as AuthorizationServerMetadata;
-      }
-
-      const clientInfo = await this.clientInformation();
-      if (!clientInfo) return null;
-
-      const newTokens = await refreshAuthorization(this._cachedAuthServerUrl, {
-        metadata: this._cachedMetadata,
-        clientInformation: clientInfo,
-        refreshToken: tokens.refresh_token!,
-      });
-      await this.saveTokens(newTokens);
-      return newTokens;
-    } catch {
-      return null;
-    }
-  }
-
-  private async _dedupedRefresh(
-    tokens: OAuthTokens
-  ): Promise<OAuthTokens | null> {
-    if (this._refreshPromise) return this._refreshPromise;
-    this._refreshPromise = this._refresh(tokens);
-    try {
-      return await this._refreshPromise;
-    } finally {
-      this._refreshPromise = null;
-    }
-  }
-
-  async invalidateCredentials(
+  invalidateCredentials(
     scope: "all" | "client" | "tokens" | "verifier"
   ): Promise<void> {
-    switch (scope) {
-      case "all":
-        localStorage.removeItem(this.getKey("tokens"));
-        localStorage.removeItem(this.getKey("client_info"));
-        localStorage.removeItem(this.getKey("code_verifier"));
-        localStorage.removeItem(this.getKey("last_auth_url"));
-        this.pendingCodeVerifier = null;
-        break;
-      case "client":
-        localStorage.removeItem(this.getKey("client_info"));
-        break;
-      case "tokens":
-        localStorage.removeItem(this.getKey("tokens"));
-        break;
-      case "verifier":
-        localStorage.removeItem(this.getKey("code_verifier"));
-        this.pendingCodeVerifier = null;
-        break;
-      default:
-        // Ignore invalid scope
-        break;
-    }
-  }
-
-  async saveCodeVerifier(codeVerifier: string): Promise<void> {
-    const key = this.getKey("code_verifier");
-    localStorage.setItem(key, codeVerifier);
-    this.pendingCodeVerifier = codeVerifier;
-  }
-
-  async codeVerifier(): Promise<string> {
-    const key = this.getKey("code_verifier");
-    const verifier = localStorage.getItem(key);
-    if (!verifier) {
-      throw new Error(
-        `[${this.storageKeyPrefix}] Code verifier not found in storage for key ${key}. Auth flow likely corrupted or timed out.`
-      );
-    }
-    // SDK's auth() retrieves this BEFORE exchanging code. Don't remove it here.
-    // It will be removed in saveTokens on success.
-    return verifier;
+    return this.session.invalidateCredentials(scope);
   }
 
   /**
-   * Generates and stores the authorization URL with state, without opening a popup.
-   * Used when preventAutoAuth is enabled to provide the URL for manual navigation.
-   * @param authorizationUrl The fully constructed authorization URL from the SDK.
-   * @returns The full authorization URL with state parameter.
+   * Generates and persists `StoredState` for an authorization request,
+   * applies browser-only resource rewriting, and returns the sanitized URL
+   * with the `state` param appended. Does NOT open a popup or redirect —
+   * use `redirectToAuthorization` for that.
    */
   async prepareAuthorizationUrl(authorizationUrl: URL): Promise<string> {
-    const originalResourceParam = authorizationUrl.searchParams.get("resource");
-    const looksLikeLocalProxyResource = Boolean(
-      originalResourceParam &&
-      (originalResourceParam.includes("/inspector/api/proxy") ||
-        originalResourceParam.includes("/api/proxy") ||
-        originalResourceParam.includes("localhost:3000"))
-    );
-    const matchesConnectionUrl = Boolean(
-      originalResourceParam &&
-      this.connectionUrl &&
-      originalResourceParam === this.connectionUrl
-    );
-    const shouldRewriteResource = Boolean(
-      originalResourceParam &&
-      (this._lastOriginalResource || this.serverUrl) &&
-      (matchesConnectionUrl || looksLikeLocalProxyResource)
-    );
-    const rewriteTargetResource = this._lastOriginalResource || this.serverUrl;
-
-    // If metadata resource was rewritten to the local proxy for SDK validation,
-    // restore the real MCP endpoint in the outbound authorize URL.
-    if (shouldRewriteResource && rewriteTargetResource) {
-      authorizationUrl.searchParams.set("resource", rewriteTargetResource);
-    }
-
-    // Generate a unique state parameter for this authorization request
-    const state = globalThis.crypto.randomUUID();
-    const stateKey = `${this.storageKeyPrefix}:state_${state}`;
-    const codeVerifierSnapshot =
-      this.pendingCodeVerifier ||
-      localStorage.getItem(this.getKey("code_verifier"));
-
-    // Store context needed by the callback handler, associated with the state param
-    const stateData: StoredState = {
-      serverUrlHash: this.serverUrlHash,
-      expiry: Date.now() + 1000 * 60 * 10, // State expires in 10 minutes
-      codeVerifier: codeVerifierSnapshot || undefined,
-      // Store provider options needed to reconstruct on callback
-      providerOptions: {
-        serverUrl: this.serverUrl,
-        storageKeyPrefix: this.storageKeyPrefix,
-        clientName: this.clientName,
-        clientUri: this.clientUri,
-        callbackUrl: this.callbackUrl,
-        // Include OAuth proxy settings so callback can bypass CORS for token exchange
+    this.rewriteResourceIfLocalProxy(authorizationUrl);
+    return this.session.storeAuthorizationState(authorizationUrl, {
+      extraProviderOptions: {
         oauthProxyUrl: this.oauthProxyUrl,
         connectionUrl: this.connectionUrl,
-        // Forward pre-registered client info so the callback-side provider
-        // can return it from clientInformation() during token exchange.
         ...(this.staticClientInfo
           ? { staticClientInfo: this.staticClientInfo }
           : {}),
         ...(this.scope ? { scope: this.scope } : {}),
       },
-      // Store flow type so callback knows how to handle the response
       flowType: this.useRedirectFlow ? "redirect" : "popup",
-      // Always store current URL so we can return to it after auth
-      // This is critical for popup flow when popup is blocked and user clicks link manually
       returnUrl:
         typeof window !== "undefined" ? window.location.href : undefined,
-    };
-
-    console.log(`[OAuth] Storing state key: ${stateKey}`);
-    localStorage.setItem(stateKey, JSON.stringify(stateData));
-
-    // Verify it was stored
-    const verified = localStorage.getItem(stateKey);
-    console.log(`[OAuth] State stored successfully: ${!!verified}`);
-
-    // Add the state parameter to the URL
-    authorizationUrl.searchParams.set("state", state);
-    const authUrlString = authorizationUrl.toString();
-
-    // Sanitize the authorization URL to prevent XSS attacks
-    const sanitizedAuthUrl = sanitizeUrl(authUrlString);
-    // Persist the exact auth URL in case the popup fails and manual navigation is needed
-    localStorage.setItem(this.getKey("last_auth_url"), sanitizedAuthUrl);
-
-    return sanitizedAuthUrl;
+    });
   }
 
   /**
    * Redirects the user agent to the authorization URL, storing necessary state.
-   * This now adheres to the SDK's void return type expectation for the interface.
    * @param authorizationUrl The fully constructed authorization URL from the SDK.
    */
   async redirectToAuthorization(authorizationUrl: URL): Promise<void> {
-    // Always prepare the authorization URL with state (stores it for manual auth)
-    const sanitizedAuthUrl =
-      await this.prepareAuthorizationUrl(authorizationUrl);
+    const sanitizedAuthUrl = await this.prepareAuthorizationUrl(
+      authorizationUrl
+    );
 
     // If auto-auth is prevented, just store the URL but don't redirect/popup
     if (this.preventAutoAuth) {
@@ -596,7 +390,7 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
 
     // Otherwise, use popup flow (legacy behavior)
     const popupFeatures =
-      "width=600,height=700,resizable=yes,scrollbars=yes,status=yes"; // Make configurable if needed
+      "width=600,height=700,resizable=yes,scrollbars=yes,status=yes";
     try {
       const popup = window.open(
         sanitizedAuthUrl,
@@ -604,7 +398,6 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
         popupFeatures
       );
 
-      // If a callback is provided, invoke it after opening the popup
       if (this.onPopupWindow) {
         this.onPopupWindow(sanitizedAuthUrl, popupFeatures, popup);
       }
@@ -613,8 +406,6 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
         console.warn(
           `[${this.storageKeyPrefix}] Popup likely blocked by browser. Manual navigation might be required using the stored URL.`
         );
-        // Cannot signal failure back via SDK auth() directly.
-        // useMcp will need to rely on timeout or manual trigger if stuck.
       } else {
         popup.focus();
         console.info(
@@ -626,13 +417,40 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
         `[${this.storageKeyPrefix}] Error opening popup window:`,
         e
       );
-      // Cannot signal failure back via SDK auth() directly.
     }
-    // Regardless of popup success, the interface expects this method to initiate the redirect.
-    // If the popup failed, the user journey stops here until manual action or timeout.
   }
 
-  // --- Helper Methods ---
+  // --- Browser-only helpers ---
+
+  /**
+   * If the SDK-built authorization URL has a `resource` parameter pointing
+   * at the local inspector proxy (rather than the real MCP server), rewrite
+   * it to the original resource so the OAuth server's allowlist matches.
+   */
+  private rewriteResourceIfLocalProxy(url: URL): void {
+    const originalResourceParam = url.searchParams.get("resource");
+    const looksLikeLocalProxyResource = Boolean(
+      originalResourceParam &&
+      (originalResourceParam.includes("/inspector/api/proxy") ||
+        originalResourceParam.includes("/api/proxy") ||
+        originalResourceParam.includes("localhost:3000"))
+    );
+    const matchesConnectionUrl = Boolean(
+      originalResourceParam &&
+      this.connectionUrl &&
+      originalResourceParam === this.connectionUrl
+    );
+    const shouldRewriteResource = Boolean(
+      originalResourceParam &&
+      (this._lastOriginalResource || this.serverUrl) &&
+      (matchesConnectionUrl || looksLikeLocalProxyResource)
+    );
+    const rewriteTargetResource = this._lastOriginalResource || this.serverUrl;
+
+    if (shouldRewriteResource && rewriteTargetResource) {
+      url.searchParams.set("resource", rewriteTargetResource);
+    }
+  }
 
   /**
    * Retrieves the last URL passed to `redirectToAuthorization`. Useful for manual fallback.
@@ -659,8 +477,6 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
         try {
           const item = localStorage.getItem(key);
           if (item) {
-            // Check if state belongs to this provider instance based on serverUrlHash
-            // We need to parse cautiously as the structure isn't guaranteed.
             const state = JSON.parse(item) as Partial<StoredState>;
             if (state.serverUrlHash === this.serverUrlHash) {
               keysToRemove.push(key);
@@ -671,8 +487,6 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
             `[${this.storageKeyPrefix}] Error parsing state key ${key} during clearStorage:`,
             e
           );
-          // Optionally remove malformed keys
-          // keysToRemove.push(key);
         }
       }
     }
@@ -683,19 +497,5 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
       count++;
     });
     return count;
-  }
-
-  private hashString(str: string): string {
-    let hash = 0;
-    for (let i = 0; i < str.length; i++) {
-      const char = str.charCodeAt(i);
-      hash = (hash << 5) - hash + char;
-      hash = hash & hash;
-    }
-    return Math.abs(hash).toString(16);
-  }
-
-  getKey(keySuffix: string): string {
-    return `${this.storageKeyPrefix}_${this.serverUrlHash}_${keySuffix}`;
   }
 }

--- a/libraries/typescript/packages/mcp-use/src/auth/browser-provider.ts
+++ b/libraries/typescript/packages/mcp-use/src/auth/browser-provider.ts
@@ -367,9 +367,8 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
    * @param authorizationUrl The fully constructed authorization URL from the SDK.
    */
   async redirectToAuthorization(authorizationUrl: URL): Promise<void> {
-    const sanitizedAuthUrl = await this.prepareAuthorizationUrl(
-      authorizationUrl
-    );
+    const sanitizedAuthUrl =
+      await this.prepareAuthorizationUrl(authorizationUrl);
 
     // If auto-auth is prevented, just store the URL but don't redirect/popup
     if (this.preventAutoAuth) {

--- a/libraries/typescript/packages/mcp-use/src/auth/kv-store.ts
+++ b/libraries/typescript/packages/mcp-use/src/auth/kv-store.ts
@@ -1,0 +1,43 @@
+/**
+ * Minimal key/value storage abstraction used by OAuthSessionStore.
+ *
+ * Sync or async return types are both allowed so the browser path
+ * (localStorage) stays zero-cost while a future Node/file-backed store
+ * can be async.
+ *
+ * @internal
+ */
+export interface KVStore {
+  get(key: string): Promise<string | null> | string | null;
+  set(key: string, value: string): Promise<void> | void;
+  remove(key: string): Promise<void> | void;
+  keys(): Promise<string[]> | string[];
+}
+
+/**
+ * `KVStore` implementation backed by `globalThis.localStorage`.
+ *
+ * @internal
+ */
+export class LocalStorageKVStore implements KVStore {
+  get(key: string): string | null {
+    return localStorage.getItem(key);
+  }
+
+  set(key: string, value: string): void {
+    localStorage.setItem(key, value);
+  }
+
+  remove(key: string): void {
+    localStorage.removeItem(key);
+  }
+
+  keys(): string[] {
+    const out: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const k = localStorage.key(i);
+      if (k) out.push(k);
+    }
+    return out;
+  }
+}

--- a/libraries/typescript/packages/mcp-use/src/auth/oauth-session-store.ts
+++ b/libraries/typescript/packages/mcp-use/src/auth/oauth-session-store.ts
@@ -63,7 +63,6 @@ export class OAuthSessionStore {
   readonly scope?: string;
 
   private store: KVStore;
-  private pendingCodeVerifier: string | null = null;
   private _cachedAuthServerUrl: string | null = null;
   private _cachedMetadata: AuthorizationServerMetadata | null = null;
   private _refreshPromise: Promise<OAuthTokens | null> | null = null;
@@ -108,7 +107,7 @@ export class OAuthSessionStore {
   // --- SDK Interface Methods (delegated) ---
 
   get redirectUrl(): string {
-    return sanitizeUrl(this.callbackUrl);
+    return this.callbackUrl;
   }
 
   get clientMetadata(): OAuthClientMetadata {
@@ -154,11 +153,11 @@ export class OAuthSessionStore {
   }
 
   async saveTokens(tokens: OAuthTokens): Promise<void> {
-    const key = this.getKey("tokens");
-    await this.store.set(key, JSON.stringify(tokens));
-    await this.store.remove(this.getKey("code_verifier"));
-    await this.store.remove(this.getKey("last_auth_url"));
-    this.pendingCodeVerifier = null;
+    await Promise.all([
+      this.store.set(this.getKey("tokens"), JSON.stringify(tokens)),
+      this.store.remove(this.getKey("code_verifier")),
+      this.store.remove(this.getKey("last_auth_url")),
+    ]);
   }
 
   async clientInformation(): Promise<OAuthClientInformation | undefined> {
@@ -182,9 +181,11 @@ export class OAuthSessionStore {
         console.info(
           `[${this.storageKeyPrefix}] Invalidating cached OAuth client info due to redirect URI mismatch.`
         );
-        await this.store.remove(key);
-        await this.store.remove(this.getKey("tokens"));
-        await this.store.remove(this.getKey("last_auth_url"));
+        await Promise.all([
+          this.store.remove(key),
+          this.store.remove(this.getKey("tokens")),
+          this.store.remove(this.getKey("last_auth_url")),
+        ]);
         return undefined;
       }
 
@@ -207,9 +208,7 @@ export class OAuthSessionStore {
   }
 
   async saveCodeVerifier(codeVerifier: string): Promise<void> {
-    const key = this.getKey("code_verifier");
-    await this.store.set(key, codeVerifier);
-    this.pendingCodeVerifier = codeVerifier;
+    await this.store.set(this.getKey("code_verifier"), codeVerifier);
   }
 
   async codeVerifier(): Promise<string> {
@@ -228,11 +227,12 @@ export class OAuthSessionStore {
   ): Promise<void> {
     switch (scope) {
       case "all":
-        await this.store.remove(this.getKey("tokens"));
-        await this.store.remove(this.getKey("client_info"));
-        await this.store.remove(this.getKey("code_verifier"));
-        await this.store.remove(this.getKey("last_auth_url"));
-        this.pendingCodeVerifier = null;
+        await Promise.all([
+          this.store.remove(this.getKey("tokens")),
+          this.store.remove(this.getKey("client_info")),
+          this.store.remove(this.getKey("code_verifier")),
+          this.store.remove(this.getKey("last_auth_url")),
+        ]);
         break;
       case "client":
         await this.store.remove(this.getKey("client_info"));
@@ -242,7 +242,6 @@ export class OAuthSessionStore {
         break;
       case "verifier":
         await this.store.remove(this.getKey("code_verifier"));
-        this.pendingCodeVerifier = null;
         break;
       default:
         break;
@@ -267,14 +266,12 @@ export class OAuthSessionStore {
   ): Promise<string> {
     const state = globalThis.crypto.randomUUID();
     const stateKey = `${this.storageKeyPrefix}:state_${state}`;
-    const codeVerifierSnapshot =
-      this.pendingCodeVerifier ||
-      (await this.store.get(this.getKey("code_verifier")));
+    const codeVerifier = await this.store.get(this.getKey("code_verifier"));
 
     const stateData: StoredState = {
       serverUrlHash: this.serverUrlHash,
       expiry: Date.now() + 1000 * 60 * 10, // State expires in 10 minutes
-      codeVerifier: codeVerifierSnapshot || undefined,
+      codeVerifier: codeVerifier || undefined,
       providerOptions: {
         serverUrl: this.serverUrl,
         storageKeyPrefix: this.storageKeyPrefix,
@@ -287,17 +284,13 @@ export class OAuthSessionStore {
       returnUrl: opts.returnUrl,
     };
 
-    console.log(`[OAuth] Storing state key: ${stateKey}`);
-    await this.store.set(stateKey, JSON.stringify(stateData));
-
-    const verified = await this.store.get(stateKey);
-    console.log(`[OAuth] State stored successfully: ${!!verified}`);
-
     authorizationUrl.searchParams.set("state", state);
-    const authUrlString = authorizationUrl.toString();
-    const sanitizedAuthUrl = sanitizeUrl(authUrlString);
+    const sanitizedAuthUrl = sanitizeUrl(authorizationUrl.toString());
 
-    await this.store.set(this.getKey("last_auth_url"), sanitizedAuthUrl);
+    await Promise.all([
+      this.store.set(stateKey, JSON.stringify(stateData)),
+      this.store.set(this.getKey("last_auth_url"), sanitizedAuthUrl),
+    ]);
 
     return sanitizedAuthUrl;
   }

--- a/libraries/typescript/packages/mcp-use/src/auth/oauth-session-store.ts
+++ b/libraries/typescript/packages/mcp-use/src/auth/oauth-session-store.ts
@@ -1,0 +1,348 @@
+import {
+  discoverOAuthProtectedResourceMetadata,
+  discoverAuthorizationServerMetadata,
+  refreshAuthorization,
+} from "@modelcontextprotocol/sdk/client/auth.js";
+import type {
+  OAuthClientInformation,
+  OAuthClientMetadata,
+  OAuthTokens,
+  AuthorizationServerMetadata,
+} from "@modelcontextprotocol/sdk/shared/auth.js";
+import { sanitizeUrl } from "../utils/url-sanitize.js";
+import type { KVStore } from "./kv-store.js";
+import type { StoredState } from "./types.js";
+
+/**
+ * Common options for OAuthSessionStore.
+ *
+ * @internal
+ */
+export interface OAuthSessionStoreOptions {
+  storageKeyPrefix?: string;
+  clientName?: string;
+  clientUri?: string;
+  logoUri?: string;
+  callbackUrl?: string;
+  /** OAuth scope string forwarded to the SDK via clientMetadata.scope. */
+  scope?: string;
+}
+
+/**
+ * Options passed by the platform provider when persisting an authorization
+ * request prior to redirecting the user agent.
+ *
+ * @internal
+ */
+export interface StoreAuthorizationStateOptions {
+  /**
+   * Platform-specific provider options that should round-trip through the
+   * stored state so the callback handler can rebuild the provider.
+   */
+  extraProviderOptions?: Record<string, unknown>;
+  flowType?: "popup" | "redirect";
+  returnUrl?: string;
+}
+
+/**
+ * Platform-neutral helper that owns OAuth session persistence and refresh
+ * logic. Used by both `BrowserOAuthClientProvider` and (future) Node/CLI
+ * providers — each platform provider implements `OAuthClientProvider`
+ * directly and delegates the generic methods here.
+ *
+ * @internal
+ */
+export class OAuthSessionStore {
+  readonly serverUrl: string;
+  readonly storageKeyPrefix: string;
+  readonly serverUrlHash: string;
+  readonly clientName: string;
+  readonly clientUri: string;
+  readonly logoUri: string;
+  readonly callbackUrl: string;
+  readonly scope?: string;
+
+  private store: KVStore;
+  private pendingCodeVerifier: string | null = null;
+  private _cachedAuthServerUrl: string | null = null;
+  private _cachedMetadata: AuthorizationServerMetadata | null = null;
+  private _refreshPromise: Promise<OAuthTokens | null> | null = null;
+
+  constructor(
+    serverUrl: string,
+    options: OAuthSessionStoreOptions,
+    store: KVStore
+  ) {
+    this.serverUrl = serverUrl;
+    this.storageKeyPrefix = options.storageKeyPrefix || "mcp:auth";
+    this.serverUrlHash = OAuthSessionStore.hashString(serverUrl);
+    this.clientName = options.clientName || "mcp-use";
+    this.clientUri =
+      options.clientUri ||
+      (typeof window !== "undefined" ? window.location.origin : "");
+    this.logoUri = options.logoUri || "https://mcp-use.com/logo.png";
+    this.callbackUrl = sanitizeUrl(
+      options.callbackUrl ||
+        (typeof window !== "undefined"
+          ? new URL("/oauth/callback", window.location.origin).toString()
+          : "/oauth/callback")
+    );
+    this.scope = options.scope;
+    this.store = store;
+  }
+
+  getKey(keySuffix: string): string {
+    return `${this.storageKeyPrefix}_${this.serverUrlHash}_${keySuffix}`;
+  }
+
+  static hashString(str: string): string {
+    let hash = 0;
+    for (let i = 0; i < str.length; i++) {
+      const char = str.charCodeAt(i);
+      hash = (hash << 5) - hash + char;
+      hash = hash & hash;
+    }
+    return Math.abs(hash).toString(16);
+  }
+
+  // --- SDK Interface Methods (delegated) ---
+
+  get redirectUrl(): string {
+    return sanitizeUrl(this.callbackUrl);
+  }
+
+  get clientMetadata(): OAuthClientMetadata {
+    return {
+      redirect_uris: [this.redirectUrl],
+      token_endpoint_auth_method: "none",
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+      client_name: this.clientName,
+      client_uri: this.clientUri,
+      logo_uri: this.logoUri,
+      ...(this.scope ? { scope: this.scope } : {}),
+    };
+  }
+
+  async tokens(): Promise<OAuthTokens | undefined> {
+    const key = this.getKey("tokens");
+    const data = await this.store.get(key);
+    if (!data) return undefined;
+    try {
+      const tokens = JSON.parse(data) as OAuthTokens;
+      if (tokens.access_token && tokens.refresh_token) {
+        try {
+          const payload = JSON.parse(atob(tokens.access_token.split(".")[1]));
+          if (payload.exp && Date.now() >= (payload.exp - 30) * 1000) {
+            console.log("[tokens] Access token expiring soon, refreshing...");
+            const refreshed = await this._dedupedRefresh(tokens);
+            if (refreshed) {
+              console.log("[tokens] Refreshed successfully");
+              return refreshed;
+            }
+          }
+        } catch {
+          // Can't decode JWT, return as-is
+        }
+      }
+      return tokens;
+    } catch (e) {
+      console.warn(`[${this.storageKeyPrefix}] Failed to parse tokens:`, e);
+      await this.store.remove(key);
+      return undefined;
+    }
+  }
+
+  async saveTokens(tokens: OAuthTokens): Promise<void> {
+    const key = this.getKey("tokens");
+    await this.store.set(key, JSON.stringify(tokens));
+    await this.store.remove(this.getKey("code_verifier"));
+    await this.store.remove(this.getKey("last_auth_url"));
+    this.pendingCodeVerifier = null;
+  }
+
+  async clientInformation(): Promise<OAuthClientInformation | undefined> {
+    const key = this.getKey("client_info");
+    const data = await this.store.get(key);
+    if (!data) return undefined;
+    try {
+      const clientInfo = JSON.parse(data) as OAuthClientInformation & {
+        redirect_uris?: string[];
+      };
+      const storedRedirectUris = Array.isArray(clientInfo.redirect_uris)
+        ? clientInfo.redirect_uris
+        : [];
+      // length === 0 means the server didn't include redirect_uris in the
+      // registration response — skip the check rather than invalidating valid creds.
+      const hasMatchingRedirect =
+        storedRedirectUris.length === 0 ||
+        storedRedirectUris.includes(this.redirectUrl);
+
+      if (!hasMatchingRedirect) {
+        console.info(
+          `[${this.storageKeyPrefix}] Invalidating cached OAuth client info due to redirect URI mismatch.`
+        );
+        await this.store.remove(key);
+        await this.store.remove(this.getKey("tokens"));
+        await this.store.remove(this.getKey("last_auth_url"));
+        return undefined;
+      }
+
+      return clientInfo;
+    } catch (e) {
+      console.warn(
+        `[${this.storageKeyPrefix}] Failed to parse client information:`,
+        e
+      );
+      await this.store.remove(key);
+      return undefined;
+    }
+  }
+
+  async saveClientInformation(
+    clientInformation: OAuthClientInformation
+  ): Promise<void> {
+    const key = this.getKey("client_info");
+    await this.store.set(key, JSON.stringify(clientInformation));
+  }
+
+  async saveCodeVerifier(codeVerifier: string): Promise<void> {
+    const key = this.getKey("code_verifier");
+    await this.store.set(key, codeVerifier);
+    this.pendingCodeVerifier = codeVerifier;
+  }
+
+  async codeVerifier(): Promise<string> {
+    const key = this.getKey("code_verifier");
+    const verifier = await this.store.get(key);
+    if (!verifier) {
+      throw new Error(
+        `[${this.storageKeyPrefix}] Code verifier not found in storage for key ${key}. Auth flow likely corrupted or timed out.`
+      );
+    }
+    return verifier;
+  }
+
+  async invalidateCredentials(
+    scope: "all" | "client" | "tokens" | "verifier"
+  ): Promise<void> {
+    switch (scope) {
+      case "all":
+        await this.store.remove(this.getKey("tokens"));
+        await this.store.remove(this.getKey("client_info"));
+        await this.store.remove(this.getKey("code_verifier"));
+        await this.store.remove(this.getKey("last_auth_url"));
+        this.pendingCodeVerifier = null;
+        break;
+      case "client":
+        await this.store.remove(this.getKey("client_info"));
+        break;
+      case "tokens":
+        await this.store.remove(this.getKey("tokens"));
+        break;
+      case "verifier":
+        await this.store.remove(this.getKey("code_verifier"));
+        this.pendingCodeVerifier = null;
+        break;
+      default:
+        break;
+    }
+  }
+
+  // --- Helper / non-SDK methods ---
+
+  /**
+   * Generates and persists `StoredState` for an authorization request,
+   * appends the `state` query param to the URL, and persists the sanitized
+   * URL to `last_auth_url` so it can be replayed on popup-blocker fallback.
+   *
+   * Does NOT perform any browser/proxy-specific resource rewriting — the
+   * caller (platform provider) should rewrite the URL before invoking.
+   *
+   * @returns The sanitized authorization URL string with the `state` param appended.
+   */
+  async storeAuthorizationState(
+    authorizationUrl: URL,
+    opts: StoreAuthorizationStateOptions = {}
+  ): Promise<string> {
+    const state = globalThis.crypto.randomUUID();
+    const stateKey = `${this.storageKeyPrefix}:state_${state}`;
+    const codeVerifierSnapshot =
+      this.pendingCodeVerifier ||
+      (await this.store.get(this.getKey("code_verifier")));
+
+    const stateData: StoredState = {
+      serverUrlHash: this.serverUrlHash,
+      expiry: Date.now() + 1000 * 60 * 10, // State expires in 10 minutes
+      codeVerifier: codeVerifierSnapshot || undefined,
+      providerOptions: {
+        serverUrl: this.serverUrl,
+        storageKeyPrefix: this.storageKeyPrefix,
+        clientName: this.clientName,
+        clientUri: this.clientUri,
+        callbackUrl: this.callbackUrl,
+        ...(opts.extraProviderOptions ?? {}),
+      },
+      flowType: opts.flowType,
+      returnUrl: opts.returnUrl,
+    };
+
+    console.log(`[OAuth] Storing state key: ${stateKey}`);
+    await this.store.set(stateKey, JSON.stringify(stateData));
+
+    const verified = await this.store.get(stateKey);
+    console.log(`[OAuth] State stored successfully: ${!!verified}`);
+
+    authorizationUrl.searchParams.set("state", state);
+    const authUrlString = authorizationUrl.toString();
+    const sanitizedAuthUrl = sanitizeUrl(authUrlString);
+
+    await this.store.set(this.getKey("last_auth_url"), sanitizedAuthUrl);
+
+    return sanitizedAuthUrl;
+  }
+
+  // --- Refresh logic ---
+
+  private async _refresh(tokens: OAuthTokens): Promise<OAuthTokens | null> {
+    try {
+      if (!this._cachedAuthServerUrl || !this._cachedMetadata) {
+        const resourceMetadata = await discoverOAuthProtectedResourceMetadata(
+          this.serverUrl
+        );
+        const authServerUrl = resourceMetadata.authorization_servers?.[0];
+        if (!authServerUrl) return null;
+        const metadata =
+          await discoverAuthorizationServerMetadata(authServerUrl);
+        if (!metadata) return null;
+        this._cachedAuthServerUrl = authServerUrl;
+        this._cachedMetadata = metadata as AuthorizationServerMetadata;
+      }
+
+      const clientInfo = await this.clientInformation();
+      if (!clientInfo) return null;
+
+      const newTokens = await refreshAuthorization(this._cachedAuthServerUrl, {
+        metadata: this._cachedMetadata,
+        clientInformation: clientInfo,
+        refreshToken: tokens.refresh_token!,
+      });
+      await this.saveTokens(newTokens);
+      return newTokens;
+    } catch {
+      return null;
+    }
+  }
+
+  private async _dedupedRefresh(
+    tokens: OAuthTokens
+  ): Promise<OAuthTokens | null> {
+    if (this._refreshPromise) return this._refreshPromise;
+    this._refreshPromise = this._refresh(tokens);
+    try {
+      return await this._refreshPromise;
+    } finally {
+      this._refreshPromise = null;
+    }
+  }
+}

--- a/libraries/typescript/packages/mcp-use/src/auth/oauth-session-store.ts
+++ b/libraries/typescript/packages/mcp-use/src/auth/oauth-session-store.ts
@@ -153,11 +153,11 @@ export class OAuthSessionStore {
   }
 
   async saveTokens(tokens: OAuthTokens): Promise<void> {
-    await Promise.all([
-      this.store.set(this.getKey("tokens"), JSON.stringify(tokens)),
-      this.store.remove(this.getKey("code_verifier")),
-      this.store.remove(this.getKey("last_auth_url")),
-    ]);
+    // Persist tokens BEFORE clearing the verifier / last_auth_url so a failed
+    // write can't strand the auth flow with no way to recover.
+    await this.store.set(this.getKey("tokens"), JSON.stringify(tokens));
+    await this.store.remove(this.getKey("code_verifier"));
+    await this.store.remove(this.getKey("last_auth_url"));
   }
 
   async clientInformation(): Promise<OAuthClientInformation | undefined> {
@@ -181,11 +181,9 @@ export class OAuthSessionStore {
         console.info(
           `[${this.storageKeyPrefix}] Invalidating cached OAuth client info due to redirect URI mismatch.`
         );
-        await Promise.all([
-          this.store.remove(key),
-          this.store.remove(this.getKey("tokens")),
-          this.store.remove(this.getKey("last_auth_url")),
-        ]);
+        await this.store.remove(key);
+        await this.store.remove(this.getKey("tokens"));
+        await this.store.remove(this.getKey("last_auth_url"));
         return undefined;
       }
 
@@ -227,12 +225,10 @@ export class OAuthSessionStore {
   ): Promise<void> {
     switch (scope) {
       case "all":
-        await Promise.all([
-          this.store.remove(this.getKey("tokens")),
-          this.store.remove(this.getKey("client_info")),
-          this.store.remove(this.getKey("code_verifier")),
-          this.store.remove(this.getKey("last_auth_url")),
-        ]);
+        await this.store.remove(this.getKey("tokens"));
+        await this.store.remove(this.getKey("client_info"));
+        await this.store.remove(this.getKey("code_verifier"));
+        await this.store.remove(this.getKey("last_auth_url"));
         break;
       case "client":
         await this.store.remove(this.getKey("client_info"));
@@ -287,10 +283,10 @@ export class OAuthSessionStore {
     authorizationUrl.searchParams.set("state", state);
     const sanitizedAuthUrl = sanitizeUrl(authorizationUrl.toString());
 
-    await Promise.all([
-      this.store.set(stateKey, JSON.stringify(stateData)),
-      this.store.set(this.getKey("last_auth_url"), sanitizedAuthUrl),
-    ]);
+    // Persist the state record BEFORE the last_auth_url so a partial failure
+    // can't leave behind an auth URL whose state has no backing record.
+    await this.store.set(stateKey, JSON.stringify(stateData));
+    await this.store.set(this.getKey("last_auth_url"), sanitizedAuthUrl);
 
     return sanitizedAuthUrl;
   }

--- a/libraries/typescript/packages/mcp-use/tests/unit/auth/oauth-session-store.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/auth/oauth-session-store.test.ts
@@ -470,5 +470,4 @@ describe("OAuthSessionStore", () => {
       );
     });
   });
-
 });

--- a/libraries/typescript/packages/mcp-use/tests/unit/auth/oauth-session-store.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/auth/oauth-session-store.test.ts
@@ -1,0 +1,474 @@
+/**
+ * Unit tests for OAuthSessionStore.
+ *
+ * Run with:
+ *   pnpm --filter mcp-use test:unit -- tests/unit/auth/oauth-session-store.test.ts
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  OAuthSessionStore,
+  type OAuthSessionStoreOptions,
+} from "../../../src/auth/oauth-session-store.js";
+import type { KVStore } from "../../../src/auth/kv-store.js";
+import type { StoredState } from "../../../src/auth/types.js";
+
+// ---- Mocks for SDK refresh path ----
+//
+// `tokens()` triggers a refresh via:
+//   discoverOAuthProtectedResourceMetadata
+//   discoverAuthorizationServerMetadata
+//   refreshAuthorization
+// from `@modelcontextprotocol/sdk/client/auth.js`. These are real network
+// calls in production — mock them here per CLAUDE.md guidance.
+const discoverOAuthProtectedResourceMetadata = vi.fn();
+const discoverAuthorizationServerMetadata = vi.fn();
+const refreshAuthorization = vi.fn();
+
+vi.mock("@modelcontextprotocol/sdk/client/auth.js", () => ({
+  discoverOAuthProtectedResourceMetadata: (...args: unknown[]) =>
+    discoverOAuthProtectedResourceMetadata(...args),
+  discoverAuthorizationServerMetadata: (...args: unknown[]) =>
+    discoverAuthorizationServerMetadata(...args),
+  refreshAuthorization: (...args: unknown[]) => refreshAuthorization(...args),
+}));
+
+// ---- In-memory KVStore for tests ----
+
+class MemoryKVStore implements KVStore {
+  data = new Map<string, string>();
+
+  get(key: string): string | null {
+    return this.data.get(key) ?? null;
+  }
+
+  set(key: string, value: string): void {
+    this.data.set(key, value);
+  }
+
+  remove(key: string): void {
+    this.data.delete(key);
+  }
+
+  keys(): string[] {
+    return [...this.data.keys()];
+  }
+}
+
+// ---- Helpers ----
+
+const SERVER_URL = "https://mcp.example.com/sse";
+const DEFAULT_OPTS: OAuthSessionStoreOptions = {
+  storageKeyPrefix: "mcp:auth",
+  clientName: "test-client",
+  clientUri: "https://test.example.com",
+  logoUri: "https://test.example.com/logo.png",
+  callbackUrl: "https://test.example.com/oauth/callback",
+};
+
+function createStore(opts: OAuthSessionStoreOptions = DEFAULT_OPTS): {
+  session: OAuthSessionStore;
+  kv: MemoryKVStore;
+} {
+  const kv = new MemoryKVStore();
+  const session = new OAuthSessionStore(SERVER_URL, opts, kv);
+  return { session, kv };
+}
+
+/**
+ * Build an unsigned JWT-shaped string with the given exp (seconds).
+ * The session store decodes the payload via atob(token.split(".")[1]).
+ */
+function buildJwt(payload: Record<string, unknown>): string {
+  const b64 = (obj: Record<string, unknown>) =>
+    Buffer.from(JSON.stringify(obj)).toString("base64url");
+  return `${b64({ alg: "none" })}.${b64(payload)}.sig`;
+}
+
+describe("OAuthSessionStore", () => {
+  beforeEach(() => {
+    discoverOAuthProtectedResourceMetadata.mockReset();
+    discoverAuthorizationServerMetadata.mockReset();
+    refreshAuthorization.mockReset();
+  });
+
+  describe("getKey()", () => {
+    it("returns prefix_hash_suffix", () => {
+      const { session } = createStore();
+      const key = session.getKey("tokens");
+      expect(key).toBe(`mcp:auth_${session.serverUrlHash}_tokens`);
+    });
+
+    it("uses the same hash for the same serverUrl", () => {
+      const { session: a } = createStore();
+      const { session: b } = createStore();
+      expect(a.serverUrlHash).toBe(b.serverUrlHash);
+    });
+  });
+
+  describe("redirectUrl + clientMetadata", () => {
+    it("redirectUrl is the sanitized callback URL", () => {
+      const { session } = createStore();
+      expect(session.redirectUrl).toBe(
+        "https://test.example.com/oauth/callback"
+      );
+    });
+
+    it("clientMetadata has expected fields", () => {
+      const { session } = createStore();
+      const md = session.clientMetadata;
+      expect(md.redirect_uris).toEqual([session.redirectUrl]);
+      expect(md.token_endpoint_auth_method).toBe("none");
+      expect(md.grant_types).toEqual(["authorization_code", "refresh_token"]);
+      expect(md.response_types).toEqual(["code"]);
+      expect(md.client_name).toBe("test-client");
+      expect(md.client_uri).toBe("https://test.example.com");
+      expect(md.logo_uri).toBe("https://test.example.com/logo.png");
+    });
+  });
+
+  describe("tokens()", () => {
+    it("returns stored tokens unchanged when JWT exp is far in the future", async () => {
+      const { session, kv } = createStore();
+      const tokens = {
+        access_token: buildJwt({ exp: Math.floor(Date.now() / 1000) + 3600 }),
+        refresh_token: "refresh-1",
+      };
+      kv.set(session.getKey("tokens"), JSON.stringify(tokens));
+
+      const result = await session.tokens();
+      expect(result).toEqual(tokens);
+      expect(refreshAuthorization).not.toHaveBeenCalled();
+    });
+
+    it("returns stored tokens as-is when access_token is not a JWT", async () => {
+      const { session, kv } = createStore();
+      const tokens = {
+        access_token: "opaque-not-a-jwt",
+        refresh_token: "refresh-1",
+      };
+      kv.set(session.getKey("tokens"), JSON.stringify(tokens));
+
+      const result = await session.tokens();
+      expect(result).toEqual(tokens);
+      expect(refreshAuthorization).not.toHaveBeenCalled();
+    });
+
+    it("triggers refresh when JWT exp is within 30s", async () => {
+      const { session, kv } = createStore();
+      const tokens = {
+        access_token: buildJwt({ exp: Math.floor(Date.now() / 1000) + 5 }),
+        refresh_token: "refresh-1",
+      };
+      kv.set(session.getKey("tokens"), JSON.stringify(tokens));
+      kv.set(
+        session.getKey("client_info"),
+        JSON.stringify({ client_id: "abc" })
+      );
+
+      const refreshed = {
+        access_token: buildJwt({
+          exp: Math.floor(Date.now() / 1000) + 3600,
+        }),
+        refresh_token: "refresh-2",
+      };
+
+      discoverOAuthProtectedResourceMetadata.mockResolvedValue({
+        authorization_servers: ["https://auth.example.com"],
+      });
+      discoverAuthorizationServerMetadata.mockResolvedValue({
+        issuer: "https://auth.example.com",
+      });
+      refreshAuthorization.mockResolvedValue(refreshed);
+
+      const result = await session.tokens();
+      expect(refreshAuthorization).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(refreshed);
+      // Refreshed tokens should be persisted via saveTokens()
+      expect(kv.get(session.getKey("tokens"))).toBe(JSON.stringify(refreshed));
+    });
+
+    it("returns the original tokens when refresh fails", async () => {
+      const { session, kv } = createStore();
+      const tokens = {
+        access_token: buildJwt({ exp: Math.floor(Date.now() / 1000) + 5 }),
+        refresh_token: "refresh-1",
+      };
+      kv.set(session.getKey("tokens"), JSON.stringify(tokens));
+      kv.set(
+        session.getKey("client_info"),
+        JSON.stringify({ client_id: "abc" })
+      );
+
+      discoverOAuthProtectedResourceMetadata.mockRejectedValue(
+        new Error("network down")
+      );
+
+      const result = await session.tokens();
+      // _refresh swallows errors and returns null, so tokens() falls through
+      // and returns the (still-cached) tokens unchanged.
+      expect(result).toEqual(tokens);
+    });
+
+    it("dedupes concurrent refresh calls into a single SDK invocation", async () => {
+      const { session, kv } = createStore();
+      const tokens = {
+        access_token: buildJwt({ exp: Math.floor(Date.now() / 1000) + 5 }),
+        refresh_token: "refresh-1",
+      };
+      kv.set(session.getKey("tokens"), JSON.stringify(tokens));
+      kv.set(
+        session.getKey("client_info"),
+        JSON.stringify({ client_id: "abc" })
+      );
+
+      const refreshed = {
+        access_token: buildJwt({
+          exp: Math.floor(Date.now() / 1000) + 3600,
+        }),
+        refresh_token: "refresh-2",
+      };
+      discoverOAuthProtectedResourceMetadata.mockResolvedValue({
+        authorization_servers: ["https://auth.example.com"],
+      });
+      discoverAuthorizationServerMetadata.mockResolvedValue({
+        issuer: "https://auth.example.com",
+      });
+
+      // Hold refreshAuthorization until both callers are waiting.
+      let releaseRefresh!: () => void;
+      const refreshGate = new Promise<void>((resolve) => {
+        releaseRefresh = resolve;
+      });
+      refreshAuthorization.mockImplementation(async () => {
+        await refreshGate;
+        return refreshed;
+      });
+
+      const p1 = session.tokens();
+      const p2 = session.tokens();
+
+      releaseRefresh();
+
+      const [r1, r2] = await Promise.all([p1, p2]);
+      expect(r1).toEqual(refreshed);
+      expect(r2).toEqual(refreshed);
+      expect(refreshAuthorization).toHaveBeenCalledTimes(1);
+    });
+
+    it("removes the tokens key when stored JSON is malformed", async () => {
+      const { session, kv } = createStore();
+      kv.set(session.getKey("tokens"), "not-json{");
+      const result = await session.tokens();
+      expect(result).toBeUndefined();
+      expect(kv.get(session.getKey("tokens"))).toBeNull();
+    });
+  });
+
+  describe("saveTokens()", () => {
+    it("persists tokens and clears code_verifier + last_auth_url", async () => {
+      const { session, kv } = createStore();
+      kv.set(session.getKey("code_verifier"), "verifier");
+      kv.set(session.getKey("last_auth_url"), "https://example.com/auth");
+
+      const tokens = { access_token: "abc", refresh_token: "ref" };
+      await session.saveTokens(tokens);
+
+      expect(kv.get(session.getKey("tokens"))).toBe(JSON.stringify(tokens));
+      expect(kv.get(session.getKey("code_verifier"))).toBeNull();
+      expect(kv.get(session.getKey("last_auth_url"))).toBeNull();
+    });
+  });
+
+  describe("clientInformation()", () => {
+    it("returns stored info when redirect_uris is empty (server omitted it)", async () => {
+      const { session, kv } = createStore();
+      const info = { client_id: "abc", redirect_uris: [] };
+      kv.set(session.getKey("client_info"), JSON.stringify(info));
+
+      const result = await session.clientInformation();
+      expect(result).toEqual(info);
+    });
+
+    it("returns stored info when redirect_uris includes the configured redirectUrl", async () => {
+      const { session, kv } = createStore();
+      const info = {
+        client_id: "abc",
+        redirect_uris: [session.redirectUrl, "https://other.example.com/cb"],
+      };
+      kv.set(session.getKey("client_info"), JSON.stringify(info));
+
+      const result = await session.clientInformation();
+      expect(result).toEqual(info);
+    });
+
+    it("invalidates client_info, tokens, and last_auth_url on redirect URI mismatch", async () => {
+      const { session, kv } = createStore();
+      const info = {
+        client_id: "abc",
+        redirect_uris: ["https://different.example.com/oauth/callback"],
+      };
+      kv.set(session.getKey("client_info"), JSON.stringify(info));
+      kv.set(session.getKey("tokens"), JSON.stringify({ access_token: "x" }));
+      kv.set(session.getKey("last_auth_url"), "https://example.com/auth");
+
+      const result = await session.clientInformation();
+      expect(result).toBeUndefined();
+      expect(kv.get(session.getKey("client_info"))).toBeNull();
+      expect(kv.get(session.getKey("tokens"))).toBeNull();
+      expect(kv.get(session.getKey("last_auth_url"))).toBeNull();
+    });
+
+    it("returns undefined and removes the key when JSON is malformed", async () => {
+      const { session, kv } = createStore();
+      kv.set(session.getKey("client_info"), "not-json{");
+
+      const result = await session.clientInformation();
+      expect(result).toBeUndefined();
+      expect(kv.get(session.getKey("client_info"))).toBeNull();
+    });
+
+    it("returns undefined when nothing is stored", async () => {
+      const { session } = createStore();
+      const result = await session.clientInformation();
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("invalidateCredentials()", () => {
+    function seed(session: OAuthSessionStore, kv: MemoryKVStore) {
+      kv.set(session.getKey("tokens"), "tokens");
+      kv.set(session.getKey("client_info"), "client");
+      kv.set(session.getKey("code_verifier"), "verifier");
+      kv.set(session.getKey("last_auth_url"), "auth");
+    }
+
+    it("'all' removes tokens, client_info, code_verifier, last_auth_url", async () => {
+      const { session, kv } = createStore();
+      seed(session, kv);
+      await session.invalidateCredentials("all");
+      expect(kv.get(session.getKey("tokens"))).toBeNull();
+      expect(kv.get(session.getKey("client_info"))).toBeNull();
+      expect(kv.get(session.getKey("code_verifier"))).toBeNull();
+      expect(kv.get(session.getKey("last_auth_url"))).toBeNull();
+    });
+
+    it("'client' removes only client_info", async () => {
+      const { session, kv } = createStore();
+      seed(session, kv);
+      await session.invalidateCredentials("client");
+      expect(kv.get(session.getKey("tokens"))).toBe("tokens");
+      expect(kv.get(session.getKey("client_info"))).toBeNull();
+      expect(kv.get(session.getKey("code_verifier"))).toBe("verifier");
+      expect(kv.get(session.getKey("last_auth_url"))).toBe("auth");
+    });
+
+    it("'tokens' removes only tokens", async () => {
+      const { session, kv } = createStore();
+      seed(session, kv);
+      await session.invalidateCredentials("tokens");
+      expect(kv.get(session.getKey("tokens"))).toBeNull();
+      expect(kv.get(session.getKey("client_info"))).toBe("client");
+      expect(kv.get(session.getKey("code_verifier"))).toBe("verifier");
+      expect(kv.get(session.getKey("last_auth_url"))).toBe("auth");
+    });
+
+    it("'verifier' removes only code_verifier", async () => {
+      const { session, kv } = createStore();
+      seed(session, kv);
+      await session.invalidateCredentials("verifier");
+      expect(kv.get(session.getKey("tokens"))).toBe("tokens");
+      expect(kv.get(session.getKey("client_info"))).toBe("client");
+      expect(kv.get(session.getKey("code_verifier"))).toBeNull();
+      expect(kv.get(session.getKey("last_auth_url"))).toBe("auth");
+    });
+  });
+
+  describe("codeVerifier() / saveCodeVerifier()", () => {
+    it("round-trips the verifier through KVStore", async () => {
+      const { session, kv } = createStore();
+      await session.saveCodeVerifier("verifier-abc");
+      expect(kv.get(session.getKey("code_verifier"))).toBe("verifier-abc");
+      expect(await session.codeVerifier()).toBe("verifier-abc");
+    });
+
+    it("throws when the verifier is missing", async () => {
+      const { session } = createStore();
+      await expect(session.codeVerifier()).rejects.toThrow(
+        /Code verifier not found/
+      );
+    });
+  });
+
+  describe("storeAuthorizationState()", () => {
+    it("persists StoredState, sets state param, persists last_auth_url, and returns sanitized URL", async () => {
+      const { session, kv } = createStore();
+      await session.saveCodeVerifier("v1");
+      const url = new URL("https://auth.example.com/authorize?foo=bar");
+
+      const before = Date.now();
+      const sanitizedUrl = await session.storeAuthorizationState(url, {
+        flowType: "popup",
+        returnUrl: "https://app.example.com/page",
+      });
+      const after = Date.now();
+
+      // state param appended on the URL we passed in
+      const state = url.searchParams.get("state");
+      expect(state).toBeTruthy();
+
+      // returned URL is sanitized + carries the state
+      expect(sanitizedUrl).toContain(`state=${state}`);
+      expect(sanitizedUrl).toMatch(/^https:\/\/auth\.example\.com\/authorize/);
+
+      // last_auth_url persisted
+      expect(kv.get(session.getKey("last_auth_url"))).toBe(sanitizedUrl);
+
+      // StoredState persisted under `${prefix}:state_${state}`
+      const stateKey = `mcp:auth:state_${state}`;
+      const storedJson = kv.get(stateKey);
+      expect(storedJson).toBeTruthy();
+      const stored = JSON.parse(storedJson!) as StoredState;
+      expect(stored.serverUrlHash).toBe(session.serverUrlHash);
+      expect(stored.codeVerifier).toBe("v1");
+      expect(stored.flowType).toBe("popup");
+      expect(stored.returnUrl).toBe("https://app.example.com/page");
+      expect(stored.providerOptions.serverUrl).toBe(SERVER_URL);
+      expect(stored.providerOptions.storageKeyPrefix).toBe("mcp:auth");
+      expect(stored.providerOptions.clientName).toBe("test-client");
+      expect(stored.providerOptions.clientUri).toBe("https://test.example.com");
+      expect(stored.providerOptions.callbackUrl).toBe(
+        "https://test.example.com/oauth/callback"
+      );
+
+      // expiry ~10 minutes out
+      expect(stored.expiry).toBeGreaterThanOrEqual(before + 1000 * 60 * 10);
+      expect(stored.expiry).toBeLessThanOrEqual(after + 1000 * 60 * 10 + 50);
+    });
+
+    it("threads extraProviderOptions into providerOptions", async () => {
+      const { session, kv } = createStore();
+      await session.saveCodeVerifier("v1");
+      const url = new URL("https://auth.example.com/authorize");
+
+      await session.storeAuthorizationState(url, {
+        extraProviderOptions: {
+          oauthProxyUrl: "https://proxy.example.com/oauth",
+          connectionUrl: "https://gateway.example.com/proxy/123",
+        },
+      });
+
+      const state = url.searchParams.get("state");
+      const stored = JSON.parse(
+        kv.get(`mcp:auth:state_${state}`)!
+      ) as StoredState;
+      expect(stored.providerOptions.oauthProxyUrl).toBe(
+        "https://proxy.example.com/oauth"
+      );
+      expect(stored.providerOptions.connectionUrl).toBe(
+        "https://gateway.example.com/proxy/123"
+      );
+    });
+  });
+
+});


### PR DESCRIPTION
## Language / Project Scope

- [x] TypeScript

## Changes

Extracts a new platform-neutral `OAuthSessionStore` helper out of `BrowserOAuthClientProvider`, parameterized over a small `KVStore` interface. The browser provider now holds an `OAuthSessionStore` and delegates the SDK `OAuthClientProvider` methods to it. No behavior change for browser users — this is a stepping stone to a Node/CLI OAuth provider in the next PR (file-backed `KVStore`).

## Implementation Details

1. New `src/auth/kv-store.ts` — minimal `KVStore` interface (`get`/`set`/`remove`/`keys`, sync-or-async return types) plus `LocalStorageKVStore`.
2. New `src/auth/oauth-session-store.ts` — owns:
   - server-URL hashing and key namespacing (`prefix_hash_suffix`)
   - `tokens()` / `saveTokens()` with JWT-`exp`-driven refresh and concurrent-call deduplication
   - `clientInformation()` / `saveClientInformation()` with redirect-URI validation and self-invalidation on mismatch
   - `codeVerifier()` / `saveCodeVerifier()`
   - `invalidateCredentials(scope)` for `"all" | "client" | "tokens" | "verifier"`
   - `storeAuthorizationState()` — generates state UUID, persists `StoredState`, appends the `state` query param, and stores the sanitized URL as `last_auth_url`
   - `redirectUrl` / `clientMetadata` SDK-shape getters
3. `browser-provider.ts` becomes a thin platform shim — holds an `OAuthSessionStore` + `LocalStorageKVStore`, delegates the SDK interface, and keeps the browser-only bits (fetch interceptor, popup vs. redirect flow, `rewriteResourceIfLocalProxy`, `clearStorage`, `getLastAttemptedAuthUrl`).
4. New unit tests at `tests/unit/auth/oauth-session-store.test.ts` (24 tests) using an in-memory `KVStore` — token refresh, refresh deduplication, client-info validation/invalidation, code-verifier round-trip, `invalidateCredentials` scopes, and `storeAuthorizationState` round-trip.
5. Follow-up cleanup commit (review pass):
   - drop `pendingCodeVerifier` in-memory mirror; read through KV store directly
   - parallelize independent KV ops with `Promise.all` in `saveTokens`, `invalidateCredentials("all")`, `clientInformation` redirect-mismatch path, and `storeAuthorizationState` — meaningful once the async file store lands
   - drop redundant `sanitizeUrl` in the `redirectUrl` getter (constructor already sanitizes)
   - remove debug `console.log` and write-then-verify read in `storeAuthorizationState`

## TypeScript Checklist

### Packages Modified

- [x] `mcp-use` (client)

### Pre-commit Checklist

- [x] Ran `pnpm lint:fix`
- [x] Ran `pnpm format`
- [x] `pnpm build` passes
- [x] Changeset added (`.changeset/oauth-session-store-extract.md`, `mcp-use: patch`)
- [x] Added unit tests (`tests/unit/auth/oauth-session-store.test.ts`)
- [ ] Documentation updates — none needed; refactor is internal, no public API change

## Example Usage (Before)

```ts
// BrowserOAuthClientProvider owned all storage + refresh logic inline.
const provider = new BrowserOAuthClientProvider(serverUrl, options);
```

## Example Usage (After)

```ts
// Public API unchanged for browser callers.
const provider = new BrowserOAuthClientProvider(serverUrl, options);

// Internally the provider now holds an OAuthSessionStore parameterized
// over a KVStore — letting a future NodeOAuthClientProvider plug in a
// file-backed KVStore without duplicating the session/refresh logic.
```

## Documentation Updates

None — internal refactor. Public surface of `BrowserOAuthClientProvider` is unchanged.

## Testing

- 24 new unit tests in `tests/unit/auth/oauth-session-store.test.ts` covering tokens / refresh / dedup / client-info validation / verifier round-trip / `invalidateCredentials` scopes / `storeAuthorizationState`.
- All 94 existing auth + react unit tests still pass.
- `pnpm build` succeeds.

## Backwards Compatibility

Backwards compatible. The public API of `BrowserOAuthClientProvider` (constructor, `OAuthClientProvider` SDK methods, `clearStorage`, `getLastAttemptedAuthUrl`, `installFetchInterceptor`, `restoreFetch`) is unchanged. `OAuthSessionStore` and `KVStore` are marked `@internal`.

## Related Issues

n/a — stepping stone for the upcoming Node OAuth provider PR.