### PR TITLE
feat(cli/auth): Node OAuth provider + agent-ready CLI client

### DIFF
--- a/libraries/typescript/.changeset/cli-borderless-tables.md
+++ b/libraries/typescript/.changeset/cli-borderless-tables.md
@@ -1,0 +1,9 @@
+---
+"@mcp-use/cli": minor
+---
+
+feat(cli): borderless aligned-columns table rendering, gh/kubectl style
+
+Replaced the box-drawing ASCII table in `mcp-use client {tools,resources,prompts,sessions} list` with a borderless layout: UPPERCASE bold headers, two-space gutter between columns, ANSI-stripped width math, ellipsis truncation for long descriptions, sized to the terminal width (or 100 cols). Tool rows now also show a `MODE` column (read-only / write / destructive, derived from the tool's MCP annotations) and an `ARGS` column (required/total).
+
+When stdout is not a TTY (pipes, agents, CI), every list command instead emits tab-separated values with no header, no decorative banners, and no ANSI — matching how the GitHub CLI behaves. This makes the CLI directly parseable by AI agents and shell pipelines.

--- a/libraries/typescript/.changeset/cli-client-headless-exit.md
+++ b/libraries/typescript/.changeset/cli-client-headless-exit.md
@@ -1,0 +1,15 @@
+---
+"@mcp-use/cli": patch
+---
+
+fix(cli): exit cleanly after `client` subcommands so headless agents don't hang
+
+Each `mcp-use client` subcommand spins up a fresh `MCPClient` + HTTP/SSE
+transport per process invocation but never closed it before returning, so
+the underlying socket kept the Node event loop alive and the CLI process
+hung after `tools list`, `tools call`, `resources read`, etc. — making the
+client unusable for headless / agent-driven flows.
+
+Each one-shot subcommand now closes its in-memory sessions and exits at
+the end. Long-running commands (`subscribe`, `interactive`) are unchanged
+and still keep the loop alive until Ctrl+C / `quit`.

--- a/libraries/typescript/.changeset/cli-oauth-non-tty-no-browser.md
+++ b/libraries/typescript/.changeset/cli-oauth-non-tty-no-browser.md
@@ -1,0 +1,22 @@
+---
+"@mcp-use/cli": patch
+---
+
+fix(cli): don't auto-open a browser for OAuth in non-TTY contexts
+
+When `mcp-use client connect` (or a session restore) hits an OAuth flow,
+the CLI used to launch the user's browser unconditionally. That's the
+right call from an interactive terminal, but surprising when an LLM
+agent or a CI script runs the same command — the agent has no way to
+"see" the browser, and the user gets an unexpected window.
+
+`stdout.isTTY` now gates the browser launch:
+
+- TTY: opens the browser as before.
+- Non-TTY: prints the authorization URL to stderr and waits on the
+  loopback callback, so the caller (human or agent) can hand the URL
+  off however it wants.
+
+The leading "→ Opening browser to authenticate..." message is also
+adjusted to "→ OAuth authentication required." in non-TTY mode so the
+log doesn't claim a browser was opened when it wasn't.

--- a/libraries/typescript/.changeset/cli-tool-call-error-details.md
+++ b/libraries/typescript/.changeset/cli-tool-call-error-details.md
@@ -1,0 +1,17 @@
+---
+"@mcp-use/cli": patch
+---
+
+fix(cli): surface tool call error details in `client tools call`
+
+Previously when a tool call returned `isError: true`, the CLI showed
+only "✗ Tool execution failed" without making it clear that the
+following content was the error message — and printed nothing at all
+when the server returned no content. Both human users and agent
+callers had no way to debug what went wrong.
+
+The output now labels the error content explicitly ("Error details:"),
+colors text content red, surfaces `structuredContent` when present,
+and falls back to "(no error details provided by server)" if the
+server returned neither. Connection-level failures (caught Errors)
+now also print any attached `data` payload.

--- a/libraries/typescript/.changeset/cli-tool-call-failure-exit-code.md
+++ b/libraries/typescript/.changeset/cli-tool-call-failure-exit-code.md
@@ -1,0 +1,12 @@
+---
+"@mcp-use/cli": patch
+---
+
+fix(cli): exit non-zero when `client tools call` returns `isError: true`
+
+`mcp-use client tools call <tool>` printed "✗ Tool execution failed"
+but still exited 0, so headless agents and shell pipelines couldn't
+distinguish a successful tool call from a failed one. The command now
+exits 1 when the tool result has `isError: true`, in both default and
+`--json` output modes. The result content is still printed first so the
+failure detail remains visible.

--- a/libraries/typescript/.changeset/cli-tool-call-key-value-args.md
+++ b/libraries/typescript/.changeset/cli-tool-call-key-value-args.md
@@ -1,0 +1,31 @@
+---
+"@mcp-use/cli": minor
+---
+
+feat(cli): accept `key=value` args for `client tools call` and `client prompts get`
+
+Previously the only way to pass arguments to a tool or prompt was a single
+JSON-encoded string, which is brittle for both humans (shell escaping) and
+agents (extra JSON-stringify step, easy to get wrong). Now each argument is a
+variadic positional in `key=value` form, with types coerced from the tool's
+input schema (`number`, `integer`, `boolean`, `array`, `object`, `string`,
+nullable unions). For nested objects or arrays, `key:=<json>` (httpie-style)
+forces the value to be parsed as JSON.
+
+```bash
+# Before
+mcp-use client tools call greet '{"name":"world","count":3,"enabled":true}'
+
+# After
+mcp-use client tools call greet name=world count=3 enabled=true
+
+# Nested values
+mcp-use client tools call create-doc title=hello meta:='{"tags":["a","b"]}'
+```
+
+The legacy single-JSON-object form is still accepted for backward
+compatibility (a single positional starting with `{` is parsed as a JSON
+object), and a leading `--` on a key is stripped if present (`--name=world`
+works the same as `name=world`). The same syntax applies to
+`mcp-use client prompts get`. Error messages now show usage examples and the
+target tool's schema so agents can self-correct.

--- a/libraries/typescript/.changeset/node-oauth-cli-flow.md
+++ b/libraries/typescript/.changeset/node-oauth-cli-flow.md
@@ -1,0 +1,37 @@
+---
+"mcp-use": minor
+"@mcp-use/cli": minor
+---
+
+feat(auth): Node OAuth client provider + CLI OAuth flow
+
+Adds a real OAuth flow to the `mcp-use` CLI. `mcp-use client connect <url>`
+against an OAuth-protected MCP server now opens a browser, captures the
+authorization code via a localhost loopback, persists tokens to
+`~/.mcp-use/oauth/<urlHash>/`, and silently refreshes them on subsequent
+commands — no flag plumbing.
+
+New on `mcp-use`:
+
+- `mcp-use/auth/node` entrypoint exporting `NodeOAuthClientProvider`,
+  `FileKVStore`, the `KVStore` type, and re-exporting the SDK's `auth` and
+  `UnauthorizedError`.
+- `NodeOAuthClientProvider` implements `OAuthClientProvider`, owns the
+  loopback callback server (preferred port 33418, walks up to 33427 on
+  conflict, persisted across runs), and exposes `getAuthorizationCode()`
+  for the orchestrator pattern in `useMcp.ts`.
+- `FileKVStore` writes tokens, client info, and code verifiers to one file
+  per key under `~/.mcp-use/oauth/<urlHash>/` with `0o600` perms and atomic
+  rename on write.
+
+New on `@mcp-use/cli`:
+
+- `mcp-use client connect <url>` auto-runs OAuth on `UnauthorizedError`
+  when no `--auth` is supplied. New flags: `--no-oauth`, `--auth-timeout`.
+- `mcp-use client auth status|refresh|logout [session]` for token
+  introspection, forced refresh, and revocation. (No `auth login` — that's
+  what `connect` is for.)
+- Follow-up commands (`tools list`, etc.) on OAuth sessions transparently
+  refresh expiring JWTs. If the refresh token itself is dead, the CLI
+  prompts to re-auth on TTY or prints the exact `connect` command to run
+  on non-TTY.

--- a/libraries/typescript/.changeset/node-oauth-force-refresh-and-xss.md
+++ b/libraries/typescript/.changeset/node-oauth-force-refresh-and-xss.md
@@ -1,0 +1,18 @@
+---
+"mcp-use": patch
+---
+
+fix(auth): make `forceRefresh()` actually exchange the refresh_token, and escape HTML in the loopback failure page
+
+- `NodeOAuthClientProvider.forceRefresh()` now delegates to a new
+  `OAuthSessionStore.forceRefresh()` that calls the existing dedup'd
+  refresh path directly. The previous implementation tried to coerce a
+  refresh by zeroing out `access_token` and re-reading via `tokens()`,
+  but `tokens()` gates the refresh path on a truthy `access_token`, so
+  no network call was ever made and the stale tokens were returned. This
+  is what `mcp-use client auth refresh` runs.
+- The loopback failure page (rendered when the OAuth server redirects
+  back with `?error=…`) now HTML-escapes both the `error` code and
+  `error_description` rather than only stripping `<>&` from the
+  description. Closes a low-severity reflected-XSS in the localhost
+  callback page.

--- a/libraries/typescript/.changeset/node-oauth-pending-flow-fix.md
+++ b/libraries/typescript/.changeset/node-oauth-pending-flow-fix.md
@@ -1,0 +1,24 @@
+---
+"mcp-use": patch
+"@mcp-use/cli": patch
+---
+
+fix(auth): handle SDK-initiated OAuth redirect on 401 in CLI connect
+
+The SDK's `StreamableHTTPClientTransport` auto-calls `auth()` on a 401, which
+in turn calls our `redirectToAuthorization()` — binding the loopback and
+opening the browser before the transport throws. Two fixes so the CLI's
+`connect` command picks up where the SDK left off instead of dying:
+
+- `NodeOAuthClientProvider` exposes `hasPendingFlow` so orchestrators can
+  detect that the SDK already kicked off the flow and skip straight to
+  `getAuthorizationCode()` (calling `auth()` again would throw "an
+  authorization is already in progress").
+- `mcp-use client connect`'s `runOAuthFlow` uses `hasPendingFlow` to skip
+  the duplicate `auth()` call, and `isUnauthorized` now also matches the
+  rewrapped 401 that `HttpConnector` throws (plain `Error` with `code = 401`).
+
+Without these, the first connect to an OAuth-protected server printed
+"Authentication required" and `process.exit(1)`'d before the browser
+callback returned — leaving the user staring at a "connection refused"
+loopback page.

--- a/libraries/typescript/.changeset/server-cli-connect-hint.md
+++ b/libraries/typescript/.changeset/server-cli-connect-hint.md
@@ -1,0 +1,7 @@
+---
+"mcp-use": patch
+---
+
+feat(server): print a one-line hint on startup pointing devs at the
+`mcp-use client connect <url>` CLI. Appears in dim gray right after
+the existing `[SERVER] Listening` / `[MCP] Endpoints` lines.

--- a/libraries/typescript/packages/cli/src/commands/client-auth.ts
+++ b/libraries/typescript/packages/cli/src/commands/client-auth.ts
@@ -1,0 +1,133 @@
+import {
+  formatError,
+  formatInfo,
+  formatKeyValue,
+  formatSuccess,
+} from "../utils/format.js";
+import { buildOAuthProvider } from "../utils/oauth.js";
+import { getActiveSession, getSession } from "../utils/session-storage.js";
+
+async function resolveSession(
+  sessionArg: string | undefined
+): Promise<{ name: string; url: string } | null> {
+  let name = sessionArg;
+  if (!name) {
+    const active = await getActiveSession();
+    if (!active) {
+      console.error(formatError("No active session"));
+      return null;
+    }
+    name = active.name;
+  }
+  const config = await getSession(name);
+  if (!config) {
+    console.error(formatError(`Session '${name}' not found`));
+    return null;
+  }
+  if (config.type !== "http") {
+    console.error(formatError("Auth commands only apply to HTTP sessions"));
+    return null;
+  }
+  if (config.authMode !== "oauth") {
+    console.error(
+      formatError(
+        `Session '${name}' was not authenticated via OAuth (authMode=${config.authMode ?? "bearer"})`
+      )
+    );
+    return null;
+  }
+  return { name, url: config.url! };
+}
+
+function formatExpiresIn(expSec: number): string {
+  const ms = expSec * 1000 - Date.now();
+  if (ms <= 0) return "expired";
+  const mins = Math.round(ms / 60_000);
+  if (mins < 60) return `${mins}m`;
+  const hours = Math.floor(mins / 60);
+  const rem = mins % 60;
+  return rem ? `${hours}h${rem}m` : `${hours}h`;
+}
+
+function decodeJwtExp(token: string): number | null {
+  try {
+    const parts = token.split(".");
+    if (parts.length < 2) return null;
+    const payload = JSON.parse(
+      Buffer.from(parts[1], "base64url").toString("utf-8")
+    );
+    return typeof payload.exp === "number" ? payload.exp : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function authStatusCommand(sessionArg?: string): Promise<void> {
+  const target = await resolveSession(sessionArg);
+  if (!target) {
+    process.exit(1);
+  }
+  const provider = await buildOAuthProvider(target.url);
+  const tokens = await provider.tokens();
+
+  const fields: Record<string, string> = {
+    session: target.name,
+    url: target.url,
+    tokens: tokens?.access_token ? "present" : "missing",
+  };
+  if (tokens?.scope) fields.scope = tokens.scope;
+  if (tokens?.access_token) {
+    const exp = decodeJwtExp(tokens.access_token);
+    fields.expires_in = exp ? formatExpiresIn(exp) : "unknown (opaque token)";
+  }
+  fields.refresh = tokens?.refresh_token ? "available" : "missing";
+
+  console.log(formatKeyValue(fields));
+
+  if (!tokens?.access_token) process.exit(1);
+}
+
+export async function authRefreshCommand(sessionArg?: string): Promise<void> {
+  const target = await resolveSession(sessionArg);
+  if (!target) {
+    process.exit(1);
+  }
+  const provider = await buildOAuthProvider(target.url);
+  const refreshed = await provider.forceRefresh();
+  if (!refreshed) {
+    console.error(
+      formatError(
+        "Refresh failed (no refresh_token, or server rejected). Re-connect to re-authenticate."
+      )
+    );
+    console.error(
+      formatInfo(
+        `Run: mcp-use client connect ${target.url} --name ${target.name}`
+      )
+    );
+    process.exit(1);
+  }
+  const exp = refreshed.access_token
+    ? decodeJwtExp(refreshed.access_token)
+    : null;
+  console.log(
+    formatSuccess(
+      `Refreshed access token${exp ? ` (expires in ${formatExpiresIn(exp)})` : ""}`
+    )
+  );
+}
+
+export async function authLogoutCommand(sessionArg?: string): Promise<void> {
+  const target = await resolveSession(sessionArg);
+  if (!target) {
+    process.exit(1);
+  }
+  const provider = await buildOAuthProvider(target.url);
+  await provider.invalidateCredentials("all");
+  console.log(formatSuccess(`Removed tokens for ${target.url}`));
+  console.log(
+    formatInfo(
+      `Session '${target.name}' kept; reconnect with \`mcp-use client connect\`.`
+    )
+  );
+}

--- a/libraries/typescript/packages/cli/src/commands/client.ts
+++ b/libraries/typescript/packages/cli/src/commands/client.ts
@@ -17,7 +17,9 @@ import {
   formatSuccess,
   formatTable,
   formatToolCall,
+  formatToolMode,
   formatWarning,
+  isStdoutTty,
 } from "../utils/format.js";
 import {
   buildOAuthProvider,
@@ -392,15 +394,22 @@ export async function listSessionsCommand(): Promise<void> {
     const sessions = await listAllSessions();
 
     if (sessions.length === 0) {
-      console.log(formatInfo("No saved sessions"));
-      console.log(
-        formatInfo("Connect to a server with: npx mcp-use client connect <url>")
-      );
+      if (isStdoutTty()) {
+        console.log(formatInfo("No saved sessions"));
+        console.log(
+          formatInfo(
+            "Connect to a server with: npx mcp-use client connect <url>"
+          )
+        );
+      }
       return;
     }
 
-    console.log(formatHeader("Saved Sessions:"));
-    console.log("");
+    const tty = isStdoutTty();
+    if (tty) {
+      console.log(formatHeader("Saved Sessions:"));
+      console.log("");
+    }
 
     const tableData = sessions.map((s) => ({
       name: s.isActive ? chalk.green.bold(`${s.name} *`) : s.name,
@@ -410,23 +419,21 @@ export async function listSessionsCommand(): Promise<void> {
           ? s.config.url || ""
           : `${s.config.command} ${(s.config.args || []).join(" ")}`,
       server: s.config.serverInfo?.name || "unknown",
-      status: activeSessions.has(s.name)
-        ? chalk.green("connected")
-        : chalk.gray("disconnected"),
     }));
 
     console.log(
       formatTable(tableData, [
         { key: "name", header: "Name" },
         { key: "type", header: "Type" },
-        { key: "target", header: "Target", width: 40 },
+        { key: "target", header: "Target", truncate: true },
         { key: "server", header: "Server" },
-        { key: "status", header: "Status" },
       ])
     );
 
-    console.log("");
-    console.log(chalk.gray("* = active session"));
+    if (tty) {
+      console.log("");
+      console.log(chalk.gray("* = active session"));
+    }
   } catch (error: any) {
     console.error(formatError(`Failed to list sessions: ${error.message}`));
     await cleanupAndExit(1);
@@ -467,22 +474,44 @@ export async function listToolsCommand(options: {
     if (options.json) {
       console.log(formatJson(tools));
     } else if (tools.length === 0) {
-      console.log(formatInfo("No tools available"));
+      if (isStdoutTty()) console.log(formatInfo("No tools available"));
     } else {
-      console.log(formatHeader(`Available Tools (${tools.length}):`));
-      console.log("");
+      const tty = isStdoutTty();
+      if (tty) {
+        console.log(formatHeader(`Available Tools (${tools.length}):`));
+        console.log("");
+      }
 
-      const tableData = tools.map((tool) => ({
-        name: chalk.bold(tool.name),
-        description: tool.description || chalk.gray("No description"),
-      }));
+      const tableData = tools.map((tool) => {
+        const props = (tool.inputSchema as any)?.properties ?? {};
+        const required = (tool.inputSchema as any)?.required ?? [];
+        const total = Object.keys(props).length;
+        const reqCount = Array.isArray(required) ? required.length : 0;
+        const argsCell =
+          total === 0 ? chalk.gray("—") : `${reqCount}/${total}`;
+        return {
+          name: chalk.bold(tool.name),
+          mode: formatToolMode((tool as any).annotations),
+          args: argsCell,
+          description: tool.description || chalk.gray("(no description)"),
+        };
+      });
 
       console.log(
         formatTable(tableData, [
-          { key: "name", header: "Tool", width: 25 },
-          { key: "description", header: "Description", width: 50 },
+          { key: "name", header: "Tool" },
+          { key: "mode", header: "Mode" },
+          { key: "args", header: "Args" },
+          { key: "description", header: "Description", truncate: true },
         ])
       );
+
+      if (tty) {
+        console.log("");
+        console.log(
+          chalk.gray("ARGS shows required/total. Modes: read-only · write · destructive.")
+        );
+      }
     }
   } catch (error: any) {
     console.error(formatError(`Failed to list tools: ${error.message}`));
@@ -625,22 +654,27 @@ export async function listResourcesCommand(options: {
     if (options.json) {
       console.log(formatJson(resources));
     } else if (resources.length === 0) {
-      console.log(formatInfo("No resources available"));
+      if (isStdoutTty()) console.log(formatInfo("No resources available"));
     } else {
-      console.log(formatHeader(`Available Resources (${resources.length}):`));
-      console.log("");
+      const tty = isStdoutTty();
+      if (tty) {
+        console.log(
+          formatHeader(`Available Resources (${resources.length}):`)
+        );
+        console.log("");
+      }
 
       const tableData = resources.map((resource) => ({
-        uri: resource.uri,
-        name: resource.name || chalk.gray("(no name)"),
+        name: chalk.bold(resource.name || "(no name)"),
         type: resource.mimeType || chalk.gray("unknown"),
+        uri: resource.uri,
       }));
 
       console.log(
         formatTable(tableData, [
-          { key: "uri", header: "URI", width: 40 },
-          { key: "name", header: "Name", width: 20 },
-          { key: "type", header: "Type", width: 15 },
+          { key: "name", header: "Name" },
+          { key: "type", header: "Type" },
+          { key: "uri", header: "URI", truncate: true },
         ])
       );
     }
@@ -769,20 +803,33 @@ export async function listPromptsCommand(options: {
     if (options.json) {
       console.log(formatJson(prompts));
     } else if (prompts.length === 0) {
-      console.log(formatInfo("No prompts available"));
+      if (isStdoutTty()) console.log(formatInfo("No prompts available"));
     } else {
-      console.log(formatHeader(`Available Prompts (${prompts.length}):`));
-      console.log("");
+      const tty = isStdoutTty();
+      if (tty) {
+        console.log(formatHeader(`Available Prompts (${prompts.length}):`));
+        console.log("");
+      }
 
-      const tableData = prompts.map((prompt) => ({
-        name: chalk.bold(prompt.name),
-        description: prompt.description || chalk.gray("No description"),
-      }));
+      const tableData = prompts.map((prompt) => {
+        const args = (prompt as any).arguments ?? [];
+        const reqCount = Array.isArray(args)
+          ? args.filter((a: any) => a?.required).length
+          : 0;
+        const total = Array.isArray(args) ? args.length : 0;
+        const argsCell = total === 0 ? chalk.gray("—") : `${reqCount}/${total}`;
+        return {
+          name: chalk.bold(prompt.name),
+          args: argsCell,
+          description: prompt.description || chalk.gray("(no description)"),
+        };
+      });
 
       console.log(
         formatTable(tableData, [
-          { key: "name", header: "Prompt", width: 25 },
-          { key: "description", header: "Description", width: 50 },
+          { key: "name", header: "Prompt" },
+          { key: "args", header: "Args" },
+          { key: "description", header: "Description", truncate: true },
         ])
       );
     }

--- a/libraries/typescript/packages/cli/src/commands/client.ts
+++ b/libraries/typescript/packages/cli/src/commands/client.ts
@@ -21,6 +21,7 @@ import {
   formatWarning,
   isStdoutTty,
 } from "../utils/format.js";
+import { parsePromptArgs, parseToolArgs } from "../utils/parse-args.js";
 import {
   buildOAuthProvider,
   isUnauthorized,
@@ -487,8 +488,7 @@ export async function listToolsCommand(options: {
         const required = (tool.inputSchema as any)?.required ?? [];
         const total = Object.keys(props).length;
         const reqCount = Array.isArray(required) ? required.length : 0;
-        const argsCell =
-          total === 0 ? chalk.gray("—") : `${reqCount}/${total}`;
+        const argsCell = total === 0 ? chalk.gray("—") : `${reqCount}/${total}`;
         return {
           name: chalk.bold(tool.name),
           mode: formatToolMode((tool as any).annotations),
@@ -509,7 +509,9 @@ export async function listToolsCommand(options: {
       if (tty) {
         console.log("");
         console.log(
-          chalk.gray("ARGS shows required/total. Modes: read-only · write · destructive.")
+          chalk.gray(
+            "ARGS shows required/total. Modes: read-only · write · destructive."
+          )
         );
       }
     }
@@ -569,7 +571,7 @@ export async function describeToolCommand(
  */
 export async function callToolCommand(
   toolName: string,
-  argsJson?: string,
+  argsList?: string[],
   options?: { session?: string; timeout?: number; json?: boolean }
 ): Promise<void> {
   try {
@@ -580,36 +582,48 @@ export async function callToolCommand(
 
     const { session } = result!;
 
-    // Parse arguments
-    let args: Record<string, any> = {};
-    if (argsJson) {
-      try {
-        args = JSON.parse(argsJson);
-      } catch (error) {
-        console.error(formatError("Invalid JSON arguments"));
-        await cleanupAndExit(1);
-      }
-    } else {
-      // Check if tool requires arguments
-      const tools = session.tools;
-      const tool = tools.find((t) => t.name === toolName);
+    const tools = session.tools;
+    const tool = tools.find((t) => t.name === toolName);
 
-      if (tool?.inputSchema?.required && tool.inputSchema.required.length > 0) {
-        console.error(
-          formatError(
-            "This tool requires arguments. Provide them as a JSON string."
-          )
-        );
+    // Parse arguments: key=value pairs, key:=jsonvalue, or a single JSON object
+    let args: Record<string, unknown> = {};
+    if (argsList && argsList.length > 0) {
+      try {
+        args = parseToolArgs(argsList, tool?.inputSchema as any);
+      } catch (error: any) {
+        console.error(formatError(error.message));
         console.log("");
-        console.log(formatInfo("Example:"));
+        console.log(formatInfo("Usage:"));
         console.log(
-          `  npx mcp-use client tools call ${toolName} '{"param": "value"}'`
+          `  npx mcp-use client tools call ${toolName} key=value [key2=value2 ...]`
         );
-        console.log("");
-        console.log(formatInfo("Tool schema:"));
-        console.log(formatSchema(tool.inputSchema));
+        console.log(
+          `  npx mcp-use client tools call ${toolName} nested:='{"a":1}'   # JSON value`
+        );
+        console.log(
+          `  npx mcp-use client tools call ${toolName} '{"key":"value"}'   # full JSON object`
+        );
+        if (tool?.inputSchema) {
+          console.log("");
+          console.log(formatInfo("Tool schema:"));
+          console.log(formatSchema(tool.inputSchema));
+        }
         await cleanupAndExit(1);
       }
+    } else if (
+      tool?.inputSchema?.required &&
+      tool.inputSchema.required.length > 0
+    ) {
+      console.error(formatError("This tool requires arguments."));
+      console.log("");
+      console.log(formatInfo("Provide arguments as key=value pairs:"));
+      console.log(
+        `  npx mcp-use client tools call ${toolName} key=value [key2=value2 ...]`
+      );
+      console.log("");
+      console.log(formatInfo("Tool schema:"));
+      console.log(formatSchema(tool.inputSchema));
+      await cleanupAndExit(1);
     }
 
     // Call the tool
@@ -658,9 +672,7 @@ export async function listResourcesCommand(options: {
     } else {
       const tty = isStdoutTty();
       if (tty) {
-        console.log(
-          formatHeader(`Available Resources (${resources.length}):`)
-        );
+        console.log(formatHeader(`Available Resources (${resources.length}):`));
         console.log("");
       }
 
@@ -845,7 +857,7 @@ export async function listPromptsCommand(options: {
  */
 export async function getPromptCommand(
   promptName: string,
-  argsJson?: string,
+  argsList?: string[],
   options?: { session?: string; json?: boolean }
 ): Promise<void> {
   try {
@@ -856,13 +868,21 @@ export async function getPromptCommand(
 
     const { session } = result!;
 
-    // Parse arguments
-    let args: Record<string, any> = {};
-    if (argsJson) {
+    // Parse arguments: key=value pairs or a single JSON object
+    let args: Record<string, string> = {};
+    if (argsList && argsList.length > 0) {
       try {
-        args = JSON.parse(argsJson);
-      } catch (error) {
-        console.error(formatError("Invalid JSON arguments"));
+        args = parsePromptArgs(argsList);
+      } catch (error: any) {
+        console.error(formatError(error.message));
+        console.log("");
+        console.log(formatInfo("Usage:"));
+        console.log(
+          `  npx mcp-use client prompts get ${promptName} key=value [key2=value2 ...]`
+        );
+        console.log(
+          `  npx mcp-use client prompts get ${promptName} '{"key":"value"}'   # full JSON object`
+        );
         await cleanupAndExit(1);
       }
     }
@@ -1152,8 +1172,10 @@ export function createClientCommand(): Command {
     .option("--json", "Output as JSON")
     .action(listToolsCommand);
   toolsCommand
-    .command("call <name> [args]")
-    .description("Call a tool with arguments (JSON string)")
+    .command("call <name> [args...]")
+    .description(
+      "Call a tool. Args as key=value pairs (use key:=<json> for nested values, or pass a JSON object)"
+    )
     .option("--session <name>", "Use specific session")
     .option("--timeout <ms>", "Request timeout in milliseconds", parseInt)
     .option("--json", "Output as JSON")
@@ -1204,8 +1226,10 @@ export function createClientCommand(): Command {
     .option("--json", "Output as JSON")
     .action(listPromptsCommand);
   promptsCommand
-    .command("get <name> [args]")
-    .description("Get a prompt with arguments (JSON string)")
+    .command("get <name> [args...]")
+    .description(
+      "Get a prompt. Args as key=value pairs (or pass a JSON object)"
+    )
     .option("--session <name>", "Use specific session")
     .option("--json", "Output as JSON")
     .action(getPromptCommand);

--- a/libraries/typescript/packages/cli/src/commands/client.ts
+++ b/libraries/typescript/packages/cli/src/commands/client.ts
@@ -3,6 +3,7 @@ import { Command } from "commander";
 import type { MCPSession } from "mcp-use/client";
 import { MCPClient } from "mcp-use/client";
 import { getPackageVersion } from "mcp-use/server";
+import type { NodeOAuthClientProvider } from "mcp-use/auth/node";
 import { createInterface } from "node:readline";
 import {
   formatError,
@@ -19,6 +20,12 @@ import {
   formatWarning,
 } from "../utils/format.js";
 import {
+  buildOAuthProvider,
+  isUnauthorized,
+  promptYesNo,
+  runOAuthFlow,
+} from "../utils/oauth.js";
+import {
   getActiveSession,
   getSession,
   listAllSessions,
@@ -26,6 +33,11 @@ import {
   setActiveSession,
   updateSessionInfo,
 } from "../utils/session-storage.js";
+import {
+  authStatusCommand,
+  authRefreshCommand,
+  authLogoutCommand,
+} from "./client-auth.js";
 
 // In-memory session map
 const activeSessions = new Map<
@@ -34,7 +46,31 @@ const activeSessions = new Map<
 >();
 
 /**
- * Get or restore a session by name
+ * Close every in-memory session and exit with `code`.
+ *
+ * Each `client` subcommand opens a fresh transport per process invocation,
+ * which keeps an HTTP/SSE socket alive after the command returns. Without
+ * this, the Node event loop never goes idle and headless agents hang. We
+ * call `closeAllSessions()` so the server sees a clean disconnect, then
+ * force-exit to guarantee termination even if the SDK transport leaves
+ * stray handles.
+ */
+async function cleanupAndExit(code: number): Promise<never> {
+  for (const [name, { client }] of activeSessions) {
+    try {
+      await client.closeAllSessions();
+    } catch {
+      // best-effort: we're exiting anyway
+    }
+    activeSessions.delete(name);
+  }
+  process.exit(code);
+}
+
+/**
+ * Get or restore a session by name. For OAuth-mode sessions whose tokens
+ * have expired and can't be refreshed, prompts to re-auth on TTY or prints
+ * a clear `connect` command to re-run on non-TTY.
  */
 async function getOrRestoreSession(
   sessionName: string | null
@@ -67,19 +103,28 @@ async function getOrRestoreSession(
     return null;
   }
 
-  // Reconnect
   try {
     const client = new MCPClient();
     const cliClientInfo = getCliClientInfo();
+    let authProvider: NodeOAuthClientProvider | undefined;
 
     if (config.type === "http") {
-      client.addServer(sessionName, {
-        url: config.url!,
-        headers: config.authToken
-          ? { Authorization: `Bearer ${config.authToken}` }
-          : undefined,
-        clientInfo: cliClientInfo,
-      });
+      if (config.authMode === "oauth") {
+        authProvider = await buildOAuthProvider(config.url!);
+        client.addServer(sessionName, {
+          url: config.url!,
+          authProvider,
+          clientInfo: cliClientInfo,
+        });
+      } else {
+        client.addServer(sessionName, {
+          url: config.url!,
+          headers: config.authToken
+            ? { Authorization: `Bearer ${config.authToken}` }
+            : undefined,
+          clientInfo: cliClientInfo,
+        });
+      }
     } else if (config.type === "stdio") {
       client.addServer(sessionName, {
         command: config.command!,
@@ -92,9 +137,38 @@ async function getOrRestoreSession(
       return null;
     }
 
-    const session = await client.createSession(sessionName);
-    activeSessions.set(sessionName, { client, session });
+    let session: MCPSession;
+    try {
+      session = await client.createSession(sessionName);
+    } catch (err) {
+      // OAuth-only fallback: tokens expired and refresh failed → re-auth.
+      if (
+        config.type === "http" &&
+        config.authMode === "oauth" &&
+        authProvider &&
+        isUnauthorized(err)
+      ) {
+        const reAuth = await promptYesNo(
+          `! Tokens for session '${sessionName}' expired and could not refresh. Re-authenticate now?`,
+          true
+        );
+        if (!reAuth) {
+          console.error(formatError(`Tokens expired and could not refresh.`));
+          console.error(
+            formatInfo(
+              `Run: mcp-use client connect ${config.url} --name ${sessionName}`
+            )
+          );
+          return null;
+        }
+        await runOAuthFlow(authProvider, config.url!);
+        session = await client.createSession(sessionName);
+      } else {
+        throw err;
+      }
+    }
 
+    activeSessions.set(sessionName, { client, session });
     console.error(formatInfo(`Reconnected to session '${sessionName}'`));
     return { name: sessionName, session };
   } catch (error: any) {
@@ -130,6 +204,8 @@ export async function connectCommand(
     name?: string;
     stdio?: boolean;
     auth?: string;
+    oauth?: boolean;
+    authTimeout?: string;
   }
 ): Promise<void> {
   try {
@@ -168,21 +244,53 @@ export async function connectCommand(
       // HTTP connection
       console.error(formatInfo(`Connecting to ${urlOrCommand}...`));
 
+      // Static --auth bypasses OAuth entirely. `--no-oauth` disables auto-OAuth
+      // on 401 (commander maps `--no-oauth` to options.oauth === false).
+      const wantOAuth = !options.auth && options.oauth !== false;
+      let authProvider: NodeOAuthClientProvider | undefined;
+      if (wantOAuth) {
+        const authTimeoutMs = options.authTimeout
+          ? Number.parseInt(options.authTimeout, 10)
+          : undefined;
+        authProvider = await buildOAuthProvider(urlOrCommand, {
+          ...(authTimeoutMs ? { authTimeoutMs } : {}),
+        });
+      }
+
       client.addServer(sessionName, {
         url: urlOrCommand,
-        headers: options.auth
-          ? { Authorization: `Bearer ${options.auth}` }
-          : undefined,
+        ...(authProvider
+          ? { authProvider }
+          : options.auth
+            ? { headers: { Authorization: `Bearer ${options.auth}` } }
+            : {}),
         clientInfo: cliClientInfo,
       });
 
-      session = await client.createSession(sessionName);
+      try {
+        session = await client.createSession(sessionName);
+      } catch (err) {
+        if (authProvider && isUnauthorized(err)) {
+          console.error(
+            formatWarning(
+              "Server requires authentication. Starting OAuth flow."
+            )
+          );
+          await runOAuthFlow(authProvider, urlOrCommand);
+          console.error(formatSuccess("Authentication successful"));
+          // Provider has tokens now; the SDK will pick them up on retry.
+          session = await client.createSession(sessionName);
+        } else {
+          throw err;
+        }
+      }
 
       // Save session config
       await saveSession(sessionName, {
         type: "http",
         url: urlOrCommand,
-        authToken: options.auth,
+        authMode: authProvider ? "oauth" : options.auth ? "bearer" : undefined,
+        authToken: authProvider ? undefined : options.auth,
         lastUsed: new Date().toISOString(),
       });
     }
@@ -229,8 +337,9 @@ export async function connectCommand(
     );
   } catch (error: any) {
     console.error(formatError(`Connection failed: ${error.message}`));
-    process.exit(1);
+    await cleanupAndExit(1);
   }
+  await cleanupAndExit(0);
 }
 
 /**
@@ -248,16 +357,16 @@ export async function disconnectCommand(
         activeSessions.delete(name);
         console.log(formatSuccess(`Disconnected from ${name}`));
       }
-      return;
+      await cleanupAndExit(0);
     }
 
     if (!sessionName) {
       const active = await getActiveSession();
       if (!active) {
         console.error(formatError("No active session to disconnect"));
-        return;
+        await cleanupAndExit(0);
       }
-      sessionName = active.name;
+      sessionName = active!.name;
     }
 
     const sessionData = activeSessions.get(sessionName);
@@ -270,8 +379,9 @@ export async function disconnectCommand(
     }
   } catch (error: any) {
     console.error(formatError(`Failed to disconnect: ${error.message}`));
-    process.exit(1);
+    await cleanupAndExit(1);
   }
+  await cleanupAndExit(0);
 }
 
 /**
@@ -319,8 +429,9 @@ export async function listSessionsCommand(): Promise<void> {
     console.log(chalk.gray("* = active session"));
   } catch (error: any) {
     console.error(formatError(`Failed to list sessions: ${error.message}`));
-    process.exit(1);
+    await cleanupAndExit(1);
   }
+  await cleanupAndExit(0);
 }
 
 /**
@@ -332,8 +443,9 @@ export async function switchSessionCommand(name: string): Promise<void> {
     console.log(formatSuccess(`Switched to session '${name}'`));
   } catch (error: any) {
     console.error(formatError(`Failed to switch session: ${error.message}`));
-    process.exit(1);
+    await cleanupAndExit(1);
   }
+  await cleanupAndExit(0);
 }
 
 /**
@@ -345,39 +457,38 @@ export async function listToolsCommand(options: {
 }): Promise<void> {
   try {
     const result = await getOrRestoreSession(options.session || null);
-    if (!result) return;
+    if (!result) {
+      await cleanupAndExit(1);
+    }
 
-    const { session } = result;
+    const { session } = result!;
     const tools = await session.listTools();
 
     if (options.json) {
       console.log(formatJson(tools));
-      return;
-    }
-
-    if (tools.length === 0) {
+    } else if (tools.length === 0) {
       console.log(formatInfo("No tools available"));
-      return;
+    } else {
+      console.log(formatHeader(`Available Tools (${tools.length}):`));
+      console.log("");
+
+      const tableData = tools.map((tool) => ({
+        name: chalk.bold(tool.name),
+        description: tool.description || chalk.gray("No description"),
+      }));
+
+      console.log(
+        formatTable(tableData, [
+          { key: "name", header: "Tool", width: 25 },
+          { key: "description", header: "Description", width: 50 },
+        ])
+      );
     }
-
-    console.log(formatHeader(`Available Tools (${tools.length}):`));
-    console.log("");
-
-    const tableData = tools.map((tool) => ({
-      name: chalk.bold(tool.name),
-      description: tool.description || chalk.gray("No description"),
-    }));
-
-    console.log(
-      formatTable(tableData, [
-        { key: "name", header: "Tool", width: 25 },
-        { key: "description", header: "Description", width: 50 },
-      ])
-    );
   } catch (error: any) {
     console.error(formatError(`Failed to list tools: ${error.message}`));
-    process.exit(1);
+    await cleanupAndExit(1);
   }
+  await cleanupAndExit(0);
 }
 
 /**
@@ -389,9 +500,11 @@ export async function describeToolCommand(
 ): Promise<void> {
   try {
     const result = await getOrRestoreSession(options.session || null);
-    if (!result) return;
+    if (!result) {
+      await cleanupAndExit(1);
+    }
 
-    const { session } = result;
+    const { session } = result!;
     const tools = session.tools;
     const tool = tools.find((t) => t.name === toolName);
 
@@ -400,25 +513,26 @@ export async function describeToolCommand(
       console.log("");
       console.log(formatInfo("Available tools:"));
       tools.forEach((t) => console.log(`  • ${t.name}`));
-      return;
+      await cleanupAndExit(1);
     }
 
-    console.log(formatHeader(`Tool: ${tool.name}`));
+    console.log(formatHeader(`Tool: ${tool!.name}`));
     console.log("");
 
-    if (tool.description) {
-      console.log(tool.description);
+    if (tool!.description) {
+      console.log(tool!.description);
       console.log("");
     }
 
-    if (tool.inputSchema) {
+    if (tool!.inputSchema) {
       console.log(formatHeader("Input Schema:"));
-      console.log(formatSchema(tool.inputSchema));
+      console.log(formatSchema(tool!.inputSchema));
     }
   } catch (error: any) {
     console.error(formatError(`Failed to describe tool: ${error.message}`));
-    process.exit(1);
+    await cleanupAndExit(1);
   }
+  await cleanupAndExit(0);
 }
 
 /**
@@ -431,9 +545,11 @@ export async function callToolCommand(
 ): Promise<void> {
   try {
     const result = await getOrRestoreSession(options?.session || null);
-    if (!result) return;
+    if (!result) {
+      await cleanupAndExit(1);
+    }
 
-    const { session } = result;
+    const { session } = result!;
 
     // Parse arguments
     let args: Record<string, any> = {};
@@ -442,7 +558,7 @@ export async function callToolCommand(
         args = JSON.parse(argsJson);
       } catch (error) {
         console.error(formatError("Invalid JSON arguments"));
-        return;
+        await cleanupAndExit(1);
       }
     } else {
       // Check if tool requires arguments
@@ -463,7 +579,7 @@ export async function callToolCommand(
         console.log("");
         console.log(formatInfo("Tool schema:"));
         console.log(formatSchema(tool.inputSchema));
-        return;
+        await cleanupAndExit(1);
       }
     }
 
@@ -480,8 +596,9 @@ export async function callToolCommand(
     }
   } catch (error: any) {
     console.error(formatError(`Failed to call tool: ${error.message}`));
-    process.exit(1);
+    await cleanupAndExit(1);
   }
+  await cleanupAndExit(0);
 }
 
 /**
@@ -493,42 +610,41 @@ export async function listResourcesCommand(options: {
 }): Promise<void> {
   try {
     const result = await getOrRestoreSession(options.session || null);
-    if (!result) return;
+    if (!result) {
+      await cleanupAndExit(1);
+    }
 
-    const { session } = result;
+    const { session } = result!;
     const resourcesResult = await session.listAllResources();
     const resources = resourcesResult.resources;
 
     if (options.json) {
       console.log(formatJson(resources));
-      return;
-    }
-
-    if (resources.length === 0) {
+    } else if (resources.length === 0) {
       console.log(formatInfo("No resources available"));
-      return;
+    } else {
+      console.log(formatHeader(`Available Resources (${resources.length}):`));
+      console.log("");
+
+      const tableData = resources.map((resource) => ({
+        uri: resource.uri,
+        name: resource.name || chalk.gray("(no name)"),
+        type: resource.mimeType || chalk.gray("unknown"),
+      }));
+
+      console.log(
+        formatTable(tableData, [
+          { key: "uri", header: "URI", width: 40 },
+          { key: "name", header: "Name", width: 20 },
+          { key: "type", header: "Type", width: 15 },
+        ])
+      );
     }
-
-    console.log(formatHeader(`Available Resources (${resources.length}):`));
-    console.log("");
-
-    const tableData = resources.map((resource) => ({
-      uri: resource.uri,
-      name: resource.name || chalk.gray("(no name)"),
-      type: resource.mimeType || chalk.gray("unknown"),
-    }));
-
-    console.log(
-      formatTable(tableData, [
-        { key: "uri", header: "URI", width: 40 },
-        { key: "name", header: "Name", width: 20 },
-        { key: "type", header: "Type", width: 15 },
-      ])
-    );
   } catch (error: any) {
     console.error(formatError(`Failed to list resources: ${error.message}`));
-    process.exit(1);
+    await cleanupAndExit(1);
   }
+  await cleanupAndExit(0);
 }
 
 /**
@@ -540,9 +656,11 @@ export async function readResourceCommand(
 ): Promise<void> {
   try {
     const result = await getOrRestoreSession(options.session || null);
-    if (!result) return;
+    if (!result) {
+      await cleanupAndExit(1);
+    }
 
-    const { session } = result;
+    const { session } = result!;
 
     console.error(formatInfo(`Reading resource: ${uri}`));
     const resource = await session.readResource(uri);
@@ -554,8 +672,9 @@ export async function readResourceCommand(
     }
   } catch (error: any) {
     console.error(formatError(`Failed to read resource: ${error.message}`));
-    process.exit(1);
+    await cleanupAndExit(1);
   }
+  await cleanupAndExit(0);
 }
 
 /**
@@ -565,11 +684,16 @@ export async function subscribeResourceCommand(
   uri: string,
   options: { session?: string }
 ): Promise<void> {
+  // Subscribe is intentionally long-lived: it keeps the process alive to
+  // receive notifications until Ctrl+C. Don't run cleanupAndExit on the
+  // success path — only on error.
   try {
     const result = await getOrRestoreSession(options.session || null);
-    if (!result) return;
+    if (!result) {
+      await cleanupAndExit(1);
+    }
 
-    const { session } = result;
+    const { session } = result!;
 
     await session.subscribeToResource(uri);
     console.log(formatSuccess(`Subscribed to resource: ${uri}`));
@@ -591,7 +715,7 @@ export async function subscribeResourceCommand(
     console.error(
       formatError(`Failed to subscribe to resource: ${error.message}`)
     );
-    process.exit(1);
+    await cleanupAndExit(1);
   }
 }
 
@@ -604,9 +728,11 @@ export async function unsubscribeResourceCommand(
 ): Promise<void> {
   try {
     const result = await getOrRestoreSession(options.session || null);
-    if (!result) return;
+    if (!result) {
+      await cleanupAndExit(1);
+    }
 
-    const { session } = result;
+    const { session } = result!;
 
     await session.unsubscribeFromResource(uri);
     console.log(formatSuccess(`Unsubscribed from resource: ${uri}`));
@@ -614,8 +740,9 @@ export async function unsubscribeResourceCommand(
     console.error(
       formatError(`Failed to unsubscribe from resource: ${error.message}`)
     );
-    process.exit(1);
+    await cleanupAndExit(1);
   }
+  await cleanupAndExit(0);
 }
 
 /**
@@ -627,40 +754,39 @@ export async function listPromptsCommand(options: {
 }): Promise<void> {
   try {
     const result = await getOrRestoreSession(options.session || null);
-    if (!result) return;
+    if (!result) {
+      await cleanupAndExit(1);
+    }
 
-    const { session } = result;
+    const { session } = result!;
     const promptsResult = await session.listPrompts();
     const prompts = promptsResult.prompts;
 
     if (options.json) {
       console.log(formatJson(prompts));
-      return;
-    }
-
-    if (prompts.length === 0) {
+    } else if (prompts.length === 0) {
       console.log(formatInfo("No prompts available"));
-      return;
+    } else {
+      console.log(formatHeader(`Available Prompts (${prompts.length}):`));
+      console.log("");
+
+      const tableData = prompts.map((prompt) => ({
+        name: chalk.bold(prompt.name),
+        description: prompt.description || chalk.gray("No description"),
+      }));
+
+      console.log(
+        formatTable(tableData, [
+          { key: "name", header: "Prompt", width: 25 },
+          { key: "description", header: "Description", width: 50 },
+        ])
+      );
     }
-
-    console.log(formatHeader(`Available Prompts (${prompts.length}):`));
-    console.log("");
-
-    const tableData = prompts.map((prompt) => ({
-      name: chalk.bold(prompt.name),
-      description: prompt.description || chalk.gray("No description"),
-    }));
-
-    console.log(
-      formatTable(tableData, [
-        { key: "name", header: "Prompt", width: 25 },
-        { key: "description", header: "Description", width: 50 },
-      ])
-    );
   } catch (error: any) {
     console.error(formatError(`Failed to list prompts: ${error.message}`));
-    process.exit(1);
+    await cleanupAndExit(1);
   }
+  await cleanupAndExit(0);
 }
 
 /**
@@ -673,9 +799,11 @@ export async function getPromptCommand(
 ): Promise<void> {
   try {
     const result = await getOrRestoreSession(options?.session || null);
-    if (!result) return;
+    if (!result) {
+      await cleanupAndExit(1);
+    }
 
-    const { session } = result;
+    const { session } = result!;
 
     // Parse arguments
     let args: Record<string, any> = {};
@@ -684,7 +812,7 @@ export async function getPromptCommand(
         args = JSON.parse(argsJson);
       } catch (error) {
         console.error(formatError("Invalid JSON arguments"));
-        return;
+        await cleanupAndExit(1);
       }
     }
 
@@ -710,8 +838,9 @@ export async function getPromptCommand(
     }
   } catch (error: any) {
     console.error(formatError(`Failed to get prompt: ${error.message}`));
-    process.exit(1);
+    await cleanupAndExit(1);
   }
+  await cleanupAndExit(0);
 }
 
 /**
@@ -774,7 +903,7 @@ export async function interactiveCommand(options: {
       if (trimmed === "exit" || trimmed === "quit") {
         console.log(formatInfo("Goodbye!"));
         rl.close();
-        process.exit(0);
+        await cleanupAndExit(0);
       }
 
       const parts = trimmed.split(" ");
@@ -903,16 +1032,16 @@ export async function interactiveCommand(options: {
       rl.prompt();
     });
 
-    rl.on("close", () => {
+    rl.on("close", async () => {
       console.log("");
       console.log(formatInfo("Goodbye!"));
-      process.exit(0);
+      await cleanupAndExit(0);
     });
   } catch (error: any) {
     console.error(
       formatError(`Failed to start interactive mode: ${error.message}`)
     );
-    process.exit(1);
+    await cleanupAndExit(1);
   }
 }
 
@@ -930,7 +1059,15 @@ export function createClientCommand(): Command {
     .description("Connect to an MCP server")
     .option("--name <name>", "Session name")
     .option("--stdio", "Use stdio connector instead of HTTP")
-    .option("--auth <token>", "Authentication token")
+    .option("--auth <token>", "Static Bearer token (skips OAuth)")
+    .option(
+      "--no-oauth",
+      "Don't auto-trigger OAuth on 401; fail with the 401 instead"
+    )
+    .option(
+      "--auth-timeout <ms>",
+      "OAuth loopback wait timeout in ms (default 300000)"
+    )
     .action(connectCommand);
 
   clientCommand
@@ -1029,6 +1166,24 @@ export function createClientCommand(): Command {
     .description("Start interactive REPL mode")
     .option("--session <name>", "Use specific session")
     .action(interactiveCommand);
+
+  // Auth scope (OAuth introspection / refresh / logout)
+  const authCommand = new Command("auth").description(
+    "Manage OAuth tokens for HTTP sessions"
+  );
+  authCommand
+    .command("status [session]")
+    .description("Show OAuth token status for a session")
+    .action(authStatusCommand);
+  authCommand
+    .command("refresh [session]")
+    .description("Force-refresh the OAuth access token")
+    .action(authRefreshCommand);
+  authCommand
+    .command("logout [session]")
+    .description("Remove stored OAuth tokens for the session's URL")
+    .action(authLogoutCommand);
+  clientCommand.addCommand(authCommand);
 
   return clientCommand;
 }

--- a/libraries/typescript/packages/cli/src/commands/client.ts
+++ b/libraries/typescript/packages/cli/src/commands/client.ts
@@ -643,6 +643,13 @@ export async function callToolCommand(
     }
   } catch (error: any) {
     console.error(formatError(`Failed to call tool: ${error.message}`));
+    if (error?.data !== undefined) {
+      console.error(
+        chalk.gray(
+          typeof error.data === "string" ? error.data : formatJson(error.data)
+        )
+      );
+    }
     await cleanupAndExit(1);
   }
   await cleanupAndExit(0);

--- a/libraries/typescript/packages/cli/src/commands/client.ts
+++ b/libraries/typescript/packages/cli/src/commands/client.ts
@@ -594,6 +594,10 @@ export async function callToolCommand(
     } else {
       console.log(formatToolCall(callResult));
     }
+
+    if (callResult.isError) {
+      await cleanupAndExit(1);
+    }
   } catch (error: any) {
     console.error(formatError(`Failed to call tool: ${error.message}`));
     await cleanupAndExit(1);

--- a/libraries/typescript/packages/cli/src/utils/format.ts
+++ b/libraries/typescript/packages/cli/src/utils/format.ts
@@ -1,70 +1,173 @@
 import chalk from "chalk";
 import type { CallToolResult } from "mcp-use/client";
 
+const ANSI_RE = /\x1b\[[0-9;]*m/g;
+const GUTTER = "  ";
+const MIN_TRUNCATABLE_WIDTH = 8;
+const DEFAULT_MAX_WIDTH = 100;
+
+function stripAnsi(s: string): string {
+  return s.replace(ANSI_RE, "");
+}
+
+function visibleWidth(s: string): number {
+  return stripAnsi(s).length;
+}
+
+function padCell(s: string, width: number): string {
+  const w = visibleWidth(s);
+  if (w >= width) return s;
+  return s + " ".repeat(width - w);
+}
+
+function truncateCell(s: string, width: number): string {
+  if (width <= 0) return "";
+  const plain = stripAnsi(s);
+  if (plain.length <= width) return s;
+  if (width === 1) return "…";
+  return plain.slice(0, width - 1) + "…";
+}
+
+export interface TableColumn {
+  key: string;
+  header: string;
+  width?: number;
+  truncate?: boolean;
+}
+
+export interface FormatTableOptions {
+  /**
+   * Force TSV output regardless of TTY detection. When undefined, auto-detects:
+   * non-TTY stdout (pipes, agents, CI) gets TSV; TTY gets the borderless table.
+   */
+  tsv?: boolean;
+  /**
+   * Maximum total line width for the table. Defaults to the terminal width
+   * (process.stdout.columns) or 100 when unavailable.
+   */
+  maxWidth?: number;
+}
+
 /**
- * Format data as a table with ASCII borders
+ * Render rows as either a borderless aligned-columns table (TTY, gh-style)
+ * or tab-separated values (non-TTY, machine-readable). Width math strips
+ * ANSI escape sequences so colored cells align correctly.
  */
 export function formatTable(
   data: Array<Record<string, any>>,
-  columns: Array<{ key: string; header: string; width?: number }>
+  columns: TableColumn[],
+  options: FormatTableOptions = {}
 ): string {
+  const tsv = options.tsv ?? !process.stdout.isTTY;
+
+  if (tsv) {
+    return data
+      .map((row) =>
+        columns
+          .map((c) =>
+            stripAnsi(String(row[c.key] ?? "")).replace(/[\t\r\n]+/g, " ")
+          )
+          .join("\t")
+      )
+      .join("\n");
+  }
+
   if (data.length === 0) {
     return chalk.gray("No items found");
   }
 
-  // Calculate column widths
-  const widths = columns.map((col) => {
-    const maxDataWidth = Math.max(
-      ...data.map((row) => String(row[col.key] || "").length)
-    );
-    const headerWidth = col.header.length;
-    return col.width || Math.max(maxDataWidth, headerWidth, 10);
+  const maxWidth = options.maxWidth ?? process.stdout.columns ?? DEFAULT_MAX_WIDTH;
+
+  // Natural width = max(header width, widest cell), per column.
+  const natural = columns.map((col) => {
+    const headerW = col.header.length;
+    const dataW = data.reduce((m, row) => {
+      return Math.max(m, visibleWidth(String(row[col.key] ?? "")));
+    }, 0);
+    return Math.max(headerW, dataW);
   });
 
-  // Helper to create a row
-  const createRow = (values: string[], bold = false) => {
-    const cells = values.map((val, i) => {
-      const padded = val.padEnd(widths[i]);
-      return bold ? chalk.bold(padded) : padded;
-    });
-    return `│ ${cells.join(" │ ")} │`;
-  };
+  const widths = columns.map((c, i) => c.width ?? natural[i]);
+  const overhead = GUTTER.length * (columns.length - 1);
+  const totalWidth = () => widths.reduce((s, w) => s + w, 0) + overhead;
 
-  // Create separator line
-  const separator = (char: string) => {
-    const parts = widths.map((w) => char.repeat(w + 2));
-    if (char === "─") {
-      return `├${parts.join("┼")}┤`;
+  // If the natural layout overflows, squeeze truncatable columns proportionally
+  // to their natural size. Non-truncatable columns keep their full width.
+  if (totalWidth() > maxWidth) {
+    const truncIdxs = columns
+      .map((c, i) => (c.truncate ? i : -1))
+      .filter((i) => i >= 0);
+    if (truncIdxs.length > 0) {
+      const fixedSum = columns.reduce(
+        (s, c, i) => s + (c.truncate ? 0 : widths[i]),
+        0
+      );
+      const remaining = Math.max(
+        truncIdxs.length * MIN_TRUNCATABLE_WIDTH,
+        maxWidth - fixedSum - overhead
+      );
+      const truncSum = truncIdxs.reduce((s, i) => s + widths[i], 0) || 1;
+      let used = 0;
+      truncIdxs.forEach((i, idx) => {
+        if (idx === truncIdxs.length - 1) {
+          widths[i] = Math.max(MIN_TRUNCATABLE_WIDTH, remaining - used);
+        } else {
+          const share = Math.max(
+            MIN_TRUNCATABLE_WIDTH,
+            Math.floor((widths[i] / truncSum) * remaining)
+          );
+          widths[i] = share;
+          used += share;
+        }
+      });
     }
-    return `└${parts.join("┴")}┘`;
-  };
+  }
 
-  // Build table
   const lines: string[] = [];
 
-  // Top border
-  lines.push(`┌${widths.map((w) => "─".repeat(w + 2)).join("┬")}┐`);
-
-  // Header
-  lines.push(
-    createRow(
-      columns.map((c) => c.header),
-      true
-    )
-  );
-
-  // Separator
-  lines.push(separator("─"));
-
-  // Data rows
-  data.forEach((row) => {
-    lines.push(createRow(columns.map((c) => String(row[c.key] || ""))));
+  // Header: UPPERCASE, bold. Pad all but the last cell.
+  const headerCells = columns.map((c, i) => {
+    const text = c.header.toUpperCase();
+    const cell = i === columns.length - 1 ? text : padCell(text, widths[i]);
+    return chalk.bold(cell);
   });
+  lines.push(headerCells.join(GUTTER).trimEnd());
 
-  // Bottom border
-  lines.push(separator("─"));
+  for (const row of data) {
+    const cells = columns.map((c, i) => {
+      let v = String(row[c.key] ?? "");
+      if (visibleWidth(v) > widths[i]) {
+        v = truncateCell(v, widths[i]);
+      }
+      return i === columns.length - 1 ? v : padCell(v, widths[i]);
+    });
+    lines.push(cells.join(GUTTER).trimEnd());
+  }
 
   return lines.join("\n");
+}
+
+/**
+ * Whether stdout is piped/redirected. Callers use this to suppress decorative
+ * headers ("Available Tools (N):") in non-TTY mode so output stays parseable.
+ */
+export function isStdoutTty(): boolean {
+  return Boolean(process.stdout.isTTY);
+}
+
+/**
+ * One-word tool mode badge derived from MCP tool annotations.
+ * `readOnlyHint` wins; explicit `destructiveHint` is shown red; everything
+ * else is "write" (yellow), the safer-than-destructive default for the many
+ * tools that simply don't annotate.
+ */
+export function formatToolMode(annotations?: {
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
+}): string {
+  if (annotations?.readOnlyHint === true) return chalk.green("read-only");
+  if (annotations?.destructiveHint === true) return chalk.red("destructive");
+  return chalk.yellow("write");
 }
 
 /**

--- a/libraries/typescript/packages/cli/src/utils/format.ts
+++ b/libraries/typescript/packages/cli/src/utils/format.ts
@@ -1,6 +1,7 @@
 import chalk from "chalk";
 import type { CallToolResult } from "mcp-use/client";
 
+// eslint-disable-next-line no-control-regex
 const ANSI_RE = /\x1b\[[0-9;]*m/g;
 const GUTTER = "  ";
 const MIN_TRUNCATABLE_WIDTH = 8;
@@ -76,7 +77,8 @@ export function formatTable(
     return chalk.gray("No items found");
   }
 
-  const maxWidth = options.maxWidth ?? process.stdout.columns ?? DEFAULT_MAX_WIDTH;
+  const maxWidth =
+    options.maxWidth ?? process.stdout.columns ?? DEFAULT_MAX_WIDTH;
 
   // Natural width = max(header width, widest cell), per column.
   const natural = columns.map((col) => {

--- a/libraries/typescript/packages/cli/src/utils/format.ts
+++ b/libraries/typescript/packages/cli/src/utils/format.ts
@@ -185,8 +185,12 @@ export function formatJson(data: any, pretty = true): string {
  */
 export function formatToolCall(result: CallToolResult): string {
   const lines: string[] = [];
+  const { isError, structuredContent } = result;
+  const hasContent = !!result.content?.length;
+  const hasStructured =
+    structuredContent !== undefined && structuredContent !== null;
 
-  if (result.isError) {
+  if (isError) {
     lines.push(chalk.red("✗ Tool execution failed"));
     lines.push("");
   } else {
@@ -194,15 +198,17 @@ export function formatToolCall(result: CallToolResult): string {
     lines.push("");
   }
 
-  // Format content
-  if (result.content && result.content.length > 0) {
+  if (hasContent) {
+    if (isError) {
+      lines.push(chalk.red.bold("Error details:"));
+    }
     result.content.forEach((item, index) => {
       if (result.content.length > 1) {
         lines.push(chalk.bold(`Content ${index + 1}:`));
       }
 
       if (item.type === "text") {
-        lines.push(item.text);
+        lines.push(isError ? chalk.red(item.text) : item.text);
       } else if (item.type === "image") {
         lines.push(chalk.cyan(`[Image: ${item.mimeType || "unknown type"}]`));
         if (item.data) {
@@ -224,6 +230,18 @@ export function formatToolCall(result: CallToolResult): string {
         lines.push("");
       }
     });
+  }
+
+  if (hasStructured) {
+    if (hasContent) lines.push("");
+    lines.push(
+      chalk.bold(isError ? "Structured error data:" : "Structured content:")
+    );
+    lines.push(formatJson(structuredContent));
+  }
+
+  if (isError && !hasContent && !hasStructured) {
+    lines.push(chalk.gray("(no error details provided by server)"));
   }
 
   return lines.join("\n");

--- a/libraries/typescript/packages/cli/src/utils/oauth.ts
+++ b/libraries/typescript/packages/cli/src/utils/oauth.ts
@@ -10,6 +10,11 @@ import { createInterface } from "node:readline";
 /**
  * Build a NodeOAuthClientProvider that opens the user's browser via the
  * `open` package (already a CLI dependency, bundled via tsup).
+ *
+ * In non-TTY contexts (piped output, agents, CI) we don't auto-open a browser
+ * — instead we print the authorization URL so the caller can surface it to a
+ * human or open it themselves. This avoids surprising browser launches when
+ * an LLM agent invokes the CLI.
  */
 export async function buildOAuthProvider(
   serverUrl: string,
@@ -21,6 +26,11 @@ export async function buildOAuthProvider(
     storageKeyPrefix: "mcp:auth",
     ...options,
     openBrowser: async (url) => {
+      if (!process.stdout.isTTY) {
+        console.error(`\n  Open this URL in a browser to authenticate:`);
+        console.error(`  ${url}\n`);
+        return;
+      }
       const { default: open } = await import("open");
       await open(url);
     },
@@ -40,7 +50,11 @@ export async function runOAuthFlow(
   serverUrl: string,
   print: (line: string) => void = console.error.bind(console)
 ): Promise<void> {
-  print(`→ Opening browser to authenticate...`);
+  print(
+    process.stdout.isTTY
+      ? `→ Opening browser to authenticate...`
+      : `→ OAuth authentication required.`
+  );
   print(
     `  Listening on http://127.0.0.1:${provider.callbackPort}/callback (waiting up to 5m)`
   );

--- a/libraries/typescript/packages/cli/src/utils/oauth.ts
+++ b/libraries/typescript/packages/cli/src/utils/oauth.ts
@@ -1,0 +1,100 @@
+import {
+  auth,
+  NodeOAuthClientProvider,
+  OAuthFlowError,
+  UnauthorizedError,
+  type NodeOAuthOptions,
+} from "mcp-use/auth/node";
+import { createInterface } from "node:readline";
+
+/**
+ * Build a NodeOAuthClientProvider that opens the user's browser via the
+ * `open` package (already a CLI dependency, bundled via tsup).
+ */
+export async function buildOAuthProvider(
+  serverUrl: string,
+  options: Omit<NodeOAuthOptions, "openBrowser"> = {}
+): Promise<NodeOAuthClientProvider> {
+  return NodeOAuthClientProvider.create(serverUrl, {
+    clientName: "mcp-use CLI",
+    clientUri: "https://mcp-use.com",
+    storageKeyPrefix: "mcp:auth",
+    ...options,
+    openBrowser: async (url) => {
+      const { default: open } = await import("open");
+      await open(url);
+    },
+  });
+}
+
+/**
+ * Run the full two-call OAuth dance:
+ *   1. auth() → triggers redirectToAuthorization (opens browser, binds loopback)
+ *   2. await provider.getAuthorizationCode()
+ *   3. auth() with the code → exchanges for tokens, persists via FileKVStore
+ *
+ * Mirrors the orchestrator pattern in `useMcp.ts:1121-1145`.
+ */
+export async function runOAuthFlow(
+  provider: NodeOAuthClientProvider,
+  serverUrl: string,
+  print: (line: string) => void = console.error.bind(console)
+): Promise<void> {
+  print(`→ Opening browser to authenticate...`);
+  print(
+    `  Listening on http://127.0.0.1:${provider.callbackPort}/callback (waiting up to 5m)`
+  );
+
+  // SDK transports (e.g. StreamableHTTPClientTransport) auto-call auth() on a
+  // 401, which already invokes redirectToAuthorization (loopback bound, browser
+  // opened). In that case skip the first auth() call — calling it again would
+  // throw "an authorization is already in progress".
+  if (!provider.hasPendingFlow) {
+    const result = await auth(provider, { serverUrl });
+    if (result === "AUTHORIZED") {
+      // Pre-existing valid tokens; nothing to do.
+      return;
+    }
+    if (result !== "REDIRECT") {
+      throw new OAuthFlowError(
+        "unexpected_auth_result",
+        `auth() returned ${result}`
+      );
+    }
+  }
+
+  const code = await provider.getAuthorizationCode();
+  await auth(provider, { serverUrl, authorizationCode: code });
+}
+
+/** True if the unwrapped error is an SDK 401 we should respond to with OAuth. */
+export function isUnauthorized(err: unknown): boolean {
+  if (err instanceof UnauthorizedError) return true;
+  // Some transports rewrap; check by name + message as a fallback.
+  if (err instanceof Error && err.name === "UnauthorizedError") return true;
+  // mcp-use's HttpConnector rewraps SDK 401s as a plain Error with `code = 401`
+  // (see packages/mcp-use/src/connectors/http.ts:228, :255).
+  if (err instanceof Error && (err as { code?: unknown }).code === 401) {
+    return true;
+  }
+  return false;
+}
+
+/** Minimal yes/no prompt. Returns true on Y/y/yes/<enter>, false otherwise. */
+export async function promptYesNo(
+  question: string,
+  defaultYes = true
+): Promise<boolean> {
+  if (!process.stdin.isTTY) return false;
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  try {
+    const answer = await new Promise<string>((resolve) => {
+      rl.question(`${question} ${defaultYes ? "[Y/n] " : "[y/N] "}`, resolve);
+    });
+    const trimmed = answer.trim().toLowerCase();
+    if (!trimmed) return defaultYes;
+    return trimmed === "y" || trimmed === "yes";
+  } finally {
+    rl.close();
+  }
+}

--- a/libraries/typescript/packages/cli/src/utils/parse-args.ts
+++ b/libraries/typescript/packages/cli/src/utils/parse-args.ts
@@ -1,0 +1,197 @@
+/**
+ * Parse positional `key=value` arguments for `tools call` and `prompts get`.
+ *
+ * Forms accepted (per token):
+ *   key=value      → string by default; coerced using the tool's input schema
+ *                    (number/integer/boolean/array/object) when available
+ *   key:=jsonvalue → value is parsed as JSON (httpie convention); use this for
+ *                    nested objects/arrays or to force a non-string scalar
+ *   --key=value    → leading `--` is accepted and stripped (forgiving for users
+ *                    who reach for a flag-style habit)
+ *
+ * Backward-compatible fallback: a single token that starts with `{` is parsed
+ * as a JSON object covering all arguments at once.
+ */
+
+type JsonSchemaLike = {
+  type?: string | string[];
+  properties?: Record<string, JsonSchemaLike>;
+  required?: string[];
+};
+
+export function parseToolArgs(
+  rawArgs: string[] | undefined,
+  inputSchema?: JsonSchemaLike
+): Record<string, unknown> {
+  if (!rawArgs || rawArgs.length === 0) return {};
+
+  // Backward-compat: single JSON object argument
+  if (rawArgs.length === 1) {
+    const trimmed = rawArgs[0].trim();
+    if (trimmed.startsWith("{")) {
+      try {
+        const parsed = JSON.parse(trimmed);
+        if (
+          parsed === null ||
+          typeof parsed !== "object" ||
+          Array.isArray(parsed)
+        ) {
+          throw new Error("expected a JSON object");
+        }
+        return parsed as Record<string, unknown>;
+      } catch (err) {
+        throw new Error(`Invalid JSON arguments: ${(err as Error).message}`);
+      }
+    }
+  }
+
+  const props = inputSchema?.properties ?? {};
+  const result: Record<string, unknown> = {};
+
+  for (const raw of rawArgs) {
+    // Strip optional leading `--` to be forgiving for flag-style habits.
+    const token = raw.startsWith("--") ? raw.slice(2) : raw;
+
+    const jsonIdx = token.indexOf(":=");
+    const eqIdx = token.indexOf("=");
+
+    let key: string;
+    let rawValue: string;
+    let forceJson = false;
+
+    if (jsonIdx !== -1 && (eqIdx === -1 || jsonIdx < eqIdx)) {
+      key = token.slice(0, jsonIdx);
+      rawValue = token.slice(jsonIdx + 2);
+      forceJson = true;
+    } else if (eqIdx !== -1) {
+      key = token.slice(0, eqIdx);
+      rawValue = token.slice(eqIdx + 1);
+    } else {
+      throw new Error(
+        `Invalid argument '${raw}'. Use key=value or key:=jsonvalue.`
+      );
+    }
+
+    if (!key) {
+      throw new Error(`Empty key in argument '${raw}'`);
+    }
+
+    result[key] = coerceArgValue(rawValue, props[key], forceJson, key);
+  }
+
+  return result;
+}
+
+function coerceArgValue(
+  value: string,
+  propSchema: JsonSchemaLike | undefined,
+  forceJson: boolean,
+  key: string
+): unknown {
+  if (forceJson) {
+    try {
+      return JSON.parse(value);
+    } catch (err) {
+      throw new Error(
+        `Invalid JSON value for '${key}': ${(err as Error).message}`
+      );
+    }
+  }
+
+  const types = Array.isArray(propSchema?.type)
+    ? propSchema!.type
+    : propSchema?.type
+      ? [propSchema.type as string]
+      : [];
+
+  if (types.includes("null") && (value === "null" || value === "")) {
+    return null;
+  }
+
+  if (types.includes("integer")) {
+    const n = Number(value);
+    if (!Number.isFinite(n) || !Number.isInteger(n)) {
+      throw new Error(`Expected integer for '${key}', got '${value}'`);
+    }
+    return n;
+  }
+
+  if (types.includes("number")) {
+    const n = Number(value);
+    if (!Number.isFinite(n)) {
+      throw new Error(`Expected number for '${key}', got '${value}'`);
+    }
+    return n;
+  }
+
+  if (types.includes("boolean")) {
+    if (value === "true" || value === "1") return true;
+    if (value === "false" || value === "0") return false;
+    throw new Error(
+      `Expected boolean (true/false) for '${key}', got '${value}'`
+    );
+  }
+
+  if (types.includes("array") || types.includes("object")) {
+    try {
+      return JSON.parse(value);
+    } catch (err) {
+      const wanted = types.includes("array") ? "array" : "object";
+      throw new Error(
+        `Expected JSON ${wanted} for '${key}'. Tip: use ${key}:=<json>. ${(err as Error).message}`
+      );
+    }
+  }
+
+  return value;
+}
+
+/**
+ * Parse positional `key=value` arguments for prompts. Prompt arguments are
+ * always strings per the MCP spec, so we skip type coercion entirely.
+ */
+export function parsePromptArgs(
+  rawArgs: string[] | undefined
+): Record<string, string> {
+  if (!rawArgs || rawArgs.length === 0) return {};
+
+  if (rawArgs.length === 1) {
+    const trimmed = rawArgs[0].trim();
+    if (trimmed.startsWith("{")) {
+      try {
+        const parsed = JSON.parse(trimmed);
+        if (
+          parsed === null ||
+          typeof parsed !== "object" ||
+          Array.isArray(parsed)
+        ) {
+          throw new Error("expected a JSON object");
+        }
+        // Coerce all values to strings for prompt args.
+        const out: Record<string, string> = {};
+        for (const [k, v] of Object.entries(parsed)) {
+          out[k] = typeof v === "string" ? v : JSON.stringify(v);
+        }
+        return out;
+      } catch (err) {
+        throw new Error(`Invalid JSON arguments: ${(err as Error).message}`);
+      }
+    }
+  }
+
+  const result: Record<string, string> = {};
+  for (const raw of rawArgs) {
+    const token = raw.startsWith("--") ? raw.slice(2) : raw;
+    const eqIdx = token.indexOf("=");
+    if (eqIdx === -1) {
+      throw new Error(`Invalid argument '${raw}'. Use key=value.`);
+    }
+    const key = token.slice(0, eqIdx);
+    const value = token.slice(eqIdx + 1);
+    if (!key) {
+      throw new Error(`Empty key in argument '${raw}'`);
+    }
+    result[key] = value;
+  }
+  return result;
+}

--- a/libraries/typescript/packages/cli/src/utils/session-storage.ts
+++ b/libraries/typescript/packages/cli/src/utils/session-storage.ts
@@ -9,7 +9,15 @@ export interface SessionConfig {
   command?: string;
   args?: string[];
   env?: Record<string, string>;
+  /** Static Bearer token. Used when authMode is undefined or "bearer". */
   authToken?: string;
+  /**
+   * How this session authenticates to the server.
+   * - "bearer": static token in `authToken`.
+   * - "oauth": tokens live in `~/.mcp-use/oauth/<urlHash>/`, managed by NodeOAuthClientProvider.
+   * Undefined = legacy bearer (back-compat with sessions saved before OAuth shipped).
+   */
+  authMode?: "bearer" | "oauth";
   lastUsed: string;
   serverInfo?: {
     name: string;

--- a/libraries/typescript/packages/cli/tests/cli-integration.test.ts
+++ b/libraries/typescript/packages/cli/tests/cli-integration.test.ts
@@ -140,8 +140,10 @@ describe("CLI Integration Tests", () => {
     it("should list sessions when none exist", async () => {
       const result = await runCLI(["client", "sessions", "list"]);
 
+      // Non-TTY (piped) stdout: gh-style empty output, just a clean exit.
+      // Decorative "No saved sessions" message is suppressed for agents/scripts.
       expect(result.exitCode).toBe(0);
-      expect(result.stdout).toContain("No saved sessions");
+      expect(result.stdout.trim()).toBe("");
     });
 
     it("should show error when no active session for tools list", async () => {

--- a/libraries/typescript/packages/cli/tests/format.test.ts
+++ b/libraries/typescript/packages/cli/tests/format.test.ts
@@ -195,7 +195,49 @@ describe("Format Utilities", () => {
       const formatted = formatToolCall(result);
 
       expect(formatted).toContain("Tool execution failed");
+      expect(formatted).toContain("Error details:");
       expect(formatted).toContain("Error message");
+    });
+
+    it("should surface fallback text when failed tool has no content", () => {
+      const result: CallToolResult = {
+        content: [],
+        isError: true,
+      };
+
+      const formatted = formatToolCall(result);
+
+      expect(formatted).toContain("Tool execution failed");
+      expect(formatted).toContain("no error details provided by server");
+    });
+
+    it("should include structuredContent on failure", () => {
+      const result = {
+        content: [{ type: "text", text: "Boom" }],
+        isError: true,
+        structuredContent: { code: "E_FAIL", retryable: false },
+      } as unknown as CallToolResult;
+
+      const formatted = formatToolCall(result);
+
+      expect(formatted).toContain("Tool execution failed");
+      expect(formatted).toContain("Boom");
+      expect(formatted).toContain("Structured error data:");
+      expect(formatted).toContain("E_FAIL");
+      expect(formatted).toContain("retryable");
+    });
+
+    it("should include structuredContent on success", () => {
+      const result = {
+        content: [{ type: "text", text: "ok" }],
+        isError: false,
+        structuredContent: { items: 3 },
+      } as unknown as CallToolResult;
+
+      const formatted = formatToolCall(result);
+
+      expect(formatted).toContain("Structured content:");
+      expect(formatted).toContain("items");
     });
 
     it("should handle image content", () => {

--- a/libraries/typescript/packages/cli/tests/format.test.ts
+++ b/libraries/typescript/packages/cli/tests/format.test.ts
@@ -18,6 +18,7 @@ import type { CallToolResult } from "mcp-use";
 
 describe("Format Utilities", () => {
   describe("formatTable", () => {
+    // eslint-disable-next-line no-control-regex
     const ANSI = /\x1b\[[0-9;]*m/g;
     const strip = (s: string) => s.replace(ANSI, "");
 
@@ -75,9 +76,7 @@ describe("Format Utilities", () => {
     });
 
     it("truncates with ellipsis when total width exceeds maxWidth", () => {
-      const data = [
-        { name: "tool-a", description: "x".repeat(200) },
-      ];
+      const data = [{ name: "tool-a", description: "x".repeat(200) }];
       const columns = [
         { key: "name", header: "Tool" },
         { key: "description", header: "Description", truncate: true },
@@ -121,7 +120,9 @@ describe("Format Utilities", () => {
     });
 
     it("strips ANSI escapes from TSV cells", () => {
-      const data = [{ name: "\x1b[1mAlice\x1b[22m", status: "\x1b[32mok\x1b[39m" }];
+      const data = [
+        { name: "\x1b[1mAlice\x1b[22m", status: "\x1b[32mok\x1b[39m" },
+      ];
       const columns = [
         { key: "name", header: "Name" },
         { key: "status", header: "Status" },
@@ -145,12 +146,16 @@ describe("Format Utilities", () => {
     });
 
     it("returns empty string for no data in tsv mode", () => {
-      const result = formatTable([], [{ key: "x", header: "X" }], { tsv: true });
+      const result = formatTable([], [{ key: "x", header: "X" }], {
+        tsv: true,
+      });
       expect(result).toBe("");
     });
 
     it("returns 'No items found' for no data in TTY mode", () => {
-      const result = formatTable([], [{ key: "x", header: "X" }], { tsv: false });
+      const result = formatTable([], [{ key: "x", header: "X" }], {
+        tsv: false,
+      });
       expect(result).toContain("No items found");
     });
   });

--- a/libraries/typescript/packages/cli/tests/format.test.ts
+++ b/libraries/typescript/packages/cli/tests/format.test.ts
@@ -18,7 +18,10 @@ import type { CallToolResult } from "mcp-use";
 
 describe("Format Utilities", () => {
   describe("formatTable", () => {
-    it("should format data as ASCII table", () => {
+    const ANSI = /\x1b\[[0-9;]*m/g;
+    const strip = (s: string) => s.replace(ANSI, "");
+
+    it("renders borderless layout with UPPERCASE bold headers", () => {
       const data = [
         { name: "Alice", age: 30 },
         { name: "Bob", age: 25 },
@@ -28,27 +31,127 @@ describe("Format Utilities", () => {
         { key: "age", header: "Age" },
       ];
 
-      const result = formatTable(data, columns);
+      const result = formatTable(data, columns, { tsv: false });
+      const lines = result.split("\n");
 
-      expect(result).toContain("┌");
-      expect(result).toContain("│");
-      expect(result).toContain("Name");
-      expect(result).toContain("Age");
-      expect(result).toContain("Alice");
-      expect(result).toContain("Bob");
+      // No box-drawing glyphs anywhere.
+      for (const glyph of ["┌", "┐", "└", "┘", "│", "─", "├", "┤", "┬", "┴"]) {
+        expect(result).not.toContain(glyph);
+      }
+
+      // Header row is UPPERCASE (boldness depends on chalk color support,
+      // which is auto-disabled under vitest's non-TTY stdio).
+      expect(strip(lines[0])).toContain("NAME");
+      expect(strip(lines[0])).toContain("AGE");
+      expect(strip(lines[0])).not.toContain("Name");
+
+      // Data rows present and aligned with a two-space gutter.
+      expect(strip(lines[1])).toMatch(/^Alice\s{2,}30$/);
+      expect(strip(lines[2])).toMatch(/^Bob\s{2,}25$/);
+
+      // Visible-width alignment: name column padded so ages start at the same offset.
+      const ageCol1 = strip(lines[1]).indexOf("30");
+      const ageCol2 = strip(lines[2]).indexOf("25");
+      expect(ageCol1).toBe(ageCol2);
     });
 
-    it("should handle empty data", () => {
-      const result = formatTable([], []);
+    it("aligns columns when cells contain ANSI escape codes", () => {
+      // chalk.bold + chalk.green; pretend they are fixed escapes.
+      const data = [
+        { name: "\x1b[1mAlice\x1b[22m", status: "\x1b[32mok\x1b[39m" },
+        { name: "Bob", status: "fail" },
+      ];
+      const columns = [
+        { key: "name", header: "Name" },
+        { key: "status", header: "Status" },
+      ];
+
+      const result = formatTable(data, columns, { tsv: false });
+      const lines = result.split("\n").map(strip);
+
+      const statusCol1 = lines[1].indexOf("ok");
+      const statusCol2 = lines[2].indexOf("fail");
+      expect(statusCol1).toBe(statusCol2);
+    });
+
+    it("truncates with ellipsis when total width exceeds maxWidth", () => {
+      const data = [
+        { name: "tool-a", description: "x".repeat(200) },
+      ];
+      const columns = [
+        { key: "name", header: "Tool" },
+        { key: "description", header: "Description", truncate: true },
+      ];
+
+      const result = formatTable(data, columns, { tsv: false, maxWidth: 40 });
+      const lines = result.split("\n").map(strip);
+
+      expect(lines[1]).toContain("…");
+      expect(lines[1].length).toBeLessThanOrEqual(40);
+    });
+
+    it("non-truncatable columns keep their full width", () => {
+      const data = [{ name: "very-long-tool-name-here", desc: "z".repeat(80) }];
+      const columns = [
+        { key: "name", header: "Tool" },
+        { key: "desc", header: "Description", truncate: true },
+      ];
+
+      const result = formatTable(data, columns, { tsv: false, maxWidth: 40 });
+      const lines = result.split("\n").map(strip);
+
+      expect(lines[1]).toContain("very-long-tool-name-here");
+    });
+
+    it("emits TSV with no header in tsv mode", () => {
+      const data = [
+        { name: "Alice", age: 30 },
+        { name: "Bob", age: 25 },
+      ];
+      const columns = [
+        { key: "name", header: "Name" },
+        { key: "age", header: "Age" },
+      ];
+
+      const result = formatTable(data, columns, { tsv: true });
+
+      expect(result).toBe("Alice\t30\nBob\t25");
+      expect(result).not.toContain("Name");
+      expect(result).not.toContain("\x1b[");
+    });
+
+    it("strips ANSI escapes from TSV cells", () => {
+      const data = [{ name: "\x1b[1mAlice\x1b[22m", status: "\x1b[32mok\x1b[39m" }];
+      const columns = [
+        { key: "name", header: "Name" },
+        { key: "status", header: "Status" },
+      ];
+
+      const result = formatTable(data, columns, { tsv: true });
+      expect(result).toBe("Alice\tok");
+    });
+
+    it("collapses tabs and newlines inside TSV cells", () => {
+      const data = [{ name: "a\tb\nc", value: "x" }];
+      const columns = [
+        { key: "name", header: "Name" },
+        { key: "value", header: "Value" },
+      ];
+
+      const result = formatTable(data, columns, { tsv: true });
+      // Single tab between columns; embedded tabs/newlines collapsed to spaces.
+      expect(result.split("\t")).toHaveLength(2);
+      expect(result.startsWith("a b c")).toBe(true);
+    });
+
+    it("returns empty string for no data in tsv mode", () => {
+      const result = formatTable([], [{ key: "x", header: "X" }], { tsv: true });
+      expect(result).toBe("");
+    });
+
+    it("returns 'No items found' for no data in TTY mode", () => {
+      const result = formatTable([], [{ key: "x", header: "X" }], { tsv: false });
       expect(result).toContain("No items found");
-    });
-
-    it("should respect column widths", () => {
-      const data = [{ name: "A" }];
-      const columns = [{ key: "name", header: "Name", width: 20 }];
-
-      const result = formatTable(data, columns);
-      expect(result).toContain("A");
     });
   });
 

--- a/libraries/typescript/packages/cli/tests/parse-args.test.ts
+++ b/libraries/typescript/packages/cli/tests/parse-args.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+import { parsePromptArgs, parseToolArgs } from "../src/utils/parse-args.js";
+
+describe("parseToolArgs", () => {
+  it("returns empty object for no args", () => {
+    expect(parseToolArgs(undefined)).toEqual({});
+    expect(parseToolArgs([])).toEqual({});
+  });
+
+  it("parses key=value pairs as strings without a schema", () => {
+    expect(parseToolArgs(["name=world", "greeting=hi"])).toEqual({
+      name: "world",
+      greeting: "hi",
+    });
+  });
+
+  it("allows '=' inside the value (only the first separates key from value)", () => {
+    expect(parseToolArgs(["query=a=b=c"])).toEqual({ query: "a=b=c" });
+  });
+
+  it("strips a leading -- so flag-style is forgiving", () => {
+    expect(parseToolArgs(["--name=world"])).toEqual({ name: "world" });
+  });
+
+  it("coerces numbers when the schema says number/integer", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        count: { type: "integer" },
+        ratio: { type: "number" },
+      },
+    };
+    expect(parseToolArgs(["count=42", "ratio=3.14"], schema)).toEqual({
+      count: 42,
+      ratio: 3.14,
+    });
+  });
+
+  it("rejects non-integer values for integer schema", () => {
+    const schema = {
+      type: "object",
+      properties: { count: { type: "integer" } },
+    };
+    expect(() => parseToolArgs(["count=3.14"], schema)).toThrow(/integer/);
+    expect(() => parseToolArgs(["count=foo"], schema)).toThrow(/integer/);
+  });
+
+  it("coerces booleans when the schema says boolean", () => {
+    const schema = {
+      type: "object",
+      properties: { enabled: { type: "boolean" } },
+    };
+    expect(parseToolArgs(["enabled=true"], schema)).toEqual({ enabled: true });
+    expect(parseToolArgs(["enabled=false"], schema)).toEqual({
+      enabled: false,
+    });
+    expect(parseToolArgs(["enabled=1"], schema)).toEqual({ enabled: true });
+    expect(parseToolArgs(["enabled=0"], schema)).toEqual({ enabled: false });
+    expect(() => parseToolArgs(["enabled=maybe"], schema)).toThrow(/boolean/);
+  });
+
+  it("parses JSON when schema says array or object", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        tags: { type: "array" },
+        meta: { type: "object" },
+      },
+    };
+    expect(parseToolArgs(['tags=["a","b"]', 'meta={"k":1}'], schema)).toEqual({
+      tags: ["a", "b"],
+      meta: { k: 1 },
+    });
+  });
+
+  it("hints at := when array/object value is not valid JSON", () => {
+    const schema = {
+      type: "object",
+      properties: { tags: { type: "array" } },
+    };
+    expect(() => parseToolArgs(["tags=a,b,c"], schema)).toThrow(/tags:=/);
+  });
+
+  it("supports :=jsonvalue to force JSON parsing", () => {
+    expect(parseToolArgs(['meta:={"k":1}'])).toEqual({ meta: { k: 1 } });
+    expect(parseToolArgs(["count:=42"])).toEqual({ count: 42 });
+    expect(parseToolArgs(["enabled:=true"])).toEqual({ enabled: true });
+    expect(parseToolArgs(["tags:=[1,2,3]"])).toEqual({ tags: [1, 2, 3] });
+  });
+
+  it("preserves := semantics over plain = when both appear", () => {
+    expect(parseToolArgs(['expr:={"a":"b=c"}'])).toEqual({
+      expr: { a: "b=c" },
+    });
+  });
+
+  it("treats a single token starting with { as a full JSON object (backward compat)", () => {
+    expect(parseToolArgs(['{"name":"world","count":3}'])).toEqual({
+      name: "world",
+      count: 3,
+    });
+  });
+
+  it("rejects a non-object JSON value in the backward-compat form", () => {
+    expect(() => parseToolArgs(["[1,2,3]"])).toThrow();
+  });
+
+  it("supports null type when schema permits it", () => {
+    const schema = {
+      type: "object",
+      properties: { nickname: { type: ["string", "null"] } },
+    };
+    expect(parseToolArgs(["nickname=null"], schema)).toEqual({
+      nickname: null,
+    });
+    expect(parseToolArgs(["nickname=Andy"], schema)).toEqual({
+      nickname: "Andy",
+    });
+  });
+
+  it("keeps unknown-key values as strings (schema only constrains known keys)", () => {
+    const schema = {
+      type: "object",
+      properties: { count: { type: "integer" } },
+    };
+    expect(parseToolArgs(["count=5", "extra=hello"], schema)).toEqual({
+      count: 5,
+      extra: "hello",
+    });
+  });
+
+  it("rejects tokens with no = separator", () => {
+    expect(() => parseToolArgs(["name"])).toThrow(/key=value/);
+  });
+
+  it("rejects empty keys", () => {
+    expect(() => parseToolArgs(["=value"])).toThrow(/Empty key/);
+  });
+
+  it("surfaces invalid JSON in :=jsonvalue with the key in the message", () => {
+    expect(() => parseToolArgs(["meta:={bad json}"])).toThrow(/meta/);
+  });
+});
+
+describe("parsePromptArgs", () => {
+  it("returns empty object for no args", () => {
+    expect(parsePromptArgs(undefined)).toEqual({});
+    expect(parsePromptArgs([])).toEqual({});
+  });
+
+  it("parses key=value pairs as strings without coercion", () => {
+    expect(parsePromptArgs(["topic=birds", "count=5"])).toEqual({
+      topic: "birds",
+      count: "5",
+    });
+  });
+
+  it("strips a leading --", () => {
+    expect(parsePromptArgs(["--topic=birds"])).toEqual({ topic: "birds" });
+  });
+
+  it("accepts a single JSON object (backward compat) and stringifies non-string values", () => {
+    expect(parsePromptArgs(['{"topic":"birds","count":5}'])).toEqual({
+      topic: "birds",
+      count: "5",
+    });
+  });
+
+  it("rejects tokens with no = separator", () => {
+    expect(() => parsePromptArgs(["topic"])).toThrow(/key=value/);
+  });
+});

--- a/libraries/typescript/packages/mcp-use/package.json
+++ b/libraries/typescript/packages/mcp-use/package.json
@@ -52,6 +52,11 @@
       "import": "./dist/src/auth/index.js",
       "require": "./dist/src/auth/index.cjs"
     },
+    "./auth/node": {
+      "types": "./dist/src/auth/index-node.d.ts",
+      "import": "./dist/src/auth/index-node.js",
+      "require": "./dist/src/auth/index-node.cjs"
+    },
     "./browser": {
       "types": "./dist/src/browser.d.ts",
       "import": "./dist/src/browser.js",

--- a/libraries/typescript/packages/mcp-use/src/auth/file-kv-store.ts
+++ b/libraries/typescript/packages/mcp-use/src/auth/file-kv-store.ts
@@ -1,0 +1,104 @@
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { KVStore } from "./kv-store.js";
+
+const isWindows = process.platform === "win32";
+
+/**
+ * `KVStore` implementation backed by `~/.mcp-use/oauth/<serverUrlHash>/`,
+ * one file per key. Used by `NodeOAuthClientProvider`.
+ *
+ * Each `set()` writes to `<key>.tmp.<rand>` then renames into place so
+ * concurrent writers can't observe a half-written file. Files are written
+ * with 0o600 and the containing directory is created with 0o700 (best-effort
+ * on Windows where POSIX bits are advisory).
+ *
+ * Cross-process refresh uses the existing `_dedupedRefresh` for in-process
+ * coalescing; concurrent CLI invocations may both refresh and the second
+ * write wins — both produce semantically equivalent token JSON, so this is
+ * safe.
+ *
+ * @internal
+ */
+export class FileKVStore implements KVStore {
+  readonly dir: string;
+
+  constructor(serverUrlHash: string, baseDir?: string) {
+    const root = baseDir ?? join(homedir(), ".mcp-use", "oauth");
+    this.dir = join(root, serverUrlHash);
+    this.ensureDir();
+  }
+
+  private ensureDir(): void {
+    if (!existsSync(this.dir)) {
+      mkdirSync(this.dir, { recursive: true, mode: 0o700 });
+    }
+    if (!isWindows) {
+      try {
+        chmodSync(this.dir, 0o700);
+      } catch {
+        // Best-effort: chmod can fail on shared volumes (NFS, mounted FS).
+      }
+    }
+  }
+
+  /**
+   * `OAuthSessionStore` keys contain colons (e.g. `mcp:auth_<hash>_tokens`)
+   * which are invalid on Windows. Replace anything outside the safe set with
+   * `_` so the same logical key maps to a stable filename across platforms.
+   */
+  private sanitize(key: string): string {
+    return key.replace(/[^a-zA-Z0-9._-]/g, "_");
+  }
+
+  private pathFor(key: string): string {
+    return join(this.dir, this.sanitize(key));
+  }
+
+  get(key: string): string | null {
+    const file = this.pathFor(key);
+    if (!existsSync(file)) return null;
+    try {
+      return readFileSync(file, "utf-8");
+    } catch {
+      return null;
+    }
+  }
+
+  set(key: string, value: string): void {
+    this.ensureDir();
+    const file = this.pathFor(key);
+    const tmp = `${file}.tmp.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}`;
+    writeFileSync(tmp, value, { encoding: "utf-8", mode: 0o600 });
+    if (!isWindows) {
+      try {
+        chmodSync(tmp, 0o600);
+      } catch {
+        // Best-effort.
+      }
+    }
+    renameSync(tmp, file);
+  }
+
+  remove(key: string): void {
+    const file = this.pathFor(key);
+    if (existsSync(file)) {
+      rmSync(file, { force: true });
+    }
+  }
+
+  keys(): string[] {
+    if (!existsSync(this.dir)) return [];
+    return readdirSync(this.dir).filter((name) => !name.includes(".tmp."));
+  }
+}

--- a/libraries/typescript/packages/mcp-use/src/auth/index-node.ts
+++ b/libraries/typescript/packages/mcp-use/src/auth/index-node.ts
@@ -1,0 +1,21 @@
+/**
+ * Node-only OAuth utilities for MCP. This entry pulls `node:http`,
+ * `node:fs`, and `node:os` — do not import from browser code.
+ *
+ * For browser OAuth, use `mcp-use/auth` instead.
+ */
+
+export {
+  NodeOAuthClientProvider,
+  OAuthFlowError,
+  type NodeOAuthOptions,
+} from "./node-provider.js";
+export { FileKVStore } from "./file-kv-store.js";
+export type { KVStore } from "./kv-store.js";
+
+// Re-export the SDK pieces an orchestrator needs to drive the two-call flow,
+// so callers don't need a direct dependency on @modelcontextprotocol/sdk.
+export {
+  auth,
+  UnauthorizedError,
+} from "@modelcontextprotocol/sdk/client/auth.js";

--- a/libraries/typescript/packages/mcp-use/src/auth/node-provider.ts
+++ b/libraries/typescript/packages/mcp-use/src/auth/node-provider.ts
@@ -86,12 +86,21 @@ h1{font-size:20px;margin:0 0 12px}p{line-height:1.5}</style></head>
 <body><h1>Authentication complete</h1>
 <p>You can close this tab and return to your terminal.</p></body></html>`;
 
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
 const FAILURE_HTML = (err: string, desc?: string) => `<!DOCTYPE html>
 <html><head><meta charset="utf-8"><title>Authentication failed</title>
 <style>body{font-family:system-ui,sans-serif;max-width:480px;margin:80px auto;padding:0 24px;color:#222}
 h1{font-size:20px;margin:0 0 12px;color:#b00020}p{line-height:1.5}code{background:#f3f3f3;padding:2px 6px;border-radius:3px}</style></head>
 <body><h1>Authentication failed</h1>
-<p><code>${err}</code>${desc ? `: ${desc.replace(/[<>&]/g, "")}` : ""}</p>
+<p><code>${escapeHtml(err)}</code>${desc ? `: ${escapeHtml(desc)}` : ""}</p>
 <p>You can close this tab and return to your terminal.</p></body></html>`;
 
 /**
@@ -301,14 +310,8 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
    * Force-refresh the access token using the persisted refresh_token.
    * Returns the new tokens on success, or null if no refresh_token / refresh failed.
    */
-  async forceRefresh(): Promise<OAuthTokens | null> {
-    const existing = await this.session.tokens();
-    if (!existing?.refresh_token) return null;
-    // OAuthSessionStore.tokens() refreshes when JWT is near expiry. To force
-    // unconditionally, drop the access_token and read again.
-    await this.saveTokens({ ...existing, access_token: "" });
-    const refreshed = await this.session.tokens();
-    return refreshed ?? null;
+  forceRefresh(): Promise<OAuthTokens | null> {
+    return this.session.forceRefresh();
   }
 
   /**

--- a/libraries/typescript/packages/mcp-use/src/auth/node-provider.ts
+++ b/libraries/typescript/packages/mcp-use/src/auth/node-provider.ts
@@ -1,0 +1,437 @@
+import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
+import type {
+  OAuthClientInformation,
+  OAuthClientMetadata,
+  OAuthTokens,
+} from "@modelcontextprotocol/sdk/shared/auth.js";
+import { createServer as createNetServer } from "node:net";
+import { createServer as createHttpServer, type Server } from "node:http";
+import { FileKVStore } from "./file-kv-store.js";
+import type { KVStore } from "./kv-store.js";
+import {
+  OAuthSessionStore,
+  type OAuthSessionStoreOptions,
+} from "./oauth-session-store.js";
+
+const DEFAULT_PORT = 33418;
+const PORT_RANGE = 10;
+const DEFAULT_AUTH_TIMEOUT_MS = 5 * 60_000;
+
+export interface NodeOAuthOptions extends OAuthSessionStoreOptions {
+  /** Preferred loopback port. Default 33418. Walks up by `portRange` on EADDRINUSE. */
+  preferredPort?: number;
+  portRange?: number;
+  /** Override the on-disk store directory (mostly for tests). */
+  baseDir?: string;
+  /** Override KV store entirely (mostly for tests). */
+  kvStore?: KVStore;
+  /** Loopback wait timeout. Default 5 minutes. */
+  authTimeoutMs?: number;
+  /** Suppress the default `open(url)` browser launch (test hook). */
+  openBrowser?: (url: string) => Promise<void> | void;
+}
+
+export class OAuthFlowError extends Error {
+  readonly code: string;
+  readonly description?: string;
+  constructor(code: string, description?: string) {
+    super(description ? `${code}: ${description}` : code);
+    this.code = code;
+    this.description = description;
+    this.name = "OAuthFlowError";
+  }
+}
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (err: Error) => void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (err: Error) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+async function isPortFree(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const tester = createNetServer();
+    tester.once("error", () => resolve(false));
+    tester.once("listening", () => {
+      tester.close(() => resolve(true));
+    });
+    tester.listen(port, "127.0.0.1");
+  });
+}
+
+async function reservePort(
+  preferred: number,
+  range: number
+): Promise<number | null> {
+  for (let p = preferred; p < preferred + range; p++) {
+    if (await isPortFree(p)) return p;
+  }
+  return null;
+}
+
+const SUCCESS_HTML = `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>Authentication complete</title>
+<style>body{font-family:system-ui,sans-serif;max-width:480px;margin:80px auto;padding:0 24px;color:#222}
+h1{font-size:20px;margin:0 0 12px}p{line-height:1.5}</style></head>
+<body><h1>Authentication complete</h1>
+<p>You can close this tab and return to your terminal.</p></body></html>`;
+
+const FAILURE_HTML = (err: string, desc?: string) => `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>Authentication failed</title>
+<style>body{font-family:system-ui,sans-serif;max-width:480px;margin:80px auto;padding:0 24px;color:#222}
+h1{font-size:20px;margin:0 0 12px;color:#b00020}p{line-height:1.5}code{background:#f3f3f3;padding:2px 6px;border-radius:3px}</style></head>
+<body><h1>Authentication failed</h1>
+<p><code>${err}</code>${desc ? `: ${desc.replace(/[<>&]/g, "")}` : ""}</p>
+<p>You can close this tab and return to your terminal.</p></body></html>`;
+
+/**
+ * Node/CLI OAuth client provider for MCP. Owns a localhost loopback callback
+ * server, opens the user's browser, and resolves the authorization code via
+ * `getAuthorizationCode()` — designed for the orchestrator pattern in
+ * `useMcp.ts:1121-1145`.
+ *
+ * Use the static `create()` factory; the constructor is internal because
+ * port reservation is async.
+ */
+export class NodeOAuthClientProvider implements OAuthClientProvider {
+  readonly serverUrl: string;
+  readonly port: number;
+
+  private session: OAuthSessionStore;
+  private kv: KVStore;
+  private authTimeoutMs: number;
+  private openBrowserOverride?: (url: string) => Promise<void> | void;
+
+  private server: Server | null = null;
+  /** Currently in-flight deferred — used to prevent overlapping flows. */
+  private pending: Deferred<string> | null = null;
+  /** Latest deferred (settled or in-flight) — what `getAuthorizationCode()` returns. */
+  private lastFlow: Deferred<string> | null = null;
+  private pendingTimer: NodeJS.Timeout | null = null;
+
+  private constructor(
+    serverUrl: string,
+    port: number,
+    session: OAuthSessionStore,
+    kv: KVStore,
+    options: NodeOAuthOptions
+  ) {
+    this.serverUrl = serverUrl;
+    this.port = port;
+    this.session = session;
+    this.kv = kv;
+    this.authTimeoutMs = options.authTimeoutMs ?? DEFAULT_AUTH_TIMEOUT_MS;
+    this.openBrowserOverride = options.openBrowser;
+  }
+
+  static async create(
+    serverUrl: string,
+    options: NodeOAuthOptions = {}
+  ): Promise<NodeOAuthClientProvider> {
+    const serverUrlHash = OAuthSessionStore.hashString(serverUrl);
+    const kv =
+      options.kvStore ?? new FileKVStore(serverUrlHash, options.baseDir);
+
+    const persistedPortRaw = await kv.get("port");
+    const persistedPort = persistedPortRaw
+      ? Number.parseInt(persistedPortRaw, 10)
+      : null;
+    const preferred =
+      persistedPort && Number.isFinite(persistedPort)
+        ? persistedPort
+        : (options.preferredPort ?? DEFAULT_PORT);
+    const range = options.portRange ?? PORT_RANGE;
+
+    let port = await reservePort(preferred, range);
+    if (port === null) {
+      // Fall back to ephemeral. Will trigger DCR re-register on next call
+      // because the redirect_uri changes — that path already works.
+      port = await new Promise<number>((resolve, reject) => {
+        const probe = createNetServer();
+        probe.once("error", reject);
+        probe.once("listening", () => {
+          const addr = probe.address();
+          const p = typeof addr === "object" && addr ? addr.port : 0;
+          probe.close(() => resolve(p));
+        });
+        probe.listen(0, "127.0.0.1");
+      });
+    }
+
+    if (port !== persistedPort) {
+      await kv.set("port", String(port));
+    }
+
+    const callbackUrl = `http://127.0.0.1:${port}/callback`;
+    const session = new OAuthSessionStore(
+      serverUrl,
+      { ...options, callbackUrl },
+      kv
+    );
+
+    return new NodeOAuthClientProvider(serverUrl, port, session, kv, options);
+  }
+
+  // --- Identity passthroughs (parallel to BrowserOAuthClientProvider) ---
+
+  get storageKeyPrefix(): string {
+    return this.session.storageKeyPrefix;
+  }
+
+  get serverUrlHash(): string {
+    return this.session.serverUrlHash;
+  }
+
+  // --- SDK Interface (delegated to OAuthSessionStore) ---
+
+  get redirectUrl(): string {
+    return this.session.redirectUrl;
+  }
+
+  get clientMetadata(): OAuthClientMetadata {
+    return this.session.clientMetadata;
+  }
+
+  tokens(): Promise<OAuthTokens | undefined> {
+    return this.session.tokens();
+  }
+
+  saveTokens(tokens: OAuthTokens): Promise<void> {
+    return this.session.saveTokens(tokens);
+  }
+
+  clientInformation(): Promise<OAuthClientInformation | undefined> {
+    return this.session.clientInformation();
+  }
+
+  saveClientInformation(info: OAuthClientInformation): Promise<void> {
+    return this.session.saveClientInformation(info);
+  }
+
+  codeVerifier(): Promise<string> {
+    return this.session.codeVerifier();
+  }
+
+  saveCodeVerifier(codeVerifier: string): Promise<void> {
+    return this.session.saveCodeVerifier(codeVerifier);
+  }
+
+  invalidateCredentials(
+    scope: "all" | "client" | "tokens" | "verifier"
+  ): Promise<void> {
+    return this.session.invalidateCredentials(scope);
+  }
+
+  /**
+   * Bind the loopback server, set up the pending-code deferred, and ask the
+   * platform to open the user's browser. Does NOT await the code; the
+   * orchestrator awaits via `getAuthorizationCode()`.
+   */
+  async redirectToAuthorization(authorizationUrl: URL): Promise<void> {
+    if (this.pending) {
+      throw new Error(
+        "NodeOAuthClientProvider: an authorization is already in progress"
+      );
+    }
+
+    const sanitizedUrl = await this.session.storeAuthorizationState(
+      authorizationUrl,
+      { flowType: "redirect" }
+    );
+
+    await this.startLoopback();
+
+    this.pending = createDeferred<string>();
+    this.lastFlow = this.pending;
+    // Swallow unhandled rejections — callers may not subscribe before the
+    // callback fires, but `getAuthorizationCode()` still returns the same
+    // settled promise so the rejection is observable when awaited.
+    this.pending.promise.catch(() => {});
+    this.pendingTimer = setTimeout(() => {
+      this.rejectPending(
+        new OAuthFlowError(
+          "timeout",
+          `No callback received within ${this.authTimeoutMs}ms`
+        )
+      );
+    }, this.authTimeoutMs);
+
+    const opener = this.openBrowserOverride ?? defaultOpener;
+    try {
+      await opener(sanitizedUrl);
+      // Browser opened (or queued). Caller will print the URL too — see CLI.
+    } catch (err) {
+      // Non-fatal: we still print/keep listening so the user can paste.
+      console.error(
+        `[mcp-use] Could not open browser automatically: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
+  }
+
+  /**
+   * Resolves with the authorization code captured by the loopback callback.
+   * Must be called after `redirectToAuthorization()`. Returns the same
+   * promise whether the callback has fired or not — callers may subscribe
+   * before or after.
+   */
+  getAuthorizationCode(): Promise<string> {
+    if (!this.lastFlow) {
+      return Promise.reject(
+        new Error(
+          "NodeOAuthClientProvider.getAuthorizationCode() called before redirectToAuthorization()"
+        )
+      );
+    }
+    return this.lastFlow.promise;
+  }
+
+  /**
+   * Force-refresh the access token using the persisted refresh_token.
+   * Returns the new tokens on success, or null if no refresh_token / refresh failed.
+   */
+  async forceRefresh(): Promise<OAuthTokens | null> {
+    const existing = await this.session.tokens();
+    if (!existing?.refresh_token) return null;
+    // OAuthSessionStore.tokens() refreshes when JWT is near expiry. To force
+    // unconditionally, drop the access_token and read again.
+    await this.saveTokens({ ...existing, access_token: "" });
+    const refreshed = await this.session.tokens();
+    return refreshed ?? null;
+  }
+
+  /**
+   * Cancel an in-progress flow (timeout, SIGINT, etc.) and close the loopback.
+   */
+  dispose(): void {
+    if (this.pending) {
+      this.rejectPending(new OAuthFlowError("cancelled", "Flow cancelled"));
+    } else {
+      this.stopLoopback();
+    }
+  }
+
+  /** Best-effort port for tests / status output. */
+  get callbackPort(): number {
+    return this.port;
+  }
+
+  /**
+   * True if `redirectToAuthorization()` has been called and we're awaiting
+   * a callback (loopback bound, browser opened). Lets orchestrators detect
+   * when the SDK transport has already kicked off the flow on a 401, so they
+   * can skip straight to `getAuthorizationCode()` instead of calling `auth()`
+   * again (which would throw "already in progress").
+   */
+  get hasPendingFlow(): boolean {
+    return this.pending !== null;
+  }
+
+  // --- Loopback internals ---
+
+  private async startLoopback(): Promise<void> {
+    if (this.server) return;
+    const server = createHttpServer((req, res) => {
+      this.handleCallback(req.url ?? "/", res);
+    });
+    this.server = server;
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(this.port, "127.0.0.1", () => {
+        server.removeListener("error", reject);
+        resolve();
+      });
+    });
+  }
+
+  private stopLoopback(): void {
+    if (this.pendingTimer) {
+      clearTimeout(this.pendingTimer);
+      this.pendingTimer = null;
+    }
+    if (this.server) {
+      this.server.close();
+      this.server = null;
+    }
+  }
+
+  private resolvePending(code: string): void {
+    const p = this.pending;
+    this.pending = null;
+    this.stopLoopback();
+    p?.resolve(code);
+  }
+
+  private rejectPending(err: Error): void {
+    const p = this.pending;
+    this.pending = null;
+    this.stopLoopback();
+    p?.reject(err);
+  }
+
+  private handleCallback(
+    rawUrl: string,
+    res: import("node:http").ServerResponse
+  ): void {
+    const url = new URL(rawUrl, `http://127.0.0.1:${this.port}`);
+
+    if (url.pathname !== "/callback") {
+      res.statusCode = 404;
+      res.end("Not Found");
+      return;
+    }
+
+    const code = url.searchParams.get("code");
+    const state = url.searchParams.get("state");
+    const err = url.searchParams.get("error");
+    const errDesc = url.searchParams.get("error_description") ?? undefined;
+
+    if (err) {
+      res.statusCode = 400;
+      res.setHeader("content-type", "text/html; charset=utf-8");
+      res.end(FAILURE_HTML(err, errDesc));
+      this.rejectPending(new OAuthFlowError(err, errDesc));
+      return;
+    }
+
+    if (!code || !state) {
+      res.statusCode = 400;
+      res.end("Missing code or state");
+      // Don't reject — the user might retry; let timeout do the cleanup.
+      return;
+    }
+
+    res.statusCode = 200;
+    res.setHeader("content-type", "text/html; charset=utf-8");
+    res.end(SUCCESS_HTML);
+    this.resolvePending(code);
+  }
+}
+
+async function defaultOpener(url: string): Promise<void> {
+  // Best-effort fallback. CLI passes a richer override (the `open` package).
+  const { spawn } = await import("node:child_process");
+  const { platform } = await import("node:process");
+  const cmd =
+    platform === "darwin" ? "open" : platform === "win32" ? "cmd" : "xdg-open";
+  const args = platform === "win32" ? ["/c", "start", "", url] : [url];
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(cmd, args, { stdio: "ignore", detached: true });
+    child.once("error", reject);
+    child.once("spawn", () => {
+      child.unref();
+      resolve();
+    });
+  });
+}

--- a/libraries/typescript/packages/mcp-use/src/auth/oauth-session-store.ts
+++ b/libraries/typescript/packages/mcp-use/src/auth/oauth-session-store.ts
@@ -334,4 +334,23 @@ export class OAuthSessionStore {
       this._refreshPromise = null;
     }
   }
+
+  /**
+   * Unconditionally exchange the persisted refresh_token for a new access
+   * token. Returns the new tokens on success, or `null` if no refresh_token
+   * is stored or the server rejected the grant. Shares the in-process
+   * coalescing window with the lazy refresh in `tokens()`.
+   */
+  async forceRefresh(): Promise<OAuthTokens | null> {
+    const data = await this.store.get(this.getKey("tokens"));
+    if (!data) return null;
+    let stored: OAuthTokens;
+    try {
+      stored = JSON.parse(data) as OAuthTokens;
+    } catch {
+      return null;
+    }
+    if (!stored.refresh_token) return null;
+    return this._dedupedRefresh(stored);
+  }
 }

--- a/libraries/typescript/packages/mcp-use/src/connectors/http.ts
+++ b/libraries/typescript/packages/mcp-use/src/connectors/http.ts
@@ -383,14 +383,15 @@ export class HttpConnector extends BaseConnector {
 
       // Store the transport for later cleanup
       this.streamableTransport = streamableTransport;
-      // Create a minimal connection manager wrapper for cleanup purposes
+      // Create a minimal connection manager wrapper for cleanup purposes.
+      // Note: terminateSession() is invoked from cleanupResources() *before*
+      // the SDK's client.close() aborts the transport's abort controller.
+      // Calling terminateSession() here would race the abort and surface a
+      // spurious AbortError on every clean shutdown.
       this.connectionManager = {
         stop: async () => {
           if (this.streamableTransport) {
             try {
-              // First terminate the session per MCP spec (sends DELETE request)
-              await this.streamableTransport.terminateSession();
-              // Then close the transport
               await this.streamableTransport.close();
             } catch (e) {
               logger.warn(`Error closing Streamable HTTP transport: ${e}`);
@@ -493,5 +494,20 @@ export class HttpConnector extends BaseConnector {
    */
   getTransportType(): "streamable-http" | "sse" | null {
     return this.transportType;
+  }
+
+  // Send the streamable-HTTP DELETE *before* super.cleanupResources() invokes
+  // client.close(). The SDK's transport.close() aborts the shared abort
+  // controller, and terminateSession()'s DELETE fetch reuses that signal —
+  // running it after close() rejects immediately with AbortError.
+  protected async cleanupResources(): Promise<void> {
+    if (this.streamableTransport) {
+      try {
+        await this.streamableTransport.terminateSession();
+      } catch (e) {
+        logger.debug(`Error terminating Streamable HTTP session: ${e}`);
+      }
+    }
+    await super.cleanupResources();
   }
 }

--- a/libraries/typescript/packages/mcp-use/src/server/utils/server-lifecycle.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/utils/server-lifecycle.ts
@@ -4,6 +4,7 @@
  * Runtime-aware helpers for server startup, path rewriting, and CORS handling.
  */
 
+import chalk from "chalk";
 import type { Hono as HonoType } from "hono";
 import { getEnv, isDeno } from "./runtime.js";
 
@@ -161,6 +162,11 @@ export async function startServer(
       }
     );
     console.log(`[SERVER] Listening`);
+    console.log(
+      chalk.gray(
+        `[MCP] Tip: connect with the CLI → npx mcp-use client connect http://${host}:${port}/mcp`
+      )
+    );
     return {
       close: async () => {},
       forceClose: async () => {},
@@ -177,6 +183,11 @@ export async function startServer(
       (_info: any) => {
         console.log(`[SERVER] Listening on http://${host}:${port}`);
         console.log(`[MCP] Endpoints: http://${host}:${port}/mcp`);
+        console.log(
+          chalk.gray(
+            `[MCP] Tip: connect with the CLI → npx mcp-use client connect http://${host}:${port}/mcp`
+          )
+        );
       }
     );
 

--- a/libraries/typescript/packages/mcp-use/tests/integration/auth/node-provider-flow.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/integration/auth/node-provider-flow.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Integration tests for NodeOAuthClientProvider.
+ *
+ * Drives the full two-call OAuth dance against an in-process fake
+ * authorization server. The only mock is the browser opener — we capture
+ * the URL the provider would have opened and `fetch` it ourselves to
+ * simulate the user granting consent.
+ *
+ * Run with:
+ *   pnpm --filter mcp-use test -- tests/integration/auth/node-provider-flow.test.ts
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { auth } from "@modelcontextprotocol/sdk/client/auth.js";
+import { createServer } from "node:http";
+import type { Server } from "node:http";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AddressInfo } from "node:net";
+import { NodeOAuthClientProvider } from "../../../src/auth/node-provider.js";
+
+interface FakeAS {
+  url: string;
+  server: Server;
+  close: () => Promise<void>;
+  registered: { redirectUris: string[] }[];
+  /** Last authorization URL captured (so the test can pretend the user accepted). */
+  lastAuthorizeUrl: string | null;
+  /** Last issued code. */
+  lastCode: string | null;
+}
+
+async function startFakeAuthServer(): Promise<FakeAS> {
+  const state: FakeAS = {
+    url: "",
+    server: undefined as unknown as Server,
+    close: async () => {},
+    registered: [],
+    lastAuthorizeUrl: null,
+    lastCode: null,
+  };
+
+  const server = createServer(async (req, res) => {
+    const url = new URL(req.url ?? "/", `http://127.0.0.1`);
+    res.setHeader("content-type", "application/json");
+
+    if (url.pathname === "/.well-known/oauth-protected-resource") {
+      res.statusCode = 200;
+      res.end(
+        JSON.stringify({
+          resource: state.url,
+          authorization_servers: [state.url],
+        })
+      );
+      return;
+    }
+
+    if (
+      url.pathname === "/.well-known/oauth-authorization-server" ||
+      url.pathname === "/.well-known/openid-configuration"
+    ) {
+      res.statusCode = 200;
+      res.end(
+        JSON.stringify({
+          issuer: state.url,
+          authorization_endpoint: `${state.url}/authorize`,
+          token_endpoint: `${state.url}/token`,
+          registration_endpoint: `${state.url}/register`,
+          response_types_supported: ["code"],
+          grant_types_supported: ["authorization_code", "refresh_token"],
+          token_endpoint_auth_methods_supported: ["none"],
+          code_challenge_methods_supported: ["S256"],
+        })
+      );
+      return;
+    }
+
+    if (url.pathname === "/register" && req.method === "POST") {
+      const body = await readBody(req);
+      const parsed = JSON.parse(body);
+      state.registered.push({ redirectUris: parsed.redirect_uris ?? [] });
+      res.statusCode = 200;
+      res.end(
+        JSON.stringify({
+          client_id: "fake-client-id",
+          redirect_uris: parsed.redirect_uris,
+          token_endpoint_auth_method: "none",
+        })
+      );
+      return;
+    }
+
+    if (url.pathname === "/authorize") {
+      // The SDK builds the URL, our provider opens "the browser". The test
+      // grabs it via openBrowser injection — we don't actually serve a UI.
+      state.lastAuthorizeUrl = url.toString();
+      res.statusCode = 200;
+      res.setHeader("content-type", "text/plain");
+      res.end("would render consent page");
+      return;
+    }
+
+    if (url.pathname === "/token" && req.method === "POST") {
+      // Issue tokens for either authorization_code or refresh_token.
+      res.statusCode = 200;
+      res.end(
+        JSON.stringify({
+          access_token: "test-access-token",
+          refresh_token: "test-refresh-token",
+          token_type: "Bearer",
+          expires_in: 3600,
+        })
+      );
+      return;
+    }
+
+    res.statusCode = 404;
+    res.end("{}");
+  });
+
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+  const addr = server.address() as AddressInfo;
+  state.url = `http://127.0.0.1:${addr.port}`;
+  state.server = server;
+  state.close = () => new Promise<void>((r) => server.close(() => r()));
+  return state;
+}
+
+function readBody(req: import("node:http").IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    req.on("data", (chunk) => (data += chunk));
+    req.on("end", () => resolve(data));
+    req.on("error", reject);
+  });
+}
+
+let baseDir: string;
+let fakeAS: FakeAS;
+
+beforeAll(async () => {
+  fakeAS = await startFakeAuthServer();
+});
+
+afterAll(async () => {
+  await fakeAS.close();
+});
+
+beforeEach(() => {
+  baseDir = mkdtempSync(join(tmpdir(), "mcp-use-node-prov-"));
+});
+
+describe("NodeOAuthClientProvider — full flow", () => {
+  it("redirectToAuthorization → loopback → getAuthorizationCode → token exchange", async () => {
+    let openedUrl: string | null = null;
+    const provider = await NodeOAuthClientProvider.create(fakeAS.url, {
+      baseDir,
+      preferredPort: 33518, // avoid clashing with default in case the dev box has one running
+      openBrowser: (url) => {
+        openedUrl = url;
+      },
+    });
+
+    const port = provider.callbackPort;
+    expect(port).toBeGreaterThanOrEqual(33518);
+
+    // Step 1: kick off the flow. SDK does discovery + DCR + builds authorize URL,
+    // then calls our redirectToAuthorization which binds loopback + invokes opener.
+    const result1 = await auth(provider, { serverUrl: fakeAS.url });
+    expect(result1).toBe("REDIRECT");
+    expect(openedUrl).toBeTruthy();
+
+    // The opened URL should target the fake AS's /authorize and contain state.
+    const opened = new URL(openedUrl!);
+    expect(opened.toString()).toContain(`${fakeAS.url}/authorize`);
+    const stateParam = opened.searchParams.get("state");
+    expect(stateParam).toBeTruthy();
+    // Redirect URI registered by DCR matches our loopback.
+    expect(fakeAS.registered).toHaveLength(1);
+    expect(fakeAS.registered[0].redirectUris).toEqual([
+      `http://127.0.0.1:${port}/callback`,
+    ]);
+
+    // Step 2: simulate the AS redirecting the user back to our loopback.
+    const callbackResp = await fetch(
+      `http://127.0.0.1:${port}/callback?code=fake-code&state=${stateParam}`
+    );
+    expect(callbackResp.status).toBe(200);
+    const html = await callbackResp.text();
+    expect(html).toContain("Authentication complete");
+
+    // Step 3: orchestrator awaits the code.
+    const code = await provider.getAuthorizationCode();
+    expect(code).toBe("fake-code");
+
+    // Step 4: exchange the code for tokens.
+    const result2 = await auth(provider, {
+      serverUrl: fakeAS.url,
+      authorizationCode: code,
+    });
+    expect(result2).toBe("AUTHORIZED");
+
+    const tokens = await provider.tokens();
+    expect(tokens?.access_token).toBe("test-access-token");
+    expect(tokens?.refresh_token).toBe("test-refresh-token");
+  });
+
+  it("rejects with OAuthFlowError on ?error= callbacks", async () => {
+    const provider = await NodeOAuthClientProvider.create(fakeAS.url, {
+      baseDir,
+      preferredPort: 33528,
+      openBrowser: () => {},
+    });
+
+    await auth(provider, { serverUrl: fakeAS.url });
+
+    const port = provider.callbackPort;
+    await fetch(
+      `http://127.0.0.1:${port}/callback?error=access_denied&error_description=user+said+no`
+    );
+
+    await expect(provider.getAuthorizationCode()).rejects.toMatchObject({
+      name: "OAuthFlowError",
+      code: "access_denied",
+    });
+  });
+
+  it("times out cleanly if no callback arrives", async () => {
+    const provider = await NodeOAuthClientProvider.create(fakeAS.url, {
+      baseDir,
+      preferredPort: 33538,
+      authTimeoutMs: 100,
+      openBrowser: () => {},
+    });
+    await auth(provider, { serverUrl: fakeAS.url });
+
+    await expect(provider.getAuthorizationCode()).rejects.toMatchObject({
+      name: "OAuthFlowError",
+      code: "timeout",
+    });
+  });
+
+  it("persists the chosen port across instances", async () => {
+    const a = await NodeOAuthClientProvider.create(fakeAS.url, {
+      baseDir,
+      preferredPort: 33548,
+      openBrowser: () => {},
+    });
+    expect(a.callbackPort).toBe(33548);
+
+    const b = await NodeOAuthClientProvider.create(fakeAS.url, {
+      baseDir,
+      preferredPort: 33999, // user passes a different preference, but disk wins
+      openBrowser: () => {},
+    });
+    expect(b.callbackPort).toBe(33548);
+  });
+
+  it("hasPendingFlow tracks the redirect → callback lifecycle", async () => {
+    let openedUrl: string | null = null;
+    const provider = await NodeOAuthClientProvider.create(fakeAS.url, {
+      baseDir,
+      preferredPort: 33568,
+      openBrowser: (url) => {
+        openedUrl = url;
+      },
+    });
+
+    expect(provider.hasPendingFlow).toBe(false);
+
+    // SDK auth() invokes redirectToAuthorization → loopback bound, pending set.
+    const result = await auth(provider, { serverUrl: fakeAS.url });
+    expect(result).toBe("REDIRECT");
+    expect(provider.hasPendingFlow).toBe(true);
+
+    // Callback resolves the flow → pending cleared.
+    const stateParam = new URL(openedUrl!).searchParams.get("state");
+    await fetch(
+      `http://127.0.0.1:${provider.callbackPort}/callback?code=c&state=${stateParam}`
+    );
+    await provider.getAuthorizationCode();
+    expect(provider.hasPendingFlow).toBe(false);
+  });
+
+  it("walks the port range when the preferred port is taken", async () => {
+    const blocker = createServer().listen(33558, "127.0.0.1");
+    try {
+      await new Promise<void>((r) => blocker.once("listening", r));
+      const provider = await NodeOAuthClientProvider.create(fakeAS.url, {
+        baseDir,
+        preferredPort: 33558,
+        portRange: 5,
+        openBrowser: () => {},
+      });
+      expect(provider.callbackPort).toBeGreaterThan(33558);
+      expect(provider.callbackPort).toBeLessThan(33558 + 5);
+    } finally {
+      await new Promise<void>((r) => blocker.close(() => r()));
+    }
+  });
+});

--- a/libraries/typescript/packages/mcp-use/tests/integration/auth/node-provider-flow.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/integration/auth/node-provider-flow.test.ts
@@ -29,6 +29,8 @@ interface FakeAS {
   lastAuthorizeUrl: string | null;
   /** Last issued code. */
   lastCode: string | null;
+  /** Count of /token POSTs by grant_type. */
+  tokenGrants: { authorization_code: number; refresh_token: number };
 }
 
 async function startFakeAuthServer(): Promise<FakeAS> {
@@ -39,6 +41,7 @@ async function startFakeAuthServer(): Promise<FakeAS> {
     registered: [],
     lastAuthorizeUrl: null,
     lastCode: null,
+    tokenGrants: { authorization_code: 0, refresh_token: 0 },
   };
 
   const server = createServer(async (req, res) => {
@@ -102,11 +105,22 @@ async function startFakeAuthServer(): Promise<FakeAS> {
     }
 
     if (url.pathname === "/token" && req.method === "POST") {
-      // Issue tokens for either authorization_code or refresh_token.
+      const body = await readBody(req);
+      const params = new URLSearchParams(body);
+      const grant = params.get("grant_type");
+      if (grant === "refresh_token") {
+        state.tokenGrants.refresh_token += 1;
+      } else {
+        state.tokenGrants.authorization_code += 1;
+      }
+      const suffix = state.tokenGrants.refresh_token;
       res.statusCode = 200;
       res.end(
         JSON.stringify({
-          access_token: "test-access-token",
+          access_token:
+            grant === "refresh_token"
+              ? `test-access-token-refreshed-${suffix}`
+              : "test-access-token",
           refresh_token: "test-refresh-token",
           token_type: "Bearer",
           expires_in: 3600,
@@ -281,6 +295,72 @@ describe("NodeOAuthClientProvider — full flow", () => {
     );
     await provider.getAuthorizationCode();
     expect(provider.hasPendingFlow).toBe(false);
+  });
+
+  it("forceRefresh exchanges the refresh_token for a new access token", async () => {
+    let openedUrl: string | null = null;
+    const provider = await NodeOAuthClientProvider.create(fakeAS.url, {
+      baseDir,
+      preferredPort: 33578,
+      openBrowser: (url) => {
+        openedUrl = url;
+      },
+    });
+
+    // Drive the initial flow so tokens + refresh_token are persisted.
+    await auth(provider, { serverUrl: fakeAS.url });
+    const stateParam = new URL(openedUrl!).searchParams.get("state");
+    await fetch(
+      `http://127.0.0.1:${provider.callbackPort}/callback?code=fake-code&state=${stateParam}`
+    );
+    const code = await provider.getAuthorizationCode();
+    await auth(provider, { serverUrl: fakeAS.url, authorizationCode: code });
+
+    const initial = await provider.tokens();
+    expect(initial?.access_token).toBe("test-access-token");
+    const grantsBefore = fakeAS.tokenGrants.refresh_token;
+
+    const refreshed = await provider.forceRefresh();
+    expect(refreshed).not.toBeNull();
+    expect(refreshed!.access_token).toMatch(/^test-access-token-refreshed-/);
+    expect(fakeAS.tokenGrants.refresh_token).toBe(grantsBefore + 1);
+
+    // Persisted tokens reflect the refreshed value.
+    const persisted = await provider.tokens();
+    expect(persisted?.access_token).toBe(refreshed!.access_token);
+  });
+
+  it("forceRefresh returns null when no refresh_token is stored", async () => {
+    const provider = await NodeOAuthClientProvider.create(fakeAS.url, {
+      baseDir,
+      preferredPort: 33588,
+      openBrowser: () => {},
+    });
+    expect(await provider.forceRefresh()).toBeNull();
+  });
+
+  it("escapes HTML in the loopback failure page", async () => {
+    const provider = await NodeOAuthClientProvider.create(fakeAS.url, {
+      baseDir,
+      preferredPort: 33598,
+      openBrowser: () => {},
+    });
+    await auth(provider, { serverUrl: fakeAS.url });
+
+    const port = provider.callbackPort;
+    const payload = "<script>alert(1)</script>";
+    const resp = await fetch(
+      `http://127.0.0.1:${port}/callback?error=${encodeURIComponent(
+        payload
+      )}&error_description=${encodeURIComponent(payload)}`
+    );
+    const html = await resp.text();
+    expect(html).not.toContain("<script>alert(1)</script>");
+    expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+
+    await expect(provider.getAuthorizationCode()).rejects.toMatchObject({
+      name: "OAuthFlowError",
+    });
   });
 
   it("walks the port range when the preferred port is taken", async () => {

--- a/libraries/typescript/packages/mcp-use/tests/unit/auth/file-kv-store.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/auth/file-kv-store.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Unit tests for FileKVStore.
+ *
+ * Run with:
+ *   pnpm --filter mcp-use test:unit -- tests/unit/auth/file-kv-store.test.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { FileKVStore } from "../../../src/auth/file-kv-store.js";
+import { mkdtempSync, rmSync, statSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const isWindows = process.platform === "win32";
+
+let baseDir: string;
+
+beforeEach(() => {
+  baseDir = mkdtempSync(join(tmpdir(), "mcp-use-fkv-"));
+});
+
+afterEach(() => {
+  rmSync(baseDir, { recursive: true, force: true });
+});
+
+describe("FileKVStore", () => {
+  it("round-trips simple keys", () => {
+    const kv = new FileKVStore("abc123", baseDir);
+    kv.set("tokens", '{"access":"x"}');
+    expect(kv.get("tokens")).toBe('{"access":"x"}');
+  });
+
+  it("returns null for missing keys", () => {
+    const kv = new FileKVStore("abc123", baseDir);
+    expect(kv.get("nope")).toBeNull();
+  });
+
+  it("removes keys", () => {
+    const kv = new FileKVStore("abc123", baseDir);
+    kv.set("k", "v");
+    expect(kv.get("k")).toBe("v");
+    kv.remove("k");
+    expect(kv.get("k")).toBeNull();
+  });
+
+  it("remove on missing key is a no-op", () => {
+    const kv = new FileKVStore("abc123", baseDir);
+    expect(() => kv.remove("never-set")).not.toThrow();
+  });
+
+  it("lists keys (excluding tmp files)", () => {
+    const kv = new FileKVStore("abc123", baseDir);
+    kv.set("tokens", "1");
+    kv.set("client_info", "2");
+    expect(kv.keys().sort()).toEqual(["client_info", "tokens"]);
+  });
+
+  it("isolates per server hash", () => {
+    const a = new FileKVStore("hash-a", baseDir);
+    const b = new FileKVStore("hash-b", baseDir);
+    a.set("tokens", "from-a");
+    b.set("tokens", "from-b");
+    expect(a.get("tokens")).toBe("from-a");
+    expect(b.get("tokens")).toBe("from-b");
+  });
+
+  it("sanitizes keys with colons (cross-platform safety)", () => {
+    const kv = new FileKVStore("abc123", baseDir);
+    kv.set("mcp:auth_abc123_tokens", "T");
+    kv.set("mcp:auth:state_xyz", "S");
+    expect(kv.get("mcp:auth_abc123_tokens")).toBe("T");
+    expect(kv.get("mcp:auth:state_xyz")).toBe("S");
+    // Keys list returns sanitized filenames, both present.
+    expect(kv.keys()).toHaveLength(2);
+  });
+
+  it("rejects directory traversal in keys", () => {
+    const kv = new FileKVStore("abc123", baseDir);
+    // Sanitization replaces "/" with "_", so this becomes a flat name.
+    expect(() => kv.set("../escape", "no")).not.toThrow();
+    expect(kv.get("../escape")).toBe("no");
+    // The actual file should be inside this.dir, not outside it.
+    const files = readdirSync(baseDir);
+    // baseDir contains exactly one subdir (abc123); no traversal-up files.
+    expect(files).toEqual(["abc123"]);
+  });
+
+  it("overwrites existing values atomically (no .tmp residue)", () => {
+    const kv = new FileKVStore("abc123", baseDir);
+    kv.set("k", "v1");
+    kv.set("k", "v2");
+    expect(kv.get("k")).toBe("v2");
+    // No temp files left over.
+    const dir = join(baseDir, "abc123");
+    const remaining = readdirSync(dir);
+    expect(remaining.filter((n) => n.includes(".tmp."))).toEqual([]);
+  });
+
+  it.skipIf(isWindows)("creates dir 0o700 and files 0o600", () => {
+    const kv = new FileKVStore("abc123", baseDir);
+    kv.set("tokens", "secret");
+    const dirStat = statSync(join(baseDir, "abc123"));
+    expect(dirStat.mode & 0o777).toBe(0o700);
+    const fileStat = statSync(join(baseDir, "abc123", "tokens"));
+    expect(fileStat.mode & 0o777).toBe(0o600);
+  });
+});

--- a/libraries/typescript/packages/mcp-use/tsup.config.ts
+++ b/libraries/typescript/packages/mcp-use/tsup.config.ts
@@ -72,6 +72,7 @@ export default defineConfig([
       "src/adapters/index.ts",
       "src/agents/index.ts",
       "src/auth/index.ts",
+      "src/auth/index-node.ts",
       "src/bin.ts",
       "src/client.ts",
       "src/server/index.ts",


### PR DESCRIPTION
## Language / Project Scope

- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

Adds a real OAuth flow to the `mcp-use client` CLI so it works against OAuth-protected MCP servers without a browser harness, and makes every one-shot client subcommand exit cleanly so headless agents can drive it. Stacked on #1451 (`refactor/oauth-client-provider-session-store`) — that PR's `OAuthSessionStore` extraction is what `NodeOAuthClientProvider` reuses.

## Implementation Details

1. **`mcp-use/auth/node` entrypoint** — new entry exporting `NodeOAuthClientProvider`, `FileKVStore`, the `KVStore` type, and re-exporting the SDK's `auth` + `UnauthorizedError`.
2. **`NodeOAuthClientProvider`** — implements `OAuthClientProvider`, owns a localhost loopback callback server (preferred port `33418`, walks up to `33427` on conflict, persisted across runs in the KV store), and exposes `getAuthorizationCode()` for the orchestrator pattern in `useMcp.ts:1121-1145`. Delegates token / client / verifier persistence to the `OAuthSessionStore` from #1451.
3. **`hasPendingFlow` getter** — needed because `StreamableHTTPClientTransport` auto-calls `auth()` on a 401, which already invokes `redirectToAuthorization()` (loopback bound, browser opened). Without this flag, the CLI's `runOAuthFlow` would call `auth()` a second time and throw _\"an authorization is already in progress\"_.
4. **`FileKVStore`** — writes one file per key under `~/.mcp-use/oauth/<urlHash>/` with `0o600` perms and atomic rename on write (`writeFile`-to-temp + `rename`).
5. **CLI `client connect`** — auto-runs OAuth on `UnauthorizedError` when no `--auth` is supplied. New flags: `--no-oauth` (disable auto-OAuth) and `--auth-timeout <ms>` (loopback wait, default 5min). `isUnauthorized` also matches the rewrapped 401 that `HttpConnector` throws (plain `Error` with `code = 401`) so the OAuth retry actually triggers — without this fix the CLI `process.exit(1)`'d before the browser callback arrived, leaving the user with a \"connection refused\" loopback page.
6. **CLI `client auth` scope** — `auth status|refresh|logout [session]` for token introspection, forced refresh, and revocation. (No `auth login` — that's what `connect` is for.)
7. **Headless exit fix** — every one-shot client subcommand (`tools list/call/describe`, `resources list/read`, `prompts list/get`, `auth *`) now closes its in-memory session and exits when done. The HTTP transport's keepalive stream was holding the Node event loop open, so processes hung forever and the CLI was unusable for agent-driven flows. `subscribe` and `interactive` are unchanged — they still keep the loop alive until Ctrl+C / `quit`.

No new runtime dependencies. The CLI's existing `open` package is reused for the browser launcher.

## Packages Modified

- [ ] `docs`
- [x] `tests`
- [x] `cli`
- [ ] `create-mcp-use-app`
- [x] `mcp-use` (server)
- [x] `mcp-use` (client)
- [ ] `inspector`

## Pre-commit Checklist

- [x] Ran `pnpm lint:fix` to auto-fix linting issues (no `lint` script — Husky pre-commit + Prettier handle this)
- [x] Ran `pnpm format` to format code with Prettier
- [x] Ran `pnpm build` and build succeeds without errors
- [x] Ran `pnpm changeset` to create a changeset (3 changesets: `node-oauth-cli-flow.md`, `cli-client-headless-exit.md`, `node-oauth-pending-flow-fix.md`)
- [x] Added or updated tests if needed
- [ ] Updated documentation in `docs/` folder if needed (TBD — not yet done in this PR)

## Example Usage (Before)

```bash
$ mcp-use client connect https://mcp.manufact.com/mcp
Connecting to https://mcp.manufact.com/mcp...
[mcp-use] info: Authentication required - skipping SSE fallback
✗ Error: Connection failed: Authentication required
# Process exits 1, no OAuth flow attempted.
```

```bash
# Even with a working session, the client hung after every command:
$ mcp-use client tools list --session manufact
... output ...
^C  # had to Ctrl+C — useless for agents
```

## Example Usage (After)

```bash
$ mcp-use client connect https://mcp.manufact.com/mcp --name manufact
Connecting to https://mcp.manufact.com/mcp...
[mcp-use] info: Authentication required - skipping SSE fallback
⚠ Server requires authentication. Starting OAuth flow.
→ Opening browser to authenticate...
  Listening on http://127.0.0.1:33418/callback (waiting up to 5m)
✓ Authentication successful
✓ Connected to manufact

Server Information:
  Name   : manufact-cloud
  Version: 1.0.0

Capabilities:
  logging, completions, prompts, resources, tools

Available: 18 tools
```

```bash
$ mcp-use client auth status manufact
  session   : manufact
  url       : https://mcp.manufact.com/mcp
  tokens    : present
  scope     : openid profile email offline_access
  expires_in: 58m
  refresh   : available

$ mcp-use client tools call list_organizations '{}' --session manufact
✓ Tool executed successfully
{ "organizations": [...] }
# Process exits 0 cleanly.
```

## Documentation Updates

None in this PR. Worth a follow-up to document the `auth/node` entrypoint and the `mcp-use client auth` subcommand in `docs/`.

## Testing

- **Unit tests added**: `packages/mcp-use/tests/unit/auth/file-kv-store.test.ts` — covers atomic writes, `0o600` perms, key-by-key isolation.
- **Integration tests added**: `packages/mcp-use/tests/integration/auth/node-provider-flow.test.ts` — drives the full two-call OAuth dance against an in-process fake authorization server. Covers happy path, `?error=` callback rejection, timeout, port persistence across runs, port-range walk on `EADDRINUSE`, and the `hasPendingFlow` redirect → callback lifecycle.
- **Manual testing**: end-to-end verified against `https://mcp.manufact.com/mcp`:
  - First-time `connect` → browser OAuth → `Connected to manufact` (18 tools, `logging, completions, prompts, resources, tools`)
  - `auth status` → tokens present, refresh available, JWT exp displayed
  - `auth refresh` → forced refresh issues a fresh access token
  - `tools list` / `tools call list_organizations` / `tools call get_organization_stats` / `tools call list_servers` — all succeed via reconnect with stored tokens
  - All commands exit 0; no orphan processes (verified via `ps aux | grep client tools`).
- **Edge cases**: SDK transport auto-triggering OAuth on 401 vs. our orchestrator (handled via `hasPendingFlow`), rewrapped 401 detection, refresh-token-dead → re-auth prompt on TTY / explicit command on non-TTY.

## Backwards Compatibility

Backwards compatible. New entrypoints (`mcp-use/auth/node`) and new CLI subcommands (`client auth ...`); existing `client connect` behavior is unchanged when `--auth <token>` is supplied.

The headless-exit fix changes process lifetime for `client tools/resources/prompts` subcommands: they now exit when done instead of hanging. Anyone relying on the previous hang-forever behavior would need to switch to `client interactive` or `client subscribe`.

## Related Issues

Closes MCP-2094