### PR TITLE
fix: prefix router resource names

### DIFF
--- a/libraries/python/mcp_use/server/router.py
+++ b/libraries/python/mcp_use/server/router.py
@@ -229,7 +229,19 @@ class MCPRouter:
             )
 
         for resource in router._pending_resources:
-            self._pending_resources.append(resource)
+            resource_name = resource.name or getattr(resource.fn, "__name__", "unknown")
+            if combined_prefix:
+                resource_name = f"{combined_prefix}_{resource_name}"
+
+            self._pending_resources.append(
+                PendingResource(
+                    fn=resource.fn,
+                    uri=resource.uri,
+                    name=resource_name,
+                    description=resource.description,
+                    mime_type=resource.mime_type,
+                )
+            )
 
         for prompt in router._pending_prompts:
             prompt_name = prompt.name or getattr(prompt.fn, "__name__", "unknown")

--- a/libraries/python/mcp_use/server/server.py
+++ b/libraries/python/mcp_use/server/server.py
@@ -319,7 +319,7 @@ class MCPServer(FastMCP):
                 resource_name = f"{prefix}_{resource_name}"
             self.resource(
                 uri=resource.uri,
-                name=resource.name,
+                name=resource_name,
                 description=resource.description,
                 mime_type=resource.mime_type,
             )(resource.fn)

--- a/libraries/python/tests/unit/server/test_router_prefixes.py
+++ b/libraries/python/tests/unit/server/test_router_prefixes.py
@@ -1,0 +1,37 @@
+from mcp_use.server import MCPRouter, MCPServer
+
+
+def test_server_include_router_prefixes_resources_like_tools_and_prompts():
+    router = MCPRouter()
+
+    @router.tool()
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    @router.resource("config://app")
+    def get_config() -> str:
+        return "cfg"
+
+    @router.prompt()
+    def greet(name: str) -> str:
+        return f"Hi {name}"
+
+    server = MCPServer(name="test-server")
+    server.include_router(router, prefix="math")
+
+    assert [tool.name for tool in server._tool_manager.list_tools()] == ["math_add"]
+    assert [resource.name for resource in server._resource_manager.list_resources()] == ["math_get_config"]
+    assert [prompt.name for prompt in server._prompt_manager.list_prompts()] == ["math_greet"]
+
+
+def test_nested_router_prefixes_resource_names():
+    child = MCPRouter()
+
+    @child.resource("config://app")
+    def get_config() -> str:
+        return "cfg"
+
+    parent = MCPRouter()
+    parent.include_router(child, prefix="math")
+
+    assert [resource.name for resource in parent.resources] == ["math_get_config"]


### PR DESCRIPTION
## Summary

Fixes inconsistent router prefixing for resources.

## Problem

`MCPServer.include_router(router, prefix=...)` prefixes tools and prompts, but resources still keep their unprefixed name. That makes composed routers behave inconsistently and can cause resource-name collisions when multiple routers expose similarly named resources.

## Changes

- Use the computed prefixed resource name when `MCPServer.include_router(...)` registers router resources.
- Apply the same resource-name prefixing in `MCPRouter.include_router(...)` for nested routers.
- Add regression coverage for server-level and nested-router resource prefixing.

Fixes #1438.

## Validation

- `.venv\Scripts\python.exe -m pytest libraries\python\tests\unit\server\test_router_prefixes.py`
- `.venv\Scripts\python.exe -m pytest libraries\python\tests\unit\server\test_server_config.py libraries\python\tests\unit\server\test_router_prefixes.py`
- `.venv\Scripts\ruff.exe check libraries\python\mcp_use\server\server.py libraries\python\mcp_use\server\router.py libraries\python\tests\unit\server\test_router_prefixes.py`
- `.venv\Scripts\python.exe -m py_compile libraries\python\mcp_use\server\server.py libraries\python\mcp_use\server\router.py libraries\python\tests\unit\server\test_router_prefixes.py`