### PR TITLE
docs(oauth examples): fix broken links in Clerk and WorkOS READMEs

### DIFF
--- a/libraries/typescript/packages/mcp-use/examples/server/oauth/clerk/README.md
+++ b/libraries/typescript/packages/mcp-use/examples/server/oauth/clerk/README.md
@@ -15,13 +15,13 @@ A production-ready example of an MCP server with Clerk OAuth 2.0 authentication,
 
 1. **Clerk Account**: Sign up at [clerk.com](https://clerk.com)
 2. **Node.js**: Version 18 or higher
-3. **Clerk Application**: Create an application in the [Clerk Dashboard](https://dashboard.clerk.com)
+3. **Clerk Application**: Create an application in the [Clerk Dashboard](https://dashboard.clerk.com/sign-in)
 
 ## Setup
 
 ### 1. Get Your Clerk Frontend API URL
 
-From the [Clerk Dashboard](https://dashboard.clerk.com):
+From the [Clerk Dashboard](https://dashboard.clerk.com/sign-in):
 
 1. Open your application
 2. Go to **Configure** → **API Keys**
@@ -33,7 +33,7 @@ From the [Clerk Dashboard](https://dashboard.clerk.com):
 
 **⚠️ IMPORTANT**: Dynamic Client Registration is **required** for MCP clients to work with Clerk.
 
-1. Go to the [Clerk Dashboard](https://dashboard.clerk.com)
+1. Go to the [Clerk Dashboard](https://dashboard.clerk.com/sign-in)
 2. Navigate to **Configure** → **OAuth Applications**
 3. Enable **Dynamic Client Registration**
 4. Save your changes

--- a/libraries/typescript/packages/mcp-use/examples/server/oauth/workos/README.md
+++ b/libraries/typescript/packages/mcp-use/examples/server/oauth/workos/README.md
@@ -15,7 +15,7 @@ A production-ready example of an MCP server with WorkOS AuthKit OAuth 2.0 authen
 
 1. **WorkOS Account**: Sign up at [workos.com](https://workos.com)
 2. **Node.js**: Version 18 or higher
-3. **AuthKit Setup**: Follow [WorkOS AuthKit Quickstart](https://workos.com/docs/authkit/quickstart) to set up your project
+3. **AuthKit Setup**: Follow [WorkOS AuthKit Quickstart](https://workos.com/docs/authkit) to set up your project
 
 ## What is WorkOS AuthKit?
 

--- a/skills/chatgpt-app-builder/SKILL.md
+++ b/skills/chatgpt-app-builder/SKILL.md
@@ -83,7 +83,7 @@ Load these before diving into tools/resources/widgets sections.
 ---
 
 ### 🔐 Adding Authentication?
-**When:** Protecting your server with OAuth (Auth0, Better Auth, WorkOS, Supabase, Keycloak, or any other provider)
+**When:** Protecting your server with OAuth (Auth0, Better Auth, Clerk, WorkOS, Supabase, Keycloak, or any other provider)
 
 - **[overview.md](references/authentication/overview.md)**
   - When: First time adding auth, understanding `ctx.auth`, or choosing a provider / integration mode
@@ -96,6 +96,10 @@ Load these before diving into tools/resources/widgets sections.
 - **[better-auth.md](references/authentication/better-auth.md)**
   - When: Using Better Auth with the `@better-auth/oauth-provider` plugin (self-hosted OAuth 2.1)
   - Covers: `oauthBetterAuthProvider`, auth URL / metadata routes, login and consent flows
+
+- **[clerk.md](references/authentication/clerk.md)**
+  - When: Using Clerk (DCR-based OAuth)
+  - Covers: `oauthClerkProvider`, enabling DCR, Frontend API URL, organization context
 
 - **[workos.md](references/authentication/workos.md)**
   - When: Using WorkOS AuthKit (DCR only)

--- a/skills/chatgpt-app-builder/references/authentication/auth0.md
+++ b/skills/chatgpt-app-builder/references/authentication/auth0.md
@@ -5,7 +5,7 @@ Setting up OAuth with Auth0. Two modes depending on whether you have access to A
 - **DCR (built-in)** → use `oauthAuth0Provider`. Requires Auth0's Early Access program.
 - **OAuth proxy** → use `oauthProxy` + `jwksVerifier` with a standard Auth0 Regular Web App. No Early Access required.
 
-**Learn more:** [Auth0 MCP Authorization Guide](https://auth0.com/ai/docs/mcp/get-started/authorization-for-your-mcp-server) · [Runnable DCR example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/auth0) · [Runnable proxy example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/auth0-proxy)
+**Learn more:** [Auth0 MCP Authorization Guide](https://auth0.com/ai/docs/mcp/get-started/authorization-for-your-mcp-server) · [Standalone starter template](https://github.com/mcp-use/mcp-oauth-auth0-template) · [Runnable DCR example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/auth0) · [Runnable proxy example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/auth0-proxy)
 
 ---
 

--- a/skills/chatgpt-app-builder/references/authentication/better-auth.md
+++ b/skills/chatgpt-app-builder/references/authentication/better-auth.md
@@ -2,7 +2,7 @@
 
 Setting up a self-hosted OAuth 2.1 authorization server with Better Auth.
 
-**Learn more:** [Better Auth OAuth Provider Plugin](https://better-auth.com/docs/plugins/oauth-provider) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/better-auth)
+**Learn more:** [Better Auth OAuth Provider Plugin](https://better-auth.com/docs/plugins/oauth-provider) · [Standalone starter template](https://github.com/mcp-use/mcp-oauth-better-auth-template) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/better-auth)
 
 > Covers the `@better-auth/oauth-provider` plugin. The older Better Auth MCP plugin is deprecated — for legacy users, see the [mcp-use adapter](https://better-auth.com/docs/plugins/mcp#framework-adapters).
 

--- a/skills/chatgpt-app-builder/references/authentication/clerk.md
+++ b/skills/chatgpt-app-builder/references/authentication/clerk.md
@@ -1,0 +1,137 @@
+# Clerk Authentication
+
+Setting up OAuth with Clerk. DCR mode only — MCP clients register themselves directly with Clerk via Dynamic Client Registration; the MCP server only verifies the resulting JWTs against Clerk's JWKS.
+
+**Learn more:** [Clerk OAuth Docs](https://clerk.com/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/clerk)
+
+---
+
+## Quick Start
+
+```typescript
+import { MCPServer, oauthClerkProvider, object } from "mcp-use/server";
+
+const server = new MCPServer({
+  name: "my-server",
+  version: "1.0.0",
+  oauth: oauthClerkProvider(),
+});
+
+server.tool(
+  { name: "whoami", description: "Get authenticated user info" },
+  async (_args, ctx) =>
+    object({
+      userId: ctx.auth.user.userId,
+      email: ctx.auth.user.email,
+      name: ctx.auth.user.name,
+    })
+);
+
+server.listen();
+```
+
+With a `.env` file:
+
+```bash
+# Development:  https://[verb-noun-##].clerk.accounts.dev
+# Production:   https://clerk.[YOUR_APP_DOMAIN].com
+MCP_USE_OAUTH_CLERK_FRONTEND_API_URL=https://verb-noun-42.clerk.accounts.dev
+```
+
+That's it. JWT verification, OAuth discovery, and `.well-known` passthrough are handled automatically.
+
+---
+
+## Setup
+
+1. Sign up at [clerk.com](https://clerk.com) and create an application.
+2. **Clerk Dashboard → Configure → OAuth Applications** — enable **Dynamic Client Registration**. This is required for MCP clients to self-register.
+3. **Clerk Dashboard → Configure → API Keys** — copy the **Frontend API URL** (shown in the `.env.local` quickstart).
+   - Development example: `https://verb-noun-42.clerk.accounts.dev`
+   - Production example: `https://clerk.yourdomain.com`
+
+---
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `MCP_USE_OAUTH_CLERK_FRONTEND_API_URL` | Yes | Clerk Frontend API URL (e.g. `https://verb-noun-42.clerk.accounts.dev`) |
+
+---
+
+## Configuration Options
+
+Zero-config (reads from env vars):
+
+```typescript
+oauth: oauthClerkProvider()
+```
+
+Explicit config (overrides env vars):
+
+```typescript
+oauth: oauthClerkProvider({
+  frontendApiUrl: "https://verb-noun-42.clerk.accounts.dev",
+  verifyJwt: process.env.NODE_ENV === "production",  // default: true
+})
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `frontendApiUrl` | `string` | env var | Clerk Frontend API URL |
+| `verifyJwt` | `boolean?` | `true` | Set `false` to skip JWT verification (**development only**) |
+
+---
+
+## User Context
+
+Clerk populates these fields on `ctx.auth.user`:
+
+| Field | Type | Source |
+|-------|------|--------|
+| `userId` | `string` | `sub` claim |
+| `email` | `string?` | `email` claim |
+| `name` | `string?` | `name` claim |
+| `roles` | `string[]?` | `roles` claim |
+| `permissions` | `string[]?` | `permissions` claim |
+
+### Organization Context
+
+Clerk includes the active organization on the JWT payload. The fields are non-standard, so cast off `ctx.auth.user`:
+
+```typescript
+server.tool(
+  { name: "get-organization-info", description: "Get the active organization" },
+  async (_args, ctx) => {
+    const { org_id, org_role, org_slug } = ctx.auth.user as {
+      org_id?: string;
+      org_role?: string;
+      org_slug?: string;
+    };
+
+    if (!org_id) {
+      return error("No active organization. Select one in Clerk first.");
+    }
+
+    return object({ org_id, org_role, org_slug });
+  }
+);
+```
+
+---
+
+## Common Mistakes
+
+- **DCR not enabled** — If MCP Inspector stalls at the registration step, confirm **Dynamic Client Registration** is enabled in Clerk Dashboard → Configure → OAuth Applications. Without DCR, there is no `client_id` for MCP clients to obtain.
+- **Wrong Frontend API URL** — Must be the full URL (with `https://`), not just the subdomain.
+- **Skipping JWT verification in production** — `verifyJwt: false` is development only.
+
+---
+
+## Next Steps
+
+- **Auth overview** → [overview.md](overview.md)
+- **Auth0 setup** → [auth0.md](auth0.md)
+- **WorkOS setup** → [workos.md](workos.md)
+- **Build tools** → [../server/tools.md](../server/tools.md)

--- a/skills/chatgpt-app-builder/references/authentication/keycloak.md
+++ b/skills/chatgpt-app-builder/references/authentication/keycloak.md
@@ -2,7 +2,7 @@
 
 Setting up OAuth with Keycloak. Keycloak exposes full OAuth 2.1 + OIDC endpoints on every realm, including native [Dynamic Client Registration](https://www.keycloak.org/securing-apps/client-registration) (RFC 7591). MCP clients discover Keycloak via `.well-known` metadata, register themselves, complete a PKCE flow, and send the access token as a bearer on MCP requests — **the MCP server only verifies the JWT against Keycloak's JWKS**.
 
-**Learn more:** [Keycloak Documentation](https://www.keycloak.org/documentation) · [Keycloak DCR](https://www.keycloak.org/securing-apps/client-registration) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/keycloak)
+**Learn more:** [Keycloak Documentation](https://www.keycloak.org/documentation) · [Keycloak DCR](https://www.keycloak.org/securing-apps/client-registration) · [Standalone starter template](https://github.com/mcp-use/mcp-oauth-keycloak-template) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/keycloak)
 
 ---
 

--- a/skills/chatgpt-app-builder/references/authentication/overview.md
+++ b/skills/chatgpt-app-builder/references/authentication/overview.md
@@ -2,10 +2,10 @@
 
 Adding OAuth 2.0/2.1 authentication to your MCP server.
 
-**Use for:** Protecting tools behind user authentication, accessing user identity in tool handlers, integrating with identity providers (Auth0, Better Auth, WorkOS, Supabase, Keycloak, Google, GitHub, Okta, Azure AD, and more).
+**Use for:** Protecting tools behind user authentication, accessing user identity in tool handlers, integrating with identity providers (Auth0, Better Auth, Clerk, WorkOS, Supabase, Keycloak, Google, GitHub, Okta, Azure AD, and more).
 
 > **Two integration modes.** Pick by whether your identity provider supports Dynamic Client Registration (DCR):
-> - **Remote auth** (`oauthAuth0Provider`, `oauthBetterAuthProvider`, `oauthKeycloakProvider`, `oauthSupabaseProvider`, `oauthWorkOSProvider`, `oauthCustomProvider`) — clients register and authenticate directly with the upstream provider; your server only verifies the resulting bearer token. Requires DCR on the upstream.
+> - **Remote auth** (`oauthAuth0Provider`, `oauthBetterAuthProvider`, `oauthClerkProvider`, `oauthKeycloakProvider`, `oauthSupabaseProvider`, `oauthWorkOSProvider`, `oauthCustomProvider`) — clients register and authenticate directly with the upstream provider; your server only verifies the resulting bearer token. Requires DCR on the upstream.
 > - **OAuth proxy** (`oauthProxy` + `jwksVerifier`) — your server holds pre-registered client credentials and mediates the token exchange. Use this for Google, GitHub, Okta, Azure AD, or any provider where you register the app in a dashboard and receive a fixed `clientId` / `clientSecret`.
 
 ---
@@ -143,6 +143,7 @@ Or pass config explicitly to override env vars. See each provider's guide for av
 |----------|---------|-----------------|-------|
 | **Auth0** | `oauthAuth0Provider()` | `domain`, `audience` (env: `MCP_USE_OAUTH_AUTH0_DOMAIN`, `MCP_USE_OAUTH_AUTH0_AUDIENCE`) | [auth0.md](auth0.md) |
 | **Better Auth** | `oauthBetterAuthProvider({ authURL })` | `BETTER_AUTH_SECRET` | [better-auth.md](better-auth.md) |
+| **Clerk** | `oauthClerkProvider()` | `frontendApiUrl` (env: `MCP_USE_OAUTH_CLERK_FRONTEND_API_URL`) | [clerk.md](clerk.md) |
 | **WorkOS** | `oauthWorkOSProvider()` | `subdomain` (env: `MCP_USE_OAUTH_WORKOS_SUBDOMAIN`) | [workos.md](workos.md) |
 | **Supabase** | `oauthSupabaseProvider()` | `projectId` (env: `MCP_USE_OAUTH_SUPABASE_PROJECT_ID`) | [supabase.md](supabase.md) |
 | **Keycloak** | `oauthKeycloakProvider()` | `serverUrl`, `realm` (env: `MCP_USE_OAUTH_KEYCLOAK_SERVER_URL`, `MCP_USE_OAUTH_KEYCLOAK_REALM`) | [keycloak.md](keycloak.md) |
@@ -198,6 +199,7 @@ Provider-specific examples (Supabase, Keycloak, Auth0, etc.) live in each provid
 
 - **Auth0 setup** → [auth0.md](auth0.md)
 - **Better Auth setup** → [better-auth.md](better-auth.md)
+- **Clerk setup** → [clerk.md](clerk.md)
 - **WorkOS setup** → [workos.md](workos.md)
 - **Supabase setup** → [supabase.md](supabase.md)
 - **Keycloak setup** → [keycloak.md](keycloak.md)

--- a/skills/chatgpt-app-builder/references/authentication/supabase.md
+++ b/skills/chatgpt-app-builder/references/authentication/supabase.md
@@ -4,7 +4,7 @@ Setting up OAuth with Supabase's OAuth 2.1 server. Supabase hosts `/authorize`, 
 
 **You host the consent UI.** Supabase redirects the browser to a URL you configure, and your route uses the Supabase JS SDK to load authorization details, render sign-in + consent, and submit the decision back to Supabase. mcp-use is not involved in that step — follow Supabase's [OAuth Server — Getting Started guide](https://supabase.com/docs/guides/auth/oauth-server/getting-started).
 
-**Learn more:** [Supabase OAuth Server — MCP Authentication](https://supabase.com/docs/guides/auth/oauth-server/mcp-authentication) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/supabase)
+**Learn more:** [Supabase OAuth Server — MCP Authentication](https://supabase.com/docs/guides/auth/oauth-server/mcp-authentication) · [Standalone starter template](https://github.com/mcp-use/mcp-oauth-supabase-template) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/supabase)
 
 > This targets Supabase's **OAuth 2.1 server** — a different feature from Supabase Auth's social logins. Enable it explicitly in the dashboard under **Authentication → OAuth Server**.
 

--- a/skills/chatgpt-app-builder/references/authentication/workos.md
+++ b/skills/chatgpt-app-builder/references/authentication/workos.md
@@ -2,7 +2,7 @@
 
 Setting up OAuth with WorkOS AuthKit. DCR mode only — MCP clients register themselves directly with WorkOS; the MCP server just verifies the resulting tokens.
 
-**Learn more:** [WorkOS AuthKit MCP docs](https://workos.com/docs/authkit/mcp) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/workos)
+**Learn more:** [WorkOS AuthKit MCP docs](https://workos.com/docs/authkit/mcp) · [Standalone starter template](https://github.com/mcp-use/mcp-oauth-workos-template) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/workos)
 
 ---
 

--- a/skills/mcp-apps-builder/SKILL.md
+++ b/skills/mcp-apps-builder/SKILL.md
@@ -83,7 +83,7 @@ Load these before diving into tools/resources/widgets sections.
 ---
 
 ### 🔐 Adding Authentication?
-**When:** Protecting your server with OAuth (Auth0, Better Auth, WorkOS, Supabase, Keycloak, or any other provider)
+**When:** Protecting your server with OAuth (Auth0, Better Auth, Clerk, WorkOS, Supabase, Keycloak, or any other provider)
 
 - **[overview.md](references/authentication/overview.md)**
   - When: First time adding auth, understanding `ctx.auth`, or choosing a provider / integration mode
@@ -96,6 +96,10 @@ Load these before diving into tools/resources/widgets sections.
 - **[better-auth.md](references/authentication/better-auth.md)**
   - When: Using Better Auth with the `@better-auth/oauth-provider` plugin (self-hosted OAuth 2.1)
   - Covers: `oauthBetterAuthProvider`, auth URL / metadata routes, login and consent flows
+
+- **[clerk.md](references/authentication/clerk.md)**
+  - When: Using Clerk (DCR-based OAuth)
+  - Covers: `oauthClerkProvider`, enabling DCR, Frontend API URL, organization context
 
 - **[workos.md](references/authentication/workos.md)**
   - When: Using WorkOS AuthKit (DCR only)

--- a/skills/mcp-apps-builder/references/authentication/auth0.md
+++ b/skills/mcp-apps-builder/references/authentication/auth0.md
@@ -5,7 +5,7 @@ Setting up OAuth with Auth0. Two modes depending on whether you have access to A
 - **DCR (built-in)** → use `oauthAuth0Provider`. Requires Auth0's Early Access program.
 - **OAuth proxy** → use `oauthProxy` + `jwksVerifier` with a standard Auth0 Regular Web App. No Early Access required.
 
-**Learn more:** [Auth0 MCP Authorization Guide](https://auth0.com/ai/docs/mcp/get-started/authorization-for-your-mcp-server) · [Runnable DCR example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/auth0) · [Runnable proxy example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/auth0-proxy)
+**Learn more:** [Auth0 MCP Authorization Guide](https://auth0.com/ai/docs/mcp/get-started/authorization-for-your-mcp-server) · [Standalone starter template](https://github.com/mcp-use/mcp-oauth-auth0-template) · [Runnable DCR example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/auth0) · [Runnable proxy example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/auth0-proxy)
 
 ---
 

--- a/skills/mcp-apps-builder/references/authentication/better-auth.md
+++ b/skills/mcp-apps-builder/references/authentication/better-auth.md
@@ -2,7 +2,7 @@
 
 Setting up a self-hosted OAuth 2.1 authorization server with Better Auth.
 
-**Learn more:** [Better Auth OAuth Provider Plugin](https://better-auth.com/docs/plugins/oauth-provider) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/better-auth)
+**Learn more:** [Better Auth OAuth Provider Plugin](https://better-auth.com/docs/plugins/oauth-provider) · [Standalone starter template](https://github.com/mcp-use/mcp-oauth-better-auth-template) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/better-auth)
 
 > Covers the `@better-auth/oauth-provider` plugin. The older Better Auth MCP plugin is deprecated — for legacy users, see the [mcp-use adapter](https://better-auth.com/docs/plugins/mcp#framework-adapters).
 

--- a/skills/mcp-apps-builder/references/authentication/clerk.md
+++ b/skills/mcp-apps-builder/references/authentication/clerk.md
@@ -1,0 +1,137 @@
+# Clerk Authentication
+
+Setting up OAuth with Clerk. DCR mode only — MCP clients register themselves directly with Clerk via Dynamic Client Registration; the MCP server only verifies the resulting JWTs against Clerk's JWKS.
+
+**Learn more:** [Clerk OAuth Docs](https://clerk.com/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/clerk)
+
+---
+
+## Quick Start
+
+```typescript
+import { MCPServer, oauthClerkProvider, object } from "mcp-use/server";
+
+const server = new MCPServer({
+  name: "my-server",
+  version: "1.0.0",
+  oauth: oauthClerkProvider(),
+});
+
+server.tool(
+  { name: "whoami", description: "Get authenticated user info" },
+  async (_args, ctx) =>
+    object({
+      userId: ctx.auth.user.userId,
+      email: ctx.auth.user.email,
+      name: ctx.auth.user.name,
+    })
+);
+
+server.listen();
+```
+
+With a `.env` file:
+
+```bash
+# Development:  https://[verb-noun-##].clerk.accounts.dev
+# Production:   https://clerk.[YOUR_APP_DOMAIN].com
+MCP_USE_OAUTH_CLERK_FRONTEND_API_URL=https://verb-noun-42.clerk.accounts.dev
+```
+
+That's it. JWT verification, OAuth discovery, and `.well-known` passthrough are handled automatically.
+
+---
+
+## Setup
+
+1. Sign up at [clerk.com](https://clerk.com) and create an application.
+2. **Clerk Dashboard → Configure → OAuth Applications** — enable **Dynamic Client Registration**. This is required for MCP clients to self-register.
+3. **Clerk Dashboard → Configure → API Keys** — copy the **Frontend API URL** (shown in the `.env.local` quickstart).
+   - Development example: `https://verb-noun-42.clerk.accounts.dev`
+   - Production example: `https://clerk.yourdomain.com`
+
+---
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `MCP_USE_OAUTH_CLERK_FRONTEND_API_URL` | Yes | Clerk Frontend API URL (e.g. `https://verb-noun-42.clerk.accounts.dev`) |
+
+---
+
+## Configuration Options
+
+Zero-config (reads from env vars):
+
+```typescript
+oauth: oauthClerkProvider()
+```
+
+Explicit config (overrides env vars):
+
+```typescript
+oauth: oauthClerkProvider({
+  frontendApiUrl: "https://verb-noun-42.clerk.accounts.dev",
+  verifyJwt: process.env.NODE_ENV === "production",  // default: true
+})
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `frontendApiUrl` | `string` | env var | Clerk Frontend API URL |
+| `verifyJwt` | `boolean?` | `true` | Set `false` to skip JWT verification (**development only**) |
+
+---
+
+## User Context
+
+Clerk populates these fields on `ctx.auth.user`:
+
+| Field | Type | Source |
+|-------|------|--------|
+| `userId` | `string` | `sub` claim |
+| `email` | `string?` | `email` claim |
+| `name` | `string?` | `name` claim |
+| `roles` | `string[]?` | `roles` claim |
+| `permissions` | `string[]?` | `permissions` claim |
+
+### Organization Context
+
+Clerk includes the active organization on the JWT payload. The fields are non-standard, so cast off `ctx.auth.user`:
+
+```typescript
+server.tool(
+  { name: "get-organization-info", description: "Get the active organization" },
+  async (_args, ctx) => {
+    const { org_id, org_role, org_slug } = ctx.auth.user as {
+      org_id?: string;
+      org_role?: string;
+      org_slug?: string;
+    };
+
+    if (!org_id) {
+      return error("No active organization. Select one in Clerk first.");
+    }
+
+    return object({ org_id, org_role, org_slug });
+  }
+);
+```
+
+---
+
+## Common Mistakes
+
+- **DCR not enabled** — If MCP Inspector stalls at the registration step, confirm **Dynamic Client Registration** is enabled in Clerk Dashboard → Configure → OAuth Applications. Without DCR, there is no `client_id` for MCP clients to obtain.
+- **Wrong Frontend API URL** — Must be the full URL (with `https://`), not just the subdomain.
+- **Skipping JWT verification in production** — `verifyJwt: false` is development only.
+
+---
+
+## Next Steps
+
+- **Auth overview** → [overview.md](overview.md)
+- **Auth0 setup** → [auth0.md](auth0.md)
+- **WorkOS setup** → [workos.md](workos.md)
+- **Build tools** → [../server/tools.md](../server/tools.md)

--- a/skills/mcp-apps-builder/references/authentication/keycloak.md
+++ b/skills/mcp-apps-builder/references/authentication/keycloak.md
@@ -2,7 +2,7 @@
 
 Setting up OAuth with Keycloak. Keycloak exposes full OAuth 2.1 + OIDC endpoints on every realm, including native [Dynamic Client Registration](https://www.keycloak.org/securing-apps/client-registration) (RFC 7591). MCP clients discover Keycloak via `.well-known` metadata, register themselves, complete a PKCE flow, and send the access token as a bearer on MCP requests — **the MCP server only verifies the JWT against Keycloak's JWKS**.
 
-**Learn more:** [Keycloak Documentation](https://www.keycloak.org/documentation) · [Keycloak DCR](https://www.keycloak.org/securing-apps/client-registration) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/keycloak)
+**Learn more:** [Keycloak Documentation](https://www.keycloak.org/documentation) · [Keycloak DCR](https://www.keycloak.org/securing-apps/client-registration) · [Standalone starter template](https://github.com/mcp-use/mcp-oauth-keycloak-template) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/keycloak)
 
 ---
 

--- a/skills/mcp-apps-builder/references/authentication/overview.md
+++ b/skills/mcp-apps-builder/references/authentication/overview.md
@@ -2,10 +2,10 @@
 
 Adding OAuth 2.0/2.1 authentication to your MCP server.
 
-**Use for:** Protecting tools behind user authentication, accessing user identity in tool handlers, integrating with identity providers (Auth0, Better Auth, WorkOS, Supabase, Keycloak, Google, GitHub, Okta, Azure AD, and more).
+**Use for:** Protecting tools behind user authentication, accessing user identity in tool handlers, integrating with identity providers (Auth0, Better Auth, Clerk, WorkOS, Supabase, Keycloak, Google, GitHub, Okta, Azure AD, and more).
 
 > **Two integration modes.** Pick by whether your identity provider supports Dynamic Client Registration (DCR):
-> - **Remote auth** (`oauthAuth0Provider`, `oauthBetterAuthProvider`, `oauthKeycloakProvider`, `oauthSupabaseProvider`, `oauthWorkOSProvider`, `oauthCustomProvider`) — clients register and authenticate directly with the upstream provider; your server only verifies the resulting bearer token. Requires DCR on the upstream.
+> - **Remote auth** (`oauthAuth0Provider`, `oauthBetterAuthProvider`, `oauthClerkProvider`, `oauthKeycloakProvider`, `oauthSupabaseProvider`, `oauthWorkOSProvider`, `oauthCustomProvider`) — clients register and authenticate directly with the upstream provider; your server only verifies the resulting bearer token. Requires DCR on the upstream.
 > - **OAuth proxy** (`oauthProxy` + `jwksVerifier`) — your server holds pre-registered client credentials and mediates the token exchange. Use this for Google, GitHub, Okta, Azure AD, or any provider where you register the app in a dashboard and receive a fixed `clientId` / `clientSecret`.
 
 ---
@@ -143,6 +143,7 @@ Or pass config explicitly to override env vars. See each provider's guide for av
 |----------|---------|-----------------|-------|
 | **Auth0** | `oauthAuth0Provider()` | `domain`, `audience` (env: `MCP_USE_OAUTH_AUTH0_DOMAIN`, `MCP_USE_OAUTH_AUTH0_AUDIENCE`) | [auth0.md](auth0.md) |
 | **Better Auth** | `oauthBetterAuthProvider({ authURL })` | `BETTER_AUTH_SECRET` | [better-auth.md](better-auth.md) |
+| **Clerk** | `oauthClerkProvider()` | `frontendApiUrl` (env: `MCP_USE_OAUTH_CLERK_FRONTEND_API_URL`) | [clerk.md](clerk.md) |
 | **WorkOS** | `oauthWorkOSProvider()` | `subdomain` (env: `MCP_USE_OAUTH_WORKOS_SUBDOMAIN`) | [workos.md](workos.md) |
 | **Supabase** | `oauthSupabaseProvider()` | `projectId` (env: `MCP_USE_OAUTH_SUPABASE_PROJECT_ID`) | [supabase.md](supabase.md) |
 | **Keycloak** | `oauthKeycloakProvider()` | `serverUrl`, `realm` (env: `MCP_USE_OAUTH_KEYCLOAK_SERVER_URL`, `MCP_USE_OAUTH_KEYCLOAK_REALM`) | [keycloak.md](keycloak.md) |
@@ -198,6 +199,7 @@ Provider-specific examples (Supabase, Keycloak, Auth0, etc.) live in each provid
 
 - **Auth0 setup** → [auth0.md](auth0.md)
 - **Better Auth setup** → [better-auth.md](better-auth.md)
+- **Clerk setup** → [clerk.md](clerk.md)
 - **WorkOS setup** → [workos.md](workos.md)
 - **Supabase setup** → [supabase.md](supabase.md)
 - **Keycloak setup** → [keycloak.md](keycloak.md)

--- a/skills/mcp-apps-builder/references/authentication/supabase.md
+++ b/skills/mcp-apps-builder/references/authentication/supabase.md
@@ -4,7 +4,7 @@ Setting up OAuth with Supabase's OAuth 2.1 server. Supabase hosts `/authorize`, 
 
 **You host the consent UI.** Supabase redirects the browser to a URL you configure, and your route uses the Supabase JS SDK to load authorization details, render sign-in + consent, and submit the decision back to Supabase. mcp-use is not involved in that step — follow Supabase's [OAuth Server — Getting Started guide](https://supabase.com/docs/guides/auth/oauth-server/getting-started).
 
-**Learn more:** [Supabase OAuth Server — MCP Authentication](https://supabase.com/docs/guides/auth/oauth-server/mcp-authentication) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/supabase)
+**Learn more:** [Supabase OAuth Server — MCP Authentication](https://supabase.com/docs/guides/auth/oauth-server/mcp-authentication) · [Standalone starter template](https://github.com/mcp-use/mcp-oauth-supabase-template) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/supabase)
 
 > This targets Supabase's **OAuth 2.1 server** — a different feature from Supabase Auth's social logins. Enable it explicitly in the dashboard under **Authentication → OAuth Server**.
 

--- a/skills/mcp-apps-builder/references/authentication/workos.md
+++ b/skills/mcp-apps-builder/references/authentication/workos.md
@@ -2,7 +2,7 @@
 
 Setting up OAuth with WorkOS AuthKit. DCR mode only — MCP clients register themselves directly with WorkOS; the MCP server just verifies the resulting tokens.
 
-**Learn more:** [WorkOS AuthKit MCP docs](https://workos.com/docs/authkit/mcp) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/workos)
+**Learn more:** [WorkOS AuthKit MCP docs](https://workos.com/docs/authkit/mcp) · [Standalone starter template](https://github.com/mcp-use/mcp-oauth-workos-template) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/workos)
 
 ---
 

--- a/skills/mcp-builder/SKILL.md
+++ b/skills/mcp-builder/SKILL.md
@@ -83,7 +83,7 @@ Load these before diving into tools/resources/widgets sections.
 ---
 
 ### 🔐 Adding Authentication?
-**When:** Protecting your server with OAuth (Auth0, Better Auth, WorkOS, Supabase, Keycloak, or any other provider)
+**When:** Protecting your server with OAuth (Auth0, Better Auth, Clerk, WorkOS, Supabase, Keycloak, or any other provider)
 
 - **[overview.md](references/authentication/overview.md)**
   - When: First time adding auth, understanding `ctx.auth`, or choosing a provider / integration mode
@@ -96,6 +96,10 @@ Load these before diving into tools/resources/widgets sections.
 - **[better-auth.md](references/authentication/better-auth.md)**
   - When: Using Better Auth with the `@better-auth/oauth-provider` plugin (self-hosted OAuth 2.1)
   - Covers: `oauthBetterAuthProvider`, auth URL / metadata routes, login and consent flows
+
+- **[clerk.md](references/authentication/clerk.md)**
+  - When: Using Clerk (DCR-based OAuth)
+  - Covers: `oauthClerkProvider`, enabling DCR, Frontend API URL, organization context
 
 - **[workos.md](references/authentication/workos.md)**
   - When: Using WorkOS AuthKit (DCR only)

--- a/skills/mcp-builder/references/authentication/auth0.md
+++ b/skills/mcp-builder/references/authentication/auth0.md
@@ -5,7 +5,7 @@ Setting up OAuth with Auth0. Two modes depending on whether you have access to A
 - **DCR (built-in)** → use `oauthAuth0Provider`. Requires Auth0's Early Access program.
 - **OAuth proxy** → use `oauthProxy` + `jwksVerifier` with a standard Auth0 Regular Web App. No Early Access required.
 
-**Learn more:** [Auth0 MCP Authorization Guide](https://auth0.com/ai/docs/mcp/get-started/authorization-for-your-mcp-server) · [Runnable DCR example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/auth0) · [Runnable proxy example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/auth0-proxy)
+**Learn more:** [Auth0 MCP Authorization Guide](https://auth0.com/ai/docs/mcp/get-started/authorization-for-your-mcp-server) · [Standalone starter template](https://github.com/mcp-use/mcp-oauth-auth0-template) · [Runnable DCR example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/auth0) · [Runnable proxy example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/auth0-proxy)
 
 ---
 

--- a/skills/mcp-builder/references/authentication/better-auth.md
+++ b/skills/mcp-builder/references/authentication/better-auth.md
@@ -2,7 +2,7 @@
 
 Setting up a self-hosted OAuth 2.1 authorization server with Better Auth.
 
-**Learn more:** [Better Auth OAuth Provider Plugin](https://better-auth.com/docs/plugins/oauth-provider) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/better-auth)
+**Learn more:** [Better Auth OAuth Provider Plugin](https://better-auth.com/docs/plugins/oauth-provider) · [Standalone starter template](https://github.com/mcp-use/mcp-oauth-better-auth-template) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/better-auth)
 
 > Covers the `@better-auth/oauth-provider` plugin. The older Better Auth MCP plugin is deprecated — for legacy users, see the [mcp-use adapter](https://better-auth.com/docs/plugins/mcp#framework-adapters).
 

--- a/skills/mcp-builder/references/authentication/clerk.md
+++ b/skills/mcp-builder/references/authentication/clerk.md
@@ -1,0 +1,137 @@
+# Clerk Authentication
+
+Setting up OAuth with Clerk. DCR mode only — MCP clients register themselves directly with Clerk via Dynamic Client Registration; the MCP server only verifies the resulting JWTs against Clerk's JWKS.
+
+**Learn more:** [Clerk OAuth Docs](https://clerk.com/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/clerk)
+
+---
+
+## Quick Start
+
+```typescript
+import { MCPServer, oauthClerkProvider, object } from "mcp-use/server";
+
+const server = new MCPServer({
+  name: "my-server",
+  version: "1.0.0",
+  oauth: oauthClerkProvider(),
+});
+
+server.tool(
+  { name: "whoami", description: "Get authenticated user info" },
+  async (_args, ctx) =>
+    object({
+      userId: ctx.auth.user.userId,
+      email: ctx.auth.user.email,
+      name: ctx.auth.user.name,
+    })
+);
+
+server.listen();
+```
+
+With a `.env` file:
+
+```bash
+# Development:  https://[verb-noun-##].clerk.accounts.dev
+# Production:   https://clerk.[YOUR_APP_DOMAIN].com
+MCP_USE_OAUTH_CLERK_FRONTEND_API_URL=https://verb-noun-42.clerk.accounts.dev
+```
+
+That's it. JWT verification, OAuth discovery, and `.well-known` passthrough are handled automatically.
+
+---
+
+## Setup
+
+1. Sign up at [clerk.com](https://clerk.com) and create an application.
+2. **Clerk Dashboard → Configure → OAuth Applications** — enable **Dynamic Client Registration**. This is required for MCP clients to self-register.
+3. **Clerk Dashboard → Configure → API Keys** — copy the **Frontend API URL** (shown in the `.env.local` quickstart).
+   - Development example: `https://verb-noun-42.clerk.accounts.dev`
+   - Production example: `https://clerk.yourdomain.com`
+
+---
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `MCP_USE_OAUTH_CLERK_FRONTEND_API_URL` | Yes | Clerk Frontend API URL (e.g. `https://verb-noun-42.clerk.accounts.dev`) |
+
+---
+
+## Configuration Options
+
+Zero-config (reads from env vars):
+
+```typescript
+oauth: oauthClerkProvider()
+```
+
+Explicit config (overrides env vars):
+
+```typescript
+oauth: oauthClerkProvider({
+  frontendApiUrl: "https://verb-noun-42.clerk.accounts.dev",
+  verifyJwt: process.env.NODE_ENV === "production",  // default: true
+})
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `frontendApiUrl` | `string` | env var | Clerk Frontend API URL |
+| `verifyJwt` | `boolean?` | `true` | Set `false` to skip JWT verification (**development only**) |
+
+---
+
+## User Context
+
+Clerk populates these fields on `ctx.auth.user`:
+
+| Field | Type | Source |
+|-------|------|--------|
+| `userId` | `string` | `sub` claim |
+| `email` | `string?` | `email` claim |
+| `name` | `string?` | `name` claim |
+| `roles` | `string[]?` | `roles` claim |
+| `permissions` | `string[]?` | `permissions` claim |
+
+### Organization Context
+
+Clerk includes the active organization on the JWT payload. The fields are non-standard, so cast off `ctx.auth.user`:
+
+```typescript
+server.tool(
+  { name: "get-organization-info", description: "Get the active organization" },
+  async (_args, ctx) => {
+    const { org_id, org_role, org_slug } = ctx.auth.user as {
+      org_id?: string;
+      org_role?: string;
+      org_slug?: string;
+    };
+
+    if (!org_id) {
+      return error("No active organization. Select one in Clerk first.");
+    }
+
+    return object({ org_id, org_role, org_slug });
+  }
+);
+```
+
+---
+
+## Common Mistakes
+
+- **DCR not enabled** — If MCP Inspector stalls at the registration step, confirm **Dynamic Client Registration** is enabled in Clerk Dashboard → Configure → OAuth Applications. Without DCR, there is no `client_id` for MCP clients to obtain.
+- **Wrong Frontend API URL** — Must be the full URL (with `https://`), not just the subdomain.
+- **Skipping JWT verification in production** — `verifyJwt: false` is development only.
+
+---
+
+## Next Steps
+
+- **Auth overview** → [overview.md](overview.md)
+- **Auth0 setup** → [auth0.md](auth0.md)
+- **WorkOS setup** → [workos.md](workos.md)
+- **Build tools** → [../server/tools.md](../server/tools.md)

--- a/skills/mcp-builder/references/authentication/keycloak.md
+++ b/skills/mcp-builder/references/authentication/keycloak.md
@@ -2,7 +2,7 @@
 
 Setting up OAuth with Keycloak. Keycloak exposes full OAuth 2.1 + OIDC endpoints on every realm, including native [Dynamic Client Registration](https://www.keycloak.org/securing-apps/client-registration) (RFC 7591). MCP clients discover Keycloak via `.well-known` metadata, register themselves, complete a PKCE flow, and send the access token as a bearer on MCP requests — **the MCP server only verifies the JWT against Keycloak's JWKS**.
 
-**Learn more:** [Keycloak Documentation](https://www.keycloak.org/documentation) · [Keycloak DCR](https://www.keycloak.org/securing-apps/client-registration) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/keycloak)
+**Learn more:** [Keycloak Documentation](https://www.keycloak.org/documentation) · [Keycloak DCR](https://www.keycloak.org/securing-apps/client-registration) · [Standalone starter template](https://github.com/mcp-use/mcp-oauth-keycloak-template) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/keycloak)
 
 ---
 

--- a/skills/mcp-builder/references/authentication/overview.md
+++ b/skills/mcp-builder/references/authentication/overview.md
@@ -2,10 +2,10 @@
 
 Adding OAuth 2.0/2.1 authentication to your MCP server.
 
-**Use for:** Protecting tools behind user authentication, accessing user identity in tool handlers, integrating with identity providers (Auth0, Better Auth, WorkOS, Supabase, Keycloak, Google, GitHub, Okta, Azure AD, and more).
+**Use for:** Protecting tools behind user authentication, accessing user identity in tool handlers, integrating with identity providers (Auth0, Better Auth, Clerk, WorkOS, Supabase, Keycloak, Google, GitHub, Okta, Azure AD, and more).
 
 > **Two integration modes.** Pick by whether your identity provider supports Dynamic Client Registration (DCR):
-> - **Remote auth** (`oauthAuth0Provider`, `oauthBetterAuthProvider`, `oauthKeycloakProvider`, `oauthSupabaseProvider`, `oauthWorkOSProvider`, `oauthCustomProvider`) — clients register and authenticate directly with the upstream provider; your server only verifies the resulting bearer token. Requires DCR on the upstream.
+> - **Remote auth** (`oauthAuth0Provider`, `oauthBetterAuthProvider`, `oauthClerkProvider`, `oauthKeycloakProvider`, `oauthSupabaseProvider`, `oauthWorkOSProvider`, `oauthCustomProvider`) — clients register and authenticate directly with the upstream provider; your server only verifies the resulting bearer token. Requires DCR on the upstream.
 > - **OAuth proxy** (`oauthProxy` + `jwksVerifier`) — your server holds pre-registered client credentials and mediates the token exchange. Use this for Google, GitHub, Okta, Azure AD, or any provider where you register the app in a dashboard and receive a fixed `clientId` / `clientSecret`.
 
 ---
@@ -143,6 +143,7 @@ Or pass config explicitly to override env vars. See each provider's guide for av
 |----------|---------|-----------------|-------|
 | **Auth0** | `oauthAuth0Provider()` | `domain`, `audience` (env: `MCP_USE_OAUTH_AUTH0_DOMAIN`, `MCP_USE_OAUTH_AUTH0_AUDIENCE`) | [auth0.md](auth0.md) |
 | **Better Auth** | `oauthBetterAuthProvider({ authURL })` | `BETTER_AUTH_SECRET` | [better-auth.md](better-auth.md) |
+| **Clerk** | `oauthClerkProvider()` | `frontendApiUrl` (env: `MCP_USE_OAUTH_CLERK_FRONTEND_API_URL`) | [clerk.md](clerk.md) |
 | **WorkOS** | `oauthWorkOSProvider()` | `subdomain` (env: `MCP_USE_OAUTH_WORKOS_SUBDOMAIN`) | [workos.md](workos.md) |
 | **Supabase** | `oauthSupabaseProvider()` | `projectId` (env: `MCP_USE_OAUTH_SUPABASE_PROJECT_ID`) | [supabase.md](supabase.md) |
 | **Keycloak** | `oauthKeycloakProvider()` | `serverUrl`, `realm` (env: `MCP_USE_OAUTH_KEYCLOAK_SERVER_URL`, `MCP_USE_OAUTH_KEYCLOAK_REALM`) | [keycloak.md](keycloak.md) |
@@ -198,6 +199,7 @@ Provider-specific examples (Supabase, Keycloak, Auth0, etc.) live in each provid
 
 - **Auth0 setup** → [auth0.md](auth0.md)
 - **Better Auth setup** → [better-auth.md](better-auth.md)
+- **Clerk setup** → [clerk.md](clerk.md)
 - **WorkOS setup** → [workos.md](workos.md)
 - **Supabase setup** → [supabase.md](supabase.md)
 - **Keycloak setup** → [keycloak.md](keycloak.md)

--- a/skills/mcp-builder/references/authentication/supabase.md
+++ b/skills/mcp-builder/references/authentication/supabase.md
@@ -4,7 +4,7 @@ Setting up OAuth with Supabase's OAuth 2.1 server. Supabase hosts `/authorize`, 
 
 **You host the consent UI.** Supabase redirects the browser to a URL you configure, and your route uses the Supabase JS SDK to load authorization details, render sign-in + consent, and submit the decision back to Supabase. mcp-use is not involved in that step — follow Supabase's [OAuth Server — Getting Started guide](https://supabase.com/docs/guides/auth/oauth-server/getting-started).
 
-**Learn more:** [Supabase OAuth Server — MCP Authentication](https://supabase.com/docs/guides/auth/oauth-server/mcp-authentication) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/supabase)
+**Learn more:** [Supabase OAuth Server — MCP Authentication](https://supabase.com/docs/guides/auth/oauth-server/mcp-authentication) · [Standalone starter template](https://github.com/mcp-use/mcp-oauth-supabase-template) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/supabase)
 
 > This targets Supabase's **OAuth 2.1 server** — a different feature from Supabase Auth's social logins. Enable it explicitly in the dashboard under **Authentication → OAuth Server**.
 

--- a/skills/mcp-builder/references/authentication/workos.md
+++ b/skills/mcp-builder/references/authentication/workos.md
@@ -2,7 +2,7 @@
 
 Setting up OAuth with WorkOS AuthKit. DCR mode only — MCP clients register themselves directly with WorkOS; the MCP server just verifies the resulting tokens.
 
-**Learn more:** [WorkOS AuthKit MCP docs](https://workos.com/docs/authkit/mcp) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/workos)
+**Learn more:** [WorkOS AuthKit MCP docs](https://workos.com/docs/authkit/mcp) · [Standalone starter template](https://github.com/mcp-use/mcp-oauth-workos-template) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/workos)
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes #1464.

Two README files in the OAuth examples link to URLs that return 404, which means new users hitting these examples land on a broken page:

- `examples/server/oauth/clerk/README.md` — three references to `https://dashboard.clerk.com` redirect to a 404 page. The actual landing page is `https://dashboard.clerk.com/sign-in` (returns 200).
- `examples/server/oauth/workos/README.md` — one reference to `https://workos.com/docs/authkit/quickstart` returns 404. The closest equivalent is `https://workos.com/docs/authkit` (returns 200), which is the AuthKit docs index where users can navigate to setup steps. The other WorkOS links in the file (`/docs/authkit/mcp`) all resolve correctly and are left alone.

## Changes

- `clerk/README.md`: 3 link updates (lines 18, 24, 36)
- `workos/README.md`: 1 link update (line 18)

No functional changes. Docs-only.

## Test plan

- [x] Verified `https://dashboard.clerk.com/sign-in` returns 200
- [x] Verified `https://workos.com/docs/authkit` returns 200
- [x] Verified all other links in both files still resolve
