### PR TITLE
docs: fix OAuth example links

### DIFF
--- a/libraries/typescript/packages/mcp-use/examples/server/oauth/clerk/README.md
+++ b/libraries/typescript/packages/mcp-use/examples/server/oauth/clerk/README.md
@@ -15,13 +15,13 @@ A production-ready example of an MCP server with Clerk OAuth 2.0 authentication,
 
 1. **Clerk Account**: Sign up at [clerk.com](https://clerk.com)
 2. **Node.js**: Version 18 or higher
-3. **Clerk Application**: Create an application in the [Clerk Dashboard](https://dashboard.clerk.com)
+3. **Clerk Application**: Create an application in the [Clerk Dashboard](https://dashboard.clerk.com/sign-in)
 
 ## Setup
 
 ### 1. Get Your Clerk Frontend API URL
 
-From the [Clerk Dashboard](https://dashboard.clerk.com):
+From the [Clerk Dashboard](https://dashboard.clerk.com/sign-in):
 
 1. Open your application
 2. Go to **Configure** → **API Keys**
@@ -33,7 +33,7 @@ From the [Clerk Dashboard](https://dashboard.clerk.com):
 
 **⚠️ IMPORTANT**: Dynamic Client Registration is **required** for MCP clients to work with Clerk.
 
-1. Go to the [Clerk Dashboard](https://dashboard.clerk.com)
+1. Go to the [Clerk Dashboard](https://dashboard.clerk.com/sign-in)
 2. Navigate to **Configure** → **OAuth Applications**
 3. Enable **Dynamic Client Registration**
 4. Save your changes

--- a/libraries/typescript/packages/mcp-use/examples/server/oauth/workos/README.md
+++ b/libraries/typescript/packages/mcp-use/examples/server/oauth/workos/README.md
@@ -15,7 +15,7 @@ A production-ready example of an MCP server with WorkOS AuthKit OAuth 2.0 authen
 
 1. **WorkOS Account**: Sign up at [workos.com](https://workos.com)
 2. **Node.js**: Version 18 or higher
-3. **AuthKit Setup**: Follow [WorkOS AuthKit Quickstart](https://workos.com/docs/authkit/quickstart) to set up your project
+3. **AuthKit Setup**: Follow [WorkOS AuthKit Quickstart](https://workos.com/docs/authkit/client-only) to set up your project
 
 ## What is WorkOS AuthKit?
 


### PR DESCRIPTION
## Summary

- update Clerk Dashboard links in the OAuth example to the sign-in URL that returns 200
- update the WorkOS AuthKit quickstart link to the current AuthKit quickstart page

Closes #1464

## Validation

- `curl -L -s -o NUL -w '%{http_code} %{url_effective}' --max-time 20 https://dashboard.clerk.com/sign-in`
- `curl -L -s -o NUL -w '%{http_code} %{url_effective}' --max-time 20 https://workos.com/docs/authkit/client-only`
- `git diff --check`