### PR TITLE
docs(oauth examples): fix broken links in Clerk and WorkOS READMEs

### DIFF
--- a/libraries/typescript/packages/mcp-use/examples/server/oauth/clerk/README.md
+++ b/libraries/typescript/packages/mcp-use/examples/server/oauth/clerk/README.md
@@ -15,13 +15,13 @@ A production-ready example of an MCP server with Clerk OAuth 2.0 authentication,
 
 1. **Clerk Account**: Sign up at [clerk.com](https://clerk.com)
 2. **Node.js**: Version 18 or higher
-3. **Clerk Application**: Create an application in the [Clerk Dashboard](https://dashboard.clerk.com)
+3. **Clerk Application**: Create an application in the [Clerk Dashboard](https://dashboard.clerk.com/sign-in)
 
 ## Setup
 
 ### 1. Get Your Clerk Frontend API URL
 
-From the [Clerk Dashboard](https://dashboard.clerk.com):
+From the [Clerk Dashboard](https://dashboard.clerk.com/sign-in):
 
 1. Open your application
 2. Go to **Configure** → **API Keys**
@@ -33,7 +33,7 @@ From the [Clerk Dashboard](https://dashboard.clerk.com):
 
 **⚠️ IMPORTANT**: Dynamic Client Registration is **required** for MCP clients to work with Clerk.
 
-1. Go to the [Clerk Dashboard](https://dashboard.clerk.com)
+1. Go to the [Clerk Dashboard](https://dashboard.clerk.com/sign-in)
 2. Navigate to **Configure** → **OAuth Applications**
 3. Enable **Dynamic Client Registration**
 4. Save your changes

--- a/libraries/typescript/packages/mcp-use/examples/server/oauth/workos/README.md
+++ b/libraries/typescript/packages/mcp-use/examples/server/oauth/workos/README.md
@@ -15,7 +15,7 @@ A production-ready example of an MCP server with WorkOS AuthKit OAuth 2.0 authen
 
 1. **WorkOS Account**: Sign up at [workos.com](https://workos.com)
 2. **Node.js**: Version 18 or higher
-3. **AuthKit Setup**: Follow [WorkOS AuthKit Quickstart](https://workos.com/docs/authkit/quickstart) to set up your project
+3. **AuthKit Setup**: Follow [WorkOS AuthKit Quickstart](https://workos.com/docs/authkit) to set up your project
 
 ## What is WorkOS AuthKit?
 


### PR DESCRIPTION
Redo of #1465 by @dvirarad — the original PR was branched off `main` and ended up squashing in the #1463 skill docs commit alongside the link fixes. This PR contains **only** the two README link fixes, branched off `canary`.

## Changes
- `examples/server/oauth/clerk/README.md`: point Clerk Dashboard links to `/sign-in` (200 instead of 404).
- `examples/server/oauth/workos/README.md`: replace 404 quickstart URL with `/docs/authkit` (200).

## Backwards Compatibility
Docs only. No code changes, no published package impact.