### PR TITLE
test(inspector): add OAuth e2e against emulated Google issuer

### DIFF
--- a/libraries/typescript/.changeset/oauth-emulate-e2e.md
+++ b/libraries/typescript/.changeset/oauth-emulate-e2e.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Add Playwright e2e test covering the inspector's OAuth redirect flow against an emulated Google issuer (via `emulate`), exercising both "Direct" and "Via Proxy" connection types. Test-only — no runtime change.

--- a/libraries/typescript/packages/inspector/package.json
+++ b/libraries/typescript/packages/inspector/package.json
@@ -132,6 +132,7 @@
     "@types/express": "^5.0.6",
     "@vitejs/plugin-react": "^6.0.0",
     "concurrently": "^9.2.1",
+    "emulate": "0.5.0",
     "eslint": "^9.39.2",
     "express": "^5.2.1",
     "oauth2-mock-server": "^8.2.0",

--- a/libraries/typescript/packages/inspector/tests/e2e/fixtures/google-emulate-server.ts
+++ b/libraries/typescript/packages/inspector/tests/e2e/fixtures/google-emulate-server.ts
@@ -1,0 +1,108 @@
+/**
+ * Uses `oauthProxy` mode rather than `oauthCustomProvider` because emulate's
+ * Google issuer exposes `/.well-known/openid-configuration` but not the
+ * `oauth-authorization-server` path that DCR-direct mode proxies through.
+ * Proxy mode lets the MCP server synthesize metadata pointing at local
+ * /authorize, /token, /register endpoints that forward upstream.
+ *
+ * emulate Google issues opaque access tokens (`google_<rand>`), not JWTs —
+ * `verifyToken` calls /oauth2/v2/userinfo with the Bearer token rather than
+ * decoding/verifying a signature.
+ */
+
+import { createEmulator } from "emulate";
+import { MCPServer, oauthProxy, text } from "mcp-use/server";
+
+const GOOGLE_EMULATOR_PORT = 4101;
+const MCP_SERVER_PORT = 4201;
+
+const STATIC_CLIENT_ID = "mcp-emulate-test-client.apps.googleusercontent.com";
+const STATIC_CLIENT_SECRET = "GOCSPX-mcp-emulate-test-secret";
+
+export const GOOGLE_MOCK_USER = {
+  email: "testuser@example.com",
+  name: "Test User",
+};
+
+export interface GoogleEmulateHandle {
+  mcpUrl: string;
+  close: () => Promise<void>;
+}
+
+export async function startGoogleEmulateFixture(): Promise<GoogleEmulateHandle> {
+  const emulator = await createEmulator({
+    service: "google",
+    port: GOOGLE_EMULATOR_PORT,
+    seed: {
+      google: {
+        users: [
+          {
+            email: GOOGLE_MOCK_USER.email,
+            name: GOOGLE_MOCK_USER.name,
+          },
+        ],
+        oauth_clients: [
+          {
+            client_id: STATIC_CLIENT_ID,
+            client_secret: STATIC_CLIENT_SECRET,
+            redirect_uris: ["http://localhost:3000/inspector/oauth/callback"],
+          },
+        ],
+      },
+    },
+  });
+
+  const emulatorUrl = emulator.url;
+
+  const mcpServer = new MCPServer({
+    name: "GoogleEmulateTestServer",
+    version: "1.0.0",
+    description: "MCP server backed by the emulate Google OAuth issuer",
+    oauth: oauthProxy({
+      issuer: emulatorUrl,
+      authEndpoint: `${emulatorUrl}/o/oauth2/v2/auth`,
+      tokenEndpoint: `${emulatorUrl}/oauth2/token`,
+      clientId: STATIC_CLIENT_ID,
+      clientSecret: STATIC_CLIENT_SECRET,
+      scopes: ["openid", "email", "profile"],
+      verifyToken: async (token: string) => {
+        const res = await fetch(`${emulatorUrl}/oauth2/v2/userinfo`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!res.ok) {
+          throw new Error(
+            `userinfo verification failed: ${res.status} ${res.statusText}`
+          );
+        }
+        const payload = (await res.json()) as Record<string, unknown>;
+        return { payload };
+      },
+      getUserInfo: (payload) => ({
+        userId: (payload.sub ?? payload.email) as string,
+        email: payload.email as string | undefined,
+        name: payload.name as string | undefined,
+        scopes: [],
+      }),
+    }),
+  });
+
+  mcpServer.tool(
+    {
+      name: "verify_auth",
+      description: "Confirm OAuth authentication succeeded",
+    },
+    async (_args, ctx) =>
+      text(
+        `OAuth authentication successful for ${ctx.auth.user.email ?? "unknown"}`
+      )
+  );
+
+  await mcpServer.listen(MCP_SERVER_PORT);
+
+  return {
+    mcpUrl: `http://localhost:${MCP_SERVER_PORT}/mcp`,
+    close: async () => {
+      await Promise.all([mcpServer.close(), emulator.close()]);
+    },
+  };
+}

--- a/libraries/typescript/packages/inspector/tests/e2e/fixtures/google-emulate-server.ts
+++ b/libraries/typescript/packages/inspector/tests/e2e/fixtures/google-emulate-server.ts
@@ -54,55 +54,60 @@ export async function startGoogleEmulateFixture(): Promise<GoogleEmulateHandle> 
 
   const emulatorUrl = emulator.url;
 
-  const mcpServer = new MCPServer({
-    name: "GoogleEmulateTestServer",
-    version: "1.0.0",
-    description: "MCP server backed by the emulate Google OAuth issuer",
-    oauth: oauthProxy({
-      issuer: emulatorUrl,
-      authEndpoint: `${emulatorUrl}/o/oauth2/v2/auth`,
-      tokenEndpoint: `${emulatorUrl}/oauth2/token`,
-      clientId: STATIC_CLIENT_ID,
-      clientSecret: STATIC_CLIENT_SECRET,
-      scopes: ["openid", "email", "profile"],
-      verifyToken: async (token: string) => {
-        const res = await fetch(`${emulatorUrl}/oauth2/v2/userinfo`, {
-          headers: { Authorization: `Bearer ${token}` },
-        });
-        if (!res.ok) {
-          throw new Error(
-            `userinfo verification failed: ${res.status} ${res.statusText}`
-          );
-        }
-        const payload = (await res.json()) as Record<string, unknown>;
-        return { payload };
-      },
-      getUserInfo: (payload) => ({
-        userId: (payload.sub ?? payload.email) as string,
-        email: payload.email as string | undefined,
-        name: payload.name as string | undefined,
-        scopes: [],
+  try {
+    const mcpServer = new MCPServer({
+      name: "GoogleEmulateTestServer",
+      version: "1.0.0",
+      description: "MCP server backed by the emulate Google OAuth issuer",
+      oauth: oauthProxy({
+        issuer: emulatorUrl,
+        authEndpoint: `${emulatorUrl}/o/oauth2/v2/auth`,
+        tokenEndpoint: `${emulatorUrl}/oauth2/token`,
+        clientId: STATIC_CLIENT_ID,
+        clientSecret: STATIC_CLIENT_SECRET,
+        scopes: ["openid", "email", "profile"],
+        verifyToken: async (token: string) => {
+          const res = await fetch(`${emulatorUrl}/oauth2/v2/userinfo`, {
+            headers: { Authorization: `Bearer ${token}` },
+          });
+          if (!res.ok) {
+            throw new Error(
+              `userinfo verification failed: ${res.status} ${res.statusText}`
+            );
+          }
+          const payload = (await res.json()) as Record<string, unknown>;
+          return { payload };
+        },
+        getUserInfo: (payload) => ({
+          userId: (payload.sub ?? payload.email) as string,
+          email: payload.email as string | undefined,
+          name: payload.name as string | undefined,
+          scopes: [],
+        }),
       }),
-    }),
-  });
+    });
 
-  mcpServer.tool(
-    {
-      name: "verify_auth",
-      description: "Confirm OAuth authentication succeeded",
-    },
-    async (_args, ctx) =>
-      text(
-        `OAuth authentication successful for ${ctx.auth.user.email ?? "unknown"}`
-      )
-  );
+    mcpServer.tool(
+      {
+        name: "verify_auth",
+        description: "Confirm OAuth authentication succeeded",
+      },
+      async (_args, ctx) =>
+        text(
+          `OAuth authentication successful for ${ctx.auth.user.email ?? "unknown"}`
+        )
+    );
 
-  await mcpServer.listen(MCP_SERVER_PORT);
+    await mcpServer.listen(MCP_SERVER_PORT);
 
-  return {
-    mcpUrl: `http://localhost:${MCP_SERVER_PORT}/mcp`,
-    close: async () => {
-      await Promise.all([mcpServer.close(), emulator.close()]);
-    },
-  };
+    return {
+      mcpUrl: `http://localhost:${MCP_SERVER_PORT}/mcp`,
+      close: async () => {
+        await Promise.all([mcpServer.close(), emulator.close()]);
+      },
+    };
+  } catch (err) {
+    await emulator.close().catch(() => {});
+    throw err;
+  }
 }

--- a/libraries/typescript/packages/inspector/tests/e2e/oauth-emulate.test.ts
+++ b/libraries/typescript/packages/inspector/tests/e2e/oauth-emulate.test.ts
@@ -1,0 +1,70 @@
+/**
+ * The authorize redirect is top-level navigation in both Direct and Via Proxy
+ * modes (useRedirectFlow: true), so the user-picker page is driven identically;
+ * the difference is whether OAuth metadata + token-exchange fetches go through
+ * the inspector backend.
+ */
+
+import { expect, test } from "@playwright/test";
+import {
+  GOOGLE_MOCK_USER,
+  startGoogleEmulateFixture,
+  type GoogleEmulateHandle,
+} from "./fixtures/google-emulate-server.js";
+
+type ConnectionType = "Direct" | "Via Proxy";
+
+// Both variants share one fixture on fixed ports (the MCP server's registered
+// redirect URI pins us to a known port), so they must run in the same worker.
+test.describe.configure({ mode: "serial" });
+
+let fixture: GoogleEmulateHandle;
+
+test.beforeAll(async () => {
+  fixture = await startGoogleEmulateFixture();
+});
+
+test.afterAll(async () => {
+  await fixture?.close();
+});
+
+test.beforeEach(async ({ page, context }) => {
+  await context.clearCookies();
+  await page.goto("http://localhost:3000/inspector");
+  await page.evaluate(() => localStorage.clear());
+});
+
+for (const connectionType of ["Direct", "Via Proxy"] as ConnectionType[]) {
+  test.describe(`OAuth flow via emulate Google (${connectionType})`, () => {
+    test("completes OAuth and reaches ready state", async ({ page }) => {
+      await page.getByTestId("connection-form-url-input").fill(fixture.mcpUrl);
+
+      if (connectionType !== "Direct") {
+        await page.getByTestId("connection-form-type-select").click();
+        await page.getByRole("option", { name: connectionType }).click();
+      }
+
+      await page.getByTestId("connection-form-connect-button").click();
+
+      await expect(
+        page.getByRole("heading", { name: fixture.mcpUrl })
+      ).toBeVisible({ timeout: 15_000 });
+
+      const authenticateLink = page.getByTestId("server-tile-authenticate");
+      await expect(authenticateLink).toBeVisible({ timeout: 15_000 });
+
+      await authenticateLink.click();
+
+      // emulate's authorize page renders one form per seeded user; pick ours by email.
+      await page
+        .locator("form.user-form")
+        .filter({ hasText: GOOGLE_MOCK_USER.email })
+        .locator("button[type=submit]")
+        .click();
+
+      await expect(page.getByTestId("tool-item-verify_auth")).toBeVisible({
+        timeout: 30_000,
+      });
+    });
+  });
+}

--- a/libraries/typescript/packages/inspector/tests/e2e/oauth-emulate.test.ts
+++ b/libraries/typescript/packages/inspector/tests/e2e/oauth-emulate.test.ts
@@ -34,7 +34,7 @@ test.beforeEach(async ({ page, context }) => {
   await page.evaluate(() => localStorage.clear());
 });
 
-for (const connectionType of ["Direct", "Via Proxy"] as ConnectionType[]) {
+function describeOAuthFlow(connectionType: ConnectionType): void {
   test.describe(`OAuth flow via emulate Google (${connectionType})`, () => {
     test("completes OAuth and reaches ready state", async ({ page }) => {
       await page.getByTestId("connection-form-url-input").fill(fixture.mcpUrl);
@@ -68,3 +68,6 @@ for (const connectionType of ["Direct", "Via Proxy"] as ConnectionType[]) {
     });
   });
 }
+
+describeOAuthFlow("Direct");
+describeOAuthFlow("Via Proxy");

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -440,6 +440,9 @@ importers:
       concurrently:
         specifier: ^9.2.1
         version: 9.2.1
+      emulate:
+        specifier: 0.5.0
+        version: 0.5.0(hono@4.12.12)
       eslint:
         specifier: ^9.39.2
         version: 9.39.2(jiti@2.6.1)
@@ -4824,6 +4827,10 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emulate@0.5.0:
+    resolution: {integrity: sha512-2LrOE8sqa1ITQ1aRR3kZhAhOCNz8hu+Kea9oBKdG/jEK6I/RYlMgHbsvQmbTTtr+nx6+fOOWkL6wqvfLeF5vuA==}
+    hasBin: true
 
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
@@ -11856,6 +11863,15 @@ snapshots:
   emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
+
+  emulate@0.5.0(hono@4.12.12):
+    dependencies:
+      '@hono/node-server': 1.19.13(hono@4.12.12)
+      commander: 14.0.3
+      picocolors: 1.1.1
+      yaml: 2.8.3
+    transitivePeerDependencies:
+      - hono
 
   encodeurl@2.0.0: {}
 


### PR DESCRIPTION
## Language / Project Scope

- [x] TypeScript

## Changes

Adds a Playwright e2e test that exercises the inspector's OAuth redirect flow end-to-end against an emulated Google OAuth issuer (`emulate`), parametrized across both "Direct" and "Via Proxy" connection types.

## Implementation Details

1. **New fixture** `tests/e2e/fixtures/google-emulate-server.ts` — boots an `emulate` Google issuer plus an `MCPServer` in `oauthProxy` mode pointing at it, registers a `verify_auth` tool, and exposes `{ mcpUrl, close }`. Uses `oauthProxy` (not `oauthCustomProvider`) because emulate's Google exposes `/.well-known/openid-configuration` but not `oauth-authorization-server`; proxy mode lets the MCP server synthesize the latter and forward authorize/token/register locally. Tokens are opaque (`google_<rand>`), so `verifyToken` calls `/oauth2/v2/userinfo` rather than verifying a JWT signature.
2. **New test** `tests/e2e/oauth-emulate.test.ts` — top-level `beforeAll`/`afterAll` share one fixture between the Direct and Via Proxy variants; `test.describe.configure({ mode: "serial" })` keeps both in the same worker (the registered OAuth redirect URI pins the MCP server to a fixed port). Each variant fills the connection form, clicks Authenticate, picks the seeded user on emulate's authorize page, and verifies the `verify_auth` tool is reachable post-callback.
3. **Dependency** — `emulate@0.5.0` added as a devDependency of `@mcp-use/inspector`.

### Packages Modified

- [x] `inspector`

### Pre-commit Checklist

- [x] Ran `pnpm changeset` (patch bump for `@mcp-use/inspector`, test-only)
- [x] Added tests
- [ ] `pnpm lint:fix` / `pnpm format` / `pnpm build` — not run (test-only change to e2e fixtures)
- [ ] Documentation — n/a

## Example Usage (After)

```bash
# From libraries/typescript/packages/inspector
pnpm test:e2e oauth-emulate.test.ts
```

## Testing

- Ran the new test locally against the dev inspector — both `Direct` and `Via Proxy` variants pass:
  - `oauth-emulate.test.ts:39:5 › OAuth flow via emulate Google (Direct) › completes OAuth and reaches ready state` ✓
  - `oauth-emulate.test.ts:39:5 › OAuth flow via emulate Google (Via Proxy) › completes OAuth and reaches ready state` ✓
- No existing tests modified.

## Backwards Compatibility

Backwards compatible — test-only addition, no runtime API change.

## Related Issues

Closes MCP-1899