### PR TITLE
fix(inspector): implement dark-mode aware scrollbars

### DIFF
--- a/libraries/typescript/.changeset/improve-inspector-scrollbars.md
+++ b/libraries/typescript/.changeset/improve-inspector-scrollbars.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Improve dark mode scrollbar styling and hover visibility in the Inspector UI.

--- a/libraries/typescript/packages/inspector/src/client/index.css
+++ b/libraries/typescript/packages/inspector/src/client/index.css
@@ -217,7 +217,26 @@
 @layer base {
   * {
     @apply border-border outline-ring/50;
+    scrollbar-width: thin;
+    scrollbar-color: var(--muted) transparent;
   }
+  ::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+
+  ::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    @apply bg-muted rounded-full border-2 border-transparent bg-clip-content;
+  }
+
+  ::-webkit-scrollbar-thumb:hover {
+    @apply bg-muted-foreground/30;
+  }
+
   body {
     @apply bg-background text-foreground;
   }

--- a/libraries/typescript/packages/inspector/src/client/index.css
+++ b/libraries/typescript/packages/inspector/src/client/index.css
@@ -234,7 +234,7 @@
   }
 
   ::-webkit-scrollbar-thumb:hover {
-    @apply bg-muted-foreground/30;
+    background-color: color-mix(in oklch, var(--muted) 80%, white);
   }
 
   body {


### PR DESCRIPTION
Fixes #1479. This adds custom scrollbar styling to the Inspector UI that adapts to dark mode, ensuring scrollbars are dark and muted when the dark theme is active.

<img width="1035" height="542" alt="Screenshot 2026-05-13 at 2 42 09 AM" src="https://github.com/user-attachments/assets/8e7e4ed4-9a08-4128-8a1a-89b3bef29d9f" />
