### PR TITLE
fix(inspector): surface MCP server auth failures with reconnect banner

### DIFF
--- a/libraries/typescript/.changeset/inspector-mcp-reconnect-banner.md
+++ b/libraries/typescript/.changeset/inspector-mcp-reconnect-banner.md
@@ -1,0 +1,20 @@
+---
+"@mcp-use/inspector": patch
+---
+
+fix(inspector): surface MCP server auth failures with a reconnect banner
+
+When the hosted inspector's chat backend returned 401 because the
+upstream MCP server rejected the user's OAuth token (e.g. Linear token
+expired), the inspector previously threw a generic `HTTP error! status:
+401` and the cloud response misleadingly pointed users at the Manufact
+account login.
+
+The chat now recognises the cloud's `{ error: "mcp_auth_required",
+mcpServerUrl }` response and renders an inline banner above the input
+("Reconnect to <server>") with a button that calls
+`connection.authenticate()`. Reconnect refreshes the OAuth token in
+localStorage; the banner clears on success and chat resumes.
+
+Pairs with a cloud-side change that drops the misleading `loginUrl`
+field from the 401 response.

--- a/libraries/typescript/packages/inspector/src/client/components/ChatTab.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ChatTab.tsx
@@ -26,6 +26,7 @@ import type { ToolInfo } from "./chat/ToolSelector";
 import { useChatMessages } from "./chat/useChatMessages";
 import { useChatMessagesClientSide } from "./chat/useChatMessagesClientSide";
 import { useConfig } from "./chat/useConfig";
+import { McpReconnectBanner } from "./chat/McpReconnectBanner";
 import { useWidgetDebug } from "../context/WidgetDebugContext";
 import { LoginModal } from "./LoginModal";
 
@@ -262,6 +263,39 @@ export function ChatTab({
   const clearRateLimitInfo = effectiveClientSide
     ? undefined
     : serverSideChat.clearRateLimitInfo;
+
+  const mcpAuthRequired = effectiveClientSide
+    ? null
+    : (serverSideChat.mcpAuthRequired ?? null);
+
+  const clearMcpAuthRequired = effectiveClientSide
+    ? undefined
+    : serverSideChat.clearMcpAuthRequired;
+
+  const handleMcpReconnect = useCallback(async () => {
+    try {
+      await connection.authenticate();
+    } catch (err) {
+      console.error("[ChatTab] MCP reconnect failed:", err);
+      toast.error(
+        err instanceof Error
+          ? `Reconnect failed: ${err.message}`
+          : "Reconnect failed"
+      );
+      return;
+    }
+    clearMcpAuthRequired?.();
+  }, [connection, clearMcpAuthRequired]);
+
+  const reconnectBannerNode = mcpAuthRequired ? (
+    <McpReconnectBanner
+      serverName={connection.name}
+      serverUrl={mcpAuthRequired.mcpServerUrl}
+      message={mcpAuthRequired.message}
+      onReconnect={handleMcpReconnect}
+      onDismiss={clearMcpAuthRequired}
+    />
+  ) : null;
 
   // Called when user clicks "Use your own API key" in the rate-limit modal.
   const handleUseApiKey = useCallback(() => {
@@ -1077,6 +1111,7 @@ export function ChatTab({
           onQuickQuestionSelect={handleQuickQuestionSelect}
           freeTierInfo={freeTierInfo}
         />
+        {reconnectBannerNode}
         {loginModalNode}
       </div>
     );
@@ -1143,11 +1178,13 @@ export function ChatTab({
 
       {loginModalNode}
 
+      {reconnectBannerNode}
+
       {/* Input Area */}
       {llmConfig && (
         <ChatInputArea
           inputValue={inputValue}
-          isConnected={isConnected && !rateLimitInfo}
+          isConnected={isConnected && !rateLimitInfo && !mcpAuthRequired}
           isLoading={isLoading}
           textareaRef={textareaRef}
           promptsDropdownOpen={promptsDropdownOpen}

--- a/libraries/typescript/packages/inspector/src/client/components/ChatTab.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ChatTab.tsx
@@ -264,13 +264,13 @@ export function ChatTab({
     ? undefined
     : serverSideChat.clearRateLimitInfo;
 
-  const mcpAuthRequired = effectiveClientSide
+  const mcpServerAuthRequired = effectiveClientSide
     ? null
-    : (serverSideChat.mcpAuthRequired ?? null);
+    : (serverSideChat.mcpServerAuthRequired ?? null);
 
-  const clearMcpAuthRequired = effectiveClientSide
+  const clearMcpServerAuthRequired = effectiveClientSide
     ? undefined
-    : serverSideChat.clearMcpAuthRequired;
+    : serverSideChat.clearMcpServerAuthRequired;
 
   const handleMcpReconnect = useCallback(async () => {
     try {
@@ -284,16 +284,16 @@ export function ChatTab({
       );
       return;
     }
-    clearMcpAuthRequired?.();
-  }, [connection, clearMcpAuthRequired]);
+    clearMcpServerAuthRequired?.();
+  }, [connection, clearMcpServerAuthRequired]);
 
-  const reconnectBannerNode = mcpAuthRequired ? (
+  const reconnectBannerNode = mcpServerAuthRequired ? (
     <McpReconnectBanner
       serverName={connection.name}
-      serverUrl={mcpAuthRequired.mcpServerUrl}
-      message={mcpAuthRequired.message}
+      serverUrl={mcpServerAuthRequired.mcpServerUrl}
+      message={mcpServerAuthRequired.message}
       onReconnect={handleMcpReconnect}
-      onDismiss={clearMcpAuthRequired}
+      onDismiss={clearMcpServerAuthRequired}
     />
   ) : null;
 
@@ -1184,7 +1184,7 @@ export function ChatTab({
       {llmConfig && (
         <ChatInputArea
           inputValue={inputValue}
-          isConnected={isConnected && !rateLimitInfo && !mcpAuthRequired}
+          isConnected={isConnected && !rateLimitInfo && !mcpServerAuthRequired}
           isLoading={isLoading}
           textareaRef={textareaRef}
           promptsDropdownOpen={promptsDropdownOpen}

--- a/libraries/typescript/packages/inspector/src/client/components/chat/McpReconnectBanner.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/McpReconnectBanner.tsx
@@ -28,7 +28,14 @@ export function McpReconnectBanner({
     }
   }, [onReconnect]);
 
-  const label = serverName || new URL(serverUrl).host;
+  let label = serverName;
+  if (!label) {
+    try {
+      label = new URL(serverUrl).host;
+    } catch {
+      label = serverUrl;
+    }
+  }
 
   return (
     <div className="w-full flex justify-center items-center px-2 sm:px-4 mb-2">

--- a/libraries/typescript/packages/inspector/src/client/components/chat/McpReconnectBanner.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/McpReconnectBanner.tsx
@@ -1,0 +1,76 @@
+import { AlertCircle, RefreshCw } from "lucide-react";
+import { useCallback, useState } from "react";
+import { Button } from "@/client/components/ui/button";
+
+interface McpReconnectBannerProps {
+  serverName?: string;
+  serverUrl: string;
+  message?: string;
+  onReconnect: () => Promise<void> | void;
+  onDismiss?: () => void;
+}
+
+export function McpReconnectBanner({
+  serverName,
+  serverUrl,
+  message,
+  onReconnect,
+  onDismiss,
+}: McpReconnectBannerProps) {
+  const [isReconnecting, setIsReconnecting] = useState(false);
+
+  const handleClick = useCallback(async () => {
+    setIsReconnecting(true);
+    try {
+      await onReconnect();
+    } finally {
+      setIsReconnecting(false);
+    }
+  }, [onReconnect]);
+
+  const label = serverName || new URL(serverUrl).host;
+
+  return (
+    <div className="w-full flex justify-center items-center px-2 sm:px-4 mb-2">
+      <div
+        role="alert"
+        className="w-full max-w-3xl flex items-start gap-3 rounded-md border border-amber-300/60 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-500/40 dark:bg-amber-950/40 dark:text-amber-100"
+      >
+        <AlertCircle className="mt-0.5 size-4 shrink-0" aria-hidden />
+        <div className="flex-1 min-w-0">
+          <div className="font-medium">
+            Reconnect to <span className="font-semibold">{label}</span>
+          </div>
+          <div className="text-xs opacity-90">
+            {message ??
+              "The MCP server rejected your credentials. Reconnect to refresh them."}
+          </div>
+        </div>
+        <div className="flex items-center gap-1">
+          <Button
+            size="sm"
+            variant="default"
+            onClick={handleClick}
+            disabled={isReconnecting}
+          >
+            <RefreshCw
+              className={`size-3.5 ${isReconnecting ? "animate-spin" : ""}`}
+              aria-hidden
+            />
+            {isReconnecting ? "Reconnecting…" : "Reconnect"}
+          </Button>
+          {onDismiss && (
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={onDismiss}
+              aria-label="Dismiss"
+            >
+              Dismiss
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessages.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessages.ts
@@ -77,7 +77,7 @@ export function useChatMessages({
   // from the upstream MCP server (token expired/revoked). Distinct from
   // `rateLimitInfo` (429 → Manufact account login) — here the user must
   // re-run the MCP server's OAuth flow.
-  const [mcpAuthRequired, setMcpAuthRequired] = useState<{
+  const [mcpServerAuthRequired, setMcpServerAuthRequired] = useState<{
     mcpServerUrl: string;
     message?: string;
   } | null>(null);
@@ -234,7 +234,7 @@ export function useChatMessages({
           if (response.status === 401) {
             const errBody = await response.json().catch(() => null);
             if (errBody?.error === "mcp_auth_required") {
-              setMcpAuthRequired({
+              setMcpServerAuthRequired({
                 mcpServerUrl:
                   (errBody.mcpServerUrl as string | undefined) ?? mcpServerUrl,
                 message: errBody.message as string | undefined,
@@ -567,15 +567,15 @@ export function useChatMessages({
   const clearMessages = useCallback(() => {
     setMessages([]);
     setRateLimitInfo(null);
-    setMcpAuthRequired(null);
+    setMcpServerAuthRequired(null);
   }, []);
 
   const clearRateLimitInfo = useCallback(() => {
     setRateLimitInfo(null);
   }, []);
 
-  const clearMcpAuthRequired = useCallback(() => {
-    setMcpAuthRequired(null);
+  const clearMcpServerAuthRequired = useCallback(() => {
+    setMcpServerAuthRequired(null);
   }, []);
 
   const stop = useCallback(() => {
@@ -621,11 +621,11 @@ export function useChatMessages({
     isLoading,
     attachments,
     rateLimitInfo,
-    mcpAuthRequired,
+    mcpServerAuthRequired,
     sendMessage,
     clearMessages,
     clearRateLimitInfo,
-    clearMcpAuthRequired,
+    clearMcpServerAuthRequired,
     setMessages,
     stop,
     addAttachment,

--- a/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessages.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessages.ts
@@ -239,9 +239,6 @@ export function useChatMessages({
                   (errBody.mcpServerUrl as string | undefined) ?? mcpServerUrl,
                 message: errBody.message as string | undefined,
               });
-              setMessages((prev) =>
-                prev.filter((m) => m.id !== `assistant-${Date.now()}`)
-              );
               return;
             }
           }

--- a/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessages.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessages.ts
@@ -73,10 +73,6 @@ export function useChatMessages({
   const [rateLimitInfo, setRateLimitInfo] = useState<{
     loginUrl: string;
   } | null>(null);
-  // Surfaced when the chat backend (cloud.mcp-use) reports a 401 originating
-  // from the upstream MCP server (token expired/revoked). Distinct from
-  // `rateLimitInfo` (429 → Manufact account login) — here the user must
-  // re-run the MCP server's OAuth flow.
   const [mcpServerAuthRequired, setMcpServerAuthRequired] = useState<{
     mcpServerUrl: string;
     message?: string;

--- a/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessages.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessages.ts
@@ -73,6 +73,14 @@ export function useChatMessages({
   const [rateLimitInfo, setRateLimitInfo] = useState<{
     loginUrl: string;
   } | null>(null);
+  // Surfaced when the chat backend (cloud.mcp-use) reports a 401 originating
+  // from the upstream MCP server (token expired/revoked). Distinct from
+  // `rateLimitInfo` (429 → Manufact account login) — here the user must
+  // re-run the MCP server's OAuth flow.
+  const [mcpAuthRequired, setMcpAuthRequired] = useState<{
+    mcpServerUrl: string;
+    message?: string;
+  } | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
 
   const sendMessage = useCallback(
@@ -222,6 +230,20 @@ export function useChatMessages({
               prev.filter((m) => m.id !== `assistant-${Date.now()}`)
             );
             return;
+          }
+          if (response.status === 401) {
+            const errBody = await response.json().catch(() => null);
+            if (errBody?.error === "mcp_auth_required") {
+              setMcpAuthRequired({
+                mcpServerUrl:
+                  (errBody.mcpServerUrl as string | undefined) ?? mcpServerUrl,
+                message: errBody.message as string | undefined,
+              });
+              setMessages((prev) =>
+                prev.filter((m) => m.id !== `assistant-${Date.now()}`)
+              );
+              return;
+            }
           }
           throw new Error(`HTTP error! status: ${response.status}`);
         }
@@ -548,10 +570,15 @@ export function useChatMessages({
   const clearMessages = useCallback(() => {
     setMessages([]);
     setRateLimitInfo(null);
+    setMcpAuthRequired(null);
   }, []);
 
   const clearRateLimitInfo = useCallback(() => {
     setRateLimitInfo(null);
+  }, []);
+
+  const clearMcpAuthRequired = useCallback(() => {
+    setMcpAuthRequired(null);
   }, []);
 
   const stop = useCallback(() => {
@@ -597,9 +624,11 @@ export function useChatMessages({
     isLoading,
     attachments,
     rateLimitInfo,
+    mcpAuthRequired,
     sendMessage,
     clearMessages,
     clearRateLimitInfo,
+    clearMcpAuthRequired,
     setMessages,
     stop,
     addAttachment,


### PR DESCRIPTION
<img width="806" height="237" alt="image" src="https://github.com/user-attachments/assets/26ca7984-3b35-47f8-be6f-2daadf261a1c" />

## Language / Project Scope

- [x] TypeScript

## Changes

When the hosted inspector's chat backend returns 401 because the upstream MCP server rejected the user's OAuth token (e.g. Linear token expired), the inspector previously threw a generic `HTTP error! status: 401` and the cloud response misleadingly pointed users at the Manufact account login. This made it look like an "authentication clash" between Manufact session and the MCP server's OAuth.

The chat now recognises the cloud's `{ error: "mcp_auth_required", mcpServerUrl }` response shape (introduced in the matching cloud PR) and renders an inline banner above the composer:

> ⚠️ Reconnect to **<server>** — The MCP server rejected the request. Reconnect to refresh your credentials. [Reconnect] [Dismiss]

The Reconnect button calls `connection.authenticate()` on the selected `McpServer`, which kicks off the existing MCP OAuth dance and refreshes tokens in localStorage. The banner clears on success and chat resumes.

## Implementation Details

1. **`useChatMessages.ts`** — new `mcpAuthRequired` state; 401 responses with `error === "mcp_auth_required"` are parsed and exposed instead of being thrown as a generic HTTP error. Exposes `mcpAuthRequired` and `clearMcpAuthRequired` alongside the existing `rateLimitInfo` plumbing.
2. **`ChatTab.tsx`** — threads `mcpAuthRequired` through from `serverSideChat` and renders the banner above the input in both the landing-form and threaded-chat layouts. The composer's `isConnected` is gated on `!mcpAuthRequired` so the user can't queue messages while the server's session is dead.
3. **`chat/McpReconnectBanner.tsx`** (new) — small amber banner with `Reconnect` (spinner during `authenticate()`) and optional `Dismiss` buttons. Width-matched to the composer (`max-w-3xl`, centered) so the alignment is consistent.

## Backwards Compatibility

Non-breaking. Pairs with a cloud-side change that returns the new 401 body shape. Until that ships, the inspector's 401 branch sees the old `{ error: "auth_required", … }` body, fails the `=== "mcp_auth_required"` check, and falls through to the existing generic throw — i.e. same UX as today.

**Deploy order: cloud first, inspector after.**