### PR TITLE
docs: document `mcp-use screenshot` and refreshed client CLI

### DIFF
--- a/docs/typescript/client/cli.mdx
+++ b/docs/typescript/client/cli.mdx
@@ -18,17 +18,13 @@ npx mcp-use client --help
 
 ```bash
 # Connect once and save the server under a name of your choice
-npx mcp-use client connect manufact https://mcp.manufact.com
+npx mcp-use client connect manufact https://mcp.manufact.com/mcp
 
 # Every subsequent command names the server it operates on
 npx mcp-use client manufact tools list
 npx mcp-use client manufact tools call read_file path=/tmp/test.txt
 npx mcp-use client manufact interactive
 ```
-
-<Note>
-There is no "active" server. Every per-server command takes the server name as its first positional argument: `mcp-use client <name> <scope> <action>`.
-</Note>
 
 ## Command Structure
 
@@ -58,8 +54,10 @@ The per-server scopes are:
 ### HTTP Server
 
 ```bash
-npx mcp-use client connect manufact https://mcp.manufact.com
+npx mcp-use client connect manufact https://mcp.manufact.com/mcp
 ```
+
+Has a full OAuth 2.1 flow built in — the CLI handles the authentication flow for you.
 
 **Options:**
 - `--auth <token>`: Static Bearer token (skips OAuth).
@@ -83,12 +81,9 @@ npx mcp-use client list
 ```
 Saved Servers:
 
-┌──────────┬───────┬─────────────────────────────┬────────────────┐
-│ Name     │ Type  │ Target                      │ Server         │
-├──────────┼───────┼─────────────────────────────┼────────────────┤
-│ manufact │ http  │ https://mcp.manufact.com    │ manufact       │
-│ fs       │ stdio │ npx -y @mc...filesystem     │ fs-server      │
-└──────────┴───────┴─────────────────────────────┴────────────────┘
+NAME      TYPE   TARGET                         SERVER
+manufact  http   https://mcp.manufact.com/mcp   manufact-cloud
+fs        stdio  npx -y @mc...filesystem        fs-server
 ```
 
 ## Tools
@@ -217,10 +212,10 @@ Saved servers are persisted in `~/.mcp-use/cli-sessions.json`:
   "sessions": {
     "manufact": {
       "type": "http",
-      "url": "https://mcp.manufact.com",
+      "url": "https://mcp.manufact.com/mcp",
       "authMode": "oauth",
       "lastUsed": "2026-05-12T10:30:00Z",
-      "serverInfo": { "name": "manufact", "version": "1.0.0" }
+      "serverInfo": { "name": "manufact-cloud", "version": "1.0.0" }
     },
     "fs": {
       "type": "stdio",

--- a/docs/typescript/client/environments.mdx
+++ b/docs/typescript/client/environments.mdx
@@ -517,12 +517,13 @@ npx mcp-use client list
 npx mcp-use client <name> <scope> <action> [args...]
 ```
 
-The per-server scopes are `tools`, `resources`, `prompts`, `auth`, plus the top-level `interactive` and `disconnect`:
+The per-server scopes are `tools`, `resources`, `prompts`, `auth`, and `screenshot`, plus the top-level `interactive` and `disconnect`:
 
 ```bash
 # Tools
 npx mcp-use client my-server tools list
 npx mcp-use client my-server tools call <tool> [args]
+npx mcp-use client my-server tools call <tool> [args] --screenshot   # widget PNG when the tool renders a UI resource
 npx mcp-use client my-server tools describe <tool>
 
 # Resources
@@ -538,9 +539,14 @@ npx mcp-use client my-server auth status
 npx mcp-use client my-server auth refresh
 npx mcp-use client my-server auth logout
 
+# Widget screenshot (saved-server form — reuses OAuth/bearer auth)
+npx mcp-use client my-server screenshot --tool <tool> [args]
+
 # Interactive mode for one server
 npx mcp-use client my-server interactive
 ```
+
+For ad-hoc screenshots against a server you haven't saved, use the top-level form with `--mcp <url>` and optional `-H` headers — see the [CLI Client guide](/typescript/client/cli#screenshot).
 
 ### Managing Multiple Servers
 

--- a/docs/typescript/server/cli-reference.mdx
+++ b/docs/typescript/server/cli-reference.mdx
@@ -21,6 +21,9 @@ The `@mcp-use/cli` is a build and development tool for creating MCP servers with
   <Card title="generate-types" icon="type" href="#generate-types-type-generation">
     Auto-derive TypeScript types from your Zod tool schemas for fully-typed widget code.
   </Card>
+  <Card title="client" icon="terminal" href="/typescript/client/cli">
+    `mcp-use client` drives MCP servers from the terminal with full OAuth support, plus `client screenshot` for headless widget capture in agent visual feedback loops.
+  </Card>
 </CardGroup>
 
 ## Installation

--- a/docs/typescript/server/cli-reference.mdx
+++ b/docs/typescript/server/cli-reference.mdx
@@ -68,15 +68,17 @@ mcp-use dev [options]
 
 **Options:**
 
-| Option                    | Description                                                        | Default           |
-| ------------------------- | ------------------------------------------------------------------ | ----------------- |
-| `-p, --path <path>`       | Project directory                                                  | Current directory |
-| `--port <port>`           | Server port                                                        | 3000              |
-| `--mcp-dir <dir>`         | Folder holding the MCP entry + resources (e.g. `src/mcp`)          | -                 |
-| `--entry <file>`          | Explicit server entry file                                         | Auto-detected     |
-| `--widgets-dir <dir>`     | Path to widgets directory                                          | `resources`       |
-| `--no-open`               | Don't auto-open inspector                                          | false             |
-| `--no-hmr`                | Disable Hot Module Reloading                                       | false             |
+| Option                    | Description                                                                  | Default           |
+| ------------------------- | ---------------------------------------------------------------------------- | ----------------- |
+| `-p, --path <path>`       | Project directory                                                            | Current directory |
+| `--port <port>`           | Server port                                                                  | 3000              |
+| `--host <host>`           | Bind address; `0.0.0.0` listens on all interfaces                            | `0.0.0.0`         |
+| `--mcp-dir <dir>`         | Folder holding the MCP entry + resources (e.g. `src/mcp`)                    | -                 |
+| `--entry <file>`          | Explicit server entry file                                                   | Auto-detected     |
+| `--widgets-dir <dir>`     | Path to widgets directory                                                    | `resources`       |
+| `--no-open`               | Don't auto-open inspector                                                    | false             |
+| `--no-hmr`                | Disable Hot Module Reloading                                                 | false             |
+| `--tunnel`                | Expose the dev server through a public tunnel URL                            | false             |
 
 <Tip>
   Use `--mcp-dir` when your MCP server lives inside an existing project (e.g. a Next.js app).
@@ -104,6 +106,9 @@ mcp-use dev -p ./my-server
 
 # MCP server inside a Next.js app
 mcp-use dev --mcp-dir src/mcp
+
+# Share the dev server publicly (useful with ChatGPT/Claude remote MCP)
+mcp-use dev --tunnel
 ```
 
 #### Hot Module Reloading (HMR)
@@ -144,13 +149,16 @@ mcp-use build [options]
 
 **Options:**
 
-| Option                    | Description                                                        | Default           |
-| ------------------------- | ------------------------------------------------------------------ | ----------------- |
-| `-p, --path <path>`       | Project directory                                                  | Current directory |
-| `--mcp-dir <dir>`         | Folder holding the MCP entry + resources (e.g. `src/mcp`)          | -                 |
-| `--entry <file>`          | Explicit server entry file                                         | Auto-detected     |
-| `--widgets-dir <dir>`     | Path to widgets directory                                          | `resources`       |
-| `--with-inspector`        | Include inspector in build                                         | false             |
+| Option                    | Description                                                                  | Default           |
+| ------------------------- | ---------------------------------------------------------------------------- | ----------------- |
+| `-p, --path <path>`       | Project directory                                                            | Current directory |
+| `--mcp-dir <dir>`         | Folder holding the MCP entry + resources (e.g. `src/mcp`)                    | -                 |
+| `--entry <file>`          | Explicit server entry file                                                   | Auto-detected     |
+| `--widgets-dir <dir>`     | Path to widgets directory                                                    | `resources`       |
+| `--with-inspector`        | Include inspector in build                                                   | false             |
+| `--inline`                | Inline all widget JS/CSS into HTML (required for the VS Code MCP Apps host)  | false             |
+| `--no-inline`             | Keep widget JS/CSS as separate files (default)                               | true              |
+| `--no-typecheck`          | Skip the `tsc --noEmit` typecheck step (faster builds; transpile-only)       | false             |
 
 **Examples:**
 
@@ -166,6 +174,12 @@ mcp-use build -p ./my-server
 
 # Build MCP server inside a Next.js app
 mcp-use build --mcp-dir src/mcp
+
+# Inline-bundled widgets for VS Code MCP Apps (CSP-locked host)
+mcp-use build --inline
+
+# Fastest build: skip the typecheck pass
+mcp-use build --no-typecheck
 ```
 
 <Tip>
@@ -189,6 +203,7 @@ mcp-use start [options]
 | ------------------------- | ------------------------------------------------------------------ | ----------------- |
 | `-p, --path <path>`       | Project directory                                                  | Current directory |
 | `--port <port>`           | Server port                                                        | 3000              |
+| `--entry <file>`          | Explicit server entry file (overrides the build manifest)          | Auto-detected     |
 | `--mcp-dir <dir>`         | Folder holding the MCP entry + resources (e.g. `src/mcp`)          | -                 |
 | `--tunnel`                | Expose via tunnel                                                  | false             |
 
@@ -235,14 +250,21 @@ mcp-use deploy [options]
 
 **Options:**
 
-| Option                | Description                       | Default        |
-| --------------------- | --------------------------------- | -------------- |
-| `--name <name>`       | Custom deployment name            | Auto-generated |
-| `--port <port>`       | Server port                       | 3000           |
-| `--runtime <runtime>` | Runtime: "node" or "python"       | "node"         |
-| `--open`              | Open deployment in browser        | false          |
-| `--env <key=value>`   | Environment variable (repeatable) | -              |
-| `--env-file <path>`   | Path to .env file                 | -              |
+| Option                  | Description                                                                          | Default        |
+| ----------------------- | ------------------------------------------------------------------------------------ | -------------- |
+| `--name <name>`         | Custom deployment name                                                               | Auto-generated |
+| `--port <port>`         | Server port                                                                          | 3000           |
+| `--runtime <runtime>`   | Runtime: `node` or `python`                                                          | Auto-detected  |
+| `--open`                | Open deployment in browser after a successful deploy                                 | false          |
+| `--env <key=value>`     | Environment variable (repeatable)                                                    | -              |
+| `--env-file <path>`     | Path to a `.env` file with environment variables                                     | -              |
+| `--new`                 | Force creation of a new deployment (don't reuse the project link)                    | false          |
+| `--root-dir <path>`     | Root directory inside the repo to deploy from (for monorepos)                        | Repo root      |
+| `--org <slug-or-id>`    | Deploy to a specific organization (by slug or ID)                                    | Active org     |
+| `-y, --yes`             | Skip confirmation prompts (for non-interactive / CI use)                             | false          |
+| `--region <region>`     | Deploy region: `US`, `EU`, or `APAC`                                                 | `US`           |
+| `--build-command <cmd>` | Custom build command (overrides auto-detection)                                      | Auto-detected  |
+| `--start-command <cmd>` | Custom start command (overrides auto-detection)                                      | Auto-detected  |
 
 **Examples:**
 
@@ -261,6 +283,15 @@ mcp-use deploy --env-file .env.production
 
 # Python runtime
 mcp-use deploy --runtime python
+
+# Monorepo: deploy a subdirectory
+mcp-use deploy --root-dir apps/mcp-server
+
+# Force a brand-new deployment instead of reusing the linked one
+mcp-use deploy --new --name my-server-v2
+
+# Non-interactive deploy to a specific org and region
+mcp-use deploy --org manufact-inc --region EU --yes
 ```
 
 **Deployment Process:**
@@ -316,6 +347,123 @@ mcp-use logout
 ```
 
 Removes authentication credentials from `~/.mcp-use/config.json`.
+
+---
+
+### Organization Commands
+
+Manage which Manufact Cloud organization the CLI talks to. Every `deploy`, `deployments`, and `servers` call resolves against the active org unless `--org` overrides it.
+
+```bash
+mcp-use org list       # List orgs you belong to (active marked with ←)
+mcp-use org current    # Show the currently active org
+mcp-use org switch     # Interactive picker that updates ~/.mcp-use/config.json
+```
+
+<Tip>
+  For non-interactive flows (CI, agents), pass `--org <slug|id|name>` directly to `login` / `deploy` / `servers ls` / `deployments ls` instead of switching state up-front.
+</Tip>
+
+---
+
+### Deployment Management
+
+The `deploy` command above creates a deployment; the `deployments` subcommand inspects and manages existing ones.
+
+```bash
+mcp-use deployments list                 # Aliased as `deployments ls`
+mcp-use deployments get <deployment-id>
+mcp-use deployments logs <deployment-id> [-b|--build] [-f|--follow]
+mcp-use deployments restart <deployment-id> [-f|--follow]
+mcp-use deployments stop <deployment-id>
+mcp-use deployments start <deployment-id>
+mcp-use deployments delete <deployment-id> [-y|--yes]   # alias: `rm`
+```
+
+| Subcommand | Description |
+| ---------- | ----------- |
+| `list` / `ls` | List deployments visible to the active org |
+| `get` | Show core details for one deployment |
+| `logs` | Tail runtime logs by default; pass `-b/--build` for build logs and `-f/--follow` to stream |
+| `restart` | Trigger a new deployment on the same server (with optional build-log follow) |
+| `stop` | Take a running deployment offline |
+| `start` | Bring a stopped deployment back online |
+| `delete` / `rm` | Delete a deployment (irreversible — prompts unless `-y` is passed) |
+
+---
+
+### Server Management
+
+`mcp-use servers` manages the Git-backed deploy targets that own one or more deployments.
+
+```bash
+mcp-use servers list [--org <slug-or-id>] [--limit <n>] [--skip <n>] [--sort <field:asc|desc>]
+mcp-use servers get <id-or-slug>
+mcp-use servers delete <server-id> [-y] [--org <slug-or-id>]   # alias: `rm`
+```
+
+Environment variables on a server are managed under `servers env`:
+
+```bash
+mcp-use servers env list --server <id> [--show-values]
+mcp-use servers env add --server <id> KEY=VALUE \
+  [--env production,preview,development] [--sensitive]
+mcp-use servers env update <var-id> --server <id> \
+  [--value <value>] [--env <envs>] [--sensitive|--no-sensitive]
+mcp-use servers env remove <var-id> --server <id>   # alias: `rm`
+```
+
+| Subcommand | Notes |
+| ---------- | ----- |
+| `env list` | Values are masked by default — pass `--show-values` to reveal non-sensitive ones |
+| `env add` | `--env` defaults to all three environments when omitted |
+| `env update` | Use `--no-sensitive` to unmark a previously-sensitive var |
+| `env remove` | Address the var by its UUID (find it via `env list`) |
+
+<Tip>
+  Use `mcp-use servers ls` to discover server IDs, then `mcp-use deployments ls` (or `get <id>`) to drill into individual deploys. The two commands are intentionally split: a server is a long-lived target; deployments are immutable builds against it.
+</Tip>
+
+---
+
+### Client Commands
+
+`mcp-use client` is the interactive MCP **client** that lives inside the same binary as the build/deploy commands above. Use it to drive a running MCP server from the terminal — call tools, read resources, get prompts, run OAuth flows, or capture a PNG of a widget for an agent's visual feedback loop.
+
+```bash
+# Save an MCP server under a short name
+mcp-use client connect <name> <url>           # OAuth or --auth <token> for bearer
+mcp-use client connect <name> "<cmd args>" --stdio
+
+# Per-server commands (every subcommand takes the name positional)
+mcp-use client <name> tools list
+mcp-use client <name> tools call <tool> [args...] [--screenshot]
+mcp-use client <name> resources list
+mcp-use client <name> prompts list
+mcp-use client <name> auth status
+mcp-use client <name> screenshot --tool <name> [args...]
+mcp-use client <name> interactive
+mcp-use client <name> disconnect
+
+# Ad-hoc widget screenshot, no saved server needed
+mcp-use client screenshot --mcp <url> --tool <name> [args...]
+
+# Manage saved servers
+mcp-use client list
+mcp-use client remove <name>
+```
+
+| Scope | Actions |
+| ----- | ------- |
+| `tools` | `list`, `call <tool> [args...]`, `describe <tool>` |
+| `resources` | `list`, `read <uri>`, `subscribe <uri>`, `unsubscribe <uri>` |
+| `prompts` | `list`, `get <prompt> [args...]` |
+| `auth` | `status`, `refresh`, `logout` (OAuth servers only) |
+| `screenshot` | Render the tool's UI resource headlessly and write a PNG |
+
+<Card title="Full Client CLI reference" icon="terminal" href="/typescript/client/cli">
+  Connect/list/remove, every scope, the arg-parsing rules, OAuth flows, ad-hoc vs. saved-server screenshot forms, `--cdp-url` for remote browsers, and storage layout. Read this if you're using `mcp-use client` from your terminal or from an agent harness.
+</Card>
 
 ---
 

--- a/libraries/typescript/.changeset/cli-rename-mcp-use-cloud-to-manufact.md
+++ b/libraries/typescript/.changeset/cli-rename-mcp-use-cloud-to-manufact.md
@@ -1,0 +1,7 @@
+---
+"@mcp-use/cli": patch
+---
+
+chore(cli): rename "mcp-use cloud" to "Manufact cloud" in login command output
+
+`mcp-use login --help` now says "Login to Manufact cloud" and the body banner reads "Logging in to Manufact cloud..." — matching the existing wording used by `logout` and `deploy`.

--- a/libraries/typescript/packages/cli/src/commands/auth.ts
+++ b/libraries/typescript/packages/cli/src/commands/auth.ts
@@ -237,7 +237,7 @@ export async function loginCommand(options?: {
       await deleteConfig();
     }
 
-    console.log(chalk.cyan.bold("Logging in to mcp-use cloud...\n"));
+    console.log(chalk.cyan.bold("Logging in to Manufact cloud...\n"));
 
     const authBaseUrl = await getAuthBaseUrl();
 

--- a/libraries/typescript/packages/cli/src/index.ts
+++ b/libraries/typescript/packages/cli/src/index.ts
@@ -2958,7 +2958,7 @@ program
 // Authentication commands
 program
   .command("login")
-  .description("Login to mcp-use cloud")
+  .description("Login to Manufact cloud")
   .option(
     "--api-key <key>",
     "Login with an API key directly (non-interactive, for CI/CD)"

--- a/skills/chatgpt-app-builder/SKILL.md
+++ b/skills/chatgpt-app-builder/SKILL.md
@@ -189,6 +189,38 @@ Load these before diving into tools/resources/widgets sections.
 
 ---
 
+### 🔁 Testing from the Terminal (Agent Feedback Loops)
+**When:** You want to verify a tool or widget *without* the inspector UI — the canonical flow for AI agents iterating on MCP servers.
+
+- **`mcp-use client`** — drives MCP servers from the terminal. Auto-runs OAuth on 401, persists saved servers under a short name, and one-shot subcommands exit cleanly so they're safe to spawn from harnesses.
+
+  ```bash
+  npx mcp-use client connect dev http://localhost:3000/mcp
+  npx mcp-use client dev tools list
+  npx mcp-use client dev tools call get-weather city=Tokyo --screenshot
+  ```
+
+  Every per-server command takes the saved name as its first positional arg (`mcp-use client <name> <scope> <action>`) — there is no "active session". Args use `key=value` (with `key:='<json>'` for nested values) or a single JSON object. When a tool renders a widget, pass `--screenshot` to also save a PNG (`./<view>-<timestamp>.png` by default, or override with `--screenshot-output <path>`).
+
+- **`mcp-use client screenshot`** — headless render of a widget tool to a PNG. Use this when you want to visually verify a widget change without opening the inspector, especially in loops where you call a tool, screenshot, eyeball the output, and edit. Two forms:
+
+  ```bash
+  # Saved-server form — reuses the auth from `mcp-use client connect`
+  npx mcp-use client dev screenshot --tool get-weather city=Tokyo \
+    --width 800 --height 600 --theme light \
+    --output ./weather.png
+
+  # Ad-hoc form — connect inline (use -H for headers on authenticated servers)
+  npx mcp-use client screenshot --mcp http://localhost:3000/mcp \
+    --tool get-weather city=Tokyo
+  ```
+
+  Add `--device-scale-factor 2` for Retina output, or `--cdp-url <ws>` plus `--inspector <publicly-reachable-url>` to drive a remote Chromium (e.g. Notte) from a sandbox without a local Chrome install.
+
+Both commands are documented in full at [docs/typescript/client/cli](https://docs.mcp-use.com/typescript/client/cli).
+
+---
+
 ## Decision Tree
 
 ```
@@ -219,6 +251,12 @@ What do you need?
 │  └─> widgets/model-context.md
 ├─ Upload/download files in a widget
 │  └─> widgets/files.md (ChatGPT Apps SDK only)
+│
+├─ Verify a tool / widget from the terminal (no inspector UI)
+│  └─> `mcp-use client <name> tools call ... --screenshot`
+│
+├─ Headless visual feedback loop for widget iteration
+│  └─> `mcp-use client <name> screenshot --tool <name> key=value ...`
 │
 └─ Deploy to production
    └─> deployment.md (cloud deploy, self-hosting, Docker)
@@ -385,3 +423,5 @@ server.listen();
 - `server.use('mcp:tools/call', fn)` - MCP middleware (tools, resources, prompts, list ops)
 - `server.use('mcp:*', fn)` - Catch-all MCP middleware
 - `server.use(fn)` - HTTP middleware (Hono)
+
+

--- a/skills/chatgpt-app-builder/SKILL.md
+++ b/skills/chatgpt-app-builder/SKILL.md
@@ -252,11 +252,9 @@ What do you need?
 ├─ Upload/download files in a widget
 │  └─> widgets/files.md (ChatGPT Apps SDK only)
 │
-├─ Verify a tool / widget from the terminal (no inspector UI)
-│  └─> `mcp-use client <name> tools call ... --screenshot`
-│
-├─ Headless visual feedback loop for widget iteration
-│  └─> `mcp-use client <name> screenshot --tool <name> key=value ...`
+├─ Verify a tool or widget from the terminal (agent feedback loop)
+│  └─> See "Testing from the Terminal" above — `mcp-use client` for tool runs,
+│      `mcp-use client <server> screenshot --tool <tool>` for headless widget PNGs
 │
 └─ Deploy to production
    └─> deployment.md (cloud deploy, self-hosting, Docker)

--- a/skills/chatgpt-app-builder/references/widgets/basics.md
+++ b/skills/chatgpt-app-builder/references/widgets/basics.md
@@ -614,7 +614,7 @@ export default function GoodWidget() {
 
 ## Testing Widgets
 
-Use the inspector to test widgets during development:
+### Option 1: Inspector (interactive)
 
 1. Start dev server: `npm run dev`
 2. Open inspector: `http://localhost:3000/inspector`
@@ -626,6 +626,28 @@ Use the inspector to test widgets during development:
 - Change widget code → Auto-reload
 - Adjust props schema → Update tool call input
 - Test edge cases (empty lists, missing optional props)
+
+### Option 2: Headless screenshot (agent-friendly)
+
+For visual feedback loops where you want to verify a widget change without leaving the terminal — call the tool, save a PNG, eyeball it, edit, repeat:
+
+```bash
+# Saved-server form (assumes you ran `mcp-use client connect dev <url>` once)
+npx mcp-use client dev screenshot --tool get-weather city=Tokyo \
+  --width 800 --height 600 --theme light \
+  --output ./weather.png
+
+# Ad-hoc form — no saved server, pass auth headers inline if needed
+npx mcp-use client screenshot --mcp http://localhost:3000/mcp \
+  --tool get-weather city=Tokyo
+```
+
+- Args are `key=value` pairs, `key:='<json>'` for nested values, or one full JSON object
+- The saved-server form reuses the auth from `mcp-use client connect` (OAuth or `--auth <token>`); the ad-hoc form accepts `-H "Header: value"` (repeatable) for authenticated servers
+- Add `--device-scale-factor 2` for Retina output
+- For sandboxed environments without a local Chrome, point `--cdp-url <ws>` at a hosted Chromium (e.g. Notte) and `--inspector <publicly-reachable-url>` at a deployed inspector
+
+Equivalently, `mcp-use client <name> tools call <tool> ... --screenshot` calls the tool *and* saves a widget PNG in one step — useful for one-shot verification.
 
 ---
 

--- a/skills/mcp-apps-builder/SKILL.md
+++ b/skills/mcp-apps-builder/SKILL.md
@@ -252,11 +252,9 @@ What do you need?
 ├─ Upload/download files in a widget
 │  └─> widgets/files.md (ChatGPT Apps SDK only)
 │
-├─ Verify a tool / widget from the terminal (no inspector UI)
-│  └─> `mcp-use client <name> tools call ... --screenshot`
-│
-├─ Headless visual feedback loop for widget iteration
-│  └─> `mcp-use client <name> screenshot --tool <name> key=value ...`
+├─ Verify a tool or widget from the terminal (agent feedback loop)
+│  └─> See "Testing from the Terminal" above — `mcp-use client` for tool runs,
+│      `mcp-use client <server> screenshot --tool <tool>` for headless widget PNGs
 │
 └─ Deploy to production
    └─> deployment.md (cloud deploy, self-hosting, Docker)

--- a/skills/mcp-apps-builder/SKILL.md
+++ b/skills/mcp-apps-builder/SKILL.md
@@ -189,6 +189,38 @@ Load these before diving into tools/resources/widgets sections.
 
 ---
 
+### 🔁 Testing from the Terminal (Agent Feedback Loops)
+**When:** You want to verify a tool or widget *without* the inspector UI — the canonical flow for AI agents iterating on MCP servers.
+
+- **`mcp-use client`** — drives MCP servers from the terminal. Auto-runs OAuth on 401, persists saved servers under a short name, and one-shot subcommands exit cleanly so they're safe to spawn from harnesses.
+
+  ```bash
+  npx mcp-use client connect dev http://localhost:3000/mcp
+  npx mcp-use client dev tools list
+  npx mcp-use client dev tools call get-weather city=Tokyo --screenshot
+  ```
+
+  Every per-server command takes the saved name as its first positional arg (`mcp-use client <name> <scope> <action>`) — there is no "active session". Args use `key=value` (with `key:='<json>'` for nested values) or a single JSON object. When a tool renders a widget, pass `--screenshot` to also save a PNG (`./<view>-<timestamp>.png` by default, or override with `--screenshot-output <path>`).
+
+- **`mcp-use client screenshot`** — headless render of a widget tool to a PNG. Use this when you want to visually verify a widget change without opening the inspector, especially in loops where you call a tool, screenshot, eyeball the output, and edit. Two forms:
+
+  ```bash
+  # Saved-server form — reuses the auth from `mcp-use client connect`
+  npx mcp-use client dev screenshot --tool get-weather city=Tokyo \
+    --width 800 --height 600 --theme light \
+    --output ./weather.png
+
+  # Ad-hoc form — connect inline (use -H for headers on authenticated servers)
+  npx mcp-use client screenshot --mcp http://localhost:3000/mcp \
+    --tool get-weather city=Tokyo
+  ```
+
+  Add `--device-scale-factor 2` for Retina output, or `--cdp-url <ws>` plus `--inspector <publicly-reachable-url>` to drive a remote Chromium (e.g. Notte) from a sandbox without a local Chrome install.
+
+Both commands are documented in full at [docs/typescript/client/cli](https://docs.mcp-use.com/typescript/client/cli).
+
+---
+
 ## Decision Tree
 
 ```
@@ -219,6 +251,12 @@ What do you need?
 │  └─> widgets/model-context.md
 ├─ Upload/download files in a widget
 │  └─> widgets/files.md (ChatGPT Apps SDK only)
+│
+├─ Verify a tool / widget from the terminal (no inspector UI)
+│  └─> `mcp-use client <name> tools call ... --screenshot`
+│
+├─ Headless visual feedback loop for widget iteration
+│  └─> `mcp-use client <name> screenshot --tool <name> key=value ...`
 │
 └─ Deploy to production
    └─> deployment.md (cloud deploy, self-hosting, Docker)

--- a/skills/mcp-apps-builder/references/widgets/basics.md
+++ b/skills/mcp-apps-builder/references/widgets/basics.md
@@ -614,7 +614,7 @@ export default function GoodWidget() {
 
 ## Testing Widgets
 
-Use the inspector to test widgets during development:
+### Option 1: Inspector (interactive)
 
 1. Start dev server: `npm run dev`
 2. Open inspector: `http://localhost:3000/inspector`
@@ -626,6 +626,28 @@ Use the inspector to test widgets during development:
 - Change widget code → Auto-reload
 - Adjust props schema → Update tool call input
 - Test edge cases (empty lists, missing optional props)
+
+### Option 2: Headless screenshot (agent-friendly)
+
+For visual feedback loops where you want to verify a widget change without leaving the terminal — call the tool, save a PNG, eyeball it, edit, repeat:
+
+```bash
+# Saved-server form (assumes you ran `mcp-use client connect dev <url>` once)
+npx mcp-use client dev screenshot --tool get-weather city=Tokyo \
+  --width 800 --height 600 --theme light \
+  --output ./weather.png
+
+# Ad-hoc form — no saved server, pass auth headers inline if needed
+npx mcp-use client screenshot --mcp http://localhost:3000/mcp \
+  --tool get-weather city=Tokyo
+```
+
+- Args are `key=value` pairs, `key:='<json>'` for nested values, or one full JSON object
+- The saved-server form reuses the auth from `mcp-use client connect` (OAuth or `--auth <token>`); the ad-hoc form accepts `-H "Header: value"` (repeatable) for authenticated servers
+- Add `--device-scale-factor 2` for Retina output
+- For sandboxed environments without a local Chrome, point `--cdp-url <ws>` at a hosted Chromium (e.g. Notte) and `--inspector <publicly-reachable-url>` at a deployed inspector
+
+Equivalently, `mcp-use client <name> tools call <tool> ... --screenshot` calls the tool *and* saves a widget PNG in one step — useful for one-shot verification.
 
 ---
 

--- a/skills/mcp-builder/SKILL.md
+++ b/skills/mcp-builder/SKILL.md
@@ -189,6 +189,38 @@ Load these before diving into tools/resources/widgets sections.
 
 ---
 
+### 🔁 Testing from the Terminal (Agent Feedback Loops)
+**When:** You want to verify a tool or widget *without* the inspector UI — the canonical flow for AI agents iterating on MCP servers.
+
+- **`mcp-use client`** — drives MCP servers from the terminal. Auto-runs OAuth on 401, persists saved servers under a short name, and one-shot subcommands exit cleanly so they're safe to spawn from harnesses.
+
+  ```bash
+  npx mcp-use client connect dev http://localhost:3000/mcp
+  npx mcp-use client dev tools list
+  npx mcp-use client dev tools call get-weather city=Tokyo --screenshot
+  ```
+
+  Every per-server command takes the saved name as its first positional arg (`mcp-use client <name> <scope> <action>`) — there is no "active session". Args use `key=value` (with `key:='<json>'` for nested values) or a single JSON object. When a tool renders a widget, pass `--screenshot` to also save a PNG (`./<view>-<timestamp>.png` by default, or override with `--screenshot-output <path>`).
+
+- **`mcp-use client screenshot`** — headless render of a widget tool to a PNG. Use this when you want to visually verify a widget change without opening the inspector, especially in loops where you call a tool, screenshot, eyeball the output, and edit. Two forms:
+
+  ```bash
+  # Saved-server form — reuses the auth from `mcp-use client connect`
+  npx mcp-use client dev screenshot --tool get-weather city=Tokyo \
+    --width 800 --height 600 --theme light \
+    --output ./weather.png
+
+  # Ad-hoc form — connect inline (use -H for headers on authenticated servers)
+  npx mcp-use client screenshot --mcp http://localhost:3000/mcp \
+    --tool get-weather city=Tokyo
+  ```
+
+  Add `--device-scale-factor 2` for Retina output, or `--cdp-url <ws>` plus `--inspector <publicly-reachable-url>` to drive a remote Chromium (e.g. Notte) from a sandbox without a local Chrome install.
+
+Both commands are documented in full at [docs/typescript/client/cli](https://docs.mcp-use.com/typescript/client/cli).
+
+---
+
 ## Decision Tree
 
 ```
@@ -219,6 +251,12 @@ What do you need?
 │  └─> widgets/model-context.md
 ├─ Upload/download files in a widget
 │  └─> widgets/files.md (ChatGPT Apps SDK only)
+│
+├─ Verify a tool / widget from the terminal (no inspector UI)
+│  └─> `mcp-use client <name> tools call ... --screenshot`
+│
+├─ Headless visual feedback loop for widget iteration
+│  └─> `mcp-use client <name> screenshot --tool <name> key=value ...`
 │
 └─ Deploy to production
    └─> deployment.md (cloud deploy, self-hosting, Docker)
@@ -385,3 +423,5 @@ server.listen();
 - `server.use('mcp:tools/call', fn)` - MCP middleware (tools, resources, prompts, list ops)
 - `server.use('mcp:*', fn)` - Catch-all MCP middleware
 - `server.use(fn)` - HTTP middleware (Hono)
+
+

--- a/skills/mcp-builder/SKILL.md
+++ b/skills/mcp-builder/SKILL.md
@@ -252,11 +252,9 @@ What do you need?
 ├─ Upload/download files in a widget
 │  └─> widgets/files.md (ChatGPT Apps SDK only)
 │
-├─ Verify a tool / widget from the terminal (no inspector UI)
-│  └─> `mcp-use client <name> tools call ... --screenshot`
-│
-├─ Headless visual feedback loop for widget iteration
-│  └─> `mcp-use client <name> screenshot --tool <name> key=value ...`
+├─ Verify a tool or widget from the terminal (agent feedback loop)
+│  └─> See "Testing from the Terminal" above — `mcp-use client` for tool runs,
+│      `mcp-use client <server> screenshot --tool <tool>` for headless widget PNGs
 │
 └─ Deploy to production
    └─> deployment.md (cloud deploy, self-hosting, Docker)

--- a/skills/mcp-builder/references/widgets/basics.md
+++ b/skills/mcp-builder/references/widgets/basics.md
@@ -614,7 +614,7 @@ export default function GoodWidget() {
 
 ## Testing Widgets
 
-Use the inspector to test widgets during development:
+### Option 1: Inspector (interactive)
 
 1. Start dev server: `npm run dev`
 2. Open inspector: `http://localhost:3000/inspector`
@@ -626,6 +626,28 @@ Use the inspector to test widgets during development:
 - Change widget code → Auto-reload
 - Adjust props schema → Update tool call input
 - Test edge cases (empty lists, missing optional props)
+
+### Option 2: Headless screenshot (agent-friendly)
+
+For visual feedback loops where you want to verify a widget change without leaving the terminal — call the tool, save a PNG, eyeball it, edit, repeat:
+
+```bash
+# Saved-server form (assumes you ran `mcp-use client connect dev <url>` once)
+npx mcp-use client dev screenshot --tool get-weather city=Tokyo \
+  --width 800 --height 600 --theme light \
+  --output ./weather.png
+
+# Ad-hoc form — no saved server, pass auth headers inline if needed
+npx mcp-use client screenshot --mcp http://localhost:3000/mcp \
+  --tool get-weather city=Tokyo
+```
+
+- Args are `key=value` pairs, `key:='<json>'` for nested values, or one full JSON object
+- The saved-server form reuses the auth from `mcp-use client connect` (OAuth or `--auth <token>`); the ad-hoc form accepts `-H "Header: value"` (repeatable) for authenticated servers
+- Add `--device-scale-factor 2` for Retina output
+- For sandboxed environments without a local Chrome, point `--cdp-url <ws>` at a hosted Chromium (e.g. Notte) and `--inspector <publicly-reachable-url>` at a deployed inspector
+
+Equivalently, `mcp-use client <name> tools call <tool> ... --screenshot` calls the tool *and* saves a widget PNG in one step — useful for one-shot verification.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add a `screenshot` command section to `docs/typescript/server/cli-reference.mdx` (CDP-based widget capture, `--cdp-url`, `--inspector`, `--session`/`--mcp`, viewport/theme/output flags) plus two new "What's New" cards.
- Refresh `docs/typescript/client/cli.mdx` for the OAuth-aware client (#1452): auto-OAuth on 401 with `--no-oauth` / `--auth-timeout`, the `auth status|refresh|logout` scope, the `tools call` auto-screenshot path (`--no-screenshot`, `--screenshot-output`), `key=value` arg syntax, one-shot clean exits, and the new `~/.mcp-use/oauth/<urlHash>/` token layout in the storage example.
- Thread the new terminal feedback loop into the `mcp-apps-builder` skill (mirrored into `mcp-builder` and `chatgpt-app-builder`) so agents iterating on widgets know about `mcp-use client tools call` and `mcp-use screenshot` alongside the inspector. Adds an "Option 2: Headless screenshot" block to `references/widgets/basics.md`.

## Why
The `mcp-use screenshot` command (#1432, #1477) and the OAuth + `auth *` overhaul of `mcp-use client` (#1452) shipped without doc/skill updates — the public CLI docs still described the pre-OAuth client, and the mcp-apps-builder skill only pointed at the inspector for verification.

## Test plan
- [ ] `docs.json` cards link to the right anchors (`#screenshot-headless-widget-capture`, `/typescript/client/cli`)
- [ ] Mintlify renders without MDX errors locally
- [ ] Skill mirrors still differ only in the `name:` frontmatter

## Backwards compatibility
Docs/skills only — no code changes, no changeset required.