### PR TITLE
fix(inspector): keep tab count badges visible in collapsed mode

### DIFF
--- a/libraries/typescript/.changeset/improve-inspector-scrollbars.md
+++ b/libraries/typescript/.changeset/improve-inspector-scrollbars.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Improve dark mode scrollbar styling and hover visibility in the Inspector UI.

--- a/libraries/typescript/packages/inspector/src/client/components/LayoutHeader.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/LayoutHeader.tsx
@@ -881,6 +881,19 @@ export function LayoutHeader({
                   }
                   const count = getTabCount(tab.id, selectedServer);
                   const showDot = shouldShowDot(tab.id, count, collapsed);
+                  const badge =
+                    count > 0 ? (
+                      <span
+                        className={cn(
+                          activeTab === tab.id
+                            ? "dark:bg-black"
+                            : "dark:bg-zinc-700",
+                          "ml-1 bg-zinc-200 text-zinc-700 dark:text-zinc-300 text-[10px] px-1.5 py-0.5 rounded-full font-medium"
+                        )}
+                      >
+                        {count}
+                      </span>
+                    ) : null;
 
                   return (
                     <TabsTrigger
@@ -889,6 +902,7 @@ export function LayoutHeader({
                       data-testid={`tab-${tab.id}`}
                       icon={tab.icon}
                       showDot={showDot}
+                      badge={badge}
                       alwaysExpanded={
                         "alwaysExpanded" in tab && tab.alwaysExpanded
                       }
@@ -897,18 +911,6 @@ export function LayoutHeader({
                         collapsed && "pl-2"
                       )}
                     >
-                      {count > 0 && !collapsed && (
-                        <span
-                          className={cn(
-                            activeTab === tab.id
-                              ? "dark:bg-black"
-                              : "dark:bg-zinc-700",
-                            "bg-zinc-200 text-zinc-700 dark:text-zinc-300 text-[10px] px-1.5 py-0.5 rounded-full font-medium"
-                          )}
-                        >
-                          {count}
-                        </span>
-                      )}
                       <span className="sr-only">{tab.label}</span>
                     </TabsTrigger>
                   );
@@ -956,6 +958,19 @@ export function LayoutHeader({
                     const tooltipText =
                       count > 0 ? `${tab.label} (${count})` : tab.label;
                     const showDot = shouldShowDot(tab.id, count, collapsed);
+                    const badge =
+                      count > 0 ? (
+                        <span
+                          className={cn(
+                            activeTab === tab.id
+                              ? " dark:bg-black "
+                              : "dark:bg-zinc-700",
+                            "ml-1 bg-zinc-200 text-zinc-700 dark:text-zinc-300 text-xs px-2 py-0.5 rounded-full font-medium"
+                          )}
+                        >
+                          {count}
+                        </span>
+                      ) : null;
 
                     return (
                       <TabsTrigger
@@ -964,6 +979,7 @@ export function LayoutHeader({
                         data-testid={`tab-${tab.id}`}
                         icon={tab.icon}
                         showDot={showDot}
+                        badge={badge}
                         alwaysExpanded={
                           "alwaysExpanded" in tab && tab.alwaysExpanded
                         }
@@ -973,21 +989,9 @@ export function LayoutHeader({
                         )}
                         title={tooltipText}
                       >
-                        <div className="items-center gap-2 hidden lg:flex">
+                        <span className="items-center gap-2 hidden lg:flex">
                           {tab.label}
-                          {count > 0 && (
-                            <span
-                              className={cn(
-                                activeTab === tab.id
-                                  ? " dark:bg-black "
-                                  : "dark:bg-zinc-700",
-                                "bg-zinc-200 text-zinc-700 dark:text-zinc-300 text-xs px-2 py-0.5 rounded-full font-medium"
-                              )}
-                            >
-                              {count}
-                            </span>
-                          )}
-                        </div>
+                        </span>
                       </TabsTrigger>
                     );
                   })}

--- a/libraries/typescript/packages/inspector/src/client/components/ui/tabs.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ui/tabs.tsx
@@ -279,6 +279,8 @@ interface TabsTriggerProps {
   showDot?: boolean;
   /** When true, the label stays visible even when the tab bar is collapsed */
   alwaysExpanded?: boolean;
+  /** Optional badge element rendered next to the icon, always visible even when collapsed */
+  badge?: React.ReactNode;
 }
 
 // conditional tooltip wrapper if collapsed
@@ -328,6 +330,7 @@ const TabsTrigger = React.forwardRef<
       title: titleProp,
       showDot = false,
       alwaysExpanded = false,
+      badge,
       ...props
     },
     ref
@@ -378,6 +381,7 @@ const TabsTrigger = React.forwardRef<
               )}
             />
           )}
+          {badge}
           {showDot && (
             <span className="absolute top-1.5 right-1.5 w-2 h-2 bg-orange-500 dark:bg-orange-400 border-2 border-white dark:border-zinc-900 rounded-full transition-opacity duration-300 z-10 animate-status-pulse-orange" />
           )}

--- a/libraries/typescript/packages/inspector/src/client/index.css
+++ b/libraries/typescript/packages/inspector/src/client/index.css
@@ -217,7 +217,26 @@
 @layer base {
   * {
     @apply border-border outline-ring/50;
+    scrollbar-width: thin;
+    scrollbar-color: var(--muted) transparent;
   }
+  ::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+
+  ::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    @apply bg-muted rounded-full border-2 border-transparent bg-clip-content;
+  }
+
+  ::-webkit-scrollbar-thumb:hover {
+    @apply bg-muted-foreground/30;
+  }
+
   body {
     @apply bg-background text-foreground;
   }

--- a/libraries/typescript/packages/inspector/src/client/index.css
+++ b/libraries/typescript/packages/inspector/src/client/index.css
@@ -234,7 +234,7 @@
   }
 
   ::-webkit-scrollbar-thumb:hover {
-    @apply bg-muted-foreground/30;
+    background-color: color-mix(in oklch, var(--muted) 80%, white);
   }
 
   body {


### PR DESCRIPTION
Closes #1480. This PR refactors TabsTrigger to use a generic 'badge' prop and ensures it remains visible even when the tab bar is collapsed/icon-only.