### PR TITLE
feat(cli): add --header/-H to mcp-use screenshot for authenticated --mcp servers

### DIFF
--- a/libraries/typescript/.changeset/screenshot-mcp-headers.md
+++ b/libraries/typescript/.changeset/screenshot-mcp-headers.md
@@ -1,0 +1,15 @@
+---
+"@mcp-use/cli": minor
+---
+
+feat(cli): add `--header` / `-H` to `mcp-use screenshot` for authenticated `--mcp <url>` servers
+
+`mcp-use screenshot --mcp <url>` now accepts repeatable `-H, --header "Key: Value"` flags (curl-style), letting you screenshot authenticated MCP servers without first running `mcp-use client connect`. The most common use is a static bearer token:
+
+```
+mcp-use screenshot --tool show-board \
+  --mcp https://my-mcp.example.com/mcp \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Headers are only honored with `--mcp <url>`; passing `--header` alongside `--session` (or the active saved session) errors with a clear message, since saved sessions already carry their own OAuth/bearer auth from `mcp-use client connect`. Header values are split on the first `:` only, so colons inside the value (e.g. ISO timestamps) are preserved. Whitespace around key and value is trimmed.

--- a/libraries/typescript/packages/cli/src/commands/screenshot.ts
+++ b/libraries/typescript/packages/cli/src/commands/screenshot.ts
@@ -32,6 +32,40 @@ interface ScreenshotOptions {
   quiet?: boolean;
   timeout: string;
   cdpUrl?: string;
+  header?: string[];
+}
+
+/**
+ * Curl-style `Key: Value` parser. Splits on the first `:` so values may
+ * contain colons, and trims both sides so `Authorization:Bearer xyz` and
+ * `Authorization: Bearer xyz` are equivalent.
+ */
+export function parseHeaderArg(raw: string): [string, string] {
+  const idx = raw.indexOf(":");
+  if (idx === -1) {
+    throw new Error(
+      `Invalid --header value "${raw}". Expected "Key: Value" (e.g. "Authorization: Bearer xyz").`
+    );
+  }
+  const key = raw.slice(0, idx).trim();
+  const value = raw.slice(idx + 1).trim();
+  if (!key) {
+    throw new Error(`Invalid --header value "${raw}". Header name is empty.`);
+  }
+  return [key, value];
+}
+
+export function parseHeaderArgs(args: string[]): Record<string, string> {
+  const headers: Record<string, string> = {};
+  for (const raw of args) {
+    const [key, value] = parseHeaderArg(raw);
+    headers[key] = value;
+  }
+  return headers;
+}
+
+function collectHeader(value: string, previous: string[] = []): string[] {
+  return previous.concat([value]);
 }
 
 interface ScreenshotBundle {
@@ -377,7 +411,8 @@ const AD_HOC_SESSION_NAME = "__screenshot_ad_hoc__";
  *  3. otherwise → restore the active saved session (errors if none)
  */
 async function resolveSessionForScreenshot(
-  options: ScreenshotOptions
+  options: ScreenshotOptions,
+  headers: Record<string, string> | undefined
 ): Promise<MCPSession | null> {
   if (options.session) {
     const result = await getOrRestoreSession(options.session);
@@ -388,6 +423,7 @@ async function resolveSessionForScreenshot(
     const client = new MCPClient();
     client.addServer(AD_HOC_SESSION_NAME, {
       url: options.mcp,
+      ...(headers ? { headers } : {}),
       clientInfo: getCliClientInfo(),
     });
     try {
@@ -422,6 +458,28 @@ export async function screenshotCommand(
       return;
     }
 
+    let headers: Record<string, string> | undefined;
+    if (options.header && options.header.length > 0) {
+      if (!options.mcp) {
+        console.error(
+          formatError(
+            "--header is only supported with --mcp <url>. Saved sessions (use --session) carry their own auth from `mcp-use client connect`."
+          )
+        );
+        exitCode = 1;
+        return;
+      }
+      try {
+        headers = parseHeaderArgs(options.header);
+      } catch (err) {
+        console.error(
+          formatError(err instanceof Error ? err.message : String(err))
+        );
+        exitCode = 1;
+        return;
+      }
+    }
+
     try {
       resolveChromePath();
     } catch (err) {
@@ -438,7 +496,7 @@ export async function screenshotCommand(
     const delayMs = options.delay ? parseInt(options.delay, 10) : 0;
 
     // Resolve session before spawning the dev server so auth issues fail fast.
-    const session = await resolveSessionForScreenshot(options);
+    const session = await resolveSessionForScreenshot(options, headers);
     if (!session) {
       exitCode = 1;
       return;
@@ -551,7 +609,13 @@ export function createScreenshotCommand(): Command {
     )
     .option(
       "--mcp <url>",
-      "Ad-hoc MCP server URL (escape hatch). Used only when no --session and no active saved session. No authentication."
+      "Ad-hoc MCP server URL (escape hatch). Used only when no --session and no active saved session. No authentication unless --header is supplied."
+    )
+    .option(
+      "-H, --header <header>",
+      'HTTP header to send to the --mcp <url> server, formatted "Key: Value". Repeatable. Use to pass an Authorization bearer token or other auth headers when screenshotting an authenticated MCP server.',
+      collectHeader,
+      [] as string[]
     )
     .option(
       "--theme <light|dark>",

--- a/libraries/typescript/packages/cli/tests/screenshot.test.ts
+++ b/libraries/typescript/packages/cli/tests/screenshot.test.ts
@@ -3,6 +3,8 @@ import {
   detectToolResourceUri,
   extractViewName,
   parseDimension,
+  parseHeaderArg,
+  parseHeaderArgs,
   timestampSuffix,
 } from "../src/commands/screenshot.js";
 
@@ -91,5 +93,76 @@ describe("detectToolResourceUri", () => {
         },
       })
     ).toBe("ui://widget/preferred.html");
+  });
+});
+
+describe("parseHeaderArg", () => {
+  it("splits on the first colon", () => {
+    expect(parseHeaderArg("Authorization: Bearer xyz")).toEqual([
+      "Authorization",
+      "Bearer xyz",
+    ]);
+  });
+
+  it("trims whitespace around key and value", () => {
+    expect(parseHeaderArg("  X-Api-Key  :   abc123 ")).toEqual([
+      "X-Api-Key",
+      "abc123",
+    ]);
+  });
+
+  it("preserves colons inside the value", () => {
+    expect(parseHeaderArg("X-Date: 2024-01-01T12:00:00Z")).toEqual([
+      "X-Date",
+      "2024-01-01T12:00:00Z",
+    ]);
+  });
+
+  it("accepts no whitespace after the colon", () => {
+    expect(parseHeaderArg("Authorization:Bearer xyz")).toEqual([
+      "Authorization",
+      "Bearer xyz",
+    ]);
+  });
+
+  it("allows an empty value", () => {
+    expect(parseHeaderArg("X-Empty:")).toEqual(["X-Empty", ""]);
+  });
+
+  it("errors when there is no colon", () => {
+    expect(() => parseHeaderArg("Authorization Bearer xyz")).toThrow(
+      /Expected "Key: Value"/
+    );
+  });
+
+  it("errors when the key is empty", () => {
+    expect(() => parseHeaderArg(": value")).toThrow(/Header name is empty/);
+  });
+});
+
+describe("parseHeaderArgs", () => {
+  it("returns an empty record for no args", () => {
+    expect(parseHeaderArgs([])).toEqual({});
+  });
+
+  it("collects multiple headers into a record", () => {
+    expect(
+      parseHeaderArgs(["Authorization: Bearer xyz", "X-Trace-Id: abc"])
+    ).toEqual({
+      Authorization: "Bearer xyz",
+      "X-Trace-Id": "abc",
+    });
+  });
+
+  it("later values for the same key override earlier ones", () => {
+    expect(parseHeaderArgs(["X-Key: first", "X-Key: second"])).toEqual({
+      "X-Key": "second",
+    });
+  });
+
+  it("propagates parse errors", () => {
+    expect(() =>
+      parseHeaderArgs(["Authorization: Bearer xyz", "no-colon"])
+    ).toThrow(/Expected "Key: Value"/);
   });
 });


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

Adds repeatable `-H, --header "Key: Value"` flags to `mcp-use screenshot` so authenticated MCP servers can be screenshotted via the ad-hoc `--mcp <url>` path without running `mcp-use client connect` first. Headers are curl-style: split on the first `:` (so values may contain colons) and whitespace-trimmed on both sides.

## Implementation Details

1. New `parseHeaderArg(raw) -> [key, value]` and `parseHeaderArgs(args) -> Record<string, string>` helpers in `packages/cli/src/commands/screenshot.ts`. Both are exported so the tests can exercise them directly.
2. Commander reducer `collectHeader` collects repeated `-H` flags into a `string[]`; `ScreenshotOptions.header` carries the raw strings.
3. `screenshotCommand` parses headers once up front (fail-fast before spawning Chrome / dev server) and threads the parsed `Record<string, string>` into `resolveSessionForScreenshot(options, headers)`. Avoids re-parsing later in the ad-hoc-session branch.
4. Misuse guard: passing `--header` without `--mcp` errors with a clear message pointing at `mcp-use client connect` for saved-session auth. `--session` carries its own auth, so combining the two would be ambiguous.
5. Updated the `--mcp` option description to mention that `--header` is the auth escape hatch.

---

## TypeScript Checklist

### Packages Modified

- [ ] `docs`
- [ ] `tests`
- [x] `cli`
- [ ] `create-mcp-use-app`
- [ ] `mcp-use` (server)
- [ ] `mcp-use` (client)
- [ ] `inspector`

### Pre-commit Checklist

- [x] Ran `pnpm lint:fix` to auto-fix linting issues
- [x] Ran `pnpm format` to format code with Prettier
- [x] Ran `pnpm build` and build succeeds without errors
- [x] Ran `pnpm changeset` to create a changeset (if this PR includes user-facing changes)
- [x] Added or updated tests if needed
- [ ] Updated documentation in `docs/` folder if needed

> Docs for `mcp-use screenshot` already describe `--mcp <url>` as unauthenticated. They could be updated in a follow-up to mention `-H`, but skipping here to keep this PR scoped.

---

## Example Usage (Before)

```bash
# To screenshot a widget on an authenticated MCP server you had to run the
# connect flow first, even for a one-shot capture with a static bearer token:
mcp-use client connect https://my-mcp.example.com/mcp --auth "$TOKEN"
mcp-use screenshot --tool show-board
```

## Example Usage (After)

```bash
# One-shot, no saved session:
mcp-use screenshot --tool show-board \
  --mcp https://my-mcp.example.com/mcp \
  -H "Authorization: Bearer $TOKEN"

# Multiple headers are fine; values may contain colons (e.g. ISO timestamps):
mcp-use screenshot --tool show-board \
  --mcp https://my-mcp.example.com/mcp \
  -H "Authorization: Bearer $TOKEN" \
  -H "X-Trace-Id: req-abc-123" \
  -H "X-Date: 2026-05-13T12:00:00Z"
```

## Documentation Updates

* None in this PR. The screenshot command docs reference `--mcp <url>` as the unauthenticated escape hatch; a follow-up can mention `-H` once we settle on whether `--headers <json>` (plural) also lands.

## Testing

- Unit tests added in `packages/cli/tests/screenshot.test.ts` covering `parseHeaderArg` (colon in value, trimming, no-whitespace-after-colon, empty value, empty key, no colon) and `parseHeaderArgs` (empty, multiple, override semantics, error propagation).
- `pnpm --filter @mcp-use/cli test` → 265 passed.
- `pnpm --filter @mcp-use/cli build` → succeeds.
- Manually traced the misuse path: `--header` without `--mcp` exits 1 with the saved-session hint before any Chrome / dev-server work runs.

## Backwards Compatibility

Fully backwards compatible. `--header` is a new optional flag; existing `--mcp <url>` and `--session <name>` invocations behave identically.

## Related Issues

n/a