### PR TITLE
chore: claim mcp-use on Context7

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/mcp-use/mcp-use",
+  "public_key": "pk_DHbfCHmtCxcbCOAR8Q9HX"
+}


### PR DESCRIPTION
## Changes
Adds a `context7.json` file at the repo root to claim the mcp-use library on [Context7](https://context7.com/mcp-use/mcp-use).

## Implementation Details
1. Created `context7.json` containing the Context7 project URL and public key

## Backwards Compatibility
Not applicable — adds a single metadata file with no code impact.