### PR TITLE
feat(cli)!: drop "active session" model — every client command takes a name

### DIFF
--- a/docs/typescript/client/authentication.mdx
+++ b/docs/typescript/client/authentication.mdx
@@ -210,19 +210,18 @@ const client = MCPClient.fromDict(config)
 The mcp-use CLI client supports bearer token authentication for connecting to secured MCP servers:
 
 ```bash
-# Connect with bearer token
-npx mcp-use client connect https://api.example.com/mcp \
-  --name my-server \
+# Connect with bearer token, saved under the name "my-server"
+npx mcp-use client connect my-server https://api.example.com/mcp \
   --auth sk-your-api-key
 
-# List tools (uses saved authentication)
-npx mcp-use client tools list
+# List tools on that saved client
+npx mcp-use client my-server tools list
 
 # Call a tool
-npx mcp-use client tools call send_email '{"to":"user@example.com"}'
+npx mcp-use client my-server tools call send_email to=user@example.com
 
 # Disconnect
-npx mcp-use client disconnect my-server
+npx mcp-use client my-server disconnect
 ```
 
 The CLI automatically saves authentication tokens in `~/.mcp-use/cli-sessions.json` for future sessions.

--- a/docs/typescript/client/authentication.mdx
+++ b/docs/typescript/client/authentication.mdx
@@ -214,7 +214,7 @@ The mcp-use CLI client supports bearer token authentication for connecting to se
 npx mcp-use client connect my-server https://api.example.com/mcp \
   --auth sk-your-api-key
 
-# List tools on that saved client
+# List tools on that saved server
 npx mcp-use client my-server tools list
 
 # Call a tool

--- a/docs/typescript/client/cli.mdx
+++ b/docs/typescript/client/cli.mdx
@@ -4,7 +4,7 @@ description: Use MCP servers directly from the terminal with the mcp-use CLI cli
 icon: "terminal"
 ---
 
-The mcp-use CLI client lets you interact with MCP servers directly from your terminal — no code required. Connect to a server, save it as a **named client**, and run tool/resource/prompt commands against that name.
+The mcp-use CLI client lets you interact with MCP servers directly from your terminal — no code required. Connect to a server, save it under a **short name**, and run tool/resource/prompt commands against that name.
 
 ## Installation
 
@@ -17,17 +17,17 @@ npx mcp-use client --help
 ## Quick Start
 
 ```bash
-# Connect once and save the client under a name of your choice
+# Connect once and save the server under a name of your choice
 npx mcp-use client connect manufact https://mcp.manufact.com
 
-# Every subsequent command names the client it operates on
+# Every subsequent command names the server it operates on
 npx mcp-use client manufact tools list
 npx mcp-use client manufact tools call read_file path=/tmp/test.txt
 npx mcp-use client manufact interactive
 ```
 
 <Note>
-There is no "active" client. Every per-client command takes the client name as its first positional argument: `mcp-use client <name> <scope> <action>`.
+There is no "active" server. Every per-server command takes the server name as its first positional argument: `mcp-use client <name> <scope> <action>`.
 </Note>
 
 ## Command Structure
@@ -36,11 +36,11 @@ The CLI has two top-level shapes under `mcp-use client`:
 
 | Shape | Purpose |
 |-------|---------|
-| `mcp-use client connect <name> <url>` | Create a new named client |
-| `mcp-use client list` | List saved clients |
-| `mcp-use client <name> <scope> <action>` | Run a command against a named client |
+| `mcp-use client connect <name> <url>` | Save an MCP server under a short name |
+| `mcp-use client list` | List saved servers |
+| `mcp-use client <name> <scope> <action>` | Run a command against a saved server |
 
-The per-client scopes are:
+The per-server scopes are:
 
 | Scope | Actions |
 |-------|---------|
@@ -71,14 +71,14 @@ npx mcp-use client connect fs "npx -y @modelcontextprotocol/server-filesystem /t
 
 The string after the name is parsed as `command args...`.
 
-## Listing Saved Clients
+## Listing Saved Servers
 
 ```bash
 npx mcp-use client list
 ```
 
 ```
-Saved Clients:
+Saved Servers:
 
 ┌──────────┬───────┬─────────────────────────────┬────────────────┐
 │ Name     │ Type  │ Target                      │ Server         │
@@ -131,7 +131,7 @@ npx mcp-use client manufact prompts get greeting '{"name":"Alice"}' --json
 
 ## Auth (OAuth)
 
-For HTTP clients that authenticated via OAuth:
+For HTTP servers that authenticated via OAuth:
 
 ```bash
 npx mcp-use client manufact auth status   # show token state + expiry
@@ -141,7 +141,7 @@ npx mcp-use client manufact auth logout   # remove stored tokens
 
 ## Interactive Mode
 
-A REPL for one specific client:
+A REPL for one specific server:
 
 ```bash
 npx mcp-use client manufact interactive
@@ -166,7 +166,7 @@ npx mcp-use client manufact disconnect
 
 ## Global Flags
 
-Per-client commands accept these flags where they make sense:
+Per-server commands accept these flags where they make sense:
 
 - `--json`: Output results as JSON (on `list`/`call`/`read`/`get`).
 - `--timeout <ms>`: Request timeout (on `tools call`).
@@ -175,7 +175,7 @@ Per-client commands accept these flags where they make sense:
 
 ## Storage
 
-Saved clients are persisted in `~/.mcp-use/cli-sessions.json`:
+Saved servers are persisted in `~/.mcp-use/cli-sessions.json`:
 
 ```json
 {

--- a/docs/typescript/client/cli.mdx
+++ b/docs/typescript/client/cli.mdx
@@ -4,11 +4,9 @@ description: Use MCP servers directly from the terminal with the mcp-use CLI cli
 icon: "terminal"
 ---
 
-The mcp-use CLI client allows you to interact with MCP servers directly from your terminal without writing any code. It provides a powerful command-line interface with scoped commands for tools, resources, prompts, and session management.
+The mcp-use CLI client lets you interact with MCP servers directly from your terminal — no code required. Connect to a server, save it as a **named client**, and run tool/resource/prompt commands against that name.
 
 ## Installation
-
-The CLI client is included with the `mcp-use` package:
 
 ```bash
 npm install -g mcp-use
@@ -18,395 +16,234 @@ npx mcp-use client --help
 
 ## Quick Start
 
-Connect to an MCP server and start using it:
-
 ```bash
-# Connect to an HTTP server
-npx mcp-use client connect http://localhost:3000/mcp --name my-server
+# Connect once and save the client under a name of your choice
+npx mcp-use client connect manufact https://mcp.manufact.com
 
-# List available tools
-npx mcp-use client tools list
-
-# Call a tool
-npx mcp-use client tools call read_file '{"path": "/tmp/test.txt"}'
-
-# Start interactive mode
-npx mcp-use client interactive
+# Every subsequent command names the client it operates on
+npx mcp-use client manufact tools list
+npx mcp-use client manufact tools call read_file path=/tmp/test.txt
+npx mcp-use client manufact interactive
 ```
+
+<Note>
+There is no "active" client. Every per-client command takes the client name as its first positional argument: `mcp-use client <name> <scope> <action>`.
+</Note>
 
 ## Command Structure
 
-The CLI client uses scoped commands organized by resource type:
+The CLI has two top-level shapes under `mcp-use client`:
 
-- **Connection Management**: `connect`, `disconnect`
-- **Sessions**: `sessions list`, `sessions switch`
-- **Tools**: `tools list`, `tools call`, `tools describe`
-- **Resources**: `resources list`, `resources read`, `resources subscribe`, `resources unsubscribe`
-- **Prompts**: `prompts list`, `prompts get`
-- **Interactive Mode**: `interactive`
+| Shape | Purpose |
+|-------|---------|
+| `mcp-use client connect <name> <url>` | Create a new named client |
+| `mcp-use client list` | List saved clients |
+| `mcp-use client <name> <scope> <action>` | Run a command against a named client |
 
-## Connection Management
+The per-client scopes are:
 
-### Connect to a Server
+| Scope | Actions |
+|-------|---------|
+| `tools` | `list`, `call <tool> [args...]`, `describe <tool>` |
+| `resources` | `list`, `read <uri>`, `subscribe <uri>`, `unsubscribe <uri>` |
+| `prompts` | `list`, `get <prompt> [args...]` |
+| `auth` | `status`, `refresh`, `logout` |
+| (top-level) | `interactive`, `disconnect` |
 
-Connect to an HTTP MCP server:
+## Connecting
+
+### HTTP Server
 
 ```bash
-npx mcp-use client connect http://localhost:3000/mcp --name my-server
+npx mcp-use client connect manufact https://mcp.manufact.com
 ```
 
 **Options:**
-- `--name <name>`: Session name (optional, auto-generated if not provided)
-- `--auth <token>`: Authentication token for Bearer auth
-- `--stdio`: Use stdio connector instead of HTTP (see below)
+- `--auth <token>`: Static Bearer token (skips OAuth).
+- `--no-oauth`: Don't auto-trigger OAuth on a 401; fail with the 401 instead.
+- `--auth-timeout <ms>`: OAuth loopback wait timeout (default 300000).
 
-### Connect to a Stdio Server
-
-Connect to a server using stdio transport:
+### Stdio Server
 
 ```bash
-npx mcp-use client connect --stdio "npx -y @modelcontextprotocol/server-filesystem /tmp" --name fs-server
+npx mcp-use client connect fs "npx -y @modelcontextprotocol/server-filesystem /tmp" --stdio
 ```
 
-The command after `--stdio` is parsed as: `command args...`
+The string after the name is parsed as `command args...`.
 
-### Disconnect from a Server
+## Listing Saved Clients
 
 ```bash
-# Disconnect from active session
-npx mcp-use client disconnect
-
-# Disconnect from specific session
-npx mcp-use client disconnect my-server
-
-# Disconnect all sessions
-npx mcp-use client disconnect --all
+npx mcp-use client list
 ```
 
-## Session Management
+```
+Saved Clients:
 
-Sessions are automatically saved to `~/.mcp-use/cli-sessions.json` and can be restored later.
+┌──────────┬───────┬─────────────────────────────┬────────────────┐
+│ Name     │ Type  │ Target                      │ Server         │
+├──────────┼───────┼─────────────────────────────┼────────────────┤
+│ manufact │ http  │ https://mcp.manufact.com    │ manufact       │
+│ fs       │ stdio │ npx -y @mc...filesystem     │ fs-server      │
+└──────────┴───────┴─────────────────────────────┴────────────────┘
+```
 
-### List Sessions
+## Tools
 
 ```bash
-npx mcp-use client sessions list
+# List
+npx mcp-use client manufact tools list
+npx mcp-use client manufact tools list --json
+
+# Describe (shows the input schema)
+npx mcp-use client manufact tools describe read_file
+
+# Call
+npx mcp-use client manufact tools call read_file path=/tmp/test.txt
+npx mcp-use client manufact tools call read_file '{"path":"/tmp/test.txt"}'
+npx mcp-use client manufact tools call read_file path=/tmp/test.txt --json
+npx mcp-use client manufact tools call slow_op --timeout 60000
 ```
 
-Output example:
-```
-Saved Sessions:
+**Arg syntax:**
+- `key=value` for simple strings/numbers/booleans (inferred from the tool schema).
+- `key:=<json>` to pass a JSON value (objects, arrays, etc.).
+- A single bare JSON object as the only arg works too: `'{"key":"value"}'`.
 
-┌──────────────┬────────┬─────────────────────────────┬────────────────┬──────────────┐
-│ Name         │ Type   │ Target                      │ Server         │ Status       │
-├──────────────┼────────┼─────────────────────────────┼────────────────┼──────────────┤
-│ my-server *  │ http   │ http://localhost:3000/mcp   │ my-mcp-server  │ connected    │
-│ fs-server    │ stdio  │ npx -y @mc...filesystem     │ fs-server      │ disconnected │
-└──────────────┴────────┴─────────────────────────────┴────────────────┴──────────────┘
-
-* = active session
-```
-
-### Switch Sessions
+## Resources
 
 ```bash
-npx mcp-use client sessions switch fs-server
+npx mcp-use client manufact resources list
+npx mcp-use client manufact resources read "file:///tmp/data.json"
+npx mcp-use client manufact resources subscribe "file:///tmp/data.json"
+npx mcp-use client manufact resources unsubscribe "file:///tmp/data.json"
 ```
 
-## Working with Tools
+`subscribe` keeps the process running and streams updates until Ctrl+C.
 
-### List Available Tools
+## Prompts
 
 ```bash
-# List tools from active session
-npx mcp-use client tools list
-
-# List tools from specific session
-npx mcp-use client tools list --session my-server
-
-# Output as JSON
-npx mcp-use client tools list --json
+npx mcp-use client manufact prompts list
+npx mcp-use client manufact prompts get greeting name=Alice
+npx mcp-use client manufact prompts get greeting '{"name":"Alice"}' --json
 ```
 
-### Describe a Tool
+## Auth (OAuth)
 
-View detailed information about a tool including its input schema:
+For HTTP clients that authenticated via OAuth:
 
 ```bash
-npx mcp-use client tools describe read_file
-```
-
-Output example:
-```
-Tool: read_file
-
-Read the contents of a file from the filesystem
-
-Input Schema:
-path (string) *required
-  The path to the file to read
-encoding (string)
-  The text encoding to use (default: utf-8)
-```
-
-### Call a Tool
-
-Execute a tool with arguments:
-
-```bash
-# With JSON arguments
-npx mcp-use client tools call read_file '{"path": "/tmp/test.txt"}'
-
-# Without arguments (for tools that don't require them)
-npx mcp-use client tools call list_files
-
-# With timeout
-npx mcp-use client tools call slow_operation '{}' --timeout 60000
-
-# Output as JSON
-npx mcp-use client tools call read_file '{"path": "/tmp/test.txt"}' --json
-```
-
-**Tips:**
-- Arguments must be valid JSON
-- If a tool requires arguments but none are provided, an error will show the schema
-- Use single quotes around JSON to avoid shell escaping issues
-
-## Working with Resources
-
-### List Available Resources
-
-```bash
-# List resources from active session
-npx mcp-use client resources list
-
-# Output as JSON
-npx mcp-use client resources list --json
-```
-
-Output example:
-```
-Available Resources (3):
-
-┌──────────────────────────────┬────────────────┬─────────────┐
-│ URI                          │ Name           │ Type        │
-├──────────────────────────────┼────────────────┼─────────────┤
-│ file:///tmp/data.json        │ Data File      │ text/json   │
-│ file:///tmp/config.yaml      │ Config         │ text/yaml   │
-│ file:///tmp/image.png        │ Screenshot     │ image/png   │
-└──────────────────────────────┴────────────────┴─────────────┘
-```
-
-### Read a Resource
-
-```bash
-npx mcp-use client resources read "file:///tmp/data.json"
-```
-
-### Subscribe to Resource Updates
-
-Subscribe to notifications when a resource changes:
-
-```bash
-npx mcp-use client resources subscribe "file:///tmp/data.json"
-```
-
-This will keep the process running and display updates as they arrive. Press Ctrl+C to stop.
-
-### Unsubscribe from Resource
-
-```bash
-npx mcp-use client resources unsubscribe "file:///tmp/data.json"
-```
-
-## Working with Prompts
-
-### List Available Prompts
-
-```bash
-npx mcp-use client prompts list
-```
-
-### Get a Prompt
-
-Retrieve a prompt with arguments:
-
-```bash
-# With arguments
-npx mcp-use client prompts get greeting '{"name": "Alice"}'
-
-# Without arguments
-npx mcp-use client prompts get daily_summary
-
-# Output as JSON
-npx mcp-use client prompts get greeting '{"name": "Alice"}' --json
+npx mcp-use client manufact auth status   # show token state + expiry
+npx mcp-use client manufact auth refresh  # force-refresh access token
+npx mcp-use client manufact auth logout   # remove stored tokens
 ```
 
 ## Interactive Mode
 
-Start an interactive REPL session for easier exploration:
+A REPL for one specific client:
 
 ```bash
-npx mcp-use client interactive
+npx mcp-use client manufact interactive
 ```
-
-In interactive mode, you can use shortened commands:
 
 ```
 mcp> tools list
 Available tools: read_file, write_file, list_directory
 
 mcp> tools call read_file
-Arguments (JSON, or press Enter for none): {"path": "/tmp/test.txt"}
-✓ Tool executed successfully
+Arguments (JSON, or press Enter for none): {"path":"/tmp/test.txt"}
 ...
-
-mcp> resources list
-Available resources: file:///tmp/data.json, file:///tmp/config.yaml
 
 mcp> exit
 ```
 
-**Available commands in interactive mode:**
-- `tools list` - List available tools
-- `tools call <name>` - Call a tool (will prompt for arguments)
-- `tools describe <name>` - Show tool details
-- `resources list` - List available resources
-- `resources read <uri>` - Read a resource
-- `prompts list` - List available prompts
-- `prompts get <name>` - Get a prompt (will prompt for arguments)
-- `sessions list` - List all sessions
-- `exit` or `quit` - Exit interactive mode
+## Disconnecting
+
+```bash
+npx mcp-use client manufact disconnect
+```
 
 ## Global Flags
 
-All commands support these global flags:
+Per-client commands accept these flags where they make sense:
 
-- `--session <name>`: Use a specific session instead of the active one
-- `--json`: Output results in JSON format
-- `--timeout <ms>`: Request timeout in milliseconds (for tool calls and resource operations)
+- `--json`: Output results as JSON (on `list`/`call`/`read`/`get`).
+- `--timeout <ms>`: Request timeout (on `tools call`).
+- `--no-screenshot`: Skip the auto-screenshot capture for tools that render a widget (on `tools call`).
+- `--screenshot-output <path>`: Override the screenshot output path.
 
-Example:
-```bash
-npx mcp-use client tools call read_file '{"path": "/tmp/test.txt"}' \
-  --session my-server \
-  --json \
-  --timeout 10000
-```
+## Storage
 
-## Session Storage
-
-Sessions are stored in `~/.mcp-use/cli-sessions.json`:
+Saved clients are persisted in `~/.mcp-use/cli-sessions.json`:
 
 ```json
 {
-  "activeSession": "my-server",
   "sessions": {
-    "my-server": {
+    "manufact": {
       "type": "http",
-      "url": "http://localhost:3000/mcp",
-      "lastUsed": "2025-12-09T10:30:00Z",
-      "serverInfo": {
-        "name": "my-mcp-server",
-        "version": "1.0.0"
-      }
+      "url": "https://mcp.manufact.com",
+      "authMode": "oauth",
+      "lastUsed": "2026-05-12T10:30:00Z",
+      "serverInfo": { "name": "manufact", "version": "1.0.0" }
     },
-    "fs-server": {
+    "fs": {
       "type": "stdio",
       "command": "npx",
       "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
-      "lastUsed": "2025-12-09T11:00:00Z"
+      "lastUsed": "2026-05-12T11:00:00Z"
     }
   }
 }
 ```
 
-You can manually edit this file to:
-- Change session names
-- Update connection details
-- Remove old sessions
+OAuth tokens live in `~/.mcp-use/oauth/<urlHash>/`, managed by the OAuth provider. Editing the JSON manually is fine — it just gets re-read on the next command.
 
-## Common Use Cases
+## Common Patterns
 
-### Debugging an MCP Server
+### Debugging a Dev Server
 
 ```bash
-# Connect to your development server
-npx mcp-use client connect http://localhost:3000/mcp --name dev
-
-# Explore available tools
-npx mcp-use client tools list
-
-# Test a specific tool
-npx mcp-use client tools describe my_tool
-npx mcp-use client tools call my_tool '{"param": "value"}'
+npx mcp-use client connect dev http://localhost:3000/mcp
+npx mcp-use client dev tools list
+npx mcp-use client dev tools describe my_tool
+npx mcp-use client dev tools call my_tool param=value
 ```
 
-### Working with Multiple Servers
+### Multiple Servers
 
 ```bash
-# Connect to multiple servers
-npx mcp-use client connect http://localhost:3000/mcp --name server1
-npx mcp-use client connect http://localhost:4000/mcp --name server2
+npx mcp-use client connect server1 http://localhost:3000/mcp
+npx mcp-use client connect server2 http://localhost:4000/mcp
 
-# List all sessions
-npx mcp-use client sessions list
-
-# Use tools from different servers
-npx mcp-use client tools list --session server1
-npx mcp-use client tools list --session server2
-
-# Switch between them
-npx mcp-use client sessions switch server2
+npx mcp-use client list
+npx mcp-use client server1 tools list
+npx mcp-use client server2 tools list
 ```
 
-### Scripting with the CLI
-
-Use the CLI in shell scripts:
+### Scripting
 
 ```bash
 #!/bin/bash
+npx mcp-use client connect script http://localhost:3000/mcp
 
-# Connect to server
-npx mcp-use client connect http://localhost:3000/mcp --name script-session
-
-# Get data as JSON
-DATA=$(npx mcp-use client tools call get_data '{}' --json)
-
-# Process with jq
+DATA=$(npx mcp-use client script tools call get_data --json)
 echo "$DATA" | jq '.content[0].text'
 
-# Disconnect
-npx mcp-use client disconnect script-session
-```
-
-### Testing Filesystem Server
-
-```bash
-# Connect to filesystem server
-npx mcp-use client connect --stdio "npx -y @modelcontextprotocol/server-filesystem /tmp" --name fs
-
-# List files
-npx mcp-use client tools call list_directory '{"path": "/tmp"}'
-
-# Read a file
-npx mcp-use client tools call read_file '{"path": "/tmp/test.txt"}'
-
-# Write a file
-npx mcp-use client tools call write_file '{"path": "/tmp/hello.txt", "content": "Hello, World!"}'
+npx mcp-use client script disconnect
 ```
 
 ## Error Handling
 
-The CLI provides helpful error messages:
+### Client Not Found
 
-### No Active Session
 ```
-✗ Error: No active session. Connect to a server first.
-Use: npx mcp-use client connect <url> --name <name>
+✗ Error: Client 'manufact' not found
+ℹ Connect with: npx mcp-use client connect manufact <url>
 ```
 
 ### Tool Not Found
+
 ```
 ✗ Error: Tool 'invalid_tool' not found
 
@@ -416,59 +253,36 @@ Available tools:
   • list_directory
 ```
 
-### Invalid Arguments
-```
-✗ Error: This tool requires arguments. Provide them as a JSON string.
+### Missing Required Arguments
 
-Example:
-  npx mcp-use client tools call read_file '{"path": "/tmp/test.txt"}'
+```
+✗ Error: This tool requires arguments.
+
+Provide arguments as key=value pairs:
+  npx mcp-use client manufact tools call read_file key=value [key2=value2 ...]
 
 Tool schema:
 path (string) *required
   The path to the file to read
 ```
 
-## Tips and Best practices
+## Migration from the old `--session` model
 
-1. **Use Named Sessions**: Always provide a `--name` when connecting to make sessions easier to manage
-2. **Interactive Mode for Exploration**: Use interactive mode when exploring a new server
-3. **JSON Output for Scripts**: Use `--json` flag when using the CLI in scripts
-4. **Session Persistence**: Sessions are saved automatically, so you can disconnect and reconnect later
-5. **Multiple Terminals**: You can have multiple terminal windows with different active sessions
+Earlier versions of the CLI tracked an "active session" and let you omit the name in most commands (`mcp-use client tools list` would use whichever session you last connected to or switched to). That implicit state was confusing — what client am I currently aimed at? — so it was removed in favor of the explicit `<name>` positional.
 
-## Troubleshooting
+| Before | After |
+|--------|-------|
+| `mcp-use client connect <url> --name foo` | `mcp-use client connect foo <url>` |
+| `mcp-use client tools list` | `mcp-use client foo tools list` |
+| `mcp-use client tools call foo_tool ... --session foo` | `mcp-use client foo tools call foo_tool ...` |
+| `mcp-use client sessions list` | `mcp-use client list` |
+| `mcp-use client sessions switch foo` | *(removed — every command takes a name)* |
+| `mcp-use client disconnect` (implicit active) | `mcp-use client foo disconnect` |
+| `mcp-use client disconnect --all` | *(removed — disconnect one at a time)* |
 
-### Connection Issues
-
-**Problem**: Can't connect to HTTP server
-
-```bash
-✗ Error: Connection failed: fetch failed
-```
-
-**Solution**: Check that:
-- The server is running
-- The URL is correct
-- The server supports HTTP/SSE transport
-- Firewall isn't blocking the connection
-
-### Stdio Server Issues
-
-**Problem**: Stdio server fails to start
-
-**Solution**:
-- Ensure the command is available (`npx`, `node`, etc.)
-- Check that the server package is installed or accessible
-- Verify the arguments are correct
-
-### Session Not Found
-
-**Problem**: Session disappeared after restart
-
-**Solution**: Sessions are stored in `~/.mcp-use/cli-sessions.json`. If deleted, you'll need to reconnect.
+Existing `~/.mcp-use/cli-sessions.json` files keep working; the obsolete `activeSession` field is silently ignored on load.
 
 ## Next Steps
 
 - Learn about [MCP Agents](/typescript/agent) for programmatic access
 - Explore [Server Development](/typescript/server) to create your own MCP servers
-- Check out [Examples](/typescript/server/examples) for more use cases

--- a/docs/typescript/client/environments.mdx
+++ b/docs/typescript/client/environments.mdx
@@ -507,17 +507,17 @@ npx mcp-use client my-server interactive
 Top-level shapes:
 
 ```bash
-# Create a named client
+# Save an MCP server under a short name
 npx mcp-use client connect <name> <url>
 
-# List saved clients
+# List saved servers
 npx mcp-use client list
 
-# Run any command against a named client
+# Run any command against a saved server
 npx mcp-use client <name> <scope> <action> [args...]
 ```
 
-The per-client scopes are `tools`, `resources`, `prompts`, `auth`, plus the top-level `interactive` and `disconnect`:
+The per-server scopes are `tools`, `resources`, `prompts`, `auth`, plus the top-level `interactive` and `disconnect`:
 
 ```bash
 # Tools
@@ -533,18 +533,18 @@ npx mcp-use client my-server resources read <uri>
 npx mcp-use client my-server prompts list
 npx mcp-use client my-server prompts get <prompt> [args]
 
-# Auth (OAuth clients only)
+# Auth (OAuth servers only)
 npx mcp-use client my-server auth status
 npx mcp-use client my-server auth refresh
 npx mcp-use client my-server auth logout
 
-# Interactive mode for one client
+# Interactive mode for one server
 npx mcp-use client my-server interactive
 ```
 
-### Managing Multiple Clients
+### Managing Multiple Servers
 
-Saved clients are persisted to `~/.mcp-use/cli-sessions.json`:
+Saved servers are persisted to `~/.mcp-use/cli-sessions.json`:
 
 ```bash
 # Connect to multiple servers
@@ -559,11 +559,11 @@ npx mcp-use client server1 tools list
 npx mcp-use client server2 tools list
 ```
 
-There is no "active" client — every command names its target explicitly.
+There is no "active" server — every command names its target explicitly.
 
 ### Interactive Mode
 
-For exploration and testing, drop into a REPL against a specific client:
+For exploration and testing, drop into a REPL against a specific server:
 
 ```bash
 npx mcp-use client my-server interactive
@@ -583,7 +583,7 @@ Use the CLI in automation scripts with the `--json` flag for machine-readable ou
 ```bash
 #!/bin/bash
 
-# Connect to server (creates a saved client named "automation")
+# Connect to server (saves it under the name "automation")
 npx mcp-use client connect automation http://localhost:3000/mcp
 
 # Get data as JSON and process with jq

--- a/docs/typescript/client/environments.mdx
+++ b/docs/typescript/client/environments.mdx
@@ -490,75 +490,84 @@ The CLI client provides a command-line interface for interacting with MCP server
 ### Quick Start
 
 ```bash
-# Connect to an HTTP server
-npx mcp-use client connect http://localhost:3000/mcp --name my-server
+# Connect to an HTTP server, saved under the name "my-server"
+npx mcp-use client connect my-server http://localhost:3000/mcp
 
 # Connect to a stdio server
-npx mcp-use client connect --stdio "npx -y @modelcontextprotocol/server-filesystem /tmp" --name fs
+npx mcp-use client connect fs "npx -y @modelcontextprotocol/server-filesystem /tmp" --stdio
 
-# List available tools
-npx mcp-use client tools list
-
-# Call a tool
-npx mcp-use client tools call read_file '{"path": "/tmp/test.txt"}'
-
-# Start interactive mode
-npx mcp-use client interactive
+# Every subsequent command names the client it operates on
+npx mcp-use client my-server tools list
+npx mcp-use client my-server tools call read_file path=/tmp/test.txt
+npx mcp-use client my-server interactive
 ```
 
 ### Command Structure
 
-The CLI uses scoped commands organized by resource type:
+Top-level shapes:
+
+```bash
+# Create a named client
+npx mcp-use client connect <name> <url>
+
+# List saved clients
+npx mcp-use client list
+
+# Run any command against a named client
+npx mcp-use client <name> <scope> <action> [args...]
+```
+
+The per-client scopes are `tools`, `resources`, `prompts`, `auth`, plus the top-level `interactive` and `disconnect`:
 
 ```bash
 # Tools
-npx mcp-use client tools list
-npx mcp-use client tools call <name> [args]
-npx mcp-use client tools describe <name>
+npx mcp-use client my-server tools list
+npx mcp-use client my-server tools call <tool> [args]
+npx mcp-use client my-server tools describe <tool>
 
 # Resources
-npx mcp-use client resources list
-npx mcp-use client resources read <uri>
+npx mcp-use client my-server resources list
+npx mcp-use client my-server resources read <uri>
 
 # Prompts
-npx mcp-use client prompts list
-npx mcp-use client prompts get <name> [args]
+npx mcp-use client my-server prompts list
+npx mcp-use client my-server prompts get <prompt> [args]
 
-# Sessions
-npx mcp-use client sessions list
-npx mcp-use client sessions switch <name>
+# Auth (OAuth clients only)
+npx mcp-use client my-server auth status
+npx mcp-use client my-server auth refresh
+npx mcp-use client my-server auth logout
 
-# Interactive mode
-npx mcp-use client interactive
+# Interactive mode for one client
+npx mcp-use client my-server interactive
 ```
 
-### Session Management
+### Managing Multiple Clients
 
-Sessions are automatically saved to `~/.mcp-use/cli-sessions.json` and persist across terminal sessions:
+Saved clients are persisted to `~/.mcp-use/cli-sessions.json`:
 
 ```bash
 # Connect to multiple servers
-npx mcp-use client connect http://localhost:3000/mcp --name server1
-npx mcp-use client connect http://localhost:4000/mcp --name server2
+npx mcp-use client connect server1 http://localhost:3000/mcp
+npx mcp-use client connect server2 http://localhost:4000/mcp
 
-# List all sessions (shows active session)
-npx mcp-use client sessions list
+# List them
+npx mcp-use client list
 
-# Switch between sessions
-npx mcp-use client sessions switch server2
-
-# Use specific session without switching
-npx mcp-use client tools list --session server1
+# Run against either, by name
+npx mcp-use client server1 tools list
+npx mcp-use client server2 tools list
 ```
+
+There is no "active" client — every command names its target explicitly.
 
 ### Interactive Mode
 
-For exploration and testing, use interactive mode:
+For exploration and testing, drop into a REPL against a specific client:
 
 ```bash
-npx mcp-use client interactive
+npx mcp-use client my-server interactive
 
-# In interactive mode:
 mcp> tools list
 mcp> tools call read_file
 Arguments (JSON): {"path": "/tmp/test.txt"}
@@ -569,22 +578,22 @@ mcp> exit
 
 ### Scripting with the CLI
 
-Use the CLI in automation scripts with `--json` flag for machine-readable output:
+Use the CLI in automation scripts with the `--json` flag for machine-readable output:
 
 ```bash
 #!/bin/bash
 
-# Connect to server
-npx mcp-use client connect http://localhost:3000/mcp --name automation
+# Connect to server (creates a saved client named "automation")
+npx mcp-use client connect automation http://localhost:3000/mcp
 
 # Get data as JSON and process with jq
-RESULT=$(npx mcp-use client tools call get_data '{}' --json 2>/dev/null)
+RESULT=$(npx mcp-use client automation tools call get_data --json 2>/dev/null)
 VALUE=$(echo "$RESULT" | jq -r '.content[0].text')
 
 echo "Retrieved value: $VALUE"
 
 # Cleanup
-npx mcp-use client disconnect automation
+npx mcp-use client automation disconnect
 ```
 
 ### CLI Features

--- a/libraries/typescript/.changeset/cli-client-no-default-session.md
+++ b/libraries/typescript/.changeset/cli-client-no-default-session.md
@@ -1,0 +1,49 @@
+---
+"@mcp-use/cli": minor
+---
+
+feat(cli)!: drop the "active session" model — every `client` command now takes a name
+
+The CLI client used to track an implicit "active session" that you switched
+between with `client sessions switch`. Per-command flags like `--session` and
+`--name` were sprinkled around to override it. The active state was hidden,
+easy to get wrong, and forced every subcommand to handle "no session" as a
+real case.
+
+It's gone. The client name is now a required positional, and every
+per-client command lives under `mcp-use client <name> <scope> <action>`:
+
+```bash
+# Before
+mcp-use client connect https://mcp.manufact.com --name manufact
+mcp-use client tools list
+mcp-use client tools call read_file path=/x --session manufact
+mcp-use client sessions list
+mcp-use client sessions switch other-server
+mcp-use client disconnect --all
+
+# After
+mcp-use client connect manufact https://mcp.manufact.com
+mcp-use client manufact tools list
+mcp-use client manufact tools call read_file path=/x
+mcp-use client list
+mcp-use client other-server <action>   # name addresses any saved client directly
+mcp-use client manufact disconnect     # disconnect one at a time
+```
+
+**Breaking changes:**
+
+- `client connect <url> --name <name>` → `client connect <name> <url>` (name is required, positional).
+- `--session <name>` is removed from every per-client subcommand; the name comes from the path instead.
+- `client sessions list` → `client list`.
+- `client sessions switch` is removed — there is no active client to switch.
+- `client disconnect --all` is removed; disconnect each client by name.
+- `mcp-use screenshot` no longer falls back to the active session; pass `--session <name>` or `--mcp <url>` explicitly.
+
+Existing `~/.mcp-use/cli-sessions.json` files keep working; the now-unused
+`activeSession` field is silently ignored on load.
+
+The CLI also gives clearer feedback for the common shape mistakes the new
+syntax invites — passing only a URL to `connect`, forgetting the client
+name before a per-client scope (`mcp-use client tools call foo`), or
+typing an unknown subcommand — instead of the bare commander defaults.

--- a/libraries/typescript/.changeset/cli-client-remove.md
+++ b/libraries/typescript/.changeset/cli-client-remove.md
@@ -1,0 +1,14 @@
+---
+"@mcp-use/cli": patch
+---
+
+feat(cli): add `mcp-use client remove <name>` to drop a saved server
+
+Saved servers could be added (`client connect`) and listed (`client list`),
+but the only way to delete one was to hand-edit
+`~/.mcp-use/cli-sessions.json`. `client remove <name>` now does this: it
+errors if no server by that name exists, closes any in-process connection,
+deletes the entry, and — for OAuth-authenticated servers — also revokes
+the stored tokens for that URL. If another saved server still points at
+the same URL the tokens are kept (they're URL-keyed, so wiping them would
+break the sibling); the CLI prints which sibling is keeping them alive.

--- a/libraries/typescript/.changeset/cli-client-rename-saved-clients-to-servers.md
+++ b/libraries/typescript/.changeset/cli-client-rename-saved-clients-to-servers.md
@@ -1,0 +1,15 @@
+---
+"@mcp-use/cli": patch
+---
+
+refactor(cli): user-facing copy now calls saved entries "servers" instead of "clients"
+
+The CLI itself is the MCP client; the things it connects to are MCP
+servers. The old copy referred to saved connections as "saved clients" /
+"named clients", which is backwards and confused users.
+
+User-facing strings (help text, error messages, table headers, REPL
+prompts, docs) now consistently say "server" / "saved server". The
+`mcp-use client` command name is unchanged — it's still the entry point
+for client-side operations — so this is purely a wording change and no
+scripts break.

--- a/libraries/typescript/.changeset/cli-client-reserved-names.md
+++ b/libraries/typescript/.changeset/cli-client-reserved-names.md
@@ -1,0 +1,16 @@
+---
+"@mcp-use/cli": patch
+---
+
+fix(cli): reject saved-server names that collide with per-server scope tokens
+
+`mcp-use client <name> ...` routes any name that isn't a reserved subcommand
+(`connect`, `list`, `remove`, `help`) to the per-server command tree. If a
+user saved a server under one of the scope names — `tools`, `resources`,
+`prompts`, `auth`, `disconnect`, `interactive` — every invocation against
+that name would instead be caught by the "missing server name" routing and
+the saved entry would be unreachable.
+
+`client connect` now refuses those names up front with the list of reserved
+names and a suggested rename, instead of silently saving an entry that can
+never be addressed.

--- a/libraries/typescript/.changeset/cli-client-unknown-name-message.md
+++ b/libraries/typescript/.changeset/cli-client-unknown-name-message.md
@@ -1,0 +1,15 @@
+---
+"@mcp-use/cli": patch
+---
+
+fix(cli): show a "not found, here's how to connect" message instead of the per-server help when `mcp-use client <name>` targets an unknown server
+
+Running `mcp-use client <name>` with no subcommand used to fall through to
+commander's per-server help — listing `tools`, `resources`, `prompts`, etc.
+That help is only useful once the server actually exists; for a name the
+user hasn't connected yet it just leaks the subcommand surface without
+telling them how to make the name resolve.
+
+When the name doesn't match a saved server, the CLI now prints the
+`client connect <name> <url>` hint (plus a pointer to `client list`) and
+exits non-zero. The per-server help is still shown when the server exists.

--- a/libraries/typescript/.changeset/cli-oauth-no-auto-open.md
+++ b/libraries/typescript/.changeset/cli-oauth-no-auto-open.md
@@ -1,0 +1,15 @@
+---
+"@mcp-use/cli": patch
+---
+
+fix(cli): stop auto-opening the browser during OAuth flows
+
+When an `mcp-use client` command needed to authenticate against an OAuth
+server it would launch the user's browser via the `open` package on TTYs,
+and only print the URL when stdout wasn't a TTY. That was surprising in two
+directions: scripts that did happen to inherit a TTY got pop-up windows, and
+the heuristic missed plenty of agentic/CI environments that *do* keep a TTY
+attached. The CLI now always prints the authorization URL and waits on the
+loopback callback — the user opens the link themselves whenever it's
+convenient. (Other CLI surfaces that intentionally open a browser, like
+`mcp-use deploy --open` and the auth login flow, are unchanged.)

--- a/libraries/typescript/.changeset/cli-sessions-test-temp-dir.md
+++ b/libraries/typescript/.changeset/cli-sessions-test-temp-dir.md
@@ -1,0 +1,10 @@
+---
+"@mcp-use/cli": patch
+---
+
+fix(cli): tests no longer touch the developer's real `~/.mcp-use` directory
+
+Two leaks are closed:
+
+- `session-storage.test.ts` computed its target path from `os.homedir()` and `rmSync`'d it in `beforeEach`/`afterEach`, so running `pnpm test` during local development deleted any saved clients on disk. The tests now mock `node:os.homedir` to a per-process temp directory.
+- `cli-integration.test.ts` spawned the real CLI as a subprocess and so read the developer's real `cli-sessions.json` when running `client list`. `runCLI` now sets `HOME` (and `USERPROFILE`) to an isolated temp dir for every spawn.

--- a/libraries/typescript/.changeset/cli-tool-call-dedupe-structured.md
+++ b/libraries/typescript/.changeset/cli-tool-call-dedupe-structured.md
@@ -10,5 +10,7 @@ client was rendering both, so every call to a structured-output tool printed
 the JSON payload twice.
 
 `mcp-use client <name> tools call ...` now treats `structuredContent` as the
-canonical form: when it's present, the content block is suppressed and only
-the structured JSON is shown.
+canonical form: when it's present, duplicate `TextContent` blocks are
+suppressed and only the structured JSON is shown. Non-text content blocks
+(image, resource) are still rendered alongside the structured payload — they
+carry information the structured form doesn't.

--- a/libraries/typescript/.changeset/cli-tool-call-dedupe-structured.md
+++ b/libraries/typescript/.changeset/cli-tool-call-dedupe-structured.md
@@ -1,0 +1,14 @@
+---
+"@mcp-use/cli": patch
+---
+
+fix(cli): stop printing tool results twice when servers return structuredContent
+
+Per the MCP spec, a tool that returns `structuredContent` SHOULD also serialize
+the same JSON into a `TextContent` block for backwards compatibility. The
+client was rendering both, so every call to a structured-output tool printed
+the JSON payload twice.
+
+`mcp-use client <name> tools call ...` now treats `structuredContent` as the
+canonical form: when it's present, the content block is suppressed and only
+the structured JSON is shown.

--- a/libraries/typescript/packages/cli/src/commands/client-auth.ts
+++ b/libraries/typescript/packages/cli/src/commands/client-auth.ts
@@ -58,12 +58,13 @@ export async function authStatusCommand(name: string): Promise<void> {
   if (!target) {
     process.exit(1);
   }
-  const provider = await buildOAuthProvider(target!.url);
+  const { name: serverName, url } = target;
+  const provider = await buildOAuthProvider(url);
   const tokens = await provider.tokens();
 
   const fields: Record<string, string> = {
-    server: target!.name,
-    url: target!.url,
+    server: serverName,
+    url,
     tokens: tokens?.access_token ? "present" : "missing",
   };
   if (tokens?.scope) fields.scope = tokens.scope;
@@ -83,7 +84,8 @@ export async function authRefreshCommand(name: string): Promise<void> {
   if (!target) {
     process.exit(1);
   }
-  const provider = await buildOAuthProvider(target!.url);
+  const { name: serverName, url } = target;
+  const provider = await buildOAuthProvider(url);
   const refreshed = await provider.forceRefresh();
   if (!refreshed) {
     console.error(
@@ -92,7 +94,7 @@ export async function authRefreshCommand(name: string): Promise<void> {
       )
     );
     console.error(
-      formatInfo(`Run: mcp-use client connect ${target!.name} ${target!.url}`)
+      formatInfo(`Run: mcp-use client connect ${serverName} ${url}`)
     );
     process.exit(1);
   }
@@ -111,12 +113,13 @@ export async function authLogoutCommand(name: string): Promise<void> {
   if (!target) {
     process.exit(1);
   }
-  const provider = await buildOAuthProvider(target!.url);
+  const { name: serverName, url } = target;
+  const provider = await buildOAuthProvider(url);
   await provider.invalidateCredentials("all");
-  console.log(formatSuccess(`Removed tokens for ${target!.url}`));
+  console.log(formatSuccess(`Removed tokens for ${url}`));
   console.log(
     formatInfo(
-      `Server '${target!.name}' kept; reconnect with \`mcp-use client connect\`.`
+      `Server '${serverName}' kept; reconnect with \`mcp-use client connect\`.`
     )
   );
 }

--- a/libraries/typescript/packages/cli/src/commands/client-auth.ts
+++ b/libraries/typescript/packages/cli/src/commands/client-auth.ts
@@ -5,33 +5,24 @@ import {
   formatSuccess,
 } from "../utils/format.js";
 import { buildOAuthProvider } from "../utils/oauth.js";
-import { getActiveSession, getSession } from "../utils/session-storage.js";
+import { getSession } from "../utils/session-storage.js";
 
 async function resolveSession(
-  sessionArg: string | undefined
+  name: string
 ): Promise<{ name: string; url: string } | null> {
-  let name = sessionArg;
-  if (!name) {
-    const active = await getActiveSession();
-    if (!active) {
-      console.error(formatError("No active session"));
-      return null;
-    }
-    name = active.name;
-  }
   const config = await getSession(name);
   if (!config) {
-    console.error(formatError(`Session '${name}' not found`));
+    console.error(formatError(`Client '${name}' not found`));
     return null;
   }
   if (config.type !== "http") {
-    console.error(formatError("Auth commands only apply to HTTP sessions"));
+    console.error(formatError("Auth commands only apply to HTTP clients"));
     return null;
   }
   if (config.authMode !== "oauth") {
     console.error(
       formatError(
-        `Session '${name}' was not authenticated via OAuth (authMode=${config.authMode ?? "bearer"})`
+        `Client '${name}' was not authenticated via OAuth (authMode=${config.authMode ?? "bearer"})`
       )
     );
     return null;
@@ -62,17 +53,17 @@ function decodeJwtExp(token: string): number | null {
   }
 }
 
-export async function authStatusCommand(sessionArg?: string): Promise<void> {
-  const target = await resolveSession(sessionArg);
+export async function authStatusCommand(name: string): Promise<void> {
+  const target = await resolveSession(name);
   if (!target) {
     process.exit(1);
   }
-  const provider = await buildOAuthProvider(target.url);
+  const provider = await buildOAuthProvider(target!.url);
   const tokens = await provider.tokens();
 
   const fields: Record<string, string> = {
-    session: target.name,
-    url: target.url,
+    client: target!.name,
+    url: target!.url,
     tokens: tokens?.access_token ? "present" : "missing",
   };
   if (tokens?.scope) fields.scope = tokens.scope;
@@ -87,12 +78,12 @@ export async function authStatusCommand(sessionArg?: string): Promise<void> {
   if (!tokens?.access_token) process.exit(1);
 }
 
-export async function authRefreshCommand(sessionArg?: string): Promise<void> {
-  const target = await resolveSession(sessionArg);
+export async function authRefreshCommand(name: string): Promise<void> {
+  const target = await resolveSession(name);
   if (!target) {
     process.exit(1);
   }
-  const provider = await buildOAuthProvider(target.url);
+  const provider = await buildOAuthProvider(target!.url);
   const refreshed = await provider.forceRefresh();
   if (!refreshed) {
     console.error(
@@ -101,9 +92,7 @@ export async function authRefreshCommand(sessionArg?: string): Promise<void> {
       )
     );
     console.error(
-      formatInfo(
-        `Run: mcp-use client connect ${target.url} --name ${target.name}`
-      )
+      formatInfo(`Run: mcp-use client connect ${target!.name} ${target!.url}`)
     );
     process.exit(1);
   }
@@ -117,17 +106,17 @@ export async function authRefreshCommand(sessionArg?: string): Promise<void> {
   );
 }
 
-export async function authLogoutCommand(sessionArg?: string): Promise<void> {
-  const target = await resolveSession(sessionArg);
+export async function authLogoutCommand(name: string): Promise<void> {
+  const target = await resolveSession(name);
   if (!target) {
     process.exit(1);
   }
-  const provider = await buildOAuthProvider(target.url);
+  const provider = await buildOAuthProvider(target!.url);
   await provider.invalidateCredentials("all");
-  console.log(formatSuccess(`Removed tokens for ${target.url}`));
+  console.log(formatSuccess(`Removed tokens for ${target!.url}`));
   console.log(
     formatInfo(
-      `Session '${target.name}' kept; reconnect with \`mcp-use client connect\`.`
+      `Client '${target!.name}' kept; reconnect with \`mcp-use client connect\`.`
     )
   );
 }

--- a/libraries/typescript/packages/cli/src/commands/client-auth.ts
+++ b/libraries/typescript/packages/cli/src/commands/client-auth.ts
@@ -12,17 +12,17 @@ async function resolveSession(
 ): Promise<{ name: string; url: string } | null> {
   const config = await getSession(name);
   if (!config) {
-    console.error(formatError(`Client '${name}' not found`));
+    console.error(formatError(`Server '${name}' not found`));
     return null;
   }
   if (config.type !== "http") {
-    console.error(formatError("Auth commands only apply to HTTP clients"));
+    console.error(formatError("Auth commands only apply to HTTP servers"));
     return null;
   }
   if (config.authMode !== "oauth") {
     console.error(
       formatError(
-        `Client '${name}' was not authenticated via OAuth (authMode=${config.authMode ?? "bearer"})`
+        `Server '${name}' was not authenticated via OAuth (authMode=${config.authMode ?? "bearer"})`
       )
     );
     return null;
@@ -62,7 +62,7 @@ export async function authStatusCommand(name: string): Promise<void> {
   const tokens = await provider.tokens();
 
   const fields: Record<string, string> = {
-    client: target!.name,
+    server: target!.name,
     url: target!.url,
     tokens: tokens?.access_token ? "present" : "missing",
   };
@@ -116,7 +116,7 @@ export async function authLogoutCommand(name: string): Promise<void> {
   console.log(formatSuccess(`Removed tokens for ${target!.url}`));
   console.log(
     formatInfo(
-      `Client '${target!.name}' kept; reconnect with \`mcp-use client connect\`.`
+      `Server '${target!.name}' kept; reconnect with \`mcp-use client connect\`.`
     )
   );
 }

--- a/libraries/typescript/packages/cli/src/commands/client.ts
+++ b/libraries/typescript/packages/cli/src/commands/client.ts
@@ -27,7 +27,9 @@ import {
   runOAuthFlow,
 } from "../utils/oauth.js";
 import {
+  getSession,
   listAllSessions,
+  removeSession,
   saveSession,
   updateSessionInfo,
 } from "../utils/session-storage.js";
@@ -50,7 +52,12 @@ import { captureToolScreenshot, detectToolResourceUri } from "./screenshot.js";
  * `createPerClientCommand`. Keep this in sync with the subcommands registered
  * in `createClientCommand` below, plus commander's built-in help tokens.
  */
-export const RESERVED_CLIENT_SUBCOMMANDS = new Set(["connect", "list", "help"]);
+export const RESERVED_CLIENT_SUBCOMMANDS = new Set([
+  "connect",
+  "list",
+  "remove",
+  "help",
+]);
 
 /**
  * Per-client scope tokens that live under `mcp-use client <name> ...`. When a
@@ -265,6 +272,70 @@ export async function disconnectCommand(name: string): Promise<void> {
     }
   } catch (error: any) {
     console.error(formatError(`Failed to disconnect: ${error.message}`));
+    await cleanupAndExit(1);
+  }
+  await cleanupAndExit(0);
+}
+
+export async function removeClientCommand(name: string): Promise<void> {
+  try {
+    const config = await getSession(name);
+    if (!config) {
+      console.error(formatError(`Server '${name}' not found`));
+      console.error("");
+      console.error("See your saved servers with:");
+      console.error("  mcp-use client list");
+      await cleanupAndExit(1);
+    }
+
+    const sessionData = activeSessions.get(name);
+    if (sessionData) {
+      await sessionData.client.closeAllSessions();
+      activeSessions.delete(name);
+    }
+
+    // OAuth tokens are keyed by URL hash, not by saved-server name, so two
+    // saved entries pointing at the same URL share one token store. Only
+    // wipe the tokens when this entry is the last one using the URL.
+    const isOAuthHttp =
+      config!.type === "http" &&
+      config!.authMode === "oauth" &&
+      typeof config!.url === "string";
+    const sharedUrlSibling = isOAuthHttp
+      ? (await listAllSessions()).find(
+          (s) =>
+            s.name !== name &&
+            s.config.type === "http" &&
+            s.config.url === config!.url
+        )
+      : undefined;
+
+    await removeSession(name);
+    console.log(formatSuccess(`Removed saved server '${name}'`));
+
+    if (isOAuthHttp) {
+      if (sharedUrlSibling) {
+        console.log(
+          formatInfo(
+            `OAuth tokens for ${config!.url} were kept because saved server '${sharedUrlSibling.name}' still uses that URL.`
+          )
+        );
+      } else {
+        try {
+          const provider = await buildOAuthProvider(config!.url!);
+          await provider.invalidateCredentials("all");
+          console.log(formatInfo(`Removed OAuth tokens for ${config!.url}`));
+        } catch (error: any) {
+          console.error(
+            formatWarning(
+              `Saved entry removed, but failed to clear OAuth tokens for ${config!.url}: ${error.message}`
+            )
+          );
+        }
+      }
+    }
+  } catch (error: any) {
+    console.error(formatError(`Failed to remove server: ${error.message}`));
     await cleanupAndExit(1);
   }
   await cleanupAndExit(0);
@@ -1035,6 +1106,13 @@ export function createClientCommand(): Command {
     .command("list")
     .description("List saved servers")
     .action(listClientsCommand);
+
+  clientCommand
+    .command("remove <name>")
+    .description(
+      "Remove a saved server. Also clears any OAuth tokens for that URL, unless another saved server still uses it."
+    )
+    .action(removeClientCommand);
 
   return clientCommand;
 }

--- a/libraries/typescript/packages/cli/src/commands/client.ts
+++ b/libraries/typescript/packages/cli/src/commands/client.ts
@@ -27,10 +27,8 @@ import {
   runOAuthFlow,
 } from "../utils/oauth.js";
 import {
-  getActiveSession,
   listAllSessions,
   saveSession,
-  setActiveSession,
   updateSessionInfo,
 } from "../utils/session-storage.js";
 import {
@@ -46,26 +44,99 @@ import {
 } from "./client-auth.js";
 import { captureToolScreenshot, detectToolResourceUri } from "./screenshot.js";
 
+/**
+ * Reserved top-level subcommands under `mcp-use client`. Any other token in
+ * that position is treated as a client name and routed via
+ * `createPerClientCommand`. Keep this in sync with the subcommands registered
+ * in `createClientCommand` below, plus commander's built-in help tokens.
+ */
+export const RESERVED_CLIENT_SUBCOMMANDS = new Set(["connect", "list", "help"]);
+
+/**
+ * Per-client scope tokens that live under `mcp-use client <name> ...`. When a
+ * user types one of these in the client-name slot (e.g.
+ * `mcp-use client tools call foo`), they almost certainly forgot the client
+ * name — route to a tailored error instead of "unknown command".
+ */
+export const PER_CLIENT_SCOPES = new Set([
+  "tools",
+  "resources",
+  "prompts",
+  "auth",
+  "disconnect",
+  "interactive",
+]);
+
 export async function connectCommand(
-  urlOrCommand: string,
+  name: string | undefined,
+  urlOrCommand: string | undefined,
   options: {
-    name?: string;
     stdio?: boolean;
     auth?: string;
     oauth?: boolean;
     authTimeout?: string;
   }
 ): Promise<void> {
-  try {
-    const sessionName = options.name || `session-${Date.now()}`;
+  // `connect` requires both <name> and <url>. Commander's default missing-arg
+  // error ("missing required argument 'url'") is confusing when users pass a
+  // URL as the only positional — they don't realize the client needs a name.
+  // Catch the common shapes here and give a tailored fix-it message.
+  if (!name || !urlOrCommand) {
+    const looksLikeUrl = !!name && /^https?:\/\//i.test(name);
 
+    if (looksLikeUrl && !urlOrCommand && !options.stdio) {
+      console.error(formatError("Missing client name."));
+      console.error("");
+      console.error(
+        formatInfo(
+          "Each saved client needs a short name you'll use to address it later."
+        )
+      );
+      console.error("");
+      console.error("Try:");
+      console.error(`  mcp-use client connect <name> ${name}`);
+      console.error("");
+      console.error("Example:");
+      console.error(`  mcp-use client connect my-server ${name}`);
+      console.error("  mcp-use client my-server tools list");
+    } else if (name && !urlOrCommand) {
+      console.error(
+        formatError(options.stdio ? "Missing <command>." : "Missing <url>.")
+      );
+      console.error("");
+      console.error(formatInfo("Usage:"));
+      console.error(
+        options.stdio
+          ? `  mcp-use client connect ${name} "<command>" --stdio`
+          : `  mcp-use client connect ${name} <url>`
+      );
+    } else {
+      console.error(formatError("Missing required arguments: <name> <url>."));
+      console.error("");
+      console.error(formatInfo("Usage:"));
+      console.error("  mcp-use client connect <name> <url>");
+      console.error("");
+      console.error("Example:");
+      console.error(
+        "  mcp-use client connect manufact https://mcp.manufact.com/mcp"
+      );
+    }
+    await cleanupAndExit(1);
+  }
+
+  // Narrow for TS: the validation block above exits on missing args. The
+  // `await cleanupAndExit` doesn't propagate `never` through control flow,
+  // so assert here once instead of sprinkling `!` everywhere.
+  const sessionName: string = name as string;
+  const target: string = urlOrCommand as string;
+
+  try {
     const client = new MCPClient();
     let session: MCPSession;
     const cliClientInfo = getCliClientInfo();
 
     if (options.stdio) {
-      // Parse stdio command
-      const parts = urlOrCommand.split(" ");
+      const parts = target.split(" ");
       const command = parts[0];
       const args = parts.slice(1);
 
@@ -81,7 +152,6 @@ export async function connectCommand(
 
       session = await client.createSession(sessionName);
 
-      // Save session config
       await saveSession(sessionName, {
         type: "stdio",
         command,
@@ -89,8 +159,7 @@ export async function connectCommand(
         lastUsed: new Date().toISOString(),
       });
     } else {
-      // HTTP connection
-      console.error(formatInfo(`Connecting to ${urlOrCommand}...`));
+      console.error(formatInfo(`Connecting to ${target}...`));
 
       // Static --auth bypasses OAuth entirely. `--no-oauth` disables auto-OAuth
       // on 401 (commander maps `--no-oauth` to options.oauth === false).
@@ -100,13 +169,13 @@ export async function connectCommand(
         const authTimeoutMs = options.authTimeout
           ? Number.parseInt(options.authTimeout, 10)
           : undefined;
-        authProvider = await buildOAuthProvider(urlOrCommand, {
+        authProvider = await buildOAuthProvider(target, {
           ...(authTimeoutMs ? { authTimeoutMs } : {}),
         });
       }
 
       client.addServer(sessionName, {
-        url: urlOrCommand,
+        url: target,
         ...(authProvider
           ? { authProvider }
           : options.auth
@@ -124,29 +193,25 @@ export async function connectCommand(
               "Server requires authentication. Starting OAuth flow."
             )
           );
-          await runOAuthFlow(authProvider, urlOrCommand);
+          await runOAuthFlow(authProvider, target);
           console.error(formatSuccess("Authentication successful"));
-          // Provider has tokens now; the SDK will pick them up on retry.
           session = await client.createSession(sessionName);
         } else {
           throw err;
         }
       }
 
-      // Save session config
       await saveSession(sessionName, {
         type: "http",
-        url: urlOrCommand,
+        url: target,
         authMode: authProvider ? "oauth" : options.auth ? "bearer" : undefined,
         authToken: authProvider ? undefined : options.auth,
         lastUsed: new Date().toISOString(),
       });
     }
 
-    // Store in memory
     activeSessions.set(sessionName, { client, session });
 
-    // Update session info
     const serverInfo = session.serverInfo;
     const capabilities = session.serverCapabilities;
 
@@ -154,8 +219,7 @@ export async function connectCommand(
       await updateSessionInfo(sessionName, serverInfo, capabilities);
     }
 
-    // Display connection info
-    console.log(formatSuccess(`Connected to ${sessionName}`));
+    console.log(formatSuccess(`Connected as '${sessionName}'`));
 
     if (serverInfo) {
       console.log("");
@@ -175,7 +239,6 @@ export async function connectCommand(
       console.log(`  ${caps || "none"}`);
     }
 
-    // Count available resources
     const tools = session.tools;
     console.log("");
     console.log(
@@ -190,40 +253,15 @@ export async function connectCommand(
   await cleanupAndExit(0);
 }
 
-/**
- * Disconnect command
- */
-export async function disconnectCommand(
-  sessionName?: string,
-  options?: { all?: boolean }
-): Promise<void> {
+export async function disconnectCommand(name: string): Promise<void> {
   try {
-    if (options?.all) {
-      // Disconnect all sessions
-      for (const [name, { client }] of activeSessions.entries()) {
-        await client.closeAllSessions();
-        activeSessions.delete(name);
-        console.log(formatSuccess(`Disconnected from ${name}`));
-      }
-      await cleanupAndExit(0);
-    }
-
-    if (!sessionName) {
-      const active = await getActiveSession();
-      if (!active) {
-        console.error(formatError("No active session to disconnect"));
-        await cleanupAndExit(0);
-      }
-      sessionName = active!.name;
-    }
-
-    const sessionData = activeSessions.get(sessionName);
+    const sessionData = activeSessions.get(name);
     if (sessionData) {
       await sessionData.client.closeAllSessions();
-      activeSessions.delete(sessionName);
-      console.log(formatSuccess(`Disconnected from ${sessionName}`));
+      activeSessions.delete(name);
+      console.log(formatSuccess(`Disconnected from ${name}`));
     } else {
-      console.log(formatInfo(`Session '${sessionName}' is not connected`));
+      console.log(formatInfo(`Client '${name}' is not connected`));
     }
   } catch (error: any) {
     console.error(formatError(`Failed to disconnect: ${error.message}`));
@@ -232,19 +270,16 @@ export async function disconnectCommand(
   await cleanupAndExit(0);
 }
 
-/**
- * List sessions command
- */
-export async function listSessionsCommand(): Promise<void> {
+export async function listClientsCommand(): Promise<void> {
   try {
     const sessions = await listAllSessions();
 
     if (sessions.length === 0) {
       if (isStdoutTty()) {
-        console.log(formatInfo("No saved sessions"));
+        console.log(formatInfo("No saved clients"));
         console.log(
           formatInfo(
-            "Connect to a server with: npx mcp-use client connect <url>"
+            "Connect to a server with: npx mcp-use client connect <name> <url>"
           )
         );
       }
@@ -253,12 +288,12 @@ export async function listSessionsCommand(): Promise<void> {
 
     const tty = isStdoutTty();
     if (tty) {
-      console.log(formatHeader("Saved Sessions:"));
+      console.log(formatHeader("Saved Clients:"));
       console.log("");
     }
 
     const tableData = sessions.map((s) => ({
-      name: s.isActive ? chalk.green.bold(`${s.name} *`) : s.name,
+      name: s.name,
       type: s.config.type,
       target:
         s.config.type === "http"
@@ -275,41 +310,19 @@ export async function listSessionsCommand(): Promise<void> {
         { key: "server", header: "Server" },
       ])
     );
-
-    if (tty) {
-      console.log("");
-      console.log(chalk.gray("* = active session"));
-    }
   } catch (error: any) {
-    console.error(formatError(`Failed to list sessions: ${error.message}`));
+    console.error(formatError(`Failed to list clients: ${error.message}`));
     await cleanupAndExit(1);
   }
   await cleanupAndExit(0);
 }
 
-/**
- * Switch session command
- */
-export async function switchSessionCommand(name: string): Promise<void> {
+export async function listToolsCommand(
+  name: string,
+  options: { json?: boolean }
+): Promise<void> {
   try {
-    await setActiveSession(name);
-    console.log(formatSuccess(`Switched to session '${name}'`));
-  } catch (error: any) {
-    console.error(formatError(`Failed to switch session: ${error.message}`));
-    await cleanupAndExit(1);
-  }
-  await cleanupAndExit(0);
-}
-
-/**
- * List tools command
- */
-export async function listToolsCommand(options: {
-  session?: string;
-  json?: boolean;
-}): Promise<void> {
-  try {
-    const result = await getOrRestoreSession(options.session || null);
+    const result = await getOrRestoreSession(name);
     if (!result) {
       await cleanupAndExit(1);
     }
@@ -367,15 +380,12 @@ export async function listToolsCommand(options: {
   await cleanupAndExit(0);
 }
 
-/**
- * Describe tool command
- */
 export async function describeToolCommand(
-  toolName: string,
-  options: { session?: string }
+  name: string,
+  toolName: string
 ): Promise<void> {
   try {
-    const result = await getOrRestoreSession(options.session || null);
+    const result = await getOrRestoreSession(name);
     if (!result) {
       await cleanupAndExit(1);
     }
@@ -411,14 +421,11 @@ export async function describeToolCommand(
   await cleanupAndExit(0);
 }
 
-/**
- * Call tool command
- */
 export async function callToolCommand(
+  name: string,
   toolName: string,
   argsList?: string[],
   options?: {
-    session?: string;
     timeout?: number;
     json?: boolean;
     screenshot?: boolean;
@@ -426,7 +433,7 @@ export async function callToolCommand(
   }
 ): Promise<void> {
   try {
-    const result = await getOrRestoreSession(options?.session || null);
+    const result = await getOrRestoreSession(name);
     if (!result) {
       await cleanupAndExit(1);
     }
@@ -436,7 +443,6 @@ export async function callToolCommand(
     const tools = session.tools;
     const tool = tools.find((t) => t.name === toolName);
 
-    // Parse arguments: key=value pairs, key:=jsonvalue, or a single JSON object
     let args: Record<string, unknown> = {};
     if (argsList && argsList.length > 0) {
       try {
@@ -446,13 +452,13 @@ export async function callToolCommand(
         console.log("");
         console.log(formatInfo("Usage:"));
         console.log(
-          `  npx mcp-use client tools call ${toolName} key=value [key2=value2 ...]`
+          `  npx mcp-use client ${name} tools call ${toolName} key=value [key2=value2 ...]`
         );
         console.log(
-          `  npx mcp-use client tools call ${toolName} nested:='{"a":1}'   # JSON value`
+          `  npx mcp-use client ${name} tools call ${toolName} nested:='{"a":1}'   # JSON value`
         );
         console.log(
-          `  npx mcp-use client tools call ${toolName} '{"key":"value"}'   # full JSON object`
+          `  npx mcp-use client ${name} tools call ${toolName} '{"key":"value"}'   # full JSON object`
         );
         if (tool?.inputSchema) {
           console.log("");
@@ -469,7 +475,7 @@ export async function callToolCommand(
       console.log("");
       console.log(formatInfo("Provide arguments as key=value pairs:"));
       console.log(
-        `  npx mcp-use client tools call ${toolName} key=value [key2=value2 ...]`
+        `  npx mcp-use client ${name} tools call ${toolName} key=value [key2=value2 ...]`
       );
       console.log("");
       console.log(formatInfo("Tool schema:"));
@@ -477,7 +483,6 @@ export async function callToolCommand(
       await cleanupAndExit(1);
     }
 
-    // Call the tool
     console.error(formatInfo(`Calling tool '${toolName}'...`));
     const callResult = await session.callTool(toolName, args, {
       timeout: options?.timeout,
@@ -565,15 +570,12 @@ export async function callToolCommand(
   await cleanupAndExit(0);
 }
 
-/**
- * List resources command
- */
-export async function listResourcesCommand(options: {
-  session?: string;
-  json?: boolean;
-}): Promise<void> {
+export async function listResourcesCommand(
+  name: string,
+  options: { json?: boolean }
+): Promise<void> {
   try {
-    const result = await getOrRestoreSession(options.session || null);
+    const result = await getOrRestoreSession(name);
     if (!result) {
       await cleanupAndExit(1);
     }
@@ -614,15 +616,13 @@ export async function listResourcesCommand(options: {
   await cleanupAndExit(0);
 }
 
-/**
- * Read resource command
- */
 export async function readResourceCommand(
+  name: string,
   uri: string,
-  options: { session?: string; json?: boolean }
+  options: { json?: boolean }
 ): Promise<void> {
   try {
-    const result = await getOrRestoreSession(options.session || null);
+    const result = await getOrRestoreSession(name);
     if (!result) {
       await cleanupAndExit(1);
     }
@@ -644,18 +644,15 @@ export async function readResourceCommand(
   await cleanupAndExit(0);
 }
 
-/**
- * Subscribe to resource command
- */
 export async function subscribeResourceCommand(
-  uri: string,
-  options: { session?: string }
+  name: string,
+  uri: string
 ): Promise<void> {
   // Subscribe is intentionally long-lived: it keeps the process alive to
   // receive notifications until Ctrl+C. Don't run cleanupAndExit on the
   // success path — only on error.
   try {
-    const result = await getOrRestoreSession(options.session || null);
+    const result = await getOrRestoreSession(name);
     if (!result) {
       await cleanupAndExit(1);
     }
@@ -665,7 +662,6 @@ export async function subscribeResourceCommand(
     await session.subscribeToResource(uri);
     console.log(formatSuccess(`Subscribed to resource: ${uri}`));
 
-    // Set up notification handler
     session.on("notification", async (notification) => {
       if (notification.method === "notifications/resources/updated") {
         console.log("");
@@ -676,7 +672,6 @@ export async function subscribeResourceCommand(
 
     console.log(formatInfo("Listening for updates... (Press Ctrl+C to stop)"));
 
-    // Keep process alive
     await new Promise(() => {});
   } catch (error: any) {
     console.error(
@@ -686,15 +681,12 @@ export async function subscribeResourceCommand(
   }
 }
 
-/**
- * Unsubscribe from resource command
- */
 export async function unsubscribeResourceCommand(
-  uri: string,
-  options: { session?: string }
+  name: string,
+  uri: string
 ): Promise<void> {
   try {
-    const result = await getOrRestoreSession(options.session || null);
+    const result = await getOrRestoreSession(name);
     if (!result) {
       await cleanupAndExit(1);
     }
@@ -712,15 +704,12 @@ export async function unsubscribeResourceCommand(
   await cleanupAndExit(0);
 }
 
-/**
- * List prompts command
- */
-export async function listPromptsCommand(options: {
-  session?: string;
-  json?: boolean;
-}): Promise<void> {
+export async function listPromptsCommand(
+  name: string,
+  options: { json?: boolean }
+): Promise<void> {
   try {
-    const result = await getOrRestoreSession(options.session || null);
+    const result = await getOrRestoreSession(name);
     if (!result) {
       await cleanupAndExit(1);
     }
@@ -769,23 +758,20 @@ export async function listPromptsCommand(options: {
   await cleanupAndExit(0);
 }
 
-/**
- * Get prompt command
- */
 export async function getPromptCommand(
+  name: string,
   promptName: string,
   argsList?: string[],
-  options?: { session?: string; json?: boolean }
+  options?: { json?: boolean }
 ): Promise<void> {
   try {
-    const result = await getOrRestoreSession(options?.session || null);
+    const result = await getOrRestoreSession(name);
     if (!result) {
       await cleanupAndExit(1);
     }
 
     const { session } = result!;
 
-    // Parse arguments: key=value pairs or a single JSON object
     let args: Record<string, string> = {};
     if (argsList && argsList.length > 0) {
       try {
@@ -795,10 +781,10 @@ export async function getPromptCommand(
         console.log("");
         console.log(formatInfo("Usage:"));
         console.log(
-          `  npx mcp-use client prompts get ${promptName} key=value [key2=value2 ...]`
+          `  npx mcp-use client ${name} prompts get ${promptName} key=value [key2=value2 ...]`
         );
         console.log(
-          `  npx mcp-use client prompts get ${promptName} '{"key":"value"}'   # full JSON object`
+          `  npx mcp-use client ${name} prompts get ${promptName} '{"key":"value"}'   # full JSON object`
         );
         await cleanupAndExit(1);
       }
@@ -831,14 +817,9 @@ export async function getPromptCommand(
   await cleanupAndExit(0);
 }
 
-/**
- * Interactive mode command
- */
-export async function interactiveCommand(options: {
-  session?: string;
-}): Promise<void> {
+export async function interactiveCommand(name: string): Promise<void> {
   try {
-    const result = await getOrRestoreSession(options.session || null);
+    const result = await getOrRestoreSession(name);
     if (!result) return;
 
     const { name: sessionName, session } = result;
@@ -863,10 +844,6 @@ export async function interactiveCommand(options: {
       chalk.gray("  prompts list            - List available prompts")
     );
     console.log(chalk.gray("  prompts get <name>      - Get a prompt"));
-    console.log(chalk.gray("  sessions list           - List all sessions"));
-    console.log(
-      chalk.gray("  sessions switch <name>  - Switch to another session")
-    );
     console.log(
       chalk.gray("  exit, quit              - Exit interactive mode")
     );
@@ -911,7 +888,6 @@ export async function interactiveCommand(options: {
           } else if (command === "call" && arg) {
             // TODO(mcp-1566): mirror the auto widget-screenshot flow from
             // `client tools call` here. Skipped for now to keep the REPL terse.
-            // Prompt for arguments
             rl.question(
               "Arguments (JSON, or press Enter for none): ",
               async (argsInput) => {
@@ -996,22 +972,10 @@ export async function interactiveCommand(options: {
               )
             );
           }
-        } else if (scope === "sessions") {
-          if (command === "list") {
-            await listSessionsCommand();
-          } else if (command === "switch" && arg) {
-            console.log(
-              formatWarning(
-                "Session switching in interactive mode will be available in a future version"
-              )
-            );
-          } else {
-            console.error(formatError("Invalid command. Try: sessions list"));
-          }
         } else {
           console.error(
             formatError(
-              "Unknown command. Type a valid scope: tools, resources, prompts, sessions"
+              "Unknown command. Type a valid scope: tools, resources, prompts"
             )
           );
         }
@@ -1036,18 +1000,25 @@ export async function interactiveCommand(options: {
 }
 
 /**
- * Create the client command group
+ * Top-level `client` command. Exposes only commands that do not target an
+ * existing named client: `connect` (which creates one) and `list`. Per-client
+ * operations live under `createPerClientCommand(<name>)` and are routed by
+ * `index.ts` based on the positional after `client`.
  */
 export function createClientCommand(): Command {
-  const clientCommand = new Command("client").description(
-    "Interactive MCP client for terminal usage"
-  );
+  const clientCommand = new Command("client")
+    .description(
+      "Interactive MCP client for terminal usage. Use `mcp-use client <name> ...` to run commands against a saved client."
+    )
+    .showHelpAfterError(
+      "(Run `mcp-use client --help` to see available commands)"
+    );
 
-  // Connection commands
   clientCommand
-    .command("connect <url>")
-    .description("Connect to an MCP server")
-    .option("--name <name>", "Session name")
+    .command("connect [name] [url]")
+    .description(
+      "Connect to an MCP server and save it as a named client. Use the name to address it in later commands (e.g. `mcp-use client <name> tools list`)."
+    )
     .option("--stdio", "Use stdio connector instead of HTTP")
     .option("--auth <token>", "Static Bearer token (skips OAuth)")
     .option(
@@ -1061,41 +1032,50 @@ export function createClientCommand(): Command {
     .action(connectCommand);
 
   clientCommand
-    .command("disconnect [session]")
-    .description("Disconnect from a session")
-    .option("--all", "Disconnect all sessions")
-    .action(disconnectCommand);
-
-  // Sessions scope
-  const sessionsCommand = new Command("sessions").description(
-    "Manage CLI sessions"
-  );
-  sessionsCommand
     .command("list")
-    .description("List all saved sessions")
-    .action(listSessionsCommand);
-  sessionsCommand
-    .command("switch <name>")
-    .description("Switch to a different session")
-    .action(switchSessionCommand);
-  clientCommand.addCommand(sessionsCommand);
+    .description("List saved clients")
+    .action(listClientsCommand);
 
-  // Tools scope
-  const toolsCommand = new Command("tools").description(
-    "Interact with MCP tools"
-  );
+  return clientCommand;
+}
+
+/**
+ * Build the per-client command subtree for a given client name. The name is
+ * captured in each action closure so subcommand definitions stay free of an
+ * extra positional argument.
+ */
+export function createPerClientCommand(name: string): Command {
+  const cmd = new Command(`mcp-use client ${name}`)
+    .description(`Commands for client '${name}'`)
+    .showHelpAfterError(
+      `(Run \`mcp-use client ${name} --help\` to see available commands)`
+    );
+
+  cmd
+    .command("disconnect")
+    .description("Disconnect from this client")
+    .action(() => disconnectCommand(name));
+
+  cmd
+    .command("interactive")
+    .description("Start interactive REPL mode for this client")
+    .action(() => interactiveCommand(name));
+
+  const toolsCommand = new Command("tools")
+    .description("Interact with MCP tools")
+    .showHelpAfterError(
+      `(Run \`mcp-use client ${name} tools --help\` to see available actions)`
+    );
   toolsCommand
     .command("list")
     .description("List available tools")
-    .option("--session <name>", "Use specific session")
     .option("--json", "Output as JSON")
-    .action(listToolsCommand);
+    .action((options) => listToolsCommand(name, options));
   toolsCommand
-    .command("call <name> [args...]")
+    .command("call <tool> [args...]")
     .description(
       "Call a tool. Args as key=value pairs (use key:=<json> for nested values, or pass a JSON object)"
     )
-    .option("--session <name>", "Use specific session")
     .option("--timeout <ms>", "Request timeout in milliseconds", parseInt)
     .option("--json", "Output as JSON")
     .option(
@@ -1106,86 +1086,79 @@ export function createClientCommand(): Command {
       "--screenshot-output <path>",
       "Output PNG path for the widget screenshot (defaults to ./<view>-<timestamp>.png)"
     )
-    .action((name, args, opts) => callToolCommand(name, args, opts));
+    .action((tool, args, options) =>
+      callToolCommand(name, tool, args, options)
+    );
   toolsCommand
-    .command("describe <name>")
+    .command("describe <tool>")
     .description("Show tool details and schema")
-    .option("--session <name>", "Use specific session")
-    .action(describeToolCommand);
-  clientCommand.addCommand(toolsCommand);
+    .action((tool) => describeToolCommand(name, tool));
+  cmd.addCommand(toolsCommand);
 
-  // Resources scope
-  const resourcesCommand = new Command("resources").description(
-    "Interact with MCP resources"
-  );
+  const resourcesCommand = new Command("resources")
+    .description("Interact with MCP resources")
+    .showHelpAfterError(
+      `(Run \`mcp-use client ${name} resources --help\` to see available actions)`
+    );
   resourcesCommand
     .command("list")
     .description("List available resources")
-    .option("--session <name>", "Use specific session")
     .option("--json", "Output as JSON")
-    .action(listResourcesCommand);
+    .action((options) => listResourcesCommand(name, options));
   resourcesCommand
     .command("read <uri>")
     .description("Read a resource by URI")
-    .option("--session <name>", "Use specific session")
     .option("--json", "Output as JSON")
-    .action(readResourceCommand);
+    .action((uri, options) => readResourceCommand(name, uri, options));
   resourcesCommand
     .command("subscribe <uri>")
     .description("Subscribe to resource updates")
-    .option("--session <name>", "Use specific session")
-    .action(subscribeResourceCommand);
+    .action((uri) => subscribeResourceCommand(name, uri));
   resourcesCommand
     .command("unsubscribe <uri>")
     .description("Unsubscribe from resource updates")
-    .option("--session <name>", "Use specific session")
-    .action(unsubscribeResourceCommand);
-  clientCommand.addCommand(resourcesCommand);
+    .action((uri) => unsubscribeResourceCommand(name, uri));
+  cmd.addCommand(resourcesCommand);
 
-  // Prompts scope
-  const promptsCommand = new Command("prompts").description(
-    "Interact with MCP prompts"
-  );
+  const promptsCommand = new Command("prompts")
+    .description("Interact with MCP prompts")
+    .showHelpAfterError(
+      `(Run \`mcp-use client ${name} prompts --help\` to see available actions)`
+    );
   promptsCommand
     .command("list")
     .description("List available prompts")
-    .option("--session <name>", "Use specific session")
     .option("--json", "Output as JSON")
-    .action(listPromptsCommand);
+    .action((options) => listPromptsCommand(name, options));
   promptsCommand
-    .command("get <name> [args...]")
+    .command("get <prompt> [args...]")
     .description(
       "Get a prompt. Args as key=value pairs (or pass a JSON object)"
     )
-    .option("--session <name>", "Use specific session")
     .option("--json", "Output as JSON")
-    .action(getPromptCommand);
-  clientCommand.addCommand(promptsCommand);
+    .action((prompt, args, options) =>
+      getPromptCommand(name, prompt, args, options)
+    );
+  cmd.addCommand(promptsCommand);
 
-  // Interactive mode
-  clientCommand
-    .command("interactive")
-    .description("Start interactive REPL mode")
-    .option("--session <name>", "Use specific session")
-    .action(interactiveCommand);
-
-  // Auth scope (OAuth introspection / refresh / logout)
-  const authCommand = new Command("auth").description(
-    "Manage OAuth tokens for HTTP sessions"
-  );
+  const authCommand = new Command("auth")
+    .description("Manage OAuth tokens for HTTP clients")
+    .showHelpAfterError(
+      `(Run \`mcp-use client ${name} auth --help\` to see available actions)`
+    );
   authCommand
-    .command("status [session]")
-    .description("Show OAuth token status for a session")
-    .action(authStatusCommand);
+    .command("status")
+    .description("Show OAuth token status for this client")
+    .action(() => authStatusCommand(name));
   authCommand
-    .command("refresh [session]")
+    .command("refresh")
     .description("Force-refresh the OAuth access token")
-    .action(authRefreshCommand);
+    .action(() => authRefreshCommand(name));
   authCommand
-    .command("logout [session]")
-    .description("Remove stored OAuth tokens for the session's URL")
-    .action(authLogoutCommand);
-  clientCommand.addCommand(authCommand);
+    .command("logout")
+    .description("Remove stored OAuth tokens for this client's URL")
+    .action(() => authLogoutCommand(name));
+  cmd.addCommand(authCommand);
 
-  return clientCommand;
+  return cmd;
 }

--- a/libraries/typescript/packages/cli/src/commands/client.ts
+++ b/libraries/typescript/packages/cli/src/commands/client.ts
@@ -79,17 +79,17 @@ export async function connectCommand(
 ): Promise<void> {
   // `connect` requires both <name> and <url>. Commander's default missing-arg
   // error ("missing required argument 'url'") is confusing when users pass a
-  // URL as the only positional — they don't realize the client needs a name.
+  // URL as the only positional — they don't realize the server needs a name.
   // Catch the common shapes here and give a tailored fix-it message.
   if (!name || !urlOrCommand) {
     const looksLikeUrl = !!name && /^https?:\/\//i.test(name);
 
     if (looksLikeUrl && !urlOrCommand && !options.stdio) {
-      console.error(formatError("Missing client name."));
+      console.error(formatError("Missing server name."));
       console.error("");
       console.error(
         formatInfo(
-          "Each saved client needs a short name you'll use to address it later."
+          "Each saved server needs a short name you'll use to address it later."
         )
       );
       console.error("");
@@ -261,7 +261,7 @@ export async function disconnectCommand(name: string): Promise<void> {
       activeSessions.delete(name);
       console.log(formatSuccess(`Disconnected from ${name}`));
     } else {
-      console.log(formatInfo(`Client '${name}' is not connected`));
+      console.log(formatInfo(`Server '${name}' is not connected`));
     }
   } catch (error: any) {
     console.error(formatError(`Failed to disconnect: ${error.message}`));
@@ -276,7 +276,7 @@ export async function listClientsCommand(): Promise<void> {
 
     if (sessions.length === 0) {
       if (isStdoutTty()) {
-        console.log(formatInfo("No saved clients"));
+        console.log(formatInfo("No saved servers"));
         console.log(
           formatInfo(
             "Connect to a server with: npx mcp-use client connect <name> <url>"
@@ -288,7 +288,7 @@ export async function listClientsCommand(): Promise<void> {
 
     const tty = isStdoutTty();
     if (tty) {
-      console.log(formatHeader("Saved Clients:"));
+      console.log(formatHeader("Saved Servers:"));
       console.log("");
     }
 
@@ -311,7 +311,7 @@ export async function listClientsCommand(): Promise<void> {
       ])
     );
   } catch (error: any) {
-    console.error(formatError(`Failed to list clients: ${error.message}`));
+    console.error(formatError(`Failed to list servers: ${error.message}`));
     await cleanupAndExit(1);
   }
   await cleanupAndExit(0);
@@ -1001,14 +1001,14 @@ export async function interactiveCommand(name: string): Promise<void> {
 
 /**
  * Top-level `client` command. Exposes only commands that do not target an
- * existing named client: `connect` (which creates one) and `list`. Per-client
+ * existing saved server: `connect` (which creates one) and `list`. Per-server
  * operations live under `createPerClientCommand(<name>)` and are routed by
  * `index.ts` based on the positional after `client`.
  */
 export function createClientCommand(): Command {
   const clientCommand = new Command("client")
     .description(
-      "Interactive MCP client for terminal usage. Use `mcp-use client <name> ...` to run commands against a saved client."
+      "Interactive MCP client for terminal usage. Use `mcp-use client <name> ...` to run commands against a saved server."
     )
     .showHelpAfterError(
       "(Run `mcp-use client --help` to see available commands)"
@@ -1017,7 +1017,7 @@ export function createClientCommand(): Command {
   clientCommand
     .command("connect [name] [url]")
     .description(
-      "Connect to an MCP server and save it as a named client. Use the name to address it in later commands (e.g. `mcp-use client <name> tools list`)."
+      "Connect to an MCP server and save it under a short name. Use the name to address it in later commands (e.g. `mcp-use client <name> tools list`)."
     )
     .option("--stdio", "Use stdio connector instead of HTTP")
     .option("--auth <token>", "Static Bearer token (skips OAuth)")
@@ -1033,32 +1033,32 @@ export function createClientCommand(): Command {
 
   clientCommand
     .command("list")
-    .description("List saved clients")
+    .description("List saved servers")
     .action(listClientsCommand);
 
   return clientCommand;
 }
 
 /**
- * Build the per-client command subtree for a given client name. The name is
- * captured in each action closure so subcommand definitions stay free of an
- * extra positional argument.
+ * Build the per-server command subtree for a given saved-server name. The
+ * name is captured in each action closure so subcommand definitions stay
+ * free of an extra positional argument.
  */
 export function createPerClientCommand(name: string): Command {
   const cmd = new Command(`mcp-use client ${name}`)
-    .description(`Commands for client '${name}'`)
+    .description(`Commands for server '${name}'`)
     .showHelpAfterError(
       `(Run \`mcp-use client ${name} --help\` to see available commands)`
     );
 
   cmd
     .command("disconnect")
-    .description("Disconnect from this client")
+    .description("Disconnect from this server")
     .action(() => disconnectCommand(name));
 
   cmd
     .command("interactive")
-    .description("Start interactive REPL mode for this client")
+    .description("Start interactive REPL mode for this server")
     .action(() => interactiveCommand(name));
 
   const toolsCommand = new Command("tools")
@@ -1142,13 +1142,13 @@ export function createPerClientCommand(name: string): Command {
   cmd.addCommand(promptsCommand);
 
   const authCommand = new Command("auth")
-    .description("Manage OAuth tokens for HTTP clients")
+    .description("Manage OAuth tokens for HTTP servers")
     .showHelpAfterError(
       `(Run \`mcp-use client ${name} auth --help\` to see available actions)`
     );
   authCommand
     .command("status")
-    .description("Show OAuth token status for this client")
+    .description("Show OAuth token status for this server")
     .action(() => authStatusCommand(name));
   authCommand
     .command("refresh")
@@ -1156,7 +1156,7 @@ export function createPerClientCommand(name: string): Command {
     .action(() => authRefreshCommand(name));
   authCommand
     .command("logout")
-    .description("Remove stored OAuth tokens for this client's URL")
+    .description("Remove stored OAuth tokens for this server's URL")
     .action(() => authLogoutCommand(name));
   cmd.addCommand(authCommand);
 

--- a/libraries/typescript/packages/cli/src/commands/client.ts
+++ b/libraries/typescript/packages/cli/src/commands/client.ts
@@ -137,6 +137,26 @@ export async function connectCommand(
   const sessionName: string = name as string;
   const target: string = urlOrCommand as string;
 
+  // Reject names that collide with per-server scope tokens. If someone saved a
+  // server as `tools`, every `mcp-use client tools ...` invocation would be
+  // intercepted by the "missing server name" routing in index.ts and the
+  // saved entry would be unreachable. Fail fast at save time instead.
+  if (PER_CLIENT_SCOPES.has(sessionName)) {
+    console.error(
+      formatError(
+        `'${sessionName}' is a reserved name and can't be used for a saved server.`
+      )
+    );
+    console.error("");
+    console.error(
+      `Reserved names: ${Array.from(PER_CLIENT_SCOPES).sort().join(", ")}`
+    );
+    console.error("");
+    console.error("Pick a different name, e.g.:");
+    console.error(`  mcp-use client connect my-${sessionName} ${target}`);
+    await cleanupAndExit(1);
+  }
+
   try {
     const client = new MCPClient();
     let session: MCPSession;

--- a/libraries/typescript/packages/cli/src/commands/deployments.ts
+++ b/libraries/typescript/packages/cli/src/commands/deployments.ts
@@ -524,9 +524,11 @@ async function startDeploymentCommand(deploymentId: string): Promise<void> {
 }
 
 export function createDeploymentsCommand(): Command {
-  const deploymentsCommand = new Command("deployments").description(
-    "Manage cloud deployments"
-  );
+  const deploymentsCommand = new Command("deployments")
+    .description("Manage cloud deployments")
+    .showHelpAfterError(
+      "(Run `mcp-use deployments --help` to see available commands)"
+    );
 
   deploymentsCommand
     .command("list")

--- a/libraries/typescript/packages/cli/src/commands/env.ts
+++ b/libraries/typescript/packages/cli/src/commands/env.ts
@@ -193,9 +193,9 @@ async function removeEnvCommand(
 }
 
 export function createEnvCommand(): Command {
-  const envCommand = new Command("env").description(
-    "Manage environment variables for a server"
-  );
+  const envCommand = new Command("env")
+    .description("Manage environment variables for a server")
+    .showHelpAfterError("(Run `mcp-use env --help` to see available commands)");
 
   envCommand
     .command("list")

--- a/libraries/typescript/packages/cli/src/commands/screenshot.ts
+++ b/libraries/typescript/packages/cli/src/commands/screenshot.ts
@@ -372,9 +372,8 @@ const AD_HOC_SESSION_NAME = "__screenshot_ad_hoc__";
  * Resolve an authenticated MCPSession for the screenshot run.
  *
  * Resolution order:
- *  1. `--session <name>` → restore that named session (errors if not found)
+ *  1. `--session <name>` → restore that named client (errors if not found)
  *  2. `--mcp <url>` → open an unauthenticated ad-hoc session at that URL
- *  3. otherwise → restore the active saved session (errors if none)
  */
 async function resolveSessionForScreenshot(
   options: ScreenshotOptions
@@ -401,8 +400,12 @@ async function resolveSessionForScreenshot(
     }
   }
 
-  const result = await getOrRestoreSession(null);
-  return result?.session ?? null;
+  console.error(
+    formatError(
+      "No MCP target. Pass --session <name> (a saved client) or --mcp <url> (ad-hoc)."
+    )
+  );
+  return null;
 }
 
 export async function screenshotCommand(
@@ -547,11 +550,11 @@ export function createScreenshotCommand(): Command {
     )
     .option(
       "--session <name>",
-      "Saved session name (from `mcp-use client connect`). Defaults to the active session."
+      "Saved client name (from `mcp-use client connect <name> <url>`)."
     )
     .option(
       "--mcp <url>",
-      "Ad-hoc MCP server URL (escape hatch). Used only when no --session and no active saved session. No authentication."
+      "Ad-hoc MCP server URL (escape hatch). Use when you don't have a saved client. No authentication."
     )
     .option(
       "--theme <light|dark>",

--- a/libraries/typescript/packages/cli/src/commands/screenshot.ts
+++ b/libraries/typescript/packages/cli/src/commands/screenshot.ts
@@ -372,7 +372,7 @@ const AD_HOC_SESSION_NAME = "__screenshot_ad_hoc__";
  * Resolve an authenticated MCPSession for the screenshot run.
  *
  * Resolution order:
- *  1. `--session <name>` → restore that named client (errors if not found)
+ *  1. `--session <name>` → restore that saved server (errors if not found)
  *  2. `--mcp <url>` → open an unauthenticated ad-hoc session at that URL
  */
 async function resolveSessionForScreenshot(
@@ -402,7 +402,7 @@ async function resolveSessionForScreenshot(
 
   console.error(
     formatError(
-      "No MCP target. Pass --session <name> (a saved client) or --mcp <url> (ad-hoc)."
+      "No MCP target. Pass --session <name> (a saved server) or --mcp <url> (ad-hoc)."
     )
   );
   return null;
@@ -550,11 +550,11 @@ export function createScreenshotCommand(): Command {
     )
     .option(
       "--session <name>",
-      "Saved client name (from `mcp-use client connect <name> <url>`)."
+      "Saved server name (from `mcp-use client connect <name> <url>`)."
     )
     .option(
       "--mcp <url>",
-      "Ad-hoc MCP server URL (escape hatch). Use when you don't have a saved client. No authentication."
+      "Ad-hoc MCP server URL (escape hatch). Use when you don't have a saved server. No authentication."
     )
     .option(
       "--theme <light|dark>",

--- a/libraries/typescript/packages/cli/src/commands/servers.ts
+++ b/libraries/typescript/packages/cli/src/commands/servers.ts
@@ -318,9 +318,11 @@ async function deleteServerCommand(
 }
 
 export function createServersCommand(): Command {
-  const serversCommand = new Command("servers").description(
-    "Manage cloud servers (Git-backed deploy targets)"
-  );
+  const serversCommand = new Command("servers")
+    .description("Manage cloud servers (Git-backed deploy targets)")
+    .showHelpAfterError(
+      "(Run `mcp-use servers --help` to see available commands)"
+    );
 
   serversCommand
     .command("list")

--- a/libraries/typescript/packages/cli/src/commands/skills.ts
+++ b/libraries/typescript/packages/cli/src/commands/skills.ts
@@ -107,9 +107,11 @@ async function addSkillsToProject(projectPath: string): Promise<void> {
 }
 
 export function createSkillsCommand(): Command {
-  const skills = new Command("skills").description(
-    "Manage mcp-use AI agent skills"
-  );
+  const skills = new Command("skills")
+    .description("Manage mcp-use AI agent skills")
+    .showHelpAfterError(
+      "(Run `mcp-use skills --help` to see available commands)"
+    );
 
   const installAction = async (options: { path: string }) => {
     const projectPath = resolve(options.path);

--- a/libraries/typescript/packages/cli/src/index.ts
+++ b/libraries/typescript/packages/cli/src/index.ts
@@ -18,6 +18,7 @@ import {
   createClientCommand,
   createPerClientCommand,
 } from "./commands/client.js";
+import { getSession } from "./utils/session-storage.js";
 import { createScreenshotCommand } from "./commands/screenshot.js";
 import { deployCommand } from "./commands/deploy.js";
 import { createDeploymentsCommand } from "./commands/deployments.js";
@@ -3128,12 +3129,12 @@ program.hook("preAction", async (_thisCommand, actionCommand) => {
 });
 
 /**
- * Per-client routing for `mcp-use client <name> ...`.
+ * Per-server routing for `mcp-use client <name> ...`.
  *
  * Commander doesn't natively dispatch on a dynamic positional that precedes a
  * subcommand group. So we intercept here: if the token after `client` isn't a
  * reserved subcommand (`connect`, `list`, `help`) or a flag, treat it as a
- * client name and parse the remainder against a per-client command tree.
+ * saved-server name and parse the remainder against a per-server command tree.
  */
 const argv = process.argv;
 const clientIdx = argv.indexOf("client", 2);
@@ -3147,26 +3148,52 @@ const perClientName =
 
 if (perClientName) {
   // Catch a common mistake: user typed `mcp-use client tools call X` and
-  // forgot the client name. Commander would otherwise route this as if
-  // "tools" were the client name and complain about an unknown command.
+  // forgot the server name. Commander would otherwise route this as if
+  // "tools" were the server name and complain about an unknown command.
   if (PER_CLIENT_SCOPES.has(perClientName)) {
     const rest = argv.slice(clientIdx + 1).join(" ");
-    console.error(chalk.red(`✖ Missing client name.`));
+    console.error(chalk.red(`✖ Missing server name.`));
     console.error("");
     console.error(
-      `'${perClientName}' is a per-client subcommand, not a client name. ` +
-        `Address it through a saved client:`
+      `'${perClientName}' is a per-server subcommand, not a server name. ` +
+        `Address it through a saved server:`
     );
     console.error("");
     console.error(`  mcp-use client <name> ${rest}`);
     console.error("");
-    console.error("See your saved clients with:");
+    console.error("See your saved servers with:");
     console.error("  mcp-use client list");
     process.exit(1);
   }
-  createPerClientCommand(perClientName).parseAsync(argv.slice(clientIdx + 2), {
-    from: "user",
-  });
+
+  const rest = argv.slice(clientIdx + 2);
+  // Bare `mcp-use client <name>` (or with `--help`/`-h`) defaults to
+  // commander's help for the per-server tree. That help is only useful when
+  // the server actually exists — for an unknown name it leaks the subcommand
+  // surface instead of telling the user how to save the server. Intercept
+  // the no-subcommand path and check existence first.
+  const isHelpOnly =
+    rest.length === 0 ||
+    (rest.length === 1 && (rest[0] === "--help" || rest[0] === "-h"));
+
+  (async () => {
+    if (isHelpOnly) {
+      const config = await getSession(perClientName);
+      if (!config) {
+        console.error(chalk.red(`✖ Server '${perClientName}' not found.`));
+        console.error("");
+        console.error("Connect to an MCP server and save it under this name:");
+        console.error(`  mcp-use client connect ${perClientName} <url>`);
+        console.error("");
+        console.error("See your saved servers with:");
+        console.error("  mcp-use client list");
+        process.exit(1);
+      }
+    }
+    await createPerClientCommand(perClientName).parseAsync(rest, {
+      from: "user",
+    });
+  })();
 } else {
   program.parse();
 }

--- a/libraries/typescript/packages/cli/src/index.ts
+++ b/libraries/typescript/packages/cli/src/index.ts
@@ -19,6 +19,7 @@ import {
   createPerClientCommand,
 } from "./commands/client.js";
 import { getSession } from "./utils/session-storage.js";
+import { formatError } from "./utils/format.js";
 import { createScreenshotCommand } from "./commands/screenshot.js";
 import { deployCommand } from "./commands/deploy.js";
 import { createDeploymentsCommand } from "./commands/deployments.js";
@@ -3137,7 +3138,10 @@ program.hook("preAction", async (_thisCommand, actionCommand) => {
  * saved-server name and parse the remainder against a per-server command tree.
  */
 const argv = process.argv;
-const clientIdx = argv.indexOf("client", 2);
+// `client` is only valid as a subcommand at argv[2] (node + script + first
+// user token). Don't use `indexOf`, since the literal string "client" can
+// also appear later in argv as someone's argument value.
+const clientIdx = argv[2] === "client" ? 2 : -1;
 const perClientName =
   clientIdx !== -1 &&
   argv.length > clientIdx + 1 &&
@@ -3152,7 +3156,7 @@ if (perClientName) {
   // "tools" were the server name and complain about an unknown command.
   if (PER_CLIENT_SCOPES.has(perClientName)) {
     const rest = argv.slice(clientIdx + 1).join(" ");
-    console.error(chalk.red(`✖ Missing server name.`));
+    console.error(formatError("Missing server name."));
     console.error("");
     console.error(
       `'${perClientName}' is a per-server subcommand, not a server name. ` +
@@ -3180,7 +3184,7 @@ if (perClientName) {
     if (isHelpOnly) {
       const config = await getSession(perClientName);
       if (!config) {
-        console.error(chalk.red(`✖ Server '${perClientName}' not found.`));
+        console.error(formatError(`Server '${perClientName}' not found.`));
         console.error("");
         console.error("Connect to an MCP server and save it under this name:");
         console.error(`  mcp-use client connect ${perClientName} <url>`);

--- a/libraries/typescript/packages/cli/src/index.ts
+++ b/libraries/typescript/packages/cli/src/index.ts
@@ -12,7 +12,12 @@ import open from "open";
 import { viteSingleFile } from "vite-plugin-singlefile";
 import { toJSONSchema } from "zod";
 import { loginCommand, logoutCommand, whoamiCommand } from "./commands/auth.js";
-import { createClientCommand } from "./commands/client.js";
+import {
+  PER_CLIENT_SCOPES,
+  RESERVED_CLIENT_SUBCOMMANDS,
+  createClientCommand,
+  createPerClientCommand,
+} from "./commands/client.js";
 import { createScreenshotCommand } from "./commands/screenshot.js";
 import { deployCommand } from "./commands/deploy.js";
 import { createDeploymentsCommand } from "./commands/deployments.js";
@@ -42,7 +47,8 @@ const packageVersion = packageJson.version || "unknown";
 program
   .name("mcp-use")
   .description("Create and run MCP servers with ui resources widgets")
-  .version(packageVersion);
+  .version(packageVersion)
+  .showHelpAfterError("(Run `mcp-use --help` to see available commands)");
 
 /**
  * Helper to display all package versions
@@ -3121,4 +3127,46 @@ program.hook("preAction", async (_thisCommand, actionCommand) => {
   await notifyIfUpdateAvailable(projectPath);
 });
 
-program.parse();
+/**
+ * Per-client routing for `mcp-use client <name> ...`.
+ *
+ * Commander doesn't natively dispatch on a dynamic positional that precedes a
+ * subcommand group. So we intercept here: if the token after `client` isn't a
+ * reserved subcommand (`connect`, `list`, `help`) or a flag, treat it as a
+ * client name and parse the remainder against a per-client command tree.
+ */
+const argv = process.argv;
+const clientIdx = argv.indexOf("client", 2);
+const perClientName =
+  clientIdx !== -1 &&
+  argv.length > clientIdx + 1 &&
+  !argv[clientIdx + 1].startsWith("-") &&
+  !RESERVED_CLIENT_SUBCOMMANDS.has(argv[clientIdx + 1])
+    ? argv[clientIdx + 1]
+    : null;
+
+if (perClientName) {
+  // Catch a common mistake: user typed `mcp-use client tools call X` and
+  // forgot the client name. Commander would otherwise route this as if
+  // "tools" were the client name and complain about an unknown command.
+  if (PER_CLIENT_SCOPES.has(perClientName)) {
+    const rest = argv.slice(clientIdx + 1).join(" ");
+    console.error(chalk.red(`✖ Missing client name.`));
+    console.error("");
+    console.error(
+      `'${perClientName}' is a per-client subcommand, not a client name. ` +
+        `Address it through a saved client:`
+    );
+    console.error("");
+    console.error(`  mcp-use client <name> ${rest}`);
+    console.error("");
+    console.error("See your saved clients with:");
+    console.error("  mcp-use client list");
+    process.exit(1);
+  }
+  createPerClientCommand(perClientName).parseAsync(argv.slice(clientIdx + 2), {
+    from: "user",
+  });
+} else {
+  program.parse();
+}

--- a/libraries/typescript/packages/cli/src/index.ts
+++ b/libraries/typescript/packages/cli/src/index.ts
@@ -3197,7 +3197,11 @@ if (perClientName) {
     await createPerClientCommand(perClientName).parseAsync(rest, {
       from: "user",
     });
-  })();
+  })().catch((err: unknown) => {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(formatError(message));
+    process.exit(1);
+  });
 } else {
   program.parse();
 }

--- a/libraries/typescript/packages/cli/src/utils/format.ts
+++ b/libraries/typescript/packages/cli/src/utils/format.ts
@@ -188,9 +188,13 @@ export function formatJson(data: any, pretty = true): string {
 export function formatToolCall(result: CallToolResult): string {
   const lines: string[] = [];
   const { isError, structuredContent } = result;
-  const hasContent = !!result.content?.length;
   const hasStructured =
     structuredContent !== undefined && structuredContent !== null;
+  // Per MCP spec, when a tool returns structuredContent it SHOULD also serialize
+  // the same JSON into a TextContent block for backwards compatibility. Treat
+  // structuredContent as the canonical form and skip the content blocks in
+  // that case so we don't print the same payload twice.
+  const showContent = !hasStructured && !!result.content?.length;
 
   if (isError) {
     lines.push(chalk.red("✗ Tool execution failed"));
@@ -200,7 +204,7 @@ export function formatToolCall(result: CallToolResult): string {
     lines.push("");
   }
 
-  if (hasContent) {
+  if (showContent) {
     if (isError) {
       lines.push(chalk.red.bold("Error details:"));
     }
@@ -235,14 +239,13 @@ export function formatToolCall(result: CallToolResult): string {
   }
 
   if (hasStructured) {
-    if (hasContent) lines.push("");
-    lines.push(
-      chalk.bold(isError ? "Structured error data:" : "Structured content:")
-    );
+    if (isError) {
+      lines.push(chalk.bold("Structured error data:"));
+    }
     lines.push(formatJson(structuredContent));
   }
 
-  if (isError && !hasContent && !hasStructured) {
+  if (isError && !showContent && !hasStructured) {
     lines.push(chalk.gray("(no error details provided by server)"));
   }
 

--- a/libraries/typescript/packages/cli/src/utils/format.ts
+++ b/libraries/typescript/packages/cli/src/utils/format.ts
@@ -190,11 +190,16 @@ export function formatToolCall(result: CallToolResult): string {
   const { isError, structuredContent } = result;
   const hasStructured =
     structuredContent !== undefined && structuredContent !== null;
-  // Per MCP spec, when a tool returns structuredContent it SHOULD also serialize
-  // the same JSON into a TextContent block for backwards compatibility. Treat
-  // structuredContent as the canonical form and skip the content blocks in
-  // that case so we don't print the same payload twice.
-  const showContent = !hasStructured && !!result.content?.length;
+  // Per MCP spec, when a tool returns structuredContent it SHOULD also
+  // serialize the same JSON into a TextContent block for backwards
+  // compatibility. Treat structuredContent as canonical and drop the text
+  // duplicate. Non-text blocks (image/resource markers) are kept — they carry
+  // information the structured payload doesn't, even though the terminal can
+  // only render them as placeholders.
+  const visibleContent = (result.content ?? []).filter(
+    (item) => !hasStructured || item.type !== "text"
+  );
+  const hasVisibleContent = visibleContent.length > 0;
 
   if (isError) {
     lines.push(chalk.red("✗ Tool execution failed"));
@@ -204,12 +209,12 @@ export function formatToolCall(result: CallToolResult): string {
     lines.push("");
   }
 
-  if (showContent) {
+  if (hasVisibleContent) {
     if (isError) {
       lines.push(chalk.red.bold("Error details:"));
     }
-    result.content.forEach((item, index) => {
-      if (result.content.length > 1) {
+    visibleContent.forEach((item, index) => {
+      if (visibleContent.length > 1) {
         lines.push(chalk.bold(`Content ${index + 1}:`));
       }
 
@@ -232,7 +237,7 @@ export function formatToolCall(result: CallToolResult): string {
         lines.push(chalk.gray(`[Unknown content type: ${item.type}]`));
       }
 
-      if (index < result.content.length - 1) {
+      if (index < visibleContent.length - 1) {
         lines.push("");
       }
     });
@@ -245,7 +250,7 @@ export function formatToolCall(result: CallToolResult): string {
     lines.push(formatJson(structuredContent));
   }
 
-  if (isError && !showContent && !hasStructured) {
+  if (isError && !hasVisibleContent && !hasStructured) {
     lines.push(chalk.gray("(no error details provided by server)"));
   }
 

--- a/libraries/typescript/packages/cli/src/utils/oauth.ts
+++ b/libraries/typescript/packages/cli/src/utils/oauth.ts
@@ -8,13 +8,10 @@ import {
 import { createInterface } from "node:readline";
 
 /**
- * Build a NodeOAuthClientProvider that opens the user's browser via the
- * `open` package (already a CLI dependency, bundled via tsup).
- *
- * In non-TTY contexts (piped output, agents, CI) we don't auto-open a browser
- * — instead we print the authorization URL so the caller can surface it to a
- * human or open it themselves. This avoids surprising browser launches when
- * an LLM agent invokes the CLI.
+ * Build a NodeOAuthClientProvider that prints the authorization URL for the
+ * user to open themselves. We never auto-launch a browser from the CLI — a
+ * surprise window when an agent or script invokes `mcp-use` is worse than the
+ * extra click for an interactive user.
  */
 export async function buildOAuthProvider(
   serverUrl: string,
@@ -26,20 +23,15 @@ export async function buildOAuthProvider(
     storageKeyPrefix: "mcp:auth",
     ...options,
     openBrowser: async (url) => {
-      if (!process.stdout.isTTY) {
-        console.error(`\n  Open this URL in a browser to authenticate:`);
-        console.error(`  ${url}\n`);
-        return;
-      }
-      const { default: open } = await import("open");
-      await open(url);
+      console.error(`\n  Open this URL in a browser to authenticate:`);
+      console.error(`  ${url}\n`);
     },
   });
 }
 
 /**
  * Run the full two-call OAuth dance:
- *   1. auth() → triggers redirectToAuthorization (opens browser, binds loopback)
+ *   1. auth() → triggers redirectToAuthorization (prints URL, binds loopback)
  *   2. await provider.getAuthorizationCode()
  *   3. auth() with the code → exchanges for tokens, persists via FileKVStore
  *
@@ -50,11 +42,7 @@ export async function runOAuthFlow(
   serverUrl: string,
   print: (line: string) => void = console.error.bind(console)
 ): Promise<void> {
-  print(
-    process.stdout.isTTY
-      ? `→ Opening browser to authenticate...`
-      : `→ OAuth authentication required.`
-  );
+  print(`→ OAuth authentication required.`);
   print(
     `  Listening on http://127.0.0.1:${provider.callbackPort}/callback (waiting up to 5m)`
   );

--- a/libraries/typescript/packages/cli/src/utils/session-storage.ts
+++ b/libraries/typescript/packages/cli/src/utils/session-storage.ts
@@ -27,15 +27,11 @@ export interface SessionConfig {
 }
 
 export interface SessionStorage {
-  activeSession: string | null;
   sessions: Record<string, SessionConfig>;
 }
 
 const SESSION_FILE_PATH = join(homedir(), ".mcp-use", "cli-sessions.json");
 
-/**
- * Ensure the session storage directory exists
- */
 async function ensureSessionDir(): Promise<void> {
   const dir = join(homedir(), ".mcp-use");
   if (!existsSync(dir)) {
@@ -44,35 +40,33 @@ async function ensureSessionDir(): Promise<void> {
 }
 
 /**
- * Load persisted sessions from disk
+ * Load persisted clients from disk.
+ *
+ * Tolerates older files that include an `activeSession` field — the field is
+ * silently dropped. The CLI no longer tracks an active client; every command
+ * names its target explicitly.
  */
 export async function loadSessions(): Promise<SessionStorage> {
   try {
     await ensureSessionDir();
 
     if (!existsSync(SESSION_FILE_PATH)) {
-      return { activeSession: null, sessions: {} };
+      return { sessions: {} };
     }
 
     const content = await readFile(SESSION_FILE_PATH, "utf-8");
-    return JSON.parse(content);
-  } catch (error) {
-    // If file doesn't exist or is invalid, return empty storage
-    return { activeSession: null, sessions: {} };
+    const parsed = JSON.parse(content);
+    return { sessions: parsed?.sessions ?? {} };
+  } catch {
+    return { sessions: {} };
   }
 }
 
-/**
- * Save sessions to disk
- */
 async function saveSessions(storage: SessionStorage): Promise<void> {
   await ensureSessionDir();
   await writeFile(SESSION_FILE_PATH, JSON.stringify(storage, null, 2), "utf-8");
 }
 
-/**
- * Save or update a session configuration
- */
 export async function saveSession(
   name: string,
   config: SessionConfig
@@ -82,100 +76,30 @@ export async function saveSession(
     ...config,
     lastUsed: new Date().toISOString(),
   };
-
-  // Set as active session if no active session exists
-  if (!storage.activeSession) {
-    storage.activeSession = name;
-  }
-
   await saveSessions(storage);
 }
 
-/**
- * Remove a session from storage
- */
 export async function removeSession(name: string): Promise<void> {
   const storage = await loadSessions();
   delete storage.sessions[name];
-
-  // Clear active session if it was the one removed
-  if (storage.activeSession === name) {
-    // Set to first available session or null
-    const sessionNames = Object.keys(storage.sessions);
-    storage.activeSession = sessionNames.length > 0 ? sessionNames[0] : null;
-  }
-
   await saveSessions(storage);
 }
 
-/**
- * Get the currently active session name
- */
-export async function getActiveSessionName(): Promise<string | null> {
-  const storage = await loadSessions();
-  return storage.activeSession;
-}
-
-/**
- * Get the active session configuration
- */
-export async function getActiveSession(): Promise<{
-  name: string;
-  config: SessionConfig;
-} | null> {
-  const storage = await loadSessions();
-  if (!storage.activeSession || !storage.sessions[storage.activeSession]) {
-    return null;
-  }
-
-  return {
-    name: storage.activeSession,
-    config: storage.sessions[storage.activeSession],
-  };
-}
-
-/**
- * Get a specific session configuration by name
- */
 export async function getSession(name: string): Promise<SessionConfig | null> {
   const storage = await loadSessions();
   return storage.sessions[name] || null;
 }
 
-/**
- * Set the active session
- */
-export async function setActiveSession(name: string): Promise<void> {
-  const storage = await loadSessions();
-
-  if (!storage.sessions[name]) {
-    throw new Error(`Session '${name}' not found`);
-  }
-
-  storage.activeSession = name;
-  storage.sessions[name].lastUsed = new Date().toISOString();
-
-  await saveSessions(storage);
-}
-
-/**
- * List all stored sessions
- */
 export async function listAllSessions(): Promise<
-  Array<{ name: string; config: SessionConfig; isActive: boolean }>
+  Array<{ name: string; config: SessionConfig }>
 > {
   const storage = await loadSessions();
-
   return Object.entries(storage.sessions).map(([name, config]) => ({
     name,
     config,
-    isActive: name === storage.activeSession,
   }));
 }
 
-/**
- * Update session info after connection
- */
 export async function updateSessionInfo(
   name: string,
   serverInfo: { name: string; version?: string },

--- a/libraries/typescript/packages/cli/src/utils/session-storage.ts
+++ b/libraries/typescript/packages/cli/src/utils/session-storage.ts
@@ -40,10 +40,10 @@ async function ensureSessionDir(): Promise<void> {
 }
 
 /**
- * Load persisted clients from disk.
+ * Load persisted servers from disk.
  *
  * Tolerates older files that include an `activeSession` field — the field is
- * silently dropped. The CLI no longer tracks an active client; every command
+ * silently dropped. The CLI no longer tracks an active server; every command
  * names its target explicitly.
  */
 export async function loadSessions(): Promise<SessionStorage> {

--- a/libraries/typescript/packages/cli/src/utils/session-storage.ts
+++ b/libraries/typescript/packages/cli/src/utils/session-storage.ts
@@ -32,11 +32,13 @@ export interface SessionStorage {
 
 const SESSION_FILE_PATH = join(homedir(), ".mcp-use", "cli-sessions.json");
 
+let _dirEnsured = false;
 async function ensureSessionDir(): Promise<void> {
-  const dir = join(homedir(), ".mcp-use");
-  if (!existsSync(dir)) {
-    await mkdir(dir, { recursive: true });
-  }
+  if (_dirEnsured) return;
+  // `mkdir({ recursive: true })` is a no-op when the dir already exists, so
+  // we don't need a separate `existsSync` check.
+  await mkdir(join(homedir(), ".mcp-use"), { recursive: true });
+  _dirEnsured = true;
 }
 
 /**

--- a/libraries/typescript/packages/cli/src/utils/session.ts
+++ b/libraries/typescript/packages/cli/src/utils/session.ts
@@ -147,7 +147,7 @@ export async function getOrRestoreSession(
     activeSessions.set(sessionName, { client, session });
     return { name: sessionName, session };
   } catch (error: any) {
-    console.error(formatError(`Failed to restore client: ${error.message}`));
+    console.error(formatError(`Failed to restore server: ${error.message}`));
     return null;
   }
 }

--- a/libraries/typescript/packages/cli/src/utils/session.ts
+++ b/libraries/typescript/packages/cli/src/utils/session.ts
@@ -9,7 +9,7 @@ import {
   promptYesNo,
   runOAuthFlow,
 } from "./oauth.js";
-import { getActiveSession, getSession } from "./session-storage.js";
+import { getSession } from "./session-storage.js";
 
 export const activeSessions = new Map<
   string,
@@ -57,24 +57,12 @@ export async function cleanupAndExit(code: number): Promise<never> {
  * Get or restore a session by name. For OAuth-mode sessions whose tokens
  * have expired and can't be refreshed, prompts to re-auth on TTY or prints
  * a clear `connect` command to re-run on non-TTY.
+ *
+ * `sessionName` is required — there is no implicit "active" client.
  */
 export async function getOrRestoreSession(
-  sessionName: string | null
+  sessionName: string
 ): Promise<{ name: string; session: MCPSession } | null> {
-  if (!sessionName) {
-    const active = await getActiveSession();
-    if (!active) {
-      console.error(
-        formatError("No active session. Connect to a server first.")
-      );
-      console.error(
-        formatInfo("Use: npx mcp-use client connect <url> --name <name>")
-      );
-      return null;
-    }
-    sessionName = active.name;
-  }
-
   if (activeSessions.has(sessionName)) {
     const { session } = activeSessions.get(sessionName)!;
     return { name: sessionName, session };
@@ -82,7 +70,12 @@ export async function getOrRestoreSession(
 
   const config = await getSession(sessionName);
   if (!config) {
-    console.error(formatError(`Session '${sessionName}' not found`));
+    console.error(formatError(`Client '${sessionName}' not found`));
+    console.error(
+      formatInfo(
+        `Connect with: npx mcp-use client connect ${sessionName} <url>`
+      )
+    );
     return null;
   }
 
@@ -132,14 +125,14 @@ export async function getOrRestoreSession(
         isUnauthorized(err)
       ) {
         const reAuth = await promptYesNo(
-          `! Tokens for session '${sessionName}' expired and could not refresh. Re-authenticate now?`,
+          `! Tokens for client '${sessionName}' expired and could not refresh. Re-authenticate now?`,
           true
         );
         if (!reAuth) {
           console.error(formatError(`Tokens expired and could not refresh.`));
           console.error(
             formatInfo(
-              `Run: mcp-use client connect ${config.url} --name ${sessionName}`
+              `Run: mcp-use client connect ${sessionName} ${config.url}`
             )
           );
           return null;
@@ -152,10 +145,9 @@ export async function getOrRestoreSession(
     }
 
     activeSessions.set(sessionName, { client, session });
-    console.error(formatInfo(`Reconnected to session '${sessionName}'`));
     return { name: sessionName, session };
   } catch (error: any) {
-    console.error(formatError(`Failed to restore session: ${error.message}`));
+    console.error(formatError(`Failed to restore client: ${error.message}`));
     return null;
   }
 }

--- a/libraries/typescript/packages/cli/src/utils/session.ts
+++ b/libraries/typescript/packages/cli/src/utils/session.ts
@@ -58,7 +58,7 @@ export async function cleanupAndExit(code: number): Promise<never> {
  * have expired and can't be refreshed, prompts to re-auth on TTY or prints
  * a clear `connect` command to re-run on non-TTY.
  *
- * `sessionName` is required — there is no implicit "active" client.
+ * `sessionName` is required — there is no implicit "active" server.
  */
 export async function getOrRestoreSession(
   sessionName: string
@@ -70,7 +70,7 @@ export async function getOrRestoreSession(
 
   const config = await getSession(sessionName);
   if (!config) {
-    console.error(formatError(`Client '${sessionName}' not found`));
+    console.error(formatError(`Server '${sessionName}' not found`));
     console.error(
       formatInfo(
         `Connect with: npx mcp-use client connect ${sessionName} <url>`
@@ -125,7 +125,7 @@ export async function getOrRestoreSession(
         isUnauthorized(err)
       ) {
         const reAuth = await promptYesNo(
-          `! Tokens for client '${sessionName}' expired and could not refresh. Re-authenticate now?`,
+          `! Tokens for server '${sessionName}' expired and could not refresh. Re-authenticate now?`,
           true
         );
         if (!reAuth) {

--- a/libraries/typescript/packages/cli/tests/cli-integration.test.ts
+++ b/libraries/typescript/packages/cli/tests/cli-integration.test.ts
@@ -178,6 +178,110 @@ describe("CLI Integration Tests", () => {
       expect(output).toMatch(/Server 'does-not-exist' not found/);
       expect(output).toContain("mcp-use client connect does-not-exist <url>");
     });
+
+    describe("remove", () => {
+      // Write the sessions file directly so we don't need a live MCP server
+      // just to test the remove path.
+      const sessionsFile = join(FAKE_HOME, ".mcp-use", "cli-sessions.json");
+
+      function writeSessions(sessions: Record<string, unknown>) {
+        mkdirSync(join(FAKE_HOME, ".mcp-use"), { recursive: true });
+        writeFileSync(
+          sessionsFile,
+          JSON.stringify({ sessions }, null, 2),
+          "utf-8"
+        );
+      }
+
+      function readSessions(): Record<string, unknown> {
+        return JSON.parse(readFileSync(sessionsFile, "utf-8")).sessions ?? {};
+      }
+
+      it("removes a saved server", async () => {
+        writeSessions({
+          "to-remove": {
+            type: "http",
+            url: "http://localhost:3000/mcp",
+            authMode: "bearer",
+            lastUsed: new Date().toISOString(),
+          },
+          keeper: {
+            type: "http",
+            url: "http://localhost:4000/mcp",
+            authMode: "bearer",
+            lastUsed: new Date().toISOString(),
+          },
+        });
+
+        const result = await runCLI(["client", "remove", "to-remove"]);
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toMatch(/Removed saved server 'to-remove'/);
+
+        const remaining = readSessions();
+        expect(remaining["to-remove"]).toBeUndefined();
+        expect(remaining["keeper"]).toBeDefined();
+      });
+
+      it("errors when the server does not exist", async () => {
+        writeSessions({});
+
+        const result = await runCLI(["client", "remove", "ghost"]);
+
+        expect(result.exitCode).toBe(1);
+        const output = result.stdout + result.stderr;
+        expect(output).toMatch(/Server 'ghost' not found/);
+        expect(output).toContain("mcp-use client list");
+      });
+
+      it("clears OAuth tokens when no other saved server uses the URL", async () => {
+        writeSessions({
+          "oauth-srv": {
+            type: "http",
+            url: "https://example.com/mcp",
+            authMode: "oauth",
+            lastUsed: new Date().toISOString(),
+          },
+        });
+
+        const result = await runCLI(["client", "remove", "oauth-srv"]);
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toMatch(/Removed saved server 'oauth-srv'/);
+        expect(result.stdout).toMatch(
+          /Removed OAuth tokens for https:\/\/example\.com\/mcp/
+        );
+        expect(readSessions()["oauth-srv"]).toBeUndefined();
+      });
+
+      it("keeps OAuth tokens when another saved server shares the URL", async () => {
+        writeSessions({
+          "oauth-srv": {
+            type: "http",
+            url: "https://example.com/mcp",
+            authMode: "oauth",
+            lastUsed: new Date().toISOString(),
+          },
+          "oauth-backup": {
+            type: "http",
+            url: "https://example.com/mcp",
+            authMode: "oauth",
+            lastUsed: new Date().toISOString(),
+          },
+        });
+
+        const result = await runCLI(["client", "remove", "oauth-srv"]);
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toMatch(/Removed saved server 'oauth-srv'/);
+        expect(result.stdout).toMatch(
+          /OAuth tokens .* were kept because saved server 'oauth-backup' still uses that URL/
+        );
+        const remaining = readSessions();
+        expect(remaining["oauth-srv"]).toBeUndefined();
+        expect(remaining["oauth-backup"]).toBeDefined();
+      });
+    });
   });
 
   describe("Connection", () => {

--- a/libraries/typescript/packages/cli/tests/cli-integration.test.ts
+++ b/libraries/typescript/packages/cli/tests/cli-integration.test.ts
@@ -90,14 +90,11 @@ describe("CLI Integration Tests", () => {
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain("Interactive MCP client");
       expect(result.stdout).toContain("connect");
-      expect(result.stdout).toContain("tools");
-      expect(result.stdout).toContain("resources");
-      expect(result.stdout).toContain("prompts");
-      expect(result.stdout).toContain("sessions");
+      expect(result.stdout).toContain("list");
     });
 
-    it("should show tools help", async () => {
-      const result = await runCLI(["client", "tools", "--help"]);
+    it("should show per-client tools help", async () => {
+      const result = await runCLI(["client", "ci-test", "tools", "--help"]);
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain("Interact with MCP tools");
@@ -106,8 +103,8 @@ describe("CLI Integration Tests", () => {
       expect(result.stdout).toContain("describe");
     });
 
-    it("should show resources help", async () => {
-      const result = await runCLI(["client", "resources", "--help"]);
+    it("should show per-client resources help", async () => {
+      const result = await runCLI(["client", "ci-test", "resources", "--help"]);
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain("Interact with MCP resources");
@@ -117,42 +114,37 @@ describe("CLI Integration Tests", () => {
       expect(result.stdout).toContain("unsubscribe");
     });
 
-    it("should show prompts help", async () => {
-      const result = await runCLI(["client", "prompts", "--help"]);
+    it("should show per-client prompts help", async () => {
+      const result = await runCLI(["client", "ci-test", "prompts", "--help"]);
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain("Interact with MCP prompts");
       expect(result.stdout).toContain("list");
       expect(result.stdout).toContain("get");
     });
-
-    it("should show sessions help", async () => {
-      const result = await runCLI(["client", "sessions", "--help"]);
-
-      expect(result.exitCode).toBe(0);
-      expect(result.stdout).toContain("Manage CLI sessions");
-      expect(result.stdout).toContain("list");
-      expect(result.stdout).toContain("switch");
-    });
   });
 
-  describe("Session Management", () => {
-    it("should list sessions when none exist", async () => {
-      const result = await runCLI(["client", "sessions", "list"]);
+  describe("Client Management", () => {
+    it("should list clients when none exist", async () => {
+      const result = await runCLI(["client", "list"]);
 
       // Non-TTY (piped) stdout: gh-style empty output, just a clean exit.
-      // Decorative "No saved sessions" message is suppressed for agents/scripts.
+      // Decorative "No saved clients" message is suppressed for agents/scripts.
       expect(result.exitCode).toBe(0);
       expect(result.stdout.trim()).toBe("");
     });
 
-    it("should show error when no active session for tools list", async () => {
-      const result = await runCLI(["client", "tools", "list"]);
+    it("should error when invoking tools on an unknown client", async () => {
+      const result = await runCLI([
+        "client",
+        "does-not-exist",
+        "tools",
+        "list",
+      ]);
 
-      // Command may exit with 0 or 1 depending on session state
-      // Just verify it mentions no session or connection error
+      expect(result.exitCode).toBe(1);
       const output = result.stdout + result.stderr;
-      expect(output).toMatch(/No active session|not found|Connection failed/i);
+      expect(output).toMatch(/not found|Connection failed/i);
     });
   });
 
@@ -161,9 +153,8 @@ describe("CLI Integration Tests", () => {
       const result = await runCLI([
         "client",
         "connect",
-        "http://invalid-host-12345.local:9999/mcp",
-        "--name",
         "test-invalid",
+        "http://invalid-host-12345.local:9999/mcp",
       ]);
 
       expect(result.exitCode).toBe(1);
@@ -174,24 +165,7 @@ describe("CLI Integration Tests", () => {
     // These tests would be better suited for e2e tests
   });
 
-  describe("Output Formats", () => {
-    it("should support --json flag for sessions list", async () => {
-      // Note: This would need sessions to exist
-      const result = await runCLI(["client", "sessions", "list", "--json"]);
-
-      // Command may work with or without --json flag depending on implementation
-      // Just verify it doesn't crash
-      expect([0, 1]).toContain(result.exitCode);
-    });
-  });
-
   describe("Error Handling", () => {
-    it("should show error for invalid command", async () => {
-      const result = await runCLI(["client", "invalid-command"]);
-
-      expect(result.exitCode).not.toBe(0);
-    });
-
     it("should show error for missing required arguments", async () => {
       const result = await runCLI(["client", "connect"]);
 
@@ -200,18 +174,42 @@ describe("CLI Integration Tests", () => {
       expect(output).toMatch(/error/i);
     });
 
-    it("should handle invalid JSON in tool call", async () => {
-      // This would need an active session, but we can test the command structure
+    it("should error when connect is missing the url positional", async () => {
+      const result = await runCLI(["client", "connect", "only-name"]);
+
+      expect(result.exitCode).not.toBe(0);
+      const output = result.stderr + result.stdout;
+      expect(output).toMatch(/error/i);
+      expect(output).toMatch(/Missing <url>/i);
+      expect(output).toContain("mcp-use client connect only-name <url>");
+    });
+
+    it("should explain that a name is needed when only a URL is provided", async () => {
       const result = await runCLI([
         "client",
+        "connect",
+        "https://mcp.example.com/mcp",
+      ]);
+
+      expect(result.exitCode).not.toBe(0);
+      const output = result.stderr + result.stdout;
+      expect(output).toMatch(/Missing client name/i);
+      expect(output).toContain("https://mcp.example.com/mcp");
+      expect(output).toMatch(/mcp-use client connect <name>/i);
+    });
+
+    it("should handle invalid JSON in tool call", async () => {
+      // Goes through the per-client routing even though the client doesn't
+      // exist — just verifies the command structure parses.
+      const result = await runCLI([
+        "client",
+        "ci-test",
         "tools",
         "call",
         "test_tool",
         "invalid-json",
       ]);
 
-      // May fail for various reasons (no session, invalid JSON, etc.)
-      // Just verify command doesn't crash
       const output = result.stdout + result.stderr;
       expect(output.length).toBeGreaterThan(0);
     });
@@ -219,19 +217,16 @@ describe("CLI Integration Tests", () => {
 
   describe("Stdio Server Connection", () => {
     it("should accept stdio flag syntax", async () => {
-      // This will fail without the actual server, but tests argument parsing
       const result = await runCLI([
         "client",
         "connect",
-        "--stdio",
-        "echo test",
-        "--name",
         "stdio-test",
+        "echo test",
+        "--stdio",
       ]);
 
-      // Will fail to connect but should parse arguments correctly
+      // Will fail to connect but should parse arguments correctly.
       expect(result.exitCode).toBe(1);
-      // The error should be about connection, not argument parsing
       expect(result.stderr).not.toContain("Unknown option");
     });
   });

--- a/libraries/typescript/packages/cli/tests/cli-integration.test.ts
+++ b/libraries/typescript/packages/cli/tests/cli-integration.test.ts
@@ -163,9 +163,7 @@ describe("CLI Integration Tests", () => {
       expect(result.exitCode).toBe(1);
       const output = result.stdout + result.stderr;
       expect(output).toMatch(/Server 'does-not-exist' not found/);
-      expect(output).toContain(
-        "mcp-use client connect does-not-exist <url>"
-      );
+      expect(output).toContain("mcp-use client connect does-not-exist <url>");
       // The per-server commander help leaks subcommand names like "tools",
       // "resources", "prompts" — make sure we suppressed it for an unknown
       // server. ("Commands:" is commander's help section header.)
@@ -178,9 +176,7 @@ describe("CLI Integration Tests", () => {
       expect(result.exitCode).toBe(1);
       const output = result.stdout + result.stderr;
       expect(output).toMatch(/Server 'does-not-exist' not found/);
-      expect(output).toContain(
-        "mcp-use client connect does-not-exist <url>"
-      );
+      expect(output).toContain("mcp-use client connect does-not-exist <url>");
     });
   });
 

--- a/libraries/typescript/packages/cli/tests/cli-integration.test.ts
+++ b/libraries/typescript/packages/cli/tests/cli-integration.test.ts
@@ -18,6 +18,10 @@ import { tmpdir } from "node:os";
 const CLI_PATH = join(__dirname, "../dist/index.cjs");
 const TEST_TIMEOUT = 30000;
 
+// Isolated HOME so spawned CLI subprocesses never read or write the real
+// ~/.mcp-use directory while tests run.
+const FAKE_HOME = mkdtempSync(join(tmpdir(), "mcp-cli-home-"));
+
 /**
  * Run a CLI command and capture output
  */
@@ -27,7 +31,12 @@ async function runCLI(
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   return new Promise((resolve, reject) => {
     const proc = spawn("node", [CLI_PATH, ...args], {
-      env: { ...process.env, NO_COLOR: "1" }, // Disable colors for easier testing
+      env: {
+        ...process.env,
+        NO_COLOR: "1", // Disable colors for easier testing
+        HOME: FAKE_HOME,
+        USERPROFILE: FAKE_HOME,
+      },
     });
 
     let stdout = "";
@@ -81,6 +90,7 @@ describe("CLI Integration Tests", () => {
     if (testDir) {
       rmSync(testDir, { recursive: true, force: true });
     }
+    rmSync(FAKE_HOME, { recursive: true, force: true });
   });
 
   describe("Help Commands", () => {

--- a/libraries/typescript/packages/cli/tests/cli-integration.test.ts
+++ b/libraries/typescript/packages/cli/tests/cli-integration.test.ts
@@ -134,17 +134,17 @@ describe("CLI Integration Tests", () => {
     });
   });
 
-  describe("Client Management", () => {
-    it("should list clients when none exist", async () => {
+  describe("Server Management", () => {
+    it("should list servers when none exist", async () => {
       const result = await runCLI(["client", "list"]);
 
       // Non-TTY (piped) stdout: gh-style empty output, just a clean exit.
-      // Decorative "No saved clients" message is suppressed for agents/scripts.
+      // Decorative "No saved servers" message is suppressed for agents/scripts.
       expect(result.exitCode).toBe(0);
       expect(result.stdout.trim()).toBe("");
     });
 
-    it("should error when invoking tools on an unknown client", async () => {
+    it("should error when invoking tools on an unknown server", async () => {
       const result = await runCLI([
         "client",
         "does-not-exist",
@@ -155,6 +155,32 @@ describe("CLI Integration Tests", () => {
       expect(result.exitCode).toBe(1);
       const output = result.stdout + result.stderr;
       expect(output).toMatch(/not found|Connection failed/i);
+    });
+
+    it("should suggest connect when bare `client <name>` targets an unknown server", async () => {
+      const result = await runCLI(["client", "does-not-exist"]);
+
+      expect(result.exitCode).toBe(1);
+      const output = result.stdout + result.stderr;
+      expect(output).toMatch(/Server 'does-not-exist' not found/);
+      expect(output).toContain(
+        "mcp-use client connect does-not-exist <url>"
+      );
+      // The per-server commander help leaks subcommand names like "tools",
+      // "resources", "prompts" — make sure we suppressed it for an unknown
+      // server. ("Commands:" is commander's help section header.)
+      expect(output).not.toMatch(/^Commands:/m);
+    });
+
+    it("should also suggest connect when `client <name> --help` targets an unknown server", async () => {
+      const result = await runCLI(["client", "does-not-exist", "--help"]);
+
+      expect(result.exitCode).toBe(1);
+      const output = result.stdout + result.stderr;
+      expect(output).toMatch(/Server 'does-not-exist' not found/);
+      expect(output).toContain(
+        "mcp-use client connect does-not-exist <url>"
+      );
     });
   });
 
@@ -203,13 +229,13 @@ describe("CLI Integration Tests", () => {
 
       expect(result.exitCode).not.toBe(0);
       const output = result.stderr + result.stdout;
-      expect(output).toMatch(/Missing client name/i);
+      expect(output).toMatch(/Missing server name/i);
       expect(output).toContain("https://mcp.example.com/mcp");
       expect(output).toMatch(/mcp-use client connect <name>/i);
     });
 
     it("should handle invalid JSON in tool call", async () => {
-      // Goes through the per-client routing even though the client doesn't
+      // Goes through the per-server routing even though the server doesn't
       // exist — just verifies the command structure parses.
       const result = await runCLI([
         "client",

--- a/libraries/typescript/packages/cli/tests/format.test.ts
+++ b/libraries/typescript/packages/cli/tests/format.test.ts
@@ -216,9 +216,11 @@ describe("Format Utilities", () => {
       expect(formatted).toContain("no error details provided by server");
     });
 
-    it("should include structuredContent on failure", () => {
+    it("should prefer structuredContent over text content on failure", () => {
       const result = {
-        content: [{ type: "text", text: "Boom" }],
+        content: [
+          { type: "text", text: '{"code":"E_FAIL","retryable":false}' },
+        ],
         isError: true,
         structuredContent: { code: "E_FAIL", retryable: false },
       } as unknown as CallToolResult;
@@ -226,23 +228,29 @@ describe("Format Utilities", () => {
       const formatted = formatToolCall(result);
 
       expect(formatted).toContain("Tool execution failed");
-      expect(formatted).toContain("Boom");
       expect(formatted).toContain("Structured error data:");
       expect(formatted).toContain("E_FAIL");
       expect(formatted).toContain("retryable");
+      // Text content is the spec-required JSON duplicate — should be suppressed
+      // so we don't print the same payload twice.
+      expect(formatted).not.toContain("Error details:");
     });
 
-    it("should include structuredContent on success", () => {
+    it("should prefer structuredContent over text content on success", () => {
       const result = {
-        content: [{ type: "text", text: "ok" }],
+        content: [{ type: "text", text: '{"items":3}' }],
         isError: false,
         structuredContent: { items: 3 },
       } as unknown as CallToolResult;
 
       const formatted = formatToolCall(result);
 
-      expect(formatted).toContain("Structured content:");
       expect(formatted).toContain("items");
+      expect(formatted).not.toContain("Structured content:");
+      // Only the structured form should appear — the text block is the JSON
+      // serialization duplicate per MCP spec.
+      const occurrences = formatted.match(/items/g) ?? [];
+      expect(occurrences.length).toBe(1);
     });
 
     it("should handle image content", () => {

--- a/libraries/typescript/packages/cli/tests/session-storage.test.ts
+++ b/libraries/typescript/packages/cli/tests/session-storage.test.ts
@@ -1,48 +1,70 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import { existsSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
+
+// Redirect ~/.mcp-use to a per-run temp dir so this test can never wipe the
+// developer's real `cli-sessions.json`. session-storage.ts derives its file
+// path from node:os.homedir(), so mocking that here is enough. vi.mock is
+// hoisted above imports, so the factory runs before session-storage loads.
+vi.mock("node:os", async (importActual) => {
+  const actual = await importActual<typeof import("node:os")>();
+  const fakeHome = actual.tmpdir
+    ? `${actual.tmpdir()}/mcp-use-cli-sessions-test-${process.pid}`
+    : `/tmp/mcp-use-cli-sessions-test-${process.pid}`;
+  return { ...actual, homedir: () => fakeHome };
+});
+
 import {
   saveSession,
   getSession,
-  getActiveSession,
-  setActiveSession,
   removeSession,
   listAllSessions,
   updateSessionInfo,
+  loadSessions,
   type SessionConfig,
 } from "../src/utils/session-storage.js";
 
-const TEST_SESSION_DIR = join(homedir(), ".mcp-use");
+const FAKE_HOME = homedir();
+const TEST_SESSION_DIR = join(FAKE_HOME, ".mcp-use");
 const TEST_SESSION_FILE = join(TEST_SESSION_DIR, "cli-sessions.json");
 
 describe("Session Storage", () => {
+  beforeAll(() => {
+    mkdirSync(TEST_SESSION_DIR, { recursive: true });
+  });
+
+  afterAll(() => {
+    rmSync(FAKE_HOME, { recursive: true, force: true });
+  });
+
   beforeEach(() => {
-    // Clean up before each test to ensure isolation
     if (existsSync(TEST_SESSION_FILE)) {
       rmSync(TEST_SESSION_FILE, { force: true });
     }
-    // Create test directory
     if (!existsSync(TEST_SESSION_DIR)) {
       mkdirSync(TEST_SESSION_DIR, { recursive: true });
     }
-    // Write empty session file
-    writeFileSync(
-      TEST_SESSION_FILE,
-      JSON.stringify({ activeSession: null, sessions: {} }),
-      "utf-8"
-    );
+    writeFileSync(TEST_SESSION_FILE, JSON.stringify({ sessions: {} }), "utf-8");
   });
 
   afterEach(() => {
-    // Clean up after each test
     if (existsSync(TEST_SESSION_FILE)) {
       rmSync(TEST_SESSION_FILE, { force: true });
     }
   });
 
   describe("saveSession", () => {
-    it("should save a new session", async () => {
+    it("saves a new session", async () => {
       const config: SessionConfig = {
         type: "http",
         url: "http://localhost:3000/mcp",
@@ -57,21 +79,7 @@ describe("Session Storage", () => {
       expect(retrieved?.url).toBe("http://localhost:3000/mcp");
     });
 
-    it("should set first session as active", async () => {
-      const config: SessionConfig = {
-        type: "http",
-        url: "http://localhost:3000/mcp",
-        lastUsed: new Date().toISOString(),
-      };
-
-      await saveSession("first-session", config);
-
-      const active = await getActiveSession();
-      expect(active).toBeDefined();
-      expect(active?.name).toBe("first-session");
-    });
-
-    it("should update lastUsed timestamp", async () => {
+    it("updates lastUsed timestamp on save", async () => {
       const config: SessionConfig = {
         type: "http",
         url: "http://localhost:3000/mcp",
@@ -84,7 +92,7 @@ describe("Session Storage", () => {
       expect(retrieved?.lastUsed).not.toBe("2020-01-01T00:00:00.000Z");
     });
 
-    it("should save stdio session configuration", async () => {
+    it("saves stdio session configuration", async () => {
       const config: SessionConfig = {
         type: "stdio",
         command: "npx",
@@ -107,12 +115,12 @@ describe("Session Storage", () => {
   });
 
   describe("getSession", () => {
-    it("should return null for non-existent session", async () => {
+    it("returns null for non-existent session", async () => {
       const session = await getSession("non-existent");
       expect(session).toBeNull();
     });
 
-    it("should retrieve saved session", async () => {
+    it("retrieves a saved session", async () => {
       const config: SessionConfig = {
         type: "http",
         url: "http://localhost:3000/mcp",
@@ -131,72 +139,8 @@ describe("Session Storage", () => {
     });
   });
 
-  describe("getActiveSession", () => {
-    it("should return null when no sessions exist", async () => {
-      const active = await getActiveSession();
-      expect(active).toBeNull();
-    });
-
-    it("should return active session", async () => {
-      const config: SessionConfig = {
-        type: "http",
-        url: "http://localhost:3000/mcp",
-        lastUsed: new Date().toISOString(),
-      };
-
-      await saveSession("test-session", config);
-      const active = await getActiveSession();
-
-      expect(active).toBeDefined();
-      expect(active?.name).toBe("test-session");
-      expect(active?.config.type).toBe("http");
-    });
-  });
-
-  describe("setActiveSession", () => {
-    it("should set active session", async () => {
-      const config1: SessionConfig = {
-        type: "http",
-        url: "http://localhost:3000/mcp",
-        lastUsed: new Date().toISOString(),
-      };
-      const config2: SessionConfig = {
-        type: "http",
-        url: "http://localhost:4000/mcp",
-        lastUsed: new Date().toISOString(),
-      };
-
-      await saveSession("session-1", config1);
-      await saveSession("session-2", config2);
-      await setActiveSession("session-2");
-
-      const active = await getActiveSession();
-      expect(active?.name).toBe("session-2");
-    });
-
-    it("should throw error for non-existent session", async () => {
-      await expect(setActiveSession("non-existent")).rejects.toThrow(
-        "Session 'non-existent' not found"
-      );
-    });
-
-    it("should update lastUsed when setting active", async () => {
-      const config: SessionConfig = {
-        type: "http",
-        url: "http://localhost:3000/mcp",
-        lastUsed: "2020-01-01T00:00:00.000Z",
-      };
-
-      await saveSession("test-session", config);
-      await setActiveSession("test-session");
-
-      const session = await getSession("test-session");
-      expect(session?.lastUsed).not.toBe("2020-01-01T00:00:00.000Z");
-    });
-  });
-
   describe("removeSession", () => {
-    it("should remove a session", async () => {
+    it("removes a session", async () => {
       const config: SessionConfig = {
         type: "http",
         url: "http://localhost:3000/mcp",
@@ -210,7 +154,7 @@ describe("Session Storage", () => {
       expect(retrieved).toBeNull();
     });
 
-    it("should update active session when removing active", async () => {
+    it("leaves other sessions intact", async () => {
       const config1: SessionConfig = {
         type: "http",
         url: "http://localhost:3000/mcp",
@@ -224,22 +168,20 @@ describe("Session Storage", () => {
 
       await saveSession("session-1", config1);
       await saveSession("session-2", config2);
-      await setActiveSession("session-1");
       await removeSession("session-1");
 
-      const active = await getActiveSession();
-      // Should switch to session-2 or be null if no sessions left
-      expect(active?.name).not.toBe("session-1");
+      expect(await getSession("session-1")).toBeNull();
+      expect(await getSession("session-2")).not.toBeNull();
     });
   });
 
   describe("listAllSessions", () => {
-    it("should return empty array when no sessions", async () => {
+    it("returns empty array when no sessions exist", async () => {
       const sessions = await listAllSessions();
       expect(sessions).toEqual([]);
     });
 
-    it("should list all sessions with active flag", async () => {
+    it("lists all saved sessions", async () => {
       const config1: SessionConfig = {
         type: "http",
         url: "http://localhost:3000/mcp",
@@ -253,21 +195,18 @@ describe("Session Storage", () => {
 
       await saveSession("session-1", config1);
       await saveSession("session-2", config2);
-      await setActiveSession("session-2");
 
       const sessions = await listAllSessions();
       expect(sessions).toHaveLength(2);
-
-      const active = sessions.find((s) => s.isActive);
-      expect(active?.name).toBe("session-2");
-
-      const inactive = sessions.find((s) => !s.isActive);
-      expect(inactive?.name).toBe("session-1");
+      expect(sessions.map((s) => s.name).sort()).toEqual([
+        "session-1",
+        "session-2",
+      ]);
     });
   });
 
   describe("updateSessionInfo", () => {
-    it("should update server info and capabilities", async () => {
+    it("updates server info and capabilities", async () => {
       const config: SessionConfig = {
         type: "http",
         url: "http://localhost:3000/mcp",
@@ -292,10 +231,36 @@ describe("Session Storage", () => {
       });
     });
 
-    it("should not fail for non-existent session", async () => {
+    it("does not throw for non-existent session", async () => {
       await expect(
         updateSessionInfo("non-existent", { name: "test-server" }, {})
       ).resolves.not.toThrow();
+    });
+  });
+
+  describe("legacy file compatibility", () => {
+    it("ignores legacy activeSession field on load", async () => {
+      // Older clients persisted `activeSession`. The new schema drops it but
+      // should still read the rest of the file.
+      writeFileSync(
+        TEST_SESSION_FILE,
+        JSON.stringify({
+          activeSession: "session-1",
+          sessions: {
+            "session-1": {
+              type: "http",
+              url: "http://localhost:3000/mcp",
+              lastUsed: new Date().toISOString(),
+            },
+          },
+        }),
+        "utf-8"
+      );
+
+      const storage = await loadSessions();
+      expect(storage.sessions["session-1"]).toBeDefined();
+      // activeSession is silently dropped on load.
+      expect((storage as any).activeSession).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
## Language / Project Scope

- [x] TypeScript
- [ ] Python
- [x] Documentation only
- [ ] CI/CD or tooling

## Changes

Three independent CLI changes, one PR (each its own commit + changeset):

1. **`feat!` (minor)** — Drop the implicit "active session" model. The client name is now a required positional and every per-client command lives under `mcp-use client <name> <scope> <action>`. Removes `client sessions switch`, `--session`, `client disconnect --all`, and the active-session fallback in `screenshot`.
2. **`fix` (patch)** — `mcp-use client <name> tools call ...` no longer prints tool results twice when servers return `structuredContent`. Per the MCP spec, servers SHOULD also serialize the same JSON into a `TextContent` block; the CLI was rendering both. The structured form is now treated as canonical and the content block is suppressed when it's present.
3. **`fix` (patch)** — The CLI test suite no longer touches the developer's real `~/.mcp-use` directory. `session-storage.test.ts` was computing its target from `os.homedir()` and `rmSync`'ing it, deleting saved clients on every `pnpm test`. `cli-integration.test.ts` was spawning the real CLI and reading the real `cli-sessions.json`. Both now use an isolated temp HOME.

## Implementation Details

1. `packages/cli/src/commands/client.ts` rewires the command tree: a top-level `connect <name> <url>` / `list` / `<name> <scope> <action>` shape, with shape-error feedback for the common mistakes the new syntax invites (URL-only `connect`, missing client name before `tools call`, unknown subcommands).
2. `packages/cli/src/utils/session-storage.ts` drops `activeSession` from the persisted schema. Older `~/.mcp-use/cli-sessions.json` files still load — the unused field is silently ignored. `getActiveSession*` helpers removed.
3. `packages/cli/src/utils/format.ts` adds `showContent = !hasStructured && !!result.content?.length` to suppress the duplicate text block when `structuredContent` is present.
4. `packages/cli/tests/session-storage.test.ts` mocks `node:os.homedir` per test process. `packages/cli/tests/cli-integration.test.ts` sets `HOME` / `USERPROFILE` on every spawned subprocess to a per-suite temp dir.
5. Docs (`docs/typescript/client/cli.mdx`, `environments.mdx`, `authentication.mdx`) are rewritten for the new shape — `client list` instead of `sessions list`, no `--session` flag, new `auth` scope (`status`/`refresh`/`logout`).

## TypeScript Checklist

### Packages Modified

- [x] `docs`
- [ ] `tests`
- [x] `cli`
- [ ] `create-mcp-use-app`
- [ ] `mcp-use` (server)
- [ ] `mcp-use` (client)
- [ ] `inspector`

### Pre-commit Checklist

- [x] Ran `pnpm lint:fix` to auto-fix linting issues
- [x] Ran `pnpm format` to format code with Prettier
- [x] Ran `pnpm build` and build succeeds without errors
- [x] Ran `pnpm changeset` to create a changeset (3 changesets — one per concern)
- [x] Added or updated tests if needed
- [x] Updated documentation in `docs/` folder

## Example Usage (Before)

```bash
# Connect, with --name for the saved client name
npx mcp-use client connect https://mcp.manufact.com --name manufact

# Per-command flags pick which saved client to use, falling back to "active"
npx mcp-use client tools list
npx mcp-use client tools call read_file path=/x --session manufact

# Active-session machinery
npx mcp-use client sessions list
npx mcp-use client sessions switch other-server
npx mcp-use client disconnect --all
```

## Example Usage (After)

```bash
# Name is required and positional
npx mcp-use client connect manufact https://mcp.manufact.com

# Every per-client command names its target explicitly
npx mcp-use client manufact tools list
npx mcp-use client manufact tools call read_file path=/x

# Saved clients
npx mcp-use client list
npx mcp-use client other-server tools list   # any client, by name

# Disconnect one at a time
npx mcp-use client manufact disconnect
```

## Documentation Updates

- `docs/typescript/client/cli.mdx` — full rewrite of the standalone CLI reference around the two top-level shapes (`connect <name> <url>` vs `<name> <scope> <action>`). Drops "Session Management" section, adds "Listing Saved Clients" and the `auth` scope. Net −186 lines.
- `docs/typescript/client/environments.mdx` — CLI subsection updated for the new positional form. Replaces "Sessions" with "Managing Multiple Clients" and explicitly notes there is no active client.
- `docs/typescript/client/authentication.mdx` — the bearer-token CLI example updated to the new shape and `key=value` arg syntax.

## Testing

- 248 tests passing across the CLI package (`pnpm --filter @mcp-use/cli test`).
- `tests/cli-integration.test.ts` updated for the new shape; new tests cover the shape-error feedback (missing-name `tools call`, URL-only `connect`).
- `tests/format.test.ts` updated to assert the structuredContent dedupe behavior on both success and error paths.
- `tests/session-storage.test.ts` rewritten to mock `homedir` to a per-process temp dir.
- Edge cases: legacy `cli-sessions.json` files containing the now-removed `activeSession` field still load (field is silently ignored).

## Backwards Compatibility

**Breaking** for the CLI surface (commit 1):

- `client connect <url> --name <name>` → `client connect <name> <url>` (name is required, positional)
- `--session <name>` is removed from every per-client subcommand
- `client sessions list` → `client list`
- `client sessions switch` removed
- `client disconnect --all` removed; disconnect each client by name
- `mcp-use screenshot` no longer falls back to the active session — pass `--session <name>` or `--mcp <url>` explicitly

The persisted `~/.mcp-use/cli-sessions.json` file format is backwards compatible — older files with `activeSession` still load (field is ignored).

The structuredContent dedupe and the test-isolation fix (commits 2 and 3) are non-breaking patches.

## Related Issues

N/A