### PR TITLE
fix(server/oauth): broker upstream redirect through /oauth/callback

### DIFF
--- a/docs/typescript/server/authentication/providers/auth0.mdx
+++ b/docs/typescript/server/authentication/providers/auth0.mdx
@@ -96,10 +96,11 @@ Auth0 supports two integration modes depending on whether you have access to Aut
 
     1. Go to **Applications → Create Application**
     2. Choose **Regular Web Application**
-    3. Under **Allowed Callback URLs**, add your MCP client's redirect URI:
+    3. Under **Allowed Callback URLs**, add the **MCP server's** OAuth callback URL:
        ```
-       http://localhost:3000/inspector/oauth/callback
+       http://localhost:3000/oauth/callback
        ```
+       You register the server's callback URL here — not the MCP client's. The proxy brokers the redirect back to whichever client started the flow, so each new client (inspector, agent, IDE) works without extra Auth0 config.
     4. Copy the **Client ID** and **Client Secret**
 
     ### 2. Create an API
@@ -151,13 +152,23 @@ Auth0 supports two integration modes depending on whether you have access to Aut
 
     The OAuth flow in proxy mode:
     ```
-    Client → /register         → receives pre-registered client_id
-    Client → /authorize        → MCP server redirects to Auth0 /authorize
-    Auth0  → redirect_uri      → returns authorization code to client
-    Client → /token            → MCP server injects credentials, forwards to Auth0
-    Auth0  → access_token (JWT)→ returned to client
-    Client → /mcp/...          → MCP server verifies JWT via Auth0 JWKS
+    Client → /register               → receives pre-registered client_id
+    Client → /authorize              → MCP server stores client's redirect_uri,
+                                        forwards to Auth0 with the server's own
+                                        /oauth/callback as redirect_uri
+    Auth0  → <server>/oauth/callback → MCP server looks up the original client
+                                        redirect_uri and 302s with the auth code
+    Client → /token                  → MCP server injects credentials and
+                                        overrides redirect_uri, forwards to Auth0
+    Auth0  → access_token (JWT)      → returned to client
+    Client → /mcp/...                → MCP server verifies JWT via Auth0 JWKS
     ```
+
+    <Tip>
+      In production, pass `allowedClientRedirectUris` to `oauthProxy()` to gate
+      which client URLs the proxy will redirect to. When unset, the proxy
+      accepts any client `redirect_uri` (developer-friendly default).
+    </Tip>
 
   </Tab>
 </Tabs>

--- a/docs/typescript/server/authentication/providers/oauth-proxy.mdx
+++ b/docs/typescript/server/authentication/providers/oauth-proxy.mdx
@@ -23,11 +23,16 @@ Common proxy targets: **Google, GitHub, Okta, Azure AD (Microsoft Entra ID), Aut
 ## How it works
 
 1. Your server exposes a `/register` endpoint that returns the configured `clientId`.
-2. The MCP client runs PKCE authorization against the upstream using that `clientId`.
-3. At token exchange, your server injects the `clientId` and `clientSecret` before forwarding to the upstream.
-4. On each `/mcp/*` request, your server verifies the bearer token via the `verifyToken` function you provided.
+2. At `/authorize`, your server stores the MCP client's `redirect_uri` and `state`, then forwards the request upstream with its own `/oauth/callback` as `redirect_uri` and a server-minted `state`.
+3. The upstream provider redirects to your server's `/oauth/callback`. The server looks up the original client `redirect_uri` and 302s the client with the authorization code and original `state`.
+4. At `/token`, your server injects the `clientId`/`clientSecret` and overrides `redirect_uri` so the upstream's redirect-uri match succeeds.
+5. On each `/mcp/*` request, your server verifies the bearer token via `verifyToken`.
 
-Your server holds the client credentials and mediates every token exchange. Tokens are passed through  -  the proxy does not mint its own.
+<Note>
+  **You register only one redirect URI upstream:** `https://<your-server>/oauth/callback`. The proxy then brokers the redirect to whichever MCP client started the flow — every new client (inspector, agent, IDE, prod deployment) works without extra provider config.
+</Note>
+
+The proxy holds your client credentials and mediates every token exchange. Tokens are passed through — the proxy does not mint its own.
 
 ## Quick start (Google)
 
@@ -84,6 +89,14 @@ oauthProxy({
 
   // Optional: extra authorize-request params (e.g. audience, access_type, prompt)
   extraAuthorizeParams: { access_type: "offline", prompt: "consent" },
+
+  // Optional: allowlist of client redirect URIs. When unset (default), any
+  // client redirect_uri is accepted. Set this in production to prevent the
+  // proxy from being abused as an open redirect.
+  allowedClientRedirectUris: [
+    "https://my-app.example.com/oauth/callback",
+    "http://localhost:3000/oauth/callback",
+  ],
 
   // Optional: custom user info extractor
   // Default pulls sub/email/name/picture and parses `scope` into scopes[].

--- a/libraries/typescript/.changeset/oauth-proxy-redirect-uri.md
+++ b/libraries/typescript/.changeset/oauth-proxy-redirect-uri.md
@@ -1,0 +1,34 @@
+---
+"mcp-use": patch
+---
+
+fix(server/oauth): `oauthProxy` now correctly mediates the redirect flow
+
+Previously the proxy forwarded the MCP client's `redirect_uri` to the upstream
+provider unchanged. That required every distinct client URL (`/inspector/oauth/callback`,
+agent loopback ports, prod deployments, etc.) to be pre-registered in the
+provider's "Allowed Callback URLs" — defeating the point of the proxy.
+
+The proxy now:
+
+- Forwards `/authorize` to the upstream with `redirect_uri = <server>/oauth/callback`
+  and a server-minted `state`. The original client `redirect_uri` and `state`
+  are stored against that minted value in a pluggable in-flight state store
+  (in-memory by default, 10-minute TTL, one-shot consumption).
+- Exposes `GET /oauth/callback`. When the upstream provider redirects there,
+  the proxy looks up the original client URI and 302s to it with the auth
+  code and original `state`. `error` and `error_description` are propagated
+  the same way.
+- Overrides `redirect_uri` in `/token` form bodies so the upstream's
+  redirect-uri match succeeds (the value at token exchange must match the
+  one used at `/authorize`).
+- Accepts an optional `allowedClientRedirectUris: string[]` on `oauthProxy()`
+  to gate which client redirect URIs the proxy will broker. Unset =
+  accept any URL (developer-friendly default). Set in production to close
+  the open-redirect vector.
+
+**Action required:** add `<your-server>/oauth/callback` to your upstream
+provider's Allowed Callback URLs and remove any client-specific entries
+(e.g. `/inspector/oauth/callback`) that were registered solely to work
+around the previous behavior. The MCP client's own callback page does not
+need to change.

--- a/libraries/typescript/packages/mcp-use/examples/server/oauth/auth0-proxy/README.md
+++ b/libraries/typescript/packages/mcp-use/examples/server/oauth/auth0-proxy/README.md
@@ -12,10 +12,13 @@ In the [Auth0 Dashboard](https://manage.auth0.com):
 
 1. Go to **Applications → Create Application**
 2. Choose **Regular Web Application**
-3. Under **Allowed Callback URLs**, add your MCP client's redirect URI, e.g.:
+3. Under **Allowed Callback URLs**, add the **MCP server's** OAuth callback:
    ```
-   http://localhost:3000/inspector/oauth/callback
+   http://localhost:3000/oauth/callback
    ```
+   You register the server's callback URL here — not the MCP client's. The
+   proxy brokers the redirect back to whichever client started the flow, so
+   each new client (inspector, agent, IDE) works without extra Auth0 config.
 4. Save changes and copy the **Client ID** and **Client Secret**
 
 ### 2. Create an API
@@ -52,12 +55,16 @@ Server starts on port 3000. Open `http://localhost:3000/inspector` to test the O
 ## OAuth Flow
 
 ```
-Client → /register         → receives pre-registered client_id
-Client → /authorize        → MCP server redirects to Auth0 /authorize
-Auth0  → redirect_uri      → returns authorization code to client
-Client → /token            → MCP server injects credentials, forwards to Auth0
-Auth0  → access_token (JWT)→ returned to client
-Client → /mcp/...          → MCP server verifies JWT via Auth0 JWKS
+Client → /register             → receives pre-registered client_id
+Client → /authorize            → MCP server stores client's redirect_uri,
+                                  forwards to Auth0 with the server's own
+                                  /oauth/callback as redirect_uri
+Auth0  → <server>/oauth/callback → MCP server looks up the original client
+                                    redirect_uri and 302s with the auth code
+Client → /token                → MCP server injects credentials and overrides
+                                  redirect_uri, forwards to Auth0
+Auth0  → access_token (JWT)    → returned to client
+Client → /mcp/...              → MCP server verifies JWT via Auth0 JWKS
 ```
 
 ## Available Tools

--- a/libraries/typescript/packages/mcp-use/examples/server/oauth/auth0-proxy/src/server.ts
+++ b/libraries/typescript/packages/mcp-use/examples/server/oauth/auth0-proxy/src/server.ts
@@ -5,9 +5,16 @@
  * Unlike the DCR-direct auth0/ example, this works without Auth0's Early Access DCR feature.
  *
  * The MCP server mediates the entire OAuth flow:
- *   /register → returns pre-registered client_id
- *   /authorize → redirects to Auth0 with injected params
- *   /token → forwards to Auth0 with injected client credentials
+ *   /register        → returns the pre-registered client_id
+ *   /authorize       → stores the client redirect_uri, forwards to Auth0 with
+ *                       <server>/oauth/callback as redirect_uri
+ *   /oauth/callback  → restores the original client URI and 302s with the code
+ *   /token           → forwards to Auth0 with injected client credentials and
+ *                       overrides redirect_uri to <server>/oauth/callback
+ *
+ * Register `<server>/oauth/callback` in Auth0's Allowed Callback URLs — the
+ * proxy then brokers the redirect to whichever MCP client started the flow,
+ * so individual clients don't need to be registered upstream.
  *
  * Environment variables:
  *   AUTH0_DOMAIN         (required) e.g. my-tenant.us.auth0.com
@@ -46,6 +53,14 @@ const server = new MCPServer({
     clientSecret,
     scopes: ["openid", "email", "profile"],
     extraAuthorizeParams: { audience },
+    // In production, set `allowedClientRedirectUris` to gate which client
+    // callback URLs the proxy will redirect to. Unset accepts any URL —
+    // fine for local development, but an open-redirect risk if exposed.
+    //
+    // allowedClientRedirectUris: [
+    //   "https://my-app.example.com/oauth/callback",
+    //   "http://localhost:3000/inspector/oauth/callback",
+    // ],
     verifyToken: jwksVerifier({
       jwksUrl: `https://${domain}/.well-known/jwks.json`,
       issuer: `https://${domain}/`,

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/index.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/index.ts
@@ -37,6 +37,12 @@ export {
 } from "./oauth-proxy.js";
 
 export {
+  createInMemoryStateStore,
+  DEFAULT_OAUTH_STATE_TTL_MS,
+  type OAuthStateRecord,
+  type OAuthStateStore,
+} from "./state-store.js";
+export {
   getAuth,
   hasAnyScope,
   hasScope,

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/oauth-proxy.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/oauth-proxy.ts
@@ -84,6 +84,18 @@ export interface OAuthProxyConfig {
    * If not provided, extracts standard OIDC claims (sub, email, name, picture).
    */
   getUserInfo?: (payload: Record<string, unknown>) => UserInfo;
+
+  /**
+   * Optional allowlist for client `redirect_uri` values passed to `/authorize`.
+   *
+   * When unset, any client redirect URI is accepted (developer-friendly
+   * default). When set, only exact matches are accepted; other values are
+   * rejected with `400 invalid_request`. Set this in production to prevent
+   * the proxy from being abused as an open redirect.
+   *
+   * @example ["https://my-app.example.com/oauth/callback", "http://localhost:3000/oauth/callback"]
+   */
+  allowedClientRedirectUris?: string[];
 }
 
 /**
@@ -230,6 +242,7 @@ export function oauthProxy(config: OAuthProxyConfig): OAuthProxy {
     clientId: config.clientId,
     clientSecret: config.clientSecret,
     extraAuthorizeParams: config.extraAuthorizeParams,
+    allowedClientRedirectUris: config.allowedClientRedirectUris,
 
     // OAuthProvider interface implementation
     getIssuer: () => config.issuer,

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/providers/types.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/providers/types.ts
@@ -103,6 +103,16 @@ export interface OAuthProxy extends OAuthProvider {
    * Extra parameters to include in authorize requests
    */
   extraAuthorizeParams?: Record<string, string>;
+
+  /**
+   * Optional allowlist for client `redirect_uri` values passed to `/authorize`.
+   *
+   * When unset, the proxy accepts any client redirect URI (the developer-
+   * friendly default). When set, only exact matches are accepted; any other
+   * value is rejected with `400 invalid_request`. Use this in production to
+   * close the open-redirect vector created by brokering the upstream callback.
+   */
+  allowedClientRedirectUris?: string[];
 }
 
 /**

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/routes.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/routes.ts
@@ -19,6 +19,32 @@ import type { Context, Hono } from "hono";
 import { cors } from "hono/cors";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import type { OAuthProvider, OAuthProxy } from "./providers/types.js";
+import {
+  createInMemoryStateStore,
+  DEFAULT_OAUTH_STATE_TTL_MS,
+  type OAuthStateStore,
+} from "./state-store.js";
+
+/**
+ * Path of the proxy's own OAuth redirect endpoint.
+ *
+ * The MCP server registers `${baseUrl}${PROXY_CALLBACK_PATH}` with the
+ * upstream provider; the proxy then brokers the redirect back to the
+ * original MCP client.
+ */
+export const PROXY_CALLBACK_PATH = "/oauth/callback";
+
+function buildProxyCallbackUrl(baseUrl: string): string {
+  return `${baseUrl.replace(/\/+$/, "")}${PROXY_CALLBACK_PATH}`;
+}
+
+function isAllowedClientRedirectUri(
+  proxy: OAuthProxy,
+  candidate: string
+): boolean {
+  if (!proxy.allowedClientRedirectUris) return true;
+  return proxy.allowedClientRedirectUris.includes(candidate);
+}
 
 /**
  * Type guard to check if oauth config is a proxy
@@ -33,13 +59,25 @@ export function isOAuthProxy(
  * Authorization endpoint handler
  *
  * In DCR-direct mode (OAuthProvider): Dormant — clients reach upstream directly.
- * In proxy mode (OAuthProxy): Active — redirects to upstream with extra params.
+ * In proxy mode (OAuthProxy): Active. The proxy:
+ *   1. Validates the client `redirect_uri` against `allowedClientRedirectUris`
+ *      (when configured).
+ *   2. Generates an opaque `proxyState` and records the original client
+ *      `redirect_uri`/`state` in the state store.
+ *   3. Forwards the request upstream with `redirect_uri` swapped to the
+ *      proxy's own `/oauth/callback` and `state` swapped to `proxyState`.
+ *
+ * The original client `state` is restored at the callback step.
  *
  * @param oauth - The OAuth provider or proxy
+ * @param baseUrl - The base URL of the MCP server (only used in proxy mode)
+ * @param stateStore - In-flight state store (only used in proxy mode)
  * @returns Hono handler that redirects to the upstream authorize endpoint
  */
 function createAuthorizeHandler(
-  oauth: OAuthProvider | OAuthProxy
+  oauth: OAuthProvider | OAuthProxy,
+  baseUrl?: string,
+  stateStore?: OAuthStateStore
 ): (c: Context) => Promise<Response> {
   return async (c: Context) => {
     const params =
@@ -73,7 +111,6 @@ function createAuthorizeHandler(
 
     // Build provider authorization URL
     const authUrl = new URL(authEndpoint);
-    authUrl.searchParams.set("redirect_uri", redirectUri as string);
     authUrl.searchParams.set("response_type", responseType as string);
     authUrl.searchParams.set("code_challenge", codeChallenge as string);
     authUrl.searchParams.set(
@@ -81,11 +118,49 @@ function createAuthorizeHandler(
       (codeChallengeMethod as string) || "S256"
     );
 
-    if (state) authUrl.searchParams.set("state", state as string);
     if (scope) authUrl.searchParams.set("scope", scope as string);
     if (audience) authUrl.searchParams.set("audience", audience as string);
 
     if (isOAuthProxy(oauth)) {
+      if (!baseUrl || !stateStore) {
+        // Defensive: setupOAuthRoutes always wires these in proxy mode.
+        return c.json(
+          {
+            error: "server_error",
+            error_description:
+              "OAuth proxy is missing baseUrl or state store wiring",
+          },
+          500
+        );
+      }
+
+      const clientRedirectUri = redirectUri as string;
+      if (!isAllowedClientRedirectUri(oauth, clientRedirectUri)) {
+        return c.json(
+          {
+            error: "invalid_request",
+            error_description: "redirect_uri is not allowed",
+          },
+          400
+        );
+      }
+
+      // Mint our own state, store the originals, and forward upstream with
+      // our `/oauth/callback` as redirect_uri. The upstream provider only
+      // ever sees the proxy's callback URL; the client URI never leaves
+      // this process.
+      const proxyState = crypto.randomUUID();
+      await stateStore.set(
+        proxyState,
+        {
+          clientRedirectUri,
+          clientState: state ? (state as string) : undefined,
+        },
+        DEFAULT_OAUTH_STATE_TTL_MS
+      );
+
+      authUrl.searchParams.set("redirect_uri", buildProxyCallbackUrl(baseUrl));
+      authUrl.searchParams.set("state", proxyState);
       // Override with the configured upstream client_id; the incoming value
       // may be stale DCR cache.
       authUrl.searchParams.set("client_id", oauth.clientId);
@@ -95,11 +170,70 @@ function createAuthorizeHandler(
         }
       }
     } else {
+      authUrl.searchParams.set("redirect_uri", redirectUri as string);
+      if (state) authUrl.searchParams.set("state", state as string);
       authUrl.searchParams.set("client_id", clientId as string);
     }
 
     // Redirect to provider
     return c.redirect(authUrl.toString(), 302);
+  };
+}
+
+/**
+ * Callback endpoint handler (proxy mode only).
+ *
+ * Receives the upstream provider's redirect, looks up the original client
+ * `redirect_uri` and `state` by the proxy state value, and 302s to the
+ * client URL with the upstream-issued `code` and the *original* client
+ * `state`. `error`/`error_description` are forwarded the same way.
+ *
+ * Records are consumed on read, so a given proxy state can only be used
+ * once.
+ *
+ * @param stateStore - In-flight state store
+ * @returns Hono handler for `GET /oauth/callback`
+ */
+export function createCallbackHandler(
+  stateStore: OAuthStateStore
+): (c: Context) => Promise<Response> {
+  return async (c: Context) => {
+    const proxyState = c.req.query("state");
+    if (!proxyState) {
+      return c.json(
+        {
+          error: "invalid_request",
+          error_description: "Missing state parameter",
+        },
+        400
+      );
+    }
+
+    const record = await stateStore.get(proxyState);
+    if (!record) {
+      return c.json(
+        {
+          error: "invalid_request",
+          error_description:
+            "Unknown or expired state — restart the OAuth flow",
+        },
+        400
+      );
+    }
+
+    const redirect = new URL(record.clientRedirectUri);
+    const passthrough = ["code", "error", "error_description"] as const;
+    for (const name of passthrough) {
+      const value = c.req.query(name);
+      if (value !== undefined) {
+        redirect.searchParams.set(name, value);
+      }
+    }
+    if (record.clientState !== undefined) {
+      redirect.searchParams.set("state", record.clientState);
+    }
+
+    return c.redirect(redirect.toString(), 302);
   };
 }
 
@@ -113,7 +247,8 @@ function createAuthorizeHandler(
  * @returns Hono handler that forwards form-encoded token exchanges upstream
  */
 function createTokenHandler(
-  oauth: OAuthProvider | OAuthProxy
+  oauth: OAuthProvider | OAuthProxy,
+  baseUrl?: string
 ): (c: Context) => Promise<Response> {
   return async (c: Context) => {
     try {
@@ -133,6 +268,20 @@ function createTokenHandler(
         // Add client_secret if configured (for confidential clients)
         if (oauth.clientSecret) {
           requestBody.set("client_secret", oauth.clientSecret);
+        }
+
+        // The upstream provider verifies that the token-exchange
+        // `redirect_uri` matches the one used at /authorize. Since we
+        // forwarded the proxy callback to /authorize, we override the
+        // client-supplied value here too. Refresh-token requests don't
+        // carry redirect_uri so we only touch authorization_code flows.
+        const grantType = requestBody.get("grant_type");
+        if (
+          baseUrl &&
+          (!grantType || grantType === "authorization_code") &&
+          requestBody.has("redirect_uri")
+        ) {
+          requestBody.set("redirect_uri", buildProxyCallbackUrl(baseUrl));
         }
       }
 
@@ -183,20 +332,31 @@ function createTokenHandler(
  *
  * **Proxy mode (OAuthProxy):**
  * - POST /register - Returns configured clientId (fake DCR endpoint)
- * - GET/POST /authorize - Redirects to upstream with extra params
- * - POST /token - Forwards with injected credentials
+ * - GET/POST /authorize - Stores the client's redirect_uri, forwards upstream
+ *   with the proxy's `/oauth/callback` as redirect_uri and a minted state
+ * - GET /oauth/callback - Receives upstream redirect, restores the original
+ *   client redirect_uri/state, and 302s the client with the auth code
+ * - POST /token - Forwards with injected credentials and overrides
+ *   redirect_uri to the proxy callback (so the upstream match passes)
  * - GET /.well-known/* - Synthesized metadata pointing to local endpoints
  *
  * @param app - The Hono application instance
  * @param oauth - The OAuth provider or proxy
  * @param baseUrl - The base URL of this server (for metadata)
+ * @param options.stateStore - Optional custom in-flight state store. Defaults
+ *   to an in-memory implementation; supply a shared store for multi-replica
+ *   deployments.
  */
 export function setupOAuthRoutes(
   app: Hono,
   oauth: OAuthProvider | OAuthProxy,
-  baseUrl: string
+  baseUrl: string,
+  options: { stateStore?: OAuthStateStore } = {}
 ): void {
   const proxyMode = isOAuthProxy(oauth);
+  const stateStore = proxyMode
+    ? (options.stateStore ?? createInMemoryStateStore())
+    : undefined;
   // Enable CORS for all OAuth-related endpoints
   // This is required for browser-based MCP clients to discover OAuth metadata
   app.use(
@@ -233,10 +393,26 @@ export function setupOAuthRoutes(
   );
 
   // Mount /authorize and /token handlers
-  const handleAuthorize = createAuthorizeHandler(oauth);
+  const handleAuthorize = createAuthorizeHandler(oauth, baseUrl, stateStore);
   app.get("/authorize", handleAuthorize);
   app.post("/authorize", handleAuthorize);
-  app.post("/token", createTokenHandler(oauth));
+  app.post("/token", createTokenHandler(oauth, baseUrl));
+
+  // In proxy mode, mount the redirect endpoint that upstream providers call
+  // back into. The handler restores the client's original redirect URI and
+  // 302s with the upstream-issued code + the original client state.
+  if (proxyMode && stateStore) {
+    app.use(
+      PROXY_CALLBACK_PATH,
+      cors({
+        origin: "*",
+        allowMethods: ["GET", "OPTIONS"],
+        allowHeaders: ["Content-Type", "Authorization"],
+        maxAge: 86400,
+      })
+    );
+    app.get(PROXY_CALLBACK_PATH, createCallbackHandler(stateStore));
+  }
 
   // In proxy mode, add /register endpoint that returns the configured clientId
   // This allows MCP clients to "register" even though the client is pre-registered

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/routes.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/routes.ts
@@ -222,7 +222,10 @@ export function createCallbackHandler(
     }
 
     const redirect = new URL(record.clientRedirectUri);
-    const passthrough = ["code", "error", "error_description"] as const;
+    // `iss` is forwarded per RFC 9207 (Authorization Server Issuer Identification);
+    // some upstreams (e.g. Auth0 with Strict Authorization Requests) include it
+    // and clients may validate against it.
+    const passthrough = ["code", "error", "error_description", "iss"] as const;
     for (const name of passthrough) {
       const value = c.req.query(name);
       if (value !== undefined) {

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/state-store.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/state-store.ts
@@ -1,0 +1,82 @@
+/**
+ * OAuth Proxy State Store
+ *
+ * Tracks in-flight authorization requests between `/authorize` and
+ * `/oauth/callback` in proxy mode. The proxy generates a random key, stores
+ * the original client `redirect_uri` and `state`, and forwards its own key
+ * as the upstream `state`. On callback, the proxy retrieves the record and
+ * redirects to the original client URI with the original state value.
+ *
+ * Records are consumed on read (one-shot) and expire after a configurable
+ * TTL. The default in-memory implementation works for single-instance
+ * deployments. For multi-replica setups, implement {@link OAuthStateStore}
+ * against a shared backend (Redis, etc.) and pass it to `setupOAuthRoutes`.
+ */
+
+/**
+ * Record stored against an in-flight proxy state key.
+ */
+export interface OAuthStateRecord {
+  /** Original client-supplied redirect URI. */
+  clientRedirectUri: string;
+  /** Original client-supplied `state` value, if any. */
+  clientState?: string;
+}
+
+/**
+ * Pluggable storage for in-flight OAuth proxy authorization state.
+ *
+ * Implementations must enforce the TTL passed to {@link set}. {@link get}
+ * must atomically delete the record so each state can only be consumed once.
+ */
+export interface OAuthStateStore {
+  /**
+   * Store a record under `key`. The record must be discarded after `ttlMs`
+   * milliseconds.
+   */
+  set(
+    key: string,
+    record: OAuthStateRecord,
+    ttlMs: number
+  ): Promise<void> | void;
+
+  /**
+   * Retrieve and delete the record stored under `key`. Returns null if no
+   * record exists or it has expired.
+   */
+  get(key: string): Promise<OAuthStateRecord | null> | OAuthStateRecord | null;
+}
+
+interface StoredEntry {
+  record: OAuthStateRecord;
+  expiresAt: number;
+}
+
+/**
+ * Default in-memory {@link OAuthStateStore} backed by a `Map`. Suitable for
+ * single-process MCP servers. Entries are lazily expired on read.
+ */
+export function createInMemoryStateStore(): OAuthStateStore {
+  const entries = new Map<string, StoredEntry>();
+
+  return {
+    set(key, record, ttlMs) {
+      entries.set(key, {
+        record,
+        expiresAt: Date.now() + ttlMs,
+      });
+    },
+    get(key) {
+      const entry = entries.get(key);
+      if (!entry) return null;
+      entries.delete(key);
+      if (entry.expiresAt < Date.now()) return null;
+      return entry.record;
+    },
+  };
+}
+
+/**
+ * Default TTL for in-flight authorization records (10 minutes).
+ */
+export const DEFAULT_OAUTH_STATE_TTL_MS = 10 * 60 * 1000;

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/state-store.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/state-store.ts
@@ -53,17 +53,42 @@ interface StoredEntry {
 }
 
 /**
+ * Minimum interval between full expiry sweeps in the in-memory store. Sweeps
+ * piggyback on `set` calls; abandoned authorize flows are still bounded by
+ * this interval even if no later read reaches them.
+ */
+const SWEEP_INTERVAL_MS = 60 * 1000;
+
+/**
  * Default in-memory {@link OAuthStateStore} backed by a `Map`. Suitable for
- * single-process MCP servers. Entries are lazily expired on read.
+ * single-process MCP servers.
+ *
+ * Records are consumed on read (one-shot). To keep abandoned authorize flows
+ * from accumulating, `set` amortises a full expiry sweep once per
+ * {@link SWEEP_INTERVAL_MS}.
  */
 export function createInMemoryStateStore(): OAuthStateStore {
   const entries = new Map<string, StoredEntry>();
+  let lastSweepAt = 0;
+
+  function sweepExpired(now: number): void {
+    for (const [key, entry] of entries) {
+      if (entry.expiresAt < now) {
+        entries.delete(key);
+      }
+    }
+    lastSweepAt = now;
+  }
 
   return {
     set(key, record, ttlMs) {
+      const now = Date.now();
+      if (now - lastSweepAt > SWEEP_INTERVAL_MS) {
+        sweepExpired(now);
+      }
       entries.set(key, {
         record,
-        expiresAt: Date.now() + ttlMs,
+        expiresAt: now + ttlMs,
       });
     },
     get(key) {

--- a/libraries/typescript/packages/mcp-use/tests/server/oauth.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/server/oauth.test.ts
@@ -9,9 +9,16 @@ import { Hono } from "hono";
 import { serve } from "@hono/node-server";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createBearerAuthMiddleware } from "../../src/server/oauth/middleware.js";
-import { setupOAuthRoutes } from "../../src/server/oauth/routes.js";
+import {
+  setupOAuthRoutes,
+  createCallbackHandler,
+} from "../../src/server/oauth/routes.js";
 import { setupOAuthForServer } from "../../src/server/oauth/setup.js";
 import { oauthProxy } from "../../src/server/oauth/oauth-proxy.js";
+import {
+  createInMemoryStateStore,
+  DEFAULT_OAUTH_STATE_TTL_MS,
+} from "../../src/server/oauth/state-store.js";
 
 // A stub verifier that accepts any token. Used in tests that don't exercise
 // the verification path (routes, metadata, registration).
@@ -126,11 +133,13 @@ describe("server OAuth integration", () => {
     expect(response.status).toBe(200);
     expect(data.access_token).toBe("abc");
     expect(tokenSpy).toHaveBeenCalledTimes(1);
-    // Verify that client credentials were injected
+    // Verify that client credentials were injected and that the
+    // proxy overrides the client-supplied redirect_uri so the upstream's
+    // redirect-uri match (against what was sent at /authorize) succeeds.
     expect(tokenSpy.mock.calls[0][0].body).toMatchObject({
       grant_type: "authorization_code",
       code: "code-123",
-      redirect_uri: "http://localhost:3000/callback",
+      redirect_uri: `${svc.baseUrl}/oauth/callback`,
       client_id: "my-client-id",
       client_secret: "my-client-secret",
     });
@@ -378,5 +387,195 @@ describe("server OAuth integration", () => {
     expect(registration.client_id).toBe("pre-registered-client-id");
     expect(registration.client_name).toBe("My MCP Client");
     expect(registration.token_endpoint_auth_method).toBe("client_secret_post");
+  });
+
+  it("swaps redirect_uri and state to proxy values at /authorize", async () => {
+    const app = new Hono();
+    const proxy = oauthProxy({
+      issuer: "https://issuer.example.com",
+      authEndpoint: "https://issuer.example.com/oauth/authorize",
+      tokenEndpoint: "https://issuer.example.com/oauth/token",
+      clientId: "upstream-client-id",
+      verifyToken: stubVerifyToken,
+    });
+
+    const svc = await listenOnRandomPort(app);
+    closers.push(svc.close);
+    setupOAuthRoutes(app, proxy, svc.baseUrl);
+
+    const params = new URLSearchParams({
+      client_id: "ignored-stale-dcr-id",
+      redirect_uri: "http://localhost:5173/inspector/oauth/callback",
+      response_type: "code",
+      code_challenge: "challenge-123",
+      state: "client-state-xyz",
+      scope: "openid",
+    });
+
+    const response = await fetch(`${svc.baseUrl}/authorize?${params}`, {
+      redirect: "manual",
+    });
+
+    expect(response.status).toBe(302);
+    const upstreamUrl = new URL(response.headers.get("location")!);
+    expect(upstreamUrl.origin + upstreamUrl.pathname).toBe(
+      "https://issuer.example.com/oauth/authorize"
+    );
+    expect(upstreamUrl.searchParams.get("redirect_uri")).toBe(
+      `${svc.baseUrl}/oauth/callback`
+    );
+    expect(upstreamUrl.searchParams.get("client_id")).toBe("upstream-client-id");
+    // The forwarded state is the proxy's minted value, not the client's.
+    const proxyState = upstreamUrl.searchParams.get("state");
+    expect(proxyState).toBeTruthy();
+    expect(proxyState).not.toBe("client-state-xyz");
+  });
+
+  it("brokers the upstream callback back to the original client URI", async () => {
+    const store = createInMemoryStateStore();
+    const handler = createCallbackHandler(store);
+    const app = new Hono();
+    app.get("/oauth/callback", handler);
+
+    const svc = await listenOnRandomPort(app);
+    closers.push(svc.close);
+
+    store.set(
+      "proxy-state-1",
+      {
+        clientRedirectUri: "http://localhost:5173/inspector/oauth/callback",
+        clientState: "client-state-xyz",
+      },
+      DEFAULT_OAUTH_STATE_TTL_MS
+    );
+
+    const callbackUrl = new URL(`${svc.baseUrl}/oauth/callback`);
+    callbackUrl.searchParams.set("code", "auth-code-abc");
+    callbackUrl.searchParams.set("state", "proxy-state-1");
+
+    const response = await fetch(callbackUrl.toString(), {
+      redirect: "manual",
+    });
+
+    expect(response.status).toBe(302);
+    const target = new URL(response.headers.get("location")!);
+    expect(`${target.origin}${target.pathname}`).toBe(
+      "http://localhost:5173/inspector/oauth/callback"
+    );
+    expect(target.searchParams.get("code")).toBe("auth-code-abc");
+    expect(target.searchParams.get("state")).toBe("client-state-xyz");
+  });
+
+  it("propagates upstream errors back to the client redirect URI", async () => {
+    const store = createInMemoryStateStore();
+    const app = new Hono();
+    app.get("/oauth/callback", createCallbackHandler(store));
+
+    const svc = await listenOnRandomPort(app);
+    closers.push(svc.close);
+
+    store.set(
+      "proxy-state-err",
+      {
+        clientRedirectUri: "http://localhost:5173/cb",
+        clientState: "s",
+      },
+      DEFAULT_OAUTH_STATE_TTL_MS
+    );
+
+    const url = new URL(`${svc.baseUrl}/oauth/callback`);
+    url.searchParams.set("state", "proxy-state-err");
+    url.searchParams.set("error", "access_denied");
+    url.searchParams.set("error_description", "user declined");
+
+    const response = await fetch(url.toString(), { redirect: "manual" });
+    expect(response.status).toBe(302);
+
+    const target = new URL(response.headers.get("location")!);
+    expect(target.searchParams.get("error")).toBe("access_denied");
+    expect(target.searchParams.get("error_description")).toBe("user declined");
+    expect(target.searchParams.get("state")).toBe("s");
+    expect(target.searchParams.get("code")).toBeNull();
+  });
+
+  it("rejects unknown or replayed state values at /oauth/callback", async () => {
+    const store = createInMemoryStateStore();
+    const app = new Hono();
+    app.get("/oauth/callback", createCallbackHandler(store));
+
+    const svc = await listenOnRandomPort(app);
+    closers.push(svc.close);
+
+    store.set(
+      "proxy-state-one-shot",
+      { clientRedirectUri: "http://localhost:5173/cb" },
+      DEFAULT_OAUTH_STATE_TTL_MS
+    );
+
+    const url = `${svc.baseUrl}/oauth/callback?state=proxy-state-one-shot&code=c`;
+    const first = await fetch(url, { redirect: "manual" });
+    expect(first.status).toBe(302);
+
+    const replay = await fetch(url, { redirect: "manual" });
+    expect(replay.status).toBe(400);
+
+    const unknown = await fetch(`${svc.baseUrl}/oauth/callback?state=nope&code=c`, {
+      redirect: "manual",
+    });
+    expect(unknown.status).toBe(400);
+  });
+
+  it("expires state records after the TTL", async () => {
+    vi.useFakeTimers();
+    try {
+      const store = createInMemoryStateStore();
+      store.set(
+        "expiring",
+        { clientRedirectUri: "http://localhost:5173/cb" },
+        1000
+      );
+      vi.advanceTimersByTime(1001);
+      expect(store.get("expiring")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("rejects /authorize redirect_uris not in allowedClientRedirectUris", async () => {
+    const app = new Hono();
+    const proxy = oauthProxy({
+      issuer: "https://issuer.example.com",
+      authEndpoint: "https://issuer.example.com/oauth/authorize",
+      tokenEndpoint: "https://issuer.example.com/oauth/token",
+      clientId: "id",
+      verifyToken: stubVerifyToken,
+      allowedClientRedirectUris: ["http://localhost:3000/oauth/callback"],
+    });
+
+    const svc = await listenOnRandomPort(app);
+    closers.push(svc.close);
+    setupOAuthRoutes(app, proxy, svc.baseUrl);
+
+    const accepted = new URLSearchParams({
+      client_id: "id",
+      redirect_uri: "http://localhost:3000/oauth/callback",
+      response_type: "code",
+      code_challenge: "c",
+    });
+    const acceptedRes = await fetch(`${svc.baseUrl}/authorize?${accepted}`, {
+      redirect: "manual",
+    });
+    expect(acceptedRes.status).toBe(302);
+
+    const rejected = new URLSearchParams({
+      client_id: "id",
+      redirect_uri: "http://attacker.example.com/cb",
+      response_type: "code",
+      code_challenge: "c",
+    });
+    const rejectedRes = await fetch(`${svc.baseUrl}/authorize?${rejected}`);
+    expect(rejectedRes.status).toBe(400);
+    const body = await rejectedRes.json();
+    expect(body.error).toBe("invalid_request");
   });
 });

--- a/libraries/typescript/packages/mcp-use/tests/server/oauth.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/server/oauth.test.ts
@@ -466,6 +466,37 @@ describe("server OAuth integration", () => {
     expect(target.searchParams.get("state")).toBe("client-state-xyz");
   });
 
+  it("forwards the RFC 9207 `iss` parameter when present on the callback", async () => {
+    const store = createInMemoryStateStore();
+    const app = new Hono();
+    app.get("/oauth/callback", createCallbackHandler(store));
+
+    const svc = await listenOnRandomPort(app);
+    closers.push(svc.close);
+
+    store.set(
+      "proxy-state-iss",
+      {
+        clientRedirectUri: "http://localhost:5173/inspector/oauth/callback",
+        clientState: "client-state-xyz",
+      },
+      DEFAULT_OAUTH_STATE_TTL_MS
+    );
+
+    const callbackUrl = new URL(`${svc.baseUrl}/oauth/callback`);
+    callbackUrl.searchParams.set("code", "auth-code-abc");
+    callbackUrl.searchParams.set("state", "proxy-state-iss");
+    callbackUrl.searchParams.set("iss", "https://issuer.example.com/");
+
+    const response = await fetch(callbackUrl.toString(), {
+      redirect: "manual",
+    });
+
+    expect(response.status).toBe(302);
+    const target = new URL(response.headers.get("location")!);
+    expect(target.searchParams.get("iss")).toBe("https://issuer.example.com/");
+  });
+
   it("propagates upstream errors back to the client redirect URI", async () => {
     const store = createInMemoryStateStore();
     const app = new Hono();

--- a/skills/chatgpt-app-builder/references/authentication/auth0.md
+++ b/skills/chatgpt-app-builder/references/authentication/auth0.md
@@ -99,7 +99,7 @@ Use a standard Auth0 **Regular Web Application** — no Early Access required. Y
 ### Setup
 
 1. **Auth0 Dashboard → Applications → Create Application** — choose **Regular Web Application**.
-2. Under **Allowed Callback URLs**, add your MCP client's redirect URI (e.g. `http://localhost:3000/inspector/oauth/callback`).
+2. Under **Allowed Callback URLs**, add the **MCP server's** OAuth callback URL (e.g. `http://localhost:3000/oauth/callback`). The proxy brokers the redirect back to whichever MCP client started the flow, so this is the only URL you ever need to register at Auth0.
 3. Copy the **Client ID** and **Client Secret**.
 4. **APIs → Create API** — set an identifier (e.g. `https://my-mcp-api/`), leave signing as RS256. This is required so Auth0 issues **JWT** access tokens instead of opaque tokens.
 

--- a/skills/mcp-apps-builder/references/authentication/auth0.md
+++ b/skills/mcp-apps-builder/references/authentication/auth0.md
@@ -99,7 +99,7 @@ Use a standard Auth0 **Regular Web Application** — no Early Access required. Y
 ### Setup
 
 1. **Auth0 Dashboard → Applications → Create Application** — choose **Regular Web Application**.
-2. Under **Allowed Callback URLs**, add your MCP client's redirect URI (e.g. `http://localhost:3000/inspector/oauth/callback`).
+2. Under **Allowed Callback URLs**, add the **MCP server's** OAuth callback URL (e.g. `http://localhost:3000/oauth/callback`). The proxy brokers the redirect back to whichever MCP client started the flow, so this is the only URL you ever need to register at Auth0.
 3. Copy the **Client ID** and **Client Secret**.
 4. **APIs → Create API** — set an identifier (e.g. `https://my-mcp-api/`), leave signing as RS256. This is required so Auth0 issues **JWT** access tokens instead of opaque tokens.
 

--- a/skills/mcp-builder/references/authentication/auth0.md
+++ b/skills/mcp-builder/references/authentication/auth0.md
@@ -99,7 +99,7 @@ Use a standard Auth0 **Regular Web Application** — no Early Access required. Y
 ### Setup
 
 1. **Auth0 Dashboard → Applications → Create Application** — choose **Regular Web Application**.
-2. Under **Allowed Callback URLs**, add your MCP client's redirect URI (e.g. `http://localhost:3000/inspector/oauth/callback`).
+2. Under **Allowed Callback URLs**, add the **MCP server's** OAuth callback URL (e.g. `http://localhost:3000/oauth/callback`). The proxy brokers the redirect back to whichever MCP client started the flow, so this is the only URL you ever need to register at Auth0.
 3. Copy the **Client ID** and **Client Secret**.
 4. **APIs → Create API** — set an identifier (e.g. `https://my-mcp-api/`), leave signing as RS256. This is required so Auth0 issues **JWT** access tokens instead of opaque tokens.
 


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

- [x] TypeScript
- [x] Documentation

## Changes

`oauthProxy` now correctly mediates the OAuth redirect flow. Previously the proxy forwarded the MCP client's `redirect_uri` to the upstream provider unchanged, which required every distinct client URL (`/inspector/oauth/callback`, agent loopback ports, prod deployments, etc.) to be pre-registered in the provider's Allowed Callback URLs — defeating the entire purpose of having a proxy.

The proxy now uses its own `/oauth/callback` route, brokers the upstream redirect back to whichever MCP client started the flow, and works against any client without further provider configuration.

## Implementation Details

1. New `OAuthStateStore` interface (`packages/mcp-use/src/server/oauth/state-store.ts`) with an in-memory `Map`-backed default — 10-minute TTL, lazy expiry, one-shot consumption. Pluggable so multi-replica deployments can supply a shared backend later.
2. `createAuthorizeHandler` in proxy mode mints a `proxyState`, stores `{ clientRedirectUri, clientState }`, and forwards upstream with `redirect_uri = <server>/oauth/callback` and `state = proxyState`.
3. New `createCallbackHandler` mounted at `GET /oauth/callback` (proxy mode only) consumes the stored record and 302s to the original client URI with the original `state` and the upstream `code` (or `error` / `error_description`).
4. `createTokenHandler` in proxy mode overrides `redirect_uri` in the `/token` form body so the upstream's redirect-URI match check succeeds.
5. Added optional `allowedClientRedirectUris: string[]` to `OAuthProxyConfig` / `OAuthProxy`. Unset = accept any client redirect URI (developer-friendly default). Set = reject non-matches with `400 invalid_request` — closes the open-redirect vector.
6. DCR-direct (`OAuthProvider`) flow is untouched.

---

## TypeScript Checklist

### Packages Modified

- [x] `docs`
- [x] `mcp-use` (server)

### Pre-commit Checklist

- [x] Ran `pnpm build` — clean
- [x] Ran `pnpm changeset` — patch bump on `mcp-use` with migration note
- [x] Added or updated tests — 6 new + 1 updated, all 10 oauth tests pass
- [x] Updated documentation in `docs/` folder

---

## Example Usage (Before)

```ts
import { MCPServer, oauthProxy, jwksVerifier } from "mcp-use/server";

const server = new MCPServer({
  oauth: oauthProxy({
    authEndpoint: `https://${domain}/authorize`,
    tokenEndpoint: `https://${domain}/oauth/token`,
    issuer: `https://${domain}/`,
    clientId,
    clientSecret,
    verifyToken: jwksVerifier({ jwksUrl, issuer, audience }),
  }),
});
```

Auth0 had to whitelist **every** distinct MCP client callback URL:

```
http://localhost:3000/inspector/oauth/callback
http://localhost:5173/inspector/oauth/callback
https://my-app.example.com/inspector/oauth/callback
```

## Example Usage (After)

Same factory call, with optional production hardening:

```ts
oauth: oauthProxy({
  authEndpoint: `https://${domain}/authorize`,
  tokenEndpoint: `https://${domain}/oauth/token`,
  issuer: `https://${domain}/`,
  clientId,
  clientSecret,
  // Optional: gate which client redirect URIs the proxy will broker.
  // Unset accepts any URL (dev-friendly); set in production to prevent
  // the proxy from being abused as an open redirect.
  allowedClientRedirectUris: [
    "https://my-app.example.com/oauth/callback",
    "http://localhost:3000/inspector/oauth/callback",
  ],
  verifyToken: jwksVerifier({ jwksUrl, issuer, audience }),
})
```

Auth0 now needs only:

```
http://localhost:3000/oauth/callback
```

## Documentation Updates

- `docs/typescript/server/authentication/providers/oauth-proxy.mdx` — Rewrote "How it works", added `allowedClientRedirectUris` to the config table, added `<Note>` callout about the single upstream callback URL.
- `docs/typescript/server/authentication/providers/auth0.mdx` — OAuth Proxy tab: updated Allowed Callback URL instructions and the flow diagram, added `<Tip>` about production hardening.
- `libraries/typescript/packages/mcp-use/examples/server/oauth/auth0-proxy/README.md` — Updated Allowed Callback URL and the flow diagram.
- `libraries/typescript/packages/mcp-use/examples/server/oauth/auth0-proxy/src/server.ts` — Updated docblock to mention `/oauth/callback`; added a commented-out `allowedClientRedirectUris` example.
- `skills/{mcp-builder,mcp-apps-builder,chatgpt-app-builder}/references/authentication/auth0.md` — Same fix in all three (they intentionally mirror).

## Testing

**Automated** (`tests/server/oauth.test.ts`, 10/10 pass):

- `/authorize` swaps `redirect_uri` and `state` to proxy values before forwarding upstream.
- `/oauth/callback` brokers back to the original client URI with the original client `state` and upstream `code`.
- `/oauth/callback` propagates `error` and `error_description` to the client.
- State entries are single-use (replay returns `400`).
- State entries expire after the TTL (vitest fake timers).
- `/token` overrides `redirect_uri` in proxy mode (upstream sees the server callback URL).
- `allowedClientRedirectUris` enforced when set; permissive when unset.
- Existing DCR-direct test stays green (no regression).

**Manual:** end-to-end Auth0 flow via the inspector. DevTools Network tab confirms Auth0 → `<server>/oauth/callback?code=…&state=<uuid>` → `<client>/inspector/oauth/callback?code=…&state=<original>`.

## Backwards Compatibility

**Breaking for upstream provider configuration** — but a bug fix in behavior. Action required from existing `oauthProxy` users:

1. Add `<your-server>/oauth/callback` to your upstream provider's Allowed Callback URLs.
2. Remove any client-specific callback entries (e.g. `/inspector/oauth/callback`) registered solely to work around the previous behavior. The MCP client's own callback page does not need to change.

Released as a `patch` because the previous behavior didn't deliver what `oauthProxy` advertised — this aligns the implementation with its documented purpose.

## Related Issues

Closes MCP-2170