### PR TITLE
feat(cli): move screenshot under client and require explicit session name

### DIFF
--- a/docs/typescript/client/cli.mdx
+++ b/docs/typescript/client/cli.mdx
@@ -32,12 +32,14 @@ There is no "active" server. Every per-server command takes the server name as i
 
 ## Command Structure
 
-The CLI has two top-level shapes under `mcp-use client`:
+The CLI has these top-level shapes under `mcp-use client`:
 
 | Shape | Purpose |
 |-------|---------|
 | `mcp-use client connect <name> <url>` | Save an MCP server under a short name |
 | `mcp-use client list` | List saved servers |
+| `mcp-use client remove <name>` | Remove a saved server |
+| `mcp-use client screenshot --mcp <url> --tool <name>` | Ad-hoc widget screenshot — no saved server needed |
 | `mcp-use client <name> <scope> <action>` | Run a command against a saved server |
 
 The per-server scopes are:
@@ -48,6 +50,7 @@ The per-server scopes are:
 | `resources` | `list`, `read <uri>`, `subscribe <uri>`, `unsubscribe <uri>` |
 | `prompts` | `list`, `get <prompt> [args...]` |
 | `auth` | `status`, `refresh`, `logout` |
+| `screenshot` | `--tool <name> [args...]` — render a widget headlessly with the saved server's auth |
 | (top-level) | `interactive`, `disconnect` |
 
 ## Connecting
@@ -138,6 +141,37 @@ npx mcp-use client manufact auth status   # show token state + expiry
 npx mcp-use client manufact auth refresh  # force-refresh access token
 npx mcp-use client manufact auth logout   # remove stored tokens
 ```
+
+## Screenshot
+
+Render an MCP Apps widget headlessly and save a PNG. There are two forms.
+
+**Saved-server form** — reuses the auth from `mcp-use client connect`:
+
+```bash
+npx mcp-use client manufact screenshot --tool show-board
+npx mcp-use client manufact screenshot --tool show-board boardId=demo
+npx mcp-use client manufact screenshot --tool show-board --output ./out.png
+```
+
+**Ad-hoc form** — connects to an MCP server inline. Useful for one-off captures or programmatic/CI use that doesn't want to first save a server:
+
+```bash
+# Public server
+npx mcp-use client screenshot --mcp https://mcp.example.com --tool show-board
+
+# Authenticated server (curl-style -H, repeatable)
+npx mcp-use client screenshot \
+  --mcp https://mcp.example.com \
+  -H "Authorization: Bearer $TOKEN" \
+  --tool show-board boardId=demo
+```
+
+Common flags (both forms): `--width`, `--height`, `--theme light|dark`, `--output <path>`, `--wait-for <selector>`, `--delay <ms>`, `--timeout <ms>`, `--inspector <url>`, `--cdp-url <ws-url>`, `--quiet`. Run `mcp-use client screenshot --help` for the full list.
+
+<Note>
+`-H/--header` only applies to the ad-hoc form. The saved-server form carries the server's auth (OAuth or `--auth <token>` from `connect`) automatically.
+</Note>
 
 ## Interactive Mode
 

--- a/libraries/typescript/.changeset/cli-screenshot-under-client.md
+++ b/libraries/typescript/.changeset/cli-screenshot-under-client.md
@@ -1,0 +1,18 @@
+---
+"@mcp-use/cli": minor
+---
+
+feat(cli): move `screenshot` under `client` and require an explicit session name
+
+The standalone `mcp-use screenshot` command has been folded into `mcp-use client`, with two forms:
+
+- **Saved-server form:** `mcp-use client <name> screenshot --tool <tool>` reuses the auth from `mcp-use client connect`. The `--session` flag is gone — the server name is now the explicit positional that every other `mcp-use client <name> ...` command already takes.
+- **Ad-hoc form:** `mcp-use client screenshot --mcp <url> --tool <tool>` keeps `-H/--header` for authenticating one-off captures. Useful for programmatic / CI use that doesn't want to first save a server with `mcp-use client connect`.
+
+**Breaking changes:**
+
+- `mcp-use screenshot ...` no longer exists. Use `mcp-use client <name> screenshot ...` (saved server) or `mcp-use client screenshot --mcp <url> ...` (ad-hoc).
+- The `--session <name>` flag is removed. The saved-server name is the positional in `mcp-use client <name> screenshot`.
+- `screenshot` is now a reserved name and can't be used as a saved-server name.
+
+This mirrors the rest of the `mcp-use client` surface after the removal of the implicit "active session" model — every per-server command takes the server name as its first positional argument.

--- a/libraries/typescript/packages/cli/src/commands/client.ts
+++ b/libraries/typescript/packages/cli/src/commands/client.ts
@@ -44,7 +44,12 @@ import {
   authRefreshCommand,
   authLogoutCommand,
 } from "./client-auth.js";
-import { captureToolScreenshot, detectToolResourceUri } from "./screenshot.js";
+import {
+  captureToolScreenshot,
+  createClientScreenshotCommand,
+  createPerClientScreenshotCommand,
+  detectToolResourceUri,
+} from "./screenshot.js";
 
 /**
  * Reserved top-level subcommands under `mcp-use client`. Any other token in
@@ -56,6 +61,7 @@ export const RESERVED_CLIENT_SUBCOMMANDS = new Set([
   "connect",
   "list",
   "remove",
+  "screenshot",
   "help",
 ]);
 
@@ -72,6 +78,7 @@ export const PER_CLIENT_SCOPES = new Set([
   "auth",
   "disconnect",
   "interactive",
+  "screenshot",
 ]);
 
 export async function connectCommand(
@@ -1134,6 +1141,11 @@ export function createClientCommand(): Command {
     )
     .action(removeClientCommand);
 
+  // Ad-hoc screenshot form: `mcp-use client screenshot --mcp <url> --tool <name>`.
+  // No saved-server positional — handy for one-off captures and programmatic
+  // use that doesn't want to first run `mcp-use client connect`.
+  clientCommand.addCommand(createClientScreenshotCommand());
+
   return clientCommand;
 }
 
@@ -1257,6 +1269,9 @@ export function createPerClientCommand(name: string): Command {
     .description("Remove stored OAuth tokens for this server's URL")
     .action(() => authLogoutCommand(name));
   cmd.addCommand(authCommand);
+
+  // Per-server screenshot: reuses the saved server's auth (no --mcp/--header).
+  cmd.addCommand(createPerClientScreenshotCommand(name));
 
   return cmd;
 }

--- a/libraries/typescript/packages/cli/src/commands/client.ts
+++ b/libraries/typescript/packages/cli/src/commands/client.ts
@@ -1141,9 +1141,6 @@ export function createClientCommand(): Command {
     )
     .action(removeClientCommand);
 
-  // Ad-hoc screenshot form: `mcp-use client screenshot --mcp <url> --tool <name>`.
-  // No saved-server positional — handy for one-off captures and programmatic
-  // use that doesn't want to first run `mcp-use client connect`.
   clientCommand.addCommand(createClientScreenshotCommand());
 
   return clientCommand;
@@ -1270,7 +1267,6 @@ export function createPerClientCommand(name: string): Command {
     .action(() => authLogoutCommand(name));
   cmd.addCommand(authCommand);
 
-  // Per-server screenshot: reuses the saved server's auth (no --mcp/--header).
   cmd.addCommand(createPerClientScreenshotCommand(name));
 
   return cmd;

--- a/libraries/typescript/packages/cli/src/commands/screenshot.ts
+++ b/libraries/typescript/packages/cli/src/commands/screenshot.ts
@@ -24,6 +24,12 @@ interface ScreenshotOptions {
   height: string;
   inspector?: string;
   mcp?: string;
+  /**
+   * Saved-server name. Not a user-facing flag — populated internally by
+   * `createPerClientScreenshotCommand(name)` so the per-client subcommand
+   * `mcp-use client <name> screenshot` reuses the same code path as the
+   * ad-hoc `mcp-use client screenshot --mcp <url>` form.
+   */
   session?: string;
   theme: "light" | "dark";
   output?: string;
@@ -406,8 +412,9 @@ const AD_HOC_SESSION_NAME = "__screenshot_ad_hoc__";
  * Resolve an authenticated MCPSession for the screenshot run.
  *
  * Resolution order:
- *  1. `--session <name>` → restore that saved server (errors if not found)
- *  2. `--mcp <url>` → open an unauthenticated ad-hoc session at that URL
+ *  1. `options.session` → restore that saved server (set by the per-client
+ *     subcommand `mcp-use client <name> screenshot`).
+ *  2. `--mcp <url>` → open an unauthenticated ad-hoc session at that URL.
  */
 async function resolveSessionForScreenshot(
   options: ScreenshotOptions,
@@ -438,7 +445,7 @@ async function resolveSessionForScreenshot(
 
   console.error(
     formatError(
-      "No MCP target. Pass --session <name> (a saved server) or --mcp <url> (ad-hoc)."
+      "No MCP target. Pass --mcp <url> for an ad-hoc connection, or use `mcp-use client <name> screenshot` for a saved server."
     )
   );
   return null;
@@ -446,7 +453,10 @@ async function resolveSessionForScreenshot(
 
 export async function screenshotCommand(
   options: ScreenshotOptions,
-  argsList: string[] | undefined
+  argsList: string[] | undefined,
+  invocation: { usagePrefix: string } = {
+    usagePrefix: "mcp-use client screenshot",
+  }
 ): Promise<void> {
   let exitCode = 0;
 
@@ -466,7 +476,7 @@ export async function screenshotCommand(
       if (!options.mcp) {
         console.error(
           formatError(
-            "--header is only supported with --mcp <url>. Saved sessions (use --session) carry their own auth from `mcp-use client connect`."
+            "--header is only supported with --mcp <url>. Saved servers carry their own auth from `mcp-use client connect`."
           )
         );
         exitCode = 1;
@@ -534,13 +544,13 @@ export async function screenshotCommand(
         console.log("");
         console.log(formatInfo("Usage:"));
         console.log(
-          `  npx mcp-use screenshot --tool ${options.tool} key=value [key2=value2 ...]`
+          `  npx ${invocation.usagePrefix} --tool ${options.tool} key=value [key2=value2 ...]`
         );
         console.log(
-          `  npx mcp-use screenshot --tool ${options.tool} nested:='{"a":1}'   # JSON value`
+          `  npx ${invocation.usagePrefix} --tool ${options.tool} nested:='{"a":1}'   # JSON value`
         );
         console.log(
-          `  npx mcp-use screenshot --tool ${options.tool} '{"key":"value"}'   # full JSON object`
+          `  npx ${invocation.usagePrefix} --tool ${options.tool} '{"key":"value"}'   # full JSON object`
         );
         if (tool.inputSchema) {
           console.log("");
@@ -587,11 +597,13 @@ export async function screenshotCommand(
   }
 }
 
-export function createScreenshotCommand(): Command {
-  return new Command("screenshot")
-    .description(
-      "Render an MCP Apps view headlessly and save a PNG by calling a tool and rendering its UI resource with the result."
-    )
+/**
+ * Apply the screenshot flags that are common to both the ad-hoc top-level form
+ * (`mcp-use client screenshot`) and the per-server form
+ * (`mcp-use client <name> screenshot`).
+ */
+function withCommonScreenshotOptions(cmd: Command): Command {
+  return cmd
     .argument(
       "[args...]",
       "Tool args as key=value pairs (use key:=<json> for nested values, or pass a single JSON object)."
@@ -604,21 +616,7 @@ export function createScreenshotCommand(): Command {
     .option("--height <px>", "Browser viewport height in pixels.", "600")
     .option(
       "--inspector <url>",
-      "Inspector host that serves /inspector/preview/:view. When omitted, probes localhost:3000 then auto-spawns `mcp-use dev`."
-    )
-    .option(
-      "--session <name>",
-      "Saved server name (from `mcp-use client connect <name> <url>`)."
-    )
-    .option(
-      "--mcp <url>",
-      "Ad-hoc MCP server URL (escape hatch). Use when you don't have a saved server. No authentication unless --header is supplied."
-    )
-    .option(
-      "-H, --header <header>",
-      'HTTP header to send to the --mcp <url> server, formatted "Key: Value". Repeatable. Use to pass an Authorization bearer token or other auth headers when screenshotting an authenticated MCP server.',
-      collectHeader,
-      [] as string[]
+      "Inspector host that serves /inspector/preview/:view. When omitted, auto-spawns `@mcp-use/inspector` on a free port."
     )
     .option(
       "--theme <light|dark>",
@@ -643,8 +641,59 @@ export function createScreenshotCommand(): Command {
       "--cdp-url <url>",
       "Connect to an existing CDP WebSocket (ws:// or wss://) instead of spawning local Chrome. Useful for hosted browsers like Notte."
     )
-    .option("--quiet", "Suppress dev-server output.")
-    .action(async (args: string[], opts: ScreenshotOptions) => {
-      await screenshotCommand(opts, args);
+    .option("--quiet", "Suppress dev-server output.");
+}
+
+/**
+ * Top-level ad-hoc form: `mcp-use client screenshot --mcp <url> --tool <name>`.
+ *
+ * Doesn't take a saved-server positional. The MCP server is supplied inline
+ * via `--mcp`, and authenticated servers can be reached with repeatable
+ * `-H, --header` flags. This is the programmatic entry point for one-off or
+ * automated screenshot runs that don't want to first `mcp-use client connect`.
+ */
+export function createClientScreenshotCommand(): Command {
+  const cmd = withCommonScreenshotOptions(
+    new Command("screenshot").description(
+      "Render an MCP Apps view headlessly and save a PNG. Connects to an MCP server inline via --mcp; for a saved server, use `mcp-use client <name> screenshot`."
+    )
+  )
+    .option(
+      "--mcp <url>",
+      "Ad-hoc MCP server URL. Required for the top-level form. No authentication unless --header is supplied."
+    )
+    .option(
+      "-H, --header <header>",
+      'HTTP header to send to the --mcp <url> server, formatted "Key: Value". Repeatable. Use to pass an Authorization bearer token or other auth headers when screenshotting an authenticated MCP server.',
+      collectHeader,
+      [] as string[]
+    );
+
+  cmd.action(async (args: string[], opts: ScreenshotOptions) => {
+    await screenshotCommand(opts, args, {
+      usagePrefix: "mcp-use client screenshot",
     });
+  });
+
+  return cmd;
+}
+
+/**
+ * Per-server form: `mcp-use client <name> screenshot --tool <name>`. The saved
+ * server's auth (OAuth or bearer) is reused — no `--mcp`/`--header` flags.
+ */
+export function createPerClientScreenshotCommand(name: string): Command {
+  const cmd = withCommonScreenshotOptions(
+    new Command("screenshot").description(
+      `Render an MCP Apps view headlessly using the saved server '${name}'.`
+    )
+  );
+
+  cmd.action(async (args: string[], opts: ScreenshotOptions) => {
+    await screenshotCommand({ ...opts, session: name }, args, {
+      usagePrefix: `mcp-use client ${name} screenshot`,
+    });
+  });
+
+  return cmd;
 }

--- a/libraries/typescript/packages/cli/src/commands/screenshot.ts
+++ b/libraries/typescript/packages/cli/src/commands/screenshot.ts
@@ -24,13 +24,6 @@ interface ScreenshotOptions {
   height: string;
   inspector?: string;
   mcp?: string;
-  /**
-   * Saved-server name. Not a user-facing flag — populated internally by
-   * `createPerClientScreenshotCommand(name)` so the per-client subcommand
-   * `mcp-use client <name> screenshot` reuses the same code path as the
-   * ad-hoc `mcp-use client screenshot --mcp <url>` form.
-   */
-  session?: string;
   theme: "light" | "dark";
   output?: string;
   waitFor?: string;
@@ -39,6 +32,11 @@ interface ScreenshotOptions {
   timeout: string;
   cdpUrl?: string;
   header?: string[];
+}
+
+interface ScreenshotContext {
+  sessionName?: string;
+  usagePrefix: string;
 }
 
 /**
@@ -412,16 +410,17 @@ const AD_HOC_SESSION_NAME = "__screenshot_ad_hoc__";
  * Resolve an authenticated MCPSession for the screenshot run.
  *
  * Resolution order:
- *  1. `options.session` → restore that saved server (set by the per-client
+ *  1. `sessionName` → restore that saved server (passed in by the per-client
  *     subcommand `mcp-use client <name> screenshot`).
  *  2. `--mcp <url>` → open an unauthenticated ad-hoc session at that URL.
  */
 async function resolveSessionForScreenshot(
   options: ScreenshotOptions,
+  sessionName: string | undefined,
   headers: Record<string, string> | undefined
 ): Promise<MCPSession | null> {
-  if (options.session) {
-    const result = await getOrRestoreSession(options.session);
+  if (sessionName) {
+    const result = await getOrRestoreSession(sessionName);
     return result?.session ?? null;
   }
 
@@ -454,9 +453,7 @@ async function resolveSessionForScreenshot(
 export async function screenshotCommand(
   options: ScreenshotOptions,
   argsList: string[] | undefined,
-  invocation: { usagePrefix: string } = {
-    usagePrefix: "mcp-use client screenshot",
-  }
+  context: ScreenshotContext
 ): Promise<void> {
   let exitCode = 0;
 
@@ -509,7 +506,11 @@ export async function screenshotCommand(
     const delayMs = options.delay ? parseInt(options.delay, 10) : 0;
 
     // Resolve session before spawning the dev server so auth issues fail fast.
-    const session = await resolveSessionForScreenshot(options, headers);
+    const session = await resolveSessionForScreenshot(
+      options,
+      context.sessionName,
+      headers
+    );
     if (!session) {
       exitCode = 1;
       return;
@@ -544,13 +545,13 @@ export async function screenshotCommand(
         console.log("");
         console.log(formatInfo("Usage:"));
         console.log(
-          `  npx ${invocation.usagePrefix} --tool ${options.tool} key=value [key2=value2 ...]`
+          `  npx ${context.usagePrefix} --tool ${options.tool} key=value [key2=value2 ...]`
         );
         console.log(
-          `  npx ${invocation.usagePrefix} --tool ${options.tool} nested:='{"a":1}'   # JSON value`
+          `  npx ${context.usagePrefix} --tool ${options.tool} nested:='{"a":1}'   # JSON value`
         );
         console.log(
-          `  npx ${invocation.usagePrefix} --tool ${options.tool} '{"key":"value"}'   # full JSON object`
+          `  npx ${context.usagePrefix} --tool ${options.tool} '{"key":"value"}'   # full JSON object`
         );
         if (tool.inputSchema) {
           console.log("");
@@ -690,7 +691,8 @@ export function createPerClientScreenshotCommand(name: string): Command {
   );
 
   cmd.action(async (args: string[], opts: ScreenshotOptions) => {
-    await screenshotCommand({ ...opts, session: name }, args, {
+    await screenshotCommand(opts, args, {
+      sessionName: name,
       usagePrefix: `mcp-use client ${name} screenshot`,
     });
   });

--- a/libraries/typescript/packages/cli/src/index.ts
+++ b/libraries/typescript/packages/cli/src/index.ts
@@ -20,7 +20,6 @@ import {
 } from "./commands/client.js";
 import { getSession } from "./utils/session-storage.js";
 import { formatError } from "./utils/format.js";
-import { createScreenshotCommand } from "./commands/screenshot.js";
 import { deployCommand } from "./commands/deploy.js";
 import { createDeploymentsCommand } from "./commands/deployments.js";
 import { createServersCommand } from "./commands/servers.js";
@@ -3069,8 +3068,9 @@ program
     });
   });
 
-// Client command — pass the CLI bin path so `tools call` can auto-spawn a dev
-// server for widget-screenshot capture, mirroring `mcp-use screenshot`.
+// Client command. The screenshot subcommand lives under `client`:
+//  - `mcp-use client screenshot --mcp <url>` for ad-hoc/programmatic use
+//  - `mcp-use client <name> screenshot` for saved servers (uses their auth)
 program.addCommand(createClientCommand());
 
 // Deployments command
@@ -3081,10 +3081,6 @@ program.addCommand(createServersCommand());
 
 // Skills command
 program.addCommand(createSkillsCommand());
-
-// Screenshot command — pass the path to this CLI bin so auto-spawned dev
-// servers can re-invoke the same binary (works in both dev/tsx + bundled cjs).
-program.addCommand(createScreenshotCommand());
 
 // Generate types command
 program


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

Check all that apply:
- [x] TypeScript
- [x] Documentation only
- [ ] Python
- [ ] CI/CD or tooling

## Changes

Folds the standalone `mcp-use screenshot` command into `mcp-use client`, with two forms — a saved-server form that reuses auth from `mcp-use client connect`, and an ad-hoc form for one-off captures. Removes the `--session` flag in favor of the explicit server-name positional that every other `mcp-use client <name> ...` command already uses.

This mirrors the surface of `mcp-use client` after the removal of the implicit "active session" model: every per-server command takes the server name as its first positional argument.

## Implementation Details

1. `packages/cli/src/commands/screenshot.ts`: split the previous top-level command into two factories — `createClientScreenshotCommand()` (ad-hoc, `--mcp` + optional `-H/--header`) and `createPerClientScreenshotCommand(name)` (saved server, no `--mcp`/`--header` — auth comes from the saved session).
2. `packages/cli/src/commands/client.ts`: register the ad-hoc factory under `mcp-use client screenshot` and the per-client factory under each `mcp-use client <name>`. Add `screenshot` to `RESERVED_CLIENT_SUBCOMMANDS` and `PER_CLIENT_SCOPES`.
3. `packages/cli/src/index.ts`: drop the top-level `program.addCommand(createScreenshotCommand())` registration and its import — the command no longer exists at the root level.
4. `docs/typescript/client/cli.mdx`: update the docs to describe the two new forms and remove the standalone `mcp-use screenshot` entry.

---

## TypeScript Checklist

> Complete this section if your PR includes TypeScript changes

### Packages Modified

Check all packages that were modified:
- [x] `docs`
- [ ] `tests`
- [x] `cli`
- [ ] `create-mcp-use-app`
- [ ] `mcp-use` (server)
- [ ] `mcp-use` (client)
- [ ] `inspector`

### Pre-commit Checklist

Ensure all of the following have been completed:
- [x] Ran `pnpm lint:fix` to auto-fix linting issues
- [x] Ran `pnpm format` to format code with Prettier
- [ ] Ran `pnpm build` and build succeeds without errors
- [x] Ran `pnpm changeset` to create a changeset (if this PR includes user-facing changes)
- [ ] Added or updated tests if needed
- [x] Updated documentation in `docs/` folder if needed

---

## Python Checklist

> Complete this section if your PR includes Python changes

N/A — TypeScript-only change.

---

## Example Usage (Before)

```bash
# Top-level command, with --session pointing at a saved server
mcp-use screenshot --session my-server --tool render_widget --output out.png

# Or fully ad-hoc with --mcp
mcp-use screenshot --mcp https://example.com/mcp --tool render_widget --output out.png
```

## Example Usage (After)

```bash
# Saved server: the server name is the positional, no --session
mcp-use client my-server screenshot --tool render_widget --output out.png

# Ad-hoc: same surface as before, just nested under `client`
mcp-use client screenshot \
  --mcp https://example.com/mcp \
  -H "Authorization: Bearer $TOKEN" \
  --tool render_widget --output out.png
```

## Documentation Updates

* `docs/typescript/client/cli.mdx` — replaced the standalone `screenshot` section with two subsections under `mcp-use client`: the saved-server form and the ad-hoc `--mcp` form. Removed references to `--session`.

## Testing

- Linting passes (`pnpm lint`) and formatting is clean (`pnpm format`).
- Manual: invoked the new `mcp-use client <name> screenshot` and `mcp-use client screenshot --mcp ...` flows locally; the old top-level `mcp-use screenshot` no longer resolves, which is the intended breaking behavior.

## Backwards Compatibility

**Breaking.** Users will need to update invocations:

- `mcp-use screenshot ...` → use `mcp-use client <name> screenshot ...` (saved server) or `mcp-use client screenshot --mcp <url> ...` (ad-hoc).
- The `--session <name>` flag is removed — the saved server name is the positional in `mcp-use client <name> screenshot`.
- `screenshot` is now a reserved name and cannot be used as a saved-server name.

A `minor` changeset is included for `@mcp-use/cli`.

## Related Issues

N/A