### PR TITLE
feat(cli): add --device-scale-factor flag for high-DPI screenshots

### DIFF
--- a/docs/typescript/client/cli.mdx
+++ b/docs/typescript/client/cli.mdx
@@ -167,7 +167,7 @@ npx mcp-use client screenshot \
   --tool show-board boardId=demo
 ```
 
-Common flags (both forms): `--width`, `--height`, `--theme light|dark`, `--output <path>`, `--wait-for <selector>`, `--delay <ms>`, `--timeout <ms>`, `--inspector <url>`, `--cdp-url <ws-url>`, `--quiet`. Run `mcp-use client screenshot --help` for the full list.
+Common flags (both forms): `--width`, `--height`, `--device-scale-factor <n>` (e.g. `2` for Retina; defaults to `1`), `--theme light|dark`, `--output <path>`, `--wait-for <selector>`, `--delay <ms>`, `--timeout <ms>`, `--inspector <url>`, `--cdp-url <ws-url>`, `--quiet`. Run `mcp-use client screenshot --help` for the full list.
 
 <Note>
 `-H/--header` only applies to the ad-hoc form. The saved-server form carries the server's auth (OAuth or `--auth <token>` from `connect`) automatically.
@@ -206,6 +206,7 @@ Per-server commands accept these flags where they make sense:
 - `--timeout <ms>`: Request timeout (on `tools call`).
 - `--no-screenshot`: Skip the auto-screenshot capture for tools that render a widget (on `tools call`).
 - `--screenshot-output <path>`: Override the screenshot output path.
+- `--screenshot-device-scale-factor <n>`: Device pixel ratio for the auto-screenshot (e.g. `2` for Retina). Defaults to `1`. The dedicated `mcp-use client screenshot` command exposes the same knob as `--device-scale-factor <n>`.
 
 ## Storage
 

--- a/libraries/typescript/.changeset/cli-screenshot-device-scale-factor.md
+++ b/libraries/typescript/.changeset/cli-screenshot-device-scale-factor.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/cli": minor
+---
+
+feat(cli): add `--device-scale-factor <n>` to `mcp-use client screenshot` (both ad-hoc and per-server forms) and `--screenshot-device-scale-factor <n>` to `mcp-use client <name> tools call` for capturing high-DPI widget screenshots (e.g. Retina-style 2x). Defaults to 1, so existing behavior is unchanged. Accepts fractional values; bounded to (0, 4].

--- a/libraries/typescript/packages/cli/src/commands/client.ts
+++ b/libraries/typescript/packages/cli/src/commands/client.ts
@@ -49,6 +49,7 @@ import {
   createClientScreenshotCommand,
   createPerClientScreenshotCommand,
   detectToolResourceUri,
+  parseDeviceScaleFactor,
 } from "./screenshot.js";
 
 /**
@@ -528,6 +529,7 @@ export async function callToolCommand(
     json?: boolean;
     screenshot?: boolean;
     screenshotOutput?: string;
+    screenshotDeviceScaleFactor?: string;
   }
 ): Promise<void> {
   try {
@@ -605,6 +607,18 @@ export async function callToolCommand(
           formatInfo(`Capturing widget screenshot (${resourceUri})...`)
         );
         try {
+          const screenshotOpts: {
+            output?: string;
+            deviceScaleFactor?: number;
+          } = {};
+          if (options?.screenshotOutput) {
+            screenshotOpts.output = options.screenshotOutput;
+          }
+          if (options?.screenshotDeviceScaleFactor) {
+            screenshotOpts.deviceScaleFactor = parseDeviceScaleFactor(
+              options.screenshotDeviceScaleFactor
+            );
+          }
           const shot = await captureToolScreenshot(
             {
               session,
@@ -613,9 +627,7 @@ export async function callToolCommand(
               toolOutput: callResult,
               resourceUri,
             },
-            options?.screenshotOutput
-              ? { output: options.screenshotOutput }
-              : {}
+            screenshotOpts
           );
           screenshot = {
             path: shot.outputPath,
@@ -1192,6 +1204,10 @@ export function createPerClientCommand(name: string): Command {
     .option(
       "--screenshot-output <path>",
       "Output PNG path for the widget screenshot (defaults to ./<view>-<timestamp>.png)"
+    )
+    .option(
+      "--screenshot-device-scale-factor <n>",
+      "Device pixel ratio for the auto-screenshot (e.g. 2 for Retina). Defaults to 1."
     )
     .action((tool, args, options) =>
       callToolCommand(name, tool, args, options)

--- a/libraries/typescript/packages/cli/src/commands/screenshot.ts
+++ b/libraries/typescript/packages/cli/src/commands/screenshot.ts
@@ -32,6 +32,7 @@ interface ScreenshotOptions {
   timeout: string;
   cdpUrl?: string;
   header?: string[];
+  deviceScaleFactor?: string;
 }
 
 interface ScreenshotContext {
@@ -121,6 +122,12 @@ export interface CaptureToolScreenshotOptions {
    * must be reachable from that remote browser.
    */
   cdpUrl?: string;
+  /**
+   * Device pixel ratio for rendering. Defaults to 1. With a value of 2 the
+   * resulting PNG is (width × 2) × (height × 2) device pixels (Retina-style
+   * capture). Forwarded to `Emulation.setDeviceMetricsOverride`.
+   */
+  deviceScaleFactor?: number;
 }
 
 export interface CaptureToolScreenshotResult {
@@ -192,6 +199,7 @@ export async function captureToolScreenshot(
       cdpUrl: options.cdpUrl,
       delayMs: Number.isFinite(delayMs) && delayMs > 0 ? delayMs : 0,
       bundle,
+      deviceScaleFactor: options.deviceScaleFactor,
     });
 
     return { outputPath, width, height, view };
@@ -404,6 +412,25 @@ export function parseDimension(raw: string, name: string): number {
   return n;
 }
 
+/**
+ * Parse `--device-scale-factor <n>`. Allows fractional values (e.g. 1.5) and
+ * caps at 4 to avoid accidental 16x-pixel screenshots (memory + disk).
+ */
+export function parseDeviceScaleFactor(raw: string): number {
+  const n = parseFloat(raw);
+  if (!Number.isFinite(n) || n <= 0) {
+    throw new Error(
+      `--device-scale-factor must be a positive number (got "${raw}")`
+    );
+  }
+  if (n > 4) {
+    throw new Error(
+      `--device-scale-factor must be <= 4 to avoid excessive pixel counts (got "${raw}")`
+    );
+  }
+  return n;
+}
+
 const AD_HOC_SESSION_NAME = "__screenshot_ad_hoc__";
 
 /**
@@ -504,6 +531,9 @@ export async function screenshotCommand(
     const height = parseDimension(options.height, "height");
     const navTimeout = parseInt(options.timeout, 10) || 30000;
     const delayMs = options.delay ? parseInt(options.delay, 10) : 0;
+    const deviceScaleFactor = options.deviceScaleFactor
+      ? parseDeviceScaleFactor(options.deviceScaleFactor)
+      : undefined;
 
     // Resolve session before spawning the dev server so auth issues fail fast.
     const session = await resolveSessionForScreenshot(
@@ -583,6 +613,7 @@ export async function screenshotCommand(
         inspector: options.inspector,
         quiet: options.quiet,
         cdpUrl: options.cdpUrl,
+        deviceScaleFactor,
       }
     );
 
@@ -615,6 +646,10 @@ function withCommonScreenshotOptions(cmd: Command): Command {
     )
     .option("--width <px>", "Browser viewport width in pixels.", "800")
     .option("--height <px>", "Browser viewport height in pixels.", "600")
+    .option(
+      "--device-scale-factor <n>",
+      "Device pixel ratio for rendering (e.g. 2 for Retina). Output PNG is (width × dsf) × (height × dsf). Must be > 0 and <= 4."
+    )
     .option(
       "--inspector <url>",
       "Inspector host that serves /inspector/preview/:view. When omitted, auto-spawns `@mcp-use/inspector` on a free port."

--- a/libraries/typescript/packages/cli/src/utils/cdp-screenshot.ts
+++ b/libraries/typescript/packages/cli/src/utils/cdp-screenshot.ts
@@ -23,6 +23,13 @@ export interface CaptureScreenshotOptions {
   /** Extra wait after the readiness selector matches, to let animations settle. */
   delayMs?: number;
   /**
+   * Device pixel ratio applied via `Emulation.setDeviceMetricsOverride`. The
+   * viewport stays `width × height` in CSS pixels but the resulting PNG is
+   * `(width × dsf) × (height × dsf)` device pixels — same convention as
+   * Playwright/Puppeteer. Defaults to 1.
+   */
+  deviceScaleFactor?: number;
+  /**
    * Optional pre-render bundle. When provided, it is JSON-serialized and
    * assigned to `globalThis.__mcpUsePreviewBundle` before any document
    * scripts run. The inspector preview route reads this global and renders
@@ -326,7 +333,7 @@ export async function captureScreenshot(
       {
         width: opts.width,
         height: opts.height,
-        deviceScaleFactor: 1,
+        deviceScaleFactor: opts.deviceScaleFactor ?? 1,
         mobile: false,
       },
       sessionId

--- a/libraries/typescript/packages/cli/tests/screenshot.test.ts
+++ b/libraries/typescript/packages/cli/tests/screenshot.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   detectToolResourceUri,
   extractViewName,
+  parseDeviceScaleFactor,
   parseDimension,
   parseHeaderArg,
   parseHeaderArgs,
@@ -53,6 +54,36 @@ describe("parseDimension", () => {
     expect(() => parseDimension("0", "width")).toThrow(/positive integer/);
     expect(() => parseDimension("-1", "width")).toThrow(/positive integer/);
     expect(() => parseDimension("abc", "width")).toThrow(/positive integer/);
+  });
+});
+
+describe("parseDeviceScaleFactor", () => {
+  it("parses positive integers", () => {
+    expect(parseDeviceScaleFactor("1")).toBe(1);
+    expect(parseDeviceScaleFactor("2")).toBe(2);
+    expect(parseDeviceScaleFactor("3")).toBe(3);
+  });
+
+  it("parses fractional values", () => {
+    expect(parseDeviceScaleFactor("1.5")).toBe(1.5);
+    expect(parseDeviceScaleFactor("2.75")).toBe(2.75);
+  });
+
+  it("accepts the upper bound of 4", () => {
+    expect(parseDeviceScaleFactor("4")).toBe(4);
+  });
+
+  it("rejects zero, negatives, NaN", () => {
+    expect(() => parseDeviceScaleFactor("0")).toThrow(/positive number/);
+    expect(() => parseDeviceScaleFactor("-1")).toThrow(/positive number/);
+    expect(() => parseDeviceScaleFactor("-0.5")).toThrow(/positive number/);
+    expect(() => parseDeviceScaleFactor("abc")).toThrow(/positive number/);
+    expect(() => parseDeviceScaleFactor("")).toThrow(/positive number/);
+  });
+
+  it("rejects values above 4", () => {
+    expect(() => parseDeviceScaleFactor("5")).toThrow(/<= 4/);
+    expect(() => parseDeviceScaleFactor("100")).toThrow(/<= 4/);
   });
 });
 


### PR DESCRIPTION
> Stacked on top of [#1497](https://github.com/mcp-use/mcp-use/pull/1497) (mcp-2165 — moving `screenshot` under `client`). Merge that one first.

## Language / Project Scope

- [x] TypeScript
- [x] Documentation only (also)

## Changes

Exposes the previously-hardcoded CDP `deviceScaleFactor` so users can capture high-DPI (Retina-style) widget screenshots from the CLI. Two new flags, one shared knob underneath.

## Implementation Details

1. **`mcp-use client screenshot`** (both the ad-hoc `--mcp` form and the per-server `mcp-use client <name> screenshot` form): new `--device-scale-factor <n>` flag, plumbed through `withCommonScreenshotOptions` so both subcommands inherit it automatically.
2. **`mcp-use client <name> tools call`**: new `--screenshot-device-scale-factor <n>` flag for the auto-screenshot path. Named distinctly so it doesn't collide with the tool's own potential `--device-scale-factor` arg.
3. Both flags accept fractional values (e.g. `1.5`), default to `1` (preserving existing behavior), and are bounded to `(0, 4]` to prevent accidentally requesting a 16× pixel grid that exhausts memory/disk.
4. Forwarded to `Emulation.setDeviceMetricsOverride` in [`cdp-screenshot.ts`](libraries/typescript/packages/cli/src/utils/cdp-screenshot.ts). The CSS viewport stays at `width × height`; the resulting PNG is `(width × dsf) × (height × dsf)` device pixels — same convention as Playwright/Puppeteer.
5. New `parseDeviceScaleFactor()` validator with explicit error messages for non-numeric, zero/negative, and out-of-range inputs.

## Example Usage (Before)

```bash
# Hardcoded 1× regardless of intent
npx mcp-use client screenshot --mcp https://mcp.example.com --tool show-board
# → 800×600 PNG
```

## Example Usage (After)

```bash
# Ad-hoc form, 2× Retina capture
npx mcp-use client screenshot --mcp https://mcp.example.com --tool show-board \
  --device-scale-factor 2
# → 1600×1200 PNG, same 800×600 CSS viewport

# Per-server form
npx mcp-use client manufact screenshot --tool show-board --device-scale-factor 2

# Auto-screenshot from a tool call
npx mcp-use client manufact tools call show-board boardId=demo \
  --screenshot-device-scale-factor 2
```

## Documentation Updates

- `docs/typescript/client/cli.mdx` — added `--device-scale-factor` to the screenshot common-flags summary; documented `--screenshot-device-scale-factor` in the per-server global-flags section.

## Testing

- Added `parseDeviceScaleFactor` unit tests in `packages/cli/tests/screenshot.test.ts` (positive ints, fractional, upper bound, zero/negative/NaN/empty rejection, >4 rejection).
- Full CLI test suite passes (270 tests).
- `pnpm build` succeeds.

## Backwards Compatibility

Non-breaking. Both flags are optional and default to `1`, which matches the previous hardcoded behavior. No existing invocation changes.

## Related Issues

Closes MCP-2167