### PR TITLE
fix(cli): error when client screenshot omits required tool args

### DIFF
--- a/libraries/typescript/.changeset/screenshot-required-args.md
+++ b/libraries/typescript/.changeset/screenshot-required-args.md
@@ -1,0 +1,12 @@
+---
+"@mcp-use/cli": patch
+---
+
+fix(cli): error when `client screenshot` omits required tool arguments
+
+`mcp-use client screenshot --tool <tool>` (and `mcp-use client <name>
+screenshot --tool <tool>`) silently produced a blank PNG and exited 0
+when the target tool declared required arguments but none were passed.
+The command now mirrors `client tools call`: it prints "This tool
+requires arguments." along with the tool schema and exits 1, before
+launching the inspector or browser.

--- a/libraries/typescript/packages/cli/src/commands/screenshot.ts
+++ b/libraries/typescript/packages/cli/src/commands/screenshot.ts
@@ -431,6 +431,12 @@ export function parseDeviceScaleFactor(raw: string): number {
   return n;
 }
 
+export function requiresArguments(inputSchema: unknown): boolean {
+  if (!inputSchema || typeof inputSchema !== "object") return false;
+  const required = (inputSchema as { required?: unknown }).required;
+  return Array.isArray(required) && required.length > 0;
+}
+
 const AD_HOC_SESSION_NAME = "__screenshot_ad_hoc__";
 
 /**
@@ -591,6 +597,18 @@ export async function screenshotCommand(
         exitCode = 1;
         return;
       }
+    } else if (requiresArguments(tool.inputSchema)) {
+      console.error(formatError("This tool requires arguments."));
+      console.log("");
+      console.log(formatInfo("Provide arguments as key=value pairs:"));
+      console.log(
+        `  npx ${invocation.usagePrefix} --tool ${options.tool} key=value [key2=value2 ...]`
+      );
+      console.log("");
+      console.log(formatInfo("Tool schema:"));
+      console.log(formatSchema(tool.inputSchema));
+      exitCode = 1;
+      return;
     }
     const toolOutput = await session.callTool(options.tool, toolArgs);
 

--- a/libraries/typescript/packages/cli/src/commands/screenshot.ts
+++ b/libraries/typescript/packages/cli/src/commands/screenshot.ts
@@ -602,7 +602,7 @@ export async function screenshotCommand(
       console.log("");
       console.log(formatInfo("Provide arguments as key=value pairs:"));
       console.log(
-        `  npx ${invocation.usagePrefix} --tool ${options.tool} key=value [key2=value2 ...]`
+        `  npx ${context.usagePrefix} --tool ${options.tool} key=value [key2=value2 ...]`
       );
       console.log("");
       console.log(formatInfo("Tool schema:"));

--- a/libraries/typescript/packages/cli/tests/screenshot.test.ts
+++ b/libraries/typescript/packages/cli/tests/screenshot.test.ts
@@ -6,6 +6,7 @@ import {
   parseDimension,
   parseHeaderArg,
   parseHeaderArgs,
+  requiresArguments,
   timestampSuffix,
 } from "../src/commands/screenshot.js";
 
@@ -84,6 +85,27 @@ describe("parseDeviceScaleFactor", () => {
   it("rejects values above 4", () => {
     expect(() => parseDeviceScaleFactor("5")).toThrow(/<= 4/);
     expect(() => parseDeviceScaleFactor("100")).toThrow(/<= 4/);
+  });
+});
+
+describe("requiresArguments", () => {
+  it("returns true when required is a non-empty array", () => {
+    expect(requiresArguments({ required: ["foo"] })).toBe(true);
+    expect(requiresArguments({ required: ["foo", "bar"] })).toBe(true);
+  });
+
+  it("returns false when required is missing, empty, or non-array", () => {
+    expect(requiresArguments({})).toBe(false);
+    expect(requiresArguments({ required: [] })).toBe(false);
+    expect(requiresArguments({ required: "foo" })).toBe(false);
+    expect(requiresArguments({ required: null })).toBe(false);
+  });
+
+  it("returns false for nullish or non-object input", () => {
+    expect(requiresArguments(undefined)).toBe(false);
+    expect(requiresArguments(null)).toBe(false);
+    expect(requiresArguments("not a schema")).toBe(false);
+    expect(requiresArguments(42)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Language / Project Scope

- [x] TypeScript

## Changes

`mcp-use client screenshot --tool <tool>` silently produced a blank PNG and exited 0 when the tool declared required arguments but none were passed. The CLI now mirrors `client tools call`: it prints `This tool requires arguments.` plus the tool schema, exits 1, and skips spawning the inspector/browser entirely.

> Stacked on top of [feature/mcp-2167-add-device-scale-factor-2-flag-for-screenshots](https://github.com/mcp-use/mcp-use/tree/feature/mcp-2167-add-device-scale-factor-2-flag-for-screenshots) — please merge that PR first.

## Implementation Details

1. Added `requiresArguments(inputSchema)` pure helper in `packages/cli/src/commands/screenshot.ts` — returns `true` when `inputSchema.required` is a non-empty array, `false` otherwise (handles nullish / non-object input).
2. In `screenshotCommand`, added an `else if (requiresArguments(tool.inputSchema))` branch after the existing parse-error block. Prints the same `formatError("This tool requires arguments.")` line, usage hint (using the per-invocation `usagePrefix` so the message reflects `client screenshot --mcp …` vs `client <name> screenshot`), and `formatSchema(tool.inputSchema)`, then sets `exitCode = 1` and returns before the browser launches.
3. No new abstraction across files — mirrors the existing pattern at `commands/client.ts:570-584`. Refactoring into a shared helper was considered but skipped: the two call sites print slightly different usage strings, and the inline version keeps the diff focused.

---

## TypeScript Checklist

### Packages Modified

- [x] `cli`

### Pre-commit Checklist

- [x] Ran `pnpm lint:fix` to auto-fix linting issues
- [x] Ran `pnpm format` to format code with Prettier
- [x] Ran `pnpm build` and build succeeds without errors
- [x] Ran `pnpm changeset` to create a changeset
- [x] Added or updated tests if needed
- [ ] Updated documentation in `docs/` folder if needed — N/A, no public API change

---

## Example Usage (Before)

```
$ mcp-use client manufact screenshot --tool get_server_client_breakdown --device-scale-factor 2 --output /tmp/x.png
[tokens] Access token expiring soon, refreshing...
[tokens] Refreshed successfully
Starting inspector on port 60769…
[inspector] 🚀 MCP Inspector running on http://localhost:60769
Saved screenshot: /tmp/x.png (800×600)
$ echo $?
0
$ file /tmp/x.png
/tmp/x.png: PNG image data, 1600 x 1200, 8-bit/color RGB, non-interlaced  # fully blank
```

## Example Usage (After)

```
$ mcp-use client manufact screenshot --tool get_server_client_breakdown --device-scale-factor 2 --output /tmp/x.png
[tokens] Access token expiring soon, refreshing...
[tokens] Refreshed successfully
✗ Error: This tool requires arguments.

Provide arguments as key=value pairs:
  npx mcp-use client manufact screenshot --tool get_server_client_breakdown key=value [key2=value2 ...]

Tool schema:
organizationId (string) *required
  The organization ID the server belongs to. ...
serverId (string) *required
  The server ID to query. ...
timeRange (string)
  ...
$ echo $?
1
$ test -f /tmp/x.png && echo exists || echo "no PNG written"
no PNG written
```

## Documentation Updates

None — error message and schema are self-documenting; no public API surface change.

## Testing

- **Unit:** Added 3 `requiresArguments` test cases in `packages/cli/tests/screenshot.test.ts` covering (a) non-empty required array, (b) missing/empty/non-array `required` field, (c) nullish / non-object input. Full screenshot test file: 32 tests pass.
- **Manual:** Reproduced the original blank-PNG bug against `mcp.manufact.com/mcp` calling `get_server_client_breakdown` with no args (silent exit 0, blank PNG). Re-ran the same command after the fix — confirmed exit 1, schema printed, no inspector spawned, no PNG written. Re-ran with valid `organizationId=… serverId=…` to confirm the happy path still renders the chart correctly.
- **Edge case considered:** Tool with `inputSchema` but no `required` field (all-optional args) — `requiresArguments` returns `false`, command proceeds with `{}` args as before.

## Backwards Compatibility

Backwards compatible. Previously the command silently succeeded with a blank output for an invalid input shape. The new behavior is strictly more correct — anyone whose CI was relying on the false-success exit code was already broken in practice (the PNG was empty). No flag changes, no schema changes.

## Related Issues

N/A — surfaced while testing the `--device-scale-factor` flag from the parent PR.