### PR TITLE
feat(cli): make widget screenshot opt-in via --screenshot

### DIFF
--- a/docs/typescript/client/cli.mdx
+++ b/docs/typescript/client/cli.mdx
@@ -204,9 +204,9 @@ Per-server commands accept these flags where they make sense:
 
 - `--json`: Output results as JSON (on `list`/`call`/`read`/`get`).
 - `--timeout <ms>`: Request timeout (on `tools call`).
-- `--no-screenshot`: Skip the auto-screenshot capture for tools that render a widget (on `tools call`).
-- `--screenshot-output <path>`: Override the screenshot output path.
-- `--screenshot-device-scale-factor <n>`: Device pixel ratio for the auto-screenshot (e.g. `2` for Retina). Defaults to `1`. The dedicated `mcp-use client screenshot` command exposes the same knob as `--device-scale-factor <n>`.
+- `--screenshot`: Capture a PNG screenshot of the rendered widget (on `tools call`, when the tool declares a UI resource). Opt-in — when omitted, the CLI prints a hint suggesting this flag.
+- `--screenshot-output <path>`: Override the screenshot output path. Implies `--screenshot`.
+- `--screenshot-device-scale-factor <n>`: Device pixel ratio for the widget screenshot (e.g. `2` for Retina). Defaults to `1`. Implies `--screenshot`. The dedicated `mcp-use client screenshot` command exposes the same knob as `--device-scale-factor <n>`.
 
 ## Storage
 

--- a/libraries/typescript/.changeset/cli-screenshot-opt-in.md
+++ b/libraries/typescript/.changeset/cli-screenshot-opt-in.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/cli": minor
+---
+
+feat(cli)!: make widget screenshot opt-in on `mcp-use client <name> tools call`. The `--no-screenshot` flag is replaced by `--screenshot`. By default, tool calls no longer capture a PNG of any rendered widget; when a tool declares a UI resource and `--screenshot` is omitted, the CLI prints a hint suggesting the flag. Passing `--screenshot-output` or `--screenshot-device-scale-factor` implies `--screenshot`. Breaking: scripts/agents relying on auto-capture must add `--screenshot`.

--- a/libraries/typescript/packages/cli/src/commands/client.ts
+++ b/libraries/typescript/packages/cli/src/commands/client.ts
@@ -588,10 +588,18 @@ export async function callToolCommand(
       timeout: options?.timeout,
     });
 
-    // Auto-screenshot if the tool renders a widget. Capture before printing
-    // so the screenshot path is part of the printed result — agents reading
-    // `--json` output get the path inside the JSON. Failures here don't fail
-    // the tool call; the result is still printed and a warning is logged.
+    // Screenshot is opt-in via --screenshot. Any of the screenshot-related
+    // flags also implies opt-in so users don't have to pass `--screenshot`
+    // alongside `--screenshot-output`. Capture before printing so the path is
+    // part of the printed result — agents reading `--json` output get it
+    // inside the JSON. Failures don't fail the tool call.
+    const toolWithMeta = session.tools.find((t) => t.name === toolName);
+    const resourceUri = detectToolResourceUri(toolWithMeta);
+    const wantsScreenshot =
+      options?.screenshot === true ||
+      options?.screenshotOutput !== undefined ||
+      options?.screenshotDeviceScaleFactor !== undefined;
+
     let screenshot: {
       path: string;
       width: number;
@@ -599,10 +607,9 @@ export async function callToolCommand(
       view: string;
     } | null = null;
     let screenshotError: string | null = null;
-    if (options?.screenshot !== false) {
-      const tool = session.tools.find((t) => t.name === toolName);
-      const resourceUri = detectToolResourceUri(tool);
-      if (resourceUri) {
+    let widgetHintUri: string | null = null;
+    if (resourceUri) {
+      if (wantsScreenshot) {
         console.error(
           formatInfo(`Capturing widget screenshot (${resourceUri})...`)
         );
@@ -638,6 +645,8 @@ export async function callToolCommand(
         } catch (err: any) {
           screenshotError = err?.message ?? String(err);
         }
+      } else {
+        widgetHintUri = resourceUri;
       }
     }
 
@@ -660,6 +669,13 @@ export async function callToolCommand(
     if (screenshotError) {
       console.error(
         formatWarning(`Skipped widget screenshot: ${screenshotError}`)
+      );
+    }
+    if (widgetHintUri) {
+      console.error(
+        formatInfo(
+          `This tool renders a widget (${widgetHintUri}). Re-run with --screenshot to save a PNG of it.`
+        )
       );
     }
 
@@ -1198,16 +1214,16 @@ export function createPerClientCommand(name: string): Command {
     .option("--timeout <ms>", "Request timeout in milliseconds", parseInt)
     .option("--json", "Output as JSON")
     .option(
-      "--no-screenshot",
-      "Skip the auto-screenshot for tools that render a widget"
+      "--screenshot",
+      "Capture a PNG screenshot of the rendered widget for tools that declare a UI resource"
     )
     .option(
       "--screenshot-output <path>",
-      "Output PNG path for the widget screenshot (defaults to ./<view>-<timestamp>.png)"
+      "Output PNG path for the widget screenshot (implies --screenshot; defaults to ./<view>-<timestamp>.png)"
     )
     .option(
       "--screenshot-device-scale-factor <n>",
-      "Device pixel ratio for the auto-screenshot (e.g. 2 for Retina). Defaults to 1."
+      "Device pixel ratio for the widget screenshot (implies --screenshot; e.g. 2 for Retina). Defaults to 1."
     )
     .action((tool, args, options) =>
       callToolCommand(name, tool, args, options)


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

- [x] TypeScript
- [x] Documentation only
- [ ] Python
- [ ] CI/CD or tooling

## Changes

Reverses the default behavior of `mcp-use client <name> tools call`: it no longer auto-captures a PNG of any rendered widget. Screenshot capture is now opt-in via `--screenshot`. When a tool declares a UI resource and `--screenshot` is omitted, the CLI prints a hint pointing the user at the flag.

## Implementation Details

1. `callToolCommand` in `libraries/typescript/packages/cli/src/commands/client.ts` now treats `options.screenshot` as a true/undefined opt-in flag instead of true-by-default-skipped-with-false.
2. `--screenshot-output` and `--screenshot-device-scale-factor` imply `--screenshot` for ergonomics — users specifying screenshot details don't have to pass the bare flag too.
3. When the tool renders a widget but no screenshot is requested, an info line is printed to stderr: `This tool renders a widget (<uri>). Re-run with --screenshot to save a PNG of it.` Going to stderr keeps `--json` stdout clean for agents.
4. Replaced the commander `--no-screenshot` boolean with `--screenshot`. Updated the option descriptions on `--screenshot-output` and `--screenshot-device-scale-factor` to call out the implication.
5. Updated `docs/typescript/client/cli.mdx` and added a changeset.

---

## TypeScript Checklist

### Packages Modified

- [x] `docs`
- [x] `cli`
- [ ] `tests`
- [ ] `create-mcp-use-app`
- [ ] `mcp-use` (server)
- [ ] `mcp-use` (client)
- [ ] `inspector`

### Pre-commit Checklist

- [x] Ran `pnpm lint:fix` to auto-fix linting issues
- [x] Ran `pnpm format` to format code with Prettier
- [x] Ran `pnpm build` and build succeeds without errors
- [x] Ran `pnpm changeset` to create a changeset
- [x] Added or updated tests if needed (existing 273 CLI tests pass; behavior change is captured in user-visible help/docs)
- [x] Updated documentation in `docs/` folder

---

## Example Usage (Before)

```bash
# Auto-screenshot on every widget-rendering tool call.
npx mcp-use client manufact tools call show-board
# → produced ./board-<ts>.png

# Opt out with --no-screenshot.
npx mcp-use client manufact tools call show-board --no-screenshot
```

## Example Usage (After)

```bash
# No screenshot by default. If the tool renders a widget, the CLI prints:
#   ℹ This tool renders a widget (ui://widget/board.html).
#     Re-run with --screenshot to save a PNG of it.
npx mcp-use client manufact tools call show-board

# Opt in to capture a screenshot:
npx mcp-use client manufact tools call show-board --screenshot

# Either of these also implies --screenshot:
npx mcp-use client manufact tools call show-board --screenshot-output ./out.png
npx mcp-use client manufact tools call show-board --screenshot-device-scale-factor 2
```

## Documentation Updates

* `docs/typescript/client/cli.mdx` — replaced the `--no-screenshot` entry under "Global Flags" with the new `--screenshot` flag; noted that `--screenshot-output` and `--screenshot-device-scale-factor` imply `--screenshot`.

## Testing

- Built `@mcp-use/cli` cleanly (`pnpm --filter @mcp-use/cli build`).
- Ran the full CLI test suite (`pnpm --filter @mcp-use/cli test`) — 273 passed, 6 todo, no regressions.
- Manually verified `node dist/index.cjs client foo tools call --help` shows the new `--screenshot` flag and the updated descriptions on the related options.

## Backwards Compatibility

**Breaking change** for the `tools call` subcommand. Migration:

- Scripts/agents relying on the previous auto-capture must add `--screenshot`.
- The `--no-screenshot` flag has been removed (no longer needed since the default is now off).

Marked as a minor bump in the changeset (project is pre-1.0 / canary) with an explicit breaking note in the changelog summary.

## Related Issues

n/a