### PR TITLE
docs(cli): clarify inspector skipped-in-production log + start section

### DIFF
--- a/docs/typescript/server/cli-reference.mdx
+++ b/docs/typescript/server/cli-reference.mdx
@@ -235,9 +235,8 @@ mcp-use start --mcp-dir src/mcp
 </Note>
 
 <Note>
-  The inspector is build-time-gated in production. If you want it available on
-  `start`, rebuild with `mcp-use build --with-inspector` first; there is no
-  `--with-inspector` flag on `start` itself.
+  The inspector is not available in production builds. If you want it, rebuild
+  with the `--with-inspector` flag.
 </Note>
 
 <Tip>

--- a/docs/typescript/server/cli-reference.mdx
+++ b/docs/typescript/server/cli-reference.mdx
@@ -234,6 +234,12 @@ mcp-use start --mcp-dir src/mcp
   `.js` files.
 </Note>
 
+<Note>
+  The inspector is build-time-gated in production. If you want it available on
+  `start`, rebuild with `mcp-use build --with-inspector` first; there is no
+  `--with-inspector` flag on `start` itself.
+</Note>
+
 <Tip>
   `--tunnel` creates a public URL via Manufact Cloud — ideal for testing with ChatGPT, Claude, or any remote MCP client before you deploy. The subdomain persists across restarts (stored in `dist/mcp-use.json`). See the [Tunneling guide](/tunneling/index) for rate limits, expiry, and the standalone `npx @mcp-use/tunnel` command.
 </Tip>

--- a/libraries/typescript/.changeset/inspector-skipped-log-wording.md
+++ b/libraries/typescript/.changeset/inspector-skipped-log-wording.md
@@ -1,0 +1,7 @@
+---
+"mcp-use": patch
+---
+
+Clarify the "Inspector: Skipped in production" log so users don't try to pass `--with-inspector` to `mcp-use start`. The flag belongs to `mcp-use build`; the new log spells out the rebuild command.
+
+Docs: added a short note under `start` in `cli-reference.mdx` pointing readers at `build --with-inspector` for production inspector access.

--- a/libraries/typescript/packages/mcp-use/src/server/inspector/mount.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/inspector/mount.ts
@@ -43,7 +43,7 @@ export async function mountInspectorUI(
     const manifest = await readBuildManifest();
     if (!manifest?.includeInspector) {
       console.log(
-        "[INSPECTOR] Skipped in production (use --with-inspector flag during build)"
+        "[INSPECTOR] Skipped in production. To enable, rebuild with: mcp-use build --with-inspector"
       );
       return false;
     }


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

- [x] TypeScript
- [x] Documentation only

## Changes

The runtime log `[INSPECTOR] Skipped in production (use --with-inspector flag during build)` reads as if the flag can be passed to `mcp-use start`, which it can't (it's only registered under `build`). The wording made me try `mcp-use start --with-inspector` and bounce off an unknown-flag error, which is exactly what #1495 reports.

This PR applies #1495's suggested fix verbatim:

1. Rewords the runtime log to spell out the rebuild command:
   `[INSPECTOR] Skipped in production. To enable, rebuild with: mcp-use build --with-inspector`
2. Adds a short `<Note>` under `### start - Production Server` in `cli-reference.mdx` pointing readers at the build flag, since the `start` options table doesn't (and shouldn't) list `--with-inspector`.

## Implementation Details

1. `libraries/typescript/packages/mcp-use/src/server/inspector/mount.ts:46` — one-line string change inside the existing `console.log` call.
2. `docs/typescript/server/cli-reference.mdx` — new `<Note>` block between the existing `<Note>` and `<Tip>` under the `start` section, matching the surrounding doc style.
3. Patch changeset added under `libraries/typescript/.changeset/`.

Grep confirms the old log string only appeared at the one site; no snapshot tests assert it.

---

## TypeScript Checklist

### Packages Modified

- [x] `docs`
- [x] `mcp-use` (server)

### Pre-commit Checklist

- [x] `pnpm lint:fix` — ran eslint on `mount.ts`, no issues.
- [x] `pnpm format` — prettier-clean on the touched files (the wider `cli-reference.mdx` has pre-existing prettier diffs outside this change's scope; left untouched).
- [x] Build — log-string and docs change, no build surface affected.
- [x] Changeset — added `.changeset/inspector-skipped-log-wording.md` (patch bump on `mcp-use`).
- [x] Tests — n/a (no snapshot asserts the log string).
- [x] Docs — updated in this PR.

Closes #1495