### PR TITLE
chore: host context7.json under Mintlify docs

### DIFF
--- a/docs/context7.json
+++ b/docs/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/mcp-use/mcp-use",
+  "public_key": "pk_DHbfCHmtCxcbCOAR8Q9HX"
+}


### PR DESCRIPTION
## Changes

Adds `docs/context7.json` so the Context7 verification file is served by Mintlify at `https://docs.mcp-use.com/context7.json`.

## Implementation Details

1. Copies the existing root `context7.json` (same `url` + `public_key`) into `docs/` — Mintlify serves any supported static file type (`.json` included) from the docs directory at the docs site root, matching the repo path.

## Why

Context7's library claim flow requires the `context7.json` to be reachable at a public URL under the project's domain. The repo-root copy isn't served anywhere. Hosting it via the Mintlify docs is the simplest way to make it reachable without adding new infra.

## Notes

- The existing root `context7.json` is intentionally left in place for repo visibility.
- `mint dev` doesn't always serve arbitrary static files locally (returns 500/404 for paths that work in production), but the deployed Mintlify CDN serves all supported static asset types — confirmed by existing assets like `/favicon.svg` and `/images/mcp_use.svg` being live on `docs.mcp-use.com`.

## Testing

- [ ] After merge + Mintlify deploy, verify `curl -I https://docs.mcp-use.com/context7.json` returns 200 with `application/json`.
- [ ] Paste that URL into the Context7 claim modal and confirm verification succeeds.

## Backwards Compatibility

Non-breaking — only adds a new file.