### PR TITLE
Add Context7 config for TypeScript docs

### DIFF
--- a/docs/typescript/context7.json
+++ b/docs/typescript/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/websites/mcp-use_typescript",
+  "public_key": "pk_DHbfCHmtCxcbCOAR8Q9HX"
+}


### PR DESCRIPTION
## Summary
- add the TypeScript docs Context7 claim file
- expose the claim file from docs/typescript/context7.json

## Testing
- not run (static file addition only)