### PR TITLE
ci(knip): enforce knip and clear final baseline findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ permissions:
 # 3. TypeScript Tests (runs if libraries/typescript/** changed)
 #    ├─ typescript-lint: ESLint checks
 #    ├─ typescript-build: Build all packages
-#    ├─ typescript-knip: Unused code/deps report (warning-only — never fails CI)
+#    ├─ typescript-knip: Unused code/deps check (fails CI on findings)
 #    ├─ typescript/mcp-use: Unit tests + agent integration tests (requires API keys)
 #    ├─ typescript/inspector: Unit tests for inspector package
 #    ├─ typescript/cli: Unit tests for CLI package
@@ -697,10 +697,8 @@ jobs:
 
   typescript-knip:
     needs: typescript-lint
-    name: typescript-knip (warning-only)
+    name: typescript-knip
     runs-on: ubuntu-latest
-    # Surface unused-code findings without failing the build. Tighten to
-    # `pnpm knip` (without --no-exit-code) once the baseline is cleaned up.
     defaults:
       run:
         working-directory: libraries/typescript
@@ -718,17 +716,23 @@ jobs:
           cache-dependency-path: libraries/typescript/pnpm-lock.yaml
       - name: Install Dependencies
         run: pnpm install --no-frozen-lockfile
-      - name: Run Knip (warning-only)
+      - name: Generate version file
+        # src/version.ts is gitignored and produced at build time; knip needs it
+        # to resolve the `./version.js` imports in packages/mcp-use.
+        run: pnpm --filter mcp-use generate:version
+      - name: Run Knip
         run: |
+          set -o pipefail
+          pnpm exec knip --no-progress 2>&1 | tee /tmp/knip-output.txt
+          status=${PIPESTATUS[0]}
           {
             echo "## Knip Findings"
             echo ""
-            echo "_Reported as warnings — tighten to fail CI once the baseline is clean._"
-            echo ""
             echo '```'
-            pnpm exec knip --no-exit-code --no-progress
+            cat /tmp/knip-output.txt
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+          exit "$status"
 
   typescript-test-inspector:
     needs: typescript-lint

--- a/libraries/typescript/knip.json
+++ b/libraries/typescript/knip.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
+  "rules": {
+    "optionalPeerDependencies": "off"
+  },
   "ignoreWorkspaces": [
     "packages/mcp-use/examples/**",
     "packages/create-mcp-use-app/src/templates/**"
@@ -15,7 +18,8 @@
         "tests/servers/**/*.ts",
         "tests/docs/**/*.ts"
       ],
-      "project": ["src/**/*.{ts,tsx}", "tests/**/*.{ts,tsx}"]
+      "project": ["src/**/*.{ts,tsx}", "tests/**/*.{ts,tsx}"],
+      "ignoreBinaries": ["lsof", "sleep", "dev"]
     },
     "packages/cli": {
       "project": ["src/**/*.ts", "tests/**/*.ts"],
@@ -38,7 +42,7 @@
       ]
     },
     "packages/create-mcp-use-app": {
-      "entry": ["scripts/**/*.{js,mjs,ts}"],
+      "entry": ["src/index.tsx", "scripts/**/*.{js,mjs,ts}"],
       "project": ["src/**/*.{ts,tsx}"]
     }
   }


### PR DESCRIPTION
## Language / Project Scope

- [x] CI/CD or tooling

## Changes

Final pass to clear the last knip findings on canary, then flip the
`typescript-knip` CI job from warning-only to enforced.

## Implementation Details

**Commit 1 — `chore(knip): clear remaining baseline findings so knip passes clean`**

`libraries/typescript/knip.json`:
- Add `src/index.tsx` as an entry for `create-mcp-use-app`. The package's
  `bin` builds from `src/index.tsx` via `tsup`, but knip's workspace
  config didn't list it as an entry, so the file was reported as unused
  and its 8 runtime deps (chalk, commander, ink, ink-select-input,
  ink-text-input, ora, react, tar) were all flagged as unused. Adding
  the entry fixes all 9 findings at once.
- Add `lsof`, `sleep`, `dev` to `ignoreBinaries` for the `mcp-use`
  workspace. `lsof` / `sleep` appear in `example:notifications`,
  `example:sampling`, and `example:completion` scripts; `dev` is a
  false positive — it's the pnpm script name in
  `pnpm --dir … dev`, not a binary.
- Turn off the `optionalPeerDependencies` rule. The langchain / langfuse
  / e2b peers are intentionally optional and loaded conditionally;
  flagging them as referenced is noise.

**Commit 2 — `ci(knip): enforce knip in CI`**

`.github/workflows/ci.yml` (the `typescript-knip` job):
- Drop `--no-exit-code` so knip findings fail the job.
- Rename the job from `typescript-knip (warning-only)` to `typescript-knip`.
- Add a `pnpm --filter mcp-use generate:version` step before running knip.
  `packages/mcp-use/src/version.ts` is gitignored and produced at build
  time; without it, knip reports 10 unresolved `./version.js` imports.
- Pipe knip output to both stdout and `$GITHUB_STEP_SUMMARY` via `tee`,
  then exit with the original knip status.

## Testing

Locally, against this branch:

```
$ pnpm --filter mcp-use generate:version
$ pnpm exec knip --no-progress
$ echo $?
0
```

Before this PR, the same command exited with `1` (referenced optional
peer deps + unused file + unused deps + unlisted binaries).

## Backwards Compatibility

No runtime changes — config and CI only. No package version bumps, no
changeset required (no `.ts`/`.tsx`/`.js`/`.jsx` files modified).

## Related Issues

Final follow-up to #1510 and #1511.