### PR TITLE
feat(server): configurable mount paths for MCP, widgets, inspector, and OAuth

### DIFF
--- a/docs/typescript/server/cli-reference.mdx
+++ b/docs/typescript/server/cli-reference.mdx
@@ -183,8 +183,9 @@ mcp-use build --no-typecheck
 ```
 
 <Tip>
-  Use the `MCP_SERVER_URL` environment variable during build to configure widget
-  asset paths for static deployments (e.g., Supabase Storage).
+  Use the `MCP_WIDGET_ASSETS_URL` environment variable during build to configure widget
+  asset paths for static deployments (e.g., Supabase Storage). `MCP_SERVER_URL` remains
+  as a backwards-compatible alias and is planned for removal in v2.
 </Tip>
 
 ---
@@ -684,11 +685,12 @@ The CLI automatically adds `.mcp-use/` to your `.gitignore` as this file contain
 
 ### Development & Build
 
-| Variable         | Description                       | Default     |
-| ---------------- | --------------------------------- | ----------- |
-| `PORT`           | Server port                       | 3000        |
-| `NODE_ENV`       | Environment mode                  | development |
-| `MCP_SERVER_URL` | Server URL for widget asset paths | -           |
+| Variable                | Description                                                                 | Default     |
+| ----------------------- | --------------------------------------------------------------------------- | ----------- |
+| `PORT`                  | Server port                                                                 | 3000        |
+| `NODE_ENV`              | Environment mode                                                            | development |
+| `MCP_WIDGET_ASSETS_URL` | Canonical server URL used during build for widget asset path HTML injection | -           |
+| `MCP_SERVER_URL`        | Deprecated alias for `MCP_WIDGET_ASSETS_URL` (to be removed in v2)         | -           |
 
 **Examples:**
 
@@ -696,7 +698,10 @@ The CLI automatically adds `.mcp-use/` to your `.gitignore` as this file contain
 # Custom port
 PORT=8080 mcp-use dev
 
-# Production build with custom MCP URL
+# Production build with custom widget assets URL (preferred)
+MCP_WIDGET_ASSETS_URL=https://myserver.com mcp-use build
+
+# Backwards-compatible alias (deprecated, to be removed in v2)
 MCP_SERVER_URL=https://myserver.com mcp-use build
 ```
 

--- a/libraries/typescript/.changeset/configurable-route-mounts.md
+++ b/libraries/typescript/.changeset/configurable-route-mounts.md
@@ -1,0 +1,47 @@
+---
+"mcp-use": minor
+"@mcp-use/inspector": minor
+"@mcp-use/cli": patch
+---
+
+feat(server): configurable mount paths for MCP, widgets, inspector, and OAuth
+
+`ServerConfig` accepts a new optional `routes` field that relocates every
+HTTP mount on the server. Defaults preserve existing behavior.
+
+```ts
+new MCPServer({
+  name: "my-server",
+  version: "1.0.0",
+  routes: {
+    mcpBasePath: "/api/mcp",        // default "/mcp"
+    sseBasePath: "/api/sse",        // default "/sse"
+    widgetsBasePath: "/ui/widgets", // default "/mcp-use/widgets"
+    publicBasePath: "/ui/static",   // default "/mcp-use/public"
+    inspectorBasePath: "/debug",    // default "/inspector"
+    oauthBasePath: "/auth",         // default ""
+  },
+});
+```
+
+Beyond the surface route config, this release threads the resolved paths through:
+
+- `mcp-use`: MCP/SSE transports, OAuth provider endpoints (`/authorize`,
+  `/token`, `/register`, `/.well-known/*`), widget pages, widget URI builder
+  (`buildWidgetUrl`), public static files, favicon, and the request-logger
+  quiet-route filter (`createRequestLogger`).
+- `@mcp-use/inspector`: `mountInspector` accepts a `basePath` that truly
+  remounts the inspector — backend routes (health, API, chat, tunnel,
+  dev-info, MCP/OAuth proxies, MCP Apps), static asset paths, the served
+  HTML's Vite-baked asset references, the React Router `basename`, and
+  OAuth callback URLs all follow the configured mount. The redirect-only
+  alias from the previous release has been removed.
+- `@mcp-use/cli`: dev banner and inspector auto-open URL read the running
+  server's `routeConfig` so `MCP:` and `Inspector:` lines match the active
+  mounts. `waitForServer` health probe also uses the configured inspector
+  base path.
+
+Migration: no action required if you don't set `routes`. If you do set
+`inspectorBasePath`, the inspector is now genuinely mounted only at that
+path — the previous redirect from the configured path to `/inspector` is
+gone, and `/inspector/*` no longer serves the SPA fallback in embedded mode.

--- a/libraries/typescript/packages/cli/src/index.ts
+++ b/libraries/typescript/packages/cli/src/index.ts
@@ -1157,8 +1157,10 @@ export default {
       }
 
       // Post-process HTML for static deployments (e.g., Supabase)
-      // If MCP_SERVER_URL is set, inject window globals at build time
-      const mcpServerUrl = process.env.MCP_SERVER_URL;
+      // MCP_WIDGET_ASSETS_URL is the canonical variable.
+      // TODO(v2): Remove MCP_SERVER_URL fallback after deprecation window.
+      const mcpServerUrl =
+        process.env.MCP_WIDGET_ASSETS_URL || process.env.MCP_SERVER_URL;
       if (mcpServerUrl) {
         try {
           const htmlPath = path.join(outDir, "index.html");
@@ -1194,7 +1196,9 @@ export default {
 
           await fs.writeFile(htmlPath, html, "utf8");
           console.log(
-            chalk.gray(`    → Injected MCP_SERVER_URL into ${widgetName}`)
+            chalk.gray(
+              `    → Injected MCP_WIDGET_ASSETS_URL/MCP_SERVER_URL into ${widgetName}`
+            )
           );
         } catch (error) {
           console.warn(

--- a/libraries/typescript/packages/cli/src/index.ts
+++ b/libraries/typescript/packages/cli/src/index.ts
@@ -150,16 +150,20 @@ async function findAvailablePort(
 async function waitForServer(
   port: number,
   host: string = "localhost",
-  maxAttempts = 30
+  maxAttempts = 30,
+  inspectorBasePath: string = "/inspector"
 ): Promise<boolean> {
   for (let i = 0; i < maxAttempts; i++) {
     const controller = new AbortController();
     try {
-      // Use /inspector/health endpoint for cleaner health checks
-      // This avoids 400 errors from the MCP endpoint which requires session headers
-      const response = await fetch(`http://${host}:${port}/inspector/health`, {
-        signal: controller.signal,
-      });
+      // Use <inspectorBasePath>/health for a cheap health probe. The MCP
+      // endpoint itself requires session headers, so /api/mcp would 400.
+      const response = await fetch(
+        `http://${host}:${port}${inspectorBasePath}/health`,
+        {
+          signal: controller.signal,
+        }
+      );
 
       if (response.ok) {
         return true;
@@ -2138,11 +2142,16 @@ program
         // Auto-open inspector if enabled
         if (options.open !== false) {
           const browserHost = normalizeBrowserHost(host);
-          const ready = await waitForServer(port, browserHost);
+          const routes = (runningServer as any)?.routeConfig;
+          const mcpBasePath = routes?.mcpBasePath ?? "/mcp";
+          const inspectorBasePath = routes?.inspectorBasePath ?? "/inspector";
+          const ready = await waitForServer(
+            port,
+            browserHost,
+            30,
+            inspectorBasePath
+          );
           if (ready) {
-            const routes = (runningServer as any)?.routeConfig;
-            const mcpBasePath = routes?.mcpBasePath ?? "/mcp";
-            const inspectorBasePath = routes?.inspectorBasePath ?? "/inspector";
             const mcpEndpoint = `http://${browserHost}:${port}${mcpBasePath}`;
             const autoConnectEndpoint = tunnelUrl
               ? `${tunnelUrl}${mcpBasePath}`

--- a/libraries/typescript/packages/cli/src/index.ts
+++ b/libraries/typescript/packages/cli/src/index.ts
@@ -2140,11 +2140,14 @@ program
           const browserHost = normalizeBrowserHost(host);
           const ready = await waitForServer(port, browserHost);
           if (ready) {
-            const mcpEndpoint = `http://${browserHost}:${port}/mcp`;
+            const routes = (runningServer as any)?.routeConfig;
+            const mcpBasePath = routes?.mcpBasePath ?? "/mcp";
+            const inspectorBasePath = routes?.inspectorBasePath ?? "/inspector";
+            const mcpEndpoint = `http://${browserHost}:${port}${mcpBasePath}`;
             const autoConnectEndpoint = tunnelUrl
-              ? `${tunnelUrl}/mcp`
+              ? `${tunnelUrl}${mcpBasePath}`
               : mcpEndpoint;
-            const inspectorUrl = `http://${browserHost}:${port}/inspector?autoConnect=${encodeURIComponent(autoConnectEndpoint)}`;
+            const inspectorUrl = `http://${browserHost}:${port}${inspectorBasePath}?autoConnect=${encodeURIComponent(autoConnectEndpoint)}`;
 
             const readyTime = Date.now() - startTime;
             console.log(chalk.green.bold(`✓ Ready in ${readyTime}ms`));
@@ -2154,7 +2157,9 @@ program
             console.log(chalk.whiteBright(`Network:  http://${host}:${port}`));
             console.log(chalk.whiteBright(`MCP:      ${mcpEndpoint}`));
             if (tunnelUrl) {
-              console.log(chalk.whiteBright(`Tunnel:   ${tunnelUrl}/mcp`));
+              console.log(
+                chalk.whiteBright(`Tunnel:   ${tunnelUrl}${mcpBasePath}`)
+              );
             }
             console.log(chalk.whiteBright(`Inspector: ${inspectorUrl}`));
             console.log(chalk.gray(`Watching for changes...\n`));
@@ -2174,12 +2179,16 @@ program
 
       // Log success when --no-open is used
       if (options.open === false) {
-        const mcpEndpoint = `http://${host}:${port}/mcp`;
+        const mcpBasePath =
+          (runningServer as any)?.routeConfig?.mcpBasePath ?? "/mcp";
+        const mcpEndpoint = `http://${host}:${port}${mcpBasePath}`;
         console.log(chalk.green.bold(`✓ Server ready`));
         console.log(chalk.whiteBright(`Local:    http://${host}:${port}`));
         console.log(chalk.whiteBright(`MCP:      ${mcpEndpoint}`));
         if (tunnelUrl) {
-          console.log(chalk.whiteBright(`Tunnel:   ${tunnelUrl}/mcp`));
+          console.log(
+            chalk.whiteBright(`Tunnel:   ${tunnelUrl}${mcpBasePath}`)
+          );
         }
         console.log(chalk.gray(`Watching for changes...\n`));
       }
@@ -2513,18 +2522,23 @@ program
         (globalThis as any).__mcpUseHmrMode = true;
 
         const browserHost = normalizeBrowserHost(host);
-        const mcpEndpoint = `http://${browserHost}:${port}/mcp`;
+        const routes = (runningServer as any)?.routeConfig;
+        const mcpBasePath = routes?.mcpBasePath ?? "/mcp";
+        const inspectorBasePath = routes?.inspectorBasePath ?? "/inspector";
+        const mcpEndpoint = `http://${browserHost}:${port}${mcpBasePath}`;
         const autoConnectEndpoint = tunnelUrl
-          ? `${tunnelUrl}/mcp`
+          ? `${tunnelUrl}${mcpBasePath}`
           : mcpEndpoint;
         console.log(chalk.green.bold(`✓ Restarted`));
         console.log(chalk.whiteBright(`MCP:      ${mcpEndpoint}`));
         if (tunnelUrl) {
-          console.log(chalk.whiteBright(`Tunnel:   ${tunnelUrl}/mcp`));
+          console.log(
+            chalk.whiteBright(`Tunnel:   ${tunnelUrl}${mcpBasePath}`)
+          );
         }
         console.log(
           chalk.whiteBright(
-            `Inspector: http://${browserHost}:${port}/inspector?autoConnect=${encodeURIComponent(autoConnectEndpoint)}`
+            `Inspector: http://${browserHost}:${port}${inspectorBasePath}?autoConnect=${encodeURIComponent(autoConnectEndpoint)}`
           )
         );
         console.log(chalk.gray(`Watching for changes...\n`));

--- a/libraries/typescript/packages/inspector/src/client/App.tsx
+++ b/libraries/typescript/packages/inspector/src/client/App.tsx
@@ -16,6 +16,7 @@ import { toast } from "sonner";
 import { InspectorProvider, useInspector } from "./context/InspectorContext";
 import { ThemeProvider } from "./context/ThemeContext";
 import { WidgetDebugProvider } from "./context/WidgetDebugContext";
+import { getInspectorBasePath } from "@/client/lib/inspector-base-path";
 
 /**
  * Syncs the active tab from InspectorContext into a ref readable by
@@ -98,7 +99,7 @@ function App() {
         <McpClientProvider
           storageProvider={storageProvider}
           enableRpcLogging={true}
-          defaultCallbackUrl={`${window.location.origin}/inspector/oauth/callback`}
+          defaultCallbackUrl={`${window.location.origin}${getInspectorBasePath()}/oauth/callback`}
           defaultAutoProxyFallback={
             proxyAddress ? { enabled: true, proxyAddress } : false
           }
@@ -207,7 +208,7 @@ function App() {
         >
           <InspectorProvider>
             <InspectorTabSync activeTabRef={activeTabRef} />
-            <Router basename="/inspector">
+            <Router basename={getInspectorBasePath()}>
               <Routes>
                 <Route path="/oauth/callback" element={<OAuthCallback />} />
                 <Route path="/preview/:view" element={<ViewPreview />} />

--- a/libraries/typescript/packages/inspector/src/client/components/InspectorDashboard.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/InspectorDashboard.tsx
@@ -52,6 +52,7 @@ import {
 import { useLocation, useNavigate } from "react-router";
 import { toast } from "sonner";
 import { INSPECTOR_RECONNECT_STORAGE_KEY } from "@/client/hooks/useAutoConnect";
+import { inspectorUrl } from "@/client/lib/inspector-base-path";
 import { ConnectionSettingsForm } from "./ConnectionSettingsForm";
 import type { CustomHeader } from "./CustomHeadersEditor";
 import { ServerCapabilitiesModal } from "./ServerCapabilitiesModal";
@@ -300,7 +301,7 @@ export function InspectorDashboard() {
   const [resetTimeoutOnProgress, setResetTimeoutOnProgress] = useState("True");
   const [maxTotalTimeout, setMaxTotalTimeout] = useState("60000");
   const [proxyAddress, setProxyAddress] = useState(
-    `${window.location.origin}/inspector/api/proxy`
+    `${window.location.origin}${inspectorUrl("/api/proxy")}`
   );
   // OAuth fields
   const [clientId, setClientId] = useState("");

--- a/libraries/typescript/packages/inspector/src/client/components/Layout.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/Layout.tsx
@@ -25,6 +25,7 @@ import type { ReactNode } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router";
 import { toast } from "sonner";
+import { inspectorUrl } from "@/client/lib/inspector-base-path";
 import { CommandPalette } from "./CommandPalette";
 import { LayoutContent } from "./LayoutContent";
 import { LayoutHeader } from "./LayoutHeader";
@@ -635,7 +636,7 @@ export function Layout({ children }: LayoutProps) {
           proxyAddress: string;
           headers?: Record<string, string>;
         } = {
-          proxyAddress: `${window.location.origin}/inspector/api/proxy`,
+          proxyAddress: `${window.location.origin}${inspectorUrl("/api/proxy")}`,
           ...(Object.keys(customHeaders).length > 0 && {
             headers: customHeaders,
           }),

--- a/libraries/typescript/packages/inspector/src/client/components/LayoutHeader.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/LayoutHeader.tsx
@@ -26,6 +26,7 @@ import {
 import type { TabType } from "@/client/context/InspectorContext";
 import { useInspector } from "@/client/context/InspectorContext";
 import { cn } from "@/client/lib/utils";
+import { inspectorUrl } from "@/client/lib/inspector-base-path";
 import {
   ArrowUpRight,
   Bell,
@@ -251,7 +252,7 @@ function TunnelBadge({
     let cancelled = false;
     (async () => {
       try {
-        const res = await fetch("/inspector/api/dev/info");
+        const res = await fetch(inspectorUrl("/api/dev/info"));
         if (!res.ok || cancelled) return;
         const info = (await res.json()) as {
           fromCli?: boolean;
@@ -357,7 +358,7 @@ function TunnelBadge({
     setIsTunnelStarting(true);
     let success = false;
     try {
-      const res = await fetch("/inspector/api/dev/start-tunnel", {
+      const res = await fetch(inspectorUrl("/api/dev/start-tunnel"), {
         method: "POST",
       });
       if (!res.ok) {
@@ -387,7 +388,7 @@ function TunnelBadge({
     setIsTunnelStarting(true);
     let success = false;
     try {
-      const res = await fetch("/inspector/api/dev/stop-tunnel", {
+      const res = await fetch(inspectorUrl("/api/dev/stop-tunnel"), {
         method: "POST",
       });
       if (!res.ok) {

--- a/libraries/typescript/packages/inspector/src/client/components/LayoutHeader.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/LayoutHeader.tsx
@@ -277,12 +277,12 @@ function TunnelBadge({
   }, [setTunnelUrl]);
 
   /**
-   * Poll /inspector/api/dev/info until the new server is ready,
+   * Poll inspector /api/dev/info until the new server is ready,
    * then redirect the inspector to reconnect via sessionStorage.
    */
   const pollAndReconnect = async (expectTunnel: boolean) => {
     const port = window.location.port || "3000";
-    const infoUrl = `http://localhost:${port}/inspector/api/dev/info`;
+    const infoUrl = `${window.location.origin}${inspectorUrl("/api/dev/info")}`;
     const deadline = Date.now() + 90_000;
 
     setTunnelPhaseMessage(

--- a/libraries/typescript/packages/inspector/src/client/components/LoginModal.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/LoginModal.tsx
@@ -29,6 +29,7 @@ import { Input } from "@/client/components/ui/input";
 import { Label } from "@/client/components/ui/label";
 import { Spinner } from "@/client/components/ui/spinner";
 import { cn } from "@/client/lib/utils";
+import { getInspectorBasePath } from "@/client/lib/inspector-base-path";
 
 /* ------------------------------------------------------------------ */
 /* Inline OAuth brand icons (no extra dependency)                       */
@@ -155,7 +156,7 @@ export function LoginModal({
     // itself (via `window.close()` + postMessage) the moment better-auth
     // finishes setting the session cookie — instead of loading the whole
     // inspector inside the popup while we wait for the parent's session poll.
-    const callbackURL = `${window.location.origin}/inspector/oauth-popup-closed.html`;
+    const callbackURL = `${window.location.origin}${getInspectorBasePath()}/oauth-popup-closed.html`;
 
     fetch(`${authOrigin}/api/auth/sign-in/social`, {
       method: "POST",

--- a/libraries/typescript/packages/inspector/src/client/components/OpenAIComponentRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/OpenAIComponentRenderer.tsx
@@ -7,6 +7,7 @@ import { MCP_APPS_CONFIG } from "../constants/mcp-apps";
 import { IFRAME_SANDBOX_PERMISSIONS } from "../constants/iframe";
 import { useTheme } from "../context/ThemeContext";
 import { useWidgetDebug } from "../context/WidgetDebugContext";
+import { inspectorUrl } from "@/client/lib/inspector-base-path";
 import { injectConsoleInterceptor } from "../utils/iframeConsoleInterceptor";
 import { FullscreenNavbar } from "./FullscreenNavbar";
 import { MCPAppsDebugControls } from "./MCPAppsDebugControls";
@@ -243,24 +244,19 @@ function OpenAIComponentRendererBase({
           },
         };
 
-        // Inspector API routes (/inspector/api/*) are always served by the same
+        // Inspector API routes are always served by the same
         // origin that hosts the inspector UI.  Use relative URLs so fetch targets
         // window.location.origin (the inspector) instead of the MCP server.
         // The previous logic mistakenly derived the base from the MCP server URL
         // (serverBaseUrl), which broke when the server ran on a different port.
-        const inspectorApiBase = "";
-
         // Store widget data on server (including the fetched HTML and dev URLs if applicable)
-        const storeResponse = await fetch(
-          `${inspectorApiBase}/inspector/api/resources/widget/store`,
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify(widgetDataToStore),
-          }
-        );
+        const storeResponse = await fetch(inspectorUrl("/api/resources/widget/store"), {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(widgetDataToStore),
+        });
 
         if (!storeResponse.ok) {
           const errorData = await storeResponse
@@ -274,12 +270,9 @@ function OpenAIComponentRendererBase({
         if (cancelled) return;
 
         // Determine if the widget iframe will be same-origin with the inspector page.
-        // When inspectorApiBase matches window.location.origin (e.g. both http://localhost:3000),
-        // the iframe is same-origin and we can access its DOM for console interception & debug controls.
-        const computedIsSameOrigin = inspectorApiBase
-          ? typeof window !== "undefined" &&
-            inspectorApiBase === window.location.origin
-          : true;
+        // The inspector API is same-origin with the page, so we can access iframe DOM
+        // for console interception and debug controls.
+        const computedIsSameOrigin = true;
 
         // Batch all state updates in one synchronous block so React 18 batches a single re-render.
         // Avoids double application from StrictMode (cancelled guard above) and multiple
@@ -291,7 +284,7 @@ function OpenAIComponentRendererBase({
         // the store so that iframe fetch gets latest data. Changing URL would reload the iframe.
         if (!hasSetWidgetUrlRef.current) {
           hasSetWidgetUrlRef.current = true;
-          const widgetUrl = `${inspectorApiBase}/inspector/api/resources/widget-content/${toolId}?t=${Date.now()}`;
+          const widgetUrl = `${inspectorUrl(`/api/resources/widget-content/${toolId}`)}?t=${Date.now()}`;
           setWidgetUrl(widgetUrl);
           // Register widget in debug context so CSP violations can be stored
           addWidget(toolId, { toolName, protocol: "chatgpt-app" });

--- a/libraries/typescript/packages/inspector/src/client/components/ServerConnectionModal.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ServerConnectionModal.tsx
@@ -24,6 +24,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/client/components/ui/dialog";
+import { inspectorUrl } from "@/client/lib/inspector-base-path";
 import { getConfiguredServerAlias } from "@/client/utils/serverNames";
 import { ConnectionSettingsForm } from "./ConnectionSettingsForm";
 import { toast } from "sonner";
@@ -68,7 +69,7 @@ export function ServerConnectionModal({
   const [resetTimeoutOnProgress, setResetTimeoutOnProgress] = useState("True");
   const [maxTotalTimeout, setMaxTotalTimeout] = useState("60000");
   const [proxyAddress, setProxyAddress] = useState(
-    `${window.location.origin}/inspector/api/proxy`
+    `${window.location.origin}${inspectorUrl("/api/proxy")}`
   );
   // OAuth fields
   const [clientId, setClientId] = useState("");
@@ -112,7 +113,9 @@ export function ServerConnectionModal({
         setProxyAddress(proxyAddress);
       } else {
         setConnectionType("Direct");
-        setProxyAddress(`${window.location.origin}/inspector/api/proxy`);
+        setProxyAddress(
+          `${window.location.origin}${inspectorUrl("/api/proxy")}`
+        );
       }
 
       // Convert headers from Record<string, string> to CustomHeader[]

--- a/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessages.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessages.ts
@@ -1,5 +1,6 @@
 import { useCallback, useRef, useState } from "react";
 import type { PromptResult } from "../../hooks/useMCPPrompts";
+import { inspectorUrl } from "@/client/lib/inspector-base-path";
 import { convertPromptResultsToMessages } from "./conversion";
 import type {
   AuthConfig,
@@ -171,7 +172,7 @@ export function useChatMessages({
         const resolvedUrl =
           chatApiUrl ??
           (waitForChatApiUrl ? await waitForChatApiUrl() : undefined) ??
-          "/inspector/api/chat/stream";
+          inspectorUrl("/api/chat/stream");
 
         const serialisedMessages = [
           ...[...messages, ...userMessages].map((m) => ({

--- a/libraries/typescript/packages/inspector/src/client/components/ui/SandboxedIframe.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ui/SandboxedIframe.tsx
@@ -21,6 +21,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { getInspectorBasePath } from "@/client/lib/inspector-base-path";
 import { IFRAME_SANDBOX_PERMISSIONS } from "../../constants/iframe";
 
 export interface SandboxedIframeHandle {
@@ -98,12 +99,14 @@ export const SandboxedIframe = forwardRef<
     const currentHost = window.location.hostname;
     const currentPort = window.location.port;
     const protocol = window.location.protocol;
+    const inspectorBasePath = getInspectorBasePath();
+    const sandboxProxyPath = `${inspectorBasePath}/api/mcp-apps/sandbox-proxy`;
 
     // Priority 1: Check for configured sandbox origin (injected at build time or runtime)
     const configuredSandboxOrigin = (window as any).__MCP_SANDBOX_ORIGIN__;
     if (configuredSandboxOrigin) {
       // Use fully configured origin (e.g., "https://sandbox-inspector.mcp-use.com")
-      return `${configuredSandboxOrigin}/inspector/api/mcp-apps/sandbox-proxy?v=${Date.now()}`;
+      return `${configuredSandboxOrigin.replace(/\/+$/, "")}${sandboxProxyPath}?v=${Date.now()}`;
     }
 
     let sandboxHost: string;
@@ -136,7 +139,7 @@ export const SandboxedIframe = forwardRef<
     }
 
     const portSuffix = currentPort ? `:${currentPort}` : "";
-    return `${protocol}//${sandboxHost}${portSuffix}/inspector/api/mcp-apps/sandbox-proxy?v=${Date.now()}`;
+    return `${protocol}//${sandboxHost}${portSuffix}${sandboxProxyPath}?v=${Date.now()}`;
   });
 
   const sandboxProxyOrigin = useMemo(() => {

--- a/libraries/typescript/packages/inspector/src/client/constants/mcp-apps.ts
+++ b/libraries/typescript/packages/inspector/src/client/constants/mcp-apps.ts
@@ -2,14 +2,19 @@
  * MCP Apps configuration constants
  */
 
+import { inspectorUrl } from "@/client/lib/inspector-base-path";
+
 export const MCP_APPS_CONFIG = {
   /**
-   * API endpoints for widget operations
+   * API endpoints for widget operations. Computed lazily so the runtime
+   * `window.__MCP_INSPECTOR_BASE_PATH__` injected by the host is available.
    */
   API_ENDPOINTS: {
-    WIDGET_STORE: "/inspector/api/mcp-apps/widget/store",
+    get WIDGET_STORE(): string {
+      return inspectorUrl("/api/mcp-apps/widget/store");
+    },
     WIDGET_CONTENT: (toolCallId: string) =>
-      `/inspector/api/mcp-apps/widget-content/${toolCallId}`,
+      inspectorUrl(`/api/mcp-apps/widget-content/${toolCallId}`),
   },
 
   /**

--- a/libraries/typescript/packages/inspector/src/client/hooks/useAutoConnect.ts
+++ b/libraries/typescript/packages/inspector/src/client/hooks/useAutoConnect.ts
@@ -296,17 +296,17 @@ export function useAutoConnect({
       // external provider and get CORS-blocked in the browser.
       //
       // However, skip the proxy when the inspector is served by the MCP server
-      // itself (same origin as the target URL): in that case /inspector/api/proxy
+      // itself (same origin as the target URL): in that case the inspector proxy
       // doesn't exist on the host and routing through it breaks direct connections.
       let proxyAddress: string | undefined;
       try {
         const targetOrigin = new URL(url).origin;
         const inspectorOrigin = window.location.origin;
         if (inspectorOrigin !== targetOrigin) {
-          proxyAddress = `${inspectorOrigin}/inspector/api/proxy`;
+          proxyAddress = `${inspectorOrigin}${inspectorUrl("/api/proxy")}`;
         }
       } catch {
-        proxyAddress = `${window.location.origin}/inspector/api/proxy`;
+        proxyAddress = `${window.location.origin}${inspectorUrl("/api/proxy")}`;
       }
 
       const proxyConfig: {

--- a/libraries/typescript/packages/inspector/src/client/hooks/useAutoConnect.ts
+++ b/libraries/typescript/packages/inspector/src/client/hooks/useAutoConnect.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "mcp-use/react";
 import { useCallback, useEffect, useState } from "react";
 import { useNavigate } from "react-router";
 import { toast } from "sonner";
+import { inspectorUrl } from "@/client/lib/inspector-base-path";
 
 /** Survives full page reload; avoids fragile long JSON in query (was resolving to localhost + http). */
 export const INSPECTOR_RECONNECT_STORAGE_KEY = "__mcpUseInspectorReconnect";
@@ -473,7 +474,7 @@ export function useAutoConnect({
     }
 
     // Fallback to config.json
-    fetch("/inspector/config.json")
+    fetch(inspectorUrl("/config.json"))
       .then((res) => res.json())
       .then((configData: { autoConnectUrl: string | null }) => {
         setConfigLoaded(true);

--- a/libraries/typescript/packages/inspector/src/client/lib/inspector-base-path.ts
+++ b/libraries/typescript/packages/inspector/src/client/lib/inspector-base-path.ts
@@ -1,0 +1,31 @@
+/**
+ * Runtime mount path for the inspector.
+ *
+ * The server injects `window.__MCP_INSPECTOR_BASE_PATH__` into the HTML shell
+ * (see `injectRuntimeConfig` in `server/shared-static.ts`). When the inspector
+ * is mounted at a non-default path (e.g. `/debug` via `routeConfig` in
+ * mcp-use), all client-side fetches must be issued against that mount.
+ *
+ * Defaults to `/inspector` so standalone CLI / older hosts keep working.
+ */
+export function getInspectorBasePath(): string {
+  if (typeof window === "undefined") return "/inspector";
+  const fromWindow = (window as { __MCP_INSPECTOR_BASE_PATH__?: string })
+    .__MCP_INSPECTOR_BASE_PATH__;
+  if (typeof fromWindow === "string" && fromWindow.length > 0) {
+    return fromWindow;
+  }
+  return "/inspector";
+}
+
+/**
+ * Build a URL under the inspector mount.
+ *
+ * Example: `inspectorUrl("/api/chat/stream")` → `"/inspector/api/chat/stream"`
+ * (or `"/debug/api/chat/stream"` when the inspector is mounted at `/debug`).
+ */
+export function inspectorUrl(suffix: string): string {
+  const base = getInspectorBasePath();
+  const normalized = suffix.startsWith("/") ? suffix : `/${suffix}`;
+  return `${base}${normalized}`;
+}

--- a/libraries/typescript/packages/inspector/src/client/rpc-log-bus-browser.ts
+++ b/libraries/typescript/packages/inspector/src/client/rpc-log-bus-browser.ts
@@ -1,4 +1,5 @@
 import { rpcLogBus, type RpcLogEvent } from "../server/rpc-log-bus.js";
+import { inspectorUrl } from "./lib/inspector-base-path.js";
 
 // Browser-side RPC log bus that sends events to server
 // This is a thin wrapper that publishes to the shared log bus
@@ -22,7 +23,7 @@ export const browserRpcLogBus = {
     // Also send to server for SSE streaming
     try {
       console.log("[RPC Log Bus Browser] Sending to server...");
-      const response = await fetch("/inspector/api/rpc/log", {
+      const response = await fetch(inspectorUrl("/api/rpc/log"), {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/libraries/typescript/packages/inspector/src/client/telemetry/telemetry.ts
+++ b/libraries/typescript/packages/inspector/src/client/telemetry/telemetry.ts
@@ -1,6 +1,7 @@
 import type { BaseTelemetryEvent } from "./events.js";
 import { MCPInspectorOpenEvent } from "./events.js";
 import { getPackageVersion } from "./utils.js";
+import { inspectorUrl } from "@/client/lib/inspector-base-path";
 
 // Environment detection function
 function isBrowserEnvironment(): boolean {
@@ -86,8 +87,8 @@ function isLocalStorageFunctional(): boolean {
 export class Telemetry {
   private static instance: Telemetry | null = null;
 
-  private readonly POSTHOG_PROXY_URL = "/inspector/api/tel/posthog";
-  private readonly SCARF_PROXY_URL = "/inspector/api/tel/scarf";
+  private readonly POSTHOG_PROXY_URL = inspectorUrl("/api/tel/posthog");
+  private readonly SCARF_PROXY_URL = inspectorUrl("/api/tel/scarf");
   private readonly UNKNOWN_USER_ID = "UNKNOWN_USER_ID";
 
   private _currUserId: string | null = null;

--- a/libraries/typescript/packages/inspector/src/server/middleware.ts
+++ b/libraries/typescript/packages/inspector/src/server/middleware.ts
@@ -31,6 +31,11 @@ export function mountInspector(
     sandboxOrigin?: string | null;
     /** Port the host app listens on (embedded inspector); required for tunnel start */
     serverPort?: number;
+    /**
+     * Mount path for all inspector routes (UI + APIs). Defaults to "/inspector".
+     * Must start with "/" and have no trailing slash.
+     */
+    basePath?: string;
   }
 ): void {
   // Find the built client files
@@ -45,11 +50,14 @@ export function mountInspector(
     );
   }
 
+  const basePath = normalizeInspectorBasePath(config?.basePath);
+
   // Build runtime config to inject into the HTML
   const runtimeConfig = {
     devMode: config?.devMode,
     sandboxOrigin: config?.sandboxOrigin,
     inspectorMode: "embedded" as const,
+    basePath,
   };
 
   // If it's already a Hono app, register routes directly.
@@ -64,7 +72,7 @@ export function mountInspector(
   // Every Hono instance exposes `.fetch`, and Express apps don't, so the
   // duck-type check alone covers both shapes unambiguously.
   if (isHonoApp(app)) {
-    registerInspectorRoutes(app, config);
+    registerInspectorRoutes(app, { ...config, basePath });
     registerStaticRoutes(app, clientDistPath, runtimeConfig);
     return;
   }
@@ -73,7 +81,7 @@ export function mountInspector(
   const honoApp = new Hono();
 
   // Register routes on Hono app
-  registerInspectorRoutes(honoApp, config);
+  registerInspectorRoutes(honoApp, { ...config, basePath });
   registerStaticRoutes(honoApp, clientDistPath, runtimeConfig);
 
   // Convert all Hono routes to Express middleware
@@ -121,4 +129,17 @@ export function mountInspector(
 
 function isHonoApp(app: Express | Hono): app is Hono {
   return typeof (app as { fetch?: unknown }).fetch === "function";
+}
+
+/**
+ * Normalize a user-supplied inspector base path. Ensures it starts with `/`,
+ * has no trailing slash, and is not empty/root.
+ */
+function normalizeInspectorBasePath(input?: string): string {
+  const trimmed = (input ?? "/inspector").trim();
+  if (trimmed === "" || trimmed === "/") {
+    return "/inspector";
+  }
+  const prefixed = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  return prefixed.replace(/\/+$/, "");
 }

--- a/libraries/typescript/packages/inspector/src/server/routes/mcp-apps.ts
+++ b/libraries/typescript/packages/inspector/src/server/routes/mcp-apps.ts
@@ -256,11 +256,17 @@ window.addEventListener('unhandledrejection', function(event) {
 </html>`;
 
 /**
- * Register MCP Apps routes on the provided Hono app
+ * Register MCP Apps routes on the provided Hono app.
+ *
+ * @param app - Hono app to register routes on.
+ * @param basePath - Inspector mount path (e.g. "/inspector" or "/debug").
  */
-export function registerMcpAppsRoutes(app: Hono) {
+export function registerMcpAppsRoutes(
+  app: Hono,
+  basePath: string = "/inspector"
+) {
   // Store widget data - reuses existing storeWidgetData function
-  app.post("/inspector/api/mcp-apps/widget/store", async (c) => {
+  app.post(`${basePath}/api/mcp-apps/widget/store`, async (c) => {
     try {
       const body = await c.req.json();
       const result = storeWidgetData({
@@ -286,7 +292,7 @@ export function registerMcpAppsRoutes(app: Hono) {
   });
 
   // Serve widget content with CSP metadata (SEP-1865)
-  app.get("/inspector/api/mcp-apps/widget-content/:toolId", async (c) => {
+  app.get(`${basePath}/api/mcp-apps/widget-content/:toolId`, async (c) => {
     try {
       const toolId = c.req.param("toolId");
       const cspModeParam = c.req.query("csp_mode") as
@@ -369,7 +375,7 @@ export function registerMcpAppsRoutes(app: Hono) {
   });
 
   // Serve sandbox proxy HTML
-  app.get("/inspector/api/mcp-apps/sandbox-proxy", (c) => {
+  app.get(`${basePath}/api/mcp-apps/sandbox-proxy`, (c) => {
     c.header("Content-Type", "text/html; charset=utf-8");
     c.header("Cache-Control", "no-cache, no-store, must-revalidate");
 

--- a/libraries/typescript/packages/inspector/src/server/shared-routes.ts
+++ b/libraries/typescript/packages/inspector/src/server/shared-routes.ts
@@ -44,6 +44,8 @@ export type InspectorRoutesConfig = {
   autoConnectUrl?: string | null;
   /** HTTP port the app listens on (embedded inspector); required for tunnel start */
   serverPort?: number;
+  /** Mount path for all inspector routes. Defaults to "/inspector". */
+  basePath?: string;
 };
 
 export function registerInspectorRoutes(
@@ -54,27 +56,28 @@ export function registerInspectorRoutes(
     setServerPort(config.serverPort);
   }
 
-  app.get("/inspector/health", (c) => {
+  const base = config?.basePath ?? "/inspector";
+
+  app.get(`${base}/health`, (c) => {
     return c.json({ status: "ok", timestamp: new Date().toISOString() });
   });
 
   // Mount MCP proxy middleware at the inspector's proxy path
   mountMcpProxy(app, {
-    path: "/inspector/api/proxy",
+    path: `${base}/api/proxy`,
   });
 
   // Mount OAuth proxy middleware at the inspector's OAuth path
   mountOAuthProxy(app, {
-    basePath: "/inspector/api/oauth",
+    basePath: `${base}/api/oauth`,
     enableLogging: true,
   });
 
-  // Mount MCP Apps routes at /inspector/api/mcp-apps
-  // Note: registerMcpAppsRoutes handles the /inspector/api/mcp-apps prefix internally
-  registerMcpAppsRoutes(app);
+  // Mount MCP Apps routes at <basePath>/api/mcp-apps
+  registerMcpAppsRoutes(app, base);
 
   // Chat API endpoint - handles MCP agent chat with custom LLM key (streaming)
-  app.post("/inspector/api/chat/stream", async (c) => {
+  app.post(`${base}/api/chat/stream`, async (c) => {
     try {
       const requestBody = await c.req.json();
 
@@ -115,7 +118,7 @@ export function registerInspectorRoutes(
   });
 
   // Chat API endpoint - handles MCP agent chat with custom LLM key (non-streaming)
-  app.post("/inspector/api/chat", async (c) => {
+  app.post(`${base}/api/chat`, async (c) => {
     try {
       const requestBody = await c.req.json();
       const result = await handleChatRequest(requestBody);
@@ -126,7 +129,7 @@ export function registerInspectorRoutes(
   });
 
   // Widget storage endpoint - store widget data for rendering
-  app.post("/inspector/api/resources/widget/store", async (c) => {
+  app.post(`${base}/api/resources/widget/store`, async (c) => {
     try {
       const body = await c.req.json();
       const result = storeWidgetData(body);
@@ -147,7 +150,7 @@ export function registerInspectorRoutes(
   });
 
   // Widget container endpoint - serves container page that loads widget
-  app.get("/inspector/api/resources/widget/:toolId", async (c) => {
+  app.get(`${base}/api/resources/widget/:toolId`, async (c) => {
     const toolId = c.req.param("toolId");
 
     // Check if data exists in storage
@@ -160,11 +163,11 @@ export function registerInspectorRoutes(
     }
 
     // Return a container page that will fetch and load the actual widget
-    return c.html(generateWidgetContainerHtml("/inspector", toolId));
+    return c.html(generateWidgetContainerHtml(base, toolId));
   });
 
   // Widget content endpoint - serves pre-fetched resource with injected OpenAI API
-  app.get("/inspector/api/resources/widget-content/:toolId", async (c) => {
+  app.get(`${base}/api/resources/widget-content/:toolId`, async (c) => {
     try {
       const toolId = c.req.param("toolId");
 
@@ -222,7 +225,7 @@ export function registerInspectorRoutes(
   });
 
   // Inspector config endpoint
-  app.get("/inspector/config.json", (c) => {
+  app.get(`${base}/config.json`, (c) => {
     return c.json({
       autoConnectUrl: config?.autoConnectUrl || null,
     });
@@ -234,7 +237,7 @@ export function registerInspectorRoutes(
     process.env.NODE_ENV === "test";
 
   // Telemetry proxy endpoint - forwards telemetry events to PostHog from server-side
-  app.post("/inspector/api/tel/posthog", async (c) => {
+  app.post(`${base}/api/tel/posthog`, async (c) => {
     // Skip telemetry in test environments
     if (isTelemetryDisabled()) {
       return c.json({ success: true });
@@ -279,7 +282,7 @@ export function registerInspectorRoutes(
   });
 
   // Telemetry proxy endpoint - forwards telemetry events to Scarf from server-side
-  app.post("/inspector/api/tel/scarf", async (c) => {
+  app.post(`${base}/api/tel/scarf`, async (c) => {
     // Skip telemetry in test environments
     if (isTelemetryDisabled()) {
       return c.json({ success: true });
@@ -316,7 +319,7 @@ export function registerInspectorRoutes(
   });
 
   // RPC Log endpoint - receives RPC events from browser
-  app.post("/inspector/api/rpc/log", async (c) => {
+  app.post(`${base}/api/rpc/log`, async (c) => {
     try {
       const event = (await c.req.json()) as RpcLogEvent;
       rpcLogBus.publish(event);
@@ -328,7 +331,7 @@ export function registerInspectorRoutes(
   });
 
   // Clear RPC log buffer endpoint
-  app.delete("/inspector/api/rpc/log", async (c) => {
+  app.delete(`${base}/api/rpc/log`, async (c) => {
     try {
       const url = new URL(c.req.url);
       const serverIdsParam = url.searchParams.get("serverIds");
@@ -344,7 +347,7 @@ export function registerInspectorRoutes(
   });
 
   // RPC Stream endpoint - streams RPC events via SSE
-  app.get("/inspector/api/rpc/stream", async (c) => {
+  app.get(`${base}/api/rpc/stream`, async (c) => {
     const url = new URL(c.req.url);
     const replay = parseInt(url.searchParams.get("replay") || "3", 10);
     const serverIdsParam = url.searchParams.get("serverIds");
@@ -424,12 +427,12 @@ export function registerInspectorRoutes(
   });
 
   // Tunnel management endpoints
-  app.get("/inspector/api/tunnel/status", (c) => {
+  app.get(`${base}/api/tunnel/status`, (c) => {
     const status = getTunnelStatus();
     return c.json(status);
   });
 
-  app.post("/inspector/api/tunnel/start", async (c) => {
+  app.post(`${base}/api/tunnel/start`, async (c) => {
     try {
       const result = await startTunnel();
       return c.json(result);
@@ -440,13 +443,13 @@ export function registerInspectorRoutes(
     }
   });
 
-  app.delete("/inspector/api/tunnel/stop", (c) => {
+  app.delete(`${base}/api/tunnel/stop`, (c) => {
     const stopped = stopTunnel();
     return c.json({ stopped });
   });
 
   /** Public MCP URL and CLI dev session (set by `mcp-use dev` / MCP_URL) */
-  app.get("/inspector/api/dev/info", (c) => {
+  app.get(`${base}/api/dev/info`, (c) => {
     const mcpUrl = process.env.MCP_URL ?? null;
     const portEnv = process.env.PORT;
     const fromCli = process.env.MCP_USE_CLI_DEV === "1";
@@ -478,7 +481,7 @@ export function registerInspectorRoutes(
    * Restart the dev server with the tunnel enabled.
    * Delegates to the CLI restart hook which re-spawns the process with --tunnel.
    */
-  app.post("/inspector/api/dev/start-tunnel", (c) => {
+  app.post(`${base}/api/dev/start-tunnel`, (c) => {
     const restart = (globalThis as any).__mcpUseDevRestart as
       | ((withTunnel: boolean) => void)
       | undefined;
@@ -493,7 +496,7 @@ export function registerInspectorRoutes(
   });
 
   /** Restart the dev server without the tunnel. */
-  app.post("/inspector/api/dev/stop-tunnel", (c) => {
+  app.post(`${base}/api/dev/stop-tunnel`, (c) => {
     const restart = (globalThis as any).__mcpUseDevRestart as
       | ((withTunnel: boolean) => void)
       | undefined;
@@ -508,7 +511,7 @@ export function registerInspectorRoutes(
   });
 
   // Legacy aliases
-  app.post("/inspector/api/dev/restart-with-tunnel", (c) => {
+  app.post(`${base}/api/dev/restart-with-tunnel`, (c) => {
     const restart = (globalThis as any).__mcpUseDevRestart as
       | ((withTunnel: boolean) => void)
       | undefined;
@@ -517,7 +520,7 @@ export function registerInspectorRoutes(
     return c.json({ ok: true, restarting: true });
   });
 
-  app.post("/inspector/api/dev/restart-without-tunnel", (c) => {
+  app.post(`${base}/api/dev/restart-without-tunnel`, (c) => {
     const restart = (globalThis as any).__mcpUseDevRestart as
       | ((withTunnel: boolean) => void)
       | undefined;

--- a/libraries/typescript/packages/inspector/src/server/shared-static.ts
+++ b/libraries/typescript/packages/inspector/src/server/shared-static.ts
@@ -41,6 +41,12 @@ interface RuntimeConfig {
   devMode?: boolean;
   /** Override sandbox origin for MCP Apps widgets behind reverse proxies */
   sandboxOrigin?: string | null;
+  /**
+   * Mount path the inspector is served from (e.g. "/inspector" or "/debug").
+   * Surfaced to the client as `window.__MCP_INSPECTOR_BASE_PATH__` so all
+   * frontend fetches can build absolute URLs against the configured mount.
+   */
+  basePath?: string;
   /** Relative path to the MCP proxy (e.g. "/inspector/api/proxy"). When set, the client uses it for autoProxyFallback. Omit when the proxy is not available (e.g. Python server serving inspector). */
   proxyUrl?: string | null;
   /** How the inspector is being served (standalone CLI, embedded in mcp-use, or cloud-hosted). Consumed by telemetry. */
@@ -81,6 +87,12 @@ function injectRuntimeConfig(html: string, config?: RuntimeConfig): string {
   if (config.sandboxOrigin) {
     scripts.push(
       `<script>window.__MCP_SANDBOX_ORIGIN__ = ${JSON.stringify(config.sandboxOrigin)};</script>`
+    );
+  }
+
+  if (config.basePath) {
+    scripts.push(
+      `<script>window.__MCP_INSPECTOR_BASE_PATH__ = ${JSON.stringify(config.basePath)};</script>`
     );
   }
 
@@ -130,6 +142,11 @@ function generateCdnShellHtml(config?: RuntimeConfig): string {
     if (config.sandboxOrigin) {
       scripts.push(
         `<script>window.__MCP_SANDBOX_ORIGIN__ = ${JSON.stringify(config.sandboxOrigin)};</script>`
+      );
+    }
+    if (config.basePath) {
+      scripts.push(
+        `<script>window.__MCP_INSPECTOR_BASE_PATH__ = ${JSON.stringify(config.basePath)};</script>`
       );
     }
     if (config.proxyUrl !== undefined) {
@@ -252,6 +269,7 @@ export function registerStaticRoutes(
   clientDistPath?: string,
   runtimeConfig?: RuntimeConfig
 ) {
+  const basePath = runtimeConfig?.basePath ?? "/inspector";
   // When the inspector's own server serves, the proxy is always available.
   // Default proxyUrl so the client can use it; callers may override with null to disable.
   // disableTelemetry is auto-populated from MCP_USE_ANONYMIZED_TELEMETRY=false so
@@ -259,10 +277,11 @@ export function registerStaticRoutes(
   // the in-browser posthog-js init triggered by `useMcp` hooks rendered inside.
   const effectiveConfig: RuntimeConfig = {
     ...runtimeConfig,
+    basePath,
     proxyUrl:
       runtimeConfig?.proxyUrl !== undefined
         ? runtimeConfig.proxyUrl
-        : "/inspector/api/proxy",
+        : `${basePath}/api/proxy`,
     disableTelemetry:
       runtimeConfig?.disableTelemetry ??
       process.env.MCP_USE_ANONYMIZED_TELEMETRY === "false",
@@ -274,13 +293,18 @@ export function registerStaticRoutes(
 
     app.get("/", (c) => {
       const url = new URL(c.req.url);
-      return c.redirect(`/inspector${url.search}`);
+      return c.redirect(`${basePath}${url.search}`);
     });
 
-    app.get("/inspector", serveShell);
-    app.get("/inspector/*", serveShell);
-    app.post("/inspector/*", serveShell);
-    app.get("*", serveShell);
+    app.get(basePath, serveShell);
+    app.get(`${basePath}/*`, serveShell);
+    app.post(`${basePath}/*`, serveShell);
+    // Standalone CLI: keep SPA catch-all so root-level routes serve the
+    // inspector. Embedded mode passes a custom basePath and shouldn't shadow
+    // unrelated host routes.
+    if (basePath === "/inspector") {
+      app.get("*", serveShell);
+    }
     return;
   }
 
@@ -312,9 +336,9 @@ export function registerStaticRoutes(
     return;
   }
 
-  // Serve static assets from /inspector/assets/*
-  app.get("/inspector/assets/*", (c) => {
-    const path = c.req.path.replace("/inspector/assets/", "assets/");
+  // Serve static assets from <basePath>/assets/*
+  app.get(`${basePath}/assets/*`, (c) => {
+    const path = c.req.path.replace(`${basePath}/assets/`, "assets/");
     const fullPath = join(distPath, path);
     if (existsSync(fullPath)) {
       const content = readFileSync(fullPath);
@@ -325,18 +349,29 @@ export function registerStaticRoutes(
     return c.notFound();
   });
 
-  // Redirect root to /inspector preserving query parameters
+  // Redirect root to <basePath> preserving query parameters
   app.get("/", (c) => {
     const url = new URL(c.req.url);
     const queryString = url.search;
-    return c.redirect(`/inspector${queryString}`);
+    return c.redirect(`${basePath}${queryString}`);
   });
+
+  // Vite builds the inspector with `base: "/inspector"`, baking that path into
+  // the emitted index.html and JS chunk imports. When the host mounts the
+  // inspector at a different path, rewrite `/inspector/` references in the
+  // served HTML so the browser pulls assets from the active mount.
+  const rewriteAssetBase = (html: string): string =>
+    basePath === "/inspector"
+      ? html
+      : html
+          .replaceAll('"/inspector/', `"${basePath}/`)
+          .replaceAll("'/inspector/", `'${basePath}/`);
 
   const serveIndex = (c: any) => {
     const indexPath = join(distPath, "index.html");
     if (existsSync(indexPath)) {
       const content = injectRuntimeConfig(
-        readFileSync(indexPath, "utf-8"),
+        rewriteAssetBase(readFileSync(indexPath, "utf-8")),
         effectiveConfig
       );
       return c.html(content);
@@ -355,15 +390,23 @@ export function registerStaticRoutes(
     `);
   };
 
-  app.get("/inspector", serveIndex);
-  app.get("/inspector/*", serveIndex);
-  app.post("/inspector/*", serveIndex);
+  app.get(basePath, serveIndex);
+  app.get(`${basePath}/*`, serveIndex);
+  app.post(`${basePath}/*`, serveIndex);
+
+  // Default-base behavior: also serve the SPA for arbitrary unmatched routes
+  // (used by the standalone inspector CLI that runs at root). When the host
+  // remounts the inspector at a custom path, restrict the SPA to that mount
+  // so unrelated routes (including the old `/inspector/*`) fall through.
+  if (basePath !== "/inspector") {
+    return;
+  }
 
   app.get("*", (c) => {
     const indexPath = join(distPath, "index.html");
     if (existsSync(indexPath)) {
       const content = injectRuntimeConfig(
-        readFileSync(indexPath, "utf-8"),
+        rewriteAssetBase(readFileSync(indexPath, "utf-8")),
         effectiveConfig
       );
       return c.html(content);
@@ -398,6 +441,7 @@ export function registerStaticRoutesWithDevProxy(
   const distPath = clientDistPath || getClientDistPath();
   const isDev =
     process.env.NODE_ENV === "development" || process.env.VITE_DEV === "true";
+  const basePath = runtimeConfig?.basePath ?? "/inspector";
 
   if (isDev) {
     console.warn(
@@ -409,8 +453,8 @@ export function registerStaticRoutesWithDevProxy(
 
       if (
         path.startsWith("/api/") ||
-        path.startsWith("/inspector/api/") ||
-        path === "/inspector/config.json"
+        path.startsWith(`${basePath}/api/`) ||
+        path === `${basePath}/config.json`
       ) {
         return c.notFound();
       }

--- a/libraries/typescript/packages/mcp-use/examples/server/basic/simple/src/server.ts
+++ b/libraries/typescript/packages/mcp-use/examples/server/basic/simple/src/server.ts
@@ -1,10 +1,21 @@
 import { MCPServer, text, object, markdown } from "mcp-use/server";
 import z from "zod";
 
+// Every mount path on this server is customized via the `routes` config:
+// MCP endpoints live under /api/*, the inspector at /debug, widgets at /ui/*,
+// and OAuth (if enabled) at /auth. Defaults preserve the original layout.
 const server = new MCPServer({
   name: "simple-example-server",
   version: "1.0.0",
   description: "A simple MCP server example",
+  routes: {
+    mcpBasePath: "/api/mcp",
+    sseBasePath: "/api/sse",
+    widgetsBasePath: "/ui/widgets",
+    publicBasePath: "/ui/static",
+    inspectorBasePath: "/debug",
+    oauthBasePath: "/auth",
+  },
 });
 
 server.tool(
@@ -35,5 +46,4 @@ server.prompt(
   async ({ name }) => text(`Hello, ${name}!`)
 );
 
-// Start the server (MCP endpoints auto-mounted at /mcp)
 await server.listen();

--- a/libraries/typescript/packages/mcp-use/src/server/endpoints/mount-mcp.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/endpoints/mount-mcp.ts
@@ -24,6 +24,7 @@ import {
 import { runWithContext } from "../context-storage.js";
 import { getDebugLevel } from "../logging.js";
 import { generateUUID } from "../utils/runtime.js";
+import type { ResolvedRouteConfig } from "../utils/routes.js";
 
 // ---------------------------------------------------------------------------
 // Helpers for distributed SSE stream routing via StreamManager
@@ -152,7 +153,8 @@ export async function mountMcp(
   }, // The McpServer instance with getServerForSession() method
   sessions: Map<string, SessionData>,
   config: ServerConfig,
-  isProductionMode: boolean
+  isProductionMode: boolean,
+  routeConfig: ResolvedRouteConfig
 ): Promise<{ mcpMounted: boolean; idleCleanupInterval?: NodeJS.Timeout }> {
   const { WebStandardStreamableHTTPServerTransport } =
     await import("@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js");
@@ -263,7 +265,7 @@ export async function mountMcp(
         if (iconSrc) {
           iconUrl = iconSrc.startsWith("http")
             ? iconSrc
-            : `${origin}/mcp-use/public/${iconSrc.replace(/^\//, "")}`;
+            : `${origin}${routeConfig.publicBasePath}/${iconSrc.replace(/^\//, "")}`;
         }
         const regs = instance.registrations;
         const landingTools =
@@ -624,13 +626,13 @@ export async function mountMcp(
     }
   };
 
-  // Mount the handler for all HTTP methods on both /mcp and /sse
-  for (const endpoint of ["/mcp", "/sse"]) {
+  // Mount the handler for all HTTP methods on both configured MCP and SSE endpoints
+  for (const endpoint of [routeConfig.mcpBasePath, routeConfig.sseBasePath]) {
     app.on(["GET", "POST", "DELETE", "HEAD"], endpoint, handleRequest);
   }
 
   console.log(
-    `[MCP] Server mounted at /mcp and /sse (${config.stateless ? "stateless" : "stateful"} mode)`
+    `[MCP] Server mounted at ${routeConfig.mcpBasePath} and ${routeConfig.sseBasePath} (${config.stateless ? "stateless" : "stateful"} mode)`
   );
 
   return { mcpMounted: true, idleCleanupInterval };

--- a/libraries/typescript/packages/mcp-use/src/server/inspector/mount.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/inspector/mount.ts
@@ -6,6 +6,7 @@
 
 import type { Hono as HonoType } from "hono";
 import { readBuildManifest } from "../widgets/index.js";
+import { DEFAULT_ROUTES } from "../utils/routes.js";
 
 /**
  * Mount MCP Inspector UI at /inspector
@@ -37,8 +38,8 @@ export async function mountInspectorUI(
   serverHost: string,
   serverPort: number | undefined,
   isProduction: boolean,
-  mcpBasePath: string = "/mcp",
-  inspectorBasePath: string = "/inspector"
+  mcpBasePath: string = DEFAULT_ROUTES.mcpBasePath,
+  inspectorBasePath: string = DEFAULT_ROUTES.inspectorBasePath
 ): Promise<boolean> {
   // In production, only mount if build manifest says so
   if (isProduction) {
@@ -74,20 +75,18 @@ export async function mountInspectorUI(
       devMode: !isProduction,
       serverPort: typeof serverPort === "number" ? serverPort : undefined,
     });
-    if (inspectorBasePath !== "/inspector") {
+    if (inspectorBasePath !== DEFAULT_ROUTES.inspectorBasePath) {
       // The inspector package currently mounts fixed routes under /inspector.
-      // Expose configured path as a compatibility alias.
-      app.get(`${inspectorBasePath}`, (c) => {
-        const q = c.req.url.includes("?")
-          ? c.req.url.substring(c.req.url.indexOf("?"))
-          : "";
-        return c.redirect(`/inspector${q}`);
-      });
-      app.get(`${inspectorBasePath}/*`, (c) => {
-        const current = new URL(c.req.url);
-        const suffix = current.pathname.substring(inspectorBasePath.length);
-        return c.redirect(`/inspector${suffix}${current.search}`);
-      });
+      // Expose configured path as a compatibility alias via redirect.
+      const handleAlias = (c: import("hono").Context) => {
+        const url = new URL(c.req.url);
+        const suffix = url.pathname.slice(inspectorBasePath.length);
+        return c.redirect(
+          `${DEFAULT_ROUTES.inspectorBasePath}${suffix}${url.search}`
+        );
+      };
+      app.get(inspectorBasePath, handleAlias);
+      app.get(`${inspectorBasePath}/*`, handleAlias);
     }
     console.log(
       `[INSPECTOR] UI available at http://${serverHost}:${serverPort}${inspectorBasePath}`

--- a/libraries/typescript/packages/mcp-use/src/server/inspector/mount.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/inspector/mount.ts
@@ -74,20 +74,8 @@ export async function mountInspectorUI(
       // behind reverse proxies (ngrok, E2B, etc.)
       devMode: !isProduction,
       serverPort: typeof serverPort === "number" ? serverPort : undefined,
+      basePath: inspectorBasePath,
     });
-    if (inspectorBasePath !== DEFAULT_ROUTES.inspectorBasePath) {
-      // The inspector package currently mounts fixed routes under /inspector.
-      // Expose configured path as a compatibility alias via redirect.
-      const handleAlias = (c: import("hono").Context) => {
-        const url = new URL(c.req.url);
-        const suffix = url.pathname.slice(inspectorBasePath.length);
-        return c.redirect(
-          `${DEFAULT_ROUTES.inspectorBasePath}${suffix}${url.search}`
-        );
-      };
-      app.get(inspectorBasePath, handleAlias);
-      app.get(`${inspectorBasePath}/*`, handleAlias);
-    }
     console.log(
       `[INSPECTOR] UI available at http://${serverHost}:${serverPort}${inspectorBasePath}`
     );

--- a/libraries/typescript/packages/mcp-use/src/server/inspector/mount.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/inspector/mount.ts
@@ -36,7 +36,9 @@ export async function mountInspectorUI(
   app: HonoType,
   serverHost: string,
   serverPort: number | undefined,
-  isProduction: boolean
+  isProduction: boolean,
+  mcpBasePath: string = "/mcp",
+  inspectorBasePath: string = "/inspector"
 ): Promise<boolean> {
   // In production, only mount if build manifest says so
   if (isProduction) {
@@ -57,7 +59,7 @@ export async function mountInspectorUI(
     const { mountInspector } = await import("@mcp-use/inspector");
     // Auto-connect to the local MCP server at /mcp (SSE endpoint)
     // Use JSON config to specify SSE transport type
-    const mcpUrl = `http://${serverHost}:${serverPort}/mcp`; // Also available at /sse
+    const mcpUrl = `http://${serverHost}:${serverPort}${mcpBasePath}`; // Also available at /sse
     const autoConnectConfig = JSON.stringify({
       url: mcpUrl,
       name: "Local MCP Server",
@@ -72,8 +74,23 @@ export async function mountInspectorUI(
       devMode: !isProduction,
       serverPort: typeof serverPort === "number" ? serverPort : undefined,
     });
+    if (inspectorBasePath !== "/inspector") {
+      // The inspector package currently mounts fixed routes under /inspector.
+      // Expose configured path as a compatibility alias.
+      app.get(`${inspectorBasePath}`, (c) => {
+        const q = c.req.url.includes("?")
+          ? c.req.url.substring(c.req.url.indexOf("?"))
+          : "";
+        return c.redirect(`/inspector${q}`);
+      });
+      app.get(`${inspectorBasePath}/*`, (c) => {
+        const current = new URL(c.req.url);
+        const suffix = current.pathname.substring(inspectorBasePath.length);
+        return c.redirect(`/inspector${suffix}${current.search}`);
+      });
+    }
     console.log(
-      `[INSPECTOR] UI available at http://${serverHost}:${serverPort}/inspector`
+      `[INSPECTOR] UI available at http://${serverHost}:${serverPort}${inspectorBasePath}`
     );
     return true;
   } catch (err) {

--- a/libraries/typescript/packages/mcp-use/src/server/logging.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/logging.ts
@@ -2,6 +2,14 @@ import chalk from "chalk";
 import type { Context, Next } from "hono";
 
 import { getEnv } from "./utils/runtime.js";
+import { DEFAULT_ROUTES } from "./utils/routes.js";
+
+export interface RequestLoggerRoutes {
+  mcpBasePath?: string;
+  inspectorBasePath?: string;
+  widgetsBasePath?: string;
+  publicBasePath?: string;
+}
 
 /**
  * Server-side debug verbosity for MCP request logging.
@@ -145,212 +153,229 @@ async function extractResponseError(res: Response): Promise<string | null> {
 }
 
 /**
- * Middleware that logs incoming HTTP requests in a compact format controlled
- * by `MCP_DEBUG_LEVEL` (or legacy `DEBUG`). See {@link getDebugLevel}.
+ * Build a request-logger middleware that suppresses noisy traffic against the
+ * configured base paths (inspector telemetry/RPC, dev widget assets, MCP
+ * polling GETs).
  *
- * Skips logging for inspector telemetry/RPC endpoints, dev widget assets, and
- * polling GETs against `/mcp` and `/inspector/api/*`.
+ * Pass the server's resolved {@link import("./utils/routes.js").ResolvedRouteConfig}
+ * so custom mounts are recognized; defaults fall back to {@link DEFAULT_ROUTES}.
  */
-export async function requestLogger(c: Context, next: Next): Promise<void> {
-  const startedAt = Date.now();
-  const timestamp = new Date().toISOString().substring(11, 23);
-  const method = c.req.method;
-  const url = c.req.url;
-  const level = getDebugLevel();
+export function createRequestLogger(
+  routes: RequestLoggerRoutes = {}
+): (c: Context, next: Next) => Promise<void> {
+  const mcpBasePath = routes.mcpBasePath ?? DEFAULT_ROUTES.mcpBasePath;
+  const inspectorBasePath =
+    routes.inspectorBasePath ?? DEFAULT_ROUTES.inspectorBasePath;
+  const widgetsBasePath =
+    routes.widgetsBasePath ?? DEFAULT_ROUTES.widgetsBasePath;
+  const publicBasePath = routes.publicBasePath ?? DEFAULT_ROUTES.publicBasePath;
 
-  const pathname = new URL(url).pathname;
+  const inspectorApiPrefix = `${inspectorBasePath}/api/`;
   const noisyPaths = [
-    "/inspector/api/tel/",
-    "/inspector/api/rpc/stream",
-    "/inspector/api/rpc/log",
-    "/inspector",
-    "/mcp-use/widgets/",
-    "/mcp-use/public/",
+    `${inspectorBasePath}/api/tel/`,
+    `${inspectorBasePath}/api/rpc/stream`,
+    `${inspectorBasePath}/api/rpc/log`,
+    inspectorBasePath,
+    `${widgetsBasePath}/`,
+    `${publicBasePath}/`,
   ];
-  const isNoisyGet =
-    method === "GET" &&
-    (pathname === "/mcp" ||
-      pathname.startsWith("/inspector/api/") ||
-      pathname.startsWith("/mcp-use/"));
 
-  if (
-    noisyPaths.some((noisyPath) => pathname.startsWith(noisyPath)) ||
-    isNoisyGet
-  ) {
-    await next();
-    return;
-  }
+  return async function requestLogger(c: Context, next: Next): Promise<void> {
+    const startedAt = Date.now();
+    const timestamp = new Date().toISOString().substring(11, 23);
+    const method = c.req.method;
+    const url = c.req.url;
+    const level = getDebugLevel();
 
-  // Capture request body up front so we can extract MCP method/params.
-  let requestBody: any = null;
-  let requestHeaders: Record<string, string> = {};
+    const pathname = new URL(url).pathname;
+    const isNoisyGet =
+      method === "GET" &&
+      (pathname === mcpBasePath ||
+        pathname.startsWith(inspectorApiPrefix) ||
+        pathname.startsWith(`${widgetsBasePath}/`) ||
+        pathname.startsWith(`${publicBasePath}/`));
 
-  if (level === "trace") {
-    const allHeaders = c.req.header();
-    if (allHeaders) requestHeaders = allHeaders;
-  }
-
-  if (method !== "GET" && method !== "HEAD") {
-    try {
-      const clonedRequest = c.req.raw.clone();
-      requestBody = await clonedRequest.json().catch(() => {
-        return clonedRequest.text().catch(() => null);
-      });
-    } catch {
-      // ignore — body is optional for the log line
+    if (
+      noisyPaths.some((noisyPath) => pathname.startsWith(noisyPath)) ||
+      isNoisyGet
+    ) {
+      await next();
+      return;
     }
-  }
 
-  await next();
+    // Capture request body up front so we can extract MCP method/params.
+    let requestBody: any = null;
+    let requestHeaders: Record<string, string> = {};
 
-  const durationMs = Date.now() - startedAt;
-  const statusCode = c.res.status;
-
-  // Session ID: incoming header for established sessions, response header for
-  // initialize requests (the SDK transport stamps it on the response).
-  const incomingSid = c.req.header("mcp-session-id");
-  const responseSid = c.res.headers.get("mcp-session-id");
-  const mcpMethod: string | undefined = requestBody?.method;
-  const isInitialize = mcpMethod === "initialize";
-
-  // Build the line. Colors mirror typical access-log palettes: timestamps,
-  // session ids, args and durations are dimmed; method/path/MCP-method are
-  // bold; outcome is green (OK) or red (ERROR).
-  const parts: string[] = [chalk.gray(`[${timestamp}]`)];
-
-  const sessPrefix = !isInitialize ? shortSessionId(incomingSid) : null;
-  if (sessPrefix) parts.push(chalk.gray(`sess=${sessPrefix}`));
-
-  parts.push(method);
-  parts.push(chalk.bold(pathname));
-
-  if (mcpMethod) {
-    if (isInitialize) {
-      const ci = requestBody?.params?.clientInfo;
-      const label =
-        ci?.name && ci?.version
-          ? `: ${ci.name}/${ci.version}`
-          : ci?.name
-            ? `: ${ci.name}`
-            : "";
-      parts.push(chalk.bold(`[initialize${label}]`));
-    } else if (mcpMethod === "tools/call") {
-      const toolName = requestBody?.params?.name ?? "?";
-      let segment = chalk.bold(`[tools/call: ${toolName}]`);
-      if (level !== "info") {
-        const args = requestBody?.params?.arguments;
-        if (args !== undefined) {
-          segment += ` args=${inlineJson(args)}`;
-        }
-      }
-      parts.push(segment);
-    } else if (mcpMethod === "resources/read") {
-      const uri = requestBody?.params?.uri ?? "?";
-      parts.push(chalk.bold(`[resources/read: ${uri}]`));
-    } else if (mcpMethod === "prompts/get") {
-      const promptName = requestBody?.params?.name ?? "?";
-      parts.push(chalk.bold(`[prompts/get: ${promptName}]`));
-    } else {
-      parts.push(chalk.bold(`[${mcpMethod}]`));
+    if (level === "trace") {
+      const allHeaders = c.req.header();
+      if (allHeaders) requestHeaders = allHeaders;
     }
-  }
 
-  if (isInitialize && responseSid) {
-    parts.push(chalk.gray(`→ session=${shortSessionId(responseSid)}`));
-  }
-
-  // Outcome:
-  //  - MCP requests: OK / ERROR <message> based on JSON-RPC error parsing.
-  //  - Plain HTTP (HEAD, etc.): the raw status code, colored by class.
-  let outcomePart: string;
-  const errMsg = await extractResponseError(c.res);
-  if (errMsg) {
-    outcomePart = chalk.red(`ERROR ${errMsg}`);
-  } else if (mcpMethod) {
-    outcomePart =
-      statusCode >= 400
-        ? chalk.red(`ERROR (HTTP ${statusCode})`)
-        : chalk.green("OK");
-  } else {
-    outcomePart =
-      statusCode >= 500
-        ? chalk.magenta(String(statusCode))
-        : statusCode >= 400
-          ? chalk.red(String(statusCode))
-          : statusCode >= 300
-            ? chalk.yellow(String(statusCode))
-            : chalk.green(String(statusCode));
-  }
-  parts.push(outcomePart);
-  parts.push(chalk.gray(`(${durationMs}ms)`));
-
-  console.log(parts.join(" "));
-
-  // Trace mode preserves the legacy DEBUG=1 behavior: detailed request and
-  // response dumps follow the summary line.
-  if (level !== "trace") return;
-
-  console.log("\n" + chalk.cyan("=".repeat(80)));
-  console.log(chalk.bold.cyan("[TRACE] Request Details"));
-  console.log(chalk.cyan("-".repeat(80)));
-
-  if (Object.keys(requestHeaders).length > 0) {
-    console.log(chalk.yellow("Request Headers:"));
-    console.log(formatForLogging(requestHeaders));
-  }
-
-  if (requestBody !== null) {
-    console.log(chalk.yellow("Request Body:"));
-    if (typeof requestBody === "string") {
-      console.log(requestBody);
-    } else {
-      console.log(formatForLogging(requestBody));
-    }
-  }
-
-  const responseHeaders: Record<string, string> = {};
-  c.res.headers.forEach((value, key) => {
-    responseHeaders[key] = value;
-  });
-  if (Object.keys(responseHeaders).length > 0) {
-    console.log(chalk.yellow("Response Headers:"));
-    console.log(formatForLogging(responseHeaders));
-  }
-
-  try {
-    if (c.res.body !== null && c.res.body !== undefined) {
+    if (method !== "GET" && method !== "HEAD") {
       try {
-        const clonedResponse = c.res.clone();
-        const responseBody = await clonedResponse.text().catch(() => null);
-
-        if (responseBody !== null && responseBody.length > 0) {
-          console.log(chalk.yellow("Response Body:"));
-          try {
-            const jsonBody = JSON.parse(responseBody);
-            console.log(formatForLogging(jsonBody));
-          } catch {
-            const maxLength = 10000;
-            if (responseBody.length > maxLength) {
-              console.log(
-                responseBody.substring(0, maxLength) +
-                  `\n... (truncated, ${responseBody.length - maxLength} more characters)`
-              );
-            } else {
-              console.log(responseBody);
-            }
-          }
-        } else {
-          console.log(chalk.yellow("Response Body:") + " (empty)");
-        }
+        const clonedRequest = c.req.raw.clone();
+        requestBody = await clonedRequest.json().catch(() => {
+          return clonedRequest.text().catch(() => null);
+        });
       } catch {
-        console.log(chalk.yellow("Response Body:") + " (unable to clone/read)");
+        // ignore — body is optional for the log line
       }
-    } else {
-      console.log(chalk.yellow("Response Body:") + " (no body)");
     }
-  } catch {
-    console.log(chalk.yellow("Response Body:") + " (unable to read)");
-  }
 
-  console.log(chalk.cyan("=".repeat(80)) + "\n");
+    await next();
+
+    const durationMs = Date.now() - startedAt;
+    const statusCode = c.res.status;
+
+    // Session ID: incoming header for established sessions, response header for
+    // initialize requests (the SDK transport stamps it on the response).
+    const incomingSid = c.req.header("mcp-session-id");
+    const responseSid = c.res.headers.get("mcp-session-id");
+    const mcpMethod: string | undefined = requestBody?.method;
+    const isInitialize = mcpMethod === "initialize";
+
+    // Build the line. Colors mirror typical access-log palettes: timestamps,
+    // session ids, args and durations are dimmed; method/path/MCP-method are
+    // bold; outcome is green (OK) or red (ERROR).
+    const parts: string[] = [chalk.gray(`[${timestamp}]`)];
+
+    const sessPrefix = !isInitialize ? shortSessionId(incomingSid) : null;
+    if (sessPrefix) parts.push(chalk.gray(`sess=${sessPrefix}`));
+
+    parts.push(method);
+    parts.push(chalk.bold(pathname));
+
+    if (mcpMethod) {
+      if (isInitialize) {
+        const ci = requestBody?.params?.clientInfo;
+        const label =
+          ci?.name && ci?.version
+            ? `: ${ci.name}/${ci.version}`
+            : ci?.name
+              ? `: ${ci.name}`
+              : "";
+        parts.push(chalk.bold(`[initialize${label}]`));
+      } else if (mcpMethod === "tools/call") {
+        const toolName = requestBody?.params?.name ?? "?";
+        let segment = chalk.bold(`[tools/call: ${toolName}]`);
+        if (level !== "info") {
+          const args = requestBody?.params?.arguments;
+          if (args !== undefined) {
+            segment += ` args=${inlineJson(args)}`;
+          }
+        }
+        parts.push(segment);
+      } else if (mcpMethod === "resources/read") {
+        const uri = requestBody?.params?.uri ?? "?";
+        parts.push(chalk.bold(`[resources/read: ${uri}]`));
+      } else if (mcpMethod === "prompts/get") {
+        const promptName = requestBody?.params?.name ?? "?";
+        parts.push(chalk.bold(`[prompts/get: ${promptName}]`));
+      } else {
+        parts.push(chalk.bold(`[${mcpMethod}]`));
+      }
+    }
+
+    if (isInitialize && responseSid) {
+      parts.push(chalk.gray(`→ session=${shortSessionId(responseSid)}`));
+    }
+
+    // Outcome:
+    //  - MCP requests: OK / ERROR <message> based on JSON-RPC error parsing.
+    //  - Plain HTTP (HEAD, etc.): the raw status code, colored by class.
+    let outcomePart: string;
+    const errMsg = await extractResponseError(c.res);
+    if (errMsg) {
+      outcomePart = chalk.red(`ERROR ${errMsg}`);
+    } else if (mcpMethod) {
+      outcomePart =
+        statusCode >= 400
+          ? chalk.red(`ERROR (HTTP ${statusCode})`)
+          : chalk.green("OK");
+    } else {
+      outcomePart =
+        statusCode >= 500
+          ? chalk.magenta(String(statusCode))
+          : statusCode >= 400
+            ? chalk.red(String(statusCode))
+            : statusCode >= 300
+              ? chalk.yellow(String(statusCode))
+              : chalk.green(String(statusCode));
+    }
+    parts.push(outcomePart);
+    parts.push(chalk.gray(`(${durationMs}ms)`));
+
+    console.log(parts.join(" "));
+
+    // Trace mode preserves the legacy DEBUG=1 behavior: detailed request and
+    // response dumps follow the summary line.
+    if (level !== "trace") return;
+
+    console.log("\n" + chalk.cyan("=".repeat(80)));
+    console.log(chalk.bold.cyan("[TRACE] Request Details"));
+    console.log(chalk.cyan("-".repeat(80)));
+
+    if (Object.keys(requestHeaders).length > 0) {
+      console.log(chalk.yellow("Request Headers:"));
+      console.log(formatForLogging(requestHeaders));
+    }
+
+    if (requestBody !== null) {
+      console.log(chalk.yellow("Request Body:"));
+      if (typeof requestBody === "string") {
+        console.log(requestBody);
+      } else {
+        console.log(formatForLogging(requestBody));
+      }
+    }
+
+    const responseHeaders: Record<string, string> = {};
+    c.res.headers.forEach((value, key) => {
+      responseHeaders[key] = value;
+    });
+    if (Object.keys(responseHeaders).length > 0) {
+      console.log(chalk.yellow("Response Headers:"));
+      console.log(formatForLogging(responseHeaders));
+    }
+
+    try {
+      if (c.res.body !== null && c.res.body !== undefined) {
+        try {
+          const clonedResponse = c.res.clone();
+          const responseBody = await clonedResponse.text().catch(() => null);
+
+          if (responseBody !== null && responseBody.length > 0) {
+            console.log(chalk.yellow("Response Body:"));
+            try {
+              const jsonBody = JSON.parse(responseBody);
+              console.log(formatForLogging(jsonBody));
+            } catch {
+              const maxLength = 10000;
+              if (responseBody.length > maxLength) {
+                console.log(
+                  responseBody.substring(0, maxLength) +
+                    `\n... (truncated, ${responseBody.length - maxLength} more characters)`
+                );
+              } else {
+                console.log(responseBody);
+              }
+            }
+          } else {
+            console.log(chalk.yellow("Response Body:") + " (empty)");
+          }
+        } catch {
+          console.log(
+            chalk.yellow("Response Body:") + " (unable to clone/read)"
+          );
+        }
+      } else {
+        console.log(chalk.yellow("Response Body:") + " (no body)");
+      }
+    } catch {
+      console.log(chalk.yellow("Response Body:") + " (unable to read)");
+    }
+
+    console.log(chalk.cyan("=".repeat(80)) + "\n");
+  };
 }

--- a/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
@@ -109,10 +109,12 @@ import {
   isProductionMode as isProductionModeHelper,
   logRegisteredItems as logRegisteredItemsHelper,
   parseTemplateUri as parseTemplateUriHelper,
+  resolveRouteConfig,
   rewriteSupabaseRequest,
   startServer,
 } from "./utils/index.js";
 import type { WithMcpUse } from "./utils/hono-proxy.js";
+import type { ResolvedRouteConfig } from "./utils/routes.js";
 import type {
   McpMiddlewareEntry,
   McpMiddlewareFn,
@@ -332,6 +334,7 @@ class MCPServerClass<HasOAuth extends boolean = false> {
    * Used for generating widget URLs and OAuth callbacks.
    */
   public serverBaseUrl?: string;
+  public routeConfig: ResolvedRouteConfig;
 
   /**
    * Optional favicon URL to display in inspector and documentation.
@@ -2367,6 +2370,7 @@ class MCPServerClass<HasOAuth extends boolean = false> {
 
     this.serverHost = config.host || "localhost";
     this.serverBaseUrl = config.baseUrl;
+    this.routeConfig = resolveRouteConfig(config.routes);
 
     // Auto-select favicon from icons array if not explicitly provided
     if (config.favicon) {
@@ -2379,14 +2383,15 @@ class MCPServerClass<HasOAuth extends boolean = false> {
     // Helper to convert relative icon paths to absolute URLs
     const processIconUrls = (
       icons: ServerConfig["icons"],
-      baseUrl?: string
+      baseUrl?: string,
+      publicBasePath: string = this.routeConfig.publicBasePath
     ) => {
       if (!icons || !baseUrl) return icons;
       return icons.map((icon) => ({
         ...icon,
         src: icon.src.startsWith("http")
           ? icon.src
-          : `${baseUrl}/mcp-use/public/${icon.src}`,
+          : `${baseUrl}${publicBasePath}/${icon.src}`,
       }));
     };
 
@@ -2439,7 +2444,7 @@ class MCPServerClass<HasOAuth extends boolean = false> {
       !isProductionModeHelper() &&
       !isDeno
     ) {
-      setupPublicRoutes(this.app, false); // Dev mode (public/)
+      setupPublicRoutes(this.app, false, this.routeConfig.publicBasePath); // Dev mode (public/)
       setupFaviconRoute(this.app, this.favicon, false);
       this.publicRoutesMode = "dev";
     }
@@ -2651,14 +2656,15 @@ class MCPServerClass<HasOAuth extends boolean = false> {
     // Helper to convert relative icon paths to absolute URLs
     const processIconUrls = (
       icons: ServerConfig["icons"],
-      baseUrl?: string
+      baseUrl?: string,
+      publicBasePath: string = this.routeConfig.publicBasePath
     ) => {
       if (!icons || !baseUrl) return icons;
       return icons.map((icon) => ({
         ...icon,
         src: icon.src.startsWith("http")
           ? icon.src
-          : `${baseUrl}/mcp-use/public/${icon.src}`,
+          : `${baseUrl}${publicBasePath}/${icon.src}`,
       }));
     };
 
@@ -3720,7 +3726,8 @@ class MCPServerClass<HasOAuth extends boolean = false> {
       this, // Pass the MCPServer instance so mountMcp can call getServerForSession()
       this.sessions,
       this.config,
-      isProductionModeHelper()
+      isProductionModeHelper(),
+      this.routeConfig
     );
 
     this.mcpMounted = result.mcpMounted;
@@ -3905,12 +3912,14 @@ class MCPServerClass<HasOAuth extends boolean = false> {
         this.app,
         this.oauthProvider,
         this.getServerBaseUrl(),
+        this.routeConfig,
         this.oauthSetupState
       );
     }
 
     await mountWidgets(this as any, {
-      baseRoute: "/mcp-use/widgets",
+      baseRoute: this.routeConfig.widgetsBasePath,
+      publicBasePath: this.routeConfig.publicBasePath,
       // Only forward `resourcesDir` when the env var is set. That lets
       // @mcp-use/cli steer widget discovery to e.g. `src/mcp/resources`
       // (via `--mcp-dir src/mcp`) without forcing the user to configure
@@ -3953,6 +3962,7 @@ class MCPServerClass<HasOAuth extends boolean = false> {
       this.serverHost,
       {
         onDenoRequest: rewriteSupabaseRequest,
+        mcpBasePath: this.routeConfig.mcpBasePath,
       }
     );
     this._httpServerClose = httpHandle.close;
@@ -4034,13 +4044,15 @@ class MCPServerClass<HasOAuth extends boolean = false> {
         this.app,
         this.oauthProvider,
         this.getServerBaseUrl(),
+        this.routeConfig,
         this.oauthSetupState
       );
     }
 
     console.log("[MCP] Mounting widgets");
     await mountWidgets(this as any, {
-      baseRoute: "/mcp-use/widgets",
+      baseRoute: this.routeConfig.widgetsBasePath,
+      publicBasePath: this.routeConfig.publicBasePath,
       // Only forward `resourcesDir` when the env var is set. That lets
       // @mcp-use/cli steer widget discovery to e.g. `src/mcp/resources`
       // (via `--mcp-dir src/mcp`) without forcing the user to configure
@@ -4148,7 +4160,9 @@ class MCPServerClass<HasOAuth extends boolean = false> {
       this.app,
       this.serverHost,
       this.serverPort,
-      isProductionModeHelper()
+      isProductionModeHelper(),
+      this.routeConfig.mcpBasePath,
+      this.routeConfig.inspectorBasePath
     );
 
     if (mounted) {

--- a/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
@@ -58,7 +58,7 @@ export type {
 
 import { getRequestContext, runWithContext } from "./context-storage.js";
 import { mountMcp as mountMcpHelper } from "./endpoints/index.js";
-import { requestLogger } from "./logging.js";
+import { createRequestLogger } from "./logging.js";
 import {
   getActiveSessions,
   sendNotification,
@@ -2424,7 +2424,7 @@ class MCPServerClass<HasOAuth extends boolean = false> {
     );
 
     // Create and configure Hono app with default middleware
-    this.app = createHonoApp(requestLogger, {
+    this.app = createHonoApp(createRequestLogger(this.routeConfig), {
       cors: this.config.cors,
       allowedOrigins: this.config.allowedOrigins,
     });

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/routes.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/routes.ts
@@ -19,6 +19,7 @@ import type { Context, Hono } from "hono";
 import { cors } from "hono/cors";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import type { OAuthProvider, OAuthProxy } from "./providers/types.js";
+import { joinRoute } from "../utils/routes.js";
 
 /**
  * Type guard to check if oauth config is a proxy
@@ -194,13 +195,34 @@ export function createTokenHandler(
 export function setupOAuthRoutes(
   app: Hono,
   oauth: OAuthProvider | OAuthProxy,
-  baseUrl: string
+  baseUrl: string,
+  oauthBasePath: string = "",
+  mcpBasePath: string = "/mcp"
 ): void {
   const proxyMode = isOAuthProxy(oauth);
+  const authorizePath = joinRoute(oauthBasePath, "/authorize");
+  const tokenPath = joinRoute(oauthBasePath, "/token");
+  const registerPath = joinRoute(oauthBasePath, "/register");
+  const oauthWellKnownPath = joinRoute(
+    oauthBasePath,
+    "/.well-known/oauth-authorization-server"
+  );
+  const oidcWellKnownPath = joinRoute(
+    oauthBasePath,
+    "/.well-known/openid-configuration"
+  );
+  const protectedResourcePath = joinRoute(
+    oauthBasePath,
+    "/.well-known/oauth-protected-resource"
+  );
+  const mcpScopedProtectedResourcePath = joinRoute(
+    oauthBasePath,
+    `/.well-known/oauth-protected-resource${mcpBasePath}`
+  );
   // Enable CORS for all OAuth-related endpoints
   // This is required for browser-based MCP clients to discover OAuth metadata
   app.use(
-    "/.well-known/*",
+    joinRoute(oauthBasePath, "/.well-known/*"),
     cors({
       origin: "*", // Allow all origins for metadata discovery
       allowMethods: ["GET", "OPTIONS"],
@@ -214,7 +236,7 @@ export function setupOAuthRoutes(
   // In DCR-direct mode: dormant (clients reach upstream directly)
   // In proxy mode: active (handles OAuth flow through the proxy)
   app.use(
-    "/authorize",
+    authorizePath,
     cors({
       origin: "*",
       allowMethods: ["GET", "POST", "OPTIONS"],
@@ -223,7 +245,7 @@ export function setupOAuthRoutes(
     })
   );
   app.use(
-    "/token",
+    tokenPath,
     cors({
       origin: "*",
       allowMethods: ["POST", "OPTIONS"],
@@ -234,9 +256,9 @@ export function setupOAuthRoutes(
 
   // Mount /authorize and /token handlers
   const handleAuthorize = createAuthorizeHandler(oauth);
-  app.get("/authorize", handleAuthorize);
-  app.post("/authorize", handleAuthorize);
-  app.post("/token", createTokenHandler(oauth));
+  app.get(authorizePath, handleAuthorize);
+  app.post(authorizePath, handleAuthorize);
+  app.post(tokenPath, createTokenHandler(oauth));
 
   // In proxy mode, add /register endpoint that returns the configured clientId
   // This allows MCP clients to "register" even though the client is pre-registered
@@ -244,7 +266,7 @@ export function setupOAuthRoutes(
     const proxy = oauth as OAuthProxy;
 
     app.use(
-      "/register",
+      registerPath,
       cors({
         origin: "*",
         allowMethods: ["POST", "OPTIONS"],
@@ -253,7 +275,7 @@ export function setupOAuthRoutes(
       })
     );
 
-    app.post("/register", async (c: Context) => {
+    app.post(registerPath, async (c: Context) => {
       const body = await c.req.json().catch(() => ({}));
 
       // Return a fake registration response with the configured clientId
@@ -292,9 +314,9 @@ export function setupOAuthRoutes(
 
       return c.json({
         issuer: baseUrl,
-        authorization_endpoint: `${baseUrl}/authorize`,
-        token_endpoint: `${baseUrl}/token`,
-        registration_endpoint: `${baseUrl}/register`,
+        authorization_endpoint: `${baseUrl}${authorizePath}`,
+        token_endpoint: `${baseUrl}${tokenPath}`,
+        registration_endpoint: `${baseUrl}${registerPath}`,
         scopes_supported: oauth.getScopesSupported(),
         response_types_supported: ["code"],
         grant_types_supported: oauth.getGrantTypesSupported(),
@@ -344,14 +366,8 @@ export function setupOAuthRoutes(
   };
 
   // Register the handler for both OAuth and OpenID Connect discovery endpoints
-  app.get(
-    "/.well-known/oauth-authorization-server",
-    handleAuthorizationServerMetadata
-  );
-  app.get(
-    "/.well-known/openid-configuration",
-    handleAuthorizationServerMetadata
-  );
+  app.get(oauthWellKnownPath, handleAuthorizationServerMetadata);
+  app.get(oidcWellKnownPath, handleAuthorizationServerMetadata);
 
   /**
    * OAuth Protected Resource Metadata
@@ -360,7 +376,7 @@ export function setupOAuthRoutes(
    * DCR-direct mode: Points to the actual OAuth provider.
    * Proxy mode: Points to the local server (which proxies to upstream).
    */
-  app.get("/.well-known/oauth-protected-resource", (c: Context) => {
+  app.get(protectedResourcePath, (c: Context) => {
     // In proxy mode, the authorization server is the local proxy
     const authServer = proxyMode ? baseUrl : oauth.getIssuer();
 
@@ -378,11 +394,11 @@ export function setupOAuthRoutes(
 
   // Path-scoped protected resource metadata per RFC 9728 — declares that the
   // `/mcp` path specifically is the protected resource.
-  app.get("/.well-known/oauth-protected-resource/mcp", (c: Context) => {
+  app.get(mcpScopedProtectedResourcePath, (c: Context) => {
     const authServer = proxyMode ? baseUrl : oauth.getIssuer();
 
     return c.json({
-      resource: `${baseUrl}/mcp`,
+      resource: `${baseUrl}${mcpBasePath}`,
       authorization_servers: [authServer],
       scopes_supported: oauth.getScopesSupported(),
       bearer_methods_supported: ["header"],

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/routes.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/routes.ts
@@ -19,7 +19,7 @@ import type { Context, Hono } from "hono";
 import { cors } from "hono/cors";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import type { OAuthProvider, OAuthProxy } from "./providers/types.js";
-import { joinRoute } from "../utils/routes.js";
+import { joinRoute, DEFAULT_ROUTES } from "../utils/routes.js";
 
 /**
  * Type guard to check if oauth config is a proxy
@@ -196,8 +196,8 @@ export function setupOAuthRoutes(
   app: Hono,
   oauth: OAuthProvider | OAuthProxy,
   baseUrl: string,
-  oauthBasePath: string = "",
-  mcpBasePath: string = "/mcp"
+  oauthBasePath: string = DEFAULT_ROUTES.oauthBasePath,
+  mcpBasePath: string = DEFAULT_ROUTES.mcpBasePath
 ): void {
   const proxyMode = isOAuthProxy(oauth);
   const authorizePath = joinRoute(oauthBasePath, "/authorize");

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/setup.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/setup.ts
@@ -9,6 +9,7 @@ import type { Hono as HonoType, Context, Next } from "hono";
 import { setupOAuthRoutes, isOAuthProxy } from "./routes.js";
 import { createBearerAuthMiddleware } from "./middleware.js";
 import type { OAuthProvider, OAuthProxy } from "./providers/types.js";
+import type { ResolvedRouteConfig } from "../utils/routes.js";
 
 /**
  * OAuth setup state
@@ -39,6 +40,7 @@ export async function setupOAuthForServer(
   app: HonoType,
   oauth: OAuthProvider | OAuthProxy,
   baseUrl: string,
+  routeConfig: ResolvedRouteConfig,
   state: OAuthSetupState
 ): Promise<OAuthSetupState> {
   if (state.complete) {
@@ -52,7 +54,13 @@ export async function setupOAuthForServer(
   const middleware = createBearerAuthMiddleware(oauth, baseUrl);
 
   // Setup OAuth routes
-  setupOAuthRoutes(app, oauth, baseUrl);
+  setupOAuthRoutes(
+    app,
+    oauth,
+    baseUrl,
+    routeConfig.oauthBasePath,
+    routeConfig.mcpBasePath
+  );
 
   if (proxyMode) {
     console.log(
@@ -67,8 +75,10 @@ export async function setupOAuthForServer(
   console.log("[OAuth] Metadata endpoints: /.well-known/*");
 
   // Apply bearer auth to all /mcp routes
-  app.use("/mcp/*", middleware);
-  console.log("[OAuth] Bearer authentication enabled on /mcp routes");
+  app.use(`${routeConfig.mcpBasePath}/*`, middleware);
+  console.log(
+    `[OAuth] Bearer authentication enabled on ${routeConfig.mcpBasePath} routes`
+  );
 
   return {
     provider: oauth,

--- a/libraries/typescript/packages/mcp-use/src/server/types/common.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/types/common.ts
@@ -36,6 +36,45 @@ export type InferZodInput<S> = S extends z.ZodTypeAny
   ? OptionalizeUndefinedFields<z.infer<S>>
   : Record<string, any>;
 
+/**
+ * Configurable HTTP mount paths for MCP server components.
+ *
+ * These values control where routes are mounted on the server.
+ * They do not change the externally advertised public URL (`baseUrl` / `MCP_URL`).
+ */
+export interface RouteConfig {
+  /**
+   * Base path for MCP HTTP transport endpoints.
+   * @default "/mcp"
+   */
+  mcpBasePath?: string;
+  /**
+   * Base path for SSE-compatible transport endpoint.
+   * @default "/sse"
+   */
+  sseBasePath?: string;
+  /**
+   * Base path for widget pages and built widget assets.
+   * @default "/mcp-use/widgets"
+   */
+  widgetsBasePath?: string;
+  /**
+   * Base path for static public files.
+   * @default "/mcp-use/public"
+   */
+  publicBasePath?: string;
+  /**
+   * Base path for inspector UI.
+   * @default "/inspector"
+   */
+  inspectorBasePath?: string;
+  /**
+   * Prefix for OAuth endpoints (authorize/token/register/.well-known/*).
+   * @default ""
+   */
+  oauthBasePath?: string;
+}
+
 export interface ServerConfig {
   /**
    * Unique identifier for the MCP server .
@@ -72,6 +111,18 @@ export interface ServerConfig {
    * @example "https://api.example.com/mcp"
    */
   baseUrl?: string;
+  /**
+   * Route mount configuration for MCP endpoints, widgets, public files, inspector, and OAuth.
+   *
+   * Defaults preserve existing behavior:
+   * - mcpBasePath: "/mcp"
+   * - sseBasePath: "/sse"
+   * - widgetsBasePath: "/mcp-use/widgets"
+   * - publicBasePath: "/mcp-use/public"
+   * - inspectorBasePath: "/inspector"
+   * - oauthBasePath: ""
+   */
+  routes?: RouteConfig;
   /**
    * Custom CORS options for the server.
    *

--- a/libraries/typescript/packages/mcp-use/src/server/types/index.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/types/index.ts
@@ -5,6 +5,7 @@
 // Common types
 export {
   ServerConfig,
+  RouteConfig,
   InputDefinition,
   ResourceAnnotations,
   OptionalizeUndefinedFields,

--- a/libraries/typescript/packages/mcp-use/src/server/utils/index.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/utils/index.ts
@@ -10,3 +10,4 @@ export * from "./hono-proxy.js";
 export * from "./completion-helpers.js";
 export * from "./elicitation-helpers.js";
 export * from "./proxy-client.js";
+export * from "./routes.js";

--- a/libraries/typescript/packages/mcp-use/src/server/utils/routes.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/utils/routes.ts
@@ -9,7 +9,7 @@ export interface ResolvedRouteConfig {
   oauthBasePath: string;
 }
 
-const DEFAULT_ROUTES: ResolvedRouteConfig = {
+export const DEFAULT_ROUTES: ResolvedRouteConfig = {
   mcpBasePath: "/mcp",
   sseBasePath: "/sse",
   widgetsBasePath: "/mcp-use/widgets",
@@ -20,13 +20,12 @@ const DEFAULT_ROUTES: ResolvedRouteConfig = {
 
 function normalizePath(input: string, allowEmpty: boolean): string {
   const trimmed = input.trim();
-  if (allowEmpty && (trimmed === "" || trimmed === "/")) return "";
-  if (!trimmed) throw new Error("Route path cannot be empty");
-
-  const withLeadingSlash = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
-  return withLeadingSlash.length > 1
-    ? withLeadingSlash.replace(/\/+$/, "")
-    : withLeadingSlash;
+  if (trimmed === "" || trimmed === "/") {
+    if (allowEmpty) return "";
+    throw new Error("Route path cannot be empty");
+  }
+  const prefixed = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  return prefixed.replace(/\/+$/, "");
 }
 
 export function resolveRouteConfig(config?: RouteConfig): ResolvedRouteConfig {
@@ -62,8 +61,5 @@ export function resolveRouteConfig(config?: RouteConfig): ResolvedRouteConfig {
 
 export function joinRoute(basePath: string, subPath: string): string {
   if (!basePath) return normalizePath(subPath, false);
-  const base = normalizePath(basePath, false);
-  const child = normalizePath(subPath, false);
-  if (child === "/") return base;
-  return `${base}${child}`;
+  return `${normalizePath(basePath, false)}${normalizePath(subPath, false)}`;
 }

--- a/libraries/typescript/packages/mcp-use/src/server/utils/routes.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/utils/routes.ts
@@ -1,0 +1,69 @@
+import type { RouteConfig } from "../types/common.js";
+
+export interface ResolvedRouteConfig {
+  mcpBasePath: string;
+  sseBasePath: string;
+  widgetsBasePath: string;
+  publicBasePath: string;
+  inspectorBasePath: string;
+  oauthBasePath: string;
+}
+
+const DEFAULT_ROUTES: ResolvedRouteConfig = {
+  mcpBasePath: "/mcp",
+  sseBasePath: "/sse",
+  widgetsBasePath: "/mcp-use/widgets",
+  publicBasePath: "/mcp-use/public",
+  inspectorBasePath: "/inspector",
+  oauthBasePath: "",
+};
+
+function normalizePath(input: string, allowEmpty: boolean): string {
+  const trimmed = input.trim();
+  if (allowEmpty && (trimmed === "" || trimmed === "/")) return "";
+  if (!trimmed) throw new Error("Route path cannot be empty");
+
+  const withLeadingSlash = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  return withLeadingSlash.length > 1
+    ? withLeadingSlash.replace(/\/+$/, "")
+    : withLeadingSlash;
+}
+
+export function resolveRouteConfig(config?: RouteConfig): ResolvedRouteConfig {
+  if (!config) return { ...DEFAULT_ROUTES };
+
+  return {
+    mcpBasePath: normalizePath(
+      config.mcpBasePath ?? DEFAULT_ROUTES.mcpBasePath,
+      false
+    ),
+    sseBasePath: normalizePath(
+      config.sseBasePath ?? DEFAULT_ROUTES.sseBasePath,
+      false
+    ),
+    widgetsBasePath: normalizePath(
+      config.widgetsBasePath ?? DEFAULT_ROUTES.widgetsBasePath,
+      false
+    ),
+    publicBasePath: normalizePath(
+      config.publicBasePath ?? DEFAULT_ROUTES.publicBasePath,
+      false
+    ),
+    inspectorBasePath: normalizePath(
+      config.inspectorBasePath ?? DEFAULT_ROUTES.inspectorBasePath,
+      false
+    ),
+    oauthBasePath: normalizePath(
+      config.oauthBasePath ?? DEFAULT_ROUTES.oauthBasePath,
+      true
+    ),
+  };
+}
+
+export function joinRoute(basePath: string, subPath: string): string {
+  if (!basePath) return normalizePath(subPath, false);
+  const base = normalizePath(basePath, false);
+  const child = normalizePath(subPath, false);
+  if (child === "/") return base;
+  return `${base}${child}`;
+}

--- a/libraries/typescript/packages/mcp-use/src/server/utils/server-lifecycle.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/utils/server-lifecycle.ts
@@ -7,6 +7,7 @@
 import chalk from "chalk";
 import type { Hono as HonoType } from "hono";
 import { getEnv, isDeno } from "./runtime.js";
+import { DEFAULT_ROUTES } from "./routes.js";
 
 export function isProductionMode(): boolean {
   // Only check NODE_ENV - CLI commands set this explicitly
@@ -130,7 +131,7 @@ export async function startServer(
     mcpBasePath?: string;
   }
 ): Promise<HttpServerHandle> {
-  const mcpBasePath = options?.mcpBasePath || "/mcp";
+  const mcpBasePath = options?.mcpBasePath || DEFAULT_ROUTES.mcpBasePath;
   if (isDeno) {
     // Deno runtime
     const corsHeaders = getDenoCorsHeaders();

--- a/libraries/typescript/packages/mcp-use/src/server/utils/server-lifecycle.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/utils/server-lifecycle.ts
@@ -127,8 +127,10 @@ export async function startServer(
   options?: {
     onDenoRequest?: (req: Request) => Request | Promise<Request>;
     onDenoResponse?: (res: Response) => Response | Promise<Response>;
+    mcpBasePath?: string;
   }
 ): Promise<HttpServerHandle> {
+  const mcpBasePath = options?.mcpBasePath || "/mcp";
   if (isDeno) {
     // Deno runtime
     const corsHeaders = getDenoCorsHeaders();
@@ -164,7 +166,7 @@ export async function startServer(
     console.log(`[SERVER] Listening`);
     console.log(
       chalk.gray(
-        `[MCP] Tip: connect with the CLI → npx mcp-use client connect http://${host}:${port}/mcp`
+        `[MCP] Tip: connect with the CLI → npx mcp-use client connect http://${host}:${port}${mcpBasePath}`
       )
     );
     return {
@@ -182,10 +184,10 @@ export async function startServer(
       },
       (_info: any) => {
         console.log(`[SERVER] Listening on http://${host}:${port}`);
-        console.log(`[MCP] Endpoints: http://${host}:${port}/mcp`);
+        console.log(`[MCP] Endpoints: http://${host}:${port}${mcpBasePath}`);
         console.log(
           chalk.gray(
-            `[MCP] Tip: connect with the CLI → npx mcp-use client connect http://${host}:${port}/mcp`
+            `[MCP] Tip: connect with the CLI → npx mcp-use client connect http://${host}:${port}${mcpBasePath}`
           )
         );
       }

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/index.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/index.ts
@@ -74,6 +74,7 @@ export {
  *
  * @param options - Configuration options
  * @param options.baseRoute - Base route for widgets (defaults to '/mcp-use/widgets')
+ * @param options.publicBasePath - Base route for public static files (defaults to '/mcp-use/public')
  * @param options.resourcesDir - Directory containing widget files (defaults to 'resources')
  * @returns Promise that resolves when all widgets are mounted
  */
@@ -81,6 +82,7 @@ export async function mountWidgets(
   server: MCPServer,
   options?: {
     baseRoute?: string;
+    publicBasePath?: string;
     resourcesDir?: string;
   }
 ): Promise<void> {
@@ -92,6 +94,10 @@ export async function mountWidgets(
     cspUrls: getCSPUrls(),
     buildId: (server as any).buildId,
     favicon: (server as any).favicon,
+    widgetsBasePath:
+      options?.baseRoute || (server as any).routeConfig?.widgetsBasePath,
+    publicBasePath:
+      options?.publicBasePath || (server as any).routeConfig?.publicBasePath,
     publicRoutesMode: (server as any).publicRoutesMode,
     /** Pre-created HTTP server for Vite HMR WebSocket support */
     httpServer: (server as any)._httpServer as
@@ -127,7 +133,10 @@ export async function mountWidgets(
   if (isProductionMode() || isDeno) {
     console.log("[WIDGETS] Mounting widgets in production mode");
     // Setup routes first for production
-    setupWidgetRoutes(app, serverConfig);
+    setupWidgetRoutes(app, serverConfig, {
+      baseRoute: options?.baseRoute,
+      publicBasePath: options?.publicBasePath,
+    });
     (server as any).publicRoutesMode = "production";
     await mountWidgetsProduction(app, serverConfig, registerWidget, options);
   } else {

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/mcp-ui-adapter.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/mcp-ui-adapter.ts
@@ -17,6 +17,7 @@ import type {
   UIResourceContent,
   UIResourceDefinition,
 } from "../types/resource.js";
+import { DEFAULT_ROUTES } from "../utils/routes.js";
 import { slugifyWidgetName } from "./widget-helpers.js";
 
 /**
@@ -26,6 +27,8 @@ export interface UrlConfig {
   baseUrl: string;
   port: number | string;
   buildId?: string;
+  /** Base path widgets are mounted at (defaults to `/mcp-use/widgets`). */
+  widgetsBasePath?: string;
 }
 
 /**
@@ -46,9 +49,11 @@ export function buildWidgetUrl(
   // Import slugifyWidgetName to ensure URL-safe widget routes
   // This must be imported dynamically to avoid circular dependencies
   const slugifiedWidget = slugifyWidgetName(widget);
+  const widgetsBasePath =
+    config.widgetsBasePath ?? DEFAULT_ROUTES.widgetsBasePath;
 
   const url = new URL(
-    `/mcp-use/widgets/${slugifiedWidget}`,
+    `${widgetsBasePath}/${slugifiedWidget}`,
     `${config.baseUrl}:${config.port}`
   );
 

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/mount-widgets-dev.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/mount-widgets-dev.ts
@@ -92,6 +92,7 @@ export async function mountWidgetsDev(
 ): Promise<void> {
   const { promises: fs } = await import("node:fs");
   const baseRoute = options?.baseRoute || "/mcp-use/widgets";
+  const publicBasePath = options?.publicBasePath || "/mcp-use/public";
   // Resolution order for the widgets directory:
   //   1. Caller-supplied `options.resourcesDir`
   //   2. `MCP_USE_WIDGETS_DIR` env var (set by @mcp-use/cli when --mcp-dir
@@ -313,7 +314,7 @@ if (container && Component) {
     <title>${widget.name} Widget</title>${
       serverConfig.favicon
         ? `
-    <link rel="icon" href="${serverConfig.serverBaseUrl.replace(/\/$/, "")}/mcp-use/public/${serverConfig.favicon}" />`
+    <link rel="icon" href="${serverConfig.serverBaseUrl.replace(/\/$/, "")}${publicBasePath}/${serverConfig.favicon}" />`
         : ""
     }
     <script type="module" src="${fullBaseUrl}/@vite/client"></script>
@@ -556,7 +557,7 @@ if (container && Component) {
     <title>${widgetName} Widget</title>${
       serverConfig.favicon
         ? `
-    <link rel="icon" href="${serverConfig.serverBaseUrl.replace(/\/$/, "")}/mcp-use/public/${serverConfig.favicon}" />`
+    <link rel="icon" href="${serverConfig.serverBaseUrl.replace(/\/$/, "")}${publicBasePath}/${serverConfig.favicon}" />`
         : ""
     }
     <script type="module" src="${fullBaseUrl}/@vite/client"></script>
@@ -700,7 +701,9 @@ if (container && Component) {
             html = processWidgetHtml(
               html,
               widgetName,
-              serverConfig.serverBaseUrl
+              serverConfig.serverBaseUrl,
+              baseRoute,
+              publicBasePath
             );
           } catch (e) {
             console.warn(
@@ -1384,7 +1387,7 @@ export default PostHog;
   // Serve static files from public directory in dev mode
   // Only set up if not already configured (e.g., in constructor)
   if (!serverConfig.publicRoutesMode) {
-    setupPublicRoutes(app, false);
+    setupPublicRoutes(app, false, publicBasePath);
     setupFaviconRoute(app, serverConfig.favicon, false);
   }
 

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/mount-widgets-dev.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/mount-widgets-dev.ts
@@ -10,6 +10,7 @@ import type { Context, Hono as HonoType, Next } from "hono";
 import { adaptConnectMiddleware } from "../connect-adapter.js";
 import type { WidgetMetadata } from "../types/widget.js";
 import { fsHelpers, getCwd, pathHelpers } from "../utils/runtime.js";
+import { DEFAULT_ROUTES } from "../utils/routes.js";
 import {
   registerWidgetFromTemplate,
   setupFaviconRoute,
@@ -91,8 +92,9 @@ export async function mountWidgetsDev(
   options?: MountWidgetsDevOptions
 ): Promise<void> {
   const { promises: fs } = await import("node:fs");
-  const baseRoute = options?.baseRoute || "/mcp-use/widgets";
-  const publicBasePath = options?.publicBasePath || "/mcp-use/public";
+  const baseRoute = options?.baseRoute || DEFAULT_ROUTES.widgetsBasePath;
+  const publicBasePath =
+    options?.publicBasePath || DEFAULT_ROUTES.publicBasePath;
   // Resolution order for the widgets directory:
   //   1. Caller-supplied `options.resourcesDir`
   //   2. `MCP_USE_WIDGETS_DIR` env var (set by @mcp-use/cli when --mcp-dir

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/mount-widgets-production.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/mount-widgets-production.ts
@@ -8,6 +8,7 @@
 import type { Hono as HonoType } from "hono";
 import type { WidgetMetadata } from "../types/widget.js";
 import { isDeno, pathHelpers, fsHelpers, getCwd } from "../utils/runtime.js";
+import { DEFAULT_ROUTES } from "../utils/routes.js";
 import { registerWidgetFromTemplate } from "./widget-helpers.js";
 import type {
   ServerConfig,
@@ -39,7 +40,7 @@ export async function mountWidgetsProduction(
   registerWidget: RegisterWidgetCallback,
   options?: MountWidgetsProductionOptions
 ): Promise<void> {
-  const baseRoute = options?.baseRoute || "/mcp-use/widgets";
+  const baseRoute = options?.baseRoute || DEFAULT_ROUTES.widgetsBasePath;
   const widgetsDir = pathHelpers.join(
     isDeno ? "." : getCwd(),
     "dist",

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/setup-widget-routes.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/setup-widget-routes.ts
@@ -7,6 +7,7 @@
 
 import type { Hono as HonoType, Context } from "hono";
 import { pathHelpers, fsHelpers, getCwd } from "../utils/runtime.js";
+import { DEFAULT_ROUTES } from "../utils/routes.js";
 import {
   getContentType,
   processWidgetHtml,
@@ -36,8 +37,9 @@ export function setupWidgetRoutes(
     publicBasePath?: string;
   }
 ): void {
-  const baseRoute = options?.baseRoute || "/mcp-use/widgets";
-  const publicBasePath = options?.publicBasePath || "/mcp-use/public";
+  const baseRoute = options?.baseRoute || DEFAULT_ROUTES.widgetsBasePath;
+  const publicBasePath =
+    options?.publicBasePath || DEFAULT_ROUTES.publicBasePath;
   // Serve static assets (JS, CSS) from the assets directory
   app.get(`${baseRoute}/:widget/assets/*`, async (c: Context) => {
     const widget = c.req.param("widget")!;

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/setup-widget-routes.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/setup-widget-routes.ts
@@ -30,10 +30,16 @@ import type { ServerConfig } from "./widget-types.js";
  */
 export function setupWidgetRoutes(
   app: HonoType,
-  serverConfig: ServerConfig
+  serverConfig: ServerConfig,
+  options?: {
+    baseRoute?: string;
+    publicBasePath?: string;
+  }
 ): void {
+  const baseRoute = options?.baseRoute || "/mcp-use/widgets";
+  const publicBasePath = options?.publicBasePath || "/mcp-use/public";
   // Serve static assets (JS, CSS) from the assets directory
-  app.get("/mcp-use/widgets/:widget/assets/*", async (c: Context) => {
+  app.get(`${baseRoute}/:widget/assets/*`, async (c: Context) => {
     const widget = c.req.param("widget")!;
     const assetFile = c.req.path.split("/assets/")[1];
     const assetPath = pathHelpers.join(
@@ -62,7 +68,7 @@ export function setupWidgetRoutes(
   });
 
   // Handle assets served from the wrong path (browser resolves ./assets/ relative to /mcp-use/widgets/)
-  app.get("/mcp-use/widgets/assets/*", async (c: Context) => {
+  app.get(`${baseRoute}/assets/*`, async (c: Context) => {
     const assetFile = c.req.path.split("/assets/")[1];
     // Try to find which widget this asset belongs to by checking all widget directories
     const widgetsDir = pathHelpers.join(
@@ -98,7 +104,7 @@ export function setupWidgetRoutes(
 
   // Serve each widget's index.html at its route
   // e.g. GET /mcp-use/widgets/kanban-board -> dist/resources/widgets/kanban-board/index.html
-  app.get("/mcp-use/widgets/:widget", async (c: Context) => {
+  app.get(`${baseRoute}/:widget`, async (c: Context) => {
     const widget = c.req.param("widget")!;
     const filePath = pathHelpers.join(
       getCwd(),
@@ -112,7 +118,13 @@ export function setupWidgetRoutes(
     try {
       let html = await fsHelpers.readFileSync(filePath, "utf8");
       // Process HTML with base URL injection and path conversion
-      html = processWidgetHtml(html, widget, serverConfig.serverBaseUrl);
+      html = processWidgetHtml(
+        html,
+        widget,
+        serverConfig.serverBaseUrl,
+        baseRoute,
+        publicBasePath
+      );
       return c.html(html);
     } catch {
       return c.notFound();
@@ -120,7 +132,7 @@ export function setupWidgetRoutes(
   });
 
   // Serve static files from public directory (production mode)
-  setupPublicRoutes(app, true);
+  setupPublicRoutes(app, true, publicBasePath);
 
   // Setup favicon route at server root (production mode)
   setupFaviconRoute(app, serverConfig.favicon, true);

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/ui-resource-registration.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/ui-resource-registration.ts
@@ -42,6 +42,11 @@ export interface UIResourceServer {
   readonly serverHost: string;
   readonly serverPort?: number;
   readonly serverBaseUrl?: string;
+  readonly routeConfig?: {
+    widgetsBasePath?: string;
+    publicBasePath?: string;
+    [key: string]: unknown;
+  };
   /** Storage for widget definitions, used to inject metadata into tool responses */
   widgetDefinitions: Map<string, Record<string, unknown>>;
   /** Registrations storage for checking existing registrations (for HMR updates) */
@@ -274,6 +279,7 @@ export function uiResourceRegistration<T extends UIResourceServer>(
     serverPort: server.serverPort || 3000,
     serverBaseUrl: server.serverBaseUrl,
     buildId: server.buildId,
+    widgetsBasePath: server.routeConfig?.widgetsBasePath,
   };
 
   // Per MCP Apps spec (SEP-1865): resource _meta.ui should contain CSP,

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/widget-helpers.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/widget-helpers.ts
@@ -310,7 +310,9 @@ export function getContentType(filename: string): string {
 export function processWidgetHtml(
   html: string,
   widgetName: string,
-  baseUrl: string
+  baseUrl: string,
+  widgetsBasePath: string = "/mcp-use/widgets",
+  publicBasePath: string = "/mcp-use/public"
 ): string {
   let processedHtml = html;
 
@@ -349,11 +351,11 @@ export function processWidgetHtml(
     // Replace relative paths that start with /mcp-use for scripts and CSS with absolute URLs
     processedHtml = processedHtml.replace(
       /src="\/mcp-use\/widgets\/([^"]+)"/g,
-      `src="${baseUrl}/mcp-use/widgets/$1"`
+      `src="${baseUrl}${widgetsBasePath}/$1"`
     );
     processedHtml = processedHtml.replace(
       /href="\/mcp-use\/widgets\/([^"]+)"/g,
-      `href="${baseUrl}/mcp-use/widgets/$1"`
+      `href="${baseUrl}${widgetsBasePath}/$1"`
     );
 
     // Add window.__getFile and window.__mcpPublicUrl to head
@@ -361,7 +363,7 @@ export function processWidgetHtml(
     const slugifiedName = slugifyWidgetName(widgetName);
     processedHtml = processedHtml.replace(
       /<head[^>]*>/i,
-      `<head>\n    <script>window.__getFile = (filename) => { return "${baseUrl}/mcp-use/widgets/${slugifiedName}/"+filename }; window.__mcpPublicUrl = "${baseUrl}/mcp-use/public";</script>`
+      `<head>\n    <script>window.__getFile = (filename) => { return "${baseUrl}${widgetsBasePath}/${slugifiedName}/"+filename }; window.__mcpPublicUrl = "${baseUrl}${publicBasePath}";</script>`
     );
   }
 
@@ -404,7 +406,12 @@ export function createWidgetRegistration(
         [key: string]: unknown;
       },
   html: string,
-  serverConfig: { serverBaseUrl: string; cspUrls: string[] },
+  serverConfig: {
+    serverBaseUrl: string;
+    cspUrls: string[];
+    widgetsBasePath?: string;
+    publicBasePath?: string;
+  },
   isDev: boolean = false
 ): {
   name: string;
@@ -711,7 +718,12 @@ export async function registerWidgetFromTemplate(
   widgetName: string,
   htmlPath: string,
   metadata: Record<string, unknown>,
-  serverConfig: { serverBaseUrl: string; cspUrls: string[] },
+  serverConfig: {
+    serverBaseUrl: string;
+    cspUrls: string[];
+    widgetsBasePath?: string;
+    publicBasePath?: string;
+  },
   registerWidget: import("./widget-types.js").RegisterWidgetCallback,
   isDev: boolean = false
 ): Promise<void> {
@@ -722,7 +734,13 @@ export async function registerWidgetFromTemplate(
   }
 
   // Process HTML with base URL injection and path conversion
-  html = processWidgetHtml(html, widgetName, serverConfig.serverBaseUrl);
+  html = processWidgetHtml(
+    html,
+    widgetName,
+    serverConfig.serverBaseUrl,
+    serverConfig.widgetsBasePath || "/mcp-use/widgets",
+    serverConfig.publicBasePath || "/mcp-use/public"
+  );
 
   // Ensure metadata has proper fallbacks
   const processedMetadata = ensureWidgetMetadata(metadata, widgetName);
@@ -759,10 +777,11 @@ export async function registerWidgetFromTemplate(
  */
 export function setupPublicRoutes(
   app: HonoType,
-  useDistDirectory: boolean = false
+  useDistDirectory: boolean = false,
+  publicBasePath: string = "/mcp-use/public"
 ): void {
-  app.get("/mcp-use/public/*", async (c: Context) => {
-    const filePath = c.req.path.replace("/mcp-use/public/", "");
+  app.get(`${publicBasePath}/*`, async (c: Context) => {
+    const filePath = c.req.path.replace(`${publicBasePath}/`, "");
     const basePath = useDistDirectory ? "dist/public" : "public";
     const fullPath = pathHelpers.join(getCwd(), basePath, filePath);
 

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/widget-helpers.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/widget-helpers.ts
@@ -210,6 +210,8 @@ export interface WidgetServerConfig {
   serverBaseUrl?: string;
   /** Build ID for cache busting */
   buildId?: string;
+  /** Base path widgets are mounted at (defaults to `/mcp-use/widgets`). */
+  widgetsBasePath?: string;
 }
 
 /**
@@ -575,6 +577,7 @@ export async function createWidgetUIResource(
     baseUrl: configBaseUrl,
     port: configPort,
     buildId: serverConfig.buildId,
+    widgetsBasePath: serverConfig.widgetsBasePath,
   };
 
   const uiResource = await createUIResourceFromDefinition(

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/widget-helpers.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/widget-helpers.ts
@@ -13,6 +13,7 @@ import type {
   WidgetProps,
 } from "../types/index.js";
 import { fsHelpers, getCwd, isDeno, pathHelpers } from "../utils/runtime.js";
+import { DEFAULT_ROUTES } from "../utils/routes.js";
 import {
   createUIResourceFromDefinition,
   type UrlConfig,
@@ -311,8 +312,8 @@ export function processWidgetHtml(
   html: string,
   widgetName: string,
   baseUrl: string,
-  widgetsBasePath: string = "/mcp-use/widgets",
-  publicBasePath: string = "/mcp-use/public"
+  widgetsBasePath: string = DEFAULT_ROUTES.widgetsBasePath,
+  publicBasePath: string = DEFAULT_ROUTES.publicBasePath
 ): string {
   let processedHtml = html;
 
@@ -738,8 +739,8 @@ export async function registerWidgetFromTemplate(
     html,
     widgetName,
     serverConfig.serverBaseUrl,
-    serverConfig.widgetsBasePath || "/mcp-use/widgets",
-    serverConfig.publicBasePath || "/mcp-use/public"
+    serverConfig.widgetsBasePath || DEFAULT_ROUTES.widgetsBasePath,
+    serverConfig.publicBasePath || DEFAULT_ROUTES.publicBasePath
   );
 
   // Ensure metadata has proper fallbacks
@@ -778,7 +779,7 @@ export async function registerWidgetFromTemplate(
 export function setupPublicRoutes(
   app: HonoType,
   useDistDirectory: boolean = false,
-  publicBasePath: string = "/mcp-use/public"
+  publicBasePath: string = DEFAULT_ROUTES.publicBasePath
 ): void {
   app.get(`${publicBasePath}/*`, async (c: Context) => {
     const filePath = c.req.path.replace(`${publicBasePath}/`, "");

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/widget-types.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/widget-types.ts
@@ -22,6 +22,10 @@ export interface ServerConfig {
   buildId?: string;
   /** Path to favicon file relative to public directory (optional) */
   favicon?: string;
+  /** Base route for widgets */
+  widgetsBasePath?: string;
+  /** Base route for public static files */
+  publicBasePath?: string;
   /** Whether public routes have been set up and in what mode (optional) */
   publicRoutesMode?: "dev" | "production" | null;
   /** Pre-created HTTP server for Vite HMR WebSocket support (optional, Node.js only) */
@@ -37,6 +41,8 @@ export interface ServerConfig {
 export interface MountWidgetsOptions {
   /** Base route for widgets (defaults to '/mcp-use/widgets') */
   baseRoute?: string;
+  /** Base route for public static files (defaults to '/mcp-use/public') */
+  publicBasePath?: string;
   /** Resources directory path (defaults to 'resources') */
   resourcesDir?: string;
 }


### PR DESCRIPTION
## Language / Project Scope

- [x] TypeScript

## Changes

Adds a new optional `routes` field on `ServerConfig` that relocates every HTTP mount on the server (MCP, SSE, widgets, public files, inspector, OAuth). Defaults preserve existing behavior.

```ts
new MCPServer({
  name: "my-server",
  version: "1.0.0",
  routes: {
    mcpBasePath: "/api/mcp",        // default "/mcp"
    sseBasePath: "/api/sse",        // default "/sse"
    widgetsBasePath: "/ui/widgets", // default "/mcp-use/widgets"
    publicBasePath: "/ui/static",   // default "/mcp-use/public"
    inspectorBasePath: "/debug",    // default "/inspector"
    oauthBasePath: "/auth",         // default ""
  },
});
```

## Implementation Details

This branch starts from the original `feat(server): configurable mount paths` commit (\`f7a8d7f\`) and threads the resolved \`routeConfig\` through every code path that previously hardcoded the old defaults:

1. **\`mcp-use\`**
   - \`DEFAULT_ROUTES\` constant replaces inline \`/mcp\` / \`/inspector\` / \`/mcp-use/widgets\` / \`/mcp-use/public\` strings.
   - MCP/SSE transports, OAuth provider endpoints, widget URI builder (\`buildWidgetUrl\`), static public files, favicon, and the request-logger quiet-route filter (\`createRequestLogger\`) all honor the configured paths.
   - Inspector mount passes \`basePath\` to \`mountInspector\` and drops the previous redirect-only compatibility shim.

2. **\`@mcp-use/inspector\`** — made truly remountable, not just aliased.
   - \`mountInspector\`, \`registerInspectorRoutes\`, \`registerMcpAppsRoutes\`, and \`registerStaticRoutes\` accept a \`basePath\` and prefix every backend route with it (health, API, chat, tunnel, dev-info, MCP/OAuth proxies, MCP Apps).
   - \`RuntimeConfig\` carries \`basePath\`; the served HTML injects \`window.__MCP_INSPECTOR_BASE_PATH__\` so the frontend can build URLs against the active mount.
   - New \`lib/inspector-base-path.ts\` helper (\`getInspectorBasePath()\`, \`inspectorUrl()\`) is used by useAutoConnect, LayoutHeader, useChatMessages, telemetry, mcp-apps constants, and rpc-log-bus instead of hardcoded \`/inspector/...\` fetches.
   - React Router \`basename\` reads the runtime base — fixes the \`<Router basename=\"/inspector\"> is not able to match the URL ...\` error when the inspector is mounted elsewhere.
   - Index HTML is post-processed at serve time to rewrite Vite's baked \`/inspector/assets/...\` references to \`\${basePath}/assets/...\` so the browser pulls the bundle from the active mount.
   - The catch-all SPA route is restricted to standalone (default-base) usage; embedded mounts no longer shadow unrelated host routes (including the old \`/inspector/*\` paths).

3. **\`@mcp-use/cli\`**
   - Dev banner (\`MCP:\`, \`Inspector:\`, \`Tunnel:\`) and the inspector auto-open URL read \`runningServer.routeConfig\` so they match the active mounts in HMR mode.
   - \`waitForServer\` accepts an \`inspectorBasePath\` arg and the HMR auto-open flow threads it through, so the health probe hits the configured mount.

## Packages Modified

- [x] \`cli\`
- [x] \`mcp-use\` (server)
- [x] \`inspector\`

## Example Usage

See \`examples/server/basic/simple/src/server.ts\` (this PR) — exercises every \`routes\` option.

## Testing

Smoke-tested with the simple example configured to use \`/api/mcp\`, \`/debug\`, \`/ui/widgets\`, etc.:

- \`POST /api/mcp\` (initialize) → 200; full MCP session (initialize → notifications/initialized → tools/list → resources/list → prompts/list) all return OK.
- \`/debug\` → inspector UI; \`/debug/health\`, \`/debug/config.json\`, \`/debug/api/oauth/metadata\` all respond from the configured mount.
- \`/debug/assets/index-...js\` → 200 \`application/javascript\` (Vite's baked paths rewritten at serve time).
- CLI banner prints \`MCP: http://localhost:PORT/api/mcp\` and \`Inspector: http://localhost:PORT/debug?autoConnect=...%2Fapi%2Fmcp\`.
- Default paths return 404 (\`/mcp\`, \`/inspector\`, \`/inspector/health\`, \`/inspector/assets/*\`, \`/inspector/api/proxy\`, \`/mcp-use/widgets/*\`) — no leakage from old mounts.

## Backwards Compatibility

No action required if you don't set \`routes\`. If you do set \`inspectorBasePath\`, the inspector is now genuinely mounted only at that path — the previous redirect from the configured path to \`/inspector\` is gone, and \`/inspector/*\` no longer serves the SPA fallback in embedded mode.

## Known Limitations

- **\`--no-hmr\`** CLI banner falls back to defaults — the child-process server prints correct paths in its own logs, but the parent CLI can't introspect a spawned tsx process. Most users hit the default HMR path.
- \`LayoutHeader.tsx\` tunnel start/stop still appends a literal \`/mcp\` suffix when rebuilding the post-restart MCP endpoint. Only fires on the tunnel UI button; not part of the basic dev flow.
- \`oauthBasePath\` route assembly was verified by code inspection (\`joinRoute(oauthBasePath, ...)\` in \`oauth/routes.ts\`), not end-to-end with a real OAuth provider example.

## Changeset

Included: \`.changeset/configurable-route-mounts.md\` (mcp-use minor, @mcp-use/inspector minor, @mcp-use/cli patch).