### PR TITLE
feat(server/oauth): allow Supabase URL override for self-hosted/local instances

### DIFF
--- a/libraries/typescript/.changeset/supabase-oauth-url-override.md
+++ b/libraries/typescript/.changeset/supabase-oauth-url-override.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": minor
+---
+
+Add `supabaseUrl` override to `oauthSupabaseProvider` so it can point at a local or self-hosted Supabase instance (e.g. `http://localhost:54321`) instead of the hosted `https://${projectId}.supabase.co` URL. Configurable via the new `supabaseUrl` config option or `MCP_USE_OAUTH_SUPABASE_URL` environment variable; `projectId` is now optional when `supabaseUrl` is provided.

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/providers.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/providers.ts
@@ -20,7 +20,18 @@ import { getEnv } from "../utils/runtime.js";
  * Configuration for Supabase OAuth provider
  */
 export interface SupabaseProviderConfig {
-  projectId: string;
+  /**
+   * Supabase project ID. Used to derive the hosted URL
+   * `https://${projectId}.supabase.co`. Either `projectId` or `supabaseUrl`
+   * must be provided.
+   */
+  projectId?: string;
+  /**
+   * Explicit Supabase base URL. Overrides the projectId-derived hosted URL
+   * — use this for self-hosted or local Supabase instances
+   * (e.g. `http://localhost:54321`).
+   */
+  supabaseUrl?: string;
   jwtSecret?: string;
   verifyJwt?: boolean;
   scopesSupported?: string[];
@@ -77,7 +88,9 @@ export interface CustomProviderConfig {
  * Create a Supabase OAuth provider
  *
  * Supports zero-config setup via environment variables:
- * - MCP_USE_OAUTH_SUPABASE_PROJECT_ID (required)
+ * - MCP_USE_OAUTH_SUPABASE_PROJECT_ID (required unless `supabaseUrl` is set)
+ * - MCP_USE_OAUTH_SUPABASE_URL        (optional override — use for local /
+ *                                      self-hosted Supabase, e.g. http://localhost:54321)
  * - MCP_USE_OAUTH_SUPABASE_JWT_SECRET (optional)
  *
  * @param config - Optional Supabase configuration (overrides environment variables)
@@ -103,25 +116,40 @@ export interface CustomProviderConfig {
  *   })
  * });
  * ```
+ *
+ * @example Local Supabase via supabaseUrl override
+ * ```typescript
+ * const server = new MCPServer({
+ *   name: 'my-server',
+ *   version: '1.0.0',
+ *   oauth: oauthSupabaseProvider({
+ *     supabaseUrl: 'http://localhost:54321'
+ *   })
+ * });
+ * ```
  */
 export function oauthSupabaseProvider(
   config: Partial<SupabaseProviderConfig> = {}
 ): OAuthProvider {
   const projectId =
     config.projectId ?? getEnv("MCP_USE_OAUTH_SUPABASE_PROJECT_ID");
+  const supabaseUrl =
+    config.supabaseUrl ?? getEnv("MCP_USE_OAUTH_SUPABASE_URL");
   const jwtSecret =
     config.jwtSecret ?? getEnv("MCP_USE_OAUTH_SUPABASE_JWT_SECRET");
 
-  if (!projectId) {
+  if (!projectId && !supabaseUrl) {
     throw new Error(
-      "Supabase projectId is required. " +
-        "Set MCP_USE_OAUTH_SUPABASE_PROJECT_ID environment variable or pass projectId in config."
+      "Supabase projectId or supabaseUrl is required. " +
+        "Set MCP_USE_OAUTH_SUPABASE_PROJECT_ID (hosted) or MCP_USE_OAUTH_SUPABASE_URL " +
+        "(self-hosted/local), or pass `projectId` / `supabaseUrl` in config."
     );
   }
 
   return new SupabaseOAuthProvider({
     provider: "supabase",
     projectId,
+    supabaseUrl,
     jwtSecret,
     verifyJwt: config.verifyJwt,
     scopesSupported: config.scopesSupported,

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/providers/supabase.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/providers/supabase.ts
@@ -22,7 +22,15 @@ export class SupabaseOAuthProvider implements OAuthProvider {
 
   constructor(config: SupabaseOAuthConfig) {
     this.config = config;
-    this.supabaseUrl = `https://${config.projectId}.supabase.co`;
+    if (config.supabaseUrl) {
+      this.supabaseUrl = config.supabaseUrl.replace(/\/$/, "");
+    } else if (config.projectId) {
+      this.supabaseUrl = `https://${config.projectId}.supabase.co`;
+    } else {
+      throw new Error(
+        "Supabase OAuth provider requires either `supabaseUrl` or `projectId`."
+      );
+    }
     this.supabaseAuthUrl = `${this.supabaseUrl}/auth/v1`;
     this.issuer = `${this.supabaseUrl}/auth/v1`;
   }

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/providers/types.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/providers/types.ts
@@ -133,7 +133,17 @@ interface BaseOAuthConfig {
  */
 export interface SupabaseOAuthConfig extends BaseOAuthConfig {
   provider: "supabase";
-  projectId: string;
+  /**
+   * Supabase project ID. Used to derive the default URL
+   * `https://${projectId}.supabase.co`. Ignored when `supabaseUrl` is set.
+   */
+  projectId?: string;
+  /**
+   * Explicit Supabase base URL. Overrides the projectId-derived hosted URL
+   * — required for self-hosted or local Supabase instances
+   * (e.g. `http://localhost:54321`).
+   */
+  supabaseUrl?: string;
   jwtSecret?: string;
   verifyJwt?: boolean;
 }

--- a/libraries/typescript/packages/mcp-use/tests/unit/server/oauth-supabase-provider.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/server/oauth-supabase-provider.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { SupabaseOAuthProvider } from "../../../src/server/oauth/providers/supabase.js";
+import { oauthSupabaseProvider } from "../../../src/server/oauth/providers.js";
+
+describe("SupabaseOAuthProvider URL resolution", () => {
+  it("derives hosted URLs from projectId", () => {
+    const provider = new SupabaseOAuthProvider({
+      provider: "supabase",
+      projectId: "abcd1234",
+    });
+
+    expect(provider.getIssuer()).toBe("https://abcd1234.supabase.co/auth/v1");
+    expect(provider.getAuthEndpoint()).toBe(
+      "https://abcd1234.supabase.co/auth/v1/oauth/authorize"
+    );
+    expect(provider.getTokenEndpoint()).toBe(
+      "https://abcd1234.supabase.co/auth/v1/oauth/token"
+    );
+  });
+
+  it("uses supabaseUrl override when provided", () => {
+    const provider = new SupabaseOAuthProvider({
+      provider: "supabase",
+      supabaseUrl: "http://localhost:54321",
+    });
+
+    expect(provider.getIssuer()).toBe("http://localhost:54321/auth/v1");
+    expect(provider.getAuthEndpoint()).toBe(
+      "http://localhost:54321/auth/v1/oauth/authorize"
+    );
+    expect(provider.getTokenEndpoint()).toBe(
+      "http://localhost:54321/auth/v1/oauth/token"
+    );
+  });
+
+  it("prefers supabaseUrl over projectId when both are set", () => {
+    const provider = new SupabaseOAuthProvider({
+      provider: "supabase",
+      projectId: "ignored",
+      supabaseUrl: "https://supabase.internal.example.com",
+    });
+
+    expect(provider.getIssuer()).toBe(
+      "https://supabase.internal.example.com/auth/v1"
+    );
+  });
+
+  it("strips a trailing slash from supabaseUrl", () => {
+    const provider = new SupabaseOAuthProvider({
+      provider: "supabase",
+      supabaseUrl: "http://localhost:54321/",
+    });
+
+    expect(provider.getIssuer()).toBe("http://localhost:54321/auth/v1");
+  });
+
+  it("throws if neither projectId nor supabaseUrl is provided", () => {
+    expect(
+      () => new SupabaseOAuthProvider({ provider: "supabase" })
+    ).toThrowError(/requires either `supabaseUrl` or `projectId`/);
+  });
+});
+
+describe("oauthSupabaseProvider factory", () => {
+  it("accepts supabaseUrl without projectId", () => {
+    const provider = oauthSupabaseProvider({
+      supabaseUrl: "http://localhost:54321",
+    });
+
+    expect(provider.getIssuer()).toBe("http://localhost:54321/auth/v1");
+  });
+
+  it("throws when neither projectId nor supabaseUrl is configured", () => {
+    expect(() => oauthSupabaseProvider({})).toThrowError(
+      /projectId or supabaseUrl is required/
+    );
+  });
+});


### PR DESCRIPTION
## Language / Project Scope

- [x] TypeScript

## Changes

`oauthSupabaseProvider` hardcoded `https://${projectId}.supabase.co` for all auth endpoints, blocking use against a local Supabase dev server (`http://localhost:54321`) or any self-hosted deployment — even though those instances expose the same OAuth 2.1 server via `[auth.oauth_server]` in `config.toml` ([Supabase docs](https://supabase.com/docs/guides/auth/oauth-server/getting-started)).

This PR adds an optional `supabaseUrl` override (plus an `MCP_USE_OAUTH_SUPABASE_URL` env var). `projectId` is now optional when `supabaseUrl` is provided; hosted-project users are unaffected.

## Implementation Details

1. `SupabaseOAuthConfig` (`providers/types.ts`) — added optional `supabaseUrl`; `projectId` is now optional.
2. `SupabaseOAuthProvider` constructor (`providers/supabase.ts`) — prefers `supabaseUrl` (trailing slash stripped), falls back to `https://${projectId}.supabase.co`, throws if neither is set.
3. `oauthSupabaseProvider` factory (`providers.ts`) — accepts `supabaseUrl` and reads `MCP_USE_OAUTH_SUPABASE_URL`; updated JSDoc with a local-Supabase example.
4. Endpoint paths (`/auth/v1/oauth/{authorize,token}`, `/auth/v1/.well-known/jwks.json`) are unchanged — they match Supabase's local OAuth server layout.

## TypeScript Checklist

### Packages Modified

- [x] ` mcp-use` (server)

### Pre-commit Checklist

- [x] Ran `pnpm build` — succeeds
- [x] Ran `pnpm changeset` — created `supabase-oauth-url-override.md` (`minor`)
- [x] Added tests — `tests/unit/server/oauth-supabase-provider.test.ts` (7 tests, all pass)
- [ ] Updated docs (no template/docs touch the Supabase override yet; the JSDoc on the factory covers the new option)

## Example Usage (Before)

```ts
// No way to point at a local Supabase — projectId was always required and
// produced https://${projectId}.supabase.co.
oauthSupabaseProvider({ projectId: "abcd1234" });
```

For local dev users had to drop down to `oauthCustomProvider` + `jwksVerifier` with manual URL wiring.

## Example Usage (After)

```ts
// Local Supabase dev server
oauthSupabaseProvider({ supabaseUrl: "http://localhost:54321" });

// Or via env
// MCP_USE_OAUTH_SUPABASE_URL=http://localhost:54321
oauthSupabaseProvider();

// Hosted (unchanged)
oauthSupabaseProvider({ projectId: "abcd1234" });
```

## Documentation Updates

- JSDoc on `oauthSupabaseProvider` updated with the new `supabaseUrl` option, `MCP_USE_OAUTH_SUPABASE_URL` env var, and a local-Supabase example.

## Testing

New unit test file `tests/unit/server/oauth-supabase-provider.test.ts` covers:

- Hosted URL derivation from `projectId`
- `supabaseUrl` override produces correct issuer / authorize / token endpoints
- `supabaseUrl` wins over `projectId` when both are set
- Trailing slash on `supabaseUrl` is stripped
- Constructor throws when neither is provided
- Factory accepts `supabaseUrl` without `projectId`
- Factory throws when neither is configured

All 7 pass. The 3 pre-existing failures in `tests/docs/agent-quick-start.test.ts` are unrelated (require `OPENAI_API_KEY`).

## Backwards Compatibility

Fully backwards compatible. Existing `projectId` / `MCP_USE_OAUTH_SUPABASE_PROJECT_ID` usage is untouched. The only signature change is `projectId` becoming optional on `SupabaseProviderConfig` / `SupabaseOAuthConfig`, which is non-breaking for callers passing a value.

## Related Issues

Closes [mcp-use/mcp-oauth-supabase-template#2](https://github.com/mcp-use/mcp-oauth-supabase-template/issues/2)