### PR TITLE
chore(typescript): add 7-day install cooldown via pnpm minimumReleaseAge

### DIFF
--- a/libraries/typescript/pnpm-workspace.yaml
+++ b/libraries/typescript/pnpm-workspace.yaml
@@ -8,3 +8,12 @@ packages:
 onlyBuiltDependencies:
   - "@tailwindcss/oxide"
   - esbuild
+
+# Block installing npm releases newer than 3 days (value is minutes) to
+# blunt supply-chain attacks where a malicious version is yanked within
+# hours of publish. Workspace-published names are exempted.
+minimumReleaseAge: 4320
+minimumReleaseAgeExclude:
+  - mcp-use
+  - "@mcp-use/*"
+  - create-mcp-use-app


### PR DESCRIPTION
## Language / Project Scope

- [x] TypeScript
- [x] CI/CD or tooling

## Changes

Adds a 3-day minimum-release-age (a.k.a. install cooldown) to the pnpm workspace, so `pnpm install` refuses to fetch any npm version published less than 72 hours ago. This is a defensive measure against the increasingly common supply-chain attack pattern where a compromised maintainer publishes a malicious version that's typically yanked within hours of discovery — a short cooldown turns most of those attacks into non-events for our installs.

## Implementation Details

1. Sets `minimumReleaseAge: 4320` (minutes) in `libraries/typescript/pnpm-workspace.yaml`.
2. Sets `minimumReleaseAgeExclude` to our own publishable names — `mcp-use`, `@mcp-use/*` (covers `@mcp-use/inspector` and `@mcp-use/cli`), and `create-mcp-use-app` — so the cooldown never blocks workspace dependents from installing freshly-released versions of our own packages.
3. Setting placed in `pnpm-workspace.yaml`, **not** `.npmrc`: in modern pnpm only auth/registry config is read from `.npmrc`, and per [pnpm docs](https://pnpm.io/settings) all other settings (including `minimumReleaseAge`) must live in `pnpm-workspace.yaml`. Putting it in `.npmrc` would be silently ignored.

### Version requirements

- `minimumReleaseAge` was introduced in **pnpm 10.16.0**. Our `packageManager` field pins **pnpm 10.30.0**, so we're well above the floor.
- pnpm 11.0.0 changes the default to `1440` (1 day) and adds `minimumReleaseAgeStrict`; this config still works there.

## Packages Modified

- [x] (root workspace config — not a package, but affects all package installs)

## Pre-commit Checklist

- [ ] Ran `pnpm lint:fix` — not applicable, only edits `pnpm-workspace.yaml`
- [ ] Ran `pnpm format` — not applicable
- [ ] Ran `pnpm build` — not applicable, no source changes
- [ ] Ran `pnpm changeset` — not applicable, no user-facing package changes
- [x] Added or updated tests if needed — N/A for config
- [x] Updated documentation in `docs/` folder if needed — N/A

## Example Usage (Before)

```bash
$ pnpm install some-pkg@1.2.3   # installs immediately, even if 1.2.3 was published 10 minutes ago
```

## Example Usage (After)

```bash
$ pnpm install some-pkg@1.2.3
# If 1.2.3 was published <72h ago, pnpm errors and resolves to the
# latest version older than 3 days instead. Our own packages
# (mcp-use, @mcp-use/*, create-mcp-use-app) bypass the cooldown.
```

## Testing

- Verified the config key name, units (minutes), exclude key, and required file location against pnpm's official settings docs (https://pnpm.io/settings) and the v10.16.0 release notes.
- No behavioral code change — this is a pnpm-level install policy.

## Backwards Compatibility

Backward compatible at the API level. The only user-visible effect: if a contributor adds a brand-new dependency version that was published less than 3 days ago, `pnpm install` will refuse it and either resolve an older version or error. The workaround is to either pin to an older version, wait the cooldown out, or add the package to `minimumReleaseAgeExclude` if there's a critical reason it needs to ship immediately.

Anyone on pnpm <10.16.0 will ignore the setting silently — but our `packageManager` field pins 10.30.0, so this only matters for off-spec environments.

## Related Issues

* Closes MCP-2186