### PR TITLE
fix: clarify inspector production startup message

### DIFF
--- a/docs/typescript/server/cli-reference.mdx
+++ b/docs/typescript/server/cli-reference.mdx
@@ -234,6 +234,12 @@ mcp-use start --mcp-dir src/mcp
   `.js` files.
 </Note>
 
+<Note>
+  The inspector is only available in production when it was included at build
+  time. Rebuild with `mcp-use build --with-inspector` before running
+  `mcp-use start`.
+</Note>
+
 <Tip>
   `--tunnel` creates a public URL via Manufact Cloud  -  ideal for testing with ChatGPT, Claude, or any remote MCP client before you deploy. The subdomain persists across restarts (stored in `dist/mcp-use.json`). See the [Tunneling guide](/tunneling/index) for rate limits, expiry, and the standalone `npx @mcp-use/tunnel` command.
 </Tip>

--- a/libraries/typescript/packages/mcp-use/src/server/inspector/mount.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/inspector/mount.ts
@@ -43,7 +43,7 @@ export async function mountInspectorUI(
     const manifest = await readBuildManifest();
     if (!manifest?.includeInspector) {
       console.log(
-        "[INSPECTOR] Skipped in production (use --with-inspector flag during build)"
+        "[INSPECTOR] Skipped in production. To enable, rebuild with: mcp-use build --with-inspector"
       );
       return false;
     }


### PR DESCRIPTION
## Summary

- Reword the production inspector skip log so it points users to `mcp-use build --with-inspector` instead of suggesting a start-time flag.
- Add a `start` CLI reference note explaining that the inspector must be included during the production build.

Fixes #1495.

## Verification

- `git diff --check`

I also attempted `pnpm install --frozen-lockfile` under `libraries/typescript`, but the npm registry downloads stalled repeatedly on this machine before completing. No generated dependency files are included in this PR.
