### PR TITLE
chore: use cross-platform clean commands

### DIFF
--- a/libraries/typescript/.changeset/cross-platform-clean-scripts.md
+++ b/libraries/typescript/.changeset/cross-platform-clean-scripts.md
@@ -1,0 +1,4 @@
+---
+---
+
+chore: replace `rm -rf` with `rimraf` in workspace cleanup scripts so they run on Windows PowerShell. No user-facing or runtime changes.

--- a/libraries/typescript/package.json
+++ b/libraries/typescript/package.json
@@ -36,10 +36,10 @@
     "release": "pnpm build && changeset publish",
     "version:check": "changeset status",
     "test_app": "pnpm test_app:starter",
-    "test_app:starter": "rm -rf test_app && pnpm build && node packages/create-mcp-use-app/dist/index.js test_app --dev --template starter && cd test_app && pnpm install && pnpm dev",
-    "test_app:mcp-apps": "rm -rf test_app && pnpm build && node packages/create-mcp-use-app/dist/index.js test_app --dev --template mcp-apps && cd test_app && pnpm install && pnpm dev",
-    "test_app:mcp-ui": "rm -rf test_app && pnpm build && node packages/create-mcp-use-app/dist/index.js test_app --dev --template mcp-ui && cd test_app && pnpm install && pnpm dev",
-    "test_app:blank": "rm -rf test_app && pnpm build && node packages/create-mcp-use-app/dist/index.js test_app --dev --template blank && cd test_app && pnpm install && pnpm dev"
+    "test_app:starter": "rimraf test_app && pnpm build && node packages/create-mcp-use-app/dist/index.js test_app --dev --template starter && cd test_app && pnpm install && pnpm dev",
+    "test_app:mcp-apps": "rimraf test_app && pnpm build && node packages/create-mcp-use-app/dist/index.js test_app --dev --template mcp-apps && cd test_app && pnpm install && pnpm dev",
+    "test_app:mcp-ui": "rimraf test_app && pnpm build && node packages/create-mcp-use-app/dist/index.js test_app --dev --template mcp-ui && cd test_app && pnpm install && pnpm dev",
+    "test_app:blank": "rimraf test_app && pnpm build && node packages/create-mcp-use-app/dist/index.js test_app --dev --template blank && cd test_app && pnpm install && pnpm dev"
   },
   "devDependencies": {
     "@changesets/cli": "^2.30.0",
@@ -55,6 +55,7 @@
     "husky": "^9.1.7",
     "knip": "^5.88.1",
     "prettier": "^3.8.2",
+    "rimraf": "^6.1.3",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3"
   },

--- a/libraries/typescript/packages/create-mcp-use-app/package.json
+++ b/libraries/typescript/packages/create-mcp-use-app/package.json
@@ -30,7 +30,7 @@
   },
   "scripts": {
     "build": "npm run clean && tsup src/index.tsx --format esm && tsc --emitDeclarationOnly --declaration && npm run copy-templates",
-    "clean": "rm -rf dist tsconfig.tsbuildinfo",
+    "clean": "rimraf dist tsconfig.tsbuildinfo",
     "copy-templates": "node scripts/copy-templates.js",
     "dev": "tsc --build --watch",
     "test": "vitest --run --passWithNoTests",

--- a/libraries/typescript/packages/create-mcp-use-app/src/__tests__/dot-directory.test.ts
+++ b/libraries/typescript/packages/create-mcp-use-app/src/__tests__/dot-directory.test.ts
@@ -7,7 +7,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import {
   deriveProjectInfo,
   findUnsafeEntries,
@@ -145,7 +145,7 @@ describe("deriveProjectInfo", () => {
   it("treats a normal name as a subdirectory", () => {
     const info = deriveProjectInfo("my-app", "/tmp");
     expect(info.useCurrentDir).toBe(false);
-    expect(info.projectPath).toBe("/tmp/my-app");
+    expect(info.projectPath).toBe(resolve("/tmp", "my-app"));
     expect(info.displayName).toBe("my-app");
     expect(info.packageName).toBe("my-app");
   });

--- a/libraries/typescript/packages/inspector/package.json
+++ b/libraries/typescript/packages/inspector/package.json
@@ -40,7 +40,7 @@
   ],
   "scripts": {
     "dev": "concurrently \"npm run dev:client\" \"npm run dev:server\"",
-    "dev:client": "rm -rf node_modules/.vite && vite --port 3000",
+    "dev:client": "rimraf node_modules/.vite && vite --port 3000",
     "dev:server": "VITE_DEV=true tsx watch src/server/server.ts",
     "dev:standalone": "tsx watch src/server/server.ts",
     "build": "npm run build:client && npm run build:client-exports && npm run build:server && npm run build:cli && npm run build:cdn",

--- a/libraries/typescript/packages/mcp-use/package.json
+++ b/libraries/typescript/packages/mcp-use/package.json
@@ -106,7 +106,7 @@
   },
   "scripts": {
     "generate:version": "node scripts/generate-version.mjs",
-    "build": "npm run generate:version && rm -rf dist && tsup && tsc --emitDeclarationOnly --declaration",
+    "build": "npm run generate:version && rimraf dist && tsup && tsc --emitDeclarationOnly --declaration",
     "test": "vitest",
     "test:run": "vitest run",
     "test:unit": "vitest run --exclude 'tests/integration/**'",

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       prettier:
         specifier: ^3.8.2
         version: 3.8.2
+      rimraf:
+        specifier: ^6.1.3
+        version: 6.1.3
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.9)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
@@ -6535,6 +6538,9 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
 
@@ -6924,6 +6930,11 @@ packages:
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rimraf@6.1.3:
+    resolution: {integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==}
+    engines: {node: 20 || >=22}
+    hasBin: true
 
   rolldown@1.0.0-rc.15:
     resolution: {integrity: sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==}
@@ -12434,7 +12445,7 @@ snapshots:
 
   glob@13.0.0:
     dependencies:
-      minimatch: 10.2.4
+      minimatch: 10.2.5
       minipass: 7.1.2
       path-scurry: 2.0.1
 
@@ -13964,6 +13975,8 @@ snapshots:
 
   p-try@2.2.0: {}
 
+  package-json-from-dist@1.0.1: {}
+
   package-manager-detector@0.2.11:
     dependencies:
       quansync: 0.2.11
@@ -14561,6 +14574,11 @@ snapshots:
       signal-exit: 4.1.0
 
   reusify@1.1.0: {}
+
+  rimraf@6.1.3:
+    dependencies:
+      glob: 13.0.0
+      package-json-from-dist: 1.0.1
 
   rolldown@1.0.0-rc.15:
     dependencies:


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

Check all that apply:
- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [x] CI/CD or tooling

## Changes

Replaces Unix-specific `rm -rf` cleanup commands in TypeScript workspace/package scripts with `rimraf` so the build and related scripts work from Windows PowerShell without requiring Git Bash or WSL.

## Implementation Details

1. Updated the TypeScript root `test_app:*` scripts to use `rimraf test_app` instead of `rm -rf test_app`.
2. Updated cleanup commands in `create-mcp-use-app`, `inspector`, and `mcp-use` package scripts to use `rimraf`.
3. Added `rimraf` as a TypeScript workspace dev dependency and updated `pnpm-lock.yaml`.
4. Updated an existing `deriveProjectInfo` test to compare against Node's platform-aware `resolve(...)` result so it passes on Windows and Unix-like systems.

---

## TypeScript Checklist

> Complete this section if your PR includes TypeScript changes

### Packages Modified

Check all packages that were modified:
- [ ] `docs`
- [x] `tests`
- [ ] `cli`
- [x] `create-mcp-use-app`
- [x] `mcp-use` (server)
- [x] `mcp-use` (client)
- [x] `inspector`

### Pre-commit Checklist

Ensure all of the following have been completed:
- [ ] Ran `pnpm lint:fix` to auto-fix linting issues
- [ ] Ran `pnpm format` to format code with Prettier
- [x] Ran `pnpm build` and build succeeds without errors
- [ ] Ran `pnpm changeset` to create a changeset (if this PR includes user-facing changes)
- [x] Added or updated tests if needed
- [ ] Updated documentation in `docs/` folder if needed

---

## Python Checklist

> Complete this section if your PR includes Python changes

### Pre-commit Checklist

Ensure all of the following have been completed:
- [ ] Code formatted with `ruff format`
- [ ] Linting passes with `ruff check`
- [ ] Added or updated tests if needed
- [ ] Updated documentation if needed

---

## Example Usage (Before)

```bash
cd libraries/typescript
pnpm build
# On Windows PowerShell, scripts using rm -rf could fail.
```

## Example Usage (After)

```bash
cd libraries/typescript
pnpm build
# Build completes using cross-platform cleanup commands.
```

## Documentation Updates

* No documentation files were updated.
* This PR only changes TypeScript package scripts, the lockfile, and one test expectation for cross-platform behavior.

## Testing

Describe how you tested these changes:
- Updated an existing `create-mcp-use-app` test to use platform-aware path resolution.
- Ran `pnpm build` from `libraries/typescript` successfully on Windows PowerShell.
- Ran `pnpm --filter create-mcp-use-app test` successfully.
- Attempted full `pnpm test`; it exceeded the local command timeout, so the directly affected package test was run separately and passed.

## Backwards Compatibility

These changes are backwards compatible. They preserve the same cleanup behavior while using a cross-platform command available through the workspace dependency.

## Related Issues

Closes #1522