### PR TITLE
Document Armorer Guard stdio proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,32 @@ main();
 
 [**→ Full TypeScript Agent Documentation**](./libraries/typescript/README.md#-quick-start)
 
+#### Guarding stdio MCP servers
+
+For local security checks before a stdio MCP server receives tool calls, wrap
+the server with [Armorer Guard](https://github.com/ArmorerLabs/Armorer-Guard):
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "armorer-guard",
+      "args": [
+        "mcp-proxy",
+        "--",
+        "npx",
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "/tmp"
+      ]
+    }
+  }
+}
+```
+
+The proxy inspects tool-call arguments locally for prompt injection, credential
+leakage, exfiltration risk, and dangerous actions before forwarding safe calls.
+
 </details>
 
 <details>


### PR DESCRIPTION
Adds an optional README snippet showing how mcp-use users can wrap a stdio MCP server with `armorer-guard mcp-proxy -- ...`.

This keeps the existing `mcpServers` configuration shape and gives users a local guardrail path for prompt injection, credential leakage, exfiltration risk, and dangerous tool-call checks before requests reach the underlying server.
