### PR TITLE
Add openapi-to-mcp skill

### DIFF
--- a/skills/openapi-to-mcp/LICENSE.txt
+++ b/skills/openapi-to-mcp/LICENSE.txt
@@ -1,0 +1,71 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License.
+
+Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License.
+
+Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution.
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+(a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions.
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks.
+
+This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty.
+
+Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability.
+
+In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability.
+
+While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/skills/openapi-to-mcp/SKILL.md
+++ b/skills/openapi-to-mcp/SKILL.md
@@ -1,0 +1,311 @@
+---
+name: openapi-to-mcp
+description: Build and deploy an MCP server from an OpenAPI / Swagger spec using the mcp-use TypeScript SDK. Use this skill whenever the user wants to "turn this OpenAPI spec into an MCP server", "make this API usable from Claude/ChatGPT", "wrap this Swagger doc as MCP tools", "expose this REST API to an LLM", "generate MCP tools from a spec", or pastes/attaches an `openapi.yaml`, `openapi.json`, or `swagger.json` and asks for a Claude-compatible version. Trigger even if the user doesn't say "MCP" — if they describe an existing HTTP API (REST endpoints, an internal service, a third-party API they have a key for) and want an LLM to call it, this is the right skill. Covers spec ingestion (file path, URL, or pasted), operation-to-tool mapping, auth wiring (apiKey, bearer, basic, OAuth bearer), scaffolding with `create-mcp-use-app`, tool generation with proper zod schemas, live testing in the mcp-use inspector, and deploying to Manufact / mcp-use cloud.
+---
+
+# Build an MCP server from an OpenAPI spec
+
+Turn an existing REST API — described by an OpenAPI 3.x or Swagger 2.0 document — into an MCP server. Each operation in the spec becomes one MCP tool the LLM can call. The server runs locally for testing and ships to Manufact / mcp-use cloud with one command.
+
+This skill is the end-to-end recipe: scope → ingest spec → map operations → scaffold → generate tools → wire auth → test → deploy.
+
+## Core philosophy: the spec is the contract
+
+The OpenAPI document is the source of truth. Tool names, descriptions, parameter shapes, and auth requirements all come from the spec — they should not be invented. This matters because:
+
+- **The LLM trusts descriptions.** If the spec says `summary: "Get current weather for a city"`, that's exactly what the LLM will read when deciding whether to call the tool. Hand-rolled summaries drift; spec-derived summaries stay in sync if the API changes.
+- **Zod schemas mirror OpenAPI schemas.** Every parameter — path, query, body — becomes a field in one zod object. Required/optional, enums, min/max, and descriptions all carry over. The LLM uses the schema to figure out what to ask the user for.
+- **Auth lives outside the spec.** OpenAPI declares the auth scheme but never the secret. Secrets come from env vars; the spec tells you which env vars to require.
+
+When in doubt, prefer mechanical fidelity to the spec over creativity. The LLM is doing the creative part — talking to the user — and only needs a faithful, well-typed handle on the API.
+
+## Process
+
+### 1. Scope the request (use AskUserQuestion)
+
+Before writing code, lock five things via the `AskUserQuestion` tool. All five are about the API and what to build — deployment is a separate question we ask later in step 10, when the user can actually evaluate it against a working server.
+
+- **Spec source**: a file path in the workspace, a URL (e.g., `https://api.example.com/openapi.json`), or pasted into chat. If pasted, save it to `openapi.yaml` or `openapi.json` first.
+- **Server base URL**: take it from `servers[0].url` in the spec if present; otherwise ask. Multiple `servers` entries are common (prod / staging) — confirm which one.
+- **Auth scheme**: read `components.securitySchemes`. If multiple, ask which to use. If the API needs an API key or token, ask which env var should hold it (`API_KEY`, `OPENAI_API_KEY`, etc.). Don't ask for the secret itself — never put it in the conversation or commit it.
+- **Operation filter**: large specs (Stripe, GitHub) have hundreds of endpoints. Ask whether to expose all operations, a tag (`pets`, `users`), or a hand-picked list. Default to "all" for specs under ~30 operations; ask above that. See `references/mapping-rules.md` for filtering patterns.
+- **Widgets**: ask whether any operations should render a widget in the chat (a React component shown inline next to the LLM's reply), or whether this is a pure tools-only server. The default for an OpenAPI wrapper is **tools-only** — the LLM reads JSON and talks. Pick widgets only when the user wants a richer UI for specific responses (a map for a geocoding endpoint, a chart for a metrics endpoint, a card list for a search result). **This answer drives the scaffold template in step 3**: tools-only → `--template blank`, any widgets → `--template mcp-apps` (which ships the `resources/` widget infrastructure pre-wired). If the user wants widgets on most operations, the `build-mcp-app` skill is usually a better fit than this one — flag that and confirm before proceeding.
+
+Don't skip this step. Generating 200 tools the user doesn't need pollutes the LLM's tool list and slows it down.
+
+### 2. Acquire and dereference the spec
+
+Get the spec into a single dereferenced JSON object on disk. Dereferencing inlines `$ref`s so downstream code never has to chase pointers.
+
+```bash
+# In the scaffolded project root
+npm install @apidevtools/swagger-parser
+```
+
+```ts
+// scripts/load-spec.ts (run once, manually or as a build step)
+import SwaggerParser from "@apidevtools/swagger-parser";
+import { writeFileSync } from "node:fs";
+
+const spec = await SwaggerParser.dereference("./openapi.yaml");
+writeFileSync("./openapi.dereferenced.json", JSON.stringify(spec, null, 2));
+```
+
+For URL specs, swagger-parser accepts the URL directly. For pasted YAML, write it to `openapi.yaml` first, then dereference. If the spec is Swagger 2.0, run it through `swagger2openapi` first (`npx swagger2openapi --outfile openapi.yaml swagger.yaml`).
+
+Sanity-check the dereferenced file: open it, search for `"$ref"` — there should be none. If there are, the spec has circular refs and swagger-parser keeps them as-is; treat those refs as opaque object types in zod.
+
+### 3. Scaffold with `create-mcp-use-app`
+
+Pick the template based on the widget answer from step 1:
+
+```bash
+# Tools-only (the default for an OpenAPI wrapper)
+npx create-mcp-use-app@latest <project-name> --template blank
+
+# Any widgets at all
+npx create-mcp-use-app@latest <project-name> --template mcp-apps
+```
+
+Let the scaffold install dependencies and `git init` — both are useful (`npm install` runs `mcp-use generate-types` postinstall, and a git repo is required by `npm run deploy` later). The skill installs companion coding-agent skills by default too; that's fine.
+
+Verify the template catalog with `npx create-mcp-use-app@latest --list-templates` if it's been a while — the available set is `blank`, `starter`, `mcp-apps` as of this writing. `starter` includes sample tools you'd rip out, so we don't recommend it here.
+
+After scaffolding, add the two extra deps the OpenAPI flow needs:
+
+```bash
+cd <project-name>
+npm install @apidevtools/swagger-parser dotenv
+```
+
+What you get from `blank` (`mcp-apps` is a superset with `resources/` + widget infrastructure):
+
+- `index.ts` at the root with a configured `MCPServer` instance — `name`, `title`, `version`, `description`, `baseUrl`, `favicon`, and an `icons[]` array. Commented-out examples for tools, resources, and prompts. Listens on `process.env.PORT` (default 3000).
+- `package.json` with scripts wired to the `mcp-use` CLI: `dev` (hot reload + inspector), `build`, `start`, `deploy`. `tsx`, `zod`, and `typescript` are already in dev/regular deps; don't reinstall them.
+- `tsconfig.json` pre-configured for ESM (`"type": "module"`).
+- `public/` with a favicon and an SVG icon — served as static assets.
+- A `.git` directory and an initial commit.
+
+The scaffold reserves the env var `MCP_URL` for the **MCP server's own public base URL** (used for widget asset URLs and similar). That is *not* the upstream API's base URL — name your upstream var `BASE_URL` (or `API_BASE_URL` if you want to be explicit) to avoid stepping on it.
+
+### 4. Plan project structure
+
+Keep the tree shallow and predictable. The point is that someone reading the project for the first time can find the OpenAPI client, the tool wiring, and the auth in three obvious files.
+
+```
+<project>/
+├── index.ts                         # MCPServer + server.tool() registration loop
+├── openapi.yaml                     # The original spec (committed)
+├── openapi.dereferenced.json        # Dereferenced spec (gitignored; regenerated)
+├── src/
+│   ├── client.ts                    # fetch-based HTTP client (base URL + auth + error handling)
+│   ├── auth.ts                      # Reads env vars, builds the auth header
+│   ├── operations.ts                # Loads dereferenced spec, exposes operation metadata
+│   └── schema.ts                    # OpenAPI schema → zod converter
+├── scripts/
+│   └── load-spec.ts                 # Dereference helper (step 2)
+├── .env.example                     # Document required env vars (API_KEY, BASE_URL, etc.)
+└── package.json
+```
+
+For tiny specs (<10 operations) you can inline `client.ts`, `auth.ts`, and `operations.ts` into `index.ts`. For anything bigger, split — the LLM works better when each file has one job.
+
+### 5. Map operations to tools
+
+For every operation in the spec, you produce one `server.tool({...}, handler)` call. The mapping is mechanical:
+
+| OpenAPI field | MCP tool field |
+|---|---|
+| `operationId` (preferred) or `${method}_${path}` sluggified | tool `name` (snake_case) |
+| `summary` + `description` | tool `description` |
+| `parameters` (path + query) + `requestBody.content."application/json".schema` | merged zod object → tool `schema` |
+| `responses.200.content."application/json".schema` | optional zod object → tool `outputSchema` |
+| `security` (or root-level fallback) | which auth headers the handler attaches |
+
+Read `references/mapping-rules.md` for the full rules — including how to name tools when `operationId` is missing, how to handle `oneOf` / `anyOf` / nullable types in zod, how to flatten multi-content request bodies, and how to deal with the response-shape gotchas (binary downloads, streaming, paginated lists).
+
+### 6. Generate the zod schemas
+
+OpenAPI types map to zod as follows. The full converter lives in `src/schema.ts` — see `references/code-templates.md` for the implementation. Key choices:
+
+- `type: string` with `enum` → `z.enum([...])`. Use the OpenAPI `description` as the `.describe()` arg so the LLM sees it.
+- `type: integer` / `type: number` → `z.number().int()` / `z.number()`. Carry over `minimum`, `maximum`, `multipleOf`.
+- `type: array` → `z.array(<itemType>)`. If `minItems` / `maxItems` exist, chain `.min()` / `.max()`.
+- `type: object` → `z.object({...})`. Required props are non-optional; others wrap in `.optional()`.
+- `oneOf` / `anyOf` → `z.union([...])`. `allOf` with object-only members → merge into one `z.object`.
+- `nullable: true` (OpenAPI 3.0) or `type: ["string", "null"]` (3.1) → `.nullable()`.
+
+Always call `.describe(openapi.description ?? openapi.summary ?? "")` on every field so the LLM gets human-readable hints when filling args.
+
+### 7. Build the HTTP client and auth layer
+
+`src/client.ts` exposes one function: `callOperation(operationId, args) → Promise<unknown>`. Internally it:
+
+1. Looks up the operation in the dereferenced spec.
+2. Substitutes path params into the URL template (`/users/{id}` + `{id: 42}` → `/users/42`).
+3. Appends query params as `?key=value`.
+4. Adds auth headers from `src/auth.ts`.
+5. Serializes the request body as JSON (or `application/x-www-form-urlencoded` if the spec says so).
+6. Sends the request; throws on non-2xx with the server's error body included.
+7. Returns parsed JSON (or text, for non-JSON responses).
+
+`src/auth.ts` reads from `process.env` based on the spec's `securitySchemes`. See `references/auth.md` for the four common schemes and how each becomes a header. Required env vars belong in `.env.example` — that's the contract for whoever runs the server later.
+
+### 8. Wire tools in `index.ts`
+
+The registration loop is small. Pseudocode:
+
+```ts
+import "dotenv/config";
+import { MCPServer, text } from "mcp-use/server";
+import { operations } from "./src/operations";
+import { callOperation } from "./src/client";
+import { operationToZod } from "./src/schema";
+
+// Keep the MCPServer fields the scaffold gave you (title, baseUrl, favicon, icons).
+// Just adjust `name`, `title`, and `description` to match the API you're wrapping.
+const server = new MCPServer({
+  name: "<api-name>",
+  title: "<API name>",
+  version: "1.0.0",
+  description: "MCP server wrapping the <API name> REST API",
+  baseUrl: process.env.MCP_URL || "http://localhost:3000",
+  favicon: "favicon.ico",
+  icons: [{ src: "icon.svg", mimeType: "image/svg+xml", sizes: ["512x512"] }],
+});
+
+for (const op of operations) {
+  server.tool(
+    {
+      name: op.toolName,
+      description: op.description,
+      schema: operationToZod(op),
+    },
+    async (args) => {
+      const result = await callOperation(op.operationId, args);
+      return text(typeof result === "string" ? result : JSON.stringify(result, null, 2));
+    },
+  );
+}
+
+// Streamable HTTP transport — the only supported transport for this skill.
+// MCP endpoint: POST http://localhost:<port>/mcp
+// Inspector:    http://localhost:<port>/inspector
+const PORT = process.env.PORT ? Number(process.env.PORT) : 3000;
+server.listen(PORT);
+```
+
+**Transport must be streamable HTTP, not stdio.** mcp-use's `server.listen(port)` sets up the streamable-HTTP transport at `/mcp` — that's the right choice for every server this skill generates. Don't substitute stdio. Stdio servers can't be deployed to Manufact / mcp-use cloud (cloud needs an HTTP endpoint to route traffic to), can't be tested with the online inspector, can't be installed as a custom connector in ChatGPT or Claude (both connect over HTTPS), and can't be hit with the curl tests in `references/testing.md`. Stdio is for local CLI-tool MCP servers, which is not what we're building here.
+
+Full templates for each file in `references/code-templates.md`.
+
+### 9. Test the server
+
+Start the dev server first — every test in this step assumes it's running:
+
+```bash
+npm run dev
+```
+
+The log prints the port (default 3000, falls back to 3001 if taken), the MCP URL (`http://localhost:<port>/mcp`), and the inspector URL. Leave this running in one terminal; use a second terminal for the test commands below.
+
+Then test in two layers. Don't claim "done" until both pass. Full recipes in `references/testing.md`.
+
+**Layer 1 — `mcp-use client` CLI.** This is the first thing to reach for. The mcp-use package ships a CLI that talks streamable HTTP, handles session/auth bookkeeping, and gives a `tools list` / `tools call` / `interactive` loop straight from the terminal. No code, no curl arithmetic.
+
+```bash
+# Save the dev server under a short name
+npx mcp-use client connect dev http://localhost:3000/mcp
+
+# List and describe tools
+npx mcp-use client dev tools list
+npx mcp-use client dev tools describe <tool_name>
+
+# Call a tool — args are key=value, or pass JSON for complex shapes
+npx mcp-use client dev tools call <tool_name> limit=5
+npx mcp-use client dev tools call <tool_name> '{"limit": 5, "filter": "active"}'
+
+# REPL mode for fast iteration
+npx mcp-use client dev interactive
+```
+
+For CI / scripted tests, add `--json` and pipe to `jq`. If `tools list` returns nothing, your operation filter in `index.ts` killed everything or `openapi.dereferenced.json` is missing. If `connect` itself fails, the dev server isn't running or it's on a different port — drop to curl (see `references/testing.md` section "Raw protocol debugging") to confirm the endpoint is alive at all.
+
+**Layer 2 — Inspector chat (the real LLM loop).** Layer 1 proves the server works. The inspector proves the **LLM can use it** — that the tool description is descriptive enough for the model to pick the right tool, that the zod schema has enough hints to fill args correctly, that the response shape isn't so weird the model can't summarize it.
+
+```
+http://localhost:<PORT>/inspector?server=http%3A%2F%2Flocalhost%3A<PORT>%2Fmcp&tab=chat
+```
+
+Test both force-invocation ("Use `list_pets` with limit 5.") and free-form discovery ("Show me the first 5 pets in the store.") — the second is harder and the one that catches description quality.
+
+Test the failure paths in both layers: missing required arg (zod rejection), wrong auth (upstream 401), upstream 5xx (point `BASE_URL` at a dead port). Both layers should degrade with a clean error, not a server crash.
+
+If you see "Failed to resolve import" or stale tool definitions in either layer: `rm -rf .mcp-use && npm run dev`.
+
+### 10. Deploy (ask the user)
+
+The server works locally. Now ask, via `AskUserQuestion`, whether to deploy it to mcp-use cloud or keep it local. Two options only — no need to enumerate alternatives:
+
+- **Deploy to mcp-use cloud** — publishes the server at a `https://<name>.run.mcp-use.com/mcp` URL usable from ChatGPT, Claude, and any MCP client. Best when the server will be used by anyone other than the developer's own dev machine.
+- **Keep local** — hand back the dev-server URL and stop. Best for prototyping against an internal API, or when the user wants to evaluate the output before committing to a public URL.
+
+If the user picks **keep local**, you're done — give them the inspector and `/mcp` URLs from step 9 and skip the rest of this step. Don't push deploy; premature deploys leak credentials and create stale public endpoints.
+
+If the user picks **deploy**, the `blank` scaffold already wires `npm run deploy` to `mcp-use deploy`. Two commands once they're logged in:
+
+```bash
+npx mcp-use login
+npm run deploy
+```
+
+This currently requires a GitHub repo. If the project isn't on GitHub yet:
+
+```bash
+gh repo create <org>/<name> --private --source=. --push
+```
+
+After deploy you get a URL like `https://<name>.run.mcp-use.com/mcp`. Set the same env vars in the Manufact dashboard (the deploy CLI prints the link to the project page) so the production server has the same auth as your local one.
+
+Full deploy walkthrough — including how to wire env vars in the dashboard, how to view logs, and how to set up branch deploys — is in `references/deploy.md`.
+
+### 11. Ship checklist
+
+Before declaring done:
+
+- `.env.example` lists every required env var with a short comment.
+- `openapi.dereferenced.json` is in `.gitignore` (regenerate from `openapi.yaml`).
+- `npm run build` passes; `npx tsc --noEmit` is clean.
+- The inspector ran every tool you care about against the live API at least once.
+- The deployed URL responds to `curl https://<name>.run.mcp-use.com/mcp` with a valid MCP response.
+- Commit and push.
+
+## Critical reference material
+
+Read these when the relevant step lands. Each file is a focused deep-dive — don't load them all upfront.
+
+- `references/mapping-rules.md` — Operation-to-tool mapping rules: naming, parameter merging, response handling, schema edge cases (oneOf/anyOf/allOf, nullable, recursive refs), filtering large specs.
+- `references/code-templates.md` — Copy-ready skeletons for `index.ts`, `src/client.ts`, `src/auth.ts`, `src/operations.ts`, `src/schema.ts`, `scripts/load-spec.ts`, `.env.example`, and `tsconfig.json`. Each is annotated.
+- `references/auth.md` — The four common auth schemes (apiKey, http bearer, http basic, OAuth2 bearer) and how each becomes a header. Includes the OAuth-with-refresh-token pattern.
+- `references/testing.md` — Inspector recipe, the `.mcp-use` stale-cache trap, how to force-invoke a tool, what to check in tool responses, common 4xx/5xx debugging.
+- `references/deploy.md` — `mcp-use deploy`, GitHub setup, env vars in the Manufact dashboard, branch deploys, observability tabs, and how to install the deployed URL as a custom MCP connector in ChatGPT or Claude.
+
+## Trigger words and aliases
+
+Use this skill whenever the user says anything in the cluster:
+
+- "build an MCP server from this OpenAPI spec / Swagger doc"
+- "turn this API / swagger.json / openapi.yaml into MCP tools"
+- "wrap [API name] as an MCP server"
+- "make [Stripe / GitHub / our internal API] callable from Claude"
+- "expose these endpoints to an LLM"
+- "I have an OpenAPI spec, generate the MCP server"
+- Pastes or attaches a `.yaml` / `.json` spec and asks for an MCP version
+- Describes an existing REST API (with a key, base URL, or docs link) and wants LLM access
+
+## When NOT to use this skill
+
+- The user wants a **widget-driven MCP App** where most/every tool renders a custom UI in the chat → use `build-mcp-app` instead. This skill can layer a widget on one or two specific tools, but if widgets are the whole point, the other skill is the right starting frame. Confirm with the user during step 1.
+- The user has no API yet and wants to **design one** from scratch → that's an API-design task, not an MCP-wrapping task.
+- The user wants to **consume** an MCP server as a client (not build one) → different skill / not this one.
+- The spec is for a **GraphQL** or **gRPC** service, not OpenAPI → this skill is OpenAPI-specific; the patterns transfer but the schema converter doesn't.

--- a/skills/openapi-to-mcp/references/auth.md
+++ b/skills/openapi-to-mcp/references/auth.md
@@ -1,0 +1,149 @@
+# Auth schemes
+
+OpenAPI declares auth in `components.securitySchemes`; each operation references a scheme via the `security` array. Four schemes cover ~95% of real-world APIs. This file shows the spec shape, the env vars to ask for, and how the header is built.
+
+The rule of thumb: never put secrets in the conversation, never commit them, and never bake them into `index.ts`. Everything goes through `process.env` so the same code runs locally and in production.
+
+## 1. API key in a header (most common)
+
+Spec:
+
+```yaml
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+```
+
+Env var: `API_KEY` (or whatever name the user prefers; document it in `.env.example`).
+
+Header built by `src/auth.ts`:
+
+```
+X-API-Key: <value of process.env.API_KEY>
+```
+
+Notes: if `in: query` or `in: cookie`, the value goes in the URL or cookie jar instead. Query-string keys are insecure (they end up in logs); flag this to the user and ask whether they want to proceed.
+
+## 2. HTTP Bearer (Authorization: Bearer ...)
+
+Spec:
+
+```yaml
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT      # informational only — doesn't change anything
+```
+
+Env var: `BEARER_TOKEN`.
+
+Header:
+
+```
+Authorization: Bearer <value of process.env.BEARER_TOKEN>
+```
+
+This is the default for most modern APIs (GitHub PATs, OpenAI, Anthropic, etc.).
+
+## 3. HTTP Basic (Authorization: Basic base64(user:pass))
+
+Spec:
+
+```yaml
+components:
+  securitySchemes:
+    BasicAuth:
+      type: http
+      scheme: basic
+```
+
+Env vars: `BASIC_USER`, `BASIC_PASS`.
+
+Header:
+
+```
+Authorization: Basic <base64(`${BASIC_USER}:${BASIC_PASS}`)>
+```
+
+Rare in modern APIs; common in older internal services.
+
+## 4. OAuth2 — pre-issued access token
+
+Spec:
+
+```yaml
+components:
+  securitySchemes:
+    OAuth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: https://example.com/oauth/authorize
+          tokenUrl: https://example.com/oauth/token
+          scopes:
+            read: Read access
+            write: Write access
+```
+
+For the MCP server, OAuth2 effectively reduces to a bearer token: you obtain an access token out of band and put it in `OAUTH_ACCESS_TOKEN` (or `BEARER_TOKEN`).
+
+Header:
+
+```
+Authorization: Bearer <token>
+```
+
+If the API needs token refresh:
+
+- The token has a short lifetime (often 1 hour).
+- Store the refresh token in `OAUTH_REFRESH_TOKEN`.
+- Wrap `callOperation` so that on a 401 the client exchanges the refresh token at `tokenUrl`, updates the in-memory access token, and retries once.
+
+Pattern (add to `src/client.ts` only if the API needs it):
+
+```ts
+let cachedToken = process.env.OAUTH_ACCESS_TOKEN;
+let tokenExpiresAt = 0;
+
+async function getAccessToken(): Promise<string> {
+  if (cachedToken && Date.now() < tokenExpiresAt - 60_000) return cachedToken;
+  const refresh = process.env.OAUTH_REFRESH_TOKEN;
+  const tokenUrl = process.env.OAUTH_TOKEN_URL;
+  if (!refresh || !tokenUrl) throw new Error("Missing OAUTH_REFRESH_TOKEN / OAUTH_TOKEN_URL");
+
+  const res = await fetch(tokenUrl, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: refresh,
+      client_id: process.env.OAUTH_CLIENT_ID ?? "",
+      client_secret: process.env.OAUTH_CLIENT_SECRET ?? "",
+    }),
+  });
+  if (!res.ok) throw new Error(`Token refresh failed: ${res.status}`);
+  const json: any = await res.json();
+  cachedToken = json.access_token;
+  tokenExpiresAt = Date.now() + (json.expires_in ?? 3600) * 1000;
+  return cachedToken!;
+}
+```
+
+For full OAuth2 with browser-based consent (no pre-issued token), defer to a one-time CLI script that hits `authorizationUrl`, captures the code, exchanges it, and prints the access + refresh tokens. The MCP server itself should stay headless.
+
+## Multiple schemes on one operation
+
+`security: [{ApiKey: [], Bearer: []}]` means **both** must be sent (AND). `security: [{ApiKey: []}, {Bearer: []}]` means **either** (OR). For OR, prefer the scheme the user provided env vars for; fall back to the next one.
+
+If the operation has `security: []` (empty array), it's explicitly unauthenticated — skip the auth header for that call.
+
+## Logging and rotation
+
+Never log header values. In `client.ts`, the `DEBUG_HTTP=1` flag logs URL + body but redacts `Authorization` and any custom auth header. Make the redaction visible (`Authorization: Bearer [REDACTED]`) so debugging stays useful.
+
+Rotate tokens by changing `.env` and restarting the dev server. In production (Manufact / mcp-use cloud), rotate via the env-var settings in the dashboard — no redeploy needed.

--- a/skills/openapi-to-mcp/references/code-templates.md
+++ b/skills/openapi-to-mcp/references/code-templates.md
@@ -1,0 +1,538 @@
+# Code templates
+
+Copy-ready skeletons. Adapt names and paths to the actual project but keep the shape — these templates compile together and any single-file rewrite usually breaks the others.
+
+## Table of contents
+
+1. `package.json` additions
+2. `.env.example`
+3. `tsconfig.json` (if missing)
+4. `scripts/load-spec.ts`
+5. `src/operations.ts`
+6. `src/schema.ts`
+7. `src/auth.ts`
+8. `src/client.ts`
+9. `index.ts`
+
+---
+
+## 1. `package.json` additions
+
+The `blank` template ships with `mcp-use`, `react`/`react-dom`/`react-router`/`tailwindcss` (used only if you add widgets later), `zod`, `tsx`, `typescript`, and `@types/node` already installed. Scripts `dev`, `build`, `start`, and `deploy` are already wired to `mcp-use`.
+
+Add only what's missing:
+
+```jsonc
+{
+  "dependencies": {
+    "@apidevtools/swagger-parser": "^10.1.1",
+    "dotenv": "^16.4.0"
+    // mcp-use and zod are already in the scaffold
+  },
+  "scripts": {
+    // keep dev, build, start, deploy from the scaffold; just add this one:
+    "load-spec": "tsx scripts/load-spec.ts"
+  }
+}
+```
+
+Install: `npm install @apidevtools/swagger-parser dotenv`. Don't reinstall `zod` or `tsx` — they're already there and version-mismatching them against the mcp-use peer dep will produce confusing errors.
+
+## 2. `.env.example`
+
+Commit this file. Never commit `.env`. Add `.env` to `.gitignore`.
+
+```dotenv
+# Base URL of the API (from openapi.yaml `servers[0].url` — override per environment)
+BASE_URL=https://api.example.com
+
+# Auth — uncomment whichever the spec declares
+# API_KEY=replace-me
+# BEARER_TOKEN=replace-me
+# BASIC_USER=user
+# BASIC_PASS=pass
+
+# Optional: log every outgoing request (use only for debugging)
+DEBUG_HTTP=0
+```
+
+## 3. `tsconfig.json`
+
+The `@latest` scaffold already ships a working `tsconfig.json` with `moduleResolution: "bundler"`, `@types/node` available, and the right `include` paths for `index.ts` + `src/**/*`. Leave it alone — no edits needed.
+
+## 4. `scripts/load-spec.ts`
+
+Dereferences the spec once, writes the result to disk. Run manually whenever `openapi.yaml` changes.
+
+```ts
+import SwaggerParser from "@apidevtools/swagger-parser";
+import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const input = process.argv[2] ?? "openapi.yaml";
+const output = process.argv[3] ?? "openapi.dereferenced.json";
+
+const spec = await SwaggerParser.dereference(resolve(input));
+writeFileSync(resolve(output), JSON.stringify(spec, null, 2));
+console.log(`Dereferenced ${input} → ${output}`);
+```
+
+Run: `npm run load-spec` (or `tsx scripts/load-spec.ts <input> <output>` for non-defaults).
+
+## 5. `src/operations.ts`
+
+Loads the dereferenced spec and produces a clean, normalized list of operations. Downstream code never touches raw OpenAPI again.
+
+```ts
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+type OperationMeta = {
+  operationId: string;       // normalized snake_case
+  toolName: string;          // = operationId (or fallback)
+  description: string;
+  method: "get" | "post" | "put" | "patch" | "delete" | "head" | "options";
+  path: string;              // raw OpenAPI path with {placeholders}
+  parameters: any[];         // OpenAPI parameter objects
+  requestBody?: any;
+  responses: Record<string, any>;
+  security?: any[];
+  tags?: string[];
+  deprecated?: boolean;
+};
+
+const SPEC_PATH = resolve("openapi.dereferenced.json");
+const spec = JSON.parse(readFileSync(SPEC_PATH, "utf8"));
+
+const METHODS = ["get", "post", "put", "patch", "delete", "head", "options"] as const;
+
+function toSnakeCase(s: string): string {
+  return s
+    .replace(/[^a-zA-Z0-9]+/g, "_")
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .toLowerCase()
+    .replace(/^_+|_+$/g, "")
+    .replace(/_+/g, "_");
+}
+
+function deriveOperationId(method: string, path: string): string {
+  return toSnakeCase(`${method}_${path}`);
+}
+
+function buildOperations(): OperationMeta[] {
+  const ops: OperationMeta[] = [];
+  const seen = new Set<string>();
+
+  for (const [path, pathItem] of Object.entries(spec.paths ?? {})) {
+    if (!pathItem || typeof pathItem !== "object") continue;
+
+    for (const method of METHODS) {
+      const op = (pathItem as any)[method];
+      if (!op) continue;
+
+      const rawId = op.operationId ?? deriveOperationId(method, path);
+      let toolName = toSnakeCase(rawId);
+      if (seen.has(toolName)) {
+        toolName = `${toolName}_${method}`;
+        console.warn(`[ops] Name collision; renamed to ${toolName}`);
+      }
+      seen.add(toolName);
+
+      const summary = op.summary?.trim() ?? "";
+      const description = op.description?.trim() ?? "";
+      const tags = op.tags ?? [];
+      const tagLine = tags.length ? `[Tags: ${tags.join(", ")}]` : "";
+      const desc =
+        [summary, description, tagLine].filter(Boolean).join("\n\n") ||
+        `${method.toUpperCase()} ${path}`;
+
+      ops.push({
+        operationId: rawId,
+        toolName,
+        description: desc,
+        method,
+        path,
+        parameters: op.parameters ?? [],
+        requestBody: op.requestBody,
+        responses: op.responses ?? {},
+        security: op.security ?? spec.security,
+        tags,
+        deprecated: op.deprecated === true,
+      });
+    }
+  }
+
+  return ops;
+}
+
+export const operations: OperationMeta[] = buildOperations();
+export type { OperationMeta };
+```
+
+## 6. `src/schema.ts`
+
+OpenAPI schema → zod converter. Recursive. Handles the cases from `references/mapping-rules.md`.
+
+```ts
+import { z, ZodTypeAny } from "zod";
+import type { OperationMeta } from "./operations";
+
+export function schemaToZod(schema: any): ZodTypeAny {
+  if (!schema || typeof schema !== "object") return z.unknown();
+
+  // Combinators
+  if (Array.isArray(schema.oneOf)) {
+    return z.union(schema.oneOf.map(schemaToZod) as any);
+  }
+  if (Array.isArray(schema.anyOf)) {
+    return z.union(schema.anyOf.map(schemaToZod) as any);
+  }
+  if (Array.isArray(schema.allOf)) {
+    // Merge object-only allOf
+    const merged = schema.allOf.reduce((acc: any, sub: any) => {
+      if (sub.type === "object" || sub.properties) {
+        return {
+          ...acc,
+          type: "object",
+          properties: { ...(acc.properties ?? {}), ...(sub.properties ?? {}) },
+          required: [...(acc.required ?? []), ...(sub.required ?? [])],
+        };
+      }
+      return acc;
+    }, {} as any);
+    return schemaToZod(merged);
+  }
+
+  // Type-based dispatch
+  const type = Array.isArray(schema.type)
+    ? schema.type.find((t: string) => t !== "null")
+    : schema.type;
+  const nullable = schema.nullable || (Array.isArray(schema.type) && schema.type.includes("null"));
+
+  let base: ZodTypeAny;
+  switch (type) {
+    case "string":
+      base = stringSchema(schema);
+      break;
+    case "integer":
+      base = numberSchema(schema, true);
+      break;
+    case "number":
+      base = numberSchema(schema, false);
+      break;
+    case "boolean":
+      base = z.boolean();
+      break;
+    case "array":
+      base = arraySchema(schema);
+      break;
+    case "object":
+      base = objectSchema(schema);
+      break;
+    default:
+      base = schema.properties ? objectSchema(schema) : z.unknown();
+  }
+
+  if (nullable) base = base.nullable();
+  if (schema.default !== undefined) base = base.default(schema.default);
+  const desc = schema.description ?? schema.title;
+  if (desc) base = base.describe(desc);
+
+  return base;
+}
+
+function stringSchema(s: any): ZodTypeAny {
+  if (Array.isArray(s.enum) && s.enum.length) return z.enum(s.enum as [string, ...string[]]);
+  let v = z.string();
+  // zod v4: datetime() type signature differs from v3; cast to keep the assign loop happy
+  if (s.format === "date-time") v = (v as any).datetime() as typeof v;
+  if (s.format === "email") v = v.email();
+  if (s.format === "uri" || s.format === "url") v = v.url();
+  if (s.format === "uuid") v = v.uuid();
+  if (typeof s.minLength === "number") v = v.min(s.minLength);
+  if (typeof s.maxLength === "number") v = v.max(s.maxLength);
+  if (s.pattern) v = v.regex(new RegExp(s.pattern));
+  return v;
+}
+
+function numberSchema(s: any, isInt: boolean): ZodTypeAny {
+  let v = isInt ? z.number().int() : z.number();
+  if (typeof s.minimum === "number") v = v.gte(s.minimum);
+  if (typeof s.maximum === "number") v = v.lte(s.maximum);
+  if (typeof s.multipleOf === "number") v = v.multipleOf(s.multipleOf);
+  return v;
+}
+
+function arraySchema(s: any): ZodTypeAny {
+  let v = z.array(schemaToZod(s.items ?? {}));
+  if (typeof s.minItems === "number") v = v.min(s.minItems);
+  if (typeof s.maxItems === "number") v = v.max(s.maxItems);
+  return v;
+}
+
+function objectSchema(s: any): ZodTypeAny {
+  const props = s.properties ?? {};
+  const required = new Set<string>(s.required ?? []);
+  const shape: Record<string, ZodTypeAny> = {};
+  for (const [key, sub] of Object.entries(props)) {
+    let v = schemaToZod(sub);
+    if (!required.has(key)) v = v.optional();
+    shape[key] = v;
+  }
+  let obj: ZodTypeAny = z.object(shape);
+  if (s.additionalProperties && typeof s.additionalProperties === "object") {
+    // zod v4: record requires explicit key type
+    obj = z.record(z.string(), schemaToZod(s.additionalProperties));
+  }
+  return obj;
+}
+
+// Merge path + query + body into one flat zod object for the tool schema.
+export function operationToZod(op: OperationMeta): ZodTypeAny {
+  const shape: Record<string, ZodTypeAny> = {};
+
+  for (const p of op.parameters) {
+    if (p.in === "cookie") continue;
+    const key = p.in === "header" ? `header_${toSnake(p.name)}` : p.name;
+    let v = schemaToZod(p.schema ?? {});
+    if (p.description) v = v.describe(p.description);
+    if (!p.required) v = v.optional();
+    shape[key] = v;
+  }
+
+  const json = op.requestBody?.content?.["application/json"]?.schema;
+  if (json) {
+    if (json.type === "object" && json.properties) {
+      const required = new Set<string>(json.required ?? []);
+      for (const [key, sub] of Object.entries(json.properties)) {
+        const fieldKey = key in shape ? `body_${key}` : key;
+        let v = schemaToZod(sub);
+        if (!required.has(key)) v = v.optional();
+        shape[fieldKey] = v;
+      }
+    } else {
+      shape["body"] = schemaToZod(json);
+    }
+  }
+
+  return z.object(shape);
+}
+
+function toSnake(s: string): string {
+  return s.replace(/[^a-zA-Z0-9]+/g, "_").toLowerCase();
+}
+```
+
+## 7. `src/auth.ts`
+
+Reads the spec's `securitySchemes`, builds a header map. See `references/auth.md` for scheme-by-scheme detail.
+
+```ts
+import { readFileSync } from "node:fs";
+
+const spec = JSON.parse(readFileSync("openapi.dereferenced.json", "utf8"));
+
+type AuthHeaders = Record<string, string>;
+
+export function buildAuthHeaders(): AuthHeaders {
+  const headers: AuthHeaders = {};
+  const schemes = spec.components?.securitySchemes ?? {};
+
+  for (const [name, scheme] of Object.entries<any>(schemes)) {
+    if (scheme.type === "apiKey" && scheme.in === "header") {
+      const value = process.env[envVarFor(name)];
+      if (value) headers[scheme.name] = value;
+    } else if (scheme.type === "http" && scheme.scheme === "bearer") {
+      const token = process.env.BEARER_TOKEN ?? process.env[envVarFor(name)];
+      if (token) headers["Authorization"] = `Bearer ${token}`;
+    } else if (scheme.type === "http" && scheme.scheme === "basic") {
+      const user = process.env.BASIC_USER;
+      const pass = process.env.BASIC_PASS;
+      if (user && pass) headers["Authorization"] = `Basic ${Buffer.from(`${user}:${pass}`).toString("base64")}`;
+    } else if (scheme.type === "oauth2") {
+      // OAuth2 access tokens come in as bearer
+      const token = process.env.BEARER_TOKEN ?? process.env.OAUTH_ACCESS_TOKEN;
+      if (token) headers["Authorization"] = `Bearer ${token}`;
+    }
+  }
+  return headers;
+}
+
+// `securitySchemes.MyKey` → process.env.MY_KEY (used when the user-friendly name in .env follows the scheme name)
+function envVarFor(schemeName: string): string {
+  return schemeName.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toUpperCase();
+}
+```
+
+## 8. `src/client.ts`
+
+```ts
+import { operations, OperationMeta } from "./operations";
+import { buildAuthHeaders } from "./auth";
+
+const BASE_URL = process.env.BASE_URL ?? defaultBaseUrl();
+const DEBUG = process.env.DEBUG_HTTP === "1";
+
+function defaultBaseUrl(): string {
+  const spec = JSON.parse(require("node:fs").readFileSync("openapi.dereferenced.json", "utf8"));
+  return spec.servers?.[0]?.url ?? "http://localhost";
+}
+
+export async function callOperation(
+  operationId: string,
+  args: Record<string, unknown>,
+): Promise<unknown> {
+  const op = operations.find((o) => o.operationId === operationId || o.toolName === operationId);
+  if (!op) throw new Error(`Unknown operation: ${operationId}`);
+
+  // Substitute path params
+  let path = op.path;
+  const usedKeys = new Set<string>();
+  for (const p of op.parameters) {
+    if (p.in === "path") {
+      const value = args[p.name];
+      if (value === undefined) throw new Error(`Missing path param: ${p.name}`);
+      path = path.replace(`{${p.name}}`, encodeURIComponent(String(value)));
+      usedKeys.add(p.name);
+    }
+  }
+
+  // Build URL with query params
+  const url = new URL(joinUrl(BASE_URL, path));
+  for (const p of op.parameters) {
+    if (p.in === "query") {
+      const value = args[p.name];
+      if (value !== undefined && value !== null) {
+        url.searchParams.set(p.name, String(value));
+        usedKeys.add(p.name);
+      }
+    }
+  }
+
+  // Build headers
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    accept: "application/json",
+    ...buildAuthHeaders(),
+  };
+  for (const p of op.parameters) {
+    if (p.in === "header") {
+      const key = `header_${p.name.replace(/[^a-zA-Z0-9]+/g, "_").toLowerCase()}`;
+      const value = args[key];
+      if (value !== undefined) {
+        headers[p.name] = String(value);
+        usedKeys.add(key);
+      }
+    }
+  }
+
+  // Build body (everything not used as path/query/header)
+  let body: string | undefined;
+  if (op.requestBody) {
+    const json = op.requestBody.content?.["application/json"]?.schema;
+    if (json) {
+      const bodyObj: Record<string, unknown> = {};
+      if (json.type === "object" && json.properties) {
+        for (const key of Object.keys(json.properties)) {
+          if (!usedKeys.has(key) && args[key] !== undefined) {
+            bodyObj[key] = args[key];
+          }
+        }
+        body = JSON.stringify(bodyObj);
+      } else if (args["body"] !== undefined) {
+        body = JSON.stringify(args["body"]);
+      }
+    }
+  }
+
+  if (DEBUG) console.log(`→ ${op.method.toUpperCase()} ${url.toString()}`, headers, body);
+
+  const res = await fetch(url, {
+    method: op.method.toUpperCase(),
+    headers,
+    body,
+  });
+
+  const contentType = res.headers.get("content-type") ?? "";
+  const text = await res.text();
+
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status} ${res.statusText} — ${text.slice(0, 500)}`);
+  }
+
+  if (contentType.includes("application/json")) {
+    try {
+      return JSON.parse(text);
+    } catch {
+      return text;
+    }
+  }
+  return text;
+}
+
+function joinUrl(base: string, path: string): string {
+  return base.replace(/\/$/, "") + (path.startsWith("/") ? path : `/${path}`);
+}
+```
+
+## 9. `index.ts`
+
+Replace the scaffolded `index.ts` with this — preserving the MCPServer fields the scaffold gave you (title, baseUrl, favicon, icons) and adding the OpenAPI tool registration loop in place of the commented examples.
+
+```ts
+import "dotenv/config";              // load .env into process.env
+import { MCPServer, text } from "mcp-use/server";
+import { operations } from "./src/operations";
+import { callOperation } from "./src/client";
+import { operationToZod } from "./src/schema";
+
+const server = new MCPServer({
+  name: "openapi-mcp",                // replace with the API's name (lowercase, hyphenated)
+  title: "OpenAPI MCP",
+  version: "1.0.0",
+  description: "MCP server wrapping the <API name> REST API",
+  baseUrl: process.env.MCP_URL || "http://localhost:3000",
+  favicon: "favicon.ico",
+  icons: [{ src: "icon.svg", mimeType: "image/svg+xml", sizes: ["512x512"] }],
+});
+
+for (const op of operations) {
+  // Optional filter — uncomment to limit which operations become tools
+  // if (!["pets", "users"].some((t) => op.tags?.includes(t))) continue;
+  // if (op.deprecated) continue;
+
+  server.tool(
+    {
+      name: op.toolName,
+      description: op.description,
+      schema: operationToZod(op),
+    },
+    async (args: any) => {
+      try {
+        const result = await callOperation(op.operationId, args);
+        return text(typeof result === "string" ? result : JSON.stringify(result, null, 2));
+      } catch (e: any) {
+        return text(`Error calling ${op.toolName}: ${e.message}`);
+      }
+    },
+  );
+}
+
+// Transport: streamable HTTP at /mcp. Do NOT swap for stdio — see SKILL.md step 8.
+const port = process.env.PORT ? Number(process.env.PORT) : 3000;
+server.listen(port);
+console.log(`MCP:       http://localhost:${port}/mcp`);
+console.log(`Inspector: http://localhost:${port}/inspector`);
+```
+
+Two practical notes:
+
+- The scaffold uses `process.env.MCP_URL` for the **MCP server's own public base URL** (asset serving, widget resolution). That's distinct from your upstream API base URL (`BASE_URL`). Don't conflate them.
+- `import "dotenv/config"` requires `npm install dotenv` (covered in section 1). If you'd rather avoid the dep, the scaffold's `npm run dev` runs through `mcp-use dev`, which loads `.env` automatically — `dotenv` is only strictly needed if you run the helper script `scripts/load-spec.ts` directly with `tsx`, since it doesn't go through the `mcp-use` CLI.
+
+---
+
+That's the whole server. Everything beyond this is iteration on:
+- which operations to expose (filter at the loop),
+- which env vars to require (edit `.env.example` + `src/auth.ts`),
+- how to handle non-JSON content types (extend `src/client.ts`).

--- a/skills/openapi-to-mcp/references/deploy.md
+++ b/skills/openapi-to-mcp/references/deploy.md
@@ -1,0 +1,83 @@
+# Deploy to Manufact / mcp-use cloud
+
+Once the inspector flow is solid, you need a public HTTPS URL so ChatGPT, Claude, or any other MCP host can reach the server. `mcp-use` ships with a deploy CLI that handles the build, container, and DNS in one command.
+
+## Prerequisites
+
+- GitHub repo. The current deploy flow needs a repo it can pull from. If the project isn't on GitHub yet:
+  ```bash
+  gh repo create <org>/<name> --private --source=. --push
+  ```
+- A Manufact / mcp-use account. The login command will prompt to create one if you don't have it.
+- Secrets in your local `.env` so you can transcribe them to the dashboard later. **Don't push `.env`** — confirm it's in `.gitignore`.
+
+## Deploy
+
+The `blank` scaffold wires `npm run deploy` to the bundled `mcp-use deploy` CLI. Two commands:
+
+```bash
+npx mcp-use login    # one-time, or: npx @mcp-use/cli login on older scaffolds
+npm run deploy       # wraps `mcp-use deploy`
+```
+
+`deploy` will:
+
+1. Push the latest commit to the configured branch (defaults to `main`).
+2. Build the project on Manufact's side.
+3. Spin up a container and route a subdomain to it.
+4. Print the live URL — typically `https://<name>.run.mcp-use.com/mcp`.
+
+If the build fails, the CLI prints the log URL. Most failures are missing env vars (no auth headers → 401 from upstream → tool errors → tests fail). The fix is in the next section.
+
+## Set production env vars
+
+The deployed container starts with no env vars. Open the project page in the Manufact dashboard (the deploy CLI prints the link) and set:
+
+- `BASE_URL` — same as local, or a production-specific override.
+- Whatever auth vars you used locally — `API_KEY`, `BEARER_TOKEN`, etc. Use **production** credentials, not your dev key.
+- `PORT` — usually not needed; Manufact sets it automatically.
+
+Restart the deployment after setting vars (the dashboard has a "Restart" button) or push a no-op commit.
+
+Verify the deployed server is up:
+
+```bash
+curl https://<name>.run.mcp-use.com/mcp
+```
+
+A valid response is a JSON-RPC error like `{"jsonrpc":"2.0","error":{"code":-32600,"message":"..."}}` — that means the server is up and speaking MCP, it just didn't get a real request. A connection refusal or 502 means the container isn't running.
+
+## Branch deploys
+
+For experimenting without breaking the main URL, push to a non-main branch and run `npx @mcp-use/cli deploy --branch <branch>`. Each branch gets its own subdomain. Useful for testing changes against the live API before merging.
+
+## Observability
+
+The Manufact dashboard surfaces:
+
+- **Logs** — every tool call, stdout, stderr.
+- **Metrics** — request count, latency, error rate per tool.
+- **Traces** — per-request span trees if you instrument with OpenTelemetry (out of scope for the first version).
+
+Tail logs while you test the deployed server. If a tool call fails in production but worked locally, 9 times out of 10 it's a missing or stale env var.
+
+## Install in ChatGPT (as a custom MCP connector)
+
+1. `chatgpt.com` → **Settings** → **Apps** → **Advanced**.
+2. Enable Developer mode if not already on.
+3. **Create app** → fill Name, Description, and **MCP Server URL** (the `https://...run.mcp-use.com/mcp` URL from the deploy).
+4. **Authentication**: if the MCP server is public (no MCP-level auth — the upstream API auth happens server-side via env vars), pick **No Auth**. The default OAuth option will fail with "MCP server does not implement OAuth" because your server is using env-var auth, not MCP OAuth.
+5. Tick the consent checkbox, create the app.
+6. Open a new chat: "Use the <app-name> app to call list_pets." If ChatGPT doesn't pick the app up automatically, click the **+** menu next to the input and select it explicitly.
+
+Verify: the tool chip shows the call, the args, and a green check. The LLM summarizes the result. If you see CSP errors, this server has no widgets so CSP shouldn't matter — but if you do see them, check that Developer mode's "Enforce CSP" toggle matches your spec.
+
+## Install in Claude
+
+`claude.ai` → **Settings** → **Connectors** → **Add custom connector**. Same URL, same "No Auth" choice. Claude doesn't have the developer-mode toggle; the connector is immediately usable in any chat after you turn it on.
+
+## Iteration after deploy
+
+For most edits, push to `main` and `mcp-use` redeploys automatically (if you connected the repo via the dashboard's GitHub integration). If you deployed via the CLI without the integration, re-run `npm run deploy` after each commit.
+
+Cache busting: if a tool definition changed and the inspector / ChatGPT shows the old one, fully reload the client. ChatGPT keeps tool schemas cached for a few minutes after a connector update.

--- a/skills/openapi-to-mcp/references/deploy.md
+++ b/skills/openapi-to-mcp/references/deploy.md
@@ -20,6 +20,14 @@ npx mcp-use login    # one-time, or: npx @mcp-use/cli login on older scaffolds
 npm run deploy       # wraps `mcp-use deploy`
 ```
 
+> **Important:** `openapi.dereferenced.json` is generated locally and should be in `.gitignore`. The cloud build won't have it unless you generate it as part of the build. Before deploying, update the `build` script in `package.json` to run the spec deref step first:
+>
+> ```json
+> "build": "tsx scripts/load-spec.ts && mcp-use build"
+> ```
+>
+> This ensures the dereferenced file is always regenerated at build time on Manufact's side, even if it's not committed to the repo.
+
 `deploy` will:
 
 1. Push the latest commit to the configured branch (defaults to `main`).

--- a/skills/openapi-to-mcp/references/mapping-rules.md
+++ b/skills/openapi-to-mcp/references/mapping-rules.md
@@ -1,0 +1,134 @@
+# OpenAPI → MCP tool mapping rules
+
+This file is the contract for how an OpenAPI document becomes a set of MCP tools. Follow it mechanically. The point is determinism: two runs of the skill against the same spec should produce the same tool list, the same names, and the same schemas.
+
+## Table of contents
+
+1. Tool naming
+2. Tool description
+3. Parameter merging (path, query, header, body)
+4. Zod schema conversion
+5. Response handling
+6. Filtering large specs
+7. Multi-content request bodies
+8. Edge cases: recursion, polymorphism, files, streams
+
+---
+
+## 1. Tool naming
+
+Order of preference:
+
+1. **`operationId` if present.** Normalize to snake_case. `getPetById` → `get_pet_by_id`. `listUsers` → `list_users`. Drop characters that aren't `[a-z0-9_]`.
+2. **`${method}_${path}` fallback.** Lowercase the method; replace `/`, `{`, `}` with `_`, collapse repeated `_`, trim. `GET /pets/{petId}/owners` → `get_pets_pet_id_owners`.
+3. **Collision resolution.** If two operations map to the same name (rare but possible with the fallback), append the method as a suffix to the second: `get_users`, `get_users_post`. Always log the rename so the user notices.
+
+Tool names are user-visible in the LLM's tool catalog. Keep them under 60 characters and avoid double underscores.
+
+## 2. Tool description
+
+Build the description from the operation in this order:
+
+```
+{summary}
+
+{description}
+
+[Tags: {tags joined}]
+```
+
+Skip any section that's empty. Trim trailing whitespace. If both `summary` and `description` are missing — which is common in hand-written specs — fall back to `${method.toUpperCase()} ${path}` so the LLM at least sees the route. Log a warning so the user can improve the spec.
+
+Don't paraphrase the description. The LLM reads what you write here; if the spec says "Returns up to 100 pets in the store, paginated", say exactly that.
+
+## 3. Parameter merging
+
+OpenAPI splits parameters across several locations. The MCP tool schema is a single flat zod object. Merge as follows:
+
+- **`parameters[].in == "path"`** → top-level field, always required (path params are non-optional in OpenAPI).
+- **`parameters[].in == "query"`** → top-level field; required if `required: true`, else `.optional()`.
+- **`parameters[].in == "header"`** → top-level field, prefixed with `header_` to avoid collisions (`X-Request-Id` → `header_x_request_id`). Most APIs don't need the LLM to set headers — usually only auth-related, and those come from env vars. Only expose a header param to the LLM if it's a real input (e.g., `X-Idempotency-Key`).
+- **`requestBody.content.application/json.schema`** → if the body schema is an object, splat its properties into the top level (so the LLM sees one flat arg list, not `{ body: { ... } }`). If the body is a primitive or array, expose it as a single `body` field.
+- **`parameters[].in == "cookie"`** → ignore. Cookie-based APIs from an MCP server are almost always a misconfiguration; surface a warning.
+
+Collision handling: if a query param and a body field share a name, prefix the query one with `query_`. Log the rename.
+
+## 4. Zod schema conversion
+
+Walk the OpenAPI schema recursively. The mapping table:
+
+| OpenAPI | Zod |
+|---|---|
+| `type: string` | `z.string()` |
+| `type: string`, `enum: [...]` | `z.enum([...])` |
+| `type: string`, `format: date-time` | `z.string().datetime()` |
+| `type: string`, `format: email` | `z.string().email()` |
+| `type: string`, `format: uri` | `z.string().url()` |
+| `type: string`, `format: uuid` | `z.string().uuid()` |
+| `type: integer` | `z.number().int()` |
+| `type: number` | `z.number()` |
+| `type: boolean` | `z.boolean()` |
+| `type: array`, `items: T` | `z.array(T)` |
+| `type: object` with `properties` | `z.object({...})` (apply `.optional()` to non-required) |
+| `type: object` with `additionalProperties: T` | `z.record(T)` |
+| `oneOf: [A, B]` | `z.union([A, B])` |
+| `anyOf: [A, B]` | `z.union([A, B])` |
+| `allOf: [A, B]` (objects) | merge into one `z.object` |
+| `nullable: true` (3.0) | `.nullable()` |
+| `type: [..., "null"]` (3.1) | `.nullable()` |
+| missing `type` | `z.unknown()` |
+
+Carry over constraints:
+
+- `minimum` / `maximum` → `.min()` / `.max()` (numbers) or `.gte()` / `.lte()`.
+- `minLength` / `maxLength` → `.min()` / `.max()` on strings.
+- `minItems` / `maxItems` → `.min()` / `.max()` on arrays.
+- `pattern` → `.regex(new RegExp(pattern))`.
+- `default` → `.default(value)`.
+- `description` or `title` → `.describe(...)`.
+
+**Always describe.** Every field should chain a `.describe()`. If the OpenAPI field has no description, fall back to the field name in human-readable form. The LLM uses descriptions to pick values; missing descriptions degrade quality more than any other single thing.
+
+## 5. Response handling
+
+The LLM doesn't strictly need an output schema — it can read the JSON the tool returns and reason about it. But declaring one improves results:
+
+- If `responses.200.content.application/json.schema` exists, convert it to zod (same rules as above) and pass as `outputSchema`.
+- If the response is a list, the schema is the list shape — the LLM will paginate naturally if `description` mentions it.
+- If the response is binary (`application/octet-stream`, `image/*`), return a text message: `"Downloaded N bytes of type X"` and either save to disk or omit. The MCP tool result should not embed binary blobs.
+- If the response is `text/event-stream` (SSE) or `application/x-ndjson`, accumulate chunks and return as text. Real streaming through MCP is possible but out of scope for the first version.
+- Non-2xx: throw with a structured error. The tool result becomes `text("Error: " + e.message)`. Include the HTTP status and the response body — the LLM uses both to decide whether to retry or ask the user.
+
+## 6. Filtering large specs
+
+When a spec has more than ~30 operations, ask the user to filter. Strategies:
+
+- **By tag.** Most large specs (Stripe, GitHub, Twilio) tag operations. Expose tags as the filter unit: "Include only the `pets` tag" maps to `operations.filter(op => op.tags?.includes("pets"))`.
+- **By prefix.** `GET /v1/charges/*` → all charges operations. Useful when tags are missing.
+- **By explicit list.** The user names ops: `["createCustomer", "listInvoices", "retrieveCharge"]`. Use this for cherry-picked exposures.
+- **Method-only.** Some users only want read access — filter to `GET` operations.
+
+Whatever filter you apply, write it into `index.ts` as a visible constant (`OPERATION_ALLOWLIST` or `INCLUDED_TAGS`) so the user can edit it later without re-running the generator.
+
+## 7. Multi-content request bodies
+
+If `requestBody.content` has multiple media types:
+
+- Prefer `application/json` if present.
+- Fall back to `application/x-www-form-urlencoded` (encode args as form data in `client.ts`).
+- Fall back to `multipart/form-data` only if the user explicitly asks (file uploads — most LLM clients aren't great at file args anyway).
+- Skip any operation whose only body type is `application/octet-stream` (binary upload) unless the user wants that operation specifically; expose it as a tool that takes a `filePath` and the handler reads the file.
+
+## 8. Edge cases
+
+**Recursive `$ref` after dereferencing.** swagger-parser keeps cycles as live refs. When you hit one, fall back to `z.lazy(() => ...)` with `z.unknown()` as the leaf — the LLM will read JSON anyway.
+
+**Polymorphism with discriminators.** OpenAPI's `discriminator` is a hint the LLM doesn't need; convert `oneOf` to a plain `z.union` and let the LLM see the discriminator field in the description.
+
+**File downloads.** GET that returns `application/pdf` etc.: the tool takes a `savePath` param, writes the body to that path, and returns `"Saved <bytes> bytes to <path>"`.
+
+**Webhooks / callbacks.** Skip `webhooks` and `callbacks` sections entirely — they're server-initiated, not LLM-initiated. If the user asks "can the LLM receive webhooks?", that's a different architecture (event-driven MCP) and out of scope.
+
+**Deprecated operations.** If `deprecated: true`, either skip or include with `[DEPRECATED]` prefix in the description. Default: skip. Tell the user.
+
+**Vendor extensions (`x-*`).** Ignore unless you recognize one. `x-internal: true` is a common signal to skip; respect it.

--- a/skills/openapi-to-mcp/references/testing.md
+++ b/skills/openapi-to-mcp/references/testing.md
@@ -24,7 +24,7 @@ cp .env.example .env
 $EDITOR .env
 
 # If you changed openapi.yaml since last time, refresh the dereferenced file
-npm run load-spec
+npx tsx scripts/load-spec.ts   # or: npm run load-spec (add "load-spec": "tsx scripts/load-spec.ts" to package.json scripts)
 
 # Start hot-reload dev server
 rm -rf .mcp-use dist        # only if you've moved files or are seeing stale-cache errors

--- a/skills/openapi-to-mcp/references/testing.md
+++ b/skills/openapi-to-mcp/references/testing.md
@@ -1,0 +1,225 @@
+# Testing the MCP server
+
+The server uses streamable HTTP at `/mcp` (see SKILL.md step 8 for why this is non-negotiable). Two ways to test it, cheapest first. Run both before declaring the build done — each layer catches a different class of bug.
+
+## Table of contents
+
+1. Start the dev server
+2. Layer 1 — `mcp-use client` CLI (primary)
+3. Layer 2 — inspector chat (LLM loop)
+4. Testing the deployed URL
+5. Raw protocol debugging (curl)
+6. Common failures and fixes
+7. What "done" looks like
+
+---
+
+## 1. Start the dev server
+
+From the project root:
+
+```bash
+# Make sure .env has the right secrets (and is gitignored)
+cp .env.example .env
+$EDITOR .env
+
+# If you changed openapi.yaml since last time, refresh the dereferenced file
+npm run load-spec
+
+# Start hot-reload dev server
+rm -rf .mcp-use dist        # only if you've moved files or are seeing stale-cache errors
+npm run dev
+```
+
+Watch the log. You should see:
+- The list of tools registered (one per operation, after any filter you applied).
+- The port the server is listening on (3000, or 3001 if 3000 is taken).
+- Both the MCP URL (`http://localhost:<port>/mcp`) and the inspector URL.
+
+If you don't see your tool list, you missed a step in the operations loop in `index.ts` (e.g., the filter skipped everything, or `openapi.dereferenced.json` is missing).
+
+## 2. Layer 1 — `mcp-use client` CLI (primary)
+
+The `mcp-use` package ships a CLI client that connects to any streamable-HTTP MCP server, handles session and auth bookkeeping, and gives a clean `tools list` / `tools call` / `interactive` surface from the terminal. This is the first thing to reach for. Full docs at <https://docs.mcp-use.com/typescript/client/cli>.
+
+### Connect once, then run commands against the name
+
+```bash
+# Save the dev server under a short name (only once per server)
+npx mcp-use client connect dev http://localhost:3000/mcp
+
+# List saved servers
+npx mcp-use client list
+```
+
+The server is persisted in `~/.mcp-use/cli-sessions.json` so the name is reusable across shells.
+
+### List and describe tools
+
+```bash
+npx mcp-use client dev tools list
+npx mcp-use client dev tools list --json
+
+# Describe shows the zod-derived input schema for one tool — useful for debugging args
+npx mcp-use client dev tools describe <tool_name>
+```
+
+If `tools list` is empty, your operation filter killed everything. Check `index.ts`.
+
+### Call tools
+
+```bash
+# Simple args (string, number, bool inferred from schema)
+npx mcp-use client dev tools call list_pets limit=5
+
+# Pass JSON for nested objects or arrays
+npx mcp-use client dev tools call create_pet '{"name":"Felix","tags":["cat","stripey"]}'
+
+# Or use the typed-JSON arg syntax
+npx mcp-use client dev tools call create_pet name=Felix tags:='["cat","stripey"]'
+
+# Long-running calls — pump the timeout
+npx mcp-use client dev tools call slow_op --timeout 60000
+```
+
+Add `--json` to any call to get raw JSON output for piping into `jq` or further scripts.
+
+### REPL mode
+
+```bash
+npx mcp-use client dev interactive
+```
+
+Drops you into a prompt where every command is in the context of the `dev` server. Useful when iterating on schema or response shape — you can list, describe, and call without retyping the server name each time.
+
+### Authentication
+
+If your MCP server itself enforces auth (different from upstream API auth — most OpenAPI wrappers don't), the CLI supports static bearer tokens (`--auth <token>` at connect time) and a full OAuth flow. For OpenAPI wrappers built with this skill, auth lives in `process.env` and is attached server-side to the upstream calls; the MCP server itself is unauthenticated and the CLI just connects directly.
+
+### When the CLI itself fails
+
+Two common cases:
+- **`Error: Client 'dev' not found`** — you forgot to `connect` first, or the saved sessions file got corrupted. Re-run `connect`.
+- **Connection refused / timeout** — the dev server isn't running, or it's on a different port (check the dev log). If the dev server is running and the CLI still can't connect, drop to curl (section 5) to confirm the endpoint is alive and speaks MCP at all.
+
+For scripted / CI use, add `--json` to any CLI command and pipe to `jq`:
+
+```bash
+npx mcp-use client dev tools list --json | jq '.[].name'
+npx mcp-use client dev tools call list_pets limit=5 --json | jq '.content[0].text'
+```
+
+That covers the "scriptable" case without a separate test file.
+
+## 3. Layer 2 — inspector chat (the real LLM loop)
+
+Layer 1 proves the server works. Layer 2 proves the LLM can actually use it. This is the one that catches description / schema problems the CLI can't see.
+
+### Open the inspector
+
+```
+http://localhost:<PORT>/inspector?server=http%3A%2F%2Flocalhost%3A<PORT>%2Fmcp&tab=chat
+```
+
+The `server` query string is URL-encoded. Without encoding, the inspector connects to nothing and silently shows zero tools. You can also open `http://localhost:<PORT>/inspector` plain and paste the MCP URL into the connection input.
+
+### Two test phases
+
+**Force-invoke (low difficulty).** Ask the model to call a specific tool by name:
+
+> Use `list_pets` with `limit: 5`.
+
+This isolates tool-execution correctness from tool-selection correctness. If this fails, fix the tool before moving on. You should already have caught it in Layer 1, but the inspector adds an LLM in the path that occasionally exposes argument-coercion quirks the CLI doesn't.
+
+**Free-form discovery (real-world difficulty).** Describe the goal in natural language and let the LLM pick:
+
+> Show me the first 5 pets in the store.
+
+The LLM should land on the right tool based on the description and schema alone. If it picks the wrong tool or hands wrong-shaped args, the OpenAPI `summary` / `description` aren't carrying enough signal — improve them in `openapi.yaml`, re-run `npm run load-spec`, restart the dev server.
+
+### What to verify
+
+1. **Tool chip** — green check, args match what you asked.
+2. **Auth was sent** — set `DEBUG_HTTP=1` in `.env` for the session if you need to see it in the log. The redaction in `client.ts` keeps the secret out of the log; the presence of the header proves it was sent.
+3. **Response shape** — parsed JSON or a useful string, not raw HTML or a 500-page error blob.
+4. **LLM follow-up** — the model summarizes the response correctly. If it's hallucinating fields that aren't in the response, your tool description or output schema needs to be tighter.
+
+### Failure paths to test in the inspector
+
+- **Missing required arg.** Ask for a call without a required field. The zod schema should reject it client-side; the chip shows the validation error.
+- **Bad auth.** Unset `API_KEY` (or set it to garbage) and restart. The tool should return `Error calling X: HTTP 401 ...` — not crash the server.
+- **Dead endpoint.** Temporarily point `BASE_URL` at `http://localhost:9999` (nothing listening). The tool returns a clean fetch error.
+
+## 4. Testing the deployed URL
+
+After step 10 (deploy), both layers apply — just point them at the production URL.
+
+```bash
+# Layer 1 — CLI (just connect to the production URL under a new name)
+npx mcp-use client connect prod https://<name>.run.mcp-use.com/mcp
+npx mcp-use client prod tools list
+npx mcp-use client prod tools call <tool> limit=5
+
+# Layer 2 — online inspector
+# Visit https://inspector.mcp-use.com and paste the production /mcp URL.
+```
+
+If layer 1 passes locally but fails against production, the issue is almost always missing or stale env vars in the Manufact dashboard (see `references/deploy.md`).
+
+## 5. Raw protocol debugging (curl)
+
+When the CLI can't connect and you need to know whether the streamable-HTTP endpoint is alive at the transport layer, drop to curl. This is for diagnosing transport-level issues only — the CLI is faster for everything else.
+
+```bash
+# Initialize a session and grab the Mcp-Session-Id header
+SESSION=$(curl -s -i -X POST http://localhost:3000/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"curl-debug","version":"1.0"}}}' \
+  | grep -i "mcp-session-id:" | awk '{print $2}' | tr -d '\r')
+echo "Session: $SESSION"
+
+# List tools
+curl -s -X POST http://localhost:3000/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Mcp-Session-Id: $SESSION" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
+```
+
+What to look for:
+
+- **Empty `SESSION`** → server didn't respond with an `Mcp-Session-Id` header. Server isn't running, wrong port, or — uncommonly — the transport got swapped to stdio. Verify `server.listen(port)` is the last line of `index.ts`.
+- **Connection refused** → port not listening.
+- **`{"jsonrpc":"2.0","error":...}` on initialize** → server is up but the request was malformed (most often a missing Accept header).
+- **Successful initialize + empty tools/list** → server is up, transport is fine, but the operations loop filtered everything out.
+
+The response body for streamable HTTP is SSE-encoded (lines prefixed with `data:`). That's normal — the CLI and SDK both parse it transparently.
+
+## 6. Common failures and fixes
+
+**`"Failed to resolve import /sessions/... index.ts"`** — Stale `.mcp-use` cache from a previous mount or path. `rm -rf .mcp-use && npm run dev`.
+
+**Inspector says "0 tools available"** — Two causes: (a) the operations loop filtered everything out — check the filter constants in `index.ts`; (b) the URL encoding in the inspector query string is wrong — re-paste using the URL-encoded form above.
+
+**Tool call returns `Error: Unknown operation: X`** — `src/client.ts` couldn't find the operation in the dereferenced spec. Probably means `openapi.dereferenced.json` is stale (you edited `openapi.yaml` without running `npm run load-spec`).
+
+**LLM never calls the right tool (only fails in Layer 2)** — Description is too thin. Layer 1 can't see this; it doesn't reason about tool selection. Open `src/operations.ts` and verify the description-building falls back to something meaningful when `summary` is empty. Adding a one-line example to the spec's `description` for that operation often fixes it.
+
+**LLM calls the tool with wrong types** — A field in the zod schema doesn't have `.describe()` or its enum values aren't in the description. Check `references/mapping-rules.md` section 4.
+
+**401 even though `.env` has the key** — dotenv isn't being loaded. Add `import "dotenv/config"` at the top of `index.ts` (the template does this); make sure `npm i dotenv` ran. Or run the server with `node --env-file=.env`.
+
+**CLI says "Client 'dev' not found"** — You haven't run `connect` for that name, or the saved sessions file at `~/.mcp-use/cli-sessions.json` got cleared. Re-run `npx mcp-use client connect dev http://localhost:3000/mcp`.
+
+## 7. What "done" looks like
+
+Before moving on to deploy:
+
+- Layer 1 (CLI): `connect` succeeds; `tools list` shows every expected tool; `tools call` returns a real or cleanly-erroring result for at least one tool.
+- Layer 2 (inspector): every tool you care about has been force-invoked successfully **and** at least one has been called via free-form discovery.
+- At least one tool has been called with an unhappy-path input (missing arg, bad auth, dead upstream) and returned a structured error in both layers.
+- The dev server log shows no warnings about unknown schemes or missing operations.
+- `npx tsc --noEmit` passes.
+
+Once that's green, jump to `references/deploy.md`.


### PR DESCRIPTION
## Summary

Adds the `openapi-to-mcp` skill to the `skills/` directory, parallel to the existing `mcp-apps-builder` skill.

## What it does

The skill guides Claude through turning any OpenAPI / Swagger spec into a live MCP server using the mcp-use TypeScript SDK — covering:

- Spec ingestion (file path, URL, or pasted JSON/YAML)
- Operation-to-tool mapping with proper Zod schemas
- Auth wiring (apiKey, bearer, basic, OAuth bearer)
- Scaffolding with `create-mcp-use-app`
- Live testing in the mcp-use inspector
- Deploying to Manufact / mcp-use cloud

## Install

```bash
npx skills install mcp-use/mcp-use --skill openapi-to-mcp
```