### PR TITLE
fix(inspector): drop unused TabCountBadge barrel re-export

### DIFF
--- a/libraries/typescript/.changeset/fix-knip-tabcountbadge-barrel.md
+++ b/libraries/typescript/.changeset/fix-knip-tabcountbadge-barrel.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Drop unused `TabCountBadge` re-export from the shared barrel; the only consumer imports it directly. Fixes Knip CI on canary.

--- a/libraries/typescript/packages/inspector/src/client/components/shared/index.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/shared/index.ts
@@ -1,4 +1,3 @@
-export { TabCountBadge } from "./TabCountBadge";
 export { ListItem } from "./ListItem";
 export { ListTabHeader } from "./ListTabHeader";
 export { RpcPanel } from "./RpcPanel";


### PR DESCRIPTION
## Changes

Remove `TabCountBadge` from `packages/inspector/src/client/components/shared/index.ts` — the only consumer (`LayoutHeader.tsx`) already imports it directly from `./shared/TabCountBadge`, so the barrel re-export is unused.

## Why

Knip started failing CI on `canary` after the original `TabCountBadge` change landed (#) — see run [26128983448](https://github.com/mcp-use/mcp-use/actions/runs/26128983448). Every PR opened against `canary` inherits this failure via the merge ref, including #1395.

## Verification

```
pnpm exec knip --no-progress
# exits 0 (only a non-blocking configuration hint remains)
```

## Backwards Compatibility

Non-breaking. The barrel re-export had zero consumers.