### PR TITLE
feat : inspector add scroll-to-bottom button

### DIFF
--- a/libraries/typescript/.changeset/quiet-dragons-scroll.md
+++ b/libraries/typescript/.changeset/quiet-dragons-scroll.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Add a centered, animated scroll-to-bottom button to the Inspector chat when viewing older messages.

--- a/libraries/typescript/packages/inspector/src/client/components/ChatTab.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ChatTab.tsx
@@ -1119,6 +1119,7 @@ export function ChatTab({
       {/* Messages Area */}
       <div
         ref={messagesAreaRef}
+        data-testid="chat-messages-scroll-container"
         className="flex-1 overflow-y-auto p-2 sm:p-4 pt-[80px] sm:pt-[100px]"
       >
         {!llmConfig ? (
@@ -1137,6 +1138,7 @@ export function ChatTab({
             pendingElicitationRequests={connection.pendingElicitationRequests}
             onApproveElicitation={connection.approveElicitation}
             onRejectElicitation={connection.rejectElicitation}
+            scrollContainerRef={messagesAreaRef}
           />
         )}
       </div>

--- a/libraries/typescript/packages/inspector/src/client/components/chat/MessageList.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/MessageList.tsx
@@ -1,7 +1,15 @@
 import { TextShimmer } from "@/client/components/ui/text-shimmer";
 import { Button } from "@/client/components/ui/button";
 import { ArrowDown } from "lucide-react";
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { AnimatePresence, motion } from "motion/react";
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type RefObject,
+} from "react";
 import type { MessageContentBlock } from "mcp-use/react";
 import { AssistantMessage } from "./AssistantMessage";
 import { ToolCallDisplay } from "./ToolCallDisplay";
@@ -56,7 +64,7 @@ interface MessageListProps {
   /** Handler called when the user cancels an elicitation. */
   onRejectElicitation?: (requestId: string, error?: string) => void;
   /** Scroll container element (the overflow-y parent). Enables scroll-to-bottom UX. */
-  scrollContainerRef?: React.RefObject<HTMLElement | null>;
+  scrollContainerRef?: RefObject<HTMLElement | null>;
 }
 
 export const MessageList = memo(
@@ -83,7 +91,8 @@ export const MessageList = memo(
     const measureIsNearBottom = useCallback(() => {
       const el = scrollContainerRef?.current;
       if (!el) return;
-      const distanceFromBottom = el.scrollHeight - (el.scrollTop + el.clientHeight);
+      const distanceFromBottom =
+        el.scrollHeight - (el.scrollTop + el.clientHeight);
       setIsNearBottom(distanceFromBottom <= bottomThresholdPx);
     }, [scrollContainerRef]);
 
@@ -94,6 +103,7 @@ export const MessageList = memo(
 
         el.scrollTo({ top: el.scrollHeight, behavior });
         messagesEndRef.current?.scrollIntoView({ behavior, block: "start" });
+        setIsNearBottom(true);
       },
       [scrollContainerRef]
     );
@@ -207,26 +217,6 @@ export const MessageList = memo(
       const lastMessage = messages[messages.length - 1];
       return message.id === lastMessage.id && lastMessage.role === "assistant";
     };
-
-    const scrollButtonNode = useMemo(() => {
-      if (!showScrollToBottom) return null;
-
-      return (
-        <div className="sticky bottom-4 flex justify-end pointer-events-none">
-          <Button
-            type="button"
-            variant="secondary"
-            className="pointer-events-auto h-9 w-9 rounded-full p-0 shadow-md"
-            onClick={() => scrollToBottom("smooth")}
-            aria-label="Scroll to bottom"
-            title="Scroll to bottom"
-            data-testid="chat-scroll-to-bottom"
-          >
-            <ArrowDown className="h-4 w-4" />
-          </Button>
-        </div>
-      );
-    }, [scrollToBottom, showScrollToBottom]);
 
     return (
       <div className="space-y-6 max-w-3xl mx-auto px-2">
@@ -425,7 +415,31 @@ export const MessageList = memo(
         {/* Reference for scrolling to bottom */}
         <div ref={messagesEndRef} />
 
-        {scrollButtonNode}
+        <div className="sticky bottom-4 z-20 h-0 -translate-y-4 pointer-events-none">
+          <AnimatePresence>
+            {showScrollToBottom && (
+              <motion.div
+                className="flex justify-center"
+                initial={{ opacity: 0, y: 8, scale: 0.96 }}
+                animate={{ opacity: 1, y: 0, scale: 1 }}
+                exit={{ opacity: 0, y: 8, scale: 0.96 }}
+                transition={{ duration: 0.18, ease: "easeOut" }}
+              >
+                <Button
+                  type="button"
+                  variant="secondary"
+                  className="pointer-events-auto size-9 rounded-full border bg-background/95 p-0 shadow-lg backdrop-blur supports-[backdrop-filter]:bg-background/80"
+                  onClick={() => scrollToBottom("smooth")}
+                  aria-label="Scroll to bottom"
+                  title="Scroll to bottom"
+                  data-testid="chat-scroll-to-bottom"
+                >
+                  <ArrowDown className="size-4" />
+                </Button>
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
       </div>
     );
   }

--- a/libraries/typescript/packages/inspector/src/client/components/chat/MessageList.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/MessageList.tsx
@@ -1,5 +1,7 @@
 import { TextShimmer } from "@/client/components/ui/text-shimmer";
-import { memo, useCallback, useEffect, useRef } from "react";
+import { Button } from "@/client/components/ui/button";
+import { ArrowDown } from "lucide-react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { MessageContentBlock } from "mcp-use/react";
 import { AssistantMessage } from "./AssistantMessage";
 import { ToolCallDisplay } from "./ToolCallDisplay";
@@ -53,6 +55,8 @@ interface MessageListProps {
   onApproveElicitation?: (requestId: string, result: ElicitResult) => void;
   /** Handler called when the user cancels an elicitation. */
   onRejectElicitation?: (requestId: string, error?: string) => void;
+  /** Scroll container element (the overflow-y parent). Enables scroll-to-bottom UX. */
+  scrollContainerRef?: React.RefObject<HTMLElement | null>;
 }
 
 export const MessageList = memo(
@@ -67,8 +71,32 @@ export const MessageList = memo(
     pendingElicitationRequests,
     onApproveElicitation,
     onRejectElicitation,
+    scrollContainerRef,
   }: MessageListProps) => {
     const messagesEndRef = useRef<HTMLDivElement>(null);
+    const [isNearBottom, setIsNearBottom] = useState(true);
+    const bottomThresholdPx = 64;
+
+    const hasMessages = messages.length > 0;
+    const showScrollToBottom = hasMessages && !isNearBottom;
+
+    const measureIsNearBottom = useCallback(() => {
+      const el = scrollContainerRef?.current;
+      if (!el) return;
+      const distanceFromBottom = el.scrollHeight - (el.scrollTop + el.clientHeight);
+      setIsNearBottom(distanceFromBottom <= bottomThresholdPx);
+    }, [scrollContainerRef]);
+
+    const scrollToBottom = useCallback(
+      (behavior: ScrollBehavior) => {
+        const el = scrollContainerRef?.current;
+        if (!el) return;
+
+        el.scrollTo({ top: el.scrollHeight, behavior });
+        messagesEndRef.current?.scrollIntoView({ behavior, block: "start" });
+      },
+      [scrollContainerRef]
+    );
 
     // Helper function to get tool metadata by name.
     // Normalizes hyphens/underscores because the Anthropic API converts
@@ -115,15 +143,23 @@ export const MessageList = memo(
       [sendMessage]
     );
 
-    // Scroll to bottom when messages change or streaming status changes
+    // Track whether the user is reading older messages vs near the bottom.
     useEffect(() => {
-      if (messages.length > 0 && messagesEndRef.current) {
-        messagesEndRef.current.scrollIntoView({
-          behavior: !isLoading ? "smooth" : "auto",
-          block: "start",
-        });
-      }
-    }, [messages.length, isLoading]);
+      const el = scrollContainerRef?.current;
+      if (!el) return;
+
+      measureIsNearBottom();
+      const onScroll = () => measureIsNearBottom();
+      el.addEventListener("scroll", onScroll, { passive: true });
+      return () => el.removeEventListener("scroll", onScroll);
+    }, [measureIsNearBottom, scrollContainerRef]);
+
+    // Auto-scroll only when the user is already near the bottom.
+    useEffect(() => {
+      if (!hasMessages || !messagesEndRef.current) return;
+      if (!isNearBottom) return;
+      scrollToBottom(!isLoading ? "smooth" : "auto");
+    }, [hasMessages, isLoading, isNearBottom, messages.length, scrollToBottom]);
 
     // Determine if we're in "thinking" state vs "streaming" state
     const isThinking =
@@ -171,6 +207,26 @@ export const MessageList = memo(
       const lastMessage = messages[messages.length - 1];
       return message.id === lastMessage.id && lastMessage.role === "assistant";
     };
+
+    const scrollButtonNode = useMemo(() => {
+      if (!showScrollToBottom) return null;
+
+      return (
+        <div className="sticky bottom-4 flex justify-end pointer-events-none">
+          <Button
+            type="button"
+            variant="secondary"
+            className="pointer-events-auto h-9 w-9 rounded-full p-0 shadow-md"
+            onClick={() => scrollToBottom("smooth")}
+            aria-label="Scroll to bottom"
+            title="Scroll to bottom"
+            data-testid="chat-scroll-to-bottom"
+          >
+            <ArrowDown className="h-4 w-4" />
+          </Button>
+        </div>
+      );
+    }, [scrollToBottom, showScrollToBottom]);
 
     return (
       <div className="space-y-6 max-w-3xl mx-auto px-2">
@@ -368,6 +424,8 @@ export const MessageList = memo(
 
         {/* Reference for scrolling to bottom */}
         <div ref={messagesEndRef} />
+
+        {scrollButtonNode}
       </div>
     );
   }

--- a/libraries/typescript/packages/inspector/tests/e2e/chat.test.ts
+++ b/libraries/typescript/packages/inspector/tests/e2e/chat.test.ts
@@ -318,9 +318,12 @@ test.describe("Inspector Chat Tests", () => {
     await scrollButton.click();
 
     await container.evaluate((el) => {
-      const distanceFromBottom = el.scrollHeight - (el.scrollTop + el.clientHeight);
+      const distanceFromBottom =
+        el.scrollHeight - (el.scrollTop + el.clientHeight);
       if (distanceFromBottom > 80) {
-        throw new Error(`Expected to be near bottom, distance=${distanceFromBottom}`);
+        throw new Error(
+          `Expected to be near bottom, distance=${distanceFromBottom}`
+        );
       }
     });
 

--- a/libraries/typescript/packages/inspector/tests/e2e/chat.test.ts
+++ b/libraries/typescript/packages/inspector/tests/e2e/chat.test.ts
@@ -284,6 +284,49 @@ test.describe("Inspector Chat Tests", () => {
     expect(clipboardText).toContain("What is 2+2?");
   });
 
+  test("should show scroll-to-bottom button when not at bottom", async ({
+    page,
+  }) => {
+    // Create enough content to overflow the messages container.
+    // Keep this short enough to avoid timeouts, but long enough to force scrolling.
+    for (let i = 0; i < 6; i++) {
+      await page
+        .getByTestId("chat-input")
+        .fill(`Write a short list of 10 items. Iteration ${i + 1}.`);
+      await page.getByTestId("chat-send-button").click();
+      await expect(page.getByTestId("chat-message-user")).toBeVisible({
+        timeout: 3000,
+      });
+      await expect(page.getByTestId("chat-message-assistant")).toBeVisible({
+        timeout: 45000,
+      });
+    }
+
+    const container = page.getByTestId("chat-messages-scroll-container");
+    await expect(container).toBeVisible();
+
+    // Scroll away from the bottom.
+    await container.evaluate((el) => {
+      el.scrollTop = 0;
+    });
+
+    // Button should appear when not near the bottom.
+    const scrollButton = page.getByTestId("chat-scroll-to-bottom");
+    await expect(scrollButton).toBeVisible({ timeout: 3000 });
+
+    // Click button and ensure we end up at the bottom.
+    await scrollButton.click();
+
+    await container.evaluate((el) => {
+      const distanceFromBottom = el.scrollHeight - (el.scrollTop + el.clientHeight);
+      if (distanceFromBottom > 80) {
+        throw new Error(`Expected to be near bottom, distance=${distanceFromBottom}`);
+      }
+    });
+
+    await expect(scrollButton).not.toBeVisible({ timeout: 3000 });
+  });
+
   test("should export chat as JSON when export JSON is clicked", async ({
     page,
     context,


### PR DESCRIPTION
#### pull Request Description

- Language / Project Scope

#### Check all that apply:
[x] TypeScript

#### Changes

- Add “scroll to bottom” button in chat.
- Only auto-scroll when already near bottom.

#### Implementation Details

- Track near-bottom from scroll container.
- Show/hide button based on scroll position.
- Add E2E test for button.

#### TypeScript Checklist
Packages Modified
- [x] inspector

Pre-commit Checklist
- [x] Ran pnpm build
- [x] Added or updated tests


####Documentation Updates
None

#### Testing

- pnpm -C libraries/typescript build
- pnpm -C libraries/typescript/packages/inspector lint
- pnpm -C libraries/typescript/packages/inspector type-check

#### Backwards Compatibility
- Backwards compatible

#### Related Issues

Closes #1532