### PR TITLE
fix(inspector): propagate server alias updates through mcp server wrapper

### DIFF
--- a/libraries/typescript/.changeset/fix-server-alias-tile-heading.md
+++ b/libraries/typescript/.changeset/fix-server-alias-tile-heading.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Treat `name` as a meaningful change in `McpServerWrapper` so alias-only edits propagate through `onUpdate` and the Inspector tile heading reflects the new alias immediately.

--- a/libraries/typescript/packages/mcp-use/src/react/McpClientProvider.tsx
+++ b/libraries/typescript/packages/mcp-use/src/react/McpClientProvider.tsx
@@ -620,6 +620,7 @@ function McpServerWrapper({
 
     if (
       !prevServer ||
+      prevServer.name !== server.name ||
       prevServer.state !== server.state ||
       prevServer.error !== server.error ||
       prevServer.authUrl !== server.authUrl ||


### PR DESCRIPTION
#### Language / Project Scope
[x] TypeScript

#### Changes

- Fix alias-only connection edits not always updating the Inspector tile heading.

#### Implementation Details

- Treat name as a meaningful change in McpServerWrapper
- Alias updates now go through normal onUpdate
- No new dependencies

#### TypeScript Checklist
- Packages Modified
[x] mcp-use (client)

- Pre-commit Checklist
[ ] pnpm lint:fix
[ ] pnpm format
[ ] pnpm build
[ ] pnpm changeset
[ ] Tests updated if needed
[ ] Docs updated if needed

##### Example Usage (Before)
- Alias saved, tile may still show serverInfo.name

##### Example Usage (After)
- Alias saved, tile shows alias immediately

#### Documentation Updates
- None

#### Testing

- Unit: mcp-client-provider-metadata-updates.test.ts
- E2E: connection.test.ts alias test

#### Backwards Compatibility
- Fully backwards compatible.

#### Related Issues
Closes : #1478