### PR TITLE
chore: remove dead typescript-format-and-lint pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,16 +25,6 @@ repos:
       - id: debug-statements
         files: ^libraries/python/.*\.py$
 
-  # TypeScript/JavaScript hooks - only run on TS/JS files
-  - repo: local
-    hooks:
-      - id: typescript-format-and-lint
-        name: TypeScript Format & Lint
-        entry: .git/hooks/typescript-pre-commit.sh
-        language: system
-        files: ^libraries/typescript/.*\.(ts|tsx|js|jsx)$
-        pass_filenames: false
-
 # Define configuration for the Python checks
 default_language_version:
   python: python3.11


### PR DESCRIPTION
## Summary
- Removes the `typescript-format-and-lint` hook from the root `.pre-commit-config.yaml`.
- The hook pointed to `.git/hooks/typescript-pre-commit.sh`, a path that is never tracked in git and was never populated by any setup step, so it could not run for anyone.
- TypeScript formatting and linting are already handled by Husky (`libraries/typescript/.husky/pre-commit`), installed automatically via `pnpm install`'s `prepare` script — so contributors lose nothing.

## Test plan
- [ ] `pre-commit run --all-files` from the repo root no longer references the missing script.
- [ ] Husky-driven TypeScript pre-commit still runs on `pnpm install` + commit (unchanged).

Closes #1536