### PR TITLE
Improve tab switch animation timing

### DIFF
--- a/libraries/typescript/.changeset/inspector-tab-count-badge.md
+++ b/libraries/typescript/.changeset/inspector-tab-count-badge.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Keep per-tab count badges visible in collapsed header tabs and align them to the right of the tab label. Extract shared `TabCountBadge` styling for mobile and desktop tab rows.

--- a/libraries/typescript/packages/inspector/src/client/components/LayoutHeader.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/LayoutHeader.tsx
@@ -881,6 +881,19 @@ export function LayoutHeader({
                   }
                   const count = getTabCount(tab.id, selectedServer);
                   const showDot = shouldShowDot(tab.id, count, collapsed);
+                  const badge =
+                    count > 0 ? (
+                      <span
+                        className={cn(
+                          activeTab === tab.id
+                            ? "dark:bg-black"
+                            : "dark:bg-zinc-700",
+                          "ml-1 bg-zinc-200 text-zinc-700 dark:text-zinc-300 text-[10px] px-1.5 py-0.5 rounded-full font-medium"
+                        )}
+                      >
+                        {count}
+                      </span>
+                    ) : null;
 
                   return (
                     <TabsTrigger
@@ -889,6 +902,7 @@ export function LayoutHeader({
                       data-testid={`tab-${tab.id}`}
                       icon={tab.icon}
                       showDot={showDot}
+                      badge={badge}
                       alwaysExpanded={
                         "alwaysExpanded" in tab && tab.alwaysExpanded
                       }
@@ -897,18 +911,6 @@ export function LayoutHeader({
                         collapsed && "pl-2"
                       )}
                     >
-                      {count > 0 && !collapsed && (
-                        <span
-                          className={cn(
-                            activeTab === tab.id
-                              ? "dark:bg-black"
-                              : "dark:bg-zinc-700",
-                            "bg-zinc-200 text-zinc-700 dark:text-zinc-300 text-[10px] px-1.5 py-0.5 rounded-full font-medium"
-                          )}
-                        >
-                          {count}
-                        </span>
-                      )}
                       <span className="sr-only">{tab.label}</span>
                     </TabsTrigger>
                   );
@@ -956,6 +958,19 @@ export function LayoutHeader({
                     const tooltipText =
                       count > 0 ? `${tab.label} (${count})` : tab.label;
                     const showDot = shouldShowDot(tab.id, count, collapsed);
+                    const badge =
+                      count > 0 ? (
+                        <span
+                          className={cn(
+                            activeTab === tab.id
+                              ? " dark:bg-black "
+                              : "dark:bg-zinc-700",
+                            "ml-1 bg-zinc-200 text-zinc-700 dark:text-zinc-300 text-xs px-2 py-0.5 rounded-full font-medium"
+                          )}
+                        >
+                          {count}
+                        </span>
+                      ) : null;
 
                     return (
                       <TabsTrigger
@@ -964,6 +979,7 @@ export function LayoutHeader({
                         data-testid={`tab-${tab.id}`}
                         icon={tab.icon}
                         showDot={showDot}
+                        badge={badge}
                         alwaysExpanded={
                           "alwaysExpanded" in tab && tab.alwaysExpanded
                         }
@@ -973,21 +989,9 @@ export function LayoutHeader({
                         )}
                         title={tooltipText}
                       >
-                        <div className="items-center gap-2 hidden lg:flex">
+                        <span className="items-center gap-2 hidden lg:flex">
                           {tab.label}
-                          {count > 0 && (
-                            <span
-                              className={cn(
-                                activeTab === tab.id
-                                  ? " dark:bg-black "
-                                  : "dark:bg-zinc-700",
-                                "bg-zinc-200 text-zinc-700 dark:text-zinc-300 text-xs px-2 py-0.5 rounded-full font-medium"
-                              )}
-                            >
-                              {count}
-                            </span>
-                          )}
-                        </div>
+                        </span>
                       </TabsTrigger>
                     );
                   })}

--- a/libraries/typescript/packages/inspector/src/client/components/LayoutHeader.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/LayoutHeader.tsx
@@ -888,7 +888,7 @@ export function LayoutHeader({
                           activeTab === tab.id
                             ? "dark:bg-black"
                             : "dark:bg-zinc-700",
-                          "ml-1 bg-zinc-200 text-zinc-700 dark:text-zinc-300 text-[10px] px-1.5 py-0.5 rounded-full font-medium"
+                          "shrink-0 ml-1 bg-zinc-200 text-zinc-700 dark:text-zinc-300 text-[10px] px-1.5 py-0.5 rounded-full font-medium"
                         )}
                       >
                         {count}
@@ -965,7 +965,7 @@ export function LayoutHeader({
                             activeTab === tab.id
                               ? " dark:bg-black "
                               : "dark:bg-zinc-700",
-                            "ml-1 bg-zinc-200 text-zinc-700 dark:text-zinc-300 text-xs px-2 py-0.5 rounded-full font-medium"
+                            "shrink-0 ml-1 bg-zinc-200 text-zinc-700 dark:text-zinc-300 text-xs px-2 py-0.5 rounded-full font-medium"
                           )}
                         >
                           {count}

--- a/libraries/typescript/packages/inspector/src/client/components/LayoutHeader.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/LayoutHeader.tsx
@@ -66,6 +66,7 @@ import {
   MCPDeployClickEvent,
   Telemetry,
 } from "@/client/telemetry";
+import { TabCountBadge } from "./shared/TabCountBadge";
 import { AddToClientDropdown } from "./AddToClientDropdown";
 import LogoAnimated from "./LogoAnimated";
 import { SdkIntegrationModal } from "./SdkIntegrationModal";
@@ -881,19 +882,6 @@ export function LayoutHeader({
                   }
                   const count = getTabCount(tab.id, selectedServer);
                   const showDot = shouldShowDot(tab.id, count, collapsed);
-                  const badge =
-                    count > 0 ? (
-                      <span
-                        className={cn(
-                          activeTab === tab.id
-                            ? "dark:bg-black"
-                            : "dark:bg-zinc-700",
-                          "shrink-0 ml-1 bg-zinc-200 text-zinc-700 dark:text-zinc-300 text-[10px] px-1.5 py-0.5 rounded-full font-medium"
-                        )}
-                      >
-                        {count}
-                      </span>
-                    ) : null;
 
                   return (
                     <TabsTrigger
@@ -902,7 +890,13 @@ export function LayoutHeader({
                       data-testid={`tab-${tab.id}`}
                       icon={tab.icon}
                       showDot={showDot}
-                      badge={badge}
+                      badge={
+                        <TabCountBadge
+                          count={count}
+                          isActive={activeTab === tab.id}
+                          size="sm"
+                        />
+                      }
                       alwaysExpanded={
                         "alwaysExpanded" in tab && tab.alwaysExpanded
                       }
@@ -958,19 +952,6 @@ export function LayoutHeader({
                     const tooltipText =
                       count > 0 ? `${tab.label} (${count})` : tab.label;
                     const showDot = shouldShowDot(tab.id, count, collapsed);
-                    const badge =
-                      count > 0 ? (
-                        <span
-                          className={cn(
-                            activeTab === tab.id
-                              ? " dark:bg-black "
-                              : "dark:bg-zinc-700",
-                            "shrink-0 ml-1 bg-zinc-200 text-zinc-700 dark:text-zinc-300 text-xs px-2 py-0.5 rounded-full font-medium"
-                          )}
-                        >
-                          {count}
-                        </span>
-                      ) : null;
 
                     return (
                       <TabsTrigger
@@ -979,7 +960,12 @@ export function LayoutHeader({
                         data-testid={`tab-${tab.id}`}
                         icon={tab.icon}
                         showDot={showDot}
-                        badge={badge}
+                        badge={
+                          <TabCountBadge
+                            count={count}
+                            isActive={activeTab === tab.id}
+                          />
+                        }
                         alwaysExpanded={
                           "alwaysExpanded" in tab && tab.alwaysExpanded
                         }

--- a/libraries/typescript/packages/inspector/src/client/components/shared/TabCountBadge.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/shared/TabCountBadge.tsx
@@ -1,0 +1,31 @@
+import { cn } from "@/client/lib/utils";
+
+interface TabCountBadgeProps {
+  count: number;
+  isActive: boolean;
+  /** `sm` for mobile header tabs; `md` for desktop */
+  size?: "sm" | "md";
+}
+
+export function TabCountBadge({
+  count,
+  isActive,
+  size = "md",
+}: TabCountBadgeProps) {
+  if (count <= 0) {
+    return null;
+  }
+
+  return (
+    <span
+      className={cn(
+        isActive ? "dark:bg-black" : "dark:bg-zinc-700",
+        "shrink-0 ml-1 bg-zinc-200 text-zinc-700 dark:text-zinc-300 rounded-full font-medium",
+        size === "sm" && "text-[10px] px-1.5 py-0.5",
+        size === "md" && "text-xs px-2 py-0.5"
+      )}
+    >
+      {count}
+    </span>
+  );
+}

--- a/libraries/typescript/packages/inspector/src/client/components/shared/index.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/shared/index.ts
@@ -1,3 +1,4 @@
+export { TabCountBadge } from "./TabCountBadge";
 export { ListItem } from "./ListItem";
 export { ListTabHeader } from "./ListTabHeader";
 export { RpcPanel } from "./RpcPanel";

--- a/libraries/typescript/packages/inspector/src/client/components/ui/tabs.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ui/tabs.tsx
@@ -256,7 +256,7 @@ function TabsList({
           <span
             ref={indicatorRef}
             className={cn(
-              "absolute transition-all duration-500 ease-in-out z-0",
+              "absolute transition-all duration-[250ms] ease-in-out z-0",
               variant === "default" &&
                 "bg-white dark:bg-zinc-700 rounded-full h-[calc(100%)] top-0 border border-zinc-300 dark:border-zinc-600",
               variant === "underline" && "bottom-0 h-0.5 bg-black dark:bg-white"
@@ -360,7 +360,7 @@ const TabsTrigger = React.forwardRef<
           aria-selected={isActive ? "true" : "false"}
           title={title}
           className={cn(
-            "relative z-10 flex-1 inline-flex items-center justify-center whitespace-nowrap text-sm font-medium ring-offset-background transition-all duration-500 ease-in-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 cursor-pointer",
+            "relative z-10 flex-1 inline-flex items-center justify-center whitespace-nowrap text-sm font-medium ring-offset-background transition-all duration-[250ms] ease-in-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 cursor-pointer",
             variant === "default" && "py-2.5",
             variant === "default" && "rounded-md px-4",
             variant === "underline" &&
@@ -374,7 +374,7 @@ const TabsTrigger = React.forwardRef<
           {Icon && (
             <Icon
               className={cn(
-                "h-4 w-4 shrink-0 transition-all duration-500 ease-in-out",
+                "h-4 w-4 shrink-0 transition-all duration-[250ms] ease-in-out",
                 showLabel && "mr-2",
                 !showLabel && "mr-0!"
               )}
@@ -385,7 +385,7 @@ const TabsTrigger = React.forwardRef<
           )}
           <span
             className={cn(
-              "min-w-0 transition-all duration-500 ease-in-out overflow-hidden",
+              "min-w-0 transition-all duration-[250ms] ease-in-out overflow-hidden",
               showLabel ? "w-auto opacity-100" : "w-0 opacity-0"
             )}
           >

--- a/libraries/typescript/packages/inspector/src/client/components/ui/tabs.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ui/tabs.tsx
@@ -279,7 +279,6 @@ interface TabsTriggerProps {
   showDot?: boolean;
   /** When true, the label stays visible even when the tab bar is collapsed */
   alwaysExpanded?: boolean;
-  /** Optional badge element rendered next to the icon, always visible even when collapsed */
   badge?: React.ReactNode;
 }
 
@@ -375,24 +374,24 @@ const TabsTrigger = React.forwardRef<
           {Icon && (
             <Icon
               className={cn(
-                "h-4 w-4 transition-all duration-500 ease-in-out",
+                "h-4 w-4 shrink-0 transition-all duration-500 ease-in-out",
                 showLabel && "mr-2",
                 !showLabel && "mr-0!"
               )}
             />
           )}
-          {badge}
           {showDot && (
             <span className="absolute top-1.5 right-1.5 w-2 h-2 bg-orange-500 dark:bg-orange-400 border-2 border-white dark:border-zinc-900 rounded-full transition-opacity duration-300 z-10 animate-status-pulse-orange" />
           )}
           <span
             className={cn(
-              "transition-all duration-500 ease-in-out overflow-hidden",
+              "min-w-0 transition-all duration-500 ease-in-out overflow-hidden",
               showLabel ? "w-auto opacity-100" : "w-0 opacity-0"
             )}
           >
             {children}
           </span>
+          {badge}
         </button>
       </ConditionalTooltip>
     );

--- a/libraries/typescript/packages/inspector/src/client/components/ui/tabs.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ui/tabs.tsx
@@ -279,6 +279,8 @@ interface TabsTriggerProps {
   showDot?: boolean;
   /** When true, the label stays visible even when the tab bar is collapsed */
   alwaysExpanded?: boolean;
+  /** Optional badge element rendered next to the icon, always visible even when collapsed */
+  badge?: React.ReactNode;
 }
 
 // conditional tooltip wrapper if collapsed
@@ -328,6 +330,7 @@ const TabsTrigger = React.forwardRef<
       title: titleProp,
       showDot = false,
       alwaysExpanded = false,
+      badge,
       ...props
     },
     ref
@@ -378,6 +381,7 @@ const TabsTrigger = React.forwardRef<
               )}
             />
           )}
+          {badge}
           {showDot && (
             <span className="absolute top-1.5 right-1.5 w-2 h-2 bg-orange-500 dark:bg-orange-400 border-2 border-white dark:border-zinc-900 rounded-full transition-opacity duration-300 z-10 animate-status-pulse-orange" />
           )}


### PR DESCRIPTION
- Updated tab switch animation duration from 500ms to 250ms
- 500ms felt a bit heavy during repeated tab switching
- 250ms feels smoother while keeping the interaction responsive