### PR TITLE
Improve tab switch animation timing

### DIFF
--- a/libraries/typescript/.changeset/improve-tab-animation-duration.md
+++ b/libraries/typescript/.changeset/improve-tab-animation-duration.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Improve tab switch animation timing for snappier UI

--- a/libraries/typescript/packages/inspector/src/client/components/ui/tabs.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ui/tabs.tsx
@@ -256,7 +256,7 @@ function TabsList({
           <span
             ref={indicatorRef}
             className={cn(
-              "absolute transition-all duration-500 ease-in-out z-0",
+              "absolute transition-all duration-[250ms] ease-in-out z-0",
               variant === "default" &&
                 "bg-white dark:bg-zinc-700 rounded-full h-[calc(100%)] top-0 border border-zinc-300 dark:border-zinc-600",
               variant === "underline" && "bottom-0 h-0.5 bg-black dark:bg-white"
@@ -360,7 +360,7 @@ const TabsTrigger = React.forwardRef<
           aria-selected={isActive ? "true" : "false"}
           title={title}
           className={cn(
-            "relative z-10 flex-1 inline-flex items-center justify-center whitespace-nowrap text-sm font-medium ring-offset-background transition-all duration-500 ease-in-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 cursor-pointer",
+            "relative z-10 flex-1 inline-flex items-center justify-center whitespace-nowrap text-sm font-medium ring-offset-background transition-all duration-[250ms] ease-in-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 cursor-pointer",
             variant === "default" && "py-2.5",
             variant === "default" && "rounded-md px-4",
             variant === "underline" &&
@@ -374,7 +374,7 @@ const TabsTrigger = React.forwardRef<
           {Icon && (
             <Icon
               className={cn(
-                "h-4 w-4 shrink-0 transition-all duration-500 ease-in-out",
+                "h-4 w-4 shrink-0 transition-all duration-[250ms] ease-in-out",
                 showLabel && "mr-2",
                 !showLabel && "mr-0!"
               )}
@@ -385,7 +385,7 @@ const TabsTrigger = React.forwardRef<
           )}
           <span
             className={cn(
-              "min-w-0 transition-all duration-500 ease-in-out overflow-hidden",
+              "min-w-0 transition-all duration-[250ms] ease-in-out overflow-hidden",
               showLabel ? "w-auto opacity-100" : "w-0 opacity-0"
             )}
           >


### PR DESCRIPTION
- Updated tab switch animation duration from 500ms to 250ms
- 500ms felt a bit heavy during repeated tab switching
- 250ms feels smoother while keeping the interaction responsive