### PR TITLE
fix(inspector): stop ToolInputForm from mutating live tool inputSchema

### DIFF
--- a/libraries/typescript/.changeset/fix-inspector-tool-schema-mutation.md
+++ b/libraries/typescript/.changeset/fix-inspector-tool-schema-mutation.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Fix Inspector chat sending an invalid tool `input_schema` to LLM providers after a tool was opened in the Tools tab. `ToolInputForm` was writing `required: boolean` onto each property of the live tool inputSchema during render; that's not valid JSON Schema (`required` belongs on the parent as a `string[]`), and Anthropic's draft 2020-12 validator rejected it with `tools.0.custom.input_schema invalid`. The render now uses a local `isRequired` and no longer mutates the schema.

--- a/libraries/typescript/packages/inspector/src/client/components/tools/ToolInputForm.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/tools/ToolInputForm.tsx
@@ -88,7 +88,6 @@ export function ToolInputForm({
           description?: string;
           nullable?: boolean;
         };
-        // Don't write onto `resolvedProp` — it aliases the live tool inputSchema.
         const isRequired = requiredFields.includes(key);
 
         // Get the current value and convert to string for display

--- a/libraries/typescript/packages/inspector/src/client/components/tools/ToolInputForm.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/tools/ToolInputForm.tsx
@@ -88,11 +88,7 @@ export function ToolInputForm({
           description?: string;
           nullable?: boolean;
         };
-        // Don't write `required` onto the property — `resolvedProp` aliases
-        // the live tool inputSchema, and `required` belongs on the parent
-        // schema as a string[], not on properties as a boolean. Mutating it
-        // here corrupts the schema for downstream consumers (e.g. the chat
-        // tab's request to Anthropic, which rejects it under draft 2020-12).
+        // Don't write onto `resolvedProp` — it aliases the live tool inputSchema.
         const isRequired = requiredFields.includes(key);
 
         // Get the current value and convert to string for display

--- a/libraries/typescript/packages/inspector/src/client/components/tools/ToolInputForm.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/tools/ToolInputForm.tsx
@@ -86,10 +86,14 @@ export function ToolInputForm({
           enum?: string[];
           enumNames?: string[];
           description?: string;
-          required?: boolean;
           nullable?: boolean;
         };
-        typedProp.required = requiredFields.includes(key);
+        // Don't write `required` onto the property — `resolvedProp` aliases
+        // the live tool inputSchema, and `required` belongs on the parent
+        // schema as a string[], not on properties as a boolean. Mutating it
+        // here corrupts the schema for downstream consumers (e.g. the chat
+        // tab's request to Anthropic, which rejects it under draft 2020-12).
+        const isRequired = requiredFields.includes(key);
 
         // Get the current value and convert to string for display
         const currentValue = toolArgs[key];
@@ -127,7 +131,7 @@ export function ToolInputForm({
               <div className="flex items-center justify-between gap-2">
                 <Label htmlFor={key} className="text-sm font-medium">
                   {key}
-                  {typedProp?.required && (
+                  {isRequired && (
                     <span className="text-red-500 ml-1">*</span>
                   )}
                 </Label>
@@ -182,7 +186,7 @@ export function ToolInputForm({
             <div key={key} className="space-y-2">
               <Label htmlFor={key} className="text-sm font-medium">
                 {key}
-                {typedProp.required && (
+                {isRequired && (
                   <span className="text-red-500 ml-1">*</span>
                 )}
               </Label>
@@ -222,7 +226,7 @@ export function ToolInputForm({
             <div className="flex items-center justify-between gap-2">
               <Label htmlFor={key} className="text-sm font-medium">
                 {key}
-                {typedProp?.required && (
+                {isRequired && (
                   <span className="text-red-500 ml-1">*</span>
                 )}
               </Label>

--- a/libraries/typescript/packages/inspector/src/client/components/tools/ToolInputForm.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/tools/ToolInputForm.tsx
@@ -126,9 +126,7 @@ export function ToolInputForm({
               <div className="flex items-center justify-between gap-2">
                 <Label htmlFor={key} className="text-sm font-medium">
                   {key}
-                  {isRequired && (
-                    <span className="text-red-500 ml-1">*</span>
-                  )}
+                  {isRequired && <span className="text-red-500 ml-1">*</span>}
                 </Label>
                 {showSendEmptyToggle && onToggleEmpty && (
                   <div className="flex items-center gap-2 shrink-0">
@@ -181,9 +179,7 @@ export function ToolInputForm({
             <div key={key} className="space-y-2">
               <Label htmlFor={key} className="text-sm font-medium">
                 {key}
-                {isRequired && (
-                  <span className="text-red-500 ml-1">*</span>
-                )}
+                {isRequired && <span className="text-red-500 ml-1">*</span>}
               </Label>
               <Select
                 value={String(toolArgs[key] || "")}
@@ -221,9 +217,7 @@ export function ToolInputForm({
             <div className="flex items-center justify-between gap-2">
               <Label htmlFor={key} className="text-sm font-medium">
                 {key}
-                {isRequired && (
-                  <span className="text-red-500 ml-1">*</span>
-                )}
+                {isRequired && <span className="text-red-500 ml-1">*</span>}
               </Label>
               {showSendEmptyToggle && onToggleEmpty && (
                 <div className="flex items-center gap-2 shrink-0">


### PR DESCRIPTION
## Summary
- Inspector chat was failing with `Anthropic 400: tools.0.custom.input_schema invalid (must match JSON Schema draft 2020-12)` after any tool had been opened in the Tools tab.
- Root cause: `ToolInputForm` was writing `required: boolean` onto each property of the live tool inputSchema during render (`typedProp.required = requiredFields.includes(key)`). `resolvedProp` aliases the object inside `connection.tools[i].inputSchema.properties[key]`, so the mutation persisted across the chat path. Per-property `required: boolean` is not valid JSON Schema — `required` belongs on the parent object as a `string[]` — and Anthropic's strict validator rejects it. OpenAI's strict validators reject the same shape.
- Fix: replace the mutation with a local `const isRequired = requiredFields.includes(key)` and use that in the three `*`-indicator render sites. No more writes to the live schema.

## Repro (before fix)
1. Open Inspector with the MCP Apps demo auto-connected.
2. Open the Tools tab and select any tool with a required input (e.g. `get-weather`).
3. Switch to the Chat tab and send any message (e.g. "hi").
4. Chat fails with the 400 above.

After the fix, the same flow succeeds.

## Test plan
- [x] TypeScript compile (both client and server tsconfigs).
- [ ] Manual: open Tools tab → select `get-weather` → switch to Chat → send "hi" with Anthropic + OpenAI providers; both succeed.
- [ ] Manual: required `*` indicator still renders correctly in `ToolInputForm` for string, object/array, and enum fields.

## Notes
- Patch changeset bumps `@mcp-use/inspector` only.
- Existing in-memory `connection.tools` references from prior sessions stay corrupted until a page refresh re-fetches the tools list; no fix needed in code, just user-facing awareness.

Fixes MCP-1970.