### PR TITLE
fix(server/inspector): normalize 0.0.0.0 to localhost in autoConnect URL

### DIFF
--- a/libraries/typescript/.changeset/fix-inspector-autoconnect-loopback.md
+++ b/libraries/typescript/.changeset/fix-inspector-autoconnect-loopback.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Fix OAuth-protected `mcp-use dev` flows by normalizing `0.0.0.0` and `::` to `localhost` in the inspector's autoConnect URL, so it matches the resource metadata published by `getServerBaseUrl()` and passes the SDK's strict origin check.

--- a/libraries/typescript/packages/mcp-use/src/server/inspector/mount.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/inspector/mount.ts
@@ -55,9 +55,18 @@ export async function mountInspectorUI(
   try {
     // @ts-ignore - Optional peer dependency, may not be installed during build
     const { mountInspector } = await import("@mcp-use/inspector");
+    // 0.0.0.0 is valid for binding but browsers can't resolve it as a
+    // destination, and the SDK's OAuth resource validator does strict
+    // origin equality — so an autoConnect URL of http://0.0.0.0:PORT/mcp
+    // mismatches the resource metadata published as http://localhost:PORT
+    // (which goes through `normalizeUrlHost` in server-helpers.ts).
+    const hostForBrowser =
+      serverHost === "0.0.0.0" || serverHost === "::"
+        ? "localhost"
+        : serverHost;
     // Auto-connect to the local MCP server at /mcp (SSE endpoint)
     // Use JSON config to specify SSE transport type
-    const mcpUrl = `http://${serverHost}:${serverPort}/mcp`; // Also available at /sse
+    const mcpUrl = `http://${hostForBrowser}:${serverPort}/mcp`; // Also available at /sse
     const autoConnectConfig = JSON.stringify({
       url: mcpUrl,
       name: "Local MCP Server",
@@ -73,7 +82,7 @@ export async function mountInspectorUI(
       serverPort: typeof serverPort === "number" ? serverPort : undefined,
     });
     console.log(
-      `[INSPECTOR] UI available at http://${serverHost}:${serverPort}/inspector`
+      `[INSPECTOR] UI available at http://${hostForBrowser}:${serverPort}/inspector`
     );
     return true;
   } catch (err) {


### PR DESCRIPTION
Closes #1551.

## What

The inspector's autoConnect URL is built from raw `serverHost`, while the OAuth `resource` metadata is built via `getServerBaseUrl()` which already normalizes `0.0.0.0` → `localhost` (see [`server-helpers.ts:157`](https://github.com/mcp-use/mcp-use/blob/main/libraries/typescript/packages/mcp-use/src/server/utils/server-helpers.ts#L157)). The SDK's `checkResourceAllowed` does strict origin equality, so the two paths disagree and OAuth-protected `mcp-use dev` apps fail at the inspector's post-callback validation:

```
Protected resource http://localhost:3000 does not match expected http://0.0.0.0:3000/mcp (or origin)
```

This applies the same normalization at `inspector/mount.ts:60`, so the autoConnect URL and the user-visible banner both use the browser-reachable host.

## Why

- Browsers can't resolve `0.0.0.0` as a destination — already documented in the framework's own `normalizeUrlHost` helper.
- The mismatch silently breaks every OAuth-enabled `mcp-use dev` smoke test in the inspector. Token issuance succeeds (`[OAuthCallback] Authorization successful`), but no token is ever attached.
- The framework already treats `0.0.0.0` and `localhost` as equivalent in two other places ([`shared-routes.ts:198`](https://github.com/mcp-use/mcp-use/blob/main/libraries/typescript/packages/inspector/src/server/shared-routes.ts#L198), [`LayoutHeader.tsx:165`](https://github.com/mcp-use/mcp-use/blob/main/libraries/typescript/packages/inspector/src/client/components/LayoutHeader.tsx#L165)) — this just adds the OAuth path.

## How

One-line normalization at the top of `mountInspectorUI`'s try block; both the autoConnect URL and the banner log read from `hostForBrowser`.

```ts
const hostForBrowser =
  serverHost === "0.0.0.0" || serverHost === "::"
    ? "localhost"
    : serverHost;
```

I deliberately kept this inline rather than importing/exporting `normalizeUrlHost` from `server-helpers.ts` — the existing helper is `function` (not `export`), and exporting it felt out of scope for a behavior fix. Happy to refactor to a shared export if preferred.

## Test plan

- [x] Reproduce against [mcp-use-apps/apps/auth-template](https://github.com/polae/mcp-use-apps/tree/auth-template/apps/auth-template) on `main`: fails with the validation error.
- [x] Apply this fix locally, repeat the flow: branded sign-in renders, Google sign-in completes, callback exchanges code, token is attached, no validation error.
- [ ] CI (workflow runs after submit).

---

cc @pietrozullo @khandrew1 — pairs with #1551; please tag with `steven`.
