### PR TITLE
perf(server-manager): prefetch tools/resources/prompts concurrently w…

### DIFF
--- a/libraries/python/mcp_use/agents/managers/server_manager.py
+++ b/libraries/python/mcp_use/agents/managers/server_manager.py
@@ -1,3 +1,5 @@
+from asyncio import gather
+
 from langchain_core.tools import BaseTool
 
 from mcp_use.agents.adapters.base import BaseAdapter
@@ -62,9 +64,11 @@ class ServerManager(BaseServerManager):
                 # Fetch tools, resources, and prompts if session is available
                 if session:
                     connector = session.connector
-                    tools = await self.adapter._create_tools_from_connectors([connector])
-                    resources = await self.adapter._create_resources_from_connectors([connector])
-                    prompts = await self.adapter._create_prompts_from_connectors([connector])
+                    tools, resources, prompts = await gather(
+                        self.adapter._create_tools_from_connectors([connector]),
+                        self.adapter._create_resources_from_connectors([connector]),
+                        self.adapter._create_prompts_from_connectors([connector]),
+                    )
                     all_tools = tools + resources + prompts
 
                     # Check if this server's tools have changed


### PR DESCRIPTION
  # Pull Request Description                                                                                                                                                         
   
  ## Language / Project Scope                                                                                                                                                        
                       
  Check all that apply:                                                                                                                                                              
  - [ ] TypeScript     
  - [x] Python
  - [ ] Documentation only
  - [ ] CI/CD or tooling
                                                                                                                                                                                     
  ## Changes
                                                                                                                                                                                     
  Parallelize the per-server prefetch of tools, resources, and prompts inside
  `ServerManager.initialize` using `asyncio.gather`. Previously the three calls
  ran sequentially, so startup latency scaled with the sum of all three                                                                                                              
  round-trips per server. They are now awaited concurrently.                                                                                                                         
                                                                                                                                                                                     
  ## Implementation Details                                                                                                                                                          
                       
  1. Replaced three sequential `await self.adapter._create_*_from_connectors([connector])`                                                                                           
     calls in `libraries/python/mcp_use/agents/managers/server_manager.py` with a single
     `await gather(...)` that issues all three in parallel.                                                                                                                          
  2. Added `from asyncio import gather` at the top of the module.
  3. No public API changes; behavior is identical aside from concurrency. No                                                                                                         
     new dependencies. 
                                                                                                                                                                                     
  ---                  
                                                                                                                                                                                     
  ## TypeScript Checklist

  > Not applicable — Python-only change.

  ### Packages Modified
  - [ ] `docs`
  - [ ] `tests`                                                                                                                                                                      
  - [ ] `cli`
  - [ ] `create-mcp-use-app`                                                                                                                                                         
  - [ ] `mcp-use` (server)                               
  - [ ] `mcp-use` (client)
  - [ ] `inspector`                                                                                                                                                                  
   
  ### Pre-commit Checklist                                                                                                                                                           
  - [ ] Ran `pnpm lint:fix`                              
  - [ ] Ran `pnpm format`
  - [ ] Ran `pnpm build`                                                                                                                                                             
  - [ ] Ran `pnpm changeset`
  - [ ] Added or updated tests if needed                                                                                                                                             
  - [ ] Updated documentation in `docs/` folder if needed
                                                                                                                                                                                     
  ---
                                                                                                                                                                                     
  ## Python Checklist                                    

  ### Pre-commit Checklist
  - [x] Code formatted with `ruff format`
  - [x] Linting passes with `ruff check`
  - [x] Added or updated tests if needed (existing unit tests in `tests/unit` still pass — 305 passed)                                                                               
  - [ ] Updated documentation if needed (no user-facing API changes)                                                                                                                 
                                                                                                                                                                                     
  ---                                                                                                                                                                                
                                                         
  ## Example Usage (Before)                                                                                                                                                          
   
  ```python                                                                                                                                                                          
  # Inside ServerManager.initialize (sequential)         
  tools = await self.adapter._create_tools_from_connectors([connector])
  resources = await self.adapter._create_resources_from_connectors([connector])
  prompts = await self.adapter._create_prompts_from_connectors([connector])                                                                                                          
  ```
  Example Usage (After)                                                                                                                                                              
```python                                                                  
  # Inside ServerManager.initialize (concurrent)
  tools, resources, prompts = await gather(                                                                                                                                          
      self.adapter._create_tools_from_connectors([connector]),
      self.adapter._create_resources_from_connectors([connector]),                                                                                                                   
      self.adapter._create_prompts_from_connectors([connector]),                                                                                                                     
  )
  ```                                                                                                                                                                         
  End-user usage of MCPAgent / ServerManager is unchanged — only the internal                                                                                                        
  initialization is faster.
                                                                                                                                                                                     
###   Documentation Updates                                  

  - None — this is a pure performance/internal change with no public API or                                                                                                          
  behavioral differences.
                                                                                                                                                                                     
###   Testing                                                

  - Ran the full Python unit test suite from libraries/python with the venv                                                                                                          
  pytest: 305 passed, 36 warnings in 30.02s.
  - No new tests added: the change is a pure concurrency refactor of three                                                                                                           
  awaits that were already individually covered by existing ServerManager                                                                                                            
  tests. Behavior (return values, ordering of tools + resources + prompts,                                                                                                           
  change-detection logic) is preserved.                                                                                                                                              
  - Edge cases considered:                                                                                                                                                           
    - Exception in any one of the three calls: gather will propagate the                                                                                                             
  first raised exception, matching the prior sequential await behavior
  where the first failing call aborted initialization.                                                                                                                               
    - Empty results from any branch: unchanged, list concatenation still
  yields a valid all_tools list.                                                                                                                                                     
                                                         
###   Backwards Compatibility                                                                                                                                                            
                                                         
  Fully backwards compatible. No public API signatures, return types, or                                                                                                             
  observable behavior changed — only the internal scheduling of three
  already-existing awaits.                                                                                                                                                           
                                                         
###   Related Issues                                                                                                                                                                     
                                                         
  Closes #1542