### PR TITLE
fix(inspector): add copy button to user messages

### DIFF
--- a/libraries/typescript/.changeset/silver-ravens-type.md
+++ b/libraries/typescript/.changeset/silver-ravens-type.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Add a copy button to user messages in the inspector chat.

--- a/libraries/typescript/packages/inspector/src/client/components/chat/AssistantMessage.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/AssistantMessage.tsx
@@ -1,37 +1,5 @@
-import { Check, Copy } from "lucide-react";
-import { useState } from "react";
 import { MarkdownRenderer } from "@/client/components/shared/MarkdownRenderer";
-import { copyToClipboard } from "@/client/utils/clipboard";
-
-/**
- * Button that copies the provided text to the clipboard and shows a brief visual confirmation.
- *
- * @param text - The string content to copy when the button is clicked.
- * @returns A button element that copies `text` to the clipboard and displays a check icon for two seconds after a successful copy.
- */
-function CopyButton({ text }: { text: string }) {
-  const [isCopied, setIsCopied] = useState(false);
-
-  const handleCopy = async () => {
-    await copyToClipboard(text);
-    setIsCopied(true);
-    setTimeout(() => setIsCopied(false), 2000);
-  };
-
-  return (
-    <button
-      className="opacity-0 group-hover/message:opacity-100 transition-opacity text-muted-foreground hover:text-foreground text-xs flex items-center gap-1"
-      onClick={handleCopy}
-      title="Copy message content"
-    >
-      {isCopied ? (
-        <Check className="h-3.5 w-3.5" />
-      ) : (
-        <Copy className="h-3.5 w-3.5" />
-      )}
-    </button>
-  );
-}
+import { CopyButton } from "./CopyButton";
 
 export interface AssistantMessageProps {
   content: string;

--- a/libraries/typescript/packages/inspector/src/client/components/chat/CopyButton.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/CopyButton.tsx
@@ -1,0 +1,34 @@
+import { Check, Copy } from "lucide-react";
+import { useState } from "react";
+import { copyToClipboard } from "@/client/utils/clipboard";
+
+/**
+ * Button that copies the provided text to the clipboard and shows a brief visual confirmation.
+ *
+ * @param text - The string content to copy when the button is clicked.
+ * @returns A button element that copies `text` to the clipboard and displays a check icon for two seconds after a successful copy.
+ */
+export function CopyButton({ text }: { text: string }) {
+  const [isCopied, setIsCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await copyToClipboard(text);
+    setIsCopied(true);
+    setTimeout(() => setIsCopied(false), 2000);
+  };
+
+  return (
+    <button
+      className="opacity-0 group-hover/message:opacity-100 transition-opacity text-muted-foreground hover:text-foreground text-xs flex items-center gap-1"
+      onClick={handleCopy}
+      title="Copy message content"
+      data-testid="copy-button"
+    >
+      {isCopied ? (
+        <Check className="h-3.5 w-3.5" />
+      ) : (
+        <Copy className="h-3.5 w-3.5" />
+      )}
+    </button>
+  );
+}

--- a/libraries/typescript/packages/inspector/src/client/components/chat/UserMessage.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/UserMessage.tsx
@@ -1,3 +1,4 @@
+import { CopyButton } from "./CopyButton";
 import type { MessageAttachment } from "./types";
 
 interface UserMessageProps {
@@ -56,9 +57,12 @@ export function UserMessage({
         </div>
 
         {timestamp && (
-          <span className="text-xs text-muted-foreground mt-1">
-            {new Date(timestamp).toLocaleTimeString()}
-          </span>
+          <div className="flex items-center gap-2 mt-2">
+            <CopyButton text={content} />
+            <span className="text-xs text-muted-foreground">
+              {new Date(timestamp).toLocaleTimeString()}
+            </span>
+          </div>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary

Extract `CopyButton` into a shared component (`chat/CopyButton.tsx`) and add it to `UserMessage`, matching the existing assistant message UX.

Resolves #1555

## Changes

- **New `CopyButton.tsx`**: extracted from `AssistantMessage.tsx`, exported as a reusable component with `data-testid="copy-button"`
- **Updated `AssistantMessage.tsx`**: now imports `CopyButton` from the shared component (no behavior change)
- **Updated `UserMessage.tsx`**: added `CopyButton` next to the timestamp, outside the chat bubble, mirroring the assistant layout

## Testing

- [x] Manual: copy button appears on user message hover
- [x] Manual: click copies text and shows checkmark for ~2s
- [ ] Automated e2e test to be added

## Acceptance criteria (from #1555)

- [x] User messages have a copy button; clicking copies the message text.
- [x] Assistant copy button continues to work unchanged.
- [x] The two messages share a single `CopyButton` implementation.
