### PR TITLE
feat: add publicLandingPage option to expose MCP landing page without auth

### DIFF
--- a/libraries/typescript/packages/inspector/src/client/components/ChatTab.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ChatTab.tsx
@@ -12,6 +12,7 @@ import React, {
   useState,
 } from "react";
 import { toast } from "sonner";
+import { ChevronDown } from "lucide-react";
 import { copyToClipboard } from "../utils/clipboard";
 import { downloadJSON } from "../utils/jsonUtils";
 import { useKeyboardShortcuts } from "../hooks/useKeyboardShortcuts";
@@ -146,6 +147,22 @@ export function ChatTab({
   const messagesAreaRef = useRef<HTMLDivElement | null>(null);
   // Track position of trigger for removal in textarea
   const triggerSpanRef = useRef<{ start: number; end: number } | null>(null);
+  const [isAtBottom, setIsAtBottom] = useState(true);
+
+  const handleScroll = useCallback(() => {
+    const el = messagesAreaRef.current;
+    if (!el) return;
+    const threshold = 80; // px from bottom considered "at bottom"
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < threshold;
+    setIsAtBottom(atBottom);
+  }, []);
+
+  const scrollToBottom = useCallback(() => {
+    messagesAreaRef.current?.scrollTo({
+      top: messagesAreaRef.current.scrollHeight,
+      behavior: "smooth",
+    });
+  }, []);
 
   const toolInfos: ToolInfo[] = useMemo(
     () =>
@@ -1119,7 +1136,8 @@ export function ChatTab({
       {/* Messages Area */}
       <div
         ref={messagesAreaRef}
-        className="flex-1 overflow-y-auto p-2 sm:p-4 pt-[80px] sm:pt-[100px]"
+        className="flex-1 overflow-y-auto p-2 sm:p-4 pt-[80px] sm:pt-[100px] relative"
+        onScroll={handleScroll}
       >
         {!llmConfig ? (
           <ConfigureEmptyState
@@ -1138,6 +1156,18 @@ export function ChatTab({
             onApproveElicitation={connection.approveElicitation}
             onRejectElicitation={connection.rejectElicitation}
           />
+        )}
+
+        {/* Scroll to bottom button — shown when user has scrolled up */}
+        {!isAtBottom && (
+          <button
+            onClick={scrollToBottom}
+            className="absolute bottom-4 right-4 sm:bottom-6 sm:right-6 w-10 h-10 rounded-full bg-background border shadow-md flex items-center justify-center text-foreground hover:bg-muted transition-colors"
+            title="Scroll to bottom"
+            data-testid="scroll-to-bottom"
+          >
+            <ChevronDown className="h-5 w-5" />
+          </button>
         )}
       </div>
 

--- a/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
@@ -3905,7 +3905,8 @@ class MCPServerClass<HasOAuth extends boolean = false> {
         this.app,
         this.oauthProvider,
         this.getServerBaseUrl(),
-        this.oauthSetupState
+        this.oauthSetupState,
+        { publicLandingPage: this.publicLandingPage }
       );
     }
 
@@ -4034,7 +4035,8 @@ class MCPServerClass<HasOAuth extends boolean = false> {
         this.app,
         this.oauthProvider,
         this.getServerBaseUrl(),
-        this.oauthSetupState
+        this.oauthSetupState,
+        { publicLandingPage: this.publicLandingPage }
       );
     }
 

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/index.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/index.ts
@@ -54,4 +54,8 @@ export {
 export type { AuthInfo } from "./utils.js";
 
 // Export setup
-export { setupOAuthForServer, type OAuthSetupState } from "./setup.js";
+export {
+  setupOAuthForServer,
+  type OAuthSetupState,
+  type OAuthSetupOptions,
+} from "./setup.js";

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/setup.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/setup.ts
@@ -20,6 +20,14 @@ export interface OAuthSetupState {
 }
 
 /**
+ * Options for OAuth setup
+ */
+export interface OAuthSetupOptions {
+  /** When true, the landing page at /mcp is accessible without authentication */
+  publicLandingPage?: boolean;
+}
+
+/**
  * Setup OAuth authentication for MCP server
  *
  * Initializes OAuth provider/proxy, creates bearer auth middleware,
@@ -39,7 +47,8 @@ export async function setupOAuthForServer(
   app: HonoType,
   oauth: OAuthProvider | OAuthProxy,
   baseUrl: string,
-  state: OAuthSetupState
+  state: OAuthSetupState,
+  options?: OAuthSetupOptions
 ): Promise<OAuthSetupState> {
   if (state.complete) {
     return state; // Already setup
@@ -49,7 +58,34 @@ export async function setupOAuthForServer(
   console.log(`[OAuth] OAuth ${proxyMode ? "proxy" : "provider"} initialized`);
 
   // Create bearer auth middleware with baseUrl for WWW-Authenticate header
-  const middleware = createBearerAuthMiddleware(oauth, baseUrl);
+  let middleware = createBearerAuthMiddleware(oauth, baseUrl);
+
+  // If publicLandingPage is enabled, wrap the middleware to skip auth for
+  // browser GET requests to /mcp (the landing page)
+  if (options?.publicLandingPage) {
+    const originalMiddleware = middleware;
+    middleware = async (c: Context, next: Next) => {
+      // Check if this is a browser GET request to /mcp (landing page)
+      if (
+        c.req.method === "GET" &&
+        c.req.path === "/mcp"
+      ) {
+        const accept = c.req.header("Accept") || "";
+        // Detect browser: accepts HTML and not JSON/SSE
+        const isBrowser =
+          accept.includes("text/html") ||
+          (!accept.includes("application/json") &&
+            !accept.includes("text/event-stream"));
+        if (isBrowser) {
+          // Skip auth for public landing page
+          return next();
+        }
+      }
+      // All other requests require auth
+      return originalMiddleware(c, next);
+    };
+    console.log("[OAuth] Landing page will be served without authentication");
+  }
 
   // Setup OAuth routes
   setupOAuthRoutes(app, oauth, baseUrl);

--- a/libraries/typescript/packages/mcp-use/src/server/types/common.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/types/common.ts
@@ -288,6 +288,29 @@ export interface ServerConfig {
    */
   oauth?: OAuthProvider;
   /**
+   * Expose the MCP landing page publicly when OAuth is enabled.
+   *
+   * When set to `true`, the landing page at `/mcp` will be accessible without
+   * authentication. This is useful when you want users to discover the MCP
+   * server's capabilities before signing in (e.g., to see available tools,
+   * prompts, and resources).
+   *
+   * When `false` (default), all `/mcp/*` routes require Bearer authentication.
+   *
+   * @default false
+   *
+   * @example
+   * ```typescript
+   * const server = new MCPServer({
+   *   name: 'my-server',
+   *   version: '1.0.0',
+   *   oauth: oauthAuth0Provider({ ... }),
+   *   publicLandingPage: true // Landing page accessible without login
+   * });
+   * ```
+   */
+  publicLandingPage?: boolean;
+  /**
    * Path to favicon file relative to public directory
    *
    * The favicon will be automatically included in all widget pages.


### PR DESCRIPTION
## Summary

When OAuth is enabled, the landing page at `/mcp` was inaccessible without authentication because all `/mcp/*` routes were protected.

This PR adds a `publicLandingPage` option to `ServerConfig` that, when set to `true`, exposes the landing page publicly while keeping other routes protected.

## Changes

- **`ServerConfig`**: Added `publicLandingPage?: boolean` option with full JSDoc documentation
- **`setupOAuthForServer`**: Added `OAuthSetupOptions` parameter with `publicLandingPage` support
- **`mcp-server.ts`**: Updated both call sites to pass `publicLandingPage` config

## Usage

```typescript
const server = new MCPServer({
  name: my-server,
  version: 1.0.0,
  oauth: oauthAuth0Provider({ ... }),
  publicLandingPage: true // Landing page accessible without login
});
```

## Fixes

Fixes #1549