### PR TITLE
fix(cli): align widget Vite base with /mcp-use/widgets

### DIFF
--- a/libraries/typescript/.changeset/fix-cli-widget-base-mcp-url.md
+++ b/libraries/typescript/.changeset/fix-cli-widget-base-mcp-url.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/cli": patch
+---
+
+Fix widget asset 404s when `MCP_URL` is set at build time. Vite's `base` and the injected `window.__getFile` now resolve to `${MCP_URL}/mcp-use/widgets/{widget}/`, matching the production static route mounted by the `mcp-use` server.

--- a/libraries/typescript/packages/cli/src/index.ts
+++ b/libraries/typescript/packages/cli/src/index.ts
@@ -36,6 +36,7 @@ import {
   withNextShimsEnv,
 } from "./utils/next-shims.js";
 import { notifyIfUpdateAvailable } from "./utils/update-check.js";
+import { getWidgetAssetBase } from "./utils/widget-paths.js";
 const program = new Command();
 
 const packageContent = readFileSync(
@@ -783,10 +784,7 @@ if (container && Component) {
       widgetName
     );
 
-    // Set base URL: use MCP_URL if set, otherwise relative path
-    const baseUrl = mcpUrl
-      ? `${mcpUrl}/${widgetName}/`
-      : `/mcp-use/widgets/${widgetName}/`;
+    const baseUrl = getWidgetAssetBase(mcpUrl, widgetName);
 
     // Extract metadata from widget before building
     let widgetMetadata: any = {};
@@ -1167,7 +1165,9 @@ export default {
           // Inject window.__mcpPublicUrl and window.__getFile into <head>
           // Note: __mcpPublicUrl uses standard format for useWidget to derive mcp_url
           // __mcpPublicAssetsUrl points to where public files are actually stored
-          const injectionScript = `<script>window.__getFile = (filename) => { return "${mcpUrl}/${widgetName}/"+filename }; window.__mcpPublicUrl = "${mcpServerUrl}/mcp-use/public"; window.__mcpPublicAssetsUrl = "${mcpUrl}/public";</script>`;
+          const widgetAssetBase = getWidgetAssetBase(mcpUrl, widgetName);
+          const mcpOrigin = mcpUrl ? mcpUrl.replace(/\/+$/, "") : mcpServerUrl;
+          const injectionScript = `<script>window.__getFile = (filename) => { return "${widgetAssetBase}"+filename }; window.__mcpPublicUrl = "${mcpServerUrl}/mcp-use/public"; window.__mcpPublicAssetsUrl = "${mcpOrigin}/mcp-use/public";</script>`;
 
           // Check if script tag already exists in head
           if (!html.includes("window.__mcpPublicUrl")) {

--- a/libraries/typescript/packages/cli/src/utils/widget-paths.ts
+++ b/libraries/typescript/packages/cli/src/utils/widget-paths.ts
@@ -1,4 +1,3 @@
-
 export function getWidgetAssetBase(
   mcpUrl: string | undefined,
   widgetName: string

--- a/libraries/typescript/packages/cli/src/utils/widget-paths.ts
+++ b/libraries/typescript/packages/cli/src/utils/widget-paths.ts
@@ -1,0 +1,12 @@
+
+export function getWidgetAssetBase(
+  mcpUrl: string | undefined,
+  widgetName: string
+): string {
+  const widgetPath = `/mcp-use/widgets/${widgetName}/`;
+  if (!mcpUrl) {
+    return widgetPath;
+  }
+  const origin = mcpUrl.replace(/\/+$/, "");
+  return `${origin}${widgetPath}`;
+}


### PR DESCRIPTION
#### changes

- Widget build with MCP_URL now uses /mcp-use/widgets/{widget}/ (matches production).

#### Implementation
- getWidgetAssetBase() in cli/src/utils/widget-paths.ts
- Used for Vite base and __getFile injection

#### Testing

- Build with MCP_URL, run mcp-use start, confirm assets load.

#### Compatibility

- Backward compatible; rebuild if built with old paths.

#### Related Issues
Closes : #1553