### PR TITLE
feat(typescript): configurable basePath for MCPServer

### DIFF
--- a/docs/typescript/server/configuration.mdx
+++ b/docs/typescript/server/configuration.mdx
@@ -37,6 +37,8 @@ const server = new MCPServer({
   host: 'localhost',                    // Bind hostname (default: 'localhost')
   baseUrl: 'https://mcp.example.com',   // Public URL for widget/asset URLs
                                         // Overrides host:port; also read from MCP_URL env var
+  basePath: '/api',                     // Mount all routes under this prefix
+                                        // (MCP transport, inspector, widgets, OAuth)
 
   // ── CORS ───────────────────────────────────────────────────
   cors: {
@@ -65,6 +67,46 @@ await server.listen(3000)
 **Port resolution order:** `listen(port)` argument → `--port` CLI flag → `PORT` env var → `3000`
 
 **Base URL resolution order:** `baseUrl` config → `MCP_URL` env var → `http://{host}:{port}`
+
+### Mounting Under a Path Prefix
+
+Use `basePath` to mount every route the server registers under a single prefix. This is useful when:
+
+- The MCP server lives behind a reverse proxy that strips a path prefix (e.g. `/api/*` routed to one upstream)
+- You want to host the MCP server alongside other routes in the same Hono app under a non-root path
+- You're deploying multiple MCP servers on one origin and need to namespace them
+
+```typescript
+const server = new MCPServer({
+  name: 'my-server',
+  version: '1.0.0',
+  basePath: '/api',
+})
+```
+
+With `basePath: '/api'`, every route the server handles moves under that prefix — including your own custom routes:
+
+| Route | Default | With `basePath: '/api'` |
+|---|---|---|
+| MCP transport (streamable HTTP) | `POST /mcp` | `POST /api/mcp` |
+| MCP transport (SSE) | `GET /sse` | `GET /api/sse` |
+| Inspector UI | `GET /inspector` | `GET /api/inspector` |
+| Widget assets | `/mcp-use/widgets/*` | `/api/mcp-use/widgets/*` |
+| Public assets | `/mcp-use/public/*` | `/api/mcp-use/public/*` |
+| OAuth metadata | `/.well-known/oauth-authorization-server` | `/api/.well-known/oauth-authorization-server` |
+| OAuth endpoints | `/authorize`, `/token`, `/register` | `/api/authorize`, `/api/token`, `/api/register` |
+| Custom route (e.g. `server.app.get('/sign-in', ...)`) | `/sign-in` | `/api/sign-in` |
+
+OAuth discovery metadata (`issuer`, `authorization_endpoint`, `token_endpoint`, `registration_endpoint`, protected-resource URLs) is rebuilt to include the prefix, so standard OAuth 2.1 / RFC 9728 discovery works without extra configuration.
+
+**Rules:**
+- Must start with `/` and must not end with `/`
+- Empty string or `"/"` means "no prefix" (the default)
+- `/favicon.ico` is always served at the root regardless of `basePath`, so browsers' implicit favicon request still resolves
+
+<Note>
+Routes you register on `server.app` (including `server.app.get(...)`, `server.app.use(...)`) automatically live under `basePath`. If you also configure OAuth on the same server (e.g. better-auth at `/api/auth/**`), update the `authURL` / callback URLs you pass to that auth provider to include `basePath` too — clients reaching the server through `basePath` need to discover those endpoints under the same prefix.
+</Note>
 
 ### Environment Variables
 

--- a/libraries/typescript/.changeset/configurable-base-path.md
+++ b/libraries/typescript/.changeset/configurable-base-path.md
@@ -1,0 +1,64 @@
+---
+"mcp-use": minor
+"@mcp-use/cli": minor
+---
+
+Add `basePath` option to `MCPServer` and restructure how the framework owns URL and disk space.
+
+### `basePath` config
+
+When `basePath` is set, all framework routes mount under that prefix:
+
+- MCP transport: `POST ${basePath}/mcp` and `${basePath}/sse`
+- Inspector UI: `GET ${basePath}/inspector`
+- OAuth endpoints: `${basePath}/authorize`, `${basePath}/token`, `${basePath}/register`
+- OAuth metadata: `${basePath}/.well-known/oauth-authorization-server` (RFC 8414 requires the discovery path at the issuer root, so this must live under `basePath`)
+- Bearer-auth middleware and user-registered routes auto-prefix under `basePath`
+- Framework assets: `${basePath}/_mcp-use/widgets/*`, `${basePath}/_mcp-use/public/*`, `${basePath}/favicon.ico`
+
+```typescript
+const server = new MCPServer({
+  name: "my-server",
+  version: "1.0.0",
+  basePath: "/api",
+});
+```
+
+The only routes that stay at the literal host root are the OAuth `.well-known/*` discovery endpoints — those are pinned to the host root by RFC 8414 / RFC 9728. Everything else lives under `basePath`.
+
+### Framework asset namespace
+
+Static framework assets live at `${basePath}/_mcp-use/*`, mirroring how Next.js separates `.next/` ↔ `/_next/`:
+
+| Concern          | URL                                            | Disk                         |
+| ---------------- | ---------------------------------------------- | ---------------------------- |
+| Widget HTML      | `${basePath}/_mcp-use/widgets/{name}`          | `.mcp-use/widgets/{name}/`   |
+| Widget assets    | `${basePath}/_mcp-use/widgets/{name}/assets/*` | same                         |
+| Public assets    | `${basePath}/_mcp-use/public/*`                | `.mcp-use/public/*`          |
+| Favicon          | `${basePath}/favicon.ico`                      | `public/favicon.ico`         |
+| Build manifest   | (not served)                                   | `.mcp-use/manifest.json`     |
+| Server handshake | (not served)                                   | `.mcp-use/server-info.json`  |
+
+This means:
+
+- The legacy `${basePath}/mcp-use/widgets/*` and `${basePath}/mcp-use/public/*` routes are gone — they're now under `_mcp-use/`.
+- `mcp-use build` writes output to `.mcp-use/` instead of `dist/` (widgets to `.mcp-use/widgets/`, public assets to `.mcp-use/public/`, manifest to `.mcp-use/manifest.json`). `dist/` now holds only your own transpiled server code.
+- The HTTP discovery endpoint `/__mcp-use/serverinfo` is removed. `MCPServer.listen()` now writes `.mcp-use/server-info.json` (host, port, basePath, mcpUrl, inspectorUrl) for out-of-process tooling to read.
+- Dev-mode widget temp directories move under `.mcp-use/.tmp/` so every top-level entry in `.mcp-use/` is a framework namespace.
+
+Browsers won't pick up favicons at `${basePath}/favicon.ico` automatically (they only probe the host root). The MCP server's `icons` config — which the SDK exposes via `getServerInfo` — is the authoritative reference for clients that need to display an icon.
+
+### Production widget HTML self-resolves basePath
+
+`mcp-use build` bakes `window.__getFile` and `window.__mcpPublicUrl` into the built widget HTML in a way that *resolves the server's basePath at runtime* from `window.location.pathname`. The same built bundle works whether the server is mounted at `/` or under any `basePath`, with no rebuild needed.
+
+Two related behavior changes:
+
+- **`<base href>` is no longer injected** into widget HTML. If a widget relied on relative URLs resolving against the server origin root, switch to absolute paths (`/mcp`, `/_mcp-use/public/...`) or read `window.__mcpPublicUrl`.
+- **`setupPublicRoutes` is no longer used in production.** The export is still available for embedders that hand-roll their own server but want the dev-mode helper that serves from `./public/`.
+
+Runtime gate: Deno keeps hand-rolled handlers (Deno doesn't load `@hono/node-server`); Node and Bun use `serveStatic`.
+
+### Embedder note
+
+If you mount `getHandler()` inside a larger app at some prefix, `/_mcp-use/` lives at the embedder's mount prefix combined with mcp-use's own `basePath`.

--- a/libraries/typescript/packages/cli/src/index.ts
+++ b/libraries/typescript/packages/cli/src/index.ts
@@ -146,23 +146,48 @@ async function findAvailablePort(
   throw new Error("No available ports found");
 }
 
-// Helper to check if server is ready
+type ServerInfo = {
+  basePath: string;
+};
+
+/**
+ * Best-effort read of `.mcp-use/server-info.json`. The server writes this
+ * file inside the `listen()` callback, so by the time `waitForServer`
+ * resolves it's already on disk.
+ *
+ * Returns `""` on any failure — caller composes URLs as
+ * `http://${host}:${port}${basePath}/mcp`, which degrades to bare `/mcp`
+ * exactly like before basePath existed.
+ */
+async function readServerBasePath(projectPath: string): Promise<string> {
+  try {
+    const filePath = path.join(projectPath, ".mcp-use", "server-info.json");
+    const raw = await readFile(filePath, "utf8");
+    const parsed = JSON.parse(raw);
+    return typeof parsed?.basePath === "string" ? parsed.basePath : "";
+  } catch {
+    return "";
+  }
+}
+
+// Helper to check if server is ready. Polls a known endpoint at the basePath
+// derived from the server-info handshake file (or root, if missing/stale).
 async function waitForServer(
   port: number,
   host: string = "localhost",
+  projectPath: string = process.cwd(),
   maxAttempts = 30
-): Promise<boolean> {
+): Promise<ServerInfo | null> {
   for (let i = 0; i < maxAttempts; i++) {
     const controller = new AbortController();
+    const basePath = await readServerBasePath(projectPath);
     try {
-      // Use /inspector/health endpoint for cleaner health checks
-      // This avoids 400 errors from the MCP endpoint which requires session headers
-      const response = await fetch(`http://${host}:${port}/inspector/health`, {
-        signal: controller.signal,
-      });
-
+      const response = await fetch(
+        `http://${host}:${port}${basePath}/inspector/health`,
+        { signal: controller.signal }
+      );
       if (response.ok) {
-        return true;
+        return { basePath };
       }
     } catch {
       // Server not ready yet
@@ -171,7 +196,7 @@ async function waitForServer(
     }
     await new Promise((resolve) => setTimeout(resolve, 1000));
   }
-  return false;
+  return null;
 }
 
 // Helper to normalize host for browser connections
@@ -705,8 +730,9 @@ async function buildWidgets(
 
     console.log(chalk.gray(`  - Building ${widgetName}...`));
 
-    // Create temp directory for build artifacts
-    const tempDir = path.join(projectPath, ".mcp-use", widgetName);
+    // Create temp directory for build artifacts under `.mcp-use/.tmp/` so it
+    // doesn't collide with framework-owned namespaces (widgets/, public/).
+    const tempDir = path.join(projectPath, ".mcp-use", ".tmp", widgetName);
     await fs.mkdir(tempDir, { recursive: true });
 
     // Create CSS file with Tailwind directives
@@ -752,7 +778,12 @@ if (container && Component) {
 }
 `;
 
-    // Create HTML template
+    // Create HTML template. The favicon href is a *relative* path so it
+    // resolves correctly whether the widget HTML is served at
+    // `/_mcp-use/widgets/<slug>/index.html` (no basePath) or
+    // `${basePath}/_mcp-use/widgets/<slug>/index.html` (basePath set).
+    // `../../public/foo.ico` lands on the same-origin `/_mcp-use/public/`
+    // namespace in both cases.
     const htmlContent = `<!doctype html>
 <html lang="en">
   <head>
@@ -761,7 +792,7 @@ if (container && Component) {
     <title>${widgetName} Widget</title>${
       favicon
         ? `
-    <link rel="icon" href="/mcp-use/public/${favicon}" />`
+    <link rel="icon" href="../../public/${favicon}" />`
         : ""
     }
   </head>
@@ -774,19 +805,14 @@ if (container && Component) {
     await fs.writeFile(path.join(tempDir, "entry.tsx"), entryContent, "utf8");
     await fs.writeFile(path.join(tempDir, "index.html"), htmlContent, "utf8");
 
-    // Build with Vite
-    const outDir = path.join(
-      projectPath,
-      "dist",
-      "resources",
-      "widgets",
-      widgetName
-    );
+    // Build widget output into the framework-owned `.mcp-use/widgets/` tree.
+    const outDir = path.join(projectPath, ".mcp-use", "widgets", widgetName);
 
-    // Set base URL: use MCP_URL if set, otherwise relative path
+    // Set base URL: use MCP_URL if set, otherwise the basePath-agnostic
+    // root namespace `/_mcp-use/widgets/<name>/`.
     const baseUrl = mcpUrl
       ? `${mcpUrl}/${widgetName}/`
-      : `/mcp-use/widgets/${widgetName}/`;
+      : `/_mcp-use/widgets/${widgetName}/`;
 
     // Extract metadata from widget before building
     let widgetMetadata: any = {};
@@ -795,6 +821,7 @@ if (container && Component) {
       const metadataTempDir = path.join(
         projectPath,
         ".mcp-use",
+        ".tmp",
         `${widgetName}-metadata`
       );
       await fs.mkdir(metadataTempDir, { recursive: true });
@@ -1156,54 +1183,62 @@ export default {
         }
       }
 
-      // Post-process HTML for static deployments (e.g., Supabase)
-      // If MCP_SERVER_URL is set, inject window globals at build time
+      // Bake runtime globals into the built HTML so production serving is a
+      // pure static read — no per-request HTML rewriter needed. Mirrors the
+      // Next.js `/_next/` model: build owns transforms, server ships bytes.
+      //
+      // - `__getFile`: asset-URL builder used by Vite's `renderBuiltUrl` hook.
+      //   Defaults to a same-origin path that *resolves the server's
+      //   `basePath` at runtime* from `window.location.pathname` (so the same
+      //   built HTML works whether the server is mounted at `/` or `/api`);
+      //   uses MCP_URL when that points at an external CDN.
+      // - `__mcpPublicUrl`: public-asset prefix. MCP_SERVER_URL roots it
+      //   absolutely for static hosts that need a full origin; otherwise it
+      //   self-resolves basePath the same way as `__getFile`.
+      // - `__mcpPublicAssetsUrl`: where public files are physically stored;
+      //   diverges from `__mcpPublicUrl` only when MCP_URL is a separate CDN.
       const mcpServerUrl = process.env.MCP_SERVER_URL;
-      if (mcpServerUrl) {
-        try {
-          const htmlPath = path.join(outDir, "index.html");
-          let html = await fs.readFile(htmlPath, "utf8");
 
-          // Inject window.__mcpPublicUrl and window.__getFile into <head>
-          // Note: __mcpPublicUrl uses standard format for useWidget to derive mcp_url
-          // __mcpPublicAssetsUrl points to where public files are actually stored
-          const injectionScript = `<script>window.__getFile = (filename) => { return "${mcpUrl}/${widgetName}/"+filename }; window.__mcpPublicUrl = "${mcpServerUrl}/mcp-use/public"; window.__mcpPublicAssetsUrl = "${mcpUrl}/public";</script>`;
+      try {
+        const htmlPath = path.join(outDir, "index.html");
+        let html = await fs.readFile(htmlPath, "utf8");
 
-          // Check if script tag already exists in head
-          if (!html.includes("window.__mcpPublicUrl")) {
-            html = html.replace(
-              /<head[^>]*>/i,
-              `<head>\n    ${injectionScript}`
-            );
-          }
+        const injectionScript = mcpUrl
+          ? // External CDN — fully-qualified URLs; basePath doesn't apply.
+            `<script>window.__getFile = (filename) => { return ${JSON.stringify(`${mcpUrl}/${widgetName}/`)}+filename }; window.__mcpPublicUrl = ${JSON.stringify(
+              mcpServerUrl
+                ? `${mcpServerUrl}/_mcp-use/public`
+                : "/_mcp-use/public"
+            )}; window.__mcpPublicAssetsUrl = ${JSON.stringify(`${mcpUrl}/public`)};</script>`
+          : // Same-origin: resolve basePath at runtime from the widget's URL.
+            // `${basePath}/_mcp-use/widgets/<slug>/index.html` is the page
+            // location, so everything before `/_mcp-use/` is the basePath.
+            `<script>(function(){var p=${
+              mcpServerUrl
+                ? JSON.stringify(mcpServerUrl)
+                : 'window.location.pathname.split("/_mcp-use/")[0]||""'
+            };window.__getFile=function(filename){return p+${JSON.stringify(`/_mcp-use/widgets/${widgetName}/`)}+filename};window.__mcpPublicUrl=p+"/_mcp-use/public";window.__mcpPublicAssetsUrl=p+"/_mcp-use/public";})();</script>`;
 
-          // Update base href if it exists, or inject it
-          if (/<base\s+[^>]*\/?>/i.test(html)) {
-            // Replace existing base tag
-            html = html.replace(
-              /<base\s+[^>]*\/?>/i,
-              `<base href="${mcpServerUrl}">`
-            );
-          } else {
-            // Inject base tag after the injection script
-            html = html.replace(
-              injectionScript,
-              `${injectionScript}\n    <base href="${mcpServerUrl}">`
-            );
-          }
-
-          await fs.writeFile(htmlPath, html, "utf8");
-          console.log(
-            chalk.gray(`    → Injected MCP_SERVER_URL into ${widgetName}`)
-          );
-        } catch (error) {
-          console.warn(
-            chalk.yellow(
-              `    ⚠ Failed to post-process HTML for ${widgetName}:`,
-              error
-            )
+        if (!html.includes("window.__mcpPublicUrl")) {
+          html = html.replace(
+            /<head[^>]*>/i,
+            (match) => `${match}\n    ${injectionScript}`
           );
         }
+
+        // Remove any stray <base> tag — Vite's absolute `base` URL means
+        // relative refs already resolve correctly, and a runtime origin in
+        // <base> would defeat static caching.
+        html = html.replace(/<base\s+[^>]*\/?>\s*/gi, "");
+
+        await fs.writeFile(htmlPath, html, "utf8");
+      } catch (error) {
+        console.warn(
+          chalk.yellow(
+            `    ⚠ Failed to post-process HTML for ${widgetName}:`,
+            error
+          )
+        );
       }
 
       console.log(chalk.green(`    ✓ Built ${widgetName}`));
@@ -1558,7 +1593,7 @@ program
       try {
         await fs.access(publicDir);
         console.log(chalk.gray("Copying public assets..."));
-        await fs.cp(publicDir, path.join(projectPath, "dist", "public"), {
+        await fs.cp(publicDir, path.join(projectPath, ".mcp-use", "public"), {
           recursive: true,
         });
         console.log(chalk.green("✓ Public assets copied"));
@@ -1566,8 +1601,8 @@ program
         // Public folder doesn't exist, skip
       }
 
-      // Create build manifest
-      const manifestPath = path.join(projectPath, "dist", "mcp-use.json");
+      // Create build manifest under the framework-owned `.mcp-use/` tree.
+      const manifestPath = path.join(projectPath, ".mcp-use", "manifest.json");
 
       // Read existing manifest to preserve tunnel subdomain and other fields
       let existingManifest: any = {};
@@ -1697,7 +1732,11 @@ program
 
       if (options.tunnel) {
         try {
-          const manifestPath = path.join(projectPath, "dist", "mcp-use.json");
+          const manifestPath = path.join(
+            projectPath,
+            ".mcp-use",
+            "manifest.json"
+          );
           let existingSubdomain: string | undefined;
 
           try {
@@ -1860,13 +1899,18 @@ program
         if (options.open !== false) {
           const startTime = Date.now();
           const browserHost = normalizeBrowserHost(host);
-          const ready = await waitForServer(port, browserHost);
-          if (ready) {
-            const mcpEndpoint = `http://${browserHost}:${port}/mcp`;
+          const serverInfo = await waitForServer(
+            port,
+            browserHost,
+            projectPath
+          );
+          if (serverInfo) {
+            const basePath = serverInfo.basePath;
+            const mcpEndpoint = `http://${browserHost}:${port}${basePath}/mcp`;
             const autoConnectEndpoint = tunnelUrl
-              ? `${tunnelUrl}/mcp`
+              ? `${tunnelUrl}${basePath}/mcp`
               : mcpEndpoint;
-            const inspectorUrl = `http://${browserHost}:${port}/inspector?autoConnect=${encodeURIComponent(autoConnectEndpoint)}`;
+            const inspectorUrl = `http://${browserHost}:${port}${basePath}/inspector?autoConnect=${encodeURIComponent(autoConnectEndpoint)}`;
 
             const readyTime = Date.now() - startTime;
             console.log(chalk.green.bold(`✓ Ready in ${readyTime}ms`));
@@ -1876,7 +1920,9 @@ program
             console.log(chalk.whiteBright(`Network:  http://${host}:${port}`));
             console.log(chalk.whiteBright(`MCP:      ${mcpEndpoint}`));
             if (tunnelUrl) {
-              console.log(chalk.whiteBright(`Tunnel:   ${tunnelUrl}/mcp`));
+              console.log(
+                chalk.whiteBright(`Tunnel:   ${tunnelUrl}${basePath}/mcp`)
+              );
             }
             console.log(chalk.whiteBright(`Inspector: ${inspectorUrl}\n`));
             await open(inspectorUrl);
@@ -2134,13 +2180,18 @@ program
         // Auto-open inspector if enabled
         if (options.open !== false) {
           const browserHost = normalizeBrowserHost(host);
-          const ready = await waitForServer(port, browserHost);
-          if (ready) {
-            const mcpEndpoint = `http://${browserHost}:${port}/mcp`;
+          const serverInfo = await waitForServer(
+            port,
+            browserHost,
+            projectPath
+          );
+          if (serverInfo) {
+            const basePath = serverInfo.basePath;
+            const mcpEndpoint = `http://${browserHost}:${port}${basePath}/mcp`;
             const autoConnectEndpoint = tunnelUrl
-              ? `${tunnelUrl}/mcp`
+              ? `${tunnelUrl}${basePath}/mcp`
               : mcpEndpoint;
-            const inspectorUrl = `http://${browserHost}:${port}/inspector?autoConnect=${encodeURIComponent(autoConnectEndpoint)}`;
+            const inspectorUrl = `http://${browserHost}:${port}${basePath}/inspector?autoConnect=${encodeURIComponent(autoConnectEndpoint)}`;
 
             const readyTime = Date.now() - startTime;
             console.log(chalk.green.bold(`✓ Ready in ${readyTime}ms`));
@@ -2150,7 +2201,9 @@ program
             console.log(chalk.whiteBright(`Network:  http://${host}:${port}`));
             console.log(chalk.whiteBright(`MCP:      ${mcpEndpoint}`));
             if (tunnelUrl) {
-              console.log(chalk.whiteBright(`Tunnel:   ${tunnelUrl}/mcp`));
+              console.log(
+                chalk.whiteBright(`Tunnel:   ${tunnelUrl}${basePath}/mcp`)
+              );
             }
             console.log(chalk.whiteBright(`Inspector: ${inspectorUrl}`));
             console.log(chalk.gray(`Watching for changes...\n`));
@@ -2434,7 +2487,11 @@ program
         // 2. Start tunnel if requested
         tunnelUrl = undefined;
         if (withTunnel) {
-          const manifestPath = path.join(projectPath, "dist", "mcp-use.json");
+          const manifestPath = path.join(
+            projectPath,
+            ".mcp-use",
+            "manifest.json"
+          );
           let existingSubdomain: string | undefined;
           try {
             const manifestContent = await readFile(manifestPath, "utf-8");
@@ -2476,7 +2533,7 @@ program
 
           // Persist subdomain
           try {
-            const mPath = path.join(projectPath, "dist", "mcp-use.json");
+            const mPath = path.join(projectPath, ".mcp-use", "manifest.json");
             let manifest: any = {};
             try {
               manifest = JSON.parse(await readFile(mPath, "utf-8"));
@@ -2655,7 +2712,11 @@ program
       if (options.tunnel) {
         try {
           // Read existing subdomain from mcp-use.json if available
-          const manifestPath = path.join(projectPath, "dist", "mcp-use.json");
+          const manifestPath = path.join(
+            projectPath,
+            ".mcp-use",
+            "manifest.json"
+          );
           let existingSubdomain: string | undefined;
 
           try {
@@ -2747,7 +2808,7 @@ program
       // Find the built server file
       // First try to read from manifest (set during build)
       let serverFile: string | undefined;
-      const manifestPath = path.join(projectPath, "dist", "mcp-use.json");
+      const manifestPath = path.join(projectPath, ".mcp-use", "manifest.json");
 
       try {
         const manifestContent = await readFile(manifestPath, "utf-8");
@@ -2798,7 +2859,7 @@ program
       if (!serverFile) {
         console.error(
           chalk.red(
-            `No built server file found. Run 'mcp-use build' first.\n\nLooked for:\n  - dist/mcp-use.json (manifest with entryPoint)\n  - dist/index.js\n  - dist/server.js\n  - dist/src/index.js\n  - dist/src/server.js`
+            `No built server file found. Run 'mcp-use build' first.\n\nLooked for:\n  - .mcp-use/manifest.json (manifest with entryPoint)\n  - dist/index.js\n  - dist/server.js\n  - dist/src/index.js\n  - dist/src/server.js`
           )
         );
         process.exit(1);

--- a/libraries/typescript/packages/mcp-use/examples/server/oauth/better-auth/src/auth.ts
+++ b/libraries/typescript/packages/mcp-use/examples/server/oauth/better-auth/src/auth.ts
@@ -15,7 +15,13 @@ import { oauthProvider } from "@better-auth/oauth-provider";
 declare const process: { env: Record<string, string | undefined> };
 
 export const auth = betterAuth({
-  baseURL: "http://localhost:3000",
+  // The mcp-use server is mounted at `/mcp-server`, so everything on
+  // `server.app` (including Better Auth's `/api/auth/**`, the sign-in
+  // page, the consent page, and `validAudiences` below) lives under
+  // that prefix. Reflect it in Better Auth's own `baseURL` so its
+  // self-published authorization endpoints, callbacks, and JWT issuer
+  // all match the externally-visible paths.
+  baseURL: "http://localhost:3000/mcp-server",
   basePath: "/api/auth",
   secret: process.env.BETTER_AUTH_SECRET || "dev-secret-change-in-production",
   socialProviders: {
@@ -33,8 +39,8 @@ export const auth = betterAuth({
       allowUnauthenticatedClientRegistration: true,
       // MCP clients send the resource URL from /.well-known/oauth-protected-resource
       // as the token request's `resource` parameter. Better Auth validates it against
-      // this list. Include the /mcp path.
-      validAudiences: ["http://localhost:3000/mcp"],
+      // this list. The MCP transport lives at `/mcp-server/mcp` externally.
+      validAudiences: ["http://localhost:3000/mcp-server/mcp"],
       // Include user profile claims in the access token JWT so
       // ctx.auth.user.email / .name / .picture are available in MCP tools.
       // Without this, Better Auth only includes standard claims (sub, iss, scope, etc.).

--- a/libraries/typescript/packages/mcp-use/examples/server/oauth/better-auth/src/server.ts
+++ b/libraries/typescript/packages/mcp-use/examples/server/oauth/better-auth/src/server.ts
@@ -26,12 +26,18 @@ import {
 
 declare const process: { env: Record<string, string | undefined> };
 
+// With `basePath: "/mcp-server"`, every route on `server.app` — including
+// the Better Auth handler at `/api/auth/**`, the sign-in/consent pages, and
+// the manually-registered `.well-known/*` metadata — moves under the prefix.
+// So tell Better Auth its authURL is `http://localhost:3000/mcp-server/api/auth`
+// and configure the GitHub OAuth callback to match the prefixed path.
 const server = new MCPServer({
   name: "better-auth-oauth-example",
   version: "1.0.0",
   description: "MCP server with Better Auth OAuth authentication",
+  basePath: "/mcp-server",
   oauth: oauthBetterAuthProvider({
-    authURL: "http://localhost:3000/api/auth",
+    authURL: "http://localhost:3000/mcp-server/api/auth",
   }),
 });
 
@@ -211,6 +217,7 @@ server.tool(
 
 server.listen({ port: 3000 }).then(() => {
   console.log("Better Auth OAuth MCP Server running on http://localhost:3000");
-  console.log("MCP Inspector: http://localhost:3000/inspector");
+  console.log("MCP Inspector: http://localhost:3000/mcp-server/inspector");
+  console.log("MCP transport: http://localhost:3000/mcp-server/mcp");
   console.log("Auth API: http://localhost:3000/api/auth");
 });

--- a/libraries/typescript/packages/mcp-use/examples/server/oauth/supabase/src/auth-routes.ts
+++ b/libraries/typescript/packages/mcp-use/examples/server/oauth/supabase/src/auth-routes.ts
@@ -78,9 +78,12 @@ function parseSessionCookie(
   }
 }
 
-function serializeSessionCookie(session: StoredSession): string {
+function serializeSessionCookie(
+  session: StoredSession,
+  cookiePath: string
+): string {
   const value = encodeURIComponent(JSON.stringify(session));
-  return `${SESSION_COOKIE}=${value}; Path=/auth; HttpOnly; SameSite=Lax; Max-Age=600`;
+  return `${SESSION_COOKIE}=${value}; Path=${cookiePath}; HttpOnly; SameSite=Lax; Max-Age=600`;
 }
 
 export function mountAuthRoutes(
@@ -88,6 +91,11 @@ export function mountAuthRoutes(
   { projectId, publishableKey }: MountAuthRoutesOptions
 ): void {
   const url = supabaseUrl(projectId);
+  // `server.app.get("/auth/...")` is auto-prefixed under `basePath`, but the
+  // HTML we render needs to know the external prefix to point fetches and
+  // the session cookie at the right place.
+  const basePath = server.basePath ?? "";
+  const authPrefix = `${basePath}/auth`;
 
   // -------------------------------------------------------------------------
   // GET /auth/consent?authorization_id=<id>
@@ -110,7 +118,7 @@ export function mountAuthRoutes(
     // Not signed in yet — show the sign-in prompt. After sign-in the page
     // reloads and falls through to the authenticated branch below.
     if (!session) {
-      return c.html(renderSignInPage(authorizationId));
+      return c.html(renderSignInPage(authorizationId, authPrefix));
     }
 
     const supabase = createServerClient(url, publishableKey);
@@ -132,7 +140,7 @@ export function mountAuthRoutes(
       return c.redirect(data.redirect_url, 302);
     }
 
-    return c.html(renderConsentPage(authorizationId, data));
+    return c.html(renderConsentPage(authorizationId, data, authPrefix));
   });
 
   // -------------------------------------------------------------------------
@@ -150,10 +158,13 @@ export function mountAuthRoutes(
     // Production: replace with signed/encrypted session storage.
     c.header(
       "Set-Cookie",
-      serializeSessionCookie({
-        access_token: data.session.access_token,
-        refresh_token: data.session.refresh_token,
-      })
+      serializeSessionCookie(
+        {
+          access_token: data.session.access_token,
+          refresh_token: data.session.refresh_token,
+        },
+        authPrefix
+      )
     );
     return c.json({ ok: true });
   });
@@ -223,7 +234,7 @@ function commonStyles(): string {
   `;
 }
 
-function renderSignInPage(authorizationId: string): string {
+function renderSignInPage(authorizationId: string, authPrefix: string): string {
   return `<!DOCTYPE html>
 <html>
 <head>
@@ -241,9 +252,9 @@ function renderSignInPage(authorizationId: string): string {
   </div>
   <script>
     async function signIn() {
-      const res = await fetch('/auth/signin', { method: 'POST' });
+      const res = await fetch('${authPrefix}/signin', { method: 'POST' });
       if (res.ok) {
-        window.location.href = '/auth/consent?authorization_id=${encodeURIComponent(authorizationId)}';
+        window.location.href = '${authPrefix}/consent?authorization_id=${encodeURIComponent(authorizationId)}';
       } else {
         document.getElementById('msg').textContent =
           'Sign-in failed. Enable anonymous sign-ins in the Supabase dashboard.';
@@ -256,7 +267,8 @@ function renderSignInPage(authorizationId: string): string {
 
 function renderConsentPage(
   authorizationId: string,
-  details: OAuthAuthorizationDetails
+  details: OAuthAuthorizationDetails,
+  authPrefix: string
 ): string {
   const clientName = escapeHtml(details.client.name || "Unknown client");
   const scopes = details.scope
@@ -285,7 +297,7 @@ function renderConsentPage(
   <script>
     async function decide(approve) {
       const res = await fetch(
-        '/auth/consent?authorization_id=${encodeURIComponent(authorizationId)}',
+        '${authPrefix}/consent?authorization_id=${encodeURIComponent(authorizationId)}',
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },

--- a/libraries/typescript/packages/mcp-use/examples/server/oauth/supabase/src/server.ts
+++ b/libraries/typescript/packages/mcp-use/examples/server/oauth/supabase/src/server.ts
@@ -54,6 +54,7 @@ const server = new MCPServer({
   name: "supabase-oauth-example",
   version: "1.0.0",
   description: "MCP server with Supabase OAuth authentication",
+  basePath: "/api",
   oauth: oauthSupabaseProvider(),
 });
 

--- a/libraries/typescript/packages/mcp-use/examples/server/ui/mcp-apps/index.ts
+++ b/libraries/typescript/packages/mcp-use/examples/server/ui/mcp-apps/index.ts
@@ -5,6 +5,7 @@ import { setTimeout as sleep } from "timers/promises";
 const server = new MCPServer({
   name: "mcp-apps-example",
   version: "1.0.0",
+  basePath: "/api",
   description:
     "Example MCP server demonstrating dual-protocol widget support (works with both ChatGPT and MCP Apps clients)",
 });
@@ -185,7 +186,7 @@ server.uiResource({
         // Parse props from URL (for both protocols)
         const params = new URLSearchParams(window.location.search);
         const propsJson = params.get('props');
-        
+
         if (propsJson) {
           try {
             const props = JSON.parse(propsJson);

--- a/libraries/typescript/packages/mcp-use/src/server/connect-adapter.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/connect-adapter.ts
@@ -109,7 +109,7 @@ export async function adaptMiddleware(
  * Based on @hono/connect approach using node-mocks-http
  *
  * @param connectMiddleware - The Connect middleware handler
- * @param middlewarePath - The path pattern the middleware is mounted at (e.g., "/mcp-use/widgets/*")
+ * @param middlewarePath - The path pattern the middleware is mounted at (e.g., "/_mcp-use/widgets/*")
  * @returns A Hono middleware function
  */
 export async function adaptConnectMiddleware(

--- a/libraries/typescript/packages/mcp-use/src/server/endpoints/mount-mcp.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/endpoints/mount-mcp.ts
@@ -152,7 +152,8 @@ export async function mountMcp(
   }, // The McpServer instance with getServerForSession() method
   sessions: Map<string, SessionData>,
   config: ServerConfig,
-  isProductionMode: boolean
+  isProductionMode: boolean,
+  basePath: string = ""
 ): Promise<{ mcpMounted: boolean; idleCleanupInterval?: NodeJS.Timeout }> {
   const { WebStandardStreamableHTTPServerTransport } =
     await import("@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js");
@@ -263,7 +264,7 @@ export async function mountMcp(
         if (iconSrc) {
           iconUrl = iconSrc.startsWith("http")
             ? iconSrc
-            : `${origin}/mcp-use/public/${iconSrc.replace(/^\//, "")}`;
+            : `${origin}${basePath}/_mcp-use/public/${iconSrc.replace(/^\//, "")}`;
         }
         const regs = instance.registrations;
         const landingTools =
@@ -624,13 +625,19 @@ export async function mountMcp(
     }
   };
 
-  // Mount the handler for all HTTP methods on both /mcp and /sse
+  // Register on the inner app at bare paths. When `basePath` is set the
+  // inner is sub-mounted under it externally, so these become
+  // `${basePath}/mcp` and `${basePath}/sse` from the outside.
   for (const endpoint of ["/mcp", "/sse"]) {
     app.on(["GET", "POST", "DELETE", "HEAD"], endpoint, handleRequest);
   }
 
+  // Log the externally-visible paths (what users hit) rather than the
+  // bare paths we just registered on the inner.
+  const externalMcp = `${basePath}/mcp`;
+  const externalSse = `${basePath}/sse`;
   console.log(
-    `[MCP] Server mounted at /mcp and /sse (${config.stateless ? "stateless" : "stateful"} mode)`
+    `[MCP] Server mounted at ${externalMcp} and ${externalSse} (${config.stateless ? "stateless" : "stateful"} mode)`
   );
 
   return { mcpMounted: true, idleCleanupInterval };

--- a/libraries/typescript/packages/mcp-use/src/server/inspector/mount.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/inspector/mount.ts
@@ -36,7 +36,8 @@ export async function mountInspectorUI(
   app: HonoType,
   serverHost: string,
   serverPort: number | undefined,
-  isProduction: boolean
+  isProduction: boolean,
+  basePath: string = ""
 ): Promise<boolean> {
   // In production, only mount if build manifest says so
   if (isProduction) {
@@ -55,15 +56,23 @@ export async function mountInspectorUI(
   try {
     // @ts-ignore - Optional peer dependency, may not be installed during build
     const { mountInspector } = await import("@mcp-use/inspector");
-    // Auto-connect to the local MCP server at /mcp (SSE endpoint)
-    // Use JSON config to specify SSE transport type
-    const mcpUrl = `http://${serverHost}:${serverPort}/mcp`; // Also available at /sse
+    // Auto-connect to the local MCP server. The transport lives at
+    // `${basePath}/mcp` externally; the inspector's auto-connect URL uses
+    // the externally-visible path because it's loaded by the user's
+    // browser, not internally.
+    const mcpUrl = `http://${serverHost}:${serverPort}${basePath}/mcp`;
     const autoConnectConfig = JSON.stringify({
       url: mcpUrl,
       name: "Local MCP Server",
       transportType: "sse",
       connectionType: "Direct",
     });
+    // The inspector registers bare `/inspector/*` routes on whatever app
+    // we hand it. We're handing it the inner app, which is already
+    // sub-mounted under `basePath` by the MCPServer constructor — so the
+    // inspector composes to `${basePath}/inspector/*` externally without
+    // any wrapping here. `basePath` still flows in for URL emission
+    // (`<base href>`, `window.__MCP_BASE_PATH__`).
     mountInspector(app, {
       autoConnectUrl: autoConnectConfig,
       // In dev mode, tell the inspector to use same-origin for MCP Apps sandbox.
@@ -71,9 +80,10 @@ export async function mountInspectorUI(
       // behind reverse proxies (ngrok, E2B, etc.)
       devMode: !isProduction,
       serverPort: typeof serverPort === "number" ? serverPort : undefined,
+      basePath,
     });
     console.log(
-      `[INSPECTOR] UI available at http://${serverHost}:${serverPort}/inspector`
+      `[INSPECTOR] UI available at http://${serverHost}:${serverPort}${basePath}/inspector`
     );
     return true;
   } catch (err) {

--- a/libraries/typescript/packages/mcp-use/src/server/logging.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/logging.ts
@@ -145,212 +145,237 @@ async function extractResponseError(res: Response): Promise<string | null> {
 }
 
 /**
- * Middleware that logs incoming HTTP requests in a compact format controlled
+ * Build the request-logging middleware, bound to a `basePath` so noisy-path
+ * filtering still works when the server is mounted under a prefix.
+ *
+ * The middleware logs incoming HTTP requests in a compact format controlled
  * by `MCP_DEBUG_LEVEL` (or legacy `DEBUG`). See {@link getDebugLevel}.
  *
- * Skips logging for inspector telemetry/RPC endpoints, dev widget assets, and
- * polling GETs against `/mcp` and `/inspector/api/*`.
+ * Skips logging for inspector telemetry/RPC endpoints, framework-internal
+ * `${basePath}/_mcp-use/*` assets, and polling GETs against `/mcp` and
+ * `/inspector/api/*` (all matched against the basePath-stripped path).
  */
-export async function requestLogger(c: Context, next: Next): Promise<void> {
-  const startedAt = Date.now();
-  const timestamp = new Date().toISOString().substring(11, 23);
-  const method = c.req.method;
-  const url = c.req.url;
-  const level = getDebugLevel();
+export function createRequestLogger(
+  basePath: string = ""
+): (c: Context, next: Next) => Promise<void> {
+  return async function requestLogger(c: Context, next: Next): Promise<void> {
+    const startedAt = Date.now();
+    const timestamp = new Date().toISOString().substring(11, 23);
+    const method = c.req.method;
+    const url = c.req.url;
+    const level = getDebugLevel();
 
-  const pathname = new URL(url).pathname;
-  const noisyPaths = [
-    "/inspector/api/tel/",
-    "/inspector/api/rpc/stream",
-    "/inspector/api/rpc/log",
-    "/inspector",
-    "/mcp-use/widgets/",
-    "/mcp-use/public/",
-  ];
-  const isNoisyGet =
-    method === "GET" &&
-    (pathname === "/mcp" ||
-      pathname.startsWith("/inspector/api/") ||
-      pathname.startsWith("/mcp-use/"));
+    const pathname = new URL(url).pathname;
+    // Strip the configured basePath before matching noisy-path patterns so
+    // requests like `/api/mcp-use/widgets/...` and `/api/inspector/api/...`
+    // are filtered the same way as the unprefixed versions.
+    const routedPath =
+      basePath && pathname.startsWith(basePath)
+        ? pathname.slice(basePath.length) || "/"
+        : pathname;
+    // Framework-internal asset paths live under `${basePath}/_mcp-use/`, so
+    // match them against the basePath-stripped `routedPath`.
+    const isInternalAsset =
+      routedPath.startsWith("/_mcp-use/widgets/") ||
+      routedPath.startsWith("/_mcp-use/public/");
+    const noisyPaths = [
+      "/inspector/api/tel/",
+      "/inspector/api/rpc/stream",
+      "/inspector/api/rpc/log",
+      "/inspector",
+    ];
+    const isNoisyGet =
+      method === "GET" &&
+      (routedPath === "/mcp" ||
+        routedPath.startsWith("/inspector/api/") ||
+        routedPath.startsWith("/_mcp-use/"));
 
-  if (
-    noisyPaths.some((noisyPath) => pathname.startsWith(noisyPath)) ||
-    isNoisyGet
-  ) {
-    await next();
-    return;
-  }
-
-  // Capture request body up front so we can extract MCP method/params.
-  let requestBody: any = null;
-  let requestHeaders: Record<string, string> = {};
-
-  if (level === "trace") {
-    const allHeaders = c.req.header();
-    if (allHeaders) requestHeaders = allHeaders;
-  }
-
-  if (method !== "GET" && method !== "HEAD") {
-    try {
-      const clonedRequest = c.req.raw.clone();
-      requestBody = await clonedRequest.json().catch(() => {
-        return clonedRequest.text().catch(() => null);
-      });
-    } catch {
-      // ignore — body is optional for the log line
+    if (isInternalAsset) {
+      await next();
+      return;
     }
-  }
 
-  await next();
-
-  const durationMs = Date.now() - startedAt;
-  const statusCode = c.res.status;
-
-  // Session ID: incoming header for established sessions, response header for
-  // initialize requests (the SDK transport stamps it on the response).
-  const incomingSid = c.req.header("mcp-session-id");
-  const responseSid = c.res.headers.get("mcp-session-id");
-  const mcpMethod: string | undefined = requestBody?.method;
-  const isInitialize = mcpMethod === "initialize";
-
-  // Build the line. Colors mirror typical access-log palettes: timestamps,
-  // session ids, args and durations are dimmed; method/path/MCP-method are
-  // bold; outcome is green (OK) or red (ERROR).
-  const parts: string[] = [chalk.gray(`[${timestamp}]`)];
-
-  const sessPrefix = !isInitialize ? shortSessionId(incomingSid) : null;
-  if (sessPrefix) parts.push(chalk.gray(`sess=${sessPrefix}`));
-
-  parts.push(method);
-  parts.push(chalk.bold(pathname));
-
-  if (mcpMethod) {
-    if (isInitialize) {
-      const ci = requestBody?.params?.clientInfo;
-      const label =
-        ci?.name && ci?.version
-          ? `: ${ci.name}/${ci.version}`
-          : ci?.name
-            ? `: ${ci.name}`
-            : "";
-      parts.push(chalk.bold(`[initialize${label}]`));
-    } else if (mcpMethod === "tools/call") {
-      const toolName = requestBody?.params?.name ?? "?";
-      let segment = chalk.bold(`[tools/call: ${toolName}]`);
-      if (level !== "info") {
-        const args = requestBody?.params?.arguments;
-        if (args !== undefined) {
-          segment += ` args=${inlineJson(args)}`;
-        }
-      }
-      parts.push(segment);
-    } else if (mcpMethod === "resources/read") {
-      const uri = requestBody?.params?.uri ?? "?";
-      parts.push(chalk.bold(`[resources/read: ${uri}]`));
-    } else if (mcpMethod === "prompts/get") {
-      const promptName = requestBody?.params?.name ?? "?";
-      parts.push(chalk.bold(`[prompts/get: ${promptName}]`));
-    } else {
-      parts.push(chalk.bold(`[${mcpMethod}]`));
+    if (
+      noisyPaths.some((noisyPath) => routedPath.startsWith(noisyPath)) ||
+      isNoisyGet
+    ) {
+      await next();
+      return;
     }
-  }
 
-  if (isInitialize && responseSid) {
-    parts.push(chalk.gray(`→ session=${shortSessionId(responseSid)}`));
-  }
+    // Capture request body up front so we can extract MCP method/params.
+    let requestBody: any = null;
+    let requestHeaders: Record<string, string> = {};
 
-  // Outcome:
-  //  - MCP requests: OK / ERROR <message> based on JSON-RPC error parsing.
-  //  - Plain HTTP (HEAD, etc.): the raw status code, colored by class.
-  let outcomePart: string;
-  const errMsg = await extractResponseError(c.res);
-  if (errMsg) {
-    outcomePart = chalk.red(`ERROR ${errMsg}`);
-  } else if (mcpMethod) {
-    outcomePart =
-      statusCode >= 400
-        ? chalk.red(`ERROR (HTTP ${statusCode})`)
-        : chalk.green("OK");
-  } else {
-    outcomePart =
-      statusCode >= 500
-        ? chalk.magenta(String(statusCode))
-        : statusCode >= 400
-          ? chalk.red(String(statusCode))
-          : statusCode >= 300
-            ? chalk.yellow(String(statusCode))
-            : chalk.green(String(statusCode));
-  }
-  parts.push(outcomePart);
-  parts.push(chalk.gray(`(${durationMs}ms)`));
-
-  console.log(parts.join(" "));
-
-  // Trace mode preserves the legacy DEBUG=1 behavior: detailed request and
-  // response dumps follow the summary line.
-  if (level !== "trace") return;
-
-  console.log("\n" + chalk.cyan("=".repeat(80)));
-  console.log(chalk.bold.cyan("[TRACE] Request Details"));
-  console.log(chalk.cyan("-".repeat(80)));
-
-  if (Object.keys(requestHeaders).length > 0) {
-    console.log(chalk.yellow("Request Headers:"));
-    console.log(formatForLogging(requestHeaders));
-  }
-
-  if (requestBody !== null) {
-    console.log(chalk.yellow("Request Body:"));
-    if (typeof requestBody === "string") {
-      console.log(requestBody);
-    } else {
-      console.log(formatForLogging(requestBody));
+    if (level === "trace") {
+      const allHeaders = c.req.header();
+      if (allHeaders) requestHeaders = allHeaders;
     }
-  }
 
-  const responseHeaders: Record<string, string> = {};
-  c.res.headers.forEach((value, key) => {
-    responseHeaders[key] = value;
-  });
-  if (Object.keys(responseHeaders).length > 0) {
-    console.log(chalk.yellow("Response Headers:"));
-    console.log(formatForLogging(responseHeaders));
-  }
-
-  try {
-    if (c.res.body !== null && c.res.body !== undefined) {
+    if (method !== "GET" && method !== "HEAD") {
       try {
-        const clonedResponse = c.res.clone();
-        const responseBody = await clonedResponse.text().catch(() => null);
-
-        if (responseBody !== null && responseBody.length > 0) {
-          console.log(chalk.yellow("Response Body:"));
-          try {
-            const jsonBody = JSON.parse(responseBody);
-            console.log(formatForLogging(jsonBody));
-          } catch {
-            const maxLength = 10000;
-            if (responseBody.length > maxLength) {
-              console.log(
-                responseBody.substring(0, maxLength) +
-                  `\n... (truncated, ${responseBody.length - maxLength} more characters)`
-              );
-            } else {
-              console.log(responseBody);
-            }
-          }
-        } else {
-          console.log(chalk.yellow("Response Body:") + " (empty)");
-        }
+        const clonedRequest = c.req.raw.clone();
+        requestBody = await clonedRequest.json().catch(() => {
+          return clonedRequest.text().catch(() => null);
+        });
       } catch {
-        console.log(chalk.yellow("Response Body:") + " (unable to clone/read)");
+        // ignore — body is optional for the log line
       }
-    } else {
-      console.log(chalk.yellow("Response Body:") + " (no body)");
     }
-  } catch {
-    console.log(chalk.yellow("Response Body:") + " (unable to read)");
-  }
 
-  console.log(chalk.cyan("=".repeat(80)) + "\n");
+    await next();
+
+    const durationMs = Date.now() - startedAt;
+    const statusCode = c.res.status;
+
+    // Session ID: incoming header for established sessions, response header for
+    // initialize requests (the SDK transport stamps it on the response).
+    const incomingSid = c.req.header("mcp-session-id");
+    const responseSid = c.res.headers.get("mcp-session-id");
+    const mcpMethod: string | undefined = requestBody?.method;
+    const isInitialize = mcpMethod === "initialize";
+
+    // Build the line. Colors mirror typical access-log palettes: timestamps,
+    // session ids, args and durations are dimmed; method/path/MCP-method are
+    // bold; outcome is green (OK) or red (ERROR).
+    const parts: string[] = [chalk.gray(`[${timestamp}]`)];
+
+    const sessPrefix = !isInitialize ? shortSessionId(incomingSid) : null;
+    if (sessPrefix) parts.push(chalk.gray(`sess=${sessPrefix}`));
+
+    parts.push(method);
+    parts.push(chalk.bold(pathname));
+
+    if (mcpMethod) {
+      if (isInitialize) {
+        const ci = requestBody?.params?.clientInfo;
+        const label =
+          ci?.name && ci?.version
+            ? `: ${ci.name}/${ci.version}`
+            : ci?.name
+              ? `: ${ci.name}`
+              : "";
+        parts.push(chalk.bold(`[initialize${label}]`));
+      } else if (mcpMethod === "tools/call") {
+        const toolName = requestBody?.params?.name ?? "?";
+        let segment = chalk.bold(`[tools/call: ${toolName}]`);
+        if (level !== "info") {
+          const args = requestBody?.params?.arguments;
+          if (args !== undefined) {
+            segment += ` args=${inlineJson(args)}`;
+          }
+        }
+        parts.push(segment);
+      } else if (mcpMethod === "resources/read") {
+        const uri = requestBody?.params?.uri ?? "?";
+        parts.push(chalk.bold(`[resources/read: ${uri}]`));
+      } else if (mcpMethod === "prompts/get") {
+        const promptName = requestBody?.params?.name ?? "?";
+        parts.push(chalk.bold(`[prompts/get: ${promptName}]`));
+      } else {
+        parts.push(chalk.bold(`[${mcpMethod}]`));
+      }
+    }
+
+    if (isInitialize && responseSid) {
+      parts.push(chalk.gray(`→ session=${shortSessionId(responseSid)}`));
+    }
+
+    // Outcome:
+    //  - MCP requests: OK / ERROR <message> based on JSON-RPC error parsing.
+    //  - Plain HTTP (HEAD, etc.): the raw status code, colored by class.
+    let outcomePart: string;
+    const errMsg = await extractResponseError(c.res);
+    if (errMsg) {
+      outcomePart = chalk.red(`ERROR ${errMsg}`);
+    } else if (mcpMethod) {
+      outcomePart =
+        statusCode >= 400
+          ? chalk.red(`ERROR (HTTP ${statusCode})`)
+          : chalk.green("OK");
+    } else {
+      outcomePart =
+        statusCode >= 500
+          ? chalk.magenta(String(statusCode))
+          : statusCode >= 400
+            ? chalk.red(String(statusCode))
+            : statusCode >= 300
+              ? chalk.yellow(String(statusCode))
+              : chalk.green(String(statusCode));
+    }
+    parts.push(outcomePart);
+    parts.push(chalk.gray(`(${durationMs}ms)`));
+
+    console.log(parts.join(" "));
+
+    // Trace mode preserves the legacy DEBUG=1 behavior: detailed request and
+    // response dumps follow the summary line.
+    if (level !== "trace") return;
+
+    console.log("\n" + chalk.cyan("=".repeat(80)));
+    console.log(chalk.bold.cyan("[TRACE] Request Details"));
+    console.log(chalk.cyan("-".repeat(80)));
+
+    if (Object.keys(requestHeaders).length > 0) {
+      console.log(chalk.yellow("Request Headers:"));
+      console.log(formatForLogging(requestHeaders));
+    }
+
+    if (requestBody !== null) {
+      console.log(chalk.yellow("Request Body:"));
+      if (typeof requestBody === "string") {
+        console.log(requestBody);
+      } else {
+        console.log(formatForLogging(requestBody));
+      }
+    }
+
+    const responseHeaders: Record<string, string> = {};
+    c.res.headers.forEach((value, key) => {
+      responseHeaders[key] = value;
+    });
+    if (Object.keys(responseHeaders).length > 0) {
+      console.log(chalk.yellow("Response Headers:"));
+      console.log(formatForLogging(responseHeaders));
+    }
+
+    try {
+      if (c.res.body !== null && c.res.body !== undefined) {
+        try {
+          const clonedResponse = c.res.clone();
+          const responseBody = await clonedResponse.text().catch(() => null);
+
+          if (responseBody !== null && responseBody.length > 0) {
+            console.log(chalk.yellow("Response Body:"));
+            try {
+              const jsonBody = JSON.parse(responseBody);
+              console.log(formatForLogging(jsonBody));
+            } catch {
+              const maxLength = 10000;
+              if (responseBody.length > maxLength) {
+                console.log(
+                  responseBody.substring(0, maxLength) +
+                    `\n... (truncated, ${responseBody.length - maxLength} more characters)`
+                );
+              } else {
+                console.log(responseBody);
+              }
+            }
+          } else {
+            console.log(chalk.yellow("Response Body:") + " (empty)");
+          }
+        } catch {
+          console.log(
+            chalk.yellow("Response Body:") + " (unable to clone/read)"
+          );
+        }
+      } else {
+        console.log(chalk.yellow("Response Body:") + " (no body)");
+      }
+    } catch {
+      console.log(chalk.yellow("Response Body:") + " (unable to read)");
+    }
+
+    console.log(chalk.cyan("=".repeat(80)) + "\n");
+  };
 }

--- a/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
@@ -41,7 +41,7 @@ import { toResourceTemplateCompleteCallbacks } from "./utils/completion-helpers.
 
 import { getRequestContext, runWithContext } from "./context-storage.js";
 import { mountMcp as mountMcpHelper } from "./endpoints/index.js";
-import { requestLogger } from "./logging.js";
+import { createRequestLogger } from "./logging.js";
 import {
   getActiveSessions,
   sendNotification,
@@ -91,7 +91,9 @@ import {
   isDeno,
   isProductionMode as isProductionModeHelper,
   logRegisteredItems as logRegisteredItemsHelper,
+  normalizeBasePath,
   parseTemplateUri as parseTemplateUriHelper,
+  resolveIconUrls,
   rewriteSupabaseRequest,
   startServer,
 } from "./utils/index.js";
@@ -258,7 +260,13 @@ class MCPServerClass<HasOAuth extends boolean = false> {
   /**
    * Hono application instance.
    *
-   * The underlying Hono app that handles HTTP routing and middleware.
+   * When `basePath` is set, this is a Hono `.basePath()` clone — route
+   * registrations made here automatically pick up the basePath prefix.
+   * The clone shares its parent's router/routes array (see Hono's
+   * `clone()`), so `app.fetch` still dispatches root-level routes such
+   * as OAuth `.well-known/*` discovery that were registered on the
+   * un-prefixed view inside the constructor before the clone was taken.
+   *
    * Can be used to add custom routes and middleware alongside MCP endpoints.
    *
    * @example
@@ -317,6 +325,14 @@ class MCPServerClass<HasOAuth extends boolean = false> {
   public serverBaseUrl?: string;
 
   /**
+   * Normalized base path prefix for every route this server mounts.
+   *
+   * Empty string means no prefix. Otherwise starts with `/` and has no
+   * trailing `/`. Computed once in the constructor from `config.basePath`.
+   */
+  public basePath: string;
+
+  /**
    * Optional favicon URL to display in inspector and documentation.
    */
   public favicon?: string;
@@ -348,15 +364,7 @@ class MCPServerClass<HasOAuth extends boolean = false> {
    */
   public sessions = new Map<string, SessionData>();
   private idleCleanupInterval?: NodeJS.Timeout;
-  private oauthSetupState = {
-    complete: false,
-    provider: undefined as OAuthProvider | undefined,
-    middleware: undefined as
-      | ((c: any, next: any) => Promise<Response | void>)
-      | undefined,
-  };
   public oauthProvider?: OAuthProvider;
-  private oauthMiddleware?: (c: any, next: any) => Promise<Response | void>;
 
   /**
    * Storage for registrations that can be replayed on new server instances
@@ -2350,6 +2358,7 @@ class MCPServerClass<HasOAuth extends boolean = false> {
 
     this.serverHost = config.host || "localhost";
     this.serverBaseUrl = config.baseUrl;
+    this.basePath = normalizeBasePath(config.basePath);
 
     // Auto-select favicon from icons array if not explicitly provided
     if (config.favicon) {
@@ -2359,20 +2368,6 @@ class MCPServerClass<HasOAuth extends boolean = false> {
       console.log(`[MCP] Auto-selected favicon from icons: ${this.favicon}`);
     }
 
-    // Helper to convert relative icon paths to absolute URLs
-    const processIconUrls = (
-      icons: ServerConfig["icons"],
-      baseUrl?: string
-    ) => {
-      if (!icons || !baseUrl) return icons;
-      return icons.map((icon) => ({
-        ...icon,
-        src: icon.src.startsWith("http")
-          ? icon.src
-          : `${baseUrl}/mcp-use/public/${icon.src}`,
-      }));
-    };
-
     // Create native SDK server instance with capabilities
     this.nativeServer = new OfficialMcpServer(
       {
@@ -2381,7 +2376,7 @@ class MCPServerClass<HasOAuth extends boolean = false> {
         description: config.description,
         title: config.title,
         websiteUrl: config.websiteUrl,
-        icons: processIconUrls(config.icons, config.baseUrl),
+        icons: resolveIconUrls(config.icons, config.baseUrl, this.basePath),
       },
       {
         capabilities: {
@@ -2401,22 +2396,59 @@ class MCPServerClass<HasOAuth extends boolean = false> {
       }
     );
 
-    // Create and configure Hono app with default middleware
-    this.app = createHonoApp(requestLogger, {
+    // Single Hono instance. Global middleware (CORS, host validation,
+    // request logging) lives on the un-prefixed root view created here.
+    // When `basePath` is set, `this.app` is later switched to a
+    // `.basePath()` clone — same underlying router and routes array (see
+    // Hono's `clone()`), but registrations through the clone automatically
+    // get the prefix prepended. No sub-mounting, no deferred route-snapshot
+    // dance.
+    const rootApp = createHonoApp(createRequestLogger(this.basePath), {
       cors: this.config.cors,
       allowedOrigins: this.config.allowedOrigins,
     });
 
+    this.oauthProvider = config.oauth;
+
+    // Mount OAuth on the un-prefixed root view BEFORE switching `this.app`
+    // to the basePath clone. OAuth has to register `.well-known/*` at the
+    // literal host root (RFC 8414 §3.1) regardless of basePath; everything
+    // else it registers (/authorize, /token, /register, /mcp middleware) is
+    // scoped under basePath via an internal `.basePath()` clone. Doing this
+    // here is the only thing that needs the un-prefixed handle — afterwards
+    // we collapse to a single `this.app` reference. `getServerBaseUrl()` is
+    // passed as a lazy getter because the port isn't bound yet when the
+    // constructor runs; metadata handlers resolve it at request time.
+    if (this.oauthProvider) {
+      setupOAuthForServer(
+        rootApp,
+        this.oauthProvider,
+        () => this.getServerBaseUrl(),
+        this.basePath
+      );
+    }
+
+    this.app = this.basePath ? rootApp.basePath(this.basePath) : rootApp;
+
     // Install the custom routes middleware FIRST (before any other routes).
     // This single middleware dispatches from the mutable _customRoutes map,
     // enabling HMR for custom HTTP routes (server.get(), server.post(), etc.)
-    // without hitting Hono's "matcher already built" error.
+    // without hitting Hono's "matcher already built" error. Registered on
+    // `this.app` so it auto-prefixes under `basePath`; the dispatcher strips
+    // the prefix from `c.req.path` so user keys stay bare (e.g.
+    // `server.get("/foo")` is reachable at `${basePath}/foo`).
     // See: https://github.com/honojs/hono/issues/3817
-    installCustomRoutesMiddleware(this.app, this._customRoutes);
+    installCustomRoutesMiddleware(
+      this.app,
+      this._customRoutes,
+      () => this.basePath
+    );
 
-    // Setup public routes immediately if icons/favicon are configured
-    // This ensures icons are served even before listen() or getHandler() is called
-    // Only set up dev routes if not in production mode - production routes will be set up later
+    // Setup public routes immediately if icons/favicon are configured.
+    // Both register on `this.app` so they auto-prefix under `basePath` —
+    // `${basePath}/_mcp-use/public/*` and `${basePath}/favicon.ico`. The
+    // MCP icon declaration in `getServerInfo` is what clients consume to
+    // discover the icon when the server is mounted under a basePath.
     if (
       (this.favicon || this.config.icons) &&
       !isProductionModeHelper() &&
@@ -2426,8 +2458,6 @@ class MCPServerClass<HasOAuth extends boolean = false> {
       setupFaviconRoute(this.app, this.favicon, false);
       this.publicRoutesMode = "dev";
     }
-
-    this.oauthProvider = config.oauth;
 
     // Wrap registration methods to capture registrations for multi-session support
     this.wrapRegistrationMethods();
@@ -2631,20 +2661,6 @@ class MCPServerClass<HasOAuth extends boolean = false> {
    * @param sessionId - Optional session ID to store registered refs for hot reload support
    */
   public getServerForSession(sessionId?: string): OfficialMcpServer {
-    // Helper to convert relative icon paths to absolute URLs
-    const processIconUrls = (
-      icons: ServerConfig["icons"],
-      baseUrl?: string
-    ) => {
-      if (!icons || !baseUrl) return icons;
-      return icons.map((icon) => ({
-        ...icon,
-        src: icon.src.startsWith("http")
-          ? icon.src
-          : `${baseUrl}/mcp-use/public/${icon.src}`,
-      }));
-    };
-
     const newServer = new OfficialMcpServer(
       {
         name: this.config.name,
@@ -2652,7 +2668,11 @@ class MCPServerClass<HasOAuth extends boolean = false> {
         description: this.config.description,
         title: this.config.title,
         websiteUrl: this.config.websiteUrl,
-        icons: processIconUrls(this.config.icons, this.serverBaseUrl),
+        icons: resolveIconUrls(
+          this.config.icons,
+          this.serverBaseUrl,
+          this.basePath
+        ),
       },
       {
         capabilities: {
@@ -3703,10 +3723,36 @@ class MCPServerClass<HasOAuth extends boolean = false> {
       this, // Pass the MCPServer instance so mountMcp can call getServerForSession()
       this.sessions,
       this.config,
-      isProductionModeHelper()
+      isProductionModeHelper(),
+      this.basePath
     );
 
     this.mcpMounted = result.mcpMounted;
+  }
+
+  /**
+   * Run the shared mount sequence used by both `listen()` and `getHandler()`:
+   * widgets → MCP transport → inspector. Each step internally guards
+   * against double-mounting, so it's safe to call this more than once
+   * across the same lifecycle. (OAuth is mounted up front in the
+   * constructor — its `.well-known/*` routes need the un-prefixed root
+   * handle, which only exists during construction.)
+   */
+  private async _setupAndMount(): Promise<void> {
+    await mountWidgets(this as any, {
+      baseRoute: "/_mcp-use/widgets",
+      // Only forward `resourcesDir` when the env var is set. That lets
+      // @mcp-use/cli steer widget discovery to e.g. `src/mcp/resources`
+      // (via `--mcp-dir src/mcp`) without forcing the user to configure
+      // anything in their server file. When the env var is unset,
+      // `mountWidgets` applies its own default (`"resources"`).
+      ...(process.env.MCP_USE_WIDGETS_DIR
+        ? { resourcesDir: process.env.MCP_USE_WIDGETS_DIR }
+        : {}),
+    });
+    await this.mountMcp();
+    // Mount inspector BEFORE Vite middleware so it claims /inspector routes.
+    await this.mountInspector();
   }
 
   /**
@@ -3882,31 +3928,7 @@ class MCPServerClass<HasOAuth extends boolean = false> {
       this.serverPort
     );
 
-    // Setup OAuth before mounting widgets/MCP (if configured)
-    if (this.oauthProvider && !this.oauthSetupState.complete) {
-      await setupOAuthForServer(
-        this.app,
-        this.oauthProvider,
-        this.getServerBaseUrl(),
-        this.oauthSetupState
-      );
-    }
-
-    await mountWidgets(this as any, {
-      baseRoute: "/mcp-use/widgets",
-      // Only forward `resourcesDir` when the env var is set. That lets
-      // @mcp-use/cli steer widget discovery to e.g. `src/mcp/resources`
-      // (via `--mcp-dir src/mcp`) without forcing the user to configure
-      // anything in their server file. When the env var is unset,
-      // `mountWidgets` applies its own default (`"resources"`).
-      ...(process.env.MCP_USE_WIDGETS_DIR
-        ? { resourcesDir: process.env.MCP_USE_WIDGETS_DIR }
-        : {}),
-    });
-    await this.mountMcp();
-
-    // Mount inspector BEFORE Vite middleware to ensure it handles /inspector routes
-    await this.mountInspector();
+    await this._setupAndMount();
 
     // Log registered items before starting server
     this.logRegisteredItems();
@@ -3929,13 +3951,17 @@ class MCPServerClass<HasOAuth extends boolean = false> {
     // Track server run event
     this._trackServerRun("http");
 
-    // Start server using runtime-aware helper
+    // Start server using runtime-aware helper. `this.app` is the basePath
+    // clone but its router/routes array is shared with the un-prefixed root
+    // view used inside the constructor for OAuth `.well-known/*`, so its
+    // fetch dispatches both prefixed and root-level routes.
     const httpHandle = await startServer(
       this.app,
       this.serverPort,
       this.serverHost,
       {
         onDenoRequest: rewriteSupabaseRequest,
+        basePath: this.basePath,
       }
     );
     this._httpServerClose = httpHandle.close;
@@ -4011,39 +4037,15 @@ class MCPServerClass<HasOAuth extends boolean = false> {
   async getHandler(options?: {
     provider?: "supabase" | "cloudflare" | "deno-deploy";
   }): Promise<(req: Request) => Promise<Response>> {
-    // Setup OAuth before mounting widgets/MCP (if configured)
-    if (this.oauthProvider && !this.oauthSetupState.complete) {
-      await setupOAuthForServer(
-        this.app,
-        this.oauthProvider,
-        this.getServerBaseUrl(),
-        this.oauthSetupState
-      );
-    }
-
-    console.log("[MCP] Mounting widgets");
-    await mountWidgets(this as any, {
-      baseRoute: "/mcp-use/widgets",
-      // Only forward `resourcesDir` when the env var is set. That lets
-      // @mcp-use/cli steer widget discovery to e.g. `src/mcp/resources`
-      // (via `--mcp-dir src/mcp`) without forcing the user to configure
-      // anything in their server file. When the env var is unset,
-      // `mountWidgets` applies its own default (`"resources"`).
-      ...(process.env.MCP_USE_WIDGETS_DIR
-        ? { resourcesDir: process.env.MCP_USE_WIDGETS_DIR }
-        : {}),
-    });
-    console.log("[MCP] Mounted widgets");
-    await this.mountMcp();
-    console.log("[MCP] Mounted MCP");
-    console.log("[MCP] Mounting inspector");
-    await this.mountInspector();
-    console.log("[MCP] Mounted inspector");
+    await this._setupAndMount();
 
     const provider = options?.provider || "fetch";
     this._trackServerRun(provider);
 
-    // Wrap the fetch handler to ensure it always returns a Promise<Response>
+    // `this.app` is the basePath clone but shares its router/routes array
+    // with the un-prefixed root view used during construction (for OAuth
+    // `.well-known/*`), so its fetch handles both prefixed and root-level
+    // routes.
     const fetchHandler = this.app.fetch.bind(this.app);
 
     // Handle platform-specific path rewriting and CORS
@@ -4131,7 +4133,8 @@ class MCPServerClass<HasOAuth extends boolean = false> {
       this.app,
       this.serverHost,
       this.serverPort,
-      isProductionModeHelper()
+      isProductionModeHelper(),
+      this.basePath
     );
 
     if (mounted) {

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/middleware.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/middleware.ts
@@ -12,12 +12,21 @@ import type { OAuthProvider, OAuthProxy } from "./providers/types.js";
  * Create bearer authentication middleware for a given OAuth provider or proxy
  *
  * @param oauth - The OAuth provider or proxy to use for token verification
- * @param baseUrl - The base URL of the server (for WWW-Authenticate header)
+ * @param getBaseUrl - Lazy getter for the server base URL (for WWW-Authenticate header).
+ *                    Called per-request so callers can defer resolution until after
+ *                    the HTTP listener has bound a port.
+ * @param basePath - Optional externally-visible prefix the server is mounted under
+ *                   (e.g. "/api"). Used to construct the path-aware
+ *                   `resource_metadata` URL per RFC 9728 §3.1, which inserts
+ *                   `/.well-known/oauth-protected-resource` between host and
+ *                   resource path — so the MCP endpoint at `<host><basePath>/mcp`
+ *                   has metadata at `<host>/.well-known/oauth-protected-resource<basePath>/mcp`.
  * @returns Hono middleware function
  */
 export function createBearerAuthMiddleware(
   oauth: OAuthProvider | OAuthProxy,
-  baseUrl?: string
+  getBaseUrl?: () => string | undefined,
+  basePath: string = ""
 ) {
   return async (c: Context, next: Next) => {
     // Allow HEAD requests through without auth - used for health checks/keep-alive
@@ -30,15 +39,19 @@ export function createBearerAuthMiddleware(
     // Build WWW-Authenticate header for 401 responses
     // This enables MCP clients to discover the OAuth configuration
     const getWWWAuthenticateHeader = () => {
-      const base = baseUrl || new URL(c.req.url).origin;
+      const base = getBaseUrl?.() || new URL(c.req.url).origin;
       const parts = [
         'Bearer error="unauthorized"',
         'error_description="Authorization needed"',
       ];
 
-      // Add resource_metadata for OAuth discovery (MCP spec)
+      // Path-aware resource_metadata URL per RFC 9728 §3.1: the metadata URL
+      // is built by inserting `/.well-known/oauth-protected-resource` between
+      // host and the resource path. The protected resource here is the MCP
+      // transport endpoint at `<basePath>/mcp`. The matching route is
+      // registered in routes.ts (`/.well-known/oauth-protected-resource<basePath>/mcp`).
       parts.push(
-        `resource_metadata="${base}/.well-known/oauth-protected-resource"`
+        `resource_metadata="${base}/.well-known/oauth-protected-resource${basePath}/mcp"`
       );
 
       return parts.join(", ");

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/routes.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/routes.ts
@@ -187,26 +187,53 @@ function createTokenHandler(
  * - POST /token - Forwards with injected credentials
  * - GET /.well-known/* - Synthesized metadata pointing to local endpoints
  *
- * @param app - The Hono application instance
+ * @param rootApp - The underlying Hono instance (un-prefixed root view)
  * @param oauth - The OAuth provider or proxy
- * @param baseUrl - The base URL of this server (for metadata)
+ * @param getBaseUrl - Lazy getter for the server base URL. Called per-request so
+ *                     callers can register routes before the HTTP listener has
+ *                     bound a port (baseUrl is only consumed inside handlers).
+ * @param basePath - Optional prefix the server is mounted under (e.g. "/api")
  */
 export function setupOAuthRoutes(
-  app: Hono,
+  rootApp: Hono,
   oauth: OAuthProvider | OAuthProxy,
-  baseUrl: string
+  getBaseUrl: () => string,
+  basePath: string = ""
 ): void {
   const proxyMode = isOAuthProxy(oauth);
-  // Enable CORS for all OAuth-related endpoints
-  // This is required for browser-based MCP clients to discover OAuth metadata
-  app.use(
-    "/.well-known/*",
+  // `getBaseUrl()` returns the server origin (no path); `basePath` is the
+  // externally-visible prefix the server is mounted under. The combination
+  // (resolved lazily inside each handler) is what goes into discovery metadata
+  // so clients land on the right paths.
+  // - /authorize, /token, /register live under `basePath` — registered on
+  //   a `.basePath()` clone so the prefix is prepended automatically.
+  // - .well-known/* discovery lives at the host root on `rootApp`. Per
+  //   RFC 8414 §3.1, the discovery URL is `<host>/.well-known/<type>` with
+  //   the issuer's path appended *after* the well-known segment — not
+  //   `<host>/<basePath>/.well-known/...`. Registering on `rootApp` keeps
+  //   the well-known endpoints at the literal host root regardless of
+  //   `basePath` (unlike `/_mcp-use/*`, which now lives under basePath).
+  const app = basePath ? rootApp.basePath(basePath) : rootApp;
+  const getPrefixedBaseUrl = () => `${getBaseUrl()}${basePath}`;
+  // Enable CORS for all OAuth-related discovery endpoints on rootApp.
+  rootApp.use(
+    "/.well-known/oauth-*",
     cors({
       origin: "*", // Allow all origins for metadata discovery
       allowMethods: ["GET", "OPTIONS"],
       allowHeaders: ["Content-Type", "Authorization"],
       exposeHeaders: ["Content-Type"],
       maxAge: 86400, // Cache preflight for 24 hours
+    })
+  );
+  rootApp.use(
+    "/.well-known/openid-configuration*",
+    cors({
+      origin: "*",
+      allowMethods: ["GET", "OPTIONS"],
+      allowHeaders: ["Content-Type", "Authorization"],
+      exposeHeaders: ["Content-Type"],
+      maxAge: 86400,
     })
   );
 
@@ -290,11 +317,12 @@ export function setupOAuthRoutes(
       const proxy = oauth as OAuthProxy;
       console.log(`[OAuth] Returning proxy mode metadata`);
 
+      const prefixedBaseUrl = getPrefixedBaseUrl();
       return c.json({
-        issuer: baseUrl,
-        authorization_endpoint: `${baseUrl}/authorize`,
-        token_endpoint: `${baseUrl}/token`,
-        registration_endpoint: `${baseUrl}/register`,
+        issuer: prefixedBaseUrl,
+        authorization_endpoint: `${prefixedBaseUrl}/authorize`,
+        token_endpoint: `${prefixedBaseUrl}/token`,
+        registration_endpoint: `${prefixedBaseUrl}/register`,
         scopes_supported: oauth.getScopesSupported(),
         response_types_supported: ["code"],
         grant_types_supported: oauth.getGrantTypesSupported(),
@@ -343,15 +371,37 @@ export function setupOAuthRoutes(
     }
   };
 
-  // Register the handler for both OAuth and OpenID Connect discovery endpoints
-  app.get(
+  // Discovery URLs the SDK probes (see `buildDiscoveryUrls` in
+  // @modelcontextprotocol/sdk client/auth.js). The SDK tries the path-aware
+  // variant first (well-known segment with the issuer's path appended), then
+  // falls back to root. Register both so either probe wins.
+  //
+  // With `basePath: "/api"` and issuer `http://host/api`:
+  //   path-aware: GET /.well-known/oauth-authorization-server/api
+  //   root:       GET /.well-known/oauth-authorization-server
+  rootApp.get(
     "/.well-known/oauth-authorization-server",
     handleAuthorizationServerMetadata
   );
-  app.get(
+  rootApp.get(
     "/.well-known/openid-configuration",
     handleAuthorizationServerMetadata
   );
+  if (basePath) {
+    rootApp.get(
+      `/.well-known/oauth-authorization-server${basePath}`,
+      handleAuthorizationServerMetadata
+    );
+    rootApp.get(
+      `/.well-known/openid-configuration${basePath}`,
+      handleAuthorizationServerMetadata
+    );
+    // OIDC Discovery 1.0 style — well-known appended after the path.
+    rootApp.get(
+      `${basePath}/.well-known/openid-configuration`,
+      handleAuthorizationServerMetadata
+    );
+  }
 
   /**
    * OAuth Protected Resource Metadata
@@ -360,32 +410,47 @@ export function setupOAuthRoutes(
    * DCR-direct mode: Points to the actual OAuth provider.
    * Proxy mode: Points to the local server (which proxies to upstream).
    */
-  app.get("/.well-known/oauth-protected-resource", (c: Context) => {
-    // In proxy mode, the authorization server is the local proxy
-    const authServer = proxyMode ? baseUrl : oauth.getIssuer();
-
+  const handleProtectedResourceMetadata = (c: Context) => {
+    const prefixedBaseUrl = getPrefixedBaseUrl();
+    const authServer = proxyMode ? prefixedBaseUrl : oauth.getIssuer();
     console.log(`[OAuth] Protected resource metadata request`);
-    console.log(`[OAuth]   - Resource: ${baseUrl}`);
+    console.log(`[OAuth]   - Resource: ${prefixedBaseUrl}`);
     console.log(`[OAuth]   - Authorization server: ${authServer}`);
-
     return c.json({
-      resource: baseUrl,
+      resource: prefixedBaseUrl,
       authorization_servers: [authServer],
       scopes_supported: oauth.getScopesSupported(),
       bearer_methods_supported: ["header"],
     });
-  });
+  };
 
-  // Path-scoped protected resource metadata per RFC 9728 — declares that the
-  // `/mcp` path specifically is the protected resource.
-  app.get("/.well-known/oauth-protected-resource/mcp", (c: Context) => {
-    const authServer = proxyMode ? baseUrl : oauth.getIssuer();
-
+  const handleProtectedResourceMetadataMcp = (c: Context) => {
+    const prefixedBaseUrl = getPrefixedBaseUrl();
+    const authServer = proxyMode ? prefixedBaseUrl : oauth.getIssuer();
     return c.json({
-      resource: `${baseUrl}/mcp`,
+      resource: `${prefixedBaseUrl}/mcp`,
       authorization_servers: [authServer],
       scopes_supported: oauth.getScopesSupported(),
       bearer_methods_supported: ["header"],
     });
-  });
+  };
+
+  rootApp.get(
+    "/.well-known/oauth-protected-resource",
+    handleProtectedResourceMetadata
+  );
+  // Path-scoped protected resource metadata per RFC 9728 — declares the MCP
+  // endpoint as the protected resource.
+  rootApp.get(
+    `/.well-known/oauth-protected-resource${basePath}/mcp`,
+    handleProtectedResourceMetadataMcp
+  );
+  if (basePath) {
+    // Also expose the basePath-scoped variant without the `/mcp` suffix, in
+    // case a client probes the issuer URL (`<host>/<basePath>`) directly.
+    rootApp.get(
+      `/.well-known/oauth-protected-resource${basePath}`,
+      handleProtectedResourceMetadata
+    );
+  }
 }

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/setup.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/setup.ts
@@ -5,58 +5,64 @@
  * Supports both DCR-direct mode (OAuthProvider) and proxy mode (OAuthProxy).
  */
 
-import type { Hono as HonoType, Context, Next } from "hono";
+import type { Hono as HonoType } from "hono";
 import { setupOAuthRoutes, isOAuthProxy } from "./routes.js";
 import { createBearerAuthMiddleware } from "./middleware.js";
 import type { OAuthProvider, OAuthProxy } from "./providers/types.js";
 
 /**
- * OAuth setup state
- */
-interface OAuthSetupState {
-  provider?: OAuthProvider | OAuthProxy;
-  middleware?: (c: Context, next: Next) => Promise<Response | void>;
-  complete: boolean;
-}
-
-/**
- * Setup OAuth authentication for MCP server
+ * Setup OAuth authentication for MCP server.
  *
- * Initializes OAuth provider/proxy, creates bearer auth middleware,
- * sets up OAuth routes, and applies auth to /mcp endpoints.
+ * Initializes OAuth provider/proxy, creates bearer auth middleware, sets up
+ * OAuth routes, and applies auth to /mcp endpoints. Synchronous — registers
+ * routes against the supplied Hono and returns immediately. baseUrl is a
+ * lazy getter consumed inside request handlers, so this can run before the
+ * HTTP listener has bound a port.
  *
  * Supports two modes:
  * - DCR-direct (OAuthProvider): Clients authenticate directly with upstream
  * - Proxy (OAuthProxy): Server proxies OAuth flow with pre-registered credentials
  *
- * @param app - Hono app instance
+ * @param rootApp - Underlying Hono app (the un-prefixed root view). Must NOT
+ *                  be a `.basePath()` clone, because `.well-known/*` discovery
+ *                  has to land at the literal host root (RFC 8414 §3.1) and
+ *                  this function does its own basePath clone internally for
+ *                  `/authorize`, `/token`, `/register`.
  * @param oauth - OAuth provider or proxy instance
- * @param baseUrl - Server base URL for OAuth redirects
- * @param state - OAuth setup state to track completion
- * @returns Updated OAuth setup state with provider and middleware
+ * @param getBaseUrl - Lazy getter for the server base URL. Called per-request.
+ * @param basePath - Optional basePath prefix to scope authorize/token/register under
  */
-export async function setupOAuthForServer(
-  app: HonoType,
+export function setupOAuthForServer(
+  rootApp: HonoType,
   oauth: OAuthProvider | OAuthProxy,
-  baseUrl: string,
-  state: OAuthSetupState
-): Promise<OAuthSetupState> {
-  if (state.complete) {
-    return state; // Already setup
-  }
-
+  getBaseUrl: () => string,
+  basePath: string = ""
+): void {
   const proxyMode = isOAuthProxy(oauth);
   console.log(`[OAuth] OAuth ${proxyMode ? "proxy" : "provider"} initialized`);
 
-  // Create bearer auth middleware with baseUrl for WWW-Authenticate header
-  const middleware = createBearerAuthMiddleware(oauth, baseUrl);
+  // Create bearer auth middleware. The WWW-Authenticate `resource_metadata`
+  // URL points at the path-aware discovery URL per RFC 9728 §3.1:
+  // `<host>/.well-known/oauth-protected-resource<basePath>/mcp` — identifying
+  // the MCP endpoint specifically as the protected resource. The matching
+  // route is registered by `setupOAuthRoutes` on the root app.
+  const middleware = createBearerAuthMiddleware(oauth, getBaseUrl, basePath);
 
-  // Setup OAuth routes
-  setupOAuthRoutes(app, oauth, baseUrl);
+  // Setup OAuth routes:
+  // - /authorize, /token, /register live under `basePath`
+  // - .well-known/* discovery lives at the host root
+  setupOAuthRoutes(rootApp, oauth, getBaseUrl, basePath);
+
+  // External (user-visible) paths for log messages.
+  const externalAuthorize = `${basePath}/authorize`;
+  const externalToken = `${basePath}/token`;
+  const externalRegister = `${basePath}/register`;
+  const externalMcp = `${basePath}/mcp`;
+  const externalWellKnown = `/.well-known/*`;
 
   if (proxyMode) {
     console.log(
-      "[OAuth] Proxy mode: clients use local /authorize, /token, /register endpoints"
+      `[OAuth] Proxy mode: clients use local ${externalAuthorize}, ${externalToken}, ${externalRegister} endpoints`
     );
     console.log("[OAuth] Credentials will be injected at token exchange");
   } else {
@@ -64,15 +70,16 @@ export async function setupOAuthForServer(
       "[OAuth] Clients will authenticate with provider directly via DCR"
     );
   }
-  console.log("[OAuth] Metadata endpoints: /.well-known/*");
+  console.log(`[OAuth] Metadata endpoints: ${externalWellKnown}`);
 
-  // Apply bearer auth to all /mcp routes
+  // Apply bearer auth to the MCP transport routes. Registered on a basePath
+  // clone so the middleware path is prefixed automatically; both
+  // `rootApp.basePath('/api').use('/mcp/*', mw)` and
+  // `rootApp.use('/api/mcp/*', mw)` would work — using the clone keeps the
+  // prefix concern out of this function.
+  const app = basePath ? rootApp.basePath(basePath) : rootApp;
   app.use("/mcp/*", middleware);
-  console.log("[OAuth] Bearer authentication enabled on /mcp routes");
-
-  return {
-    provider: oauth,
-    middleware: middleware,
-    complete: true,
-  };
+  console.log(
+    `[OAuth] Bearer authentication enabled on ${externalMcp}/* routes`
+  );
 }

--- a/libraries/typescript/packages/mcp-use/src/server/types/common.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/types/common.ts
@@ -73,6 +73,21 @@ export interface ServerConfig {
    */
   baseUrl?: string;
   /**
+   * Mount every route the server registers under this path prefix.
+   *
+   * Affects the MCP transport (`/mcp`, `/sse`), the inspector UI, widget +
+   * public asset routes, OAuth flow + metadata endpoints, and the bearer-auth
+   * middleware. With `basePath: "/api"` the MCP transport is reachable at
+   * `/api/mcp`, the inspector at `/api/inspector`, etc.
+   *
+   * Must start with a `/` and must not end with one. An empty string or `"/"`
+   * means "no prefix" (the default).
+   *
+   * @example "/api"
+   * @example "/mcp-server"
+   */
+  basePath?: string;
+  /**
    * Custom CORS options for the server.
    *
    * By default, mcp-use enables permissive CORS (`origin: "*"`) for development ergonomics.

--- a/libraries/typescript/packages/mcp-use/src/server/types/resource.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/types/resource.ts
@@ -695,7 +695,7 @@ export interface WidgetManifest {
 export interface DiscoverWidgetsOptions {
   /**
    * Path to widgets directory.
-   * Defaults to dist/resources/mcp-use/widgets.
+   * Defaults to .mcp-use/widgets.
    *
    * @example "./resources/widgets"
    */

--- a/libraries/typescript/packages/mcp-use/src/server/utils/hono-proxy.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/utils/hono-proxy.ts
@@ -68,17 +68,30 @@ const HMR_HTTP_METHODS = new Set([
  * custom route handlers from the mutable _customRoutes map.
  * This is called once at server startup so we never need to add
  * routes to Hono after the matcher is built (which would fail in Hono v4+).
+ *
+ * When the server is configured with a `basePath`, this middleware lives on
+ * the inner (sub-mounted) Hono. `c.req.path` is the full original URL path
+ * (Hono preserves it across sub-mounts), so we strip the prefix before
+ * looking up handlers — user code calls `server.get("/foo", ...)` and the
+ * request arrives at `${basePath}/foo`. The `getBasePath` accessor is read
+ * at dispatch time rather than captured, so the value is correct even if
+ * the field is set after this function runs.
  */
 export function installCustomRoutesMiddleware(
   app: HonoType,
-
-  customRoutes: Map<string, ((...args: any[]) => any)[]>
+  customRoutes: Map<string, ((...args: any[]) => any)[]>,
+  getBasePath: () => string = () => ""
 ): void {
   // Register a single catch-all middleware that checks the custom routes map
   // Must use `all` to match any HTTP method
   app.all("*", async (c: any, next: any) => {
     const method = c.req.method.toLowerCase();
-    const path = c.req.path;
+    const basePath = getBasePath();
+    const rawPath = c.req.path as string;
+    const path =
+      basePath && rawPath.startsWith(basePath)
+        ? rawPath.slice(basePath.length) || "/"
+        : rawPath;
 
     // Check for exact match: "get:/api/fruits"
     const key = `${method}:${path}`;

--- a/libraries/typescript/packages/mcp-use/src/server/utils/server-helpers.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/utils/server-helpers.ts
@@ -10,6 +10,44 @@ import { hostHeaderValidation } from "../middleware/host-validation.js";
 import { getEnv } from "./runtime.js";
 
 /**
+ * Resolve relative icon `src` values to absolute URLs under the framework's
+ * public asset prefix (`${basePath}/_mcp-use/public/`). Paths already
+ * starting with `http` are passed through unchanged. Returns
+ * `undefined`/the original array when `icons` or `baseUrl` is missing.
+ */
+export function resolveIconUrls<
+  T extends { src: string } = { src: string; [k: string]: unknown },
+>(
+  icons: T[] | undefined,
+  baseUrl?: string,
+  basePath: string = ""
+): T[] | undefined {
+  if (!icons || !baseUrl) return icons;
+  return icons.map((icon) => ({
+    ...icon,
+    src: icon.src.startsWith("http")
+      ? icon.src
+      : `${baseUrl}${basePath}/_mcp-use/public/${icon.src}`,
+  }));
+}
+
+/**
+ * Normalize a user-supplied `basePath` into the form the rest of the server
+ * expects: empty string for "no prefix", otherwise a leading `/` with no
+ * trailing `/`. Throws if the input is shaped wrong so misconfiguration shows
+ * up at startup rather than as confusing 404s.
+ */
+export function normalizeBasePath(input: string | undefined): string {
+  if (input === undefined || input === "" || input === "/") return "";
+  if (!input.startsWith("/")) {
+    throw new Error(
+      `[MCP] basePath must start with "/", got ${JSON.stringify(input)}`
+    );
+  }
+  return input.replace(/\/+$/, "");
+}
+
+/**
  * Get default CORS configuration for MCP server
  *
  * @returns CORS options object for Hono cors middleware

--- a/libraries/typescript/packages/mcp-use/src/server/utils/server-info-file.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/utils/server-info-file.ts
@@ -1,0 +1,60 @@
+/**
+ * Best-effort handshake file written after a server starts listening.
+ *
+ * The file lives at `.mcp-use/server-info.json` and lets out-of-process
+ * tooling (CLI, inspector launcher) discover the running server's basePath
+ * and constructed URLs without an HTTP discovery endpoint.
+ *
+ * Failures are swallowed — startup must never block on the file write.
+ * Stale files are tolerated: next `listen()` overwrites them, and the cost
+ * of a stale read is one 404 on auto-open.
+ */
+
+import { isDeno } from "./runtime.js";
+
+export interface ServerInfoFile {
+  host: string;
+  port: number;
+  basePath: string;
+  mcpUrl: string;
+  inspectorUrl: string;
+  writtenAt: string;
+}
+
+/**
+ * Write the server-info handshake file. Best-effort: swallows errors so
+ * startup never blocks. Skipped on Deno (no filesystem write here).
+ */
+export async function writeServerInfoFile(info: {
+  host: string;
+  port: number;
+  basePath: string;
+}): Promise<void> {
+  if (isDeno) return;
+
+  try {
+    const { promises: fs } = await import("node:fs");
+    const path = await import("node:path");
+    const dir = path.join(process.cwd(), ".mcp-use");
+    await fs.mkdir(dir, { recursive: true });
+
+    const browserHost = info.host === "0.0.0.0" ? "localhost" : info.host;
+    const origin = `http://${browserHost}:${info.port}`;
+    const payload: ServerInfoFile = {
+      host: info.host,
+      port: info.port,
+      basePath: info.basePath,
+      mcpUrl: `${origin}${info.basePath}/mcp`,
+      inspectorUrl: `${origin}${info.basePath}/inspector`,
+      writtenAt: new Date().toISOString(),
+    };
+
+    await fs.writeFile(
+      path.join(dir, "server-info.json"),
+      JSON.stringify(payload, null, 2),
+      "utf8"
+    );
+  } catch {
+    // swallow — never block startup on this
+  }
+}

--- a/libraries/typescript/packages/mcp-use/src/server/utils/server-lifecycle.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/utils/server-lifecycle.ts
@@ -7,6 +7,7 @@
 import chalk from "chalk";
 import type { Hono as HonoType } from "hono";
 import { getEnv, isDeno } from "./runtime.js";
+import { writeServerInfoFile } from "./server-info-file.js";
 
 export function isProductionMode(): boolean {
   // Only check NODE_ENV - CLI commands set this explicitly
@@ -127,8 +128,11 @@ export async function startServer(
   options?: {
     onDenoRequest?: (req: Request) => Request | Promise<Request>;
     onDenoResponse?: (res: Response) => Response | Promise<Response>;
+    /** Configured base path (e.g. "/api"). Empty for no prefix. */
+    basePath?: string;
   }
 ): Promise<HttpServerHandle> {
+  const basePath = options?.basePath ?? "";
   if (isDeno) {
     // Deno runtime
     const corsHeaders = getDenoCorsHeaders();
@@ -164,7 +168,7 @@ export async function startServer(
     console.log(`[SERVER] Listening`);
     console.log(
       chalk.gray(
-        `[MCP] Tip: connect with the CLI → npx mcp-use client connect http://${host}:${port}/mcp`
+        `[MCP] Tip: connect with the CLI → npx mcp-use client connect http://${host}:${port}${basePath}/mcp`
       )
     );
     return {
@@ -181,11 +185,14 @@ export async function startServer(
         hostname: host,
       },
       (_info: any) => {
+        // Best-effort handshake file written before the first log line so
+        // tooling that waits for the server can read basePath from disk.
+        void writeServerInfoFile({ host, port, basePath });
         console.log(`[SERVER] Listening on http://${host}:${port}`);
-        console.log(`[MCP] Endpoints: http://${host}:${port}/mcp`);
+        console.log(`[MCP] Endpoints: http://${host}:${port}${basePath}/mcp`);
         console.log(
           chalk.gray(
-            `[MCP] Tip: connect with the CLI → npx mcp-use client connect http://${host}:${port}/mcp`
+            `[MCP] Tip: connect with the CLI → npx mcp-use client connect http://${host}:${port}${basePath}/mcp`
           )
         );
       }

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/index.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/index.ts
@@ -28,7 +28,7 @@ export { uiResourceRegistration } from "./ui-resource-registration.js";
  * In production mode: serves pre-built static widgets
  *
  * @param options - Configuration options
- * @param options.baseRoute - Base route for widgets (defaults to '/mcp-use/widgets')
+ * @param options.baseRoute - Base route for widgets (defaults to '/_mcp-use/widgets')
  * @param options.resourcesDir - Directory containing widget files (defaults to 'resources')
  * @returns Promise that resolves when all widgets are mounted
  */
@@ -48,6 +48,7 @@ export async function mountWidgets(
     buildId: (server as any).buildId,
     favicon: (server as any).favicon,
     publicRoutesMode: (server as any).publicRoutesMode,
+    basePath: (server as any).basePath ?? "",
     /** Pre-created HTTP server for Vite HMR WebSocket support */
     httpServer: (server as any)._httpServer as
       | import("http").Server
@@ -77,12 +78,18 @@ export async function mountWidgets(
     (server as any).removeWidgetTool(toolName);
   };
 
-  const app = server.app;
+  // `/_mcp-use/widgets/*`, `/_mcp-use/public/*`, and `/favicon.ico` all live
+  // under the configured `basePath` (empty string == host root). Pass the
+  // basePath-aware Hono view so registrations get auto-prefixed. This is
+  // also the same Hono instance handed to `startServer()`, so attaching
+  // `__viteWsProxy` to it lets the lifecycle helper pick the WS proxy up.
+  const app = (server as any).app as import("hono").Hono;
+  const basePath = serverConfig.basePath;
 
   if (isProductionMode() || isDeno) {
     console.log("[WIDGETS] Mounting widgets in production mode");
     // Setup routes first for production
-    setupWidgetRoutes(app, serverConfig);
+    setupWidgetRoutes(app, serverConfig, basePath);
     (server as any).publicRoutesMode = "production";
     await mountWidgetsProduction(app, serverConfig, registerWidget, options);
   } else {

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/mcp-ui-adapter.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/mcp-ui-adapter.ts
@@ -26,6 +26,8 @@ export interface UrlConfig {
   baseUrl: string;
   port: number | string;
   buildId?: string;
+  /** Server basePath prefix (e.g. "/api"). Empty string when unset. */
+  basePath?: string;
 }
 
 /**
@@ -47,8 +49,9 @@ export function buildWidgetUrl(
   // This must be imported dynamically to avoid circular dependencies
   const slugifiedWidget = slugifyWidgetName(widget);
 
+  const basePath = config.basePath ?? "";
   const url = new URL(
-    `/mcp-use/widgets/${slugifiedWidget}`,
+    `${basePath}/_mcp-use/widgets/${slugifiedWidget}`,
     `${config.baseUrl}:${config.port}`
   );
 

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/mount-widgets-dev.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/mount-widgets-dev.ts
@@ -23,7 +23,7 @@ import type {
   UpdateWidgetToolCallback,
 } from "./widget-types.js";
 
-const TMP_MCP_USE_DIR = ".mcp-use";
+const TMP_MCP_USE_DIR = pathHelpers.join(".mcp-use", ".tmp");
 
 const DEFAULT_HMR_PORT = 24678;
 
@@ -91,7 +91,13 @@ export async function mountWidgetsDev(
   options?: MountWidgetsDevOptions
 ): Promise<void> {
   const { promises: fs } = await import("node:fs");
-  const baseRoute = options?.baseRoute || "/mcp-use/widgets";
+  const baseRoute = options?.baseRoute || "/_mcp-use/widgets";
+  const basePath = serverConfig.basePath ?? "";
+  // Widget routes register on the basePath-aware Hono view so they land at
+  // `${basePath}${baseRoute}/*`. `externalBaseRoute` is the full
+  // browser-visible prefix (basePath + baseRoute) used for HTML emission,
+  // Vite's `base`, and the HMR WS upgrade matcher.
+  const externalBaseRoute = `${basePath}${baseRoute}`;
   // Resolution order for the widgets directory:
   //   1. Caller-supplied `options.resourcesDir`
   //   2. `MCP_USE_WIDGETS_DIR` env var (set by @mcp-use/cli when --mcp-dir
@@ -301,10 +307,8 @@ if (container && Component) {
 `;
 
     // Include Vite client and React refresh preamble explicitly
-    // This is needed when loading in sandboxed iframes where auto-injection may not work
-    // Use the base route path (not full URL) so URLs resolve against the document origin.
-    // This works both locally and behind reverse proxies (ngrok, E2B, etc.)
-    const fullBaseUrl = `${serverConfig.serverBaseUrl}${baseRoute}`;
+    // This is needed when loading in sandboxed iframes where auto-injection may not work.
+    // URLs use `externalBaseRoute` so they resolve under `basePath` when set.
     const htmlContent = `<!doctype html>
 <html lang="en">
   <head>
@@ -313,12 +317,12 @@ if (container && Component) {
     <title>${widget.name} Widget</title>${
       serverConfig.favicon
         ? `
-    <link rel="icon" href="${serverConfig.serverBaseUrl.replace(/\/$/, "")}/mcp-use/public/${serverConfig.favicon}" />`
+    <link rel="icon" href="${basePath}/_mcp-use/public/${serverConfig.favicon}" />`
         : ""
     }
-    <script type="module" src="${fullBaseUrl}/@vite/client"></script>
+    <script type="module" src="${externalBaseRoute}/@vite/client"></script>
     <script type="module">
-      import RefreshRuntime from '${fullBaseUrl}/@react-refresh';
+      import RefreshRuntime from '${externalBaseRoute}/@react-refresh';
       RefreshRuntime.injectIntoGlobalHook(window);
       window.$RefreshReg$ = () => {};
       window.$RefreshSig$ = () => (type) => type;
@@ -327,7 +331,7 @@ if (container && Component) {
   </head>
   <body>
     <div id="widget-root"></div>
-    <script type="module" src="${fullBaseUrl}/${slugifiedName}/entry.tsx"></script>
+    <script type="module" src="${externalBaseRoute}/${slugifiedName}/entry.tsx"></script>
   </body>
 </html>`;
 
@@ -546,8 +550,7 @@ if (container && Component) {
 }
 `;
 
-        // Use the base route path for URLs so they resolve against the document origin
-        const fullBaseUrl = `${serverConfig.serverBaseUrl}${baseRoute}`;
+        // URLs use `externalBaseRoute` so they resolve under `basePath` when set.
         const htmlContent = `<!doctype html>
 <html lang="en">
   <head>
@@ -556,12 +559,12 @@ if (container && Component) {
     <title>${widgetName} Widget</title>${
       serverConfig.favicon
         ? `
-    <link rel="icon" href="${serverConfig.serverBaseUrl.replace(/\/$/, "")}/mcp-use/public/${serverConfig.favicon}" />`
+    <link rel="icon" href="${basePath}/_mcp-use/public/${serverConfig.favicon}" />`
         : ""
     }
-    <script type="module" src="${fullBaseUrl}/@vite/client"></script>
+    <script type="module" src="${externalBaseRoute}/@vite/client"></script>
     <script type="module">
-      import RefreshRuntime from '${fullBaseUrl}/@react-refresh';
+      import RefreshRuntime from '${externalBaseRoute}/@react-refresh';
       RefreshRuntime.injectIntoGlobalHook(window);
       window.$RefreshReg$ = () => {};
       window.$RefreshSig$ = () => (type) => type;
@@ -570,7 +573,7 @@ if (container && Component) {
   </head>
   <body>
     <div id="widget-root"></div>
-    <script type="module" src="${fullBaseUrl}/${slugifiedName}/entry.tsx"></script>
+    <script type="module" src="${externalBaseRoute}/${slugifiedName}/entry.tsx"></script>
   </body>
 </html>`;
 
@@ -697,11 +700,7 @@ if (container && Component) {
           let html = "";
           try {
             html = await fsHelpers.readFileSync(htmlPath);
-            html = processWidgetHtml(
-              html,
-              widgetName,
-              serverConfig.serverBaseUrl
-            );
+            html = processWidgetHtml(html, widgetName);
           } catch (e) {
             console.warn(
               `[WIDGET-HMR] Failed to read HTML for ${widgetName}:`,
@@ -1147,7 +1146,11 @@ export default PostHog;
 
   const viteServer = await createServer({
     root: tempDir,
-    base: baseRoute + "/",
+    // Vite's HMR client derives its WebSocket URL from `base`, and asset URLs
+    // emitted by Vite's transform pass use the same value. The browser sees
+    // the full `${basePath}${baseRoute}/` prefix, so that's what Vite emits;
+    // the Hono middleware strips both before forwarding to Vite internally.
+    base: externalBaseRoute + "/",
     plugins: [
       serverOnlyGuard,
       zodJitlessPlugin,
@@ -1296,13 +1299,17 @@ export default PostHog;
 
     // Store the proxy setup function - it will be called when the HTTP server is available
     const hmrPort = viteHmrPort;
-    const widgetRoute = baseRoute;
     // Pre-import net module at setup time (works in both CJS and ESM)
     const netModule = await import("node:net");
     const setupWsProxy = (httpServer: import("http").Server) => {
       httpServer.on("upgrade", (req: any, socket: any, head: any) => {
-        // Only proxy requests to the widget base route
-        if (req.url?.startsWith(`${widgetRoute}/`) || req.url === widgetRoute) {
+        // Match the browser-visible URL (basePath + baseRoute) — the HMR
+        // client connects through the configured `base` so the upgrade
+        // request carries the same prefix the page used.
+        if (
+          req.url?.startsWith(`${externalBaseRoute}/`) ||
+          req.url === externalBaseRoute
+        ) {
           const upstream = netModule.createConnection(
             { port: hmrPort, host: "localhost" },
             () => {
@@ -1326,11 +1333,15 @@ export default PostHog;
       });
     };
 
-    // Store for later use when HTTP server is available
+    // Stash the proxy setup on `app`. The same Hono instance is passed to
+    // `startServer()`, where the lifecycle helper reads `__viteWsProxy` off
+    // it. The HTTP server proxy itself looks at the raw upgrade URL, which
+    // carries the full basePath-prefixed path the browser used.
     (app as any).__viteWsProxy = setupWsProxy;
   }
 
-  // Custom middleware to handle widget-specific paths
+  // Custom middleware to handle widget-specific paths. Registered on the
+  // basePath-aware Hono view so it auto-prefixes under `basePath`.
   app.use(`${baseRoute}/*`, async (c: Context, next: Next) => {
     const url = new URL(c.req.url);
     const pathname = url.pathname;
@@ -1345,16 +1356,17 @@ export default PostHog;
       );
 
       if (widget) {
-        // If requesting the root of a widget, serve its index.html
-        // Use slugified name for URL paths
+        // If requesting the root of a widget, serve its index.html.
         const relativePath = pathname.replace(baseRoute, "");
         if (
           relativePath === `/${slugifiedNameFromUrl}` ||
           relativePath === `/${slugifiedNameFromUrl}/`
         ) {
-          // Rewrite the URL for Vite by creating a new request with modified URL
+          // Rewrite the URL for Vite by creating a new request with modified URL.
+          // The connect adapter below strips `externalBaseRoute` before
+          // handing the URL to Vite, so the full prefix must be present here.
           const newUrl = new URL(c.req.url);
-          newUrl.pathname = `${baseRoute}/${slugifiedNameFromUrl}/index.html`;
+          newUrl.pathname = `${externalBaseRoute}/${slugifiedNameFromUrl}/index.html`;
           // Create a new request with modified URL and update the context
           const newRequest = new Request(newUrl.toString(), c.req.raw);
           // Update the request in the context by creating a new context-like object
@@ -1374,15 +1386,21 @@ export default PostHog;
     await next();
   });
 
-  // Mount the single Vite server for all widgets using adapter
+  // Mount the single Vite server for all widgets using adapter.
+  // The adapter strips its `middlewarePath` prefix from `c.req.raw.url`
+  // before handing the request to Vite. Vite's `base` is set to
+  // `externalBaseRoute + "/"`, so we strip the same prefix here — the
+  // request the underlying middleware sees is bare, exactly as it would be
+  // without any prefix.
   const viteMiddleware = await adaptConnectMiddleware(
     viteServer.middlewares,
-    `${baseRoute}/*`
+    `${externalBaseRoute}/*`
   );
   app.use(`${baseRoute}/*`, viteMiddleware);
 
-  // Serve static files from public directory in dev mode
-  // Only set up if not already configured (e.g., in constructor)
+  // Serve static files from public directory in dev mode. Public + favicon
+  // register on the basePath-aware app so they land at
+  // `${basePath}/_mcp-use/public/*` and `${basePath}/favicon.ico`.
   if (!serverConfig.publicRoutesMode) {
     setupPublicRoutes(app, false);
     setupFaviconRoute(app, serverConfig.favicon, false);

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/mount-widgets-production.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/mount-widgets-production.ts
@@ -1,7 +1,7 @@
 /**
  * Production mode widget mounting
  *
- * This module handles serving pre-built widgets from the dist/resources/widgets/ directory.
+ * This module handles serving pre-built widgets from the .mcp-use/widgets/ directory.
  * Widgets are built using the 'mcp-use build' command and served as static files in production.
  */
 
@@ -21,36 +21,36 @@ import type {
 type MountWidgetsProductionOptions = MountWidgetsOptions;
 
 /**
- * Mount pre-built widgets from dist/resources/widgets/ directory in production mode
+ * Mount pre-built widgets from .mcp-use/widgets/ directory in production mode
  *
  * Serves static widget bundles that were built using the build command.
  * Reads the manifest file to discover available widgets and their metadata,
  * then registers each widget as both a tool and resource.
  *
- * @param app - Hono app instance (not used directly, kept for consistency)
+ * @param _app - basePath-aware Hono view (currently unused; kept for
+ *   signature parity with the dev variant and future static-route needs)
  * @param serverConfig - Server configuration (baseUrl, CSP URLs, buildId)
  * @param registerWidget - Callback to register each discovered widget
  * @param options - Optional configuration (baseRoute)
  * @returns Promise that resolves when all widgets are mounted
  */
 export async function mountWidgetsProduction(
-  app: HonoType,
+  _app: HonoType,
   serverConfig: ServerConfig,
   registerWidget: RegisterWidgetCallback,
   options?: MountWidgetsProductionOptions
 ): Promise<void> {
-  const baseRoute = options?.baseRoute || "/mcp-use/widgets";
+  const baseRoute = options?.baseRoute || "/_mcp-use/widgets";
   const widgetsDir = pathHelpers.join(
     isDeno ? "." : getCwd(),
-    "dist",
-    "resources",
+    ".mcp-use",
     "widgets"
   );
 
   console.log("widgetsDir", widgetsDir);
 
   // Discover built widgets from manifest
-  const manifestPath = "./dist/mcp-use.json";
+  const manifestPath = "./.mcp-use/manifest.json";
   let widgets: string[] = [];
   let widgetsMetadata: Record<string, any> = {};
 
@@ -109,7 +109,7 @@ export async function mountWidgetsProduction(
   }
 
   console.log(
-    `[WIDGETS] Serving ${widgets.length} pre-built widget(s) from dist/resources/widgets/`
+    `[WIDGETS] Serving ${widgets.length} pre-built widget(s) from .mcp-use/widgets/`
   );
 
   // Register tools and resources for each widget

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/setup-widget-routes.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/setup-widget-routes.ts
@@ -1,127 +1,101 @@
 /**
  * Static widget route handlers
  *
- * This module sets up HTTP routes for serving widget assets, HTML files,
- * and public resources in production mode.
+ * In production, `${basePath}/_mcp-use/*` is a pure static-file namespace
+ * mapped to `.mcp-use/` on disk — Next.js-style. Built HTML already contains
+ * the runtime globals it needs (baked in by the CLI's `buildWidgets`), so
+ * the framework just ships bytes.
  */
 
-import type { Hono as HonoType, Context } from "hono";
-import { pathHelpers, fsHelpers, getCwd } from "../utils/runtime.js";
-import {
-  getContentType,
-  processWidgetHtml,
-  setupPublicRoutes,
-  setupFaviconRoute,
-} from "./widget-helpers.js";
+import { serveStatic } from "@hono/node-server/serve-static";
+import type { Context, Hono as HonoType } from "hono";
+import { fsHelpers, getCwd, isDeno, pathHelpers } from "../utils/runtime.js";
+import { getContentType, setupFaviconRoute } from "./widget-helpers.js";
 import type { ServerConfig } from "./widget-types.js";
 
 /**
- * Setup static file serving routes for widgets
+ * Mount static routes for `${basePath}/_mcp-use/*` on the basePath-aware app.
  *
- * Creates HTTP routes to serve:
- * - Widget assets (JS, CSS, images) from dist/resources/widgets/{widget}/assets/
- * - Widget HTML files from dist/resources/widgets/{widget}/index.html
- * - Public files from dist/public/ or public/ directories
+ * Node + Bun: one `serveStatic` mount handles widgets, assets, and public
+ * files in a single middleware. Deno can't use `@hono/node-server`, so it
+ * falls back to hand-rolled handlers that go through the `fsHelpers`
+ * cross-runtime shim.
  *
- * These routes are used in production mode to serve pre-built widget bundles.
+ * Favicon is registered separately at `/favicon.ico` (basePath-prefixed
+ * to `${basePath}/favicon.ico`) because it needs an explicit Cache-Control
+ * header that `serveStatic` doesn't add by default.
  *
- * @param app - Hono app instance to mount routes on
- * @param serverConfig - Server configuration (baseUrl)
+ * @param app - basePath-aware Hono view. The `/_mcp-use/*` route below is
+ *   auto-prefixed to `${basePath}/_mcp-use/*`.
+ * @param serverConfig - Server configuration.
+ * @param basePath - Server basePath prefix (e.g. `/api`). Used by the
+ *   serveStatic rewriter to strip the prefix before mapping to disk paths.
  */
 export function setupWidgetRoutes(
   app: HonoType,
-  serverConfig: ServerConfig
+  serverConfig: ServerConfig,
+  basePath: string = ""
 ): void {
-  // Serve static assets (JS, CSS) from the assets directory
-  app.get("/mcp-use/widgets/:widget/assets/*", async (c: Context) => {
-    const widget = c.req.param("widget")!;
-    const assetFile = c.req.path.split("/assets/")[1];
-    const assetPath = pathHelpers.join(
-      getCwd(),
-      "dist",
-      "resources",
-      "widgets",
-      widget,
-      "assets",
-      assetFile
+  if (isDeno) {
+    setupWidgetRoutesDeno(app);
+  } else {
+    app.get(
+      "/_mcp-use/*",
+      serveStatic({
+        root: "./.mcp-use",
+        // Strip both the basePath prefix and the `/_mcp-use` namespace to
+        // get a path relative to `./.mcp-use/` on disk. Works whether or not
+        // basePath is set.
+        rewriteRequestPath: (p) =>
+          p.replace(new RegExp(`^${escapeRegex(basePath)}/_mcp-use`), ""),
+      })
     );
+  }
 
-    try {
-      if (await fsHelpers.existsSync(assetPath)) {
-        const content = await fsHelpers.readFile(assetPath);
-        const contentType = getContentType(assetFile);
-        return new Response(content, {
-          status: 200,
-          headers: { "Content-Type": contentType },
-        });
-      }
-      return c.notFound();
-    } catch {
-      return c.notFound();
-    }
-  });
-
-  // Handle assets served from the wrong path (browser resolves ./assets/ relative to /mcp-use/widgets/)
-  app.get("/mcp-use/widgets/assets/*", async (c: Context) => {
-    const assetFile = c.req.path.split("/assets/")[1];
-    // Try to find which widget this asset belongs to by checking all widget directories
-    const widgetsDir = pathHelpers.join(
-      getCwd(),
-      "dist",
-      "resources",
-      "widgets"
-    );
-
-    try {
-      const widgets = await fsHelpers.readdirSync(widgetsDir);
-      for (const widget of widgets) {
-        const assetPath = pathHelpers.join(
-          widgetsDir,
-          widget,
-          "assets",
-          assetFile
-        );
-        if (await fsHelpers.existsSync(assetPath)) {
-          const content = await fsHelpers.readFile(assetPath);
-          const contentType = getContentType(assetFile);
-          return new Response(content, {
-            status: 200,
-            headers: { "Content-Type": contentType },
-          });
-        }
-      }
-      return c.notFound();
-    } catch {
-      return c.notFound();
-    }
-  });
-
-  // Serve each widget's index.html at its route
-  // e.g. GET /mcp-use/widgets/kanban-board -> dist/resources/widgets/kanban-board/index.html
-  app.get("/mcp-use/widgets/:widget", async (c: Context) => {
-    const widget = c.req.param("widget")!;
-    const filePath = pathHelpers.join(
-      getCwd(),
-      "dist",
-      "resources",
-      "widgets",
-      widget,
-      "index.html"
-    );
-
-    try {
-      let html = await fsHelpers.readFileSync(filePath, "utf8");
-      // Process HTML with base URL injection and path conversion
-      html = processWidgetHtml(html, widget, serverConfig.serverBaseUrl);
-      return c.html(html);
-    } catch {
-      return c.notFound();
-    }
-  });
-
-  // Serve static files from public directory (production mode)
-  setupPublicRoutes(app, true);
-
-  // Setup favicon route at server root (production mode)
   setupFaviconRoute(app, serverConfig.favicon, true);
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Deno fallback — three small handlers backed by `fsHelpers.readFile`.
+ * Kept separate so the Node/Bun path stays a one-liner.
+ *
+ * The handlers slice `c.req.path` on the `/_mcp-use/...` segment instead of
+ * matching from the start, so they work regardless of basePath.
+ */
+function setupWidgetRoutesDeno(app: HonoType): void {
+  const serveDenoFile = async (
+    c: Context,
+    segments: string[]
+  ): Promise<Response> => {
+    const fullPath = pathHelpers.join(getCwd(), ".mcp-use", ...segments);
+    try {
+      const content = await fsHelpers.readFile(fullPath);
+      return new Response(content, {
+        status: 200,
+        headers: { "Content-Type": getContentType(segments.at(-1) ?? "") },
+      });
+    } catch {
+      return c.notFound();
+    }
+  };
+
+  app.get("/_mcp-use/widgets/:widget", async (c) => {
+    const widget = c.req.param("widget")!;
+    return serveDenoFile(c, ["widgets", widget, "index.html"]);
+  });
+
+  app.get("/_mcp-use/widgets/:widget/assets/*", async (c) => {
+    const widget = c.req.param("widget")!;
+    const assetFile = c.req.path.split("/assets/")[1] ?? "";
+    return serveDenoFile(c, ["widgets", widget, "assets", assetFile]);
+  });
+
+  app.get("/_mcp-use/public/*", async (c) => {
+    const filePath = c.req.path.split("/_mcp-use/public/")[1] ?? "";
+    return serveDenoFile(c, ["public", filePath]);
+  });
 }

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/ui-resource-registration.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/ui-resource-registration.ts
@@ -42,6 +42,8 @@ interface UIResourceServer {
   readonly serverHost: string;
   readonly serverPort?: number;
   readonly serverBaseUrl?: string;
+  /** Normalized basePath prefix (e.g. "/api"). Empty string when unset. */
+  readonly basePath?: string;
   /** Storage for widget definitions, used to inject metadata into tool responses */
   widgetDefinitions: Map<string, Record<string, unknown>>;
   /** Registrations storage for checking existing registrations (for HMR updates) */
@@ -274,6 +276,7 @@ export function uiResourceRegistration<T extends UIResourceServer>(
     serverPort: server.serverPort || 3000,
     serverBaseUrl: server.serverBaseUrl,
     buildId: server.buildId,
+    basePath: server.basePath,
   };
 
   // Per MCP Apps spec (SEP-1865): resource _meta.ui should contain CSP,

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/widget-helpers.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/widget-helpers.ts
@@ -187,8 +187,8 @@ export async function readBuildManifest(): Promise<{
   try {
     const manifestPath = pathHelpers.join(
       isDeno ? "." : getCwd(),
-      "dist",
-      "mcp-use.json"
+      ".mcp-use",
+      "manifest.json"
     );
     const content = await fsHelpers.readFileSync(manifestPath, "utf8");
     return JSON.parse(content);
@@ -209,6 +209,8 @@ export interface WidgetServerConfig {
   serverBaseUrl?: string;
   /** Build ID for cache busting */
   buildId?: string;
+  /** Server basePath prefix (e.g. "/api"). Empty string when unset. */
+  basePath?: string;
 }
 
 /**
@@ -294,78 +296,38 @@ export function getContentType(filename: string): string {
 }
 
 /**
- * Process widget HTML with base URL injection and path conversion
+ * Inject runtime globals into widget HTML.
+ *
+ * The injected script resolves the server's `basePath` at runtime from
+ * `window.location.pathname` (splitting on the literal `/_mcp-use/` segment).
+ * This keeps the baked HTML basePath-agnostic — the same `.mcp-use/widgets/
+ * <name>/index.html` file produced by `packages/cli/src/index.ts` works
+ * whether the server is mounted at the host root or under a `basePath` like
+ * `/api`, with no rebuild needed.
+ *
+ * Production builds bake these globals at build time (CLI). Dev mode calls
+ * this on the fly from the Vite middleware. Idempotent: if the globals are
+ * already present, this is a no-op.
  *
  * @param html - Original HTML content
- * @param widgetName - Widget identifier
- * @param baseUrl - Server base URL
- * @returns Processed HTML with injected base tag and absolute URLs
- *
- * @example
- * ```typescript
- * const html = '<html><head></head><body>...</body></html>';
- * const processed = processWidgetHtml(html, 'kanban-board', 'http://localhost:3000');
- * ```
+ * @param widgetName - Widget identifier (will be slugified for URL paths)
+ * @returns HTML with the globals script injected after the opening `<head>`
  */
-export function processWidgetHtml(
-  html: string,
-  widgetName: string,
-  baseUrl: string
-): string {
-  let processedHtml = html;
-
-  // Inject or replace base tag with server base URL
-  if (baseUrl && processedHtml) {
-    // Remove HTML comments temporarily to avoid matching base tags inside comments
-    let htmlWithoutComments = processedHtml;
-    let prevHtmlWithoutComments;
-    do {
-      prevHtmlWithoutComments = htmlWithoutComments;
-      htmlWithoutComments = htmlWithoutComments.replace(/<!--[\s\S]*?-->/g, "");
-    } while (prevHtmlWithoutComments !== htmlWithoutComments);
-
-    // Try to replace existing base tag (only if not in comments)
-    const baseTagRegex = /<base\s+[^>]*\/?>/i;
-    if (baseTagRegex.test(htmlWithoutComments)) {
-      // Find and replace the actual base tag in the original HTML
-      const actualBaseTagMatch = processedHtml.match(/<base\s+[^>]*\/?>/i);
-      if (actualBaseTagMatch) {
-        processedHtml = processedHtml.replace(
-          actualBaseTagMatch[0],
-          `<base href="${baseUrl}" />`
-        );
-      }
-    } else {
-      // Inject base tag in head if it doesn't exist
-      const headTagRegex = /<head[^>]*>/i;
-      if (headTagRegex.test(processedHtml)) {
-        processedHtml = processedHtml.replace(
-          headTagRegex,
-          (match) => `${match}\n    <base href="${baseUrl}" />`
-        );
-      }
-    }
-
-    // Replace relative paths that start with /mcp-use for scripts and CSS with absolute URLs
-    processedHtml = processedHtml.replace(
-      /src="\/mcp-use\/widgets\/([^"]+)"/g,
-      `src="${baseUrl}/mcp-use/widgets/$1"`
-    );
-    processedHtml = processedHtml.replace(
-      /href="\/mcp-use\/widgets\/([^"]+)"/g,
-      `href="${baseUrl}/mcp-use/widgets/$1"`
-    );
-
-    // Add window.__getFile and window.__mcpPublicUrl to head
-    // Use slugified name for URL routing
-    const slugifiedName = slugifyWidgetName(widgetName);
-    processedHtml = processedHtml.replace(
-      /<head[^>]*>/i,
-      `<head>\n    <script>window.__getFile = (filename) => { return "${baseUrl}/mcp-use/widgets/${slugifiedName}/"+filename }; window.__mcpPublicUrl = "${baseUrl}/mcp-use/public";</script>`
-    );
+export function processWidgetHtml(html: string, widgetName: string): string {
+  if (!html || html.includes("window.__mcpPublicUrl")) {
+    return html;
   }
 
-  return processedHtml;
+  const slugifiedName = slugifyWidgetName(widgetName);
+  // The widget HTML is always served at `<basePath>/_mcp-use/widgets/<slug>/...`,
+  // so the prefix preceding `/_mcp-use/` in `window.location.pathname` IS the
+  // server's basePath (possibly empty). Compute it once and use it to build
+  // sibling URLs (own assets, public files).
+  return html.replace(
+    /<head[^>]*>/i,
+    (match) =>
+      `${match}\n    <script>(function(){var p=window.location.pathname.split("/_mcp-use/")[0]||"";window.__getFile=function(filename){return p+"/_mcp-use/widgets/${slugifiedName}/"+filename};window.__mcpPublicUrl=p+"/_mcp-use/public";})();</script>`
+  );
 }
 
 /**
@@ -567,6 +529,7 @@ export async function createWidgetUIResource(
     baseUrl: configBaseUrl,
     port: configPort,
     buildId: serverConfig.buildId,
+    basePath: serverConfig.basePath ?? "",
   };
 
   const uiResource = await createUIResourceFromDefinition(
@@ -699,7 +662,7 @@ async function readWidgetHtml(
  * ```typescript
  * await registerWidgetFromTemplate(
  *   'kanban-board',
- *   './dist/resources/widgets/kanban-board/index.html',
+ *   './.mcp-use/widgets/kanban-board/index.html',
  *   { title: 'Kanban Board' },
  *   serverConfig,
  *   registerWidget,
@@ -721,8 +684,8 @@ export async function registerWidgetFromTemplate(
     return; // readWidgetHtml already logged the error
   }
 
-  // Process HTML with base URL injection and path conversion
-  html = processWidgetHtml(html, widgetName, serverConfig.serverBaseUrl);
+  // Inject runtime globals (no-op if already baked at build time).
+  html = processWidgetHtml(html, widgetName);
 
   // Ensure metadata has proper fallbacks
   const processedMetadata = ensureWidgetMetadata(metadata, widgetName);
@@ -742,11 +705,11 @@ export async function registerWidgetFromTemplate(
 /**
  * Setup static file serving routes for public files
  *
- * Creates an HTTP route to serve files from the public/ or dist/public/ directory.
+ * Creates an HTTP route to serve files from the public/ or .mcp-use/public/ directory.
  * This function encapsulates the common pattern of serving static files.
  *
  * @param app - Hono app instance to mount routes on
- * @param useDistDirectory - Whether to serve from dist/public (production) or public (dev)
+ * @param useDistDirectory - Whether to serve from .mcp-use/public (production) or public (dev)
  *
  * @example
  * ```typescript
@@ -761,21 +724,23 @@ export function setupPublicRoutes(
   app: HonoType,
   useDistDirectory: boolean = false
 ): void {
-  app.get("/mcp-use/public/*", async (c: Context) => {
-    const filePath = c.req.path.replace("/mcp-use/public/", "");
-    const basePath = useDistDirectory ? "dist/public" : "public";
-    const fullPath = pathHelpers.join(getCwd(), basePath, filePath);
+  // Callers pass the basePath-aware app so the final route lands at
+  // `${basePath}/_mcp-use/public/*`. The `split("/_mcp-use/public/")` below
+  // is unambiguous regardless of basePath since `_mcp-use` is reserved.
+  const routePrefix = "/_mcp-use/public/";
+  app.get(`${routePrefix}*`, async (c: Context) => {
+    const filePath = c.req.path.split(routePrefix)[1] ?? "";
+    // Production reads from `.mcp-use/public` (built output). Dev reads
+    // from the user's source `public/` directory.
+    const fsBase = useDistDirectory ? ".mcp-use/public" : "public";
+    const fullPath = pathHelpers.join(getCwd(), fsBase, filePath);
 
     try {
-      if (await fsHelpers.existsSync(fullPath)) {
-        const content = await fsHelpers.readFile(fullPath);
-        const contentType = getContentType(filePath);
-        return new Response(content, {
-          status: 200,
-          headers: { "Content-Type": contentType },
-        });
-      }
-      return c.notFound();
+      const content = await fsHelpers.readFile(fullPath);
+      return new Response(content, {
+        status: 200,
+        headers: { "Content-Type": getContentType(filePath) },
+      });
     } catch {
       return c.notFound();
     }
@@ -790,7 +755,7 @@ export function setupPublicRoutes(
  *
  * @param app - Hono app instance to mount routes on
  * @param faviconPath - Path to favicon file relative to public directory
- * @param useDistDirectory - Whether to serve from dist/public (production) or public (dev)
+ * @param useDistDirectory - Whether to serve from .mcp-use/public (production) or public (dev)
  *
  * @example
  * ```typescript
@@ -810,25 +775,29 @@ export function setupFaviconRoute(
     return; // No favicon configured
   }
 
-  app.get("/favicon.ico", async (c: Context) => {
-    const basePath = useDistDirectory ? "dist/public" : "public";
-    const fullPath = pathHelpers.join(getCwd(), basePath, faviconPath);
+  const handler = async (c: Context) => {
+    const fsBase = useDistDirectory ? ".mcp-use/public" : "public";
+    const fullPath = pathHelpers.join(getCwd(), fsBase, faviconPath);
 
     try {
-      if (await fsHelpers.existsSync(fullPath)) {
-        const content = await fsHelpers.readFile(fullPath);
-        const contentType = getContentType(faviconPath);
-        return new Response(content, {
-          status: 200,
-          headers: {
-            "Content-Type": contentType,
-            "Cache-Control": "public, max-age=31536000", // Cache for 1 year
-          },
-        });
-      }
-      return c.notFound();
+      const content = await fsHelpers.readFile(fullPath);
+      return new Response(content, {
+        status: 200,
+        headers: {
+          "Content-Type": getContentType(faviconPath),
+          "Cache-Control": "public, max-age=31536000", // Cache for 1 year
+        },
+      });
     } catch {
       return c.notFound();
     }
-  });
+  };
+
+  // Register at `/favicon.ico` on the basePath-aware app — final route lands
+  // at `${basePath}/favicon.ico`. Browsers' implicit `GET /favicon.ico` at
+  // the host root won't resolve when basePath is set; the MCP icon
+  // declaration in `getServerInfo` is the authoritative reference for
+  // clients that consume the icon, and the rendered landing page links to
+  // the basePath-prefixed URL.
+  app.get("/favicon.ico", handler);
 }

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/widget-types.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/widget-types.ts
@@ -27,6 +27,11 @@ export interface ServerConfig {
   /** Pre-created HTTP server for Vite HMR WebSocket support (optional, Node.js only) */
 
   httpServer?: any;
+  /**
+   * Normalized base path prefix for every route this server mounts.
+   * Empty string means "no prefix".
+   */
+  basePath?: string;
 }
 
 /**
@@ -35,7 +40,7 @@ export interface ServerConfig {
  * Common options used for both development and production widget mounting.
  */
 export interface MountWidgetsOptions {
-  /** Base route for widgets (defaults to '/mcp-use/widgets') */
+  /** Base route for widgets (defaults to '/_mcp-use/widgets') */
   baseRoute?: string;
   /** Resources directory path (defaults to 'resources') */
   resourcesDir?: string;

--- a/libraries/typescript/packages/mcp-use/tests/server/oauth.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/server/oauth.test.ts
@@ -54,7 +54,7 @@ describe("server OAuth integration", () => {
     const svc = await listenOnRandomPort(app);
     closers.push(svc.close);
 
-    setupOAuthRoutes(app, proxy, svc.baseUrl);
+    setupOAuthRoutes(app, proxy, () => svc.baseUrl);
 
     const response = await fetch(
       `${svc.baseUrl}/.well-known/oauth-authorization-server`
@@ -67,6 +67,58 @@ describe("server OAuth integration", () => {
     expect(metadata.registration_endpoint).toBe(`${svc.baseUrl}/register`);
     // In proxy mode, the issuer is the local server URL
     expect(metadata.issuer).toBe(svc.baseUrl);
+  });
+
+  it("publishes basePath-prefixed endpoints when configured", async () => {
+    // `setupOAuthRoutes` takes the underlying root Hono plus a basePath.
+    // Internally it registers /authorize, /token, /register on a
+    // `.basePath()` clone (so they live at `${basePath}/...`) and
+    // /.well-known/* on the root (per RFC 8414 §3.1).
+    const app = new Hono();
+
+    const proxy = oauthProxy({
+      issuer: "https://issuer.example.com",
+      authEndpoint: "https://issuer.example.com/oauth/authorize",
+      tokenEndpoint: "https://issuer.example.com/oauth/token",
+      clientId: "test-client-id",
+      scopes: ["openid"],
+      verifyToken: stubVerifyToken,
+    });
+
+    const svc = await listenOnRandomPort(app);
+    closers.push(svc.close);
+
+    setupOAuthRoutes(app, proxy, () => svc.baseUrl, "/api");
+
+    // RFC 8414 §3.1 path-aware variant: well-known appended with the
+    // issuer's path. This is the SDK's preferred probe.
+    const response = await fetch(
+      `${svc.baseUrl}/.well-known/oauth-authorization-server/api`
+    );
+    expect(response.status).toBe(200);
+    const metadata = await response.json();
+
+    expect(metadata.issuer).toBe(`${svc.baseUrl}/api`);
+    expect(metadata.authorization_endpoint).toBe(
+      `${svc.baseUrl}/api/authorize`
+    );
+    expect(metadata.token_endpoint).toBe(`${svc.baseUrl}/api/token`);
+    expect(metadata.registration_endpoint).toBe(`${svc.baseUrl}/api/register`);
+
+    // The root well-known path should still serve metadata as the SDK's
+    // fallback probe (and for clients that don't append the path).
+    const rootMetadata = await fetch(
+      `${svc.baseUrl}/.well-known/oauth-authorization-server`
+    );
+    expect(rootMetadata.status).toBe(200);
+
+    // RFC 9728 path-scoped protected resource metadata for the MCP transport.
+    const prResponse = await fetch(
+      `${svc.baseUrl}/.well-known/oauth-protected-resource/api/mcp`
+    );
+    expect(prResponse.status).toBe(200);
+    const pr = await prResponse.json();
+    expect(pr.resource).toBe(`${svc.baseUrl}/api/mcp`);
   });
 
   it("proxies token requests and injects client credentials", async () => {
@@ -104,7 +156,7 @@ describe("server OAuth integration", () => {
     const svc = await listenOnRandomPort(app);
     closers.push(svc.close);
 
-    setupOAuthRoutes(app, proxy, svc.baseUrl);
+    setupOAuthRoutes(app, proxy, () => svc.baseUrl);
 
     const form = new URLSearchParams({
       grant_type: "authorization_code",
@@ -164,6 +216,39 @@ describe("server OAuth integration", () => {
     expect(authorized.status).toBe(200);
   });
 
+  it("advertises path-aware resource_metadata URL with basePath", async () => {
+    // Per RFC 9728 §3.1, the resource metadata URL is built by inserting
+    // `/.well-known/oauth-protected-resource` between host and the resource
+    // path. For an MCP endpoint at `<host>/api/mcp` that's
+    // `<host>/.well-known/oauth-protected-resource/api/mcp`.
+    const app = new Hono();
+
+    const proxy = oauthProxy({
+      issuer: "https://issuer.example.com",
+      authEndpoint: "https://issuer.example.com/oauth/authorize",
+      tokenEndpoint: "https://issuer.example.com/oauth/token",
+      clientId: "test-client",
+      verifyToken: stubVerifyToken,
+    });
+
+    const svc = await listenOnRandomPort(app);
+    closers.push(svc.close);
+
+    app.use(
+      "/api/mcp/*",
+      createBearerAuthMiddleware(proxy, () => svc.baseUrl, "/api")
+    );
+    app.get("/api/mcp/test", (c) => c.json({ ok: true }));
+
+    const response = await fetch(`${svc.baseUrl}/api/mcp/test`);
+    expect(response.status).toBe(401);
+
+    const wwwAuth = response.headers.get("www-authenticate");
+    expect(wwwAuth).toContain(
+      `resource_metadata="${svc.baseUrl}/.well-known/oauth-protected-resource/api/mcp"`
+    );
+  });
+
   it("returns configured clientId from /register endpoint", async () => {
     const app = new Hono();
 
@@ -179,7 +264,7 @@ describe("server OAuth integration", () => {
     const svc = await listenOnRandomPort(app);
     closers.push(svc.close);
 
-    setupOAuthRoutes(app, proxy, svc.baseUrl);
+    setupOAuthRoutes(app, proxy, () => svc.baseUrl);
 
     const response = await fetch(`${svc.baseUrl}/register`, {
       method: "POST",

--- a/libraries/typescript/packages/mcp-use/tests/unit/server/base-path.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/server/base-path.test.ts
@@ -111,7 +111,7 @@ describe("MCPServer basePath", () => {
       expect(root.status).toBe(404);
     });
 
-    it("mounts framework-internal assets under basePath at `${basePath}/_mcp-use/*`", async () => {
+    it("mounts framework-internal assets under basePath at <basePath>/_mcp-use/*", async () => {
       const server = new MCPServer({
         name: "internal-assets-base-path",
         version: "1.0.0",
@@ -152,7 +152,9 @@ describe("MCPServer basePath", () => {
         originalNodeEnv = process.env.NODE_ENV;
         process.env.NODE_ENV = "production";
 
-        await mkdir(join(fixturesDir, "widgets", "sample"), { recursive: true });
+        await mkdir(join(fixturesDir, "widgets", "sample"), {
+          recursive: true,
+        });
         await mkdir(join(fixturesDir, "widgets", "sample", "assets"), {
           recursive: true,
         });
@@ -194,9 +196,7 @@ describe("MCPServer basePath", () => {
 
         const handler = await server.getHandler();
         const res = await handler(
-          new Request(
-            "http://localhost/api/_mcp-use/widgets/sample/index.html"
-          )
+          new Request("http://localhost/api/_mcp-use/widgets/sample/index.html")
         );
 
         expect(res.status).toBe(200);

--- a/libraries/typescript/packages/mcp-use/tests/unit/server/base-path.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/server/base-path.test.ts
@@ -2,30 +2,8 @@ import { mkdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { MCPServer, oauthSupabaseProvider } from "../../../src/server/index.js";
-import { normalizeBasePath } from "../../../src/server/utils/server-helpers.js";
 
 describe("MCPServer basePath", () => {
-  describe("normalizeBasePath", () => {
-    it("returns empty string for undefined / empty / '/'", () => {
-      expect(normalizeBasePath(undefined)).toBe("");
-      expect(normalizeBasePath("")).toBe("");
-      expect(normalizeBasePath("/")).toBe("");
-    });
-
-    it("strips trailing slashes", () => {
-      expect(normalizeBasePath("/api/")).toBe("/api");
-      expect(normalizeBasePath("/api///")).toBe("/api");
-    });
-
-    it("preserves nested paths", () => {
-      expect(normalizeBasePath("/a/b/c")).toBe("/a/b/c");
-    });
-
-    it("throws when the prefix is missing the leading slash", () => {
-      expect(() => normalizeBasePath("api")).toThrow(/must start with/);
-    });
-  });
-
   describe("route mounting", () => {
     it("mounts MCP transport at the configured basePath and 404s the root", async () => {
       const server = new MCPServer({
@@ -325,26 +303,6 @@ describe("MCPServer basePath", () => {
         new Request("http://localhost:3000/token", { method: "POST" })
       );
       expect(rootToken.status).toBe(404);
-    });
-  });
-
-  describe("instance state", () => {
-    it("exposes the normalized basePath as a public field", () => {
-      const server = new MCPServer({
-        name: "base-path-field",
-        version: "1.0.0",
-        basePath: "/api/",
-      });
-
-      expect(server.basePath).toBe("/api");
-    });
-
-    it("defaults basePath to empty string", () => {
-      const server = new MCPServer({
-        name: "base-path-empty",
-        version: "1.0.0",
-      });
-      expect(server.basePath).toBe("");
     });
   });
 });

--- a/libraries/typescript/packages/mcp-use/tests/unit/server/base-path.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/server/base-path.test.ts
@@ -1,0 +1,350 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { MCPServer, oauthSupabaseProvider } from "../../../src/server/index.js";
+import { normalizeBasePath } from "../../../src/server/utils/server-helpers.js";
+
+describe("MCPServer basePath", () => {
+  describe("normalizeBasePath", () => {
+    it("returns empty string for undefined / empty / '/'", () => {
+      expect(normalizeBasePath(undefined)).toBe("");
+      expect(normalizeBasePath("")).toBe("");
+      expect(normalizeBasePath("/")).toBe("");
+    });
+
+    it("strips trailing slashes", () => {
+      expect(normalizeBasePath("/api/")).toBe("/api");
+      expect(normalizeBasePath("/api///")).toBe("/api");
+    });
+
+    it("preserves nested paths", () => {
+      expect(normalizeBasePath("/a/b/c")).toBe("/a/b/c");
+    });
+
+    it("throws when the prefix is missing the leading slash", () => {
+      expect(() => normalizeBasePath("api")).toThrow(/must start with/);
+    });
+  });
+
+  describe("route mounting", () => {
+    it("mounts MCP transport at the configured basePath and 404s the root", async () => {
+      const server = new MCPServer({
+        name: "base-path-test",
+        version: "1.0.0",
+        basePath: "/api",
+      });
+
+      const handler = await server.getHandler();
+
+      const prefixed = await handler(
+        new Request("http://localhost/api/mcp", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json, text/event-stream",
+          },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "initialize",
+            params: {
+              protocolVersion: "2025-06-18",
+              capabilities: {},
+              clientInfo: { name: "test", version: "1.0.0" },
+            },
+          }),
+        })
+      );
+      // 200 means the transport accepted and handled the initialize request.
+      expect(prefixed.status).toBe(200);
+
+      const root = await handler(
+        new Request("http://localhost/mcp", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json, text/event-stream",
+          },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "initialize",
+            params: {
+              protocolVersion: "2025-06-18",
+              capabilities: {},
+              clientInfo: { name: "test", version: "1.0.0" },
+            },
+          }),
+        })
+      );
+      expect(root.status).toBe(404);
+    });
+
+    it("mounts MCP transport at /mcp when no basePath is set (back-compat)", async () => {
+      const server = new MCPServer({
+        name: "base-path-default",
+        version: "1.0.0",
+      });
+
+      const handler = await server.getHandler();
+      const response = await handler(
+        new Request("http://localhost/mcp", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json, text/event-stream",
+          },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "initialize",
+            params: {
+              protocolVersion: "2025-06-18",
+              capabilities: {},
+              clientInfo: { name: "test", version: "1.0.0" },
+            },
+          }),
+        })
+      );
+
+      expect(response.status).toBe(200);
+    });
+
+    it("auto-prefixes user-registered routes under basePath", async () => {
+      const server = new MCPServer({
+        name: "user-route-prefix",
+        version: "1.0.0",
+        basePath: "/api",
+      });
+
+      // User registers a custom route on `server.app`. With basePath set,
+      // this should be reachable at `${basePath}/health`, not at `/health`.
+      server.app.get("/health", (c) => c.text("ok"));
+
+      const handler = await server.getHandler();
+
+      const prefixed = await handler(
+        new Request("http://localhost/api/health")
+      );
+      expect(prefixed.status).toBe(200);
+      expect(await prefixed.text()).toBe("ok");
+
+      const root = await handler(new Request("http://localhost/health"));
+      expect(root.status).toBe(404);
+    });
+
+    it("mounts framework-internal assets under basePath at `${basePath}/_mcp-use/*`", async () => {
+      const server = new MCPServer({
+        name: "internal-assets-base-path",
+        version: "1.0.0",
+        basePath: "/api",
+      });
+
+      const handler = await server.getHandler();
+
+      // Unprefixed `/_mcp-use/*` no longer resolves — the framework
+      // namespace is mounted under the configured basePath.
+      const root = await handler(
+        new Request("http://localhost/_mcp-use/public/missing.png")
+      );
+      expect(root.status).toBe(404);
+
+      // Prefixed path: 404 for a missing file is the expected production
+      // result (the route exists, the file doesn't).
+      const prefixed = await handler(
+        new Request("http://localhost/api/_mcp-use/public/missing.png")
+      );
+      expect(prefixed.status).toBe(404);
+
+      // The legacy `/__mcp-use/serverinfo` HTTP endpoint is gone; the same
+      // information now lives in `.mcp-use/server-info.json` after listen().
+      const removed = await handler(
+        new Request("http://localhost/__mcp-use/serverinfo")
+      );
+      expect(removed.status).toBe(404);
+    });
+
+    describe("static serving from .mcp-use/", () => {
+      const fixturesDir = join(process.cwd(), ".mcp-use");
+      let originalNodeEnv: string | undefined;
+
+      beforeAll(async () => {
+        // serveStatic only mounts when NODE_ENV=production (see
+        // widgets/index.ts:86). Force prod for this block; restore after.
+        originalNodeEnv = process.env.NODE_ENV;
+        process.env.NODE_ENV = "production";
+
+        await mkdir(join(fixturesDir, "widgets", "sample"), { recursive: true });
+        await mkdir(join(fixturesDir, "widgets", "sample", "assets"), {
+          recursive: true,
+        });
+        await mkdir(join(fixturesDir, "public"), { recursive: true });
+        await writeFile(
+          join(fixturesDir, "widgets", "sample", "index.html"),
+          `<!doctype html><html><head><script>window.__mcpPublicUrl="/_mcp-use/public";</script></head><body>sample</body></html>`,
+          "utf8"
+        );
+        await writeFile(
+          join(fixturesDir, "widgets", "sample", "assets", "entry.js"),
+          `console.log("hi");`,
+          "utf8"
+        );
+        await writeFile(
+          join(fixturesDir, "public", "hello.txt"),
+          "hello world",
+          "utf8"
+        );
+      });
+
+      afterAll(async () => {
+        process.env.NODE_ENV = originalNodeEnv;
+        // Remove only the fixtures we created — leave anything else under
+        // .mcp-use/ alone (e.g. real generated files from other tests).
+        await rm(join(fixturesDir, "widgets", "sample"), {
+          recursive: true,
+          force: true,
+        });
+        await rm(join(fixturesDir, "public", "hello.txt"), { force: true });
+      });
+
+      it("serves widget HTML byte-for-byte from disk under basePath", async () => {
+        const server = new MCPServer({
+          name: "static-widget-html",
+          version: "1.0.0",
+          basePath: "/api",
+        });
+
+        const handler = await server.getHandler();
+        const res = await handler(
+          new Request(
+            "http://localhost/api/_mcp-use/widgets/sample/index.html"
+          )
+        );
+
+        expect(res.status).toBe(200);
+        const body = await res.text();
+        expect(body).toContain('window.__mcpPublicUrl="/_mcp-use/public"');
+        expect(body).toContain("<body>sample</body>");
+      });
+
+      it("serves widget JS assets with correct content-type", async () => {
+        const server = new MCPServer({
+          name: "static-widget-assets",
+          version: "1.0.0",
+        });
+
+        const handler = await server.getHandler();
+        const res = await handler(
+          new Request(
+            "http://localhost/_mcp-use/widgets/sample/assets/entry.js"
+          )
+        );
+
+        expect(res.status).toBe(200);
+        expect(res.headers.get("content-type")).toMatch(/javascript/);
+        expect(await res.text()).toBe(`console.log("hi");`);
+      });
+
+      it("serves public files from .mcp-use/public/ under basePath", async () => {
+        const server = new MCPServer({
+          name: "static-public",
+          version: "1.0.0",
+          basePath: "/api",
+        });
+
+        const handler = await server.getHandler();
+        const res = await handler(
+          new Request("http://localhost/api/_mcp-use/public/hello.txt")
+        );
+
+        expect(res.status).toBe(200);
+        expect(await res.text()).toBe("hello world");
+      });
+    });
+
+    it("serves OAuth discovery at root and path-aware paths (basePath-agnostic)", async () => {
+      const server = new MCPServer({
+        name: "oauth-discovery-base-path",
+        version: "1.0.0",
+        basePath: "/api",
+        baseUrl: "http://localhost:3000",
+        oauth: oauthSupabaseProvider({ projectId: "abc123" }),
+      });
+
+      const handler = await server.getHandler();
+
+      // 1. Root-level RFC 9728 protected resource metadata (SDK fallback)
+      const root = await handler(
+        new Request(
+          "http://localhost:3000/.well-known/oauth-protected-resource"
+        )
+      );
+      expect(root.status).toBe(200);
+      const rootBody = (await root.json()) as {
+        resource: string;
+        authorization_servers: string[];
+      };
+      expect(rootBody.resource).toBe("http://localhost:3000/api");
+      expect(rootBody.authorization_servers).toEqual([
+        "https://abc123.supabase.co/auth/v1",
+      ]);
+
+      // 2. Path-scoped RFC 9728: <host>/.well-known/oauth-protected-resource/api/mcp
+      //    (what the SDK's `discoverMetadataWithFallback` probes first)
+      const scoped = await handler(
+        new Request(
+          "http://localhost:3000/.well-known/oauth-protected-resource/api/mcp"
+        )
+      );
+      expect(scoped.status).toBe(200);
+      const scopedBody = (await scoped.json()) as { resource: string };
+      expect(scopedBody.resource).toBe("http://localhost:3000/api/mcp");
+
+      // 3. Root RFC 8414 authorization server metadata route is mounted
+      //    (DCR-direct mode proxies upstream — we just assert the route
+      //    exists, not the body, since upstream is network-dependent).
+      const authMeta = await handler(
+        new Request(
+          "http://localhost:3000/.well-known/oauth-authorization-server"
+        )
+      );
+      expect(authMeta.status).not.toBe(404);
+
+      // 4. Path-aware RFC 8414: <host>/.well-known/oauth-authorization-server/api
+      const authMetaPath = await handler(
+        new Request(
+          "http://localhost:3000/.well-known/oauth-authorization-server/api"
+        )
+      );
+      expect(authMetaPath.status).not.toBe(404);
+
+      // 5. /token stays under basePath. Root /token must 404 — that's the
+      //    bug class this restructure prevents for embedded apps where
+      //    arbitrary host routes would otherwise collide.
+      const rootToken = await handler(
+        new Request("http://localhost:3000/token", { method: "POST" })
+      );
+      expect(rootToken.status).toBe(404);
+    });
+  });
+
+  describe("instance state", () => {
+    it("exposes the normalized basePath as a public field", () => {
+      const server = new MCPServer({
+        name: "base-path-field",
+        version: "1.0.0",
+        basePath: "/api/",
+      });
+
+      expect(server.basePath).toBe("/api");
+    });
+
+    it("defaults basePath to empty string", () => {
+      const server = new MCPServer({
+        name: "base-path-empty",
+        version: "1.0.0",
+      });
+      expect(server.basePath).toBe("");
+    });
+  });
+});

--- a/libraries/typescript/packages/mcp-use/tests/unit/server/logging.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/server/logging.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Context, Next } from "hono";
 
-import { getDebugLevel, requestLogger } from "../../../src/server/logging.js";
+import {
+  createRequestLogger,
+  getDebugLevel,
+} from "../../../src/server/logging.js";
+
+const requestLogger = createRequestLogger();
 
 // ---------------------------------------------------------------------------
 // Helpers


### PR DESCRIPTION
## Summary
Adds a `basePath` option to `MCPServer` so the framework can be mounted under any URL prefix. With `basePath: "/api"` set, all framework routes (MCP transport, inspector UI, OAuth `/authorize`/`/token`/`/register`, widget assets, bearer-auth middleware, user-registered routes) auto-prefix under `/api`. Only the OAuth `.well-known/*` discovery endpoints stay at the literal host root, per RFC 8414 / RFC 9728.

This is the foundation PR. The follow-up [`feat/mcp-2074-inspector-basepath-discovery`](https://github.com/mcp-use/mcp-use/compare/feat/mcp-2074-basepath...feat/mcp-2074-inspector-basepath-discovery) wires the inspector client to discover the prefix at runtime.

Refs: MCP-2074

## Implementation Details
1. **Single-clone routing.** Hono's `app.basePath()` builds the prefixed router; the un-prefixed root view is retained for the OAuth `.well-known/*` discovery endpoints (which must live at the literal host root). No deferred route snapshotting — registrations through the clone simply auto-prefix.
2. **Path-aware `WWW-Authenticate`.** The `resource_metadata` URL points at `/.well-known/oauth-protected-resource${basePath}/mcp`, so clients land on the right protected-resource metadata regardless of mount point.
3. **Log filtering.** `createRequestLogger(basePath)` strips the prefix before applying noisy-path heuristics, so dev requests don't fill the log when basePath is set.
4. **Framework assets namespace.** Static framework assets live under `${basePath}/_mcp-use/*`, mirroring Next.js's `.next/` ↔ `/_next/` convention.
5. **Out-of-process discovery.** `MCPServer.listen()` writes `.mcp-use/server-info.json` (host, port, basePath, mcpUrl, inspectorUrl) so CLI / IDE integrations can locate a running server without an HTTP probe.

## Example Usage (After)
\`\`\`ts
new MCPServer({
  name: "my-server",
  version: "1.0.0",
  basePath: "/api",
});
// MCP transport: /api/mcp
// Inspector: /api/inspector
// OAuth /authorize, /token, /register: /api/authorize, /api/token, /api/register
// .well-known/* (host root, RFC 8414 §3.1): /.well-known/oauth-protected-resource/api/mcp
\`\`\`

## Testing
- New unit tests in \`tests/unit/server/base-path.test.ts\` cover route mounting, OAuth discovery URLs (root + path-aware), \`/token\` staying under basePath, and the \`server-info.json\` payload shape.
- Existing OAuth integration tests in \`tests/server/oauth.test.ts\` extended for the basePath case.

## Backwards Compatibility
Non-breaking. \`basePath\` defaults to empty (no prefix) — existing servers mount at the host root as today.