### PR TITLE
feat(inspector): runtime basePath discovery via window.__MCP_BASE_PATH__

### DIFF
--- a/libraries/typescript/.changeset/inspector-basepath-discovery.md
+++ b/libraries/typescript/.changeset/inspector-basepath-discovery.md
@@ -1,0 +1,9 @@
+---
+"@mcp-use/inspector": minor
+---
+
+Discover the embedding host's `basePath` at runtime and prefix all same-origin URLs with it.
+
+When the inspector is embedded in an `MCPServer` configured with a `basePath` (e.g. `"/api"`), the server injects the prefix into a `window.__MCP_BASE_PATH__` global on the served HTML. New `getBasePath()` / `inspectorPath()` helpers in `client/utils/basePath.ts` read that global so React Router's `basename`, fetch URLs (proxy, telemetry, dev info, tunnel, chat stream, widget store), and config endpoints route to the prefixed paths. Standalone/CDN mode and unprefixed deployments keep the existing bare-path behavior because the global is absent.
+
+Server-side: `shared-static` and `middleware` inject the global into served HTML; `vite.config.ts` keeps `/inspector` as the dev base.

--- a/libraries/typescript/packages/inspector/src/client/App.tsx
+++ b/libraries/typescript/packages/inspector/src/client/App.tsx
@@ -16,6 +16,7 @@ import { toast } from "sonner";
 import { InspectorProvider, useInspector } from "./context/InspectorContext";
 import { ThemeProvider } from "./context/ThemeContext";
 import { WidgetDebugProvider } from "./context/WidgetDebugContext";
+import { getBasePath, inspectorPath } from "./utils/basePath";
 
 /**
  * Syncs the active tab from InspectorContext into a ref readable by
@@ -98,7 +99,7 @@ function App() {
         <McpClientProvider
           storageProvider={storageProvider}
           enableRpcLogging={true}
-          defaultCallbackUrl={`${window.location.origin}/inspector/oauth/callback`}
+          defaultCallbackUrl={`${window.location.origin}${inspectorPath("/inspector/oauth/callback")}`}
           defaultAutoProxyFallback={
             proxyAddress ? { enabled: true, proxyAddress } : false
           }
@@ -207,7 +208,7 @@ function App() {
         >
           <InspectorProvider>
             <InspectorTabSync activeTabRef={activeTabRef} />
-            <Router basename="/inspector">
+            <Router basename={`${getBasePath()}/inspector`}>
               <Routes>
                 <Route path="/oauth/callback" element={<OAuthCallback />} />
                 <Route path="/preview/:view" element={<ViewPreview />} />

--- a/libraries/typescript/packages/inspector/src/client/components/InspectorDashboard.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/InspectorDashboard.tsx
@@ -38,6 +38,7 @@ import {
 } from "mcp-use/react";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { copyToClipboard } from "@/client/utils/clipboard";
+import { inspectorPath } from "@/client/utils/basePath";
 import {
   buildOAuthStaticConfig,
   getStoredConnectionConfig,
@@ -300,7 +301,7 @@ export function InspectorDashboard() {
   const [resetTimeoutOnProgress, setResetTimeoutOnProgress] = useState("True");
   const [maxTotalTimeout, setMaxTotalTimeout] = useState("60000");
   const [proxyAddress, setProxyAddress] = useState(
-    `${window.location.origin}/inspector/api/proxy`
+    `${window.location.origin}${inspectorPath("/inspector/api/proxy")}`
   );
   // OAuth fields
   const [clientId, setClientId] = useState("");

--- a/libraries/typescript/packages/inspector/src/client/components/Layout.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/Layout.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/client/context/InspectorContext";
 import { useAutoConnect } from "@/client/hooks/useAutoConnect";
 import { useKeyboardShortcuts } from "@/client/hooks/useKeyboardShortcuts";
+import { inspectorPath } from "@/client/utils/basePath";
 import { useSavedRequests } from "@/client/hooks/useSavedRequests";
 import {
   MCPCommandPaletteOpenEvent,
@@ -635,7 +636,7 @@ export function Layout({ children }: LayoutProps) {
           proxyAddress: string;
           headers?: Record<string, string>;
         } = {
-          proxyAddress: `${window.location.origin}/inspector/api/proxy`,
+          proxyAddress: `${window.location.origin}${inspectorPath("/inspector/api/proxy")}`,
           ...(Object.keys(customHeaders).length > 0 && {
             headers: customHeaders,
           }),

--- a/libraries/typescript/packages/inspector/src/client/components/LayoutHeader.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/LayoutHeader.tsx
@@ -53,6 +53,7 @@ import {
   Wrench,
 } from "lucide-react";
 import { INSPECTOR_RECONNECT_STORAGE_KEY } from "@/client/hooks/useAutoConnect";
+import { inspectorPath } from "@/client/utils/basePath";
 import type { McpServer } from "mcp-use/react";
 import { useEffect, useState } from "react";
 
@@ -252,7 +253,7 @@ function TunnelBadge({
     let cancelled = false;
     (async () => {
       try {
-        const res = await fetch("/inspector/api/dev/info");
+        const res = await fetch(inspectorPath("/inspector/api/dev/info"));
         if (!res.ok || cancelled) return;
         const info = (await res.json()) as {
           fromCli?: boolean;
@@ -282,7 +283,7 @@ function TunnelBadge({
    */
   const pollAndReconnect = async (expectTunnel: boolean) => {
     const port = window.location.port || "3000";
-    const infoUrl = `http://localhost:${port}/inspector/api/dev/info`;
+    const infoUrl = `http://localhost:${port}${inspectorPath("/inspector/api/dev/info")}`;
     const deadline = Date.now() + 90_000;
 
     setTunnelPhaseMessage(
@@ -358,9 +359,12 @@ function TunnelBadge({
     setIsTunnelStarting(true);
     let success = false;
     try {
-      const res = await fetch("/inspector/api/dev/start-tunnel", {
-        method: "POST",
-      });
+      const res = await fetch(
+        inspectorPath("/inspector/api/dev/start-tunnel"),
+        {
+          method: "POST",
+        }
+      );
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
         toast.error((data as any).error || "Failed to start tunnel");
@@ -388,7 +392,7 @@ function TunnelBadge({
     setIsTunnelStarting(true);
     let success = false;
     try {
-      const res = await fetch("/inspector/api/dev/stop-tunnel", {
+      const res = await fetch(inspectorPath("/inspector/api/dev/stop-tunnel"), {
         method: "POST",
       });
       if (!res.ok) {

--- a/libraries/typescript/packages/inspector/src/client/components/LoginModal.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/LoginModal.tsx
@@ -28,6 +28,7 @@ import {
 import { Input } from "@/client/components/ui/input";
 import { Label } from "@/client/components/ui/label";
 import { Spinner } from "@/client/components/ui/spinner";
+import { inspectorPath } from "@/client/utils/basePath";
 import { cn } from "@/client/lib/utils";
 
 /* ------------------------------------------------------------------ */
@@ -155,7 +156,7 @@ export function LoginModal({
     // itself (via `window.close()` + postMessage) the moment better-auth
     // finishes setting the session cookie — instead of loading the whole
     // inspector inside the popup while we wait for the parent's session poll.
-    const callbackURL = `${window.location.origin}/inspector/oauth-popup-closed.html`;
+    const callbackURL = `${window.location.origin}${inspectorPath("/inspector/oauth-popup-closed.html")}`;
 
     fetch(`${authOrigin}/api/auth/sign-in/social`, {
       method: "POST",

--- a/libraries/typescript/packages/inspector/src/client/components/MCPAppsRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/MCPAppsRenderer.tsx
@@ -297,7 +297,7 @@ function MCPAppsRendererBase({
 
         // Store widget data
         const storeResponse = await fetch(
-          MCP_APPS_CONFIG.API_ENDPOINTS.WIDGET_STORE,
+          MCP_APPS_CONFIG.API_ENDPOINTS.WIDGET_STORE(),
           {
             method: "POST",
             headers: { "Content-Type": "application/json" },

--- a/libraries/typescript/packages/inspector/src/client/components/OpenAIComponentRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/OpenAIComponentRenderer.tsx
@@ -8,6 +8,7 @@ import { IFRAME_SANDBOX_PERMISSIONS } from "../constants/iframe";
 import { useTheme } from "../context/ThemeContext";
 import { useWidgetDebug } from "../context/WidgetDebugContext";
 import { injectConsoleInterceptor } from "../utils/iframeConsoleInterceptor";
+import { inspectorPath } from "../utils/basePath";
 import { FullscreenNavbar } from "./FullscreenNavbar";
 import { MCPAppsDebugControls } from "./MCPAppsDebugControls";
 import { Spinner } from "./ui/spinner";
@@ -252,7 +253,7 @@ function OpenAIComponentRendererBase({
 
         // Store widget data on server (including the fetched HTML and dev URLs if applicable)
         const storeResponse = await fetch(
-          `${inspectorApiBase}/inspector/api/resources/widget/store`,
+          `${inspectorApiBase}${inspectorPath("/inspector/api/resources/widget/store")}`,
           {
             method: "POST",
             headers: {
@@ -291,7 +292,7 @@ function OpenAIComponentRendererBase({
         // the store so that iframe fetch gets latest data. Changing URL would reload the iframe.
         if (!hasSetWidgetUrlRef.current) {
           hasSetWidgetUrlRef.current = true;
-          const widgetUrl = `${inspectorApiBase}/inspector/api/resources/widget-content/${toolId}?t=${Date.now()}`;
+          const widgetUrl = `${inspectorApiBase}${inspectorPath("/inspector/api/resources/widget-content")}/${toolId}?t=${Date.now()}`;
           setWidgetUrl(widgetUrl);
           // Register widget in debug context so CSP violations can be stored
           addWidget(toolId, { toolName, protocol: "chatgpt-app" });

--- a/libraries/typescript/packages/inspector/src/client/components/ServerConnectionModal.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ServerConnectionModal.tsx
@@ -25,6 +25,7 @@ import {
   DialogTitle,
 } from "@/client/components/ui/dialog";
 import { getConfiguredServerAlias } from "@/client/utils/serverNames";
+import { inspectorPath } from "@/client/utils/basePath";
 import { ConnectionSettingsForm } from "./ConnectionSettingsForm";
 import { toast } from "sonner";
 
@@ -68,7 +69,7 @@ export function ServerConnectionModal({
   const [resetTimeoutOnProgress, setResetTimeoutOnProgress] = useState("True");
   const [maxTotalTimeout, setMaxTotalTimeout] = useState("60000");
   const [proxyAddress, setProxyAddress] = useState(
-    `${window.location.origin}/inspector/api/proxy`
+    `${window.location.origin}${inspectorPath("/inspector/api/proxy")}`
   );
   // OAuth fields
   const [clientId, setClientId] = useState("");
@@ -112,7 +113,9 @@ export function ServerConnectionModal({
         setProxyAddress(proxyAddress);
       } else {
         setConnectionType("Direct");
-        setProxyAddress(`${window.location.origin}/inspector/api/proxy`);
+        setProxyAddress(
+          `${window.location.origin}${inspectorPath("/inspector/api/proxy")}`
+        );
       }
 
       // Convert headers from Record<string, string> to CustomHeader[]

--- a/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessages.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessages.ts
@@ -1,5 +1,6 @@
 import { useCallback, useRef, useState } from "react";
 import type { PromptResult } from "../../hooks/useMCPPrompts";
+import { inspectorPath } from "../../utils/basePath";
 import { convertPromptResultsToMessages } from "./conversion";
 import type {
   AuthConfig,
@@ -175,7 +176,7 @@ export function useChatMessages({
         const resolvedUrl =
           chatApiUrl ??
           (waitForChatApiUrl ? await waitForChatApiUrl() : undefined) ??
-          "/inspector/api/chat/stream";
+          inspectorPath("/inspector/api/chat/stream");
 
         const serialisedMessages = [
           ...[...messages, ...userMessages].map((m) => ({

--- a/libraries/typescript/packages/inspector/src/client/components/ui/SandboxedIframe.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ui/SandboxedIframe.tsx
@@ -22,6 +22,7 @@ import {
   useState,
 } from "react";
 import { IFRAME_SANDBOX_PERMISSIONS } from "../../constants/iframe";
+import { inspectorPath } from "../../utils/basePath";
 
 export interface SandboxedIframeHandle {
   postMessage: (data: unknown) => void;
@@ -103,7 +104,7 @@ export const SandboxedIframe = forwardRef<
     const configuredSandboxOrigin = (window as any).__MCP_SANDBOX_ORIGIN__;
     if (configuredSandboxOrigin) {
       // Use fully configured origin (e.g., "https://sandbox-inspector.mcp-use.com")
-      return `${configuredSandboxOrigin}/inspector/api/mcp-apps/sandbox-proxy?v=${Date.now()}`;
+      return `${configuredSandboxOrigin}${inspectorPath("/inspector/api/mcp-apps/sandbox-proxy")}?v=${Date.now()}`;
     }
 
     let sandboxHost: string;
@@ -136,7 +137,7 @@ export const SandboxedIframe = forwardRef<
     }
 
     const portSuffix = currentPort ? `:${currentPort}` : "";
-    return `${protocol}//${sandboxHost}${portSuffix}/inspector/api/mcp-apps/sandbox-proxy?v=${Date.now()}`;
+    return `${protocol}//${sandboxHost}${portSuffix}${inspectorPath("/inspector/api/mcp-apps/sandbox-proxy")}?v=${Date.now()}`;
   });
 
   const sandboxProxyOrigin = useMemo(() => {

--- a/libraries/typescript/packages/inspector/src/client/constants/mcp-apps.ts
+++ b/libraries/typescript/packages/inspector/src/client/constants/mcp-apps.ts
@@ -2,14 +2,20 @@
  * MCP Apps configuration constants
  */
 
+import { inspectorPath } from "../utils/basePath";
+
 export const MCP_APPS_CONFIG = {
   /**
    * API endpoints for widget operations
+   *
+   * Note: these are getters (not eager string literals) so they pick up the
+   * runtime basePath even if this module is imported before
+   * `window.__MCP_BASE_PATH__` has been read off the injected script.
    */
   API_ENDPOINTS: {
-    WIDGET_STORE: "/inspector/api/mcp-apps/widget/store",
+    WIDGET_STORE: () => inspectorPath("/inspector/api/mcp-apps/widget/store"),
     WIDGET_CONTENT: (toolCallId: string) =>
-      `/inspector/api/mcp-apps/widget-content/${toolCallId}`,
+      inspectorPath(`/inspector/api/mcp-apps/widget-content/${toolCallId}`),
   },
 
   /**

--- a/libraries/typescript/packages/inspector/src/client/hooks/useAutoConnect.ts
+++ b/libraries/typescript/packages/inspector/src/client/hooks/useAutoConnect.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "mcp-use/react";
 import { useCallback, useEffect, useState } from "react";
 import { useNavigate } from "react-router";
 import { toast } from "sonner";
+import { inspectorPath } from "../utils/basePath";
 
 /** Survives full page reload; avoids fragile long JSON in query (was resolving to localhost + http). */
 export const INSPECTOR_RECONNECT_STORAGE_KEY = "__mcpUseInspectorReconnect";
@@ -302,10 +303,10 @@ export function useAutoConnect({
         const targetOrigin = new URL(url).origin;
         const inspectorOrigin = window.location.origin;
         if (inspectorOrigin !== targetOrigin) {
-          proxyAddress = `${inspectorOrigin}/inspector/api/proxy`;
+          proxyAddress = `${inspectorOrigin}${inspectorPath("/inspector/api/proxy")}`;
         }
       } catch {
-        proxyAddress = `${window.location.origin}/inspector/api/proxy`;
+        proxyAddress = `${window.location.origin}${inspectorPath("/inspector/api/proxy")}`;
       }
 
       const proxyConfig: {
@@ -473,7 +474,7 @@ export function useAutoConnect({
     }
 
     // Fallback to config.json
-    fetch("/inspector/config.json")
+    fetch(inspectorPath("/inspector/config.json"))
       .then((res) => res.json())
       .then((configData: { autoConnectUrl: string | null }) => {
         setConfigLoaded(true);

--- a/libraries/typescript/packages/inspector/src/client/telemetry/telemetry.ts
+++ b/libraries/typescript/packages/inspector/src/client/telemetry/telemetry.ts
@@ -1,3 +1,4 @@
+import { inspectorPath } from "../utils/basePath.js";
 import type { BaseTelemetryEvent } from "./events.js";
 import { MCPInspectorOpenEvent } from "./events.js";
 import { getPackageVersion } from "./utils.js";
@@ -86,8 +87,10 @@ function isLocalStorageFunctional(): boolean {
 export class Telemetry {
   private static instance: Telemetry | null = null;
 
-  private readonly POSTHOG_PROXY_URL = "/inspector/api/tel/posthog";
-  private readonly SCARF_PROXY_URL = "/inspector/api/tel/scarf";
+  private readonly POSTHOG_PROXY_URL = inspectorPath(
+    "/inspector/api/tel/posthog"
+  );
+  private readonly SCARF_PROXY_URL = inspectorPath("/inspector/api/tel/scarf");
   private readonly UNKNOWN_USER_ID = "UNKNOWN_USER_ID";
 
   private _currUserId: string | null = null;

--- a/libraries/typescript/packages/inspector/src/client/utils/basePath.ts
+++ b/libraries/typescript/packages/inspector/src/client/utils/basePath.ts
@@ -1,0 +1,36 @@
+/**
+ * Runtime base-path helpers.
+ *
+ * When the inspector is embedded in an MCPServer that was configured with a
+ * `basePath` (e.g. `"/api"`), the embedding host injects the prefix into a
+ * `window.__MCP_BASE_PATH__` global from the served HTML. Same-origin
+ * fetches and React Router need to read that global rather than assuming the
+ * inspector lives at `/inspector` on the document origin.
+ *
+ * In standalone/CDN mode and when no basePath is configured, the global is
+ * absent or empty, so these helpers return the historical bare values.
+ */
+
+declare global {
+  interface Window {
+    __MCP_BASE_PATH__?: string;
+  }
+}
+
+/** Returns the runtime base-path prefix, normalized to no trailing slash. */
+export function getBasePath(): string {
+  if (typeof window === "undefined") return "";
+  const raw = window.__MCP_BASE_PATH__;
+  if (!raw || raw === "/") return "";
+  return raw.replace(/\/+$/, "");
+}
+
+/**
+ * Prefix an inspector-rooted path (one that historically started with
+ * `/inspector/...`) with the runtime base path.
+ *
+ * @example inspectorPath("/inspector/api/chat/stream") → "/api/inspector/api/chat/stream"
+ */
+export function inspectorPath(path: string): string {
+  return `${getBasePath()}${path}`;
+}

--- a/libraries/typescript/packages/inspector/src/server/middleware.ts
+++ b/libraries/typescript/packages/inspector/src/server/middleware.ts
@@ -31,6 +31,16 @@ export function mountInspector(
     sandboxOrigin?: string | null;
     /** Port the host app listens on (embedded inspector); required for tunnel start */
     serverPort?: number;
+    /**
+     * Path prefix the embedding host mounts the inspector under.
+     *
+     * When set (e.g. `"/api"`), the served HTML gets a `<base href>` of
+     * `${basePath}/inspector/` and `window.__MCP_BASE_PATH__` is exposed so
+     * the client can prefix React Router and same-origin fetch URLs.
+     *
+     * Empty/undefined keeps the historical behavior (mounted at `/inspector`).
+     */
+    basePath?: string;
   }
 ): void {
   // Find the built client files
@@ -50,6 +60,7 @@ export function mountInspector(
     devMode: config?.devMode,
     sandboxOrigin: config?.sandboxOrigin,
     inspectorMode: "embedded" as const,
+    basePath: config?.basePath,
   };
 
   // If it's already a Hono app, register routes directly.

--- a/libraries/typescript/packages/inspector/src/server/shared-routes.ts
+++ b/libraries/typescript/packages/inspector/src/server/shared-routes.ts
@@ -44,6 +44,14 @@ export type InspectorRoutesConfig = {
   autoConnectUrl?: string | null;
   /** HTTP port the app listens on (embedded inspector); required for tunnel start */
   serverPort?: number;
+  /**
+   * Embedding host's mount prefix (no trailing slash). Used to construct
+   * absolute URLs that the browser will fetch back (e.g. inside the widget
+   * container HTML). Hono route registrations themselves use the bare
+   * `/inspector/...` paths since the embedding host mounts a sub-Hono at
+   * `basePath` and the prefix is composed automatically.
+   */
+  basePath?: string;
 };
 
 export function registerInspectorRoutes(
@@ -159,8 +167,12 @@ export function registerInspectorRoutes(
       );
     }
 
-    // Return a container page that will fetch and load the actual widget
-    return c.html(generateWidgetContainerHtml("/inspector", toolId));
+    // Return a container page that will fetch and load the actual widget.
+    // Use the runtime basePath so the inner fetch lands on the right URL
+    // when the embedding host mounts the inspector under a prefix.
+    return c.html(
+      generateWidgetContainerHtml(`${config?.basePath ?? ""}/inspector`, toolId)
+    );
   });
 
   // Widget content endpoint - serves pre-fetched resource with injected OpenAI API

--- a/libraries/typescript/packages/inspector/src/server/shared-static.ts
+++ b/libraries/typescript/packages/inspector/src/server/shared-static.ts
@@ -63,6 +63,14 @@ interface RuntimeConfig {
    * network calls are made.
    */
   disableTelemetry?: boolean;
+  /**
+   * Path prefix the embedding host mounts the inspector under (no trailing
+   * slash). When non-empty, the served HTML gets a `<base href>` of
+   * `${basePath}/inspector/` so Vite's relative asset URLs resolve under the
+   * prefix, and `window.__MCP_BASE_PATH__` is exposed so the client can
+   * prefix React Router and same-origin fetch URLs.
+   */
+  basePath?: string;
 }
 
 /**
@@ -108,10 +116,38 @@ function injectRuntimeConfig(html: string, config?: RuntimeConfig): string {
     );
   }
 
-  if (scripts.length === 0) return html;
+  // Expose the runtime basePath so the React client can prefix Router
+  // basename and same-origin fetches. Default empty string = legacy
+  // "mounted at /inspector" behavior.
+  const basePath = config.basePath ?? "";
+  scripts.push(
+    `<script>window.__MCP_BASE_PATH__ = ${JSON.stringify(basePath)};</script>`
+  );
+
+  // With Vite built using `base: "./"`, asset URLs in the served HTML are
+  // relative ("./assets/foo.js"). The browser resolves them against the
+  // document's <base href> if present. Inject one matching the embedding
+  // host's mount so chunks load from `${basePath}/inspector/assets/...`.
+  // The trailing slash is required for <base href> path resolution.
+  const baseHref = `${basePath}/inspector/`;
+  const baseTag = `<base href="${baseHref}">`;
+
+  let injected = html;
+  // <base> must come before any asset reference. Vite emits <meta charset>
+  // first; place <base> immediately after it (or after <head> as a fallback).
+  if (/<meta\s+charset=[^>]*>/i.test(injected)) {
+    injected = injected.replace(
+      /(<meta\s+charset=[^>]*>)/i,
+      `$1\n    ${baseTag}`
+    );
+  } else {
+    injected = injected.replace(/<head[^>]*>/i, (m) => `${m}\n    ${baseTag}`);
+  }
+
+  if (scripts.length === 0) return injected;
 
   const injection = scripts.join("\n    ");
-  return html.replace("</head>", `    ${injection}\n  </head>`);
+  return injected.replace("</head>", `    ${injection}\n  </head>`);
 }
 
 /**
@@ -152,13 +188,22 @@ function generateCdnShellHtml(config?: RuntimeConfig): string {
         `<script>window.__MCP_USE_ANONYMIZED_TELEMETRY__ = false;try{localStorage.setItem("MCP_USE_ANONYMIZED_TELEMETRY","false");}catch(e){}</script>`
       );
     }
+    scripts.push(
+      `<script>window.__MCP_BASE_PATH__ = ${JSON.stringify(config.basePath ?? "")};</script>`
+    );
     return scripts.join("\n    ");
   })();
+
+  // CDN shell loads JS from absolute https:// CDN URLs, so <base href> is
+  // only needed for any future same-origin relative refs — emit it anyway
+  // so behavior stays consistent with the local-file path.
+  const baseTag = `<base href="${config?.basePath ?? ""}/inspector/">`;
 
   return `<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    ${baseTag}
     <link
       rel="icon"
       type="image/svg+xml"
@@ -257,12 +302,13 @@ export function registerStaticRoutes(
   // disableTelemetry is auto-populated from MCP_USE_ANONYMIZED_TELEMETRY=false so
   // setting that single env var disables both the inspector's own telemetry and
   // the in-browser posthog-js init triggered by `useMcp` hooks rendered inside.
+  const basePath = runtimeConfig?.basePath ?? "";
   const effectiveConfig: RuntimeConfig = {
     ...runtimeConfig,
     proxyUrl:
       runtimeConfig?.proxyUrl !== undefined
         ? runtimeConfig.proxyUrl
-        : "/inspector/api/proxy",
+        : `${basePath}/inspector/api/proxy`,
     disableTelemetry:
       runtimeConfig?.disableTelemetry ??
       process.env.MCP_USE_ANONYMIZED_TELEMETRY === "false",
@@ -314,8 +360,12 @@ export function registerStaticRoutes(
 
   // Serve static assets from /inspector/assets/*
   app.get("/inspector/assets/*", (c) => {
-    const path = c.req.path.replace("/inspector/assets/", "assets/");
-    const fullPath = join(distPath, path);
+    // Use the suffix after `/assets/` so this still works when the inspector
+    // is mounted under a host-supplied basePath (e.g. `/api/inspector/...`),
+    // where `c.req.path` is the full original URL even inside a sub-Hono.
+    const afterAssets = c.req.path.split("/assets/")[1];
+    if (afterAssets === undefined) return c.notFound();
+    const fullPath = join(distPath, "assets", afterAssets);
     if (existsSync(fullPath)) {
       const content = readFileSync(fullPath);
       const contentType = getContentType(fullPath);

--- a/libraries/typescript/packages/inspector/src/server/shared-utils.ts
+++ b/libraries/typescript/packages/inspector/src/server/shared-utils.ts
@@ -5,10 +5,15 @@
 
 import { convertMessagesToProvider } from "../llm/messageFormat";
 import { runToolLoop, runToolLoopNonStreaming } from "../llm/toolLoop";
-import type { ProviderMessage, ProviderName, ProviderTool } from "../llm/types";
+import type { ProviderMessage, ProviderTool } from "../llm/types";
 
 interface LLMConfig {
-  provider: ProviderName;
+  provider:
+    | "openai"
+    | "openai-compatible"
+    | "anthropic"
+    | "google"
+    | "openrouter";
   model: string;
   apiKey: string;
   temperature?: number;

--- a/libraries/typescript/packages/inspector/src/server/tunnel.ts
+++ b/libraries/typescript/packages/inspector/src/server/tunnel.ts
@@ -32,7 +32,7 @@ function readSubdomainFromManifest(): string | undefined {
   const projectPath = process.env.MCP_USE_PROJECT_PATH || process.cwd();
   try {
     const raw = readFileSync(
-      join(projectPath, "dist", "mcp-use.json"),
+      join(projectPath, ".mcp-use", "manifest.json"),
       "utf-8"
     );
     const manifest = JSON.parse(raw);

--- a/libraries/typescript/packages/inspector/vite.config.ts
+++ b/libraries/typescript/packages/inspector/vite.config.ts
@@ -9,8 +9,18 @@ const packageJson = JSON.parse(
   readFileSync(path.resolve(__dirname, "package.json"), "utf-8")
 );
 
-export default defineConfig({
-  base: "/inspector",
+export default defineConfig(({ command }) => ({
+  // For the production build, ship the inspector with **relative** asset URLs
+  // (`./assets/...`) so it's portable: an embedding host can mount the bundle
+  // under any prefix and a runtime `<base href>` resolves the chunks
+  // correctly. Vite's own dynamic-chunk loader uses `import.meta.url`, so
+  // code-splitting keeps working.
+  //
+  // For `vite dev`, keep the historical `/inspector` mount so the standalone
+  // dev URL (http://localhost:3000/inspector) and the API-proxy rules below
+  // continue to work exactly as before — relative base in dev would shift
+  // the dev URL to `/` and break the workflow.
+  base: command === "build" ? "./" : "/inspector",
   plugins: [
     react(),
     tailwindcss(),
@@ -181,4 +191,4 @@ export default defineConfig({
       },
     },
   },
-});
+}));


### PR DESCRIPTION
## Summary
When the inspector is embedded in an MCPServer configured with a `basePath` (e.g. `/api`), the inspector client now discovers that prefix at runtime via a `window.__MCP_BASE_PATH__` global injected into the served HTML, and routes all same-origin URLs through it.

Stacked on #1562 (configurable basePath for MCPServer). Review only this PR's diff once #1562 is merged; until then, the comparison base is `feat/mcp-2074-basepath`.

Refs: MCP-2074

## Implementation Details
1. **Discovery helpers.** New `client/utils/basePath.ts` exposes `getBasePath()` and `inspectorPath()`. Both read `window.__MCP_BASE_PATH__` lazily so any module-level constants that resolve URLs (e.g. `MCP_APPS_CONFIG.API_ENDPOINTS.WIDGET_STORE`, now a getter) pick up the runtime prefix even when imported before the global is set.
2. **React Router basename.** Derives from `getBasePath()` so the SPA mounts at `${basePath}/inspector` instead of `/inspector` when embedded.
3. **Same-origin fetch URLs.** Proxy address, telemetry, dev info, tunnel start/stop, chat stream, OAuth callback, widget store/content, sandbox proxy, and `config.json` all go through `inspectorPath()`.
4. **Server-side injection.** Inspector server's `shared-static` route and the `middleware` HTML injector both stamp `<script>window.__MCP_BASE_PATH__ = "${basePath}"</script>` into served HTML. `vite.config.ts` keeps `/inspector` as the dev base so standalone dev still works.

## Example Usage (After)
With #1562's `basePath: "/api"`:
- Inspector loads at `/api/inspector/`
- React Router uses `basename="/api"`, so links resolve to `/api/inspector/...`
- Inspector's fetch calls hit `/api/inspector/api/...` instead of `/api/...`

## Backwards Compatibility
Non-breaking. Standalone / CDN mode and unprefixed deployments keep their existing bare-path behavior because `__MCP_BASE_PATH__` is absent (`getBasePath()` returns \`""\`).

## Testing
- Verified locally with an MCPServer at `basePath: "/api"` — the inspector loads at `/api/inspector`, React Router navigates correctly, and all same-origin fetches resolve to the prefixed paths.
- Verified standalone inspector (no basePath) still loads at `/inspector`.