### PR TITLE
feat(examples): add uncertainty-aware bookkeeping MCP example

### DIFF
--- a/libraries/python/examples/bookkeeping_tools/.env.example
+++ b/libraries/python/examples/bookkeeping_tools/.env.example
@@ -1,0 +1,1 @@
+GEMINI_API_KEY=your_gemini_api_key_here

--- a/libraries/python/examples/bookkeeping_tools/README.md
+++ b/libraries/python/examples/bookkeeping_tools/README.md
@@ -1,0 +1,28 @@
+# Bookkeeping Tools MCP Server
+
+An MCP server exposing two tools for SaaS startup 
+bookkeeping — transaction categorization with confidence 
+scoring and human-review flagging.
+
+Works without any API key for common vendors (AWS, 
+Figma, Google Ads). Flags ambiguous cases with specific 
+clarifying questions rather than guessing.
+
+## What it demonstrates
+- Building an MCPServer with two tools
+- Rule-based categorization with confidence scoring
+- Uncertainty handling — flags review cases explicitly
+- Using MCPAgent to interact with the server
+
+## Setup
+1. pip install -r requirements.txt
+2. cp .env.example .env and add GEMINI_API_KEY
+3. python server.py
+
+## Run
+python server.py    # start the MCP server
+python client.py   # run the agent demo
+
+## Background
+Motivated by reliability research on AI bookkeeping:
+https://github.com/Wali05/bookkeeping-ai-eval

--- a/libraries/python/examples/bookkeeping_tools/client.py
+++ b/libraries/python/examples/bookkeeping_tools/client.py
@@ -1,0 +1,27 @@
+import asyncio
+
+from dotenv import load_dotenv
+from langchain_google_genai import ChatGoogleGenerativeAI
+
+from mcp_use import MCPAgent, MCPClient
+
+load_dotenv()
+
+
+async def main():
+    client = MCPClient({"mcpServers": {"bookkeeping": {"url": "http://localhost:8000/mcp"}}})
+
+    llm = ChatGoogleGenerativeAI(model="gemini-3.1-flash-lite")
+    agent = MCPAgent(llm=llm, client=client, max_steps=10)
+
+    result = await agent.run(
+        "I have these transactions from last month: "
+        "AWS EC2 $840, annual Figma subscription $1440, "
+        "Deel contractor payment $3200, Google Ads $2100. "
+        "Categorize them and flag any that need my review."
+    )
+    print(result)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/libraries/python/examples/bookkeeping_tools/requirements.txt
+++ b/libraries/python/examples/bookkeeping_tools/requirements.txt
@@ -1,0 +1,3 @@
+mcp-use
+langchain-google-genai
+python-dotenv

--- a/libraries/python/examples/bookkeeping_tools/server.py
+++ b/libraries/python/examples/bookkeeping_tools/server.py
@@ -1,0 +1,116 @@
+import json
+from typing import Annotated
+
+from dotenv import load_dotenv
+from pydantic import Field
+
+from mcp_use import MCPServer
+
+load_dotenv()
+server = MCPServer("bookkeeping-tools")
+
+
+@server.tool()
+async def categorize_transaction(
+    description: Annotated[str, Field(description="Description of the transaction")],
+    vendor: Annotated[str, Field(description="Vendor or merchant name")],
+    amount: Annotated[float, Field(description="Transaction amount")],
+) -> dict:
+    """
+    Categorize a financial transaction for SaaS startup
+    bookkeeping. Returns category, confidence (0-100),
+    and a needs_review flag for ambiguous cases.
+    Works without any API key for common vendors.
+    """
+    # Rule-based classification first (no API needed)
+    vendor_lower = vendor.lower()
+    desc_lower = description.lower()
+
+    # High-confidence rule-based cases
+    cloud_cogs = ["aws", "amazon web services", "gcp", "google cloud", "azure"]
+    saas_tools = ["figma", "notion", "slack", "github", "linear", "vercel"]
+    ads = ["google ads", "meta ads", "facebook ads", "linkedin ads"]
+
+    if any(v in vendor_lower for v in cloud_cogs):
+        # Ambiguous: COGS vs OPEX depends on usage
+        return {
+            "category": "Needs Review",
+            "confidence": 55,
+            "reasoning": "Cloud infra is COGS if serving customers, OPEX if internal tooling",
+            "needs_review": True,
+            "clarifying_question": f"Is the {vendor} charge "
+            f"${amount:.0f} for infrastructure serving "
+            "customers (COGS) or internal development "
+            "tooling (Operating Expense)?",
+        }
+
+    if any(v in vendor_lower for v in saas_tools):
+        category = "Prepaid Expense" if amount > 500 else "Operating Expense"
+        return {"category": category, "confidence": 90, "reasoning": "SaaS tool subscription", "needs_review": False}
+
+    if (
+        any(v in vendor_lower for v in ads)
+        or any(v in desc_lower for v in ads)
+        or "ads" in desc_lower
+        or "advertising" in desc_lower
+    ):
+        return {
+            "category": "Sales and Marketing",
+            "confidence": 95,
+            "reasoning": "Digital advertising spend",
+            "needs_review": False,
+        }
+
+    contractors = ["deel", "remote.com", "remote", "papaya global", "rippling", "gusto", "mercury payroll"]
+
+    if any(v in vendor_lower for v in contractors):
+        return {
+            "category": "Contract Labor",
+            "confidence": 80,
+            "reasoning": "Contractor payroll platform — likely a 1099 contractor payment",
+            "needs_review": True,
+            "clarifying_question": f"Is the ${amount:.0f} "
+            f"Deel payment for a full-time employee "
+            "(W2) or an independent contractor (1099)? "
+            "This affects tax reporting.",
+        }
+
+    # Ambiguous: needs review
+    return {
+        "category": "Needs Review",
+        "confidence": 40,
+        "reasoning": "Vendor not recognized — manual classification required",
+        "needs_review": True,
+        "clarifying_question": f"What is the business purpose of the ${amount:.0f} payment to {vendor}?",
+    }
+
+
+@server.tool()
+async def flag_ambiguous_transactions(
+    transactions_json: Annotated[str, Field(description="JSON array of transactions")],
+) -> str:
+    """
+    Takes a JSON array of transactions and returns only
+    those needing human review. Each flagged item includes
+    a specific clarifying question.
+
+    Input format: [{"description": ..., "vendor": ...,
+                    "amount": ...}]
+    """
+    transactions = json.loads(transactions_json)
+    flagged = []
+    for tx in transactions:
+        result = await categorize_transaction(tx["description"], tx["vendor"], tx["amount"])
+        if result["needs_review"]:
+            flagged.append(
+                {
+                    "transaction": tx,
+                    "category": result["category"],
+                    "clarifying_question": result.get("clarifying_question", "Please clarify this transaction."),
+                }
+            )
+    return json.dumps(flagged, indent=2)
+
+
+if __name__ == "__main__":
+    server.run()


### PR DESCRIPTION
## Language / Project Scope
Check all that apply:
- [ ] TypeScript
- [x] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes
Added a new Python example demonstrating an MCPServer for 
SaaS startup bookkeeping with uncertainty handling, plus a 
corresponding MCPAgent client.

## Implementation Details
1. `categorize_transaction` tool — rule-based classification 
   with confidence scoring and needs_review flag. 
   Rule-based categorization logic works without external APIs.
2. `flag_ambiguous_transactions` tool — processes a batch of 
   transactions and returns only ambiguous ones, each with a 
   targeted clarifying question.
3. `client.py` — MCPAgent demo showing how an agent calls 
   both tools over HTTP transport.

## Python Checklist
- [x] Code formatted with `ruff format`
- [x] Linting passes with `ruff check`
- [ ] Added or updated tests if needed
- [ ] Updated documentation if needed

## Example Usage (After)
```python
# Terminal 1
python server.py

# Terminal 2 — agent calls both tools automatically
python client.py
# Output: categorizes AWS EC2, Figma, Google Ads, Deel
# and flags ambiguous ones with clarifying questions
```

## Testing
- Ran ruff format and ruff check — 1 issue auto-fixed
- Tested end-to-end locally using the Gemini client configuration
- All 4 transactions categorize correctly

## Backwards Compatibility
N/A — isolated new example, no existing code modified.

## Background
Motivated by reliability research on AI bookkeeping:
https://github.com/Wali05/bookkeeping-ai-eval