### PR TITLE
feat(typescript): in-process mode for oauthBetterAuthProvider

### DIFF
--- a/docs/typescript/server/configuration.mdx
+++ b/docs/typescript/server/configuration.mdx
@@ -37,6 +37,8 @@ const server = new MCPServer({
   host: 'localhost',                    // Bind hostname (default: 'localhost')
   baseUrl: 'https://mcp.example.com',   // Public URL for widget/asset URLs
                                         // Overrides host:port; also read from MCP_URL env var
+  basePath: '/api',                     // Mount all routes under this prefix
+                                        // (MCP transport, inspector, widgets, OAuth)
 
   // ── CORS ───────────────────────────────────────────────────
   cors: {
@@ -65,6 +67,46 @@ await server.listen(3000)
 **Port resolution order:** `listen(port)` argument → `--port` CLI flag → `PORT` env var → `3000`
 
 **Base URL resolution order:** `baseUrl` config → `MCP_URL` env var → `http://{host}:{port}`
+
+### Mounting Under a Path Prefix
+
+Use `basePath` to mount every route the server registers under a single prefix. This is useful when:
+
+- The MCP server lives behind a reverse proxy that strips a path prefix (e.g. `/api/*` routed to one upstream)
+- You want to host the MCP server alongside other routes in the same Hono app under a non-root path
+- You're deploying multiple MCP servers on one origin and need to namespace them
+
+```typescript
+const server = new MCPServer({
+  name: 'my-server',
+  version: '1.0.0',
+  basePath: '/api',
+})
+```
+
+With `basePath: '/api'`, every route the server handles moves under that prefix — including your own custom routes:
+
+| Route | Default | With `basePath: '/api'` |
+|---|---|---|
+| MCP transport (streamable HTTP) | `POST /mcp` | `POST /api/mcp` |
+| MCP transport (SSE) | `GET /sse` | `GET /api/sse` |
+| Inspector UI | `GET /inspector` | `GET /api/inspector` |
+| Widget assets | `/mcp-use/widgets/*` | `/api/mcp-use/widgets/*` |
+| Public assets | `/mcp-use/public/*` | `/api/mcp-use/public/*` |
+| OAuth metadata | `/.well-known/oauth-authorization-server` | `/api/.well-known/oauth-authorization-server` |
+| OAuth endpoints | `/authorize`, `/token`, `/register` | `/api/authorize`, `/api/token`, `/api/register` |
+| Custom route (e.g. `server.app.get('/sign-in', ...)`) | `/sign-in` | `/api/sign-in` |
+
+OAuth discovery metadata (`issuer`, `authorization_endpoint`, `token_endpoint`, `registration_endpoint`, protected-resource URLs) is rebuilt to include the prefix, so standard OAuth 2.1 / RFC 9728 discovery works without extra configuration.
+
+**Rules:**
+- Must start with `/` and must not end with `/`
+- Empty string or `"/"` means "no prefix" (the default)
+- `/favicon.ico` is always served at the root regardless of `basePath`, so browsers' implicit favicon request still resolves
+
+<Note>
+Routes you register on `server.app` (including `server.app.get(...)`, `server.app.use(...)`) automatically live under `basePath`. If you also configure OAuth on the same server (e.g. better-auth at `/api/auth/**`), update the `authURL` / callback URLs you pass to that auth provider to include `basePath` too — clients reaching the server through `basePath` need to discover those endpoints under the same prefix.
+</Note>
 
 ### Environment Variables
 

--- a/libraries/typescript/.changeset/better-auth-in-process-mode.md
+++ b/libraries/typescript/.changeset/better-auth-in-process-mode.md
@@ -1,0 +1,55 @@
+---
+"mcp-use": minor
+---
+
+Add in-process mode to `oauthBetterAuthProvider`. The function now accepts a Better Auth instance directly — the SDK mounts Better Auth's API handler under the MCPServer's `basePath` and serves OAuth discovery (`/.well-known/oauth-authorization-server`, `/.well-known/openid-configuration`, including the RFC 8414 §3.1 path-insertion variants) at the host root automatically. Discovery routes are synthesized locally via `auth.api.getOAuthServerConfig` / `auth.api.getOpenIdConfig`, so no upstream fetch is involved and no extra wiring is required.
+
+### Before
+
+```typescript
+const server = new MCPServer({
+  basePath: "/mcp-server",
+  oauth: oauthBetterAuthProvider({
+    authURL: "http://localhost:3000/mcp-server/api/auth",
+  }),
+});
+
+// Developer had to mount everything manually. `server.app` is the basePath
+// clone, so well-known endpoints registered through it ended up under
+// /mcp-server/.well-known/* — silently broken because RFC 8414 §3.1 requires
+// the path-insertion variant at the literal host root.
+server.app.on(["GET", "POST"], "/api/auth/**", (c) => auth.handler(c.req.raw));
+server.app.get("/.well-known/oauth-authorization-server", authServerHandler);
+server.app.get("/.well-known/oauth-authorization-server/api/auth", authServerHandler);
+server.app.get("/.well-known/openid-configuration", openIdHandler);
+server.app.get("/.well-known/openid-configuration/api/auth", openIdHandler);
+```
+
+### After
+
+```typescript
+const server = new MCPServer({
+  basePath: "/mcp-server",
+  oauth: oauthBetterAuthProvider(auth),
+});
+```
+
+Set `auth.options.basePath` to where Better Auth should live inside the MCPServer's basePath — e.g. `basePath: "/mcp-server/api/auth"` with `baseURL: "http://localhost:3000"`. Better Auth signs tokens with `${baseURL}${basePath}` as the issuer, advertises every endpoint anchored on it, and the SDK mounts `auth.handler` at the same path. Anchoring Better Auth at a sub-path of the MCPServer basePath (rather than the basePath itself) keeps `auth.handler` from shadowing routes like the MCP transport. The SDK mirrors Better Auth's own `withPath` resolution, so passing the full path via `baseURL` works identically if you prefer.
+
+### External mode unchanged
+
+Pass `{ authURL }` for a Better Auth deployment running on a separate origin:
+
+```typescript
+oauthBetterAuthProvider({ authURL: "https://auth.example.com/api/auth" })
+```
+
+The two modes are mutually exclusive — the argument shape selects the mode (a Better Auth instance has `handler` + `options`; a config object doesn't).
+
+### Provider hook (for library authors)
+
+`OAuthProvider` gains three optional hooks for custom providers:
+
+- `authorizationServerMetadataHandler?(req: Request): Response | Promise<Response>` — replaces the default upstream-fetch behavior on `.well-known/oauth-authorization-server`
+- `openIdConfigurationMetadataHandler?` — same, for `.well-known/openid-configuration`
+- `installRoutes?(rootApp: Hono, basePath: string): void` — mount provider-specific routes on the root Hono app after defaults are registered

--- a/libraries/typescript/.changeset/configurable-base-path.md
+++ b/libraries/typescript/.changeset/configurable-base-path.md
@@ -42,6 +42,17 @@ This means:
 - The HTTP discovery endpoint `/__mcp-use/serverinfo` is removed. `MCPServer.listen()` now writes `.mcp-use/server-info.json` (host, port, basePath, mcpUrl, inspectorUrl) for out-of-process tooling to read.
 - Dev-mode widget temp directories move under `.mcp-use/.tmp/` so every top-level entry in `.mcp-use/` is a framework namespace.
 
+### Production serving is now fully static
+
+`/_mcp-use/*` is served by a single Hono `serveStatic` middleware in production — built widget HTML is shipped byte-for-byte from disk. The CLI's `buildWidgets` bakes `window.__getFile` and `window.__mcpPublicUrl` directly into `index.html` at build time (previously only when `MCP_SERVER_URL` was set), so no per-request HTML rewriting happens.
+
+Two related behavior changes:
+
+- **`<base href>` is no longer injected** into widget HTML. If a widget relied on relative URLs resolving against the server origin root, switch to absolute paths (`/mcp`, `/_mcp-use/public/...`) or read `window.__mcpPublicUrl`.
+- **`setupPublicRoutes` is no longer used in production.** The export is still available for embedders that hand-roll their own server but want the dev-mode helper that serves from `./public/`.
+
+Runtime gate: Deno keeps hand-rolled handlers (Deno doesn't load `@hono/node-server`); Node and Bun use `serveStatic`.
+
 ### Embedder note
 
 If you mount `getHandler()` inside a larger app at some prefix, `/_mcp-use/` lives at the embedder's mount prefix, not the host root. "BasePath-agnostic" means "ignores mcp-use's own basePath config," not "magically escapes the embedder."

--- a/libraries/typescript/.changeset/configurable-base-path.md
+++ b/libraries/typescript/.changeset/configurable-base-path.md
@@ -1,18 +1,19 @@
 ---
 "mcp-use": minor
+"@mcp-use/cli": minor
 ---
 
-Add `basePath` option to `MCPServer` for mounting every server route under a configurable prefix.
+Add `basePath` option to `MCPServer` and restructure how the framework owns URL and disk space.
 
-When `basePath` is set, the MCP transport, inspector UI, widget/public asset routes, OAuth flow + metadata endpoints, and bearer-auth middleware all live under that prefix. For example, with `basePath: "/api"`:
+### `basePath` config
 
-- MCP transport: `POST /api/mcp` and `/api/sse`
-- Inspector UI: `GET /api/inspector`
-- Widgets: `/api/mcp-use/widgets/*`, public assets: `/api/mcp-use/public/*`
-- OAuth metadata: `/api/.well-known/oauth-authorization-server`
-- OAuth endpoints: `/api/authorize`, `/api/token`, `/api/register`
+When `basePath` is set, all user-facing protocol routes mount under that prefix:
 
-`/favicon.ico` continues to be served at the root so browsers' implicit favicon request still resolves. OAuth metadata responses (issuer, authorization_endpoint, etc.) include the prefix so standard discovery works without extra configuration.
+- MCP transport: `POST ${basePath}/mcp` and `${basePath}/sse`
+- Inspector UI: `GET ${basePath}/inspector`
+- OAuth endpoints: `${basePath}/authorize`, `${basePath}/token`, `${basePath}/register`
+- OAuth metadata: `${basePath}/.well-known/oauth-authorization-server` (RFC 8414 requires the discovery path at the issuer root, so this must live under `basePath`)
+- Bearer-auth middleware and user-registered routes auto-prefix under `basePath`
 
 ```typescript
 const server = new MCPServer({
@@ -21,3 +22,26 @@ const server = new MCPServer({
   basePath: "/api",
 });
 ```
+
+### Framework asset namespace
+
+Static framework assets escape `basePath` and live at a fixed root namespace, mirroring how Next.js separates `.next/` ↔ `/_next/`:
+
+| Concern         | URL                              | Disk                         |
+| --------------- | -------------------------------- | ---------------------------- |
+| Widget HTML     | `/_mcp-use/widgets/{name}`       | `.mcp-use/widgets/{name}/`   |
+| Widget assets   | `/_mcp-use/widgets/{name}/assets/*` | same                      |
+| Public assets   | `/_mcp-use/public/*`             | `.mcp-use/public/*`          |
+| Build manifest  | (not served)                     | `.mcp-use/manifest.json`     |
+| Server handshake| (not served)                     | `.mcp-use/server-info.json`  |
+
+This means:
+
+- The legacy `${basePath}/mcp-use/widgets/*` and `${basePath}/mcp-use/public/*` routes are gone — replace with `/_mcp-use/widgets/*` and `/_mcp-use/public/*` (bare absolute paths in widget HTML — no baseUrl/basePath interpolation needed).
+- `mcp-use build` writes output to `.mcp-use/` instead of `dist/` (widgets to `.mcp-use/widgets/`, public assets to `.mcp-use/public/`, manifest to `.mcp-use/manifest.json`). `dist/` now holds only your own transpiled server code.
+- The HTTP discovery endpoint `/__mcp-use/serverinfo` is removed. `MCPServer.listen()` now writes `.mcp-use/server-info.json` (host, port, basePath, mcpUrl, inspectorUrl) for out-of-process tooling to read.
+- Dev-mode widget temp directories move under `.mcp-use/.tmp/` so every top-level entry in `.mcp-use/` is a framework namespace.
+
+### Embedder note
+
+If you mount `getHandler()` inside a larger app at some prefix, `/_mcp-use/` lives at the embedder's mount prefix, not the host root. "BasePath-agnostic" means "ignores mcp-use's own basePath config," not "magically escapes the embedder."

--- a/libraries/typescript/.changeset/configurable-base-path.md
+++ b/libraries/typescript/.changeset/configurable-base-path.md
@@ -1,0 +1,23 @@
+---
+"mcp-use": minor
+---
+
+Add `basePath` option to `MCPServer` for mounting every server route under a configurable prefix.
+
+When `basePath` is set, the MCP transport, inspector UI, widget/public asset routes, OAuth flow + metadata endpoints, and bearer-auth middleware all live under that prefix. For example, with `basePath: "/api"`:
+
+- MCP transport: `POST /api/mcp` and `/api/sse`
+- Inspector UI: `GET /api/inspector`
+- Widgets: `/api/mcp-use/widgets/*`, public assets: `/api/mcp-use/public/*`
+- OAuth metadata: `/api/.well-known/oauth-authorization-server`
+- OAuth endpoints: `/api/authorize`, `/api/token`, `/api/register`
+
+`/favicon.ico` continues to be served at the root so browsers' implicit favicon request still resolves. OAuth metadata responses (issuer, authorization_endpoint, etc.) include the prefix so standard discovery works without extra configuration.
+
+```typescript
+const server = new MCPServer({
+  name: "my-server",
+  version: "1.0.0",
+  basePath: "/api",
+});
+```

--- a/libraries/typescript/.changeset/configurable-base-path.md
+++ b/libraries/typescript/.changeset/configurable-base-path.md
@@ -7,13 +7,14 @@ Add `basePath` option to `MCPServer` and restructure how the framework owns URL 
 
 ### `basePath` config
 
-When `basePath` is set, all user-facing protocol routes mount under that prefix:
+When `basePath` is set, all framework routes mount under that prefix:
 
 - MCP transport: `POST ${basePath}/mcp` and `${basePath}/sse`
 - Inspector UI: `GET ${basePath}/inspector`
 - OAuth endpoints: `${basePath}/authorize`, `${basePath}/token`, `${basePath}/register`
 - OAuth metadata: `${basePath}/.well-known/oauth-authorization-server` (RFC 8414 requires the discovery path at the issuer root, so this must live under `basePath`)
 - Bearer-auth middleware and user-registered routes auto-prefix under `basePath`
+- Framework assets: `${basePath}/_mcp-use/widgets/*`, `${basePath}/_mcp-use/public/*`, `${basePath}/favicon.ico`
 
 ```typescript
 const server = new MCPServer({
@@ -23,28 +24,33 @@ const server = new MCPServer({
 });
 ```
 
+The only routes that stay at the literal host root are the OAuth `.well-known/*` discovery endpoints — those are pinned to the host root by RFC 8414 / RFC 9728. Everything else lives under `basePath`.
+
 ### Framework asset namespace
 
-Static framework assets escape `basePath` and live at a fixed root namespace, mirroring how Next.js separates `.next/` ↔ `/_next/`:
+Static framework assets live at `${basePath}/_mcp-use/*`, mirroring how Next.js separates `.next/` ↔ `/_next/`:
 
-| Concern         | URL                              | Disk                         |
-| --------------- | -------------------------------- | ---------------------------- |
-| Widget HTML     | `/_mcp-use/widgets/{name}`       | `.mcp-use/widgets/{name}/`   |
-| Widget assets   | `/_mcp-use/widgets/{name}/assets/*` | same                      |
-| Public assets   | `/_mcp-use/public/*`             | `.mcp-use/public/*`          |
-| Build manifest  | (not served)                     | `.mcp-use/manifest.json`     |
-| Server handshake| (not served)                     | `.mcp-use/server-info.json`  |
+| Concern          | URL                                            | Disk                         |
+| ---------------- | ---------------------------------------------- | ---------------------------- |
+| Widget HTML      | `${basePath}/_mcp-use/widgets/{name}`          | `.mcp-use/widgets/{name}/`   |
+| Widget assets    | `${basePath}/_mcp-use/widgets/{name}/assets/*` | same                         |
+| Public assets    | `${basePath}/_mcp-use/public/*`                | `.mcp-use/public/*`          |
+| Favicon          | `${basePath}/favicon.ico`                      | `public/favicon.ico`         |
+| Build manifest   | (not served)                                   | `.mcp-use/manifest.json`     |
+| Server handshake | (not served)                                   | `.mcp-use/server-info.json`  |
 
 This means:
 
-- The legacy `${basePath}/mcp-use/widgets/*` and `${basePath}/mcp-use/public/*` routes are gone — replace with `/_mcp-use/widgets/*` and `/_mcp-use/public/*` (bare absolute paths in widget HTML — no baseUrl/basePath interpolation needed).
+- The legacy `${basePath}/mcp-use/widgets/*` and `${basePath}/mcp-use/public/*` routes are gone — they're now under `_mcp-use/`.
 - `mcp-use build` writes output to `.mcp-use/` instead of `dist/` (widgets to `.mcp-use/widgets/`, public assets to `.mcp-use/public/`, manifest to `.mcp-use/manifest.json`). `dist/` now holds only your own transpiled server code.
 - The HTTP discovery endpoint `/__mcp-use/serverinfo` is removed. `MCPServer.listen()` now writes `.mcp-use/server-info.json` (host, port, basePath, mcpUrl, inspectorUrl) for out-of-process tooling to read.
 - Dev-mode widget temp directories move under `.mcp-use/.tmp/` so every top-level entry in `.mcp-use/` is a framework namespace.
 
-### Production serving is now fully static
+Browsers won't pick up favicons at `${basePath}/favicon.ico` automatically (they only probe the host root). The MCP server's `icons` config — which the SDK exposes via `getServerInfo` — is the authoritative reference for clients that need to display an icon.
 
-`/_mcp-use/*` is served by a single Hono `serveStatic` middleware in production — built widget HTML is shipped byte-for-byte from disk. The CLI's `buildWidgets` bakes `window.__getFile` and `window.__mcpPublicUrl` directly into `index.html` at build time (previously only when `MCP_SERVER_URL` was set), so no per-request HTML rewriting happens.
+### Production widget HTML self-resolves basePath
+
+`mcp-use build` bakes `window.__getFile` and `window.__mcpPublicUrl` into the built widget HTML in a way that *resolves the server's basePath at runtime* from `window.location.pathname`. The same built bundle works whether the server is mounted at `/` or under any `basePath`, with no rebuild needed.
 
 Two related behavior changes:
 
@@ -55,4 +61,4 @@ Runtime gate: Deno keeps hand-rolled handlers (Deno doesn't load `@hono/node-ser
 
 ### Embedder note
 
-If you mount `getHandler()` inside a larger app at some prefix, `/_mcp-use/` lives at the embedder's mount prefix, not the host root. "BasePath-agnostic" means "ignores mcp-use's own basePath config," not "magically escapes the embedder."
+If you mount `getHandler()` inside a larger app at some prefix, `/_mcp-use/` lives at the embedder's mount prefix combined with mcp-use's own `basePath`.

--- a/libraries/typescript/packages/cli/src/index.ts
+++ b/libraries/typescript/packages/cli/src/index.ts
@@ -181,21 +181,14 @@ function normalizeBrowserHost(host: string): string {
 }
 
 /**
- * Read the running server's basePath from `.mcp-use/server-info.json` if the
- * server wrote one on startup. Returns "" when the file is missing or stale,
- * which preserves the historical bare `/mcp` / `/inspector` behavior for
- * servers configured without a basePath.
- *
- * The file is polled (not just read once) because `waitForServer` only
- * confirms the HTTP port is open — server-info.json is written immediately
- * before that point, so it should already exist by the time we read.
+ * Read the running server's basePath from `.mcp-use/server-info.json`. The
+ * server writes this file before reporting ready, so it should already exist
+ * by the time we read. Returns "" when missing or unparseable.
  */
 async function readServerBasePath(projectPath: string): Promise<string> {
   try {
-    const { readFile } = await import("node:fs/promises");
-    const { join } = await import("node:path");
     const raw = await readFile(
-      join(projectPath, ".mcp-use", "server-info.json"),
+      path.join(projectPath, ".mcp-use", "server-info.json"),
       "utf-8"
     );
     const parsed = JSON.parse(raw);

--- a/libraries/typescript/packages/cli/src/index.ts
+++ b/libraries/typescript/packages/cli/src/index.ts
@@ -1178,54 +1178,53 @@ export default {
         }
       }
 
-      // Post-process HTML for static deployments (e.g., Supabase)
-      // If MCP_SERVER_URL is set, inject window globals at build time
+      // Bake runtime globals into the built HTML so production serving is a
+      // pure static read — no per-request HTML rewriter needed. Mirrors the
+      // Next.js `/_next/` model: build owns transforms, server ships bytes.
+      //
+      // - `__getFile`: asset-URL builder used by Vite's `renderBuiltUrl` hook.
+      //   Defaults to the framework's `/_mcp-use/widgets/{name}/` path; uses
+      //   MCP_URL when that points at an external CDN (static deployments).
+      // - `__mcpPublicUrl`: public-asset prefix. MCP_SERVER_URL roots it
+      //   absolutely for static hosts that need a full origin; otherwise the
+      //   bare path is fine (served from the same origin as the widget).
+      // - `__mcpPublicAssetsUrl`: where public files are physically stored;
+      //   diverges from `__mcpPublicUrl` only when MCP_URL is a separate CDN.
       const mcpServerUrl = process.env.MCP_SERVER_URL;
-      if (mcpServerUrl) {
-        try {
-          const htmlPath = path.join(outDir, "index.html");
-          let html = await fs.readFile(htmlPath, "utf8");
+      const assetBase = mcpUrl
+        ? `${mcpUrl}/${widgetName}/`
+        : `/_mcp-use/widgets/${widgetName}/`;
+      const publicUrl = mcpServerUrl
+        ? `${mcpServerUrl}/_mcp-use/public`
+        : "/_mcp-use/public";
+      const publicAssetsUrl = mcpUrl ? `${mcpUrl}/public` : "/_mcp-use/public";
 
-          // Inject window.__mcpPublicUrl and window.__getFile into <head>
-          // Note: __mcpPublicUrl uses standard format for useWidget to derive mcp_url
-          // __mcpPublicAssetsUrl points to where public files are actually stored
-          const injectionScript = `<script>window.__getFile = (filename) => { return "${mcpUrl}/${widgetName}/"+filename }; window.__mcpPublicUrl = "${mcpServerUrl}/_mcp-use/public"; window.__mcpPublicAssetsUrl = "${mcpUrl}/public";</script>`;
+      try {
+        const htmlPath = path.join(outDir, "index.html");
+        let html = await fs.readFile(htmlPath, "utf8");
 
-          // Check if script tag already exists in head
-          if (!html.includes("window.__mcpPublicUrl")) {
-            html = html.replace(
-              /<head[^>]*>/i,
-              `<head>\n    ${injectionScript}`
-            );
-          }
+        const injectionScript = `<script>window.__getFile = (filename) => { return ${JSON.stringify(assetBase)}+filename }; window.__mcpPublicUrl = ${JSON.stringify(publicUrl)}; window.__mcpPublicAssetsUrl = ${JSON.stringify(publicAssetsUrl)};</script>`;
 
-          // Update base href if it exists, or inject it
-          if (/<base\s+[^>]*\/?>/i.test(html)) {
-            // Replace existing base tag
-            html = html.replace(
-              /<base\s+[^>]*\/?>/i,
-              `<base href="${mcpServerUrl}">`
-            );
-          } else {
-            // Inject base tag after the injection script
-            html = html.replace(
-              injectionScript,
-              `${injectionScript}\n    <base href="${mcpServerUrl}">`
-            );
-          }
-
-          await fs.writeFile(htmlPath, html, "utf8");
-          console.log(
-            chalk.gray(`    → Injected MCP_SERVER_URL into ${widgetName}`)
-          );
-        } catch (error) {
-          console.warn(
-            chalk.yellow(
-              `    ⚠ Failed to post-process HTML for ${widgetName}:`,
-              error
-            )
+        if (!html.includes("window.__mcpPublicUrl")) {
+          html = html.replace(
+            /<head[^>]*>/i,
+            (match) => `${match}\n    ${injectionScript}`
           );
         }
+
+        // Remove any stray <base> tag — Vite's absolute `base` URL means
+        // relative refs already resolve correctly, and a runtime origin in
+        // <base> would defeat static caching.
+        html = html.replace(/<base\s+[^>]*\/?>\s*/gi, "");
+
+        await fs.writeFile(htmlPath, html, "utf8");
+      } catch (error) {
+        console.warn(
+          chalk.yellow(
+            `    ⚠ Failed to post-process HTML for ${widgetName}:`,
+            error
+          )
+        );
       }
 
       console.log(chalk.green(`    ✓ Built ${widgetName}`));

--- a/libraries/typescript/packages/cli/src/index.ts
+++ b/libraries/typescript/packages/cli/src/index.ts
@@ -778,7 +778,12 @@ if (container && Component) {
 }
 `;
 
-    // Create HTML template
+    // Create HTML template. The favicon href is a *relative* path so it
+    // resolves correctly whether the widget HTML is served at
+    // `/_mcp-use/widgets/<slug>/index.html` (no basePath) or
+    // `${basePath}/_mcp-use/widgets/<slug>/index.html` (basePath set).
+    // `../../public/foo.ico` lands on the same-origin `/_mcp-use/public/`
+    // namespace in both cases.
     const htmlContent = `<!doctype html>
 <html lang="en">
   <head>
@@ -787,7 +792,7 @@ if (container && Component) {
     <title>${widgetName} Widget</title>${
       favicon
         ? `
-    <link rel="icon" href="/_mcp-use/public/${favicon}" />`
+    <link rel="icon" href="../../public/${favicon}" />`
         : ""
     }
   </head>
@@ -1183,27 +1188,36 @@ export default {
       // Next.js `/_next/` model: build owns transforms, server ships bytes.
       //
       // - `__getFile`: asset-URL builder used by Vite's `renderBuiltUrl` hook.
-      //   Defaults to the framework's `/_mcp-use/widgets/{name}/` path; uses
-      //   MCP_URL when that points at an external CDN (static deployments).
+      //   Defaults to a same-origin path that *resolves the server's
+      //   `basePath` at runtime* from `window.location.pathname` (so the same
+      //   built HTML works whether the server is mounted at `/` or `/api`);
+      //   uses MCP_URL when that points at an external CDN.
       // - `__mcpPublicUrl`: public-asset prefix. MCP_SERVER_URL roots it
-      //   absolutely for static hosts that need a full origin; otherwise the
-      //   bare path is fine (served from the same origin as the widget).
+      //   absolutely for static hosts that need a full origin; otherwise it
+      //   self-resolves basePath the same way as `__getFile`.
       // - `__mcpPublicAssetsUrl`: where public files are physically stored;
       //   diverges from `__mcpPublicUrl` only when MCP_URL is a separate CDN.
       const mcpServerUrl = process.env.MCP_SERVER_URL;
-      const assetBase = mcpUrl
-        ? `${mcpUrl}/${widgetName}/`
-        : `/_mcp-use/widgets/${widgetName}/`;
-      const publicUrl = mcpServerUrl
-        ? `${mcpServerUrl}/_mcp-use/public`
-        : "/_mcp-use/public";
-      const publicAssetsUrl = mcpUrl ? `${mcpUrl}/public` : "/_mcp-use/public";
 
       try {
         const htmlPath = path.join(outDir, "index.html");
         let html = await fs.readFile(htmlPath, "utf8");
 
-        const injectionScript = `<script>window.__getFile = (filename) => { return ${JSON.stringify(assetBase)}+filename }; window.__mcpPublicUrl = ${JSON.stringify(publicUrl)}; window.__mcpPublicAssetsUrl = ${JSON.stringify(publicAssetsUrl)};</script>`;
+        const injectionScript = mcpUrl
+          ? // External CDN — fully-qualified URLs; basePath doesn't apply.
+            `<script>window.__getFile = (filename) => { return ${JSON.stringify(`${mcpUrl}/${widgetName}/`)}+filename }; window.__mcpPublicUrl = ${JSON.stringify(
+              mcpServerUrl
+                ? `${mcpServerUrl}/_mcp-use/public`
+                : "/_mcp-use/public"
+            )}; window.__mcpPublicAssetsUrl = ${JSON.stringify(`${mcpUrl}/public`)};</script>`
+          : // Same-origin: resolve basePath at runtime from the widget's URL.
+            // `${basePath}/_mcp-use/widgets/<slug>/index.html` is the page
+            // location, so everything before `/_mcp-use/` is the basePath.
+            `<script>(function(){var p=${
+              mcpServerUrl
+                ? JSON.stringify(mcpServerUrl)
+                : 'window.location.pathname.split("/_mcp-use/")[0]||""'
+            };window.__getFile=function(filename){return p+${JSON.stringify(`/_mcp-use/widgets/${widgetName}/`)}+filename};window.__mcpPublicUrl=p+"/_mcp-use/public";window.__mcpPublicAssetsUrl=p+"/_mcp-use/public";})();</script>`;
 
         if (!html.includes("window.__mcpPublicUrl")) {
           html = html.replace(

--- a/libraries/typescript/packages/cli/src/index.ts
+++ b/libraries/typescript/packages/cli/src/index.ts
@@ -148,56 +148,46 @@ async function findAvailablePort(
 
 type ServerInfo = {
   basePath: string;
-  mcpPath?: string;
-  inspectorPath?: string;
-  mcpUrl?: string;
-  inspectorUrl?: string;
 };
 
-async function fetchServerInfo(
-  port: number,
-  host: string = "localhost",
-  signal?: AbortSignal
-): Promise<ServerInfo | null> {
-  const response = await fetch(`http://${host}:${port}/__mcp-use/serverinfo`, {
-    signal,
-  });
-  if (!response.ok) return null;
-
-  const parsed = await response.json();
-  return {
-    basePath: typeof parsed?.basePath === "string" ? parsed.basePath : "",
-    mcpPath: typeof parsed?.mcpPath === "string" ? parsed.mcpPath : undefined,
-    inspectorPath:
-      typeof parsed?.inspectorPath === "string"
-        ? parsed.inspectorPath
-        : undefined,
-    mcpUrl: typeof parsed?.mcpUrl === "string" ? parsed.mcpUrl : undefined,
-    inspectorUrl:
-      typeof parsed?.inspectorUrl === "string"
-        ? parsed.inspectorUrl
-        : undefined,
-  };
+/**
+ * Best-effort read of `.mcp-use/server-info.json`. The server writes this
+ * file inside the `listen()` callback, so by the time `waitForServer`
+ * resolves it's already on disk.
+ *
+ * Returns `""` on any failure — caller composes URLs as
+ * `http://${host}:${port}${basePath}/mcp`, which degrades to bare `/mcp`
+ * exactly like before basePath existed.
+ */
+async function readServerBasePath(projectPath: string): Promise<string> {
+  try {
+    const filePath = path.join(projectPath, ".mcp-use", "server-info.json");
+    const raw = await readFile(filePath, "utf8");
+    const parsed = JSON.parse(raw);
+    return typeof parsed?.basePath === "string" ? parsed.basePath : "";
+  } catch {
+    return "";
+  }
 }
 
-// Helper to check if server is ready and discover its externally-mounted paths.
+// Helper to check if server is ready. Polls a known endpoint at the basePath
+// derived from the server-info handshake file (or root, if missing/stale).
 async function waitForServer(
   port: number,
   host: string = "localhost",
+  projectPath: string = process.cwd(),
   maxAttempts = 30
 ): Promise<ServerInfo | null> {
   for (let i = 0; i < maxAttempts; i++) {
     const controller = new AbortController();
+    const basePath = await readServerBasePath(projectPath);
     try {
-      const serverInfo = await fetchServerInfo(port, host, controller.signal);
-      if (serverInfo) return serverInfo;
-
-      // Back-compat for older servers without the discovery endpoint.
-      const response = await fetch(`http://${host}:${port}/inspector/health`, {
-        signal: controller.signal,
-      });
+      const response = await fetch(
+        `http://${host}:${port}${basePath}/inspector/health`,
+        { signal: controller.signal }
+      );
       if (response.ok) {
-        return { basePath: "" };
+        return { basePath };
       }
     } catch {
       // Server not ready yet
@@ -740,8 +730,9 @@ async function buildWidgets(
 
     console.log(chalk.gray(`  - Building ${widgetName}...`));
 
-    // Create temp directory for build artifacts
-    const tempDir = path.join(projectPath, ".mcp-use", widgetName);
+    // Create temp directory for build artifacts under `.mcp-use/.tmp/` so it
+    // doesn't collide with framework-owned namespaces (widgets/, public/).
+    const tempDir = path.join(projectPath, ".mcp-use", ".tmp", widgetName);
     await fs.mkdir(tempDir, { recursive: true });
 
     // Create CSS file with Tailwind directives
@@ -796,7 +787,7 @@ if (container && Component) {
     <title>${widgetName} Widget</title>${
       favicon
         ? `
-    <link rel="icon" href="/mcp-use/public/${favicon}" />`
+    <link rel="icon" href="/_mcp-use/public/${favicon}" />`
         : ""
     }
   </head>
@@ -809,19 +800,14 @@ if (container && Component) {
     await fs.writeFile(path.join(tempDir, "entry.tsx"), entryContent, "utf8");
     await fs.writeFile(path.join(tempDir, "index.html"), htmlContent, "utf8");
 
-    // Build with Vite
-    const outDir = path.join(
-      projectPath,
-      "dist",
-      "resources",
-      "widgets",
-      widgetName
-    );
+    // Build widget output into the framework-owned `.mcp-use/widgets/` tree.
+    const outDir = path.join(projectPath, ".mcp-use", "widgets", widgetName);
 
-    // Set base URL: use MCP_URL if set, otherwise relative path
+    // Set base URL: use MCP_URL if set, otherwise the basePath-agnostic
+    // root namespace `/_mcp-use/widgets/<name>/`.
     const baseUrl = mcpUrl
       ? `${mcpUrl}/${widgetName}/`
-      : `/mcp-use/widgets/${widgetName}/`;
+      : `/_mcp-use/widgets/${widgetName}/`;
 
     // Extract metadata from widget before building
     let widgetMetadata: any = {};
@@ -830,6 +816,7 @@ if (container && Component) {
       const metadataTempDir = path.join(
         projectPath,
         ".mcp-use",
+        ".tmp",
         `${widgetName}-metadata`
       );
       await fs.mkdir(metadataTempDir, { recursive: true });
@@ -1202,7 +1189,7 @@ export default {
           // Inject window.__mcpPublicUrl and window.__getFile into <head>
           // Note: __mcpPublicUrl uses standard format for useWidget to derive mcp_url
           // __mcpPublicAssetsUrl points to where public files are actually stored
-          const injectionScript = `<script>window.__getFile = (filename) => { return "${mcpUrl}/${widgetName}/"+filename }; window.__mcpPublicUrl = "${mcpServerUrl}/mcp-use/public"; window.__mcpPublicAssetsUrl = "${mcpUrl}/public";</script>`;
+          const injectionScript = `<script>window.__getFile = (filename) => { return "${mcpUrl}/${widgetName}/"+filename }; window.__mcpPublicUrl = "${mcpServerUrl}/_mcp-use/public"; window.__mcpPublicAssetsUrl = "${mcpUrl}/public";</script>`;
 
           // Check if script tag already exists in head
           if (!html.includes("window.__mcpPublicUrl")) {
@@ -1593,7 +1580,7 @@ program
       try {
         await fs.access(publicDir);
         console.log(chalk.gray("Copying public assets..."));
-        await fs.cp(publicDir, path.join(projectPath, "dist", "public"), {
+        await fs.cp(publicDir, path.join(projectPath, ".mcp-use", "public"), {
           recursive: true,
         });
         console.log(chalk.green("✓ Public assets copied"));
@@ -1601,8 +1588,8 @@ program
         // Public folder doesn't exist, skip
       }
 
-      // Create build manifest
-      const manifestPath = path.join(projectPath, "dist", "mcp-use.json");
+      // Create build manifest under the framework-owned `.mcp-use/` tree.
+      const manifestPath = path.join(projectPath, ".mcp-use", "manifest.json");
 
       // Read existing manifest to preserve tunnel subdomain and other fields
       let existingManifest: any = {};
@@ -1732,7 +1719,11 @@ program
 
       if (options.tunnel) {
         try {
-          const manifestPath = path.join(projectPath, "dist", "mcp-use.json");
+          const manifestPath = path.join(
+            projectPath,
+            ".mcp-use",
+            "manifest.json"
+          );
           let existingSubdomain: string | undefined;
 
           try {
@@ -1895,7 +1886,11 @@ program
         if (options.open !== false) {
           const startTime = Date.now();
           const browserHost = normalizeBrowserHost(host);
-          const serverInfo = await waitForServer(port, browserHost);
+          const serverInfo = await waitForServer(
+            port,
+            browserHost,
+            projectPath
+          );
           if (serverInfo) {
             const basePath = serverInfo.basePath;
             const mcpEndpoint = `http://${browserHost}:${port}${basePath}/mcp`;
@@ -2172,7 +2167,11 @@ program
         // Auto-open inspector if enabled
         if (options.open !== false) {
           const browserHost = normalizeBrowserHost(host);
-          const serverInfo = await waitForServer(port, browserHost);
+          const serverInfo = await waitForServer(
+            port,
+            browserHost,
+            projectPath
+          );
           if (serverInfo) {
             const basePath = serverInfo.basePath;
             const mcpEndpoint = `http://${browserHost}:${port}${basePath}/mcp`;
@@ -2475,7 +2474,11 @@ program
         // 2. Start tunnel if requested
         tunnelUrl = undefined;
         if (withTunnel) {
-          const manifestPath = path.join(projectPath, "dist", "mcp-use.json");
+          const manifestPath = path.join(
+            projectPath,
+            ".mcp-use",
+            "manifest.json"
+          );
           let existingSubdomain: string | undefined;
           try {
             const manifestContent = await readFile(manifestPath, "utf-8");
@@ -2517,7 +2520,7 @@ program
 
           // Persist subdomain
           try {
-            const mPath = path.join(projectPath, "dist", "mcp-use.json");
+            const mPath = path.join(projectPath, ".mcp-use", "manifest.json");
             let manifest: any = {};
             try {
               manifest = JSON.parse(await readFile(mPath, "utf-8"));
@@ -2696,7 +2699,11 @@ program
       if (options.tunnel) {
         try {
           // Read existing subdomain from mcp-use.json if available
-          const manifestPath = path.join(projectPath, "dist", "mcp-use.json");
+          const manifestPath = path.join(
+            projectPath,
+            ".mcp-use",
+            "manifest.json"
+          );
           let existingSubdomain: string | undefined;
 
           try {
@@ -2788,7 +2795,7 @@ program
       // Find the built server file
       // First try to read from manifest (set during build)
       let serverFile: string | undefined;
-      const manifestPath = path.join(projectPath, "dist", "mcp-use.json");
+      const manifestPath = path.join(projectPath, ".mcp-use", "manifest.json");
 
       try {
         const manifestContent = await readFile(manifestPath, "utf-8");
@@ -2839,7 +2846,7 @@ program
       if (!serverFile) {
         console.error(
           chalk.red(
-            `No built server file found. Run 'mcp-use build' first.\n\nLooked for:\n  - dist/mcp-use.json (manifest with entryPoint)\n  - dist/index.js\n  - dist/server.js\n  - dist/src/index.js\n  - dist/src/server.js`
+            `No built server file found. Run 'mcp-use build' first.\n\nLooked for:\n  - .mcp-use/manifest.json (manifest with entryPoint)\n  - dist/index.js\n  - dist/server.js\n  - dist/src/index.js\n  - dist/src/server.js`
           )
         );
         process.exit(1);

--- a/libraries/typescript/packages/cli/src/index.ts
+++ b/libraries/typescript/packages/cli/src/index.ts
@@ -146,23 +146,58 @@ async function findAvailablePort(
   throw new Error("No available ports found");
 }
 
-// Helper to check if server is ready
+type ServerInfo = {
+  basePath: string;
+  mcpPath?: string;
+  inspectorPath?: string;
+  mcpUrl?: string;
+  inspectorUrl?: string;
+};
+
+async function fetchServerInfo(
+  port: number,
+  host: string = "localhost",
+  signal?: AbortSignal
+): Promise<ServerInfo | null> {
+  const response = await fetch(`http://${host}:${port}/__mcp-use/serverinfo`, {
+    signal,
+  });
+  if (!response.ok) return null;
+
+  const parsed = await response.json();
+  return {
+    basePath: typeof parsed?.basePath === "string" ? parsed.basePath : "",
+    mcpPath: typeof parsed?.mcpPath === "string" ? parsed.mcpPath : undefined,
+    inspectorPath:
+      typeof parsed?.inspectorPath === "string"
+        ? parsed.inspectorPath
+        : undefined,
+    mcpUrl: typeof parsed?.mcpUrl === "string" ? parsed.mcpUrl : undefined,
+    inspectorUrl:
+      typeof parsed?.inspectorUrl === "string"
+        ? parsed.inspectorUrl
+        : undefined,
+  };
+}
+
+// Helper to check if server is ready and discover its externally-mounted paths.
 async function waitForServer(
   port: number,
   host: string = "localhost",
   maxAttempts = 30
-): Promise<boolean> {
+): Promise<ServerInfo | null> {
   for (let i = 0; i < maxAttempts; i++) {
     const controller = new AbortController();
     try {
-      // Use /inspector/health endpoint for cleaner health checks
-      // This avoids 400 errors from the MCP endpoint which requires session headers
+      const serverInfo = await fetchServerInfo(port, host, controller.signal);
+      if (serverInfo) return serverInfo;
+
+      // Back-compat for older servers without the discovery endpoint.
       const response = await fetch(`http://${host}:${port}/inspector/health`, {
         signal: controller.signal,
       });
-
       if (response.ok) {
-        return true;
+        return { basePath: "" };
       }
     } catch {
       // Server not ready yet
@@ -171,31 +206,13 @@ async function waitForServer(
     }
     await new Promise((resolve) => setTimeout(resolve, 1000));
   }
-  return false;
+  return null;
 }
 
 // Helper to normalize host for browser connections
 // 0.0.0.0 is valid for server binding but browsers cannot connect to it
 function normalizeBrowserHost(host: string): string {
   return host === "0.0.0.0" ? "localhost" : host;
-}
-
-/**
- * Read the running server's basePath from `.mcp-use/server-info.json`. The
- * server writes this file before reporting ready, so it should already exist
- * by the time we read. Returns "" when missing or unparseable.
- */
-async function readServerBasePath(projectPath: string): Promise<string> {
-  try {
-    const raw = await readFile(
-      path.join(projectPath, ".mcp-use", "server-info.json"),
-      "utf-8"
-    );
-    const parsed = JSON.parse(raw);
-    return typeof parsed?.basePath === "string" ? parsed.basePath : "";
-  } catch {
-    return "";
-  }
 }
 
 // Helper to run a command
@@ -1878,9 +1895,9 @@ program
         if (options.open !== false) {
           const startTime = Date.now();
           const browserHost = normalizeBrowserHost(host);
-          const ready = await waitForServer(port, browserHost);
-          if (ready) {
-            const basePath = await readServerBasePath(projectPath);
+          const serverInfo = await waitForServer(port, browserHost);
+          if (serverInfo) {
+            const basePath = serverInfo.basePath;
             const mcpEndpoint = `http://${browserHost}:${port}${basePath}/mcp`;
             const autoConnectEndpoint = tunnelUrl
               ? `${tunnelUrl}${basePath}/mcp`
@@ -2155,9 +2172,9 @@ program
         // Auto-open inspector if enabled
         if (options.open !== false) {
           const browserHost = normalizeBrowserHost(host);
-          const ready = await waitForServer(port, browserHost);
-          if (ready) {
-            const basePath = await readServerBasePath(projectPath);
+          const serverInfo = await waitForServer(port, browserHost);
+          if (serverInfo) {
+            const basePath = serverInfo.basePath;
             const mcpEndpoint = `http://${browserHost}:${port}${basePath}/mcp`;
             const autoConnectEndpoint = tunnelUrl
               ? `${tunnelUrl}${basePath}/mcp`

--- a/libraries/typescript/packages/cli/src/index.ts
+++ b/libraries/typescript/packages/cli/src/index.ts
@@ -180,6 +180,31 @@ function normalizeBrowserHost(host: string): string {
   return host === "0.0.0.0" ? "localhost" : host;
 }
 
+/**
+ * Read the running server's basePath from `.mcp-use/server-info.json` if the
+ * server wrote one on startup. Returns "" when the file is missing or stale,
+ * which preserves the historical bare `/mcp` / `/inspector` behavior for
+ * servers configured without a basePath.
+ *
+ * The file is polled (not just read once) because `waitForServer` only
+ * confirms the HTTP port is open — server-info.json is written immediately
+ * before that point, so it should already exist by the time we read.
+ */
+async function readServerBasePath(projectPath: string): Promise<string> {
+  try {
+    const { readFile } = await import("node:fs/promises");
+    const { join } = await import("node:path");
+    const raw = await readFile(
+      join(projectPath, ".mcp-use", "server-info.json"),
+      "utf-8"
+    );
+    const parsed = JSON.parse(raw);
+    return typeof parsed?.basePath === "string" ? parsed.basePath : "";
+  } catch {
+    return "";
+  }
+}
+
 // Helper to run a command
 function runCommand(
   command: string,
@@ -1862,11 +1887,12 @@ program
           const browserHost = normalizeBrowserHost(host);
           const ready = await waitForServer(port, browserHost);
           if (ready) {
-            const mcpEndpoint = `http://${browserHost}:${port}/mcp`;
+            const basePath = await readServerBasePath(projectPath);
+            const mcpEndpoint = `http://${browserHost}:${port}${basePath}/mcp`;
             const autoConnectEndpoint = tunnelUrl
-              ? `${tunnelUrl}/mcp`
+              ? `${tunnelUrl}${basePath}/mcp`
               : mcpEndpoint;
-            const inspectorUrl = `http://${browserHost}:${port}/inspector?autoConnect=${encodeURIComponent(autoConnectEndpoint)}`;
+            const inspectorUrl = `http://${browserHost}:${port}${basePath}/inspector?autoConnect=${encodeURIComponent(autoConnectEndpoint)}`;
 
             const readyTime = Date.now() - startTime;
             console.log(chalk.green.bold(`✓ Ready in ${readyTime}ms`));
@@ -1876,7 +1902,9 @@ program
             console.log(chalk.whiteBright(`Network:  http://${host}:${port}`));
             console.log(chalk.whiteBright(`MCP:      ${mcpEndpoint}`));
             if (tunnelUrl) {
-              console.log(chalk.whiteBright(`Tunnel:   ${tunnelUrl}/mcp`));
+              console.log(
+                chalk.whiteBright(`Tunnel:   ${tunnelUrl}${basePath}/mcp`)
+              );
             }
             console.log(chalk.whiteBright(`Inspector: ${inspectorUrl}\n`));
             await open(inspectorUrl);
@@ -2136,11 +2164,12 @@ program
           const browserHost = normalizeBrowserHost(host);
           const ready = await waitForServer(port, browserHost);
           if (ready) {
-            const mcpEndpoint = `http://${browserHost}:${port}/mcp`;
+            const basePath = await readServerBasePath(projectPath);
+            const mcpEndpoint = `http://${browserHost}:${port}${basePath}/mcp`;
             const autoConnectEndpoint = tunnelUrl
-              ? `${tunnelUrl}/mcp`
+              ? `${tunnelUrl}${basePath}/mcp`
               : mcpEndpoint;
-            const inspectorUrl = `http://${browserHost}:${port}/inspector?autoConnect=${encodeURIComponent(autoConnectEndpoint)}`;
+            const inspectorUrl = `http://${browserHost}:${port}${basePath}/inspector?autoConnect=${encodeURIComponent(autoConnectEndpoint)}`;
 
             const readyTime = Date.now() - startTime;
             console.log(chalk.green.bold(`✓ Ready in ${readyTime}ms`));
@@ -2150,7 +2179,9 @@ program
             console.log(chalk.whiteBright(`Network:  http://${host}:${port}`));
             console.log(chalk.whiteBright(`MCP:      ${mcpEndpoint}`));
             if (tunnelUrl) {
-              console.log(chalk.whiteBright(`Tunnel:   ${tunnelUrl}/mcp`));
+              console.log(
+                chalk.whiteBright(`Tunnel:   ${tunnelUrl}${basePath}/mcp`)
+              );
             }
             console.log(chalk.whiteBright(`Inspector: ${inspectorUrl}`));
             console.log(chalk.gray(`Watching for changes...\n`));

--- a/libraries/typescript/packages/inspector/src/client/App.tsx
+++ b/libraries/typescript/packages/inspector/src/client/App.tsx
@@ -16,6 +16,7 @@ import { toast } from "sonner";
 import { InspectorProvider, useInspector } from "./context/InspectorContext";
 import { ThemeProvider } from "./context/ThemeContext";
 import { WidgetDebugProvider } from "./context/WidgetDebugContext";
+import { getBasePath, inspectorPath } from "./utils/basePath";
 
 /**
  * Syncs the active tab from InspectorContext into a ref readable by
@@ -98,7 +99,7 @@ function App() {
         <McpClientProvider
           storageProvider={storageProvider}
           enableRpcLogging={true}
-          defaultCallbackUrl={`${window.location.origin}/inspector/oauth/callback`}
+          defaultCallbackUrl={`${window.location.origin}${inspectorPath("/inspector/oauth/callback")}`}
           defaultAutoProxyFallback={
             proxyAddress ? { enabled: true, proxyAddress } : false
           }
@@ -207,7 +208,7 @@ function App() {
         >
           <InspectorProvider>
             <InspectorTabSync activeTabRef={activeTabRef} />
-            <Router basename="/inspector">
+            <Router basename={`${getBasePath()}/inspector`}>
               <Routes>
                 <Route path="/oauth/callback" element={<OAuthCallback />} />
                 <Route path="/preview/:view" element={<ViewPreview />} />

--- a/libraries/typescript/packages/inspector/src/client/components/InspectorDashboard.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/InspectorDashboard.tsx
@@ -38,6 +38,7 @@ import {
 } from "mcp-use/react";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { copyToClipboard } from "@/client/utils/clipboard";
+import { inspectorPath } from "@/client/utils/basePath";
 import {
   buildOAuthStaticConfig,
   getStoredConnectionConfig,
@@ -300,7 +301,7 @@ export function InspectorDashboard() {
   const [resetTimeoutOnProgress, setResetTimeoutOnProgress] = useState("True");
   const [maxTotalTimeout, setMaxTotalTimeout] = useState("60000");
   const [proxyAddress, setProxyAddress] = useState(
-    `${window.location.origin}/inspector/api/proxy`
+    `${window.location.origin}${inspectorPath("/inspector/api/proxy")}`
   );
   // OAuth fields
   const [clientId, setClientId] = useState("");

--- a/libraries/typescript/packages/inspector/src/client/components/Layout.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/Layout.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/client/context/InspectorContext";
 import { useAutoConnect } from "@/client/hooks/useAutoConnect";
 import { useKeyboardShortcuts } from "@/client/hooks/useKeyboardShortcuts";
+import { inspectorPath } from "@/client/utils/basePath";
 import { useSavedRequests } from "@/client/hooks/useSavedRequests";
 import {
   MCPCommandPaletteOpenEvent,
@@ -635,7 +636,7 @@ export function Layout({ children }: LayoutProps) {
           proxyAddress: string;
           headers?: Record<string, string>;
         } = {
-          proxyAddress: `${window.location.origin}/inspector/api/proxy`,
+          proxyAddress: `${window.location.origin}${inspectorPath("/inspector/api/proxy")}`,
           ...(Object.keys(customHeaders).length > 0 && {
             headers: customHeaders,
           }),

--- a/libraries/typescript/packages/inspector/src/client/components/LayoutHeader.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/LayoutHeader.tsx
@@ -358,9 +358,12 @@ function TunnelBadge({
     setIsTunnelStarting(true);
     let success = false;
     try {
-      const res = await fetch(inspectorPath("/inspector/api/dev/start-tunnel"), {
-        method: "POST",
-      });
+      const res = await fetch(
+        inspectorPath("/inspector/api/dev/start-tunnel"),
+        {
+          method: "POST",
+        }
+      );
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
         toast.error((data as any).error || "Failed to start tunnel");

--- a/libraries/typescript/packages/inspector/src/client/components/LayoutHeader.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/LayoutHeader.tsx
@@ -53,6 +53,7 @@ import {
   Wrench,
 } from "lucide-react";
 import { INSPECTOR_RECONNECT_STORAGE_KEY } from "@/client/hooks/useAutoConnect";
+import { inspectorPath } from "@/client/utils/basePath";
 import type { McpServer } from "mcp-use/react";
 import { useEffect, useState } from "react";
 
@@ -251,7 +252,7 @@ function TunnelBadge({
     let cancelled = false;
     (async () => {
       try {
-        const res = await fetch("/inspector/api/dev/info");
+        const res = await fetch(inspectorPath("/inspector/api/dev/info"));
         if (!res.ok || cancelled) return;
         const info = (await res.json()) as {
           fromCli?: boolean;
@@ -281,7 +282,7 @@ function TunnelBadge({
    */
   const pollAndReconnect = async (expectTunnel: boolean) => {
     const port = window.location.port || "3000";
-    const infoUrl = `http://localhost:${port}/inspector/api/dev/info`;
+    const infoUrl = `http://localhost:${port}${inspectorPath("/inspector/api/dev/info")}`;
     const deadline = Date.now() + 90_000;
 
     setTunnelPhaseMessage(
@@ -357,7 +358,7 @@ function TunnelBadge({
     setIsTunnelStarting(true);
     let success = false;
     try {
-      const res = await fetch("/inspector/api/dev/start-tunnel", {
+      const res = await fetch(inspectorPath("/inspector/api/dev/start-tunnel"), {
         method: "POST",
       });
       if (!res.ok) {
@@ -387,7 +388,7 @@ function TunnelBadge({
     setIsTunnelStarting(true);
     let success = false;
     try {
-      const res = await fetch("/inspector/api/dev/stop-tunnel", {
+      const res = await fetch(inspectorPath("/inspector/api/dev/stop-tunnel"), {
         method: "POST",
       });
       if (!res.ok) {

--- a/libraries/typescript/packages/inspector/src/client/components/LoginModal.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/LoginModal.tsx
@@ -28,6 +28,7 @@ import {
 import { Input } from "@/client/components/ui/input";
 import { Label } from "@/client/components/ui/label";
 import { Spinner } from "@/client/components/ui/spinner";
+import { inspectorPath } from "@/client/utils/basePath";
 import { cn } from "@/client/lib/utils";
 
 /* ------------------------------------------------------------------ */
@@ -155,7 +156,7 @@ export function LoginModal({
     // itself (via `window.close()` + postMessage) the moment better-auth
     // finishes setting the session cookie — instead of loading the whole
     // inspector inside the popup while we wait for the parent's session poll.
-    const callbackURL = `${window.location.origin}/inspector/oauth-popup-closed.html`;
+    const callbackURL = `${window.location.origin}${inspectorPath("/inspector/oauth-popup-closed.html")}`;
 
     fetch(`${authOrigin}/api/auth/sign-in/social`, {
       method: "POST",

--- a/libraries/typescript/packages/inspector/src/client/components/MCPAppsRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/MCPAppsRenderer.tsx
@@ -297,7 +297,7 @@ function MCPAppsRendererBase({
 
         // Store widget data
         const storeResponse = await fetch(
-          MCP_APPS_CONFIG.API_ENDPOINTS.WIDGET_STORE,
+          MCP_APPS_CONFIG.API_ENDPOINTS.WIDGET_STORE(),
           {
             method: "POST",
             headers: { "Content-Type": "application/json" },

--- a/libraries/typescript/packages/inspector/src/client/components/OpenAIComponentRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/OpenAIComponentRenderer.tsx
@@ -8,6 +8,7 @@ import { IFRAME_SANDBOX_PERMISSIONS } from "../constants/iframe";
 import { useTheme } from "../context/ThemeContext";
 import { useWidgetDebug } from "../context/WidgetDebugContext";
 import { injectConsoleInterceptor } from "../utils/iframeConsoleInterceptor";
+import { inspectorPath } from "../utils/basePath";
 import { FullscreenNavbar } from "./FullscreenNavbar";
 import { MCPAppsDebugControls } from "./MCPAppsDebugControls";
 import { Spinner } from "./ui/spinner";
@@ -252,7 +253,7 @@ function OpenAIComponentRendererBase({
 
         // Store widget data on server (including the fetched HTML and dev URLs if applicable)
         const storeResponse = await fetch(
-          `${inspectorApiBase}/inspector/api/resources/widget/store`,
+          `${inspectorApiBase}${inspectorPath("/inspector/api/resources/widget/store")}`,
           {
             method: "POST",
             headers: {
@@ -291,7 +292,7 @@ function OpenAIComponentRendererBase({
         // the store so that iframe fetch gets latest data. Changing URL would reload the iframe.
         if (!hasSetWidgetUrlRef.current) {
           hasSetWidgetUrlRef.current = true;
-          const widgetUrl = `${inspectorApiBase}/inspector/api/resources/widget-content/${toolId}?t=${Date.now()}`;
+          const widgetUrl = `${inspectorApiBase}${inspectorPath("/inspector/api/resources/widget-content")}/${toolId}?t=${Date.now()}`;
           setWidgetUrl(widgetUrl);
           // Register widget in debug context so CSP violations can be stored
           addWidget(toolId, { toolName, protocol: "chatgpt-app" });

--- a/libraries/typescript/packages/inspector/src/client/components/ServerConnectionModal.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ServerConnectionModal.tsx
@@ -113,7 +113,9 @@ export function ServerConnectionModal({
         setProxyAddress(proxyAddress);
       } else {
         setConnectionType("Direct");
-        setProxyAddress(`${window.location.origin}${inspectorPath("/inspector/api/proxy")}`);
+        setProxyAddress(
+          `${window.location.origin}${inspectorPath("/inspector/api/proxy")}`
+        );
       }
 
       // Convert headers from Record<string, string> to CustomHeader[]

--- a/libraries/typescript/packages/inspector/src/client/components/ServerConnectionModal.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ServerConnectionModal.tsx
@@ -25,6 +25,7 @@ import {
   DialogTitle,
 } from "@/client/components/ui/dialog";
 import { getConfiguredServerAlias } from "@/client/utils/serverNames";
+import { inspectorPath } from "@/client/utils/basePath";
 import { ConnectionSettingsForm } from "./ConnectionSettingsForm";
 import { toast } from "sonner";
 
@@ -68,7 +69,7 @@ export function ServerConnectionModal({
   const [resetTimeoutOnProgress, setResetTimeoutOnProgress] = useState("True");
   const [maxTotalTimeout, setMaxTotalTimeout] = useState("60000");
   const [proxyAddress, setProxyAddress] = useState(
-    `${window.location.origin}/inspector/api/proxy`
+    `${window.location.origin}${inspectorPath("/inspector/api/proxy")}`
   );
   // OAuth fields
   const [clientId, setClientId] = useState("");
@@ -112,7 +113,7 @@ export function ServerConnectionModal({
         setProxyAddress(proxyAddress);
       } else {
         setConnectionType("Direct");
-        setProxyAddress(`${window.location.origin}/inspector/api/proxy`);
+        setProxyAddress(`${window.location.origin}${inspectorPath("/inspector/api/proxy")}`);
       }
 
       // Convert headers from Record<string, string> to CustomHeader[]

--- a/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessages.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessages.ts
@@ -1,5 +1,6 @@
 import { useCallback, useRef, useState } from "react";
 import type { PromptResult } from "../../hooks/useMCPPrompts";
+import { inspectorPath } from "../../utils/basePath";
 import { convertPromptResultsToMessages } from "./conversion";
 import type {
   AuthConfig,
@@ -175,7 +176,7 @@ export function useChatMessages({
         const resolvedUrl =
           chatApiUrl ??
           (waitForChatApiUrl ? await waitForChatApiUrl() : undefined) ??
-          "/inspector/api/chat/stream";
+          inspectorPath("/inspector/api/chat/stream");
 
         const serialisedMessages = [
           ...[...messages, ...userMessages].map((m) => ({

--- a/libraries/typescript/packages/inspector/src/client/components/ui/SandboxedIframe.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ui/SandboxedIframe.tsx
@@ -22,6 +22,7 @@ import {
   useState,
 } from "react";
 import { IFRAME_SANDBOX_PERMISSIONS } from "../../constants/iframe";
+import { inspectorPath } from "../../utils/basePath";
 
 export interface SandboxedIframeHandle {
   postMessage: (data: unknown) => void;
@@ -103,7 +104,7 @@ export const SandboxedIframe = forwardRef<
     const configuredSandboxOrigin = (window as any).__MCP_SANDBOX_ORIGIN__;
     if (configuredSandboxOrigin) {
       // Use fully configured origin (e.g., "https://sandbox-inspector.mcp-use.com")
-      return `${configuredSandboxOrigin}/inspector/api/mcp-apps/sandbox-proxy?v=${Date.now()}`;
+      return `${configuredSandboxOrigin}${inspectorPath("/inspector/api/mcp-apps/sandbox-proxy")}?v=${Date.now()}`;
     }
 
     let sandboxHost: string;
@@ -136,7 +137,7 @@ export const SandboxedIframe = forwardRef<
     }
 
     const portSuffix = currentPort ? `:${currentPort}` : "";
-    return `${protocol}//${sandboxHost}${portSuffix}/inspector/api/mcp-apps/sandbox-proxy?v=${Date.now()}`;
+    return `${protocol}//${sandboxHost}${portSuffix}${inspectorPath("/inspector/api/mcp-apps/sandbox-proxy")}?v=${Date.now()}`;
   });
 
   const sandboxProxyOrigin = useMemo(() => {

--- a/libraries/typescript/packages/inspector/src/client/constants/mcp-apps.ts
+++ b/libraries/typescript/packages/inspector/src/client/constants/mcp-apps.ts
@@ -2,14 +2,21 @@
  * MCP Apps configuration constants
  */
 
+import { inspectorPath } from "../utils/basePath";
+
 export const MCP_APPS_CONFIG = {
   /**
    * API endpoints for widget operations
+   *
+   * Note: these are getters (not eager string literals) so they pick up the
+   * runtime basePath even if this module is imported before
+   * `window.__MCP_BASE_PATH__` has been read off the injected script.
    */
   API_ENDPOINTS: {
-    WIDGET_STORE: "/inspector/api/mcp-apps/widget/store",
+    WIDGET_STORE: () =>
+      inspectorPath("/inspector/api/mcp-apps/widget/store"),
     WIDGET_CONTENT: (toolCallId: string) =>
-      `/inspector/api/mcp-apps/widget-content/${toolCallId}`,
+      inspectorPath(`/inspector/api/mcp-apps/widget-content/${toolCallId}`),
   },
 
   /**

--- a/libraries/typescript/packages/inspector/src/client/constants/mcp-apps.ts
+++ b/libraries/typescript/packages/inspector/src/client/constants/mcp-apps.ts
@@ -13,8 +13,7 @@ export const MCP_APPS_CONFIG = {
    * `window.__MCP_BASE_PATH__` has been read off the injected script.
    */
   API_ENDPOINTS: {
-    WIDGET_STORE: () =>
-      inspectorPath("/inspector/api/mcp-apps/widget/store"),
+    WIDGET_STORE: () => inspectorPath("/inspector/api/mcp-apps/widget/store"),
     WIDGET_CONTENT: (toolCallId: string) =>
       inspectorPath(`/inspector/api/mcp-apps/widget-content/${toolCallId}`),
   },

--- a/libraries/typescript/packages/inspector/src/client/hooks/useAutoConnect.ts
+++ b/libraries/typescript/packages/inspector/src/client/hooks/useAutoConnect.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "mcp-use/react";
 import { useCallback, useEffect, useState } from "react";
 import { useNavigate } from "react-router";
 import { toast } from "sonner";
+import { inspectorPath } from "../utils/basePath";
 
 /** Survives full page reload; avoids fragile long JSON in query (was resolving to localhost + http). */
 export const INSPECTOR_RECONNECT_STORAGE_KEY = "__mcpUseInspectorReconnect";
@@ -302,10 +303,10 @@ export function useAutoConnect({
         const targetOrigin = new URL(url).origin;
         const inspectorOrigin = window.location.origin;
         if (inspectorOrigin !== targetOrigin) {
-          proxyAddress = `${inspectorOrigin}/inspector/api/proxy`;
+          proxyAddress = `${inspectorOrigin}${inspectorPath("/inspector/api/proxy")}`;
         }
       } catch {
-        proxyAddress = `${window.location.origin}/inspector/api/proxy`;
+        proxyAddress = `${window.location.origin}${inspectorPath("/inspector/api/proxy")}`;
       }
 
       const proxyConfig: {
@@ -473,7 +474,7 @@ export function useAutoConnect({
     }
 
     // Fallback to config.json
-    fetch("/inspector/config.json")
+    fetch(inspectorPath("/inspector/config.json"))
       .then((res) => res.json())
       .then((configData: { autoConnectUrl: string | null }) => {
         setConfigLoaded(true);

--- a/libraries/typescript/packages/inspector/src/client/telemetry/telemetry.ts
+++ b/libraries/typescript/packages/inspector/src/client/telemetry/telemetry.ts
@@ -1,3 +1,4 @@
+import { inspectorPath } from "../utils/basePath.js";
 import type { BaseTelemetryEvent } from "./events.js";
 import { MCPInspectorOpenEvent } from "./events.js";
 import { getPackageVersion } from "./utils.js";
@@ -86,8 +87,12 @@ function isLocalStorageFunctional(): boolean {
 export class Telemetry {
   private static instance: Telemetry | null = null;
 
-  private readonly POSTHOG_PROXY_URL = "/inspector/api/tel/posthog";
-  private readonly SCARF_PROXY_URL = "/inspector/api/tel/scarf";
+  private readonly POSTHOG_PROXY_URL = inspectorPath(
+    "/inspector/api/tel/posthog"
+  );
+  private readonly SCARF_PROXY_URL = inspectorPath(
+    "/inspector/api/tel/scarf"
+  );
   private readonly UNKNOWN_USER_ID = "UNKNOWN_USER_ID";
 
   private _currUserId: string | null = null;

--- a/libraries/typescript/packages/inspector/src/client/telemetry/telemetry.ts
+++ b/libraries/typescript/packages/inspector/src/client/telemetry/telemetry.ts
@@ -90,9 +90,7 @@ export class Telemetry {
   private readonly POSTHOG_PROXY_URL = inspectorPath(
     "/inspector/api/tel/posthog"
   );
-  private readonly SCARF_PROXY_URL = inspectorPath(
-    "/inspector/api/tel/scarf"
-  );
+  private readonly SCARF_PROXY_URL = inspectorPath("/inspector/api/tel/scarf");
   private readonly UNKNOWN_USER_ID = "UNKNOWN_USER_ID";
 
   private _currUserId: string | null = null;

--- a/libraries/typescript/packages/inspector/src/client/utils/basePath.ts
+++ b/libraries/typescript/packages/inspector/src/client/utils/basePath.ts
@@ -1,0 +1,36 @@
+/**
+ * Runtime base-path helpers.
+ *
+ * When the inspector is embedded in an MCPServer that was configured with a
+ * `basePath` (e.g. `"/api"`), the embedding host injects the prefix into a
+ * `window.__MCP_BASE_PATH__` global from the served HTML. Same-origin
+ * fetches and React Router need to read that global rather than assuming the
+ * inspector lives at `/inspector` on the document origin.
+ *
+ * In standalone/CDN mode and when no basePath is configured, the global is
+ * absent or empty, so these helpers return the historical bare values.
+ */
+
+declare global {
+  interface Window {
+    __MCP_BASE_PATH__?: string;
+  }
+}
+
+/** Returns the runtime base-path prefix, normalized to no trailing slash. */
+export function getBasePath(): string {
+  if (typeof window === "undefined") return "";
+  const raw = window.__MCP_BASE_PATH__;
+  if (!raw || raw === "/") return "";
+  return raw.replace(/\/+$/, "");
+}
+
+/**
+ * Prefix an inspector-rooted path (one that historically started with
+ * `/inspector/...`) with the runtime base path.
+ *
+ * @example inspectorPath("/inspector/api/chat/stream") → "/api/inspector/api/chat/stream"
+ */
+export function inspectorPath(path: string): string {
+  return `${getBasePath()}${path}`;
+}

--- a/libraries/typescript/packages/inspector/src/server/middleware.ts
+++ b/libraries/typescript/packages/inspector/src/server/middleware.ts
@@ -31,6 +31,16 @@ export function mountInspector(
     sandboxOrigin?: string | null;
     /** Port the host app listens on (embedded inspector); required for tunnel start */
     serverPort?: number;
+    /**
+     * Path prefix the embedding host mounts the inspector under.
+     *
+     * When set (e.g. `"/api"`), the served HTML gets a `<base href>` of
+     * `${basePath}/inspector/` and `window.__MCP_BASE_PATH__` is exposed so
+     * the client can prefix React Router and same-origin fetch URLs.
+     *
+     * Empty/undefined keeps the historical behavior (mounted at `/inspector`).
+     */
+    basePath?: string;
   }
 ): void {
   // Find the built client files
@@ -50,6 +60,7 @@ export function mountInspector(
     devMode: config?.devMode,
     sandboxOrigin: config?.sandboxOrigin,
     inspectorMode: "embedded" as const,
+    basePath: config?.basePath,
   };
 
   // If it's already a Hono app, register routes directly.

--- a/libraries/typescript/packages/inspector/src/server/shared-routes.ts
+++ b/libraries/typescript/packages/inspector/src/server/shared-routes.ts
@@ -44,6 +44,14 @@ export type InspectorRoutesConfig = {
   autoConnectUrl?: string | null;
   /** HTTP port the app listens on (embedded inspector); required for tunnel start */
   serverPort?: number;
+  /**
+   * Embedding host's mount prefix (no trailing slash). Used to construct
+   * absolute URLs that the browser will fetch back (e.g. inside the widget
+   * container HTML). Hono route registrations themselves use the bare
+   * `/inspector/...` paths since the embedding host mounts a sub-Hono at
+   * `basePath` and the prefix is composed automatically.
+   */
+  basePath?: string;
 };
 
 export function registerInspectorRoutes(
@@ -159,8 +167,15 @@ export function registerInspectorRoutes(
       );
     }
 
-    // Return a container page that will fetch and load the actual widget
-    return c.html(generateWidgetContainerHtml("/inspector", toolId));
+    // Return a container page that will fetch and load the actual widget.
+    // Use the runtime basePath so the inner fetch lands on the right URL
+    // when the embedding host mounts the inspector under a prefix.
+    return c.html(
+      generateWidgetContainerHtml(
+        `${config?.basePath ?? ""}/inspector`,
+        toolId
+      )
+    );
   });
 
   // Widget content endpoint - serves pre-fetched resource with injected OpenAI API

--- a/libraries/typescript/packages/inspector/src/server/shared-routes.ts
+++ b/libraries/typescript/packages/inspector/src/server/shared-routes.ts
@@ -171,10 +171,7 @@ export function registerInspectorRoutes(
     // Use the runtime basePath so the inner fetch lands on the right URL
     // when the embedding host mounts the inspector under a prefix.
     return c.html(
-      generateWidgetContainerHtml(
-        `${config?.basePath ?? ""}/inspector`,
-        toolId
-      )
+      generateWidgetContainerHtml(`${config?.basePath ?? ""}/inspector`, toolId)
     );
   });
 

--- a/libraries/typescript/packages/inspector/src/server/shared-static.ts
+++ b/libraries/typescript/packages/inspector/src/server/shared-static.ts
@@ -63,6 +63,14 @@ interface RuntimeConfig {
    * network calls are made.
    */
   disableTelemetry?: boolean;
+  /**
+   * Path prefix the embedding host mounts the inspector under (no trailing
+   * slash). When non-empty, the served HTML gets a `<base href>` of
+   * `${basePath}/inspector/` so Vite's relative asset URLs resolve under the
+   * prefix, and `window.__MCP_BASE_PATH__` is exposed so the client can
+   * prefix React Router and same-origin fetch URLs.
+   */
+  basePath?: string;
 }
 
 /**
@@ -108,10 +116,38 @@ function injectRuntimeConfig(html: string, config?: RuntimeConfig): string {
     );
   }
 
-  if (scripts.length === 0) return html;
+  // Expose the runtime basePath so the React client can prefix Router
+  // basename and same-origin fetches. Default empty string = legacy
+  // "mounted at /inspector" behavior.
+  const basePath = config.basePath ?? "";
+  scripts.push(
+    `<script>window.__MCP_BASE_PATH__ = ${JSON.stringify(basePath)};</script>`
+  );
+
+  // With Vite built using `base: "./"`, asset URLs in the served HTML are
+  // relative ("./assets/foo.js"). The browser resolves them against the
+  // document's <base href> if present. Inject one matching the embedding
+  // host's mount so chunks load from `${basePath}/inspector/assets/...`.
+  // The trailing slash is required for <base href> path resolution.
+  const baseHref = `${basePath}/inspector/`;
+  const baseTag = `<base href="${baseHref}">`;
+
+  let injected = html;
+  // <base> must come before any asset reference. Vite emits <meta charset>
+  // first; place <base> immediately after it (or after <head> as a fallback).
+  if (/<meta\s+charset=[^>]*>/i.test(injected)) {
+    injected = injected.replace(
+      /(<meta\s+charset=[^>]*>)/i,
+      `$1\n    ${baseTag}`
+    );
+  } else {
+    injected = injected.replace(/<head[^>]*>/i, (m) => `${m}\n    ${baseTag}`);
+  }
+
+  if (scripts.length === 0) return injected;
 
   const injection = scripts.join("\n    ");
-  return html.replace("</head>", `    ${injection}\n  </head>`);
+  return injected.replace("</head>", `    ${injection}\n  </head>`);
 }
 
 /**
@@ -152,13 +188,22 @@ function generateCdnShellHtml(config?: RuntimeConfig): string {
         `<script>window.__MCP_USE_ANONYMIZED_TELEMETRY__ = false;try{localStorage.setItem("MCP_USE_ANONYMIZED_TELEMETRY","false");}catch(e){}</script>`
       );
     }
+    scripts.push(
+      `<script>window.__MCP_BASE_PATH__ = ${JSON.stringify(config.basePath ?? "")};</script>`
+    );
     return scripts.join("\n    ");
   })();
+
+  // CDN shell loads JS from absolute https:// CDN URLs, so <base href> is
+  // only needed for any future same-origin relative refs — emit it anyway
+  // so behavior stays consistent with the local-file path.
+  const baseTag = `<base href="${config?.basePath ?? ""}/inspector/">`;
 
   return `<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    ${baseTag}
     <link
       rel="icon"
       type="image/svg+xml"
@@ -257,12 +302,13 @@ export function registerStaticRoutes(
   // disableTelemetry is auto-populated from MCP_USE_ANONYMIZED_TELEMETRY=false so
   // setting that single env var disables both the inspector's own telemetry and
   // the in-browser posthog-js init triggered by `useMcp` hooks rendered inside.
+  const basePath = runtimeConfig?.basePath ?? "";
   const effectiveConfig: RuntimeConfig = {
     ...runtimeConfig,
     proxyUrl:
       runtimeConfig?.proxyUrl !== undefined
         ? runtimeConfig.proxyUrl
-        : "/inspector/api/proxy",
+        : `${basePath}/inspector/api/proxy`,
     disableTelemetry:
       runtimeConfig?.disableTelemetry ??
       process.env.MCP_USE_ANONYMIZED_TELEMETRY === "false",
@@ -314,8 +360,12 @@ export function registerStaticRoutes(
 
   // Serve static assets from /inspector/assets/*
   app.get("/inspector/assets/*", (c) => {
-    const path = c.req.path.replace("/inspector/assets/", "assets/");
-    const fullPath = join(distPath, path);
+    // Use the suffix after `/assets/` so this still works when the inspector
+    // is mounted under a host-supplied basePath (e.g. `/api/inspector/...`),
+    // where `c.req.path` is the full original URL even inside a sub-Hono.
+    const afterAssets = c.req.path.split("/assets/")[1];
+    if (afterAssets === undefined) return c.notFound();
+    const fullPath = join(distPath, "assets", afterAssets);
     if (existsSync(fullPath)) {
       const content = readFileSync(fullPath);
       const contentType = getContentType(fullPath);

--- a/libraries/typescript/packages/inspector/src/server/tunnel.ts
+++ b/libraries/typescript/packages/inspector/src/server/tunnel.ts
@@ -32,7 +32,7 @@ function readSubdomainFromManifest(): string | undefined {
   const projectPath = process.env.MCP_USE_PROJECT_PATH || process.cwd();
   try {
     const raw = readFileSync(
-      join(projectPath, "dist", "mcp-use.json"),
+      join(projectPath, ".mcp-use", "manifest.json"),
       "utf-8"
     );
     const manifest = JSON.parse(raw);

--- a/libraries/typescript/packages/inspector/vite.config.ts
+++ b/libraries/typescript/packages/inspector/vite.config.ts
@@ -10,7 +10,11 @@ const packageJson = JSON.parse(
 );
 
 export default defineConfig({
-  base: "/inspector",
+  // Relative base so the built inspector is portable: the embedding host
+  // serves it under whatever URL it wants and injects a runtime <base href>
+  // that the browser uses to resolve these relative asset paths. Vite's own
+  // dynamic chunk loader uses import.meta.url, so code-splitting still works.
+  base: "./",
   plugins: [
     react(),
     tailwindcss(),

--- a/libraries/typescript/packages/inspector/vite.config.ts
+++ b/libraries/typescript/packages/inspector/vite.config.ts
@@ -9,12 +9,18 @@ const packageJson = JSON.parse(
   readFileSync(path.resolve(__dirname, "package.json"), "utf-8")
 );
 
-export default defineConfig({
-  // Relative base so the built inspector is portable: the embedding host
-  // serves it under whatever URL it wants and injects a runtime <base href>
-  // that the browser uses to resolve these relative asset paths. Vite's own
-  // dynamic chunk loader uses import.meta.url, so code-splitting still works.
-  base: "./",
+export default defineConfig(({ command }) => ({
+  // For the production build, ship the inspector with **relative** asset URLs
+  // (`./assets/...`) so it's portable: an embedding host can mount the bundle
+  // under any prefix and a runtime `<base href>` resolves the chunks
+  // correctly. Vite's own dynamic-chunk loader uses `import.meta.url`, so
+  // code-splitting keeps working.
+  //
+  // For `vite dev`, keep the historical `/inspector` mount so the standalone
+  // dev URL (http://localhost:3000/inspector) and the API-proxy rules below
+  // continue to work exactly as before — relative base in dev would shift
+  // the dev URL to `/` and break the workflow.
+  base: command === "build" ? "./" : "/inspector",
   plugins: [
     react(),
     tailwindcss(),
@@ -185,4 +191,4 @@ export default defineConfig({
       },
     },
   },
-});
+}));

--- a/libraries/typescript/packages/mcp-use/examples/server/oauth/better-auth/src/auth.ts
+++ b/libraries/typescript/packages/mcp-use/examples/server/oauth/better-auth/src/auth.ts
@@ -15,7 +15,13 @@ import { oauthProvider } from "@better-auth/oauth-provider";
 declare const process: { env: Record<string, string | undefined> };
 
 export const auth = betterAuth({
-  baseURL: "http://localhost:3000",
+  // The mcp-use server is mounted at `/mcp-server`, so everything on
+  // `server.app` (including Better Auth's `/api/auth/**`, the sign-in
+  // page, the consent page, and `validAudiences` below) lives under
+  // that prefix. Reflect it in Better Auth's own `baseURL` so its
+  // self-published authorization endpoints, callbacks, and JWT issuer
+  // all match the externally-visible paths.
+  baseURL: "http://localhost:3000/mcp-server",
   basePath: "/api/auth",
   secret: process.env.BETTER_AUTH_SECRET || "dev-secret-change-in-production",
   socialProviders: {
@@ -33,8 +39,8 @@ export const auth = betterAuth({
       allowUnauthenticatedClientRegistration: true,
       // MCP clients send the resource URL from /.well-known/oauth-protected-resource
       // as the token request's `resource` parameter. Better Auth validates it against
-      // this list. Include the /mcp path.
-      validAudiences: ["http://localhost:3000/mcp"],
+      // this list. The MCP transport lives at `/mcp-server/mcp` externally.
+      validAudiences: ["http://localhost:3000/mcp-server/mcp"],
       // Include user profile claims in the access token JWT so
       // ctx.auth.user.email / .name / .picture are available in MCP tools.
       // Without this, Better Auth only includes standard claims (sub, iss, scope, etc.).

--- a/libraries/typescript/packages/mcp-use/examples/server/oauth/better-auth/src/auth.ts
+++ b/libraries/typescript/packages/mcp-use/examples/server/oauth/better-auth/src/auth.ts
@@ -15,14 +15,15 @@ import { oauthProvider } from "@better-auth/oauth-provider";
 declare const process: { env: Record<string, string | undefined> };
 
 export const auth = betterAuth({
-  // The mcp-use server is mounted at `/mcp-server`, so everything on
-  // `server.app` (including Better Auth's `/api/auth/**`, the sign-in
-  // page, the consent page, and `validAudiences` below) lives under
-  // that prefix. Reflect it in Better Auth's own `baseURL` so its
-  // self-published authorization endpoints, callbacks, and JWT issuer
-  // all match the externally-visible paths.
-  baseURL: "http://localhost:3000/mcp-server",
-  basePath: "/api/auth",
+  // The MCP server lives at `/mcp-server` (see server.ts) and we want Better
+  // Auth nested under it at `/mcp-server/api/auth` — both so it doesn't
+  // shadow MCP's own routes under the basePath, and so every endpoint
+  // (issuer, /oauth2/*, /sign-in/*, /jwks, …) anchors on a sub-path that
+  // never collides with the MCP transport. `baseURL` stays as the origin
+  // and `basePath` carries the full path; that's the same split Better Auth
+  // uses elsewhere, just with the MCP basePath segment prepended.
+  baseURL: "http://localhost:3000",
+  basePath: "/mcp-server/api/auth",
   secret: process.env.BETTER_AUTH_SECRET || "dev-secret-change-in-production",
   socialProviders: {
     github: {
@@ -33,8 +34,8 @@ export const auth = betterAuth({
   plugins: [
     jwt(),
     oauthProvider({
-      loginPage: "/sign-in",
-      consentPage: "/consent",
+      loginPage: "/mcp-server/sign-in",
+      consentPage: "/mcp-server/consent",
       allowDynamicClientRegistration: true,
       allowUnauthenticatedClientRegistration: true,
       // MCP clients send the resource URL from /.well-known/oauth-protected-resource

--- a/libraries/typescript/packages/mcp-use/examples/server/oauth/better-auth/src/server.ts
+++ b/libraries/typescript/packages/mcp-use/examples/server/oauth/better-auth/src/server.ts
@@ -2,13 +2,16 @@
  * Better Auth OAuth MCP Server Example
  *
  * Demonstrates running Better Auth and an MCP server on a single Hono app.
- * The auth server and MCP resource server share one port — no separate processes.
+ * The auth server and MCP resource server share one port — no separate
+ * processes. Passing the `auth` instance directly to `oauthBetterAuthProvider`
+ * is enough; the SDK mounts Better Auth's handler under MCPServer's basePath
+ * and registers OAuth discovery (`.well-known/*`) at the host root.
  *
  * Setup:
  * 1. Copy .env.example to .env and fill in GitHub OAuth credentials
  * 2. Run: pnpx auth@latest migrate (creates the database tables)
  * 3. Run: pnpm dev
- * 4. Open MCP Inspector at http://localhost:3000/inspector
+ * 4. Open MCP Inspector at http://localhost:3000/mcp-server/inspector
  *
  * Environment variables:
  * - BETTER_AUTH_SECRET (required)
@@ -19,69 +22,18 @@
 // @ts-nocheck
 import { MCPServer, oauthBetterAuthProvider, object } from "mcp-use/server";
 import { auth } from "./auth.js";
-import {
-  oauthProviderAuthServerMetadata,
-  oauthProviderOpenIdConfigMetadata,
-} from "@better-auth/oauth-provider";
 
 declare const process: { env: Record<string, string | undefined> };
 
-// With `basePath: "/mcp-server"`, every route on `server.app` — including
-// the Better Auth handler at `/api/auth/**`, the sign-in/consent pages, and
-// the manually-registered `.well-known/*` metadata — moves under the prefix.
-// So tell Better Auth its authURL is `http://localhost:3000/mcp-server/api/auth`
-// and configure the GitHub OAuth callback to match the prefixed path.
 const server = new MCPServer({
   name: "better-auth-oauth-example",
   version: "1.0.0",
   description: "MCP server with Better Auth OAuth authentication",
   basePath: "/mcp-server",
-  oauth: oauthBetterAuthProvider({
-    authURL: "http://localhost:3000/mcp-server/api/auth",
-  }),
+  oauth: oauthBetterAuthProvider(auth),
 });
 
 // ---------------------------------------------------------------------------
-// Mount Better Auth on the MCP server's Hono app
-// ---------------------------------------------------------------------------
-
-// Handle all Better Auth API routes
-server.app.on(["GET", "POST"], "/api/auth/**", (c) => auth.handler(c.req.raw));
-
-// Mount .well-known/oauth-authorization-server metadata
-// RFC 8414 uses path insertion: /.well-known/oauth-authorization-server{issuer-path}
-// We mount at both the root (fallback) and the spec-compliant path.
-// CORS headers needed for browser-based MCP clients (e.g. MCP Inspector).
-const corsHeaders = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Methods": "GET",
-};
-const authServerMetadataHandler = oauthProviderAuthServerMetadata(auth, {
-  headers: corsHeaders,
-});
-server.app.get("/.well-known/oauth-authorization-server", async (c) => {
-  return authServerMetadataHandler(c.req.raw);
-});
-server.app.get(
-  "/.well-known/oauth-authorization-server/api/auth",
-  async (c) => {
-    return authServerMetadataHandler(c.req.raw);
-  }
-);
-
-// Mount .well-known/openid-configuration metadata
-// Required because the openid scope is supported.
-// RFC 8414 path insertion: /.well-known/openid-configuration{issuer-path}
-const openIdConfigHandler = oauthProviderOpenIdConfigMetadata(auth, {
-  headers: corsHeaders,
-});
-server.app.get("/.well-known/openid-configuration", async (c) => {
-  return openIdConfigHandler(c.req.raw);
-});
-server.app.get("/.well-known/openid-configuration/api/auth", async (c) => {
-  return openIdConfigHandler(c.req.raw);
-});
-
 // Login page — redirects to GitHub OAuth
 // ---------------------------------------------------------------------------
 server.app.get("/sign-in", (c) => {
@@ -108,13 +60,13 @@ server.app.get("/sign-in", (c) => {
   </div>
   <script>
     async function signIn() {
-      const res = await fetch('/api/auth/sign-in/social', {
+      const res = await fetch('/mcp-server/api/auth/sign-in/social', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
         body: JSON.stringify({
           provider: 'github',
-          callbackURL: '/api/auth/oauth2/authorize${queryString}',
+          callbackURL: '/mcp-server/api/auth/oauth2/authorize${queryString}',
         }),
       });
       const data = await res.json();
@@ -170,7 +122,7 @@ server.app.get("/consent", (c) => {
   <script>
     async function handleConsent(accept) {
       const oauthQuery = window.location.search.slice(1); // strip leading '?'
-      const res = await fetch('/api/auth/oauth2/consent', {
+      const res = await fetch('/mcp-server/api/auth/oauth2/consent', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
@@ -219,5 +171,5 @@ server.listen({ port: 3000 }).then(() => {
   console.log("Better Auth OAuth MCP Server running on http://localhost:3000");
   console.log("MCP Inspector: http://localhost:3000/mcp-server/inspector");
   console.log("MCP transport: http://localhost:3000/mcp-server/mcp");
-  console.log("Auth API: http://localhost:3000/api/auth");
+  console.log("Auth API: http://localhost:3000/mcp-server/api/auth");
 });

--- a/libraries/typescript/packages/mcp-use/examples/server/oauth/better-auth/src/server.ts
+++ b/libraries/typescript/packages/mcp-use/examples/server/oauth/better-auth/src/server.ts
@@ -26,12 +26,18 @@ import {
 
 declare const process: { env: Record<string, string | undefined> };
 
+// With `basePath: "/mcp-server"`, every route on `server.app` — including
+// the Better Auth handler at `/api/auth/**`, the sign-in/consent pages, and
+// the manually-registered `.well-known/*` metadata — moves under the prefix.
+// So tell Better Auth its authURL is `http://localhost:3000/mcp-server/api/auth`
+// and configure the GitHub OAuth callback to match the prefixed path.
 const server = new MCPServer({
   name: "better-auth-oauth-example",
   version: "1.0.0",
   description: "MCP server with Better Auth OAuth authentication",
+  basePath: "/mcp-server",
   oauth: oauthBetterAuthProvider({
-    authURL: "http://localhost:3000/api/auth",
+    authURL: "http://localhost:3000/mcp-server/api/auth",
   }),
 });
 
@@ -211,6 +217,7 @@ server.tool(
 
 server.listen({ port: 3000 }).then(() => {
   console.log("Better Auth OAuth MCP Server running on http://localhost:3000");
-  console.log("MCP Inspector: http://localhost:3000/inspector");
+  console.log("MCP Inspector: http://localhost:3000/mcp-server/inspector");
+  console.log("MCP transport: http://localhost:3000/mcp-server/mcp");
   console.log("Auth API: http://localhost:3000/api/auth");
 });

--- a/libraries/typescript/packages/mcp-use/examples/server/oauth/supabase/src/auth-routes.ts
+++ b/libraries/typescript/packages/mcp-use/examples/server/oauth/supabase/src/auth-routes.ts
@@ -78,9 +78,12 @@ function parseSessionCookie(
   }
 }
 
-function serializeSessionCookie(session: StoredSession): string {
+function serializeSessionCookie(
+  session: StoredSession,
+  cookiePath: string
+): string {
   const value = encodeURIComponent(JSON.stringify(session));
-  return `${SESSION_COOKIE}=${value}; Path=/auth; HttpOnly; SameSite=Lax; Max-Age=600`;
+  return `${SESSION_COOKIE}=${value}; Path=${cookiePath}; HttpOnly; SameSite=Lax; Max-Age=600`;
 }
 
 export function mountAuthRoutes(
@@ -88,6 +91,11 @@ export function mountAuthRoutes(
   { projectId, publishableKey }: MountAuthRoutesOptions
 ): void {
   const url = supabaseUrl(projectId);
+  // `server.app.get("/auth/...")` is auto-prefixed under `basePath`, but the
+  // HTML we render needs to know the external prefix to point fetches and
+  // the session cookie at the right place.
+  const basePath = server.basePath ?? "";
+  const authPrefix = `${basePath}/auth`;
 
   // -------------------------------------------------------------------------
   // GET /auth/consent?authorization_id=<id>
@@ -110,7 +118,7 @@ export function mountAuthRoutes(
     // Not signed in yet — show the sign-in prompt. After sign-in the page
     // reloads and falls through to the authenticated branch below.
     if (!session) {
-      return c.html(renderSignInPage(authorizationId));
+      return c.html(renderSignInPage(authorizationId, authPrefix));
     }
 
     const supabase = createServerClient(url, publishableKey);
@@ -132,7 +140,7 @@ export function mountAuthRoutes(
       return c.redirect(data.redirect_url, 302);
     }
 
-    return c.html(renderConsentPage(authorizationId, data));
+    return c.html(renderConsentPage(authorizationId, data, authPrefix));
   });
 
   // -------------------------------------------------------------------------
@@ -150,10 +158,13 @@ export function mountAuthRoutes(
     // Production: replace with signed/encrypted session storage.
     c.header(
       "Set-Cookie",
-      serializeSessionCookie({
-        access_token: data.session.access_token,
-        refresh_token: data.session.refresh_token,
-      })
+      serializeSessionCookie(
+        {
+          access_token: data.session.access_token,
+          refresh_token: data.session.refresh_token,
+        },
+        authPrefix
+      )
     );
     return c.json({ ok: true });
   });
@@ -223,7 +234,7 @@ function commonStyles(): string {
   `;
 }
 
-function renderSignInPage(authorizationId: string): string {
+function renderSignInPage(authorizationId: string, authPrefix: string): string {
   return `<!DOCTYPE html>
 <html>
 <head>
@@ -241,9 +252,9 @@ function renderSignInPage(authorizationId: string): string {
   </div>
   <script>
     async function signIn() {
-      const res = await fetch('/auth/signin', { method: 'POST' });
+      const res = await fetch('${authPrefix}/signin', { method: 'POST' });
       if (res.ok) {
-        window.location.href = '/auth/consent?authorization_id=${encodeURIComponent(authorizationId)}';
+        window.location.href = '${authPrefix}/consent?authorization_id=${encodeURIComponent(authorizationId)}';
       } else {
         document.getElementById('msg').textContent =
           'Sign-in failed. Enable anonymous sign-ins in the Supabase dashboard.';
@@ -256,7 +267,8 @@ function renderSignInPage(authorizationId: string): string {
 
 function renderConsentPage(
   authorizationId: string,
-  details: OAuthAuthorizationDetails
+  details: OAuthAuthorizationDetails,
+  authPrefix: string
 ): string {
   const clientName = escapeHtml(details.client.name || "Unknown client");
   const scopes = details.scope
@@ -285,7 +297,7 @@ function renderConsentPage(
   <script>
     async function decide(approve) {
       const res = await fetch(
-        '/auth/consent?authorization_id=${encodeURIComponent(authorizationId)}',
+        '${authPrefix}/consent?authorization_id=${encodeURIComponent(authorizationId)}',
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },

--- a/libraries/typescript/packages/mcp-use/examples/server/oauth/supabase/src/server.ts
+++ b/libraries/typescript/packages/mcp-use/examples/server/oauth/supabase/src/server.ts
@@ -54,6 +54,7 @@ const server = new MCPServer({
   name: "supabase-oauth-example",
   version: "1.0.0",
   description: "MCP server with Supabase OAuth authentication",
+  basePath: "/api",
   oauth: oauthSupabaseProvider(),
 });
 

--- a/libraries/typescript/packages/mcp-use/examples/server/ui/mcp-apps/index.ts
+++ b/libraries/typescript/packages/mcp-use/examples/server/ui/mcp-apps/index.ts
@@ -5,6 +5,7 @@ import { setTimeout as sleep } from "timers/promises";
 const server = new MCPServer({
   name: "mcp-apps-example",
   version: "1.0.0",
+  basePath: "/api",
   description:
     "Example MCP server demonstrating dual-protocol widget support (works with both ChatGPT and MCP Apps clients)",
 });
@@ -185,7 +186,7 @@ server.uiResource({
         // Parse props from URL (for both protocols)
         const params = new URLSearchParams(window.location.search);
         const propsJson = params.get('props');
-        
+
         if (propsJson) {
           try {
             const props = JSON.parse(propsJson);

--- a/libraries/typescript/packages/mcp-use/src/server/connect-adapter.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/connect-adapter.ts
@@ -109,7 +109,7 @@ export async function adaptMiddleware(
  * Based on @hono/connect approach using node-mocks-http
  *
  * @param connectMiddleware - The Connect middleware handler
- * @param middlewarePath - The path pattern the middleware is mounted at (e.g., "/mcp-use/widgets/*")
+ * @param middlewarePath - The path pattern the middleware is mounted at (e.g., "/_mcp-use/widgets/*")
  * @returns A Hono middleware function
  */
 export async function adaptConnectMiddleware(

--- a/libraries/typescript/packages/mcp-use/src/server/endpoints/mount-mcp.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/endpoints/mount-mcp.ts
@@ -264,7 +264,7 @@ export async function mountMcp(
         if (iconSrc) {
           iconUrl = iconSrc.startsWith("http")
             ? iconSrc
-            : `${origin}${basePath}/mcp-use/public/${iconSrc.replace(/^\//, "")}`;
+            : `${origin}/_mcp-use/public/${iconSrc.replace(/^\//, "")}`;
         }
         const regs = instance.registrations;
         const landingTools =

--- a/libraries/typescript/packages/mcp-use/src/server/endpoints/mount-mcp.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/endpoints/mount-mcp.ts
@@ -264,7 +264,7 @@ export async function mountMcp(
         if (iconSrc) {
           iconUrl = iconSrc.startsWith("http")
             ? iconSrc
-            : `${origin}/_mcp-use/public/${iconSrc.replace(/^\//, "")}`;
+            : `${origin}${basePath}/_mcp-use/public/${iconSrc.replace(/^\//, "")}`;
         }
         const regs = instance.registrations;
         const landingTools =

--- a/libraries/typescript/packages/mcp-use/src/server/endpoints/mount-mcp.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/endpoints/mount-mcp.ts
@@ -625,15 +625,19 @@ export async function mountMcp(
     }
   };
 
-  // Mount the handler for all HTTP methods on both /mcp and /sse
-  const mcpPath = `${basePath}/mcp`;
-  const ssePath = `${basePath}/sse`;
-  for (const endpoint of [mcpPath, ssePath]) {
+  // Register on the inner app at bare paths. When `basePath` is set the
+  // inner is sub-mounted under it externally, so these become
+  // `${basePath}/mcp` and `${basePath}/sse` from the outside.
+  for (const endpoint of ["/mcp", "/sse"]) {
     app.on(["GET", "POST", "DELETE", "HEAD"], endpoint, handleRequest);
   }
 
+  // Log the externally-visible paths (what users hit) rather than the
+  // bare paths we just registered on the inner.
+  const externalMcp = `${basePath}/mcp`;
+  const externalSse = `${basePath}/sse`;
   console.log(
-    `[MCP] Server mounted at ${mcpPath} and ${ssePath} (${config.stateless ? "stateless" : "stateful"} mode)`
+    `[MCP] Server mounted at ${externalMcp} and ${externalSse} (${config.stateless ? "stateless" : "stateful"} mode)`
   );
 
   return { mcpMounted: true, idleCleanupInterval };

--- a/libraries/typescript/packages/mcp-use/src/server/endpoints/mount-mcp.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/endpoints/mount-mcp.ts
@@ -152,7 +152,8 @@ export async function mountMcp(
   }, // The McpServer instance with getServerForSession() method
   sessions: Map<string, SessionData>,
   config: ServerConfig,
-  isProductionMode: boolean
+  isProductionMode: boolean,
+  basePath: string = ""
 ): Promise<{ mcpMounted: boolean; idleCleanupInterval?: NodeJS.Timeout }> {
   const { WebStandardStreamableHTTPServerTransport } =
     await import("@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js");
@@ -263,7 +264,7 @@ export async function mountMcp(
         if (iconSrc) {
           iconUrl = iconSrc.startsWith("http")
             ? iconSrc
-            : `${origin}/mcp-use/public/${iconSrc.replace(/^\//, "")}`;
+            : `${origin}${basePath}/mcp-use/public/${iconSrc.replace(/^\//, "")}`;
         }
         const regs = instance.registrations;
         const landingTools =
@@ -625,12 +626,14 @@ export async function mountMcp(
   };
 
   // Mount the handler for all HTTP methods on both /mcp and /sse
-  for (const endpoint of ["/mcp", "/sse"]) {
+  const mcpPath = `${basePath}/mcp`;
+  const ssePath = `${basePath}/sse`;
+  for (const endpoint of [mcpPath, ssePath]) {
     app.on(["GET", "POST", "DELETE", "HEAD"], endpoint, handleRequest);
   }
 
   console.log(
-    `[MCP] Server mounted at /mcp and /sse (${config.stateless ? "stateless" : "stateful"} mode)`
+    `[MCP] Server mounted at ${mcpPath} and ${ssePath} (${config.stateless ? "stateless" : "stateful"} mode)`
   );
 
   return { mcpMounted: true, idleCleanupInterval };

--- a/libraries/typescript/packages/mcp-use/src/server/inspector/mount.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/inspector/mount.ts
@@ -4,7 +4,7 @@
  * Handles mounting of the MCP Inspector UI at /inspector endpoint.
  */
 
-import type { Hono as HonoType } from "hono";
+import { Hono, type Hono as HonoType } from "hono";
 import { readBuildManifest } from "../widgets/index.js";
 
 /**
@@ -36,7 +36,8 @@ export async function mountInspectorUI(
   app: HonoType,
   serverHost: string,
   serverPort: number | undefined,
-  isProduction: boolean
+  isProduction: boolean,
+  basePath: string = ""
 ): Promise<boolean> {
   // In production, only mount if build manifest says so
   if (isProduction) {
@@ -55,25 +56,41 @@ export async function mountInspectorUI(
   try {
     // @ts-ignore - Optional peer dependency, may not be installed during build
     const { mountInspector } = await import("@mcp-use/inspector");
-    // Auto-connect to the local MCP server at /mcp (SSE endpoint)
+    // Auto-connect to the local MCP server at ${basePath}/mcp (SSE endpoint)
     // Use JSON config to specify SSE transport type
-    const mcpUrl = `http://${serverHost}:${serverPort}/mcp`; // Also available at /sse
+    const mcpUrl = `http://${serverHost}:${serverPort}${basePath}/mcp`; // Also available at ${basePath}/sse
     const autoConnectConfig = JSON.stringify({
       url: mcpUrl,
       name: "Local MCP Server",
       transportType: "sse",
       connectionType: "Direct",
     });
-    mountInspector(app, {
+    // When basePath is set, register the inspector's bare `/inspector/*`
+    // routes on a sub-Hono mounted at the prefix so request URLs compose to
+    // ${basePath}/inspector/*. We also pass `basePath` into mountInspector
+    // itself so the served HTML can inject a matching <base href> (used by
+    // Vite's relative asset URLs) and `window.__MCP_BASE_PATH__` (used by
+    // React Router and same-origin fetches in the client bundle). With no
+    // basePath we register directly on the main app to match historical
+    // behavior exactly.
+    const inspectorOptions = {
       autoConnectUrl: autoConnectConfig,
       // In dev mode, tell the inspector to use same-origin for MCP Apps sandbox.
       // This avoids requiring a sandbox-{hostname} subdomain that doesn't exist
       // behind reverse proxies (ngrok, E2B, etc.)
       devMode: !isProduction,
       serverPort: typeof serverPort === "number" ? serverPort : undefined,
-    });
+      basePath,
+    };
+    if (basePath) {
+      const inspectorApp = new Hono();
+      mountInspector(inspectorApp, inspectorOptions);
+      app.route(basePath, inspectorApp);
+    } else {
+      mountInspector(app, inspectorOptions);
+    }
     console.log(
-      `[INSPECTOR] UI available at http://${serverHost}:${serverPort}/inspector`
+      `[INSPECTOR] UI available at http://${serverHost}:${serverPort}${basePath}/inspector`
     );
     return true;
   } catch (err) {

--- a/libraries/typescript/packages/mcp-use/src/server/inspector/mount.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/inspector/mount.ts
@@ -4,7 +4,7 @@
  * Handles mounting of the MCP Inspector UI at /inspector endpoint.
  */
 
-import { Hono, type Hono as HonoType } from "hono";
+import type { Hono as HonoType } from "hono";
 import { readBuildManifest } from "../widgets/index.js";
 
 /**
@@ -56,18 +56,24 @@ export async function mountInspectorUI(
   try {
     // @ts-ignore - Optional peer dependency, may not be installed during build
     const { mountInspector } = await import("@mcp-use/inspector");
-    // Auto-connect to the local MCP server at ${basePath}/mcp (SSE endpoint)
-    // Use JSON config to specify SSE transport type
-    const mcpUrl = `http://${serverHost}:${serverPort}${basePath}/mcp`; // Also available at ${basePath}/sse
+    // Auto-connect to the local MCP server. The transport lives at
+    // `${basePath}/mcp` externally; the inspector's auto-connect URL uses
+    // the externally-visible path because it's loaded by the user's
+    // browser, not internally.
+    const mcpUrl = `http://${serverHost}:${serverPort}${basePath}/mcp`;
     const autoConnectConfig = JSON.stringify({
       url: mcpUrl,
       name: "Local MCP Server",
       transportType: "sse",
       connectionType: "Direct",
     });
-    // mountInspector registers bare `/inspector/*` routes, so under a
-    // basePath we wrap it in a sub-Hono mounted at the prefix.
-    const inspectorOptions = {
+    // The inspector registers bare `/inspector/*` routes on whatever app
+    // we hand it. We're handing it the inner app, which is already
+    // sub-mounted under `basePath` by the MCPServer constructor — so the
+    // inspector composes to `${basePath}/inspector/*` externally without
+    // any wrapping here. `basePath` still flows in for URL emission
+    // (`<base href>`, `window.__MCP_BASE_PATH__`).
+    mountInspector(app, {
       autoConnectUrl: autoConnectConfig,
       // In dev mode, tell the inspector to use same-origin for MCP Apps sandbox.
       // This avoids requiring a sandbox-{hostname} subdomain that doesn't exist
@@ -75,14 +81,7 @@ export async function mountInspectorUI(
       devMode: !isProduction,
       serverPort: typeof serverPort === "number" ? serverPort : undefined,
       basePath,
-    };
-    if (basePath) {
-      const inspectorApp = new Hono();
-      mountInspector(inspectorApp, inspectorOptions);
-      app.route(basePath, inspectorApp);
-    } else {
-      mountInspector(app, inspectorOptions);
-    }
+    });
     console.log(
       `[INSPECTOR] UI available at http://${serverHost}:${serverPort}${basePath}/inspector`
     );

--- a/libraries/typescript/packages/mcp-use/src/server/inspector/mount.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/inspector/mount.ts
@@ -65,14 +65,8 @@ export async function mountInspectorUI(
       transportType: "sse",
       connectionType: "Direct",
     });
-    // When basePath is set, register the inspector's bare `/inspector/*`
-    // routes on a sub-Hono mounted at the prefix so request URLs compose to
-    // ${basePath}/inspector/*. We also pass `basePath` into mountInspector
-    // itself so the served HTML can inject a matching <base href> (used by
-    // Vite's relative asset URLs) and `window.__MCP_BASE_PATH__` (used by
-    // React Router and same-origin fetches in the client bundle). With no
-    // basePath we register directly on the main app to match historical
-    // behavior exactly.
+    // mountInspector registers bare `/inspector/*` routes, so under a
+    // basePath we wrap it in a sub-Hono mounted at the prefix.
     const inspectorOptions = {
       autoConnectUrl: autoConnectConfig,
       // In dev mode, tell the inspector to use same-origin for MCP Apps sandbox.

--- a/libraries/typescript/packages/mcp-use/src/server/logging.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/logging.ts
@@ -151,9 +151,9 @@ async function extractResponseError(res: Response): Promise<string | null> {
  * The middleware logs incoming HTTP requests in a compact format controlled
  * by `MCP_DEBUG_LEVEL` (or legacy `DEBUG`). See {@link getDebugLevel}.
  *
- * Skips logging for inspector telemetry/RPC endpoints, dev widget assets, and
- * polling GETs against `/mcp` and `/inspector/api/*` — including their
- * basePath-prefixed equivalents.
+ * Skips logging for inspector telemetry/RPC endpoints, framework-internal
+ * `/_mcp-use/*` assets, and polling GETs against `/mcp` and `/inspector/api/*` —
+ * including their basePath-prefixed equivalents (where applicable).
  */
 export function createRequestLogger(
   basePath: string = ""
@@ -173,19 +173,28 @@ export function createRequestLogger(
       basePath && pathname.startsWith(basePath)
         ? pathname.slice(basePath.length) || "/"
         : pathname;
+    // Framework-internal asset paths live at the host root under `/_mcp-use/`
+    // (basePath-agnostic). Match them on the raw `pathname`, not on the
+    // basePath-stripped `routedPath`, since they never carry the prefix.
+    const isInternalAsset =
+      pathname.startsWith("/_mcp-use/widgets/") ||
+      pathname.startsWith("/_mcp-use/public/");
     const noisyPaths = [
       "/inspector/api/tel/",
       "/inspector/api/rpc/stream",
       "/inspector/api/rpc/log",
       "/inspector",
-      "/mcp-use/widgets/",
-      "/mcp-use/public/",
     ];
     const isNoisyGet =
       method === "GET" &&
       (routedPath === "/mcp" ||
         routedPath.startsWith("/inspector/api/") ||
-        routedPath.startsWith("/mcp-use/"));
+        pathname.startsWith("/_mcp-use/"));
+
+    if (isInternalAsset) {
+      await next();
+      return;
+    }
 
     if (
       noisyPaths.some((noisyPath) => routedPath.startsWith(noisyPath)) ||

--- a/libraries/typescript/packages/mcp-use/src/server/logging.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/logging.ts
@@ -152,8 +152,8 @@ async function extractResponseError(res: Response): Promise<string | null> {
  * by `MCP_DEBUG_LEVEL` (or legacy `DEBUG`). See {@link getDebugLevel}.
  *
  * Skips logging for inspector telemetry/RPC endpoints, framework-internal
- * `/_mcp-use/*` assets, and polling GETs against `/mcp` and `/inspector/api/*` —
- * including their basePath-prefixed equivalents (where applicable).
+ * `${basePath}/_mcp-use/*` assets, and polling GETs against `/mcp` and
+ * `/inspector/api/*` (all matched against the basePath-stripped path).
  */
 export function createRequestLogger(
   basePath: string = ""
@@ -173,12 +173,11 @@ export function createRequestLogger(
       basePath && pathname.startsWith(basePath)
         ? pathname.slice(basePath.length) || "/"
         : pathname;
-    // Framework-internal asset paths live at the host root under `/_mcp-use/`
-    // (basePath-agnostic). Match them on the raw `pathname`, not on the
-    // basePath-stripped `routedPath`, since they never carry the prefix.
+    // Framework-internal asset paths live under `${basePath}/_mcp-use/`, so
+    // match them against the basePath-stripped `routedPath`.
     const isInternalAsset =
-      pathname.startsWith("/_mcp-use/widgets/") ||
-      pathname.startsWith("/_mcp-use/public/");
+      routedPath.startsWith("/_mcp-use/widgets/") ||
+      routedPath.startsWith("/_mcp-use/public/");
     const noisyPaths = [
       "/inspector/api/tel/",
       "/inspector/api/rpc/stream",
@@ -189,7 +188,7 @@ export function createRequestLogger(
       method === "GET" &&
       (routedPath === "/mcp" ||
         routedPath.startsWith("/inspector/api/") ||
-        pathname.startsWith("/_mcp-use/"));
+        routedPath.startsWith("/_mcp-use/"));
 
     if (isInternalAsset) {
       await next();

--- a/libraries/typescript/packages/mcp-use/src/server/logging.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/logging.ts
@@ -145,212 +145,229 @@ async function extractResponseError(res: Response): Promise<string | null> {
 }
 
 /**
- * Middleware that logs incoming HTTP requests in a compact format controlled
+ * Build the request-logging middleware, bound to a `basePath` so noisy-path
+ * filtering still works when the server is mounted under a prefix.
+ *
+ * The middleware logs incoming HTTP requests in a compact format controlled
  * by `MCP_DEBUG_LEVEL` (or legacy `DEBUG`). See {@link getDebugLevel}.
  *
  * Skips logging for inspector telemetry/RPC endpoints, dev widget assets, and
- * polling GETs against `/mcp` and `/inspector/api/*`.
+ * polling GETs against `/mcp` and `/inspector/api/*` — including their
+ * basePath-prefixed equivalents.
  */
-export async function requestLogger(c: Context, next: Next): Promise<void> {
-  const startedAt = Date.now();
-  const timestamp = new Date().toISOString().substring(11, 23);
-  const method = c.req.method;
-  const url = c.req.url;
-  const level = getDebugLevel();
+export function createRequestLogger(
+  basePath: string = ""
+): (c: Context, next: Next) => Promise<void> {
+  return async function requestLogger(c: Context, next: Next): Promise<void> {
+    const startedAt = Date.now();
+    const timestamp = new Date().toISOString().substring(11, 23);
+    const method = c.req.method;
+    const url = c.req.url;
+    const level = getDebugLevel();
 
-  const pathname = new URL(url).pathname;
-  const noisyPaths = [
-    "/inspector/api/tel/",
-    "/inspector/api/rpc/stream",
-    "/inspector/api/rpc/log",
-    "/inspector",
-    "/mcp-use/widgets/",
-    "/mcp-use/public/",
-  ];
-  const isNoisyGet =
-    method === "GET" &&
-    (pathname === "/mcp" ||
-      pathname.startsWith("/inspector/api/") ||
-      pathname.startsWith("/mcp-use/"));
+    const pathname = new URL(url).pathname;
+    // Strip the configured basePath before matching noisy-path patterns so
+    // requests like `/api/mcp-use/widgets/...` and `/api/inspector/api/...`
+    // are filtered the same way as the unprefixed versions.
+    const routedPath =
+      basePath && pathname.startsWith(basePath)
+        ? pathname.slice(basePath.length) || "/"
+        : pathname;
+    const noisyPaths = [
+      "/inspector/api/tel/",
+      "/inspector/api/rpc/stream",
+      "/inspector/api/rpc/log",
+      "/inspector",
+      "/mcp-use/widgets/",
+      "/mcp-use/public/",
+    ];
+    const isNoisyGet =
+      method === "GET" &&
+      (routedPath === "/mcp" ||
+        routedPath.startsWith("/inspector/api/") ||
+        routedPath.startsWith("/mcp-use/"));
 
-  if (
-    noisyPaths.some((noisyPath) => pathname.startsWith(noisyPath)) ||
-    isNoisyGet
-  ) {
-    await next();
-    return;
-  }
-
-  // Capture request body up front so we can extract MCP method/params.
-  let requestBody: any = null;
-  let requestHeaders: Record<string, string> = {};
-
-  if (level === "trace") {
-    const allHeaders = c.req.header();
-    if (allHeaders) requestHeaders = allHeaders;
-  }
-
-  if (method !== "GET" && method !== "HEAD") {
-    try {
-      const clonedRequest = c.req.raw.clone();
-      requestBody = await clonedRequest.json().catch(() => {
-        return clonedRequest.text().catch(() => null);
-      });
-    } catch {
-      // ignore — body is optional for the log line
+    if (
+      noisyPaths.some((noisyPath) => routedPath.startsWith(noisyPath)) ||
+      isNoisyGet
+    ) {
+      await next();
+      return;
     }
-  }
 
-  await next();
+    // Capture request body up front so we can extract MCP method/params.
+    let requestBody: any = null;
+    let requestHeaders: Record<string, string> = {};
 
-  const durationMs = Date.now() - startedAt;
-  const statusCode = c.res.status;
-
-  // Session ID: incoming header for established sessions, response header for
-  // initialize requests (the SDK transport stamps it on the response).
-  const incomingSid = c.req.header("mcp-session-id");
-  const responseSid = c.res.headers.get("mcp-session-id");
-  const mcpMethod: string | undefined = requestBody?.method;
-  const isInitialize = mcpMethod === "initialize";
-
-  // Build the line. Colors mirror typical access-log palettes: timestamps,
-  // session ids, args and durations are dimmed; method/path/MCP-method are
-  // bold; outcome is green (OK) or red (ERROR).
-  const parts: string[] = [chalk.gray(`[${timestamp}]`)];
-
-  const sessPrefix = !isInitialize ? shortSessionId(incomingSid) : null;
-  if (sessPrefix) parts.push(chalk.gray(`sess=${sessPrefix}`));
-
-  parts.push(method);
-  parts.push(chalk.bold(pathname));
-
-  if (mcpMethod) {
-    if (isInitialize) {
-      const ci = requestBody?.params?.clientInfo;
-      const label =
-        ci?.name && ci?.version
-          ? `: ${ci.name}/${ci.version}`
-          : ci?.name
-            ? `: ${ci.name}`
-            : "";
-      parts.push(chalk.bold(`[initialize${label}]`));
-    } else if (mcpMethod === "tools/call") {
-      const toolName = requestBody?.params?.name ?? "?";
-      let segment = chalk.bold(`[tools/call: ${toolName}]`);
-      if (level !== "info") {
-        const args = requestBody?.params?.arguments;
-        if (args !== undefined) {
-          segment += ` args=${inlineJson(args)}`;
-        }
-      }
-      parts.push(segment);
-    } else if (mcpMethod === "resources/read") {
-      const uri = requestBody?.params?.uri ?? "?";
-      parts.push(chalk.bold(`[resources/read: ${uri}]`));
-    } else if (mcpMethod === "prompts/get") {
-      const promptName = requestBody?.params?.name ?? "?";
-      parts.push(chalk.bold(`[prompts/get: ${promptName}]`));
-    } else {
-      parts.push(chalk.bold(`[${mcpMethod}]`));
+    if (level === "trace") {
+      const allHeaders = c.req.header();
+      if (allHeaders) requestHeaders = allHeaders;
     }
-  }
 
-  if (isInitialize && responseSid) {
-    parts.push(chalk.gray(`→ session=${shortSessionId(responseSid)}`));
-  }
-
-  // Outcome:
-  //  - MCP requests: OK / ERROR <message> based on JSON-RPC error parsing.
-  //  - Plain HTTP (HEAD, etc.): the raw status code, colored by class.
-  let outcomePart: string;
-  const errMsg = await extractResponseError(c.res);
-  if (errMsg) {
-    outcomePart = chalk.red(`ERROR ${errMsg}`);
-  } else if (mcpMethod) {
-    outcomePart =
-      statusCode >= 400
-        ? chalk.red(`ERROR (HTTP ${statusCode})`)
-        : chalk.green("OK");
-  } else {
-    outcomePart =
-      statusCode >= 500
-        ? chalk.magenta(String(statusCode))
-        : statusCode >= 400
-          ? chalk.red(String(statusCode))
-          : statusCode >= 300
-            ? chalk.yellow(String(statusCode))
-            : chalk.green(String(statusCode));
-  }
-  parts.push(outcomePart);
-  parts.push(chalk.gray(`(${durationMs}ms)`));
-
-  console.log(parts.join(" "));
-
-  // Trace mode preserves the legacy DEBUG=1 behavior: detailed request and
-  // response dumps follow the summary line.
-  if (level !== "trace") return;
-
-  console.log("\n" + chalk.cyan("=".repeat(80)));
-  console.log(chalk.bold.cyan("[TRACE] Request Details"));
-  console.log(chalk.cyan("-".repeat(80)));
-
-  if (Object.keys(requestHeaders).length > 0) {
-    console.log(chalk.yellow("Request Headers:"));
-    console.log(formatForLogging(requestHeaders));
-  }
-
-  if (requestBody !== null) {
-    console.log(chalk.yellow("Request Body:"));
-    if (typeof requestBody === "string") {
-      console.log(requestBody);
-    } else {
-      console.log(formatForLogging(requestBody));
-    }
-  }
-
-  const responseHeaders: Record<string, string> = {};
-  c.res.headers.forEach((value, key) => {
-    responseHeaders[key] = value;
-  });
-  if (Object.keys(responseHeaders).length > 0) {
-    console.log(chalk.yellow("Response Headers:"));
-    console.log(formatForLogging(responseHeaders));
-  }
-
-  try {
-    if (c.res.body !== null && c.res.body !== undefined) {
+    if (method !== "GET" && method !== "HEAD") {
       try {
-        const clonedResponse = c.res.clone();
-        const responseBody = await clonedResponse.text().catch(() => null);
-
-        if (responseBody !== null && responseBody.length > 0) {
-          console.log(chalk.yellow("Response Body:"));
-          try {
-            const jsonBody = JSON.parse(responseBody);
-            console.log(formatForLogging(jsonBody));
-          } catch {
-            const maxLength = 10000;
-            if (responseBody.length > maxLength) {
-              console.log(
-                responseBody.substring(0, maxLength) +
-                  `\n... (truncated, ${responseBody.length - maxLength} more characters)`
-              );
-            } else {
-              console.log(responseBody);
-            }
-          }
-        } else {
-          console.log(chalk.yellow("Response Body:") + " (empty)");
-        }
+        const clonedRequest = c.req.raw.clone();
+        requestBody = await clonedRequest.json().catch(() => {
+          return clonedRequest.text().catch(() => null);
+        });
       } catch {
-        console.log(chalk.yellow("Response Body:") + " (unable to clone/read)");
+        // ignore — body is optional for the log line
       }
-    } else {
-      console.log(chalk.yellow("Response Body:") + " (no body)");
     }
-  } catch {
-    console.log(chalk.yellow("Response Body:") + " (unable to read)");
-  }
 
-  console.log(chalk.cyan("=".repeat(80)) + "\n");
+    await next();
+
+    const durationMs = Date.now() - startedAt;
+    const statusCode = c.res.status;
+
+    // Session ID: incoming header for established sessions, response header for
+    // initialize requests (the SDK transport stamps it on the response).
+    const incomingSid = c.req.header("mcp-session-id");
+    const responseSid = c.res.headers.get("mcp-session-id");
+    const mcpMethod: string | undefined = requestBody?.method;
+    const isInitialize = mcpMethod === "initialize";
+
+    // Build the line. Colors mirror typical access-log palettes: timestamps,
+    // session ids, args and durations are dimmed; method/path/MCP-method are
+    // bold; outcome is green (OK) or red (ERROR).
+    const parts: string[] = [chalk.gray(`[${timestamp}]`)];
+
+    const sessPrefix = !isInitialize ? shortSessionId(incomingSid) : null;
+    if (sessPrefix) parts.push(chalk.gray(`sess=${sessPrefix}`));
+
+    parts.push(method);
+    parts.push(chalk.bold(pathname));
+
+    if (mcpMethod) {
+      if (isInitialize) {
+        const ci = requestBody?.params?.clientInfo;
+        const label =
+          ci?.name && ci?.version
+            ? `: ${ci.name}/${ci.version}`
+            : ci?.name
+              ? `: ${ci.name}`
+              : "";
+        parts.push(chalk.bold(`[initialize${label}]`));
+      } else if (mcpMethod === "tools/call") {
+        const toolName = requestBody?.params?.name ?? "?";
+        let segment = chalk.bold(`[tools/call: ${toolName}]`);
+        if (level !== "info") {
+          const args = requestBody?.params?.arguments;
+          if (args !== undefined) {
+            segment += ` args=${inlineJson(args)}`;
+          }
+        }
+        parts.push(segment);
+      } else if (mcpMethod === "resources/read") {
+        const uri = requestBody?.params?.uri ?? "?";
+        parts.push(chalk.bold(`[resources/read: ${uri}]`));
+      } else if (mcpMethod === "prompts/get") {
+        const promptName = requestBody?.params?.name ?? "?";
+        parts.push(chalk.bold(`[prompts/get: ${promptName}]`));
+      } else {
+        parts.push(chalk.bold(`[${mcpMethod}]`));
+      }
+    }
+
+    if (isInitialize && responseSid) {
+      parts.push(chalk.gray(`→ session=${shortSessionId(responseSid)}`));
+    }
+
+    // Outcome:
+    //  - MCP requests: OK / ERROR <message> based on JSON-RPC error parsing.
+    //  - Plain HTTP (HEAD, etc.): the raw status code, colored by class.
+    let outcomePart: string;
+    const errMsg = await extractResponseError(c.res);
+    if (errMsg) {
+      outcomePart = chalk.red(`ERROR ${errMsg}`);
+    } else if (mcpMethod) {
+      outcomePart =
+        statusCode >= 400
+          ? chalk.red(`ERROR (HTTP ${statusCode})`)
+          : chalk.green("OK");
+    } else {
+      outcomePart =
+        statusCode >= 500
+          ? chalk.magenta(String(statusCode))
+          : statusCode >= 400
+            ? chalk.red(String(statusCode))
+            : statusCode >= 300
+              ? chalk.yellow(String(statusCode))
+              : chalk.green(String(statusCode));
+    }
+    parts.push(outcomePart);
+    parts.push(chalk.gray(`(${durationMs}ms)`));
+
+    console.log(parts.join(" "));
+
+    // Trace mode preserves the legacy DEBUG=1 behavior: detailed request and
+    // response dumps follow the summary line.
+    if (level !== "trace") return;
+
+    console.log("\n" + chalk.cyan("=".repeat(80)));
+    console.log(chalk.bold.cyan("[TRACE] Request Details"));
+    console.log(chalk.cyan("-".repeat(80)));
+
+    if (Object.keys(requestHeaders).length > 0) {
+      console.log(chalk.yellow("Request Headers:"));
+      console.log(formatForLogging(requestHeaders));
+    }
+
+    if (requestBody !== null) {
+      console.log(chalk.yellow("Request Body:"));
+      if (typeof requestBody === "string") {
+        console.log(requestBody);
+      } else {
+        console.log(formatForLogging(requestBody));
+      }
+    }
+
+    const responseHeaders: Record<string, string> = {};
+    c.res.headers.forEach((value, key) => {
+      responseHeaders[key] = value;
+    });
+    if (Object.keys(responseHeaders).length > 0) {
+      console.log(chalk.yellow("Response Headers:"));
+      console.log(formatForLogging(responseHeaders));
+    }
+
+    try {
+      if (c.res.body !== null && c.res.body !== undefined) {
+        try {
+          const clonedResponse = c.res.clone();
+          const responseBody = await clonedResponse.text().catch(() => null);
+
+          if (responseBody !== null && responseBody.length > 0) {
+            console.log(chalk.yellow("Response Body:"));
+            try {
+              const jsonBody = JSON.parse(responseBody);
+              console.log(formatForLogging(jsonBody));
+            } catch {
+              const maxLength = 10000;
+              if (responseBody.length > maxLength) {
+                console.log(
+                  responseBody.substring(0, maxLength) +
+                    `\n... (truncated, ${responseBody.length - maxLength} more characters)`
+                );
+              } else {
+                console.log(responseBody);
+              }
+            }
+          } else {
+            console.log(chalk.yellow("Response Body:") + " (empty)");
+          }
+        } catch {
+          console.log(
+            chalk.yellow("Response Body:") + " (unable to clone/read)"
+          );
+        }
+      } else {
+        console.log(chalk.yellow("Response Body:") + " (no body)");
+      }
+    } catch {
+      console.log(chalk.yellow("Response Body:") + " (unable to read)");
+    }
+
+    console.log(chalk.cyan("=".repeat(80)) + "\n");
+  };
 }

--- a/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
@@ -91,9 +91,11 @@ import {
   isDeno,
   isProductionMode as isProductionModeHelper,
   logRegisteredItems as logRegisteredItemsHelper,
+  normalizeBasePath,
   parseTemplateUri as parseTemplateUriHelper,
   rewriteSupabaseRequest,
   startServer,
+  writeServerInfoFile,
 } from "./utils/index.js";
 import type { WithMcpUse } from "./utils/hono-proxy.js";
 import type {
@@ -315,6 +317,14 @@ class MCPServerClass<HasOAuth extends boolean = false> {
    * Used for generating widget URLs and OAuth callbacks.
    */
   public serverBaseUrl?: string;
+
+  /**
+   * Normalized base path prefix for every route this server mounts.
+   *
+   * Empty string means no prefix. Otherwise starts with `/` and has no
+   * trailing `/`. Computed once in the constructor from `config.basePath`.
+   */
+  public basePath: string;
 
   /**
    * Optional favicon URL to display in inspector and documentation.
@@ -2350,6 +2360,7 @@ class MCPServerClass<HasOAuth extends boolean = false> {
 
     this.serverHost = config.host || "localhost";
     this.serverBaseUrl = config.baseUrl;
+    this.basePath = normalizeBasePath(config.basePath);
 
     // Auto-select favicon from icons array if not explicitly provided
     if (config.favicon) {
@@ -2360,6 +2371,7 @@ class MCPServerClass<HasOAuth extends boolean = false> {
     }
 
     // Helper to convert relative icon paths to absolute URLs
+    const basePathForIcons = this.basePath;
     const processIconUrls = (
       icons: ServerConfig["icons"],
       baseUrl?: string
@@ -2369,7 +2381,7 @@ class MCPServerClass<HasOAuth extends boolean = false> {
         ...icon,
         src: icon.src.startsWith("http")
           ? icon.src
-          : `${baseUrl}/mcp-use/public/${icon.src}`,
+          : `${baseUrl}${basePathForIcons}/mcp-use/public/${icon.src}`,
       }));
     };
 
@@ -2422,8 +2434,8 @@ class MCPServerClass<HasOAuth extends boolean = false> {
       !isProductionModeHelper() &&
       !isDeno
     ) {
-      setupPublicRoutes(this.app, false); // Dev mode (public/)
-      setupFaviconRoute(this.app, this.favicon, false);
+      setupPublicRoutes(this.app, false, this.basePath); // Dev mode (public/)
+      setupFaviconRoute(this.app, this.favicon, false, this.basePath);
       this.publicRoutesMode = "dev";
     }
 
@@ -2632,6 +2644,7 @@ class MCPServerClass<HasOAuth extends boolean = false> {
    */
   public getServerForSession(sessionId?: string): OfficialMcpServer {
     // Helper to convert relative icon paths to absolute URLs
+    const basePathForIcons = this.basePath;
     const processIconUrls = (
       icons: ServerConfig["icons"],
       baseUrl?: string
@@ -2641,7 +2654,7 @@ class MCPServerClass<HasOAuth extends boolean = false> {
         ...icon,
         src: icon.src.startsWith("http")
           ? icon.src
-          : `${baseUrl}/mcp-use/public/${icon.src}`,
+          : `${baseUrl}${basePathForIcons}/mcp-use/public/${icon.src}`,
       }));
     };
 
@@ -3703,7 +3716,8 @@ class MCPServerClass<HasOAuth extends boolean = false> {
       this, // Pass the MCPServer instance so mountMcp can call getServerForSession()
       this.sessions,
       this.config,
-      isProductionModeHelper()
+      isProductionModeHelper(),
+      this.basePath
     );
 
     this.mcpMounted = result.mcpMounted;
@@ -3888,12 +3902,13 @@ class MCPServerClass<HasOAuth extends boolean = false> {
         this.app,
         this.oauthProvider,
         this.getServerBaseUrl(),
-        this.oauthSetupState
+        this.oauthSetupState,
+        this.basePath
       );
     }
 
     await mountWidgets(this as any, {
-      baseRoute: "/mcp-use/widgets",
+      baseRoute: `${this.basePath}/mcp-use/widgets`,
       // Only forward `resourcesDir` when the env var is set. That lets
       // @mcp-use/cli steer widget discovery to e.g. `src/mcp/resources`
       // (via `--mcp-dir src/mcp`) without forcing the user to configure
@@ -3929,6 +3944,15 @@ class MCPServerClass<HasOAuth extends boolean = false> {
     // Track server run event
     this._trackServerRun("http");
 
+    // Write a small machine-readable handoff so external tools (the CLI's
+    // auto-open, screenshot, etc.) can discover the configured basePath
+    // without parsing source. Best-effort — failures must not break startup.
+    await writeServerInfoFile({
+      host: this.serverHost,
+      port: this.serverPort,
+      basePath: this.basePath,
+    });
+
     // Start server using runtime-aware helper
     const httpHandle = await startServer(
       this.app,
@@ -3936,6 +3960,7 @@ class MCPServerClass<HasOAuth extends boolean = false> {
       this.serverHost,
       {
         onDenoRequest: rewriteSupabaseRequest,
+        basePath: this.basePath,
       }
     );
     this._httpServerClose = httpHandle.close;
@@ -4017,13 +4042,14 @@ class MCPServerClass<HasOAuth extends boolean = false> {
         this.app,
         this.oauthProvider,
         this.getServerBaseUrl(),
-        this.oauthSetupState
+        this.oauthSetupState,
+        this.basePath
       );
     }
 
     console.log("[MCP] Mounting widgets");
     await mountWidgets(this as any, {
-      baseRoute: "/mcp-use/widgets",
+      baseRoute: `${this.basePath}/mcp-use/widgets`,
       // Only forward `resourcesDir` when the env var is set. That lets
       // @mcp-use/cli steer widget discovery to e.g. `src/mcp/resources`
       // (via `--mcp-dir src/mcp`) without forcing the user to configure
@@ -4131,7 +4157,8 @@ class MCPServerClass<HasOAuth extends boolean = false> {
       this.app,
       this.serverHost,
       this.serverPort,
-      isProductionModeHelper()
+      isProductionModeHelper(),
+      this.basePath
     );
 
     if (mounted) {

--- a/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
@@ -260,7 +260,13 @@ class MCPServerClass<HasOAuth extends boolean = false> {
   /**
    * Hono application instance.
    *
-   * The underlying Hono app that handles HTTP routing and middleware.
+   * When `basePath` is set, this is a Hono `.basePath()` clone — route
+   * registrations made here automatically pick up the basePath prefix.
+   * The clone shares its parent's router/routes array (see Hono's
+   * `clone()`), so `app.fetch` still dispatches root-level routes such
+   * as OAuth `.well-known/*` discovery that were registered on the
+   * un-prefixed view inside the constructor before the clone was taken.
+   *
    * Can be used to add custom routes and middleware alongside MCP endpoints.
    *
    * @example
@@ -270,20 +276,6 @@ class MCPServerClass<HasOAuth extends boolean = false> {
    * ```
    */
   public app: HonoType;
-
-  /**
-   * @internal The underlying Hono instance. Receives HTTP requests and holds
-   * global middleware (CORS, host validation, request logging) plus routes
-   * that must stay at the host root (`/favicon.ico`, `/.well-known/*`,
-   * `/_mcp-use/*`).
-   *
-   * `this.app` is either `_rootApp` directly (no basePath) or a Hono
-   * `basePath()` clone of it (with basePath). The clone shares this
-   * instance's router and routes array, so route registrations on
-   * `this.app` end up on the same router as `_rootApp` — just with the
-   * basePath prefix prepended at registration time.
-   */
-  private _rootApp!: HonoType;
 
   /** @internal Whether MCP endpoints have been mounted */
   private mcpMounted = false;
@@ -372,15 +364,7 @@ class MCPServerClass<HasOAuth extends boolean = false> {
    */
   public sessions = new Map<string, SessionData>();
   private idleCleanupInterval?: NodeJS.Timeout;
-  private oauthSetupState = {
-    complete: false,
-    provider: undefined as OAuthProvider | undefined,
-    middleware: undefined as
-      | ((c: any, next: any) => Promise<Response | void>)
-      | undefined,
-  };
   public oauthProvider?: OAuthProvider;
-  private oauthMiddleware?: (c: any, next: any) => Promise<Response | void>;
 
   /**
    * Storage for registrations that can be replayed on new server instances
@@ -2392,7 +2376,7 @@ class MCPServerClass<HasOAuth extends boolean = false> {
         description: config.description,
         title: config.title,
         websiteUrl: config.websiteUrl,
-        icons: resolveIconUrls(config.icons, config.baseUrl),
+        icons: resolveIconUrls(config.icons, config.baseUrl, this.basePath),
       },
       {
         capabilities: {
@@ -2413,18 +2397,38 @@ class MCPServerClass<HasOAuth extends boolean = false> {
     );
 
     // Single Hono instance. Global middleware (CORS, host validation,
-    // request logging) lives here. When `basePath` is set, `this.app` is a
-    // `.basePath()` clone — same underlying router, but route registrations
-    // automatically get the prefix prepended. No sub-mounting, no deferred
-    // route-snapshot dance.
-    this._rootApp = createHonoApp(createRequestLogger(this.basePath), {
+    // request logging) lives on the un-prefixed root view created here.
+    // When `basePath` is set, `this.app` is later switched to a
+    // `.basePath()` clone — same underlying router and routes array (see
+    // Hono's `clone()`), but registrations through the clone automatically
+    // get the prefix prepended. No sub-mounting, no deferred route-snapshot
+    // dance.
+    const rootApp = createHonoApp(createRequestLogger(this.basePath), {
       cors: this.config.cors,
       allowedOrigins: this.config.allowedOrigins,
     });
 
-    this.app = this.basePath
-      ? this._rootApp.basePath(this.basePath)
-      : this._rootApp;
+    this.oauthProvider = config.oauth;
+
+    // Mount OAuth on the un-prefixed root view BEFORE switching `this.app`
+    // to the basePath clone. OAuth has to register `.well-known/*` at the
+    // literal host root (RFC 8414 §3.1) regardless of basePath; everything
+    // else it registers (/authorize, /token, /register, /mcp middleware) is
+    // scoped under basePath via an internal `.basePath()` clone. Doing this
+    // here is the only thing that needs the un-prefixed handle — afterwards
+    // we collapse to a single `this.app` reference. `getServerBaseUrl()` is
+    // passed as a lazy getter because the port isn't bound yet when the
+    // constructor runs; metadata handlers resolve it at request time.
+    if (this.oauthProvider) {
+      setupOAuthForServer(
+        rootApp,
+        this.oauthProvider,
+        () => this.getServerBaseUrl(),
+        this.basePath
+      );
+    }
+
+    this.app = this.basePath ? rootApp.basePath(this.basePath) : rootApp;
 
     // Install the custom routes middleware FIRST (before any other routes).
     // This single middleware dispatches from the mutable _customRoutes map,
@@ -2441,20 +2445,19 @@ class MCPServerClass<HasOAuth extends boolean = false> {
     );
 
     // Setup public routes immediately if icons/favicon are configured.
-    // Public assets register on `this.app` (auto-prefixed); favicon
-    // registers on `_rootApp` so browsers' implicit `GET /favicon.ico`
-    // resolves regardless of basePath.
+    // Both register on `this.app` so they auto-prefix under `basePath` —
+    // `${basePath}/_mcp-use/public/*` and `${basePath}/favicon.ico`. The
+    // MCP icon declaration in `getServerInfo` is what clients consume to
+    // discover the icon when the server is mounted under a basePath.
     if (
       (this.favicon || this.config.icons) &&
       !isProductionModeHelper() &&
       !isDeno
     ) {
       setupPublicRoutes(this.app, false); // Dev mode (public/)
-      setupFaviconRoute(this._rootApp, this.favicon, false);
+      setupFaviconRoute(this.app, this.favicon, false);
       this.publicRoutesMode = "dev";
     }
-
-    this.oauthProvider = config.oauth;
 
     // Wrap registration methods to capture registrations for multi-session support
     this.wrapRegistrationMethods();
@@ -2665,7 +2668,11 @@ class MCPServerClass<HasOAuth extends boolean = false> {
         description: this.config.description,
         title: this.config.title,
         websiteUrl: this.config.websiteUrl,
-        icons: resolveIconUrls(this.config.icons, this.serverBaseUrl),
+        icons: resolveIconUrls(
+          this.config.icons,
+          this.serverBaseUrl,
+          this.basePath
+        ),
       },
       {
         capabilities: {
@@ -3725,21 +3732,13 @@ class MCPServerClass<HasOAuth extends boolean = false> {
 
   /**
    * Run the shared mount sequence used by both `listen()` and `getHandler()`:
-   * OAuth setup (if configured) → widgets → MCP transport → inspector. Each
-   * step internally guards against double-mounting, so it's safe to call this
-   * more than once across the same lifecycle.
+   * widgets → MCP transport → inspector. Each step internally guards
+   * against double-mounting, so it's safe to call this more than once
+   * across the same lifecycle. (OAuth is mounted up front in the
+   * constructor — its `.well-known/*` routes need the un-prefixed root
+   * handle, which only exists during construction.)
    */
   private async _setupAndMount(): Promise<void> {
-    if (this.oauthProvider && !this.oauthSetupState.complete) {
-      await setupOAuthForServer(
-        this._rootApp,
-        this.oauthProvider,
-        this.getServerBaseUrl(),
-        this.oauthSetupState,
-        this.basePath
-      );
-    }
-
     await mountWidgets(this as any, {
       baseRoute: "/_mcp-use/widgets",
       // Only forward `resourcesDir` when the env var is set. That lets
@@ -3952,11 +3951,12 @@ class MCPServerClass<HasOAuth extends boolean = false> {
     // Track server run event
     this._trackServerRun("http");
 
-    // Start server using runtime-aware helper. Serve from `_rootApp` so the
-    // outer Hono (with global middleware) receives all requests; routes
-    // registered via `this.app.basePath()` are already on the same router.
+    // Start server using runtime-aware helper. `this.app` is the basePath
+    // clone but its router/routes array is shared with the un-prefixed root
+    // view used inside the constructor for OAuth `.well-known/*`, so its
+    // fetch dispatches both prefixed and root-level routes.
     const httpHandle = await startServer(
-      this._rootApp,
+      this.app,
       this.serverPort,
       this.serverHost,
       {
@@ -4042,9 +4042,11 @@ class MCPServerClass<HasOAuth extends boolean = false> {
     const provider = options?.provider || "fetch";
     this._trackServerRun(provider);
 
-    // Serve from `_rootApp` so global middleware runs; basePath-prefixed
-    // routes registered via `this.app` share the same underlying router.
-    const fetchHandler = this._rootApp.fetch.bind(this._rootApp);
+    // `this.app` is the basePath clone but shares its router/routes array
+    // with the un-prefixed root view used during construction (for OAuth
+    // `.well-known/*`), so its fetch handles both prefixed and root-level
+    // routes.
+    const fetchHandler = this.app.fetch.bind(this.app);
 
     // Handle platform-specific path rewriting and CORS
     if (options?.provider === "supabase") {

--- a/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
@@ -11,7 +11,7 @@ import type {
   CreateMessageResult,
 } from "@modelcontextprotocol/sdk/types.js";
 import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
-import { Hono, type Hono as HonoType } from "hono";
+import type { Hono as HonoType } from "hono";
 import { z } from "zod";
 import { Telemetry } from "../telemetry/telemetry-node.js";
 import { getPackageVersion } from "../version.js";
@@ -271,13 +271,16 @@ class MCPServerClass<HasOAuth extends boolean = false> {
   public app: HonoType;
 
   /**
-   * @internal Outer Hono that actually receives HTTP requests. When `basePath`
-   * is set, `app` is sub-mounted on this under the prefix and global
-   * middleware (CORS, host validation, request logging) lives here so it
-   * runs before route matching. When `basePath` is unset, `_rootApp === app`.
+   * @internal The underlying Hono instance. Receives HTTP requests and holds
+   * global middleware (CORS, host validation, request logging) plus routes
+   * that must stay at the host root (`/favicon.ico`, `/.well-known/*`,
+   * `/_mcp-use/*`).
    *
-   * Always use `_rootApp` for: serving HTTP, registering routes that must
-   * stay at root (e.g. `/favicon.ico`), and applying global middleware.
+   * `this.app` is either `_rootApp` directly (no basePath) or a Hono
+   * `basePath()` clone of it (with basePath). The clone shares this
+   * instance's router and routes array, so route registrations on
+   * `this.app` end up on the same router as `_rootApp` — just with the
+   * basePath prefix prepended at registration time.
    */
   private _rootApp!: HonoType;
 
@@ -2380,8 +2383,8 @@ class MCPServerClass<HasOAuth extends boolean = false> {
       console.log(`[MCP] Auto-selected favicon from icons: ${this.favicon}`);
     }
 
-    // Helper to convert relative icon paths to absolute URLs
-    const basePathForIcons = this.basePath;
+    // Helper to convert relative icon paths to absolute URLs.
+    // Public assets are served at `/_mcp-use/public/` (basePath-agnostic).
     const processIconUrls = (
       icons: ServerConfig["icons"],
       baseUrl?: string
@@ -2391,7 +2394,7 @@ class MCPServerClass<HasOAuth extends boolean = false> {
         ...icon,
         src: icon.src.startsWith("http")
           ? icon.src
-          : `${baseUrl}${basePathForIcons}/mcp-use/public/${icon.src}`,
+          : `${baseUrl}/_mcp-use/public/${icon.src}`,
       }));
     };
 
@@ -2423,35 +2426,27 @@ class MCPServerClass<HasOAuth extends boolean = false> {
       }
     );
 
-    // Create the outer Hono with global middleware (CORS, host validation,
-    // request logging). When `basePath` is set, the user-facing `this.app`
-    // is a separate inner Hono that gets sub-mounted under the prefix
-    // later — at listen() / getHandler() time, after all internal and
-    // user routes have been added. The deferred mount is required because
-    // Hono's `app.route(path, subApp)` snapshots the sub-app's routes at
-    // call time; routes added to the sub-app after that don't propagate.
-    // When `basePath` is unset, inner and outer are the same instance —
-    // zero overhead, identical to legacy behavior.
+    // Single Hono instance. Global middleware (CORS, host validation,
+    // request logging) lives here. When `basePath` is set, `this.app` is a
+    // `.basePath()` clone — same underlying router, but route registrations
+    // automatically get the prefix prepended. No sub-mounting, no deferred
+    // route-snapshot dance.
     this._rootApp = createHonoApp(createRequestLogger(this.basePath), {
       cors: this.config.cors,
       allowedOrigins: this.config.allowedOrigins,
     });
 
-    if (this.basePath) {
-      this.app = new Hono();
-    } else {
-      this.app = this._rootApp;
-    }
-
-    this.setupServerInfoRoute();
+    this.app = this.basePath
+      ? this._rootApp.basePath(this.basePath)
+      : this._rootApp;
 
     // Install the custom routes middleware FIRST (before any other routes).
     // This single middleware dispatches from the mutable _customRoutes map,
     // enabling HMR for custom HTTP routes (server.get(), server.post(), etc.)
     // without hitting Hono's "matcher already built" error. Registered on
-    // the inner app so user routes auto-prefix under `basePath`. The
-    // dispatcher strips the prefix from `c.req.path` so user keys stay
-    // bare (e.g. `server.get("/foo")` is reachable at `${basePath}/foo`).
+    // `this.app` so it auto-prefixes under `basePath`; the dispatcher strips
+    // the prefix from `c.req.path` so user keys stay bare (e.g.
+    // `server.get("/foo")` is reachable at `${basePath}/foo`).
     // See: https://github.com/honojs/hono/issues/3817
     installCustomRoutesMiddleware(
       this.app,
@@ -2460,9 +2455,9 @@ class MCPServerClass<HasOAuth extends boolean = false> {
     );
 
     // Setup public routes immediately if icons/favicon are configured.
-    // Public assets register on the inner app (auto-prefixed); favicon
-    // additionally registers at root on `_rootApp` so browsers' implicit
-    // `GET /favicon.ico` resolves regardless of basePath.
+    // Public assets register on `this.app` (auto-prefixed); favicon
+    // registers on `_rootApp` so browsers' implicit `GET /favicon.ico`
+    // resolves regardless of basePath.
     if (
       (this.favicon || this.config.icons) &&
       !isProductionModeHelper() &&
@@ -2677,8 +2672,8 @@ class MCPServerClass<HasOAuth extends boolean = false> {
    * @param sessionId - Optional session ID to store registered refs for hot reload support
    */
   public getServerForSession(sessionId?: string): OfficialMcpServer {
-    // Helper to convert relative icon paths to absolute URLs
-    const basePathForIcons = this.basePath;
+    // Helper to convert relative icon paths to absolute URLs.
+    // Public assets live at `/_mcp-use/public/` regardless of basePath.
     const processIconUrls = (
       icons: ServerConfig["icons"],
       baseUrl?: string
@@ -2688,7 +2683,7 @@ class MCPServerClass<HasOAuth extends boolean = false> {
         ...icon,
         src: icon.src.startsWith("http")
           ? icon.src
-          : `${baseUrl}${basePathForIcons}/mcp-use/public/${icon.src}`,
+          : `${baseUrl}/_mcp-use/public/${icon.src}`,
       }));
     };
 
@@ -3758,52 +3753,6 @@ class MCPServerClass<HasOAuth extends boolean = false> {
   }
 
   /**
-   * Track whether the inner app has been sub-mounted on `_rootApp`. Hono's
-   * `route(path, subApp)` snapshots routes at call time, so we defer this
-   * until all internal + user routes have been registered.
-   * @internal
-   */
-  private _innerAppMounted = false;
-
-  /**
-   * Root-level discovery endpoint for CLI/dev tooling. This intentionally
-   * lives on `_rootApp` instead of `this.app` so it remains available at a
-   * stable, unprefixed path even when the server is configured with
-   * `basePath`.
-   * @internal
-   */
-  private setupServerInfoRoute(): void {
-    this._rootApp.get("/__mcp-use/serverinfo", (c) => {
-      const origin = new URL(c.req.url).origin;
-      return c.json({
-        basePath: this.basePath,
-        mcpPath: `${this.basePath}/mcp`,
-        inspectorPath: `${this.basePath}/inspector`,
-        mcpUrl: `${origin}${this.basePath}/mcp`,
-        inspectorUrl: `${origin}${this.basePath}/inspector`,
-      });
-    });
-  }
-
-  /**
-   * Sub-mount the inner app under `basePath` on `_rootApp`. Must be called
-   * once, after every route the server cares about has been registered on
-   * `this.app` (MCP transport, OAuth, widgets, inspector, user routes).
-   * No-op when `basePath` is unset (inner and outer are already the same
-   * instance) or when already mounted.
-   * @internal
-   */
-  private _finalizeRouteMount(): void {
-    if (this._innerAppMounted) return;
-    if (!this.basePath) {
-      this._innerAppMounted = true;
-      return;
-    }
-    this._rootApp.route(this.basePath, this.app);
-    this._innerAppMounted = true;
-  }
-
-  /**
    * Starts the HTTP server and begins listening for connections.
    *
    * This method is the primary way to run an MCP server as a standalone HTTP service.
@@ -3979,7 +3928,7 @@ class MCPServerClass<HasOAuth extends boolean = false> {
     // Setup OAuth before mounting widgets/MCP (if configured)
     if (this.oauthProvider && !this.oauthSetupState.complete) {
       await setupOAuthForServer(
-        this.app,
+        this._rootApp,
         this.oauthProvider,
         this.getServerBaseUrl(),
         this.oauthSetupState,
@@ -3988,7 +3937,7 @@ class MCPServerClass<HasOAuth extends boolean = false> {
     }
 
     await mountWidgets(this as any, {
-      baseRoute: "/mcp-use/widgets",
+      baseRoute: "/_mcp-use/widgets",
       // Only forward `resourcesDir` when the env var is set. That lets
       // @mcp-use/cli steer widget discovery to e.g. `src/mcp/resources`
       // (via `--mcp-dir src/mcp`) without forcing the user to configure
@@ -4024,15 +3973,9 @@ class MCPServerClass<HasOAuth extends boolean = false> {
     // Track server run event
     this._trackServerRun("http");
 
-    // Finalize the sub-mount now that all internal and user routes are
-    // registered on `this.app`. Hono snapshots sub-app routes at
-    // `route()` time, so this has to happen after `mountMcp`, `mountWidgets`,
-    // `mountInspector`, and any user code that called `server.app.use/get`.
-    this._finalizeRouteMount();
-
     // Start server using runtime-aware helper. Serve from `_rootApp` so the
-    // outer Hono (with global middleware) receives all requests and the
-    // sub-mount under `basePath` dispatches user/MCP routes correctly.
+    // outer Hono (with global middleware) receives all requests; routes
+    // registered via `this.app.basePath()` are already on the same router.
     const httpHandle = await startServer(
       this._rootApp,
       this.serverPort,
@@ -4118,7 +4061,7 @@ class MCPServerClass<HasOAuth extends boolean = false> {
     // Setup OAuth before mounting widgets/MCP (if configured)
     if (this.oauthProvider && !this.oauthSetupState.complete) {
       await setupOAuthForServer(
-        this.app,
+        this._rootApp,
         this.oauthProvider,
         this.getServerBaseUrl(),
         this.oauthSetupState,
@@ -4128,7 +4071,7 @@ class MCPServerClass<HasOAuth extends boolean = false> {
 
     console.log("[MCP] Mounting widgets");
     await mountWidgets(this as any, {
-      baseRoute: "/mcp-use/widgets",
+      baseRoute: "/_mcp-use/widgets",
       // Only forward `resourcesDir` when the env var is set. That lets
       // @mcp-use/cli steer widget discovery to e.g. `src/mcp/resources`
       // (via `--mcp-dir src/mcp`) without forcing the user to configure
@@ -4148,15 +4091,8 @@ class MCPServerClass<HasOAuth extends boolean = false> {
     const provider = options?.provider || "fetch";
     this._trackServerRun(provider);
 
-    // Finalize the sub-mount now that all internal routes are registered.
-    // Same rationale as listen(): Hono snapshots sub-app routes at
-    // `route()` time, so the call has to happen after MCP/widgets/inspector
-    // mounting completes.
-    this._finalizeRouteMount();
-
-    // Wrap the fetch handler to ensure it always returns a Promise<Response>.
-    // Serve from `_rootApp` so global middleware runs and the sub-mount at
-    // `basePath` dispatches correctly when configured.
+    // Serve from `_rootApp` so global middleware runs; basePath-prefixed
+    // routes registered via `this.app` share the same underlying router.
     const fetchHandler = this._rootApp.fetch.bind(this._rootApp);
 
     // Handle platform-specific path rewriting and CORS

--- a/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
@@ -93,6 +93,7 @@ import {
   logRegisteredItems as logRegisteredItemsHelper,
   normalizeBasePath,
   parseTemplateUri as parseTemplateUriHelper,
+  resolveIconUrls,
   rewriteSupabaseRequest,
   startServer,
 } from "./utils/index.js";
@@ -2383,21 +2384,6 @@ class MCPServerClass<HasOAuth extends boolean = false> {
       console.log(`[MCP] Auto-selected favicon from icons: ${this.favicon}`);
     }
 
-    // Helper to convert relative icon paths to absolute URLs.
-    // Public assets are served at `/_mcp-use/public/` (basePath-agnostic).
-    const processIconUrls = (
-      icons: ServerConfig["icons"],
-      baseUrl?: string
-    ) => {
-      if (!icons || !baseUrl) return icons;
-      return icons.map((icon) => ({
-        ...icon,
-        src: icon.src.startsWith("http")
-          ? icon.src
-          : `${baseUrl}/_mcp-use/public/${icon.src}`,
-      }));
-    };
-
     // Create native SDK server instance with capabilities
     this.nativeServer = new OfficialMcpServer(
       {
@@ -2406,7 +2392,7 @@ class MCPServerClass<HasOAuth extends boolean = false> {
         description: config.description,
         title: config.title,
         websiteUrl: config.websiteUrl,
-        icons: processIconUrls(config.icons, config.baseUrl),
+        icons: resolveIconUrls(config.icons, config.baseUrl),
       },
       {
         capabilities: {
@@ -2672,21 +2658,6 @@ class MCPServerClass<HasOAuth extends boolean = false> {
    * @param sessionId - Optional session ID to store registered refs for hot reload support
    */
   public getServerForSession(sessionId?: string): OfficialMcpServer {
-    // Helper to convert relative icon paths to absolute URLs.
-    // Public assets live at `/_mcp-use/public/` regardless of basePath.
-    const processIconUrls = (
-      icons: ServerConfig["icons"],
-      baseUrl?: string
-    ) => {
-      if (!icons || !baseUrl) return icons;
-      return icons.map((icon) => ({
-        ...icon,
-        src: icon.src.startsWith("http")
-          ? icon.src
-          : `${baseUrl}/_mcp-use/public/${icon.src}`,
-      }));
-    };
-
     const newServer = new OfficialMcpServer(
       {
         name: this.config.name,
@@ -2694,7 +2665,7 @@ class MCPServerClass<HasOAuth extends boolean = false> {
         description: this.config.description,
         title: this.config.title,
         websiteUrl: this.config.websiteUrl,
-        icons: processIconUrls(this.config.icons, this.serverBaseUrl),
+        icons: resolveIconUrls(this.config.icons, this.serverBaseUrl),
       },
       {
         capabilities: {
@@ -3753,6 +3724,39 @@ class MCPServerClass<HasOAuth extends boolean = false> {
   }
 
   /**
+   * Run the shared mount sequence used by both `listen()` and `getHandler()`:
+   * OAuth setup (if configured) → widgets → MCP transport → inspector. Each
+   * step internally guards against double-mounting, so it's safe to call this
+   * more than once across the same lifecycle.
+   */
+  private async _setupAndMount(): Promise<void> {
+    if (this.oauthProvider && !this.oauthSetupState.complete) {
+      await setupOAuthForServer(
+        this._rootApp,
+        this.oauthProvider,
+        this.getServerBaseUrl(),
+        this.oauthSetupState,
+        this.basePath
+      );
+    }
+
+    await mountWidgets(this as any, {
+      baseRoute: "/_mcp-use/widgets",
+      // Only forward `resourcesDir` when the env var is set. That lets
+      // @mcp-use/cli steer widget discovery to e.g. `src/mcp/resources`
+      // (via `--mcp-dir src/mcp`) without forcing the user to configure
+      // anything in their server file. When the env var is unset,
+      // `mountWidgets` applies its own default (`"resources"`).
+      ...(process.env.MCP_USE_WIDGETS_DIR
+        ? { resourcesDir: process.env.MCP_USE_WIDGETS_DIR }
+        : {}),
+    });
+    await this.mountMcp();
+    // Mount inspector BEFORE Vite middleware so it claims /inspector routes.
+    await this.mountInspector();
+  }
+
+  /**
    * Starts the HTTP server and begins listening for connections.
    *
    * This method is the primary way to run an MCP server as a standalone HTTP service.
@@ -3925,32 +3929,7 @@ class MCPServerClass<HasOAuth extends boolean = false> {
       this.serverPort
     );
 
-    // Setup OAuth before mounting widgets/MCP (if configured)
-    if (this.oauthProvider && !this.oauthSetupState.complete) {
-      await setupOAuthForServer(
-        this._rootApp,
-        this.oauthProvider,
-        this.getServerBaseUrl(),
-        this.oauthSetupState,
-        this.basePath
-      );
-    }
-
-    await mountWidgets(this as any, {
-      baseRoute: "/_mcp-use/widgets",
-      // Only forward `resourcesDir` when the env var is set. That lets
-      // @mcp-use/cli steer widget discovery to e.g. `src/mcp/resources`
-      // (via `--mcp-dir src/mcp`) without forcing the user to configure
-      // anything in their server file. When the env var is unset,
-      // `mountWidgets` applies its own default (`"resources"`).
-      ...(process.env.MCP_USE_WIDGETS_DIR
-        ? { resourcesDir: process.env.MCP_USE_WIDGETS_DIR }
-        : {}),
-    });
-    await this.mountMcp();
-
-    // Mount inspector BEFORE Vite middleware to ensure it handles /inspector routes
-    await this.mountInspector();
+    await this._setupAndMount();
 
     // Log registered items before starting server
     this.logRegisteredItems();
@@ -4058,35 +4037,7 @@ class MCPServerClass<HasOAuth extends boolean = false> {
   async getHandler(options?: {
     provider?: "supabase" | "cloudflare" | "deno-deploy";
   }): Promise<(req: Request) => Promise<Response>> {
-    // Setup OAuth before mounting widgets/MCP (if configured)
-    if (this.oauthProvider && !this.oauthSetupState.complete) {
-      await setupOAuthForServer(
-        this._rootApp,
-        this.oauthProvider,
-        this.getServerBaseUrl(),
-        this.oauthSetupState,
-        this.basePath
-      );
-    }
-
-    console.log("[MCP] Mounting widgets");
-    await mountWidgets(this as any, {
-      baseRoute: "/_mcp-use/widgets",
-      // Only forward `resourcesDir` when the env var is set. That lets
-      // @mcp-use/cli steer widget discovery to e.g. `src/mcp/resources`
-      // (via `--mcp-dir src/mcp`) without forcing the user to configure
-      // anything in their server file. When the env var is unset,
-      // `mountWidgets` applies its own default (`"resources"`).
-      ...(process.env.MCP_USE_WIDGETS_DIR
-        ? { resourcesDir: process.env.MCP_USE_WIDGETS_DIR }
-        : {}),
-    });
-    console.log("[MCP] Mounted widgets");
-    await this.mountMcp();
-    console.log("[MCP] Mounted MCP");
-    console.log("[MCP] Mounting inspector");
-    await this.mountInspector();
-    console.log("[MCP] Mounted inspector");
+    await this._setupAndMount();
 
     const provider = options?.provider || "fetch";
     this._trackServerRun(provider);

--- a/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
@@ -41,7 +41,7 @@ import { toResourceTemplateCompleteCallbacks } from "./utils/completion-helpers.
 
 import { getRequestContext, runWithContext } from "./context-storage.js";
 import { mountMcp as mountMcpHelper } from "./endpoints/index.js";
-import { requestLogger } from "./logging.js";
+import { createRequestLogger } from "./logging.js";
 import {
   getActiveSessions,
   sendNotification,
@@ -2432,7 +2432,7 @@ class MCPServerClass<HasOAuth extends boolean = false> {
     // call time; routes added to the sub-app after that don't propagate.
     // When `basePath` is unset, inner and outer are the same instance —
     // zero overhead, identical to legacy behavior.
-    this._rootApp = createHonoApp(requestLogger, {
+    this._rootApp = createHonoApp(createRequestLogger(this.basePath), {
       cors: this.config.cors,
       allowedOrigins: this.config.allowedOrigins,
     });

--- a/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
@@ -11,7 +11,7 @@ import type {
   CreateMessageResult,
 } from "@modelcontextprotocol/sdk/types.js";
 import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
-import type { Hono as HonoType } from "hono";
+import { Hono, type Hono as HonoType } from "hono";
 import { z } from "zod";
 import { Telemetry } from "../telemetry/telemetry-node.js";
 import { getPackageVersion } from "../version.js";
@@ -95,7 +95,6 @@ import {
   parseTemplateUri as parseTemplateUriHelper,
   rewriteSupabaseRequest,
   startServer,
-  writeServerInfoFile,
 } from "./utils/index.js";
 import type { WithMcpUse } from "./utils/hono-proxy.js";
 import type {
@@ -270,6 +269,17 @@ class MCPServerClass<HasOAuth extends boolean = false> {
    * ```
    */
   public app: HonoType;
+
+  /**
+   * @internal Outer Hono that actually receives HTTP requests. When `basePath`
+   * is set, `app` is sub-mounted on this under the prefix and global
+   * middleware (CORS, host validation, request logging) lives here so it
+   * runs before route matching. When `basePath` is unset, `_rootApp === app`.
+   *
+   * Always use `_rootApp` for: serving HTTP, registering routes that must
+   * stay at root (e.g. `/favicon.ico`), and applying global middleware.
+   */
+  private _rootApp!: HonoType;
 
   /** @internal Whether MCP endpoints have been mounted */
   private mcpMounted = false;
@@ -2413,29 +2423,53 @@ class MCPServerClass<HasOAuth extends boolean = false> {
       }
     );
 
-    // Create and configure Hono app with default middleware
-    this.app = createHonoApp(requestLogger, {
+    // Create the outer Hono with global middleware (CORS, host validation,
+    // request logging). When `basePath` is set, the user-facing `this.app`
+    // is a separate inner Hono that gets sub-mounted under the prefix
+    // later — at listen() / getHandler() time, after all internal and
+    // user routes have been added. The deferred mount is required because
+    // Hono's `app.route(path, subApp)` snapshots the sub-app's routes at
+    // call time; routes added to the sub-app after that don't propagate.
+    // When `basePath` is unset, inner and outer are the same instance —
+    // zero overhead, identical to legacy behavior.
+    this._rootApp = createHonoApp(requestLogger, {
       cors: this.config.cors,
       allowedOrigins: this.config.allowedOrigins,
     });
 
+    if (this.basePath) {
+      this.app = new Hono();
+    } else {
+      this.app = this._rootApp;
+    }
+
+    this.setupServerInfoRoute();
+
     // Install the custom routes middleware FIRST (before any other routes).
     // This single middleware dispatches from the mutable _customRoutes map,
     // enabling HMR for custom HTTP routes (server.get(), server.post(), etc.)
-    // without hitting Hono's "matcher already built" error.
+    // without hitting Hono's "matcher already built" error. Registered on
+    // the inner app so user routes auto-prefix under `basePath`. The
+    // dispatcher strips the prefix from `c.req.path` so user keys stay
+    // bare (e.g. `server.get("/foo")` is reachable at `${basePath}/foo`).
     // See: https://github.com/honojs/hono/issues/3817
-    installCustomRoutesMiddleware(this.app, this._customRoutes);
+    installCustomRoutesMiddleware(
+      this.app,
+      this._customRoutes,
+      () => this.basePath
+    );
 
-    // Setup public routes immediately if icons/favicon are configured
-    // This ensures icons are served even before listen() or getHandler() is called
-    // Only set up dev routes if not in production mode - production routes will be set up later
+    // Setup public routes immediately if icons/favicon are configured.
+    // Public assets register on the inner app (auto-prefixed); favicon
+    // additionally registers at root on `_rootApp` so browsers' implicit
+    // `GET /favicon.ico` resolves regardless of basePath.
     if (
       (this.favicon || this.config.icons) &&
       !isProductionModeHelper() &&
       !isDeno
     ) {
-      setupPublicRoutes(this.app, false, this.basePath); // Dev mode (public/)
-      setupFaviconRoute(this.app, this.favicon, false, this.basePath);
+      setupPublicRoutes(this.app, false); // Dev mode (public/)
+      setupFaviconRoute(this._rootApp, this.favicon, false);
       this.publicRoutesMode = "dev";
     }
 
@@ -3724,6 +3758,52 @@ class MCPServerClass<HasOAuth extends boolean = false> {
   }
 
   /**
+   * Track whether the inner app has been sub-mounted on `_rootApp`. Hono's
+   * `route(path, subApp)` snapshots routes at call time, so we defer this
+   * until all internal + user routes have been registered.
+   * @internal
+   */
+  private _innerAppMounted = false;
+
+  /**
+   * Root-level discovery endpoint for CLI/dev tooling. This intentionally
+   * lives on `_rootApp` instead of `this.app` so it remains available at a
+   * stable, unprefixed path even when the server is configured with
+   * `basePath`.
+   * @internal
+   */
+  private setupServerInfoRoute(): void {
+    this._rootApp.get("/__mcp-use/serverinfo", (c) => {
+      const origin = new URL(c.req.url).origin;
+      return c.json({
+        basePath: this.basePath,
+        mcpPath: `${this.basePath}/mcp`,
+        inspectorPath: `${this.basePath}/inspector`,
+        mcpUrl: `${origin}${this.basePath}/mcp`,
+        inspectorUrl: `${origin}${this.basePath}/inspector`,
+      });
+    });
+  }
+
+  /**
+   * Sub-mount the inner app under `basePath` on `_rootApp`. Must be called
+   * once, after every route the server cares about has been registered on
+   * `this.app` (MCP transport, OAuth, widgets, inspector, user routes).
+   * No-op when `basePath` is unset (inner and outer are already the same
+   * instance) or when already mounted.
+   * @internal
+   */
+  private _finalizeRouteMount(): void {
+    if (this._innerAppMounted) return;
+    if (!this.basePath) {
+      this._innerAppMounted = true;
+      return;
+    }
+    this._rootApp.route(this.basePath, this.app);
+    this._innerAppMounted = true;
+  }
+
+  /**
    * Starts the HTTP server and begins listening for connections.
    *
    * This method is the primary way to run an MCP server as a standalone HTTP service.
@@ -3908,7 +3988,7 @@ class MCPServerClass<HasOAuth extends boolean = false> {
     }
 
     await mountWidgets(this as any, {
-      baseRoute: `${this.basePath}/mcp-use/widgets`,
+      baseRoute: "/mcp-use/widgets",
       // Only forward `resourcesDir` when the env var is set. That lets
       // @mcp-use/cli steer widget discovery to e.g. `src/mcp/resources`
       // (via `--mcp-dir src/mcp`) without forcing the user to configure
@@ -3944,18 +4024,17 @@ class MCPServerClass<HasOAuth extends boolean = false> {
     // Track server run event
     this._trackServerRun("http");
 
-    // Write a small machine-readable handoff so external tools (the CLI's
-    // auto-open, screenshot, etc.) can discover the configured basePath
-    // without parsing source. Best-effort — failures must not break startup.
-    await writeServerInfoFile({
-      host: this.serverHost,
-      port: this.serverPort,
-      basePath: this.basePath,
-    });
+    // Finalize the sub-mount now that all internal and user routes are
+    // registered on `this.app`. Hono snapshots sub-app routes at
+    // `route()` time, so this has to happen after `mountMcp`, `mountWidgets`,
+    // `mountInspector`, and any user code that called `server.app.use/get`.
+    this._finalizeRouteMount();
 
-    // Start server using runtime-aware helper
+    // Start server using runtime-aware helper. Serve from `_rootApp` so the
+    // outer Hono (with global middleware) receives all requests and the
+    // sub-mount under `basePath` dispatches user/MCP routes correctly.
     const httpHandle = await startServer(
-      this.app,
+      this._rootApp,
       this.serverPort,
       this.serverHost,
       {
@@ -4049,7 +4128,7 @@ class MCPServerClass<HasOAuth extends boolean = false> {
 
     console.log("[MCP] Mounting widgets");
     await mountWidgets(this as any, {
-      baseRoute: `${this.basePath}/mcp-use/widgets`,
+      baseRoute: "/mcp-use/widgets",
       // Only forward `resourcesDir` when the env var is set. That lets
       // @mcp-use/cli steer widget discovery to e.g. `src/mcp/resources`
       // (via `--mcp-dir src/mcp`) without forcing the user to configure
@@ -4069,8 +4148,16 @@ class MCPServerClass<HasOAuth extends boolean = false> {
     const provider = options?.provider || "fetch";
     this._trackServerRun(provider);
 
-    // Wrap the fetch handler to ensure it always returns a Promise<Response>
-    const fetchHandler = this.app.fetch.bind(this.app);
+    // Finalize the sub-mount now that all internal routes are registered.
+    // Same rationale as listen(): Hono snapshots sub-app routes at
+    // `route()` time, so the call has to happen after MCP/widgets/inspector
+    // mounting completes.
+    this._finalizeRouteMount();
+
+    // Wrap the fetch handler to ensure it always returns a Promise<Response>.
+    // Serve from `_rootApp` so global middleware runs and the sub-mount at
+    // `basePath` dispatches correctly when configured.
+    const fetchHandler = this._rootApp.fetch.bind(this._rootApp);
 
     // Handle platform-specific path rewriting and CORS
     if (options?.provider === "supabase") {

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/middleware.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/middleware.ts
@@ -12,12 +12,14 @@ import type { OAuthProvider, OAuthProxy } from "./providers/types.js";
  * Create bearer authentication middleware for a given OAuth provider or proxy
  *
  * @param oauth - The OAuth provider or proxy to use for token verification
- * @param baseUrl - The base URL of the server (for WWW-Authenticate header)
+ * @param getBaseUrl - Lazy getter for the server base URL (for WWW-Authenticate header).
+ *                    Called per-request so callers can defer resolution until after
+ *                    the HTTP listener has bound a port.
  * @returns Hono middleware function
  */
 export function createBearerAuthMiddleware(
   oauth: OAuthProvider | OAuthProxy,
-  baseUrl?: string
+  getBaseUrl?: () => string | undefined
 ) {
   return async (c: Context, next: Next) => {
     // Allow HEAD requests through without auth - used for health checks/keep-alive
@@ -30,7 +32,7 @@ export function createBearerAuthMiddleware(
     // Build WWW-Authenticate header for 401 responses
     // This enables MCP clients to discover the OAuth configuration
     const getWWWAuthenticateHeader = () => {
-      const base = baseUrl || new URL(c.req.url).origin;
+      const base = getBaseUrl?.() || new URL(c.req.url).origin;
       const parts = [
         'Bearer error="unauthorized"',
         'error_description="Authorization needed"',

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/middleware.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/middleware.ts
@@ -15,11 +15,18 @@ import type { OAuthProvider, OAuthProxy } from "./providers/types.js";
  * @param getBaseUrl - Lazy getter for the server base URL (for WWW-Authenticate header).
  *                    Called per-request so callers can defer resolution until after
  *                    the HTTP listener has bound a port.
+ * @param basePath - Optional externally-visible prefix the server is mounted under
+ *                   (e.g. "/api"). Used to construct the path-aware
+ *                   `resource_metadata` URL per RFC 9728 §3.1, which inserts
+ *                   `/.well-known/oauth-protected-resource` between host and
+ *                   resource path — so the MCP endpoint at `<host><basePath>/mcp`
+ *                   has metadata at `<host>/.well-known/oauth-protected-resource<basePath>/mcp`.
  * @returns Hono middleware function
  */
 export function createBearerAuthMiddleware(
   oauth: OAuthProvider | OAuthProxy,
-  getBaseUrl?: () => string | undefined
+  getBaseUrl?: () => string | undefined,
+  basePath: string = ""
 ) {
   return async (c: Context, next: Next) => {
     // Allow HEAD requests through without auth - used for health checks/keep-alive
@@ -38,9 +45,13 @@ export function createBearerAuthMiddleware(
         'error_description="Authorization needed"',
       ];
 
-      // Add resource_metadata for OAuth discovery (MCP spec)
+      // Path-aware resource_metadata URL per RFC 9728 §3.1: the metadata URL
+      // is built by inserting `/.well-known/oauth-protected-resource` between
+      // host and the resource path. The protected resource here is the MCP
+      // transport endpoint at `<basePath>/mcp`. The matching route is
+      // registered in routes.ts (`/.well-known/oauth-protected-resource<basePath>/mcp`).
       parts.push(
-        `resource_metadata="${base}/.well-known/oauth-protected-resource"`
+        `resource_metadata="${base}/.well-known/oauth-protected-resource${basePath}/mcp"`
       );
 
       return parts.join(", ");

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/providers.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/providers.ts
@@ -12,6 +12,7 @@ import { ClerkOAuthProvider } from "./providers/clerk.js";
 import { KeycloakOAuthProvider } from "./providers/keycloak.js";
 import { WorkOSOAuthProvider } from "./providers/workos.js";
 import { BetterAuthOAuthProvider } from "./providers/better-auth.js";
+import type { BetterAuthInstance } from "./providers/types.js";
 import { CustomOAuthProvider } from "./providers/custom.js";
 import type { UserInfo } from "./providers/types.js";
 import { getEnv } from "../utils/runtime.js";
@@ -398,7 +399,7 @@ export function oauthClerkProvider(
 }
 
 /**
- * Configuration for Better Auth OAuth provider
+ * Configuration for Better Auth OAuth provider (external mode).
  */
 export interface BetterAuthProviderConfig {
   authURL: string;
@@ -410,46 +411,80 @@ export interface BetterAuthProviderConfig {
 }
 
 /**
- * Create a Better Auth OAuth provider
+ * Type guard for distinguishing a Better Auth instance from a config object.
  *
- * MCP clients discover Better Auth's OAuth endpoints via `.well-known`
- * passthrough and communicate directly with Better Auth for registration,
- * authorization, and token exchange. The MCP server only verifies tokens
- * and provides metadata.
+ * A Better Auth instance exposes `handler` (the request handler) and `options`
+ * (the configuration object). Plain config objects don't have these shapes.
+ */
+function isBetterAuthInstance(arg: unknown): arg is BetterAuthInstance {
+  return (
+    typeof arg === "object" &&
+    arg !== null &&
+    typeof (arg as { handler?: unknown }).handler === "function" &&
+    typeof (arg as { options?: unknown }).options === "object"
+  );
+}
+
+/**
+ * Create a Better Auth OAuth provider.
  *
- * Better Auth's OAuth Provider plugin exposes standard OAuth 2.0 endpoints:
- * - /oauth2/authorize - Authorization endpoint
- * - /oauth2/token - Token endpoint
- * - /oauth2/register - Dynamic Client Registration
- * - /jwks - JSON Web Key Set for token verification
+ * Two modes, distinguished by the argument shape:
  *
- * Environment variables:
- * - MCP_USE_OAUTH_BETTER_AUTH_URL (required)
+ * **In-process** — pass the Better Auth instance directly. The SDK mounts
+ * Better Auth's API handler under the MCPServer's basePath, serves OAuth
+ * discovery metadata locally (synthesized from `auth.api.getOAuthServerConfig`),
+ * and verifies tokens against Better Auth's JWKS. Set `auth.options.baseURL`
+ * to the externally-visible URL (including any MCPServer basePath).
  *
- * @param config - Optional Better Auth configuration (overrides environment variables)
- * @returns OAuthProvider instance
- *
- * @example
  * ```typescript
+ * import { betterAuth } from "better-auth";
+ * import { oauthProvider } from "@better-auth/oauth-provider";
+ *
+ * const auth = betterAuth({
+ *   baseURL: "http://localhost:3000/mcp-server",
+ *   plugins: [oauthProvider({ ... })],
+ *   // ...
+ * });
+ *
  * const server = new MCPServer({
- *   name: 'my-server',
- *   version: '1.0.0',
- *   oauth: oauthBetterAuthProvider({
- *     authURL: 'http://localhost:3000/api/auth'
- *   })
+ *   basePath: "/mcp-server",
+ *   oauth: oauthBetterAuthProvider(auth),
  * });
  * ```
  *
+ * **External** — pass a config object with `authURL` for a Better Auth
+ * deployment running on a separate origin. The SDK only verifies tokens; you
+ * mount Better Auth's routes yourself on the other origin.
+ *
+ * ```typescript
+ * oauthBetterAuthProvider({ authURL: "https://auth.example.com/api/auth" })
+ * ```
+ *
+ * Environment variable: `MCP_USE_OAUTH_BETTER_AUTH_URL` is consulted only in
+ * external mode when neither argument is provided.
+ *
+ * @param arg - Either a Better Auth instance (in-process) or `{ authURL }` (external).
+ * @returns OAuthProvider instance
  */
 export function oauthBetterAuthProvider(
-  config: Partial<BetterAuthProviderConfig> = {}
+  arg: BetterAuthInstance | Partial<BetterAuthProviderConfig> = {}
 ): OAuthProvider {
+  if (isBetterAuthInstance(arg)) {
+    return new BetterAuthOAuthProvider({
+      provider: "better-auth",
+      auth: arg,
+    });
+  }
+
+  const config = arg;
   const authURL = config.authURL ?? getEnv("MCP_USE_OAUTH_BETTER_AUTH_URL");
 
   if (!authURL) {
     throw new Error(
-      "Better Auth authURL is required. " +
-        "Set MCP_USE_OAUTH_BETTER_AUTH_URL environment variable or pass authURL in config."
+      "Better Auth OAuth provider requires either a Better Auth instance " +
+        "(in-process mode) or `authURL` (external mode). For external mode, " +
+        "set the `MCP_USE_OAUTH_BETTER_AUTH_URL` environment variable or pass " +
+        "`{ authURL }` in the config."
     );
   }
 

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/providers/better-auth.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/providers/better-auth.ts
@@ -1,39 +1,168 @@
 /**
  * Better Auth OAuth Provider
  *
- * Implements OAuth authentication for Better Auth instances using the
- * OAuth Provider plugin. MCP clients discover Better Auth's OAuth
- * endpoints via `.well-known` passthrough and communicate directly with
- * Better Auth for registration, authorization, and token exchange. The
- * MCP server only verifies tokens issued by Better Auth.
+ * Two modes, distinguished by what you pass at construction:
+ *
+ * - **In-process** (`{ auth }`): The SDK mounts Better Auth's API handler on
+ *   the MCP server's root Hono app and serves OAuth discovery metadata
+ *   (`.well-known/oauth-authorization-server`, `/.well-known/openid-configuration`)
+ *   itself by delegating to `auth.api.getOAuthServerConfig` /
+ *   `auth.api.getOpenIdConfig`. The well-known endpoints land at the literal
+ *   host root regardless of MCPServer basePath, and the path-insertion
+ *   variants (RFC 8414 §3.1) are registered at the issuer's pathname — so a
+ *   server with basePath `/mcp-server` and Better Auth at `/mcp-server/api/auth`
+ *   produces `/.well-known/oauth-authorization-server/mcp-server/api/auth`.
+ *
+ * - **External** (`{ authURL }`): Better Auth runs on a separate origin. The
+ *   SDK only verifies tokens (via JWKS); discovery and the OAuth flow are
+ *   proxied/passed through.
  *
  * Learn more: https://better-auth.com/docs/plugins/oauth-provider
  */
 
+import type { Hono as HonoType } from "hono";
 import { jwtVerify, createRemoteJWKSet, decodeJwt } from "jose";
 import type {
+  BetterAuthInstance,
+  BetterAuthOAuthConfig,
   OAuthProvider,
   UserInfo,
-  BetterAuthOAuthConfig,
 } from "./types.js";
+
+const METADATA_CACHE_CONTROL =
+  "public, max-age=15, stale-while-revalidate=15, stale-if-error=86400";
+
+const CORS_HEADERS: Record<string, string> = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+};
+
+function metadataResponse(body: Record<string, unknown>): Response {
+  const headers = new Headers(CORS_HEADERS);
+  headers.set("Cache-Control", METADATA_CACHE_CONTROL);
+  headers.set("Content-Type", "application/json");
+  return new Response(JSON.stringify(body), { status: 200, headers });
+}
+
+function stripTrailingSlash(s: string): string {
+  return s.replace(/\/+$/, "");
+}
+
+/**
+ * Mirror Better Auth's own baseURL resolution (`utils/url.ts → withPath`):
+ * if `baseURL` already has a path, leave it alone; otherwise append
+ * `basePath` (default `/api/auth`). This is what Better Auth uses for
+ * `ctx.context.baseURL` — the value it signs into tokens as `iss` and
+ * substitutes into every advertised endpoint URL — so the SDK must derive
+ * the same value or token verification and route mounting silently drift
+ * apart.
+ */
+function resolveBetterAuthBaseURL(
+  baseURL: string,
+  basePath: string | undefined
+): string {
+  const trimmedBase = stripTrailingSlash(baseURL);
+  let hasPath = false;
+  try {
+    hasPath = stripTrailingSlash(new URL(trimmedBase).pathname) !== "";
+  } catch {
+    // Malformed URL — fall through and let `new URL(...)` later surface the
+    // error with its native message rather than swallowing it here.
+  }
+  if (hasPath) return trimmedBase;
+  const path = basePath ?? "/api/auth";
+  if (!path || path === "/") return trimmedBase;
+  const normalized = path.startsWith("/") ? path : `/${path}`;
+  return `${trimmedBase}${stripTrailingSlash(normalized)}`;
+}
 
 export class BetterAuthOAuthProvider implements OAuthProvider {
   private config: BetterAuthOAuthConfig;
-  private authURL: string;
+  private auth: BetterAuthInstance | undefined;
+  /** Full issuer URL, e.g. "http://localhost:3000/mcp-server/api/auth". */
   private issuer: string;
+  /** JWKS endpoint URL. Always `${issuer}/jwks` for Better Auth. */
   private jwksUrl: string;
+  /** Pathname of `issuer` (e.g. "/mcp-server/api/auth"); "" for host-root. */
+  private issuerPath: string;
   private jwks: ReturnType<typeof createRemoteJWKSet> | null = null;
+
+  // In-process hooks. Wired up in the constructor when `config.auth` is set;
+  // left undefined for external mode so `setupOAuthRoutes` falls back to its
+  // default upstream-fetch behavior.
+  authorizationServerMetadataHandler?: (req: Request) => Promise<Response>;
+  openIdConfigurationMetadataHandler?: (req: Request) => Promise<Response>;
+  installRoutes?: (rootApp: HonoType, basePath: string) => void;
 
   constructor(config: BetterAuthOAuthConfig) {
     this.config = config;
-    // Normalize authURL by stripping trailing slash
-    this.authURL = config.authURL.endsWith("/")
-      ? config.authURL.slice(0, -1)
-      : config.authURL;
-    // Better Auth sets iss to ctx.context.authURL (the full base URL including path)
-    this.issuer = this.authURL;
-    // Better Auth always exposes JWKS at /jwks
-    this.jwksUrl = `${this.authURL}/jwks`;
+    this.auth = config.auth;
+
+    if (config.auth) {
+      // In-process: derive the issuer the same way Better Auth resolves
+      // `ctx.context.baseURL` internally — see `resolveBetterAuthBaseURL`.
+      // The issuer is also where `auth.handler` listens (everything under
+      // it is routed to Better Auth), so the user should set
+      // `auth.options.baseURL` to the full externally-visible URL where
+      // they want Better Auth to live, e.g.
+      // `"http://localhost:3000/mcp-server/api/auth"`.
+      const baseURL = config.auth.options.baseURL;
+      if (!baseURL) {
+        throw new Error(
+          "Better Auth in-process mode requires `auth.options.baseURL` to be set " +
+            "to the externally-visible URL where Better Auth should live, " +
+            "e.g. 'http://localhost:3000/mcp-server/api/auth'."
+        );
+      }
+      this.issuer = resolveBetterAuthBaseURL(
+        baseURL,
+        config.auth.options.basePath
+      );
+    } else if (config.authURL) {
+      // External: trust the configured URL as the issuer.
+      this.issuer = stripTrailingSlash(config.authURL);
+    } else {
+      throw new Error(
+        "Better Auth OAuth provider requires either `auth` (in-process mode) " +
+          "or `authURL` (external mode)."
+      );
+    }
+
+    this.jwksUrl = `${this.issuer}/jwks`;
+    this.issuerPath = stripTrailingSlash(new URL(this.issuer).pathname);
+
+    // Wire up in-process hooks now that `this.auth`, `this.issuerPath`, etc.
+    // are populated. External mode leaves these undefined so the SDK falls
+    // back to fetching metadata from the upstream issuer.
+    if (this.auth) {
+      const auth = this.auth;
+      this.authorizationServerMetadataHandler = async (req) =>
+        metadataResponse(
+          await auth.api.getOAuthServerConfig({
+            request: req,
+            asResponse: false,
+          })
+        );
+      this.openIdConfigurationMetadataHandler = async (req) =>
+        metadataResponse(
+          await auth.api.getOpenIdConfig({
+            request: req,
+            asResponse: false,
+          })
+        );
+      this.installRoutes = (rootApp, _mcpBasePath) => {
+        // Mount Better Auth's API handler at the issuer's pathname on the
+        // root app. The issuer composes from `auth.options.baseURL` (which
+        // the user sets to include MCPServer's basePath) plus Better Auth's
+        // own basePath (default `/api/auth`). For the example with
+        // `baseURL: "http://localhost:3000/mcp-server"`, that's
+        // `/mcp-server/api/auth/*`.
+        const handlerPath = this.issuerPath || "";
+        rootApp.on(["GET", "POST"], `${handlerPath}/*`, (c) =>
+          auth.handler(c.req.raw)
+        );
+      };
+    }
   }
 
   private getJWKS(): ReturnType<typeof createRemoteJWKSet> {
@@ -43,15 +172,14 @@ export class BetterAuthOAuthProvider implements OAuthProvider {
     return this.jwks;
   }
 
-  async verifyToken(token: string): Promise<any> {
-    // Skip verification in development mode if configured
+  async verifyToken(
+    token: string
+  ): Promise<{ payload: Record<string, unknown> }> {
     if (this.config.verifyJwt === false) {
       console.warn("[Better Auth OAuth] ⚠️  JWT verification is disabled");
       console.warn(
         "[Better Auth OAuth]     Enable verifyJwt: true for production"
       );
-
-      // Decode without verification
       const parts = token.split(".");
       if (parts.length !== 3) {
         throw new Error("Invalid JWT format");
@@ -81,14 +209,11 @@ export class BetterAuthOAuthProvider implements OAuthProvider {
       email: payload.email as string | undefined,
       name: payload.name as string | undefined,
       picture: payload.picture as string | undefined,
-      // Better Auth doesn't include roles/permissions in access tokens by default,
-      // but they can be added via customAccessTokenClaims
       roles: (payload.roles as string[]) || [],
       permissions: (payload.permissions as string[]) || [],
       scopes: scope ? scope.split(" ") : [],
-      // Better Auth-specific claims
-      azp: payload.azp, // Authorized party (client ID)
-      sid: payload.sid, // Session ID
+      azp: payload.azp,
+      sid: payload.sid,
       email_verified: payload.email_verified,
     };
   }
@@ -98,11 +223,11 @@ export class BetterAuthOAuthProvider implements OAuthProvider {
   }
 
   getAuthEndpoint(): string {
-    return `${this.authURL}/oauth2/authorize`;
+    return `${this.issuer}/oauth2/authorize`;
   }
 
   getTokenEndpoint(): string {
-    return `${this.authURL}/oauth2/token`;
+    return `${this.issuer}/oauth2/token`;
   }
 
   getScopesSupported(): string[] {

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/providers/types.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/providers/types.ts
@@ -11,6 +11,8 @@
  * will reintroduce proxy-mode behavior in a future change.
  */
 
+import type { Hono as HonoType } from "hono";
+
 export interface OAuthProvider {
   /**
    * Verify and decode a JWT token
@@ -68,6 +70,42 @@ export interface OAuthProvider {
    * @returns The audience string, or undefined if not configured
    */
   getAudience?(): string | undefined;
+
+  /**
+   * Override the default `.well-known/oauth-authorization-server` handler.
+   *
+   * The default behavior fetches metadata from the upstream issuer. Providers
+   * running in-process (e.g. Better Auth mounted on the same Hono app) supply
+   * this hook to synthesize metadata from a local source instead — necessary
+   * when the issuer is on the same host but doesn't serve `.well-known/*`
+   * itself.
+   */
+  authorizationServerMetadataHandler?(
+    req: Request
+  ): Response | Promise<Response>;
+
+  /**
+   * Override the default `.well-known/openid-configuration` handler.
+   * Same semantics as {@link authorizationServerMetadataHandler}.
+   */
+  openIdConfigurationMetadataHandler?(
+    req: Request
+  ): Response | Promise<Response>;
+
+  /**
+   * Register provider-specific routes on the root Hono app after the SDK's
+   * default OAuth routes are installed.
+   *
+   * Used by in-process providers to mount their request handler (e.g.
+   * `auth.handler`) at the issuer path on the host root. The SDK's
+   * `.well-known/*` registrations live at the literal host root regardless of
+   * basePath, so providers can also use this hook to register additional
+   * discovery paths.
+   *
+   * @param rootApp - Un-prefixed root Hono app
+   * @param basePath - MCPServer basePath (empty string when not set)
+   */
+  installRoutes?(rootApp: HonoType, basePath: string): void;
 }
 
 /**
@@ -192,11 +230,48 @@ export interface ClerkOAuthConfig extends BaseOAuthConfig {
 }
 
 /**
- * Better Auth OAuth provider configuration
+ * Minimal shape required of a Better Auth instance for in-process mode.
+ *
+ * Better Auth's exported type is huge and generic over plugin configuration;
+ * we only need the runtime surface the SDK actually calls, so this stays
+ * structural and avoids a direct dependency on `better-auth` types.
+ */
+export interface BetterAuthInstance {
+  handler: (req: Request) => Response | Promise<Response>;
+  options: {
+    baseURL?: string;
+    basePath?: string;
+    [key: string]: unknown;
+  };
+  api: {
+    getOAuthServerConfig: (input: {
+      request: Request;
+      asResponse: false;
+    }) => Promise<Record<string, unknown>>;
+    getOpenIdConfig: (input: {
+      request: Request;
+      asResponse: false;
+    }) => Promise<Record<string, unknown>>;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+/**
+ * Better Auth OAuth provider configuration.
+ *
+ * Two mutually exclusive modes:
+ * - **In-process** (`auth`): SDK mounts Better Auth's handler at the
+ *   server's basePath and serves discovery metadata locally.
+ * - **External** (`authURL`): Better Auth runs on a separate origin; the SDK
+ *   only verifies tokens issued by it.
  */
 export interface BetterAuthOAuthConfig extends BaseOAuthConfig {
   provider: "better-auth";
-  authURL: string;
+  /** In-process mode: the Better Auth instance to mount. */
+  auth?: BetterAuthInstance;
+  /** External mode: full base URL of the remote Better Auth deployment. */
+  authURL?: string;
   verifyJwt?: boolean;
   getUserInfo?: (
     payload: Record<string, unknown>

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/routes.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/routes.ts
@@ -194,13 +194,15 @@ function createTokenHandler(
 export function setupOAuthRoutes(
   app: Hono,
   oauth: OAuthProvider | OAuthProxy,
-  baseUrl: string
+  baseUrl: string,
+  basePath: string = ""
 ): void {
   const proxyMode = isOAuthProxy(oauth);
+  const prefixedBaseUrl = `${baseUrl}${basePath}`;
   // Enable CORS for all OAuth-related endpoints
   // This is required for browser-based MCP clients to discover OAuth metadata
   app.use(
-    "/.well-known/*",
+    `${basePath}/.well-known/*`,
     cors({
       origin: "*", // Allow all origins for metadata discovery
       allowMethods: ["GET", "OPTIONS"],
@@ -214,7 +216,7 @@ export function setupOAuthRoutes(
   // In DCR-direct mode: dormant (clients reach upstream directly)
   // In proxy mode: active (handles OAuth flow through the proxy)
   app.use(
-    "/authorize",
+    `${basePath}/authorize`,
     cors({
       origin: "*",
       allowMethods: ["GET", "POST", "OPTIONS"],
@@ -223,7 +225,7 @@ export function setupOAuthRoutes(
     })
   );
   app.use(
-    "/token",
+    `${basePath}/token`,
     cors({
       origin: "*",
       allowMethods: ["POST", "OPTIONS"],
@@ -234,9 +236,9 @@ export function setupOAuthRoutes(
 
   // Mount /authorize and /token handlers
   const handleAuthorize = createAuthorizeHandler(oauth);
-  app.get("/authorize", handleAuthorize);
-  app.post("/authorize", handleAuthorize);
-  app.post("/token", createTokenHandler(oauth));
+  app.get(`${basePath}/authorize`, handleAuthorize);
+  app.post(`${basePath}/authorize`, handleAuthorize);
+  app.post(`${basePath}/token`, createTokenHandler(oauth));
 
   // In proxy mode, add /register endpoint that returns the configured clientId
   // This allows MCP clients to "register" even though the client is pre-registered
@@ -244,7 +246,7 @@ export function setupOAuthRoutes(
     const proxy = oauth as OAuthProxy;
 
     app.use(
-      "/register",
+      `${basePath}/register`,
       cors({
         origin: "*",
         allowMethods: ["POST", "OPTIONS"],
@@ -253,7 +255,7 @@ export function setupOAuthRoutes(
       })
     );
 
-    app.post("/register", async (c: Context) => {
+    app.post(`${basePath}/register`, async (c: Context) => {
       const body = await c.req.json().catch(() => ({}));
 
       // Return a fake registration response with the configured clientId
@@ -291,10 +293,10 @@ export function setupOAuthRoutes(
       console.log(`[OAuth] Returning proxy mode metadata`);
 
       return c.json({
-        issuer: baseUrl,
-        authorization_endpoint: `${baseUrl}/authorize`,
-        token_endpoint: `${baseUrl}/token`,
-        registration_endpoint: `${baseUrl}/register`,
+        issuer: prefixedBaseUrl,
+        authorization_endpoint: `${prefixedBaseUrl}/authorize`,
+        token_endpoint: `${prefixedBaseUrl}/token`,
+        registration_endpoint: `${prefixedBaseUrl}/register`,
         scopes_supported: oauth.getScopesSupported(),
         response_types_supported: ["code"],
         grant_types_supported: oauth.getGrantTypesSupported(),
@@ -345,11 +347,11 @@ export function setupOAuthRoutes(
 
   // Register the handler for both OAuth and OpenID Connect discovery endpoints
   app.get(
-    "/.well-known/oauth-authorization-server",
+    `${basePath}/.well-known/oauth-authorization-server`,
     handleAuthorizationServerMetadata
   );
   app.get(
-    "/.well-known/openid-configuration",
+    `${basePath}/.well-known/openid-configuration`,
     handleAuthorizationServerMetadata
   );
 
@@ -360,16 +362,16 @@ export function setupOAuthRoutes(
    * DCR-direct mode: Points to the actual OAuth provider.
    * Proxy mode: Points to the local server (which proxies to upstream).
    */
-  app.get("/.well-known/oauth-protected-resource", (c: Context) => {
+  app.get(`${basePath}/.well-known/oauth-protected-resource`, (c: Context) => {
     // In proxy mode, the authorization server is the local proxy
-    const authServer = proxyMode ? baseUrl : oauth.getIssuer();
+    const authServer = proxyMode ? prefixedBaseUrl : oauth.getIssuer();
 
     console.log(`[OAuth] Protected resource metadata request`);
-    console.log(`[OAuth]   - Resource: ${baseUrl}`);
+    console.log(`[OAuth]   - Resource: ${prefixedBaseUrl}`);
     console.log(`[OAuth]   - Authorization server: ${authServer}`);
 
     return c.json({
-      resource: baseUrl,
+      resource: prefixedBaseUrl,
       authorization_servers: [authServer],
       scopes_supported: oauth.getScopesSupported(),
       bearer_methods_supported: ["header"],
@@ -378,14 +380,17 @@ export function setupOAuthRoutes(
 
   // Path-scoped protected resource metadata per RFC 9728 — declares that the
   // `/mcp` path specifically is the protected resource.
-  app.get("/.well-known/oauth-protected-resource/mcp", (c: Context) => {
-    const authServer = proxyMode ? baseUrl : oauth.getIssuer();
+  app.get(
+    `${basePath}/.well-known/oauth-protected-resource/mcp`,
+    (c: Context) => {
+      const authServer = proxyMode ? prefixedBaseUrl : oauth.getIssuer();
 
-    return c.json({
-      resource: `${baseUrl}/mcp`,
-      authorization_servers: [authServer],
-      scopes_supported: oauth.getScopesSupported(),
-      bearer_methods_supported: ["header"],
-    });
-  });
+      return c.json({
+        resource: `${prefixedBaseUrl}/mcp`,
+        authorization_servers: [authServer],
+        scopes_supported: oauth.getScopesSupported(),
+        bearer_methods_supported: ["header"],
+      });
+    }
+  );
 }

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/routes.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/routes.ts
@@ -187,33 +187,49 @@ function createTokenHandler(
  * - POST /token - Forwards with injected credentials
  * - GET /.well-known/* - Synthesized metadata pointing to local endpoints
  *
- * @param app - The Hono application instance
+ * @param rootApp - The underlying Hono instance (un-prefixed root view)
  * @param oauth - The OAuth provider or proxy
  * @param baseUrl - The base URL of this server (for metadata)
+ * @param basePath - Optional prefix the server is mounted under (e.g. "/api")
  */
 export function setupOAuthRoutes(
-  app: Hono,
+  rootApp: Hono,
   oauth: OAuthProvider | OAuthProxy,
   baseUrl: string,
   basePath: string = ""
 ): void {
   const proxyMode = isOAuthProxy(oauth);
   // `baseUrl` is the server origin (no path); `basePath` is the externally-
-  // visible prefix the inner app is sub-mounted under. The combination is
-  // what goes into discovery metadata so clients land on the right paths.
-  // Route registrations themselves use bare paths — the sub-mount adds the
-  // prefix externally.
+  // visible prefix the server is mounted under. The combination is what
+  // goes into discovery metadata so clients land on the right paths.
+  // - /authorize, /token, /register live under `basePath` — registered on
+  //   a `.basePath()` clone so the prefix is prepended automatically.
+  // - .well-known/* discovery lives at the host root on `rootApp`. Per
+  //   RFC 8414 §3.1, the discovery URL is `<host>/.well-known/<type>` with
+  //   the issuer's path appended *after* the well-known segment — not
+  //   `<host>/<basePath>/.well-known/...`. Registering on `rootApp` makes
+  //   discovery basePath-agnostic for the same reason `/_mcp-use/*` is.
+  const app = basePath ? rootApp.basePath(basePath) : rootApp;
   const prefixedBaseUrl = `${baseUrl}${basePath}`;
-  // Enable CORS for all OAuth-related endpoints
-  // This is required for browser-based MCP clients to discover OAuth metadata
-  app.use(
-    "/.well-known/*",
+  // Enable CORS for all OAuth-related discovery endpoints on rootApp.
+  rootApp.use(
+    "/.well-known/oauth-*",
     cors({
       origin: "*", // Allow all origins for metadata discovery
       allowMethods: ["GET", "OPTIONS"],
       allowHeaders: ["Content-Type", "Authorization"],
       exposeHeaders: ["Content-Type"],
       maxAge: 86400, // Cache preflight for 24 hours
+    })
+  );
+  rootApp.use(
+    "/.well-known/openid-configuration*",
+    cors({
+      origin: "*",
+      allowMethods: ["GET", "OPTIONS"],
+      allowHeaders: ["Content-Type", "Authorization"],
+      exposeHeaders: ["Content-Type"],
+      maxAge: 86400,
     })
   );
 
@@ -350,15 +366,37 @@ export function setupOAuthRoutes(
     }
   };
 
-  // Register the handler for both OAuth and OpenID Connect discovery endpoints
-  app.get(
+  // Discovery URLs the SDK probes (see `buildDiscoveryUrls` in
+  // @modelcontextprotocol/sdk client/auth.js). The SDK tries the path-aware
+  // variant first (well-known segment with the issuer's path appended), then
+  // falls back to root. Register both so either probe wins.
+  //
+  // With `basePath: "/api"` and issuer `http://host/api`:
+  //   path-aware: GET /.well-known/oauth-authorization-server/api
+  //   root:       GET /.well-known/oauth-authorization-server
+  rootApp.get(
     "/.well-known/oauth-authorization-server",
     handleAuthorizationServerMetadata
   );
-  app.get(
+  rootApp.get(
     "/.well-known/openid-configuration",
     handleAuthorizationServerMetadata
   );
+  if (basePath) {
+    rootApp.get(
+      `/.well-known/oauth-authorization-server${basePath}`,
+      handleAuthorizationServerMetadata
+    );
+    rootApp.get(
+      `/.well-known/openid-configuration${basePath}`,
+      handleAuthorizationServerMetadata
+    );
+    // OIDC Discovery 1.0 style — well-known appended after the path.
+    rootApp.get(
+      `${basePath}/.well-known/openid-configuration`,
+      handleAuthorizationServerMetadata
+    );
+  }
 
   /**
    * OAuth Protected Resource Metadata
@@ -367,32 +405,45 @@ export function setupOAuthRoutes(
    * DCR-direct mode: Points to the actual OAuth provider.
    * Proxy mode: Points to the local server (which proxies to upstream).
    */
-  app.get("/.well-known/oauth-protected-resource", (c: Context) => {
-    // In proxy mode, the authorization server is the local proxy
+  const handleProtectedResourceMetadata = (c: Context) => {
     const authServer = proxyMode ? prefixedBaseUrl : oauth.getIssuer();
-
     console.log(`[OAuth] Protected resource metadata request`);
     console.log(`[OAuth]   - Resource: ${prefixedBaseUrl}`);
     console.log(`[OAuth]   - Authorization server: ${authServer}`);
-
     return c.json({
       resource: prefixedBaseUrl,
       authorization_servers: [authServer],
       scopes_supported: oauth.getScopesSupported(),
       bearer_methods_supported: ["header"],
     });
-  });
+  };
 
-  // Path-scoped protected resource metadata per RFC 9728 — declares that the
-  // `/mcp` path specifically is the protected resource.
-  app.get("/.well-known/oauth-protected-resource/mcp", (c: Context) => {
+  const handleProtectedResourceMetadataMcp = (c: Context) => {
     const authServer = proxyMode ? prefixedBaseUrl : oauth.getIssuer();
-
     return c.json({
       resource: `${prefixedBaseUrl}/mcp`,
       authorization_servers: [authServer],
       scopes_supported: oauth.getScopesSupported(),
       bearer_methods_supported: ["header"],
     });
-  });
+  };
+
+  rootApp.get(
+    "/.well-known/oauth-protected-resource",
+    handleProtectedResourceMetadata
+  );
+  // Path-scoped protected resource metadata per RFC 9728 — declares the MCP
+  // endpoint as the protected resource.
+  rootApp.get(
+    `/.well-known/oauth-protected-resource${basePath}/mcp`,
+    handleProtectedResourceMetadataMcp
+  );
+  if (basePath) {
+    // Also expose the basePath-scoped variant without the `/mcp` suffix, in
+    // case a client probes the issuer URL (`<host>/<basePath>`) directly.
+    rootApp.get(
+      `/.well-known/oauth-protected-resource${basePath}`,
+      handleProtectedResourceMetadata
+    );
+  }
 }

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/routes.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/routes.ts
@@ -198,11 +198,16 @@ export function setupOAuthRoutes(
   basePath: string = ""
 ): void {
   const proxyMode = isOAuthProxy(oauth);
+  // `baseUrl` is the server origin (no path); `basePath` is the externally-
+  // visible prefix the inner app is sub-mounted under. The combination is
+  // what goes into discovery metadata so clients land on the right paths.
+  // Route registrations themselves use bare paths — the sub-mount adds the
+  // prefix externally.
   const prefixedBaseUrl = `${baseUrl}${basePath}`;
   // Enable CORS for all OAuth-related endpoints
   // This is required for browser-based MCP clients to discover OAuth metadata
   app.use(
-    `${basePath}/.well-known/*`,
+    "/.well-known/*",
     cors({
       origin: "*", // Allow all origins for metadata discovery
       allowMethods: ["GET", "OPTIONS"],
@@ -216,7 +221,7 @@ export function setupOAuthRoutes(
   // In DCR-direct mode: dormant (clients reach upstream directly)
   // In proxy mode: active (handles OAuth flow through the proxy)
   app.use(
-    `${basePath}/authorize`,
+    "/authorize",
     cors({
       origin: "*",
       allowMethods: ["GET", "POST", "OPTIONS"],
@@ -225,7 +230,7 @@ export function setupOAuthRoutes(
     })
   );
   app.use(
-    `${basePath}/token`,
+    "/token",
     cors({
       origin: "*",
       allowMethods: ["POST", "OPTIONS"],
@@ -236,9 +241,9 @@ export function setupOAuthRoutes(
 
   // Mount /authorize and /token handlers
   const handleAuthorize = createAuthorizeHandler(oauth);
-  app.get(`${basePath}/authorize`, handleAuthorize);
-  app.post(`${basePath}/authorize`, handleAuthorize);
-  app.post(`${basePath}/token`, createTokenHandler(oauth));
+  app.get("/authorize", handleAuthorize);
+  app.post("/authorize", handleAuthorize);
+  app.post("/token", createTokenHandler(oauth));
 
   // In proxy mode, add /register endpoint that returns the configured clientId
   // This allows MCP clients to "register" even though the client is pre-registered
@@ -246,7 +251,7 @@ export function setupOAuthRoutes(
     const proxy = oauth as OAuthProxy;
 
     app.use(
-      `${basePath}/register`,
+      "/register",
       cors({
         origin: "*",
         allowMethods: ["POST", "OPTIONS"],
@@ -255,7 +260,7 @@ export function setupOAuthRoutes(
       })
     );
 
-    app.post(`${basePath}/register`, async (c: Context) => {
+    app.post("/register", async (c: Context) => {
       const body = await c.req.json().catch(() => ({}));
 
       // Return a fake registration response with the configured clientId
@@ -347,11 +352,11 @@ export function setupOAuthRoutes(
 
   // Register the handler for both OAuth and OpenID Connect discovery endpoints
   app.get(
-    `${basePath}/.well-known/oauth-authorization-server`,
+    "/.well-known/oauth-authorization-server",
     handleAuthorizationServerMetadata
   );
   app.get(
-    `${basePath}/.well-known/openid-configuration`,
+    "/.well-known/openid-configuration",
     handleAuthorizationServerMetadata
   );
 
@@ -362,7 +367,7 @@ export function setupOAuthRoutes(
    * DCR-direct mode: Points to the actual OAuth provider.
    * Proxy mode: Points to the local server (which proxies to upstream).
    */
-  app.get(`${basePath}/.well-known/oauth-protected-resource`, (c: Context) => {
+  app.get("/.well-known/oauth-protected-resource", (c: Context) => {
     // In proxy mode, the authorization server is the local proxy
     const authServer = proxyMode ? prefixedBaseUrl : oauth.getIssuer();
 
@@ -380,17 +385,14 @@ export function setupOAuthRoutes(
 
   // Path-scoped protected resource metadata per RFC 9728 — declares that the
   // `/mcp` path specifically is the protected resource.
-  app.get(
-    `${basePath}/.well-known/oauth-protected-resource/mcp`,
-    (c: Context) => {
-      const authServer = proxyMode ? prefixedBaseUrl : oauth.getIssuer();
+  app.get("/.well-known/oauth-protected-resource/mcp", (c: Context) => {
+    const authServer = proxyMode ? prefixedBaseUrl : oauth.getIssuer();
 
-      return c.json({
-        resource: `${prefixedBaseUrl}/mcp`,
-        authorization_servers: [authServer],
-        scopes_supported: oauth.getScopesSupported(),
-        bearer_methods_supported: ["header"],
-      });
-    }
-  );
+    return c.json({
+      resource: `${prefixedBaseUrl}/mcp`,
+      authorization_servers: [authServer],
+      scopes_supported: oauth.getScopesSupported(),
+      bearer_methods_supported: ["header"],
+    });
+  });
 }

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/routes.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/routes.ts
@@ -189,28 +189,32 @@ function createTokenHandler(
  *
  * @param rootApp - The underlying Hono instance (un-prefixed root view)
  * @param oauth - The OAuth provider or proxy
- * @param baseUrl - The base URL of this server (for metadata)
+ * @param getBaseUrl - Lazy getter for the server base URL. Called per-request so
+ *                     callers can register routes before the HTTP listener has
+ *                     bound a port (baseUrl is only consumed inside handlers).
  * @param basePath - Optional prefix the server is mounted under (e.g. "/api")
  */
 export function setupOAuthRoutes(
   rootApp: Hono,
   oauth: OAuthProvider | OAuthProxy,
-  baseUrl: string,
+  getBaseUrl: () => string,
   basePath: string = ""
 ): void {
   const proxyMode = isOAuthProxy(oauth);
-  // `baseUrl` is the server origin (no path); `basePath` is the externally-
-  // visible prefix the server is mounted under. The combination is what
-  // goes into discovery metadata so clients land on the right paths.
+  // `getBaseUrl()` returns the server origin (no path); `basePath` is the
+  // externally-visible prefix the server is mounted under. The combination
+  // (resolved lazily inside each handler) is what goes into discovery metadata
+  // so clients land on the right paths.
   // - /authorize, /token, /register live under `basePath` — registered on
   //   a `.basePath()` clone so the prefix is prepended automatically.
   // - .well-known/* discovery lives at the host root on `rootApp`. Per
   //   RFC 8414 §3.1, the discovery URL is `<host>/.well-known/<type>` with
   //   the issuer's path appended *after* the well-known segment — not
-  //   `<host>/<basePath>/.well-known/...`. Registering on `rootApp` makes
-  //   discovery basePath-agnostic for the same reason `/_mcp-use/*` is.
+  //   `<host>/<basePath>/.well-known/...`. Registering on `rootApp` keeps
+  //   the well-known endpoints at the literal host root regardless of
+  //   `basePath` (unlike `/_mcp-use/*`, which now lives under basePath).
   const app = basePath ? rootApp.basePath(basePath) : rootApp;
-  const prefixedBaseUrl = `${baseUrl}${basePath}`;
+  const getPrefixedBaseUrl = () => `${getBaseUrl()}${basePath}`;
   // Enable CORS for all OAuth-related discovery endpoints on rootApp.
   rootApp.use(
     "/.well-known/oauth-*",
@@ -313,6 +317,7 @@ export function setupOAuthRoutes(
       const proxy = oauth as OAuthProxy;
       console.log(`[OAuth] Returning proxy mode metadata`);
 
+      const prefixedBaseUrl = getPrefixedBaseUrl();
       return c.json({
         issuer: prefixedBaseUrl,
         authorization_endpoint: `${prefixedBaseUrl}/authorize`,
@@ -406,6 +411,7 @@ export function setupOAuthRoutes(
    * Proxy mode: Points to the local server (which proxies to upstream).
    */
   const handleProtectedResourceMetadata = (c: Context) => {
+    const prefixedBaseUrl = getPrefixedBaseUrl();
     const authServer = proxyMode ? prefixedBaseUrl : oauth.getIssuer();
     console.log(`[OAuth] Protected resource metadata request`);
     console.log(`[OAuth]   - Resource: ${prefixedBaseUrl}`);
@@ -419,6 +425,7 @@ export function setupOAuthRoutes(
   };
 
   const handleProtectedResourceMetadataMcp = (c: Context) => {
+    const prefixedBaseUrl = getPrefixedBaseUrl();
     const authServer = proxyMode ? prefixedBaseUrl : oauth.getIssuer();
     return c.json({
       resource: `${prefixedBaseUrl}/mcp`,

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/routes.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/routes.ts
@@ -305,10 +305,13 @@ export function setupOAuthRoutes(
    * OAuth Authorization Server Metadata
    * As per RFC 8414: https://tools.ietf.org/html/rfc8414
    *
-   * DCR-direct mode: Fetches and returns metadata from upstream provider.
-   * Proxy mode: Synthesizes metadata pointing to local endpoints.
+   * Resolution order:
+   *   1. Provider-supplied override handler (in-process providers like
+   *      Better Auth that synthesize metadata from a local source).
+   *   2. Proxy mode: synthesize pointing to local endpoints.
+   *   3. DCR-direct mode: fetch from the upstream issuer.
    */
-  const handleAuthorizationServerMetadata = async (c: Context) => {
+  const defaultAuthorizationServerMetadataHandler = async (c: Context) => {
     const requestPath = new URL(c.req.url).pathname;
     console.log(`[OAuth] Metadata request: ${requestPath}`);
 
@@ -371,35 +374,66 @@ export function setupOAuthRoutes(
     }
   };
 
-  // Discovery URLs the SDK probes (see `buildDiscoveryUrls` in
-  // @modelcontextprotocol/sdk client/auth.js). The SDK tries the path-aware
-  // variant first (well-known segment with the issuer's path appended), then
-  // falls back to root. Register both so either probe wins.
+  // Resolve metadata handlers — provider overrides take precedence over the
+  // SDK default (which proxies upstream / synthesizes for proxy mode). In-
+  // process providers like Better Auth supply overrides so the SDK can
+  // answer discovery requests locally without round-tripping to the issuer.
+  const wrapOverride =
+    (override: (req: Request) => Response | Promise<Response>) =>
+    (c: Context) =>
+      override(c.req.raw);
+
+  const handleAuthorizationServerMetadata =
+    oauth.authorizationServerMetadataHandler
+      ? wrapOverride(oauth.authorizationServerMetadataHandler.bind(oauth))
+      : defaultAuthorizationServerMetadataHandler;
+
+  const handleOpenIdConfigMetadata = oauth.openIdConfigurationMetadataHandler
+    ? wrapOverride(oauth.openIdConfigurationMetadataHandler.bind(oauth))
+    : defaultAuthorizationServerMetadataHandler;
+
+  // Path-insertion variants per RFC 8414 §3.1: clients probe
+  // `/.well-known/<type>{issuer-path}` on the issuer's host. Two reasonable
+  // suffixes exist on the local server:
   //
-  // With `basePath: "/api"` and issuer `http://host/api`:
-  //   path-aware: GET /.well-known/oauth-authorization-server/api
-  //   root:       GET /.well-known/oauth-authorization-server
+  // - `basePath`: what proxy-mode metadata advertises as the issuer path, and
+  //   what SDK clients use as a basePath-aware fallback against the resource
+  //   server even when the upstream issuer lives on a different host.
+  // - the pathname of `oauth.getIssuer()`: spec-correct for in-process
+  //   providers like Better Auth where the issuer is on the local host with a
+  //   path deeper than basePath (e.g. `/mcp-server/api/auth`). Anchoring on
+  //   basePath alone produces a silent 404 for these.
+  //
+  // Register both when they differ — neither collides with the other.
+  const issuerPath = (() => {
+    try {
+      return new URL(oauth.getIssuer()).pathname.replace(/\/+$/, "");
+    } catch {
+      return "";
+    }
+  })();
+  const wellKnownSuffixes = new Set<string>();
+  if (basePath) wellKnownSuffixes.add(basePath);
+  if (issuerPath) wellKnownSuffixes.add(issuerPath);
+
   rootApp.get(
     "/.well-known/oauth-authorization-server",
     handleAuthorizationServerMetadata
   );
-  rootApp.get(
-    "/.well-known/openid-configuration",
-    handleAuthorizationServerMetadata
-  );
-  if (basePath) {
+  rootApp.get("/.well-known/openid-configuration", handleOpenIdConfigMetadata);
+  for (const suffix of wellKnownSuffixes) {
     rootApp.get(
-      `/.well-known/oauth-authorization-server${basePath}`,
+      `/.well-known/oauth-authorization-server${suffix}`,
       handleAuthorizationServerMetadata
     );
     rootApp.get(
-      `/.well-known/openid-configuration${basePath}`,
-      handleAuthorizationServerMetadata
+      `/.well-known/openid-configuration${suffix}`,
+      handleOpenIdConfigMetadata
     );
     // OIDC Discovery 1.0 style — well-known appended after the path.
     rootApp.get(
-      `${basePath}/.well-known/openid-configuration`,
-      handleAuthorizationServerMetadata
+      `${suffix}/.well-known/openid-configuration`,
+      handleOpenIdConfigMetadata
     );
   }
 

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/setup.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/setup.ts
@@ -39,7 +39,8 @@ export async function setupOAuthForServer(
   app: HonoType,
   oauth: OAuthProvider | OAuthProxy,
   baseUrl: string,
-  state: OAuthSetupState
+  state: OAuthSetupState,
+  basePath: string = ""
 ): Promise<OAuthSetupState> {
   if (state.complete) {
     return state; // Already setup
@@ -48,15 +49,17 @@ export async function setupOAuthForServer(
   const proxyMode = isOAuthProxy(oauth);
   console.log(`[OAuth] OAuth ${proxyMode ? "proxy" : "provider"} initialized`);
 
-  // Create bearer auth middleware with baseUrl for WWW-Authenticate header
-  const middleware = createBearerAuthMiddleware(oauth, baseUrl);
+  // Create bearer auth middleware with the prefixed baseUrl for the
+  // WWW-Authenticate `resource_metadata` URL so clients discover the
+  // metadata at the same prefix the transport lives under.
+  const middleware = createBearerAuthMiddleware(oauth, `${baseUrl}${basePath}`);
 
   // Setup OAuth routes
-  setupOAuthRoutes(app, oauth, baseUrl);
+  setupOAuthRoutes(app, oauth, baseUrl, basePath);
 
   if (proxyMode) {
     console.log(
-      "[OAuth] Proxy mode: clients use local /authorize, /token, /register endpoints"
+      `[OAuth] Proxy mode: clients use local ${basePath}/authorize, ${basePath}/token, ${basePath}/register endpoints`
     );
     console.log("[OAuth] Credentials will be injected at token exchange");
   } else {
@@ -64,11 +67,12 @@ export async function setupOAuthForServer(
       "[OAuth] Clients will authenticate with provider directly via DCR"
     );
   }
-  console.log("[OAuth] Metadata endpoints: /.well-known/*");
+  console.log(`[OAuth] Metadata endpoints: ${basePath}/.well-known/*`);
 
-  // Apply bearer auth to all /mcp routes
-  app.use("/mcp/*", middleware);
-  console.log("[OAuth] Bearer authentication enabled on /mcp routes");
+  // Apply bearer auth to the MCP transport routes under the configured prefix
+  const mcpAuthPath = `${basePath}/mcp/*`;
+  app.use(mcpAuthPath, middleware);
+  console.log(`[OAuth] Bearer authentication enabled on ${mcpAuthPath} routes`);
 
   return {
     provider: oauth,

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/setup.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/setup.ts
@@ -53,6 +53,13 @@ export function setupOAuthForServer(
   // - .well-known/* discovery lives at the host root
   setupOAuthRoutes(rootApp, oauth, getBaseUrl, basePath);
 
+  // Let providers install provider-specific routes after the defaults are
+  // registered. In-process providers (e.g. Better Auth) use this to mount
+  // their request handler at the issuer's pathname on the root app, so
+  // requests to `${basePath}${auth.options.basePath}/**` reach Better Auth's
+  // OAuth endpoints (/oauth2/authorize, /oauth2/token, /jwks, etc).
+  oauth.installRoutes?.(rootApp, basePath);
+
   // External (user-visible) paths for log messages.
   const externalAuthorize = `${basePath}/authorize`;
   const externalToken = `${basePath}/token`;

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/setup.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/setup.ts
@@ -54,12 +54,21 @@ export async function setupOAuthForServer(
   // metadata at the same prefix the transport lives under.
   const middleware = createBearerAuthMiddleware(oauth, `${baseUrl}${basePath}`);
 
-  // Setup OAuth routes
+  // Setup OAuth routes. Route registrations use bare paths; the inner app's
+  // sub-mount at `basePath` adds the prefix externally. Response bodies
+  // (issuer, *_endpoint, resource) are built from `baseUrl + basePath` so
+  // clients land on the right URLs.
   setupOAuthRoutes(app, oauth, baseUrl, basePath);
+
+  // External (user-visible) paths for log messages.
+  const externalAuthorize = `${basePath}/authorize`;
+  const externalToken = `${basePath}/token`;
+  const externalRegister = `${basePath}/register`;
+  const externalWellKnown = `${basePath}/.well-known/*`;
 
   if (proxyMode) {
     console.log(
-      `[OAuth] Proxy mode: clients use local ${basePath}/authorize, ${basePath}/token, ${basePath}/register endpoints`
+      `[OAuth] Proxy mode: clients use local ${externalAuthorize}, ${externalToken}, ${externalRegister} endpoints`
     );
     console.log("[OAuth] Credentials will be injected at token exchange");
   } else {
@@ -67,12 +76,15 @@ export async function setupOAuthForServer(
       "[OAuth] Clients will authenticate with provider directly via DCR"
     );
   }
-  console.log(`[OAuth] Metadata endpoints: ${basePath}/.well-known/*`);
+  console.log(`[OAuth] Metadata endpoints: ${externalWellKnown}`);
 
-  // Apply bearer auth to the MCP transport routes under the configured prefix
-  const mcpAuthPath = `${basePath}/mcp/*`;
-  app.use(mcpAuthPath, middleware);
-  console.log(`[OAuth] Bearer authentication enabled on ${mcpAuthPath} routes`);
+  // Apply bearer auth to the MCP transport routes. Registered on the inner
+  // app at the bare path; the sub-mount makes it match `${basePath}/mcp/*`
+  // externally.
+  app.use("/mcp/*", middleware);
+  console.log(
+    `[OAuth] Bearer authentication enabled on ${basePath}/mcp/* routes`
+  );
 
   return {
     provider: oauth,

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/setup.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/setup.ts
@@ -42,9 +42,11 @@ export function setupOAuthForServer(
   console.log(`[OAuth] OAuth ${proxyMode ? "proxy" : "provider"} initialized`);
 
   // Create bearer auth middleware. The WWW-Authenticate `resource_metadata`
-  // URL points at the host-root discovery path (RFC 9728 §5.1) so clients
-  // hit the route mounted on the root app, independent of basePath.
-  const middleware = createBearerAuthMiddleware(oauth, getBaseUrl);
+  // URL points at the path-aware discovery URL per RFC 9728 §3.1:
+  // `<host>/.well-known/oauth-protected-resource<basePath>/mcp` — identifying
+  // the MCP endpoint specifically as the protected resource. The matching
+  // route is registered by `setupOAuthRoutes` on the root app.
+  const middleware = createBearerAuthMiddleware(oauth, getBaseUrl, basePath);
 
   // Setup OAuth routes:
   // - /authorize, /token, /register live under `basePath`

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/setup.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/setup.ts
@@ -5,60 +5,51 @@
  * Supports both DCR-direct mode (OAuthProvider) and proxy mode (OAuthProxy).
  */
 
-import type { Hono as HonoType, Context, Next } from "hono";
+import type { Hono as HonoType } from "hono";
 import { setupOAuthRoutes, isOAuthProxy } from "./routes.js";
 import { createBearerAuthMiddleware } from "./middleware.js";
 import type { OAuthProvider, OAuthProxy } from "./providers/types.js";
 
 /**
- * OAuth setup state
- */
-interface OAuthSetupState {
-  provider?: OAuthProvider | OAuthProxy;
-  middleware?: (c: Context, next: Next) => Promise<Response | void>;
-  complete: boolean;
-}
-
-/**
- * Setup OAuth authentication for MCP server
+ * Setup OAuth authentication for MCP server.
  *
- * Initializes OAuth provider/proxy, creates bearer auth middleware,
- * sets up OAuth routes, and applies auth to /mcp endpoints.
+ * Initializes OAuth provider/proxy, creates bearer auth middleware, sets up
+ * OAuth routes, and applies auth to /mcp endpoints. Synchronous — registers
+ * routes against the supplied Hono and returns immediately. baseUrl is a
+ * lazy getter consumed inside request handlers, so this can run before the
+ * HTTP listener has bound a port.
  *
  * Supports two modes:
  * - DCR-direct (OAuthProvider): Clients authenticate directly with upstream
  * - Proxy (OAuthProxy): Server proxies OAuth flow with pre-registered credentials
  *
- * @param rootApp - Underlying Hono app (the un-prefixed root view)
+ * @param rootApp - Underlying Hono app (the un-prefixed root view). Must NOT
+ *                  be a `.basePath()` clone, because `.well-known/*` discovery
+ *                  has to land at the literal host root (RFC 8414 §3.1) and
+ *                  this function does its own basePath clone internally for
+ *                  `/authorize`, `/token`, `/register`.
  * @param oauth - OAuth provider or proxy instance
- * @param baseUrl - Server base URL for OAuth redirects
- * @param state - OAuth setup state to track completion
+ * @param getBaseUrl - Lazy getter for the server base URL. Called per-request.
  * @param basePath - Optional basePath prefix to scope authorize/token/register under
- * @returns Updated OAuth setup state with provider and middleware
  */
-export async function setupOAuthForServer(
+export function setupOAuthForServer(
   rootApp: HonoType,
   oauth: OAuthProvider | OAuthProxy,
-  baseUrl: string,
-  state: OAuthSetupState,
+  getBaseUrl: () => string,
   basePath: string = ""
-): Promise<OAuthSetupState> {
-  if (state.complete) {
-    return state; // Already setup
-  }
-
+): void {
   const proxyMode = isOAuthProxy(oauth);
   console.log(`[OAuth] OAuth ${proxyMode ? "proxy" : "provider"} initialized`);
 
   // Create bearer auth middleware. The WWW-Authenticate `resource_metadata`
   // URL points at the host-root discovery path (RFC 9728 §5.1) so clients
   // hit the route mounted on the root app, independent of basePath.
-  const middleware = createBearerAuthMiddleware(oauth, baseUrl);
+  const middleware = createBearerAuthMiddleware(oauth, getBaseUrl);
 
   // Setup OAuth routes:
   // - /authorize, /token, /register live under `basePath`
   // - .well-known/* discovery lives at the host root
-  setupOAuthRoutes(rootApp, oauth, baseUrl, basePath);
+  setupOAuthRoutes(rootApp, oauth, getBaseUrl, basePath);
 
   // External (user-visible) paths for log messages.
   const externalAuthorize = `${basePath}/authorize`;
@@ -89,10 +80,4 @@ export async function setupOAuthForServer(
   console.log(
     `[OAuth] Bearer authentication enabled on ${externalMcp}/* routes`
   );
-
-  return {
-    provider: oauth,
-    middleware: middleware,
-    complete: true,
-  };
 }

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/setup.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/setup.ts
@@ -64,6 +64,7 @@ export async function setupOAuthForServer(
   const externalAuthorize = `${basePath}/authorize`;
   const externalToken = `${basePath}/token`;
   const externalRegister = `${basePath}/register`;
+  const externalMcp = `${basePath}/mcp`;
   const externalWellKnown = `/.well-known/*`;
 
   if (proxyMode) {
@@ -86,7 +87,7 @@ export async function setupOAuthForServer(
   const app = basePath ? rootApp.basePath(basePath) : rootApp;
   app.use("/mcp/*", middleware);
   console.log(
-    `[OAuth] Bearer authentication enabled on ${basePath}/mcp/* routes`
+    `[OAuth] Bearer authentication enabled on ${externalMcp}/* routes`
   );
 
   return {

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/setup.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/setup.ts
@@ -29,14 +29,15 @@ interface OAuthSetupState {
  * - DCR-direct (OAuthProvider): Clients authenticate directly with upstream
  * - Proxy (OAuthProxy): Server proxies OAuth flow with pre-registered credentials
  *
- * @param app - Hono app instance
+ * @param rootApp - Underlying Hono app (the un-prefixed root view)
  * @param oauth - OAuth provider or proxy instance
  * @param baseUrl - Server base URL for OAuth redirects
  * @param state - OAuth setup state to track completion
+ * @param basePath - Optional basePath prefix to scope authorize/token/register under
  * @returns Updated OAuth setup state with provider and middleware
  */
 export async function setupOAuthForServer(
-  app: HonoType,
+  rootApp: HonoType,
   oauth: OAuthProvider | OAuthProxy,
   baseUrl: string,
   state: OAuthSetupState,
@@ -49,22 +50,21 @@ export async function setupOAuthForServer(
   const proxyMode = isOAuthProxy(oauth);
   console.log(`[OAuth] OAuth ${proxyMode ? "proxy" : "provider"} initialized`);
 
-  // Create bearer auth middleware with the prefixed baseUrl for the
-  // WWW-Authenticate `resource_metadata` URL so clients discover the
-  // metadata at the same prefix the transport lives under.
-  const middleware = createBearerAuthMiddleware(oauth, `${baseUrl}${basePath}`);
+  // Create bearer auth middleware. The WWW-Authenticate `resource_metadata`
+  // URL points at the host-root discovery path (RFC 9728 §5.1) so clients
+  // hit the route mounted on the root app, independent of basePath.
+  const middleware = createBearerAuthMiddleware(oauth, baseUrl);
 
-  // Setup OAuth routes. Route registrations use bare paths; the inner app's
-  // sub-mount at `basePath` adds the prefix externally. Response bodies
-  // (issuer, *_endpoint, resource) are built from `baseUrl + basePath` so
-  // clients land on the right URLs.
-  setupOAuthRoutes(app, oauth, baseUrl, basePath);
+  // Setup OAuth routes:
+  // - /authorize, /token, /register live under `basePath`
+  // - .well-known/* discovery lives at the host root
+  setupOAuthRoutes(rootApp, oauth, baseUrl, basePath);
 
   // External (user-visible) paths for log messages.
   const externalAuthorize = `${basePath}/authorize`;
   const externalToken = `${basePath}/token`;
   const externalRegister = `${basePath}/register`;
-  const externalWellKnown = `${basePath}/.well-known/*`;
+  const externalWellKnown = `/.well-known/*`;
 
   if (proxyMode) {
     console.log(
@@ -78,9 +78,12 @@ export async function setupOAuthForServer(
   }
   console.log(`[OAuth] Metadata endpoints: ${externalWellKnown}`);
 
-  // Apply bearer auth to the MCP transport routes. Registered on the inner
-  // app at the bare path; the sub-mount makes it match `${basePath}/mcp/*`
-  // externally.
+  // Apply bearer auth to the MCP transport routes. Registered on a basePath
+  // clone so the middleware path is prefixed automatically; both
+  // `rootApp.basePath('/api').use('/mcp/*', mw)` and
+  // `rootApp.use('/api/mcp/*', mw)` would work — using the clone keeps the
+  // prefix concern out of this function.
+  const app = basePath ? rootApp.basePath(basePath) : rootApp;
   app.use("/mcp/*", middleware);
   console.log(
     `[OAuth] Bearer authentication enabled on ${basePath}/mcp/* routes`

--- a/libraries/typescript/packages/mcp-use/src/server/types/common.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/types/common.ts
@@ -73,6 +73,21 @@ export interface ServerConfig {
    */
   baseUrl?: string;
   /**
+   * Mount every route the server registers under this path prefix.
+   *
+   * Affects the MCP transport (`/mcp`, `/sse`), the inspector UI, widget +
+   * public asset routes, OAuth flow + metadata endpoints, and the bearer-auth
+   * middleware. With `basePath: "/api"` the MCP transport is reachable at
+   * `/api/mcp`, the inspector at `/api/inspector`, etc.
+   *
+   * Must start with a `/` and must not end with one. An empty string or `"/"`
+   * means "no prefix" (the default).
+   *
+   * @example "/api"
+   * @example "/mcp-server"
+   */
+  basePath?: string;
+  /**
    * Custom CORS options for the server.
    *
    * By default, mcp-use enables permissive CORS (`origin: "*"`) for development ergonomics.

--- a/libraries/typescript/packages/mcp-use/src/server/types/resource.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/types/resource.ts
@@ -695,7 +695,7 @@ export interface WidgetManifest {
 export interface DiscoverWidgetsOptions {
   /**
    * Path to widgets directory.
-   * Defaults to dist/resources/mcp-use/widgets.
+   * Defaults to .mcp-use/widgets.
    *
    * @example "./resources/widgets"
    */

--- a/libraries/typescript/packages/mcp-use/src/server/utils/hono-proxy.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/utils/hono-proxy.ts
@@ -68,17 +68,30 @@ const HMR_HTTP_METHODS = new Set([
  * custom route handlers from the mutable _customRoutes map.
  * This is called once at server startup so we never need to add
  * routes to Hono after the matcher is built (which would fail in Hono v4+).
+ *
+ * When the server is configured with a `basePath`, this middleware lives on
+ * the inner (sub-mounted) Hono. `c.req.path` is the full original URL path
+ * (Hono preserves it across sub-mounts), so we strip the prefix before
+ * looking up handlers — user code calls `server.get("/foo", ...)` and the
+ * request arrives at `${basePath}/foo`. The `getBasePath` accessor is read
+ * at dispatch time rather than captured, so the value is correct even if
+ * the field is set after this function runs.
  */
 export function installCustomRoutesMiddleware(
   app: HonoType,
-
-  customRoutes: Map<string, ((...args: any[]) => any)[]>
+  customRoutes: Map<string, ((...args: any[]) => any)[]>,
+  getBasePath: () => string = () => ""
 ): void {
   // Register a single catch-all middleware that checks the custom routes map
   // Must use `all` to match any HTTP method
   app.all("*", async (c: any, next: any) => {
     const method = c.req.method.toLowerCase();
-    const path = c.req.path;
+    const basePath = getBasePath();
+    const rawPath = c.req.path as string;
+    const path =
+      basePath && rawPath.startsWith(basePath)
+        ? rawPath.slice(basePath.length) || "/"
+        : rawPath;
 
     // Check for exact match: "get:/api/fruits"
     const key = `${method}:${path}`;

--- a/libraries/typescript/packages/mcp-use/src/server/utils/server-helpers.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/utils/server-helpers.ts
@@ -10,6 +10,28 @@ import { hostHeaderValidation } from "../middleware/host-validation.js";
 import { getEnv } from "./runtime.js";
 
 /**
+ * Normalize a user-supplied `basePath` into the form the rest of the server
+ * expects: empty string for "no prefix", otherwise a leading `/` with no
+ * trailing `/`. Throws if the input is shaped wrong so misconfiguration shows
+ * up at startup rather than as confusing 404s.
+ */
+export function normalizeBasePath(input: string | undefined): string {
+  if (input === undefined || input === "" || input === "/") return "";
+  if (typeof input !== "string") {
+    throw new TypeError(
+      `[MCP] basePath must be a string, got ${typeof input}`
+    );
+  }
+  if (!input.startsWith("/")) {
+    throw new Error(
+      `[MCP] basePath must start with "/", got ${JSON.stringify(input)}`
+    );
+  }
+  const trimmed = input.replace(/\/+$/, "");
+  return trimmed;
+}
+
+/**
  * Get default CORS configuration for MCP server
  *
  * @returns CORS options object for Hono cors middleware

--- a/libraries/typescript/packages/mcp-use/src/server/utils/server-helpers.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/utils/server-helpers.ts
@@ -11,19 +11,23 @@ import { getEnv } from "./runtime.js";
 
 /**
  * Resolve relative icon `src` values to absolute URLs under the framework's
- * basePath-agnostic public asset prefix. Paths already starting with `http`
- * are passed through unchanged. Returns `undefined`/the original array when
- * `icons` or `baseUrl` is missing.
+ * public asset prefix (`${basePath}/_mcp-use/public/`). Paths already
+ * starting with `http` are passed through unchanged. Returns
+ * `undefined`/the original array when `icons` or `baseUrl` is missing.
  */
 export function resolveIconUrls<
   T extends { src: string } = { src: string; [k: string]: unknown },
->(icons: T[] | undefined, baseUrl?: string): T[] | undefined {
+>(
+  icons: T[] | undefined,
+  baseUrl?: string,
+  basePath: string = ""
+): T[] | undefined {
   if (!icons || !baseUrl) return icons;
   return icons.map((icon) => ({
     ...icon,
     src: icon.src.startsWith("http")
       ? icon.src
-      : `${baseUrl}/_mcp-use/public/${icon.src}`,
+      : `${baseUrl}${basePath}/_mcp-use/public/${icon.src}`,
   }));
 }
 

--- a/libraries/typescript/packages/mcp-use/src/server/utils/server-helpers.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/utils/server-helpers.ts
@@ -10,6 +10,24 @@ import { hostHeaderValidation } from "../middleware/host-validation.js";
 import { getEnv } from "./runtime.js";
 
 /**
+ * Resolve relative icon `src` values to absolute URLs under the framework's
+ * basePath-agnostic public asset prefix. Paths already starting with `http`
+ * are passed through unchanged. Returns `undefined`/the original array when
+ * `icons` or `baseUrl` is missing.
+ */
+export function resolveIconUrls<
+  T extends { src: string } = { src: string; [k: string]: unknown },
+>(icons: T[] | undefined, baseUrl?: string): T[] | undefined {
+  if (!icons || !baseUrl) return icons;
+  return icons.map((icon) => ({
+    ...icon,
+    src: icon.src.startsWith("http")
+      ? icon.src
+      : `${baseUrl}/_mcp-use/public/${icon.src}`,
+  }));
+}
+
+/**
  * Normalize a user-supplied `basePath` into the form the rest of the server
  * expects: empty string for "no prefix", otherwise a leading `/` with no
  * trailing `/`. Throws if the input is shaped wrong so misconfiguration shows

--- a/libraries/typescript/packages/mcp-use/src/server/utils/server-helpers.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/utils/server-helpers.ts
@@ -18,9 +18,7 @@ import { getEnv } from "./runtime.js";
 export function normalizeBasePath(input: string | undefined): string {
   if (input === undefined || input === "" || input === "/") return "";
   if (typeof input !== "string") {
-    throw new TypeError(
-      `[MCP] basePath must be a string, got ${typeof input}`
-    );
+    throw new TypeError(`[MCP] basePath must be a string, got ${typeof input}`);
   }
   if (!input.startsWith("/")) {
     throw new Error(

--- a/libraries/typescript/packages/mcp-use/src/server/utils/server-helpers.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/utils/server-helpers.ts
@@ -17,16 +17,12 @@ import { getEnv } from "./runtime.js";
  */
 export function normalizeBasePath(input: string | undefined): string {
   if (input === undefined || input === "" || input === "/") return "";
-  if (typeof input !== "string") {
-    throw new TypeError(`[MCP] basePath must be a string, got ${typeof input}`);
-  }
   if (!input.startsWith("/")) {
     throw new Error(
       `[MCP] basePath must start with "/", got ${JSON.stringify(input)}`
     );
   }
-  const trimmed = input.replace(/\/+$/, "");
-  return trimmed;
+  return input.replace(/\/+$/, "");
 }
 
 /**

--- a/libraries/typescript/packages/mcp-use/src/server/utils/server-info-file.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/utils/server-info-file.ts
@@ -1,0 +1,60 @@
+/**
+ * Best-effort handshake file written after a server starts listening.
+ *
+ * The file lives at `.mcp-use/server-info.json` and lets out-of-process
+ * tooling (CLI, inspector launcher) discover the running server's basePath
+ * and constructed URLs without an HTTP discovery endpoint.
+ *
+ * Failures are swallowed — startup must never block on the file write.
+ * Stale files are tolerated: next `listen()` overwrites them, and the cost
+ * of a stale read is one 404 on auto-open.
+ */
+
+import { isDeno } from "./runtime.js";
+
+export interface ServerInfoFile {
+  host: string;
+  port: number;
+  basePath: string;
+  mcpUrl: string;
+  inspectorUrl: string;
+  writtenAt: string;
+}
+
+/**
+ * Write the server-info handshake file. Best-effort: swallows errors so
+ * startup never blocks. Skipped on Deno (no filesystem write here).
+ */
+export async function writeServerInfoFile(info: {
+  host: string;
+  port: number;
+  basePath: string;
+}): Promise<void> {
+  if (isDeno) return;
+
+  try {
+    const { promises: fs } = await import("node:fs");
+    const path = await import("node:path");
+    const dir = path.join(process.cwd(), ".mcp-use");
+    await fs.mkdir(dir, { recursive: true });
+
+    const browserHost = info.host === "0.0.0.0" ? "localhost" : info.host;
+    const origin = `http://${browserHost}:${info.port}`;
+    const payload: ServerInfoFile = {
+      host: info.host,
+      port: info.port,
+      basePath: info.basePath,
+      mcpUrl: `${origin}${info.basePath}/mcp`,
+      inspectorUrl: `${origin}${info.basePath}/inspector`,
+      writtenAt: new Date().toISOString(),
+    };
+
+    await fs.writeFile(
+      path.join(dir, "server-info.json"),
+      JSON.stringify(payload, null, 2),
+      "utf8"
+    );
+  } catch {
+    // swallow — never block startup on this
+  }
+}

--- a/libraries/typescript/packages/mcp-use/src/server/utils/server-lifecycle.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/utils/server-lifecycle.ts
@@ -35,7 +35,10 @@ export async function writeServerInfoFile(info: {
       inspectorUrl: `http://${info.host}:${info.port}${info.basePath}/inspector`,
       writtenAt: new Date().toISOString(),
     };
-    await writeFile(join(dir, "server-info.json"), JSON.stringify(payload, null, 2));
+    await writeFile(
+      join(dir, "server-info.json"),
+      JSON.stringify(payload, null, 2)
+    );
   } catch {
     // Best-effort — tooling falls back to /mcp and /inspector if the file is absent.
   }

--- a/libraries/typescript/packages/mcp-use/src/server/utils/server-lifecycle.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/utils/server-lifecycle.ts
@@ -8,6 +8,39 @@ import chalk from "chalk";
 import type { Hono as HonoType } from "hono";
 import { getEnv, isDeno } from "./runtime.js";
 
+/**
+ * Best-effort handoff for external tools that spawn the user's server as a
+ * child process (the CLI's `mcp-use dev` auto-open, the screenshot command,
+ * etc.). Writing `.mcp-use/server-info.json` lets those tools discover the
+ * configured `basePath` and rendered URLs without parsing source or
+ * scraping stdout. Skipped on Deno and silently ignored on failure — a
+ * read/write error must never block server startup.
+ */
+export async function writeServerInfoFile(info: {
+  host: string;
+  port?: number;
+  basePath: string;
+}): Promise<void> {
+  if (isDeno) return;
+  try {
+    const { mkdir, writeFile } = await import("node:fs/promises");
+    const { join } = await import("node:path");
+    const dir = join(process.cwd(), ".mcp-use");
+    await mkdir(dir, { recursive: true });
+    const payload = {
+      host: info.host,
+      port: info.port,
+      basePath: info.basePath,
+      mcpUrl: `http://${info.host}:${info.port}${info.basePath}/mcp`,
+      inspectorUrl: `http://${info.host}:${info.port}${info.basePath}/inspector`,
+      writtenAt: new Date().toISOString(),
+    };
+    await writeFile(join(dir, "server-info.json"), JSON.stringify(payload, null, 2));
+  } catch {
+    // Best-effort — tooling falls back to /mcp and /inspector if the file is absent.
+  }
+}
+
 export function isProductionMode(): boolean {
   // Only check NODE_ENV - CLI commands set this explicitly
   // 'mcp-use dev' sets NODE_ENV=development
@@ -127,8 +160,11 @@ export async function startServer(
   options?: {
     onDenoRequest?: (req: Request) => Request | Promise<Request>;
     onDenoResponse?: (res: Response) => Response | Promise<Response>;
+    /** Configured base path (e.g. "/api"). Empty for no prefix. */
+    basePath?: string;
   }
 ): Promise<HttpServerHandle> {
+  const basePath = options?.basePath ?? "";
   if (isDeno) {
     // Deno runtime
     const corsHeaders = getDenoCorsHeaders();
@@ -164,7 +200,7 @@ export async function startServer(
     console.log(`[SERVER] Listening`);
     console.log(
       chalk.gray(
-        `[MCP] Tip: connect with the CLI → npx mcp-use client connect http://${host}:${port}/mcp`
+        `[MCP] Tip: connect with the CLI → npx mcp-use client connect http://${host}:${port}${basePath}/mcp`
       )
     );
     return {
@@ -182,10 +218,10 @@ export async function startServer(
       },
       (_info: any) => {
         console.log(`[SERVER] Listening on http://${host}:${port}`);
-        console.log(`[MCP] Endpoints: http://${host}:${port}/mcp`);
+        console.log(`[MCP] Endpoints: http://${host}:${port}${basePath}/mcp`);
         console.log(
           chalk.gray(
-            `[MCP] Tip: connect with the CLI → npx mcp-use client connect http://${host}:${port}/mcp`
+            `[MCP] Tip: connect with the CLI → npx mcp-use client connect http://${host}:${port}${basePath}/mcp`
           )
         );
       }

--- a/libraries/typescript/packages/mcp-use/src/server/utils/server-lifecycle.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/utils/server-lifecycle.ts
@@ -8,42 +8,6 @@ import chalk from "chalk";
 import type { Hono as HonoType } from "hono";
 import { getEnv, isDeno } from "./runtime.js";
 
-/**
- * Best-effort handoff for external tools that spawn the user's server as a
- * child process (the CLI's `mcp-use dev` auto-open, the screenshot command,
- * etc.). Writing `.mcp-use/server-info.json` lets those tools discover the
- * configured `basePath` and rendered URLs without parsing source or
- * scraping stdout. Skipped on Deno and silently ignored on failure — a
- * read/write error must never block server startup.
- */
-export async function writeServerInfoFile(info: {
-  host: string;
-  port?: number;
-  basePath: string;
-}): Promise<void> {
-  if (isDeno) return;
-  try {
-    const { mkdir, writeFile } = await import("node:fs/promises");
-    const { join } = await import("node:path");
-    const dir = join(process.cwd(), ".mcp-use");
-    await mkdir(dir, { recursive: true });
-    const payload = {
-      host: info.host,
-      port: info.port,
-      basePath: info.basePath,
-      mcpUrl: `http://${info.host}:${info.port}${info.basePath}/mcp`,
-      inspectorUrl: `http://${info.host}:${info.port}${info.basePath}/inspector`,
-      writtenAt: new Date().toISOString(),
-    };
-    await writeFile(
-      join(dir, "server-info.json"),
-      JSON.stringify(payload, null, 2)
-    );
-  } catch {
-    // Best-effort — tooling falls back to /mcp and /inspector if the file is absent.
-  }
-}
-
 export function isProductionMode(): boolean {
   // Only check NODE_ENV - CLI commands set this explicitly
   // 'mcp-use dev' sets NODE_ENV=development

--- a/libraries/typescript/packages/mcp-use/src/server/utils/server-lifecycle.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/utils/server-lifecycle.ts
@@ -7,6 +7,7 @@
 import chalk from "chalk";
 import type { Hono as HonoType } from "hono";
 import { getEnv, isDeno } from "./runtime.js";
+import { writeServerInfoFile } from "./server-info-file.js";
 
 export function isProductionMode(): boolean {
   // Only check NODE_ENV - CLI commands set this explicitly
@@ -184,6 +185,9 @@ export async function startServer(
         hostname: host,
       },
       (_info: any) => {
+        // Best-effort handshake file written before the first log line so
+        // tooling that waits for the server can read basePath from disk.
+        void writeServerInfoFile({ host, port, basePath });
         console.log(`[SERVER] Listening on http://${host}:${port}`);
         console.log(`[MCP] Endpoints: http://${host}:${port}${basePath}/mcp`);
         console.log(

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/index.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/index.ts
@@ -49,6 +49,12 @@ export async function mountWidgets(
     favicon: (server as any).favicon,
     publicRoutesMode: (server as any).publicRoutesMode,
     basePath: (server as any).basePath ?? "",
+    /**
+     * Outer Hono so widget setup can register favicon at root regardless of
+     * the basePath sub-mount. Falls back to `(server as any).app` when the
+     * server doesn't expose `_rootApp` (older instances, no basePath).
+     */
+    rootApp: (server as any)._rootApp ?? (server as any).app,
     /** Pre-created HTTP server for Vite HMR WebSocket support */
     httpServer: (server as any)._httpServer as
       | import("http").Server

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/index.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/index.ts
@@ -28,7 +28,7 @@ export { uiResourceRegistration } from "./ui-resource-registration.js";
  * In production mode: serves pre-built static widgets
  *
  * @param options - Configuration options
- * @param options.baseRoute - Base route for widgets (defaults to '/mcp-use/widgets')
+ * @param options.baseRoute - Base route for widgets (defaults to '/_mcp-use/widgets')
  * @param options.resourcesDir - Directory containing widget files (defaults to 'resources')
  * @returns Promise that resolves when all widgets are mounted
  */
@@ -49,12 +49,6 @@ export async function mountWidgets(
     favicon: (server as any).favicon,
     publicRoutesMode: (server as any).publicRoutesMode,
     basePath: (server as any).basePath ?? "",
-    /**
-     * Outer Hono so widget setup can register favicon at root regardless of
-     * the basePath sub-mount. Falls back to `(server as any).app` when the
-     * server doesn't expose `_rootApp` (older instances, no basePath).
-     */
-    rootApp: (server as any)._rootApp ?? (server as any).app,
     /** Pre-created HTTP server for Vite HMR WebSocket support */
     httpServer: (server as any)._httpServer as
       | import("http").Server
@@ -84,18 +78,26 @@ export async function mountWidgets(
     (server as any).removeWidgetTool(toolName);
   };
 
-  const app = server.app;
+  // `/_mcp-use/widgets/*`, `/_mcp-use/public/*`, and `/favicon.ico` all live
+  // at the host root regardless of basePath. Pass the underlying root Hono
+  // so registrations bypass any basePath prefix.
+  const rootApp = (server as any)._rootApp ?? (server as any).app;
 
   if (isProductionMode() || isDeno) {
     console.log("[WIDGETS] Mounting widgets in production mode");
     // Setup routes first for production
-    setupWidgetRoutes(app, serverConfig);
+    setupWidgetRoutes(rootApp, serverConfig);
     (server as any).publicRoutesMode = "production";
-    await mountWidgetsProduction(app, serverConfig, registerWidget, options);
+    await mountWidgetsProduction(
+      rootApp,
+      serverConfig,
+      registerWidget,
+      options
+    );
   } else {
     console.log("[WIDGETS] Mounting widgets in development mode");
     await mountWidgetsDev(
-      app,
+      rootApp,
       serverConfig,
       registerWidget,
       updateWidgetTool,

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/index.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/index.ts
@@ -79,25 +79,23 @@ export async function mountWidgets(
   };
 
   // `/_mcp-use/widgets/*`, `/_mcp-use/public/*`, and `/favicon.ico` all live
-  // at the host root regardless of basePath. Pass the underlying root Hono
-  // so registrations bypass any basePath prefix.
-  const rootApp = (server as any)._rootApp as import("hono").Hono;
+  // under the configured `basePath` (empty string == host root). Pass the
+  // basePath-aware Hono view so registrations get auto-prefixed. This is
+  // also the same Hono instance handed to `startServer()`, so attaching
+  // `__viteWsProxy` to it lets the lifecycle helper pick the WS proxy up.
+  const app = (server as any).app as import("hono").Hono;
+  const basePath = serverConfig.basePath;
 
   if (isProductionMode() || isDeno) {
     console.log("[WIDGETS] Mounting widgets in production mode");
     // Setup routes first for production
-    setupWidgetRoutes(rootApp, serverConfig);
+    setupWidgetRoutes(app, serverConfig, basePath);
     (server as any).publicRoutesMode = "production";
-    await mountWidgetsProduction(
-      rootApp,
-      serverConfig,
-      registerWidget,
-      options
-    );
+    await mountWidgetsProduction(app, serverConfig, registerWidget, options);
   } else {
     console.log("[WIDGETS] Mounting widgets in development mode");
     await mountWidgetsDev(
-      rootApp,
+      app,
       serverConfig,
       registerWidget,
       updateWidgetTool,

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/index.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/index.ts
@@ -48,6 +48,7 @@ export async function mountWidgets(
     buildId: (server as any).buildId,
     favicon: (server as any).favicon,
     publicRoutesMode: (server as any).publicRoutesMode,
+    basePath: (server as any).basePath ?? "",
     /** Pre-created HTTP server for Vite HMR WebSocket support */
     httpServer: (server as any)._httpServer as
       | import("http").Server

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/index.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/index.ts
@@ -81,7 +81,7 @@ export async function mountWidgets(
   // `/_mcp-use/widgets/*`, `/_mcp-use/public/*`, and `/favicon.ico` all live
   // at the host root regardless of basePath. Pass the underlying root Hono
   // so registrations bypass any basePath prefix.
-  const rootApp = (server as any)._rootApp ?? (server as any).app;
+  const rootApp = (server as any)._rootApp as import("hono").Hono;
 
   if (isProductionMode() || isDeno) {
     console.log("[WIDGETS] Mounting widgets in production mode");

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/mcp-ui-adapter.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/mcp-ui-adapter.ts
@@ -48,7 +48,7 @@ export function buildWidgetUrl(
   const slugifiedWidget = slugifyWidgetName(widget);
 
   const url = new URL(
-    `/mcp-use/widgets/${slugifiedWidget}`,
+    `/_mcp-use/widgets/${slugifiedWidget}`,
     `${config.baseUrl}:${config.port}`
   );
 

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/mcp-ui-adapter.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/mcp-ui-adapter.ts
@@ -26,6 +26,8 @@ export interface UrlConfig {
   baseUrl: string;
   port: number | string;
   buildId?: string;
+  /** Server basePath prefix (e.g. "/api"). Empty string when unset. */
+  basePath?: string;
 }
 
 /**
@@ -47,8 +49,9 @@ export function buildWidgetUrl(
   // This must be imported dynamically to avoid circular dependencies
   const slugifiedWidget = slugifyWidgetName(widget);
 
+  const basePath = config.basePath ?? "";
   const url = new URL(
-    `/_mcp-use/widgets/${slugifiedWidget}`,
+    `${basePath}/_mcp-use/widgets/${slugifiedWidget}`,
     `${config.baseUrl}:${config.port}`
   );
 

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/mount-widgets-dev.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/mount-widgets-dev.ts
@@ -83,7 +83,7 @@ type MountWidgetsDevOptions = MountWidgetsOptions;
  * @returns Nothing.
  */
 export async function mountWidgetsDev(
-  rootApp: HonoType,
+  app: HonoType,
   serverConfig: ServerConfig,
   registerWidget: RegisterWidgetCallback,
   updateWidgetTool: UpdateWidgetToolCallback,
@@ -92,8 +92,12 @@ export async function mountWidgetsDev(
 ): Promise<void> {
   const { promises: fs } = await import("node:fs");
   const baseRoute = options?.baseRoute || "/_mcp-use/widgets";
-  // All widget routes live at the host root regardless of `basePath`, so
-  // they register directly on `rootApp` (the underlying Hono).
+  const basePath = serverConfig.basePath ?? "";
+  // Widget routes register on the basePath-aware Hono view so they land at
+  // `${basePath}${baseRoute}/*`. `externalBaseRoute` is the full
+  // browser-visible prefix (basePath + baseRoute) used for HTML emission,
+  // Vite's `base`, and the HMR WS upgrade matcher.
+  const externalBaseRoute = `${basePath}${baseRoute}`;
   // Resolution order for the widgets directory:
   //   1. Caller-supplied `options.resourcesDir`
   //   2. `MCP_USE_WIDGETS_DIR` env var (set by @mcp-use/cli when --mcp-dir
@@ -304,7 +308,7 @@ if (container && Component) {
 
     // Include Vite client and React refresh preamble explicitly
     // This is needed when loading in sandboxed iframes where auto-injection may not work.
-    // `_mcp-use/widgets/` lives at the host root, so URLs are bare absolute paths.
+    // URLs use `externalBaseRoute` so they resolve under `basePath` when set.
     const htmlContent = `<!doctype html>
 <html lang="en">
   <head>
@@ -313,12 +317,12 @@ if (container && Component) {
     <title>${widget.name} Widget</title>${
       serverConfig.favicon
         ? `
-    <link rel="icon" href="/_mcp-use/public/${serverConfig.favicon}" />`
+    <link rel="icon" href="${basePath}/_mcp-use/public/${serverConfig.favicon}" />`
         : ""
     }
-    <script type="module" src="${baseRoute}/@vite/client"></script>
+    <script type="module" src="${externalBaseRoute}/@vite/client"></script>
     <script type="module">
-      import RefreshRuntime from '${baseRoute}/@react-refresh';
+      import RefreshRuntime from '${externalBaseRoute}/@react-refresh';
       RefreshRuntime.injectIntoGlobalHook(window);
       window.$RefreshReg$ = () => {};
       window.$RefreshSig$ = () => (type) => type;
@@ -327,7 +331,7 @@ if (container && Component) {
   </head>
   <body>
     <div id="widget-root"></div>
-    <script type="module" src="${baseRoute}/${slugifiedName}/entry.tsx"></script>
+    <script type="module" src="${externalBaseRoute}/${slugifiedName}/entry.tsx"></script>
   </body>
 </html>`;
 
@@ -546,7 +550,7 @@ if (container && Component) {
 }
 `;
 
-        // `_mcp-use/widgets/` lives at the host root, so URLs are bare absolute paths.
+        // URLs use `externalBaseRoute` so they resolve under `basePath` when set.
         const htmlContent = `<!doctype html>
 <html lang="en">
   <head>
@@ -555,12 +559,12 @@ if (container && Component) {
     <title>${widgetName} Widget</title>${
       serverConfig.favicon
         ? `
-    <link rel="icon" href="/_mcp-use/public/${serverConfig.favicon}" />`
+    <link rel="icon" href="${basePath}/_mcp-use/public/${serverConfig.favicon}" />`
         : ""
     }
-    <script type="module" src="${baseRoute}/@vite/client"></script>
+    <script type="module" src="${externalBaseRoute}/@vite/client"></script>
     <script type="module">
-      import RefreshRuntime from '${baseRoute}/@react-refresh';
+      import RefreshRuntime from '${externalBaseRoute}/@react-refresh';
       RefreshRuntime.injectIntoGlobalHook(window);
       window.$RefreshReg$ = () => {};
       window.$RefreshSig$ = () => (type) => type;
@@ -569,7 +573,7 @@ if (container && Component) {
   </head>
   <body>
     <div id="widget-root"></div>
-    <script type="module" src="${baseRoute}/${slugifiedName}/entry.tsx"></script>
+    <script type="module" src="${externalBaseRoute}/${slugifiedName}/entry.tsx"></script>
   </body>
 </html>`;
 
@@ -1143,9 +1147,10 @@ export default PostHog;
   const viteServer = await createServer({
     root: tempDir,
     // Vite's HMR client derives its WebSocket URL from `base`, and asset URLs
-    // emitted by Vite's transform pass use the same value. `_mcp-use/widgets/`
-    // lives at the host root regardless of `basePath`, so this is a constant.
-    base: baseRoute + "/",
+    // emitted by Vite's transform pass use the same value. The browser sees
+    // the full `${basePath}${baseRoute}/` prefix, so that's what Vite emits;
+    // the Hono middleware strips both before forwarding to Vite internally.
+    base: externalBaseRoute + "/",
     plugins: [
       serverOnlyGuard,
       zodJitlessPlugin,
@@ -1298,9 +1303,13 @@ export default PostHog;
     const netModule = await import("node:net");
     const setupWsProxy = (httpServer: import("http").Server) => {
       httpServer.on("upgrade", (req: any, socket: any, head: any) => {
-        // `_mcp-use/widgets/` always lives at root, so the upgrade match
-        // is a fixed string — no basePath interpolation.
-        if (req.url?.startsWith(`${baseRoute}/`) || req.url === baseRoute) {
+        // Match the browser-visible URL (basePath + baseRoute) — the HMR
+        // client connects through the configured `base` so the upgrade
+        // request carries the same prefix the page used.
+        if (
+          req.url?.startsWith(`${externalBaseRoute}/`) ||
+          req.url === externalBaseRoute
+        ) {
           const upstream = netModule.createConnection(
             { port: hmrPort, host: "localhost" },
             () => {
@@ -1324,16 +1333,16 @@ export default PostHog;
       });
     };
 
-    // HMR always lives at the host root, so stash the proxy setup on the
-    // root Hono — the lifecycle helper reads it off whatever app it hands
-    // to `startServer()`, which is always `_rootApp`.
-    (rootApp as any).__viteWsProxy = setupWsProxy;
+    // Stash the proxy setup on `app`. The same Hono instance is passed to
+    // `startServer()`, where the lifecycle helper reads `__viteWsProxy` off
+    // it. The HTTP server proxy itself looks at the raw upgrade URL, which
+    // carries the full basePath-prefixed path the browser used.
+    (app as any).__viteWsProxy = setupWsProxy;
   }
 
-  // Custom middleware to handle widget-specific paths.
-  // Registered on the outer (root) app — `_mcp-use/widgets/` lives at the
-  // host root and is independent of any `basePath` sub-mount.
-  rootApp.use(`${baseRoute}/*`, async (c: Context, next: Next) => {
+  // Custom middleware to handle widget-specific paths. Registered on the
+  // basePath-aware Hono view so it auto-prefixes under `basePath`.
+  app.use(`${baseRoute}/*`, async (c: Context, next: Next) => {
     const url = new URL(c.req.url);
     const pathname = url.pathname;
     const widgetMatch = pathname.replace(baseRoute, "").match(/^\/([^/]+)/);
@@ -1354,10 +1363,10 @@ export default PostHog;
           relativePath === `/${slugifiedNameFromUrl}/`
         ) {
           // Rewrite the URL for Vite by creating a new request with modified URL.
-          // The connect adapter below strips `baseRoute` before handing the
-          // URL to Vite, so the prefix must be present here.
+          // The connect adapter below strips `externalBaseRoute` before
+          // handing the URL to Vite, so the full prefix must be present here.
           const newUrl = new URL(c.req.url);
-          newUrl.pathname = `${baseRoute}/${slugifiedNameFromUrl}/index.html`;
+          newUrl.pathname = `${externalBaseRoute}/${slugifiedNameFromUrl}/index.html`;
           // Create a new request with modified URL and update the context
           const newRequest = new Request(newUrl.toString(), c.req.raw);
           // Update the request in the context by creating a new context-like object
@@ -1378,25 +1387,28 @@ export default PostHog;
   });
 
   // Mount the single Vite server for all widgets using adapter.
-  // The adapter strips its `middlewarePath` prefix from `c.req.raw.url` before
-  // handing the request to Vite. `_mcp-use/widgets/` lives at the host root,
-  // so the prefix is just `baseRoute`.
+  // The adapter strips its `middlewarePath` prefix from `c.req.raw.url`
+  // before handing the request to Vite. Vite's `base` is set to
+  // `externalBaseRoute + "/"`, so we strip the same prefix here — the
+  // request the underlying middleware sees is bare, exactly as it would be
+  // without any prefix.
   const viteMiddleware = await adaptConnectMiddleware(
     viteServer.middlewares,
-    `${baseRoute}/*`
+    `${externalBaseRoute}/*`
   );
-  rootApp.use(`${baseRoute}/*`, viteMiddleware);
+  app.use(`${baseRoute}/*`, viteMiddleware);
 
-  // Serve static files from public directory in dev mode.
-  // Public + favicon always live at root.
+  // Serve static files from public directory in dev mode. Public + favicon
+  // register on the basePath-aware app so they land at
+  // `${basePath}/_mcp-use/public/*` and `${basePath}/favicon.ico`.
   if (!serverConfig.publicRoutesMode) {
-    setupPublicRoutes(rootApp, false);
-    setupFaviconRoute(rootApp, serverConfig.favicon, false);
+    setupPublicRoutes(app, false);
+    setupFaviconRoute(app, serverConfig.favicon, false);
   }
 
   // Add a catch-all 404 handler for widget routes to prevent falling through to other middleware
   // (like the inspector) which might intercept the request and return the wrong content
-  rootApp.use(`${baseRoute}/*`, async (c: Context) => {
+  app.use(`${baseRoute}/*`, async (c: Context) => {
     const url = new URL(c.req.url);
     // Check if it's an asset request
     const isAsset = url.pathname.match(

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/mount-widgets-dev.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/mount-widgets-dev.ts
@@ -696,11 +696,7 @@ if (container && Component) {
           let html = "";
           try {
             html = await fsHelpers.readFileSync(htmlPath);
-            html = processWidgetHtml(
-              html,
-              widgetName,
-              serverConfig.serverBaseUrl
-            );
+            html = processWidgetHtml(html, widgetName);
           } catch (e) {
             console.warn(
               `[WIDGET-HMR] Failed to read HTML for ${widgetName}:`,

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/mount-widgets-dev.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/mount-widgets-dev.ts
@@ -92,6 +92,12 @@ export async function mountWidgetsDev(
 ): Promise<void> {
   const { promises: fs } = await import("node:fs");
   const baseRoute = options?.baseRoute || "/mcp-use/widgets";
+  const basePath = serverConfig.basePath ?? "";
+  // Hono leaves `c.req.path` / `c.req.raw.url` unprefixed across sub-mounts,
+  // so any code that inspects URLs (instead of using the route matcher) needs
+  // the full external prefix. Route patterns passed to `app.use(...)` stay as
+  // `baseRoute` — Hono's matcher composes them with the sub-mount automatically.
+  const externalRoute = `${basePath}${baseRoute}`;
   // Resolution order for the widgets directory:
   //   1. Caller-supplied `options.resourcesDir`
   //   2. `MCP_USE_WIDGETS_DIR` env var (set by @mcp-use/cli when --mcp-dir
@@ -302,9 +308,10 @@ if (container && Component) {
 
     // Include Vite client and React refresh preamble explicitly
     // This is needed when loading in sandboxed iframes where auto-injection may not work
-    // Use the base route path (not full URL) so URLs resolve against the document origin.
-    // This works both locally and behind reverse proxies (ngrok, E2B, etc.)
-    const fullBaseUrl = `${serverConfig.serverBaseUrl}${baseRoute}`;
+    // Use the externally-visible route (basePath + baseRoute) so URLs the
+    // browser actually hits resolve to our Vite mount, not the unprefixed
+    // path which only matches when basePath is empty.
+    const fullBaseUrl = `${serverConfig.serverBaseUrl}${externalRoute}`;
     const htmlContent = `<!doctype html>
 <html lang="en">
   <head>
@@ -313,7 +320,7 @@ if (container && Component) {
     <title>${widget.name} Widget</title>${
       serverConfig.favicon
         ? `
-    <link rel="icon" href="${serverConfig.serverBaseUrl.replace(/\/$/, "")}${serverConfig.basePath ?? ""}/mcp-use/public/${serverConfig.favicon}" />`
+    <link rel="icon" href="${serverConfig.serverBaseUrl.replace(/\/$/, "")}${basePath}/mcp-use/public/${serverConfig.favicon}" />`
         : ""
     }
     <script type="module" src="${fullBaseUrl}/@vite/client"></script>
@@ -546,8 +553,9 @@ if (container && Component) {
 }
 `;
 
-        // Use the base route path for URLs so they resolve against the document origin
-        const fullBaseUrl = `${serverConfig.serverBaseUrl}${baseRoute}`;
+        // Use the externally-visible route (basePath + baseRoute) for URLs so
+        // the browser hits our Vite mount even when basePath is configured.
+        const fullBaseUrl = `${serverConfig.serverBaseUrl}${externalRoute}`;
         const htmlContent = `<!doctype html>
 <html lang="en">
   <head>
@@ -556,7 +564,7 @@ if (container && Component) {
     <title>${widgetName} Widget</title>${
       serverConfig.favicon
         ? `
-    <link rel="icon" href="${serverConfig.serverBaseUrl.replace(/\/$/, "")}${serverConfig.basePath ?? ""}/mcp-use/public/${serverConfig.favicon}" />`
+    <link rel="icon" href="${serverConfig.serverBaseUrl.replace(/\/$/, "")}${basePath}/mcp-use/public/${serverConfig.favicon}" />`
         : ""
     }
     <script type="module" src="${fullBaseUrl}/@vite/client"></script>
@@ -1147,7 +1155,12 @@ export default PostHog;
 
   const viteServer = await createServer({
     root: tempDir,
-    base: baseRoute + "/",
+    // Vite's HMR client derives its WebSocket URL from `base`, and asset URLs
+    // emitted by Vite's transform pass also use it. We point both at the
+    // externally-visible route so the browser hits `${basePath}/mcp-use/widgets/...`
+    // and the WS upgrade matches the proxy set up in setupWsProxy below.
+    // Without basePath, this equals `baseRoute + "/"` — same as before.
+    base: externalRoute + "/",
     plugins: [
       serverOnlyGuard,
       zodJitlessPlugin,
@@ -1296,7 +1309,9 @@ export default PostHog;
 
     // Store the proxy setup function - it will be called when the HTTP server is available
     const hmrPort = viteHmrPort;
-    const widgetRoute = baseRoute;
+    // `req.url` here is the raw Node IncomingMessage URL, which includes any
+    // configured basePath — match against the externally-visible route.
+    const widgetRoute = externalRoute;
     // Pre-import net module at setup time (works in both CJS and ESM)
     const netModule = await import("node:net");
     const setupWsProxy = (httpServer: import("http").Server) => {
@@ -1326,15 +1341,23 @@ export default PostHog;
       });
     };
 
-    // Store for later use when HTTP server is available
+    // Store for later use when HTTP server is available. The lifecycle
+    // helper reads this off the app it actually hands to `startServer` —
+    // when `basePath` is set, that's the outer `_rootApp`, not this inner
+    // app. Stash on both so the lookup hits regardless.
     (app as any).__viteWsProxy = setupWsProxy;
+    if (serverConfig.rootApp && serverConfig.rootApp !== app) {
+      (serverConfig.rootApp as any).__viteWsProxy = setupWsProxy;
+    }
   }
 
   // Custom middleware to handle widget-specific paths
   app.use(`${baseRoute}/*`, async (c: Context, next: Next) => {
     const url = new URL(c.req.url);
     const pathname = url.pathname;
-    const widgetMatch = pathname.replace(baseRoute, "").match(/^\/([^/]+)/);
+    // `pathname` is the full URL including any configured basePath, so strip
+    // the externally-visible route (basePath + baseRoute), not just baseRoute.
+    const widgetMatch = pathname.replace(externalRoute, "").match(/^\/([^/]+)/);
 
     if (widgetMatch) {
       // URL contains slugified widget name, need to find original widget name
@@ -1347,14 +1370,17 @@ export default PostHog;
       if (widget) {
         // If requesting the root of a widget, serve its index.html
         // Use slugified name for URL paths
-        const relativePath = pathname.replace(baseRoute, "");
+        const relativePath = pathname.replace(externalRoute, "");
         if (
           relativePath === `/${slugifiedNameFromUrl}` ||
           relativePath === `/${slugifiedNameFromUrl}/`
         ) {
-          // Rewrite the URL for Vite by creating a new request with modified URL
+          // Rewrite the URL for Vite by creating a new request with modified URL.
+          // Keep the external prefix on the new pathname — downstream middleware
+          // (notably the connect adapter for Vite) strips it before handing
+          // the URL to Vite, so the prefix must be present here.
           const newUrl = new URL(c.req.url);
-          newUrl.pathname = `${baseRoute}/${slugifiedNameFromUrl}/index.html`;
+          newUrl.pathname = `${externalRoute}/${slugifiedNameFromUrl}/index.html`;
           // Create a new request with modified URL and update the context
           const newRequest = new Request(newUrl.toString(), c.req.raw);
           // Update the request in the context by creating a new context-like object
@@ -1374,10 +1400,15 @@ export default PostHog;
     await next();
   });
 
-  // Mount the single Vite server for all widgets using adapter
+  // Mount the single Vite server for all widgets using adapter.
+  // The adapter strips its `middlewarePath` prefix from `c.req.raw.url` before
+  // handing the request to Vite. That URL still has any configured basePath,
+  // so we pass the externally-visible route (basePath + baseRoute) — otherwise
+  // Vite receives e.g. `/api/mcp-use/widgets/foo` and 404s because its `base`
+  // is `/mcp-use/widgets/`.
   const viteMiddleware = await adaptConnectMiddleware(
     viteServer.middlewares,
-    `${baseRoute}/*`
+    `${externalRoute}/*`
   );
   app.use(`${baseRoute}/*`, viteMiddleware);
 

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/mount-widgets-dev.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/mount-widgets-dev.ts
@@ -313,7 +313,7 @@ if (container && Component) {
     <title>${widget.name} Widget</title>${
       serverConfig.favicon
         ? `
-    <link rel="icon" href="${serverConfig.serverBaseUrl.replace(/\/$/, "")}/mcp-use/public/${serverConfig.favicon}" />`
+    <link rel="icon" href="${serverConfig.serverBaseUrl.replace(/\/$/, "")}${serverConfig.basePath ?? ""}/mcp-use/public/${serverConfig.favicon}" />`
         : ""
     }
     <script type="module" src="${fullBaseUrl}/@vite/client"></script>
@@ -556,7 +556,7 @@ if (container && Component) {
     <title>${widgetName} Widget</title>${
       serverConfig.favicon
         ? `
-    <link rel="icon" href="${serverConfig.serverBaseUrl.replace(/\/$/, "")}/mcp-use/public/${serverConfig.favicon}" />`
+    <link rel="icon" href="${serverConfig.serverBaseUrl.replace(/\/$/, "")}${serverConfig.basePath ?? ""}/mcp-use/public/${serverConfig.favicon}" />`
         : ""
     }
     <script type="module" src="${fullBaseUrl}/@vite/client"></script>

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/mount-widgets-dev.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/mount-widgets-dev.ts
@@ -23,7 +23,7 @@ import type {
   UpdateWidgetToolCallback,
 } from "./widget-types.js";
 
-const TMP_MCP_USE_DIR = ".mcp-use";
+const TMP_MCP_USE_DIR = pathHelpers.join(".mcp-use", ".tmp");
 
 const DEFAULT_HMR_PORT = 24678;
 
@@ -83,7 +83,7 @@ type MountWidgetsDevOptions = MountWidgetsOptions;
  * @returns Nothing.
  */
 export async function mountWidgetsDev(
-  app: HonoType,
+  rootApp: HonoType,
   serverConfig: ServerConfig,
   registerWidget: RegisterWidgetCallback,
   updateWidgetTool: UpdateWidgetToolCallback,
@@ -91,13 +91,9 @@ export async function mountWidgetsDev(
   options?: MountWidgetsDevOptions
 ): Promise<void> {
   const { promises: fs } = await import("node:fs");
-  const baseRoute = options?.baseRoute || "/mcp-use/widgets";
-  const basePath = serverConfig.basePath ?? "";
-  // Hono leaves `c.req.path` / `c.req.raw.url` unprefixed across sub-mounts,
-  // so any code that inspects URLs (instead of using the route matcher) needs
-  // the full external prefix. Route patterns passed to `app.use(...)` stay as
-  // `baseRoute` — Hono's matcher composes them with the sub-mount automatically.
-  const externalRoute = `${basePath}${baseRoute}`;
+  const baseRoute = options?.baseRoute || "/_mcp-use/widgets";
+  // All widget routes live at the host root regardless of `basePath`, so
+  // they register directly on `rootApp` (the underlying Hono).
   // Resolution order for the widgets directory:
   //   1. Caller-supplied `options.resourcesDir`
   //   2. `MCP_USE_WIDGETS_DIR` env var (set by @mcp-use/cli when --mcp-dir
@@ -307,11 +303,8 @@ if (container && Component) {
 `;
 
     // Include Vite client and React refresh preamble explicitly
-    // This is needed when loading in sandboxed iframes where auto-injection may not work
-    // Use the externally-visible route (basePath + baseRoute) so URLs the
-    // browser actually hits resolve to our Vite mount, not the unprefixed
-    // path which only matches when basePath is empty.
-    const fullBaseUrl = `${serverConfig.serverBaseUrl}${externalRoute}`;
+    // This is needed when loading in sandboxed iframes where auto-injection may not work.
+    // `_mcp-use/widgets/` lives at the host root, so URLs are bare absolute paths.
     const htmlContent = `<!doctype html>
 <html lang="en">
   <head>
@@ -320,12 +313,12 @@ if (container && Component) {
     <title>${widget.name} Widget</title>${
       serverConfig.favicon
         ? `
-    <link rel="icon" href="${serverConfig.serverBaseUrl.replace(/\/$/, "")}${basePath}/mcp-use/public/${serverConfig.favicon}" />`
+    <link rel="icon" href="/_mcp-use/public/${serverConfig.favicon}" />`
         : ""
     }
-    <script type="module" src="${fullBaseUrl}/@vite/client"></script>
+    <script type="module" src="${baseRoute}/@vite/client"></script>
     <script type="module">
-      import RefreshRuntime from '${fullBaseUrl}/@react-refresh';
+      import RefreshRuntime from '${baseRoute}/@react-refresh';
       RefreshRuntime.injectIntoGlobalHook(window);
       window.$RefreshReg$ = () => {};
       window.$RefreshSig$ = () => (type) => type;
@@ -334,7 +327,7 @@ if (container && Component) {
   </head>
   <body>
     <div id="widget-root"></div>
-    <script type="module" src="${fullBaseUrl}/${slugifiedName}/entry.tsx"></script>
+    <script type="module" src="${baseRoute}/${slugifiedName}/entry.tsx"></script>
   </body>
 </html>`;
 
@@ -553,9 +546,7 @@ if (container && Component) {
 }
 `;
 
-        // Use the externally-visible route (basePath + baseRoute) for URLs so
-        // the browser hits our Vite mount even when basePath is configured.
-        const fullBaseUrl = `${serverConfig.serverBaseUrl}${externalRoute}`;
+        // `_mcp-use/widgets/` lives at the host root, so URLs are bare absolute paths.
         const htmlContent = `<!doctype html>
 <html lang="en">
   <head>
@@ -564,12 +555,12 @@ if (container && Component) {
     <title>${widgetName} Widget</title>${
       serverConfig.favicon
         ? `
-    <link rel="icon" href="${serverConfig.serverBaseUrl.replace(/\/$/, "")}${basePath}/mcp-use/public/${serverConfig.favicon}" />`
+    <link rel="icon" href="/_mcp-use/public/${serverConfig.favicon}" />`
         : ""
     }
-    <script type="module" src="${fullBaseUrl}/@vite/client"></script>
+    <script type="module" src="${baseRoute}/@vite/client"></script>
     <script type="module">
-      import RefreshRuntime from '${fullBaseUrl}/@react-refresh';
+      import RefreshRuntime from '${baseRoute}/@react-refresh';
       RefreshRuntime.injectIntoGlobalHook(window);
       window.$RefreshReg$ = () => {};
       window.$RefreshSig$ = () => (type) => type;
@@ -578,7 +569,7 @@ if (container && Component) {
   </head>
   <body>
     <div id="widget-root"></div>
-    <script type="module" src="${fullBaseUrl}/${slugifiedName}/entry.tsx"></script>
+    <script type="module" src="${baseRoute}/${slugifiedName}/entry.tsx"></script>
   </body>
 </html>`;
 
@@ -1156,11 +1147,9 @@ export default PostHog;
   const viteServer = await createServer({
     root: tempDir,
     // Vite's HMR client derives its WebSocket URL from `base`, and asset URLs
-    // emitted by Vite's transform pass also use it. We point both at the
-    // externally-visible route so the browser hits `${basePath}/mcp-use/widgets/...`
-    // and the WS upgrade matches the proxy set up in setupWsProxy below.
-    // Without basePath, this equals `baseRoute + "/"` — same as before.
-    base: externalRoute + "/",
+    // emitted by Vite's transform pass use the same value. `_mcp-use/widgets/`
+    // lives at the host root regardless of `basePath`, so this is a constant.
+    base: baseRoute + "/",
     plugins: [
       serverOnlyGuard,
       zodJitlessPlugin,
@@ -1309,15 +1298,13 @@ export default PostHog;
 
     // Store the proxy setup function - it will be called when the HTTP server is available
     const hmrPort = viteHmrPort;
-    // `req.url` here is the raw Node IncomingMessage URL, which includes any
-    // configured basePath — match against the externally-visible route.
-    const widgetRoute = externalRoute;
     // Pre-import net module at setup time (works in both CJS and ESM)
     const netModule = await import("node:net");
     const setupWsProxy = (httpServer: import("http").Server) => {
       httpServer.on("upgrade", (req: any, socket: any, head: any) => {
-        // Only proxy requests to the widget base route
-        if (req.url?.startsWith(`${widgetRoute}/`) || req.url === widgetRoute) {
+        // `_mcp-use/widgets/` always lives at root, so the upgrade match
+        // is a fixed string — no basePath interpolation.
+        if (req.url?.startsWith(`${baseRoute}/`) || req.url === baseRoute) {
           const upstream = netModule.createConnection(
             { port: hmrPort, host: "localhost" },
             () => {
@@ -1341,23 +1328,19 @@ export default PostHog;
       });
     };
 
-    // Store for later use when HTTP server is available. The lifecycle
-    // helper reads this off the app it actually hands to `startServer` —
-    // when `basePath` is set, that's the outer `_rootApp`, not this inner
-    // app. Stash on both so the lookup hits regardless.
-    (app as any).__viteWsProxy = setupWsProxy;
-    if (serverConfig.rootApp && serverConfig.rootApp !== app) {
-      (serverConfig.rootApp as any).__viteWsProxy = setupWsProxy;
-    }
+    // HMR always lives at the host root, so stash the proxy setup on the
+    // root Hono — the lifecycle helper reads it off whatever app it hands
+    // to `startServer()`, which is always `_rootApp`.
+    (rootApp as any).__viteWsProxy = setupWsProxy;
   }
 
-  // Custom middleware to handle widget-specific paths
-  app.use(`${baseRoute}/*`, async (c: Context, next: Next) => {
+  // Custom middleware to handle widget-specific paths.
+  // Registered on the outer (root) app — `_mcp-use/widgets/` lives at the
+  // host root and is independent of any `basePath` sub-mount.
+  rootApp.use(`${baseRoute}/*`, async (c: Context, next: Next) => {
     const url = new URL(c.req.url);
     const pathname = url.pathname;
-    // `pathname` is the full URL including any configured basePath, so strip
-    // the externally-visible route (basePath + baseRoute), not just baseRoute.
-    const widgetMatch = pathname.replace(externalRoute, "").match(/^\/([^/]+)/);
+    const widgetMatch = pathname.replace(baseRoute, "").match(/^\/([^/]+)/);
 
     if (widgetMatch) {
       // URL contains slugified widget name, need to find original widget name
@@ -1368,19 +1351,17 @@ export default PostHog;
       );
 
       if (widget) {
-        // If requesting the root of a widget, serve its index.html
-        // Use slugified name for URL paths
-        const relativePath = pathname.replace(externalRoute, "");
+        // If requesting the root of a widget, serve its index.html.
+        const relativePath = pathname.replace(baseRoute, "");
         if (
           relativePath === `/${slugifiedNameFromUrl}` ||
           relativePath === `/${slugifiedNameFromUrl}/`
         ) {
           // Rewrite the URL for Vite by creating a new request with modified URL.
-          // Keep the external prefix on the new pathname — downstream middleware
-          // (notably the connect adapter for Vite) strips it before handing
-          // the URL to Vite, so the prefix must be present here.
+          // The connect adapter below strips `baseRoute` before handing the
+          // URL to Vite, so the prefix must be present here.
           const newUrl = new URL(c.req.url);
-          newUrl.pathname = `${externalRoute}/${slugifiedNameFromUrl}/index.html`;
+          newUrl.pathname = `${baseRoute}/${slugifiedNameFromUrl}/index.html`;
           // Create a new request with modified URL and update the context
           const newRequest = new Request(newUrl.toString(), c.req.raw);
           // Update the request in the context by creating a new context-like object
@@ -1402,29 +1383,24 @@ export default PostHog;
 
   // Mount the single Vite server for all widgets using adapter.
   // The adapter strips its `middlewarePath` prefix from `c.req.raw.url` before
-  // handing the request to Vite. That URL still has any configured basePath,
-  // so we pass the externally-visible route (basePath + baseRoute) — otherwise
-  // Vite receives e.g. `/api/mcp-use/widgets/foo` and 404s because its `base`
-  // is `/mcp-use/widgets/`.
+  // handing the request to Vite. `_mcp-use/widgets/` lives at the host root,
+  // so the prefix is just `baseRoute`.
   const viteMiddleware = await adaptConnectMiddleware(
     viteServer.middlewares,
-    `${externalRoute}/*`
+    `${baseRoute}/*`
   );
-  app.use(`${baseRoute}/*`, viteMiddleware);
+  rootApp.use(`${baseRoute}/*`, viteMiddleware);
 
-  // Serve static files from public directory in dev mode
-  // Only set up if not already configured (e.g., in constructor).
-  // Favicon goes on the outer app so browsers' implicit `/favicon.ico`
-  // resolves regardless of basePath; falls back to inner when no outer.
+  // Serve static files from public directory in dev mode.
+  // Public + favicon always live at root.
   if (!serverConfig.publicRoutesMode) {
-    setupPublicRoutes(app, false);
-    const faviconHost = (serverConfig as any).rootApp ?? app;
-    setupFaviconRoute(faviconHost, serverConfig.favicon, false);
+    setupPublicRoutes(rootApp, false);
+    setupFaviconRoute(rootApp, serverConfig.favicon, false);
   }
 
   // Add a catch-all 404 handler for widget routes to prevent falling through to other middleware
   // (like the inspector) which might intercept the request and return the wrong content
-  app.use(`${baseRoute}/*`, async (c: Context) => {
+  rootApp.use(`${baseRoute}/*`, async (c: Context) => {
     const url = new URL(c.req.url);
     // Check if it's an asset request
     const isAsset = url.pathname.match(

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/mount-widgets-dev.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/mount-widgets-dev.ts
@@ -1382,10 +1382,13 @@ export default PostHog;
   app.use(`${baseRoute}/*`, viteMiddleware);
 
   // Serve static files from public directory in dev mode
-  // Only set up if not already configured (e.g., in constructor)
+  // Only set up if not already configured (e.g., in constructor).
+  // Favicon goes on the outer app so browsers' implicit `/favicon.ico`
+  // resolves regardless of basePath; falls back to inner when no outer.
   if (!serverConfig.publicRoutesMode) {
     setupPublicRoutes(app, false);
-    setupFaviconRoute(app, serverConfig.favicon, false);
+    const faviconHost = (serverConfig as any).rootApp ?? app;
+    setupFaviconRoute(faviconHost, serverConfig.favicon, false);
   }
 
   // Add a catch-all 404 handler for widget routes to prevent falling through to other middleware

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/mount-widgets-production.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/mount-widgets-production.ts
@@ -27,7 +27,7 @@ type MountWidgetsProductionOptions = MountWidgetsOptions;
  * Reads the manifest file to discover available widgets and their metadata,
  * then registers each widget as both a tool and resource.
  *
- * @param _rootApp - Underlying Hono instance (currently unused; kept for
+ * @param _app - basePath-aware Hono view (currently unused; kept for
  *   signature parity with the dev variant and future static-route needs)
  * @param serverConfig - Server configuration (baseUrl, CSP URLs, buildId)
  * @param registerWidget - Callback to register each discovered widget
@@ -35,7 +35,7 @@ type MountWidgetsProductionOptions = MountWidgetsOptions;
  * @returns Promise that resolves when all widgets are mounted
  */
 export async function mountWidgetsProduction(
-  _rootApp: HonoType,
+  _app: HonoType,
   serverConfig: ServerConfig,
   registerWidget: RegisterWidgetCallback,
   options?: MountWidgetsProductionOptions

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/mount-widgets-production.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/mount-widgets-production.ts
@@ -1,7 +1,7 @@
 /**
  * Production mode widget mounting
  *
- * This module handles serving pre-built widgets from the dist/resources/widgets/ directory.
+ * This module handles serving pre-built widgets from the .mcp-use/widgets/ directory.
  * Widgets are built using the 'mcp-use build' command and served as static files in production.
  */
 
@@ -21,36 +21,36 @@ import type {
 type MountWidgetsProductionOptions = MountWidgetsOptions;
 
 /**
- * Mount pre-built widgets from dist/resources/widgets/ directory in production mode
+ * Mount pre-built widgets from .mcp-use/widgets/ directory in production mode
  *
  * Serves static widget bundles that were built using the build command.
  * Reads the manifest file to discover available widgets and their metadata,
  * then registers each widget as both a tool and resource.
  *
- * @param app - Hono app instance (not used directly, kept for consistency)
+ * @param _rootApp - Underlying Hono instance (currently unused; kept for
+ *   signature parity with the dev variant and future static-route needs)
  * @param serverConfig - Server configuration (baseUrl, CSP URLs, buildId)
  * @param registerWidget - Callback to register each discovered widget
  * @param options - Optional configuration (baseRoute)
  * @returns Promise that resolves when all widgets are mounted
  */
 export async function mountWidgetsProduction(
-  app: HonoType,
+  _rootApp: HonoType,
   serverConfig: ServerConfig,
   registerWidget: RegisterWidgetCallback,
   options?: MountWidgetsProductionOptions
 ): Promise<void> {
-  const baseRoute = options?.baseRoute || "/mcp-use/widgets";
+  const baseRoute = options?.baseRoute || "/_mcp-use/widgets";
   const widgetsDir = pathHelpers.join(
     isDeno ? "." : getCwd(),
-    "dist",
-    "resources",
+    ".mcp-use",
     "widgets"
   );
 
   console.log("widgetsDir", widgetsDir);
 
   // Discover built widgets from manifest
-  const manifestPath = "./dist/mcp-use.json";
+  const manifestPath = "./.mcp-use/manifest.json";
   let widgets: string[] = [];
   let widgetsMetadata: Record<string, any> = {};
 
@@ -109,7 +109,7 @@ export async function mountWidgetsProduction(
   }
 
   console.log(
-    `[WIDGETS] Serving ${widgets.length} pre-built widget(s) from dist/resources/widgets/`
+    `[WIDGETS] Serving ${widgets.length} pre-built widget(s) from .mcp-use/widgets/`
   );
 
   // Register tools and resources for each widget

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/setup-widget-routes.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/setup-widget-routes.ts
@@ -5,47 +5,62 @@
  * and public resources in production mode.
  */
 
-import type { Hono as HonoType, Context } from "hono";
-import { pathHelpers, fsHelpers, getCwd } from "../utils/runtime.js";
+import type { Context, Hono as HonoType } from "hono";
+import { fsHelpers, getCwd, pathHelpers } from "../utils/runtime.js";
 import {
   getContentType,
   processWidgetHtml,
-  setupPublicRoutes,
   setupFaviconRoute,
+  setupPublicRoutes,
 } from "./widget-helpers.js";
 import type { ServerConfig } from "./widget-types.js";
 
 /**
  * Setup static file serving routes for widgets
  *
- * Creates HTTP routes to serve:
- * - Widget assets (JS, CSS, images) from dist/resources/widgets/{widget}/assets/
- * - Widget HTML files from dist/resources/widgets/{widget}/index.html
- * - Public files from dist/public/ or public/ directories
+ * Routes (always at the host root — basePath-agnostic):
+ * - `/_mcp-use/widgets/{widget}`              → .mcp-use/widgets/{widget}/index.html
+ * - `/_mcp-use/widgets/{widget}/assets/*`     → .mcp-use/widgets/{widget}/assets/*
+ * - `/_mcp-use/public/*`                      → .mcp-use/public/*
  *
- * These routes are used in production mode to serve pre-built widget bundles.
+ * Widget HTML is post-processed via `processWidgetHtml` so emitted asset
+ * URLs are bare `/_mcp-use/widgets/...` references.
  *
- * @param app - Hono app instance to mount routes on
- * @param serverConfig - Server configuration (baseUrl)
+ * @param rootApp - The underlying Hono instance. All `_mcp-use/*` routes
+ *   register here so they bypass any `basePath` prefix.
+ * @param serverConfig - Server configuration.
  */
 export function setupWidgetRoutes(
-  app: HonoType,
+  rootApp: HonoType,
   serverConfig: ServerConfig
 ): void {
-  const basePath = serverConfig.basePath ?? "";
-  // Register on the inner app at bare paths. When `basePath` is configured
-  // the inner app is sub-mounted under it externally, so these become
-  // `${basePath}/mcp-use/widgets/...` from the outside. `basePath` is still
-  // threaded into `processWidgetHtml` because emitted HTML needs absolute
-  // URLs that include the prefix.
-  // Serve static assets (JS, CSS) from the assets directory
-  app.get("/mcp-use/widgets/:widget/assets/*", async (c: Context) => {
+  // Widget HTML (single index.html per widget)
+  rootApp.get("/_mcp-use/widgets/:widget", async (c: Context) => {
+    const widget = c.req.param("widget")!;
+    const filePath = pathHelpers.join(
+      getCwd(),
+      ".mcp-use",
+      "widgets",
+      widget,
+      "index.html"
+    );
+
+    try {
+      let html = await fsHelpers.readFileSync(filePath, "utf8");
+      html = processWidgetHtml(html, widget, serverConfig.serverBaseUrl);
+      return c.html(html);
+    } catch {
+      return c.notFound();
+    }
+  });
+
+  // Widget assets (JS/CSS/images) — single handler, prefix-strip → file path.
+  rootApp.get("/_mcp-use/widgets/:widget/assets/*", async (c: Context) => {
     const widget = c.req.param("widget")!;
     const assetFile = c.req.path.split("/assets/")[1];
     const assetPath = pathHelpers.join(
       getCwd(),
-      "dist",
-      "resources",
+      ".mcp-use",
       "widgets",
       widget,
       "assets",
@@ -55,10 +70,9 @@ export function setupWidgetRoutes(
     try {
       if (await fsHelpers.existsSync(assetPath)) {
         const content = await fsHelpers.readFile(assetPath);
-        const contentType = getContentType(assetFile);
         return new Response(content, {
           status: 200,
-          headers: { "Content-Type": contentType },
+          headers: { "Content-Type": getContentType(assetFile) },
         });
       }
       return c.notFound();
@@ -67,79 +81,9 @@ export function setupWidgetRoutes(
     }
   });
 
-  // Handle assets served from the wrong path (browser resolves ./assets/ relative to /mcp-use/widgets/)
-  app.get("/mcp-use/widgets/assets/*", async (c: Context) => {
-    const assetFile = c.req.path.split("/assets/")[1];
-    // Try to find which widget this asset belongs to by checking all widget directories
-    const widgetsDir = pathHelpers.join(
-      getCwd(),
-      "dist",
-      "resources",
-      "widgets"
-    );
+  // Public assets at `/_mcp-use/public/*`
+  setupPublicRoutes(rootApp, true);
 
-    try {
-      const widgets = await fsHelpers.readdirSync(widgetsDir);
-      for (const widget of widgets) {
-        const assetPath = pathHelpers.join(
-          widgetsDir,
-          widget,
-          "assets",
-          assetFile
-        );
-        if (await fsHelpers.existsSync(assetPath)) {
-          const content = await fsHelpers.readFile(assetPath);
-          const contentType = getContentType(assetFile);
-          return new Response(content, {
-            status: 200,
-            headers: { "Content-Type": contentType },
-          });
-        }
-      }
-      return c.notFound();
-    } catch {
-      return c.notFound();
-    }
-  });
-
-  // Serve each widget's index.html at its route
-  // e.g. GET /mcp-use/widgets/kanban-board -> dist/resources/widgets/kanban-board/index.html
-  app.get("/mcp-use/widgets/:widget", async (c: Context) => {
-    const widget = c.req.param("widget")!;
-    const filePath = pathHelpers.join(
-      getCwd(),
-      "dist",
-      "resources",
-      "widgets",
-      widget,
-      "index.html"
-    );
-
-    try {
-      let html = await fsHelpers.readFileSync(filePath, "utf8");
-      // Process HTML with base URL injection and path conversion.
-      // basePath still flows in here because emitted <script src>/<link href>
-      // URLs need to be absolute and include the prefix so the browser
-      // requests `${baseUrl}${basePath}/mcp-use/widgets/...`.
-      html = processWidgetHtml(
-        html,
-        widget,
-        serverConfig.serverBaseUrl,
-        basePath
-      );
-      return c.html(html);
-    } catch {
-      return c.notFound();
-    }
-  });
-
-  // Serve static files from public directory (production mode)
-  setupPublicRoutes(app, true);
-
-  // Setup favicon at server root (production mode). Register on the outer
-  // app so browsers' implicit `GET /favicon.ico` always resolves — even
-  // when `basePath` is set and the inner app only handles prefixed
-  // requests. Falls back to the inner app when no outer is supplied.
-  const faviconHost = (serverConfig as any).rootApp ?? app;
-  setupFaviconRoute(faviconHost, serverConfig.favicon, true);
+  // Favicon at server root (production mode).
+  setupFaviconRoute(rootApp, serverConfig.favicon, true);
 }

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/setup-widget-routes.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/setup-widget-routes.ts
@@ -34,33 +34,36 @@ export function setupWidgetRoutes(
 ): void {
   const basePath = serverConfig.basePath ?? "";
   // Serve static assets (JS, CSS) from the assets directory
-  app.get(`${basePath}/mcp-use/widgets/:widget/assets/*`, async (c: Context) => {
-    const widget = c.req.param("widget")!;
-    const assetFile = c.req.path.split("/assets/")[1];
-    const assetPath = pathHelpers.join(
-      getCwd(),
-      "dist",
-      "resources",
-      "widgets",
-      widget,
-      "assets",
-      assetFile
-    );
+  app.get(
+    `${basePath}/mcp-use/widgets/:widget/assets/*`,
+    async (c: Context) => {
+      const widget = c.req.param("widget")!;
+      const assetFile = c.req.path.split("/assets/")[1];
+      const assetPath = pathHelpers.join(
+        getCwd(),
+        "dist",
+        "resources",
+        "widgets",
+        widget,
+        "assets",
+        assetFile
+      );
 
-    try {
-      if (await fsHelpers.existsSync(assetPath)) {
-        const content = await fsHelpers.readFile(assetPath);
-        const contentType = getContentType(assetFile);
-        return new Response(content, {
-          status: 200,
-          headers: { "Content-Type": contentType },
-        });
+      try {
+        if (await fsHelpers.existsSync(assetPath)) {
+          const content = await fsHelpers.readFile(assetPath);
+          const contentType = getContentType(assetFile);
+          return new Response(content, {
+            status: 200,
+            headers: { "Content-Type": contentType },
+          });
+        }
+        return c.notFound();
+      } catch {
+        return c.notFound();
       }
-      return c.notFound();
-    } catch {
-      return c.notFound();
     }
-  });
+  );
 
   // Handle assets served from the wrong path (browser resolves ./assets/ relative to /mcp-use/widgets/)
   app.get(`${basePath}/mcp-use/widgets/assets/*`, async (c: Context) => {
@@ -113,7 +116,12 @@ export function setupWidgetRoutes(
     try {
       let html = await fsHelpers.readFileSync(filePath, "utf8");
       // Process HTML with base URL injection and path conversion
-      html = processWidgetHtml(html, widget, serverConfig.serverBaseUrl, basePath);
+      html = processWidgetHtml(
+        html,
+        widget,
+        serverConfig.serverBaseUrl,
+        basePath
+      );
       return c.html(html);
     } catch {
       return c.notFound();

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/setup-widget-routes.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/setup-widget-routes.ts
@@ -32,8 +32,9 @@ export function setupWidgetRoutes(
   app: HonoType,
   serverConfig: ServerConfig
 ): void {
+  const basePath = serverConfig.basePath ?? "";
   // Serve static assets (JS, CSS) from the assets directory
-  app.get("/mcp-use/widgets/:widget/assets/*", async (c: Context) => {
+  app.get(`${basePath}/mcp-use/widgets/:widget/assets/*`, async (c: Context) => {
     const widget = c.req.param("widget")!;
     const assetFile = c.req.path.split("/assets/")[1];
     const assetPath = pathHelpers.join(
@@ -62,7 +63,7 @@ export function setupWidgetRoutes(
   });
 
   // Handle assets served from the wrong path (browser resolves ./assets/ relative to /mcp-use/widgets/)
-  app.get("/mcp-use/widgets/assets/*", async (c: Context) => {
+  app.get(`${basePath}/mcp-use/widgets/assets/*`, async (c: Context) => {
     const assetFile = c.req.path.split("/assets/")[1];
     // Try to find which widget this asset belongs to by checking all widget directories
     const widgetsDir = pathHelpers.join(
@@ -98,7 +99,7 @@ export function setupWidgetRoutes(
 
   // Serve each widget's index.html at its route
   // e.g. GET /mcp-use/widgets/kanban-board -> dist/resources/widgets/kanban-board/index.html
-  app.get("/mcp-use/widgets/:widget", async (c: Context) => {
+  app.get(`${basePath}/mcp-use/widgets/:widget`, async (c: Context) => {
     const widget = c.req.param("widget")!;
     const filePath = pathHelpers.join(
       getCwd(),
@@ -112,7 +113,7 @@ export function setupWidgetRoutes(
     try {
       let html = await fsHelpers.readFileSync(filePath, "utf8");
       // Process HTML with base URL injection and path conversion
-      html = processWidgetHtml(html, widget, serverConfig.serverBaseUrl);
+      html = processWidgetHtml(html, widget, serverConfig.serverBaseUrl, basePath);
       return c.html(html);
     } catch {
       return c.notFound();
@@ -120,8 +121,8 @@ export function setupWidgetRoutes(
   });
 
   // Serve static files from public directory (production mode)
-  setupPublicRoutes(app, true);
+  setupPublicRoutes(app, true, basePath);
 
   // Setup favicon route at server root (production mode)
-  setupFaviconRoute(app, serverConfig.favicon, true);
+  setupFaviconRoute(app, serverConfig.favicon, true, basePath);
 }

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/setup-widget-routes.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/setup-widget-routes.ts
@@ -1,86 +1,87 @@
 /**
  * Static widget route handlers
  *
- * This module sets up HTTP routes for serving widget assets, HTML files,
- * and public resources in production mode.
+ * In production, `/_mcp-use/*` is a pure static-file namespace mapped to
+ * `.mcp-use/` on disk — Next.js-style. Built HTML already contains the
+ * runtime globals it needs (baked in by the CLI's `buildWidgets`), so the
+ * framework just ships bytes.
  */
 
+import { serveStatic } from "@hono/node-server/serve-static";
 import type { Context, Hono as HonoType } from "hono";
-import { fsHelpers, getCwd, pathHelpers } from "../utils/runtime.js";
-import {
-  getContentType,
-  processWidgetHtml,
-  setupFaviconRoute,
-  setupPublicRoutes,
-} from "./widget-helpers.js";
+import { fsHelpers, getCwd, isDeno, pathHelpers } from "../utils/runtime.js";
+import { getContentType, setupFaviconRoute } from "./widget-helpers.js";
 import type { ServerConfig } from "./widget-types.js";
 
 /**
- * Setup static file serving routes for widgets
+ * Mount static routes for `/_mcp-use/*` on the root Hono app.
  *
- * Routes (always at the host root — basePath-agnostic):
- * - `/_mcp-use/widgets/{widget}`              → .mcp-use/widgets/{widget}/index.html
- * - `/_mcp-use/widgets/{widget}/assets/*`     → .mcp-use/widgets/{widget}/assets/*
- * - `/_mcp-use/public/*`                      → .mcp-use/public/*
+ * Node + Bun: one `serveStatic` mount handles widgets, assets, and public
+ * files in a single middleware. Deno can't use `@hono/node-server`, so it
+ * falls back to hand-rolled handlers that go through the `fsHelpers`
+ * cross-runtime shim.
  *
- * Widget HTML is post-processed via `processWidgetHtml` so emitted asset
- * URLs are bare `/_mcp-use/widgets/...` references.
+ * Favicon is registered separately at `/favicon.ico` because it lives
+ * outside the `/_mcp-use/` namespace and needs an explicit Cache-Control
+ * header that `serveStatic` doesn't add by default.
  *
- * @param rootApp - The underlying Hono instance. All `_mcp-use/*` routes
- *   register here so they bypass any `basePath` prefix.
+ * @param rootApp - Underlying Hono instance. `/_mcp-use/*` always mounts at
+ *   the host root, so it bypasses any `basePath` prefix.
  * @param serverConfig - Server configuration.
  */
 export function setupWidgetRoutes(
   rootApp: HonoType,
   serverConfig: ServerConfig
 ): void {
-  // Widget HTML (single index.html per widget)
-  rootApp.get("/_mcp-use/widgets/:widget", async (c: Context) => {
-    const widget = c.req.param("widget")!;
-    const filePath = pathHelpers.join(
-      getCwd(),
-      ".mcp-use",
-      "widgets",
-      widget,
-      "index.html"
+  if (isDeno) {
+    setupWidgetRoutesDeno(rootApp);
+  } else {
+    rootApp.get(
+      "/_mcp-use/*",
+      serveStatic({
+        root: "./.mcp-use",
+        rewriteRequestPath: (p) => p.replace(/^\/_mcp-use/, ""),
+      })
     );
+  }
 
+  setupFaviconRoute(rootApp, serverConfig.favicon, true);
+}
+
+/**
+ * Deno fallback — three small handlers backed by `fsHelpers.readFile`.
+ * Kept separate so the Node/Bun path stays a one-liner.
+ */
+function setupWidgetRoutesDeno(rootApp: HonoType): void {
+  const serveDenoFile = async (
+    c: Context,
+    segments: string[]
+  ): Promise<Response> => {
+    const fullPath = pathHelpers.join(getCwd(), ".mcp-use", ...segments);
     try {
-      let html = await fsHelpers.readFileSync(filePath, "utf8");
-      html = processWidgetHtml(html, widget, serverConfig.serverBaseUrl);
-      return c.html(html);
-    } catch {
-      return c.notFound();
-    }
-  });
-
-  // Widget assets (JS/CSS/images) — single handler, prefix-strip → file path.
-  rootApp.get("/_mcp-use/widgets/:widget/assets/*", async (c: Context) => {
-    const widget = c.req.param("widget")!;
-    const assetFile = c.req.path.split("/assets/")[1];
-    const assetPath = pathHelpers.join(
-      getCwd(),
-      ".mcp-use",
-      "widgets",
-      widget,
-      "assets",
-      assetFile
-    );
-
-    try {
-      const content = await fsHelpers.readFile(assetPath);
+      const content = await fsHelpers.readFile(fullPath);
       return new Response(content, {
         status: 200,
-        headers: { "Content-Type": getContentType(assetFile) },
+        headers: { "Content-Type": getContentType(segments.at(-1) ?? "") },
       });
     } catch {
       return c.notFound();
     }
+  };
+
+  rootApp.get("/_mcp-use/widgets/:widget", async (c) => {
+    const widget = c.req.param("widget")!;
+    return serveDenoFile(c, ["widgets", widget, "index.html"]);
   });
 
-  // Public assets at `/_mcp-use/public/*`
-  setupPublicRoutes(rootApp, true);
+  rootApp.get("/_mcp-use/widgets/:widget/assets/*", async (c) => {
+    const widget = c.req.param("widget")!;
+    const assetFile = c.req.path.split("/assets/")[1] ?? "";
+    return serveDenoFile(c, ["widgets", widget, "assets", assetFile]);
+  });
 
-  // Favicon at server root (production mode).
-  setupFaviconRoute(rootApp, serverConfig.favicon, true);
+  rootApp.get("/_mcp-use/public/*", async (c) => {
+    const filePath = c.req.path.split("/_mcp-use/public/")[1] ?? "";
+    return serveDenoFile(c, ["public", filePath]);
+  });
 }

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/setup-widget-routes.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/setup-widget-routes.ts
@@ -1,10 +1,10 @@
 /**
  * Static widget route handlers
  *
- * In production, `/_mcp-use/*` is a pure static-file namespace mapped to
- * `.mcp-use/` on disk — Next.js-style. Built HTML already contains the
- * runtime globals it needs (baked in by the CLI's `buildWidgets`), so the
- * framework just ships bytes.
+ * In production, `${basePath}/_mcp-use/*` is a pure static-file namespace
+ * mapped to `.mcp-use/` on disk — Next.js-style. Built HTML already contains
+ * the runtime globals it needs (baked in by the CLI's `buildWidgets`), so
+ * the framework just ships bytes.
  */
 
 import { serveStatic } from "@hono/node-server/serve-static";
@@ -14,45 +14,59 @@ import { getContentType, setupFaviconRoute } from "./widget-helpers.js";
 import type { ServerConfig } from "./widget-types.js";
 
 /**
- * Mount static routes for `/_mcp-use/*` on the root Hono app.
+ * Mount static routes for `${basePath}/_mcp-use/*` on the basePath-aware app.
  *
  * Node + Bun: one `serveStatic` mount handles widgets, assets, and public
  * files in a single middleware. Deno can't use `@hono/node-server`, so it
  * falls back to hand-rolled handlers that go through the `fsHelpers`
  * cross-runtime shim.
  *
- * Favicon is registered separately at `/favicon.ico` because it lives
- * outside the `/_mcp-use/` namespace and needs an explicit Cache-Control
+ * Favicon is registered separately at `/favicon.ico` (basePath-prefixed
+ * to `${basePath}/favicon.ico`) because it needs an explicit Cache-Control
  * header that `serveStatic` doesn't add by default.
  *
- * @param rootApp - Underlying Hono instance. `/_mcp-use/*` always mounts at
- *   the host root, so it bypasses any `basePath` prefix.
+ * @param app - basePath-aware Hono view. The `/_mcp-use/*` route below is
+ *   auto-prefixed to `${basePath}/_mcp-use/*`.
  * @param serverConfig - Server configuration.
+ * @param basePath - Server basePath prefix (e.g. `/api`). Used by the
+ *   serveStatic rewriter to strip the prefix before mapping to disk paths.
  */
 export function setupWidgetRoutes(
-  rootApp: HonoType,
-  serverConfig: ServerConfig
+  app: HonoType,
+  serverConfig: ServerConfig,
+  basePath: string = ""
 ): void {
   if (isDeno) {
-    setupWidgetRoutesDeno(rootApp);
+    setupWidgetRoutesDeno(app);
   } else {
-    rootApp.get(
+    app.get(
       "/_mcp-use/*",
       serveStatic({
         root: "./.mcp-use",
-        rewriteRequestPath: (p) => p.replace(/^\/_mcp-use/, ""),
+        // Strip both the basePath prefix and the `/_mcp-use` namespace to
+        // get a path relative to `./.mcp-use/` on disk. Works whether or not
+        // basePath is set.
+        rewriteRequestPath: (p) =>
+          p.replace(new RegExp(`^${escapeRegex(basePath)}/_mcp-use`), ""),
       })
     );
   }
 
-  setupFaviconRoute(rootApp, serverConfig.favicon, true);
+  setupFaviconRoute(app, serverConfig.favicon, true);
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 /**
  * Deno fallback — three small handlers backed by `fsHelpers.readFile`.
  * Kept separate so the Node/Bun path stays a one-liner.
+ *
+ * The handlers slice `c.req.path` on the `/_mcp-use/...` segment instead of
+ * matching from the start, so they work regardless of basePath.
  */
-function setupWidgetRoutesDeno(rootApp: HonoType): void {
+function setupWidgetRoutesDeno(app: HonoType): void {
   const serveDenoFile = async (
     c: Context,
     segments: string[]
@@ -69,18 +83,18 @@ function setupWidgetRoutesDeno(rootApp: HonoType): void {
     }
   };
 
-  rootApp.get("/_mcp-use/widgets/:widget", async (c) => {
+  app.get("/_mcp-use/widgets/:widget", async (c) => {
     const widget = c.req.param("widget")!;
     return serveDenoFile(c, ["widgets", widget, "index.html"]);
   });
 
-  rootApp.get("/_mcp-use/widgets/:widget/assets/*", async (c) => {
+  app.get("/_mcp-use/widgets/:widget/assets/*", async (c) => {
     const widget = c.req.param("widget")!;
     const assetFile = c.req.path.split("/assets/")[1] ?? "";
     return serveDenoFile(c, ["widgets", widget, "assets", assetFile]);
   });
 
-  rootApp.get("/_mcp-use/public/*", async (c) => {
+  app.get("/_mcp-use/public/*", async (c) => {
     const filePath = c.req.path.split("/_mcp-use/public/")[1] ?? "";
     return serveDenoFile(c, ["public", filePath]);
   });

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/setup-widget-routes.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/setup-widget-routes.ts
@@ -33,40 +33,42 @@ export function setupWidgetRoutes(
   serverConfig: ServerConfig
 ): void {
   const basePath = serverConfig.basePath ?? "";
+  // Register on the inner app at bare paths. When `basePath` is configured
+  // the inner app is sub-mounted under it externally, so these become
+  // `${basePath}/mcp-use/widgets/...` from the outside. `basePath` is still
+  // threaded into `processWidgetHtml` because emitted HTML needs absolute
+  // URLs that include the prefix.
   // Serve static assets (JS, CSS) from the assets directory
-  app.get(
-    `${basePath}/mcp-use/widgets/:widget/assets/*`,
-    async (c: Context) => {
-      const widget = c.req.param("widget")!;
-      const assetFile = c.req.path.split("/assets/")[1];
-      const assetPath = pathHelpers.join(
-        getCwd(),
-        "dist",
-        "resources",
-        "widgets",
-        widget,
-        "assets",
-        assetFile
-      );
+  app.get("/mcp-use/widgets/:widget/assets/*", async (c: Context) => {
+    const widget = c.req.param("widget")!;
+    const assetFile = c.req.path.split("/assets/")[1];
+    const assetPath = pathHelpers.join(
+      getCwd(),
+      "dist",
+      "resources",
+      "widgets",
+      widget,
+      "assets",
+      assetFile
+    );
 
-      try {
-        if (await fsHelpers.existsSync(assetPath)) {
-          const content = await fsHelpers.readFile(assetPath);
-          const contentType = getContentType(assetFile);
-          return new Response(content, {
-            status: 200,
-            headers: { "Content-Type": contentType },
-          });
-        }
-        return c.notFound();
-      } catch {
-        return c.notFound();
+    try {
+      if (await fsHelpers.existsSync(assetPath)) {
+        const content = await fsHelpers.readFile(assetPath);
+        const contentType = getContentType(assetFile);
+        return new Response(content, {
+          status: 200,
+          headers: { "Content-Type": contentType },
+        });
       }
+      return c.notFound();
+    } catch {
+      return c.notFound();
     }
-  );
+  });
 
   // Handle assets served from the wrong path (browser resolves ./assets/ relative to /mcp-use/widgets/)
-  app.get(`${basePath}/mcp-use/widgets/assets/*`, async (c: Context) => {
+  app.get("/mcp-use/widgets/assets/*", async (c: Context) => {
     const assetFile = c.req.path.split("/assets/")[1];
     // Try to find which widget this asset belongs to by checking all widget directories
     const widgetsDir = pathHelpers.join(
@@ -102,7 +104,7 @@ export function setupWidgetRoutes(
 
   // Serve each widget's index.html at its route
   // e.g. GET /mcp-use/widgets/kanban-board -> dist/resources/widgets/kanban-board/index.html
-  app.get(`${basePath}/mcp-use/widgets/:widget`, async (c: Context) => {
+  app.get("/mcp-use/widgets/:widget", async (c: Context) => {
     const widget = c.req.param("widget")!;
     const filePath = pathHelpers.join(
       getCwd(),
@@ -115,7 +117,10 @@ export function setupWidgetRoutes(
 
     try {
       let html = await fsHelpers.readFileSync(filePath, "utf8");
-      // Process HTML with base URL injection and path conversion
+      // Process HTML with base URL injection and path conversion.
+      // basePath still flows in here because emitted <script src>/<link href>
+      // URLs need to be absolute and include the prefix so the browser
+      // requests `${baseUrl}${basePath}/mcp-use/widgets/...`.
       html = processWidgetHtml(
         html,
         widget,
@@ -129,8 +134,12 @@ export function setupWidgetRoutes(
   });
 
   // Serve static files from public directory (production mode)
-  setupPublicRoutes(app, true, basePath);
+  setupPublicRoutes(app, true);
 
-  // Setup favicon route at server root (production mode)
-  setupFaviconRoute(app, serverConfig.favicon, true, basePath);
+  // Setup favicon at server root (production mode). Register on the outer
+  // app so browsers' implicit `GET /favicon.ico` always resolves — even
+  // when `basePath` is set and the inner app only handles prefixed
+  // requests. Falls back to the inner app when no outer is supplied.
+  const faviconHost = (serverConfig as any).rootApp ?? app;
+  setupFaviconRoute(faviconHost, serverConfig.favicon, true);
 }

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/setup-widget-routes.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/setup-widget-routes.ts
@@ -68,14 +68,11 @@ export function setupWidgetRoutes(
     );
 
     try {
-      if (await fsHelpers.existsSync(assetPath)) {
-        const content = await fsHelpers.readFile(assetPath);
-        return new Response(content, {
-          status: 200,
-          headers: { "Content-Type": getContentType(assetFile) },
-        });
-      }
-      return c.notFound();
+      const content = await fsHelpers.readFile(assetPath);
+      return new Response(content, {
+        status: 200,
+        headers: { "Content-Type": getContentType(assetFile) },
+      });
     } catch {
       return c.notFound();
     }

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/ui-resource-registration.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/ui-resource-registration.ts
@@ -42,6 +42,8 @@ interface UIResourceServer {
   readonly serverHost: string;
   readonly serverPort?: number;
   readonly serverBaseUrl?: string;
+  /** Normalized basePath prefix (e.g. "/api"). Empty string when unset. */
+  readonly basePath?: string;
   /** Storage for widget definitions, used to inject metadata into tool responses */
   widgetDefinitions: Map<string, Record<string, unknown>>;
   /** Registrations storage for checking existing registrations (for HMR updates) */
@@ -274,6 +276,7 @@ export function uiResourceRegistration<T extends UIResourceServer>(
     serverPort: server.serverPort || 3000,
     serverBaseUrl: server.serverBaseUrl,
     buildId: server.buildId,
+    basePath: server.basePath,
   };
 
   // Per MCP Apps spec (SEP-1865): resource _meta.ui should contain CSP,

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/widget-helpers.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/widget-helpers.ts
@@ -294,78 +294,32 @@ export function getContentType(filename: string): string {
 }
 
 /**
- * Process widget HTML with base URL injection and path conversion
+ * Inject runtime globals into widget HTML.
+ *
+ * Production builds bake these globals at build time
+ * (`packages/cli/src/index.ts`), so this function is effectively dev-only —
+ * the CLI's `buildWidgets` already wrote the script into `.mcp-use/widgets/
+ * &lt;name&gt;/index.html` before it lands on disk. It stays here for the dev
+ * Vite middleware, which serves un-baked HTML on the fly.
+ *
+ * Idempotent: if the globals are already present (production reads), this
+ * is a no-op.
  *
  * @param html - Original HTML content
- * @param widgetName - Widget identifier
- * @param baseUrl - Server base URL
- * @returns Processed HTML with injected base tag and absolute URLs
- *
- * @example
- * ```typescript
- * const html = '<html><head></head><body>...</body></html>';
- * const processed = processWidgetHtml(html, 'kanban-board', 'http://localhost:3000');
- * ```
+ * @param widgetName - Widget identifier (will be slugified for URL paths)
+ * @returns HTML with the globals script injected after the opening `<head>`
  */
-export function processWidgetHtml(
-  html: string,
-  widgetName: string,
-  baseUrl: string
-): string {
-  let processedHtml = html;
-
-  // Inject or replace base tag with server base URL
-  if (baseUrl && processedHtml) {
-    // Strip HTML comments before probing for a <base> tag so we don't match
-    // one inside a comment. HTML comments can't nest, so one pass suffices.
-    const htmlWithoutComments = processedHtml.replace(/<!--[\s\S]*?-->/g, "");
-
-    // Try to replace existing base tag (only if not in comments)
-    const baseTagRegex = /<base\s+[^>]*\/?>/i;
-    if (baseTagRegex.test(htmlWithoutComments)) {
-      // Find and replace the actual base tag in the original HTML
-      const actualBaseTagMatch = processedHtml.match(/<base\s+[^>]*\/?>/i);
-      if (actualBaseTagMatch) {
-        processedHtml = processedHtml.replace(
-          actualBaseTagMatch[0],
-          `<base href="${baseUrl}" />`
-        );
-      }
-    } else {
-      // Inject base tag in head if it doesn't exist
-      const headTagRegex = /<head[^>]*>/i;
-      if (headTagRegex.test(processedHtml)) {
-        processedHtml = processedHtml.replace(
-          headTagRegex,
-          (match) => `${match}\n    <base href="${baseUrl}" />`
-        );
-      }
-    }
-
-    // Rewrite legacy `/mcp-use/widgets/...` references to the new
-    // basePath-agnostic `/_mcp-use/widgets/...` root. Emitted as bare
-    // absolute paths so the browser resolves them against the document
-    // origin — no baseUrl/basePath interpolation needed.
-    processedHtml = processedHtml.replace(
-      /src="\/(?:_)?mcp-use\/widgets\/([^"]+)"/g,
-      `src="/_mcp-use/widgets/$1"`
-    );
-    processedHtml = processedHtml.replace(
-      /href="\/(?:_)?mcp-use\/widgets\/([^"]+)"/g,
-      `href="/_mcp-use/widgets/$1"`
-    );
-
-    // Add window.__getFile and window.__mcpPublicUrl to head.
-    // The `_mcp-use/` namespace lives at the root regardless of basePath,
-    // so we emit bare absolute paths.
-    const slugifiedName = slugifyWidgetName(widgetName);
-    processedHtml = processedHtml.replace(
-      /<head[^>]*>/i,
-      `<head>\n    <script>window.__getFile = (filename) => { return "/_mcp-use/widgets/${slugifiedName}/"+filename }; window.__mcpPublicUrl = "/_mcp-use/public";</script>`
-    );
+export function processWidgetHtml(html: string, widgetName: string): string {
+  if (!html || html.includes("window.__mcpPublicUrl")) {
+    return html;
   }
 
-  return processedHtml;
+  const slugifiedName = slugifyWidgetName(widgetName);
+  return html.replace(
+    /<head[^>]*>/i,
+    (match) =>
+      `${match}\n    <script>window.__getFile = (filename) => { return "/_mcp-use/widgets/${slugifiedName}/"+filename }; window.__mcpPublicUrl = "/_mcp-use/public";</script>`
+  );
 }
 
 /**
@@ -721,8 +675,8 @@ export async function registerWidgetFromTemplate(
     return; // readWidgetHtml already logged the error
   }
 
-  // Process HTML with base URL injection and path conversion
-  html = processWidgetHtml(html, widgetName, serverConfig.serverBaseUrl);
+  // Inject runtime globals (no-op if already baked at build time).
+  html = processWidgetHtml(html, widgetName);
 
   // Ensure metadata has proper fallbacks
   const processedMetadata = ensureWidgetMetadata(metadata, widgetName);

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/widget-helpers.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/widget-helpers.ts
@@ -765,12 +765,17 @@ export async function registerWidgetFromTemplate(
  */
 export function setupPublicRoutes(
   app: HonoType,
-  useDistDirectory: boolean = false,
-  basePath: string = ""
+  useDistDirectory: boolean = false
 ): void {
-  const routePrefix = `${basePath}/mcp-use/public/`;
+  // Register on the passed-in app at the bare path. When the caller passes
+  // the inner (sub-mounted) Hono, this becomes `${basePath}/mcp-use/public/*`
+  // externally; otherwise it lives at root.
+  const routePrefix = "/mcp-use/public/";
   app.get(`${routePrefix}*`, async (c: Context) => {
-    const filePath = c.req.path.replace(routePrefix, "");
+    // `c.req.path` is the full original URL path even inside a sub-mount,
+    // so split on `/mcp-use/public/` (the static literal) to recover the
+    // file portion regardless of any externally-applied prefix.
+    const filePath = c.req.path.split(routePrefix)[1] ?? "";
     const fsBase = useDistDirectory ? "dist/public" : "public";
     const fullPath = pathHelpers.join(getCwd(), fsBase, filePath);
 
@@ -812,8 +817,7 @@ export function setupPublicRoutes(
 export function setupFaviconRoute(
   app: HonoType,
   faviconPath: string | undefined,
-  useDistDirectory: boolean = false,
-  basePath: string = ""
+  useDistDirectory: boolean = false
 ): void {
   if (!faviconPath) {
     return; // No favicon configured
@@ -841,11 +845,7 @@ export function setupFaviconRoute(
     }
   };
 
-  // Always serve at /favicon.ico so browsers' implicit root request works,
-  // and additionally under the basePath so links generated under the prefix
-  // continue to resolve.
+  // Register at bare /favicon.ico. Callers should pass the outer (_rootApp)
+  // so browsers' implicit `GET /favicon.ico` resolves regardless of basePath.
   app.get("/favicon.ico", handler);
-  if (basePath) {
-    app.get(`${basePath}/favicon.ico`, handler);
-  }
 }

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/widget-helpers.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/widget-helpers.ts
@@ -209,6 +209,8 @@ export interface WidgetServerConfig {
   serverBaseUrl?: string;
   /** Build ID for cache busting */
   buildId?: string;
+  /** Server basePath prefix (e.g. "/api"). Empty string when unset. */
+  basePath?: string;
 }
 
 /**
@@ -296,14 +298,16 @@ export function getContentType(filename: string): string {
 /**
  * Inject runtime globals into widget HTML.
  *
- * Production builds bake these globals at build time
- * (`packages/cli/src/index.ts`), so this function is effectively dev-only —
- * the CLI's `buildWidgets` already wrote the script into `.mcp-use/widgets/
- * &lt;name&gt;/index.html` before it lands on disk. It stays here for the dev
- * Vite middleware, which serves un-baked HTML on the fly.
+ * The injected script resolves the server's `basePath` at runtime from
+ * `window.location.pathname` (splitting on the literal `/_mcp-use/` segment).
+ * This keeps the baked HTML basePath-agnostic — the same `.mcp-use/widgets/
+ * <name>/index.html` file produced by `packages/cli/src/index.ts` works
+ * whether the server is mounted at the host root or under a `basePath` like
+ * `/api`, with no rebuild needed.
  *
- * Idempotent: if the globals are already present (production reads), this
- * is a no-op.
+ * Production builds bake these globals at build time (CLI). Dev mode calls
+ * this on the fly from the Vite middleware. Idempotent: if the globals are
+ * already present, this is a no-op.
  *
  * @param html - Original HTML content
  * @param widgetName - Widget identifier (will be slugified for URL paths)
@@ -315,10 +319,14 @@ export function processWidgetHtml(html: string, widgetName: string): string {
   }
 
   const slugifiedName = slugifyWidgetName(widgetName);
+  // The widget HTML is always served at `<basePath>/_mcp-use/widgets/<slug>/...`,
+  // so the prefix preceding `/_mcp-use/` in `window.location.pathname` IS the
+  // server's basePath (possibly empty). Compute it once and use it to build
+  // sibling URLs (own assets, public files).
   return html.replace(
     /<head[^>]*>/i,
     (match) =>
-      `${match}\n    <script>window.__getFile = (filename) => { return "/_mcp-use/widgets/${slugifiedName}/"+filename }; window.__mcpPublicUrl = "/_mcp-use/public";</script>`
+      `${match}\n    <script>(function(){var p=window.location.pathname.split("/_mcp-use/")[0]||"";window.__getFile=function(filename){return p+"/_mcp-use/widgets/${slugifiedName}/"+filename};window.__mcpPublicUrl=p+"/_mcp-use/public";})();</script>`
   );
 }
 
@@ -521,6 +529,7 @@ export async function createWidgetUIResource(
     baseUrl: configBaseUrl,
     port: configPort,
     buildId: serverConfig.buildId,
+    basePath: serverConfig.basePath ?? "",
   };
 
   const uiResource = await createUIResourceFromDefinition(
@@ -715,8 +724,9 @@ export function setupPublicRoutes(
   app: HonoType,
   useDistDirectory: boolean = false
 ): void {
-  // Register on the outer (root) app at `/_mcp-use/public/*` so public
-  // assets are reachable at a stable, basePath-agnostic URL.
+  // Callers pass the basePath-aware app so the final route lands at
+  // `${basePath}/_mcp-use/public/*`. The `split("/_mcp-use/public/")` below
+  // is unambiguous regardless of basePath since `_mcp-use` is reserved.
   const routePrefix = "/_mcp-use/public/";
   app.get(`${routePrefix}*`, async (c: Context) => {
     const filePath = c.req.path.split(routePrefix)[1] ?? "";
@@ -783,8 +793,11 @@ export function setupFaviconRoute(
     }
   };
 
-  // Register at bare /favicon.ico. Callers should pass the underlying root
-  // Hono so browsers' implicit `GET /favicon.ico` resolves regardless of
-  // basePath.
+  // Register at `/favicon.ico` on the basePath-aware app — final route lands
+  // at `${basePath}/favicon.ico`. Browsers' implicit `GET /favicon.ico` at
+  // the host root won't resolve when basePath is set; the MCP icon
+  // declaration in `getServerInfo` is the authoritative reference for
+  // clients that consume the icon, and the rendered landing page links to
+  // the basePath-prefixed URL.
   app.get("/favicon.ico", handler);
 }

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/widget-helpers.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/widget-helpers.ts
@@ -187,8 +187,8 @@ export async function readBuildManifest(): Promise<{
   try {
     const manifestPath = pathHelpers.join(
       isDeno ? "." : getCwd(),
-      "dist",
-      "mcp-use.json"
+      ".mcp-use",
+      "manifest.json"
     );
     const content = await fsHelpers.readFileSync(manifestPath, "utf8");
     return JSON.parse(content);
@@ -310,8 +310,7 @@ export function getContentType(filename: string): string {
 export function processWidgetHtml(
   html: string,
   widgetName: string,
-  baseUrl: string,
-  basePath: string = ""
+  baseUrl: string
 ): string {
   let processedHtml = html;
 
@@ -347,22 +346,26 @@ export function processWidgetHtml(
       }
     }
 
-    // Replace relative paths that start with /mcp-use for scripts and CSS with absolute URLs
+    // Rewrite legacy `/mcp-use/widgets/...` references to the new
+    // basePath-agnostic `/_mcp-use/widgets/...` root. Emitted as bare
+    // absolute paths so the browser resolves them against the document
+    // origin — no baseUrl/basePath interpolation needed.
     processedHtml = processedHtml.replace(
-      /src="\/mcp-use\/widgets\/([^"]+)"/g,
-      `src="${baseUrl}${basePath}/mcp-use/widgets/$1"`
+      /src="\/(?:_)?mcp-use\/widgets\/([^"]+)"/g,
+      `src="/_mcp-use/widgets/$1"`
     );
     processedHtml = processedHtml.replace(
-      /href="\/mcp-use\/widgets\/([^"]+)"/g,
-      `href="${baseUrl}${basePath}/mcp-use/widgets/$1"`
+      /href="\/(?:_)?mcp-use\/widgets\/([^"]+)"/g,
+      `href="/_mcp-use/widgets/$1"`
     );
 
-    // Add window.__getFile and window.__mcpPublicUrl to head
-    // Use slugified name for URL routing
+    // Add window.__getFile and window.__mcpPublicUrl to head.
+    // The `_mcp-use/` namespace lives at the root regardless of basePath,
+    // so we emit bare absolute paths.
     const slugifiedName = slugifyWidgetName(widgetName);
     processedHtml = processedHtml.replace(
       /<head[^>]*>/i,
-      `<head>\n    <script>window.__getFile = (filename) => { return "${baseUrl}${basePath}/mcp-use/widgets/${slugifiedName}/"+filename }; window.__mcpPublicUrl = "${baseUrl}${basePath}/mcp-use/public";</script>`
+      `<head>\n    <script>window.__getFile = (filename) => { return "/_mcp-use/widgets/${slugifiedName}/"+filename }; window.__mcpPublicUrl = "/_mcp-use/public";</script>`
     );
   }
 
@@ -700,7 +703,7 @@ async function readWidgetHtml(
  * ```typescript
  * await registerWidgetFromTemplate(
  *   'kanban-board',
- *   './dist/resources/widgets/kanban-board/index.html',
+ *   './.mcp-use/widgets/kanban-board/index.html',
  *   { title: 'Kanban Board' },
  *   serverConfig,
  *   registerWidget,
@@ -712,7 +715,7 @@ export async function registerWidgetFromTemplate(
   widgetName: string,
   htmlPath: string,
   metadata: Record<string, unknown>,
-  serverConfig: { serverBaseUrl: string; cspUrls: string[]; basePath?: string },
+  serverConfig: { serverBaseUrl: string; cspUrls: string[] },
   registerWidget: import("./widget-types.js").RegisterWidgetCallback,
   isDev: boolean = false
 ): Promise<void> {
@@ -723,12 +726,7 @@ export async function registerWidgetFromTemplate(
   }
 
   // Process HTML with base URL injection and path conversion
-  html = processWidgetHtml(
-    html,
-    widgetName,
-    serverConfig.serverBaseUrl,
-    serverConfig.basePath ?? ""
-  );
+  html = processWidgetHtml(html, widgetName, serverConfig.serverBaseUrl);
 
   // Ensure metadata has proper fallbacks
   const processedMetadata = ensureWidgetMetadata(metadata, widgetName);
@@ -748,11 +746,11 @@ export async function registerWidgetFromTemplate(
 /**
  * Setup static file serving routes for public files
  *
- * Creates an HTTP route to serve files from the public/ or dist/public/ directory.
+ * Creates an HTTP route to serve files from the public/ or .mcp-use/public/ directory.
  * This function encapsulates the common pattern of serving static files.
  *
  * @param app - Hono app instance to mount routes on
- * @param useDistDirectory - Whether to serve from dist/public (production) or public (dev)
+ * @param useDistDirectory - Whether to serve from .mcp-use/public (production) or public (dev)
  *
  * @example
  * ```typescript
@@ -767,16 +765,14 @@ export function setupPublicRoutes(
   app: HonoType,
   useDistDirectory: boolean = false
 ): void {
-  // Register on the passed-in app at the bare path. When the caller passes
-  // the inner (sub-mounted) Hono, this becomes `${basePath}/mcp-use/public/*`
-  // externally; otherwise it lives at root.
-  const routePrefix = "/mcp-use/public/";
+  // Register on the outer (root) app at `/_mcp-use/public/*` so public
+  // assets are reachable at a stable, basePath-agnostic URL.
+  const routePrefix = "/_mcp-use/public/";
   app.get(`${routePrefix}*`, async (c: Context) => {
-    // `c.req.path` is the full original URL path even inside a sub-mount,
-    // so split on `/mcp-use/public/` (the static literal) to recover the
-    // file portion regardless of any externally-applied prefix.
     const filePath = c.req.path.split(routePrefix)[1] ?? "";
-    const fsBase = useDistDirectory ? "dist/public" : "public";
+    // Production reads from `.mcp-use/public` (built output). Dev reads
+    // from the user's source `public/` directory.
+    const fsBase = useDistDirectory ? ".mcp-use/public" : "public";
     const fullPath = pathHelpers.join(getCwd(), fsBase, filePath);
 
     try {
@@ -803,7 +799,7 @@ export function setupPublicRoutes(
  *
  * @param app - Hono app instance to mount routes on
  * @param faviconPath - Path to favicon file relative to public directory
- * @param useDistDirectory - Whether to serve from dist/public (production) or public (dev)
+ * @param useDistDirectory - Whether to serve from .mcp-use/public (production) or public (dev)
  *
  * @example
  * ```typescript
@@ -824,7 +820,7 @@ export function setupFaviconRoute(
   }
 
   const handler = async (c: Context) => {
-    const fsBase = useDistDirectory ? "dist/public" : "public";
+    const fsBase = useDistDirectory ? ".mcp-use/public" : "public";
     const fullPath = pathHelpers.join(getCwd(), fsBase, faviconPath);
 
     try {
@@ -845,7 +841,8 @@ export function setupFaviconRoute(
     }
   };
 
-  // Register at bare /favicon.ico. Callers should pass the outer (_rootApp)
-  // so browsers' implicit `GET /favicon.ico` resolves regardless of basePath.
+  // Register at bare /favicon.ico. Callers should pass the underlying root
+  // Hono so browsers' implicit `GET /favicon.ico` resolves regardless of
+  // basePath.
   app.get("/favicon.ico", handler);
 }

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/widget-helpers.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/widget-helpers.ts
@@ -310,7 +310,8 @@ export function getContentType(filename: string): string {
 export function processWidgetHtml(
   html: string,
   widgetName: string,
-  baseUrl: string
+  baseUrl: string,
+  basePath: string = ""
 ): string {
   let processedHtml = html;
 
@@ -349,11 +350,11 @@ export function processWidgetHtml(
     // Replace relative paths that start with /mcp-use for scripts and CSS with absolute URLs
     processedHtml = processedHtml.replace(
       /src="\/mcp-use\/widgets\/([^"]+)"/g,
-      `src="${baseUrl}/mcp-use/widgets/$1"`
+      `src="${baseUrl}${basePath}/mcp-use/widgets/$1"`
     );
     processedHtml = processedHtml.replace(
       /href="\/mcp-use\/widgets\/([^"]+)"/g,
-      `href="${baseUrl}/mcp-use/widgets/$1"`
+      `href="${baseUrl}${basePath}/mcp-use/widgets/$1"`
     );
 
     // Add window.__getFile and window.__mcpPublicUrl to head
@@ -361,7 +362,7 @@ export function processWidgetHtml(
     const slugifiedName = slugifyWidgetName(widgetName);
     processedHtml = processedHtml.replace(
       /<head[^>]*>/i,
-      `<head>\n    <script>window.__getFile = (filename) => { return "${baseUrl}/mcp-use/widgets/${slugifiedName}/"+filename }; window.__mcpPublicUrl = "${baseUrl}/mcp-use/public";</script>`
+      `<head>\n    <script>window.__getFile = (filename) => { return "${baseUrl}${basePath}/mcp-use/widgets/${slugifiedName}/"+filename }; window.__mcpPublicUrl = "${baseUrl}${basePath}/mcp-use/public";</script>`
     );
   }
 
@@ -711,7 +712,7 @@ export async function registerWidgetFromTemplate(
   widgetName: string,
   htmlPath: string,
   metadata: Record<string, unknown>,
-  serverConfig: { serverBaseUrl: string; cspUrls: string[] },
+  serverConfig: { serverBaseUrl: string; cspUrls: string[]; basePath?: string },
   registerWidget: import("./widget-types.js").RegisterWidgetCallback,
   isDev: boolean = false
 ): Promise<void> {
@@ -722,7 +723,12 @@ export async function registerWidgetFromTemplate(
   }
 
   // Process HTML with base URL injection and path conversion
-  html = processWidgetHtml(html, widgetName, serverConfig.serverBaseUrl);
+  html = processWidgetHtml(
+    html,
+    widgetName,
+    serverConfig.serverBaseUrl,
+    serverConfig.basePath ?? ""
+  );
 
   // Ensure metadata has proper fallbacks
   const processedMetadata = ensureWidgetMetadata(metadata, widgetName);
@@ -759,12 +765,14 @@ export async function registerWidgetFromTemplate(
  */
 export function setupPublicRoutes(
   app: HonoType,
-  useDistDirectory: boolean = false
+  useDistDirectory: boolean = false,
+  basePath: string = ""
 ): void {
-  app.get("/mcp-use/public/*", async (c: Context) => {
-    const filePath = c.req.path.replace("/mcp-use/public/", "");
-    const basePath = useDistDirectory ? "dist/public" : "public";
-    const fullPath = pathHelpers.join(getCwd(), basePath, filePath);
+  const routePrefix = `${basePath}/mcp-use/public/`;
+  app.get(`${routePrefix}*`, async (c: Context) => {
+    const filePath = c.req.path.replace(routePrefix, "");
+    const fsBase = useDistDirectory ? "dist/public" : "public";
+    const fullPath = pathHelpers.join(getCwd(), fsBase, filePath);
 
     try {
       if (await fsHelpers.existsSync(fullPath)) {
@@ -804,15 +812,16 @@ export function setupPublicRoutes(
 export function setupFaviconRoute(
   app: HonoType,
   faviconPath: string | undefined,
-  useDistDirectory: boolean = false
+  useDistDirectory: boolean = false,
+  basePath: string = ""
 ): void {
   if (!faviconPath) {
     return; // No favicon configured
   }
 
-  app.get("/favicon.ico", async (c: Context) => {
-    const basePath = useDistDirectory ? "dist/public" : "public";
-    const fullPath = pathHelpers.join(getCwd(), basePath, faviconPath);
+  const handler = async (c: Context) => {
+    const fsBase = useDistDirectory ? "dist/public" : "public";
+    const fullPath = pathHelpers.join(getCwd(), fsBase, faviconPath);
 
     try {
       if (await fsHelpers.existsSync(fullPath)) {
@@ -830,5 +839,13 @@ export function setupFaviconRoute(
     } catch {
       return c.notFound();
     }
-  });
+  };
+
+  // Always serve at /favicon.ico so browsers' implicit root request works,
+  // and additionally under the basePath so links generated under the prefix
+  // continue to resolve.
+  app.get("/favicon.ico", handler);
+  if (basePath) {
+    app.get(`${basePath}/favicon.ico`, handler);
+  }
 }

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/widget-helpers.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/widget-helpers.ts
@@ -316,13 +316,9 @@ export function processWidgetHtml(
 
   // Inject or replace base tag with server base URL
   if (baseUrl && processedHtml) {
-    // Remove HTML comments temporarily to avoid matching base tags inside comments
-    let htmlWithoutComments = processedHtml;
-    let prevHtmlWithoutComments;
-    do {
-      prevHtmlWithoutComments = htmlWithoutComments;
-      htmlWithoutComments = htmlWithoutComments.replace(/<!--[\s\S]*?-->/g, "");
-    } while (prevHtmlWithoutComments !== htmlWithoutComments);
+    // Strip HTML comments before probing for a <base> tag so we don't match
+    // one inside a comment. HTML comments can't nest, so one pass suffices.
+    const htmlWithoutComments = processedHtml.replace(/<!--[\s\S]*?-->/g, "");
 
     // Try to replace existing base tag (only if not in comments)
     const baseTagRegex = /<base\s+[^>]*\/?>/i;
@@ -776,15 +772,11 @@ export function setupPublicRoutes(
     const fullPath = pathHelpers.join(getCwd(), fsBase, filePath);
 
     try {
-      if (await fsHelpers.existsSync(fullPath)) {
-        const content = await fsHelpers.readFile(fullPath);
-        const contentType = getContentType(filePath);
-        return new Response(content, {
-          status: 200,
-          headers: { "Content-Type": contentType },
-        });
-      }
-      return c.notFound();
+      const content = await fsHelpers.readFile(fullPath);
+      return new Response(content, {
+        status: 200,
+        headers: { "Content-Type": getContentType(filePath) },
+      });
     } catch {
       return c.notFound();
     }
@@ -824,18 +816,14 @@ export function setupFaviconRoute(
     const fullPath = pathHelpers.join(getCwd(), fsBase, faviconPath);
 
     try {
-      if (await fsHelpers.existsSync(fullPath)) {
-        const content = await fsHelpers.readFile(fullPath);
-        const contentType = getContentType(faviconPath);
-        return new Response(content, {
-          status: 200,
-          headers: {
-            "Content-Type": contentType,
-            "Cache-Control": "public, max-age=31536000", // Cache for 1 year
-          },
-        });
-      }
-      return c.notFound();
+      const content = await fsHelpers.readFile(fullPath);
+      return new Response(content, {
+        status: 200,
+        headers: {
+          "Content-Type": getContentType(faviconPath),
+          "Cache-Control": "public, max-age=31536000", // Cache for 1 year
+        },
+      });
     } catch {
       return c.notFound();
     }

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/widget-types.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/widget-types.ts
@@ -32,14 +32,6 @@ export interface ServerConfig {
    * Empty string means "no prefix".
    */
   basePath?: string;
-  /**
-   * Outer Hono receiving raw HTTP requests. When `basePath` is set, this
-   * differs from the inner `app` passed to widget mount helpers; favicon
-   * and other always-at-root routes register here. When `basePath` is
-   * unset, this is the same instance as the inner app.
-   * @internal
-   */
-  rootApp?: any;
 }
 
 /**
@@ -48,7 +40,7 @@ export interface ServerConfig {
  * Common options used for both development and production widget mounting.
  */
 export interface MountWidgetsOptions {
-  /** Base route for widgets (defaults to '/mcp-use/widgets') */
+  /** Base route for widgets (defaults to '/_mcp-use/widgets') */
   baseRoute?: string;
   /** Resources directory path (defaults to 'resources') */
   resourcesDir?: string;

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/widget-types.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/widget-types.ts
@@ -27,6 +27,11 @@ export interface ServerConfig {
   /** Pre-created HTTP server for Vite HMR WebSocket support (optional, Node.js only) */
 
   httpServer?: any;
+  /**
+   * Normalized base path prefix for every route this server mounts.
+   * Empty string means "no prefix".
+   */
+  basePath?: string;
 }
 
 /**

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/widget-types.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/widget-types.ts
@@ -32,6 +32,14 @@ export interface ServerConfig {
    * Empty string means "no prefix".
    */
   basePath?: string;
+  /**
+   * Outer Hono receiving raw HTTP requests. When `basePath` is set, this
+   * differs from the inner `app` passed to widget mount helpers; favicon
+   * and other always-at-root routes register here. When `basePath` is
+   * unset, this is the same instance as the inner app.
+   * @internal
+   */
+  rootApp?: any;
 }
 
 /**

--- a/libraries/typescript/packages/mcp-use/tests/server/oauth-better-auth.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/server/oauth-better-auth.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Better Auth OAuth provider — in-process and external modes.
+ */
+
+import { Hono } from "hono";
+import { serve } from "@hono/node-server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setupOAuthForServer } from "../../src/server/oauth/setup.js";
+import { oauthBetterAuthProvider } from "../../src/server/oauth/providers.js";
+import type { BetterAuthInstance } from "../../src/server/oauth/providers/types.js";
+
+async function listenOnRandomPort(
+  app: Hono
+): Promise<{ baseUrl: string; close: () => void }> {
+  return new Promise((resolve) => {
+    const server = serve({ fetch: app.fetch, port: 0 }, (info) => {
+      resolve({
+        baseUrl: `http://127.0.0.1:${info.port}`,
+        close: () => server.close(),
+      });
+    });
+  });
+}
+
+const closers: Array<() => void> = [];
+afterEach(() => {
+  while (closers.length > 0) closers.pop()?.();
+});
+
+/**
+ * Build a Better Auth instance double that captures requests routed through
+ * `handler` and returns canned metadata from `api.getOAuthServerConfig` /
+ * `api.getOpenIdConfig`. We don't want to spin up real Better Auth here —
+ * the SDK only needs the structural shape declared by {@link BetterAuthInstance}.
+ */
+function makeAuthDouble(opts: {
+  baseURL: string;
+  basePath?: string;
+  authServerMetadata?: Record<string, unknown>;
+  openIdConfig?: Record<string, unknown>;
+}): {
+  auth: BetterAuthInstance;
+  handlerCalls: Array<{ url: string; method: string }>;
+} {
+  const handlerCalls: Array<{ url: string; method: string }> = [];
+  const auth: BetterAuthInstance = {
+    handler: vi.fn(async (req: Request) => {
+      handlerCalls.push({ url: req.url, method: req.method });
+      return new Response("ok", { status: 200 });
+    }),
+    options: {
+      baseURL: opts.baseURL,
+      ...(opts.basePath !== undefined ? { basePath: opts.basePath } : {}),
+    },
+    api: {
+      getOAuthServerConfig: vi.fn(
+        async () =>
+          opts.authServerMetadata ?? {
+            issuer: `${opts.baseURL}${opts.basePath ?? "/api/auth"}`,
+            authorization_endpoint: `${opts.baseURL}${
+              opts.basePath ?? "/api/auth"
+            }/oauth2/authorize`,
+            token_endpoint: `${opts.baseURL}${
+              opts.basePath ?? "/api/auth"
+            }/oauth2/token`,
+          }
+      ),
+      getOpenIdConfig: vi.fn(
+        async () =>
+          opts.openIdConfig ?? {
+            issuer: `${opts.baseURL}${opts.basePath ?? "/api/auth"}`,
+          }
+      ),
+    },
+  };
+  return { auth, handlerCalls };
+}
+
+describe("oauthBetterAuthProvider — in-process mode", () => {
+  it("serves discovery at the issuer-path-suffixed well-known URL", async () => {
+    // The MCPServer is at basePath `/mcp-server`; Better Auth's externally-
+    // visible URL is the full path `/mcp-server/api/auth`. The
+    // spec-compliant path-insertion probe is
+    // `/.well-known/oauth-authorization-server/mcp-server/api/auth` at the
+    // literal host root.
+    const app = new Hono();
+    const svc = await listenOnRandomPort(app);
+    closers.push(svc.close);
+
+    const { auth } = makeAuthDouble({
+      baseURL: `${svc.baseUrl}/mcp-server/api/auth`,
+      authServerMetadata: {
+        issuer: `${svc.baseUrl}/mcp-server/api/auth`,
+        authorization_endpoint: `${svc.baseUrl}/mcp-server/api/auth/oauth2/authorize`,
+        token_endpoint: `${svc.baseUrl}/mcp-server/api/auth/oauth2/token`,
+      },
+    });
+    const provider = oauthBetterAuthProvider(auth);
+    setupOAuthForServer(app, provider, () => svc.baseUrl, "/mcp-server");
+
+    // 1. RFC 8414 §3.1 path-insertion variant at the issuer's pathname.
+    const res = await fetch(
+      `${svc.baseUrl}/.well-known/oauth-authorization-server/mcp-server/api/auth`
+    );
+    expect(res.status).toBe(200);
+    const meta = await res.json();
+    expect(meta.issuer).toBe(`${svc.baseUrl}/mcp-server/api/auth`);
+    expect(meta.authorization_endpoint).toBe(
+      `${svc.baseUrl}/mcp-server/api/auth/oauth2/authorize`
+    );
+
+    // 2. Root fallback still works.
+    const rootRes = await fetch(
+      `${svc.baseUrl}/.well-known/oauth-authorization-server`
+    );
+    expect(rootRes.status).toBe(200);
+  });
+
+  it("mounts auth.handler at the issuer's path on the root app", async () => {
+    const app = new Hono();
+    const svc = await listenOnRandomPort(app);
+    closers.push(svc.close);
+
+    const { auth, handlerCalls } = makeAuthDouble({
+      baseURL: `${svc.baseUrl}/mcp-server/api/auth`,
+    });
+    const provider = oauthBetterAuthProvider(auth);
+    setupOAuthForServer(app, provider, () => svc.baseUrl, "/mcp-server");
+
+    // A request under the mounted path reaches Better Auth's handler.
+    const res = await fetch(`${svc.baseUrl}/mcp-server/api/auth/sign-in`);
+    expect(res.status).toBe(200);
+    expect(handlerCalls).toHaveLength(1);
+    expect(handlerCalls[0].url).toContain("/mcp-server/api/auth/sign-in");
+  });
+
+  it("falls back to baseURL + basePath when baseURL has no path", () => {
+    // Mirrors Better Auth's own `withPath` behavior: an origin-only
+    // `baseURL` gets `basePath` appended; a `baseURL` with a path is left
+    // alone. This is the value Better Auth signs into tokens as `iss`.
+    const { auth: pathless } = makeAuthDouble({
+      baseURL: "http://example.com",
+    });
+    expect(oauthBetterAuthProvider(pathless).getIssuer()).toBe(
+      "http://example.com/api/auth"
+    );
+
+    const { auth: customBase } = makeAuthDouble({
+      baseURL: "http://example.com",
+      basePath: "/auth",
+    });
+    expect(oauthBetterAuthProvider(customBase).getIssuer()).toBe(
+      "http://example.com/auth"
+    );
+
+    const { auth: withFullPath } = makeAuthDouble({
+      baseURL: "http://example.com/anywhere/api/auth",
+    });
+    // basePath is ignored when baseURL already has a path.
+    expect(oauthBetterAuthProvider(withFullPath).getIssuer()).toBe(
+      "http://example.com/anywhere/api/auth"
+    );
+  });
+
+  it("throws a helpful error when auth.options.baseURL is missing", () => {
+    const auth: BetterAuthInstance = {
+      handler: async () => new Response(),
+      options: {},
+      api: {
+        getOAuthServerConfig: async () => ({}),
+        getOpenIdConfig: async () => ({}),
+      },
+    };
+    expect(() => oauthBetterAuthProvider(auth)).toThrow(
+      /auth\.options\.baseURL/
+    );
+  });
+});
+
+describe("oauthBetterAuthProvider — external mode", () => {
+  it("uses the configured authURL as the issuer", () => {
+    const provider = oauthBetterAuthProvider({
+      authURL: "http://auth.example.com/api/auth",
+    });
+    expect(provider.getIssuer()).toBe("http://auth.example.com/api/auth");
+    // External mode leaves the in-process hooks undefined so the SDK falls
+    // back to its default upstream-fetch metadata behavior.
+    expect(provider.authorizationServerMetadataHandler).toBeUndefined();
+    expect(provider.installRoutes).toBeUndefined();
+  });
+
+  it("requires either an auth instance or authURL", () => {
+    expect(() => oauthBetterAuthProvider({})).toThrow(
+      /Better Auth instance|authURL/
+    );
+  });
+});

--- a/libraries/typescript/packages/mcp-use/tests/server/oauth.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/server/oauth.test.ts
@@ -69,6 +69,53 @@ describe("server OAuth integration", () => {
     expect(metadata.issuer).toBe(svc.baseUrl);
   });
 
+  it("publishes basePath-prefixed endpoints when configured", async () => {
+    const app = new Hono();
+
+    const proxy = oauthProxy({
+      issuer: "https://issuer.example.com",
+      authEndpoint: "https://issuer.example.com/oauth/authorize",
+      tokenEndpoint: "https://issuer.example.com/oauth/token",
+      clientId: "test-client-id",
+      scopes: ["openid"],
+      verifyToken: stubVerifyToken,
+    });
+
+    const svc = await listenOnRandomPort(app);
+    closers.push(svc.close);
+
+    setupOAuthRoutes(app, proxy, svc.baseUrl, "/api");
+
+    const response = await fetch(
+      `${svc.baseUrl}/api/.well-known/oauth-authorization-server`
+    );
+    expect(response.status).toBe(200);
+    const metadata = await response.json();
+
+    expect(metadata.issuer).toBe(`${svc.baseUrl}/api`);
+    expect(metadata.authorization_endpoint).toBe(
+      `${svc.baseUrl}/api/authorize`
+    );
+    expect(metadata.token_endpoint).toBe(`${svc.baseUrl}/api/token`);
+    expect(metadata.registration_endpoint).toBe(`${svc.baseUrl}/api/register`);
+
+    // The protected-resource metadata for the MCP transport should point at
+    // the prefixed transport URL.
+    const prResponse = await fetch(
+      `${svc.baseUrl}/api/.well-known/oauth-protected-resource/mcp`
+    );
+    expect(prResponse.status).toBe(200);
+    const pr = await prResponse.json();
+    expect(pr.resource).toBe(`${svc.baseUrl}/api/mcp`);
+
+    // The root well-known path must NOT serve metadata when basePath is set
+    // (everything is scoped under the prefix per the user's mount).
+    const rootResponse = await fetch(
+      `${svc.baseUrl}/.well-known/oauth-authorization-server`
+    );
+    expect(rootResponse.status).toBe(404);
+  });
+
   it("proxies token requests and injects client credentials", async () => {
     const tokenSpy = vi.fn();
 

--- a/libraries/typescript/packages/mcp-use/tests/server/oauth.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/server/oauth.test.ts
@@ -216,6 +216,39 @@ describe("server OAuth integration", () => {
     expect(authorized.status).toBe(200);
   });
 
+  it("advertises path-aware resource_metadata URL with basePath", async () => {
+    // Per RFC 9728 §3.1, the resource metadata URL is built by inserting
+    // `/.well-known/oauth-protected-resource` between host and the resource
+    // path. For an MCP endpoint at `<host>/api/mcp` that's
+    // `<host>/.well-known/oauth-protected-resource/api/mcp`.
+    const app = new Hono();
+
+    const proxy = oauthProxy({
+      issuer: "https://issuer.example.com",
+      authEndpoint: "https://issuer.example.com/oauth/authorize",
+      tokenEndpoint: "https://issuer.example.com/oauth/token",
+      clientId: "test-client",
+      verifyToken: stubVerifyToken,
+    });
+
+    const svc = await listenOnRandomPort(app);
+    closers.push(svc.close);
+
+    app.use(
+      "/api/mcp/*",
+      createBearerAuthMiddleware(proxy, () => svc.baseUrl, "/api")
+    );
+    app.get("/api/mcp/test", (c) => c.json({ ok: true }));
+
+    const response = await fetch(`${svc.baseUrl}/api/mcp/test`);
+    expect(response.status).toBe(401);
+
+    const wwwAuth = response.headers.get("www-authenticate");
+    expect(wwwAuth).toContain(
+      `resource_metadata="${svc.baseUrl}/.well-known/oauth-protected-resource/api/mcp"`
+    );
+  });
+
   it("returns configured clientId from /register endpoint", async () => {
     const app = new Hono();
 

--- a/libraries/typescript/packages/mcp-use/tests/server/oauth.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/server/oauth.test.ts
@@ -54,7 +54,7 @@ describe("server OAuth integration", () => {
     const svc = await listenOnRandomPort(app);
     closers.push(svc.close);
 
-    setupOAuthRoutes(app, proxy, svc.baseUrl);
+    setupOAuthRoutes(app, proxy, () => svc.baseUrl);
 
     const response = await fetch(
       `${svc.baseUrl}/.well-known/oauth-authorization-server`
@@ -88,7 +88,7 @@ describe("server OAuth integration", () => {
     const svc = await listenOnRandomPort(app);
     closers.push(svc.close);
 
-    setupOAuthRoutes(app, proxy, svc.baseUrl, "/api");
+    setupOAuthRoutes(app, proxy, () => svc.baseUrl, "/api");
 
     // RFC 8414 §3.1 path-aware variant: well-known appended with the
     // issuer's path. This is the SDK's preferred probe.
@@ -156,7 +156,7 @@ describe("server OAuth integration", () => {
     const svc = await listenOnRandomPort(app);
     closers.push(svc.close);
 
-    setupOAuthRoutes(app, proxy, svc.baseUrl);
+    setupOAuthRoutes(app, proxy, () => svc.baseUrl);
 
     const form = new URLSearchParams({
       grant_type: "authorization_code",
@@ -231,7 +231,7 @@ describe("server OAuth integration", () => {
     const svc = await listenOnRandomPort(app);
     closers.push(svc.close);
 
-    setupOAuthRoutes(app, proxy, svc.baseUrl);
+    setupOAuthRoutes(app, proxy, () => svc.baseUrl);
 
     const response = await fetch(`${svc.baseUrl}/register`, {
       method: "POST",

--- a/libraries/typescript/packages/mcp-use/tests/server/oauth.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/server/oauth.test.ts
@@ -70,11 +70,11 @@ describe("server OAuth integration", () => {
   });
 
   it("publishes basePath-prefixed endpoints when configured", async () => {
-    // `setupOAuthRoutes` registers at bare paths; the caller is responsible
-    // for sub-mounting under the prefix. MCPServer does this by routing an
-    // inner Hono on the outer; here we reproduce the same wiring directly.
-    const outer = new Hono();
-    const inner = new Hono();
+    // `setupOAuthRoutes` takes the underlying root Hono plus a basePath.
+    // Internally it registers /authorize, /token, /register on a
+    // `.basePath()` clone (so they live at `${basePath}/...`) and
+    // /.well-known/* on the root (per RFC 8414 §3.1).
+    const app = new Hono();
 
     const proxy = oauthProxy({
       issuer: "https://issuer.example.com",
@@ -85,16 +85,15 @@ describe("server OAuth integration", () => {
       verifyToken: stubVerifyToken,
     });
 
-    const svc = await listenOnRandomPort(outer);
+    const svc = await listenOnRandomPort(app);
     closers.push(svc.close);
 
-    // Register OAuth routes on the inner at bare paths (the helper builds
-    // response bodies that include `${baseUrl}${basePath}` for discovery).
-    setupOAuthRoutes(inner, proxy, svc.baseUrl, "/api");
-    outer.route("/api", inner);
+    setupOAuthRoutes(app, proxy, svc.baseUrl, "/api");
 
+    // RFC 8414 §3.1 path-aware variant: well-known appended with the
+    // issuer's path. This is the SDK's preferred probe.
     const response = await fetch(
-      `${svc.baseUrl}/api/.well-known/oauth-authorization-server`
+      `${svc.baseUrl}/.well-known/oauth-authorization-server/api`
     );
     expect(response.status).toBe(200);
     const metadata = await response.json();
@@ -106,21 +105,20 @@ describe("server OAuth integration", () => {
     expect(metadata.token_endpoint).toBe(`${svc.baseUrl}/api/token`);
     expect(metadata.registration_endpoint).toBe(`${svc.baseUrl}/api/register`);
 
-    // The protected-resource metadata for the MCP transport should point at
-    // the prefixed transport URL.
+    // The root well-known path should still serve metadata as the SDK's
+    // fallback probe (and for clients that don't append the path).
+    const rootMetadata = await fetch(
+      `${svc.baseUrl}/.well-known/oauth-authorization-server`
+    );
+    expect(rootMetadata.status).toBe(200);
+
+    // RFC 9728 path-scoped protected resource metadata for the MCP transport.
     const prResponse = await fetch(
-      `${svc.baseUrl}/api/.well-known/oauth-protected-resource/mcp`
+      `${svc.baseUrl}/.well-known/oauth-protected-resource/api/mcp`
     );
     expect(prResponse.status).toBe(200);
     const pr = await prResponse.json();
     expect(pr.resource).toBe(`${svc.baseUrl}/api/mcp`);
-
-    // The root well-known path must NOT serve metadata when basePath is set
-    // (everything is scoped under the prefix per the user's mount).
-    const rootResponse = await fetch(
-      `${svc.baseUrl}/.well-known/oauth-authorization-server`
-    );
-    expect(rootResponse.status).toBe(404);
   });
 
   it("proxies token requests and injects client credentials", async () => {

--- a/libraries/typescript/packages/mcp-use/tests/server/oauth.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/server/oauth.test.ts
@@ -70,7 +70,11 @@ describe("server OAuth integration", () => {
   });
 
   it("publishes basePath-prefixed endpoints when configured", async () => {
-    const app = new Hono();
+    // `setupOAuthRoutes` registers at bare paths; the caller is responsible
+    // for sub-mounting under the prefix. MCPServer does this by routing an
+    // inner Hono on the outer; here we reproduce the same wiring directly.
+    const outer = new Hono();
+    const inner = new Hono();
 
     const proxy = oauthProxy({
       issuer: "https://issuer.example.com",
@@ -81,10 +85,13 @@ describe("server OAuth integration", () => {
       verifyToken: stubVerifyToken,
     });
 
-    const svc = await listenOnRandomPort(app);
+    const svc = await listenOnRandomPort(outer);
     closers.push(svc.close);
 
-    setupOAuthRoutes(app, proxy, svc.baseUrl, "/api");
+    // Register OAuth routes on the inner at bare paths (the helper builds
+    // response bodies that include `${baseUrl}${basePath}` for discovery).
+    setupOAuthRoutes(inner, proxy, svc.baseUrl, "/api");
+    outer.route("/api", inner);
 
     const response = await fetch(
       `${svc.baseUrl}/api/.well-known/oauth-authorization-server`

--- a/libraries/typescript/packages/mcp-use/tests/unit/server/base-path.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/server/base-path.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { MCPServer } from "../../../src/server/index.js";
+import { MCPServer, oauthSupabaseProvider } from "../../../src/server/index.js";
 import { normalizeBasePath } from "../../../src/server/utils/server-helpers.js";
 
 describe("MCPServer basePath", () => {
@@ -131,26 +131,93 @@ describe("MCPServer basePath", () => {
       expect(root.status).toBe(404);
     });
 
-    it("serves root serverinfo with basePath-aware URLs", async () => {
+    it("mounts framework-internal assets at /_mcp-use/ regardless of basePath", async () => {
       const server = new MCPServer({
-        name: "serverinfo-base-path",
+        name: "internal-assets-base-path",
         version: "1.0.0",
         basePath: "/api",
       });
 
       const handler = await server.getHandler();
-      const response = await handler(
+
+      // `_mcp-use/*` is basePath-agnostic — a missing widget still returns
+      // 404 rather than falling through to the inner sub-mount.
+      const internal = await handler(
+        new Request("http://localhost/_mcp-use/public/missing.png")
+      );
+      expect(internal.status).toBe(404);
+
+      // The legacy `/__mcp-use/serverinfo` HTTP endpoint is gone; the same
+      // information now lives in `.mcp-use/server-info.json` after listen().
+      const removed = await handler(
         new Request("http://localhost/__mcp-use/serverinfo")
       );
+      expect(removed.status).toBe(404);
+    });
 
-      expect(response.status).toBe(200);
-      expect(await response.json()).toEqual({
+    it("serves OAuth discovery at root and path-aware paths (basePath-agnostic)", async () => {
+      const server = new MCPServer({
+        name: "oauth-discovery-base-path",
+        version: "1.0.0",
         basePath: "/api",
-        mcpPath: "/api/mcp",
-        inspectorPath: "/api/inspector",
-        mcpUrl: "http://localhost/api/mcp",
-        inspectorUrl: "http://localhost/api/inspector",
+        baseUrl: "http://localhost:3000",
+        oauth: oauthSupabaseProvider({ projectId: "abc123" }),
       });
+
+      const handler = await server.getHandler();
+
+      // 1. Root-level RFC 9728 protected resource metadata (SDK fallback)
+      const root = await handler(
+        new Request(
+          "http://localhost:3000/.well-known/oauth-protected-resource"
+        )
+      );
+      expect(root.status).toBe(200);
+      const rootBody = (await root.json()) as {
+        resource: string;
+        authorization_servers: string[];
+      };
+      expect(rootBody.resource).toBe("http://localhost:3000/api");
+      expect(rootBody.authorization_servers).toEqual([
+        "https://abc123.supabase.co/auth/v1",
+      ]);
+
+      // 2. Path-scoped RFC 9728: <host>/.well-known/oauth-protected-resource/api/mcp
+      //    (what the SDK's `discoverMetadataWithFallback` probes first)
+      const scoped = await handler(
+        new Request(
+          "http://localhost:3000/.well-known/oauth-protected-resource/api/mcp"
+        )
+      );
+      expect(scoped.status).toBe(200);
+      const scopedBody = (await scoped.json()) as { resource: string };
+      expect(scopedBody.resource).toBe("http://localhost:3000/api/mcp");
+
+      // 3. Root RFC 8414 authorization server metadata route is mounted
+      //    (DCR-direct mode proxies upstream — we just assert the route
+      //    exists, not the body, since upstream is network-dependent).
+      const authMeta = await handler(
+        new Request(
+          "http://localhost:3000/.well-known/oauth-authorization-server"
+        )
+      );
+      expect(authMeta.status).not.toBe(404);
+
+      // 4. Path-aware RFC 8414: <host>/.well-known/oauth-authorization-server/api
+      const authMetaPath = await handler(
+        new Request(
+          "http://localhost:3000/.well-known/oauth-authorization-server/api"
+        )
+      );
+      expect(authMetaPath.status).not.toBe(404);
+
+      // 5. /token stays under basePath. Root /token must 404 — that's the
+      //    bug class this restructure prevents for embedded apps where
+      //    arbitrary host routes would otherwise collide.
+      const rootToken = await handler(
+        new Request("http://localhost:3000/token", { method: "POST" })
+      );
+      expect(rootToken.status).toBe(404);
     });
   });
 

--- a/libraries/typescript/packages/mcp-use/tests/unit/server/base-path.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/server/base-path.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import { MCPServer } from "../../../src/server/index.js";
+import { normalizeBasePath } from "../../../src/server/utils/server-helpers.js";
+
+describe("MCPServer basePath", () => {
+  describe("normalizeBasePath", () => {
+    it("returns empty string for undefined / empty / '/'", () => {
+      expect(normalizeBasePath(undefined)).toBe("");
+      expect(normalizeBasePath("")).toBe("");
+      expect(normalizeBasePath("/")).toBe("");
+    });
+
+    it("strips trailing slashes", () => {
+      expect(normalizeBasePath("/api/")).toBe("/api");
+      expect(normalizeBasePath("/api///")).toBe("/api");
+    });
+
+    it("preserves nested paths", () => {
+      expect(normalizeBasePath("/a/b/c")).toBe("/a/b/c");
+    });
+
+    it("throws when the prefix is missing the leading slash", () => {
+      expect(() => normalizeBasePath("api")).toThrow(/must start with/);
+    });
+  });
+
+  describe("route mounting", () => {
+    it("mounts MCP transport at the configured basePath and 404s the root", async () => {
+      const server = new MCPServer({
+        name: "base-path-test",
+        version: "1.0.0",
+        basePath: "/api",
+      });
+
+      const handler = await server.getHandler();
+
+      const prefixed = await handler(
+        new Request("http://localhost/api/mcp", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json, text/event-stream",
+          },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "initialize",
+            params: {
+              protocolVersion: "2025-06-18",
+              capabilities: {},
+              clientInfo: { name: "test", version: "1.0.0" },
+            },
+          }),
+        })
+      );
+      // 200 means the transport accepted and handled the initialize request.
+      expect(prefixed.status).toBe(200);
+
+      const root = await handler(
+        new Request("http://localhost/mcp", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json, text/event-stream",
+          },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "initialize",
+            params: {
+              protocolVersion: "2025-06-18",
+              capabilities: {},
+              clientInfo: { name: "test", version: "1.0.0" },
+            },
+          }),
+        })
+      );
+      expect(root.status).toBe(404);
+    });
+
+    it("mounts MCP transport at /mcp when no basePath is set (back-compat)", async () => {
+      const server = new MCPServer({
+        name: "base-path-default",
+        version: "1.0.0",
+      });
+
+      const handler = await server.getHandler();
+      const response = await handler(
+        new Request("http://localhost/mcp", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json, text/event-stream",
+          },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "initialize",
+            params: {
+              protocolVersion: "2025-06-18",
+              capabilities: {},
+              clientInfo: { name: "test", version: "1.0.0" },
+            },
+          }),
+        })
+      );
+
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe("instance state", () => {
+    it("exposes the normalized basePath as a public field", () => {
+      const server = new MCPServer({
+        name: "base-path-field",
+        version: "1.0.0",
+        basePath: "/api/",
+      });
+
+      expect(server.basePath).toBe("/api");
+    });
+
+    it("defaults basePath to empty string", () => {
+      const server = new MCPServer({
+        name: "base-path-empty",
+        version: "1.0.0",
+      });
+      expect(server.basePath).toBe("");
+    });
+  });
+});

--- a/libraries/typescript/packages/mcp-use/tests/unit/server/base-path.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/server/base-path.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { MCPServer, oauthSupabaseProvider } from "../../../src/server/index.js";
 import { normalizeBasePath } from "../../../src/server/utils/server-helpers.js";
 
@@ -153,6 +155,102 @@ describe("MCPServer basePath", () => {
         new Request("http://localhost/__mcp-use/serverinfo")
       );
       expect(removed.status).toBe(404);
+    });
+
+    describe("static serving from .mcp-use/", () => {
+      const fixturesDir = join(process.cwd(), ".mcp-use");
+      let originalNodeEnv: string | undefined;
+
+      beforeAll(async () => {
+        // serveStatic only mounts when NODE_ENV=production (see
+        // widgets/index.ts:86). Force prod for this block; restore after.
+        originalNodeEnv = process.env.NODE_ENV;
+        process.env.NODE_ENV = "production";
+
+        await mkdir(join(fixturesDir, "widgets", "sample"), { recursive: true });
+        await mkdir(join(fixturesDir, "widgets", "sample", "assets"), {
+          recursive: true,
+        });
+        await mkdir(join(fixturesDir, "public"), { recursive: true });
+        await writeFile(
+          join(fixturesDir, "widgets", "sample", "index.html"),
+          `<!doctype html><html><head><script>window.__mcpPublicUrl="/_mcp-use/public";</script></head><body>sample</body></html>`,
+          "utf8"
+        );
+        await writeFile(
+          join(fixturesDir, "widgets", "sample", "assets", "entry.js"),
+          `console.log("hi");`,
+          "utf8"
+        );
+        await writeFile(
+          join(fixturesDir, "public", "hello.txt"),
+          "hello world",
+          "utf8"
+        );
+      });
+
+      afterAll(async () => {
+        process.env.NODE_ENV = originalNodeEnv;
+        // Remove only the fixtures we created — leave anything else under
+        // .mcp-use/ alone (e.g. real generated files from other tests).
+        await rm(join(fixturesDir, "widgets", "sample"), {
+          recursive: true,
+          force: true,
+        });
+        await rm(join(fixturesDir, "public", "hello.txt"), { force: true });
+      });
+
+      it("serves widget HTML byte-for-byte from disk (no runtime transforms)", async () => {
+        const server = new MCPServer({
+          name: "static-widget-html",
+          version: "1.0.0",
+          basePath: "/api",
+        });
+
+        const handler = await server.getHandler();
+        const res = await handler(
+          new Request("http://localhost/_mcp-use/widgets/sample/index.html")
+        );
+
+        expect(res.status).toBe(200);
+        const body = await res.text();
+        expect(body).toContain('window.__mcpPublicUrl="/_mcp-use/public"');
+        expect(body).toContain("<body>sample</body>");
+      });
+
+      it("serves widget JS assets with correct content-type", async () => {
+        const server = new MCPServer({
+          name: "static-widget-assets",
+          version: "1.0.0",
+        });
+
+        const handler = await server.getHandler();
+        const res = await handler(
+          new Request(
+            "http://localhost/_mcp-use/widgets/sample/assets/entry.js"
+          )
+        );
+
+        expect(res.status).toBe(200);
+        expect(res.headers.get("content-type")).toMatch(/javascript/);
+        expect(await res.text()).toBe(`console.log("hi");`);
+      });
+
+      it("serves public files from .mcp-use/public/ at root namespace", async () => {
+        const server = new MCPServer({
+          name: "static-public",
+          version: "1.0.0",
+          basePath: "/api",
+        });
+
+        const handler = await server.getHandler();
+        const res = await handler(
+          new Request("http://localhost/_mcp-use/public/hello.txt")
+        );
+
+        expect(res.status).toBe(200);
+        expect(await res.text()).toBe("hello world");
+      });
     });
 
     it("serves OAuth discovery at root and path-aware paths (basePath-agnostic)", async () => {

--- a/libraries/typescript/packages/mcp-use/tests/unit/server/base-path.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/server/base-path.test.ts
@@ -121,7 +121,9 @@ describe("MCPServer basePath", () => {
 
       const handler = await server.getHandler();
 
-      const prefixed = await handler(new Request("http://localhost/api/health"));
+      const prefixed = await handler(
+        new Request("http://localhost/api/health")
+      );
       expect(prefixed.status).toBe(200);
       expect(await prefixed.text()).toBe("ok");
 

--- a/libraries/typescript/packages/mcp-use/tests/unit/server/base-path.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/server/base-path.test.ts
@@ -107,6 +107,49 @@ describe("MCPServer basePath", () => {
 
       expect(response.status).toBe(200);
     });
+
+    it("auto-prefixes user-registered routes under basePath", async () => {
+      const server = new MCPServer({
+        name: "user-route-prefix",
+        version: "1.0.0",
+        basePath: "/api",
+      });
+
+      // User registers a custom route on `server.app`. With basePath set,
+      // this should be reachable at `${basePath}/health`, not at `/health`.
+      server.app.get("/health", (c) => c.text("ok"));
+
+      const handler = await server.getHandler();
+
+      const prefixed = await handler(new Request("http://localhost/api/health"));
+      expect(prefixed.status).toBe(200);
+      expect(await prefixed.text()).toBe("ok");
+
+      const root = await handler(new Request("http://localhost/health"));
+      expect(root.status).toBe(404);
+    });
+
+    it("serves root serverinfo with basePath-aware URLs", async () => {
+      const server = new MCPServer({
+        name: "serverinfo-base-path",
+        version: "1.0.0",
+        basePath: "/api",
+      });
+
+      const handler = await server.getHandler();
+      const response = await handler(
+        new Request("http://localhost/__mcp-use/serverinfo")
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({
+        basePath: "/api",
+        mcpPath: "/api/mcp",
+        inspectorPath: "/api/inspector",
+        mcpUrl: "http://localhost/api/mcp",
+        inspectorUrl: "http://localhost/api/inspector",
+      });
+    });
   });
 
   describe("instance state", () => {

--- a/libraries/typescript/packages/mcp-use/tests/unit/server/base-path.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/server/base-path.test.ts
@@ -133,7 +133,7 @@ describe("MCPServer basePath", () => {
       expect(root.status).toBe(404);
     });
 
-    it("mounts framework-internal assets at /_mcp-use/ regardless of basePath", async () => {
+    it("mounts framework-internal assets under basePath at `${basePath}/_mcp-use/*`", async () => {
       const server = new MCPServer({
         name: "internal-assets-base-path",
         version: "1.0.0",
@@ -142,12 +142,19 @@ describe("MCPServer basePath", () => {
 
       const handler = await server.getHandler();
 
-      // `_mcp-use/*` is basePath-agnostic — a missing widget still returns
-      // 404 rather than falling through to the inner sub-mount.
-      const internal = await handler(
+      // Unprefixed `/_mcp-use/*` no longer resolves — the framework
+      // namespace is mounted under the configured basePath.
+      const root = await handler(
         new Request("http://localhost/_mcp-use/public/missing.png")
       );
-      expect(internal.status).toBe(404);
+      expect(root.status).toBe(404);
+
+      // Prefixed path: 404 for a missing file is the expected production
+      // result (the route exists, the file doesn't).
+      const prefixed = await handler(
+        new Request("http://localhost/api/_mcp-use/public/missing.png")
+      );
+      expect(prefixed.status).toBe(404);
 
       // The legacy `/__mcp-use/serverinfo` HTTP endpoint is gone; the same
       // information now lives in `.mcp-use/server-info.json` after listen().
@@ -200,7 +207,7 @@ describe("MCPServer basePath", () => {
         await rm(join(fixturesDir, "public", "hello.txt"), { force: true });
       });
 
-      it("serves widget HTML byte-for-byte from disk (no runtime transforms)", async () => {
+      it("serves widget HTML byte-for-byte from disk under basePath", async () => {
         const server = new MCPServer({
           name: "static-widget-html",
           version: "1.0.0",
@@ -209,7 +216,9 @@ describe("MCPServer basePath", () => {
 
         const handler = await server.getHandler();
         const res = await handler(
-          new Request("http://localhost/_mcp-use/widgets/sample/index.html")
+          new Request(
+            "http://localhost/api/_mcp-use/widgets/sample/index.html"
+          )
         );
 
         expect(res.status).toBe(200);
@@ -236,7 +245,7 @@ describe("MCPServer basePath", () => {
         expect(await res.text()).toBe(`console.log("hi");`);
       });
 
-      it("serves public files from .mcp-use/public/ at root namespace", async () => {
+      it("serves public files from .mcp-use/public/ under basePath", async () => {
         const server = new MCPServer({
           name: "static-public",
           version: "1.0.0",
@@ -245,7 +254,7 @@ describe("MCPServer basePath", () => {
 
         const handler = await server.getHandler();
         const res = await handler(
-          new Request("http://localhost/_mcp-use/public/hello.txt")
+          new Request("http://localhost/api/_mcp-use/public/hello.txt")
         );
 
         expect(res.status).toBe(200);

--- a/libraries/typescript/packages/mcp-use/tests/unit/server/logging.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/server/logging.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Context, Next } from "hono";
 
-import { getDebugLevel, requestLogger } from "../../../src/server/logging.js";
+import {
+  createRequestLogger,
+  getDebugLevel,
+} from "../../../src/server/logging.js";
+
+const requestLogger = createRequestLogger();
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/skills/chatgpt-app-builder/references/foundations/architecture.md
+++ b/skills/chatgpt-app-builder/references/foundations/architecture.md
@@ -243,6 +243,39 @@ server.tool(
 
 ---
 
+## Mounting Under a Path Prefix
+
+Use the `basePath` server option to move every route mcp-use registers under a single prefix. Useful when the server lives behind a reverse proxy that namespaces paths, or when you want to host MCP alongside other routes on the same origin.
+
+```typescript
+const server = new MCPServer({
+  name: "my-server",
+  version: "1.0.0",
+  basePath: "/api",
+});
+```
+
+With `basePath: "/api"`:
+
+| Default | With prefix |
+|---|---|
+| `POST /mcp` | `POST /api/mcp` |
+| `GET /sse` | `GET /api/sse` |
+| `GET /inspector` | `GET /api/inspector` |
+| `/mcp-use/widgets/*` | `/api/mcp-use/widgets/*` |
+| `/.well-known/oauth-authorization-server` | `/api/.well-known/oauth-authorization-server` |
+| `/authorize`, `/token`, `/register` | `/api/authorize`, `/api/token`, `/api/register` |
+
+OAuth discovery metadata (`issuer`, `authorization_endpoint`, `token_endpoint`, etc.) is rebuilt to include the prefix, so standard OAuth 2.1 / RFC 9728 discovery works without extra config.
+
+**Rules:**
+- Must start with `/` and must not end with `/`
+- Empty string or `"/"` means "no prefix" (the default)
+- `/favicon.ico` stays at the root so browsers' implicit favicon request still resolves
+- Custom routes you register with `server.get(...)` or `server.app.get(...)` are **not** auto-prefixed — write them at the path you want them served from
+
+---
+
 ## Custom HTTP Endpoints
 
 You can mix MCP tools with custom HTTP routes:

--- a/skills/mcp-apps-builder/references/foundations/architecture.md
+++ b/skills/mcp-apps-builder/references/foundations/architecture.md
@@ -243,6 +243,39 @@ server.tool(
 
 ---
 
+## Mounting Under a Path Prefix
+
+Use the `basePath` server option to move every route mcp-use registers under a single prefix. Useful when the server lives behind a reverse proxy that namespaces paths, or when you want to host MCP alongside other routes on the same origin.
+
+```typescript
+const server = new MCPServer({
+  name: "my-server",
+  version: "1.0.0",
+  basePath: "/api",
+});
+```
+
+With `basePath: "/api"`:
+
+| Default | With prefix |
+|---|---|
+| `POST /mcp` | `POST /api/mcp` |
+| `GET /sse` | `GET /api/sse` |
+| `GET /inspector` | `GET /api/inspector` |
+| `/mcp-use/widgets/*` | `/api/mcp-use/widgets/*` |
+| `/.well-known/oauth-authorization-server` | `/api/.well-known/oauth-authorization-server` |
+| `/authorize`, `/token`, `/register` | `/api/authorize`, `/api/token`, `/api/register` |
+
+OAuth discovery metadata (`issuer`, `authorization_endpoint`, `token_endpoint`, etc.) is rebuilt to include the prefix, so standard OAuth 2.1 / RFC 9728 discovery works without extra config.
+
+**Rules:**
+- Must start with `/` and must not end with `/`
+- Empty string or `"/"` means "no prefix" (the default)
+- `/favicon.ico` stays at the root so browsers' implicit favicon request still resolves
+- Custom routes you register with `server.get(...)` or `server.app.get(...)` are **not** auto-prefixed — write them at the path you want them served from
+
+---
+
 ## Custom HTTP Endpoints
 
 You can mix MCP tools with custom HTTP routes:

--- a/skills/mcp-builder/references/foundations/architecture.md
+++ b/skills/mcp-builder/references/foundations/architecture.md
@@ -243,6 +243,39 @@ server.tool(
 
 ---
 
+## Mounting Under a Path Prefix
+
+Use the `basePath` server option to move every route mcp-use registers under a single prefix. Useful when the server lives behind a reverse proxy that namespaces paths, or when you want to host MCP alongside other routes on the same origin.
+
+```typescript
+const server = new MCPServer({
+  name: "my-server",
+  version: "1.0.0",
+  basePath: "/api",
+});
+```
+
+With `basePath: "/api"`:
+
+| Default | With prefix |
+|---|---|
+| `POST /mcp` | `POST /api/mcp` |
+| `GET /sse` | `GET /api/sse` |
+| `GET /inspector` | `GET /api/inspector` |
+| `/mcp-use/widgets/*` | `/api/mcp-use/widgets/*` |
+| `/.well-known/oauth-authorization-server` | `/api/.well-known/oauth-authorization-server` |
+| `/authorize`, `/token`, `/register` | `/api/authorize`, `/api/token`, `/api/register` |
+
+OAuth discovery metadata (`issuer`, `authorization_endpoint`, `token_endpoint`, etc.) is rebuilt to include the prefix, so standard OAuth 2.1 / RFC 9728 discovery works without extra config.
+
+**Rules:**
+- Must start with `/` and must not end with `/`
+- Empty string or `"/"` means "no prefix" (the default)
+- `/favicon.ico` stays at the root so browsers' implicit favicon request still resolves
+- Custom routes you register with `server.get(...)` or `server.app.get(...)` are **not** auto-prefixed — write them at the path you want them served from
+
+---
+
 ## Custom HTTP Endpoints
 
 You can mix MCP tools with custom HTTP routes:


### PR DESCRIPTION
## Summary

Accept a Better Auth instance directly in `oauthBetterAuthProvider`. The SDK mounts `auth.handler` under the MCPServer's basePath and serves OAuth discovery locally (synthesized via `auth.api.getOAuthServerConfig` / `getOpenIdConfig`). The RFC 8414 §3.1 path-insertion variants register at the issuer's pathname so probes hit the right URL even when the issuer path is deeper than the MCP basePath.

The argument is polymorphic — an auth instance selects in-process mode; `{ authURL }` remains for external Better Auth deployments.

## Before

```typescript
const server = new MCPServer({
  basePath: "/mcp-server",
  oauth: oauthBetterAuthProvider({
    authURL: "http://localhost:3000/mcp-server/api/auth",
  }),
});

// Developer had to mount everything manually. `server.app` is the basePath
// clone, so well-known endpoints registered through it ended up under
// /mcp-server/.well-known/* — silently broken because RFC 8414 §3.1 requires
// the path-insertion variant at the literal host root.
server.app.on(["GET", "POST"], "/api/auth/**", (c) => auth.handler(c.req.raw));
server.app.get("/.well-known/oauth-authorization-server", authServerHandler);
server.app.get("/.well-known/oauth-authorization-server/api/auth", authServerHandler);
server.app.get("/.well-known/openid-configuration", openIdHandler);
server.app.get("/.well-known/openid-configuration/api/auth", openIdHandler);
```

## After

```typescript
const server = new MCPServer({
  basePath: "/mcp-server",
  oauth: oauthBetterAuthProvider(auth),
});
```

Set `auth.options.basePath` to where Better Auth should live inside the MCPServer's basePath — e.g. `basePath: "/mcp-server/api/auth"` with `baseURL: "http://localhost:3000"`. Anchoring Better Auth at a sub-path of the MCPServer basePath (rather than the basePath itself) keeps `auth.handler` from shadowing routes like the MCP transport. The SDK mirrors Better Auth's own `withPath` resolution, so passing the full path via `baseURL` works identically.

## Plumbing

`OAuthProvider` gains three optional hooks for custom providers:

- `authorizationServerMetadataHandler?(req)` — replaces the default upstream-fetch behavior for `.well-known/oauth-authorization-server`
- `openIdConfigurationMetadataHandler?(req)` — same, for `.well-known/openid-configuration`
- `installRoutes?(rootApp, basePath)` — mount provider-specific routes on the root Hono app after defaults are registered

`setupOAuthRoutes` now also registers `.well-known/*` at the issuer's pathname (in addition to `basePath`) so in-process providers whose issuer lives at a deeper path than basePath aren't a silent 404.

## External mode unchanged

```typescript
oauthBetterAuthProvider({ authURL: "https://auth.example.com/api/auth" })
```

The two modes are mutually exclusive — the argument shape selects the mode (an instance has `handler` + `options`; a config object doesn't).

## Test plan

- [x] `tests/server/oauth-better-auth.test.ts` — in-process: discovery served at issuer-path-suffixed well-known URL, `auth.handler` mounted at issuer pathname, `withPath` fallback behavior, missing-baseURL error; external: `authURL` is issuer, hooks left undefined, missing-args error
- [x] Existing `tests/server/oauth.test.ts` still passes (proxy / basePath suffixes)
- [x] `pnpm build` clean
- [ ] Manual: run the Better Auth example, confirm Inspector + Claude can complete the OAuth flow

## Backwards Compatibility

Non-breaking. External-mode `{ authURL }` callers still work as-is. In-process mode is a new shape.

## Related

Builds on #1517 (basePath PR). Replaces failed attempt on `feat/better-auth-in-process-mode`.