### PR TITLE
server(sessions): validate configured session file path to prevent pa…

### DIFF
--- a/libraries/typescript/packages/mcp-use/src/server/sessions/stores/filesystem.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/sessions/stores/filesystem.ts
@@ -17,7 +17,7 @@
 
 import { existsSync, readFileSync } from "node:fs";
 import { mkdir, rename, unlink, writeFile } from "node:fs/promises";
-import { dirname, join, resolve, normalize, isAbsolute } from "node:path";
+import { dirname, join, resolve, normalize, isAbsolute, relative as pathRelative } from "node:path";
 import type { SessionMetadata } from "../session-manager.js";
 import type { SessionStore } from "./index.js";
 
@@ -85,7 +85,10 @@ export class FileSystemSessionStore implements SessionStore {
    * Validate and resolve a configured path.
    * - Resolves relative paths against process.cwd()
    * - Normalizes the resolved path
-   * - Ensures the resolved path is within the process.cwd() tree to prevent path traversal
+   * - Ensures the resolved path is contained inside the project root to prevent path traversal
+   *
+   * Note: absolute paths that resolve outside the project are rejected. Use this
+   * to fail fast on misconfiguration and avoid accidental writes outside the repo.
    */
   private validatePath(pathStr: string): string {
     const resolved = isAbsolute(pathStr) ? resolve(pathStr) : resolve(process.cwd(), pathStr);
@@ -93,14 +96,22 @@ export class FileSystemSessionStore implements SessionStore {
 
     const cwdRoot = resolve(process.cwd());
 
-    // Prevent escaping the cwd when a relative path was provided
-    if (!normalized.startsWith(cwdRoot)) {
-      throw new Error(
-        `FileSystemSessionStore: path must be absolute or within the project directory (resolved: ${normalized})`
-      );
+    // Perform a boundary-aware containment check using path.relative.
+    // On Windows, compare case-insensitively to avoid false negatives.
+    const isWindows = process.platform === "win32";
+    const baseForCompare = isWindows ? cwdRoot.toLowerCase() : cwdRoot;
+    const targetForCompare = isWindows ? normalized.toLowerCase() : normalized;
+
+    const rel = pathRelative(baseForCompare, targetForCompare);
+
+    // Accept when the relative path is empty (same path) or does not begin with '..'
+    if (rel === "" || (!rel.startsWith("..") && !isAbsolute(rel))) {
+      return normalized;
     }
 
-    return normalized;
+    throw new Error(
+      `FileSystemSessionStore: configured path must resolve inside the project directory (resolved: ${normalized})`
+    );
   }
 
   /**

--- a/libraries/typescript/packages/mcp-use/src/server/sessions/stores/filesystem.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/sessions/stores/filesystem.ts
@@ -17,7 +17,7 @@
 
 import { existsSync, readFileSync } from "node:fs";
 import { mkdir, rename, unlink, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve, normalize, isAbsolute } from "node:path";
 import type { SessionMetadata } from "../session-manager.js";
 import type { SessionStore } from "./index.js";
 
@@ -72,13 +72,35 @@ export class FileSystemSessionStore implements SessionStore {
   private pendingSave = false;
 
   constructor(config: FileSystemSessionStoreConfig = {}) {
-    this.filePath =
-      config.path ?? join(process.cwd(), ".mcp-use", "sessions.json");
+    const rawPath = config.path ?? join(process.cwd(), ".mcp-use", "sessions.json");
+    this.filePath = this.validatePath(rawPath);
     this.debounceMs = config.debounceMs ?? 100;
     this.maxAgeMs = config.maxAgeMs ?? 24 * 60 * 60 * 1000; // 24 hours
 
     // Load existing sessions synchronously on construction
     this.loadSessionsSync();
+  }
+
+  /**
+   * Validate and resolve a configured path.
+   * - Resolves relative paths against process.cwd()
+   * - Normalizes the resolved path
+   * - Ensures the resolved path is within the process.cwd() tree to prevent path traversal
+   */
+  private validatePath(pathStr: string): string {
+    const resolved = isAbsolute(pathStr) ? resolve(pathStr) : resolve(process.cwd(), pathStr);
+    const normalized = normalize(resolved);
+
+    const cwdRoot = resolve(process.cwd());
+
+    // Prevent escaping the cwd when a relative path was provided
+    if (!normalized.startsWith(cwdRoot)) {
+      throw new Error(
+        `FileSystemSessionStore: path must be absolute or within the project directory (resolved: ${normalized})`
+      );
+    }
+
+    return normalized;
   }
 
   /**


### PR DESCRIPTION
Changes

Add path validation to the FileSystem session store to prevent path traversal when consumers configure a custom session file path.
Add unit tests that reproduce path-traversal attempts and assert safe behavior.


Implementation Details

(1) . Added a private validatePath(pathStr: string): string to [filesystem.ts](vscode-file://vscode-app/d:/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html) 
which:
Resolves relative paths against process.cwd(), normalizes them, and verifies the resolved path is contained inside the repository root.
Throws an error when a configured path resolves outside the project directory.


(2) Updated the FileSystemSessionStore constructor to call validatePath for the configured path. 

(3) Added unit test: libraries/typescript/packages/mcp-use/tests/security/filesystem-path-traversal.test.ts to:
Verify traversal attempts are rejected.
Verify valid relative and absolute in-repo paths are accepted and persisted.

(4) Architectural decision: keep validation simple and synchronous during construction so misconfiguration fails fast. Recommended follow-up (non-blocking): switch to path.relative() containment check to avoid subtle Windows/drive-letter edge cases.

TypeScript Checklist

Packages Modified

 docs
 tests
 cli
 create-mcp-use-app
 mcp-use (server)
 mcp-use (client)
 inspector

Pre-commit Checklist

 Ran pnpm lint:fix
 Ran pnpm format
 Ran pnpm build
 Ran pnpm changeset (if user-facing)
 Added unit tests
 Updated docs (none required for this small security fix)


Example Usage (Before)
new FileSystemSessionStore({ path: '../secrets/sessions.json' }) // could escape repo root


Example Usage (After)
new FileSystemSessionStore({ path: '.mcp-use/sessions.json' }) // allowed
new FileSystemSessionStore({ path: '/absolute/path/inside/repo/.mcp-use/sessions.json' }) // allowed
new FileSystemSessionStore({ path: '../outside/sessions.json' }) // throws at construction.



Documentation Updates
None required; behavior is a tightened validation of existing configuration. If desired, add a short note to the server/session-store docs describing valid path constraints.


Testing
Unit tests added: tests/security/filesystem-path-traversal.test.ts — covers rejection of out-of-repo paths and acceptance of valid paths.
Manual test: constructed FileSystemSessionStore with bad path and observed constructor throw.
Integration tests unrelated to this change (OpenAI, HMR, Windows ESM) may still fail in CI due to environment; they are out-of-scope for this PR.



Backwards Compatibility

Non-breaking: only rejects misconfigured paths that would previously write outside the project. This is a security hardening; users who intentionally configured an out-of-repo path will need to update their config.


Issues 

Close  #1569 
