### PR TITLE
fix(oauth): redact token verification errors

### DIFF
--- a/libraries/typescript/.changeset/silent-oauth-errors.md
+++ b/libraries/typescript/.changeset/silent-oauth-errors.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Redact OAuth token verification errors from client responses while logging details server-side.

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/middleware.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/middleware.ts
@@ -94,8 +94,9 @@ export function createBearerAuthMiddleware(
 
       await next();
     } catch (error) {
+      console.error("[OAuth Middleware] Token verification failed:", error);
       c.header("WWW-Authenticate", getWWWAuthenticateHeader());
-      return c.json({ error: `Invalid token: ${error}` }, 401);
+      return c.json({ error: "Invalid token" }, 401);
     }
   };
 }

--- a/libraries/typescript/packages/mcp-use/tests/server/oauth.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/server/oauth.test.ts
@@ -164,6 +164,45 @@ describe("server OAuth integration", () => {
     expect(authorized.status).toBe(200);
   });
 
+  it("does not expose token verification internals to clients", async () => {
+    const app = new Hono();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const proxy = oauthProxy({
+      issuer: "https://issuer.example.com",
+      authEndpoint: "https://issuer.example.com/oauth/authorize",
+      tokenEndpoint: "https://issuer.example.com/oauth/token",
+      clientId: "test-client",
+      verifyToken: async () => {
+        throw new Error(
+          "JWKS fetch failed at https://issuer.example.com/.well-known/jwks.json"
+        );
+      },
+    });
+
+    app.use("/mcp/*", createBearerAuthMiddleware(proxy));
+    app.get("/mcp/test", (c) => c.json({ ok: true }));
+
+    const svc = await listenOnRandomPort(app);
+    closers.push(svc.close);
+
+    const response = await fetch(`${svc.baseUrl}/mcp/test`, {
+      headers: { Authorization: "Bearer token-123" },
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body).toEqual({ error: "Invalid token" });
+    expect(JSON.stringify(body)).not.toContain("JWKS");
+    expect(JSON.stringify(body)).not.toContain("issuer.example.com");
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[OAuth Middleware] Token verification failed:",
+      expect.any(Error)
+    );
+
+    errorSpy.mockRestore();
+  });
+
   it("returns configured clientId from /register endpoint", async () => {
     const app = new Hono();
 


### PR DESCRIPTION
## Summary
- returns a generic Invalid token response from OAuth middleware verification failures
- logs the original verification error server-side for debugging
- adds a regression test that verifies JWKS/provider details are not exposed to clients

Fixes #1570.

## Verification
- git diff --check
- pnpm exec vitest run tests/server/oauth.test.ts