### PR TITLE
fix(server): throttle filesystem session saves

### DIFF
--- a/libraries/typescript/packages/mcp-use/src/server/sessions/stores/filesystem.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/sessions/stores/filesystem.ts
@@ -37,6 +37,18 @@ export interface FileSystemSessionStoreConfig {
   debounceMs?: number;
 
   /**
+   * Minimum delay in milliseconds between disk writes (default: 500)
+   * Protects the filesystem from sustained rapid session churn.
+   */
+  minSaveIntervalMs?: number;
+
+  /**
+   * Maximum number of disk writes allowed per rolling second (default: 2)
+   * Additional writes are coalesced into the next allowed save.
+   */
+  maxSavesPerSecond?: number;
+
+  /**
    * Maximum session age in milliseconds (default: 24 hours)
    * Sessions older than this are cleaned up on load
    */
@@ -66,16 +78,35 @@ export class FileSystemSessionStore implements SessionStore {
   private sessions = new Map<string, SessionMetadata>();
   private readonly filePath: string;
   private readonly debounceMs: number;
+  private readonly minSaveIntervalMs: number;
+  private readonly maxSavesPerSecond: number;
   private readonly maxAgeMs: number;
   private saveTimer: NodeJS.Timeout | null = null;
   private saving = false;
   private pendingSave = false;
+  private lastSaveAt = 0;
+  private saveTimestamps: number[] = [];
 
   constructor(config: FileSystemSessionStoreConfig = {}) {
     this.filePath =
       config.path ?? join(process.cwd(), ".mcp-use", "sessions.json");
     this.debounceMs = config.debounceMs ?? 100;
+    this.minSaveIntervalMs = config.minSaveIntervalMs ?? 500;
+    this.maxSavesPerSecond = config.maxSavesPerSecond ?? 2;
     this.maxAgeMs = config.maxAgeMs ?? 24 * 60 * 60 * 1000; // 24 hours
+
+    if (this.debounceMs < 0) {
+      throw new Error("debounceMs must be non-negative");
+    }
+    if (this.minSaveIntervalMs < 0) {
+      throw new Error("minSaveIntervalMs must be non-negative");
+    }
+    if (
+      !Number.isInteger(this.maxSavesPerSecond) ||
+      this.maxSavesPerSecond < 1
+    ) {
+      throw new Error("maxSavesPerSecond must be a positive integer");
+    }
 
     // Load existing sessions synchronously on construction
     this.loadSessionsSync();
@@ -188,7 +219,7 @@ export class FileSystemSessionStore implements SessionStore {
     // Schedule cleanup using setTimeout as fallback
     setTimeout(() => {
       this.sessions.delete(sessionId);
-      this.scheduleSave();
+      void this.scheduleSave();
     }, ttlMs);
   }
 
@@ -223,10 +254,40 @@ export class FileSystemSessionStore implements SessionStore {
       clearTimeout(this.saveTimer);
     }
 
-    // Schedule new save after debounce delay
-    this.saveTimer = setTimeout(() => {
-      this.performSave();
-    }, this.debounceMs);
+    const delay = this.getSaveDelay();
+
+    // Schedule new save after debounce and throttle delay
+    this.saveTimer = setTimeout(async () => {
+      await this.performSave();
+    }, delay);
+  }
+
+  /**
+   * Compute the next allowed save time. Debouncing handles short bursts,
+   * minSaveInterval handles sustained churn, and maxSavesPerSecond protects
+   * against repeated immediate flushes/saves in a rolling one-second window.
+   */
+  private getSaveDelay(): number {
+    const now = Date.now();
+    let delay = this.debounceMs;
+
+    if (this.lastSaveAt > 0) {
+      delay = Math.max(
+        delay,
+        Math.max(0, this.minSaveIntervalMs - (now - this.lastSaveAt))
+      );
+    }
+
+    this.saveTimestamps = this.saveTimestamps.filter(
+      (timestamp) => now - timestamp < 1000
+    );
+
+    if (this.saveTimestamps.length >= this.maxSavesPerSecond) {
+      const oldestSave = this.saveTimestamps[0];
+      delay = Math.max(delay, Math.max(0, 1000 - (now - oldestSave)));
+    }
+
+    return delay;
   }
 
   /**
@@ -253,6 +314,12 @@ export class FileSystemSessionStore implements SessionStore {
       const tempPath = `${this.filePath}.tmp`;
       await writeFile(tempPath, JSON.stringify(data, null, 2), "utf-8");
       await rename(tempPath, this.filePath);
+      const now = Date.now();
+      this.lastSaveAt = now;
+      this.saveTimestamps = [
+        ...this.saveTimestamps.filter((timestamp) => now - timestamp < 1000),
+        now,
+      ];
     } catch (error: any) {
       console.error(
         `[FileSystemSessionStore] Error saving sessions:`,

--- a/libraries/typescript/packages/mcp-use/tests/unit/server/session-stores.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/server/session-stores.test.ts
@@ -6,8 +6,12 @@
  * Run with Redis: infisical run --env=dev --projectId=13272018-648f-41fd-911c-908a27c9901e -- pnpm test tests/unit/server/session-stores.test.ts
  */
 
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
+  FileSystemSessionStore,
   InMemorySessionStore,
   RedisSessionStore,
 } from "../../../src/server/index.js";
@@ -178,6 +182,135 @@ describe("InMemorySessionStore", () => {
       expect(retrieved?.lastAccessedAt).toBe(2000);
       expect(retrieved?.logLevel).toBe("debug");
     });
+  });
+});
+
+describe("FileSystemSessionStore", () => {
+  let tempDir: string;
+  let sessionFile: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "mcp-use-session-store-"));
+    sessionFile = join(tempDir, "sessions.json");
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function wait(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  function readSessions(): Record<string, SessionMetadata> {
+    return JSON.parse(readFileSync(sessionFile, "utf-8"));
+  }
+
+  it("coalesces bursty updates into one debounced write", async () => {
+    const store = new FileSystemSessionStore({
+      path: sessionFile,
+      debounceMs: 20,
+      minSaveIntervalMs: 100,
+    });
+
+    const sessionData: SessionMetadata = {
+      lastAccessedAt: Date.now(),
+    };
+
+    await store.set("session-1", sessionData);
+    await store.set("session-2", sessionData);
+    await store.set("session-3", sessionData);
+
+    await wait(10);
+    expect(existsSync(sessionFile)).toBe(false);
+
+    await wait(30);
+    expect(Object.keys(readSessions()).sort()).toEqual([
+      "session-1",
+      "session-2",
+      "session-3",
+    ]);
+  });
+
+  it("enforces the minimum interval between sustained writes", async () => {
+    const store = new FileSystemSessionStore({
+      path: sessionFile,
+      debounceMs: 10,
+      minSaveIntervalMs: 100,
+    });
+
+    const sessionData: SessionMetadata = {
+      lastAccessedAt: Date.now(),
+    };
+
+    await store.set("session-1", sessionData);
+    await wait(30);
+    expect(Object.keys(readSessions())).toEqual(["session-1"]);
+
+    await store.set("session-2", sessionData);
+    await wait(50);
+    expect(Object.keys(readSessions())).toEqual(["session-1"]);
+
+    await wait(80);
+    expect(Object.keys(readSessions()).sort()).toEqual([
+      "session-1",
+      "session-2",
+    ]);
+  });
+
+  it("caps filesystem saves per rolling second", async () => {
+    const store = new FileSystemSessionStore({
+      path: sessionFile,
+      debounceMs: 0,
+      minSaveIntervalMs: 0,
+      maxSavesPerSecond: 2,
+    });
+
+    const sessionData: SessionMetadata = {
+      lastAccessedAt: Date.now(),
+    };
+
+    await store.set("session-1", sessionData);
+    await wait(20);
+    expect(Object.keys(readSessions())).toEqual(["session-1"]);
+
+    await store.set("session-2", sessionData);
+    await wait(20);
+    expect(Object.keys(readSessions()).sort()).toEqual([
+      "session-1",
+      "session-2",
+    ]);
+
+    await store.set("session-3", sessionData);
+    await wait(100);
+    expect(Object.keys(readSessions()).sort()).toEqual([
+      "session-1",
+      "session-2",
+    ]);
+
+    await wait(950);
+    expect(Object.keys(readSessions()).sort()).toEqual([
+      "session-1",
+      "session-2",
+      "session-3",
+    ]);
+  });
+
+  it("flushes immediately for process-exit persistence", async () => {
+    const store = new FileSystemSessionStore({
+      path: sessionFile,
+      debounceMs: 10_000,
+      minSaveIntervalMs: 10_000,
+    });
+
+    const sessionData: SessionMetadata = {
+      lastAccessedAt: Date.now(),
+    };
+
+    await store.set("session-1", sessionData);
+    await store.flush();
+
+    expect(Object.keys(readSessions())).toEqual(["session-1"]);
   });
 });
 


### PR DESCRIPTION
## Summary
- Add configurable `minSaveIntervalMs` and `maxSavesPerSecond` controls to `FileSystemSessionStore`.
- Coalesce bursty session mutations while enforcing a minimum interval and rolling per-second write cap.
- Preserve `flush()` as the immediate persistence path for process-exit/shutdown flows.
- Add regression coverage for burst coalescing, sustained-write throttling, save-rate caps, and flush behavior.

Fixes #1568.

## Verification
- `npx -y pnpm@10.30.0 --dir libraries/typescript/packages/mcp-use run generate:version`
- `npx -y pnpm@10.30.0 --dir libraries/typescript/packages/mcp-use exec vitest run tests/unit/server/session-stores.test.ts` (15 passed, 1 Redis skip)
- `npx -y pnpm@10.30.0 --dir libraries/typescript exec eslint packages/mcp-use/src/server/sessions/stores/filesystem.ts packages/mcp-use/tests/unit/server/session-stores.test.ts`
- `npx -y pnpm@10.30.0 --dir libraries/typescript exec prettier --write packages/mcp-use/src/server/sessions/stores/filesystem.ts packages/mcp-use/tests/unit/server/session-stores.test.ts`
- `git diff --check`