### PR TITLE
Redact OAuth token verification errors

### DIFF
--- a/libraries/typescript/packages/mcp-use/src/server/oauth/middleware.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/middleware.ts
@@ -94,8 +94,9 @@ export function createBearerAuthMiddleware(
 
       await next();
     } catch (error) {
+      console.warn("[OAuth] Token verification failed:", error);
       c.header("WWW-Authenticate", getWWWAuthenticateHeader());
-      return c.json({ error: `Invalid token: ${error}` }, 401);
+      return c.json({ error: "Invalid token" }, 401);
     }
   };
 }

--- a/libraries/typescript/packages/mcp-use/tests/server/oauth.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/server/oauth.test.ts
@@ -164,6 +164,47 @@ describe("server OAuth integration", () => {
     expect(authorized.status).toBe(200);
   });
 
+  it("does not leak verifier error details for invalid bearer tokens", async () => {
+    const app = new Hono();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const proxy = oauthProxy({
+      issuer: "https://issuer.example.com",
+      authEndpoint: "https://issuer.example.com/oauth/authorize",
+      tokenEndpoint: "https://issuer.example.com/oauth/token",
+      clientId: "test-client",
+      verifyToken: async () => {
+        throw new Error(
+          "jwt expired for tenant=acme internal_key_id=secret-kid-123"
+        );
+      },
+    });
+
+    app.use("/mcp/*", createBearerAuthMiddleware(proxy));
+    app.get("/mcp/test", (c) => c.json({ ok: true }));
+
+    const svc = await listenOnRandomPort(app);
+    closers.push(svc.close);
+
+    const response = await fetch(`${svc.baseUrl}/mcp/test`, {
+      headers: { Authorization: "Bearer bad-token" },
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body).toEqual({ error: "Invalid token" });
+    expect(JSON.stringify(body)).not.toContain("secret-kid-123");
+    expect(response.headers.get("WWW-Authenticate")).toContain(
+      'Bearer error="unauthorized"'
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[OAuth] Token verification failed:",
+      expect.any(Error)
+    );
+
+    warnSpy.mockRestore();
+  });
+
   it("returns configured clientId from /register endpoint", async () => {
     const app = new Hono();
 


### PR DESCRIPTION
## Summary
- stop returning raw verifier exceptions from the bearer auth middleware
- keep the OAuth discovery `WWW-Authenticate` response intact for MCP clients
- log verifier details server-side and add regression coverage for secret-bearing errors

## Why
When `verifyToken()` throws, the current 401 body includes the exception string. Provider errors can include tenant identifiers, key ids, issuer internals, or other operational detail that should not be reflected to clients.

## Tests
- `pnpm --filter mcp-use test:run tests/server/oauth.test.ts`
- `pnpm --filter mcp-use exec prettier --check src/server/oauth/middleware.ts tests/server/oauth.test.ts`
- `pnpm --filter mcp-use generate:version && pnpm --filter mcp-use exec tsc --noEmit`