### PR TITLE
fix: RFC 8414 compliance for OAuth metadata discovery with path-suffix issuers

### DIFF
--- a/libraries/typescript/packages/mcp-use/src/server/oauth/routes.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/routes.ts
@@ -308,7 +308,10 @@ export function setupOAuthRoutes(
     // DCR-direct mode: proxy to upstream
     try {
       const issuer = oauth.getIssuer();
-      const metadataUrl = `${issuer}/.well-known/oauth-authorization-server`;
+      // RFC 8414 §3: The well-known segment goes between the host and path
+      const u = new URL(issuer);
+      const path = u.pathname.replace(/\/$/, "");
+      const metadataUrl = `${u.origin}/.well-known/oauth-authorization-server${path}`;
       console.log(`[OAuth] Fetching metadata from provider: ${metadataUrl}`);
       const response = await fetch(metadataUrl);
 

--- a/libraries/typescript/packages/mcp-use/tests/server/oauth.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/server/oauth.test.ts
@@ -11,6 +11,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createBearerAuthMiddleware } from "../../src/server/oauth/middleware.js";
 import { setupOAuthRoutes } from "../../src/server/oauth/routes.js";
 import { oauthProxy } from "../../src/server/oauth/oauth-proxy.js";
+import type { OAuthProvider } from "../../src/server/oauth/providers/types.js";
 
 // A stub verifier that accepts any token. Used in tests that don't exercise
 // the verification path (routes, metadata, registration).
@@ -196,5 +197,141 @@ describe("server OAuth integration", () => {
     expect(registration.client_id).toBe("pre-registered-client-id");
     expect(registration.client_name).toBe("My MCP Client");
     expect(registration.token_endpoint_auth_method).toBe("client_secret_post");
+  });
+
+  it("fetches metadata from upstream provider with path-suffix issuer (RFC 8414)", async () => {
+    // This test verifies the fix for issuers with path components
+    // Example: PropelAuth's https://auth.<tenant>.com/oauth/2.1
+
+    // Track the URL that was requested to verify RFC 8414 compliance
+    const metadataSpy = vi.fn();
+
+    // Upstream OAuth server with a path-suffix issuer
+    // Per RFC 8414, the well-known segment goes between host and path
+    // So for issuer https://auth.example.com/oauth/2.1,
+    // the metadata URL should be https://auth.example.com/.well-known/oauth-authorization-server/oauth/2.1
+    const upstream = new Hono();
+    upstream.get("/.well-known/oauth-authorization-server/*", async (c) => {
+      const pathname = new URL(c.req.url).pathname;
+      metadataSpy(pathname);
+      
+      // Return metadata with the issuer matching the upstream base URL
+      return c.json({
+        issuer: `${c.req.url.split('/.well-known')[0]}/oauth/2.1`,
+        authorization_endpoint: `${c.req.url.split('/.well-known')[0]}/oauth/2.1/authorize`,
+        token_endpoint: `${c.req.url.split('/.well-known')[0]}/oauth/2.1/token`,
+        registration_endpoint: `${c.req.url.split('/.well-known')[0]}/oauth/2.1/register`,
+        response_types_supported: ["code"],
+        grant_types_supported: ["authorization_code"],
+        token_endpoint_auth_methods_supported: ["none"],
+        code_challenge_methods_supported: ["S256"],
+      });
+    });
+
+    const upstreamSvc = await listenOnRandomPort(upstream);
+    closers.push(upstreamSvc.close);
+
+    // Create a mock OAuthProvider for DCR-direct mode
+    const mockProvider: OAuthProvider = {
+      getIssuer: () => `${upstreamSvc.baseUrl}/oauth/2.1`,
+      getAuthEndpoint: () =>
+        `${upstreamSvc.baseUrl}/oauth/2.1/authorize`,
+      getTokenEndpoint: () => `${upstreamSvc.baseUrl}/oauth/2.1/token`,
+      getScopesSupported: () => ["openid", "profile"],
+      getGrantTypesSupported: () => ["authorization_code"],
+      verifyToken: stubVerifyToken,
+      getUserInfo: () => ({
+        userId: "test-user",
+        email: "test@example.com",
+      }),
+    };
+
+    const app = new Hono();
+    const svc = await listenOnRandomPort(app);
+    closers.push(svc.close);
+
+    setupOAuthRoutes(app, mockProvider, svc.baseUrl);
+
+    // Request the metadata from the MCP server
+    const response = await fetch(
+      `${svc.baseUrl}/.well-known/oauth-authorization-server`
+    );
+
+    expect(response.status).toBe(200);
+
+    const metadata = await response.json();
+    // The metadata issuer should match what the upstream returned (based on its local URL)
+    expect(metadata.issuer).toContain("/oauth/2.1");
+
+    // Verify that the upstream was called with RFC 8414 compliant path
+    // The well-known segment should be between the host and the path
+    expect(metadataSpy).toHaveBeenCalledTimes(1);
+    expect(metadataSpy.mock.calls[0][0]).toBe(
+      "/.well-known/oauth-authorization-server/oauth/2.1"
+    );
+  });
+
+  it("fetches OIDC configuration from upstream with path-suffix issuer", async () => {
+    // Test the same RFC 8414 fix for the OIDC discovery endpoint
+    // Note: Both endpoints use the same handler, so they both fetch from
+    // /.well-known/oauth-authorization-server on the upstream
+    const metadataSpy = vi.fn();
+
+    const upstream = new Hono();
+    // Both discovery endpoints fetch from oauth-authorization-server
+    upstream.get("/.well-known/oauth-authorization-server/*", async (c) => {
+      const pathname = new URL(c.req.url).pathname;
+      metadataSpy(pathname);
+      
+      // Return metadata with the issuer matching the upstream base URL
+      return c.json({
+        issuer: `${c.req.url.split('/.well-known')[0]}/oauth/2.1`,
+        authorization_endpoint: `${c.req.url.split('/.well-known')[0]}/oauth/2.1/authorize`,
+        token_endpoint: `${c.req.url.split('/.well-known')[0]}/oauth/2.1/token`,
+        registration_endpoint: `${c.req.url.split('/.well-known')[0]}/oauth/2.1/register`,
+        userinfo_endpoint: `${c.req.url.split('/.well-known')[0]}/oauth/2.1/userinfo`,
+        response_types_supported: ["code"],
+        grant_types_supported: ["authorization_code"],
+        subject_types_supported: ["public"],
+        id_token_signing_alg_values_supported: ["RS256"],
+      });
+    });
+
+    const upstreamSvc = await listenOnRandomPort(upstream);
+    closers.push(upstreamSvc.close);
+
+    const mockProvider: OAuthProvider = {
+      getIssuer: () => `${upstreamSvc.baseUrl}/oauth/2.1`,
+      getAuthEndpoint: () =>
+        `${upstreamSvc.baseUrl}/oauth/2.1/authorize`,
+      getTokenEndpoint: () => `${upstreamSvc.baseUrl}/oauth/2.1/token`,
+      getScopesSupported: () => ["openid", "profile"],
+      getGrantTypesSupported: () => ["authorization_code"],
+      verifyToken: stubVerifyToken,
+      getUserInfo: () => ({
+        userId: "test-user",
+        email: "test@example.com",
+      }),
+    };
+
+    const app = new Hono();
+    const svc = await listenOnRandomPort(app);
+    closers.push(svc.close);
+
+    setupOAuthRoutes(app, mockProvider, svc.baseUrl);
+
+    const response = await fetch(
+      `${svc.baseUrl}/.well-known/openid-configuration`
+    );
+
+    expect(response.status).toBe(200);
+
+    const metadata = await response.json();
+    expect(metadata.issuer).toContain("/oauth/2.1");
+    expect(metadataSpy).toHaveBeenCalledTimes(1);
+    // The handler constructs the RFC 8414 compliant path
+    expect(metadataSpy.mock.calls[0][0]).toBe(
+      "/.well-known/oauth-authorization-server/oauth/2.1"
+    );
   });
 });


### PR DESCRIPTION
## Changes
Fixed RFC 8414 compliance issue where the `.well-known/oauth-authorization-server` and `.well-known/openid-configuration` handlers were constructing invalid metadata URLs for issuers with path components (e.g., PropelAuth tenants).

## Implementation Details
1. **Updated metadata URL construction** in `src/server/oauth/routes.ts`:
   - Changed from: `${issuer}/.well-known/oauth-authorization-server`
   - Changed to: `${u.origin}/.well-known/oauth-authorization-server${path}` (RFC 8414 §3 compliant)
   - The well-known segment now correctly goes between the host and the path, not at the end

2. **No architectural changes** — only fixed the URL construction logic for DCR-direct mode metadata proxying

3. **Applies to both endpoints**: Both `/.well-known/oauth-authorization-server` and `/.well-known/openid-configuration` use the same handler and now both construct RFC 8414 compliant URLs

## Example Usage (Before)
For issuer `https://auth.example.com/oauth/2.1`:
- **Built URL**: `https://auth.example.com/oauth/2.1/.well-known/oauth-authorization-server`
- **Result**: ❌ 404 Not Found — upstream returns error

## Example Usage (After)
For issuer `https://auth.example.com/oauth/2.1`:
- **Built URL**: `https://auth.example.com/.well-known/oauth-authorization-server/oauth/2.1`
- **Result**: ✅ 200 OK — metadata retrieved successfully

## Testing
- Added comprehensive test: `fetches metadata from upstream provider with path-suffix issuer (RFC 8414)`
- Added comprehensive test: `fetches OIDC configuration from upstream with path-suffix issuer`
- All 6 OAuth integration tests passing
- Tests verify the RFC 8414 compliant URL is constructed and the upstream is called correctly
- Tests cover both OAuth and OIDC discovery endpoints

## Backwards Compatibility
✅ **Fully backward compatible** — only fixes incorrect behavior:
- Issuers without paths: `https://issuer.example.com` still work as before
- Issuers with paths: `https://issuer.example.com/oauth/2.1` now work correctly (previously returned 500)
- No API changes, no configuration changes needed
- Users with path-suffix issuers can now remove their workaround handlers

## Related Issues
Fixes issue: /.well-known/oauth-authorization-server handler returns 500 for an AS with a path-suffix issuer


Close #1576 