### PR TITLE
feat(cli): headless screenshot with auto-sizing and external MCP server support

### DIFF
--- a/libraries/typescript/.changeset/screenshot-external-mcp-autosizing.md
+++ b/libraries/typescript/.changeset/screenshot-external-mcp-autosizing.md
@@ -1,0 +1,6 @@
+---
+"@mcp-use/cli": minor
+"@mcp-use/inspector": minor
+---
+
+`mcp-use client screenshot` now auto-sizes screenshots to the widget's natural rendered dimensions when `--width`/`--height` are omitted, eliminating excess whitespace. Fixes screenshotting against external MCP servers (e.g. Excalidraw) — URIs like `ui://excalidraw/mcp-app.html` were breaking the preview route; they are now correctly handled as `<server>-<name>`.

--- a/libraries/typescript/packages/cli/src/commands/screenshot.ts
+++ b/libraries/typescript/packages/cli/src/commands/screenshot.ts
@@ -20,8 +20,8 @@ import {
 
 interface ScreenshotOptions {
   tool?: string;
-  width: string;
-  height: string;
+  width?: string;
+  height?: string;
   inspector?: string;
   mcp?: string;
   theme: "light" | "dark";
@@ -107,7 +107,16 @@ interface CaptureToolScreenshotInputs {
 }
 
 interface CaptureToolScreenshotOptions {
+  /**
+   * Desired output width in CSS pixels. When omitted, the screenshot fits the
+   * widget's natural rendered width. When set, also overrides the inline-mode
+   * 768px max-width cap so the widget renders at the requested width.
+   */
   width?: number;
+  /**
+   * Desired output height in CSS pixels. When omitted, the screenshot fits the
+   * widget's natural rendered height.
+   */
   height?: number;
   theme?: "light" | "dark";
   output?: string;
@@ -132,7 +141,9 @@ interface CaptureToolScreenshotOptions {
 
 interface CaptureToolScreenshotResult {
   outputPath: string;
+  /** Final clip width in CSS pixels (what the PNG visually represents). */
   width: number;
+  /** Final clip height in CSS pixels. */
   height: number;
   view: string;
 }
@@ -148,8 +159,7 @@ export async function captureToolScreenshot(
   inputs: CaptureToolScreenshotInputs,
   options: CaptureToolScreenshotOptions = {}
 ): Promise<CaptureToolScreenshotResult> {
-  const width = options.width ?? 800;
-  const height = options.height ?? 600;
+  const { width, height } = options;
   const theme: "light" | "dark" = options.theme ?? "light";
   const timeoutMs = options.timeoutMs ?? 30000;
   const delayMs = options.delayMs ?? 0;
@@ -158,8 +168,6 @@ export async function captureToolScreenshot(
   const view = extractViewName(inputs.resourceUri);
 
   const devOptions: ScreenshotOptions = {
-    width: String(width),
-    height: String(height),
     theme,
     timeout: String(timeoutMs),
     inspector: options.inspector,
@@ -182,12 +190,18 @@ export async function captureToolScreenshot(
 
     const previewUrl = new URL(`/inspector/preview/${view}`, devHandle.url);
     previewUrl.searchParams.set("theme", theme);
+    // Width also drives the inline-mode max-width inside the iframe: when set,
+    // the widget renders at this width, then we clip to it. When unset, the
+    // widget renders at its natural width (capped at 768).
+    if (width !== undefined) {
+      previewUrl.searchParams.set("width", String(width));
+    }
 
     const ts = timestampSuffix();
     const outputPath = path.resolve(options.output ?? `./${view}-${ts}.png`);
     await mkdir(path.dirname(outputPath), { recursive: true });
 
-    await captureScreenshot({
+    const captured = await captureScreenshot({
       url: previewUrl.toString(),
       width,
       height,
@@ -202,7 +216,12 @@ export async function captureToolScreenshot(
       deviceScaleFactor: options.deviceScaleFactor,
     });
 
-    return { outputPath, width, height, view };
+    return {
+      outputPath,
+      width: captured.width,
+      height: captured.height,
+      view,
+    };
   } finally {
     killChild(devHandle?.child);
   }
@@ -398,10 +417,12 @@ export function timestampSuffix(date = new Date()): string {
 }
 
 export function extractViewName(resourceUri: string): string {
-  const m = resourceUri.match(/^ui:\/\/widget\/(.+)$/);
-  if (!m) return resourceUri;
-  // Strip trailing .html and any .<buildId> segment before it.
-  return m[1].replace(/\.html$/, "").replace(/\.[0-9a-f]+$/i, "");
+  // ui://<host>/<path>[.<buildId>].html
+  const m = resourceUri.match(/^ui:\/\/([^/]+)\/(.+)$/);
+  if (!m) return encodeURIComponent(resourceUri);
+  const name = m[2].replace(/\.html$/, "").replace(/\.[0-9a-f]+$/i, "");
+  // Built-in "widget" namespace: drop the host prefix to keep existing names short.
+  return m[1] === "widget" ? name : `${m[1]}-${name}`;
 }
 
 export function parseDimension(raw: string, name: string): number {
@@ -533,8 +554,14 @@ async function screenshotCommand(
       return;
     }
 
-    const width = parseDimension(options.width, "width");
-    const height = parseDimension(options.height, "height");
+    const width =
+      options.width !== undefined
+        ? parseDimension(options.width, "width")
+        : undefined;
+    const height =
+      options.height !== undefined
+        ? parseDimension(options.height, "height")
+        : undefined;
     const navTimeout = parseInt(options.timeout, 10) || 30000;
     const delayMs = options.delay ? parseInt(options.delay, 10) : 0;
     const deviceScaleFactor = options.deviceScaleFactor
@@ -662,8 +689,14 @@ function withCommonScreenshotOptions(cmd: Command): Command {
       "--tool <name>",
       "Tool to call. Its UI resource is rendered with the result."
     )
-    .option("--width <px>", "Browser viewport width in pixels.", "800")
-    .option("--height <px>", "Browser viewport height in pixels.", "600")
+    .option(
+      "--width <px>",
+      "Output image width in pixels. When omitted, fits the widget's natural width. When set, the widget renders at this width (overrides the inline-mode 768px cap)."
+    )
+    .option(
+      "--height <px>",
+      "Output image height in pixels. When omitted, fits the widget's natural height."
+    )
     .option(
       "--device-scale-factor <n>",
       "Device pixel ratio for rendering (e.g. 2 for Retina). Output PNG is (width × dsf) × (height × dsf). Must be > 0 and <= 4."

--- a/libraries/typescript/packages/cli/src/utils/cdp-screenshot.ts
+++ b/libraries/typescript/packages/cli/src/utils/cdp-screenshot.ts
@@ -6,8 +6,18 @@ import WebSocket from "ws";
 
 interface CaptureScreenshotOptions {
   url: string;
-  width: number;
-  height: number;
+  /**
+   * Desired output width in CSS pixels. Optional — when omitted, the capture
+   * clips to the rendered widget's natural width (read from `body[data-view-width]`
+   * set by the inspector preview route). Falls back to the internal default
+   * viewport width if the page didn't expose a width.
+   */
+  width?: number;
+  /**
+   * Desired output height in CSS pixels. Same semantics as `width` — omit to
+   * fit the widget's natural height.
+   */
+  height?: number;
   theme: "light" | "dark";
   waitForSelector: string;
   timeoutMs: number;
@@ -176,9 +186,16 @@ function waitForDevToolsUrl(
  *   - Page.navigate, then poll Runtime.evaluate for `waitForSelector`.
  *   - Page.captureScreenshot, write PNG, clean up.
  */
+export interface CaptureScreenshotResult {
+  /** Final clip width in CSS pixels (what the PNG visually represents). */
+  width: number;
+  /** Final clip height in CSS pixels. */
+  height: number;
+}
+
 export async function captureScreenshot(
   opts: CaptureScreenshotOptions
-): Promise<void> {
+): Promise<CaptureScreenshotResult> {
   let userDataDir: string | undefined;
   let child: ChildProcess | undefined;
   let cdp: CdpClient | undefined;
@@ -214,6 +231,16 @@ export async function captureScreenshot(
     }
   };
 
+  // The browser viewport (Chrome window + setDeviceMetricsOverride) must be
+  // big enough to contain the widget's render box. When the caller didn't
+  // specify dimensions, use a generous default so widgets have room to lay
+  // out at their natural size; the final clip is narrowed afterward based on
+  // either the user's explicit dimensions or the widget's reported rect.
+  const DEFAULT_VIEWPORT_WIDTH = 1280;
+  const DEFAULT_VIEWPORT_HEIGHT = 2000;
+  const viewportWidth = Math.max(opts.width ?? 0, DEFAULT_VIEWPORT_WIDTH);
+  const viewportHeight = Math.max(opts.height ?? 0, DEFAULT_VIEWPORT_HEIGHT);
+
   try {
     let wsUrl: string;
     if (opts.cdpUrl) {
@@ -235,7 +262,7 @@ export async function captureScreenshot(
         "--disable-gpu",
         "--hide-scrollbars",
         "--mute-audio",
-        `--window-size=${opts.width},${opts.height}`,
+        `--window-size=${viewportWidth},${viewportHeight}`,
         "about:blank",
       ];
       child = spawn(opts.chromePath, chromeArgs, {
@@ -331,8 +358,8 @@ export async function captureScreenshot(
     await cdp.send(
       "Emulation.setDeviceMetricsOverride",
       {
-        width: opts.width,
-        height: opts.height,
+        width: viewportWidth,
+        height: viewportHeight,
         deviceScaleFactor: opts.deviceScaleFactor ?? 1,
         mobile: false,
       },
@@ -394,22 +421,61 @@ export async function captureScreenshot(
       await new Promise((res) => setTimeout(res, opts.delayMs));
     }
 
+    // Prefer the widget rect that ViewPreview's bundle-mode readiness signal
+    // serializes onto body[data-view-*]. When present, this lets us clip to
+    // the actual rendered widget instead of the (often larger) viewport,
+    // avoiding the whitespace problem when widgets are shorter than the
+    // browser canvas. Falls back to the viewport when the attrs are missing
+    // (e.g. live mode, or widgets that never finish loading).
+    const rectResult = await cdp.send<{
+      result?: {
+        value?: {
+          x?: number;
+          y?: number;
+          width?: number;
+          height?: number;
+        };
+      };
+    }>(
+      "Runtime.evaluate",
+      {
+        expression: `(() => {
+          const d = document.body.dataset;
+          const n = (s) => { const v = parseFloat(s ?? ""); return Number.isFinite(v) ? v : undefined; };
+          return { x: n(d.viewX), y: n(d.viewY), width: n(d.viewWidth), height: n(d.viewHeight) };
+        })()`,
+        returnByValue: true,
+      },
+      sessionId
+    );
+    // Clip preference: explicit caller dimensions > widget's reported rect >
+    // viewport dimensions. The widget rect's origin is used to anchor the
+    // clip so even centered widgets are captured tightly.
+    const rect = rectResult.result?.value ?? {};
+    const clip = {
+      x: rect.x ?? 0,
+      y: rect.y ?? 0,
+      width:
+        opts.width ??
+        (rect.width && rect.width > 0 ? rect.width : viewportWidth),
+      height:
+        opts.height ??
+        (rect.height && rect.height > 0 ? rect.height : viewportHeight),
+      scale: 1,
+    };
+
     const shot = await cdp.send<{ data: string }>(
       "Page.captureScreenshot",
       {
         format: "png",
-        clip: {
-          x: 0,
-          y: 0,
-          width: opts.width,
-          height: opts.height,
-          scale: 1,
-        },
+        clip,
       },
       sessionId
     );
 
     writeFileSync(opts.outputPath, Buffer.from(shot.data, "base64"));
+
+    return { width: clip.width, height: clip.height };
   } finally {
     cleanup();
   }

--- a/libraries/typescript/packages/cli/src/utils/cdp-screenshot.ts
+++ b/libraries/typescript/packages/cli/src/utils/cdp-screenshot.ts
@@ -186,7 +186,7 @@ function waitForDevToolsUrl(
  *   - Page.navigate, then poll Runtime.evaluate for `waitForSelector`.
  *   - Page.captureScreenshot, write PNG, clean up.
  */
-export interface CaptureScreenshotResult {
+interface CaptureScreenshotResult {
   /** Final clip width in CSS pixels (what the PNG visually represents). */
   width: number;
   /** Final clip height in CSS pixels. */

--- a/libraries/typescript/packages/cli/tests/screenshot.test.ts
+++ b/libraries/typescript/packages/cli/tests/screenshot.test.ts
@@ -40,8 +40,16 @@ describe("extractViewName", () => {
     );
   });
 
-  it("returns the original string when prefix doesn't match", () => {
-    expect(extractViewName("not-a-widget-uri")).toBe("not-a-widget-uri");
+  it("prefixes host name for non-widget namespaces", () => {
+    expect(extractViewName("ui://excalidraw/mcp-app.html")).toBe(
+      "excalidraw-mcp-app"
+    );
+  });
+
+  it("returns percent-encoded string when prefix doesn't match", () => {
+    expect(extractViewName("not-a-widget-uri")).toBe(
+      encodeURIComponent("not-a-widget-uri")
+    );
   });
 });
 

--- a/libraries/typescript/packages/inspector/src/client/components/MCPAppsRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/MCPAppsRenderer.tsx
@@ -120,6 +120,8 @@ interface MCPAppsRendererProps {
   onReady?: () => void;
   /** When true in fullscreen mode, suppresses the fullscreen navbar + top padding so the iframe fills the viewport edge-to-edge. Used by the preview/screenshot route. */
   chromeless?: boolean;
+  /** Override the inline-mode max-width cap (default: 768 on desktop, device width on mobile). Used by the preview/screenshot route to render widgets wider than the chat-column width. */
+  inlineWidthOverride?: number;
 }
 
 function MCPAppsRendererBase({
@@ -144,6 +146,7 @@ function MCPAppsRendererBase({
   onRerun,
   onReady,
   chromeless,
+  inlineWidthOverride,
 }: MCPAppsRendererProps) {
   const sandboxRef = useRef<SandboxedIframeHandle>(null);
   const bridgeRef = useRef<AppBridge | null>(null);
@@ -218,8 +221,11 @@ function MCPAppsRendererBase({
   // Calculate dimensions based on device type
   const { maxWidth, maxHeight } = useDeviceViewport(deviceType, customViewport);
 
-  // Calculate inline max-width: desktop/tablet use 768px (ChatGPT chat width), mobile uses device width
-  const inlineMaxWidth = deviceType === "mobile" ? maxWidth : 768;
+  // Calculate inline max-width: desktop/tablet use 768px (ChatGPT chat width), mobile uses device width.
+  // inlineWidthOverride (set by the preview/screenshot route) bypasses the cap so widgets can render
+  // at arbitrary widths for capture.
+  const inlineMaxWidth =
+    inlineWidthOverride ?? (deviceType === "mobile" ? maxWidth : 768);
 
   // Get the tool definition from the server's tool list (memoized to prevent infinite re-renders)
   // Stringify toolName to ensure stable reference if it's passed as an object
@@ -1208,6 +1214,7 @@ function mcpAppsRendererAreEqual(
   if (prev.onRerun !== next.onRerun) return false;
   if (prev.onReady !== next.onReady) return false;
   if (prev.chromeless !== next.chromeless) return false;
+  if (prev.inlineWidthOverride !== next.inlineWidthOverride) return false;
   if (prev.onDisplayModeChange !== next.onDisplayModeChange) return false;
   if (prev.className !== next.className) return false;
   if (prev.serverBaseUrl !== next.serverBaseUrl) return false;

--- a/libraries/typescript/packages/inspector/src/client/components/ViewPreview.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ViewPreview.tsx
@@ -20,7 +20,7 @@
  */
 
 import { useMcpClient } from "mcp-use/react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useParams, useSearchParams } from "react-router";
 import { MCPAppsRenderer } from "./MCPAppsRenderer";
 
@@ -125,21 +125,104 @@ function usePreviewReadinessSignal(rendererReady: boolean): void {
 }
 
 /**
+ * Bundle-mode readiness: after the renderer signals ready, watch the iframe's
+ * bounding rect via ResizeObserver. Once the rect stops changing for a short
+ * idle window (~250ms — enough to absorb the inline-height 300ms transition
+ * and any post-layout settling), serialize the rect onto body data attributes
+ * and flip `data-view-ready="true"` so the screenshot CLI can read it and
+ * use it as the capture clip. Falls back gracefully if the iframe never
+ * appears or never reports a size (the CLI's overall timeout still bounds us).
+ */
+function useBundleReadinessSignal(
+  rendererReady: boolean,
+  containerRef: React.RefObject<HTMLDivElement | null>
+): void {
+  useEffect(() => {
+    if (!rendererReady) return;
+    let cancelled = false;
+    let stableTimer: ReturnType<typeof setTimeout> | undefined;
+    let observer: ResizeObserver | undefined;
+
+    const writeReady = (rect: DOMRect | null) => {
+      if (cancelled) return;
+      if (rect) {
+        document.body.dataset.viewX = String(Math.round(rect.left));
+        document.body.dataset.viewY = String(Math.round(rect.top));
+        document.body.dataset.viewWidth = String(Math.round(rect.width));
+        document.body.dataset.viewHeight = String(Math.round(rect.height));
+      }
+      document.body.setAttribute("data-view-ready", "true");
+    };
+
+    (async () => {
+      try {
+        await document.fonts.ready;
+      } catch {
+        // fonts API may be unavailable; proceed anyway
+      }
+      if (cancelled) return;
+      await new Promise((r) => requestAnimationFrame(() => r(undefined)));
+      await new Promise((r) => requestAnimationFrame(() => r(undefined)));
+      if (cancelled) return;
+
+      const iframe = containerRef.current?.querySelector("iframe");
+      if (!iframe) {
+        writeReady(null);
+        return;
+      }
+
+      const scheduleStable = () => {
+        if (stableTimer) clearTimeout(stableTimer);
+        stableTimer = setTimeout(() => {
+          if (cancelled) return;
+          observer?.disconnect();
+          writeReady(iframe.getBoundingClientRect());
+        }, 250);
+      };
+
+      observer = new ResizeObserver(scheduleStable);
+      observer.observe(iframe);
+      scheduleStable();
+    })();
+
+    return () => {
+      cancelled = true;
+      if (stableTimer) clearTimeout(stableTimer);
+      observer?.disconnect();
+      document.body.removeAttribute("data-view-ready");
+      delete document.body.dataset.viewX;
+      delete document.body.dataset.viewY;
+      delete document.body.dataset.viewWidth;
+      delete document.body.dataset.viewHeight;
+    };
+  }, [rendererReady, containerRef]);
+}
+
+/**
  * Bundle mode: render from inline data injected by the screenshot CLI.
  * No live MCP connection. Runtime widget calls (`oncalltool`,
  * `onlistresources`) intentionally fall through to MCPAppsRenderer's
  * "no server" path and throw — bundle mode targets initial render only.
+ *
+ * Uses `displayMode="inline"` so the iframe auto-sizes to the widget's
+ * reported height (avoiding the whitespace that fullscreen mode produces
+ * for widgets shorter than the viewport). An optional `?width=N` query
+ * param overrides the inline 768px max-width cap so callers can request
+ * wider screenshots.
  */
 function ViewPreviewBundle({
   view,
   bundle,
+  widthOverride,
 }: {
   view: string;
   bundle: PreviewBundle;
+  widthOverride?: number;
 }) {
   const [rendererReady, setRendererReady] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
   usePreviewViewport();
-  usePreviewReadinessSignal(rendererReady);
+  useBundleReadinessSignal(rendererReady, containerRef);
 
   const readResource = useMemo(() => {
     return async (uri: string) => {
@@ -154,7 +237,7 @@ function ViewPreviewBundle({
   );
 
   return (
-    <div style={{ width: "100vw", height: "100vh" }}>
+    <div ref={containerRef} style={{ width: "100vw", height: "100vh" }}>
       <MCPAppsRenderer
         serverId={PREVIEW_BUNDLE_SERVER_ID}
         toolCallId={toolCallId}
@@ -163,7 +246,8 @@ function ViewPreviewBundle({
         toolOutput={bundle.toolOutput}
         resourceUri={bundle.resourceUri}
         readResource={readResource}
-        displayMode="fullscreen"
+        displayMode="inline"
+        inlineWidthOverride={widthOverride}
         noWrapper
         chromeless
         onReady={() => setRendererReady(true)}
@@ -298,14 +382,28 @@ function ViewPreviewLive({ view }: { view: string }) {
 
 export function ViewPreview() {
   const params = useParams<{ view: string }>();
+  const [search] = useSearchParams();
   const view = params.view ?? "";
 
   // Bundle is read once at mount. The screenshot CLI sets it via CDP
   // before any document scripts run, so it's stable across renders.
   const bundle = useMemo(() => readPreviewBundle(), []);
 
+  const widthOverride = useMemo(() => {
+    const raw = search.get("width");
+    if (!raw) return undefined;
+    const n = parseInt(raw, 10);
+    return Number.isFinite(n) && n > 0 ? n : undefined;
+  }, [search]);
+
   if (bundle) {
-    return <ViewPreviewBundle view={view} bundle={bundle} />;
+    return (
+      <ViewPreviewBundle
+        view={view}
+        bundle={bundle}
+        widthOverride={widthOverride}
+      />
+    );
   }
   return <ViewPreviewLive view={view} />;
 }


### PR DESCRIPTION
## Changes

Overhaul of the `mcp-use client screenshot` command: widgets now clip to their natural rendered size, and screenshots work correctly against external MCP servers (e.g. Excalidraw).

## Implementation Details

1. **Auto-sizing** — `width`/`height` are now optional. When omitted, the CLI reads `body[data-view-*]` rect attributes written by the preview page and clips the screenshot to the widget's actual bounding box, eliminating whitespace from unused viewport space.

2. **ResizeObserver-based readiness** (`ViewPreview.tsx`) — `useBundleReadinessSignal` watches the iframe via `ResizeObserver` and waits for the layout to stabilize (~250ms idle) before setting `data-view-ready="true"` and serializing the iframe rect. Replaces the simple two-rAF approach for bundle mode.

3. **Inline display mode** (`ViewPreview.tsx`) — `ViewPreviewBundle` switches to `displayMode="inline"` so the iframe auto-sizes to the widget's content height rather than filling the full viewport.

4. **`inlineWidthOverride` prop** (`MCPAppsRenderer.tsx`) — New prop bypasses the 768px inline max-width cap when the `?width=N` query param is set, so explicit-width screenshots render at the requested size.

5. **External MCP server URI fix** (`screenshot.ts`) — `extractViewName` previously only handled `ui://widget/<name>.html`. Any other `ui://` scheme (e.g. `ui://excalidraw/mcp-app.html`) was returned as-is, embedding `://` in the preview URL path and breaking React Router's route match. Now flattens to `<server>-<name>` for non-widget namespaces.

## Example Usage (After)

```bash
# Natural-size screenshot — clips tightly to the widget
mcp-use client screenshot --mcp https://mcp.excalidraw.com/mcp --tool create_view elements='[...]'

# Explicit width
mcp-use client screenshot --mcp https://mcp.excalidraw.com/mcp --tool create_view --width 1200 elements='[...]'
```

## Testing

- All 274 existing tests pass
- Added `extractViewName` test for `ui://excalidraw/mcp-app.html` → `excalidraw-mcp-app`
- Manually verified end-to-end against `https://mcp.excalidraw.com/mcp`

## Backwards Compatibility

`--width` and `--height` flags still work as before; omitting them is new behavior (auto-size). No breaking changes.