### PR TITLE
Add OpenAPI-based server generation to the TypeScript SDK

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -524,6 +524,7 @@
                     "icon": "box",
                     "pages": [
                       "typescript/server/tools",
+                      "typescript/server/openapi",
                       "typescript/server/resources",
                       "typescript/server/prompts"
                     ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -524,7 +524,6 @@
                     "icon": "box",
                     "pages": [
                       "typescript/server/tools",
-                      "typescript/server/openapi",
                       "typescript/server/resources",
                       "typescript/server/prompts"
                     ]
@@ -602,7 +601,8 @@
                       "typescript/server/deployment/supabase",
                       "typescript/server/deployment/google"
                     ]
-                  }
+                  },
+                  "typescript/server/openapi"
                 ]
               },
               {

--- a/docs/typescript/server/examples.mdx
+++ b/docs/typescript/server/examples.mdx
@@ -38,6 +38,19 @@ pnpm run example:server:streaming-props
 
 Tools include `generate-code` and `generate-json` with a code-preview widget that updates live while arguments stream. Test in the [MCP Inspector](/inspector/index) by invoking those tools and watching the widget.
 
+## OpenAPI Server Example
+
+Generates MCP tools from a focused subset of the National Weather Service OpenAPI document using [`MCPServer.fromOpenAPI()`](/typescript/server/openapi). The example fetches the live spec, keeps the generated tool list small, and forwards the required Weather.gov headers to upstream API calls.
+
+**Example location:** `libraries/typescript/packages/mcp-use/examples/server/features/openapi`
+
+**Run from the example directory:**
+
+```bash
+cd libraries/typescript/packages/mcp-use/examples/server/features/openapi
+pnpm dev
+```
+
 ## Weather Service Server
 
 A complete weather information server with tools, resources, and UI widgets.

--- a/docs/typescript/server/index.mdx
+++ b/docs/typescript/server/index.mdx
@@ -192,6 +192,9 @@ class McpServer {
   <Card title="Tools" icon="wrench" href="/typescript/server/tools">
     Build executable functions with parameters and validation
   </Card>
+  <Card title="OpenAPI" icon="file-code" href="/typescript/server/openapi">
+    Generate MCP tools from an existing OpenAPI document
+  </Card>
   <Card title="Resources" icon="folder-open" href="/typescript/server/resources">
     Expose static and dynamic content via URI-based resources
   </Card>

--- a/docs/typescript/server/openapi.mdx
+++ b/docs/typescript/server/openapi.mdx
@@ -7,7 +7,7 @@ icon: "file-code"
 `MCPServer.fromOpenAPI()` creates an MCP server from a parsed OpenAPI document. Each included OpenAPI operation is registered as an MCP tool that calls the matching HTTP endpoint.
 
 <Tip>
-We do not recommend mapping a production API directly to MCP without review. LLMs usually perform better with a deliberately crafted MCP server: focused tools, clear names, model-friendly descriptions, and workflows that match the tasks users actually ask for. Use `fromOpenAPI()` for prototypes, demos, internal tools, and as a fast starting point before curating the final server.
+We do not recommend mapping a production API directly to MCP without review. LLMs usually perform better with a deliberately crafted MCP server: focused tools, clear names, model-friendly descriptions, and workflows that match the tasks users actually ask for. 
 </Tip>
 
 ## Basic Usage
@@ -15,11 +15,15 @@ We do not recommend mapping a production API directly to MCP without review. LLM
 Load or import an OpenAPI document, then pass it to `MCPServer.fromOpenAPI()`:
 
 ```typescript
-import { MCPServer } from "mcp-use/server";
+import { MCPServer, type OpenAPIDocument } from "mcp-use/server";
 
-const spec = await fetch("https://api.example.com/openapi.json").then(
-  (response) => response.json()
-);
+const response = await fetch("https://api.example.com/openapi.json");
+
+if (!response.ok) {
+  throw new Error(`Failed to fetch OpenAPI spec: ${response.status}`);
+}
+
+const spec = (await response.json()) as OpenAPIDocument;
 
 const server = MCPServer.fromOpenAPI({
   spec,
@@ -165,7 +169,11 @@ type FromOpenAPIOptions = {
 
 If you run into these limits, use the generated server as a reference and move the important operations into hand-written `server.tool()` definitions.
 
-See the complete runnable reference example in `libraries/typescript/packages/mcp-use/examples/server/features/openapi`.
+## Example
+
+<Card title="OpenAPI Server Example" icon="github" href="https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/features/openapi">
+  Complete runnable example that generates MCP tools from the National Weather Service OpenAPI document.
+</Card>
 
 ## Next Steps
 

--- a/docs/typescript/server/openapi.mdx
+++ b/docs/typescript/server/openapi.mdx
@@ -1,0 +1,179 @@
+---
+title: "OpenAPI"
+description: "Generate MCP tools from an OpenAPI document"
+icon: "file-code"
+---
+
+`MCPServer.fromOpenAPI()` creates an MCP server from a parsed OpenAPI document. Each included OpenAPI operation is registered as an MCP tool that calls the matching HTTP endpoint.
+
+<Tip>
+We do not recommend mapping a production API directly to MCP without review. LLMs usually perform better with a deliberately crafted MCP server: focused tools, clear names, model-friendly descriptions, and workflows that match the tasks users actually ask for. Use `fromOpenAPI()` for prototypes, demos, internal tools, and as a fast starting point before curating the final server.
+</Tip>
+
+## Basic Usage
+
+Load or import an OpenAPI document, then pass it to `MCPServer.fromOpenAPI()`:
+
+```typescript
+import { MCPServer } from "mcp-use/server";
+
+const spec = await fetch("https://api.example.com/openapi.json").then(
+  (response) => response.json()
+);
+
+const server = MCPServer.fromOpenAPI({
+  spec,
+  baseUrl: "https://api.example.com",
+});
+
+await server.listen(3000);
+```
+
+The generated server uses the OpenAPI document for:
+
+- Server name and version, unless you override them
+- Tool names, based on `operationId` when available
+- Tool descriptions, from `summary`, `description`, and the HTTP route
+- Input schemas, from parameters and JSON request bodies
+- HTTP method, path, query string, headers, and request body
+
+## When to Use It
+
+`fromOpenAPI()` is useful when you want to quickly expose an existing HTTP API to an MCP client:
+
+- Prototyping an MCP integration before designing custom tools
+- Wrapping a small internal API for trusted users
+- Testing whether an API's operations are useful in an LLM workflow
+- Bootstrapping a hand-crafted MCP server from an existing OpenAPI spec
+
+For user-facing or high-volume servers, prefer a custom MCP server once you know the workflow. A good custom server often combines multiple HTTP calls into one tool, hides API-specific fields the model should not reason about, adds better descriptions, and returns only the response shape the model needs.
+
+## Authentication and Headers
+
+`fromOpenAPI()` supports two simple upstream authentication patterns:
+
+- Bearer token auth
+- Static header auth, such as an API key header
+
+Read secrets from environment variables instead of hard-coding them:
+
+```typescript
+const server = MCPServer.fromOpenAPI({
+  spec,
+  baseUrl: "https://api.example.com",
+  auth: {
+    type: "bearer",
+    token: process.env.EXAMPLE_API_TOKEN,
+  },
+});
+```
+
+For API key headers:
+
+```typescript
+const server = MCPServer.fromOpenAPI({
+  spec,
+  baseUrl: "https://api.example.com",
+  auth: {
+    type: "header",
+    name: "x-api-key",
+    value: process.env.EXAMPLE_API_KEY,
+  },
+});
+```
+
+Use `headers` for static headers that should be sent with every upstream request:
+
+```typescript
+const server = MCPServer.fromOpenAPI({
+  spec,
+  baseUrl: "https://api.example.com",
+  headers: {
+    "User-Agent": "my-mcp-server/1.0",
+    Accept: "application/json",
+  },
+});
+```
+
+<Note>
+The `auth` and `headers` options authenticate requests from your MCP server to the upstream API. They do not add authentication to the MCP server itself. To protect the MCP endpoint, configure server authentication separately.
+</Note>
+
+## Request and Response Mapping
+
+Generated tools flatten OpenAPI parameters into a single input object:
+
+- `path` parameters become required top-level fields
+- `query` parameters become optional or required top-level fields
+- `header` parameters become top-level fields and are sent as HTTP headers
+- `cookie` parameters are ignored
+- JSON request bodies become a `body` field
+
+For example, an operation like `GET /users/{userId}/projects?limit=10` becomes a tool with `userId` and `limit` inputs.
+
+JSON responses are returned with the `object()` response helper. Non-JSON responses are returned as text. If the upstream API returns a non-2xx response, the generated tool returns an MCP error response containing the upstream response text.
+
+## Naming and Descriptions
+
+Tool quality depends heavily on the OpenAPI document. Before exposing generated tools to users, review the spec for:
+
+- Clear `operationId` values
+- Human-readable `summary` and `description` fields
+- Helpful parameter descriptions
+- Small, accurate schemas
+- Tags that match useful task areas
+
+If the generated names or descriptions feel too API-shaped, that is usually a sign to write custom tools. For example, a custom `search_customer_orders` tool may be better than separate generated tools for `listCustomers`, `getCustomer`, `listOrders`, and `getOrder`.
+
+## Options
+
+```typescript
+type FromOpenAPIOptions = {
+  spec: OpenAPIDocument;
+  baseUrl?: string;
+  name?: string;
+  version?: string;
+  auth?: OpenAPIAuth;
+  headers?: Record<string, string>;
+  tags?: string[];
+  exclude?: OpenAPIExcludeRule[];
+  fetch?: typeof fetch;
+};
+```
+
+| Option | Description |
+| --- | --- |
+| `spec` | Parsed OpenAPI document. This is required. |
+| `baseUrl` | Upstream API base URL. Defaults to `spec.servers[0].url` when present. |
+| `name` | MCP server name. Defaults to `spec.info.title`. |
+| `version` | MCP server version. Defaults to `spec.info.version` or `1.0.0`. |
+| `auth` | Bearer token or static header auth for upstream API requests. |
+| `headers` | Static headers sent with every upstream API request. |
+| `tags` | Include only operations with one of these OpenAPI tags. |
+| `exclude` | Exclude operations by operation ID, path, method, or tag. |
+| `fetch` | Custom fetch implementation, useful for tests or custom transports. |
+
+## Limitations
+
+`fromOpenAPI()` is intentionally simple. It currently focuses on straightforward REST-style APIs with JSON request and response bodies.
+
+- It does not design model-friendly workflows for you
+- It does not add MCP server authentication
+- It does not support cookie parameters
+- It only maps JSON request bodies into tool input
+- It does not automatically bundle remote `$ref` values outside the loaded document
+
+If you run into these limits, use the generated server as a reference and move the important operations into hand-written `server.tool()` definitions.
+
+See the complete runnable reference example in `libraries/typescript/packages/mcp-use/examples/server/features/openapi`.
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Tools" icon="wrench" href="/typescript/server/tools">
+    Learn how to create hand-crafted MCP tools with Zod schemas and custom handlers.
+  </Card>
+  <Card title="Examples" icon="folder-code" href="/typescript/server/examples">
+    Browse runnable server examples, including the OpenAPI feature example.
+  </Card>
+</CardGroup>

--- a/libraries/typescript/.changeset/openapi-server-tools.md
+++ b/libraries/typescript/.changeset/openapi-server-tools.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": minor
+---
+
+Add `MCPServer.fromOpenAPI` for creating MCP servers from bundled OpenAPI documents, registering included operations as tools with generated input schemas and request handling.

--- a/libraries/typescript/packages/mcp-use/examples/README.md
+++ b/libraries/typescript/packages/mcp-use/examples/README.md
@@ -71,6 +71,7 @@
 | [completion/src/server.ts](server/features/completion/src/server.ts) | Completion for prompt and resource arguments |
 | [conformance/src/server.ts](server/features/conformance/src/server.ts) | MCP conformance test server |
 | [dns-rebinding/src/server.ts](server/features/dns-rebinding/src/server.ts) | DNS rebinding protection |
+| [openapi/src/server.ts](server/features/openapi/src/server.ts) | Generate MCP tools from an OpenAPI spec |
 | [express-middleware/index.ts](server/features/express-middleware/index.ts) | Express and Hono middleware integration |
 | [middleware/src/server.ts](server/features/middleware/src/server.ts) | Built-in middleware pipeline |
 | [proxy/src/server.ts](server/features/proxy/src/server.ts) | Proxy server setup |

--- a/libraries/typescript/packages/mcp-use/examples/server/features/openapi/README.md
+++ b/libraries/typescript/packages/mcp-use/examples/server/features/openapi/README.md
@@ -15,14 +15,5 @@ tools can be called immediately.
 ## Run
 
 ```sh
-pnpm --filter openapi-server-example dev
-```
-
-Then connect with the CLI:
-
-```sh
-mcp-use client connect openapi-example http://localhost:3010/mcp --no-oauth
-mcp-use client openapi-example tools list
-mcp-use client openapi-example tools call getTodo id=todo-1
-mcp-use client openapi-example tools call updateTodo id=todo-2 body:='{"completed":true}'
+pnpm dev
 ```

--- a/libraries/typescript/packages/mcp-use/examples/server/features/openapi/README.md
+++ b/libraries/typescript/packages/mcp-use/examples/server/features/openapi/README.md
@@ -1,0 +1,28 @@
+# OpenAPI Server Example
+
+This example creates an MCP server from a bundled OpenAPI document:
+
+```ts
+const server = MCPServer.fromOpenAPI({
+  spec: openapiSpec,
+  baseUrl: "http://localhost:3010/api",
+});
+```
+
+The example also mounts a tiny REST API at `/api/todos` so the generated MCP
+tools can be called immediately.
+
+## Run
+
+```sh
+pnpm --filter openapi-server-example dev
+```
+
+Then connect with the CLI:
+
+```sh
+mcp-use client connect openapi-example http://localhost:3010/mcp --no-oauth
+mcp-use client openapi-example tools list
+mcp-use client openapi-example tools call getTodo id=todo-1
+mcp-use client openapi-example tools call updateTodo id=todo-2 body:='{"completed":true}'
+```

--- a/libraries/typescript/packages/mcp-use/examples/server/features/openapi/README.md
+++ b/libraries/typescript/packages/mcp-use/examples/server/features/openapi/README.md
@@ -1,19 +1,35 @@
 # OpenAPI Server Example
 
-This example creates an MCP server from a bundled OpenAPI document:
+This example fetches the live National Weather Service OpenAPI document and
+creates an MCP server from a small read-only subset of its operations:
 
 ```ts
+const openapiSpec = await fetch("https://api.weather.gov/openapi.json").then(
+  (response) => response.json()
+);
+
 const server = MCPServer.fromOpenAPI({
   spec: openapiSpec,
-  baseUrl: "http://localhost:3010/api",
+  baseUrl: "https://api.weather.gov",
+  headers: {
+    "User-Agent": "mcp-use-openapi-example/1.0",
+  },
 });
 ```
 
-The example also mounts a tiny REST API at `/api/todos` so the generated MCP
-tools can be called immediately.
+The generated tools call the public `api.weather.gov` endpoints directly. The
+example keeps the tool list focused by registering only point metadata,
+gridpoint forecasts, latest station observations, and active alerts by area.
 
 ## Run
 
 ```sh
 pnpm dev
+```
+
+Set `WEATHER_USER_AGENT` if you want to provide your own contact string for
+weather.gov requests:
+
+```sh
+WEATHER_USER_AGENT="my-app/1.0 me@example.com" pnpm dev
 ```

--- a/libraries/typescript/packages/mcp-use/examples/server/features/openapi/package.json
+++ b/libraries/typescript/packages/mcp-use/examples/server/features/openapi/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "openapi-server-example",
+  "type": "module",
+  "version": "1.0.0",
+  "description": "MCP server generated from a bundled OpenAPI spec",
+  "author": "",
+  "license": "MIT",
+  "keywords": [
+    "mcp",
+    "server",
+    "openapi",
+    "example"
+  ],
+  "main": "src/server.ts",
+  "scripts": {
+    "dev": "tsx src/server.ts",
+    "start": "tsx src/server.ts",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "mcp-use": "workspace:*",
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3"
+  },
+  "devDependencies": {
+    "@types/node": "^25.0.2",
+    "tsx": "^4.21.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/libraries/typescript/packages/mcp-use/examples/server/features/openapi/src/server.ts
+++ b/libraries/typescript/packages/mcp-use/examples/server/features/openapi/src/server.ts
@@ -1,0 +1,183 @@
+import { MCPServer, type OpenAPIDocument } from "mcp-use/server";
+
+const PORT = Number(process.env.PORT ?? 3010);
+const baseUrl = `http://localhost:${PORT}/api`;
+
+const openapiSpec: OpenAPIDocument = {
+  openapi: "3.1.0",
+  info: {
+    title: "Todo OpenAPI Example",
+    version: "1.0.0",
+  },
+  servers: [{ url: baseUrl }],
+  paths: {
+    "/todos": {
+      get: {
+        operationId: "listTodos",
+        summary: "List todos",
+        description: "Return the example todos, optionally filtered by status.",
+        tags: ["todos"],
+        parameters: [
+          {
+            name: "completed",
+            in: "query",
+            required: false,
+            description: "Filter todos by completion state.",
+            schema: { type: "boolean" },
+          },
+        ],
+        responses: {
+          "200": {
+            description: "Todo list",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "array",
+                  items: { $ref: "#/components/schemas/Todo" },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/todos/{id}": {
+      get: {
+        operationId: "getTodo",
+        summary: "Get a todo",
+        description: "Return one todo by id.",
+        tags: ["todos"],
+        parameters: [
+          {
+            name: "id",
+            in: "path",
+            required: true,
+            description: "Todo id.",
+            schema: { type: "string" },
+          },
+        ],
+        responses: {
+          "200": {
+            description: "Todo",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/Todo" },
+              },
+            },
+          },
+        },
+      },
+      patch: {
+        operationId: "updateTodo",
+        summary: "Update a todo",
+        description: "Update the title or completion state for one todo.",
+        tags: ["todos"],
+        parameters: [
+          {
+            name: "id",
+            in: "path",
+            required: true,
+            description: "Todo id.",
+            schema: { type: "string" },
+          },
+        ],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/TodoUpdate" },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "Updated todo",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/Todo" },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {
+      Todo: {
+        type: "object",
+        required: ["id", "title", "completed"],
+        properties: {
+          id: { type: "string" },
+          title: { type: "string" },
+          completed: { type: "boolean" },
+        },
+      },
+      TodoUpdate: {
+        type: "object",
+        properties: {
+          title: { type: "string", description: "New todo title." },
+          completed: {
+            type: "boolean",
+            description: "Whether the todo is complete.",
+          },
+        },
+      },
+    },
+  },
+};
+
+type Todo = {
+  id: string;
+  title: string;
+  completed: boolean;
+};
+
+const todos = new Map<string, Todo>([
+  ["todo-1", { id: "todo-1", title: "Write the OpenAPI spec", completed: true }],
+  [
+    "todo-2",
+    { id: "todo-2", title: "Generate MCP tools from it", completed: false },
+  ],
+]);
+
+const server = MCPServer.fromOpenAPI({
+  spec: openapiSpec,
+  baseUrl,
+});
+
+server.app.get("/api/todos", (c) => {
+  const completed = c.req.query("completed");
+  const allTodos = [...todos.values()];
+  const filtered =
+    completed === undefined
+      ? allTodos
+      : allTodos.filter((todo) => String(todo.completed) === completed);
+
+  return c.json(filtered);
+});
+
+server.app.get("/api/todos/:id", (c) => {
+  const todo = todos.get(c.req.param("id"));
+  if (!todo) {
+    return c.json({ error: "Todo not found" }, 404);
+  }
+
+  return c.json(todo);
+});
+
+server.app.patch("/api/todos/:id", async (c) => {
+  const id = c.req.param("id");
+  const todo = todos.get(id);
+  if (!todo) {
+    return c.json({ error: "Todo not found" }, 404);
+  }
+
+  const patch = (await c.req.json()) as Partial<Pick<Todo, "title" | "completed">>;
+  const updated = { ...todo, ...patch };
+  todos.set(id, updated);
+
+  return c.json(updated);
+});
+
+await server.listen(PORT);

--- a/libraries/typescript/packages/mcp-use/examples/server/features/openapi/src/server.ts
+++ b/libraries/typescript/packages/mcp-use/examples/server/features/openapi/src/server.ts
@@ -7,6 +7,8 @@ const USER_AGENT =
   process.env.WEATHER_USER_AGENT ??
   "mcp-use-openapi-example/1.0 (https://github.com/mcp-use/mcp-use)";
 
+// Keep the example focused: the full weather.gov spec would generate dozens of
+// tools, which makes the inspector harder to scan for a quick OpenAPI demo.
 const includedPaths = [
   "/points/{latitude},{longitude}",
   "/gridpoints/{wfo}/{x},{y}/forecast",

--- a/libraries/typescript/packages/mcp-use/examples/server/features/openapi/src/server.ts
+++ b/libraries/typescript/packages/mcp-use/examples/server/features/openapi/src/server.ts
@@ -1,188 +1,68 @@
 import { MCPServer, type OpenAPIDocument } from "mcp-use/server";
 
 const PORT = Number(process.env.PORT ?? 3010);
-const baseUrl = `http://localhost:${PORT}/api`;
+const WEATHER_API_BASE_URL = "https://api.weather.gov";
+const WEATHER_OPENAPI_URL = `${WEATHER_API_BASE_URL}/openapi.json`;
+const USER_AGENT =
+  process.env.WEATHER_USER_AGENT ??
+  "mcp-use-openapi-example/1.0 (https://github.com/mcp-use/mcp-use)";
 
-const openapiSpec: OpenAPIDocument = {
-  openapi: "3.1.0",
-  info: {
-    title: "Todo OpenAPI Example",
-    version: "1.0.0",
-  },
-  servers: [{ url: baseUrl }],
-  paths: {
-    "/todos": {
-      get: {
-        operationId: "listTodos",
-        summary: "List todos",
-        description: "Return the example todos, optionally filtered by status.",
-        tags: ["todos"],
-        parameters: [
-          {
-            name: "completed",
-            in: "query",
-            required: false,
-            description: "Filter todos by completion state.",
-            schema: { type: "boolean" },
-          },
-        ],
-        responses: {
-          "200": {
-            description: "Todo list",
-            content: {
-              "application/json": {
-                schema: {
-                  type: "array",
-                  items: { $ref: "#/components/schemas/Todo" },
-                },
-              },
-            },
-          },
-        },
-      },
-    },
-    "/todos/{id}": {
-      get: {
-        operationId: "getTodo",
-        summary: "Get a todo",
-        description: "Return one todo by id.",
-        tags: ["todos"],
-        parameters: [
-          {
-            name: "id",
-            in: "path",
-            required: true,
-            description: "Todo id.",
-            schema: { type: "string" },
-          },
-        ],
-        responses: {
-          "200": {
-            description: "Todo",
-            content: {
-              "application/json": {
-                schema: { $ref: "#/components/schemas/Todo" },
-              },
-            },
-          },
-        },
-      },
-      patch: {
-        operationId: "updateTodo",
-        summary: "Update a todo",
-        description: "Update the title or completion state for one todo.",
-        tags: ["todos"],
-        parameters: [
-          {
-            name: "id",
-            in: "path",
-            required: true,
-            description: "Todo id.",
-            schema: { type: "string" },
-          },
-        ],
-        requestBody: {
-          required: true,
-          content: {
-            "application/json": {
-              schema: { $ref: "#/components/schemas/TodoUpdate" },
-            },
-          },
-        },
-        responses: {
-          "200": {
-            description: "Updated todo",
-            content: {
-              "application/json": {
-                schema: { $ref: "#/components/schemas/Todo" },
-              },
-            },
-          },
-        },
-      },
-    },
-  },
-  components: {
-    schemas: {
-      Todo: {
-        type: "object",
-        required: ["id", "title", "completed"],
-        properties: {
-          id: { type: "string" },
-          title: { type: "string" },
-          completed: { type: "boolean" },
-        },
-      },
-      TodoUpdate: {
-        type: "object",
-        properties: {
-          title: { type: "string", description: "New todo title." },
-          completed: {
-            type: "boolean",
-            description: "Whether the todo is complete.",
-          },
-        },
-      },
-    },
-  },
-};
+const includedPaths = [
+  "/points/{latitude},{longitude}",
+  "/gridpoints/{wfo}/{x},{y}/forecast",
+  "/stations/{stationId}/observations/latest",
+  "/alerts/active/area/{area}",
+] as const;
 
-type Todo = {
-  id: string;
-  title: string;
-  completed: boolean;
-};
-
-const todos = new Map<string, Todo>([
-  [
-    "todo-1",
-    { id: "todo-1", title: "Write the OpenAPI spec", completed: true },
-  ],
-  [
-    "todo-2",
-    { id: "todo-2", title: "Generate MCP tools from it", completed: false },
-  ],
-]);
+const openapiSpec = await loadWeatherOpenAPISpec();
 
 const server = MCPServer.fromOpenAPI({
   spec: openapiSpec,
-  baseUrl,
-});
-
-server.app.get("/api/todos", (c) => {
-  const completed = c.req.query("completed");
-  const allTodos = [...todos.values()];
-  const filtered =
-    completed === undefined
-      ? allTodos
-      : allTodos.filter((todo) => String(todo.completed) === completed);
-
-  return c.json(filtered);
-});
-
-server.app.get("/api/todos/:id", (c) => {
-  const todo = todos.get(c.req.param("id"));
-  if (!todo) {
-    return c.json({ error: "Todo not found" }, 404);
-  }
-
-  return c.json(todo);
-});
-
-server.app.patch("/api/todos/:id", async (c) => {
-  const id = c.req.param("id");
-  const todo = todos.get(id);
-  if (!todo) {
-    return c.json({ error: "Todo not found" }, 404);
-  }
-
-  const patch = (await c.req.json()) as Partial<
-    Pick<Todo, "title" | "completed">
-  >;
-  const updated = { ...todo, ...patch };
-  todos.set(id, updated);
-
-  return c.json(updated);
+  baseUrl: WEATHER_API_BASE_URL,
+  headers: {
+    "User-Agent": USER_AGENT,
+    Accept: "application/geo+json, application/json",
+  },
+  name: "National Weather Service",
 });
 
 await server.listen(PORT);
+
+async function loadWeatherOpenAPISpec(): Promise<OpenAPIDocument> {
+  const response = await fetch(WEATHER_OPENAPI_URL, {
+    headers: {
+      "User-Agent": USER_AGENT,
+      Accept: "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch ${WEATHER_OPENAPI_URL}: ${response.status} ${response.statusText}`
+    );
+  }
+
+  const spec = (await response.json()) as OpenAPIDocument;
+  return pickPaths(spec, includedPaths);
+}
+
+function pickPaths(
+  spec: OpenAPIDocument,
+  paths: readonly string[]
+): OpenAPIDocument {
+  const sourcePaths = spec.paths ?? {};
+  const pickedPaths: NonNullable<OpenAPIDocument["paths"]> = {};
+
+  for (const path of paths) {
+    const pathItem = sourcePaths[path];
+    if (!pathItem) {
+      throw new Error(`OpenAPI spec did not include expected path: ${path}`);
+    }
+    pickedPaths[path] = pathItem;
+  }
+
+  return {
+    ...spec,
+    paths: pickedPaths,
+  };
+}

--- a/libraries/typescript/packages/mcp-use/examples/server/features/openapi/src/server.ts
+++ b/libraries/typescript/packages/mcp-use/examples/server/features/openapi/src/server.ts
@@ -134,7 +134,10 @@ type Todo = {
 };
 
 const todos = new Map<string, Todo>([
-  ["todo-1", { id: "todo-1", title: "Write the OpenAPI spec", completed: true }],
+  [
+    "todo-1",
+    { id: "todo-1", title: "Write the OpenAPI spec", completed: true },
+  ],
   [
     "todo-2",
     { id: "todo-2", title: "Generate MCP tools from it", completed: false },
@@ -173,7 +176,9 @@ server.app.patch("/api/todos/:id", async (c) => {
     return c.json({ error: "Todo not found" }, 404);
   }
 
-  const patch = (await c.req.json()) as Partial<Pick<Todo, "title" | "completed">>;
+  const patch = (await c.req.json()) as Partial<
+    Pick<Todo, "title" | "completed">
+  >;
   const updated = { ...todo, ...patch };
   todos.set(id, updated);
 

--- a/libraries/typescript/packages/mcp-use/examples/server/features/openapi/tsconfig.json
+++ b/libraries/typescript/packages/mcp-use/examples/server/features/openapi/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/libraries/typescript/packages/mcp-use/src/server/index.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/index.ts
@@ -3,6 +3,12 @@ export {
   MCPServer,
   type McpServerInstance,
 } from "./mcp-server.js";
+export type {
+  FromOpenAPIOptions,
+  OpenAPIAuth,
+  OpenAPIDocument,
+  OpenAPIExcludeRule,
+} from "./openapi/index.js";
 
 // Export version information (global)
 export { getPackageVersion, VERSION } from "../version.js";

--- a/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
@@ -236,7 +236,9 @@ class MCPServerClass<HasOAuth extends boolean = false> {
    *
    * Each included OpenAPI operation is registered as an MCP tool.
    */
-  public static fromOpenAPI(options: FromOpenAPIOptions): MCPServerClass<false> {
+  public static fromOpenAPI(
+    options: FromOpenAPIOptions
+  ): MCPServerClass<false> {
     const server = new MCPServerClass({
       name: options.name ?? options.spec.info.title,
       version: options.version ?? options.spec.info.version ?? "1.0.0",

--- a/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
@@ -18,6 +18,10 @@ import { getPackageVersion } from "../version.js";
 
 import { countChanges, logChanges, syncPrimitive } from "./hmr-sync.js";
 import { mountInspectorUI } from "./inspector/index.js";
+import {
+  registerOpenAPITools,
+  type FromOpenAPIOptions,
+} from "./openapi/index.js";
 import { registerPrompt } from "./prompts/index.js";
 import {
   registerResource,
@@ -225,6 +229,21 @@ class MCPServerClass<HasOAuth extends boolean = false> {
    */
   public static getPackageVersion(): string {
     return getPackageVersion();
+  }
+
+  /**
+   * Create an MCP server from a parsed, bundled OpenAPI document.
+   *
+   * Each included OpenAPI operation is registered as an MCP tool.
+   */
+  public static fromOpenAPI(options: FromOpenAPIOptions): MCPServerClass<false> {
+    const server = new MCPServerClass({
+      name: options.name ?? options.spec.info.title,
+      version: options.version ?? options.spec.info.version ?? "1.0.0",
+    }) as MCPServerClass<false>;
+
+    registerOpenAPITools(server, options);
+    return server;
   }
 
   /**
@@ -4161,6 +4180,7 @@ interface MCPServerConstructor {
   ): McpServerInstance<true>;
   // Overload: when OAuth is not configured, return McpServerInstance<false>
   new (config: ServerConfig): McpServerInstance<false>;
+  fromOpenAPI(options: FromOpenAPIOptions): McpServerInstance<false>;
   prototype: MCPServerClass<boolean>;
 }
 

--- a/libraries/typescript/packages/mcp-use/src/server/openapi/index.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/openapi/index.ts
@@ -1,0 +1,31 @@
+import { callOpenAPIOperation } from "./request.js";
+import { createToolInputSchema } from "./schema.js";
+import { createToolDescription, createToolNames } from "./naming.js";
+import { collectOperations } from "./operations.js";
+import type { FromOpenAPIOptions, OpenAPIServerLike } from "./types.js";
+
+export type {
+  FromOpenAPIOptions,
+  OpenAPIAuth,
+  OpenAPIDocument,
+  OpenAPIExcludeRule,
+} from "./types.js";
+
+export function registerOpenAPITools(
+  server: OpenAPIServerLike,
+  options: FromOpenAPIOptions
+): void {
+  const operations = collectOperations(options.spec, options);
+  const names = createToolNames(operations);
+
+  for (const [index, operation] of operations.entries()) {
+    server.tool(
+      {
+        name: names[index],
+        description: createToolDescription(operation),
+        schema: createToolInputSchema(options.spec, operation),
+      },
+      async (params) => callOpenAPIOperation(operation, params, options)
+    );
+  }
+}

--- a/libraries/typescript/packages/mcp-use/src/server/openapi/naming.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/openapi/naming.ts
@@ -1,0 +1,45 @@
+import type { CollectedOpenAPIOperation } from "./types.js";
+
+export function createToolNames(
+  operations: CollectedOpenAPIOperation[]
+): string[] {
+  const seen = new Map<string, number>();
+  const names: string[] = [];
+
+  for (const operation of operations) {
+    const baseName = slugifyToolName(
+      operation.operation.operationId ??
+        `${operation.method}_${operation.path
+          .replace(/[{}]/g, "")
+          .replace(/\//g, "_")}`
+    );
+    const count = seen.get(baseName) ?? 0;
+    seen.set(baseName, count + 1);
+    names.push(count === 0 ? baseName : `${baseName}_${count + 1}`);
+  }
+
+  return names;
+}
+
+export function createToolDescription(
+  operation: CollectedOpenAPIOperation
+): string {
+  return [
+    operation.operation.summary,
+    operation.operation.description,
+    `HTTP: ${operation.method.toUpperCase()} ${operation.path}`,
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+}
+
+function slugifyToolName(value: string): string {
+  const slug = value
+    .trim()
+    .replace(/[^a-zA-Z0-9_-]+/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, 64);
+
+  return slug || "openapi_tool";
+}

--- a/libraries/typescript/packages/mcp-use/src/server/openapi/operations.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/openapi/operations.ts
@@ -1,0 +1,138 @@
+import { isReferenceObject, resolveRef } from "./refs.js";
+import type {
+  CollectedOpenAPIOperation,
+  FromOpenAPIOptions,
+  OpenAPIDocument,
+  OpenAPIExcludeRule,
+  OpenAPIHttpMethod,
+  OpenAPIOperationObject,
+  OpenAPIParameterObject,
+  OpenAPIPathItemObject,
+  OpenAPIRequestBodyObject,
+} from "./types.js";
+
+const HTTP_METHODS: OpenAPIHttpMethod[] = [
+  "get",
+  "put",
+  "post",
+  "delete",
+  "options",
+  "head",
+  "patch",
+  "trace",
+];
+
+export function collectOperations(
+  spec: OpenAPIDocument,
+  options: Pick<FromOpenAPIOptions, "tags" | "exclude">
+): CollectedOpenAPIOperation[] {
+  const collected: CollectedOpenAPIOperation[] = [];
+
+  for (const [path, pathItemOrRef] of Object.entries(spec.paths ?? {})) {
+    const pathItem = resolveRef<OpenAPIPathItemObject>(spec, pathItemOrRef);
+    if (!pathItem || isReferenceObject(pathItem)) {
+      continue;
+    }
+
+    const pathParameters = resolveParameters(spec, pathItem.parameters);
+
+    for (const method of HTTP_METHODS) {
+      const operation = pathItem[method];
+      if (!operation) {
+        continue;
+      }
+
+      const resolvedOperation = resolveRef<OpenAPIOperationObject>(
+        spec,
+        operation
+      );
+      const operationParameters = resolveParameters(
+        spec,
+        resolvedOperation.parameters
+      );
+      const requestBody = resolvedOperation.requestBody
+        ? resolveRef<OpenAPIRequestBodyObject>(spec, resolvedOperation.requestBody)
+        : undefined;
+
+      const item: CollectedOpenAPIOperation = {
+        method,
+        path,
+        operation: resolvedOperation,
+        parameters: mergeParameters(pathParameters, operationParameters),
+        requestBody,
+      };
+
+      if (isIncluded(item, options)) {
+        collected.push(item);
+      }
+    }
+  }
+
+  return collected;
+}
+
+function resolveParameters(
+  spec: OpenAPIDocument,
+  parameters?: Array<OpenAPIParameterObject | { $ref: string }>
+): OpenAPIParameterObject[] {
+  return (parameters ?? []).map((parameter) =>
+    resolveRef<OpenAPIParameterObject>(spec, parameter)
+  );
+}
+
+function mergeParameters(
+  pathParameters: OpenAPIParameterObject[],
+  operationParameters: OpenAPIParameterObject[]
+): OpenAPIParameterObject[] {
+  const merged = new Map<string, OpenAPIParameterObject>();
+
+  for (const parameter of [...pathParameters, ...operationParameters]) {
+    merged.set(`${parameter.in}:${parameter.name}`, parameter);
+  }
+
+  return [...merged.values()];
+}
+
+function isIncluded(
+  operation: CollectedOpenAPIOperation,
+  options: Pick<FromOpenAPIOptions, "tags" | "exclude">
+): boolean {
+  if (options.tags?.length) {
+    const tags = new Set(operation.operation.tags ?? []);
+    if (!options.tags.some((tag) => tags.has(tag))) {
+      return false;
+    }
+  }
+
+  return !(options.exclude ?? []).some((rule) => matchesExcludeRule(operation, rule));
+}
+
+function matchesExcludeRule(
+  operation: CollectedOpenAPIOperation,
+  rule: OpenAPIExcludeRule
+): boolean {
+  if (rule.method && rule.method.toLowerCase() !== operation.method) {
+    return false;
+  }
+
+  if (rule.operationId && !matchesPattern(rule.operationId, operation.operation.operationId ?? "")) {
+    return false;
+  }
+
+  if (rule.path && !matchesPattern(rule.path, operation.path)) {
+    return false;
+  }
+
+  if (rule.tags?.length) {
+    const tags = new Set(operation.operation.tags ?? []);
+    if (!rule.tags.some((tag) => tags.has(tag))) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function matchesPattern(pattern: string | RegExp, value: string): boolean {
+  return typeof pattern === "string" ? pattern === value : pattern.test(value);
+}

--- a/libraries/typescript/packages/mcp-use/src/server/openapi/operations.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/openapi/operations.ts
@@ -51,7 +51,10 @@ export function collectOperations(
         resolvedOperation.parameters
       );
       const requestBody = resolvedOperation.requestBody
-        ? resolveRef<OpenAPIRequestBodyObject>(spec, resolvedOperation.requestBody)
+        ? resolveRef<OpenAPIRequestBodyObject>(
+            spec,
+            resolvedOperation.requestBody
+          )
         : undefined;
 
       const item: CollectedOpenAPIOperation = {
@@ -104,7 +107,9 @@ function isIncluded(
     }
   }
 
-  return !(options.exclude ?? []).some((rule) => matchesExcludeRule(operation, rule));
+  return !(options.exclude ?? []).some((rule) =>
+    matchesExcludeRule(operation, rule)
+  );
 }
 
 function matchesExcludeRule(
@@ -115,7 +120,10 @@ function matchesExcludeRule(
     return false;
   }
 
-  if (rule.operationId && !matchesPattern(rule.operationId, operation.operation.operationId ?? "")) {
+  if (
+    rule.operationId &&
+    !matchesPattern(rule.operationId, operation.operation.operationId ?? "")
+  ) {
     return false;
   }
 

--- a/libraries/typescript/packages/mcp-use/src/server/openapi/refs.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/openapi/refs.ts
@@ -1,0 +1,35 @@
+import type { OpenAPIDocument, OpenAPIReferenceObject } from "./types.js";
+
+export function isReferenceObject(value: unknown): value is OpenAPIReferenceObject {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    typeof (value as { $ref?: unknown }).$ref === "string"
+  );
+}
+
+export function resolveRef<T>(spec: OpenAPIDocument, value: T | OpenAPIReferenceObject): T {
+  if (!isReferenceObject(value)) {
+    return value;
+  }
+
+  const ref = value.$ref;
+  if (!ref.startsWith("#/")) {
+    return {} as T;
+  }
+
+  const segments = ref
+    .slice(2)
+    .split("/")
+    .map((segment) => segment.replace(/~1/g, "/").replace(/~0/g, "~"));
+
+  let current: unknown = spec;
+  for (const segment of segments) {
+    if (!current || typeof current !== "object") {
+      return {} as T;
+    }
+    current = (current as Record<string, unknown>)[segment];
+  }
+
+  return current as T;
+}

--- a/libraries/typescript/packages/mcp-use/src/server/openapi/refs.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/openapi/refs.ts
@@ -1,6 +1,8 @@
 import type { OpenAPIDocument, OpenAPIReferenceObject } from "./types.js";
 
-export function isReferenceObject(value: unknown): value is OpenAPIReferenceObject {
+export function isReferenceObject(
+  value: unknown
+): value is OpenAPIReferenceObject {
   return (
     !!value &&
     typeof value === "object" &&
@@ -8,7 +10,10 @@ export function isReferenceObject(value: unknown): value is OpenAPIReferenceObje
   );
 }
 
-export function resolveRef<T>(spec: OpenAPIDocument, value: T | OpenAPIReferenceObject): T {
+export function resolveRef<T>(
+  spec: OpenAPIDocument,
+  value: T | OpenAPIReferenceObject
+): T {
   if (!isReferenceObject(value)) {
     return value;
   }

--- a/libraries/typescript/packages/mcp-use/src/server/openapi/request.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/openapi/request.ts
@@ -1,0 +1,119 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { error, object as objectResponse, text } from "../utils/response-helpers.js";
+import type {
+  CollectedOpenAPIOperation,
+  FromOpenAPIOptions,
+  OpenAPIParameterObject,
+} from "./types.js";
+
+export async function callOpenAPIOperation(
+  operation: CollectedOpenAPIOperation,
+  params: Record<string, unknown>,
+  options: FromOpenAPIOptions
+): Promise<CallToolResult> {
+  const fetchImpl = options.fetch ?? fetch;
+  const url = buildUrl(operation, params, options);
+  const headers = buildHeaders(operation.parameters, params, options);
+  const body = params.body === undefined ? undefined : JSON.stringify(params.body);
+
+  if (body !== undefined && !hasHeader(headers, "content-type")) {
+    headers["content-type"] = "application/json";
+  }
+
+  const response = await fetchImpl(url, {
+    method: operation.method.toUpperCase(),
+    headers,
+    body,
+  });
+
+  const contentType = response.headers.get("content-type") ?? "";
+
+  if (!response.ok) {
+    return error(await response.text());
+  }
+
+  if (contentType.includes("application/json") || contentType.includes("+json")) {
+    return objectResponse(await response.json());
+  }
+
+  return text(await response.text());
+}
+
+function buildUrl(
+  operation: CollectedOpenAPIOperation,
+  params: Record<string, unknown>,
+  options: FromOpenAPIOptions
+): string {
+  const baseUrl = options.baseUrl ?? options.spec.servers?.[0]?.url ?? "";
+  const interpolatedPath = operation.path.replace(
+    /{([^}]+)}/g,
+    (_match, name: string) => encodeURIComponent(String(params[name] ?? ""))
+  );
+  const url = new URL(
+    interpolatedPath.replace(/^\/+/, ""),
+    ensureTrailingSlash(baseUrl)
+  );
+
+  for (const parameter of operation.parameters) {
+    if (parameter.in !== "query") {
+      continue;
+    }
+    const value = params[parameter.name];
+    if (value === undefined || value === null || value === "") {
+      continue;
+    }
+    appendQueryParam(url, parameter.name, value);
+  }
+
+  return url.toString();
+}
+
+function buildHeaders(
+  parameters: OpenAPIParameterObject[],
+  params: Record<string, unknown>,
+  options: FromOpenAPIOptions
+): Record<string, string> {
+  const headers: Record<string, string> = { ...(options.headers ?? {}) };
+
+  for (const parameter of parameters) {
+    if (parameter.in !== "header") {
+      continue;
+    }
+    const value = params[parameter.name];
+    if (value === undefined || value === null || value === "") {
+      continue;
+    }
+    headers[parameter.name] = String(value);
+  }
+
+  if (options.auth?.type === "bearer" && options.auth.token) {
+    headers.authorization = `Bearer ${options.auth.token}`;
+  }
+
+  if (options.auth?.type === "header" && options.auth.value) {
+    headers[options.auth.name] = options.auth.value;
+  }
+
+  return headers;
+}
+
+function appendQueryParam(url: URL, name: string, value: unknown): void {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      if (item !== undefined && item !== null && item !== "") {
+        url.searchParams.append(name, String(item));
+      }
+    }
+    return;
+  }
+
+  url.searchParams.set(name, String(value));
+}
+
+function ensureTrailingSlash(url: string): string {
+  return url.endsWith("/") ? url : `${url}/`;
+}
+
+function hasHeader(headers: Record<string, string>, name: string): boolean {
+  return Object.keys(headers).some((headerName) => headerName.toLowerCase() === name);
+}

--- a/libraries/typescript/packages/mcp-use/src/server/openapi/request.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/openapi/request.ts
@@ -1,5 +1,9 @@
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { error, object as objectResponse, text } from "../utils/response-helpers.js";
+import {
+  error,
+  object as objectResponse,
+  text,
+} from "../utils/response-helpers.js";
 import type {
   CollectedOpenAPIOperation,
   FromOpenAPIOptions,
@@ -14,7 +18,8 @@ export async function callOpenAPIOperation(
   const fetchImpl = options.fetch ?? fetch;
   const url = buildUrl(operation, params, options);
   const headers = buildHeaders(operation.parameters, params, options);
-  const body = params.body === undefined ? undefined : JSON.stringify(params.body);
+  const body =
+    params.body === undefined ? undefined : JSON.stringify(params.body);
 
   if (body !== undefined && !hasHeader(headers, "content-type")) {
     headers["content-type"] = "application/json";
@@ -32,7 +37,10 @@ export async function callOpenAPIOperation(
     return error(await response.text());
   }
 
-  if (contentType.includes("application/json") || contentType.includes("+json")) {
+  if (
+    contentType.includes("application/json") ||
+    contentType.includes("+json")
+  ) {
     return objectResponse(await response.json());
   }
 
@@ -115,5 +123,7 @@ function ensureTrailingSlash(url: string): string {
 }
 
 function hasHeader(headers: Record<string, string>, name: string): boolean {
-  return Object.keys(headers).some((headerName) => headerName.toLowerCase() === name);
+  return Object.keys(headers).some(
+    (headerName) => headerName.toLowerCase() === name
+  );
 }

--- a/libraries/typescript/packages/mcp-use/src/server/openapi/schema.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/openapi/schema.ts
@@ -1,0 +1,177 @@
+import { z } from "zod";
+import { isReferenceObject, resolveRef } from "./refs.js";
+import type {
+  CollectedOpenAPIOperation,
+  OpenAPIDocument,
+  OpenAPIReferenceObject,
+  OpenAPISchemaObject,
+} from "./types.js";
+
+export function createToolInputSchema(
+  spec: OpenAPIDocument,
+  operation: CollectedOpenAPIOperation
+): z.ZodObject<Record<string, z.ZodTypeAny>> {
+  const shape: Record<string, z.ZodTypeAny> = {};
+
+  for (const parameter of operation.parameters) {
+    if (parameter.in === "cookie") {
+      continue;
+    }
+
+    const parameterSchema = parameter.schema
+      ? schemaToZod(spec, parameter.schema)
+      : z.any();
+    const described = parameter.description
+      ? parameterSchema.describe(parameter.description)
+      : parameterSchema.describe(`${parameter.in} parameter`);
+
+    shape[parameter.name] =
+      parameter.required || parameter.in === "path"
+        ? described
+        : described.optional();
+  }
+
+  const jsonBodySchema = getJsonRequestBodySchema(operation.requestBody);
+  if (jsonBodySchema) {
+    const bodySchema = schemaToZod(spec, jsonBodySchema);
+    shape.body = operation.requestBody?.required
+      ? bodySchema
+      : bodySchema.optional();
+  }
+
+  return z.object(shape);
+}
+
+export function schemaToZod(
+  spec: OpenAPIDocument,
+  schemaOrRef: OpenAPISchemaObject | OpenAPIReferenceObject
+): z.ZodTypeAny {
+  const schema = resolveRef<OpenAPISchemaObject>(spec, schemaOrRef);
+
+  if (!schema || typeof schema !== "object" || isReferenceObject(schema)) {
+    return z.any();
+  }
+
+  if (schema.enum && schema.enum.length > 0) {
+    return withNullable(schema, enumToZod(schema.enum));
+  }
+
+  if (schema.oneOf?.length || schema.anyOf?.length) {
+    const variants = schema.oneOf ?? schema.anyOf ?? [];
+    const zodVariants = variants.map((variant) => schemaToZod(spec, variant));
+    if (zodVariants.length === 1) {
+      return withNullable(schema, zodVariants[0]);
+    }
+    if (zodVariants.length >= 2) {
+      return withNullable(schema, z.union(zodVariants as [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]]));
+    }
+  }
+
+  if (schema.allOf?.length) {
+    const objectSchemas = schema.allOf
+      .map((part) => schemaToZod(spec, part))
+      .filter((part): part is z.ZodObject<any> => part instanceof z.ZodObject);
+
+    if (objectSchemas.length > 0) {
+      return withNullable(
+        schema,
+        objectSchemas.slice(1).reduce((merged, current) => merged.merge(current), objectSchemas[0])
+      );
+    }
+  }
+
+  const schemaType = Array.isArray(schema.type)
+    ? schema.type.find((type) => type !== "null")
+    : schema.type;
+
+  switch (schemaType) {
+    case "string":
+      return withNullable(schema, z.string());
+    case "integer":
+    case "number":
+      return withNullable(schema, z.number());
+    case "boolean":
+      return withNullable(schema, z.boolean());
+    case "array":
+      return withNullable(
+        schema,
+        z.array(schema.items ? schemaToZod(spec, schema.items) : z.any())
+      );
+    case "object":
+      return withNullable(schema, objectSchemaToZod(spec, schema));
+    default:
+      if (schema.properties) {
+        return withNullable(schema, objectSchemaToZod(spec, schema));
+      }
+      return withNullable(schema, z.any());
+  }
+}
+
+function objectSchemaToZod(
+  spec: OpenAPIDocument,
+  schema: OpenAPISchemaObject
+): z.ZodTypeAny {
+  const shape: Record<string, z.ZodTypeAny> = {};
+  const required = new Set(schema.required ?? []);
+
+  for (const [name, property] of Object.entries(schema.properties ?? {})) {
+    const resolvedProperty = resolveRef<OpenAPISchemaObject>(spec, property);
+    const description =
+      !isReferenceObject(resolvedProperty) && resolvedProperty.description
+        ? resolvedProperty.description
+        : undefined;
+    const propertySchema = schemaToZod(spec, property);
+    const described = description ? propertySchema.describe(description) : propertySchema;
+
+    shape[name] = required.has(name) ? described : described.optional();
+  }
+
+  return z.object(shape);
+}
+
+function enumToZod(values: Array<string | number | boolean | null>): z.ZodTypeAny {
+  if (values.every((value): value is string => typeof value === "string")) {
+    return z.enum(values as [string, ...string[]]);
+  }
+
+  if (values.length === 1) {
+    return z.literal(values[0]);
+  }
+
+  return z.union(
+    values.map((value) => z.literal(value)) as [
+      z.ZodLiteral<any>,
+      z.ZodLiteral<any>,
+      ...z.ZodLiteral<any>[],
+    ]
+  );
+}
+
+function withNullable(schema: OpenAPISchemaObject, zodSchema: z.ZodTypeAny): z.ZodTypeAny {
+  if (
+    schema.nullable ||
+    (Array.isArray(schema.type) && schema.type.includes("null")) ||
+    schema.enum?.includes(null)
+  ) {
+    return zodSchema.nullable();
+  }
+
+  return zodSchema;
+}
+
+function getJsonRequestBodySchema(
+  requestBody: CollectedOpenAPIOperation["requestBody"]
+): OpenAPISchemaObject | OpenAPIReferenceObject | undefined {
+  const content = requestBody?.content;
+  if (!content) {
+    return undefined;
+  }
+
+  return (
+    content["application/json"]?.schema ??
+    content["application/*+json"]?.schema ??
+    Object.entries(content).find(([mediaType]) =>
+      mediaType.includes("+json")
+    )?.[1].schema
+  );
+}

--- a/libraries/typescript/packages/mcp-use/src/server/openapi/schema.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/openapi/schema.ts
@@ -42,7 +42,7 @@ export function createToolInputSchema(
   return z.object(shape);
 }
 
-export function schemaToZod(
+function schemaToZod(
   spec: OpenAPIDocument,
   schemaOrRef: OpenAPISchemaObject | OpenAPIReferenceObject
 ): z.ZodTypeAny {
@@ -63,7 +63,10 @@ export function schemaToZod(
       return withNullable(schema, zodVariants[0]);
     }
     if (zodVariants.length >= 2) {
-      return withNullable(schema, z.union(zodVariants as [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]]));
+      return withNullable(
+        schema,
+        z.union(zodVariants as [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]])
+      );
     }
   }
 
@@ -75,7 +78,9 @@ export function schemaToZod(
     if (objectSchemas.length > 0) {
       return withNullable(
         schema,
-        objectSchemas.slice(1).reduce((merged, current) => merged.merge(current), objectSchemas[0])
+        objectSchemas
+          .slice(1)
+          .reduce((merged, current) => merged.merge(current), objectSchemas[0])
       );
     }
   }
@@ -121,7 +126,9 @@ function objectSchemaToZod(
         ? resolvedProperty.description
         : undefined;
     const propertySchema = schemaToZod(spec, property);
-    const described = description ? propertySchema.describe(description) : propertySchema;
+    const described = description
+      ? propertySchema.describe(description)
+      : propertySchema;
 
     shape[name] = required.has(name) ? described : described.optional();
   }
@@ -129,7 +136,9 @@ function objectSchemaToZod(
   return z.object(shape);
 }
 
-function enumToZod(values: Array<string | number | boolean | null>): z.ZodTypeAny {
+function enumToZod(
+  values: Array<string | number | boolean | null>
+): z.ZodTypeAny {
   if (values.every((value): value is string => typeof value === "string")) {
     return z.enum(values as [string, ...string[]]);
   }
@@ -147,7 +156,10 @@ function enumToZod(values: Array<string | number | boolean | null>): z.ZodTypeAn
   );
 }
 
-function withNullable(schema: OpenAPISchemaObject, zodSchema: z.ZodTypeAny): z.ZodTypeAny {
+function withNullable(
+  schema: OpenAPISchemaObject,
+  zodSchema: z.ZodTypeAny
+): z.ZodTypeAny {
   if (
     schema.nullable ||
     (Array.isArray(schema.type) && schema.type.includes("null")) ||

--- a/libraries/typescript/packages/mcp-use/src/server/openapi/schema.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/openapi/schema.ts
@@ -133,7 +133,18 @@ function objectSchemaToZod(
     shape[name] = required.has(name) ? described : described.optional();
   }
 
-  return z.object(shape);
+  const objectSchema = z.object(shape);
+  const additionalProperties = schema.additionalProperties;
+
+  if (additionalProperties === false) {
+    return objectSchema.strict();
+  }
+
+  if (additionalProperties && typeof additionalProperties === "object") {
+    return objectSchema.catchall(schemaToZod(spec, additionalProperties));
+  }
+
+  return objectSchema.passthrough();
 }
 
 function enumToZod(

--- a/libraries/typescript/packages/mcp-use/src/server/openapi/types.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/openapi/types.ts
@@ -1,0 +1,110 @@
+import type { MCPServer } from "../mcp-server.js";
+
+export type OpenAPIHttpMethod =
+  | "get"
+  | "put"
+  | "post"
+  | "delete"
+  | "options"
+  | "head"
+  | "patch"
+  | "trace";
+
+export type OpenAPIReferenceObject = {
+  $ref: string;
+};
+
+export type OpenAPISchemaObject = {
+  type?: string | string[];
+  properties?: Record<string, OpenAPISchemaObject | OpenAPIReferenceObject>;
+  items?: OpenAPISchemaObject | OpenAPIReferenceObject;
+  required?: string[];
+  enum?: Array<string | number | boolean | null>;
+  format?: string;
+  description?: string;
+  nullable?: boolean;
+  oneOf?: Array<OpenAPISchemaObject | OpenAPIReferenceObject>;
+  anyOf?: Array<OpenAPISchemaObject | OpenAPIReferenceObject>;
+  allOf?: Array<OpenAPISchemaObject | OpenAPIReferenceObject>;
+  additionalProperties?: boolean | OpenAPISchemaObject | OpenAPIReferenceObject;
+  [key: string]: unknown;
+};
+
+export type OpenAPIParameterObject = {
+  name: string;
+  in: "query" | "header" | "path" | "cookie";
+  description?: string;
+  required?: boolean;
+  schema?: OpenAPISchemaObject | OpenAPIReferenceObject;
+};
+
+export type OpenAPIRequestBodyObject = {
+  description?: string;
+  required?: boolean;
+  content?: Record<
+    string,
+    {
+      schema?: OpenAPISchemaObject | OpenAPIReferenceObject;
+    }
+  >;
+};
+
+export type OpenAPIOperationObject = {
+  operationId?: string;
+  summary?: string;
+  description?: string;
+  tags?: string[];
+  parameters?: Array<OpenAPIParameterObject | OpenAPIReferenceObject>;
+  requestBody?: OpenAPIRequestBodyObject | OpenAPIReferenceObject;
+  responses?: Record<string, unknown>;
+};
+
+export type OpenAPIPathItemObject = Partial<
+  Record<OpenAPIHttpMethod, OpenAPIOperationObject>
+> & {
+  parameters?: Array<OpenAPIParameterObject | OpenAPIReferenceObject>;
+};
+
+export type OpenAPIDocument = {
+  openapi: string;
+  info: {
+    title: string;
+    version?: string;
+  };
+  servers?: Array<{ url: string }>;
+  paths?: Record<string, OpenAPIPathItemObject | OpenAPIReferenceObject>;
+  components?: Record<string, unknown>;
+};
+
+export type OpenAPIAuth =
+  | { type: "bearer"; token: string | undefined }
+  | { type: "header"; name: string; value: string | undefined };
+
+export type OpenAPIExcludeRule = {
+  operationId?: string | RegExp;
+  path?: string | RegExp;
+  method?: OpenAPIHttpMethod | Uppercase<OpenAPIHttpMethod>;
+  tags?: string[];
+};
+
+export type FromOpenAPIOptions = {
+  spec: OpenAPIDocument;
+  baseUrl?: string;
+  name?: string;
+  version?: string;
+  auth?: OpenAPIAuth;
+  headers?: Record<string, string>;
+  tags?: string[];
+  exclude?: OpenAPIExcludeRule[];
+  fetch?: typeof fetch;
+};
+
+export type OpenAPIServerLike = Pick<MCPServer, "tool">;
+
+export type CollectedOpenAPIOperation = {
+  method: OpenAPIHttpMethod;
+  path: string;
+  operation: OpenAPIOperationObject;
+  parameters: OpenAPIParameterObject[];
+  requestBody?: OpenAPIRequestBodyObject;
+};

--- a/libraries/typescript/packages/mcp-use/tests/unit/server/openapi.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/server/openapi.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it, vi } from "vitest";
+import { MCPServer, type OpenAPIDocument } from "../../../src/server/index.js";
+
+const spec: OpenAPIDocument = {
+  openapi: "3.1.0",
+  info: {
+    title: "Test API",
+    version: "2026-05-27",
+  },
+  servers: [{ url: "https://api.example.com/v1" }],
+  paths: {
+    "/todos/{id}": {
+      parameters: [
+        {
+          name: "id",
+          in: "path",
+          required: true,
+          schema: { type: "string" },
+        },
+      ],
+      get: {
+        operationId: "getTodo",
+        summary: "Get a todo",
+        tags: ["todos"],
+        parameters: [
+          {
+            name: "include",
+            in: "query",
+            schema: {
+              type: "string",
+              enum: ["comments", "owner"],
+            },
+          },
+        ],
+        responses: { "200": { description: "ok" } },
+      },
+      patch: {
+        operationId: "updateTodo",
+        summary: "Update a todo",
+        tags: ["todos"],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/TodoUpdate" },
+            },
+          },
+        },
+        responses: { "200": { description: "ok" } },
+      },
+    },
+    "/admin/stats": {
+      get: {
+        operationId: "getAdminStats",
+        tags: ["admin"],
+        responses: { "200": { description: "ok" } },
+      },
+    },
+  },
+  components: {
+    schemas: {
+      TodoUpdate: {
+        type: "object",
+        required: ["title"],
+        properties: {
+          title: { type: "string", description: "Todo title" },
+          completed: { type: "boolean" },
+        },
+      },
+    },
+  },
+};
+
+describe("MCPServer.fromOpenAPI", () => {
+  it("registers included OpenAPI operations as tools", () => {
+    const server = MCPServer.fromOpenAPI({
+      spec,
+      tags: ["todos"],
+      exclude: [{ operationId: "updateTodo" }],
+    });
+
+    expect(server.config.name).toBe("Test API");
+    expect(server.config.version).toBe("2026-05-27");
+    expect(server.registeredTools).toEqual(["getTodo"]);
+  });
+
+  it("creates deterministic fallback names without collisions", () => {
+    const server = MCPServer.fromOpenAPI({
+      spec: {
+        openapi: "3.1.0",
+        info: { title: "Fallback API", version: "1.0.0" },
+        paths: {
+          "/reports/{id}": {
+            get: {
+              responses: { "200": { description: "ok" } },
+            },
+            post: {
+              responses: { "200": { description: "ok" } },
+            },
+          },
+        },
+      },
+      baseUrl: "https://api.example.com",
+    });
+
+    expect(server.registeredTools).toEqual([
+      "get_reports_id",
+      "post_reports_id",
+    ]);
+  });
+
+  it("deduplicates colliding operationIds", () => {
+    const server = MCPServer.fromOpenAPI({
+      spec: {
+        openapi: "3.1.0",
+        info: { title: "Collision API", version: "1.0.0" },
+        paths: {
+          "/first": {
+            get: {
+              operationId: "getReport",
+              responses: { "200": { description: "ok" } },
+            },
+          },
+          "/second": {
+            get: {
+              operationId: "getReport",
+              responses: { "200": { description: "ok" } },
+            },
+          },
+        },
+      },
+      baseUrl: "https://api.example.com",
+    });
+
+    expect(server.registeredTools).toEqual(["getReport", "getReport_2"]);
+  });
+
+  it("creates Zod input schemas from parameters and local refs", () => {
+    const server = MCPServer.fromOpenAPI({ spec, tags: ["todos"] });
+    const getTodo = server.registrations.tools.get("getTodo");
+    const updateTodo = server.registrations.tools.get("updateTodo");
+
+    expect(getTodo?.config.schema?.safeParse({ id: "todo_123" }).success).toBe(
+      true
+    );
+    expect(getTodo?.config.schema?.safeParse({}).success).toBe(false);
+    expect(
+      updateTodo?.config.schema?.safeParse({
+        id: "todo_123",
+        body: { title: "Buy milk" },
+      }).success
+    ).toBe(true);
+    expect(
+      updateTodo?.config.schema?.safeParse({
+        id: "todo_123",
+        body: { completed: true },
+      }).success
+    ).toBe(false);
+  });
+
+  it("calls the target API with path, query, body, and auth mapping", async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(JSON.stringify({ id: "todo_123" }), {
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const server = MCPServer.fromOpenAPI({
+      spec,
+      auth: { type: "bearer", token: "test-token" },
+      fetch: fetchMock,
+    });
+
+    const getTodo = server.registrations.tools.get("getTodo");
+    const result = await getTodo?.handler({
+      id: "todo 123",
+      include: "comments",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.com/v1/todos/todo%20123?include=comments",
+      {
+        method: "GET",
+        headers: { authorization: "Bearer test-token" },
+        body: undefined,
+      }
+    );
+    expect(result?.structuredContent).toEqual({ id: "todo_123" });
+  });
+
+  it("sends JSON request bodies", async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response("updated", {
+        headers: { "content-type": "text/plain" },
+      });
+    });
+    const server = MCPServer.fromOpenAPI({ spec, fetch: fetchMock });
+    const updateTodo = server.registrations.tools.get("updateTodo");
+
+    const result = await updateTodo?.handler({
+      id: "todo_123",
+      body: { title: "Updated" },
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.com/v1/todos/todo_123",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ title: "Updated" }),
+      }
+    );
+    expect(result?.content).toEqual([{ type: "text", text: "updated" }]);
+  });
+});

--- a/libraries/typescript/packages/mcp-use/tests/unit/server/openapi.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/server/openapi.test.ts
@@ -158,6 +158,50 @@ describe("MCPServer.fromOpenAPI", () => {
     ).toBe(false);
   });
 
+  it("preserves additionalProperties fields in object request bodies", () => {
+    const server = MCPServer.fromOpenAPI({
+      spec: {
+        openapi: "3.1.0",
+        info: { title: "Metadata API", version: "1.0.0" },
+        paths: {
+          "/metadata": {
+            post: {
+              operationId: "setMetadata",
+              requestBody: {
+                required: true,
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "object",
+                      additionalProperties: { type: "string" },
+                    },
+                  },
+                },
+              },
+              responses: { "200": { description: "ok" } },
+            },
+          },
+        },
+      },
+      baseUrl: "https://api.example.com",
+    });
+    const setMetadata = server.registrations.tools.get("setMetadata");
+
+    const parsed = setMetadata?.config.schema?.safeParse({
+      body: { color: "blue", size: "large" },
+    });
+
+    expect(parsed?.success).toBe(true);
+    expect(parsed?.data).toEqual({
+      body: { color: "blue", size: "large" },
+    });
+    expect(
+      setMetadata?.config.schema?.safeParse({
+        body: { retries: 3 },
+      }).success
+    ).toBe(false);
+  });
+
   it("calls the target API with path, query, body, and auth mapping", async () => {
     const fetchMock = vi.fn(async () => {
       return new Response(JSON.stringify({ id: "todo_123" }), {

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -937,6 +937,28 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  packages/mcp-use/examples/server/features/openapi:
+    dependencies:
+      mcp-use:
+        specifier: workspace:*
+        version: link:../../../..
+      react:
+        specifier: ^19.2.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.0
+        version: 19.2.4(react@19.2.4)
+    devDependencies:
+      '@types/node':
+        specifier: ^25.0.2
+        version: 25.6.0
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   packages/mcp-use/examples/server/features/proxy:
     dependencies:
       '@modelcontextprotocol/sdk':


### PR DESCRIPTION
## Summary
- Add `MCPServer.fromOpenAPI(...)` to generate MCP tools from a bundled OpenAPI document
- Implement dependency-light OpenAPI parsing, local `$ref` resolution, schema conversion, naming, and request execution
- Add unit coverage for tool discovery, schema mapping, auth/header handling, request bodies, and tool-name deduplication
- Include a standalone OpenAPI example server and document it in the examples index

## Testing
- `pnpm --filter mcp-use exec vitest run tests/unit/server/openapi.test.ts`
- `pnpm --filter mcp-use exec tsc --noEmit`
- `pnpm --filter mcp-use run build`
- `pnpm --filter @mcp-use/cli run build`
- Local end-to-end validation with the `mcp-use client` CLI against the new OpenAPI example server