### PR TITLE
Throttle filesystem session store saves

### DIFF
--- a/libraries/typescript/packages/mcp-use/src/server/sessions/stores/filesystem.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/sessions/stores/filesystem.ts
@@ -37,6 +37,12 @@ export interface FileSystemSessionStoreConfig {
   debounceMs?: number;
 
   /**
+   * Minimum time in milliseconds between disk writes (default: 500)
+   * Throttles sustained write bursts after the initial debounced save
+   */
+  minSaveIntervalMs?: number;
+
+  /**
    * Maximum session age in milliseconds (default: 24 hours)
    * Sessions older than this are cleaned up on load
    */
@@ -66,15 +72,18 @@ export class FileSystemSessionStore implements SessionStore {
   private sessions = new Map<string, SessionMetadata>();
   private readonly filePath: string;
   private readonly debounceMs: number;
+  private readonly minSaveIntervalMs: number;
   private readonly maxAgeMs: number;
   private saveTimer: NodeJS.Timeout | null = null;
   private saving = false;
   private pendingSave = false;
+  private lastSaveTime = 0;
 
   constructor(config: FileSystemSessionStoreConfig = {}) {
     this.filePath =
       config.path ?? join(process.cwd(), ".mcp-use", "sessions.json");
     this.debounceMs = config.debounceMs ?? 100;
+    this.minSaveIntervalMs = config.minSaveIntervalMs ?? 500;
     this.maxAgeMs = config.maxAgeMs ?? 24 * 60 * 60 * 1000; // 24 hours
 
     // Load existing sessions synchronously on construction
@@ -208,8 +217,8 @@ export class FileSystemSessionStore implements SessionStore {
   }
 
   /**
-   * Schedule a save operation with debouncing
-   * Prevents excessive disk I/O from rapid consecutive writes
+   * Schedule a save operation with debouncing and throttling
+   * Prevents excessive disk I/O from rapid or sustained consecutive writes
    */
   private async scheduleSave(): Promise<void> {
     // If already saving, mark that another save is pending
@@ -223,10 +232,15 @@ export class FileSystemSessionStore implements SessionStore {
       clearTimeout(this.saveTimer);
     }
 
-    // Schedule new save after debounce delay
+    const throttleMs =
+      this.lastSaveTime === 0
+        ? 0
+        : Math.max(0, this.minSaveIntervalMs - (Date.now() - this.lastSaveTime));
+
+    // Schedule new save after both the debounce and throttle windows have elapsed
     this.saveTimer = setTimeout(() => {
       this.performSave();
-    }, this.debounceMs);
+    }, Math.max(this.debounceMs, throttleMs));
   }
 
   /**
@@ -253,6 +267,7 @@ export class FileSystemSessionStore implements SessionStore {
       const tempPath = `${this.filePath}.tmp`;
       await writeFile(tempPath, JSON.stringify(data, null, 2), "utf-8");
       await rename(tempPath, this.filePath);
+      this.lastSaveTime = Date.now();
     } catch (error: any) {
       console.error(
         `[FileSystemSessionStore] Error saving sessions:`,

--- a/libraries/typescript/packages/mcp-use/tests/unit/server/session-stores.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/server/session-stores.test.ts
@@ -7,7 +7,11 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
+  FileSystemSessionStore,
   InMemorySessionStore,
   RedisSessionStore,
 } from "../../../src/server/index.js";
@@ -177,6 +181,87 @@ describe("InMemorySessionStore", () => {
 
       expect(retrieved?.lastAccessedAt).toBe(2000);
       expect(retrieved?.logLevel).toBe("debug");
+    });
+  });
+});
+
+describe("FileSystemSessionStore", () => {
+  let testDir: string;
+  let sessionFile: string;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    testDir = await mkdtemp(join(tmpdir(), "mcp-use-session-store-"));
+    sessionFile = join(testDir, "sessions.json");
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  async function readSessionsFile() {
+    return JSON.parse(await readFile(sessionFile, "utf-8"));
+  }
+
+  async function expectPersistedSessions(
+    expected: Record<string, SessionMetadata>
+  ) {
+    await vi.waitFor(async () => {
+      expect(await readSessionsFile()).toEqual(expected);
+    });
+  }
+
+  it("coalesces rapid updates into one debounced save", async () => {
+    const store = new FileSystemSessionStore({
+      path: sessionFile,
+      debounceMs: 25,
+      minSaveIntervalMs: 100,
+    });
+
+    await store.set("session-1", { lastAccessedAt: 1 });
+    await store.set("session-2", { lastAccessedAt: 2 });
+    await store.delete("session-1");
+
+    await vi.advanceTimersByTimeAsync(24);
+    await expect(readFile(sessionFile, "utf-8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+
+    await vi.advanceTimersByTimeAsync(1);
+
+    await expectPersistedSessions({
+      "session-2": { lastAccessedAt: 2 },
+    });
+  });
+
+  it("throttles sustained updates after the first save", async () => {
+    const store = new FileSystemSessionStore({
+      path: sessionFile,
+      debounceMs: 25,
+      minSaveIntervalMs: 100,
+    });
+
+    await store.set("session-1", { lastAccessedAt: 1 });
+    await vi.advanceTimersByTimeAsync(25);
+
+    await expectPersistedSessions({
+      "session-1": { lastAccessedAt: 1 },
+    });
+
+    await store.set("session-2", { lastAccessedAt: 2 });
+    await vi.advanceTimersByTimeAsync(99);
+
+    expect(await readSessionsFile()).toEqual({
+      "session-1": { lastAccessedAt: 1 },
+    });
+
+    await vi.advanceTimersByTimeAsync(1);
+
+    await expectPersistedSessions({
+      "session-1": { lastAccessedAt: 1 },
+      "session-2": { lastAccessedAt: 2 },
     });
   });
 });


### PR DESCRIPTION
## Summary
- add configurable `minSaveIntervalMs` throttling to `FileSystemSessionStore`
- keep the existing debounce behavior for the first save while coalescing sustained update bursts
- add filesystem-backed regression tests for burst coalescing and throttled follow-up writes

## Why
`FileSystemSessionStore` is development/single-instance oriented, but high-churn MCP sessions can still schedule disk persistence at the debounce cadence. The new throttle limits sustained write frequency without changing the atomic temp-file/rename persistence path.

Fixes #1568.

## Validation
- `pnpm --dir libraries/typescript/packages/mcp-use generate:version`
- `pnpm --dir libraries/typescript/packages/mcp-use test:run tests/unit/server/session-stores.test.ts` (13 passed, Redis suite skipped because Redis is not configured)
- `pnpm --dir libraries/typescript/packages/mcp-use exec tsc --noEmit`
- `pnpm --dir libraries/typescript/packages/mcp-use exec eslint src/server/sessions/stores/filesystem.ts tests/unit/server/session-stores.test.ts`