### PR TITLE
chore: remove dead TypeScript pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,17 +25,6 @@ repos:
       - id: debug-statements
         files: ^libraries/python/.*\.py$
 
-  # TypeScript/JavaScript hooks - only run on TS/JS files
-  - repo: local
-    hooks:
-      - id: typescript-format-and-lint
-        name: TypeScript Format & Lint
-        entry: .git/hooks/typescript-pre-commit.sh
-        language: system
-        files: ^libraries/typescript/.*\.(ts|tsx|js|jsx)$
-        pass_filenames: false
-
 # Define configuration for the Python checks
 default_language_version:
   python: python3.11
-


### PR DESCRIPTION
## Summary
- remove the dead local TypeScript pre-commit hook from the root pre-commit config
- keep the existing Python hooks unchanged

Closes #1536.

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".pre-commit-config.yaml"); puts "yaml ok"'

Note: I could not run `pre-commit run check-yaml --files .pre-commit-config.yaml` locally because `pre-commit` is not installed in this environment.