### PR TITLE
fix: prefix resource names in MCPServer.include_router

### DIFF
--- a/libraries/python/mcp_use/server/server.py
+++ b/libraries/python/mcp_use/server/server.py
@@ -319,7 +319,7 @@ class MCPServer(FastMCP):
                 resource_name = f"{prefix}_{resource_name}"
             self.resource(
                 uri=resource.uri,
-                name=resource.name,
+                name=resource_name,
                 description=resource.description,
                 mime_type=resource.mime_type,
             )(resource.fn)

--- a/libraries/python/tests/unit/server/test_include_router.py
+++ b/libraries/python/tests/unit/server/test_include_router.py
@@ -1,0 +1,46 @@
+"""Tests for MCPServer.include_router name prefixing."""
+
+from mcp_use.server import MCPRouter, MCPServer
+
+
+def test_include_router_prefixes_tools_resources_and_prompts():
+    router = MCPRouter()
+
+    @router.tool()
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    @router.resource("config://app")
+    def get_config() -> str:
+        return "cfg"
+
+    @router.prompt()
+    def greet(name: str) -> str:
+        return f"Hi {name}"
+
+    server = MCPServer(name="t")
+    server.include_router(router, prefix="math")
+
+    tool_names = [t.name for t in server._tool_manager.list_tools()]
+    resource_names = [r.name for r in server._resource_manager.list_resources()]
+    prompt_names = [p.name for p in server._prompt_manager.list_prompts()]
+
+    # Resources must be prefixed consistently with tools and prompts; before the
+    # fix the resource kept its unprefixed name.
+    assert tool_names == ["math_add"]
+    assert resource_names == ["math_get_config"]
+    assert prompt_names == ["math_greet"]
+
+
+def test_include_router_without_prefix_keeps_names():
+    router = MCPRouter()
+
+    @router.resource("config://app")
+    def get_config() -> str:
+        return "cfg"
+
+    server = MCPServer(name="t")
+    server.include_router(router)
+
+    resource_names = [r.name for r in server._resource_manager.list_resources()]
+    assert resource_names == ["get_config"]


### PR DESCRIPTION
When `MCPServer.include_router(router, prefix=...)` is used, the prefix is applied to tool and prompt names but silently dropped for resources. The prefixed `resource_name` is computed but the call site passes the original `resource.name`:

```python
for resource in router.resources:
    resource_name = resource.name or getattr(resource.fn, "__name__", "unknown")
    if prefix:
        resource_name = f"{prefix}_{resource_name}"   # computed
    self.resource(
        uri=resource.uri,
        name=resource.name,                           # but resource.name is used
        ...
    )(resource.fn)
```

The tool branch (`name=tool_name`) and prompt branch (`name=prompt_name`) both use the prefixed name; resources should too, otherwise routers cannot be composed without resource-name collisions across modules. One-line fix to use `resource_name`.

Added `tests/unit/server/test_include_router.py` asserting tools, resources, and prompts are all prefixed consistently (and that names are unchanged without a prefix). Verified passing locally with `uv run --extra dev pytest`.

Fixes #1438