### PR TITLE
fix: hide OAuth token verification details

### DIFF
--- a/libraries/typescript/packages/mcp-use/src/server/oauth/middleware.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/middleware.ts
@@ -94,8 +94,9 @@ export function createBearerAuthMiddleware(
 
       await next();
     } catch (error) {
+      console.error("[OAuth Middleware] Token verification failed:", error);
       c.header("WWW-Authenticate", getWWWAuthenticateHeader());
-      return c.json({ error: `Invalid token: ${error}` }, 401);
+      return c.json({ error: "Invalid token" }, 401);
     }
   };
 }

--- a/libraries/typescript/packages/mcp-use/tests/server/oauth.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/server/oauth.test.ts
@@ -32,6 +32,7 @@ async function listenOnRandomPort(
 const closers: Array<() => void> = [];
 
 afterEach(() => {
+  vi.restoreAllMocks();
   while (closers.length > 0) {
     closers.pop()?.();
   }
@@ -162,6 +163,48 @@ describe("server OAuth integration", () => {
       headers: { Authorization: "Bearer token-123" },
     });
     expect(authorized.status).toBe(200);
+  });
+
+  it("does not expose token verification errors to clients", async () => {
+    const app = new Hono();
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    const proxy = oauthProxy({
+      issuer: "https://issuer.example.com",
+      authEndpoint: "https://issuer.example.com/oauth/authorize",
+      tokenEndpoint: "https://issuer.example.com/oauth/token",
+      clientId: "test-client",
+      verifyToken: async () => {
+        throw new Error(
+          "JWKS fetch failed for https://issuer.example.com/.well-known/jwks.json"
+        );
+      },
+    });
+
+    app.use("/mcp/*", createBearerAuthMiddleware(proxy));
+    app.get("/mcp/test", (c) => c.json({ ok: true }));
+
+    const svc = await listenOnRandomPort(app);
+    closers.push(svc.close);
+
+    const response = await fetch(`${svc.baseUrl}/mcp/test`, {
+      headers: { Authorization: "Bearer token-123" },
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data).toEqual({ error: "Invalid token" });
+    expect(JSON.stringify(data)).not.toContain("JWKS");
+    expect(JSON.stringify(data)).not.toContain("issuer.example.com");
+    expect(response.headers.get("WWW-Authenticate")).toContain(
+      "oauth-protected-resource"
+    );
+    expect(consoleError).toHaveBeenCalledWith(
+      "[OAuth Middleware] Token verification failed:",
+      expect.any(Error)
+    );
   });
 
   it("returns configured clientId from /register endpoint", async () => {


### PR DESCRIPTION
## Problem

OAuth bearer middleware currently returns the raw token verification exception in the 401 response body. Those errors can include provider/JWKS URLs or library internals, which should stay server-side.

Fixes #1570.

## Fix

Return a generic `Invalid token` response for verification failures while logging the original error on the server. The existing `WWW-Authenticate` discovery header is preserved.

## Test

- `pnpm --dir libraries/typescript --filter mcp-use test:run tests/server/oauth.test.ts`
- `pnpm --dir libraries/typescript exec prettier --check packages/mcp-use/src/server/oauth/middleware.ts packages/mcp-use/tests/server/oauth.test.ts`
- `pnpm --dir libraries/typescript exec eslint packages/mcp-use/src/server/oauth/middleware.ts packages/mcp-use/tests/server/oauth.test.ts`
- `git diff --check`

## Risk

Low. This only changes the client-facing error body for invalid bearer tokens; successful auth and OAuth discovery headers are unchanged.