### PR TITLE
[Fix] Auto-inject postMessage readiness signal into programmatic mcpApps widgets

### DIFF
--- a/libraries/typescript/.changeset/screenshot-pipeline-timeout-fix.md
+++ b/libraries/typescript/.changeset/screenshot-pipeline-timeout-fix.md
@@ -1,0 +1,6 @@
+---
+"mcp-use": patch
+"@mcp-use/inspector": patch
+---
+
+Inject readiness postMessage signal into programmatic widgets so that the CLI and REPL screenshot pipeline can detect when rendering is complete, preventing timeouts on widgets that lack the full AppBridge SDK.

--- a/libraries/typescript/packages/inspector/src/client/components/MCPAppsRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/MCPAppsRenderer.tsx
@@ -934,6 +934,19 @@ function MCPAppsRendererBase({
   // Handle CSP violations
   const handleSandboxMessage = useCallback(
     (event: MessageEvent) => {
+      // Programmatic widgets (without AppBridge) send this message once loaded.
+      // This allows the screenshot pipeline to detect readiness even for simple
+      // raw HTML widgets that don't use the full AppBridge SDK.
+      if (event.data?.type === "mcp-use:widget-ready") {
+        if (!readyFiredRef.current && initCount === 0) {
+          readyFiredRef.current = true;
+          setShowSpinner(false);
+          hasLoadedOnceRef.current = true;
+          onReady?.();
+        }
+        return;
+      }
+
       if (event.data?.type !== "mcp-apps:csp-violation") return;
 
       const {
@@ -963,8 +976,9 @@ function MCPAppsRendererBase({
         sourceFile ? `at ${sourceFile}:${lineNumber}:${columnNumber}` : ""
       );
     },
-    [toolCallId, addCspViolation]
+    [toolCallId, addCspViolation, initCount, onReady]
   );
+
 
   // Handle fullscreen changes
   useEffect(() => {
@@ -1026,11 +1040,12 @@ function MCPAppsRendererBase({
   const readyFiredRef = useRef(false);
   useEffect(() => {
     if (readyFiredRef.current) return;
-    if (initCount > 0) {
+    // Wait for BOTH the AppBridge handshake AND the spinner to be completely hidden
+    if (initCount > 0 && !showSpinner) {
       readyFiredRef.current = true;
       onReady?.();
     }
-  }, [initCount, onReady]);
+  }, [initCount, showSpinner, onReady]);
 
   useEffect(() => {
     if (!iframeEffectivelyReady || !showSpinner) return;

--- a/libraries/typescript/packages/mcp-use/examples/server/ui/mcp-apps/index.ts
+++ b/libraries/typescript/packages/mcp-use/examples/server/ui/mcp-apps/index.ts
@@ -195,6 +195,9 @@ server.uiResource({
             console.error('Failed to parse props:', e);
           }
         }
+        
+        // Signal to the MCP screenshot pipeline that the widget is done rendering
+        document.body.setAttribute('data-view-ready', 'true');
       </script>
     </body>
     </html>

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/mcp-ui-adapter.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/mcp-ui-adapter.ts
@@ -250,6 +250,39 @@ export function createAppsSdkResource(
  * )
  * ```
  */
+/**
+ * Small script injected into every programmatic mcpApps widget.
+ * Fires a postMessage to the parent (SandboxedIframe proxy) once the page
+ * has loaded so that MCPAppsRenderer can call onReady() even for widgets
+ * that don't use the full AppBridge SDK.
+ */
+const MCP_APPS_READY_SCRIPT = `
+<script>
+(function () {
+  function signalReady() {
+    window.parent.postMessage({ type: 'mcp-use:widget-ready' }, '*');
+  }
+  if (document.readyState === 'complete' || document.readyState === 'interactive') {
+    signalReady();
+  } else {
+    window.addEventListener('load', signalReady);
+  }
+})();
+</script>`;
+
+/**
+ * Inject the readiness script into an HTML string just before </body>.
+ * Falls back to appending at the end if no </body> tag is present.
+ */
+function injectReadinessScript(html: string): string {
+  const tag = "</body>";
+  const idx = html.lastIndexOf(tag);
+  if (idx !== -1) {
+    return html.slice(0, idx) + MCP_APPS_READY_SCRIPT + html.slice(idx);
+  }
+  return html + MCP_APPS_READY_SCRIPT;
+}
+
 export function createMcpAppsResource(
   uri: string,
   htmlTemplate: string,
@@ -270,7 +303,9 @@ export function createMcpAppsResource(
   const resource: any = {
     uri,
     mimeType: "text/html;profile=mcp-app",
-    text: htmlTemplate,
+    // Inject readiness postMessage script so the screenshot CLI can detect
+    // when even simple programmatic widgets (without AppBridge) are ready.
+    text: injectReadinessScript(htmlTemplate),
   };
 
   // Build _meta.ui metadata per MCP Apps spec (SEP-1865):
@@ -300,6 +335,8 @@ export function createMcpAppsResource(
     resource,
   };
 }
+
+
 
 /**
  * Create a UIResource from a high-level definition


### PR DESCRIPTION
Fixes #1593

Programmatic widgets built with raw HTML strings (like greeting-card) had no way to signal the screenshot pipeline that they finished loading. This caused the CLI screenshot command to always time out after 30 seconds.

Fix:

- **mcp-ui-adapter.ts** — Automatically injects a tiny postMessage script before `</body>` in every programmatic mcpApps widget HTML.
- **MCPAppsRenderer.tsx** — Listens for the `mcp-use:widget-ready` message, hides the spinner, and fires `onReady()` so the CLI camera takes the screenshot instantly.
