### PR TITLE
fix(python): accept stdio configs without args

### DIFF
--- a/libraries/python/mcp_use/client/config.py
+++ b/libraries/python/mcp_use/client/config.py
@@ -62,15 +62,16 @@ def create_connector_from_config(
 
     # Stdio connector (command-based)
     if is_stdio_server(server_config) and not sandbox:
+        args = server_config.get("args", [])
         _telemetry.track_connector_init(
             connector_type="stdio",
             server_command=server_config["command"],
-            server_args=server_config["args"],
-            public_identifier=f"stdio:{server_config['command']} {' '.join(server_config['args'])}",
+            server_args=args,
+            public_identifier=(f"stdio:{server_config['command']}" + (f" {' '.join(args)}" if args else "")),
         )
         return StdioConnector(
             command=server_config["command"],
-            args=server_config["args"],
+            args=args,
             env=server_config.get("env", None),
             sampling_callback=sampling_callback,
             elicitation_callback=elicitation_callback,
@@ -83,15 +84,16 @@ def create_connector_from_config(
 
     # Sandboxed connector
     elif is_stdio_server(server_config) and sandbox:
+        args = server_config.get("args", [])
         _telemetry.track_connector_init(
             connector_type="sandbox",
             server_command=server_config["command"],
-            server_args=server_config["args"],
-            public_identifier=f"sandbox:{server_config['command']} {' '.join(server_config['args'])}",
+            server_args=args,
+            public_identifier=(f"sandbox:{server_config['command']}" + (f" {' '.join(args)}" if args else "")),
         )
         return SandboxConnector(
             command=server_config["command"],
-            args=server_config["args"],
+            args=args,
             env=server_config.get("env", None),
             e2b_options=sandbox_options,
             sampling_callback=sampling_callback,

--- a/libraries/python/mcp_use/client/connectors/stdio.py
+++ b/libraries/python/mcp_use/client/connectors/stdio.py
@@ -179,4 +179,4 @@ class StdioConnector(BaseConnector):
     @property
     def public_identifier(self) -> str:
         """Get the identifier for the connector."""
-        return f"stdio:{self.command} {' '.join(self.args)}"
+        return f"stdio:{self.command}" + (f" {' '.join(self.args)}" if self.args else "")

--- a/libraries/python/mcp_use/client/connectors/utils.py
+++ b/libraries/python/mcp_use/client/connectors/utils.py
@@ -10,4 +10,4 @@ def is_stdio_server(server_config: dict[str, Any]) -> bool:
     Returns:
         True if the server is a stdio server, False otherwise
     """
-    return "command" in server_config and "args" in server_config
+    return "command" in server_config

--- a/libraries/python/tests/unit/test_config.py
+++ b/libraries/python/tests/unit/test_config.py
@@ -215,6 +215,17 @@ class TestConnectorCreation(unittest.TestCase):
         self.assertEqual(connector.args, ["-m", "mcp_server"])
         self.assertIsNone(connector.env)
 
+    def test_create_stdio_connector_without_args(self):
+        """Test creating a stdio connector when args are omitted."""
+        server_config = {"command": "python"}
+
+        connector = create_connector_from_config(server_config)
+
+        self.assertIsInstance(connector, StdioConnector)
+        self.assertEqual(connector.command, "python")
+        self.assertEqual(connector.args, [])
+        self.assertIsNone(connector.env)
+
     def test_create_connector_invalid_config(self):
         """Test creating a connector with invalid config raises ValueError."""
         server_config = {"invalid": "config"}

--- a/libraries/python/tests/unit/test_stdio_connector.py
+++ b/libraries/python/tests/unit/test_stdio_connector.py
@@ -55,6 +55,12 @@ class TestStdioConnectorInitialization:
         assert connector._tools is None
         assert connector._connected is False
 
+    def test_public_identifier_without_args(self):
+        """Test that the public identifier has no trailing space when args are omitted."""
+        connector = StdioConnector(command="python")
+
+        assert connector.public_identifier == "stdio:python"
+
 
 class TestStdioConnectorConnection:
     """Tests for StdioConnector connection methods."""


### PR DESCRIPTION
## Language / Project Scope

Check all that apply:
- [ ] TypeScript
- [x] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

accept stdio server configs when `args` is omitted and trim the stdio public identifier so it does not include a trailing space for empty-args configs.

## Implementation Details

1. updated stdio connector detection to treat any config with `command` as stdio.
2. defaulted missing `args` to an empty list in connector creation so command-only configs work consistently.
3. trimmed `StdioConnector.public_identifier` to avoid trailing whitespace when no args are present.
4. added regression tests covering command-only stdio configs and the empty-args public identifier case.

---

## Python Checklist

### Pre-commit Checklist

Ensure all of the following have been completed:
- [x] Code formatted with `ruff format`
- [x] Linting passes with `ruff check`
- [x] Added or updated tests if needed
- [ ] Updated documentation if needed

## example usage (before)

```python
server_config = {"command": "python"}
create_connector_from_config(server_config)
# -> failed because args was required
```

## example usage (after)

```python
server_config = {"command": "python"}
create_connector_from_config(server_config)
# -> creates a StdioConnector with args=[]
```

## Documentation Updates

* no docs files were updated.

## Testing

- added unit coverage for command-only stdio configs in `tests/unit/test_config.py`.
- added a unit regression test for `StdioConnector.public_identifier` in `tests/unit/test_stdio_connector.py`.
- verified with `ruff check`, `ruff format`, and targeted `pytest` runs for both test files.

## Backwards Compatibility

backwards compatible and existing configs with `args` continue to work, and command-only stdio configs are now accepted.
