### PR TITLE
fix(python): reset agent state between runs

### DIFF
--- a/libraries/python/mcp_use/agents/mcpagent.py
+++ b/libraries/python/mcp_use/agents/mcpagent.py
@@ -691,6 +691,7 @@ class MCPAgent:
         success = False
         final_output = None
         steps_taken = 0
+        self.tools_used_names = []
 
         try:
             # 1. Initialize if needed
@@ -974,7 +975,7 @@ class MCPAgent:
             raise RuntimeError("MCP agent failed to initialise – call initialise() first?")
 
         # 2. Configure max steps -------------------------------------------------
-        self.max_steps = max_steps or self.max_steps
+        effective_max_steps = max_steps or self.max_steps
 
         # 3. Build inputs --------------------------------------------------------
         human_query = self._ensure_human_message(query)
@@ -983,7 +984,7 @@ class MCPAgent:
         inputs = {"messages": [*langchain_history, human_query]}
 
         # 4. Stream & collect response chunks ------------------------------------
-        recursion_limit = self.max_steps * 2
+        recursion_limit = effective_max_steps * 2
         # Collect AI message content from streaming chunks
         turn_messages = []
 

--- a/libraries/python/tests/unit/test_agent.py
+++ b/libraries/python/tests/unit/test_agent.py
@@ -279,6 +279,40 @@ class TestMCPAgentStream:
         assert outputs[-1] == "4"
 
     @pytest.mark.asyncio
+    async def test_stream_resets_tools_used_names_between_calls(self):
+        """stream() should reset tools_used_names for each run."""
+        llm = self._mock_llm()
+        client = MagicMock(spec=MCPClient)
+        agent = MCPAgent(llm=llm, client=client, max_steps=5)
+        agent.callbacks = []
+        agent.telemetry = MagicMock()
+
+        executor = MagicMock()
+        agent._agent_executor = executor
+        agent._initialized = True
+
+        async def mock_astream(inputs, stream_mode=None, config=None):
+            yield {
+                "agent": {
+                    "messages": [
+                        AIMessage(content="", tool_calls=[{"name": "add", "args": {"a": 2, "b": 2}, "id": "call_1"}])
+                    ]
+                }
+            }
+            yield {"tools": {"messages": [ToolMessage(content="4", tool_call_id="call_1")]}}
+            yield {"agent": {"messages": [AIMessage(content="4")]}}
+
+        executor.astream = MagicMock(side_effect=mock_astream)
+
+        async for _ in agent.stream("Add 2 and 2", manage_connector=False):
+            pass
+        assert agent.tools_used_names == ["add"]
+
+        async for _ in agent.stream("Add 2 and 2 again", manage_connector=False):
+            pass
+        assert agent.tools_used_names == ["add"]
+
+    @pytest.mark.asyncio
     async def test_stream_handles_block_tool_results_without_losing_history(self):
         """stream() should tolerate LangChain ToolMessage block content produced by richer tool outputs."""
         llm = self._mock_llm()
@@ -383,3 +417,32 @@ class TestMCPAgentStreamEvents:
         assert any(isinstance(message, AIMessage) and message.content == ai_message.content for message in history), (
             "Final AI message should be stored by stream_events()"
         )
+
+    @pytest.mark.asyncio
+    async def test_stream_events_does_not_mutate_max_steps_between_calls(self):
+        """stream_events() should use per-call max_steps without mutating the agent default."""
+        llm = self._mock_llm()
+        client = MagicMock(spec=MCPClient)
+        agent = MCPAgent(llm=llm, client=client, max_steps=5, memory_enabled=True)
+        agent.callbacks = []
+        agent.telemetry = MagicMock()
+
+        executor = MagicMock()
+        agent._agent_executor = executor
+        agent._initialized = True
+
+        recursion_limits: list[int] = []
+
+        async def mock_astream_events(inputs, config=None):
+            recursion_limits.append(config["recursion_limit"])
+            yield {"event": "on_chat_model_end", "data": {"output": AIMessage(content="done")}}
+
+        executor.astream_events = MagicMock(side_effect=mock_astream_events)
+
+        async for _ in agent.stream_events("First call", max_steps=3, manage_connector=False):
+            pass
+        async for _ in agent.stream_events("Second call", manage_connector=False):
+            pass
+
+        assert recursion_limits == [6, 10]
+        assert agent.max_steps == 5


### PR DESCRIPTION
## Language / Project Scope

Check all that apply:
- [ ] TypeScript
- [x] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

fix agent state leakage between consecutive runs by resetting per-run tool usage tracking and keeping `max_steps` scoped to each call.

## Implementation Details

1. reset `tools_used_names` at the start of `MCPAgent.stream()` so each run reports only its own tool usage.
2. replace the mutable `self.max_steps` assignment in `_generate_response_chunks_async()` with a local `effective_max_steps` value.
3. add regression tests covering repeated runs and per-call `max_steps` behavior.

---

## Python Checklist

### Pre-commit Checklist

Ensure all of the following have been completed:
- [x] Code formatted with `ruff format`
- [x] Linting passes with `ruff check`
- [x] Added or updated tests if needed
- [ ] Updated documentation if needed

## Example Usage (Before)

```python
# before, state could leak across calls:
await agent.stream("first query", max_steps=3)
await agent.stream("second query")
# tools_used_names and max_steps could reflect the previous call
```

## Example Usage (After)

```python
# after, each call is isolated:
await agent.stream("first query", max_steps=3)
await agent.stream("second query")
# tools_used_names and max_steps are independent per call
```

## Documentation Updates


## Testing

- added a unit regression test to verify `tools_used_names` resets between consecutive `stream()` calls.
- added a unit regression test to verify `stream_events()` does not mutate the agent’s default `max_steps`.
- verified with `ruff format`, `ruff check`, and targeted `pytest` runs for the new tests.

## Backwards Compatibility

backwards compatible as this is a bug fix that restores per-call isolation without changing public APIs.

