### PR TITLE
Hash Claude resource domains from authored ui.domain

### DIFF
--- a/libraries/typescript/packages/mcp-use/src/server/sessions/session-manager.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/sessions/session-manager.ts
@@ -8,6 +8,7 @@
 import type { Context } from "hono";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { Implementation } from "@modelcontextprotocol/sdk/types.js";
 
 /**
  * Serializable session metadata
@@ -23,7 +24,7 @@ export interface SessionMetadata {
   /** Client capabilities advertised during initialization */
   clientCapabilities?: Record<string, unknown>;
   /** Client info (name, version) */
-  clientInfo?: Record<string, unknown>;
+  clientInfo?: Implementation;
   /** Protocol version negotiated during initialization */
   protocolVersion?: string;
   /** Progress token for current tool call (if any) */

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/protocol-helpers.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/protocol-helpers.ts
@@ -5,6 +5,9 @@
  * Reduces duplication in ui-resource-registration.ts
  */
 
+import { createHash } from "node:crypto";
+import type { Implementation } from "@modelcontextprotocol/sdk/types.js";
+
 import { McpAppsAdapter } from "./adapters/mcp-apps.js";
 import { AppsSdkAdapter } from "./adapters/apps-sdk.js";
 import type { UIResourceDefinition } from "../types/resource.js";
@@ -112,6 +115,50 @@ export function buildResourceUiMeta(
   }
 
   return uiMeta && Object.keys(uiMeta).length > 0 ? uiMeta : undefined;
+}
+
+export function isClaudeClient(clientInfo: Implementation): boolean {
+  return clientInfo.name.toLowerCase().includes("claude");
+}
+
+export function computeClaudeResourceDomain(domain: string): string {
+  if (domain.endsWith(".claudemcpcontent.com")) {
+    return domain;
+  }
+
+  return `${createHash("sha256")
+    .update(domain)
+    .digest("hex")
+    .slice(0, 32)}.claudemcpcontent.com`;
+}
+
+export function getMcpUiResourceDomain(
+  resource: { _meta?: Record<string, unknown> }
+): string | undefined {
+  const uiMeta = resource._meta?.ui as Record<string, unknown> | undefined;
+  const domain = uiMeta?.domain;
+  return typeof domain === "string" && domain.length > 0 ? domain : undefined;
+}
+
+export function applyClaudeResourceDomain(
+  resource: { _meta?: Record<string, unknown> },
+  clientInfo: Implementation
+): void {
+  if (!isClaudeClient(clientInfo)) {
+    return;
+  }
+
+  const domain = getMcpUiResourceDomain(resource);
+  if (!domain) {
+    return;
+  }
+
+  resource._meta = resource._meta ?? {};
+  const uiMeta = resource._meta.ui as Record<string, unknown> | undefined;
+  resource._meta.ui = {
+    ...uiMeta,
+    domain: computeClaudeResourceDomain(domain),
+  };
 }
 
 /**

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/protocol-helpers.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/protocol-helpers.ts
@@ -132,9 +132,9 @@ export function computeClaudeResourceDomain(domain: string): string {
     .slice(0, 32)}.claudemcpcontent.com`;
 }
 
-export function getMcpUiResourceDomain(
-  resource: { _meta?: Record<string, unknown> }
-): string | undefined {
+export function getMcpUiResourceDomain(resource: {
+  _meta?: Record<string, unknown>;
+}): string | undefined {
   const uiMeta = resource._meta?.ui as Record<string, unknown> | undefined;
   const domain = uiMeta?.domain;
   return typeof domain === "string" && domain.length > 0 ? domain : undefined;

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/ui-resource-registration.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/ui-resource-registration.ts
@@ -24,11 +24,16 @@ import {
   type WidgetServerConfig,
 } from "./widget-helpers.js";
 import {
+  applyClaudeResourceDomain,
   buildDualProtocolMetadata,
   buildResourceUiMeta,
   generateToolOutput,
+  getMcpUiResourceDomain,
   getBuildIdPart,
 } from "./protocol-helpers.js";
+import { getRequestContext } from "../context-storage.js";
+import { findSessionContext } from "../tools/tool-execution-helpers.js";
+import type { SessionData } from "../sessions/session-manager.js";
 
 /**
  * Minimal server interface for UI resource registration
@@ -51,7 +56,7 @@ interface UIResourceServer {
     resourceTemplates: Map<string, any>;
   };
   /** Active sessions for sending notifications (for HMR updates) */
-  sessions?: Map<string, { server?: { sendToolListChanged?: () => void } }>;
+  sessions?: Map<string, SessionData>;
   resource: (
     definition: ResourceDefinition | ResourceDefinitionWithoutCallback,
     callback?: any
@@ -315,6 +320,26 @@ export function uiResourceRegistration<T extends UIResourceServer>(
     return (full as UIResourceDefinition) ?? enrichedDefinition;
   };
 
+  const applyHostResourceMetadata = (uiResource: {
+    resource: { _meta?: Record<string, unknown> };
+  }) => {
+    if (!getMcpUiResourceDomain(uiResource.resource)) {
+      return;
+    }
+
+    const sessions = server.sessions || new Map();
+    const { session } = findSessionContext(
+      sessions,
+      getRequestContext(),
+      undefined,
+      undefined
+    );
+
+    if (session?.clientInfo) {
+      applyClaudeResourceDomain(uiResource.resource, session.clientInfo);
+    }
+  };
+
   const resourceReadCallback = async () => {
     const latestDef = getLatestDefinition();
     const params =
@@ -329,6 +354,7 @@ export function uiResourceRegistration<T extends UIResourceServer>(
     );
 
     uiResource.resource.uri = resourceUri;
+    applyHostResourceMetadata(uiResource);
 
     return {
       contents: [uiResource.resource],
@@ -347,6 +373,7 @@ export function uiResourceRegistration<T extends UIResourceServer>(
     );
 
     uiResource.resource.uri = uri.toString();
+    applyHostResourceMetadata(uiResource);
 
     return {
       contents: [uiResource.resource],

--- a/libraries/typescript/packages/mcp-use/tests/unit/server/protocol-helpers.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/server/protocol-helpers.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyClaudeResourceDomain,
+  computeClaudeResourceDomain,
+  isClaudeClient,
+} from "../../../src/server/widgets/protocol-helpers.js";
+
+describe("protocol helpers", () => {
+  describe("Claude resource domains", () => {
+    it("detects Claude clients by advertised client name", () => {
+      expect(isClaudeClient({ name: "claude-desktop", version: "1.0.0" })).toBe(
+        true
+      );
+      expect(isClaudeClient({ name: "Claude Code", version: "1.0.0" })).toBe(
+        true
+      );
+      expect(isClaudeClient({ name: "test-client", version: "1.0.0" })).toBe(
+        false
+      );
+    });
+
+    it("computes Claude's hash-based resource domain from ui.domain", () => {
+      expect(computeClaudeResourceDomain("https://example.com/mcp")).toBe(
+        "c3d80a4ed901ee05b21755a88273b4a4.claudemcpcontent.com"
+      );
+    });
+
+    it("does not hash an already computed Claude domain again", () => {
+      const domain = "c3d80a4ed901ee05b21755a88273b4a4.claudemcpcontent.com";
+
+      expect(computeClaudeResourceDomain(domain)).toBe(domain);
+    });
+
+    it("rewrites only ui.domain for Claude while preserving other metadata", () => {
+      const resource = {
+        _meta: {
+          "mcp-use/propsSchema": { message: { type: "string" } },
+          ui: {
+            domain: "https://example.com/mcp",
+            prefersBorder: true,
+            csp: {
+              connectDomains: ["https://example.com"],
+            },
+          },
+        },
+      };
+
+      applyClaudeResourceDomain(resource, {
+        name: "claude-desktop",
+        version: "1.0.0",
+      });
+
+      expect(resource._meta.ui).toEqual({
+        domain: "c3d80a4ed901ee05b21755a88273b4a4.claudemcpcontent.com",
+        prefersBorder: true,
+        csp: {
+          connectDomains: ["https://example.com"],
+        },
+      });
+      expect(resource._meta["mcp-use/propsSchema"]).toEqual({
+        message: { type: "string" },
+      });
+    });
+
+    it("leaves non-Claude resource domains unchanged", () => {
+      const resource = {
+        _meta: {
+          ui: {
+            domain: "https://example.com/mcp",
+          },
+        },
+      };
+
+      applyClaudeResourceDomain(resource, {
+        name: "test-client",
+        version: "1.0.0",
+      });
+
+      expect(resource._meta.ui.domain).toBe("https://example.com/mcp");
+    });
+  });
+});

--- a/libraries/typescript/packages/mcp-use/tests/unit/server/ui-resource-registration.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/server/ui-resource-registration.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { MCPServer } from "../../../src/server/mcp-server.js";
+import { runWithContext } from "../../../src/server/context-storage.js";
+
+describe("uiResourceRegistration", () => {
+  it("hashes resource _meta.ui.domain for Claude resource reads", async () => {
+    const server = new MCPServer({
+      name: "test-server",
+      version: "1.0.0",
+    });
+
+    server.uiResource({
+      type: "mcpApps",
+      name: "domain-widget",
+      title: "Domain Widget",
+      description: "Widget with a host-specific domain",
+      htmlTemplate: "<div>Domain widget</div>",
+      metadata: {
+        domain: "https://example.com/mcp",
+        prefersBorder: true,
+      },
+    });
+
+    const requestContext = {} as any;
+    server.sessions.set("session-1", {
+      context: requestContext,
+      clientInfo: { name: "claude-desktop", version: "1.0.0" },
+    } as any);
+
+    const resourceRegistration = server.registrations.resources.get(
+      "domain-widget:ui://widget/domain-widget.html"
+    );
+    expect(resourceRegistration).toBeDefined();
+
+    const result = await runWithContext(requestContext, () =>
+      resourceRegistration!.handler()
+    );
+    const resource = result.contents[0];
+
+    expect(resource._meta?.ui).toMatchObject({
+      domain: "c3d80a4ed901ee05b21755a88273b4a4.claudemcpcontent.com",
+      prefersBorder: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Hash `resource._meta.ui.domain` into Claude's `*.claudemcpcontent.com` format only when the connecting client is Claude
- Skip the session lookup entirely when no `ui.domain` was authored
- Add unit coverage for the domain transform and resource-read wiring

https://claude.com/docs/connectors/building/mcp-apps/cross-compatibility#domain-handling

## Testing
- `vitest run tests/unit/server/protocol-helpers.test.ts tests/unit/server/ui-resource-registration.test.ts`
- `tsc --noEmit`