### PR TITLE
Add MCP server instructions to TypeScript docs and templates

### DIFF
--- a/docs/typescript/getting-started/installation.mdx
+++ b/docs/typescript/getting-started/installation.mdx
@@ -111,7 +111,6 @@ const server = new MCPServer({
   title: "My Server", // display name
   version: "1.0.0",
   description: "My custom MCP server",
-  instructions: "Use get_weather when the user asks about current city weather.",
   websiteUrl: "https://mcp-use.com",
   favicon: "favicon.ico",
   icons: [

--- a/docs/typescript/getting-started/installation.mdx
+++ b/docs/typescript/getting-started/installation.mdx
@@ -50,6 +50,7 @@ Check out [UI Widgets](/typescript/server/mcp-apps) with support to MCP-UI and O
 The generated project includes pre-configured server metadata that is visible in MCP Inspector and MCP clients:
 
 - **Name & Title**: Both set to your project name (customizable in `index.ts`)
+- **Instructions**: Model-facing guidance for cross-tool workflows and server-wide constraints
 - **Icons**: mcp-use branding icons included in `public/` folder
 - **Website URL**: Defaults to https://mcp-use.com (customizable)
 - **Favicon**: Included for browser display
@@ -69,6 +70,7 @@ const server = new MCPServer({
   title: 'My Custom Title',    // display name - shown in clients
   version: '1.0.0',
   description: 'My awesome server',
+  instructions: 'Use lookup tools before write tools; ask for confirmation before changes.',
   websiteUrl: 'https://my-site.com',  // Your website or docs
   favicon: 'favicon.ico',      // Already in public/ folder
   icons: [
@@ -109,6 +111,7 @@ const server = new MCPServer({
   title: "My Server", // display name
   version: "1.0.0",
   description: "My custom MCP server",
+  instructions: "Use get_weather when the user asks about current city weather.",
   websiteUrl: "https://mcp-use.com",
   favicon: "favicon.ico",
   icons: [

--- a/docs/typescript/getting-started/quickstart.mdx
+++ b/docs/typescript/getting-started/quickstart.mdx
@@ -172,7 +172,7 @@ This command will create a new MCP server with:
 - A complete TypeScript MCP server project structure.
 - Example MCP Tools and Resources to get you started.
 - Example UI Widgets React components in `resources/` folder exposed as tools and resources in MCP Apps and ChatGPT Apps SDK format.
-- Pre-configured server metadata (title, icons, websiteUrl) with your project name.
+- Pre-configured server metadata (title, instructions, icons, websiteUrl) with your project name.
 - Hot Module Reloading (HMR) - modify tools/prompts/resources without restarting or dropping connections.
 - Automatically launches an MCP Inspector in your browser to test your server.
 

--- a/docs/typescript/server/configuration.mdx
+++ b/docs/typescript/server/configuration.mdx
@@ -23,6 +23,7 @@ const server = new MCPServer({
   // ── Identity (shown in Inspector / MCP clients) ───────────
   title: 'My Server',                   // Display name (defaults to name)
   description: 'What this server does', // Shown during discovery
+  instructions: 'Use search before fetch-details; confirm before writes.',
   websiteUrl: 'https://myserver.com',
   favicon: 'favicon.ico',               // Relative to public/ dir
   icons: [
@@ -65,6 +66,22 @@ await server.listen(3000)
 **Port resolution order:** `listen(port)` argument → `--port` CLI flag → `PORT` env var → `3000`
 
 **Base URL resolution order:** `baseUrl` config → `MCP_URL` env var → `http://{host}:{port}`
+
+### Server Instructions
+
+`instructions` are returned during MCP initialization so compatible clients can use them as model-facing guidance for your server. Use them for cross-tool workflows, constraints, and server-wide behavior that does not belong in a single tool description:
+
+```typescript
+const server = new MCPServer({
+  name: 'inventory-server',
+  version: '1.0.0',
+  description: 'Inventory lookup and order preparation',
+  instructions:
+    'Call search-products before get-product-details. Confirm availability before preparing an order.',
+})
+```
+
+Keep instructions short and specific. Tool descriptions should still explain what each individual tool does.
 
 ### Environment Variables
 

--- a/docs/typescript/server/creating-mcp-apps-server.mdx
+++ b/docs/typescript/server/creating-mcp-apps-server.mdx
@@ -457,6 +457,8 @@ const server = new MCPServer({
   name: "my-widget-server",
   version: "1.0.0",
   description: "MCP server with widget support",
+  instructions:
+    "Use search-tools for visual search results before get-product-details.",
   baseUrl: process.env.MCP_URL || "http://localhost:3000",
 });
 

--- a/docs/typescript/server/mcp-apps.mdx
+++ b/docs/typescript/server/mcp-apps.mdx
@@ -84,6 +84,8 @@ import { MCPServer } from "mcp-use/server";
 const server = new MCPServer({
   name: "my-server",
   version: "1.0.0",
+  instructions:
+    "Use weather-display when the user wants a visual forecast or comparison.",
   baseUrl: process.env.MCP_URL || "http://localhost:3000",
 });
 

--- a/docs/typescript/server/mcp-apps.mdx
+++ b/docs/typescript/server/mcp-apps.mdx
@@ -85,7 +85,7 @@ const server = new MCPServer({
   name: "my-server",
   version: "1.0.0",
   instructions:
-    "Use weather-display when the user wants a visual forecast or comparison.",
+    "For ecommerce requests, check product availability before starting checkout or suggesting substitutions.",
   baseUrl: process.env.MCP_URL || "http://localhost:3000",
 });
 

--- a/libraries/typescript/.changeset/bright-maps-instruct.md
+++ b/libraries/typescript/.changeset/bright-maps-instruct.md
@@ -1,5 +1,5 @@
 ---
-"mcp-use": patch
+"mcp-use": minor
 "create-mcp-use-app": patch
 ---
 

--- a/libraries/typescript/.changeset/bright-maps-instruct.md
+++ b/libraries/typescript/.changeset/bright-maps-instruct.md
@@ -1,0 +1,6 @@
+---
+"mcp-use": patch
+"create-mcp-use-app": patch
+---
+
+Add MCP server instructions support to TypeScript server configuration and scaffolded templates.

--- a/libraries/typescript/packages/create-mcp-use-app/src/templates/blank/index.ts
+++ b/libraries/typescript/packages/create-mcp-use-app/src/templates/blank/index.ts
@@ -6,8 +6,6 @@ const server = new MCPServer({
   title: "{{PROJECT_NAME}}", // display name
   version: "1.0.0",
   description: "Blank mcp-use server",
-  instructions:
-    "Describe when and how clients should use this server's tools, resources, and prompts.",
   baseUrl: process.env.MCP_URL || "http://localhost:3000", // Full base URL (e.g., https://myserver.com)
   favicon: "favicon.ico",
   websiteUrl: "https://mcp-use.com", // Can be customized later

--- a/libraries/typescript/packages/create-mcp-use-app/src/templates/blank/index.ts
+++ b/libraries/typescript/packages/create-mcp-use-app/src/templates/blank/index.ts
@@ -6,6 +6,8 @@ const server = new MCPServer({
   title: "{{PROJECT_NAME}}", // display name
   version: "1.0.0",
   description: "Blank mcp-use server",
+  instructions:
+    "Describe when and how clients should use this server's tools, resources, and prompts.",
   baseUrl: process.env.MCP_URL || "http://localhost:3000", // Full base URL (e.g., https://myserver.com)
   favicon: "favicon.ico",
   websiteUrl: "https://mcp-use.com", // Can be customized later

--- a/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/index.ts
+++ b/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/index.ts
@@ -6,6 +6,8 @@ const server = new MCPServer({
   title: "{{PROJECT_NAME}}", // display name
   version: "1.0.0",
   description: "MCP server with MCP Apps integration",
+  instructions:
+    "Use search-tools to find fruit matches before calling get-fruit-details. Prefer the widget result when the user wants to browse or compare options visually.",
   baseUrl: process.env.MCP_URL || "http://localhost:3000", // Full base URL (e.g., https://myserver.com)
   favicon: "favicon.ico",
   websiteUrl: "https://mcp-use.com", // Can be customized later

--- a/libraries/typescript/packages/create-mcp-use-app/src/templates/starter/index.ts
+++ b/libraries/typescript/packages/create-mcp-use-app/src/templates/starter/index.ts
@@ -7,6 +7,8 @@ const server = new MCPServer({
   title: "{{PROJECT_NAME}}", // display name
   version: "1.0.0",
   description: "My first MCP server with all features",
+  instructions:
+    "Use fetch-weather for current conditions, read config://settings before assuming user preferences, and use review-code only when the user asks for code feedback.",
   baseUrl: process.env.MCP_URL || "http://localhost:3000", // Full base URL (e.g., https://myserver.com)
   favicon: "favicon.ico",
   websiteUrl: "https://mcp-use.com", // Can be customized later

--- a/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
@@ -2298,6 +2298,7 @@ class MCPServerClass<HasOAuth extends boolean = false> {
    * @param config.sessionIdleTimeoutMs - Session idle timeout (default: 86400000 = 1 day)
    * @param config.cors - Optional CORS configuration overrides
    * @param config.allowedOrigins - Allowed origins for DNS rebinding host validation
+   * @param config.instructions - Server-wide model instructions returned during MCP initialization
    *
    * @returns Proxied server instance supporting both MCP and Hono methods
    *
@@ -2401,6 +2402,7 @@ class MCPServerClass<HasOAuth extends boolean = false> {
         icons: processIconUrls(config.icons, config.baseUrl),
       },
       {
+        instructions: config.instructions,
         capabilities: {
           logging: {},
           completions: {},
@@ -2672,6 +2674,7 @@ class MCPServerClass<HasOAuth extends boolean = false> {
         icons: processIconUrls(this.config.icons, this.serverBaseUrl),
       },
       {
+        instructions: this.config.instructions,
         capabilities: {
           logging: {},
           completions: {},

--- a/libraries/typescript/packages/mcp-use/src/server/types/common.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/types/common.ts
@@ -58,6 +58,16 @@ export interface ServerConfig {
    */
   description?: string;
   /**
+   * Instructions for AI models using this server.
+   *
+   * Use this for server-wide guidance such as cross-tool workflows,
+   * ordering constraints, or safety requirements. Do not repeat
+   * individual tool descriptions here.
+   *
+   * @example "Call search-products before get-product-details. Confirm inventory before creating orders."
+   */
+  instructions?: string;
+  /**
    * Hostname for widget URLs and server endpoints.
    * Defaults to 'localhost' in development.
    *


### PR DESCRIPTION
Closes #1595\n\n## Summary\n- Add TypeScript MCPServer config support for MCP server instructions and pass it through to the underlying SDK server instances.\n- Update create-mcp-use-app templates to include example server instructions.\n- Document server instructions in TypeScript configuration and getting started docs.\n- Add a TypeScript changeset for mcp-use and create-mcp-use-app.\n\n## Verification\n- git diff --check HEAD~1..HEAD\n- Confirmed @modelcontextprotocol/sdk@1.27.1 exposes ServerOptions.instructions?: string.\n\nNote: Full TypeScript build was not run locally because dependency installation failed with ENOSPC (no space left on device).