### PR TITLE
Move mcp-apps template pnpm settings to workspace config

### DIFF
--- a/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/package.json
+++ b/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/package.json
@@ -42,10 +42,5 @@
     "@types/react-dom": "^19.2.3",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3"
-  },
-  "pnpm": {
-    "overrides": {
-      "lodash": ">=4.18.0"
-    }
   }
 }

--- a/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/pnpm-workspace.yaml
+++ b/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+overrides:
+  lodash: ">=4.18.0"


### PR DESCRIPTION
## Summary
- move the generated mcp-apps template pnpm override into pnpm-workspace.yaml
- remove the ignored package.json pnpm config that triggers pnpm v10 warnings

## Test
- pnpm install --lockfile-only --ignore-scripts