### PR TITLE
fix(cli): align widget asset base URL with production routes

### DIFF
--- a/libraries/typescript/.changeset/fix-widget-build-base-url.md
+++ b/libraries/typescript/.changeset/fix-widget-build-base-url.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/cli": patch
+---
+
+Fix widget build asset base URLs when `MCP_URL` is set so generated bundles use the production `/mcp-use/widgets/<widget>/` route.

--- a/libraries/typescript/packages/cli/src/index.ts
+++ b/libraries/typescript/packages/cli/src/index.ts
@@ -36,6 +36,7 @@ import {
   withNextShimsEnv,
 } from "./utils/next-shims.js";
 import { notifyIfUpdateAvailable } from "./utils/update-check.js";
+import { getWidgetBuildBaseUrl } from "./utils/widget-base-url.js";
 const program = new Command();
 
 const packageContent = readFileSync(
@@ -783,10 +784,8 @@ if (container && Component) {
       widgetName
     );
 
-    // Set base URL: use MCP_URL if set, otherwise relative path
-    const baseUrl = mcpUrl
-      ? `${mcpUrl}/${widgetName}/`
-      : `/mcp-use/widgets/${widgetName}/`;
+    // Set base URL to the same route used by the production widget server.
+    const baseUrl = getWidgetBuildBaseUrl(widgetName, mcpUrl);
 
     // Extract metadata from widget before building
     let widgetMetadata: any = {};
@@ -1167,7 +1166,8 @@ export default {
           // Inject window.__mcpPublicUrl and window.__getFile into <head>
           // Note: __mcpPublicUrl uses standard format for useWidget to derive mcp_url
           // __mcpPublicAssetsUrl points to where public files are actually stored
-          const injectionScript = `<script>window.__getFile = (filename) => { return "${mcpUrl}/${widgetName}/"+filename }; window.__mcpPublicUrl = "${mcpServerUrl}/mcp-use/public"; window.__mcpPublicAssetsUrl = "${mcpUrl}/public";</script>`;
+          const widgetPublicBaseUrl = getWidgetBuildBaseUrl(widgetName, mcpUrl);
+          const injectionScript = `<script>window.__getFile = (filename) => { return "${widgetPublicBaseUrl}"+filename }; window.__mcpPublicUrl = "${mcpServerUrl}/mcp-use/public"; window.__mcpPublicAssetsUrl = "${mcpUrl}/public";</script>`;
 
           // Check if script tag already exists in head
           if (!html.includes("window.__mcpPublicUrl")) {

--- a/libraries/typescript/packages/cli/src/utils/widget-base-url.ts
+++ b/libraries/typescript/packages/cli/src/utils/widget-base-url.ts
@@ -1,0 +1,21 @@
+const PRODUCTION_WIDGET_ROUTE = "/mcp-use/widgets";
+
+/**
+ * Return the Vite base URL that matches the production widget static route.
+ *
+ * The production server mounts built widget assets under
+ * /mcp-use/widgets/:widget/assets/*, so builds that use an absolute MCP_URL
+ * must keep the same route prefix instead of publishing assets under
+ * /:widget/assets/*.
+ */
+export function getWidgetBuildBaseUrl(
+  widgetName: string,
+  mcpUrl?: string
+): string {
+  const widgetRoute = `${PRODUCTION_WIDGET_ROUTE}/${widgetName}/`;
+  if (!mcpUrl) {
+    return widgetRoute;
+  }
+
+  return `${mcpUrl.replace(/\/+$/, "")}${widgetRoute}`;
+}

--- a/libraries/typescript/packages/cli/tests/widget-base-url.test.ts
+++ b/libraries/typescript/packages/cli/tests/widget-base-url.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { getWidgetBuildBaseUrl } from "../src/utils/widget-base-url.js";
+
+describe("widget build base URL", () => {
+  it("uses the production widget route under MCP_URL", () => {
+    expect(
+      getWidgetBuildBaseUrl("chart-widget", "https://my-slug.run.mcp-use.com")
+    ).toBe("https://my-slug.run.mcp-use.com/mcp-use/widgets/chart-widget/");
+  });
+
+  it("trims a trailing slash from MCP_URL before appending the widget route", () => {
+    expect(
+      getWidgetBuildBaseUrl("chart-widget", "https://my-slug.run.mcp-use.com/")
+    ).toBe("https://my-slug.run.mcp-use.com/mcp-use/widgets/chart-widget/");
+  });
+
+  it("keeps the existing relative production route when MCP_URL is unset", () => {
+    expect(getWidgetBuildBaseUrl("chart-widget")).toBe(
+      "/mcp-use/widgets/chart-widget/"
+    );
+  });
+});


### PR DESCRIPTION
## Changes
Fix widget builds created with `MCP_URL` so generated asset URLs keep the production widget route prefix.

## Implementation Details
1. Added a small `getWidgetBuildBaseUrl()` helper for `@mcp-use/cli`.
2. Reused it for Vite's widget build `base` and for the static-deployment `window.__getFile` helper.
3. Added a regression test covering absolute `MCP_URL`, trailing slashes, and the unset/default route.
4. Added a patch changeset for `@mcp-use/cli`.

## Testing
- [x] `pnpm dlx vitest@4.0.17 run --config /tmp/mcp-use-vitest.config.mjs /Users/clawuser/workspace/opensource/2026-06-03/mcp-use_mcp-use/libraries/typescript/packages/cli/tests/widget-base-url.test.ts`
- [x] `pnpm dlx tsx@4.21.0` manual assertions for `getWidgetBuildBaseUrl`
- [x] `pnpm dlx prettier@3.8.2 --check` on changed files

## Backwards Compatibility
Non-breaking: relative widget builds still use `/mcp-use/widgets/<widget>/`; builds with `MCP_URL` now match the production static route.

Closes #1553
