### PR TITLE
fix(inspector): widget fullscreen above embedded host chrome (MCP-2181)

### DIFF
--- a/.github/workflows/bump-mcp-use-reusable.yml
+++ b/.github/workflows/bump-mcp-use-reusable.yml
@@ -63,7 +63,7 @@ jobs:
 
           if [ "${{ steps.pm.outputs.pm }}" = "pnpm" ]; then
             corepack enable
-            pnpm install --config.dangerously-allow-all-builds=true
+            pnpm install --no-frozen-lockfile --config.dangerously-allow-all-builds=true
             pnpm run build
           else
             npm install

--- a/.github/workflows/bump-mcp-use-reusable.yml
+++ b/.github/workflows/bump-mcp-use-reusable.yml
@@ -30,8 +30,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
 
       - name: Detect package manager
         id: pm

--- a/.github/workflows/bump-mcp-use-reusable.yml
+++ b/.github/workflows/bump-mcp-use-reusable.yml
@@ -1,0 +1,90 @@
+name: Bump mcp-use (reusable)
+
+on:
+  workflow_call:
+
+permissions:
+  contents: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve npm stable mcp-use version
+        id: target
+        run: |
+          TARGET="$(npm view mcp-use version)"
+          echo "version=$TARGET" >> "$GITHUB_OUTPUT"
+          echo "caret=^${TARGET}" >> "$GITHUB_OUTPUT"
+          echo "Target mcp-use: $TARGET (^${TARGET})"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Detect package manager
+        id: pm
+        run: |
+          if [ -f pnpm-lock.yaml ] || grep -q '"packageManager".*pnpm' package.json 2>/dev/null; then
+            echo "pm=pnpm" >> "$GITHUB_OUTPUT"
+          else
+            echo "pm=npm" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Bump, install, and build
+        id: bump
+        env:
+          TARGET: ${{ steps.target.outputs.version }}
+          CARET: ${{ steps.target.outputs.caret }}
+        run: |
+          set -e
+          CURRENT="$(node -p "require('./package.json').dependencies?.['mcp-use'] ?? require('./package.json').devDependencies?.['mcp-use'] ?? ''")"
+          echo "Current specifier: ${CURRENT:-<none>}"
+
+          rm -rf node_modules
+          node -e "
+            const fs = require('fs');
+            const p = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            p.dependencies = p.dependencies || {};
+            p.dependencies['mcp-use'] = process.env.CARET;
+            fs.writeFileSync('package.json', JSON.stringify(p, null, 2) + '\n');
+          "
+
+          if [ "${{ steps.pm.outputs.pm }}" = "pnpm" ]; then
+            corepack enable
+            pnpm install --config.dangerously-allow-all-builds=true
+            pnpm run build
+          else
+            npm install
+            npm run build
+          fi
+
+          INSTALLED="$(node -p "require('./node_modules/mcp-use/package.json').version")"
+          echo "Installed mcp-use@${INSTALLED}"
+
+      - name: Commit and push
+        env:
+          TARGET: ${{ steps.target.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add package.json
+          [ -f pnpm-lock.yaml ] && git add pnpm-lock.yaml
+          [ -f package-lock.json ] && git add package-lock.json
+          if git diff --cached --quiet; then
+            echo "No changes to commit (already on mcp-use ${TARGET})."
+            exit 0
+          fi
+          git commit -m "chore(deps): bump mcp-use to ${TARGET}"
+          git push

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -30,11 +30,6 @@
   "icons": {
     "library": "lucide"
   },
-  "banner": {
-    "content": "Launch Week 1 is here. See everything we shipped. [Read more →](https://manufact.com/launchweek/1)",
-    "dismissible": true,
-    "type": "info"
-  },
   "feedback": {
     "thumbsRating": true,
     "suggestEdit": true,

--- a/libraries/typescript/.changeset/fix-widget-fullscreen-cloud-chrome.md
+++ b/libraries/typescript/.changeset/fix-widget-fullscreen-cloud-chrome.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Fix MCP App and ChatGPT App widget fullscreen overlays rendering below embedded host chrome (e.g. cloud chat headers). Fullscreen shells are portaled to `document.body` at `z-[100]`, expose `data-mcp-widget-fullscreen` on the document root for hosts, and show the exit navbar in CSS fullscreen fallback for Apps SDK widgets.

--- a/libraries/typescript/.changeset/fix-widget-fullscreen-cloud-chrome.md
+++ b/libraries/typescript/.changeset/fix-widget-fullscreen-cloud-chrome.md
@@ -2,4 +2,4 @@
 "@mcp-use/inspector": patch
 ---
 
-Fix MCP App and ChatGPT App widget fullscreen overlays rendering below embedded host chrome (e.g. cloud chat headers). Fullscreen shells are portaled to `document.body` at `z-[100]`, expose `data-mcp-widget-fullscreen` on the document root for hosts, and show the exit navbar in CSS fullscreen fallback for Apps SDK widgets.
+Fix cloud chat widget fullscreen (MCP-2181): prefer native `requestFullscreen()` so the widget stays mounted and host chrome is hidden via the browser top layer. CSS `fixed inset-0` overlay applies only when the Fullscreen API fails. Sets `data-mcp-widget-fullscreen` on the document root for optional host chrome hiding in CSS fallback.

--- a/libraries/typescript/.changeset/fix-widget-fullscreen-cloud-chrome.md
+++ b/libraries/typescript/.changeset/fix-widget-fullscreen-cloud-chrome.md
@@ -2,4 +2,4 @@
 "@mcp-use/inspector": patch
 ---
 
-Fix cloud chat widget fullscreen (MCP-2181): prefer native `requestFullscreen()` so the widget stays mounted and host chrome is hidden via the browser top layer. CSS `fixed inset-0` overlay applies only when the Fullscreen API fails. Sets `data-mcp-widget-fullscreen` on the document root for optional host chrome hiding in CSS fallback.
+Fix cloud chat widget fullscreen (MCP-2181): prefer native `requestFullscreen()` on the iframe wrapper so the widget stays mounted and host chrome is hidden via the browser top layer. Route widget `ui/request-display-mode` through the same path; avoid resetting MCP Apps / OpenAI load state on display-mode toggles. CSS `fixed inset-0` overlay applies only when the Fullscreen API fails. Sets `data-mcp-widget-fullscreen` on the document root for optional host chrome hiding in CSS fallback.

--- a/libraries/typescript/.changeset/fix-widget-fullscreen-cloud-chrome.md
+++ b/libraries/typescript/.changeset/fix-widget-fullscreen-cloud-chrome.md
@@ -2,4 +2,4 @@
 "@mcp-use/inspector": patch
 ---
 
-Fix cloud chat widget fullscreen (MCP-2181): prefer native `requestFullscreen()` on the iframe wrapper so the widget stays mounted and host chrome is hidden via the browser top layer. Route widget `ui/request-display-mode` through the same path; avoid resetting MCP Apps / OpenAI load state on display-mode toggles. CSS `fixed inset-0` overlay applies only when the Fullscreen API fails. Sets `data-mcp-widget-fullscreen` on the document root for optional host chrome hiding in CSS fallback.
+Fix cloud chat widget display modes (MCP-2181): native fullscreen on the widget shell with exit navbar; PiP portaled to `document.body` at `z-[100]`. Reconnect AppBridge after sandbox iframe remounts so display-mode toggles do not leave the widget stuck loading. Sets `data-mcp-widget-display-mode` on the document root.

--- a/libraries/typescript/packages/inspector/src/client/components/FullscreenNavbar.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/FullscreenNavbar.tsx
@@ -17,7 +17,7 @@ export function FullscreenNavbar({
   return (
     <div
       className={cn(
-        "fixed top-0 left-0 right-0 z-50 flex items-center justify-between px-4 py-3",
+        "shrink-0 z-50 flex w-full items-center justify-between px-4 py-3",
         "bg-background/80 backdrop-blur-md border-b border-border",
         "supports-[backdrop-filter]:bg-background/60",
         className

--- a/libraries/typescript/packages/inspector/src/client/components/MCPAppsRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/MCPAppsRenderer.tsx
@@ -510,6 +510,9 @@ function MCPAppsRendererBase({
     if (!iframe?.contentWindow) return;
 
     lastInitTimeRef.current = 0;
+    toolInputSentRef.current = null;
+    lastSentPropsRef.current = null;
+    lastSentToolOutputKeyRef.current = null;
     setInitCount(0);
 
     // Create a custom transport that posts messages through the SandboxedIframe
@@ -847,7 +850,6 @@ function MCPAppsRendererBase({
     sandboxRef,
     toolCallId,
     sandboxGeneration,
-    isReady,
     // readResource, server: use refs to avoid bridge tear-down/recreate on parent re-renders
     // (which would reset initCount and cause iframe/widget to re-init, appearing as "re-render")
   ]);

--- a/libraries/typescript/packages/inspector/src/client/components/MCPAppsRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/MCPAppsRenderer.tsx
@@ -40,11 +40,7 @@ import { useWidgetDebug } from "../context/WidgetDebugContext";
 import { useDeviceViewport } from "../hooks/useDeviceViewport";
 import { useMcpAppsHostContext } from "../hooks/useMcpAppsHostContext";
 import { cn } from "../lib/utils";
-import {
-  useWidgetFullscreenDocumentChrome,
-  WIDGET_FULLSCREEN_NATIVE_CLASSES,
-  WIDGET_FULLSCREEN_OVERLAY_CLASSES,
-} from "../lib/widget-fullscreen";
+import { useWidgetFullscreenControls } from "../lib/widget-fullscreen";
 import type { WidgetDeclaredCsp } from "../context/WidgetDebugContext";
 import { FullscreenNavbar } from "./FullscreenNavbar";
 import type { SandboxedIframeHandle } from "./ui/SandboxedIframe";
@@ -195,20 +191,30 @@ function MCPAppsRendererBase({
   const [prefersBorder, setPrefersBorder] = useState<boolean>(false);
   const [internalDisplayMode, setInternalDisplayMode] =
     useState<DisplayMode>("inline");
-  /** True when fullscreen mode uses CSS overlay because requestFullscreen failed. */
-  const [cssFullscreenFallback, setCssFullscreenFallback] = useState(false);
-
   // Use controlled displayMode if provided, otherwise use internal state
   const displayMode = displayModeProp ?? internalDisplayMode;
+
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  const setDisplayMode = useCallback(
+    (mode: DisplayMode) => {
+      if (onDisplayModeChange) onDisplayModeChange(mode);
+      else setInternalDisplayMode(mode);
+    },
+    [onDisplayModeChange]
+  );
+
+  const { handleDisplayModeChange, fullscreenShellClassName, isFullscreen } =
+    useWidgetFullscreenControls({
+      containerRef,
+      displayMode,
+      setDisplayMode,
+    });
 
   // Keep a ref so the onsizechange closure (captured at bridge creation) always
   // reads the current displayMode without needing to recreate the bridge.
   const displayModeRef = useRef(displayMode);
   displayModeRef.current = displayMode;
-
-  const isPipMode = displayMode === "pip";
-  const isFullscreenMode = displayMode === "fullscreen";
-  useWidgetFullscreenDocumentChrome(isFullscreenMode);
 
   // Track the last height requested by the widget in inline mode.
   // This persists across fullscreen/PiP transitions so the iframe is
@@ -217,9 +223,6 @@ function MCPAppsRendererBase({
   const [inlineHeight, setInlineHeight] = useState<number>(
     MCP_APPS_CONFIG.DIMENSIONS.DEFAULT_HEIGHT
   );
-
-  // Use useRef instead of useState to avoid state updates during ref callback
-  const containerRef = useRef<HTMLDivElement | null>(null);
 
   // Use playground settings when available
   const cspMode = playground.cspMode;
@@ -977,63 +980,6 @@ function MCPAppsRendererBase({
     [toolCallId, addCspViolation]
   );
 
-  const applyDisplayMode = useCallback(
-    (mode: DisplayMode) => {
-      if (onDisplayModeChange) {
-        onDisplayModeChange(mode);
-      } else {
-        setInternalDisplayMode(mode);
-      }
-    },
-    [onDisplayModeChange]
-  );
-
-  // Handle fullscreen changes
-  useEffect(() => {
-    const handleFullscreenChange = () => {
-      if (!document.fullscreenElement && displayMode === "fullscreen") {
-        setCssFullscreenFallback(false);
-        applyDisplayMode("inline");
-      }
-    };
-
-    document.addEventListener("fullscreenchange", handleFullscreenChange);
-    return () => {
-      document.removeEventListener("fullscreenchange", handleFullscreenChange);
-    };
-  }, [displayMode, applyDisplayMode]);
-
-  // Handle display mode changes — native Fullscreen API first, CSS overlay on failure
-  const handleDisplayModeChange = useCallback(
-    async (mode: DisplayMode) => {
-      if (mode === "fullscreen") {
-        try {
-          if (containerRef.current) {
-            await containerRef.current.requestFullscreen();
-          }
-          setCssFullscreenFallback(false);
-          applyDisplayMode("fullscreen");
-        } catch (err) {
-          console.error("[MCPAppsRenderer] Fullscreen error:", err);
-          setCssFullscreenFallback(true);
-          applyDisplayMode("fullscreen");
-        }
-        return;
-      }
-
-      try {
-        if (document.fullscreenElement) {
-          await document.exitFullscreen();
-        }
-      } catch (err) {
-        console.error("[MCPAppsRenderer] Exit fullscreen error:", err);
-      }
-      setCssFullscreenFallback(false);
-      applyDisplayMode(mode);
-    },
-    [applyDisplayMode]
-  );
-
   // Hide spinner after iframe loads + brief delay for widget to render (first load only)
   // Also hide when bridge initializes (initCount > 0), which proves the iframe is loaded
   // even if the onLoad event was missed during a rapid remount/re-render cycle.
@@ -1083,18 +1029,11 @@ function MCPAppsRendererBase({
     );
   }
 
-  const isPip = isPipMode;
-  const isFullscreen = isFullscreenMode;
-
-  const fullscreenShellClass = isFullscreen
-    ? cssFullscreenFallback
-      ? WIDGET_FULLSCREEN_OVERLAY_CLASSES
-      : WIDGET_FULLSCREEN_NATIVE_CLASSES
-    : undefined;
+  const isPip = displayMode === "pip";
 
   const containerClassName = (() => {
-    if (isFullscreen && fullscreenShellClass) {
-      return fullscreenShellClass;
+    if (fullscreenShellClassName) {
+      return fullscreenShellClassName;
     }
 
     if (isPip) {

--- a/libraries/typescript/packages/inspector/src/client/components/MCPAppsRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/MCPAppsRenderer.tsx
@@ -195,26 +195,43 @@ function MCPAppsRendererBase({
   const displayMode = displayModeProp ?? internalDisplayMode;
 
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const fullscreenTargetRef = useRef<HTMLDivElement | null>(null);
+  const prevControlledDisplayModeRef = useRef(displayModeProp);
 
   const setDisplayMode = useCallback(
     (mode: DisplayMode) => {
+      if (displayModeProp !== undefined) {
+        prevControlledDisplayModeRef.current = mode;
+      }
       if (onDisplayModeChange) onDisplayModeChange(mode);
       else setInternalDisplayMode(mode);
     },
-    [onDisplayModeChange]
+    [onDisplayModeChange, displayModeProp]
   );
 
   const { handleDisplayModeChange, fullscreenShellClassName, isFullscreen } =
     useWidgetFullscreenControls({
       containerRef,
+      fullscreenTargetRef,
       displayMode,
       setDisplayMode,
     });
+
+  const handleDisplayModeChangeRef = useRef(handleDisplayModeChange);
+  handleDisplayModeChangeRef.current = handleDisplayModeChange;
 
   // Keep a ref so the onsizechange closure (captured at bridge creation) always
   // reads the current displayMode without needing to recreate the bridge.
   const displayModeRef = useRef(displayMode);
   displayModeRef.current = displayMode;
+
+  // Controlled displayMode (e.g. MCPAppsDebugControls): sync native fullscreen without remounting.
+  useEffect(() => {
+    if (displayModeProp === undefined) return;
+    if (prevControlledDisplayModeRef.current === displayModeProp) return;
+    prevControlledDisplayModeRef.current = displayModeProp;
+    void handleDisplayModeChangeRef.current(displayModeProp);
+  }, [displayModeProp]);
 
   // Track the last height requested by the widget in inline mode.
   // This persists across fullscreen/PiP transitions so the iframe is
@@ -257,6 +274,12 @@ function MCPAppsRendererBase({
     toolMetadata,
     tool,
   });
+
+  // Reset load flags when the widget identity changes (not on display-mode toggles).
+  useEffect(() => {
+    hasLoadedOnceRef.current = false;
+    readyFiredRef.current = false;
+  }, [toolCallId, resourceUri]);
 
   // Fetch widget HTML when component mounts
   useEffect(() => {
@@ -607,12 +630,8 @@ function MCPAppsRendererBase({
     };
 
     bridge.onrequestdisplaymode = async ({ mode }) => {
-      const requestedMode = mode ?? "inline";
-      if (onDisplayModeChange) {
-        onDisplayModeChange(requestedMode);
-      } else {
-        setInternalDisplayMode(requestedMode);
-      }
+      const requestedMode = (mode ?? "inline") as DisplayMode;
+      await handleDisplayModeChangeRef.current(requestedMode);
       return { mode: requestedMode };
     };
 
@@ -1087,6 +1106,7 @@ function MCPAppsRendererBase({
 
         {/* Main content with centering like Apps SDK */}
         <div
+          ref={fullscreenTargetRef}
           className={cn(
             "flex-1 w-full h-full flex justify-center items-center relative",
             isFullscreen && !chromeless && "pt-14",

--- a/libraries/typescript/packages/inspector/src/client/components/MCPAppsRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/MCPAppsRenderer.tsx
@@ -32,7 +32,6 @@ import {
   useState,
   type CSSProperties,
 } from "react";
-import { createPortal } from "react-dom";
 import { rpcLogBus } from "../../server/rpc-log-bus.js";
 import { consoleLogBus } from "../console-log-bus";
 import { IFRAME_SANDBOX_PERMISSIONS, MCP_APPS_CONFIG } from "../constants";
@@ -43,6 +42,7 @@ import { useMcpAppsHostContext } from "../hooks/useMcpAppsHostContext";
 import { cn } from "../lib/utils";
 import {
   useWidgetFullscreenDocumentChrome,
+  WIDGET_FULLSCREEN_NATIVE_CLASSES,
   WIDGET_FULLSCREEN_OVERLAY_CLASSES,
 } from "../lib/widget-fullscreen";
 import type { WidgetDeclaredCsp } from "../context/WidgetDebugContext";
@@ -195,6 +195,8 @@ function MCPAppsRendererBase({
   const [prefersBorder, setPrefersBorder] = useState<boolean>(false);
   const [internalDisplayMode, setInternalDisplayMode] =
     useState<DisplayMode>("inline");
+  /** True when fullscreen mode uses CSS overlay because requestFullscreen failed. */
+  const [cssFullscreenFallback, setCssFullscreenFallback] = useState(false);
 
   // Use controlled displayMode if provided, otherwise use internal state
   const displayMode = displayModeProp ?? internalDisplayMode;
@@ -975,15 +977,23 @@ function MCPAppsRendererBase({
     [toolCallId, addCspViolation]
   );
 
+  const applyDisplayMode = useCallback(
+    (mode: DisplayMode) => {
+      if (onDisplayModeChange) {
+        onDisplayModeChange(mode);
+      } else {
+        setInternalDisplayMode(mode);
+      }
+    },
+    [onDisplayModeChange]
+  );
+
   // Handle fullscreen changes
   useEffect(() => {
     const handleFullscreenChange = () => {
       if (!document.fullscreenElement && displayMode === "fullscreen") {
-        if (onDisplayModeChange) {
-          onDisplayModeChange("inline");
-        } else {
-          setInternalDisplayMode("inline");
-        }
+        setCssFullscreenFallback(false);
+        applyDisplayMode("inline");
       }
     };
 
@@ -991,39 +1001,37 @@ function MCPAppsRendererBase({
     return () => {
       document.removeEventListener("fullscreenchange", handleFullscreenChange);
     };
-  }, [displayMode, onDisplayModeChange]);
+  }, [displayMode, applyDisplayMode]);
 
-  // Handle display mode changes
+  // Handle display mode changes — native Fullscreen API first, CSS overlay on failure
   const handleDisplayModeChange = useCallback(
     async (mode: DisplayMode) => {
-      try {
-        if (mode === "fullscreen") {
+      if (mode === "fullscreen") {
+        try {
           if (containerRef.current) {
             await containerRef.current.requestFullscreen();
           }
-        } else {
-          if (document.fullscreenElement) {
-            await document.exitFullscreen();
-          }
+          setCssFullscreenFallback(false);
+          applyDisplayMode("fullscreen");
+        } catch (err) {
+          console.error("[MCPAppsRenderer] Fullscreen error:", err);
+          setCssFullscreenFallback(true);
+          applyDisplayMode("fullscreen");
         }
+        return;
+      }
 
-        // Call the callback if provided (controlled), otherwise update internal state
-        if (onDisplayModeChange) {
-          onDisplayModeChange(mode);
-        } else {
-          setInternalDisplayMode(mode);
+      try {
+        if (document.fullscreenElement) {
+          await document.exitFullscreen();
         }
       } catch (err) {
-        console.error("[MCPAppsRenderer] Display mode error:", err);
-        // Still update state even on error
-        if (onDisplayModeChange) {
-          onDisplayModeChange(mode);
-        } else {
-          setInternalDisplayMode(mode);
-        }
+        console.error("[MCPAppsRenderer] Exit fullscreen error:", err);
       }
+      setCssFullscreenFallback(false);
+      applyDisplayMode(mode);
     },
-    [onDisplayModeChange]
+    [applyDisplayMode]
   );
 
   // Hide spinner after iframe loads + brief delay for widget to render (first load only)
@@ -1078,9 +1086,15 @@ function MCPAppsRendererBase({
   const isPip = isPipMode;
   const isFullscreen = isFullscreenMode;
 
+  const fullscreenShellClass = isFullscreen
+    ? cssFullscreenFallback
+      ? WIDGET_FULLSCREEN_OVERLAY_CLASSES
+      : WIDGET_FULLSCREEN_NATIVE_CLASSES
+    : undefined;
+
   const containerClassName = (() => {
-    if (isFullscreen) {
-      return WIDGET_FULLSCREEN_OVERLAY_CLASSES;
+    if (isFullscreen && fullscreenShellClass) {
+      return fullscreenShellClass;
     }
 
     if (isPip) {
@@ -1101,98 +1115,92 @@ function MCPAppsRendererBase({
     transition: isFullscreen || isPip ? undefined : "height 300ms ease-out",
   };
 
-  const widgetShell = (
-    <div
-      ref={containerRef}
-      className={containerClassName}
-      style={
-        isPip
-          ? { maxWidth: MCP_APPS_CONFIG.DIMENSIONS.PIP_MAX_WIDTH }
-          : undefined
-      }
-    >
-      {isFullscreen && !chromeless && (
-        <FullscreenNavbar
-          title={toolName}
-          onClose={() => handleDisplayModeChange("inline")}
-          testId="debugger-exit-fullscreen-button"
-        />
-      )}
-
-      {isPip && (
-        <button
-          data-testid="debugger-exit-pip-button"
-          onClick={() => handleDisplayModeChange("inline")}
-          className="absolute left-2 top-2 z-30 flex h-6 w-6 items-center justify-center rounded-md bg-background/80 hover:bg-background border border-zinc-200 dark:border-zinc-700 text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors cursor-pointer"
-          aria-label="Close PiP mode"
-          title="Close PiP mode"
-        >
-          <X className="w-4 h-4" />
-        </button>
-      )}
-
-      {/* Main content with centering like Apps SDK */}
-      <div
-        className={cn(
-          "flex-1 w-full h-full flex justify-center items-center relative",
-          isFullscreen && !chromeless && "pt-14",
-          !isPip && !isFullscreen && (invoking || invoked) && "pt-8"
-        )}
-      >
-        {showSpinner && (
-          <div className="flex absolute left-0 top-0 items-center justify-center w-full h-full z-10">
-            <Spinner className="size-5" />
-          </div>
-        )}
-        <div
-          className="relative w-full h-full"
-          style={{ maxWidth: iframeStyle.maxWidth }}
-        >
-          <div className="absolute -top-8 left-2 z-10 h-full">
-            {/* Status label above the widget — only in inline mode */}
-            {!isPip && !isFullscreen && (invoking || invoked) && (
-              <div className="whitespace-nowrap">
-                {invoking && !toolOutput && (
-                  <TextShimmer className="text-xs ">{invoking}</TextShimmer>
-                )}
-                {invoked && !!toolOutput && (
-                  <span className="text-xs text-muted-foreground">
-                    {invoked}
-                  </span>
-                )}
-              </div>
-            )}
-          </div>
-          <SandboxedIframe
-            ref={sandboxRef}
-            html={widgetHtml}
-            sandbox={IFRAME_SANDBOX_PERMISSIONS}
-            csp={widgetCsp}
-            permissions={widgetPermissions}
-            permissive={cspMode === "permissive"}
-            onLoad={() => setIsReady(true)}
-            onMessage={handleSandboxMessage}
-            title={`MCP App: ${toolName}`}
-            className={cn(
-              displayMode === "inline" && "w-full",
-              displayMode === "fullscreen" && "w-full h-full rounded-none",
-              displayMode === "pip" && "w-full h-full",
-              displayMode !== "fullscreen" && prefersBorder && "rounded-lg",
-              "overflow-hidden",
-              prefersBorder && "border border-zinc-200 dark:border-zinc-700"
-            )}
-            style={iframeStyle}
-          />{" "}
-        </div>
-      </div>
-    </div>
-  );
-
   return (
     <WidgetWrapper className={className} noWrapper={noWrapper}>
-      {isFullscreen && typeof document !== "undefined"
-        ? createPortal(widgetShell, document.body)
-        : widgetShell}
+      <div
+        ref={containerRef}
+        className={containerClassName}
+        style={
+          isPip
+            ? { maxWidth: MCP_APPS_CONFIG.DIMENSIONS.PIP_MAX_WIDTH }
+            : undefined
+        }
+      >
+        {isFullscreen && !chromeless && (
+          <FullscreenNavbar
+            title={toolName}
+            onClose={() => handleDisplayModeChange("inline")}
+            testId="debugger-exit-fullscreen-button"
+          />
+        )}
+
+        {isPip && (
+          <button
+            data-testid="debugger-exit-pip-button"
+            onClick={() => handleDisplayModeChange("inline")}
+            className="absolute left-2 top-2 z-30 flex h-6 w-6 items-center justify-center rounded-md bg-background/80 hover:bg-background border border-zinc-200 dark:border-zinc-700 text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors cursor-pointer"
+            aria-label="Close PiP mode"
+            title="Close PiP mode"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        )}
+
+        {/* Main content with centering like Apps SDK */}
+        <div
+          className={cn(
+            "flex-1 w-full h-full flex justify-center items-center relative",
+            isFullscreen && !chromeless && "pt-14",
+            !isPip && !isFullscreen && (invoking || invoked) && "pt-8"
+          )}
+        >
+          {showSpinner && (
+            <div className="flex absolute left-0 top-0 items-center justify-center w-full h-full z-10">
+              <Spinner className="size-5" />
+            </div>
+          )}
+          <div
+            className="relative w-full h-full"
+            style={{ maxWidth: iframeStyle.maxWidth }}
+          >
+            <div className="absolute -top-8 left-2 z-10 h-full">
+              {/* Status label above the widget — only in inline mode */}
+              {!isPip && !isFullscreen && (invoking || invoked) && (
+                <div className="whitespace-nowrap">
+                  {invoking && !toolOutput && (
+                    <TextShimmer className="text-xs ">{invoking}</TextShimmer>
+                  )}
+                  {invoked && !!toolOutput && (
+                    <span className="text-xs text-muted-foreground">
+                      {invoked}
+                    </span>
+                  )}
+                </div>
+              )}
+            </div>
+            <SandboxedIframe
+              ref={sandboxRef}
+              html={widgetHtml}
+              sandbox={IFRAME_SANDBOX_PERMISSIONS}
+              csp={widgetCsp}
+              permissions={widgetPermissions}
+              permissive={cspMode === "permissive"}
+              onLoad={() => setIsReady(true)}
+              onMessage={handleSandboxMessage}
+              title={`MCP App: ${toolName}`}
+              className={cn(
+                displayMode === "inline" && "w-full",
+                displayMode === "fullscreen" && "w-full h-full rounded-none",
+                displayMode === "pip" && "w-full h-full",
+                displayMode !== "fullscreen" && prefersBorder && "rounded-lg",
+                "overflow-hidden",
+                prefersBorder && "border border-zinc-200 dark:border-zinc-700"
+              )}
+              style={iframeStyle}
+            />{" "}
+          </div>
+        </div>
+      </div>
     </WidgetWrapper>
   );
 }

--- a/libraries/typescript/packages/inspector/src/client/components/MCPAppsRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/MCPAppsRenderer.tsx
@@ -32,6 +32,7 @@ import {
   useState,
   type CSSProperties,
 } from "react";
+import { createPortal } from "react-dom";
 import { rpcLogBus } from "../../server/rpc-log-bus.js";
 import { consoleLogBus } from "../console-log-bus";
 import { IFRAME_SANDBOX_PERMISSIONS, MCP_APPS_CONFIG } from "../constants";
@@ -40,7 +41,8 @@ import { useWidgetDebug } from "../context/WidgetDebugContext";
 import { useDeviceViewport } from "../hooks/useDeviceViewport";
 import { useMcpAppsHostContext } from "../hooks/useMcpAppsHostContext";
 import { cn } from "../lib/utils";
-import { useWidgetFullscreenControls } from "../lib/widget-fullscreen";
+import { useSandboxRemountGeneration } from "../lib/use-sandbox-remount-generation";
+import { useWidgetDisplayModeControls } from "../lib/widget-fullscreen";
 import type { WidgetDeclaredCsp } from "../context/WidgetDebugContext";
 import { FullscreenNavbar } from "./FullscreenNavbar";
 import type { SandboxedIframeHandle } from "./ui/SandboxedIframe";
@@ -208,12 +210,28 @@ function MCPAppsRendererBase({
     [onDisplayModeChange, displayModeProp]
   );
 
-  const { handleDisplayModeChange, fullscreenShellClassName, isFullscreen } =
-    useWidgetFullscreenControls({
-      containerRef,
-      displayMode,
-      setDisplayMode,
-    });
+  const { sandboxGeneration, onSandboxMount } = useSandboxRemountGeneration();
+
+  const handleSandboxMount = useCallback(() => {
+    if (onSandboxMount()) {
+      if (hasLoadedOnceRef.current) {
+        setShowSpinner(true);
+        setIsReady(false);
+      }
+    }
+  }, [onSandboxMount]);
+
+  const {
+    handleDisplayModeChange,
+    fullscreenShellClassName,
+    pipShellClassName,
+    isFullscreen,
+    isPip,
+  } = useWidgetDisplayModeControls({
+    containerRef,
+    displayMode,
+    setDisplayMode,
+  });
 
   const handleDisplayModeChangeRef = useRef(handleDisplayModeChange);
   handleDisplayModeChangeRef.current = handleDisplayModeChange;
@@ -484,13 +502,14 @@ function MCPAppsRendererBase({
     };
   }, [initCount, resourceUri, readResource]);
 
-  // Initialize AppBridge when HTML is ready
+  // Initialize AppBridge when HTML is ready (re-run when sandbox iframe remounts)
   useEffect(() => {
     if (!widgetHtml || !sandboxRef.current) return;
 
     const iframe = sandboxRef.current.getIframeElement();
     if (!iframe?.contentWindow) return;
 
+    lastInitTimeRef.current = 0;
     setInitCount(0);
 
     // Create a custom transport that posts messages through the SandboxedIframe
@@ -727,10 +746,12 @@ function MCPAppsRendererBase({
 
     // Set up message handler for incoming messages from widget (via SandboxedIframe)
     const handleMessage = (event: MessageEvent) => {
+      const activeIframe = sandboxRef.current?.getIframeElement();
+      if (!activeIframe?.contentWindow) return;
       // Only process messages from our sandbox proxy
-      const proxyOrigin = new URL(iframe.src).origin;
+      const proxyOrigin = new URL(activeIframe.src).origin;
       if (event.origin !== proxyOrigin) return;
-      if (event.source !== iframe.contentWindow) return;
+      if (event.source !== activeIframe.contentWindow) return;
 
       if (event.data?.type === "iframe-console-log") {
         if (
@@ -825,6 +846,8 @@ function MCPAppsRendererBase({
     widgetHtml,
     sandboxRef,
     toolCallId,
+    sandboxGeneration,
+    isReady,
     // readResource, server: use refs to avoid bridge tear-down/recreate on parent re-renders
     // (which would reset initCount and cause iframe/widget to re-init, appearing as "re-render")
   ]);
@@ -1000,7 +1023,8 @@ function MCPAppsRendererBase({
   // Hide spinner after iframe loads + brief delay for widget to render (first load only)
   // Also hide when bridge initializes (initCount > 0), which proves the iframe is loaded
   // even if the onLoad event was missed during a rapid remount/re-render cycle.
-  const iframeEffectivelyReady = isReady || initCount > 0;
+  const iframeEffectivelyReady =
+    initCount > 0 || (isReady && !hasLoadedOnceRef.current);
 
   // Fire onReady once after the AppBridge handshake completes (initCount goes 0 → 1).
   const readyFiredRef = useRef(false);
@@ -1046,21 +1070,13 @@ function MCPAppsRendererBase({
     );
   }
 
-  const isPip = displayMode === "pip";
-
   const containerClassName = (() => {
     if (fullscreenShellClassName) {
       return fullscreenShellClassName;
     }
-
-    if (isPip) {
-      return [
-        `fixed top-4 left-1/2 -translate-x-1/2 z-50 rounded-3xl w-full min-w-[300px] h-[400px]`,
-        "shadow-2xl border overflow-hidden",
-        "bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80",
-      ].join(" ");
+    if (pipShellClassName) {
+      return pipShellClassName;
     }
-
     return "flex group flex-1 items-center justify-center";
   })();
 
@@ -1071,101 +1087,108 @@ function MCPAppsRendererBase({
     transition: isFullscreen || isPip ? undefined : "height 300ms ease-out",
   };
 
-  return (
-    <WidgetWrapper className={className} noWrapper={noWrapper}>
+  const widgetShell = (
+    <div
+      ref={containerRef}
+      className={containerClassName}
+      style={
+        isPip
+          ? { maxWidth: MCP_APPS_CONFIG.DIMENSIONS.PIP_MAX_WIDTH }
+          : undefined
+      }
+    >
+      {isFullscreen && !chromeless && (
+        <FullscreenNavbar
+          title={toolName}
+          onClose={() => handleDisplayModeChange("inline")}
+          testId="debugger-exit-fullscreen-button"
+        />
+      )}
+
+      {isPip && (
+        <button
+          data-testid="debugger-exit-pip-button"
+          onClick={() => handleDisplayModeChange("inline")}
+          className="absolute left-2 top-2 z-30 flex h-6 w-6 items-center justify-center rounded-md bg-background/80 hover:bg-background border border-zinc-200 dark:border-zinc-700 text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors cursor-pointer"
+          aria-label="Close PiP mode"
+          title="Close PiP mode"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      )}
+
+      {/* Main content with centering like Apps SDK */}
       <div
-        ref={containerRef}
-        className={containerClassName}
-        style={
-          isPip
-            ? { maxWidth: MCP_APPS_CONFIG.DIMENSIONS.PIP_MAX_WIDTH }
-            : undefined
-        }
+        className={cn(
+          "relative w-full min-h-0",
+          isFullscreen || isPip
+            ? "flex flex-1 flex-col"
+            : "flex flex-1 justify-center items-center",
+          !isPip && !isFullscreen && (invoking || invoked) && "pt-8"
+        )}
       >
-        {isFullscreen && !chromeless && (
-          <FullscreenNavbar
-            title={toolName}
-            onClose={() => handleDisplayModeChange("inline")}
-            testId="debugger-exit-fullscreen-button"
-          />
+        {showSpinner && (
+          <div className="flex absolute left-0 top-0 items-center justify-center w-full h-full z-10">
+            <Spinner className="size-5" />
+          </div>
         )}
-
-        {isPip && (
-          <button
-            data-testid="debugger-exit-pip-button"
-            onClick={() => handleDisplayModeChange("inline")}
-            className="absolute left-2 top-2 z-30 flex h-6 w-6 items-center justify-center rounded-md bg-background/80 hover:bg-background border border-zinc-200 dark:border-zinc-700 text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors cursor-pointer"
-            aria-label="Close PiP mode"
-            title="Close PiP mode"
-          >
-            <X className="w-4 h-4" />
-          </button>
-        )}
-
-        {/* Main content with centering like Apps SDK */}
         <div
           className={cn(
-            "relative w-full min-h-0",
+            "relative w-full",
+            isFullscreen || isPip ? "h-full min-h-0 flex-1" : "h-full"
+          )}
+          style={
             isFullscreen || isPip
-              ? "flex flex-1 flex-col"
-              : "flex flex-1 justify-center items-center",
-            !isPip && !isFullscreen && (invoking || invoked) && "pt-8"
-          )}
+              ? undefined
+              : { maxWidth: iframeStyle.maxWidth }
+          }
         >
-          {showSpinner && (
-            <div className="flex absolute left-0 top-0 items-center justify-center w-full h-full z-10">
-              <Spinner className="size-5" />
-            </div>
-          )}
-          <div
-            className={cn(
-              "relative w-full",
-              isFullscreen || isPip ? "h-full min-h-0 flex-1" : "h-full"
+          <div className="absolute -top-8 left-2 z-10 h-full">
+            {/* Status label above the widget — only in inline mode */}
+            {!isPip && !isFullscreen && (invoking || invoked) && (
+              <div className="whitespace-nowrap">
+                {invoking && !toolOutput && (
+                  <TextShimmer className="text-xs ">{invoking}</TextShimmer>
+                )}
+                {invoked && !!toolOutput && (
+                  <span className="text-xs text-muted-foreground">
+                    {invoked}
+                  </span>
+                )}
+              </div>
             )}
-            style={
-              isFullscreen || isPip
-                ? undefined
-                : { maxWidth: iframeStyle.maxWidth }
-            }
-          >
-            <div className="absolute -top-8 left-2 z-10 h-full">
-              {/* Status label above the widget — only in inline mode */}
-              {!isPip && !isFullscreen && (invoking || invoked) && (
-                <div className="whitespace-nowrap">
-                  {invoking && !toolOutput && (
-                    <TextShimmer className="text-xs ">{invoking}</TextShimmer>
-                  )}
-                  {invoked && !!toolOutput && (
-                    <span className="text-xs text-muted-foreground">
-                      {invoked}
-                    </span>
-                  )}
-                </div>
-              )}
-            </div>
-            <SandboxedIframe
-              ref={sandboxRef}
-              html={widgetHtml}
-              sandbox={IFRAME_SANDBOX_PERMISSIONS}
-              csp={widgetCsp}
-              permissions={widgetPermissions}
-              permissive={cspMode === "permissive"}
-              onLoad={() => setIsReady(true)}
-              onMessage={handleSandboxMessage}
-              title={`MCP App: ${toolName}`}
-              className={cn(
-                displayMode === "inline" && "w-full",
-                displayMode === "fullscreen" && "w-full h-full rounded-none",
-                displayMode === "pip" && "w-full h-full",
-                displayMode !== "fullscreen" && prefersBorder && "rounded-lg",
-                "overflow-hidden",
-                prefersBorder && "border border-zinc-200 dark:border-zinc-700"
-              )}
-              style={iframeStyle}
-            />{" "}
           </div>
+          <SandboxedIframe
+            ref={sandboxRef}
+            html={widgetHtml}
+            sandbox={IFRAME_SANDBOX_PERMISSIONS}
+            csp={widgetCsp}
+            permissions={widgetPermissions}
+            permissive={cspMode === "permissive"}
+            onSandboxMount={handleSandboxMount}
+            onLoad={() => setIsReady(true)}
+            onMessage={handleSandboxMessage}
+            title={`MCP App: ${toolName}`}
+            className={cn(
+              displayMode === "inline" && "w-full",
+              displayMode === "fullscreen" && "w-full h-full rounded-none",
+              displayMode === "pip" && "w-full h-full",
+              displayMode !== "fullscreen" && prefersBorder && "rounded-lg",
+              "overflow-hidden",
+              prefersBorder && "border border-zinc-200 dark:border-zinc-700"
+            )}
+            style={iframeStyle}
+          />{" "}
         </div>
       </div>
+    </div>
+  );
+
+  return (
+    <WidgetWrapper className={className} noWrapper={noWrapper}>
+      {isPip && typeof document !== "undefined"
+        ? createPortal(widgetShell, document.body)
+        : widgetShell}
     </WidgetWrapper>
   );
 }

--- a/libraries/typescript/packages/inspector/src/client/components/MCPAppsRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/MCPAppsRenderer.tsx
@@ -32,6 +32,7 @@ import {
   useState,
   type CSSProperties,
 } from "react";
+import { createPortal } from "react-dom";
 import { rpcLogBus } from "../../server/rpc-log-bus.js";
 import { consoleLogBus } from "../console-log-bus";
 import { IFRAME_SANDBOX_PERMISSIONS, MCP_APPS_CONFIG } from "../constants";
@@ -40,6 +41,10 @@ import { useWidgetDebug } from "../context/WidgetDebugContext";
 import { useDeviceViewport } from "../hooks/useDeviceViewport";
 import { useMcpAppsHostContext } from "../hooks/useMcpAppsHostContext";
 import { cn } from "../lib/utils";
+import {
+  useWidgetFullscreenDocumentChrome,
+  WIDGET_FULLSCREEN_OVERLAY_CLASSES,
+} from "../lib/widget-fullscreen";
 import type { WidgetDeclaredCsp } from "../context/WidgetDebugContext";
 import { FullscreenNavbar } from "./FullscreenNavbar";
 import type { SandboxedIframeHandle } from "./ui/SandboxedIframe";
@@ -198,6 +203,10 @@ function MCPAppsRendererBase({
   // reads the current displayMode without needing to recreate the bridge.
   const displayModeRef = useRef(displayMode);
   displayModeRef.current = displayMode;
+
+  const isPipMode = displayMode === "pip";
+  const isFullscreenMode = displayMode === "fullscreen";
+  useWidgetFullscreenDocumentChrome(isFullscreenMode);
 
   // Track the last height requested by the widget in inline mode.
   // This persists across fullscreen/PiP transitions so the iframe is
@@ -1066,12 +1075,12 @@ function MCPAppsRendererBase({
     );
   }
 
-  const isPip = displayMode === "pip";
-  const isFullscreen = displayMode === "fullscreen";
+  const isPip = isPipMode;
+  const isFullscreen = isFullscreenMode;
 
   const containerClassName = (() => {
     if (isFullscreen) {
-      return "fixed inset-0 z-40 w-full h-full bg-background flex flex-col";
+      return WIDGET_FULLSCREEN_OVERLAY_CLASSES;
     }
 
     if (isPip) {
@@ -1092,92 +1101,98 @@ function MCPAppsRendererBase({
     transition: isFullscreen || isPip ? undefined : "height 300ms ease-out",
   };
 
-  return (
-    <WidgetWrapper className={className} noWrapper={noWrapper}>
-      <div
-        ref={containerRef}
-        className={containerClassName}
-        style={
-          isPip
-            ? { maxWidth: MCP_APPS_CONFIG.DIMENSIONS.PIP_MAX_WIDTH }
-            : undefined
-        }
-      >
-        {isFullscreen && !chromeless && (
-          <FullscreenNavbar
-            title={toolName}
-            onClose={() => handleDisplayModeChange("inline")}
-            testId="debugger-exit-fullscreen-button"
-          />
-        )}
+  const widgetShell = (
+    <div
+      ref={containerRef}
+      className={containerClassName}
+      style={
+        isPip
+          ? { maxWidth: MCP_APPS_CONFIG.DIMENSIONS.PIP_MAX_WIDTH }
+          : undefined
+      }
+    >
+      {isFullscreen && !chromeless && (
+        <FullscreenNavbar
+          title={toolName}
+          onClose={() => handleDisplayModeChange("inline")}
+          testId="debugger-exit-fullscreen-button"
+        />
+      )}
 
-        {isPip && (
-          <button
-            data-testid="debugger-exit-pip-button"
-            onClick={() => handleDisplayModeChange("inline")}
-            className="absolute left-2 top-2 z-30 flex h-6 w-6 items-center justify-center rounded-md bg-background/80 hover:bg-background border border-zinc-200 dark:border-zinc-700 text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors cursor-pointer"
-            aria-label="Close PiP mode"
-            title="Close PiP mode"
-          >
-            <X className="w-4 h-4" />
-          </button>
-        )}
-
-        {/* Main content with centering like Apps SDK */}
-        <div
-          className={cn(
-            "flex-1 w-full h-full flex justify-center items-center relative",
-            isFullscreen && !chromeless && "pt-14",
-            !isPip && !isFullscreen && (invoking || invoked) && "pt-8"
-          )}
+      {isPip && (
+        <button
+          data-testid="debugger-exit-pip-button"
+          onClick={() => handleDisplayModeChange("inline")}
+          className="absolute left-2 top-2 z-30 flex h-6 w-6 items-center justify-center rounded-md bg-background/80 hover:bg-background border border-zinc-200 dark:border-zinc-700 text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors cursor-pointer"
+          aria-label="Close PiP mode"
+          title="Close PiP mode"
         >
-          {showSpinner && (
-            <div className="flex absolute left-0 top-0 items-center justify-center w-full h-full z-10">
-              <Spinner className="size-5" />
-            </div>
-          )}
-          <div
-            className="relative w-full h-full"
-            style={{ maxWidth: iframeStyle.maxWidth }}
-          >
-            <div className="absolute -top-8 left-2 z-10 h-full">
-              {/* Status label above the widget — only in inline mode */}
-              {!isPip && !isFullscreen && (invoking || invoked) && (
-                <div className="whitespace-nowrap">
-                  {invoking && !toolOutput && (
-                    <TextShimmer className="text-xs ">{invoking}</TextShimmer>
-                  )}
-                  {invoked && !!toolOutput && (
-                    <span className="text-xs text-muted-foreground">
-                      {invoked}
-                    </span>
-                  )}
-                </div>
-              )}
-            </div>
-            <SandboxedIframe
-              ref={sandboxRef}
-              html={widgetHtml}
-              sandbox={IFRAME_SANDBOX_PERMISSIONS}
-              csp={widgetCsp}
-              permissions={widgetPermissions}
-              permissive={cspMode === "permissive"}
-              onLoad={() => setIsReady(true)}
-              onMessage={handleSandboxMessage}
-              title={`MCP App: ${toolName}`}
-              className={cn(
-                displayMode === "inline" && "w-full",
-                displayMode === "fullscreen" && "w-full h-full rounded-none",
-                displayMode === "pip" && "w-full h-full",
-                displayMode !== "fullscreen" && prefersBorder && "rounded-lg",
-                "overflow-hidden",
-                prefersBorder && "border border-zinc-200 dark:border-zinc-700"
-              )}
-              style={iframeStyle}
-            />{" "}
+          <X className="w-4 h-4" />
+        </button>
+      )}
+
+      {/* Main content with centering like Apps SDK */}
+      <div
+        className={cn(
+          "flex-1 w-full h-full flex justify-center items-center relative",
+          isFullscreen && !chromeless && "pt-14",
+          !isPip && !isFullscreen && (invoking || invoked) && "pt-8"
+        )}
+      >
+        {showSpinner && (
+          <div className="flex absolute left-0 top-0 items-center justify-center w-full h-full z-10">
+            <Spinner className="size-5" />
           </div>
+        )}
+        <div
+          className="relative w-full h-full"
+          style={{ maxWidth: iframeStyle.maxWidth }}
+        >
+          <div className="absolute -top-8 left-2 z-10 h-full">
+            {/* Status label above the widget — only in inline mode */}
+            {!isPip && !isFullscreen && (invoking || invoked) && (
+              <div className="whitespace-nowrap">
+                {invoking && !toolOutput && (
+                  <TextShimmer className="text-xs ">{invoking}</TextShimmer>
+                )}
+                {invoked && !!toolOutput && (
+                  <span className="text-xs text-muted-foreground">
+                    {invoked}
+                  </span>
+                )}
+              </div>
+            )}
+          </div>
+          <SandboxedIframe
+            ref={sandboxRef}
+            html={widgetHtml}
+            sandbox={IFRAME_SANDBOX_PERMISSIONS}
+            csp={widgetCsp}
+            permissions={widgetPermissions}
+            permissive={cspMode === "permissive"}
+            onLoad={() => setIsReady(true)}
+            onMessage={handleSandboxMessage}
+            title={`MCP App: ${toolName}`}
+            className={cn(
+              displayMode === "inline" && "w-full",
+              displayMode === "fullscreen" && "w-full h-full rounded-none",
+              displayMode === "pip" && "w-full h-full",
+              displayMode !== "fullscreen" && prefersBorder && "rounded-lg",
+              "overflow-hidden",
+              prefersBorder && "border border-zinc-200 dark:border-zinc-700"
+            )}
+            style={iframeStyle}
+          />{" "}
         </div>
       </div>
+    </div>
+  );
+
+  return (
+    <WidgetWrapper className={className} noWrapper={noWrapper}>
+      {isFullscreen && typeof document !== "undefined"
+        ? createPortal(widgetShell, document.body)
+        : widgetShell}
     </WidgetWrapper>
   );
 }

--- a/libraries/typescript/packages/inspector/src/client/components/MCPAppsRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/MCPAppsRenderer.tsx
@@ -195,7 +195,6 @@ function MCPAppsRendererBase({
   const displayMode = displayModeProp ?? internalDisplayMode;
 
   const containerRef = useRef<HTMLDivElement | null>(null);
-  const fullscreenTargetRef = useRef<HTMLDivElement | null>(null);
   const prevControlledDisplayModeRef = useRef(displayModeProp);
 
   const setDisplayMode = useCallback(
@@ -212,7 +211,6 @@ function MCPAppsRendererBase({
   const { handleDisplayModeChange, fullscreenShellClassName, isFullscreen } =
     useWidgetFullscreenControls({
       containerRef,
-      fullscreenTargetRef,
       displayMode,
       setDisplayMode,
     });
@@ -1106,10 +1104,11 @@ function MCPAppsRendererBase({
 
         {/* Main content with centering like Apps SDK */}
         <div
-          ref={fullscreenTargetRef}
           className={cn(
-            "flex-1 w-full h-full flex justify-center items-center relative",
-            isFullscreen && !chromeless && "pt-14",
+            "relative w-full min-h-0",
+            isFullscreen || isPip
+              ? "flex flex-1 flex-col"
+              : "flex flex-1 justify-center items-center",
             !isPip && !isFullscreen && (invoking || invoked) && "pt-8"
           )}
         >
@@ -1119,8 +1118,15 @@ function MCPAppsRendererBase({
             </div>
           )}
           <div
-            className="relative w-full h-full"
-            style={{ maxWidth: iframeStyle.maxWidth }}
+            className={cn(
+              "relative w-full",
+              isFullscreen || isPip ? "h-full min-h-0 flex-1" : "h-full"
+            )}
+            style={
+              isFullscreen || isPip
+                ? undefined
+                : { maxWidth: iframeStyle.maxWidth }
+            }
           >
             <div className="absolute -top-8 left-2 z-10 h-full">
               {/* Status label above the widget — only in inline mode */}

--- a/libraries/typescript/packages/inspector/src/client/components/OpenAIComponentRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/OpenAIComponentRenderer.tsx
@@ -113,6 +113,7 @@ function OpenAIComponentRendererBase({
     typeof window.HTMLIFrameElement
   > | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const fullscreenTargetRef = useRef<HTMLDivElement>(null);
   const [isReady, setIsReady] = useState(false);
   const [showSkeleton, setShowSkeleton] = useState(true);
   const hasLoadedOnceRef = useRef(false);
@@ -150,6 +151,8 @@ function OpenAIComponentRendererBase({
   // outside the inspector's own McpClientProvider).
   const { servers } = useMcpClient();
   const server = servers.find((connection) => connection.id === serverId);
+  const serverRef = useRef(server);
+  serverRef.current = server;
   const serverBaseUrl = serverBaseUrlProp ?? server?.url;
   const { resolvedTheme } = useTheme();
   const { playground, addWidget, addCspViolation } = useWidgetDebug();
@@ -501,19 +504,30 @@ function OpenAIComponentRendererBase({
   const { handleDisplayModeChange, fullscreenShellClassName } =
     useWidgetFullscreenControls({
       containerRef,
+      fullscreenTargetRef,
       displayMode,
       setDisplayMode: setDisplayModeWithGlobals,
     });
+
+  const handleDisplayModeChangeRef = useRef(handleDisplayModeChange);
+  handleDisplayModeChangeRef.current = handleDisplayModeChange;
+
+  const widgetUrlRef = useRef<string | null>(null);
 
   // Handle postMessage communication with iframe
   useEffect(() => {
     if (!widgetUrl) return;
 
-    // Reset readiness whenever we load a new widget URL.
-    // Only show skeleton on first load, not on prop updates
-    setIsReady(false);
-    if (!hasLoadedOnceRef.current) {
-      setShowSkeleton(true);
+    const widgetUrlChanged = widgetUrlRef.current !== widgetUrl;
+    widgetUrlRef.current = widgetUrl;
+
+    // Reset readiness only when the iframe URL changes, not on unrelated re-runs
+    // (e.g. unstable `server` reference during chat streaming).
+    if (widgetUrlChanged) {
+      setIsReady(false);
+      if (!hasLoadedOnceRef.current) {
+        setShowSkeleton(true);
+      }
     }
     setError(null);
 
@@ -616,7 +630,8 @@ function OpenAIComponentRendererBase({
 
         case "openai:callTool":
           try {
-            if (!server) {
+            const currentServer = serverRef.current;
+            if (!currentServer) {
               throw new Error("Server connection not available");
             }
 
@@ -624,7 +639,7 @@ function OpenAIComponentRendererBase({
 
             // Call the tool via the MCP connection
             // Use a 10 minute timeout for tool calls, as tools may trigger sampling
-            const result = await server.callTool(toolName, params || {}, {
+            const result = await currentServer.callTool(toolName, params || {}, {
               timeout: 600000, // 10 minutes
               resetTimeoutOnProgress: true,
             });
@@ -753,7 +768,7 @@ function OpenAIComponentRendererBase({
           try {
             const { mode } = event.data;
             if (mode && ["inline", "pip", "fullscreen"].includes(mode)) {
-              await handleDisplayModeChange(mode);
+              await handleDisplayModeChangeRef.current(mode);
             }
           } catch (err) {
             console.error(
@@ -860,16 +875,7 @@ function OpenAIComponentRendererBase({
       iframe?.removeEventListener("load", handleLoad);
       iframe?.removeEventListener("error", handleError);
     };
-  }, [
-    widgetUrl,
-    isSameOrigin,
-    handleDisplayModeChange,
-    server,
-    serverId,
-    resolvedTheme,
-    updateIframeGlobals,
-    useDevMode,
-  ]);
+  }, [widgetUrl, isSameOrigin, serverId, updateIframeGlobals, useDevMode]);
 
   // Sync theme changes to iframe's color-scheme for light-dark() CSS function
   // OpenAI Apps SDK UI uses [data-theme] attribute to set color-scheme via CSS
@@ -1080,6 +1086,7 @@ function OpenAIComponentRendererBase({
         )}
 
         <div
+          ref={fullscreenTargetRef}
           className={cn(
             "flex-1 w-full flex justify-center items-center relative",
             displayMode === "fullscreen" && "pt-14",

--- a/libraries/typescript/packages/inspector/src/client/components/OpenAIComponentRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/OpenAIComponentRenderer.tsx
@@ -639,10 +639,14 @@ function OpenAIComponentRendererBase({
 
             // Call the tool via the MCP connection
             // Use a 10 minute timeout for tool calls, as tools may trigger sampling
-            const result = await currentServer.callTool(toolName, params || {}, {
-              timeout: 600000, // 10 minutes
-              resetTimeoutOnProgress: true,
-            });
+            const result = await currentServer.callTool(
+              toolName,
+              params || {},
+              {
+                timeout: 600000, // 10 minutes
+                resetTimeoutOnProgress: true,
+              }
+            );
 
             // Format the result to match OpenAI's expected format
             // MCP tools return { contents: [...] }, we need to convert to OpenAI format

--- a/libraries/typescript/packages/inspector/src/client/components/OpenAIComponentRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/OpenAIComponentRenderer.tsx
@@ -8,11 +8,7 @@ import { IFRAME_SANDBOX_PERMISSIONS } from "../constants/iframe";
 import { useTheme } from "../context/ThemeContext";
 import { useWidgetDebug } from "../context/WidgetDebugContext";
 import { injectConsoleInterceptor } from "../utils/iframeConsoleInterceptor";
-import {
-  useWidgetFullscreenDocumentChrome,
-  WIDGET_FULLSCREEN_NATIVE_CLASSES,
-  WIDGET_FULLSCREEN_OVERLAY_CLASSES,
-} from "../lib/widget-fullscreen";
+import { useWidgetFullscreenControls } from "../lib/widget-fullscreen";
 import { FullscreenNavbar } from "./FullscreenNavbar";
 import { MCPAppsDebugControls } from "./MCPAppsDebugControls";
 import { Spinner } from "./ui/spinner";
@@ -131,9 +127,6 @@ function OpenAIComponentRendererBase({
   const [displayMode, setDisplayMode] = useState<
     "inline" | "pip" | "fullscreen"
   >("inline");
-  const [cssFullscreenFallback, setCssFullscreenFallback] = useState(false);
-
-  useWidgetFullscreenDocumentChrome(displayMode === "fullscreen");
   const [isSameOrigin, setIsSameOrigin] = useState<boolean>(false);
   const [isPipHovered, setIsPipHovered] = useState<boolean>(false);
   const [useDevMode, setUseDevMode] = useState<boolean>(false);
@@ -497,7 +490,7 @@ function OpenAIComponentRendererBase({
     });
   }, [toolResult, isReady, updateIframeGlobals]);
 
-  const applyDisplayMode = useCallback(
+  const setDisplayModeWithGlobals = useCallback(
     (mode: "inline" | "pip" | "fullscreen") => {
       setDisplayMode(mode);
       updateIframeGlobals({ displayMode: mode });
@@ -505,42 +498,12 @@ function OpenAIComponentRendererBase({
     [updateIframeGlobals]
   );
 
-  // Native Fullscreen API first; CSS overlay only when requestFullscreen fails
-  const handleDisplayModeChange = useCallback(
-    async (mode: "inline" | "pip" | "fullscreen") => {
-      if (mode === "fullscreen") {
-        if (document.fullscreenElement) {
-          setCssFullscreenFallback(false);
-          applyDisplayMode("fullscreen");
-          return;
-        }
-
-        try {
-          if (containerRef.current) {
-            await containerRef.current.requestFullscreen();
-          }
-          setCssFullscreenFallback(false);
-          applyDisplayMode("fullscreen");
-        } catch (err) {
-          console.error("[OpenAIComponentRenderer] Fullscreen error:", err);
-          setCssFullscreenFallback(true);
-          applyDisplayMode("fullscreen");
-        }
-        return;
-      }
-
-      try {
-        if (document.fullscreenElement) {
-          await document.exitFullscreen();
-        }
-      } catch (err) {
-        console.error("[OpenAIComponentRenderer] Exit fullscreen error:", err);
-      }
-      setCssFullscreenFallback(false);
-      applyDisplayMode(mode);
-    },
-    [applyDisplayMode]
-  );
+  const { handleDisplayModeChange, fullscreenShellClassName } =
+    useWidgetFullscreenControls({
+      containerRef,
+      displayMode,
+      setDisplayMode: setDisplayModeWithGlobals,
+    });
 
   // Handle postMessage communication with iframe
   useEffect(() => {
@@ -1009,28 +972,6 @@ function OpenAIComponentRendererBase({
     };
   }, [iframeHeight]);
 
-  // Listen for fullscreen changes to sync state
-  useEffect(() => {
-    const handleFullscreenChange = () => {
-      if (!document.fullscreenElement && displayMode === "fullscreen") {
-        setCssFullscreenFallback(false);
-        applyDisplayMode("inline");
-      } else if (document.fullscreenElement && displayMode !== "fullscreen") {
-        setCssFullscreenFallback(false);
-        applyDisplayMode("fullscreen");
-      }
-    };
-
-    document.addEventListener("fullscreenchange", handleFullscreenChange);
-    document.addEventListener("fullscreenerror", (e) => {
-      console.error("[OpenAIComponentRenderer] Fullscreen error:", e);
-    });
-
-    return () => {
-      document.removeEventListener("fullscreenchange", handleFullscreenChange);
-    };
-  }, [displayMode, applyDisplayMode]);
-
   // Watch for theme changes and update iframe
   // Also update when iframe becomes ready to ensure initial theme is set correctly
   useEffect(() => {
@@ -1099,10 +1040,7 @@ function OpenAIComponentRendererBase({
         className={cn(
           "w-full h-full flex flex-col justify-center items-center",
           centerVertically && "items-center",
-          displayMode === "fullscreen" &&
-            (cssFullscreenFallback
-              ? WIDGET_FULLSCREEN_OVERLAY_CLASSES
-              : WIDGET_FULLSCREEN_NATIVE_CLASSES),
+          fullscreenShellClassName,
           displayMode === "pip" &&
             `fixed top-4 left-1/2 -translate-x-1/2 z-50 rounded-3xl w-full min-w-[300px] h-[400px] shadow-2xl border overflow-hidden`
         )}

--- a/libraries/typescript/packages/inspector/src/client/components/OpenAIComponentRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/OpenAIComponentRenderer.tsx
@@ -113,7 +113,6 @@ function OpenAIComponentRendererBase({
     typeof window.HTMLIFrameElement
   > | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-  const fullscreenTargetRef = useRef<HTMLDivElement>(null);
   const [isReady, setIsReady] = useState(false);
   const [showSkeleton, setShowSkeleton] = useState(true);
   const hasLoadedOnceRef = useRef(false);
@@ -504,7 +503,6 @@ function OpenAIComponentRendererBase({
   const { handleDisplayModeChange, fullscreenShellClassName } =
     useWidgetFullscreenControls({
       containerRef,
-      fullscreenTargetRef,
       displayMode,
       setDisplayMode: setDisplayModeWithGlobals,
     });
@@ -1048,8 +1046,13 @@ function OpenAIComponentRendererBase({
       <div
         ref={containerRef}
         className={cn(
-          "w-full h-full flex flex-col justify-center items-center",
-          centerVertically && "items-center",
+          "w-full h-full flex flex-col min-h-0",
+          displayMode === "fullscreen"
+            ? "items-stretch justify-stretch"
+            : cn(
+                "justify-center items-center",
+                centerVertically && "items-center"
+              ),
           fullscreenShellClassName,
           displayMode === "pip" &&
             `fixed top-4 left-1/2 -translate-x-1/2 z-50 rounded-3xl w-full min-w-[300px] h-[400px] shadow-2xl border overflow-hidden`
@@ -1090,15 +1093,25 @@ function OpenAIComponentRendererBase({
         )}
 
         <div
-          ref={fullscreenTargetRef}
           className={cn(
-            "flex-1 w-full flex justify-center items-center relative",
-            displayMode === "fullscreen" && "pt-14",
-            centerVertically && "items-center",
+            "relative w-full min-h-0",
+            displayMode === "fullscreen" || displayMode === "pip"
+              ? "flex flex-1 flex-col"
+              : cn(
+                  "flex flex-1 justify-center items-center",
+                  centerVertically && "items-center"
+                ),
             displayMode === "inline" && (invoking || invoked) && "pt-8"
           )}
         >
-          <div className="relative w-full max-w-[768px]">
+          <div
+            className={cn(
+              "relative w-full",
+              displayMode === "fullscreen" || displayMode === "pip"
+                ? "h-full min-h-0 flex-1"
+                : "max-w-[768px]"
+            )}
+          >
             {displayMode === "inline" && (invoking || invoked) && (
               <div className="absolute -top-8 left-2 z-10 whitespace-nowrap">
                 {invoking && !toolResult && (

--- a/libraries/typescript/packages/inspector/src/client/components/OpenAIComponentRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/OpenAIComponentRenderer.tsx
@@ -3,7 +3,6 @@ import { TextShimmer } from "@/client/components/ui/text-shimmer";
 import { X } from "lucide-react";
 import { useMcpClient } from "mcp-use/react";
 import { memo, useCallback, useEffect, useRef, useState } from "react";
-import { createPortal } from "react-dom";
 import { MCP_APPS_CONFIG } from "../constants/mcp-apps";
 import { IFRAME_SANDBOX_PERMISSIONS } from "../constants/iframe";
 import { useTheme } from "../context/ThemeContext";
@@ -11,6 +10,7 @@ import { useWidgetDebug } from "../context/WidgetDebugContext";
 import { injectConsoleInterceptor } from "../utils/iframeConsoleInterceptor";
 import {
   useWidgetFullscreenDocumentChrome,
+  WIDGET_FULLSCREEN_NATIVE_CLASSES,
   WIDGET_FULLSCREEN_OVERLAY_CLASSES,
 } from "../lib/widget-fullscreen";
 import { FullscreenNavbar } from "./FullscreenNavbar";
@@ -131,6 +131,7 @@ function OpenAIComponentRendererBase({
   const [displayMode, setDisplayMode] = useState<
     "inline" | "pip" | "fullscreen"
   >("inline");
+  const [cssFullscreenFallback, setCssFullscreenFallback] = useState(false);
 
   useWidgetFullscreenDocumentChrome(displayMode === "fullscreen");
   const [isSameOrigin, setIsSameOrigin] = useState<boolean>(false);
@@ -496,42 +497,49 @@ function OpenAIComponentRendererBase({
     });
   }, [toolResult, isReady, updateIframeGlobals]);
 
-  // Handle display mode changes with native Fullscreen API
-  const handleDisplayModeChange = useCallback(
-    async (mode: "inline" | "pip" | "fullscreen") => {
-      try {
-        if (mode === "fullscreen") {
-          // Enter fullscreen
-          if (document.fullscreenElement) {
-            // Already in fullscreen, just update state
-            setDisplayMode(mode);
-            updateIframeGlobals({ displayMode: mode });
-            return;
-          }
-
-          if (containerRef.current) {
-            await containerRef.current.requestFullscreen();
-            setDisplayMode(mode);
-            updateIframeGlobals({ displayMode: mode });
-            console.log("[OpenAIComponentRenderer] Entered fullscreen");
-          }
-        } else {
-          // Exit fullscreen
-          if (document.fullscreenElement) {
-            await document.exitFullscreen();
-          }
-          setDisplayMode(mode);
-          updateIframeGlobals({ displayMode: mode });
-          console.log("[OpenAIComponentRenderer] Exited fullscreen");
-        }
-      } catch (err) {
-        console.error("[OpenAIComponentRenderer] Fullscreen error:", err);
-        // Fallback to CSS-based fullscreen if native API fails
-        setDisplayMode(mode);
-        updateIframeGlobals({ displayMode: mode });
-      }
+  const applyDisplayMode = useCallback(
+    (mode: "inline" | "pip" | "fullscreen") => {
+      setDisplayMode(mode);
+      updateIframeGlobals({ displayMode: mode });
     },
     [updateIframeGlobals]
+  );
+
+  // Native Fullscreen API first; CSS overlay only when requestFullscreen fails
+  const handleDisplayModeChange = useCallback(
+    async (mode: "inline" | "pip" | "fullscreen") => {
+      if (mode === "fullscreen") {
+        if (document.fullscreenElement) {
+          setCssFullscreenFallback(false);
+          applyDisplayMode("fullscreen");
+          return;
+        }
+
+        try {
+          if (containerRef.current) {
+            await containerRef.current.requestFullscreen();
+          }
+          setCssFullscreenFallback(false);
+          applyDisplayMode("fullscreen");
+        } catch (err) {
+          console.error("[OpenAIComponentRenderer] Fullscreen error:", err);
+          setCssFullscreenFallback(true);
+          applyDisplayMode("fullscreen");
+        }
+        return;
+      }
+
+      try {
+        if (document.fullscreenElement) {
+          await document.exitFullscreen();
+        }
+      } catch (err) {
+        console.error("[OpenAIComponentRenderer] Exit fullscreen error:", err);
+      }
+      setCssFullscreenFallback(false);
+      applyDisplayMode(mode);
+    },
+    [applyDisplayMode]
   );
 
   // Handle postMessage communication with iframe
@@ -1005,14 +1013,11 @@ function OpenAIComponentRendererBase({
   useEffect(() => {
     const handleFullscreenChange = () => {
       if (!document.fullscreenElement && displayMode === "fullscreen") {
-        // User exited fullscreen via ESC or other means
-        setDisplayMode("inline");
-        updateIframeGlobals({ displayMode: "inline" });
-        console.log("[OpenAIComponentRenderer] Fullscreen exited by user");
+        setCssFullscreenFallback(false);
+        applyDisplayMode("inline");
       } else if (document.fullscreenElement && displayMode !== "fullscreen") {
-        // Fullscreen was entered externally
-        setDisplayMode("fullscreen");
-        updateIframeGlobals({ displayMode: "fullscreen" });
+        setCssFullscreenFallback(false);
+        applyDisplayMode("fullscreen");
       }
     };
 
@@ -1024,7 +1029,7 @@ function OpenAIComponentRendererBase({
     return () => {
       document.removeEventListener("fullscreenchange", handleFullscreenChange);
     };
-  }, [displayMode, updateIframeGlobals]);
+  }, [displayMode, applyDisplayMode]);
 
   // Watch for theme changes and update iframe
   // Also update when iframe becomes ready to ensure initial theme is set correctly
@@ -1089,101 +1094,95 @@ function OpenAIComponentRendererBase({
             />
           </div>
         )}
-      {(() => {
-        const widgetShell = (
-          <div
-            ref={containerRef}
+      <div
+        ref={containerRef}
+        className={cn(
+          "w-full h-full flex flex-col justify-center items-center",
+          centerVertically && "items-center",
+          displayMode === "fullscreen" &&
+            (cssFullscreenFallback
+              ? WIDGET_FULLSCREEN_OVERLAY_CLASSES
+              : WIDGET_FULLSCREEN_NATIVE_CLASSES),
+          displayMode === "pip" &&
+            `fixed top-4 left-1/2 -translate-x-1/2 z-50 rounded-3xl w-full min-w-[300px] h-[400px] shadow-2xl border overflow-hidden`
+        )}
+        style={
+          displayMode === "pip"
+            ? { maxWidth: MCP_APPS_CONFIG.DIMENSIONS.PIP_MAX_WIDTH }
+            : undefined
+        }
+        onMouseEnter={() => displayMode === "pip" && setIsPipHovered(true)}
+        onMouseLeave={() => displayMode === "pip" && setIsPipHovered(false)}
+      >
+        {displayMode === "fullscreen" && (
+          <FullscreenNavbar
+            title={toolName}
+            onClose={() => handleDisplayModeChange("inline")}
+          />
+        )}
+
+        {displayMode === "pip" && (
+          <button
+            onClick={() => handleDisplayModeChange("inline")}
             className={cn(
-              "w-full h-full flex flex-col justify-center items-center",
-              centerVertically && "items-center",
-              displayMode === "fullscreen" && WIDGET_FULLSCREEN_OVERLAY_CLASSES,
-              displayMode === "pip" &&
-                `fixed top-4 left-1/2 -translate-x-1/2 z-50 rounded-3xl w-full min-w-[300px] h-[400px] shadow-2xl border overflow-hidden`
+              "absolute top-2 right-2 z-50",
+              "flex items-center justify-center",
+              "w-8 h-8 rounded-full",
+              "bg-background/90 hover:bg-background",
+              "border border-border",
+              "shadow-lg",
+              "transition-opacity duration-200",
+              "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+              isPipHovered ? "opacity-100" : "opacity-0"
             )}
-            style={
-              displayMode === "pip"
-                ? { maxWidth: MCP_APPS_CONFIG.DIMENSIONS.PIP_MAX_WIDTH }
-                : undefined
-            }
-            onMouseEnter={() => displayMode === "pip" && setIsPipHovered(true)}
-            onMouseLeave={() => displayMode === "pip" && setIsPipHovered(false)}
+            aria-label="Exit Picture in Picture"
           >
-            {displayMode === "fullscreen" && (
-              <FullscreenNavbar
-                title={toolName}
-                onClose={() => handleDisplayModeChange("inline")}
-              />
-            )}
+            <X className="w-4 h-4 text-foreground" />
+          </button>
+        )}
 
-            {displayMode === "pip" && (
-              <button
-                onClick={() => handleDisplayModeChange("inline")}
-                className={cn(
-                  "absolute top-2 right-2 z-50",
-                  "flex items-center justify-center",
-                  "w-8 h-8 rounded-full",
-                  "bg-background/90 hover:bg-background",
-                  "border border-border",
-                  "shadow-lg",
-                  "transition-opacity duration-200",
-                  "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
-                  isPipHovered ? "opacity-100" : "opacity-0"
+        <div
+          className={cn(
+            "flex-1 w-full flex justify-center items-center relative",
+            displayMode === "fullscreen" && "pt-14",
+            centerVertically && "items-center",
+            displayMode === "inline" && (invoking || invoked) && "pt-8"
+          )}
+        >
+          <div className="relative w-full max-w-[768px]">
+            {displayMode === "inline" && (invoking || invoked) && (
+              <div className="absolute -top-8 left-2 z-10 whitespace-nowrap">
+                {invoking && !toolResult && (
+                  <TextShimmer className="text-xs">{invoking}</TextShimmer>
                 )}
-                aria-label="Exit Picture in Picture"
-              >
-                <X className="w-4 h-4 text-foreground" />
-              </button>
-            )}
-
-            <div
-              className={cn(
-                "flex-1 w-full flex justify-center items-center relative",
-                displayMode === "fullscreen" && "pt-14",
-                centerVertically && "items-center",
-                displayMode === "inline" && (invoking || invoked) && "pt-8"
-              )}
-            >
-              <div className="relative w-full max-w-[768px]">
-                {/* Status label above the widget — only in inline mode, matching MCPAppsRenderer */}
-                {displayMode === "inline" && (invoking || invoked) && (
-                  <div className="absolute -top-8 left-2 z-10 whitespace-nowrap">
-                    {invoking && !toolResult && (
-                      <TextShimmer className="text-xs">{invoking}</TextShimmer>
-                    )}
-                    {invoked && toolResult && (
-                      <span className="text-xs text-muted-foreground">
-                        {invoked}
-                      </span>
-                    )}
-                  </div>
+                {invoked && toolResult && (
+                  <span className="text-xs text-muted-foreground">
+                    {invoked}
+                  </span>
                 )}
-                <iframe
-                  ref={iframeRef}
-                  src={widgetUrl}
-                  className={cn(
-                    displayMode === "inline" && "w-full",
-                    displayMode === "fullscreen" &&
-                      "w-full h-full rounded-none",
-                    displayMode === "pip" && "w-full h-full rounded-lg"
-                  )}
-                  style={{
-                    height:
-                      displayMode === "fullscreen" || displayMode === "pip"
-                        ? "100%"
-                        : `${iframeHeight}px`,
-                  }}
-                  sandbox={IFRAME_SANDBOX_PERMISSIONS}
-                  title={`OpenAI Component: ${toolName}`}
-                  allow="web-share"
-                />
               </div>
-            </div>
+            )}
+            <iframe
+              ref={iframeRef}
+              src={widgetUrl}
+              className={cn(
+                displayMode === "inline" && "w-full",
+                displayMode === "fullscreen" && "w-full h-full rounded-none",
+                displayMode === "pip" && "w-full h-full rounded-lg"
+              )}
+              style={{
+                height:
+                  displayMode === "fullscreen" || displayMode === "pip"
+                    ? "100%"
+                    : `${iframeHeight}px`,
+              }}
+              sandbox={IFRAME_SANDBOX_PERMISSIONS}
+              title={`OpenAI Component: ${toolName}`}
+              allow="web-share"
+            />
           </div>
-        );
-        return displayMode === "fullscreen" && typeof document !== "undefined"
-          ? createPortal(widgetShell, document.body)
-          : widgetShell;
-      })()}
+        </div>
+      </div>
     </Wrapper>
   );
 }

--- a/libraries/typescript/packages/inspector/src/client/components/OpenAIComponentRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/OpenAIComponentRenderer.tsx
@@ -3,12 +3,13 @@ import { TextShimmer } from "@/client/components/ui/text-shimmer";
 import { X } from "lucide-react";
 import { useMcpClient } from "mcp-use/react";
 import { memo, useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { MCP_APPS_CONFIG } from "../constants/mcp-apps";
 import { IFRAME_SANDBOX_PERMISSIONS } from "../constants/iframe";
 import { useTheme } from "../context/ThemeContext";
 import { useWidgetDebug } from "../context/WidgetDebugContext";
 import { injectConsoleInterceptor } from "../utils/iframeConsoleInterceptor";
-import { useWidgetFullscreenControls } from "../lib/widget-fullscreen";
+import { useWidgetDisplayModeControls } from "../lib/widget-fullscreen";
 import { FullscreenNavbar } from "./FullscreenNavbar";
 import { MCPAppsDebugControls } from "./MCPAppsDebugControls";
 import { Spinner } from "./ui/spinner";
@@ -500,12 +501,32 @@ function OpenAIComponentRendererBase({
     [updateIframeGlobals]
   );
 
-  const { handleDisplayModeChange, fullscreenShellClassName } =
-    useWidgetFullscreenControls({
-      containerRef,
-      displayMode,
-      setDisplayMode: setDisplayModeWithGlobals,
-    });
+  const {
+    handleDisplayModeChange,
+    fullscreenShellClassName,
+    pipShellClassName,
+    isPip,
+  } = useWidgetDisplayModeControls({
+    containerRef,
+    displayMode,
+    setDisplayMode: setDisplayModeWithGlobals,
+  });
+
+  const iframeMountCountRef = useRef(0);
+  const [iframeMountGeneration, setIframeMountGeneration] = useState(0);
+
+  const setIframeRef = useCallback((node: HTMLIFrameElement | null) => {
+    iframeRef.current = node;
+    if (!node) return;
+    iframeMountCountRef.current += 1;
+    if (iframeMountCountRef.current > 1) {
+      setIframeMountGeneration((g) => g + 1);
+      if (hasLoadedOnceRef.current) {
+        setShowSkeleton(true);
+        setIsReady(false);
+      }
+    }
+  }, []);
 
   const handleDisplayModeChangeRef = useRef(handleDisplayModeChange);
   handleDisplayModeChangeRef.current = handleDisplayModeChange;
@@ -532,11 +553,8 @@ function OpenAIComponentRendererBase({
     let hasHandledLoad = false;
 
     const handleMessage = async (event: any) => {
-      // Only accept messages from our iframe
-      if (
-        !iframeRef.current ||
-        event.source !== iframeRef.current.contentWindow
-      ) {
+      const activeIframe = iframeRef.current;
+      if (!activeIframe || event.source !== activeIframe.contentWindow) {
         return;
       }
 
@@ -877,7 +895,14 @@ function OpenAIComponentRendererBase({
       iframe?.removeEventListener("load", handleLoad);
       iframe?.removeEventListener("error", handleError);
     };
-  }, [widgetUrl, isSameOrigin, serverId, updateIframeGlobals, useDevMode]);
+  }, [
+    widgetUrl,
+    isSameOrigin,
+    serverId,
+    updateIframeGlobals,
+    useDevMode,
+    iframeMountGeneration,
+  ]);
 
   // Sync theme changes to iframe's color-scheme for light-dark() CSS function
   // OpenAI Apps SDK UI uses [data-theme] attribute to set color-scheme via CSS
@@ -907,13 +932,8 @@ function OpenAIComponentRendererBase({
   }, [resolvedTheme, isReady, isSameOrigin, updateIframeGlobals]);
 
   // Hide skeleton once the iframe has loaded real content.
-  // The readyState guard in the load handler already ensures we only set
-  // isReady when the iframe has actual scripts (not a stale blank document),
-  // so no additional delay is needed.
   useEffect(() => {
-    if (!isReady || !showSkeleton) {
-      return;
-    }
+    if (!isReady || !showSkeleton) return;
     setShowSkeleton(false);
     hasLoadedOnceRef.current = true;
   }, [isReady, showSkeleton]);
@@ -1014,9 +1034,111 @@ function OpenAIComponentRendererBase({
     );
   }
 
+  const widgetShell = (
+    <div
+      ref={containerRef}
+      className={cn(
+        "w-full h-full flex flex-col min-h-0",
+        displayMode === "fullscreen"
+          ? "items-stretch justify-stretch"
+          : cn(
+              "justify-center items-center",
+              centerVertically && "items-center"
+            ),
+        fullscreenShellClassName,
+        pipShellClassName
+      )}
+      style={
+        isPip
+          ? { maxWidth: MCP_APPS_CONFIG.DIMENSIONS.PIP_MAX_WIDTH }
+          : undefined
+      }
+      onMouseEnter={() => isPip && setIsPipHovered(true)}
+      onMouseLeave={() => isPip && setIsPipHovered(false)}
+    >
+      {displayMode === "fullscreen" && (
+        <FullscreenNavbar
+          title={toolName}
+          onClose={() => handleDisplayModeChange("inline")}
+        />
+      )}
+
+      {isPip && (
+        <button
+          onClick={() => handleDisplayModeChange("inline")}
+          className={cn(
+            "absolute top-2 right-2 z-50",
+            "flex items-center justify-center",
+            "w-8 h-8 rounded-full",
+            "bg-background/90 hover:bg-background",
+            "border border-border",
+            "shadow-lg",
+            "transition-opacity duration-200",
+            "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+            isPipHovered ? "opacity-100" : "opacity-0"
+          )}
+          aria-label="Exit Picture in Picture"
+        >
+          <X className="w-4 h-4 text-foreground" />
+        </button>
+      )}
+
+      <div
+        className={cn(
+          "relative w-full min-h-0",
+          displayMode === "fullscreen" || displayMode === "pip"
+            ? "flex flex-1 flex-col"
+            : cn(
+                "flex flex-1 justify-center items-center",
+                centerVertically && "items-center"
+              ),
+          displayMode === "inline" && (invoking || invoked) && "pt-8"
+        )}
+      >
+        <div
+          className={cn(
+            "relative w-full",
+            displayMode === "fullscreen" || displayMode === "pip"
+              ? "h-full min-h-0 flex-1"
+              : "max-w-[768px]"
+          )}
+        >
+          {displayMode === "inline" && (invoking || invoked) && (
+            <div className="absolute -top-8 left-2 z-10 whitespace-nowrap">
+              {invoking && !toolResult && (
+                <TextShimmer className="text-xs">{invoking}</TextShimmer>
+              )}
+              {invoked && toolResult && (
+                <span className="text-xs text-muted-foreground">{invoked}</span>
+              )}
+            </div>
+          )}
+          <iframe
+            ref={setIframeRef}
+            src={widgetUrl}
+            className={cn(
+              displayMode === "inline" && "w-full",
+              displayMode === "fullscreen" && "w-full h-full rounded-none",
+              displayMode === "pip" && "w-full h-full rounded-lg"
+            )}
+            style={{
+              height:
+                displayMode === "fullscreen" || displayMode === "pip"
+                  ? "100%"
+                  : `${iframeHeight}px`,
+            }}
+            sandbox={IFRAME_SANDBOX_PERMISSIONS}
+            title={`OpenAI Component: ${toolName}`}
+            allow="web-share"
+          />
+        </div>
+      </div>
+    </div>
+  );
+
   return (
     <Wrapper className={className} noWrapper={noWrapper}>
-      {showSkeleton && (
+      {!isPip && showSkeleton && (
         <div className="flex absolute left-0 top-0 items-center justify-center w-full h-full z-0">
           <Spinner className="size-5" />
         </div>
@@ -1024,8 +1146,8 @@ function OpenAIComponentRendererBase({
 
       {showConsole &&
         isSameOrigin &&
-        displayMode !== "fullscreen" &&
-        displayMode !== "pip" && (
+        !isPip &&
+        displayMode !== "fullscreen" && (
           <div className="absolute top-2 right-2 z-30 flex items-center gap-2">
             <MCPAppsDebugControls
               displayMode={displayMode}
@@ -1043,108 +1165,19 @@ function OpenAIComponentRendererBase({
             />
           </div>
         )}
-      <div
-        ref={containerRef}
-        className={cn(
-          "w-full h-full flex flex-col min-h-0",
-          displayMode === "fullscreen"
-            ? "items-stretch justify-stretch"
-            : cn(
-                "justify-center items-center",
-                centerVertically && "items-center"
-              ),
-          fullscreenShellClassName,
-          displayMode === "pip" &&
-            `fixed top-4 left-1/2 -translate-x-1/2 z-50 rounded-3xl w-full min-w-[300px] h-[400px] shadow-2xl border overflow-hidden`
-        )}
-        style={
-          displayMode === "pip"
-            ? { maxWidth: MCP_APPS_CONFIG.DIMENSIONS.PIP_MAX_WIDTH }
-            : undefined
-        }
-        onMouseEnter={() => displayMode === "pip" && setIsPipHovered(true)}
-        onMouseLeave={() => displayMode === "pip" && setIsPipHovered(false)}
-      >
-        {displayMode === "fullscreen" && (
-          <FullscreenNavbar
-            title={toolName}
-            onClose={() => handleDisplayModeChange("inline")}
-          />
-        )}
 
-        {displayMode === "pip" && (
-          <button
-            onClick={() => handleDisplayModeChange("inline")}
-            className={cn(
-              "absolute top-2 right-2 z-50",
-              "flex items-center justify-center",
-              "w-8 h-8 rounded-full",
-              "bg-background/90 hover:bg-background",
-              "border border-border",
-              "shadow-lg",
-              "transition-opacity duration-200",
-              "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
-              isPipHovered ? "opacity-100" : "opacity-0"
-            )}
-            aria-label="Exit Picture in Picture"
-          >
-            <X className="w-4 h-4 text-foreground" />
-          </button>
-        )}
-
-        <div
-          className={cn(
-            "relative w-full min-h-0",
-            displayMode === "fullscreen" || displayMode === "pip"
-              ? "flex flex-1 flex-col"
-              : cn(
-                  "flex flex-1 justify-center items-center",
-                  centerVertically && "items-center"
-                ),
-            displayMode === "inline" && (invoking || invoked) && "pt-8"
+      {isPip && typeof document !== "undefined" ? (
+        <>
+          {showSkeleton && (
+            <div className="fixed inset-0 z-[99] flex items-center justify-center bg-background/40">
+              <Spinner className="size-5" />
+            </div>
           )}
-        >
-          <div
-            className={cn(
-              "relative w-full",
-              displayMode === "fullscreen" || displayMode === "pip"
-                ? "h-full min-h-0 flex-1"
-                : "max-w-[768px]"
-            )}
-          >
-            {displayMode === "inline" && (invoking || invoked) && (
-              <div className="absolute -top-8 left-2 z-10 whitespace-nowrap">
-                {invoking && !toolResult && (
-                  <TextShimmer className="text-xs">{invoking}</TextShimmer>
-                )}
-                {invoked && toolResult && (
-                  <span className="text-xs text-muted-foreground">
-                    {invoked}
-                  </span>
-                )}
-              </div>
-            )}
-            <iframe
-              ref={iframeRef}
-              src={widgetUrl}
-              className={cn(
-                displayMode === "inline" && "w-full",
-                displayMode === "fullscreen" && "w-full h-full rounded-none",
-                displayMode === "pip" && "w-full h-full rounded-lg"
-              )}
-              style={{
-                height:
-                  displayMode === "fullscreen" || displayMode === "pip"
-                    ? "100%"
-                    : `${iframeHeight}px`,
-              }}
-              sandbox={IFRAME_SANDBOX_PERMISSIONS}
-              title={`OpenAI Component: ${toolName}`}
-              allow="web-share"
-            />
-          </div>
-        </div>
-      </div>
+          {createPortal(widgetShell, document.body)}
+        </>
+      ) : (
+        widgetShell
+      )}
     </Wrapper>
   );
 }

--- a/libraries/typescript/packages/inspector/src/client/components/OpenAIComponentRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/OpenAIComponentRenderer.tsx
@@ -3,11 +3,16 @@ import { TextShimmer } from "@/client/components/ui/text-shimmer";
 import { X } from "lucide-react";
 import { useMcpClient } from "mcp-use/react";
 import { memo, useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { MCP_APPS_CONFIG } from "../constants/mcp-apps";
 import { IFRAME_SANDBOX_PERMISSIONS } from "../constants/iframe";
 import { useTheme } from "../context/ThemeContext";
 import { useWidgetDebug } from "../context/WidgetDebugContext";
 import { injectConsoleInterceptor } from "../utils/iframeConsoleInterceptor";
+import {
+  useWidgetFullscreenDocumentChrome,
+  WIDGET_FULLSCREEN_OVERLAY_CLASSES,
+} from "../lib/widget-fullscreen";
 import { FullscreenNavbar } from "./FullscreenNavbar";
 import { MCPAppsDebugControls } from "./MCPAppsDebugControls";
 import { Spinner } from "./ui/spinner";
@@ -126,6 +131,8 @@ function OpenAIComponentRendererBase({
   const [displayMode, setDisplayMode] = useState<
     "inline" | "pip" | "fullscreen"
   >("inline");
+
+  useWidgetFullscreenDocumentChrome(displayMode === "fullscreen");
   const [isSameOrigin, setIsSameOrigin] = useState<boolean>(false);
   const [isPipHovered, setIsPipHovered] = useState<boolean>(false);
   const [useDevMode, setUseDevMode] = useState<boolean>(false);
@@ -1082,93 +1089,101 @@ function OpenAIComponentRendererBase({
             />
           </div>
         )}
-      <div
-        ref={containerRef}
-        className={cn(
-          "w-full h-full flex flex-col justify-center items-center",
-          centerVertically && "items-center",
-          displayMode === "fullscreen" && "bg-background",
-          displayMode === "pip" &&
-            `fixed top-4 left-1/2 -translate-x-1/2 z-50 rounded-3xl w-full min-w-[300px] h-[400px] shadow-2xl border overflow-hidden`
-        )}
-        style={
-          displayMode === "pip"
-            ? { maxWidth: MCP_APPS_CONFIG.DIMENSIONS.PIP_MAX_WIDTH }
-            : undefined
-        }
-        onMouseEnter={() => displayMode === "pip" && setIsPipHovered(true)}
-        onMouseLeave={() => displayMode === "pip" && setIsPipHovered(false)}
-      >
-        {displayMode === "fullscreen" && document.fullscreenElement && (
-          <FullscreenNavbar
-            title={toolName}
-            onClose={() => handleDisplayModeChange("inline")}
-          />
-        )}
-
-        {displayMode === "pip" && (
-          <button
-            onClick={() => handleDisplayModeChange("inline")}
+      {(() => {
+        const widgetShell = (
+          <div
+            ref={containerRef}
             className={cn(
-              "absolute top-2 right-2 z-50",
-              "flex items-center justify-center",
-              "w-8 h-8 rounded-full",
-              "bg-background/90 hover:bg-background",
-              "border border-border",
-              "shadow-lg",
-              "transition-opacity duration-200",
-              "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
-              isPipHovered ? "opacity-100" : "opacity-0"
+              "w-full h-full flex flex-col justify-center items-center",
+              centerVertically && "items-center",
+              displayMode === "fullscreen" && WIDGET_FULLSCREEN_OVERLAY_CLASSES,
+              displayMode === "pip" &&
+                `fixed top-4 left-1/2 -translate-x-1/2 z-50 rounded-3xl w-full min-w-[300px] h-[400px] shadow-2xl border overflow-hidden`
             )}
-            aria-label="Exit Picture in Picture"
+            style={
+              displayMode === "pip"
+                ? { maxWidth: MCP_APPS_CONFIG.DIMENSIONS.PIP_MAX_WIDTH }
+                : undefined
+            }
+            onMouseEnter={() => displayMode === "pip" && setIsPipHovered(true)}
+            onMouseLeave={() => displayMode === "pip" && setIsPipHovered(false)}
           >
-            <X className="w-4 h-4 text-foreground" />
-          </button>
-        )}
-
-        <div
-          className={cn(
-            "flex-1 w-full flex justify-center items-center relative",
-            displayMode === "fullscreen" && "pt-14",
-            centerVertically && "items-center",
-            displayMode === "inline" && (invoking || invoked) && "pt-8"
-          )}
-        >
-          <div className="relative w-full max-w-[768px]">
-            {/* Status label above the widget — only in inline mode, matching MCPAppsRenderer */}
-            {displayMode === "inline" && (invoking || invoked) && (
-              <div className="absolute -top-8 left-2 z-10 whitespace-nowrap">
-                {invoking && !toolResult && (
-                  <TextShimmer className="text-xs">{invoking}</TextShimmer>
-                )}
-                {invoked && toolResult && (
-                  <span className="text-xs text-muted-foreground">
-                    {invoked}
-                  </span>
-                )}
-              </div>
+            {displayMode === "fullscreen" && (
+              <FullscreenNavbar
+                title={toolName}
+                onClose={() => handleDisplayModeChange("inline")}
+              />
             )}
-            <iframe
-              ref={iframeRef}
-              src={widgetUrl}
+
+            {displayMode === "pip" && (
+              <button
+                onClick={() => handleDisplayModeChange("inline")}
+                className={cn(
+                  "absolute top-2 right-2 z-50",
+                  "flex items-center justify-center",
+                  "w-8 h-8 rounded-full",
+                  "bg-background/90 hover:bg-background",
+                  "border border-border",
+                  "shadow-lg",
+                  "transition-opacity duration-200",
+                  "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+                  isPipHovered ? "opacity-100" : "opacity-0"
+                )}
+                aria-label="Exit Picture in Picture"
+              >
+                <X className="w-4 h-4 text-foreground" />
+              </button>
+            )}
+
+            <div
               className={cn(
-                displayMode === "inline" && "w-full",
-                displayMode === "fullscreen" && "w-full h-full rounded-none",
-                displayMode === "pip" && "w-full h-full rounded-lg"
+                "flex-1 w-full flex justify-center items-center relative",
+                displayMode === "fullscreen" && "pt-14",
+                centerVertically && "items-center",
+                displayMode === "inline" && (invoking || invoked) && "pt-8"
               )}
-              style={{
-                height:
-                  displayMode === "fullscreen" || displayMode === "pip"
-                    ? "100%"
-                    : `${iframeHeight}px`,
-              }}
-              sandbox={IFRAME_SANDBOX_PERMISSIONS}
-              title={`OpenAI Component: ${toolName}`}
-              allow="web-share"
-            />
+            >
+              <div className="relative w-full max-w-[768px]">
+                {/* Status label above the widget — only in inline mode, matching MCPAppsRenderer */}
+                {displayMode === "inline" && (invoking || invoked) && (
+                  <div className="absolute -top-8 left-2 z-10 whitespace-nowrap">
+                    {invoking && !toolResult && (
+                      <TextShimmer className="text-xs">{invoking}</TextShimmer>
+                    )}
+                    {invoked && toolResult && (
+                      <span className="text-xs text-muted-foreground">
+                        {invoked}
+                      </span>
+                    )}
+                  </div>
+                )}
+                <iframe
+                  ref={iframeRef}
+                  src={widgetUrl}
+                  className={cn(
+                    displayMode === "inline" && "w-full",
+                    displayMode === "fullscreen" &&
+                      "w-full h-full rounded-none",
+                    displayMode === "pip" && "w-full h-full rounded-lg"
+                  )}
+                  style={{
+                    height:
+                      displayMode === "fullscreen" || displayMode === "pip"
+                        ? "100%"
+                        : `${iframeHeight}px`,
+                  }}
+                  sandbox={IFRAME_SANDBOX_PERMISSIONS}
+                  title={`OpenAI Component: ${toolName}`}
+                  allow="web-share"
+                />
+              </div>
+            </div>
           </div>
-        </div>
-      </div>
+        );
+        return displayMode === "fullscreen" && typeof document !== "undefined"
+          ? createPortal(widgetShell, document.body)
+          : widgetShell;
+      })()}
     </Wrapper>
   );
 }

--- a/libraries/typescript/packages/inspector/src/client/components/ui/SandboxedIframe.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ui/SandboxedIframe.tsx
@@ -53,6 +53,8 @@ interface SandboxedIframeProps {
   onProxyReady?: () => void;
   /** Callback when the outer iframe has loaded */
   onLoad?: () => void;
+  /** Fired once when this sandbox instance mounts (used to detect remounts). */
+  onSandboxMount?: () => void;
   /** Callback for messages from guest UI (excluding sandbox-internal messages) */
   onMessage: (event: MessageEvent) => void;
   /** CSS class for the outer iframe */
@@ -83,6 +85,7 @@ export const SandboxedIframe = forwardRef<
     permissive,
     onProxyReady,
     onLoad,
+    onSandboxMount,
     onMessage,
     className,
     style,
@@ -92,6 +95,10 @@ export const SandboxedIframe = forwardRef<
 ) {
   const outerRef = useRef<HTMLIFrameElement>(null);
   const [proxyReady, setProxyReady] = useState(false);
+
+  useEffect(() => {
+    onSandboxMount?.();
+  }, [onSandboxMount]);
 
   // SEP-1865: Host and Sandbox MUST have different origins
   const [sandboxProxyUrl] = useState(() => {

--- a/libraries/typescript/packages/inspector/src/client/lib/use-sandbox-remount-generation.ts
+++ b/libraries/typescript/packages/inspector/src/client/lib/use-sandbox-remount-generation.ts
@@ -1,0 +1,21 @@
+import { useCallback, useRef, useState } from "react";
+
+/**
+ * Tracks SandboxedIframe remounts so AppBridge can tear down and reconnect.
+ * First mount does not increment; subsequent mounts (e.g. PiP portal) do.
+ */
+export function useSandboxRemountGeneration() {
+  const [generation, setGeneration] = useState(0);
+  const hasMountedOnceRef = useRef(false);
+
+  const onSandboxMount = useCallback(() => {
+    if (!hasMountedOnceRef.current) {
+      hasMountedOnceRef.current = true;
+      return false;
+    }
+    setGeneration((g) => g + 1);
+    return true;
+  }, []);
+
+  return { sandboxGeneration: generation, onSandboxMount };
+}

--- a/libraries/typescript/packages/inspector/src/client/lib/widget-fullscreen.ts
+++ b/libraries/typescript/packages/inspector/src/client/lib/widget-fullscreen.ts
@@ -31,13 +31,18 @@ export function useWidgetFullscreenDocumentChrome(active: boolean): void {
 /** Native Fullscreen API first; CSS overlay only when `requestFullscreen` fails. */
 export function useWidgetFullscreenControls({
   containerRef,
+  fullscreenTargetRef,
   displayMode,
   setDisplayMode,
 }: {
+  /** Layout shell (navbar, padding). Not used for `requestFullscreen` when `fullscreenTargetRef` is set. */
   containerRef: RefObject<HTMLElement | null>;
+  /** Element promoted to browser fullscreen (typically the iframe wrapper). */
+  fullscreenTargetRef?: RefObject<HTMLElement | null>;
   displayMode: WidgetDisplayMode;
   setDisplayMode: (mode: WidgetDisplayMode) => void;
 }) {
+  const fullscreenElementRef = fullscreenTargetRef ?? containerRef;
   const [cssFallback, setCssFallback] = useState(false);
   const isFullscreen = displayMode === "fullscreen";
 
@@ -59,13 +64,12 @@ export function useWidgetFullscreenControls({
     async (mode: WidgetDisplayMode) => {
       if (mode === "fullscreen") {
         try {
-          await containerRef.current?.requestFullscreen();
+          await fullscreenElementRef.current?.requestFullscreen();
           setCssFallback(false);
-          setDisplayMode("fullscreen");
         } catch {
           setCssFallback(true);
-          setDisplayMode("fullscreen");
         }
+        setDisplayMode("fullscreen");
         return;
       }
 
@@ -79,7 +83,7 @@ export function useWidgetFullscreenControls({
       setCssFallback(false);
       setDisplayMode(mode);
     },
-    [containerRef, setDisplayMode]
+    [fullscreenElementRef, setDisplayMode]
   );
 
   const fullscreenShellClassName = isFullscreen

--- a/libraries/typescript/packages/inspector/src/client/lib/widget-fullscreen.ts
+++ b/libraries/typescript/packages/inspector/src/client/lib/widget-fullscreen.ts
@@ -1,14 +1,38 @@
 import { useEffect } from "react";
 
-/** Viewport-covering shell for CSS fullscreen (portaled to `document.body`). */
+/** Viewport-covering shell when Fullscreen API is unavailable (CSS fallback). */
 export const WIDGET_FULLSCREEN_OVERLAY_CLASSES =
   "fixed inset-0 z-[100] w-full h-full bg-background flex flex-col";
 
+/** Minimal shell when the browser owns the viewport via Fullscreen API. */
+export const WIDGET_FULLSCREEN_NATIVE_CLASSES =
+  "w-full h-full bg-background flex flex-col";
+
 /**
- * Set on `document.documentElement` while a widget is in CSS fullscreen so host
+ * Set on `document.documentElement` while a widget is in fullscreen so host
  * apps (e.g. cloud dashboard) can hide sidebars / chat chrome.
  */
 export const WIDGET_FULLSCREEN_DOCUMENT_ATTR = "data-mcp-widget-fullscreen";
+
+/** True when display mode is fullscreen but the container is not the native fullscreen element. */
+export function isCssFullscreenFallback(
+  isFullscreenMode: boolean,
+  container: HTMLElement | null
+): boolean {
+  if (!isFullscreenMode) return false;
+  if (typeof document === "undefined") return true;
+  return document.fullscreenElement !== container;
+}
+
+export function widgetFullscreenShellClassName(
+  isFullscreenMode: boolean,
+  container: HTMLElement | null
+): string | undefined {
+  if (!isFullscreenMode) return undefined;
+  return isCssFullscreenFallback(isFullscreenMode, container)
+    ? WIDGET_FULLSCREEN_OVERLAY_CLASSES
+    : WIDGET_FULLSCREEN_NATIVE_CLASSES;
+}
 
 export function useWidgetFullscreenDocumentChrome(active: boolean): void {
   useEffect(() => {

--- a/libraries/typescript/packages/inspector/src/client/lib/widget-fullscreen.ts
+++ b/libraries/typescript/packages/inspector/src/client/lib/widget-fullscreen.ts
@@ -11,7 +11,19 @@ export const WIDGET_FULLSCREEN_NATIVE_CLASSES = SHELL_BASE;
 /** Shell when Fullscreen API is unavailable (CSS fallback). */
 export const WIDGET_FULLSCREEN_OVERLAY_CLASSES = `fixed inset-0 z-[100] ${SHELL_BASE}`;
 
+/** PiP floating card; portaled to document.body to escape host stacking contexts. */
+export const WIDGET_PIP_SHELL_CLASSES = [
+  "fixed top-4 left-1/2 -translate-x-1/2 z-[100]",
+  "rounded-3xl w-full min-w-[300px] h-[400px]",
+  "shadow-2xl border overflow-hidden",
+  "bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80",
+  "flex flex-col",
+].join(" ");
+
+/** @deprecated Use WIDGET_DISPLAY_MODE_ATTR */
 export const WIDGET_FULLSCREEN_DOCUMENT_ATTR = "data-mcp-widget-fullscreen";
+
+export const WIDGET_DISPLAY_MODE_ATTR = "data-mcp-widget-display-mode";
 
 function fullscreenShellClass(cssFallback: boolean): string {
   return cssFallback
@@ -19,18 +31,40 @@ function fullscreenShellClass(cssFallback: boolean): string {
     : WIDGET_FULLSCREEN_NATIVE_CLASSES;
 }
 
-export function useWidgetFullscreenDocumentChrome(active: boolean): void {
+export function useWidgetDisplayModeDocumentChrome(
+  displayMode: WidgetDisplayMode
+): void {
   useEffect(() => {
-    if (typeof document === "undefined" || !active) return;
-    document.documentElement.setAttribute(WIDGET_FULLSCREEN_DOCUMENT_ATTR, "");
-    return () => {
-      document.documentElement.removeAttribute(WIDGET_FULLSCREEN_DOCUMENT_ATTR);
-    };
-  }, [active]);
+    if (typeof document === "undefined") return;
+    if (displayMode === "pip" || displayMode === "fullscreen") {
+      document.documentElement.setAttribute(
+        WIDGET_DISPLAY_MODE_ATTR,
+        displayMode
+      );
+      if (displayMode === "fullscreen") {
+        document.documentElement.setAttribute(
+          WIDGET_FULLSCREEN_DOCUMENT_ATTR,
+          ""
+        );
+      } else {
+        document.documentElement.removeAttribute(
+          WIDGET_FULLSCREEN_DOCUMENT_ATTR
+        );
+      }
+      return () => {
+        document.documentElement.removeAttribute(WIDGET_DISPLAY_MODE_ATTR);
+        document.documentElement.removeAttribute(
+          WIDGET_FULLSCREEN_DOCUMENT_ATTR
+        );
+      };
+    }
+    document.documentElement.removeAttribute(WIDGET_DISPLAY_MODE_ATTR);
+    document.documentElement.removeAttribute(WIDGET_FULLSCREEN_DOCUMENT_ATTR);
+  }, [displayMode]);
 }
 
 /** Native Fullscreen API first; CSS overlay only when `requestFullscreen` fails. */
-export function useWidgetFullscreenControls({
+export function useWidgetDisplayModeControls({
   containerRef,
   displayMode,
   setDisplayMode,
@@ -42,8 +76,9 @@ export function useWidgetFullscreenControls({
 }) {
   const [cssFallback, setCssFallback] = useState(false);
   const isFullscreen = displayMode === "fullscreen";
+  const isPip = displayMode === "pip";
 
-  useWidgetFullscreenDocumentChrome(isFullscreen);
+  useWidgetDisplayModeDocumentChrome(displayMode);
 
   useEffect(() => {
     const onFullscreenChange = () => {
@@ -87,5 +122,20 @@ export function useWidgetFullscreenControls({
     ? fullscreenShellClass(cssFallback)
     : undefined;
 
-  return { handleDisplayModeChange, fullscreenShellClassName, isFullscreen };
+  const pipShellClassName = isPip ? WIDGET_PIP_SHELL_CLASSES : undefined;
+
+  return {
+    handleDisplayModeChange,
+    fullscreenShellClassName,
+    pipShellClassName,
+    isFullscreen,
+    isPip,
+  };
 }
+
+/** @deprecated Use useWidgetDisplayModeControls */
+export const useWidgetFullscreenControls = useWidgetDisplayModeControls;
+
+/** @deprecated Use useWidgetDisplayModeDocumentChrome */
+export const useWidgetFullscreenDocumentChrome = (active: boolean) =>
+  useWidgetDisplayModeDocumentChrome(active ? "fullscreen" : "inline");

--- a/libraries/typescript/packages/inspector/src/client/lib/widget-fullscreen.ts
+++ b/libraries/typescript/packages/inspector/src/client/lib/widget-fullscreen.ts
@@ -1,0 +1,21 @@
+import { useEffect } from "react";
+
+/** Viewport-covering shell for CSS fullscreen (portaled to `document.body`). */
+export const WIDGET_FULLSCREEN_OVERLAY_CLASSES =
+  "fixed inset-0 z-[100] w-full h-full bg-background flex flex-col";
+
+/**
+ * Set on `document.documentElement` while a widget is in CSS fullscreen so host
+ * apps (e.g. cloud dashboard) can hide sidebars / chat chrome.
+ */
+export const WIDGET_FULLSCREEN_DOCUMENT_ATTR = "data-mcp-widget-fullscreen";
+
+export function useWidgetFullscreenDocumentChrome(active: boolean): void {
+  useEffect(() => {
+    if (typeof document === "undefined" || !active) return;
+    document.documentElement.setAttribute(WIDGET_FULLSCREEN_DOCUMENT_ATTR, "");
+    return () => {
+      document.documentElement.removeAttribute(WIDGET_FULLSCREEN_DOCUMENT_ATTR);
+    };
+  }, [active]);
+}

--- a/libraries/typescript/packages/inspector/src/client/lib/widget-fullscreen.ts
+++ b/libraries/typescript/packages/inspector/src/client/lib/widget-fullscreen.ts
@@ -1,35 +1,19 @@
-import { useEffect } from "react";
+import { useCallback, useEffect, useState, type RefObject } from "react";
 
-/** Viewport-covering shell when Fullscreen API is unavailable (CSS fallback). */
-export const WIDGET_FULLSCREEN_OVERLAY_CLASSES =
-  "fixed inset-0 z-[100] w-full h-full bg-background flex flex-col";
+export type WidgetDisplayMode = "inline" | "pip" | "fullscreen";
 
-/** Minimal shell when the browser owns the viewport via Fullscreen API. */
-export const WIDGET_FULLSCREEN_NATIVE_CLASSES =
-  "w-full h-full bg-background flex flex-col";
+const SHELL_BASE = "w-full h-full bg-background flex flex-col";
 
-/**
- * Set on `document.documentElement` while a widget is in fullscreen so host
- * apps (e.g. cloud dashboard) can hide sidebars / chat chrome.
- */
+/** Shell when the browser owns the viewport via Fullscreen API. */
+export const WIDGET_FULLSCREEN_NATIVE_CLASSES = SHELL_BASE;
+
+/** Shell when Fullscreen API is unavailable (CSS fallback). */
+export const WIDGET_FULLSCREEN_OVERLAY_CLASSES = `fixed inset-0 z-[100] ${SHELL_BASE}`;
+
 export const WIDGET_FULLSCREEN_DOCUMENT_ATTR = "data-mcp-widget-fullscreen";
 
-/** True when display mode is fullscreen but the container is not the native fullscreen element. */
-export function isCssFullscreenFallback(
-  isFullscreenMode: boolean,
-  container: HTMLElement | null
-): boolean {
-  if (!isFullscreenMode) return false;
-  if (typeof document === "undefined") return true;
-  return document.fullscreenElement !== container;
-}
-
-export function widgetFullscreenShellClassName(
-  isFullscreenMode: boolean,
-  container: HTMLElement | null
-): string | undefined {
-  if (!isFullscreenMode) return undefined;
-  return isCssFullscreenFallback(isFullscreenMode, container)
+function fullscreenShellClass(cssFallback: boolean): string {
+  return cssFallback
     ? WIDGET_FULLSCREEN_OVERLAY_CLASSES
     : WIDGET_FULLSCREEN_NATIVE_CLASSES;
 }
@@ -42,4 +26,65 @@ export function useWidgetFullscreenDocumentChrome(active: boolean): void {
       document.documentElement.removeAttribute(WIDGET_FULLSCREEN_DOCUMENT_ATTR);
     };
   }, [active]);
+}
+
+/** Native Fullscreen API first; CSS overlay only when `requestFullscreen` fails. */
+export function useWidgetFullscreenControls({
+  containerRef,
+  displayMode,
+  setDisplayMode,
+}: {
+  containerRef: RefObject<HTMLElement | null>;
+  displayMode: WidgetDisplayMode;
+  setDisplayMode: (mode: WidgetDisplayMode) => void;
+}) {
+  const [cssFallback, setCssFallback] = useState(false);
+  const isFullscreen = displayMode === "fullscreen";
+
+  useWidgetFullscreenDocumentChrome(isFullscreen);
+
+  useEffect(() => {
+    const onFullscreenChange = () => {
+      if (!document.fullscreenElement && displayMode === "fullscreen") {
+        setCssFallback(false);
+        setDisplayMode("inline");
+      }
+    };
+    document.addEventListener("fullscreenchange", onFullscreenChange);
+    return () =>
+      document.removeEventListener("fullscreenchange", onFullscreenChange);
+  }, [displayMode, setDisplayMode]);
+
+  const handleDisplayModeChange = useCallback(
+    async (mode: WidgetDisplayMode) => {
+      if (mode === "fullscreen") {
+        try {
+          await containerRef.current?.requestFullscreen();
+          setCssFallback(false);
+          setDisplayMode("fullscreen");
+        } catch {
+          setCssFallback(true);
+          setDisplayMode("fullscreen");
+        }
+        return;
+      }
+
+      try {
+        if (document.fullscreenElement) {
+          await document.exitFullscreen();
+        }
+      } catch {
+        // exitFullscreen can fail if already exited
+      }
+      setCssFallback(false);
+      setDisplayMode(mode);
+    },
+    [containerRef, setDisplayMode]
+  );
+
+  const fullscreenShellClassName = isFullscreen
+    ? fullscreenShellClass(cssFallback)
+    : undefined;
+
+  return { handleDisplayModeChange, fullscreenShellClassName, isFullscreen };
 }

--- a/libraries/typescript/packages/inspector/src/client/lib/widget-fullscreen.ts
+++ b/libraries/typescript/packages/inspector/src/client/lib/widget-fullscreen.ts
@@ -2,7 +2,8 @@ import { useCallback, useEffect, useState, type RefObject } from "react";
 
 export type WidgetDisplayMode = "inline" | "pip" | "fullscreen";
 
-const SHELL_BASE = "w-full h-full bg-background flex flex-col";
+const SHELL_BASE =
+  "w-full h-full min-h-0 bg-background flex flex-col [&:fullscreen]:h-full [&:fullscreen]:w-full [&:fullscreen]:bg-background";
 
 /** Shell when the browser owns the viewport via Fullscreen API. */
 export const WIDGET_FULLSCREEN_NATIVE_CLASSES = SHELL_BASE;
@@ -31,18 +32,14 @@ export function useWidgetFullscreenDocumentChrome(active: boolean): void {
 /** Native Fullscreen API first; CSS overlay only when `requestFullscreen` fails. */
 export function useWidgetFullscreenControls({
   containerRef,
-  fullscreenTargetRef,
   displayMode,
   setDisplayMode,
 }: {
-  /** Layout shell (navbar, padding). Not used for `requestFullscreen` when `fullscreenTargetRef` is set. */
+  /** Shell that includes exit chrome + widget; promoted via `requestFullscreen`. */
   containerRef: RefObject<HTMLElement | null>;
-  /** Element promoted to browser fullscreen (typically the iframe wrapper). */
-  fullscreenTargetRef?: RefObject<HTMLElement | null>;
   displayMode: WidgetDisplayMode;
   setDisplayMode: (mode: WidgetDisplayMode) => void;
 }) {
-  const fullscreenElementRef = fullscreenTargetRef ?? containerRef;
   const [cssFallback, setCssFallback] = useState(false);
   const isFullscreen = displayMode === "fullscreen";
 
@@ -64,7 +61,7 @@ export function useWidgetFullscreenControls({
     async (mode: WidgetDisplayMode) => {
       if (mode === "fullscreen") {
         try {
-          await fullscreenElementRef.current?.requestFullscreen();
+          await containerRef.current?.requestFullscreen();
           setCssFallback(false);
         } catch {
           setCssFallback(true);
@@ -83,7 +80,7 @@ export function useWidgetFullscreenControls({
       setCssFallback(false);
       setDisplayMode(mode);
     },
-    [fullscreenElementRef, setDisplayMode]
+    [containerRef, setDisplayMode]
   );
 
   const fullscreenShellClassName = isFullscreen


### PR DESCRIPTION
## Summary

- Fixes MCP-2181: in cloud chat (and other embedded hosts), the widget **Exit Fullscreen** control was hidden behind **New Chat** and other header chrome at `z-50`.
- Fullscreen MCP App / ChatGPT App shells are **portaled to `document.body`** at **`z-[100]`** so they paint above nested dashboard stacking contexts.
- Sets **`data-mcp-widget-fullscreen`** on `document.documentElement` while CSS fullscreen is active so hosts can hide sidebars/headers (follow-up in mcp-use-cloud optional).
- **ChatGPT Apps** (`OpenAIComponentRenderer`): shows the exit navbar whenever `displayMode === "fullscreen"`, not only when `document.fullscreenElement` is set.

## Implementation

- New [`widget-fullscreen.ts`](libraries/typescript/packages/inspector/src/client/lib/widget-fullscreen.ts) shared overlay classes + document chrome hook.
- [`MCPAppsRenderer`](libraries/typescript/packages/inspector/src/client/components/MCPAppsRenderer.tsx) and [`OpenAIComponentRenderer`](libraries/typescript/packages/inspector/src/client/components/OpenAIComponentRenderer.tsx) portal the fullscreen shell.

## Test plan

- [x] `pnpm --filter @mcp-use/inspector lint`
- [x] `pnpm format:check` (typescript monorepo)
- [x] `pnpm --filter @mcp-use/inspector build`
- [ ] Manual: server cloud chat → run MCP App widget → fullscreen → **Exit Fullscreen** is clickable above **New Chat**
- [ ] Manual: ESC / exit returns to inline; `data-mcp-widget-fullscreen` removed from `<html>`
- [ ] Bump `@mcp-use/inspector` in mcp-use-cloud after release

## Related

Linear MCP-2181