### PR TITLE
fix(inspector): drop unused widget-fullscreen exports to satisfy knip

### DIFF
--- a/libraries/typescript/packages/inspector/src/client/lib/widget-fullscreen.ts
+++ b/libraries/typescript/packages/inspector/src/client/lib/widget-fullscreen.ts
@@ -1,18 +1,18 @@
 import { useCallback, useEffect, useState, type RefObject } from "react";
 
-export type WidgetDisplayMode = "inline" | "pip" | "fullscreen";
+type WidgetDisplayMode = "inline" | "pip" | "fullscreen";
 
 const SHELL_BASE =
   "w-full h-full min-h-0 bg-background flex flex-col [&:fullscreen]:h-full [&:fullscreen]:w-full [&:fullscreen]:bg-background";
 
 /** Shell when the browser owns the viewport via Fullscreen API. */
-export const WIDGET_FULLSCREEN_NATIVE_CLASSES = SHELL_BASE;
+const WIDGET_FULLSCREEN_NATIVE_CLASSES = SHELL_BASE;
 
 /** Shell when Fullscreen API is unavailable (CSS fallback). */
-export const WIDGET_FULLSCREEN_OVERLAY_CLASSES = `fixed inset-0 z-[100] ${SHELL_BASE}`;
+const WIDGET_FULLSCREEN_OVERLAY_CLASSES = `fixed inset-0 z-[100] ${SHELL_BASE}`;
 
 /** PiP floating card; portaled to document.body to escape host stacking contexts. */
-export const WIDGET_PIP_SHELL_CLASSES = [
+const WIDGET_PIP_SHELL_CLASSES = [
   "fixed top-4 left-1/2 -translate-x-1/2 z-[100]",
   "rounded-3xl w-full min-w-[300px] h-[400px]",
   "shadow-2xl border overflow-hidden",
@@ -20,10 +20,10 @@ export const WIDGET_PIP_SHELL_CLASSES = [
   "flex flex-col",
 ].join(" ");
 
-/** @deprecated Use WIDGET_DISPLAY_MODE_ATTR */
-export const WIDGET_FULLSCREEN_DOCUMENT_ATTR = "data-mcp-widget-fullscreen";
+/** Legacy host hook; kept alongside the display-mode attr for embedded hosts. */
+const WIDGET_FULLSCREEN_DOCUMENT_ATTR = "data-mcp-widget-fullscreen";
 
-export const WIDGET_DISPLAY_MODE_ATTR = "data-mcp-widget-display-mode";
+const WIDGET_DISPLAY_MODE_ATTR = "data-mcp-widget-display-mode";
 
 function fullscreenShellClass(cssFallback: boolean): string {
   return cssFallback
@@ -31,7 +31,7 @@ function fullscreenShellClass(cssFallback: boolean): string {
     : WIDGET_FULLSCREEN_NATIVE_CLASSES;
 }
 
-export function useWidgetDisplayModeDocumentChrome(
+function useWidgetDisplayModeDocumentChrome(
   displayMode: WidgetDisplayMode
 ): void {
   useEffect(() => {
@@ -132,10 +132,3 @@ export function useWidgetDisplayModeControls({
     isPip,
   };
 }
-
-/** @deprecated Use useWidgetDisplayModeControls */
-export const useWidgetFullscreenControls = useWidgetDisplayModeControls;
-
-/** @deprecated Use useWidgetDisplayModeDocumentChrome */
-export const useWidgetFullscreenDocumentChrome = (active: boolean) =>
-  useWidgetDisplayModeDocumentChrome(active ? "fullscreen" : "inline");


### PR DESCRIPTION
## Changes

Fixes the failing `typescript-knip` CI job on `canary`.

`packages/inspector/src/client/lib/widget-fullscreen.ts` (added in #1605) exported a batch of symbols that nothing outside the file consumes, which knip flagged as 8 unused exports, 1 unused exported type, and 1 duplicate export. The only externally-consumed symbol is `useWidgetDisplayModeControls` (used by `MCPAppsRenderer.tsx` and `OpenAIComponentRenderer.tsx`).

## Implementation Details

1. Dropped `export` from internal-only declarations that are referenced solely within the file:
   - `WIDGET_FULLSCREEN_NATIVE_CLASSES`, `WIDGET_FULLSCREEN_OVERLAY_CLASSES`, `WIDGET_PIP_SHELL_CLASSES`
   - `WIDGET_FULLSCREEN_DOCUMENT_ATTR`, `WIDGET_DISPLAY_MODE_ATTR`
   - the `WidgetDisplayMode` type
   - the `useWidgetDisplayModeDocumentChrome` helper
2. Removed the two dead `@deprecated` aliases (`useWidgetFullscreenControls`, `useWidgetFullscreenDocumentChrome`). They were pre-emptive backward-compat shims pointing at names that were introduced and renamed within #1605 itself — nothing depends on them.
3. `useWidgetDisplayModeControls` stays exported (the sole real consumer).

No behavior change — this only narrows visibility of internal symbols.

## Testing

- `pnpm exec knip --no-progress` → exit 0 (only a pre-existing, unrelated configuration *hint* remains, which does not fail the build)
- `pnpm --filter @mcp-use/inspector run type-check` → exit 0
- Prettier formatting applied

## Backwards Compatibility

Not breaking. All removed/unexported symbols were internal to the inspector client bundle and not part of any published package's public API.