### PR TITLE
Skip emulate OAuth tests in builtin E2E

### DIFF
--- a/libraries/typescript/packages/inspector/tests/e2e/scripts/run-test-matrix.mjs
+++ b/libraries/typescript/packages/inspector/tests/e2e/scripts/run-test-matrix.mjs
@@ -335,10 +335,10 @@ async function main() {
     if (mode === "builtin") {
       playwrightArgs.push(
         "--grep-invert",
-        "auth-flows.test.ts|connection.test.ts|setup.test.ts|python.test.ts"
+        "auth-flows.test.ts|connection.test.ts|oauth-emulate.test.ts|setup.test.ts|python.test.ts"
       );
       console.log(
-        "⏭️  Skipping auth-flows, connection, and setup tests (not applicable for builtin mode)\n"
+        "⏭️  Skipping auth-flows, connection, oauth-emulate, and setup tests (not applicable for builtin mode)\n"
       );
     } else {
       playwrightArgs.push(


### PR DESCRIPTION
## Summary

Exclude `oauth-emulate.test.ts` from the Inspector E2E builtin-mode matrix.

## Why

Builtin mode runs the MCP server with its built-in Inspector and is mainly used for HMR/dev-server coverage. The emulate OAuth tests create their own external MCP server and exercise OAuth connection flows, which better match the external-server `mix` and `prod` modes.

## Validation

- `pnpm --filter @mcp-use/inspector exec playwright test --grep-invert 'auth-flows.test.ts|connection.test.ts|oauth-emulate.test.ts|setup.test.ts|python.test.ts' --list`
- Confirmed builtin selection drops from 76 to 74 tests and no longer includes `oauth-emulate.test.ts`.