### PR TITLE
fix(mcp-use): pin published dependency versions

### DIFF
--- a/libraries/typescript/packages/mcp-use/package.json
+++ b/libraries/typescript/packages/mcp-use/package.json
@@ -218,23 +218,23 @@
     }
   },
   "dependencies": {
-    "@hono/node-server": "^1.19.13",
-    "@mcp-ui/server": "^6.1.0",
+    "@hono/node-server": "1.19.13",
+    "@mcp-ui/server": "6.1.0",
     "@mcp-use/cli": "workspace:*",
     "@mcp-use/inspector": "workspace:*",
-    "@modelcontextprotocol/ext-apps": "^1.0.1",
-    "@modelcontextprotocol/sdk": "^1.26.0",
-    "express": "^5.2.1",
-    "hono": "^4.12.12",
-    "jose": "^6.1.3",
-    "node-mocks-http": "^1.17.2",
-    "posthog-js": "^1.351.3",
-    "posthog-node": "^5.24.17"
+    "@modelcontextprotocol/ext-apps": "1.0.1",
+    "@modelcontextprotocol/sdk": "1.26.0",
+    "express": "5.2.1",
+    "hono": "4.12.12",
+    "jose": "6.1.3",
+    "node-mocks-http": "1.17.2",
+    "posthog-js": "1.351.3",
+    "posthog-node": "5.24.17"
   },
   "optionalDependencies": {
-    "chalk": "^5.6.2",
-    "cli-highlight": "^2.1.11",
-    "redis": "^5.10.0"
+    "chalk": "5.6.2",
+    "cli-highlight": "2.1.11",
+    "redis": "5.10.0"
   },
   "devDependencies": {
     "@langchain/openai": "^1.2.8",

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -498,7 +498,7 @@ importers:
         specifier: ^1.1.8
         version: 1.1.18(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.17.0(ws@8.19.0)(zod@4.3.5))
       '@mcp-ui/server':
-        specifier: ^6.1.0
+        specifier: 6.1.0
         version: 6.1.0(@cfworker/json-schema@4.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.5)
       '@mcp-use/cli':
         specifier: workspace:*
@@ -507,19 +507,19 @@ importers:
         specifier: workspace:*
         version: link:../inspector
       '@modelcontextprotocol/ext-apps':
-        specifier: ^1.0.1
+        specifier: 1.0.1
         version: 1.0.1(@modelcontextprotocol/sdk@1.27.1(patch_hash=c19f2c8d79a374e03317396864f51a5d896e73b8a2231766cdc88bfbac98161e)(@cfworker/json-schema@4.1.1)(zod@4.3.5))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.5)
       '@modelcontextprotocol/sdk':
         specifier: '>=1.25.2'
         version: 1.27.1(patch_hash=c19f2c8d79a374e03317396864f51a5d896e73b8a2231766cdc88bfbac98161e)(@cfworker/json-schema@4.1.1)(zod@4.3.5)
       express:
-        specifier: ^5.2.1
+        specifier: 5.2.1
         version: 5.2.1
       hono:
         specifier: '>=4.12.12'
         version: 4.12.12
       jose:
-        specifier: ^6.1.3
+        specifier: 6.1.3
         version: 6.1.3
       langchain:
         specifier: ^1.2.3
@@ -531,13 +531,13 @@ importers:
         specifier: ^3.38.6
         version: 3.38.6(langchain@1.2.16(@langchain/core@1.1.18(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.17.0(ws@8.19.0)(zod@4.3.5)))(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.17.0(ws@8.19.0)(zod@4.3.5))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.5)))
       node-mocks-http:
-        specifier: ^1.17.2
+        specifier: 1.17.2
         version: 1.17.2(@types/express@5.0.6)(@types/node@25.6.0)
       posthog-js:
-        specifier: ^1.351.3
-        version: 1.351.4
+        specifier: 1.351.3
+        version: 1.351.3
       posthog-node:
-        specifier: ^5.24.17
+        specifier: 5.24.17
         version: 5.24.17
       react-router:
         specifier: ^7.12.0
@@ -590,13 +590,13 @@ importers:
         version: 4.3.5
     optionalDependencies:
       chalk:
-        specifier: ^5.6.2
+        specifier: 5.6.2
         version: 5.6.2
       cli-highlight:
-        specifier: ^2.1.11
+        specifier: 2.1.11
         version: 2.1.11
       redis:
-        specifier: ^5.10.0
+        specifier: 5.10.0
         version: 5.10.0
 
   packages/mcp-use/examples/client/browser/react:
@@ -2631,8 +2631,8 @@ packages:
   '@posthog/core@1.23.1':
     resolution: {integrity: sha512-GViD5mOv/mcbZcyzz3z9CS0R79JzxVaqEz4sP5Dsea178M/j3ZWe6gaHDZB9yuyGfcmIMQ/8K14yv+7QrK4sQQ==}
 
-  '@posthog/types@1.351.4':
-    resolution: {integrity: sha512-PMrNdOGVIiUczixF+AkodxIigAr3OM2LMfs565uTPZaIUip7S+njoaZRoIT66VJJviWtbLtzJHR49YJtIRIiWQ==}
+  '@posthog/types@1.351.3':
+    resolution: {integrity: sha512-Fuckp/fdL0Ku/kVYljbUdJli8vF07e5+tBsf4GzYBQjfZCGhlT0l37XqVQ05Uk7l/pUDONZD+OOXNBgBzW32gA==}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -6693,8 +6693,8 @@ packages:
     resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
     engines: {node: ^10 || ^12 || >=14}
 
-  posthog-js@1.351.4:
-    resolution: {integrity: sha512-vLSYHMN31FGs1cTJ/SCW0aCLiV6K6ZW63Q1K3B16iWRBVTwz/kg6sJZi6Z/oFeKOuy9I5K/LbVLDBCaTTlcESA==}
+  posthog-js@1.351.3:
+    resolution: {integrity: sha512-c2sQOhbo0Ed2Cgq+gTMFiArneu2/+HTf6sJdHw60oj2BIXTHjQfGY7H2XzA7ZZHsDNVVVcpsqpxrUhyzGsfDhQ==}
 
   posthog-node@5.24.17:
     resolution: {integrity: sha512-mdb8TKt+YCRbGQdYar3AKNUPCyEiqcprScF4unYpGALF6HlBaEuO6wPuIqXXpCWkw4VclJYCKbb6lq6pH6bJeA==}
@@ -9018,7 +9018,7 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
 
-  '@posthog/types@1.351.4': {}
+  '@posthog/types@1.351.3': {}
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -14118,7 +14118,7 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  posthog-js@1.351.4:
+  posthog-js@1.351.3:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/api-logs': 0.208.0
@@ -14126,7 +14126,7 @@ snapshots:
       '@opentelemetry/resources': 2.5.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.0)
       '@posthog/core': 1.23.1
-      '@posthog/types': 1.351.4
+      '@posthog/types': 1.351.3
       core-js: 3.48.0
       dompurify: 3.3.3
       fflate: 0.4.8


### PR DESCRIPTION
## Summary
- Pin mcp-use published dependencies and optional dependencies to exact versions instead of caret ranges
- Pin posthog-js in the lockfile to 1.351.3 so lockfile regeneration does not drift to freshly published PostHog patches

Fixes MCP-2351

## Verification
- pnpm install --frozen-lockfile --filter mcp-use
- pnpm --filter mcp-use build