### PR TITLE
fix(docs): update server API reference links

### DIFF
--- a/docs/typescript/server/deployment/mcp-use.mdx
+++ b/docs/typescript/server/deployment/mcp-use.mdx
@@ -98,4 +98,4 @@ mcp-use start
 - [Deploying to Supabase](./supabase) - Alternative deployment option
 - [Configuration Guide](../configuration) - Advanced server configuration
 - [UI Widgets](../mcp-apps) - Building interactive widgets
-- [API Reference](../api-reference) - Complete API documentation
+- [API Reference](/typescript/server/index#mcpserver-api-reference) - Complete API documentation

--- a/docs/typescript/server/examples.mdx
+++ b/docs/typescript/server/examples.mdx
@@ -707,6 +707,6 @@ These examples demonstrate:
 ## Next Steps
 
 - [Getting Started](/typescript/getting-started/quickstart) - Set up your first server
-- [API Reference](./api-reference) - Complete API documentation
+- [API Reference](/typescript/server/index#mcpserver-api-reference) - Complete API documentation
 - [Tools Guide](./tools) - Deep dive into tool development
 - [UI Widgets](./mcp-apps) - Building interactive widgets

--- a/docs/typescript/server/prompts.mdx
+++ b/docs/typescript/server/prompts.mdx
@@ -256,5 +256,5 @@ The callback receives the current input value and optional context containing ot
 
 - [Tools Guide](./tools) - Building executable tools
 - [Resources Guide](./resources) - Managing content
-- [API Reference](./api-reference) - Complete API documentation
+- [API Reference](/typescript/server/index#mcpserver-api-reference) - Complete API documentation
 - [Examples](./examples) - Real-world implementations


### PR DESCRIPTION
## Summary

- Update three stale TypeScript server docs links that still pointed at the removed api-reference page
- Point them at the canonical /typescript/server/index#mcpserver-api-reference target used by the docs redirect

## Verification

- cd docs && mint broken-links

Fixes the broken-link failure seen in the Documentation workflow for #1508: https://github.com/mcp-use/mcp-use/actions/runs/26903000162/job/79360143224?pr=1508