### PR TITLE
Fix builtin inspector auto-connect to use HTTP

### DIFF
--- a/libraries/typescript/.changeset/fix-builtin-inspector-autoconnect-http.md
+++ b/libraries/typescript/.changeset/fix-builtin-inspector-autoconnect-http.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Fix built-in inspector auto-connect to use streamable HTTP for the local `/mcp` endpoint instead of SSE.

--- a/libraries/typescript/packages/inspector/tests/e2e/chat.test.ts
+++ b/libraries/typescript/packages/inspector/tests/e2e/chat.test.ts
@@ -2,8 +2,10 @@ import { expect, test } from "@playwright/test";
 import {
   configureLLMAPI,
   connectToConformanceServer,
+  goToInspectorWithAutoConnectAndOpenTools,
   navigateToTools,
 } from "./helpers/connection";
+import { getTestMatrix } from "./helpers/test-matrix";
 
 test.describe("Inspector Chat Tests", () => {
   // Note: To run these tests with a real MCP server:
@@ -17,14 +19,22 @@ test.describe("Inspector Chat Tests", () => {
   test.beforeEach(async ({ page, context }) => {
     // Clear localStorage and cookies before each test
     await context.clearCookies();
-    await page.goto("http://localhost:3000/inspector");
-    await page.evaluate(() => localStorage.clear());
 
-    // Connect to server using helper
-    await connectToConformanceServer(page);
+    const { usesBuiltinInspector, inspectorUrl } = getTestMatrix();
+    if (usesBuiltinInspector) {
+      await goToInspectorWithAutoConnectAndOpenTools(page, {
+        waitForWidgets: true,
+      });
+    } else {
+      await page.goto(inspectorUrl);
+      await page.evaluate(() => localStorage.clear());
 
-    // Navigate to Tools tab
-    await navigateToTools(page);
+      // Connect to server using helper
+      await connectToConformanceServer(page);
+
+      // Navigate to Tools tab
+      await navigateToTools(page);
+    }
 
     // Configure LLM API
     await configureLLMAPI(page);

--- a/libraries/typescript/packages/inspector/tests/e2e/command-palette.test.ts
+++ b/libraries/typescript/packages/inspector/tests/e2e/command-palette.test.ts
@@ -1,8 +1,10 @@
 import { expect, test, type Page } from "@playwright/test";
 import {
   connectToConformanceServer,
+  goToInspectorWithAutoConnectAndOpenTools,
   navigateToTools,
 } from "./helpers/connection";
+import { getTestMatrix } from "./helpers/test-matrix";
 
 let page: Page;
 
@@ -14,15 +16,23 @@ test.describe("Inspector Command Palette Tests", () => {
 
   test.beforeAll(async ({ browser }) => {
     page = await browser.newPage();
-    await page.goto("http://localhost:3000/inspector");
-    await page.waitForLoadState("networkidle");
     // Clear localStorage and cookies after navigation
     await page.context().clearCookies();
-    await page.evaluate(() => localStorage.clear());
 
-    // Connect to conformance server
-    await connectToConformanceServer(page);
-    await navigateToTools(page);
+    const { usesBuiltinInspector, inspectorUrl } = getTestMatrix();
+    if (usesBuiltinInspector) {
+      await goToInspectorWithAutoConnectAndOpenTools(page, {
+        waitForWidgets: true,
+      });
+    } else {
+      await page.goto(inspectorUrl);
+      await page.waitForLoadState("networkidle");
+      await page.evaluate(() => localStorage.clear());
+
+      // Connect to conformance server
+      await connectToConformanceServer(page);
+      await navigateToTools(page);
+    }
   });
 
   test.afterAll(async () => {

--- a/libraries/typescript/packages/inspector/tests/e2e/helpers/connection.ts
+++ b/libraries/typescript/packages/inspector/tests/e2e/helpers/connection.ts
@@ -143,10 +143,18 @@ export async function goToInspectorWithAutoConnectAndOpenTools(
   page: Page,
   options?: { waitForWidgets?: boolean }
 ) {
-  const { inspectorUrl, serverUrl } = getTestMatrix();
+  const { inspectorUrl, serverUrl, usesBuiltinInspector } = getTestMatrix();
   const waitForWidgets = options?.waitForWidgets ?? false;
-  const url = `${inspectorUrl}?autoConnect=${encodeURIComponent(serverUrl)}`;
-  await page.goto(url);
+  const autoConnectConfig = {
+    url: serverUrl,
+    name: process.env.TEST_SERVER_NAME || "ConformanceTestServer",
+    transportType: "http",
+    connectionType: "Direct",
+  };
+  const url = `${inspectorUrl}?autoConnect=${encodeURIComponent(
+    JSON.stringify(autoConnectConfig)
+  )}`;
+  await page.goto(usesBuiltinInspector ? inspectorUrl : url);
   await expect(page.getByRole("heading", { name: "Tools" })).toBeVisible();
   await expect(page.getByTestId("tool-item-test_simple_text")).toBeVisible();
 

--- a/libraries/typescript/packages/inspector/tests/e2e/helpers/connection.ts
+++ b/libraries/typescript/packages/inspector/tests/e2e/helpers/connection.ts
@@ -145,15 +145,7 @@ export async function goToInspectorWithAutoConnectAndOpenTools(
 ) {
   const { inspectorUrl, serverUrl, usesBuiltinInspector } = getTestMatrix();
   const waitForWidgets = options?.waitForWidgets ?? false;
-  const autoConnectConfig = {
-    url: serverUrl,
-    name: process.env.TEST_SERVER_NAME || "ConformanceTestServer",
-    transportType: "http",
-    connectionType: "Direct",
-  };
-  const url = `${inspectorUrl}?autoConnect=${encodeURIComponent(
-    JSON.stringify(autoConnectConfig)
-  )}`;
+  const url = `${inspectorUrl}?autoConnect=${encodeURIComponent(serverUrl)}`;
   await page.goto(usesBuiltinInspector ? inspectorUrl : url);
   await expect(page.getByRole("heading", { name: "Tools" })).toBeVisible();
   await expect(page.getByTestId("tool-item-test_simple_text")).toBeVisible();

--- a/libraries/typescript/packages/mcp-use/src/server/inspector/mount.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/inspector/mount.ts
@@ -64,13 +64,12 @@ export async function mountInspectorUI(
       serverHost === "0.0.0.0" || serverHost === "::"
         ? "localhost"
         : serverHost;
-    // Auto-connect to the local MCP server at /mcp (SSE endpoint)
-    // Use JSON config to specify SSE transport type
-    const mcpUrl = `http://${hostForBrowser}:${serverPort}/mcp`; // Also available at /sse
+    // Auto-connect to the local MCP server at /mcp using streamable HTTP.
+    const mcpUrl = `http://${hostForBrowser}:${serverPort}/mcp`;
     const autoConnectConfig = JSON.stringify({
       url: mcpUrl,
       name: "Local MCP Server",
-      transportType: "sse",
+      transportType: "http",
       connectionType: "Direct",
     });
     mountInspector(app, {


### PR DESCRIPTION
## Summary
- Switch the builtin inspector’s auto-connect config from SSE to HTTP for the local MCP server.
- Update builtin e2e setup to use the auto-connect flow in builtin mode instead of manually reconnecting a duplicate server.
- Keep the standalone/mix-mode connection path unchanged.

## Testing
- Ran the targeted builtin Playwright subset for the original failing chat and command palette specs.
- Verified the full 12-test failing set now passes in builtin mode.