### PR TITLE
fix(server): apply prefix to resources in include_router

### DIFF
--- a/libraries/python/mcp_use/server/server.py
+++ b/libraries/python/mcp_use/server/server.py
@@ -319,7 +319,7 @@ class MCPServer(FastMCP):
                 resource_name = f"{prefix}_{resource_name}"
             self.resource(
                 uri=resource.uri,
-                name=resource.name,
+                name=resource_name,
                 description=resource.description,
                 mime_type=resource.mime_type,
             )(resource.fn)

--- a/libraries/python/tests/unit/server/test_router.py
+++ b/libraries/python/tests/unit/server/test_router.py
@@ -1,0 +1,94 @@
+"""
+Regression tests for MCPServer.include_router prefix behaviour.
+
+Covers: https://github.com/mcp-use/mcp-use/issues/1438
+Bug: include_router(prefix=...) applied the prefix to tools and prompts but
+     silently dropped it for resources (resource.name was used instead of the
+     computed resource_name variable).
+"""
+
+import pytest
+
+from mcp_use.server import MCPRouter, MCPServer
+
+
+@pytest.fixture()
+def router() -> MCPRouter:
+    r = MCPRouter()
+
+    @r.tool()
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    @r.resource(uri="config://app", name="get_config")
+    def get_config() -> str:
+        return "{}"
+
+    @r.prompt()
+    def greet(name: str) -> str:
+        return f"Hello, {name}!"
+
+    return r
+
+
+class TestIncludeRouterPrefix:
+    """include_router(prefix=...) must apply the prefix to tools, resources, AND prompts."""
+
+    @pytest.mark.asyncio
+    async def test_tool_gets_prefix(self, router: MCPRouter):
+        server = MCPServer(name="test-server")
+        server.include_router(router, prefix="math")
+
+        tools = await server.list_tools()
+        names = [t.name for t in tools]
+        assert "math_add" in names
+        assert "add" not in names
+
+    @pytest.mark.asyncio
+    async def test_resource_gets_prefix(self, router: MCPRouter):
+        server = MCPServer(name="test-server")
+        server.include_router(router, prefix="math")
+
+        resources = await server.list_resources()
+        names = [r.name for r in resources]
+        assert "math_get_config" in names
+        assert "get_config" not in names
+
+    @pytest.mark.asyncio
+    async def test_prompt_gets_prefix(self, router: MCPRouter):
+        server = MCPServer(name="test-server")
+        server.include_router(router, prefix="math")
+
+        prompts = await server.list_prompts()
+        names = [p.name for p in prompts]
+        assert "math_greet" in names
+        assert "greet" not in names
+
+    @pytest.mark.asyncio
+    async def test_no_prefix_leaves_names_unchanged(self, router: MCPRouter):
+        server = MCPServer(name="test-server")
+        server.include_router(router)
+
+        tools = await server.list_tools()
+        resources = await server.list_resources()
+        prompts = await server.list_prompts()
+
+        assert any(t.name == "add" for t in tools)
+        assert any(r.name == "get_config" for r in resources)
+        assert any(p.name == "greet" for p in prompts)
+
+    @pytest.mark.asyncio
+    async def test_resource_name_none_falls_back_to_function_name_with_prefix(self):
+        """When resource name is None, the function name should be used as the base."""
+        r = MCPRouter()
+
+        @r.resource(uri="config://app")
+        def my_config() -> str:
+            return "{}"
+
+        server = MCPServer(name="test-server")
+        server.include_router(r, prefix="ns")
+
+        resources = await server.list_resources()
+        names = [res.name for res in resources]
+        assert "ns_my_config" in names


### PR DESCRIPTION

  ## Changes
  Fix `include_router(prefix=...)` not applying the prefix to resources.

  ## Implementation Details
  1. In `server.py`, the resource loop computed `resource_name` with the prefix applied
     but passed `resource.name` (the original) to `self.resource()`. Changed to pass
     `resource_name` instead.

  ## Example Usage (Before)
  server.include_router(router, prefix="math")
  # TOOLS:     ['math_add']      ✓
  # RESOURCES: ['get_config']    ✗ (prefix missing)
  # PROMPTS:   ['math_greet']    ✓

  ## Example Usage (After)
  server.include_router(router, prefix="math")
  # TOOLS:     ['math_add']       ✓
  # RESOURCES: ['math_get_config'] ✓
  # PROMPTS:   ['math_greet']     ✓

  ## Testing
  - Added `tests/unit/server/test_router.py` with 5 tests covering prefix
    application for tools, resources, and prompts, the no-prefix case,
    and the name=None fallback to function name.
  - All 5 tests pass.

  ## Backwards Compatibility
  Breaking only for users who were working around the bug by manually prefixing
  resource names. Anyone using `include_router(prefix=...)` as documented will
  now get correct behaviour.

  ## Related Issues
  Closes #1438