### PR TITLE
Handle paginated server and deployment lists

### DIFF
--- a/libraries/typescript/.changeset/fix-cli-cloud-list-pagination.md
+++ b/libraries/typescript/.changeset/fix-cli-cloud-list-pagination.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/cli": patch
+---
+
+Handle paginated Cloud API responses in `servers list` and `deployments list`, with a default page size of 30 and next-page guidance.

--- a/libraries/typescript/packages/cli/src/commands/deployments.ts
+++ b/libraries/typescript/packages/cli/src/commands/deployments.ts
@@ -6,6 +6,8 @@ import { isLoggedIn } from "../utils/config.js";
 import { handleCommandError } from "../utils/errors.js";
 import { formatRelativeTime } from "../utils/format.js";
 
+const DEFAULT_LIST_LIMIT = 30;
+
 async function prompt(question: string): Promise<boolean> {
   const readline = await import("node:readline");
   const rl = readline.createInterface({
@@ -41,7 +43,36 @@ function formatId(id: string): string {
   return id;
 }
 
-async function listDeploymentsCommand(): Promise<void> {
+function formatPageHeader(label: string, count: number, total: number): string {
+  return count === total
+    ? `${label} (${total})`
+    : `${label} (${count} of ${total})`;
+}
+
+function printNextPageHint(
+  command: string,
+  page: { items: unknown[]; total: number; limit: number; skip: number },
+  extraArgs: string[] = []
+): void {
+  const nextSkip = page.skip + page.items.length;
+  if (nextSkip >= page.total) return;
+
+  const args = [
+    command,
+    "--limit",
+    String(page.limit),
+    "--skip",
+    String(nextSkip),
+    ...extraArgs,
+  ];
+  console.log(chalk.gray(`Next page: ${args.join(" ")}`));
+}
+
+async function listDeploymentsCommand(options: {
+  limit?: string;
+  skip?: string;
+  sort?: string;
+}): Promise<void> {
   try {
     if (!(await isLoggedIn())) {
       console.log(chalk.red("✗ You are not logged in."));
@@ -53,11 +84,29 @@ async function listDeploymentsCommand(): Promise<void> {
       process.exit(1);
     }
 
+    const limit = options.limit
+      ? parseInt(options.limit, 10)
+      : DEFAULT_LIST_LIMIT;
+    const skip = options.skip ? parseInt(options.skip, 10) : undefined;
+    if (limit !== undefined && (Number.isNaN(limit) || limit < 1)) {
+      console.log(chalk.red("✗ Invalid --limit"));
+      process.exit(1);
+    }
+    if (skip !== undefined && (Number.isNaN(skip) || skip < 0)) {
+      console.log(chalk.red("✗ Invalid --skip"));
+      process.exit(1);
+    }
+
     const api = await McpUseAPI.create();
-    const [deployments, authResult] = await Promise.all([
-      api.listDeployments(),
+    const [page, authResult] = await Promise.all([
+      api.listDeployments({
+        limit,
+        skip,
+        sort: options.sort ?? "createdAt:desc",
+      }),
       api.testAuth(),
     ]);
+    const deployments = page.items;
 
     const orgMap = new Map(authResult.orgs.map((o) => [o.id, o.name]));
 
@@ -90,17 +139,31 @@ async function listDeploymentsCommand(): Promise<void> {
     );
 
     if (sortedDeployments.length === 0) {
-      console.log(chalk.yellow("No deployments found."));
-      console.log(
-        chalk.gray(
-          "\nDeploy your first MCP server with " + chalk.white("mcp-use deploy")
-        )
-      );
+      if (page.total === 0) {
+        console.log(chalk.yellow("No deployments found."));
+        console.log(
+          chalk.gray(
+            "\nDeploy your first MCP server with " +
+              chalk.white("mcp-use deploy")
+          )
+        );
+      } else {
+        console.log(
+          chalk.yellow(`No deployments found at --skip ${page.skip}.`)
+        );
+        console.log(chalk.gray(`Total deployments: ${page.total}`));
+      }
       return;
     }
 
     console.log(
-      chalk.cyan.bold(`\n📦 Deployments (${sortedDeployments.length})\n`)
+      chalk.cyan.bold(
+        `\n📦 ${formatPageHeader(
+          "Deployments",
+          sortedDeployments.length,
+          page.total
+        )}\n`
+      )
     );
 
     console.log(
@@ -127,6 +190,9 @@ async function listDeploymentsCommand(): Promise<void> {
       );
     }
 
+    const extraArgs = [];
+    if (options.sort) extraArgs.push("--sort", options.sort);
+    printNextPageHint("mcp-use deployments list", page, extraArgs);
     console.log();
   } catch (error) {
     handleCommandError(error, "Failed to list deployments");
@@ -533,7 +599,10 @@ export function createDeploymentsCommand(): Command {
   deploymentsCommand
     .command("list")
     .alias("ls")
-    .description("List all deployments")
+    .description("List deployments")
+    .option("--limit <n>", "Page size (default 30)")
+    .option("--skip <n>", "Offset for pagination")
+    .option("--sort <field:asc|desc>", "Sort (e.g. createdAt:desc)")
     .action(listDeploymentsCommand);
 
   deploymentsCommand

--- a/libraries/typescript/packages/cli/src/commands/servers.ts
+++ b/libraries/typescript/packages/cli/src/commands/servers.ts
@@ -8,6 +8,8 @@ import { formatRelativeTime } from "../utils/format.js";
 import { resolveOrgFromOption } from "./auth.js";
 import { createEnvCommand } from "./env.js";
 
+const DEFAULT_LIST_LIMIT = 30;
+
 async function prompt(question: string): Promise<boolean> {
   const readline = await import("node:readline");
   const rl = readline.createInterface({
@@ -61,6 +63,31 @@ function getStatusColor(status: string): (text: string) => string {
   return chalk.gray;
 }
 
+function formatPageHeader(label: string, count: number, total: number): string {
+  return count === total
+    ? `${label} (${total})`
+    : `${label} (${count} of ${total})`;
+}
+
+function printNextPageHint(
+  command: string,
+  page: { items: unknown[]; total: number; limit: number; skip: number },
+  extraArgs: string[] = []
+): void {
+  const nextSkip = page.skip + page.items.length;
+  if (nextSkip >= page.total) return;
+
+  const args = [
+    command,
+    "--limit",
+    String(page.limit),
+    "--skip",
+    String(nextSkip),
+    ...extraArgs,
+  ];
+  console.log(chalk.gray(`Next page: ${args.join(" ")}`));
+}
+
 async function listServersCommand(options: {
   org?: string;
   limit?: string;
@@ -82,7 +109,9 @@ async function listServersCommand(options: {
     await applyOrgOption(api, options.org);
     if (options.org) console.log();
 
-    const limit = options.limit ? parseInt(options.limit, 10) : undefined;
+    const limit = options.limit
+      ? parseInt(options.limit, 10)
+      : DEFAULT_LIST_LIMIT;
     const skip = options.skip ? parseInt(options.skip, 10) : undefined;
     if (limit !== undefined && (Number.isNaN(limit) || limit < 1)) {
       console.log(chalk.red("✗ Invalid --limit"));
@@ -93,23 +122,33 @@ async function listServersCommand(options: {
       process.exit(1);
     }
 
-    const servers = await api.listServers({
+    const page = await api.listServers({
       limit,
       skip,
       sort: options.sort,
     });
+    const servers = page.items;
 
     if (servers.length === 0) {
-      console.log(chalk.yellow("No servers found."));
-      console.log(
-        chalk.gray(
-          "\nCreate one by deploying with " + chalk.white("mcp-use deploy")
-        )
-      );
+      if (page.total === 0) {
+        console.log(chalk.yellow("No servers found."));
+        console.log(
+          chalk.gray(
+            "\nCreate one by deploying with " + chalk.white("mcp-use deploy")
+          )
+        );
+      } else {
+        console.log(chalk.yellow(`No servers found at --skip ${page.skip}.`));
+        console.log(chalk.gray(`Total servers: ${page.total}`));
+      }
       return;
     }
 
-    console.log(chalk.cyan.bold(`\n🖥  Servers (${servers.length})\n`));
+    console.log(
+      chalk.cyan.bold(
+        `\n🖥  ${formatPageHeader("Servers", servers.length, page.total)}\n`
+      )
+    );
 
     console.log(
       chalk.white.bold(
@@ -132,6 +171,10 @@ async function listServersCommand(options: {
       );
     }
 
+    const extraArgs = [];
+    if (options.sort) extraArgs.push("--sort", options.sort);
+    if (options.org) extraArgs.push("--org", options.org);
+    printNextPageHint("mcp-use servers list", page, extraArgs);
     console.log();
   } catch (error) {
     handleCommandError(error, "Failed to list servers");
@@ -329,7 +372,7 @@ export function createServersCommand(): Command {
     .alias("ls")
     .description("List servers for the current organization")
     .option("--org <slug-or-id>", "Target organization (slug, id, or name)")
-    .option("--limit <n>", "Page size (1–100, default 50)")
+    .option("--limit <n>", "Page size (default 30)")
     .option("--skip <n>", "Offset for pagination")
     .option("--sort <field:asc|desc>", "Sort (e.g. updatedAt:desc)")
     .action(listServersCommand);

--- a/libraries/typescript/packages/cli/src/utils/api.ts
+++ b/libraries/typescript/packages/cli/src/utils/api.ts
@@ -163,6 +163,63 @@ interface BuildLogsResponse {
   status: string;
 }
 
+interface PaginatedResponse<T> {
+  items: T[];
+  total: number;
+  limit: number;
+  skip: number;
+}
+
+interface PaginationParams {
+  limit?: number;
+  skip?: number;
+}
+
+interface SortablePaginationParams extends PaginationParams {
+  sort?: string;
+}
+
+function normalizePaginatedResponse<T>(
+  response: PaginatedResponse<T> | T[],
+  params?: PaginationParams
+): PaginatedResponse<T> {
+  if (Array.isArray(response)) {
+    return {
+      items: response,
+      total: response.length,
+      limit: params?.limit ?? response.length,
+      skip: params?.skip ?? 0,
+    };
+  }
+
+  return {
+    items: response.items,
+    total: response.total,
+    limit: response.limit,
+    skip: response.skip,
+  };
+}
+
+function buildPaginationQuery(
+  params?: SortablePaginationParams & { organizationId?: string }
+): string {
+  const search = new URLSearchParams();
+  if (params?.organizationId) {
+    search.set("organizationId", params.organizationId);
+  }
+  if (params?.limit != null) {
+    search.set("limit", String(params.limit));
+  }
+  if (params?.skip != null) {
+    search.set("skip", String(params.skip));
+  }
+  if (params?.sort) {
+    search.set("sort", params.sort);
+  }
+  const q = search.toString();
+  return q ? `?${q}` : "";
+}
+
 // ── GitHub ──────────────────────────────────────────────────────────
 
 export interface GitHubInstallation {
@@ -392,22 +449,11 @@ export class McpUseAPI {
     limit?: number;
     skip?: number;
     sort?: string;
-  }): Promise<CloudServer[]> {
-    const search = new URLSearchParams();
-    if (params?.organizationId) {
-      search.set("organizationId", params.organizationId);
-    }
-    if (params?.limit != null) {
-      search.set("limit", String(params.limit));
-    }
-    if (params?.skip != null) {
-      search.set("skip", String(params.skip));
-    }
-    if (params?.sort) {
-      search.set("sort", params.sort);
-    }
-    const q = search.toString();
-    return this.request<CloudServer[]>(`/servers${q ? `?${q}` : ""}`);
+  }): Promise<PaginatedResponse<CloudServer>> {
+    const response = await this.request<
+      PaginatedResponse<CloudServer> | CloudServer[]
+    >(`/servers${buildPaginationQuery(params)}`);
+    return normalizePaginatedResponse(response, params);
   }
 
   async getServer(idOrSlug: string): Promise<CloudServer> {
@@ -481,8 +527,13 @@ export class McpUseAPI {
     return this.request<Deployment>(`/deployments/${deploymentId}`);
   }
 
-  async listDeployments(): Promise<Deployment[]> {
-    return this.request<Deployment[]>("/deployments");
+  async listDeployments(
+    params?: SortablePaginationParams
+  ): Promise<PaginatedResponse<Deployment>> {
+    const response = await this.request<
+      PaginatedResponse<Deployment> | Deployment[]
+    >(`/deployments${buildPaginationQuery(params)}`);
+    return normalizePaginatedResponse(response, params);
   }
 
   async deleteDeployment(deploymentId: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Update the CLI API client to treat `servers` and `deployments` as paginated responses with `items`, `total`, `limit`, and `skip`.
- Make `servers list` and `deployments list` page-aware, including totals and next-page hints.
- Set the default list limit to `30` for both commands while keeping explicit `--limit` and `--skip` overrides.
- Add regression coverage for paginated responses and legacy array fallback behavior.

## Testing
- `pnpm --filter @mcp-use/cli build`
- `pnpm --filter @mcp-use/cli exec vitest run tests/api-pagination.test.ts tests/deployments.test.ts`
- Live smoke-tested the built CLI against the cloud API for `servers list` and `deployments list` with and without explicit `--limit`.