### PR TITLE
Fix/bedrock empty tool result structured content

### DIFF
--- a/libraries/python/mcp_use/agents/adapters/langchain_adapter.py
+++ b/libraries/python/mcp_use/agents/adapters/langchain_adapter.py
@@ -6,6 +6,7 @@ This module provides utilities to convert MCP tools to LangChain tools.
 
 import re
 from typing import Any, NoReturn
+import json
 
 from jsonschema_pydantic import jsonschema_to_pydantic
 from langchain_core.tools import BaseTool
@@ -35,7 +36,7 @@ LangChainContentBlock = dict[str, Any]
 LangChainToolResult = str | LangChainContentBlock | list[LangChainContentBlock]
 
 
-def _mcp_content_to_langchain(content: list[Any]) -> str | list[LangChainContentBlock]:
+def _mcp_content_to_langchain(tool_result: CallToolResult) ->LangChainToolResult:
     """Convert MCP tool result content to LangChain-compatible format.
 
     Maps MCP content types to LangChain content blocks:
@@ -46,15 +47,18 @@ def _mcp_content_to_langchain(content: list[Any]) -> str | list[LangChainContent
 
     If the result is a single TextContent, returns a plain string for simplicity.
     """
-    if not content:
-        return ""
+    if not tool_result.content:
+        if hasattr(tool_result, "structuredContent") and tool_result.structuredContent:
+            return json.dumps(tool_result.structuredContent)
+        return "(no content)"
+
 
     # Single TextContent → plain string (most common case)
-    if len(content) == 1 and isinstance(content[0], TextContent):
-        return content[0].text
+    if len(tool_result.content) == 1 and isinstance(tool_result.content[0], TextContent):
+        return tool_result.content[0].text
 
     blocks: list[LangChainContentBlock] = []
-    for item in content:
+    for item in tool_result.content:
         match item:
             case TextContent():
                 blocks.append({"type": "text", "text": item.text})
@@ -182,7 +186,7 @@ class LangChainAdapter(BaseAdapter[BaseTool]):
                     tool_result: CallToolResult = await self.tool_connector.call_tool(self.name, kwargs)
                     converted_content: LangChainToolResult | None = None
                     try:
-                        converted_content = _mcp_content_to_langchain(tool_result.content)
+                        converted_content = _mcp_content_to_langchain(tool_result)
                         if tool_result.isError:
                             error_message = (
                                 converted_content

--- a/libraries/python/tests/unit/test_langchain_adapter.py
+++ b/libraries/python/tests/unit/test_langchain_adapter.py
@@ -22,26 +22,30 @@ class TestLangChainAdapterContentConversion:
 
     def test_single_text_content_returns_plain_string(self):
         """Single text results should preserve the simple string contract."""
-        result = _mcp_content_to_langchain([TextContent(type="text", text="hello world")])
+        result = _mcp_content_to_langchain(
+            CallToolResult(content=[TextContent(type="text", text="hello world")])
+        )
 
         assert result == "hello world"
 
     def test_mixed_content_returns_langchain_blocks(self):
         """Mixed content should map to LangChain block dictionaries."""
         result = _mcp_content_to_langchain(
-            [
-                TextContent(type="text", text="intro"),
-                ImageContent(type="image", data="aGVsbG8=", mimeType="image/png"),
-                AudioContent(type="audio", data="d29ybGQ=", mimeType="audio/mpeg"),
-                EmbeddedResource(
-                    type="resource",
-                    resource=TextResourceContents(uri="file:///tmp/readme.txt", text="resource text"),
-                ),
-                EmbeddedResource(
-                    type="resource",
-                    resource=BlobResourceContents(uri="file:///tmp/data.bin", blob="ZGF0YQ=="),
-                ),
-            ]
+            CallToolResult(
+                content=[
+                    TextContent(type="text", text="intro"),
+                    ImageContent(type="image", data="aGVsbG8=", mimeType="image/png"),
+                    AudioContent(type="audio", data="d29ybGQ=", mimeType="audio/mpeg"),
+                    EmbeddedResource(
+                        type="resource",
+                        resource=TextResourceContents(uri="file:///tmp/readme.txt", text="resource text"),
+                    ),
+                    EmbeddedResource(
+                        type="resource",
+                        resource=BlobResourceContents(uri="file:///tmp/data.bin", blob="ZGF0YQ=="),
+                    ),
+                ]
+            )
         )
 
         assert result == [
@@ -70,15 +74,46 @@ class TestLangChainAdapterContentConversion:
     def test_unknown_embedded_resource_falls_back_to_text(self):
         """Unexpected embedded resource payloads should not be dropped silently."""
         result = _mcp_content_to_langchain(
-            [
-                EmbeddedResource.model_construct(
-                    type="resource",
-                    resource={"unexpected": "value"},
-                )
-            ]
+            CallToolResult(
+                content=[
+                    EmbeddedResource.model_construct(
+                        type="resource",
+                        resource={"unexpected": "value"},
+                    )
+                ]
+            )
         )
 
         assert result == "{'unexpected': 'value'}"
+
+    def test_empty_content_with_structured_content_returns_json(self):
+        """Empty content[] with structuredContent should return JSON string instead of empty string.
+
+        Regression test for https://github.com/mcp-use/mcp-use/issues/1604
+        Bedrock rejects empty string ToolMessages, so we fall back to structuredContent.
+        """
+        result = _mcp_content_to_langchain(
+            CallToolResult(
+                content=[],
+                structuredContent={"success": True, "data": {"value": 42}},
+            )
+        )
+
+        import json
+        assert result == json.dumps({"success": True, "data": {"value": 42}})
+
+    def test_empty_content_without_structured_content_returns_placeholder(self):
+        """Empty content[] with no structuredContent should return a non-empty placeholder.
+
+        Regression test for https://github.com/mcp-use/mcp-use/issues/1604
+        Bedrock rejects empty string ToolMessages.
+        """
+        result = _mcp_content_to_langchain(
+            CallToolResult(content=[], structuredContent=None)
+        )
+
+        assert result == "(no content)"
+        assert result != ""
 
 
 class TestLangChainAdapterToolExecution:


### PR DESCRIPTION
 ## Changes
  Fix `_mcp_content_to_langchain` crashing AWS Bedrock when an MCP server returns an empty `content[]` with data in `structuredContent` (MCP 2025-11-05 spec).

  ## Implementation Details
  1. Changed `_mcp_content_to_langchain` to accept a full `CallToolResult` object instead of just the `content` list, so it can access both `content` and `structuredContent`.
  2. When `content` is empty, fall back to `json.dumps(structuredContent)` if available, otherwise return `"(no content)"` — both are non-empty strings that Bedrock accepts.
  3. Updated the call site to pass `tool_result` instead of `tool_result.content`.

  ## Example Usage (Before)
  ```python
  # MCP server (2025-11-05 spec) returns:
  # {"content": [], "structuredContent": {"success": true, "data": {...}}}
  # → _mcp_content_to_langchain returns ""
  # → Bedrock raises ValidationException: tool_use ids found without tool_result blocks

  Example Usage (After)

  # Same response from MCP server
  # → _mcp_content_to_langchain returns json.dumps({"success": true, "data": {...}})
  # → Bedrock accepts it, agent continues normally

  Testing

  - Updated 3 existing tests to pass CallToolResult instead of a raw list (required by new signature)
  - Added test_empty_content_with_structured_content_returns_json — confirms structuredContent fallback works
  - Added test_empty_content_without_structured_content_returns_placeholder — confirms "(no content)" is returned instead of "" when both fields are empty
  - All 6 tests pass

  Backwards Compatibility

  No breaking change for existing users. The only behavioral difference is when content[] is empty — previously returned "", now returns structured data or a placeholder. Both are non-empty strings compatible
  with all LLM providers.

  Related Issues

  
  ```
Closes #1604