### PR TITLE
fix(adapters): PromptTool returns string instead of raw PromptMessage list

### DIFF
--- a/libraries/python/mcp_use/agents/adapters/langchain_adapter.py
+++ b/libraries/python/mcp_use/agents/adapters/langchain_adapter.py
@@ -297,7 +297,9 @@ class LangChainAdapter(BaseAdapter[BaseTool]):
                 logger.debug(f'Prompt tool: "{self.name}" called with args: {kwargs}')
                 try:
                     result = await self.tool_connector.get_prompt(self.name, kwargs)
-                    return result.messages
+                    if not result.messages:
+                        return "(no prompt content)"
+                    return "\n".join(str(m.content) for m in result.messages)
                 except Exception as e:
                     if self.handle_tool_error:
                         return format_error(e, tool=self.name)  # Format the error to make LLM understand it


### PR DESCRIPTION
## Problem

\`PromptTool._arun\` returns \`result.messages\` directly — a \`list[PromptMessage]\`. LangGraph wraps this in a \`ToolMessage\` with \`content=[]\` (empty list), which AWS Bedrock rejects with:

\`\`\`
ValidationException: tool_use ids found without tool_result blocks immediately after
\`\`\`

This affects any MCP server that exposes a prompt alongside a tool with the same name (e.g. Enterpret's \`initialize_wisdom\`). The LLM calls the prompt tool, gets back an empty list, and Bedrock rejects the next message as malformed.

This is a companion fix to #1620 — that PR addresses \`CallToolResult.content=[]\` in **regular tools**; this PR addresses the same class of bug in **prompt tools**.

Closes #1621

## Fix

Convert \`result.messages\` to a plain string before returning, so LangGraph always creates a \`ToolMessage\` with non-empty string content:

\`\`\`python
# Before
return result.messages

# After
if not result.messages:
    return "(no prompt content)"
return "\n".join(str(m.content) for m in result.messages)
\`\`\`

## Testing

Verified end-to-end with:
- Enterpret Wisdom MCP server (exposes \`initialize_wisdom\` as both tool and prompt)
- \`ChatBedrock\` with \`claude-sonnet-4-6\` on AWS Bedrock
- Agent completes full multi-step workflow without \`ValidationException\`