### PR TITLE
Fix idle cleanup of session refs

### DIFF
--- a/libraries/typescript/.changeset/fresh-walls-clean.md
+++ b/libraries/typescript/.changeset/fresh-walls-clean.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Fix idle session cleanup to release registered refs for expired sessions.

--- a/libraries/typescript/packages/mcp-use/src/server/sessions/session-manager.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/sessions/session-manager.ts
@@ -73,6 +73,7 @@ export function startIdleCleanup(
   transports?: Map<string, { close?: () => Promise<void> | void }>,
   mcpServerInstance?: {
     cleanupSessionSubscriptions?: (sessionId: string) => void;
+    cleanupSessionRefs?: (sessionId: string) => void;
   }
 ): NodeJS.Timeout | undefined {
   if (idleTimeoutMs <= 0) {
@@ -107,10 +108,11 @@ export function startIdleCleanup(
         transports?.delete(sessionId);
 
         sessions.delete(sessionId);
-        // Clean up resource subscriptions for this session if mcpServerInstance provided
+        // Clean up server-owned per-session resources if mcpServerInstance provided
         mcpServerInstance?.cleanupSessionSubscriptions?.(sessionId);
+        mcpServerInstance?.cleanupSessionRefs?.(sessionId);
         console.log(
-          `[MCP] Cleaned up resource subscriptions for session ${sessionId}`
+          `[MCP] Cleaned up server resources for session ${sessionId}`
         );
       }
     }

--- a/libraries/typescript/packages/mcp-use/tests/unit/server/session-manager.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/server/session-manager.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  startIdleCleanup,
+  type SessionData,
+} from "../../../src/server/sessions/index.js";
+
+describe("startIdleCleanup", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("cleans server resources for expired sessions", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    const sessions = new Map<string, SessionData>([
+      [
+        "expired-session",
+        {
+          lastAccessedAt: Date.now() - 2_000,
+          transport: {} as SessionData["transport"],
+        },
+      ],
+    ]);
+    const closeTransport = vi.fn();
+    const transports = new Map([
+      [
+        "expired-session",
+        {
+          close: closeTransport,
+        },
+      ],
+    ]);
+    const mcpServerInstance = {
+      cleanupSessionSubscriptions: vi.fn(),
+      cleanupSessionRefs: vi.fn(),
+    };
+
+    const interval = startIdleCleanup(
+      sessions,
+      1_000,
+      transports,
+      mcpServerInstance
+    );
+
+    expect(interval).toBeDefined();
+
+    vi.advanceTimersByTime(60_000);
+
+    expect(sessions.has("expired-session")).toBe(false);
+    expect(transports.has("expired-session")).toBe(false);
+    expect(closeTransport).toHaveBeenCalledTimes(1);
+    expect(mcpServerInstance.cleanupSessionSubscriptions).toHaveBeenCalledWith(
+      "expired-session"
+    );
+    expect(mcpServerInstance.cleanupSessionRefs).toHaveBeenCalledWith(
+      "expired-session"
+    );
+
+    clearInterval(interval);
+  });
+});


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

Check all that apply:
- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

Idle session cleanup now mirrors graceful session close cleanup by releasing both resource subscriptions and registered tool/prompt/resource refs for expired sessions. This prevents `sessionRegisteredRefs` entries from remaining after sessions are removed by the idle timeout.

## Review Readiness

Help maintainers review this quickly:

- [x] The PR is scoped to one issue or one clearly related change
- [x] The PR description explains the user-visible problem and the fix
- [x] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [x] I verified the affected package/docs path with the commands listed below
- [x] I checked for existing open PRs that already solve the same issue

## Implementation Details

1. Extended the `startIdleCleanup` server callback shape to include `cleanupSessionRefs`.
2. Calls `cleanupSessionRefs(sessionId)` when an idle session expires, alongside existing subscription cleanup.
3. Added a focused Vitest regression test for expired-session cleanup callbacks.
4. Added a patch changeset for `mcp-use`.

---

## TypeScript Checklist

> Complete this section if your PR includes TypeScript changes

### Packages Modified

Check all packages that were modified:
- [ ] `docs`
- [x] `tests`
- [ ] `cli`
- [ ] `create-mcp-use-app`
- [x] `mcp-use` (server)
- [ ] `mcp-use` (client)
- [ ] `inspector`

### Pre-commit Checklist

Ensure all of the following have been completed:
- [ ] Ran `pnpm lint:fix` to auto-fix linting issues
- [ ] Ran `pnpm format` to format code with Prettier
- [x] Ran `pnpm build` and build succeeds without errors
- [x] Ran `pnpm changeset` to create a changeset (if this PR includes user-facing changes)
- [x] Added or updated tests if needed
- [x] Updated documentation in `docs/` folder if needed

---

## Python Checklist

> Complete this section if your PR includes Python changes

### Pre-commit Checklist

Ensure all of the following have been completed:
- [ ] Code formatted with `ruff format`
- [ ] Linting passes with `ruff check`
- [ ] Added or updated tests if needed
- [ ] Updated documentation if needed

---

## Example Usage (Before)

```typescript
// Idle timeout removed the session and subscriptions, but left sessionRegisteredRefs for that session.
```

## Example Usage (After)

```typescript
// Idle timeout removes the session, subscriptions, transports, and sessionRegisteredRefs entry.
```

## Documentation Updates

No documentation files were updated. This is an internal cleanup behavior fix.

## Testing

- `PNPM_STORE_DIR=/tmp/mcp-use-1623-pnpm-store pnpm test:run tests/unit/server/session-manager.test.ts`
- `PNPM_STORE_DIR=/tmp/mcp-use-1623-pnpm-store pnpm --filter mcp-use build`
- `PNPM_STORE_DIR=/tmp/mcp-use-1623-pnpm-store pnpm exec prettier --check packages/mcp-use/src/server/sessions/session-manager.ts packages/mcp-use/tests/unit/server/session-manager.test.ts .changeset/fresh-walls-clean.md`
- `PNPM_STORE_DIR=/tmp/mcp-use-1623-pnpm-store pnpm exec eslint packages/mcp-use/src/server/sessions/session-manager.ts packages/mcp-use/tests/unit/server/session-manager.test.ts`
- `git diff --check`

Also ran `PNPM_STORE_DIR=/tmp/mcp-use-1623-pnpm-store pnpm test:unit`; 48 test files passed, but `tests/docs/agent-quick-start.test.ts` failed because `OPENAI_API_KEY` is not set in this environment.

## Backwards Compatibility

Backwards compatible. This only invokes an optional existing cleanup callback during idle expiration.

## Related Issues

Closes #1623