### PR TITLE
Fix/resource tool partial content loss

### DIFF
--- a/libraries/python/mcp_use/agents/adapters/langchain_adapter.py
+++ b/libraries/python/mcp_use/agents/adapters/langchain_adapter.py
@@ -243,10 +243,10 @@ class LangChainAdapter(BaseAdapter[BaseTool]):
                         else:
 
                             parts.append(str(content))
-                        "\n".join(parts)
 
 
-                    return parts
+
+                    return  "\n".join(parts)
                 except Exception as e:
                     if self.handle_tool_error:
                         return format_error(e, tool=self.name)  # Format the error to make LLM understand it

--- a/libraries/python/mcp_use/agents/adapters/langchain_adapter.py
+++ b/libraries/python/mcp_use/agents/adapters/langchain_adapter.py
@@ -233,14 +233,20 @@ class LangChainAdapter(BaseAdapter[BaseTool]):
                 logger.debug(f'Resource tool: "{self.name}" called')
                 try:
                     result = await self.tool_connector.read_resource(mcp_resource.uri)
+                    parts =[]
                     for content in result.contents:
                         # Attempt to decode bytes if necessary
                         if isinstance(content, bytes):
-                            content_decoded = content.decode()
-                        else:
-                            content_decoded = str(content)
 
-                    return content_decoded
+                            parts.append(content.decode())
+
+                        else:
+
+                            parts.append(str(content))
+                        "\n".join(parts)
+
+
+                    return parts
                 except Exception as e:
                     if self.handle_tool_error:
                         return format_error(e, tool=self.name)  # Format the error to make LLM understand it

--- a/libraries/python/tests/unit/test_langchain_adapter.py
+++ b/libraries/python/tests/unit/test_langchain_adapter.py
@@ -9,6 +9,8 @@ from mcp.types import (
     CallToolResult,
     EmbeddedResource,
     ImageContent,
+    ReadResourceResult,
+    Resource,
     TextContent,
     TextResourceContents,
     Tool,
@@ -79,6 +81,61 @@ class TestLangChainAdapterContentConversion:
         )
 
         assert result == "{'unexpected': 'value'}"
+
+
+class TestLangChainAdapterResourceTool:
+    """Tests for resource tool _arun — regression for partial content loss bug."""
+
+    def _make_resource_tool(self, read_resource_return):
+        adapter = LangChainAdapter()
+        connector = MagicMock()
+        connector.read_resource = AsyncMock(return_value=read_resource_return)
+        resource = Resource(name="test_resource", uri="config://app")
+        return adapter._convert_resource(resource, connector)
+
+    @pytest.mark.asyncio
+    async def test_single_content_block_returned(self):
+        """Single content block should be returned as a plain string."""
+        tool = self._make_resource_tool(
+            ReadResourceResult(
+                contents=[TextResourceContents(uri="config://app", text="hello world")]
+            )
+        )
+        result = await tool._arun()
+        assert result == "TextContent(type='text', text='hello world')" or "hello world" in result
+
+    @pytest.mark.asyncio
+    async def test_multiple_content_blocks_all_returned(self):
+        """All content blocks must be returned joined — regression for data loss bug.
+
+        Previously only the last block was returned; the rest were silently dropped.
+        """
+        tool = self._make_resource_tool(
+            ReadResourceResult(
+                contents=[
+                    TextResourceContents(uri="config://app", text="page 1"),
+                    TextResourceContents(uri="config://app", text="page 2"),
+                    TextResourceContents(uri="config://app", text="page 3"),
+                ]
+            )
+        )
+        result = await tool._arun()
+        assert "page 1" in result
+        assert "page 2" in result
+        assert "page 3" in result
+
+    @pytest.mark.asyncio
+    async def test_empty_contents_returns_empty_string(self):
+        """Empty contents must return empty string, not crash with UnboundLocalError.
+
+        Previously this raised: UnboundLocalError: cannot access local variable
+        'content_decoded' before assignment.
+        """
+        tool = self._make_resource_tool(
+            ReadResourceResult(contents=[])
+        )
+        result = await tool._arun()
+        assert result == ""
 
 
 class TestLangChainAdapterToolExecution:


### PR DESCRIPTION
 ## Changes
  Fix `_convert_resource` returning only the last content block when a resource has multiple contents, and crashing with `UnboundLocalError` when contents is empty.

  ## Implementation Details
  1. Replaced the overwriting `content_decoded` variable with a `parts` list that collects all content blocks across iterations.
  2. Changed `return content_decoded` to `return "\n".join(parts)` outside the loop, so all blocks are joined and returned.
  3. Empty contents now returns `""` instead of crashing.

  ## Example Usage (Before)
  ```python
  # Resource returns 3 content blocks
  result.contents = ["page 1", "page 2", "page 3"]
  # → agent receives only "page 3"  (page 1 and page 2 silently dropped)

  # Resource returns empty contents
  result.contents = []
  # → UnboundLocalError: cannot access local variable 'content_decoded' before assignment
  ```

  ## Example Usage (After)
  ```python
  # Resource returns 3 content blocks
  result.contents = ["page 1", "page 2", "page 3"]
  # → agent receives "page 1\npage 2\npage 3"

  # Resource returns empty contents
  result.contents = []
  # → agent receives ""
  ```

  ## Testing
  - Added `TestLangChainAdapterResourceTool` class in `tests/unit/test_langchain_adapter.py` with 3 tests:
    - `test_single_content_block_returned` — normal case still works
    - `test_multiple_content_blocks_all_returned` — regression for data loss bug
    - `test_empty_contents_returns_empty_string` — regression for UnboundLocalError
  - All 7 tests pass

  ## Backwards Compatibility
  No breaking change. Single content block behaviour is unchanged. Multi-block resources now return complete data instead of partial data.

  ## Related Issues
  Closes #1625