### PR TITLE
fix: require bearer auth on /sse MCP transport

### DIFF
--- a/libraries/typescript/.changeset/fix-sse-oauth-auth.md
+++ b/libraries/typescript/.changeset/fix-sse-oauth-auth.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Fix an authentication bypass on OAuth-protected MCP servers. The MCP JSON-RPC handler is mounted on both `/mcp` and `/sse`, but the bearer-auth middleware was only applied to `/mcp/*`, leaving `/sse` reachable without a token. The middleware now also covers `/sse` (and `/sse/*`), and the server advertises RFC 9728 path-scoped protected-resource metadata for `/sse`.

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/routes.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/routes.ts
@@ -388,4 +388,17 @@ export function setupOAuthRoutes(
       bearer_methods_supported: ["header"],
     });
   });
+
+  // Path-scoped protected resource metadata for the `/sse` transport, which is
+  // mounted alongside `/mcp` and is equally protected by the bearer middleware.
+  app.get("/.well-known/oauth-protected-resource/sse", (c: Context) => {
+    const authServer = proxyMode ? baseUrl : oauth.getIssuer();
+
+    return c.json({
+      resource: `${baseUrl}/sse`,
+      authorization_servers: [authServer],
+      scopes_supported: oauth.getScopesSupported(),
+      bearer_methods_supported: ["header"],
+    });
+  });
 }

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/setup.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/setup.ts
@@ -87,9 +87,13 @@ export async function setupOAuthForServer(
     };
   }
 
-  // Apply bearer auth to all /mcp routes
+  // Apply bearer auth to all MCP transport routes. The MCP JSON-RPC handler is
+  // mounted on both /mcp and /sse (see endpoints/mount-mcp.ts), so both must be
+  // guarded. /sse covers the exact mounted path and /sse/* guards subpaths.
   app.use("/mcp/*", middleware);
-  console.log("[OAuth] Bearer authentication enabled on /mcp routes");
+  app.use("/sse", middleware);
+  app.use("/sse/*", middleware);
+  console.log("[OAuth] Bearer authentication enabled on /mcp and /sse routes");
 
   return {
     provider: oauth,

--- a/libraries/typescript/packages/mcp-use/tests/server/oauth.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/server/oauth.test.ts
@@ -10,8 +10,8 @@ import { serve } from "@hono/node-server";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createBearerAuthMiddleware } from "../../src/server/oauth/middleware.js";
 import { setupOAuthRoutes } from "../../src/server/oauth/routes.js";
-import { oauthProxy } from "../../src/server/oauth/oauth-proxy.js";
 import { setupOAuthForServer } from "../../src/server/oauth/setup.js";
+import { oauthProxy } from "../../src/server/oauth/oauth-proxy.js";
 
 // A stub verifier that accepts any token. Used in tests that don't exercise
 // the verification path (routes, metadata, registration).
@@ -293,6 +293,57 @@ describe("server OAuth integration", () => {
     );
 
     errorSpy.mockRestore();
+  });
+
+  it("protects the /sse transport with bearer auth (regression: /sse bypass)", async () => {
+    const app = new Hono();
+
+    const proxy = oauthProxy({
+      issuer: "https://issuer.example.com",
+      authEndpoint: "https://issuer.example.com/oauth/authorize",
+      tokenEndpoint: "https://issuer.example.com/oauth/token",
+      clientId: "test-client",
+      verifyToken: async () => ({
+        payload: { sub: "user-1", scope: "openid profile" },
+      }),
+    });
+
+    const svc = await listenOnRandomPort(app);
+    closers.push(svc.close);
+
+    // Register OAuth via the real setup path (mirrors MCPServer.listen()).
+    await setupOAuthForServer(app, proxy, svc.baseUrl, { complete: false });
+
+    // Stub handlers standing in for the mounted MCP JSON-RPC handler. These are
+    // registered after the middleware, matching mountMcp() ordering.
+    for (const endpoint of ["/mcp", "/sse"]) {
+      app.on(["GET", "POST"], endpoint, (c) => c.json({ ok: true }));
+    }
+
+    // Unauthenticated requests to /sse must be rejected (the bypass).
+    const sseGet = await fetch(`${svc.baseUrl}/sse`);
+    expect(sseGet.status).toBe(401);
+
+    const ssePost = await fetch(`${svc.baseUrl}/sse`, { method: "POST" });
+    expect(ssePost.status).toBe(401);
+
+    // Authenticated requests to /sse reach the handler.
+    const sseAuthorized = await fetch(`${svc.baseUrl}/sse`, {
+      headers: { Authorization: "Bearer token-123" },
+    });
+    expect(sseAuthorized.status).toBe(200);
+
+    // /mcp remains protected too.
+    const mcpUnauthorized = await fetch(`${svc.baseUrl}/mcp`);
+    expect(mcpUnauthorized.status).toBe(401);
+
+    // Path-scoped protected-resource metadata is advertised for /sse.
+    const metaResponse = await fetch(
+      `${svc.baseUrl}/.well-known/oauth-protected-resource/sse`
+    );
+    expect(metaResponse.status).toBe(200);
+    const metadata = await metaResponse.json();
+    expect(metadata.resource).toBe(`${svc.baseUrl}/sse`);
   });
 
   it("returns configured clientId from /register endpoint", async () => {


### PR DESCRIPTION
The MCP JSON-RPC handler is mounted on both /mcp and /sse, but the OAuth bearer-auth middleware was only applied to /mcp/*, leaving /sse reachable without a token on OAuth-protected servers. Apply the middleware to /sse and /sse/* as well, and advertise RFC 9728 path-scoped protected-resource metadata for /sse. Adds a regression test exercising setupOAuthForServer.
