### PR TITLE
fix(cli): check repo access across all GitHub installations

### DIFF
--- a/libraries/typescript/.changeset/mcp-2358-cli-repo-access.md
+++ b/libraries/typescript/.changeset/mcp-2358-cli-repo-access.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/cli": patch
+---
+
+Fix repo access check during deploy to look across all GitHub App installations instead of only the first one, so deploys of repos owned by any linked installation no longer fail the access check.

--- a/libraries/typescript/packages/cli/src/utils/api.ts
+++ b/libraries/typescript/packages/cli/src/utils/api.ts
@@ -613,16 +613,29 @@ export class McpUseAPI {
       return { user: { login: "", id: 0, avatar_url: "" }, repos: [] };
     }
 
+    // An organization can have multiple GitHub installations (e.g. a user
+    // account and one or more GitHub orgs). Aggregate repos across all of
+    // them instead of only the first, otherwise repos owned by any other
+    // installation are reported as inaccessible.
     const inst = installResp.installations[0];
-    const reposResp = await this.request<{
-      repos: Array<{
-        id: number;
-        name: string;
-        fullName: string;
-        private: boolean;
-        ownerAvatarUrl: string | null;
-      }>;
-    }>(`/github/installations/${inst.installationId}/repos`);
+    const repoLists = await Promise.all(
+      installResp.installations.map(async (installation) => {
+        try {
+          const reposResp = await this.request<{
+            repos: Array<{
+              id: number;
+              name: string;
+              fullName: string;
+              private: boolean;
+              ownerAvatarUrl: string | null;
+            }>;
+          }>(`/github/installations/${installation.installationId}/repos`);
+          return reposResp.repos;
+        } catch {
+          return [];
+        }
+      })
+    );
 
     return {
       user: {
@@ -630,7 +643,7 @@ export class McpUseAPI {
         id: 0,
         avatar_url: inst.account?.avatar_url ?? "",
       },
-      repos: reposResp.repos.map((r) => ({
+      repos: repoLists.flat().map((r) => ({
         id: r.id,
         name: r.name,
         full_name: r.fullName,


### PR DESCRIPTION
## Problem

`mcp-use deploy` fails with `⚠️ GitHub App doesn't have access to <owner>/<repo>` even when the GitHub App is installed with **all repositories** access, whenever the Manufact organization is linked to multiple GitHub installations and the repo belongs to any installation other than the first.

`getGitHubRepos()` in `packages/cli/src/utils/api.ts` fetched repos from `installations[0]` only, so `checkRepoAccess()` never saw repos owned by other installations. The `-y` flow then opens the GitHub App install page and polls until timeout.

## Real-world repro

Manufact Demo Org has 4 installations (`manufacts`, `mcp-use`, `Pederzh`, `pietrozullo`). Deploying `mcp-use/resend-mcp-app` failed because `installations[0]` resolved to `manufacts`, while the repo lives in the `mcp-use` installation (repository_selection: all, 221 repos). With this patch applied locally, the same deploy succeeds end-to-end.

## Fix

Aggregate repos across **all** installations (`Promise.all` + `flat()`), tolerating per-installation fetch failures. The `user` field keeps reporting the first installation's account, as before.

## Follow-up (not in this PR)

`getGitHubInstallationId()` has the same `installations[0]` pattern (used for settings URLs).

Fixes MCP-2358