### PR TITLE
Dependabot open against Canary

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/libraries/typescript"
+    target-branch: "canary"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "pip"
+    directory: "/libraries/python"
+    target-branch: "canary"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "canary"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/.github/workflows/dependabot-changesets.yml
+++ b/.github/workflows/dependabot-changesets.yml
@@ -48,10 +48,12 @@ jobs:
             
             core.setOutput('head_ref', pr.head.ref);
             core.setOutput('head_sha', pr.head.sha);
+            core.setOutput('base_ref', pr.base.ref);
             core.info(`✅ Found Dependabot PR #${prNumber}: ${pr.head.ref}`);
             return {
               head_ref: pr.head.ref,
               head_sha: pr.head.sha,
+              base_ref: pr.base.ref,
             };
 
       - name: Checkout
@@ -86,6 +88,7 @@ jobs:
             const TYPESCRIPT_DIR = "libraries/typescript";
             const CHANGESET_DIR = `${TYPESCRIPT_DIR}/.changeset`;
             const FORCE = '${{ github.event.inputs.force }}' === 'true';
+            const BASE_REF = '${{ steps.pr-info.outputs.base_ref || github.base_ref || 'canary' }}';
 
             // Check if we're on a dependabot branch
             const { stdout } = await exec.getExecOutput("git", ["branch", "--show-current"]);
@@ -120,7 +123,7 @@ jobs:
             }
 
             // Get changed package.json files from the diff against base branch
-            const { stdout: diffOutput } = await exec.getExecOutput("git", ["diff", "--name-only", "origin/main...HEAD"]);
+            const { stdout: diffOutput } = await exec.getExecOutput("git", ["diff", "--name-only", `origin/${BASE_REF}...HEAD`]);
             const diffFiles = diffOutput.split("\n").filter(Boolean);
             
             console.log(`Found ${diffFiles.length} changed files in PR`);
@@ -239,4 +242,3 @@ jobs:
             await exec.exec("git", ["push"]);
 
             console.log("✅ Changeset committed and pushed");
-


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` so Dependabot opens npm, pip, and GitHub Actions update PRs against `canary`
- Update the Dependabot changeset workflow to read the PR base branch dynamically instead of assuming `main`
- Preserve changeset generation for Dependabot updates when the target branch is `canary`

## Testing
- Not run (not requested)
- Validated the YAML syntax at a high level during review