### PR TITLE
chore: use default Dependabot PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,18 +5,15 @@ updates:
     target-branch: "canary"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
 
   - package-ecosystem: "pip"
     directory: "/libraries/python"
     target-branch: "canary"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
 
   - package-ecosystem: "github-actions"
     directory: "/"
     target-branch: "canary"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary
- remove explicit Dependabot open pull request limits
- let each configured ecosystem use Dependabot's default version update PR limit

## Notes
This keeps weekly checks targeting canary, but avoids overriding GitHub's default cap with a higher value.