### PR TITLE
feat(greeting-card): migrate greeting-card resource to React widget tool

### DIFF
--- a/libraries/typescript/.changeset/migrate-greeting-card-widget.md
+++ b/libraries/typescript/.changeset/migrate-greeting-card-widget.md
@@ -1,5 +1,0 @@
----
-"mcp-use": patch
----
-
-Migrate greeting-card resource example to a React widget tool to support dual-protocol rendering.

--- a/libraries/typescript/.changeset/migrate-greeting-card-widget.md
+++ b/libraries/typescript/.changeset/migrate-greeting-card-widget.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Migrate greeting-card resource example to a React widget tool to support dual-protocol rendering.

--- a/libraries/typescript/packages/mcp-use/examples/server/ui/mcp-apps/index.ts
+++ b/libraries/typescript/packages/mcp-use/examples/server/ui/mcp-apps/index.ts
@@ -126,86 +126,30 @@ server.tool(
   }
 );
 
-// Example 2: Simple greeting widget (programmatic, auto-exposed as tool)
-// NOTE: You can also create React widgets in resources/ directory like weather-display
-server.uiResource({
-  type: "mcpApps",
-  name: "greeting-card",
-  title: "Greeting Card",
-  description: "Shows a personalized greeting message",
-  props: {
-    name: {
-      type: "string",
-      required: true,
-      description: "Name to greet",
-    },
-    greeting: {
-      type: "string",
-      required: true,
-      description: "Greeting message",
+// Example 2: Simple greeting tool backed by a React widget in resources/
+server.tool(
+  {
+    name: "greeting-card",
+    description: "Shows a personalized greeting message",
+    schema: z.object({
+      name: z.string().describe("Name to greet"),
+      greeting: z.string().describe("Greeting message"),
+    }),
+    widget: {
+      name: "greeting-card",
+      invoking: "Creating greeting card...",
+      invoked: "Greeting card ready",
     },
   },
-  htmlTemplate: `
-    <!DOCTYPE html>
-    <html>
-    <head>
-      <meta charset="UTF-8">
-      <meta name="viewport" content="width=device-width, initial-scale=1.0">
-      <style>
-        body {
-          margin: 0;
-          padding: 20px;
-          font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-        }
-        .greeting-card {
-          background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
-          border-radius: 12px;
-          padding: 32px;
-          color: white;
-          text-align: center;
-          max-width: 400px;
-        }
-        .greeting {
-          font-size: 36px;
-          font-weight: 700;
-          margin-bottom: 16px;
-        }
-        .name {
-          font-size: 48px;
-          font-weight: 800;
-        }
-      </style>
-    </head>
-    <body>
-      <div class="greeting-card">
-        <div class="greeting" id="greeting">Hello</div>
-        <div class="name" id="name">World</div>
-      </div>
-      <script>
-        // Parse props from URL (for both protocols)
-        const params = new URLSearchParams(window.location.search);
-        const propsJson = params.get('props');
-        
-        if (propsJson) {
-          try {
-            const props = JSON.parse(propsJson);
-            document.getElementById('greeting').textContent = props.greeting || 'Hello';
-            document.getElementById('name').textContent = props.name || 'World';
-          } catch (e) {
-            console.error('Failed to parse props:', e);
-          }
-        }
-      </script>
-    </body>
-    </html>
-  `,
-  metadata: {
-    prefersBorder: true,
-    widgetDescription: "A colorful greeting card with personalized message",
-  },
-  // This widget is automatically exposed as a tool
-  exposeAsTool: true,
-});
+  async ({ name, greeting }) =>
+    widget({
+      props: {
+        name,
+        greeting,
+      },
+      message: `${greeting} ${name}`,
+    })
+);
 
 // Brand info tool (returns structured data)
 server.tool(
@@ -252,7 +196,7 @@ This server demonstrates dual-protocol widget support:
 Try these tools:
 - get-weather: Get weather for a city (uses weather-display widget)
 - get-weather-delayed: Test widget lifecycle with 5s delay (Issue #930)
-- greeting-display: Auto-exposed widget with props
+- greeting-card: Personalized greeting widget backed by a React resource
 - get-info: Learn about dual-protocol support
 
 To test Issue #930 fix:

--- a/libraries/typescript/packages/mcp-use/examples/server/ui/mcp-apps/resources/greeting-card/widget.tsx
+++ b/libraries/typescript/packages/mcp-use/examples/server/ui/mcp-apps/resources/greeting-card/widget.tsx
@@ -13,7 +13,7 @@ export const widgetMetadata: WidgetMetadata = {
   props: propSchema,
   exposeAsTool: false,
   metadata: {
-    prefersBorder: true,
+    prefersBorder: false,
     widgetDescription: "A colorful greeting card with personalized message",
   },
   annotations: {
@@ -28,21 +28,37 @@ const GreetingCard: React.FC = () => {
 
   return (
     <McpUseProvider debugger viewControls autoSize>
-      <div className="flex items-center justify-center min-h-[240px] p-4">
-        {isPending ? (
-          <div className="rounded-3xl border border-pink-200/70 bg-gradient-to-br from-pink-100 to-rose-200 px-8 py-10 shadow-lg shadow-pink-200/40 dark:border-pink-500/30 dark:from-pink-950/40 dark:to-rose-900/40">
-            <div className="h-12 w-12 animate-spin rounded-full border-b-2 border-pink-600 dark:border-pink-300" />
+      <div className="flex items-center justify-center min-h-[260px] p-6 bg-zinc-900/5 dark:bg-zinc-950 transition-colors duration-300">
+        <div className="w-full max-w-[380px] rounded-lg border border-zinc-200/80 dark:border-zinc-800/80 bg-zinc-950 text-zinc-400 font-mono shadow-2xl overflow-hidden text-left">
+          {/* Header */}
+          <div className="px-4 py-2.5 bg-zinc-100 dark:bg-zinc-900 border-b border-zinc-200/80 dark:border-zinc-800/80 select-none">
+            <span className="text-[11px] font-semibold text-zinc-800 dark:text-zinc-200">
+              greeting-card
+            </span>
           </div>
-        ) : (
-          <div className="min-w-[360px] rounded-3xl border border-pink-200/70 bg-gradient-to-br from-fuchsia-400 via-pink-500 to-rose-500 px-10 py-12 text-center text-white shadow-2xl shadow-pink-500/30 dark:border-pink-500/30 dark:from-fuchsia-500 dark:via-pink-600 dark:to-rose-600">
-            <div className="text-4xl font-semibold leading-none tracking-tight opacity-90">
-              {props.greeting}
-            </div>
-            <div className="mt-4 text-5xl font-extrabold leading-none tracking-tight">
-              {props.name}
-            </div>
+
+          {/* Terminal Body */}
+          <div className="p-5 flex flex-col gap-1.5 bg-zinc-950">
+            {isPending ? (
+              <div className="flex flex-col gap-2">
+                <div className="flex items-center gap-2 text-xs text-zinc-500 animate-pulse">
+                  <span>Executing...</span>
+                </div>
+              </div>
+            ) : (
+              <>
+                {/* Greeting Line */}
+                <div className="text-lg font-bold text-zinc-100 leading-tight">
+                  {props.greeting}
+                </div>
+                {/* Name Line */}
+                <div className="text-lg font-bold text-zinc-100 leading-tight">
+                  {props.name}
+                </div>
+              </>
+            )}
           </div>
-        )}
+        </div>
       </div>
     </McpUseProvider>
   );

--- a/libraries/typescript/packages/mcp-use/examples/server/ui/mcp-apps/resources/greeting-card/widget.tsx
+++ b/libraries/typescript/packages/mcp-use/examples/server/ui/mcp-apps/resources/greeting-card/widget.tsx
@@ -1,0 +1,51 @@
+import { McpUseProvider, useWidget, type WidgetMetadata } from "mcp-use/react";
+import React from "react";
+import { z } from "zod";
+import "../styles.css";
+
+const propSchema = z.object({
+  name: z.string().describe("Name to greet"),
+  greeting: z.string().describe("Greeting message"),
+});
+
+export const widgetMetadata: WidgetMetadata = {
+  description: "Display a personalized greeting message",
+  props: propSchema,
+  exposeAsTool: false,
+  metadata: {
+    prefersBorder: true,
+    widgetDescription: "A colorful greeting card with personalized message",
+  },
+  annotations: {
+    readOnlyHint: true,
+  },
+};
+
+type GreetingProps = z.infer<typeof propSchema>;
+
+const GreetingCard: React.FC = () => {
+  const { props, isPending } = useWidget<GreetingProps>();
+
+  return (
+    <McpUseProvider debugger viewControls autoSize>
+      <div className="flex items-center justify-center min-h-[240px] p-4">
+        {isPending ? (
+          <div className="rounded-3xl border border-pink-200/70 bg-gradient-to-br from-pink-100 to-rose-200 px-8 py-10 shadow-lg shadow-pink-200/40 dark:border-pink-500/30 dark:from-pink-950/40 dark:to-rose-900/40">
+            <div className="h-12 w-12 animate-spin rounded-full border-b-2 border-pink-600 dark:border-pink-300" />
+          </div>
+        ) : (
+          <div className="min-w-[360px] rounded-3xl border border-pink-200/70 bg-gradient-to-br from-fuchsia-400 via-pink-500 to-rose-500 px-10 py-12 text-center text-white shadow-2xl shadow-pink-500/30 dark:border-pink-500/30 dark:from-fuchsia-500 dark:via-pink-600 dark:to-rose-600">
+            <div className="text-4xl font-semibold leading-none tracking-tight opacity-90">
+              {props.greeting}
+            </div>
+            <div className="mt-4 text-5xl font-extrabold leading-none tracking-tight">
+              {props.name}
+            </div>
+          </div>
+        )}
+      </div>
+    </McpUseProvider>
+  );
+};
+
+export default GreetingCard;


### PR DESCRIPTION
Closes #1658 

Updated the greeting-card example to use a React widget and pass data through widget({ props })

Previously, the widget always displayed the default "Hello World" message because the greeting values returned by the tool were not being passed to the UI correctly. With this change, the widget receives the provided name and greeting values and renders them as expected

### Screenshots

<img width="1710" height="1077" alt="Screenshot 2026-06-05 at 1 11 22 PM" src="https://github.com/user-attachments/assets/b85c842f-226d-458d-943a-5bcb5de50294" />
