### PR TITLE
Potential fix for code scanning alert no. 78: Incomplete string escaping or encoding

### DIFF
--- a/libraries/typescript/.changeset/fix-zod-to-ts-string-escaping.md
+++ b/libraries/typescript/.changeset/fix-zod-to-ts-string-escaping.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Fix incomplete escaping when converting Zod string literals and enums to TypeScript type strings. Backslashes are now escaped before double quotes so generated `.d.ts` output remains valid when literal values contain `\` or `"`.

--- a/libraries/typescript/packages/mcp-use/src/server/utils/zod-to-ts.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/utils/zod-to-ts.ts
@@ -6,6 +6,13 @@
 import type { z } from "zod";
 
 /**
+ * Escape a string so it can be safely embedded in a TypeScript double-quoted string literal.
+ */
+function escapeTsStringLiteral(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+/**
  * Convert a Zod schema to a TypeScript type string
  * @param schema - The Zod schema to convert
  * @returns TypeScript type string representation
@@ -77,7 +84,7 @@ export function zodToTypeString(schema: z.ZodTypeAny): string {
     case "ZodLiteral": {
       const value = def.value;
       if (typeof value === "string") {
-        return `"${value.replace(/"/g, '\\"')}"`;
+        return `"${escapeTsStringLiteral(value)}"`;
       }
       if (typeof value === "number") {
         return String(value);
@@ -95,7 +102,7 @@ export function zodToTypeString(schema: z.ZodTypeAny): string {
           ? Object.values(def.entries as Record<string, string>)
           : undefined;
       if (!values || values.length === 0) return "string";
-      return values.map((v) => `"${v.replace(/"/g, '\\"')}"`).join(" | ");
+      return values.map((v) => `"${escapeTsStringLiteral(v)}"`).join(" | ");
     }
 
     case "ZodNativeEnum": {


### PR DESCRIPTION
Potential fix for [https://github.com/mcp-use/mcp-use/security/code-scanning/78](https://github.com/mcp-use/mcp-use/security/code-scanning/78)

To fix the problem, all generated TypeScript string literals must fully escape characters that are significant in TypeScript string syntax. At a minimum, we must escape backslashes and double quotes (since double quotes are used as delimiters here). The safest approach is to centralize this logic in a small helper that performs proper escaping and then use that helper in all places where we emit `"${...}"`.

Concretely, in `libraries/typescript/packages/mcp-use/src/server/utils/zod-to-ts.ts`, define a helper function, e.g. `escapeTsStringLiteral`, near the top of the file. This function should first escape backslashes globally (`/\\/g, "\\\\"`) and then escape double quotes globally (`/"/g, '\\"'`) so that previously inserted backslashes are not affected incorrectly. Then, in the `ZodLiteral` case, replace the current `value.replace(/"/g, '\\"')` with `escapeTsStringLiteral(value)`. Likewise, in the `ZodEnum` case, replace `v.replace(/"/g, '\\"')` with `escapeTsStringLiteral(v)`. No new imports are required; the helper uses only built-in string operations. Existing functionality is preserved, but now also handles backslashes correctly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
