### PR TITLE
fix: clean up sessionRegisteredRefs for ungracefully-closed sessions

### DIFF
--- a/libraries/typescript/packages/mcp-use/src/server/sessions/session-manager.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/sessions/session-manager.ts
@@ -73,6 +73,7 @@ export function startIdleCleanup(
   transports?: Map<string, { close?: () => Promise<void> | void }>,
   mcpServerInstance?: {
     cleanupSessionSubscriptions?: (sessionId: string) => void;
+    cleanupSessionRefs?: (sessionId: string) => void;
   }
 ): NodeJS.Timeout | undefined {
   if (idleTimeoutMs <= 0) {
@@ -109,6 +110,8 @@ export function startIdleCleanup(
         sessions.delete(sessionId);
         // Clean up resource subscriptions for this session if mcpServerInstance provided
         mcpServerInstance?.cleanupSessionSubscriptions?.(sessionId);
+        // Clean up registered refs for this session to prevent memory leaks
+        mcpServerInstance?.cleanupSessionRefs?.(sessionId);
         console.log(
           `[MCP] Cleaned up resource subscriptions for session ${sessionId}`
         );


### PR DESCRIPTION
## Summary

Fixes #1623 — Memory leak where `startIdleCleanup` leaked `sessionRegisteredRefs` (~326 KB/session, never freed).

## Root Cause

The idle cleanup loop called `cleanupSessionSubscriptions` but missed `cleanupSessionRefs`. The graceful-close path (`onsessionclosed`) correctly called both. Ungracefully-closed sessions went through idle eviction which never cleaned their ref maps.

## Fix (2 lines)

1. Added `cleanupSessionRefs` to the `mcpServerInstance` parameter type
2. Added `mcpServerInstance?.cleanupSessionRefs?.(sessionId)` call in the idle eviction loop

## Impact

Prevents unbounded memory growth of ~326 KB per ungracefully-closed session.

Fixes #1623