### PR TITLE
fix(mcp-use): bump hono to 4.12.23 for CVE-2026-47674

### DIFF
--- a/libraries/typescript/.changeset/fix-dependabot-hono-ip-restriction.md
+++ b/libraries/typescript/.changeset/fix-dependabot-hono-ip-restriction.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Bump `hono` to `4.12.23` to address [CVE-2026-47674](https://github.com/advisories/GHSA-xrhx-7g5j-rcj5), where non-canonical IPv6 forms could bypass static deny rules in the `ip-restriction` middleware.

--- a/libraries/typescript/package.json
+++ b/libraries/typescript/package.json
@@ -90,7 +90,7 @@
       "js-yaml": ">=3.14.2 || >=4.1.1",
       "flatted": ">=3.4.2",
       "tar": ">=7.5.11",
-      "hono": ">=4.12.18",
+      "hono": ">=4.12.21",
       "@hono/node-server": ">=1.19.10",
       "express-rate-limit": ">=8.2.2",
       "dompurify": ">=3.4.0",

--- a/libraries/typescript/packages/mcp-use/package.json
+++ b/libraries/typescript/packages/mcp-use/package.json
@@ -225,7 +225,7 @@
     "@modelcontextprotocol/ext-apps": "1.0.1",
     "@modelcontextprotocol/sdk": "1.26.0",
     "express": "5.2.1",
-    "hono": "4.12.18",
+    "hono": "4.12.23",
     "jose": "6.1.3",
     "node-mocks-http": "1.17.2",
     "posthog-js": "1.351.3",

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -30,7 +30,7 @@ overrides:
   js-yaml: '>=3.14.2 || >=4.1.1'
   flatted: '>=3.4.2'
   tar: '>=7.5.11'
-  hono: '>=4.12.18'
+  hono: '>=4.12.21'
   '@hono/node-server': '>=1.19.10'
   express-rate-limit: '>=8.2.2'
   dompurify: '>=3.4.0'
@@ -397,7 +397,7 @@ importers:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       hono:
-        specifier: '>=4.12.18'
+        specifier: '>=4.12.21'
         version: 4.12.23
       lucide-react:
         specifier: ^0.562.0
@@ -527,7 +527,7 @@ importers:
         specifier: 5.2.1
         version: 5.2.1
       hono:
-        specifier: '>=4.12.18'
+        specifier: '>=4.12.21'
         version: 4.12.23
       jose:
         specifier: 6.1.3
@@ -1389,6 +1389,46 @@ importers:
         specifier: '>=8.0.5'
         version: 8.0.8(@types/node@25.3.0)(esbuild@0.27.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
+  test_app:
+    dependencies:
+      '@openai/apps-sdk-ui':
+        specifier: ^0.2.1
+        version: 0.2.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.0)
+      mcp-use:
+        specifier: workspace:*
+        version: link:../packages/mcp-use
+      react:
+        specifier: ^19.2.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.0
+        version: 19.2.4(react@19.2.4)
+      react-router:
+        specifier: ^7.15.0
+        version: 7.16.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      tailwindcss:
+        specifier: ^4.2.0
+        version: 4.2.0
+      zod:
+        specifier: 4.3.5
+        version: 4.3.5
+    devDependencies:
+      '@types/node':
+        specifier: ^25.3.0
+        version: 25.6.0
+      '@types/react':
+        specifier: ^19.2.7
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
 packages:
 
   '@acemir/cssom@0.9.31':
@@ -1999,7 +2039,7 @@ packages:
     resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: '>=4.12.18'
+      hono: '>=4.12.21'
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}


### PR DESCRIPTION
## Summary

- Bumps the direct `hono` dependency in `mcp-use` from `4.12.18` to `4.12.23`
- Raises the `pnpm.overrides` floor from `>=4.12.18` to `>=4.12.21`
- Fixes [Dependabot alert #222](https://github.com/mcp-use/mcp-use/security/dependabot/222) / [GHSA-xrhx-7g5j-rcj5](https://github.com/advisories/GHSA-xrhx-7g5j-rcj5)

## Context

Hono versions before `4.12.21` allow non-canonical IPv6 representations to bypass static deny rules in the `ip-restriction` middleware.

## Test plan

- [x] `pnpm install` (lockfile updated)
- [x] `pnpm lint:fix`
- [x] `pnpm format`
- [ ] CI passes