### PR TITLE
fix(ci): remove untrusted PR checkout from Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,20 +25,12 @@ jobs:
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
+      # Do not checkout PR head here — issue_comment is privileged; claude-code-action
+      # checks out PR refs safely and restores trusted config from the base branch.
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          fetch-depth: 0
-
-      - name: Checkout PR branch (if PR comment)
-        if: github.event.issue.pull_request
-        env:
-          PR_NUMBER: ${{ github.event.issue.number }}
-        run: |
-          echo "Fetching PR #$PR_NUMBER..."
-          git fetch origin pull/$PR_NUMBER/head:pr-$PR_NUMBER
-          git checkout pr-$PR_NUMBER
-          echo "Successfully checked out PR branch"
+          fetch-depth: 1
 
       - name: Run Claude Code
         id: claude


### PR DESCRIPTION
## Summary
- Removes the manual PR head checkout step that triggered CodeQL alert #83 (`actions/untrusted-checkout/high`)
- Aligns with official `claude-code-action` security guidance: trusted base-branch checkout only; action handles PR refs safely
- Upgrades `actions/checkout` to v6 and sets `fetch-depth: 1`

## Test plan
- [ ] CodeQL alert #83 closes after merge (or on this PR scan)
- [ ] `@claude` on a PR comment from a write-access collaborator still works with correct PR context
- [ ] `@claude` on a non-PR issue still works
- [ ] Fork contributors without write access remain blocked by the action's permission check

## Security notes
`issue_comment` is a privileged trigger. The removed step checked out untrusted fork PR code into `$GITHUB_WORKSPACE` before `claude-code-action` ran, which could expose secrets via attacker-controlled `.claude/` / `.mcp.json` files. `claude-code-action@v1` now restores trusted config from the base branch before operating on PR heads.

Closes CodeQL alert #83