### PR TITLE
Skip OpenAI docs test when API key is unavailable

### DIFF
--- a/libraries/typescript/packages/mcp-use/tests/docs/agent-quick-start.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/docs/agent-quick-start.test.ts
@@ -14,8 +14,11 @@ import { OPENAI_MODEL } from "../integration/agent/constants.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const simpleServerPath = resolve(__dirname, "../servers/simple_server.ts");
+const describeIfOpenAIKey = process.env.OPENAI_API_KEY
+  ? describe
+  : describe.skip;
 
-describe("Documentation Example: MCPAgent Quick Start", () => {
+describeIfOpenAIKey("Documentation Example: MCPAgent Quick Start", () => {
   let client: MCPClient;
   let llm: ChatOpenAI;
   let agent: MCPAgent;


### PR DESCRIPTION
## Summary
- Skip the MCPAgent quick-start docs test when OPENAI_API_KEY is not set.
- Keeps forked PR CI from failing on OpenAI-backed docs tests when secrets are unavailable.

## Verification
- git diff --check

Note: This is the same missing-secret failure currently visible in unrelated TypeScript PR test runs.