### PR TITLE
Fix Python adapter content conversion for structured tools and resources

### DIFF
--- a/libraries/python/mcp_use/agents/adapters/langchain_adapter.py
+++ b/libraries/python/mcp_use/agents/adapters/langchain_adapter.py
@@ -4,6 +4,7 @@ LangChain adapter for MCP tools.
 This module provides utilities to convert MCP tools to LangChain tools.
 """
 
+import json
 import re
 from typing import Any, NoReturn
 
@@ -33,9 +34,29 @@ from mcp_use.logging import logger
 
 LangChainContentBlock = dict[str, Any]
 LangChainToolResult = str | LangChainContentBlock | list[LangChainContentBlock]
+_MISSING = object()
 
 
-def _mcp_content_to_langchain(content: list[Any]) -> str | list[LangChainContentBlock]:
+def _serialize_structured_content(structured_content: Any) -> str:
+    """Serialize MCP structured content into text that every LangChain provider accepts."""
+    if isinstance(structured_content, str):
+        return structured_content
+    if hasattr(structured_content, "model_dump"):
+        structured_content = structured_content.model_dump(mode="json")
+    return json.dumps(structured_content, ensure_ascii=False, default=str)
+
+
+def _get_structured_content(tool_result: CallToolResult) -> Any:
+    """Return structuredContent from either MCP wire-style or Python-style field names."""
+    structured_content = getattr(tool_result, "structuredContent", _MISSING)
+    if structured_content is not _MISSING:
+        return structured_content
+    return getattr(tool_result, "structured_content", None)
+
+
+def _mcp_content_to_langchain(
+    content: list[Any], structured_content: Any | None = None
+) -> str | list[LangChainContentBlock]:
     """Convert MCP tool result content to LangChain-compatible format.
 
     Maps MCP content types to LangChain content blocks:
@@ -47,7 +68,9 @@ def _mcp_content_to_langchain(content: list[Any]) -> str | list[LangChainContent
     If the result is a single TextContent, returns a plain string for simplicity.
     """
     if not content:
-        return ""
+        if structured_content is not None:
+            return _serialize_structured_content(structured_content)
+        return "(no content)"
 
     # Single TextContent → plain string (most common case)
     if len(content) == 1 and isinstance(content[0], TextContent):
@@ -103,6 +126,17 @@ def _mcp_content_to_langchain(content: list[Any]) -> str | list[LangChainContent
         return "\n".join(b["text"] for b in blocks)
 
     return blocks
+
+
+def _resource_content_to_text(content: Any) -> str:
+    """Decode one MCP resource content block into text."""
+    if isinstance(content, TextResourceContents):
+        return content.text
+    if isinstance(content, BlobResourceContents):
+        return content.blob
+    if isinstance(content, bytes):
+        return content.decode()
+    return str(content)
 
 
 class LangChainAdapter(BaseAdapter[BaseTool]):
@@ -182,7 +216,10 @@ class LangChainAdapter(BaseAdapter[BaseTool]):
                     tool_result: CallToolResult = await self.tool_connector.call_tool(self.name, kwargs)
                     converted_content: LangChainToolResult | None = None
                     try:
-                        converted_content = _mcp_content_to_langchain(tool_result.content)
+                        converted_content = _mcp_content_to_langchain(
+                            tool_result.content,
+                            structured_content=_get_structured_content(tool_result),
+                        )
                         if tool_result.isError:
                             error_message = (
                                 converted_content
@@ -233,14 +270,7 @@ class LangChainAdapter(BaseAdapter[BaseTool]):
                 logger.debug(f'Resource tool: "{self.name}" called')
                 try:
                     result = await self.tool_connector.read_resource(mcp_resource.uri)
-                    for content in result.contents:
-                        # Attempt to decode bytes if necessary
-                        if isinstance(content, bytes):
-                            content_decoded = content.decode()
-                        else:
-                            content_decoded = str(content)
-
-                    return content_decoded
+                    return "\n".join(_resource_content_to_text(content) for content in result.contents)
                 except Exception as e:
                     if self.handle_tool_error:
                         return format_error(e, tool=self.name)  # Format the error to make LLM understand it

--- a/libraries/python/tests/unit/test_langchain_adapter.py
+++ b/libraries/python/tests/unit/test_langchain_adapter.py
@@ -9,6 +9,7 @@ from mcp.types import (
     CallToolResult,
     EmbeddedResource,
     ImageContent,
+    Resource,
     TextContent,
     TextResourceContents,
     Tool,
@@ -80,6 +81,21 @@ class TestLangChainAdapterContentConversion:
 
         assert result == "{'unexpected': 'value'}"
 
+    def test_empty_content_uses_structured_content(self):
+        """Structured tool results should not become empty LangChain tool messages."""
+        result = _mcp_content_to_langchain(
+            [],
+            structured_content={"success": True, "data": {"value": 42}},
+        )
+
+        assert result == '{"success": true, "data": {"value": 42}}'
+
+    def test_empty_content_without_structured_content_returns_placeholder(self):
+        """Empty tool results need non-empty text for providers that reject blank tool messages."""
+        result = _mcp_content_to_langchain([])
+
+        assert result == "(no content)"
+
 
 class TestLangChainAdapterToolExecution:
     """Tests for LangChain tool execution behavior."""
@@ -112,3 +128,78 @@ class TestLangChainAdapterToolExecution:
         assert result["details"] == "tool failed"
         assert result["tool"] == "failing_tool"
         assert result["tool_content"] == "tool failed"
+
+    @pytest.mark.asyncio
+    async def test_empty_tool_content_returns_structured_content(self):
+        """Tool execution should preserve structuredContent when content is empty."""
+        adapter = LangChainAdapter()
+        connector = MagicMock()
+        connector.call_tool = AsyncMock(
+            return_value=CallToolResult(
+                content=[],
+                structuredContent={"success": True, "data": {"value": 42}},
+                isError=False,
+            )
+        )
+
+        tool = Tool(
+            name="structured_tool",
+            description="A tool that returns structured content",
+            inputSchema={"type": "object", "properties": {}},
+        )
+        langchain_tool = adapter._convert_tool(tool, connector)
+
+        assert langchain_tool is not None
+
+        result = await langchain_tool._arun()
+
+        connector.call_tool.assert_awaited_once_with("structured_tool", {})
+        assert result == '{"success": true, "data": {"value": 42}}'
+
+
+class TestLangChainAdapterResourceExecution:
+    """Tests for LangChain resource tool execution behavior."""
+
+    @pytest.mark.asyncio
+    async def test_resource_tool_returns_all_content_blocks(self):
+        """Resource tools should not silently drop all but the final content block."""
+        adapter = LangChainAdapter()
+        connector = MagicMock()
+        connector.read_resource = AsyncMock(
+            return_value=MagicMock(
+                contents=[
+                    TextResourceContents(uri="file:///tmp/report.txt", text="page 1"),
+                    TextResourceContents(uri="file:///tmp/report.txt", text="page 2"),
+                    BlobResourceContents(uri="file:///tmp/report.bin", blob="cGFnZSAz"),
+                ]
+            )
+        )
+        resource = Resource.model_construct(
+            uri="file:///tmp/report.txt",
+            name="report",
+            description="A multi-part report",
+        )
+        langchain_resource = adapter._convert_resource(resource, connector)
+
+        result = await langchain_resource._arun()
+
+        connector.read_resource.assert_awaited_once_with("file:///tmp/report.txt")
+        assert result == "page 1\npage 2\ncGFnZSAz"
+
+    @pytest.mark.asyncio
+    async def test_resource_tool_returns_empty_string_for_empty_contents(self):
+        """Resource tools should handle empty content lists gracefully."""
+        adapter = LangChainAdapter()
+        connector = MagicMock()
+        connector.read_resource = AsyncMock(return_value=MagicMock(contents=[]))
+        resource = Resource.model_construct(
+            uri="file:///tmp/empty.txt",
+            name="empty",
+            description="An empty resource",
+        )
+        langchain_resource = adapter._convert_resource(resource, connector)
+
+        result = await langchain_resource._arun()
+
+        connector.read_resource.assert_awaited_once_with("file:///tmp/empty.txt")
+        assert result == ""


### PR DESCRIPTION
Closes #1604
Closes #1625

## Summary
- Preserve MCP `structuredContent` when a tool result has empty `content[]`, returning serialized structured data instead of an empty LangChain tool message.
- Return a non-empty placeholder for truly empty tool results so providers that reject blank tool messages still receive a tool result.
- Decode and join all resource content blocks instead of returning only the last block, and handle empty resource contents without crashing.
- Add focused LangChain adapter regression tests for structured tool results and resource content conversion.

## Verification
- `/private/tmp/mcp-use-python-content-venv/bin/python -m pytest libraries/python/tests/unit/test_langchain_adapter.py`
- `/private/tmp/mcp-use-python-content-venv/bin/python -m ruff check libraries/python/mcp_use/agents/adapters/langchain_adapter.py libraries/python/tests/unit/test_langchain_adapter.py`
- `/private/tmp/mcp-use-python-content-venv/bin/python -m ruff format --check libraries/python/mcp_use/agents/adapters/langchain_adapter.py libraries/python/tests/unit/test_langchain_adapter.py`
- `git diff --check`

## Notes
- I checked for open PRs covering #1604 or #1625 and did not find any before opening this.