### PR TITLE
feat(widgets): add widgetMetadata.openai.openInAppUrl for ChatGPT

### DIFF
--- a/docs/typescript/server/mcp-apps.mdx
+++ b/docs/typescript/server/mcp-apps.mdx
@@ -361,6 +361,28 @@ const WeatherDisplay: React.FC = () => {
 export default WeatherDisplay;
 ```
 
+## ChatGPT-only widget metadata (`openai`)
+
+Some widget settings only apply inside ChatGPT's Apps SDK. Put them under the top-level `openai` field in `widgetMetadata` (not inside the dual-protocol `metadata` object). MCP Apps clients ignore this namespace.
+
+### `openai.openInAppUrl`
+
+Sets the destination for ChatGPT's fullscreen **Open in app** button by calling `window.openai.setOpenInAppUrl({ href })` when the widget loads. If you omit it, ChatGPT keeps the default behavior and opens the widget's current iframe path.
+
+```tsx
+export const widgetMetadata: WidgetMetadata = {
+  description: "Product detail view",
+  props: propSchema,
+  openai: {
+    openInAppUrl: "https://example.com/products/detail",
+  },
+};
+```
+
+<Note>
+This is a ChatGPT Apps SDK feature only. It has no effect in MCP Apps hosts such as Claude Desktop.
+</Note>
+
 **The same widget code works with:**
 
 - ✅ Claude Desktop (MCP Apps protocol)

--- a/libraries/typescript/.changeset/openai-open-in-app-url.md
+++ b/libraries/typescript/.changeset/openai-open-in-app-url.md
@@ -1,0 +1,7 @@
+---
+"mcp-use": minor
+"@mcp-use/cli": patch
+"@mcp-use/inspector": patch
+---
+
+Add `widgetMetadata.openai.openInAppUrl` for ChatGPT Apps SDK widgets. When set, mcp-use injects the configured URL and calls `window.openai.setOpenInAppUrl({ href })` on widget load.

--- a/libraries/typescript/packages/cli/src/index.ts
+++ b/libraries/typescript/packages/cli/src/index.ts
@@ -1154,13 +1154,26 @@ export default {
         }
       }
 
-      // Post-process HTML for static deployments (e.g., Supabase)
-      // If MCP_SERVER_URL is set, inject window globals at build time
-      const mcpServerUrl = process.env.MCP_SERVER_URL;
-      if (mcpServerUrl) {
-        try {
-          const htmlPath = path.join(outDir, "index.html");
-          let html = await fs.readFile(htmlPath, "utf8");
+      // Post-process HTML for static deployments and ChatGPT open-in-app URL
+      try {
+        const htmlPath = path.join(outDir, "index.html");
+        let html = await fs.readFile(htmlPath, "utf8");
+
+        const openInAppUrl =
+          typeof widgetMetadata.openai?.openInAppUrl === "string"
+            ? widgetMetadata.openai.openInAppUrl
+            : undefined;
+        if (openInAppUrl && !html.includes("window.__mcpWidgetOpenai")) {
+          const openInAppScript = `<script>(function(){var c=${JSON.stringify({ openInAppUrl })};window.__mcpWidgetOpenai=c;var href=c.openInAppUrl;if(!href)return;function apply(){if(window.openai&&typeof window.openai.setOpenInAppUrl==="function"){window.openai.setOpenInAppUrl({href:href}).catch(function(err){console.error("[mcp-use] setOpenInAppUrl failed:",err);});return true;}return false;}if(!apply()){window.addEventListener("openai:set_globals",function(){apply();});}})();</script>`;
+          html = html.replace(
+            /<head[^>]*>/i,
+            `<head>\n    ${openInAppScript}`
+          );
+        }
+
+        // If MCP_SERVER_URL is set, inject window globals at build time
+        const mcpServerUrl = process.env.MCP_SERVER_URL;
+        if (mcpServerUrl) {
 
           // Inject window.__mcpPublicUrl and window.__getFile into <head>
           // Note: __mcpPublicUrl uses standard format for useWidget to derive mcp_url
@@ -1196,14 +1209,23 @@ export default {
           console.log(
             chalk.gray(`    → Injected MCP_SERVER_URL into ${widgetName}`)
           );
-        } catch (error) {
-          console.warn(
-            chalk.yellow(
-              `    ⚠ Failed to post-process HTML for ${widgetName}:`,
-              error
-            )
-          );
         }
+
+        if (openInAppUrl) {
+          await fs.writeFile(htmlPath, html, "utf8");
+          console.log(
+            chalk.gray(`    → Injected openInAppUrl into ${widgetName}`)
+          );
+        } else if (!mcpServerUrl) {
+          await fs.writeFile(htmlPath, html, "utf8");
+        }
+      } catch (error) {
+        console.warn(
+          chalk.yellow(
+            `    ⚠ Failed to post-process HTML for ${widgetName}:`,
+            error
+          )
+        );
       }
 
       console.log(chalk.green(`    ✓ Built ${widgetName}`));

--- a/libraries/typescript/packages/inspector/src/server/shared-utils.ts
+++ b/libraries/typescript/packages/inspector/src/server/shared-utils.ts
@@ -827,6 +827,18 @@ export function generateWidgetContentHtml(widgetData: WidgetData): {
             window.parent.postMessage(message, '*');
           },
 
+          async setOpenInAppUrl(payload) {
+            const href = typeof payload === 'string' ? payload : payload?.href;
+            console.log('[OpenAI Widget] setOpenInAppUrl called with:', href);
+            if (!href || !String(href).trim()) {
+              throw new Error('The href parameter is required.');
+            }
+            window.parent.postMessage({
+              type: 'openai:setOpenInAppUrl',
+              href
+            }, '*');
+          },
+
           openExternal(payload) {
             const href = typeof payload === 'string' ? payload : payload?.href;
             if (href) {

--- a/libraries/typescript/packages/mcp-use/src/react/McpUseProvider.tsx
+++ b/libraries/typescript/packages/mcp-use/src/react/McpUseProvider.tsx
@@ -5,6 +5,7 @@ import React, {
   useRef,
   useState,
 } from "react";
+import { applyOpenInAppUrlFromConfig } from "./apply-open-in-app-url.js";
 import { ErrorBoundary } from "./ErrorBoundary.js";
 import { getMcpAppsBridge } from "./mcp-apps-bridge.js";
 import { ThemeProvider } from "./ThemeProvider.js";
@@ -80,6 +81,8 @@ export function McpUseProvider({
   const lastHeightRef = useRef<number>(0);
   const debounceTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const notificationInProgressRef = useRef<boolean>(false);
+
+  useEffect(() => applyOpenInAppUrlFromConfig(), []);
 
   // Notify host about height changes (dual-protocol support)
   const notifyHeight = useCallback((height: number) => {

--- a/libraries/typescript/packages/mcp-use/src/react/apply-open-in-app-url.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/apply-open-in-app-url.ts
@@ -1,0 +1,41 @@
+import { SET_GLOBALS_EVENT_TYPE } from "./widget-types.js";
+
+export interface McpWidgetOpenaiConfig {
+  openInAppUrl?: string;
+}
+
+/**
+ * Apply `widgetMetadata.openai.openInAppUrl` by calling
+ * `window.openai.setOpenInAppUrl({ href })` when running in ChatGPT.
+ */
+export function applyOpenInAppUrlFromConfig(): () => void {
+  if (typeof window === "undefined") {
+    return () => {};
+  }
+
+  const href = window.__mcpWidgetOpenai?.openInAppUrl;
+  if (!href) {
+    return () => {};
+  }
+
+  const apply = () => {
+    if (typeof window.openai?.setOpenInAppUrl === "function") {
+      window.openai.setOpenInAppUrl({ href }).catch((error) => {
+        console.error("[mcp-use] Failed to set open in app URL:", error);
+      });
+      return true;
+    }
+    return false;
+  };
+
+  if (apply()) {
+    return () => {};
+  }
+
+  const onGlobals = () => {
+    apply();
+  };
+
+  window.addEventListener(SET_GLOBALS_EVENT_TYPE, onGlobals);
+  return () => window.removeEventListener(SET_GLOBALS_EVENT_TYPE, onGlobals);
+}

--- a/libraries/typescript/packages/mcp-use/src/react/widget-types.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/widget-types.ts
@@ -139,6 +139,12 @@ export interface API<WidgetState extends UnknownObject = UnknownObject> {
   notifyIntrinsicHeight: (height: number) => Promise<void>;
 
   /**
+   * Override the fullscreen "Open in app" destination in ChatGPT.
+   * @see https://developers.openai.com/apps-sdk/reference
+   */
+  setOpenInAppUrl?: (payload: { href: string }) => Promise<void>;
+
+  /**
    * Upload a file to the host.
    * Only available in ChatGPT Apps SDK environments.
    * Use `useFiles().isSupported` to detect availability before calling.
@@ -168,6 +174,9 @@ declare global {
     __getFile?: (filename: string) => string;
     __mcpPublicUrl?: string;
     __mcpPublicAssetsUrl?: string;
+    __mcpWidgetOpenai?: {
+      openInAppUrl?: string;
+    };
   }
 
   interface WindowEventMap {

--- a/libraries/typescript/packages/mcp-use/src/server/types/widget.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/types/widget.ts
@@ -4,6 +4,7 @@ import type { ToolAnnotations } from "./tool.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { z } from "zod";
 import type { CSPConfig } from "../widgets/adapters/types.js";
+import type { WidgetOpenaiConfig } from "../widgets/widget-openai-config.js";
 
 export interface WidgetMetadata {
   /**
@@ -130,4 +131,12 @@ export interface WidgetMetadata {
      */
     invoked?: string;
   };
+
+  /**
+   * ChatGPT Apps SDK-specific widget configuration.
+   *
+   * Ignored by MCP Apps clients (Claude, Goose, etc.). Use this namespace for
+   * settings that map to `window.openai` APIs in ChatGPT only.
+   */
+  openai?: WidgetOpenaiConfig;
 }

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/mount-widgets-dev.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/mount-widgets-dev.ts
@@ -677,6 +677,8 @@ if (container && Component) {
           // Import helpers for widget registration
           const { slugifyWidgetName, processWidgetHtml } =
             await import("./widget-helpers.js");
+          const { getWidgetOpenaiConfig, injectWidgetOpenaiConfig } =
+            await import("./widget-openai-config.js");
           const { buildDualProtocolMetadata, getBuildIdPart } =
             await import("./protocol-helpers.js");
 
@@ -702,6 +704,18 @@ if (container && Component) {
               widgetName,
               serverConfig.serverBaseUrl
             );
+            const openInAppUrl = getWidgetOpenaiConfig(metadata)?.openInAppUrl;
+            if (openInAppUrl) {
+              html = injectWidgetOpenaiConfig(html, openInAppUrl);
+              try {
+                await fs.writeFile(htmlPath, html, "utf8");
+              } catch (writeError) {
+                console.warn(
+                  `[WIDGET-HMR] Failed to write openInAppUrl config for ${widgetName}:`,
+                  writeError
+                );
+              }
+            }
           } catch (e) {
             console.warn(
               `[WIDGET-HMR] Failed to read HTML for ${widgetName}:`,

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/widget-helpers.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/widget-helpers.ts
@@ -17,6 +17,17 @@ import {
   createUIResourceFromDefinition,
   type UrlConfig,
 } from "./mcp-ui-adapter.js";
+import {
+  getWidgetOpenaiConfig,
+  injectWidgetOpenaiConfig,
+} from "./widget-openai-config.js";
+
+export {
+  buildOpenInAppUrlInjectionScript,
+  getWidgetOpenaiConfig,
+  injectWidgetOpenaiConfig,
+} from "./widget-openai-config.js";
+export type { WidgetOpenaiConfig } from "./widget-openai-config.js";
 
 /**
  * Slugify a widget name to make it URI-safe
@@ -723,6 +734,21 @@ export async function registerWidgetFromTemplate(
 
   // Process HTML with base URL injection and path conversion
   html = processWidgetHtml(html, widgetName, serverConfig.serverBaseUrl);
+
+  const openInAppUrl = getWidgetOpenaiConfig(metadata)?.openInAppUrl;
+  if (openInAppUrl) {
+    html = injectWidgetOpenaiConfig(html, openInAppUrl);
+    if (isDev) {
+      try {
+        await fsHelpers.writeFileSync(htmlPath, html, "utf8");
+      } catch (error) {
+        console.warn(
+          `[WIDGET] Failed to write openInAppUrl config for ${widgetName}:`,
+          error
+        );
+      }
+    }
+  }
 
   // Ensure metadata has proper fallbacks
   const processedMetadata = ensureWidgetMetadata(metadata, widgetName);

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/widget-openai-config.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/widget-openai-config.ts
@@ -1,0 +1,53 @@
+/**
+ * ChatGPT Apps SDK-specific widget configuration helpers.
+ */
+
+export interface WidgetOpenaiConfig {
+  /** URL opened when the user taps "Open in app" in ChatGPT fullscreen mode. */
+  openInAppUrl?: string;
+}
+
+/**
+ * Read ChatGPT-specific config from widget metadata.
+ */
+export function getWidgetOpenaiConfig(
+  metadata: Record<string, unknown> | undefined
+): WidgetOpenaiConfig | undefined {
+  if (!metadata?.openai || typeof metadata.openai !== "object") {
+    return undefined;
+  }
+
+  const openai = metadata.openai as WidgetOpenaiConfig;
+  if (
+    typeof openai.openInAppUrl !== "string" ||
+    openai.openInAppUrl.trim().length === 0
+  ) {
+    return undefined;
+  }
+
+  return { openInAppUrl: openai.openInAppUrl };
+}
+
+/**
+ * Inline script that sets `window.__mcpWidgetOpenai` and calls
+ * `window.openai.setOpenInAppUrl({ href })` when the Apps SDK is ready.
+ */
+export function buildOpenInAppUrlInjectionScript(openInAppUrl: string): string {
+  const configJson = JSON.stringify({ openInAppUrl });
+  return `<script>(function(){var c=${configJson};window.__mcpWidgetOpenai=c;var href=c.openInAppUrl;if(!href)return;function apply(){if(window.openai&&typeof window.openai.setOpenInAppUrl==="function"){window.openai.setOpenInAppUrl({href:href}).catch(function(err){console.error("[mcp-use] setOpenInAppUrl failed:",err);});return true;}return false;}if(!apply()){window.addEventListener("openai:set_globals",function(){apply();});}})();</script>`;
+}
+
+/**
+ * Inject ChatGPT open-in-app configuration into widget HTML.
+ */
+export function injectWidgetOpenaiConfig(
+  html: string,
+  openInAppUrl: string | undefined
+): string {
+  if (!openInAppUrl || html.includes("window.__mcpWidgetOpenai")) {
+    return html;
+  }
+
+  const script = buildOpenInAppUrlInjectionScript(openInAppUrl);
+  return html.replace(/<head[^>]*>/i, (match) => `${match}\n    ${script}`);
+}

--- a/libraries/typescript/packages/mcp-use/tests/unit/react/apply-open-in-app-url.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/react/apply-open-in-app-url.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SET_GLOBALS_EVENT_TYPE } from "../../../src/react/widget-types.js";
+import { applyOpenInAppUrlFromConfig } from "../../../src/react/apply-open-in-app-url.js";
+
+describe("applyOpenInAppUrlFromConfig", () => {
+  beforeEach(() => {
+    (global as any).window = {
+      __mcpWidgetOpenai: undefined,
+      openai: undefined,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    };
+  });
+
+  afterEach(() => {
+    delete (global as any).window;
+  });
+
+  it("calls window.openai.setOpenInAppUrl when config and API are available", () => {
+    const setOpenInAppUrl = vi.fn().mockResolvedValue(undefined);
+    (global as any).window.__mcpWidgetOpenai = {
+      openInAppUrl: "https://example.com/app",
+    };
+    (global as any).window.openai = { setOpenInAppUrl };
+
+    applyOpenInAppUrlFromConfig();
+
+    expect(setOpenInAppUrl).toHaveBeenCalledWith({
+      href: "https://example.com/app",
+    });
+    expect((global as any).window.addEventListener).not.toHaveBeenCalled();
+  });
+
+  it("waits for openai:set_globals when setOpenInAppUrl is not ready yet", () => {
+    (global as any).window.__mcpWidgetOpenai = {
+      openInAppUrl: "https://example.com/app",
+    };
+
+    applyOpenInAppUrlFromConfig();
+
+    expect((global as any).window.addEventListener).toHaveBeenCalledWith(
+      SET_GLOBALS_EVENT_TYPE,
+      expect.any(Function)
+    );
+  });
+
+  it("does nothing when openInAppUrl is not configured", () => {
+    const cleanup = applyOpenInAppUrlFromConfig();
+    expect(cleanup).toEqual(expect.any(Function));
+    expect((global as any).window.addEventListener).not.toHaveBeenCalled();
+  });
+});

--- a/libraries/typescript/packages/mcp-use/tests/unit/server/widget-openai-config.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/server/widget-openai-config.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildOpenInAppUrlInjectionScript,
+  getWidgetOpenaiConfig,
+  injectWidgetOpenaiConfig,
+} from "../../../src/server/widgets/widget-openai-config.js";
+
+describe("widget openai config", () => {
+  it("reads openInAppUrl from widget metadata", () => {
+    expect(
+      getWidgetOpenaiConfig({
+        openai: { openInAppUrl: "https://example.com/app" },
+      })
+    ).toEqual({ openInAppUrl: "https://example.com/app" });
+  });
+
+  it("returns undefined when openInAppUrl is missing or blank", () => {
+    expect(getWidgetOpenaiConfig({ openai: {} })).toBeUndefined();
+    expect(
+      getWidgetOpenaiConfig({ openai: { openInAppUrl: "   " } })
+    ).toBeUndefined();
+    expect(getWidgetOpenaiConfig({})).toBeUndefined();
+  });
+
+  it("injects openInAppUrl script into widget HTML", () => {
+    const html = "<html><head></head><body></body></html>";
+    const result = injectWidgetOpenaiConfig(
+      html,
+      "https://example.com/products/123"
+    );
+
+    expect(result).toContain("window.__mcpWidgetOpenai");
+    expect(result).toContain("setOpenInAppUrl");
+    expect(result).toContain("https://example.com/products/123");
+  });
+
+  it("does not inject duplicate openInAppUrl scripts", () => {
+    const html = injectWidgetOpenaiConfig(
+      "<html><head></head><body></body></html>",
+      "https://example.com/app"
+    );
+
+    expect(
+      injectWidgetOpenaiConfig(html, "https://example.com/app")
+    ).toBe(html);
+  });
+
+  it("builds a script that sets window.__mcpWidgetOpenai", () => {
+    const script = buildOpenInAppUrlInjectionScript("https://chatgpt.com/app");
+    expect(script).toContain('openInAppUrl":"https://chatgpt.com/app"');
+    expect(script.startsWith("<script>")).toBe(true);
+    expect(script.endsWith("</script>")).toBe(true);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changes

Adds a ChatGPT-specific `openai` namespace on `widgetMetadata` with an `openInAppUrl` field. When set, mcp-use configures ChatGPT's fullscreen **Open in app** button by calling `window.openai.setOpenInAppUrl({ href })`.

## Implementation Details

1. Extended `WidgetMetadata` with `openai?: { openInAppUrl?: string }` (ChatGPT-only; ignored by MCP Apps clients).
2. Added server helpers to read the config and inject a small HTML bootstrap script into widget pages during dev registration, HMR updates, and CLI production builds.
3. Added `applyOpenInAppUrlFromConfig()` and wired it into `McpUseProvider` so widgets using the provider also apply the URL once `window.openai` is ready.
4. Extended Apps SDK typings with `setOpenInAppUrl` and added an inspector mock for local debugging.
5. Documented the field in `docs/typescript/server/mcp-apps.mdx`.

## Example Usage (Before)

```tsx
export const widgetMetadata: WidgetMetadata = {
  description: "Product detail view",
  props: propSchema,
};
// ChatGPT used the default iframe path for "Open in app"
```

## Example Usage (After)

```tsx
export const widgetMetadata: WidgetMetadata = {
  description: "Product detail view",
  props: propSchema,
  openai: {
    openInAppUrl: "https://example.com/products/detail",
  },
};
```

## Documentation Updates

- `docs/typescript/server/mcp-apps.mdx` — new **ChatGPT-only widget metadata (`openai`)** section documenting `openai.openInAppUrl`.

## Testing

- Added unit tests for config parsing, HTML injection, and runtime application.
- Ran `pnpm --filter mcp-use test:unit` (557 tests passed).

## Backwards Compatibility

Fully backwards compatible. The `openai` field is optional and has no effect when omitted or when running in non-ChatGPT hosts.

## Related Issues

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c685828-e7cf-4aa2-9100-6b52a21c26a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c685828-e7cf-4aa2-9100-6b52a21c26a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

