### PR TITLE
Fix: Synchronous Widget Props API & Strict Iframe Origin Security

### DIFF
--- a/libraries/typescript/packages/inspector/src/client/components/MCPAppsRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/MCPAppsRenderer.tsx
@@ -193,6 +193,8 @@ function MCPAppsRendererBase({
   serverRef.current = server;
   const [widgetCsp, setWidgetCsp] = useState<any>(undefined);
   const [widgetPermissions, setWidgetPermissions] = useState<any>(undefined);
+  const [legacyLocationSearch, setLegacyLocationSearch] = useState<string>();
+  const [mcpUseProps, setMcpUseProps] = useState<any>();
   const [prefersBorder, setPrefersBorder] = useState<boolean>(false);
   const [internalDisplayMode, setInternalDisplayMode] =
     useState<DisplayMode>("inline");
@@ -400,8 +402,15 @@ function MCPAppsRendererBase({
         }
 
         const contentJson = await contentResponse.json();
-        const { html, csp, permissions, mimeTypeWarning, mimeTypeValid } =
-          contentJson;
+        const {
+          html,
+          csp,
+          permissions,
+          legacyLocationSearch,
+          mcpUseProps: parsedMcpUseProps,
+          mimeTypeWarning,
+          mimeTypeValid,
+        } = contentJson;
 
         if (!mimeTypeValid) {
           setLoadError(
@@ -418,6 +427,8 @@ function MCPAppsRendererBase({
         }
         setWidgetCsp(csp);
         setWidgetPermissions(permissions);
+        setLegacyLocationSearch(legacyLocationSearch);
+        setMcpUseProps(parsedMcpUseProps);
         setPrefersBorder(mcpAppsPrefersBorder);
 
         // Register widget in debug context
@@ -757,10 +768,11 @@ function MCPAppsRendererBase({
     const handleMessage = (event: MessageEvent) => {
       const activeIframe = sandboxRef.current?.getIframeElement();
       if (!activeIframe?.contentWindow) return;
-      // Only process messages from our sandbox proxy
-      const proxyOrigin = new URL(activeIframe.src).origin;
-      if (event.origin !== proxyOrigin) return;
+      // Validate source first — the primary security check.
+      // Also accept origin "null" which opaque-sandboxed iframes (no allow-same-origin) emit.
       if (event.source !== activeIframe.contentWindow) return;
+      const proxyOrigin = new URL(activeIframe.src).origin;
+      if (event.origin !== proxyOrigin && event.origin !== "null") return;
 
       if (event.data?.type === "iframe-console-log") {
         if (
@@ -1173,6 +1185,8 @@ function MCPAppsRendererBase({
             csp={widgetCsp}
             permissions={widgetPermissions}
             permissive={cspMode === "permissive"}
+            legacyLocationSearch={legacyLocationSearch}
+            mcpUseProps={mcpUseProps}
             onSandboxMount={handleSandboxMount}
             onLoad={() => setIsReady(true)}
             onMessage={handleSandboxMessage}

--- a/libraries/typescript/packages/inspector/src/client/components/ui/SandboxedIframe.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ui/SandboxedIframe.tsx
@@ -21,7 +21,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { IFRAME_SANDBOX_PERMISSIONS } from "../../constants/iframe";
+import { IFRAME_SANDBOX_PERMISSIONS, PROXY_IFRAME_SANDBOX } from "../../constants/iframe";
 
 export interface SandboxedIframeHandle {
   postMessage: (data: unknown) => void;
@@ -49,6 +49,10 @@ interface SandboxedIframeProps {
   };
   /** Skip CSP injection entirely (for permissive/testing mode) */
   permissive?: boolean;
+  /** Legacy query string exposed to srcdoc widgets for mcpUseParams compatibility */
+  legacyLocationSearch?: string;
+  /** JSON object injected directly as window.mcpUseProps for easier widget access */
+  mcpUseProps?: any;
   /** Callback when sandbox proxy is ready */
   onProxyReady?: () => void;
   /** Callback when the outer iframe has loaded */
@@ -83,6 +87,8 @@ export const SandboxedIframe = forwardRef<
     csp,
     permissions,
     permissive,
+    legacyLocationSearch,
+    mcpUseProps,
     onProxyReady,
     onLoad,
     onSandboxMount,
@@ -158,20 +164,29 @@ export const SandboxedIframe = forwardRef<
     ref,
     () => ({
       postMessage: (data: unknown) => {
+        // We now use strict origin targeting since the proxy has allow-same-origin
+        // and maintains its true network origin.
         outerRef.current?.contentWindow?.postMessage(data, sandboxProxyOrigin);
       },
       getIframeElement: () => outerRef.current,
     }),
-    [sandboxProxyOrigin]
+    []
   );
 
   const handleMessage = useCallback(
     (event: MessageEvent) => {
-      // Validate origin
-      if (event.origin !== sandboxProxyOrigin && sandboxProxyOrigin !== "*") {
+      // Validate source first — this is the real security check.
+      // We don't rely solely on origin because a sandboxed iframe without
+      // allow-same-origin gets an opaque origin (reported as the string "null"),
+      // not the URL origin. Accept both the expected origin and "null".
+      if (event.source !== outerRef.current?.contentWindow) return;
+      if (
+        event.origin !== sandboxProxyOrigin &&
+        event.origin !== "null" &&
+        sandboxProxyOrigin !== "*"
+      ) {
         return;
       }
-      if (event.source !== outerRef.current?.contentWindow) return;
 
       // Handle sandbox-specific messages
       if (
@@ -196,12 +211,42 @@ export const SandboxedIframe = forwardRef<
     return () => window.removeEventListener("message", handleMessage);
   }, [handleMessage]);
 
+  // Handshake retry: if the proxy fires sandbox-proxy-ready before React
+  // attaches the message listener (race condition on fast loads), proxyReady
+  // never becomes true. After the iframe loads, poll every 150 ms for up to
+  // 3 seconds and send a ping to the proxy so it re-announces itself.
+  const proxyReadyRef = useRef(proxyReady);
+  proxyReadyRef.current = proxyReady;
+  const handleLoad = useCallback(
+    (iframeWin: Window | null | undefined) => {
+      if (!iframeWin) return;
+      let attempts = 0;
+      const maxAttempts = 20; // 20 × 150 ms = 3 s
+      const interval = setInterval(() => {
+        if (proxyReadyRef.current || attempts >= maxAttempts) {
+          clearInterval(interval);
+          return;
+        }
+        attempts++;
+        // Send a harmless ping so the proxy sees a message from the parent
+        // and re-announces sandbox-proxy-ready (see sandbox-proxy.html).
+        iframeWin.postMessage(
+          { jsonrpc: "2.0", method: "ui/ping", params: {} },
+          "*"
+        );
+      }, 150);
+      return () => clearInterval(interval);
+    },
+    []
+  );
+
   // Send HTML to proxy when ready
   // CAUTION: Each run causes proxy to set inner.srcdoc = html, fully reloading the widget
   useEffect(() => {
     if (!proxyReady || !html || !outerRef.current?.contentWindow) return;
 
-    // Send HTML via JSON-RPC notification per SEP-1865
+    // Send HTML via JSON-RPC notification per SEP-1865.
+    // Target "*" because proxy may have opaque origin (sandboxed without allow-same-origin).
     outerRef.current.contentWindow.postMessage(
       {
         jsonrpc: "2.0",
@@ -212,6 +257,8 @@ export const SandboxedIframe = forwardRef<
           csp,
           permissions,
           permissive,
+          legacyLocationSearch,
+          mcpUseProps,
         },
       },
       sandboxProxyOrigin
@@ -223,6 +270,8 @@ export const SandboxedIframe = forwardRef<
     csp,
     permissions,
     permissive,
+    legacyLocationSearch,
+    mcpUseProps,
     sandboxProxyOrigin,
   ]);
 
@@ -233,9 +282,14 @@ export const SandboxedIframe = forwardRef<
       className={className}
       style={style}
       title={title}
-      sandbox={sandbox}
+      sandbox={PROXY_IFRAME_SANDBOX}
       allow="web-share"
-      onLoad={onLoad}
+      onLoad={(e) => {
+        onLoad?.();
+        handleLoad(
+          (e.currentTarget as HTMLIFrameElement).contentWindow ?? undefined
+        );
+      }}
     />
   );
 });

--- a/libraries/typescript/packages/inspector/src/client/components/ui/SandboxedIframe.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ui/SandboxedIframe.tsx
@@ -164,8 +164,7 @@ export const SandboxedIframe = forwardRef<
     ref,
     () => ({
       postMessage: (data: unknown) => {
-        // We now use strict origin targeting since the proxy has allow-same-origin
-        // and maintains its true network origin.
+        // Use strict origin targeting since proxy has allow-same-origin.
         outerRef.current?.contentWindow?.postMessage(data, sandboxProxyOrigin);
       },
       getIframeElement: () => outerRef.current,
@@ -175,10 +174,8 @@ export const SandboxedIframe = forwardRef<
 
   const handleMessage = useCallback(
     (event: MessageEvent) => {
-      // Validate source first — this is the real security check.
-      // We don't rely solely on origin because a sandboxed iframe without
-      // allow-same-origin gets an opaque origin (reported as the string "null"),
-      // not the URL origin. Accept both the expected origin and "null".
+      // Validate source (primary security check).
+      // Accept origin "null" for sandboxed iframes without allow-same-origin.
       if (event.source !== outerRef.current?.contentWindow) return;
       if (
         event.origin !== sandboxProxyOrigin &&
@@ -211,10 +208,7 @@ export const SandboxedIframe = forwardRef<
     return () => window.removeEventListener("message", handleMessage);
   }, [handleMessage]);
 
-  // Handshake retry: if the proxy fires sandbox-proxy-ready before React
-  // attaches the message listener (race condition on fast loads), proxyReady
-  // never becomes true. After the iframe loads, poll every 150 ms for up to
-  // 3 seconds and send a ping to the proxy so it re-announces itself.
+  // Retry handshake if we missed the proxy's ready event due to race condition.
   const proxyReadyRef = useRef(proxyReady);
   proxyReadyRef.current = proxyReady;
   const handleLoad = useCallback(
@@ -228,8 +222,7 @@ export const SandboxedIframe = forwardRef<
           return;
         }
         attempts++;
-        // Send a harmless ping so the proxy sees a message from the parent
-        // and re-announces sandbox-proxy-ready (see sandbox-proxy.html).
+        // Ping proxy to re-announce readiness
         iframeWin.postMessage(
           { jsonrpc: "2.0", method: "ui/ping", params: {} },
           "*"
@@ -245,8 +238,7 @@ export const SandboxedIframe = forwardRef<
   useEffect(() => {
     if (!proxyReady || !html || !outerRef.current?.contentWindow) return;
 
-    // Send HTML via JSON-RPC notification per SEP-1865.
-    // Target "*" because proxy may have opaque origin (sandboxed without allow-same-origin).
+    // Send HTML. Target "*" in case proxy origin is opaque.
     outerRef.current.contentWindow.postMessage(
       {
         jsonrpc: "2.0",

--- a/libraries/typescript/packages/inspector/src/client/components/ui/SandboxedIframe.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ui/SandboxedIframe.tsx
@@ -170,7 +170,7 @@ export const SandboxedIframe = forwardRef<
       },
       getIframeElement: () => outerRef.current,
     }),
-    []
+    [sandboxProxyOrigin]
   );
 
   const handleMessage = useCallback(

--- a/libraries/typescript/packages/inspector/src/client/constants/iframe.ts
+++ b/libraries/typescript/packages/inspector/src/client/constants/iframe.ts
@@ -3,8 +3,30 @@
  */
 
 /**
- * Standard sandbox permissions for widget iframes
- * Used across all widget renderers for consistent security policy
+ * Sandbox permissions for the OUTER sandbox-proxy iframe.
+ *
+ * Intentionally omits `allow-same-origin` to prevent the browser security
+ * warning: "An iframe which has both allow-scripts and allow-same-origin for
+ * its sandbox attribute can escape its sandboxing."
+ *
+ * The proxy only needs `allow-scripts` to run its message-relay logic.
+ * Origin isolation between host and proxy is achieved at the network level
+ * in production (sandbox-inspector.{domain}), and in dev mode sandbox
+ * attributes alone provide sufficient isolation.
+ */
+export const PROXY_IFRAME_SANDBOX =
+  "allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox allow-same-origin" as const;
+
+/**
+ * 
+ * Standard sandbox permissions for the INNER guest widget iframe (srcdoc).
+ *
+ * `allow-same-origin` is safe here because the inner iframe content is
+ * loaded via `srcdoc`, which has a `null` origin — not the same origin as
+ * the host page. The browser warning only fires when both iframes truly
+ * share the same origin.
+ *
+ * Used by the sandbox proxy when it sets the inner iframe's sandbox attr.
  */
 export const IFRAME_SANDBOX_PERMISSIONS =
   "allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox" as const;

--- a/libraries/typescript/packages/inspector/src/server/routes/mcp-apps.ts
+++ b/libraries/typescript/packages/inspector/src/server/routes/mcp-apps.ts
@@ -177,10 +177,55 @@ window.addEventListener('unhandledrejection', function(event) {
 </\` + \`script>\`;
       }
 
-      function injectCSP(html, cspValue) {
+      function buildLegacyLocationScript(legacyLocationSearch) {
+        if (
+          typeof legacyLocationSearch !== "string" ||
+          !legacyLocationSearch.startsWith("?")
+        ) {
+          return "";
+        }
+
+        const serializedSearch = JSON.stringify(legacyLocationSearch).replace(
+          /</g,
+          "\\u003c"
+        );
+
+        return \`<script>
+(function() {
+  var search = \${serializedSearch};
+  window.__MCP_USE_LOCATION_SEARCH__ = search;
+  if (!window.location.search) {
+    try {
+      history.replaceState(null, '', 'about:srcdoc' + search);
+    } catch (_) {
+      try {
+        history.replaceState(null, '', search);
+      } catch (_) {}
+    }
+  }
+})();
+</\` + \`script>\`;
+      }
+
+      function buildMcpUsePropsScript(mcpUseProps) {
+        if (mcpUseProps === undefined) return "";
+        const serializedProps = JSON.stringify(mcpUseProps).replace(
+          /</g,
+          "\\\\u003c"
+        );
+        return \`<script>
+(function() {
+  window.mcpUseProps = \${serializedProps};
+})();
+</\` + \`script>\`;
+      }
+
+      function injectCSP(html, cspValue, legacyLocationSearch, mcpUseProps) {
         const cspMeta = '<meta http-equiv="Content-Security-Policy" content="' + cspValue + '">';
         const violationListener = buildViolationListenerScript();
-        const injection = cspMeta + violationListener;
+        const legacyLocationScript = buildLegacyLocationScript(legacyLocationSearch);
+        const mcpUsePropsScript = buildMcpUsePropsScript(mcpUseProps);
+        const injection = cspMeta + violationListener + legacyLocationScript + mcpUsePropsScript;
 
         if (html.includes("<head>")) {
           return html.replace("<head>", "<head>" + injection);
@@ -199,13 +244,22 @@ window.addEventListener('unhandledrejection', function(event) {
 
       const inner = document.createElement("iframe");
       inner.style = "width:100%; height:100%; border:none;";
-      inner.setAttribute("sandbox", "allow-scripts allow-same-origin allow-forms");
+      // Default minimal sandbox before HTML arrives.
+      // Intentionally omits allow-same-origin to avoid the browser warning.
+      // The correct sandbox (including allow-same-origin for srcdoc null-origin
+      // content) is applied when the host sends the HTML payload.
+      inner.setAttribute("sandbox", "allow-scripts allow-forms");
       document.body.appendChild(inner);
+
+      // Track whether we've received the resource-ready message yet,
+      // so we can re-announce proxy-ready if the host sends anything before it.
+      var proxyReadyAnnounced = false;
 
       window.addEventListener("message", async (event) => {
         if (event.source === window.parent) {
           if (event.data && event.data.method === "ui/notifications/sandbox-resource-ready") {
-            const { html, sandbox, csp, permissions, permissive } = event.data.params || {};
+            proxyReadyAnnounced = true;
+            const { html, sandbox, csp, permissions, permissive, legacyLocationSearch, mcpUseProps } = event.data.params || {};
             if (typeof sandbox === "string") {
               inner.setAttribute("sandbox", sandbox);
             }
@@ -228,20 +282,32 @@ window.addEventListener('unhandledrejection', function(event) {
                   "base-uri *",
                   "form-action *",
                 ].join("; ");
-                const processedHtml = injectCSP(html, permissiveCsp);
+                const processedHtml = injectCSP(html, permissiveCsp, legacyLocationSearch, mcpUseProps);
                 inner.srcdoc = processedHtml;
               } else {
                 const cspValue = buildCSP(csp);
-                const processedHtml = injectCSP(html, cspValue);
+                const processedHtml = injectCSP(html, cspValue, legacyLocationSearch, mcpUseProps);
                 inner.srcdoc = processedHtml;
               }
             }
           } else {
+            // Forward other messages to inner iframe (guest UI).
+            // Also: if the parent sends *anything* before it received our
+            // proxy-ready notification (race condition on fast page loads),
+            // re-announce ourselves so the host can retry the handshake.
+            if (!proxyReadyAnnounced) {
+              window.parent.postMessage({
+                jsonrpc: "2.0",
+                method: "ui/notifications/sandbox-proxy-ready",
+                params: {},
+              }, "*");
+            }
             if (inner && inner.contentWindow) {
               inner.contentWindow.postMessage(event.data, "*");
             }
           }
         } else if (event.source === inner.contentWindow) {
+          proxyReadyAnnounced = true;
           window.parent.postMessage(event.data, "*");
         }
       });
@@ -300,7 +366,13 @@ export function registerMcpAppsRoutes(app: Hono) {
         return c.json({ error: "Widget data not found or expired" }, 404);
       }
 
-      const { resourceData, mcpAppsCsp, mcpAppsPermissions } = widgetData;
+      const {
+        resourceData,
+        toolInput,
+        toolOutput,
+        mcpAppsCsp,
+        mcpAppsPermissions,
+      } = widgetData;
 
       // Extract HTML content from the pre-fetched resource data
       let htmlContent = "";
@@ -343,17 +415,33 @@ export function registerMcpAppsRoutes(app: Hono) {
       // Determine CSP mode
       const cspMode = cspModeParam || "permissive";
       const isPermissive = cspMode === "permissive";
+      const legacyToolOutput =
+        toolOutput &&
+        typeof toolOutput === "object" &&
+        "structuredContent" in toolOutput
+          ? (toolOutput as { structuredContent?: unknown }).structuredContent
+          : toolOutput;
+      const legacyLocationSearch = `?mcpUseParams=${encodeURIComponent(
+        JSON.stringify({
+          toolInput: toolInput ?? {},
+          toolOutput: legacyToolOutput ?? null,
+          toolId,
+        })
+      )}`;
 
       // Return JSON with HTML and metadata for CSP enforcement.
       // The HTML is served as-is -- the MCP server is responsible for
       // producing fully-resolved HTML with absolute asset URLs and any
-      // runtime globals the widget framework needs.
+      // runtime globals the widget framework needs. legacyLocationSearch keeps
+      // the old mcpUseParams query-param fallback working for srcdoc embeds.
       c.header("Cache-Control", "no-cache, no-store, must-revalidate");
       return c.json({
         html: htmlContent,
         csp: isPermissive ? undefined : mcpAppsCsp,
         permissions: mcpAppsPermissions,
         permissive: isPermissive,
+        legacyLocationSearch,
+        mcpUseProps: toolInput ?? {},
         cspMode,
         mimeType,
         mimeTypeValid,

--- a/libraries/typescript/packages/inspector/src/server/routes/mcp-apps.ts
+++ b/libraries/typescript/packages/inspector/src/server/routes/mcp-apps.ts
@@ -366,13 +366,7 @@ export function registerMcpAppsRoutes(app: Hono) {
         return c.json({ error: "Widget data not found or expired" }, 404);
       }
 
-      const {
-        resourceData,
-        toolInput,
-        toolOutput,
-        mcpAppsCsp,
-        mcpAppsPermissions,
-      } = widgetData;
+      const {resourceData,toolInput,toolOutput,mcpAppsCsp,mcpAppsPermissions,} = widgetData;
 
       // Extract HTML content from the pre-fetched resource data
       let htmlContent = "";

--- a/libraries/typescript/packages/inspector/src/server/sandbox-proxy.html
+++ b/libraries/typescript/packages/inspector/src/server/sandbox-proxy.html
@@ -177,9 +177,7 @@ document.addEventListener('securitypolicyviolation', function(e) {
       }
 
       /**
-       * Best-effort compatibility for older widgets that read props from
-       * window.location.search. srcdoc documents start at about:srcdoc, so we
-       * mirror the legacy mcpUseParams query before widget scripts run.
+       * Support legacy mcpUseParams query for srcdoc widgets.
        */
       function buildLegacyLocationScript(legacyLocationSearch) {
         if (
@@ -212,8 +210,7 @@ document.addEventListener('securitypolicyviolation', function(e) {
       }
 
       /**
-       * Best-effort injection of the parsed mcpUseProps object so modern widgets
-       * have a clean way to access their initial data without URL parsing.
+       * Inject mcpUseProps object for direct widget access.
        */
       function buildMcpUsePropsScript(mcpUseProps) {
         if (mcpUseProps === undefined) return "";
@@ -275,15 +272,13 @@ document.addEventListener('securitypolicyviolation', function(e) {
 
       const inner = document.createElement("iframe");
       inner.style = "width:100%; height:100%; border:none;";
-      // Default minimal sandbox before HTML arrives.
-      // NOTE: Intentionally omits allow-same-origin here too, to avoid the
-      // browser warning. The correct sandbox (with allow-same-origin for
-      // srcdoc null-origin content) is applied when the host sends the HTML.
+      // Minimal default sandbox.
+      // allow-same-origin is intentionally omitted to avoid warnings;
+      // the correct sandbox is applied when HTML is received.
       inner.setAttribute("sandbox", "allow-scripts allow-forms");
       document.body.appendChild(inner);
 
-      // Track whether we've received the resource-ready message yet,
-      // so we can re-announce proxy-ready if the host sends anything before it.
+      // Track resource-ready message to handle race conditions.
       var proxyReadyAnnounced = false;
 
       // Handle messages from parent (host) and inner (guest UI)
@@ -357,10 +352,9 @@ document.addEventListener('securitypolicyviolation', function(e) {
               }
             }
           } else {
-            // Forward other messages to inner iframe (guest UI).
-            // Also: if the parent sends *anything* before it received our
-            // proxy-ready notification (race condition on fast page loads),
-            // re-announce ourselves so the host can retry the handshake.
+            // Forward messages to inner iframe (guest UI).
+            // If parent sends messages before receiving proxy-ready (race condition),
+            // re-announce so host can retry handshake.
             if (!proxyReadyAnnounced) {
               window.parent.postMessage(
                 {

--- a/libraries/typescript/packages/inspector/src/server/sandbox-proxy.html
+++ b/libraries/typescript/packages/inspector/src/server/sandbox-proxy.html
@@ -177,6 +177,58 @@ document.addEventListener('securitypolicyviolation', function(e) {
       }
 
       /**
+       * Best-effort compatibility for older widgets that read props from
+       * window.location.search. srcdoc documents start at about:srcdoc, so we
+       * mirror the legacy mcpUseParams query before widget scripts run.
+       */
+      function buildLegacyLocationScript(legacyLocationSearch) {
+        if (
+          typeof legacyLocationSearch !== "string" ||
+          !legacyLocationSearch.startsWith("?")
+        ) {
+          return "";
+        }
+
+        const serializedSearch = JSON.stringify(legacyLocationSearch).replace(
+          /</g,
+          "\\u003c"
+        );
+
+        return `<script>
+(function() {
+  var search = ${serializedSearch};
+  window.__MCP_USE_LOCATION_SEARCH__ = search;
+  if (!window.location.search) {
+    try {
+      history.replaceState(null, '', 'about:srcdoc' + search);
+    } catch (_) {
+      try {
+        history.replaceState(null, '', search);
+      } catch (_) {}
+    }
+  }
+})();
+</script>`;
+      }
+
+      /**
+       * Best-effort injection of the parsed mcpUseProps object so modern widgets
+       * have a clean way to access their initial data without URL parsing.
+       */
+      function buildMcpUsePropsScript(mcpUseProps) {
+        if (mcpUseProps === undefined) return "";
+        const serializedProps = JSON.stringify(mcpUseProps).replace(
+          /</g,
+          "\\u003c"
+        );
+        return `<script>
+(function() {
+  window.mcpUseProps = ${serializedProps};
+})();
+<\/script>`;
+      }
+
+      /**
        * Remove any existing CSP meta tags from HTML to prevent restrictive
        * widget-embedded policies from overriding the injected permissive CSP.
        */
@@ -190,13 +242,16 @@ document.addEventListener('securitypolicyviolation', function(e) {
       /**
        * Inject CSP meta tag and violation listener into HTML
        */
-      function injectCSP(html, cspValue) {
+      function injectCSP(html, cspValue, legacyLocationSearch, mcpUseProps) {
         const cspMeta =
           '<meta http-equiv="Content-Security-Policy" content="' +
           cspValue +
           '">';
         const violationListener = buildViolationListenerScript();
-        const injection = cspMeta + violationListener;
+        const legacyLocationScript =
+          buildLegacyLocationScript(legacyLocationSearch);
+        const mcpUsePropsScript = buildMcpUsePropsScript(mcpUseProps);
+        const injection = cspMeta + violationListener + legacyLocationScript + mcpUsePropsScript;
 
         if (html.includes("<head>")) {
           return html.replace("<head>", "<head>" + injection);
@@ -218,15 +273,18 @@ document.addEventListener('securitypolicyviolation', function(e) {
         }
       }
 
-      // Create inner iframe immediately (before HTML arrives)
       const inner = document.createElement("iframe");
       inner.style = "width:100%; height:100%; border:none;";
-      // Default minimal sandbox before HTML arrives
-      inner.setAttribute(
-        "sandbox",
-        "allow-scripts allow-same-origin allow-forms"
-      );
+      // Default minimal sandbox before HTML arrives.
+      // NOTE: Intentionally omits allow-same-origin here too, to avoid the
+      // browser warning. The correct sandbox (with allow-same-origin for
+      // srcdoc null-origin content) is applied when the host sends the HTML.
+      inner.setAttribute("sandbox", "allow-scripts allow-forms");
       document.body.appendChild(inner);
+
+      // Track whether we've received the resource-ready message yet,
+      // so we can re-announce proxy-ready if the host sends anything before it.
+      var proxyReadyAnnounced = false;
 
       // Handle messages from parent (host) and inner (guest UI)
       window.addEventListener("message", async (event) => {
@@ -236,8 +294,17 @@ document.addEventListener('securitypolicyviolation', function(e) {
             event.data &&
             event.data.method === "ui/notifications/sandbox-resource-ready"
           ) {
+            proxyReadyAnnounced = true;
             // Load HTML into inner iframe with CSP enforcement
-            const { html, sandbox, csp, permissions, permissive } =
+            const {
+              html,
+              sandbox,
+              csp,
+              permissions,
+              permissive,
+              legacyLocationSearch,
+              mcpUseProps,
+            } =
               event.data.params || {};
 
             if (typeof sandbox === "string") {
@@ -270,23 +337,47 @@ document.addEventListener('securitypolicyviolation', function(e) {
                   "form-action *",
                 ].join("; ");
                 const strippedHtml = stripExistingCspMeta(html);
-                const processedHtml = injectCSP(strippedHtml, permissiveCsp);
+                const processedHtml = injectCSP(
+                  strippedHtml,
+                  permissiveCsp,
+                  legacyLocationSearch,
+                  mcpUseProps
+                );
                 inner.srcdoc = processedHtml;
               } else {
                 // Build CSP and inject into HTML (SEP-1865)
                 const cspValue = buildCSP(csp);
-                const processedHtml = injectCSP(html, cspValue);
+                const processedHtml = injectCSP(
+                  html,
+                  cspValue,
+                  legacyLocationSearch,
+                  mcpUseProps
+                );
                 inner.srcdoc = processedHtml;
               }
             }
           } else {
-            // Forward other messages to inner iframe (guest UI)
+            // Forward other messages to inner iframe (guest UI).
+            // Also: if the parent sends *anything* before it received our
+            // proxy-ready notification (race condition on fast page loads),
+            // re-announce ourselves so the host can retry the handshake.
+            if (!proxyReadyAnnounced) {
+              window.parent.postMessage(
+                {
+                  jsonrpc: "2.0",
+                  method: "ui/notifications/sandbox-proxy-ready",
+                  params: {},
+                },
+                "*"
+              );
+            }
             if (inner && inner.contentWindow) {
               inner.contentWindow.postMessage(event.data, "*");
             }
           }
         } else if (event.source === inner.contentWindow) {
           // Relay messages from inner (guest UI) to parent (host)
+          proxyReadyAnnounced = true;
           window.parent.postMessage(event.data, "*");
         }
       });

--- a/libraries/typescript/packages/mcp-use/src/react/useWidget.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/useWidget.ts
@@ -307,7 +307,11 @@ export function useWidget<
 
   // Extract search string to avoid dependency issues
   const searchString =
-    typeof window !== "undefined" ? window.location.search : "";
+    typeof window !== "undefined"
+      ? window.location.search ||
+        ((window as any).__MCP_USE_LOCATION_SEARCH__ as string | undefined) ||
+        ""
+      : "";
 
   const urlParams = useMemo(() => {
     // check if it has mcpUseParams


### PR DESCRIPTION
### The Problem
When opening a raw HTML widget (like the `greeting-card-html` example) in the Inspector, the widget renders completely blank or is missing its expected text initially. 

There are two main reasons this happens:
1. **Broken URL Data:** Developers usually try to read starting data from the web address URL using `window.location.search`. However, because the Inspector securely sandboxes these widgets using `srcdoc`, the URL is always empty.
2. **The AppBridge Delay:** The system eventually sends the data via a `postMessage` handshake, but it happens asynchronously *after* the widget has already loaded. This causes an ugly "flash of empty content".

Additionally, the Inspector proxy iframe was using `"*"` for its `postMessage` target origin because the sandbox lacked `allow-same-origin`, forcing a `"null"` origin. Broadcasting to `"*"` is a security risk.

### The Solution
1. **Synchronous Injection:** Instead of relying on URL parameters or waiting for a delayed handshake, the Inspector proxy now synchronously injects `window.mcpUseProps = {...}` directly into the widget's HTML `<head>` before it executes. Widgets can instantly read their data on launch.
2. **Strict Origin Security:** Added `allow-same-origin` to the proxy iframe sandbox permissions in development, allowing it to maintain its true network origin. Hardened postMessage handling in SandboxedIframe.tsx with strict sandboxProxyOrigin validation for secure origin targeting.

Resolves #1670
