### PR TITLE
fix(ci): TypeScript GitHub release mechanism

### DIFF
--- a/.github/workflows/typescript-release.yml
+++ b/.github/workflows/typescript-release.yml
@@ -352,7 +352,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -e  # Exit immediately if any command fails
-          
+
+          # Configure git identity - changesets creates annotated tags (git tag -m),
+          # which fail without user.name/user.email configured
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
           # Ensure we're on the latest commit and have all remote refs
           git fetch --tags --force
           git checkout main
@@ -368,8 +373,8 @@ jobs:
           NEW_TAGS=$(git tag --points-at HEAD)
           
           if [ -z "$NEW_TAGS" ]; then
-            echo "⚠️  No tags were created by changeset tag"
-            exit 0
+            echo "❌ No tags were created by changeset tag - packages were published to npm but tagging failed"
+            exit 1
           fi
           
           echo "📦 Tags created: $NEW_TAGS"


### PR DESCRIPTION
## Changes
Fixes the TypeScript release workflow so stable releases actually create git tags, GitHub releases, and Discord notifications — instead of silently stopping after the npm publish.

## Implementation Details
1. **Configure git identity before publishing on main** — changesets creates annotated tags (`git tag -m`), which fail without `user.name`/`user.email`. The canary path sets it in an earlier step, but the main publish path never did, so `git tag` failed silently on every stable release (changesets discards the exit code after logging `New tag:`). The identity values are the same ones the official `changesets/action` uses internally.
2. **Fail loudly when no tags are created** — the `exit 0` guard after `changeset tag` masked the failure: runs went green while tags, GitHub releases, and the Discord notification were all skipped. Now the step exits 1, since at that point packages were already published to npm and an empty `git tag --points-at HEAD` can only mean tagging failed.

npm publishing is unaffected — it happens before the tag check, and on a re-run `changeset publish` skips already-published versions.

## Evidence
Run [26977775359](https://github.com/mcp-use/mcp-use/actions/runs/26977775359) (`mcp-use@1.29.1`): packages published to npm, then `⚠️ No tags were created by changeset tag` → `No tags file found` → `No release tags found, skipping Discord notification` — all green. That's why GitHub's Latest release still points at `Python v1.7.0`.

## Testing
- Verified against the failing run logs that the only missing precondition on the main path is the git identity (canary path with identity configured works and produces releases)
- Verified `changesets/action` source uses identical `git config` values

## Backwards Compatibility
No package or API changes — CI workflow only. Note: existing published versions (1.29.1 etc.) still need a one-off backfill of tags/releases; this fix covers future releases.

## Related Issues
Closes MCP-2381