### PR TITLE
fix(python): fix resource data loss and empty-content Bedrock crash

### DIFF
--- a/libraries/python/mcp_use/agents/adapters/langchain_adapter.py
+++ b/libraries/python/mcp_use/agents/adapters/langchain_adapter.py
@@ -4,6 +4,7 @@ LangChain adapter for MCP tools.
 This module provides utilities to convert MCP tools to LangChain tools.
 """
 
+import json
 import re
 from typing import Any, NoReturn
 
@@ -35,7 +36,10 @@ LangChainContentBlock = dict[str, Any]
 LangChainToolResult = str | LangChainContentBlock | list[LangChainContentBlock]
 
 
-def _mcp_content_to_langchain(content: list[Any]) -> str | list[LangChainContentBlock]:
+def _mcp_content_to_langchain(
+    content: list[Any],
+    structured_content: dict[str, Any] | None = None,
+) -> str | list[LangChainContentBlock]:
     """Convert MCP tool result content to LangChain-compatible format.
 
     Maps MCP content types to LangChain content blocks:
@@ -45,9 +49,13 @@ def _mcp_content_to_langchain(content: list[Any]) -> str | list[LangChainContent
       - EmbeddedResource   → text or file block depending on resource type
 
     If the result is a single TextContent, returns a plain string for simplicity.
+    When content is empty, falls back to structuredContent (MCP 2025-11-25 spec)
+    serialized as JSON. Returns "(no content)" if both are absent.
     """
     if not content:
-        return ""
+        if structured_content is not None:
+            return json.dumps(structured_content)
+        return "(no content)"
 
     # Single TextContent → plain string (most common case)
     if len(content) == 1 and isinstance(content[0], TextContent):
@@ -182,7 +190,9 @@ class LangChainAdapter(BaseAdapter[BaseTool]):
                     tool_result: CallToolResult = await self.tool_connector.call_tool(self.name, kwargs)
                     converted_content: LangChainToolResult | None = None
                     try:
-                        converted_content = _mcp_content_to_langchain(tool_result.content)
+                        converted_content = _mcp_content_to_langchain(
+                            tool_result.content, tool_result.structuredContent
+                        )
                         if tool_result.isError:
                             error_message = (
                                 converted_content
@@ -233,14 +243,13 @@ class LangChainAdapter(BaseAdapter[BaseTool]):
                 logger.debug(f'Resource tool: "{self.name}" called')
                 try:
                     result = await self.tool_connector.read_resource(mcp_resource.uri)
+                    parts = []
                     for content in result.contents:
-                        # Attempt to decode bytes if necessary
                         if isinstance(content, bytes):
-                            content_decoded = content.decode()
+                            parts.append(content.decode())
                         else:
-                            content_decoded = str(content)
-
-                    return content_decoded
+                            parts.append(str(content))
+                    return "\n".join(parts)
                 except Exception as e:
                     if self.handle_tool_error:
                         return format_error(e, tool=self.name)  # Format the error to make LLM understand it

--- a/libraries/python/tests/unit/test_langchain_adapter.py
+++ b/libraries/python/tests/unit/test_langchain_adapter.py
@@ -1,5 +1,6 @@
 """Unit tests for LangChain adapter content conversion."""
 
+import json
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -9,6 +10,7 @@ from mcp.types import (
     CallToolResult,
     EmbeddedResource,
     ImageContent,
+    Resource,
     TextContent,
     TextResourceContents,
     Tool,
@@ -80,6 +82,30 @@ class TestLangChainAdapterContentConversion:
 
         assert result == "{'unexpected': 'value'}"
 
+    # --- Issue #1604: empty content + structuredContent fallback ---
+
+    def test_empty_content_with_structured_content_returns_json(self):
+        """MCP 2025-11-25 servers may return empty content[] with structuredContent.
+        The adapter must fall back to JSON-serialized structuredContent so that
+        Bedrock (and other strict LLMs) never receive an empty tool result."""
+        structured = {"success": True, "data": {"count": 3}}
+        result = _mcp_content_to_langchain([], structured_content=structured)
+
+        assert result == json.dumps(structured)
+
+    def test_empty_content_without_structured_content_returns_placeholder(self):
+        """When both content and structuredContent are absent, a non-empty
+        placeholder string must be returned to avoid Bedrock ValidationException."""
+        result = _mcp_content_to_langchain([])
+
+        assert result == "(no content)"
+
+    def test_empty_content_structured_content_none_returns_placeholder(self):
+        """Explicit None for structured_content still yields the placeholder."""
+        result = _mcp_content_to_langchain([], structured_content=None)
+
+        assert result == "(no content)"
+
 
 class TestLangChainAdapterToolExecution:
     """Tests for LangChain tool execution behavior."""
@@ -112,3 +138,65 @@ class TestLangChainAdapterToolExecution:
         assert result["details"] == "tool failed"
         assert result["tool"] == "failing_tool"
         assert result["tool_content"] == "tool failed"
+
+
+class TestLangChainAdapterResourceTool:
+    """Tests for _convert_resource fixes (issue #1625)."""
+
+    @pytest.mark.asyncio
+    async def test_resource_tool_concatenates_multiple_content_blocks(self):
+        """All content blocks must be joined; the old code silently dropped all
+        but the last block, causing data loss for multi-page resources."""
+        adapter = LangChainAdapter()
+        connector = MagicMock()
+
+        read_result = MagicMock()
+        read_result.contents = [
+            TextResourceContents(uri="file:///f", text="page 1"),
+            TextResourceContents(uri="file:///f", text="page 2"),
+            TextResourceContents(uri="file:///f", text="page 3"),
+        ]
+        connector.read_resource = AsyncMock(return_value=read_result)
+
+        mcp_resource = Resource(uri="file:///f", name="multi_page")
+        tool = adapter._convert_resource(mcp_resource, connector)
+        result = await tool._arun()
+
+        # All three blocks must be present, joined by newlines
+        assert "page 1" in result
+        assert "page 2" in result
+        assert "page 3" in result
+
+    @pytest.mark.asyncio
+    async def test_resource_tool_returns_empty_string_for_empty_contents(self):
+        """An empty contents list must return '' without raising UnboundLocalError.
+        The old code crashed because content_decoded was never assigned."""
+        adapter = LangChainAdapter()
+        connector = MagicMock()
+
+        read_result = MagicMock()
+        read_result.contents = []
+        connector.read_resource = AsyncMock(return_value=read_result)
+
+        mcp_resource = Resource(uri="file:///empty", name="empty_resource")
+        tool = adapter._convert_resource(mcp_resource, connector)
+        result = await tool._arun()
+
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_resource_tool_decodes_bytes_content(self):
+        """Bytes content blocks must be decoded to strings before joining."""
+        adapter = LangChainAdapter()
+        connector = MagicMock()
+
+        read_result = MagicMock()
+        read_result.contents = [b"hello", b" world"]
+        connector.read_resource = AsyncMock(return_value=read_result)
+
+        mcp_resource = Resource(uri="file:///bytes", name="bytes_resource")
+        tool = adapter._convert_resource(mcp_resource, connector)
+        result = await tool._arun()
+
+        assert "hello" in result
+        assert "world" in result


### PR DESCRIPTION
# Pull Request Description 

## Language / Project Scope

- [ ] TypeScript
- [x] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

Two related bugs in langchain_adapter.py that both cause AWS Bedrock ValidationException errors.

## Review Readiness

- [x] The PR is scoped to one issue or one clearly related change
- [x] The PR description explains the user-visible problem and the fix
- [x] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [x] I verified the affected package/docs path with the commands listed below
- [x] I checked for existing open PRs that already solve the same issue

## Implementation Details

Problem 1 — Issue #1625: _convert_resource._arun silently drops content blocks

The loop assigned content_decoded on every iteration, overwriting the previous value. A resource returning ["page 1", "page 2", "page 3"] silently returned only "page 3". On an empty result.contents, the variable was never assigned, causing UnboundLocalError.

Problem 2 — Issue #1604: _mcp_content_to_langchain returns "" for empty content

MCP 2025-11-25 servers place response data in structuredContent rather than content[]. The function returned "", which Bedrock rejects as a missing tool_result block: ValidationException: tool_use ids found without tool_result blocks immediately after.

---

## Python Checklist

- [x] Code formatted with ruff format
- [x] Linting passes with ruff check
- [x] Added or updated tests if needed
- [ ] Updated documentation if needed

---

## Example Usage (Before)

**Issue #1625 — data loss and crash:**

```python
# multi-block resource: overwrites every iteration, only last block returned
for content in result.contents:
    content_decoded = str(content)
return content_decoded  # UnboundLocalError when result.contents is empty
```

**Issue #1604 — Bedrock rejects empty tool result:**

```python
if not content:
    return ""  # Bedrock rejects ToolMessage with content=""
```

## Example Usage (After)

**Issue #1625 — all blocks accumulated and joined:**

```python
parts = []
for content in result.contents:
    parts.append(content.decode() if isinstance(content, bytes) else str(content))
return "\n".join(parts)  # "" for empty, full joined string for multi-block
```

**Issue #1604 — falls back to structuredContent, then placeholder:**

```python
if not content:
    if structured_content is not None:
        return json.dumps(structured_content)  # MCP 2025-11-25 spec
    return "(no content)"  # safe non-empty placeholder
```

## Testing

- pytest tests/unit/test_langchain_adapter.py — all 10 tests pass
- 3 new tests for _convert_resource: multi-block concatenation, empty contents (no crash), bytes decoding
- 3 new tests for _mcp_content_to_langchain: structuredContent fallback, no-content placeholder, explicit None

## Backwards Compatibility

_mcp_content_to_langchain gains one optional parameter defaulting to None, fully backwards compatible. The empty-content return value changes from "" to "(no content)". An empty string was already broken for Bedrock, so no working use case is affected.

## Related Issues

Closes #1604
Closes #1625
