### PR TITLE
fix(python): preserve rich MCP tool content in BaseAdapter.parse_result

### DIFF
--- a/libraries/python/mcp_use/agents/adapters/base.py
+++ b/libraries/python/mcp_use/agents/adapters/base.py
@@ -7,7 +7,17 @@ This module provides the abstract base class that all MCP tool adapters should i
 from abc import ABC, abstractmethod
 from typing import Any, Generic, TypeVar
 
-from mcp.types import Prompt, Resource, Tool
+from mcp.types import (
+    AudioContent,
+    BlobResourceContents,
+    EmbeddedResource,
+    ImageContent,
+    Prompt,
+    Resource,
+    TextContent,
+    TextResourceContents,
+    Tool,
+)
 
 from mcp_use.client.client import MCPClient
 from mcp_use.client.connectors.base import BaseConnector
@@ -17,6 +27,63 @@ from mcp_use.telemetry.utils import track_adapter_usage
 
 # Generic type for the tools created by the adapter
 T = TypeVar("T")
+
+
+def _mcp_content_to_text(content: Any) -> str:
+    """Convert MCP tool result content into a readable string without flattening structure.
+
+    The MCP ``CallToolResult.content`` field is a list of typed content blocks. Calling
+    ``str()`` on that list produces a low-quality Python ``repr`` (and, for images/audio,
+    dumps large base64 payloads into the model context). This helper preserves the
+    meaningful information from each block instead:
+
+      - TextContent      → the text itself
+      - ImageContent     → ``[image: <mime_type>]`` placeholder (base64 data is omitted)
+      - AudioContent     → ``[audio: <mime_type>]`` placeholder (base64 data is omitted)
+      - EmbeddedResource → the resource text, or a ``[resource: ...]`` placeholder for blobs
+
+    Args:
+        content: The ``content`` attribute of a ``CallToolResult`` (typically a list of
+            content blocks), or any value that should be rendered as text.
+
+    Returns:
+        A readable string representation of the content. Multiple blocks are joined with
+        newlines; a single text block is returned as a plain string.
+    """
+    # Defensive: non-list payloads (or already-string content) fall back to str().
+    if not isinstance(content, list):
+        return str(content)
+
+    if not content:
+        return ""
+
+    # Single text block → plain string (the most common case).
+    if len(content) == 1 and isinstance(content[0], TextContent):
+        return content[0].text
+
+    parts: list[str] = []
+    for item in content:
+        match item:
+            case TextContent():
+                parts.append(item.text)
+            case ImageContent():
+                parts.append(f"[image: {item.mimeType}]")
+            case AudioContent():
+                parts.append(f"[audio: {item.mimeType}]")
+            case EmbeddedResource():
+                resource = item.resource
+                if isinstance(resource, TextResourceContents):
+                    parts.append(resource.text)
+                elif isinstance(resource, BlobResourceContents):
+                    mime_type = resource.mimeType or "application/octet-stream"
+                    parts.append(f"[resource: {mime_type} ({resource.uri})]")
+                else:
+                    parts.append(str(resource))
+            case _:
+                # Fallback for unknown content types.
+                parts.append(str(item))
+
+    return "\n".join(parts)
 
 
 class BaseAdapter(Generic[T], ABC):
@@ -58,14 +125,14 @@ class BaseAdapter(Generic[T], ABC):
         """
         if getattr(tool_result, "isError", False):
             # Handle errors first
-            error_content = tool_result.content or "Unknown error"
+            error_content = _mcp_content_to_text(tool_result.content) or "Unknown error"
             return f"Error: {error_content}"
         elif hasattr(tool_result, "contents"):  # For Resources (ReadResourceResult)
             return "\n".join(c.decode() if isinstance(c, bytes) else str(c) for c in tool_result.contents)
         elif hasattr(tool_result, "messages"):  # For Prompts (GetPromptResult)
             return "\n".join(str(s) for s in tool_result.messages)
         elif hasattr(tool_result, "content"):  # For Tools (CallToolResult)
-            return str(tool_result.content)
+            return _mcp_content_to_text(tool_result.content)
         else:
             # Fallback for unexpected types
             return str(tool_result)

--- a/libraries/python/tests/unit/test_base_adapter.py
+++ b/libraries/python/tests/unit/test_base_adapter.py
@@ -1,0 +1,122 @@
+"""Unit tests for BaseAdapter result parsing and MCP content conversion."""
+
+from mcp.types import (
+    AudioContent,
+    BlobResourceContents,
+    CallToolResult,
+    EmbeddedResource,
+    ImageContent,
+    TextContent,
+    TextResourceContents,
+)
+
+from mcp_use.agents.adapters.base import BaseAdapter, _mcp_content_to_text
+
+
+class _StubAdapter(BaseAdapter):
+    """Minimal concrete adapter so the non-abstract ``parse_result`` can be exercised."""
+
+    def _convert_tool(self, mcp_tool, connector):
+        return None
+
+    def _convert_resource(self, mcp_resource, connector):
+        return None
+
+    def _convert_prompt(self, mcp_prompt, connector):
+        return None
+
+
+class TestMcpContentToText:
+    """Tests for the ``_mcp_content_to_text`` helper."""
+
+    def test_single_text_content_returns_plain_string(self):
+        """A single text block should be returned as a bare string."""
+        result = _mcp_content_to_text([TextContent(type="text", text="hello world")])
+
+        assert result == "hello world"
+
+    def test_multiple_text_contents_are_joined_with_newlines(self):
+        """Multiple text blocks should be preserved, not collapsed into a repr."""
+        result = _mcp_content_to_text(
+            [
+                TextContent(type="text", text="line one"),
+                TextContent(type="text", text="line two"),
+            ]
+        )
+
+        assert result == "line one\nline two"
+
+    def test_mixed_content_preserves_each_block_without_dumping_base64(self):
+        """Mixed content should map to readable placeholders and never inline base64 data."""
+        result = _mcp_content_to_text(
+            [
+                TextContent(type="text", text="intro"),
+                ImageContent(type="image", data="aGVsbG8=", mimeType="image/png"),
+                AudioContent(type="audio", data="d29ybGQ=", mimeType="audio/mpeg"),
+                EmbeddedResource(
+                    type="resource",
+                    resource=TextResourceContents(uri="file:///tmp/readme.txt", text="resource text"),
+                ),
+                EmbeddedResource(
+                    type="resource",
+                    resource=BlobResourceContents(uri="file:///tmp/data.bin", blob="ZGF0YQ=="),
+                ),
+            ]
+        )
+
+        assert result == (
+            "intro\n"
+            "[image: image/png]\n"
+            "[audio: audio/mpeg]\n"
+            "resource text\n"
+            "[resource: application/octet-stream (file:///tmp/data.bin)]"
+        )
+        # The raw base64 payloads must not leak into the rendered string.
+        assert "aGVsbG8=" not in result
+        assert "d29ybGQ=" not in result
+        assert "ZGF0YQ==" not in result
+
+    def test_empty_content_returns_empty_string(self):
+        """An empty content list should render as an empty string."""
+        assert _mcp_content_to_text([]) == ""
+
+    def test_non_list_content_falls_back_to_str(self):
+        """Unexpected, non-list payloads should degrade gracefully via str()."""
+        assert _mcp_content_to_text("already a string") == "already a string"
+        assert _mcp_content_to_text(None) == "None"
+
+
+class TestParseResult:
+    """Tests for ``BaseAdapter.parse_result`` using the stub adapter."""
+
+    def test_call_tool_result_success_uses_readable_text(self):
+        """A successful CallToolResult should be parsed via the content helper."""
+        adapter = _StubAdapter()
+        result = CallToolResult(
+            content=[
+                TextContent(type="text", text="caption"),
+                ImageContent(type="image", data="aGVsbG8=", mimeType="image/png"),
+            ]
+        )
+
+        parsed = adapter.parse_result(result)
+
+        assert parsed == "caption\n[image: image/png]"
+        assert "aGVsbG8=" not in parsed
+
+    def test_error_result_returns_formatted_readable_error(self):
+        """Error results should surface the readable error text, not a repr."""
+        adapter = _StubAdapter()
+        result = CallToolResult(
+            content=[TextContent(type="text", text="tool blew up")],
+            isError=True,
+        )
+
+        assert adapter.parse_result(result) == "Error: tool blew up"
+
+    def test_error_result_with_empty_content_falls_back_to_unknown(self):
+        """An error result with no content should report a generic message."""
+        adapter = _StubAdapter()
+        result = CallToolResult(content=[], isError=True)
+
+        assert adapter.parse_result(result) == "Error: Unknown error"


### PR DESCRIPTION
Fixes #1197.

`BaseAdapter.parse_result` did `str(tool_result.content)` for `CallToolResult`, which renders the typed MCP content blocks as a Python `repr` and dumps base64 image/audio/blob payloads into the model context.

Added `_mcp_content_to_text()` to render each block instead:
- `TextContent` → text
- `ImageContent` / `AudioContent` → `[image: <mime>]` / `[audio: <mime>]` (no base64)
- `EmbeddedResource` → resource text, or `[resource: <mime> (<uri>)]` for blobs

Applied to the success and error branches. `parse_result` still returns `str` — not breaking. Mirrors #1192 for the non-LangChain flows.

**Tests:** added `tests/unit/test_base_adapter.py` (8 tests). `pytest tests/unit` → 26 passed, `ruff` clean.

![tests passing](https://github.com/user-attachments/assets/29f84b2f-fa8b-49ca-a3d1-aab76e5d1479)
