### PR TITLE
fix(cli): cleanly unsubscribe on Ctrl+C (SIGINT)

### DIFF
--- a/libraries/typescript/.changeset/clean-cli-subscribe-sigint.md
+++ b/libraries/typescript/.changeset/clean-cli-subscribe-sigint.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/cli": patch
+---
+
+Cleanly unsubscribe from resource subscriptions when stopping the CLI with Ctrl+C.

--- a/libraries/typescript/packages/cli/src/commands/client.ts
+++ b/libraries/typescript/packages/cli/src/commands/client.ts
@@ -798,6 +798,17 @@ async function subscribeResourceCommand(
 
     console.log(formatInfo("Listening for updates... (Press Ctrl+C to stop)"));
 
+    // Handle Ctrl+C (SIGINT) to unsubscribe cleanly
+    process.once("SIGINT", async () => {
+      console.log(formatInfo("\nUnsubscribing and shutting down..."));
+      try {
+        await session.unsubscribeFromResource(uri);
+      } catch (e) {
+        // ignore errors during shutdown
+      }
+      await cleanupAndExit(0);
+    });
+
     await new Promise(() => {});
   } catch (error: any) {
     console.error(


### PR DESCRIPTION
Closes https://github.com/mcp-use/mcp-use/issues/1686

<img width="949" height="158" alt="Screenshot 2026-06-09 at 1 20 56 AM" src="https://github.com/user-attachments/assets/d4715982-273e-49a8-8ace-43faabdd0bb1" />
