### PR TITLE
fix(python): correct dev setup docs in CLAUDE.md

### DIFF
--- a/libraries/python/CLAUDE.md
+++ b/libraries/python/CLAUDE.md
@@ -15,17 +15,17 @@ This file provides guidance for working with the Python implementation of mcp-us
 ### Setup
 
 ```bash
-# Activate virtual environment (if it exists)
-source env/bin/activate
+# Create virtual environment
+uv venv
 
-# Create virtual environment if it doesn't exist
-# python -m venv env && source env/bin/activate
+# Activate virtual environment
+source .venv/bin/activate  # On Windows: .venv\Scripts\activate
 
 # Install for development
-pip install -e ".[dev,search]"
+uv pip install -e ".[dev,search]"
 
 # Install with optional dependencies
-pip install -e ".[dev,anthropic,openai,e2b,search]"
+uv pip install -e ".[dev,anthropic,openai,e2b,search]"
 ```
 
 ### Code Quality
@@ -170,7 +170,7 @@ export MCP_USE_DEBUG=2
 
 ## Code Style and Standards
 
-- **Line Length**: 200 characters (configured in ruff.toml)
+- **Line Length**: 120 characters (configured in `pyproject.toml`)
 - **Python Version**: 3.11+ required
 - **Formatting**: Use Ruff for formatting and linting
 - **Type Hints**: All public APIs should have type hints


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

Check all that apply:
- [ ] TypeScript
- [x] Python
- [x] Documentation only
- [ ] CI/CD or tooling

## Changes

Fixes some stale inaccuracies in `libraries/python/CLAUDE.md` that would break a contributor's local setup from step one.

## Review Readiness

Help maintainers review this quickly:

- [x] The PR is scoped to one issue or one clearly related change
- [x] The PR description explains the user-visible problem and the fix
- [x] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [x] I verified the affected package/docs path with the commands listed below
- [x] I checked for existing open PRs that already solve the same issue

---

## Python Checklist

> Complete this section if your PR includes Python changes

### Pre-commit Checklist

Ensure all of the following have been completed:
- [x] Code formatted with `ruff format`
- [x] Linting passes with `ruff check`
- [ ] Added or updated tests if needed
- [x] Updated documentation if needed

---

## Example Usage (Before)

```
# source env/bin/activate  -> "No such file or directory"
source env/bin/activate
pip install -e ".[dev,search]"
```

## Example Usage (After)

```
uv venv
source .venv/bin/activate
uv pip install -e ".[dev,search]"
```

## Documentation Updates
`libraries/python/CLAUDE.md`: just fixed the setup commands and a line length reference.