### PR TITLE
fix(python): use python3 instead of python3.11 in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,5 +27,4 @@ repos:
 
 # Define configuration for the Python checks
 default_language_version:
-  python: python3.11
-
+  python: python3

--- a/libraries/python/.pre-commit-config.yaml
+++ b/libraries/python/.pre-commit-config.yaml
@@ -25,4 +25,4 @@ repos:
     -   id: debug-statements
 
 default_language_version:
-    python: python3.11
+    python: python3


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

Check all that apply:
- [ ] TypeScript
- [x] Python
- [ ] Documentation only
- [x] CI/CD or tooling

## Changes
Fix a hard blocker that prevents any commit from going through on python 3.12+ systems. Both pre-commit config files hardcoded `python3.11`, which causing pre-commit to fail on machines where `python3.11` is not installed - which is maybe a new contributor setups today. In `CONTRIBUTING.md` also it's written "Python 3.11 or higher" as the prerequisite.

## Review Readiness

Help maintainers review this quickly:

- [x] The PR is scoped to one issue or one clearly related change
- [x] The PR description explains the user-visible problem and the fix
- [x] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [x] I verified the affected package/docs path with the commands listed below
- [x] I checked for existing open PRs that already solve the same issue

---

## Python Checklist

> Complete this section if your PR includes Python changes

### Pre-commit Checklist

Ensure all of the following have been completed:
- [x] Code formatted with `ruff format`
- [x] Linting passes with `ruff check`
- [ ] Added or updated tests if needed
- [ ] Updated documentation if needed

---

## Testing

Verified by running `git commit`