### PR TITLE
feat(cli): managed (no-GitHub) deploy + device-code login

### DIFF
--- a/libraries/typescript/.changeset/managed-deploy-cli.md
+++ b/libraries/typescript/.changeset/managed-deploy-cli.md
@@ -2,6 +2,6 @@
 "@mcp-use/cli": minor
 ---
 
-Add `mcp-use deploy --managed` to deploy a local MCP server without connecting your own GitHub. The project source is packed into a tarball and uploaded; the server is created in the platform-managed org and deployed through the normal pipeline (redeploys reuse the linked server).
+Add `mcp-use deploy --managed` to deploy a local MCP server without connecting your own GitHub. The project source is packed into a tarball and uploaded; the server is created in the platform-managed org and deployed through the normal pipeline. Redeploys of a managed project are auto-detected from the linked server, so `--managed` is only needed on the first deploy.
 
 Also add `mcp-use login --device-code <code>` for non-interactive authentication with a pre-approved OAuth device code (used by the web onboarding flow), skipping the browser step.

--- a/libraries/typescript/.changeset/managed-deploy-cli.md
+++ b/libraries/typescript/.changeset/managed-deploy-cli.md
@@ -1,0 +1,7 @@
+---
+"@mcp-use/cli": minor
+---
+
+Add `mcp-use deploy --managed` to deploy a local MCP server without connecting your own GitHub. The project source is packed into a tarball and uploaded; the server is created in the platform-managed org and deployed through the normal pipeline (redeploys reuse the linked server).
+
+Also add `mcp-use login --device-code <code>` for non-interactive authentication with a pre-approved OAuth device code (used by the web onboarding flow), skipping the browser step.

--- a/libraries/typescript/.changeset/managed-deploy-cli.md
+++ b/libraries/typescript/.changeset/managed-deploy-cli.md
@@ -2,6 +2,6 @@
 "@mcp-use/cli": minor
 ---
 
-Add `mcp-use deploy --managed` to deploy a local MCP server without connecting your own GitHub. The project source is packed into a tarball and uploaded; the server is created in the platform-managed org and deployed through the normal pipeline. Redeploys of a managed project are auto-detected from the linked server, so `--managed` is only needed on the first deploy.
+Add `mcp-use deploy --no-github` to deploy a local MCP server without connecting your own GitHub. The project source is packed into a tarball and uploaded; the server is created in the platform-managed org and deployed through the normal pipeline. Redeploys of a platform-managed project are auto-detected from the linked server, so `--no-github` is only needed on the first deploy.
 
 Also add `mcp-use login --device-code <code>` for non-interactive authentication with a pre-approved OAuth device code (used by the web onboarding flow), skipping the browser step.

--- a/libraries/typescript/packages/cli/src/commands/auth.ts
+++ b/libraries/typescript/packages/cli/src/commands/auth.ts
@@ -181,6 +181,13 @@ export async function loginCommand(options?: {
   silent?: boolean;
   apiKey?: string;
   org?: string;
+  /**
+   * A pre-approved OAuth device code (RFC 8628). When provided, skip requesting
+   * a new code + opening a browser and poll the token endpoint directly. Used by
+   * the web onboarding flow, which creates and approves the code, then embeds it
+   * in the agent's prompt.
+   */
+  deviceCode?: string;
 }): Promise<void> {
   try {
     const directKey = options?.apiKey || process.env.MCP_USE_API_KEY;
@@ -203,7 +210,9 @@ export async function loginCommand(options?: {
       return;
     }
 
-    if (await isLoggedIn()) {
+    // A provided device code means an explicit (re)login as that account —
+    // bypass the "already logged in" short-circuit and authenticate with it.
+    if (!options?.deviceCode && (await isLoggedIn())) {
       let needsReauth = false;
       try {
         await (await McpUseAPI.create()).testAuth();
@@ -241,36 +250,44 @@ export async function loginCommand(options?: {
 
     const authBaseUrl = await getAuthBaseUrl();
 
-    const deviceResp = await requestDeviceCode(authBaseUrl);
-    const {
-      device_code,
-      user_code,
-      verification_uri,
-      verification_uri_complete,
-      interval,
-    } = deviceResp;
+    let device_code: string;
+    let interval: number;
 
-    const displayCode =
-      user_code.length === 8
-        ? `${user_code.slice(0, 4)}-${user_code.slice(4)}`
-        : user_code;
+    if (options?.deviceCode) {
+      // Pre-approved device code (from the web onboarding flow): no browser, no
+      // user code prompt — just poll the token endpoint until it's redeemed.
+      device_code = options.deviceCode.trim();
+      interval = 2;
+      console.log(chalk.gray("  Authenticating with provided device code..."));
+    } else {
+      const deviceResp = await requestDeviceCode(authBaseUrl);
+      device_code = deviceResp.device_code;
+      interval = deviceResp.interval || 5;
 
-    console.log(chalk.white("  Visit: ") + chalk.cyan(verification_uri));
-    console.log(chalk.white("  Code:  ") + chalk.bold.white(displayCode));
-    console.log();
+      const { user_code, verification_uri, verification_uri_complete } =
+        deviceResp;
+      const displayCode =
+        user_code.length === 8
+          ? `${user_code.slice(0, 4)}-${user_code.slice(4)}`
+          : user_code;
 
-    const urlToOpen = verification_uri_complete || verification_uri;
-    try {
-      await open(urlToOpen);
-      console.log(chalk.gray("  Browser opened. Waiting for approval..."));
-    } catch {
-      console.log(chalk.gray("  Open the URL above in your browser."));
+      console.log(chalk.white("  Visit: ") + chalk.cyan(verification_uri));
+      console.log(chalk.white("  Code:  ") + chalk.bold.white(displayCode));
+      console.log();
+
+      const urlToOpen = verification_uri_complete || verification_uri;
+      try {
+        await open(urlToOpen);
+        console.log(chalk.gray("  Browser opened. Waiting for approval..."));
+      } catch {
+        console.log(chalk.gray("  Open the URL above in your browser."));
+      }
     }
 
     const accessToken = await pollForDeviceToken(
       authBaseUrl,
       device_code,
-      interval || 5
+      interval
     );
 
     console.log(chalk.gray("\n  Creating persistent API key..."));

--- a/libraries/typescript/packages/cli/src/commands/deploy.ts
+++ b/libraries/typescript/packages/cli/src/commands/deploy.ts
@@ -25,6 +25,7 @@ import {
 } from "../utils/git.js";
 import { getMcpServerUrl } from "../utils/cloud-urls.js";
 import { getProjectLink, saveProjectLink } from "../utils/project-link.js";
+import { packProjectTarball, sanitizeRepoName } from "../utils/tarball.js";
 import {
   loginCommand,
   promptOrgSelection,
@@ -194,6 +195,12 @@ interface DeployOptions {
   region?: "US" | "EU" | "APAC";
   buildCommand?: string;
   startCommand?: string;
+  /**
+   * Deploy the local source directly via the platform-managed GitHub org,
+   * without connecting the user's own GitHub. Uploads a tarball instead of
+   * pushing to a user repo.
+   */
+  managed?: boolean;
 }
 
 async function isMcpProject(cwd: string = process.cwd()): Promise<boolean> {
@@ -678,6 +685,130 @@ async function promptGitHubInstallation(
 }
 
 // ---------------------------------------------------------------------------
+// Managed deploy (no user GitHub) — upload local source as a tarball
+// ---------------------------------------------------------------------------
+
+/**
+ * Deploy the local project directly via the platform-managed GitHub org. No
+ * user GitHub connection, no git remote — the source is packed into a tarball
+ * and uploaded. Reuses the project link for redeploys (push source + redeploy).
+ */
+async function deployViaManagedUpload(
+  api: McpUseAPI,
+  options: DeployOptions,
+  ctx: { cwd: string; organizationId: string }
+): Promise<void> {
+  const { cwd, organizationId } = ctx;
+  const projectDir = options.rootDir ? path.resolve(cwd, options.rootDir) : cwd;
+
+  try {
+    await fs.access(projectDir);
+  } catch {
+    console.log(chalk.red(`✗ Project directory not found: ${projectDir}`));
+    process.exit(1);
+  }
+
+  const isMcp = await isMcpProject(projectDir);
+  if (!isMcp && !options.yes) {
+    console.log(
+      chalk.yellow("⚠️  This doesn't look like an MCP server project.")
+    );
+    const shouldContinue = await prompt(
+      chalk.white("Continue anyway? (y/n): ")
+    );
+    if (!shouldContinue) process.exit(0);
+    console.log();
+  }
+
+  const envVars = await buildEnvVars(options);
+  const branch = "main";
+  const projectName = options.name || (await getProjectName(projectDir));
+
+  console.log(chalk.gray("Packaging project source..."));
+  const tarball = await packProjectTarball(projectDir);
+  console.log(
+    chalk.gray(
+      `  Archive size: ${(tarball.length / 1024 / 1024).toFixed(2)} MB`
+    )
+  );
+  if (tarball.length > 80 * 1024 * 1024) {
+    console.log(
+      chalk.red(
+        "✗ Project archive exceeds 80 MB. Add large/derived files to .gitignore and retry."
+      )
+    );
+    process.exit(1);
+  }
+
+  // Redeploy an existing managed server when linked (keeps the same URL).
+  const existingLink = !options.new ? await getProjectLink(cwd) : null;
+  let serverId = existingLink?.serverId;
+  if (serverId) {
+    try {
+      const linked = await api.getServer(serverId);
+      if (linked.organizationId !== organizationId) serverId = undefined;
+    } catch {
+      serverId = undefined;
+    }
+  }
+
+  let deploymentId: string | undefined;
+
+  if (serverId) {
+    console.log(chalk.gray("Uploading source and redeploying..."));
+    if (Object.keys(envVars).length > 0) {
+      await syncEnvVarsToServer(api, serverId, envVars);
+    }
+    await api.pushSourceToServer(serverId, {
+      tarball,
+      branch,
+      commitMessage: "Redeploy from mcp-use CLI",
+    });
+    const dep = await api.createDeployment({
+      serverId,
+      branch,
+      trigger: "redeploy",
+    });
+    deploymentId = dep.id;
+    await saveProjectLink(cwd, {
+      deploymentId: dep.id,
+      deploymentName: projectName,
+      serverId,
+      linkedAt: new Date().toISOString(),
+    });
+  } else {
+    console.log(chalk.gray("Creating managed server and deploying..."));
+    const result = await api.createServerFromManagedUpload({
+      organizationId,
+      name: projectName,
+      repoName: sanitizeRepoName(projectName),
+      tarball,
+      branch,
+      commitMessage: "Deploy from mcp-use CLI",
+      port: options.port,
+      env: Object.keys(envVars).length > 0 ? envVars : undefined,
+    });
+    deploymentId = result.deploymentId ?? undefined;
+    if (result.server?.id && deploymentId) {
+      await saveProjectLink(cwd, {
+        deploymentId,
+        deploymentName: projectName,
+        serverId: result.server.id,
+        linkedAt: new Date().toISOString(),
+      });
+    }
+  }
+
+  if (!deploymentId) {
+    console.log(chalk.red("✗ No deployment was created."));
+    process.exit(1);
+  }
+
+  console.log(chalk.green("✓ Deployment created: ") + chalk.gray(deploymentId));
+  await displayDeploymentProgress(api, deploymentId, { yes: options.yes });
+}
+
+// ---------------------------------------------------------------------------
 // Main deploy command
 // ---------------------------------------------------------------------------
 
@@ -810,6 +941,14 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
     api = await ensureApiSessionForDeploy(api, options, resolvedOrgId);
 
     console.log(chalk.cyan.bold("\n🚀 Deploying to Manufact cloud...\n"));
+
+    // ── Managed deploy: skip GitHub entirely, upload local source ─────
+    if (options.managed) {
+      const organizationId =
+        resolvedOrgId ?? (await api.resolveOrganizationId());
+      await deployViaManagedUpload(api, options, { cwd, organizationId });
+      return;
+    }
 
     // ── Step 3: GitHub connection ─────────────────────────────────
     const reauth = () => promptReauthenticateOn401(options, resolvedOrgId);

--- a/libraries/typescript/packages/cli/src/commands/deploy.ts
+++ b/libraries/typescript/packages/cli/src/commands/deploy.ts
@@ -943,7 +943,21 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
     console.log(chalk.cyan.bold("\n🚀 Deploying to Manufact cloud...\n"));
 
     // ── Managed deploy: skip GitHub entirely, upload local source ─────
-    if (options.managed) {
+    // Explicit via --managed, or auto-detected when redeploying a project
+    // already linked to a managed server (so --managed isn't needed again).
+    let useManaged = !!options.managed;
+    if (!useManaged && !options.new) {
+      const link = await getProjectLink(cwd);
+      if (link?.serverId) {
+        try {
+          const linked = await api.getServer(link.serverId);
+          if (linked.connectedRepository?.isManaged) useManaged = true;
+        } catch {
+          // Server gone / inaccessible — fall through to the normal flow.
+        }
+      }
+    }
+    if (useManaged) {
       const organizationId =
         resolvedOrgId ?? (await api.resolveOrganizationId());
       await deployViaManagedUpload(api, options, { cwd, organizationId });

--- a/libraries/typescript/packages/cli/src/commands/deploy.ts
+++ b/libraries/typescript/packages/cli/src/commands/deploy.ts
@@ -196,11 +196,10 @@ interface DeployOptions {
   buildCommand?: string;
   startCommand?: string;
   /**
-   * Deploy the local source directly via the platform-managed GitHub org,
-   * without connecting the user's own GitHub. Uploads a tarball instead of
-   * pushing to a user repo.
+   * Upload local source without connecting the user's GitHub. Uses the
+   * platform-managed org and a tarball instead of pushing to a user repo.
    */
-  managed?: boolean;
+  noGithub?: boolean;
 }
 
 async function isMcpProject(cwd: string = process.cwd()): Promise<boolean> {
@@ -777,7 +776,7 @@ async function deployViaManagedUpload(
       linkedAt: new Date().toISOString(),
     });
   } else {
-    console.log(chalk.gray("Creating managed server and deploying..."));
+    console.log(chalk.gray("Uploading source (no GitHub required)..."));
     const result = await api.createServerFromManagedUpload({
       organizationId,
       name: projectName,
@@ -942,22 +941,22 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
 
     console.log(chalk.cyan.bold("\n🚀 Deploying to Manufact cloud...\n"));
 
-    // ── Managed deploy: skip GitHub entirely, upload local source ─────
-    // Explicit via --managed, or auto-detected when redeploying a project
-    // already linked to a managed server (so --managed isn't needed again).
-    let useManaged = !!options.managed;
-    if (!useManaged && !options.new) {
+    // ── No-GitHub deploy: upload local source via platform-managed org ──
+    // Explicit via --no-github, or auto-detected when redeploying a project
+    // already linked to a platform-managed server (--no-github not needed again).
+    let useNoGithubDeploy = !!options.noGithub;
+    if (!useNoGithubDeploy && !options.new) {
       const link = await getProjectLink(cwd);
       if (link?.serverId) {
         try {
           const linked = await api.getServer(link.serverId);
-          if (linked.connectedRepository?.isManaged) useManaged = true;
+          if (linked.connectedRepository?.isManaged) useNoGithubDeploy = true;
         } catch {
           // Server gone / inaccessible — fall through to the normal flow.
         }
       }
     }
-    if (useManaged) {
+    if (useNoGithubDeploy) {
       const organizationId =
         resolvedOrgId ?? (await api.resolveOrganizationId());
       await deployViaManagedUpload(api, options, { cwd, organizationId });

--- a/libraries/typescript/packages/cli/src/index.ts
+++ b/libraries/typescript/packages/cli/src/index.ts
@@ -2964,18 +2964,28 @@ program
     "Login with an API key directly (non-interactive, for CI/CD)"
   )
   .option("--org <slug|id|name>", "Select an organization non-interactively")
-  .action(async (opts: { apiKey?: string; org?: string }) => {
-    try {
-      await loginCommand({ apiKey: opts.apiKey, org: opts.org });
-      process.exit(0);
-    } catch (error) {
-      console.error(
-        chalk.red.bold("\n✗ Login failed:"),
-        chalk.red(error instanceof Error ? error.message : "Unknown error")
-      );
-      process.exit(1);
+  .option(
+    "--device-code <code>",
+    "Authenticate with a pre-approved device code (non-interactive; e.g. from the web onboarding flow)"
+  )
+  .action(
+    async (opts: { apiKey?: string; org?: string; deviceCode?: string }) => {
+      try {
+        await loginCommand({
+          apiKey: opts.apiKey,
+          org: opts.org,
+          deviceCode: opts.deviceCode,
+        });
+        process.exit(0);
+      } catch (error) {
+        console.error(
+          chalk.red.bold("\n✗ Login failed:"),
+          chalk.red(error instanceof Error ? error.message : "Unknown error")
+        );
+        process.exit(1);
+      }
     }
-  });
+  );
 
 program
   .command("logout")
@@ -3050,6 +3060,10 @@ program
     "--start-command <cmd>",
     "Custom start command (overrides auto-detection)"
   )
+  .option(
+    "--managed",
+    "Deploy local source without connecting GitHub (uses the platform-managed org)"
+  )
   .action(async (options) => {
     await deployCommand({
       open: options.open,
@@ -3065,6 +3079,7 @@ program
       region: options.region,
       buildCommand: options.buildCommand,
       startCommand: options.startCommand,
+      managed: options.managed,
     });
   });
 

--- a/libraries/typescript/packages/cli/src/index.ts
+++ b/libraries/typescript/packages/cli/src/index.ts
@@ -3061,8 +3061,8 @@ program
     "Custom start command (overrides auto-detection)"
   )
   .option(
-    "--managed",
-    "Deploy local source without connecting GitHub (uses the platform-managed org)"
+    "--no-github",
+    "Upload local source without connecting GitHub (repo hosted in the platform-managed org)"
   )
   .action(async (options) => {
     await deployCommand({
@@ -3079,7 +3079,7 @@ program
       region: options.region,
       buildCommand: options.buildCommand,
       startCommand: options.startCommand,
-      managed: options.managed,
+      noGithub: options.github === false,
     });
   });
 

--- a/libraries/typescript/packages/cli/src/utils/api.ts
+++ b/libraries/typescript/packages/cli/src/utils/api.ts
@@ -79,6 +79,8 @@ interface CloudServerConnectedRepository {
   repoFullName: string;
   productionBranch: string;
   isActive: boolean;
+  /** True when deployed via the platform-managed org (no user GitHub). */
+  isManaged?: boolean;
   userId: string;
   githubInstallationId: string;
   createdAt: string;

--- a/libraries/typescript/packages/cli/src/utils/api.ts
+++ b/libraries/typescript/packages/cli/src/utils/api.ts
@@ -444,6 +444,100 @@ export class McpUseAPI {
     });
   }
 
+  /** Multipart helper: POST/PUT a tarball + fields without the JSON Content-Type. */
+  private async uploadMultipart<T>(
+    endpoint: string,
+    form: FormData,
+    timeout = 120000
+  ): Promise<T> {
+    const url = `${this.baseUrl}${endpoint}`;
+    const headers: Record<string, string> = {
+      "x-mcp-creation-location": "cli",
+    };
+    if (this.apiKey) headers["x-api-key"] = this.apiKey;
+    if (this.orgId) headers["x-profile-id"] = this.orgId;
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeout);
+    try {
+      const response = await fetch(url, {
+        method: "POST",
+        headers,
+        body: form,
+        signal: controller.signal,
+      });
+      clearTimeout(timeoutId);
+      if (response.status === 401) throw new ApiUnauthorizedError();
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`API request failed: ${response.status} ${errorText}`);
+      }
+      return response.json() as Promise<T>;
+    } catch (error: any) {
+      clearTimeout(timeoutId);
+      if (error.name === "AbortError") {
+        throw new Error(`Request timeout after ${timeout / 1000}s.`);
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Create a server from a source tarball deployed into the platform-managed
+   * GitHub org (no user GitHub connection required).
+   */
+  async createServerFromManagedUpload(input: {
+    organizationId: string;
+    name: string;
+    repoName: string;
+    tarball: Buffer;
+    branch?: string;
+    commitMessage?: string;
+    port?: number;
+    env?: Record<string, string>;
+  }): Promise<CreateServerResponse> {
+    const form = new FormData();
+    form.set(
+      "sourceFile",
+      new Blob([new Uint8Array(input.tarball)], { type: "application/gzip" }),
+      "source.tar.gz"
+    );
+    form.set("organizationId", input.organizationId);
+    form.set("managed", "true");
+    form.set("name", input.name);
+    form.set("repoName", input.repoName);
+    form.set("private", "true");
+    form.set("branch", input.branch ?? "main");
+    form.set("commitMessage", input.commitMessage ?? "Deploy from mcp-use CLI");
+    if (input.port != null) form.set("port", String(input.port));
+    if (input.env && Object.keys(input.env).length > 0) {
+      form.set("env", JSON.stringify(input.env));
+    }
+    return this.uploadMultipart<CreateServerResponse>("/servers", form);
+  }
+
+  /** Push a new source tarball as a commit on an existing server's repo. */
+  async pushSourceToServer(
+    serverId: string,
+    input: { tarball: Buffer; branch?: string; commitMessage?: string }
+  ): Promise<{ commitSha: string; repoFullName: string; branch: string }> {
+    const form = new FormData();
+    form.set(
+      "sourceFile",
+      new Blob([new Uint8Array(input.tarball)], { type: "application/gzip" }),
+      "source.tar.gz"
+    );
+    form.set("branch", input.branch ?? "main");
+    form.set(
+      "commitMessage",
+      input.commitMessage ?? "Redeploy from mcp-use CLI"
+    );
+    return this.uploadMultipart(
+      `/servers/${encodeURIComponent(serverId)}/source`,
+      form
+    );
+  }
+
   async listServers(params?: {
     organizationId?: string;
     limit?: number;

--- a/libraries/typescript/packages/cli/src/utils/tarball.ts
+++ b/libraries/typescript/packages/cli/src/utils/tarball.ts
@@ -1,0 +1,67 @@
+import { create } from "tar";
+import type { Readable } from "node:stream";
+
+/**
+ * Directories never worth uploading (build output, deps, VCS, local state).
+ */
+const EXCLUDE_DIRS = new Set([
+  ".git",
+  "node_modules",
+  "dist",
+  "build",
+  ".next",
+  ".turbo",
+  ".vercel",
+  ".cache",
+  "coverage",
+  ".mcp-use",
+]);
+
+/**
+ * Pack a project directory into a gzip tarball for upload to the cloud
+ * `POST /servers` (managed) / `POST /servers/:id/source` endpoints.
+ *
+ * Every entry is nested under a single wrapper directory (`prefix`) because the
+ * backend's extractor strips the first path segment (it expects GitHub's
+ * `owner-repo-sha/` tarball layout). Secrets (`.env*`) and heavy/derived
+ * directories are excluded.
+ */
+export async function packProjectTarball(
+  projectDir: string,
+  prefix = "app"
+): Promise<Buffer> {
+  const stream = create(
+    {
+      gzip: true,
+      cwd: projectDir,
+      prefix,
+      portable: true,
+      filter: (entryPath: string) => {
+        const segments = entryPath.split(/[/\\]/).filter((s) => s && s !== ".");
+        if (segments.some((seg) => EXCLUDE_DIRS.has(seg))) return false;
+        const base = segments[segments.length - 1] ?? "";
+        if (base === ".DS_Store") return false;
+        // Never ship local secrets; env vars are passed explicitly via --env.
+        if (base === ".env" || base.startsWith(".env.")) return false;
+        return true;
+      },
+    },
+    ["."]
+  ) as unknown as Readable;
+
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(Buffer.from(chunk as Buffer));
+  }
+  return Buffer.concat(chunks);
+}
+
+/** Coerce an arbitrary project name into a valid GitHub repo name. */
+export function sanitizeRepoName(name: string): string {
+  const cleaned = name
+    .trim()
+    .replace(/[^a-zA-Z0-9._-]+/g, "-")
+    .replace(/^[-.]+|[-.]+$/g, "")
+    .slice(0, 80);
+  return cleaned || "mcp-server";
+}

--- a/libraries/typescript/packages/cli/tests/tarball.test.ts
+++ b/libraries/typescript/packages/cli/tests/tarball.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { list } from "tar";
+import { packProjectTarball, sanitizeRepoName } from "../src/utils/tarball.js";
+
+describe("sanitizeRepoName", () => {
+  it("keeps already-valid names", () => {
+    expect(sanitizeRepoName("my-mcp.server_1")).toBe("my-mcp.server_1");
+  });
+
+  it("replaces invalid characters with dashes", () => {
+    expect(sanitizeRepoName("@scope/My Cool App!")).toBe("scope-My-Cool-App");
+  });
+
+  it("trims leading/trailing separators and caps length", () => {
+    expect(sanitizeRepoName("---weird---")).toBe("weird");
+    expect(sanitizeRepoName("a".repeat(200)).length).toBe(80);
+  });
+
+  it("falls back to a default when empty", () => {
+    expect(sanitizeRepoName("@#$%")).toBe("mcp-server");
+  });
+});
+
+describe("packProjectTarball", () => {
+  it("nests entries under a prefix and excludes deps/build/secrets", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "tarball-test-"));
+    try {
+      await writeFile(join(dir, "package.json"), '{"name":"demo"}');
+      await mkdir(join(dir, "src"), { recursive: true });
+      await writeFile(join(dir, "src", "index.ts"), "export const x = 1;");
+      await writeFile(join(dir, ".env"), "SECRET=should-not-ship");
+      await mkdir(join(dir, "node_modules", "left-pad"), { recursive: true });
+      await writeFile(join(dir, "node_modules", "left-pad", "index.js"), "//");
+      await mkdir(join(dir, "dist"), { recursive: true });
+      await writeFile(join(dir, "dist", "index.js"), "//");
+
+      const buf = await packProjectTarball(dir, "app");
+      expect(buf.length).toBeGreaterThan(0);
+
+      // Re-read the archive entries to assert layout + exclusions.
+      const archivePath = join(dir, "out.tgz");
+      await writeFile(archivePath, buf);
+      const found: string[] = [];
+      await list({ file: archivePath, onentry: (e) => found.push(e.path) });
+
+      const normalized = found.map((p) => p.replace(/\/$/, ""));
+      expect(normalized).toContain("app/package.json");
+      expect(normalized).toContain("app/src/index.ts");
+      expect(normalized.some((p) => p.includes("node_modules"))).toBe(false);
+      expect(normalized.some((p) => p.startsWith("app/dist"))).toBe(false);
+      expect(normalized.some((p) => p.endsWith(".env"))).toBe(false);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/skills/mcp-apps-builder/references/foundations/deployment.md
+++ b/skills/mcp-apps-builder/references/foundations/deployment.md
@@ -12,11 +12,37 @@ mcp-use whoami
 
 If this fails or the user has never logged in, run `mcp-use login` first — it opens a browser for OAuth.
 
+**Non-interactive / agent contexts:** if you were handed a one-time device code
+(e.g. from the web onboarding flow), authenticate without a browser:
+
+```bash
+mcp-use login --device-code <CODE>
+```
+
+The code is short-lived and already approved, so the CLI redeems it immediately.
+
 ---
 
 ## Quick Deploy (Manufact Cloud)
 
-The fastest path to production — one command:
+There are two ways to deploy, depending on where the code should live.
+
+### Option A — Managed repo (no GitHub required)
+
+Best for getting live fast, or when the user hasn't connected GitHub. The CLI
+uploads your local source; the repo is created in the platform-managed org and
+deployed through the normal pipeline:
+
+```bash
+mcp-use deploy --managed
+```
+
+No git remote, no GitHub App install. The user can later move it to their own
+GitHub from the server's dashboard ("Connect your GitHub").
+
+### Option B — Your own GitHub
+
+Deploys from a repository in the user's GitHub account (enables push-to-deploy):
 
 ```bash
 mcp-use deploy
@@ -28,19 +54,21 @@ Or via the npm script (pre-configured in all templates):
 npm run deploy
 ```
 
-Your server is live at `https://{slug}.run.mcp-use.com/mcp`.
+Either way, your server is live at `https://{slug}.run.mcp-use.com/mcp`.
 
 ---
 
 ## Prerequisites
 
-Before running `mcp-use deploy`:
+**Managed deploy (`--managed`)** only needs you to be **logged in** (`mcp-use whoami`).
+No git, no GitHub App — the CLI uploads your local source directly.
 
-1. **Logged in** — run `mcp-use whoami` to verify, or `mcp-use login` if needed
-2. **Git repository** — your project must be a git repo
-3. **GitHub remote** — the `origin` remote must point to GitHub (SSH or HTTPS)
-4. **Changes pushed** — deployment pulls from GitHub, not your local files. Commit and push first.
-5. **GitHub App installed** — the mcp-use GitHub App must have access to the repo. The CLI will prompt you to install it if missing.
+**GitHub deploy** (`mcp-use deploy` without `--managed`) additionally needs:
+
+1. **Git repository** — your project must be a git repo
+2. **GitHub remote** — the `origin` remote must point to GitHub (SSH or HTTPS)
+3. **Changes pushed** — deployment pulls from GitHub, not your local files. Commit and push first.
+4. **GitHub App installed** — the mcp-use GitHub App must have access to the repo. The CLI prompts you to install it if missing, or install it at `github.com/apps/mcp-use/installations/new`.
 
 ---
 
@@ -50,15 +78,21 @@ Before running `mcp-use deploy`:
 mcp-use deploy [options]
 ```
 
-| Flag | Description | Default |
-|------|-------------|---------|
-| `--name <name>` | Custom deployment name | `package.json` name or directory name |
-| `--port <port>` | Server port | `3000` |
-| `--runtime <runtime>` | `"node"` or `"python"` | Auto-detected from project files |
-| `--env <KEY=VALUE>` | Set environment variable (repeatable) | — |
-| `--env-file <path>` | Load env vars from a file | — |
-| `--open` | Open deployment in browser after success | `false` |
-| `--new` | Force a fresh deployment (ignore existing link) | `false` |
+| Flag                  | Description                                                  | Default                               |
+| --------------------- | ------------------------------------------------------------ | ------------------------------------- |
+| `--managed`           | Deploy local source via the platform-managed org (no GitHub) | `false`                               |
+| `--org <slug>`        | Deploy to a specific organization (by slug or id)            | configured org                        |
+| `--name <name>`       | Custom deployment name                                       | `package.json` name or directory name |
+| `--port <port>`       | Server port                                                  | `3000`                                |
+| `--runtime <runtime>` | `"node"` or `"python"`                                       | Auto-detected from project files      |
+| `--env <KEY=VALUE>`   | Set environment variable (repeatable)                        | —                                     |
+| `--env-file <path>`   | Load env vars from a file                                    | —                                     |
+| `--open`              | Open deployment in browser after success                     | `false`                               |
+| `--new`               | Force a fresh deployment (ignore existing link)              | `false`                               |
+| `-y, --yes`           | Skip confirmation prompts (non-interactive / CI / agents)    | `false`                               |
+
+> Redeploys of a managed project are auto-detected from the linked server, so
+> `--managed` is only needed on the first deploy.
 
 ### Setting Environment Variables
 
@@ -83,6 +117,6 @@ mcp-use deploy --env-file .env.production
 - ❌ Hardcoding secrets in code or committing `.env`
   - ✅ Use `--env` / `--env-file` flags, or `mcp-use deployments env set`
 - ❌ Forgetting to install the mcp-use GitHub App on the repo
-  - ✅ The CLI will prompt you, but you can also install it at `github.com/apps/mcp-use`
+  - ✅ The CLI will prompt you, but you can also install it at `github.com/apps/mcp-use` — or skip GitHub entirely with `mcp-use deploy --managed`
 - ❌ Running `mcp-use start` without `mcp-use build` first
   - ✅ Always build before starting in production

--- a/skills/mcp-apps-builder/references/foundations/deployment.md
+++ b/skills/mcp-apps-builder/references/foundations/deployment.md
@@ -34,7 +34,7 @@ uploads your local source; the repo is created in the platform-managed org and
 deployed through the normal pipeline:
 
 ```bash
-mcp-use deploy --managed
+mcp-use deploy --no-github
 ```
 
 No git remote, no GitHub App install. The user can later move it to their own
@@ -60,10 +60,10 @@ Either way, your server is live at `https://{slug}.run.mcp-use.com/mcp`.
 
 ## Prerequisites
 
-**Managed deploy (`--managed`)** only needs you to be **logged in** (`mcp-use whoami`).
+**No-GitHub deploy (`--no-github`)** only needs you to be **logged in** (`mcp-use whoami`).
 No git, no GitHub App — the CLI uploads your local source directly.
 
-**GitHub deploy** (`mcp-use deploy` without `--managed`) additionally needs:
+**GitHub deploy** (`mcp-use deploy` without `--no-github`) additionally needs:
 
 1. **Git repository** — your project must be a git repo
 2. **GitHub remote** — the `origin` remote must point to GitHub (SSH or HTTPS)
@@ -80,7 +80,7 @@ mcp-use deploy [options]
 
 | Flag                  | Description                                                  | Default                               |
 | --------------------- | ------------------------------------------------------------ | ------------------------------------- |
-| `--managed`           | Deploy local source via the platform-managed org (no GitHub) | `false`                               |
+| `--no-github`         | Upload local source without connecting GitHub                | `false`                               |
 | `--org <slug>`        | Deploy to a specific organization (by slug or id)            | configured org                        |
 | `--name <name>`       | Custom deployment name                                       | `package.json` name or directory name |
 | `--port <port>`       | Server port                                                  | `3000`                                |
@@ -91,8 +91,8 @@ mcp-use deploy [options]
 | `--new`               | Force a fresh deployment (ignore existing link)              | `false`                               |
 | `-y, --yes`           | Skip confirmation prompts (non-interactive / CI / agents)    | `false`                               |
 
-> Redeploys of a managed project are auto-detected from the linked server, so
-> `--managed` is only needed on the first deploy.
+> Redeploys of a platform-managed project are auto-detected from the linked server, so
+> `--no-github` is only needed on the first deploy.
 
 ### Setting Environment Variables
 
@@ -117,6 +117,6 @@ mcp-use deploy --env-file .env.production
 - ❌ Hardcoding secrets in code or committing `.env`
   - ✅ Use `--env` / `--env-file` flags, or `mcp-use deployments env set`
 - ❌ Forgetting to install the mcp-use GitHub App on the repo
-  - ✅ The CLI will prompt you, but you can also install it at `github.com/apps/mcp-use` — or skip GitHub entirely with `mcp-use deploy --managed`
+  - ✅ The CLI will prompt you, but you can also install it at `github.com/apps/mcp-use` — or skip GitHub entirely with `mcp-use deploy --no-github`
 - ❌ Running `mcp-use start` without `mcp-use build` first
   - ✅ Always build before starting in production


### PR DESCRIPTION
## Summary
- Adds `mcp-use deploy --managed`: packs the local project into a gzip tarball and uploads it to `POST /servers` with `managed=true`, so a user can deploy **without connecting their own GitHub**. The server's repo is created in the platform-managed org via the installation token; redeploys reuse the linked server (`.mcp-use/project.json`) via `POST /servers/:id/source` + a redeploy.
- Adds `mcp-use login --device-code <code>`: non-interactive auth with a **pre-approved** OAuth device code (RFC 8628). Skips requesting a code and opening a browser — used by the web onboarding flow, which creates + approves the code and embeds it in the agent prompt.

## Implementation
- `src/utils/tarball.ts` — `packProjectTarball()` (nests entries under a wrapper prefix since the backend strips the first path segment; excludes `node_modules`/build dirs/`.env*`) + `sanitizeRepoName()`.
- `src/utils/api.ts` — `uploadMultipart()` helper, `createServerFromManagedUpload()`, `pushSourceToServer()`.
- `src/commands/deploy.ts` — early managed path (`deployViaManagedUpload`) that skips the GitHub-connection/`promptGitHubInstallation` step; `--managed` flag wired in `src/index.ts`.
- `src/commands/auth.ts` — `loginCommand({ deviceCode })` polls the token endpoint directly; `--device-code` wired in `src/index.ts`.

> Requires the matching backend support (managed `GithubInstallation` row + `managed=true` on the multipart create endpoint).

## Test plan
- [x] `vitest` unit tests for `packProjectTarball` (layout + exclusions) and `sanitizeRepoName`
- [x] `tsc --noEmit` passes
- [ ] End-to-end: `mcp-use login --device-code <code>` then `mcp-use deploy --managed -y --org <slug>` against a backend with `GITHUB_MANAGED_*` configured (via this PR's pkg.pr.new pre-release)