### PR TITLE
fix: iframe collapse when widget renders null

### DIFF
--- a/docs/typescript/server/widget-components/mcpuseprovider.mdx
+++ b/docs/typescript/server/widget-components/mcpuseprovider.mdx
@@ -95,6 +95,23 @@ Enable automatic height notifications for dynamic content:
 </McpUseProvider>
 ```
 
+<Tip>
+**Widgets that conditionally render `null`**: When `autoSize={true}` is enabled and your widget returns `null` (e.g., when there are no results to display), the iframe will automatically collapse to zero height. This allows hosts to properly hide empty widgets.
+
+```tsx
+function SearchWidget() {
+  const { props } = useWidget<{ results: string[] }>();
+  
+  // Widget collapses when no results
+  if (props.results?.length === 0) {
+    return null;
+  }
+  
+  return <div>{/* render results */}</div>;
+}
+```
+</Tip>
+
 ## Complete Example
 
 ```tsx

--- a/libraries/typescript/.changeset/fix-zero-height-notification.md
+++ b/libraries/typescript/.changeset/fix-zero-height-notification.md
@@ -1,0 +1,7 @@
+---
+"mcp-use": patch
+---
+
+Fix iframe collapse when widget renders null by allowing zero-height notifications
+
+Previously, the `height > 0` guard in `McpUseProvider` prevent height notifications when a widget rendered `null`, causing the iframe to persist at its last non-zero height. This fix allows zero heights to pass through unconditionally while maintaining the threshold check for positive heights, enabling proper iframe collapse for empty widgets.

--- a/libraries/typescript/packages/mcp-use/src/react/McpUseProvider.tsx
+++ b/libraries/typescript/packages/mcp-use/src/react/McpUseProvider.tsx
@@ -128,9 +128,9 @@ export function McpUseProvider({
         clearTimeout(debounceTimeoutRef.current);
       }
       debounceTimeoutRef.current = setTimeout(() => {
-        // Only notify if height changed by more than threshold and is positive
+        // Always notify zero height and for positive heights only notify if changed by more than threshold
         const heightDiff = Math.abs(height - lastHeightRef.current);
-        if (heightDiff >= MIN_HEIGHT_CHANGE_PX && height > 0) {
+        if (height === 0 || heightDiff >= MIN_HEIGHT_CHANGE_PX) {
           lastHeightRef.current = height;
           notifyHeight(height);
         }


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

Check all that apply:
- [x] TypeScript
- [ ] Python
- [x] Documentation only
- [ ] CI/CD or tooling

## Changes
Fixed iframe collapse issue when widgets render null.

## Review Readiness

Help maintainers review this quickly:

- [x] The PR is scoped to one issue or one clearly related change
- [x] The PR description explains the user-visible problem and the fix
- [x] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [x] I verified the affected package/docs path with the commands listed below
- [x] I checked for existing open PRs that already solve the same issue

## Implementation Details
Updated McpUseProvider.tsx height notification logic to always allow zero height values.

---

## TypeScript Checklist

### Packages Modified

Check all packages that were modified:
- [x] `docs`
- [ ] `tests`
- [ ] `cli`
- [ ] `create-mcp-use-app`
- [x] `mcp-use` (server)
- [ ] `mcp-use` (client)
- [ ] `inspector`

### Pre-commit Checklist

Ensure all of the following have been completed:
- [x] Ran `pnpm lint:fix` to auto-fix linting issues
- [x] Ran `pnpm format` to format code with Prettier
- [x] Ran `pnpm build` and build succeeds without errors
- [x] Ran `pnpm changeset` to create a changeset (if this PR includes user-facing changes)
- [ ] Added or updated tests if needed
- [x] Updated documentation in `docs/` folder if needed

## Documentation Updates
`docs/typescript/server/widget-components/mcpuseprovider.mdx` - added explaination that widgets returning `null` will automatically collapse the iframe when `autoSize={true}` is enabled.

## Testing
- existing unit tests
- build verification
- linting

## Related Issues

Closes #1692 