### PR TITLE
fix(typescript): stop inspector widget status label blocking iframe i…

### DIFF
--- a/libraries/typescript/.changeset/inspector-widget-status-pointer-events.md
+++ b/libraries/typescript/.changeset/inspector-widget-status-pointer-events.md
@@ -1,0 +1,15 @@
+---
+"@mcp-use/inspector": patch
+---
+
+fix(inspector): stop widget status labels from blocking iframe pointer events
+
+The MCP Apps preview pane rendered the invoking/invoked status label in an
+absolutely positioned wrapper with `h-full`, which intercepted hover, click,
+and form control interactions in a vertical strip along the left edge of the
+widget iframe for the entire lifetime of the panel.
+
+Apply `pointer-events-none`, drop the full-height wrapper, and align the Apps
+SDK status label with the same non-blocking behavior.
+
+Closes #1678

--- a/libraries/typescript/packages/inspector/src/client/components/MCPAppsRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/MCPAppsRenderer.tsx
@@ -1151,21 +1151,18 @@ function MCPAppsRendererBase({
               : { maxWidth: iframeStyle.maxWidth }
           }
         >
-          <div className="absolute -top-8 left-2 z-10 h-full">
-            {/* Status label above the widget — only in inline mode */}
-            {!isPip && !isFullscreen && (invoking || invoked) && (
-              <div className="whitespace-nowrap">
-                {invoking && !toolOutput && (
-                  <TextShimmer className="text-xs ">{invoking}</TextShimmer>
-                )}
-                {invoked && !!toolOutput && (
-                  <span className="text-xs text-muted-foreground">
-                    {invoked}
-                  </span>
-                )}
-              </div>
-            )}
-          </div>
+          {!isPip && !isFullscreen && (invoking || invoked) && (
+            <div className="absolute -top-8 left-2 z-10 whitespace-nowrap pointer-events-none">
+              {invoking && !toolOutput && (
+                <TextShimmer className="text-xs ">{invoking}</TextShimmer>
+              )}
+              {invoked && !!toolOutput && (
+                <span className="text-xs text-muted-foreground">
+                  {invoked}
+                </span>
+              )}
+            </div>
+          )}
           <SandboxedIframe
             ref={sandboxRef}
             html={widgetHtml}

--- a/libraries/typescript/packages/inspector/src/client/components/OpenAIComponentRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/OpenAIComponentRenderer.tsx
@@ -1104,7 +1104,7 @@ function OpenAIComponentRendererBase({
           )}
         >
           {displayMode === "inline" && (invoking || invoked) && (
-            <div className="absolute -top-8 left-2 z-10 whitespace-nowrap">
+            <div className="absolute -top-8 left-2 z-10 whitespace-nowrap pointer-events-none">
               {invoking && !toolResult && (
                 <TextShimmer className="text-xs">{invoking}</TextShimmer>
               )}

--- a/libraries/typescript/packages/mcp-use/examples/server/ui/mcp-apps/index.ts
+++ b/libraries/typescript/packages/mcp-use/examples/server/ui/mcp-apps/index.ts
@@ -126,86 +126,30 @@ server.tool(
   }
 );
 
-// Example 2: Simple greeting widget (programmatic, auto-exposed as tool)
-// NOTE: You can also create React widgets in resources/ directory like weather-display
-server.uiResource({
-  type: "mcpApps",
-  name: "greeting-card",
-  title: "Greeting Card",
-  description: "Shows a personalized greeting message",
-  props: {
-    name: {
-      type: "string",
-      required: true,
-      description: "Name to greet",
-    },
-    greeting: {
-      type: "string",
-      required: true,
-      description: "Greeting message",
+// Example 2: Simple greeting tool backed by a React widget in resources/
+server.tool(
+  {
+    name: "greeting-card",
+    description: "Shows a personalized greeting message",
+    schema: z.object({
+      name: z.string().describe("Name to greet"),
+      greeting: z.string().describe("Greeting message"),
+    }),
+    widget: {
+      name: "greeting-card",
+      invoking: "Creating greeting card...",
+      invoked: "Greeting card ready",
     },
   },
-  htmlTemplate: `
-    <!DOCTYPE html>
-    <html>
-    <head>
-      <meta charset="UTF-8">
-      <meta name="viewport" content="width=device-width, initial-scale=1.0">
-      <style>
-        body {
-          margin: 0;
-          padding: 20px;
-          font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-        }
-        .greeting-card {
-          background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
-          border-radius: 12px;
-          padding: 32px;
-          color: white;
-          text-align: center;
-          max-width: 400px;
-        }
-        .greeting {
-          font-size: 36px;
-          font-weight: 700;
-          margin-bottom: 16px;
-        }
-        .name {
-          font-size: 48px;
-          font-weight: 800;
-        }
-      </style>
-    </head>
-    <body>
-      <div class="greeting-card">
-        <div class="greeting" id="greeting">Hello</div>
-        <div class="name" id="name">World</div>
-      </div>
-      <script>
-        // Parse props from URL (for both protocols)
-        const params = new URLSearchParams(window.location.search);
-        const propsJson = params.get('props');
-        
-        if (propsJson) {
-          try {
-            const props = JSON.parse(propsJson);
-            document.getElementById('greeting').textContent = props.greeting || 'Hello';
-            document.getElementById('name').textContent = props.name || 'World';
-          } catch (e) {
-            console.error('Failed to parse props:', e);
-          }
-        }
-      </script>
-    </body>
-    </html>
-  `,
-  metadata: {
-    prefersBorder: true,
-    widgetDescription: "A colorful greeting card with personalized message",
-  },
-  // This widget is automatically exposed as a tool
-  exposeAsTool: true,
-});
+  async ({ name, greeting }) =>
+    widget({
+      props: {
+        name,
+        greeting,
+      },
+      message: `${greeting} ${name}`,
+    })
+);
 
 // Brand info tool (returns structured data)
 server.tool(
@@ -252,7 +196,7 @@ This server demonstrates dual-protocol widget support:
 Try these tools:
 - get-weather: Get weather for a city (uses weather-display widget)
 - get-weather-delayed: Test widget lifecycle with 5s delay (Issue #930)
-- greeting-display: Auto-exposed widget with props
+- greeting-card: Personalized greeting widget backed by a React resource
 - get-info: Learn about dual-protocol support
 
 To test Issue #930 fix:

--- a/libraries/typescript/packages/mcp-use/examples/server/ui/mcp-apps/resources/greeting-card/widget.tsx
+++ b/libraries/typescript/packages/mcp-use/examples/server/ui/mcp-apps/resources/greeting-card/widget.tsx
@@ -1,0 +1,67 @@
+import { McpUseProvider, useWidget, type WidgetMetadata } from "mcp-use/react";
+import React from "react";
+import { z } from "zod";
+import "../styles.css";
+
+const propSchema = z.object({
+  name: z.string().describe("Name to greet"),
+  greeting: z.string().describe("Greeting message"),
+});
+
+export const widgetMetadata: WidgetMetadata = {
+  description: "Display a personalized greeting message",
+  props: propSchema,
+  exposeAsTool: false,
+  metadata: {
+    prefersBorder: false,
+    widgetDescription: "A colorful greeting card with personalized message",
+  },
+  annotations: {
+    readOnlyHint: true,
+  },
+};
+
+type GreetingProps = z.infer<typeof propSchema>;
+
+const GreetingCard: React.FC = () => {
+  const { props, isPending } = useWidget<GreetingProps>();
+
+  return (
+    <McpUseProvider debugger viewControls autoSize>
+      <div className="flex items-center justify-center min-h-[260px] p-6 bg-zinc-900/5 dark:bg-zinc-950 transition-colors duration-300">
+        <div className="w-full max-w-[380px] rounded-lg border border-zinc-200/80 dark:border-zinc-800/80 bg-zinc-950 text-zinc-400 font-mono shadow-2xl overflow-hidden text-left">
+          {/* Header */}
+          <div className="px-4 py-2.5 bg-zinc-100 dark:bg-zinc-900 border-b border-zinc-200/80 dark:border-zinc-800/80 select-none">
+            <span className="text-[11px] font-semibold text-zinc-800 dark:text-zinc-200">
+              greeting-card
+            </span>
+          </div>
+
+          {/* Terminal Body */}
+          <div className="p-5 flex flex-col gap-1.5 bg-zinc-950">
+            {isPending ? (
+              <div className="flex flex-col gap-2">
+                <div className="flex items-center gap-2 text-xs text-zinc-500 animate-pulse">
+                  <span>Executing...</span>
+                </div>
+              </div>
+            ) : (
+              <>
+                {/* Greeting Line */}
+                <div className="text-lg font-bold text-zinc-100 leading-tight">
+                  {props.greeting}
+                </div>
+                {/* Name Line */}
+                <div className="text-lg font-bold text-zinc-100 leading-tight">
+                  {props.name}
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    </McpUseProvider>
+  );
+};
+
+export default GreetingCard;


### PR DESCRIPTION

# Pull Request Description

## Language / Project Scope

Check all that apply:
- [ x] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

Describe the changes introduced by this PR in a concise manner.

## Review Readiness

Help maintainers review this quickly:

- [ x ] The PR is scoped to one issue or one clearly related change
- [ x ] The PR description explains the user-visible problem and the fix
- [ x ] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [ ] I verified the affected package/docs path with the commands listed below
- [ ] I checked for existing open PRs that already solve the same issue

## Implementation Details

1. Add `pointer-events-none` to the status label wrapper in `MCPAppsRenderer.tsx`
2. Remove `h-full` so the overlay only covers the label text height (matches `OpenAIComponentRenderer`)
3. Conditionally render the wrapper only when `invoking` or `invoked` metadata is present

---

## TypeScript Checklist

> Complete this section if your PR includes TypeScript changes

### Packages Modified

Check all packages that were modified:
- [ ] `docs`
- [ ] `tests`
- [ ] `cli`
- [ ] `create-mcp-use-app`
- [ ] `mcp-use` (server)
- [ ] `mcp-use` (client)
- [ x] `inspector`

### Pre-commit Checklist

Ensure all of the following have been completed:
- [ x] Ran `pnpm lint:fix` to auto-fix linting issues
- [ x] Ran `pnpm format` to format code with Prettier
- [ x] Ran `pnpm build` and build succeeds without errors
- [ ] Ran `pnpm changeset` to create a changeset (if this PR includes user-facing changes)
- [ ] Added or updated tests if needed
- [ ] Updated documentation in `docs/` folder if needed

---

## Example Usage (Before)

```
Interactive elements in the left ~150–220px of the inspector widget preview were unclickable and did not show hover styles. Same widget worked correctly outside the inspector.

```

## Example Usage (After)

```
Status label still displays; pointer events reach the iframe. Left-column controls work in the preview pane.

```
## Testing

1. `mcp-use dev` → open inspector → invoke a widget tool
2. Hover/click elements on the left side of the preview (dropdowns, buttons, links)
3. In DevTools, confirm status wrapper has `pointer-events: none`

## Related Issues

Closes #1678 