### PR TITLE
Canary

### DIFF
--- a/docs/inspector/changelog.mdx
+++ b/docs/inspector/changelog.mdx
@@ -6,6 +6,14 @@ rss: true
 tag: "New"
 ---
 
+<Update label="v8.0.1" description="June 2026">
+  ## Widget status label pointer-events fix
+  Patch release paired with `mcp-use` v1.30.1  -  invoking/invoked labels in the MCP Apps preview pane no longer block iframe interactions.
+
+- **Fix**: MCP Apps preview status label used an absolutely positioned `h-full` wrapper that intercepted hover, click, and form controls along the left edge of the widget iframe; apply `pointer-events-none`, remove the full-height wrapper, and align the Apps SDK label in `OpenAIComponentRenderer` (`#1694`, `#1678`)
+- **Update**: Updated mcp-use to v1.30.1
+</Update>
+
 <Update label="v8.0.0" description="June 2026">
   ## mcp-use v1.30.0
   Major release paired with `mcp-use` v1.30.0  -  peer dependency moves to `>=1.30.0-canary.0`; no inspector-specific runtime changes.

--- a/docs/typescript/changelog/changelog.mdx
+++ b/docs/typescript/changelog/changelog.mdx
@@ -6,6 +6,20 @@ rss: true
 tag: "New"
 ---
 
+<Update label="v1.30.1" description="June 2026">
+  ## Deploy without GitHub, device-code login & widget iframe fixes
+  Patch release for `McpUseProvider` zero-height collapse; `@mcp-use/cli` minor adds tarball deploy without a user GitHub repo and non-interactive device-code login for web onboarding.
+
+- **Enhancement** (@mcp-use/cli): `mcp-use deploy --no-github` packs the local project into a tarball and uploads it to the platform-managed org so first deploy works without connecting GitHub; redeploys of a linked platform-managed server auto-detect from `connectedRepository.isManaged` (`#1691`)
+- **New** (@mcp-use/cli): `mcp-use login --device-code <code>` authenticates with a pre-approved OAuth device code for non-interactive flows (web onboarding), skipping the browser step (`#1691`)
+- **Fix**: `McpUseProvider` with `autoSize` now notifies zero height when a widget renders `null`, so host iframes collapse instead of keeping the last non-zero height (`#1693`)
+- **Fix** (@mcp-use/inspector): MCP Apps / Apps SDK status labels no longer intercept iframe pointer events  -  see inspector changelog (`#1694`, `#1678`)
+- **Documentation**: tip on `<McpUseProvider />` for widgets that conditionally return `null` with `autoSize`
+- **Documentation**: `deploy --no-github`, `login --device-code`, and dual deploy paths in the CLI reference and Manufact Cloud deployment guide
+- **Update**: Updated @mcp-use/inspector to v8.0.1
+- **Update**: Updated @mcp-use/cli to v3.4.0
+</Update>
+
 <Update label="v1.30.0" description="June 2026">
   <Frame>
     <img src="https://mcp-use.com/api/og/release?v=1.30.0&title=OpenAPI%20server%20generation%20%26%20MCP%20instructions&date=2026-06&lang=typescript" alt="Release 1.30.0" />

--- a/docs/typescript/changelog/changelog.mdx
+++ b/docs/typescript/changelog/changelog.mdx
@@ -8,11 +8,14 @@ tag: "New"
 
 <Update label="v1.30.1" description="June 2026">
   ## Deploy without GitHub, device-code login & widget iframe fixes
-  Patch release for `McpUseProvider` zero-height collapse; `@mcp-use/cli` minor adds tarball deploy without a user GitHub repo and non-interactive device-code login for web onboarding.
+  Patch release for `McpUseProvider` zero-height collapse, `useMcp` disconnect/reconnect race fixes, and clearer not-ready errors; `@mcp-use/cli` minor adds tarball deploy without a user GitHub repo and non-interactive device-code login for web onboarding.
 
 - **Enhancement** (@mcp-use/cli): `mcp-use deploy --no-github` packs the local project into a tarball and uploads it to the platform-managed org so first deploy works without connecting GitHub; redeploys of a linked platform-managed server auto-detect from `connectedRepository.isManaged` (`#1691`)
 - **New** (@mcp-use/cli): `mcp-use login --device-code <code>` authenticates with a pre-approved OAuth device code for non-interactive flows (web onboarding), skipping the browser step (`#1691`)
 - **Fix**: `McpUseProvider` with `autoSize` now notifies zero height when a widget renders `null`, so host iframes collapse instead of keeping the last non-zero height (`#1693`)
+- **Fix** (react): `useMcp` stale `disconnect()` after a URL change or a manual disconnect racing a reconnect no longer nulls `clientRef` or resets hook state to `discovering` when superseded by a newer `connect()` (`connectEpochRef`) — fixes "MCP client is not ready (current state: ready)" and similar races in the inspector and other embeds (`#1528`)
+- **Fix** (client): `BaseMCPClient.closeSession()` only deletes a session slot when it still references the closing session, so a parallel `createSession()` from a reconnect is not wiped — fixes "No active session found" on the next tool call after reconnect (`#1528`)
+- **Enhancement** (react): clearer "MCP client is not ready" errors via `formatMcpNotReadyReason`, distinguishing a missing client (`client disconnected`) from a non-ready state (`#1528`)
 - **Fix** (@mcp-use/inspector): MCP Apps / Apps SDK status labels no longer intercept iframe pointer events  -  see inspector changelog (`#1694`, `#1678`)
 - **Documentation**: tip on `<McpUseProvider />` for widgets that conditionally return `null` with `autoSize`
 - **Documentation**: `deploy --no-github`, `login --device-code`, and dual deploy paths in the CLI reference and Manufact Cloud deployment guide

--- a/docs/typescript/server/cli-reference.mdx
+++ b/docs/typescript/server/cli-reference.mdx
@@ -257,6 +257,7 @@ mcp-use deploy [options]
 
 | Option                  | Description                                                                          | Default        |
 | ----------------------- | ------------------------------------------------------------------------------------ | -------------- |
+| `--no-github`           | Pack and upload local source without connecting GitHub (platform-managed repo)        | false          |
 | `--name <name>`         | Custom deployment name                                                               | Auto-generated |
 | `--port <port>`         | Server port                                                                          | 3000           |
 | `--runtime <runtime>`   | Runtime: `node` or `python`                                                          | Auto-detected  |
@@ -276,6 +277,9 @@ mcp-use deploy [options]
 ```bash
 # Basic deployment
 mcp-use deploy
+
+# Deploy without connecting GitHub (uploads local source)
+mcp-use deploy --no-github
 
 # Deploy with custom name and open in browser
 mcp-use deploy --name my-server --open
@@ -300,6 +304,17 @@ mcp-use deploy --org manufact-inc --region EU --yes
 ```
 
 **Deployment Process:**
+
+**With `--no-github` (or a linked platform-managed server):**
+
+1. Packs the local project into a tarball and uploads it
+2. Creates or reuses a server in the platform-managed org
+3. Builds and deploys through the normal pipeline
+4. Returns deployment URLs (MCP endpoint and Inspector)
+
+Redeploys of a project already linked to a platform-managed server auto-detect the upload path — `--no-github` is only required on the first deploy.
+
+**Default (GitHub):**
 
 1. Checks if project is a GitHub repository
 2. Prompts to install GitHub App if needed
@@ -328,9 +343,23 @@ Starts an OAuth-style device code flow to authenticate with [Manufact Cloud](htt
 **Options:**
 
 - `--api-key <key>`  -  Skip the browser flow and save an API key directly. Intended for CI/CD.
+- `--device-code <code>`  -  Redeem a pre-approved OAuth device code without opening a browser. Used by the web onboarding flow and other non-interactive harnesses.
 - `--org <slug|id|name>`  -  Pick an organization up-front and skip the post-login prompt. Use this when running in agent harnesses or non-TTY environments where the interactive selection cannot be answered.
 
-**What happens:**
+**Examples:**
+
+```bash
+# Interactive browser login
+mcp-use login
+
+# Non-interactive login with a one-time device code (from web onboarding)
+mcp-use login --device-code ABC123
+
+# CI / agents — API key and org up front
+mcp-use login --api-key mcp_... --org my-org
+```
+
+**What happens (interactive login):**
 
 1. CLI generates a device code
 2. Opens browser to authentication page

--- a/docs/typescript/server/deployment/mcp-use.mdx
+++ b/docs/typescript/server/deployment/mcp-use.mdx
@@ -7,35 +7,69 @@ icon: "/images/logo-mcp-use.svg"
 Deploy your MCP server to **Manufact Cloud**, the recommended deployment platform for mcp-use servers. With a single command, you can deploy your server and get a production-ready URL.
 
 ## Prerequisites
-**mcp-use Account**: Sign up at [mcp-use.com](https://mcp-use.com) or login via CLI
+
+**Manufact Cloud account**: Sign up at [mcp-use.com](https://mcp-use.com) or log in via CLI:
+
+```bash
+mcp-use login
+```
+
+For non-interactive flows (web onboarding, agents), use a pre-approved device code:
+
+```bash
+mcp-use login --device-code <CODE>
+```
+
+See the [CLI reference](/typescript/server/cli-reference#login---authenticate-with-manufact-cloud) for `--api-key` and `--org` options.
 
 ## Quick Deployment
 
 Deploy your MCP server in one command:
 
-```bash 
+```bash
 # Install the CLI (if you are using create-mcp-use-app this step is not needed)
 npm install -g @mcp-use/cli
 
 # Login to Manufact Cloud
-npm run mcp-use login
+mcp-use login
 
 # Deploy your server
-npm run mcp-use deploy
+mcp-use deploy
 ```
-
 
 That's it! Your server will be built and deployed automatically.
 
+## Deploy Without GitHub
+
+You do not need a GitHub repository to deploy. Use `--no-github` to upload your local project source directly — the platform creates a managed repo and runs the normal build pipeline:
+
+```bash
+mcp-use deploy --no-github
+```
+
+This path:
+
+- ✅ Works without a git remote or GitHub App installation
+- ✅ Uploads your local files (not GitHub)
+- ✅ Creates the server in the platform-managed org
+- ✅ Supports redeploys — linked projects auto-detect the upload path, so `--no-github` is only needed on the first deploy
+
+You can later connect your own GitHub repository from the server dashboard ("Connect your GitHub") if you want push-to-deploy.
+
+<Tip>
+  Web onboarding uses `mcp-use login --device-code` followed by `mcp-use deploy --no-github -y` for a fully non-interactive first deploy.
+</Tip>
+
 ## GitHub Repository Deployment
 
-If your project is a GitHub repository, `mcp-use deploy` will automatically detect it and offer to deploy from GitHub:
+If your project is a GitHub repository, `mcp-use deploy` (without `--no-github`) automatically detects it and offers to deploy from GitHub:
 
 ```bash
 mcp-use deploy
 ```
 
 You'll see:
+
 ```
 GitHub repository detected:
   Repository: your-org/your-repo
@@ -46,11 +80,11 @@ Deploy from GitHub repository your-org/your-repo? (y/n):
 ```
 
 This approach:
+
 - ✅ Deploys directly from your GitHub repository
 - ✅ Automatically detects build and start commands
 - ✅ Uses the latest commit from your branch
-- ✅ No need to upload source code manually
-
+- ✅ Requires the mcp-use GitHub App on the repo and changes pushed to GitHub
 
 ## After Deployment
 
@@ -82,7 +116,6 @@ The `autoConnect` parameter and other Inspector URL options are documented in [I
 }
 ```
 
-
 ### Test Locally First
 
 Before deploying, test your server locally:
@@ -98,4 +131,5 @@ mcp-use start
 - [Deploying to Supabase](./supabase) - Alternative deployment option
 - [Configuration Guide](../configuration) - Advanced server configuration
 - [UI Widgets](../mcp-apps) - Building interactive widgets
+- [CLI Reference](/typescript/server/cli-reference#deploy---cloud-deployment) - All deploy and login flags
 - [API Reference](/typescript/server/index#mcpserver-api-reference) - Complete API documentation

--- a/docs/typescript/server/widget-components/mcpuseprovider.mdx
+++ b/docs/typescript/server/widget-components/mcpuseprovider.mdx
@@ -95,6 +95,23 @@ Enable automatic height notifications for dynamic content:
 </McpUseProvider>
 ```
 
+<Tip>
+**Widgets that conditionally render `null`**: When `autoSize={true}` is enabled and your widget returns `null` (e.g., when there are no results to display), the iframe will automatically collapse to zero height. This allows hosts to properly hide empty widgets.
+
+```tsx
+function SearchWidget() {
+  const { props } = useWidget<{ results: string[] }>();
+  
+  // Widget collapses when no results
+  if (props.results?.length === 0) {
+    return null;
+  }
+  
+  return <div>{/* render results */}</div>;
+}
+```
+</Tip>
+
 ## Complete Example
 
 ```tsx

--- a/docs/typescript/server/widget-components/usewidget.mdx
+++ b/docs/typescript/server/widget-components/usewidget.mdx
@@ -383,7 +383,7 @@ useEffect(() => {
 }, [content]);
 ```
 
-Or use `McpUseProvider` with `autoSize={true}` for automatic height notifications.
+Or use [`McpUseProvider`](./mcpuseprovider) with `autoSize={true}` for automatic height notifications — including zero-height collapse when your widget conditionally renders `null`.
 
 ### 5. State Management
 

--- a/libraries/typescript/.changeset/fix-zero-height-notification.md
+++ b/libraries/typescript/.changeset/fix-zero-height-notification.md
@@ -1,0 +1,7 @@
+---
+"mcp-use": patch
+---
+
+Fix iframe collapse when widget renders null by allowing zero-height notifications
+
+Previously, the `height > 0` guard in `McpUseProvider` prevent height notifications when a widget rendered `null`, causing the iframe to persist at its last non-zero height. This fix allows zero heights to pass through unconditionally while maintaining the threshold check for positive heights, enabling proper iframe collapse for empty widgets.

--- a/libraries/typescript/.changeset/inspector-widget-status-pointer-events.md
+++ b/libraries/typescript/.changeset/inspector-widget-status-pointer-events.md
@@ -1,0 +1,15 @@
+---
+"@mcp-use/inspector": patch
+---
+
+fix(inspector): stop widget status labels from blocking iframe pointer events
+
+The MCP Apps preview pane rendered the invoking/invoked status label in an
+absolutely positioned wrapper with `h-full`, which intercepted hover, click,
+and form control interactions in a vertical strip along the left edge of the
+widget iframe for the entire lifetime of the panel.
+
+Apply `pointer-events-none`, drop the full-height wrapper, and align the Apps
+SDK status label with the same non-blocking behavior.
+
+Closes #1678

--- a/libraries/typescript/.changeset/managed-deploy-cli.md
+++ b/libraries/typescript/.changeset/managed-deploy-cli.md
@@ -1,0 +1,7 @@
+---
+"@mcp-use/cli": minor
+---
+
+Add `mcp-use deploy --no-github` to deploy a local MCP server without connecting your own GitHub. The project source is packed into a tarball and uploaded; the server is created in the platform-managed org and deployed through the normal pipeline. Redeploys of a platform-managed project are auto-detected from the linked server, so `--no-github` is only needed on the first deploy.
+
+Also add `mcp-use login --device-code <code>` for non-interactive authentication with a pre-approved OAuth device code (used by the web onboarding flow), skipping the browser step.

--- a/libraries/typescript/.changeset/pre.json
+++ b/libraries/typescript/.changeset/pre.json
@@ -8,6 +8,7 @@
     "mcp-use": "1.30.0"
   },
   "changesets": [
+    "fix-zero-height-notification",
     "inspector-widget-status-pointer-events",
     "managed-deploy-cli"
   ]

--- a/libraries/typescript/.changeset/pre.json
+++ b/libraries/typescript/.changeset/pre.json
@@ -7,5 +7,7 @@
     "@mcp-use/inspector": "8.0.0",
     "mcp-use": "1.30.0"
   },
-  "changesets": []
+  "changesets": [
+    "managed-deploy-cli"
+  ]
 }

--- a/libraries/typescript/.changeset/pre.json
+++ b/libraries/typescript/.changeset/pre.json
@@ -1,0 +1,11 @@
+{
+  "mode": "pre",
+  "tag": "canary",
+  "initialVersions": {
+    "@mcp-use/cli": "3.3.2",
+    "create-mcp-use-app": "0.14.15",
+    "@mcp-use/inspector": "8.0.0",
+    "mcp-use": "1.30.0"
+  },
+  "changesets": []
+}

--- a/libraries/typescript/.changeset/pre.json
+++ b/libraries/typescript/.changeset/pre.json
@@ -8,6 +8,7 @@
     "mcp-use": "1.30.0"
   },
   "changesets": [
+    "inspector-widget-status-pointer-events",
     "managed-deploy-cli"
   ]
 }

--- a/libraries/typescript/.changeset/pre.json
+++ b/libraries/typescript/.changeset/pre.json
@@ -10,6 +10,7 @@
   "changesets": [
     "fix-zero-height-notification",
     "inspector-widget-status-pointer-events",
-    "managed-deploy-cli"
+    "managed-deploy-cli",
+    "usemcp-disconnect-url-race"
   ]
 }

--- a/libraries/typescript/.changeset/usemcp-disconnect-url-race.md
+++ b/libraries/typescript/.changeset/usemcp-disconnect-url-race.md
@@ -1,0 +1,30 @@
+---
+"mcp-use": patch
+---
+
+fix(react,client): prevent stale disconnect from wiping a reconnected MCP session
+
+When `useMcp` reconnects after a URL change (e.g. dashboard environment
+switch), the previous effect's async `disconnect()` could finish after the
+new `connect()` and either:
+
+1. set `clientRef` to null while React state remained `ready` — surfacing
+   as "MCP client is not ready (current state: ready)"; or
+2. wipe the freshly-created session out of the underlying client's session
+   map — surfacing as "No active session found" on the next tool call.
+
+`disconnect()` now only nulls `clientRef` **and** resets the hook state when
+it has not been superseded by a newer `connect()` (a `connectEpochRef` counter
+bumped at the start of each `connect()`, plus a client-identity check). This
+covers both the case where `connect()` reuses the same `BrowserMCPClient`
+instance for the new URL and a manual `disconnect()` racing a reconnect, which
+must not clobber the live connection's state back to `discovering`.
+
+`BaseMCPClient.closeSession()` now only deletes `sessions[name]` if the slot
+still references the captured session. A parallel `createSession()` from a
+newer `connect()` may have already written a new session there while we were
+awaiting `session.disconnect()`; the previous unconditional `delete` in the
+`finally` block would wipe that new session and break tool calls.
+
+MCP operation errors also distinguish a missing client from a non-ready
+state.

--- a/libraries/typescript/packages/cli/CHANGELOG.md
+++ b/libraries/typescript/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @mcp-use/cli
 
+## 3.4.0-canary.2
+
+### Patch Changes
+
+- Updated dependencies [8c00a55]
+  - mcp-use@1.30.1-canary.2
+  - @mcp-use/inspector@8.0.1-canary.2
+
 ## 3.4.0-canary.1
 
 ### Patch Changes

--- a/libraries/typescript/packages/cli/CHANGELOG.md
+++ b/libraries/typescript/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @mcp-use/cli
 
+## 3.4.0-canary.3
+
+### Patch Changes
+
+- Updated dependencies [ea4e6f1]
+  - mcp-use@1.30.1-canary.3
+  - @mcp-use/inspector@8.0.1-canary.3
+
 ## 3.4.0-canary.2
 
 ### Patch Changes

--- a/libraries/typescript/packages/cli/CHANGELOG.md
+++ b/libraries/typescript/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @mcp-use/cli
 
+## 3.4.0-canary.1
+
+### Patch Changes
+
+- Updated dependencies [afb0e79]
+  - @mcp-use/inspector@8.0.1-canary.1
+  - mcp-use@1.30.1-canary.1
+
 ## 3.4.0-canary.0
 
 ### Minor Changes

--- a/libraries/typescript/packages/cli/CHANGELOG.md
+++ b/libraries/typescript/packages/cli/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @mcp-use/cli
 
+## 3.4.0-canary.0
+
+### Minor Changes
+
+- bad4578: Add `mcp-use deploy --no-github` to deploy a local MCP server without connecting your own GitHub. The project source is packed into a tarball and uploaded; the server is created in the platform-managed org and deployed through the normal pipeline. Redeploys of a platform-managed project are auto-detected from the linked server, so `--no-github` is only needed on the first deploy.
+
+  Also add `mcp-use login --device-code <code>` for non-interactive authentication with a pre-approved OAuth device code (used by the web onboarding flow), skipping the browser step.
+
+### Patch Changes
+
+- mcp-use@1.30.1-canary.0
+- @mcp-use/inspector@8.0.1-canary.0
+
 ## 3.3.2
 
 ### Patch Changes

--- a/libraries/typescript/packages/cli/README.md
+++ b/libraries/typescript/packages/cli/README.md
@@ -125,6 +125,9 @@ Deploy your MCP server to production via [manufact.com](https://manufact.com):
 # Login to Manufact cloud
 mcp-use login
 
+# Non-interactive login with a pre-approved device code (web onboarding, agents)
+mcp-use login --device-code <code>
+
 # Non-interactive login (for agents / CI) — picks an org without prompting
 mcp-use login --org <slug|id|name>
 
@@ -140,6 +143,7 @@ mcp-use logout
 
 **Deploy Options:**
 
+- `--no-github` - Upload local source without connecting GitHub (platform-managed repo)
 - `--name <name>` - Custom deployment name
 - `--port <port>` - Server port (default: 3000)
 - `--runtime <runtime>` - Runtime environment: "node" or "python"
@@ -148,8 +152,11 @@ mcp-use logout
 **Example:**
 
 ```bash
-# Basic deployment
+# Basic deployment (from GitHub when configured)
 mcp-use deploy
+
+# Deploy without GitHub — uploads local source
+mcp-use deploy --no-github
 
 # Deploy with custom options
 mcp-use deploy --name my-server --port 8000 --open

--- a/libraries/typescript/packages/cli/package.json
+++ b/libraries/typescript/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-use/cli",
   "type": "module",
-  "version": "3.4.0-canary.0",
+  "version": "3.4.0-canary.1",
   "description": "The mcp-use CLI is a tool for building and deploying MCP servers with support for ChatGPT Apps, Code Mode, OAuth, Notifications, Sampling, Observability and more.",
   "author": "mcp-use, Inc.",
   "license": "MIT",

--- a/libraries/typescript/packages/cli/package.json
+++ b/libraries/typescript/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-use/cli",
   "type": "module",
-  "version": "3.4.0-canary.1",
+  "version": "3.4.0-canary.2",
   "description": "The mcp-use CLI is a tool for building and deploying MCP servers with support for ChatGPT Apps, Code Mode, OAuth, Notifications, Sampling, Observability and more.",
   "author": "mcp-use, Inc.",
   "license": "MIT",

--- a/libraries/typescript/packages/cli/package.json
+++ b/libraries/typescript/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-use/cli",
   "type": "module",
-  "version": "3.3.2",
+  "version": "3.4.0-canary.0",
   "description": "The mcp-use CLI is a tool for building and deploying MCP servers with support for ChatGPT Apps, Code Mode, OAuth, Notifications, Sampling, Observability and more.",
   "author": "mcp-use, Inc.",
   "license": "MIT",

--- a/libraries/typescript/packages/cli/package.json
+++ b/libraries/typescript/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-use/cli",
   "type": "module",
-  "version": "3.4.0-canary.2",
+  "version": "3.4.0-canary.3",
   "description": "The mcp-use CLI is a tool for building and deploying MCP servers with support for ChatGPT Apps, Code Mode, OAuth, Notifications, Sampling, Observability and more.",
   "author": "mcp-use, Inc.",
   "license": "MIT",

--- a/libraries/typescript/packages/cli/src/commands/auth.ts
+++ b/libraries/typescript/packages/cli/src/commands/auth.ts
@@ -181,6 +181,13 @@ export async function loginCommand(options?: {
   silent?: boolean;
   apiKey?: string;
   org?: string;
+  /**
+   * A pre-approved OAuth device code (RFC 8628). When provided, skip requesting
+   * a new code + opening a browser and poll the token endpoint directly. Used by
+   * the web onboarding flow, which creates and approves the code, then embeds it
+   * in the agent's prompt.
+   */
+  deviceCode?: string;
 }): Promise<void> {
   try {
     const directKey = options?.apiKey || process.env.MCP_USE_API_KEY;
@@ -203,7 +210,9 @@ export async function loginCommand(options?: {
       return;
     }
 
-    if (await isLoggedIn()) {
+    // A provided device code means an explicit (re)login as that account —
+    // bypass the "already logged in" short-circuit and authenticate with it.
+    if (!options?.deviceCode && (await isLoggedIn())) {
       let needsReauth = false;
       try {
         await (await McpUseAPI.create()).testAuth();
@@ -241,36 +250,44 @@ export async function loginCommand(options?: {
 
     const authBaseUrl = await getAuthBaseUrl();
 
-    const deviceResp = await requestDeviceCode(authBaseUrl);
-    const {
-      device_code,
-      user_code,
-      verification_uri,
-      verification_uri_complete,
-      interval,
-    } = deviceResp;
+    let device_code: string;
+    let interval: number;
 
-    const displayCode =
-      user_code.length === 8
-        ? `${user_code.slice(0, 4)}-${user_code.slice(4)}`
-        : user_code;
+    if (options?.deviceCode) {
+      // Pre-approved device code (from the web onboarding flow): no browser, no
+      // user code prompt — just poll the token endpoint until it's redeemed.
+      device_code = options.deviceCode.trim();
+      interval = 2;
+      console.log(chalk.gray("  Authenticating with provided device code..."));
+    } else {
+      const deviceResp = await requestDeviceCode(authBaseUrl);
+      device_code = deviceResp.device_code;
+      interval = deviceResp.interval || 5;
 
-    console.log(chalk.white("  Visit: ") + chalk.cyan(verification_uri));
-    console.log(chalk.white("  Code:  ") + chalk.bold.white(displayCode));
-    console.log();
+      const { user_code, verification_uri, verification_uri_complete } =
+        deviceResp;
+      const displayCode =
+        user_code.length === 8
+          ? `${user_code.slice(0, 4)}-${user_code.slice(4)}`
+          : user_code;
 
-    const urlToOpen = verification_uri_complete || verification_uri;
-    try {
-      await open(urlToOpen);
-      console.log(chalk.gray("  Browser opened. Waiting for approval..."));
-    } catch {
-      console.log(chalk.gray("  Open the URL above in your browser."));
+      console.log(chalk.white("  Visit: ") + chalk.cyan(verification_uri));
+      console.log(chalk.white("  Code:  ") + chalk.bold.white(displayCode));
+      console.log();
+
+      const urlToOpen = verification_uri_complete || verification_uri;
+      try {
+        await open(urlToOpen);
+        console.log(chalk.gray("  Browser opened. Waiting for approval..."));
+      } catch {
+        console.log(chalk.gray("  Open the URL above in your browser."));
+      }
     }
 
     const accessToken = await pollForDeviceToken(
       authBaseUrl,
       device_code,
-      interval || 5
+      interval
     );
 
     console.log(chalk.gray("\n  Creating persistent API key..."));

--- a/libraries/typescript/packages/cli/src/commands/deploy.ts
+++ b/libraries/typescript/packages/cli/src/commands/deploy.ts
@@ -25,6 +25,7 @@ import {
 } from "../utils/git.js";
 import { getMcpServerUrl } from "../utils/cloud-urls.js";
 import { getProjectLink, saveProjectLink } from "../utils/project-link.js";
+import { packProjectTarball, sanitizeRepoName } from "../utils/tarball.js";
 import {
   loginCommand,
   promptOrgSelection,
@@ -194,6 +195,11 @@ interface DeployOptions {
   region?: "US" | "EU" | "APAC";
   buildCommand?: string;
   startCommand?: string;
+  /**
+   * Upload local source without connecting the user's GitHub. Uses the
+   * platform-managed org and a tarball instead of pushing to a user repo.
+   */
+  noGithub?: boolean;
 }
 
 async function isMcpProject(cwd: string = process.cwd()): Promise<boolean> {
@@ -678,6 +684,130 @@ async function promptGitHubInstallation(
 }
 
 // ---------------------------------------------------------------------------
+// Managed deploy (no user GitHub) — upload local source as a tarball
+// ---------------------------------------------------------------------------
+
+/**
+ * Deploy the local project directly via the platform-managed GitHub org. No
+ * user GitHub connection, no git remote — the source is packed into a tarball
+ * and uploaded. Reuses the project link for redeploys (push source + redeploy).
+ */
+async function deployViaManagedUpload(
+  api: McpUseAPI,
+  options: DeployOptions,
+  ctx: { cwd: string; organizationId: string }
+): Promise<void> {
+  const { cwd, organizationId } = ctx;
+  const projectDir = options.rootDir ? path.resolve(cwd, options.rootDir) : cwd;
+
+  try {
+    await fs.access(projectDir);
+  } catch {
+    console.log(chalk.red(`✗ Project directory not found: ${projectDir}`));
+    process.exit(1);
+  }
+
+  const isMcp = await isMcpProject(projectDir);
+  if (!isMcp && !options.yes) {
+    console.log(
+      chalk.yellow("⚠️  This doesn't look like an MCP server project.")
+    );
+    const shouldContinue = await prompt(
+      chalk.white("Continue anyway? (y/n): ")
+    );
+    if (!shouldContinue) process.exit(0);
+    console.log();
+  }
+
+  const envVars = await buildEnvVars(options);
+  const branch = "main";
+  const projectName = options.name || (await getProjectName(projectDir));
+
+  console.log(chalk.gray("Packaging project source..."));
+  const tarball = await packProjectTarball(projectDir);
+  console.log(
+    chalk.gray(
+      `  Archive size: ${(tarball.length / 1024 / 1024).toFixed(2)} MB`
+    )
+  );
+  if (tarball.length > 80 * 1024 * 1024) {
+    console.log(
+      chalk.red(
+        "✗ Project archive exceeds 80 MB. Add large/derived files to .gitignore and retry."
+      )
+    );
+    process.exit(1);
+  }
+
+  // Redeploy an existing managed server when linked (keeps the same URL).
+  const existingLink = !options.new ? await getProjectLink(cwd) : null;
+  let serverId = existingLink?.serverId;
+  if (serverId) {
+    try {
+      const linked = await api.getServer(serverId);
+      if (linked.organizationId !== organizationId) serverId = undefined;
+    } catch {
+      serverId = undefined;
+    }
+  }
+
+  let deploymentId: string | undefined;
+
+  if (serverId) {
+    console.log(chalk.gray("Uploading source and redeploying..."));
+    if (Object.keys(envVars).length > 0) {
+      await syncEnvVarsToServer(api, serverId, envVars);
+    }
+    await api.pushSourceToServer(serverId, {
+      tarball,
+      branch,
+      commitMessage: "Redeploy from mcp-use CLI",
+    });
+    const dep = await api.createDeployment({
+      serverId,
+      branch,
+      trigger: "redeploy",
+    });
+    deploymentId = dep.id;
+    await saveProjectLink(cwd, {
+      deploymentId: dep.id,
+      deploymentName: projectName,
+      serverId,
+      linkedAt: new Date().toISOString(),
+    });
+  } else {
+    console.log(chalk.gray("Uploading source (no GitHub required)..."));
+    const result = await api.createServerFromManagedUpload({
+      organizationId,
+      name: projectName,
+      repoName: sanitizeRepoName(projectName),
+      tarball,
+      branch,
+      commitMessage: "Deploy from mcp-use CLI",
+      port: options.port,
+      env: Object.keys(envVars).length > 0 ? envVars : undefined,
+    });
+    deploymentId = result.deploymentId ?? undefined;
+    if (result.server?.id && deploymentId) {
+      await saveProjectLink(cwd, {
+        deploymentId,
+        deploymentName: projectName,
+        serverId: result.server.id,
+        linkedAt: new Date().toISOString(),
+      });
+    }
+  }
+
+  if (!deploymentId) {
+    console.log(chalk.red("✗ No deployment was created."));
+    process.exit(1);
+  }
+
+  console.log(chalk.green("✓ Deployment created: ") + chalk.gray(deploymentId));
+  await displayDeploymentProgress(api, deploymentId, { yes: options.yes });
+}
+
+// ---------------------------------------------------------------------------
 // Main deploy command
 // ---------------------------------------------------------------------------
 
@@ -810,6 +940,28 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
     api = await ensureApiSessionForDeploy(api, options, resolvedOrgId);
 
     console.log(chalk.cyan.bold("\n🚀 Deploying to Manufact cloud...\n"));
+
+    // ── No-GitHub deploy: upload local source via platform-managed org ──
+    // Explicit via --no-github, or auto-detected when redeploying a project
+    // already linked to a platform-managed server (--no-github not needed again).
+    let useNoGithubDeploy = !!options.noGithub;
+    if (!useNoGithubDeploy && !options.new) {
+      const link = await getProjectLink(cwd);
+      if (link?.serverId) {
+        try {
+          const linked = await api.getServer(link.serverId);
+          if (linked.connectedRepository?.isManaged) useNoGithubDeploy = true;
+        } catch {
+          // Server gone / inaccessible — fall through to the normal flow.
+        }
+      }
+    }
+    if (useNoGithubDeploy) {
+      const organizationId =
+        resolvedOrgId ?? (await api.resolveOrganizationId());
+      await deployViaManagedUpload(api, options, { cwd, organizationId });
+      return;
+    }
 
     // ── Step 3: GitHub connection ─────────────────────────────────
     const reauth = () => promptReauthenticateOn401(options, resolvedOrgId);

--- a/libraries/typescript/packages/cli/src/index.ts
+++ b/libraries/typescript/packages/cli/src/index.ts
@@ -2964,18 +2964,28 @@ program
     "Login with an API key directly (non-interactive, for CI/CD)"
   )
   .option("--org <slug|id|name>", "Select an organization non-interactively")
-  .action(async (opts: { apiKey?: string; org?: string }) => {
-    try {
-      await loginCommand({ apiKey: opts.apiKey, org: opts.org });
-      process.exit(0);
-    } catch (error) {
-      console.error(
-        chalk.red.bold("\n✗ Login failed:"),
-        chalk.red(error instanceof Error ? error.message : "Unknown error")
-      );
-      process.exit(1);
+  .option(
+    "--device-code <code>",
+    "Authenticate with a pre-approved device code (non-interactive; e.g. from the web onboarding flow)"
+  )
+  .action(
+    async (opts: { apiKey?: string; org?: string; deviceCode?: string }) => {
+      try {
+        await loginCommand({
+          apiKey: opts.apiKey,
+          org: opts.org,
+          deviceCode: opts.deviceCode,
+        });
+        process.exit(0);
+      } catch (error) {
+        console.error(
+          chalk.red.bold("\n✗ Login failed:"),
+          chalk.red(error instanceof Error ? error.message : "Unknown error")
+        );
+        process.exit(1);
+      }
     }
-  });
+  );
 
 program
   .command("logout")
@@ -3050,6 +3060,10 @@ program
     "--start-command <cmd>",
     "Custom start command (overrides auto-detection)"
   )
+  .option(
+    "--no-github",
+    "Upload local source without connecting GitHub (repo hosted in the platform-managed org)"
+  )
   .action(async (options) => {
     await deployCommand({
       open: options.open,
@@ -3065,6 +3079,7 @@ program
       region: options.region,
       buildCommand: options.buildCommand,
       startCommand: options.startCommand,
+      noGithub: options.github === false,
     });
   });
 

--- a/libraries/typescript/packages/cli/src/utils/api.ts
+++ b/libraries/typescript/packages/cli/src/utils/api.ts
@@ -79,6 +79,8 @@ interface CloudServerConnectedRepository {
   repoFullName: string;
   productionBranch: string;
   isActive: boolean;
+  /** True when deployed via the platform-managed org (no user GitHub). */
+  isManaged?: boolean;
   userId: string;
   githubInstallationId: string;
   createdAt: string;
@@ -442,6 +444,100 @@ export class McpUseAPI {
       method: "POST",
       body: JSON.stringify(body),
     });
+  }
+
+  /** Multipart helper: POST/PUT a tarball + fields without the JSON Content-Type. */
+  private async uploadMultipart<T>(
+    endpoint: string,
+    form: FormData,
+    timeout = 120000
+  ): Promise<T> {
+    const url = `${this.baseUrl}${endpoint}`;
+    const headers: Record<string, string> = {
+      "x-mcp-creation-location": "cli",
+    };
+    if (this.apiKey) headers["x-api-key"] = this.apiKey;
+    if (this.orgId) headers["x-profile-id"] = this.orgId;
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeout);
+    try {
+      const response = await fetch(url, {
+        method: "POST",
+        headers,
+        body: form,
+        signal: controller.signal,
+      });
+      clearTimeout(timeoutId);
+      if (response.status === 401) throw new ApiUnauthorizedError();
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`API request failed: ${response.status} ${errorText}`);
+      }
+      return response.json() as Promise<T>;
+    } catch (error: any) {
+      clearTimeout(timeoutId);
+      if (error.name === "AbortError") {
+        throw new Error(`Request timeout after ${timeout / 1000}s.`);
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Create a server from a source tarball deployed into the platform-managed
+   * GitHub org (no user GitHub connection required).
+   */
+  async createServerFromManagedUpload(input: {
+    organizationId: string;
+    name: string;
+    repoName: string;
+    tarball: Buffer;
+    branch?: string;
+    commitMessage?: string;
+    port?: number;
+    env?: Record<string, string>;
+  }): Promise<CreateServerResponse> {
+    const form = new FormData();
+    form.set(
+      "sourceFile",
+      new Blob([new Uint8Array(input.tarball)], { type: "application/gzip" }),
+      "source.tar.gz"
+    );
+    form.set("organizationId", input.organizationId);
+    form.set("managed", "true");
+    form.set("name", input.name);
+    form.set("repoName", input.repoName);
+    form.set("private", "true");
+    form.set("branch", input.branch ?? "main");
+    form.set("commitMessage", input.commitMessage ?? "Deploy from mcp-use CLI");
+    if (input.port != null) form.set("port", String(input.port));
+    if (input.env && Object.keys(input.env).length > 0) {
+      form.set("env", JSON.stringify(input.env));
+    }
+    return this.uploadMultipart<CreateServerResponse>("/servers", form);
+  }
+
+  /** Push a new source tarball as a commit on an existing server's repo. */
+  async pushSourceToServer(
+    serverId: string,
+    input: { tarball: Buffer; branch?: string; commitMessage?: string }
+  ): Promise<{ commitSha: string; repoFullName: string; branch: string }> {
+    const form = new FormData();
+    form.set(
+      "sourceFile",
+      new Blob([new Uint8Array(input.tarball)], { type: "application/gzip" }),
+      "source.tar.gz"
+    );
+    form.set("branch", input.branch ?? "main");
+    form.set(
+      "commitMessage",
+      input.commitMessage ?? "Redeploy from mcp-use CLI"
+    );
+    return this.uploadMultipart(
+      `/servers/${encodeURIComponent(serverId)}/source`,
+      form
+    );
   }
 
   async listServers(params?: {

--- a/libraries/typescript/packages/cli/src/utils/tarball.ts
+++ b/libraries/typescript/packages/cli/src/utils/tarball.ts
@@ -1,0 +1,67 @@
+import { create } from "tar";
+import type { Readable } from "node:stream";
+
+/**
+ * Directories never worth uploading (build output, deps, VCS, local state).
+ */
+const EXCLUDE_DIRS = new Set([
+  ".git",
+  "node_modules",
+  "dist",
+  "build",
+  ".next",
+  ".turbo",
+  ".vercel",
+  ".cache",
+  "coverage",
+  ".mcp-use",
+]);
+
+/**
+ * Pack a project directory into a gzip tarball for upload to the cloud
+ * `POST /servers` (managed) / `POST /servers/:id/source` endpoints.
+ *
+ * Every entry is nested under a single wrapper directory (`prefix`) because the
+ * backend's extractor strips the first path segment (it expects GitHub's
+ * `owner-repo-sha/` tarball layout). Secrets (`.env*`) and heavy/derived
+ * directories are excluded.
+ */
+export async function packProjectTarball(
+  projectDir: string,
+  prefix = "app"
+): Promise<Buffer> {
+  const stream = create(
+    {
+      gzip: true,
+      cwd: projectDir,
+      prefix,
+      portable: true,
+      filter: (entryPath: string) => {
+        const segments = entryPath.split(/[/\\]/).filter((s) => s && s !== ".");
+        if (segments.some((seg) => EXCLUDE_DIRS.has(seg))) return false;
+        const base = segments[segments.length - 1] ?? "";
+        if (base === ".DS_Store") return false;
+        // Never ship local secrets; env vars are passed explicitly via --env.
+        if (base === ".env" || base.startsWith(".env.")) return false;
+        return true;
+      },
+    },
+    ["."]
+  ) as unknown as Readable;
+
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(Buffer.from(chunk as Buffer));
+  }
+  return Buffer.concat(chunks);
+}
+
+/** Coerce an arbitrary project name into a valid GitHub repo name. */
+export function sanitizeRepoName(name: string): string {
+  const cleaned = name
+    .trim()
+    .replace(/[^a-zA-Z0-9._-]+/g, "-")
+    .replace(/^[-.]+|[-.]+$/g, "")
+    .slice(0, 80);
+  return cleaned || "mcp-server";
+}

--- a/libraries/typescript/packages/cli/tests/tarball.test.ts
+++ b/libraries/typescript/packages/cli/tests/tarball.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { list } from "tar";
+import { packProjectTarball, sanitizeRepoName } from "../src/utils/tarball.js";
+
+describe("sanitizeRepoName", () => {
+  it("keeps already-valid names", () => {
+    expect(sanitizeRepoName("my-mcp.server_1")).toBe("my-mcp.server_1");
+  });
+
+  it("replaces invalid characters with dashes", () => {
+    expect(sanitizeRepoName("@scope/My Cool App!")).toBe("scope-My-Cool-App");
+  });
+
+  it("trims leading/trailing separators and caps length", () => {
+    expect(sanitizeRepoName("---weird---")).toBe("weird");
+    expect(sanitizeRepoName("a".repeat(200)).length).toBe(80);
+  });
+
+  it("falls back to a default when empty", () => {
+    expect(sanitizeRepoName("@#$%")).toBe("mcp-server");
+  });
+});
+
+describe("packProjectTarball", () => {
+  it("nests entries under a prefix and excludes deps/build/secrets", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "tarball-test-"));
+    try {
+      await writeFile(join(dir, "package.json"), '{"name":"demo"}');
+      await mkdir(join(dir, "src"), { recursive: true });
+      await writeFile(join(dir, "src", "index.ts"), "export const x = 1;");
+      await writeFile(join(dir, ".env"), "SECRET=should-not-ship");
+      await mkdir(join(dir, "node_modules", "left-pad"), { recursive: true });
+      await writeFile(join(dir, "node_modules", "left-pad", "index.js"), "//");
+      await mkdir(join(dir, "dist"), { recursive: true });
+      await writeFile(join(dir, "dist", "index.js"), "//");
+
+      const buf = await packProjectTarball(dir, "app");
+      expect(buf.length).toBeGreaterThan(0);
+
+      // Re-read the archive entries to assert layout + exclusions.
+      const archivePath = join(dir, "out.tgz");
+      await writeFile(archivePath, buf);
+      const found: string[] = [];
+      await list({ file: archivePath, onentry: (e) => found.push(e.path) });
+
+      const normalized = found.map((p) => p.replace(/\/$/, ""));
+      expect(normalized).toContain("app/package.json");
+      expect(normalized).toContain("app/src/index.ts");
+      expect(normalized.some((p) => p.includes("node_modules"))).toBe(false);
+      expect(normalized.some((p) => p.startsWith("app/dist"))).toBe(false);
+      expect(normalized.some((p) => p.endsWith(".env"))).toBe(false);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/libraries/typescript/packages/inspector/CHANGELOG.md
+++ b/libraries/typescript/packages/inspector/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @mcp-use/inspector
 
+## 8.0.1-canary.1
+
+### Patch Changes
+
+- afb0e79: fix(inspector): stop widget status labels from blocking iframe pointer events
+
+  The MCP Apps preview pane rendered the invoking/invoked status label in an
+  absolutely positioned wrapper with `h-full`, which intercepted hover, click,
+  and form control interactions in a vertical strip along the left edge of the
+  widget iframe for the entire lifetime of the panel.
+
+  Apply `pointer-events-none`, drop the full-height wrapper, and align the Apps
+  SDK status label with the same non-blocking behavior.
+
+  Closes #1678
+  - mcp-use@1.30.1-canary.1
+
 ## 8.0.1-canary.0
 
 ### Patch Changes

--- a/libraries/typescript/packages/inspector/CHANGELOG.md
+++ b/libraries/typescript/packages/inspector/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @mcp-use/inspector
 
+## 8.0.1-canary.0
+
+### Patch Changes
+
+- mcp-use@1.30.1-canary.0
+
 ## 8.0.0
 
 ### Patch Changes

--- a/libraries/typescript/packages/inspector/CHANGELOG.md
+++ b/libraries/typescript/packages/inspector/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @mcp-use/inspector
 
+## 8.0.1-canary.2
+
+### Patch Changes
+
+- Updated dependencies [8c00a55]
+  - mcp-use@1.30.1-canary.2
+
 ## 8.0.1-canary.1
 
 ### Patch Changes

--- a/libraries/typescript/packages/inspector/CHANGELOG.md
+++ b/libraries/typescript/packages/inspector/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @mcp-use/inspector
 
+## 8.0.1-canary.3
+
+### Patch Changes
+
+- Updated dependencies [ea4e6f1]
+  - mcp-use@1.30.1-canary.3
+
 ## 8.0.1-canary.2
 
 ### Patch Changes

--- a/libraries/typescript/packages/inspector/package.json
+++ b/libraries/typescript/packages/inspector/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-use/inspector",
   "type": "module",
-  "version": "8.0.1-canary.2",
+  "version": "8.0.1-canary.3",
   "description": "MCP Inspector - A tool for inspecting and debugging MCP servers",
   "author": "",
   "license": "MIT",

--- a/libraries/typescript/packages/inspector/package.json
+++ b/libraries/typescript/packages/inspector/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-use/inspector",
   "type": "module",
-  "version": "8.0.0",
+  "version": "8.0.1-canary.0",
   "description": "MCP Inspector - A tool for inspecting and debugging MCP servers",
   "author": "",
   "license": "MIT",
@@ -80,7 +80,7 @@
   },
   "peerDependencies": {
     "express": "^4.21.2 || ^5.0.0",
-    "mcp-use": ">=1.30.0-canary.0",
+    "mcp-use": ">=1.30.1-canary.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
     "react-router": "^7.12.0"

--- a/libraries/typescript/packages/inspector/package.json
+++ b/libraries/typescript/packages/inspector/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-use/inspector",
   "type": "module",
-  "version": "8.0.1-canary.1",
+  "version": "8.0.1-canary.2",
   "description": "MCP Inspector - A tool for inspecting and debugging MCP servers",
   "author": "",
   "license": "MIT",

--- a/libraries/typescript/packages/inspector/package.json
+++ b/libraries/typescript/packages/inspector/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-use/inspector",
   "type": "module",
-  "version": "8.0.1-canary.0",
+  "version": "8.0.1-canary.1",
   "description": "MCP Inspector - A tool for inspecting and debugging MCP servers",
   "author": "",
   "license": "MIT",

--- a/libraries/typescript/packages/inspector/src/client/components/MCPAppsRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/MCPAppsRenderer.tsx
@@ -1157,9 +1157,7 @@ function MCPAppsRendererBase({
                 <TextShimmer className="text-xs ">{invoking}</TextShimmer>
               )}
               {invoked && !!toolOutput && (
-                <span className="text-xs text-muted-foreground">
-                  {invoked}
-                </span>
+                <span className="text-xs text-muted-foreground">{invoked}</span>
               )}
             </div>
           )}

--- a/libraries/typescript/packages/inspector/src/client/components/MCPAppsRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/MCPAppsRenderer.tsx
@@ -1151,21 +1151,18 @@ function MCPAppsRendererBase({
               : { maxWidth: iframeStyle.maxWidth }
           }
         >
-          <div className="absolute -top-8 left-2 z-10 h-full">
-            {/* Status label above the widget — only in inline mode */}
-            {!isPip && !isFullscreen && (invoking || invoked) && (
-              <div className="whitespace-nowrap">
-                {invoking && !toolOutput && (
-                  <TextShimmer className="text-xs ">{invoking}</TextShimmer>
-                )}
-                {invoked && !!toolOutput && (
-                  <span className="text-xs text-muted-foreground">
-                    {invoked}
-                  </span>
-                )}
-              </div>
-            )}
-          </div>
+          {!isPip && !isFullscreen && (invoking || invoked) && (
+            <div className="absolute -top-8 left-2 z-10 whitespace-nowrap pointer-events-none">
+              {invoking && !toolOutput && (
+                <TextShimmer className="text-xs ">{invoking}</TextShimmer>
+              )}
+              {invoked && !!toolOutput && (
+                <span className="text-xs text-muted-foreground">
+                  {invoked}
+                </span>
+              )}
+            </div>
+          )}
           <SandboxedIframe
             ref={sandboxRef}
             html={widgetHtml}

--- a/libraries/typescript/packages/inspector/src/client/components/OpenAIComponentRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/OpenAIComponentRenderer.tsx
@@ -1104,7 +1104,7 @@ function OpenAIComponentRendererBase({
           )}
         >
           {displayMode === "inline" && (invoking || invoked) && (
-            <div className="absolute -top-8 left-2 z-10 whitespace-nowrap">
+            <div className="absolute -top-8 left-2 z-10 whitespace-nowrap pointer-events-none">
               {invoking && !toolResult && (
                 <TextShimmer className="text-xs">{invoking}</TextShimmer>
               )}

--- a/libraries/typescript/packages/mcp-use/CHANGELOG.md
+++ b/libraries/typescript/packages/mcp-use/CHANGELOG.md
@@ -1,5 +1,13 @@
 # mcp-use
 
+## 1.30.1-canary.0
+
+### Patch Changes
+
+- Updated dependencies [bad4578]
+  - @mcp-use/cli@3.4.0-canary.0
+  - @mcp-use/inspector@8.0.1-canary.0
+
 ## 1.30.0
 
 ### Minor Changes

--- a/libraries/typescript/packages/mcp-use/CHANGELOG.md
+++ b/libraries/typescript/packages/mcp-use/CHANGELOG.md
@@ -1,5 +1,13 @@
 # mcp-use
 
+## 1.30.1-canary.1
+
+### Patch Changes
+
+- Updated dependencies [afb0e79]
+  - @mcp-use/inspector@8.0.1-canary.1
+  - @mcp-use/cli@3.4.0-canary.1
+
 ## 1.30.1-canary.0
 
 ### Patch Changes

--- a/libraries/typescript/packages/mcp-use/CHANGELOG.md
+++ b/libraries/typescript/packages/mcp-use/CHANGELOG.md
@@ -1,5 +1,37 @@
 # mcp-use
 
+## 1.30.1-canary.3
+
+### Patch Changes
+
+- ea4e6f1: fix(react,client): prevent stale disconnect from wiping a reconnected MCP session
+
+  When `useMcp` reconnects after a URL change (e.g. dashboard environment
+  switch), the previous effect's async `disconnect()` could finish after the
+  new `connect()` and either:
+  1. set `clientRef` to null while React state remained `ready` — surfacing
+     as "MCP client is not ready (current state: ready)"; or
+  2. wipe the freshly-created session out of the underlying client's session
+     map — surfacing as "No active session found" on the next tool call.
+
+  `disconnect()` now only nulls `clientRef` **and** resets the hook state when
+  it has not been superseded by a newer `connect()` (a `connectEpochRef` counter
+  bumped at the start of each `connect()`, plus a client-identity check). This
+  covers both the case where `connect()` reuses the same `BrowserMCPClient`
+  instance for the new URL and a manual `disconnect()` racing a reconnect, which
+  must not clobber the live connection's state back to `discovering`.
+
+  `BaseMCPClient.closeSession()` now only deletes `sessions[name]` if the slot
+  still references the captured session. A parallel `createSession()` from a
+  newer `connect()` may have already written a new session there while we were
+  awaiting `session.disconnect()`; the previous unconditional `delete` in the
+  `finally` block would wipe that new session and break tool calls.
+
+  MCP operation errors also distinguish a missing client from a non-ready
+  state.
+  - @mcp-use/cli@3.4.0-canary.3
+  - @mcp-use/inspector@8.0.1-canary.3
+
 ## 1.30.1-canary.2
 
 ### Patch Changes

--- a/libraries/typescript/packages/mcp-use/CHANGELOG.md
+++ b/libraries/typescript/packages/mcp-use/CHANGELOG.md
@@ -1,5 +1,15 @@
 # mcp-use
 
+## 1.30.1-canary.2
+
+### Patch Changes
+
+- 8c00a55: Fix iframe collapse when widget renders null by allowing zero-height notifications
+
+  Previously, the `height > 0` guard in `McpUseProvider` prevent height notifications when a widget rendered `null`, causing the iframe to persist at its last non-zero height. This fix allows zero heights to pass through unconditionally while maintaining the threshold check for positive heights, enabling proper iframe collapse for empty widgets.
+  - @mcp-use/cli@3.4.0-canary.2
+  - @mcp-use/inspector@8.0.1-canary.2
+
 ## 1.30.1-canary.1
 
 ### Patch Changes

--- a/libraries/typescript/packages/mcp-use/examples/server/ui/mcp-apps/index.ts
+++ b/libraries/typescript/packages/mcp-use/examples/server/ui/mcp-apps/index.ts
@@ -126,86 +126,30 @@ server.tool(
   }
 );
 
-// Example 2: Simple greeting widget (programmatic, auto-exposed as tool)
-// NOTE: You can also create React widgets in resources/ directory like weather-display
-server.uiResource({
-  type: "mcpApps",
-  name: "greeting-card",
-  title: "Greeting Card",
-  description: "Shows a personalized greeting message",
-  props: {
-    name: {
-      type: "string",
-      required: true,
-      description: "Name to greet",
-    },
-    greeting: {
-      type: "string",
-      required: true,
-      description: "Greeting message",
+// Example 2: Simple greeting tool backed by a React widget in resources/
+server.tool(
+  {
+    name: "greeting-card",
+    description: "Shows a personalized greeting message",
+    schema: z.object({
+      name: z.string().describe("Name to greet"),
+      greeting: z.string().describe("Greeting message"),
+    }),
+    widget: {
+      name: "greeting-card",
+      invoking: "Creating greeting card...",
+      invoked: "Greeting card ready",
     },
   },
-  htmlTemplate: `
-    <!DOCTYPE html>
-    <html>
-    <head>
-      <meta charset="UTF-8">
-      <meta name="viewport" content="width=device-width, initial-scale=1.0">
-      <style>
-        body {
-          margin: 0;
-          padding: 20px;
-          font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-        }
-        .greeting-card {
-          background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
-          border-radius: 12px;
-          padding: 32px;
-          color: white;
-          text-align: center;
-          max-width: 400px;
-        }
-        .greeting {
-          font-size: 36px;
-          font-weight: 700;
-          margin-bottom: 16px;
-        }
-        .name {
-          font-size: 48px;
-          font-weight: 800;
-        }
-      </style>
-    </head>
-    <body>
-      <div class="greeting-card">
-        <div class="greeting" id="greeting">Hello</div>
-        <div class="name" id="name">World</div>
-      </div>
-      <script>
-        // Parse props from URL (for both protocols)
-        const params = new URLSearchParams(window.location.search);
-        const propsJson = params.get('props');
-        
-        if (propsJson) {
-          try {
-            const props = JSON.parse(propsJson);
-            document.getElementById('greeting').textContent = props.greeting || 'Hello';
-            document.getElementById('name').textContent = props.name || 'World';
-          } catch (e) {
-            console.error('Failed to parse props:', e);
-          }
-        }
-      </script>
-    </body>
-    </html>
-  `,
-  metadata: {
-    prefersBorder: true,
-    widgetDescription: "A colorful greeting card with personalized message",
-  },
-  // This widget is automatically exposed as a tool
-  exposeAsTool: true,
-});
+  async ({ name, greeting }) =>
+    widget({
+      props: {
+        name,
+        greeting,
+      },
+      message: `${greeting} ${name}`,
+    })
+);
 
 // Brand info tool (returns structured data)
 server.tool(
@@ -252,7 +196,7 @@ This server demonstrates dual-protocol widget support:
 Try these tools:
 - get-weather: Get weather for a city (uses weather-display widget)
 - get-weather-delayed: Test widget lifecycle with 5s delay (Issue #930)
-- greeting-display: Auto-exposed widget with props
+- greeting-card: Personalized greeting widget backed by a React resource
 - get-info: Learn about dual-protocol support
 
 To test Issue #930 fix:

--- a/libraries/typescript/packages/mcp-use/examples/server/ui/mcp-apps/resources/greeting-card/widget.tsx
+++ b/libraries/typescript/packages/mcp-use/examples/server/ui/mcp-apps/resources/greeting-card/widget.tsx
@@ -1,0 +1,67 @@
+import { McpUseProvider, useWidget, type WidgetMetadata } from "mcp-use/react";
+import React from "react";
+import { z } from "zod";
+import "../styles.css";
+
+const propSchema = z.object({
+  name: z.string().describe("Name to greet"),
+  greeting: z.string().describe("Greeting message"),
+});
+
+export const widgetMetadata: WidgetMetadata = {
+  description: "Display a personalized greeting message",
+  props: propSchema,
+  exposeAsTool: false,
+  metadata: {
+    prefersBorder: false,
+    widgetDescription: "A colorful greeting card with personalized message",
+  },
+  annotations: {
+    readOnlyHint: true,
+  },
+};
+
+type GreetingProps = z.infer<typeof propSchema>;
+
+const GreetingCard: React.FC = () => {
+  const { props, isPending } = useWidget<GreetingProps>();
+
+  return (
+    <McpUseProvider debugger viewControls autoSize>
+      <div className="flex items-center justify-center min-h-[260px] p-6 bg-zinc-900/5 dark:bg-zinc-950 transition-colors duration-300">
+        <div className="w-full max-w-[380px] rounded-lg border border-zinc-200/80 dark:border-zinc-800/80 bg-zinc-950 text-zinc-400 font-mono shadow-2xl overflow-hidden text-left">
+          {/* Header */}
+          <div className="px-4 py-2.5 bg-zinc-100 dark:bg-zinc-900 border-b border-zinc-200/80 dark:border-zinc-800/80 select-none">
+            <span className="text-[11px] font-semibold text-zinc-800 dark:text-zinc-200">
+              greeting-card
+            </span>
+          </div>
+
+          {/* Terminal Body */}
+          <div className="p-5 flex flex-col gap-1.5 bg-zinc-950">
+            {isPending ? (
+              <div className="flex flex-col gap-2">
+                <div className="flex items-center gap-2 text-xs text-zinc-500 animate-pulse">
+                  <span>Executing...</span>
+                </div>
+              </div>
+            ) : (
+              <>
+                {/* Greeting Line */}
+                <div className="text-lg font-bold text-zinc-100 leading-tight">
+                  {props.greeting}
+                </div>
+                {/* Name Line */}
+                <div className="text-lg font-bold text-zinc-100 leading-tight">
+                  {props.name}
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    </McpUseProvider>
+  );
+};
+
+export default GreetingCard;

--- a/libraries/typescript/packages/mcp-use/package.json
+++ b/libraries/typescript/packages/mcp-use/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-use",
   "type": "module",
-  "version": "1.30.1-canary.2",
+  "version": "1.30.1-canary.3",
   "packageManager": "pnpm@10.26.0+sha512.3b3f6c725ebe712506c0ab1ad4133cf86b1f4b687effce62a9b38b4d72e3954242e643190fc51fa1642949c735f403debd44f5cb0edd657abe63a8b6a7e1e402",
   "description": "Opinionated MCP Framework for TypeScript (@modelcontextprotocol/sdk compatible) - Build MCP Agents, Clients and Servers with support for ChatGPT Apps, Code Mode, OAuth, Notifications, Sampling, Observability and more.",
   "author": "mcp-use, Inc.",

--- a/libraries/typescript/packages/mcp-use/package.json
+++ b/libraries/typescript/packages/mcp-use/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-use",
   "type": "module",
-  "version": "1.30.1-canary.0",
+  "version": "1.30.1-canary.1",
   "packageManager": "pnpm@10.26.0+sha512.3b3f6c725ebe712506c0ab1ad4133cf86b1f4b687effce62a9b38b4d72e3954242e643190fc51fa1642949c735f403debd44f5cb0edd657abe63a8b6a7e1e402",
   "description": "Opinionated MCP Framework for TypeScript (@modelcontextprotocol/sdk compatible) - Build MCP Agents, Clients and Servers with support for ChatGPT Apps, Code Mode, OAuth, Notifications, Sampling, Observability and more.",
   "author": "mcp-use, Inc.",

--- a/libraries/typescript/packages/mcp-use/package.json
+++ b/libraries/typescript/packages/mcp-use/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-use",
   "type": "module",
-  "version": "1.30.0",
+  "version": "1.30.1-canary.0",
   "packageManager": "pnpm@10.26.0+sha512.3b3f6c725ebe712506c0ab1ad4133cf86b1f4b687effce62a9b38b4d72e3954242e643190fc51fa1642949c735f403debd44f5cb0edd657abe63a8b6a7e1e402",
   "description": "Opinionated MCP Framework for TypeScript (@modelcontextprotocol/sdk compatible) - Build MCP Agents, Clients and Servers with support for ChatGPT Apps, Code Mode, OAuth, Notifications, Sampling, Observability and more.",
   "author": "mcp-use, Inc.",

--- a/libraries/typescript/packages/mcp-use/package.json
+++ b/libraries/typescript/packages/mcp-use/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-use",
   "type": "module",
-  "version": "1.30.1-canary.1",
+  "version": "1.30.1-canary.2",
   "packageManager": "pnpm@10.26.0+sha512.3b3f6c725ebe712506c0ab1ad4133cf86b1f4b687effce62a9b38b4d72e3954242e643190fc51fa1642949c735f403debd44f5cb0edd657abe63a8b6a7e1e402",
   "description": "Opinionated MCP Framework for TypeScript (@modelcontextprotocol/sdk compatible) - Build MCP Agents, Clients and Servers with support for ChatGPT Apps, Code Mode, OAuth, Notifications, Sampling, Observability and more.",
   "author": "mcp-use, Inc.",

--- a/libraries/typescript/packages/mcp-use/src/client/base.ts
+++ b/libraries/typescript/packages/mcp-use/src/client/base.ts
@@ -466,8 +466,17 @@ export abstract class BaseMCPClient {
     } catch (e) {
       logger.error(`Error closing session for server '${serverName}': ${e}`);
     } finally {
-      delete this.sessions[serverName];
-      this.activeSessions = this.activeSessions.filter((n) => n !== serverName);
+      // Only remove the slot if it still references the session we captured.
+      // A parallel createSession() (e.g. URL/env change in useMcp) may have
+      // written a new session here while we were awaiting `session.disconnect()`;
+      // wiping that would leave consumers with `getSession() === null` and
+      // surface as "No active session found".
+      if (this.sessions[serverName] === session) {
+        delete this.sessions[serverName];
+        this.activeSessions = this.activeSessions.filter(
+          (n) => n !== serverName
+        );
+      }
     }
   }
 

--- a/libraries/typescript/packages/mcp-use/src/react/McpUseProvider.tsx
+++ b/libraries/typescript/packages/mcp-use/src/react/McpUseProvider.tsx
@@ -128,9 +128,9 @@ export function McpUseProvider({
         clearTimeout(debounceTimeoutRef.current);
       }
       debounceTimeoutRef.current = setTimeout(() => {
-        // Only notify if height changed by more than threshold and is positive
+        // Always notify zero height and for positive heights only notify if changed by more than threshold
         const heightDiff = Math.abs(height - lastHeightRef.current);
-        if (heightDiff >= MIN_HEIGHT_CHANGE_PX && height > 0) {
+        if (height === 0 || heightDiff >= MIN_HEIGHT_CHANGE_PX) {
           lastHeightRef.current = height;
           notifyHeight(height);
         }

--- a/libraries/typescript/packages/mcp-use/src/react/useMcp-helpers.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/useMcp-helpers.ts
@@ -3,6 +3,14 @@ import type { OAuthClientInformation } from "@modelcontextprotocol/sdk/shared/au
 
 export const USE_MCP_SERVER_NAME = "inspector-server";
 
+/** Human-readable reason when MCP operations run before the client is usable. */
+export function formatMcpNotReadyReason(
+  state: string,
+  hasClient: boolean
+): string {
+  return !hasClient ? `client disconnected (state=${state})` : `state=${state}`;
+}
+
 type OAuthClientConfig = {
   name?: string;
   version?: string;

--- a/libraries/typescript/packages/mcp-use/src/react/useMcp.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/useMcp.ts
@@ -434,8 +434,7 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
       // bumped the epoch — possibly reusing the same client instance — while
       // closeSession was in flight. If so, this disconnect is stale: it must
       // neither null the (now newer) clientRef nor reset the live state.
-      const supersededByNewerConnect =
-        connectEpochRef.current !== epochAtStart;
+      const supersededByNewerConnect = connectEpochRef.current !== epochAtStart;
 
       if (clientRef.current === clientToClose && !supersededByNewerConnect) {
         clientRef.current = null;

--- a/libraries/typescript/packages/mcp-use/src/react/useMcp.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/useMcp.ts
@@ -24,6 +24,7 @@ import {
   deriveOAuthClientConfigFromClientInfo,
   isOAuthDiscoveryFailure,
   startConnectionHealthMonitoring,
+  formatMcpNotReadyReason,
   USE_MCP_SERVER_NAME,
 } from "./useMcp-helpers.js";
 import type { UseMcpOptions, UseMcpResult } from "./types.js";
@@ -322,6 +323,8 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
   const connectingRef = useRef<boolean>(false);
   const isMountedRef = useRef<boolean>(true);
   const connectAttemptRef = useRef<number>(0);
+  /** Bumped at the start of each connect(); disconnect only clears clientRef if epoch unchanged. */
+  const connectEpochRef = useRef(0);
   const authTimeoutRef = useRef<number | null>(null);
   const retryScheduledRef = useRef<boolean>(false);
 
@@ -406,10 +409,12 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
       if (authTimeoutRef.current) clearTimeout(authTimeoutRef.current);
       authTimeoutRef.current = null;
 
-      if (clientRef.current) {
+      const epochAtStart = connectEpochRef.current;
+      const clientToClose = clientRef.current;
+      if (clientToClose) {
         try {
           const serverName = USE_MCP_SERVER_NAME;
-          const session = clientRef.current.getSession(serverName);
+          const session = clientToClose.getSession(serverName);
 
           // Clean up health check monitoring if it exists
           if (session && (session as any)._healthCheckCleanup) {
@@ -419,15 +424,24 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
 
           // Only try to close if session exists (avoids noisy warning logs)
           if (session) {
-            await clientRef.current.closeSession(serverName);
+            await clientToClose.closeSession(serverName);
           }
         } catch (err) {
           if (!quiet) addLog("warn", "Error closing session:", err);
         }
       }
-      clientRef.current = null;
+      // A newer connect() (e.g. dashboard environment / URL change) may have
+      // bumped the epoch — possibly reusing the same client instance — while
+      // closeSession was in flight. If so, this disconnect is stale: it must
+      // neither null the (now newer) clientRef nor reset the live state.
+      const supersededByNewerConnect =
+        connectEpochRef.current !== epochAtStart;
 
-      if (isMountedRef.current && !quiet) {
+      if (clientRef.current === clientToClose && !supersededByNewerConnect) {
+        clientRef.current = null;
+      }
+
+      if (isMountedRef.current && !quiet && !supersededByNewerConnect) {
         setState("discovering");
         setTools([]);
         setResources([]);
@@ -495,7 +509,8 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
         );
 
         // Clear client/auth refs to force fresh initialization with proxy.
-        // Keep externally provided auth providers intact.
+        // Keep externally provided auth providers intact. Synchronous clear;
+        // reconnect is deferred via setTimeout below, so no disconnect race.
         clientRef.current = null;
         if (!providedAuthProvider) {
           authProviderRef.current = null;
@@ -596,6 +611,7 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
     }
 
     connectingRef.current = true;
+    connectEpochRef.current += 1;
     connectAttemptRef.current += 1;
     setError(undefined);
     setAuthUrl(undefined);
@@ -1322,7 +1338,7 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
     ) => {
       if (stateRef.current !== "ready" || !clientRef.current) {
         throw new Error(
-          `MCP client is not ready (current state: ${state}). Cannot call tool "${name}".`
+          `MCP client is not ready (${formatMcpNotReadyReason(stateRef.current, !!clientRef.current)}). Cannot call tool "${name}".`
         );
       }
       addLog("info", `Calling tool: ${name}`, args);
@@ -1580,7 +1596,7 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
   const listResources = useCallback(async () => {
     if (stateRef.current !== "ready" || !clientRef.current) {
       throw new Error(
-        `MCP client is not ready (current state: ${state}). Cannot list resources.`
+        `MCP client is not ready (${formatMcpNotReadyReason(stateRef.current, !!clientRef.current)}). Cannot list resources.`
       );
     }
     addLog("info", "Listing resources");
@@ -1616,7 +1632,7 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
     async (uri: string) => {
       if (stateRef.current !== "ready" || !clientRef.current) {
         throw new Error(
-          `MCP client is not ready (current state: ${state}). Cannot read resource.`
+          `MCP client is not ready (${formatMcpNotReadyReason(stateRef.current, !!clientRef.current)}). Cannot read resource.`
         );
       }
       addLog("info", `Reading resource: ${uri}`);
@@ -1673,7 +1689,7 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
   const listPrompts = useCallback(async () => {
     if (stateRef.current !== "ready" || !clientRef.current) {
       throw new Error(
-        `MCP client is not ready (current state: ${state}). Cannot list prompts.`
+        `MCP client is not ready (${formatMcpNotReadyReason(stateRef.current, !!clientRef.current)}). Cannot list prompts.`
       );
     }
     addLog("info", "Listing prompts");
@@ -1847,7 +1863,7 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
     async (name: string, args?: Record<string, unknown>) => {
       if (stateRef.current !== "ready" || !clientRef.current) {
         throw new Error(
-          `MCP client is not ready (current state: ${state}). Cannot get prompt.`
+          `MCP client is not ready (${formatMcpNotReadyReason(stateRef.current, !!clientRef.current)}). Cannot get prompt.`
         );
       }
       addLog("info", `Getting prompt: ${name}`, args);
@@ -1889,7 +1905,7 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
     async (params: CompleteRequestParams): Promise<CompleteResult> => {
       if (stateRef.current !== "ready" || !clientRef.current) {
         throw new Error(
-          `MCP client is not ready (current state: ${state}). Cannot request completion.`
+          `MCP client is not ready (${formatMcpNotReadyReason(stateRef.current, !!clientRef.current)}). Cannot request completion.`
         );
       }
 

--- a/libraries/typescript/packages/mcp-use/tests/unit/client/close-session-slot-guard.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/client/close-session-slot-guard.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Regression: BaseMCPClient.closeSession must only remove the session slot it
+ * actually closed. A parallel createSession() (e.g. a URL/env change in useMcp
+ * that reuses the same client instance) can write a new session into the same
+ * slot while the original session's disconnect() is still awaiting. The old
+ * unconditional `delete this.sessions[name]` in the finally block wiped that
+ * new session, surfacing as "No active session found" on the next tool call.
+ *
+ * Run with: pnpm test tests/unit/client/close-session-slot-guard.test.ts
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { BaseMCPClient } from "../../../src/client/base.js";
+import type { BaseConnector } from "../../../src/connectors/base.js";
+import type { MCPSession } from "../../../src/session.js";
+
+class TestMCPClient extends BaseMCPClient {
+  protected createConnectorFromConfig(): BaseConnector {
+    throw new Error("not needed for these tests");
+  }
+
+  /** Test helper to seed/replace a session slot directly. */
+  setSession(name: string, session: MCPSession | undefined): void {
+    if (session) {
+      (this as unknown as { sessions: Record<string, MCPSession> }).sessions[
+        name
+      ] = session;
+    } else {
+      delete (this as unknown as { sessions: Record<string, MCPSession> })
+        .sessions[name];
+    }
+  }
+
+  getSessionSlot(name: string): MCPSession | undefined {
+    return (this as unknown as { sessions: Record<string, MCPSession> })
+      .sessions[name];
+  }
+}
+
+function makeDeferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+function makeSession(disconnect: () => Promise<void>): MCPSession {
+  return { disconnect: vi.fn(disconnect) } as unknown as MCPSession;
+}
+
+describe("BaseMCPClient.closeSession slot guard", () => {
+  it("does NOT delete the slot when a newer session replaced it mid-disconnect", async () => {
+    const client = new TestMCPClient();
+    const deferred = makeDeferred();
+
+    const oldSession = makeSession(() => deferred.promise);
+    client.setSession("server", oldSession);
+    client.activeSessions = ["server"];
+
+    // Start closing the old session; disconnect() is still pending here.
+    const closePromise = client.closeSession("server");
+
+    // A parallel reconnect writes a fresh session into the same slot.
+    const newSession = makeSession(() => Promise.resolve());
+    client.setSession("server", newSession);
+
+    // Now let the old session's disconnect resolve and the finally block run.
+    deferred.resolve();
+    await closePromise;
+
+    expect(oldSession.disconnect).toHaveBeenCalledTimes(1);
+    // The new session must survive — the stale close must not wipe it.
+    expect(client.getSessionSlot("server")).toBe(newSession);
+    expect(client.activeSessions).toContain("server");
+  });
+
+  it("deletes the slot in the normal (no-race) case", async () => {
+    const client = new TestMCPClient();
+    const session = makeSession(() => Promise.resolve());
+    client.setSession("server", session);
+    client.activeSessions = ["server"];
+
+    await client.closeSession("server");
+
+    expect(session.disconnect).toHaveBeenCalledTimes(1);
+    expect(client.getSessionSlot("server")).toBeUndefined();
+    expect(client.activeSessions).not.toContain("server");
+  });
+
+  it("still clears the slot even if disconnect() throws", async () => {
+    const client = new TestMCPClient();
+    const session = makeSession(() => Promise.reject(new Error("boom")));
+    client.setSession("server", session);
+    client.activeSessions = ["server"];
+
+    await client.closeSession("server");
+
+    expect(client.getSessionSlot("server")).toBeUndefined();
+    expect(client.activeSessions).not.toContain("server");
+  });
+});

--- a/libraries/typescript/packages/mcp-use/tests/unit/react/useMcp-disconnect-reused-client-race.test.tsx
+++ b/libraries/typescript/packages/mcp-use/tests/unit/react/useMcp-disconnect-reused-client-race.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+
+/**
+ * Regression: stale disconnect() must not null clientRef when connect() reuses the
+ * same BrowserMCPClient instance and bumps connectEpoch before closeSession resolves.
+ */
+
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, create } from "react-test-renderer";
+
+function makeConnector() {
+  return {
+    tools: [],
+    serverInfo: { name: "test-server" },
+    serverCapabilities: {},
+    listAllResources: vi.fn().mockResolvedValue({ resources: [] }),
+    listPrompts: vi.fn().mockResolvedValue({ prompts: [] }),
+    listResourceTemplates: vi.fn().mockResolvedValue({ resourceTemplates: [] }),
+  };
+}
+
+let closeSessionDeferred: {
+  promise: Promise<void>;
+  resolve: () => void;
+} | null = null;
+
+function createCloseSessionDeferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+const mockAuthProvider = {
+  serverUrl: "http://localhost/a/mcp",
+  tokens: vi.fn().mockResolvedValue(undefined),
+  clearStorage: vi.fn().mockReturnValue(0),
+  restoreFetch: vi.fn(),
+};
+
+function makeSession() {
+  return {
+    on: vi.fn(),
+    connector: makeConnector(),
+    initialize: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+/** Single client instance — connect() reuses it when clientRef is non-null. */
+let activeSession: ReturnType<typeof makeSession> | null = null;
+
+const sharedClient = {
+  addServer: vi.fn().mockResolvedValue(undefined),
+  removeServer: vi.fn().mockResolvedValue(undefined),
+  listSessions: vi.fn().mockReturnValue([]),
+  getSession: vi.fn(() => activeSession),
+  createSession: vi.fn(),
+  closeSession: vi.fn(),
+};
+
+vi.mock("../../../src/client/browser.js", () => ({
+  BrowserMCPClient: vi.fn(function () {
+    return sharedClient;
+  }),
+}));
+
+vi.mock("../../../src/auth/browser-provider.js", () => ({
+  createBrowserOAuthProvider: vi.fn(() => ({
+    provider: null,
+    oauthProxyUrl: undefined,
+  })),
+}));
+
+vi.mock("../../../src/telemetry/index.js", () => ({
+  Tel: {
+    getInstance: () => ({
+      trackUseMcpConnection: vi.fn().mockResolvedValue(undefined),
+      trackUseMcpToolCall: vi.fn().mockResolvedValue(undefined),
+    }),
+  },
+}));
+
+vi.mock("../../../src/utils/favicon-detector.js", () => ({
+  detectFavicon: vi.fn().mockResolvedValue(null),
+}));
+
+describe("useMcp disconnect vs reused client race", () => {
+  let useMcp: typeof import("../../../src/react/useMcp.js").useMcp;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    closeSessionDeferred = null;
+    activeSession = null;
+    mockAuthProvider.serverUrl = "http://localhost/a/mcp";
+    sharedClient.createSession.mockImplementation(async () => {
+      activeSession = makeSession();
+      return activeSession;
+    });
+    sharedClient.closeSession.mockImplementation(() => {
+      if (!closeSessionDeferred) {
+        return Promise.resolve();
+      }
+      return closeSessionDeferred.promise;
+    });
+
+    vi.resetModules();
+    const module = await import("../../../src/react/useMcp.js");
+    useMcp = module.useMcp;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("keeps client live when closeSession resolves after a reused-instance reconnect", async () => {
+    let latest: ReturnType<typeof useMcp> | undefined;
+
+    function TestComponent({ url }: { url: string }) {
+      latest = useMcp({
+        url,
+        enabled: true,
+        authProvider: mockAuthProvider,
+        transportType: "http",
+        autoProxyFallback: false,
+        autoRetry: false,
+        autoReconnect: false,
+        logLevel: "silent",
+      });
+      return null;
+    }
+
+    let renderer: ReturnType<typeof create>;
+
+    await act(async () => {
+      renderer = create(<TestComponent url="http://localhost/a/mcp" />);
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(latest?.state).toBe("ready");
+    expect(latest?.client).toBe(sharedClient);
+
+    closeSessionDeferred = createCloseSessionDeferred();
+
+    mockAuthProvider.serverUrl = "http://localhost/b/mcp";
+
+    await act(async () => {
+      renderer!.update(<TestComponent url="http://localhost/b/mcp" />);
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(latest?.state).toBe("ready");
+    expect(latest?.client).toBe(sharedClient);
+
+    await act(async () => {
+      closeSessionDeferred!.resolve();
+      await closeSessionDeferred!.promise;
+      await Promise.resolve();
+    });
+
+    expect(latest?.state).toBe("ready");
+    expect(latest?.client).toBe(sharedClient);
+    expect(sharedClient.closeSession).toHaveBeenCalled();
+  });
+});

--- a/libraries/typescript/packages/mcp-use/tests/unit/react/useMcp-not-ready-reason.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/react/useMcp-not-ready-reason.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { formatMcpNotReadyReason } from "../../../src/react/useMcp-helpers.js";
+
+describe("formatMcpNotReadyReason", () => {
+  it("reports disconnected client when ref is null but state is ready", () => {
+    expect(formatMcpNotReadyReason("ready", false)).toBe(
+      "client disconnected (state=ready)"
+    );
+  });
+
+  it("reports state when client exists but state is not ready", () => {
+    expect(formatMcpNotReadyReason("discovering", true)).toBe(
+      "state=discovering"
+    );
+  });
+});

--- a/skills/mcp-apps-builder/references/foundations/deployment.md
+++ b/skills/mcp-apps-builder/references/foundations/deployment.md
@@ -12,11 +12,37 @@ mcp-use whoami
 
 If this fails or the user has never logged in, run `mcp-use login` first — it opens a browser for OAuth.
 
+**Non-interactive / agent contexts:** if you were handed a one-time device code
+(e.g. from the web onboarding flow), authenticate without a browser:
+
+```bash
+mcp-use login --device-code <CODE>
+```
+
+The code is short-lived and already approved, so the CLI redeems it immediately.
+
 ---
 
 ## Quick Deploy (Manufact Cloud)
 
-The fastest path to production — one command:
+There are two ways to deploy, depending on where the code should live.
+
+### Option A — Managed repo (no GitHub required)
+
+Best for getting live fast, or when the user hasn't connected GitHub. The CLI
+uploads your local source; the repo is created in the platform-managed org and
+deployed through the normal pipeline:
+
+```bash
+mcp-use deploy --no-github
+```
+
+No git remote, no GitHub App install. The user can later move it to their own
+GitHub from the server's dashboard ("Connect your GitHub").
+
+### Option B — Your own GitHub
+
+Deploys from a repository in the user's GitHub account (enables push-to-deploy):
 
 ```bash
 mcp-use deploy
@@ -28,19 +54,21 @@ Or via the npm script (pre-configured in all templates):
 npm run deploy
 ```
 
-Your server is live at `https://{slug}.run.mcp-use.com/mcp`.
+Either way, your server is live at `https://{slug}.run.mcp-use.com/mcp`.
 
 ---
 
 ## Prerequisites
 
-Before running `mcp-use deploy`:
+**No-GitHub deploy (`--no-github`)** only needs you to be **logged in** (`mcp-use whoami`).
+No git, no GitHub App — the CLI uploads your local source directly.
 
-1. **Logged in** — run `mcp-use whoami` to verify, or `mcp-use login` if needed
-2. **Git repository** — your project must be a git repo
-3. **GitHub remote** — the `origin` remote must point to GitHub (SSH or HTTPS)
-4. **Changes pushed** — deployment pulls from GitHub, not your local files. Commit and push first.
-5. **GitHub App installed** — the mcp-use GitHub App must have access to the repo. The CLI will prompt you to install it if missing.
+**GitHub deploy** (`mcp-use deploy` without `--no-github`) additionally needs:
+
+1. **Git repository** — your project must be a git repo
+2. **GitHub remote** — the `origin` remote must point to GitHub (SSH or HTTPS)
+3. **Changes pushed** — deployment pulls from GitHub, not your local files. Commit and push first.
+4. **GitHub App installed** — the mcp-use GitHub App must have access to the repo. The CLI prompts you to install it if missing, or install it at `github.com/apps/mcp-use/installations/new`.
 
 ---
 
@@ -50,15 +78,21 @@ Before running `mcp-use deploy`:
 mcp-use deploy [options]
 ```
 
-| Flag | Description | Default |
-|------|-------------|---------|
-| `--name <name>` | Custom deployment name | `package.json` name or directory name |
-| `--port <port>` | Server port | `3000` |
-| `--runtime <runtime>` | `"node"` or `"python"` | Auto-detected from project files |
-| `--env <KEY=VALUE>` | Set environment variable (repeatable) | — |
-| `--env-file <path>` | Load env vars from a file | — |
-| `--open` | Open deployment in browser after success | `false` |
-| `--new` | Force a fresh deployment (ignore existing link) | `false` |
+| Flag                  | Description                                                  | Default                               |
+| --------------------- | ------------------------------------------------------------ | ------------------------------------- |
+| `--no-github`         | Upload local source without connecting GitHub                | `false`                               |
+| `--org <slug>`        | Deploy to a specific organization (by slug or id)            | configured org                        |
+| `--name <name>`       | Custom deployment name                                       | `package.json` name or directory name |
+| `--port <port>`       | Server port                                                  | `3000`                                |
+| `--runtime <runtime>` | `"node"` or `"python"`                                       | Auto-detected from project files      |
+| `--env <KEY=VALUE>`   | Set environment variable (repeatable)                        | —                                     |
+| `--env-file <path>`   | Load env vars from a file                                    | —                                     |
+| `--open`              | Open deployment in browser after success                     | `false`                               |
+| `--new`               | Force a fresh deployment (ignore existing link)              | `false`                               |
+| `-y, --yes`           | Skip confirmation prompts (non-interactive / CI / agents)    | `false`                               |
+
+> Redeploys of a platform-managed project are auto-detected from the linked server, so
+> `--no-github` is only needed on the first deploy.
 
 ### Setting Environment Variables
 
@@ -83,6 +117,6 @@ mcp-use deploy --env-file .env.production
 - ❌ Hardcoding secrets in code or committing `.env`
   - ✅ Use `--env` / `--env-file` flags, or `mcp-use deployments env set`
 - ❌ Forgetting to install the mcp-use GitHub App on the repo
-  - ✅ The CLI will prompt you, but you can also install it at `github.com/apps/mcp-use`
+  - ✅ The CLI will prompt you, but you can also install it at `github.com/apps/mcp-use` — or skip GitHub entirely with `mcp-use deploy --no-github`
 - ❌ Running `mcp-use start` without `mcp-use build` first
   - ✅ Always build before starting in production


### PR DESCRIPTION
* feat(cli): add managed (no-GitHub) deploy and device-code login

- `mcp-use deploy --managed` packs the local project into a tarball and uploads it to the platform-managed GitHub org, so users can deploy without connecting their own GitHub. Redeploys reuse the linked server.
- `mcp-use login --device-code <code>` authenticates non-interactively with a pre-approved OAuth device code (used by the web onboarding flow), skipping the browser step.

* feat(cli): auto-detect managed server on redeploy

A project linked to a managed server now redeploys via the managed upload path without needing --managed again (detected from the server's connectedRepository.isManaged flag).

* docs(skill): document managed deploy + device-code login

Update the mcp-apps-builder deployment guide for `mcp-use deploy --managed` (no GitHub required) and non-interactive `mcp-use login --device-code`.

* refactor(cli): rename managed deploy option to no-github

Updated the CLI command from `--managed` to `--no-github` for deploying local sources without connecting to GitHub. This change clarifies the functionality and aligns with the new documentation. The deployment process remains unchanged, allowing users to upload their project source directly to the platform-managed organization. Additionally, updated related documentation to reflect this change.
