### PR TITLE
fix(mcp-use): move chalk to regular dependencies (statically imported, not optional)

### DIFF
--- a/libraries/typescript/.changeset/chalk-regular-dependency.md
+++ b/libraries/typescript/.changeset/chalk-regular-dependency.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Move chalk from optionalDependencies to dependencies. It is statically imported by server code (`src/server/logging.ts`, `src/server/utils/server-lifecycle.ts`), so installs that skip optional packages (`pnpm install --no-optional`, `npm config set optional false`) would fail at module load.

--- a/libraries/typescript/.changeset/chalk-v4-cjs-fix.md
+++ b/libraries/typescript/.changeset/chalk-v4-cjs-fix.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Downgrade chalk to v4 to fix CJS builds. chalk 5 is ESM-only and is kept external by tsup, so the CJS bundle's `require("chalk")` on Node ≥ 22 returned the module namespace instead of the chalk instance, crashing CJS-built backends (e.g. the Next.js template) on startup with `TypeError: import_chalk.default.gray is not a function`.

--- a/libraries/typescript/.changeset/pre.json
+++ b/libraries/typescript/.changeset/pre.json
@@ -7,5 +7,7 @@
     "@mcp-use/inspector": "8.0.1",
     "mcp-use": "1.30.1"
   },
-  "changesets": []
+  "changesets": [
+    "chalk-v4-cjs-fix"
+  ]
 }

--- a/libraries/typescript/.changeset/pre.json
+++ b/libraries/typescript/.changeset/pre.json
@@ -1,0 +1,11 @@
+{
+  "mode": "pre",
+  "tag": "canary",
+  "initialVersions": {
+    "@mcp-use/cli": "3.4.0",
+    "create-mcp-use-app": "0.14.15",
+    "@mcp-use/inspector": "8.0.1",
+    "mcp-use": "1.30.1"
+  },
+  "changesets": []
+}

--- a/libraries/typescript/packages/cli/CHANGELOG.md
+++ b/libraries/typescript/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @mcp-use/cli
 
+## 3.4.1-canary.0
+
+### Patch Changes
+
+- Updated dependencies [f9fb29b]
+  - mcp-use@1.30.2-canary.0
+  - @mcp-use/inspector@8.0.2-canary.0
+
 ## 3.4.0
 
 ### Minor Changes

--- a/libraries/typescript/packages/cli/package.json
+++ b/libraries/typescript/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-use/cli",
   "type": "module",
-  "version": "3.4.0",
+  "version": "3.4.1-canary.0",
   "description": "The mcp-use CLI is a tool for building and deploying MCP servers with support for ChatGPT Apps, Code Mode, OAuth, Notifications, Sampling, Observability and more.",
   "author": "mcp-use, Inc.",
   "license": "MIT",

--- a/libraries/typescript/packages/inspector/CHANGELOG.md
+++ b/libraries/typescript/packages/inspector/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @mcp-use/inspector
 
+## 8.0.2-canary.0
+
+### Patch Changes
+
+- Updated dependencies [f9fb29b]
+  - mcp-use@1.30.2-canary.0
+
 ## 8.0.1
 
 ### Patch Changes

--- a/libraries/typescript/packages/inspector/package.json
+++ b/libraries/typescript/packages/inspector/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-use/inspector",
   "type": "module",
-  "version": "8.0.1",
+  "version": "8.0.2-canary.0",
   "description": "MCP Inspector - A tool for inspecting and debugging MCP servers",
   "author": "",
   "license": "MIT",
@@ -80,7 +80,7 @@
   },
   "peerDependencies": {
     "express": "^4.21.2 || ^5.0.0",
-    "mcp-use": ">=1.30.1-canary.0",
+    "mcp-use": ">=1.30.2-canary.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
     "react-router": "^7.12.0"

--- a/libraries/typescript/packages/mcp-use/CHANGELOG.md
+++ b/libraries/typescript/packages/mcp-use/CHANGELOG.md
@@ -1,5 +1,13 @@
 # mcp-use
 
+## 1.30.2-canary.0
+
+### Patch Changes
+
+- f9fb29b: Downgrade chalk to v4 to fix CJS builds. chalk 5 is ESM-only and is kept external by tsup, so the CJS bundle's `require("chalk")` on Node ≥ 22 returned the module namespace instead of the chalk instance, crashing CJS-built backends (e.g. the Next.js template) on startup with `TypeError: import_chalk.default.gray is not a function`.
+  - @mcp-use/cli@3.4.1-canary.0
+  - @mcp-use/inspector@8.0.2-canary.0
+
 ## 1.30.1
 
 ### Patch Changes

--- a/libraries/typescript/packages/mcp-use/package.json
+++ b/libraries/typescript/packages/mcp-use/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-use",
   "type": "module",
-  "version": "1.30.1",
+  "version": "1.30.2-canary.0",
   "packageManager": "pnpm@10.26.0+sha512.3b3f6c725ebe712506c0ab1ad4133cf86b1f4b687effce62a9b38b4d72e3954242e643190fc51fa1642949c735f403debd44f5cb0edd657abe63a8b6a7e1e402",
   "description": "Opinionated MCP Framework for TypeScript (@modelcontextprotocol/sdk compatible) - Build MCP Agents, Clients and Servers with support for ChatGPT Apps, Code Mode, OAuth, Notifications, Sampling, Observability and more.",
   "author": "mcp-use, Inc.",

--- a/libraries/typescript/packages/mcp-use/package.json
+++ b/libraries/typescript/packages/mcp-use/package.json
@@ -224,6 +224,7 @@
     "@mcp-use/inspector": "workspace:*",
     "@modelcontextprotocol/ext-apps": "1.0.1",
     "@modelcontextprotocol/sdk": "1.26.0",
+    "chalk": "4.1.2",
     "express": "5.2.1",
     "hono": "4.12.23",
     "jose": "6.1.3",
@@ -232,7 +233,6 @@
     "posthog-node": "5.24.17"
   },
   "optionalDependencies": {
-    "chalk": "4.1.2",
     "cli-highlight": "2.1.11",
     "redis": "5.10.0"
   },

--- a/libraries/typescript/packages/mcp-use/package.json
+++ b/libraries/typescript/packages/mcp-use/package.json
@@ -232,7 +232,7 @@
     "posthog-node": "5.24.17"
   },
   "optionalDependencies": {
-    "chalk": "5.6.2",
+    "chalk": "4.1.2",
     "cli-highlight": "2.1.11",
     "redis": "5.10.0"
   },

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -601,8 +601,8 @@ importers:
         version: 4.3.5
     optionalDependencies:
       chalk:
-        specifier: 5.6.2
-        version: 5.6.2
+        specifier: 4.1.2
+        version: 4.1.2
       cli-highlight:
         specifier: 2.1.11
         version: 2.1.11

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -523,6 +523,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: '>=1.25.2'
         version: 1.27.1(patch_hash=c19f2c8d79a374e03317396864f51a5d896e73b8a2231766cdc88bfbac98161e)(@cfworker/json-schema@4.1.1)(zod@4.3.5)
+      chalk:
+        specifier: 4.1.2
+        version: 4.1.2
       express:
         specifier: 5.2.1
         version: 5.2.1
@@ -600,9 +603,6 @@ importers:
         specifier: 4.3.5
         version: 4.3.5
     optionalDependencies:
-      chalk:
-        specifier: 4.1.2
-        version: 4.1.2
       cli-highlight:
         specifier: 2.1.11
         version: 2.1.11


### PR DESCRIPTION
## Why

Follow-up to #1697, addressing a point raised by Copilot there: `chalk` was listed in `optionalDependencies`, but it is imported statically in server code (`src/server/logging.ts`, `src/server/utils/server-lifecycle.ts`). Unlike `src/agents/display.ts` — which dynamically imports its display deps with a plain-text fallback — those modules fail at load time if the package is missing. So installs that skip optional packages (`pnpm install --no-optional`, `npm config set optional false`) crash the server, meaning chalk wasn't truly optional.

## Change

- Move `chalk@4.1.2` from `optionalDependencies` to `dependencies` (lockfile importer entry moved accordingly, validated with `pnpm install --frozen-lockfile`)
- Patch changeset included

`cli-highlight` and `redis` stay optional — they are dynamically imported with fallbacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)