### PR TITLE
fix(mcp-use): move chalk to regular dependencies (statically imported, not optional)

### DIFF
--- a/libraries/typescript/.changeset/chalk-regular-dependency.md
+++ b/libraries/typescript/.changeset/chalk-regular-dependency.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Move chalk from optionalDependencies to dependencies. It is statically imported by server code (`src/server/logging.ts`, `src/server/utils/server-lifecycle.ts`), so installs that skip optional packages (`pnpm install --no-optional`, `npm config set optional false`) would fail at module load.

--- a/libraries/typescript/packages/mcp-use/package.json
+++ b/libraries/typescript/packages/mcp-use/package.json
@@ -224,6 +224,7 @@
     "@mcp-use/inspector": "workspace:*",
     "@modelcontextprotocol/ext-apps": "1.0.1",
     "@modelcontextprotocol/sdk": "1.26.0",
+    "chalk": "4.1.2",
     "express": "5.2.1",
     "hono": "4.12.23",
     "jose": "6.1.3",
@@ -232,7 +233,6 @@
     "posthog-node": "5.24.17"
   },
   "optionalDependencies": {
-    "chalk": "4.1.2",
     "cli-highlight": "2.1.11",
     "redis": "5.10.0"
   },

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -523,6 +523,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: '>=1.25.2'
         version: 1.27.1(patch_hash=c19f2c8d79a374e03317396864f51a5d896e73b8a2231766cdc88bfbac98161e)(@cfworker/json-schema@4.1.1)(zod@4.3.5)
+      chalk:
+        specifier: 4.1.2
+        version: 4.1.2
       express:
         specifier: 5.2.1
         version: 5.2.1
@@ -600,9 +603,6 @@ importers:
         specifier: 4.3.5
         version: 4.3.5
     optionalDependencies:
-      chalk:
-        specifier: 4.1.2
-        version: 4.1.2
       cli-highlight:
         specifier: 2.1.11
         version: 2.1.11


### PR DESCRIPTION
## Why

Redo of #1700 (closed — its branch conflicted after canary was reset for the 1.30.2 release), addressing a point raised by Copilot on #1697: `chalk` is listed in `optionalDependencies`, but it is imported statically in server code (`src/server/logging.ts`, `src/server/utils/server-lifecycle.ts`). Unlike `src/agents/display.ts` — which dynamically imports its display deps with a plain-text fallback — those modules fail at load time if the package is missing. So installs that skip optional packages (`pnpm install --no-optional`, `npm config set optional false`) crash the server, meaning chalk isn't truly optional.

## Change

- Move `chalk@4.1.2` from `optionalDependencies` to `dependencies` (lockfile importer entry moved accordingly, validated with `pnpm install --frozen-lockfile`)
- Patch changeset included

`cli-highlight` and `redis` stay optional — they are dynamically imported with fallbacks.

Linear: MCP-2418

🤖 Generated with [Claude Code](https://claude.com/claude-code)