### PR TITLE
feat(cli): add servers update subcommand to mutate productionBranch and server config

### DIFF
--- a/libraries/typescript/.changeset/cli-servers-update.md
+++ b/libraries/typescript/.changeset/cli-servers-update.md
@@ -1,0 +1,7 @@
+---
+"@mcp-use/cli": minor
+---
+
+Add `servers update` subcommand to mutate server-level config after creation.
+
+Previously there was no way to change `productionBranch` (or `buildCommand` / `startCommand` / `name`) on an existing server without deleting and recreating it — losing the URL slug and all env vars.

--- a/libraries/typescript/packages/cli/src/commands/servers.ts
+++ b/libraries/typescript/packages/cli/src/commands/servers.ts
@@ -1,5 +1,6 @@
 import chalk from "chalk";
 import { Command } from "commander";
+import type { UpdateServerBody } from "../utils/api.js";
 import { McpUseAPI } from "../utils/api.js";
 import { getMcpServerUrlForCloudServer } from "../utils/cloud-urls.js";
 import { getWebUrl, isLoggedIn, readConfig } from "../utils/config.js";
@@ -360,6 +361,67 @@ async function deleteServerCommand(
   }
 }
 
+async function updateServerCommand(
+  idOrSlug: string,
+  options: {
+    branch?: string;
+    name?: string;
+    buildCommand?: string;
+    startCommand?: string;
+    description?: string;
+    org?: string;
+  }
+): Promise<void> {
+  try {
+    if (!(await isLoggedIn())) {
+      console.log(chalk.red("✗ You are not logged in."));
+      console.log(
+        chalk.gray(
+          "Run " + chalk.white("npx mcp-use login") + " to get started."
+        )
+      );
+      process.exit(1);
+    }
+
+    const body: UpdateServerBody = {};
+    if (options.branch !== undefined) body.branch = options.branch;
+    if (options.name !== undefined) body.name = options.name;
+    if (options.buildCommand !== undefined)
+      body.buildCommand = options.buildCommand;
+    if (options.startCommand !== undefined)
+      body.startCommand = options.startCommand;
+    if (options.description !== undefined)
+      body.description = options.description;
+
+    if (Object.keys(body).length === 0) {
+      console.error(
+        chalk.red(
+          "✗ Nothing to update. Provide at least one of: --branch, --name, --build-command, --start-command, --description."
+        )
+      );
+      process.exit(1);
+    }
+
+    const api = await McpUseAPI.create();
+    await applyOrgOption(api, options.org);
+    if (options.org) console.log();
+
+    const server = await api.updateServer(idOrSlug, body);
+
+    const label = server.name || server.slug || server.id;
+    console.log(chalk.green.bold(`\n✓ Server updated: ${label}`));
+    if (server.connectedRepository) {
+      console.log(
+        chalk.gray("  Prod branch: ") +
+          chalk.cyan(server.connectedRepository.productionBranch)
+      );
+    }
+    console.log();
+  } catch (error) {
+    handleCommandError(error, "Failed to update server");
+  }
+}
+
 export function createServersCommand(): Command {
   const serversCommand = new Command("servers")
     .description("Manage cloud servers (Git-backed deploy targets)")
@@ -383,6 +445,21 @@ export function createServersCommand(): Command {
     .option("--org <slug-or-id>", "Resolve org context before fetch")
     .description("Show server details and recent deployments")
     .action(getServerCommand);
+
+  serversCommand
+    .command("update")
+    .argument("<id-or-slug>", "Server UUID or slug")
+    .description("Update server configuration (branch, name, commands, …)")
+    .option(
+      "--branch <name>",
+      "New production branch — controls which branch triggers production deploys"
+    )
+    .option("--name <name>", "Rename the server")
+    .option("--build-command <cmd>", "Override the build command")
+    .option("--start-command <cmd>", "Override the start command")
+    .option("--description <text>", "Update the server description")
+    .option("--org <slug-or-id>", "Target organization")
+    .action(updateServerCommand);
 
   serversCommand
     .command("delete")

--- a/libraries/typescript/packages/cli/src/utils/api.ts
+++ b/libraries/typescript/packages/cli/src/utils/api.ts
@@ -253,6 +253,18 @@ interface GitHubReposResponse {
   repos: GitHubRepo[];
 }
 
+// ── Server update ───────────────────────────────────────────────────
+
+export interface UpdateServerBody {
+  name?: string;
+  description?: string;
+  // New production branch(e.g."main"). Takes effect on next deploy.
+  branch?: string;
+  buildCommand?: string;
+  startCommand?: string;
+  tags?: string[];
+}
+
 // ── Env Variables ───────────────────────────────────────────────────
 
 export type EnvEnvironment = "production" | "preview" | "development";
@@ -468,6 +480,13 @@ export class McpUseAPI {
         method: "DELETE",
       }
     );
+  }
+
+  async updateServer(id: string, body: UpdateServerBody): Promise<CloudServer> {
+    return this.request<CloudServer>(`/servers/${encodeURIComponent(id)}`, {
+      method: "PATCH",
+      body: JSON.stringify(body),
+    });
   }
 
   // ── Env Variables ────────────────────────────────────────────────


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

Check all that apply:
- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes
Adds a servers update subcommand to `@mcp-use/cli` that lets users mutate server-level configuration (production branch, name, build/start commands, description) on an existing cloud server without deleting and recreating it.

## Review Readiness

Help maintainers review this quickly:

- [x] The PR is scoped to one issue or one clearly related change
- [x] The PR description explains the user-visible problem and the fix
- [x] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [x] I verified the affected package/docs path with the commands listed below
- [x] I checked for existing open PRs that already solve the same issue

## Implementation Details
- `servers.ts` - added `updateServerCommand()` function and wired it as `servers update <id-or-slug>` with `--branch, --name, --build-command, --start-command, --description, --org flags`. Validates that at least one flag is provided before hitting the API.
- `api.ts` - added `UpdateServerBody` interface (exported) and `McpUseAPI.updateServer(id, body)` which issues a `PATCH /servers/:id` request.

---

## TypeScript Checklist

### Packages Modified

Check all packages that were modified:
- [ ] `docs`
- [ ] `tests`
- [x] `cli`
- [ ] `create-mcp-use-app`
- [ ] `mcp-use` (server)
- [ ] `mcp-use` (client)
- [ ] `inspector`

### Pre-commit Checklist

Ensure all of the following have been completed:
- [x] Ran `pnpm lint:fix` to auto-fix linting issues
- [x] Ran `pnpm format` to format code with Prettier
- [x] Ran `pnpm build` and build succeeds without errors
- [x] Ran `pnpm changeset` to create a changeset (if this PR includes user-facing changes)
- [ ] Added or updated tests if needed
- [ ] Updated documentation in `docs/` folder if needed

---

## Testing
- `node dist/index.cjs servers --help`
```
Usage: mcp-use servers [options] [command]

Manage cloud servers (Git-backed deploy targets)

Options:
  -h, --help                       display help for command

Commands:
  list|ls [options]                List servers for the current organization
  get [options] <id-or-slug>       Show server details and recent deployments
  update [options] <id-or-slug>    Update server configuration (branch, name, commands, …)
  delete|rm [options] <server-id>  Delete a server and all its deployments
  env                              Manage environment variables for a server
  help [command]                   display help for command
```
- `node dist/index.cjs servers update --help`
```
Usage: mcp-use servers update [options] <id-or-slug>

Update server configuration (branch, name, commands, …)

Arguments:
  id-or-slug             Server UUID or slug

Options:
  --branch <name>        New production branch — controls which branch triggers production deploys
  --name <name>          Rename the server
  --build-command <cmd>  Override the build command
  --start-command <cmd>  Override the start command
  --description <text>   Update the server description
  --org <slug-or-id>     Target organization
  -h, --help             display help for command
```
- `node dist/index.cjs servers update some-id`
```
✗ Nothing to update. Provide at least one of: --branch, --name, --build-command, --start-command, --description.
```
- `node dist/index.cjs servers update 00000000-0000-0000-0000-000000000000 --branch main`
```
✗ Failed to update server: API request failed: 404 {"error":"Server not found"}
```
it does not showing 405, proving the route exists and is authenticated.

## Related Issues
Closes #1546