### PR TITLE
feat(cli): servers update + branch-scoped env/deploy management

### DIFF
--- a/libraries/typescript/.changeset/cli-servers-update-env-branch.md
+++ b/libraries/typescript/.changeset/cli-servers-update-env-branch.md
@@ -4,7 +4,7 @@
 
 Add `servers update` and branch-scoped environment management to the CLI.
 
-- `mcp-use servers update <id-or-slug>` mutates server config in place (production branch, name, description, build/start commands) without deleting and recreating the server — preserving the URL slug and env vars. `--branch` maps to the backend `productionBranch`; `--build-command`/`--start-command` are stored under the server `config`.
+- `mcp-use servers update <id-or-slug>` mutates server config in place (production branch, name, description, build/start commands) without deleting and recreating the server — preserving the URL slug and env vars. `--branch` maps to the backend `productionBranch`; `--build-command`/`--start-command` are stored under the server `config`. Pass an empty string to either flag to clear the override (`null` merge-patch on the backend).
 - `mcp-use deploy` gains `--branch <name>` (defaults to the current git branch) and scopes `--env`/`--env-file` sync to that branch's preview environment.
 - `mcp-use servers env list/add/update/rm` gain `--branch <name>` for branch-scoped variables, and `update`/`rm` now accept a variable KEY (resolved within the branch scope) in addition to a UUID.
 - `mcp-use deployments restart` gains `--branch <name>` (defaults to the deployment's branch).

--- a/libraries/typescript/.changeset/cli-servers-update-env-branch.md
+++ b/libraries/typescript/.changeset/cli-servers-update-env-branch.md
@@ -1,0 +1,10 @@
+---
+"@mcp-use/cli": minor
+---
+
+Add `servers update` and branch-scoped environment management to the CLI.
+
+- `mcp-use servers update <id-or-slug>` mutates server config in place (production branch, name, description, build/start commands) without deleting and recreating the server — preserving the URL slug and env vars. `--branch` maps to the backend `productionBranch`; `--build-command`/`--start-command` are stored under the server `config`.
+- `mcp-use deploy` gains `--branch <name>` (defaults to the current git branch) and scopes `--env`/`--env-file` sync to that branch's preview environment.
+- `mcp-use servers env list/add/update/rm` gain `--branch <name>` for branch-scoped variables, and `update`/`rm` now accept a variable KEY (resolved within the branch scope) in addition to a UUID.
+- `mcp-use deployments restart` gains `--branch <name>` (defaults to the deployment's branch).

--- a/libraries/typescript/packages/cli/README.md
+++ b/libraries/typescript/packages/cli/README.md
@@ -187,10 +187,15 @@ mcp-use servers update my-server --branch main
 # Override build / start commands or rename the server
 mcp-use servers update my-server --build-command "npm run build" --start-command "npm start"
 mcp-use servers update my-server --name "My Server" --description "…"
+
+# Clear a build/start override (pass an empty string)
+mcp-use servers update my-server --build-command "" --start-command ""
 ```
 
 Flags: `--branch` (production branch), `--name`, `--description`,
 `--build-command`, `--start-command`, `--org`. At least one is required.
+Pass an empty string to `--build-command` or `--start-command` to remove the
+stored override.
 
 ### `servers env` — environment variables
 

--- a/libraries/typescript/packages/cli/README.md
+++ b/libraries/typescript/packages/cli/README.md
@@ -147,6 +147,9 @@ mcp-use logout
 - `--name <name>` - Custom deployment name
 - `--port <port>` - Server port (default: 3000)
 - `--runtime <runtime>` - Runtime environment: "node" or "python"
+- `--branch <name>` - Deploy branch (default: current git branch). Also scopes `--env` / `--env-file` sync to that branch's preview env.
+- `--env <key=value...>` - Set environment variable **values** (repeatable)
+- `--env-file <path>` - Load environment variable values from a `.env` file
 - `--open` - Open deployment in browser after success
 
 **Example:**
@@ -160,7 +163,75 @@ mcp-use deploy --no-github
 
 # Deploy with custom options
 mcp-use deploy --name my-server --port 8000 --open
+
+# Deploy a branch and scope env values to its preview env
+mcp-use deploy --branch feature-x --env API_KEY=abc123
 ```
+
+---
+
+## ☁️ Managing cloud servers
+
+After a server exists you can update its configuration and environment
+variables without redeploying from scratch.
+
+### `servers update`
+
+Mutate server-level config in place (no delete/recreate, so the URL slug and
+env vars are preserved):
+
+```bash
+# Change the production branch (which branch triggers production deploys)
+mcp-use servers update my-server --branch main
+
+# Override build / start commands or rename the server
+mcp-use servers update my-server --build-command "npm run build" --start-command "npm start"
+mcp-use servers update my-server --name "My Server" --description "…"
+```
+
+Flags: `--branch` (production branch), `--name`, `--description`,
+`--build-command`, `--start-command`, `--org`. At least one is required.
+
+### `servers env` — environment variables
+
+```bash
+# List (production scope), or scope to a branch's preview env
+mcp-use servers env list --server <id>
+mcp-use servers env list --server <id> --branch feature-x
+
+# Add a variable. --env selects which environment TAGS it applies to;
+# --branch pins it to a branch's preview env (omit for production).
+mcp-use servers env add API_KEY=abc123 --server <id> --env production,preview
+mcp-use servers env add API_KEY=abc123 --server <id> --branch feature-x
+
+# Update / remove by KEY (resolved within the branch scope) or by UUID
+mcp-use servers env update API_KEY --server <id> --value newval --branch feature-x
+mcp-use servers env rm API_KEY --server <id> --branch feature-x
+```
+
+### `deployments restart`
+
+```bash
+# Restart reusing the deployment's branch, or target a different branch
+mcp-use deployments restart <deployment-id>
+mcp-use deployments restart <deployment-id> --branch feature-x
+```
+
+### Environment naming
+
+The platform models environments as `production`, `preview`, and
+`development` (the `--env` tag) plus an optional **branch** pin (`--branch`).
+There is no literal `test` environment. Common aliases map as:
+
+| You might say | Use |
+| --- | --- |
+| `prod` | `production` |
+| `dev` | `development` |
+| `staging` / per-branch | a `--branch <name>` preview (optionally tagged `preview`) |
+
+Note the two different `--env` meanings: on `deploy` it sets variable
+**values** (`KEY=VALUE`), while on `servers env` it selects the environment
+**tags** a variable applies to (`production,preview,development`).
 
 ---
 

--- a/libraries/typescript/packages/cli/src/commands/deploy.ts
+++ b/libraries/typescript/packages/cli/src/commands/deploy.ts
@@ -2,7 +2,11 @@ import chalk from "chalk";
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import open from "open";
-import type { GitHubConnectionStatus, OrgInfo } from "../utils/api.js";
+import type {
+  EnvEnvironment,
+  GitHubConnectionStatus,
+  OrgInfo,
+} from "../utils/api.js";
 import {
   ApiUnauthorizedError,
   GitHubAuthRequiredError,
@@ -115,12 +119,18 @@ function parseEnvVar(envStr: string): { key: string; value: string } {
 export async function syncEnvVarsToServer(
   api: McpUseAPI,
   serverId: string,
-  envVars: Record<string, string>
+  envVars: Record<string, string>,
+  opts?: { branch?: string; environments?: EnvEnvironment[] }
 ): Promise<{ created: number; updated: number }> {
   const entries = Object.entries(envVars);
   if (entries.length === 0) return { created: 0, updated: 0 };
 
-  const existing = await api.listEnvVariables(serverId);
+  // Scope the sync to the deploy branch's preview env when a branch is given;
+  // otherwise operate on production scope (branch IS NULL), matching prior behavior.
+  const existing = await api.listEnvVariables(
+    serverId,
+    opts?.branch ? { branch: opts.branch } : undefined
+  );
   const byKey = new Map(existing.map((v) => [v.key, v]));
 
   const results = await Promise.all(
@@ -130,7 +140,12 @@ export async function syncEnvVarsToServer(
         await api.updateEnvVariable(serverId, found.id, { value });
         return "updated" as const;
       }
-      await api.createEnvVariable(serverId, { key, value });
+      await api.createEnvVariable(serverId, {
+        key,
+        value,
+        ...(opts?.branch ? { branch: opts.branch } : {}),
+        ...(opts?.environments ? { environments: opts.environments } : {}),
+      });
       return "created" as const;
     })
   );
@@ -195,6 +210,11 @@ interface DeployOptions {
   region?: "US" | "EU" | "APAC";
   buildCommand?: string;
   startCommand?: string;
+  /**
+   * Deploy branch. Defaults to the current git branch (managed flow: "main").
+   * Also scopes env-var sync to that branch's preview env.
+   */
+  branch?: string;
   /**
    * Upload local source without connecting the user's GitHub. Uses the
    * platform-managed org and a tarball instead of pushing to a user repo.
@@ -720,7 +740,7 @@ async function deployViaManagedUpload(
   }
 
   const envVars = await buildEnvVars(options);
-  const branch = "main";
+  const branch = options.branch || "main";
   const projectName = options.name || (await getProjectName(projectDir));
 
   console.log(chalk.gray("Packaging project source..."));
@@ -756,7 +776,12 @@ async function deployViaManagedUpload(
   if (serverId) {
     console.log(chalk.gray("Uploading source and redeploying..."));
     if (Object.keys(envVars).length > 0) {
-      await syncEnvVarsToServer(api, serverId, envVars);
+      await syncEnvVarsToServer(
+        api,
+        serverId,
+        envVars,
+        options.branch ? { branch: options.branch } : undefined
+      );
     }
     await api.pushSourceToServer(serverId, {
       tarball,
@@ -1073,7 +1098,7 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
 
     let gitInfo = await getGitInfo(cwd);
     let repoFullName: string | undefined;
-    let branch: string = "main";
+    let branch: string = options.branch || "main";
 
     if (!gitInfo.isGitRepo || !gitInfo.remoteUrl) {
       // No git repo or no remote — offer to create one
@@ -1271,7 +1296,7 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
 
       gitInfo = await getGitInfo(cwd);
       repoFullName = repoResult.fullName;
-      branch = gitInfo.branch || "main";
+      branch = options.branch || gitInfo.branch || "main";
     } else if (!isGitHubUrl(gitInfo.remoteUrl!)) {
       console.log(chalk.red("✗ Remote is not a GitHub repository"));
       console.log(chalk.yellow(`   Current remote: ${gitInfo.remoteUrl}\n`));
@@ -1281,7 +1306,7 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
       process.exit(1);
     } else {
       repoFullName = `${gitInfo.owner}/${gitInfo.repo}`;
-      branch = gitInfo.branch || "main";
+      branch = options.branch || gitInfo.branch || "main";
 
       // Resolve installation matching the repo owner
       const ownerLower = gitInfo.owner!.toLowerCase();
@@ -1451,7 +1476,12 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
           console.log(chalk.cyan(`  URL: ${getMcpServerUrl(existingDep)}\n`));
 
           if (Object.keys(envVars).length > 0) {
-            const synced = await syncEnvVarsToServer(api, serverId, envVars);
+            const synced = await syncEnvVarsToServer(
+              api,
+              serverId,
+              envVars,
+              options.branch ? { branch: options.branch } : undefined
+            );
             console.log(
               chalk.green(
                 `✓ Synced ${synced.created + synced.updated} environment variable(s)` +
@@ -1508,7 +1538,12 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
 
     if (serverId) {
       if (Object.keys(envVars).length > 0) {
-        const synced = await syncEnvVarsToServer(api, serverId, envVars);
+        const synced = await syncEnvVarsToServer(
+          api,
+          serverId,
+          envVars,
+          options.branch ? { branch: options.branch } : undefined
+        );
         console.log(
           chalk.green(
             `✓ Synced ${synced.created + synced.updated} environment variable(s)` +

--- a/libraries/typescript/packages/cli/src/commands/deployments.ts
+++ b/libraries/typescript/packages/cli/src/commands/deployments.ts
@@ -279,7 +279,7 @@ async function getDeploymentCommand(deploymentId: string): Promise<void> {
 
 async function restartDeploymentCommand(
   deploymentId: string,
-  options: { follow?: boolean }
+  options: { follow?: boolean; branch?: string }
 ): Promise<void> {
   try {
     if (!(await isLoggedIn())) {
@@ -306,8 +306,12 @@ async function restartDeploymentCommand(
       chalk.cyan.bold(`\n🔄 Restarting deployment: ${deployment.name}\n`)
     );
 
+    // Reuse the deployment's branch by default; `--branch` overrides to target
+    // a different branch's preview.
+    const branch = options.branch ?? deployment.gitBranch ?? undefined;
     const newDep = await api.createDeployment({
       serverId: deployment.serverId,
+      ...(branch ? { branch } : {}),
       trigger: "redeploy",
     });
 
@@ -615,6 +619,10 @@ export function createDeploymentsCommand(): Command {
     .command("restart")
     .argument("<deployment-id>", "Deployment ID")
     .option("-f, --follow", "Follow build logs")
+    .option(
+      "--branch <name>",
+      "Target branch for the redeploy (default: the deployment's branch)"
+    )
     .description(
       "Restart a deployment (triggers a new deployment on the same server)"
     )

--- a/libraries/typescript/packages/cli/src/commands/env.ts
+++ b/libraries/typescript/packages/cli/src/commands/env.ts
@@ -41,6 +41,54 @@ function envBadge(env: EnvEnvironment): string {
   return chalk.blue("dev");
 }
 
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Resolve an env-var reference (UUID or KEY) to its variable id. A UUID is used
+ * directly; otherwise the key is looked up within the given branch scope
+ * (omit branch for production / branch IS NULL).
+ */
+async function resolveVarId(
+  api: McpUseAPI,
+  server: string,
+  keyOrId: string,
+  branch?: string
+): Promise<string> {
+  if (UUID_RE.test(keyOrId)) return keyOrId;
+
+  const vars = await api.listEnvVariables(
+    server,
+    branch ? { branch } : undefined
+  );
+  const matches = vars.filter((v) => v.key === keyOrId);
+  const scope = branch ? `branch "${branch}"` : "production";
+  if (matches.length === 0) {
+    console.error(
+      chalk.red(
+        `✗ No environment variable with key "${keyOrId}" in ${scope} scope.`
+      )
+    );
+    console.error(
+      chalk.gray(
+        branch
+          ? "Check the key, or omit --branch to target production scope."
+          : "Check the key, or pass --branch <name> if it lives on a branch."
+      )
+    );
+    process.exit(1);
+  }
+  if (matches.length > 1) {
+    console.error(
+      chalk.red(
+        `✗ Multiple variables match key "${keyOrId}" in ${scope} scope. Pass the variable id instead.`
+      )
+    );
+    process.exit(1);
+  }
+  return matches[0].id;
+}
+
 function printEnvVar(v: EnvVariable, showValue = false): void {
   const envs = v.environments.map(envBadge).join(" ");
   const val = v.sensitive
@@ -48,9 +96,10 @@ function printEnvVar(v: EnvVariable, showValue = false): void {
     : showValue
       ? chalk.cyan(v.value)
       : chalk.gray("(hidden — use --show-values to reveal)");
+  const branch = v.branch ? "  " + chalk.magenta(`branch:${v.branch}`) : "";
   console.log(`  ${chalk.white.bold(v.key.padEnd(32))} ${val}`);
   console.log(
-    `    ${chalk.gray("id:")} ${chalk.gray(v.id)}  ${envs}${v.sensitive ? "  " + chalk.yellow("🔒 sensitive") : ""}`
+    `    ${chalk.gray("id:")} ${chalk.gray(v.id)}  ${envs}${branch}${v.sensitive ? "  " + chalk.yellow("🔒 sensitive") : ""}`
   );
 }
 
@@ -66,22 +115,31 @@ async function requireLogin(): Promise<void> {
 
 async function listEnvCommand(options: {
   server: string;
+  branch?: string;
   showValues?: boolean;
 }): Promise<void> {
   try {
     await requireLogin();
 
     const api = await McpUseAPI.create();
-    const vars = await api.listEnvVariables(options.server);
+    const vars = await api.listEnvVariables(
+      options.server,
+      options.branch ? { branch: options.branch } : undefined
+    );
 
+    const scope = options.branch ? `branch "${options.branch}"` : "production";
     if (vars.length === 0) {
       console.log(
-        chalk.yellow("\nNo environment variables set for this server.\n")
+        chalk.yellow(
+          `\nNo environment variables set for this server (${scope} scope).\n`
+        )
       );
       return;
     }
 
-    console.log(chalk.cyan.bold(`\nEnvironment Variables (${vars.length})\n`));
+    console.log(
+      chalk.cyan.bold(`\nEnvironment Variables — ${scope} (${vars.length})\n`)
+    );
     for (const v of vars) {
       printEnvVar(v, options.showValues);
       console.log();
@@ -93,7 +151,12 @@ async function listEnvCommand(options: {
 
 async function addEnvCommand(
   assignment: string,
-  options: { server: string; env?: string; sensitive?: boolean }
+  options: {
+    server: string;
+    env?: string;
+    branch?: string;
+    sensitive?: boolean;
+  }
 ): Promise<void> {
   try {
     await requireLogin();
@@ -125,6 +188,7 @@ async function addEnvCommand(
       key,
       value,
       environments,
+      ...(options.branch ? { branch: options.branch } : {}),
       sensitive: options.sensitive ?? false,
     });
 
@@ -139,8 +203,14 @@ async function addEnvCommand(
 }
 
 async function updateEnvCommand(
-  varId: string,
-  options: { server: string; value?: string; env?: string; sensitive?: boolean }
+  keyOrId: string,
+  options: {
+    server: string;
+    value?: string;
+    env?: string;
+    branch?: string;
+    sensitive?: boolean;
+  }
 ): Promise<void> {
   try {
     await requireLogin();
@@ -164,6 +234,12 @@ async function updateEnvCommand(
     if (options.sensitive !== undefined) body.sensitive = options.sensitive;
 
     const api = await McpUseAPI.create();
+    const varId = await resolveVarId(
+      api,
+      options.server,
+      keyOrId,
+      options.branch
+    );
     const updated = await api.updateEnvVariable(options.server, varId, body);
 
     console.log(
@@ -177,16 +253,22 @@ async function updateEnvCommand(
 }
 
 async function removeEnvCommand(
-  varId: string,
-  options: { server: string }
+  keyOrId: string,
+  options: { server: string; branch?: string }
 ): Promise<void> {
   try {
     await requireLogin();
 
     const api = await McpUseAPI.create();
+    const varId = await resolveVarId(
+      api,
+      options.server,
+      keyOrId,
+      options.branch
+    );
     await api.deleteEnvVariable(options.server, varId);
 
-    console.log(chalk.green(`\n✓ Environment variable ${varId} removed.\n`));
+    console.log(chalk.green(`\n✓ Environment variable ${keyOrId} removed.\n`));
   } catch (error) {
     handleCommandError(error, "Failed to remove environment variable");
   }
@@ -202,6 +284,10 @@ export function createEnvCommand(): Command {
     .alias("ls")
     .description("List environment variables for a server")
     .requiredOption("--server <id>", "Server UUID")
+    .option(
+      "--branch <name>",
+      "Scope to a branch's preview env (omit for production)"
+    )
     .option("--show-values", "Reveal non-sensitive values in output")
     .action(listEnvCommand);
 
@@ -215,6 +301,10 @@ export function createEnvCommand(): Command {
       "Comma-separated environments: production,preview,development (default: all)"
     )
     .option(
+      "--branch <name>",
+      "Pin the variable to a branch's preview env (omit for production)"
+    )
+    .option(
       "--sensitive",
       "Mark the variable as sensitive (value masked in UI)"
     )
@@ -222,13 +312,17 @@ export function createEnvCommand(): Command {
 
   envCommand
     .command("update")
-    .argument("<var-id>", "Environment variable UUID")
+    .argument("<key-or-id>", "Environment variable KEY or UUID")
     .description("Update an existing environment variable")
     .requiredOption("--server <id>", "Server UUID")
     .option("--value <value>", "New value")
     .option(
       "--env <environments>",
       "New environments (comma-separated: production,preview,development)"
+    )
+    .option(
+      "--branch <name>",
+      "Branch scope used to resolve a KEY (omit for production)"
     )
     .option("--sensitive", "Mark as sensitive")
     .option("--no-sensitive", "Unmark as sensitive")
@@ -237,9 +331,13 @@ export function createEnvCommand(): Command {
   envCommand
     .command("remove")
     .alias("rm")
-    .argument("<var-id>", "Environment variable UUID")
+    .argument("<key-or-id>", "Environment variable KEY or UUID")
     .description("Remove an environment variable from a server")
     .requiredOption("--server <id>", "Server UUID")
+    .option(
+      "--branch <name>",
+      "Branch scope used to resolve a KEY (omit for production)"
+    )
     .action(removeEnvCommand);
 
   return envCommand;

--- a/libraries/typescript/packages/cli/src/commands/servers.ts
+++ b/libraries/typescript/packages/cli/src/commands/servers.ts
@@ -1,5 +1,6 @@
 import chalk from "chalk";
 import { Command } from "commander";
+import type { UpdateServerBody } from "../utils/api.js";
 import { McpUseAPI } from "../utils/api.js";
 import { getMcpServerUrlForCloudServer } from "../utils/cloud-urls.js";
 import { getWebUrl, isLoggedIn, readConfig } from "../utils/config.js";
@@ -304,6 +305,74 @@ async function getServerCommand(idOrSlug: string, options: { org?: string }) {
   }
 }
 
+async function updateServerCommand(
+  idOrSlug: string,
+  options: {
+    branch?: string;
+    name?: string;
+    buildCommand?: string;
+    startCommand?: string;
+    description?: string;
+    org?: string;
+  }
+): Promise<void> {
+  try {
+    if (!(await isLoggedIn())) {
+      console.log(chalk.red("✗ You are not logged in."));
+      console.log(
+        chalk.gray(
+          "Run " + chalk.white("npx mcp-use login") + " to get started."
+        )
+      );
+      process.exit(1);
+    }
+
+    // Map CLI flags to the backend `UpdateServerBody` shape. `--branch` is the
+    // production branch (`productionBranch`); build/start command overrides are
+    // nested under `config` (the backend merges `config` shallowly, so only the
+    // provided keys change).
+    const body: UpdateServerBody = {};
+    if (options.name !== undefined) body.name = options.name;
+    if (options.description !== undefined)
+      body.description = options.description;
+    if (options.branch !== undefined) body.productionBranch = options.branch;
+
+    const config: Record<string, unknown> = {};
+    if (options.buildCommand !== undefined)
+      config.buildCommand = options.buildCommand;
+    if (options.startCommand !== undefined)
+      config.startCommand = options.startCommand;
+    if (Object.keys(config).length > 0) body.config = config;
+
+    if (Object.keys(body).length === 0) {
+      console.error(
+        chalk.red(
+          "✗ Nothing to update. Provide at least one of: --branch, --name, --build-command, --start-command, --description."
+        )
+      );
+      process.exit(1);
+    }
+
+    const api = await McpUseAPI.create();
+    await applyOrgOption(api, options.org);
+    if (options.org) console.log();
+
+    const server = await api.updateServer(idOrSlug, body);
+
+    const label = server.name || server.slug || server.id;
+    console.log(chalk.green.bold(`\n✓ Server updated: ${label}`));
+    if (server.connectedRepository) {
+      console.log(
+        chalk.gray("  Prod branch: ") +
+          chalk.cyan(server.connectedRepository.productionBranch)
+      );
+    }
+    console.log();
+  } catch (error) {
+    handleCommandError(error, "Failed to update server");
+  }
+}
+
 async function deleteServerCommand(
   serverId: string,
   options: { yes?: boolean; org?: string }
@@ -386,6 +455,21 @@ export function createServersCommand(): Command {
     .option("--org <slug-or-id>", "Resolve org context before fetch")
     .description("Show server details and recent deployments")
     .action(getServerCommand);
+
+  serversCommand
+    .command("update")
+    .argument("<id-or-slug>", "Server UUID or slug")
+    .description("Update server configuration (branch, name, commands, …)")
+    .option(
+      "--branch <name>",
+      "New production branch — controls which branch triggers production deploys"
+    )
+    .option("--name <name>", "Rename the server")
+    .option("--build-command <cmd>", "Override the build command")
+    .option("--start-command <cmd>", "Override the start command")
+    .option("--description <text>", "Update the server description")
+    .option("--org <slug-or-id>", "Target organization")
+    .action(updateServerCommand);
 
   serversCommand
     .command("delete")

--- a/libraries/typescript/packages/cli/src/commands/servers.ts
+++ b/libraries/typescript/packages/cli/src/commands/servers.ts
@@ -338,10 +338,15 @@ async function updateServerCommand(
     if (options.branch !== undefined) body.productionBranch = options.branch;
 
     const config: Record<string, unknown> = {};
-    if (options.buildCommand !== undefined)
-      config.buildCommand = options.buildCommand;
-    if (options.startCommand !== undefined)
-      config.startCommand = options.startCommand;
+    if (options.buildCommand !== undefined) {
+      // Empty string clears the override (backend merge-patch: null removes key).
+      config.buildCommand =
+        options.buildCommand === "" ? null : options.buildCommand;
+    }
+    if (options.startCommand !== undefined) {
+      config.startCommand =
+        options.startCommand === "" ? null : options.startCommand;
+    }
     if (Object.keys(config).length > 0) body.config = config;
 
     if (Object.keys(body).length === 0) {
@@ -465,8 +470,14 @@ export function createServersCommand(): Command {
       "New production branch — controls which branch triggers production deploys"
     )
     .option("--name <name>", "Rename the server")
-    .option("--build-command <cmd>", "Override the build command")
-    .option("--start-command <cmd>", "Override the start command")
+    .option(
+      "--build-command <cmd>",
+      "Override the build command (pass an empty string to clear)"
+    )
+    .option(
+      "--start-command <cmd>",
+      "Override the start command (pass an empty string to clear)"
+    )
     .option("--description <text>", "Update the server description")
     .option("--org <slug-or-id>", "Target organization")
     .action(updateServerCommand);

--- a/libraries/typescript/packages/cli/src/index.ts
+++ b/libraries/typescript/packages/cli/src/index.ts
@@ -3039,9 +3039,13 @@ program
   )
   .option(
     "--env <key=value...>",
-    "Environment variables (can be used multiple times)"
+    "Environment variable values as KEY=VALUE (repeatable). Note: this sets values, unlike `servers env --env` which selects environment tags."
   )
   .option("--env-file <path>", "Path to .env file with environment variables")
+  .option(
+    "--branch <name>",
+    "Deploy branch (default: current git branch). Also scopes --env/--env-file sync to that branch's preview env."
+  )
   .option(
     "--root-dir <path>",
     "Root directory within repo to deploy from (for monorepos)"
@@ -3073,6 +3077,7 @@ program
       new: options.new,
       env: options.env,
       envFile: options.envFile,
+      branch: options.branch,
       rootDir: options.rootDir,
       org: options.org,
       yes: options.yes,

--- a/libraries/typescript/packages/cli/src/utils/api.ts
+++ b/libraries/typescript/packages/cli/src/utils/api.ts
@@ -73,6 +73,23 @@ interface CreateServerResponse {
   deploymentId: string | null;
 }
 
+// ── Server update ──────────────────────────────────────────────────
+
+/**
+ * Body for `PATCH /servers/:id`. Field names mirror the backend
+ * `UpdateServerBody` exactly. `productionBranch` controls which branch
+ * triggers production deploys; build/start command overrides live nested
+ * under `config` (the backend merges `config` shallowly with the existing
+ * value, so only the provided keys change).
+ */
+export interface UpdateServerBody {
+  name?: string;
+  description?: string;
+  productionBranch?: string;
+  tags?: string[];
+  config?: Record<string, unknown>;
+}
+
 /** Connected GitHub repository (subset of OpenAPI server payload). */
 interface CloudServerConnectedRepository {
   id: string;
@@ -266,6 +283,8 @@ export interface EnvVariable {
   key: string;
   value: string;
   environments: EnvEnvironment[];
+  /** Branch pin: null/omitted = production scope; a branch name = that branch's preview. */
+  branch?: string | null;
   sensitive: boolean;
   createdAt: string;
   updatedAt: string;
@@ -275,12 +294,16 @@ interface CreateEnvVariableBody {
   key: string;
   value: string;
   environments?: EnvEnvironment[];
+  /** Branch pin (body field). Null/omitted = production scope. */
+  branch?: string | null;
   sensitive?: boolean;
 }
 
 interface UpdateEnvVariableBody {
   value?: string;
   environments?: EnvEnvironment[];
+  /** Branch pin (body field). Null/omitted = production scope. */
+  branch?: string | null;
   sensitive?: boolean;
 }
 
@@ -562,6 +585,19 @@ export class McpUseAPI {
     return this.request<CloudServer>(`/servers/${path}`);
   }
 
+  async updateServer(
+    idOrSlug: string,
+    body: UpdateServerBody
+  ): Promise<CloudServer> {
+    return this.request<CloudServer>(
+      `/servers/${encodeURIComponent(idOrSlug)}`,
+      {
+        method: "PATCH",
+        body: JSON.stringify(body),
+      }
+    );
+  }
+
   async deleteServer(id: string): Promise<void> {
     await this.request<{ success: boolean }>(
       `/servers/${encodeURIComponent(id)}`,
@@ -573,9 +609,13 @@ export class McpUseAPI {
 
   // ── Env Variables ────────────────────────────────────────────────
 
-  async listEnvVariables(serverId: string): Promise<EnvVariable[]> {
+  async listEnvVariables(
+    serverId: string,
+    opts?: { branch?: string }
+  ): Promise<EnvVariable[]> {
+    const q = opts?.branch ? `?branch=${encodeURIComponent(opts.branch)}` : "";
     return this.request<EnvVariable[]>(
-      `/servers/${encodeURIComponent(serverId)}/env-variables`
+      `/servers/${encodeURIComponent(serverId)}/env-variables${q}`
     );
   }
 

--- a/libraries/typescript/packages/cli/tests/deployments.test.ts
+++ b/libraries/typescript/packages/cli/tests/deployments.test.ts
@@ -832,7 +832,10 @@ describe("syncEnvVarsToServer", () => {
       { API_KEY: "abc", DATABASE_URL: "postgres://x" }
     );
 
-    expect(mockApiInstance.listEnvVariables).toHaveBeenCalledWith(SERVER_ID);
+    expect(mockApiInstance.listEnvVariables).toHaveBeenCalledWith(
+      SERVER_ID,
+      undefined
+    );
     expect(mockApiInstance.createEnvVariable).toHaveBeenCalledTimes(2);
     expect(mockApiInstance.createEnvVariable).toHaveBeenCalledWith(SERVER_ID, {
       key: "API_KEY",

--- a/libraries/typescript/packages/cli/tests/servers-update-env-branch.test.ts
+++ b/libraries/typescript/packages/cli/tests/servers-update-env-branch.test.ts
@@ -1,0 +1,267 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Unit tests for the MCP-1794 / `servers update` CLI work:
+ *  - `servers update` field mapping (branch -> productionBranch, build/start
+ *    commands nested under config)
+ *  - env-var branch scoping + resolving a variable by KEY
+ *  - deploy-time env sync honoring a branch scope
+ */
+
+const mockApiInstance = {
+  updateServer: vi.fn(),
+  listEnvVariables: vi.fn(),
+  createEnvVariable: vi.fn(),
+  updateEnvVariable: vi.fn(),
+  deleteEnvVariable: vi.fn(),
+  testAuth: vi.fn(),
+};
+
+vi.mock("../src/utils/api.js", () => {
+  return {
+    McpUseAPI: class {
+      static async create() {
+        return mockApiInstance;
+      }
+      constructor() {
+        return mockApiInstance;
+      }
+    },
+    ApiUnauthorizedError: class ApiUnauthorizedError extends Error {},
+  };
+});
+
+vi.mock("../src/utils/config.js", () => {
+  return {
+    isLoggedIn: vi.fn(async () => true),
+    getApiKey: vi.fn(),
+    getApiUrl: vi.fn(),
+    getOrgId: vi.fn(),
+    getWebUrl: vi.fn(async () => "https://mcp-use.com"),
+    readConfig: vi.fn(async () => ({})),
+  };
+});
+
+// Record handled errors instead of exiting the process.
+const handleCommandError = vi.fn();
+vi.mock("../src/utils/errors.js", () => ({ handleCommandError }));
+
+vi.mock("chalk", () => {
+  const passthrough: any = new Proxy(
+    function passthrough(s: string) {
+      return s;
+    },
+    {
+      get: () => passthrough,
+      apply: (_t, _this, args) => args[0],
+    }
+  );
+  return { default: passthrough };
+});
+
+vi.mock("node:readline", () => {
+  return {
+    createInterface: vi.fn(() => ({
+      question: vi.fn((_q, cb) => cb("y")),
+      close: vi.fn(),
+    })),
+  };
+});
+
+const SERVER_ID = "11111111-1111-1111-1111-111111111111";
+const VAR_ID = "22222222-2222-2222-2222-222222222222";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("servers update field mapping", () => {
+  it("maps --branch to productionBranch and build/start commands into config", async () => {
+    const { createServersCommand } = await import("../src/commands/servers.js");
+    mockApiInstance.updateServer.mockResolvedValue({
+      id: SERVER_ID,
+      name: "my-server",
+      slug: "my-server",
+      connectedRepository: { productionBranch: "dev" },
+    });
+
+    const cmd = createServersCommand();
+    await cmd.parseAsync(
+      [
+        "update",
+        SERVER_ID,
+        "--branch",
+        "dev",
+        "--build-command",
+        "npm run build",
+        "--start-command",
+        "npm start",
+        "--name",
+        "renamed",
+      ],
+      { from: "user" }
+    );
+
+    expect(mockApiInstance.updateServer).toHaveBeenCalledTimes(1);
+    expect(mockApiInstance.updateServer).toHaveBeenCalledWith(SERVER_ID, {
+      name: "renamed",
+      productionBranch: "dev",
+      config: { buildCommand: "npm run build", startCommand: "npm start" },
+    });
+  });
+
+  it("does not call the API when no fields are provided", async () => {
+    const { createServersCommand } = await import("../src/commands/servers.js");
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`exit:${code}`);
+    }) as never);
+
+    const cmd = createServersCommand();
+    await cmd.parseAsync(["update", SERVER_ID], { from: "user" });
+
+    expect(mockApiInstance.updateServer).not.toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+  });
+});
+
+describe("env-var branch scoping + resolve-by-key", () => {
+  it("add --branch pins the variable to the branch scope (body field)", async () => {
+    const { createEnvCommand } = await import("../src/commands/env.js");
+    mockApiInstance.createEnvVariable.mockResolvedValue({
+      id: VAR_ID,
+      key: "FOO",
+      value: "bar",
+      environments: ["preview"],
+      branch: "dev",
+      sensitive: false,
+    });
+
+    const cmd = createEnvCommand();
+    await cmd.parseAsync(
+      [
+        "add",
+        "FOO=bar",
+        "--server",
+        SERVER_ID,
+        "--branch",
+        "dev",
+        "--env",
+        "preview",
+      ],
+      { from: "user" }
+    );
+
+    expect(mockApiInstance.createEnvVariable).toHaveBeenCalledWith(
+      SERVER_ID,
+      expect.objectContaining({
+        key: "FOO",
+        value: "bar",
+        environments: ["preview"],
+        branch: "dev",
+      })
+    );
+  });
+
+  it("update by KEY resolves the id within the branch scope", async () => {
+    const { createEnvCommand } = await import("../src/commands/env.js");
+    mockApiInstance.listEnvVariables.mockResolvedValue([
+      {
+        id: VAR_ID,
+        key: "API_KEY",
+        value: "old",
+        environments: ["production"],
+        branch: "dev",
+        sensitive: false,
+      },
+    ]);
+    mockApiInstance.updateEnvVariable.mockResolvedValue({
+      id: VAR_ID,
+      key: "API_KEY",
+      value: "new",
+      environments: ["production"],
+      branch: "dev",
+      sensitive: false,
+    });
+
+    const cmd = createEnvCommand();
+    await cmd.parseAsync(
+      [
+        "update",
+        "API_KEY",
+        "--server",
+        SERVER_ID,
+        "--branch",
+        "dev",
+        "--value",
+        "new",
+      ],
+      { from: "user" }
+    );
+
+    expect(mockApiInstance.listEnvVariables).toHaveBeenCalledWith(SERVER_ID, {
+      branch: "dev",
+    });
+    expect(mockApiInstance.updateEnvVariable).toHaveBeenCalledWith(
+      SERVER_ID,
+      VAR_ID,
+      expect.objectContaining({ value: "new" })
+    );
+  });
+
+  it("remove by UUID skips the key lookup", async () => {
+    const { createEnvCommand } = await import("../src/commands/env.js");
+    mockApiInstance.deleteEnvVariable.mockResolvedValue(undefined);
+
+    const cmd = createEnvCommand();
+    await cmd.parseAsync(["remove", VAR_ID, "--server", SERVER_ID], {
+      from: "user",
+    });
+
+    expect(mockApiInstance.listEnvVariables).not.toHaveBeenCalled();
+    expect(mockApiInstance.deleteEnvVariable).toHaveBeenCalledWith(
+      SERVER_ID,
+      VAR_ID
+    );
+  });
+
+  it("list --branch scopes the query", async () => {
+    const { createEnvCommand } = await import("../src/commands/env.js");
+    mockApiInstance.listEnvVariables.mockResolvedValue([]);
+
+    const cmd = createEnvCommand();
+    await cmd.parseAsync(["list", "--server", SERVER_ID, "--branch", "dev"], {
+      from: "user",
+    });
+
+    expect(mockApiInstance.listEnvVariables).toHaveBeenCalledWith(SERVER_ID, {
+      branch: "dev",
+    });
+  });
+});
+
+describe("syncEnvVarsToServer branch scoping", () => {
+  it("scopes the list query and create body to the given branch", async () => {
+    const { syncEnvVarsToServer } = await import("../src/commands/deploy.js");
+    mockApiInstance.listEnvVariables.mockResolvedValue([]);
+    mockApiInstance.createEnvVariable.mockResolvedValue({ id: VAR_ID });
+
+    const result = await syncEnvVarsToServer(
+      mockApiInstance as never,
+      SERVER_ID,
+      { API_KEY: "abc" },
+      { branch: "dev" }
+    );
+
+    expect(mockApiInstance.listEnvVariables).toHaveBeenCalledWith(SERVER_ID, {
+      branch: "dev",
+    });
+    expect(mockApiInstance.createEnvVariable).toHaveBeenCalledWith(
+      SERVER_ID,
+      expect.objectContaining({ key: "API_KEY", value: "abc", branch: "dev" })
+    );
+    expect(result).toEqual({ created: 1, updated: 0 });
+  });
+});

--- a/libraries/typescript/packages/cli/tests/servers-update-env-branch.test.ts
+++ b/libraries/typescript/packages/cli/tests/servers-update-env-branch.test.ts
@@ -110,6 +110,25 @@ describe("servers update field mapping", () => {
     });
   });
 
+  it("maps empty --build-command / --start-command to null (clear override)", async () => {
+    const { createServersCommand } = await import("../src/commands/servers.js");
+    mockApiInstance.updateServer.mockResolvedValue({
+      id: SERVER_ID,
+      name: "my-server",
+      slug: "my-server",
+    });
+
+    const cmd = createServersCommand();
+    await cmd.parseAsync(
+      ["update", SERVER_ID, "--build-command", "", "--start-command", ""],
+      { from: "user" }
+    );
+
+    expect(mockApiInstance.updateServer).toHaveBeenCalledWith(SERVER_ID, {
+      config: { buildCommand: null, startCommand: null },
+    });
+  });
+
   it("does not call the API when no fields are provided", async () => {
     const { createServersCommand } = await import("../src/commands/servers.js");
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((

--- a/skills/mcp-apps-builder/references/foundations/deployment.md
+++ b/skills/mcp-apps-builder/references/foundations/deployment.md
@@ -85,8 +85,9 @@ mcp-use deploy [options]
 | `--name <name>`       | Custom deployment name                                       | `package.json` name or directory name |
 | `--port <port>`       | Server port                                                  | `3000`                                |
 | `--runtime <runtime>` | `"node"` or `"python"`                                       | Auto-detected from project files      |
-| `--env <KEY=VALUE>`   | Set environment variable (repeatable)                        | —                                     |
+| `--env <KEY=VALUE>`   | Set environment variable value (repeatable)                  | —                                     |
 | `--env-file <path>`   | Load env vars from a file                                    | —                                     |
+| `--branch <name>`     | Deploy branch; also scopes `--env`/`--env-file` to its preview | current git branch                  |
 | `--open`              | Open deployment in browser after success                     | `false`                               |
 | `--new`               | Force a fresh deployment (ignore existing link)              | `false`                               |
 | `-y, --yes`           | Skip confirmation prompts (non-interactive / CI / agents)    | `false`                               |
@@ -106,6 +107,19 @@ mcp-use deploy --env-file .env.production
 
 **NEVER commit secrets to git.** Use `--env` or `--env-file` for API keys, database URLs, and other sensitive values.
 
+After the server exists, manage env vars (and other config) without redeploying:
+
+```bash
+# Env vars (production scope, or scope to a branch's preview with --branch)
+mcp-use servers env list   --server <id>
+mcp-use servers env add    API_KEY=sk-xxx --server <id> --env production,preview
+mcp-use servers env update API_KEY --server <id> --value sk-yyy   # by KEY or UUID
+mcp-use servers env rm     API_KEY --server <id>
+
+# Server config in place (no delete/recreate): production branch, name, commands
+mcp-use servers update <id> --branch main --build-command "npm run build"
+```
+
 ---
 
 ## Common Mistakes
@@ -115,7 +129,7 @@ mcp-use deploy --env-file .env.production
 - ❌ Running `mcp-use deploy` with uncommitted/unpushed changes
   - ✅ The cloud builds from GitHub — always `git push` first
 - ❌ Hardcoding secrets in code or committing `.env`
-  - ✅ Use `--env` / `--env-file` flags, or `mcp-use deployments env set`
+  - ✅ Use `--env` / `--env-file` flags, or `mcp-use servers env add KEY=VALUE --server <id>`
 - ❌ Forgetting to install the mcp-use GitHub App on the repo
   - ✅ The CLI will prompt you, but you can also install it at `github.com/apps/mcp-use` — or skip GitHub entirely with `mcp-use deploy --no-github`
 - ❌ Running `mcp-use start` without `mcp-use build` first

--- a/skills/mcp-apps-builder/references/foundations/deployment.md
+++ b/skills/mcp-apps-builder/references/foundations/deployment.md
@@ -118,6 +118,7 @@ mcp-use servers env rm     API_KEY --server <id>
 
 # Server config in place (no delete/recreate): production branch, name, commands
 mcp-use servers update <id> --branch main --build-command "npm run build"
+# Clear a build/start override: pass an empty string (--build-command "")
 ```
 
 ---

--- a/skills/openapi-to-mcp/references/deploy.md
+++ b/skills/openapi-to-mcp/references/deploy.md
@@ -45,7 +45,14 @@ The deployed container starts with no env vars. Open the project page in the Man
 - Whatever auth vars you used locally — `API_KEY`, `BEARER_TOKEN`, etc. Use **production** credentials, not your dev key.
 - `PORT` — usually not needed; Manufact sets it automatically.
 
-Restart the deployment after setting vars (the dashboard has a "Restart" button) or push a no-op commit.
+You can also set these from the CLI instead of the dashboard:
+
+```bash
+mcp-use servers env add API_KEY=sk-prod --server <id>
+mcp-use servers env add BASE_URL=https://api.example.com --server <id>
+```
+
+Restart the deployment after setting vars (the dashboard has a "Restart" button, or run `mcp-use deployments restart <deployment-id>`) or push a no-op commit.
 
 Verify the deployed server is up:
 


### PR DESCRIPTION
## Summary

Adds `mcp-use servers update` and completes the MCP-1794 branch-scoping work for env vars and deploys. Supersedes #1706 with the correct field mapping (that PR sent `branch` and top-level `buildCommand`/`startCommand`, which the backend silently strips).

## Changes

- **`servers update <id-or-slug>`** — mutate server config in place without delete/recreate (preserves URL slug + env vars). Flags: `--branch` (→ backend `productionBranch`), `--name`, `--description`, `--build-command`/`--start-command` (nested under `config`), `--org`. At least one required.
- **`deploy --branch <name>`** — defaults to the current git branch; also scopes `--env`/`--env-file` sync to that branch's preview env.
- **`servers env list/add/update/rm --branch <name>`** — branch-scoped variables; `update`/`rm` now accept a variable KEY (resolved within the branch scope) in addition to a UUID.
- **`deployments restart --branch <name>`** — defaults to the deployment's branch.
- **api.ts** — adds `UpdateServerBody` + `updateServer()`, threads `branch` into env-var body types and `listEnvVariables`.
- Docs: CLI README section for `servers`/`servers env`/restart + env naming mapping (`prod`→`production`, `dev`→`development`, no `test` env). Updated `skills/mcp-apps-builder` and `skills/openapi-to-mcp` (fixed a stale `mcp-use deployments env set` reference).

## Testing

- New `tests/servers-update-env-branch.test.ts` (7 tests): field mapping, nothing-to-update guard, env branch scoping, resolve-by-KEY, UUID passthrough, deploy env-sync scoping.
- Full CLI suite green: 18 files / 286 tests. `pnpm build` passes.
- `pnpm changeset` added (`@mcp-use/cli` minor).

## Related

- Backend counterpart: mcp-use-cloud#798 (strict `UpdateServerBody` + typed `config`) makes wrong field names 400 instead of silently no-op.
- Supersedes #1706.
- Closes MCP-1794 CLI gaps.