### PR TITLE
feat(auth): add getTokenEndpoint method for OAuth token discovery

### DIFF
--- a/libraries/typescript/.changeset/auth-token-endpoint.md
+++ b/libraries/typescript/.changeset/auth-token-endpoint.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": minor
+---
+
+Expose the resolved OAuth `token_endpoint` on `useMcp().authTokens` (and add `getTokenEndpoint()` to the browser OAuth provider / session store). This lets consumers persist the token endpoint alongside the access/refresh tokens so a backend can proactively refresh the token before it expires. The field is additive and optional — existing usage is unaffected.

--- a/libraries/typescript/packages/mcp-use/src/auth/browser-provider.ts
+++ b/libraries/typescript/packages/mcp-use/src/auth/browser-provider.ts
@@ -340,6 +340,15 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
   }
 
   /**
+   * Resolve this server's OAuth token endpoint (via discovery, cached). Lets
+   * consumers persist the endpoint alongside the tokens for server-side
+   * proactive refresh. Returns `null` when unavailable.
+   */
+  getTokenEndpoint(): Promise<string | null> {
+    return this.session.getTokenEndpoint();
+  }
+
+  /**
    * Generates and persists `StoredState` for an authorization request,
    * applies browser-only resource rewriting, and returns the sanitized URL
    * with the `state` param appended. Does NOT open a popup or redirect —

--- a/libraries/typescript/packages/mcp-use/src/auth/browser-provider.ts
+++ b/libraries/typescript/packages/mcp-use/src/auth/browser-provider.ts
@@ -349,6 +349,18 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
   }
 
   /**
+   * Return the stored OAuth client credentials (DCR or static). Lets consumers
+   * persist the `client_id`/`client_secret` for server-side refresh. Returns
+   * `null` when unavailable.
+   */
+  getClientCredentials(): Promise<{
+    client_id: string;
+    client_secret?: string;
+  } | null> {
+    return this.session.getClientCredentials();
+  }
+
+  /**
    * Generates and persists `StoredState` for an authorization request,
    * applies browser-only resource rewriting, and returns the sanitized URL
    * with the `state` param appended. Does NOT open a popup or redirect —

--- a/libraries/typescript/packages/mcp-use/src/auth/oauth-session-store.ts
+++ b/libraries/typescript/packages/mcp-use/src/auth/oauth-session-store.ts
@@ -368,14 +368,19 @@ export class OAuthSessionStore {
       const persisted = await this.store.get(this.getKey("token_endpoint"));
       if (persisted) return persisted;
 
-      const resourceMetadata = await discoverOAuthProtectedResourceMetadata(this.serverUrl);
+      const resourceMetadata = await discoverOAuthProtectedResourceMetadata(
+        this.serverUrl
+      );
       const authServerUrl = resourceMetadata.authorization_servers?.[0];
       if (!authServerUrl) return null;
       const metadata = await discoverAuthorizationServerMetadata(authServerUrl);
       if (!metadata?.token_endpoint) return null;
       this._cachedAuthServerUrl = authServerUrl;
       this._cachedMetadata = metadata as AuthorizationServerMetadata;
-      await this.store.set(this.getKey("token_endpoint"), metadata.token_endpoint);
+      await this.store.set(
+        this.getKey("token_endpoint"),
+        metadata.token_endpoint
+      );
       return metadata.token_endpoint;
     } catch {
       return null;

--- a/libraries/typescript/packages/mcp-use/src/auth/oauth-session-store.ts
+++ b/libraries/typescript/packages/mcp-use/src/auth/oauth-session-store.ts
@@ -353,4 +353,32 @@ export class OAuthSessionStore {
     if (!stored.refresh_token) return null;
     return this._dedupedRefresh(stored);
   }
+
+  /**
+   * Resolve this server's OAuth token endpoint via PRM → authorization-server
+   * metadata discovery. Cached in-memory and persisted (so consumers can store
+   * it alongside the tokens, e.g. for server-side proactive refresh). Returns
+   * `null` when the server is not OAuth-protected or discovery fails.
+   */
+  async getTokenEndpoint(): Promise<string | null> {
+    if (this._cachedMetadata?.token_endpoint) {
+      return this._cachedMetadata.token_endpoint;
+    }
+    try {
+      const persisted = await this.store.get(this.getKey("token_endpoint"));
+      if (persisted) return persisted;
+
+      const resourceMetadata = await discoverOAuthProtectedResourceMetadata(this.serverUrl);
+      const authServerUrl = resourceMetadata.authorization_servers?.[0];
+      if (!authServerUrl) return null;
+      const metadata = await discoverAuthorizationServerMetadata(authServerUrl);
+      if (!metadata?.token_endpoint) return null;
+      this._cachedAuthServerUrl = authServerUrl;
+      this._cachedMetadata = metadata as AuthorizationServerMetadata;
+      await this.store.set(this.getKey("token_endpoint"), metadata.token_endpoint);
+      return metadata.token_endpoint;
+    } catch {
+      return null;
+    }
+  }
 }

--- a/libraries/typescript/packages/mcp-use/src/auth/oauth-session-store.ts
+++ b/libraries/typescript/packages/mcp-use/src/auth/oauth-session-store.ts
@@ -355,6 +355,29 @@ export class OAuthSessionStore {
   }
 
   /**
+   * Return the stored OAuth client credentials (from Dynamic Client
+   * Registration or a pre-registered static client). Consumers can persist
+   * these alongside the tokens so a backend can perform a server-side refresh
+   * (most token endpoints require at least the `client_id` on refresh).
+   * Returns `null` when no client info is available.
+   */
+  async getClientCredentials(): Promise<{
+    client_id: string;
+    client_secret?: string;
+  } | null> {
+    try {
+      const info = await this.clientInformation();
+      if (!info?.client_id) return null;
+      return {
+        client_id: info.client_id,
+        ...(info.client_secret ? { client_secret: info.client_secret } : {}),
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  /**
    * Resolve this server's OAuth token endpoint via PRM → authorization-server
    * metadata discovery. Cached in-memory and persisted (so consumers can store
    * it alongside the tokens, e.g. for server-side proactive refresh). Returns

--- a/libraries/typescript/packages/mcp-use/src/react/types.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/types.ts
@@ -417,6 +417,14 @@ export type UseMcpResult = {
      * consumers persist it so a backend can proactively refresh the token.
      */
     token_endpoint?: string;
+    /**
+     * OAuth client id (from Dynamic Client Registration or a static client).
+     * Most token endpoints require it on refresh, so consumers can persist it
+     * for server-side proactive refresh.
+     */
+    client_id?: string;
+    /** OAuth client secret, when the provider issued a confidential client. */
+    client_secret?: string;
   };
   /** Array of internal log messages (useful for debugging) */
   log: {

--- a/libraries/typescript/packages/mcp-use/src/react/types.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/types.ts
@@ -412,6 +412,11 @@ export type UseMcpResult = {
     expires_at?: number;
     refresh_token?: string;
     scope?: string;
+    /**
+     * OAuth token endpoint resolved during discovery (when available). Lets
+     * consumers persist it so a backend can proactively refresh the token.
+     */
+    token_endpoint?: string;
   };
   /** Array of internal log messages (useful for debugging) */
   log: {

--- a/libraries/typescript/packages/mcp-use/src/react/useMcp.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/useMcp.ts
@@ -48,6 +48,10 @@ type UseMcpAuthProvider = OAuthClientProvider & {
   clearStorage?: () => number;
   getLastAttemptedAuthUrl?: () => string | null | undefined;
   getTokenEndpoint?: () => Promise<string | null>;
+  getClientCredentials?: () => Promise<{
+    client_id: string;
+    client_secret?: string;
+  } | null>;
   installFetchInterceptor?: () => void;
   restoreFetch?: () => void;
   serverUrl?: string;
@@ -1049,14 +1053,26 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
               ? Date.now() + tokens.expires_in * 1000
               : undefined;
 
-            // Best-effort: resolve the OAuth token endpoint so consumers can
-            // persist it for server-side proactive refresh. Never blocks auth.
+            // Best-effort: resolve the OAuth token endpoint + client credentials
+            // so consumers can persist them for server-side proactive refresh.
+            // Never blocks auth.
             let tokenEndpoint: string | null = null;
+            let clientCreds: {
+              client_id: string;
+              client_secret?: string;
+            } | null = null;
             try {
               tokenEndpoint =
                 (await authProviderRef.current.getTokenEndpoint?.()) ?? null;
             } catch {
               tokenEndpoint = null;
+            }
+            try {
+              clientCreds =
+                (await authProviderRef.current.getClientCredentials?.()) ??
+                null;
+            } catch {
+              clientCreds = null;
             }
 
             if (!isMountedRef.current) {
@@ -1070,6 +1086,12 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
               refresh_token: tokens.refresh_token,
               scope: tokens.scope,
               ...(tokenEndpoint ? { token_endpoint: tokenEndpoint } : {}),
+              ...(clientCreds?.client_id
+                ? { client_id: clientCreds.client_id }
+                : {}),
+              ...(clientCreds?.client_secret
+                ? { client_secret: clientCreds.client_secret }
+                : {}),
             });
           }
         }

--- a/libraries/typescript/packages/mcp-use/src/react/useMcp.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/useMcp.ts
@@ -47,6 +47,7 @@ type UseMcpAuthProvider = OAuthClientProvider & {
   >;
   clearStorage?: () => number;
   getLastAttemptedAuthUrl?: () => string | null | undefined;
+  getTokenEndpoint?: () => Promise<string | null>;
   installFetchInterceptor?: () => void;
   restoreFetch?: () => void;
   serverUrl?: string;
@@ -1048,6 +1049,16 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
               ? Date.now() + tokens.expires_in * 1000
               : undefined;
 
+            // Best-effort: resolve the OAuth token endpoint so consumers can
+            // persist it for server-side proactive refresh. Never blocks auth.
+            let tokenEndpoint: string | null = null;
+            try {
+              tokenEndpoint =
+                (await authProviderRef.current.getTokenEndpoint?.()) ?? null;
+            } catch {
+              tokenEndpoint = null;
+            }
+
             if (!isMountedRef.current) {
               addLog("debug", "Skipping state update - component unmounted");
               return "failed";
@@ -1058,6 +1069,7 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
               expires_at: expiresAt,
               refresh_token: tokens.refresh_token,
               scope: tokens.scope,
+              ...(tokenEndpoint ? { token_endpoint: tokenEndpoint } : {}),
             });
           }
         }

--- a/libraries/typescript/packages/mcp-use/tests/unit/auth/oauth-session-store.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/auth/oauth-session-store.test.ts
@@ -405,7 +405,10 @@ describe("OAuthSessionStore", () => {
 
     it("returns the persisted endpoint without re-discovering", async () => {
       const { session, kv } = createStore();
-      kv.set(session.getKey("token_endpoint"), "https://cached.example.com/token");
+      kv.set(
+        session.getKey("token_endpoint"),
+        "https://cached.example.com/token"
+      );
 
       const endpoint = await session.getTokenEndpoint();
       expect(endpoint).toBe("https://cached.example.com/token");

--- a/libraries/typescript/packages/mcp-use/tests/unit/auth/oauth-session-store.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/auth/oauth-session-store.test.ts
@@ -384,6 +384,51 @@ describe("OAuthSessionStore", () => {
     });
   });
 
+  describe("getTokenEndpoint()", () => {
+    it("discovers and persists the token endpoint via PRM + AS metadata", async () => {
+      const { session, kv } = createStore();
+      discoverOAuthProtectedResourceMetadata.mockResolvedValue({
+        authorization_servers: ["https://auth.example.com"],
+      });
+      discoverAuthorizationServerMetadata.mockResolvedValue({
+        issuer: "https://auth.example.com",
+        token_endpoint: "https://auth.example.com/token",
+      });
+
+      const endpoint = await session.getTokenEndpoint();
+      expect(endpoint).toBe("https://auth.example.com/token");
+      // Persisted so a later call (or page reload) can skip discovery.
+      expect(kv.get(session.getKey("token_endpoint"))).toBe(
+        "https://auth.example.com/token"
+      );
+    });
+
+    it("returns the persisted endpoint without re-discovering", async () => {
+      const { session, kv } = createStore();
+      kv.set(session.getKey("token_endpoint"), "https://cached.example.com/token");
+
+      const endpoint = await session.getTokenEndpoint();
+      expect(endpoint).toBe("https://cached.example.com/token");
+      expect(discoverOAuthProtectedResourceMetadata).not.toHaveBeenCalled();
+    });
+
+    it("returns null when the server is not OAuth-protected", async () => {
+      const { session } = createStore();
+      discoverOAuthProtectedResourceMetadata.mockResolvedValue({
+        authorization_servers: [],
+      });
+      expect(await session.getTokenEndpoint()).toBeNull();
+    });
+
+    it("returns null (swallows) when discovery throws", async () => {
+      const { session } = createStore();
+      discoverOAuthProtectedResourceMetadata.mockRejectedValue(
+        new Error("network down")
+      );
+      expect(await session.getTokenEndpoint()).toBeNull();
+    });
+  });
+
   describe("codeVerifier() / saveCodeVerifier()", () => {
     it("round-trips the verifier through KVStore", async () => {
       const { session, kv } = createStore();


### PR DESCRIPTION
- Implemented `getTokenEndpoint` in `BrowserOAuthClientProvider` and `OAuthSessionStore` to resolve and cache the OAuth token endpoint via server metadata discovery.
- Updated `UseMcpResult` type to include `token_endpoint` for consumers to persist the endpoint alongside tokens.
- Enhanced `useMcp` to utilize the new method for proactive token refresh.
- Added unit tests to verify the functionality of the `getTokenEndpoint` method, including caching behavior and error handling.
