### PR TITLE
fix(cli): update EnvVariable type to allow null values for sensitive rows

### DIFF
--- a/libraries/typescript/.changeset/cli-sensitive-env-vars.md
+++ b/libraries/typescript/.changeset/cli-sensitive-env-vars.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/cli": patch
+---
+
+Support write-only (sensitive) environment variables. The cloud API now withholds the value of `sensitive` env vars on read (returns `null`), so `EnvVariable.value` is nullable and `env list` / `env add` / `env update` print `<sensitive>` for withheld values instead of an empty string.

--- a/libraries/typescript/packages/cli/src/commands/env.ts
+++ b/libraries/typescript/packages/cli/src/commands/env.ts
@@ -91,11 +91,12 @@ async function resolveVarId(
 
 function printEnvVar(v: EnvVariable, showValue = false): void {
   const envs = v.environments.map(envBadge).join(" ");
-  const val = v.sensitive
-    ? chalk.gray("<sensitive>")
-    : showValue
-      ? chalk.cyan(v.value)
-      : chalk.gray("(hidden — use --show-values to reveal)");
+  const val =
+    v.sensitive || v.value === null
+      ? chalk.gray("<sensitive>")
+      : showValue
+        ? chalk.cyan(v.value)
+        : chalk.gray("(hidden — use --show-values to reveal)");
   const branch = v.branch ? "  " + chalk.magenta(`branch:${v.branch}`) : "";
   console.log(`  ${chalk.white.bold(v.key.padEnd(32))} ${val}`);
   console.log(

--- a/libraries/typescript/packages/cli/src/utils/api.ts
+++ b/libraries/typescript/packages/cli/src/utils/api.ts
@@ -281,7 +281,8 @@ export interface EnvVariable {
   id: string;
   serverId: string;
   key: string;
-  value: string;
+  /** `null` for write-only `sensitive` rows — the API withholds the stored value. */
+  value: string | null;
   environments: EnvEnvironment[];
   /** Branch pin: null/omitted = production scope; a branch name = that branch's preview. */
   branch?: string | null;


### PR DESCRIPTION
- Modified the `value` property in the `EnvVariable` interface to accept `null`, indicating write-only sensitive rows where the stored value is withheld by the API.
- Adjusted the `printEnvVar` function to handle cases where `value` is `null`, ensuring proper display of sensitive information.
