### PR TITLE
fix(server): handle comma-separated X-Forwarded-Proto/Host in tunnel/proxy chains

### DIFF
--- a/libraries/typescript/.changeset/mcp-forwarded-proto-list.md
+++ b/libraries/typescript/.changeset/mcp-forwarded-proto-list.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Fix `TypeError: Invalid URL` when an MCP server is reached through a multi-hop proxy/tunnel chain. `X-Forwarded-Proto` and `X-Forwarded-Host` are comma-separated lists when a request passes through more than one proxy (e.g. a tunnel where the edge sets `https` and the local hop appends `http`, yielding `https,http`). The server now uses the leftmost (original client-facing) value when reconstructing the request URL instead of interpolating the whole list into an invalid URL like `https,http://host/mcp`.

--- a/libraries/typescript/packages/mcp-use/src/server/endpoints/mount-mcp.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/endpoints/mount-mcp.ts
@@ -26,6 +26,45 @@ import { getDebugLevel } from "../logging.js";
 import { generateUUID } from "../utils/runtime.js";
 
 // ---------------------------------------------------------------------------
+// URL reconstruction from proxy headers
+// ---------------------------------------------------------------------------
+
+/**
+ * Reconstruct the public-facing URL for a request, honoring proxy headers.
+ *
+ * `X-Forwarded-Proto` / `X-Forwarded-Host` become comma-separated lists when a
+ * request passes through multiple proxies. Tunnel chains are the common case:
+ * the edge sets `X-Forwarded-Proto: https`, then the local tunnel hop appends
+ * its own scheme, so the origin server sees `https,http`. The leftmost value is
+ * the original client-facing one, so we take it. Without this, naive
+ * interpolation yields an invalid URL like `https,http://host/mcp` that throws
+ * in `new URL()` (`TypeError: Invalid URL`).
+ */
+export function buildForwardedUrl(opts: {
+  reqUrl: string;
+  path: string;
+  forwardedProto?: string;
+  forwardedProtocol?: string;
+  forwardedHost?: string;
+  host?: string;
+}): string {
+  const firstForwardedValue = (value: string | undefined): string | undefined =>
+    value?.split(",")[0]?.trim() || undefined;
+
+  const proto =
+    firstForwardedValue(opts.forwardedProto) ||
+    firstForwardedValue(opts.forwardedProtocol) ||
+    new URL(opts.reqUrl).protocol.replace(":", "");
+
+  const host =
+    firstForwardedValue(opts.forwardedHost) ||
+    opts.host ||
+    new URL(opts.reqUrl).host;
+
+  return `${proto}://${host}${opts.path}`;
+}
+
+// ---------------------------------------------------------------------------
 // Helpers for distributed SSE stream routing via StreamManager
 // ---------------------------------------------------------------------------
 
@@ -213,22 +252,16 @@ export async function mountMcp(
   }
 
   // Helper function to construct the full URL considering proxy headers
-  const getFullUrl = (c: Context): string => {
-    // Check for proxy headers (common in production deployments)
-    const proto =
-      c.req.header("X-Forwarded-Proto") ||
-      c.req.header("X-Forwarded-Protocol") ||
-      new URL(c.req.url).protocol.replace(":", "");
-
-    const host =
-      c.req.header("X-Forwarded-Host") ||
-      c.req.header("Host") ||
-      new URL(c.req.url).host;
-
-    const path = c.req.path;
-
-    return `${proto}://${host}${path}`;
-  };
+  // (common in production deployments and tunnel chains). See buildForwardedUrl.
+  const getFullUrl = (c: Context): string =>
+    buildForwardedUrl({
+      reqUrl: c.req.url,
+      path: c.req.path,
+      forwardedProto: c.req.header("X-Forwarded-Proto"),
+      forwardedProtocol: c.req.header("X-Forwarded-Protocol"),
+      forwardedHost: c.req.header("X-Forwarded-Host"),
+      host: c.req.header("Host"),
+    });
 
   // Universal request handler - using Web Standard APIs (no Express adapters needed!)
   const handleRequest = async (c: Context) => {

--- a/libraries/typescript/packages/mcp-use/tests/unit/server/forwarded-url.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/server/forwarded-url.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { buildForwardedUrl } from "../../../src/server/endpoints/mount-mcp.js";
+
+describe("buildForwardedUrl", () => {
+  const base = {
+    reqUrl: "http://127.0.0.1:3001/mcp",
+    path: "/mcp",
+  };
+
+  it("falls back to the request URL when no proxy headers are present", () => {
+    expect(buildForwardedUrl(base)).toBe("http://127.0.0.1:3001/mcp");
+  });
+
+  it("honors single-value X-Forwarded-Proto / X-Forwarded-Host", () => {
+    expect(
+      buildForwardedUrl({
+        ...base,
+        forwardedProto: "https",
+        forwardedHost: "alone-chocolate.local.mcp-use.run",
+      })
+    ).toBe("https://alone-chocolate.local.mcp-use.run/mcp");
+  });
+
+  it("takes the first value of a comma-separated X-Forwarded-Proto (tunnel chain)", () => {
+    // Regression: tunnel chains produce "https,http" (edge sets https, local
+    // hop appends http). Naive interpolation built "https,http://host/mcp",
+    // which throws TypeError: Invalid URL in `new URL()`.
+    const url = buildForwardedUrl({
+      ...base,
+      forwardedProto: "https,http",
+      forwardedHost: "alone-chocolate.local.mcp-use.run",
+    });
+
+    expect(url).toBe("https://alone-chocolate.local.mcp-use.run/mcp");
+    // The result must be a valid URL — this is what previously threw.
+    expect(() => new URL(url)).not.toThrow();
+  });
+
+  it("trims whitespace in comma-separated lists (RFC 7239 style spacing)", () => {
+    expect(
+      buildForwardedUrl({
+        ...base,
+        forwardedProto: "https, http",
+        forwardedHost: "example.com, internal.local",
+      })
+    ).toBe("https://example.com/mcp");
+  });
+
+  it("falls back to X-Forwarded-Protocol when X-Forwarded-Proto is absent", () => {
+    expect(
+      buildForwardedUrl({
+        ...base,
+        forwardedProtocol: "https",
+        forwardedHost: "example.com",
+      })
+    ).toBe("https://example.com/mcp");
+  });
+
+  it("prefers the Host header over the request URL host when no X-Forwarded-Host", () => {
+    expect(
+      buildForwardedUrl({
+        ...base,
+        forwardedProto: "https",
+        host: "public.example.com",
+      })
+    ).toBe("https://public.example.com/mcp");
+  });
+
+  it("ignores empty forwarded header values", () => {
+    expect(
+      buildForwardedUrl({
+        ...base,
+        forwardedProto: "",
+        forwardedHost: "",
+      })
+    ).toBe("http://127.0.0.1:3001/mcp");
+  });
+});


### PR DESCRIPTION
## Language / Project Scope

- [x] TypeScript

## Changes

Fixes a `TypeError: Invalid URL` when an MCP server is reached through a multi-hop proxy/tunnel chain (e.g. tunneling a server through `@mcp-use/tunnel` / the inspector proxy).

`X-Forwarded-Proto` and `X-Forwarded-Host` are comma-separated lists when a request passes through more than one proxy. A common case is a tunnel chain where the edge terminates TLS and sets `X-Forwarded-Proto: https`, then the local tunnel hop forwards over plain HTTP and appends its own scheme, so the origin server receives `https,http`. The MCP endpoint's URL reconstruction (`getFullUrl` in `mount-mcp.ts`) interpolated the raw header value, producing an invalid URL like `https,http://host/mcp` that throws in `new URL()`.

Symptom: the landing/GET probe through the tunnel 500s, and the inspector proxy reports the opaque `{"error":"Proxy request failed","details":"fetch failed"}` because the thrown error tears down the connection.

## Implementation Details

1. Extracted the proxy-header URL reconstruction out of the `getFullUrl` closure into an exported, pure `buildForwardedUrl()` in `src/server/endpoints/mount-mcp.ts`.
2. `buildForwardedUrl()` takes the leftmost (original client-facing) value of each forwarded header via `value.split(",")[0].trim()`, falling back to `X-Forwarded-Protocol`, the `Host` header, and finally the request URL — preserving the previous precedence.
3. `getFullUrl` now delegates to it; behavior for single-valued headers is unchanged.

## TypeScript Checklist

### Packages Modified
- [x] `mcp-use` (server)
- [x] `tests`

### Pre-commit Checklist
- [x] Ran `pnpm format` (Prettier) on changed files
- [x] Linting passes (`eslint`) on changed files
- [x] Typecheck passes (`tsc --noEmit`)
- [x] Added tests
- [x] Created a changeset (`mcp-use` patch)

## Example Usage (Before)

```
# Request reaches origin through a tunnel chain with X-Forwarded-Proto: https,http
# → getFullUrl() builds "https,http://host/mcp"
# → new URL(...) throws:
TypeError: Invalid URL  input: 'https,http://host/mcp'
# Inspector: {"error":"Proxy request failed","details":"fetch failed"}
```

## Example Usage (After)

```
# X-Forwarded-Proto: https,http  → "https" is used
# → "https://host/mcp"  (valid)
```

## Documentation Updates

* None — internal behavior fix, no public API or docs change.

## Testing

- Added `tests/unit/server/forwarded-url.test.ts` (7 cases): no-header fallback, single-value headers, the `https,http` regression (asserts the result is a valid URL), whitespace trimming (`https, http`), `X-Forwarded-Protocol` fallback, `Host` fallback, and empty-value handling.
- `pnpm vitest run tests/unit/server/forwarded-url.test.ts` → 7 passed.
- Verified the originally-reported tunnel error no longer reproduces after rebuilding.

## Backwards Compatibility

Backwards compatible. Single-valued forwarded headers and the no-header case behave exactly as before; only the previously-broken comma-separated case changes (now parsed correctly instead of throwing). `buildForwardedUrl` is a newly exported helper — purely additive.

## Related Issues

N/A
