### PR TITLE
feat(mcp-use): ChatGPT "Open in app" URL support for widgets

### DIFF
--- a/docs/typescript/server/mcp-apps.mdx
+++ b/docs/typescript/server/mcp-apps.mdx
@@ -524,9 +524,24 @@ server.uiResource({
     // ChatGPT specific (ignored by MCP Apps clients)
     widgetDescription: "Special description for ChatGPT",
     widgetDomain: "https://chatgpt.com",
+
+    // ChatGPT runtime configuration (ignored by MCP Apps clients)
+    openai: {
+      // URL ChatGPT's "Open in app" affordance links to. Applied automatically
+      // via window.openai.setOpenInAppUrl when the widget mounts in ChatGPT.
+      openInAppUrl: "https://app.example.com",
+    },
   },
 });
 ```
+
+<Note>
+`metadata.openai.openInAppUrl` is applied once on mount, ideal for a static
+"Open in app" link. For a **dynamic** URL — e.g. a deep link to the specific
+record the widget is showing — call `setOpenInAppUrl(href)` from
+[`useWidget()`](/typescript/server/widget-components/usewidget) instead. Both
+are ChatGPT-only and no-op on MCP Apps hosts.
+</Note>
 
 ## Migration from Apps SDK
 

--- a/docs/typescript/server/widget-components/usewidget.mdx
+++ b/docs/typescript/server/widget-components/usewidget.mdx
@@ -99,6 +99,7 @@ useWidget<
 | `sendFollowUpMessage`   | `(content: string \| MessageContentBlock[]) => Promise<void>`                | Send a follow-up message; string shorthand or full content block array (SEP-1865) |
 | `openExternal`          | `(href: string) => void`                                                     | Open an external URL in a new tab                            |
 | `requestDisplayMode`    | `(mode: DisplayMode) => Promise<{ mode: DisplayMode }>`                      | Request a different display mode                             |
+| `setOpenInAppUrl`       | `(href: string) => void`                                                     | ChatGPT only: set the URL the "Open in app" affordance links to (no-op on other hosts) |
 | `notifyIntrinsicHeight` | `(height: number) => Promise<void>`                                          | Notify OpenAI about intrinsic height changes for auto-sizing |
 
 ### Availability
@@ -448,6 +449,37 @@ const handleFullscreen = async () => {
   // result.mode is the granted mode (may differ from requested)
 };
 ```
+
+### 9. Open in app URL (ChatGPT only)
+
+Control the link ChatGPT's "Open in app" affordance points to. Use the
+imperative action for a dynamic, per-record deep link:
+
+```tsx
+const { props, setOpenInAppUrl } = useWidget();
+
+useEffect(() => {
+  if (props.id) {
+    setOpenInAppUrl(`https://app.example.com/records/${props.id}`);
+  }
+}, [props.id]);
+```
+
+For a static URL, declare it once in the widget definition and it is applied
+automatically when the widget mounts inside ChatGPT:
+
+```ts
+metadata: {
+  openai: {
+    openInAppUrl: "https://app.example.com",
+  },
+}
+```
+
+<Note>
+Both are ChatGPT Apps SDK features. On MCP Apps hosts (and the local
+URL-params fallback) they are a no-op.
+</Note>
 
 ## Default Values
 

--- a/libraries/typescript/.changeset/cli-sensitive-env-vars.md
+++ b/libraries/typescript/.changeset/cli-sensitive-env-vars.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/cli": patch
+---
+
+Support write-only (sensitive) environment variables. The cloud API now withholds the value of `sensitive` env vars on read (returns `null`), so `EnvVariable.value` is nullable and `env list` / `env add` / `env update` print `<sensitive>` for withheld values instead of an empty string.

--- a/libraries/typescript/.changeset/openai-open-in-app-url.md
+++ b/libraries/typescript/.changeset/openai-open-in-app-url.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": minor
+---
+
+Add ChatGPT "Open in app" URL support for widgets. Widgets can now call `setOpenInAppUrl(href)` from `useWidget()` to control the link ChatGPT's "Open in app" affordance points to (ChatGPT Apps SDK only — a no-op on MCP Apps hosts and the URL-params fallback). For a static URL, set `metadata.openai.openInAppUrl` in the widget definition and it is applied automatically via `window.openai.setOpenInAppUrl` when the widget mounts inside ChatGPT.

--- a/libraries/typescript/.changeset/pre.json
+++ b/libraries/typescript/.changeset/pre.json
@@ -1,0 +1,11 @@
+{
+  "mode": "pre",
+  "tag": "canary",
+  "initialVersions": {
+    "@mcp-use/cli": "3.5.1",
+    "create-mcp-use-app": "0.14.15",
+    "@mcp-use/inspector": "10.0.0",
+    "mcp-use": "1.32.0"
+  },
+  "changesets": []
+}

--- a/libraries/typescript/.changeset/pre.json
+++ b/libraries/typescript/.changeset/pre.json
@@ -7,5 +7,7 @@
     "@mcp-use/inspector": "10.0.0",
     "mcp-use": "1.32.0"
   },
-  "changesets": []
+  "changesets": [
+    "cli-sensitive-env-vars"
+  ]
 }

--- a/libraries/typescript/packages/cli/CHANGELOG.md
+++ b/libraries/typescript/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @mcp-use/cli
 
+## 3.5.2-canary.0
+
+### Patch Changes
+
+- d64db0f: Support write-only (sensitive) environment variables. The cloud API now withholds the value of `sensitive` env vars on read (returns `null`), so `EnvVariable.value` is nullable and `env list` / `env add` / `env update` print `<sensitive>` for withheld values instead of an empty string.
+  - mcp-use@1.32.1-canary.0
+  - @mcp-use/inspector@10.0.1-canary.0
+
 ## 3.5.1
 
 ### Patch Changes

--- a/libraries/typescript/packages/cli/package.json
+++ b/libraries/typescript/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-use/cli",
   "type": "module",
-  "version": "3.5.1",
+  "version": "3.5.2-canary.0",
   "description": "The mcp-use CLI is a tool for building and deploying MCP servers with support for ChatGPT Apps, Code Mode, OAuth, Notifications, Sampling, Observability and more.",
   "author": "mcp-use, Inc.",
   "license": "MIT",

--- a/libraries/typescript/packages/cli/src/commands/env.ts
+++ b/libraries/typescript/packages/cli/src/commands/env.ts
@@ -91,11 +91,12 @@ async function resolveVarId(
 
 function printEnvVar(v: EnvVariable, showValue = false): void {
   const envs = v.environments.map(envBadge).join(" ");
-  const val = v.sensitive
-    ? chalk.gray("<sensitive>")
-    : showValue
-      ? chalk.cyan(v.value)
-      : chalk.gray("(hidden — use --show-values to reveal)");
+  const val =
+    v.sensitive || v.value === null
+      ? chalk.gray("<sensitive>")
+      : showValue
+        ? chalk.cyan(v.value)
+        : chalk.gray("(hidden — use --show-values to reveal)");
   const branch = v.branch ? "  " + chalk.magenta(`branch:${v.branch}`) : "";
   console.log(`  ${chalk.white.bold(v.key.padEnd(32))} ${val}`);
   console.log(

--- a/libraries/typescript/packages/cli/src/utils/api.ts
+++ b/libraries/typescript/packages/cli/src/utils/api.ts
@@ -281,7 +281,8 @@ export interface EnvVariable {
   id: string;
   serverId: string;
   key: string;
-  value: string;
+  /** `null` for write-only `sensitive` rows — the API withholds the stored value. */
+  value: string | null;
   environments: EnvEnvironment[];
   /** Branch pin: null/omitted = production scope; a branch name = that branch's preview. */
   branch?: string | null;

--- a/libraries/typescript/packages/inspector/CHANGELOG.md
+++ b/libraries/typescript/packages/inspector/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @mcp-use/inspector
 
+## 10.0.1-canary.0
+
+### Patch Changes
+
+- mcp-use@1.32.1-canary.0
+
 ## 10.0.0
 
 ### Patch Changes

--- a/libraries/typescript/packages/inspector/package.json
+++ b/libraries/typescript/packages/inspector/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-use/inspector",
   "type": "module",
-  "version": "10.0.0",
+  "version": "10.0.1-canary.0",
   "description": "MCP Inspector - A tool for inspecting and debugging MCP servers",
   "author": "",
   "license": "MIT",
@@ -80,7 +80,7 @@
   },
   "peerDependencies": {
     "express": "^4.21.2 || ^5.0.0",
-    "mcp-use": ">=1.32.0-canary.0",
+    "mcp-use": ">=1.32.1-canary.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
     "react-router": "^7.12.0"

--- a/libraries/typescript/packages/mcp-use/CHANGELOG.md
+++ b/libraries/typescript/packages/mcp-use/CHANGELOG.md
@@ -1,5 +1,13 @@
 # mcp-use
 
+## 1.32.1-canary.0
+
+### Patch Changes
+
+- Updated dependencies [d64db0f]
+  - @mcp-use/cli@3.5.2-canary.0
+  - @mcp-use/inspector@10.0.1-canary.0
+
 ## 1.32.0
 
 ### Minor Changes

--- a/libraries/typescript/packages/mcp-use/examples/server/ui/mcp-apps/resources/greeting-card/widget.tsx
+++ b/libraries/typescript/packages/mcp-use/examples/server/ui/mcp-apps/resources/greeting-card/widget.tsx
@@ -15,6 +15,11 @@ export const widgetMetadata: WidgetMetadata = {
   metadata: {
     prefersBorder: false,
     widgetDescription: "A colorful greeting card with personalized message",
+    openai: {
+      // ChatGPT-only: link the "Open in app" affordance to this URL. Applied
+      // automatically via window.openai.setOpenInAppUrl when mounted in ChatGPT.
+      openInAppUrl: "https://www.example.com",
+    },
   },
   annotations: {
     readOnlyHint: true,

--- a/libraries/typescript/packages/mcp-use/package.json
+++ b/libraries/typescript/packages/mcp-use/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-use",
   "type": "module",
-  "version": "1.32.0",
+  "version": "1.32.1-canary.0",
   "packageManager": "pnpm@10.26.0+sha512.3b3f6c725ebe712506c0ab1ad4133cf86b1f4b687effce62a9b38b4d72e3954242e643190fc51fa1642949c735f403debd44f5cb0edd657abe63a8b6a7e1e402",
   "description": "Opinionated MCP Framework for TypeScript (@modelcontextprotocol/sdk compatible) - Build MCP Agents, Clients and Servers with support for ChatGPT Apps, Code Mode, OAuth, Notifications, Sampling, Observability and more.",
   "author": "mcp-use, Inc.",

--- a/libraries/typescript/packages/mcp-use/src/react/useWidget.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/useWidget.ts
@@ -649,6 +649,22 @@ export function useWidget<
     [provider]
   );
 
+  const setOpenInAppUrl = useCallback(
+    (href: string): void => {
+      // ChatGPT Apps SDK only; MCP Apps and the URL-params fallback have no
+      // equivalent affordance, so this is a no-op there.
+      if (provider !== "openai") {
+        return;
+      }
+      // Older ChatGPT hosts may not expose this method.
+      if (!window.openai?.setOpenInAppUrl) {
+        return;
+      }
+      window.openai.setOpenInAppUrl({ href });
+    },
+    [provider]
+  );
+
   const requestDisplayMode = useCallback(
     async (mode: DisplayMode): Promise<{ mode: DisplayMode }> => {
       if (provider === "mcp-apps") {
@@ -731,6 +747,19 @@ export function useWidget<
     },
     [provider, widgetState, localWidgetState]
   );
+
+  // Apply the declarative `metadata.openai.openInAppUrl` (injected by the server
+  // as window.__mcpOpenInAppUrl) once the ChatGPT Apps SDK is available. Static
+  // counterpart to the imperative setOpenInAppUrl action.
+  const openInAppUrlAppliedRef = useRef(false);
+  useEffect(() => {
+    if (openInAppUrlAppliedRef.current) return;
+    if (provider !== "openai" || typeof window === "undefined") return;
+    const href = window.__mcpOpenInAppUrl;
+    if (!href || !window.openai?.setOpenInAppUrl) return;
+    window.openai.setOpenInAppUrl({ href });
+    openInAppUrlAppliedRef.current = true;
+  }, [provider]);
 
   // Determine if tool is still executing
   const isPending = useMemo(() => {
@@ -831,6 +860,7 @@ export function useWidget<
     sendFollowUpMessage,
     openExternal,
     requestDisplayMode,
+    setOpenInAppUrl,
 
     // Availability
     isAvailable: isOpenAiAvailable || isMcpAppsConnected,

--- a/libraries/typescript/packages/mcp-use/src/react/widget-types.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/widget-types.ts
@@ -151,6 +151,14 @@ export interface API<WidgetState extends UnknownObject = UnknownObject> {
    * Use `useFiles().isSupported` to detect availability before calling.
    */
   getFileDownloadUrl?: (file: FileMetadata) => Promise<{ downloadUrl: string }>;
+
+  /**
+   * Set the URL that ChatGPT's "Open in app" affordance links to.
+   *
+   * ChatGPT Apps SDK only. May be absent on older hosts — feature-detect
+   * before calling (`useWidget().setOpenInAppUrl` handles this for you).
+   */
+  setOpenInAppUrl?: (args: { href: string }) => void;
 }
 
 // Event types
@@ -168,6 +176,7 @@ declare global {
     __getFile?: (filename: string) => string;
     __mcpPublicUrl?: string;
     __mcpPublicAssetsUrl?: string;
+    __mcpOpenInAppUrl?: string;
   }
 
   interface WindowEventMap {
@@ -404,6 +413,18 @@ interface UseWidgetResultBase<
    * (e.g. policy violation or invalid URL) — errors are logged but not thrown.
    */
   openExternal: (href: string) => void;
+
+  /**
+   * Set the URL that ChatGPT's "Open in app" button links to.
+   *
+   * ChatGPT Apps SDK only — calls `window.openai.setOpenInAppUrl`. No-op on
+   * MCP Apps hosts, the URL-params fallback, and ChatGPT hosts that don't
+   * expose the method. Use this for a dynamic deep link (e.g. to the specific
+   * record the widget is displaying); for a static URL, set
+   * `metadata.openai.openInAppUrl` in the widget definition to have it applied
+   * automatically on mount.
+   */
+  setOpenInAppUrl: (href: string) => void;
 
   /**
    * Request the host to change the widget's display mode.

--- a/libraries/typescript/packages/mcp-use/src/server/types/widget.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/types/widget.ts
@@ -129,5 +129,23 @@ export interface WidgetMetadata {
      * Auto-default: `"{name} ready"`
      */
     invoked?: string;
+    /**
+     * ChatGPT-specific runtime configuration (Apps SDK only, ignored by MCP Apps).
+     *
+     * Unlike the other `metadata` fields — which are passthrough metadata the
+     * host reads directly — these drive imperative `window.openai` calls made
+     * by the widget runtime when it mounts inside ChatGPT.
+     */
+    openai?: {
+      /**
+       * URL that ChatGPT's "Open in app" affordance links to.
+       *
+       * Applied automatically via `window.openai.setOpenInAppUrl` when the
+       * widget mounts inside ChatGPT. For a dynamic href (e.g. a deep link to
+       * the specific record being shown), call `setOpenInAppUrl` from
+       * `useWidget()` instead.
+       */
+      openInAppUrl?: string;
+    };
   };
 }

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/adapters/base.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/adapters/base.ts
@@ -110,7 +110,7 @@ export abstract class BaseProtocolAdapter implements ProtocolAdapter {
     if ("metadata" in definition && definition.metadata) {
       for (const [key, value] of Object.entries(definition.metadata)) {
         if (
-          !["csp", "prefersBorder", "domain"].includes(key) &&
+          !["csp", "prefersBorder", "domain", "openai"].includes(key) &&
           value !== undefined
         ) {
           meta[key] = value;
@@ -149,7 +149,7 @@ export abstract class BaseProtocolAdapter implements ProtocolAdapter {
 
     // Transform additional fields
     for (const [key, value] of Object.entries(meta)) {
-      if (!["csp", "prefersBorder", "domain"].includes(key)) {
+      if (!["csp", "prefersBorder", "domain", "openai"].includes(key)) {
         result[this.transformMetadataKey(key)] = value;
       }
     }

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/adapters/types.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/adapters/types.ts
@@ -176,6 +176,26 @@ export interface UnifiedWidgetMetadata {
   invoked?: string;
 
   /**
+   * ChatGPT-specific runtime configuration (Apps SDK only, ignored by MCP Apps).
+   *
+   * Unlike the other fields — which are passthrough metadata the host reads
+   * directly — these drive imperative `window.openai` calls made by the widget
+   * runtime when it mounts inside ChatGPT. They are not serialized into the
+   * resource `_meta`.
+   */
+  openai?: {
+    /**
+     * URL that ChatGPT's "Open in app" affordance links to.
+     *
+     * Applied automatically via `window.openai.setOpenInAppUrl` when the widget
+     * mounts inside ChatGPT. For a dynamic href (e.g. a deep link to the
+     * specific record being shown), call `setOpenInAppUrl` from `useWidget()`
+     * instead.
+     */
+    openInAppUrl?: string;
+  };
+
+  /**
    * Allow arbitrary additional properties for future spec evolution
    */
   [key: string]: any;

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/mount-widgets-dev.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/mount-widgets-dev.ts
@@ -697,10 +697,16 @@ if (container && Component) {
           let html = "";
           try {
             html = await fsHelpers.readFileSync(htmlPath);
+            const openInAppUrl = (
+              metadata?.metadata as
+                | { openai?: { openInAppUrl?: string } }
+                | undefined
+            )?.openai?.openInAppUrl;
             html = processWidgetHtml(
               html,
               widgetName,
-              serverConfig.serverBaseUrl
+              serverConfig.serverBaseUrl,
+              openInAppUrl
             );
           } catch (e) {
             console.warn(

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/widget-helpers.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/widget-helpers.ts
@@ -299,6 +299,8 @@ export function getContentType(filename: string): string {
  * @param html - Original HTML content
  * @param widgetName - Widget identifier
  * @param baseUrl - Server base URL
+ * @param openInAppUrl - Optional ChatGPT "Open in app" URL, injected as
+ *   `window.__mcpOpenInAppUrl` so the widget runtime can apply it on mount
  * @returns Processed HTML with injected base tag and absolute URLs
  *
  * @example
@@ -310,7 +312,8 @@ export function getContentType(filename: string): string {
 export function processWidgetHtml(
   html: string,
   widgetName: string,
-  baseUrl: string
+  baseUrl: string,
+  openInAppUrl?: string
 ): string {
   let processedHtml = html;
 
@@ -359,9 +362,19 @@ export function processWidgetHtml(
     // Add window.__getFile and window.__mcpPublicUrl to head
     // Use slugified name for URL routing
     const slugifiedName = slugifyWidgetName(widgetName);
+    // ChatGPT-only "Open in app" URL (Apps SDK). Escape for an inline <script>:
+    // JSON.stringify handles JS string quoting, and the additional replacements
+    // neutralize "</script>" breakout and the U+2028/U+2029 line separators.
+    const openInAppUrlScript = openInAppUrl
+      ? ` window.__mcpOpenInAppUrl = ${JSON.stringify(openInAppUrl)
+          .replace(/</g, "\\u003c")
+          .replace(/>/g, "\\u003e")
+          .replace(/\u2028/g, "\\u2028")
+          .replace(/\u2029/g, "\\u2029")};`
+      : "";
     processedHtml = processedHtml.replace(
       /<head[^>]*>/i,
-      `<head>\n    <script>window.__getFile = (filename) => { return "${baseUrl}/mcp-use/widgets/${slugifiedName}/"+filename }; window.__mcpPublicUrl = "${baseUrl}/mcp-use/public";</script>`
+      `<head>\n    <script>window.__getFile = (filename) => { return "${baseUrl}/mcp-use/widgets/${slugifiedName}/"+filename }; window.__mcpPublicUrl = "${baseUrl}/mcp-use/public";${openInAppUrlScript}</script>`
     );
   }
 
@@ -721,8 +734,17 @@ export async function registerWidgetFromTemplate(
     return; // readWidgetHtml already logged the error
   }
 
-  // Process HTML with base URL injection and path conversion
-  html = processWidgetHtml(html, widgetName, serverConfig.serverBaseUrl);
+  // Process HTML with base URL injection and path conversion.
+  // The ChatGPT-only "Open in app" URL lives under the unified metadata block.
+  const openInAppUrl = (
+    metadata?.metadata as { openai?: { openInAppUrl?: string } } | undefined
+  )?.openai?.openInAppUrl;
+  html = processWidgetHtml(
+    html,
+    widgetName,
+    serverConfig.serverBaseUrl,
+    openInAppUrl
+  );
 
   // Ensure metadata has proper fallbacks
   const processedMetadata = ensureWidgetMetadata(metadata, widgetName);

--- a/libraries/typescript/packages/mcp-use/tests/unit/react/useWidget-openInAppUrl.test.tsx
+++ b/libraries/typescript/packages/mcp-use/tests/unit/react/useWidget-openInAppUrl.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+
+/**
+ * Tests for ChatGPT "Open in app" URL support in useWidget:
+ *
+ * - The imperative `setOpenInAppUrl(href)` forwards `{ href }` to
+ *   `window.openai.setOpenInAppUrl` when running inside ChatGPT.
+ * - It is a graceful no-op when the host does not expose the method, and
+ *   outside ChatGPT (no `window.openai`).
+ * - The declarative `metadata.openai.openInAppUrl` — delivered to the iframe as
+ *   `window.__mcpOpenInAppUrl` — is applied once on mount.
+ */
+
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, create } from "react-test-renderer";
+import { useWidget } from "../../../src/react/useWidget.js";
+
+let latest: ReturnType<typeof useWidget> | null = null;
+
+function Probe() {
+  latest = useWidget();
+  return null;
+}
+
+function renderWidget() {
+  let renderer: ReturnType<typeof create>;
+  act(() => {
+    renderer = create(<Probe />);
+  });
+  // @ts-expect-error assigned inside act
+  return renderer;
+}
+
+function setOpenAi(value: unknown) {
+  (window as any).openai = value;
+}
+
+beforeEach(() => {
+  latest = null;
+  delete (window as any).openai;
+  delete (window as any).__mcpOpenInAppUrl;
+});
+
+afterEach(() => {
+  delete (window as any).openai;
+  delete (window as any).__mcpOpenInAppUrl;
+  vi.clearAllMocks();
+});
+
+describe("imperative setOpenInAppUrl", () => {
+  it("forwards { href } to window.openai.setOpenInAppUrl", () => {
+    const setOpenInAppUrl = vi.fn();
+    setOpenAi({ setOpenInAppUrl });
+
+    const renderer = renderWidget();
+    act(() => {
+      latest!.setOpenInAppUrl("https://app.example.com/item/42");
+    });
+
+    expect(setOpenInAppUrl).toHaveBeenCalledWith({
+      href: "https://app.example.com/item/42",
+    });
+    act(() => renderer.unmount());
+  });
+
+  it("is a graceful no-op when the host lacks the method", () => {
+    setOpenAi({}); // ChatGPT provider, but older host without the method
+    const renderer = renderWidget();
+
+    expect(() =>
+      act(() => {
+        latest!.setOpenInAppUrl("https://app.example.com/x");
+      })
+    ).not.toThrow();
+    act(() => renderer.unmount());
+  });
+
+  it("is a no-op outside ChatGPT (no window.openai)", () => {
+    vi.useFakeTimers();
+    try {
+      const renderer = renderWidget(); // provider falls back to mcp-ui
+      expect(() =>
+        act(() => {
+          latest!.setOpenInAppUrl("https://app.example.com/x");
+        })
+      ).not.toThrow();
+      act(() => renderer.unmount());
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("declarative metadata.openai.openInAppUrl", () => {
+  it("applies window.__mcpOpenInAppUrl once on mount", () => {
+    const setOpenInAppUrl = vi.fn();
+    (window as any).__mcpOpenInAppUrl = "https://app.example.com/from-meta";
+    setOpenAi({ setOpenInAppUrl });
+
+    const renderer = renderWidget();
+
+    expect(setOpenInAppUrl).toHaveBeenCalledTimes(1);
+    expect(setOpenInAppUrl).toHaveBeenCalledWith({
+      href: "https://app.example.com/from-meta",
+    });
+    act(() => renderer.unmount());
+  });
+
+  it("does not call setOpenInAppUrl on mount when nothing is configured", () => {
+    const setOpenInAppUrl = vi.fn();
+    setOpenAi({ setOpenInAppUrl });
+
+    const renderer = renderWidget();
+
+    expect(setOpenInAppUrl).not.toHaveBeenCalled();
+    act(() => renderer.unmount());
+  });
+
+  it("does not throw when configured but the host lacks the method", () => {
+    (window as any).__mcpOpenInAppUrl = "https://app.example.com/from-meta";
+    setOpenAi({}); // no setOpenInAppUrl on the host
+
+    expect(() => {
+      const renderer = renderWidget();
+      act(() => renderer.unmount());
+    }).not.toThrow();
+  });
+});

--- a/libraries/typescript/packages/mcp-use/tests/unit/server/widget-open-in-app-url.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/server/widget-open-in-app-url.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for the ChatGPT-only "Open in app" URL (window.openai.setOpenInAppUrl)
+ * support on the server side:
+ *
+ * - `metadata.openai.openInAppUrl` is NOT serialized into the resource `_meta`
+ *   by either protocol adapter (it is a runtime directive, not host passthrough).
+ * - Other unified metadata fields (e.g. prefersBorder) are still serialized,
+ *   proving the exclusion is surgical.
+ * - `processWidgetHtml` injects `window.__mcpOpenInAppUrl` into the widget HTML
+ *   head when an `openInAppUrl` is provided, escaping the value safely, and
+ *   omits it otherwise.
+ */
+
+import { describe, it, expect } from "vitest";
+import { AppsSdkAdapter } from "../../../src/server/widgets/adapters/apps-sdk.js";
+import { McpAppsAdapter } from "../../../src/server/widgets/adapters/mcp-apps.js";
+import { processWidgetHtml } from "../../../src/server/widgets/widget-helpers.js";
+
+// Minimal UIResourceDefinition-shaped object for adapter tests.
+function makeDefinition(metadata: Record<string, unknown>) {
+  return {
+    type: "mcpApps",
+    name: "demo-widget",
+    htmlTemplate: "<div>demo</div>",
+    metadata,
+  } as any;
+}
+
+describe("openInAppUrl is excluded from resource _meta", () => {
+  it("Apps SDK adapter does not emit an openai/* key for openInAppUrl", () => {
+    const adapter = new AppsSdkAdapter();
+    const { _meta } = adapter.buildResourceMetadata(
+      makeDefinition({
+        prefersBorder: true,
+        openai: { openInAppUrl: "https://app.example.com/item/42" },
+      })
+    );
+
+    const keys = Object.keys(_meta ?? {});
+    // The runtime directive must not leak into host-read metadata.
+    expect(keys).not.toContain("openai");
+    expect(keys).not.toContain("openai/openai");
+    expect(JSON.stringify(_meta)).not.toContain("openInAppUrl");
+    // Genuine passthrough fields are still transformed and serialized.
+    expect(_meta).toHaveProperty("openai/widgetPrefersBorder", true);
+  });
+
+  it("MCP Apps adapter does not emit openInAppUrl under _meta.ui", () => {
+    const adapter = new McpAppsAdapter();
+    const { _meta } = adapter.buildResourceMetadata(
+      makeDefinition({
+        prefersBorder: true,
+        openai: { openInAppUrl: "https://app.example.com/item/42" },
+      })
+    );
+
+    expect(JSON.stringify(_meta)).not.toContain("openInAppUrl");
+    expect(JSON.stringify(_meta)).not.toContain("openai");
+    // Genuine passthrough fields are still serialized under the ui namespace.
+    expect((_meta as any)?.ui).toHaveProperty("prefersBorder", true);
+  });
+});
+
+describe("processWidgetHtml injects window.__mcpOpenInAppUrl", () => {
+  const html = "<html><head></head><body></body></html>";
+  const baseUrl = "http://localhost:3000";
+
+  it("injects the global when an openInAppUrl is provided", () => {
+    const out = processWidgetHtml(
+      html,
+      "demo-widget",
+      baseUrl,
+      "https://app.example.com/item/42"
+    );
+    expect(out).toContain(
+      'window.__mcpOpenInAppUrl = "https://app.example.com/item/42";'
+    );
+  });
+
+  it("omits the global when no openInAppUrl is provided", () => {
+    const out = processWidgetHtml(html, "demo-widget", baseUrl);
+    expect(out).not.toContain("__mcpOpenInAppUrl");
+  });
+
+  it("escapes the URL so it cannot break out of the inline script", () => {
+    const nasty = "https://evil.example.com/x</script><script>alert(1)";
+    const out = processWidgetHtml(html, "demo-widget", baseUrl, nasty);
+    // The injected <script> must not be terminable by the value.
+    expect(out).not.toContain("</script><script>alert(1)");
+    // < and > are unicode-escaped inside the JS string literal.
+    expect(out).toContain("\\u003c/script\\u003e");
+    expect(out).toContain("evil.example.com");
+  });
+});


### PR DESCRIPTION
## Language / Project Scope

- [x] TypeScript
- [x] Documentation only

## Changes

Adds support for controlling the URL behind ChatGPT's **"Open in app"** affordance from widgets. This is a ChatGPT Apps SDK feature — it is a no-op on MCP Apps hosts and the URL-params fallback.

Two complementary entry points:

- **Dynamic** — `setOpenInAppUrl(href)` action from `useWidget()`, for a per-record deep link (e.g. linking to the specific record the widget is currently displaying).
- **Static** — `metadata.openai.openInAppUrl` in the widget definition, applied automatically when the widget mounts inside ChatGPT.

## Implementation Details

1. **`useWidget()` action** (`src/react/useWidget.ts`): new `setOpenInAppUrl(href)` that guards on `provider === "openai"` and feature-detects `window.openai?.setOpenInAppUrl` before calling it (older ChatGPT hosts may not expose the method).
2. **Static URL application** (`src/react/useWidget.ts`): a mount-time `useEffect` reads `window.__mcpOpenInAppUrl` (injected by the server) and applies it once via `window.openai.setOpenInAppUrl`.
3. **Types** (`src/react/widget-types.ts`): adds `setOpenInAppUrl?` to the OpenAI `API` interface, `__mcpOpenInAppUrl?` to the `Window` global, and `setOpenInAppUrl` to the hook result type.
4. **Server metadata** (`src/server/types/widget.ts`, `adapters/types.ts`): new `metadata.openai.openInAppUrl?` field. Unlike other metadata fields, the `openai` block drives runtime `window.openai` calls rather than serialized resource `_meta`, so it is **excluded** from metadata passthrough in `adapters/base.ts`.
5. **HTML injection** (`src/server/widgets/widget-helpers.ts`): `processWidgetHtml` takes an optional `openInAppUrl` and injects `window.__mcpOpenInAppUrl` into the head `<script>`, escaped against `</script>` breakout and U+2028/U+2029 line separators. Both call sites (`widget-helpers.ts`, `mount-widgets-dev.ts`) pull the value from the unified metadata block.

## Example Usage (After)

Static (widget definition):

```ts
metadata: {
  openai: {
    openInAppUrl: "https://app.example.com",
  },
}
```

Dynamic (component):

```tsx
const { props, setOpenInAppUrl } = useWidget();

useEffect(() => {
  if (props.id) {
    setOpenInAppUrl(`https://app.example.com/records/${props.id}`);
  }
}, [props.id]);
```

## Documentation Updates

- `docs/typescript/server/mcp-apps.mdx` — documents `metadata.openai.openInAppUrl`
- `docs/typescript/server/widget-components/usewidget.mdx` — documents the `setOpenInAppUrl` action
- `examples/.../greeting-card/widget.tsx` — demonstrates the static metadata field

## Testing

- `tests/unit/react/useWidget-openInAppUrl.test.tsx` — imperative action + static mount-time application, including the no-op paths for non-ChatGPT providers and missing host method
- `tests/unit/server/widget-open-in-app-url.test.ts` — server-side HTML injection and escaping
- All 11 tests pass; `tsc --noEmit` is clean.

## Backwards Compatibility

Non-breaking. New optional API and metadata field; existing widgets are unaffected.