### PR TITLE
fix(server/oauth): broker upstream OAuth callback through /oauth/callback

### DIFF
--- a/.changeset/oauth-proxy-brokered-callback.md
+++ b/.changeset/oauth-proxy-brokered-callback.md
@@ -1,0 +1,7 @@
+---
+"mcp-use": patch
+---
+
+OAuth proxy mode now brokers the upstream callback through the server's own `/oauth/callback` instead of forwarding each MCP client's redirect URI upstream. Register a single redirect URI on your OAuth provider — `<your-server-domain>/oauth/callback` — and every MCP client (Claude, ChatGPT, the inspector, ...) can authenticate without registering its own callback. The client's redirect URI and state are carried statelessly through the upstream `state` parameter, PKCE stays end-to-end between the client and the upstream, and `/token` rewrites `redirect_uri` to match the brokered authorize request.
+
+If you previously registered client callback URLs (e.g. `http://localhost:3000/inspector/oauth/callback`) on your provider, add `<your-server-domain>/oauth/callback` instead.

--- a/docs/typescript/server/authentication/providers/auth0.mdx
+++ b/docs/typescript/server/authentication/providers/auth0.mdx
@@ -96,10 +96,11 @@ Auth0 supports two integration modes depending on whether you have access to Aut
 
     1. Go to **Applications → Create Application**
     2. Choose **Regular Web Application**
-    3. Under **Allowed Callback URLs**, add your MCP client's redirect URI:
+    3. Under **Allowed Callback URLs**, add your **MCP server's** callback URL:
        ```
-       http://localhost:3000/inspector/oauth/callback
+       http://localhost:3000/oauth/callback
        ```
+       The server brokers the OAuth callback for every MCP client (Claude, ChatGPT, the inspector, ...), so this is the only URL you register  -  individual clients never need their own redirect URIs added here. In production, use your deployed server's domain, e.g. `https://my-server.example.com/oauth/callback`.
     4. Copy the **Client ID** and **Client Secret**
 
     ### 2. Create an API
@@ -153,7 +154,8 @@ Auth0 supports two integration modes depending on whether you have access to Aut
     ```
     Client → /register         → receives pre-registered client_id
     Client → /authorize        → MCP server redirects to Auth0 /authorize
-    Auth0  → redirect_uri      → returns authorization code to client
+    Auth0  → /oauth/callback   → MCP server receives the authorization code
+    Server → client redirect   → forwards the code to the client's own callback
     Client → /token            → MCP server injects credentials, forwards to Auth0
     Auth0  → access_token (JWT)→ returned to client
     Client → /mcp/...          → MCP server verifies JWT via Auth0 JWKS

--- a/docs/typescript/server/authentication/providers/oauth-proxy.mdx
+++ b/docs/typescript/server/authentication/providers/oauth-proxy.mdx
@@ -23,11 +23,16 @@ Common proxy targets: **Google, GitHub, Okta, Azure AD (Microsoft Entra ID), Aut
 ## How it works
 
 1. Your server exposes a `/register` endpoint that returns the configured `clientId`.
-2. The MCP client runs PKCE authorization against the upstream using that `clientId`.
-3. At token exchange, your server injects the `clientId` and `clientSecret` before forwarding to the upstream.
-4. On each `/mcp/*` request, your server verifies the bearer token via the `verifyToken` function you provided.
+2. The MCP client starts PKCE authorization at your server's `/authorize`, which redirects to the upstream with the server's own `/oauth/callback` as the redirect URI.
+3. The upstream redirects back to `<your-server>/oauth/callback`, and your server forwards the authorization code to the client's original redirect URI.
+4. At token exchange, your server injects the `clientId` and `clientSecret` before forwarding to the upstream.
+5. On each `/mcp/*` request, your server verifies the bearer token via the `verifyToken` function you provided.
 
-Your server holds the client credentials and mediates every token exchange. Tokens are passed through  -  the proxy does not mint its own.
+Your server holds the client credentials and mediates every token exchange. Tokens are passed through  -  the proxy does not mint its own, and PKCE runs end-to-end between the MCP client and the upstream provider.
+
+<Note>
+  Register exactly one redirect URI in your provider's dashboard: `<your-server-domain>/oauth/callback` (e.g. `http://localhost:3000/oauth/callback` during development). MCP clients never need their own redirect URIs registered upstream  -  the server brokers the callback for all of them.
+</Note>
 
 ## Quick start (Google)
 

--- a/libraries/typescript/packages/mcp-use/examples/server/oauth/auth0-proxy/README.md
+++ b/libraries/typescript/packages/mcp-use/examples/server/oauth/auth0-proxy/README.md
@@ -12,10 +12,11 @@ In the [Auth0 Dashboard](https://manage.auth0.com):
 
 1. Go to **Applications → Create Application**
 2. Choose **Regular Web Application**
-3. Under **Allowed Callback URLs**, add your MCP client's redirect URI, e.g.:
+3. Under **Allowed Callback URLs**, add your **MCP server's** callback URL:
    ```
-   http://localhost:3000/inspector/oauth/callback
+   http://localhost:3000/oauth/callback
    ```
+   The server brokers the callback for every MCP client, so this is the only URL you register — clients never need their own redirect URIs added here.
 4. Save changes and copy the **Client ID** and **Client Secret**
 
 ### 2. Create an API
@@ -54,7 +55,8 @@ Server starts on port 3000. Open `http://localhost:3000/inspector` to test the O
 ```
 Client → /register         → receives pre-registered client_id
 Client → /authorize        → MCP server redirects to Auth0 /authorize
-Auth0  → redirect_uri      → returns authorization code to client
+Auth0  → /oauth/callback   → MCP server receives the authorization code
+Server → client redirect   → forwards the code to the client's own callback
 Client → /token            → MCP server injects credentials, forwards to Auth0
 Auth0  → access_token (JWT)→ returned to client
 Client → /mcp/...          → MCP server verifies JWT via Auth0 JWKS

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/oauth-proxy.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/oauth-proxy.ts
@@ -137,6 +137,20 @@ export function jwksVerifier(config: JwksVerifierConfig): VerifyToken {
   const jwks = createRemoteJWKSet(new URL(config.jwksUrl));
 
   return async (token) => {
+    // A signed JWT has exactly three dot-separated segments. Opaque tokens —
+    // what Auth0 and others issue when the authorize request carries no valid
+    // `audience` — have none, and would otherwise fail deep inside jose as the
+    // cryptic "JWSInvalid: Invalid Compact JWS". Catch it early with a hint
+    // that points at the actual cause.
+    if (token.split(".").length !== 3) {
+      throw new Error(
+        "Access token is not a signed JWT, so it can't be verified against the JWKS. " +
+          "Many providers — Auth0 included — only issue JWT access tokens when the " +
+          "authorization request specifies a valid `audience` (your API identifier). " +
+          "Check your `audience` configuration."
+      );
+    }
+
     try {
       const result = await jwtVerify(token, jwks, {
         issuer: config.issuer,

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/routes.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/routes.ts
@@ -10,12 +10,14 @@
  * 2. **Proxy mode (OAuthProxy):** For providers that don't support DCR
  *    (e.g., Google, GitHub). The MCP server:
  *    - Exposes /register returning the configured clientId
- *    - Redirects /authorize to upstream with extra params
+ *    - Redirects /authorize to upstream, brokering the callback through its
+ *      own /oauth/callback so only `<baseUrl>/oauth/callback` needs to be
+ *      registered with the upstream provider
  *    - Forwards /token requests with injected credentials
  *    - Synthesizes `.well-known` metadata pointing to local endpoints
  */
 
-import type { Context, Hono } from "hono";
+import type { Context, Hono, Next } from "hono";
 import { cors } from "hono/cors";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import type { OAuthProvider, OAuthProxy } from "./providers/types.js";
@@ -36,16 +38,88 @@ export function isOAuthProxy(
 }
 
 /**
+ * Callback transaction carried through the upstream `state` parameter.
+ *
+ * In proxy mode the client's redirect_uri and state are packed into the
+ * `state` value sent upstream (base64url JSON), so /oauth/callback can
+ * restore them without any server-side storage. This keeps the broker
+ * stateless — it survives restarts and multi-instance deployments.
+ */
+interface CallbackTxn {
+  /** Client's original redirect_uri */
+  redirectUri: string;
+  /** Client's original state, if any */
+  state?: string;
+}
+
+function base64UrlEncode(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function base64UrlDecode(value: string): string {
+  const base64 = value.replace(/-/g, "+").replace(/_/g, "/");
+  const binary = atob(base64);
+  const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+}
+
+function encodeCallbackTxn(txn: CallbackTxn): string {
+  return base64UrlEncode(JSON.stringify(txn));
+}
+
+function decodeCallbackTxn(value: string): CallbackTxn | null {
+  try {
+    const parsed = JSON.parse(base64UrlDecode(value));
+    if (
+      typeof parsed?.redirectUri !== "string" ||
+      !isValidRedirectUri(parsed.redirectUri)
+    ) {
+      return null;
+    }
+    return {
+      redirectUri: parsed.redirectUri,
+      state: typeof parsed.state === "string" ? parsed.state : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function isValidRedirectUri(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Authorization endpoint handler
  *
  * In DCR-direct mode (OAuthProvider): Dormant — clients reach upstream directly.
- * In proxy mode (OAuthProxy): Active — redirects to upstream with extra params.
+ * In proxy mode (OAuthProxy): Active — redirects to upstream, replacing the
+ * client's redirect_uri with the local /oauth/callback so only the proxy's
+ * callback needs to be registered upstream. The client's redirect_uri and
+ * state are packed into the upstream `state` and restored at the callback.
+ * PKCE parameters pass through untouched, so the challenge/verifier pair
+ * stays end-to-end between the MCP client and the upstream provider.
  *
  * @param oauth - The OAuth provider or proxy
+ * @param baseUrl - The base URL of this server (for the brokered callback)
  * @returns Hono handler that redirects to the upstream authorize endpoint
  */
 function createAuthorizeHandler(
-  oauth: OAuthProvider | OAuthProxy
+  oauth: OAuthProvider | OAuthProxy,
+  baseUrl: string
 ): (c: Context) => Promise<Response> {
   return async (c: Context) => {
     const params =
@@ -74,12 +148,21 @@ function createAuthorizeHandler(
       );
     }
 
+    if (!isValidRedirectUri(redirectUri as string)) {
+      return c.json(
+        {
+          error: "invalid_request",
+          error_description: "redirect_uri must be a valid http(s) URL",
+        },
+        400
+      );
+    }
+
     // Get authorization endpoint - uniform for both provider and proxy
     const authEndpoint = oauth.getAuthEndpoint();
 
     // Build provider authorization URL
     const authUrl = new URL(authEndpoint);
-    authUrl.searchParams.set("redirect_uri", redirectUri as string);
     authUrl.searchParams.set("response_type", responseType as string);
     authUrl.searchParams.set("code_challenge", codeChallenge as string);
     authUrl.searchParams.set(
@@ -87,11 +170,21 @@ function createAuthorizeHandler(
       (codeChallengeMethod as string) || "S256"
     );
 
-    if (state) authUrl.searchParams.set("state", state as string);
     if (scope) authUrl.searchParams.set("scope", scope as string);
     if (audience) authUrl.searchParams.set("audience", audience as string);
 
     if (isOAuthProxy(oauth)) {
+      // Broker the callback: send upstream to the local /oauth/callback and
+      // carry the client's redirect_uri + state inside the upstream state.
+      // Only `<baseUrl>/oauth/callback` needs to be registered upstream.
+      authUrl.searchParams.set("redirect_uri", `${baseUrl}/oauth/callback`);
+      authUrl.searchParams.set(
+        "state",
+        encodeCallbackTxn({
+          redirectUri: redirectUri as string,
+          state: state ? (state as string) : undefined,
+        })
+      );
       // Override with the configured upstream client_id; the incoming value
       // may be stale DCR cache.
       authUrl.searchParams.set("client_id", oauth.clientId);
@@ -101,6 +194,8 @@ function createAuthorizeHandler(
         }
       }
     } else {
+      authUrl.searchParams.set("redirect_uri", redirectUri as string);
+      if (state) authUrl.searchParams.set("state", state as string);
       authUrl.searchParams.set("client_id", clientId as string);
     }
 
@@ -110,16 +205,87 @@ function createAuthorizeHandler(
 }
 
 /**
+ * Brokered callback endpoint handler (proxy mode only)
+ *
+ * Receives the upstream provider's redirect at `<baseUrl>/oauth/callback`,
+ * restores the client's original redirect_uri + state from the upstream
+ * `state` parameter, and forwards the authorization code (or upstream error)
+ * to the client. The code itself passes through untouched — the client
+ * exchanges it at the local /token endpoint, which rewrites redirect_uri to
+ * match what was sent upstream.
+ *
+ * If the `state` parameter doesn't decode to a broker transaction, the
+ * request falls through to later routes: browser clients (e.g. `useMcp`)
+ * default their own redirect URI to `/oauth/callback` on their origin, and a
+ * frontend served from the same origin as this server must keep receiving
+ * its callback page.
+ *
+ * @returns Hono handler that redirects back to the MCP client's callback
+ */
+function createCallbackHandler(): (
+  c: Context,
+  next: Next
+) => Promise<Response | void> {
+  return async (c: Context, next: Next) => {
+    const query = c.req.query();
+
+    const txn = query.state ? decodeCallbackTxn(query.state) : null;
+    if (!txn) {
+      // No decodable broker transaction in `state`. This is expected when a
+      // same-origin frontend serves its own callback page at /oauth/callback,
+      // so pass through to let its route handle the request. If you expected
+      // the proxy to handle this redirect, the upstream provider isn't
+      // echoing back the `state` the proxy sent at /authorize.
+      return next();
+    }
+
+    const redirect = new URL(txn.redirectUri);
+
+    if (query.error) {
+      // Forward upstream errors (e.g. access_denied) to the client
+      redirect.searchParams.set("error", query.error);
+      if (query.error_description) {
+        redirect.searchParams.set("error_description", query.error_description);
+      }
+      if (query.error_uri) {
+        redirect.searchParams.set("error_uri", query.error_uri);
+      }
+    } else if (query.code) {
+      redirect.searchParams.set("code", query.code);
+    } else {
+      return c.json(
+        {
+          error: "invalid_request",
+          error_description: "Callback is missing both code and error",
+        },
+        400
+      );
+    }
+
+    if (txn.state !== undefined) {
+      redirect.searchParams.set("state", txn.state);
+    }
+
+    return c.redirect(redirect.toString(), 302);
+  };
+}
+
+/**
  * Token endpoint handler
  *
  * In DCR-direct mode (OAuthProvider): Dormant — clients call upstream directly.
- * In proxy mode (OAuthProxy): Active — injects clientId/clientSecret before forwarding.
+ * In proxy mode (OAuthProxy): Active — injects clientId/clientSecret and
+ * rewrites redirect_uri to the brokered /oauth/callback before forwarding
+ * (RFC 6749 §4.1.3 requires it to match the authorize request, which used
+ * the local callback rather than the client's).
  *
  * @param oauth - The OAuth provider or proxy
+ * @param baseUrl - The base URL of this server (for the brokered callback)
  * @returns Hono handler that forwards form-encoded token exchanges upstream
  */
 function createTokenHandler(
-  oauth: OAuthProvider | OAuthProxy
+  oauth: OAuthProvider | OAuthProxy,
+  baseUrl: string
 ): (c: Context) => Promise<Response> {
   return async (c: Context) => {
     try {
@@ -139,6 +305,13 @@ function createTokenHandler(
         // Add client_secret if configured (for confidential clients)
         if (oauth.clientSecret) {
           requestBody.set("client_secret", oauth.clientSecret);
+        }
+
+        // The authorize request used the brokered /oauth/callback, so the
+        // token exchange must present the same redirect_uri — not the
+        // client's own callback.
+        if (requestBody.has("redirect_uri")) {
+          requestBody.set("redirect_uri", `${baseUrl}/oauth/callback`);
         }
       }
 
@@ -189,8 +362,10 @@ function createTokenHandler(
  *
  * **Proxy mode (OAuthProxy):**
  * - POST /register - Returns configured clientId (fake DCR endpoint)
- * - GET/POST /authorize - Redirects to upstream with extra params
- * - POST /token - Forwards with injected credentials
+ * - GET/POST /authorize - Redirects to upstream, brokering the callback locally
+ * - GET /oauth/callback - Receives the upstream redirect and forwards the
+ *   code to the MCP client's original redirect_uri
+ * - POST /token - Forwards with injected credentials and the brokered redirect_uri
  * - GET /.well-known/* - Synthesized metadata pointing to local endpoints
  *
  * @param app - The Hono application instance
@@ -239,15 +414,20 @@ export function setupOAuthRoutes(
   );
 
   // Mount /authorize and /token handlers
-  const handleAuthorize = createAuthorizeHandler(oauth);
+  const handleAuthorize = createAuthorizeHandler(oauth, baseUrl);
   app.get("/authorize", handleAuthorize);
   app.post("/authorize", handleAuthorize);
-  app.post("/token", createTokenHandler(oauth));
+  app.post("/token", createTokenHandler(oauth, baseUrl));
 
   // In proxy mode, add /register endpoint that returns the configured clientId
   // This allows MCP clients to "register" even though the client is pre-registered
   if (proxyMode) {
     const proxy = oauth as OAuthProxy;
+
+    // Brokered upstream callback. This is a top-level browser navigation
+    // (no CORS needed) — register `<baseUrl>/oauth/callback` as the only
+    // redirect URI on the upstream provider.
+    app.get("/oauth/callback", createCallbackHandler());
 
     app.use(
       "/register",

--- a/libraries/typescript/packages/mcp-use/tests/server/oauth.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/server/oauth.test.ts
@@ -11,7 +11,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createBearerAuthMiddleware } from "../../src/server/oauth/middleware.js";
 import { setupOAuthRoutes } from "../../src/server/oauth/routes.js";
 import { setupOAuthForServer } from "../../src/server/oauth/setup.js";
-import { oauthProxy } from "../../src/server/oauth/oauth-proxy.js";
+import {
+  oauthProxy,
+  jwksVerifier,
+} from "../../src/server/oauth/oauth-proxy.js";
 import { oauthCustomProvider } from "../../src/server/oauth/providers.js";
 
 // A stub verifier that accepts any token. Used in tests that don't exercise
@@ -127,14 +130,207 @@ describe("server OAuth integration", () => {
     expect(response.status).toBe(200);
     expect(data.access_token).toBe("abc");
     expect(tokenSpy).toHaveBeenCalledTimes(1);
-    // Verify that client credentials were injected
+    // Verify that client credentials were injected and redirect_uri was
+    // rewritten to the brokered callback (it must match the authorize request)
     expect(tokenSpy.mock.calls[0][0].body).toMatchObject({
       grant_type: "authorization_code",
       code: "code-123",
-      redirect_uri: "http://localhost:3000/callback",
+      redirect_uri: `${svc.baseUrl}/oauth/callback`,
       client_id: "my-client-id",
       client_secret: "my-client-secret",
     });
+  });
+
+  it("brokers the authorize redirect through the local /oauth/callback", async () => {
+    const app = new Hono();
+
+    const proxy = oauthProxy({
+      issuer: "https://issuer.example.com",
+      authEndpoint: "https://issuer.example.com/oauth/authorize",
+      tokenEndpoint: "https://issuer.example.com/oauth/token",
+      clientId: "my-client-id",
+      verifyToken: stubVerifyToken,
+    });
+
+    const svc = await listenOnRandomPort(app);
+    closers.push(svc.close);
+
+    setupOAuthRoutes(app, proxy, svc.baseUrl);
+
+    const authorizeUrl = new URL(`${svc.baseUrl}/authorize`);
+    authorizeUrl.searchParams.set("client_id", "dcr-cached-client");
+    authorizeUrl.searchParams.set(
+      "redirect_uri",
+      "https://client.example.com/inspector/oauth/callback?session=42"
+    );
+    authorizeUrl.searchParams.set("response_type", "code");
+    authorizeUrl.searchParams.set("code_challenge", "challenge-abc");
+    authorizeUrl.searchParams.set("code_challenge_method", "S256");
+    authorizeUrl.searchParams.set("state", "client-state-xyz");
+
+    const response = await fetch(authorizeUrl, { redirect: "manual" });
+    expect(response.status).toBe(302);
+
+    const upstream = new URL(response.headers.get("location")!);
+    // Upstream sees only the proxy's callback — clients never need their own
+    // redirect URIs registered on the provider
+    expect(upstream.searchParams.get("redirect_uri")).toBe(
+      `${svc.baseUrl}/oauth/callback`
+    );
+    // PKCE passes through end-to-end
+    expect(upstream.searchParams.get("code_challenge")).toBe("challenge-abc");
+    expect(upstream.searchParams.get("client_id")).toBe("my-client-id");
+    // The client's redirect_uri and state ride inside the upstream state
+    const upstreamState = upstream.searchParams.get("state")!;
+    expect(upstreamState).not.toBe("client-state-xyz");
+
+    // Simulate the upstream provider redirecting back to the broker
+    const callbackUrl = new URL(`${svc.baseUrl}/oauth/callback`);
+    callbackUrl.searchParams.set("code", "upstream-code-123");
+    callbackUrl.searchParams.set("state", upstreamState);
+
+    const callback = await fetch(callbackUrl, { redirect: "manual" });
+    expect(callback.status).toBe(302);
+
+    const clientRedirect = new URL(callback.headers.get("location")!);
+    expect(clientRedirect.origin).toBe("https://client.example.com");
+    expect(clientRedirect.pathname).toBe("/inspector/oauth/callback");
+    // Pre-existing query params on the client redirect_uri survive
+    expect(clientRedirect.searchParams.get("session")).toBe("42");
+    expect(clientRedirect.searchParams.get("code")).toBe("upstream-code-123");
+    expect(clientRedirect.searchParams.get("state")).toBe("client-state-xyz");
+  });
+
+  it("forwards upstream errors to the client's redirect_uri", async () => {
+    const app = new Hono();
+
+    const proxy = oauthProxy({
+      issuer: "https://issuer.example.com",
+      authEndpoint: "https://issuer.example.com/oauth/authorize",
+      tokenEndpoint: "https://issuer.example.com/oauth/token",
+      clientId: "my-client-id",
+      verifyToken: stubVerifyToken,
+    });
+
+    const svc = await listenOnRandomPort(app);
+    closers.push(svc.close);
+
+    setupOAuthRoutes(app, proxy, svc.baseUrl);
+
+    const authorizeUrl = new URL(`${svc.baseUrl}/authorize`);
+    authorizeUrl.searchParams.set("client_id", "client");
+    authorizeUrl.searchParams.set(
+      "redirect_uri",
+      "https://client.example.com/callback"
+    );
+    authorizeUrl.searchParams.set("response_type", "code");
+    authorizeUrl.searchParams.set("code_challenge", "challenge");
+    authorizeUrl.searchParams.set("state", "client-state");
+
+    const response = await fetch(authorizeUrl, { redirect: "manual" });
+    const upstreamState = new URL(
+      response.headers.get("location")!
+    ).searchParams.get("state")!;
+
+    const callbackUrl = new URL(`${svc.baseUrl}/oauth/callback`);
+    callbackUrl.searchParams.set("error", "access_denied");
+    callbackUrl.searchParams.set("error_description", "User cancelled");
+    callbackUrl.searchParams.set("state", upstreamState);
+
+    const callback = await fetch(callbackUrl, { redirect: "manual" });
+    expect(callback.status).toBe(302);
+
+    const clientRedirect = new URL(callback.headers.get("location")!);
+    expect(clientRedirect.searchParams.get("error")).toBe("access_denied");
+    expect(clientRedirect.searchParams.get("error_description")).toBe(
+      "User cancelled"
+    );
+    expect(clientRedirect.searchParams.get("state")).toBe("client-state");
+    expect(clientRedirect.searchParams.get("code")).toBeNull();
+  });
+
+  it("falls through /oauth/callback when state is not a broker transaction", async () => {
+    const app = new Hono();
+
+    const proxy = oauthProxy({
+      issuer: "https://issuer.example.com",
+      authEndpoint: "https://issuer.example.com/oauth/authorize",
+      tokenEndpoint: "https://issuer.example.com/oauth/token",
+      clientId: "my-client-id",
+      verifyToken: stubVerifyToken,
+    });
+
+    const svc = await listenOnRandomPort(app);
+    closers.push(svc.close);
+
+    setupOAuthRoutes(app, proxy, svc.baseUrl);
+
+    // A same-origin frontend may serve its own callback page at this path
+    // (useMcp defaults to `<origin>/oauth/callback`)
+    app.get("/oauth/callback", (c) => c.text("frontend callback page"));
+
+    const response = await fetch(
+      `${svc.baseUrl}/oauth/callback?code=abc&state=random-client-state`
+    );
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("frontend callback page");
+
+    // Without a downstream route, an unrecognized state 404s
+    const app2 = new Hono();
+    const svc2 = await listenOnRandomPort(app2);
+    closers.push(svc2.close);
+    setupOAuthRoutes(app2, proxy, svc2.baseUrl);
+
+    const notFound = await fetch(
+      `${svc2.baseUrl}/oauth/callback?code=abc&state=garbage`
+    );
+    expect(notFound.status).toBe(404);
+  });
+
+  it("jwksVerifier rejects opaque (non-JWT) tokens with an actionable hint", async () => {
+    const verify = jwksVerifier({
+      jwksUrl: "https://issuer.example.com/.well-known/jwks.json",
+      issuer: "https://issuer.example.com/",
+      audience: "https://api.example.com",
+    });
+
+    // An opaque Auth0 token (no dots) is rejected before any network/JWKS call,
+    // with a message that points at the missing `audience` rather than jose's
+    // cryptic "Invalid Compact JWS".
+    await expect(verify("opaque-token-without-dots")).rejects.toThrow(
+      /not a signed JWT.*audience/s
+    );
+
+    // A malformed two-segment token is likewise caught early.
+    await expect(verify("header.payload")).rejects.toThrow(/not a signed JWT/);
+  });
+
+  it("rejects authorize requests with an invalid redirect_uri", async () => {
+    const app = new Hono();
+
+    const proxy = oauthProxy({
+      issuer: "https://issuer.example.com",
+      authEndpoint: "https://issuer.example.com/oauth/authorize",
+      tokenEndpoint: "https://issuer.example.com/oauth/token",
+      clientId: "my-client-id",
+      verifyToken: stubVerifyToken,
+    });
+
+    const svc = await listenOnRandomPort(app);
+    closers.push(svc.close);
+
+    setupOAuthRoutes(app, proxy, svc.baseUrl);
+
+    const authorizeUrl = new URL(`${svc.baseUrl}/authorize`);
+    authorizeUrl.searchParams.set("client_id", "client");
+    authorizeUrl.searchParams.set("redirect_uri", "not-a-url");
+    authorizeUrl.searchParams.set("response_type", "code");
+    authorizeUrl.searchParams.set("code_challenge", "challenge");
+
+    const response = await fetch(authorizeUrl, { redirect: "manual" });
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toBe("invalid_request");
   });
 
   it("allows browser GET to /mcp through OAuth when publicLandingPage is enabled", async () => {


### PR DESCRIPTION
## Changes

OAuth **proxy mode** no longer forwards each MCP client's `redirect_uri` to the upstream provider. Instead, the server brokers the callback through its own `/oauth/callback`, so only **one** redirect URI — `<server-domain>/oauth/callback` — needs to be registered on the provider. Every MCP client (Claude, ChatGPT, the inspector, ...) can then authenticate without registering its own callback.

This resolves the confusion in MCP-2170: the Auth0 docs implied each client's redirect URI had to be configured on the provider. It should be the server's, matching the FastMCP OAuth proxy flow.

## Implementation Details

1. **`/authorize` (proxy mode)** — sends the upstream `redirect_uri=<baseUrl>/oauth/callback` and packs the client's original `redirect_uri` + `state` into the upstream `state` as base64url JSON. Stateless: no server-side store, survives restarts and multi-instance deployments. PKCE (`code_challenge`) passes through untouched, so the challenge/verifier pair stays end-to-end between the MCP client and the upstream.
2. **`GET /oauth/callback` (new, proxy mode)** — decodes the transaction from `state`, then 302s to the client's original `redirect_uri` with the `code` (or forwards `error`/`error_description`/`error_uri`) and the client's original `state`. If `state` doesn't decode to a broker transaction, it falls through to later routes so a same-origin frontend serving its own callback page (e.g. `useMcp`'s default `/oauth/callback`) keeps working.
3. **`/token` (proxy mode)** — rewrites `redirect_uri` to `<baseUrl>/oauth/callback` so the token exchange matches the authorize request (RFC 6749 §4.1.3).
4. **`jwksVerifier`** — rejects opaque (non-JWT) access tokens up front with an actionable message ("...only issue JWT access tokens when the authorization request specifies a valid `audience`...") instead of jose's cryptic `JWSInvalid: Invalid Compact JWS`.
5. Added `redirect_uri` validation on `/authorize` (must be a valid http(s) URL).

`baseUrl` is the value already passed to `setupOAuthRoutes` (computed once at `listen()` via `getServerBaseUrl()`), so authorize and token always agree.

## Example Usage (Before)

Register every client's callback on the provider:
```
http://localhost:3000/inspector/oauth/callback
https://claude.ai/api/mcp/auth_callback
...
```

## Example Usage (After)

Register one URL — the server's:
```
http://localhost:3000/oauth/callback
```

## Documentation Updates

- `docs/typescript/server/authentication/providers/oauth-proxy.mdx` — updated "How it works" + a note that only `<server-domain>/oauth/callback` is registered upstream.
- `docs/typescript/server/authentication/providers/auth0.mdx` — register the server's callback; corrected the flow diagram.
- `examples/server/oauth/auth0-proxy/README.md` — same corrections.

## Testing

- Added unit/integration tests in `tests/server/oauth.test.ts` (14 pass):
  - full broker roundtrip — upstream sees only `/oauth/callback`, client gets `code` + original `state`, pre-existing query params on the client `redirect_uri` survive
  - `/token` rewrites `redirect_uri` to the brokered callback
  - upstream errors forwarded to the client's `redirect_uri`
  - same-origin fall-through when `state` isn't a broker transaction (and 404 when no downstream route)
  - invalid `redirect_uri` rejected at `/authorize`
  - `jwksVerifier` rejects opaque tokens with the actionable hint
- `pnpm --filter mcp-use test:unit` green, `tsc` clean, lint/format clean.
- Verified end-to-end against a live Auth0 Regular Web App (proxy mode) via the inspector: authorize → broker → token → authenticated `/mcp`.

## Backwards Compatibility

Behavioral change for proxy-mode servers (changeset: `minor`). If you previously registered client callback URLs on your provider, register `<server-domain>/oauth/callback` instead. DCR-direct mode (`OAuthProvider`) is unaffected — its `/authorize` still forwards the client's `redirect_uri` and `state` directly.

## Related Issues

Closes MCP-2170