### PR TITLE
fix(typescript): enable JSON responses in stateful StreamableHTTP transport to prevent tool call hanging

### DIFF
--- a/libraries/typescript/packages/mcp-use/src/server/endpoints/mount-mcp.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/endpoints/mount-mcp.ts
@@ -400,6 +400,7 @@ export async function mountMcp(
         const server = mcpServerInstance.getServerForSession(sessionId);
         const transport = new WebStandardStreamableHTTPServerTransport({
           sessionIdGenerator: () => sessionId,
+          enableJsonResponse: true,
 
           onsessioninitialized: async (sid: string) => {
             if (getDebugLevel() !== "info") {
@@ -516,6 +517,7 @@ export async function mountMcp(
       const server = mcpServerInstance.getServerForSession(newSessionId);
       const transport = new WebStandardStreamableHTTPServerTransport({
         sessionIdGenerator: () => newSessionId,
+        enableJsonResponse: true,
 
         onsessioninitialized: async (sid: string) => {
           if (getDebugLevel() !== "info") {

--- a/libraries/typescript/packages/mcp-use/tests/integration/issue-1724-json-response.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/integration/issue-1724-json-response.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { z } from "zod";
+import { MCPServer } from "../../src/server/index.js";
+import { text } from "../../src/server/utils/response-helpers.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+const TEST_PORT = 3095;
+const SERVER_URL = `http://localhost:${TEST_PORT}/mcp`;
+
+describe("Issue #1724 - Stateful transport should return tool results in POST response (not SSE)", () => {
+  let server: MCPServer;
+
+  beforeAll(async () => {
+    server = new MCPServer({
+      name: "issue-1724-test-server",
+      version: "1.0.0",
+    });
+
+    server.tool(
+      {
+        name: "hello",
+        description: "Says hello",
+        schema: z.object({
+          name: z.string(),
+        }),
+      },
+      async ({ name }) => {
+        return text(`Hello, ${name}!`);
+      }
+    );
+
+    await server.listen(TEST_PORT);
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  });
+
+  afterAll(async () => {
+    await (server as any).close?.();
+  });
+
+  it("should return tool result via POST (not hang waiting for SSE)", async () => {
+    const transport = new StreamableHTTPClientTransport(new URL(SERVER_URL));
+    const client = new Client(
+      { name: "test-client", version: "1.0.0" },
+      {}
+    );
+
+    try {
+      await client.connect(transport);
+
+      const result = await client.callTool(
+        { name: "hello", arguments: { name: "world" } },
+        undefined,
+        { timeout: 5000 }
+      );
+
+      expect(result).toBeDefined();
+      expect(result.content).toBeDefined();
+      const textContent = (result.content as Array<{ type: string; text?: string }>)
+        .find((c) => c.type === "text");
+      expect(textContent?.text).toBe("Hello, world!");
+    } finally {
+      await client.close();
+    }
+  });
+
+  it("should handle concurrent tool calls without hanging", async () => {
+    const transport = new StreamableHTTPClientTransport(new URL(SERVER_URL));
+    const client = new Client(
+      { name: "test-client", version: "1.0.0" },
+      {}
+    );
+
+    try {
+      await client.connect(transport);
+
+      const results = await Promise.all([
+        client.callTool(
+          { name: "hello", arguments: { name: "alice" } },
+          undefined,
+          { timeout: 5000 }
+        ),
+        client.callTool(
+          { name: "hello", arguments: { name: "bob" } },
+          undefined,
+          { timeout: 5000 }
+        ),
+      ]);
+
+      expect(results).toHaveLength(2);
+      for (const result of results) {
+        expect(result).toBeDefined();
+        expect(result.content).toBeDefined();
+      }
+    } finally {
+      await client.close();
+    }
+  });
+
+  it("POST response should be 200 (JSON) not 202 (SSE deferred)", async () => {
+    const sessionId = await initializeSession();
+
+    const response = await makeToolCallRequest(TEST_PORT, sessionId);
+
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body.result).toBeDefined();
+    expect(body.result.content).toBeDefined();
+  });
+});
+
+async function initializeSession(): Promise<string> {
+  const initRequest = {
+    jsonrpc: "2.0",
+    id: "1",
+    method: "initialize",
+    params: {
+      protocolVersion: "2024-11-05",
+      capabilities: {},
+      clientInfo: { name: "test", version: "1.0.0" },
+    },
+  };
+
+  const initResponse = await fetch(`http://localhost:${TEST_PORT}/mcp`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+    },
+    body: JSON.stringify(initRequest),
+  });
+
+  const sessionId = initResponse.headers.get("mcp-session-id");
+  if (!sessionId) throw new Error("No session ID in response");
+
+  await fetch(`http://localhost:${TEST_PORT}/mcp`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+      "mcp-session-id": sessionId,
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+    }),
+  });
+
+  return sessionId;
+}
+
+async function makeToolCallRequest(port: number, sessionId: string): Promise<Response> {
+  return fetch(`http://localhost:${port}/mcp`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+      "mcp-session-id": sessionId,
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: "2",
+      method: "tools/call",
+      params: {
+        name: "hello",
+        arguments: { name: "world" },
+      },
+    }),
+  });
+}


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

Check all that apply:
- [X] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

Added `enableJsonResponse: true` to both stateful `WebStandardStreamableHTTPServerTransport` constructors in `mount-mcp.ts`. Without this flag, stateful sessions used SSE delivery for tool call results, which silently dropped responses when the SSE stream wasn't fully established — causing clients (like the inspector) to hang forever until timeout. The stateless transport already had this flag.

## Review Readiness

Help maintainers review this quickly:

- [X] The PR is scoped to one issue or one clearly related change
- [X] The PR description explains the user-visible problem and the fix
- [X] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [X] I verified the affected package/docs path with the commands listed below
- [X] I checked for existing open PRs that already solve the same issue

## Implementation Details

1. Added `enableJsonResponse: true` to the session recovery transport in `mount-mcp.ts:403`
2. Added `enableJsonResponse: true` to the new session transport in `mount-mcp.ts:520`
3. Both stateful paths now match the stateless path (line 331) which already set this flag
4. No dependencies added or modified

---

## TypeScript Checklist

> Complete this section if your PR includes TypeScript changes

### Packages Modified

Check all packages that were modified:
- [ ] `docs`
- [X] `tests`
- [ ] `cli`
- [ ] `create-mcp-use-app`
- [X] `mcp-use` (server)
- [ ] `mcp-use` (client)
- [ ] `inspector`

### Pre-commit Checklist

Ensure all of the following have been completed:
- [ ] Ran `pnpm lint:fix` to auto-fix linting issues
- [ ] Ran `pnpm format` to format code with Prettier
- [X] Ran `pnpm build` and build succeeds without errors
- [X] Ran `pnpm changeset` to create a changeset (if this PR includes user-facing changes)
- [X] Added or updated tests if needed
- [ ] Updated documentation in `docs/` folder if needed

---

## Example Usage (Before)

```typescript
// Tool call hangs — POST returns 202, result sent via SSE and dropped
const transport = new WebStandardStreamableHTTPServerTransport({
  sessionIdGenerator: () => sessionId,
  // missing: enableJsonResponse: true
});
```

## Example Usage (After)

```typescript
// Tool call returns immediately — POST returns 200 with JSON body
const transport = new WebStandardStreamableHTTPServerTransport({
  sessionIdGenerator: () => sessionId,
  enableJsonResponse: true,
});
```

## Documentation Updates

None required — bug fix aligning stateful behavior with existing stateless behavior.

## Testing

- Added `tests/integration/issue-1724-json-response.test.ts` with 3 tests:
  - Sequential tool call via SDK client
  - Concurrent tool calls via SDK client
  - Direct HTTP check confirming POST returns 200 with JSON body (not 202 SSE)
- All 287 CLI tests pass, all 574 mcp-use unit tests pass
- All integration tests pass in isolation

## Backwards Compatibility

Fully backwards compatible. `enableJsonResponse: true` makes stateful transports return JSON-RPC responses directly in POST body instead of deferring to SSE. The SDK's `StreamableHTTPClientTransport` and the inspector both handle JSON POST responses correctly.

## Related Issues

Closes #1724
