### PR TITLE
fix(typescript): silence dev widget logs when project has no widgets

### DIFF
--- a/libraries/typescript/.changeset/silence-empty-widget-logs.md
+++ b/libraries/typescript/.changeset/silence-empty-widget-logs.md
@@ -1,0 +1,8 @@
+---
+"mcp-use": patch
+---
+
+Silence dev-mode widget startup logs when a project has no widgets. An empty or
+absent `resources/` directory no longer prints the `[WIDGETS]` mounting/serving/
+watching messages. The Vite watcher still starts so widgets created later (e.g.
+Mango/E2B sandboxes) are picked up and logged when they appear.

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/index.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/index.ts
@@ -86,7 +86,6 @@ export async function mountWidgets(
     (server as any).publicRoutesMode = "production";
     await mountWidgetsProduction(app, serverConfig, registerWidget, options);
   } else {
-    console.log("[WIDGETS] Mounting widgets in development mode");
     await mountWidgetsDev(
       app,
       serverConfig,

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/mount-widgets-dev.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/mount-widgets-dev.ts
@@ -104,12 +104,11 @@ export async function mountWidgetsDev(
   // Ensure resources directory exists - create it if missing.
   // In dynamic workflows (e.g., Mango/E2B), widgets are created after the server starts,
   // so we need the directory to exist for the Vite file watcher to monitor it.
+  // Created silently: a project that never uses widgets shouldn't be told about
+  // a directory it didn't ask for.
   try {
     await fs.access(srcDir);
   } catch {
-    console.log(
-      `[WIDGETS] No ${resourcesDir}/ directory found - creating it for widget watching`
-    );
     await fs.mkdir(srcDir, { recursive: true });
   }
 
@@ -146,18 +145,19 @@ export async function mountWidgetsDev(
         }
       }
     }
-  } catch (error) {
-    console.log(`[WIDGETS] No widgets found in ${resourcesDir}/ directory`);
+  } catch {
+    // resources/ couldn't be read - nothing to mount, stay silent.
     return;
   }
 
-  if (entries.length === 0) {
-    console.log(
-      `[WIDGETS] No widgets found in ${resourcesDir}/ directory yet - watching for new widgets...`
-    );
-    // Don't return - still start the Vite dev server so it watches for new widget files.
-    // This is critical for workflows where widgets are created after the server starts
-    // (e.g., Mango/E2B sandboxes where Claude creates widgets dynamically).
+  // Only emit widget startup logs when the project actually has widgets. An
+  // empty (or freshly-created) resources/ directory means this project isn't
+  // using widgets yet, so we do the setup silently. We still start the Vite
+  // watcher below so widgets created later (e.g. Mango/E2B sandboxes where
+  // widgets are created after startup) are picked up - those emit their own logs.
+  const hasWidgets = entries.length > 0;
+  if (hasWidgets) {
+    console.log("[WIDGETS] Mounting widgets in development mode");
   }
 
   // Create a temp directory for widget entry files
@@ -346,9 +346,11 @@ if (container && Component) {
   // Note: WebSocket protocol (ws/wss) is auto-detected by Vite client from the page URL
 
   // Create a single shared Vite dev server for all widgets
-  console.log(
-    `[WIDGETS] Serving ${entries.length} widget(s) with shared Vite dev server and HMR`
-  );
+  if (hasWidgets) {
+    console.log(
+      `[WIDGETS] Serving ${entries.length} widget(s) with shared Vite dev server and HMR`
+    );
+  }
 
   // Create a plugin to handle CSS imports in SSR only
   const ssrCssPlugin = {
@@ -395,7 +397,9 @@ if (container && Component) {
       // This ensures HMR works when widget source files change
       const resourcesPath = pathHelpers.join(getCwd(), resourcesDir);
       server.watcher.add(resourcesPath);
-      console.log(`[WIDGETS] Watching resources directory: ${resourcesPath}`);
+      if (hasWidgets) {
+        console.log(`[WIDGETS] Watching resources directory: ${resourcesPath}`);
+      }
 
       // Watch for file deletions and clean up corresponding .mcp-use directories
       server.watcher.on("unlink", async (filePath: string) => {
@@ -1290,9 +1294,11 @@ export default PostHog;
     (viteServer.config.server.hmr as { port?: number })?.port ??
     DEFAULT_HMR_PORT;
   if (viteHmrPort) {
-    console.log(
-      `[WIDGETS] Vite HMR WebSocket on port ${viteHmrPort}, setting up proxy on main server`
-    );
+    if (hasWidgets) {
+      console.log(
+        `[WIDGETS] Vite HMR WebSocket on port ${viteHmrPort}, setting up proxy on main server`
+      );
+    }
 
     // Store the proxy setup function - it will be called when the HTTP server is available
     const hmrPort = viteHmrPort;


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

Check all that apply:
- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

When an MCP server starts in development mode and the project has no `resources/` directory (or an empty one) the widget mounting pipeline emitted 5 noisy `[WIDGETS]` logs on every startup even though the project never uses widgets. This PR silences those logs when no widgets are present, while keeping the Vite watcher running so dynamically-created widgets (e.g. Mango/E2B sandbox workflows) are still picked up.

## Review Readiness

- [x] The PR is scoped to one issue or one clearly related change
- [x] The PR description explains the user-visible problem and the fix
- [x] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [x] I verified the affected package/docs path with the commands listed below
- [x] I checked for existing open PRs that already solve the same issue

## Implementation Details

1. In `mount-widgets-dev.ts`: after scanning `resources/` for widget entries, compute `const hasWidgets = entries.length > 0` and gate the startup logs behind it.
2. Logs gated (only print when at least one widget exists): "Mounting widgets in development mode", "Serving N widget(s) with shared Vite dev server and HMR", "Watching resources directory", "Vite HMR WebSocket on port".
3. Removed the two always-firing "No resources/ directory found" and "No widgets found…" logs; the `resources/` directory is now created silently when absent.
4. Moved the "Mounting widgets in development mode" log from `widgets/index.ts` into `mountWidgetsDev` so it can be gated correctly.
5. Intentionally NOT gated: `New widget added: X` and `Cleaned up stale widget: X` — these are real state transitions that should always be visible.

---

## TypeScript Checklist

### Packages Modified

- [ ] `docs`
- [ ] `tests`
- [ ] `cli`
- [ ] `create-mcp-use-app`
- [x] `mcp-use` (server)
- [ ] `mcp-use` (client)
- [ ] `inspector`

### Pre-commit Checklist

- [x] Ran `pnpm lint:fix` to auto-fix linting issues
- [x] Ran `pnpm format` to format code with Prettier
- [x] Ran `pnpm build` and build succeeds without errors
- [x] Ran `pnpm changeset` to create a changeset (if this PR includes user-facing changes)
- [ ] Added or updated tests if needed
- [ ] Updated documentation in `docs/` folder if needed

---

## Example Usage (Before)

```bash
# Starting a server with no resources/ directory printed 5 lines every time:
[WIDGETS] Mounting widgets in development mode
[WIDGETS] No resources/ directory found - creating it for widget watching
[WIDGETS] No widgets found in resources/ directory yet - watching for new widgets...
[WIDGETS] Serving 0 widget(s) with shared Vite dev server and HMR
[WIDGETS] Watching resources directory: /path/to/project/resources
```

## Example Usage (After with no widgets)

```bash
Loading server from index.ts...
[CSP] No CSP_URLS environment variable found
[HMR] Loaded: file://path/to/project/directory
[MCP] Server mounted at /mcp and /sse (stateful mode)
[OAuth Proxy] Mounted OAuth proxy routes at /inspector/api/oauth/metadata and /inspector/api/oauth/proxy
[INSPECTOR] UI available at http://localhost:3000/inspector
```

## Documentation Updates
## Testing
Manual testing: verified against a minimal `MCPServer` with and without a `resources/` directory.

- Empty/absent `resources/` → zero [WIDGETS] startup logs; server and inspector still work normally.

- With a widget in `resources/` → all logs appear as before.

The Vite watcher still starts in both cases, confirmed by dynamically dropping a widget file into `resources/` after startup and observing the `New widget added` log fire correctly.

## Backwards Compatibility
Non-breaking. Log output only, no API or behaviour changes. Projects that use widgets see identical output to before.

## Related Issues
Closes #1727 