### PR TITLE
fix(cli): authoritative GitHub repo-access check for deploy (MCP-2467)

### DIFF
--- a/libraries/typescript/.changeset/deploy-repo-access-targeted-check.md
+++ b/libraries/typescript/.changeset/deploy-repo-access-targeted-check.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/cli": patch
+---
+
+Fix `mcp-use deploy` falsely reporting that the GitHub App cannot access a repository. The pre-flight repo-access check no longer lists/paginates an installation's repos (which only inspected the first page, so repos on later pages were missed, and fully paginating hung on very large orgs). It now asks the backend an authoritative per-installation question (a single GitHub `repos.get`), trying the installation whose account matches the repo owner first and falling back to the others. Requires the backend `GET /github/installations/:installationId/repos/:owner/:repo/access` endpoint.

--- a/libraries/typescript/packages/cli/src/commands/deploy.ts
+++ b/libraries/typescript/packages/cli/src/commands/deploy.ts
@@ -577,12 +577,7 @@ async function checkRepoAccess(
   owner: string,
   repo: string
 ): Promise<boolean> {
-  try {
-    const resp = await api.getGitHubRepos(true);
-    return resp.repos.some((r) => r.full_name === `${owner}/${repo}`);
-  } catch {
-    return false;
-  }
+  return api.checkGitHubRepoAccess(owner, repo);
 }
 
 async function promptGitHubInstallation(

--- a/libraries/typescript/packages/cli/src/utils/api.ts
+++ b/libraries/typescript/packages/cli/src/utils/api.ts
@@ -254,25 +254,6 @@ export interface GitHubConnectionStatus {
   installations?: GitHubInstallation[];
 }
 
-interface GitHubRepo {
-  id: number;
-  name: string;
-  full_name: string;
-  private: boolean;
-  owner: {
-    login: string;
-  };
-}
-
-interface GitHubReposResponse {
-  user: {
-    login: string;
-    id: number;
-    avatar_url: string;
-  };
-  repos: GitHubRepo[];
-}
-
 // ── Env Variables ───────────────────────────────────────────────────
 
 export type EnvEnvironment = "production" | "preview" | "development";
@@ -737,62 +718,58 @@ export class McpUseAPI {
     };
   }
 
-  async getGitHubRepos(_refresh?: boolean): Promise<GitHubReposResponse> {
-    const orgId = await this.resolveOrganizationId();
-    const installResp = await this.request<{
-      installations: Array<{
-        id: string;
-        installationId: string;
-        account: {
-          login: string;
-          avatar_url: string | null;
-          type: string;
-        } | null;
-      }>;
-    }>(`/github/installations?organizationId=${orgId}`);
+  /**
+   * Returns true if the GitHub App can access `${owner}/${repo}` via any of the
+   * organization's installations.
+   *
+   * An organization can have multiple GitHub installations (e.g. a personal
+   * account and one or more GitHub orgs), so we check across all of them.
+   *
+   * Each check is a single authoritative backend call (`repos.get` with the
+   * installation token) rather than listing repos. The old listing approach
+   * only returned the first page — so a repo on a later page was wrongly
+   * reported inaccessible — and fully paginating it hung on very large orgs.
+   * We try the installation whose account matches the repo owner first to
+   * minimize GitHub calls.
+   */
+  async checkGitHubRepoAccess(owner: string, repo: string): Promise<boolean> {
+    const status = await this.getGitHubConnectionStatus();
+    const installations = status.installations ?? [];
+    if (installations.length === 0) return false;
 
-    if (installResp.installations.length === 0) {
-      return { user: { login: "", id: 0, avatar_url: "" }, repos: [] };
+    const ownerLower = owner.toLowerCase();
+    const ordered = [...installations].sort((a, b) => {
+      const aMatch = a.account_login.toLowerCase() === ownerLower ? 0 : 1;
+      const bMatch = b.account_login.toLowerCase() === ownerLower ? 0 : 1;
+      return aMatch - bMatch;
+    });
+
+    for (const installation of ordered) {
+      const hasAccess = await this.installationCanAccessRepo(
+        installation.installation_id,
+        owner,
+        repo
+      );
+      if (hasAccess) return true;
     }
+    return false;
+  }
 
-    // An organization can have multiple GitHub installations (e.g. a user
-    // account and one or more GitHub orgs). Aggregate repos across all of
-    // them instead of only the first, otherwise repos owned by any other
-    // installation are reported as inaccessible.
-    const inst = installResp.installations[0];
-    const repoLists = await Promise.all(
-      installResp.installations.map(async (installation) => {
-        try {
-          const reposResp = await this.request<{
-            repos: Array<{
-              id: number;
-              name: string;
-              fullName: string;
-              private: boolean;
-              ownerAvatarUrl: string | null;
-            }>;
-          }>(`/github/installations/${installation.installationId}/repos`);
-          return reposResp.repos;
-        } catch {
-          return [];
-        }
-      })
-    );
-
-    return {
-      user: {
-        login: inst.account?.login ?? "",
-        id: 0,
-        avatar_url: inst.account?.avatar_url ?? "",
-      },
-      repos: repoLists.flat().map((r) => ({
-        id: r.id,
-        name: r.name,
-        full_name: r.fullName,
-        private: r.private,
-        owner: { login: r.fullName.split("/")[0] ?? "" },
-      })),
-    };
+  private async installationCanAccessRepo(
+    installationId: string,
+    owner: string,
+    repo: string
+  ): Promise<boolean> {
+    try {
+      const resp = await this.request<{ hasAccess: boolean }>(
+        `/github/installations/${installationId}/repos/${encodeURIComponent(
+          owner
+        )}/${encodeURIComponent(repo)}/access`
+      );
+      return resp.hasAccess;
+    } catch {
+      return false;
+    }
   }
 
   async getGitHubAppName(): Promise<string> {

--- a/libraries/typescript/packages/cli/tests/github-repo-access.test.ts
+++ b/libraries/typescript/packages/cli/tests/github-repo-access.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { McpUseAPI } from "../src/utils/api.js";
+
+/**
+ * Unit tests for the MCP-2467 deploy repo-access check. The CLI now asks the
+ * backend an authoritative, per-installation `repos/:owner/:repo/access`
+ * question (single GitHub `repos.get`) instead of listing/paginating repos,
+ * which previously missed repos on later pages and hung on very large orgs.
+ */
+
+interface Installation {
+  id: string;
+  installationId: string;
+  login: string;
+  type: string;
+}
+
+function makeApi(): McpUseAPI {
+  // orgId is set so resolveOrganizationId() short-circuits without a network call.
+  return new McpUseAPI("https://api.test", "key", "org-123");
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+/**
+ * Routes fetch calls: the installations list endpoint returns `installations`,
+ * and each `.../repos/:owner/:repo/access` endpoint resolves to `accessByInst`
+ * keyed on installationId (defaults to false / 404 when absent).
+ */
+function installFetch(
+  installations: Installation[],
+  accessByInst: Record<string, boolean>
+): { calls: string[] } {
+  const calls: string[] = [];
+  const fetchMock = vi.fn(async (url: string) => {
+    calls.push(url);
+    if (url.includes("/github/installations?")) {
+      return jsonResponse({
+        installations: installations.map((i) => ({
+          id: i.id,
+          installationId: i.installationId,
+          account: { login: i.login, avatar_url: null, type: i.type },
+        })),
+      });
+    }
+    const m = url.match(
+      /\/github\/installations\/([^/]+)\/repos\/[^/]+\/[^/]+\/access$/
+    );
+    if (m) {
+      const instId = m[1]!;
+      const hasAccess = accessByInst[instId] ?? false;
+      if (!hasAccess) return jsonResponse({ error: "Not Found" }, 404);
+      return jsonResponse({ hasAccess: true });
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return { calls };
+}
+
+const ORG_INSTALL: Installation = {
+  id: "db-org",
+  installationId: "1001",
+  login: "acme",
+  type: "Organization",
+};
+const USER_INSTALL: Installation = {
+  id: "db-user",
+  installationId: "2002",
+  login: "octocat",
+  type: "User",
+};
+
+describe("McpUseAPI.checkGitHubRepoAccess", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns true via the owner-matched installation and queries it first", async () => {
+    // Owner-matched installation listed second to prove ordering puts it first.
+    const { calls } = installFetch([USER_INSTALL, ORG_INSTALL], {
+      "1001": true,
+    });
+    const api = makeApi();
+
+    await expect(api.checkGitHubRepoAccess("acme", "widget")).resolves.toBe(
+      true
+    );
+
+    const accessCalls = calls.filter((u) => u.includes("/access"));
+    // First access check hits the owner-matched org installation and matches,
+    // so the non-matching user installation is never queried.
+    expect(accessCalls).toHaveLength(1);
+    expect(accessCalls[0]).toBe(
+      "https://api.test/github/installations/1001/repos/acme/widget/access"
+    );
+  });
+
+  it("finds the repo via a non-owner installation when the owner-matched one has no access", async () => {
+    // Repo owner "acme" has no matching installation login; access is granted
+    // through the "octocat" installation instead (MCP-2358 cross-installation).
+    const { calls } = installFetch([ORG_INSTALL, USER_INSTALL], {
+      "2002": true,
+    });
+    const api = makeApi();
+
+    await expect(api.checkGitHubRepoAccess("acme", "widget")).resolves.toBe(
+      true
+    );
+    const accessCalls = calls.filter((u) => u.includes("/access"));
+    expect(accessCalls.length).toBeGreaterThanOrEqual(1);
+    expect(accessCalls).toContain(
+      "https://api.test/github/installations/2002/repos/acme/widget/access"
+    );
+  });
+
+  it("returns false when no installation can access the repo", async () => {
+    installFetch([ORG_INSTALL, USER_INSTALL], {});
+    const api = makeApi();
+
+    await expect(api.checkGitHubRepoAccess("acme", "ghost")).resolves.toBe(
+      false
+    );
+  });
+
+  it("returns false when there are no installations", async () => {
+    const { calls } = installFetch([], {});
+    const api = makeApi();
+
+    await expect(api.checkGitHubRepoAccess("acme", "widget")).resolves.toBe(
+      false
+    );
+    expect(calls.filter((u) => u.includes("/access"))).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- `mcp-use deploy`'s pre-flight GitHub repo-access check no longer lists/paginates an installation's repos. It now asks the backend an authoritative per-installation question (a single `repos.get`) via `GET /github/installations/:installationId/repos/:owner/:repo/access`.
- The installation whose account matches the repo owner is checked first, then the others — preserving the across-installations fix from MCP-2358 without pagination.

## Why
The previous check only inspected the **first page** of each installation's repos, so a repo on a later page (the real repro: `mcp-use/talkie-mcp` on page 3) was wrongly reported as inaccessible (MCP-2467). The earlier full-pagination version hung on very large orgs, so re-paginating was not an option.

## Implementation
- `McpUseAPI.checkGitHubRepoAccess(owner, repo)` orders installations owner-first and calls the new targeted endpoint per installation (`installationCanAccessRepo`).
- Removed the now-unused `getGitHubRepos()` method and its `GitHubReposResponse`/`GitHubRepo` types.
- `checkRepoAccess()` in `deploy.ts` delegates to the new API method.

## Testing
- New `tests/github-repo-access.test.ts`: owner-matched installation is queried first and short-circuits; cross-installation match (owner has no matching installation login); no-access => false; no installations => false.
- `pnpm --filter @mcp-use/cli build` + `test` (291 pass), eslint + prettier clean.
- Changeset added (`@mcp-use/cli` patch).

## Dependency
Requires the backend endpoint in mcp-use/mcp-use-cloud#842. Merge/deploy that first.

## Related
- Linear: MCP-2467. Follows up MCP-2358.