### PR TITLE
fix(python): accept read_timeout_seconds in WebSocketConnector.call_tool

### DIFF
--- a/libraries/python/mcp_use/client/connectors/websocket.py
+++ b/libraries/python/mcp_use/client/connectors/websocket.py
@@ -8,6 +8,7 @@ through WebSocket connections.
 import asyncio
 import json
 import uuid
+from datetime import timedelta
 from typing import Any
 
 import httpx
@@ -178,7 +179,12 @@ class WebSocketConnector(BaseConnector):
         if errors:
             logger.warning(f"Encountered {len(errors)} errors during resource cleanup")
 
-    async def _send_request(self, method: str, params: dict[str, Any] | None = None) -> Any:
+    async def _send_request(
+        self,
+        method: str,
+        params: dict[str, Any] | None = None,
+        read_timeout_seconds: timedelta | None = None,
+    ) -> Any:
         """Send a request and wait for a response."""
         if not self.ws:
             raise RuntimeError("WebSocket is not connected")
@@ -197,6 +203,8 @@ class WebSocketConnector(BaseConnector):
 
         # Wait for the response
         try:
+            if read_timeout_seconds is not None:
+                return await asyncio.wait_for(future, timeout=read_timeout_seconds.total_seconds())
             return await future
         except Exception as e:
             # Remove the request from pending requests
@@ -229,10 +237,19 @@ class WebSocketConnector(BaseConnector):
             raise RuntimeError("MCP client is not initialized")
         return self._tools
 
-    async def call_tool(self, name: str, arguments: dict[str, Any]) -> Any:
+    async def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+        read_timeout_seconds: timedelta | None = None,
+    ) -> Any:
         """Call an MCP tool with the given arguments."""
         logger.debug(f"Calling tool '{name}' with arguments: {arguments}")
-        return await self._send_request("tools/call", {"name": name, "arguments": arguments})
+        return await self._send_request(
+            "tools/call",
+            {"name": name, "arguments": arguments},
+            read_timeout_seconds=read_timeout_seconds,
+        )
 
     async def list_resources(self) -> list[dict[str, Any]]:
         """List all available resources from the MCP implementation."""

--- a/libraries/python/tests/unit/test_websocket_connector.py
+++ b/libraries/python/tests/unit/test_websocket_connector.py
@@ -1,0 +1,74 @@
+"""
+Unit tests for the WebSocketConnector class.
+
+Regression coverage for the ``call_tool`` signature mismatch: ``MCPSession``
+forwards ``read_timeout_seconds`` as a third positional argument, so the
+connector must accept it like every other connector and ``BaseConnector``.
+"""
+
+import asyncio
+from datetime import timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from mcp_use.client.connectors.websocket import WebSocketConnector
+
+
+@pytest.fixture(autouse=True)
+def mock_logger():
+    """Mock the logger to prevent errors during tests."""
+    with patch("mcp_use.client.connectors.websocket.logger") as mock_logger:
+        yield mock_logger
+
+
+async def test_call_tool_accepts_read_timeout_seconds_positionally():
+    """call_tool must accept read_timeout_seconds the way MCPSession passes it.
+
+    MCPSession.call_tool does ``connector.call_tool(name, arguments, read_timeout_seconds)``,
+    so a connector whose signature is ``call_tool(self, name, arguments)`` raises
+    ``TypeError: ... takes 3 positional arguments but 4 were given``.
+    """
+    connector = WebSocketConnector(url="ws://localhost:8000")
+    connector._send_request = AsyncMock(return_value={"ok": True})
+
+    timeout = timedelta(seconds=5)
+    result = await connector.call_tool("my_tool", {"x": 1}, timeout)
+
+    assert result == {"ok": True}
+    connector._send_request.assert_awaited_once_with(
+        "tools/call",
+        {"name": "my_tool", "arguments": {"x": 1}},
+        read_timeout_seconds=timeout,
+    )
+
+
+async def test_call_tool_without_timeout_resolves_result():
+    """Default (no timeout) path returns the response result."""
+    connector = WebSocketConnector(url="ws://localhost:8000")
+    connector.ws = AsyncMock()
+
+    async def resolve_pending():
+        for _ in range(200):
+            if connector.pending_requests:
+                request_id = next(iter(connector.pending_requests))
+                connector.pending_requests[request_id].set_result({"content": "done"})
+                return
+            await asyncio.sleep(0.001)
+
+    resolver = asyncio.create_task(resolve_pending())
+    result = await connector.call_tool("t", {})
+    await resolver
+
+    assert result == {"content": "done"}
+
+
+async def test_call_tool_honors_timeout_and_cleans_up():
+    """When read_timeout_seconds elapses with no response, raise and drop the request."""
+    connector = WebSocketConnector(url="ws://localhost:8000")
+    connector.ws = AsyncMock()  # send() is awaited; the future is never resolved
+
+    with pytest.raises(asyncio.TimeoutError):
+        await connector.call_tool("t", {}, timedelta(seconds=0.01))
+
+    assert connector.pending_requests == {}


### PR DESCRIPTION
Closes #1731

`MCPSession.call_tool` forwards `read_timeout_seconds` as a third positional argument to the connector (`session.py`: `self.connector.call_tool(name, arguments, read_timeout_seconds)`), matching `BaseConnector.call_tool`. `WebSocketConnector.call_tool` only declared `(self, name, arguments)`, so every tool call routed through a websocket session raised:

```
TypeError: WebSocketConnector.call_tool() takes 3 positional arguments but 4 were given
```

This aligns the signature with the shared connector interface and threads the timeout through `_send_request` via `asyncio.wait_for`, so it is honored when supplied and ignored (current behavior) when `None`. On timeout the existing `except` branch drops the request from `pending_requests`.

Verified by stashing the source fix and running the new test against the unpatched connector, which reproduces the exact `TypeError` from the issue; with the fix applied all three new cases pass.

New unit coverage in `tests/unit/test_websocket_connector.py`:
- `call_tool` accepts `read_timeout_seconds` positionally the way `MCPSession` passes it
- default (no timeout) path resolves and returns the result
- a supplied timeout is enforced and the pending request is cleaned up

`ruff check .`, `ruff format --check .`, and `pytest tests/unit` pass locally (the one unrelated pre-existing failure in `test_config.py::test_create_sandboxed_stdio_connector` patches the deprecated `mcp_use.connectors.sandbox` path and is independent of this change).