### PR TITLE
Make MCP Apps primary widget runtime & Apply Host Context Styles

### DIFF
--- a/libraries/typescript/.changeset/mcp-apps-primary-widget-runtime.md
+++ b/libraries/typescript/.changeset/mcp-apps-primary-widget-runtime.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Use the MCP Apps bridge as the primary widget runtime even when `window.openai` is present, while keeping OpenAI extension APIs such as file upload and download available through `useFiles`.

--- a/libraries/typescript/packages/inspector/src/client/hooks/useMcpAppsHostContext.ts
+++ b/libraries/typescript/packages/inspector/src/client/hooks/useMcpAppsHostContext.ts
@@ -24,6 +24,64 @@ interface HostContextParams {
   tool?: Tool; // Full Tool object from MCP SDK
 }
 
+function readCssVar(styles: CSSStyleDeclaration, name: string): string {
+  return styles.getPropertyValue(name).trim();
+}
+
+function buildHostStyleVariables(): Record<string, string> {
+  if (typeof window === "undefined") return {};
+
+  const styles = getComputedStyle(document.documentElement);
+  const variables: Record<string, string> = {};
+  const add = (name: string, value: string) => {
+    if (value) variables[name] = value;
+  };
+
+  const background = readCssVar(styles, "--background");
+  const foreground = readCssVar(styles, "--foreground");
+  const card = readCssVar(styles, "--card");
+  const muted = readCssVar(styles, "--muted");
+  const mutedForeground = readCssVar(styles, "--muted-foreground");
+  const primary = readCssVar(styles, "--primary");
+  const primaryForeground = readCssVar(styles, "--primary-foreground");
+  const secondary = readCssVar(styles, "--secondary");
+  const accent = readCssVar(styles, "--accent");
+  const accentForeground = readCssVar(styles, "--accent-foreground");
+  const destructive = readCssVar(styles, "--destructive");
+  const border = readCssVar(styles, "--border");
+  const ring = readCssVar(styles, "--ring");
+  const radius = readCssVar(styles, "--radius");
+
+  add("--color-background-primary", background);
+  add("--color-background-secondary", card || secondary);
+  add("--color-background-tertiary", muted || accent);
+  add("--color-background-inverse", primary);
+  add("--color-background-ghost", accent || muted);
+  add("--color-background-danger", destructive);
+
+  add("--color-text-primary", foreground);
+  add("--color-text-secondary", mutedForeground);
+  add("--color-text-tertiary", mutedForeground);
+  add("--color-text-inverse", primaryForeground);
+  add("--color-text-ghost", accentForeground || mutedForeground);
+  add("--color-text-danger", destructive);
+
+  add("--color-border-primary", border);
+  add("--color-border-secondary", border);
+  add("--color-border-tertiary", border);
+  add("--color-ring-primary", ring || border);
+
+  add("--border-radius-sm", radius);
+  add("--border-radius-md", radius);
+  add("--border-radius-lg", radius);
+  add(
+    "--font-sans",
+    "system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif"
+  );
+
+  return variables;
+}
+
 /**
  * Build SEP-1865 compliant host context for MCP Apps
  */
@@ -53,7 +111,7 @@ export function useMcpAppsHostContext({
       userAgent: "mcp-use-inspector/0.16.2",
       deviceCapabilities: playground.capabilities,
       safeAreaInsets: playground.safeAreaInsets,
-      styles: { variables: {} as any },
+      styles: { variables: buildHostStyleVariables() as any },
       toolInfo: tool
         ? {
             id: toolCallId,

--- a/libraries/typescript/packages/mcp-use/src/react/McpUseProvider.tsx
+++ b/libraries/typescript/packages/mcp-use/src/react/McpUseProvider.tsx
@@ -31,7 +31,7 @@ interface McpUseProviderProps {
   viewControls?: boolean | "pip" | "fullscreen";
   /**
    * Automatically notify host about container height changes for auto-sizing
-   * Supports both ChatGPT Apps SDK (window.openai) and MCP Apps (postMessage bridge)
+   * Uses MCP Apps `ui/notifications/size-changed`.
    * Uses ResizeObserver to monitor the children container
    * @default false
    */
@@ -62,9 +62,7 @@ interface McpUseProviderProps {
  * @example
  * ```tsx
  * <McpUseProvider debugger viewControls autoSize>
- *   <AppsSDKUIProvider linkComponent={Link}>
- *     <div>My widget content</div>
- *   </AppsSDKUIProvider>
+ *   <div>My widget content</div>
  * </McpUseProvider>
  * ```
  */
@@ -81,42 +79,28 @@ export function McpUseProvider({
   const debounceTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const notificationInProgressRef = useRef<boolean>(false);
 
-  // Notify host about height changes (dual-protocol support)
+  // Notify host about height changes via MCP Apps.
   const notifyHeight = useCallback((height: number) => {
     if (typeof window === "undefined") return;
 
     notificationInProgressRef.current = true;
 
-    // Try ChatGPT Apps SDK first
-    if (window.openai?.notifyIntrinsicHeight) {
-      window.openai
-        .notifyIntrinsicHeight(height)
-        .then(() => {
-          notificationInProgressRef.current = false;
-        })
-        .catch((error) => {
-          notificationInProgressRef.current = false;
-          console.error(
-            "[McpUseProvider] Failed to notify intrinsic height (ChatGPT):",
-            error
-          );
-        });
+    if (window === window.parent) {
+      notificationInProgressRef.current = false;
       return;
     }
 
-    // Fall back to MCP Apps bridge
-    // Always try to send - the bridge will handle if not connected yet
     try {
       const bridge = getMcpAppsBridge();
       bridge.sendSizeChanged({ height });
       console.log("[McpUseProvider] Sent size-changed notification:", height);
-      notificationInProgressRef.current = false;
     } catch (error) {
-      notificationInProgressRef.current = false;
       console.error(
         "[McpUseProvider] Failed to notify size change (MCP Apps):",
         error
       );
+    } finally {
+      notificationInProgressRef.current = false;
     }
   }, []);
 

--- a/libraries/typescript/packages/mcp-use/src/react/McpUseProvider.tsx
+++ b/libraries/typescript/packages/mcp-use/src/react/McpUseProvider.tsx
@@ -40,11 +40,9 @@ interface McpUseProviderProps {
    * Set color-scheme on the document root to match the active theme.
    * Enables native dark scrollbars and CSS light-dark() function.
    *
-   * Leave disabled (default) when you want a transparent iframe background.
-   * Setting color-scheme to an explicit value ("dark"/"light") causes browsers
-   * to paint an opaque canvas behind iframes when the widget and host documents
-   * use different schemes, making background-color: transparent ineffective.
-   * @default false
+   * Disable only when you need the browser canvas to stay transparent in hosts
+   * that render widgets over a differently-themed background.
+   * @default true
    */
   colorScheme?: boolean;
 }
@@ -71,7 +69,7 @@ export function McpUseProvider({
   debugger: enableDebugger = false,
   viewControls = false,
   autoSize = true,
-  colorScheme = false,
+  colorScheme = true,
 }: McpUseProviderProps) {
   const [containerElement, setContainerElement] =
     useState<HTMLDivElement | null>(null);

--- a/libraries/typescript/packages/mcp-use/src/react/ThemeProvider.tsx
+++ b/libraries/typescript/packages/mcp-use/src/react/ThemeProvider.tsx
@@ -5,7 +5,7 @@ import { useWidget } from "./useWidget.js";
  * ThemeProvider that manages dark mode class on document root
  *
  * Priority:
- * 1. useWidget theme (from OpenAI Apps SDK)
+ * 1. useWidget theme (from host context)
  * 2. System preference (prefers-color-scheme: dark)
  *
  * Sets the "dark" class and data-theme attribute on document.documentElement.
@@ -45,7 +45,7 @@ export const ThemeProvider: React.FC<{
 
   // Apply theme synchronously before browser paint to prevent flash
   // Sets CSS class (for Tailwind dark mode) and data-theme attribute
-  // (for OpenAI Apps SDK UI design tokens).
+  // (for UI design tokens).
   useLayoutEffect(() => {
     if (typeof document === "undefined") return;
 
@@ -55,7 +55,7 @@ export const ThemeProvider: React.FC<{
     root.classList.remove("light", "dark");
     root.classList.add(effectiveTheme === "dark" ? "dark" : "light");
 
-    // Set data-theme attribute (OpenAI Apps SDK UI design tokens)
+    // Set data-theme attribute (UI design tokens)
     root.setAttribute(
       "data-theme",
       effectiveTheme === "dark" ? "dark" : "light"

--- a/libraries/typescript/packages/mcp-use/src/react/ThemeProvider.tsx
+++ b/libraries/typescript/packages/mcp-use/src/react/ThemeProvider.tsx
@@ -10,15 +10,14 @@ import { useWidget } from "./useWidget.js";
  * 2. System preference (prefers-color-scheme: dark)
  *
  * Sets the "dark" class and data-theme attribute on document.documentElement.
- * color-scheme is only set when the colorScheme prop is true — setting it to an
- * explicit value causes browsers to paint an opaque canvas behind iframes when
- * the widget and host documents use different schemes.
+ * color-scheme is set by default so host variables using CSS light-dark()
+ * resolve against the active host theme.
  */
 export const ThemeProvider: React.FC<{
   children: React.ReactNode;
   colorScheme?: boolean;
-}> = ({ children, colorScheme = false }) => {
-  const { theme, isAvailable, hostContext, hostInfo } = useWidget();
+}> = ({ children, colorScheme = true }) => {
+  const { theme, isAvailable, hostContext } = useWidget();
   const [systemPreference, setSystemPreference] = useState<"light" | "dark">(
     () => {
       if (typeof window === "undefined") return "light";
@@ -62,10 +61,6 @@ export const ThemeProvider: React.FC<{
       effectiveTheme === "dark" ? "dark" : "light"
     );
 
-    // Only set color-scheme when explicitly opted in via the colorScheme prop.
-    // Setting it to "dark"/"light" triggers browsers to paint an opaque canvas
-    // behind iframes when the widget scheme differs from the host scheme, which
-    // makes background-color: transparent ineffective.
     if (colorScheme) {
       root.style.colorScheme = effectiveTheme === "dark" ? "dark" : "light";
     } else {
@@ -74,11 +69,8 @@ export const ThemeProvider: React.FC<{
   }, [effectiveTheme, colorScheme]);
 
   useLayoutEffect(() => {
-    applyHostStyleVariables(hostContext, {
-      source: "ThemeProvider",
-      hostName: hostInfo?.name,
-    });
-  }, [hostContext, hostInfo?.name]);
+    applyHostStyleVariables(hostContext?.styles?.variables);
+  }, [hostContext]);
 
   return <>{children}</>;
 };

--- a/libraries/typescript/packages/mcp-use/src/react/ThemeProvider.tsx
+++ b/libraries/typescript/packages/mcp-use/src/react/ThemeProvider.tsx
@@ -6,7 +6,7 @@ import { useWidget } from "./useWidget.js";
  * ThemeProvider that manages dark mode class on document root
  *
  * Priority:
- * 1. useWidget theme (from host context)
+ * 1. Explicit host context theme
  * 2. System preference (prefers-color-scheme: dark)
  *
  * Sets the "dark" class and data-theme attribute on document.documentElement.
@@ -17,7 +17,7 @@ export const ThemeProvider: React.FC<{
   children: React.ReactNode;
   colorScheme?: boolean;
 }> = ({ children, colorScheme = true }) => {
-  const { theme, isAvailable, hostContext } = useWidget();
+  const { hostContext } = useWidget();
   const [systemPreference, setSystemPreference] = useState<"light" | "dark">(
     () => {
       if (typeof window === "undefined") return "light";
@@ -40,8 +40,14 @@ export const ThemeProvider: React.FC<{
     return () => mediaQuery.removeEventListener("change", handleChange);
   }, []);
 
-  // Calculate effective theme
-  const effectiveTheme = isAvailable ? theme : systemPreference;
+  // Calculate effective theme. useWidget() normalizes a missing host theme to
+  // "light" for consumers, so ThemeProvider reads the raw host context to avoid
+  // treating an omitted host value as an explicit light-mode preference.
+  const hostTheme =
+    hostContext?.theme === "dark" || hostContext?.theme === "light"
+      ? hostContext.theme
+      : undefined;
+  const effectiveTheme = hostTheme ?? systemPreference;
 
   // Apply theme synchronously before browser paint to prevent flash
   // Sets CSS class (for Tailwind dark mode) and data-theme attribute

--- a/libraries/typescript/packages/mcp-use/src/react/ThemeProvider.tsx
+++ b/libraries/typescript/packages/mcp-use/src/react/ThemeProvider.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useLayoutEffect, useState } from "react";
+import { applyHostStyleVariables } from "./host-styles.js";
 import { useWidget } from "./useWidget.js";
 
 /**
@@ -17,7 +18,7 @@ export const ThemeProvider: React.FC<{
   children: React.ReactNode;
   colorScheme?: boolean;
 }> = ({ children, colorScheme = false }) => {
-  const { theme, isAvailable } = useWidget();
+  const { theme, isAvailable, hostContext, hostInfo } = useWidget();
   const [systemPreference, setSystemPreference] = useState<"light" | "dark">(
     () => {
       if (typeof window === "undefined") return "light";
@@ -71,6 +72,13 @@ export const ThemeProvider: React.FC<{
       root.style.colorScheme = "";
     }
   }, [effectiveTheme, colorScheme]);
+
+  useLayoutEffect(() => {
+    applyHostStyleVariables(hostContext, {
+      source: "ThemeProvider",
+      hostName: hostInfo?.name,
+    });
+  }, [hostContext, hostInfo?.name]);
 
   return <>{children}</>;
 };

--- a/libraries/typescript/packages/mcp-use/src/react/WIDGET_HOOKS.md
+++ b/libraries/typescript/packages/mcp-use/src/react/WIDGET_HOOKS.md
@@ -1,14 +1,14 @@
-# Widget Hooks for OpenAI Apps SDK
+# Widget Hooks for MCP Apps
 
-The `useWidget` hook provides a type-safe React adapter for the OpenAI Apps SDK `window.openai` API, making it easy to build MCP-use widgets that work seamlessly with ChatGPT's Apps SDK.
+The `useWidget` hook provides a type-safe React adapter for the MCP Apps widget runtime, making it easy to build MCP-use widgets that work across MCP Apps hosts. In ChatGPT, `window.openai` may still exist for OpenAI-specific extension APIs, but widget data, actions, and autosizing use the MCP Apps bridge.
 
 ## Overview
 
-The `useWidget` hook wraps the OpenAI Apps SDK's `window.openai` global API and provides:
+The `useWidget` hook wraps the MCP Apps postMessage bridge and provides:
 
-- **Type-safe props access**: Automatically maps MCP UI props from `toolInput`
-- **Reactive state management**: Subscribes to all OpenAI global changes
-- **Layout awareness**: Access to theme, display mode, safe areas, etc.
+- **Type-safe props access**: Automatically maps MCP Apps tool input and structured output
+- **Reactive state management**: Sends widget state through MCP Apps model-context updates
+- **Layout awareness**: Access to host context such as theme, display mode, safe areas, etc.
 - **Action methods**: Call tools, send messages, open external links, etc.
 
 ## Basic Usage
@@ -24,7 +24,7 @@ interface MyWidgetProps {
 
 const MyWidget: React.FC = () => {
   const { props, theme, callTool } = useWidget<MyWidgetProps>();
-  
+
   return (
     <div data-theme={theme}>
       <h1>{props.title}</h1>
@@ -55,7 +55,7 @@ Main hook that provides access to all widget functionality.
   metadata: TMetadata | null;       // Tool response metadata
   state: TState | null;             // Persisted widget state
   setState: (state: TState) => Promise<void>;
-  
+
   // Layout and Theme
   theme: 'light' | 'dark';          // Current theme
   displayMode: 'inline' | 'pip' | 'fullscreen';
@@ -63,15 +63,15 @@ Main hook that provides access to all widget functionality.
   maxHeight: number;                // Maximum available height
   userAgent: UserAgent;             // Device and capabilities info
   locale: string;                   // Current locale
-  
+
   // Actions
   callTool: (name: string, args: Record<string, unknown>) => Promise<CallToolResponse>;
   sendFollowUpMessage: (content: string | MessageContentBlock[]) => Promise<void>;
   openExternal: (href: string) => void;
   requestDisplayMode: (mode: DisplayMode) => Promise<{ mode: DisplayMode }>;
-  
+
   // Availability
-  isAvailable: boolean;             // Whether window.openai is available
+  isAvailable: boolean;             // Whether the MCP Apps bridge is connected
 }
 ```
 
@@ -112,11 +112,11 @@ import { useWidgetState } from 'mcp-use/react';
 
 const MyWidget: React.FC = () => {
   const [favorites, setFavorites] = useWidgetState<string[]>([]);
-  
+
   const addFavorite = async (item: string) => {
     await setFavorites(prev => [...(prev || []), item]);
   };
-  
+
   return <div>Favorites: {favorites?.length || 0}</div>;
 };
 ```
@@ -144,15 +144,15 @@ type WeatherProps = z.infer<typeof propSchema>;
 const WeatherWidget: React.FC = () => {
   const { props, theme, sendFollowUpMessage } = useWidget<WeatherProps>();
   const { city, weather, temperature } = props;
-  
+
   // Theme-aware styling
   const bgColor = theme === 'dark' ? 'bg-gray-900' : 'bg-white';
   const textColor = theme === 'dark' ? 'text-gray-100' : 'text-gray-800';
-  
+
   const askForForecast = async () => {
     await sendFollowUpMessage(`What's the 7-day forecast for ${city}?`);
   };
-  
+
   return (
     <div className={`${bgColor} ${textColor} rounded-xl shadow-lg p-6`}>
       <h2 className="text-2xl font-bold mb-2">{city}</h2>
@@ -160,7 +160,7 @@ const WeatherWidget: React.FC = () => {
         <span className="text-4xl">{temperature}°</span>
         <p className="text-lg capitalize">{weather}</p>
       </div>
-      <button 
+      <button
         onClick={askForForecast}
         className="mt-4 px-4 py-2 bg-blue-500 text-white rounded"
       >
@@ -180,12 +180,12 @@ export default WeatherWidget;
 ```tsx
 const MyWidget: React.FC = () => {
   const { callTool } = useWidget();
-  
+
   const refreshData = async () => {
     const result = await callTool('refresh_data', { city: 'San Francisco' });
     console.log('Refreshed:', result);
   };
-  
+
   return <button onClick={refreshData}>Refresh</button>;
 };
 ```
@@ -197,7 +197,7 @@ Widget state is persisted across sessions and shown to the model:
 ```tsx
 const PizzaWidget: React.FC = () => {
   const [favorites, setFavorites] = useWidgetState<string[]>([]);
-  
+
   const toggleFavorite = async (id: string) => {
     await setFavorites(prev => {
       const current = prev || [];
@@ -206,7 +206,7 @@ const PizzaWidget: React.FC = () => {
         : [...current, id];
     });
   };
-  
+
   return (
     <div>
       {/* Your UI */}
@@ -220,12 +220,12 @@ const PizzaWidget: React.FC = () => {
 ```tsx
 const MapWidget: React.FC = () => {
   const { requestDisplayMode } = useWidget();
-  
+
   const goFullscreen = async () => {
     const result = await requestDisplayMode('fullscreen');
     console.log('Display mode:', result.mode);
   };
-  
+
   return <button onClick={goFullscreen}>Go Fullscreen</button>;
 };
 ```
@@ -235,7 +235,7 @@ const MapWidget: React.FC = () => {
 ```tsx
 const MyWidget: React.FC = () => {
   const { openExternal } = useWidget();
-  
+
   return (
     <button onClick={() => openExternal('https://example.com')}>
       Open Website
@@ -272,7 +272,7 @@ const WeatherWidget: React.FC = () => {
     state,      // Type: WeatherState | null
     setState,   // Type: (state: WeatherState) => Promise<void>
   } = useWidget<WeatherProps, WeatherOutput, unknown, WeatherState>();
-  
+
   // All properties are fully typed!
   const { city, temperature, conditions } = props;
   const forecast = output?.forecast;
@@ -291,7 +291,7 @@ const WeatherWidget: React.FC = () => {
    ```tsx
    // Instead of:
    const { props } = useWidget<MyProps>();
-   
+
    // Use:
    const props = useWidgetProps<MyProps>();
    ```
@@ -307,7 +307,7 @@ const WeatherWidget: React.FC = () => {
 5. **Check availability**: For SSR or testing, check if the API is available:
    ```tsx
    const { isAvailable, callTool } = useWidget();
-   
+
    if (!isAvailable) {
      return <div>Widget API not available</div>;
    }
@@ -317,10 +317,9 @@ const WeatherWidget: React.FC = () => {
 
 The `useWidget` hook is designed to work seamlessly with MCP-use's widget system:
 
-1. **Props are automatically mapped** from MCP's `toolInput` to the OpenAI Apps SDK format
+1. **Props are automatically mapped** from MCP Apps tool input and tool-result notifications
 2. **Widget metadata** (`widgetMetadata` export) defines the input schema
 3. **Build system** handles bundling and deployment
 4. **Type safety** is maintained throughout the entire stack
 
 See the [MCP-use documentation](https://mcp-use.com/docs) for more information on building and deploying widgets.
-

--- a/libraries/typescript/packages/mcp-use/src/react/host-styles.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/host-styles.ts
@@ -1,0 +1,45 @@
+import type { HostContext } from "./widget-types.js";
+
+const CUSTOM_PROPERTY_NAME = /^--[A-Za-z0-9_-]+$/;
+
+export function applyHostStyleVariables(
+  hostContext: HostContext | undefined,
+  options?: { source?: string; hostName?: string }
+): void {
+  if (typeof document === "undefined" || !hostContext) return;
+
+  const variables = hostContext?.styles?.variables;
+  const entries = variables ? Object.entries(variables) : [];
+  const root = document.documentElement;
+  const applied: Record<string, string> = {};
+  const skipped: Record<string, string> = {};
+
+  for (const [name, value] of entries) {
+    if (!CUSTOM_PROPERTY_NAME.test(name)) {
+      skipped[name] = value;
+      continue;
+    }
+
+    root.style.setProperty(name, value);
+    applied[name] = root.style.getPropertyValue(name);
+  }
+
+  const computed = Object.fromEntries(
+    Object.keys(applied).map((name) => [
+      name,
+      getComputedStyle(root).getPropertyValue(name),
+    ])
+  );
+
+  console.log("[mcp-use host context]", {
+    source: options?.source ?? "theme-provider",
+    hostName: options?.hostName,
+    variableCount: entries.length,
+    hostContext: hostContext ?? null,
+    applied,
+    skipped,
+    computed,
+    documentTheme: root.getAttribute("data-theme"),
+    documentClass: root.className,
+  });
+}

--- a/libraries/typescript/packages/mcp-use/src/react/host-styles.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/host-styles.ts
@@ -1,45 +1,19 @@
-import type { HostContext } from "./widget-types.js";
-
 const CUSTOM_PROPERTY_NAME = /^--[A-Za-z0-9_-]+$/;
 
 export function applyHostStyleVariables(
-  hostContext: HostContext | undefined,
-  options?: { source?: string; hostName?: string }
+  variables: Record<string, string | undefined> | undefined,
+  root?: HTMLElement
 ): void {
-  if (typeof document === "undefined" || !hostContext) return;
+  if (typeof document === "undefined" || !variables) return;
 
-  const variables = hostContext?.styles?.variables;
-  const entries = variables ? Object.entries(variables) : [];
-  const root = document.documentElement;
-  const applied: Record<string, string> = {};
-  const skipped: Record<string, string> = {};
+  const target = root ?? document.documentElement;
 
-  for (const [name, value] of entries) {
+  for (const [name, value] of Object.entries(variables)) {
+    if (value === undefined) continue;
     if (!CUSTOM_PROPERTY_NAME.test(name)) {
-      skipped[name] = value;
       continue;
     }
 
-    root.style.setProperty(name, value);
-    applied[name] = root.style.getPropertyValue(name);
+    target.style.setProperty(name, value);
   }
-
-  const computed = Object.fromEntries(
-    Object.keys(applied).map((name) => [
-      name,
-      getComputedStyle(root).getPropertyValue(name),
-    ])
-  );
-
-  console.log("[mcp-use host context]", {
-    source: options?.source ?? "theme-provider",
-    hostName: options?.hostName,
-    variableCount: entries.length,
-    hostContext: hostContext ?? null,
-    applied,
-    skipped,
-    computed,
-    documentTheme: root.getAttribute("data-theme"),
-    documentClass: root.className,
-  });
 }

--- a/libraries/typescript/packages/mcp-use/src/react/index.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/index.ts
@@ -35,7 +35,7 @@ export type {
 // Export ModelContext component and module-level API
 export { ModelContext, modelContext } from "./model-context.js";
 
-// Export OpenAI Apps SDK widget hooks and types
+// Export widget hooks and types
 export { ErrorBoundary } from "./ErrorBoundary.js";
 export { Image } from "./Image.js";
 export { ThemeProvider } from "./ThemeProvider.js";

--- a/libraries/typescript/packages/mcp-use/src/react/mcp-apps-bridge.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/mcp-apps-bridge.ts
@@ -14,8 +14,8 @@ import {
 import { MCP_APPS_BRIDGE_CONFIG } from "./constants.js";
 import type {
   DisplayMode,
+  HostContext,
   MessageContentBlock,
-  Theme,
 } from "./widget-types.js";
 
 // JSON-RPC message types (using imported types with compatible names)
@@ -23,38 +23,6 @@ type JSONRPCRequest = JsonRpcRequest;
 type JSONRPCResponse = JsonRpcResponse | JsonRpcError;
 type JSONRPCNotification = JsonRpcNotification;
 type JSONRPCMessage = JSONRPCRequest | JSONRPCResponse | JSONRPCNotification;
-
-// Host context from ui/initialize response
-interface HostContext {
-  theme?: Theme;
-  displayMode?: DisplayMode;
-  containerDimensions?: {
-    width?: number;
-    height?: number;
-    maxWidth?: number;
-    maxHeight?: number;
-  };
-  locale?: string;
-  timeZone?: string;
-  platform?: "web" | "desktop" | "mobile";
-  userAgent?: string;
-  deviceCapabilities?: {
-    touch?: boolean;
-    hover?: boolean;
-  };
-  safeAreaInsets?: {
-    top: number;
-    right: number;
-    bottom: number;
-    left: number;
-  };
-  styles?: {
-    variables?: Record<string, string>;
-    css?: {
-      fonts?: string;
-    };
-  };
-}
 
 interface McpUiInitializeResult {
   protocolVersion: string;

--- a/libraries/typescript/packages/mcp-use/src/react/model-context.tsx
+++ b/libraries/typescript/packages/mcp-use/src/react/model-context.tsx
@@ -4,7 +4,7 @@
  *
  * The component registers content in a parent-child tree that is serialized
  * into an indented markdown-like string and pushed to the host via
- * ui/update-model-context (MCP Apps) or setWidgetState (ChatGPT Apps SDK).
+ * ui/update-model-context (MCP Apps).
  *
  * Two complementary APIs:
  *
@@ -173,7 +173,7 @@ interface ModelContextProps {
  *
  * Registers `content` in a hierarchical tree that is serialized into an
  * indented string and pushed to the host via `ui/update-model-context`
- * (MCP Apps) or `setWidgetState` (ChatGPT Apps SDK).
+ * (MCP Apps).
  *
  * - Supports empty children (self-closing `<ModelContext content="..." />`)
  * - Nested `<ModelContext>` components become child nodes in the tree

--- a/libraries/typescript/packages/mcp-use/src/react/useCallTool.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/useCallTool.ts
@@ -190,21 +190,9 @@ export function useCallTool(name: string): any {
     try {
       let raw: any;
 
-      // Detect provider and call tool
       if (typeof window !== "undefined") {
-        if (window.openai?.callTool) {
-          // OpenAI Apps SDK
-          raw = await window.openai.callTool(
-            name,
-            args as Record<string, unknown>
-          );
-        } else if (window !== window.parent) {
-          // MCP Apps bridge
-          const bridge = getMcpAppsBridge();
-          raw = await bridge.callTool(name, args as Record<string, unknown>);
-        } else {
-          throw new Error("No tool calling interface available");
-        }
+        const bridge = getMcpAppsBridge();
+        raw = await bridge.callTool(name, args as Record<string, unknown>);
       } else {
         throw new Error("useCallTool can only be used in browser environment");
       }

--- a/libraries/typescript/packages/mcp-use/src/react/useFiles.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/useFiles.ts
@@ -1,8 +1,8 @@
 /**
  * useFiles — React hook for file upload and download in widgets.
  *
- * File operations are only supported in the ChatGPT Apps SDK environment.
- * The MCP Apps spec (SEP-1865) has deferred file handling:
+ * File operations are only supported through the OpenAI window.openai extension.
+ * The MCP Apps spec (SEP-1865) has deferred standard file handling:
  * https://github.com/modelcontextprotocol/ext-apps/issues/201
  *
  * Always check `isSupported` before calling `upload` or `getDownloadUrl`.
@@ -39,7 +39,7 @@ export interface UseFilesResult {
   /**
    * Whether the host supports file operations.
    *
-   * `true` only in the ChatGPT Apps SDK environment where
+   * `true` only when the OpenAI window.openai extension exposes
    * `window.openai.uploadFile` and `window.openai.getFileDownloadUrl`
    * are available. Always check this flag before calling `upload` or
    * `getDownloadUrl`.
@@ -74,7 +74,8 @@ export interface UseFilesResult {
 /**
  * Hook for file upload and download operations in widgets.
  *
- * File operations are **only available in the ChatGPT Apps SDK** environment.
+ * File operations are **only available through the OpenAI window.openai
+ * extension**.
  * Always guard usage with the `isSupported` flag:
  *
  * ```tsx
@@ -112,7 +113,7 @@ export function useFiles(): UseFilesResult {
           throw new Error(
             "[useFiles] File upload is not supported in this host. " +
               "Check `isSupported` before calling `upload`. " +
-              "File operations are only available in the ChatGPT Apps SDK environment."
+              "File operations are only available through the OpenAI window.openai extension."
           );
         }
 
@@ -151,7 +152,7 @@ export function useFiles(): UseFilesResult {
           throw new Error(
             "[useFiles] File download is not supported in this host. " +
               "Check `isSupported` before calling `getDownloadUrl`. " +
-              "File operations are only available in the ChatGPT Apps SDK environment."
+              "File operations are only available through the OpenAI window.openai extension."
           );
         }
         return (window.openai as any).getFileDownloadUrl(file) as Promise<{

--- a/libraries/typescript/packages/mcp-use/src/react/useWidget.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/useWidget.ts
@@ -131,15 +131,37 @@ export function useWidget<
   > | null>(null);
 
   const latestModelContextDescriptionRef = useRef<string | null>(null);
+  const latestWidgetStateRef = useRef<TState | null>(null);
 
-  const pushModelContextToMcpApps = useCallback((description: string): void => {
+  const pushModelContextToMcpApps = useCallback((): void => {
     const bridge = getMcpAppsBridge();
     if (!bridge.isConnected()) return;
 
+    const currentState =
+      (latestWidgetStateRef.current as Record<string, unknown> | null) ?? {};
+    const description = latestModelContextDescriptionRef.current;
+    const hasDescription = description !== null && description.trim().length > 0;
+    const structuredContent =
+      hasDescription
+        ? { ...currentState, [MODEL_CONTEXT_KEY]: description }
+        : currentState;
+    const visibleState = Object.fromEntries(
+      Object.entries(currentState).filter(([key]) => key !== MODEL_CONTEXT_KEY)
+    );
+    const hasVisibleState = Object.keys(visibleState).length > 0;
+    const text =
+      hasDescription && hasVisibleState
+        ? `${description}\n\nState: ${JSON.stringify(visibleState)}`
+        : hasDescription
+          ? description
+          : hasVisibleState
+            ? JSON.stringify(visibleState)
+            : "";
+
     bridge
       .updateModelContext({
-        structuredContent: { [MODEL_CONTEXT_KEY]: description },
-        content: [{ type: "text", text: description }],
+        structuredContent,
+        content: [{ type: "text", text }],
       })
       .catch((err: unknown) => {
         console.warn("[ModelContext] Failed to update model context:", err);
@@ -179,9 +201,11 @@ export function useWidget<
         if (hostInfo) setMcpAppsHostInfo(hostInfo);
         if (hostCapabilities) setMcpAppsHostCapabilities(hostCapabilities);
 
-        const description = latestModelContextDescriptionRef.current;
-        if (description !== null) {
-          pushModelContextToMcpApps(description);
+        if (
+          latestModelContextDescriptionRef.current !== null ||
+          latestWidgetStateRef.current !== null
+        ) {
+          pushModelContextToMcpApps();
         }
       })
       .catch((error) => {
@@ -367,6 +391,7 @@ export function useWidget<
   // Use local state for widget state. MCP Apps state is local + model context
   // updates via ui/update-model-context.
   const [localWidgetState, setLocalWidgetState] = useState<TState | null>(null);
+  latestWidgetStateRef.current = localWidgetState;
 
   // Keep a ref to the current provider so the flush handler always uses the
   // latest value without needing to re-register on every provider change.
@@ -382,7 +407,7 @@ export function useWidget<
       const currentProvider = providerRef.current;
 
       if (currentProvider === "mcp-apps") {
-        pushModelContextToMcpApps(description);
+        pushModelContextToMcpApps();
       }
     });
     return deregister;
@@ -433,37 +458,18 @@ export function useWidget<
     async (
       state: TState | ((prevState: TState | null) => TState)
     ): Promise<void> => {
-      const currentState = localWidgetState;
+      const currentState = latestWidgetStateRef.current;
       const newState =
         typeof state === "function"
           ? (state as (prevState: TState | null) => TState)(currentState)
           : state;
 
+      latestWidgetStateRef.current = newState;
       setLocalWidgetState(newState);
 
-      const bridge = getMcpAppsBridge();
-      const structuredContent = newState as Record<string, unknown>;
-      bridge
-        .updateModelContext({
-          structuredContent,
-          content: [
-            {
-              type: "text",
-              text: JSON.stringify(
-                Object.fromEntries(
-                  Object.entries(structuredContent).filter(
-                    ([k]) => k !== MODEL_CONTEXT_KEY
-                  )
-                )
-              ),
-            },
-          ],
-        })
-        .catch((err) => {
-          console.warn("[useWidget] Failed to update model context:", err);
-        });
+      pushModelContextToMcpApps();
     },
-    [localWidgetState]
+    [pushModelContextToMcpApps]
   );
 
   // Determine if tool is still executing

--- a/libraries/typescript/packages/mcp-use/src/react/useWidget.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/useWidget.ts
@@ -15,6 +15,7 @@ import {
 import type {
   CallToolResponse,
   DisplayMode,
+  HostContext,
   MessageContentBlock,
   SafeArea,
   Theme,
@@ -118,7 +119,8 @@ export function useWidget<
     string,
     unknown
   > | null>(null);
-  const [mcpAppsHostContext, setMcpAppsHostContext] = useState<any>(null);
+  const [mcpAppsHostContext, setMcpAppsHostContext] =
+    useState<HostContext | null>(null);
   const [mcpAppsHostInfo, setMcpAppsHostInfo] = useState<{
     name: string;
     version: string;
@@ -562,6 +564,7 @@ export function useWidget<
     // Host identity (MCP Apps only)
     hostInfo: mcpAppsHostInfo ?? undefined,
     hostCapabilities: mcpAppsHostCapabilities ?? undefined,
+    hostContext: mcpAppsHostContext ?? undefined,
   } as UseWidgetResult<TProps, TState, TOutput, TMetadata, TToolInput>;
 }
 

--- a/libraries/typescript/packages/mcp-use/src/react/useWidget.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/useWidget.ts
@@ -140,11 +140,11 @@ export function useWidget<
     const currentState =
       (latestWidgetStateRef.current as Record<string, unknown> | null) ?? {};
     const description = latestModelContextDescriptionRef.current;
-    const hasDescription = description !== null && description.trim().length > 0;
-    const structuredContent =
-      hasDescription
-        ? { ...currentState, [MODEL_CONTEXT_KEY]: description }
-        : currentState;
+    const hasDescription =
+      description !== null && description.trim().length > 0;
+    const structuredContent = hasDescription
+      ? { ...currentState, [MODEL_CONTEXT_KEY]: description }
+      : currentState;
     const visibleState = Object.fromEntries(
       Object.entries(currentState).filter(([key]) => key !== MODEL_CONTEXT_KEY)
     );

--- a/libraries/typescript/packages/mcp-use/src/react/useWidget.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/useWidget.ts
@@ -4,13 +4,7 @@
  * available for extension APIs.
  */
 
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { getMcpAppsBridge } from "./mcp-apps-bridge.js";
 import { WIDGET_DEFAULTS } from "./constants.js";
 import { normalizeCallToolResponse } from "./widget-utils.js";
@@ -136,22 +130,19 @@ export function useWidget<
 
   const latestModelContextDescriptionRef = useRef<string | null>(null);
 
-  const pushModelContextToMcpApps = useCallback(
-    (description: string): void => {
-      const bridge = getMcpAppsBridge();
-      if (!bridge.isConnected()) return;
+  const pushModelContextToMcpApps = useCallback((description: string): void => {
+    const bridge = getMcpAppsBridge();
+    if (!bridge.isConnected()) return;
 
-      bridge
-        .updateModelContext({
-          structuredContent: { [MODEL_CONTEXT_KEY]: description },
-          content: [{ type: "text", text: description }],
-        })
-        .catch((err: unknown) => {
-          console.warn("[ModelContext] Failed to update model context:", err);
-        });
-    },
-    []
-  );
+    bridge
+      .updateModelContext({
+        structuredContent: { [MODEL_CONTEXT_KEY]: description },
+        content: [{ type: "text", text: description }],
+      })
+      .catch((err: unknown) => {
+        console.warn("[ModelContext] Failed to update model context:", err);
+      });
+  }, []);
 
   // Initialize MCP Apps bridge for hosted widget iframes. ChatGPT may also
   // expose window.openai, but MCP Apps remains the base protocol.
@@ -421,15 +412,12 @@ export function useWidget<
     []
   );
 
-  const openExternal = useCallback(
-    (href: string): void => {
-      const bridge = getMcpAppsBridge();
-      bridge.openLink(href).catch((error) => {
-        console.error("Failed to open link:", error);
-      });
-    },
-    []
-  );
+  const openExternal = useCallback((href: string): void => {
+    const bridge = getMcpAppsBridge();
+    bridge.openLink(href).catch((error) => {
+      console.error("Failed to open link:", error);
+    });
+  }, []);
 
   const requestDisplayMode = useCallback(
     async (mode: DisplayMode): Promise<{ mode: DisplayMode }> => {
@@ -498,12 +486,7 @@ export function useWidget<
       return toolOutput === null || toolOutput === undefined;
     }
     return false;
-  }, [
-    provider,
-    mcpAppsToolOutput,
-    toolOutput,
-    urlParams.toolId,
-  ]);
+  }, [provider, mcpAppsToolOutput, toolOutput, urlParams.toolId]);
 
   // Partial/streaming tool input (available during LLM argument generation)
   const partialToolInput = useMemo(() => {

--- a/libraries/typescript/packages/mcp-use/src/react/useWidget.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/useWidget.ts
@@ -1,6 +1,7 @@
 /**
- * React hook for OpenAI Apps SDK and MCP Apps widget development
- * Wraps window.openai API (Apps SDK) and MCP Apps postMessage protocol
+ * React hook for MCP Apps widget development.
+ * Uses MCP Apps postMessage as the base protocol and keeps window.openai
+ * available for extension APIs.
  */
 
 import {
@@ -9,7 +10,6 @@ import {
   useMemo,
   useRef,
   useState,
-  useSyncExternalStore,
 } from "react";
 import { getMcpAppsBridge } from "./mcp-apps-bridge.js";
 import { WIDGET_DEFAULTS } from "./constants.js";
@@ -22,76 +22,25 @@ import type {
   CallToolResponse,
   DisplayMode,
   MessageContentBlock,
-  OpenAiGlobals,
   SafeArea,
-  SetGlobalsEvent,
   Theme,
   UnknownObject,
   UserAgent,
   UseWidgetResult,
 } from "./widget-types.js";
-import { SET_GLOBALS_EVENT_TYPE } from "./widget-types.js";
 
 /**
- * Hook to subscribe to a single value from window.openai globals.
- * Only triggers onChange when the value actually changes, to avoid redundant
- * re-renders from duplicate events (e.g. theme sync that re-sends same toolOutput).
- */
-function useOpenAiGlobal<K extends keyof OpenAiGlobals>(
-  key: K
-): OpenAiGlobals[K] | undefined {
-  return useSyncExternalStore(
-    (onChange) => {
-      // Initialize from current snapshot so redundant events with same values are ignored
-      let lastValue: unknown =
-        typeof window !== "undefined" && window.openai
-          ? (window.openai as OpenAiGlobals)[key]
-          : undefined;
-      const handleSetGlobal = (event: any) => {
-        const customEvent = event as SetGlobalsEvent;
-        const value = customEvent.detail.globals[key];
-        if (value === undefined) {
-          return;
-        }
-        if (value === lastValue) return;
-        lastValue = value;
-        onChange();
-      };
-
-      if (typeof window !== "undefined") {
-        window.addEventListener(SET_GLOBALS_EVENT_TYPE, handleSetGlobal);
-      }
-
-      return () => {
-        if (typeof window !== "undefined") {
-          window.removeEventListener(SET_GLOBALS_EVENT_TYPE, handleSetGlobal);
-        }
-      };
-    },
-    () =>
-      typeof window !== "undefined" && window.openai
-        ? window.openai[key]
-        : undefined
-  );
-}
-
-/**
- * React hook for building MCP Apps and ChatGPT Apps SDK widgets.
+ * React hook for building MCP Apps widgets.
  *
- * Abstracts over three runtime providers, selected automatically:
+ * Abstracts over two data providers, selected automatically:
  *
- * 1. **ChatGPT Apps SDK** (`window.openai`) — active when the widget is loaded
- *    inside ChatGPT. Data arrives via `window.openai.toolInput`,
- *    `window.openai.toolOutput`, etc. and through the `openai:set_globals`
- *    custom event.
- *
- * 2. **MCP Apps bridge** (SEP-1865 `postMessage`) — active when the widget is
- *    loaded in any SEP-1865-compliant host (e.g. Claude, Cursor) that is not
- *    ChatGPT. The hook connects via `ui/initialize` and listens for
+ * 1. **MCP Apps bridge** (SEP-1865 `postMessage`) — primary runtime for
+ *    hosted widget iframes, including ChatGPT. The hook connects via
+ *    `ui/initialize` and listens for
  *    `ui/notifications/tool-input`, `ui/notifications/tool-input-partial`,
  *    `ui/notifications/tool-result`, and `ui/notifications/host-context-changed`.
  *
- * 3. **URL params fallback** (`mcpUseParams`) — used during local development
+ * 2. **URL params fallback** (`mcpUseParams`) — used during local development
  *    (`mcp-use dev` inspector) where `toolInput` and `toolOutput` are injected
  *    via the query string. No live streaming in this mode.
  *
@@ -152,9 +101,9 @@ export function useWidget<
 >(
   defaultProps?: TProps
 ): UseWidgetResult<TProps, TState, TOutput, TMetadata, TToolInput> {
-  // Check if window.openai is available - use state to allow re-checking after async injection
-  const [isOpenAiAvailable, setIsOpenAiAvailable] = useState(
-    () => typeof window !== "undefined" && !!window.openai
+  const isWidgetIframe = useMemo(
+    () => typeof window !== "undefined" && window !== window.parent,
+    []
   );
 
   // Check if MCP Apps bridge is available
@@ -185,59 +134,29 @@ export function useWidget<
     unknown
   > | null>(null);
 
-  // Re-check for window.openai availability after mount (in case it's injected asynchronously)
+  const latestModelContextDescriptionRef = useRef<string | null>(null);
+
+  const pushModelContextToMcpApps = useCallback(
+    (description: string): void => {
+      const bridge = getMcpAppsBridge();
+      if (!bridge.isConnected()) return;
+
+      bridge
+        .updateModelContext({
+          structuredContent: { [MODEL_CONTEXT_KEY]: description },
+          content: [{ type: "text", text: description }],
+        })
+        .catch((err: unknown) => {
+          console.warn("[ModelContext] Failed to update model context:", err);
+        });
+    },
+    []
+  );
+
+  // Initialize MCP Apps bridge for hosted widget iframes. ChatGPT may also
+  // expose window.openai, but MCP Apps remains the base protocol.
   useEffect(() => {
-    // Initial check
-    if (typeof window !== "undefined" && window.openai) {
-      setIsOpenAiAvailable(true);
-      return;
-    }
-
-    // Poll for window.openai if not immediately available (for async script injection)
-    const checkInterval = setInterval(() => {
-      if (typeof window !== "undefined" && window.openai) {
-        setIsOpenAiAvailable(true);
-        clearInterval(checkInterval);
-      }
-    }, 100);
-
-    // Also listen for the openai:set_globals event which fires when the API is ready
-    const handleSetGlobals = () => {
-      if (typeof window !== "undefined" && window.openai) {
-        setIsOpenAiAvailable(true);
-        clearInterval(checkInterval);
-      }
-    };
-
-    if (typeof window !== "undefined") {
-      window.addEventListener(SET_GLOBALS_EVENT_TYPE, handleSetGlobals);
-    }
-
-    // Cleanup after 5 seconds max (should be injected by then)
-    const timeout = setTimeout(() => {
-      clearInterval(checkInterval);
-      if (typeof window !== "undefined") {
-        window.removeEventListener(SET_GLOBALS_EVENT_TYPE, handleSetGlobals);
-      }
-    }, 5000);
-
-    return () => {
-      clearInterval(checkInterval);
-      clearTimeout(timeout);
-      if (typeof window !== "undefined") {
-        window.removeEventListener(SET_GLOBALS_EVENT_TYPE, handleSetGlobals);
-      }
-    };
-  }, []);
-
-  // Initialize MCP Apps bridge if not in Apps SDK mode
-  useEffect(() => {
-    // Only try MCP Apps if window.openai is not available and we're in an iframe
-    if (
-      typeof window === "undefined" ||
-      window.openai ||
-      window === window.parent
-    ) {
+    if (!isWidgetIframe || typeof window === "undefined") {
       return;
     }
 
@@ -266,6 +185,11 @@ export function useWidget<
         const hostCapabilities = bridge.getHostCapabilities();
         if (hostInfo) setMcpAppsHostInfo(hostInfo);
         if (hostCapabilities) setMcpAppsHostCapabilities(hostCapabilities);
+
+        const description = latestModelContextDescriptionRef.current;
+        if (description !== null) {
+          pushModelContextToMcpApps(description);
+        }
       })
       .catch((error) => {
         console.warn("[useWidget] Failed to connect to MCP Apps host:", error);
@@ -297,13 +221,7 @@ export function useWidget<
       unsubToolResult();
       unsubHostContext();
     };
-  }, []);
-
-  const provider = useMemo(() => {
-    if (isOpenAiAvailable) return "openai";
-    if (isMcpAppsConnected) return "mcp-apps";
-    return "mcp-ui";
-  }, [isOpenAiAvailable, isMcpAppsConnected]);
+  }, [pushModelContextToMcpApps, isWidgetIframe]);
 
   // Extract search string to avoid dependency issues
   const searchString =
@@ -326,59 +244,22 @@ export function useWidget<
     };
   }, [searchString]);
 
-  // Always subscribe to openai globals (hooks must be called unconditionally)
-  const openaiToolInput = useOpenAiGlobal("toolInput") as
-    | TToolInput
-    | undefined;
-  const openaiToolOutput = useOpenAiGlobal("toolOutput") as
-    | TOutput
-    | null
-    | undefined;
-  const toolResponseMetadata = useOpenAiGlobal("toolResponseMetadata") as
-    | TMetadata
-    | null
-    | undefined;
-  const widgetState = useOpenAiGlobal("widgetState") as
-    | TState
-    | null
-    | undefined;
-  const openaiTheme = useOpenAiGlobal("theme") as Theme | undefined;
-  const openaiDisplayMode = useOpenAiGlobal("displayMode") as
-    | DisplayMode
-    | undefined;
-  const openaiSafeArea = useOpenAiGlobal("safeArea") as SafeArea | undefined;
-  const openaiMaxHeight = useOpenAiGlobal("maxHeight") as number | undefined;
-  const openaiUserAgent = useOpenAiGlobal("userAgent") as UserAgent | undefined;
-  const openaiLocale = useOpenAiGlobal("locale") as string | undefined;
+  const provider = useMemo(() => {
+    return isWidgetIframe ? "mcp-apps" : "mcp-ui";
+  }, [isWidgetIframe]);
 
   // Select data source based on provider
   const toolInput = useMemo(() => {
-    if (provider === "openai") return openaiToolInput;
     if (provider === "mcp-apps")
       return mcpAppsToolInput as TToolInput | undefined;
     return urlParams.toolInput as TToolInput | undefined;
-  }, [provider, openaiToolInput, mcpAppsToolInput, urlParams.toolInput]);
+  }, [provider, mcpAppsToolInput, urlParams.toolInput]);
 
   const toolOutput = useMemo(() => {
-    if (provider === "openai") {
-      // Unwrap CallToolResult envelope if the host passed the full tool-result params
-      const raw = openaiToolOutput as
-        | Record<string, unknown>
-        | null
-        | undefined;
-      if (
-        raw &&
-        raw.structuredContent &&
-        typeof raw.structuredContent === "object"
-      ) {
-        return raw.structuredContent as TOutput | null | undefined;
-      }
-      return openaiToolOutput;
-    }
     if (provider === "mcp-apps")
       return mcpAppsToolOutput as TOutput | null | undefined;
     return urlParams.toolOutput as TOutput | null | undefined;
-  }, [provider, openaiToolOutput, mcpAppsToolOutput, urlParams.toolOutput]);
+  }, [provider, mcpAppsToolOutput, urlParams.toolOutput]);
 
   // Props semantics:
   // - Widget exposed as tool: props = toolInput (args to the tool); when result arrives, props = structuredContent (tool can echo/override).
@@ -389,18 +270,8 @@ export function useWidget<
     const base = (defaultProps || {}) as Record<string, unknown> as TProps;
 
     // Extract structuredContent from provider-specific toolOutput.
-    // Some hosts (e.g. compat runtimes bridging MCP Apps → window.openai) pass the
-    // full CallToolResult envelope { content, structuredContent, _meta } as toolOutput
-    // instead of pre-extracting structuredContent. Detect and unwrap when needed.
     let structuredContent: Record<string, unknown> | undefined;
-    if (provider === "openai" && openaiToolOutput) {
-      const raw = openaiToolOutput as Record<string, unknown>;
-      if (raw.structuredContent && typeof raw.structuredContent === "object") {
-        structuredContent = raw.structuredContent as Record<string, unknown>;
-      } else {
-        structuredContent = raw;
-      }
-    } else if (provider === "mcp-apps" && mcpAppsToolOutput) {
+    if (provider === "mcp-apps" && mcpAppsToolOutput) {
       structuredContent = mcpAppsToolOutput as Record<string, unknown>;
     } else if (provider === "mcp-ui" && urlParams.toolOutput) {
       structuredContent = urlParams.toolOutput as Record<string, unknown>;
@@ -412,7 +283,6 @@ export function useWidget<
   }, [
     provider,
     toolInput,
-    openaiToolOutput,
     mcpAppsToolOutput,
     urlParams.toolOutput,
     defaultProps,
@@ -420,46 +290,38 @@ export function useWidget<
 
   // Theme, displayMode, and other host context from provider
   const theme = useMemo(() => {
-    if (provider === "openai") return openaiTheme;
     if (provider === "mcp-apps" && mcpAppsHostContext) {
       return mcpAppsHostContext.theme as Theme | undefined;
     }
     return undefined;
-  }, [provider, openaiTheme, mcpAppsHostContext]);
+  }, [provider, mcpAppsHostContext]);
 
   const displayMode = useMemo(() => {
-    if (provider === "openai") return openaiDisplayMode;
     if (provider === "mcp-apps" && mcpAppsHostContext) {
       return mcpAppsHostContext.displayMode as DisplayMode | undefined;
     }
     return undefined;
-  }, [provider, openaiDisplayMode, mcpAppsHostContext]);
+  }, [provider, mcpAppsHostContext]);
 
   const safeArea = useMemo(() => {
-    if (provider === "openai") return openaiSafeArea;
     if (provider === "mcp-apps" && mcpAppsHostContext?.safeAreaInsets) {
       return {
         insets: mcpAppsHostContext.safeAreaInsets,
       } as SafeArea;
     }
     return undefined;
-  }, [provider, openaiSafeArea, mcpAppsHostContext]);
+  }, [provider, mcpAppsHostContext]);
 
   const maxHeight = useMemo(() => {
-    if (provider === "openai") return openaiMaxHeight;
     if (provider === "mcp-apps" && mcpAppsHostContext?.containerDimensions) {
       return mcpAppsHostContext.containerDimensions.maxHeight as
         | number
         | undefined;
     }
     return undefined;
-  }, [provider, openaiMaxHeight, mcpAppsHostContext]);
+  }, [provider, mcpAppsHostContext]);
 
   const maxWidth = useMemo(() => {
-    if (provider === "openai") {
-      // ChatGPT Apps SDK doesn't expose maxWidth
-      return undefined;
-    }
     if (provider === "mcp-apps" && mcpAppsHostContext?.containerDimensions) {
       return mcpAppsHostContext.containerDimensions.maxWidth as
         | number
@@ -469,7 +331,6 @@ export function useWidget<
   }, [provider, mcpAppsHostContext]);
 
   const userAgent = useMemo(() => {
-    if (provider === "openai") return openaiUserAgent;
     if (provider === "mcp-apps" && mcpAppsHostContext) {
       // Map MCP Apps device capabilities to UserAgent format
       return {
@@ -485,23 +346,16 @@ export function useWidget<
       } as UserAgent;
     }
     return undefined;
-  }, [provider, openaiUserAgent, mcpAppsHostContext]);
+  }, [provider, mcpAppsHostContext]);
 
   const locale = useMemo(() => {
-    if (provider === "openai") return openaiLocale;
     if (provider === "mcp-apps" && mcpAppsHostContext) {
       return mcpAppsHostContext.locale as string | undefined;
     }
     return undefined;
-  }, [provider, openaiLocale, mcpAppsHostContext]);
+  }, [provider, mcpAppsHostContext]);
 
   const timeZone = useMemo(() => {
-    if (provider === "openai") {
-      // ChatGPT Apps SDK doesn't expose timeZone, use browser default
-      return typeof window !== "undefined"
-        ? Intl.DateTimeFormat().resolvedOptions().timeZone
-        : undefined;
-    }
     if (provider === "mcp-apps" && mcpAppsHostContext) {
       return mcpAppsHostContext.timeZone as string | undefined;
     }
@@ -517,66 +371,29 @@ export function useWidget<
     return "";
   }, []);
 
-  // Use local state for widget state with sync to window.openai
+  // Use local state for widget state. MCP Apps state is local + model context
+  // updates via ui/update-model-context.
   const [localWidgetState, setLocalWidgetState] = useState<TState | null>(null);
-
-  // Sync widget state from window.openai
-  useEffect(() => {
-    if (widgetState !== undefined) {
-      setLocalWidgetState(widgetState);
-    }
-  }, [widgetState]);
 
   // Keep a ref to the current provider so the flush handler always uses the
   // latest value without needing to re-register on every provider change.
   const providerRef = useRef(provider);
   providerRef.current = provider;
 
-  // Keep a ref to localWidgetState for the same reason
-  const localWidgetStateRef = useRef(localWidgetState);
-  localWidgetStateRef.current = localWidgetState;
-
   // Register the model-context flush handler for the lifetime of this widget.
   // When the node tree changes, this handler is called with the serialized
   // description and pushes it to the host under MODEL_CONTEXT_KEY.
   useEffect(() => {
     const deregister = registerModelContextFlush((description) => {
+      latestModelContextDescriptionRef.current = description;
       const currentProvider = providerRef.current;
 
       if (currentProvider === "mcp-apps") {
-        const bridge = getMcpAppsBridge();
-        if (bridge.isConnected()) {
-          bridge
-            .updateModelContext({
-              structuredContent: { [MODEL_CONTEXT_KEY]: description },
-              content: [{ type: "text", text: description }],
-            })
-            .catch((err: unknown) => {
-              console.warn(
-                "[ModelContext] Failed to update model context:",
-                err
-              );
-            });
-        }
-        return;
-      }
-
-      if (currentProvider === "openai" && window.openai?.setWidgetState) {
-        const prev = (window.openai.widgetState ??
-          localWidgetStateRef.current ??
-          {}) as Record<string, unknown>;
-        window.openai
-          .setWidgetState({
-            ...prev,
-            [MODEL_CONTEXT_KEY]: description,
-          } as TState)
-          .catch((err: unknown) => {
-            console.warn("[ModelContext] Failed to set widget state:", err);
-          });
+        pushModelContextToMcpApps(description);
       }
     });
     return deregister;
-  }, []);
+  }, [pushModelContextToMcpApps]);
 
   // Stable API methods
   const callTool = useCallback(
@@ -584,19 +401,11 @@ export function useWidget<
       name: string,
       args: Record<string, unknown>
     ): Promise<CallToolResponse> => {
-      if (provider === "mcp-apps") {
-        const bridge = getMcpAppsBridge();
-        const raw = await bridge.callTool(name, args);
-        return normalizeCallToolResponse(raw);
-      }
-
-      if (!window.openai?.callTool) {
-        throw new Error("window.openai.callTool is not available");
-      }
-      const raw = await window.openai.callTool(name, args);
+      const bridge = getMcpAppsBridge();
+      const raw = await bridge.callTool(name, args);
       return normalizeCallToolResponse(raw);
     },
-    [provider]
+    []
   );
 
   const sendFollowUpMessage = useCallback(
@@ -606,140 +415,69 @@ export function useWidget<
           ? [{ type: "text", text: content }]
           : content;
 
-      if (provider === "mcp-apps") {
-        const bridge = getMcpAppsBridge();
-        await bridge.sendMessage(contentArray);
-        return;
-      }
-
-      if (!window.openai?.sendFollowUpMessage) {
-        throw new Error("window.openai.sendFollowUpMessage is not available");
-      }
-      // window.openai only supports plain text; extract and join text blocks
-      const prompt =
-        typeof content === "string"
-          ? content
-          : contentArray
-              .filter(
-                (c): c is { type: "text"; text: string } =>
-                  c.type === "text" && "text" in c
-              )
-              .map((c) => c.text)
-              .join("\n");
-      return window.openai.sendFollowUpMessage({ prompt });
+      const bridge = getMcpAppsBridge();
+      await bridge.sendMessage(contentArray);
     },
-    [provider]
+    []
   );
 
   const openExternal = useCallback(
     (href: string): void => {
-      if (provider === "mcp-apps") {
-        const bridge = getMcpAppsBridge();
-        bridge.openLink(href).catch((error) => {
-          console.error("Failed to open link:", error);
-        });
-        return;
-      }
-
-      if (!window.openai?.openExternal) {
-        throw new Error("window.openai.openExternal is not available");
-      }
-      window.openai.openExternal({ href });
+      const bridge = getMcpAppsBridge();
+      bridge.openLink(href).catch((error) => {
+        console.error("Failed to open link:", error);
+      });
     },
-    [provider]
+    []
   );
 
   const requestDisplayMode = useCallback(
     async (mode: DisplayMode): Promise<{ mode: DisplayMode }> => {
-      if (provider === "mcp-apps") {
-        const bridge = getMcpAppsBridge();
-        return await bridge.requestDisplayMode(mode);
-      }
-
-      if (!window.openai?.requestDisplayMode) {
-        throw new Error("window.openai.requestDisplayMode is not available");
-      }
-      return window.openai.requestDisplayMode({ mode });
+      const bridge = getMcpAppsBridge();
+      return await bridge.requestDisplayMode(mode);
     },
-    [provider]
+    []
   );
 
   const setState = useCallback(
     async (
       state: TState | ((prevState: TState | null) => TState)
     ): Promise<void> => {
-      // MCP Apps: update local state + send ui/update-model-context to host
-      // so the model can reason about UI state on future turns (per SEP-1865)
-      if (provider === "mcp-apps") {
-        const currentState = localWidgetState;
-        const newState =
-          typeof state === "function"
-            ? (state as (prevState: TState | null) => TState)(currentState)
-            : state;
-        setLocalWidgetState(newState);
-
-        const bridge = getMcpAppsBridge();
-        // Preserve __model_context from any prior update-model-context calls
-        // so setState doesn't wipe out the model context annotations.
-        const structuredContent = newState as Record<string, unknown>;
-        bridge
-          .updateModelContext({
-            structuredContent,
-            content: [
-              {
-                type: "text",
-                text: JSON.stringify(
-                  Object.fromEntries(
-                    Object.entries(structuredContent).filter(
-                      ([k]) => k !== MODEL_CONTEXT_KEY
-                    )
-                  )
-                ),
-              },
-            ],
-          })
-          .catch((err) => {
-            console.warn("[useWidget] Failed to update model context:", err);
-          });
-        return;
-      }
-
-      if (!window.openai?.setWidgetState) {
-        throw new Error("window.openai.setWidgetState is not available");
-      }
-
-      // Use functional update to always get latest state
-      // Prefer widgetState (from window.openai) over localWidgetState for most up-to-date value
-      const currentState =
-        widgetState !== undefined ? widgetState : localWidgetState;
+      const currentState = localWidgetState;
       const newState =
         typeof state === "function"
           ? (state as (prevState: TState | null) => TState)(currentState)
           : state;
 
-      // Preserve __model_context so setState doesn't wipe annotations
-      const prevModelContext = (
-        (window.openai.widgetState ?? {}) as Record<string, unknown>
-      )[MODEL_CONTEXT_KEY];
-
       setLocalWidgetState(newState);
-      return window.openai.setWidgetState(
-        prevModelContext !== undefined
-          ? ({ ...newState, [MODEL_CONTEXT_KEY]: prevModelContext } as TState)
-          : newState
-      );
+
+      const bridge = getMcpAppsBridge();
+      const structuredContent = newState as Record<string, unknown>;
+      bridge
+        .updateModelContext({
+          structuredContent,
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(
+                Object.fromEntries(
+                  Object.entries(structuredContent).filter(
+                    ([k]) => k !== MODEL_CONTEXT_KEY
+                  )
+                )
+              ),
+            },
+          ],
+        })
+        .catch((err) => {
+          console.warn("[useWidget] Failed to update model context:", err);
+        });
     },
-    [provider, widgetState, localWidgetState]
+    [localWidgetState]
   );
 
   // Determine if tool is still executing
   const isPending = useMemo(() => {
-    if (provider === "openai") {
-      // Tool is pending until the host delivers either toolOutput (structuredContent)
-      // or toolResponseMetadata (_meta). Checking both mirrors how MCP Apps works and
-      // avoids staying stuck when the server omits _meta from the tool result.
-      return openaiToolOutput === null && toolResponseMetadata === null;
-    }
     if (provider === "mcp-apps") {
       // In MCP Apps, widget is pending until we receive tool-result notification
       // We check toolOutput instead of toolInput because input is sent immediately
@@ -762,8 +500,6 @@ export function useWidget<
     return false;
   }, [
     provider,
-    openaiToolOutput,
-    toolResponseMetadata,
     mcpAppsToolOutput,
     toolOutput,
     urlParams.toolId,
@@ -774,7 +510,7 @@ export function useWidget<
     if (provider === "mcp-apps" && mcpAppsPartialToolInput) {
       return mcpAppsPartialToolInput as Partial<TToolInput>;
     }
-    // OpenAI Apps SDK and URL params don't support streaming tool input
+    // URL params don't support streaming tool input.
     return null;
   }, [provider, mcpAppsPartialToolInput]);
 
@@ -798,7 +534,7 @@ export function useWidget<
     output: (toolOutput ?? null) as TOutput | null,
     metadata: (provider === "mcp-apps"
       ? (mcpAppsResponseMetadata ?? null)
-      : (toolResponseMetadata ?? null)) as TMetadata | null,
+      : null) as TMetadata | null,
     state: localWidgetState
       ? (Object.fromEntries(
           Object.entries(localWidgetState as Record<string, unknown>).filter(
@@ -833,7 +569,7 @@ export function useWidget<
     requestDisplayMode,
 
     // Availability
-    isAvailable: isOpenAiAvailable || isMcpAppsConnected,
+    isAvailable: provider === "mcp-apps" ? isMcpAppsConnected : false,
     isPending,
 
     // Streaming
@@ -885,18 +621,15 @@ export function useWidgetState<TState>(
   TState | null,
   (state: TState | ((prev: TState | null) => TState)) => Promise<void>,
 ] {
-  const { state, setState } = useWidget<UnknownObject, TState>();
+  const widget = useWidget<UnknownObject, TState>();
+  const { state, setState, isAvailable } = widget;
 
   // Initialize with default if provided and state is null
   useEffect(() => {
-    if (
-      state === null &&
-      defaultState !== undefined &&
-      window.openai?.setWidgetState
-    ) {
+    if (state === null && defaultState !== undefined && isAvailable) {
       setState(defaultState);
     }
-  }, []); // Only run once on mount
+  }, [defaultState, isAvailable, setState, state]);
 
   return [state, setState] as const;
 }

--- a/libraries/typescript/packages/mcp-use/src/react/widget-types.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/widget-types.ts
@@ -61,6 +61,34 @@ export type UserAgent = {
   };
 };
 
+export interface HostContext {
+  theme?: Theme;
+  displayMode?: DisplayMode;
+  availableDisplayModes?: DisplayMode[];
+  containerDimensions?: {
+    width?: number;
+    height?: number;
+    maxWidth?: number;
+    maxHeight?: number;
+  };
+  locale?: string;
+  timeZone?: string;
+  platform?: "web" | "desktop" | "mobile";
+  userAgent?: string;
+  deviceCapabilities?: {
+    touch?: boolean;
+    hover?: boolean;
+  };
+  safeAreaInsets?: SafeAreaInsets;
+  styles?: {
+    variables?: Record<string, string>;
+    css?: {
+      fonts?: string;
+    };
+  };
+  [key: string]: unknown;
+}
+
 export type CallToolResponse = {
   content: Array<{
     type: string;
@@ -471,6 +499,14 @@ interface UseWidgetResultBase<
    * ```
    */
   hostCapabilities?: Record<string, unknown>;
+
+  /**
+   * Raw host context received through the MCP Apps bridge.
+   *
+   * Includes standardized host style variables at
+   * `hostContext.styles.variables` when provided by the host.
+   */
+  hostContext?: HostContext;
 }
 
 /**

--- a/libraries/typescript/packages/mcp-use/src/react/widget-types.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/widget-types.ts
@@ -2,8 +2,6 @@
  * Type definitions for the window.openai extension API.
  */
 
-/* global CustomEvent */
-
 export type UnknownObject = Record<string, unknown>;
 
 /**
@@ -152,25 +150,12 @@ export interface API<WidgetState extends UnknownObject = UnknownObject> {
   getFileDownloadUrl?: (file: FileMetadata) => Promise<{ downloadUrl: string }>;
 }
 
-// Event types
-export const SET_GLOBALS_EVENT_TYPE = "openai:set_globals";
-
-export class SetGlobalsEvent extends CustomEvent<{
-  globals: Partial<OpenAiGlobals>;
-}> {
-  readonly type = SET_GLOBALS_EVENT_TYPE;
-}
-
 declare global {
   interface Window {
     openai?: API<any> & OpenAiGlobals<any, any, any, any>;
     __getFile?: (filename: string) => string;
     __mcpPublicUrl?: string;
     __mcpPublicAssetsUrl?: string;
-  }
-
-  interface WindowEventMap {
-    [SET_GLOBALS_EVENT_TYPE]: SetGlobalsEvent;
   }
 }
 

--- a/libraries/typescript/packages/mcp-use/src/react/widget-types.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/widget-types.ts
@@ -81,7 +81,7 @@ export interface HostContext {
   };
   safeAreaInsets?: SafeAreaInsets;
   styles?: {
-    variables?: Record<string, string>;
+    variables?: Record<string, string | undefined>;
     css?: {
       fonts?: string;
     };

--- a/libraries/typescript/packages/mcp-use/src/react/widget-types.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/widget-types.ts
@@ -1,6 +1,5 @@
 /**
- * Type definitions for OpenAI Apps SDK window.openai API
- * Based on: https://developers.openai.com/apps-sdk/build/custom-ux
+ * Type definitions for the window.openai extension API.
  */
 
 /* global CustomEvent */
@@ -140,14 +139,14 @@ export interface API<WidgetState extends UnknownObject = UnknownObject> {
 
   /**
    * Upload a file to the host.
-   * Only available in ChatGPT Apps SDK environments.
+   * Only available when the OpenAI window.openai extension exposes file APIs.
    * Use `useFiles().isSupported` to detect availability before calling.
    */
   uploadFile?: (file: File) => Promise<FileMetadata>;
 
   /**
    * Get a temporary download URL for a previously uploaded file.
-   * Only available in ChatGPT Apps SDK environments.
+   * Only available when the OpenAI window.openai extension exposes file APIs.
    * Use `useFiles().isSupported` to detect availability before calling.
    */
   getFileDownloadUrl?: (file: FileMetadata) => Promise<{ downloadUrl: string }>;
@@ -188,9 +187,9 @@ interface UseWidgetResultBase<
    * The arguments the model passed when calling the tool.
    *
    * Delivered via `ui/notifications/tool-input` (SEP-1865) once after the
-   * `ui/initialize` handshake completes, or via `window.openai.toolInput` in
-   * the ChatGPT Apps SDK. This reflects exactly what the LLM decided to send —
-   * useful for displaying a "requested" summary alongside the rendered result.
+   * `ui/initialize` handshake completes. This reflects exactly what the LLM
+   * decided to send — useful for displaying a "requested" summary alongside
+   * the rendered result.
    */
   toolInput: TToolInput;
 
@@ -201,8 +200,7 @@ interface UseWidgetResultBase<
    * from the tool response, not `structuredContent`. Use `output` (i.e. `props`)
    * to pass rich, structured data to the widget without polluting the model context.
    *
-   * Delivered via `ui/notifications/tool-result` (SEP-1865) /
-   * `window.openai.toolOutput` (Apps SDK). `null` while the tool is still
+   * Delivered via `ui/notifications/tool-result` (SEP-1865). `null` while the tool is still
    * executing (`isPending === true`).
    */
   output: TOutput | null;
@@ -219,9 +217,8 @@ interface UseWidgetResultBase<
   /**
    * Persisted widget state that the model can read on future turns.
    *
-   * On MCP Apps, calling `setState` sends a `ui/update-model-context` request
-   * (SEP-1865) so the updated state is available to the LLM in the next
-   * conversation turn. On ChatGPT, it calls `window.openai.setWidgetState`.
+   * Calling `setState` sends a `ui/update-model-context` request (SEP-1865) so
+   * the updated state is available to the LLM in the next conversation turn.
    * Use this to keep the model informed about user interactions (selected items,
    * filters, current view, etc.) without requiring an explicit tool call.
    */
@@ -231,9 +228,8 @@ interface UseWidgetResultBase<
    * Update the persisted widget state.
    *
    * Accepts either a new state value or a functional updater `(prev) => next`.
-   * On MCP Apps, sends `ui/update-model-context` (SEP-1865) with the new state
-   * so the LLM can reason about it on future turns. On ChatGPT Apps SDK, calls
-   * `window.openai.setWidgetState`. Multiple rapid updates before the next user
+   * Sends `ui/update-model-context` (SEP-1865) with the new state so the LLM
+   * can reason about it on future turns. Multiple rapid updates before the next user
    * message are deduplicated by the host — only the last value is sent to the
    * model.
    */
@@ -247,8 +243,7 @@ interface UseWidgetResultBase<
    * The host's current color-scheme preference.
    *
    * `"light"` or `"dark"`. Changes are notified via
-   * `ui/notifications/host-context-changed` (SEP-1865) / `openai:set_globals`
-   * (Apps SDK). Use the standardized `--color-*` CSS variables provided by the
+   * `ui/notifications/host-context-changed` (SEP-1865). Use the standardized `--color-*` CSS variables provided by the
    * host for automatic theming, or branch on this value to apply your own
    * styles.
    *
@@ -270,8 +265,7 @@ interface UseWidgetResultBase<
    *
    * Changes when the host responds to a `requestDisplayMode` call or when the
    * host initiates a layout change. Updated via
-   * `ui/notifications/host-context-changed` (SEP-1865) / `openai:set_globals`
-   * (Apps SDK).
+   * `ui/notifications/host-context-changed` (SEP-1865).
    *
    * @see requestDisplayMode
    */
@@ -299,7 +293,7 @@ interface UseWidgetResultBase<
    * When provided, the container is in *flexible* mode: the widget controls its
    * own height up to this ceiling. When omitted (undefined in raw host context),
    * height is unbounded. From `HostContext.containerDimensions.maxHeight`
-   * (SEP-1865) / `window.openai.maxHeight` (Apps SDK).
+   * (SEP-1865).
    *
    * Use this to cap scrollable lists or lazy-rendered content so the widget
    * doesn't overflow the host's layout.
@@ -309,9 +303,8 @@ interface UseWidgetResultBase<
   /**
    * Maximum width the widget container can grow to, in pixels.
    *
-   * Behaves the same as `maxHeight` but for the horizontal axis. Only provided
-   * by MCP Apps hosts (SEP-1865 `HostContext.containerDimensions.maxWidth`);
-   * the ChatGPT Apps SDK does not expose a max-width constraint.
+   * Behaves the same as `maxHeight` but for the horizontal axis. Provided by
+   * MCP Apps hosts through SEP-1865 `HostContext.containerDimensions.maxWidth`.
    * `undefined` when unbounded or unavailable.
    */
   maxWidth?: number;
@@ -322,8 +315,7 @@ interface UseWidgetResultBase<
    * Use `userAgent.device.type` (`"mobile"`, `"tablet"`, `"desktop"`) to adapt
    * layout density, and `userAgent.capabilities.hover` / `.touch` to decide
    * whether to show hover-only UI elements or touch-friendly hit targets.
-   * From `HostContext.platform` and `HostContext.deviceCapabilities` (SEP-1865)
-   * / `window.openai.userAgent` (Apps SDK).
+   * From `HostContext.platform` and `HostContext.deviceCapabilities` (SEP-1865).
    */
   userAgent: UserAgent;
 
@@ -333,7 +325,7 @@ interface UseWidgetResultBase<
    *
    * Use this to initialize `Intl` formatters, load the correct translation
    * bundle, or set the `lang` attribute on the root element. From
-   * `HostContext.locale` (SEP-1865) / `window.openai.locale` (Apps SDK).
+   * `HostContext.locale` (SEP-1865).
    */
   locale: string;
 
@@ -341,10 +333,9 @@ interface UseWidgetResultBase<
    * The user's timezone as an IANA identifier (e.g. `"America/New_York"`,
    * `"Europe/Paris"`).
    *
-   * Pass to `Intl.DateTimeFormat` when displaying local times. On ChatGPT the
-   * Apps SDK does not expose a timezone, so this falls back to the browser's
-   * own `Intl.DateTimeFormat().resolvedOptions().timeZone`. From
-   * `HostContext.timeZone` (SEP-1865).
+   * Pass to `Intl.DateTimeFormat` when displaying local times. From
+   * `HostContext.timeZone` (SEP-1865), with a browser timezone fallback when
+   * host context is not yet available.
    */
   timeZone: string;
 
@@ -383,9 +374,8 @@ interface UseWidgetResultBase<
   /**
    * Add a user-role message to the conversation and trigger a new model turn.
    *
-   * On MCP Apps, sends a `ui/message` request (SEP-1865) with
-   * `role: "user"`. On ChatGPT Apps SDK, calls
-   * `window.openai.sendFollowUpMessage`. The host may request user consent
+   * Sends a `ui/message` request (SEP-1865) with
+   * `role: "user"`. The host may request user consent
    * before adding the message.
    *
    * Use this to let the widget drive the conversation — for example, when the
@@ -399,8 +389,7 @@ interface UseWidgetResultBase<
   /**
    * Ask the host to open a URL in the user's default browser or a new tab.
    *
-   * On MCP Apps, sends a `ui/open-link` request (SEP-1865). On ChatGPT Apps
-   * SDK, calls `window.openai.openExternal`. The host may deny the request
+   * Sends a `ui/open-link` request (SEP-1865). The host may deny the request
    * (e.g. policy violation or invalid URL) — errors are logged but not thrown.
    */
   openExternal: (href: string) => void;
@@ -408,8 +397,7 @@ interface UseWidgetResultBase<
   /**
    * Request the host to change the widget's display mode.
    *
-   * Sends `ui/request-display-mode` (SEP-1865) /
-   * `window.openai.requestDisplayMode` (Apps SDK). The host returns the
+   * Sends `ui/request-display-mode` (SEP-1865). The host returns the
    * *actual* granted mode, which may differ from the requested one — always
    * check the response `mode` field. PiP (`"pip"`) is coerced to
    * `"fullscreen"` on mobile by the ChatGPT host.
@@ -426,8 +414,7 @@ interface UseWidgetResultBase<
   /**
    * Whether the widget runtime is connected and ready.
    *
-   * `true` when either `window.openai` (ChatGPT Apps SDK) or the MCP Apps
-   * `postMessage` bridge (SEP-1865) has successfully initialized. `false` while
+   * `true` when the MCP Apps `postMessage` bridge (SEP-1865) has initialized. `false` while
    * still connecting, or when the widget is rendered outside a supported host
    * (e.g. during local development via URL params).
    */
@@ -444,8 +431,7 @@ interface UseWidgetResultBase<
    * `null` when the LLM has finished generating arguments or when the host does
    * not support partial streaming.
    *
-   * Only available on MCP Apps hosts; always `null` on ChatGPT Apps SDK and URL
-   * params fallback.
+   * Only available on MCP Apps hosts; always `null` on the URL params fallback.
    *
    * @see isStreaming
    */
@@ -460,7 +446,8 @@ interface UseWidgetResultBase<
    *
    * Becomes `false` once `ui/notifications/tool-input` (the complete arguments)
    * is received. Only `true` on MCP Apps hosts that send
-   * `ui/notifications/tool-input-partial`; always `false` on ChatGPT Apps SDK.
+   * `ui/notifications/tool-input-partial`; always `false` on the URL params
+   * fallback.
    *
    * @see partialToolInput
    */
@@ -470,8 +457,7 @@ interface UseWidgetResultBase<
    * Name and version of the MCP Apps host as reported during the
    * `ui/initialize` handshake (SEP-1865).
    *
-   * `undefined` when running inside ChatGPT (Apps SDK path) or outside a
-   * supported MCP Apps host. Use this to conditionally tailor the UI for
+   * `undefined` when running outside a supported MCP Apps host. Use this to conditionally tailor the UI for
    * specific host environments.
    *
    * @example
@@ -486,8 +472,8 @@ interface UseWidgetResultBase<
    * Host capabilities advertised during the `ui/initialize` handshake
    * (SEP-1865 `HostCapabilities` object).
    *
-   * `undefined` when running inside ChatGPT (Apps SDK path), outside a
-   * supported MCP Apps host, or when the host did not include capabilities.
+   * `undefined` when running outside a supported MCP Apps host or when the
+   * host did not include capabilities.
    * Use this to check for optional host features such as `openLinks`,
    * `serverTools`, or `serverResources`.
    *
@@ -529,8 +515,7 @@ export type UseWidgetResult<
          * `true` while the tool is still executing.
          *
          * On MCP Apps, becomes `false` once `ui/notifications/tool-result` is
-         * received (SEP-1865). On ChatGPT Apps SDK, becomes `false` once
-         * `toolResponseMetadata` is non-null. While `true`, `props` is typed as
+         * received (SEP-1865). While `true`, `props` is typed as
          * `Partial<TProps>` — guard on this value before accessing required fields.
          */
         isPending: true;
@@ -538,7 +523,7 @@ export type UseWidgetResult<
          * Widget props — partial while the tool is still executing.
          *
          * Populated from `structuredContent` in the tool result (delivered via
-         * `ui/notifications/tool-result` / `window.openai.toolOutput`). Fields
+         * `ui/notifications/tool-result`). Fields
          * may be `undefined` until the tool completes. Guard on `isPending` to
          * narrow the type to the full `TProps` shape.
          */

--- a/libraries/typescript/packages/mcp-use/tests/unit/react/host-styles.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/react/host-styles.test.ts
@@ -35,9 +35,8 @@ vi.mock("../../../src/react/mcp-apps-bridge.js", () => ({
 }));
 
 const { McpUseProvider } = await import("../../../src/react/McpUseProvider.js");
-const { _resetModelContextForTesting } = await import(
-  "../../../src/react/model-context.js"
-);
+const { _resetModelContextForTesting } =
+  await import("../../../src/react/model-context.js");
 
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
 

--- a/libraries/typescript/packages/mcp-use/tests/unit/react/host-styles.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/react/host-styles.test.ts
@@ -1,0 +1,180 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, create } from "react-test-renderer";
+
+const { bridge } = vi.hoisted(() => {
+  const bridge = {
+    connect: vi.fn(),
+    isConnected: vi.fn(),
+    getToolInput: vi.fn(),
+    getToolOutput: vi.fn(),
+    getToolResponseMetadata: vi.fn(),
+    getHostContext: vi.fn(),
+    getPartialToolInput: vi.fn(),
+    getHostInfo: vi.fn(),
+    getHostCapabilities: vi.fn(),
+    onToolInput: vi.fn(),
+    onToolInputPartial: vi.fn(),
+    onToolResult: vi.fn(),
+    onHostContextChange: vi.fn(),
+    callTool: vi.fn(),
+    sendMessage: vi.fn(),
+    openLink: vi.fn(),
+    requestDisplayMode: vi.fn(),
+    updateModelContext: vi.fn(),
+    sendSizeChanged: vi.fn(),
+  };
+
+  return { bridge };
+});
+
+vi.mock("../../../src/react/mcp-apps-bridge.js", () => ({
+  getMcpAppsBridge: () => bridge,
+}));
+
+const { McpUseProvider } = await import("../../../src/react/McpUseProvider.js");
+const { _resetModelContextForTesting } = await import(
+  "../../../src/react/model-context.js"
+);
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+const originalParent = window.parent;
+const iframeParent = { postMessage: vi.fn() };
+
+async function flushMicrotasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function renderProvider() {
+  return create(
+    React.createElement(
+      McpUseProvider,
+      { autoSize: false },
+      React.createElement("div", null, "content")
+    )
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  _resetModelContextForTesting();
+
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn().mockReturnValue({
+      matches: false,
+      media: "",
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })
+  );
+
+  Object.defineProperty(window, "parent", {
+    configurable: true,
+    value: iframeParent,
+  });
+
+  bridge.connect.mockResolvedValue(undefined);
+  bridge.isConnected.mockReturnValue(true);
+  bridge.getToolInput.mockReturnValue(null);
+  bridge.getToolOutput.mockReturnValue(null);
+  bridge.getToolResponseMetadata.mockReturnValue(null);
+  bridge.getHostContext.mockReturnValue({
+    theme: "dark",
+    displayMode: "fullscreen",
+    styles: {
+      variables: {
+        "--color-background-primary": "transparent",
+        "--color-background-secondary": "rgb(12 13 14)",
+        "--color-background-tertiary": undefined,
+        "--color-text-primary": "rgb(250 250 250)",
+        color: "red",
+      },
+    },
+  });
+  bridge.getPartialToolInput.mockReturnValue(null);
+  bridge.getHostInfo.mockReturnValue(null);
+  bridge.getHostCapabilities.mockReturnValue(null);
+  bridge.onToolInput.mockReturnValue(() => undefined);
+  bridge.onToolInputPartial.mockReturnValue(() => undefined);
+  bridge.onToolResult.mockReturnValue(() => undefined);
+  bridge.onHostContextChange.mockReturnValue(() => undefined);
+  bridge.updateModelContext.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  _resetModelContextForTesting();
+  Object.defineProperty(window, "parent", {
+    configurable: true,
+    value: originalParent,
+  });
+  vi.unstubAllGlobals();
+  document.documentElement.removeAttribute("style");
+  document.documentElement.removeAttribute("data-theme");
+  document.documentElement.classList.remove("light", "dark");
+});
+
+describe("host styles", () => {
+  it("applies host context CSS variables through McpUseProvider", async () => {
+    await act(async () => {
+      renderProvider();
+      await flushMicrotasks();
+    });
+
+    expect(
+      document.documentElement.style.getPropertyValue(
+        "--color-background-secondary"
+      )
+    ).toBe("rgb(12 13 14)");
+    expect(
+      document.documentElement.style.getPropertyValue(
+        "--color-background-primary"
+      )
+    ).toBe("transparent");
+    expect(
+      document.documentElement.style.getPropertyValue(
+        "--color-background-tertiary"
+      )
+    ).toBe("");
+    expect(document.documentElement.style.getPropertyValue("color")).toBe("");
+    expect(document.documentElement.style.colorScheme).toBe("dark");
+  });
+
+  it("uses system dark preference when MCP Apps host context omits theme", async () => {
+    vi.mocked(window.matchMedia).mockReturnValue({
+      matches: true,
+      media: "(prefers-color-scheme: dark)",
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    });
+    bridge.getHostContext.mockReturnValue({
+      displayMode: "inline",
+      styles: {
+        variables: {
+          "--color-background-secondary": "light-dark(white, black)",
+        },
+      },
+    });
+
+    await act(async () => {
+      renderProvider();
+      await flushMicrotasks();
+    });
+
+    expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(document.documentElement.style.colorScheme).toBe("dark");
+  });
+});

--- a/libraries/typescript/packages/mcp-use/tests/unit/react/mcp-apps-primary-runtime.test.tsx
+++ b/libraries/typescript/packages/mcp-use/tests/unit/react/mcp-apps-primary-runtime.test.tsx
@@ -1,0 +1,249 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, create } from "react-test-renderer";
+
+const { bridge } = vi.hoisted(() => {
+  const bridge = {
+    connect: vi.fn(),
+    isConnected: vi.fn(),
+    getToolInput: vi.fn(),
+    getToolOutput: vi.fn(),
+    getToolResponseMetadata: vi.fn(),
+    getHostContext: vi.fn(),
+    getPartialToolInput: vi.fn(),
+    getHostInfo: vi.fn(),
+    getHostCapabilities: vi.fn(),
+    onToolInput: vi.fn(),
+    onToolInputPartial: vi.fn(),
+    onToolResult: vi.fn(),
+    onHostContextChange: vi.fn(),
+    callTool: vi.fn(),
+    sendMessage: vi.fn(),
+    openLink: vi.fn(),
+    requestDisplayMode: vi.fn(),
+    updateModelContext: vi.fn(),
+    sendSizeChanged: vi.fn(),
+  };
+
+  return { bridge };
+});
+
+vi.mock("../../../src/react/mcp-apps-bridge.js", () => ({
+  getMcpAppsBridge: () => bridge,
+}));
+
+const { useWidget } = await import("../../../src/react/useWidget.js");
+const { useCallTool } = await import("../../../src/react/useCallTool.js");
+const { McpUseProvider } = await import(
+  "../../../src/react/McpUseProvider.js"
+);
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+const originalParent = window.parent;
+const iframeParent = { postMessage: vi.fn() };
+
+function makeOpenAiMock() {
+  return {
+    toolInput: { source: "openai-input" },
+    toolOutput: { source: "openai-output" },
+    toolResponseMetadata: { source: "openai-meta" },
+    widgetState: null,
+    theme: "light",
+    displayMode: "inline",
+    maxHeight: 111,
+    locale: "en-US",
+    safeArea: { insets: { top: 0, right: 0, bottom: 0, left: 0 } },
+    userAgent: {
+      device: { type: "desktop" },
+      capabilities: { hover: true, touch: false },
+    },
+    callTool: vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: "openai" }],
+      structuredContent: { source: "openai-call" },
+    }),
+    sendFollowUpMessage: vi.fn().mockResolvedValue(undefined),
+    openExternal: vi.fn(),
+    requestDisplayMode: vi.fn().mockResolvedValue({ mode: "fullscreen" }),
+    setWidgetState: vi.fn().mockResolvedValue(undefined),
+    notifyIntrinsicHeight: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+async function flushMicrotasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn().mockReturnValue({
+      matches: false,
+      media: "",
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })
+  );
+
+  Object.defineProperty(window, "parent", {
+    configurable: true,
+    value: iframeParent,
+  });
+  window.openai = makeOpenAiMock() as any;
+
+  bridge.connect.mockResolvedValue(undefined);
+  bridge.isConnected.mockReturnValue(true);
+  bridge.getToolInput.mockReturnValue({ source: "mcp-input" });
+  bridge.getToolOutput.mockReturnValue({ source: "mcp-output" });
+  bridge.getToolResponseMetadata.mockReturnValue({ source: "mcp-meta" });
+  bridge.getHostContext.mockReturnValue({
+    theme: "dark",
+    displayMode: "fullscreen",
+    locale: "fr-FR",
+    timeZone: "Europe/Paris",
+    platform: "mobile",
+    containerDimensions: { maxHeight: 444, maxWidth: 333 },
+    safeAreaInsets: { top: 1, right: 2, bottom: 3, left: 4 },
+    deviceCapabilities: { hover: false, touch: true },
+  });
+  bridge.getPartialToolInput.mockReturnValue(null);
+  bridge.getHostInfo.mockReturnValue({ name: "chatgpt", version: "1.0.0" });
+  bridge.getHostCapabilities.mockReturnValue({ openLinks: true });
+  bridge.onToolInput.mockReturnValue(() => undefined);
+  bridge.onToolInputPartial.mockReturnValue(() => undefined);
+  bridge.onToolResult.mockReturnValue(() => undefined);
+  bridge.onHostContextChange.mockReturnValue(() => undefined);
+  bridge.callTool.mockResolvedValue({
+    content: [{ type: "text", text: "mcp" }],
+    structuredContent: { source: "mcp-call" },
+  });
+  bridge.sendMessage.mockResolvedValue(undefined);
+  bridge.openLink.mockResolvedValue(undefined);
+  bridge.requestDisplayMode.mockResolvedValue({ mode: "fullscreen" });
+  bridge.updateModelContext.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  Object.defineProperty(window, "parent", {
+    configurable: true,
+    value: originalParent,
+  });
+  delete (window as any).openai;
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe("MCP Apps primary widget runtime", () => {
+  it("uses MCP Apps data and actions when ChatGPT also exposes window.openai", async () => {
+    let latest: ReturnType<typeof useWidget> | undefined;
+
+    function TestComponent() {
+      latest = useWidget();
+      return null;
+    }
+
+    await act(async () => {
+      create(<TestComponent />);
+      await flushMicrotasks();
+    });
+
+    expect(bridge.connect).toHaveBeenCalledOnce();
+    expect(latest?.props).toEqual({ source: "mcp-output" });
+    expect(latest?.toolInput).toEqual({ source: "mcp-input" });
+    expect(latest?.metadata).toEqual({ source: "mcp-meta" });
+    expect(latest?.theme).toBe("dark");
+    expect(latest?.displayMode).toBe("fullscreen");
+    expect(latest?.locale).toBe("fr-FR");
+    expect(latest?.timeZone).toBe("Europe/Paris");
+    expect(latest?.maxHeight).toBe(444);
+    expect(latest?.maxWidth).toBe(333);
+    expect(latest?.hostInfo).toEqual({ name: "chatgpt", version: "1.0.0" });
+    expect(latest?.hostCapabilities).toEqual({ openLinks: true });
+
+    await act(async () => {
+      await latest!.callTool("lookup", { id: 1 });
+      await latest!.setState({ selected: "mcp" });
+    });
+
+    expect(bridge.callTool).toHaveBeenCalledWith("lookup", { id: 1 });
+    expect(window.openai?.callTool).not.toHaveBeenCalled();
+    expect(bridge.updateModelContext).toHaveBeenCalledWith({
+      structuredContent: { selected: "mcp" },
+      content: [{ type: "text", text: "{\"selected\":\"mcp\"}" }],
+    });
+    expect(window.openai?.setWidgetState).not.toHaveBeenCalled();
+  });
+
+  it("routes useCallTool through the MCP Apps bridge before window.openai", async () => {
+    let latest: ReturnType<typeof useCallTool> | undefined;
+
+    function TestComponent() {
+      latest = useCallTool("lookup");
+      return null;
+    }
+
+    await act(async () => {
+      create(<TestComponent />);
+    });
+
+    await act(async () => {
+      await latest!.callToolAsync({ id: 2 });
+    });
+
+    expect(bridge.callTool).toHaveBeenCalledWith("lookup", { id: 2 });
+    expect(window.openai?.callTool).not.toHaveBeenCalled();
+  });
+
+  it("sends autosize notifications over MCP Apps instead of window.openai", async () => {
+    vi.useFakeTimers();
+
+    let resizeCallback: ResizeObserverCallback | undefined;
+
+    class MockResizeObserver {
+      observe = vi.fn();
+      disconnect = vi.fn();
+
+      constructor(callback: ResizeObserverCallback) {
+        resizeCallback = callback;
+      }
+    }
+
+    vi.stubGlobal("ResizeObserver", MockResizeObserver);
+    const containerNode = { scrollHeight: 260 };
+
+    await act(async () => {
+      create(
+        <McpUseProvider autoSize>
+          <div>content</div>
+        </McpUseProvider>,
+        {
+          createNodeMock: (element) =>
+            element.type === "div" ? containerNode : null,
+        }
+      );
+      await flushMicrotasks();
+    });
+
+    await act(async () => {
+      resizeCallback?.([
+        {
+          contentRect: { height: 240 },
+          target: { scrollHeight: 260 },
+        },
+      ] as ResizeObserverEntry[], {} as ResizeObserver);
+      vi.advanceTimersByTime(150);
+    });
+
+    expect(bridge.sendSizeChanged).toHaveBeenCalledWith({ height: 260 });
+    expect(window.openai?.notifyIntrinsicHeight).not.toHaveBeenCalled();
+  });
+});

--- a/libraries/typescript/packages/mcp-use/tests/unit/react/mcp-apps-primary-runtime.test.tsx
+++ b/libraries/typescript/packages/mcp-use/tests/unit/react/mcp-apps-primary-runtime.test.tsx
@@ -116,7 +116,9 @@ beforeEach(() => {
       variables: {
         "--color-background-primary": "transparent",
         "--color-background-secondary": "rgb(12 13 14)",
+        "--color-background-tertiary": undefined,
         "--color-text-primary": "rgb(250 250 250)",
+        color: "red",
       },
     },
   });
@@ -276,5 +278,12 @@ describe("MCP Apps primary widget runtime", () => {
         "--color-background-primary"
       )
     ).toBe("transparent");
+    expect(
+      document.documentElement.style.getPropertyValue(
+        "--color-background-tertiary"
+      )
+    ).toBe("");
+    expect(document.documentElement.style.getPropertyValue("color")).toBe("");
+    expect(document.documentElement.style.colorScheme).toBe("dark");
   });
 });

--- a/libraries/typescript/packages/mcp-use/tests/unit/react/mcp-apps-primary-runtime.test.tsx
+++ b/libraries/typescript/packages/mcp-use/tests/unit/react/mcp-apps-primary-runtime.test.tsx
@@ -37,9 +37,8 @@ vi.mock("../../../src/react/mcp-apps-bridge.js", () => ({
 const { useWidget } = await import("../../../src/react/useWidget.js");
 const { useCallTool } = await import("../../../src/react/useCallTool.js");
 const { McpUseProvider } = await import("../../../src/react/McpUseProvider.js");
-const { ModelContext, _resetModelContextForTesting } = await import(
-  "../../../src/react/model-context.js"
-);
+const { ModelContext, _resetModelContextForTesting } =
+  await import("../../../src/react/model-context.js");
 
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
 

--- a/libraries/typescript/packages/mcp-use/tests/unit/react/mcp-apps-primary-runtime.test.tsx
+++ b/libraries/typescript/packages/mcp-use/tests/unit/react/mcp-apps-primary-runtime.test.tsx
@@ -36,9 +36,7 @@ vi.mock("../../../src/react/mcp-apps-bridge.js", () => ({
 
 const { useWidget } = await import("../../../src/react/useWidget.js");
 const { useCallTool } = await import("../../../src/react/useCallTool.js");
-const { McpUseProvider } = await import(
-  "../../../src/react/McpUseProvider.js"
-);
+const { McpUseProvider } = await import("../../../src/react/McpUseProvider.js");
 
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -178,7 +176,7 @@ describe("MCP Apps primary widget runtime", () => {
     expect(window.openai?.callTool).not.toHaveBeenCalled();
     expect(bridge.updateModelContext).toHaveBeenCalledWith({
       structuredContent: { selected: "mcp" },
-      content: [{ type: "text", text: "{\"selected\":\"mcp\"}" }],
+      content: [{ type: "text", text: '{"selected":"mcp"}' }],
     });
     expect(window.openai?.setWidgetState).not.toHaveBeenCalled();
   });
@@ -234,12 +232,15 @@ describe("MCP Apps primary widget runtime", () => {
     });
 
     await act(async () => {
-      resizeCallback?.([
-        {
-          contentRect: { height: 240 },
-          target: { scrollHeight: 260 },
-        },
-      ] as ResizeObserverEntry[], {} as ResizeObserver);
+      resizeCallback?.(
+        [
+          {
+            contentRect: { height: 240 },
+            target: { scrollHeight: 260 },
+          },
+        ] as ResizeObserverEntry[],
+        {} as ResizeObserver
+      );
       vi.advanceTimersByTime(150);
     });
 

--- a/libraries/typescript/packages/mcp-use/tests/unit/react/mcp-apps-primary-runtime.test.tsx
+++ b/libraries/typescript/packages/mcp-use/tests/unit/react/mcp-apps-primary-runtime.test.tsx
@@ -112,6 +112,13 @@ beforeEach(() => {
     containerDimensions: { maxHeight: 444, maxWidth: 333 },
     safeAreaInsets: { top: 1, right: 2, bottom: 3, left: 4 },
     deviceCapabilities: { hover: false, touch: true },
+    styles: {
+      variables: {
+        "--color-background-primary": "transparent",
+        "--color-background-secondary": "rgb(12 13 14)",
+        "--color-text-primary": "rgb(250 250 250)",
+      },
+    },
   });
   bridge.getPartialToolInput.mockReturnValue(null);
   bridge.getHostInfo.mockReturnValue({ name: "chatgpt", version: "1.0.0" });
@@ -138,6 +145,7 @@ afterEach(() => {
   delete (window as any).openai;
   vi.unstubAllGlobals();
   vi.useRealTimers();
+  document.documentElement.removeAttribute("style");
 });
 
 describe("MCP Apps primary widget runtime", () => {
@@ -246,5 +254,27 @@ describe("MCP Apps primary widget runtime", () => {
 
     expect(bridge.sendSizeChanged).toHaveBeenCalledWith({ height: 260 });
     expect(window.openai?.notifyIntrinsicHeight).not.toHaveBeenCalled();
+  });
+
+  it("applies host context CSS variables through McpUseProvider", async () => {
+    await act(async () => {
+      create(
+        <McpUseProvider>
+          <div>content</div>
+        </McpUseProvider>
+      );
+      await flushMicrotasks();
+    });
+
+    expect(
+      document.documentElement.style.getPropertyValue(
+        "--color-background-secondary"
+      )
+    ).toBe("rgb(12 13 14)");
+    expect(
+      document.documentElement.style.getPropertyValue(
+        "--color-background-primary"
+      )
+    ).toBe("transparent");
   });
 });

--- a/libraries/typescript/packages/mcp-use/tests/unit/react/mcp-apps-primary-runtime.test.tsx
+++ b/libraries/typescript/packages/mcp-use/tests/unit/react/mcp-apps-primary-runtime.test.tsx
@@ -286,4 +286,38 @@ describe("MCP Apps primary widget runtime", () => {
     expect(document.documentElement.style.getPropertyValue("color")).toBe("");
     expect(document.documentElement.style.colorScheme).toBe("dark");
   });
+
+  it("uses system dark preference when MCP Apps host context omits theme", async () => {
+    vi.mocked(window.matchMedia).mockReturnValue({
+      matches: true,
+      media: "(prefers-color-scheme: dark)",
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    });
+    bridge.getHostContext.mockReturnValue({
+      displayMode: "inline",
+      styles: {
+        variables: {
+          "--color-background-secondary": "light-dark(white, black)",
+        },
+      },
+    });
+
+    await act(async () => {
+      create(
+        <McpUseProvider>
+          <div>content</div>
+        </McpUseProvider>
+      );
+      await flushMicrotasks();
+    });
+
+    expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(document.documentElement.style.colorScheme).toBe("dark");
+  });
 });

--- a/libraries/typescript/packages/mcp-use/tests/unit/react/mcp-apps-primary-runtime.test.tsx
+++ b/libraries/typescript/packages/mcp-use/tests/unit/react/mcp-apps-primary-runtime.test.tsx
@@ -37,6 +37,9 @@ vi.mock("../../../src/react/mcp-apps-bridge.js", () => ({
 const { useWidget } = await import("../../../src/react/useWidget.js");
 const { useCallTool } = await import("../../../src/react/useCallTool.js");
 const { McpUseProvider } = await import("../../../src/react/McpUseProvider.js");
+const { ModelContext, _resetModelContextForTesting } = await import(
+  "../../../src/react/model-context.js"
+);
 
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -77,6 +80,7 @@ async function flushMicrotasks() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  _resetModelContextForTesting();
 
   vi.stubGlobal(
     "matchMedia",
@@ -140,6 +144,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  _resetModelContextForTesting();
   Object.defineProperty(window, "parent", {
     configurable: true,
     value: originalParent,
@@ -189,6 +194,46 @@ describe("MCP Apps primary widget runtime", () => {
       content: [{ type: "text", text: '{"selected":"mcp"}' }],
     });
     expect(window.openai?.setWidgetState).not.toHaveBeenCalled();
+  });
+
+  it("preserves ModelContext annotations when widget state is overwritten", async () => {
+    let latest: ReturnType<typeof useWidget> | undefined;
+
+    function TestComponent() {
+      latest = useWidget();
+      return <ModelContext content="Viewing product A" />;
+    }
+
+    await act(async () => {
+      create(<TestComponent />);
+      await flushMicrotasks();
+    });
+
+    expect(bridge.updateModelContext).toHaveBeenCalledWith({
+      structuredContent: {
+        __model_context: "- Viewing product A",
+      },
+      content: [{ type: "text", text: "- Viewing product A" }],
+    });
+
+    bridge.updateModelContext.mockClear();
+
+    await act(async () => {
+      await latest!.setState({ selectedTab: "reviews" });
+    });
+
+    expect(bridge.updateModelContext).toHaveBeenCalledWith({
+      structuredContent: {
+        selectedTab: "reviews",
+        __model_context: "- Viewing product A",
+      },
+      content: [
+        {
+          type: "text",
+          text: '- Viewing product A\n\nState: {"selectedTab":"reviews"}',
+        },
+      ],
+    });
   });
 
   it("routes useCallTool through the MCP Apps bridge before window.openai", async () => {

--- a/libraries/typescript/packages/mcp-use/tests/unit/react/mcp-apps-primary-runtime.test.tsx
+++ b/libraries/typescript/packages/mcp-use/tests/unit/react/mcp-apps-primary-runtime.test.tsx
@@ -153,6 +153,8 @@ afterEach(() => {
   vi.unstubAllGlobals();
   vi.useRealTimers();
   document.documentElement.removeAttribute("style");
+  document.documentElement.removeAttribute("data-theme");
+  document.documentElement.classList.remove("light", "dark");
 });
 
 describe("MCP Apps primary widget runtime", () => {
@@ -301,68 +303,5 @@ describe("MCP Apps primary widget runtime", () => {
 
     expect(bridge.sendSizeChanged).toHaveBeenCalledWith({ height: 260 });
     expect(window.openai?.notifyIntrinsicHeight).not.toHaveBeenCalled();
-  });
-
-  it("applies host context CSS variables through McpUseProvider", async () => {
-    await act(async () => {
-      create(
-        <McpUseProvider>
-          <div>content</div>
-        </McpUseProvider>
-      );
-      await flushMicrotasks();
-    });
-
-    expect(
-      document.documentElement.style.getPropertyValue(
-        "--color-background-secondary"
-      )
-    ).toBe("rgb(12 13 14)");
-    expect(
-      document.documentElement.style.getPropertyValue(
-        "--color-background-primary"
-      )
-    ).toBe("transparent");
-    expect(
-      document.documentElement.style.getPropertyValue(
-        "--color-background-tertiary"
-      )
-    ).toBe("");
-    expect(document.documentElement.style.getPropertyValue("color")).toBe("");
-    expect(document.documentElement.style.colorScheme).toBe("dark");
-  });
-
-  it("uses system dark preference when MCP Apps host context omits theme", async () => {
-    vi.mocked(window.matchMedia).mockReturnValue({
-      matches: true,
-      media: "(prefers-color-scheme: dark)",
-      onchange: null,
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-    });
-    bridge.getHostContext.mockReturnValue({
-      displayMode: "inline",
-      styles: {
-        variables: {
-          "--color-background-secondary": "light-dark(white, black)",
-        },
-      },
-    });
-
-    await act(async () => {
-      create(
-        <McpUseProvider>
-          <div>content</div>
-        </McpUseProvider>
-      );
-      await flushMicrotasks();
-    });
-
-    expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
-    expect(document.documentElement.classList.contains("dark")).toBe(true);
-    expect(document.documentElement.style.colorScheme).toBe("dark");
   });
 });


### PR DESCRIPTION
## Summary

- Treat MCP Apps as the primary widget runtime in iframes, even when ChatGPT also exposes `window.openai`.
- Route widget data, actions, tool calls, model-context updates, and autosize through the MCP Apps bridge.
- Keep `useFiles` on the OpenAI `window.openai` extension APIs for upload/download support.
- Add a patch changeset and a regression test covering the dual-bridge ChatGPT case.

## Validation

- `pnpm --dir libraries/typescript/packages/mcp-use exec vitest run tests/unit/react`
- `pnpm --dir libraries/typescript/packages/mcp-use exec tsc --noEmit --pretty false`
- `git diff --cached --check`
