### PR TITLE
Apply MCP Apps host style variables

### DIFF
--- a/libraries/typescript/packages/inspector/src/client/hooks/useMcpAppsHostContext.ts
+++ b/libraries/typescript/packages/inspector/src/client/hooks/useMcpAppsHostContext.ts
@@ -24,6 +24,64 @@ interface HostContextParams {
   tool?: Tool; // Full Tool object from MCP SDK
 }
 
+function readCssVar(styles: CSSStyleDeclaration, name: string): string {
+  return styles.getPropertyValue(name).trim();
+}
+
+function buildHostStyleVariables(): Record<string, string> {
+  if (typeof window === "undefined") return {};
+
+  const styles = getComputedStyle(document.documentElement);
+  const variables: Record<string, string> = {};
+  const add = (name: string, value: string) => {
+    if (value) variables[name] = value;
+  };
+
+  const background = readCssVar(styles, "--background");
+  const foreground = readCssVar(styles, "--foreground");
+  const card = readCssVar(styles, "--card");
+  const muted = readCssVar(styles, "--muted");
+  const mutedForeground = readCssVar(styles, "--muted-foreground");
+  const primary = readCssVar(styles, "--primary");
+  const primaryForeground = readCssVar(styles, "--primary-foreground");
+  const secondary = readCssVar(styles, "--secondary");
+  const accent = readCssVar(styles, "--accent");
+  const accentForeground = readCssVar(styles, "--accent-foreground");
+  const destructive = readCssVar(styles, "--destructive");
+  const border = readCssVar(styles, "--border");
+  const ring = readCssVar(styles, "--ring");
+  const radius = readCssVar(styles, "--radius");
+
+  add("--color-background-primary", background);
+  add("--color-background-secondary", card || secondary);
+  add("--color-background-tertiary", muted || accent);
+  add("--color-background-inverse", primary);
+  add("--color-background-ghost", accent || muted);
+  add("--color-background-danger", destructive);
+
+  add("--color-text-primary", foreground);
+  add("--color-text-secondary", mutedForeground);
+  add("--color-text-tertiary", mutedForeground);
+  add("--color-text-inverse", primaryForeground);
+  add("--color-text-ghost", accentForeground || mutedForeground);
+  add("--color-text-danger", destructive);
+
+  add("--color-border-primary", border);
+  add("--color-border-secondary", border);
+  add("--color-border-tertiary", border);
+  add("--color-ring-primary", ring || border);
+
+  add("--border-radius-sm", radius);
+  add("--border-radius-md", radius);
+  add("--border-radius-lg", radius);
+  add(
+    "--font-sans",
+    "system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif"
+  );
+
+  return variables;
+}
+
 /**
  * Build SEP-1865 compliant host context for MCP Apps
  */
@@ -53,7 +111,7 @@ export function useMcpAppsHostContext({
       userAgent: "mcp-use-inspector/0.16.2",
       deviceCapabilities: playground.capabilities,
       safeAreaInsets: playground.safeAreaInsets,
-      styles: { variables: {} as any },
+      styles: { variables: buildHostStyleVariables() as any },
       toolInfo: tool
         ? {
             id: toolCallId,

--- a/libraries/typescript/packages/mcp-use/src/react/McpUseProvider.tsx
+++ b/libraries/typescript/packages/mcp-use/src/react/McpUseProvider.tsx
@@ -40,11 +40,9 @@ interface McpUseProviderProps {
    * Set color-scheme on the document root to match the active theme.
    * Enables native dark scrollbars and CSS light-dark() function.
    *
-   * Leave disabled (default) when you want a transparent iframe background.
-   * Setting color-scheme to an explicit value ("dark"/"light") causes browsers
-   * to paint an opaque canvas behind iframes when the widget and host documents
-   * use different schemes, making background-color: transparent ineffective.
-   * @default false
+   * Disable only when you need the browser canvas to stay transparent in hosts
+   * that render widgets over a differently-themed background.
+   * @default true
    */
   colorScheme?: boolean;
 }
@@ -71,7 +69,7 @@ export function McpUseProvider({
   debugger: enableDebugger = false,
   viewControls = false,
   autoSize = true,
-  colorScheme = false,
+  colorScheme = true,
 }: McpUseProviderProps) {
   const [containerElement, setContainerElement] =
     useState<HTMLDivElement | null>(null);

--- a/libraries/typescript/packages/mcp-use/src/react/ThemeProvider.tsx
+++ b/libraries/typescript/packages/mcp-use/src/react/ThemeProvider.tsx
@@ -10,15 +10,14 @@ import { useWidget } from "./useWidget.js";
  * 2. System preference (prefers-color-scheme: dark)
  *
  * Sets the "dark" class and data-theme attribute on document.documentElement.
- * color-scheme is only set when the colorScheme prop is true — setting it to an
- * explicit value causes browsers to paint an opaque canvas behind iframes when
- * the widget and host documents use different schemes.
+ * color-scheme is set by default so host variables using CSS light-dark()
+ * resolve against the active host theme.
  */
 export const ThemeProvider: React.FC<{
   children: React.ReactNode;
   colorScheme?: boolean;
-}> = ({ children, colorScheme = false }) => {
-  const { theme, isAvailable, hostContext, hostInfo } = useWidget();
+}> = ({ children, colorScheme = true }) => {
+  const { theme, isAvailable, hostContext } = useWidget();
   const [systemPreference, setSystemPreference] = useState<"light" | "dark">(
     () => {
       if (typeof window === "undefined") return "light";
@@ -62,10 +61,6 @@ export const ThemeProvider: React.FC<{
       effectiveTheme === "dark" ? "dark" : "light"
     );
 
-    // Only set color-scheme when explicitly opted in via the colorScheme prop.
-    // Setting it to "dark"/"light" triggers browsers to paint an opaque canvas
-    // behind iframes when the widget scheme differs from the host scheme, which
-    // makes background-color: transparent ineffective.
     if (colorScheme) {
       root.style.colorScheme = effectiveTheme === "dark" ? "dark" : "light";
     } else {
@@ -74,11 +69,8 @@ export const ThemeProvider: React.FC<{
   }, [effectiveTheme, colorScheme]);
 
   useLayoutEffect(() => {
-    applyHostStyleVariables(hostContext, {
-      source: "ThemeProvider",
-      hostName: hostInfo?.name,
-    });
-  }, [hostContext, hostInfo?.name]);
+    applyHostStyleVariables(hostContext?.styles?.variables);
+  }, [hostContext]);
 
   return <>{children}</>;
 };

--- a/libraries/typescript/packages/mcp-use/src/react/ThemeProvider.tsx
+++ b/libraries/typescript/packages/mcp-use/src/react/ThemeProvider.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useLayoutEffect, useState } from "react";
+import { applyHostStyleVariables } from "./host-styles.js";
 import { useWidget } from "./useWidget.js";
 
 /**
@@ -17,7 +18,7 @@ export const ThemeProvider: React.FC<{
   children: React.ReactNode;
   colorScheme?: boolean;
 }> = ({ children, colorScheme = false }) => {
-  const { theme, isAvailable } = useWidget();
+  const { theme, isAvailable, hostContext, hostInfo } = useWidget();
   const [systemPreference, setSystemPreference] = useState<"light" | "dark">(
     () => {
       if (typeof window === "undefined") return "light";
@@ -71,6 +72,13 @@ export const ThemeProvider: React.FC<{
       root.style.colorScheme = "";
     }
   }, [effectiveTheme, colorScheme]);
+
+  useLayoutEffect(() => {
+    applyHostStyleVariables(hostContext, {
+      source: "ThemeProvider",
+      hostName: hostInfo?.name,
+    });
+  }, [hostContext, hostInfo?.name]);
 
   return <>{children}</>;
 };

--- a/libraries/typescript/packages/mcp-use/src/react/host-styles.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/host-styles.ts
@@ -1,0 +1,45 @@
+import type { HostContext } from "./widget-types.js";
+
+const CUSTOM_PROPERTY_NAME = /^--[A-Za-z0-9_-]+$/;
+
+export function applyHostStyleVariables(
+  hostContext: HostContext | undefined,
+  options?: { source?: string; hostName?: string }
+): void {
+  if (typeof document === "undefined" || !hostContext) return;
+
+  const variables = hostContext?.styles?.variables;
+  const entries = variables ? Object.entries(variables) : [];
+  const root = document.documentElement;
+  const applied: Record<string, string> = {};
+  const skipped: Record<string, string> = {};
+
+  for (const [name, value] of entries) {
+    if (!CUSTOM_PROPERTY_NAME.test(name)) {
+      skipped[name] = value;
+      continue;
+    }
+
+    root.style.setProperty(name, value);
+    applied[name] = root.style.getPropertyValue(name);
+  }
+
+  const computed = Object.fromEntries(
+    Object.keys(applied).map((name) => [
+      name,
+      getComputedStyle(root).getPropertyValue(name),
+    ])
+  );
+
+  console.log("[mcp-use host context]", {
+    source: options?.source ?? "theme-provider",
+    hostName: options?.hostName,
+    variableCount: entries.length,
+    hostContext: hostContext ?? null,
+    applied,
+    skipped,
+    computed,
+    documentTheme: root.getAttribute("data-theme"),
+    documentClass: root.className,
+  });
+}

--- a/libraries/typescript/packages/mcp-use/src/react/host-styles.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/host-styles.ts
@@ -1,45 +1,19 @@
-import type { HostContext } from "./widget-types.js";
-
 const CUSTOM_PROPERTY_NAME = /^--[A-Za-z0-9_-]+$/;
 
 export function applyHostStyleVariables(
-  hostContext: HostContext | undefined,
-  options?: { source?: string; hostName?: string }
+  variables: Record<string, string | undefined> | undefined,
+  root?: HTMLElement
 ): void {
-  if (typeof document === "undefined" || !hostContext) return;
+  if (typeof document === "undefined" || !variables) return;
 
-  const variables = hostContext?.styles?.variables;
-  const entries = variables ? Object.entries(variables) : [];
-  const root = document.documentElement;
-  const applied: Record<string, string> = {};
-  const skipped: Record<string, string> = {};
+  const target = root ?? document.documentElement;
 
-  for (const [name, value] of entries) {
+  for (const [name, value] of Object.entries(variables)) {
+    if (value === undefined) continue;
     if (!CUSTOM_PROPERTY_NAME.test(name)) {
-      skipped[name] = value;
       continue;
     }
 
-    root.style.setProperty(name, value);
-    applied[name] = root.style.getPropertyValue(name);
+    target.style.setProperty(name, value);
   }
-
-  const computed = Object.fromEntries(
-    Object.keys(applied).map((name) => [
-      name,
-      getComputedStyle(root).getPropertyValue(name),
-    ])
-  );
-
-  console.log("[mcp-use host context]", {
-    source: options?.source ?? "theme-provider",
-    hostName: options?.hostName,
-    variableCount: entries.length,
-    hostContext: hostContext ?? null,
-    applied,
-    skipped,
-    computed,
-    documentTheme: root.getAttribute("data-theme"),
-    documentClass: root.className,
-  });
 }

--- a/libraries/typescript/packages/mcp-use/src/react/mcp-apps-bridge.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/mcp-apps-bridge.ts
@@ -14,8 +14,8 @@ import {
 import { MCP_APPS_BRIDGE_CONFIG } from "./constants.js";
 import type {
   DisplayMode,
+  HostContext,
   MessageContentBlock,
-  Theme,
 } from "./widget-types.js";
 
 // JSON-RPC message types (using imported types with compatible names)
@@ -23,38 +23,6 @@ type JSONRPCRequest = JsonRpcRequest;
 type JSONRPCResponse = JsonRpcResponse | JsonRpcError;
 type JSONRPCNotification = JsonRpcNotification;
 type JSONRPCMessage = JSONRPCRequest | JSONRPCResponse | JSONRPCNotification;
-
-// Host context from ui/initialize response
-interface HostContext {
-  theme?: Theme;
-  displayMode?: DisplayMode;
-  containerDimensions?: {
-    width?: number;
-    height?: number;
-    maxWidth?: number;
-    maxHeight?: number;
-  };
-  locale?: string;
-  timeZone?: string;
-  platform?: "web" | "desktop" | "mobile";
-  userAgent?: string;
-  deviceCapabilities?: {
-    touch?: boolean;
-    hover?: boolean;
-  };
-  safeAreaInsets?: {
-    top: number;
-    right: number;
-    bottom: number;
-    left: number;
-  };
-  styles?: {
-    variables?: Record<string, string>;
-    css?: {
-      fonts?: string;
-    };
-  };
-}
 
 interface McpUiInitializeResult {
   protocolVersion: string;

--- a/libraries/typescript/packages/mcp-use/src/react/useWidget.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/useWidget.ts
@@ -15,6 +15,7 @@ import {
 import type {
   CallToolResponse,
   DisplayMode,
+  HostContext,
   MessageContentBlock,
   SafeArea,
   Theme,
@@ -118,7 +119,8 @@ export function useWidget<
     string,
     unknown
   > | null>(null);
-  const [mcpAppsHostContext, setMcpAppsHostContext] = useState<any>(null);
+  const [mcpAppsHostContext, setMcpAppsHostContext] =
+    useState<HostContext | null>(null);
   const [mcpAppsHostInfo, setMcpAppsHostInfo] = useState<{
     name: string;
     version: string;
@@ -562,6 +564,7 @@ export function useWidget<
     // Host identity (MCP Apps only)
     hostInfo: mcpAppsHostInfo ?? undefined,
     hostCapabilities: mcpAppsHostCapabilities ?? undefined,
+    hostContext: mcpAppsHostContext ?? undefined,
   } as UseWidgetResult<TProps, TState, TOutput, TMetadata, TToolInput>;
 }
 

--- a/libraries/typescript/packages/mcp-use/src/react/widget-types.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/widget-types.ts
@@ -61,6 +61,34 @@ export type UserAgent = {
   };
 };
 
+export interface HostContext {
+  theme?: Theme;
+  displayMode?: DisplayMode;
+  availableDisplayModes?: DisplayMode[];
+  containerDimensions?: {
+    width?: number;
+    height?: number;
+    maxWidth?: number;
+    maxHeight?: number;
+  };
+  locale?: string;
+  timeZone?: string;
+  platform?: "web" | "desktop" | "mobile";
+  userAgent?: string;
+  deviceCapabilities?: {
+    touch?: boolean;
+    hover?: boolean;
+  };
+  safeAreaInsets?: SafeAreaInsets;
+  styles?: {
+    variables?: Record<string, string>;
+    css?: {
+      fonts?: string;
+    };
+  };
+  [key: string]: unknown;
+}
+
 export type CallToolResponse = {
   content: Array<{
     type: string;
@@ -471,6 +499,14 @@ interface UseWidgetResultBase<
    * ```
    */
   hostCapabilities?: Record<string, unknown>;
+
+  /**
+   * Raw host context received through the MCP Apps bridge.
+   *
+   * Includes standardized host style variables at
+   * `hostContext.styles.variables` when provided by the host.
+   */
+  hostContext?: HostContext;
 }
 
 /**

--- a/libraries/typescript/packages/mcp-use/src/react/widget-types.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/widget-types.ts
@@ -81,7 +81,7 @@ export interface HostContext {
   };
   safeAreaInsets?: SafeAreaInsets;
   styles?: {
-    variables?: Record<string, string>;
+    variables?: Record<string, string | undefined>;
     css?: {
       fonts?: string;
     };

--- a/libraries/typescript/packages/mcp-use/tests/unit/react/mcp-apps-primary-runtime.test.tsx
+++ b/libraries/typescript/packages/mcp-use/tests/unit/react/mcp-apps-primary-runtime.test.tsx
@@ -116,7 +116,9 @@ beforeEach(() => {
       variables: {
         "--color-background-primary": "transparent",
         "--color-background-secondary": "rgb(12 13 14)",
+        "--color-background-tertiary": undefined,
         "--color-text-primary": "rgb(250 250 250)",
+        color: "red",
       },
     },
   });
@@ -276,5 +278,12 @@ describe("MCP Apps primary widget runtime", () => {
         "--color-background-primary"
       )
     ).toBe("transparent");
+    expect(
+      document.documentElement.style.getPropertyValue(
+        "--color-background-tertiary"
+      )
+    ).toBe("");
+    expect(document.documentElement.style.getPropertyValue("color")).toBe("");
+    expect(document.documentElement.style.colorScheme).toBe("dark");
   });
 });

--- a/libraries/typescript/packages/mcp-use/tests/unit/react/mcp-apps-primary-runtime.test.tsx
+++ b/libraries/typescript/packages/mcp-use/tests/unit/react/mcp-apps-primary-runtime.test.tsx
@@ -112,6 +112,13 @@ beforeEach(() => {
     containerDimensions: { maxHeight: 444, maxWidth: 333 },
     safeAreaInsets: { top: 1, right: 2, bottom: 3, left: 4 },
     deviceCapabilities: { hover: false, touch: true },
+    styles: {
+      variables: {
+        "--color-background-primary": "transparent",
+        "--color-background-secondary": "rgb(12 13 14)",
+        "--color-text-primary": "rgb(250 250 250)",
+      },
+    },
   });
   bridge.getPartialToolInput.mockReturnValue(null);
   bridge.getHostInfo.mockReturnValue({ name: "chatgpt", version: "1.0.0" });
@@ -138,6 +145,7 @@ afterEach(() => {
   delete (window as any).openai;
   vi.unstubAllGlobals();
   vi.useRealTimers();
+  document.documentElement.removeAttribute("style");
 });
 
 describe("MCP Apps primary widget runtime", () => {
@@ -246,5 +254,27 @@ describe("MCP Apps primary widget runtime", () => {
 
     expect(bridge.sendSizeChanged).toHaveBeenCalledWith({ height: 260 });
     expect(window.openai?.notifyIntrinsicHeight).not.toHaveBeenCalled();
+  });
+
+  it("applies host context CSS variables through McpUseProvider", async () => {
+    await act(async () => {
+      create(
+        <McpUseProvider>
+          <div>content</div>
+        </McpUseProvider>
+      );
+      await flushMicrotasks();
+    });
+
+    expect(
+      document.documentElement.style.getPropertyValue(
+        "--color-background-secondary"
+      )
+    ).toBe("rgb(12 13 14)");
+    expect(
+      document.documentElement.style.getPropertyValue(
+        "--color-background-primary"
+      )
+    ).toBe("transparent");
   });
 });


### PR DESCRIPTION
Stacked on #1739.

This keeps the primary MCP Apps widget runtime change separate from the host style variable plumbing.\n\nChanges in this PR:
- Adds host style variable propagation for MCP Apps host context.
- Applies the variables through the React theme/runtime bridge.
- Extends the runtime tests for host style behavior.