### PR TITLE
[codex] fix inspector oauth emulate callback

### DIFF
--- a/libraries/typescript/packages/inspector/tests/e2e/fixtures/google-emulate-server.ts
+++ b/libraries/typescript/packages/inspector/tests/e2e/fixtures/google-emulate-server.ts
@@ -15,6 +15,7 @@ import { MCPServer, oauthProxy, text } from "mcp-use/server";
 
 const GOOGLE_EMULATOR_PORT = 4101;
 const MCP_SERVER_PORT = 4201;
+const MCP_SERVER_OAUTH_CALLBACK = `http://localhost:${MCP_SERVER_PORT}/oauth/callback`;
 
 const STATIC_CLIENT_ID = "mcp-emulate-test-client.apps.googleusercontent.com";
 const STATIC_CLIENT_SECRET = "GOCSPX-mcp-emulate-test-secret";
@@ -45,7 +46,7 @@ export async function startGoogleEmulateFixture(): Promise<GoogleEmulateHandle> 
           {
             client_id: STATIC_CLIENT_ID,
             client_secret: STATIC_CLIENT_SECRET,
-            redirect_uris: ["http://localhost:3000/inspector/oauth/callback"],
+            redirect_uris: [MCP_SERVER_OAUTH_CALLBACK],
           },
         ],
       },


### PR DESCRIPTION
## Summary

Fix the OAuth emulate e2e fixture after the Canary oauthProxy callback broker change.

Proxy-mode OAuth now sends upstream providers to the MCP server callback (`/oauth/callback`) and then brokers back to the inspector callback. The emulate Google fixture was still registering only the inspector callback, so emulate rejected the authorize request with `Redirect URI mismatch` before the test could submit the seeded user form.

## Validation

- `pnpm exec playwright test tests/e2e/oauth-emulate.test.ts --workers=1 --reporter=line` (`2 passed`)
