### PR TITLE
fix(cli): preserve deployment list sort order

### DIFF
--- a/libraries/typescript/.changeset/cli-deployments-list-sort-order.md
+++ b/libraries/typescript/.changeset/cli-deployments-list-sort-order.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/cli": patch
+---
+
+`mcp-use deployments list` now preserves the deployment ordering returned by the API instead of re-sorting by creation date on the client. This keeps the displayed order consistent with the server's pagination and sort.

--- a/libraries/typescript/packages/cli/src/commands/deployments.ts
+++ b/libraries/typescript/packages/cli/src/commands/deployments.ts
@@ -133,12 +133,7 @@ async function listDeploymentsCommand(options: {
       }
     }
 
-    const sortedDeployments = [...deployments].sort(
-      (a, b) =>
-        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-    );
-
-    if (sortedDeployments.length === 0) {
+    if (deployments.length === 0) {
       if (page.total === 0) {
         console.log(chalk.yellow("No deployments found."));
         console.log(
@@ -160,7 +155,7 @@ async function listDeploymentsCommand(options: {
       chalk.cyan.bold(
         `\n📦 ${formatPageHeader(
           "Deployments",
-          sortedDeployments.length,
+          deployments.length,
           page.total
         )}\n`
       )
@@ -173,7 +168,7 @@ async function listDeploymentsCommand(options: {
     );
     console.log(chalk.gray("─".repeat(155)));
 
-    for (const deployment of sortedDeployments) {
+    for (const deployment of deployments) {
       const id = formatId(deployment.id).padEnd(40);
       const name = deployment.name.substring(0, 24).padEnd(25);
       const orgName = deployment.serverId

--- a/libraries/typescript/packages/cli/tests/deployments.test.ts
+++ b/libraries/typescript/packages/cli/tests/deployments.test.ts
@@ -15,6 +15,8 @@ const mockApiInstance = {
   createEnvVariable: vi.fn(),
   updateEnvVariable: vi.fn(),
   deleteEnvVariable: vi.fn(),
+  testAuth: vi.fn(),
+  getServer: vi.fn(),
 };
 
 // Mock the entire api module
@@ -782,6 +784,50 @@ describe("Error Handling", () => {
       : apiError;
 
     expect(userMessage).toBe("Deployment not found");
+  });
+});
+
+describe("deployments list command", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("preserves the API order when --sort is provided", async () => {
+    const { isLoggedIn } = await import("../src/utils/config.js");
+    vi.mocked(isLoggedIn).mockResolvedValue(true);
+    mockApiInstance.testAuth.mockResolvedValue({ orgs: [] });
+    mockApiInstance.getServer.mockResolvedValue({ organizationId: "org_1" });
+    mockApiInstance.listDeployments.mockResolvedValue({
+      items: [
+        {
+          ...mockDeployment,
+          id: "dep_alpha",
+          name: "alpha",
+          createdAt: "2024-01-01T00:00:00Z",
+          serverId: "srv_1",
+        },
+        {
+          ...mockDeployment,
+          id: "dep_beta",
+          name: "beta",
+          createdAt: "2024-02-01T00:00:00Z",
+          serverId: "srv_1",
+        },
+      ],
+      total: 2,
+      limit: 30,
+      skip: 0,
+    });
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const { createDeploymentsCommand } =
+      await import("../src/commands/deployments.js");
+    const cmd = createDeploymentsCommand();
+    await cmd.parseAsync(["list", "--sort", "name:asc"], { from: "user" });
+
+    const output = logSpy.mock.calls.map((args) => args.join(" ")).join("\n");
+    expect(output.indexOf("alpha")).toBeLessThan(output.indexOf("beta"));
+    logSpy.mockRestore();
   });
 });
 


### PR DESCRIPTION
## Summary
- preserve the deployment page order returned by the API
- avoid re-sorting `deployments list --sort ...` output by `createdAt`
- add a regression test for custom sort output order

## Tests
- pnpm --filter @mcp-use/cli exec vitest run tests/deployments.test.ts
- pnpm exec prettier --check packages/cli/src/commands/deployments.ts packages/cli/tests/deployments.test.ts
- git diff --check

Closes #1751