### PR TITLE
Fix Codex skill install path to use `.agents/skills`

### DIFF
--- a/docs/typescript/server/cli-reference.mdx
+++ b/docs/typescript/server/cli-reference.mdx
@@ -517,7 +517,7 @@ Downloads the latest mcp-use skills from [github.com/mcp-use/mcp-use](https://gi
 2. Installs them into all agent preset directories:
    - `.cursor/skills/` (Cursor)
    - `.claude/skills/` (Claude Code)
-   - `.agent/skills/` (Codex)
+   - `.agents/skills/` (Codex)
 
 **Options:**
 

--- a/libraries/typescript/.changeset/codex-skills-folder.md
+++ b/libraries/typescript/.changeset/codex-skills-folder.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/cli": patch
+---
+
+Fix Codex skills installation to use `.agents/skills` instead of the unsupported `.agent/skills` path.

--- a/libraries/typescript/packages/cli/src/commands/skills.ts
+++ b/libraries/typescript/packages/cli/src/commands/skills.ts
@@ -31,7 +31,7 @@ type AgentPreset = "cursor" | "claude-code" | "codex";
 const AGENT_PRESET_FOLDERS: Record<AgentPreset, string> = {
   cursor: ".cursor",
   "claude-code": ".claude",
-  codex: ".agent",
+  codex: ".agents",
 };
 
 const ALL_PRESETS: AgentPreset[] = ["cursor", "claude-code", "codex"];
@@ -64,7 +64,7 @@ function sendInstallTelemetryEvent(agents: string, skills: string): void {
 /**
  * Download and extract skills from the mcp-use GitHub repository
  * and install them into the project's agent preset directories
- * (.cursor/skills, .claude/skills, .agent/skills).
+ * (.cursor/skills, .claude/skills, .agents/skills).
  */
 async function addSkillsToProject(projectPath: string): Promise<void> {
   const tarballUrl = `https://codeload.github.com/${REPO_OWNER}/${REPO_NAME}/tar.gz/${REPO_BRANCH}`;
@@ -124,7 +124,7 @@ export function createSkillsCommand(): Command {
     console.log(chalk.cyan("📚 Installing mcp-use skills..."));
     console.log(
       chalk.gray(
-        "   Downloading from github.com/mcp-use/mcp-use → .cursor/skills, .claude/skills, .agent/skills"
+        "   Downloading from github.com/mcp-use/mcp-use → .cursor/skills, .claude/skills, .agents/skills"
       )
     );
 


### PR DESCRIPTION
## Summary
- Update the Codex preset install target from `.agent/skills` to `.agents/skills`
- Align CLI output and inline docs with the corrected Codex skills directory
- Keep the TypeScript CLI reference in sync with the install behavior

## Testing
- Not run (not requested)