### PR TITLE
fix(cli): surface GitHub App install URL up front on deploy

### DIFF
--- a/libraries/typescript/.changeset/deploy-github-install-url.md
+++ b/libraries/typescript/.changeset/deploy-github-install-url.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/cli": patch
+---
+
+`mcp-use deploy` now surfaces the GitHub App installation URL up front when the app isn't connected or lacks repo access, before any prompt. In a non-interactive context (an agent or CI, without `--yes`) it prints the URL and clear next steps and exits cleanly instead of hanging on an unanswerable prompt.

--- a/libraries/typescript/packages/cli/src/commands/deploy.ts
+++ b/libraries/typescript/packages/cli/src/commands/deploy.ts
@@ -597,7 +597,7 @@ export function gitHubInstallUrl(appName: string): string {
  *   a prompt that will never be answered, so the caller prints the install URL
  *   and bails cleanly instead of hanging.
  */
-export type InstallFlowMode = "auto" | "interactive" | "non-interactive";
+type InstallFlowMode = "auto" | "interactive" | "non-interactive";
 
 export function resolveInstallFlowMode(opts: {
   yes: boolean;

--- a/libraries/typescript/packages/cli/src/commands/deploy.ts
+++ b/libraries/typescript/packages/cli/src/commands/deploy.ts
@@ -582,7 +582,32 @@ async function checkRepoAccess(
   return api.checkGitHubRepoAccess(owner, repo);
 }
 
-async function promptGitHubInstallation(
+/** The GitHub App installation page for the given app slug. */
+export function gitHubInstallUrl(appName: string): string {
+  return `https://github.com/apps/${appName}/installations/new`;
+}
+
+/**
+ * How the GitHub App installation step should behave, given the `--yes` flag
+ * and whether stdin is an interactive TTY.
+ *
+ * - `auto`: caller passed `--yes`; open the browser and poll for completion.
+ * - `interactive`: a TTY is attached; ask the user before opening the browser.
+ * - `non-interactive`: no TTY and no `--yes` (an agent or CI). We can't block on
+ *   a prompt that will never be answered, so the caller prints the install URL
+ *   and bails cleanly instead of hanging.
+ */
+export type InstallFlowMode = "auto" | "interactive" | "non-interactive";
+
+export function resolveInstallFlowMode(opts: {
+  yes: boolean;
+  isTTY: boolean;
+}): InstallFlowMode {
+  if (opts.yes) return "auto";
+  return opts.isTTY ? "interactive" : "non-interactive";
+}
+
+export async function promptGitHubInstallation(
   api: McpUseAPI,
   reason: "not_connected" | "no_access",
   repoName?: string,
@@ -594,57 +619,93 @@ async function promptGitHubInstallation(
 ): Promise<{ ok: boolean; api: McpUseAPI }> {
   const yes = !!opts?.yes;
   const reauth = opts?.reauth;
-  console.log();
+  let client = api;
 
+  // Resolve the install URL up front so it is ALWAYS surfaced — before any
+  // prompt, and regardless of whether stdin is interactive. This is the single
+  // actionable step that fixes a missing or incomplete GitHub App installation,
+  // and an agent or CI run needs to see it without answering a prompt.
+  let appName: string;
+  for (;;) {
+    try {
+      appName = await client.getGitHubAppName();
+      break;
+    } catch (e) {
+      if (e instanceof ApiUnauthorizedError && reauth) {
+        client = await reauth();
+        await client.testAuth();
+        continue;
+      }
+      throw e;
+    }
+  }
+  const installUrl = gitHubInstallUrl(appName);
+
+  console.log();
   if (reason === "not_connected") {
     console.log(chalk.yellow("⚠️  GitHub account not connected"));
-    console.log(
-      chalk.white("Deployments require a connected GitHub account.\n")
-    );
+    console.log(chalk.white("Deployments require a connected GitHub account."));
   } else {
     console.log(
       chalk.yellow("⚠️  GitHub App doesn't have access to this repository")
     );
     console.log(
       chalk.white(
-        `The GitHub App needs permission to access ${chalk.cyan(repoName || "this repository")}.\n`
+        `The GitHub App needs permission to access ${chalk.cyan(repoName || "this repository")}.`
       )
     );
   }
 
-  const shouldInstall = yes
-    ? true
-    : await prompt(
-        chalk.white(
-          `Would you like to ${reason === "not_connected" ? "connect" : "configure"} GitHub now? (Y/n): `
-        ),
-        "y"
+  // Always print the install URL so it is actionable even when the prompt is
+  // declined or stdin is non-interactive.
+  console.log(
+    chalk.white(
+      `\nInstall${reason === "no_access" ? " / configure" : ""} the GitHub App to continue:`
+    )
+  );
+  console.log(chalk.cyan.bold(`  ${installUrl}`));
+  if (reason === "no_access") {
+    console.log(
+      chalk.gray(
+        `  Grant access to ${repoName || "your repository"} on the app's settings page.`
+      )
+    );
+  }
+
+  const mode = resolveInstallFlowMode({ yes, isTTY: !!process.stdin.isTTY });
+
+  if (mode === "non-interactive") {
+    // An agent or CI: don't block on a prompt that can't be answered. The URL
+    // is already printed above; tell the caller what to do next and bail.
+    console.log(
+      chalk.white(
+        `\nOpen the URL above to install the GitHub App, then re-run ${chalk.cyan("mcp-use deploy")}.`
+      )
+    );
+    return { ok: false, api: client };
+  }
+
+  if (mode === "interactive") {
+    const shouldInstall = await prompt(
+      chalk.white(
+        `\nWould you like to ${reason === "not_connected" ? "connect" : "configure"} GitHub now? (Y/n): `
+      ),
+      "y"
+    );
+    if (!shouldInstall) {
+      console.log(
+        chalk.gray(
+          `\nOpen the URL above when ready, then re-run ${chalk.cyan("mcp-use deploy")}.`
+        )
       );
-  if (!shouldInstall) return { ok: false, api };
-
-  let client = api;
-
-  try {
-    let appName: string;
-    for (;;) {
-      try {
-        appName = await client.getGitHubAppName();
-        break;
-      } catch (e) {
-        if (e instanceof ApiUnauthorizedError && reauth) {
-          client = await reauth();
-          await client.testAuth();
-          continue;
-        }
-        throw e;
-      }
+      return { ok: false, api: client };
     }
+  }
 
-    const installUrl = `https://github.com/apps/${appName}/installations/new`;
-
+  // mode === "auto" (--yes), or interactive with a confirmed "yes": open the
+  // browser to the install page.
+  try {
     console.log(chalk.cyan(`\nOpening browser...`));
-    console.log(chalk.gray(`URL: ${installUrl}\n`));
-
     if (reason === "no_access") {
       console.log(
         chalk.white("Please add ") +
@@ -659,7 +720,7 @@ async function promptGitHubInstallation(
 
     await open(installUrl);
 
-    if (!yes) {
+    if (mode === "interactive") {
       await prompt(chalk.white("Press Enter when done..."), "y");
     } else {
       console.log(chalk.gray("Waiting for GitHub configuration (polling)..."));
@@ -693,8 +754,7 @@ async function promptGitHubInstallation(
     }
     console.log(chalk.yellow("\n⚠️  Unable to open browser automatically"));
     console.log(
-      chalk.white("Please visit: ") +
-        chalk.cyan("https://manufact.com/cloud/settings")
+      chalk.white("Please open the URL above: ") + chalk.cyan(installUrl)
     );
     return { ok: false, api: client };
   }
@@ -1377,11 +1437,7 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
               `\n✗ Repository ${chalk.cyan(repoFullName)} is still not accessible.`
             )
           );
-          console.log(
-            chalk.cyan(
-              `  https://github.com/apps/${appName}/installations/new\n`
-            )
-          );
+          console.log(chalk.cyan(`  ${gitHubInstallUrl(appName)}\n`));
           process.exit(1);
         }
       }

--- a/libraries/typescript/packages/cli/src/commands/deploy.ts
+++ b/libraries/typescript/packages/cli/src/commands/deploy.ts
@@ -619,6 +619,7 @@ export async function promptGitHubInstallation(
 ): Promise<{ ok: boolean; api: McpUseAPI }> {
   const yes = !!opts?.yes;
   const reauth = opts?.reauth;
+  const noAccess = reason === "no_access";
   let client = api;
 
   // Resolve the install URL up front so it is ALWAYS surfaced — before any
@@ -642,10 +643,7 @@ export async function promptGitHubInstallation(
   const installUrl = gitHubInstallUrl(appName);
 
   console.log();
-  if (reason === "not_connected") {
-    console.log(chalk.yellow("⚠️  GitHub account not connected"));
-    console.log(chalk.white("Deployments require a connected GitHub account."));
-  } else {
+  if (noAccess) {
     console.log(
       chalk.yellow("⚠️  GitHub App doesn't have access to this repository")
     );
@@ -654,17 +652,20 @@ export async function promptGitHubInstallation(
         `The GitHub App needs permission to access ${chalk.cyan(repoName || "this repository")}.`
       )
     );
+  } else {
+    console.log(chalk.yellow("⚠️  GitHub account not connected"));
+    console.log(chalk.white("Deployments require a connected GitHub account."));
   }
 
   // Always print the install URL so it is actionable even when the prompt is
   // declined or stdin is non-interactive.
   console.log(
     chalk.white(
-      `\nInstall${reason === "no_access" ? " / configure" : ""} the GitHub App to continue:`
+      `\nInstall${noAccess ? " / configure" : ""} the GitHub App to continue:`
     )
   );
   console.log(chalk.cyan.bold(`  ${installUrl}`));
-  if (reason === "no_access") {
+  if (noAccess) {
     console.log(
       chalk.gray(
         `  Grant access to ${repoName || "your repository"} on the app's settings page.`
@@ -688,7 +689,7 @@ export async function promptGitHubInstallation(
   if (mode === "interactive") {
     const shouldInstall = await prompt(
       chalk.white(
-        `\nWould you like to ${reason === "not_connected" ? "connect" : "configure"} GitHub now? (Y/n): `
+        `\nWould you like to ${noAccess ? "configure" : "connect"} GitHub now? (Y/n): `
       ),
       "y"
     );
@@ -706,7 +707,7 @@ export async function promptGitHubInstallation(
   // browser to the install page.
   try {
     console.log(chalk.cyan(`\nOpening browser...`));
-    if (reason === "no_access") {
+    if (noAccess) {
       console.log(
         chalk.white("Please add ") +
           chalk.cyan.bold(repoName || "your repository") +

--- a/libraries/typescript/packages/cli/src/utils/api.ts
+++ b/libraries/typescript/packages/cli/src/utils/api.ts
@@ -244,7 +244,7 @@ function buildPaginationQuery(
 
 // ── GitHub ──────────────────────────────────────────────────────────
 
-export interface GitHubInstallation {
+interface GitHubInstallation {
   id: string;
   installation_id: string;
   account_login: string;

--- a/libraries/typescript/packages/cli/tests/github-install-flow.test.ts
+++ b/libraries/typescript/packages/cli/tests/github-install-flow.test.ts
@@ -1,10 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import open from "open";
 import type { McpUseAPI } from "../src/utils/api.js";
 import {
   gitHubInstallUrl,
   promptGitHubInstallation,
   resolveInstallFlowMode,
 } from "../src/commands/deploy.js";
+
+// Stub the browser launcher so the non-interactive path can assert it is never
+// invoked — a regression that fell through to open() would otherwise launch a
+// real browser in CI instead of failing the test.
+vi.mock("open", () => ({ default: vi.fn() }));
 
 /**
  * Unit tests for the MCP-2243 deploy GitHub-App installation flow. The deploy
@@ -18,14 +24,9 @@ describe("gitHubInstallUrl", () => {
     expect(gitHubInstallUrl("mcp-use")).toBe(
       "https://github.com/apps/mcp-use/installations/new"
     );
-  });
-
-  it("respects non-production app slugs", () => {
+    // Non-production slugs are interpolated, not hardcoded.
     expect(gitHubInstallUrl("mcp-use-dev")).toBe(
       "https://github.com/apps/mcp-use-dev/installations/new"
-    );
-    expect(gitHubInstallUrl("mcp-use-local")).toBe(
-      "https://github.com/apps/mcp-use-local/installations/new"
     );
   });
 });
@@ -52,9 +53,8 @@ describe("resolveInstallFlowMode", () => {
 /**
  * Drives the real promptGitHubInstallation() through the non-interactive path
  * (no TTY, no --yes) — the agent/CI scenario from MCP-2243. We assert it prints
- * the install URL and bails cleanly, rather than blocking on a prompt. A
- * stubbed API supplies the app slug; reaching the prompt or `open()` would hang
- * the test, so the absence of a hang is itself part of what's verified.
+ * the install URL, never opens a browser, and bails cleanly rather than blocking
+ * on a prompt. A stubbed API supplies the app slug.
  */
 describe("promptGitHubInstallation (non-interactive)", () => {
   const originalIsTTY = process.stdin.isTTY;
@@ -102,6 +102,7 @@ describe("promptGitHubInstallation (non-interactive)", () => {
     );
 
     expect(result.ok).toBe(false);
+    expect(open).not.toHaveBeenCalled();
     const output = logs.join("\n");
     expect(output).toContain(
       "https://github.com/apps/mcp-use/installations/new"
@@ -122,6 +123,7 @@ describe("promptGitHubInstallation (non-interactive)", () => {
     );
 
     expect(result.ok).toBe(false);
+    expect(open).not.toHaveBeenCalled();
     const output = logs.join("\n");
     expect(output).toContain(
       "https://github.com/apps/mcp-use/installations/new"

--- a/libraries/typescript/packages/cli/tests/github-install-flow.test.ts
+++ b/libraries/typescript/packages/cli/tests/github-install-flow.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { McpUseAPI } from "../src/utils/api.js";
+import {
+  gitHubInstallUrl,
+  promptGitHubInstallation,
+  resolveInstallFlowMode,
+} from "../src/commands/deploy.js";
+
+/**
+ * Unit tests for the MCP-2243 deploy GitHub-App installation flow. The deploy
+ * command now surfaces the install URL up front and chooses how to proceed
+ * based on the `--yes` flag and whether stdin is an interactive TTY — so an
+ * agent or CI run never hangs on an unanswerable prompt.
+ */
+
+describe("gitHubInstallUrl", () => {
+  it("builds the install page URL for the resolved app slug", () => {
+    expect(gitHubInstallUrl("mcp-use")).toBe(
+      "https://github.com/apps/mcp-use/installations/new"
+    );
+  });
+
+  it("respects non-production app slugs", () => {
+    expect(gitHubInstallUrl("mcp-use-dev")).toBe(
+      "https://github.com/apps/mcp-use-dev/installations/new"
+    );
+    expect(gitHubInstallUrl("mcp-use-local")).toBe(
+      "https://github.com/apps/mcp-use-local/installations/new"
+    );
+  });
+});
+
+describe("resolveInstallFlowMode", () => {
+  it("returns 'auto' when --yes is set, regardless of TTY", () => {
+    expect(resolveInstallFlowMode({ yes: true, isTTY: true })).toBe("auto");
+    expect(resolveInstallFlowMode({ yes: true, isTTY: false })).toBe("auto");
+  });
+
+  it("returns 'interactive' for a TTY without --yes", () => {
+    expect(resolveInstallFlowMode({ yes: false, isTTY: true })).toBe(
+      "interactive"
+    );
+  });
+
+  it("returns 'non-interactive' without a TTY or --yes (agent/CI)", () => {
+    expect(resolveInstallFlowMode({ yes: false, isTTY: false })).toBe(
+      "non-interactive"
+    );
+  });
+});
+
+/**
+ * Drives the real promptGitHubInstallation() through the non-interactive path
+ * (no TTY, no --yes) — the agent/CI scenario from MCP-2243. We assert it prints
+ * the install URL and bails cleanly, rather than blocking on a prompt. A
+ * stubbed API supplies the app slug; reaching the prompt or `open()` would hang
+ * the test, so the absence of a hang is itself part of what's verified.
+ */
+describe("promptGitHubInstallation (non-interactive)", () => {
+  const originalIsTTY = process.stdin.isTTY;
+  let logs: string[];
+
+  function fakeApi(appName = "mcp-use"): McpUseAPI {
+    return {
+      getGitHubAppName: vi.fn(async () => appName),
+    } as unknown as McpUseAPI;
+  }
+
+  const reauth = async (): Promise<McpUseAPI> => {
+    throw new Error("reauth should not be called in this flow");
+  };
+
+  beforeEach(() => {
+    logs = [];
+    // Force the non-interactive branch regardless of the real test runner stdio.
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: false,
+      configurable: true,
+    });
+    vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      logs.push(args.map((a) => String(a)).join(" "));
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: originalIsTTY,
+      configurable: true,
+    });
+  });
+
+  it("prints the install URL and exits cleanly for a missing connection", async () => {
+    const api = fakeApi();
+    const result = await promptGitHubInstallation(
+      api,
+      "not_connected",
+      undefined,
+      {
+        reauth,
+      }
+    );
+
+    expect(result.ok).toBe(false);
+    const output = logs.join("\n");
+    expect(output).toContain(
+      "https://github.com/apps/mcp-use/installations/new"
+    );
+    expect(output).toContain("GitHub account not connected");
+    expect(output).toContain("re-run");
+  });
+
+  it("prints the install URL for a repo the app cannot access", async () => {
+    const api = fakeApi();
+    const result = await promptGitHubInstallation(
+      api,
+      "no_access",
+      "acme/widget",
+      {
+        reauth,
+      }
+    );
+
+    expect(result.ok).toBe(false);
+    const output = logs.join("\n");
+    expect(output).toContain(
+      "https://github.com/apps/mcp-use/installations/new"
+    );
+    expect(output).toContain("acme/widget");
+  });
+
+  it("uses the resolved non-production app slug in the URL", async () => {
+    const api = fakeApi("mcp-use-dev");
+    await promptGitHubInstallation(api, "not_connected", undefined, { reauth });
+
+    expect(logs.join("\n")).toContain(
+      "https://github.com/apps/mcp-use-dev/installations/new"
+    );
+  });
+});


### PR DESCRIPTION
## Changes

`mcp-use deploy` now surfaces the GitHub App installation URL **up front** whenever the GitHub App isn't connected or lacks access to the target repo — before any prompt, and regardless of whether stdin is interactive.

Previously the install URL was only printed *after* the user answered the interactive `Would you like to connect GitHub now? (Y/n)` prompt. When deploy ran in a non-interactive context (an agent or CI), that readline prompt blocked, the URL/browser-open was never reached, and there was no actionable output explaining that the GitHub App simply needed to be installed.

## Implementation Details

1. `promptGitHubInstallation()` now resolves the install URL first and always prints it prominently, then branches on a flow mode derived from `--yes` and `process.stdin.isTTY`.
2. New `non-interactive` mode (no TTY, no `--yes`): prints the URL + next steps and returns cleanly instead of blocking on an unanswerable prompt — this unblocks agent/CI runs.
3. Extracted two small, unit-tested pure helpers: `gitHubInstallUrl(appName)` and `resolveInstallFlowMode({ yes, isTTY })`. Deduped URL construction at the repo-access retry-failure message.

| Context | Behavior |
|---|---|
| `--yes` | Print URL → open browser → poll up to 120s (unchanged) |
| Interactive TTY | Print URL → prompt → on yes open browser + wait; on no, print "open URL then re-run" |
| Non-TTY (agent/CI), no `--yes` | Print URL + clear next steps, exit cleanly without hanging (new) |

## Example Usage (Before)

An agent runs `mcp-use deploy` with the app uninstalled → hangs on `Would you like to connect GitHub now? (Y/n)`; the install URL is never shown, so the agent can't tell what's wrong.

## Example Usage (After)

```
⚠️  GitHub account not connected
Deployments require a connected GitHub account.

Install the GitHub App to continue:
  https://github.com/apps/mcp-use/installations/new

Open the URL above to install the GitHub App, then re-run mcp-use deploy.
```

→ exits cleanly, no hang. The `no_access` variant additionally names the repo and prints a "Grant access…" line.

## Documentation Updates

- None required (terminal-output/UX change only).

## Testing

- Added `packages/cli/tests/github-install-flow.test.ts` (8 tests): the pure URL builder, the `--yes`/TTY decision matrix, and three real-behavior tests that invoke `promptGitHubInstallation()` with stdin forced non-TTY and assert the URL is printed, the app slug (incl. `mcp-use-dev`) is honored, the repo name appears, and `{ ok: false }` is returned.
- Full CLI suite passes (300 passed / 6 todo). `pnpm build`, ESLint, and Prettier all clean.
- Verified the rendered output end-to-end by driving the real function via `tsx` in a non-TTY shell.

## Backwards Compatibility

Not breaking. The `--yes` and interactive TTY paths behave as before (the URL is just shown a little earlier). Only the previously-hanging non-interactive path changes — it now exits cleanly with an actionable message.
