### PR TITLE
Add Xquik remote MCP inspector example

### DIFF
--- a/docs/inspector/connection-settings.mdx
+++ b/docs/inspector/connection-settings.mdx
@@ -139,6 +139,24 @@ Add custom HTTP headers to all requests sent to the MCP server.
 - **Version Headers**: `X-API-Version: v2`
 - **Request IDs**: `X-Request-ID: <uuid>`
 
+### Authenticated Remote MCP Example
+
+Xquik exposes a streamable HTTP MCP endpoint at `https://xquik.com/mcp`.
+Use a bearer header when connecting it through the inspector:
+
+```json
+{
+  "url": "https://xquik.com/mcp",
+  "transportType": "http",
+  "connectionType": "Direct",
+  "headers": {
+    "Authorization": "Bearer <XQUIK_API_KEY>"
+  }
+}
+```
+
+Keep copied configs private when they include API keys.
+
 ### Security Considerations
 
 <Warning>


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

Check all that apply:
- [ ] TypeScript
- [ ] Python
- [x] Documentation only
- [ ] CI/CD or tooling

## Changes

Adds a concise authenticated remote MCP example for Xquik in the Inspector connection settings documentation.

## Review Readiness

Help maintainers review this quickly:

- [x] The PR is scoped to one issue or one clearly related change
- [x] The PR description explains the user-visible problem and the fix
- [x] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [x] I verified the affected package/docs path with the commands listed below
- [x] I checked for existing open PRs that already solve the same issue

## Implementation Details

1. Adds an Inspector custom-header example for the Xquik streamable HTTP MCP endpoint.
2. Shows the required bearer header with an API key placeholder.
3. Adds no dependencies and changes no runtime code.

## TypeScript Checklist

> Complete this section if your PR includes TypeScript changes

### Packages Modified

Check all packages that were modified:
- [x] `docs`
- [ ] `tests`
- [ ] `cli`
- [ ] `create-mcp-use-app`
- [ ] `mcp-use` (server)
- [ ] `mcp-use` (client)
- [ ] `inspector`

### Pre-commit Checklist

Ensure all of the following have been completed:
- [ ] Ran `pnpm lint:fix` to auto-fix linting issues
- [ ] Ran `pnpm format` to format code with Prettier
- [ ] Ran `pnpm build` and build succeeds without errors
- [ ] Ran `pnpm changeset` to create a changeset if this PR includes user-facing changes
- [ ] Added or updated tests if needed
- [x] Updated documentation in `docs/` folder if needed

## Python Checklist

> Complete this section if your PR includes Python changes

### Pre-commit Checklist

Ensure all of the following have been completed:
- [ ] Code formatted with `ruff format`
- [ ] Linting passes with `ruff check`
- [ ] Added or updated tests if needed
- [ ] Updated documentation if needed

## Example Usage (Before)

```json
{
  "url": "https://mcp.example.com/mcp",
  "transportType": "http",
  "connectionType": "Direct",
  "headers": {
    "Authorization": "Bearer token123"
  }
}
```

## Example Usage (After)

```json
{
  "url": "https://xquik.com/mcp",
  "transportType": "http",
  "connectionType": "Direct",
  "headers": {
    "Authorization": "Bearer <XQUIK_API_KEY>"
  }
}
```

## Documentation Updates

* `docs/inspector/connection-settings.mdx`: adds an authenticated remote MCP example for Xquik.

## Testing

- Ran the diff whitespace check.
- Checked the public Xquik MCP endpoint returns auth required status without credentials.
- Checked the Xquik MCP manifest URL is reachable.
- Checked open and closed PRs and issues for existing Xquik references.

## Backwards Compatibility

This is documentation only and does not change runtime behavior.

## Related Issues

None
