### PR TITLE
fix: respect empty path lists in AuthMiddleware

### DIFF
--- a/libraries/python/mcp_use/server/auth/middleware.py
+++ b/libraries/python/mcp_use/server/auth/middleware.py
@@ -46,13 +46,13 @@ class AuthMiddleware(BaseHTTPMiddleware):
         """
         super().__init__(app)
         self.auth_provider = auth_provider
-        self.exclude_paths = exclude_paths or [
+        self.exclude_paths = exclude_paths if exclude_paths is not None else [
             "/health",
             "/docs",
             "/inspector",
             "/openmcp.json",
         ]
-        self.protected_paths = protected_paths or ["/mcp"]
+        self.protected_paths = protected_paths if protected_paths is not None else ["/mcp"]
 
     def _is_protected_path(self, path: str) -> bool:
         """Check if the path requires authentication."""


### PR DESCRIPTION
## Summary

`AuthMiddleware.__init__` uses `or` to fall back to default path lists when `exclude_paths` or `protected_paths` are not provided. Since empty lists are falsy in Python, passing `exclude_paths=[]` or `protected_paths=[]` silently falls back to the defaults, making it impossible to:

- Disable default path exclusions (to explicitly protect `/docs` or `/health`)
- Disable default MCP protection at the middleware layer

## Fix

Replace `or` with `is not None` checks so that:
- `None` means "use defaults" (unchanged behavior)
- `[]` means "no paths" (now respected correctly)

## Reproduction

From the issue:

```python
# Before fix: /mcp returns 200 even with protected_paths=[]
# After fix: /mcp returns 401 (protected) or respects the empty list
app.add_middleware(AuthMiddleware, auth_provider=provider, protected_paths=[])

# Before fix: /docs returns 200 (excluded) even with exclude_paths=[]
# After fix: /docs is no longer excluded when exclude_paths=[]
app.add_middleware(AuthMiddleware, auth_provider=provider, exclude_paths=[], protected_paths=["/docs"])
```

Closes #1753
