### PR TITLE
fix(inspector): stop prompting signed-in users to log in (MCP-2142)

### DIFF
--- a/libraries/typescript/.changeset/mcp-2142-inspector-signed-in-prompt.md
+++ b/libraries/typescript/.changeset/mcp-2142-inspector-signed-in-prompt.md
@@ -1,0 +1,14 @@
+---
+"@mcp-use/inspector": patch
+---
+
+fix(inspector): stop prompting signed-in users to log in on the hosted free tier
+
+The hosted inspector (`inspector.manufact.com`) showed the "You're using
+Manufact's free tier — Sign in to increase your limits" CTA to every visitor
+using the managed LLM, even when they were already authenticated (MCP-2142).
+
+`ChatTab` now resolves the shared Manufact session (via the new
+`useHostedSession` hook, also used by `HostedUserMenu`) and only renders the
+free-tier sign-in/upgrade chrome for anonymous visitors. The visibility rule is
+extracted into a pure `shouldShowFreeTierUpgrade` helper and unit-tested.

--- a/libraries/typescript/packages/inspector/src/client/components/ChatTab.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ChatTab.tsx
@@ -14,6 +14,8 @@ import React, {
 import { toast } from "sonner";
 import { copyToClipboard } from "../utils/clipboard";
 import { downloadJSON } from "../utils/jsonUtils";
+import { shouldShowFreeTierUpgrade } from "./chat/freeTier";
+import { useHostedSession } from "../hooks/useHostedSession";
 import { useKeyboardShortcuts } from "../hooks/useKeyboardShortcuts";
 import { useMCPPrompts } from "../hooks/useMCPPrompts";
 import { ChatHeader } from "./chat/ChatHeader";
@@ -320,10 +322,22 @@ export function ChatTab({
     setShowLoginModal(true);
   }, [setConfigDialogOpen]);
 
-  const freeTierInfo =
-    isManaged && enableFreeTierUpgrade
-      ? { onLoginClick: handleOpenLogin }
-      : undefined;
+  // Whether the visitor is signed in to Manufact (hosted free-tier only). Used
+  // to suppress the "Sign in to increase your limits" prompt once authenticated
+  // — otherwise signed-in users keep getting asked to log in (MCP-2142). Only
+  // probed for the hosted free-tier UI; BYOK and host embeds skip the fetch.
+  const { user: hostedUser } = useHostedSession(
+    enableFreeTierUpgrade ? chatApiUrl : undefined
+  );
+  const isHostedAuthenticated = hostedUser != null;
+
+  const freeTierInfo = shouldShowFreeTierUpgrade({
+    isManaged,
+    enableFreeTierUpgrade,
+    isAuthenticated: isHostedAuthenticated,
+  })
+    ? { onLoginClick: handleOpenLogin }
+    : undefined;
 
   // Host embed (e.g. cloud dashboard) passes `managedLlmConfig` + `hideModelBadge`
   // because it renders its own model row (`ServerChatHeader`). Suppress inspector

--- a/libraries/typescript/packages/inspector/src/client/components/HostedUserMenu.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/HostedUserMenu.tsx
@@ -18,9 +18,13 @@
  *  Session check is a simple GET — no WebSockets or polling. The only
  *  re-check triggers are: initial mount and `manufact:session-changed`.
  */
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useRef } from "react";
 import type React from "react";
 import { LayoutDashboard } from "lucide-react";
+import {
+  useHostedSession,
+  type HostedUser,
+} from "@/client/hooks/useHostedSession";
 import { Button } from "@/client/components/ui/button";
 import {
   DropdownMenu,
@@ -35,13 +39,6 @@ import {
   AvatarFallback,
   AvatarImage,
 } from "@/client/components/ui/avatar";
-
-interface HostedUser {
-  id: string;
-  name?: string | null;
-  email?: string | null;
-  image?: string | null;
-}
 
 function getInitial(
   name: string | null | undefined,
@@ -75,48 +72,17 @@ export function HostedUserMenu({
   fallback = null,
   onUserResolved,
 }: HostedUserMenuProps) {
-  const [user, setUser] = useState<HostedUser | null>(null);
-  const [loaded, setLoaded] = useState(false);
+  const { user, loaded } = useHostedSession(chatApiUrl);
 
-  const fetchSession = useCallback(() => {
-    let cancelled = false;
-    const sessionUrl = `${new URL(chatApiUrl).origin}/api/auth/get-session`;
-
-    fetch(sessionUrl, { credentials: "include" })
-      .then((res) => (res.ok ? res.json() : null))
-      .then((data) => {
-        if (!cancelled) {
-          const resolved = data?.user ?? null;
-          setUser(resolved);
-          setLoaded(true);
-          onUserResolved?.(resolved);
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setLoaded(true);
-          onUserResolved?.(null);
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [chatApiUrl]);
-
+  // Notify the parent (LayoutHeader) whenever the resolved session changes.
+  const lastReportedId = useRef<string | null | undefined>(undefined);
   useEffect(() => {
-    const cleanup = fetchSession();
-    return cleanup;
-  }, [fetchSession]);
-
-  useEffect(() => {
-    const handler = () => {
-      fetchSession();
-    };
-    window.addEventListener("manufact:session-changed", handler);
-    return () =>
-      window.removeEventListener("manufact:session-changed", handler);
-  }, [fetchSession]);
+    if (!loaded) return;
+    const id = user?.id ?? null;
+    if (lastReportedId.current === id) return;
+    lastReportedId.current = id;
+    onUserResolved?.(user);
+  }, [loaded, user, onUserResolved]);
 
   // While the session check is still in-flight render nothing to avoid a flash.
   if (!loaded) return null;

--- a/libraries/typescript/packages/inspector/src/client/components/chat/__tests__/freeTier.test.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/__tests__/freeTier.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { shouldShowFreeTierUpgrade } from "../freeTier";
+
+describe("shouldShowFreeTierUpgrade", () => {
+  it("shows the sign-in CTA for anonymous managed visitors (hosted inspector)", () => {
+    expect(
+      shouldShowFreeTierUpgrade({
+        isManaged: true,
+        enableFreeTierUpgrade: true,
+        isAuthenticated: false,
+      })
+    ).toBe(true);
+  });
+
+  it("hides the sign-in CTA once the visitor is signed in (MCP-2142)", () => {
+    expect(
+      shouldShowFreeTierUpgrade({
+        isManaged: true,
+        enableFreeTierUpgrade: true,
+        isAuthenticated: true,
+      })
+    ).toBe(false);
+  });
+
+  it("never shows when the host did not opt into the free-tier UI (embeds)", () => {
+    expect(
+      shouldShowFreeTierUpgrade({
+        isManaged: true,
+        enableFreeTierUpgrade: false,
+        isAuthenticated: false,
+      })
+    ).toBe(false);
+  });
+
+  it("never shows for BYOK / client-side LLM (not managed)", () => {
+    expect(
+      shouldShowFreeTierUpgrade({
+        isManaged: false,
+        enableFreeTierUpgrade: true,
+        isAuthenticated: false,
+      })
+    ).toBe(false);
+  });
+});

--- a/libraries/typescript/packages/inspector/src/client/components/chat/freeTier.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/freeTier.ts
@@ -1,0 +1,26 @@
+/**
+ * Free-tier upgrade prompt visibility.
+ *
+ * The hosted inspector (inspector.manufact.com) shows a "Sign in to increase
+ * your limits" CTA for anonymous visitors using Manufact's managed LLM. It must
+ * NOT be shown to users who are already signed in — otherwise signed-in users
+ * keep getting asked to log in (MCP-2142).
+ *
+ * Pure decision so it can be unit-tested without rendering React.
+ */
+interface FreeTierVisibilityInput {
+  /** Chat is using the server-managed (Manufact) LLM, not a BYOK key. */
+  isManaged: boolean;
+  /** Host opted into the free-tier sign-in/upgrade UI (hosted inspector only). */
+  enableFreeTierUpgrade: boolean;
+  /** Visitor is signed in to Manufact (shared session cookie resolved). */
+  isAuthenticated: boolean;
+}
+
+export function shouldShowFreeTierUpgrade({
+  isManaged,
+  enableFreeTierUpgrade,
+  isAuthenticated,
+}: FreeTierVisibilityInput): boolean {
+  return isManaged && enableFreeTierUpgrade && !isAuthenticated;
+}

--- a/libraries/typescript/packages/inspector/src/client/hooks/useHostedSession.ts
+++ b/libraries/typescript/packages/inspector/src/client/hooks/useHostedSession.ts
@@ -1,0 +1,87 @@
+/**
+ * useHostedSession — shared session probe for the hosted inspector
+ *
+ * Fetches the current user from `<chatApiUrl origin>/api/auth/get-session`
+ * using the shared session cookie (works across *.manufact.com when the backend
+ * runs with COOKIE_DOMAIN=.manufact.com).
+ *
+ * Single source of truth for "is the visitor signed in to Manufact?", consumed
+ * by both `HostedUserMenu` (avatar) and `ChatTab` (so the free-tier sign-in
+ * prompt is hidden once the user is authenticated — see MCP-2142).
+ *
+ * Re-checks on mount and whenever `manufact:session-changed` is dispatched
+ * (LoginModal fires this after a successful sign-in), so the UI updates the
+ * moment the session cookie is set without a page reload.
+ */
+import { useCallback, useEffect, useState } from "react";
+
+export interface HostedUser {
+  id: string;
+  name?: string | null;
+  email?: string | null;
+  image?: string | null;
+}
+
+interface HostedSession {
+  /** Authenticated user, or null when signed out / still loading. */
+  user: HostedUser | null;
+  /** True once the first session check has resolved (success or failure). */
+  loaded: boolean;
+}
+
+/**
+ * @param chatApiUrl - Hosted chat endpoint. When undefined/null the hook stays
+ *   idle (no fetch) — local/BYOK inspector has no Manufact session to probe.
+ */
+export function useHostedSession(
+  chatApiUrl: string | null | undefined
+): HostedSession {
+  const [user, setUser] = useState<HostedUser | null>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  const fetchSession = useCallback(() => {
+    if (!chatApiUrl) {
+      setUser(null);
+      setLoaded(true);
+      return () => {};
+    }
+
+    let cancelled = false;
+    let sessionUrl: string;
+    try {
+      sessionUrl = `${new URL(chatApiUrl).origin}/api/auth/get-session`;
+    } catch {
+      setUser(null);
+      setLoaded(true);
+      return () => {};
+    }
+
+    fetch(sessionUrl, { credentials: "include" })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (cancelled) return;
+        setUser((data?.user as HostedUser | undefined) ?? null);
+        setLoaded(true);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setUser(null);
+        setLoaded(true);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [chatApiUrl]);
+
+  useEffect(() => fetchSession(), [fetchSession]);
+
+  useEffect(() => {
+    const handler = () => fetchSession();
+    window.addEventListener("manufact:session-changed", handler);
+    return () =>
+      window.removeEventListener("manufact:session-changed", handler);
+  }, [fetchSession]);
+
+  return { user, loaded };
+}


### PR DESCRIPTION
## Summary
The hosted inspector (`inspector.manufact.com`) showed the **"You're using Manufact's free tier — Sign in to increase your limits"** CTA to every visitor using the managed LLM, even when they were already signed in ([MCP-2142](https://linear.app/manufact/issue/MCP-2142)). Reproduced live: while authenticated, the model/usage dialog still rendered the free-tier sign-in prompt.

Root cause: the inspector chat UI had no knowledge of the hosted Manufact session. `HostedUserMenu` fetched `/api/auth/get-session` only for the avatar; `ChatTab` computed the free-tier CTA purely from `isManaged && enableFreeTierUpgrade`.

## Changes
- New shared `useHostedSession` hook — single source of truth for the Manufact session (reacts to `manufact:session-changed`, only probes in hosted free-tier mode).
- `HostedUserMenu` refactored to consume the hook (removes a duplicate session fetch).
- `ChatTab` hides the free-tier sign-in/upgrade chrome once authenticated, via a pure `shouldShowFreeTierUpgrade()` helper.
- Unit tests for the visibility rule.

Host embeds (e.g. the cloud dashboard) are unaffected — they don't opt into `enableFreeTierUpgrade`.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on changed files
- [x] `knip` clean
- [x] `vitest` — `freeTier.test.ts` (4 cases) pass
- [ ] Validate on canary deploy at `inspector.dev.manufact.com` (signed-in user no longer prompted)