### PR TITLE
Fix Python WebSocket and auth edge cases

### DIFF
--- a/libraries/python/mcp_use/client/config.py
+++ b/libraries/python/mcp_use/client/config.py
@@ -137,6 +137,13 @@ def create_connector_from_config(
             url=server_config["ws_url"],
             headers=server_config.get("headers", None),
             auth=server_config.get("auth", {}),
+            sampling_callback=sampling_callback,
+            elicitation_callback=elicitation_callback,
+            message_handler=message_handler,
+            logging_callback=logging_callback,
+            middleware=middleware,
+            roots=roots,
+            list_roots_callback=list_roots_callback,
         )
 
     raise ValueError("Cannot determine connector type from config")

--- a/libraries/python/mcp_use/client/connectors/websocket.py
+++ b/libraries/python/mcp_use/client/connectors/websocket.py
@@ -11,10 +11,12 @@ import uuid
 from typing import Any
 
 import httpx
+from mcp.client.session import ElicitationFnT, ListRootsFnT, LoggingFnT, MessageHandlerFnT, SamplingFnT
 from mcp.types import Tool
 from websockets import ClientConnection
 
 from mcp_use.client.connectors.base import BaseConnector
+from mcp_use.client.middleware import Middleware
 from mcp_use.client.task_managers import ConnectionManager, WebSocketConnectionManager
 from mcp_use.logging import logger
 
@@ -31,6 +33,13 @@ class WebSocketConnector(BaseConnector):
         url: str,
         headers: dict[str, str] | None = None,
         auth: str | dict[str, Any] | httpx.Auth | None = None,
+        sampling_callback: SamplingFnT | None = None,
+        elicitation_callback: ElicitationFnT | None = None,
+        message_handler: MessageHandlerFnT | None = None,
+        logging_callback: LoggingFnT | None = None,
+        middleware: list[Middleware] | None = None,
+        roots: list[Any] | None = None,
+        list_roots_callback: ListRootsFnT | None = None,
     ):
         """Initialize a new WebSocket connector.
 
@@ -42,6 +51,15 @@ class WebSocketConnector(BaseConnector):
                 - A dict: Not supported for WebSocket (will log warning)
                 - An httpx.Auth object: Not supported for WebSocket (will log warning)
         """
+        super().__init__(
+            sampling_callback=sampling_callback,
+            elicitation_callback=elicitation_callback,
+            message_handler=message_handler,
+            logging_callback=logging_callback,
+            middleware=middleware,
+            roots=roots,
+            list_roots_callback=list_roots_callback,
+        )
         self.url = url
         self.headers = headers or {}
 
@@ -225,7 +243,7 @@ class WebSocketConnector(BaseConnector):
     @property
     def tools(self) -> list[Tool]:
         """Get the list of available tools."""
-        if not self._tools:
+        if self._tools is None:
             raise RuntimeError("MCP client is not initialized")
         return self._tools
 

--- a/libraries/python/mcp_use/server/auth/middleware.py
+++ b/libraries/python/mcp_use/server/auth/middleware.py
@@ -46,13 +46,17 @@ class AuthMiddleware(BaseHTTPMiddleware):
         """
         super().__init__(app)
         self.auth_provider = auth_provider
-        self.exclude_paths = exclude_paths or [
-            "/health",
-            "/docs",
-            "/inspector",
-            "/openmcp.json",
-        ]
-        self.protected_paths = protected_paths or ["/mcp"]
+        self.exclude_paths = (
+            [
+                "/health",
+                "/docs",
+                "/inspector",
+                "/openmcp.json",
+            ]
+            if exclude_paths is None
+            else exclude_paths
+        )
+        self.protected_paths = ["/mcp"] if protected_paths is None else protected_paths
 
     def _is_protected_path(self, path: str) -> bool:
         """Check if the path requires authentication."""

--- a/libraries/python/tests/unit/server/auth/test_auth_middleware.py
+++ b/libraries/python/tests/unit/server/auth/test_auth_middleware.py
@@ -234,6 +234,41 @@ class TestAuthMiddlewareCustomPaths:
         response = client.get("/public")
         assert response.status_code == 200
 
+    def test_empty_protected_paths_disable_default_mcp_protection(self):
+        """An explicit empty protected path list should not fall back to /mcp."""
+
+        async def endpoint(request: Request) -> JSONResponse:
+            return JSONResponse({"ok": True})
+
+        app = Starlette(routes=[Route("/mcp", endpoint, methods=["GET"])])
+        app.add_middleware(
+            AuthMiddleware,
+            auth_provider=MockAuthProvider(),
+            protected_paths=[],
+        )
+        client = TestClient(app, raise_server_exceptions=False)
+
+        response = client.get("/mcp")
+        assert response.status_code == 200
+
+    def test_empty_exclude_paths_disable_default_exclusions(self):
+        """An explicit empty exclude path list should not keep default exclusions."""
+
+        async def endpoint(request: Request) -> JSONResponse:
+            return JSONResponse({"ok": True})
+
+        app = Starlette(routes=[Route("/docs", endpoint, methods=["GET"])])
+        app.add_middleware(
+            AuthMiddleware,
+            auth_provider=MockAuthProvider(),
+            exclude_paths=[],
+            protected_paths=["/docs"],
+        )
+        client = TestClient(app, raise_server_exceptions=False)
+
+        response = client.get("/docs")
+        assert response.status_code == 401
+
 
 class TestAuthMiddlewarePathMatchingSecurity:
     """Test that path matching is secure against prefix attacks."""

--- a/libraries/python/tests/unit/test_config.py
+++ b/libraries/python/tests/unit/test_config.py
@@ -12,6 +12,7 @@ from mcp_use.client.auth.bearer import BearerAuth
 from mcp_use.client.config import create_connector_from_config, load_config_file
 from mcp_use.client.connectors import HttpConnector, SandboxConnector, StdioConnector, WebSocketConnector
 from mcp_use.client.connectors.sandbox import SandboxOptions
+from mcp_use.client.middleware import Middleware
 
 
 class TestConfigLoading(unittest.TestCase):
@@ -143,6 +144,36 @@ class TestConnectorCreation(unittest.TestCase):
         self.assertIsInstance(connector, WebSocketConnector)
         self.assertEqual(connector.url, "ws://test.com")
         self.assertEqual(connector.headers, {})
+
+    def test_create_websocket_connector_preserves_common_options(self):
+        """WebSocket connectors receive the same common options as other transports."""
+        server_config = {"ws_url": "ws://test.com"}
+        middleware = Middleware()
+        sampling_callback = object()
+        elicitation_callback = object()
+        message_handler = object()
+        logging_callback = object()
+        roots = []
+        list_roots_callback = object()
+
+        connector = create_connector_from_config(
+            server_config,
+            sampling_callback=sampling_callback,
+            elicitation_callback=elicitation_callback,
+            message_handler=message_handler,
+            logging_callback=logging_callback,
+            middleware=[middleware],
+            roots=roots,
+            list_roots_callback=list_roots_callback,
+        )
+
+        self.assertIs(connector.sampling_callback, sampling_callback)
+        self.assertIs(connector.elicitation_callback, elicitation_callback)
+        self.assertIs(connector.message_handler, message_handler)
+        self.assertIs(connector.logging_callback, logging_callback)
+        self.assertEqual(connector.get_roots(), roots)
+        self.assertIs(connector._user_list_roots_callback, list_roots_callback)
+        self.assertIn(middleware, connector.middleware_manager.middlewares)
 
     def test_create_stdio_connector(self):
         """Test creating a stdio connector from config."""

--- a/libraries/python/tests/unit/test_websocket_connector.py
+++ b/libraries/python/tests/unit/test_websocket_connector.py
@@ -1,0 +1,26 @@
+"""Unit tests for the WebSocket connector."""
+
+from typing import Any
+
+import pytest
+
+from mcp_use.client.connectors.websocket import WebSocketConnector
+
+
+@pytest.mark.asyncio
+async def test_tools_property_allows_initialized_empty_tool_list():
+    """An initialized connector may legitimately expose zero tools."""
+    connector = WebSocketConnector("ws://localhost:8080")
+
+    async def fake_send_request(method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        if method == "initialize":
+            return {}
+        if method == "tools/list":
+            return {"tools": []}
+        raise AssertionError(f"unexpected method: {method}")
+
+    connector._send_request = fake_send_request
+
+    await connector.initialize()
+
+    assert connector.tools == []


### PR DESCRIPTION
## Summary
- allow initialized WebSocket connectors to expose an empty tools list
- pass common connector callbacks, roots, and middleware through `ws_url` config
- respect explicit empty AuthMiddleware path lists instead of falling back to defaults

Fixes #1747.
Fixes #1748.
Fixes #1753.

## Testing
- `MCP_USE_ANONYMIZED_TELEMETRY=false uv run --python python3.12 --extra dev pytest tests/unit/test_websocket_connector.py tests/unit/test_config.py::TestConnectorCreation::test_create_websocket_connector_preserves_common_options tests/unit/server/auth/test_auth_middleware.py::TestAuthMiddlewareCustomPaths -q`
- `uv run --python python3.12 --extra dev ruff check mcp_use/client/connectors/websocket.py mcp_use/client/config.py mcp_use/server/auth/middleware.py tests/unit/test_websocket_connector.py tests/unit/test_config.py tests/unit/server/auth/test_auth_middleware.py`
- `uv run --python python3.12 --extra dev ruff format --check mcp_use/client/connectors/websocket.py mcp_use/client/config.py mcp_use/server/auth/middleware.py tests/unit/test_websocket_connector.py tests/unit/test_config.py tests/unit/server/auth/test_auth_middleware.py`