### PR TITLE
fix(cli): preserve deployments list sort order

### DIFF
--- a/libraries/typescript/.changeset/cli-deployments-sort-order.md
+++ b/libraries/typescript/.changeset/cli-deployments-sort-order.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/cli": patch
+---
+
+Preserve API ordering for deployments list when an explicit sort is provided.

--- a/libraries/typescript/packages/cli/src/commands/deployments.ts
+++ b/libraries/typescript/packages/cli/src/commands/deployments.ts
@@ -133,12 +133,14 @@ async function listDeploymentsCommand(options: {
       }
     }
 
-    const sortedDeployments = [...deployments].sort(
-      (a, b) =>
-        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-    );
+    const displayDeployments = options.sort
+      ? deployments
+      : [...deployments].sort(
+          (a, b) =>
+            new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+        );
 
-    if (sortedDeployments.length === 0) {
+    if (displayDeployments.length === 0) {
       if (page.total === 0) {
         console.log(chalk.yellow("No deployments found."));
         console.log(
@@ -160,7 +162,7 @@ async function listDeploymentsCommand(options: {
       chalk.cyan.bold(
         `\n📦 ${formatPageHeader(
           "Deployments",
-          sortedDeployments.length,
+          displayDeployments.length,
           page.total
         )}\n`
       )
@@ -173,7 +175,7 @@ async function listDeploymentsCommand(options: {
     );
     console.log(chalk.gray("─".repeat(155)));
 
-    for (const deployment of sortedDeployments) {
+    for (const deployment of displayDeployments) {
       const id = formatId(deployment.id).padEnd(40);
       const name = deployment.name.substring(0, 24).padEnd(25);
       const orgName = deployment.serverId

--- a/libraries/typescript/packages/cli/tests/deployments.test.ts
+++ b/libraries/typescript/packages/cli/tests/deployments.test.ts
@@ -4,6 +4,8 @@ import type { Deployment, EnvVariable } from "../src/utils/api.js";
 // Create a mock API instance
 const mockApiInstance = {
   listDeployments: vi.fn(),
+  testAuth: vi.fn(),
+  getServer: vi.fn(),
   getDeployment: vi.fn(),
   deleteDeployment: vi.fn(),
   updateDeployment: vi.fn(),
@@ -508,6 +510,7 @@ describe("Deployment Command Integration", () => {
   let consoleErrors: string[];
 
   beforeEach(() => {
+    vi.clearAllMocks();
     consoleOutput = [];
     consoleErrors = [];
     originalConsoleLog = console.log;
@@ -544,6 +547,90 @@ describe("Deployment Command Integration", () => {
       vi.mocked(isLoggedIn).mockResolvedValue(true);
 
       expect(await isLoggedIn()).toBe(true);
+    });
+  });
+
+  describe("list command", () => {
+    it("preserves the API order when --sort is provided", async () => {
+      const { isLoggedIn } = await import("../src/utils/config.js");
+      vi.mocked(isLoggedIn).mockResolvedValue(true);
+      mockApiInstance.testAuth.mockResolvedValue({ orgs: [] });
+      mockApiInstance.getServer.mockResolvedValue({ organizationId: "org_1" });
+      mockApiInstance.listDeployments.mockResolvedValue({
+        items: [
+          {
+            ...mockDeployment,
+            id: "dep_alpha",
+            name: "alpha",
+            createdAt: "2024-01-01T00:00:00Z",
+            serverId: "srv_1",
+          },
+          {
+            ...mockDeployment,
+            id: "dep_beta",
+            name: "beta",
+            createdAt: "2024-02-01T00:00:00Z",
+            serverId: "srv_1",
+          },
+        ],
+        total: 2,
+        limit: 30,
+        skip: 0,
+      });
+
+      const { createDeploymentsCommand } =
+        await import("../src/commands/deployments.js");
+      const cmd = createDeploymentsCommand();
+      await cmd.parseAsync(["list", "--sort", "name:asc"], { from: "user" });
+
+      const output = consoleOutput.join("\n");
+      expect(output.indexOf("alpha")).toBeLessThan(output.indexOf("beta"));
+      expect(mockApiInstance.listDeployments).toHaveBeenCalledWith({
+        limit: 30,
+        skip: undefined,
+        sort: "name:asc",
+      });
+    });
+
+    it("keeps createdAt descending display order when --sort is omitted", async () => {
+      const { isLoggedIn } = await import("../src/utils/config.js");
+      vi.mocked(isLoggedIn).mockResolvedValue(true);
+      mockApiInstance.testAuth.mockResolvedValue({ orgs: [] });
+      mockApiInstance.getServer.mockResolvedValue({ organizationId: "org_1" });
+      mockApiInstance.listDeployments.mockResolvedValue({
+        items: [
+          {
+            ...mockDeployment,
+            id: "dep_alpha",
+            name: "alpha",
+            createdAt: "2024-01-01T00:00:00Z",
+            serverId: "srv_1",
+          },
+          {
+            ...mockDeployment,
+            id: "dep_beta",
+            name: "beta",
+            createdAt: "2024-02-01T00:00:00Z",
+            serverId: "srv_1",
+          },
+        ],
+        total: 2,
+        limit: 30,
+        skip: 0,
+      });
+
+      const { createDeploymentsCommand } =
+        await import("../src/commands/deployments.js");
+      const cmd = createDeploymentsCommand();
+      await cmd.parseAsync(["list"], { from: "user" });
+
+      const output = consoleOutput.join("\n");
+      expect(output.indexOf("beta")).toBeLessThan(output.indexOf("alpha"));
+      expect(mockApiInstance.listDeployments).toHaveBeenCalledWith({
+        limit: 30,
+        skip: undefined,
+        sort: "createdAt:desc",
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- Preserve API-returned deployment order when `mcp-use deployments list --sort <field>` is used.
- Keep the existing no-`--sort` createdAt descending display behavior.
- Add focused regression coverage and a patch changeset for `@mcp-use/cli`.

Closes #1751

## Root Cause
The CLI sent the requested sort to the deployments API, but then always re-sorted the returned page locally by `createdAt` descending before printing. That could make paginated output ignore the explicit sort order.

## Validation
- `pnpm --filter @mcp-use/cli exec vitest run tests/deployments.test.ts`
- `pnpm --filter @mcp-use/cli test`
- `pnpm build`
- `pnpm format:check`
- `pnpm lint`

## Notes
- `pnpm test` was attempted but blocked by unrelated `mcp-use` agent integration tests requiring `OPENAI_API_KEY`.
