### PR TITLE
fix(inspector): scope OAuth proxy fetch per server configuration

### DIFF
--- a/libraries/typescript/.changeset/scoped-oauth-proxy-fetch.md
+++ b/libraries/typescript/.changeset/scoped-oauth-proxy-fetch.md
@@ -1,0 +1,18 @@
+---
+"mcp-use": patch
+---
+
+fix(inspector): scope OAuth proxy fetch per server configuration
+
+The browser OAuth provider previously installed a global `window.fetch`
+interceptor to route OAuth requests through the inspector proxy. With multiple
+servers, connecting one server "Via Proxy" mutated `fetch` for the entire page,
+so other servers (including ones set to "Direct") and unrelated requests were
+affected, and switching a server from "Via Proxy" back to "Direct" could leave a
+stale interceptor behind.
+
+`BrowserOAuthClientProvider` now exposes a scoped `getProxyFetch()` that returns
+a `fetch` confined to a single provider. It is passed only to that server's SDK
+transport and `auth()` calls (via the SDK's `fetch` / `fetchFn` options), so
+OAuth-proxy behavior is scoped to the selected server's connection and the
+global `fetch` is never mutated.

--- a/libraries/typescript/packages/mcp-use/src/auth/browser-provider.ts
+++ b/libraries/typescript/packages/mcp-use/src/auth/browser-provider.ts
@@ -34,6 +34,15 @@ interface BrowserOAuthOptions {
   /** MCP proxy URL that client connected to (for resource field rewriting) */
   connectionUrl?: string;
   /**
+   * When true (default), OAuth requests (.well-known metadata, token,
+   * register, authorize) are routed through `oauthProxyUrl` to bypass CORS.
+   * The routing is applied only to the scoped fetch returned by
+   * {@link BrowserOAuthClientProvider.getProxyFetch}; it never mutates the
+   * global `fetch`. Set to false to connect directly even when an OAuth proxy
+   * URL is available (e.g. when the MCP gateway already proxies OAuth).
+   */
+  proxyOAuthRequests?: boolean;
+  /**
    * Pre-registered OAuth client information. When set, the SDK skips
    * Dynamic Client Registration and uses this client_id directly.
    * Required for proxy-mode auth servers (e.g. Slack, WorkOS proxy)
@@ -62,7 +71,7 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
   private useRedirectFlow?: boolean;
   private oauthProxyUrl?: string;
   private connectionUrl?: string;
-  private originalFetch?: typeof fetch;
+  private proxyOAuthRequests: boolean;
   private _lastOriginalResource: string | null = null;
   readonly onPopupWindow:
     | ((
@@ -83,6 +92,7 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
     this.useRedirectFlow = options.useRedirectFlow;
     this.oauthProxyUrl = options.oauthProxyUrl;
     this.connectionUrl = options.connectionUrl;
+    this.proxyOAuthRequests = options.proxyOAuthRequests ?? true;
     this.staticClientInfo = options.staticClientInfo;
     this.onPopupWindow = options.onPopupWindow;
   }
@@ -122,36 +132,38 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
   }
 
   /**
-   * Install fetch interceptor to proxy OAuth requests through the backend
+   * Returns a `fetch` function, scoped to this provider, that routes OAuth
+   * requests (`.well-known` metadata, token, register, authorize) through the
+   * configured `oauthProxyUrl` to bypass CORS. All other requests are passed
+   * through to `baseFetch` unchanged.
+   *
+   * Unlike patching the global `fetch`, the returned function only affects the
+   * transport/auth calls it is explicitly handed to (via the SDK transport's
+   * `fetch` option or `auth({ fetchFn })`). Connecting one server "Via Proxy"
+   * therefore never alters fetch behavior for other servers, other
+   * connections, or the rest of the page.
+   *
+   * When this provider is not configured to proxy OAuth requests (no
+   * `oauthProxyUrl`, or `proxyOAuthRequests` disabled), the provided
+   * `baseFetch` is returned as-is (or `undefined` when none is given, letting
+   * the SDK fall back to its default `fetch`).
+   *
+   * @param baseFetch - The fetch used for non-OAuth requests and for the
+   *   underlying proxy calls. Defaults to the global `fetch`.
    */
-  installFetchInterceptor(): void {
-    if (!this.oauthProxyUrl) {
-      console.warn(
-        "[BrowserOAuthProvider] No OAuth proxy URL configured, skipping fetch interceptor installation"
-      );
-      return; // No proxy configured
+  getProxyFetch(baseFetch?: typeof fetch): typeof fetch | undefined {
+    if (!this.proxyOAuthRequests || !this.oauthProxyUrl) {
+      // Nothing to scope — return the caller's base fetch (possibly undefined).
+      return baseFetch;
     }
 
-    // Store original fetch if not already stored
-    if (!this.originalFetch) {
-      this.originalFetch = window.fetch;
-    } else {
-      console.warn(
-        "[BrowserOAuthProvider] Fetch interceptor already installed"
-      );
-      return; // Already installed
-    }
-
+    const base: typeof fetch = baseFetch ?? globalThis.fetch.bind(globalThis);
     const oauthProxyUrl = this.oauthProxyUrl;
     const connectionUrl = this.connectionUrl; // Capture connectionUrl in closure
     const serverUrl = this.serverUrl; // Capture serverUrl for WWW-Authenticate discovery
-    const originalFetch = this.originalFetch;
-    console.log(
-      `[BrowserOAuthProvider] Installing fetch interceptor with proxy: ${oauthProxyUrl}`
-    );
 
-    // Create interceptor
-    window.fetch = async (
+    // Create scoped fetch
+    return async (
       input: RequestInfo | URL,
       init?: RequestInit
     ): Promise<Response> => {
@@ -168,7 +180,7 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
         url.match(/\/(register|token|authorize)$/);
 
       if (!isOAuthRequest) {
-        return await originalFetch(input, init);
+        return await base(input, init);
       }
 
       // Don't intercept requests already going to our OAuth proxy (avoid circular proxying)
@@ -182,7 +194,7 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
           (urlObj.pathname.startsWith(proxyUrlObj.pathname) ||
             url.includes("/inspector/api/oauth"))
         ) {
-          return await originalFetch(input, init);
+          return await base(input, init);
         }
       } catch {
         // If URL parsing fails, continue with interception (better safe than sorry)
@@ -221,7 +233,7 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
             proxyUrl.searchParams.set("mcp_url", serverUrl);
           }
 
-          const metadataResponse = await originalFetch(proxyUrl.toString(), {
+          const metadataResponse = await base(proxyUrl.toString(), {
             ...init,
             method: "GET",
             headers,
@@ -249,7 +261,7 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
 
         // OAuth endpoint requests: serialize and proxy the full request unchanged.
         const body = init?.body ? await serializeBody(init.body) : undefined;
-        const response = await originalFetch(proxyEndpoint, {
+        const response = await base(proxyEndpoint, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -273,20 +285,9 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
           "[OAuth Proxy] Request failed, falling back to direct fetch:",
           error
         );
-        return await originalFetch(input, init);
+        return await base(input, init);
       }
     };
-  }
-
-  /**
-   * Restore original fetch after OAuth flow completes
-   */
-  restoreFetch(): void {
-    if (this.originalFetch) {
-      console.log("[BrowserOAuthProvider] Restoring original fetch");
-      window.fetch = this.originalFetch;
-      this.originalFetch = undefined;
-    }
   }
 
   // --- SDK Interface Methods (delegated) ---

--- a/libraries/typescript/packages/mcp-use/src/auth/callback.ts
+++ b/libraries/typescript/packages/mcp-use/src/auth/callback.ts
@@ -464,13 +464,15 @@ async function doOnMcpAuthorization() {
       );
     }
 
-    // Install fetch interceptor if OAuth proxy was configured or inferred
-    // This is needed to bypass CORS for token exchange requests
+    // Build a fetch scoped to this provider that routes the token-exchange
+    // request through the OAuth proxy (to bypass CORS) when one is configured
+    // or inferred. This is passed only to auth() below — it never mutates the
+    // global fetch.
+    const scopedFetch = provider.getProxyFetch();
     if (oauthProxyUrl) {
       console.log(
-        `${logPrefix} Installing fetch interceptor for token exchange (proxy: ${oauthProxyUrl})`
+        `${logPrefix} Using scoped OAuth proxy fetch for token exchange (proxy: ${oauthProxyUrl})`
       );
-      provider.installFetchInterceptor();
     }
 
     // --- Call SDK Auth Function ---
@@ -493,6 +495,7 @@ async function doOnMcpAuthorization() {
     const authResult = await auth(provider, {
       serverUrl: sdkServerUrl,
       authorizationCode: code,
+      fetchFn: scopedFetch,
     });
 
     if (authResult === "AUTHORIZED") {

--- a/libraries/typescript/packages/mcp-use/src/react/useMcp-helpers.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/useMcp-helpers.ts
@@ -77,7 +77,12 @@ export function createBrowserOAuthProvider(params: {
     features: string,
     window: globalThis.Window | null
   ) => void;
-  installFetchInterceptor: boolean;
+  /**
+   * Whether the provider should route OAuth requests through the derived
+   * OAuth proxy (to bypass CORS). The provider exposes this via its scoped
+   * `getProxyFetch()` — it never patches the global `fetch`.
+   */
+  proxyOAuthRequests: boolean;
   staticClientInfo?: OAuthClientInformation;
   scope?: string;
 }): {
@@ -97,13 +102,10 @@ export function createBrowserOAuthProvider(params: {
     oauthProxyUrl,
     connectionUrl: params.gatewayUrl,
     onPopupWindow: params.onPopupWindow,
+    proxyOAuthRequests: params.proxyOAuthRequests,
     staticClientInfo: params.staticClientInfo,
     scope: params.scope,
   });
-
-  if (oauthProxyUrl && params.installFetchInterceptor) {
-    provider.installFetchInterceptor();
-  }
 
   return { provider, oauthProxyUrl };
 }

--- a/libraries/typescript/packages/mcp-use/src/react/useMcp.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/useMcp.ts
@@ -2312,10 +2312,6 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
       isMountedRef.current = false;
       addLog("debug", "useMcp unmounting, disconnecting.");
 
-      // No global fetch teardown is needed: OAuth proxying is scoped to the
-      // provider's getProxyFetch() and the SDK transport/auth calls it is
-      // passed to, so unmounting never leaves a stale global fetch behind.
-
       // NOTE: We intentionally do NOT clear OAuth storage on unmount, even
       // mid-flow. Wrapper remounts (provider `_updateVersion` bumps, route
       // churn, StrictMode double-mounting) would otherwise destroy the

--- a/libraries/typescript/packages/mcp-use/src/react/useMcp.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/useMcp.ts
@@ -52,8 +52,13 @@ type UseMcpAuthProvider = OAuthClientProvider & {
     client_id: string;
     client_secret?: string;
   } | null>;
-  installFetchInterceptor?: () => void;
-  restoreFetch?: () => void;
+  /**
+   * Returns a `fetch` scoped to this provider that routes OAuth requests
+   * through the configured OAuth proxy (bypassing CORS) while leaving the
+   * global `fetch` untouched. Passed to the SDK transport / `auth()` so proxy
+   * behavior is confined to this server's connection.
+   */
+  getProxyFetch?: (baseFetch?: typeof fetch) => typeof fetch | undefined;
   serverUrl?: string;
   /** localStorage key for a given suffix (e.g. "tokens"). */
   getKey?: (keySuffix: string) => string;
@@ -662,7 +667,7 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
         useRedirectFlow,
         gatewayUrl,
         onPopupWindow,
-        installFetchInterceptor: true,
+        proxyOAuthRequests: true,
         staticClientInfo,
         scope: oauthScope,
       });
@@ -718,8 +723,16 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
           // Use SSE transport when explicitly requested
           preferSse: transportTypeParam === "sse",
           clientInfo: mergedClientInfo,
-          // Pass custom fetch if provided (e.g., OAuth retry fetch for scope-step-up)
-          ...(customFetch && { fetch: customFetch }),
+          // Pass a fetch that scopes OAuth-proxy routing to this server's
+          // transport/auth calls. getProxyFetch wraps `customFetch` (e.g. the
+          // OAuth retry fetch for scope step-up) when proxying, or returns it
+          // unchanged otherwise. Never mutates the global fetch.
+          ...(() => {
+            const scopedFetch =
+              authProviderRef.current?.getProxyFetch?.(customFetch) ??
+              customFetch;
+            return scopedFetch ? { fetch: scopedFetch } : {};
+          })(),
           // Pass clientOptions for custom capabilities (e.g., MCP Apps extension)
           ...(clientOptions && { clientOptions }),
           // Pass user-configurable reconnection options, or when autoReconnect
@@ -1205,6 +1218,7 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
                   serverUrl: url,
                   ...(resourceMetadataUrl && { resourceMetadataUrl }),
                   ...(scope && { scope }),
+                  fetchFn: authProviderRef.current.getProxyFetch?.(),
                 });
 
                 if (authResult === "REDIRECT") {
@@ -1224,6 +1238,7 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
                     ...(resourceMetadataUrl && { resourceMetadataUrl }),
                     ...(scope && { scope }),
                     authorizationCode: authCode,
+                    fetchFn: authProviderRef.current.getProxyFetch?.(),
                   });
                 }
 
@@ -1493,6 +1508,7 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
             parsedUrl.origin + parsedUrl.pathname.replace(/\/+$/, "");
           await auth(authProviderRef.current, {
             serverUrl: baseUrl,
+            fetchFn: authProviderRef.current.getProxyFetch?.(),
           });
           connectRef.current?.();
           return;
@@ -1540,17 +1556,17 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
             useRedirectFlow,
             gatewayUrl,
             onPopupWindow: captureOnPopupWindow,
-            installFetchInterceptor: !gatewayUrl,
+            proxyOAuthRequests: !gatewayUrl,
             staticClientInfo,
             scope: oauthScope,
           });
 
         if (oauthProxyUrl && !gatewayUrl) {
-          addLog("info", "Installed OAuth fetch interceptor for manual auth");
+          addLog("info", "Scoped OAuth proxy fetch enabled for manual auth");
         } else if (oauthProxyUrl && gatewayUrl) {
           addLog(
             "info",
-            "Using MCP gateway proxy for OAuth (no fetch interceptor needed)"
+            "Using MCP gateway proxy for OAuth (no scoped OAuth fetch needed)"
           );
         }
 
@@ -1567,6 +1583,7 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
         try {
           await auth(freshAuthProvider, {
             serverUrl: baseUrl,
+            fetchFn: freshAuthProvider.getProxyFetch?.(),
           });
           addLog("info", "OAuth flow completed (tokens obtained)");
         } catch (err: unknown) {
@@ -2274,7 +2291,7 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
         useRedirectFlow,
         gatewayUrl,
         onPopupWindow,
-        installFetchInterceptor: true,
+        proxyOAuthRequests: true,
         staticClientInfo,
         scope: oauthScope,
       });
@@ -2295,9 +2312,9 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
       isMountedRef.current = false;
       addLog("debug", "useMcp unmounting, disconnecting.");
 
-      // Restore window.fetch if a proxy interceptor was installed.
-      // restoreFetch() is a no-op when no interceptor is active.
-      authProviderRef.current?.restoreFetch?.();
+      // No global fetch teardown is needed: OAuth proxying is scoped to the
+      // provider's getProxyFetch() and the SDK transport/auth calls it is
+      // passed to, so unmounting never leaves a stale global fetch behind.
 
       // NOTE: We intentionally do NOT clear OAuth storage on unmount, even
       // mid-flow. Wrapper remounts (provider `_updateVersion` bumps, route

--- a/libraries/typescript/packages/mcp-use/tests/unit/auth/browser-provider-proxy-fetch.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/auth/browser-provider-proxy-fetch.test.ts
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+
+/**
+ * Tests that OAuth proxy behavior is scoped to the provider via
+ * `getProxyFetch()` and never mutates the global `fetch`.
+ *
+ * Related issue: #1766 — Inspector: setting one server to "Via Proxy" must not
+ * affect every fetch globally. Multiple servers should independently choose
+ * "Via Proxy" or "Direct", and proxy behavior must be confined to the selected
+ * server's connection rather than patching `window.fetch`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BrowserOAuthClientProvider } from "../../../src/auth/browser-provider.js";
+
+const PROXY_URL = "https://inspector.local/inspector/api/oauth";
+
+describe("BrowserOAuthClientProvider — scoped OAuth proxy fetch", () => {
+  let globalFetchSpy: ReturnType<typeof vi.fn>;
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    localStorage.clear();
+    originalFetch = globalThis.fetch;
+    globalFetchSpy = vi.fn(async () => new Response("{}", { status: 200 }));
+    globalThis.fetch = globalFetchSpy as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  function makeProvider(options: Record<string, unknown> = {}) {
+    return new BrowserOAuthClientProvider("https://server-a.example.com/mcp", {
+      callbackUrl: "https://app.example.com/oauth/callback",
+      ...options,
+    });
+  }
+
+  it("never reassigns the global fetch when building a scoped proxy fetch", () => {
+    const fetchBefore = globalThis.fetch;
+    const provider = makeProvider({ oauthProxyUrl: PROXY_URL });
+
+    const scoped = provider.getProxyFetch();
+
+    // The global fetch must be left untouched — the whole point of #1766.
+    expect(globalThis.fetch).toBe(fetchBefore);
+    // A distinct, scoped fetch is returned (not the global one).
+    expect(scoped).toBeTypeOf("function");
+    expect(scoped).not.toBe(globalThis.fetch);
+  });
+
+  it("routes OAuth metadata requests through the proxy without touching non-OAuth requests", async () => {
+    const provider = makeProvider({ oauthProxyUrl: PROXY_URL });
+    const scoped = provider.getProxyFetch()!;
+
+    // Non-OAuth request: passes straight through to the base fetch, untouched.
+    await scoped("https://server-a.example.com/mcp");
+    expect(globalFetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(globalFetchSpy.mock.calls[0][0])).toBe(
+      "https://server-a.example.com/mcp"
+    );
+
+    // OAuth metadata request: rewritten to go through the OAuth proxy.
+    await scoped(
+      "https://server-a.example.com/.well-known/oauth-authorization-server"
+    );
+    expect(globalFetchSpy).toHaveBeenCalledTimes(2);
+    const proxiedUrl = String(globalFetchSpy.mock.calls[1][0]);
+    expect(proxiedUrl.startsWith(`${PROXY_URL}/metadata`)).toBe(true);
+  });
+
+  it("Server B (Direct) gets a plain fetch and never proxies — even while Server A uses a proxy", async () => {
+    // Server A: "Via Proxy".
+    const serverA = new BrowserOAuthClientProvider(
+      "https://server-a.example.com/mcp",
+      {
+        callbackUrl: "https://app.example.com/oauth/callback",
+        oauthProxyUrl: PROXY_URL,
+      }
+    );
+    // Server B: "Direct" (no OAuth proxy configured).
+    const serverB = new BrowserOAuthClientProvider(
+      "https://server-b.example.com/mcp",
+      { callbackUrl: "https://app.example.com/oauth/callback" }
+    );
+
+    // Building Server A's proxy fetch must not affect anything else.
+    const fetchA = serverA.getProxyFetch();
+    expect(fetchA).toBeTypeOf("function");
+
+    // Server B returns the base fetch as-is (no scoping/proxy wrapper).
+    const baseFetchB = vi.fn(
+      async () => new Response("{}", { status: 200 })
+    ) as unknown as typeof fetch;
+    const fetchB = serverB.getProxyFetch(baseFetchB);
+    expect(fetchB).toBe(baseFetchB);
+
+    // An OAuth-shaped request through Server B's fetch must go DIRECT, not via
+    // Server A's proxy.
+    await fetchB!(
+      "https://server-b.example.com/.well-known/oauth-authorization-server"
+    );
+    expect(baseFetchB).toHaveBeenCalledTimes(1);
+    expect(String((baseFetchB as any).mock.calls[0][0])).toBe(
+      "https://server-b.example.com/.well-known/oauth-authorization-server"
+    );
+    // The global fetch was never used for Server B's request.
+    expect(globalFetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns the base fetch unchanged when proxyOAuthRequests is disabled", () => {
+    const provider = makeProvider({
+      oauthProxyUrl: PROXY_URL,
+      proxyOAuthRequests: false,
+    });
+
+    const base = vi.fn() as unknown as typeof fetch;
+    expect(provider.getProxyFetch(base)).toBe(base);
+    expect(provider.getProxyFetch()).toBeUndefined();
+  });
+
+  it("returns the base fetch unchanged when no OAuth proxy URL is configured", () => {
+    const provider = makeProvider();
+
+    const base = vi.fn() as unknown as typeof fetch;
+    expect(provider.getProxyFetch(base)).toBe(base);
+    expect(provider.getProxyFetch()).toBeUndefined();
+  });
+
+  it("wraps a provided base fetch (e.g. scope step-up retry) for non-OAuth requests", async () => {
+    const provider = makeProvider({ oauthProxyUrl: PROXY_URL });
+    const customFetch = vi.fn(
+      async () => new Response("{}", { status: 200 })
+    ) as unknown as typeof fetch;
+
+    const scoped = provider.getProxyFetch(customFetch)!;
+    await scoped("https://server-a.example.com/mcp");
+
+    // Non-OAuth request flows through the provided base fetch, not the global.
+    expect(customFetch).toHaveBeenCalledTimes(1);
+    expect(globalFetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/libraries/typescript/packages/mcp-use/tests/unit/react/useMcp-disconnect-reused-client-race.test.tsx
+++ b/libraries/typescript/packages/mcp-use/tests/unit/react/useMcp-disconnect-reused-client-race.test.tsx
@@ -37,7 +37,6 @@ const mockAuthProvider = {
   serverUrl: "http://localhost/a/mcp",
   tokens: vi.fn().mockResolvedValue(undefined),
   clearStorage: vi.fn().mockReturnValue(0),
-  restoreFetch: vi.fn(),
 };
 
 function makeSession() {

--- a/libraries/typescript/packages/mcp-use/tests/unit/react/useMcp-proxyCleanup.test.tsx
+++ b/libraries/typescript/packages/mcp-use/tests/unit/react/useMcp-proxyCleanup.test.tsx
@@ -1,12 +1,16 @@
 // @vitest-environment jsdom
 
 /**
- * Tests that useMcp calls restoreFetch() on unmount to tear down any
- * window.fetch interceptor installed by a proxy-mode OAuth provider.
+ * Tests that useMcp scopes OAuth proxy behavior to the connection instead of
+ * mutating the global fetch.
  *
- * Related issue: MCP-1713 — Inspector: switching from "Via Proxy" → "Direct"
- * fails with "Protected resource does not match" error because the stale
- * interceptor from the proxy connection is never removed.
+ * Originally tracked the MCP-1713 symptom (switching "Via Proxy" → "Direct"
+ * failed because a stale global fetch interceptor was never torn down). That
+ * class of bug — and the related #1766 (one "Via Proxy" server affecting every
+ * fetch globally) — is now structurally impossible: the provider exposes a
+ * scoped `getProxyFetch()` that is passed only to the SDK transport/auth, so
+ * the global `fetch` is never reassigned and there is nothing to "restore" on
+ * unmount.
  */
 
 import React from "react";
@@ -43,21 +47,28 @@ vi.mock("../../../src/telemetry/index.js", () => ({
 
 describe("useMcp proxy connection cleanup", () => {
   let useMcp: any;
+  let originalFetch: typeof globalThis.fetch;
 
   beforeEach(async () => {
     vi.resetModules();
+    originalFetch = globalThis.fetch;
     const module = await import("../../../src/react/useMcp.js");
     useMcp = module.useMcp;
   });
 
   afterEach(() => {
+    globalThis.fetch = originalFetch;
     vi.clearAllMocks();
   });
 
-  it("calls restoreFetch() on the auth provider when the hook unmounts", async () => {
-    const restoreFetch = vi.fn();
+  it("never reassigns the global fetch across a proxy connection's mount/unmount", async () => {
+    const fetchBefore = globalThis.fetch;
+
+    // A proxy-mode auth provider exposes a scoped getProxyFetch(); the hook must
+    // not install or tear down any global fetch interceptor.
+    const getProxyFetch = vi.fn((base?: typeof fetch) => base);
     const mockAuthProvider = {
-      restoreFetch,
+      getProxyFetch,
       clearStorage: vi.fn().mockReturnValue(0),
       serverUrl: "http://localhost:3001/mcp",
     };
@@ -77,13 +88,14 @@ describe("useMcp proxy connection cleanup", () => {
       renderer = create(<TestComponent />);
     });
 
-    expect(restoreFetch).not.toHaveBeenCalled();
+    expect(globalThis.fetch).toBe(fetchBefore);
 
     await act(async () => {
       renderer!.unmount();
     });
 
-    expect(restoreFetch).toHaveBeenCalledOnce();
+    // Global fetch identity is preserved — no global interceptor was installed.
+    expect(globalThis.fetch).toBe(fetchBefore);
   });
 
   it("does not throw on unmount when no auth provider is set", async () => {


### PR DESCRIPTION
## Changes

The Inspector's OAuth proxy took over the global `fetch`. In a list of multiple servers, setting **one** server to "Via Proxy" caused **every** fetch on the page to go through that proxy- breaking the ability to reliably test multiple servers side by side.

`BrowserOAuthClientProvider.installFetchInterceptor()` did `window.fetch = …` (a process-wide mutation). This change replaces that global patch with a per-provider scoped fetch so proxy behavior is confined to the server/configuration that selected it.

## Implementation Details

1. **`auth/browser-provider.ts`** - Replaced `installFetchInterceptor()` / `restoreFetch()` (and the `originalFetch` field) with a scoped `getProxyFetch(baseFetch?)`. It returns a `fetch` that routes only OAuth requests (`.well-known` metadata, token, register, authorize) through the configured OAuth proxy and passes everything else to `baseFetch`. It never touches the global `fetch`. Added a `proxyOAuthRequests` option (default `true`) so a provider can opt out (e.g. when an MCP gateway already proxies OAuth).
2. **`react/useMcp.ts`** - Passes the scoped fetch into the SDK transport (`fetch`) and into all `auth()` calls (`fetchFn`). The MCP SDK threads its transport `fetch` into `auth({ fetchFn })`, which propagates it through metadata discovery, token exchange, and dynamic client registration - so OAuth is fully covered without any global patch. Replaced the `installFetchInterceptor` flags with `proxyOAuthRequests` and removed the global `restoreFetch()` unmount teardown.
3. **`react/useMcp-helpers.ts`** - `createBrowserOAuthProvider` now configures `proxyOAuthRequests` on the provider instead of installing a global interceptor.
4. **`auth/callback.ts`** - The token-exchange `auth()` call now receives a scoped `fetchFn` instead of patching global fetch.

Because the Inspector wraps each server in its own `useMcp` instance (one `BrowserOAuthClientProvider` per server) via `McpClientProvider`, each server independently chooses Via Proxy or Direct with no cross-contamination.

## Example Usage

```ts
// Server A - "Via Proxy": only A's transport/auth get the proxy-routing fetch
const fetchA = providerA.getProxyFetch(); // OAuth → proxy, everything else → base

// Server B - "Direct": no OAuth proxy configured
const fetchB = providerB.getProxyFetch(); // undefined → SDK uses normal fetch

// globalThis.fetch is never reassigned by either.
```

## Testing

- Added `tests/unit/auth/browser-provider-proxy-fetch.test.ts`: Server A ("Via Proxy") vs Server B ("Direct") - asserts B never proxies, that building A's proxy fetch never reassigns the global `fetch`, and that OAuth metadata requests are rewritten to the proxy.
- Rewrote `tests/unit/react/useMcp-proxyCleanup.test.tsx` to assert the global `fetch` identity is preserved across a proxy connection's mount/unmount (replacing the now-obsolete `restoreFetch` assertion).
- `pnpm --filter mcp-use test:unit` → **605 passed / 6 skipped**; `tsc --noEmit`, `pnpm build`, `eslint`, and `prettier --check` all clean.

## Backwards Compatibility

Behavior-preserving for end users: providers proxy OAuth requests under the same conditions as before, just scoped to their own connection. This also structurally removes the related "stale interceptor after switching Via Proxy → Direct" failure mode.

The public `installFetchInterceptor()` / `restoreFetch()` methods on `BrowserOAuthClientProvider` are **removed** (replaced by `getProxyFetch()`). Per the repo guidance to avoid unrequested backward-compat shims, no deprecation wrappers were added — happy to add them if preferred.

## Related Issues

Closes #1766