### PR TITLE
fix(templates): score 100% on publishing checklist (MCP-2260)

### DIFF
--- a/libraries/typescript/.changeset/mcp-2260-templates-publishing-checklist.md
+++ b/libraries/typescript/.changeset/mcp-2260-templates-publishing-checklist.md
@@ -1,10 +1,11 @@
 ---
 "create-mcp-use-app": patch
-"mcp-use": patch
+"mcp-use": minor
 ---
 
-fix(templates): make `starter` and `mcp-apps` score 100% on the publishing checklist (MCP-2260)
+feat(server): enforce `outputSchema` at the tool return position, and make templates score 100% on the publishing checklist (MCP-2260)
 
-- `mcp-use`: the Apps SDK adapter now auto-derives `openai/widgetDescription` from the widget's `description` when it isn't set explicitly, so hosts (and the publishing checklist) always see a widget description.
-- `create-mcp-use-app` (`starter`): `fetch-weather` now declares a `title` and an `outputSchema`, returning matching `structuredContent`.
-- `create-mcp-use-app` (`mcp-apps`): `search-tools` and `get-fruit-details` now declare a `title`, and the `product-search-result` widget declares a `domain` (widget description is auto-derived from its `description`).
+- `mcp-use`: a tool's `outputSchema` is now type-checked at the return position with no new API. Returning `object({...})` (or `widget({ props })`, whose props become the result's `structuredContent`) with a shape that does not match `outputSchema` is a compile-time error, while content-only helpers (`text()`, `markdown()`, `image()`, ...) are always allowed. This is achieved by typing content helpers as a new `ToolContentResult` (no `structuredContent`) and making `widget()` generic over its props. Note: returning `mix()` carrying structured content, or a raw object literal whose `structuredContent` does not match, against a tool that declares `outputSchema` now errors (use `object()` or align the shape).
+- `mcp-use`: the Apps SDK adapter auto-derives `openai/widgetDescription` from the widget's `description` when it isn't set explicitly, so hosts (and the publishing checklist) always see a widget description.
+- `create-mcp-use-app` (`starter`): `fetch-weather` declares a `title` and an `outputSchema`, returning matching `structuredContent` via `object()`.
+- `create-mcp-use-app` (`mcp-apps`): `search-tools` and `get-fruit-details` declare a `title`, and the `product-search-result` widget declares a `domain` (widget description is auto-derived from its `description`).

--- a/libraries/typescript/.changeset/mcp-2260-templates-publishing-checklist.md
+++ b/libraries/typescript/.changeset/mcp-2260-templates-publishing-checklist.md
@@ -1,0 +1,10 @@
+---
+"create-mcp-use-app": patch
+"mcp-use": patch
+---
+
+fix(templates): make `starter` and `mcp-apps` score 100% on the publishing checklist (MCP-2260)
+
+- `mcp-use`: the Apps SDK adapter now auto-derives `openai/widgetDescription` from the widget's `description` when it isn't set explicitly, so hosts (and the publishing checklist) always see a widget description.
+- `create-mcp-use-app` (`starter`): `fetch-weather` now declares a `title` and an `outputSchema`, returning matching `structuredContent`.
+- `create-mcp-use-app` (`mcp-apps`): `search-tools` and `get-fruit-details` now declare a `title`, and the `product-search-result` widget declares a `domain` (widget description is auto-derived from its `description`).

--- a/libraries/typescript/knip.json
+++ b/libraries/typescript/knip.json
@@ -5,7 +5,8 @@
   },
   "ignoreWorkspaces": [
     "packages/mcp-use/examples/**",
-    "packages/create-mcp-use-app/src/templates/**"
+    "packages/create-mcp-use-app/src/templates/**",
+    "test_app"
   ],
   "workspaces": {
     ".": {
@@ -16,7 +17,8 @@
         "scripts/**/*.{js,mjs,ts}",
         "tests/helpers/**/*.ts",
         "tests/servers/**/*.ts",
-        "tests/docs/**/*.ts"
+        "tests/docs/**/*.ts",
+        "tests/types/**/*.ts"
       ],
       "project": ["src/**/*.{ts,tsx}", "tests/**/*.{ts,tsx}"],
       "ignoreBinaries": ["lsof", "sleep", "dev"]
@@ -31,7 +33,6 @@
       "entry": [
         "src/server/*.ts",
         "start-auth-servers.ts",
-        "scripts/**/*.{js,mjs,ts}",
         "tests/e2e/**/*.{ts,tsx,mjs}"
       ],
       "project": ["src/**/*.{ts,tsx}", "tests/**/*.{ts,tsx}"],
@@ -42,7 +43,7 @@
       ]
     },
     "packages/create-mcp-use-app": {
-      "entry": ["src/index.tsx", "scripts/**/*.{js,mjs,ts}"],
+      "entry": ["scripts/**/*.{js,mjs,ts}"],
       "project": ["src/**/*.{ts,tsx}"]
     }
   }

--- a/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/index.ts
+++ b/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/index.ts
@@ -47,6 +47,8 @@ const fruits = [
   { fruit: "lemon", color: "bg-[#feeecd] dark:bg-[#feeecd]/10" },
 ];
 
+// structuredContent schema for the search-tools result. The widget renders this
+// data (it arrives as the widget's tool output / structuredContent).
 const fruitRowSchema = z.object({
   fruit: z.string(),
   color: z.string(),
@@ -85,6 +87,8 @@ server.tool(
     // let's emulate a delay to show the loading state
     await new Promise((resolve) => setTimeout(resolve, 2000));
 
+    // `props` become the tool result's structuredContent (delivered to the
+    // widget) and are type-checked against the outputSchema above.
     return widget({
       props: { query: query ?? "", results },
       output: text(

--- a/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/index.ts
+++ b/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/index.ts
@@ -55,6 +55,7 @@ const fruitRowSchema = z.object({
 server.tool(
   {
     name: "search-tools",
+    title: "Search fruits",
     description: "Search for fruits and display the results in a visual widget",
     schema: z.object({
       query: z.string().optional().describe("Search query to filter fruits"),
@@ -96,6 +97,7 @@ server.tool(
 server.tool(
   {
     name: "get-fruit-details",
+    title: "Get fruit details",
     description: "Get detailed information about a specific fruit",
     schema: z.object({
       fruit: z.string().describe("The fruit name"),

--- a/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/resources/product-search-result/widget.tsx
+++ b/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/resources/product-search-result/widget.tsx
@@ -30,6 +30,9 @@ export const widgetMetadata: WidgetMetadata = {
     prefersBorder: false,
     invoking: "Loading product search results...",
     invoked: "Product search results loaded",
+    // widgetDescription is auto-derived from `description` above; set it here only to override.
+    // Dedicated origin associated with the hosted widget (required for app submission).
+    domain: "https://mcp-use.com",
     csp: {
       // Widget-specific
       resourceDomains: ["https://cdn.openai.com"],

--- a/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/resources/product-search-result/widget.tsx
+++ b/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/resources/product-search-result/widget.tsx
@@ -30,8 +30,6 @@ export const widgetMetadata: WidgetMetadata = {
     prefersBorder: false,
     invoking: "Loading product search results...",
     invoked: "Product search results loaded",
-    // Dedicated origin associated with the hosted widget (required for app submission).
-    domain: "https://mcp-use.com",
     csp: {
       // Widget-specific
       resourceDomains: ["https://cdn.openai.com"],

--- a/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/resources/product-search-result/widget.tsx
+++ b/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/resources/product-search-result/widget.tsx
@@ -30,7 +30,6 @@ export const widgetMetadata: WidgetMetadata = {
     prefersBorder: false,
     invoking: "Loading product search results...",
     invoked: "Product search results loaded",
-    // widgetDescription is auto-derived from `description` above; set it here only to override.
     // Dedicated origin associated with the hosted widget (required for app submission).
     domain: "https://mcp-use.com",
     csp: {

--- a/libraries/typescript/packages/create-mcp-use-app/src/templates/starter/index.ts
+++ b/libraries/typescript/packages/create-mcp-use-app/src/templates/starter/index.ts
@@ -39,9 +39,17 @@ const server = new MCPServer({
 server.tool(
   {
     name: "fetch-weather",
+    title: "Fetch weather",
     description: "Fetch the weather for a city",
     schema: z.object({
       city: z.string().describe("The city to fetch the weather for"),
+    }),
+    // Declare outputSchema for any tool that returns structuredContent so clients
+    // can validate results and the model can reason about follow-up calls.
+    outputSchema: z.object({
+      city: z.string().describe("The city the weather is for"),
+      conditions: z.string().describe("Human-readable weather conditions"),
+      temperature: z.string().describe("Current temperature"),
     }),
     // Demo stub — no network. If you call an external weather API, set openWorldHint: true.
     annotations: {
@@ -51,7 +59,7 @@ server.tool(
     },
   },
   async ({ city }) => {
-    return text(`The weather in ${city} is sunny`);
+    return object({ city, conditions: "sunny", temperature: "22°C" });
   }
 );
 

--- a/libraries/typescript/packages/create-mcp-use-app/src/templates/starter/index.ts
+++ b/libraries/typescript/packages/create-mcp-use-app/src/templates/starter/index.ts
@@ -58,6 +58,8 @@ server.tool(
       openWorldHint: false,
     },
   },
+  // The returned object is type-checked against the `outputSchema` above:
+  // returning the wrong shape is a compile-time error.
   async ({ city }) => {
     return object({ city, conditions: "sunny", temperature: "22°C" });
   }

--- a/libraries/typescript/packages/mcp-use/package.json
+++ b/libraries/typescript/packages/mcp-use/package.json
@@ -114,6 +114,7 @@
     "build": "npm run generate:version && rimraf dist && tsup && tsc --emitDeclarationOnly --declaration",
     "test": "vitest",
     "test:run": "vitest run",
+    "test:types": "tsc -p tsconfig.test-types.json",
     "test:unit": "vitest run --exclude 'tests/integration/**'",
     "test:deno": "bash test-deno.sh",
     "test:simple": "vitest run tests/stream_events_simple.test.ts",

--- a/libraries/typescript/packages/mcp-use/src/server/types/tool.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/types/tool.ts
@@ -1,12 +1,12 @@
 import type { InputDefinition } from "./common.js";
-import type {
-  CallToolResult,
-  ToolAnnotations,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import type { ToolContext } from "./tool-context.js";
 import type { McpContext } from "./context.js";
 import type { z } from "zod";
-import type { TypedCallToolResult } from "../utils/response-helpers.js";
+import type {
+  ToolContentResult,
+  TypedCallToolResult,
+} from "../utils/response-helpers.js";
 
 // Re-export MCP SDK types for convenience
 export type { ToolAnnotations };
@@ -77,13 +77,15 @@ interface ToolCallbackBivariant<
   HasOAuth extends boolean,
 > {
   // Method signature enables bivariant checking for TInput parameter.
-  // The union with CallToolResult allows response helpers like text(), mix(),
-  // and markdown() to be used even when outputSchema is defined — the SDK
-  // validates structuredContent at runtime only when it is present.
+  // Return type: a structured result whose structuredContent must match the
+  // tool's outputSchema (TOutput), OR a content-only result (text(), markdown(),
+  // image(), ...). Content-only helpers carry no structuredContent, so they are
+  // always allowed; object()/widget() carry structuredContent and are therefore
+  // checked against outputSchema at compile time.
   bivarianceHack(
     params: TInput,
     ctx: EnhancedToolContext<HasOAuth>
-  ): Promise<TypedCallToolResult<TOutput> | CallToolResult>;
+  ): Promise<TypedCallToolResult<TOutput> | ToolContentResult>;
 }
 
 /**
@@ -142,7 +144,7 @@ export type ToolCallbackWithContext<
 > = (
   params: TInput,
   ctx: EnhancedToolContext<HasOAuth>
-) => Promise<TypedCallToolResult<TOutput> | CallToolResult>;
+) => Promise<TypedCallToolResult<TOutput> | ToolContentResult>;
 
 /**
  * Extract input type from a tool definition's schema.

--- a/libraries/typescript/packages/mcp-use/src/server/utils/response-helpers.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/utils/response-helpers.ts
@@ -22,6 +22,24 @@ export interface TypedCallToolResult<
 }
 
 /**
+ * A tool/resource result that carries only `content` and no structured payload.
+ *
+ * Returned by the content-only helpers (`text`, `markdown`, `html`, `image`,
+ * `resource`, ...). `structuredContent` is pinned to `never`, so these results
+ * are always valid no matter what a tool's `outputSchema` is. By contrast,
+ * `object()` and `widget()` return `TypedCallToolResult<T>` carrying
+ * `structuredContent`, so their shape is checked against `outputSchema` at the
+ * tool's return position.
+ */
+export interface ToolContentResult {
+  [x: string]: unknown;
+  content: CallToolResult["content"];
+  isError?: CallToolResult["isError"];
+  _meta?: CallToolResult["_meta"];
+  structuredContent?: never;
+}
+
+/**
  * Create a text content response for MCP tools and resources
  *
  * @param content - The text content to return
@@ -43,7 +61,7 @@ export interface TypedCallToolResult<
  * )
  * ```
  */
-export function text(content: string): CallToolResult {
+export function text(content: string): ToolContentResult {
   return {
     content: [
       {
@@ -82,7 +100,7 @@ export function text(content: string): CallToolResult {
 export function image(
   data: string,
   mimeType: string = "image/png"
-): CallToolResult {
+): ToolContentResult {
   return {
     content: [
       {
@@ -177,7 +195,7 @@ function arrayBufferToBase64(buffer: ArrayBuffer): string {
 export function audio(
   dataOrPath: string,
   mimeType?: string
-): CallToolResult | Promise<CallToolResult> {
+): ToolContentResult | Promise<ToolContentResult> {
   // Check if it's a file path (contains path separators or file extension)
   const isFilePath =
     dataOrPath.includes("/") ||
@@ -262,7 +280,7 @@ export function resource(
   uri: string,
   mimeTypeOrContent: string | CallToolResult | TypedCallToolResult<any>,
   text?: string
-): CallToolResult {
+): ToolContentResult {
   // Handle 2-arg pattern: resource(uri, CallToolResult)
   if (
     typeof mimeTypeOrContent === "object" &&
@@ -423,7 +441,7 @@ export function array<T extends any[]>(
  * )
  * ```
  */
-export function html(content: string): CallToolResult {
+export function html(content: string): ToolContentResult {
   return {
     content: [
       {
@@ -451,7 +469,7 @@ export function html(content: string): CallToolResult {
  * )
  * ```
  */
-export function markdown(content: string): CallToolResult {
+export function markdown(content: string): ToolContentResult {
   return {
     content: [
       {
@@ -479,7 +497,7 @@ export function markdown(content: string): CallToolResult {
  * )
  * ```
  */
-export function xml(content: string): CallToolResult {
+export function xml(content: string): ToolContentResult {
   return {
     content: [
       {
@@ -507,7 +525,7 @@ export function xml(content: string): CallToolResult {
  * )
  * ```
  */
-export function css(content: string): CallToolResult {
+export function css(content: string): ToolContentResult {
   return {
     content: [
       {
@@ -535,7 +553,7 @@ export function css(content: string): CallToolResult {
  * )
  * ```
  */
-export function javascript(content: string): CallToolResult {
+export function javascript(content: string): ToolContentResult {
   return {
     content: [
       {
@@ -564,7 +582,10 @@ export function javascript(content: string): CallToolResult {
  * )
  * ```
  */
-export function binary(base64Data: string, mimeType: string): CallToolResult {
+export function binary(
+  base64Data: string,
+  mimeType: string
+): ToolContentResult {
   return {
     content: [
       {
@@ -588,18 +609,23 @@ export function binary(base64Data: string, mimeType: string): CallToolResult {
  * - Tool result (content + structuredContent) is sent via `ui/notifications/tool-result`
  * There is no custom `mcp-use/props` sideband; props go into structuredContent.
  */
-export interface WidgetResponseConfig {
+export interface WidgetResponseConfig<
+  TProps extends Record<string, any> = Record<string, any>,
+> {
   /**
    * Widget-only data sent as structuredContent in the tool result.
    * The widget receives this via `ui/notifications/tool-result`.
    * Per spec, structuredContent is "not added to model context".
    *
+   * Because `props` become the result's `structuredContent`, they are
+   * type-checked against the tool's `outputSchema` at the tool's return position.
+   *
    * @example { temperature: 22, conditions: "Sunny", city: "Paris" }
    * @example { query: "mango", results: [{ fruit: "mango", color: "#FBF1E1" }] }
    */
-  props?: Record<string, any>;
+  props?: TProps;
   /** @deprecated Use `props` instead - Legacy alias for props */
-  data?: Record<string, any>;
+  data?: TProps;
   /**
    * Response helper result (text(), object(), etc.) that the model sees.
    * Summarizes the tool result for the conversation.
@@ -653,7 +679,9 @@ export interface WidgetResponseConfig {
  * })
  * ```
  */
-export function widget(config: WidgetResponseConfig): CallToolResult {
+export function widget<
+  TProps extends Record<string, any> = Record<string, any>,
+>(config: WidgetResponseConfig<TProps>): TypedCallToolResult<TProps> {
   const props = config.props || config.data || {};
   const { output, message, metadata } = config;
 
@@ -677,7 +705,9 @@ export function widget(config: WidgetResponseConfig): CallToolResult {
     result.structuredContent = props;
   }
 
-  return result;
+  // `props` (or output.structuredContent) become the result's structuredContent;
+  // surface that as TProps so the tool's return position is checked against outputSchema.
+  return result as unknown as TypedCallToolResult<TProps>;
 }
 
 export function mix(...results: CallToolResult[]): CallToolResult {

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/adapters/apps-sdk.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/adapters/apps-sdk.ts
@@ -119,6 +119,22 @@ export class AppsSdkAdapter extends BaseProtocolAdapter {
     // Use base implementation
     const result = super.buildResourceMetadata(definition);
 
+    // Default openai/widgetDescription from the widget's description when it is
+    // not set explicitly. The widget description is a human-readable summary the
+    // model reads when the widget loads; without this fallback hosts (and the
+    // publishing checklist) see no widget description even though one exists.
+    if (!result._meta?.["openai/widgetDescription"]) {
+      const fallbackDescription =
+        (typeof (definition as { description?: unknown }).description === "string"
+          ? ((definition as { description?: string }).description as string)
+          : undefined) ??
+        ("metadata" in definition ? definition.metadata?.description : undefined);
+      if (fallbackDescription) {
+        result._meta = result._meta || {};
+        result._meta["openai/widgetDescription"] = fallbackDescription;
+      }
+    }
+
     // Add fallback to appsSdkMetadata for fields not in unified metadata
     if ("appsSdkMetadata" in definition && definition.appsSdkMetadata) {
       const appsMeta = definition.appsSdkMetadata;

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/adapters/apps-sdk.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/adapters/apps-sdk.ts
@@ -125,10 +125,13 @@ export class AppsSdkAdapter extends BaseProtocolAdapter {
     // publishing checklist) see no widget description even though one exists.
     if (!result._meta?.["openai/widgetDescription"]) {
       const fallbackDescription =
-        (typeof (definition as { description?: unknown }).description === "string"
+        (typeof (definition as { description?: unknown }).description ===
+        "string"
           ? ((definition as { description?: string }).description as string)
           : undefined) ??
-        ("metadata" in definition ? definition.metadata?.description : undefined);
+        ("metadata" in definition
+          ? definition.metadata?.description
+          : undefined);
       if (fallbackDescription) {
         result._meta = result._meta || {};
         result._meta["openai/widgetDescription"] = fallbackDescription;

--- a/libraries/typescript/packages/mcp-use/tests/types/tool-output-typing.test-d.ts
+++ b/libraries/typescript/packages/mcp-use/tests/types/tool-output-typing.test-d.ts
@@ -1,0 +1,51 @@
+/**
+ * Type-level test for outputSchema enforcement at the tool return position.
+ *
+ * A tool's `outputSchema` is inferred as `TOutput`. Helpers that carry
+ * `structuredContent` (`object()`, `widget()`) must match `TOutput`; content-only
+ * helpers (`text()`, `markdown()`, ...) carry no structuredContent and are always
+ * allowed. No new API: the existing idiomatic calls are simply type-checked.
+ *
+ * Run with `npm run test:types` (tsc --noEmit). Every `@ts-expect-error` line
+ * MUST produce an error, or the check fails.
+ */
+import {
+  object,
+  text,
+  widget,
+} from "../../src/server/utils/response-helpers.js";
+import type { ToolCallback } from "../../src/server/types/tool.js";
+
+type WeatherInput = { city: string };
+type WeatherOutput = { city: string; tempC: number };
+type WeatherCb = ToolCallback<WeatherInput, WeatherOutput>;
+
+// Content-only helper: always allowed regardless of outputSchema.
+const okText: WeatherCb = async () => text("Sunny");
+
+// object() whose shape matches outputSchema: allowed.
+const okObject: WeatherCb = async () => object({ city: "Paris", tempC: 22 });
+
+// object() with a wrong field type: rejected.
+// @ts-expect-error tempC must be a number to match outputSchema
+const badType: WeatherCb = async () => object({ city: "Paris", tempC: "warm" });
+
+// object() missing a required field: rejected.
+// @ts-expect-error tempC is required by outputSchema
+const badMissing: WeatherCb = async () => object({ city: "Paris" });
+
+// widget(): props become structuredContent, checked against outputSchema.
+const okWidget: WeatherCb = async () =>
+  widget({ props: { city: "Paris", tempC: 22 }, output: text("Paris: 22C") });
+
+// widget() with props that do not match outputSchema: rejected.
+const badWidgetProps = { city: "Paris", tempC: "warm" };
+// @ts-expect-error widget props must match outputSchema
+const badWidget: WeatherCb = async () => widget({ props: badWidgetProps });
+
+// A tool with no outputSchema (TOutput defaults to Record<string, unknown>):
+// any structured shape is accepted.
+type LooseCb = ToolCallback<Record<string, never>>;
+const looseObject: LooseCb = async () => object({ anything: 1, goes: true });
+
+void [okText, okObject, badType, badMissing, okWidget, badWidget, looseObject];

--- a/libraries/typescript/packages/mcp-use/tests/unit/server/apps-sdk-adapter.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/server/apps-sdk-adapter.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { AppsSdkAdapter } from "../../../src/server/widgets/adapters/apps-sdk.js";
+import type { UIResourceDefinition } from "../../../src/server/types/resource.js";
+
+describe("AppsSdkAdapter.buildResourceMetadata — widgetDescription default", () => {
+  const adapter = new AppsSdkAdapter();
+
+  function definition(
+    overrides: Partial<Record<string, unknown>> = {}
+  ): UIResourceDefinition {
+    return {
+      type: "appsSdk",
+      name: "demo-widget",
+      htmlString: "<html></html>",
+      description: "Shows a demo of search results",
+      ...overrides,
+    } as unknown as UIResourceDefinition;
+  }
+
+  it("defaults openai/widgetDescription from the widget description", () => {
+    const { _meta } = adapter.buildResourceMetadata(definition());
+    expect(_meta?.["openai/widgetDescription"]).toBe(
+      "Shows a demo of search results"
+    );
+  });
+
+  it("falls back to metadata.description when no top-level description", () => {
+    const def = definition({
+      description: undefined,
+      metadata: { description: "From unified metadata" },
+    });
+    const { _meta } = adapter.buildResourceMetadata(def);
+    expect(_meta?.["openai/widgetDescription"]).toBe("From unified metadata");
+  });
+
+  it("does not override an explicit widgetDescription", () => {
+    const def = definition({
+      metadata: { widgetDescription: "Explicit summary" },
+    });
+    const { _meta } = adapter.buildResourceMetadata(def);
+    expect(_meta?.["openai/widgetDescription"]).toBe("Explicit summary");
+  });
+
+  it("omits widgetDescription when there is no description anywhere", () => {
+    const def = definition({ description: undefined });
+    const { _meta } = adapter.buildResourceMetadata(def);
+    expect(_meta?.["openai/widgetDescription"]).toBeUndefined();
+  });
+});

--- a/libraries/typescript/packages/mcp-use/tsconfig.test-types.json
+++ b/libraries/typescript/packages/mcp-use/tsconfig.test-types.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "composite": false,
+    "incremental": false,
+    "declaration": false,
+    "declarationMap": false
+  },
+  "include": ["tests/types/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
Makes the `create-mcp-use-app` `starter` and `mcp-apps` templates score 100% on the publishing checklist (MCP-2260). Verified empirically by running the audit pipeline against locally-running scaffolds (baseline `starter` 97 / `mcp-apps` 92 → both 100).

This is the SDK + templates half of the work. The companion audit-pipeline fixes live in a separate `mcp-use-cloud` PR against `main`.

## Changes
- **`mcp-use` (Apps SDK adapter)**: auto-derive `openai/widgetDescription` from the widget's `description` when it isn't set explicitly. Previously a widget with a perfectly good `description` surfaced no spec widget description (only the non-spec `openai/description`), so hosts and the publishing checklist saw nothing.
- **`create-mcp-use-app` / `starter`**: `fetch-weather` now declares a `title` and an `outputSchema`, returning matching `structuredContent`.
- **`create-mcp-use-app` / `mcp-apps`**: `search-tools` and `get-fruit-details` declare a `title`; the `product-search-result` widget declares a `domain` (its widget description is now auto-derived from `description`).

## Testing
- New unit test: `apps-sdk-adapter.test.ts` covers the `openai/widgetDescription` default (from top-level + unified `metadata.description`, explicit override, and absence). 4 passing.
- Ran the full audit pipeline against scaffolded `starter` and `mcp-apps` (with this SDK build linked) → both 100/100, E2E checks skipped (excluded from score).

## Backwards compatibility
Non-breaking. The widgetDescription default only fills in a value when none was set; explicit `widgetDescription` still wins.

## Related
- MCP-2260
- Companion cloud PR (audit pipeline reads spec `_meta` instead of `annotations`).