### PR TITLE
fix(websocket): respect read_timeout_seconds for tool calls

### DIFF
--- a/libraries/python/mcp_use/client/connectors/websocket.py
+++ b/libraries/python/mcp_use/client/connectors/websocket.py
@@ -8,6 +8,7 @@ through WebSocket connections.
 import asyncio
 import json
 import uuid
+from datetime import timedelta
 from typing import Any
 
 import httpx
@@ -178,7 +179,12 @@ class WebSocketConnector(BaseConnector):
         if errors:
             logger.warning(f"Encountered {len(errors)} errors during resource cleanup")
 
-    async def _send_request(self, method: str, params: dict[str, Any] | None = None) -> Any:
+    async def _send_request(
+        self,
+        method: str,
+        params: dict[str, Any] | None = None,
+        read_timeout_seconds: timedelta | None = None,
+    ) -> Any:
         """Send a request and wait for a response."""
         if not self.ws:
             raise RuntimeError("WebSocket is not connected")
@@ -197,7 +203,11 @@ class WebSocketConnector(BaseConnector):
 
         # Wait for the response
         try:
-            return await future
+            if read_timeout_seconds is None:
+                return await future
+
+            timeout = read_timeout_seconds.total_seconds()
+            return await asyncio.wait_for(future, timeout=timeout)
         except Exception as e:
             # Remove the request from pending requests
             self.pending_requests.pop(request_id, None)
@@ -229,10 +239,19 @@ class WebSocketConnector(BaseConnector):
             raise RuntimeError("MCP client is not initialized")
         return self._tools
 
-    async def call_tool(self, name: str, arguments: dict[str, Any]) -> Any:
+    async def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+        read_timeout_seconds: timedelta | None = None,
+    ) -> Any:
         """Call an MCP tool with the given arguments."""
         logger.debug(f"Calling tool '{name}' with arguments: {arguments}")
-        return await self._send_request("tools/call", {"name": name, "arguments": arguments})
+        return await self._send_request(
+            "tools/call",
+            {"name": name, "arguments": arguments},
+            read_timeout_seconds,
+        )
 
     async def list_resources(self) -> list[dict[str, Any]]:
         """List all available resources from the MCP implementation."""

--- a/libraries/python/tests/unit/test_websocket_connector.py
+++ b/libraries/python/tests/unit/test_websocket_connector.py
@@ -1,0 +1,22 @@
+import asyncio
+from datetime import timedelta
+from unittest.mock import AsyncMock
+
+import pytest
+
+from mcp_use.client.connectors.websocket import WebSocketConnector
+
+
+@pytest.mark.asyncio
+async def test_call_tool_respects_read_timeout_seconds():
+    connector = WebSocketConnector("ws://localhost:8080")
+    connector.ws = AsyncMock()
+
+    with pytest.raises(asyncio.TimeoutError):
+        await connector.call_tool(
+            "slow_tool",
+            {"value": 1},
+            read_timeout_seconds=timedelta(milliseconds=10),
+        )
+
+    assert connector.pending_requests == {}


### PR DESCRIPTION
## Summary

Fix WebSocket tool calls to respect `read_timeout_seconds`.

`BaseConnector.call_tool()` supports `read_timeout_seconds`, but the WebSocket connector was not propagating it into the request wait path. If the WebSocket connection stayed open but the server never returned a response for a request, `await future` could wait indefinitely.

This change:

* Adds `read_timeout_seconds` support to `_send_request()`
* Uses `asyncio.wait_for()` when a timeout is provided
* Propagates `read_timeout_seconds` through `call_tool()`
* Adds a regression test for the timeout behavior

## Issue

Fixes #1733

## Testing

```bash
python -m pytest libraries/python/tests/unit/test_websocket_connector.py -vv
```

Result:

```text
1 passed
```
