### PR TITLE
test: move connector telemetry mocks to module scope

### DIFF
--- a/libraries/typescript/packages/mcp-use/tests/unit/telemetry/connector-telemetry.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/telemetry/connector-telemetry.test.ts
@@ -9,8 +9,13 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-// Create mock tracking function
-const mockTrackConnectorInit = vi.fn().mockResolvedValue(undefined);
+const { mockTrackConnectorInit, mockCapture, mockFlush, mockShutdown } =
+  vi.hoisted(() => ({
+    mockTrackConnectorInit: vi.fn().mockResolvedValue(undefined),
+    mockCapture: vi.fn(),
+    mockFlush: vi.fn(),
+    mockShutdown: vi.fn(),
+  }));
 
 // Mock the telemetry module
 vi.mock("../../../src/telemetry/telemetry-node.js", () => ({
@@ -20,6 +25,25 @@ vi.mock("../../../src/telemetry/telemetry-node.js", () => ({
       isEnabled: true,
     })),
   },
+}));
+
+vi.mock("posthog-node", () => ({
+  PostHog: class MockPostHog {
+    capture = mockCapture;
+    flush = mockFlush;
+    shutdown = mockShutdown;
+  },
+}));
+
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn().mockReturnValue(false),
+  mkdirSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  readFileSync: vi.fn().mockReturnValue("test-user-id"),
+}));
+
+vi.mock("node:os", () => ({
+  homedir: vi.fn().mockReturnValue("/mock/home"),
 }));
 
 describe("Connector Telemetry Integration", () => {
@@ -229,32 +253,6 @@ describe("Connector Telemetry Integration", () => {
   });
 
   describe("Integration tests - actual connector connection", () => {
-    // Mock PostHog for integration tests
-    const mockCapture = vi.fn();
-    const mockFlush = vi.fn();
-    const mockShutdown = vi.fn();
-
-    beforeEach(() => {
-      vi.mock("posthog-node", () => {
-        return {
-          PostHog: class MockPostHog {
-            capture = mockCapture;
-            flush = mockFlush;
-            shutdown = mockShutdown;
-          },
-        };
-      });
-      vi.mock("node:fs", () => ({
-        existsSync: vi.fn().mockReturnValue(false),
-        mkdirSync: vi.fn(),
-        writeFileSync: vi.fn(),
-        readFileSync: vi.fn().mockReturnValue("test-user-id"),
-      }));
-      vi.mock("node:os", () => ({
-        homedir: vi.fn().mockReturnValue("/mock/home"),
-      }));
-    });
-
     it("should track HttpConnector init when connect() is called", async () => {
       // Note: This test would require mocking the HTTP transport
       // For now, we verify the BaseConnector method works correctly


### PR DESCRIPTION
Fixes #1777

## Summary

- moves the `posthog-node`, `node:fs`, and `node:os` mocks in `connector-telemetry.test.ts` to module scope
- uses `vi.hoisted` for shared mock functions referenced by hoisted mock factories
- keeps the existing test behavior while matching Vitest's actual mock execution order

## Verification

- `pnpm --filter mcp-use exec vitest run tests/unit/telemetry/connector-telemetry.test.ts`
- `pnpm --filter mcp-use test:unit -- tests/unit/telemetry/connector-telemetry.test.ts`
- `pnpm --filter mcp-use exec eslint tests/unit/telemetry/connector-telemetry.test.ts`
- `pnpm --filter mcp-use build`

Note: the broader focused test command still shows the repo's existing PostHog browser telemetry warnings and Vitest close timeout, but the three nested `vi.mock(...)` warnings are removed.
