### PR TITLE
Add Python 3.14 support coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ permissions:
 #
 # 2. Python Tests (runs if libraries/python/** changed)
 #    ├─ python-lint: Ruff linting and formatting checks
-#    ├─ python-unit-tests: Matrix [Python 3.11, 3.12]
+#    ├─ python-unit-tests: Matrix [Python 3.11, 3.12, 3.13, 3.14]
 #    ├─ python-transport-tests: Matrix [stdio, sse, streamable_http]
 #    │  └─ python-transport-tests-report: Posts PR comment with test results table
 #    ├─ python-primitive-tests: Matrix [7 MCP primitives]
@@ -174,7 +174,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
         deps: ["latest", "minimum"]
     defaults:
       run:

--- a/libraries/python/DEPENDENCY_POLICY.md
+++ b/libraries/python/DEPENDENCY_POLICY.md
@@ -5,8 +5,8 @@ This document describes how mcp-use manages its dependencies for the Python SDK.
 ## Python Version Support
 
 - **Minimum supported**: Python 3.11
-- **Tested on CI**: Python 3.11, 3.12
-- **Policy**: We support the two most recent minor Python versions. When a new Python version is released, we add support within one release cycle and may drop the oldest supported version with a major version bump.
+- **Tested on CI**: Python 3.11, 3.12, 3.13, 3.14
+- **Policy**: We keep the published `requires-python` range aligned with CI coverage. When a new Python version is released, we add CI coverage within one release cycle. Dropping an older supported version requires a major version bump.
 
 ## MCP SDK (`mcp` package)
 

--- a/libraries/python/pyproject.toml
+++ b/libraries/python/pyproject.toml
@@ -17,6 +17,8 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [


### PR DESCRIPTION
Closes #1778

## Summary

- Add Python 3.13 and 3.14 classifiers to the Python package metadata.
- Expand Python unit-test CI coverage to run on Python 3.11, 3.12, 3.13, and 3.14 for both latest and minimum direct dependency resolution.
- Update the Python dependency policy so the stated tested versions match CI coverage.

## Verification

- `python3 -m venv /private/tmp/mcp-use-py314-check && /private/tmp/mcp-use-py314-check/bin/python -m pip install --upgrade pip uv`
- `/private/tmp/mcp-use-py314-check/bin/python -m pip install -e ".[dev]"`
- `/private/tmp/mcp-use-py314-check/bin/python -m pip install -e ".[e2b]"`
- `/private/tmp/mcp-use-py314-check/bin/python -c "import mcp_use, sys; print(sys.version.split()[0]); print(mcp_use.__version__ if hasattr(mcp_use, '__version__') else 'import-ok')"`
- `HOME=/private/tmp MCP_USE_ANONYMIZED_TELEMETRY=false /private/tmp/mcp-use-py314-check/bin/python -m pytest tests/unit/test_config.py -q`
- `HOME=/private/tmp MCP_USE_ANONYMIZED_TELEMETRY=false /private/tmp/mcp-use-py314-check/bin/python -m pytest tests/unit/server/test_server_config.py tests/unit/server/test_json_schema.py -q`
- `/private/tmp/mcp-use-py314-check/bin/python -m ruff check pyproject.toml DEPENDENCY_POLICY.md`
- `/private/tmp/mcp-use-py314-check/bin/python -m ruff format --check pyproject.toml`
- `git diff --check`

## Notes

Local verification was run on Python 3.13.2 because Python 3.14 is not installed in this local environment. This PR adds Python 3.14 to GitHub Actions so CI verifies the supported runtime directly.
