### PR TITLE
fix(server): harden widget/public static routes against path traversal

### DIFF
--- a/libraries/typescript/.changeset/tall-spiders-grow.md
+++ b/libraries/typescript/.changeset/tall-spiders-grow.md
@@ -1,0 +1,7 @@
+---
+"mcp-use": patch
+---
+
+Harden the static widget/public file routes against path traversal. `setupPublicRoutes`, the `/mcp-use/widgets/:widget` and `/mcp-use/widgets/.../assets/*` routes, and the favicon route now reject any request whose raw or decoded path contains a `..` segment, an absolute path, or a NUL byte (and, for single-segment widget names, a path separator) before any filesystem access. `pathHelpers.join` now also lexically collapses `.`/`..` segments as defense-in-depth.
+
+In practice the mainstream runtime adapters (Node via `@hono/node-server`, Deno, Bun, Workers) already normalize `..` out of the request path before routing, so this was not exploitable on a standard deployment. The new guards are the real containment control for embeddings that don't normalize the path (e.g. mounting the Hono app under Express) and protect against future adapter changes.

--- a/libraries/typescript/packages/mcp-use/src/server/utils/runtime.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/utils/runtime.ts
@@ -79,16 +79,85 @@ export const fsHelpers = {
   },
 };
 
+/**
+ * Collapse `.`/`..` segments in a `/`-joined path. Pure and cross-runtime (no
+ * `node:path`, so it stays synchronous and works in Deno).
+ *
+ * ponytail: lexical-only normalization — no symlink/realpath resolution. This is
+ * defense-in-depth: a normalized *absolute* path can still point outside an
+ * intended base dir, so handlers serving request-derived paths MUST still reject
+ * traversal up front via `safeSubpath`/`safeSegment`. The real containment guard
+ * lives at the route handlers, not here.
+ */
+function normalizePosix(path: string): string {
+  const isAbsolute = path.startsWith("/");
+  const out: string[] = [];
+  for (const seg of path.split("/")) {
+    if (seg === "" || seg === ".") continue;
+    if (seg === "..") {
+      if (out.length > 0 && out[out.length - 1] !== "..") out.pop();
+      else if (!isAbsolute) out.push("..");
+      // For absolute paths, a leading `..` that would escape root is dropped.
+    } else {
+      out.push(seg);
+    }
+  }
+  const joined = out.join("/");
+  if (isAbsolute) return "/" + joined;
+  return joined === "" ? "." : joined;
+}
+
+/**
+ * Validate a request-derived static-file subpath, rejecting path traversal.
+ *
+ * Returns the original `raw` value when safe (so the caller reads exactly what
+ * the runtime handed it), or `null` when the request must be refused. Both the
+ * raw and percent-decoded views are checked so encoded `..` (e.g. `%2e%2e`) is
+ * caught even on embeddings that don't pre-decode the path (e.g. mounting the
+ * Hono app under Express). Mainstream runtimes (Node/Deno/Bun/Workers) already
+ * collapse `..` when constructing the WHATWG Request, so this is defense-in-depth.
+ */
+export function safeSubpath(raw: string): string | null {
+  if (raw.includes("\0")) return null;
+  const views = [raw];
+  try {
+    const decoded = decodeURIComponent(raw);
+    if (decoded !== raw) views.push(decoded);
+  } catch {
+    // Malformed percent-encoding can't be a decoded traversal the OS resolves;
+    // fall through and validate the raw form only.
+  }
+  for (const view of views) {
+    const norm = view.replace(/\\/g, "/");
+    // Reject absolute paths (POSIX root, UNC `//`, or Windows drive `C:`).
+    if (norm.startsWith("/") || /^[A-Za-z]:/.test(norm)) return null;
+    if (norm.split("/").some((s) => s === ".." || s === ".")) return null;
+  }
+  return raw;
+}
+
+/**
+ * Like {@link safeSubpath} but for a single path segment (e.g. a `:widget` route
+ * param): additionally rejects path separators and empty input.
+ */
+export function safeSegment(raw: string): string | null {
+  const safe = safeSubpath(raw);
+  if (
+    safe === null ||
+    safe === "" ||
+    safe.includes("/") ||
+    safe.includes("\\")
+  ) {
+    return null;
+  }
+  return safe;
+}
+
 // Runtime-aware path helpers
 export const pathHelpers = {
   join(...paths: string[]): string {
-    if (isDeno) {
-      // Use simple path joining for Deno (web-standard approach)
-      return paths.join("/").replace(/\/+/g, "/");
-    }
-    // For Node, we need to use the sync version or cache the import
-    // We'll use a simple implementation that works for both
-    return paths.join("/").replace(/\/+/g, "/");
+    // Collapse `.`/`..` and redundant slashes. Cross-runtime; see normalizePosix.
+    return normalizePosix(paths.join("/"));
   },
 
   relative(from: string, to: string): string {

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/setup-widget-routes.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/setup-widget-routes.ts
@@ -6,7 +6,13 @@
  */
 
 import type { Hono as HonoType, Context } from "hono";
-import { pathHelpers, fsHelpers, getCwd } from "../utils/runtime.js";
+import {
+  pathHelpers,
+  fsHelpers,
+  getCwd,
+  safeSubpath,
+  safeSegment,
+} from "../utils/runtime.js";
 import {
   getContentType,
   processWidgetHtml,
@@ -34,8 +40,11 @@ export function setupWidgetRoutes(
 ): void {
   // Serve static assets (JS, CSS) from the assets directory
   app.get("/mcp-use/widgets/:widget/assets/*", async (c: Context) => {
-    const widget = c.req.param("widget")!;
-    const assetFile = c.req.path.split("/assets/")[1];
+    // Reject path traversal in both the widget name and the asset subpath.
+    const widget = safeSegment(c.req.param("widget")!);
+    const rawAsset = c.req.path.split("/assets/")[1];
+    const assetFile = rawAsset == null ? null : safeSubpath(rawAsset);
+    if (widget === null || assetFile === null) return c.notFound();
     const assetPath = pathHelpers.join(
       getCwd(),
       "dist",
@@ -63,7 +72,9 @@ export function setupWidgetRoutes(
 
   // Handle assets served from the wrong path (browser resolves ./assets/ relative to /mcp-use/widgets/)
   app.get("/mcp-use/widgets/assets/*", async (c: Context) => {
-    const assetFile = c.req.path.split("/assets/")[1];
+    const rawAsset = c.req.path.split("/assets/")[1];
+    const assetFile = rawAsset == null ? null : safeSubpath(rawAsset);
+    if (assetFile === null) return c.notFound();
     // Try to find which widget this asset belongs to by checking all widget directories
     const widgetsDir = pathHelpers.join(
       getCwd(),
@@ -99,7 +110,9 @@ export function setupWidgetRoutes(
   // Serve each widget's index.html at its route
   // e.g. GET /mcp-use/widgets/kanban-board -> dist/resources/widgets/kanban-board/index.html
   app.get("/mcp-use/widgets/:widget", async (c: Context) => {
-    const widget = c.req.param("widget")!;
+    // A `..` widget segment would otherwise climb out of the widgets dir.
+    const widget = safeSegment(c.req.param("widget")!);
+    if (widget === null) return c.notFound();
     const filePath = pathHelpers.join(
       getCwd(),
       "dist",

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/widget-helpers.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/widget-helpers.ts
@@ -12,7 +12,13 @@ import type {
   UIResourceDefinition,
   WidgetProps,
 } from "../types/index.js";
-import { fsHelpers, getCwd, isDeno, pathHelpers } from "../utils/runtime.js";
+import {
+  fsHelpers,
+  getCwd,
+  isDeno,
+  pathHelpers,
+  safeSubpath,
+} from "../utils/runtime.js";
 import {
   createUIResourceFromDefinition,
   type UrlConfig,
@@ -762,7 +768,10 @@ export function setupPublicRoutes(
   useDistDirectory: boolean = false
 ): void {
   app.get("/mcp-use/public/*", async (c: Context) => {
-    const filePath = c.req.path.replace("/mcp-use/public/", "");
+    // ponytail: reject path traversal before any fs access. pathHelpers.join does
+    // NOT sandbox to the base dir, so this guard is the real containment control.
+    const filePath = safeSubpath(c.req.path.replace("/mcp-use/public/", ""));
+    if (filePath === null) return c.notFound();
     const basePath = useDistDirectory ? "dist/public" : "public";
     const fullPath = pathHelpers.join(getCwd(), basePath, filePath);
 
@@ -811,13 +820,17 @@ export function setupFaviconRoute(
   }
 
   app.get("/favicon.ico", async (c: Context) => {
+    // Defense-in-depth: faviconPath is server config, but still keep it inside the
+    // public dir so a misconfigured path can't read arbitrary files.
+    const safeFavicon = safeSubpath(faviconPath);
+    if (safeFavicon === null) return c.notFound();
     const basePath = useDistDirectory ? "dist/public" : "public";
-    const fullPath = pathHelpers.join(getCwd(), basePath, faviconPath);
+    const fullPath = pathHelpers.join(getCwd(), basePath, safeFavicon);
 
     try {
       if (await fsHelpers.existsSync(fullPath)) {
         const content = await fsHelpers.readFile(fullPath);
-        const contentType = getContentType(faviconPath);
+        const contentType = getContentType(safeFavicon);
         return new Response(content, {
           status: 200,
           headers: {

--- a/libraries/typescript/packages/mcp-use/tests/unit/server/widget-path-safety.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/server/widget-path-safety.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  pathHelpers,
+  safeSegment,
+  safeSubpath,
+} from "../../../src/server/utils/runtime.js";
+
+// Guards for the unauthenticated static widget/public routes. The runtime
+// adapters normalize `..` in practice, but these guards are the real
+// containment control for embeddings that don't (e.g. mounting under Express).
+
+describe("safeSubpath", () => {
+  it("rejects path traversal payloads", () => {
+    const bad = [
+      "../../etc/passwd",
+      "..%2f..%2fetc/passwd", // encoded slash
+      "%2e%2e/%2e%2e/etc/passwd", // encoded dots
+      "%2e%2e%2f%2e%2e%2fetc/passwd", // fully encoded
+      "/etc/passwd", // absolute
+      "//etc/passwd", // UNC-ish absolute
+      "a/../../b", // escapes after descending
+      "a/..\\..\\b", // backslash separators
+      "..\\..\\windows", // windows traversal
+      "C:/Windows/win.ini", // drive-absolute
+      "foo\0/etc/passwd", // NUL byte
+      "./.", // dot segments only
+    ];
+    for (const input of bad) {
+      expect(safeSubpath(input), input).toBeNull();
+    }
+  });
+
+  it("accepts legitimate relative subpaths unchanged", () => {
+    const ok = [
+      "index.js",
+      "assets/app.css",
+      "sub/dir/file.png",
+      "logo.svg",
+      "a.b.c.min.js",
+      "nested..name/file.js", // `..` only as part of a name, not a segment
+    ];
+    for (const input of ok) {
+      expect(safeSubpath(input), input).toBe(input);
+    }
+  });
+});
+
+describe("safeSegment", () => {
+  it("rejects separators, empties, and traversal", () => {
+    for (const input of ["..", ".", "", "a/b", "a\\b", "..%2f", "/x", "x\0"]) {
+      expect(safeSegment(input), input).toBeNull();
+    }
+  });
+
+  it("accepts a single safe segment", () => {
+    expect(safeSegment("kanban-board")).toBe("kanban-board");
+    expect(safeSegment("Widget_123")).toBe("Widget_123");
+  });
+});
+
+describe("pathHelpers.join (defense-in-depth normalization)", () => {
+  it("joins and collapses redundant slashes", () => {
+    expect(pathHelpers.join("/app", "dist/public", "a/b.css")).toBe(
+      "/app/dist/public/a/b.css"
+    );
+    expect(pathHelpers.join("/app//dist", "public")).toBe("/app/dist/public");
+  });
+
+  it("collapses . and .. segments", () => {
+    expect(pathHelpers.join("/app", "./dist", "./public")).toBe(
+      "/app/dist/public"
+    );
+    expect(pathHelpers.join("/app/dist/public", "../../x")).toBe("/app/x");
+  });
+});


### PR DESCRIPTION
## Changes

Adds containment guards to the unauthenticated static-file routes served by `MCPServer` so a request path can no longer escape the intended public/widget directories.

- New `safeSubpath()` / `safeSegment()` helpers in `server/utils/runtime.ts` reject `..` segments, absolute paths (POSIX `/`, UNC `//`, Windows `C:`), and NUL bytes — checking **both** the raw and percent-decoded views (catches `%2e%2e`, `..%2f`, backslash variants).
- Guards applied before any fs access in:
  - `setupPublicRoutes` (`/mcp-use/public/*`)
  - `setupFaviconRoute` (`/favicon.ico`)
  - `/mcp-use/widgets/:widget/assets/*`, `/mcp-use/widgets/assets/*`, `/mcp-use/widgets/:widget`
- `pathHelpers.join` now lexically collapses `.`/`..` (defense-in-depth; cross-runtime, stays sync for Deno).

## Severity / context

Originally reported as an unauthenticated arbitrary-file-read (path traversal via `pathHelpers.join`, which does not collapse `..`). On investigation this is **not exploitable on a standard deployment**: the mainstream runtime adapters (`@hono/node-server`, Deno, Bun, Workers) normalize `..` out of the request path before routing, so the malicious path never matches the route. Verified with a local repro under `@hono/node-server` — `GET /mcp-use/public/../../secret.txt` arrives at the handler as `/secret.txt` and 404s.

These guards are therefore **defense-in-depth**: they protect embeddings that don't pre-normalize (e.g. mounting the Hono app under Express) and guard against future adapter changes. Patch-level changeset included.

## Testing

- New `tests/unit/server/widget-path-safety.test.ts` (6 cases): traversal payloads, encoded/backslash/drive variants, NUL byte, and `join` normalization.
- `tsc --noEmit` clean, ESLint + Prettier clean on changed files.
- Full server unit suite: 196 passed / 2 skipped, no regressions.

## Backwards compatibility

Non-breaking. Legitimate asset/public paths (no `..`) are served exactly as before; only traversal-shaped requests now 404 instead of reading outside the base dir.