### PR TITLE
fix(typescript): add cwd support to StdioConnector

### DIFF
--- a/libraries/typescript/packages/mcp-use/src/connectors/stdio.ts
+++ b/libraries/typescript/packages/mcp-use/src/connectors/stdio.ts
@@ -18,6 +18,7 @@ export class StdioConnector extends BaseConnector {
   private readonly command: string;
   private readonly args: string[];
   private readonly env?: Record<string, string>;
+  private readonly cwd?: string;
   private readonly errlog: Writable;
   private readonly clientInfo: ClientInfo;
 
@@ -25,12 +26,15 @@ export class StdioConnector extends BaseConnector {
     command = "npx",
     args = [],
     env,
+    cwd,
     errlog = process.stderr,
     ...rest
   }: {
     command?: string;
     args?: string[];
     env?: Record<string, string>;
+    /** Working directory for the spawned process. */
+    cwd?: string;
     errlog?: Writable;
   } & StdioConnectorOptions = {}) {
     super(rest);
@@ -38,6 +42,7 @@ export class StdioConnector extends BaseConnector {
     this.command = command;
     this.args = args;
     this.env = env;
+    this.cwd = cwd;
     this.errlog = errlog;
     this.clientInfo = rest.clientInfo ?? {
       name: "stdio-connector",
@@ -74,6 +79,7 @@ export class StdioConnector extends BaseConnector {
         command: this.command,
         args: this.args,
         env: mergedEnv,
+        ...(this.cwd !== undefined ? { cwd: this.cwd } : {}),
       };
 
       // 2. Start the connection manager -> returns a live transport


### PR DESCRIPTION
## What

Adds an optional `cwd` parameter to `StdioConnector` and threads it through to the `StdioServerParameters` passed to the underlying SDK transport.

## Why

`StdioServerParameters` from `@modelcontextprotocol/sdk` already supports a `cwd` field for setting the working directory of the spawned process. `StdioConnector` was silently discarding it, which breaks servers that rely on a specific working directory — for example, those that resolve config files or `node_modules` relative to their project root.

```ts
// Before: no way to set cwd — server always starts in the process cwd
const connector = new StdioConnector({ command: "node", args: ["server.js"] });

// After: cwd is forwarded to the spawned process
const connector = new StdioConnector({
  command: "node",
  args: ["server.js"],
  cwd: "/path/to/project",
});
```

## Changes

- `src/connectors/stdio.ts`: add `cwd?: string` to the constructor param type (with JSDoc), store it as a private field, and spread it into `serverParams` only when defined (preserves existing default-to-process-cwd behaviour for callers that omit it)

Closes #1784