### PR TITLE
test(telemetry): move connector telemetry Vitest mocks to module scope

### DIFF
--- a/libraries/typescript/packages/mcp-use/tests/unit/telemetry/connector-telemetry.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/telemetry/connector-telemetry.test.ts
@@ -12,6 +12,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // Create mock tracking function
 const mockTrackConnectorInit = vi.fn().mockResolvedValue(undefined);
 
+// Mock PostHog for integration tests
+const mockCapture = vi.fn();
+const mockFlush = vi.fn();
+const mockShutdown = vi.fn();
+
 // Mock the telemetry module
 vi.mock("../../../src/telemetry/telemetry-node.js", () => ({
   Telemetry: {
@@ -20,6 +25,27 @@ vi.mock("../../../src/telemetry/telemetry-node.js", () => ({
       isEnabled: true,
     })),
   },
+}));
+
+vi.mock("posthog-node", () => {
+  return {
+    PostHog: class MockPostHog {
+      capture = mockCapture;
+      flush = mockFlush;
+      shutdown = mockShutdown;
+    },
+  };
+});
+
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn().mockReturnValue(false),
+  mkdirSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  readFileSync: vi.fn().mockReturnValue("test-user-id"),
+}));
+
+vi.mock("node:os", () => ({
+  homedir: vi.fn().mockReturnValue("/mock/home"),
 }));
 
 describe("Connector Telemetry Integration", () => {
@@ -229,32 +255,6 @@ describe("Connector Telemetry Integration", () => {
   });
 
   describe("Integration tests - actual connector connection", () => {
-    // Mock PostHog for integration tests
-    const mockCapture = vi.fn();
-    const mockFlush = vi.fn();
-    const mockShutdown = vi.fn();
-
-    beforeEach(() => {
-      vi.mock("posthog-node", () => {
-        return {
-          PostHog: class MockPostHog {
-            capture = mockCapture;
-            flush = mockFlush;
-            shutdown = mockShutdown;
-          },
-        };
-      });
-      vi.mock("node:fs", () => ({
-        existsSync: vi.fn().mockReturnValue(false),
-        mkdirSync: vi.fn(),
-        writeFileSync: vi.fn(),
-        readFileSync: vi.fn().mockReturnValue("test-user-id"),
-      }));
-      vi.mock("node:os", () => ({
-        homedir: vi.fn().mockReturnValue("/mock/home"),
-      }));
-    });
-
     it("should track HttpConnector init when connect() is called", async () => {
       // Note: This test would require mocking the HTTP transport
       // For now, we verify the BaseConnector method works correctly


### PR DESCRIPTION
## Summary

Fixes #1777.

Moves `vi.mock()` calls for `posthog-node`, `node:fs`, and `node:os` from inside a `beforeEach` in the connector telemetry integration tests to module scope.

Vitest hoists `vi.mock()` to the top of the file regardless of placement. Defining mocks inside `beforeEach` is misleading and triggers Vitest warnings without changing behavior.

## Motivation

The connector telemetry test defined a few `vi.mock(...)` calls inside `beforeEach`. Vitest hoists these mocks anyway, so it warns that they should be moved to the top level of the module. The warning also says this will become an error in a future Vitest version.

## Changes

- Hoist PostHog, `node:fs`, and `node:os` mocks to module scope (after the existing `telemetry-node` mock)
- Add `mockCapture`, `mockFlush`, and `mockShutdown` at module scope
- Remove the nested `beforeEach` that contained the mock definitions
- Align with the pattern used in `telemetry.test.ts`

## Tests

```bash
cd libraries/typescript/packages/mcp-use
npx vitest run tests/unit/telemetry/connector-telemetry.test.ts
# 11 passed
```

## Notes

- Test-only refactor; no production code changes.
- composer-2.5 review: APPROVE, low risk.