### PR TITLE
fix(python): set _connected before cleanup in ws/sandbox disconnect

### DIFF
--- a/libraries/python/mcp_use/client/connectors/sandbox.py
+++ b/libraries/python/mcp_use/client/connectors/sandbox.py
@@ -331,9 +331,13 @@ class SandboxConnector(BaseConnector):
             logger.debug("Not connected to MCP implementation")
             return
 
+        # Mark as disconnected before awaiting cleanup so any re-entrant call
+        # (e.g. AsyncExitStack teardown firing while _cleanup_resources is
+        # suspended) sees _connected == False and returns early.
+        self._connected = False
+
         logger.debug("Disconnecting from MCP implementation")
         await self._cleanup_resources()
-        self._connected = False
         logger.debug("Disconnected from MCP implementation")
 
     @property

--- a/libraries/python/mcp_use/client/connectors/websocket.py
+++ b/libraries/python/mcp_use/client/connectors/websocket.py
@@ -124,9 +124,13 @@ class WebSocketConnector(BaseConnector):
             logger.debug("Not connected to MCP implementation")
             return
 
+        # Mark as disconnected before awaiting cleanup so any re-entrant call
+        # (e.g. AsyncExitStack teardown firing while _cleanup_resources is
+        # suspended) sees _connected == False and returns early.
+        self._connected = False
+
         logger.debug("Disconnecting from MCP implementation")
         await self._cleanup_resources()
-        self._connected = False
         logger.debug("Disconnected from MCP implementation")
 
     async def _cleanup_resources(self) -> None:

--- a/libraries/python/tests/unit/test_sandbox_connector.py
+++ b/libraries/python/tests/unit/test_sandbox_connector.py
@@ -309,3 +309,27 @@ class TestSandboxConnectorCleanup:
             assert connector.stdout_lines == []
             assert connector.stderr_lines == []
             assert connector.base_url is None
+
+
+class TestSandboxConnectorDisconnect:
+    """Tests for SandboxConnector.disconnect()."""
+
+    @pytest.mark.asyncio
+    async def test_disconnect_reentrant_call_skips_second_cleanup(self, mock_sandbox_modules, mock_os_environ):
+        """Re-entrant disconnect during cleanup should not run cleanup twice."""
+        sandbox_options = SandboxOptions(api_key="test-api-key")
+        connector = SandboxConnector("npx", ["test-command"], e2b_options=sandbox_options)
+        connector._connected = True
+        cleanup_call_count = 0
+
+        async def reentrant_cleanup() -> None:
+            nonlocal cleanup_call_count
+            cleanup_call_count += 1
+            await connector.disconnect()
+
+        connector._cleanup_resources = reentrant_cleanup
+
+        await connector.disconnect()
+
+        assert cleanup_call_count == 1
+        assert connector._connected is False

--- a/libraries/python/tests/unit/test_websocket_connector.py
+++ b/libraries/python/tests/unit/test_websocket_connector.py
@@ -1,0 +1,28 @@
+"""Unit tests for WebSocketConnector."""
+
+import pytest
+
+from mcp_use.client.connectors.websocket import WebSocketConnector
+
+
+class TestWebSocketConnectorDisconnect:
+    """Tests for WebSocketConnector.disconnect()."""
+
+    @pytest.mark.asyncio
+    async def test_disconnect_reentrant_call_skips_second_cleanup(self):
+        """Re-entrant disconnect during cleanup should not run cleanup twice."""
+        connector = WebSocketConnector("ws://localhost:8080")
+        connector._connected = True
+        cleanup_call_count = 0
+
+        async def reentrant_cleanup() -> None:
+            nonlocal cleanup_call_count
+            cleanup_call_count += 1
+            await connector.disconnect()
+
+        connector._cleanup_resources = reentrant_cleanup
+
+        await connector.disconnect()
+
+        assert cleanup_call_count == 1
+        assert connector._connected is False


### PR DESCRIPTION
## Summary

Set `_connected = False` before awaiting `_cleanup_resources()` in `WebSocketConnector` and `SandboxConnector`, mirroring the disconnect ordering fix proposed for `BaseConnector` in #1412.

## Motivation

Both connector subclasses override `disconnect()` but still cleared `_connected` only after cleanup finished. A re-entrant `disconnect()` during cleanup (e.g. `AsyncExitStack` teardown while cleanup is suspended) could see `_connected == True`, fall through, and tear down WebSocket/sandbox resources twice. On Windows this can surface as `ValueError: I/O operation on closed pipe` (#1220).

Fixes #1415

## Changes

- `websocket.py`: move `_connected = False` before `await self._cleanup_resources()`
- `sandbox.py`: same ordering change with explanatory comment
- `test_websocket_connector.py`: regression test for re-entrant disconnect
- `test_sandbox_connector.py`: matching regression test

## Tests

```bash
cd libraries/python
MCP_USE_ANONYMIZED_TELEMETRY=false pytest tests/unit/test_websocket_connector.py tests/unit/test_sandbox_connector.py::TestSandboxConnectorDisconnect -q
# 2 passed

ruff check mcp_use/client/connectors/websocket.py mcp_use/client/connectors/sandbox.py tests/unit/test_websocket_connector.py tests/unit/test_sandbox_connector.py
# All checks passed

ruff format --check <same files>
# passed
```

## Notes

- Scoped to the two subclasses called out in #1415; `BaseConnector` ordering is tracked separately in #1412.
- composer-2.5 review: **APPROVE**