### PR TITLE
fix(inspector): replace stale auto-connect transports

### DIFF
--- a/libraries/typescript/.changeset/slow-lobsters-juggle.md
+++ b/libraries/typescript/.changeset/slow-lobsters-juggle.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Replace stale saved auto-connect entries when the advertised transport changes, so embedded Inspector instances do not keep retrying deprecated SSE connections after switching to streamable HTTP.

--- a/libraries/typescript/packages/inspector/src/client/hooks/__tests__/useAutoConnect.test.ts
+++ b/libraries/typescript/packages/inspector/src/client/hooks/__tests__/useAutoConnect.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldReplaceAutoConnectConnection } from "../useAutoConnect";
+
+describe("shouldReplaceAutoConnectConnection", () => {
+  it("replaces a non-ready saved SSE connection when auto-connect now requires HTTP", () => {
+    expect(
+      shouldReplaceAutoConnectConnection(
+        {
+          url: "http://localhost:3002/mcp",
+          state: "failed",
+          transportType: "sse",
+        },
+        { url: "http://localhost:3002/mcp", transportType: "http" }
+      )
+    ).toBe(true);
+  });
+
+  it("keeps ready connections even if their transport differs", () => {
+    expect(
+      shouldReplaceAutoConnectConnection(
+        {
+          url: "http://localhost:3002/mcp",
+          state: "ready",
+          transportType: "sse",
+        },
+        { url: "http://localhost:3002/mcp", transportType: "http" }
+      )
+    ).toBe(false);
+  });
+
+  it("keeps connections whose transport already matches", () => {
+    expect(
+      shouldReplaceAutoConnectConnection(
+        {
+          url: "http://localhost:3002/mcp",
+          state: "failed",
+          transportType: "http",
+        },
+        { url: "http://localhost:3002/mcp", transportType: "http" }
+      )
+    ).toBe(false);
+  });
+});

--- a/libraries/typescript/packages/inspector/src/client/hooks/useAutoConnect.ts
+++ b/libraries/typescript/packages/inspector/src/client/hooks/useAutoConnect.ts
@@ -48,6 +48,21 @@ interface ConnectionConfig {
   };
 }
 
+export function shouldReplaceAutoConnectConnection(
+  existing: {
+    url?: string;
+    state?: string;
+    transportType?: "http" | "sse";
+  },
+  config: Pick<ConnectionConfig, "url" | "transportType">
+): boolean {
+  return (
+    existing.url === config.url &&
+    existing.state !== "ready" &&
+    (existing.transportType ?? "http") !== config.transportType
+  );
+}
+
 /**
  * Parse an "autoConnect" parameter that may be a plain URL or a JSON-encoded connection configuration.
  *
@@ -227,7 +242,7 @@ function parseAutoConnectParam(param: string): ConnectionConfig | null {
 export function useAutoConnect({
   connections,
   addConnection,
-  removeConnection: _removeConnection,
+  removeConnection,
   configLoaded: contextConfigLoaded,
   embedded = false,
 }: UseAutoConnectOptions): AutoConnectState {
@@ -334,6 +349,17 @@ export function useAutoConnect({
       const existing = connections.find((c) => c.url === config.url);
 
       if (existing) {
+        if (shouldReplaceAutoConnectConnection(existing, config)) {
+          console.warn(
+            "[useAutoConnect] Existing connection transport differs from auto-connect config; replacing it"
+          );
+          removeConnection(existing.id);
+          setAutoConnectConfig(config);
+          setIsAutoConnecting(true);
+          attemptConnection(config);
+          return;
+        }
+
         // Connection already exists
         if (existing.state === "ready") {
           // Already connected - navigate immediately
@@ -366,7 +392,7 @@ export function useAutoConnect({
         attemptConnection(config);
       }
     },
-    [connections, navigate, attemptConnection]
+    [connections, navigate, removeConnection, attemptConnection]
   );
 
   // Load config and initiate auto-connect


### PR DESCRIPTION
## Summary
- Replace non-ready saved Inspector auto-connect entries when the advertised transport changes for the same server URL.
- Prevent embedded dev Inspector sessions from retrying stale SSE connections after the local server now advertises streamable HTTP.
- Add a patch changeset for `@mcp-use/inspector`.

## Motivation
While debugging a local OAuth connector flow, the embedded Inspector kept opening `GET /mcp` with `Accept: text/event-stream` and no `mcp-session-id`, which the server rejected with `Bad Request: Server not initialized`. The server was already advertising `transportType: "http"`, but the Inspector reused a persisted same-URL connection saved with `transportType: "sse"` instead of replacing it.

## Test plan
- `pnpm --filter @mcp-use/inspector test:unit -- src/client/hooks/__tests__/useAutoConnect.test.ts`
- `pnpm --filter @mcp-use/inspector lint`
- `pnpm format`