### PR TITLE
feat(cli): expose monorepo auto-deploy trigger config

### DIFF
--- a/docs/typescript/server/cli-reference.mdx
+++ b/docs/typescript/server/cli-reference.mdx
@@ -271,6 +271,9 @@ mcp-use deploy [options]
 | `--region <region>`     | Deploy region: `US`, `EU`, or `APAC`                                                 | `US`           |
 | `--build-command <cmd>` | Custom build command (overrides auto-detection)                                      | Auto-detected  |
 | `--start-command <cmd>` | Custom start command (overrides auto-detection)                                      | Auto-detected  |
+| `--dockerfile <path>`   | Path to a non-default Dockerfile (relative to `--root-dir` / repo root)              | `Dockerfile`   |
+| `--watch-paths <glob...>` | Only auto-deploy when matching files change (monorepos). Set on new-server creation. | All changes    |
+| `--wait-for-ci`         | Hold GitHub auto-deploys until other check runs pass. Set on new-server creation.    | false          |
 
 **Examples:**
 
@@ -295,6 +298,9 @@ mcp-use deploy --runtime python
 
 # Monorepo: deploy a subdirectory
 mcp-use deploy --root-dir apps/mcp-server
+
+# Monorepo: only redeploy when this app or shared code changes
+mcp-use deploy --root-dir apps/mcp-server --watch-paths "apps/mcp-server/**" "packages/shared/**"
 
 # Force a brand-new deployment instead of reusing the linked one
 mcp-use deploy --new --name my-server-v2
@@ -433,7 +439,29 @@ mcp-use deployments delete <deployment-id> [-y|--yes]   # alias: `rm`
 ```bash
 mcp-use servers list [--org <slug-or-id>] [--limit <n>] [--skip <n>] [--sort <field:asc|desc>]
 mcp-use servers get <id-or-slug>
+mcp-use servers update <id-or-slug> [options]
 mcp-use servers delete <server-id> [-y] [--org <slug-or-id>]   # alias: `rm`
+```
+
+`servers update` changes server config after creation:
+
+| Option | Description |
+| ------ | ----------- |
+| `--branch <name>` | Production branch — controls which branch triggers production deploys |
+| `--name <name>` | Rename the server |
+| `--description <text>` | Update the server description |
+| `--build-command <cmd>` | Override the build command (empty string clears it) |
+| `--start-command <cmd>` | Override the start command (empty string clears it) |
+| `--root-dir <path>` | Repo subdirectory to build from (empty string resets to repo root) |
+| `--watch-paths <glob...>` | Only auto-deploy when matching files change (empty `""` clears the filter) |
+| `--deploy-branches <glob...>` | Branch globs (besides production) allowed to auto-deploy (empty `""` allows all) |
+| `--wait-for-ci` / `--no-wait-for-ci` | Hold auto-deploys until other check runs pass |
+
+```bash
+# Monorepo: scope an existing server to its own subtree + shared code
+mcp-use servers update my-app \
+  --watch-paths "apps/my-app/**" "packages/shared/**" \
+  --deploy-branches "release/*"
 ```
 
 Environment variables on a server are managed under `servers env`:

--- a/docs/typescript/server/deployment/mcp-use.mdx
+++ b/docs/typescript/server/deployment/mcp-use.mdx
@@ -86,6 +86,39 @@ This approach:
 - ✅ Uses the latest commit from your branch
 - ✅ Requires the mcp-use GitHub App on the repo and changes pushed to GitHub
 
+## Monorepos & multiple apps
+
+If you deploy several servers from the same repository, every push to that repo is evaluated against **each** connected server. By default a server redeploys on any push to its production branch, which in a monorepo means an unrelated change can rebuild an app you didn't touch. Two per-server filters scope that down:
+
+- **Watch paths** (`--watch-paths`): globs matched against the push's changed files. The server only auto-deploys when a changed file matches. Empty (the default) means any change triggers a deploy.
+- **Branch allow list** (`--deploy-branches`): globs of branches (besides the production branch) that are allowed to trigger auto-deploys. The production branch always deploys; an empty list allows all branches.
+
+```bash
+# Create a server that only redeploys when its own app or shared code changes
+mcp-use deploy \
+  --root-dir apps/iching \
+  --watch-paths "apps/iching/**" "packages/shared/**"
+
+# Tune an existing server's triggers (no redeploy of unrelated apps)
+mcp-use servers update <id-or-slug> \
+  --watch-paths "apps/iching/**" "packages/shared/**" \
+  --deploy-branches "release/*"
+
+# Clear the watch paths (back to "any change deploys")
+mcp-use servers update <id-or-slug> --watch-paths ""
+```
+
+<Note>
+Watch paths and branch patterns are also editable from the dashboard — see [Deployments](https://docs.manufact.com/dashboard/deployments) and [Server settings](https://docs.manufact.com/dashboard/settings).
+</Note>
+
+### Branch URLs and sessions
+
+- The **production branch** serves the canonical URL `https://<slug>.deploy.mcp-use.com/mcp`. Pushing to it swaps the running container, so live MCP sessions on the canonical URL receive `mcp_session_terminated` and clients reconnect.
+- Every other branch gets its own stable preview URL `https://<slug>--br-<branch>.deploy.mcp-use.com/mcp`, so you can test changes against real clients before merging. Preview deployments require the Hobby plan or higher.
+
+`mcp-use servers update --branch <name>` changes which branch is the production branch after creation.
+
 ## After Deployment
 
 Once deployment completes, you'll receive:

--- a/libraries/typescript/.changeset/monorepo-deploy-triggers.md
+++ b/libraries/typescript/.changeset/monorepo-deploy-triggers.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/cli": minor
+---
+
+Expose monorepo auto-deploy trigger config in the CLI. `mcp-use deploy` gains `--watch-paths` and `--wait-for-ci` for new GitHub servers, and `mcp-use servers update` gains `--watch-paths`, `--deploy-branches`, `--wait-for-ci`/`--no-wait-for-ci`, and `--root-dir`. `mcp-use servers get`/`update` now print the effective watch paths, deploy branch patterns, and wait-for-CI setting. This closes the gap where the Cloud API accepted these fields but the CLI could not set them, so monorepo apps can be scoped to only redeploy on relevant changes.

--- a/libraries/typescript/packages/cli/src/commands/deploy.ts
+++ b/libraries/typescript/packages/cli/src/commands/deploy.ts
@@ -213,6 +213,16 @@ interface DeployOptions {
   /** Path to a non-default Dockerfile (relative to rootDir / repo root). */
   dockerfile?: string;
   /**
+   * Glob patterns limiting which repo changes trigger auto-deploy (monorepos).
+   * Applied only when creating a new GitHub server.
+   */
+  watchPaths?: string[];
+  /**
+   * Hold GitHub auto-deploys until other check runs pass. Applied only when
+   * creating a new GitHub server.
+   */
+  waitForCi?: boolean;
+  /**
    * Deploy branch. Defaults to the current git branch (managed flow: "main").
    * Also scopes env-var sync to that branch's preview env.
    */
@@ -1607,6 +1617,8 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
         buildCommand: options.buildCommand,
         startCommand: options.startCommand,
         dockerfilePath: options.dockerfile,
+        watchPaths: options.watchPaths,
+        waitForCi: options.waitForCi,
       });
 
       deploymentId = serverResult.deploymentId ?? "";

--- a/libraries/typescript/packages/cli/src/commands/servers.ts
+++ b/libraries/typescript/packages/cli/src/commands/servers.ts
@@ -233,6 +233,32 @@ async function getServerCommand(idOrSlug: string, options: { org?: string }) {
       console.log(
         chalk.white("  Prod branch: ") + chalk.gray(cr.productionBranch)
       );
+      if (cr.watchPaths !== undefined) {
+        console.log(
+          chalk.white("  Watch paths: ") +
+            chalk.gray(
+              cr.watchPaths.length > 0
+                ? cr.watchPaths.join(", ")
+                : "(all changes)"
+            )
+        );
+      }
+      if (cr.deployBranchPatterns !== undefined) {
+        console.log(
+          chalk.white("  Deploy branches: ") +
+            chalk.gray(
+              cr.deployBranchPatterns.length > 0
+                ? cr.deployBranchPatterns.join(", ")
+                : "(all branches)"
+            )
+        );
+      }
+      if (cr.waitForCi !== undefined) {
+        console.log(
+          chalk.white("  Wait for CI: ") +
+            chalk.gray(cr.waitForCi ? "yes" : "no")
+        );
+      }
     }
 
     if (server.activeDeploymentId) {
@@ -305,6 +331,14 @@ async function getServerCommand(idOrSlug: string, options: { org?: string }) {
   }
 }
 
+/**
+ * Resolves a variadic glob option to the array sent to the API. A lone empty
+ * string (`--watch-paths ""`) clears the list; otherwise empties are dropped.
+ */
+function resolveGlobList(values: string[]): string[] {
+  return values.map((v) => v.trim()).filter((v) => v.length > 0);
+}
+
 async function updateServerCommand(
   idOrSlug: string,
   options: {
@@ -313,8 +347,13 @@ async function updateServerCommand(
     buildCommand?: string;
     startCommand?: string;
     description?: string;
+    watchPaths?: string[];
+    deployBranches?: string[];
+    waitForCi?: boolean;
+    rootDir?: string;
     org?: string;
-  }
+  },
+  command?: Command
 ): Promise<void> {
   try {
     if (!(await isLoggedIn())) {
@@ -336,6 +375,20 @@ async function updateServerCommand(
     if (options.description !== undefined)
       body.description = options.description;
     if (options.branch !== undefined) body.productionBranch = options.branch;
+    // Auto-deploy trigger config lives on the connected repository (top-level
+    // on the PATCH body, not under `config`). A lone `""` clears the list.
+    if (options.watchPaths !== undefined)
+      body.watchPaths = resolveGlobList(options.watchPaths);
+    if (options.deployBranches !== undefined)
+      body.deployBranchPatterns = resolveGlobList(options.deployBranches);
+    // `--no-wait-for-ci` makes commander default `waitForCi` to true, so only
+    // forward it when the user actually passed one of the flags.
+    if (
+      options.waitForCi !== undefined &&
+      command?.getOptionValueSource("waitForCi") === "cli"
+    ) {
+      body.waitForCi = options.waitForCi;
+    }
 
     const config: Record<string, unknown> = {};
     if (options.buildCommand !== undefined) {
@@ -347,12 +400,16 @@ async function updateServerCommand(
       config.startCommand =
         options.startCommand === "" ? null : options.startCommand;
     }
+    if (options.rootDir !== undefined) {
+      // Empty string resets to the repo root (merge-patch: null removes key).
+      config.rootDir = options.rootDir === "" ? null : options.rootDir;
+    }
     if (Object.keys(config).length > 0) body.config = config;
 
     if (Object.keys(body).length === 0) {
       console.error(
         chalk.red(
-          "✗ Nothing to update. Provide at least one of: --branch, --name, --build-command, --start-command, --description."
+          "✗ Nothing to update. Provide at least one of: --branch, --name, --build-command, --start-command, --description, --watch-paths, --deploy-branches, --wait-for-ci/--no-wait-for-ci, --root-dir."
         )
       );
       process.exit(1);
@@ -366,11 +423,37 @@ async function updateServerCommand(
 
     const label = server.name || server.slug || server.id;
     console.log(chalk.green.bold(`\n✓ Server updated: ${label}`));
-    if (server.connectedRepository) {
+    const repo = server.connectedRepository;
+    if (repo) {
       console.log(
-        chalk.gray("  Prod branch: ") +
-          chalk.cyan(server.connectedRepository.productionBranch)
+        chalk.gray("  Prod branch: ") + chalk.cyan(repo.productionBranch)
       );
+      if (repo.watchPaths !== undefined) {
+        console.log(
+          chalk.gray("  Watch paths: ") +
+            chalk.cyan(
+              repo.watchPaths.length > 0
+                ? repo.watchPaths.join(", ")
+                : "(all changes)"
+            )
+        );
+      }
+      if (repo.deployBranchPatterns !== undefined) {
+        console.log(
+          chalk.gray("  Deploy branches: ") +
+            chalk.cyan(
+              repo.deployBranchPatterns.length > 0
+                ? repo.deployBranchPatterns.join(", ")
+                : "(all branches)"
+            )
+        );
+      }
+      if (repo.waitForCi !== undefined) {
+        console.log(
+          chalk.gray("  Wait for CI: ") +
+            chalk.cyan(repo.waitForCi ? "yes" : "no")
+        );
+      }
     }
     console.log();
   } catch (error) {
@@ -479,6 +562,23 @@ export function createServersCommand(): Command {
       "Override the start command (pass an empty string to clear)"
     )
     .option("--description <text>", "Update the server description")
+    .option(
+      "--watch-paths <glob...>",
+      'Only auto-deploy when files matching these globs change (monorepos). Pass "" to clear.'
+    )
+    .option(
+      "--deploy-branches <glob...>",
+      'Branch globs allowed to trigger auto-deploys (besides the production branch). Pass "" to allow all.'
+    )
+    .option(
+      "--wait-for-ci",
+      "Hold GitHub auto-deploys until other check runs pass"
+    )
+    .option("--no-wait-for-ci", "Do not wait for other check runs")
+    .option(
+      "--root-dir <path>",
+      'Repo subdirectory to build from (monorepos). Pass "" to reset to the repo root.'
+    )
     .option("--org <slug-or-id>", "Target organization")
     .action(updateServerCommand);
 

--- a/libraries/typescript/packages/cli/src/index.ts
+++ b/libraries/typescript/packages/cli/src/index.ts
@@ -3069,6 +3069,14 @@ program
     "Path to a non-default Dockerfile (relative to rootDir / repo root)"
   )
   .option(
+    "--watch-paths <glob...>",
+    "Only auto-deploy when files matching these globs change (monorepos). Set on new-server creation."
+  )
+  .option(
+    "--wait-for-ci",
+    "Hold GitHub auto-deploys until other check runs pass. Set on new-server creation."
+  )
+  .option(
     "--no-github",
     "Upload local source without connecting GitHub (repo hosted in the platform-managed org)"
   )
@@ -3089,6 +3097,8 @@ program
       buildCommand: options.buildCommand,
       startCommand: options.startCommand,
       dockerfile: options.dockerfile,
+      watchPaths: options.watchPaths,
+      waitForCi: options.waitForCi,
       noGithub: options.github === false,
     });
   });

--- a/libraries/typescript/packages/cli/src/utils/api.ts
+++ b/libraries/typescript/packages/cli/src/utils/api.ts
@@ -68,6 +68,10 @@ interface CreateServerBody {
   description?: string;
   tags?: string[];
   region?: string;
+  /** Glob patterns; only matching repo changes trigger auto-deploy. Empty = all changes. */
+  watchPaths?: string[];
+  /** When true, GitHub auto-deploy waits for other check runs to succeed. */
+  waitForCi?: boolean;
 }
 
 interface CreateServerResponse {
@@ -89,6 +93,12 @@ export interface UpdateServerBody {
   description?: string;
   productionBranch?: string;
   tags?: string[];
+  /** Glob patterns; only matching repo changes trigger auto-deploy. Empty array = all changes. */
+  watchPaths?: string[];
+  /** Branch globs for webhook auto-deploys; empty array allows all branches. */
+  deployBranchPatterns?: string[];
+  /** When true, GitHub auto-deploy waits for other check runs to succeed. */
+  waitForCi?: boolean;
   config?: Record<string, unknown>;
 }
 
@@ -98,6 +108,12 @@ interface CloudServerConnectedRepository {
   /** Null for platform-managed repos — the API never exposes the managed repo path. */
   repoFullName: string | null;
   productionBranch: string;
+  /** Glob patterns limiting which repo changes trigger auto-deploy. Empty = all changes. */
+  watchPaths?: string[];
+  /** Branch globs for webhook auto-deploys. Empty = all branches. */
+  deployBranchPatterns?: string[];
+  /** When true, GitHub auto-deploy waits for other check runs to succeed. */
+  waitForCi?: boolean;
   isActive: boolean;
   /** True when deployed via the platform-managed org (no user GitHub). */
   isManaged?: boolean;

--- a/libraries/typescript/packages/cli/tests/servers-update-env-branch.test.ts
+++ b/libraries/typescript/packages/cli/tests/servers-update-env-branch.test.ts
@@ -129,6 +129,89 @@ describe("servers update field mapping", () => {
     });
   });
 
+  it("maps watch paths / deploy branches / wait-for-ci / root-dir", async () => {
+    const { createServersCommand } = await import("../src/commands/servers.js");
+    mockApiInstance.updateServer.mockResolvedValue({
+      id: SERVER_ID,
+      name: "my-server",
+      slug: "my-server",
+    });
+
+    const cmd = createServersCommand();
+    await cmd.parseAsync(
+      [
+        "update",
+        SERVER_ID,
+        "--watch-paths",
+        "apps/foo/**",
+        "packages/shared/**",
+        "--deploy-branches",
+        "release/*",
+        "--wait-for-ci",
+        "--root-dir",
+        "apps/foo",
+      ],
+      { from: "user" }
+    );
+
+    expect(mockApiInstance.updateServer).toHaveBeenCalledWith(SERVER_ID, {
+      watchPaths: ["apps/foo/**", "packages/shared/**"],
+      deployBranchPatterns: ["release/*"],
+      waitForCi: true,
+      config: { rootDir: "apps/foo" },
+    });
+  });
+
+  it("clears watch paths / deploy branches and resets root dir with empty values", async () => {
+    const { createServersCommand } = await import("../src/commands/servers.js");
+    mockApiInstance.updateServer.mockResolvedValue({
+      id: SERVER_ID,
+      name: "my-server",
+      slug: "my-server",
+    });
+
+    const cmd = createServersCommand();
+    await cmd.parseAsync(
+      [
+        "update",
+        SERVER_ID,
+        "--watch-paths",
+        "",
+        "--deploy-branches",
+        "",
+        "--no-wait-for-ci",
+        "--root-dir",
+        "",
+      ],
+      { from: "user" }
+    );
+
+    expect(mockApiInstance.updateServer).toHaveBeenCalledWith(SERVER_ID, {
+      watchPaths: [],
+      deployBranchPatterns: [],
+      waitForCi: false,
+      config: { rootDir: null },
+    });
+  });
+
+  it("omits waitForCi when neither --wait-for-ci flag is passed", async () => {
+    const { createServersCommand } = await import("../src/commands/servers.js");
+    mockApiInstance.updateServer.mockResolvedValue({
+      id: SERVER_ID,
+      name: "my-server",
+      slug: "my-server",
+    });
+
+    const cmd = createServersCommand();
+    await cmd.parseAsync(["update", SERVER_ID, "--name", "renamed"], {
+      from: "user",
+    });
+
+    expect(mockApiInstance.updateServer).toHaveBeenCalledWith(SERVER_ID, {
+      name: "renamed",
+    });
+  });
+
   it("does not call the API when no fields are provided", async () => {
     const { createServersCommand } = await import("../src/commands/servers.js");
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((


### PR DESCRIPTION
## Summary

Closes the CLI/API mismatch behind #1547. The Cloud platform already supports per-server deploy filtering (`watchPaths`, `deployBranchPatterns`, `waitForCi`) plus monorepo `rootDir`, but the CLI could not set them — so this PR wires them through.

- `mcp-use deploy`: new `--watch-paths <glob...>` and `--wait-for-ci` (applied when creating a new GitHub server).
- `mcp-use servers update`: new `--watch-paths`, `--deploy-branches`, `--wait-for-ci`/`--no-wait-for-ci`, and `--root-dir`. Watch paths / deploy branches map to the top-level PATCH body; `rootDir` merges under `config`. Empty `""` clears a list (or resets root dir to repo root).
- `mcp-use servers get`/`update` now print the effective watch paths, deploy branch patterns, and wait-for-CI setting.

## Why

#1547 reported "every push rebuilds every app in a monorepo, prod branch is only a URL selector, no path filter." That is no longer true — watch paths + branch allow lists already exist server-side. The remaining gap was that they were dashboard-only; this makes them CLI-configurable so monorepo apps redeploy only on relevant changes.

## Implementation

- `--no-wait-for-ci` makes commander default `waitForCi` to `true`, so it's only forwarded when the user actually passed one of the flags (via `getOptionValueSource`).
- Extended `CreateServerBody`, `UpdateServerBody`, and `CloudServerConnectedRepository` in the CLI API client.

## Docs

- Rewrote the "Monorepos & multiple apps" section in `docs/typescript/server/deployment/mcp-use.mdx` with the correct behavior (replaces the outdated description in PR #1559).
- Updated `cli-reference.mdx` deploy + `servers update` flag tables and examples.

(Companion docs in `docs.manufact` and matching `update_server` fields in the manufact MCP server are tracked separately.)

## Testing

- Added unit tests for `servers update` flag→body mapping (set, clear, omit). `pnpm vitest` for the CLI passes (12/12).
- `prettier` + `eslint --fix` run on changed CLI files.

## Backwards Compatibility

Non-breaking — all new flags are optional and additive.

## Related Issues

Closes #1547. Supersedes #1559.