### PR TITLE
fix(mcp-use): restore Apps SDK compatibility in useWidget (fallback, no major)

### DIFF
--- a/libraries/typescript/.changeset/usewidget-apps-sdk-fallback.md
+++ b/libraries/typescript/.changeset/usewidget-apps-sdk-fallback.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Fix `useWidget` breaking Apps SDK-only widgets. The MCP Apps bridge remains the primary runtime, but `window.openai` (Apps SDK) is now used as a compatibility fallback when the bridge does not connect, instead of being dropped entirely. Previously, any widget iframe whose host only spoke the Apps SDK (e.g. a ChatGPT widget without MCP Apps support) stayed stuck on the loading spinner because `useWidget` ignored `window.openai` data. A connected MCP Apps bridge still always wins, so ChatGPT continues to use MCP Apps as the source of truth.

--- a/libraries/typescript/packages/inspector/tests/e2e/chat.test.ts
+++ b/libraries/typescript/packages/inspector/tests/e2e/chat.test.ts
@@ -305,12 +305,16 @@ test.describe("Inspector Chat Tests", () => {
         .getByTestId("chat-input")
         .fill(`Write a short list of 10 items. Iteration ${i + 1}.`);
       await page.getByTestId("chat-send-button").click();
-      await expect(page.getByTestId("chat-message-user")).toBeVisible({
+      // Each iteration adds one user + one assistant message. Assert on the
+      // count (not visibility) so the locator stays unambiguous after the
+      // first turn, which would otherwise trip Playwright strict mode.
+      await expect(page.getByTestId("chat-message-user")).toHaveCount(i + 1, {
         timeout: 3000,
       });
-      await expect(page.getByTestId("chat-message-assistant")).toBeVisible({
-        timeout: 45000,
-      });
+      await expect(page.getByTestId("chat-message-assistant")).toHaveCount(
+        i + 1,
+        { timeout: 45000 }
+      );
     }
 
     const container = page.getByTestId("chat-messages-scroll-container");
@@ -325,18 +329,19 @@ test.describe("Inspector Chat Tests", () => {
     const scrollButton = page.getByTestId("chat-scroll-to-bottom");
     await expect(scrollButton).toBeVisible({ timeout: 3000 });
 
-    // Click button and ensure we end up at the bottom.
+    // Click button and ensure we end up at the bottom. The scroll is animated,
+    // so poll until it settles instead of measuring synchronously.
     await scrollButton.click();
 
-    await container.evaluate((el) => {
-      const distanceFromBottom =
-        el.scrollHeight - (el.scrollTop + el.clientHeight);
-      if (distanceFromBottom > 80) {
-        throw new Error(
-          `Expected to be near bottom, distance=${distanceFromBottom}`
-        );
-      }
-    });
+    await expect
+      .poll(
+        () =>
+          container.evaluate(
+            (el) => el.scrollHeight - (el.scrollTop + el.clientHeight)
+          ),
+        { timeout: 5000 }
+      )
+      .toBeLessThanOrEqual(80);
 
     await expect(scrollButton).not.toBeVisible({ timeout: 3000 });
   });

--- a/libraries/typescript/packages/mcp-use/src/react/useWidget.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/useWidget.ts
@@ -1,10 +1,17 @@
 /**
  * React hook for MCP Apps widget development.
- * Uses MCP Apps postMessage as the base protocol and keeps window.openai
- * available for extension APIs.
+ * Uses MCP Apps postMessage as the primary protocol, with a window.openai
+ * (Apps SDK) compatibility fallback for hosts that only speak the Apps SDK.
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 import { getMcpAppsBridge } from "./mcp-apps-bridge.js";
 import { WIDGET_DEFAULTS } from "./constants.js";
 import { normalizeCallToolResponse } from "./widget-utils.js";
@@ -17,17 +24,66 @@ import type {
   DisplayMode,
   HostContext,
   MessageContentBlock,
+  OpenAiGlobals,
   SafeArea,
+  SetGlobalsEvent,
   Theme,
   UnknownObject,
   UserAgent,
   UseWidgetResult,
 } from "./widget-types.js";
+import { SET_GLOBALS_EVENT_TYPE } from "./widget-types.js";
+
+/**
+ * Hook to subscribe to a single value from window.openai globals.
+ * Only triggers onChange when the value actually changes, to avoid redundant
+ * re-renders from duplicate events (e.g. theme sync that re-sends same toolOutput).
+ *
+ * This powers the Apps SDK compatibility fallback. MCP Apps remains the primary
+ * runtime; these values are only consumed when the MCP Apps bridge is not
+ * connected (see `provider`).
+ */
+function useOpenAiGlobal<K extends keyof OpenAiGlobals>(
+  key: K
+): OpenAiGlobals[K] | undefined {
+  return useSyncExternalStore(
+    (onChange) => {
+      // Initialize from current snapshot so redundant events with same values are ignored
+      let lastValue: unknown =
+        typeof window !== "undefined" && window.openai
+          ? (window.openai as OpenAiGlobals)[key]
+          : undefined;
+      const handleSetGlobal = (event: SetGlobalsEvent) => {
+        const value = event.detail.globals[key];
+        if (value === undefined) {
+          return;
+        }
+        if (value === lastValue) return;
+        lastValue = value;
+        onChange();
+      };
+
+      if (typeof window !== "undefined") {
+        window.addEventListener(SET_GLOBALS_EVENT_TYPE, handleSetGlobal);
+      }
+
+      return () => {
+        if (typeof window !== "undefined") {
+          window.removeEventListener(SET_GLOBALS_EVENT_TYPE, handleSetGlobal);
+        }
+      };
+    },
+    () =>
+      typeof window !== "undefined" && window.openai
+        ? window.openai[key]
+        : undefined
+  );
+}
 
 /**
  * React hook for building MCP Apps widgets.
  *
- * Abstracts over two data providers, selected automatically:
+ * Abstracts over three data providers, selected automatically:
  *
  * 1. **MCP Apps bridge** (SEP-1865 `postMessage`) — primary runtime for
  *    hosted widget iframes, including ChatGPT. The hook connects via
@@ -35,7 +91,14 @@ import type {
  *    `ui/notifications/tool-input`, `ui/notifications/tool-input-partial`,
  *    `ui/notifications/tool-result`, and `ui/notifications/host-context-changed`.
  *
- * 2. **URL params fallback** (`mcpUseParams`) — used during local development
+ * 2. **Apps SDK fallback** (`window.openai`) — used only when the MCP Apps
+ *    bridge does not connect (e.g. a host that exposes `window.openai` but does
+ *    not speak the MCP Apps protocol). Data arrives via `window.openai.toolInput`
+ *    / `window.openai.toolOutput` and the `openai:set_globals` custom event. MCP
+ *    Apps always wins once its bridge connects, even when `window.openai` is also
+ *    present (ChatGPT).
+ *
+ * 3. **URL params fallback** (`mcpUseParams`) — used during local development
  *    (`mcp-use dev` inspector) where `toolInput` and `toolOutput` are injected
  *    via the query string. No live streaming in this mode.
  *
@@ -99,6 +162,12 @@ export function useWidget<
   const isWidgetIframe = useMemo(
     () => typeof window !== "undefined" && window !== window.parent,
     []
+  );
+
+  // Apps SDK availability (compatibility fallback). State so we can re-check
+  // after async window.openai injection.
+  const [isOpenAiAvailable, setIsOpenAiAvailable] = useState(
+    () => typeof window !== "undefined" && !!window.openai
   );
 
   // Check if MCP Apps bridge is available
@@ -168,8 +237,50 @@ export function useWidget<
       });
   }, []);
 
+  // Re-check for window.openai availability after mount (in case it's injected
+  // asynchronously). Powers the Apps SDK compatibility fallback.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    // Initial check
+    if (window.openai) {
+      setIsOpenAiAvailable(true);
+      return;
+    }
+
+    // Poll for window.openai if not immediately available (async script injection)
+    const checkInterval = setInterval(() => {
+      if (window.openai) {
+        setIsOpenAiAvailable(true);
+        clearInterval(checkInterval);
+      }
+    }, 100);
+
+    // Also listen for the openai:set_globals event which fires when the API is ready
+    const handleSetGlobals = () => {
+      if (window.openai) {
+        setIsOpenAiAvailable(true);
+        clearInterval(checkInterval);
+      }
+    };
+    window.addEventListener(SET_GLOBALS_EVENT_TYPE, handleSetGlobals);
+
+    // Stop polling after 5 seconds (should be injected by then)
+    const timeout = setTimeout(() => {
+      clearInterval(checkInterval);
+      window.removeEventListener(SET_GLOBALS_EVENT_TYPE, handleSetGlobals);
+    }, 5000);
+
+    return () => {
+      clearInterval(checkInterval);
+      clearTimeout(timeout);
+      window.removeEventListener(SET_GLOBALS_EVENT_TYPE, handleSetGlobals);
+    };
+  }, []);
+
   // Initialize MCP Apps bridge for hosted widget iframes. ChatGPT may also
-  // expose window.openai, but MCP Apps remains the base protocol.
+  // expose window.openai, but MCP Apps remains the primary protocol — when the
+  // bridge connects it wins over the Apps SDK fallback.
   useEffect(() => {
     if (!isWidgetIframe || typeof window === "undefined") {
       return;
@@ -261,22 +372,70 @@ export function useWidget<
     };
   }, [searchString]);
 
+  // Provider selection: MCP Apps is primary. The Apps SDK (`window.openai`)
+  // path is a compatibility fallback used only while/if the MCP Apps bridge is
+  // not connected. A connected bridge always wins (preserves the "MCP Apps
+  // primary even when window.openai is present" behavior for ChatGPT).
   const provider = useMemo(() => {
-    return isWidgetIframe ? "mcp-apps" : "mcp-ui";
-  }, [isWidgetIframe]);
+    if (!isWidgetIframe) return "mcp-ui";
+    if (isMcpAppsConnected) return "mcp-apps";
+    if (isOpenAiAvailable) return "openai";
+    return "mcp-apps";
+  }, [isWidgetIframe, isMcpAppsConnected, isOpenAiAvailable]);
+
+  // Apps SDK globals (consumed only when provider === "openai").
+  const openaiToolInput = useOpenAiGlobal("toolInput") as
+    | TToolInput
+    | undefined;
+  const openaiToolOutput = useOpenAiGlobal("toolOutput") as
+    | TOutput
+    | null
+    | undefined;
+  const openaiResponseMetadata = useOpenAiGlobal("toolResponseMetadata") as
+    | TMetadata
+    | null
+    | undefined;
+  const openaiWidgetState = useOpenAiGlobal("widgetState") as
+    | TState
+    | null
+    | undefined;
+  const openaiTheme = useOpenAiGlobal("theme") as Theme | undefined;
+  const openaiDisplayMode = useOpenAiGlobal("displayMode") as
+    | DisplayMode
+    | undefined;
+  const openaiSafeArea = useOpenAiGlobal("safeArea") as SafeArea | undefined;
+  const openaiMaxHeight = useOpenAiGlobal("maxHeight") as number | undefined;
+  const openaiUserAgent = useOpenAiGlobal("userAgent") as UserAgent | undefined;
+  const openaiLocale = useOpenAiGlobal("locale") as string | undefined;
 
   // Select data source based on provider
   const toolInput = useMemo(() => {
+    if (provider === "openai") return openaiToolInput;
     if (provider === "mcp-apps")
       return mcpAppsToolInput as TToolInput | undefined;
     return urlParams.toolInput as TToolInput | undefined;
-  }, [provider, mcpAppsToolInput, urlParams.toolInput]);
+  }, [provider, openaiToolInput, mcpAppsToolInput, urlParams.toolInput]);
 
   const toolOutput = useMemo(() => {
+    if (provider === "openai") {
+      // Unwrap CallToolResult envelope if the host passed the full tool-result params
+      const raw = openaiToolOutput as
+        | Record<string, unknown>
+        | null
+        | undefined;
+      if (
+        raw &&
+        raw.structuredContent &&
+        typeof raw.structuredContent === "object"
+      ) {
+        return raw.structuredContent as TOutput | null | undefined;
+      }
+      return openaiToolOutput;
+    }
     if (provider === "mcp-apps")
       return mcpAppsToolOutput as TOutput | null | undefined;
     return urlParams.toolOutput as TOutput | null | undefined;
-  }, [provider, mcpAppsToolOutput, urlParams.toolOutput]);
+  }, [provider, openaiToolOutput, mcpAppsToolOutput, urlParams.toolOutput]);
 
   // Props semantics:
   // - Widget exposed as tool: props = toolInput (args to the tool); when result arrives, props = structuredContent (tool can echo/override).
@@ -287,8 +446,18 @@ export function useWidget<
     const base = (defaultProps || {}) as Record<string, unknown> as TProps;
 
     // Extract structuredContent from provider-specific toolOutput.
+    // Some hosts (e.g. compat runtimes bridging MCP Apps → window.openai) pass the
+    // full CallToolResult envelope { content, structuredContent, _meta } as toolOutput
+    // instead of pre-extracting structuredContent. Detect and unwrap when needed.
     let structuredContent: Record<string, unknown> | undefined;
-    if (provider === "mcp-apps" && mcpAppsToolOutput) {
+    if (provider === "openai" && openaiToolOutput) {
+      const raw = openaiToolOutput as Record<string, unknown>;
+      if (raw.structuredContent && typeof raw.structuredContent === "object") {
+        structuredContent = raw.structuredContent as Record<string, unknown>;
+      } else {
+        structuredContent = raw;
+      }
+    } else if (provider === "mcp-apps" && mcpAppsToolOutput) {
       structuredContent = mcpAppsToolOutput as Record<string, unknown>;
     } else if (provider === "mcp-ui" && urlParams.toolOutput) {
       structuredContent = urlParams.toolOutput as Record<string, unknown>;
@@ -300,6 +469,7 @@ export function useWidget<
   }, [
     provider,
     toolInput,
+    openaiToolOutput,
     mcpAppsToolOutput,
     urlParams.toolOutput,
     defaultProps,
@@ -307,38 +477,46 @@ export function useWidget<
 
   // Theme, displayMode, and other host context from provider
   const theme = useMemo(() => {
+    if (provider === "openai") return openaiTheme;
     if (provider === "mcp-apps" && mcpAppsHostContext) {
       return mcpAppsHostContext.theme as Theme | undefined;
     }
     return undefined;
-  }, [provider, mcpAppsHostContext]);
+  }, [provider, openaiTheme, mcpAppsHostContext]);
 
   const displayMode = useMemo(() => {
+    if (provider === "openai") return openaiDisplayMode;
     if (provider === "mcp-apps" && mcpAppsHostContext) {
       return mcpAppsHostContext.displayMode as DisplayMode | undefined;
     }
     return undefined;
-  }, [provider, mcpAppsHostContext]);
+  }, [provider, openaiDisplayMode, mcpAppsHostContext]);
 
   const safeArea = useMemo(() => {
+    if (provider === "openai") return openaiSafeArea;
     if (provider === "mcp-apps" && mcpAppsHostContext?.safeAreaInsets) {
       return {
         insets: mcpAppsHostContext.safeAreaInsets,
       } as SafeArea;
     }
     return undefined;
-  }, [provider, mcpAppsHostContext]);
+  }, [provider, openaiSafeArea, mcpAppsHostContext]);
 
   const maxHeight = useMemo(() => {
+    if (provider === "openai") return openaiMaxHeight;
     if (provider === "mcp-apps" && mcpAppsHostContext?.containerDimensions) {
       return mcpAppsHostContext.containerDimensions.maxHeight as
         | number
         | undefined;
     }
     return undefined;
-  }, [provider, mcpAppsHostContext]);
+  }, [provider, openaiMaxHeight, mcpAppsHostContext]);
 
   const maxWidth = useMemo(() => {
+    if (provider === "openai") {
+      // ChatGPT Apps SDK doesn't expose maxWidth
+      return undefined;
+    }
     if (provider === "mcp-apps" && mcpAppsHostContext?.containerDimensions) {
       return mcpAppsHostContext.containerDimensions.maxWidth as
         | number
@@ -348,6 +526,7 @@ export function useWidget<
   }, [provider, mcpAppsHostContext]);
 
   const userAgent = useMemo(() => {
+    if (provider === "openai") return openaiUserAgent;
     if (provider === "mcp-apps" && mcpAppsHostContext) {
       // Map MCP Apps device capabilities to UserAgent format
       return {
@@ -363,16 +542,23 @@ export function useWidget<
       } as UserAgent;
     }
     return undefined;
-  }, [provider, mcpAppsHostContext]);
+  }, [provider, openaiUserAgent, mcpAppsHostContext]);
 
   const locale = useMemo(() => {
+    if (provider === "openai") return openaiLocale;
     if (provider === "mcp-apps" && mcpAppsHostContext) {
       return mcpAppsHostContext.locale as string | undefined;
     }
     return undefined;
-  }, [provider, mcpAppsHostContext]);
+  }, [provider, openaiLocale, mcpAppsHostContext]);
 
   const timeZone = useMemo(() => {
+    if (provider === "openai") {
+      // ChatGPT Apps SDK doesn't expose timeZone, use browser default
+      return typeof window !== "undefined"
+        ? Intl.DateTimeFormat().resolvedOptions().timeZone
+        : undefined;
+    }
     if (provider === "mcp-apps" && mcpAppsHostContext) {
       return mcpAppsHostContext.timeZone as string | undefined;
     }
@@ -398,6 +584,14 @@ export function useWidget<
   const providerRef = useRef(provider);
   providerRef.current = provider;
 
+  // Sync widget state from window.openai when the Apps SDK fallback is active.
+  // Gated on provider so it never clobbers MCP Apps-managed state.
+  useEffect(() => {
+    if (provider === "openai" && openaiWidgetState !== undefined) {
+      setLocalWidgetState(openaiWidgetState);
+    }
+  }, [provider, openaiWidgetState]);
+
   // Register the model-context flush handler for the lifetime of this widget.
   // When the node tree changes, this handler is called with the serialized
   // description and pushes it to the host under MODEL_CONTEXT_KEY.
@@ -408,6 +602,26 @@ export function useWidget<
 
       if (currentProvider === "mcp-apps") {
         pushModelContextToMcpApps();
+        return;
+      }
+
+      if (currentProvider === "openai" && window.openai?.setWidgetState) {
+        // Skip empty descriptions: avoids a spurious write during the brief
+        // window before the MCP Apps bridge connects (ChatGPT exposes both).
+        if (description === null || description.trim().length === 0) {
+          return;
+        }
+        const prev = (window.openai.widgetState ??
+          latestWidgetStateRef.current ??
+          {}) as Record<string, unknown>;
+        window.openai
+          .setWidgetState({
+            ...prev,
+            [MODEL_CONTEXT_KEY]: description,
+          } as UnknownObject)
+          .catch((err: unknown) => {
+            console.warn("[ModelContext] Failed to set widget state:", err);
+          });
       }
     });
     return deregister;
@@ -419,11 +633,19 @@ export function useWidget<
       name: string,
       args: Record<string, unknown>
     ): Promise<CallToolResponse> => {
+      if (provider === "openai") {
+        if (!window.openai?.callTool) {
+          throw new Error("window.openai.callTool is not available");
+        }
+        const raw = await window.openai.callTool(name, args);
+        return normalizeCallToolResponse(raw);
+      }
+
       const bridge = getMcpAppsBridge();
       const raw = await bridge.callTool(name, args);
       return normalizeCallToolResponse(raw);
     },
-    []
+    [provider]
   );
 
   const sendFollowUpMessage = useCallback(
@@ -433,25 +655,61 @@ export function useWidget<
           ? [{ type: "text", text: content }]
           : content;
 
+      if (provider === "openai") {
+        if (!window.openai?.sendFollowUpMessage) {
+          throw new Error("window.openai.sendFollowUpMessage is not available");
+        }
+        // window.openai only supports plain text; extract and join text blocks
+        const prompt =
+          typeof content === "string"
+            ? content
+            : contentArray
+                .filter(
+                  (c): c is { type: "text"; text: string } =>
+                    c.type === "text" && "text" in c
+                )
+                .map((c) => c.text)
+                .join("\n");
+        return window.openai.sendFollowUpMessage({ prompt });
+      }
+
       const bridge = getMcpAppsBridge();
       await bridge.sendMessage(contentArray);
     },
-    []
+    [provider]
   );
 
-  const openExternal = useCallback((href: string): void => {
-    const bridge = getMcpAppsBridge();
-    bridge.openLink(href).catch((error) => {
-      console.error("Failed to open link:", error);
-    });
-  }, []);
+  const openExternal = useCallback(
+    (href: string): void => {
+      if (provider === "openai") {
+        if (!window.openai?.openExternal) {
+          throw new Error("window.openai.openExternal is not available");
+        }
+        window.openai.openExternal({ href });
+        return;
+      }
+
+      const bridge = getMcpAppsBridge();
+      bridge.openLink(href).catch((error) => {
+        console.error("Failed to open link:", error);
+      });
+    },
+    [provider]
+  );
 
   const requestDisplayMode = useCallback(
     async (mode: DisplayMode): Promise<{ mode: DisplayMode }> => {
+      if (provider === "openai") {
+        if (!window.openai?.requestDisplayMode) {
+          throw new Error("window.openai.requestDisplayMode is not available");
+        }
+        return window.openai.requestDisplayMode({ mode });
+      }
+
       const bridge = getMcpAppsBridge();
       return await bridge.requestDisplayMode(mode);
     },
-    []
+    [provider]
   );
 
   const setState = useCallback(
@@ -467,6 +725,25 @@ export function useWidget<
       latestWidgetStateRef.current = newState;
       setLocalWidgetState(newState);
 
+      // Apps SDK fallback: persist via window.openai.setWidgetState, preserving
+      // any prior __model_context annotation.
+      if (providerRef.current === "openai") {
+        if (!window.openai?.setWidgetState) {
+          throw new Error("window.openai.setWidgetState is not available");
+        }
+        const prevModelContext = (
+          (window.openai.widgetState ?? {}) as Record<string, unknown>
+        )[MODEL_CONTEXT_KEY];
+        return window.openai.setWidgetState(
+          prevModelContext !== undefined
+            ? ({
+                ...(newState as Record<string, unknown>),
+                [MODEL_CONTEXT_KEY]: prevModelContext,
+              } as UnknownObject)
+            : (newState as UnknownObject)
+        );
+      }
+
       pushModelContextToMcpApps();
     },
     [pushModelContextToMcpApps]
@@ -474,6 +751,12 @@ export function useWidget<
 
   // Determine if tool is still executing
   const isPending = useMemo(() => {
+    if (provider === "openai") {
+      // Tool is pending until the host delivers either toolOutput
+      // (structuredContent) or toolResponseMetadata (_meta). Checking both
+      // mirrors MCP Apps and avoids staying stuck when the server omits _meta.
+      return openaiToolOutput === null && openaiResponseMetadata === null;
+    }
     if (provider === "mcp-apps") {
       // In MCP Apps, widget is pending until we receive tool-result notification
       // We check toolOutput instead of toolInput because input is sent immediately
@@ -494,14 +777,21 @@ export function useWidget<
       return toolOutput === null || toolOutput === undefined;
     }
     return false;
-  }, [provider, mcpAppsToolOutput, toolOutput, urlParams.toolId]);
+  }, [
+    provider,
+    openaiToolOutput,
+    openaiResponseMetadata,
+    mcpAppsToolOutput,
+    toolOutput,
+    urlParams.toolId,
+  ]);
 
   // Partial/streaming tool input (available during LLM argument generation)
   const partialToolInput = useMemo(() => {
     if (provider === "mcp-apps" && mcpAppsPartialToolInput) {
       return mcpAppsPartialToolInput as Partial<TToolInput>;
     }
-    // URL params don't support streaming tool input.
+    // Apps SDK and URL params don't support streaming tool input.
     return null;
   }, [provider, mcpAppsPartialToolInput]);
 
@@ -525,7 +815,9 @@ export function useWidget<
     output: (toolOutput ?? null) as TOutput | null,
     metadata: (provider === "mcp-apps"
       ? (mcpAppsResponseMetadata ?? null)
-      : null) as TMetadata | null,
+      : provider === "openai"
+        ? (openaiResponseMetadata ?? null)
+        : null) as TMetadata | null,
     state: localWidgetState
       ? (Object.fromEntries(
           Object.entries(localWidgetState as Record<string, unknown>).filter(
@@ -560,7 +852,12 @@ export function useWidget<
     requestDisplayMode,
 
     // Availability
-    isAvailable: provider === "mcp-apps" ? isMcpAppsConnected : false,
+    isAvailable:
+      provider === "mcp-apps"
+        ? isMcpAppsConnected
+        : provider === "openai"
+          ? isOpenAiAvailable
+          : false,
     isPending,
 
     // Streaming

--- a/libraries/typescript/packages/mcp-use/src/react/widget-types.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/widget-types.ts
@@ -135,6 +135,17 @@ export interface OpenAiGlobals<
   widgetState: WidgetState | null;
 }
 
+/**
+ * Custom event name dispatched by Apps SDK hosts (`window.openai`) when globals
+ * change. Used by the `window.openai` compatibility fallback in `useWidget`,
+ * which only activates when the MCP Apps bridge is not connected.
+ */
+export const SET_GLOBALS_EVENT_TYPE = "openai:set_globals";
+
+export type SetGlobalsEvent = CustomEvent<{
+  globals: Partial<OpenAiGlobals>;
+}>;
+
 export interface API<WidgetState extends UnknownObject = UnknownObject> {
   /** Calls a tool on your MCP. Returns the full response. */
   callTool: (
@@ -184,6 +195,10 @@ declare global {
     __getFile?: (filename: string) => string;
     __mcpPublicUrl?: string;
     __mcpPublicAssetsUrl?: string;
+  }
+
+  interface WindowEventMap {
+    "openai:set_globals": SetGlobalsEvent;
   }
 }
 

--- a/libraries/typescript/packages/mcp-use/tests/unit/react/mcp-apps-primary-runtime.test.tsx
+++ b/libraries/typescript/packages/mcp-use/tests/unit/react/mcp-apps-primary-runtime.test.tsx
@@ -197,6 +197,41 @@ describe("MCP Apps primary widget runtime", () => {
     expect(window.openai?.setWidgetState).not.toHaveBeenCalled();
   });
 
+  it("falls back to window.openai when the MCP Apps bridge never connects", async () => {
+    // Simulate an Apps SDK-only host: window.openai is present but the parent
+    // does not speak MCP Apps, so the bridge connect never resolves.
+    bridge.connect.mockReturnValue(new Promise<void>(() => {}));
+    bridge.isConnected.mockReturnValue(false);
+
+    let latest: ReturnType<typeof useWidget> | undefined;
+
+    function TestComponent() {
+      latest = useWidget();
+      return null;
+    }
+
+    await act(async () => {
+      create(<TestComponent />);
+      await flushMicrotasks();
+    });
+
+    // Data comes from window.openai, not the (never-connected) bridge.
+    expect(latest?.isPending).toBe(false);
+    expect(latest?.props).toEqual({ source: "openai-output" });
+    expect(latest?.toolInput).toEqual({ source: "openai-input" });
+    expect(latest?.metadata).toEqual({ source: "openai-meta" });
+    expect(latest?.theme).toBe("light");
+    expect(latest?.maxHeight).toBe(111);
+    expect(latest?.isAvailable).toBe(true);
+
+    // Actions route to window.openai while the bridge is unavailable.
+    await act(async () => {
+      await latest!.callTool("lookup", { id: 9 });
+    });
+    expect(window.openai?.callTool).toHaveBeenCalledWith("lookup", { id: 9 });
+    expect(bridge.callTool).not.toHaveBeenCalled();
+  });
+
   it("preserves ModelContext annotations when widget state is overwritten", async () => {
     let latest: ReturnType<typeof useWidget> | undefined;
 


### PR DESCRIPTION
## Summary

Restores `window.openai` (Apps SDK) support in `useWidget` as a **compatibility fallback**, while keeping the MCP Apps bridge as the primary widget runtime.

#1739 ("Make MCP Apps primary widget runtime") made the MCP Apps bridge the **sole** runtime for iframe widgets and deleted the entire `window.openai` data/action path. Any host that only speaks the Apps SDK — including real ChatGPT widgets without MCP Apps support, and the inspector's Apps SDK preview tab — never connects the bridge, so `isPending` stayed `true` forever and the widget was stuck on its loading spinner.

## Why this approach (avoid a major release)

Dropping Apps SDK support outright is a **breaking change** for existing users who ship Apps SDK-only widgets — that would force a major version bump. Instead, this PR keeps both runtimes working:

- **MCP Apps is primary**: once the bridge connects it wins for all data and actions, even when `window.openai` is also present (ChatGPT). This preserves the #1739 intent and its unit test.
- **Apps SDK is a fallback**: used only while/if the bridge is not connected, so Apps SDK-only hosts render again.

This keeps the change **backward compatible (patch)**. We will fully **remove Apps SDK support in V2**, where dropping it is acceptable as a major.

## Provider selection

```ts
if (!isWidgetIframe) return "mcp-ui";
if (isMcpAppsConnected) return "mcp-apps"; // primary, wins over window.openai
if (isOpenAiAvailable) return "openai";    // Apps SDK compatibility fallback
return "mcp-apps";                          // default: wait for an MCP Apps host
```

## Changes

- `useWidget.ts`: re-add the `window.openai` subscriber + availability detection and branch `isPending`, `props`, host context (theme/locale/displayMode/safeArea/maxHeight/userAgent/timeZone), `metadata`, `isAvailable`, and all actions on the `openai` provider. Empty model-context writes are skipped so no spurious `setWidgetState` fires during the brief pre-connect window.
- `widget-types.ts`: re-add `SET_GLOBALS_EVENT_TYPE` / `SetGlobalsEvent` + `WindowEventMap` augmentation.
- Unit test: added a case for "bridge never connects + `window.openai` present -> renders via Apps SDK".
- `chat.test.ts`: fixed two pre-existing issues in the scroll-to-bottom test (strict-mode `chat-message-user` locator -> `toHaveCount`; measuring the animated scroll synchronously -> `expect.poll`).

## Testing

- `pnpm --filter mcp-use test` (react unit tests): all pass, incl. the new fallback case and the existing `mcp-apps-primary-runtime` test.
- `tsc` clean; eslint + prettier clean on changed files.
- Full inspector e2e: `infisical run … pnpm test:e2e:builtin` -> **78 passed**.

## Backwards compatibility

Non-breaking (patch). Apps SDK support is intentionally retained until V2.