### PR TITLE
Adopt auto connection mode in inspector docs and UI

### DIFF
--- a/docs/inspector/connection-settings.mdx
+++ b/docs/inspector/connection-settings.mdx
@@ -4,23 +4,31 @@ description: "Advanced connection configuration and settings"
 icon: "settings"
 ---
 
-The MCP Inspector provides extensive configuration options for connecting to MCP servers, including connection types, transport protocols, timeouts, OAuth authentication, and custom headers.
+The MCP Inspector provides extensive configuration options for connecting to MCP servers, including connection mode, transport protocols, timeouts, OAuth authentication, and custom headers.
 
-## Connection Types
+## Connection Mode
 
-### Direct Connection
+By default, the Inspector uses **Auto** mode: it tries to connect directly to the MCP server first, then automatically falls back to the configured Inspector proxy if the direct connection fails for cases such as CORS or proxy-only routing.
 
-Connect directly to the MCP server without a proxy. This is the default and recommended option for most use cases.
+You normally do not need to change this setting. Open **Configuration** from the connection form if you need to force a specific mode.
+
+### Auto
+
+Try a direct connection first, then fall back to the Inspector proxy when direct connection fails. This is the default and recommended option for most use cases.
+
+### Direct
+
+Connect directly to the MCP server without proxy fallback.
 
 **When to use:**
 
-- Local development servers
-- Servers accessible from your network
-- Servers with public endpoints
+- Local development servers that are same-origin with the Inspector
+- Servers that require direct browser access
+- Debugging direct-only behavior
 
-### Via Proxy
+### Proxy
 
-Connect through a proxy server. Useful when you need to route traffic through an intermediary or when direct connections are blocked.
+Connect through the configured Inspector proxy immediately.
 
 **When to use:**
 
@@ -28,19 +36,6 @@ Connect through a proxy server. Useful when you need to route traffic through an
 - CORS restrictions
 - Testing proxy configurations
 - Development environments with proxy setup
-
-### Auto-Switch
-
-The inspector can automatically try both connection types if one fails. Enable this in the connection settings:
-
-1. Open the **Connection Type** dropdown
-2. Toggle **Auto-switch** on
-3. If Direct connection fails, the inspector will automatically try Via Proxy (and vice versa)
-
-<Note>
-  Auto-switch is skipped for authentication errors (401, Unauthorized) since
-  both connection types will fail the same way.
-</Note>
 
 ## Server display names
 
@@ -66,9 +61,9 @@ Maximum total time (in milliseconds) for the entire operation, including retries
 
 **Default:** `60000` (60 seconds)
 
-### Inspector Proxy Address
+### Proxy Endpoint
 
-The proxy endpoint URL when using "Via Proxy" connection type.
+The proxy endpoint URL used by **Auto** fallback and by forced **Proxy** mode.
 
 **Default:** `${window.location.origin}/inspector/api/proxy`
 
@@ -82,7 +77,6 @@ By default the inspector relies on Dynamic Client Registration (DCR), so no cred
 
 1. Click the **Authentication** button in the connection form
 2. Enter your OAuth credentials:
-
    - **Client ID**: Pre-registered OAuth client ID. Setting this skips DCR.
    - **Client Secret**: Pre-registered OAuth client secret (optional). Required for confidential clients without PKCE; when set alongside Client ID, the SDK switches token-endpoint auth from `none` to `client_secret_basic`/`client_secret_post`.
    - **Scope**: Space-separated list of OAuth scopes
@@ -167,7 +161,7 @@ Export your connection configuration as JSON:
 {
   "url": "https://mcp.example.com/mcp",
   "transportType": "http",
-  "connectionType": "Direct",
+  "connectionMode": "auto",
   "headers": {
     "Authorization": "Bearer token123"
   },

--- a/docs/inspector/url-parameters.mdx
+++ b/docs/inspector/url-parameters.mdx
@@ -8,14 +8,14 @@ The Inspector supports URL query parameters for deep linking to a specific serve
 
 ## Parameters
 
-| Parameter | Purpose | Values |
-|-----------|---------|--------|
-| **server** | Select a connected server by ID, or open and connect to a server by URL | Connection ID (URL) or HTTP(S) URL |
-| **autoConnect** | Open Inspector and connect to a server automatically | URL string or JSON config |
-| **tab** | Open a specific tab | `tools`, `prompts`, `resources`, `chat`, `sampling`, `elicitation`, `notifications`, `playground` |
-| **tunnelUrl** | Tunnel subdomain or URL (preserved when navigating) | URL string |
-| **embedded** | Run Inspector in embedded mode (e.g. iframe) | `true` |
-| **embeddedConfig** | Embedded mode styling (background, padding) | JSON string |
+| Parameter          | Purpose                                                                 | Values                                                                                            |
+| ------------------ | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| **server**         | Select a connected server by ID, or open and connect to a server by URL | Connection ID (URL) or HTTP(S) URL                                                                |
+| **autoConnect**    | Open Inspector and connect to a server automatically                    | URL string or JSON config                                                                         |
+| **tab**            | Open a specific tab                                                     | `tools`, `prompts`, `resources`, `chat`, `sampling`, `elicitation`, `notifications`, `playground` |
+| **tunnelUrl**      | Tunnel subdomain or URL (preserved when navigating)                     | URL string                                                                                        |
+| **embedded**       | Run Inspector in embedded mode (e.g. iframe)                            | `true`                                                                                            |
+| **embeddedConfig** | Embedded mode styling (background, padding)                             | JSON string                                                                                       |
 
 ## server
 
@@ -44,13 +44,18 @@ Open the Inspector and connect to a server automatically. Use a plain URL or a J
 **JSON config** (URL-encode the value in the query string):
 
 ```json
-{"url":"https://mcp.example.com/mcp","name":"My Server","transportType":"sse"}
+{
+  "url": "https://mcp.example.com/mcp",
+  "name": "My Server",
+  "transportType": "sse"
+}
 ```
 
-Supported JSON fields: `url` (required), `name`, `transportType` (`"http"` or `"sse"`), `connectionType` (`"Direct"` or `"Via Proxy"`), `customHeaders`, `auth` (OAuth tokens), `requestTimeout`, `resetTimeoutOnProgress`, `maxTotalTimeout`.
+Supported JSON fields: `url` (required), `name`, `transportType` (`"http"` or `"sse"`), `connectionMode` (`"auto"`, `"direct"`, or `"proxy"`), `autoProxyFallback` (for a custom Auto fallback proxy), `connectionType` (`"Direct"` or `"Via Proxy"` for older links), `customHeaders`, `auth` (OAuth tokens), `requestTimeout`, `resetTimeoutOnProgress`, `maxTotalTimeout`.
 
 <Tip>
-When passing a JSON object for **autoConnect**, URL-encode the value so special characters are valid in the query string.
+  When passing a JSON object for **autoConnect**, URL-encode the value so
+  special characters are valid in the query string.
 </Tip>
 
 ## tab
@@ -92,7 +97,7 @@ Optional JSON config for embedded mode styling. Use with **embedded=true**.
 **Example** (URL-encoded):
 
 ```json
-{"backgroundColor":"#f5f5f5","padding":"16px"}
+{ "backgroundColor": "#f5f5f5", "padding": "16px" }
 ```
 
 ## Example URLs

--- a/libraries/typescript/.changeset/auto-proxy-fallback-mode.md
+++ b/libraries/typescript/.changeset/auto-proxy-fallback-mode.md
@@ -1,0 +1,21 @@
+---
+"@mcp-use/inspector": patch
+"mcp-use": patch
+---
+
+fix(inspector): default connections to Auto mode with proxy fallback
+
+The Inspector connection form no longer asks users to choose between Direct and
+Via Proxy before connecting. New connections use Auto mode by default: the
+Inspector tries a direct browser connection first, then falls back to the
+configured Inspector proxy when direct connection fails because of CORS or other
+proxy-resolvable connection errors.
+
+Direct and Proxy are still available as advanced connection mode overrides in
+the Configuration dialog, alongside the editable Proxy Endpoint. The Inspector
+also preserves legacy `connectionType` configs while writing the new
+`connectionMode` field.
+
+`useMcp` now applies the runtime proxy config after automatic fallback when it
+derives gateway URLs and headers, so fallback retries route through the proxy
+instead of continuing to use the original direct transport config.

--- a/libraries/typescript/packages/inspector/src/client/App.tsx
+++ b/libraries/typescript/packages/inspector/src/client/App.tsx
@@ -16,6 +16,7 @@ import { toast } from "sonner";
 import { InspectorProvider, useInspector } from "./context/InspectorContext";
 import { ThemeProvider } from "./context/ThemeContext";
 import { WidgetDebugProvider } from "./context/WidgetDebugContext";
+import { getDefaultInspectorProxyAddress } from "./utils/connectionUpdates";
 
 /**
  * Syncs the active tab from InspectorContext into a ref readable by
@@ -63,13 +64,9 @@ function App() {
     [isEmbedded]
   );
 
-  // Read the proxy path injected by the inspector server (undefined when served
-  // from a Python/custom server that fetches static HTML and has no proxy).
-  const injectedProxyPath = (window as Window & { __MCP_PROXY_URL__?: string })
-    .__MCP_PROXY_URL__;
-  const proxyAddress = injectedProxyPath
-    ? `${window.location.origin}${injectedProxyPath}`
-    : undefined;
+  // Read the proxy path injected by the inspector server. Missing injection
+  // falls back to the standard Inspector route; explicit null disables proxy.
+  const proxyAddress = getDefaultInspectorProxyAddress();
 
   // App-level so it fires regardless of route, and after <Toaster /> mounts.
   useEffect(() => {

--- a/libraries/typescript/packages/inspector/src/client/components/ConnectionSettingsForm.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ConnectionSettingsForm.tsx
@@ -15,7 +15,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/client/components/ui/select";
-import { Switch } from "@/client/components/ui/switch";
 import { cn } from "@/client/lib/utils";
 import { copyToClipboard } from "@/client/utils/clipboard";
 import { Cog, Copy, FileText, Shield } from "lucide-react";
@@ -23,6 +22,10 @@ import { useRef, useState } from "react";
 import { toast } from "sonner";
 import type { CustomHeader } from "./CustomHeadersEditor";
 import { CustomHeadersEditor } from "./CustomHeadersEditor";
+import {
+  normalizeConnectionMode,
+  type ConnectionMode,
+} from "@/client/utils/connectionUpdates";
 
 interface ConnectionSettingsFormProps {
   // Form state
@@ -30,8 +33,8 @@ interface ConnectionSettingsFormProps {
   setAlias: (value: string) => void;
   url: string;
   setUrl: (value: string) => void;
-  connectionType: string;
-  setConnectionType: (value: string) => void;
+  connectionMode: ConnectionMode;
+  setConnectionMode: (value: ConnectionMode) => void;
   customHeaders: CustomHeader[];
   setCustomHeaders: (headers: CustomHeader[]) => void;
   requestTimeout: string;
@@ -50,10 +53,6 @@ interface ConnectionSettingsFormProps {
   setClientSecret: (value: string) => void;
   scope: string;
   setScope: (value: string) => void;
-
-  // Auto-switch
-  autoSwitch?: boolean;
-  setAutoSwitch?: (value: boolean) => void;
 
   // Callbacks
   onConnect?: () => void;
@@ -89,8 +88,8 @@ export function ConnectionSettingsForm({
   setAlias,
   url,
   setUrl,
-  connectionType,
-  setConnectionType,
+  connectionMode,
+  setConnectionMode,
   customHeaders,
   setCustomHeaders,
   requestTimeout,
@@ -107,8 +106,6 @@ export function ConnectionSettingsForm({
   setClientSecret,
   scope,
   setScope,
-  autoSwitch,
-  setAutoSwitch,
   onConnect,
   onSave,
   onCancel,
@@ -137,9 +134,10 @@ export function ConnectionSettingsForm({
       url,
       ...(alias.trim() ? { name: alias.trim() } : {}),
       transportType: "http", // HTTP only - SSE is deprecated
-      connectionType,
+      connectionMode,
+      connectionType: connectionMode === "proxy" ? "Via Proxy" : "Direct",
       proxyConfig:
-        connectionType === "Via Proxy" && proxyAddress.trim()
+        connectionMode === "proxy" && proxyAddress.trim()
           ? {
               proxyAddress: proxyAddress.trim(),
               customHeaders: customHeaders.reduce(
@@ -151,6 +149,13 @@ export function ConnectionSettingsForm({
                 },
                 {} as Record<string, string>
               ),
+            }
+          : undefined,
+      autoProxyFallback:
+        connectionMode === "auto" && proxyAddress.trim()
+          ? {
+              enabled: true,
+              proxyAddress: proxyAddress.trim(),
             }
           : undefined,
       customHeaders: customHeaders.reduce(
@@ -188,9 +193,6 @@ export function ConnectionSettingsForm({
     ? "bg-white/10 border-white/20 text-white placeholder:text-white/50"
     : "";
   const labelClassName = isStyled ? "text-white/90" : "";
-  const selectTriggerClassName = isStyled
-    ? "bg-white/10 border-white/20 text-white"
-    : "";
   const buttonClassName = isStyled
     ? "bg-white/10 border-white/20 text-white hover:bg-white/20"
     : "";
@@ -218,12 +220,21 @@ export function ConnectionSettingsForm({
         // Transport type is always HTTP now (SSE is deprecated)
         // No need to set transportType from config
 
-        if (config.connectionType) {
-          setConnectionType(config.connectionType);
-        }
+        const pastedProxyAddress =
+          config.proxyConfig?.proxyAddress ||
+          (typeof config.autoProxyFallback === "object"
+            ? config.autoProxyFallback.proxyAddress
+            : undefined);
+        setConnectionMode(
+          normalizeConnectionMode(
+            config.connectionMode,
+            config.connectionType,
+            !!pastedProxyAddress
+          )
+        );
 
-        if (config.proxyConfig?.proxyAddress) {
-          setProxyAddress(config.proxyConfig.proxyAddress);
+        if (pastedProxyAddress) {
+          setProxyAddress(pastedProxyAddress);
         }
 
         // Extract headers from proxyConfig (preferred) or top-level customHeaders/headers
@@ -357,51 +368,6 @@ export function ConnectionSettingsForm({
         </p>
       </div>
 
-      {/* Connection Type */}
-      <div className="space-y-2">
-        <div className="flex items-center justify-between">
-          <Label className={labelClassName}>Connection Type</Label>
-          {setAutoSwitch && (
-            <div className="flex items-center gap-2">
-              <Label
-                htmlFor="auto-switch"
-                className={cn(
-                  "text-xs cursor-pointer",
-                  isStyled ? "text-white/70" : "text-muted-foreground"
-                )}
-              >
-                Auto-switch
-              </Label>
-              <Switch
-                id="auto-switch"
-                data-testid="connection-form-auto-switch"
-                checked={autoSwitch}
-                onCheckedChange={(value) => {
-                  setAutoSwitch(value);
-                  localStorage.setItem(
-                    "mcp-inspector-auto-switch",
-                    String(value)
-                  );
-                }}
-                className="scale-75"
-              />
-            </div>
-          )}
-        </div>
-        <Select value={connectionType} onValueChange={setConnectionType}>
-          <SelectTrigger
-            className={cn("w-full", selectTriggerClassName)}
-            data-testid="connection-form-type-select"
-          >
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="Direct">Direct</SelectItem>
-            <SelectItem value="Via Proxy">Via Proxy</SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
-
       {/* Configuration Buttons Row */}
       <div className="flex flex-row gap-3 @lg:flex-col">
         {/* Authentication Button */}
@@ -522,6 +488,32 @@ export function ConnectionSettingsForm({
               <DialogTitle>Configuration</DialogTitle>
             </DialogHeader>
             <div className="space-y-4">
+              {/* Connection Mode */}
+              <div className="space-y-2">
+                <Label className="text-sm flex items-center gap-1">
+                  Connection Mode
+                  <span className="text-muted-foreground text-xs">(?)</span>
+                </Label>
+                <Select
+                  value={connectionMode}
+                  onValueChange={(value) =>
+                    setConnectionMode(value as ConnectionMode)
+                  }
+                >
+                  <SelectTrigger
+                    className="w-full"
+                    data-testid="config-dialog-connection-mode-select"
+                  >
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="auto">Auto</SelectItem>
+                    <SelectItem value="direct">Direct</SelectItem>
+                    <SelectItem value="proxy">Proxy</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
               {/* Request Timeout */}
               <div className="space-y-2">
                 <Label className="text-sm flex items-center gap-1">
@@ -573,10 +565,10 @@ export function ConnectionSettingsForm({
                 />
               </div>
 
-              {/* Inspector Proxy Address */}
+              {/* Proxy Endpoint */}
               <div className="space-y-2">
                 <Label className="text-sm flex items-center gap-1">
-                  Inspector Proxy Address
+                  Proxy Endpoint
                   <span className="text-muted-foreground text-xs">(?)</span>
                 </Label>
                 <Input

--- a/libraries/typescript/packages/inspector/src/client/components/InspectorDashboard.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/InspectorDashboard.tsx
@@ -40,8 +40,11 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 import { copyToClipboard } from "@/client/utils/clipboard";
 import {
   buildOAuthStaticConfig,
+  getDefaultInspectorProxyAddress,
   getStoredConnectionConfig,
   isAliasOnlyConnectionUpdate,
+  normalizeConnectionMode,
+  type ConnectionMode,
   type EditableConnectionConfig,
   type OAuthStaticConfig,
 } from "@/client/utils/connectionUpdates";
@@ -152,15 +155,26 @@ export function InspectorDashboard() {
       name?: string,
       proxyConfig?: any,
       transportType?: "http" | "sse",
-      oauth?: OAuthStaticConfig
+      oauth?: OAuthStaticConfig,
+      connectionMode: ConnectionMode = proxyConfig?.proxyAddress
+        ? "proxy"
+        : "auto",
+      autoProxyFallback:
+        | boolean
+        | {
+            enabled?: boolean;
+            proxyAddress?: string;
+          } = proxyConfig?.proxyAddress ? false : false
     ) => {
       addServer(url, {
         url,
         name,
+        connectionMode,
         proxyConfig,
         transportType,
         preventAutoAuth: true,
         useRedirectFlow: true,
+        autoProxyFallback,
         ...(oauth ? { oauth } : {}),
       });
     },
@@ -176,8 +190,15 @@ export function InspectorDashboard() {
           proxyAddress?: string;
           headers?: Record<string, string>;
         };
+        connectionMode?: ConnectionMode;
         transportType?: "http" | "sse";
         oauth?: OAuthStaticConfig;
+        autoProxyFallback?:
+          | boolean
+          | {
+              enabled?: boolean;
+              proxyAddress?: string;
+            };
       }
     ) => {
       // Check if already updating this connection
@@ -295,13 +316,13 @@ export function InspectorDashboard() {
   // Form state
   const [alias, setAlias] = useState("");
   const [url, setUrl] = useState("");
-  const [connectionType, setConnectionType] = useState("Direct");
+  const [connectionMode, setConnectionMode] = useState<ConnectionMode>("auto");
   const [customHeaders, setCustomHeaders] = useState<CustomHeader[]>([]);
   const [requestTimeout, setRequestTimeout] = useState("10000");
   const [resetTimeoutOnProgress, setResetTimeoutOnProgress] = useState("True");
   const [maxTotalTimeout, setMaxTotalTimeout] = useState("60000");
   const [proxyAddress, setProxyAddress] = useState(
-    `${window.location.origin}/inspector/api/proxy`
+    getDefaultInspectorProxyAddress()
   );
   // OAuth fields
   const [clientId, setClientId] = useState("");
@@ -409,14 +430,20 @@ export function InspectorDashboard() {
       {} as Record<string, string>
     );
 
-    // Prepare proxy configuration if "Via Proxy" is selected
+    // Prepare proxy configuration for forced proxy mode
     const proxyConfig =
-      connectionType === "Via Proxy" && proxyAddress.trim()
+      connectionMode === "proxy" && proxyAddress.trim()
         ? {
             proxyAddress: proxyAddress.trim(),
             headers: headersObject,
           }
         : undefined;
+    const autoProxyFallback =
+      connectionMode === "auto"
+        ? proxyAddress.trim()
+          ? { enabled: true, proxyAddress: proxyAddress.trim() }
+          : false
+        : false;
 
     const oauthConfig = buildOAuthStaticConfig(clientId, clientSecret, scope);
 
@@ -436,14 +463,9 @@ export function InspectorDashboard() {
           },
         },
       },
-      ...(proxyConfig
-        ? {
-            proxyConfig,
-            // Disable autoProxyFallback when proxy is explicitly configured
-            // User has chosen "Via Proxy" - use proxy from the start
-            autoProxyFallback: false,
-          }
-        : {}),
+      connectionMode,
+      autoProxyFallback,
+      ...(proxyConfig ? { proxyConfig } : {}),
       ...(Object.keys(headersObject).length > 0 && !proxyConfig
         ? { headers: headersObject }
         : {}),
@@ -472,6 +494,7 @@ export function InspectorDashboard() {
     setAlias("");
     setUrl("");
     setCustomHeaders([]);
+    setConnectionMode("auto");
     setClientId("");
     setClientSecret("");
     setScope("");
@@ -480,7 +503,7 @@ export function InspectorDashboard() {
   }, [
     url,
     alias,
-    connectionType,
+    connectionMode,
     proxyAddress,
     customHeaders,
     clientId,
@@ -537,11 +560,22 @@ export function InspectorDashboard() {
         connection.customHeaders ||
         {};
 
-      // Determine connection type and proxyConfig
+      // Determine connection mode and proxyConfig
+      const fallbackProxyAddress =
+        typeof storedConfig?.autoProxyFallback === "object"
+          ? storedConfig.autoProxyFallback.proxyAddress
+          : typeof connection.autoProxyFallback === "object"
+            ? connection.autoProxyFallback.proxyAddress
+            : undefined;
       const hasProxyAddress =
         storedConfig?.proxyConfig?.proxyAddress ||
-        connection.proxyConfig?.proxyAddress;
-      const connectionType = hasProxyAddress ? "Via Proxy" : "Direct";
+        connection.proxyConfig?.proxyAddress ||
+        fallbackProxyAddress;
+      const connectionMode = normalizeConnectionMode(
+        storedConfig?.connectionMode || (connection as any).connectionMode,
+        storedConfig?.connectionType || (connection as any).connectionType,
+        !!hasProxyAddress
+      );
       const proxyConfig = hasProxyAddress
         ? storedConfig?.proxyConfig || connection.proxyConfig
         : undefined;
@@ -552,8 +586,17 @@ export function InspectorDashboard() {
           ? { name: getConfiguredServerAlias(storedConfig || connection) }
           : {}),
         transportType: connection.transportType || "http",
-        connectionType,
+        connectionMode,
+        connectionType: connectionMode === "proxy" ? "Via Proxy" : "Direct",
         proxyConfig,
+        autoProxyFallback:
+          connectionMode === "auto"
+            ? (storedConfig?.autoProxyFallback ??
+              connection.autoProxyFallback ??
+              (fallbackProxyAddress
+                ? { enabled: true, proxyAddress: fallbackProxyAddress }
+                : undefined))
+            : undefined,
         customHeaders,
         requestTimeout: connection.requestTimeout || 10000,
         resetTimeoutOnProgress: connection.resetTimeoutOnProgress !== false,
@@ -593,7 +636,17 @@ export function InspectorDashboard() {
           config.name,
           config.proxyConfig,
           config.transportType,
-          config.oauth
+          config.oauth,
+          config.connectionMode,
+          config.connectionMode === "auto"
+            ? (config.autoProxyFallback ??
+                (config.proxyConfig?.proxyAddress
+                  ? {
+                      enabled: true,
+                      proxyAddress: config.proxyConfig.proxyAddress,
+                    }
+                  : false))
+            : false
         );
       } else if (
         currentConnection &&
@@ -606,9 +659,20 @@ export function InspectorDashboard() {
         // Otherwise just update the existing connection
         updateConnectionConfig(editingConnectionId, {
           name: config.name,
+          connectionMode: config.connectionMode,
           proxyConfig: config.proxyConfig,
           transportType: config.transportType,
           oauth: config.oauth,
+          autoProxyFallback:
+            config.connectionMode === "auto"
+              ? (config.autoProxyFallback ??
+                (config.proxyConfig?.proxyAddress
+                  ? {
+                      enabled: true,
+                      proxyAddress: config.proxyConfig.proxyAddress,
+                    }
+                  : false))
+              : false,
         });
       }
 
@@ -1092,7 +1156,7 @@ export function InspectorDashboard() {
                                     transportType:
                                       (connection as any).transportType ||
                                       "http",
-                                    connectionType: "Direct",
+                                    connectionMode: "auto",
                                   })
                                 );
                               } catch {
@@ -1183,8 +1247,8 @@ export function InspectorDashboard() {
             setAlias={setAlias}
             url={url}
             setUrl={setUrl}
-            connectionType={connectionType}
-            setConnectionType={setConnectionType}
+            connectionMode={connectionMode}
+            setConnectionMode={setConnectionMode}
             customHeaders={customHeaders}
             setCustomHeaders={setCustomHeaders}
             requestTimeout={requestTimeout}

--- a/libraries/typescript/packages/inspector/src/client/components/Layout.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/Layout.tsx
@@ -15,8 +15,10 @@ import {
   Telemetry,
 } from "@/client/telemetry";
 import {
+  getDefaultInspectorProxyAddress,
   getStoredConnectionConfig,
   isAliasOnlyConnectionUpdate,
+  normalizeConnectionMode,
   type ConnectionMode,
   type EditableConnectionConfig,
   type OAuthStaticConfig,
@@ -664,20 +666,53 @@ export function Layout({ children }: LayoutProps) {
           customHeaders.Authorization = `${formatted} ${srv.auth.access_token}`;
         }
 
-        const proxyConfig: {
-          proxyAddress: string;
-          headers?: Record<string, string>;
-        } = {
-          proxyAddress: `${window.location.origin}/inspector/api/proxy`,
-          ...(Object.keys(customHeaders).length > 0 && {
-            headers: customHeaders,
-          }),
-        };
+        const explicitProxyAddress =
+          typeof srv.proxyConfig?.proxyAddress === "string"
+            ? srv.proxyConfig.proxyAddress.trim()
+            : "";
+        let defaultProxyAddress = "";
+        try {
+          if (new URL(url).origin !== window.location.origin) {
+            defaultProxyAddress = getDefaultInspectorProxyAddress();
+          }
+        } catch {
+          defaultProxyAddress = getDefaultInspectorProxyAddress();
+        }
+
+        const proxyAddress = explicitProxyAddress || defaultProxyAddress;
+        const connectionMode = normalizeConnectionMode(
+          srv.connectionMode,
+          srv.connectionType,
+          !!explicitProxyAddress
+        );
+        const proxyConfig =
+          connectionMode === "proxy" && proxyAddress
+            ? {
+                proxyAddress,
+                ...(Object.keys(customHeaders).length > 0 && {
+                  headers: customHeaders,
+                }),
+              }
+            : Object.keys(customHeaders).length > 0
+              ? { headers: customHeaders }
+              : undefined;
+        const autoProxyFallback =
+          connectionMode === "auto" && proxyAddress
+            ? { enabled: true, proxyAddress }
+            : false;
 
         // Avoid duplicates
         const existing = connections.find((c) => c.url === url);
         if (!existing) {
-          addConnection(url, name, proxyConfig, transportType);
+          addConnection(
+            url,
+            name,
+            proxyConfig,
+            transportType,
+            undefined,
+            connectionMode,
+            autoProxyFallback
+          );
         }
 
         if (!firstServerId) {

--- a/libraries/typescript/packages/inspector/src/client/components/Layout.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/Layout.tsx
@@ -17,6 +17,7 @@ import {
 import {
   getStoredConnectionConfig,
   isAliasOnlyConnectionUpdate,
+  type ConnectionMode,
   type EditableConnectionConfig,
   type OAuthStaticConfig,
 } from "@/client/utils/connectionUpdates";
@@ -63,15 +64,26 @@ export function Layout({ children }: LayoutProps) {
       name?: string,
       proxyConfig?: any,
       transportType?: "http" | "sse",
-      oauth?: OAuthStaticConfig
+      oauth?: OAuthStaticConfig,
+      connectionMode: ConnectionMode = proxyConfig?.proxyAddress
+        ? "proxy"
+        : "auto",
+      autoProxyFallback:
+        | boolean
+        | {
+            enabled?: boolean;
+            proxyAddress?: string;
+          } = proxyConfig?.proxyAddress ? false : false
     ) => {
       addServer(url, {
         url,
         name,
+        connectionMode,
         proxyConfig,
         transportType,
         preventAutoAuth: true,
         useRedirectFlow: true,
+        autoProxyFallback,
         clientOptions: {
           capabilities: {
             extensions: {
@@ -400,7 +412,17 @@ export function Layout({ children }: LayoutProps) {
           config.name,
           config.proxyConfig,
           config.transportType,
-          config.oauth
+          config.oauth,
+          config.connectionMode,
+          config.connectionMode === "auto"
+            ? (config.autoProxyFallback ??
+                (config.proxyConfig?.proxyAddress
+                  ? {
+                      enabled: true,
+                      proxyAddress: config.proxyConfig.proxyAddress,
+                    }
+                  : false))
+            : false
         );
       } else if (
         currentConnection &&
@@ -413,9 +435,20 @@ export function Layout({ children }: LayoutProps) {
         // Otherwise just update the existing connection
         updateConnectionConfig(editingConnectionId, {
           name: config.name,
+          connectionMode: config.connectionMode,
           proxyConfig: config.proxyConfig,
           transportType: config.transportType,
           oauth: config.oauth,
+          autoProxyFallback:
+            config.connectionMode === "auto"
+              ? (config.autoProxyFallback ??
+                (config.proxyConfig?.proxyAddress
+                  ? {
+                      enabled: true,
+                      proxyAddress: config.proxyConfig.proxyAddress,
+                    }
+                  : false))
+              : false,
         });
       }
 

--- a/libraries/typescript/packages/inspector/src/client/components/LayoutHeader.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/LayoutHeader.tsx
@@ -307,7 +307,7 @@ function TunnelBadge({
                 url: mcpEndpoint,
                 name: "Local MCP Server",
                 transportType: "http",
-                connectionType: "Direct",
+                connectionMode: "auto",
               })
             );
             toast.success(

--- a/libraries/typescript/packages/inspector/src/client/components/ServerConnectionModal.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ServerConnectionModal.tsx
@@ -1,6 +1,9 @@
 import type { McpServer } from "mcp-use/react";
 import {
   buildOAuthStaticConfig,
+  getDefaultInspectorProxyAddress,
+  normalizeConnectionMode,
+  type ConnectionMode,
   type OAuthStaticConfig,
 } from "@/client/utils/connectionUpdates";
 
@@ -15,6 +18,12 @@ type MCPConnectionWithConfig = MCPConnection & {
   headers?: Record<string, string>;
   customHeaders?: Record<string, string>;
   oauth?: OAuthStaticConfig;
+  autoProxyFallback?:
+    | boolean
+    | {
+        enabled?: boolean;
+        proxyAddress?: string;
+      };
 };
 import type { CustomHeader } from "./CustomHeadersEditor";
 import { useEffect, useState } from "react";
@@ -40,6 +49,13 @@ interface ServerConnectionModalProps {
       proxyAddress?: string;
       headers?: Record<string, string>;
     };
+    connectionMode?: ConnectionMode;
+    autoProxyFallback?:
+      | boolean
+      | {
+          enabled?: boolean;
+          proxyAddress?: string;
+        };
     oauth?: OAuthStaticConfig;
   }) => void;
 }
@@ -62,13 +78,13 @@ export function ServerConnectionModal({
   // Form state
   const [alias, setAlias] = useState("");
   const [url, setUrl] = useState("");
-  const [connectionType, setConnectionType] = useState("Direct");
+  const [connectionMode, setConnectionMode] = useState<ConnectionMode>("auto");
   const [customHeaders, setCustomHeaders] = useState<CustomHeader[]>([]);
   const [requestTimeout, setRequestTimeout] = useState("10000");
   const [resetTimeoutOnProgress, setResetTimeoutOnProgress] = useState("True");
   const [maxTotalTimeout, setMaxTotalTimeout] = useState("60000");
   const [proxyAddress, setProxyAddress] = useState(
-    `${window.location.origin}/inspector/api/proxy`
+    getDefaultInspectorProxyAddress()
   );
   // OAuth fields
   const [clientId, setClientId] = useState("");
@@ -103,16 +119,29 @@ export function ServerConnectionModal({
       // Transport type is always HTTP now (SSE is deprecated)
       // No need to set transportType from connection
 
-      // Determine connection type based on proxyConfig
+      // Determine connection mode based on modern config, legacy connectionType, or proxyConfig
+      const fallbackProxyAddress =
+        typeof storedConfig?.autoProxyFallback === "object"
+          ? storedConfig.autoProxyFallback.proxyAddress
+          : typeof connectionWithConfig.autoProxyFallback === "object"
+            ? connectionWithConfig.autoProxyFallback.proxyAddress
+            : undefined;
       const proxyAddress =
         storedConfig?.proxyConfig?.proxyAddress ||
-        connectionWithConfig.proxyConfig?.proxyAddress;
+        connectionWithConfig.proxyConfig?.proxyAddress ||
+        fallbackProxyAddress;
+      const mode = normalizeConnectionMode(
+        storedConfig?.connectionMode ||
+          (connectionWithConfig as any).connectionMode,
+        storedConfig?.connectionType ||
+          (connectionWithConfig as any).connectionType,
+        !!proxyAddress
+      );
+      setConnectionMode(mode);
       if (proxyAddress) {
-        setConnectionType("Via Proxy");
         setProxyAddress(proxyAddress);
       } else {
-        setConnectionType("Direct");
-        setProxyAddress(`${window.location.origin}/inspector/api/proxy`);
+        setProxyAddress(getDefaultInspectorProxyAddress());
       }
 
       // Convert headers from Record<string, string> to CustomHeader[]
@@ -178,32 +207,32 @@ export function ServerConnectionModal({
       }
     }
 
-    // Prepare proxy configuration if "Via Proxy" is selected
+    const headers = customHeaders.reduce(
+      (acc, header) => {
+        if (header.name && header.value) {
+          acc[header.name] = header.value;
+        }
+        return acc;
+      },
+      {} as Record<string, string>
+    );
+
     const proxyConfig =
-      connectionType === "Via Proxy" && proxyAddress.trim()
+      connectionMode === "proxy" && proxyAddress.trim()
         ? {
             proxyAddress: proxyAddress.trim(),
-            headers: customHeaders.reduce(
-              (acc, header) => {
-                if (header.name && header.value) {
-                  acc[header.name] = header.value;
-                }
-                return acc;
-              },
-              {} as Record<string, string>
-            ),
+            headers,
           }
-        : {
-            headers: customHeaders.reduce(
-              (acc, header) => {
-                if (header.name && header.value) {
-                  acc[header.name] = header.value;
-                }
-                return acc;
-              },
-              {} as Record<string, string>
-            ),
-          };
+        : Object.keys(headers).length > 0
+          ? { headers }
+          : undefined;
+
+    const autoProxyFallback =
+      connectionMode === "auto"
+        ? proxyAddress.trim()
+          ? { enabled: true, proxyAddress: proxyAddress.trim() }
+          : false
+        : false;
 
     // Always use HTTP transport (SSE is deprecated)
     const actualTransportType = "http";
@@ -214,7 +243,9 @@ export function ServerConnectionModal({
       url: normalizedUrl,
       name: alias.trim() || normalizedUrl,
       transportType: actualTransportType,
+      connectionMode,
       proxyConfig,
+      autoProxyFallback,
       ...(oauth ? { oauth } : {}),
     });
 
@@ -232,8 +263,8 @@ export function ServerConnectionModal({
           setAlias={setAlias}
           url={url}
           setUrl={setUrl}
-          connectionType={connectionType}
-          setConnectionType={setConnectionType}
+          connectionMode={connectionMode}
+          setConnectionMode={setConnectionMode}
           customHeaders={customHeaders}
           setCustomHeaders={setCustomHeaders}
           requestTimeout={requestTimeout}

--- a/libraries/typescript/packages/inspector/src/client/hooks/useAutoConnect.ts
+++ b/libraries/typescript/packages/inspector/src/client/hooks/useAutoConnect.ts
@@ -2,6 +2,12 @@ import type { McpServer } from "mcp-use/react";
 import { useCallback, useEffect, useState } from "react";
 import { useNavigate } from "react-router";
 import { toast } from "sonner";
+import {
+  getDefaultInspectorProxyAddress,
+  normalizeConnectionMode,
+  type ConnectionMode,
+  type OAuthStaticConfig,
+} from "@/client/utils/connectionUpdates";
 
 /** Survives full page reload; avoids fragile long JSON in query (was resolving to localhost + http). */
 export const INSPECTOR_RECONNECT_STORAGE_KEY = "__mcpUseInspectorReconnect";
@@ -18,7 +24,15 @@ interface UseAutoConnectOptions {
       proxyAddress?: string;
       customHeaders?: Record<string, string>;
     },
-    transportType?: "http" | "sse"
+    transportType?: "http" | "sse",
+    oauth?: OAuthStaticConfig,
+    connectionMode?: ConnectionMode,
+    autoProxyFallback?:
+      | boolean
+      | {
+          enabled?: boolean;
+          proxyAddress?: string;
+        }
   ) => void;
   removeConnection: (id: string) => void;
   configLoaded: boolean;
@@ -34,7 +48,14 @@ interface ConnectionConfig {
   url: string;
   name: string;
   transportType: "http" | "sse";
-  connectionType: "Direct" | "Via Proxy";
+  connectionMode: ConnectionMode;
+  connectionType?: "Direct" | "Via Proxy";
+  autoProxyFallback?:
+    | boolean
+    | {
+        enabled?: boolean;
+        proxyAddress?: string;
+      };
   customHeaders?: Record<string, string>;
   requestTimeout?: number;
   resetTimeoutOnProgress?: boolean;
@@ -111,6 +132,7 @@ function parseAutoConnectParam(param: string): ConnectionConfig | null {
       name: "Auto-connected Server",
       transportType: "http",
       connectionType: "Direct",
+      connectionMode: "auto",
     };
   }
 
@@ -174,8 +196,14 @@ function parseAutoConnectParam(param: string): ConnectionConfig | null {
           url: url,
           name: parsed.name || "Auto-connected Server",
           transportType: parsed.transportType === "sse" ? "sse" : "http",
+          connectionMode: normalizeConnectionMode(
+            parsed.connectionMode,
+            parsed.connectionType,
+            !!parsed.proxyConfig?.proxyAddress
+          ),
           connectionType:
             parsed.connectionType === "Via Proxy" ? "Via Proxy" : "Direct",
+          autoProxyFallback: parsed.autoProxyFallback,
           customHeaders: parsed.customHeaders || {},
           requestTimeout: parsed.requestTimeout,
           resetTimeoutOnProgress: parsed.resetTimeoutOnProgress,
@@ -205,6 +233,7 @@ function parseAutoConnectParam(param: string): ConnectionConfig | null {
           name: "Auto-connected Server",
           transportType: "http",
           connectionType: "Direct",
+          connectionMode: "auto",
         };
       }
       console.warn(
@@ -255,7 +284,7 @@ export function useAutoConnect({
   // Unified connection attempt function
   const attemptConnection = useCallback(
     (config: ConnectionConfig) => {
-      const { url, name, transportType, connectionType, customHeaders, auth } =
+      const { url, name, transportType, connectionMode, customHeaders, auth } =
         config;
 
       console.log("[useAutoConnect] Config received:", config);
@@ -317,28 +346,52 @@ export function useAutoConnect({
         const targetOrigin = new URL(url).origin;
         const inspectorOrigin = window.location.origin;
         if (inspectorOrigin !== targetOrigin) {
-          proxyAddress = `${inspectorOrigin}/inspector/api/proxy`;
+          proxyAddress = getDefaultInspectorProxyAddress();
         }
       } catch {
-        proxyAddress = `${window.location.origin}/inspector/api/proxy`;
+        proxyAddress = getDefaultInspectorProxyAddress();
       }
 
-      const proxyConfig: {
-        proxyAddress?: string;
-        headers?: Record<string, string>;
-      } = {
-        ...(proxyAddress ? { proxyAddress } : {}),
-        ...(Object.keys(finalCustomHeaders).length > 0 && {
-          headers: finalCustomHeaders,
-        }),
-      };
+      const proxyConfig:
+        | {
+            proxyAddress?: string;
+            headers?: Record<string, string>;
+          }
+        | undefined =
+        connectionMode === "proxy" && proxyAddress
+          ? {
+              proxyAddress,
+              ...(Object.keys(finalCustomHeaders).length > 0 && {
+                headers: finalCustomHeaders,
+              }),
+            }
+          : Object.keys(finalCustomHeaders).length > 0
+            ? { headers: finalCustomHeaders }
+            : undefined;
+
+      const autoProxyFallback =
+        connectionMode === "auto"
+          ? config.autoProxyFallback !== undefined
+            ? config.autoProxyFallback
+            : proxyAddress
+              ? { enabled: true, proxyAddress }
+              : false
+          : false;
 
       console.warn(
-        `[useAutoConnect] Attempting connection (${connectionType}):`,
-        { url, transportType, proxyConfig }
+        `[useAutoConnect] Attempting connection (${connectionMode}):`,
+        { url, transportType, proxyConfig, autoProxyFallback }
       );
 
-      addConnection(url, name, proxyConfig, transportType);
+      addConnection(
+        url,
+        name,
+        proxyConfig,
+        transportType,
+        undefined,
+        connectionMode,
+        autoProxyFallback
+      );
     },
     [addConnection]
   );

--- a/libraries/typescript/packages/inspector/src/client/utils/connectionUpdates.ts
+++ b/libraries/typescript/packages/inspector/src/client/utils/connectionUpdates.ts
@@ -4,10 +4,63 @@ export interface OAuthStaticConfig {
   scope?: string;
 }
 
+export type ConnectionMode = "auto" | "direct" | "proxy";
+
+type InspectorWindow = Window & { __MCP_PROXY_URL__?: string | null };
+
+export function getDefaultInspectorProxyAddress(): string {
+  if (typeof window === "undefined") {
+    return "";
+  }
+
+  const injectedProxyPath = (window as InspectorWindow).__MCP_PROXY_URL__;
+  if (injectedProxyPath === null) {
+    return "";
+  }
+
+  return `${window.location.origin}${injectedProxyPath || "/inspector/api/proxy"}`;
+}
+
+export function normalizeConnectionMode(
+  mode?: string,
+  legacyConnectionType?: string,
+  hasProxyAddress = false
+): ConnectionMode {
+  if (mode === "auto" || mode === "direct" || mode === "proxy") {
+    return mode;
+  }
+  if (legacyConnectionType === "Via Proxy") {
+    return "proxy";
+  }
+  if (legacyConnectionType === "Direct") {
+    return "auto";
+  }
+  return hasProxyAddress ? "proxy" : "auto";
+}
+
+export type AutoProxyFallbackConfig =
+  | boolean
+  | {
+      enabled?: boolean;
+      proxyAddress?: string;
+    };
+
+function getAutoProxyFallbackAddress(
+  autoProxyFallback?: AutoProxyFallbackConfig
+): string {
+  if (!autoProxyFallback || typeof autoProxyFallback === "boolean") {
+    return "";
+  }
+
+  return autoProxyFallback.proxyAddress?.trim() || "";
+}
+
 interface ConnectionLike {
   url?: string;
   name?: string;
   transportType?: "http" | "sse";
+  connectionMode?: ConnectionMode;
+  connectionType?: "Direct" | "Via Proxy";
   proxyConfig?: {
     proxyAddress?: string;
     headers?: Record<string, string>;
@@ -16,12 +69,15 @@ interface ConnectionLike {
   headers?: Record<string, string>;
   customHeaders?: Record<string, string>;
   oauth?: OAuthStaticConfig;
+  autoProxyFallback?: AutoProxyFallbackConfig;
 }
 
 export interface EditableConnectionConfig {
   url: string;
   name?: string;
   transportType: "http" | "sse";
+  connectionMode?: ConnectionMode;
+  connectionType?: "Direct" | "Via Proxy";
   proxyConfig?: {
     proxyAddress?: string;
     headers?: Record<string, string>;
@@ -30,6 +86,7 @@ export interface EditableConnectionConfig {
   headers?: Record<string, string>;
   customHeaders?: Record<string, string>;
   oauth?: OAuthStaticConfig;
+  autoProxyFallback?: AutoProxyFallbackConfig;
 }
 
 /**
@@ -95,18 +152,27 @@ function normalizeConnection(
   name: string;
   transportType: "http" | "sse";
   proxyAddress: string;
+  connectionMode: ConnectionMode;
   headers: Record<string, string>;
   oauthClientId: string;
   oauthClientSecret: string;
   oauthScope: string;
 } {
   const normalizedUrl = connection.url?.trim() || "";
+  const proxyAddress =
+    connection.proxyConfig?.proxyAddress?.trim() ||
+    getAutoProxyFallbackAddress(connection.autoProxyFallback);
 
   return {
     url: normalizedUrl,
     name: connection.name?.trim() || normalizedUrl,
     transportType: connection.transportType || "http",
-    proxyAddress: connection.proxyConfig?.proxyAddress?.trim() || "",
+    proxyAddress,
+    connectionMode: normalizeConnectionMode(
+      connection.connectionMode,
+      connection.connectionType,
+      !!proxyAddress
+    ),
     headers: getComparableHeaders(connection),
     oauthClientId: connection.oauth?.clientId?.trim() || "",
     oauthClientSecret: connection.oauth?.clientSecret?.trim() || "",
@@ -125,6 +191,7 @@ export function isAliasOnlyConnectionUpdate(
     currentConnection.url === nextConnection.url &&
     currentConnection.transportType === nextConnection.transportType &&
     currentConnection.proxyAddress === nextConnection.proxyAddress &&
+    currentConnection.connectionMode === nextConnection.connectionMode &&
     JSON.stringify(currentConnection.headers) ===
       JSON.stringify(nextConnection.headers) &&
     currentConnection.oauthClientId === nextConnection.oauthClientId &&

--- a/libraries/typescript/packages/inspector/src/server/shared-static.ts
+++ b/libraries/typescript/packages/inspector/src/server/shared-static.ts
@@ -41,7 +41,7 @@ interface RuntimeConfig {
   devMode?: boolean;
   /** Override sandbox origin for MCP Apps widgets behind reverse proxies */
   sandboxOrigin?: string | null;
-  /** Relative path to the MCP proxy (e.g. "/inspector/api/proxy"). When set, the client uses it for autoProxyFallback. Omit when the proxy is not available (e.g. Python server serving inspector). */
+  /** Relative path to the MCP proxy (e.g. "/inspector/api/proxy"). Set null when the proxy is not available (e.g. Python server serving inspector). */
   proxyUrl?: string | null;
   /** How the inspector is being served (standalone CLI, embedded in mcp-use, or cloud-hosted). Consumed by telemetry. */
   inspectorMode?: InspectorMode;

--- a/libraries/typescript/packages/inspector/tests/e2e/oauth-emulate.test.ts
+++ b/libraries/typescript/packages/inspector/tests/e2e/oauth-emulate.test.ts
@@ -1,8 +1,8 @@
 /**
- * The authorize redirect is top-level navigation in both Direct and Via Proxy
- * modes (useRedirectFlow: true), so the user-picker page is driven identically;
- * the difference is whether OAuth metadata + token-exchange fetches go through
- * the inspector backend.
+ * The authorize redirect is top-level navigation in both Auto and forced Proxy
+ * modes (useRedirectFlow: true), so the user-picker page is driven identically.
+ * Auto starts direct and can fall back; forced Proxy routes through the inspector
+ * backend from the start.
  */
 
 import { expect, test } from "@playwright/test";
@@ -12,7 +12,7 @@ import {
   type GoogleEmulateHandle,
 } from "./fixtures/google-emulate-server.js";
 
-type ConnectionType = "Direct" | "Via Proxy";
+type ConnectionMode = "auto" | "proxy";
 
 // Both variants share one fixture on fixed ports (the MCP server's registered
 // redirect URI pins us to a known port), so they must run in the same worker.
@@ -34,14 +34,19 @@ test.beforeEach(async ({ page, context }) => {
   await page.evaluate(() => localStorage.clear());
 });
 
-function describeOAuthFlow(connectionType: ConnectionType): void {
-  test.describe(`OAuth flow via emulate Google (${connectionType})`, () => {
+function describeOAuthFlow(connectionMode: ConnectionMode): void {
+  test.describe(`OAuth flow via emulate Google (${connectionMode})`, () => {
     test("completes OAuth and reaches ready state", async ({ page }) => {
       await page.getByTestId("connection-form-url-input").fill(fixture.mcpUrl);
 
-      if (connectionType !== "Direct") {
-        await page.getByTestId("connection-form-type-select").click();
-        await page.getByRole("option", { name: connectionType }).click();
+      if (connectionMode !== "auto") {
+        await page.getByTestId("connection-form-config-button").click();
+        await page.getByTestId("config-dialog-connection-mode-select").click();
+        await page.getByRole("option", { name: "Proxy" }).click();
+        await page
+          .getByRole("dialog")
+          .getByRole("button", { name: "Save" })
+          .click();
       }
 
       await page.getByTestId("connection-form-connect-button").click();
@@ -69,5 +74,5 @@ function describeOAuthFlow(connectionType: ConnectionType): void {
   });
 }
 
-describeOAuthFlow("Direct");
-describeOAuthFlow("Via Proxy");
+describeOAuthFlow("auto");
+describeOAuthFlow("proxy");

--- a/libraries/typescript/packages/mcp-use/src/react/types.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/types.ts
@@ -45,6 +45,12 @@ export type UseMcpOptions = {
     customHeaders?: Record<string, string>;
   };
   /**
+   * Connection policy used by higher-level clients such as the Inspector.
+   * Behavior is controlled by `proxyConfig` and `autoProxyFallback`; this field
+   * is persisted so editors can distinguish Auto, forced Direct, and forced Proxy.
+   */
+  connectionMode?: "auto" | "direct" | "proxy";
+  /**
    * Enable automatic proxy fallback when direct connection fails
    * When enabled, if a direct connection fails with FastMCP or CORS errors,
    * automatically retries using the proxy configuration

--- a/libraries/typescript/packages/mcp-use/src/react/useMcp.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/useMcp.ts
@@ -22,7 +22,7 @@ import { Logger, type LogLevel, logger } from "../logging.js";
 import { Tel } from "../telemetry/telemetry-browser.js";
 import { assert } from "../utils/assert.js";
 import { detectFavicon } from "../utils/favicon-detector.js";
-import { applyProxyConfig } from "../utils/proxy-config.js";
+import { applyProxyConfig, type ProxyConfig } from "../utils/proxy-config.js";
 import { sanitizeUrl } from "../utils/url-sanitize.js";
 import { getPackageVersion } from "../version.js";
 import {
@@ -283,25 +283,44 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
     };
   }, [autoReconnect]);
 
-  // Track whether we've already tried proxy fallback
-  const hasTriedProxyFallbackRef = useRef(false);
-  const [effectiveProxyConfig, setEffectiveProxyConfig] = useState(proxyConfig);
+  // Runtime proxy config is set only after automatic direct -> proxy fallback.
+  const [effectiveProxyConfig, setEffectiveProxyConfig] = useState<
+    ProxyConfig | undefined
+  >(undefined);
 
-  // Sync effectiveProxyConfig with proxyConfig prop changes
+  // Reset runtime fallback when the requested connection changes.
   useEffect(() => {
-    setEffectiveProxyConfig(proxyConfig);
-  }, [proxyConfig]);
+    setEffectiveProxyConfig(undefined);
+  }, [url, proxyConfig]);
+
+  const activeProxyConfig = useMemo(() => {
+    if (!effectiveProxyConfig?.proxyAddress) {
+      return proxyConfig;
+    }
+
+    const latestHeaders =
+      proxyConfig?.headers ?? proxyConfig?.customHeaders ?? {};
+    return {
+      ...effectiveProxyConfig,
+      headers: {
+        ...latestHeaders,
+        ...(effectiveProxyConfig.headers ??
+          effectiveProxyConfig.customHeaders ??
+          {}),
+      },
+    };
+  }, [effectiveProxyConfig, proxyConfig]);
 
   // Extract gateway URL and headers from proxy configuration
-  // Use proxyConfig directly (not effectiveProxyConfig) to ensure we always
-  // have the latest headers, even before the sync useEffect runs
+  // Use the runtime proxy after automatic fallback, while still merging in
+  // the latest requested headers from proxyConfig.
   const { gatewayUrl, proxyHeaders } = useMemo(() => {
-    const result = applyProxyConfig(url || "", proxyConfig);
+    const result = applyProxyConfig(url || "", activeProxyConfig);
     return {
-      gatewayUrl: proxyConfig?.proxyAddress,
+      gatewayUrl: activeProxyConfig?.proxyAddress,
       proxyHeaders: result.headers,
     };
-  }, [url, proxyConfig]);
+  }, [url, activeProxyConfig]);
 
   // OAuth provider should ALWAYS use the original target URL for OAuth discovery,
   // not the proxy URL. The proxy is only used for making the actual HTTP requests.
@@ -498,7 +517,7 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
       // Don't use a ref to track this - it causes issues with React strict mode
       // where multiple instances share the same ref but have different state
       const shouldTryProxyFallback =
-        autoProxyFallbackConfig.enabled && !effectiveProxyConfig?.proxyAddress; // Only fallback if not already using proxy
+        autoProxyFallbackConfig.enabled && !activeProxyConfig?.proxyAddress; // Only fallback if not already using proxy
 
       // Detect CORS errors (these can't have status codes, so check message)
       const isCorsError =
@@ -604,7 +623,7 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
       onSampling,
       onElicitation,
       autoProxyFallbackConfig,
-      effectiveProxyConfig,
+      activeProxyConfig,
       providedAuthProvider,
     ]
   );
@@ -2238,15 +2257,6 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
       if (authTimeoutRef.current) clearTimeout(authTimeoutRef.current);
     };
   }, [addLog]);
-
-  /**
-   * Effect: Reset proxy fallback tracking when URL changes
-   * This allows the fallback to try again for a different server
-   */
-  useEffect(() => {
-    hasTriedProxyFallbackRef.current = false;
-    setEffectiveProxyConfig(proxyConfig);
-  }, [url, proxyConfig]);
 
   /**
    * Effect: Main connection lifecycle


### PR DESCRIPTION
The inspector used to require users to select either direct or via proxy, but this ended up being confusing for a lot of users. Now we try direct mode first, and if direct mode fails, we automatically fall back to the proxy as the new auto mode. If the user still wants to select by hand, they can go into the configuration and set it, and they can also set it to a different proxy if they want 