### PR TITLE
fix(react): point useMcp auto proxy fallback at live inspector host

### DIFF
--- a/libraries/typescript/.changeset/fix-auto-proxy-fallback-host.md
+++ b/libraries/typescript/.changeset/fix-auto-proxy-fallback-host.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Fix `useMcp` auto proxy fallback pointing at a retired host. The default `autoProxyFallback` proxy address was `https://inspector.mcp-use.com/inspector/api/proxy`, which now 301-redirects to `inspector.manufact.com`. Browsers treat a redirect on a CORS preflight as a hard failure, so the automatic direct→proxy fallback could never connect (it would retry through a dead URL and fail). The default now points at the live `https://inspector.manufact.com/inspector/api/proxy`.

--- a/libraries/typescript/packages/mcp-use/src/react/types.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/types.ts
@@ -56,7 +56,7 @@ export type UseMcpOptions = {
    * automatically retries using the proxy configuration
    *
    * Can be:
-   * - `true`: Enable with default proxy (https://inspector.mcp-use.com/inspector/api/proxy)
+   * - `true`: Enable with default proxy (https://inspector.manufact.com/inspector/api/proxy)
    * - `false`: Disable automatic fallback (default)
    * - `{ enabled: boolean, proxyAddress?: string }`: Custom configuration
    *

--- a/libraries/typescript/packages/mcp-use/src/react/useMcp.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/useMcp.ts
@@ -37,6 +37,11 @@ import type { UseMcpOptions, UseMcpResult } from "./types.js";
 
 const DEFAULT_RECONNECT_DELAY = 3000;
 const DEFAULT_RETRY_DELAY = 5000;
+// Live hosted inspector proxy. The former inspector.mcp-use.com host now
+// 301-redirects here, which breaks browser CORS preflights (redirects on a
+// preflight are a hard failure), so the default must point at the live host.
+const DEFAULT_PROXY_FALLBACK_ADDRESS =
+  "https://inspector.manufact.com/inspector/api/proxy";
 
 // Define Transport types literal for clarity
 type TransportType = "http" | "sse";
@@ -238,14 +243,13 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
     if (typeof autoProxyFallback === "boolean") {
       return {
         enabled: autoProxyFallback,
-        proxyAddress: "https://inspector.mcp-use.com/inspector/api/proxy",
+        proxyAddress: DEFAULT_PROXY_FALLBACK_ADDRESS,
       };
     }
     return {
       enabled: autoProxyFallback.enabled !== false,
       proxyAddress:
-        autoProxyFallback.proxyAddress ||
-        "https://inspector.mcp-use.com/inspector/api/proxy",
+        autoProxyFallback.proxyAddress || DEFAULT_PROXY_FALLBACK_ADDRESS,
     };
   }, [autoProxyFallback]);
 


### PR DESCRIPTION
## Changes
Fix the `useMcp` automatic direct→proxy fallback, which could never connect because its default proxy address pointed at a retired host.

## Implementation Details
1. The default `autoProxyFallback` proxy address was `https://inspector.mcp-use.com/inspector/api/proxy`, which now **301-redirects** to `inspector.manufact.com`.
2. Browsers treat a redirect on a CORS **preflight** as a hard failure, so the fallback retry would hit the dead URL and fail (`Failed to fetch`), then the "already tried proxy" guard would give up.
3. Extracted a `DEFAULT_PROXY_FALLBACK_ADDRESS` constant pointing at the live `https://inspector.manufact.com/inspector/api/proxy` and used it for both the boolean and object forms of `autoProxyFallback`.
4. Updated the JSDoc in `types.ts` documenting the default.

## How it was found
Runtime debugging against `https://mcp.openfunnel.dev/mcp` (an OAuth-protected server with no CORS on `/mcp`):
- direct connect → CORS `Failed to fetch` → fallback fired
- retry went through `inspector.mcp-use.com` → `301` → preflight failure
- live `inspector.manufact.com` proxy verified: `OPTIONS` → `204` with `access-control-allow-origin: *`, `POST` → `200` forwarding the MCP `initialize` handshake.

## Backwards Compatibility
Non-breaking — only changes a default URL value. Consumers passing an explicit `autoProxyFallback.proxyAddress` are unaffected.

## Notes
Base is `canary` (to be rebased on `main`); branch was cut from the latest `origin/main`.