### PR TITLE
fix(python): allow initialized empty tools list in WebSocketConnector

### DIFF
--- a/libraries/python/mcp_use/client/connectors/websocket.py
+++ b/libraries/python/mcp_use/client/connectors/websocket.py
@@ -225,7 +225,7 @@ class WebSocketConnector(BaseConnector):
     @property
     def tools(self) -> list[Tool]:
         """Get the list of available tools."""
-        if not self._tools:
+        if self._tools is None:
             raise RuntimeError("MCP client is not initialized")
         return self._tools
 

--- a/libraries/python/tests/unit/test_websocket_connector.py
+++ b/libraries/python/tests/unit/test_websocket_connector.py
@@ -1,0 +1,37 @@
+"""Unit tests for the WebSocketConnector class."""
+
+from typing import Any
+
+import pytest
+
+from mcp_use.client.connectors.websocket import WebSocketConnector
+
+
+class TestWebSocketConnectorToolsProperty:
+    """Tests for WebSocketConnector.tools property initialization semantics."""
+
+    def test_tools_property_not_initialized(self):
+        """Uninitialized connectors should still raise RuntimeError."""
+        connector = WebSocketConnector("ws://localhost:8080")
+        connector._tools = None
+
+        with pytest.raises(RuntimeError, match="MCP client is not initialized"):
+            _ = connector.tools
+
+    @pytest.mark.asyncio
+    async def test_tools_property_allows_initialized_empty_tool_list(self):
+        """An initialized empty tools list is valid and must not raise."""
+        connector = WebSocketConnector("ws://localhost:8080")
+
+        async def fake_send_request(method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+            if method == "initialize":
+                return {}
+            if method == "tools/list":
+                return {"tools": []}
+            raise AssertionError(f"unexpected method: {method}")
+
+        connector._send_request = fake_send_request
+
+        await connector.initialize()
+
+        assert connector.tools == []


### PR DESCRIPTION
## Summary

Fix `WebSocketConnector.tools` so an initialized MCP session that exposes zero tools returns `[]` instead of raising `RuntimeError`.

## Motivation

Fixes #1747.

After successful initialization, a WebSocket MCP server may legitimately return `{"tools": []}`. The connector cached that as an empty list, but the `tools` property used `if not self._tools`, which treats `[]` the same as the uninitialized `None` state.

`HttpConnector` and `StdioConnector` inherit the correct `self._tools is None` check from `BaseConnector`; only `WebSocketConnector` overrides the property with the falsy check.

## Changes

- Change the uninitialized guard in `WebSocketConnector.tools` from `if not self._tools` to `if self._tools is None`, matching `BaseConnector`.
- Add unit tests covering uninitialized and initialized-empty-tool-list behavior.

## Tests

```bash
cd libraries/python
pytest tests/unit/test_websocket_connector.py -vv
ruff check mcp_use/client/connectors/websocket.py tests/unit/test_websocket_connector.py
ruff format --check mcp_use/client/connectors/websocket.py tests/unit/test_websocket_connector.py
```

- `pytest tests/unit/test_websocket_connector.py -vv` — 2 passed
- `ruff check` — passed
- `ruff format --check` — passed

## Notes

Minimal one-line behavioral fix plus focused regression tests. No API or dependency changes.