### PR TITLE
test: move connector telemetry mocks to module scope

### DIFF
--- a/libraries/typescript/packages/mcp-use/tests/unit/telemetry/connector-telemetry.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/telemetry/connector-telemetry.test.ts
@@ -11,6 +11,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Create mock tracking function
 const mockTrackConnectorInit = vi.fn().mockResolvedValue(undefined);
+const mockCapture = vi.fn();
+const mockFlush = vi.fn();
+const mockShutdown = vi.fn();
 
 // Mock the telemetry module
 vi.mock("../../../src/telemetry/telemetry-node.js", () => ({
@@ -20,6 +23,27 @@ vi.mock("../../../src/telemetry/telemetry-node.js", () => ({
       isEnabled: true,
     })),
   },
+}));
+
+vi.mock("posthog-node", () => {
+  return {
+    PostHog: class MockPostHog {
+      capture = mockCapture;
+      flush = mockFlush;
+      shutdown = mockShutdown;
+    },
+  };
+});
+
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn().mockReturnValue(false),
+  mkdirSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  readFileSync: vi.fn().mockReturnValue("test-user-id"),
+}));
+
+vi.mock("node:os", () => ({
+  homedir: vi.fn().mockReturnValue("/mock/home"),
 }));
 
 describe("Connector Telemetry Integration", () => {
@@ -229,32 +253,6 @@ describe("Connector Telemetry Integration", () => {
   });
 
   describe("Integration tests - actual connector connection", () => {
-    // Mock PostHog for integration tests
-    const mockCapture = vi.fn();
-    const mockFlush = vi.fn();
-    const mockShutdown = vi.fn();
-
-    beforeEach(() => {
-      vi.mock("posthog-node", () => {
-        return {
-          PostHog: class MockPostHog {
-            capture = mockCapture;
-            flush = mockFlush;
-            shutdown = mockShutdown;
-          },
-        };
-      });
-      vi.mock("node:fs", () => ({
-        existsSync: vi.fn().mockReturnValue(false),
-        mkdirSync: vi.fn(),
-        writeFileSync: vi.fn(),
-        readFileSync: vi.fn().mockReturnValue("test-user-id"),
-      }));
-      vi.mock("node:os", () => ({
-        homedir: vi.fn().mockReturnValue("/mock/home"),
-      }));
-    });
-
     it("should track HttpConnector init when connect() is called", async () => {
       // Note: This test would require mocking the HTTP transport
       // For now, we verify the BaseConnector method works correctly


### PR DESCRIPTION
## Summary
- move connector telemetry PostHog/fs/os mocks from nested beforeEach to module scope
- keep the existing mock behavior while matching Vitest's hoisted mock execution order

Fixes #1777.

## Tests
- PATH=/Users/vsc_agent/.nvm/versions/node/v22.21.0/bin:/Users/vsc_agent/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Users/vsc_agent/.openclaw/npm/projects/openclaw-codex-8902d781d4/node_modules/@openclaw/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/codex-path:/Users/vsc_agent/.openclaw/agents/main/agent/codex-home/tmp/arg0/codex-arg0QBIt9S:/opt/homebrew/Cellar/node/25.5.0/bin:/opt/homebrew/opt/node/bin:/Users/vsc_agent/Library/pnpm:/Users/vsc_agent/.local/bin corepack pnpm --dir libraries/typescript/packages/mcp-use test:run tests/unit/telemetry/connector-telemetry.test.ts
- PATH=/Users/vsc_agent/.nvm/versions/node/v22.21.0/bin:/Users/vsc_agent/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Users/vsc_agent/.openclaw/npm/projects/openclaw-codex-8902d781d4/node_modules/@openclaw/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/codex-path:/Users/vsc_agent/.openclaw/agents/main/agent/codex-home/tmp/arg0/codex-arg0QBIt9S:/opt/homebrew/Cellar/node/25.5.0/bin:/opt/homebrew/opt/node/bin:/Users/vsc_agent/Library/pnpm:/Users/vsc_agent/.local/bin corepack pnpm --dir libraries/typescript/packages/mcp-use run generate:version
- PATH=/Users/vsc_agent/.nvm/versions/node/v22.21.0/bin:/Users/vsc_agent/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Users/vsc_agent/.openclaw/npm/projects/openclaw-codex-8902d781d4/node_modules/@openclaw/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/codex-path:/Users/vsc_agent/.openclaw/agents/main/agent/codex-home/tmp/arg0/codex-arg0QBIt9S:/opt/homebrew/Cellar/node/25.5.0/bin:/opt/homebrew/opt/node/bin:/Users/vsc_agent/Library/pnpm:/Users/vsc_agent/.local/bin corepack pnpm --dir libraries/typescript/packages/mcp-use test:run tests/unit/telemetry