### PR TITLE
fix(cli): coerce tool args from union schemas

### DIFF
--- a/libraries/typescript/.changeset/cli-union-schema-args.md
+++ b/libraries/typescript/.changeset/cli-union-schema-args.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/cli": patch
+---
+
+Fix CLI tool-call argument coercion for nullable `anyOf` and `oneOf` tool schemas.

--- a/libraries/typescript/packages/cli/src/utils/parse-args.ts
+++ b/libraries/typescript/packages/cli/src/utils/parse-args.ts
@@ -17,6 +17,8 @@ type JsonSchemaLike = {
   type?: string | string[];
   properties?: Record<string, JsonSchemaLike>;
   required?: string[];
+  anyOf?: JsonSchemaLike[];
+  oneOf?: JsonSchemaLike[];
 };
 
 export function parseToolArgs(
@@ -98,11 +100,7 @@ function coerceArgValue(
     }
   }
 
-  const types = Array.isArray(propSchema?.type)
-    ? propSchema!.type
-    : propSchema?.type
-      ? [propSchema.type as string]
-      : [];
+  const types = collectSchemaTypes(propSchema);
 
   if (types.includes("null") && (value === "null" || value === "")) {
     return null;
@@ -144,6 +142,45 @@ function coerceArgValue(
   }
 
   return value;
+}
+
+function collectSchemaTypes(schema: JsonSchemaLike | undefined): string[] {
+  if (!schema) return [];
+
+  const directTypes = normalizeSchemaTypes(schema.type);
+  if (directTypes.length > 0) return directTypes;
+
+  return (
+    nullableUnionTypes(schema.anyOf) ?? nullableUnionTypes(schema.oneOf) ?? []
+  );
+}
+
+function normalizeSchemaTypes(type: string | string[] | undefined): string[] {
+  if (Array.isArray(type)) return [...new Set(type)];
+  return type ? [type] : [];
+}
+
+function nullableUnionTypes(
+  variants: JsonSchemaLike[] | undefined
+): string[] | undefined {
+  if (!variants) return undefined;
+
+  const variantTypes = variants.map((variant) =>
+    normalizeSchemaTypes(variant.type)
+  );
+  const types = [...new Set(variantTypes.flat())];
+  if (!types.includes("null")) return undefined;
+
+  if (variantTypes.some((type) => type.length === 0)) {
+    return ["null"];
+  }
+
+  const nonNullTypes = types.filter((type) => type !== "null");
+  if (nonNullTypes.length === 1) {
+    return [nonNullTypes[0], "null"];
+  }
+
+  return ["null"];
 }
 
 /**

--- a/libraries/typescript/packages/cli/tests/parse-args.test.ts
+++ b/libraries/typescript/packages/cli/tests/parse-args.test.ts
@@ -118,6 +118,57 @@ describe("parseToolArgs", () => {
     });
   });
 
+  it("coerces values from nullable anyOf/oneOf schemas", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        count: {
+          anyOf: [{ type: "integer" }, { type: "null" }],
+        },
+        enabled: {
+          oneOf: [{ type: "boolean" }, { type: "null" }],
+        },
+      },
+    };
+
+    expect(parseToolArgs(["count=42", "enabled=false"], schema)).toEqual({
+      count: 42,
+      enabled: false,
+    });
+    expect(parseToolArgs(["count=null", "enabled=null"], schema)).toEqual({
+      count: null,
+      enabled: null,
+    });
+  });
+
+  it("preserves string fallback for mixed anyOf schemas", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        value: {
+          anyOf: [{ type: "integer" }, { type: "string" }, { type: "null" }],
+        },
+      },
+    };
+
+    expect(parseToolArgs(["value=abc"], schema)).toEqual({ value: "abc" });
+    expect(parseToolArgs(["value=null"], schema)).toEqual({ value: null });
+  });
+
+  it("preserves string fallback when nullable unions include opaque variants", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        mode: {
+          anyOf: [{ type: "integer" }, { const: "auto" }, { type: "null" }],
+        },
+      },
+    };
+
+    expect(parseToolArgs(["mode=auto"], schema)).toEqual({ mode: "auto" });
+    expect(parseToolArgs(["mode=null"], schema)).toEqual({ mode: null });
+  });
+
   it("keeps unknown-key values as strings (schema only constrains known keys)", () => {
     const schema = {
       type: "object",


### PR DESCRIPTION
## Problem

`mcp-use client tools call` accepts positional `key=value` arguments and uses the tool input schema to coerce strings into typed JSON values. That coercion only looked at a property's direct `type` field, so nullable schemas expressed with `anyOf` or `oneOf` were treated as untyped.

For example, a schema branch like `anyOf: [{ type: "integer" }, { type: "null" }]` left `count=42` as the string `"42"` instead of the number `42`.

## Root cause

`parseToolArgs()` built its coercion list from `propSchema.type` only. JSON Schema combinators were ignored, even though MCP tool schemas commonly use them for nullable values.

## Solution

- Collect nullable single-type schemas from direct `type` fields and `anyOf`/`oneOf` branches.
- Reuse the existing CLI coercion rules for integers, numbers, booleans, arrays, objects, and nulls.
- Add regression coverage for nullable `anyOf`/`oneOf` tool schemas, mixed unions with a string fallback, and opaque union branches that should not be coerced.
- Add the required TypeScript changeset.

## Tests

- `pnpm --dir packages/cli exec vitest run tests/parse-args.test.ts`
- `pnpm prettier --check packages/cli/src/utils/parse-args.ts packages/cli/tests/parse-args.test.ts .changeset/cli-union-schema-args.md`
- `npx -y -p node -p pnpm.30.0 pnpm --filter mcp-use build`
- `pnpm --filter @mcp-use/cli build`
- `pnpm --filter @mcp-use/cli test`

## Risk

Low. This only changes known-key CLI argument coercion when the existing schema declares a simple nullable primitive through JSON Schema combinators. Unknown keys, raw JSON object args, and explicit `key:=jsonvalue` behavior are unchanged.

