### PR TITLE
fix(python): avoid mutating adapter input schemas

### DIFF
--- a/libraries/python/mcp_use/agents/adapters/base.py
+++ b/libraries/python/mcp_use/agents/adapters/base.py
@@ -5,6 +5,7 @@ This module provides the abstract base class that all MCP tool adapters should i
 """
 
 from abc import ABC, abstractmethod
+from copy import deepcopy
 from typing import Any, Generic, TypeVar
 
 from mcp.types import Prompt, Resource, Tool
@@ -79,6 +80,10 @@ class BaseAdapter(Generic[T], ABC):
         Returns:
             The fixed JSON schema.
         """
+        return self._fix_schema(deepcopy(schema))
+
+    def _fix_schema(self, schema: Any) -> Any:
+        """Normalize a copied schema recursively."""
         if isinstance(schema, dict):
             if "type" in schema and isinstance(schema["type"], list):
                 schema["anyOf"] = [{"type": t} for t in schema["type"]]
@@ -89,9 +94,9 @@ class BaseAdapter(Generic[T], ABC):
                 schema["type"] = "string"
 
             for key, value in schema.items():
-                schema[key] = self.fix_schema(value)  # Apply recursively
+                schema[key] = self._fix_schema(value)  # Apply recursively
         elif isinstance(schema, list):
-            return [self.fix_schema(item) for item in schema]
+            return [self._fix_schema(item) for item in schema]
         return schema
 
     async def _get_connectors(self, client: MCPClient) -> list[BaseConnector]:

--- a/libraries/python/tests/unit/test_enum_handling.py
+++ b/libraries/python/tests/unit/test_enum_handling.py
@@ -3,6 +3,7 @@ Unit tests for enum handling in LangChain adapter.
 """
 
 import unittest
+from copy import deepcopy
 from enum import Enum
 from unittest.mock import Mock
 
@@ -103,6 +104,30 @@ class TestEnumHandling(unittest.TestCase):
         nested_props = fixed_schema["properties"]["nested"]["properties"]
         self.assertIn("type", nested_props["code_type"])
         self.assertEqual(nested_props["code_type"]["type"], "string")
+
+    def test_fix_schema_does_not_mutate_original_schema(self):
+        """Test that schema fixing leaves the caller's schema unchanged."""
+        original_schema = {
+            "type": "object",
+            "properties": {
+                "nickname": {"type": ["string", "null"]},
+                "nested": {
+                    "type": "object",
+                    "properties": {"code_type": {"enum": ["a", "b", "c"]}},
+                },
+            },
+        }
+        expected_schema = deepcopy(original_schema)
+
+        fixed_schema = self.adapter.fix_schema(original_schema)
+
+        self.assertEqual(original_schema, expected_schema)
+        self.assertIsNot(fixed_schema, original_schema)
+        self.assertEqual(
+            fixed_schema["properties"]["nickname"]["anyOf"],
+            [{"type": "string"}, {"type": "null"}],
+        )
+        self.assertEqual(fixed_schema["properties"]["nested"]["properties"]["code_type"]["type"], "string")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`BaseAdapter.fix_schema()` normalizes JSON Schema dictionaries in place. Adapter conversion paths pass MCP tool schemas into this helper, so converting a tool can rewrite the original `inputSchema` object that other code may still hold or reuse.

## Root cause

The recursive normalizer mutates each dictionary it visits and is called directly on caller-owned schema objects.

## Solution

- Deep-copy the schema once at the public `fix_schema()` boundary.
- Keep the existing recursive normalization behavior on the copied schema.
- Add a regression test proving that nullable-type and enum normalization still happen while the original schema remains unchanged.

## Tests

Fresh local verification from `libraries/python`:

- `uv run --extra dev python -m pytest tests/unit/test_enum_handling.py -q` -> `6 passed, 13 warnings`
- `uv run --extra dev ruff check mcp_use/agents/adapters/base.py tests/unit/test_enum_handling.py` -> `All checks passed!`
- `uv run --extra dev ruff format --check mcp_use/agents/adapters/base.py tests/unit/test_enum_handling.py` -> `2 files already formatted`
- `uv run --extra dev ruff check .` -> `All checks passed!`
- `uv run --extra dev ruff format --check .` -> `224 files already formatted`
- `uv run --extra dev --extra e2b python -m pytest tests/unit -q` -> `306 passed, 38 warnings in 37.01s`

## Risk

Low. The normalized return value is unchanged; this only prevents schema rewrites from leaking back into caller-owned MCP tool objects.
