### PR TITLE
fix(cli): display union schema types

### DIFF
--- a/libraries/typescript/.changeset/cli-schema-union-display.md
+++ b/libraries/typescript/.changeset/cli-schema-union-display.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/cli": patch
+---
+
+Improve CLI schema display for nullable `anyOf`, `oneOf`, and array type unions.

--- a/libraries/typescript/packages/cli/src/utils/format.ts
+++ b/libraries/typescript/packages/cli/src/utils/format.ts
@@ -312,7 +312,7 @@ export function formatSchema(schema: any, indent = 0): string {
   if (schema.type === "object" && schema.properties) {
     Object.entries(schema.properties).forEach(([key, value]: [string, any]) => {
       const required = schema.required?.includes(key);
-      const type = value.type || "any";
+      const type = formatSchemaType(value);
       const desc = value.description || "";
 
       const keyStr = required ? chalk.bold(key) : key;
@@ -343,13 +343,30 @@ export function formatSchema(schema: any, indent = 0): string {
       }
     });
   } else {
-    lines.push(`${pad}${chalk.cyan(`Type: ${schema.type || "any"}`)}`);
+    lines.push(`${pad}${chalk.cyan(`Type: ${formatSchemaType(schema)}`)}`);
     if (schema.description) {
       lines.push(`${pad}${chalk.gray(schema.description)}`);
     }
   }
 
   return lines.join("\n");
+}
+
+function formatSchemaType(schema: any): string {
+  if (Array.isArray(schema?.type)) {
+    return schema.type.join(" | ");
+  }
+
+  if (schema?.type) {
+    return schema.type;
+  }
+
+  const union = schema?.anyOf ?? schema?.oneOf;
+  if (Array.isArray(union) && union.length > 0) {
+    return union.map((variant) => formatSchemaType(variant)).join(" | ");
+  }
+
+  return "any";
 }
 
 /**

--- a/libraries/typescript/packages/cli/tests/format.test.ts
+++ b/libraries/typescript/packages/cli/tests/format.test.ts
@@ -427,6 +427,44 @@ describe("Format Utilities", () => {
       expect(formatted).toContain("Items:");
     });
 
+    it("should format nullable anyOf and oneOf property types", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          limit: {
+            anyOf: [{ type: "integer" }, { type: "null" }],
+            description: "Maximum result count",
+          },
+          includeHidden: {
+            oneOf: [{ type: "boolean" }, { type: "null" }],
+          },
+        },
+      };
+
+      const formatted = formatSchema(schema);
+
+      expect(formatted).toContain("limit");
+      expect(formatted).toContain("(integer | null)");
+      expect(formatted).toContain("Maximum result count");
+      expect(formatted).toContain("includeHidden");
+      expect(formatted).toContain("(boolean | null)");
+      expect(formatted).not.toContain("(any)");
+    });
+
+    it("should format array type unions", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          nickname: { type: ["string", "null"] },
+        },
+      };
+
+      const formatted = formatSchema(schema);
+
+      expect(formatted).toContain("nickname");
+      expect(formatted).toContain("(string | null)");
+    });
+
     it("should handle null schema", () => {
       const formatted = formatSchema(null);
       expect(formatted).toContain("No schema");


### PR DESCRIPTION
## Problem

CLI schema output only reads a property's direct `type` field. Nullable schemas expressed with `anyOf` or `oneOf` are displayed as `(any)`, and array-valued types are rendered as comma-joined strings such as `(string,null)`.

That makes tool schema output harder to use because users cannot see the expected argument type from the CLI.

## Root cause

`formatSchema()` formats types with `value.type || "any"` and does not normalize JSON Schema union forms before rendering.

## Solution

- Add a schema type display helper for direct types, array-valued types, `anyOf`, and `oneOf`.
- Render union variants with ` | ` for readability.
- Add regression tests for nullable `anyOf`/`oneOf` properties and `type: ["string", "null"]`.
- Add the required TypeScript changeset.

## Tests

- `pnpm --dir packages/cli exec vitest run tests/format.test.ts`
- `pnpm prettier --check packages/cli/src/utils/format.ts packages/cli/tests/format.test.ts .changeset/cli-schema-union-display.md`
- `pnpm --filter @mcp-use/cli build`
- `pnpm --filter @mcp-use/cli test`

## Risk

Low. This is display-only; it does not change CLI parsing or tool-call behavior.
