### PR TITLE
fix(server): await widget structured content

### DIFF
--- a/libraries/typescript/.changeset/await-widget-structured-content.md
+++ b/libraries/typescript/.changeset/await-widget-structured-content.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Await async widget `structuredContent` callbacks before returning tool output.

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/protocol-helpers.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/protocol-helpers.ts
@@ -169,18 +169,18 @@ export function applyClaudeResourceDomain(
  * @param displayName - Display name for the widget
  * @returns Tool output with content array
  */
-export function generateToolOutput(
+export async function generateToolOutput(
   definition: UIResourceDefinition,
   params: Record<string, unknown>,
   displayName: string
-): {
+): Promise<{
   content: Array<{
     type: string;
     text?: string;
     resource?: { uri: string; mimeType?: string };
   }>;
   structuredContent?: unknown;
-} {
+}> {
   const result: {
     content: Array<{
       type: string;
@@ -195,7 +195,7 @@ export function generateToolOutput(
   // Add structured content if available
   if ("structuredContent" in definition && definition.structuredContent) {
     if (typeof definition.structuredContent === "function") {
-      result.structuredContent = definition.structuredContent(params);
+      result.structuredContent = await definition.structuredContent(params);
     } else {
       result.structuredContent = definition.structuredContent;
     }

--- a/libraries/typescript/packages/mcp-use/src/server/widgets/ui-resource-registration.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/widgets/ui-resource-registration.ts
@@ -594,7 +594,7 @@ export function uiResourceRegistration<T extends UIResourceServer>(
           ? typeof enrichedDefinition.toolOutput === "function"
             ? enrichedDefinition.toolOutput(params)
             : enrichedDefinition.toolOutput
-          : generateToolOutput(enrichedDefinition, params, displayName);
+          : await generateToolOutput(enrichedDefinition, params, displayName);
 
         // Ensure content exists (required by CallToolResult) - text items only
         const content = toolOutputResult?.content || [

--- a/libraries/typescript/packages/mcp-use/tests/unit/server/protocol-helpers.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/server/protocol-helpers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   applyClaudeResourceDomain,
   computeClaudeResourceDomain,
+  generateToolOutput,
   isClaudeClient,
 } from "../../../src/server/widgets/protocol-helpers.js";
 
@@ -77,6 +78,31 @@ describe("protocol helpers", () => {
       });
 
       expect(resource._meta.ui.domain).toBe("https://example.com/mcp");
+    });
+  });
+
+  describe("tool output generation", () => {
+    it("awaits async structuredContent callbacks", async () => {
+      const result = await generateToolOutput(
+        {
+          type: "appsSdk",
+          name: "weather-widget",
+          htmlTemplate: "<div></div>",
+          structuredContent: async (params: Record<string, unknown>) => ({
+            city: params.city,
+            temperature: 72,
+          }),
+        } as any,
+        { city: "Berlin" },
+        "Weather"
+      );
+
+      expect(result.content).toEqual([{ type: "text", text: "Weather" }]);
+      expect(result.structuredContent).toEqual({
+        city: "Berlin",
+        temperature: 72,
+      });
+      expect(result.structuredContent).not.toBeInstanceOf(Promise);
     });
   });
 });


### PR DESCRIPTION
## Problem

`generateToolOutput()` supports widget definitions with a `structuredContent` callback, but it assigns the callback result directly. If that callback is async, the tool result contains a `Promise` instead of resolved structured JSON.

## Root cause

The helper was synchronous and did not await function-valued `structuredContent`.

## Solution

- Make `generateToolOutput()` async.
- Await function-valued `structuredContent` callbacks before assigning the result.
- Await the helper at its only call site in widget tool registration.
- Add a regression test for an async structured-content callback.

## Tests

- `pnpm --dir packages/mcp-use exec vitest run tests/unit/server/protocol-helpers.test.ts`
- `pnpm prettier --check packages/mcp-use/src/server/widgets/protocol-helpers.ts packages/mcp-use/src/server/widgets/ui-resource-registration.ts packages/mcp-use/tests/unit/server/protocol-helpers.test.ts .changeset/await-widget-structured-content.md`
- `pnpm --filter mcp-use build`
- `pnpm changeset status --since=main`

Note: `pnpm --filter mcp-use test:unit` was also attempted, but this local Node 25.2.1 environment fails unrelated browser auth/export tests around built artifacts and `localStorage.clear`.

## Risk

Low. The helper has a single async call site, synchronous structured content remains supported, and the returned tool result now contains serializable structured content instead of a promise.
