### PR TITLE
fix(cli): preserve zero screenshot timeout

### DIFF
--- a/libraries/typescript/.changeset/screenshot-timeout-zero.md
+++ b/libraries/typescript/.changeset/screenshot-timeout-zero.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/cli": patch
+---
+
+Preserve explicit `--timeout 0` values when capturing CLI screenshots.

--- a/libraries/typescript/packages/cli/src/commands/screenshot.ts
+++ b/libraries/typescript/packages/cli/src/commands/screenshot.ts
@@ -452,6 +452,14 @@ export function parseDeviceScaleFactor(raw: string): number {
   return n;
 }
 
+export function parseScreenshotTimeout(
+  raw: string,
+  defaultTimeout = 30000
+): number {
+  const n = parseInt(raw, 10);
+  return Number.isNaN(n) ? defaultTimeout : n;
+}
+
 export function requiresArguments(inputSchema: unknown): boolean {
   if (!inputSchema || typeof inputSchema !== "object") return false;
   const required = (inputSchema as { required?: unknown }).required;
@@ -562,7 +570,7 @@ async function screenshotCommand(
       options.height !== undefined
         ? parseDimension(options.height, "height")
         : undefined;
-    const navTimeout = parseInt(options.timeout, 10) || 30000;
+    const navTimeout = parseScreenshotTimeout(options.timeout);
     const delayMs = options.delay ? parseInt(options.delay, 10) : 0;
     const deviceScaleFactor = options.deviceScaleFactor
       ? parseDeviceScaleFactor(options.deviceScaleFactor)

--- a/libraries/typescript/packages/cli/tests/screenshot.test.ts
+++ b/libraries/typescript/packages/cli/tests/screenshot.test.ts
@@ -6,6 +6,7 @@ import {
   parseDimension,
   parseHeaderArg,
   parseHeaderArgs,
+  parseScreenshotTimeout,
   requiresArguments,
   timestampSuffix,
 } from "../src/commands/screenshot.js";
@@ -93,6 +94,16 @@ describe("parseDeviceScaleFactor", () => {
   it("rejects values above 4", () => {
     expect(() => parseDeviceScaleFactor("5")).toThrow(/<= 4/);
     expect(() => parseDeviceScaleFactor("100")).toThrow(/<= 4/);
+  });
+});
+
+describe("parseScreenshotTimeout", () => {
+  it("preserves an explicit zero timeout", () => {
+    expect(parseScreenshotTimeout("0")).toBe(0);
+  });
+
+  it("uses the default timeout when parsing fails", () => {
+    expect(parseScreenshotTimeout("abc")).toBe(30000);
   });
 });
 


### PR DESCRIPTION
## Problem

The screenshot command parses `--timeout` with `parseInt(options.timeout, 10) || 30000`. Because `0` is falsy, an explicit `--timeout 0` is silently replaced with the default `30000`.

## Root cause

Timeout parsing used a truthiness fallback instead of defaulting only when parsing fails.

## Solution

- Add `parseScreenshotTimeout()` to preserve numeric zero.
- Keep the existing fallback for invalid timeout strings.
- Use the helper when computing the screenshot navigation timeout.
- Add regression tests for `0` and invalid-string fallback behavior.
- Add the required TypeScript changeset.

## Tests

- `pnpm --dir packages/cli exec vitest run tests/screenshot.test.ts`
- `pnpm prettier --check packages/cli/src/commands/screenshot.ts packages/cli/tests/screenshot.test.ts .changeset/screenshot-timeout-zero.md`
- `pnpm --filter @mcp-use/cli build`
- `pnpm --filter @mcp-use/cli test`
- `pnpm changeset status --since=main`

## Risk

Low. Invalid timeout input keeps the current default behavior; this only preserves an explicit numeric value that was previously lost.
