### PR TITLE
fix(python): forward common connector options to WebSocketConnector

### DIFF
--- a/libraries/python/mcp_use/client/config.py
+++ b/libraries/python/mcp_use/client/config.py
@@ -137,6 +137,13 @@ def create_connector_from_config(
             url=server_config["ws_url"],
             headers=server_config.get("headers", None),
             auth=server_config.get("auth", {}),
+            sampling_callback=sampling_callback,
+            elicitation_callback=elicitation_callback,
+            message_handler=message_handler,
+            logging_callback=logging_callback,
+            middleware=middleware,
+            roots=roots,
+            list_roots_callback=list_roots_callback,
         )
 
     raise ValueError("Cannot determine connector type from config")

--- a/libraries/python/mcp_use/client/connectors/websocket.py
+++ b/libraries/python/mcp_use/client/connectors/websocket.py
@@ -11,10 +11,12 @@ import uuid
 from typing import Any
 
 import httpx
-from mcp.types import Tool
+from mcp.client.session import ElicitationFnT, ListRootsFnT, LoggingFnT, MessageHandlerFnT, SamplingFnT
+from mcp.types import Root, Tool
 from websockets import ClientConnection
 
 from mcp_use.client.connectors.base import BaseConnector
+from mcp_use.client.middleware import Middleware
 from mcp_use.client.task_managers import ConnectionManager, WebSocketConnectionManager
 from mcp_use.logging import logger
 
@@ -31,6 +33,13 @@ class WebSocketConnector(BaseConnector):
         url: str,
         headers: dict[str, str] | None = None,
         auth: str | dict[str, Any] | httpx.Auth | None = None,
+        sampling_callback: SamplingFnT | None = None,
+        elicitation_callback: ElicitationFnT | None = None,
+        message_handler: MessageHandlerFnT | None = None,
+        logging_callback: LoggingFnT | None = None,
+        middleware: list[Middleware] | None = None,
+        roots: list[Root] | None = None,
+        list_roots_callback: ListRootsFnT | None = None,
     ):
         """Initialize a new WebSocket connector.
 
@@ -41,7 +50,23 @@ class WebSocketConnector(BaseConnector):
                 - A string token: Use Bearer token authentication
                 - A dict: Not supported for WebSocket (will log warning)
                 - An httpx.Auth object: Not supported for WebSocket (will log warning)
+            sampling_callback: Optional sampling callback.
+            elicitation_callback: Optional elicitation callback.
+            message_handler: Optional callback to handle messages.
+            logging_callback: Optional callback to handle log messages.
+            middleware: Optional list of middleware.
+            roots: Optional initial list of roots to advertise to the server.
+            list_roots_callback: Optional custom callback to handle roots/list requests.
         """
+        super().__init__(
+            sampling_callback=sampling_callback,
+            elicitation_callback=elicitation_callback,
+            message_handler=message_handler,
+            logging_callback=logging_callback,
+            middleware=middleware,
+            roots=roots,
+            list_roots_callback=list_roots_callback,
+        )
         self.url = url
         self.headers = headers or {}
 

--- a/libraries/python/tests/unit/test_config.py
+++ b/libraries/python/tests/unit/test_config.py
@@ -12,6 +12,7 @@ from mcp_use.client.auth.bearer import BearerAuth
 from mcp_use.client.config import create_connector_from_config, load_config_file
 from mcp_use.client.connectors import HttpConnector, SandboxConnector, StdioConnector, WebSocketConnector
 from mcp_use.client.connectors.sandbox import SandboxOptions
+from mcp_use.client.middleware import Middleware
 
 
 class TestConfigLoading(unittest.TestCase):
@@ -143,6 +144,37 @@ class TestConnectorCreation(unittest.TestCase):
         self.assertIsInstance(connector, WebSocketConnector)
         self.assertEqual(connector.url, "ws://test.com")
         self.assertEqual(connector.headers, {})
+
+    def test_create_websocket_connector_preserves_common_options(self):
+        """WebSocket connectors should receive the same common options as other transports."""
+        server_config = {"ws_url": "ws://test.com"}
+        middleware = Middleware()
+        sampling_callback = object()
+        elicitation_callback = object()
+        message_handler = object()
+        logging_callback = object()
+        roots = []
+        list_roots_callback = object()
+
+        connector = create_connector_from_config(
+            server_config,
+            sampling_callback=sampling_callback,
+            elicitation_callback=elicitation_callback,
+            message_handler=message_handler,
+            logging_callback=logging_callback,
+            middleware=[middleware],
+            roots=roots,
+            list_roots_callback=list_roots_callback,
+        )
+
+        self.assertIsInstance(connector, WebSocketConnector)
+        self.assertIs(connector.sampling_callback, sampling_callback)
+        self.assertIs(connector.elicitation_callback, elicitation_callback)
+        self.assertIs(connector.message_handler, message_handler)
+        self.assertIs(connector.logging_callback, logging_callback)
+        self.assertEqual(connector.get_roots(), roots)
+        self.assertIs(connector._user_list_roots_callback, list_roots_callback)
+        self.assertIn(middleware, connector.middleware_manager.middlewares)
 
     def test_create_stdio_connector(self):
         """Test creating a stdio connector from config."""


### PR DESCRIPTION
## Summary

Forward sampling, elicitation, message, logging callbacks, middleware, roots, and list_roots_callback through `create_connector_from_config()` when the config uses `ws_url`, and initialize `WebSocketConnector` via `BaseConnector` so WebSocket sessions behave like stdio and HTTP transports.

## Motivation

Fixes #1748. The `ws_url` branch only passed URL/headers/auth to `WebSocketConnector`, silently dropping client/session options that stdio and HTTP connectors already receive.

## Changes

- `libraries/python/mcp_use/client/connectors/websocket.py`: accept common connector options and call `super().__init__(...)`
- `libraries/python/mcp_use/client/config.py`: pass those options for `ws_url` configs
- `libraries/python/tests/unit/test_config.py`: add regression test asserting all forwarded options are preserved

## Tests

```bash
cd libraries/python
MCP_USE_ANONYMIZED_TELEMETRY=false pytest tests/unit/test_config.py::TestConnectorCreation::test_create_websocket_connector_preserves_common_options -q
MCP_USE_ANONYMIZED_TELEMETRY=false pytest tests/unit/test_config.py -q
ruff check mcp_use/client/config.py mcp_use/client/connectors/websocket.py tests/unit/test_config.py
```

- Focused regression test: passed
- Full `test_config.py`: 13 passed (1 pre-existing sandbox/E2B failure unrelated to this change)
- Ruff: passed

## Notes

- Composer-2.5 review: APPROVE
- No behavior change for stdio/HTTP connectors
- `verify` remains HTTP-only and is intentionally not forwarded to WebSocket