### PR TITLE
fix(cli): respect PORT when start uses -p path

### DIFF
--- a/libraries/typescript/packages/cli/src/index.ts
+++ b/libraries/typescript/packages/cli/src/index.ts
@@ -37,6 +37,7 @@ import {
 } from "./utils/next-shims.js";
 import { notifyIfUpdateAvailable } from "./utils/update-check.js";
 import { getWidgetAssetBase } from "./utils/widget-paths.js";
+import { resolveStartPort } from "./utils/start-port.js";
 const program = new Command();
 
 const packageContent = readFileSync(
@@ -2624,17 +2625,8 @@ program
   .action(async (options) => {
     try {
       const projectPath = path.resolve(options.path);
-      // Priority: --port flag > process.env.PORT > default
-      // Check if --port or -p was explicitly provided in command line
-      const portFlagProvided =
-        process.argv.includes("--port") ||
-        process.argv.includes("-p") ||
-        process.argv.some((arg) => arg.startsWith("--port=")) ||
-        process.argv.some((arg) => arg.startsWith("-p="));
-
-      let port = portFlagProvided
-        ? parseInt(options.port, 10) // Flag explicitly provided, use it
-        : parseInt(process.env.PORT || options.port || "3000", 10); // Check env, then default
+      // Priority: --port flag > process.env.PORT > default.
+      let port = resolveStartPort(process.argv, options.port, process.env.PORT);
 
       // Check if port is available, find alternative if needed
       if (!(await isPortAvailable(port))) {

--- a/libraries/typescript/packages/cli/src/utils/start-port.ts
+++ b/libraries/typescript/packages/cli/src/utils/start-port.ts
@@ -1,0 +1,15 @@
+export function hasExplicitPortFlag(argv: readonly string[]): boolean {
+  return argv.some((arg) => arg === "--port" || arg.startsWith("--port="));
+}
+
+export function resolveStartPort(
+  argv: readonly string[],
+  optionPort: string | undefined,
+  envPort: string | undefined
+): number {
+  const rawPort = hasExplicitPortFlag(argv)
+    ? optionPort
+    : envPort || optionPort || "3000";
+
+  return parseInt(rawPort || "3000", 10);
+}

--- a/libraries/typescript/packages/cli/tests/start-port.test.ts
+++ b/libraries/typescript/packages/cli/tests/start-port.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import {
+  hasExplicitPortFlag,
+  resolveStartPort,
+} from "../src/utils/start-port.js";
+
+describe("start port resolution", () => {
+  it("does not treat the -p path alias as an explicit port flag", () => {
+    const argv = ["node", "mcp-use", "start", "-p", "./app"];
+
+    expect(hasExplicitPortFlag(argv)).toBe(false);
+    expect(resolveStartPort(argv, "3000", "4173")).toBe(4173);
+  });
+
+  it("uses an explicit long --port flag ahead of PORT", () => {
+    const argv = ["node", "mcp-use", "start", "--port", "5050"];
+
+    expect(hasExplicitPortFlag(argv)).toBe(true);
+    expect(resolveStartPort(argv, "5050", "4173")).toBe(5050);
+  });
+
+  it("uses an explicit --port=value flag ahead of PORT", () => {
+    const argv = ["node", "mcp-use", "start", "--port=5050"];
+
+    expect(hasExplicitPortFlag(argv)).toBe(true);
+    expect(resolveStartPort(argv, "5050", "4173")).toBe(5050);
+  });
+});


### PR DESCRIPTION
Fixes #1813

## Problem

`mcp-use start -p <path>` uses `-p` as the short alias for `--path`, but the start command also treated `-p` as if the user had explicitly set a port.

That made `PORT=4173 mcp-use start -p ./app` ignore `PORT` and use the default `--port` value instead.

## Root cause

The explicit-port check inspected raw `process.argv` for both `--port` and `-p`, even though `start` does not define a short alias for `--port`.

## Solution

Add a small start-port helper that only treats `--port` and `--port=<value>` as explicit port flags. The existing precedence remains: explicit `--port` > `PORT` env > default.

## Tests

- `pnpm --dir libraries/typescript --filter @mcp-use/cli test -- start-port.test.ts`
- `pnpm --dir libraries/typescript --filter @mcp-use/cli build`
- `pnpm --dir libraries/typescript exec prettier --check packages/cli/src/index.ts packages/cli/src/utils/start-port.ts packages/cli/tests/start-port.test.ts`
- `pnpm --dir libraries/typescript exec eslint packages/cli/src/index.ts packages/cli/src/utils/start-port.ts packages/cli/tests/start-port.test.ts`

## Risk

Low. This only changes explicit-port detection for `start`; `-p` continues to mean `--path`.
