### PR TITLE
fix(cli): detect occupied TCP ports before startup

### DIFF
--- a/libraries/typescript/packages/cli/src/index.ts
+++ b/libraries/typescript/packages/cli/src/index.ts
@@ -37,6 +37,7 @@ import {
 } from "./utils/next-shims.js";
 import { notifyIfUpdateAvailable } from "./utils/update-check.js";
 import { getWidgetAssetBase } from "./utils/widget-paths.js";
+import { findAvailablePort, isPortAvailable } from "./utils/ports.js";
 const program = new Command();
 
 const packageContent = readFileSync(
@@ -119,32 +120,6 @@ function displayPackageVersions(projectPath?: string) {
       }
     }
   }
-}
-
-// Helper to check if port is available
-async function isPortAvailable(
-  port: number,
-  host: string = "localhost"
-): Promise<boolean> {
-  try {
-    await fetch(`http://${host}:${port}`);
-    return false; // Port is in use
-  } catch {
-    return true; // Port is available
-  }
-}
-
-// Helper to find an available port
-async function findAvailablePort(
-  startPort: number,
-  host: string = "localhost"
-): Promise<number> {
-  for (let port = startPort; port < startPort + 100; port++) {
-    if (await isPortAvailable(port, host)) {
-      return port;
-    }
-  }
-  throw new Error("No available ports found");
 }
 
 // Helper to check if server is ready

--- a/libraries/typescript/packages/cli/src/utils/ports.ts
+++ b/libraries/typescript/packages/cli/src/utils/ports.ts
@@ -1,0 +1,57 @@
+import net from "node:net";
+
+export async function isPortAvailable(
+  port: number,
+  host: string = "localhost"
+): Promise<boolean> {
+  if (host === "localhost") {
+    const loopbackResults = await Promise.all([
+      canBindPort(port, "127.0.0.1", true),
+      canBindPort(port, "::1", true),
+    ]);
+    return loopbackResults.every(Boolean);
+  }
+
+  return canBindPort(port, host);
+}
+
+async function canBindPort(
+  port: number,
+  host: string,
+  ignoreUnsupportedHost = false
+): Promise<boolean> {
+  return new Promise((resolve) => {
+    const server = net.createServer();
+
+    server.once("error", (error: NodeJS.ErrnoException) => {
+      if (
+        ignoreUnsupportedHost &&
+        (error.code === "EADDRNOTAVAIL" || error.code === "EINVAL")
+      ) {
+        resolve(true);
+        return;
+      }
+      resolve(false);
+    });
+
+    server.once("listening", () => {
+      server.close(() => {
+        resolve(true);
+      });
+    });
+
+    server.listen(port, host);
+  });
+}
+
+export async function findAvailablePort(
+  startPort: number,
+  host: string = "localhost"
+): Promise<number> {
+  for (let port = startPort; port < startPort + 100; port++) {
+    if (await isPortAvailable(port, host)) {
+      return port;
+    }
+  }
+  throw new Error("No available ports found");
+}

--- a/libraries/typescript/packages/cli/tests/ports.test.ts
+++ b/libraries/typescript/packages/cli/tests/ports.test.ts
@@ -1,0 +1,59 @@
+import net from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+import { findAvailablePort, isPortAvailable } from "../src/utils/ports.js";
+
+const openServers: net.Server[] = [];
+
+async function listenOnEphemeralPort(host = "127.0.0.1") {
+  const server = net.createServer();
+  openServers.push(server);
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, host, () => resolve());
+  });
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Expected TCP server to bind to a numeric port");
+  }
+
+  return { server, port: address.port, host };
+}
+
+afterEach(async () => {
+  await Promise.all(
+    openServers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve, reject) => {
+          if (!server.listening) {
+            resolve();
+            return;
+          }
+          server.close((error) => (error ? reject(error) : resolve()));
+        })
+    )
+  );
+});
+
+describe("CLI port helpers", () => {
+  it("detects a port occupied by a non-HTTP TCP listener", async () => {
+    const { port, host } = await listenOnEphemeralPort();
+
+    await expect(isPortAvailable(port, host)).resolves.toBe(false);
+  });
+
+  it("checks IPv4 loopback listeners when probing localhost", async () => {
+    const { port } = await listenOnEphemeralPort("127.0.0.1");
+
+    await expect(isPortAvailable(port)).resolves.toBe(false);
+  });
+
+  it("skips a non-HTTP TCP listener when finding an available port", async () => {
+    const { port, host } = await listenOnEphemeralPort();
+
+    const availablePort = await findAvailablePort(port, host);
+
+    expect(availablePort).not.toBe(port);
+  });
+});


### PR DESCRIPTION
Fixes #1814

## Problem

The CLI port preflight used an HTTP request to decide whether a port was occupied. Non-HTTP TCP listeners make that request fail, so the CLI could incorrectly treat an occupied port as available and then fail later when the server tried to bind.

## Root cause

Port availability was tested at the application protocol layer (`fetch(http://host:port)`) instead of using the same TCP bind semantics the server startup path depends on.

## Solution

Move the port helpers into a tested utility and probe availability by attempting to bind a TCP server. The default `localhost` path checks both `127.0.0.1` and `::1` so an IPv4-only loopback listener is not missed when the platform resolves `localhost` to IPv6.

## Tests

- `pnpm --dir libraries/typescript --filter @mcp-use/cli test -- ports.test.ts`
- `pnpm --dir libraries/typescript --filter @mcp-use/cli build`
- `pnpm --dir libraries/typescript exec prettier --check packages/cli/src/index.ts packages/cli/src/utils/ports.ts packages/cli/tests/ports.test.ts`
- `pnpm --dir libraries/typescript exec eslint packages/cli/src/index.ts packages/cli/src/utils/ports.ts packages/cli/tests/ports.test.ts`

## Risk

Low. This is still a best-effort preflight because any port can be claimed between the probe and final server bind, but it now detects the common non-HTTP listener collision that the previous fetch check missed.
