### PR TITLE
fix(cli): preserve quoted stdio command arguments

### DIFF
--- a/libraries/typescript/packages/cli/src/commands/client.ts
+++ b/libraries/typescript/packages/cli/src/commands/client.ts
@@ -21,6 +21,7 @@ import {
   isStdoutTty,
 } from "../utils/format.js";
 import { parsePromptArgs, parseToolArgs } from "../utils/parse-args.js";
+import { parseStdioTarget } from "../utils/stdio-target.js";
 import {
   buildOAuthProvider,
   isUnauthorized,
@@ -171,9 +172,7 @@ async function connectCommand(
     const cliClientInfo = getCliClientInfo();
 
     if (options.stdio) {
-      const parts = target.split(" ");
-      const command = parts[0];
-      const args = parts.slice(1);
+      const { command, args } = parseStdioTarget(target);
 
       console.error(
         formatInfo(`Connecting to stdio server: ${command} ${args.join(" ")}`)

--- a/libraries/typescript/packages/cli/src/utils/stdio-target.ts
+++ b/libraries/typescript/packages/cli/src/utils/stdio-target.ts
@@ -1,0 +1,92 @@
+export interface StdioTarget {
+  command: string;
+  args: string[];
+}
+
+export function parseStdioTarget(target: string): StdioTarget {
+  const parts = splitCommandLine(target);
+
+  if (parts.length === 0) {
+    throw new Error("Stdio command cannot be empty");
+  }
+
+  const [command, ...args] = parts;
+  return { command, args };
+}
+
+function splitCommandLine(input: string): string[] {
+  const parts: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | undefined;
+  let tokenStarted = false;
+
+  for (let index = 0; index < input.length; index++) {
+    const char = input[index];
+
+    if (char === "\\") {
+      const next = input[index + 1];
+
+      if (next === undefined || quote === "'") {
+        current += char;
+        tokenStarted = true;
+        continue;
+      }
+
+      if (quote === '"' && (next === '"' || next === "\\")) {
+        current += next;
+        tokenStarted = true;
+        index++;
+        continue;
+      }
+
+      if (!quote && (/[\s'"\\]/.test(next) || next === "\\")) {
+        current += next;
+        tokenStarted = true;
+        index++;
+        continue;
+      }
+
+      current += char;
+      tokenStarted = true;
+      continue;
+    }
+
+    if (quote) {
+      if (char === quote) {
+        quote = undefined;
+      } else {
+        current += char;
+      }
+      tokenStarted = true;
+      continue;
+    }
+
+    if (char === "'" || char === '"') {
+      quote = char;
+      tokenStarted = true;
+      continue;
+    }
+
+    if (/\s/.test(char)) {
+      if (tokenStarted) {
+        parts.push(current);
+        current = "";
+        tokenStarted = false;
+      }
+      continue;
+    }
+
+    current += char;
+    tokenStarted = true;
+  }
+
+  if (quote) {
+    throw new Error("Unterminated quote in stdio command");
+  }
+
+  if (tokenStarted) {
+    parts.push(current);
+  }
+
+  return parts;
+}

--- a/libraries/typescript/packages/cli/tests/stdio-target.test.ts
+++ b/libraries/typescript/packages/cli/tests/stdio-target.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { parseStdioTarget } from "../src/utils/stdio-target.js";
+
+describe("parseStdioTarget", () => {
+  it("keeps simple stdio commands unchanged", () => {
+    expect(
+      parseStdioTarget("npx -y @modelcontextprotocol/server-filesystem /tmp")
+    ).toEqual({
+      command: "npx",
+      args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+    });
+  });
+
+  it("preserves quoted command paths and arguments with spaces", () => {
+    expect(
+      parseStdioTarget('"/opt/MCP Servers/server" "--config=dev env.json"')
+    ).toEqual({
+      command: "/opt/MCP Servers/server",
+      args: ["--config=dev env.json"],
+    });
+  });
+
+  it("preserves Windows backslashes inside quoted command paths", () => {
+    expect(
+      parseStdioTarget(
+        String.raw`"C:\Program Files\nodejs\node.exe" "server path.js" --flag`
+      )
+    ).toEqual({
+      command: String.raw`C:\Program Files\nodejs\node.exe`,
+      args: ["server path.js", "--flag"],
+    });
+  });
+
+  it("preserves intentionally empty quoted arguments", () => {
+    expect(parseStdioTarget('node server.js ""')).toEqual({
+      command: "node",
+      args: ["server.js", ""],
+    });
+  });
+
+  it("rejects unterminated quoted commands", () => {
+    expect(() => parseStdioTarget('"node server.js')).toThrow(
+      "Unterminated quote"
+    );
+  });
+});


### PR DESCRIPTION
Fixes #1815

## Problem

`mcp-use client connect --stdio` split the target command on raw spaces. Quoted executable paths and arguments containing spaces were broken before being saved as `{ command, args }`.

## Root cause

The stdio connect path used `target.split(" ")`, which cannot represent quoted strings, escaped whitespace, Windows paths with spaces, or intentionally empty quoted arguments.

## Solution

Add a small shell-like tokenizer for saved stdio target strings and use it when building the command/args pair. This is intentionally limited parsing for quoting and escaping; it does not execute shell syntax or emulate a full POSIX/Windows shell.

## Tests

- `pnpm --dir libraries/typescript --filter @mcp-use/cli test -- stdio-target.test.ts`
- `pnpm --dir libraries/typescript --filter @mcp-use/cli build`
- `pnpm --dir libraries/typescript exec prettier --check packages/cli/src/commands/client.ts packages/cli/src/utils/stdio-target.ts packages/cli/tests/stdio-target.test.ts`
- `pnpm --dir libraries/typescript exec eslint packages/cli/src/commands/client.ts packages/cli/src/utils/stdio-target.ts packages/cli/tests/stdio-target.test.ts`

## Risk

Low to moderate. This changes parsing semantics for `--stdio` command strings, but keeps the existing command-plus-argv execution model and adds coverage for simple commands, quoted paths, Windows paths, empty args, and malformed quotes.
