### PR TITLE
fix(server): handle empty OpenAPI JSON responses

### DIFF
--- a/libraries/typescript/.changeset/openapi-empty-json-responses.md
+++ b/libraries/typescript/.changeset/openapi-empty-json-responses.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Handle successful OpenAPI JSON responses with empty bodies without throwing.

--- a/libraries/typescript/packages/mcp-use/src/server/openapi/request.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/openapi/request.ts
@@ -41,7 +41,8 @@ export async function callOpenAPIOperation(
     contentType.includes("application/json") ||
     contentType.includes("+json")
   ) {
-    return objectResponse(await response.json());
+    const responseText = await response.text();
+    return objectResponse(responseText ? JSON.parse(responseText) : {});
   }
 
   return text(await response.text());

--- a/libraries/typescript/packages/mcp-use/tests/unit/server/openapi.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/server/openapi.test.ts
@@ -255,4 +255,28 @@ describe("MCPServer.fromOpenAPI", () => {
     );
     expect(result?.content).toEqual([{ type: "text", text: "updated" }]);
   });
+
+  it("handles empty JSON success responses", async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(null, {
+        status: 204,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const server = MCPServer.fromOpenAPI({ spec, fetch: fetchMock });
+    const getTodo = server.registrations.tools.get("getTodo");
+
+    const result = await getTodo?.handler({ id: "todo_123" });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.com/v1/todos/todo_123",
+      {
+        method: "GET",
+        headers: {},
+        body: undefined,
+      }
+    );
+    expect(result?.structuredContent).toEqual({});
+    expect(result?.content).toEqual([{ type: "text", text: "{}" }]);
+  });
 });


### PR DESCRIPTION
Fixes #1816

## Problem

OpenAPI-generated tools threw `SyntaxError: Unexpected end of JSON input` for successful responses that declared a JSON content type but had an empty body, such as `204 No Content`.

## Root cause

The JSON response path called `response.json()` unconditionally for successful JSON content types.

## Solution

Read the response body as text first. Non-empty JSON bodies are parsed as before; empty JSON success bodies return `objectResponse({})`, preserving a structured JSON result without throwing.

## Tests

- `pnpm --dir libraries/typescript --filter mcp-use exec vitest run tests/unit/server/openapi.test.ts`
- `pnpm --dir libraries/typescript --filter mcp-use build`
- `pnpm --dir libraries/typescript exec prettier --check packages/mcp-use/src/server/openapi/request.ts packages/mcp-use/tests/unit/server/openapi.test.ts`
- `pnpm --dir libraries/typescript exec eslint packages/mcp-use/src/server/openapi/request.ts packages/mcp-use/tests/unit/server/openapi.test.ts`

## Risk

Low. Empty JSON success responses now surface as `{}` / `"{}"` instead of throwing. Non-empty JSON and text responses keep the existing behavior.
