### PR TITLE
fix(python): keep missing auth unauthenticated

### DIFF
--- a/libraries/python/mcp_use/client/config.py
+++ b/libraries/python/mcp_use/client/config.py
@@ -113,7 +113,7 @@ def create_connector_from_config(
         return HttpConnector(
             base_url=server_config["url"],
             headers=server_config.get("headers", None),
-            auth=server_config.get("auth", {}),
+            auth=server_config.get("auth"),
             timeout=server_config.get("timeout", 5),
             sse_read_timeout=server_config.get("sse_read_timeout", 60 * 5),
             sampling_callback=sampling_callback,
@@ -136,7 +136,7 @@ def create_connector_from_config(
         return WebSocketConnector(
             url=server_config["ws_url"],
             headers=server_config.get("headers", None),
-            auth=server_config.get("auth", {}),
+            auth=server_config.get("auth"),
         )
 
     raise ValueError("Cannot determine connector type from config")

--- a/libraries/python/tests/unit/test_config.py
+++ b/libraries/python/tests/unit/test_config.py
@@ -95,6 +95,7 @@ class TestConnectorCreation(unittest.TestCase):
         self.assertEqual(connector.base_url, "http://test.com")
         self.assertEqual(connector.headers, {})
         self.assertIsNone(connector._auth)
+        self.assertIsNone(connector._oauth)
 
     def test_create_websocket_connector(self):
         """Test creating a WebSocket connector from config."""
@@ -143,6 +144,15 @@ class TestConnectorCreation(unittest.TestCase):
         self.assertIsInstance(connector, WebSocketConnector)
         self.assertEqual(connector.url, "ws://test.com")
         self.assertEqual(connector.headers, {})
+
+    @patch("mcp_use.client.connectors.websocket.logger.warning")
+    def test_create_websocket_connector_minimal_does_not_warn_about_auth(self, mock_warning):
+        """Test minimal WebSocket config is treated as unauthenticated."""
+        server_config = {"ws_url": "ws://test.com"}
+
+        create_connector_from_config(server_config)
+
+        mock_warning.assert_not_called()
 
     def test_create_stdio_connector(self):
         """Test creating a stdio connector from config."""


### PR DESCRIPTION
Fixes #1817

## Problem

Python connector config creation passed `auth={}` when the config omitted `auth`. That made minimal configs look like configured auth objects:

- HTTP initialized OAuth state from the empty dict.
- WebSocket entered the unsupported non-bearer auth warning path.

## Root cause

`create_connector_from_config()` used `server_config.get("auth", {})` for HTTP and WebSocket connectors instead of preserving `None` for an absent optional field.

## Solution

Pass `server_config.get("auth")` so omitted auth remains `None`. Explicit auth values continue to flow through unchanged.

## Tests

- `uv run --project libraries/python pytest libraries/python/tests/unit/test_config.py`
- `uv run --project libraries/python pytest libraries/python/tests/unit/test_http_connector.py libraries/python/tests/unit/test_websocket_connection_manager.py`
- `uv run --project libraries/python ruff check libraries/python/mcp_use/client/config.py libraries/python/tests/unit/test_config.py`
- `uv run --project libraries/python ruff format --check libraries/python/mcp_use/client/config.py libraries/python/tests/unit/test_config.py`

## Risk

Low. This makes missing auth behave as unauthenticated; users who want OAuth or bearer auth still need to supply the `auth` field explicitly.
