### PR TITLE
fix(openapi): handle empty JSON success responses without throwing

### DIFF
--- a/libraries/typescript/packages/mcp-use/src/server/openapi/request.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/openapi/request.ts
@@ -41,7 +41,11 @@ export async function callOpenAPIOperation(
     contentType.includes("application/json") ||
     contentType.includes("+json")
   ) {
-    return objectResponse(await response.json());
+    const responseBody = await response.text();
+    if (!responseBody.trim()) {
+      return objectResponse({});
+    }
+    return objectResponse(JSON.parse(responseBody));
   }
 
   return text(await response.text());

--- a/libraries/typescript/packages/mcp-use/tests/unit/server/openapi.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/server/openapi.test.ts
@@ -231,6 +231,37 @@ describe("MCPServer.fromOpenAPI", () => {
     expect(result?.structuredContent).toEqual({ id: "todo_123" });
   });
 
+  it("returns an empty object for successful JSON responses with no body", async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(null, {
+        status: 204,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const server = MCPServer.fromOpenAPI({
+      spec: {
+        openapi: "3.1.0",
+        info: { title: "Delete API", version: "1.0.0" },
+        paths: {
+          "/items/{id}": {
+            delete: {
+              operationId: "deleteItem",
+              responses: { "204": { description: "deleted" } },
+            },
+          },
+        },
+      },
+      baseUrl: "https://api.example.com",
+      fetch: fetchMock,
+    });
+
+    const deleteItem = server.registrations.tools.get("deleteItem");
+    const result = await deleteItem?.handler({ id: "item_1" });
+
+    expect(result?.structuredContent).toEqual({});
+    expect(result?.isError).toBeFalsy();
+  });
+
   it("sends JSON request bodies", async () => {
     const fetchMock = vi.fn(async () => {
       return new Response("updated", {


### PR DESCRIPTION
## Summary

OpenAPI-generated MCP tools no longer throw when a successful upstream response declares a JSON content type but has an empty body (for example `204 No Content`).

## Motivation

Fixes #1816. `response.json()` raises `SyntaxError: Unexpected end of JSON input` on empty bodies, causing valid API calls to surface as failing MCP tools.

## Changes

- Parse JSON success responses via `response.text()` first in `callOpenAPIOperation`
- Return an empty structured object when the body is blank
- Add a regression test for a `204` response with `application/json` content type

## Tests

```bash
cd libraries/typescript/packages/mcp-use
pnpm build
pnpm exec vitest run tests/unit/server/openapi.test.ts
```

Result: 8/8 tests passed.

## Notes

- Whitespace-only JSON bodies are treated as empty and return `{}`
- Invalid JSON still throws from `JSON.parse`, matching prior `response.json()` behavior
