### PR TITLE
Add migration page and simplify overview framing

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -162,6 +162,7 @@
                   "typescript/mcp-apps/model-context",
                   "typescript/mcp-apps/interactivity",
                   "typescript/mcp-apps/apps-sdk-compatibility",
+                  "typescript/mcp-apps/migrating-from-apps-sdk",
                   "typescript/mcp-apps/content-security-policy"
                 ]
               },
@@ -752,6 +753,10 @@
     {
       "source": "/typescript/server/apps-sdk-compatibility",
       "destination": "/typescript/mcp-apps/apps-sdk-compatibility"
+    },
+    {
+      "source": "/typescript/server/migrating-from-apps-sdk",
+      "destination": "/typescript/mcp-apps/migrating-from-apps-sdk"
     },
     {
       "source": "/typescript/server/content-security-policy",

--- a/docs/typescript/getting-started/installation.mdx
+++ b/docs/typescript/getting-started/installation.mdx
@@ -42,7 +42,7 @@ This command will:
 - Optionally install skills for agent support
 
 <Tip>
-Check out [UI Widgets](/typescript/mcp-apps) with support to MCP-UI and OpenAI Apps SDK for ChatGPT.
+Check out [MCP Apps](/typescript/mcp-apps) to build interactive widgets for MCP clients and ChatGPT.
 </Tip>
 
 ### Server Metadata

--- a/docs/typescript/mcp-apps.mdx
+++ b/docs/typescript/mcp-apps.mdx
@@ -59,7 +59,7 @@ The tool definition in `index.ts` chooses the widget with `widget: { name }`. Th
 
 The widget file uses `useWidget()` to read `props`, pending state, host context, widget state, and host actions.
 
-## What the model sees
+## What the model sees {#server-returning-data}
 
 MCP tool results separate model-visible output from widget-only data.
 
@@ -75,9 +75,9 @@ For a deeper explanation of widget state, model-visible context, and the `useWid
 
 ## Compatibility
 
-`mcp-use` uses the normal widget APIs to emit the metadata and bridge behavior ChatGPT needs, so the same widget code can run in ChatGPT and MCP Apps hosts.
+Build with the standard MCP Apps APIs. The same widget code runs in MCP Apps hosts and in ChatGPT.
 
-Apps SDK APIs remain useful for ChatGPT-specific host extensions that are not part of the shared MCP Apps spec yet. Use [Apps SDK compatibility](/typescript/mcp-apps/apps-sdk-compatibility) when you need to understand that boundary.
+For ChatGPT-specific host behavior or legacy `appsSdk` registrations, see [Apps SDK compatibility](/typescript/mcp-apps/apps-sdk-compatibility) and [Migrate from Apps SDK](/typescript/mcp-apps/migrating-from-apps-sdk).
 
 ## Start here
 
@@ -116,6 +116,13 @@ Apps SDK APIs remain useful for ChatGPT-specific host extensions that are not pa
     href="/typescript/mcp-apps/apps-sdk-compatibility"
   >
     Understand how MCP Apps run in ChatGPT and when Apps SDK extensions matter.
+  </Card>
+  <Card
+    title="Migrate from Apps SDK"
+    icon="arrow-right-arrow-left"
+    href="/typescript/mcp-apps/migrating-from-apps-sdk"
+  >
+    Move legacy ChatGPT Apps SDK registrations to the MCP Apps workflow.
   </Card>
   <Card
     title="Content Security Policy"

--- a/docs/typescript/mcp-apps/apps-sdk-compatibility.mdx
+++ b/docs/typescript/mcp-apps/apps-sdk-compatibility.mdx
@@ -10,14 +10,15 @@ ChatGPT supports MCP Apps. That means a widget built with the MCP Apps bridge ca
 
 ## How ChatGPT fits in
 
-OpenAI's Apps SDK remains supported, and ChatGPT also implements the MCP Apps UI standard. `mcp-use` generates MCP Apps metadata and ChatGPT compatibility metadata from the same widget definitions.
+ChatGPT implements the MCP Apps UI standard. Build with the normal MCP Apps APIs; `mcp-use` emits the metadata ChatGPT needs from the same widget definitions.
 
 In practice:
 
 - Use `widget: { name }` and `widget({ props, output })` on the server.
 - Use `useWidget()` and `useCallTool()` in React widgets.
-- Let `mcp-use` translate compatibility metadata for ChatGPT.
 - Reach for Apps SDK extensions only when a ChatGPT-specific capability has no shared MCP Apps equivalent yet.
+
+If you have legacy `type: "appsSdk"` registrations, see [Migrate from Apps SDK](/typescript/mcp-apps/migrating-from-apps-sdk).
 
 ## What mcp-use abstracts
 

--- a/docs/typescript/mcp-apps/migrating-from-apps-sdk.mdx
+++ b/docs/typescript/mcp-apps/migrating-from-apps-sdk.mdx
@@ -1,0 +1,114 @@
+---
+title: "Migrate from Apps SDK"
+description: "Move existing ChatGPT Apps SDK widgets to the MCP Apps workflow in mcp-use."
+icon: "arrow-right-arrow-left"
+---
+
+If you have widgets registered with `type: "appsSdk"` and `appsSdkMetadata`, migrate to the standard MCP Apps workflow. Widget React code does not need to change — only server registration and metadata format.
+
+New projects should use [Build widgets](/typescript/mcp-apps/widgets) from the start.
+
+## Before (ChatGPT only)
+
+```typescript
+server.uiResource({
+  type: "appsSdk",
+  name: "my-widget",
+  htmlTemplate: `...`,
+  appsSdkMetadata: {
+    "openai/widgetCSP": {
+      connect_domains: ["https://api.example.com"],
+      resource_domains: ["https://cdn.example.com"],
+    },
+    "openai/widgetPrefersBorder": true,
+    "openai/widgetDescription": "My widget description",
+  },
+});
+```
+
+## After (MCP Apps)
+
+```typescript
+server.uiResource({
+  type: "mcpApps",
+  name: "my-widget",
+  htmlTemplate: `...`,
+  metadata: {
+    csp: {
+      connectDomains: ["https://api.example.com"],
+      resourceDomains: ["https://cdn.example.com"],
+    },
+    prefersBorder: true,
+    widgetDescription: "My widget description",
+  },
+});
+```
+
+For file-based widgets, move the same fields into `widgetMetadata.metadata` in `resources/<name>/widget.tsx`.
+
+## Key changes
+
+- `type: "appsSdk"` → `type: "mcpApps"`
+- `appsSdkMetadata` → `metadata`
+- `"openai/widgetCSP"` → `csp` (remove the `openai/` prefix)
+- `connect_domains` → `connectDomains` (snake_case → camelCase)
+- `resource_domains` → `resourceDomains`
+- `"openai/widgetPrefersBorder"` → `prefersBorder`
+
+## Field mapping
+
+| Apps SDK (`appsSdkMetadata`) | MCP Apps (`metadata`) | Notes |
+| --- | --- | --- |
+| `"openai/widgetCSP"` | `csp` | CSP configuration object |
+| `connect_domains` | `connectDomains` | Connection domains |
+| `resource_domains` | `resourceDomains` | Resource domains |
+| `frame_domains` | `frameDomains` | Frame domains |
+| `redirect_domains` | `redirectDomains` | Redirect domains (ChatGPT-specific) |
+| `script_directives` | `scriptDirectives` | Script CSP directives |
+| `style_directives` | `styleDirectives` | Style CSP directives |
+| `"openai/widgetPrefersBorder"` | `prefersBorder` | Boolean |
+| `"openai/widgetDomain"` | `domain` | Custom domain string |
+| `"openai/widgetDescription"` | `widgetDescription` | Widget description |
+| `"openai/widgetAccessible"` | `widgetAccessible` | Can stay in `appsSdkMetadata` for ChatGPT overrides |
+| `"openai/locale"` | `locale` | Can stay in `appsSdkMetadata` for ChatGPT overrides |
+| `"openai/toolInvocation/invoking"` | `invoking` | Status text while the tool runs |
+| `"openai/toolInvocation/invoked"` | `invoked` | Status text after the tool completes |
+
+See [Content Security Policy](/typescript/mcp-apps/content-security-policy) for full CSP configuration.
+
+## Migration checklist
+
+1. Change `type: "appsSdk"` to `type: "mcpApps"`.
+2. Rename `appsSdkMetadata` to `metadata`.
+3. Transform CSP keys from snake_case `openai/widgetCSP` to camelCase `csp`.
+4. Remove the `openai/` prefix from remaining metadata keys.
+5. Test in the [Inspector](/inspector) and in ChatGPT.
+6. Verify props, theme, tool calls, and CSP still work.
+
+## ChatGPT-specific overrides (optional)
+
+If you need ChatGPT-only metadata after migrating, keep `appsSdkMetadata` alongside `metadata`:
+
+```typescript
+server.uiResource({
+  type: "mcpApps",
+  name: "my-widget",
+  htmlTemplate: `...`,
+  metadata: {
+    csp: { connectDomains: ["https://api.example.com"] },
+    prefersBorder: true,
+  },
+  appsSdkMetadata: {
+    "openai/widgetDescription": "ChatGPT-specific description",
+  },
+});
+```
+
+## Stay on Apps SDK (legacy)
+
+`type: "appsSdk"` still works if you only target ChatGPT and cannot migrate yet. Prefer `type: "mcpApps"` for new work.
+
+## Next steps
+
+- [Apps SDK compatibility](/typescript/mcp-apps/apps-sdk-compatibility) — how MCP Apps run in ChatGPT
+- [Build widgets](/typescript/mcp-apps/widgets) — the standard widget workflow


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

Check all that apply:
- [ ] TypeScript
- [ ] Python
- [ x] Documentation only
- [ ] CI/CD or tooling

## Changes

Move Apps SDK migration content to a dedicated page, de-emphasize
dual-protocol language on the overview, and preserve the

## Review Readiness

Help maintainers review this quickly:

- [ x] The PR is scoped to one issue or one clearly related change

## Resolves Issues

Closes #1344 
