### PR TITLE
feat(typescript): @mcp-use/server v2 — build/dev/start CLI + inspector CDN shell (MCP-2601)

### DIFF
--- a/libraries/typescript/eslint.config.js
+++ b/libraries/typescript/eslint.config.js
@@ -291,9 +291,10 @@ export default [
       ],
     },
   },
-  // @mcp-use/server (v2 greenfield) — strictest type safety, no escape hatches.
-  // `any` is banned outright; `unknown` is allowed only at real boundaries and
-  // must be narrowed before use (the no-unsafe-* rules enforce this).
+  // @mcp-use/server (v2 greenfield, includes the folded-in dev/build
+  // toolchain under src/cli/) — strictest type safety, no escape hatches.
+  // `any` is banned outright; `unknown` is allowed only at real boundaries
+  // and must be narrowed before use (the no-unsafe-* rules enforce this).
   // Doc comments must be valid TSDoc (see packages/server/CLAUDE.md).
   {
     files: ["packages/server/src/**/*.ts"],

--- a/libraries/typescript/packages/server/.gitignore
+++ b/libraries/typescript/packages/server/.gitignore
@@ -1,0 +1,1 @@
+tests/cli/.tmp

--- a/libraries/typescript/packages/server/examples/railway/README.md
+++ b/libraries/typescript/packages/server/examples/railway/README.md
@@ -5,9 +5,13 @@ any container/VM host without a serverless invocation model) runs an app.
 
 ## What this demonstrates
 
-- **`await server.listen(port)`** — a persistent `node:http` listener via
-  `@hono/node-server`, as opposed to the per-invocation `getHandler()` handler
-  used on serverless platforms (see the `vercel` example).
+- **The CLI entry contract** (`specs/CLI_SPEC.md`): `src/index.ts` registers
+  tools and `export default server` — it never calls `listen()` itself.
+  `mcp-use dev` (local reload), `mcp-use build` (compile to
+  `.mcp-use/build/`), and `mcp-use start` (serve the build) own the socket
+  and shutdown signals. This is the node-deployment door, as opposed to the
+  per-invocation `getHandler()` handler used on serverless platforms (see the
+  `vercel` example).
 - **A long-lived process is still stateless MCP.** `MCPServer` builds a fresh
   SDK server from its tool/resource/prompt registry on *every* request (see
   `../../specs/SPEC.md`) — the Node process living across requests is a deployment
@@ -42,12 +46,21 @@ any container/VM host without a serverless invocation model) runs an app.
 ## Run locally
 
 ```sh
-pnpm start
+pnpm dev
 ```
 
-This runs `node src/index.ts` directly — Node 24 executes erasable-syntax
-TypeScript natively, no build step. It binds `127.0.0.1:3000` (no
-`RAILWAY_PUBLIC_DOMAIN` is set locally) and logs the MCP endpoint URL.
+This runs `mcp-use dev` (the dev/build toolchain built into `@mcp-use/server`,
+on top of `vite` as a devDependency): it imports `src/index.ts`,
+serves the exported server on `127.0.0.1:3000` (no `RAILWAY_PUBLIC_DOMAIN` is
+set locally), and reloads the entry on file change. Or exercise the
+production path locally:
+
+```sh
+pnpm build && pnpm start
+```
+
+`mcp-use build` compiles the server to `.mcp-use/build/` (gitignored);
+`mcp-use start` serves that build and logs the MCP endpoint URL.
 
 Talk to it with any MCP client pointed at `http://localhost:3000/mcp`, or by
 hand with curl (responses are SSE-framed; the JSON-RPC payload is on the
@@ -63,17 +76,17 @@ curl http://localhost:3000/mcp \
 ## Deploy on Railway
 
 1. Point a Railway service at this directory (or the monorepo, with this as
-   the service's root). Railway's Nixpacks/Railpack builder detects the
-   `start` script in `package.json` (`node src/index.ts`) with zero
-   configuration — `railway.json` here only makes the replica count and
-   restart policy explicit, it isn't required to build or run.
-2. Railway injects `PORT` (the port your process must bind and listen on) and
-   `RAILWAY_PUBLIC_DOMAIN` (the service's public hostname, e.g.
-   `your-app.up.railway.app` — bare hostname, no scheme or port).
-   `src/index.ts` reads both: when `RAILWAY_PUBLIC_DOMAIN` is present it
-   binds `0.0.0.0` so the container can receive edge traffic; otherwise it
-   falls back to the local `127.0.0.1` dev config with DNS-rebinding
-   protection on.
+   the service's root). `railway.json` sets the build command (`npm run
+   build`, i.e. `mcp-use build`) and start command (`npm run start`, i.e.
+   `mcp-use start` serving `.mcp-use/build/`), plus the replica count and
+   restart policy.
+2. Railway injects `PORT` (the port your process must bind and listen on —
+   `mcp-use start` reads it) and `RAILWAY_PUBLIC_DOMAIN` (the service's
+   public hostname, e.g. `your-app.up.railway.app` — bare hostname, no scheme
+   or port). `src/index.ts` reads the latter: when `RAILWAY_PUBLIC_DOMAIN` is
+   present it sets `host: "0.0.0.0"` on the server so the container can
+   receive edge traffic; otherwise it falls back to the local `127.0.0.1`
+   dev config with DNS-rebinding protection on.
 3. Deploy. Point your MCP client at
    `https://<your-service>.up.railway.app/mcp`.
 

--- a/libraries/typescript/packages/server/examples/railway/package.json
+++ b/libraries/typescript/packages/server/examples/railway/package.json
@@ -3,12 +3,14 @@
   "type": "module",
   "version": "0.0.0",
   "private": true,
-  "description": "Example: @mcp-use/server on a long-lived Node server (Railway-style) via listen().",
+  "description": "Example: @mcp-use/server on a long-lived Node server (Railway-style) via mcp-use build/start.",
   "engines": {
     "node": ">=24.0.0"
   },
   "scripts": {
-    "start": "node src/index.ts",
+    "dev": "mcp-use dev",
+    "build": "mcp-use build",
+    "start": "mcp-use start",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -17,6 +19,7 @@
   },
   "devDependencies": {
     "@types/node": "^24.13.2",
-    "typescript": "7.0.1-rc"
+    "typescript": "7.0.1-rc",
+    "vite": "^8.0.16"
   }
 }

--- a/libraries/typescript/packages/server/examples/railway/railway.json
+++ b/libraries/typescript/packages/server/examples/railway/railway.json
@@ -1,7 +1,10 @@
 {
   "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "buildCommand": "npm run build"
+  },
   "deploy": {
-    "startCommand": "node src/index.ts",
+    "startCommand": "npm run start",
     "numReplicas": 2,
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 3

--- a/libraries/typescript/packages/server/examples/railway/src/index.ts
+++ b/libraries/typescript/packages/server/examples/railway/src/index.ts
@@ -1,12 +1,14 @@
 /**
  * @mcp-use/server on a long-lived Node server (Railway-style).
  *
- * `MCPServer.listen()` starts a persistent `node:http` listener, but the MCP
- * protocol layer underneath stays stateless: every request builds a fresh SDK
- * server from the tool/resource registry (see ../../../specs/SPEC.md). The process
- * living across requests is purely a deployment convenience — no MCP session
- * state lives in it, so any replica behind a load balancer can serve any
- * request with no session affinity.
+ * This module follows the CLI entry contract (../../../specs/CLI_SPEC.md): it
+ * default-exports the `MCPServer` instance and never calls `listen()` itself
+ * — `mcp-use dev` and `mcp-use start` own the socket (and shutdown signals).
+ * The MCP protocol layer underneath stays stateless: every request builds a
+ * fresh SDK server from the tool/resource registry (see ../../../specs/SPEC.md).
+ * The process living across requests is purely a deployment convenience — no
+ * MCP session state lives in it, so any replica behind a load balancer can
+ * serve any request with no session affinity.
  */
 import { MCPServer } from "@mcp-use/server";
 import { z } from "zod";
@@ -122,24 +124,14 @@ server.resource(
   })
 );
 
-const port = Number(process.env.PORT ?? 3000);
-const started = await server.listen(port);
-
-// `listen()`'s returned url is always a localhost label, even when bound to
-// 0.0.0.0 for public serving — reconstruct the real public URL ourselves.
-const publicUrl = publicDomain ? `https://${publicDomain}${BASE_PATH}` : started.url;
-console.log(`MCP server listening on port ${started.port}`);
-console.log(`MCP endpoint: ${publicUrl}`);
-
-for (const signal of ["SIGINT", "SIGTERM"] as const) {
-  process.on(signal, () => {
-    console.log(`Received ${signal}, closing server...`);
-    server
-      .close()
-      .then(() => process.exit(0))
-      .catch((err: unknown) => {
-        console.error("Error during shutdown:", err);
-        process.exit(1);
-      });
-  });
+// On Railway, the service's public MCP endpoint is
+// `https://${RAILWAY_PUBLIC_DOMAIN}${BASE_PATH}` — `mcp-use start` logs the
+// local bind URL, and the edge terminates TLS in front of it.
+if (publicDomain !== undefined) {
+  console.log(`Public MCP endpoint: https://${publicDomain}${BASE_PATH}`);
 }
+
+// Entry contract (CLI_SPEC.md): export the server; never call listen() here.
+// `mcp-use dev`/`mcp-use start` bind the socket using this instance's config
+// (host, basePath) and handle SIGINT/SIGTERM shutdown.
+export default server;

--- a/libraries/typescript/packages/server/package.json
+++ b/libraries/typescript/packages/server/package.json
@@ -30,6 +30,9 @@
   },
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "bin": {
+    "mcp-use": "./dist/bin.js"
+  },
   "files": [
     "dist"
   ],
@@ -49,10 +52,20 @@
     "@modelcontextprotocol/server": "2.0.0-beta.2",
     "hono": "^4.12.27"
   },
+  "peerDependencies": {
+    "vite": "^8.0.0"
+  },
+  "peerDependenciesMeta": {
+    "vite": {
+      "optional": true
+    }
+  },
   "devDependencies": {
+    "@mcp-use/server": "workspace:*",
     "@modelcontextprotocol/client": "2.0.0-beta.2",
     "@types/node": "^24.13.2",
     "typescript": "7.0.1-rc",
+    "vite": "^8.0.16",
     "vitest": "^4.1.9",
     "zod": "^4.4.3"
   }

--- a/libraries/typescript/packages/server/specs/CLI_SPEC.md
+++ b/libraries/typescript/packages/server/specs/CLI_SPEC.md
@@ -86,6 +86,8 @@ Target user `package.json` shape:
 }
 ```
 
+**Self-referencing devDependency (in-repo testing only).** `packages/server/package.json` lists `"@mcp-use/server": "workspace:*"` in its own `devDependencies`. The CLI tests run the real `build`/`dev` pipeline against `tests/cli/fixtures/basic`, whose entry imports `@mcp-use/server` by its public name — the fixture stands in for a real user project, so it must exercise the same resolution path users hit. Node's own resolver would handle that via package self-reference (a package may import its own name through its `exports` map), but Vite/Rolldown's resolver and tsc's bundler mode don't implement self-reference, so inside this repo the name must physically exist in `node_modules` for the toolchain to resolve it. The self-dep makes pnpm create exactly that link (`node_modules/@mcp-use/server → ..`; pnpm accepts self-deps without complaint). It is invisible to consumers — installers ignore a dependency's `devDependencies` — and creates no build-graph cycle. Do not "fix" it by switching the fixture to a relative import (stops testing the user-facing path) or by adding a Vite `resolve.alias` in the test harness (bypasses the exact resolver behavior under test).
+
 ## Workspace layout (`.mcp-use/`)
 
 The build system keeps v1's reworked workspace convention **exactly** — it was deliberately redesigned just before this greenfield rewrite (see `packages/mcp-use/src/server/config/paths.ts`, `resolveWorkspacePaths`); do not invent a new layout. `.mcp-use/` is the per-project, fixed-convention, gitignored workspace — the `.next` analog. Everything tooling writes for a project lives under it, a checkout stays clean, and `rm -rf .mcp-use` is always safe:

--- a/libraries/typescript/packages/server/specs/CLI_SPEC.md
+++ b/libraries/typescript/packages/server/specs/CLI_SPEC.md
@@ -1,0 +1,190 @@
+# @mcp-use/server — build/dev/start CLI spec
+
+**Status:** Implemented (`build`/`dev`/`start` + inspector CDN shell; `examples/railway` migrated to the entry contract and verified end-to-end). Companion to `SPEC.md`; this document is the v2 build/dev/start contract (Linear MCP-2601). It records decisions already made — it is a contract, not an options memo.
+**Scope:** `mcp-use build`, `mcp-use dev`, `mcp-use start`, and Inspector mounting via CDN.
+**Packages:** a single package, `@mcp-use/server` — the bin, `start`, the inspector shell, *and* the `dev`/`build` toolchain (`src/cli/`), which the bin reaches only through a dynamic import (§ Package layout, below). There is no separate toolchain package; an earlier revision of this spec shipped one (provisionally named `@mcp-use/devkit`, at `packages/devkit`) and folded it back in — see "Why one package, not two" below. The old `packages/cli` stays untouched and green until cutover; nothing in it is ported wholesale.
+**v1 reference:** `packages/cli` defines *what* the commands must do for users, never how. The v1 dependency cycle (`mcp-use` `bin.ts` statically imported `@mcp-use/cli`, the CLI imported `mcp-use/config`, and all three packages — including inspector — declared each other as runtime workspace deps) is the anti-pattern this spec exists to make structurally impossible.
+
+## Goals
+
+- Installing `mcp-use` (plus `vite` as a devDependency) makes `"dev": "mcp-use dev"`, `"build": "mcp-use build"`, `"start": "mcp-use start"` work in a user's `package.json` scripts.
+- Production `mcp-use start` requires **zero** build-toolchain code — no vite, no cli chunk, nothing beyond `@mcp-use/server`'s own runtime deps.
+- Command implementations are lazy-loaded per subcommand; `start` never pays for `dev`/`build` machinery.
+- The inspector UI ships to users via CDN, not as a package dependency of anything.
+
+## Non-goals (this phase)
+
+- React/views and any client-side Vite environment (view bundling) — Phase 5 territory.
+- HMR of any kind, including server-side `list_changed` notification sync (see "Why no HMR" below). Dev reload here is **reload, not HMR**.
+- Typegen (watch-mode type generation is part of the Phase 5 dev contract, not this one).
+- Tunnel, deploy/cloud commands, project scaffolding.
+- Auth (`AUTH_SPEC.md` owns that; these commands neither add nor bypass it).
+
+## Entry contract
+
+The user's server entry module **default-exports the `MCPServer` instance and never calls `listen()` itself**:
+
+```ts
+// src/index.ts
+import { MCPServer } from "mcp-use";
+const server = new MCPServer({ name: "acme-tools", version: "1.0.0" });
+server.tool(/* … */);
+export default server;
+```
+
+`mcp-use dev` and `mcp-use start` own the socket. Serverless targets (Vercel, etc.) bypass the CLI entirely and wrap `server.getHandler()` in their own handler file — `examples/vercel` already matches this shape (module-scope server + `api/mcp.ts` wrapping `getHandler()`). `mcp-use build` is the blessed path for node deployments, but `package.json` scripts are user-owned; nothing enforces it.
+
+**Entry discovery:** conventional locations, first hit wins — `src/index.ts`, `src/server.ts`, `index.ts`, `server.ts` — overridable with `--entry <path>` on `dev` and `build`.
+
+Migration note: `examples/railway` has been migrated to the export-default shape (its platform door is `mcp-use build` + `mcp-use start`; host selection via `RAILWAY_PUBLIC_DOMAIN` stays constructor config on the server, which `dev`/`start` honor through `listen()`).
+
+## Package layout & dependency rules
+
+`@mcp-use/server` ships the bin:
+
+```jsonc
+// packages/server/package.json
+{ "bin": { "mcp-use": "./dist/bin.js" } }
+```
+
+`bin.ts` is tiny: it implements `start` **inline** (zero toolchain deps) and dispatches `dev` and `build` via **`await import("./cli/index.js")`** — a dynamic import of a sibling chunk *inside this same package*, built from `src/cli/*` as its own tsup entry (`dist/cli/index.js`, alongside `dist/index.js` and `dist/bin.js`; code-splitting is on specifically so this is a real separate file with a real dynamic import, not inlined into `dist/bin.js`). Nothing on the `start`/library import path (`dist/index.js`, and everything `dist/bin.js` reaches *without* going through that dynamic import) ever evaluates `src/cli/*` — and therefore never evaluates `vite`, which only `src/cli/build.ts` and `src/cli/dev.ts` import.
+
+`vite` is declared as an **optional peer dependency**:
+
+```jsonc
+// packages/server/package.json
+{
+  "peerDependencies": { "vite": "^8.0.0" },
+  "peerDependenciesMeta": { "vite": { "optional": true } }
+}
+```
+
+Rationale: npm 7+ auto-installs a package's *required* peer dependencies, which would drag vite into every production `npm i mcp-use` — exactly what the CLI-cycle rework is trying to avoid. Marking it `optional: true` in `peerDependenciesMeta` opts out of that auto-install, so a production install without `vite` in the user's own `devDependencies` stays lean; declaring it as a peer at all (rather than omitting it entirely) also gets the *version* resolved correctly under pnpm's isolated `node_modules` layout when it is present, instead of each consumer potentially resolving a different transitive copy. `vite` is never a regular dependency of `@mcp-use/server` — regular dependencies are always installed, defeating the point.
+
+When `vite` is missing, `src/cli/build.ts`/`src/cli/dev.ts`'s own `import { build } from "vite"` fails to resolve, and that rejection propagates up through the bin's `import("./cli/index.js")` call. The bin classifies it (`ERR_MODULE_NOT_FOUND` naming `'vite'`, via `isViteMissing` in `bin/main.ts`) and prints an actionable hint instead of a raw stack trace:
+
+```
+mcp-use dev requires Vite. Install it:
+  npm i -D vite
+```
+
+**Hard rule:** `@mcp-use/server` declares **no dependency of any kind** — regular, peer, or optional — on `@mcp-use/inspector`. The inspector is reached only over HTTP (below), never imported. There is a separate, narrower invariant for the toolchain now that it lives inside this package: `vite` must never become a regular dependency, and the `src/cli/*` chunk must never be reachable from the `start` command or from this package's `"."` library export — only from the bin's `dev`/`build` dispatch.
+
+**Why one package, not two.** An earlier revision of this spec shipped the toolchain as a separate `@mcp-use/devkit` package, reached via a `node_modules`-walking dynamic import resolved from the *user's* project (mirroring how a bare `import("@mcp-use/devkit")` inside `@mcp-use/server` could never succeed under pnpm's isolated installs, since the runtime package only sees its own declared deps). Ecosystem precedent settled on folding the toolchain into the main package instead: Astro/`skybridge`-style tools ship one core package with `vite` as a peer and `await import("vite")` internally; SvelteKit does the same (`vite` as a peer of `@sveltejs/kit`, not a separate kit-plus-vite-adapter split); Next.js ships one package and lazily imports each subcommand's machinery. Folding in gets the same "start pays nothing for the toolchain" property via a same-package dynamic import (verified structurally by the build output, not by hoping a separate package's resolution walk succeeds) while removing an entire package, its own dependency-direction rule, and its own release/version-matching surface. Ours differs from that precedent only in making the peer *optional* rather than required, for the auto-install reason above.
+
+Target user `package.json` shape:
+
+```jsonc
+{
+  "scripts": {
+    "dev": "mcp-use dev",
+    "build": "mcp-use build",
+    "start": "mcp-use start"
+  },
+  "dependencies": { "mcp-use": "^2" },
+  "devDependencies": { "vite": "^8" }
+}
+```
+
+## Workspace layout (`.mcp-use/`)
+
+The build system keeps v1's reworked workspace convention **exactly** — it was deliberately redesigned just before this greenfield rewrite (see `packages/mcp-use/src/server/config/paths.ts`, `resolveWorkspacePaths`); do not invent a new layout. `.mcp-use/` is the per-project, fixed-convention, gitignored workspace — the `.next` analog. Everything tooling writes for a project lives under it, a checkout stays clean, and `rm -rf .mcp-use` is always safe:
+
+```
+.mcp-use/
+├─ build/        ← compiled server + manifest.json (this spec)
+├─ generated/    ← typegen output (.d.ts) — reserved; Phase 5
+├─ cache/        ← disposable dev/build scratch (vite entries, metadata)
+├─ state/        ← mutable runtime state (e.g. tunnel state) — reserved; future
+└─ cloud/        ← cloud linkage (link.json) — reserved; future
+```
+
+This phase writes only `build/` (and may use `cache/`); `generated/`, `state/`, and `cloud/` are **reserved by convention now** so no tool squats on them before their phases land. v1's invariant carries over: `build/` contains no mutable runtime state (that is `state/`'s job), so build output stays reproducible and disposable.
+
+Rules, all inherited from v1 and locked:
+
+- **No config file.** There is deliberately no `mcp-use.json` and no `outDir` knob: runtime/project configuration lives on the `MCPServer` constructor (tooling reads it by importing the entry and introspecting the instance); the `.mcp-use/` layout is fixed convention, not configuration.
+- **Same names, re-declared.** The manifest basename is `manifest.json` (v1's `BUILD_MANIFEST_NAME`), the workspace dir `.mcp-use` (v1's `WORKSPACE_DIR_NAME`). `src/cli/workspace.ts` **re-declares** these constants itself — it must not import them from the old `mcp-use` package (no dependency on the old package).
+- **Per-project, not global.** `.mcp-use/` is distinct from the **global** `~/.mcp-use/` directory (CLI auth, credentials, per-user caches); nothing in this spec touches the global store.
+
+## Commands
+
+### `mcp-use build` (in `src/cli/build.ts`, dispatched from the bin)
+
+Vite build of the **SSR/node environment only** — no client environment exists yet (Phase 5 adds it for views). Rolldown/Vite emits the server bundle to `.mcp-use/build/` (workspace layout above) with `packages: "external"` semantics: dependencies stay external and resolve from `node_modules` at runtime; only the user's own source is bundled.
+
+Writes `.mcp-use/build/manifest.json` (v1's `BUILD_MANIFEST_NAME`, shape compatible in spirit with the v1 manifest):
+
+```jsonc
+{ "buildId": "…", "entryPoint": "index.js", "createdAt": "…", "inspector": true }
+```
+
+**No typecheck step in v0** — deliberate. Users run `tsc --noEmit` via their own script; the build is transpile-only and fast.
+
+### `mcp-use dev` (in `src/cli/dev.ts`, dispatched from the bin)
+
+A single long-lived process. It:
+
+1. Creates a Vite dev server (Environment API, node/SSR environment only) and loads the entry through the module runner.
+2. Grabs the default-exported `MCPServer`, wraps `server.getHandler()` behind an **atomically swappable reference**.
+3. Binds **one** `@hono/node-server` listener that delegates every request to the current handler.
+
+On file change: Vite invalidates, dev re-imports the entry through the runner, and swaps the handler reference. No registration diffing, no MCP notifications — the next request simply hits the new handler, which is correct by construction under the stateless model.
+
+- **Port:** `--port`, else `PORT` env, else `3000`; if taken, probe upward.
+- **Host:** `127.0.0.1` by default; `--host` to override (matching the server's own localhost-first posture, SPEC.md delta 5).
+- **Env:** `.env` loaded via Node's native `process.loadEnvFile()` (guarded by an `existsSync` check, since `loadEnvFile` throws on a missing file) before the entry is imported.
+- **Errors:** a throwing entry module keeps the *previous* handler alive and prints the error — the dev process never crashes on a bad save.
+
+### `mcp-use start` (inline in `@mcp-use/server` bin)
+
+1. Reads `.mcp-use/build/manifest.json`; if missing, an actionable error pointing at `mcp-use build`.
+2. Imports the built entry, takes the default export, serves it via `listen()`.
+3. **Port:** `--port` / `PORT` / `3000`. Sets `NODE_ENV=production`.
+
+Requires zero cli-chunk/vite/toolchain code — a production image needs only `mcp-use` and the app's own runtime deps.
+
+## Inspector mounting (FastAPI/Swagger-UI model)
+
+The inspector UI is **not a package dependency anywhere**. `@mcp-use/server` itself owns a tiny dependency-free HTML shell route — the exact analog of FastAPI's `get_swagger_ui_html` for `/docs`:
+
+- `GET ${basePath}/inspector` returns a small HTML page whose `<script type="module">` loads the inspector bundle from a CDN: a jsDelivr/unpkg URL for `@mcp-use/inspector`'s CDN bundle (`build:cdn` output, `dist/cdn/inspector.js` — a single self-contained ESM file), **pinned to a major version** so users get inspector updates without SDK bumps.
+- Config (autoConnect URL = the MCP endpoint at `basePath`, plus `basePath` itself) is passed via a serialized `window` global read by the bundle.
+
+`ServerConfig` gains:
+
+```ts
+inspector?: boolean | { assetsUrl?: string }; // default: enabled
+```
+
+Default **enabled**, mounted in both dev and production — like FastAPI's `/docs`; users set `inspector: false` to disable. Because the shell is just an HTML string with a CDN script tag, this does not violate the no-inspector-dependency rule.
+
+**Known limitation, recorded honestly** (Linear MCP-2075): the full v1 inspector also expects a backend proxy route; the CDN shell in this phase is browser-only and connects directly to the same-origin MCP endpoint. Acceptable for now — the current inspector may not fully support the v2 client protocol yet; "renders and connects" is the bar.
+
+## Offline & self-hosting
+
+- `inspector.assetsUrl` overrides the CDN base (FastAPI's `swagger_js_url` analog) — point it at a self-hosted copy of the bundle for air-gapped environments.
+- **Future (deferred, not v0):** `mcp-use dev` may detect a locally installed `@mcp-use/inspector` in the project's `node_modules` and serve its `dist/` from the dev server for fully-offline dev.
+- Browsers will serve the CDN bundle from HTTP cache after first load; that's best-effort, not the offline story.
+
+## Why no HMR & no `list_changed` sync
+
+v1's HMR stack — chokidar + tsx loaders + `syncRegistrationsFrom` + per-session `sendToolListChanged` over long-lived SSE — is deliberately **not ported**. v2 statelessness removes both halves of the problem it solved:
+
+- **The staleness problem is gone.** Every request builds a fresh server from current code (fresh-server-per-request, SPEC.md ground rules), so the next `tools/list` is always current. There is no long-lived server instance whose registrations could drift from disk.
+- **The delivery channel is gone.** No sessions and no SSE means there is nowhere to *send* a `list_changed` notification.
+
+Dev reload (the handler swap above) is reload, not HMR: no state is preserved across swaps because there is no state. A dev-only side-channel so an open inspector tab auto-refreshes after a swap is **future work** (below), not part of this contract.
+
+## Future (deferred)
+
+- Dev side-channel for inspector auto-refresh on handler swap.
+- Views + the client Vite environment (view bundling) — Phase 5.
+- Typegen (watch-mode regeneration in `dev`) — Phase 5 dev contract.
+- Local-inspector serving from `node_modules` for offline dev.
+- Tunnel; deploy/cloud commands.
+
+## Open questions
+
+- **Inspector proxy route.** The full inspector expects a backend proxy; deciding whether/where a v2 proxy route lives (server? cli chunk? inspector package serving itself?) is open — this phase ships the browser-only CDN shell.
+- **Production default for the inspector.** Default-on in production mirrors FastAPI `/docs`, but whether it should become dev-only-default before GA is undecided.

--- a/libraries/typescript/packages/server/specs/SPEC.md
+++ b/libraries/typescript/packages/server/specs/SPEC.md
@@ -98,6 +98,7 @@ server.prompt(
 
 await server.listen(3000);          // Node HTTP
 const fetch = server.getHandler();  // web-standard handler (edge/tests)
+server.basePath;                    // readonly accessor (default "/mcp") — lets tooling introspect the mount point
 ```
 
 Result model (raw wire shapes; see the no-response-helpers ground rule): tool callbacks return the SDK's `CallToolResult`, resource callbacks `ReadResourceResult` (each `contents` entry addresses itself with the read `uri` and carries its own `mimeType`; the definition's `mimeType` is listing metadata only), prompt callbacks `GetPromptResult` (`description` passes through verbatim — the definition's is not injected). `ToolResult<TOutput>` in `src/tools.ts` encodes the SDK's runtime rule at compile time: tools **without** an `outputSchema` accept any `CallToolResult`; tools **with** one must return `structuredContent` matching the schema's inferred type — any JSON root, per the 2026 wire — or set `isError: true` (the SDK exempts `isError` results from output validation; anything else without `structuredContent` throws at call time).

--- a/libraries/typescript/packages/server/src/bin.ts
+++ b/libraries/typescript/packages/server/src/bin.ts
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+/*
+ * `mcp-use` bin entry point (specs/CLI_SPEC.md).
+ *
+ * Kept to a single call so all logic lives in testable modules under
+ * src/bin/. On success the process is NOT exited: `start` (and `dev`) keep
+ * serving, and `--help`/`--version` let the event loop drain naturally.
+ */
+import { main } from "./bin/main.js";
+
+main(process.argv.slice(2)).then(
+  (code) => {
+    process.exitCode = code;
+  },
+  (error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+);

--- a/libraries/typescript/packages/server/src/bin/args.ts
+++ b/libraries/typescript/packages/server/src/bin/args.ts
@@ -1,0 +1,147 @@
+/**
+ * Hand-rolled argv parsing for the `mcp-use` bin.
+ *
+ * Deliberately dependency-free (no commander): the bin must add zero runtime
+ * dependencies to the package (see specs/CLI_SPEC.md, dependency rules).
+ */
+
+/**
+ * Result of parsing the `mcp-use` command line.
+ *
+ * @internal
+ */
+export interface ParsedArgs {
+  /** First positional argument — the subcommand — or `undefined` if none was given. */
+  command: string | undefined;
+  /** Value of `--port`/`-p`, or `undefined` if the flag was not passed. */
+  port: number | undefined;
+  /** Value of `--entry`, or `undefined` if the flag was not passed. */
+  entry: string | undefined;
+  /** Value of `--host`, or `undefined` if the flag was not passed. */
+  host: string | undefined;
+  /** Whether `--help`/`-h` was passed. */
+  help: boolean;
+  /** Whether `--version`/`-v` was passed. */
+  version: boolean;
+}
+
+/**
+ * Parse the `mcp-use` argv (everything after the node binary and script path).
+ *
+ * Supports `--flag value` and `--flag=value` forms. The first bare token is
+ * taken as the subcommand.
+ *
+ * @param argv - Raw arguments, typically `process.argv.slice(2)`.
+ * @throws Error on an unknown flag, a missing flag value, an out-of-range
+ * port, or a second positional argument.
+ *
+ * @internal
+ */
+export function parseArgs(argv: readonly string[]): ParsedArgs {
+  const args: ParsedArgs = {
+    command: undefined,
+    port: undefined,
+    entry: undefined,
+    host: undefined,
+    help: false,
+    version: false,
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i];
+    if (token === undefined) continue;
+
+    // Split `--flag=value` into flag + inline value.
+    let flag = token;
+    let inline: string | undefined;
+    if (token.startsWith("--")) {
+      const eq = token.indexOf("=");
+      if (eq !== -1) {
+        flag = token.slice(0, eq);
+        inline = token.slice(eq + 1);
+      }
+    }
+
+    /** Consume the flag's value: inline (`=`) or the next argv token. */
+    const takeValue = (): string => {
+      if (inline !== undefined) return inline;
+      const next = argv[++i];
+      if (next === undefined || next.startsWith("-")) {
+        throw new Error(`Missing value for ${flag}`);
+      }
+      return next;
+    };
+
+    switch (flag) {
+      case "-h":
+      case "--help":
+        args.help = true;
+        break;
+      case "-v":
+      case "--version":
+        args.version = true;
+        break;
+      case "-p":
+      case "--port":
+        args.port = parsePort(takeValue());
+        break;
+      case "--entry":
+        args.entry = takeValue();
+        break;
+      case "--host":
+        args.host = takeValue();
+        break;
+      default:
+        if (flag.startsWith("-")) {
+          throw new Error(`Unknown option: ${flag}`);
+        }
+        if (args.command !== undefined) {
+          throw new Error(`Unexpected argument: ${flag}`);
+        }
+        args.command = flag;
+    }
+  }
+
+  return args;
+}
+
+/**
+ * Resolve the port `mcp-use start` serves on.
+ *
+ * Precedence: `--port` flag, then the `PORT` environment variable, then
+ * `3000`. A `PORT` value that is not a valid port number is ignored (the
+ * default applies); an invalid `--port` flag has already been rejected by
+ * {@link parseArgs}.
+ *
+ * @param flagPort - Port from the `--port`/`-p` flag, if given.
+ * @param env - Environment to read `PORT` from.
+ * @defaultValue `env` defaults to `process.env`.
+ *
+ * @internal
+ */
+export function resolvePort(
+  flagPort: number | undefined,
+  env: Readonly<Record<string, string | undefined>> = process.env
+): number {
+  if (flagPort !== undefined) return flagPort;
+  const raw = env.PORT;
+  if (raw !== undefined && raw.trim() !== "") {
+    const port = Number(raw);
+    if (isValidPort(port)) return port;
+  }
+  return 3000;
+}
+
+/** Parse a `--port` value, rejecting anything that is not a valid port. */
+function parsePort(value: string): number {
+  const port = Number(value);
+  if (!isValidPort(port)) {
+    throw new Error(`Invalid port: ${value}`);
+  }
+  return port;
+}
+
+/** Whether a number is a bindable TCP port (0 = ephemeral). */
+function isValidPort(port: number): boolean {
+  return Number.isInteger(port) && port >= 0 && port <= 65535;
+}

--- a/libraries/typescript/packages/server/src/bin/main.ts
+++ b/libraries/typescript/packages/server/src/bin/main.ts
@@ -1,0 +1,204 @@
+/**
+ * Command dispatch for the `mcp-use` bin (specs/CLI_SPEC.md).
+ *
+ * `start` is implemented inline (zero toolchain deps); `dev` and `build` are
+ * dispatched via a dynamic `import("../cli/index.js")` — the sibling
+ * `dist/cli/index.js` chunk built from `src/cli/*` (its own tsup
+ * entry). The import is dynamic, not static, so `start` and every other path
+ * through this file never evaluate cli code — and therefore never
+ * evaluate `vite`, which the cli chunk imports.
+ *
+ * `vite` is an *optional* peer dependency of this package (never a regular
+ * dependency): npm/pnpm do not auto-install optional peers, so a production
+ * `npm i mcp-use` stays lean. When it is missing, the cli chunk's own
+ * `import("vite")` (in `cli/build.ts`/`cli/dev.ts`) rejects with
+ * `ERR_MODULE_NOT_FOUND`, which propagates here and is classified by
+ * {@link isViteMissing} into the actionable install hint below.
+ */
+import { readFileSync } from "node:fs";
+
+import { parseArgs, type ParsedArgs } from "./args.js";
+import { runStart } from "./start.js";
+
+/**
+ * Options this bin passes to the cli's `runDev`/`runBuild`.
+ *
+ * @internal
+ */
+export interface CliCommandOptions {
+  /** Project root the command operates on (`process.cwd()`). */
+  cwd: string;
+  /** Server entry module override (`--entry`). */
+  entry?: string;
+  /** Port override (`--port`/`-p`). */
+  port?: number;
+  /** Host override (`--host`). */
+  host?: string;
+}
+
+/** The subset of the cli chunk's exports this bin calls. */
+interface CliModule {
+  runDev(options: CliCommandOptions): Promise<void>;
+  runBuild(options: CliCommandOptions): Promise<void>;
+}
+
+const HELP = `mcp-use — run MCP servers built with mcp-use
+
+Usage: mcp-use <command> [options]
+
+Commands:
+  dev      Start the dev server (requires vite)
+  build    Build the server into .mcp-use/build (requires vite)
+  start    Serve the production build from .mcp-use/build
+
+Options:
+  -p, --port <n>     Port to serve on (default: $PORT or 3000)
+  --host <host>      Host to bind (dev only)
+  --entry <path>     Server entry module (dev/build only)
+  -h, --help         Show this help
+  -v, --version      Print the version`;
+
+/**
+ * Run the `mcp-use` CLI.
+ *
+ * @param argv - Raw arguments, typically `process.argv.slice(2)`.
+ * @returns The process exit code. A `0` from `start`/`dev` means the command
+ * launched successfully and the process should stay alive serving.
+ *
+ * @internal
+ */
+export async function main(argv: readonly string[]): Promise<number> {
+  let args: ParsedArgs;
+  try {
+    args = parseArgs(argv);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+
+  if (args.version) {
+    console.log(readOwnVersion());
+    return 0;
+  }
+  if (args.help) {
+    console.log(HELP);
+    return 0;
+  }
+
+  switch (args.command) {
+    case "start":
+      return startCommand(args);
+    case "dev":
+    case "build":
+      return cliCommand(args.command, args);
+    case undefined:
+      console.error(HELP);
+      return 1;
+    default:
+      console.error(`Unknown command: ${args.command}\n\n${HELP}`);
+      return 1;
+  }
+}
+
+/** `mcp-use start`: serve the production build, wire shutdown signals. */
+async function startCommand(args: ParsedArgs): Promise<number> {
+  let started;
+  try {
+    started = await runStart({ cwd: process.cwd(), port: args.port });
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+
+  console.log(`mcp-use server running at ${started.url}`);
+
+  const shutdown = (): void => {
+    started.close().then(
+      () => process.exit(0),
+      (error: unknown) => {
+        console.error(error instanceof Error ? error.message : String(error));
+        process.exit(1);
+      }
+    );
+  };
+  process.once("SIGINT", shutdown);
+  process.once("SIGTERM", shutdown);
+  return 0;
+}
+
+/** `mcp-use dev` / `mcp-use build`: dispatch to the cli chunk. */
+async function cliCommand(
+  command: "dev" | "build",
+  args: ParsedArgs
+): Promise<number> {
+  const options: CliCommandOptions = {
+    cwd: process.cwd(),
+    ...(args.entry !== undefined && { entry: args.entry }),
+    ...(args.port !== undefined && { port: args.port }),
+    ...(args.host !== undefined && { host: args.host }),
+  };
+
+  try {
+    const cli = (await import("../cli/index.js")) as CliModule;
+    if (command === "dev") {
+      await cli.runDev(options);
+    } else {
+      await cli.runBuild(options);
+    }
+    return 0;
+  } catch (error) {
+    if (isViteMissing(error)) {
+      console.error(
+        `mcp-use ${command} requires Vite. Install it:\n  npm i -D vite`
+      );
+      return 1;
+    }
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+}
+
+/**
+ * Whether `error` is Node's module-resolution failure for the missing,
+ * optional `vite` peer dependency, as opposed to any other failure raised
+ * while running `dev`/`build` (a bad entry, a Vite build error, …).
+ *
+ * A missing `vite` surfaces as `ERR_MODULE_NOT_FOUND` naming `'vite'` — the
+ * cli chunk's own `import("vite")` rejects before its `runDev`/`runBuild`
+ * ever runs, and that rejection propagates through the dynamic
+ * `import("../cli/index.js")` in {@link cliCommand} unchanged.
+ *
+ * @param error - The value caught around the cli dispatch.
+ *
+ * @internal
+ */
+export function isViteMissing(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const code = (error as NodeJS.ErrnoException).code;
+  return code === "ERR_MODULE_NOT_FOUND" && error.message.includes("'vite'");
+}
+
+/**
+ * Read this package's own version for `--version`.
+ *
+ * Probes both layouts — `dist/bin.js` (bundled, package root is one level
+ * up) and `src/bin/main.ts` (tests, package root is two levels up) — and
+ * verifies the manifest's `name` so an unrelated package.json never wins.
+ */
+function readOwnVersion(): string {
+  for (const relative of ["../package.json", "../../package.json"]) {
+    try {
+      const raw = readFileSync(new URL(relative, import.meta.url), "utf8");
+      const pkg = JSON.parse(raw) as { name?: unknown; version?: unknown };
+      if (
+        (pkg.name === "@mcp-use/server" || pkg.name === "mcp-use") &&
+        typeof pkg.version === "string"
+      ) {
+        return pkg.version;
+      }
+    } catch {
+      // Not there or unreadable — try the next candidate.
+    }
+  }
+  return "unknown";
+}

--- a/libraries/typescript/packages/server/src/bin/start.ts
+++ b/libraries/typescript/packages/server/src/bin/start.ts
@@ -1,0 +1,150 @@
+/**
+ * Inline implementation of `mcp-use start` (specs/CLI_SPEC.md).
+ *
+ * Serves a production build from `.mcp-use/build/` with zero toolchain
+ * dependencies: read the manifest, import the built entry, call `listen()`
+ * on its default-exported server.
+ */
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { resolvePort } from "./args.js";
+
+/*
+ * Workspace constants, re-declared per CLI_SPEC.md ("Same names,
+ * re-declared") — never imported from the old `mcp-use` package.
+ */
+const WORKSPACE_DIR_NAME = ".mcp-use";
+const BUILD_SUBDIR_NAME = "build";
+const BUILD_MANIFEST_NAME = "manifest.json";
+
+/**
+ * The duck-typed contract `start` needs from the built entry's default
+ * export — satisfied by an `MCPServer` instance. Checked at runtime, not by
+ * an `instanceof`, so a build made against a different copy of the package
+ * still starts.
+ */
+interface ListenableServer {
+  listen(port?: number): Promise<unknown>;
+  close?(): unknown;
+}
+
+/**
+ * Options for {@link runStart}.
+ *
+ * @internal
+ */
+export interface StartOptions {
+  /** Project root containing the `.mcp-use/` workspace. */
+  cwd: string;
+  /** Port from the `--port`/`-p` flag; falls back to `PORT` env, then 3000. */
+  port?: number | undefined;
+}
+
+/**
+ * Handle to a server started by {@link runStart}.
+ *
+ * @internal
+ */
+export interface StartedServer {
+  /** Port the server reported it bound. */
+  port: number;
+  /** URL of the MCP endpoint, as reported by the server's `listen()`. */
+  url: string;
+  /** Stop the server (delegates to the instance's `close()`, if present). */
+  close(): Promise<void>;
+}
+
+/**
+ * Run `mcp-use start`: serve the production build under
+ * `<cwd>/.mcp-use/build/`.
+ *
+ * Reads the build manifest, sets `NODE_ENV=production` (only if unset),
+ * imports the built entry, and calls `listen()` on its default export.
+ *
+ * @param options - Project root and optional port override.
+ * @throws Error with an actionable message when the manifest is missing
+ * (pointing at `mcp-use build`), malformed, or the entry's default export is
+ * not a server.
+ *
+ * @internal
+ */
+export async function runStart(options: StartOptions): Promise<StartedServer> {
+  const buildDir = join(options.cwd, WORKSPACE_DIR_NAME, BUILD_SUBDIR_NAME);
+  const manifestPath = join(buildDir, BUILD_MANIFEST_NAME);
+
+  let rawManifest: string;
+  try {
+    rawManifest = await readFile(manifestPath, "utf8");
+  } catch {
+    throw new Error(
+      `No production build found (missing ${manifestPath}).\n` +
+        `Run \`mcp-use build\` first, then \`mcp-use start\`.`
+    );
+  }
+
+  let entryPoint: string;
+  try {
+    const manifest = JSON.parse(rawManifest) as { entryPoint?: unknown };
+    if (typeof manifest.entryPoint !== "string" || manifest.entryPoint === "") {
+      throw new Error("missing entryPoint");
+    }
+    entryPoint = manifest.entryPoint;
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Invalid build manifest at ${manifestPath} (${reason}).\n` +
+        `Re-run \`mcp-use build\`.`
+    );
+  }
+
+  // Production posture, but never clobber an explicit NODE_ENV.
+  process.env.NODE_ENV ??= "production";
+
+  const entryPath = join(buildDir, entryPoint);
+  const entryUrl = pathToFileURL(entryPath).href;
+  const entryModule = (await import(entryUrl)) as { default?: unknown };
+
+  if (!("default" in entryModule) || entryModule.default === undefined) {
+    throw new Error(
+      `The built entry (${entryPath}) has no default export.\n` +
+        `The server entry must \`export default\` its MCPServer instance ` +
+        `(see the mcp-use entry contract).`
+    );
+  }
+  const candidate = entryModule.default;
+  if (!isListenable(candidate)) {
+    throw new Error(
+      `The default export of ${entryPath} is not an MCPServer: it has no ` +
+        `listen() method. Export the MCPServer instance as the default export.`
+    );
+  }
+
+  const port = resolvePort(options.port);
+  const result = (await candidate.listen(port)) as
+    | { port?: unknown; url?: unknown }
+    | undefined;
+  const boundPort = typeof result?.port === "number" ? result.port : port;
+  const url =
+    typeof result?.url === "string"
+      ? result.url
+      : `http://localhost:${boundPort}`;
+
+  return {
+    port: boundPort,
+    url,
+    close: async () => {
+      await candidate.close?.();
+    },
+  };
+}
+
+/** Duck-check that a value looks like a server we can `listen()` on. */
+function isListenable(value: unknown): value is ListenableServer {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { listen?: unknown }).listen === "function"
+  );
+}

--- a/libraries/typescript/packages/server/src/cli/build.ts
+++ b/libraries/typescript/packages/server/src/cli/build.ts
@@ -1,0 +1,116 @@
+/**
+ * `mcp-use build` — Vite SSR/node build of the user's server entry into the
+ * `.mcp-use/build/` workspace directory (CLI_SPEC.md § Commands → build).
+ *
+ * `vite` is an optional peer dependency of `@mcp-use/server` (never a regular
+ * dependency): this module is only ever reached through the bin's dynamic
+ * `import("./cli/index.js")`, so a missing install surfaces as a rejected
+ * promise there (classified by `bin/main.ts`'s `isViteMissing`), not at
+ * package load time.
+ */
+
+import { randomBytes } from "node:crypto";
+import { mkdir, writeFile } from "node:fs/promises";
+import { relative } from "node:path";
+import { build } from "vite";
+
+import { discoverEntry } from "./entry.js";
+import {
+  resolveWorkspacePaths,
+  type BuildManifest,
+} from "./workspace.js";
+
+/** Fixed filename of the emitted server entry inside `.mcp-use/build/`. */
+const BUILD_ENTRY_NAME = "index.js";
+
+/**
+ * Options for {@link runBuild}.
+ *
+ * @internal
+ */
+export interface BuildOptions {
+  /** Absolute path to the project root (the directory containing the entry). */
+  cwd: string;
+  /**
+   * Explicit entry path (the `--entry` flag), absolute or relative to `cwd`.
+   *
+   * @defaultValue Conventional discovery: `src/index.ts`, `src/server.ts`,
+   * `index.ts`, `server.ts` — first hit wins.
+   */
+  entry?: string;
+}
+
+/**
+ * Build the project's server for production: a Vite build of the SSR/node
+ * environment only (no client environment exists in this phase), emitted as
+ * ESM to `.mcp-use/build/` with a `manifest.json` alongside it.
+ *
+ * Dependencies stay external (`packages: "external"` semantics): only the
+ * user's own source is bundled; every bare import resolves from
+ * `node_modules` at runtime. The built entry preserves the default export
+ * (the `MCPServer` instance) so `mcp-use start` can import and serve it.
+ *
+ * There is deliberately no typecheck step — the build is transpile-only;
+ * users run `tsc --noEmit` via their own script.
+ *
+ * @param options - Project root and optional entry override.
+ * @throws If no entry is found (see {@link discoverEntry}), or if `vite` is
+ * not installed (`mcp-use build` requires it as a devDependency) — the
+ * `import("vite")` rejection propagates to the bin's dispatch boundary,
+ * which classifies it and prints the install hint.
+ *
+ * @internal Reached only via the bin's `import("./cli/index.js")`
+ * dispatch (`bin/main.ts`) — not re-exported from the package's "." entry.
+ */
+export async function runBuild(options: BuildOptions): Promise<void> {
+  const startedAt = performance.now();
+  const entry = discoverEntry(options.cwd, options.entry);
+  const paths = resolveWorkspacePaths(options.cwd);
+
+  await build({
+    root: options.cwd,
+    configFile: false,
+    envFile: false,
+    logLevel: "warn",
+    cacheDir: paths.cache,
+    build: {
+      // SSR/node build of the entry only — no client environment.
+      ssr: entry,
+      outDir: paths.build,
+      emptyOutDir: true,
+      target: "node24",
+      sourcemap: true,
+      minify: false,
+      rollupOptions: {
+        output: {
+          format: "es",
+          entryFileNames: BUILD_ENTRY_NAME,
+        },
+      },
+    },
+    ssr: {
+      // Externalize ALL bare imports (including linked workspace packages):
+      // the user's source is bundled, node_modules resolve at runtime.
+      external: true,
+      target: "node",
+    },
+  });
+
+  const manifest: BuildManifest = {
+    buildId: randomBytes(8).toString("hex"),
+    entryPoint: BUILD_ENTRY_NAME,
+    createdAt: new Date().toISOString(),
+    inspector: true,
+  };
+  await mkdir(paths.build, { recursive: true });
+  await writeFile(
+    paths.buildManifest,
+    `${JSON.stringify(manifest, null, 2)}\n`
+  );
+
+  const duration = Math.round(performance.now() - startedAt);
+  console.log(
+    `[mcp-use] built ${relative(options.cwd, entry)} → ` +
+      `${relative(options.cwd, paths.build)}/${BUILD_ENTRY_NAME} (${duration}ms)`
+  );
+}

--- a/libraries/typescript/packages/server/src/cli/dev.ts
+++ b/libraries/typescript/packages/server/src/cli/dev.ts
@@ -1,0 +1,283 @@
+/**
+ * `mcp-use dev` — a single long-lived dev process (CLI_SPEC.md § Commands →
+ * dev): a Vite dev server (Environment API, node/SSR environment only) loads
+ * the entry through the module runner; one HTTP listener delegates every
+ * request to an atomically swappable handler reference.
+ *
+ * Reload, not HMR: on file change the entry is re-imported and the handler
+ * reference swapped — no registration diffing, no MCP notifications. Under
+ * the stateless model the next request simply hits the new handler.
+ *
+ * `vite` is an optional peer dependency of `@mcp-use/server` (never a regular
+ * dependency): this module is only ever reached through the bin's dynamic
+ * `import("./cli/index.js")`, so a missing install surfaces as a rejected
+ * promise there (classified by `bin/main.ts`'s `isViteMissing`), not at
+ * package load time.
+ */
+
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { createServer, createServerModuleRunner } from "vite";
+import { serve } from "@hono/node-server";
+
+import { discoverEntry } from "./entry.js";
+import { resolvePort } from "./port.js";
+import { resolveWorkspacePaths } from "./workspace.js";
+
+/** Web-standard request handler, as returned by `MCPServer.getHandler()`. */
+type FetchHandler = (request: Request) => Promise<Response>;
+
+/**
+ * The duck-typed shape the entry's default export must satisfy: an
+ * `MCPServer` instance (checked structurally so the runner may load its own
+ * copy of `@mcp-use/server`).
+ */
+interface ServerLike {
+  getHandler(): FetchHandler;
+  /** URL path prefix the MCP endpoint is mounted at (default `"/mcp"`). */
+  readonly basePath?: string;
+}
+
+/**
+ * Options for {@link runDev}.
+ *
+ * @internal
+ */
+export interface DevOptions {
+  /** Absolute path to the project root. */
+  cwd: string;
+  /**
+   * Explicit entry path (the `--entry` flag), absolute or relative to `cwd`.
+   *
+   * @defaultValue Conventional discovery: `src/index.ts`, `src/server.ts`,
+   * `index.ts`, `server.ts` — first hit wins.
+   */
+  entry?: string;
+  /**
+   * Preferred port. When taken, the next free port upward is used (and the
+   * substitution logged).
+   *
+   * @defaultValue The `PORT` environment variable, else `3000`.
+   */
+  port?: number;
+  /**
+   * Host to bind.
+   *
+   * @defaultValue `"127.0.0.1"` (matching the server's localhost-first posture).
+   */
+  host?: string;
+  /**
+   * Abort signal for embedding and tests: aborting shuts the dev process
+   * down gracefully (same path as SIGINT/SIGTERM). The CLI itself does not
+   * pass this.
+   */
+  signal?: AbortSignal;
+}
+
+/**
+ * Validate the entry module's default export and return it as a
+ * {@link ServerLike}.
+ */
+function serverFrom(moduleExports: Record<string, unknown>): ServerLike {
+  const server = moduleExports["default"];
+  if (server === null || typeof server !== "object") {
+    throw new Error(
+      "The server entry must default-export the MCPServer instance " +
+        "(`export default server`) and never call listen() itself — " +
+        "`mcp-use dev` owns the socket."
+    );
+  }
+  const candidate = server as Partial<ServerLike>;
+  if (typeof candidate.getHandler !== "function") {
+    throw new Error(
+      "The entry's default export has no getHandler() — it must be the " +
+        "MCPServer instance (`export default server`)."
+    );
+  }
+  return candidate as ServerLike;
+}
+
+/**
+ * Run the dev server: import the entry through Vite's module runner (full
+ * TS/alias support), serve `server.getHandler()` on one long-lived HTTP
+ * listener, and swap the handler on file change.
+ *
+ * A throwing re-import keeps the previous handler alive and prints the error
+ * — the dev process never crashes on a bad save. `.env` (if present) is
+ * loaded from `cwd` via `process.loadEnvFile()` before the entry is first
+ * imported.
+ *
+ * The returned promise resolves after a graceful shutdown (SIGINT/SIGTERM or
+ * `options.signal` aborting).
+ *
+ * @param options - Project root, optional entry override, port and host.
+ * @throws If no entry is found, if the initial import fails, if the entry's
+ * default export is not an `MCPServer` (see the entry contract in
+ * CLI_SPEC.md), or if `vite` is not installed (`mcp-use dev` requires it as a
+ * devDependency).
+ *
+ * @internal Reached only via the bin's `import("./cli/index.js")`
+ * dispatch (`bin/main.ts`) — not re-exported from the package's "." entry.
+ */
+export async function runDev(options: DevOptions): Promise<void> {
+  const host = options.host ?? "127.0.0.1";
+  const paths = resolveWorkspacePaths(options.cwd);
+
+  // Load .env before the entry is imported so module-scope code sees it.
+  // `loadEnvFile` throws ENOENT when the file is missing, unlike dotenv's
+  // silent no-op — guard explicitly to preserve that behavior.
+  const envPath = join(options.cwd, ".env");
+  if (existsSync(envPath)) {
+    process.loadEnvFile(envPath);
+  }
+
+  const entry = discoverEntry(options.cwd, options.entry);
+
+  const vite = await createServer({
+    root: options.cwd,
+    configFile: false,
+    envFile: false,
+    logLevel: "warn",
+    cacheDir: paths.cache,
+    server: {
+      // We never use Vite's HTTP server; middleware mode keeps it unbound.
+      middlewareMode: true,
+      // Reload, not HMR (CLI_SPEC.md § Why no HMR).
+      hmr: false,
+    },
+    ssr: {
+      // Match the build: every bare import resolves from node_modules.
+      external: true,
+    },
+  });
+
+  const environment = vite.environments.ssr;
+  const runner = createServerModuleRunner(environment, {
+    hmr: false,
+    sourcemapInterceptor: "node",
+  });
+
+  const importServer = async (): Promise<ServerLike> =>
+    serverFrom(await runner.import(entry));
+
+  // Initial import must succeed — fail loudly before binding the socket.
+  let currentHandler: FetchHandler;
+  let basePath: string;
+  try {
+    const server = await importServer();
+    currentHandler = server.getHandler();
+    basePath = server.basePath ?? "/mcp";
+  } catch (error) {
+    await runner.close();
+    await vite.close();
+    throw error;
+  }
+
+  // --- Reload on file change (serialized; a failed reload keeps the old
+  // handler; changes during a reload trigger one follow-up pass). -----------
+  let reloading = false;
+  let dirty = false;
+  const reload = (): void => {
+    if (reloading) {
+      dirty = true;
+      return;
+    }
+    reloading = true;
+    void (async () => {
+      do {
+        dirty = false;
+        try {
+          // Drop every evaluated module so the re-import sees current code
+          // (the server-side transform cache was already invalidated by the
+          // watcher); then swap the handler reference atomically.
+          runner.evaluatedModules.clear();
+          const server = await importServer();
+          currentHandler = server.getHandler();
+          basePath = server.basePath ?? "/mcp";
+          console.log("[mcp-use] reloaded server entry");
+        } catch (error) {
+          console.error(
+            "[mcp-use] reload failed — keeping the previous server:\n",
+            error
+          );
+        }
+      } while (dirty);
+      reloading = false;
+    })();
+  };
+
+  const onFileEvent = (file: string): void => {
+    // Only files in the entry's module graph matter (the watcher also sees
+    // unrelated project files).
+    const modules = environment.moduleGraph.getModulesByFile(file);
+    if (modules === undefined || modules.size === 0) {
+      return;
+    }
+    for (const mod of modules) {
+      environment.moduleGraph.invalidateModule(mod);
+    }
+    reload();
+  };
+  vite.watcher.on("change", onFileEvent);
+  vite.watcher.on("add", onFileEvent);
+  vite.watcher.on("unlink", onFileEvent);
+
+  // --- One long-lived HTTP listener delegating to the current handler. -----
+  const requestedPort =
+    options.port ??
+    (process.env["PORT"] !== undefined
+      ? Number.parseInt(process.env["PORT"], 10)
+      : 3000);
+  const { port, requested } = await resolvePort(requestedPort, host);
+  if (port !== requested) {
+    console.log(`[mcp-use] port ${requested} is taken, using ${port}`);
+  }
+
+  const httpServer = await new Promise<ReturnType<typeof serve>>(
+    (resolve, reject) => {
+      const server = serve(
+        {
+          fetch: (request: Request) => currentHandler(request),
+          port,
+          hostname: host,
+        },
+        () => resolve(server)
+      );
+      server.once("error", reject);
+    }
+  );
+
+  // basePath was introspected from the loaded MCPServer instance above.
+  console.log(`[mcp-use] dev server ready`);
+  console.log(`  ➜ MCP endpoint:  http://localhost:${port}${basePath}`);
+  console.log(`  ➜ Inspector:     http://localhost:${port}${basePath}/inspector`);
+
+  // --- Graceful shutdown (SIGINT/SIGTERM or options.signal). ---------------
+  await new Promise<void>((resolve) => {
+    let closing = false;
+    const shutdown = (): void => {
+      if (closing) return;
+      closing = true;
+      process.off("SIGINT", shutdown);
+      process.off("SIGTERM", shutdown);
+      void (async () => {
+        vite.watcher.off("change", onFileEvent);
+        vite.watcher.off("add", onFileEvent);
+        vite.watcher.off("unlink", onFileEvent);
+        await new Promise<void>((done) => httpServer.close(() => done()));
+        await runner.close();
+        await vite.close();
+        resolve();
+      })();
+    };
+    process.on("SIGINT", shutdown);
+    process.on("SIGTERM", shutdown);
+    if (options.signal !== undefined) {
+      if (options.signal.aborted) {
+        shutdown();
+      } else {
+        options.signal.addEventListener("abort", shutdown, { once: true });
+      }
+    }
+  });
+}

--- a/libraries/typescript/packages/server/src/cli/entry.ts
+++ b/libraries/typescript/packages/server/src/cli/entry.ts
@@ -1,0 +1,62 @@
+/**
+ * Server-entry discovery for `mcp-use build` and `mcp-use dev`.
+ *
+ * The entry contract (CLI_SPEC.md): the user's entry module default-exports
+ * the `MCPServer` instance and never calls `listen()` itself — the CLI owns
+ * the socket.
+ */
+
+import { existsSync } from "node:fs";
+import { isAbsolute, join, resolve } from "node:path";
+
+/**
+ * Conventional entry locations, checked in order relative to the project
+ * root; the first existing file wins.
+ *
+ * @internal
+ */
+export const ENTRY_CANDIDATES = [
+  "src/index.ts",
+  "src/server.ts",
+  "index.ts",
+  "server.ts",
+] as const;
+
+/**
+ * Locate the server entry for a project.
+ *
+ * With `override` set (the `--entry` flag), the path is resolved against
+ * `cwd` and must exist. Otherwise the {@link ENTRY_CANDIDATES} are probed in
+ * order and the first hit wins.
+ *
+ * @param cwd - Absolute path to the project root.
+ * @param override - Explicit entry path (`--entry`), absolute or relative to `cwd`.
+ * @returns Absolute path to the entry file.
+ * @throws If the override does not exist, or no conventional candidate is
+ * found — the error lists every location that was checked.
+ *
+ * @internal
+ */
+export function discoverEntry(cwd: string, override?: string): string {
+  if (override !== undefined) {
+    const entry = isAbsolute(override) ? override : resolve(cwd, override);
+    if (!existsSync(entry)) {
+      throw new Error(
+        `Entry not found: ${entry} (from --entry "${override}")`
+      );
+    }
+    return entry;
+  }
+  for (const candidate of ENTRY_CANDIDATES) {
+    const entry = join(cwd, candidate);
+    if (existsSync(entry)) {
+      return entry;
+    }
+  }
+  throw new Error(
+    `No server entry found in ${cwd}. Looked for: ` +
+      `${ENTRY_CANDIDATES.join(", ")}. ` +
+      `Create one of these (default-exporting your MCPServer instance) ` +
+      `or pass --entry <path>.`
+  );
+}

--- a/libraries/typescript/packages/server/src/cli/index.ts
+++ b/libraries/typescript/packages/server/src/cli/index.ts
@@ -1,0 +1,25 @@
+/**
+ * The `mcp-use` dev/build toolchain, built on Vite.
+ *
+ * Implements `mcp-use build` and `mcp-use dev`; `src/bin/main.ts` dispatches
+ * to {@link runBuild} and {@link runDev} via a dynamic `import("./cli/index.js")`
+ * so nothing on the `start`/library import path ever evaluates this module
+ * (and therefore never evaluates Vite — see `specs/CLI_SPEC.md` § Package
+ * layout & dependency rules). `vite` itself is an optional peer dependency:
+ * it is imported lazily inside {@link runBuild}/{@link runDev} so a missing
+ * install fails with an actionable hint instead of at module load time.
+ *
+ * @packageDocumentation
+ */
+
+export { runBuild, type BuildOptions } from "./build.js";
+export { runDev, type DevOptions } from "./dev.js";
+export { discoverEntry, ENTRY_CANDIDATES } from "./entry.js";
+export { resolvePort, type ResolvedPort } from "./port.js";
+export {
+  BUILD_MANIFEST_NAME,
+  WORKSPACE_DIR_NAME,
+  resolveWorkspacePaths,
+  type BuildManifest,
+  type WorkspacePaths,
+} from "./workspace.js";

--- a/libraries/typescript/packages/server/src/cli/port.ts
+++ b/libraries/typescript/packages/server/src/cli/port.ts
@@ -1,0 +1,60 @@
+/**
+ * Port resolution for `mcp-use dev`: `--port`, else `PORT` env, else 3000 — probing
+ * upward when the requested port is taken.
+ */
+
+import { createServer } from "node:net";
+
+/** How many consecutive ports to probe before giving up. */
+const MAX_PROBES = 100;
+
+/**
+ * Outcome of {@link resolvePort}.
+ *
+ * @internal
+ */
+export interface ResolvedPort {
+  /** The free port to bind. */
+  port: number;
+  /** The port that was originally requested (differs when probing moved on). */
+  requested: number;
+}
+
+/** Check whether `port` is free to bind on `host`. */
+function isPortFree(port: number, host: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const probe = createServer();
+    probe.unref();
+    probe.once("error", () => resolve(false));
+    probe.listen({ port, host }, () => {
+      probe.close(() => resolve(true));
+    });
+  });
+}
+
+/**
+ * Resolve the port to bind: take `requested` (already reduced from
+ * `--port` / `PORT` / the default by the caller) and probe upward until a
+ * free port is found.
+ *
+ * @param requested - The preferred port.
+ * @param host - The host the server will bind (probing binds the same host).
+ * @returns The first free port at or above `requested`, plus the original
+ * request so callers can log the substitution.
+ * @throws If no free port is found within {@link MAX_PROBES} attempts.
+ *
+ * @internal
+ */
+export async function resolvePort(
+  requested: number,
+  host: string
+): Promise<ResolvedPort> {
+  for (let port = requested; port < requested + MAX_PROBES; port++) {
+    if (await isPortFree(port, host)) {
+      return { port, requested };
+    }
+  }
+  throw new Error(
+    `No free port found between ${requested} and ${requested + MAX_PROBES - 1} on ${host}.`
+  );
+}

--- a/libraries/typescript/packages/server/src/cli/workspace.ts
+++ b/libraries/typescript/packages/server/src/cli/workspace.ts
@@ -1,0 +1,121 @@
+/**
+ * The per-project `.mcp-use/` workspace convention — the Next.js `.next`
+ * analog. Everything tooling writes for a project lives under this single,
+ * gitignored directory so a checkout stays clean and `rm -rf .mcp-use` is
+ * always safe.
+ *
+ * The layout is a fixed convention, not configuration: there is deliberately
+ * no config file and no `outDir` knob (runtime/project configuration lives on
+ * the `MCPServer` constructor). This module mirrors v1's
+ * `resolveWorkspacePaths` (`packages/mcp-use/src/server/config/paths.ts`) —
+ * same names, re-declared here because this toolchain must not depend on the
+ * old `mcp-use` package.
+ *
+ * This module is PURE: it only derives path strings (no filesystem access).
+ *
+ * Layout (relative to the project root):
+ *
+ * ```text
+ * .mcp-use/
+ * ├─ build/        ← compiled server + manifest.json (this package)
+ * ├─ generated/    ← typegen output (.d.ts) — reserved; Phase 5
+ * ├─ cache/        ← disposable dev/build scratch
+ * ├─ state/        ← mutable runtime state — reserved; future
+ * └─ cloud/        ← cloud linkage (link.json) — reserved; future
+ * ```
+ *
+ * `build/` must contain NO mutable runtime state (that is `state/`'s job) so
+ * build output stays reproducible and disposable. This is the per-project
+ * workspace, distinct from the global `~/.mcp-use/` store (CLI auth,
+ * credentials, per-user caches).
+ */
+
+import { join } from "node:path";
+
+/**
+ * Fixed name of the per-project workspace directory.
+ *
+ * @internal
+ */
+export const WORKSPACE_DIR_NAME = ".mcp-use";
+
+/**
+ * Basename of the build manifest written inside the build output directory.
+ *
+ * @internal
+ */
+export const BUILD_MANIFEST_NAME = "manifest.json";
+
+/**
+ * Manifest written to `.mcp-use/build/manifest.json` by {@link runBuild} and
+ * read back by `mcp-use start`.
+ *
+ * @internal
+ */
+export interface BuildManifest {
+  /** Unique identifier for this build (random hex, regenerated per build). */
+  buildId: string;
+  /**
+   * Filename of the emitted server entry, relative to the build directory
+   * (e.g. `"index.js"`). `mcp-use start` imports `<build>/<entryPoint>` and
+   * serves its default export.
+   */
+  entryPoint: string;
+  /** ISO-8601 timestamp of when the build finished. */
+  createdAt: string;
+  /** Whether the built server mounts the inspector shell route. */
+  inspector: boolean;
+}
+
+/**
+ * Every resolved path for a project's `.mcp-use/` workspace.
+ *
+ * @internal
+ */
+export interface WorkspacePaths {
+  /** The project root (the directory containing `.mcp-use/`). */
+  projectRoot: string;
+  /** The `.mcp-use/` workspace directory. */
+  workspace: string;
+  /** Build output directory: `.mcp-use/build`. */
+  build: string;
+  /** Generated `.d.ts` artifacts directory — reserved for typegen (Phase 5). */
+  generated: string;
+  /** Disposable dev/build scratch directory. */
+  cache: string;
+  /** Mutable runtime state directory — reserved. */
+  state: string;
+  /** Cloud linkage directory — reserved. */
+  cloud: string;
+  /** Build manifest: `<build>/manifest.json`. */
+  buildManifest: string;
+}
+
+/**
+ * Derive every workspace path for a project from its root. Pure — no
+ * filesystem access.
+ *
+ * @param projectRoot - Absolute path to the project root.
+ *
+ * @example
+ * ```ts
+ * const paths = resolveWorkspacePaths(process.cwd());
+ * console.log(paths.build); // <cwd>/.mcp-use/build
+ * ```
+ *
+ * @internal
+ */
+export function resolveWorkspacePaths(projectRoot: string): WorkspacePaths {
+  const workspace = join(projectRoot, WORKSPACE_DIR_NAME);
+  const build = join(workspace, "build");
+  return {
+    projectRoot,
+    workspace,
+    build,
+    generated: join(workspace, "generated"),
+    cache: join(workspace, "cache"),
+    state: join(workspace, "state"),
+    cloud: join(workspace, "cloud"),
+    buildManifest: join(build, BUILD_MANIFEST_NAME),
+  };
+}

--- a/libraries/typescript/packages/server/src/config.ts
+++ b/libraries/typescript/packages/server/src/config.ts
@@ -1,4 +1,22 @@
 /**
+ * Options for the inspector shell route — the object form of
+ * {@link ServerConfig.inspector}.
+ */
+export interface InspectorOptions {
+  /**
+   * Full replacement URL for the inspector bundle script (FastAPI's
+   * `swagger_js_url` analog). The shell's `<script type="module">` loads
+   * exactly this URL, so it must point at a complete copy of the
+   * `@mcp-use/inspector` CDN bundle (`dist/cdn/inspector.js`) — self-host it
+   * for air-gapped environments where the public CDN is unreachable.
+   *
+   * @defaultValue The jsDelivr URL for `@mcp-use/inspector`, pinned to the
+   * current major version.
+   */
+  assetsUrl?: string;
+}
+
+/**
  * Server identity and behavior, passed to `new MCPServer(...)`.
  *
  * Phase 1 carries only the fields the core consumes. Fields from the old
@@ -42,4 +60,40 @@ export interface ServerConfig {
    * header always pass (non-browser MCP clients don't send one).
    */
   allowedOrigins?: string[];
+  /**
+   * Inspector shell route at `${basePath}/inspector` — a browser UI for
+   * exploring and calling the server's tools, resources, and prompts.
+   *
+   * @remarks
+   * Follows the FastAPI `/docs` model: the server itself ships only a tiny
+   * dependency-free HTML page whose `<script type="module">` loads the
+   * `@mcp-use/inspector` bundle from a CDN (jsDelivr, pinned to the current
+   * major version), so the UI updates independently of SDK releases and adds
+   * nothing to the install. The page tells the inspector to connect to this
+   * server's MCP endpoint at `basePath`, deriving the URL from the browser's
+   * own origin.
+   *
+   * `true`, `{}`, and leaving the field unset all mean enabled; set `false`
+   * to disable the route, or pass `{ assetsUrl }` to load the bundle from a
+   * self-hosted copy instead of the public CDN (air-gapped environments).
+   *
+   * @defaultValue `true`
+   *
+   * @example
+   * ```ts
+   * // Default: inspector served at /mcp/inspector from the public CDN.
+   * new MCPServer({ name: "my-server", version: "1.0.0" });
+   *
+   * // Disabled:
+   * new MCPServer({ name: "my-server", version: "1.0.0", inspector: false });
+   *
+   * // Air-gapped: load a self-hosted copy of the inspector bundle.
+   * new MCPServer({
+   *   name: "my-server",
+   *   version: "1.0.0",
+   *   inspector: { assetsUrl: "https://intranet.example.com/inspector.js" },
+   * });
+   * ```
+   */
+  inspector?: boolean | InspectorOptions;
 }

--- a/libraries/typescript/packages/server/src/index.ts
+++ b/libraries/typescript/packages/server/src/index.ts
@@ -37,7 +37,7 @@ export type {
   StandardSchemaWithJSON,
 } from "@modelcontextprotocol/server";
 
-export type { ServerConfig } from "./config.js";
+export type { InspectorOptions, ServerConfig } from "./config.js";
 export type { RequestContext } from "./context.js";
 export type {
   InferToolInput,

--- a/libraries/typescript/packages/server/src/inspector-shell.ts
+++ b/libraries/typescript/packages/server/src/inspector-shell.ts
@@ -1,0 +1,142 @@
+/**
+ * Inspector CDN shell — the FastAPI `/docs` analog.
+ *
+ * The server ships no inspector code: it serves a tiny self-contained HTML
+ * page whose `<script type="module">` loads the `@mcp-use/inspector` CDN
+ * bundle (a single self-contained ESM file), pinned to a major version so the
+ * UI updates independently of SDK releases. Runtime configuration crosses to
+ * the bundle through a serialized `window` global; the connect URL is derived
+ * in the browser from the page's own origin, so the server never guesses its
+ * public hostname.
+ */
+import type { Env, Hono } from "hono";
+
+import type { InspectorOptions } from "./config.js";
+
+/**
+ * Major version of `@mcp-use/inspector` the default CDN URL pins to.
+ *
+ * Users pick up inspector patch/minor releases without an SDK bump; a new
+ * inspector major requires deliberately raising this constant.
+ */
+export const INSPECTOR_MAJOR_VERSION = 11;
+
+/**
+ * Default URL the inspector shell loads the UI bundle from: the jsDelivr
+ * copy of `@mcp-use/inspector`'s CDN build (`dist/cdn/inspector.js`), pinned
+ * to {@link INSPECTOR_MAJOR_VERSION}. Override per server with
+ * {@link InspectorOptions.assetsUrl}.
+ */
+export const DEFAULT_INSPECTOR_ASSETS_URL = `https://cdn.jsdelivr.net/npm/@mcp-use/inspector@${INSPECTOR_MAJOR_VERSION}/dist/cdn/inspector.js`;
+
+/** Inputs for {@link renderInspectorShell}. */
+export interface InspectorShellOptions {
+  /** Server display name, used in the page title. */
+  serverName: string;
+  /** Route path the MCP endpoint is mounted on (e.g. `/mcp`). */
+  basePath: string;
+  /**
+   * Full replacement URL for the inspector bundle script. Defaults to
+   * {@link DEFAULT_INSPECTOR_ASSETS_URL}.
+   */
+  assetsUrl?: string | undefined;
+}
+
+/** Escape a string for interpolation into HTML text or attribute values. */
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+/**
+ * Serialize a value for interpolation inside an inline `<script>` body.
+ *
+ * `<` is escaped to its unicode JSON escape (backslash-u003c) so serialized
+ * config can never form a `</script>` (or `<!--`) sequence and break out of
+ * the script element.
+ */
+function serializeForInlineScript(value: string): string {
+  return JSON.stringify(value).replaceAll("<", "\\u003c");
+}
+
+/**
+ * Render the inspector shell page.
+ *
+ * A minimal dark-background document (no white flash before the UI paints)
+ * with a `#root` mount node, an inline script publishing
+ * `window.__MCP_USE_INSPECTOR__ = { autoConnectUrl, basePath }` — where
+ * `autoConnectUrl` is computed client-side as
+ * `window.location.origin + basePath` — and a module script loading the
+ * inspector bundle. All server-provided values are HTML-escaped or
+ * JSON-serialized with `<` escaped, so config can't inject markup.
+ */
+export function renderInspectorShell(options: InspectorShellOptions): string {
+  const { serverName, basePath, assetsUrl } = options;
+  const serializedBasePath = serializeForInlineScript(basePath);
+  const scriptSrc = escapeHtml(assetsUrl ?? DEFAULT_INSPECTOR_ASSETS_URL);
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>${escapeHtml(serverName)} — MCP Inspector</title>
+    <style>
+      :root { color-scheme: dark; }
+      html, body { height: 100%; margin: 0; background-color: #0c0c0d; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script>
+      (function () {
+        var basePath = ${serializedBasePath};
+        // The connect URL is derived from the page's own origin: the server
+        // never guesses the hostname a browser reached it by.
+        window.__MCP_USE_INSPECTOR__ = {
+          autoConnectUrl: window.location.origin + basePath,
+          basePath: basePath,
+        };
+        // Read by the current inspector bundle to derive its own URLs.
+        window.__MCP_BASE_PATH__ = basePath;
+      })();
+    </script>
+    <script type="module" src="${scriptSrc}"></script>
+  </body>
+</html>
+`;
+}
+
+/**
+ * Mount the inspector shell on a Hono app at `${basePath}/inspector`.
+ *
+ * Registers GET for both the bare and trailing-slash paths (Hono answers
+ * HEAD from GET handlers automatically) and serves the pre-rendered shell as
+ * `text/html; charset=utf-8`. No-op when `inspector` is `false`;
+ * `undefined`, `true`, and `{}` all mean enabled.
+ *
+ * @internal Wiring for `MCPServer` — mounted on the same app as the MCP
+ * endpoint, so any configured Host/Origin validation middleware applies to
+ * this route too.
+ */
+export function mountInspectorShell<E extends Env>(
+  app: Hono<E>,
+  inspector: boolean | InspectorOptions | undefined,
+  options: { serverName: string; basePath: string }
+): void {
+  if (inspector === false) {
+    return;
+  }
+  const { assetsUrl } = typeof inspector === "object" ? inspector : {};
+  // Config is fixed at mount time, so the page renders once, not per request.
+  const html = renderInspectorShell({
+    serverName: options.serverName,
+    basePath: options.basePath,
+    assetsUrl,
+  });
+  const path = `${options.basePath}/inspector`;
+  app.on("GET", [path, `${path}/`], (c) => c.html(html));
+}

--- a/libraries/typescript/packages/server/src/mount-mcp.ts
+++ b/libraries/typescript/packages/server/src/mount-mcp.ts
@@ -46,7 +46,7 @@ export function mountMcp<E extends Env>(
 ): McpHttpHandler {
   const { path = "/mcp", handler: handlerOptions } = options;
   const handler = createMcpHandler(factory, {
-    legacy: "reject",
+    legacy: "stateless",
     ...handlerOptions,
   });
   app.all(path, (c) => {

--- a/libraries/typescript/packages/server/src/server.ts
+++ b/libraries/typescript/packages/server/src/server.ts
@@ -14,6 +14,7 @@ import { Hono } from "hono";
 
 import type { ServerConfig } from "./config.js";
 import { toRequestContext } from "./context.js";
+import { mountInspectorShell } from "./inspector-shell.js";
 import { mountMcp } from "./mount-mcp.js";
 import type {
   InferPromptInput,
@@ -102,6 +103,17 @@ export class MCPServer {
    */
   constructor(config: ServerConfig) {
     this.#config = config;
+  }
+
+  /**
+   * The URL path prefix the MCP endpoint is mounted at.
+   *
+   * Reflects `config.basePath` (default `"/mcp"`). Exposed so tooling that
+   * imports the entry module — `mcp-use dev`'s startup log, for example —
+   * can build the endpoint and inspector URLs without assuming the default.
+   */
+  get basePath(): string {
+    return this.#basePath();
   }
 
   /**
@@ -304,6 +316,12 @@ export class MCPServer {
       }
       const handler = mountMcp(app, () => this.#buildSdkServer(), {
         path: this.#basePath(),
+      });
+      // Inspector shell (default enabled, FastAPI /docs style) rides the
+      // same app, so the validation middleware above covers it too.
+      mountInspectorShell(app, this.#config.inspector, {
+        serverName: this.#config.name,
+        basePath: this.#basePath(),
       });
       this.#app = app;
       this.#handler = handler;

--- a/libraries/typescript/packages/server/tests/bin-start.test.ts
+++ b/libraries/typescript/packages/server/tests/bin-start.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Tests for the `mcp-use` bin: argv parsing, port precedence, and the inline
+ * `start` command run against real on-disk fixtures — a temp project with a
+ * `.mcp-use/build/` workspace containing a manifest and a built entry, with
+ * zero mocks of the filesystem or module loader.
+ */
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+
+import { parseArgs, resolvePort } from "../src/bin/args.js";
+import { isViteMissing, main } from "../src/bin/main.js";
+import { runStart } from "../src/bin/start.js";
+
+/** An entry that echoes back the port it was asked to listen on (no bind). */
+const ECHO_ENTRY = `
+const server = {
+  async listen(port = 3000) {
+    return { port, url: \`http://localhost:\${port}/mcp\` };
+  },
+  async close() {},
+};
+export default server;
+`;
+
+/** An entry that binds a real HTTP server so the started URL can be fetched. */
+const HTTP_ENTRY = `
+import { createServer } from "node:http";
+let http;
+const server = {
+  async listen(port = 3000) {
+    http = createServer((req, res) => { res.end("hello from built server"); });
+    await new Promise((resolve) => http.listen(port, "127.0.0.1", resolve));
+    const bound = http.address().port;
+    return { port: bound, url: \`http://127.0.0.1:\${bound}/mcp\` };
+  },
+  async close() {
+    await new Promise((resolve) => http.close(resolve));
+  },
+};
+export default server;
+`;
+
+const tempDirs: string[] = [];
+
+/** Create a temp project with a `.mcp-use/build/` workspace fixture. */
+async function makeProject(options?: {
+  entrySource?: string;
+  manifest?: string;
+}): Promise<string> {
+  const cwd = await mkdtemp(join(tmpdir(), "mcp-use-bin-"));
+  tempDirs.push(cwd);
+  const buildDir = join(cwd, ".mcp-use", "build");
+  await mkdir(buildDir, { recursive: true });
+  await writeFile(
+    join(buildDir, "manifest.json"),
+    options?.manifest ??
+      JSON.stringify({
+        buildId: "test",
+        entryPoint: "index.js",
+        createdAt: new Date().toISOString(),
+      })
+  );
+  if (options?.entrySource !== undefined) {
+    await writeFile(join(buildDir, "index.js"), options.entrySource);
+  }
+  return cwd;
+}
+
+afterAll(async () => {
+  await Promise.all(
+    tempDirs.map((dir) => rm(dir, { recursive: true, force: true }))
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe("parseArgs", () => {
+  it("extracts the subcommand", () => {
+    expect(parseArgs(["start"]).command).toBe("start");
+    expect(parseArgs([]).command).toBeUndefined();
+  });
+
+  it("parses --port, -p, and --port=<n>", () => {
+    expect(parseArgs(["start", "--port", "8080"]).port).toBe(8080);
+    expect(parseArgs(["start", "-p", "8080"]).port).toBe(8080);
+    expect(parseArgs(["start", "--port=8080"]).port).toBe(8080);
+  });
+
+  it("parses --entry and --host", () => {
+    const args = parseArgs(["dev", "--entry", "src/app.ts", "--host", "::1"]);
+    expect(args.entry).toBe("src/app.ts");
+    expect(args.host).toBe("::1");
+  });
+
+  it("parses help and version flags", () => {
+    expect(parseArgs(["--help"]).help).toBe(true);
+    expect(parseArgs(["-h"]).help).toBe(true);
+    expect(parseArgs(["--version"]).version).toBe(true);
+    expect(parseArgs(["-v"]).version).toBe(true);
+  });
+
+  it("rejects invalid ports", () => {
+    expect(() => parseArgs(["start", "--port", "nope"])).toThrow(
+      /invalid port/i
+    );
+    expect(() => parseArgs(["start", "--port", "70000"])).toThrow(
+      /invalid port/i
+    );
+  });
+
+  it("rejects a flag with a missing value", () => {
+    expect(() => parseArgs(["start", "--port"])).toThrow(/missing value/i);
+    expect(() => parseArgs(["dev", "--entry", "--host"])).toThrow(
+      /missing value/i
+    );
+  });
+
+  it("rejects unknown options and extra positionals", () => {
+    expect(() => parseArgs(["start", "--bogus"])).toThrow(/unknown option/i);
+    expect(() => parseArgs(["start", "extra"])).toThrow(
+      /unexpected argument/i
+    );
+  });
+});
+
+describe("resolvePort", () => {
+  it("prefers the flag over PORT env over the 3000 default", () => {
+    expect(resolvePort(8080, { PORT: "4000" })).toBe(8080);
+    expect(resolvePort(undefined, { PORT: "4000" })).toBe(4000);
+    expect(resolvePort(undefined, {})).toBe(3000);
+  });
+
+  it("ignores an unusable PORT env value", () => {
+    expect(resolvePort(undefined, { PORT: "not-a-port" })).toBe(3000);
+    expect(resolvePort(undefined, { PORT: "" })).toBe(3000);
+  });
+});
+
+describe("runStart", () => {
+  it("errors actionably when there is no build", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "mcp-use-bin-empty-"));
+    tempDirs.push(cwd);
+    await expect(runStart({ cwd })).rejects.toThrow(/mcp-use build/);
+    await expect(runStart({ cwd })).rejects.toThrow(/no production build/i);
+  });
+
+  it("errors on a manifest without an entryPoint", async () => {
+    const cwd = await makeProject({ manifest: `{ "buildId": "x" }` });
+    await expect(runStart({ cwd })).rejects.toThrow(/invalid build manifest/i);
+  });
+
+  it("errors when the entry has no default export", async () => {
+    const cwd = await makeProject({ entrySource: `export const x = 1;` });
+    await expect(runStart({ cwd })).rejects.toThrow(/no default export/);
+  });
+
+  it("errors when the default export has no listen()", async () => {
+    const cwd = await makeProject({
+      entrySource: `export default { notAServer: true };`,
+    });
+    await expect(runStart({ cwd })).rejects.toThrow(/listen/);
+  });
+
+  it("starts the built entry and responds over HTTP", async () => {
+    const cwd = await makeProject({ entrySource: HTTP_ENTRY });
+    const started = await runStart({ cwd, port: 0 });
+    try {
+      expect(started.port).toBeGreaterThan(0);
+      expect(started.url).toBe(`http://127.0.0.1:${started.port}/mcp`);
+      const response = await fetch(started.url);
+      expect(await response.text()).toBe("hello from built server");
+    } finally {
+      await started.close();
+    }
+  });
+
+  it("applies port precedence: flag over PORT env over 3000", async () => {
+    const cwd = await makeProject({ entrySource: ECHO_ENTRY });
+
+    vi.stubEnv("PORT", "4123");
+    expect((await runStart({ cwd, port: 5001 })).port).toBe(5001);
+    expect((await runStart({ cwd })).port).toBe(4123);
+
+    vi.stubEnv("PORT", undefined);
+    expect((await runStart({ cwd })).port).toBe(3000);
+  });
+
+  it("sets NODE_ENV=production only when unset", async () => {
+    const cwd = await makeProject({ entrySource: ECHO_ENTRY });
+
+    vi.stubEnv("NODE_ENV", undefined);
+    await runStart({ cwd, port: 5002 });
+    expect(process.env.NODE_ENV).toBe("production");
+
+    vi.stubEnv("NODE_ENV", "staging");
+    await runStart({ cwd, port: 5003 });
+    expect(process.env.NODE_ENV).toBe("staging");
+  });
+});
+
+describe("main", () => {
+  it("prints help and fails on an unknown command", async () => {
+    const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+    await expect(main(["frobnicate"])).resolves.toBe(1);
+    expect(errors.mock.calls.flat().join("\n")).toContain("Usage: mcp-use");
+  });
+
+  it("prints help and fails when no command is given", async () => {
+    const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+    await expect(main([])).resolves.toBe(1);
+    expect(errors.mock.calls.flat().join("\n")).toContain("Usage: mcp-use");
+  });
+
+  it("prints the package version for --version", async () => {
+    const logs = vi.spyOn(console, "log").mockImplementation(() => {});
+    await expect(main(["--version"])).resolves.toBe(0);
+    expect(logs.mock.calls.flat().join("")).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it("prints help for --help", async () => {
+    const logs = vi.spyOn(console, "log").mockImplementation(() => {});
+    await expect(main(["--help"])).resolves.toBe(0);
+    expect(logs.mock.calls.flat().join("\n")).toContain("Usage: mcp-use");
+  });
+
+  it("errors actionably when dev/build has no server entry (cli chunk loads, vite is present)", async () => {
+    // vite is a devDependency of this package (needed to run the cli's
+    // own tests below), so it is always resolvable here — this test proves
+    // the cli chunk dispatch itself works (import succeeds, runDev/runBuild
+    // run) by driving it to its next failure mode instead: no server entry in
+    // this cwd's fixture. See `describe("isViteMissing")` for the missing-vite
+    // classification this bin also has to handle, unit-tested directly since
+    // reliably un-resolving vite from *this* workspace is impractical (vite
+    // is required by tests/cli/*). Runs against the real process.cwd()
+    // (this package) with a deliberately nonexistent --entry override.
+    const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+    await expect(main(["build", "--entry", "nope.ts"])).resolves.toBe(1);
+    const output = errors.mock.calls.flat().join("\n");
+    expect(output).toMatch(/Entry not found/);
+  });
+});
+
+describe("isViteMissing", () => {
+  /**
+   * Node's exact shape for a missing bare import, confirmed against a real
+   * `await import("./mod.js")` where `mod.js` does `import { x } from "vite"`
+   * and vite is not installed:
+   * `Error: Cannot find package 'vite' imported from <path>`,
+   * `error.code === "ERR_MODULE_NOT_FOUND"`.
+   */
+  function moduleNotFoundError(specifier: string): NodeJS.ErrnoException {
+    const error = new Error(
+      `Cannot find package '${specifier}' imported from /project/cli/build.js`
+    ) as NodeJS.ErrnoException;
+    error.code = "ERR_MODULE_NOT_FOUND";
+    return error;
+  }
+
+  it("classifies a missing vite import", () => {
+    expect(isViteMissing(moduleNotFoundError("vite"))).toBe(true);
+  });
+
+  it("does not classify a missing unrelated package", () => {
+    expect(isViteMissing(moduleNotFoundError("left-pad"))).toBe(false);
+  });
+
+  it("does not classify a module-not-found for a local file path", () => {
+    const error = new Error(
+      "Cannot find module '/project/.mcp-use/build/index.js' imported from /project"
+    ) as NodeJS.ErrnoException;
+    error.code = "ERR_MODULE_NOT_FOUND";
+    expect(isViteMissing(error)).toBe(false);
+  });
+
+  it("does not classify errors with a different code", () => {
+    const error = new Error("Cannot find package 'vite'") as NodeJS.ErrnoException;
+    error.code = "ERR_INVALID_ARG_TYPE";
+    expect(isViteMissing(error)).toBe(false);
+  });
+
+  it("does not classify non-Error values", () => {
+    expect(isViteMissing("nope")).toBe(false);
+    expect(isViteMissing(undefined)).toBe(false);
+  });
+});

--- a/libraries/typescript/packages/server/tests/cli/build.test.ts
+++ b/libraries/typescript/packages/server/tests/cli/build.test.ts
@@ -1,0 +1,106 @@
+/** e2e tests for runBuild: real Vite build of the fixture, real import. */
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterAll, describe, expect, it } from "vitest";
+
+import {
+  BUILD_MANIFEST_NAME,
+  runBuild,
+  WORKSPACE_DIR_NAME,
+  type BuildManifest,
+} from "../../src/cli/index.js";
+import { copyFixture, removeDir } from "./helpers.js";
+
+const dirs: string[] = [];
+afterAll(() => {
+  for (const dir of dirs) removeDir(dir);
+});
+
+describe("runBuild", () => {
+  it("emits an ESM bundle + manifest to .mcp-use/build and preserves the default export", async () => {
+    const cwd = copyFixture("build");
+    dirs.push(cwd);
+
+    await runBuild({ cwd });
+
+    const buildDir = join(cwd, WORKSPACE_DIR_NAME, "build");
+    const entryFile = join(buildDir, "index.js");
+    expect(existsSync(entryFile)).toBe(true);
+    expect(existsSync(`${entryFile}.map`)).toBe(true);
+
+    // Manifest shape per CLI_SPEC.md § Commands → build.
+    const manifest = JSON.parse(
+      readFileSync(join(buildDir, BUILD_MANIFEST_NAME), "utf8")
+    ) as BuildManifest;
+    expect(manifest.entryPoint).toBe("index.js");
+    expect(manifest.buildId).toMatch(/^[0-9a-f]{16}$/);
+    expect(new Date(manifest.createdAt).getTime()).not.toBeNaN();
+    expect(manifest.inspector).toBe(true);
+
+    // packages:"external" semantics — bare imports stay external, only the
+    // user's source is bundled.
+    const code = readFileSync(entryFile, "utf8");
+    expect(code).toMatch(/from ["']@mcp-use\/server["']/);
+    expect(code).toMatch(/from ["']zod["']/);
+
+    // The built entry runs under plain node and default-exports the
+    // MCPServer instance (getHandler present); drive a real request through
+    // the handler to prove the export is live.
+    const mod = (await import(pathToFileURL(entryFile).href)) as {
+      default: { getHandler(): (request: Request) => Promise<Response> };
+    };
+    expect(typeof mod.default.getHandler).toBe("function");
+
+    const handler = mod.default.getHandler();
+    const response = await handler(
+      new Request("http://localhost/mcp", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+          "mcp-protocol-version": "2026-07-28",
+          "mcp-method": "tools/call",
+          "mcp-name": "add",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: {
+            name: "add",
+            arguments: { a: 1, b: 2 },
+            _meta: {
+              "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+              "io.modelcontextprotocol/clientInfo": {
+                name: "cli-test",
+                version: "0.0.0",
+              },
+              "io.modelcontextprotocol/clientCapabilities": {},
+            },
+          },
+        }),
+      })
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      result: { content: [{ type: "text", text: "3" }] },
+    });
+  });
+
+  it("honors an --entry override", async () => {
+    const cwd = copyFixture("build-entry");
+    dirs.push(cwd);
+    await runBuild({ cwd, entry: "src/index.ts" });
+    expect(
+      existsSync(join(cwd, WORKSPACE_DIR_NAME, "build", "index.js"))
+    ).toBe(true);
+  });
+
+  it("fails with the candidate list when no entry exists", async () => {
+    const cwd = copyFixture("build-noentry");
+    dirs.push(cwd);
+    removeDir(join(cwd, "src"));
+    await expect(runBuild({ cwd })).rejects.toThrow(/No server entry found/);
+  });
+});

--- a/libraries/typescript/packages/server/tests/cli/dev.test.ts
+++ b/libraries/typescript/packages/server/tests/cli/dev.test.ts
@@ -1,0 +1,142 @@
+/**
+ * e2e tests for runDev: a real Vite dev server + module runner serving the
+ * fixture over HTTP, including edit-triggered reload and error resilience.
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { runDev } from "../../src/cli/index.js";
+import {
+  copyFixture,
+  getFreePort,
+  listToolNames,
+  occupyPort,
+  removeDir,
+  waitFor,
+} from "./helpers.js";
+
+interface DevHandle {
+  url: string;
+  stop: () => Promise<void>;
+}
+
+const cleanups: (() => Promise<void> | void)[] = [];
+afterEach(async () => {
+  while (cleanups.length > 0) {
+    await cleanups.pop()?.();
+  }
+});
+
+/** Start runDev in-process and wait for the ready log to learn the URL. */
+async function startDev(cwd: string, port: number): Promise<DevHandle> {
+  const lines: string[] = [];
+  const logSpy = vi
+    .spyOn(console, "log")
+    .mockImplementation((...args: unknown[]) => {
+      lines.push(args.map(String).join(" "));
+    });
+
+  const controller = new AbortController();
+  const done = runDev({ cwd, port, signal: controller.signal });
+  // Surface startup failures instead of hanging in waitFor.
+  let startupError: unknown;
+  done.catch((error: unknown) => (startupError = error));
+
+  try {
+    const endpointLine = await waitFor(async () => {
+      if (startupError !== undefined) throw startupError;
+      return lines.find((l) => l.includes("MCP endpoint"));
+    });
+    const url = /(http:\/\/\S+)/.exec(endpointLine)?.[1];
+    if (url === undefined) throw new Error(`no URL in: ${endpointLine}`);
+    return {
+      url,
+      stop: async () => {
+        controller.abort();
+        await done;
+        logSpy.mockRestore();
+      },
+    };
+  } catch (error) {
+    logSpy.mockRestore();
+    controller.abort();
+    await done.catch(() => {});
+    throw error;
+  }
+}
+
+describe("runDev", () => {
+  it("serves the MCP endpoint and reloads on file change", async () => {
+    const cwd = copyFixture("dev");
+    cleanups.push(() => removeDir(cwd));
+
+    const port = await getFreePort();
+    const dev = await startDev(cwd, port);
+    cleanups.push(dev.stop);
+
+    expect(dev.url).toBe(`http://localhost:${port}/mcp`);
+    expect(await listToolNames(dev.url)).toEqual(["add"]);
+
+    // --- Edit-triggered reload: add a tool, poll until tools/list shows it.
+    const entry = join(cwd, "src", "index.ts");
+    const source = readFileSync(entry, "utf8");
+    writeFileSync(
+      entry,
+      source.replace(
+        "export default server;",
+        `server.tool(
+  { name: "subtract", description: "Subtract", schema: z.object({ a: z.number(), b: z.number() }) },
+  async ({ a, b }) => ({ content: [{ type: "text", text: String(a - b) }] })
+);
+export default server;`
+      )
+    );
+    await waitFor(async () =>
+      (await listToolNames(dev.url)).includes("subtract") ? true : undefined
+    );
+    expect(await listToolNames(dev.url)).toEqual(["add", "subtract"]);
+
+    // --- A broken save keeps the previous handler alive (never crashes).
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    cleanups.push(() => errorSpy.mockRestore());
+    writeFileSync(entry, "this is not valid typescript {{{\n");
+    await waitFor(async () =>
+      errorSpy.mock.calls.some((call) =>
+        String(call[0]).includes("reload failed")
+      )
+        ? true
+        : undefined
+    );
+    expect(await listToolNames(dev.url)).toEqual(["add", "subtract"]);
+  });
+
+  it("probes upward when the requested port is taken", async () => {
+    const cwd = copyFixture("dev-port");
+    cleanups.push(() => removeDir(cwd));
+
+    const port = await getFreePort();
+    const blocker = await occupyPort(port);
+    cleanups.push(
+      () => new Promise<void>((r) => blocker.close(() => r()))
+    );
+
+    const dev = await startDev(cwd, port);
+    cleanups.push(dev.stop);
+
+    const boundPort = Number(new URL(dev.url).port);
+    expect(boundPort).toBeGreaterThan(port);
+    expect(await listToolNames(dev.url)).toEqual(["add"]);
+  });
+
+  it("rejects an entry without a default MCPServer export", async () => {
+    const cwd = copyFixture("dev-bad");
+    cleanups.push(() => removeDir(cwd));
+    writeFileSync(join(cwd, "src", "index.ts"), "export const nope = 1;\n");
+
+    const port = await getFreePort();
+    await expect(runDev({ cwd, port })).rejects.toThrow(
+      /export default server/
+    );
+  });
+});

--- a/libraries/typescript/packages/server/tests/cli/entry.test.ts
+++ b/libraries/typescript/packages/server/tests/cli/entry.test.ts
@@ -1,0 +1,67 @@
+/** Unit tests for entry discovery (CLI_SPEC.md § Entry contract). */
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+
+import { discoverEntry, ENTRY_CANDIDATES } from "../../src/cli/index.js";
+import { removeDir, TMP_ROOT } from "./helpers.js";
+
+let counter = 0;
+const dirs: string[] = [];
+
+function makeProject(files: string[]): string {
+  const dir = join(TMP_ROOT, `entry-${process.pid}-${counter++}`);
+  for (const file of files) {
+    mkdirSync(join(dir, file, ".."), { recursive: true });
+    writeFileSync(join(dir, file), "export default {};\n");
+  }
+  mkdirSync(dir, { recursive: true });
+  dirs.push(dir);
+  return dir;
+}
+
+afterAll(() => {
+  for (const dir of dirs) removeDir(dir);
+});
+
+describe("discoverEntry", () => {
+  it("finds each conventional candidate", () => {
+    for (const candidate of ENTRY_CANDIDATES) {
+      const dir = makeProject([candidate]);
+      expect(discoverEntry(dir)).toBe(join(dir, candidate));
+    }
+  });
+
+  it("prefers candidates in order (first hit wins)", () => {
+    const dir = makeProject(["src/index.ts", "src/server.ts", "index.ts"]);
+    expect(discoverEntry(dir)).toBe(join(dir, "src/index.ts"));
+
+    const dir2 = makeProject(["src/server.ts", "server.ts"]);
+    expect(discoverEntry(dir2)).toBe(join(dir2, "src/server.ts"));
+  });
+
+  it("resolves an --entry override relative to cwd", () => {
+    const dir = makeProject(["custom/main.ts"]);
+    expect(discoverEntry(dir, "custom/main.ts")).toBe(
+      join(dir, "custom/main.ts")
+    );
+  });
+
+  it("accepts an absolute --entry override", () => {
+    const dir = makeProject(["custom/main.ts"]);
+    const absolute = join(dir, "custom/main.ts");
+    expect(discoverEntry(dir, absolute)).toBe(absolute);
+  });
+
+  it("throws when the --entry override does not exist", () => {
+    const dir = makeProject([]);
+    expect(() => discoverEntry(dir, "nope.ts")).toThrow(/Entry not found/);
+  });
+
+  it("throws listing every candidate when none is found", () => {
+    const dir = makeProject([]);
+    expect(() => discoverEntry(dir)).toThrow(
+      /src\/index\.ts, src\/server\.ts, index\.ts, server\.ts/
+    );
+  });
+});

--- a/libraries/typescript/packages/server/tests/cli/fixtures/basic/package.json
+++ b/libraries/typescript/packages/server/tests/cli/fixtures/basic/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "cli-fixture-basic",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module"
+}

--- a/libraries/typescript/packages/server/tests/cli/fixtures/basic/src/index.ts
+++ b/libraries/typescript/packages/server/tests/cli/fixtures/basic/src/index.ts
@@ -1,0 +1,17 @@
+import { MCPServer } from "@mcp-use/server";
+import { z } from "zod";
+
+const server = new MCPServer({ name: "fixture-basic", version: "1.0.0" });
+
+server.tool(
+  {
+    name: "add",
+    description: "Add two numbers",
+    schema: z.object({ a: z.number(), b: z.number() }),
+  },
+  async ({ a, b }) => ({
+    content: [{ type: "text", text: String(a + b) }],
+  })
+);
+
+export default server;

--- a/libraries/typescript/packages/server/tests/cli/helpers.ts
+++ b/libraries/typescript/packages/server/tests/cli/helpers.ts
@@ -1,0 +1,138 @@
+/** Shared test helpers: fixture copying, raw 2026-07-28 MCP requests, polling. */
+import { randomBytes } from "node:crypto";
+import { cpSync, mkdirSync, rmSync } from "node:fs";
+import { createServer, type Server } from "node:net";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+/** Absolute path to the committed basic fixture project. */
+export const FIXTURE_BASIC = join(here, "fixtures", "basic");
+
+/**
+ * Scratch root for mutable fixture copies. Lives inside the package (not the
+ * OS tmpdir) so node resolution of externalized bare imports still walks up
+ * into `packages/server/node_modules` — where `@mcp-use/server` declares
+ * itself as a `devDependency` (see package.json) purely so pnpm links a real
+ * `node_modules/@mcp-use/server` → package-root symlink there. That entry is
+ * what lets the fixture's own `import "@mcp-use/server"` (and this package's
+ * `runBuild`/`runDev`, which build/serve the fixture as if it were an
+ * ordinary user project) resolve during both Vite/Rolldown bundling and
+ * `tsc` typechecking of `tests/cli/fixtures/basic/`, neither of which
+ * implements Node's own package self-reference algorithm.
+ */
+export const TMP_ROOT = join(here, ".tmp");
+
+/** Copy the basic fixture into a fresh scratch dir; returns its path. */
+export function copyFixture(label: string): string {
+  const dest = join(TMP_ROOT, `${label}-${randomBytes(4).toString("hex")}`);
+  mkdirSync(dest, { recursive: true });
+  cpSync(FIXTURE_BASIC, dest, { recursive: true });
+  return dest;
+}
+
+/** Remove a scratch dir, ignoring failures. */
+export function removeDir(dir: string): void {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+/** The per-request _meta envelope required by the stateless 2026-07-28 wire. */
+const META = {
+  "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+  "io.modelcontextprotocol/clientInfo": { name: "cli-test", version: "0.0.0" },
+  "io.modelcontextprotocol/clientCapabilities": {},
+};
+
+/**
+ * Issue a raw 2026-07-28 MCP request against a dev/built server and return
+ * the parsed JSON-RPC response body.
+ */
+export async function mcpRequest(
+  baseUrl: string,
+  method: string,
+  params: Record<string, unknown> = {}
+): Promise<Record<string, unknown>> {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    accept: "application/json, text/event-stream",
+    "mcp-protocol-version": "2026-07-28",
+    "mcp-method": method,
+  };
+  if (typeof params["name"] === "string") {
+    headers["mcp-name"] = params["name"];
+  }
+  const response = await fetch(baseUrl, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method,
+      params: { ...params, _meta: META },
+    }),
+  });
+  if (!response.ok) {
+    throw new Error(`${method} → HTTP ${response.status}`);
+  }
+  return (await response.json()) as Record<string, unknown>;
+}
+
+/** List tool names via a raw tools/list request. */
+export async function listToolNames(baseUrl: string): Promise<string[]> {
+  const body = await mcpRequest(baseUrl, "tools/list");
+  const result = body["result"] as { tools: { name: string }[] };
+  return result.tools.map((t) => t.name).sort();
+}
+
+/** Poll `probe` until it resolves truthy or the timeout elapses. */
+export async function waitFor<T>(
+  probe: () => Promise<T | undefined>,
+  { timeout = 15000, interval = 200 } = {}
+): Promise<T> {
+  const deadline = Date.now() + timeout;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      const value = await probe();
+      if (value !== undefined) return value;
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((r) => setTimeout(r, interval));
+  }
+  throw new Error(
+    `waitFor timed out after ${timeout}ms` +
+      (lastError !== undefined ? `; last error: ${String(lastError)}` : "")
+  );
+}
+
+/**
+ * Find a free port OUTSIDE the OS ephemeral range (binding port 0 hands out
+ * ephemeral ports, and a loopback fetch to an ephemeral port can TCP
+ * self-connect — the kernel picks source port == destination port — echoing
+ * the request back as the "response").
+ */
+export async function getFreePort(host = "127.0.0.1"): Promise<number> {
+  for (let attempt = 0; attempt < 50; attempt++) {
+    const candidate = 20000 + Math.floor(Math.random() * 20000);
+    const free = await new Promise<boolean>((resolve) => {
+      const server = createServer();
+      server.once("error", () => resolve(false));
+      server.listen({ port: candidate, host }, () => {
+        server.close(() => resolve(true));
+      });
+    });
+    if (free) return candidate;
+  }
+  throw new Error("no free non-ephemeral port found");
+}
+
+/** Occupy a port with a bare TCP server; returns the server (call close()). */
+export async function occupyPort(port: number, host = "127.0.0.1"): Promise<Server> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen({ port, host }, () => resolve(server));
+  });
+}

--- a/libraries/typescript/packages/server/tests/inspector-shell.test.ts
+++ b/libraries/typescript/packages/server/tests/inspector-shell.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Tests for the inspector CDN shell route: default-enabled mounting at
+ * `${basePath}/inspector`, the `inspector` config forms (`false`,
+ * `{ assetsUrl }`), script-injection escaping, and coexistence with the MCP
+ * endpoint — driven through `getHandler()`, no network.
+ */
+import { describe, expect, it } from "vitest";
+
+import { MCPServer } from "../src/index.js";
+import type { ServerConfig } from "../src/index.js";
+
+const DEFAULT_CDN_URL =
+  "https://cdn.jsdelivr.net/npm/@mcp-use/inspector@11/dist/cdn/inspector.js";
+
+function makeServer(config: Partial<ServerConfig> = {}): MCPServer {
+  const server = new MCPServer({
+    name: "shell-test",
+    version: "1.0.0",
+    ...config,
+  });
+  server.tool({ name: "ping" }, async () => ({
+    content: [{ type: "text", text: "pong" }],
+  }));
+  return server;
+}
+
+/** GET the given path through the server's web-standard handler. */
+async function get(
+  server: MCPServer,
+  path: string,
+  method = "GET"
+): Promise<Response> {
+  return server.getHandler()(
+    new Request(`http://localhost${path}`, { method })
+  );
+}
+
+/** Synthetic 2026-07-28 tools/list request against the MCP endpoint. */
+function toolsListRequest(basePath: string): Request {
+  return new Request(`http://localhost${basePath}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+      "mcp-protocol-version": "2026-07-28",
+      "mcp-method": "tools/list",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/list",
+      params: {
+        _meta: {
+          "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+          "io.modelcontextprotocol/clientInfo": {
+            name: "raw-request",
+            version: "0.0.0",
+          },
+          "io.modelcontextprotocol/clientCapabilities": {},
+        },
+      },
+    }),
+  });
+}
+
+describe("inspector shell route", () => {
+  it("serves the CDN shell at basePath + /inspector by default", async () => {
+    const server = makeServer();
+    const response = await get(server, "/mcp/inspector");
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toMatch(
+      /^text\/html;\s*charset=utf-8$/i
+    );
+
+    const html = await response.text();
+    expect(html).toContain("<!doctype html>");
+    // The bundle loads from the version-pinned public CDN.
+    expect(html).toContain(`<script type="module" src="${DEFAULT_CDN_URL}">`);
+    // Serialized runtime config: basePath from the server, autoConnectUrl
+    // derived client-side from the page's own origin (no host guessing).
+    expect(html).toContain("window.__MCP_USE_INSPECTOR__");
+    expect(html).toContain('var basePath = "/mcp";');
+    expect(html).toContain("window.location.origin + basePath");
+    // Root node for the bundle to mount into, and a dark background so the
+    // page doesn't flash white before the UI paints.
+    expect(html).toContain('<div id="root">');
+    expect(html).toContain("background-color: #0c0c0d");
+    // The server name appears (escaped) in the title.
+    expect(html).toContain("<title>shell-test — MCP Inspector</title>");
+    await server.close();
+  });
+
+  it("serves the trailing-slash variant and answers HEAD", async () => {
+    const server = makeServer();
+    const withSlash = await get(server, "/mcp/inspector/");
+    expect(withSlash.status).toBe(200);
+    expect(await withSlash.text()).toContain("window.__MCP_USE_INSPECTOR__");
+
+    // Hono answers HEAD from the GET handler with an empty body.
+    const head = await get(server, "/mcp/inspector", "HEAD");
+    expect(head.status).toBe(200);
+    expect(head.headers.get("content-type")).toMatch(/text\/html/i);
+    expect(await head.text()).toBe("");
+    await server.close();
+  });
+
+  it("treats true and {} the same as the default (enabled)", async () => {
+    for (const inspector of [true, {}] as const) {
+      const server = makeServer({ inspector });
+      const response = await get(server, "/mcp/inspector");
+      expect(response.status).toBe(200);
+      expect(await response.text()).toContain(DEFAULT_CDN_URL);
+      await server.close();
+    }
+  });
+
+  it("returns 404 when inspector is false", async () => {
+    const server = makeServer({ inspector: false });
+    expect((await get(server, "/mcp/inspector")).status).toBe(404);
+    expect((await get(server, "/mcp/inspector/")).status).toBe(404);
+    // The MCP endpoint itself is unaffected.
+    const mcp = await server.getHandler()(toolsListRequest("/mcp"));
+    expect(mcp.status).toBe(200);
+    await server.close();
+  });
+
+  it("follows a custom basePath", async () => {
+    const server = makeServer({ basePath: "/api/mcp" });
+    const response = await get(server, "/api/mcp/inspector");
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain('var basePath = "/api/mcp";');
+    // Not mounted at the default location.
+    expect((await get(server, "/mcp/inspector")).status).toBe(404);
+    await server.close();
+  });
+
+  it("loads the bundle from assetsUrl when provided", async () => {
+    const assetsUrl = "https://intranet.example.com/vendor/inspector.js";
+    const server = makeServer({ inspector: { assetsUrl } });
+    const html = await (await get(server, "/mcp/inspector")).text();
+    expect(html).toContain(`<script type="module" src="${assetsUrl}">`);
+    // The default CDN URL is fully replaced, not merely preferred.
+    expect(html).not.toContain("cdn.jsdelivr.net");
+    await server.close();
+  });
+
+  it("never emits user-provided values with an unescaped <", async () => {
+    const server = makeServer({
+      name: 'evil</title><script>alert("pwned")</script>',
+      inspector: { assetsUrl: 'https://x.test/a.js"></script><script>hack()' },
+    });
+    const html = await (await get(server, "/mcp/inspector")).text();
+    expect(html).not.toContain("</title><script>");
+    expect(html).not.toContain("<script>alert");
+    expect(html).not.toContain("<script>hack");
+    expect(html).toContain("evil&lt;/title&gt;");
+    await server.close();
+  });
+
+  it("keeps the MCP endpoint working with the shell enabled", async () => {
+    const server = makeServer();
+    const handler = server.getHandler();
+    const response = await handler(toolsListRequest("/mcp"));
+    expect(response.status).toBe(200);
+    const body: unknown = await response.json();
+    expect(body).toMatchObject({
+      result: { tools: [{ name: "ping" }] },
+    });
+    // And the shell is live on the same handler.
+    const shell = await handler(new Request("http://localhost/mcp/inspector"));
+    expect(shell.status).toBe(200);
+    await server.close();
+  });
+});

--- a/libraries/typescript/packages/server/tests/mcp-server.test.ts
+++ b/libraries/typescript/packages/server/tests/mcp-server.test.ts
@@ -498,6 +498,22 @@ async function rawStatus(
   });
 }
 
+describe("MCPServer basePath accessor", () => {
+  it("defaults to /mcp", () => {
+    const server = new MCPServer({ name: "bp-test", version: "1.0.0" });
+    expect(server.basePath).toBe("/mcp");
+  });
+
+  it("reflects config.basePath", () => {
+    const server = new MCPServer({
+      name: "bp-test",
+      version: "1.0.0",
+      basePath: "/api/mcp",
+    });
+    expect(server.basePath).toBe("/api/mcp");
+  });
+});
+
 describe("MCPServer getHandler (no network)", () => {
   it("serves MCP through the web-standard handler on a custom basePath", async () => {
     const server = new MCPServer({

--- a/libraries/typescript/packages/server/tsconfig.test.json
+++ b/libraries/typescript/packages/server/tsconfig.test.json
@@ -14,5 +14,5 @@
     "rootDir": "."
   },
   "include": ["src/**/*", "tests/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "tests/cli/.tmp"]
 }

--- a/libraries/typescript/packages/server/tsup.config.ts
+++ b/libraries/typescript/packages/server/tsup.config.ts
@@ -3,13 +3,29 @@ import { defineConfig } from "tsup";
 export default defineConfig({
   entry: {
     index: "src/index.ts",
+    // The `mcp-use` bin (package.json "bin"). Its source shebang is
+    // preserved by esbuild, so dist/bin.js stays directly executable.
+    bin: "src/bin.ts",
+    // The dev/build toolchain (Vite), emitted as its own dist/cli/index.js
+    // and reached only via `bin/main.ts`'s dynamic `import("./cli/index.js")`
+    // — nothing in `index`/`bin`'s static import graph reaches src/cli/*,
+    // so `start` and the library export path never evaluate a module that
+    // imports vite (CLI_SPEC.md § Package layout & dependency rules).
+    "cli/index": "src/cli/index.ts",
   },
   // ESM-only: the v2 @modelcontextprotocol/* packages ship no CJS entry, so a
   // CJS build of this package could never load them.
   format: ["esm"],
   target: "node24",
   dts: false,
-  splitting: false,
+  // Splitting on is load-bearing, not a size optimization: without it esbuild
+  // inlines the dynamically-`import()`-ed cli module graph directly into
+  // dist/bin.js as a lazily-*initialized* — but still statically imported —
+  // module, hoisting `import "vite"` to the top of dist/bin.js and violating
+  // the invariant that `start` never evaluates a module that imports vite.
+  // With splitting on, the cli entry becomes a genuinely separate
+  // dist/cli/index.js chunk reached by a real runtime dynamic import.
+  splitting: true,
   sourcemap: true,
   clean: true,
 });

--- a/libraries/typescript/packages/server/vitest.config.ts
+++ b/libraries/typescript/packages/server/vitest.config.ts
@@ -5,8 +5,11 @@ export default defineConfig({
     globals: true,
     environment: "node",
     include: ["tests/**/*.test.ts"],
-    exclude: ["node_modules/**", "dist/**"],
-    testTimeout: 30000,
-    hookTimeout: 30000,
+    exclude: ["node_modules/**", "dist/**", "tests/cli/.tmp/**"],
+    // Real Vite build/dev servers in tests/cli/*.test.ts (moved from the
+    // now-folded-in @mcp-use/devkit package) need more headroom than the rest
+    // of this package's tests.
+    testTimeout: 60000,
+    hookTimeout: 60000,
   },
 });

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -1500,6 +1500,9 @@ importers:
         specifier: '>=4.12.27'
         version: 4.12.27
     devDependencies:
+      '@mcp-use/server':
+        specifier: workspace:*
+        version: 'link:'
       '@modelcontextprotocol/client':
         specifier: 2.0.0-beta.2
         version: 2.0.0-beta.2
@@ -1509,6 +1512,9 @@ importers:
       typescript:
         specifier: 7.0.1-rc
         version: 7.0.1-rc
+      vite:
+        specifier: '>=8.0.5'
+        version: 8.0.16(@types/node@24.13.2)(esbuild@0.27.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: '>=4.1.9'
         version: 4.1.9(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -1531,6 +1537,9 @@ importers:
       typescript:
         specifier: 7.0.1-rc
         version: 7.0.1-rc
+      vite:
+        specifier: '>=8.0.5'
+        version: 8.0.16(@types/node@24.13.2)(esbuild@0.27.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/server/examples/vercel:
     dependencies:
@@ -1886,9 +1895,6 @@ packages:
 
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
-
-  '@emnapi/runtime@1.9.2':
-    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
@@ -2481,18 +2487,6 @@ packages:
   '@modelcontextprotocol/server@2.0.0-beta.2':
     resolution: {integrity: sha512-XK+sgFntT5ZzeqtTGpT9uti+Sqmq7YJZdx/N76eLJv9UA9vKvP04Qh9Hc45LCeIHGfTKRwDG6eh4C1Hs4omyIg==}
     engines: {node: '>=20'}
-
-  '@napi-rs/wasm-runtime@1.1.3':
-    resolution: {integrity: sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==}
-    peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
-
-  '@napi-rs/wasm-runtime@1.1.4':
-    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
-    peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
 
   '@napi-rs/wasm-runtime@1.1.5':
     resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
@@ -4066,9 +4060,6 @@ packages:
     peerDependencies:
       react: ^19.2.0
 
-  '@tybys/wasm-util@0.10.1':
-    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
-
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
@@ -4629,11 +4620,6 @@ packages:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
-
-  acorn@8.15.0:
-    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
 
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
@@ -6732,9 +6718,6 @@ packages:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
     engines: {node: '>= 18'}
 
-  mlly@1.8.0:
-    resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
-
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
@@ -7750,10 +7733,6 @@ packages:
     resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
     engines: {node: '>=18'}
 
-  tinyglobby@0.2.16:
-    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
-    engines: {node: '>=12.0.0'}
-
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
@@ -8689,11 +8668,6 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.9.2':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
@@ -9012,7 +8986,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.9.2
+      '@emnapi/runtime': 1.10.0
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
@@ -9244,20 +9218,6 @@ snapshots:
   '@modelcontextprotocol/server@2.0.0-beta.2':
     dependencies:
       zod: 4.4.3
-
-  '@napi-rs/wasm-runtime@1.1.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
-    dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.1
-    optional: true
-
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
-    dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.2
-    optional: true
 
   '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -9517,7 +9477,7 @@ snapshots:
 
   '@oxc-resolver/binding-wasm32-wasi@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -11414,11 +11374,6 @@ snapshots:
       '@tanstack/query-core': 5.90.20
       react: 19.2.4
 
-  '@tybys/wasm-util@0.10.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   '@tybys/wasm-util@0.10.2':
     dependencies:
       tslib: 2.8.1
@@ -11467,7 +11422,7 @@ snapshots:
 
   '@types/estree-jsx@1.0.5':
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   '@types/estree@1.0.8': {}
 
@@ -11494,7 +11449,7 @@ snapshots:
 
   '@types/jsdom@27.0.0':
     dependencies:
-      '@types/node': 25.2.0
+      '@types/node': 25.6.0
       '@types/tough-cookie': 4.0.5
       parse5: 7.3.0
 
@@ -11857,7 +11812,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@unrs/resolver-binding-win32-arm64-msvc@1.12.2':
@@ -11993,8 +11948,6 @@ snapshots:
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
-
-  acorn@8.15.0: {}
 
   acorn@8.16.0: {}
 
@@ -12957,7 +12910,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   esutils@2.0.3: {}
 
@@ -13302,7 +13255,7 @@ snapshots:
 
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       '@types/hast': 3.0.4
       '@types/unist': 3.0.3
       comma-separated-tokens: 2.0.3
@@ -14436,13 +14389,6 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
-  mlly@1.8.0:
-    dependencies:
-      acorn: 8.15.0
-      pathe: 2.0.3
-      pkg-types: 1.3.1
-      ufo: 1.6.3
-
   mlly@1.8.2:
     dependencies:
       acorn: 8.16.0
@@ -14832,7 +14778,7 @@ snapshots:
   pkg-types@1.3.1:
     dependencies:
       confbox: 0.1.8
-      mlly: 1.8.0
+      mlly: 1.8.2
       pathe: 2.0.3
 
   platform@1.3.6: {}
@@ -15784,11 +15730,6 @@ snapshots:
 
   tinyexec@1.0.2: {}
 
-  tinyglobby@0.2.16:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
@@ -15863,7 +15804,7 @@ snapshots:
       source-map: 0.7.6
       sucrase: 3.35.1
       tinyexec: 0.3.2
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tree-kill: 1.2.2
     optionalDependencies:
       postcss: 8.5.15
@@ -15891,7 +15832,7 @@ snapshots:
       source-map: 0.7.6
       sucrase: 3.35.1
       tinyexec: 0.3.2
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tree-kill: 1.2.2
     optionalDependencies:
       postcss: 8.5.15


### PR DESCRIPTION
## Summary

Lands the v2 `@mcp-use/server` package work on the integration branch: the scaffold, config/validation semantics, and the full build/dev/start toolchain per `packages/server/specs/CLI_SPEC.md` (the implemented contract; `SPEC.md` remains the package contract).

### Toolchain (`mcp-use build` / `dev` / `start`)
- **Single package**: the dev/build toolchain lives in `src/cli/` inside `@mcp-use/server`, reached only through a dynamic import from the bin's dispatch. `start` and the library `"."` export never evaluate vite-importing modules.
- **`vite` is an optional peerDependency** — absent from production installs; missing vite yields an actionable `npm i -D vite` hint.
- **Entry contract**: entry modules `export default server` and never call `listen()` — dev/start own the socket; serverless wraps `getHandler()`.
- **build**: Vite SSR build → `.mcp-use/build/` + manifest. **dev**: Vite Environment API module runner with an atomic handler swap behind one listener (reload, not HMR — v2 servers are stateless). **start**: serves the built entry.

### Inspector (FastAPI `/docs` model)
- `GET ${basePath}/inspector` serves a tiny dependency-free HTML shell that loads the `@mcp-use/inspector` CDN bundle from jsDelivr, pinned to major v11 (verified live: HTTP 200, `access-control-allow-origin: *`).
- `inspector?: boolean | { assetsUrl }` config — default enabled; `assetsUrl` overrides the bundle URL for air-gapped/self-hosted setups.
- The server declares **no dependency of any kind** on `@mcp-use/inspector`; the embedded inspector connects same-origin, so no CORS-proxy backend is mounted (proxy stays with the standalone/hosted inspector).

### Also
- `MCPServer` gains a readonly `basePath` accessor for tooling introspection.
- Legacy wire mode relaxed from `"reject"` to `"stateless"`.
- `allowedHosts`/`allowedOrigins` additive semantics; SDK bumped to `2.0.0-beta.2`.
- `examples/railway` migrated to the entry contract and verified end-to-end.
- Typed `useCallTool` design proposals added under specs.

## Test plan

- `pnpm build` — dist chunk isolation holds (no vite reachable from `dist/bin.js` start path or `dist/index.js`)
- `pnpm test:run` — typecheck + 84 tests across 8 files pass (mcp-server, inspector-shell, bin-start, cli build/dev/entry)
- `npx eslint packages/server/src packages/server/tests` — clean (strictest config: no-`any`, TSDoc enforced)
- examples/railway ran end-to-end via `mcp-use dev`/`build`/`start`

https://claude.ai/code/session_012wzYppyk7JtFePEjweiWFm