### PR TITLE
fix(client): wire oauthProxyUrl + stop misclassifying discovered OAuth servers

### DIFF
--- a/libraries/typescript/.changeset/oauth-proxy-url-and-pending-auth.md
+++ b/libraries/typescript/.changeset/oauth-proxy-url-and-pending-auth.md
@@ -1,0 +1,8 @@
+---
+"mcp-use": minor
+---
+
+Add `oauthProxyUrl` and stop misclassifying discovered OAuth servers as unsupported.
+
+- `UseMcpOptions.oauthProxyUrl` lets consumers route only OAuth traffic (`.well-known` discovery, DCR, token exchange) through a transparent server-side proxy for browser CORS while keeping MCP traffic direct to the server. It takes precedence over the URL derived from `proxyConfig.proxyAddress`, and because the transparent proxy swaps the `fetch` rather than the metadata URLs, RFC 8414 §3.3 issuer validation still passes. This replaces routing MCP through the proxy purely to reach the OAuth endpoints, which anchored OAuth discovery on the proxy origin and broke auth for gateway-hosted servers.
+- `useMcp` no longer drops a server to `failed` with "Server does not support OAuth" when OAuth discovery already succeeded on an earlier pass. If the auth provider has a prepared authorization URL (and `preventAutoAuth` is set), a later discovery failure — e.g. from a token refresh, SSE fallback, or a metadata probe that fell back to the transport origin — surfaces `pending_auth` (keeping the Authenticate button) instead of masking the working OAuth flow.

--- a/libraries/typescript/packages/mcp-use/src/react/types.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/types.ts
@@ -45,6 +45,19 @@ export type UseMcpOptions = {
     customHeaders?: Record<string, string>;
   };
   /**
+   * OAuth proxy base URL (e.g. `https://inspector.example.com/inspector/api/oauth`)
+   * used to route OAuth requests (`.well-known` discovery, DCR, token exchange)
+   * through a transparent server-side proxy — bypassing browser CORS against
+   * third-party identity providers — WITHOUT proxying MCP traffic itself.
+   *
+   * The proxy is transparent: it forwards requests and responses unmodified, so
+   * the SDK's authorization-server issuer validation (RFC 8414 §3.3) still
+   * passes. When omitted, the OAuth proxy URL is derived from
+   * `proxyConfig.proxyAddress` (replacing a trailing `/proxy` with `/oauth`),
+   * preserving the existing behavior for fully-proxied connections.
+   */
+  oauthProxyUrl?: string;
+  /**
    * Connection policy used by higher-level clients such as the Inspector.
    * Behavior is controlled by `proxyConfig` and `autoProxyFallback`; this field
    * is persisted so editors can distinguish Auto, forced Direct, and forced Proxy.

--- a/libraries/typescript/packages/mcp-use/src/react/useMcp-helpers.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/useMcp-helpers.ts
@@ -72,6 +72,12 @@ export function createBrowserOAuthProvider(params: {
   preventAutoAuth: boolean;
   useRedirectFlow: boolean;
   gatewayUrl?: string;
+  /**
+   * Explicit OAuth proxy base URL. Takes precedence over the URL derived from
+   * `gatewayUrl`. Lets consumers proxy OAuth traffic (CORS bypass) while
+   * keeping MCP traffic direct.
+   */
+  oauthProxyUrl?: string;
   onPopupWindow?: (
     url: string,
     features: string,
@@ -89,7 +95,8 @@ export function createBrowserOAuthProvider(params: {
   provider: BrowserOAuthClientProvider;
   oauthProxyUrl?: string;
 } {
-  const oauthProxyUrl = deriveOAuthProxyUrl(params.gatewayUrl);
+  const oauthProxyUrl =
+    params.oauthProxyUrl ?? deriveOAuthProxyUrl(params.gatewayUrl);
   const provider = new BrowserOAuthClientProvider(params.effectiveOAuthUrl, {
     storageKeyPrefix: params.storageKeyPrefix,
     clientName: params.oauthClientConfig.name,

--- a/libraries/typescript/packages/mcp-use/src/react/useMcp.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/useMcp.ts
@@ -112,6 +112,7 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
     headers: headersOption,
     customHeaders: customHeadersOption,
     proxyConfig,
+    oauthProxyUrl: oauthProxyUrlOption,
     autoProxyFallback = true,
     debug: _debug = false,
     logLevel: logLevelOption,
@@ -685,6 +686,7 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
         preventAutoAuth,
         useRedirectFlow,
         gatewayUrl,
+        oauthProxyUrl: oauthProxyUrlOption,
         onPopupWindow,
         proxyOAuthRequests: true,
         staticClientInfo,
@@ -692,10 +694,7 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
       });
       authProviderRef.current = provider;
       if (oauthProxyUrl) {
-        addLog(
-          "debug",
-          `OAuth proxy URL derived from gateway: ${oauthProxyUrl}`
-        );
+        addLog("debug", `OAuth proxy URL in effect: ${oauthProxyUrl}`);
       }
       addLog(
         "debug",
@@ -1133,6 +1132,27 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
         const error = err as Error & { code?: number; message?: string };
         const errorMessage = error?.message || String(err);
 
+        // A prepared authorization URL means OAuth discovery already succeeded on
+        // an earlier pass. A later failure (token refresh, SSE fallback, or a
+        // metadata probe that fell back to the transport origin) must NOT be
+        // misclassified as "server does not support OAuth" — that drops us to
+        // `failed` and hides the Authenticate button. When we already have a
+        // stored auth URL and an OAuth provider, surface `pending_auth` instead.
+        const preparedAuthUrl =
+          authProviderRef.current?.getLastAttemptedAuthUrl?.();
+        if (preparedAuthUrl && authProviderRef.current && preventAutoAuth) {
+          addLog(
+            "info",
+            "OAuth already discovered (stored auth URL present); awaiting manual authentication."
+          );
+          if (isMountedRef.current) {
+            setState("pending_auth");
+            setAuthUrl(preparedAuthUrl);
+          }
+          connectingRef.current = false;
+          return "auth_redirect";
+        }
+
         // Check if OAuth discovery failed (indicates server doesn't support OAuth)
         // This happens when a 401 triggers OAuth discovery but the server has no OAuth endpoints
         const oauthDiscoveryFailed = isOAuthDiscoveryFailure(err);
@@ -1370,6 +1390,7 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
     mergedClientInfo,
     // IMPORTANT: Include proxy-related dependencies so connect() uses updated values after fallback
     gatewayUrl,
+    oauthProxyUrlOption,
     allHeaders,
     effectiveOAuthUrl,
   ]);
@@ -1564,7 +1585,11 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
           onPopupWindow?.(popupUrl, features, popupWin);
         };
 
-        // Recreate the auth provider WITHOUT preventAutoAuth
+        // Recreate the auth provider WITHOUT preventAutoAuth.
+        // proxyOAuthRequests is always true: the scoped OAuth proxy fetch is
+        // the sole browser-CORS mechanism (the gateway no longer fronts OAuth
+        // metadata — it broke RFC 8414 §3.3 issuer validation for strict
+        // clients). It is a no-op when no OAuth proxy URL is configured.
         const { provider: freshAuthProvider, oauthProxyUrl } =
           createBrowserOAuthProvider({
             effectiveOAuthUrl,
@@ -1574,19 +1599,15 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
             preventAutoAuth: false,
             useRedirectFlow,
             gatewayUrl,
+            oauthProxyUrl: oauthProxyUrlOption,
             onPopupWindow: captureOnPopupWindow,
-            proxyOAuthRequests: !gatewayUrl,
+            proxyOAuthRequests: true,
             staticClientInfo,
             scope: oauthScope,
           });
 
-        if (oauthProxyUrl && !gatewayUrl) {
+        if (oauthProxyUrl) {
           addLog("info", "Scoped OAuth proxy fetch enabled for manual auth");
-        } else if (oauthProxyUrl && gatewayUrl) {
-          addLog(
-            "info",
-            "Using MCP gateway proxy for OAuth (no scoped OAuth fetch needed)"
-          );
         }
 
         // Replace the auth provider
@@ -2300,6 +2321,7 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
         preventAutoAuth,
         useRedirectFlow,
         gatewayUrl,
+        oauthProxyUrl: oauthProxyUrlOption,
         onPopupWindow,
         proxyOAuthRequests: true,
         staticClientInfo,
@@ -2307,10 +2329,7 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
       });
       authProviderRef.current = provider;
       if (oauthProxyUrl) {
-        addLog(
-          "debug",
-          `OAuth proxy URL derived from gateway: ${oauthProxyUrl}`
-        );
+        addLog("debug", `OAuth proxy URL in effect: ${oauthProxyUrl}`);
       }
       addLog(
         "debug",


### PR DESCRIPTION
## Summary

Fixes the missing **Authenticate** button on hosted OAuth MCP servers in the cloud dashboard.

Root cause: routing hosted-server MCP traffic through the inspector proxy (to reach OAuth endpoints for CORS) anchored OAuth discovery on the **proxy origin**. A secondary discovery pass (stale-token refresh / SSE fallback) then hit an HTML/500 on `inspector.../.well-known/oauth-authorization-server`, which `isOAuthDiscoveryFailure()` matched — so `useMcp` set state `failed` with *"Server does not support OAuth"* instead of `pending_auth`, hiding the button.

This ports the `oauthProxyUrl` option (previously only on the v2 branch) onto the 1.x line and adds a misclassification guard, so the cloud can consume it via a normal `mcp-use` version bump.

## Changes

- **Wire `UseMcpOptions.oauthProxyUrl` end-to-end.** `createBrowserOAuthProvider` now honors an explicit `oauthProxyUrl` (precedence over the URL derived from `proxyConfig.proxyAddress`). This lets consumers proxy only OAuth traffic (`.well-known`, DCR, token) for browser CORS while MCP traffic stays **direct** to the server/gateway. The transparent proxy swaps the `fetch`, not the metadata URLs, so RFC 8414 §3.3 issuer validation still passes. The `preventAutoAuth` manual-auth flow now always uses the scoped OAuth proxy fetch (`proxyOAuthRequests: true`) instead of the MCP gateway proxy.
- **Stop misclassifying discovered OAuth servers.** In the connect `catch`, if the auth provider already has a prepared authorization URL (discovery succeeded earlier) and `preventAutoAuth` is set, surface `pending_auth` (keeping the Authenticate button) rather than failing with "server does not support OAuth" on a later refresh/fallback error.

Changeset: `mcp-use` minor.