### PR TITLE
fix(auth): re-anchor proxy-origin .well-known discovery onto the MCP server

### DIFF
--- a/libraries/typescript/.changeset/reanchor-wellknown-discovery.md
+++ b/libraries/typescript/.changeset/reanchor-wellknown-discovery.md
@@ -1,0 +1,9 @@
+---
+"mcp-use": patch
+---
+
+Fix OAuth discovery for MCP connections tunneled through a gateway/inspector proxy.
+
+When MCP traffic goes through a proxy (`proxyConfig` / `gatewayUrl`), the SDK transport derives `/.well-known/*` discovery URLs from the proxy URL whenever no `resource_metadata` hint is available — the SSE transport's EventSource cannot read `WWW-Authenticate`, and token refresh runs without a 401 response at hand. Discovery then landed on the proxy origin (which serves no OAuth metadata), failed, and the server was misclassified as "does not support OAuth", hiding the Authenticate button.
+
+`BrowserOAuthClientProvider.getProxyFetch()` now re-anchors connection-origin `.well-known` lookups onto the actual MCP server before routing them through the OAuth proxy, reproducing exactly what a direct connection would have requested (including the RFC 8414 §3.1 / RFC 9728 §3.1 path-insertion form). MCP traffic can therefore always stay behind the proxy — required since browser CORS on direct connections cannot be guaranteed (edge errors bypass CORS middleware) — without breaking OAuth discovery.

--- a/libraries/typescript/packages/mcp-use/src/auth/browser-provider.ts
+++ b/libraries/typescript/packages/mcp-use/src/auth/browser-provider.ts
@@ -132,6 +132,47 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
   }
 
   /**
+   * Re-anchor an SDK-derived OAuth discovery URL from the MCP connection
+   * (proxy) origin onto the actual MCP server.
+   *
+   * When MCP traffic is tunneled through a gateway/inspector proxy, the SDK
+   * transport derives `/.well-known/*` URLs from the URL it connected to (the
+   * proxy) whenever no `resource_metadata` hint is available — the SSE
+   * transport's EventSource cannot read `WWW-Authenticate`, and token refresh
+   * runs without a 401 response at hand. The proxy origin serves no OAuth
+   * metadata, so discovery would fail and the server would be misclassified
+   * as "does not support OAuth". Rewriting reproduces what a direct
+   * connection would have requested: the same well-known document, anchored
+   * on the server origin, with the RFC 8414 §3.1 / RFC 9728 §3.1 path
+   * insertion using the server's path instead of the proxy's.
+   */
+  private reanchorWellKnownUrl(url: string): string {
+    if (!this.connectionUrl) return url;
+    try {
+      const requested = new URL(url);
+      const connection = new URL(this.connectionUrl);
+      if (requested.origin !== connection.origin) return url;
+      if (!requested.pathname.startsWith("/.well-known/")) return url;
+
+      const target = new URL(this.serverUrl);
+      const rest = requested.pathname.slice("/.well-known/".length);
+      const [doc, ...suffixParts] = rest.split("/");
+      if (!doc) return url;
+
+      const suffix = suffixParts.length ? `/${suffixParts.join("/")}` : "";
+      const connectionPath = connection.pathname.replace(/\/+$/, "");
+      const targetPath = target.pathname.replace(/\/+$/, "");
+      // Path-insertion form: swap the proxy's inserted path for the server's.
+      // Root form (no suffix) stays root. Unrelated suffixes are preserved.
+      const newSuffix = suffix && suffix === connectionPath ? targetPath : suffix;
+
+      return `${target.origin}/.well-known/${doc}${newSuffix}${requested.search}`;
+    } catch {
+      return url;
+    }
+  }
+
+  /**
    * Returns a `fetch` function, scoped to this provider, that routes OAuth
    * requests (`.well-known` metadata, token, register, authorize) through the
    * configured `oauthProxyUrl` to bypass CORS. All other requests are passed
@@ -167,12 +208,17 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
       input: RequestInfo | URL,
       init?: RequestInit
     ): Promise<Response> => {
-      const url =
+      const requestedUrl =
         typeof input === "string"
           ? input
           : input instanceof URL
             ? input.toString()
             : input.url;
+
+      // SDK discovery derives .well-known URLs from the transport URL; when MCP
+      // is tunneled through a proxy that is the proxy origin. Re-anchor those
+      // onto the real MCP server before deciding how to route the request.
+      const url = this.reanchorWellKnownUrl(requestedUrl);
 
       // Check if this is an OAuth-related request that needs CORS bypass
       const isOAuthRequest =
@@ -285,7 +331,11 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
           "[OAuth Proxy] Request failed, falling back to direct fetch:",
           error
         );
-        return await base(input, init);
+        // Fall back to the re-anchored URL — a direct fetch to the proxy
+        // origin would never serve OAuth metadata.
+        return url !== requestedUrl
+          ? await base(url, init)
+          : await base(input, init);
       }
     };
   }

--- a/libraries/typescript/packages/mcp-use/src/auth/browser-provider.ts
+++ b/libraries/typescript/packages/mcp-use/src/auth/browser-provider.ts
@@ -164,7 +164,8 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
       const targetPath = target.pathname.replace(/\/+$/, "");
       // Path-insertion form: swap the proxy's inserted path for the server's.
       // Root form (no suffix) stays root. Unrelated suffixes are preserved.
-      const newSuffix = suffix && suffix === connectionPath ? targetPath : suffix;
+      const newSuffix =
+        suffix && suffix === connectionPath ? targetPath : suffix;
 
       return `${target.origin}/.well-known/${doc}${newSuffix}${requested.search}`;
     } catch {

--- a/libraries/typescript/packages/mcp-use/tests/unit/auth/browser-provider-proxy-fetch.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/auth/browser-provider-proxy-fetch.test.ts
@@ -201,7 +201,9 @@ describe("BrowserOAuthClientProvider — scoped OAuth proxy fetch", () => {
     });
 
     it("does not rewrite anything when no connectionUrl is configured (direct)", async () => {
-      const scoped = makeProvider({ oauthProxyUrl: PROXY_URL }).getProxyFetch()!;
+      const scoped = makeProvider({
+        oauthProxyUrl: PROXY_URL,
+      }).getProxyFetch()!;
 
       await scoped(
         "https://server-a.example.com/.well-known/oauth-protected-resource/mcp"

--- a/libraries/typescript/packages/mcp-use/tests/unit/auth/browser-provider-proxy-fetch.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/auth/browser-provider-proxy-fetch.test.ts
@@ -143,4 +143,73 @@ describe("BrowserOAuthClientProvider — scoped OAuth proxy fetch", () => {
     expect(customFetch).toHaveBeenCalledTimes(1);
     expect(globalFetchSpy).not.toHaveBeenCalled();
   });
+
+  describe("re-anchoring proxy-origin .well-known discovery onto the MCP server", () => {
+    // MCP traffic tunneled through a gateway proxy: the SDK transport derives
+    // .well-known URLs from the proxy URL whenever no resource_metadata hint is
+    // available (SSE EventSource can't read WWW-Authenticate; token refresh has
+    // no 401 response). Those must be re-anchored onto the real server or
+    // discovery lands on the proxy origin and fails.
+    const CONNECTION_URL = "https://inspector.local/inspector/api/proxy";
+
+    function makeProxiedProvider() {
+      return makeProvider({
+        oauthProxyUrl: PROXY_URL,
+        connectionUrl: CONNECTION_URL,
+      });
+    }
+
+    function proxiedMetadataTarget(callIndex: number): string {
+      const proxied = new URL(String(globalFetchSpy.mock.calls[callIndex][0]));
+      return proxied.searchParams.get("url")!;
+    }
+
+    it("rewrites the path-insertion PRM lookup to the server origin + path", async () => {
+      const scoped = makeProxiedProvider().getProxyFetch()!;
+
+      await scoped(
+        "https://inspector.local/.well-known/oauth-protected-resource/inspector/api/proxy"
+      );
+
+      expect(proxiedMetadataTarget(0)).toBe(
+        "https://server-a.example.com/.well-known/oauth-protected-resource/mcp"
+      );
+    });
+
+    it("rewrites the root-form AS metadata lookup to the server origin", async () => {
+      const scoped = makeProxiedProvider().getProxyFetch()!;
+
+      await scoped(
+        "https://inspector.local/.well-known/oauth-authorization-server"
+      );
+
+      expect(proxiedMetadataTarget(0)).toBe(
+        "https://server-a.example.com/.well-known/oauth-authorization-server"
+      );
+    });
+
+    it("leaves .well-known lookups on unrelated origins untouched", async () => {
+      const scoped = makeProxiedProvider().getProxyFetch()!;
+
+      await scoped(
+        "https://idp.example.org/.well-known/oauth-authorization-server"
+      );
+
+      expect(proxiedMetadataTarget(0)).toBe(
+        "https://idp.example.org/.well-known/oauth-authorization-server"
+      );
+    });
+
+    it("does not rewrite anything when no connectionUrl is configured (direct)", async () => {
+      const scoped = makeProvider({ oauthProxyUrl: PROXY_URL }).getProxyFetch()!;
+
+      await scoped(
+        "https://server-a.example.com/.well-known/oauth-protected-resource/mcp"
+      );
+
+      expect(proxiedMetadataTarget(0)).toBe(
+        "https://server-a.example.com/.well-known/oauth-protected-resource/mcp"
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up to #1840/#1841: the `pending_auth` guard alone did not restore the Authenticate button for gateway-hosted OAuth servers (verified live on manufact.com with 1.34.0), because discovery fails *before* any auth URL is prepared.

**Root cause:** MCP traffic is (correctly, and by design) always tunneled through the gateway/inspector proxy — browser CORS on direct connections cannot be guaranteed since edge errors (Cloudflare 502s, redirects) bypass the gateway's CORS middleware. But with the transport connected to the proxy URL, the SDK derives `/.well-known/*` discovery URLs from the **proxy origin** whenever no `resource_metadata` hint is available: the SSE transport's EventSource cannot read `WWW-Authenticate`, and token refresh runs without a 401 response at hand. Discovery then lands on `inspector…/.well-known/oauth-authorization-server` (HTML/404), matches `isOAuthDiscoveryFailure()`, and the server is misclassified as "does not support OAuth" — hiding the Authenticate button.

**Fix:** `BrowserOAuthClientProvider.getProxyFetch()` now re-anchors connection-origin `.well-known` lookups onto the actual MCP server before routing them through the OAuth proxy — reproducing exactly what a direct connection would have requested, including the RFC 8414 §3.1 / RFC 9728 §3.1 path-insertion form (`/.well-known/oauth-protected-resource/inspector/api/proxy` → `https://<server>/.well-known/oauth-protected-resource/mcp`). Unrelated origins (e.g. the IdP's own metadata) are untouched, and nothing changes for direct connections (no `connectionUrl`).

## Verification

- Unit tests added for path-insertion PRM, root-form AS metadata, unrelated origins, and the direct (no `connectionUrl`) case.
- Headless replay of the exact failing prod call shape — `auth(provider, { serverUrl: <proxy URL> })` with **no** `resourceMetadataUrl`, against live infra (AgentMail/Clerk through inspector.manufact.com) — now completes to `REDIRECT` with a stored Clerk authorization URL (previously: discovery failure on the inspector origin).

Changeset: `mcp-use` patch.

## Test plan

- [ ] CI green (the jsdom `localStorage.clear` failures in this test file are a local-env quirk; CI runs them)
- [ ] After release: bump mcp-use in mcp-use-cloud (website keeps `proxyConfig` for ALL servers) and verify the Authenticate button on the AgentMail overview