### PR TITLE
Release v1.34.1 — hosted OAuth discovery through the proxy

### DIFF
--- a/docs/typescript/changelog/changelog.mdx
+++ b/docs/typescript/changelog/changelog.mdx
@@ -6,6 +6,13 @@ tag: "New"
 rss: true
 ---
 
+<Update label="v1.34.1" description="July 2026">
+  ## Hosted OAuth discovery through the proxy
+  Patch release fixing the Authenticate button on gateway-hosted OAuth servers when MCP traffic is proxied for CORS.
+
+- **Fix** (auth): `BrowserOAuthClientProvider` re-anchors proxy-origin `.well-known` OAuth discovery onto the actual MCP server. When MCP is tunneled through the inspector/gateway proxy, the SDK derived discovery URLs from the proxy origin whenever no `WWW-Authenticate` hint was available (SSE transport, token refresh) — discovery failed on the proxy origin and the server was misclassified as "does not support OAuth". Lookups are now rewritten to the server origin (including the RFC 8414 §3.1 / RFC 9728 §3.1 path-insertion form), so MCP traffic can stay behind the proxy while OAuth still resolves (`#1843`)
+</Update>
+
 <Update label="v1.34.0" description="July 2026">
   <Frame>
     <img src="https://mcp-use.com/api/og/release?v=1.34.0&title=OAuth%20proxy%20URL%20%26%20hosted%20auth%20reliability&date=2026-07&lang=typescript" alt="Release 1.34.0" />

--- a/libraries/typescript/.changeset/pre.json
+++ b/libraries/typescript/.changeset/pre.json
@@ -1,0 +1,11 @@
+{
+  "mode": "pre",
+  "tag": "canary",
+  "initialVersions": {
+    "@mcp-use/cli": "3.6.1",
+    "create-mcp-use-app": "0.14.17",
+    "@mcp-use/inspector": "12.0.0",
+    "mcp-use": "1.34.0"
+  },
+  "changesets": []
+}

--- a/libraries/typescript/.changeset/pre.json
+++ b/libraries/typescript/.changeset/pre.json
@@ -7,5 +7,7 @@
     "@mcp-use/inspector": "12.0.0",
     "mcp-use": "1.34.0"
   },
-  "changesets": []
+  "changesets": [
+    "reanchor-wellknown-discovery"
+  ]
 }

--- a/libraries/typescript/.changeset/reanchor-wellknown-discovery.md
+++ b/libraries/typescript/.changeset/reanchor-wellknown-discovery.md
@@ -1,0 +1,9 @@
+---
+"mcp-use": patch
+---
+
+Fix OAuth discovery for MCP connections tunneled through a gateway/inspector proxy.
+
+When MCP traffic goes through a proxy (`proxyConfig` / `gatewayUrl`), the SDK transport derives `/.well-known/*` discovery URLs from the proxy URL whenever no `resource_metadata` hint is available — the SSE transport's EventSource cannot read `WWW-Authenticate`, and token refresh runs without a 401 response at hand. Discovery then landed on the proxy origin (which serves no OAuth metadata), failed, and the server was misclassified as "does not support OAuth", hiding the Authenticate button.
+
+`BrowserOAuthClientProvider.getProxyFetch()` now re-anchors connection-origin `.well-known` lookups onto the actual MCP server before routing them through the OAuth proxy, reproducing exactly what a direct connection would have requested (including the RFC 8414 §3.1 / RFC 9728 §3.1 path-insertion form). MCP traffic can therefore always stay behind the proxy — required since browser CORS on direct connections cannot be guaranteed (edge errors bypass CORS middleware) — without breaking OAuth discovery.

--- a/libraries/typescript/packages/cli/CHANGELOG.md
+++ b/libraries/typescript/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @mcp-use/cli
 
+## 3.6.2-canary.0
+
+### Patch Changes
+
+- Updated dependencies [bda5276]
+  - mcp-use@1.34.1-canary.0
+  - @mcp-use/inspector@12.0.1-canary.0
+
 ## 3.6.1
 
 ### Patch Changes

--- a/libraries/typescript/packages/cli/package.json
+++ b/libraries/typescript/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-use/cli",
   "type": "module",
-  "version": "3.6.1",
+  "version": "3.6.2-canary.0",
   "description": "The mcp-use CLI is a tool for building and deploying MCP servers with support for ChatGPT Apps, Code Mode, OAuth, Notifications, Sampling, Observability and more.",
   "author": "mcp-use, Inc.",
   "license": "MIT",

--- a/libraries/typescript/packages/inspector/CHANGELOG.md
+++ b/libraries/typescript/packages/inspector/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @mcp-use/inspector
 
+## 12.0.1-canary.0
+
+### Patch Changes
+
+- Updated dependencies [bda5276]
+  - mcp-use@1.34.1-canary.0
+
 ## 12.0.0
 
 ### Patch Changes

--- a/libraries/typescript/packages/inspector/package.json
+++ b/libraries/typescript/packages/inspector/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-use/inspector",
   "type": "module",
-  "version": "12.0.0",
+  "version": "12.0.1-canary.0",
   "description": "MCP Inspector - A tool for inspecting and debugging MCP servers",
   "author": "",
   "license": "MIT",
@@ -80,7 +80,7 @@
   },
   "peerDependencies": {
     "express": "^4.21.2 || ^5.0.0",
-    "mcp-use": ">=1.34.0-canary.0",
+    "mcp-use": ">=1.34.1-canary.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
     "react-router": "^7.12.0"

--- a/libraries/typescript/packages/mcp-use/CHANGELOG.md
+++ b/libraries/typescript/packages/mcp-use/CHANGELOG.md
@@ -1,5 +1,17 @@
 # mcp-use
 
+## 1.34.1-canary.0
+
+### Patch Changes
+
+- bda5276: Fix OAuth discovery for MCP connections tunneled through a gateway/inspector proxy.
+
+  When MCP traffic goes through a proxy (`proxyConfig` / `gatewayUrl`), the SDK transport derives `/.well-known/*` discovery URLs from the proxy URL whenever no `resource_metadata` hint is available — the SSE transport's EventSource cannot read `WWW-Authenticate`, and token refresh runs without a 401 response at hand. Discovery then landed on the proxy origin (which serves no OAuth metadata), failed, and the server was misclassified as "does not support OAuth", hiding the Authenticate button.
+
+  `BrowserOAuthClientProvider.getProxyFetch()` now re-anchors connection-origin `.well-known` lookups onto the actual MCP server before routing them through the OAuth proxy, reproducing exactly what a direct connection would have requested (including the RFC 8414 §3.1 / RFC 9728 §3.1 path-insertion form). MCP traffic can therefore always stay behind the proxy — required since browser CORS on direct connections cannot be guaranteed (edge errors bypass CORS middleware) — without breaking OAuth discovery.
+  - @mcp-use/cli@3.6.2-canary.0
+  - @mcp-use/inspector@12.0.1-canary.0
+
 ## 1.34.0
 
 ### Minor Changes

--- a/libraries/typescript/packages/mcp-use/package.json
+++ b/libraries/typescript/packages/mcp-use/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-use",
   "type": "module",
-  "version": "1.34.0",
+  "version": "1.34.1-canary.0",
   "packageManager": "pnpm@10.26.0+sha512.3b3f6c725ebe712506c0ab1ad4133cf86b1f4b687effce62a9b38b4d72e3954242e643190fc51fa1642949c735f403debd44f5cb0edd657abe63a8b6a7e1e402",
   "description": "Opinionated MCP Framework for TypeScript (@modelcontextprotocol/sdk compatible) - Build MCP Agents, Clients and Servers with support for ChatGPT Apps, Code Mode, OAuth, Notifications, Sampling, Observability and more.",
   "author": "mcp-use, Inc.",

--- a/libraries/typescript/packages/mcp-use/src/auth/browser-provider.ts
+++ b/libraries/typescript/packages/mcp-use/src/auth/browser-provider.ts
@@ -132,6 +132,48 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
   }
 
   /**
+   * Re-anchor an SDK-derived OAuth discovery URL from the MCP connection
+   * (proxy) origin onto the actual MCP server.
+   *
+   * When MCP traffic is tunneled through a gateway/inspector proxy, the SDK
+   * transport derives `/.well-known/*` URLs from the URL it connected to (the
+   * proxy) whenever no `resource_metadata` hint is available — the SSE
+   * transport's EventSource cannot read `WWW-Authenticate`, and token refresh
+   * runs without a 401 response at hand. The proxy origin serves no OAuth
+   * metadata, so discovery would fail and the server would be misclassified
+   * as "does not support OAuth". Rewriting reproduces what a direct
+   * connection would have requested: the same well-known document, anchored
+   * on the server origin, with the RFC 8414 §3.1 / RFC 9728 §3.1 path
+   * insertion using the server's path instead of the proxy's.
+   */
+  private reanchorWellKnownUrl(url: string): string {
+    if (!this.connectionUrl) return url;
+    try {
+      const requested = new URL(url);
+      const connection = new URL(this.connectionUrl);
+      if (requested.origin !== connection.origin) return url;
+      if (!requested.pathname.startsWith("/.well-known/")) return url;
+
+      const target = new URL(this.serverUrl);
+      const rest = requested.pathname.slice("/.well-known/".length);
+      const [doc, ...suffixParts] = rest.split("/");
+      if (!doc) return url;
+
+      const suffix = suffixParts.length ? `/${suffixParts.join("/")}` : "";
+      const connectionPath = connection.pathname.replace(/\/+$/, "");
+      const targetPath = target.pathname.replace(/\/+$/, "");
+      // Path-insertion form: swap the proxy's inserted path for the server's.
+      // Root form (no suffix) stays root. Unrelated suffixes are preserved.
+      const newSuffix =
+        suffix && suffix === connectionPath ? targetPath : suffix;
+
+      return `${target.origin}/.well-known/${doc}${newSuffix}${requested.search}`;
+    } catch {
+      return url;
+    }
+  }
+
+  /**
    * Returns a `fetch` function, scoped to this provider, that routes OAuth
    * requests (`.well-known` metadata, token, register, authorize) through the
    * configured `oauthProxyUrl` to bypass CORS. All other requests are passed
@@ -167,12 +209,17 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
       input: RequestInfo | URL,
       init?: RequestInit
     ): Promise<Response> => {
-      const url =
+      const requestedUrl =
         typeof input === "string"
           ? input
           : input instanceof URL
             ? input.toString()
             : input.url;
+
+      // SDK discovery derives .well-known URLs from the transport URL; when MCP
+      // is tunneled through a proxy that is the proxy origin. Re-anchor those
+      // onto the real MCP server before deciding how to route the request.
+      const url = this.reanchorWellKnownUrl(requestedUrl);
 
       // Check if this is an OAuth-related request that needs CORS bypass
       const isOAuthRequest =
@@ -285,7 +332,11 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
           "[OAuth Proxy] Request failed, falling back to direct fetch:",
           error
         );
-        return await base(input, init);
+        // Fall back to the re-anchored URL — a direct fetch to the proxy
+        // origin would never serve OAuth metadata.
+        return url !== requestedUrl
+          ? await base(url, init)
+          : await base(input, init);
       }
     };
   }

--- a/libraries/typescript/packages/mcp-use/tests/unit/auth/browser-provider-proxy-fetch.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/auth/browser-provider-proxy-fetch.test.ts
@@ -143,4 +143,75 @@ describe("BrowserOAuthClientProvider — scoped OAuth proxy fetch", () => {
     expect(customFetch).toHaveBeenCalledTimes(1);
     expect(globalFetchSpy).not.toHaveBeenCalled();
   });
+
+  describe("re-anchoring proxy-origin .well-known discovery onto the MCP server", () => {
+    // MCP traffic tunneled through a gateway proxy: the SDK transport derives
+    // .well-known URLs from the proxy URL whenever no resource_metadata hint is
+    // available (SSE EventSource can't read WWW-Authenticate; token refresh has
+    // no 401 response). Those must be re-anchored onto the real server or
+    // discovery lands on the proxy origin and fails.
+    const CONNECTION_URL = "https://inspector.local/inspector/api/proxy";
+
+    function makeProxiedProvider() {
+      return makeProvider({
+        oauthProxyUrl: PROXY_URL,
+        connectionUrl: CONNECTION_URL,
+      });
+    }
+
+    function proxiedMetadataTarget(callIndex: number): string {
+      const proxied = new URL(String(globalFetchSpy.mock.calls[callIndex][0]));
+      return proxied.searchParams.get("url")!;
+    }
+
+    it("rewrites the path-insertion PRM lookup to the server origin + path", async () => {
+      const scoped = makeProxiedProvider().getProxyFetch()!;
+
+      await scoped(
+        "https://inspector.local/.well-known/oauth-protected-resource/inspector/api/proxy"
+      );
+
+      expect(proxiedMetadataTarget(0)).toBe(
+        "https://server-a.example.com/.well-known/oauth-protected-resource/mcp"
+      );
+    });
+
+    it("rewrites the root-form AS metadata lookup to the server origin", async () => {
+      const scoped = makeProxiedProvider().getProxyFetch()!;
+
+      await scoped(
+        "https://inspector.local/.well-known/oauth-authorization-server"
+      );
+
+      expect(proxiedMetadataTarget(0)).toBe(
+        "https://server-a.example.com/.well-known/oauth-authorization-server"
+      );
+    });
+
+    it("leaves .well-known lookups on unrelated origins untouched", async () => {
+      const scoped = makeProxiedProvider().getProxyFetch()!;
+
+      await scoped(
+        "https://idp.example.org/.well-known/oauth-authorization-server"
+      );
+
+      expect(proxiedMetadataTarget(0)).toBe(
+        "https://idp.example.org/.well-known/oauth-authorization-server"
+      );
+    });
+
+    it("does not rewrite anything when no connectionUrl is configured (direct)", async () => {
+      const scoped = makeProvider({
+        oauthProxyUrl: PROXY_URL,
+      }).getProxyFetch()!;
+
+      await scoped(
+        "https://server-a.example.com/.well-known/oauth-protected-resource/mcp"
+      );
+
+      expect(proxiedMetadataTarget(0)).toBe(
+        "https://server-a.example.com/.well-known/oauth-protected-resource/mcp"
+      );
+    });
+  });
 });


### PR DESCRIPTION
Promotes `canary` to `main` for the **v1.34.1** patch release.

## What ships

- **Fix** (`mcp-use`, auth): `BrowserOAuthClientProvider` re-anchors proxy-origin `.well-known` OAuth discovery onto the actual MCP server (#1843). Restores the Authenticate button on gateway-hosted OAuth servers (e.g. AgentMail) while keeping ALL MCP traffic behind the inspector proxy for CORS. Verified in prod against the live AgentMail server.

Includes the changelog entry for v1.34.1.

## After merge

The `main` release workflow opens the "exit prerelease mode and version packages" PR — merging that publishes `mcp-use@1.34.1` to the `latest` tag.