### PR TITLE
fix(inspector): support backend-less CDN shell — auto-connect + real version (MCP-2601)

### DIFF
--- a/libraries/typescript/.changeset/inspector-cdn-shell-fixes.md
+++ b/libraries/typescript/.changeset/inspector-cdn-shell-fixes.md
@@ -3,9 +3,9 @@
 ---
 
 Fix the CDN bundle when served by a backend-less shell (the upcoming
-`@mcp-use/server` v2 `/inspector` route):
+SDK v2 `/inspector` route):
 
-- Auto-connect now reads the connect URL the shell injects as
+- Auto-connect now reads the connect URL the SDK v2 shell injects as
   `window.__MCP_USE_INSPECTOR__.autoConnectUrl` instead of requiring the
   inspector backend's `config.json` endpoint.
 - The version badge and MCP `clientInfo` fall back to the compile-time

--- a/libraries/typescript/.changeset/inspector-cdn-shell-fixes.md
+++ b/libraries/typescript/.changeset/inspector-cdn-shell-fixes.md
@@ -1,0 +1,13 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Fix the CDN bundle when served by a backend-less shell (the upcoming
+`@mcp-use/server` v2 `/inspector` route):
+
+- Auto-connect now reads the connect URL the shell injects as
+  `window.__MCP_USE_INSPECTOR__.autoConnectUrl` instead of requiring the
+  inspector backend's `config.json` endpoint.
+- The version badge and MCP `clientInfo` fall back to the compile-time
+  bundle version when `window.__INSPECTOR_VERSION__` is not injected,
+  instead of reporting a hardcoded `1.0.0`.

--- a/libraries/typescript/packages/inspector/src/client/App.tsx
+++ b/libraries/typescript/packages/inspector/src/client/App.tsx
@@ -16,6 +16,7 @@ import { toast } from "sonner";
 import { InspectorProvider, useInspector } from "./context/InspectorContext";
 import { ThemeProvider } from "./context/ThemeContext";
 import { WidgetDebugProvider } from "./context/WidgetDebugContext";
+import { getPackageVersion } from "@/client/telemetry";
 import { getDefaultInspectorProxyAddress } from "./utils/connectionUpdates";
 
 /**
@@ -101,7 +102,7 @@ function App() {
           }
           clientInfo={{
             name: "mcp-use Inspector",
-            version: (window as any).__INSPECTOR_VERSION__,
+            version: getPackageVersion(),
             websiteUrl: "https://mcp-use.com",
             icons: [{ src: "https://mcp-use.com/logo.png" }],
             capabilities: {

--- a/libraries/typescript/packages/inspector/src/client/components/InspectorDashboard.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/InspectorDashboard.tsx
@@ -15,6 +15,7 @@ import {
   TooltipTrigger,
 } from "@/client/components/ui/tooltip";
 import {
+  getPackageVersion,
   MCPServerAddedEvent,
   MCPServerConnectionEvent,
   MCPServerRemovedEvent,
@@ -797,10 +798,7 @@ export function InspectorDashboard() {
                   variant="secondary"
                   className="text-xs cursor-pointer hover:bg-secondary/80 transition-colors"
                 >
-                  v
-                  {(typeof window !== "undefined" &&
-                    (window as any).__INSPECTOR_VERSION__) ||
-                    "1.0.0"}
+                  v{getPackageVersion()}
                 </Badge>
               </a>
             </TooltipTrigger>

--- a/libraries/typescript/packages/inspector/src/client/hooks/useAutoConnect.ts
+++ b/libraries/typescript/packages/inspector/src/client/hooks/useAutoConnect.ts
@@ -551,6 +551,24 @@ export function useAutoConnect({
       return;
     }
 
+    // Serialized runtime config injected by the @mcp-use/server v2 CDN shell
+    // (window.__MCP_USE_INSPECTOR__) — the shell has no inspector backend, so
+    // this replaces the config.json fetch below.
+    const shellAutoConnectUrl = (
+      window as Window & {
+        __MCP_USE_INSPECTOR__?: { autoConnectUrl?: string };
+      }
+    ).__MCP_USE_INSPECTOR__?.autoConnectUrl;
+    if (shellAutoConnectUrl) {
+      const config = parseAutoConnectParam(shellAutoConnectUrl);
+      if (config) {
+        handleAutoConnectConfig(config);
+      }
+
+      setConfigLoaded(true);
+      return;
+    }
+
     // Fallback to config.json
     fetch("/inspector/config.json")
       .then((res) => res.json())

--- a/libraries/typescript/packages/inspector/src/client/hooks/useAutoConnect.ts
+++ b/libraries/typescript/packages/inspector/src/client/hooks/useAutoConnect.ts
@@ -551,7 +551,7 @@ export function useAutoConnect({
       return;
     }
 
-    // Serialized runtime config injected by the @mcp-use/server v2 CDN shell
+    // Serialized runtime config injected by the SDK v2 CDN shell
     // (window.__MCP_USE_INSPECTOR__) — the shell has no inspector backend, so
     // this replaces the config.json fetch below.
     const shellAutoConnectUrl = (

--- a/libraries/typescript/packages/inspector/src/client/telemetry/utils.ts
+++ b/libraries/typescript/packages/inspector/src/client/telemetry/utils.ts
@@ -1,6 +1,11 @@
 export function getPackageVersion(): string {
   try {
-    // Use global variable injected at build time
+    if (typeof window !== "undefined") {
+      const runtimeVersion = (window as any).__INSPECTOR_VERSION__;
+      if (runtimeVersion !== undefined) {
+        return runtimeVersion;
+      }
+    }
     if (typeof __INSPECTOR_VERSION__ !== "undefined") {
       return __INSPECTOR_VERSION__;
     }


### PR DESCRIPTION
## Summary

Client-only fixes so the inspector CDN bundle (`dist/cdn/inspector.js`) works when served by a backend-less shell — specifically the upcoming SDK v2 `${basePath}/inspector` route, which is a bare HTML page with no inspector API routes:

- **Auto-connect without a backend**: `useAutoConnect` now reads the connect URL the shell injects as `window.__MCP_USE_INSPECTOR__.autoConnectUrl` before falling back to the `config.json` fetch (which 404s on the v2 shell).
- **Real version without injection**: `getPackageVersion()` falls back to the compile-time `__INSPECTOR_VERSION__` define when `window.__INSPECTOR_VERSION__` isn't injected, and the dashboard badge + MCP `clientInfo` use it instead of direct `window` reads with a hardcoded `1.0.0` fallback.

Marked as a **patch changeset** for `@mcp-use/inspector` — once released, the published `dist/cdn` bundle becomes usable from any npm CDN by the SDK v2 shell, unblocking the v2 branch (`v2-inspector-dev`) from its temporary self-hosted bundle.

## Test plan

- [x] `pnpm exec tsc --noEmit` in `packages/inspector` passes
- [x] Full `libraries/typescript` workspace build passes
- [x] Same fixes verified end-to-end on the v2 branch: shell-served bundle renders, auto-connects to the local server, and shows the real package version