### PR TITLE
feat(typescript): working inspector CDN shell + dev tunneling for v2 (MCP-2601)

### DIFF
--- a/libraries/typescript/packages/inspector/src/client/App.tsx
+++ b/libraries/typescript/packages/inspector/src/client/App.tsx
@@ -16,6 +16,7 @@ import { toast } from "sonner";
 import { InspectorProvider, useInspector } from "./context/InspectorContext";
 import { ThemeProvider } from "./context/ThemeContext";
 import { WidgetDebugProvider } from "./context/WidgetDebugContext";
+import { getPackageVersion } from "@/client/telemetry";
 import { getInspectorBase } from "./utils/basePath";
 import { getDefaultInspectorProxyAddress } from "./utils/connectionUpdates";
 
@@ -107,7 +108,7 @@ function App() {
           }
           clientInfo={{
             name: "mcp-use Inspector",
-            version: (window as any).__INSPECTOR_VERSION__,
+            version: getPackageVersion(),
             websiteUrl: "https://mcp-use.com",
             icons: [{ src: "https://mcp-use.com/logo.png" }],
             capabilities: {

--- a/libraries/typescript/packages/inspector/src/client/components/InspectorDashboard.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/InspectorDashboard.tsx
@@ -15,6 +15,7 @@ import {
   TooltipTrigger,
 } from "@/client/components/ui/tooltip";
 import {
+  getPackageVersion,
   MCPServerAddedEvent,
   MCPServerConnectionEvent,
   MCPServerRemovedEvent,
@@ -797,10 +798,7 @@ export function InspectorDashboard() {
                   variant="secondary"
                   className="text-xs cursor-pointer hover:bg-secondary/80 transition-colors"
                 >
-                  v
-                  {(typeof window !== "undefined" &&
-                    (window as any).__INSPECTOR_VERSION__) ||
-                    "1.0.0"}
+                  v{getPackageVersion()}
                 </Badge>
               </a>
             </TooltipTrigger>

--- a/libraries/typescript/packages/inspector/src/client/hooks/useAutoConnect.ts
+++ b/libraries/typescript/packages/inspector/src/client/hooks/useAutoConnect.ts
@@ -552,6 +552,24 @@ export function useAutoConnect({
       return;
     }
 
+    // Serialized runtime config injected by the SDK v2 CDN shell
+    // (window.__MCP_USE_INSPECTOR__) — the shell has no inspector backend, so
+    // this replaces the config.json fetch below.
+    const shellAutoConnectUrl = (
+      window as Window & {
+        __MCP_USE_INSPECTOR__?: { autoConnectUrl?: string };
+      }
+    ).__MCP_USE_INSPECTOR__?.autoConnectUrl;
+    if (shellAutoConnectUrl) {
+      const config = parseAutoConnectParam(shellAutoConnectUrl);
+      if (config) {
+        handleAutoConnectConfig(config);
+      }
+
+      setConfigLoaded(true);
+      return;
+    }
+
     // Fallback to config.json
     fetch(`${getInspectorBase()}/config.json`)
       .then((res) => res.json())

--- a/libraries/typescript/packages/inspector/src/client/telemetry/utils.ts
+++ b/libraries/typescript/packages/inspector/src/client/telemetry/utils.ts
@@ -1,6 +1,11 @@
 export function getPackageVersion(): string {
   try {
-    // Use global variable injected at build time
+    if (typeof window !== "undefined") {
+      const runtimeVersion = (window as any).__INSPECTOR_VERSION__;
+      if (runtimeVersion !== undefined) {
+        return runtimeVersion;
+      }
+    }
     if (typeof __INSPECTOR_VERSION__ !== "undefined") {
       return __INSPECTOR_VERSION__;
     }

--- a/libraries/typescript/packages/server/specs/CLI_SPEC.md
+++ b/libraries/typescript/packages/server/specs/CLI_SPEC.md
@@ -17,7 +17,7 @@
 - React/views and any client-side Vite environment (view bundling) — Phase 5 territory.
 - HMR of any kind, including server-side `list_changed` notification sync (see "Why no HMR" below). Dev reload here is **reload, not HMR**.
 - Typegen (watch-mode type generation is part of the Phase 5 dev contract, not this one).
-- Tunnel, deploy/cloud commands, project scaffolding.
+- Deploy/cloud commands, project scaffolding.
 - Auth (`AUTH_SPEC.md` owns that; these commands neither add nor bypass it).
 
 ## Entry contract
@@ -97,11 +97,11 @@ The build system keeps v1's reworked workspace convention **exactly** — it was
 ├─ build/        ← compiled server + manifest.json (this spec)
 ├─ generated/    ← typegen output (.d.ts) — reserved; Phase 5
 ├─ cache/        ← disposable dev/build scratch (vite entries, metadata)
-├─ state/        ← mutable runtime state (e.g. tunnel state) — reserved; future
+├─ state/        ← mutable runtime state (e.g. tunnel.json)
 └─ cloud/        ← cloud linkage (link.json) — reserved; future
 ```
 
-This phase writes only `build/` (and may use `cache/`); `generated/`, `state/`, and `cloud/` are **reserved by convention now** so no tool squats on them before their phases land. v1's invariant carries over: `build/` contains no mutable runtime state (that is `state/`'s job), so build output stays reproducible and disposable.
+This phase writes `build/` (and may use `cache/` and `state/tunnel.json` during dev); `generated/` and `cloud/` are **reserved by convention now** so no tool squats on them before their phases land. v1's invariant carries over: `build/` contains no mutable runtime state (that is `state/`'s job), so build output stays reproducible and disposable.
 
 Rules, all inherited from v1 and locked:
 
@@ -135,8 +135,22 @@ On file change: Vite invalidates, dev re-imports the entry through the runner, a
 
 - **Port:** `--port`, else `PORT` env, else `3000`; if taken, probe upward.
 - **Host:** `127.0.0.1` by default; `--host` to override (matching the server's own localhost-first posture, SPEC.md delta 5).
+- **Tunnel:** `--tunnel` starts a public tunnel as soon as the HTTP listener is bound (via `npx @mcp-use/tunnel`). The inspector UI can also start/stop the tunnel at runtime through dev-only API routes (below) without restarting the dev process.
+- **Auto-open:** once the listener is bound, the inspector URL is opened in the default browser (dependency-free `open`/`start`/`xdg-open` spawn, best-effort). `--no-open` disables it, and it is skipped automatically when stdout is not a TTY, so agents/CI never trigger a browser launch or see a "failed to open" error.
 - **Env:** `.env` loaded via Node's native `process.loadEnvFile()` (guarded by an `existsSync` check, since `loadEnvFile` throws on a missing file) before the entry is imported.
 - **Errors:** a throwing entry module keeps the *previous* handler alive and prints the error — the dev process never crashes on a bad save.
+
+#### Dev-only inspector API routes (tunnel)
+
+Intercepted by the dev HTTP listener before the MCP handler (exact path match on the introspected `basePath`, default `/mcp`):
+
+| Method | Path | Response |
+|--------|------|----------|
+| `GET` | `{basePath}/inspector/api/dev/info` | `{ mcpUrl, port, fromCli: true, tunnelUrl }` — `mcpUrl` is `{tunnelUrl}{basePath}` when a tunnel is active, else `null`; `tunnelUrl` is the public origin or `null`. |
+| `POST` | `{basePath}/inspector/api/dev/start-tunnel` | `{ ok: true, restarting: false }` on success; `{ error }` with status 500 on failure. |
+| `POST` | `{basePath}/inspector/api/dev/stop-tunnel` | `{ ok: true }`. |
+
+Tunnel subdomain persistence lives at `.mcp-use/state/tunnel.json` (v1-compatible `{ subdomain }` shape). The tunnel release API base URL defaults to `https://local.mcp-use.run` and is overridable via `MCP_USE_TUNNEL_API`.
 
 ### `mcp-use start` (inline in `@mcp-use/server` bin)
 
@@ -150,7 +164,7 @@ Requires zero cli-chunk/vite/toolchain code — a production image needs only `m
 
 The inspector UI is **not a package dependency anywhere**. `@mcp-use/server` itself owns a tiny dependency-free HTML shell route — the exact analog of FastAPI's `get_swagger_ui_html` for `/docs`:
 
-- `GET ${basePath}/inspector` returns a small HTML page whose `<script type="module">` loads the inspector bundle from a CDN: a jsDelivr/unpkg URL for `@mcp-use/inspector`'s CDN bundle (`build:cdn` output, `dist/cdn/inspector.js` — a single self-contained ESM file), **pinned to a major version** so users get inspector updates without SDK bumps.
+- `GET ${basePath}/inspector` returns a small HTML page whose `<script type="module">` loads the inspector bundle from a CDN: currently the mcp-use R2 bucket serving this branch's `build:cdn` output (the `inspector@{version}.js` + `.css` pair), **pinned to an exact version**. Moves to the jsDelivr npm copy once an inspector release ships the v2 branch's basePath-aware client (published bundles up to 12.x hardcode `/inspector` as the router basename and cannot run under `${basePath}/inspector`).
 - Config (autoConnect URL = the MCP endpoint at `basePath`, plus `basePath` itself) is passed via a serialized `window` global read by the bundle.
 
 `ServerConfig` gains:
@@ -184,7 +198,7 @@ Dev reload (the handler swap above) is reload, not HMR: no state is preserved ac
 - Views + the client Vite environment (view bundling) — Phase 5.
 - Typegen (watch-mode regeneration in `dev`) — Phase 5 dev contract.
 - Local-inspector serving from `node_modules` for offline dev.
-- Tunnel; deploy/cloud commands.
+- Deploy/cloud commands.
 
 ## Open questions
 

--- a/libraries/typescript/packages/server/src/bin/args.ts
+++ b/libraries/typescript/packages/server/src/bin/args.ts
@@ -19,6 +19,10 @@ export interface ParsedArgs {
   entry: string | undefined;
   /** Value of `--host`, or `undefined` if the flag was not passed. */
   host: string | undefined;
+  /** Whether `--tunnel` was passed (dev only). */
+  tunnel: boolean;
+  /** `false` when `--no-open` was passed (dev only); `true` otherwise. */
+  open: boolean;
   /** Whether `--help`/`-h` was passed. */
   help: boolean;
   /** Whether `--version`/`-v` was passed. */
@@ -43,6 +47,8 @@ export function parseArgs(argv: readonly string[]): ParsedArgs {
     port: undefined,
     entry: undefined,
     host: undefined,
+    tunnel: false,
+    open: true,
     help: false,
     version: false,
   };
@@ -90,6 +96,12 @@ export function parseArgs(argv: readonly string[]): ParsedArgs {
         break;
       case "--host":
         args.host = takeValue();
+        break;
+      case "--tunnel":
+        args.tunnel = true;
+        break;
+      case "--no-open":
+        args.open = false;
         break;
       default:
         if (flag.startsWith("-")) {

--- a/libraries/typescript/packages/server/src/bin/main.ts
+++ b/libraries/typescript/packages/server/src/bin/main.ts
@@ -34,6 +34,10 @@ export interface CliCommandOptions {
   port?: number;
   /** Host override (`--host`). */
   host?: string;
+  /** Start a public tunnel at dev startup (`--tunnel`). */
+  tunnel?: boolean;
+  /** Auto-open the inspector in a browser at dev startup (`--no-open` disables). */
+  open?: boolean;
 }
 
 /** The subset of the cli chunk's exports this bin calls. */
@@ -55,6 +59,8 @@ Options:
   -p, --port <n>     Port to serve on (default: $PORT or 3000)
   --host <host>      Host to bind (dev only)
   --entry <path>     Server entry module (dev/build only)
+  --tunnel           Expose the dev server through a public tunnel (dev only)
+  --no-open          Do not auto-open the inspector in a browser (dev only)
   -h, --help         Show this help
   -v, --version      Print the version`;
 
@@ -136,6 +142,8 @@ async function cliCommand(
     ...(args.entry !== undefined && { entry: args.entry }),
     ...(args.port !== undefined && { port: args.port }),
     ...(args.host !== undefined && { host: args.host }),
+    ...(args.tunnel && { tunnel: true }),
+    ...(!args.open && { open: false }),
   };
 
   try {

--- a/libraries/typescript/packages/server/src/cli/dev-api.ts
+++ b/libraries/typescript/packages/server/src/cli/dev-api.ts
@@ -1,0 +1,99 @@
+/**
+ * Dev-only inspector API routes intercepted by `mcp-use dev` before the MCP
+ * handler — tunnel controls and session metadata for the inspector UI.
+ */
+
+import type { TunnelManager } from "./tunnel.js";
+
+/** Web-standard request handler, as returned by `MCPServer.getHandler()`. */
+type FetchHandler = (request: Request) => Promise<Response>;
+
+/**
+ * Dependencies for {@link createDevApiHandler}.
+ *
+ * @internal
+ */
+export interface DevApiHandlerOptions {
+  /** Returns the current MCP mount path (may change after a dev reload). */
+  getBasePath: () => string;
+  /** Port the dev HTTP listener is bound to. */
+  port: number;
+  /** Tunnel lifecycle manager owned by the dev process. */
+  tunnel: TunnelManager;
+}
+
+/** JSON body for `GET …/inspector/api/dev/info`. */
+export interface DevInfoResponse {
+  /** Full MCP endpoint URL when a tunnel is active; otherwise `null`. */
+  mcpUrl: string | null;
+  /** Port the dev server listens on. */
+  port: number;
+  /** Whether the request is served by `mcp-use dev` (always `true` here). */
+  fromCli: true;
+  /** Public tunnel origin URL, or `null` when no tunnel is running. */
+  tunnelUrl: string | null;
+}
+
+/**
+ * Wrap an MCP {@link FetchHandler} so dev-only inspector API routes are
+ * answered in-process before delegating everything else.
+ *
+ * @param options - Base path, bound port, and tunnel manager.
+ * @param fallback - Handler to invoke when the request is not a dev API route.
+ *
+ * @example
+ * ```ts
+ * const handler = createDevApiHandler(
+ *   { getBasePath: () => "/mcp", port: 3000, tunnel },
+ *   server.getHandler()
+ * );
+ * ```
+ */
+export function createDevApiHandler(
+  options: DevApiHandlerOptions,
+  fallback: FetchHandler
+): FetchHandler {
+  const devInfo = (): DevInfoResponse => {
+    const basePath = options.getBasePath();
+    const { url: tunnelUrl } = options.tunnel.status();
+    return {
+      mcpUrl:
+        tunnelUrl !== null
+          ? `${tunnelUrl.replace(/\/+$/, "")}${basePath}`
+          : null,
+      port: options.port,
+      fromCli: true,
+      tunnelUrl,
+    };
+  };
+
+  return async (request: Request): Promise<Response> => {
+    const basePath = options.getBasePath();
+    const infoPath = `${basePath}/inspector/api/dev/info`;
+    const startPath = `${basePath}/inspector/api/dev/start-tunnel`;
+    const stopPath = `${basePath}/inspector/api/dev/stop-tunnel`;
+    const pathname = new URL(request.url).pathname;
+
+    if (request.method === "GET" && pathname === infoPath) {
+      return Response.json(devInfo());
+    }
+
+    if (request.method === "POST" && pathname === startPath) {
+      try {
+        await options.tunnel.start(options.port);
+        return Response.json({ ok: true, restarting: false });
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "Failed to start tunnel";
+        return Response.json({ error: message }, { status: 500 });
+      }
+    }
+
+    if (request.method === "POST" && pathname === stopPath) {
+      await options.tunnel.stop();
+      return Response.json({ ok: true });
+    }
+
+    return fallback(request);
+  };
+}

--- a/libraries/typescript/packages/server/src/cli/dev.ts
+++ b/libraries/typescript/packages/server/src/cli/dev.ts
@@ -15,6 +15,7 @@
  * package load time.
  */
 
+import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { createServer, createServerModuleRunner } from "vite";
@@ -22,6 +23,8 @@ import { serve } from "@hono/node-server";
 
 import { discoverEntry } from "./entry.js";
 import { resolvePort } from "./port.js";
+import { createDevApiHandler } from "./dev-api.js";
+import { createTunnelManager } from "./tunnel.js";
 import { resolveWorkspacePaths } from "./workspace.js";
 
 /** Web-standard request handler, as returned by `MCPServer.getHandler()`. */
@@ -72,6 +75,48 @@ export interface DevOptions {
    * pass this.
    */
   signal?: AbortSignal;
+  /**
+   * When `true`, start a public tunnel as soon as the HTTP listener is bound
+   * (same as the inspector "Start Tunnel" control, but at startup).
+   *
+   * @defaultValue `false`
+   */
+  tunnel?: boolean;
+  /**
+   * Auto-open the inspector in the default browser once the listener is
+   * bound (`--no-open` sets this to `false`). Opening is additionally
+   * skipped when stdout is not a TTY — agents and CI never get a spurious
+   * browser launch or a "failed to open" error.
+   *
+   * @defaultValue `true`
+   */
+  open?: boolean;
+}
+
+/**
+ * Best-effort open of `url` in the platform's default browser.
+ *
+ * Dependency-free (`open`/`start`/`xdg-open` via spawn), detached, and
+ * error-swallowing: a missing opener (headless Linux, containers) must never
+ * crash or log noise into the dev process.
+ */
+function openInBrowser(url: string): void {
+  const [command, args]: [string, string[]] =
+    process.platform === "darwin"
+      ? ["open", [url]]
+      : process.platform === "win32"
+        ? // `start` is a cmd built-in; the empty string is the window title.
+          ["cmd", ["/c", "start", "", url]]
+        : ["xdg-open", [url]];
+  try {
+    const child = spawn(command, args, { stdio: "ignore", detached: true });
+    child.on("error", () => {
+      // Swallow: auto-open is a convenience, never a failure.
+    });
+    child.unref();
+  } catch {
+    // Synchronous spawn failures are equally non-fatal.
+  }
 }
 
 /**
@@ -232,12 +277,23 @@ export async function runDev(options: DevOptions): Promise<void> {
   if (port !== requested) {
     console.log(`[mcp-use] port ${requested} is taken, using ${port}`);
   }
+  process.env["PORT"] = String(port);
+
+  const tunnelManager = createTunnelManager(paths.tunnel);
+  const devFetch = createDevApiHandler(
+    {
+      getBasePath: () => basePath,
+      port,
+      tunnel: tunnelManager,
+    },
+    (request) => currentHandler(request)
+  );
 
   const httpServer = await new Promise<ReturnType<typeof serve>>(
     (resolve, reject) => {
       const server = serve(
         {
-          fetch: (request: Request) => currentHandler(request),
+          fetch: (request: Request) => devFetch(request),
           port,
           hostname: host,
         },
@@ -252,6 +308,25 @@ export async function runDev(options: DevOptions): Promise<void> {
   console.log(`  ➜ MCP endpoint:  http://localhost:${port}${basePath}`);
   console.log(`  ➜ Inspector:     http://localhost:${port}${basePath}/inspector`);
 
+  if (options.tunnel === true) {
+    try {
+      const { url } = await tunnelManager.start(port);
+      console.log(`  ➜ Tunnel:        ${url}${basePath}`);
+    } catch (error) {
+      await tunnelManager.stop();
+      await new Promise<void>((done) => httpServer.close(() => done()));
+      await runner.close();
+      await vite.close();
+      throw error;
+    }
+  }
+
+  // Auto-open the inspector — unless disabled (`--no-open`) or stdout is not
+  // a TTY (agents/CI: no browser to open, and no error to fail on).
+  if (options.open !== false && process.stdout.isTTY === true) {
+    openInBrowser(`http://localhost:${port}${basePath}/inspector`);
+  }
+
   // --- Graceful shutdown (SIGINT/SIGTERM or options.signal). ---------------
   await new Promise<void>((resolve) => {
     let closing = false;
@@ -264,6 +339,7 @@ export async function runDev(options: DevOptions): Promise<void> {
         vite.watcher.off("change", onFileEvent);
         vite.watcher.off("add", onFileEvent);
         vite.watcher.off("unlink", onFileEvent);
+        await tunnelManager.stop();
         await new Promise<void>((done) => httpServer.close(() => done()));
         await runner.close();
         await vite.close();

--- a/libraries/typescript/packages/server/src/cli/tunnel.ts
+++ b/libraries/typescript/packages/server/src/cli/tunnel.ts
@@ -1,0 +1,264 @@
+/**
+ * Tunnel lifecycle for `mcp-use dev` — spawns `@mcp-use/tunnel` via `npx`,
+ * parses the public URL from stdout, persists the subdomain under
+ * `.mcp-use/state/tunnel.json`, and releases it through the tunnel API before
+ * reuse (matching v1 `packages/cli` conventions).
+ */
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { spawn, type ChildProcess } from "node:child_process";
+import { dirname } from "node:path";
+
+/** Default base URL for the tunnel reservation/release API. */
+const DEFAULT_TUNNEL_API = "https://local.mcp-use.run";
+
+/**
+ * Base URL of the tunnel API (subdomain reservation/release). Overridable via
+ * the `MCP_USE_TUNNEL_API` environment variable.
+ */
+export function tunnelApiBase(): string {
+  return process.env["MCP_USE_TUNNEL_API"] ?? DEFAULT_TUNNEL_API;
+}
+
+/** On-disk shape of `.mcp-use/state/tunnel.json`. */
+interface TunnelStateFile {
+  /** Last successfully assigned tunnel subdomain. */
+  subdomain: string;
+}
+
+/**
+ * Minimal tunnel manager surface used by {@link createDevApiHandler} and
+ * {@link runDev}.
+ */
+export interface TunnelManager {
+  /**
+   * Start (or attach) a tunnel targeting `port` and return the public origin
+   * URL and assigned subdomain.
+   */
+  start(port: number): Promise<{ url: string; subdomain: string }>;
+  /** Stop the tunnel child process and release the subdomain. */
+  stop(): Promise<void>;
+  /** Current tunnel public origin URL, or `null` when no tunnel is active. */
+  status(): { url: string | null };
+}
+
+/**
+ * Create a tunnel manager that reads and writes subdomain state at
+ * `stateFilePath` (typically `.mcp-use/state/tunnel.json`).
+ *
+ * @param stateFilePath - Absolute path to the tunnel state JSON file.
+ *
+ * @example
+ * ```ts
+ * const tunnel = createTunnelManager(paths.tunnel);
+ * const { url } = await tunnel.start(3000);
+ * console.log(url); // https://happy-cat.local.mcp-use.run
+ * ```
+ */
+export function createTunnelManager(stateFilePath: string): TunnelManager {
+  let proc: ChildProcess | undefined;
+  let currentUrl: string | null = null;
+  let currentSubdomain: string | undefined;
+
+  const markShutdown = (): void => {
+    if (
+      proc !== undefined &&
+      "markShutdown" in proc &&
+      typeof (proc as { markShutdown?: () => void }).markShutdown ===
+        "function"
+    ) {
+      (proc as { markShutdown: () => void }).markShutdown();
+    }
+  };
+
+  const releaseSubdomain = async (subdomain: string): Promise<void> => {
+    try {
+      await fetch(`${tunnelApiBase()}/api/tunnels/${subdomain}`, {
+        method: "DELETE",
+      });
+    } catch {
+      // Best-effort cleanup; ignore DELETE failures.
+    }
+  };
+
+  const loadSavedSubdomain = async (): Promise<string | undefined> => {
+    try {
+      const content = await readFile(stateFilePath, "utf8");
+      const state = JSON.parse(content) as Partial<TunnelStateFile>;
+      return typeof state.subdomain === "string" ? state.subdomain : undefined;
+    } catch {
+      return undefined;
+    }
+  };
+
+  const persistSubdomain = async (subdomain: string): Promise<void> => {
+    try {
+      await mkdir(dirname(stateFilePath), { recursive: true });
+      await writeFile(
+        stateFilePath,
+        JSON.stringify({ subdomain } satisfies TunnelStateFile, null, 2),
+        "utf8"
+      );
+    } catch (error) {
+      console.warn(
+        `[mcp-use] failed to save tunnel subdomain: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+  };
+
+  const spawnTunnel = (
+    port: number,
+    subdomain?: string
+  ): Promise<{ url: string; subdomain: string; process: ChildProcess }> =>
+    new Promise((resolve, reject) => {
+      console.log(`[mcp-use] starting tunnel for port ${port}…`);
+
+      const tunnelArgs = ["--yes", "@mcp-use/tunnel", String(port)];
+      if (subdomain !== undefined) {
+        tunnelArgs.push("--subdomain", subdomain);
+      }
+
+      const child = spawn("npx", tunnelArgs, {
+        stdio: ["ignore", "pipe", "pipe"],
+        shell: process.platform === "win32",
+      });
+
+      let resolved = false;
+      let shuttingDown = false;
+
+      const markChildShutdown = (): void => {
+        shuttingDown = true;
+      };
+      (child as unknown as { markShutdown: () => void }).markShutdown =
+        markChildShutdown;
+
+      child.stdout.on("data", (data: Buffer) => {
+        const text = data.toString();
+        const isShutdownMessage =
+          text.includes("Shutting down") || text.includes("🛑");
+        const isErrorMessage = text.includes("✖") || text.includes("Error:");
+
+        if (!shuttingDown && !isShutdownMessage && !isErrorMessage) {
+          process.stdout.write(text);
+        }
+
+        const urlMatch = text.match(/https?:\/\/([a-z0-9-]+\.[a-z0-9.-]+)/i);
+        if (urlMatch !== null && !resolved) {
+          const url = urlMatch[0];
+          const fullDomain = urlMatch[1] ?? "";
+          const subdomainMatch = fullDomain.match(/^([a-z0-9-]+)\./i);
+          let extractedSubdomain = subdomainMatch?.[1] ?? fullDomain.split(".")[0] ?? "";
+          if (!/^[a-z0-9-]+$/i.test(extractedSubdomain)) {
+            console.warn(
+              `[mcp-use] warning: extracted subdomain "${extractedSubdomain}" does not match expected format`
+            );
+            extractedSubdomain = "";
+          }
+          resolved = true;
+          clearTimeout(setupTimeout);
+          // No log here — the tunnel child's own stdout (passed through
+          // above) already announces the public URL.
+          resolve({ url, subdomain: extractedSubdomain, process: child });
+        }
+      });
+
+      child.stderr.on("data", (data: Buffer) => {
+        const text = data.toString();
+        if (
+          !shuttingDown &&
+          !text.includes("INFO") &&
+          !text.includes("bore_cli") &&
+          !text.includes("Shutting down") &&
+          // npx inherits pnpm-only npm_config_* env vars (e.g.
+          // minimum-release-age, verify-deps-before-run) and warns about
+          // every key it doesn't recognize — pure noise for the user.
+          !/npm warn Unknown (?:env|project|user|builtin) config/.test(text)
+        ) {
+          process.stderr.write(data);
+        }
+      });
+
+      child.on("error", (error) => {
+        if (!resolved) {
+          clearTimeout(setupTimeout);
+          reject(new Error(`Failed to start tunnel: ${error.message}`));
+        }
+      });
+
+      child.on("exit", (code) => {
+        if (code !== 0 && code !== null && !resolved) {
+          clearTimeout(setupTimeout);
+          reject(new Error(`Tunnel process exited with code ${code}`));
+        }
+      });
+
+      const setupTimeout = setTimeout(() => {
+        if (!resolved) {
+          child.kill();
+          reject(new Error("Tunnel setup timed out"));
+        }
+      }, 30_000);
+    });
+
+  return {
+    status(): { url: string | null } {
+      return { url: currentUrl };
+    },
+
+    async start(port: number): Promise<{ url: string; subdomain: string }> {
+      if (currentUrl !== null) {
+        return {
+          url: currentUrl,
+          subdomain: currentSubdomain ?? "",
+        };
+      }
+
+      let existingSubdomain = await loadSavedSubdomain();
+      if (existingSubdomain !== undefined) {
+        console.log(
+          `[mcp-use] found existing subdomain: ${existingSubdomain}`
+        );
+        await releaseSubdomain(existingSubdomain);
+      }
+
+      let tunnelInfo: Awaited<ReturnType<typeof spawnTunnel>>;
+      try {
+        tunnelInfo = await spawnTunnel(port, existingSubdomain);
+      } catch (error) {
+        if (existingSubdomain !== undefined) {
+          console.log(
+            `[mcp-use] subdomain "${existingSubdomain}" unavailable, requesting a new one…`
+          );
+          tunnelInfo = await spawnTunnel(port, undefined);
+        } else {
+          throw error;
+        }
+      }
+
+      proc = tunnelInfo.process;
+      currentUrl = tunnelInfo.url;
+      currentSubdomain = tunnelInfo.subdomain;
+      await persistSubdomain(tunnelInfo.subdomain);
+
+      return { url: tunnelInfo.url, subdomain: tunnelInfo.subdomain };
+    },
+
+    async stop(): Promise<void> {
+      markShutdown();
+
+      if (currentSubdomain !== undefined) {
+        await releaseSubdomain(currentSubdomain);
+      }
+
+      if (proc !== undefined) {
+        proc.kill("SIGINT");
+        proc = undefined;
+      }
+
+      currentUrl = null;
+      currentSubdomain = undefined;
+    },
+  };
+}

--- a/libraries/typescript/packages/server/src/cli/workspace.ts
+++ b/libraries/typescript/packages/server/src/cli/workspace.ts
@@ -20,7 +20,7 @@
  * ├─ build/        ← compiled server + manifest.json (this package)
  * ├─ generated/    ← typegen output (.d.ts) — reserved; Phase 5
  * ├─ cache/        ← disposable dev/build scratch
- * ├─ state/        ← mutable runtime state — reserved; future
+ * ├─ state/        ← mutable runtime state (e.g. tunnel.json)
  * └─ cloud/        ← cloud linkage (link.json) — reserved; future
  * ```
  *
@@ -83,12 +83,14 @@ export interface WorkspacePaths {
   generated: string;
   /** Disposable dev/build scratch directory. */
   cache: string;
-  /** Mutable runtime state directory — reserved. */
+  /** Mutable runtime state directory. */
   state: string;
   /** Cloud linkage directory — reserved. */
   cloud: string;
   /** Build manifest: `<build>/manifest.json`. */
   buildManifest: string;
+  /** Tunnel subdomain persistence: `<state>/tunnel.json`. */
+  tunnel: string;
 }
 
 /**
@@ -117,5 +119,6 @@ export function resolveWorkspacePaths(projectRoot: string): WorkspacePaths {
     state: join(workspace, "state"),
     cloud: join(workspace, "cloud"),
     buildManifest: join(build, BUILD_MANIFEST_NAME),
+    tunnel: join(workspace, "state", "tunnel.json"),
   };
 }

--- a/libraries/typescript/packages/server/src/config.ts
+++ b/libraries/typescript/packages/server/src/config.ts
@@ -10,8 +10,8 @@ export interface InspectorOptions {
    * `@mcp-use/inspector` CDN bundle (`dist/cdn/inspector.js`) — self-host it
    * for air-gapped environments where the public CDN is unreachable.
    *
-   * @defaultValue The jsDelivr URL for `@mcp-use/inspector`, pinned to the
-   * current major version.
+   * @defaultValue The mcp-use CDN URL for the `@mcp-use/inspector` bundle,
+   * pinned to the current version.
    */
   assetsUrl?: string;
 }
@@ -67,8 +67,8 @@ export interface ServerConfig {
    * @remarks
    * Follows the FastAPI `/docs` model: the server itself ships only a tiny
    * dependency-free HTML page whose `<script type="module">` loads the
-   * `@mcp-use/inspector` bundle from a CDN (jsDelivr, pinned to the current
-   * major version), so the UI updates independently of SDK releases and adds
+   * `@mcp-use/inspector` bundle from a CDN (pinned to the current inspector
+   * version), so the UI updates independently of SDK releases and adds
    * nothing to the install. The page tells the inspector to connect to this
    * server's MCP endpoint at `basePath`, deriving the URL from the browser's
    * own origin.

--- a/libraries/typescript/packages/server/src/inspector-shell.ts
+++ b/libraries/typescript/packages/server/src/inspector-shell.ts
@@ -14,20 +14,41 @@ import type { Env, Hono } from "hono";
 import type { InspectorOptions } from "./config.js";
 
 /**
- * Major version of `@mcp-use/inspector` the default CDN URL pins to.
+ * Exact version of the `@mcp-use/inspector` CDN bundle the default URL pins
+ * to (matching the R2 object key `inspector@{version}.js`).
  *
- * Users pick up inspector patch/minor releases without an SDK bump; a new
- * inspector major requires deliberately raising this constant.
+ * Bumping the inspector requires uploading the new `.js`/`.css` pair and
+ * raising this constant together.
  */
-export const INSPECTOR_MAJOR_VERSION = 11;
+export const INSPECTOR_VERSION = "11.0.0";
 
 /**
- * Default URL the inspector shell loads the UI bundle from: the jsDelivr
- * copy of `@mcp-use/inspector`'s CDN build (`dist/cdn/inspector.js`), pinned
- * to {@link INSPECTOR_MAJOR_VERSION}. Override per server with
- * {@link InspectorOptions.assetsUrl}.
+ * Default URL the inspector shell loads the UI bundle from: the
+ * `@mcp-use/inspector` CDN build (`dist/cdn/inspector.js`) built from this
+ * branch and hosted on Cloudflare R2, pinned to {@link INSPECTOR_VERSION}.
+ * Override per server with {@link InspectorOptions.assetsUrl}.
+ *
+ * TODO(inspector-cdn): swap to the jsDelivr npm copy
+ * (`https://cdn.jsdelivr.net/npm/@mcp-use/inspector@<major>/dist/cdn/inspector.js`)
+ * once an inspector release includes this branch's basePath-aware client —
+ * published bundles up to 12.x hardcode `/inspector` as the router basename
+ * and cannot run under `${basePath}/inspector`. Also replace the temporary
+ * `r2.dev` development URL with the `inspector-cdn.mcp-use.com` custom
+ * domain if R2 hosting outlives the v2 merge.
  */
-export const DEFAULT_INSPECTOR_ASSETS_URL = `https://cdn.jsdelivr.net/npm/@mcp-use/inspector@${INSPECTOR_MAJOR_VERSION}/dist/cdn/inspector.js`;
+export const DEFAULT_INSPECTOR_ASSETS_URL = `https://pub-5337e54ad50f432cab3e646138da1efc.r2.dev/inspector@${INSPECTOR_VERSION}.js`;
+
+/**
+ * Derive the stylesheet URL that accompanies an inspector bundle URL.
+ *
+ * The CDN build ships as a `.js`/`.css` pair with the same basename
+ * (`inspector@{version}.js` + `inspector@{version}.css`), so the stylesheet
+ * URL is the script URL with its `.js` suffix swapped for `.css`. Query
+ * strings and fragments are preserved.
+ */
+export function inspectorStylesUrl(assetsUrl: string): string {
+  return assetsUrl.replace(/\.js(?=$|[?#])/, ".css");
+}
 
 /** Inputs for {@link renderInspectorShell}. */
 export interface InspectorShellOptions {
@@ -70,20 +91,24 @@ function serializeForInlineScript(value: string): string {
  * with a `#root` mount node, an inline script publishing
  * `window.__MCP_USE_INSPECTOR__ = { autoConnectUrl, basePath }` — where
  * `autoConnectUrl` is computed client-side as
- * `window.location.origin + basePath` — and a module script loading the
- * inspector bundle. All server-provided values are HTML-escaped or
- * JSON-serialized with `<` escaped, so config can't inject markup.
+ * `window.location.origin + basePath` — a stylesheet link for the bundle's
+ * companion CSS (see {@link inspectorStylesUrl}), and a module script
+ * loading the inspector bundle. All server-provided values are HTML-escaped
+ * or JSON-serialized with `<` escaped, so config can't inject markup.
  */
 export function renderInspectorShell(options: InspectorShellOptions): string {
   const { serverName, basePath, assetsUrl } = options;
   const serializedBasePath = serializeForInlineScript(basePath);
-  const scriptSrc = escapeHtml(assetsUrl ?? DEFAULT_INSPECTOR_ASSETS_URL);
+  const bundleUrl = assetsUrl ?? DEFAULT_INSPECTOR_ASSETS_URL;
+  const scriptSrc = escapeHtml(bundleUrl);
+  const stylesHref = escapeHtml(inspectorStylesUrl(bundleUrl));
   return `<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>${escapeHtml(serverName)} — MCP Inspector</title>
+    <link rel="stylesheet" href="${stylesHref}" />
     <style>
       :root { color-scheme: dark; }
       html, body { height: 100%; margin: 0; background-color: #0c0c0d; }
@@ -102,6 +127,23 @@ export function renderInspectorShell(options: InspectorShellOptions): string {
         };
         // Read by the current inspector bundle to derive its own URLs.
         window.__MCP_BASE_PATH__ = basePath;
+        // The bundle carries Node-flavored dependencies that touch \`process\`
+        // at module scope; give them the same browser polyfill the v1
+        // inspector shell provides, or the bundle throws on load.
+        if (typeof window.process === "undefined") {
+          window.process = {
+            env: {},
+            platform: "browser",
+            browser: true,
+            version: "v18.0.0",
+            versions: { node: "18.0.0" },
+            cwd: function () { return "/"; },
+            nextTick: function (fn) {
+              var args = Array.prototype.slice.call(arguments, 1);
+              queueMicrotask(function () { fn.apply(null, args); });
+            },
+          };
+        }
       })();
     </script>
     <script type="module" src="${scriptSrc}"></script>

--- a/libraries/typescript/packages/server/tests/bin-start.test.ts
+++ b/libraries/typescript/packages/server/tests/bin-start.test.ts
@@ -97,6 +97,16 @@ describe("parseArgs", () => {
     expect(args.host).toBe("::1");
   });
 
+  it("parses --tunnel", () => {
+    expect(parseArgs(["dev", "--tunnel"]).tunnel).toBe(true);
+    expect(parseArgs(["dev"]).tunnel).toBe(false);
+  });
+
+  it("parses --no-open (auto-open defaults to on)", () => {
+    expect(parseArgs(["dev", "--no-open"]).open).toBe(false);
+    expect(parseArgs(["dev"]).open).toBe(true);
+  });
+
   it("parses help and version flags", () => {
     expect(parseArgs(["--help"]).help).toBe(true);
     expect(parseArgs(["-h"]).help).toBe(true);

--- a/libraries/typescript/packages/server/tests/cli/dev-api.test.ts
+++ b/libraries/typescript/packages/server/tests/cli/dev-api.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Unit tests for dev-only inspector API route interception.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { createDevApiHandler } from "../../src/cli/dev-api.js";
+import type { TunnelManager } from "../../src/cli/tunnel.js";
+
+function fakeTunnel(initialUrl: string | null = null): {
+  manager: TunnelManager;
+  setUrl: (url: string | null) => void;
+  start: ReturnType<typeof vi.fn>;
+  stop: ReturnType<typeof vi.fn>;
+} {
+  let url = initialUrl;
+  const start = vi.fn(async () => {
+    url = "https://happy-cat.local.mcp-use.run";
+    return { url, subdomain: "happy-cat" };
+  });
+  const stop = vi.fn(async () => {
+    url = null;
+  });
+  const manager: TunnelManager = {
+    start,
+    stop,
+    status: () => ({ url }),
+  };
+  return {
+    manager,
+    setUrl: (next) => {
+      url = next;
+    },
+    start,
+    stop,
+  };
+}
+
+describe("createDevApiHandler", () => {
+  const basePath = "/mcp";
+  const port = 4242;
+  const origin = "http://127.0.0.1:4242";
+
+  it("returns dev info with fromCli and no tunnel by default", async () => {
+    const tunnel = fakeTunnel();
+    const handler = createDevApiHandler(
+      { getBasePath: () => basePath, port, tunnel: tunnel.manager },
+      async () => new Response("fallback", { status: 418 })
+    );
+
+    const res = await handler(
+      new Request(`${origin}${basePath}/inspector/api/dev/info`)
+    );
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      mcpUrl: null,
+      port,
+      fromCli: true,
+      tunnelUrl: null,
+    });
+  });
+
+  it("includes tunnel URLs in dev info when a tunnel is active", async () => {
+    const tunnel = fakeTunnel("https://happy-cat.local.mcp-use.run");
+    const handler = createDevApiHandler(
+      { getBasePath: () => basePath, port, tunnel: tunnel.manager },
+      async () => new Response("fallback")
+    );
+
+    const res = await handler(
+      new Request(`${origin}${basePath}/inspector/api/dev/info`)
+    );
+    await expect(res.json()).resolves.toEqual({
+      mcpUrl: "https://happy-cat.local.mcp-use.run/mcp",
+      port,
+      fromCli: true,
+      tunnelUrl: "https://happy-cat.local.mcp-use.run",
+    });
+  });
+
+  it("starts the tunnel via POST start-tunnel without restarting", async () => {
+    const tunnel = fakeTunnel();
+    const handler = createDevApiHandler(
+      { getBasePath: () => basePath, port, tunnel: tunnel.manager },
+      async () => new Response("fallback")
+    );
+
+    const res = await handler(
+      new Request(`${origin}${basePath}/inspector/api/dev/start-tunnel`, {
+        method: "POST",
+      })
+    );
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true, restarting: false });
+    expect(tunnel.start).toHaveBeenCalledWith(port);
+  });
+
+  it("returns 500 when start-tunnel fails", async () => {
+    const tunnel = fakeTunnel();
+    tunnel.start.mockRejectedValueOnce(new Error("tunnel setup timed out"));
+    const handler = createDevApiHandler(
+      { getBasePath: () => basePath, port, tunnel: tunnel.manager },
+      async () => new Response("fallback")
+    );
+
+    const res = await handler(
+      new Request(`${origin}${basePath}/inspector/api/dev/start-tunnel`, {
+        method: "POST",
+      })
+    );
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toEqual({
+      error: "tunnel setup timed out",
+    });
+  });
+
+  it("stops the tunnel via POST stop-tunnel", async () => {
+    const tunnel = fakeTunnel("https://happy-cat.local.mcp-use.run");
+    const handler = createDevApiHandler(
+      { getBasePath: () => basePath, port, tunnel: tunnel.manager },
+      async () => new Response("fallback")
+    );
+
+    const res = await handler(
+      new Request(`${origin}${basePath}/inspector/api/dev/stop-tunnel`, {
+        method: "POST",
+      })
+    );
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true });
+    expect(tunnel.stop).toHaveBeenCalled();
+  });
+
+  it("delegates non-matching paths to the fallback handler", async () => {
+    const tunnel = fakeTunnel();
+    const fallback = vi.fn(async () => new Response("mcp"));
+    const handler = createDevApiHandler(
+      { getBasePath: () => basePath, port, tunnel: tunnel.manager },
+      fallback
+    );
+
+    const res = await handler(new Request(`${origin}${basePath}`));
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("mcp");
+    expect(fallback).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not match similar paths with extra segments", async () => {
+    const tunnel = fakeTunnel();
+    const fallback = vi.fn(async () => new Response("ok"));
+    const handler = createDevApiHandler(
+      { getBasePath: () => basePath, port, tunnel: tunnel.manager },
+      fallback
+    );
+
+    await handler(
+      new Request(`${origin}${basePath}/inspector/api/dev/info/extra`)
+    );
+    expect(fallback).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the current base path from getBasePath on each request", async () => {
+    const tunnel = fakeTunnel();
+    let currentBasePath = "/mcp";
+    const handler = createDevApiHandler(
+      {
+        getBasePath: () => currentBasePath,
+        port,
+        tunnel: tunnel.manager,
+      },
+      async () => new Response("fallback")
+    );
+
+    await handler(new Request(`${origin}/api/inspector/api/dev/info`));
+    currentBasePath = "/api";
+    const res = await handler(
+      new Request(`${origin}/api/inspector/api/dev/info`)
+    );
+    expect(res.status).toBe(200);
+  });
+});

--- a/libraries/typescript/packages/server/tests/inspector-shell.test.ts
+++ b/libraries/typescript/packages/server/tests/inspector-shell.test.ts
@@ -10,7 +10,7 @@ import { MCPServer } from "../src/index.js";
 import type { ServerConfig } from "../src/index.js";
 
 const DEFAULT_CDN_URL =
-  "https://cdn.jsdelivr.net/npm/@mcp-use/inspector@11/dist/cdn/inspector.js";
+  "https://pub-5337e54ad50f432cab3e646138da1efc.r2.dev/inspector@11.0.0.js";
 
 function makeServer(config: Partial<ServerConfig> = {}): MCPServer {
   const server = new MCPServer({
@@ -74,13 +74,19 @@ describe("inspector shell route", () => {
 
     const html = await response.text();
     expect(html).toContain("<!doctype html>");
-    // The bundle loads from the version-pinned public CDN.
+    // The bundle loads from the version-pinned public CDN, together with its
+    // companion stylesheet (same basename, .css suffix).
     expect(html).toContain(`<script type="module" src="${DEFAULT_CDN_URL}">`);
+    expect(html).toContain(
+      `<link rel="stylesheet" href="${DEFAULT_CDN_URL.replace(/\.js$/, ".css")}" />`
+    );
     // Serialized runtime config: basePath from the server, autoConnectUrl
     // derived client-side from the page's own origin (no host guessing).
     expect(html).toContain("window.__MCP_USE_INSPECTOR__");
     expect(html).toContain('var basePath = "/mcp";');
     expect(html).toContain("window.location.origin + basePath");
+    // Browser polyfill for the bundle's Node-flavored module-scope code.
+    expect(html).toContain("window.process = {");
     // Root node for the bundle to mount into, and a dark background so the
     // page doesn't flash white before the UI paints.
     expect(html).toContain('<div id="root">');
@@ -139,8 +145,12 @@ describe("inspector shell route", () => {
     const server = makeServer({ inspector: { assetsUrl } });
     const html = await (await get(server, "/mcp/inspector")).text();
     expect(html).toContain(`<script type="module" src="${assetsUrl}">`);
+    // The stylesheet follows the custom bundle URL too.
+    expect(html).toContain(
+      '<link rel="stylesheet" href="https://intranet.example.com/vendor/inspector.css" />'
+    );
     // The default CDN URL is fully replaced, not merely preferred.
-    expect(html).not.toContain("cdn.jsdelivr.net");
+    expect(html).not.toContain("r2.dev");
     await server.close();
   });
 


### PR DESCRIPTION
## Summary

Makes the v2 inspector CDN shell actually work end-to-end, and brings tunneling to the v2 CLI:

**Inspector shell (`@mcp-use/server`)**
- Default assets URL now points at the mcp-use R2 bucket serving this branch's CDN build (`inspector@11.0.0.js`), pinned to an exact version. Published inspector bundles (through 12.x) hardcode the `/inspector` router basename and can't run under `${basePath}/inspector` — the shell swaps to jsDelivr once a release ships this branch's basePath-aware client (see TODO in `inspector-shell.ts`).
- The shell now loads the bundle's companion stylesheet (the CDN build is a `.js`/`.css` pair — previously the UI rendered unstyled) and injects the `window.process` polyfill the bundle needs at module scope (previously it crashed with `process is not defined`), matching the v1 shell.

**Inspector client**
- Auto-connect reads the shell-injected `window.__MCP_USE_INSPECTOR__.autoConnectUrl` (the v2 shell has no inspector backend to serve `config.json`).
- Version badge and MCP `clientInfo` fall back to the compile-time bundle version instead of a hardcoded `1.0.0`. (These two client fixes were also released to canary separately as inspector `12.0.2` via #1846.)

**Dev tunneling (v2 CLI — previously deferred in CLI_SPEC)**
- `mcp-use dev --tunnel` spawns `npx @mcp-use/tunnel` against the bound port.
- The dev listener answers the inspector's dev-only API routes in-process (`GET dev/info`, `POST dev/start-tunnel`, `POST dev/stop-tunnel`), so the UI's tunnel toggle works with no server restart — unlike v1, which restarted the whole process. Subdomains persist and release v1-style via `.mcp-use/state/tunnel.json`.
- pnpm-injected `npm_config_*` noise from npx is filtered out of tunnel output.
- Dev auto-opens the inspector in the browser; `--no-open` disables, and non-TTY contexts (agents/CI) skip it automatically.

## Test plan

- [x] 94 tests pass (`pnpm run test:run`), including new `dev-api` unit tests with a faked tunnel manager
- [x] Verified in the browser: shell-served bundle renders styled, auto-connects, shows real version (v11.0.0)
- [x] Tunnel start/stop exercised through the inspector UI: public URL served `tools/list` through `*.local.mcp-use.run`, stop tore it down cleanly
- [x] Non-TTY `mcp-use dev` starts with no browser-open attempt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the v2 inspector CDN shell work end-to-end and adds first-class dev tunneling to `mcp-use dev`. Implements MCP-2601.

- **New Features**
  - `@mcp-use/server` inspector shell now loads `@mcp-use/inspector` from the mcp‑use R2 CDN pinned to an exact version, injects the companion CSS, and provides a `window.process` polyfill.
  - The shell publishes `window.__MCP_USE_INSPECTOR__` (`basePath`, `autoConnectUrl`); the client auto‑connects from this instead of `config.json` and shows the real bundle version.
  - `mcp-use dev --tunnel` runs `npx @mcp-use/tunnel` for the bound port; the dev server exposes `GET dev/info`, `POST dev/start-tunnel`, and `POST dev/stop-tunnel` so the UI can toggle tunnels without restarts.
  - Tunnel subdomains persist to `.mcp-use/state/tunnel.json` and are released on stop; noisy `npm_config_*` lines from `npx` are filtered.
  - The inspector auto‑opens in a browser on startup; use `--no-open` to disable, and non‑TTY environments skip opening automatically.

<sup>Written for commit a712e2494811d386693721846d56580e7e86bedf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

