### PR TITLE
feat(typescript): typed request logging for @mcp-use/server v2

### DIFF
--- a/libraries/typescript/packages/server/specs/CLI_SPEC.md
+++ b/libraries/typescript/packages/server/specs/CLI_SPEC.md
@@ -170,10 +170,10 @@ The inspector UI is **not a package dependency anywhere**. `@mcp-use/server` its
 `ServerConfig` gains:
 
 ```ts
-inspector?: boolean | { assetsUrl?: string }; // default: enabled
+inspector?: { enabled?: boolean; assetsUrl?: string }; // default: enabled
 ```
 
-Default **enabled**, mounted in both dev and production — like FastAPI's `/docs`; users set `inspector: false` to disable. Because the shell is just an HTML string with a CDN script tag, this does not violate the no-inspector-dependency rule.
+Default **enabled**, mounted in both dev and production — like FastAPI's `/docs`; users set `inspector: { enabled: false }` to disable. (Originally shipped as `boolean | { assetsUrl }`; changed to the object-only `{ enabled }` shape when `logging` landed so all on/off-with-options config reads the same way — no boolean unions.) Because the shell is just an HTML string with a CDN script tag, this does not violate the no-inspector-dependency rule.
 
 **Known limitation, recorded honestly** (Linear MCP-2075): the full v1 inspector also expects a backend proxy route; the CDN shell in this phase is browser-only and connects directly to the same-origin MCP endpoint. Acceptable for now — the current inspector may not fully support the v2 client protocol yet; "renders and connects" is the bar.
 

--- a/libraries/typescript/packages/server/specs/SPEC.md
+++ b/libraries/typescript/packages/server/specs/SPEC.md
@@ -1,6 +1,6 @@
 # @mcp-use/server — v2 server rebuild
 
-**Status:** Phase 1 (basic MCP pieces) implemented. This document is the working contract; it is updated as each phase lands.
+**Status:** Phase 1 (basic MCP pieces) implemented, plus the build/dev/start CLI and inspector CDN shell (contract in `CLI_SPEC.md`) and built-in request logging (§ Request logging). This document is the working contract; it is updated as each phase lands.
 **Package:** `@mcp-use/server` (private during development; renamed/published as `mcp-use@2.x` at cutover, replacing `packages/mcp-use`).
 **Branch target:** `v2`.
 
@@ -45,6 +45,8 @@ const server = new MCPServer({
   host: "127.0.0.1",           // optional; "0.0.0.0" for public listen()
   allowedHosts: undefined,     // optional, e.g. ["api.example.com"]; additive to localhost
   allowedOrigins: undefined,   // optional origin hostnames; defaults to the Host allowlist
+  inspector: { enabled: true, assetsUrl: undefined }, // optional; see CLI_SPEC.md
+  logging: { enabled: true, level: "info" },          // optional; see § Request logging
 });
 
 server.tool(
@@ -120,6 +122,28 @@ Callback context (`ctx`, second parameter): `{ signal, request? }` — request-s
 **Intentionally absent from Phase 1** (land with their phase): `ctx.sample`/`ctx.elicit`/`ctx.auth`/`ctx.req` (Hono context), OAuth, middleware (`server.use`), notifications/subscriptions, views/widgets, landing page, OpenAPI import, telemetry, typegen, stdio serving.
 
 **Examples** (`examples/vercel`, `examples/railway`): the two deployment doors, each verified end-to-end. Vercel = serverless via `getHandler()` exported as `export default { fetch }` from an `api/` function — zero host config (delta 5). Railway = long-lived `listen()` on `0.0.0.0` (bound only when `RAILWAY_PUBLIC_DOMAIN` is present), SIGINT/SIGTERM → `close()`.
+
+## Request logging (landed 2026-07-06)
+
+Built-in HTTP/MCP request logging (`src/logging.ts`), on by default. One summary line per HTTP request plus an indented detail line for MCP requests:
+
+```text
+12:45:01 POST /mcp 200 in 12ms
+  tools/call greet cursor/1.2.0
+```
+
+Contract:
+
+- **Format.** Summary line: `HH:MM:SS` UTC timestamp, HTTP verb, pathname, status (colored by class), duration. Detail line: plain two-space-indented ASCII (no box-drawing glyphs) carrying the MCP method (colored by namespace), its subject (tool name / resource URI / prompt name / `clientName/version` for initialize), and the calling client from the 2026-07-28 per-request `_meta` envelope (`io.modelcontextprotocol/clientInfo` — the stateless replacement for v1's session-id prefix; omitted on initialize, whose subject already is the client). Machine-parseable by construction: summary lines start with a timestamp, detail lines with whitespace. Tool `isError` results and JSON-RPC errors append `ERROR <message>`; the pair is emitted as one `console.log` so it stays atomic under concurrency.
+- **Levels** (`logging.level`, overridden by the `MCP_USE_LOG_LEVEL` env var; `info` | `debug` | `trace`):
+  - `info` (default): summary + detail only — **no request or response payloads**, so secrets in tool arguments/results stay out of production logs.
+  - `debug`: echoes compact single-line input/output on the detail line, truncated at 80 chars — tool/prompt arguments, and `-> <result>` for `tools/call` (`structuredContent` when present, else a lone text block). Resource/prompt result payloads are never echoed (bulk content).
+  - `trace`: debug plus a full request/response header+body dump after the pair (v1's `DEBUG=1` behavior).
+- **Typed against the SDK, exhaustively.** Detail formatting is a table mapped over the SDK's `RequestMethod` union with params typed per method via `RequestTypeMap`; a new protocol method in an SDK bump is a **compile error** here until a formatter is chosen (the v1 logger's silent `[unknown-method]` fallback is the anti-pattern this replaces). Bodies are narrowed with `isJSONRPCRequest`, and the parsed body comes from `c.var.parsedBody` when `createMcpHonoApp` mounted the app (no re-parse; cloned+parsed only on bare apps).
+- **Safety.** Credential headers (`authorization`, `proxy-authorization`, `cookie`, `set-cookie`, `x-api-key`) are `[REDACTED]` in trace dumps; request-derived strings (method/subject/client/error) are stripped of control characters so hostile values cannot forge log lines or emit terminal escapes; `subscriptions/listen` responses are never awaited for an outcome (unbounded SSE stream — reading it would block the middleware chain).
+- **Colors** via a ~10-line internal ANSI helper — **no chalk/picocolors dependency** (dependency-budget ground rule). Honors `NO_COLOR`; plain text when stdout is not a TTY or absent (edge runtimes).
+- **Noise.** Inspector shell page loads and favicon probes (GET/HEAD) are skipped; non-MCP requests log the summary line only.
+- **Config & exports.** `logging?: { enabled?: boolean; level?: "info" | "debug" | "trace" }` on `ServerConfig` (default enabled at `info`). The convention set here: on/off-with-options config fields are object-only with an `enabled` flag — no `boolean | object` unions (`inspector` was migrated to match). `requestLogger(options)`, `LoggingOptions`, and `LogLevel` are exported from the package root for hand-composed `mountMcp` apps.
 
 ## Later phases (each gets its own scope + delta notes before work starts)
 

--- a/libraries/typescript/packages/server/src/config.ts
+++ b/libraries/typescript/packages/server/src/config.ts
@@ -109,12 +109,15 @@ export interface ServerConfig {
   /**
    * HTTP/MCP request logging: one summary line per request plus an indented
    * detail line naming the MCP method, its subject (tool name, resource URI,
-   * prompt name), compact input/output, and the calling client.
+   * prompt name), and the calling client.
    *
-   * Enabled at the `info` level by default; set `{ enabled: false }` to
-   * disable, or `{ level: "debug" }` to add full request/response header and
-   * body dumps. The `MCP_USE_LOG_LEVEL` environment variable
-   * (`info` | `debug`) overrides the configured level.
+   * Enabled at the `info` level by default, which prints no request or
+   * response payloads. Set `{ enabled: false }` to disable,
+   * `{ level: "debug" }` to echo compact truncated tool/prompt input and
+   * tool output on the detail line, or `{ level: "trace" }` for debug plus
+   * full request/response header and body dumps. The `MCP_USE_LOG_LEVEL`
+   * environment variable (`info` | `debug` | `trace`) overrides the
+   * configured level.
    */
   logging?: LoggingOptions;
 }

--- a/libraries/typescript/packages/server/src/config.ts
+++ b/libraries/typescript/packages/server/src/config.ts
@@ -1,8 +1,16 @@
+import type { LoggingOptions } from "./logging.js";
+
 /**
- * Options for the inspector shell route — the object form of
+ * Options for the inspector shell route — the shape of
  * {@link ServerConfig.inspector}.
  */
 export interface InspectorOptions {
+  /**
+   * Whether the inspector shell route is mounted.
+   *
+   * @defaultValue `true`
+   */
+  enabled?: boolean;
   /**
    * Full replacement URL for the inspector bundle script (FastAPI's
    * `swagger_js_url` analog). The shell's `<script type="module">` loads
@@ -73,11 +81,9 @@ export interface ServerConfig {
    * server's MCP endpoint at `basePath`, deriving the URL from the browser's
    * own origin.
    *
-   * `true`, `{}`, and leaving the field unset all mean enabled; set `false`
-   * to disable the route, or pass `{ assetsUrl }` to load the bundle from a
-   * self-hosted copy instead of the public CDN (air-gapped environments).
-   *
-   * @defaultValue `true`
+   * Enabled by default; set `{ enabled: false }` to disable the route, or
+   * pass `{ assetsUrl }` to load the bundle from a self-hosted copy instead
+   * of the public CDN (air-gapped environments).
    *
    * @example
    * ```ts
@@ -85,7 +91,11 @@ export interface ServerConfig {
    * new MCPServer({ name: "my-server", version: "1.0.0" });
    *
    * // Disabled:
-   * new MCPServer({ name: "my-server", version: "1.0.0", inspector: false });
+   * new MCPServer({
+   *   name: "my-server",
+   *   version: "1.0.0",
+   *   inspector: { enabled: false },
+   * });
    *
    * // Air-gapped: load a self-hosted copy of the inspector bundle.
    * new MCPServer({
@@ -95,5 +105,16 @@ export interface ServerConfig {
    * });
    * ```
    */
-  inspector?: boolean | InspectorOptions;
+  inspector?: InspectorOptions;
+  /**
+   * HTTP/MCP request logging: one summary line per request plus an indented
+   * detail line naming the MCP method, its subject (tool name, resource URI,
+   * prompt name), compact input/output, and the calling client.
+   *
+   * Enabled at the `info` level by default; set `{ enabled: false }` to
+   * disable, or `{ level: "debug" }` to add full request/response header and
+   * body dumps. The `MCP_USE_LOG_LEVEL` environment variable
+   * (`info` | `debug`) overrides the configured level.
+   */
+  logging?: LoggingOptions;
 }

--- a/libraries/typescript/packages/server/src/index.ts
+++ b/libraries/typescript/packages/server/src/index.ts
@@ -8,6 +8,8 @@
 export { MCPServer } from "./server.js";
 export { mountMcp } from "./mount-mcp.js";
 export type { MountMcpOptions } from "./mount-mcp.js";
+export { requestLogger } from "./logging.js";
+export type { LoggingOptions, LogLevel } from "./logging.js";
 
 /**
  * Wire result shapes (re-exported from the SDK): callbacks return these raw

--- a/libraries/typescript/packages/server/src/inspector-shell.ts
+++ b/libraries/typescript/packages/server/src/inspector-shell.ts
@@ -157,8 +157,8 @@ export function renderInspectorShell(options: InspectorShellOptions): string {
  *
  * Registers GET for both the bare and trailing-slash paths (Hono answers
  * HEAD from GET handlers automatically) and serves the pre-rendered shell as
- * `text/html; charset=utf-8`. No-op when `inspector` is `false`;
- * `undefined`, `true`, and `{}` all mean enabled.
+ * `text/html; charset=utf-8`. No-op when `inspector.enabled` is `false`;
+ * `undefined` and `{}` mean enabled.
  *
  * @internal Wiring for `MCPServer` — mounted on the same app as the MCP
  * endpoint, so any configured Host/Origin validation middleware applies to
@@ -166,13 +166,13 @@ export function renderInspectorShell(options: InspectorShellOptions): string {
  */
 export function mountInspectorShell<E extends Env>(
   app: Hono<E>,
-  inspector: boolean | InspectorOptions | undefined,
+  inspector: InspectorOptions | undefined,
   options: { serverName: string; basePath: string }
 ): void {
-  if (inspector === false) {
+  if (inspector?.enabled === false) {
     return;
   }
-  const { assetsUrl } = typeof inspector === "object" ? inspector : {};
+  const { assetsUrl } = inspector ?? {};
   // Config is fixed at mount time, so the page renders once, not per request.
   const html = renderInspectorShell({
     serverName: options.serverName,

--- a/libraries/typescript/packages/server/src/logging.ts
+++ b/libraries/typescript/packages/server/src/logging.ts
@@ -234,7 +234,7 @@ function formatClientIdentity(message: JSONRPCRequest): string | undefined {
  */
 function sanitize(text: string): string {
   // eslint-disable-next-line no-control-regex
-  return text.replace(/[\u0000-\u001F\u007F]+/g, " ");
+  return text.replace(/[\u0000-\u001F\u007F-\u009F]+/g, " ");
 }
 
 /** Namespace color for the detail line's method segment. */

--- a/libraries/typescript/packages/server/src/logging.ts
+++ b/libraries/typescript/packages/server/src/logging.ts
@@ -1,0 +1,549 @@
+/**
+ * Compact HTTP/MCP request logging.
+ *
+ * One summary line per HTTP request, plus an indented detail line for MCP
+ * (JSON-RPC) requests naming the protocol method, its subject (tool name,
+ * resource URI, prompt name), compact truncated input/output, and the
+ * calling client:
+ *
+ * ```text
+ * 12:45:01 POST /mcp 200 in 12ms
+ *   tools/call greet {"who":"world"} -> "hi world" raw-request/0.0.0
+ * ```
+ *
+ * Detail lines are plain two-space-indented ASCII (no box-drawing glyphs) so
+ * log parsers and agents can tell the two apart mechanically: summary lines
+ * start with a timestamp, detail lines start with whitespace.
+ *
+ * Two verbosity levels, resolved per request from the `MCP_USE_LOG_LEVEL`
+ * environment variable (overriding any configured level):
+ *
+ * - `info` (default): the compact summary + detail lines only.
+ * - `debug`: adds a full request/response dump (headers and bodies) after the
+ *   summary. `trace` is accepted as an alias for `debug` (the v1 name).
+ */
+import {
+  CLIENT_INFO_META_KEY,
+  isJSONRPCRequest,
+  type Implementation,
+  type JSONRPCRequest,
+  type RequestMethod,
+  type RequestTypeMap,
+} from "@modelcontextprotocol/server";
+import type { Context, MiddlewareHandler } from "hono";
+
+/** Verbosity of the request logger. */
+export type LogLevel = "info" | "debug";
+
+/** Options for {@link requestLogger} — the shape of `config.logging`. */
+export interface LoggingOptions {
+  /**
+   * Whether request logging is on.
+   *
+   * @defaultValue `true`
+   */
+  enabled?: boolean;
+  /**
+   * Verbosity: `info` (compact lines, default) or `debug` (adds full
+   * request/response header and body dumps). The `MCP_USE_LOG_LEVEL`
+   * environment variable overrides this when set.
+   */
+  level?: LogLevel;
+}
+
+/* ------------------------------------------------------------------------ *
+ * ANSI styling (no color-library dependency)
+ * ------------------------------------------------------------------------ */
+
+/**
+ * Whether to emit ANSI escapes: only on a TTY stdout, and never when the
+ * `NO_COLOR` convention is set. Edge runtimes without `process.stdout`
+ * (Workers, Deno Deploy) get plain text.
+ */
+function colorsEnabled(): boolean {
+  if (typeof process === "undefined") return false;
+  if (process.env?.["NO_COLOR"] !== undefined) return false;
+  return process.stdout?.isTTY === true;
+}
+
+type Style = (text: string) => string;
+
+function ansi(open: number, close: number): Style {
+  return (text) =>
+    colorsEnabled() ? `\u001B[${open}m${text}\u001B[${close}m` : text;
+}
+
+const bold = ansi(1, 22);
+const dim = ansi(2, 22);
+const red = ansi(31, 39);
+const green = ansi(32, 39);
+const yellow = ansi(33, 39);
+const blue = ansi(34, 39);
+const magenta = ansi(35, 39);
+const cyan = ansi(36, 39);
+const gray = ansi(90, 39);
+
+/* ------------------------------------------------------------------------ *
+ * Level resolution
+ * ------------------------------------------------------------------------ */
+
+/**
+ * Effective log level: `MCP_USE_LOG_LEVEL` when it names a known level
+ * (`trace` — the v1 name for the dump tier — maps to `debug`), otherwise the
+ * configured level, otherwise `info`.
+ */
+export function resolveLogLevel(configured?: LogLevel): LogLevel {
+  const raw =
+    typeof process === "undefined"
+      ? undefined
+      : process.env?.["MCP_USE_LOG_LEVEL"]?.toLowerCase();
+  if (raw === "debug" || raw === "trace") return "debug";
+  if (raw === "info") return "info";
+  return configured ?? "info";
+}
+
+/* ------------------------------------------------------------------------ *
+ * MCP detail formatting (typed against the SDK's protocol method surface)
+ * ------------------------------------------------------------------------ */
+
+/** What one protocol method contributes to the detail line. */
+interface McpDetail {
+  /** Short subject next to the method name (tool name, resource URI, …). */
+  subject?: string | undefined;
+  /** Caller-provided input worth echoing inline (tool/prompt arguments). */
+  input?: unknown;
+}
+
+/**
+ * Detail extractor for one protocol method: given the method's typed params,
+ * return the subject and inline input to show, or `{}` when the method name
+ * says it all.
+ */
+type DetailFormatter<M extends RequestMethod> = (
+  params: RequestTypeMap[M]["params"]
+) => McpDetail;
+
+function formatClientInfo(info: Implementation | undefined): string | undefined {
+  if (info === undefined) return undefined;
+  return typeof info.version === "string" && info.version !== ""
+    ? `${info.name}/${info.version}`
+    : info.name;
+}
+
+/**
+ * Exhaustive over {@link RequestMethod}: adding a protocol method to the SDK
+ * makes this table a compile error until a formatter is chosen — the inverse
+ * of v1's silent `[unknown-method]` fallback.
+ */
+const detailFormatters: {
+  [M in RequestMethod]: DetailFormatter<M>;
+} = {
+  initialize: (p) => ({ subject: formatClientInfo(p.clientInfo) }),
+  ping: () => ({}),
+  "server/discover": () => ({}),
+  "completion/complete": (p) => ({
+    subject: p.ref.type === "ref/prompt" ? p.ref.name : p.ref.uri,
+    input: p.argument,
+  }),
+  "logging/setLevel": (p) => ({ subject: p.level }),
+  "prompts/get": (p) => ({ subject: p.name, input: p.arguments }),
+  "prompts/list": () => ({}),
+  "resources/list": () => ({}),
+  "resources/templates/list": () => ({}),
+  "resources/read": (p) => ({ subject: p.uri }),
+  "resources/subscribe": (p) => ({ subject: p.uri }),
+  "resources/unsubscribe": (p) => ({ subject: p.uri }),
+  "subscriptions/listen": () => ({}),
+  "tools/call": (p) => ({ subject: p.name, input: p.arguments }),
+  "tools/list": () => ({}),
+  "sampling/createMessage": () => ({}),
+  "elicitation/create": () => ({}),
+  "roots/list": () => ({}),
+};
+
+function isKnownMethod(method: string): method is RequestMethod {
+  return Object.prototype.hasOwnProperty.call(detailFormatters, method);
+}
+
+/**
+ * Detail for a guard-proved JSON-RPC request. The guard proves the JSON-RPC
+ * envelope, not method-specific params, so the formatter call is fenced: a
+ * malformed body (which the SDK will reject downstream anyway) logs without
+ * a subject rather than throwing here.
+ */
+function formatDetail(message: JSONRPCRequest): McpDetail {
+  if (!isKnownMethod(message.method)) return {};
+  try {
+    const formatter = detailFormatters[message.method] as (
+      params: unknown
+    ) => McpDetail;
+    const detail = formatter(message.params);
+    return typeof detail.subject === "string" || detail.subject === undefined
+      ? detail
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+/** Longest inline JSON segment (input or output) before truncation. */
+const INLINE_JSON_MAX_LENGTH = 80;
+
+/**
+ * Compact single-line JSON for inline input/output echoing, truncated to
+ * {@link INLINE_JSON_MAX_LENGTH} characters.
+ */
+function inlineJson(value: unknown): string {
+  let text: string;
+  try {
+    text = JSON.stringify(value) ?? String(value);
+  } catch {
+    text = String(value);
+  }
+  return text.length > INLINE_JSON_MAX_LENGTH
+    ? `${text.slice(0, INLINE_JSON_MAX_LENGTH)}...`
+    : text;
+}
+
+/**
+ * Client identity from the per-request `_meta` envelope every 2026-07-28
+ * request carries (`io.modelcontextprotocol/clientInfo`) — the stateless
+ * replacement for v1's session-id prefix. `undefined` for requests without
+ * the envelope (legacy-era traffic).
+ */
+function formatClientIdentity(message: JSONRPCRequest): string | undefined {
+  const meta = message.params?._meta;
+  if (meta === undefined) return undefined;
+  const info = (meta as Record<string, unknown>)[CLIENT_INFO_META_KEY];
+  if (
+    typeof info !== "object" ||
+    info === null ||
+    typeof (info as Implementation).name !== "string"
+  ) {
+    return undefined;
+  }
+  return formatClientInfo(info as Implementation);
+}
+
+/** Namespace color for the detail line's method segment. */
+function methodStyle(method: string): Style {
+  if (method.startsWith("tools/")) return cyan;
+  if (method.startsWith("resources/")) return green;
+  if (method.startsWith("prompts/")) return magenta;
+  if (method === "initialize" || method === "ping") return gray;
+  return blue;
+}
+
+/* ------------------------------------------------------------------------ *
+ * Response outcome
+ * ------------------------------------------------------------------------ */
+
+/** The JSON-RPC-level outcome parsed from a response body. */
+interface ResponseOutcome {
+  /** Error message when the exchange failed (JSON-RPC error or tool error). */
+  errorMessage: string | null;
+  /** The JSON-RPC `result` payload when the exchange succeeded. */
+  result?: unknown;
+}
+
+/**
+ * Parse the JSON-RPC outcome from the response body: an error message from
+ * the error envelope (`{ error: { message } }`) or a tool-call error
+ * (`{ result: { isError: true, content: [{ text }] } }`), otherwise the
+ * successful `result` payload. Handles both `application/json` and
+ * `text/event-stream` bodies.
+ */
+async function extractResponseOutcome(res: Response): Promise<ResponseOutcome> {
+  if (!res.body) return { errorMessage: null };
+
+  let text: string;
+  try {
+    text = await res.clone().text();
+  } catch {
+    return { errorMessage: null };
+  }
+  if (!text) return { errorMessage: null };
+
+  const isSse = (res.headers.get("content-type") ?? "").includes(
+    "text/event-stream"
+  );
+  const payloads: unknown[] = [];
+  const tryParse = (raw: string) => {
+    try {
+      payloads.push(JSON.parse(raw));
+    } catch {
+      // not JSON — skip
+    }
+  };
+  if (isSse) {
+    for (const line of text.split(/\r?\n/)) {
+      if (line.startsWith("data:")) {
+        const data = line.slice(5).trim();
+        if (data) tryParse(data);
+      }
+    }
+  } else {
+    tryParse(text);
+  }
+
+  let result: unknown;
+  for (const payload of payloads) {
+    if (payload === null || typeof payload !== "object") continue;
+    const message = payload as {
+      error?: { message?: unknown };
+      result?: { isError?: unknown; content?: unknown };
+    };
+    if (typeof message.error?.message === "string") {
+      return { errorMessage: message.error.message };
+    }
+    if (message.result?.isError === true) {
+      const blocks = Array.isArray(message.result.content)
+        ? (message.result.content as { type?: unknown; text?: unknown }[])
+        : [];
+      const textBlock = blocks.find(
+        (b) => b?.type === "text" && typeof b.text === "string"
+      );
+      return {
+        errorMessage: textBlock ? String(textBlock.text) : "tool error",
+      };
+    }
+    if ("result" in message) result = message.result;
+  }
+  return { errorMessage: null, result };
+}
+
+/**
+ * Compact view of a successful `tools/call` result for inline echoing:
+ * `structuredContent` when present, a lone text block's text, or the raw
+ * content blocks.
+ */
+function compactToolResult(result: unknown): unknown {
+  if (result === null || typeof result !== "object") return result;
+  const { structuredContent, content } = result as {
+    structuredContent?: unknown;
+    content?: unknown;
+  };
+  if (structuredContent !== undefined) return structuredContent;
+  if (Array.isArray(content)) {
+    const [block] = content as { type?: unknown; text?: unknown }[];
+    if (content.length === 1 && block?.type === "text") return block.text;
+  }
+  return content;
+}
+
+/* ------------------------------------------------------------------------ *
+ * Debug dump
+ * ------------------------------------------------------------------------ */
+
+/** Pretty-print a value for the debug dump, truncating long strings. */
+function formatForDump(value: unknown): string {
+  function truncate(val: unknown): unknown {
+    if (typeof val === "string" && val.length > 100) {
+      return `${val.slice(0, 100)}...`;
+    }
+    if (Array.isArray(val)) return val.map(truncate);
+    if (val !== null && typeof val === "object") {
+      return Object.fromEntries(
+        Object.entries(val as Record<string, unknown>).map(([k, v]) => [
+          k,
+          truncate(v),
+        ])
+      );
+    }
+    return val;
+  }
+  try {
+    return JSON.stringify(truncate(value), null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+const DUMP_BODY_MAX_LENGTH = 10_000;
+
+async function printDebugDump(
+  c: Context,
+  requestHeaders: Record<string, string>,
+  requestBody: unknown,
+  readResponseBody: boolean
+): Promise<void> {
+  console.log(`\n${cyan("=".repeat(80))}`);
+  console.log(bold(cyan("[DEBUG] Request Details")));
+  console.log(cyan("-".repeat(80)));
+
+  if (Object.keys(requestHeaders).length > 0) {
+    console.log(yellow("Request Headers:"));
+    console.log(formatForDump(requestHeaders));
+  }
+  if (requestBody !== undefined) {
+    console.log(yellow("Request Body:"));
+    console.log(
+      typeof requestBody === "string" ? requestBody : formatForDump(requestBody)
+    );
+  }
+
+  const responseHeaders: Record<string, string> = {};
+  c.res.headers.forEach((value, key) => {
+    responseHeaders[key] = value;
+  });
+  if (Object.keys(responseHeaders).length > 0) {
+    console.log(yellow("Response Headers:"));
+    console.log(formatForDump(responseHeaders));
+  }
+
+  if (!readResponseBody) {
+    console.log(`${yellow("Response Body:")} (streaming — not dumped)`);
+  } else if (c.res.body === null) {
+    console.log(`${yellow("Response Body:")} (no body)`);
+  } else {
+    try {
+      const text = await c.res.clone().text();
+      if (text.length === 0) {
+        console.log(`${yellow("Response Body:")} (empty)`);
+      } else {
+        console.log(yellow("Response Body:"));
+        try {
+          console.log(formatForDump(JSON.parse(text)));
+        } catch {
+          console.log(
+            text.length > DUMP_BODY_MAX_LENGTH
+              ? `${text.slice(0, DUMP_BODY_MAX_LENGTH)}\n... (truncated, ${
+                  text.length - DUMP_BODY_MAX_LENGTH
+                } more characters)`
+              : text
+          );
+        }
+      }
+    } catch {
+      console.log(`${yellow("Response Body:")} (unable to read)`);
+    }
+  }
+
+  console.log(`${cyan("=".repeat(80))}\n`);
+}
+
+/* ------------------------------------------------------------------------ *
+ * Middleware
+ * ------------------------------------------------------------------------ */
+
+/** Style an HTTP status code by its class. */
+function styleStatus(status: number): string {
+  const text = String(status);
+  if (status >= 500) return magenta(text);
+  if (status >= 400) return red(text);
+  if (status >= 300) return yellow(text);
+  return green(text);
+}
+
+/**
+ * Cosmetic noise suppression: inspector shell page loads and favicon probes
+ * add nothing to a request log.
+ */
+function isNoisyRequest(httpMethod: string, pathname: string): boolean {
+  if (httpMethod !== "GET" && httpMethod !== "HEAD") return false;
+  return pathname.includes("/inspector") || pathname.endsWith("/favicon.ico");
+}
+
+/**
+ * Hono middleware logging every request in the compact two-line format (see
+ * the module docs). Register it on the app the MCP endpoint is mounted on;
+ * `MCPServer` does so automatically unless `config.logging.enabled` is
+ * `false`.
+ */
+export function requestLogger(options: LoggingOptions = {}): MiddlewareHandler {
+  if (options.enabled === false) {
+    return (_c, next) => next();
+  }
+  return async (c, next) => {
+    const level = resolveLogLevel(options.level);
+    const startedAt = Date.now();
+    const httpMethod = c.req.method;
+    const pathname = new URL(c.req.url).pathname;
+
+    if (isNoisyRequest(httpMethod, pathname)) {
+      await next();
+      return;
+    }
+
+    const requestHeaders: Record<string, string> =
+      level === "debug" ? c.req.header() : {};
+
+    // Body: prefer the parsed body createMcpHonoApp's JSON middleware stashed
+    // in context vars (a request body is only readable once); fall back to
+    // cloning on bare apps where that middleware is absent.
+    let requestBody: unknown;
+    if (httpMethod !== "GET" && httpMethod !== "HEAD") {
+      const parsedBody = (c.var as Record<string, unknown>)["parsedBody"];
+      if (parsedBody !== undefined) {
+        requestBody = parsedBody;
+      } else {
+        try {
+          requestBody = await c.req.raw.clone().json();
+        } catch {
+          // Non-JSON body — the summary line logs without MCP detail.
+        }
+      }
+    }
+
+    await next();
+
+    const durationMs = Date.now() - startedAt;
+    const timestamp = new Date().toISOString().substring(11, 19);
+    const mcpRequest = isJSONRPCRequest(requestBody) ? requestBody : undefined;
+
+    // Long-lived streams (subscriptions/listen keeps its SSE stream open
+    // indefinitely) must not be awaited for an outcome — reading the full
+    // body would block the log line, and the middleware chain, forever.
+    const isStreamingMethod = mcpRequest?.method === "subscriptions/listen";
+
+    const lines: string[] = [
+      [
+        dim(timestamp),
+        bold(httpMethod),
+        pathname,
+        styleStatus(c.res.status),
+        dim(`in ${durationMs}ms`),
+      ].join(" "),
+    ];
+
+    if (mcpRequest !== undefined) {
+      const parts: string[] = [
+        `  ${methodStyle(mcpRequest.method)(mcpRequest.method)}`,
+      ];
+      const detail = formatDetail(mcpRequest);
+      if (detail.subject !== undefined) parts.push(bold(detail.subject));
+      if (detail.input !== undefined) parts.push(inlineJson(detail.input));
+      const outcome: ResponseOutcome = isStreamingMethod
+        ? { errorMessage: null }
+        : await extractResponseOutcome(c.res);
+      // Echo tool output inline (truncated): the one result callers reliably
+      // want to glance at. Resource/prompt payloads are bulk content — the
+      // debug dump covers those.
+      if (
+        mcpRequest.method === "tools/call" &&
+        outcome.errorMessage === null &&
+        outcome.result !== undefined
+      ) {
+        parts.push(dim("->"), inlineJson(compactToolResult(outcome.result)));
+      }
+      // The initialize subject *is* the client identity — don't repeat it.
+      if (mcpRequest.method !== "initialize") {
+        const client = formatClientIdentity(mcpRequest);
+        if (client !== undefined) parts.push(dim(client));
+      }
+      if (outcome.errorMessage !== null) {
+        parts.push(red(`ERROR ${outcome.errorMessage}`));
+      } else if (c.res.status >= 400) {
+        parts.push(red(`ERROR (HTTP ${c.res.status})`));
+      }
+      lines.push(parts.join(" "));
+    }
+
+    // One console.log per request keeps the pair atomic under concurrency.
+    console.log(lines.join("\n"));
+
+    if (level === "debug") {
+      await printDebugDump(c, requestHeaders, requestBody, !isStreamingMethod);
+    }
+  };
+}

--- a/libraries/typescript/packages/server/src/logging.ts
+++ b/libraries/typescript/packages/server/src/logging.ts
@@ -3,24 +3,27 @@
  *
  * One summary line per HTTP request, plus an indented detail line for MCP
  * (JSON-RPC) requests naming the protocol method, its subject (tool name,
- * resource URI, prompt name), compact truncated input/output, and the
- * calling client:
+ * resource URI, prompt name), and the calling client:
  *
  * ```text
  * 12:45:01 POST /mcp 200 in 12ms
- *   tools/call greet {"who":"world"} -> "hi world" raw-request/0.0.0
+ *   tools/call greet raw-request/0.0.0
  * ```
  *
  * Detail lines are plain two-space-indented ASCII (no box-drawing glyphs) so
  * log parsers and agents can tell the two apart mechanically: summary lines
  * start with a timestamp, detail lines start with whitespace.
  *
- * Two verbosity levels, resolved per request from the `MCP_USE_LOG_LEVEL`
+ * Three verbosity levels, resolved per request from the `MCP_USE_LOG_LEVEL`
  * environment variable (overriding any configured level):
  *
- * - `info` (default): the compact summary + detail lines only.
- * - `debug`: adds a full request/response dump (headers and bodies) after the
- *   summary. `trace` is accepted as an alias for `debug` (the v1 name).
+ * - `info` (default): the compact summary + detail lines only — no request
+ *   or response payloads, so secrets in tool arguments/results stay out of
+ *   production logs.
+ * - `debug`: echoes compact truncated input/output on the detail line:
+ *   `tools/call greet {"who":"world"} -> "hi world" raw-request/0.0.0`.
+ * - `trace`: debug plus a full request/response dump (headers and bodies)
+ *   after the summary.
  */
 import {
   CLIENT_INFO_META_KEY,
@@ -33,7 +36,7 @@ import {
 import type { Context, MiddlewareHandler } from "hono";
 
 /** Verbosity of the request logger. */
-export type LogLevel = "info" | "debug";
+export type LogLevel = "info" | "debug" | "trace";
 
 /** Options for {@link requestLogger} — the shape of `config.logging`. */
 export interface LoggingOptions {
@@ -44,9 +47,10 @@ export interface LoggingOptions {
    */
   enabled?: boolean;
   /**
-   * Verbosity: `info` (compact lines, default) or `debug` (adds full
-   * request/response header and body dumps). The `MCP_USE_LOG_LEVEL`
-   * environment variable overrides this when set.
+   * Verbosity: `info` (compact lines without payloads, default), `debug`
+   * (adds compact truncated input/output on the detail line), or `trace`
+   * (debug plus full request/response header and body dumps). The
+   * `MCP_USE_LOG_LEVEL` environment variable overrides this when set.
    */
   level?: LogLevel;
 }
@@ -88,17 +92,15 @@ const gray = ansi(90, 39);
  * ------------------------------------------------------------------------ */
 
 /**
- * Effective log level: `MCP_USE_LOG_LEVEL` when it names a known level
- * (`trace` — the v1 name for the dump tier — maps to `debug`), otherwise the
- * configured level, otherwise `info`.
+ * Effective log level: `MCP_USE_LOG_LEVEL` when it names a known level,
+ * otherwise the configured level, otherwise `info`.
  */
 export function resolveLogLevel(configured?: LogLevel): LogLevel {
   const raw =
     typeof process === "undefined"
       ? undefined
       : process.env?.["MCP_USE_LOG_LEVEL"]?.toLowerCase();
-  if (raw === "debug" || raw === "trace") return "debug";
-  if (raw === "info") return "info";
+  if (raw === "info" || raw === "debug" || raw === "trace") return raw;
   return configured ?? "info";
 }
 
@@ -225,6 +227,16 @@ function formatClientIdentity(message: JSONRPCRequest): string | undefined {
   return formatClientInfo(info as Implementation);
 }
 
+/**
+ * Strip control characters (newlines, ANSI escapes, …) from request-derived
+ * strings so a hostile method/subject/error value cannot forge extra log
+ * lines or terminal escape sequences.
+ */
+function sanitize(text: string): string {
+  // eslint-disable-next-line no-control-regex
+  return text.replace(/[\u0000-\u001F\u007F]+/g, " ");
+}
+
 /** Namespace color for the detail line's method segment. */
 function methodStyle(method: string): Style {
   if (method.startsWith("tools/")) return cyan;
@@ -237,6 +249,27 @@ function methodStyle(method: string): Style {
 /* ------------------------------------------------------------------------ *
  * Response outcome
  * ------------------------------------------------------------------------ */
+
+/** Header names whose values are credentials and never worth dumping. */
+const REDACTED_HEADERS = new Set([
+  "authorization",
+  "proxy-authorization",
+  "cookie",
+  "set-cookie",
+  "x-api-key",
+]);
+
+/** Replace credential-bearing header values with a `[REDACTED]` marker. */
+function redactHeaders(
+  headers: Record<string, string>
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(headers).map(([name, value]) => [
+      name,
+      REDACTED_HEADERS.has(name.toLowerCase()) ? "[REDACTED]" : value,
+    ])
+  );
+}
 
 /** The JSON-RPC-level outcome parsed from a response body. */
 interface ResponseOutcome {
@@ -332,10 +365,10 @@ function compactToolResult(result: unknown): unknown {
 }
 
 /* ------------------------------------------------------------------------ *
- * Debug dump
+ * Trace dump
  * ------------------------------------------------------------------------ */
 
-/** Pretty-print a value for the debug dump, truncating long strings. */
+/** Pretty-print a value for the trace dump, truncating long strings. */
 function formatForDump(value: unknown): string {
   function truncate(val: unknown): unknown {
     if (typeof val === "string" && val.length > 100) {
@@ -361,19 +394,19 @@ function formatForDump(value: unknown): string {
 
 const DUMP_BODY_MAX_LENGTH = 10_000;
 
-async function printDebugDump(
+async function printTraceDump(
   c: Context,
   requestHeaders: Record<string, string>,
   requestBody: unknown,
   readResponseBody: boolean
 ): Promise<void> {
   console.log(`\n${cyan("=".repeat(80))}`);
-  console.log(bold(cyan("[DEBUG] Request Details")));
+  console.log(bold(cyan("[TRACE] Request Details")));
   console.log(cyan("-".repeat(80)));
 
   if (Object.keys(requestHeaders).length > 0) {
     console.log(yellow("Request Headers:"));
-    console.log(formatForDump(requestHeaders));
+    console.log(formatForDump(redactHeaders(requestHeaders)));
   }
   if (requestBody !== undefined) {
     console.log(yellow("Request Body:"));
@@ -388,7 +421,7 @@ async function printDebugDump(
   });
   if (Object.keys(responseHeaders).length > 0) {
     console.log(yellow("Response Headers:"));
-    console.log(formatForDump(responseHeaders));
+    console.log(formatForDump(redactHeaders(responseHeaders)));
   }
 
   if (!readResponseBody) {
@@ -466,7 +499,7 @@ export function requestLogger(options: LoggingOptions = {}): MiddlewareHandler {
     }
 
     const requestHeaders: Record<string, string> =
-      level === "debug" ? c.req.header() : {};
+      level === "trace" ? c.req.header() : {};
 
     // Body: prefer the parsed body createMcpHonoApp's JSON middleware stashed
     // in context vars (a request body is only readable once); fall back to
@@ -507,19 +540,29 @@ export function requestLogger(options: LoggingOptions = {}): MiddlewareHandler {
     ];
 
     if (mcpRequest !== undefined) {
-      const parts: string[] = [
-        `  ${methodStyle(mcpRequest.method)(mcpRequest.method)}`,
-      ];
+      // Request-derived strings are sanitized: a hostile method/subject/
+      // error value must not forge log lines or emit terminal escapes.
+      const method = sanitize(mcpRequest.method);
+      const parts: string[] = [`  ${methodStyle(method)(method)}`];
       const detail = formatDetail(mcpRequest);
-      if (detail.subject !== undefined) parts.push(bold(detail.subject));
-      if (detail.input !== undefined) parts.push(inlineJson(detail.input));
+      if (detail.subject !== undefined) {
+        parts.push(bold(sanitize(detail.subject)));
+      }
+      // Inline input/output echoing is debug+ only: tool arguments and
+      // results can carry secrets, so the default info level never prints
+      // request or response payloads.
+      const echoPayloads = level !== "info";
+      if (echoPayloads && detail.input !== undefined) {
+        parts.push(inlineJson(detail.input));
+      }
       const outcome: ResponseOutcome = isStreamingMethod
         ? { errorMessage: null }
         : await extractResponseOutcome(c.res);
       // Echo tool output inline (truncated): the one result callers reliably
       // want to glance at. Resource/prompt payloads are bulk content — the
-      // debug dump covers those.
+      // trace dump covers those.
       if (
+        echoPayloads &&
         mcpRequest.method === "tools/call" &&
         outcome.errorMessage === null &&
         outcome.result !== undefined
@@ -529,10 +572,10 @@ export function requestLogger(options: LoggingOptions = {}): MiddlewareHandler {
       // The initialize subject *is* the client identity — don't repeat it.
       if (mcpRequest.method !== "initialize") {
         const client = formatClientIdentity(mcpRequest);
-        if (client !== undefined) parts.push(dim(client));
+        if (client !== undefined) parts.push(dim(sanitize(client)));
       }
       if (outcome.errorMessage !== null) {
-        parts.push(red(`ERROR ${outcome.errorMessage}`));
+        parts.push(red(`ERROR ${sanitize(outcome.errorMessage)}`));
       } else if (c.res.status >= 400) {
         parts.push(red(`ERROR (HTTP ${c.res.status})`));
       }
@@ -542,8 +585,8 @@ export function requestLogger(options: LoggingOptions = {}): MiddlewareHandler {
     // One console.log per request keeps the pair atomic under concurrency.
     console.log(lines.join("\n"));
 
-    if (level === "debug") {
-      await printDebugDump(c, requestHeaders, requestBody, !isStreamingMethod);
+    if (level === "trace") {
+      await printTraceDump(c, requestHeaders, requestBody, !isStreamingMethod);
     }
   };
 }

--- a/libraries/typescript/packages/server/src/server.ts
+++ b/libraries/typescript/packages/server/src/server.ts
@@ -15,6 +15,7 @@ import { Hono } from "hono";
 import type { ServerConfig } from "./config.js";
 import { toRequestContext } from "./context.js";
 import { mountInspectorShell } from "./inspector-shell.js";
+import { requestLogger } from "./logging.js";
 import { mountMcp } from "./mount-mcp.js";
 import type {
   InferPromptInput,
@@ -314,6 +315,7 @@ export class MCPServer {
           );
         }
       }
+      app.use("*", requestLogger(this.#config.logging));
       const handler = mountMcp(app, () => this.#buildSdkServer(), {
         path: this.#basePath(),
       });

--- a/libraries/typescript/packages/server/tests/inspector-shell.test.ts
+++ b/libraries/typescript/packages/server/tests/inspector-shell.test.ts
@@ -1,6 +1,6 @@
 /**
  * Tests for the inspector CDN shell route: default-enabled mounting at
- * `${basePath}/inspector`, the `inspector` config forms (`false`,
+ * `${basePath}/inspector`, the `inspector` config forms (`{ enabled: false }`,
  * `{ assetsUrl }`), script-injection escaping, and coexistence with the MCP
  * endpoint — driven through `getHandler()`, no network.
  */
@@ -110,8 +110,8 @@ describe("inspector shell route", () => {
     await server.close();
   });
 
-  it("treats true and {} the same as the default (enabled)", async () => {
-    for (const inspector of [true, {}] as const) {
+  it("treats {} and { enabled: true } the same as the default (enabled)", async () => {
+    for (const inspector of [{}, { enabled: true }] as const) {
       const server = makeServer({ inspector });
       const response = await get(server, "/mcp/inspector");
       expect(response.status).toBe(200);
@@ -120,8 +120,8 @@ describe("inspector shell route", () => {
     }
   });
 
-  it("returns 404 when inspector is false", async () => {
-    const server = makeServer({ inspector: false });
+  it("returns 404 when the inspector is disabled", async () => {
+    const server = makeServer({ inspector: { enabled: false } });
     expect((await get(server, "/mcp/inspector")).status).toBe(404);
     expect((await get(server, "/mcp/inspector/")).status).toBe(404);
     // The MCP endpoint itself is unaffected.

--- a/libraries/typescript/packages/server/tests/logging.test.ts
+++ b/libraries/typescript/packages/server/tests/logging.test.ts
@@ -115,14 +115,32 @@ describe("requestLogger (via MCPServer.getHandler)", () => {
     const lines = loggedLines();
     expect(lines).toHaveLength(2);
     expect(lines[0]).toMatch(/^\d{2}:\d{2}:\d{2} POST \/mcp 200 in \d+ms$/);
+    // info level: no request/response payloads on the detail line.
+    expect(lines[1]).toBe("  tools/call greet raw-request/0.0.0");
+    await server.close();
+  });
+
+  it("echoes inline input/output at debug level", async () => {
+    const server = buildServer({ logging: { level: "debug" } });
+    await server
+      .getHandler()(
+        mcpRequest(
+          "tools/call",
+          { name: "greet", arguments: { who: "world" } },
+          { "mcp-name": "greet" }
+        )
+      );
+    const lines = loggedLines();
+    // debug adds inline payloads but no trace dump.
+    expect(lines).toHaveLength(2);
     expect(lines[1]).toBe(
       '  tools/call greet {"who":"world"} -> "hi world" raw-request/0.0.0'
     );
     await server.close();
   });
 
-  it("truncates long inline input", async () => {
-    const server = buildServer();
+  it("truncates long inline input at debug level", async () => {
+    const server = buildServer({ logging: { level: "debug" } });
     await server
       .getHandler()(
         mcpRequest(
@@ -166,9 +184,7 @@ describe("requestLogger (via MCPServer.getHandler)", () => {
           { "mcp-name": "standup" }
         )
       );
-    expect(loggedLines()[1]).toBe(
-      '  prompts/get standup {"team":"core"} raw-request/0.0.0'
-    );
+    expect(loggedLines()[1]).toBe("  prompts/get standup raw-request/0.0.0");
     await server.close();
   });
 
@@ -216,8 +232,7 @@ describe("requestLogger (via MCPServer.getHandler)", () => {
         )
       );
     expect(loggedLines()[1]).toBe(
-      '  tools/call fail {"reason":"on purpose"} raw-request/0.0.0 ' +
-        "ERROR failed: on purpose"
+      "  tools/call fail raw-request/0.0.0 ERROR failed: on purpose"
     );
     await server.close();
   });
@@ -270,8 +285,8 @@ describe("requestLogger (via MCPServer.getHandler)", () => {
     await server.close();
   });
 
-  it("emits the full request/response dump at debug level", async () => {
-    const server = buildServer({ logging: { level: "debug" } });
+  it("emits the full request/response dump at trace level", async () => {
+    const server = buildServer({ logging: { level: "trace" } });
     await server
       .getHandler()(
         mcpRequest(
@@ -281,20 +296,56 @@ describe("requestLogger (via MCPServer.getHandler)", () => {
         )
       );
     const output = loggedLines().join("\n");
-    expect(output).toContain("[DEBUG] Request Details");
+    expect(output).toContain("[TRACE] Request Details");
     expect(output).toContain("Request Headers:");
     expect(output).toContain("Request Body:");
     expect(output).toContain("Response Body:");
-    // The dump carries the tool arguments (what v1's mid-tier args= showed).
     expect(output).toContain('"who": "dump"');
+    // Trace includes debug's inline echo too.
+    expect(output).toContain('  tools/call greet {"who":"dump"}');
+    await server.close();
+  });
+
+  it("redacts credential headers in the trace dump", async () => {
+    const server = buildServer({ logging: { level: "trace" } });
+    await server
+      .getHandler()(
+        mcpRequest(
+          "tools/call",
+          { name: "greet", arguments: { who: "auth" } },
+          { "mcp-name": "greet", authorization: "Bearer super-secret-token" }
+        )
+      );
+    const output = loggedLines().join("\n");
+    expect(output).toContain('"authorization": "[REDACTED]"');
+    expect(output).not.toContain("super-secret-token");
+    await server.close();
+  });
+
+  it("sanitizes control characters out of request-derived log text", async () => {
+    const server = buildServer();
+    await server
+      .getHandler()(
+        mcpRequest(
+          "tools/call",
+          { name: "fail", arguments: { reason: "line1\nFORGED 200 OK" } },
+          { "mcp-name": "fail" }
+        )
+      );
+    const lines = loggedLines();
+    // The injected newline must not produce a third log line.
+    expect(lines).toHaveLength(2);
+    expect(lines[1]).toBe(
+      "  tools/call fail raw-request/0.0.0 ERROR failed: line1 FORGED 200 OK"
+    );
     await server.close();
   });
 
   it("MCP_USE_LOG_LEVEL overrides the configured level", async () => {
-    vi.stubEnv("MCP_USE_LOG_LEVEL", "debug");
+    vi.stubEnv("MCP_USE_LOG_LEVEL", "trace");
     const server = buildServer();
     await server.getHandler()(mcpRequest("tools/list", {}));
-    expect(loggedLines().join("\n")).toContain("[DEBUG] Request Details");
+    expect(loggedLines().join("\n")).toContain("[TRACE] Request Details");
     await server.close();
   });
 
@@ -310,9 +361,7 @@ describe("requestLogger (via MCPServer.getHandler)", () => {
           { "mcp-name": "greet", host: "api.example.com" }
         )
       );
-    expect(loggedLines()[1]).toBe(
-      '  tools/call greet {"who":"hono"} -> "hi hono" raw-request/0.0.0'
-    );
+    expect(loggedLines()[1]).toBe("  tools/call greet raw-request/0.0.0");
     await server.close();
   });
 });

--- a/libraries/typescript/packages/server/tests/logging.test.ts
+++ b/libraries/typescript/packages/server/tests/logging.test.ts
@@ -1,0 +1,318 @@
+/**
+ * Request-logging tests: the compact two-line format (HTTP summary line plus
+ * indented MCP detail line), error surfacing, level handling, and noise
+ * skipping — driven through `MCPServer.getHandler()` with synthetic
+ * 2026-07-28 requests, capturing `console.log`.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+import { MCPServer } from "../src/index.js";
+import type { ServerConfig } from "../src/index.js";
+
+/** The per-request `_meta` envelope every 2026-07-28 request carries. */
+const MODERN_ENVELOPE = {
+  "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+  "io.modelcontextprotocol/clientInfo": {
+    name: "raw-request",
+    version: "0.0.0",
+  },
+  "io.modelcontextprotocol/clientCapabilities": {},
+};
+
+function buildServer(config: Partial<ServerConfig> = {}): MCPServer {
+  const server = new MCPServer({
+    name: "logging-test",
+    version: "1.0.0",
+    ...config,
+  });
+  server.tool(
+    { name: "greet", schema: z.object({ who: z.string() }) },
+    async ({ who }) => ({ content: [{ type: "text", text: `hi ${who}` }] })
+  );
+  server.tool(
+    { name: "fail", schema: z.object({ reason: z.string() }) },
+    async ({ reason }) => ({
+      content: [{ type: "text", text: `failed: ${reason}` }],
+      isError: true,
+    })
+  );
+  server.resource(
+    { name: "config", uri: "config://settings" },
+    async (uri) => ({
+      contents: [{ uri: uri.href, text: "{}" }],
+    })
+  );
+  server.prompt(
+    { name: "standup", schema: z.object({ team: z.string() }) },
+    async ({ team }) => ({
+      messages: [
+        { role: "user", content: { type: "text", text: `standup ${team}` } },
+      ],
+    })
+  );
+  return server;
+}
+
+/** Synthetic modern (2026-07-28) MCP request against a getHandler(). */
+function mcpRequest(
+  method: string,
+  params: Record<string, unknown>,
+  headers: Record<string, string> = {}
+): Request {
+  return new Request("http://localhost/mcp", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+      "mcp-protocol-version": "2026-07-28",
+      "mcp-method": method,
+      ...headers,
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method,
+      params: { ...params, _meta: MODERN_ENVELOPE },
+    }),
+  });
+}
+
+describe("requestLogger (via MCPServer.getHandler)", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // Force deterministic output: no ANSI escapes, no env-level override.
+    vi.stubEnv("NO_COLOR", "1");
+    vi.stubEnv("MCP_USE_LOG_LEVEL", "");
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    vi.unstubAllEnvs();
+  });
+
+  /** All captured console.log lines, flattened. */
+  function loggedLines(): string[] {
+    return (logSpy.mock.calls as unknown[][])
+      .map((call) => call.map(String).join(" "))
+      .flatMap((entry) => entry.split("\n"));
+  }
+
+  it("logs a two-line summary + detail for tools/call", async () => {
+    const server = buildServer();
+    const response = await server
+      .getHandler()(
+        mcpRequest(
+          "tools/call",
+          { name: "greet", arguments: { who: "world" } },
+          { "mcp-name": "greet" }
+        )
+      );
+    expect(response.status).toBe(200);
+
+    const lines = loggedLines();
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toMatch(/^\d{2}:\d{2}:\d{2} POST \/mcp 200 in \d+ms$/);
+    expect(lines[1]).toBe(
+      '  tools/call greet {"who":"world"} -> "hi world" raw-request/0.0.0'
+    );
+    await server.close();
+  });
+
+  it("truncates long inline input", async () => {
+    const server = buildServer();
+    await server
+      .getHandler()(
+        mcpRequest(
+          "tools/call",
+          { name: "greet", arguments: { who: "x".repeat(200) } },
+          { "mcp-name": "greet" }
+        )
+      );
+    const detail = loggedLines()[1] ?? "";
+    expect(detail).toContain('{"who":"xxx');
+    expect(detail).toContain("...");
+    // 80-char cap plus the ellipsis.
+    const inputSegment = detail.split(" ")[3] ?? "";
+    expect(inputSegment.length).toBeLessThanOrEqual(83);
+    await server.close();
+  });
+
+  it("logs the resource URI for resources/read", async () => {
+    const server = buildServer();
+    await server
+      .getHandler()(
+        mcpRequest(
+          "resources/read",
+          { uri: "config://settings" },
+          { "mcp-name": "config://settings" }
+        )
+      );
+    expect(loggedLines()[1]).toBe(
+      "  resources/read config://settings raw-request/0.0.0"
+    );
+    await server.close();
+  });
+
+  it("logs the prompt name for prompts/get", async () => {
+    const server = buildServer();
+    await server
+      .getHandler()(
+        mcpRequest(
+          "prompts/get",
+          { name: "standup", arguments: { team: "core" } },
+          { "mcp-name": "standup" }
+        )
+      );
+    expect(loggedLines()[1]).toBe(
+      '  prompts/get standup {"team":"core"} raw-request/0.0.0'
+    );
+    await server.close();
+  });
+
+  it("logs methods without a subject as the bare method name", async () => {
+    const server = buildServer();
+    await server.getHandler()(mcpRequest("tools/list", {}));
+    expect(loggedLines()[1]).toBe("  tools/list raw-request/0.0.0");
+    await server.close();
+  });
+
+  it("shows clientInfo as the initialize subject without repeating it", async () => {
+    const server = buildServer();
+    // Legacy handshake: initialize carries clientInfo in params, no envelope.
+    await server.getHandler()(
+      new Request("http://localhost/mcp", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: "2025-06-18",
+            capabilities: {},
+            clientInfo: { name: "legacy-client", version: "2.1.0" },
+          },
+        }),
+      })
+    );
+    expect(loggedLines()[1]).toBe("  initialize legacy-client/2.1.0");
+    await server.close();
+  });
+
+  it("appends ERROR with the tool's message for isError results", async () => {
+    const server = buildServer();
+    await server
+      .getHandler()(
+        mcpRequest(
+          "tools/call",
+          { name: "fail", arguments: { reason: "on purpose" } },
+          { "mcp-name": "fail" }
+        )
+      );
+    expect(loggedLines()[1]).toBe(
+      '  tools/call fail {"reason":"on purpose"} raw-request/0.0.0 ' +
+        "ERROR failed: on purpose"
+    );
+    await server.close();
+  });
+
+  it("appends ERROR with the JSON-RPC error message for protocol errors", async () => {
+    const server = buildServer();
+    await server
+      .getHandler()(
+        mcpRequest(
+          "tools/call",
+          { name: "no-such-tool", arguments: {} },
+          { "mcp-name": "no-such-tool" }
+        )
+      );
+    const detail = loggedLines()[1];
+    expect(detail).toContain("  tools/call no-such-tool");
+    expect(detail).toMatch(/ERROR .*no-such-tool/);
+    await server.close();
+  });
+
+  it("logs a single line for non-MCP requests", async () => {
+    const server = buildServer();
+    await server
+      .getHandler()(new Request("http://localhost/health", { method: "GET" }));
+    const lines = loggedLines();
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatch(/^\d{2}:\d{2}:\d{2} GET \/health 404 in \d+ms$/);
+    await server.close();
+  });
+
+  it("skips inspector shell and favicon noise", async () => {
+    const server = buildServer();
+    const handler = server.getHandler();
+    await handler(
+      new Request("http://localhost/mcp/inspector", { method: "GET" })
+    );
+    await handler(
+      new Request("http://localhost/favicon.ico", { method: "GET" })
+    );
+    expect(logSpy).not.toHaveBeenCalled();
+    await server.close();
+  });
+
+  it("logs nothing when logging is disabled", async () => {
+    const server = buildServer({ logging: { enabled: false } });
+    const response = await server
+      .getHandler()(mcpRequest("tools/list", {}));
+    expect(response.status).toBe(200);
+    expect(logSpy).not.toHaveBeenCalled();
+    await server.close();
+  });
+
+  it("emits the full request/response dump at debug level", async () => {
+    const server = buildServer({ logging: { level: "debug" } });
+    await server
+      .getHandler()(
+        mcpRequest(
+          "tools/call",
+          { name: "greet", arguments: { who: "dump" } },
+          { "mcp-name": "greet" }
+        )
+      );
+    const output = loggedLines().join("\n");
+    expect(output).toContain("[DEBUG] Request Details");
+    expect(output).toContain("Request Headers:");
+    expect(output).toContain("Request Body:");
+    expect(output).toContain("Response Body:");
+    // The dump carries the tool arguments (what v1's mid-tier args= showed).
+    expect(output).toContain('"who": "dump"');
+    await server.close();
+  });
+
+  it("MCP_USE_LOG_LEVEL overrides the configured level", async () => {
+    vi.stubEnv("MCP_USE_LOG_LEVEL", "debug");
+    const server = buildServer();
+    await server.getHandler()(mcpRequest("tools/list", {}));
+    expect(loggedLines().join("\n")).toContain("[DEBUG] Request Details");
+    await server.close();
+  });
+
+  it("reads the pre-parsed body on the Host-validated path", async () => {
+    // allowedHosts mounts via createMcpHonoApp, whose JSON middleware stashes
+    // parsedBody in context vars — the logger must pick it up from there.
+    const server = buildServer({ allowedHosts: ["api.example.com"] });
+    await server
+      .getHandler()(
+        mcpRequest(
+          "tools/call",
+          { name: "greet", arguments: { who: "hono" } },
+          { "mcp-name": "greet", host: "api.example.com" }
+        )
+      );
+    expect(loggedLines()[1]).toBe(
+      '  tools/call greet {"who":"hono"} -> "hi hono" raw-request/0.0.0'
+    );
+    await server.close();
+  });
+});

--- a/libraries/typescript/packages/server/tests/logging.test.ts
+++ b/libraries/typescript/packages/server/tests/logging.test.ts
@@ -135,7 +135,7 @@ describe("requestLogger (via MCPServer.getHandler)", () => {
     expect(detail).toContain('{"who":"xxx');
     expect(detail).toContain("...");
     // 80-char cap plus the ellipsis.
-    const inputSegment = detail.split(" ")[3] ?? "";
+    const inputSegment = detail.split(" ")[4] ?? "";
     expect(inputSegment.length).toBeLessThanOrEqual(83);
     await server.close();
   });


### PR DESCRIPTION
## Summary

- Adds HTTP/MCP request logging to `@mcp-use/server`: one summary line per request plus an indented detail line with the MCP method, subject (tool name / resource URI / prompt name), compact truncated input/output, and the calling client from the 2026-07-28 `_meta` envelope:

  ```
  12:45:01 POST /mcp 200 in 12ms
    tools/call greet {"who":"world"} -> "hi world" cursor/1.2.0
  ```

- Typesafe by construction: the detail formatters are an exhaustive table over the SDK's `RequestMethod` union, so a new protocol method in a future SDK release is a compile error rather than a silent fallback (the inverse of v1's untyped if/else chain). Bodies are narrowed with `isJSONRPCRequest` and read from `c.var.parsedBody` when available (no re-parsing).
- Two levels (`info` default, `debug` = full request/response dump; `MCP_USE_LOG_LEVEL` overrides, `trace` accepted as a v1 alias). Colors via a tiny internal ANSI helper honoring `NO_COLOR` and non-TTY/edge runtimes — no chalk dependency. Tool errors and JSON-RPC errors append `ERROR <message>` to the detail line; long-lived `subscriptions/listen` streams are never awaited for an outcome.
- Config: `logging?: { enabled?: boolean; level?: "info" | "debug" }` on `ServerConfig` (default on), and `inspector` aligned to the same `{ enabled }` options shape (`inspector: { enabled: false }` replaces `inspector: false`). `requestLogger` + types are exported for hand-composed `mountMcp` apps.

## Test plan

- [x] `pnpm run test:run` in `packages/server` — typecheck + 108 tests pass (14 new logging tests: two-line format, subjects per method, inline input/output + truncation, error suffixes, noise skipping, `enabled: false`, debug dump, env override, pre-parsed-body path)
- [x] Live smoke against `listen()` verifying the output format above

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds compact, typed request logging to `@mcp-use/server` v2: one HTTP summary line plus an MCP detail line. Adds `info`/`debug`/`trace` levels (default is payload‑free), redacts credentials in trace dumps, sanitizes control characters, and aligns `inspector` to an object‑only `{ enabled }` options shape.

- **New Features**
  - Two-line logs per request; detail shows MCP method, subject, and client from `_meta`. Debug echoes truncated tool/prompt input and tool output; trace adds full request/response dumps with credential‑header redaction.
  - Exhaustive, typesafe formatters over SDK `RequestMethod`; strips control chars to prevent forged lines; reads pre‑parsed bodies when available; skips inspector and favicon noise; ANSI colors honor `NO_COLOR` and non‑TTY.
  - Level resolved per request (`MCP_USE_LOG_LEVEL` overrides). `MCPServer` mounts logging by default; exports `requestLogger`, `LoggingOptions`, `LogLevel`.

- **Migration**
  - Replace `inspector: false` with `inspector: { enabled: false }` (object‑only, no boolean union).
  - Logging is on by default; disable with `logging: { enabled: false }`, set `logging: { level: "debug" | "trace" }`, or use `MCP_USE_LOG_LEVEL`.

<sup>Written for commit cfcb7b067142b40fa522676cc17f409f6a56a434. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

