### PR TITLE
fix: JSON Schema dialect compat between v1-era servers and v2 clients (#1839)

### DIFF
--- a/libraries/typescript/.changeset/dialect-json-schema-validator.md
+++ b/libraries/typescript/.changeset/dialect-json-schema-validator.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/client": patch
+---
+
+Default `jsonSchemaValidator` (`DialectJsonSchemaValidator`) now accepts JSON Schema draft-04/-07/2019-09 dialects emitted by v1-era servers, fixing `InvalidParams` on `callTool` for tools with `outputSchema` (issue #1839).

--- a/libraries/typescript/.changeset/strip-tools-list-schema-dialect.md
+++ b/libraries/typescript/.changeset/strip-tools-list-schema-dialect.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Strip draft-07 `$schema` from tool `inputSchema` and `outputSchema` in `tools/list` responses. The v1 SDK stamps `http://json-schema.org/draft-07/schema#`, which v2 MCP clients reject when compiling output schemas; omitting `$schema` is accepted by both v1 and v2 clients (issue #1839).

--- a/libraries/typescript/packages/client/src/connectors/base.ts
+++ b/libraries/typescript/packages/client/src/connectors/base.ts
@@ -43,6 +43,11 @@ export type NotificationHandler = (
 export interface ConnectorInitOptions {
   /**
    * Options forwarded to the underlying MCP `Client` instance.
+   *
+   * By default, HTTP connectors use `DialectJsonSchemaValidator` to support
+   * common `$schema` dialects (draft-04, draft-07, 2019-09, 2020-12) for
+   * cross-version compatibility with v1-era servers. Override with
+   * `clientOptions.jsonSchemaValidator` if stricter validation is needed.
    */
   clientOptions?: ClientOptions;
   /**

--- a/libraries/typescript/packages/client/src/connectors/base.ts
+++ b/libraries/typescript/packages/client/src/connectors/base.ts
@@ -44,9 +44,9 @@ export interface ConnectorInitOptions {
   /**
    * Options forwarded to the underlying MCP `Client` instance.
    *
-   * By default, HTTP connectors use `DialectJsonSchemaValidator` to support
-   * common `$schema` dialects (draft-04, draft-07, 2019-09, 2020-12) for
-   * cross-version compatibility with v1-era servers. Override with
+   * By default, all connectors (HTTP and stdio) use `DialectJsonSchemaValidator`
+   * to support common `$schema` dialects (draft-04, draft-07, 2019-09, 2020-12)
+   * for cross-version compatibility with v1-era servers. Override with
    * `clientOptions.jsonSchemaValidator` if stricter validation is needed.
    */
   clientOptions?: ClientOptions;

--- a/libraries/typescript/packages/client/src/connectors/http.ts
+++ b/libraries/typescript/packages/client/src/connectors/http.ts
@@ -31,6 +31,7 @@ function detectUnauthorized(err: unknown, depth = 0): boolean {
   return false;
 }
 import { SseConnectionManager } from "../task_managers/sse.js";
+import { DialectJsonSchemaValidator } from "../validators/dialect-json-schema-validator.js";
 import type { ConnectorInitOptions } from "./base.js";
 import { BaseConnector } from "./base.js";
 
@@ -156,6 +157,9 @@ export class HttpConnector extends BaseConnector {
   private buildClientOptions(): ClientOptions {
     return {
       ...(this.opts.clientOptions || {}),
+      jsonSchemaValidator:
+        this.opts.clientOptions?.jsonSchemaValidator ??
+        new DialectJsonSchemaValidator(),
       versionNegotiation: {
         // Allow a caller-supplied versionNegotiation in clientOptions to win.
         mode: this.protocolNegotiation,

--- a/libraries/typescript/packages/client/src/connectors/stdio.ts
+++ b/libraries/typescript/packages/client/src/connectors/stdio.ts
@@ -8,6 +8,7 @@ import type { ConnectorInitOptions } from "./base.js";
 
 import { logger } from "../logging.js";
 import { StdioConnectionManager } from "../task_managers/stdio.js";
+import { DialectJsonSchemaValidator } from "../validators/dialect-json-schema-validator.js";
 import { BaseConnector } from "./base.js";
 import type { ClientInfo } from "./http.js";
 
@@ -102,6 +103,9 @@ export class StdioConnector extends BaseConnector {
       // Always advertise roots capability - server may query roots/list even if client has no roots
       const clientOptions = {
         ...(this.opts.clientOptions || {}),
+        jsonSchemaValidator:
+          this.opts.clientOptions?.jsonSchemaValidator ??
+          new DialectJsonSchemaValidator(),
         versionNegotiation: {
           mode: this.protocolNegotiation,
           ...(this.opts.clientOptions?.versionNegotiation ?? {}),

--- a/libraries/typescript/packages/client/src/index.ts
+++ b/libraries/typescript/packages/client/src/index.ts
@@ -16,6 +16,9 @@ export * from "./connectors/base.js";
 export * from "./connectors/http.js";
 export * from "./connectors/stdio.js";
 
+// JSON Schema validation
+export * from "./validators/dialect-json-schema-validator.js";
+
 // Browser client, code mode, code executors, schema conversion
 export * from "./client/browser.js";
 export * from "./client/connectors/codeMode.js";

--- a/libraries/typescript/packages/client/src/validators/dialect-json-schema-validator.ts
+++ b/libraries/typescript/packages/client/src/validators/dialect-json-schema-validator.ts
@@ -1,0 +1,53 @@
+import type {
+  JsonSchemaType,
+  jsonSchemaValidator,
+} from "@modelcontextprotocol/client";
+import {
+  CfWorkerJsonSchemaValidator,
+  type CfWorkerSchemaDraft,
+} from "@modelcontextprotocol/client/validators/cf-worker";
+
+const DRAFT_04_URI = "http://json-schema.org/draft-04/schema";
+const DRAFT_07_URI = "http://json-schema.org/draft-07/schema";
+const DRAFT_2019_09_URIS = new Set([
+  "https://json-schema.org/draft/2019-09/schema",
+  "http://json-schema.org/draft/2019-09/schema",
+]);
+const DRAFT_2020_12_URIS = new Set([
+  "https://json-schema.org/draft/2020-12/schema",
+  "http://json-schema.org/draft/2020-12/schema",
+]);
+
+function resolveDraft(schema: JsonSchemaType): CfWorkerSchemaDraft | undefined {
+  if (!("$schema" in schema) || typeof schema.$schema !== "string") {
+    return "2020-12";
+  }
+
+  const normalized = schema.$schema.replace(/#$/, "");
+
+  if (normalized === DRAFT_04_URI) return "4";
+  if (normalized === DRAFT_07_URI) return "7";
+  if (DRAFT_2019_09_URIS.has(normalized)) return "2019-09";
+  if (DRAFT_2020_12_URIS.has(normalized)) return "2020-12";
+
+  return undefined;
+}
+
+/**
+ * JSON Schema validator that maps common `$schema` dialect URIs to the
+ * matching `@cfworker/json-schema` draft. The v2 SDK default rejects any
+ * schema not declaring JSON Schema 2020-12 as an "unsupported dialect", which
+ * breaks `tools/call` against v1-era servers that emit draft-04/-07/2019-09
+ * `$schema` on tool `outputSchema` (mcp-use#1839). Unknown `$schema` URIs
+ * still fail fast via the SDK's strict default validator.
+ */
+export class DialectJsonSchemaValidator implements jsonSchemaValidator {
+  getValidator<T>(schema: JsonSchemaType) {
+    const draft = resolveDraft(schema);
+    const delegate =
+      draft !== undefined
+        ? new CfWorkerJsonSchemaValidator({ draft })
+        : new CfWorkerJsonSchemaValidator();
+    return delegate.getValidator<T>(schema);
+  }
+}

--- a/libraries/typescript/packages/client/src/validators/dialect-json-schema-validator.ts
+++ b/libraries/typescript/packages/client/src/validators/dialect-json-schema-validator.ts
@@ -8,7 +8,10 @@ import {
 } from "@modelcontextprotocol/client/validators/cf-worker";
 
 const DRAFT_04_URI = "http://json-schema.org/draft-04/schema";
-const DRAFT_07_URI = "http://json-schema.org/draft-07/schema";
+const DRAFT_07_URIS = new Set([
+  "http://json-schema.org/draft-07/schema",
+  "https://json-schema.org/draft-07/schema",
+]);
 const DRAFT_2019_09_URIS = new Set([
   "https://json-schema.org/draft/2019-09/schema",
   "http://json-schema.org/draft/2019-09/schema",
@@ -26,7 +29,7 @@ function resolveDraft(schema: JsonSchemaType): CfWorkerSchemaDraft | undefined {
   const normalized = schema.$schema.replace(/#$/, "");
 
   if (normalized === DRAFT_04_URI) return "4";
-  if (normalized === DRAFT_07_URI) return "7";
+  if (DRAFT_07_URIS.has(normalized)) return "7";
   if (DRAFT_2019_09_URIS.has(normalized)) return "2019-09";
   if (DRAFT_2020_12_URIS.has(normalized)) return "2020-12";
 

--- a/libraries/typescript/packages/client/tests/unit/validators/dialect-json-schema-validator.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/validators/dialect-json-schema-validator.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import type { JsonSchemaType } from "@modelcontextprotocol/client";
+import { DialectJsonSchemaValidator } from "../../../src/validators/dialect-json-schema-validator.js";
+
+describe("DialectJsonSchemaValidator", () => {
+  const validator = new DialectJsonSchemaValidator();
+
+  it("accepts draft-07 schemas and validates conforming data", () => {
+    const schema: JsonSchemaType = {
+      type: "object",
+      properties: { name: { type: "string" } },
+      required: ["name"],
+      $schema: "http://json-schema.org/draft-07/schema#",
+    };
+
+    const validate = validator.getValidator<{ name: string }>(schema);
+
+    const valid = validate({ name: "alice" });
+    expect(valid.valid).toBe(true);
+    if (valid.valid) {
+      expect(valid.data).toEqual({ name: "alice" });
+      expect(valid.errorMessage).toBeUndefined();
+    }
+
+    const invalid = validate({});
+    expect(invalid.valid).toBe(false);
+    if (!invalid.valid) {
+      expect(invalid.data).toBeUndefined();
+      expect(invalid.errorMessage).toBeTruthy();
+    }
+  });
+
+  it("accepts explicit 2020-12 schemas", () => {
+    const schema: JsonSchemaType = {
+      type: "object",
+      properties: { count: { type: "number" } },
+      required: ["count"],
+      $schema: "https://json-schema.org/draft/2020-12/schema",
+    };
+
+    const validate = validator.getValidator<{ count: number }>(schema);
+    expect(validate({ count: 1 }).valid).toBe(true);
+    expect(validate({ count: "nope" }).valid).toBe(false);
+  });
+
+  it("defaults schemas without $schema to 2020-12", () => {
+    const schema: JsonSchemaType = {
+      type: "object",
+      properties: { ok: { type: "boolean" } },
+      required: ["ok"],
+    };
+
+    const validate = validator.getValidator<{ ok: boolean }>(schema);
+    expect(validate({ ok: true }).valid).toBe(true);
+    expect(validate({ ok: "yes" }).valid).toBe(false);
+  });
+
+  it("accepts draft-04 schemas", () => {
+    const schema: JsonSchemaType = {
+      type: "object",
+      properties: { id: { type: "integer" } },
+      required: ["id"],
+      $schema: "http://json-schema.org/draft-04/schema#",
+    };
+
+    const validate = validator.getValidator<{ id: number }>(schema);
+    expect(validate({ id: 1 }).valid).toBe(true);
+    expect(validate({ id: "1" }).valid).toBe(false);
+  });
+
+  it("accepts 2019-09 schemas", () => {
+    const schema: JsonSchemaType = {
+      type: "object",
+      properties: { tag: { type: "string" } },
+      required: ["tag"],
+      $schema: "https://json-schema.org/draft/2019-09/schema#",
+    };
+
+    const validate = validator.getValidator<{ tag: string }>(schema);
+    expect(validate({ tag: "v1" }).valid).toBe(true);
+    expect(validate({ tag: 1 }).valid).toBe(false);
+  });
+
+  it("throws for unknown $schema dialects", () => {
+    const schema: JsonSchemaType = {
+      type: "object",
+      properties: { x: { type: "string" } },
+      $schema: "https://example.com/my-schema",
+    };
+
+    expect(() => validator.getValidator(schema)).toThrow(/unsupported dialect/i);
+  });
+
+  it("validates v1-era server outputSchema shapes", () => {
+    const schema: JsonSchemaType = {
+      type: "object",
+      properties: { text: { type: "string" } },
+      required: ["text"],
+      $schema: "http://json-schema.org/draft-07/schema#",
+      additionalProperties: false,
+    };
+
+    const validate = validator.getValidator<{ text: string }>(schema);
+    expect(validate({ text: "hi" }).valid).toBe(true);
+    expect(validate({}).valid).toBe(false);
+  });
+});

--- a/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
@@ -124,6 +124,51 @@ function isSafePropertyKey(key: string): boolean {
 }
 
 /**
+ * v1 SDK Zod→JSON Schema conversion stamps draft-07 `$schema`; v2 MCP clients
+ * reject non-2020-12 dialects. Omitting `$schema` is accepted by both (issue #1839).
+ */
+function stripSchemaDialect(
+  schema: Record<string, unknown>
+): Record<string, unknown> {
+  const { $schema, ...rest } = schema;
+  return rest;
+}
+
+function stripToolsListSchemaDialects(tools: unknown[]): unknown[] {
+  return tools.map((tool) => {
+    if (!tool || typeof tool !== "object") return tool;
+
+    const record = tool as Record<string, unknown>;
+    const inputSchema = record.inputSchema;
+    const outputSchema = record.outputSchema;
+
+    return {
+      ...record,
+      ...(inputSchema &&
+      typeof inputSchema === "object" &&
+      inputSchema !== null &&
+      "$schema" in inputSchema
+        ? {
+            inputSchema: stripSchemaDialect(
+              inputSchema as Record<string, unknown>
+            ),
+          }
+        : {}),
+      ...(outputSchema &&
+      typeof outputSchema === "object" &&
+      outputSchema !== null &&
+      "$schema" in outputSchema
+        ? {
+            outputSchema: stripSchemaDialect(
+              outputSchema as Record<string, unknown>
+            ),
+          }
+        : {}),
+    };
+  });
+}
+
+/**
  * Auto-selects a favicon from the icons array based on priority.
  *
  * Priority order:
@@ -3363,7 +3408,11 @@ class MCPServerClass<HasOAuth extends boolean = false> {
         };
         const innerFn = async () => {
           const result = await original(req, extra);
-          return result[resultKey] ?? result;
+          let items = result[resultKey] ?? result;
+          if (method === "tools/list" && Array.isArray(items)) {
+            items = stripToolsListSchemaDialects(items);
+          }
+          return items;
         };
         const filtered = await composeMiddleware(
           mcpMiddlewares(),

--- a/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/mcp-server.ts
@@ -134,6 +134,19 @@ function stripSchemaDialect(
   return rest;
 }
 
+/**
+ * Removes `$schema` fields from tool input and output schemas in `tools/list`
+ * responses for cross-version compatibility.
+ *
+ * The v2 SDK's default validator rejects schemas with older `$schema` dialects
+ * (draft-04, draft-07) that v1-era servers may emit. By omitting `$schema`,
+ * schemas validate against the client's default dialect, allowing v2 clients
+ * to consume tools from v1 servers without strict dialect enforcement.
+ *
+ * Clients using `DialectJsonSchemaValidator` (HTTP connector default) already
+ * accept common dialects, but this stripping ensures broader client
+ * compatibility where the validator may be stricter.
+ */
 function stripToolsListSchemaDialects(tools: unknown[]): unknown[] {
   return tools.map((tool) => {
     if (!tool || typeof tool !== "object") return tool;

--- a/libraries/typescript/packages/mcp-use/tests/unit/server/tools-list-schema-dialect.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/server/tools-list-schema-dialect.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Regression test for issue #1839: tools/list must not emit draft-07 $schema on
+ * tool input/output schemas (v2 MCP clients reject non-2020-12 dialects).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { z } from "zod";
+import { MCPServer } from "../../../src/server/index.js";
+import { object, text } from "../../../src/server/utils/response-helpers.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+const TEST_PORT = 3100;
+const SERVER_URL = `http://localhost:${TEST_PORT}/mcp`;
+
+describe("tools/list schema dialect", () => {
+  let server: MCPServer;
+  let client: Client;
+  let transport: StreamableHTTPClientTransport;
+
+  beforeAll(async () => {
+    server = new MCPServer({
+      name: "tools-list-schema-dialect-server",
+      version: "1.0.0",
+    });
+
+    server.tool(
+      {
+        name: "weather",
+        description: "Get weather for a city",
+        schema: z.object({
+          city: z.string().describe("City name"),
+        }),
+        outputSchema: z.object({
+          city: z.string(),
+          tempC: z.number(),
+        }),
+      },
+      async ({ city }) => object({ city, tempC: 22 })
+    );
+
+    server.tool(
+      {
+        name: "echo",
+        description: "Echo input without structured output",
+        schema: z.object({
+          message: z.string(),
+        }),
+      },
+      async ({ message }) => text(message)
+    );
+
+    await server.listen(TEST_PORT);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    transport = new StreamableHTTPClientTransport(new URL(SERVER_URL));
+    client = new Client({ name: "schema-dialect-test-client", version: "1.0.0" }, {});
+    await client.connect(transport);
+  });
+
+  afterAll(async () => {
+    await client.close();
+    await (server as any).close?.();
+  });
+
+  it("strips $schema from inputSchema and outputSchema on tools with outputSchema", async () => {
+    const result = await client.listTools();
+    const weather = result.tools.find((tool) => tool.name === "weather");
+    expect(weather).toBeDefined();
+
+    expect(weather!.inputSchema).toBeDefined();
+    expect(weather!.inputSchema).not.toHaveProperty("$schema");
+    expect(weather!.inputSchema).toMatchObject({
+      type: "object",
+      properties: {
+        city: expect.objectContaining({ type: "string" }),
+      },
+      required: ["city"],
+    });
+
+    expect(weather!.outputSchema).toBeDefined();
+    expect(weather!.outputSchema).not.toHaveProperty("$schema");
+    expect(weather!.outputSchema).toMatchObject({
+      type: "object",
+      properties: {
+        city: expect.objectContaining({ type: "string" }),
+        tempC: expect.objectContaining({ type: "number" }),
+      },
+      required: ["city", "tempC"],
+    });
+  });
+
+  it("lists tools without outputSchema and strips $schema from inputSchema only", async () => {
+    const result = await client.listTools();
+    const echo = result.tools.find((tool) => tool.name === "echo");
+    expect(echo).toBeDefined();
+    expect(echo!.outputSchema).toBeUndefined();
+
+    expect(echo!.inputSchema).toBeDefined();
+    expect(echo!.inputSchema).not.toHaveProperty("$schema");
+    expect(echo!.inputSchema).toMatchObject({
+      type: "object",
+      properties: {
+        message: expect.objectContaining({ type: "string" }),
+      },
+      required: ["message"],
+    });
+  });
+});


### PR DESCRIPTION
Fixes #1839.

## Summary

A default-configured v2 MCP client rejects every tool with an `outputSchema` on any server built with the v1 TypeScript SDK: the v1 SDK's `tools/list` handler stamps Zod-derived schemas with `"$schema": "http://json-schema.org/draft-07/schema#"`, and the v2 SDK's default validators (Ajv on Node, CfWorker in browser) hard-fail on any dialect other than 2020-12, surfacing as `ProtocolError(InvalidParams)` on `callTool` before the request is sent. This is not mcp-use-specific — a stock `@modelcontextprotocol/sdk@1.29.0` server fails identically against a stock `@modelcontextprotocol/client@2.0.0-beta.2`.

This PR fixes both directions:

- **`@mcp-use/client`**: new `DialectJsonSchemaValidator` wired as the default `jsonSchemaValidator` in the HTTP and stdio connectors (caller-supplied validator still wins). It maps draft-04/-07/2019-09 `$schema` URIs to the matching `@cfworker/json-schema` draft; missing `$schema` is treated as 2020-12 per spec; unknown dialects still fail fast via the SDK's strict default. This un-breaks the entire installed base of v1-era servers, ours and third-party.
- **`mcp-use` (server)**: the existing `tools/list` middleware wrapper now strips the root-level `$schema` from tool `inputSchema`/`outputSchema`. Omitting `$schema` is accepted by both v1 clients (Ajv with `validateSchema: false`) and v2 clients (treated as 2020-12). Backport candidate for canary.

## Validation

- Unit: client 185/185 passed (7 new validator tests); mcp-use 234 passed / 2 skipped (new `tools/list` regression test over real Streamable HTTP).
- E2E matrix (real wire traffic):

| Server | Client | Result |
|---|---|---|
| stock v1 SDK 1.29.0 | stock v2 (defaults) | fails, `InvalidParams` (baseline) |
| published `mcp-use@1.34.2` (current deployments) | stock v2 (defaults) | fails, `InvalidParams` (baseline) |
| published `mcp-use@1.34.2` | patched `@mcp-use/client` | succeeds |
| stock v1 SDK 1.29.0 | patched `@mcp-use/client` | succeeds |
| patched `mcp-use` server | stock v2 (defaults) | succeeds, no `$schema` on wire |

## Notes

- Upstream: no existing issue covers the cross-version break (typescript-sdk#2084 tracks the server-emission half only); an upstream issue draft was prepared separately.
- Changesets included for both packages (patch).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes JSON Schema dialect incompatibility between v1-era servers and v2 clients, so tools with `outputSchema` no longer fail with InvalidParams. Adds a default validator in the client and strips `$schema` in server tool listings to restore cross-version compatibility (fixes #1839).

- **Bug Fixes**
  - Client (`@mcp-use/client`): set `DialectJsonSchemaValidator` as the default in all connectors (HTTP and stdio), mapping draft-04/-07/2019-09 `$schema` URIs (http and https) to the matching `@cfworker/json-schema` draft; unknown dialects still fail fast.
  - Server (`mcp-use`): strip root `$schema` from tool `inputSchema`/`outputSchema` in `tools/list` responses so both v1 and v2 clients accept the schemas.

<sup>Written for commit 78ad3bd55bc0c2456a3f55a1a714d19e4386a24e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

