### PR TITLE
fix(auth): surface OAuth resource mismatch instead of silent auth loop (MCP-2678)

### DIFF
--- a/libraries/typescript/.changeset/surface-oauth-resource-mismatch.md
+++ b/libraries/typescript/.changeset/surface-oauth-resource-mismatch.md
@@ -1,0 +1,12 @@
+---
+"mcp-use": patch
+---
+
+Fix the silent OAuth authentication loop on resource mismatch (MCP-2678).
+
+When MCP traffic is tunneled through a gateway/inspector proxy, the OAuth proxy rewrites the protected-resource-metadata `resource` field to the connection (proxy) URL so transport-anchored auth runs validate. Manual `authenticate()` runs validate against the real server URL instead, so the SDK's strict check threw `Protected resource <proxy> does not match expected <server> (or origin)` — and `useMcp` swallowed the throw as the expected popup handoff, cycling `pending_auth` → `authenticating` forever without surfacing an error (seen connecting to `https://www.cubic.dev/api/mcp` and `https://mcp.predictleads.com/`).
+
+Two fixes:
+
+- `BrowserOAuthClientProvider` now implements the SDK's `validateResourceURL` hook: it accepts resources valid for either the requested server URL or the proxy connection URL, and in the rewrite case returns the real upstream resource (from the proxy's `_original_resource`, falling back to the server URL) so the authorization request carries the resource the OAuth server actually protects.
+- `useMcp.authenticate()` no longer treats every `auth()` throw as a popup/redirect handoff: when `auth()` throws without opening a popup or preparing an authorization URL, the connection now transitions to `failed` with the error message, so UIs render the failure instead of hanging.

--- a/libraries/typescript/packages/mcp-use/src/auth/browser-provider.ts
+++ b/libraries/typescript/packages/mcp-use/src/auth/browser-provider.ts
@@ -1,5 +1,9 @@
 // browser-provider.ts
 import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
+import {
+  checkResourceAllowed,
+  resourceUrlFromServerUrl,
+} from "@modelcontextprotocol/sdk/shared/auth-utils.js";
 import type {
   OAuthClientInformation,
   OAuthClientMetadata,
@@ -389,6 +393,61 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
     scope: "all" | "client" | "tokens" | "verifier"
   ): Promise<void> {
     return this.session.invalidateCredentials(scope);
+  }
+
+  /**
+   * SDK resource-validation hook (replaces the strict check in the SDK's
+   * `selectResourceURL`).
+   *
+   * When MCP traffic is tunneled through a gateway/inspector proxy, the OAuth
+   * proxy rewrites the protected-resource-metadata `resource` field to the
+   * connection (proxy) URL so that transport-anchored auth runs validate. But
+   * manual auth runs (`auth({ serverUrl: <real MCP URL> })`) validate against
+   * the real server URL, and the rewritten resource then fails the SDK's
+   * strict check with "Protected resource ... does not match expected ...".
+   *
+   * Accept both anchors: the requested server URL (SDK default behavior) and
+   * the proxy connection URL (the rewrite case). In the rewrite case, return
+   * the real upstream resource — the proxy stashes it in `_original_resource`
+   * (cached as `_lastOriginalResource` by {@link getProxyFetch}) — so the
+   * authorization request carries the resource the OAuth server actually
+   * protects, not the proxy URL.
+   */
+  async validateResourceURL(
+    serverUrl: string | URL,
+    resource?: string
+  ): Promise<URL | undefined> {
+    // Mirror SDK behavior: no resource in metadata -> omit the resource param.
+    if (!resource) return undefined;
+
+    const requestedResource = resourceUrlFromServerUrl(serverUrl);
+    if (
+      checkResourceAllowed({
+        requestedResource,
+        configuredResource: resource,
+      })
+    ) {
+      return new URL(resource);
+    }
+
+    // OAuth-proxy rewrite case: the resource is valid for the MCP connection
+    // (proxy) URL — exactly the check the SDK would have run had this auth
+    // pass been anchored on the transport URL.
+    if (
+      this.connectionUrl &&
+      checkResourceAllowed({
+        requestedResource: resourceUrlFromServerUrl(this.connectionUrl),
+        configuredResource: resource,
+      })
+    ) {
+      return resourceUrlFromServerUrl(
+        this._lastOriginalResource ?? this.serverUrl
+      );
+    }
+
+    throw new Error(
+      `Protected resource ${resource} does not match expected ${requestedResource} (or origin)`
+    );
   }
 
   /**

--- a/libraries/typescript/packages/mcp-use/src/react/useMcp.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/useMcp.ts
@@ -1620,6 +1620,7 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
         const parsedUrl = new URL(url);
         const baseUrl =
           parsedUrl.origin + parsedUrl.pathname.replace(/\/+$/, "");
+        let authFlowError: Error | null = null;
         try {
           await auth(freshAuthProvider, {
             serverUrl: baseUrl,
@@ -1627,17 +1628,33 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
           });
           addLog("info", "OAuth flow completed (tokens obtained)");
         } catch (err: unknown) {
-          // This is expected when auth opens popup/redirect - the flow continues there
+          // May be the expected popup/redirect handoff (flow continues in the
+          // popup) — or a real discovery/validation failure. Disambiguated
+          // below via the captured popup handle and the stored auth URL.
+          authFlowError = err instanceof Error ? err : new Error(String(err));
           addLog(
             "info",
             "OAuth flow initiated (popup/redirect):",
-            err instanceof Error ? err.message : "Redirecting..."
+            authFlowError.message
           );
         }
 
         // Update authUrl with the new URL from the fresh provider
         // This is critical for the fallback link when popup is blocked
         const newAuthUrl = freshAuthProvider.getLastAttemptedAuthUrl?.();
+
+        // auth() threw without opening a popup or preparing an authorization
+        // URL (clearStorage() above wiped any stale one): this is a real
+        // failure (e.g. OAuth resource mismatch), not a popup handoff.
+        // Surface it instead of waiting for a popup that will never report —
+        // that wait silently loops pending_auth -> authenticating forever.
+        if (authFlowError && !capturedPopup && !newAuthUrl) {
+          failConnection(
+            `Authentication failed: ${authFlowError.message}`,
+            authFlowError
+          );
+          return;
+        }
         if (newAuthUrl) {
           setAuthUrl(newAuthUrl);
           addLog("info", "Updated auth URL for fallback:", newAuthUrl);

--- a/libraries/typescript/packages/mcp-use/tests/unit/auth/browser-provider-resource-validation.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/auth/browser-provider-resource-validation.test.ts
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+
+/**
+ * Tests for `BrowserOAuthClientProvider.validateResourceURL` — the SDK
+ * resource-validation hook (MCP-2678).
+ *
+ * When MCP traffic goes through a gateway/inspector proxy, the OAuth proxy
+ * rewrites the protected-resource-metadata `resource` field to the connection
+ * (proxy) URL. Manual auth runs validate against the REAL server URL, so the
+ * SDK's strict check threw "Protected resource <proxy> does not match
+ * expected <server> (or origin)" and the auth flow silently looped. The
+ * provider hook must accept both anchors and return the real resource.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BrowserOAuthClientProvider } from "../../../src/auth/browser-provider.js";
+
+const SERVER_URL = "https://www.cubic.dev/api/mcp";
+const CONNECTION_URL = "https://inspector.manufact.com/inspector/api/proxy";
+const PROXY_URL = "https://inspector.manufact.com/inspector/api/oauth";
+
+function makeProvider(options: Record<string, unknown> = {}) {
+  return new BrowserOAuthClientProvider(SERVER_URL, {
+    callbackUrl: "https://app.example.com/oauth/callback",
+    ...options,
+  });
+}
+
+describe("BrowserOAuthClientProvider.validateResourceURL", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("returns undefined when metadata has no resource (mirrors SDK)", async () => {
+    const provider = makeProvider();
+    await expect(
+      provider.validateResourceURL(SERVER_URL, undefined)
+    ).resolves.toBeUndefined();
+  });
+
+  it("returns the resource when it matches the requested server URL exactly", async () => {
+    const provider = makeProvider();
+    const result = await provider.validateResourceURL(SERVER_URL, SERVER_URL);
+    expect(result?.toString()).toBe(SERVER_URL);
+  });
+
+  it("returns the resource when it is a path prefix of the requested server URL", async () => {
+    const provider = makeProvider();
+    const result = await provider.validateResourceURL(
+      SERVER_URL,
+      "https://www.cubic.dev/api"
+    );
+    expect(result?.toString()).toBe("https://www.cubic.dev/api");
+  });
+
+  it("accepts a resource rewritten to the connection URL and returns the server resource", async () => {
+    // The OAuth proxy rewrote PRM `resource` -> connection URL. Validation
+    // against the real server URL must still pass, and the resource used in
+    // the authorization request must be the real one, not the proxy URL.
+    const provider = makeProvider({ connectionUrl: CONNECTION_URL });
+    const result = await provider.validateResourceURL(
+      SERVER_URL,
+      CONNECTION_URL
+    );
+    expect(result?.toString()).toBe(SERVER_URL);
+  });
+
+  it("handles root-path server URLs in the rewrite case (e.g. predictleads)", async () => {
+    const rootServerUrl = "https://mcp.predictleads.com/";
+    const provider = new BrowserOAuthClientProvider(rootServerUrl, {
+      callbackUrl: "https://app.example.com/oauth/callback",
+      connectionUrl: CONNECTION_URL,
+    });
+    const result = await provider.validateResourceURL(
+      rootServerUrl,
+      CONNECTION_URL
+    );
+    expect(result?.toString()).toBe(rootServerUrl);
+  });
+
+  it("prefers the cached _original_resource from proxied metadata over serverUrl", async () => {
+    const provider = makeProvider({
+      connectionUrl: CONNECTION_URL,
+      oauthProxyUrl: PROXY_URL,
+    });
+
+    // Populate the provider's original-resource cache the way it happens in
+    // production: a PRM fetch through the scoped proxy fetch whose response
+    // carries `_original_resource` (stashed by the OAuth proxy on rewrite).
+    const originalResource = "https://www.cubic.dev/api/mcp/scoped";
+    const baseFetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            resource: CONNECTION_URL,
+            authorization_servers: ["https://as.example.com"],
+            _original_resource: originalResource,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    ) as unknown as typeof fetch;
+    const scoped = provider.getProxyFetch(baseFetch)!;
+    await scoped(
+      "https://www.cubic.dev/.well-known/oauth-protected-resource/api/mcp"
+    );
+
+    const result = await provider.validateResourceURL(
+      SERVER_URL,
+      CONNECTION_URL
+    );
+    expect(result?.toString()).toBe(originalResource);
+  });
+
+  it("throws the SDK-style mismatch error for a genuinely foreign resource", async () => {
+    const provider = makeProvider({ connectionUrl: CONNECTION_URL });
+    await expect(
+      provider.validateResourceURL(SERVER_URL, "https://evil.example.com/mcp")
+    ).rejects.toThrow(
+      "Protected resource https://evil.example.com/mcp does not match expected https://www.cubic.dev/api/mcp (or origin)"
+    );
+  });
+
+  it("throws on connection-URL resource when no connectionUrl is configured (direct)", async () => {
+    const provider = makeProvider();
+    await expect(
+      provider.validateResourceURL(SERVER_URL, CONNECTION_URL)
+    ).rejects.toThrow(/does not match expected/);
+  });
+});


### PR DESCRIPTION
## Changes

Connecting to servers that need the inspector-proxy fallback (e.g. `https://www.cubic.dev/api/mcp`, `https://mcp.predictleads.com/`) entered a silent authentication loop: Checking → Authenticate → Authenticating, forever, with only a log line:

```
[useMcp] OAuth flow initiated (popup/redirect): "Protected resource https://inspector.manufact.com/inspector/api/proxy does not match expected https://www.cubic.dev/api/mcp (or origin)"
```

Root cause: the OAuth proxy rewrites the protected-resource-metadata `resource` field to the connection (proxy) URL so transport-anchored auth runs validate — but manual `authenticate()` runs validate against the **real** server URL, so the SDK's strict `selectResourceURL` check threw. `useMcp` then swallowed the throw as the expected popup handoff and waited on a popup that was never opened.

## Implementation Details

1. `BrowserOAuthClientProvider` now implements the SDK's `validateResourceURL` hook: accepts resources valid for either the requested server URL (SDK default) or the proxy `connectionUrl` (the rewrite case). In the rewrite case it returns the real upstream resource — the proxy's `_original_resource` (cached by `getProxyFetch`), falling back to the server URL — so the authorization request carries the resource the OAuth server actually protects.
2. `useMcp.authenticate()` no longer treats every `auth()` throw as a popup/redirect handoff: when `auth()` throws without opening a popup and without preparing an authorization URL (`clearStorage()` at flow start guarantees any stored URL is fresh), it calls `failConnection()` → state `failed` with the error set, so UIs surface the failure instead of hanging.

## Testing

- New `tests/unit/auth/browser-provider-resource-validation.test.ts` (8 cases): exact/path-prefix match, connection-URL rewrite → returns server resource, root-path server URL (predictleads shape), `_original_resource` cached via a real proxied metadata fetch, genuine mismatch → throws SDK-style error, direct (no connectionUrl) mismatch → throws.
- Full `mcp-use` unit suite passes; package builds (tsup + tsc declarations).

## Backwards Compatibility

Non-breaking. Servers that validated before still validate identically; the hook only adds tolerance for the proxy-rewrite case and correct failure surfacing.

Fixes MCP-2678.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a silent OAuth auth loop by correctly handling resource mismatches when using proxy connections, and surfaces real auth failures instead of hanging. Aligns `mcp-use` with MCP-2678.

- **Bug Fixes**
  - `BrowserOAuthClientProvider`: implements `validateResourceURL` to accept resources anchored to the server URL or proxy `connectionUrl`; on rewrite, returns the upstream resource from `_original_resource` (fallback: `serverUrl`).
  - `useMcp.authenticate()`: when `auth()` throws without opening a popup or preparing an auth URL, the connection now fails with the error so UIs don’t loop forever.

<sup>Written for commit 734851dba30b7d2b72fd40d56500d414cc53d57a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

