### PR TITLE
fix(inspector): point tunnel docs link at mcp-use.com

### DIFF
--- a/libraries/typescript/.changeset/tunneling-docs-link.md
+++ b/libraries/typescript/.changeset/tunneling-docs-link.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Fix broken tunneling docs link in the tunnel popover. The "Docs" link pointed to https://manufact.com/docs/tunneling, which returns a 404; it now points to https://mcp-use.com/docs/tunneling.

--- a/libraries/typescript/packages/inspector/src/client/components/LayoutHeader.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/LayoutHeader.tsx
@@ -477,7 +477,7 @@ function TunnelBadge({
             <div className="flex items-center justify-between mb-3">
               <h4 className="font-semibold text-sm">Tunnel URL</h4>
               <a
-                href="https://manufact.com/docs/tunneling"
+                href="https://mcp-use.com/docs/tunneling"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

The "Docs" link in the Inspector's tunnel popover points to `https://manufact.com/docs/tunneling`, which returns a 404 (it redirects to `docs.manufact.com/tunneling`, also 404). The tunneling docs actually live at `https://mcp-use.com/docs/tunneling` (source in this repo at `docs/tunneling/index.mdx`, registered in `docs/docs.json`).

This PR updates the href to the working URL.

## Review Readiness

- [x] The PR is scoped to one issue or one clearly related change
- [x] The PR description explains the user-visible problem and the fix
- [x] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [x] I verified the affected package/docs path with the commands listed below
- [x] I checked for existing open PRs that already solve the same issue

## Implementation Details

1. `libraries/typescript/packages/inspector/src/client/components/LayoutHeader.tsx`: changed the tunnel popover Docs href from `https://manufact.com/docs/tunneling` to `https://mcp-use.com/docs/tunneling`.
2. Added a patch changeset for `@mcp-use/inspector`.

Verification:

```bash
curl -s -o /dev/null -w '%{http_code}' https://manufact.com/docs/tunneling   # 404
curl -s -o /dev/null -w '%{http_code}' https://mcp-use.com/docs/tunneling    # 200
```

Note: a few other stale `manufact.com/docs/...` links exist in `create-mcp-use-app` and example READMEs — left out of scope here to keep the diff focused on #1833; happy to follow up in a separate PR if wanted.

## TypeScript Checklist

### Packages Modified

- [ ] `docs`
- [ ] `tests`
- [ ] `cli`
- [ ] `create-mcp-use-app`
- [ ] `mcp-use` (server)
- [ ] `mcp-use` (client)
- [x] `inspector`

### Pre-commit Checklist

- [x] Ran `pnpm lint:fix` to auto-fix linting issues (via Husky pre-commit)
- [x] Ran `pnpm format` to format code with Prettier (via Husky pre-commit)
- [x] Changeset added (`libraries/typescript/.changeset/tunneling-docs-link.md`)
- [ ] Tests: not applicable — static href change
- [ ] Docs: not applicable — docs page already exists

## Related Issues

Closes #1833

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the Inspector tunnel popover "Docs" link to the correct tunneling docs at https://mcp-use.com/docs/tunneling, fixing the 404.

<sup>Written for commit f3a9f0ab740430eed8d542e598f147c042d18765. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

