### PR TITLE
fix(docs): repair dead links flagged by link checker

### DIFF
--- a/libraries/python/README.md
+++ b/libraries/python/README.md
@@ -92,7 +92,7 @@ mcp-use for Python provides three main capabilities:
     <td>Build your own agents with any framework using the LangChain adapter or create new adapters</td>
   </tr>
   <tr>
-    <td>❓ <a href="https://mcp-use.com/what-should-we-build-next"><strong>What should we build next</strong></a></td>
+    <td>❓ <a href="https://github.com/mcp-use/mcp-use/issues"><strong>What should we build next</strong></a></td>
     <td>Let us know what you'd like us to build next</td>
   </tr>
 </table>

--- a/libraries/typescript/.changeset/fix-dead-doc-links.md
+++ b/libraries/typescript/.changeset/fix-dead-doc-links.md
@@ -1,0 +1,6 @@
+---
+"@mcp-use/inspector": patch
+"mcp-use": patch
+---
+
+Fix dead documentation links flagged by the link checker: the CLI client example and inspector README pointed at docs pages that no longer exist.

--- a/libraries/typescript/packages/inspector/README.md
+++ b/libraries/typescript/packages/inspector/README.md
@@ -413,7 +413,6 @@ See our [contributing guide](https://github.com/mcp-use/mcp-use/blob/main/CONTRI
 ## 📚 Learn More
 
 - [Inspector Documentation](https://mcp-use.com/docs/inspector) - Complete usage guide and tutorials
-- [Self-Hosting Guide](https://mcp-use.com/docs/inspector/self-hosting) - Deploy your own instance
 - [mcp-use Documentation](https://mcp-use.com/docs) - Full framework documentation
 - [Model Context Protocol](https://modelcontextprotocol.io) - Official MCP specification
 - [GitHub Repository](https://github.com/mcp-use/mcp-use) - Source code and examples

--- a/libraries/typescript/packages/mcp-use/examples/client/cli/CLI.md
+++ b/libraries/typescript/packages/mcp-use/examples/client/cli/CLI.md
@@ -195,6 +195,6 @@ Check that:
 
 ## Next Steps
 
-- Read the full [CLI Client documentation](https://mcp-use.com/docs/typescript/client/cli)
+- Read the full [CLI Client documentation](https://docs.mcp-use.com/typescript/tooling/client-cli)
 - Explore [MCP Server examples](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server)
 - Learn about [MCP Agents](https://mcp-use.com/docs/typescript/agent)

--- a/lychee.toml
+++ b/lychee.toml
@@ -31,6 +31,15 @@ exclude = [
 
 ]
 
+# Skip generated changelogs - historical release notes reference docs URLs
+# that were valid at release time; rewriting them is misleading
+exclude_path = [
+  "libraries/typescript/packages/cli/CHANGELOG.md",
+  "libraries/typescript/packages/create-mcp-use-app/CHANGELOG.md",
+  "libraries/typescript/packages/inspector/CHANGELOG.md",
+  "libraries/typescript/packages/mcp-use/CHANGELOG.md",
+]
+
 exclude_loopback = true
 exclude_link_local = true
 # Maximum number of redirects to follow

--- a/lychee.toml
+++ b/lychee.toml
@@ -34,10 +34,10 @@ exclude = [
 # Skip generated changelogs - historical release notes reference docs URLs
 # that were valid at release time; rewriting them is misleading
 exclude_path = [
-  "libraries/typescript/packages/cli/CHANGELOG.md",
-  "libraries/typescript/packages/create-mcp-use-app/CHANGELOG.md",
-  "libraries/typescript/packages/inspector/CHANGELOG.md",
-  "libraries/typescript/packages/mcp-use/CHANGELOG.md",
+  "libraries/typescript/packages/cli/CHANGELOG\\.md$",
+  "libraries/typescript/packages/create-mcp-use-app/CHANGELOG\\.md$",
+  "libraries/typescript/packages/inspector/CHANGELOG\\.md$",
+  "libraries/typescript/packages/mcp-use/CHANGELOG\\.md$",
 ]
 
 exclude_loopback = true

--- a/skills/chatgpt-app-builder/SKILL.md
+++ b/skills/chatgpt-app-builder/SKILL.md
@@ -217,7 +217,7 @@ Load these before diving into tools/resources/widgets sections.
 
   Add `--device-scale-factor 2` for Retina output, or `--cdp-url <ws>` plus `--inspector <publicly-reachable-url>` to drive a remote Chromium (e.g. Notte) from a sandbox without a local Chrome install.
 
-Both commands are documented in full at [docs/typescript/client/cli](https://docs.mcp-use.com/typescript/client/cli).
+Both commands are documented in full at [docs/typescript/tooling/client-cli](https://docs.mcp-use.com/typescript/tooling/client-cli).
 
 ---
 

--- a/skills/mcp-apps-builder/SKILL.md
+++ b/skills/mcp-apps-builder/SKILL.md
@@ -217,7 +217,7 @@ Load these before diving into tools/resources/widgets sections.
 
   Add `--device-scale-factor 2` for Retina output, or `--cdp-url <ws>` plus `--inspector <publicly-reachable-url>` to drive a remote Chromium (e.g. Notte) from a sandbox without a local Chrome install.
 
-Both commands are documented in full at [docs/typescript/client/cli](https://docs.mcp-use.com/typescript/client/cli).
+Both commands are documented in full at [docs/typescript/tooling/client-cli](https://docs.mcp-use.com/typescript/tooling/client-cli).
 
 ---
 

--- a/skills/mcp-builder/SKILL.md
+++ b/skills/mcp-builder/SKILL.md
@@ -217,7 +217,7 @@ Load these before diving into tools/resources/widgets sections.
 
   Add `--device-scale-factor 2` for Retina output, or `--cdp-url <ws>` plus `--inspector <publicly-reachable-url>` to drive a remote Chromium (e.g. Notte) from a sandbox without a local Chrome install.
 
-Both commands are documented in full at [docs/typescript/client/cli](https://docs.mcp-use.com/typescript/client/cli).
+Both commands are documented in full at [docs/typescript/tooling/client-cli](https://docs.mcp-use.com/typescript/tooling/client-cli).
 
 ---
 

--- a/skills/openapi-to-mcp/references/testing.md
+++ b/skills/openapi-to-mcp/references/testing.md
@@ -40,7 +40,7 @@ If you don't see your tool list, you missed a step in the operations loop in `in
 
 ## 2. Layer 1 — `mcp-use client` CLI (primary)
 
-The `mcp-use` package ships a CLI client that connects to any streamable-HTTP MCP server, handles session and auth bookkeeping, and gives a clean `tools list` / `tools call` / `interactive` surface from the terminal. This is the first thing to reach for. Full docs at <https://docs.mcp-use.com/typescript/client/cli>.
+The `mcp-use` package ships a CLI client that connects to any streamable-HTTP MCP server, handles session and auth bookkeeping, and gives a clean `tools list` / `tools call` / `interactive` surface from the terminal. This is the first thing to reach for. Full docs at <https://docs.mcp-use.com/typescript/tooling/client-cli>.
 
 ### Connect once, then run commands against the name
 


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

- [x] TypeScript
- [x] Python
- [x] Documentation only
- [x] CI/CD or tooling

## Changes

The scheduled link checker (#1838) reported 19 dead links. This PR resolves all of them:

1. **Dead CLI client docs URL** — `…/typescript/client/cli` returns 404; the page now lives at `https://docs.mcp-use.com/typescript/tooling/client-cli` (verified 200, source: `docs/typescript/tooling/client-cli.mdx`). Updated in the CLI client example (`examples/client/cli/CLI.md`) and the four skills files.
2. **Inspector README self-hosting link** — `mcp-use.com/docs/inspector/self-hosting` 404s and no such docs page exists; removed the bullet (the Inspector Documentation link directly above covers it).
3. **Python README "What should we build next"** — `mcp-use.com/what-should-we-build-next` returns 410 Gone; now points at GitHub issues, which matches the cell's "Let us know what you'd like us to build next" text.
4. **Generated package CHANGELOGs** — the remaining 12 errors are in historical release notes (`packages/*/CHANGELOG.md`), where links were valid at release time. Rather than rewriting release history, added `exclude_path` entries for the four changelogs in `lychee.toml`. Happy to fix the changelog links in-place instead if maintainers prefer.

## Review Readiness

- [x] The PR is scoped to one issue or one clearly related change
- [x] The PR description explains the user-visible problem and the fix
- [x] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [x] I verified the affected package/docs path with the commands listed below
- [x] I checked for existing open PRs that already solve the same issue

## Implementation Details

1. Replaced 5 occurrences of the dead CLI docs URL with `https://docs.mcp-use.com/typescript/tooling/client-cli`.
2. Removed one dead bullet from `packages/inspector/README.md`.
3. Repointed one 410 link in `libraries/python/README.md`.
4. Added `exclude_path` (4 changelog paths) to `lychee.toml`.
5. Added a patch changeset for `mcp-use` and `@mcp-use/inspector` (their published README/example files changed).

Verification:

```bash
curl -s -o /dev/null -w '%{http_code}' https://docs.mcp-use.com/typescript/client/cli          # 404 (old)
curl -s -o /dev/null -w '%{http_code}' https://docs.mcp-use.com/typescript/tooling/client-cli  # 200 (new)
curl -s -o /dev/null -w '%{http_code}' https://mcp-use.com/what-should-we-build-next           # 410 (old)
curl -s -o /dev/null -w '%{http_code}' https://mcp-use.com/docs/inspector/self-hosting         # 404 (removed)
```

A repo-wide grep confirms no occurrences of the dead URLs remain outside the excluded changelogs.

## Related Issues

Closes #1838

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix 19 dead docs links and update the link checker to ignore historical changelogs with correct exclude regex. Restores green link checks and removes confusing references. Closes #1838.

- **Bug Fixes**
  - Update CLI docs URL to https://docs.mcp-use.com/typescript/tooling/client-cli in the CLI example and 4 skills.
  - Remove Inspector README "Self-Hosting Guide" (page does not exist).
  - Point Python README "What should we build next" to GitHub issues.
  - Exclude generated `CHANGELOG.md` files from `lychee` and fix the exclude regex (escape dots, anchor patterns); add patch changesets for `mcp-use` and `@mcp-use/inspector`.

<sup>Written for commit 77e7bcca9f57886d494b529785e2cb2528a58d66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

