### PR TITLE
fix(cli): do not treat -p path alias as explicit port flag

### DIFF
--- a/libraries/typescript/packages/cli/src/index.ts
+++ b/libraries/typescript/packages/cli/src/index.ts
@@ -20,6 +20,7 @@ import {
 } from "./commands/client.js";
 import { getSession } from "./utils/session-storage.js";
 import { formatError } from "./utils/format.js";
+import { isStartPortFlagExplicit } from "./utils/start-port.js";
 import { deployCommand } from "./commands/deploy.js";
 import { createDeploymentsCommand } from "./commands/deployments.js";
 import { createServersCommand } from "./commands/servers.js";
@@ -2625,12 +2626,8 @@ program
     try {
       const projectPath = path.resolve(options.path);
       // Priority: --port flag > process.env.PORT > default
-      // Check if --port or -p was explicitly provided in command line
-      const portFlagProvided =
-        process.argv.includes("--port") ||
-        process.argv.includes("-p") ||
-        process.argv.some((arg) => arg.startsWith("--port=")) ||
-        process.argv.some((arg) => arg.startsWith("-p="));
+      // `-p` is the --path alias; only --port counts as an explicit port override.
+      const portFlagProvided = isStartPortFlagExplicit(process.argv);
 
       let port = portFlagProvided
         ? parseInt(options.port, 10) // Flag explicitly provided, use it

--- a/libraries/typescript/packages/cli/src/utils/start-port.ts
+++ b/libraries/typescript/packages/cli/src/utils/start-port.ts
@@ -1,0 +1,11 @@
+/**
+ * Detect whether the user explicitly passed a port override to `mcp-use start`.
+ *
+ * `-p` is reserved for `--path`; only `--port` / `--port=<value>` should count
+ * as an explicit port flag so `PORT` env precedence is preserved.
+ */
+export function isStartPortFlagExplicit(argv: string[]): boolean {
+  return (
+    argv.includes("--port") || argv.some((arg) => arg.startsWith("--port="))
+  );
+}

--- a/libraries/typescript/packages/cli/tests/start-port.test.ts
+++ b/libraries/typescript/packages/cli/tests/start-port.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { isStartPortFlagExplicit } from "../src/utils/start-port.js";
+
+describe("isStartPortFlagExplicit", () => {
+  it("returns true when --port is provided", () => {
+    expect(isStartPortFlagExplicit(["node", "mcp-use", "start", "--port"])).toBe(
+      true
+    );
+    expect(
+      isStartPortFlagExplicit(["node", "mcp-use", "start", "--port=4173"])
+    ).toBe(true);
+  });
+
+  it("returns false when only the -p path alias is provided", () => {
+    expect(
+      isStartPortFlagExplicit(["node", "mcp-use", "start", "-p", "./app"])
+    ).toBe(false);
+    expect(
+      isStartPortFlagExplicit(["node", "mcp-use", "start", "-p=./app"])
+    ).toBe(false);
+  });
+
+  it("returns false when no port flag is provided", () => {
+    expect(isStartPortFlagExplicit(["node", "mcp-use", "start"])).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Fix `mcp-use start` port detection so the `-p` path alias no longer bypasses the `PORT` environment variable.

## Motivation

`start` defines `-p` as the short alias for `--path`, but the command also treated any `-p` token as proof that `--port` was explicitly provided. That broke the intended precedence (`--port` > `PORT` > default) for commands like:

```bash
PORT=4173 mcp-use start -p ./app
```

## Changes

- Add `isStartPortFlagExplicit()` helper that only recognizes `--port` / `--port=<value>`
- Use the helper in the `start` command instead of scanning raw `process.argv` for `-p`
- Add unit tests covering `-p ./app`, `-p=./app`, and explicit `--port` forms

## Tests

- `pnpm test tests/start-port.test.ts` — 3 passed

## Notes

composer-2.5 review: APPROVE

Fixes #1813

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes port detection in `mcp-use start` so the `-p` path alias for `--path` no longer overrides the `PORT` environment variable. Restores precedence: `--port` > `PORT` > default.

- **Bug Fixes**
  - Add `isStartPortFlagExplicit()` to only accept `--port`/`--port=<value>`.
  - Use the helper in `start` instead of scanning `process.argv` for `-p`.
  - Add unit tests for `-p ./app`, `-p=./app`, and explicit `--port` forms.

<sup>Written for commit 1c93fcbdfc277edae0c55290acd4ba65ec2939a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

