### PR TITLE
docs(inspector): add self-hosting guide

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -224,6 +224,7 @@
                       "inspector/keyboard-shortcuts",
                       "inspector/command-palette",
                       "inspector/integration",
+                      "inspector/self-hosting",
                       "inspector/debugging-chatgpt-apps"
                     ]
                   },
@@ -705,6 +706,7 @@
               "inspector/keyboard-shortcuts",
               "inspector/command-palette",
               "inspector/integration",
+              "inspector/self-hosting",
               "inspector/debugging-chatgpt-apps"
             ]
           }

--- a/docs/inspector/self-hosting.mdx
+++ b/docs/inspector/self-hosting.mdx
@@ -1,0 +1,75 @@
+---
+title: "Self-Hosting"
+description: "Deploy your own MCP Inspector instance with Docker."
+icon: "container"
+---
+
+Run the Inspector on your own infrastructure when you need full control over your debugging environment — for example in enterprise or air-gapped networks where the hosted [inspector.mcp-use.com](https://inspector.mcp-use.com) is not an option.
+
+The official Docker image is published at [`mcpuse/inspector`](https://hub.docker.com/r/mcpuse/inspector) on Docker Hub.
+
+## Quick start
+
+```bash
+docker run -d -p 8080:8080 --name mcp-inspector mcpuse/inspector:latest
+```
+
+Then open `http://localhost:8080` to access your self-hosted Inspector.
+
+## Deployment options
+
+<Tabs>
+  <Tab title="Docker Run">
+    ```bash
+    docker run -d \
+      --name mcp-inspector \
+      -p 8080:8080 \
+      mcpuse/inspector:latest
+    ```
+  </Tab>
+  <Tab title="Docker Compose">
+    ```yaml
+    services:
+      mcp-inspector:
+        image: mcpuse/inspector:latest
+        ports:
+          - "8080:8080"
+        restart: unless-stopped
+        healthcheck:
+          test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/inspector"]
+          interval: 30s
+          timeout: 10s
+          retries: 3
+    ```
+  </Tab>
+</Tabs>
+
+<Note>
+The image is based on `node:20-alpine`, which ships `wget` (BusyBox) but not `curl` — use `wget` in healthchecks.
+</Note>
+
+## Ports
+
+The container always listens on port `8080` — the image's start command pins it with `--port 8080`, so a `PORT` environment variable has no effect. To serve on a different host port, remap it with Docker instead:
+
+```bash
+docker run -d -p 3001:8080 mcpuse/inspector:latest
+```
+
+`NODE_ENV=production` is already set in the image; no environment variables are required.
+
+<Note>
+When connecting from a self-hosted Inspector to an MCP server on another host, the browser must be able to reach the server directly, or you can use the proxy connection mode. See [Connection settings](/inspector/connection-settings) for when to use each.
+</Note>
+
+## Alternatives
+
+Self-hosting is one of three ways to run the Inspector:
+
+| Option | Command | Best for |
+| --- | --- | --- |
+| Hosted | [inspector.mcp-use.com](https://inspector.mcp-use.com) | Quick testing, no install |
+| Local CLI | `npx @mcp-use/inspector` | Local development |
+| Self-hosted | `docker run mcpuse/inspector:latest` | Production, enterprise, air-gapped |
+
+Servers built with `mcp-use` also auto-mount the Inspector at `/inspector` — see the [Inspector overview](/inspector/index).

--- a/docs/inspector/self-hosting.mdx
+++ b/docs/inspector/self-hosting.mdx
@@ -4,17 +4,21 @@ description: "Deploy your own MCP Inspector instance with Docker."
 icon: "container"
 ---
 
-Run the Inspector on your own infrastructure when you need full control over your debugging environment — for example in enterprise or air-gapped networks where the hosted [inspector.mcp-use.com](https://inspector.mcp-use.com) is not an option.
+Run the Inspector on your own infrastructure when you need full control over your debugging environment.
 
 The official Docker image is published at [`mcpuse/inspector`](https://hub.docker.com/r/mcpuse/inspector) on Docker Hub.
 
 ## Quick start
 
 ```bash
-docker run -d -p 8080:8080 --name mcp-inspector mcpuse/inspector:latest
+docker run -d -p 127.0.0.1:8080:8080 --name mcp-inspector mcpuse/inspector:latest
 ```
 
 Then open `http://localhost:8080` to access your self-hosted Inspector.
+
+<Warning>
+Anyone who can reach the Inspector can use it to connect to and call your MCP servers. The examples bind to `127.0.0.1` so the Inspector is only reachable from the host itself. If you need remote access, put it behind a reverse proxy with authentication and TLS, or restrict access with firewall rules — don't publish port 8080 on all interfaces.
+</Warning>
 
 ## Deployment options
 
@@ -23,7 +27,7 @@ Then open `http://localhost:8080` to access your self-hosted Inspector.
     ```bash
     docker run -d \
       --name mcp-inspector \
-      -p 8080:8080 \
+      -p 127.0.0.1:8080:8080 \
       mcpuse/inspector:latest
     ```
   </Tab>
@@ -33,7 +37,7 @@ Then open `http://localhost:8080` to access your self-hosted Inspector.
       mcp-inspector:
         image: mcpuse/inspector:latest
         ports:
-          - "8080:8080"
+          - "127.0.0.1:8080:8080"
         restart: unless-stopped
         healthcheck:
           test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/inspector"]
@@ -53,10 +57,23 @@ The image is based on `node:20-alpine`, which ships `wget` (BusyBox) but not `cu
 The container always listens on port `8080` — the image's start command pins it with `--port 8080`, so a `PORT` environment variable has no effect. To serve on a different host port, remap it with Docker instead:
 
 ```bash
-docker run -d -p 3001:8080 mcpuse/inspector:latest
+docker run -d -p 127.0.0.1:3001:8080 mcpuse/inspector:latest
 ```
 
 `NODE_ENV=production` is already set in the image; no environment variables are required.
+
+## Air-gapped installation
+
+For hosts without registry access, transfer the image as a tarball:
+
+```bash
+# On a connected host
+docker pull mcpuse/inspector:latest
+docker save mcpuse/inspector:latest -o mcp-inspector.tar
+
+# On the air-gapped host
+docker load -i mcp-inspector.tar
+```
 
 <Note>
 When connecting from a self-hosted Inspector to an MCP server on another host, the browser must be able to reach the server directly, or you can use the proxy connection mode. See [Connection settings](/inspector/connection-settings) for when to use each.


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

Check all that apply:
- [ ] TypeScript
- [ ] Python
- [x] Documentation only
- [ ] CI/CD or tooling

## Changes

Adds a **Self-Hosting** page to the Inspector docs (`docs/inspector/self-hosting.mdx`) covering the official `mcpuse/inspector` Docker image, and registers it in both Inspector nav sections of `docs.json`.

The hosted Inspector and the local CLI are documented, but the Docker image (7.4k+ pulls on Docker Hub) had no docs page at all — users running in enterprise or air-gapped environments had nothing to point at. This complements #1855, which removed a dead self-hosting link without a replacement target.

## Review Readiness

- [x] The PR is scoped to one issue or one clearly related change
- [x] The PR description explains the user-visible problem and the fix
- [x] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [x] I verified the affected package/docs path with the commands listed below
- [x] I checked for existing open PRs that already solve the same issue

## Implementation Details

1. New `docs/inspector/self-hosting.mdx`: quick start, `docker run` / Docker Compose tabs, port behavior, and a comparison of the three ways to run the Inspector (hosted / CLI / self-hosted).
2. Content was verified against the actual image and source rather than assumed:
   - The container pins its listen port via `CMD ["npx", "@mcp-use/inspector", "--port", "8080"]` (`packages/inspector/Dockerfile`), and the server reads the port only from the `--port` flag (`src/server/utils.ts`) — so the guide documents Docker port remapping (`-p 3001:8080`) instead of a `PORT` env var, which would silently do nothing.
   - The compose healthcheck uses `wget --spider` because the `node:20-alpine` base image ships BusyBox `wget` but not `curl`.
   - Root `/` redirects to `/inspector` (`src/server/shared-static.ts`), so the healthcheck targets `/inspector` directly.
3. `docs.json`: added `inspector/self-hosting` after `inspector/integration` in both nav groups, matching existing ordering.

## Documentation Checklist

- [x] Verified internal links resolve (`/inspector/connection-settings`, `/inspector/index` — both exist and match the link style used elsewhere)
- [x] Docker Hub image `mcpuse/inspector` confirmed active with `latest` tag

## Backwards Compatibility

Docs-only; no code changes.

## Related Issues

Complements #1855 (dead self-hosting link removal).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Self-Hosting page for MCP Inspector that documents the official `mcpuse/inspector` Docker image, with secure defaults that bind to 127.0.0.1 and an exposure warning with reverse-proxy/firewall guidance. Includes quick start docker run and Compose examples, clarifies port mapping (container listens on 8080), adds air-gapped save/load steps, and registers the page in both Inspector nav sections.

<sup>Written for commit c551d51c55967938e442556297543a4a0c3a0196. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

