### PR TITLE
fix(docs): repair 26 dead links across READMEs, changelogs, and skills

### DIFF
--- a/libraries/python/README.md
+++ b/libraries/python/README.md
@@ -91,10 +91,6 @@ mcp-use for Python provides three main capabilities:
     <td>🔧 <a href="#build-a-custom-agent"><strong>Custom Agents</strong></a></td>
     <td>Build your own agents with any framework using the LangChain adapter or create new adapters</td>
   </tr>
-  <tr>
-    <td>❓ <a href="https://mcp-use.com/what-should-we-build-next"><strong>What should we build next</strong></a></td>
-    <td>Let us know what you'd like us to build next</td>
-  </tr>
 </table>
 
 ---

--- a/libraries/typescript/packages/cli/CHANGELOG.md
+++ b/libraries/typescript/packages/cli/CHANGELOG.md
@@ -5318,7 +5318,7 @@ screenshot --tool <tool>`) silently produced a blank PNG and exited 0
 
   WebSocket transport support has been removed. Use streamable HTTP or SSE transports instead.
 
-  **Learn more:** [Client Configuration](https://mcp-use.com/docs/typescript/client/client-configuration)
+  **Learn more:** [Client Configuration](https://docs.mcp-use.com/typescript/client/index)
 
   ## Features
 
@@ -5393,13 +5393,13 @@ screenshot --tool <tool>`) silently produced a blank PNG and exited 0
   - CLI build process includes favicon in widget HTML pages
   - Long-term caching (1 year) for favicon assets
 
-  **Learn more:** [UI Widgets](https://mcp-use.com/docs/typescript/server/ui-widgets) and [Server Configuration](https://mcp-use.com/docs/typescript/server/configuration)
+  **Learn more:** [UI Widgets](https://mcp-use.com/docs/typescript/server/ui-widgets) and [Server Configuration](https://docs.mcp-use.com/typescript/api-reference/server/server-config)
 
   ### CLI Client Support
 
   Added dedicated CLI client support for better command-line integration and testing.
 
-  **Learn more:** [CLI Client](https://mcp-use.com/docs/typescript/client/cli)
+  **Learn more:** [CLI Client](https://docs.mcp-use.com/typescript/tooling/client-cli)
 
   ### Enhanced Session Methods
   - `callTool()` method now defaults args to an empty object

--- a/libraries/typescript/packages/create-mcp-use-app/CHANGELOG.md
+++ b/libraries/typescript/packages/create-mcp-use-app/CHANGELOG.md
@@ -822,7 +822,7 @@
 
   WebSocket transport support has been removed. Use streamable HTTP or SSE transports instead.
 
-  **Learn more:** [Client Configuration](https://mcp-use.com/docs/typescript/client/client-configuration)
+  **Learn more:** [Client Configuration](https://docs.mcp-use.com/typescript/client/index)
 
   ## Features
 
@@ -897,13 +897,13 @@
   - CLI build process includes favicon in widget HTML pages
   - Long-term caching (1 year) for favicon assets
 
-  **Learn more:** [UI Widgets](https://mcp-use.com/docs/typescript/server/ui-widgets) and [Server Configuration](https://mcp-use.com/docs/typescript/server/configuration)
+  **Learn more:** [UI Widgets](https://mcp-use.com/docs/typescript/server/ui-widgets) and [Server Configuration](https://docs.mcp-use.com/typescript/api-reference/server/server-config)
 
   ### CLI Client Support
 
   Added dedicated CLI client support for better command-line integration and testing.
 
-  **Learn more:** [CLI Client](https://mcp-use.com/docs/typescript/client/cli)
+  **Learn more:** [CLI Client](https://docs.mcp-use.com/typescript/tooling/client-cli)
 
   ### Enhanced Session Methods
   - `callTool()` method now defaults args to an empty object

--- a/libraries/typescript/packages/inspector/CHANGELOG.md
+++ b/libraries/typescript/packages/inspector/CHANGELOG.md
@@ -4722,7 +4722,7 @@ mcpServerUrl }` response and renders an inline banner above the input
 
   WebSocket transport support has been removed. Use streamable HTTP or SSE transports instead.
 
-  **Learn more:** [Client Configuration](https://mcp-use.com/docs/typescript/client/client-configuration)
+  **Learn more:** [Client Configuration](https://docs.mcp-use.com/typescript/client/index)
 
   ## Features
 
@@ -4797,13 +4797,13 @@ mcpServerUrl }` response and renders an inline banner above the input
   - CLI build process includes favicon in widget HTML pages
   - Long-term caching (1 year) for favicon assets
 
-  **Learn more:** [UI Widgets](https://mcp-use.com/docs/typescript/server/ui-widgets) and [Server Configuration](https://mcp-use.com/docs/typescript/server/configuration)
+  **Learn more:** [UI Widgets](https://mcp-use.com/docs/typescript/server/ui-widgets) and [Server Configuration](https://docs.mcp-use.com/typescript/api-reference/server/server-config)
 
   ### CLI Client Support
 
   Added dedicated CLI client support for better command-line integration and testing.
 
-  **Learn more:** [CLI Client](https://mcp-use.com/docs/typescript/client/cli)
+  **Learn more:** [CLI Client](https://docs.mcp-use.com/typescript/tooling/client-cli)
 
   ### Enhanced Session Methods
   - `callTool()` method now defaults args to an empty object

--- a/libraries/typescript/packages/mcp-use/CHANGELOG.md
+++ b/libraries/typescript/packages/mcp-use/CHANGELOG.md
@@ -5761,7 +5761,7 @@
 
   WebSocket transport support has been removed. Use streamable HTTP or SSE transports instead.
 
-  **Learn more:** [Client Configuration](https://mcp-use.com/docs/typescript/client/client-configuration)
+  **Learn more:** [Client Configuration](https://docs.mcp-use.com/typescript/client/index)
 
   ## Features
 
@@ -5836,13 +5836,13 @@
   - CLI build process includes favicon in widget HTML pages
   - Long-term caching (1 year) for favicon assets
 
-  **Learn more:** [UI Widgets](https://mcp-use.com/docs/typescript/server/ui-widgets) and [Server Configuration](https://mcp-use.com/docs/typescript/server/configuration)
+  **Learn more:** [UI Widgets](https://mcp-use.com/docs/typescript/server/ui-widgets) and [Server Configuration](https://docs.mcp-use.com/typescript/api-reference/server/server-config)
 
   ### CLI Client Support
 
   Added dedicated CLI client support for better command-line integration and testing.
 
-  **Learn more:** [CLI Client](https://mcp-use.com/docs/typescript/client/cli)
+  **Learn more:** [CLI Client](https://docs.mcp-use.com/typescript/tooling/client-cli)
 
   ### Enhanced Session Methods
   - `callTool()` method now defaults args to an empty object

--- a/libraries/typescript/packages/mcp-use/examples/client/cli/CLI.md
+++ b/libraries/typescript/packages/mcp-use/examples/client/cli/CLI.md
@@ -195,6 +195,6 @@ Check that:
 
 ## Next Steps
 
-- Read the full [CLI Client documentation](https://mcp-use.com/docs/typescript/client/cli)
+- Read the full [CLI Client documentation](https://docs.mcp-use.com/typescript/tooling/client-cli)
 - Explore [MCP Server examples](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server)
 - Learn about [MCP Agents](https://mcp-use.com/docs/typescript/agent)

--- a/lychee.toml
+++ b/lychee.toml
@@ -29,6 +29,13 @@ exclude = [
   # Example/template URLs
   "^https://github\\.com/your-org/",
 
+  # GitHub /stargazers pages return 404 to non-browser clients (bot mitigation);
+  # they load fine in a browser. Verified against other repos' stargazers pages too.
+  "^https://github\\.com/[^/]+/[^/]+/stargazers$",
+
+  # star-history.com badge API intermittently returns 500s; the badge is decorative
+  "^https://api\\.star-history\\.com",
+
 ]
 
 exclude_loopback = true

--- a/lychee.toml
+++ b/lychee.toml
@@ -34,7 +34,7 @@ exclude = [
   "^https://github\\.com/[^/]+/[^/]+/stargazers$",
 
   # star-history.com badge API intermittently returns 500s; the badge is decorative
-  "^https://api\\.star-history\\.com",
+  "^https://api\\.star-history\\.com/svg",
 
 ]
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -34,7 +34,7 @@ exclude = [
   "^https://github\\.com/[^/]+/[^/]+/stargazers$",
 
   # star-history.com badge API intermittently returns 500s; the badge is decorative
-  "^https://api\\.star-history\\.com/svg",
+  "^https://api\\.star-history\\.com/svg(\\?|$)",
 
 ]
 

--- a/skills/chatgpt-app-builder/SKILL.md
+++ b/skills/chatgpt-app-builder/SKILL.md
@@ -217,7 +217,7 @@ Load these before diving into tools/resources/widgets sections.
 
   Add `--device-scale-factor 2` for Retina output, or `--cdp-url <ws>` plus `--inspector <publicly-reachable-url>` to drive a remote Chromium (e.g. Notte) from a sandbox without a local Chrome install.
 
-Both commands are documented in full at [docs/typescript/client/cli](https://docs.mcp-use.com/typescript/client/cli).
+Both commands are documented in full at [docs/typescript/client/cli](https://docs.mcp-use.com/typescript/tooling/client-cli).
 
 ---
 

--- a/skills/chatgpt-app-builder/SKILL.md
+++ b/skills/chatgpt-app-builder/SKILL.md
@@ -217,7 +217,7 @@ Load these before diving into tools/resources/widgets sections.
 
   Add `--device-scale-factor 2` for Retina output, or `--cdp-url <ws>` plus `--inspector <publicly-reachable-url>` to drive a remote Chromium (e.g. Notte) from a sandbox without a local Chrome install.
 
-Both commands are documented in full at [docs/typescript/client/cli](https://docs.mcp-use.com/typescript/tooling/client-cli).
+Both commands are documented in full at [docs/typescript/tooling/client-cli](https://docs.mcp-use.com/typescript/tooling/client-cli).
 
 ---
 

--- a/skills/mcp-apps-builder/SKILL.md
+++ b/skills/mcp-apps-builder/SKILL.md
@@ -217,7 +217,7 @@ Load these before diving into tools/resources/widgets sections.
 
   Add `--device-scale-factor 2` for Retina output, or `--cdp-url <ws>` plus `--inspector <publicly-reachable-url>` to drive a remote Chromium (e.g. Notte) from a sandbox without a local Chrome install.
 
-Both commands are documented in full at [docs/typescript/client/cli](https://docs.mcp-use.com/typescript/client/cli).
+Both commands are documented in full at [docs/typescript/client/cli](https://docs.mcp-use.com/typescript/tooling/client-cli).
 
 ---
 

--- a/skills/mcp-apps-builder/SKILL.md
+++ b/skills/mcp-apps-builder/SKILL.md
@@ -217,7 +217,7 @@ Load these before diving into tools/resources/widgets sections.
 
   Add `--device-scale-factor 2` for Retina output, or `--cdp-url <ws>` plus `--inspector <publicly-reachable-url>` to drive a remote Chromium (e.g. Notte) from a sandbox without a local Chrome install.
 
-Both commands are documented in full at [docs/typescript/client/cli](https://docs.mcp-use.com/typescript/tooling/client-cli).
+Both commands are documented in full at [docs/typescript/tooling/client-cli](https://docs.mcp-use.com/typescript/tooling/client-cli).
 
 ---
 

--- a/skills/mcp-builder/SKILL.md
+++ b/skills/mcp-builder/SKILL.md
@@ -217,7 +217,7 @@ Load these before diving into tools/resources/widgets sections.
 
   Add `--device-scale-factor 2` for Retina output, or `--cdp-url <ws>` plus `--inspector <publicly-reachable-url>` to drive a remote Chromium (e.g. Notte) from a sandbox without a local Chrome install.
 
-Both commands are documented in full at [docs/typescript/client/cli](https://docs.mcp-use.com/typescript/client/cli).
+Both commands are documented in full at [docs/typescript/client/cli](https://docs.mcp-use.com/typescript/tooling/client-cli).
 
 ---
 

--- a/skills/mcp-builder/SKILL.md
+++ b/skills/mcp-builder/SKILL.md
@@ -217,7 +217,7 @@ Load these before diving into tools/resources/widgets sections.
 
   Add `--device-scale-factor 2` for Retina output, or `--cdp-url <ws>` plus `--inspector <publicly-reachable-url>` to drive a remote Chromium (e.g. Notte) from a sandbox without a local Chrome install.
 
-Both commands are documented in full at [docs/typescript/client/cli](https://docs.mcp-use.com/typescript/tooling/client-cli).
+Both commands are documented in full at [docs/typescript/tooling/client-cli](https://docs.mcp-use.com/typescript/tooling/client-cli).
 
 ---
 

--- a/skills/openapi-to-mcp/references/testing.md
+++ b/skills/openapi-to-mcp/references/testing.md
@@ -40,7 +40,7 @@ If you don't see your tool list, you missed a step in the operations loop in `in
 
 ## 2. Layer 1 — `mcp-use client` CLI (primary)
 
-The `mcp-use` package ships a CLI client that connects to any streamable-HTTP MCP server, handles session and auth bookkeeping, and gives a clean `tools list` / `tools call` / `interactive` surface from the terminal. This is the first thing to reach for. Full docs at <https://docs.mcp-use.com/typescript/client/cli>.
+The `mcp-use` package ships a CLI client that connects to any streamable-HTTP MCP server, handles session and auth bookkeeping, and gives a clean `tools list` / `tools call` / `interactive` surface from the terminal. This is the first thing to reach for. Full docs at <https://docs.mcp-use.com/typescript/tooling/client-cli>.
 
 ### Connect once, then run commands against the name
 


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

Check all that apply:
- [ ] TypeScript
- [ ] Python
- [x] Documentation only
- [ ] CI/CD or tooling

## Changes

A local run of the same lychee check that the weekly `links.yml` workflow uses found **27 broken links** on `main` (the docs restructure in #1780 deleted three pages that many files still point at). This PR repairs them ahead of Sunday's scheduled Link Checker run.

## Review Readiness

- [x] The PR is scoped to one issue or one clearly related change
- [x] The PR description explains the user-visible problem and the fix
- [x] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [x] I verified the affected package/docs path with the commands listed below
- [x] I checked for existing open PRs that already solve the same issue

## Implementation Details

**URL rewrites** — every replacement target verified live (HTTP 200):

1. `…/typescript/client/cli` → `docs.mcp-use.com/typescript/tooling/client-cli` (page moved in #1780) — 4 changelogs, `examples/client/cli/CLI.md`, and 4 `skills/*` files
2. `…/typescript/client/client-configuration` → `docs.mcp-use.com/typescript/client/index` (deleted in #1780; the client overview covers configuration now) — 4 changelogs
3. `…/typescript/server/configuration` → `docs.mcp-use.com/typescript/api-reference/server/server-config` (deleted in #1780; ServerConfig API reference is the successor) — 4 changelogs

**Removals:**

4. Python README: dropped the "What should we build next" table row — `mcp-use.com/what-should-we-build-next` returns **410 Gone** (and its redirect target does too)

**lychee.toml excludes** (false positives, not real rot):

5. `github.com/*/*/stargazers` — GitHub returns 404 to non-browser clients as bot mitigation; verified the same happens for unrelated repos (e.g. facebook/react), pages load fine in a browser
6. `api.star-history.com` — decorative README badge, intermittently returns 500

**Intentionally left:** `inspector/README.md` links `docs/inspector/self-hosting`, a page that has never existed — #1861 (open) creates it, which resolves that link on merge.

## Testing

- `git ls-files '*.md' '*.html' '*.rst' | xargs lychee …` with the repo's `lychee.toml`: **27 errors → 1** (the #1861-dependent link above)
- All replacement URLs individually curl-verified as 200

## Backwards Compatibility

Docs/config only; no code changes. Changelog edits are URL-only, entry text untouched.

## Related Issues

Closes #1867. Closes #1939 (weekly Link Checker Reports — identical 27-error set re-filed Jul 12 and Jul 19). Previous report: #1838, fixed by #1855. Complements #1861.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 26 broken links across READMEs, changelogs, examples, and skills after the docs restructure, so users land on the right pages and the weekly link checker stays green.

- **Bug Fixes**
  - Repointed TypeScript docs links and aligned link text: CLI client → https://docs.mcp-use.com/typescript/tooling/client-cli; client configuration → https://docs.mcp-use.com/typescript/client/index; server configuration → https://docs.mcp-use.com/typescript/api-reference/server/server-config
  - Removed the stale “What should we build next” row from the Python README (target returns 410).
  - Tightened `lychee.toml` excludes: ignore GitHub `/stargazers`; restrict `api.star-history.com` to the `/svg` badge endpoint with a strict boundary (`/svg` followed by `?` or end-of-URL).
  - Repo-wide `lychee` scan: 27 errors → 1; the remaining link (`inspector/README.md` → `docs/inspector/self-hosting`) is resolved by #1861.

<sup>Written for commit 03daa70c0e7aef150252b66fe9608fb0ff2129e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1864?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

