### PR TITLE
docs(python): add audited filesystem example

### DIFF
--- a/libraries/python/examples/audited_filesystem_use.py
+++ b/libraries/python/examples/audited_filesystem_use.py
@@ -1,0 +1,81 @@
+"""
+Audited tool calls example for mcp_use.
+
+This example demonstrates how to put a governance proxy between an
+MCPAgent and an MCP server, so every tool call the agent makes is
+checked against a policy and recorded in a tamper-evident audit trail
+before it reaches the server. The proxy is just another stdio MCP
+server in the config: no changes to mcp_use or to the upstream server.
+
+This uses Vaara (https://github.com/vaaraio/vaara) as the proxy:
+
+    pip install vaara
+
+Special Thanks to https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem
+for the server.
+"""
+
+import asyncio
+import sys
+
+from dotenv import load_dotenv
+from langchain_openai import ChatOpenAI
+
+from mcp_use import MCPAgent, MCPClient
+
+# The same filesystem server as filesystem_use.py, but spawned and
+# governed by the proxy. Arguments that start with a dash (like -y)
+# must use the --upstream-arg=VALUE form.
+config = {
+    "mcpServers": {
+        "filesystem-audited": {
+            "command": sys.executable,
+            "args": [
+                "-m",
+                "vaara.integrations.mcp_proxy",
+                "--upstream",
+                "npx",
+                "--upstream-arg=-y",
+                "--upstream-arg=@modelcontextprotocol/server-filesystem",
+                "--upstream-arg=THE_PATH_TO_YOUR_DIRECTORY",
+                "--db",
+                "audit.db",
+                "--agent-id",
+                "mcp-use-agent",
+            ],
+        }
+    }
+}
+
+
+async def main():
+    """Run the example with every tool call audited."""
+    # Load environment variables
+    load_dotenv()
+
+    # Create MCPClient from config
+    client = MCPClient.from_dict(config)
+    # Create LLM
+    llm = ChatOpenAI(model="gpt-5")
+
+    # Create agent with the client
+    agent = MCPAgent(llm=llm, client=client, max_steps=30, pretty_print=True)
+
+    # Run the query
+    result = await agent.run(
+        "Hello can you give me a list of files and directories in the current directory",
+        max_steps=30,
+    )
+    print(f"\nResult: {result}")
+
+    # Each tool call above is now a hash-chained sequence in audit.db:
+    # action_requested -> risk_scored -> decision_made -> outcome_recorded.
+    # Blocked calls come back as isError responses with the reason, and
+    # the block lands in the same chain. Summarise what the policy did
+    # (or would have done, with --shadow on the proxy) with:
+    #   vaara trail shadow-report --db audit.db
+
+
+if __name__ == "__main__":
+    # Run the appropriate example
+    asyncio.run(main())


### PR DESCRIPTION
Adds `libraries/python/examples/audited_filesystem_use.py`: the same filesystem agent as `filesystem_use.py`, with a governance proxy between the agent and the MCP server, so every tool call the agent makes is checked against a policy and written to a hash-chained audit trail before it reaches the server.

The point of the example is the pattern rather than the specific tool: the proxy is just another stdio entry in the `mcpServers` config, so it composes with mcp-use's own allowed/disallowed tool lists without any change to mcp_use or the upstream server. Useful for anyone who needs a record of what their agent actually did (incident review, compliance, or just debugging with receipts).

Uses Vaara (AGPL, `pip install vaara`) as the proxy; I maintain it. The wiring was tested against mcp-use 1.7.0: the client lists the upstream's 14 tools through the proxy and a governed `read_text_file` call produces the four chained audit records the comments describe. Happy to adjust the example (or drop the vendor mention down to a config comment) if you'd prefer a different shape.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an audited filesystem example that routes `mcp_use` tool calls through a governance proxy so every call is policy-checked and written to a tamper‑evident audit trail. The proxy is configured as a stdio entry in `mcpServers`, so it works with existing allow/deny lists without changing `mcp_use` or the upstream `@modelcontextprotocol/server-filesystem`.

- **New Features**
  - Adds `libraries/python/examples/audited_filesystem_use.py`.
  - Runs `@modelcontextprotocol/server-filesystem` via `npx` behind `vaara.integrations.mcp_proxy`.
  - Writes a hash-chained trail to `audit.db` for each call; blocked calls return errors with reasons.

- **Dependencies**
  - Optional: `vaara` (`pip install vaara`).

<sup>Written for commit dd5a99ece24a87967178ac682e58d845941e039d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1866?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

