### PR TITLE
fix(inspector): honor PORT env var in Docker image

### DIFF
--- a/libraries/typescript/packages/inspector/Dockerfile
+++ b/libraries/typescript/packages/inspector/Dockerfile
@@ -15,9 +15,11 @@ RUN npm install -g @mcp-use/inspector@${VERSION}
 # Set production environment
 ENV NODE_ENV=production
 
-# Expose 8080 (standard alternative HTTP port for production)
-# Note: The actual port is controlled by $PORT env var
+# Expose 8080 (standard alternative HTTP port for production).
+# The listen port honors the PORT environment variable (PaaS platforms like
+# Cloud Run, Railway, and Heroku inject it) and defaults to 8080.
 EXPOSE 8080
 
-# Start the inspector
-CMD ["npx", "@mcp-use/inspector", "--port", "8080"]
+# Start the inspector. Shell form so ${PORT:-8080} expands; exec keeps the
+# node process as PID 1 for signal handling.
+CMD ["sh", "-c", "exec npx @mcp-use/inspector --port ${PORT:-8080}"]

--- a/libraries/typescript/packages/inspector/Dockerfile
+++ b/libraries/typescript/packages/inspector/Dockerfile
@@ -22,4 +22,4 @@ EXPOSE 8080
 
 # Start the inspector. Shell form so ${PORT:-8080} expands; exec keeps the
 # node process as PID 1 for signal handling.
-CMD ["sh", "-c", "exec npx @mcp-use/inspector --port ${PORT:-8080}"]
+CMD ["sh", "-c", "exec npx @mcp-use/inspector --port \"${PORT:-8080}\""]


### PR DESCRIPTION
## Summary

Closes #1868

The inspector Dockerfile documented that the listen port was controlled by `$PORT`, but the exec-form `CMD` pinned `--port 8080` and the server only reads the `--port` flag — so platforms that inject `PORT` and route to it (Cloud Run, Railway, Heroku, Render) got a container listening on the wrong port.

- `CMD` is now shell-form with `${PORT:-8080}`, making the documented behavior true while keeping `8080` as the default.
- `exec` keeps the node process as PID 1 so signal handling (SIGTERM on platform scale-down) is unchanged.
- Comment updated to describe the actual contract.

## How did you test this change?

Built the image locally from this branch and ran the issue's reproduction:

```
$ docker run -d -e PORT=9999 inspector-port-test
  wget http://localhost:9999/inspector → 200 (exit 0)
  wget http://localhost:8080/inspector → connection refused
$ docker run -d inspector-port-test          # no PORT
  wget http://localhost:8080/inspector → 200 (exit 0)
$ cat /proc/1/comm → npm exec (node as PID 1, exec working)
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `@mcp-use/inspector` Docker image honor the `PORT` env var so PaaS platforms route to the correct port. Defaults to 8080 when `PORT` is not set.

- **Bug Fixes**
  - Run via `sh -c` with quoted `${PORT:-8080}` so `PORT` is honored and can’t inject flags.
  - Use `exec` to keep Node as PID 1 for proper SIGTERM handling.
  - Update Dockerfile comment to document the `PORT` contract and common PaaS behavior.

<sup>Written for commit 77a261fe0b073112386bac830024a7f7fa84da11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

