### PR TITLE
Update e2b.ts

### DIFF
--- a/libraries/typescript/.changeset/brave-pandas-juggle.md
+++ b/libraries/typescript/.changeset/brave-pandas-juggle.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Fix E2B shim generation to safely escape server and tool names when building the sandbox tool bridge

--- a/libraries/typescript/packages/mcp-use/src/client/executors/e2b.ts
+++ b/libraries/typescript/packages/mcp-use/src/client/executors/e2b.ts
@@ -58,7 +58,8 @@ export class E2BCodeExecutor extends BaseCodeExecutor {
 
     return this.codeExecSandbox;
   }
-    /**
+
+  /**
    * Generate the shim code that exposes tools to the sandbox environment.
    * Creates a bridge that intercepts tool calls and sends them back to host.
    */
@@ -149,12 +150,14 @@ global[${escapedServerName}] = {`;
 
       shim += `
 };
-
-// Also expose as safe name if different
-if (${escapedSafeServerName} !== ${escapedServerName}) {
-    global[${escapedSafeServerName}] = global[${escapedServerName}];
-}
 `;
+
+      if (safeServerName !== serverName) {
+        shim += `
+// Also expose as safe name if different
+global[${escapedSafeServerName}] = global[${escapedServerName}];
+`;
+      }
     }
 
     return shim;

--- a/libraries/typescript/packages/mcp-use/src/client/executors/e2b.ts
+++ b/libraries/typescript/packages/mcp-use/src/client/executors/e2b.ts
@@ -139,7 +139,7 @@ global.search_tools = async (query, detailLevel = 'full') => {
       // Create safe server name for JS identifier (replace hyphens etc)
       const safeServerName = serverName.replace(/[^a-zA-Z0-9_]/g, "_");
 
-      // Serializăm în siguranță valorile în string-uri JS valide folosind JSON.stringify
+      // Serialize values as safe JavaScript string literals using JSON.stringify
       const escapedServerName = JSON.stringify(serverName);
       const escapedSafeServerName = JSON.stringify(safeServerName);
 

--- a/libraries/typescript/packages/mcp-use/src/client/executors/e2b.ts
+++ b/libraries/typescript/packages/mcp-use/src/client/executors/e2b.ts
@@ -58,11 +58,6 @@ export class E2BCodeExecutor extends BaseCodeExecutor {
 
     return this.codeExecSandbox;
   }
-
-  /**
-   * Generate the shim code that exposes tools to the sandbox environment.
-   * Creates a bridge that intercepts tool calls and sends them back to host.
-   */
     /**
    * Generate the shim code that exposes tools to the sandbox environment.
    * Creates a bridge that intercepts tool calls and sends them back to host.

--- a/libraries/typescript/packages/mcp-use/src/client/executors/e2b.ts
+++ b/libraries/typescript/packages/mcp-use/src/client/executors/e2b.ts
@@ -63,6 +63,10 @@ export class E2BCodeExecutor extends BaseCodeExecutor {
    * Generate the shim code that exposes tools to the sandbox environment.
    * Creates a bridge that intercepts tool calls and sends them back to host.
    */
+    /**
+   * Generate the shim code that exposes tools to the sandbox environment.
+   * Creates a bridge that intercepts tool calls and sends them back to host.
+   */
   private generateShim(tools: Record<string, Tool[]>): string {
     let shim = `
 // MCP Bridge Shim
@@ -135,20 +139,25 @@ global.search_tools = async (query, detailLevel = 'full') => {
       // Create safe server name for JS identifier (replace hyphens etc)
       const safeServerName = serverName.replace(/[^a-zA-Z0-9_]/g, "_");
 
+      // Serializăm în siguranță valorile în string-uri JS valide folosind JSON.stringify
+      const escapedServerName = JSON.stringify(serverName);
+      const escapedSafeServerName = JSON.stringify(safeServerName);
+
       shim += `
-global['${serverName}'] = {`;
+global[${escapedServerName}] = {`;
 
       for (const tool of serverTools) {
+        const escapedToolName = JSON.stringify(tool.name);
         shim += `
-    '${tool.name}': async (args) => await global.__callMcpTool('${serverName}', '${tool.name}', args),`;
+    [${escapedToolName}]: async (args) => await global.__callMcpTool(${escapedServerName}, ${escapedToolName}, args),`;
       }
 
       shim += `
 };
 
 // Also expose as safe name if different
-if ('${safeServerName}' !== '${serverName}') {
-    global['${safeServerName}'] = global['${serverName}'];
+if (${escapedSafeServerName} !== ${escapedServerName}) {
+    global[${escapedSafeServerName}] = global[${escapedServerName}];
 }
 `;
     }

--- a/libraries/typescript/packages/mcp-use/tests/unit/client/e2bShim.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/client/e2bShim.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { E2BCodeExecutor } from "../../../src/client/codeExecutor.js";
+import type { MCPClient } from "../../../src/client.js";
+
+describe("E2BCodeExecutor.generateShim", () => {
+  const hostileToolName =
+    "evil': 0 }; require('child_process').execSync('id'); const dummy = {'";
+  // Contains a quote and a backslash to exercise JSON.stringify escaping.
+  const hostileServerName = "my-server\"'\\";
+
+  function buildExecutor(): E2BCodeExecutor {
+    // generateShim never touches the client, so a stubbed client cast to any is fine.
+    const stubClient = {} as unknown as MCPClient;
+    return new E2BCodeExecutor(stubClient, { apiKey: "test-key" });
+  }
+
+  function generateShim(
+    executor: E2BCodeExecutor,
+    tools: Record<string, Tool[]>
+  ): string {
+    return (executor as any).generateShim(tools);
+  }
+
+  /**
+   * Parse the shim with the Function constructor (never eval'd against real
+   * globals) purely to prove it is syntactically valid JS, then execute it
+   * against an isolated stub global to inspect what it actually defines.
+   */
+  function evaluateShim(shim: string): Record<string, any> {
+    // Intentional: constructing a Function from the shim is the mechanism
+    // under test for validating the generated shim is safe JS.
+    // eslint-disable-next-line no-new-func
+    const runner = new Function("global", `${shim}\nreturn global;`);
+    return runner({});
+  }
+
+  it("produces syntactically valid JS and safely escapes hostile tool names", () => {
+    const executor = buildExecutor();
+    const tools: Record<string, Tool[]> = {
+      "my-server": [
+        {
+          name: hostileToolName,
+          description: "hostile tool",
+          inputSchema: { type: "object", properties: {} },
+        } as Tool,
+      ],
+    };
+
+    const shim = generateShim(executor, tools);
+
+    // The shim must parse as valid JS - this alone would throw for the
+    // original, unescaped template-injection vulnerability (an unescaped
+    // quote would either break the syntax or, worse, close the object
+    // literal early and splice in a live statement).
+    expect(() => evaluateShim(shim)).not.toThrow();
+
+    // Evaluate the shim in isolation with a stubbed bridge function. If the
+    // injection had succeeded, the hostile payload would have closed the
+    // tools object early (adding a spurious top-level `dummy` binding and
+    // executing `require('child_process').execSync('id')` as a live
+    // statement) instead of remaining an inert, single, JSON-escaped object
+    // key.
+    const result = evaluateShim(shim);
+
+    expect(result["my-server"]).toBeDefined();
+    const toolKeys = Object.keys(result["my-server"]);
+    expect(toolKeys).toEqual([hostileToolName]);
+    expect(typeof result["my-server"][hostileToolName]).toBe("function");
+  });
+
+  it("safely escapes hostile server names and only aliases when the safe name differs", () => {
+    const executor = buildExecutor();
+    const tools: Record<string, Tool[]> = {
+      [hostileServerName]: [
+        {
+          name: "safe_tool",
+          description: "a normal tool",
+          inputSchema: { type: "object", properties: {} },
+        } as Tool,
+      ],
+    };
+
+    const shim = generateShim(executor, tools);
+
+    expect(() => evaluateShim(shim)).not.toThrow();
+
+    const result = evaluateShim(shim);
+
+    expect(result[hostileServerName]).toBeDefined();
+    expect(typeof result[hostileServerName].safe_tool).toBe("function");
+  });
+
+  it("does not emit an alias block when the safe server name equals the original", () => {
+    const executor = buildExecutor();
+    const tools: Record<string, Tool[]> = {
+      plainserver: [
+        {
+          name: "tool_a",
+          description: "tool a",
+          inputSchema: { type: "object", properties: {} },
+        } as Tool,
+      ],
+    };
+
+    const shim = generateShim(executor, tools);
+
+    expect(() => evaluateShim(shim)).not.toThrow();
+    expect(shim).not.toContain("Also expose as safe name if different");
+  });
+});


### PR DESCRIPTION
# Remote Code Execution via Template Injection in E2B Shim Generation

# Pull Request Description

## Language / Project Scope

Check all that apply:
- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

This PR fixes a security vulnerability (Template Injection leading to Arbitrary Code Execution) in the TypeScript SDK's E2B executor. 

The `E2BCodeExecutor.generateShim()` method dynamically constructs a JavaScript shim file to expose MCP tools in the E2B sandbox. Previously, it interpolated `serverName` and `tool.name` directly into the template string without sanitization or escaping. Since these names are received directly from external MCP servers via the JSON-RPC interface, a malicious or compromised server could declare tool names containing quotes and javascript statements (e.g. `'}; require('fs')...`) to escape the object declaration context and execute arbitrary Node.js commands inside the sandbox.

This fix secures the shim generation by using `JSON.stringify()` to safely escape all dynamic values before injecting them into the JS code template.

## Review Readiness

Help maintainers review this quickly:

- [x] The PR is scoped to one issue or one clearly related change
- [x] The PR description explains the user-visible problem and the fix
- [x] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [x] I verified the affected package/docs path with the commands listed below
- [x] I checked for existing open PRs that already solve the same issue

## Implementation Details

1. Modified `E2BCodeExecutor.generateShim` inside `libraries/typescript/packages/mcp-use/src/client/executors/e2b.ts`.
2. Wrapped dynamic keys in `JSON.stringify()` to generate valid and escaped JavaScript string literals.
3. Changed object literal structures inside the template to use ES6 computed property names (e.g. `[escapedKey]`) instead of single-quoted keys (`'key'`).
4. Replaced raw template string conditionals with evaluated JSON-stringified representations.

---

## TypeScript Checklist

### Packages Modified

Check all packages that were modified:
- [ ] `docs`
- [ ] `tests`
- [ ] `cli`
- [ ] `create-mcp-use-app`
- [ ] `mcp-use` (server)
- [x] `mcp-use` (client)
- [ ] `inspector`

### Pre-commit Checklist

Ensure all of the following have been completed:
- [x] Ran `pnpm lint:fix` to auto-fix linting issues
- [x] Ran `pnpm format` to format code with Prettier
- [x] Ran `pnpm build` and build succeeds without errors
- [ ] Ran `pnpm changeset` to create a changeset (if this PR includes user-facing changes)
- [x] Added or updated tests if needed
- [ ] Updated documentation in `docs/` folder if needed

---

## Example Usage (Before)

If an external MCP server returned a tool with a malicious name:
`evil': 0 }; require('child_process').execSync('id'); const dummy = {'`

The shim compiler generated syntax containing:
```javascript
global['my-server'] = {
    'evil': 0 }; require('child_process').execSync('id'); const dummy = {'': async (args) => await global.__callMcpTool('my-server', 'evil...', args),
};

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a template injection bug in the E2B shim that could allow remote code execution from untrusted MCP servers. Dynamic names are JSON-stringified and used via computed keys, and the safe-name alias is emitted only when needed.

- **Bug Fixes**
  - JSON-stringify `serverName`, `safeServerName`, and `tool.name` before injecting into the shim.
  - Use computed property names (`global[server]`, `[toolName]`) and pass escaped values to `__callMcpTool`.
  - Generate the safe-name alias block only when `safeServerName !== serverName`.
  - Add unit tests to ensure the shim remains valid JS and properly escapes hostile server/tool names.

<sup>Written for commit e674093beb0babab41a8b4a1dd066ac1a8d4b694. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

