### PR TITLE
fix(inspector): honor PORT env var in Docker and CLI startup

### DIFF
--- a/libraries/typescript/packages/inspector/Dockerfile
+++ b/libraries/typescript/packages/inspector/Dockerfile
@@ -19,5 +19,5 @@ ENV NODE_ENV=production
 # Note: The actual port is controlled by $PORT env var
 EXPOSE 8080
 
-# Start the inspector
-CMD ["npx", "@mcp-use/inspector", "--port", "8080"]
+# Start the inspector (--port omitted so $PORT is honored; defaults to 8080)
+CMD ["npx", "@mcp-use/inspector", "--no-open"]

--- a/libraries/typescript/packages/inspector/src/server/cli.ts
+++ b/libraries/typescript/packages/inspector/src/server/cli.ts
@@ -9,13 +9,20 @@ import { registerInspectorRoutes } from "./shared-routes.js";
 import type { InspectorMode } from "./shared-static.js";
 import { registerStaticRoutes } from "./shared-static.js";
 import { setServerPort } from "./tunnel.js";
-import { findAvailablePort, isValidUrl } from "./utils.js";
+import {
+  findAvailablePort,
+  isValidUrl,
+  resolveInspectorPort,
+} from "./utils.js";
 import { getInspectorVersion } from "./version.js";
 
 // Parse command line arguments
 const args = process.argv.slice(2);
 let mcpUrl: string | undefined;
-let startPort = 8080;
+let startPort = resolveInspectorPort({
+  cliPort: null,
+  defaultPort: 8080,
+});
 let noOpen = false;
 
 for (let i = 0; i < args.length; i++) {
@@ -60,7 +67,7 @@ Usage:
 
 Options:
   --url <url>    MCP server URL to auto-connect to (e.g., http://localhost:3000/mcp)
-  --port <port>  Starting port to try (default: 8080, will find next available)
+  --port <port>  Starting port to try (default: $PORT or 8080, will find next available)
   --no-open      Do not auto-open inspector in browser
   --version, -v  Show the inspector version
   --help, -h     Show this help message

--- a/libraries/typescript/packages/inspector/src/server/server.ts
+++ b/libraries/typescript/packages/inspector/src/server/server.ts
@@ -6,7 +6,12 @@ import open from "open";
 import { registerInspectorRoutes } from "./shared-routes.js";
 import { registerStaticRoutesWithDevProxy } from "./shared-static.js";
 import { setServerPort } from "./tunnel.js";
-import { isPortAvailable, parsePortFromArgs, hasNoOpenFlag } from "./utils.js";
+import {
+  isPortAvailable,
+  parsePortFromArgs,
+  hasNoOpenFlag,
+  resolveInspectorPort,
+} from "./utils.js";
 
 const app = new Hono();
 
@@ -92,9 +97,12 @@ async function startServer() {
     const isDev =
       process.env.NODE_ENV === "development" || process.env.VITE_DEV === "true";
 
-    // Check for port from command line arguments first
+    // Check for port from command line arguments first, then PORT env
     const cliPort = parsePortFromArgs();
-    let port = cliPort ?? (isDev ? 3001 : 3000);
+    let port = resolveInspectorPort({
+      cliPort,
+      defaultPort: isDev ? 3001 : 3000,
+    });
     const available = await isPortAvailable(port);
 
     if (!available) {

--- a/libraries/typescript/packages/inspector/src/server/utils.ts
+++ b/libraries/typescript/packages/inspector/src/server/utils.ts
@@ -54,6 +54,35 @@ export async function isPortAvailable(port: number): Promise<boolean> {
 }
 
 /**
+ * Parses a TCP port number from the `PORT` environment variable.
+ *
+ * @returns The parsed port number if valid, `null` if unset or invalid.
+ */
+export function parsePortFromEnv(): number | null {
+  const rawPort = process.env.PORT;
+  if (!rawPort) {
+    return null;
+  }
+
+  const portValue = Number.parseInt(rawPort, 10);
+  if (!Number.isNaN(portValue) && portValue >= 1 && portValue <= 65535) {
+    return portValue;
+  }
+
+  return null;
+}
+
+/**
+ * Resolves the inspector listen port with precedence: CLI `--port`, then `PORT` env.
+ */
+export function resolveInspectorPort(options: {
+  cliPort: number | null;
+  defaultPort: number;
+}): number {
+  return options.cliPort ?? parsePortFromEnv() ?? options.defaultPort;
+}
+
+/**
  * Parses a TCP port number from command-line arguments using the `--port` flag.
  *
  * If `--port` is present and followed by an integer between 1 and 65535, returns that port.

--- a/libraries/typescript/packages/inspector/tests/unit/server/port.test.ts
+++ b/libraries/typescript/packages/inspector/tests/unit/server/port.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  parsePortFromEnv,
+  resolveInspectorPort,
+} from "../../../src/server/utils.js";
+
+describe("parsePortFromEnv", () => {
+  const originalPort = process.env.PORT;
+
+  afterEach(() => {
+    if (originalPort === undefined) {
+      delete process.env.PORT;
+    } else {
+      process.env.PORT = originalPort;
+    }
+  });
+
+  it("returns null when PORT is unset", () => {
+    delete process.env.PORT;
+    expect(parsePortFromEnv()).toBeNull();
+  });
+
+  it("parses a valid PORT value", () => {
+    process.env.PORT = "9999";
+    expect(parsePortFromEnv()).toBe(9999);
+  });
+
+  it("rejects invalid PORT values", () => {
+    process.env.PORT = "not-a-port";
+    expect(parsePortFromEnv()).toBeNull();
+
+    process.env.PORT = "0";
+    expect(parsePortFromEnv()).toBeNull();
+  });
+});
+
+describe("resolveInspectorPort", () => {
+  const originalPort = process.env.PORT;
+
+  afterEach(() => {
+    if (originalPort === undefined) {
+      delete process.env.PORT;
+    } else {
+      process.env.PORT = originalPort;
+    }
+  });
+
+  it("prefers CLI port over PORT env and default", () => {
+    process.env.PORT = "9000";
+    expect(
+      resolveInspectorPort({
+        cliPort: 7000,
+        defaultPort: 8080,
+      })
+    ).toBe(7000);
+  });
+
+  it("falls back to PORT env when CLI port is absent", () => {
+    process.env.PORT = "9000";
+    expect(
+      resolveInspectorPort({
+        cliPort: null,
+        defaultPort: 8080,
+      })
+    ).toBe(9000);
+  });
+
+  it("falls back to default when neither CLI nor PORT is set", () => {
+    delete process.env.PORT;
+    expect(
+      resolveInspectorPort({
+        cliPort: null,
+        defaultPort: 8080,
+      })
+    ).toBe(8080);
+  });
+});


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

Check all that apply:
- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

Honor the `PORT` environment variable when starting the MCP Inspector in Docker and via the CLI, matching the existing Dockerfile comment and README documentation.

## Review Readiness

- [x] The PR is scoped to one issue or one clearly related change
- [x] The PR description explains the user-visible problem and the fix
- [x] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [x] I verified the affected package/docs path with the commands listed below
- [x] I checked for existing open PRs that already solve the same issue

## Implementation Details

1. Added `parsePortFromEnv()` and `resolveInspectorPort()` in `src/server/utils.ts` with precedence: CLI `--port` > `PORT` env > default.
2. Updated `cli.ts` (Docker/production entrypoint) to resolve port from env instead of hardcoded 8080.
3. Updated `server.ts` for consistency on the dev server entry path.
4. Changed Dockerfile `CMD` to omit hardcoded `--port 8080` and add `--no-open` for headless containers.
5. Added unit tests for port resolution precedence.

---

## TypeScript Checklist

### Packages Modified
- [x] `inspector`

### Pre-commit Checklist
- [x] Ran `pnpm lint:fix` to auto-fix linting issues (eslint on changed files — clean)
- [ ] Ran `pnpm format` to format code with Prettier
- [ ] Ran `pnpm build` and build succeeds without errors
- [ ] Ran `pnpm changeset` to create a changeset (if this PR includes user-facing changes)
- [x] Added or updated tests if needed
- [ ] Updated documentation in `docs/` folder if needed

---

## Example Usage (Before)

```bash
docker run -e PORT=9999 mcpuse/inspector:latest
# Still listened on 8080; PORT ignored
```

## Example Usage (After)

```bash
docker run -e PORT=9999 mcpuse/inspector:latest
# Listens on 9999 (or next available port if busy)
```

## Testing

- `pnpm --filter @mcp-use/inspector test:unit` — 66/66 passed (includes 6 new port resolution tests)
- `pnpm exec eslint` on changed files — clean

## Backwards Compatibility

Fully backwards compatible. Default port remains 8080 when `PORT` is unset. Explicit `--port` still takes precedence.

## Related Issues

Closes #1868
