### PR TITLE
feat(inspector): add MiniMax image-capable provider

### DIFF
--- a/libraries/typescript/.changeset/bright-images-flow.md
+++ b/libraries/typescript/.changeset/bright-images-flow.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": minor
+---
+
+Add MiniMax chat configuration with global and China endpoint presets and image tool result support for MiniMax-M3.

--- a/libraries/typescript/packages/inspector/README.md
+++ b/libraries/typescript/packages/inspector/README.md
@@ -237,12 +237,14 @@ The Chat tab provides an interactive interface to test the MCP server with an LL
 **Setup:**
 
 1. Click **"Configure API Key"** to open the configuration modal
-2. Select your **Provider** (OpenAI, Anthropic, Google, or Ollama)
+2. Select your **Provider** (OpenAI, Anthropic, Google, MiniMax, or Ollama)
 3. Choose the **Model** (gpt-4o, claude-3-5-sonnet, etc.)
 4. Enter your **API Key** (stored locally in browser)
 5. Click **"Save Configuration"**
 
 For **Ollama**, the API key is optional and you can point the inspector at a local or remote Ollama host by setting the **Base URL** (defaults to `http://localhost:11434`).
+
+For **MiniMax**, choose `MiniMax-M3` to send image attachments and image tool results to the model, then select the global or China endpoint for the compatible protocol you use. See the [global API reference](https://platform.minimax.io/docs/api-reference/api-overview) or [China API reference](https://platform.minimaxi.com/docs/api-reference/api-overview) for account-specific setup.
 
 **Using Chat:**
 

--- a/libraries/typescript/packages/inspector/src/client/components/chat/ConfigurationDialog.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/ConfigurationDialog.tsx
@@ -33,8 +33,10 @@ import {
 } from "@/client/components/ui/select";
 
 import { cn } from "@/client/lib/utils";
+import { MINIMAX_ENDPOINTS, MINIMAX_MODELS } from "@/llm/providers/minimax";
 import type { ProviderName } from "@/llm/types";
 import {
+  DEFAULT_MODELS,
   getDefaultBaseUrl,
   providerRequiresApiKey,
   providerSupportsBaseUrl,
@@ -352,6 +354,8 @@ export function ConfigurationDialog({
           fetchedModels = await fetchAnthropicModels(tempApiKey);
         } else if (tempProvider === "google") {
           fetchedModels = await fetchGoogleModels(tempApiKey);
+        } else if (tempProvider === "minimax") {
+          fetchedModels = MINIMAX_MODELS.map((id) => ({ id }));
         } else if (tempProvider === "openrouter") {
           fetchedModels = await fetchOpenRouterModels(tempApiKey);
         } else if (tempProvider === "ollama") {
@@ -381,7 +385,7 @@ export function ConfigurationDialog({
   // Reset model when provider changes
   useEffect(() => {
     if (open) {
-      onModelChange("");
+      onModelChange(tempProvider === "minimax" ? DEFAULT_MODELS.minimax : "");
     }
   }, [tempProvider, open, onModelChange]);
 
@@ -402,9 +406,11 @@ export function ConfigurationDialog({
       ? "http://localhost:11434/v1"
       : getDefaultBaseUrl(tempProvider);
   const baseUrlHelp =
-    tempProvider === "openai-compatible"
-      ? "Base URL of your OpenAI-compatible API. Local servers must have CORS enabled."
-      : null;
+    tempProvider === "minimax"
+      ? "Choose a global or China endpoint and compatible protocol."
+      : tempProvider === "openai-compatible"
+        ? "Base URL of your OpenAI-compatible API. Local servers must have CORS enabled."
+        : null;
   const apiKeyHelp =
     tempProvider === "ollama"
       ? "Optional for local Ollama. Stored locally and never sent to our servers."
@@ -474,6 +480,12 @@ export function ConfigurationDialog({
                     <span>{getProviderLabel("google")}</span>
                   </div>
                 </SelectItem>
+                <SelectItem value="minimax">
+                  <div className="flex items-center gap-2">
+                    <ProviderIcon provider="minimax" />
+                    <span>{getProviderLabel("minimax")}</span>
+                  </div>
+                </SelectItem>
                 <SelectItem value="ollama">
                   <div className="flex items-center gap-2">
                     <ProviderIcon provider="ollama" />
@@ -497,13 +509,30 @@ export function ConfigurationDialog({
 
           {showBaseUrlField && (
             <div className="space-y-2">
-              <Label>Base URL</Label>
-              <Input
-                value={tempBaseUrl}
-                onChange={(e) => onBaseUrlChange(e.target.value)}
-                placeholder={baseUrlPlaceholder}
-                data-testid="chat-config-base-url-input"
-              />
+              <Label>
+                {tempProvider === "minimax" ? "Endpoint" : "Base URL"}
+              </Label>
+              {tempProvider === "minimax" ? (
+                <Select value={tempBaseUrl} onValueChange={onBaseUrlChange}>
+                  <SelectTrigger data-testid="chat-config-base-url-select">
+                    <SelectValue placeholder="Select an endpoint" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {MINIMAX_ENDPOINTS.map((endpoint) => (
+                      <SelectItem key={endpoint.id} value={endpoint.baseUrl}>
+                        {endpoint.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              ) : (
+                <Input
+                  value={tempBaseUrl}
+                  onChange={(e) => onBaseUrlChange(e.target.value)}
+                  placeholder={baseUrlPlaceholder}
+                  data-testid="chat-config-base-url-input"
+                />
+              )}
               {baseUrlHelp && (
                 <p className="text-xs text-muted-foreground">{baseUrlHelp}</p>
               )}

--- a/libraries/typescript/packages/inspector/src/client/components/chat/providerMeta.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/providerMeta.tsx
@@ -17,6 +17,8 @@ export function getProviderLabel(provider: ProviderName): string {
       return "Anthropic";
     case "google":
       return "Google";
+    case "minimax":
+      return "MiniMax";
     case "openrouter":
       return "OpenRouter";
     case "ollama":

--- a/libraries/typescript/packages/inspector/src/client/components/chat/types.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/types.ts
@@ -1,4 +1,8 @@
 import { DEFAULT_OLLAMA_BASE_URL } from "@/llm/providers/ollama/utils";
+import {
+  DEFAULT_MINIMAX_BASE_URL,
+  MINIMAX_MODELS,
+} from "@/llm/providers/minimax";
 import type { ProviderName } from "@/llm/types";
 
 export interface MessageAttachment {
@@ -77,11 +81,13 @@ export const DEFAULT_MODELS: Record<ProviderName, string> = {
   "openai-compatible": "",
   anthropic: "claude-haiku-4-5-20251001",
   google: "gemini-2.5-flash",
+  minimax: MINIMAX_MODELS[0],
   openrouter: "meta-llama/llama-3.1-8b-instruct:free",
   ollama: "qwen3",
 };
 
 const DEFAULT_BASE_URLS: Partial<Record<ProviderName, string>> = {
+  minimax: DEFAULT_MINIMAX_BASE_URL,
   ollama: DEFAULT_OLLAMA_BASE_URL,
 };
 
@@ -90,7 +96,11 @@ export function providerRequiresApiKey(provider: ProviderName): boolean {
 }
 
 export function providerSupportsBaseUrl(provider: ProviderName): boolean {
-  return provider === "ollama" || provider === "openai-compatible";
+  return (
+    provider === "minimax" ||
+    provider === "ollama" ||
+    provider === "openai-compatible"
+  );
 }
 
 export function getDefaultBaseUrl(provider: ProviderName): string {

--- a/libraries/typescript/packages/inspector/src/llm/__tests__/minimax.test.ts
+++ b/libraries/typescript/packages/inspector/src/llm/__tests__/minimax.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { chat, MINIMAX_ENDPOINTS, MINIMAX_MODELS } from "../providers/minimax";
+import type { ProviderMessage } from "../types";
+
+const imageToolMessages: ProviderMessage[] = [
+  { role: "user", content: "Create an image." },
+  {
+    role: "assistant",
+    content: "",
+    toolCalls: [{ id: "call_1", name: "generate-image", args: {} }],
+  },
+  {
+    role: "tool",
+    content: [
+      {
+        type: "image",
+        data: "AAAA",
+        mimeType: "image/png",
+        url: "data:image/png;base64,AAAA",
+      },
+    ],
+    toolCallId: "call_1",
+    toolName: "generate-image",
+  },
+];
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("MiniMax provider", () => {
+  it("exposes the configured model IDs and public endpoint presets", () => {
+    expect(MINIMAX_MODELS).toEqual(["MiniMax-M3", "MiniMax-M2.7"]);
+    expect(MINIMAX_ENDPOINTS.map((endpoint) => endpoint.region)).toEqual([
+      "global_en",
+      "cn_zh",
+      "global_en",
+      "cn_zh",
+    ]);
+    expect(MINIMAX_ENDPOINTS.map((endpoint) => endpoint.baseUrl)).toEqual([
+      "https://api.minimax.io/v1",
+      "https://api.minimaxi.com/v1",
+      "https://api.minimax.io/anthropic",
+      "https://api.minimaxi.com/anthropic",
+    ]);
+    expect(
+      MINIMAX_ENDPOINTS.filter(
+        (endpoint) => endpoint.protocol === "anthropic"
+      ).every((endpoint) => endpoint.baseUrl.endsWith("/anthropic"))
+    ).toBe(true);
+  });
+
+  for (const endpoint of MINIMAX_ENDPOINTS) {
+    it(`sends image tool results through ${endpoint.label}`, async () => {
+      const responseBody =
+        endpoint.protocol === "anthropic"
+          ? { content: [{ type: "text", text: "ok" }] }
+          : { choices: [{ message: { content: "ok" } }] };
+      const fetchMock = vi.fn(
+        async (_input: RequestInfo | URL, _init?: RequestInit) =>
+          new Response(JSON.stringify(responseBody), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      await chat({
+        config: {
+          provider: "minimax",
+          model: MINIMAX_MODELS[0],
+          apiKey: "test-key",
+          baseUrl: endpoint.baseUrl,
+        },
+        messages: imageToolMessages,
+      });
+
+      expect(fetchMock).toHaveBeenCalledOnce();
+      const [url, init] = fetchMock.mock.calls[0];
+      const expectedPath =
+        endpoint.protocol === "anthropic"
+          ? "/v1/messages"
+          : "/chat/completions";
+      expect(url).toBe(`${endpoint.baseUrl}${expectedPath}`);
+      expect(init?.method).toBe("POST");
+      expect(init?.headers).toMatchObject({
+        Authorization: "Bearer test-key",
+      });
+
+      const body = JSON.parse(String(init?.body));
+      if (endpoint.protocol === "anthropic") {
+        const toolResult = body.messages
+          .flatMap((message: { content?: unknown[] }) => message.content ?? [])
+          .find((block: { type?: string }) => block.type === "tool_result");
+        expect(toolResult.content).toContainEqual({
+          type: "image",
+          source: {
+            type: "base64",
+            media_type: "image/png",
+            data: "AAAA",
+          },
+        });
+      } else {
+        const imagePart = body.messages
+          .flatMap((message: { content?: unknown[] }) =>
+            Array.isArray(message.content) ? message.content : []
+          )
+          .find((part: { type?: string }) => part.type === "image_url");
+        expect(imagePart).toEqual({
+          type: "image_url",
+          image_url: { url: "data:image/png;base64,AAAA" },
+        });
+      }
+    });
+  }
+});

--- a/libraries/typescript/packages/inspector/src/llm/providers/anthropic.ts
+++ b/libraries/typescript/packages/inspector/src/llm/providers/anthropic.ts
@@ -19,6 +19,31 @@ const DEFAULT_ENDPOINT = "https://api.anthropic.com/v1/messages";
 const ANTHROPIC_VERSION = "2023-06-01";
 const DEFAULT_MAX_TOKENS = 4096;
 
+function buildEndpoint(config: ProviderConfig): string {
+  if (!config.baseUrl) return DEFAULT_ENDPOINT;
+  const baseUrl = config.baseUrl.endsWith("/")
+    ? config.baseUrl.slice(0, -1)
+    : config.baseUrl;
+  return `${baseUrl}/v1/messages`;
+}
+
+function buildHeaders(config: ProviderConfig): Record<string, string> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "anthropic-version": ANTHROPIC_VERSION,
+    "anthropic-dangerous-direct-browser-access": "true",
+    ...config.extraHeaders,
+  };
+  if (!headers.Authorization && !headers["x-api-key"] && config.apiKey) {
+    headers["x-api-key"] = config.apiKey;
+  }
+  return headers;
+}
+
+function getRequestLabel(config: ProviderConfig): string {
+  return config.provider === "minimax" ? "MiniMax" : "Anthropic";
+}
+
 function buildImageBlock(p: ContentPart) {
   if (p.type !== "image") return null;
   if (p.data && p.mimeType) {
@@ -154,21 +179,16 @@ export async function* streamChat(
   params: ChatParams
 ): AsyncGenerator<LlmStreamEvent, void, unknown> {
   const { config, signal } = params;
-  const res = await fetch(DEFAULT_ENDPOINT, {
+  const res = await fetch(buildEndpoint(config), {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "x-api-key": config.apiKey,
-      "anthropic-version": ANTHROPIC_VERSION,
-      "anthropic-dangerous-direct-browser-access": "true",
-    },
+    headers: buildHeaders(config),
     body: JSON.stringify(buildBody(params, true)),
     signal,
   });
   if (!res.ok || !res.body) {
     const text = await res.text().catch(() => "");
     throw new Error(
-      `Anthropic request failed (${res.status} ${res.statusText}): ${text}`
+      `${getRequestLabel(config)} request failed (${res.status} ${res.statusText}): ${text}`
     );
   }
 
@@ -276,21 +296,16 @@ export async function chat(params: ChatParams): Promise<{
   toolCalls: { id: string; name: string; args: Record<string, unknown> }[];
 }> {
   const { config, signal } = params;
-  const res = await fetch(DEFAULT_ENDPOINT, {
+  const res = await fetch(buildEndpoint(config), {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "x-api-key": config.apiKey,
-      "anthropic-version": ANTHROPIC_VERSION,
-      "anthropic-dangerous-direct-browser-access": "true",
-    },
+    headers: buildHeaders(config),
     body: JSON.stringify(buildBody(params, false)),
     signal,
   });
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(
-      `Anthropic request failed (${res.status} ${res.statusText}): ${text}`
+      `${getRequestLabel(config)} request failed (${res.status} ${res.statusText}): ${text}`
     );
   }
   const json = await res.json();

--- a/libraries/typescript/packages/inspector/src/llm/providers/index.ts
+++ b/libraries/typescript/packages/inspector/src/llm/providers/index.ts
@@ -6,6 +6,7 @@ import type {
 } from "../types";
 import * as anthropic from "./anthropic";
 import * as google from "./google";
+import * as minimax from "./minimax";
 import * as ollama from "./ollama";
 import * as openai from "./openai";
 
@@ -47,6 +48,8 @@ export function streamChat(
       return anthropic.streamChat(params);
     case "google":
       return google.streamChat(params);
+    case "minimax":
+      return minimax.streamChat(params);
     case "openrouter":
       return openai.streamChat(withOpenRouter(params));
     case "ollama":
@@ -65,6 +68,8 @@ export function chat(params: ChatParams): Promise<ChatResult> {
       return anthropic.chat(params);
     case "google":
       return google.chat(params);
+    case "minimax":
+      return minimax.chat(params);
     case "openrouter":
       return openai.chat(withOpenRouter(params));
     case "ollama":

--- a/libraries/typescript/packages/inspector/src/llm/providers/minimax.ts
+++ b/libraries/typescript/packages/inspector/src/llm/providers/minimax.ts
@@ -1,0 +1,93 @@
+import type {
+  LlmStreamEvent,
+  ProviderConfig,
+  ProviderMessage,
+  ProviderTool,
+} from "../types";
+import * as anthropic from "./anthropic";
+import * as openai from "./openai";
+
+interface ChatParams {
+  config: ProviderConfig;
+  messages: ProviderMessage[];
+  tools?: ProviderTool[];
+  signal?: AbortSignal;
+}
+
+interface ChatResult {
+  text: string;
+  toolCalls: { id: string; name: string; args: Record<string, unknown> }[];
+}
+
+export const MINIMAX_MODELS = ["MiniMax-M3", "MiniMax-M2.7"] as const;
+
+export const MINIMAX_ENDPOINTS = [
+  {
+    id: "global_en-openai",
+    region: "global_en",
+    label: "Global (OpenAI-compatible)",
+    baseUrl: "https://api.minimax.io/v1",
+    protocol: "openai",
+  },
+  {
+    id: "cn_zh-openai",
+    region: "cn_zh",
+    label: "China (OpenAI-compatible)",
+    baseUrl: "https://api.minimaxi.com/v1",
+    protocol: "openai",
+  },
+  {
+    id: "global_en-anthropic",
+    region: "global_en",
+    label: "Global (Anthropic-compatible)",
+    baseUrl: "https://api.minimax.io/anthropic",
+    protocol: "anthropic",
+  },
+  {
+    id: "cn_zh-anthropic",
+    region: "cn_zh",
+    label: "China (Anthropic-compatible)",
+    baseUrl: "https://api.minimaxi.com/anthropic",
+    protocol: "anthropic",
+  },
+] as const;
+
+export const DEFAULT_MINIMAX_BASE_URL = MINIMAX_ENDPOINTS[0].baseUrl;
+
+function usesAnthropicProtocol(baseUrl?: string): boolean {
+  if (!baseUrl) return false;
+  const endpoint = MINIMAX_ENDPOINTS.find(
+    (candidate) => candidate.baseUrl === baseUrl
+  );
+  return endpoint?.protocol === "anthropic" || baseUrl.endsWith("/anthropic");
+}
+
+function withBearerAuth(params: ChatParams): ChatParams {
+  if (!params.config.apiKey) return params;
+  return {
+    ...params,
+    config: {
+      ...params.config,
+      extraHeaders: {
+        ...params.config.extraHeaders,
+        Authorization: `Bearer ${params.config.apiKey}`,
+      },
+    },
+  };
+}
+
+export function streamChat(
+  params: ChatParams
+): AsyncGenerator<LlmStreamEvent, void, unknown> {
+  const configured = withBearerAuth(params);
+  return usesAnthropicProtocol(configured.config.baseUrl)
+    ? anthropic.streamChat(configured)
+    : openai.streamChat(configured);
+}
+
+export function chat(params: ChatParams): Promise<ChatResult> {
+  const configured = withBearerAuth(params);
+  return usesAnthropicProtocol(configured.config.baseUrl)
+    ? anthropic.chat(configured)
+    : openai.chat(configured);
+}

--- a/libraries/typescript/packages/inspector/src/llm/providers/openai.ts
+++ b/libraries/typescript/packages/inspector/src/llm/providers/openai.ts
@@ -35,6 +35,10 @@ function buildHeaders(config: ProviderConfig): Record<string, string> {
   return headers;
 }
 
+function getRequestLabel(config: ProviderConfig): string {
+  return config.provider === "minimax" ? "MiniMax" : "OpenAI";
+}
+
 function toOpenAIContent(content: string | ContentPart[]): unknown {
   if (typeof content === "string") return content;
   return content.map((p) => {
@@ -130,7 +134,7 @@ export async function* streamChat(
   if (!res.ok || !res.body) {
     const text = await res.text().catch(() => "");
     throw new Error(
-      `OpenAI request failed (${res.status} ${res.statusText}): ${text}`
+      `${getRequestLabel(config)} request failed (${res.status} ${res.statusText}): ${text}`
     );
   }
 
@@ -250,7 +254,7 @@ export async function chat(params: ChatParams): Promise<{
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(
-      `OpenAI request failed (${res.status} ${res.statusText}): ${text}`
+      `${getRequestLabel(config)} request failed (${res.status} ${res.statusText}): ${text}`
     );
   }
   const json = await res.json();

--- a/libraries/typescript/packages/inspector/src/llm/types.ts
+++ b/libraries/typescript/packages/inspector/src/llm/types.ts
@@ -13,6 +13,7 @@ export type ProviderName =
   | "openai-compatible"
   | "anthropic"
   | "google"
+  | "minimax"
   | "openrouter"
   | "ollama";
 


### PR DESCRIPTION
Reason: add target image capability using existing tool/provider pattern

## Changes

- Add MiniMax to the inspector chat provider configuration.
- Include MiniMax-M3 and MiniMax-M2.7 model choices.
- Expose global and China endpoint presets for both supported compatible API protocols.
- Forward image attachments and image tool results through the existing multimodal request path.
- Document the configuration and add request-capture coverage for every endpoint preset.

## Testing

- `pnpm --filter mcp-use build`
- `pnpm --filter @mcp-use/inspector test:unit`
- `pnpm --filter @mcp-use/inspector type-check`
- `pnpm --filter @mcp-use/inspector lint`
- `pnpm --filter @mcp-use/inspector build`
- `pnpm changeset status`

## Backwards Compatibility

This change is additive and keeps existing provider configurations unchanged.
