### PR TITLE
Add token-count badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@
         <img src="https://img.shields.io/npm/v/mcp-use.svg"/></a>
     <a href="https://www.npmjs.com/package/mcp-use" alt="NPM Downloads">
         <img src="https://img.shields.io/npm/dw/mcp-use.svg"/></a>
+    <a href="https://gittokens.rsamf.com/badge/mcp-use/mcp-use" alt="Tokens">
+        <img src="https://img.shields.io/endpoint?url=https://gittokens.rsamf.com/badge/mcp-use/mcp-use" /></a>
     <br/>
 </p>
 </div>


### PR DESCRIPTION
Hi! This PR adds one line to the README: a badge showing an estimate of how many LLM tokens this repo weighs. Since this project is the kind of thing people load into an LLM's context window, the number seemed genuinely useful to surface.

Preview: ![tokens](https://img.shields.io/endpoint?url=https://gittokens.rsamf.com/badge/mcp-use/mcp-use)

Full disclosure: I built the free, open-source service behind the badge (https://github.com/rsamf/gittokens), and I'm proposing it to a small, hand-picked set of repos where it seems like a good fit. If it isn't a fit here, please just close this, and I won't resubmit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a token-count badge to the README to display an estimate of the repo’s LLM token size, helping users quickly tell if `mcp-use` fits in a context window.
The badge uses a live Shields.io endpoint and updates automatically.

<sup>Written for commit 778d845c6d2e6f2a620f6b61bfd1c1877c64b695. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

