### PR TITLE
fix(typescript): remove leftover resourceCallbacks debug log

### DIFF
--- a/.changeset/brown-poets-clean.md
+++ b/.changeset/brown-poets-clean.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Remove a leftover debug `console.log` that printed `resourceCallbacks undefined` on every resource template registration

--- a/libraries/typescript/packages/mcp-use/src/server/resources/index.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/resources/index.ts
@@ -358,8 +358,6 @@ export function registerResourceTemplate(
           | ResourceTemplateDefinitionWithoutCallback
       ).resourceTemplate.callbacks;
 
-  console.log("resourceCallbacks", resourceCallbacks);
-
   // Create ResourceTemplate instance from SDK
   const template = new ResourceTemplate(uriTemplate, {
     complete: toResourceTemplateCompleteCallbacks(resourceCallbacks?.complete), // Optional: callback for auto-completion


### PR DESCRIPTION
## Description

Removes a leftover debug `console.log("resourceCallbacks", resourceCallbacks)` in `packages/mcp-use/src/server/resources/index.ts`. It prints a bare `resourceCallbacks undefined` line on **every resource template registration** — with MCP Apps widgets that's every dev boot and every HMR reload.

Beyond noise, it has real cost: in #1875 the reporter flagged this exact line as a suspect while debugging an unrelated problem ("The `resourceCallbacks undefined` looks a bit suspect in case that is related") — stray internal dumps send people chasing ghosts.

The line dates to the completion-callbacks work (#966, landed via #970); the value is still used immediately below when constructing the `ResourceTemplate`, so removing the log changes no behavior.

## Evidence

Before (any project with a widget, `npx mcp-use dev`):

```
[WIDGET] multiple-choice-drill mounted at /mcp-use/widgets/multiple-choice-drill
resourceCallbacks undefined
[MCP] Server mounted at /mcp and /sse (stateless mode)
```

After: line gone; `pnpm --filter mcp-use build` clean, unit suite green (474 passed / 2 skipped — excluding `tests/unit/auth/browser-provider-*`, which fail identically on untouched `main`, unrelated to this change).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added a changeset (patch, `mcp-use`)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove leftover debug `console.log` in `mcp-use` ResourceTemplate registration to stop noisy "resourceCallbacks undefined" output on every registration and dev reload. No behavior change; reduces console noise and avoids misleading debugging signals.

<sup>Written for commit 49586893204b7ca178989b9d5923829a9ddf0827. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

