### PR TITLE
feat(server): add v2 elicitation support

### DIFF
--- a/libraries/typescript/packages/server/examples/conformance/src/index.ts
+++ b/libraries/typescript/packages/server/examples/conformance/src/index.ts
@@ -247,26 +247,26 @@ server.tool(
     description: "A tool that uses elicitation to get user input",
   },
   async (_input, ctx) => {
-    const form = await ctx.input.form({
-      key: "elicitation",
-      message: "Please provide your information",
-      schema: z.object({
+    const form = await ctx.elicit(
+      "elicitation",
+      "Please provide your information",
+      z.object({
         name: z.string().default("Anonymous"),
         age: z.number().default(0),
-      }),
-    });
+      })
+    );
     if (form.status === "required") return form.result;
-    if (form.status === "accepted") {
+    if (form.status === "accept") {
       return {
         content: [
           {
             type: "text",
-            text: `Received: ${form.value.name}, age ${form.value.age}`,
+            text: `Received: ${form.data.name}, age ${form.data.age}`,
           },
         ],
       };
     }
-    if (form.status === "declined") {
+    if (form.status === "decline") {
       return { content: [{ type: "text", text: "User declined" }] };
     }
     return { content: [{ type: "text", text: "Operation cancelled" }] };
@@ -280,29 +280,29 @@ server.tool(
       "A tool that uses elicitation with default values for all primitive types (SEP-1034)",
   },
   async (_input, ctx) => {
-    const form = await ctx.input.form({
-      key: "elicitation-sep1034",
-      message: "Please provide your information",
-      schema: z.object({
+    const form = await ctx.elicit(
+      "elicitation-sep1034",
+      "Please provide your information",
+      z.object({
         name: z.string().default("John Doe"),
         age: z.number().int().default(30),
         score: z.number().default(95.5),
         status: z.enum(["active", "inactive", "pending"]).default("active"),
         verified: z.boolean().default(true),
-      }),
-    });
+      })
+    );
     if (form.status === "required") return form.result;
-    if (form.status === "accepted") {
+    if (form.status === "accept") {
       return {
         content: [
           {
             type: "text",
-            text: `Elicitation completed: action=accept, content=${JSON.stringify(form.value)}`,
+            text: `Elicitation completed: action=accept, content=${JSON.stringify(form.data)}`,
           },
         ],
       };
     }
-    if (form.status === "declined") {
+    if (form.status === "decline") {
       return {
         content: [
           { type: "text", text: "Elicitation completed: action=decline" },
@@ -323,29 +323,29 @@ server.tool(
   },
   async (_input, ctx) => {
     // ponytail: z.enum stand-ins for v1 enumSchema variants; titles/names not preserved
-    const form = await ctx.input.form({
-      key: "elicitation-sep1330",
-      message: "Please choose your options",
-      schema: z.object({
+    const form = await ctx.elicit(
+      "elicitation-sep1330",
+      "Please choose your options",
+      z.object({
         untitledSingle: z.enum(["option1", "option2", "option3"]),
         titledSingle: z.enum(["value1", "value2", "value3"]),
         legacyEnum: z.enum(["opt1", "opt2", "opt3"]),
         untitledMulti: z.array(z.enum(["option1", "option2", "option3"])),
         titledMulti: z.array(z.enum(["value1", "value2", "value3"])),
-      }),
-    });
+      })
+    );
     if (form.status === "required") return form.result;
-    if (form.status === "accepted") {
+    if (form.status === "accept") {
       return {
         content: [
           {
             type: "text",
-            text: `Elicitation completed: action=accept, content=${JSON.stringify(form.value)}`,
+            text: `Elicitation completed: action=accept, content=${JSON.stringify(form.data)}`,
           },
         ],
       };
     }
-    if (form.status === "declined") {
+    if (form.status === "decline") {
       return {
         content: [
           { type: "text", text: "Elicitation completed: action=decline" },

--- a/libraries/typescript/packages/server/examples/elicitation/README.md
+++ b/libraries/typescript/packages/server/examples/elicitation/README.md
@@ -1,0 +1,94 @@
+# Elicitation example
+
+A small `mcp-use` project demonstrating both MCP elicitation modes:
+
+- `deploy` requests typed, structured confirmation through form elicitation.
+- `connect-service` asks the client to open an external authorization URL.
+
+Both are ordinary tools. When input is missing, `ctx.elicit` produces an
+`input_required` tool result. A capable client collects the input and retries
+the original call; on that invocation, the same helper returns the response.
+
+## Form elicitation
+
+Pass a stable correlation key, the user-facing message, and a Standard Schema:
+
+```ts
+const confirmation = await ctx.elicit(
+  "deployment-approval",
+  `Deploy to ${environment}?`,
+  z.object({
+    approve: z.boolean(),
+    note: z.string().optional(),
+  })
+);
+
+if (confirmation.status === "required") {
+  return confirmation.result;
+}
+
+if (confirmation.status !== "accept" || !confirmation.data.approve) {
+  return {
+    content: [{ type: "text", text: "Deployment not approved." }],
+    isError: true,
+  };
+}
+
+// Perform the deployment here, after accepted input is available.
+```
+
+The accepted `data` type is inferred from the schema. Accepted content is also
+validated against it; invalid client data results in another `input_required`
+round instead of reaching the side effect.
+
+The key (`deployment-approval` above) must remain stable across retries. It
+correlates the embedded request with its response. Advanced tools that need
+several sequential rounds should also carry their current step in verified
+`requestState`.
+
+## URL elicitation
+
+Pass a URL string instead of a schema:
+
+```ts
+const authorization = await ctx.elicit(
+  "service-authorization",
+  "Authorize access to GitHub",
+  authorizationUrl
+);
+
+if (authorization.status === "required") {
+  return authorization.result;
+}
+
+if (authorization.status !== "accept") {
+  return {
+    content: [{ type: "text", text: "Authorization cancelled." }],
+    isError: true,
+  };
+}
+```
+
+Use URL mode for authentication, credentials, payment details, or other
+sensitive interactions whose submitted values should stay on the external
+site instead of passing through the model or MCP client. In a real
+authorization flow, verify the callback and state on your backend; the
+client's `accept` action alone is not proof that authorization succeeded.
+
+## Run the example
+
+From this directory, start the server:
+
+```sh
+pnpm dev
+```
+
+Connect an MCP client with form and URL elicitation support to
+`http://localhost:3000/mcp`, then call either `deploy` or `connect-service`.
+
+## Typecheck and build
+
+```sh
+pnpm typecheck
+pnpm build
+```

--- a/libraries/typescript/packages/server/examples/elicitation/package.json
+++ b/libraries/typescript/packages/server/examples/elicitation/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "mcp-use-example-elicitation",
+  "type": "module",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Example: typed form and URL elicitation with mcp-use.",
+  "engines": {
+    "node": ">=24.0.0"
+  },
+  "scripts": {
+    "dev": "mcp-use dev",
+    "build": "mcp-use build",
+    "start": "mcp-use start",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "mcp-use": "workspace:*",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "^24.13.2",
+    "typescript": "7.0.1-rc",
+    "vite": "^8.0.16"
+  }
+}

--- a/libraries/typescript/packages/server/examples/elicitation/src/index.ts
+++ b/libraries/typescript/packages/server/examples/elicitation/src/index.ts
@@ -1,0 +1,136 @@
+import { MCPServer } from "mcp-use";
+import { z } from "zod";
+
+const server = new MCPServer({
+  name: "elicitation-example",
+  version: "1.0.0",
+  title: "Elicitation Example",
+  description:
+    "Demonstrates typed form and URL elicitation through input_required.",
+});
+
+const deploymentApproval = z.object({
+  approve: z.boolean().describe("Approve this deployment"),
+  note: z
+    .string()
+    .max(200)
+    .optional()
+    .describe("Optional note for the deployment log"),
+});
+
+server.tool(
+  {
+    name: "deploy",
+    title: "Deploy an environment",
+    description:
+      "Ask the user for confirmation, then simulate deploying an environment.",
+    inputSchema: z.object({
+      environment: z
+        .enum(["staging", "production"])
+        .describe("Environment to deploy"),
+    }),
+    outputSchema: z.object({
+      environment: z.string(),
+      deployed: z.boolean(),
+      note: z.string().optional(),
+    }),
+    annotations: { destructiveHint: true },
+  },
+  async ({ environment }, ctx) => {
+    const confirmation = await ctx.elicit(
+      "deployment-approval",
+      `Deploy to ${environment}?`,
+      deploymentApproval
+    );
+
+    // On the first invocation this is an InputRequiredResult. The client
+    // collects input and retries this same tool call with the response.
+    if (confirmation.status === "required") {
+      return confirmation.result;
+    }
+
+    if (confirmation.status !== "accept") {
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              confirmation.status === "decline"
+                ? "Deployment declined by the user."
+                : "Deployment cancelled by the user.",
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    if (!confirmation.data.approve) {
+      return {
+        content: [{ type: "text", text: "Deployment was not approved." }],
+        isError: true,
+      };
+    }
+
+    // Put side effects after elicitation is accepted: the callback runs again
+    // for every input_required round.
+    const result = {
+      environment,
+      deployed: true,
+      ...(confirmation.data.note !== undefined && {
+        note: confirmation.data.note,
+      }),
+    };
+
+    return {
+      content: [{ type: "text", text: JSON.stringify(result) }],
+      structuredContent: result,
+    };
+  }
+);
+
+server.tool(
+  {
+    name: "connect-service",
+    title: "Connect a service",
+    description:
+      "Open a browser authorization flow using URL-mode elicitation.",
+    inputSchema: z.object({
+      service: z.enum(["github", "slack"]),
+    }),
+  },
+  async ({ service }, ctx) => {
+    const authorizationUrl = new URL("https://example.com/authorize");
+    authorizationUrl.searchParams.set("service", service);
+
+    const authorization = await ctx.elicit(
+      "service-authorization",
+      `Authorize access to ${service}`,
+      authorizationUrl.href
+    );
+
+    if (authorization.status === "required") {
+      return authorization.result;
+    }
+
+    if (authorization.status !== "accept") {
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              authorization.status === "decline"
+                ? "Authorization declined by the user."
+                : "Authorization cancelled by the user.",
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    return {
+      content: [{ type: "text", text: `Connected ${service}.` }],
+    };
+  }
+);
+
+export default server;

--- a/libraries/typescript/packages/server/examples/elicitation/tsconfig.json
+++ b/libraries/typescript/packages/server/examples/elicitation/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2024"],
+    "types": ["node"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}

--- a/libraries/typescript/packages/server/examples/views/basic/src/index.ts
+++ b/libraries/typescript/packages/server/examples/views/basic/src/index.ts
@@ -274,24 +274,24 @@ export const collectUserInfo = server.tool(
     outputSchema: z.object({ name: z.string(), age: z.number() }),
   },
   async (_input, ctx) => {
-    const form = await ctx.input.form({
-      key: "profile",
-      message: "Provide a profile for the client example",
-      schema: z.object({
+    const form = await ctx.elicit(
+      "profile",
+      "Provide a profile for the client example",
+      z.object({
         name: z.string().default("Anonymous"),
         age: z.number().default(0),
-      }),
-    });
+      })
+    );
     if (form.status === "required") return form.result;
-    if (form.status === "accepted") {
+    if (form.status === "accept") {
       return {
         content: [
           {
             type: "text",
-            text: `Received ${form.value.name}, age ${form.value.age}`,
+            text: `Received ${form.data.name}, age ${form.data.age}`,
           },
         ],
-        structuredContent: form.value,
+        structuredContent: form.data,
       };
     }
     return {

--- a/libraries/typescript/packages/server/specs/SPEC.md
+++ b/libraries/typescript/packages/server/specs/SPEC.md
@@ -109,13 +109,9 @@ server.basePath; // readonly accessor (default "/mcp") — lets tooling introspe
 
 Result model (raw wire shapes; see the no-response-helpers ground rule): tool callbacks return the SDK's `CallToolResult`, resource callbacks `ReadResourceResult` (each `contents` entry addresses itself with the read `uri` and carries its own `mimeType`; the definition's `mimeType` is listing metadata only), prompt callbacks `GetPromptResult` (`description` passes through verbatim — the definition's is not injected). `ToolResult<TOutput>` in `src/tools.ts` encodes the SDK's runtime rule at compile time: tools **without** an `outputSchema` accept any `CallToolResult`; tools **with** one must return `structuredContent` matching the schema's inferred type — any JSON root, per the 2026 wire — or set `isError: true` (the SDK exempts `isError` results from output validation; anything else without `structuredContent` throws at call time).
 
-Callback context (`ctx`, second parameter): `{ signal, request?, client, inputResponses?, requestState?, auth? }` — request-scoped only. `inputResponses` and `requestState` expose the official v2 multi-round-trip state; use the re-exported `inputRequired`, `inputResponse`, and `acceptedContent` helpers. `ctx.client` exposes per-request client capabilities (`VIEWS_SPEC.md`), and with OAuth configured, `ctx.auth` is present (`AUTH_SPEC.md` / `AUTH_IMPLEMENTATION.md`). Nothing session-scoped is added.
+Callback context (`ctx`, second parameter): `{ signal, request?, client, elicit, inputResponses?, requestState, reportProgress, sendLog, auth? }` — request-scoped only. `ctx.elicit` is the typed form/URL convenience path; `inputResponses` and `requestState()` expose the official v2 multi-round-trip state for advanced flows. The package root re-exports `inputRequired`, `inputResponse`, `acceptedContent`, and `createRequestStateCodec`. `ctx.client` exposes per-request client capabilities (`VIEWS_SPEC.md`), and with OAuth configured, `ctx.auth` is present (`AUTH_SPEC.md` / `AUTH_IMPLEMENTATION.md`). Nothing session-scoped is added.
 
-For the common human-input path, `ctx.input.form({ key, message, schema })`
-combines correlation and Standard Schema validation. Return `form.result` when
-`status === "required"`; accepted values are inferred from `schema`, while
-decline, cancel, and invalid states remain explicit. `ctx.reportProgress(...)`
-is request-scoped and returns `false` when the caller supplied no progress token.
+For the common human-input path, `await ctx.elicit(key, message, schemaOrUrl)` combines correlation and Standard Schema validation. Return `result` when `status === "required"`; accepted form values are inferred from the schema, while decline and cancel remain explicit. Invalid accepted form content produces another `required` result. `ctx.reportProgress(...)` is request-scoped and returns `false` when the caller supplied no progress token.
 
 **Deltas vs the old package (protocol- or SDK-forced):**
 
@@ -129,7 +125,7 @@ is request-scoped and returns `false` when the caller supplied no progress token
 8. `resourceTemplate()` uses a `const` type parameter so `uriTemplate` stays a string literal through inference — without it TS widens object-literal properties to `string` and template-param typing silently degrades to `Record<string, string | string[]>` (it had, undetected, before the type-level tests). Template inference handles RFC 6570 operators, comma-separated variable lists, and `*`/`:n` modifiers.
 9. The modern wire is the per-request `_meta` envelope, not a handshake (see the 2026-07-28-first ground rule; 2025-era clients are served through the stateless legacy fallback by default, or rejected under `legacy: "reject"`). The official client connects modern with `versionNegotiation: { mode: { pin: "2026-07-28" } }` (or `'auto'`) — its default is the legacy handshake. Hand-rolled modern requests carry the per-request `_meta` envelope (`protocolVersion`/`clientInfo`/`clientCapabilities` keys) plus `mcp-protocol-version`/`mcp-method` headers, and `mcp-name` mirroring `params.name` on name-addressed methods; modern exchanges answer with a single JSON body (`responseMode: 'auto'`), not SSE framing.
 
-**Intentionally absent from the core primitive layer:** push-style `ctx.sample`/`ctx.elicit`, middleware (`server.use`), landing page, OpenAPI import, telemetry, typegen, and stdio serving. Views are governed by `VIEWS_SPEC.md`. The v2 MRTR primitives (`inputRequired`, `inputResponse`, `acceptedContent`) and cross-request notification methods are available without introducing session state.
+**Intentionally absent from the core primitive layer:** legacy push-style sampling/roots APIs, middleware (`server.use`), landing page, OpenAPI import, telemetry, typegen, and stdio serving. Views are governed by `VIEWS_SPEC.md`. Typed `ctx.elicit` and the raw v2 MRTR primitives (`inputRequired`, `inputResponse`, `acceptedContent`) operate through explicit `input_required` returns without introducing session state.
 
 **Examples** (`examples/vercel`, `examples/railway`): the two deployment doors, each verified end-to-end. Vercel = serverless via `getHandler()` exported as `export default { fetch }` from an `api/` function — zero host config (delta 5). Railway = the CLI entry contract (`CLI_SPEC.md`): the entry default-exports the server and never calls `listen()` itself; `mcp-use build` + `mcp-use start` own the socket (host selection via `RAILWAY_PUBLIC_DOMAIN` stays constructor config, which `start`'s `listen()` honors), and the bin handles SIGINT/SIGTERM → `close()`.
 
@@ -155,6 +151,44 @@ Contract:
 - **Noise.** Inspector shell page loads and favicon probes (GET/HEAD) are skipped; non-MCP requests log the summary line only.
 - **Config & exports.** `logging?: { enabled?: boolean; level?: "info" | "debug" | "trace" }` on `ServerConfig` (default enabled at `info`). On/off-with-options config fields are object-only with an `enabled` flag — no `boolean | object` unions. `requestLogger(options)`, `LoggingOptions`, and `LogLevel` are exported from the package root for hand-composed `mountMcp` apps.
 
+## Elicitation and input_required
+
+Tool callbacks may return the SDK's raw `InputRequiredResult` in addition to a completed `CallToolResult`, including when the tool declares an `outputSchema`. The package root re-exports the official `inputRequired`, `acceptedContent`, `inputResponse`, and `createRequestStateCodec` helpers and their core result/request types as advanced escape hatches. No mcp-use-specific tool-result wrapper exists.
+
+`RequestContext` exposes `inputResponses`, `requestState()`, and a v1-shaped `elicit` builder:
+
+```ts
+server.tool(
+  {
+    name: "deploy",
+    inputSchema: z.object({ environment: z.string() }),
+  },
+  async ({ environment }, ctx) => {
+    const confirmation = await ctx.elicit(
+      "confirm",
+      `Deploy to ${environment}?`,
+      z.object({ confirm: z.boolean() }),
+    );
+    if (confirmation.status === "required") {
+      return confirmation.result;
+    }
+    if (
+      confirmation.status !== "accept" ||
+      confirmation.data.confirm !== true
+    ) {
+      return { content: [{ type: "text", text: "Cancelled" }], isError: true };
+    }
+    return { content: [{ type: "text", text: "Deployed" }] };
+  }
+);
+```
+
+`ctx.elicit(key, message, schema)` handles typed form mode; `ctx.elicit(key, message, url)` handles URL mode. It returns `{ status: "required", result }` on first entry (and after invalid Standard Schema form data), `{ status: "accept", data }` for an accepted typed form, `{ status: "accept" }` for accepted URL mode, or `{ status: "decline" | "cancel" }`. The explicit key correlates the embedded request with the response on retry.
+
+`ctx.elicit` is asynchronous only so Standard Schema validators may be synchronous or asynchronous. It never waits for user input inside the handler: the stateless 2026 protocol still requires the handler to return `input_required`, after which the client retries the original tool. Keeping the `required` return branch explicit makes handler re-entry visible and avoids a hidden suspension mechanism that could make repeated pre-elicitation side effects surprising. URL mode needs no `elicitationId`; correlation is the key, with integrity-protected `requestState` for sequential rounds. No server-side request remains open while the user responds.
+
+`ctx.elicit` validates accepted Standard Schema form content before exposing typed `data`; malformed accepted data produces another `required` result. The raw `inputResponses` collection is still exposed for advanced parallel or mixed-request flows and contains only the current round. Those flows use `acceptedContent` for schema validation and `inputResponse` to distinguish missing / accept / decline / cancel and other embedded request kinds. Sequential flows use `requestState`; `ServerConfig.requestState.verify` passes through to the SDK, and state that influences authorization or business logic must be protected (normally with `createRequestStateCodec`). View result metadata is attached only to completed results, never to intermediate `input_required` returns.
+
 ## Later phases (each gets its own scope + delta notes before work starts)
 
 - **Build/dev/start CLI: implemented** — contract in **`CLI_SPEC.md`** (bin + lazily imported toolchain in this package, `.mcp-use/` workspace, inspector CDN shell, entry contract).
@@ -162,7 +196,7 @@ Contract:
 - **Serving hardening:** mounting into a user's existing Hono app (validation middleware guidance) — `mountMcp` itself is implemented; stdio serving decision (`serveStdio` works off the same factory); expose the underlying `McpServerFactory` (`server.factory()`) so any official adapter can consume it. Plus DX debts found building the examples: (1) `listen()`'s returned `url` is hardcoded to `localhost` — wrong for public binds; (2) no diagnostic when `basePath` drifts from where the handler is actually mounted (silent 404) — warn at `getHandler()` time.
 - **Auth: direct resource-server mode implemented; proxy mode deferred.** Contract in **`AUTH_SPEC.md`** / **`AUTH_IMPLEMENTATION.md`** (resource-server posture, `ctx.auth`, `bearerAuth`/`oauthMetadata`, provider adapters, RFC 9728 metadata). OAuth proxy mode (local authorization server) remains deferred.
 - **Product shell:** OAuth providers + scope guards + `.well-known` (with auth, above), operation middleware (`server.use("mcp:*")`), landing page, and resource-subscription ergonomics. Cross-request v2 list/resource notifications are implemented through `MCPServer.notify*`, backed by the SDK handler bus. Every per-request SDK server advertises tool/prompt/resource `listChanged` (and resource `subscribe`) even while a registry is empty, so a client connected before the first primitive is added can subscribe. `getHandler({ bus })` accepts an SDK `ServerEventBus` for entries that need several handler instances to share open subscriptions; `mcp-use dev` uses one process-scoped bus across every reload generation and publishes all three list invalidations after a successful handler swap.
-- **Elicitation & context:** MRTR state and helpers are implemented; future work may add higher-level form validation and progress ergonomics. Push-style sampling/roots remain legacy-only and are deprecated in the 2026-07-28 spec.
+- **Elicitation & context:** MRTR state, typed form and URL elicitation, progress, and logging helpers are implemented. Push-style sampling/roots remain legacy-only and are deprecated in the 2026-07-28 spec.
 - **Integration:** OpenAPI import and telemetry (posthog-node, opt-out). The independently published `@mcp-use/client` remains the SDK boundary; the framework consumes it for `mcp-use client` rather than folding or re-exporting the SDK from the server runtime.
 
 ## Open questions (answered per phase, not up front)

--- a/libraries/typescript/packages/server/src/config.ts
+++ b/libraries/typescript/packages/server/src/config.ts
@@ -1,3 +1,5 @@
+import type { ServerOptions } from "@modelcontextprotocol/server";
+
 import type { LoggingOptions } from "./logging.js";
 import type { OAuthProvider } from "./oauth/index.js";
 
@@ -154,6 +156,18 @@ interface BaseServerConfig {
    * configured level.
    */
   logging?: LoggingOptions;
+  /**
+   * Integrity verification for `requestState` echoed across
+   * `input_required` rounds.
+   *
+   * Use the SDK's `createRequestStateCodec(...).verify` here when state
+   * affects authorization, resource access, or business logic. Without a
+   * verifier, {@link RequestContext.requestState} returns the raw,
+   * attacker-controlled wire string.
+   *
+   * @defaultValue `undefined`
+   */
+  requestState?: ServerOptions["requestState"];
 }
 
 /**

--- a/libraries/typescript/packages/server/src/context.ts
+++ b/libraries/typescript/packages/server/src/context.ts
@@ -3,7 +3,9 @@ import {
   inputRequired,
   inputResponse,
   type AuthInfo,
+  type InputRequest,
   type InputRequiredResult,
+  type RequestStateAccessor,
   type ServerContext,
   type StandardSchemaWithJSON,
 } from "@modelcontextprotocol/server";
@@ -27,37 +29,50 @@ export interface RequestClientContext {
   supportsViews(): boolean;
 }
 
-/** Options for a typed v2 form elicitation round. */
-export interface FormInputOptions<
-  TSchema extends StandardSchemaWithJSON = StandardSchemaWithJSON,
-> {
-  /** Stable key used to correlate this form across request rounds. */
-  key: string;
-  /** Human-readable question shown by the client. */
-  message: string;
-  /** Synchronously or asynchronously validating Standard Schema. */
-  schema: TSchema;
-  /** Optional opaque state echoed on the next round. Integrity-protect it if load-bearing. */
-  requestState?: string;
-}
-
-/** Result of resolving a typed form elicitation round. */
-export type FormInputResult<TValue> =
+/**
+ * Result of a {@link Elicit} call.
+ *
+ * `required` means the callback must return `result`; the client then gathers
+ * input and retries the tool. Accepted form results carry schema-validated,
+ * inferred `data`. URL acceptances and declined/cancelled results carry no
+ * data.
+ */
+export type ElicitationResult<T = never> =
   | { status: "required"; result: InputRequiredResult }
-  | { status: "accepted"; value: TValue }
-  | { status: "declined" }
-  | { status: "cancelled" }
-  | { status: "invalid"; issues: readonly unknown[] };
+  | { status: "decline" | "cancel" }
+  | ([T] extends [never] ? { status: "accept" } : { status: "accept"; data: T });
 
-/** High-level typed input helpers for v2 multi-round-trip requests. */
-export interface RequestInputContext {
-  /**
-   * Resolve a form response or return the `input_required` result the handler
-   * should return directly.
-   */
-  form<TSchema extends StandardSchemaWithJSON>(
-    options: FormInputOptions<TSchema>
-  ): Promise<FormInputResult<StandardSchemaWithJSON.InferOutput<TSchema>>>;
+/**
+ * Requests or reads one keyed elicitation in a multi-round-trip tool callback.
+ *
+ * The explicit key correlates the request with the client's response on
+ * re-entry. On the first entry, or after an invalid form response, this returns
+ * `{ status: "required", result }`; return that result from the tool. On
+ * re-entry it returns `accept`, `decline`, or `cancel` and validates accepted
+ * Standard Schema form data before exposing it. Validation may be synchronous
+ * or asynchronous.
+ *
+ * @example
+ * ```ts
+ * const confirmation = await ctx.elicit(
+ *   "confirm",
+ *   "Deploy to production?",
+ *   schema,
+ * );
+ * if (confirmation.status === "required") {
+ *   return confirmation.result;
+ * }
+ * ```
+ */
+export interface Elicit {
+  /** Request or read a typed form-mode elicitation. */
+  <S extends StandardSchemaWithJSON>(
+    key: string,
+    message: string,
+    schema: S
+  ): Promise<ElicitationResult<StandardSchemaWithJSON.InferOutput<S>>>;
+  /** Request or read a URL-mode elicitation. */
+  (key: string, message: string, url: string): Promise<ElicitationResult>;
 }
 
 /**
@@ -86,12 +101,19 @@ type RequestContextBase = {
   request?: Request;
   /** Per-request client capability queries. */
   client: RequestClientContext;
-  /** Typed v2 multi-round-trip input helpers. */
-  input: RequestInputContext;
-  /** Responses supplied by the client during a v2 multi-round-trip request. */
+  /** Request or read a keyed form- or URL-mode elicitation. */
+  elicit: Elicit;
+  /**
+   * Bare responses supplied when the client retries an `input_required`
+   * round. Values are client input; validate them before use.
+   */
   inputResponses?: ServerContext["mcpReq"]["inputResponses"];
-  /** Opaque state echoed by the client during a v2 multi-round-trip request. */
-  requestState?: ServerContext["mcpReq"]["requestState"];
+  /**
+   * Read opaque state echoed by the client for this `input_required` round.
+   * The generic is only a type assertion. Configure `requestState.verify`
+   * when state affects authorization or business logic.
+   */
+  requestState: RequestStateAccessor;
   /**
    * Report request-scoped progress when the caller supplied a progress token.
    *
@@ -155,53 +177,57 @@ function toClientContext(ctx: ServerContext): RequestClientContext {
   };
 }
 
-function toInputContext(ctx: ServerContext): RequestInputContext {
-  return {
-    async form<TSchema extends StandardSchemaWithJSON>(
-      options: FormInputOptions<TSchema>
-    ): Promise<FormInputResult<StandardSchemaWithJSON.InferOutput<TSchema>>> {
-      const response = inputResponse(ctx.mcpReq.inputResponses, options.key);
-      if (response.kind === "missing") {
-        return {
-          status: "required",
-          result: inputRequired({
-            inputRequests: {
-              [options.key]: inputRequired.elicit({
-                message: options.message,
-                requestedSchema: options.schema,
-              }),
-            },
-            ...(options.requestState !== undefined && {
-              requestState: options.requestState,
-            }),
-          }),
-        };
-      }
-      if (response.kind !== "elicit") {
-        return {
-          status: "invalid",
-          issues: [{ message: `Unexpected ${response.kind} input response` }],
-        };
-      }
-      if (response.action === "decline") return { status: "declined" };
-      if (response.action === "cancel") return { status: "cancelled" };
-      if (response.content === undefined) {
-        return {
-          status: "invalid",
-          issues: [{ message: "Accepted form response has no content" }],
-        };
-      }
-      const outcome = await options.schema["~standard"].validate(
-        response.content
+function createElicit(
+  inputResponses: ServerContext["mcpReq"]["inputResponses"]
+): Elicit {
+  return async function elicit(
+    key: string,
+    message: string,
+    schemaOrUrl?: StandardSchemaWithJSON | string
+  ): Promise<ElicitationResult<unknown> | ElicitationResult> {
+    let request: InputRequest;
+    let formSchema: StandardSchemaWithJSON | undefined;
+
+    if (typeof schemaOrUrl === "string") {
+      request = inputRequired.elicitUrl({
+        message,
+        url: schemaOrUrl,
+      });
+    } else if (schemaOrUrl !== undefined) {
+      formSchema = schemaOrUrl;
+      request = inputRequired.elicit({
+        message,
+        requestedSchema: schemaOrUrl,
+      });
+    } else {
+      throw new TypeError(
+        "ctx.elicit(key, message, value) requires a form schema or URL string"
       );
-      return outcome.issues === undefined
-        ? {
-            status: "accepted",
-            value: outcome.value as StandardSchemaWithJSON.InferOutput<TSchema>,
-          }
-        : { status: "invalid", issues: outcome.issues };
-    },
-  };
+    }
+
+    const response = inputResponse(inputResponses, key);
+    if (response.kind === "elicit") {
+      if (response.action !== "accept") {
+        return { status: response.action };
+      }
+      if (formSchema === undefined) {
+        return { status: "accept" };
+      }
+      if (response.content !== undefined) {
+        const outcome = await formSchema["~standard"].validate(
+          response.content
+        );
+        if (outcome.issues === undefined) {
+          return { status: "accept", data: outcome.value };
+        }
+      }
+    }
+
+    return {
+      status: "required",
+      result: inputRequired({ inputRequests: { [key]: request } }),
+    };
+  } as Elicit;
 }
 
 /**
@@ -220,11 +246,9 @@ export function toRequestContext(
     ...(ctx.mcpReq.inputResponses !== undefined && {
       inputResponses: ctx.mcpReq.inputResponses,
     }),
-    ...(ctx.mcpReq.requestState !== undefined && {
-      requestState: ctx.mcpReq.requestState,
-    }),
     client: toClientContext(ctx),
-    input: toInputContext(ctx),
+    elicit: createElicit(ctx.mcpReq.inputResponses),
+    requestState: <T = unknown>() => ctx.mcpReq.requestState<T>(),
     async reportProgress(progress, total, message): Promise<boolean> {
       const progressToken = ctx.mcpReq._meta?.progressToken;
       if (progressToken === undefined) return false;

--- a/libraries/typescript/packages/server/src/context.ts
+++ b/libraries/typescript/packages/server/src/context.ts
@@ -40,7 +40,9 @@ export interface RequestClientContext {
 export type ElicitationResult<T = never> =
   | { status: "required"; result: InputRequiredResult }
   | { status: "decline" | "cancel" }
-  | ([T] extends [never] ? { status: "accept" } : { status: "accept"; data: T });
+  | ([T] extends [never]
+      ? { status: "accept" }
+      : { status: "accept"; data: T });
 
 /**
  * Requests or reads one keyed elicitation in a multi-round-trip tool callback.

--- a/libraries/typescript/packages/server/src/index.ts
+++ b/libraries/typescript/packages/server/src/index.ts
@@ -40,8 +40,13 @@ export type {
   PromptMessage,
   ReadResourceResult,
 } from "@modelcontextprotocol/server";
+/**
+ * Official SDK helpers for authoring and reading multi-round-trip
+ * `input_required` results.
+ */
 export {
   acceptedContent,
+  createRequestStateCodec,
   inputRequired,
   inputResponse,
   isInputRequiredResult,
@@ -63,12 +68,11 @@ export type {
 
 export type { InspectorOptions, ServerConfig } from "./config.js";
 export type {
-  FormInputOptions,
-  FormInputResult,
+  Elicit,
+  ElicitationResult,
   OAuthAuth,
   RequestClientContext,
   RequestContext,
-  RequestInputContext,
 } from "./context.js";
 export type {
   InferToolInput,

--- a/libraries/typescript/packages/server/src/server.ts
+++ b/libraries/typescript/packages/server/src/server.ts
@@ -3,6 +3,7 @@ import {
   localhostAllowedOrigins,
   McpServer as SdkMcpServer,
   ResourceTemplate,
+  isInputRequiredResult,
   type McpHttpHandler,
   type McpRequestContext,
   type PromptCallback as SdkPromptCallback,
@@ -875,6 +876,9 @@ export class MCPServer<TUser = never> {
         },
         ...(instructions !== undefined && { instructions }),
         ...(authInfo !== undefined && { authInfo }),
+        ...(this.#config.requestState !== undefined && {
+          requestState: this.#config.requestState,
+        }),
       }
     );
 
@@ -940,7 +944,11 @@ export class MCPServer<TUser = never> {
           // The SDK has already validated `args` against the input schema.
           const params = args as Record<string, unknown>;
           const result = await callback(params, this.#toRequestContext(ctx));
-          if (wireResultMeta === undefined || result.isError === true) {
+          if (
+            isInputRequiredResult(result) ||
+            wireResultMeta === undefined ||
+            result.isError === true
+          ) {
             return result;
           }
           return {
@@ -952,7 +960,11 @@ export class MCPServer<TUser = never> {
     } else {
       server.registerTool(definition.name, config, async (ctx) => {
         const result = await callback({}, this.#toRequestContext(ctx));
-        if (wireResultMeta === undefined || result.isError === true) {
+        if (
+          isInputRequiredResult(result) ||
+          wireResultMeta === undefined ||
+          result.isError === true
+        ) {
           return result;
         }
         return {

--- a/libraries/typescript/packages/server/src/tools.ts
+++ b/libraries/typescript/packages/server/src/tools.ts
@@ -117,7 +117,8 @@ export interface ToolRef<
 
 /**
  * Result a tool callback may return, keyed by the tool's inferred output
- * type. The shape is the SDK's raw {@link CallToolResult} — there is no
+ * type. Completed calls use the SDK's raw {@link CallToolResult}; interactive
+ * calls may return an {@link InputRequiredResult}. There is no
  * framework-specific result layer.
  *
  * Without an `outputSchema` (`TOutput = never`) any `CallToolResult` is

--- a/libraries/typescript/packages/server/tests/elicitation.test.ts
+++ b/libraries/typescript/packages/server/tests/elicitation.test.ts
@@ -1,0 +1,221 @@
+/**
+ * End-to-end coverage for v2 multi-round-trip elicitation over real HTTP.
+ */
+import {
+  Client,
+  StreamableHTTPClientTransport,
+} from "@modelcontextprotocol/client";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { MCPServer } from "../src/index.js";
+
+const confirmationSchema = z.object({ confirm: z.boolean() });
+const asyncConfirmationSchema = confirmationSchema.superRefine(
+  async ({ confirm }, refinement) => {
+    await Promise.resolve();
+    if (!confirm) {
+      refinement.addIssue({
+        code: "custom",
+        message: "Confirmation is required",
+      });
+    }
+  }
+);
+
+describe("elicitation and input_required", () => {
+  const seenRequests: Array<{
+    mode?: string | undefined;
+    message: string;
+    url?: string | undefined;
+  }> = [];
+  const server = new MCPServer({
+    name: "elicitation-test",
+    version: "1.0.0",
+  });
+  let client: Client;
+  let asyncFormAttempts = 0;
+  let invalidFormAttempts = 0;
+
+  server.tool(
+    {
+      name: "deploy",
+      inputSchema: z.object({ environment: z.string() }),
+      outputSchema: z.object({
+        environment: z.string(),
+        deployed: z.boolean(),
+      }),
+    },
+    async ({ environment }, ctx) => {
+      const confirmation = await ctx.elicit(
+        "confirm",
+        `Deploy to ${environment}?`,
+        environment === "async-invalid-first"
+          ? asyncConfirmationSchema
+          : confirmationSchema
+      );
+      if (confirmation.status === "required") {
+        return confirmation.result;
+      }
+      if (confirmation.status !== "accept") {
+        return {
+          content: [
+            { type: "text", text: `Deployment ${confirmation.status}` },
+          ],
+          isError: true,
+        };
+      }
+      if (confirmation.data.confirm !== true) {
+        return {
+          content: [{ type: "text", text: "Deployment not confirmed" }],
+          isError: true,
+        };
+      }
+
+      const result = { environment, deployed: true };
+      return {
+        content: [{ type: "text", text: JSON.stringify(result) }],
+        structuredContent: result,
+      };
+    }
+  );
+
+  server.tool({ name: "link-account" }, async (_params, ctx) => {
+    const authorization = await ctx.elicit(
+      "authorize",
+      "Sign in to link your account",
+      "https://example.com/authorize"
+    );
+    if (authorization.status === "required") {
+      return authorization.result;
+    }
+    return {
+      content: [
+        {
+          type: "text",
+          text:
+            authorization.status === "accept"
+              ? "Account linked"
+              : "Account not linked",
+        },
+      ],
+      ...(authorization.status !== "accept"
+        ? { isError: true as const }
+        : {}),
+    };
+  });
+
+  beforeAll(async () => {
+    const started = await server.listen(0);
+    client = new Client(
+      { name: "elicitation-test-client", version: "1.0.0" },
+      {
+        capabilities: { elicitation: { form: {}, url: {} } },
+        versionNegotiation: { mode: { pin: "2026-07-28" } },
+      }
+    );
+    client.setRequestHandler("elicitation/create", async (request) => {
+      seenRequests.push(request.params);
+      if (request.params.mode === "url") {
+        return { action: "accept" };
+      }
+      if (request.params.message === "Deploy to decline?") {
+        return { action: "decline" };
+      }
+      if (request.params.message === "Deploy to invalid-first?") {
+        invalidFormAttempts += 1;
+        return invalidFormAttempts === 1
+          ? { action: "accept", content: { confirm: "yes" } }
+          : { action: "accept", content: { confirm: true } };
+      }
+      if (request.params.message === "Deploy to async-invalid-first?") {
+        asyncFormAttempts += 1;
+        return asyncFormAttempts === 1
+          ? { action: "accept", content: { confirm: false } }
+          : { action: "accept", content: { confirm: true } };
+      }
+      return { action: "accept", content: { confirm: true } };
+    });
+    await client.connect(
+      new StreamableHTTPClientTransport(new URL(started.url))
+    );
+  });
+
+  afterAll(async () => {
+    await client.close();
+    await server.close();
+  });
+
+  it("round-trips a v1-style form elicitation and returns the final tool result", async () => {
+    const result = await client.callTool({
+      name: "deploy",
+      arguments: { environment: "production" },
+    });
+
+    expect(result.structuredContent).toEqual({
+      environment: "production",
+      deployed: true,
+    });
+    expect(seenRequests).toContainEqual(
+      expect.objectContaining({
+        mode: "form",
+        message: "Deploy to production?",
+      })
+    );
+  });
+
+  it("round-trips a v1-style URL elicitation", async () => {
+    const result = await client.callTool({ name: "link-account" });
+
+    expect(result.content).toContainEqual({
+      type: "text",
+      text: "Account linked",
+    });
+    expect(seenRequests).toContainEqual(
+      expect.objectContaining({
+        mode: "url",
+        message: "Sign in to link your account",
+        url: "https://example.com/authorize",
+      })
+    );
+  });
+
+  it("surfaces a declined elicitation without re-requesting it", async () => {
+    const result = await client.callTool({
+      name: "deploy",
+      arguments: { environment: "decline" },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContainEqual({
+      type: "text",
+      text: "Deployment decline",
+    });
+  });
+
+  it("re-requests form input that fails Standard Schema validation", async () => {
+    const result = await client.callTool({
+      name: "deploy",
+      arguments: { environment: "invalid-first" },
+    });
+
+    expect(result.structuredContent).toEqual({
+      environment: "invalid-first",
+      deployed: true,
+    });
+    expect(invalidFormAttempts).toBe(2);
+  });
+
+  it("awaits asynchronous Standard Schema validation", async () => {
+    const result = await client.callTool({
+      name: "deploy",
+      arguments: { environment: "async-invalid-first" },
+    });
+
+    expect(result.structuredContent).toEqual({
+      environment: "async-invalid-first",
+      deployed: true,
+    });
+    expect(asyncFormAttempts).toBe(2);
+  });
+});

--- a/libraries/typescript/packages/server/tests/elicitation.test.ts
+++ b/libraries/typescript/packages/server/tests/elicitation.test.ts
@@ -99,9 +99,7 @@ describe("elicitation and input_required", () => {
               : "Account not linked",
         },
       ],
-      ...(authorization.status !== "accept"
-        ? { isError: true as const }
-        : {}),
+      ...(authorization.status !== "accept" ? { isError: true as const } : {}),
     };
   });
 

--- a/libraries/typescript/packages/server/tests/type-level.test.ts
+++ b/libraries/typescript/packages/server/tests/type-level.test.ts
@@ -54,6 +54,25 @@ describe("tool registration return-position checks", () => {
       content: [{ type: "text", text: "boom" }],
       isError: true,
     }));
+    server.tool({ name: "interactive", outputSchema }, async (_params, ctx) => {
+      const answer = await ctx.elicit(
+        "answer",
+        "Provide an answer",
+        z.object({ answer: z.number() })
+      );
+      if (answer.status === "required") return answer.result;
+      if (answer.status !== "accept") {
+        return {
+          content: [{ type: "text", text: answer.status }],
+          isError: true,
+        };
+      }
+      expectTypeOf(answer.data).toEqualTypeOf<{ answer: number }>();
+      return {
+        content: [{ type: "text", text: String(answer.data.answer) }],
+        structuredContent: answer.data,
+      };
+    });
     expect(true).toBe(true); // assertions above are compile-time
   });
 
@@ -107,6 +126,32 @@ describe("tool registration return-position checks", () => {
       isError: true,
     }));
     expect(true).toBe(true); // assertions above are compile-time
+  });
+});
+
+describe("elicitation context", () => {
+  it("infers form data and supports URL mode", () => {
+    const server = new MCPServer({ name: "types", version: "0.0.0" });
+    server.tool({ name: "elicit-types" }, async (_params, ctx) => {
+      const form = await ctx.elicit(
+        "profile",
+        "Your profile",
+        z.object({ name: z.string() })
+      );
+      const url = await ctx.elicit(
+        "signin",
+        "Sign in",
+        "https://example.com/sign-in"
+      );
+      if (form.status === "accept") {
+        expectTypeOf(form.data).toEqualTypeOf<{ name: string }>();
+      }
+      expect(url).toBeDefined();
+      return form.status === "required"
+        ? form.result
+        : { content: [{ type: "text", text: form.status }] };
+    });
+    expect(true).toBe(true);
   });
 });
 

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -657,6 +657,25 @@ importers:
         specifier: 7.0.1-rc
         version: 7.0.1-rc
 
+  packages/server/examples/elicitation:
+    dependencies:
+      mcp-use:
+        specifier: workspace:*
+        version: link:../..
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@types/node':
+        specifier: ^24.13.2
+        version: 24.13.2
+      typescript:
+        specifier: 7.0.1-rc
+        version: 7.0.1-rc
+      vite:
+        specifier: '>=8.0.5'
+        version: 8.0.16(@types/node@24.13.2)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+
   packages/server/examples/railway:
     dependencies:
       mcp-use:
@@ -784,34 +803,6 @@ importers:
       mcp-use:
         specifier: workspace:*
         version: link:../../..
-      react:
-        specifier: ^19.2.0
-        version: 19.2.4
-      react-dom:
-        specifier: ^19.2.0
-        version: 19.2.4(react@19.2.4)
-      zod:
-        specifier: 4.4.3
-        version: 4.4.3
-    devDependencies:
-      '@types/node':
-        specifier: ^24.13.2
-        version: 24.13.2
-      '@types/react':
-        specifier: ^19.2.7
-        version: 19.2.17
-      '@types/react-dom':
-        specifier: ^19.2.3
-        version: 19.2.3(@types/react@19.2.17)
-      typescript:
-        specifier: 7.0.1-rc
-        version: 7.0.1-rc
-
-  test_app:
-    dependencies:
-      mcp-use:
-        specifier: workspace:*
-        version: link:../packages/server
       react:
         specifier: ^19.2.0
         version: 19.2.4


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds v2 MCP elicitation (`input_required`) to the `@mcp-use/server` v2 server so tools can request typed form or URL input and continue on retry, with Standard Schema validation and optional request-state verification.

- **New Features**
  - Added `ctx.elicit(key, message, schemaOrUrl)` for typed form or URL elicitation; returns `{ status: "required" | "accept" | "decline" | "cancel" }` and typed `data` for forms.
  - Tool callbacks can return the official `InputRequiredResult`; result metadata is attached only to completed responses.
  - Validates accepted form content against Standard Schema; invalid input triggers another `input_required` round (supports async validators).
  - Exposes SDK helpers and state: `inputRequired`, `acceptedContent`, `inputResponse`, `createRequestStateCodec`; plus `ctx.inputResponses` and `ctx.requestState()` accessor.
  - New `ServerConfig.requestState.verify` passes through to the SDK for integrity-protected sequential rounds.
  - Added an example app for typed form and URL flows in `packages/server/examples/elicitation`; updated conformance and basic view examples to use `ctx.elicit`.

- **Migration**
  - Use `await ctx.elicit(key, message, schemaOrUrl)` inside tools; if `status === "required"`, return `result` and let the client retry; handle `accept/decline/cancel` on re-entry.
  - Move side effects after an accepted response; the handler runs again for each elicitation round.
  - Keep the `key` stable across retries; set `requestState.verify` (e.g., via `createRequestStateCodec(...).verify`) when state influences auth or business logic.

<sup>Written for commit 3bda41a59bcfc92af46db26036d0ce66676ddc67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



