### PR TITLE
docs(typescript): document V2 beta release channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ to build MCP Apps for ChatGPT / Claude & MCP Servers for AI Agents.
 
 Visit our [docs](https://mcp-use.com/docs) or jump to a quickstart ([TypeScript](https://mcp-use.com/docs/typescript/getting-started/quickstart) | [Python](https://mcp-use.com/docs/python/getting-started/quickstart))
 
+### V2 TypeScript beta
+
+V2 prereleases are published from reviewed pull requests merged into the `beta` branch, using GitHub OIDC trusted publishing. They use npm's `beta` dist tag and do not change `latest` or `canary`.
+
+```bash
+npm install mcp-use@beta @mcp-use/client@beta @mcp-use/agent@beta
+npm install @mcp-use/cli@beta @mcp-use/inspector@beta
+npm create mcp-use-app@beta
+```
+
 ### Skills for Coding Agents
 
 > **Using Claude Code, Codex, Cursor or other AI coding agents?**

--- a/libraries/typescript/README.md
+++ b/libraries/typescript/README.md
@@ -590,20 +590,6 @@ git commit -m "feat: your feature description"
 - Merge the Version PR to publish stable versions
 - Packages published with `latest` tag on npm
 
-#### V2 Beta Prereleases (beta branch)
-
-- Merge a reviewed PR into `beta` to trigger the V2 beta release workflow
-- CI publishes only the versioned beta packages with GitHub OIDC trusted publishing
-- Versions use the `x.y.z-beta.N` form and are published with the `beta` dist tag
-- The workflow verifies that `latest`, `canary`, and every other non-beta dist tag are unchanged
-
-```bash
-# Install V2 beta packages
-npm install mcp-use@beta @mcp-use/client@beta @mcp-use/agent@beta
-npm install @mcp-use/cli@beta @mcp-use/inspector@beta
-npm create mcp-use-app@beta
-```
-
 #### Canary Prereleases (canary branch)
 
 - Push changes with changesets to `canary` branch

--- a/libraries/typescript/README.md
+++ b/libraries/typescript/README.md
@@ -590,6 +590,20 @@ git commit -m "feat: your feature description"
 - Merge the Version PR to publish stable versions
 - Packages published with `latest` tag on npm
 
+#### V2 Beta Prereleases (beta branch)
+
+- Merge a reviewed PR into `beta` to trigger the V2 beta release workflow
+- CI publishes only the versioned beta packages with GitHub OIDC trusted publishing
+- Versions use the `x.y.z-beta.N` form and are published with the `beta` dist tag
+- The workflow verifies that `latest`, `canary`, and every other non-beta dist tag are unchanged
+
+```bash
+# Install V2 beta packages
+npm install mcp-use@beta @mcp-use/client@beta @mcp-use/agent@beta
+npm install @mcp-use/cli@beta @mcp-use/inspector@beta
+npm create mcp-use-app@beta
+```
+
 #### Canary Prereleases (canary branch)
 
 - Push changes with changesets to `canary` branch


### PR DESCRIPTION
Documents the V2 beta install channel and its release invariants.

Merging this PR into `beta` triggers the isolated GitHub OIDC beta workflow. The workflow is guarded to publish only the six planned beta versions and verify that `latest`, `canary`, and every other non-beta tag remain unchanged.

No package source or version state changes are included in this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document the V2 TypeScript beta release channel in the README, including `@beta` install commands and how publishing works. Merging to `beta` runs an isolated OIDC trusted publish that only releases `x.y.z-beta.N` with the `beta` dist-tag and verifies `latest`, `canary`, and other tags are unchanged; no source or version changes in this PR.

<sup>Written for commit c12b01fbd08d8f52c36e3310b382d2b0681c20e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1886?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

