### PR TITLE
ci(typescript): publish v2 beta from Node 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -587,7 +587,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [22]
+        node-version: [20, 22]
     name: typescript-lint (node-${{ matrix.node-version }})
     defaults:
       run:
@@ -624,7 +624,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [22]
+        node-version: [20, 22]
     name: typescript-build (node-${{ matrix.node-version }})
     defaults:
       run:
@@ -664,7 +664,7 @@ jobs:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
     strategy:
       matrix:
-        node-version: [22]
+        node-version: [20, 22]
     defaults:
       run:
         working-directory: libraries/typescript
@@ -718,7 +718,7 @@ jobs:
           version: 10.6.1
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 20
           cache: "pnpm"
           cache-dependency-path: libraries/typescript/pnpm-lock.yaml
       - name: Install Dependencies
@@ -747,7 +747,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [22]
+        node-version: [20, 22]
     defaults:
       run:
         working-directory: libraries/typescript
@@ -779,7 +779,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node-version: [22]
+        node-version: [20, 22]
     defaults:
       run:
         working-directory: libraries/typescript
@@ -829,7 +829,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 20
           cache: "pnpm"
           cache-dependency-path: libraries/typescript/pnpm-lock.yaml
 
@@ -865,7 +865,7 @@ jobs:
           version: 10.6.1
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 20
           cache: "pnpm"
           cache-dependency-path: libraries/typescript/pnpm-lock.yaml
       - name: Install Dependencies
@@ -928,7 +928,7 @@ jobs:
           version: 10.6.1
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 20
       - name: Setup Yarn
         if: matrix.pm == 'yarn'
         run: corepack enable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -587,7 +587,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [22]
     name: typescript-lint (node-${{ matrix.node-version }})
     defaults:
       run:
@@ -624,7 +624,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [22]
     name: typescript-build (node-${{ matrix.node-version }})
     defaults:
       run:
@@ -664,7 +664,7 @@ jobs:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [22]
     defaults:
       run:
         working-directory: libraries/typescript
@@ -718,7 +718,7 @@ jobs:
           version: 10.6.1
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: "pnpm"
           cache-dependency-path: libraries/typescript/pnpm-lock.yaml
       - name: Install Dependencies
@@ -747,7 +747,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [22]
     defaults:
       run:
         working-directory: libraries/typescript
@@ -779,7 +779,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node-version: [20, 22]
+        node-version: [22]
     defaults:
       run:
         working-directory: libraries/typescript
@@ -829,7 +829,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: "pnpm"
           cache-dependency-path: libraries/typescript/pnpm-lock.yaml
 
@@ -865,7 +865,7 @@ jobs:
           version: 10.6.1
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: "pnpm"
           cache-dependency-path: libraries/typescript/pnpm-lock.yaml
       - name: Install Dependencies
@@ -928,7 +928,7 @@ jobs:
           version: 10.6.1
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       - name: Setup Yarn
         if: matrix.pm == 'yarn'
         run: corepack enable

--- a/libraries/typescript/README.md
+++ b/libraries/typescript/README.md
@@ -590,6 +590,13 @@ git commit -m "feat: your feature description"
 - Merge the Version PR to publish stable versions
 - Packages published with `latest` tag on npm
 
+#### V2 Beta Prereleases (beta branch)
+
+- Merge a reviewed PR into `beta` to trigger the V2 beta release workflow
+- GitHub Actions publishes the versioned beta packages with OIDC trusted publishing
+- Versions use the `x.y.z-beta.N` form and npm's `beta` dist tag
+- The workflow verifies that `latest`, `canary`, and every other non-beta dist tag are unchanged
+
 #### Canary Prereleases (canary branch)
 
 - Push changes with changesets to `canary` branch


### PR DESCRIPTION
Restores the TypeScript beta release trigger and moves TypeScript CI jobs from Node 20 to Node 22, which is required by the workspace's pinned pnpm 11.13.1. Merging into beta triggers the OIDC-only beta publisher.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the TypeScript v2 beta prerelease workflow and runs the v2 checks/publisher on Node 22 while keeping the existing CI matrix. Adds README guidance for triggering v2 beta releases.

- **New Features**
  - Re-enable v2 beta publishing on the `beta` branch using OIDC; publishes `x.y.z-beta.N` under npm’s `beta` tag and verifies `latest`, `canary`, and other non-beta tags are unchanged.
  - Document how to trigger v2 beta prereleases in `libraries/typescript/README.md`.

<sup>Written for commit e41a303cbd6f34b34e0fbfa145812e66a21ac409. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1887?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

