### PR TITLE
test(release): allow subsequent v2 beta releases

### DIFF
--- a/libraries/typescript/tests/release-versioning.test.mjs
+++ b/libraries/typescript/tests/release-versioning.test.mjs
@@ -27,6 +27,14 @@ const stableVersions = {
   inspector: "20.0.0",
   "create-mcp-use-app": "2.0.0",
 };
+const initialVersions = {
+  server: "1.34.3",
+  agent: "1.0.0",
+  client: "1.0.0",
+  cli: "3.6.4",
+  inspector: "19.0.0",
+  "create-mcp-use-app": "1.0.0",
+};
 
 function setup(type, clientVersion) {
   const directory = mkdtempSync(join(tmpdir(), "mcp-use-version-test-"));
@@ -92,6 +100,31 @@ test("produces the exact initial beta package versions", () => {
       join(workspaceRoot, "node_modules"),
       join(directory, "node_modules")
     );
+    for (const file of readdirSync(join(directory, ".changeset"))) {
+      if (file.endsWith(".md") && file !== "README.md") {
+        rmSync(join(directory, ".changeset", file));
+      }
+    }
+    rmSync(join(directory, ".changeset", "pre.json"), { force: true });
+    for (const [packageDirectory, version] of Object.entries(initialVersions)) {
+      const file = join(
+        directory,
+        "packages",
+        packageDirectory,
+        "package.json"
+      );
+      const packageManifest = JSON.parse(readFileSync(file, "utf8"));
+      packageManifest.version = version;
+      writeFileSync(file, `${JSON.stringify(packageManifest, null, 2)}\n`);
+    }
+    writeFileSync(
+      join(directory, ".changeset", "initial-v2.md"),
+      `---\n"mcp-use": major\n"@mcp-use/agent": major\n"@mcp-use/client": major\n"@mcp-use/cli": major\n"@mcp-use/inspector": major\n"create-mcp-use-app": major\n---\n\nSynthetic initial V2 release.\n`
+    );
+    execFileSync(changesetBin, ["pre", "enter", "beta"], {
+      cwd: directory,
+      stdio: "ignore",
+    });
     const planFile = join(directory, "initial-plan.json");
     const expected = {
       server: ["mcp-use", "2.0.0-beta.0"],


### PR DESCRIPTION
Fixes the initial-beta fixture so it starts from v1 manifests and its own synthetic Changeset. This keeps the one-time beta.0 assertion valid while allowing live beta iterations such as the pending mcp-use@2.0.0-beta.1 release.\n\nVerified: pnpm test:release-versioning (4/4).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the initial v2 beta release test by seeding from v1 package manifests and a synthetic Changeset, keeping the one-time `beta.0` assertion stable while allowing subsequent v2 betas like `mcp-use@2.0.0-beta.1`.

- **Bug Fixes**
  - Reset the fixture to v1 versions for `server`, `@mcp-use/agent`, `@mcp-use/client`, `@mcp-use/cli`, `@mcp-use/inspector`, and `create-mcp-use-app`.
  - Remove existing `.md` changesets and `pre.json` in `.changeset` to isolate the run.
  - Add `initial-v2.md` with `major` bumps and enter `pre` mode for `beta`.

<sup>Written for commit 03cde9dadf601822fe064acd15cb9a77a92f8a6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

