### PR TITLE
fix(server): follow inspector beta CDN tag

### DIFF
--- a/libraries/typescript/.changeset/follow-inspector-beta-cdn.md
+++ b/libraries/typescript/.changeset/follow-inspector-beta-cdn.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Load the default Inspector UI from the npm `beta` dist-tag so Inspector beta fixes reach mcp-use beta users without waiting for another SDK release.

--- a/libraries/typescript/packages/server/src/inspector-shell.ts
+++ b/libraries/typescript/packages/server/src/inspector-shell.ts
@@ -13,29 +13,20 @@ import type { InspectorOptions } from "./config.js";
 import type { FetchHandler } from "./fetch-app.js";
 
 /**
- * Exact version of the `@mcp-use/inspector` CDN bundle the default URL pins
- * to (matching the R2 object key `inspector@{version}.js`).
+ * npm dist-tag of the `@mcp-use/inspector` CDN bundle the default URL follows.
  *
- * Bumping the inspector requires uploading the full `dist/cdn/` output (entry,
- * lazy chunks, and CSS) and raising this constant together.
+ * Every new Inspector beta published with this tag becomes the default
+ * inspector for mcp-use servers without requiring an mcp-use release.
  */
-export const INSPECTOR_VERSION = "11.0.0";
+export const INSPECTOR_TAG = "beta";
 
 /**
  * Default URL the inspector shell loads the UI bundle from: the
  * `@mcp-use/inspector` CDN build (`dist/cdn/inspector.js`) built from this
- * branch and hosted on Cloudflare R2, pinned to {@link INSPECTOR_VERSION}.
+ * branch and served by jsDelivr from npm's {@link INSPECTOR_TAG} tag.
  * Override per server with {@link InspectorOptions.assetsUrl}.
- *
- * TODO(inspector-cdn): swap to the jsDelivr npm copy
- * (`https://cdn.jsdelivr.net/npm/@mcp-use/inspector@<major>/dist/cdn/inspector.js`)
- * once an inspector release includes this branch's basePath-aware client —
- * published bundles up to 12.x hardcode `/inspector` as the router basename
- * and cannot run under `${basePath}/inspector`. Also replace the temporary
- * `r2.dev` development URL with the `inspector-cdn.mcp-use.com` custom
- * domain if R2 hosting outlives the v2 merge.
  */
-export const DEFAULT_INSPECTOR_ASSETS_URL = `https://pub-5337e54ad50f432cab3e646138da1efc.r2.dev/inspector@${INSPECTOR_VERSION}.js`;
+export const DEFAULT_INSPECTOR_ASSETS_URL = `https://cdn.jsdelivr.net/npm/@mcp-use/inspector@${INSPECTOR_TAG}/dist/cdn/inspector.js`;
 
 /**
  * Derive the stylesheet URL that accompanies an inspector bundle URL.

--- a/libraries/typescript/packages/server/tests/inspector-shell.test.ts
+++ b/libraries/typescript/packages/server/tests/inspector-shell.test.ts
@@ -10,7 +10,7 @@ import { MCPServer } from "../src/index.js";
 import type { ServerConfig } from "../src/index.js";
 
 const DEFAULT_CDN_URL =
-  "https://pub-5337e54ad50f432cab3e646138da1efc.r2.dev/inspector@11.0.0.js";
+  "https://cdn.jsdelivr.net/npm/@mcp-use/inspector@beta/dist/cdn/inspector.js";
 
 afterEach(() => {
   vi.unstubAllEnvs();
@@ -91,10 +91,10 @@ describe("inspector shell route", () => {
     expect(html).toContain("window.location.origin + basePath");
     // Browser polyfill for the bundle's Node-flavored module-scope code.
     expect(html).toContain("window.process = {");
-    // Root node for the bundle to mount into, and a dark background so the
-    // page doesn't flash white before the UI paints.
+    // Root node for the bundle to mount into, with the inspector's neutral
+    // background applied before the UI paints.
     expect(html).toContain('<div id="root">');
-    expect(html).toContain("background-color: #0c0c0d");
+    expect(html).toContain("background-color: #f3f3f3");
     // The server name appears (escaped) in the title.
     expect(html).toContain("<title>shell-test — MCP Inspector</title>");
     await server.close();
@@ -154,7 +154,7 @@ describe("inspector shell route", () => {
       '<link rel="stylesheet" href="https://intranet.example.com/vendor/inspector.css" />'
     );
     // The default CDN URL is fully replaced, not merely preferred.
-    expect(html).not.toContain("r2.dev");
+    expect(html).not.toContain("cdn.jsdelivr.net");
     await server.close();
   });
 


### PR DESCRIPTION
## Summary

Use jsDelivr's `@beta` dist-tag for the default Inspector bundle.

This lets existing beta `mcp-use` servers receive Inspector beta fixes without requiring a new `mcp-use` release.

## Validation

- `pnpm exec vitest run tests/inspector-shell.test.ts`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the default Inspector bundle to jsDelivr’s npm CDN using the `beta` dist-tag of `@mcp-use/inspector` so beta `mcp-use` servers automatically receive Inspector fixes without a new SDK release. Updated the default assets URL and tests (new CDN URL, neutral background).

<sup>Written for commit 2b8732a852c8a4248a5d5718249129b6707de7eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

