### PR TITLE
feat(server): proxy multiple MCP servers

### DIFF
--- a/docs/typescript/api-reference/server/mcp-server.mdx
+++ b/docs/typescript/api-reference/server/mcp-server.mdx
@@ -281,29 +281,33 @@ listen(port?: number): Promise<void>
 
 ### proxy
 
-Mounts one or more remote MCP servers onto this server. It introspects each remote server's tools, resources, and prompts and registers them natively, so this server acts as a gateway. Pass a map of namespace to connection config, or pass a single `MCPSession` plus a `namespace` option. Sampling and elicitation requests from proxied tools are forwarded to the active client session when request context is available. Resolves once mounting is complete.
+Mounts one or more remote HTTP MCP servers onto this server. It introspects each remote server's tools, static resources, and prompts and registers them natively, so this server acts as a gateway. Config-map keys automatically namespace capabilities; an existing `MCPConnection` uses its negotiated server name. Connection, introspection, and collision failures are reported diagnostically while successfully mountable capabilities remain available.
+
+Proxy config accepts caller-managed bearer tokens and authentication headers. It does not expose stdio or automatic OAuth options, and it disables client auto-OAuth internally so proxy setup and server startup never open a browser.
 
 **Parameters**
-><ParamField body="config" type="Record<string, any> | MCPSession" required="true" >   A map of namespace to server connection config, or a single `MCPSession`. </ParamField>
-><ParamField body="options" type="{ namespace?: string } | undefined" default="undefined" >   Additional options. Provide `namespace` when passing a single `MCPSession`. </ParamField>
+><ParamField body="config" type="Record<string, ProxyServerConfig> | ProxyConnection" required="true" >   A name-keyed map of HTTP server connection config, or one ready caller-owned connection. </ParamField>
 
 **Returns**
 ><ResponseField name="returns" type="Promise<void>" />
 
 **Example**
 ```ts wrap
-// Using a config map of namespaces
+// Config keys become namespaces automatically
 await server.proxy({
-  db: { command: "node", args: ["db.js"] },
+  db: {
+    url: "https://database.example.com/mcp",
+    authToken: process.env.DATABASE_MCP_TOKEN,
+  },
 });
 
-// Using an explicit session
-await server.proxy(mySession, { namespace: "db" });
+// The connection's negotiated server name becomes its namespace
+await server.proxy(connection);
 ```
 
 **Signature**
 ```ts wrap
-proxy(config: Record<string, any> | MCPSession, options?: { namespace?: string }): Promise<void>
+proxy(config: Record<string, ProxyServerConfig> | ProxyConnection): Promise<void>
 ```
 
 ## Static methods

--- a/docs/typescript/server/proxy.mdx
+++ b/docs/typescript/server/proxy.mdx
@@ -4,7 +4,7 @@ description: "Proxy multiple MCP servers through one TypeScript MCP endpoint wit
 icon: "git-merge"
 ---
 
-`server.proxy()` connects to multiple upstream MCP servers and exposes their tools, static resources, and prompts through one endpoint. Each upstream server gets a namespace so capability names do not collide.
+`server.proxy()` connects to multiple upstream HTTP MCP servers and exposes their tools, static resources, and prompts through one endpoint. Config-map keys and negotiated server names automatically namespace proxied capabilities.
 
 ## Install the optional client
 
@@ -18,7 +18,7 @@ If you call `server.proxy()` without the client installed, mcp-use throws an err
 
 ## Proxy multiple servers
 
-Pass an object whose keys are namespaces and whose values are `@mcp-use/client` connection settings. You can mix HTTP and stdio servers.
+Pass an object whose keys identify upstreams and whose values contain HTTP connection settings. The keys automatically become capability namespaces.
 
 ```typescript
 import { MCPServer } from "mcp-use";
@@ -29,19 +29,12 @@ const server = new MCPServer({
 });
 
 await server.proxy({
-  database: {
-    command: "node",
-    args: ["./database-server.mjs"],
-  },
   weather: {
     url: "https://weather.example.com/mcp",
-    oauth: false,
   },
   internal: {
     url: "https://internal.example.com/mcp",
-    headers: {
-      Authorization: `Bearer ${process.env.INTERNAL_MCP_TOKEN}`,
-    },
+    authToken: process.env.INTERNAL_MCP_TOKEN,
   },
 });
 
@@ -56,17 +49,18 @@ The gateway exposes upstream names with a `<namespace>_` prefix:
 
 | Upstream capability            | Gateway capability  |
 | ------------------------------ | ------------------- |
-| `database` tool `query`        | `database_query`    |
 | `weather` prompt `forecast`    | `weather_forecast`  |
 | `internal` resource `handbook` | `internal_handbook` |
 
 Static resource URIs use the `mcp-use-proxy` scheme. The gateway maps each proxy URI back to the original upstream URI when a client reads it.
 
-Call `proxy()` before `listen()` or `getHandler()`. The server connects and introspects every upstream first, then registers the complete set. A connection, introspection, or name-collision error leaves the parent registry unchanged.
+Call `proxy()` before `listen()` or `getHandler()`. Registration is best-effort: a connection failure skips that upstream, an introspection failure skips only the affected capability kind, and a name collision skips only the colliding capability. Each failure is written to the server's diagnostics while other upstreams and capabilities remain available.
+
+Proxy config deliberately supports bearer tokens and explicit authentication headers, but not automatic OAuth. `server.proxy()` disables the client's browser-based OAuth flow, so starting the gateway never opens a browser. Obtain and refresh credentials in your application, then pass them with `authToken` or `headers`.
 
 ## Mount an existing connection
 
-Pass a ready `MCPConnection` when your application needs to create the client itself, such as for custom OAuth setup.
+Pass a ready `MCPConnection` when your application creates the client itself. The upstream's negotiated server name automatically becomes the namespace.
 
 ```typescript
 import { MCPClient } from "@mcp-use/client";
@@ -76,6 +70,8 @@ const client = new MCPClient({
   mcpServers: {
     secure_database: {
       url: "https://database.example.com/mcp",
+      authToken: process.env.DATABASE_MCP_TOKEN,
+      oauth: false,
     },
   },
 });
@@ -87,7 +83,7 @@ const server = new MCPServer({
   version: "1.0.0",
 });
 
-await server.proxy(connection, { namespace: "database" });
+await server.proxy(connection);
 await server.listen(3000);
 ```
 

--- a/docs/typescript/server/proxy.mdx
+++ b/docs/typescript/server/proxy.mdx
@@ -1,124 +1,113 @@
 ---
-title: "Server Composition"
-description: "Compose multiple MCP servers into one unified aggregator server."
+title: "Compose MCP servers"
+description: "Proxy multiple MCP servers through one TypeScript MCP endpoint with server.proxy() and the optional @mcp-use/client package."
 icon: "git-merge"
 ---
 
-The `mcp-use` TypeScript SDK lets you proxy and compose multiple MCP servers into a single unified aggregator server.
+`server.proxy()` connects to multiple upstream MCP servers and exposes their tools, static resources, and prompts through one endpoint. Each upstream server gets a namespace so capability names do not collide.
 
-This is extremely useful when you have multiple microservices or specialized MCP servers (like a database server, a weather server, and an internal API server) and you want to expose all of their tools, resources, and prompts through a single unified endpoint.
+## Install the optional client
 
-## High-Level API (Config Object)
+Proxying requires `@mcp-use/client` v2. The package is an optional peer of `mcp-use`, so applications that do not call `server.proxy()` do not need to install it.
 
-The most elegant way to proxy servers is to pass a configuration object directly to `server.proxy()`. The keys of the object act as the **namespaces** for the child servers, preventing any naming collisions.
-
-```typescript
-import { MCPServer, text } from "mcp-use/server";
-import path from "node:path";
-
-const server = new MCPServer({ name: "UnifiedServer", version: "1.0.0" });
-
-// The SDK handles all connections, sessions, and synchronization automatically
-await server.proxy({
-  // Proxy a local TypeScript server (using the 'tsx' runner)
-  database: {
-    command: "tsx",
-    args: [path.resolve(__dirname, "./db-server.ts")],
-  },
-
-  // Proxy a local Python FastMCP server
-  weather: {
-    command: "uv",
-    args: ["run", "weather_server.py"],
-    env: { ...process.env, FASTMCP_LOG_LEVEL: "ERROR" },
-  },
-
-  // Proxy a remote server over HTTP
-  manufact: {
-    url: "https://manufact.com/docs/mcp",
-  },
-});
-
-// Expose our own tools alongside the proxied ones
-server.tool(
-  {
-    name: "aggregator_status",
-    description: "Check aggregator status",
-  },
-  async () => text("All systems operational"),
-);
-
-// Start the unified server
-await server.listen(3000);
+```bash
+npm install mcp-use @mcp-use/client
 ```
 
-In the example above, the `database` tools will be prefixed with `database_` (e.g. `database_query`), the `weather` tools will be prefixed with `weather_` (e.g. `weather_get_forecast`), and so on.
+If you call `server.proxy()` without the client installed, mcp-use throws an error with the install command. Importing or running a server without calling `proxy()` does not load the client package.
 
-## Low-Level API (Explicit Session)
+## Proxy multiple servers
 
-For advanced use cases (such as dynamically determining auth headers or using
-custom connectors), you can inject an `MCPConnection` directly into `proxy`.
+Pass an object whose keys are namespaces and whose values are `@mcp-use/client` connection settings. You can mix HTTP and stdio servers.
 
 ```typescript
-import { MCPServer } from "mcp-use/server";
-import { MCPClient } from "@mcp-use/client";
+import { MCPServer } from "mcp-use";
 
-const server = new MCPServer({ name: "UnifiedServer", version: "1.0.0" });
+const server = new MCPServer({
+  name: "gateway",
+  version: "1.0.0",
+});
 
-// Create a custom client orchestration
-const customClient = new MCPClient({
-  mcpServers: {
-    secure_db: {
-      url: "https://secure-db.example.com/mcp",
+await server.proxy({
+  database: {
+    command: "node",
+    args: ["./database-server.mjs"],
+  },
+  weather: {
+    url: "https://weather.example.com/mcp",
+    oauth: false,
+  },
+  internal: {
+    url: "https://internal.example.com/mcp",
+    headers: {
+      Authorization: `Bearer ${process.env.INTERNAL_MCP_TOKEN}`,
     },
   },
 });
 
-// Manage the session manually
-const dbSession = await customClient.createSession("secure_db");
-
-// Proxy the active session, manually specifying the namespace
-await server.proxy(dbSession, { namespace: "secure_db" });
+server.tool({ name: "gateway_status" }, async () => ({
+  content: [{ type: "text", text: "Gateway is running" }],
+}));
 
 await server.listen(3000);
 ```
 
-## Example Usage
+The gateway exposes upstream names with a `<namespace>_` prefix:
 
-<Card
-  title="Proxy Server Example"
-  icon="github"
-  href="https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/features/proxy"
->
-  See a fully working example of server composition in the mcp-use repository.
-</Card>
+| Upstream capability            | Gateway capability  |
+| ------------------------------ | ------------------- |
+| `database` tool `query`        | `database_query`    |
+| `weather` prompt `forecast`    | `weather_forecast`  |
+| `internal` resource `handbook` | `internal_handbook` |
 
-## How It Works
+Static resource URIs use the `mcp-use-proxy` scheme. The gateway maps each proxy URI back to the original upstream URI when a client reads it.
 
-When you proxy a server, the `mcp-use` SDK automatically:
+Call `proxy()` before `listen()` or `getHandler()`. The server connects and introspects every upstream first, then registers the complete set. A connection, introspection, or name-collision error leaves the parent registry unchanged.
 
-1. **Introspects** the child server by calling `listTools()`, `listResources()`, and `listPrompts()`.
-2. **Translates** the raw JSON Schemas returned by the child server into runtime `Zod` schemas for perfect compatibility with the `mcp-use` validation pipeline.
-3. **Namespaces** the component names to prevent collisions.
-4. **Relays** execution. When a client calls a proxied tool, the Aggregator intercepts it and forwards the execution to the child server.
-5. **Synchronizes** state. The Aggregator listens to `notifications/tools/list_changed` (and other list_changed events) emitted by the child server and instantly forwards them to all clients connected to the Aggregator.
+## Mount an existing connection
 
-## Advanced Features
+Pass a ready `MCPConnection` when your application needs to create the client itself, such as for custom OAuth setup.
 
-The `mcp-use` proxying system goes far beyond simple tool forwarding. It transparently supports the most advanced features of the Model Context Protocol:
+```typescript
+import { MCPClient } from "@mcp-use/client";
+import { MCPServer } from "mcp-use";
 
-### LLM Sampling & Elicitation
+const client = new MCPClient({
+  mcpServers: {
+    secure_database: {
+      url: "https://database.example.com/mcp",
+    },
+  },
+});
 
-If a child server requests LLM Sampling (`sampling/createMessage`) or Elicitation (`elicitation/create`), the Aggregator automatically intercepts the out-of-band JSONRPC request, dynamically resolves the HTTP context of the specific user who triggered the tool, and routes the request back to that specific user's client.
+const connection = await client.connect("secure_database");
 
-If a request context is somehow lost (e.g., executing a tool via a headless script), the Aggregator provides graceful fallbacks so the child server doesn't hang.
+const server = new MCPServer({
+  name: "gateway",
+  version: "1.0.0",
+});
 
-### Progress Tracking
+await server.proxy(connection, { namespace: "database" });
+await server.listen(3000);
+```
 
-If a child tool emits `notifications/progress` events, the Aggregator catches those events and pipes them directly through the unified `ToolContext` back to the parent client.
+The parent server owns connections it creates from a config object and closes them in `server.close()`. Your application remains responsible for an explicitly supplied connection:
 
-### Resource URIs
+```typescript
+await server.close();
+await client.close();
+```
 
-To prevent URI collisions across different servers, the proxy automatically prepends the namespace to the resource URI protocol.
+## Forwarded behavior
 
-For example, if the `weather` server exposes a resource at `app://settings`, the Aggregator will expose it as `weather://app://settings`. When a client reads that resource, the Aggregator strips the prefix and requests the original URI from the child server.
+The proxy introspects each upstream once during setup and forwards:
+
+- Tool metadata, input and output JSON Schemas, calls, structured content, error results, cancellation, and progress
+- Static resource metadata and reads
+- Prompt metadata, argument schemas, and prompt requests
+
+The initial v2 implementation does not proxy resource templates, completions, subscriptions, upstream list-change re-synchronization, or legacy push-style sampling and elicitation callbacks.
+
+## Run the complete example
+
+The [multiple-server proxy example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/proxy) starts two local upstream servers and proxies both through one gateway.

--- a/libraries/typescript/.changeset/calm-proxies-compose.md
+++ b/libraries/typescript/.changeset/calm-proxies-compose.md
@@ -1,0 +1,7 @@
+---
+"mcp-use": minor
+---
+
+Add `MCPServer.proxy()` for composing multiple upstream MCP servers through the
+optional `@mcp-use/client` v2 peer. Config-map connections are namespaced and
+server-owned; ready `MCPConnection` instances can also be mounted directly.

--- a/libraries/typescript/.changeset/calm-proxies-compose.md
+++ b/libraries/typescript/.changeset/calm-proxies-compose.md
@@ -3,5 +3,7 @@
 ---
 
 Add `MCPServer.proxy()` for composing multiple upstream MCP servers through the
-optional `@mcp-use/client` v2 peer. Config-map connections are namespaced and
-server-owned; ready `MCPConnection` instances can also be mounted directly.
+optional `@mcp-use/client` v2 peer. HTTP upstreams are automatically namespaced
+and registered best-effort, authenticated connections use caller-managed bearer
+tokens or headers without browser OAuth, and ready `MCPConnection` instances can
+also be mounted with their negotiated server name as the namespace.

--- a/libraries/typescript/packages/server/examples/proxy/README.md
+++ b/libraries/typescript/packages/server/examples/proxy/README.md
@@ -1,0 +1,30 @@
+# Multiple-server proxy example
+
+This example starts two upstream MCP servers and exposes both through one gateway. The gateway adds `weather_` and `inventory_` namespaces while preserving a local `gateway_status` tool.
+
+## Run the gateway
+
+From `libraries/typescript`:
+
+```bash
+pnpm install
+pnpm --filter mcp-use-example-proxy start
+```
+
+The gateway listens at `http://localhost:3000/mcp`. Set `PORT` to use another port.
+
+The process starts and stops both upstream servers automatically. The upstream servers use ephemeral local ports, so the example does not require separate terminals or port configuration.
+
+## Inspect the exposed capabilities
+
+Connect an MCP client to `http://localhost:3000/mcp`. The gateway exposes:
+
+| Capability | Name | Source |
+| --- | --- | --- |
+| Tool | `gateway_status` | Gateway |
+| Tool | `weather_forecast` | Weather server |
+| Prompt | `weather_plan_trip` | Weather server |
+| Tool | `inventory_find_product` | Inventory server |
+| Resource | `inventory_featured_product` | Inventory server |
+
+This package lists `@mcp-use/client` as a dependency because it calls `server.proxy()`. Projects that do not use `server.proxy()` do not need to install the optional client peer.

--- a/libraries/typescript/packages/server/examples/proxy/package.json
+++ b/libraries/typescript/packages/server/examples/proxy/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "mcp-use-example-proxy",
+  "type": "module",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Example: proxy multiple MCP servers through one mcp-use endpoint.",
+  "engines": {
+    "node": ">=24.0.0"
+  },
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "start": "tsx src/index.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@mcp-use/client": "workspace:*",
+    "mcp-use": "workspace:*",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "^24.13.2",
+    "tsx": "^4.21.0",
+    "typescript": "7.0.1-rc"
+  }
+}

--- a/libraries/typescript/packages/server/examples/proxy/src/index.ts
+++ b/libraries/typescript/packages/server/examples/proxy/src/index.ts
@@ -2,7 +2,7 @@ import { createProxyExample } from "./server.js";
 
 function getPort(): number {
   const value = process.env["PORT"] ?? "3000";
-  const port = Number(value);
+  const port = value.trim() === "" ? Number.NaN : Number(value);
   if (!Number.isInteger(port) || port < 0 || port > 65_535) {
     throw new Error(
       `PORT must be an integer from 0 to 65535; received ${value}`
@@ -21,8 +21,13 @@ try {
   );
 
   await new Promise<void>((resolve) => {
-    process.once("SIGINT", resolve);
-    process.once("SIGTERM", resolve);
+    const shutdown = (): void => {
+      process.off("SIGINT", shutdown);
+      process.off("SIGTERM", shutdown);
+      resolve();
+    };
+    process.once("SIGINT", shutdown);
+    process.once("SIGTERM", shutdown);
   });
 } finally {
   await example.close();

--- a/libraries/typescript/packages/server/examples/proxy/src/index.ts
+++ b/libraries/typescript/packages/server/examples/proxy/src/index.ts
@@ -1,0 +1,29 @@
+import { createProxyExample } from "./server.js";
+
+function getPort(): number {
+  const value = process.env["PORT"] ?? "3000";
+  const port = Number(value);
+  if (!Number.isInteger(port) || port < 0 || port > 65_535) {
+    throw new Error(
+      `PORT must be an integer from 0 to 65535; received ${value}`
+    );
+  }
+  return port;
+}
+
+const example = await createProxyExample();
+
+try {
+  const address = await example.server.listen(getPort());
+  console.log(`Proxy gateway: ${address.url}`);
+  console.log(
+    "Tools: gateway_status, weather_forecast, inventory_find_product"
+  );
+
+  await new Promise<void>((resolve) => {
+    process.once("SIGINT", resolve);
+    process.once("SIGTERM", resolve);
+  });
+} finally {
+  await example.close();
+}

--- a/libraries/typescript/packages/server/examples/proxy/src/server.ts
+++ b/libraries/typescript/packages/server/examples/proxy/src/server.ts
@@ -1,0 +1,84 @@
+import { MCPServer } from "mcp-use";
+
+import { createInventoryServer, createWeatherServer } from "./upstreams.js";
+
+/** Running servers and cleanup returned by {@link createProxyExample}. */
+export interface ProxyExample {
+  /** Gateway that exposes local and proxied capabilities. */
+  server: MCPServer;
+  /** Close the gateway and both upstream servers. Safe to call more than once. */
+  close(): Promise<void>;
+}
+
+/**
+ * Start two ephemeral upstream servers and mount them on one proxy gateway.
+ * The caller chooses when and where the returned gateway starts listening.
+ */
+export async function createProxyExample(): Promise<ProxyExample> {
+  const weather = createWeatherServer();
+  const inventory = createInventoryServer();
+  let gateway: MCPServer | undefined;
+
+  try {
+    const [weatherAddress, inventoryAddress] = await Promise.all([
+      weather.listen(0),
+      inventory.listen(0),
+    ]);
+
+    gateway = new MCPServer({
+      name: "multi-server-proxy",
+      version: "1.0.0",
+    });
+
+    gateway.tool(
+      {
+        name: "gateway_status",
+        description: "Report whether the proxy gateway is running.",
+      },
+      async () => ({
+        content: [{ type: "text", text: "Proxy gateway is running" }],
+      })
+    );
+
+    await gateway.proxy({
+      weather: {
+        url: weatherAddress.url,
+        oauth: false,
+      },
+      inventory: {
+        url: inventoryAddress.url,
+        oauth: false,
+      },
+    });
+  } catch (error) {
+    await Promise.allSettled([
+      gateway?.close(),
+      weather.close(),
+      inventory.close(),
+    ]);
+    throw error;
+  }
+
+  let closed = false;
+  return {
+    server: gateway,
+    async close() {
+      if (closed) return;
+      closed = true;
+      const results = await Promise.allSettled([
+        gateway.close(),
+        weather.close(),
+        inventory.close(),
+      ]);
+      const errors = results.flatMap((result) =>
+        result.status === "rejected" ? [result.reason] : []
+      );
+      if (errors.length > 0) {
+        throw new AggregateError(
+          errors,
+          "Failed to close proxy example servers"
+        );
+      }
+    },
+  };
+}

--- a/libraries/typescript/packages/server/examples/proxy/src/server.ts
+++ b/libraries/typescript/packages/server/examples/proxy/src/server.ts
@@ -43,11 +43,9 @@ export async function createProxyExample(): Promise<ProxyExample> {
     await gateway.proxy({
       weather: {
         url: weatherAddress.url,
-        oauth: false,
       },
       inventory: {
         url: inventoryAddress.url,
-        oauth: false,
       },
     });
   } catch (error) {

--- a/libraries/typescript/packages/server/examples/proxy/src/upstreams.ts
+++ b/libraries/typescript/packages/server/examples/proxy/src/upstreams.ts
@@ -1,0 +1,95 @@
+import { MCPServer } from "mcp-use";
+import { z } from "zod";
+
+/** Create the weather server mounted under the `weather` namespace. */
+export function createWeatherServer(): MCPServer {
+  const server = new MCPServer({
+    name: "weather-upstream",
+    version: "1.0.0",
+  });
+
+  server.tool(
+    {
+      name: "forecast",
+      description: "Return a sample forecast for a city.",
+      inputSchema: z.object({ city: z.string() }),
+    },
+    async ({ city }) => ({
+      content: [
+        {
+          type: "text",
+          text: `${city}: 21°C, clear skies`,
+        },
+      ],
+    })
+  );
+
+  server.prompt(
+    {
+      name: "plan_trip",
+      description: "Create a prompt for planning around the weather.",
+      schema: z.object({ city: z.string() }),
+    },
+    async ({ city }) => ({
+      messages: [
+        {
+          role: "user",
+          content: {
+            type: "text",
+            text: `Plan a one-day trip to ${city} for clear, 21°C weather.`,
+          },
+        },
+      ],
+    })
+  );
+
+  return server;
+}
+
+/** Create the inventory server mounted under the `inventory` namespace. */
+export function createInventoryServer(): MCPServer {
+  const server = new MCPServer({
+    name: "inventory-upstream",
+    version: "1.0.0",
+  });
+
+  server.tool(
+    {
+      name: "find_product",
+      description: "Look up a sample product by SKU.",
+      inputSchema: z.object({ sku: z.string() }),
+    },
+    async ({ sku }) => ({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({ sku, name: "Travel umbrella", inStock: true }),
+        },
+      ],
+    })
+  );
+
+  server.resource(
+    {
+      name: "featured_product",
+      uri: "inventory://featured",
+      description: "The featured product in the sample inventory.",
+      mimeType: "application/json",
+    },
+    async (uri) => ({
+      contents: [
+        {
+          uri: uri.href,
+          mimeType: "application/json",
+          text: JSON.stringify({
+            sku: "UMBRELLA-01",
+            name: "Travel umbrella",
+            inStock: true,
+          }),
+        },
+      ],
+    })
+  );
+
+  return server;
+}

--- a/libraries/typescript/packages/server/examples/proxy/tsconfig.json
+++ b/libraries/typescript/packages/server/examples/proxy/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2024"],
+    "types": ["node"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}

--- a/libraries/typescript/packages/server/specs/SPEC.md
+++ b/libraries/typescript/packages/server/specs/SPEC.md
@@ -197,25 +197,30 @@ Calls use `options.baseUrl`, then the first `spec.servers` URL; constructing a g
 
 ## Upstream server composition
 
-`await server.proxy(servers)` composes namespace-keyed upstream MCP servers into the static parent registry before `listen()` or `getHandler()`. The server dynamically imports the optional `@mcp-use/client` v2 peer, creates one `MCPClient` for the supplied configuration, calls `connectAll()`, introspects every ready `MCPConnection`, and mounts forwarders only after every namespace has been introspected and checked for collisions. A failed connection, introspection, or collision leaves the parent registry unchanged and closes every connection created by that call.
+`await server.proxy(servers)` composes name-keyed upstream HTTP MCP servers into the static parent registry before `listen()` or `getHandler()`. The server dynamically imports the optional `@mcp-use/client` v2 peer, creates one `MCPClient`, and connects to each configured server independently. Config-map keys automatically namespace capabilities. Connection failures skip that upstream, introspection failures skip only the affected capability kind, and name collisions skip only the colliding capability; every skipped item emits a diagnostic while successfully mountable upstreams and capabilities remain registered.
 
 ```ts
 await server.proxy({
-  database: { command: "node", args: ["./database.mjs"] },
-  weather: { url: "https://weather.example.com/mcp", oauth: false },
+  weather: { url: "https://weather.example.com/mcp" },
+  database: {
+    url: "https://database.example.com/mcp",
+    authToken: process.env.DATABASE_MCP_TOKEN,
+  },
 });
 ```
 
-The namespace prefixes tool, resource, and prompt names with `<namespace>_`. Static resource listing URIs use `mcp-use-proxy:///<encoded namespace>/<encoded upstream URI>` so any namespace is valid and upstream URI schemes cannot collide. Reads forward the original URI. Tool calls preserve raw results (including `isError`, `structuredContent`, `_meta`, and `input_required` where the client supports it), downstream cancellation is passed upstream, and upstream progress is reported through the active downstream request context. Input/output JSON Schemas, annotations, titles, and descriptions are advertised from the introspected upstream metadata; validation remains authoritative upstream.
+The automatic namespace prefixes tool, resource, and prompt names with `<namespace>_`. Static resource listing URIs use `mcp-use-proxy:///<encoded namespace>/<encoded upstream URI>` so any namespace is valid and upstream URI schemes cannot collide. Reads forward the original URI. Tool calls preserve raw results (including `isError`, `structuredContent`, `_meta`, and `input_required` where the client supports it), downstream cancellation is passed upstream, and upstream progress is reported through the active downstream request context. A failed downstream progress notification is diagnosed without rejecting the upstream tool call. Input/output JSON Schemas, annotations, titles, and descriptions are advertised from the introspected upstream metadata; validation remains authoritative upstream.
 
 The low-level overload accepts an existing ready connection:
 
 ```ts
 const connection = await client.connect("database");
-await server.proxy(connection, { namespace: "database" });
+await server.proxy(connection);
 ```
 
-Connections created from a config map are owned by the parent and closed by `server.close()`. An explicitly supplied connection remains caller-owned. Calling `proxy()` after the parent starts throws before loading the optional peer. If `@mcp-use/client` is absent, config-map proxying throws with an unversioned npm install command; importing and running a server that never calls `proxy()` does not evaluate or require the client package.
+An existing connection's negotiated server name supplies its automatic namespace. Connections created from a config map are owned by the parent and closed by `server.close()`, including when shutdown overlaps an in-flight `proxy()` call. Cleanup waits for every owned client even if one close fails. An explicitly supplied connection remains caller-owned. Calling `proxy()` after the parent starts or closes throws before mounting capabilities. If `@mcp-use/client` is absent, config-map proxying throws with an unversioned npm install command; importing and running a server that never calls `proxy()` does not evaluate or require the client package.
+
+Proxy configuration is HTTP-only and accepts explicit bearer tokens or authentication headers. The public proxy API has no stdio or OAuth options. Internally the server forces client auto-OAuth off, so proxy setup and server startup never open a browser or acquire tokens; applications own credential acquisition and refresh.
 
 The initial v2 surface proxies tools, static resources, and prompts. It does not proxy resource templates, completions, subscriptions, upstream list-change re-synchronization, or legacy push-style sampling/elicitation callbacks.
 

--- a/libraries/typescript/packages/server/specs/SPEC.md
+++ b/libraries/typescript/packages/server/specs/SPEC.md
@@ -18,7 +18,7 @@ Greenfield framework on the official v2 SDK (`@modelcontextprotocol/server`, sta
 - No feature may require session state; cross-request continuity uses explicit handles in results.
 - One framework package. `mcp-use` ships the server runtime and the complete first-party CLI: `dev`, `build`, `start`, cloud auth, organizations, servers, deployments, deploy, client, screenshot, and skills (`CLI_SPEC.md`). Each substantial command is a genuine lazy chunk; `dev` and `build` are separate chunks, and neither `start` nor a library export may statically evaluate Vite or unrelated command code.
 - Vite is a regular dependency so `npm install mcp-use` is sufficient for `mcp-use dev` and `mcp-use build`. `@vitejs/plugin-react` becomes a regular dependency when views land. `react` and `react-dom` remain optional peers owned by view applications.
-- `mcp-use` has no npm dependency edge of any kind to `@mcp-use/inspector`; embedded inspector integration is HTTP/CDN only. `@mcp-use/client` remains an independently published SDK and an **optional peer** — `mcp-use client` and `mcp-use screenshot` load it on demand and print install instructions when it is missing; the library entry and `start` never evaluate it.
+- `mcp-use` has no npm dependency edge of any kind to `@mcp-use/inspector`; embedded inspector integration is HTTP/CDN only. `@mcp-use/client` remains an independently published SDK and an **optional peer** — `server.proxy()`, `mcp-use client`, and `mcp-use screenshot` load it on demand and print install instructions when it is missing; the library entry and `start` never evaluate it.
 - `create-mcp-use-app` remains a separately published, zero-runtime-dependency scaffolder. There is no `@mcp-use/config` package.
 - ESM-only (forced by the SDK). Node ≥ 24 (current LTS) — this package tracks the latest runtime, not the SDK's `>=20` floor.
 - Dependencies track latest releases: caret ranges at current latest; TypeScript is a package-local devDep pinned to the TS 7 RC (native compiler; exact pin while pre-release — caret ranges don't traverse pre-releases; workspace root still pins 5.9 for the old packages). Watch the root `pnpm.overrides`: they _replace_ this package's specifiers, so v1-era audit floors/pins there must be raised or removed when they'd hold this package back (zod/vitest raised).
@@ -195,6 +195,30 @@ Calls use `options.baseUrl`, then the first `spec.servers` URL; constructing a g
 
 `examples/openapi` is the runnable reference: it fetches the National Weather Service document at entry load, selects four read-only weather operations, and default-exports the generated server for the standard `mcp-use dev` / `build` / `start` lifecycle.
 
+## Upstream server composition
+
+`await server.proxy(servers)` composes namespace-keyed upstream MCP servers into the static parent registry before `listen()` or `getHandler()`. The server dynamically imports the optional `@mcp-use/client` v2 peer, creates one `MCPClient` for the supplied configuration, calls `connectAll()`, introspects every ready `MCPConnection`, and mounts forwarders only after every namespace has been introspected and checked for collisions. A failed connection, introspection, or collision leaves the parent registry unchanged and closes every connection created by that call.
+
+```ts
+await server.proxy({
+  database: { command: "node", args: ["./database.mjs"] },
+  weather: { url: "https://weather.example.com/mcp", oauth: false },
+});
+```
+
+The namespace prefixes tool, resource, and prompt names with `<namespace>_`. Static resource listing URIs use `mcp-use-proxy:///<encoded namespace>/<encoded upstream URI>` so any namespace is valid and upstream URI schemes cannot collide. Reads forward the original URI. Tool calls preserve raw results (including `isError`, `structuredContent`, `_meta`, and `input_required` where the client supports it), downstream cancellation is passed upstream, and upstream progress is reported through the active downstream request context. Input/output JSON Schemas, annotations, titles, and descriptions are advertised from the introspected upstream metadata; validation remains authoritative upstream.
+
+The low-level overload accepts an existing ready connection:
+
+```ts
+const connection = await client.connect("database");
+await server.proxy(connection, { namespace: "database" });
+```
+
+Connections created from a config map are owned by the parent and closed by `server.close()`. An explicitly supplied connection remains caller-owned. Calling `proxy()` after the parent starts throws before loading the optional peer. If `@mcp-use/client` is absent, config-map proxying throws with an unversioned npm install command; importing and running a server that never calls `proxy()` does not evaluate or require the client package.
+
+The initial v2 surface proxies tools, static resources, and prompts. It does not proxy resource templates, completions, subscriptions, upstream list-change re-synchronization, or legacy push-style sampling/elicitation callbacks.
+
 ## Request logging
 
 Built-in HTTP/MCP request logging (`src/logging.ts`), on by default. One summary line per HTTP request plus an indented detail line for MCP requests:
@@ -263,7 +287,7 @@ server.tool(
 - **Auth: direct resource-server mode implemented; proxy mode deferred.** Contract in **`AUTH_SPEC.md`** / **`AUTH_IMPLEMENTATION.md`** (resource-server posture, `ctx.auth`, `bearerAuth`/`oauthMetadata`, provider adapters, RFC 9728 metadata). OAuth proxy mode (local authorization server) remains deferred.
 - **Product shell:** OAuth providers + scope guards + `.well-known` (with auth, above), operation middleware (`server.use("mcp:*")`) and observer events (`server.on("mcp:*")`), optional `ServerConfig.cors`, the browser landing page, and resource-subscription ergonomics are implemented. Cross-request v2 list/resource notifications are implemented through `MCPServer.notify*`, backed by the SDK handler bus. Every per-request SDK server advertises tool/prompt/resource `listChanged` (and resource `subscribe`) even while a registry is empty, so a client connected before the first primitive is added can subscribe. `getHandler({ bus })` accepts an SDK `ServerEventBus` for entries that need several handler instances to share open subscriptions; `mcp-use dev` uses one process-scoped bus across every reload generation and publishes all three list invalidations after a successful handler swap.
 - **Elicitation & context:** MRTR state, typed form and URL elicitation, progress, and logging helpers are implemented. Push-style sampling/roots remain legacy-only and are deprecated in the 2026-07-28 spec.
-- **Integration:** OpenAPI import is implemented. Telemetry (posthog-node, opt-out) remains deferred. The independently published `@mcp-use/client` remains the SDK boundary; the framework consumes it for `mcp-use client` rather than folding or re-exporting the SDK from the server runtime.
+- **Integration:** OpenAPI import and upstream server composition are implemented. Telemetry (posthog-node, opt-out) remains deferred. The independently published `@mcp-use/client` remains the SDK boundary; the framework consumes it on demand for `server.proxy()` and `mcp-use client` rather than folding or re-exporting the SDK from the server runtime.
 
 ## Open questions (answered per phase, not up front)
 

--- a/libraries/typescript/packages/server/src/index.ts
+++ b/libraries/typescript/packages/server/src/index.ts
@@ -155,13 +155,10 @@ export type {
 export type {
   ProxyConnection,
   ProxyHttpConfig,
-  ProxyOAuthOptions,
-  ProxyOptions,
   ProxyProgress,
   ProxyPrompt,
   ProxyRequestOptions,
   ProxyResource,
   ProxyServerConfig,
-  ProxyStdioConfig,
   ProxyTool,
 } from "./proxy.js";

--- a/libraries/typescript/packages/server/src/index.ts
+++ b/libraries/typescript/packages/server/src/index.ts
@@ -152,3 +152,16 @@ export type {
   PromptCallback,
   PromptDefinition,
 } from "./prompts.js";
+export type {
+  ProxyConnection,
+  ProxyHttpConfig,
+  ProxyOAuthOptions,
+  ProxyOptions,
+  ProxyProgress,
+  ProxyPrompt,
+  ProxyRequestOptions,
+  ProxyResource,
+  ProxyServerConfig,
+  ProxyStdioConfig,
+  ProxyTool,
+} from "./proxy.js";

--- a/libraries/typescript/packages/server/src/proxy.ts
+++ b/libraries/typescript/packages/server/src/proxy.ts
@@ -53,7 +53,7 @@ export interface ProxyRequestOptions {
   /** Aborts the upstream request when the downstream request is cancelled. */
   signal?: AbortSignal;
   /** Receives upstream progress notifications. */
-  onprogress?: (progress: ProxyProgress) => void | Promise<void>;
+  onprogress?: (progress: ProxyProgress) => void;
 }
 
 /** Structural connection contract accepted by the low-level proxy overload. */
@@ -353,20 +353,32 @@ function mountPlan(host: ProxyMountHost, plan: ProxyNamespacePlan): void {
     const callback = async (
       params: Record<string, unknown>,
       ctx: RequestContext
-    ) =>
-      plan.connection.callTool(upstreamName, params, {
-        signal: ctx.signal,
-        onprogress: (progress) => {
-          void ctx
-            .reportProgress(progress.progress, progress.total, progress.message)
-            .catch((error: unknown) => {
-              proxyDiagnostic(
-                `Failed to forward progress for proxied tool "${definition.name}"`,
-                error
-              );
+    ) => {
+      let progressForwarding = Promise.resolve();
+      try {
+        return await plan.connection.callTool(upstreamName, params, {
+          signal: ctx.signal,
+          onprogress: (progress) => {
+            progressForwarding = progressForwarding.then(async () => {
+              try {
+                await ctx.reportProgress(
+                  progress.progress,
+                  progress.total,
+                  progress.message
+                );
+              } catch (error) {
+                proxyDiagnostic(
+                  `Failed to forward progress for proxied tool "${definition.name}"`,
+                  error
+                );
+              }
             });
-        },
-      });
+          },
+        });
+      } finally {
+        await progressForwarding;
+      }
+    };
     host.registerTool(definition, callback as ToolCallback);
   }
 

--- a/libraries/typescript/packages/server/src/proxy.ts
+++ b/libraries/typescript/packages/server/src/proxy.ts
@@ -9,49 +9,15 @@ import type {
   ToolAnnotations,
 } from "@modelcontextprotocol/server";
 import type {
+  HttpServerConfig as ClientHttpServerConfig,
   MCPClient as ClientMCPClient,
   MCPConnection as ClientMCPConnection,
-  ServerConfig as ClientServerConfig,
 } from "@mcp-use/client";
 
 import type { RequestContext } from "./context.js";
 import type { PromptCallback, PromptDefinition } from "./prompts.js";
 import type { ResourceCallback, ResourceDefinition } from "./resources.js";
 import type { ToolCallback, ToolDefinition } from "./tools.js";
-
-/** Automatic OAuth settings forwarded to `@mcp-use/client` v2. */
-export interface ProxyOAuthOptions {
-  /** Prefix used when persisting OAuth state. */
-  storageKeyPrefix?: string;
-  /** OAuth client display name. */
-  clientName?: string;
-  /** OAuth client website URL. */
-  clientUri?: string;
-  /** OAuth client logo URL. */
-  logoUri?: string;
-  /** OAuth callback URL override. */
-  callbackUrl?: string;
-  /** OAuth Client ID Metadata Document URL. */
-  clientMetadataUrl?: string;
-  /** Space-delimited scopes requested during authorization. */
-  scope?: string;
-  /** Preferred loopback callback port in Node.js. */
-  preferredPort?: number;
-  /** Number of additional loopback ports tried after the preferred port. */
-  portRange?: number;
-  /** Maximum time to wait for OAuth completion in milliseconds. */
-  authTimeoutMs?: number;
-  /** Browser-opening callback used by Node.js OAuth flows. */
-  openBrowser?: (url: string) => void | Promise<void>;
-  /** Wait for explicit authentication instead of opening OAuth automatically. */
-  preventAutoAuth?: boolean;
-  /** Use a full-page redirect instead of a popup in browser environments. */
-  useRedirectFlow?: boolean;
-  /** Same-origin OAuth proxy base URL for browser environments. */
-  oauthProxyUrl?: string;
-  /** Route OAuth HTTP requests through `oauthProxyUrl`. */
-  proxyOAuthRequests?: boolean;
-}
 
 /** HTTP connection settings accepted by {@link MCPServer.proxy}. */
 export interface ProxyHttpConfig {
@@ -65,34 +31,12 @@ export interface ProxyHttpConfig {
   timeout?: number;
   /** Fetch implementation used for upstream HTTP requests. */
   fetch?: typeof fetch;
-  /** Disable automatic OAuth, or configure the client's automatic OAuth flow. */
-  oauth?: false | ProxyOAuthOptions;
-  /** Protocol negotiation mode forwarded to `@mcp-use/client`. */
-  protocolNegotiation?: "auto" | "legacy" | { pin: string };
-}
-
-/** Node stdio connection settings accepted by {@link MCPServer.proxy}. */
-export interface ProxyStdioConfig {
-  /** Executable that starts the upstream MCP server. */
-  command: string;
-  /** Command-line arguments passed to the executable. */
-  args: string[];
-  /** Environment passed to the child process. */
-  env?: Record<string, string>;
-  /** Working directory for the child process. */
-  cwd?: string;
   /** Protocol negotiation mode forwarded to `@mcp-use/client`. */
   protocolNegotiation?: "auto" | "legacy" | { pin: string };
 }
 
 /** Connection settings for one upstream server. */
-export type ProxyServerConfig = ProxyHttpConfig | ProxyStdioConfig;
-
-/** Options for mounting an existing {@link ProxyConnection}. */
-export interface ProxyOptions {
-  /** Prefix applied to mounted capability names. Omit to preserve names. */
-  namespace?: string;
-}
+export type ProxyServerConfig = ProxyHttpConfig;
 
 /** Progress payload received while a proxied tool is running. */
 export interface ProxyProgress {
@@ -114,6 +58,8 @@ export interface ProxyRequestOptions {
 
 /** Structural connection contract accepted by the low-level proxy overload. */
 export interface ProxyConnection {
+  /** Negotiated metadata used to derive the automatic capability namespace. */
+  readonly info: { server: { name: string } };
   /** Whether the upstream advertised a named MCP capability. */
   supports?(capability: string): boolean;
   /** List upstream tools. */
@@ -208,7 +154,7 @@ export interface ProxyMountHost {
 }
 
 interface ProxyNamespacePlan {
-  namespace: string | undefined;
+  namespace: string;
   connection: ProxyConnection;
   tools: ProxyTool[];
   resources: ProxyResource[];
@@ -221,7 +167,7 @@ interface ProxyClientPackage {
 
 type Assert<T extends true> = T;
 type _ProxyConfigMatchesClient = Assert<
-  ProxyServerConfig extends ClientServerConfig ? true : false
+  ProxyServerConfig extends ClientHttpServerConfig ? true : false
 >;
 type _ClientConnectionMatchesProxy = Assert<
   ClientMCPConnection extends ProxyConnection ? true : false
@@ -255,7 +201,7 @@ function passthroughJsonSchema(
 function promptArgsToJsonSchema(
   args: PromptArgument[] | undefined
 ): JsonSchemaType {
-  const properties: Record<string, JsonSchemaType> = {};
+  const properties = Object.create(null) as Record<string, JsonSchemaType>;
   const required: string[] = [];
   for (const arg of args ?? []) {
     properties[arg.name] = {
@@ -271,15 +217,11 @@ function promptArgsToJsonSchema(
   };
 }
 
-function prefixedName(namespace: string | undefined, name: string): string {
-  return namespace === undefined ? name : `${namespace}_${name}`;
+function prefixedName(namespace: string, name: string): string {
+  return `${namespace}_${name}`;
 }
 
-function proxiedResourceUri(
-  namespace: string | undefined,
-  uri: string
-): string {
-  if (namespace === undefined) return uri;
+function proxiedResourceUri(namespace: string, uri: string): string {
   return `mcp-use-proxy:///${encodeURIComponent(namespace)}/${encodeURIComponent(uri)}`;
 }
 
@@ -302,6 +244,15 @@ function isClientPackageMissing(error: unknown): boolean {
     (code === "ERR_MODULE_NOT_FOUND" || code === "MODULE_NOT_FOUND") &&
     error.message.includes("@mcp-use/client")
   );
+}
+
+function proxyDiagnostic(message: string, error?: unknown): void {
+  if (error === undefined) {
+    console.error(`[mcp-use] ${message}`);
+    return;
+  }
+  const detail = error instanceof Error ? error.message : String(error);
+  console.error(`[mcp-use] ${message}: ${detail}`);
 }
 
 /** Convert a missing optional-client import into the proxy install error. @internal */
@@ -331,94 +282,63 @@ function supports(
 }
 
 async function introspect(
-  namespace: string | undefined,
+  namespace: string,
   connection: ProxyConnection
 ): Promise<ProxyNamespacePlan> {
-  try {
-    const tools = supports(connection, "tools")
-      ? await connection.listTools()
-      : [];
-    let resources: ProxyResource[] = [];
-    if (supports(connection, "resources")) {
+  let tools: ProxyTool[] = [];
+  if (supports(connection, "tools")) {
+    try {
+      tools = await connection.listTools();
+    } catch (error) {
+      proxyDiagnostic(
+        `Failed to introspect tools from upstream MCP server "${namespace}"`,
+        error
+      );
+    }
+  }
+
+  let resources: ProxyResource[] = [];
+  if (supports(connection, "resources")) {
+    try {
       if (connection.listAllResources !== undefined) {
         resources = (await connection.listAllResources()).resources;
       } else if (connection.listResources !== undefined) {
         resources = (await connection.listResources()).resources;
       }
-    }
-    const prompts = supports(connection, "prompts")
-      ? (await connection.listPrompts()).prompts
-      : [];
-    return { namespace, connection, tools, resources, prompts };
-  } catch (error) {
-    const label = namespace ?? "unnamed";
-    const message = error instanceof Error ? error.message : String(error);
-    throw new Error(
-      `Failed to introspect upstream MCP server "${label}": ${message}`,
-      { cause: error }
-    );
-  }
-}
-
-function assertMountable(
-  host: ProxyMountHost,
-  plans: ProxyNamespacePlan[]
-): void {
-  const planned = {
-    tool: new Set<string>(),
-    resource: new Set<string>(),
-    prompt: new Set<string>(),
-  };
-
-  const assertFree = (
-    kind: "tool" | "resource" | "prompt",
-    name: string,
-    namespace: string | undefined
-  ): void => {
-    const exists =
-      kind === "tool"
-        ? host.hasTool(name)
-        : kind === "resource"
-          ? host.hasResource(name)
-          : host.hasPrompt(name);
-    if (exists || planned[kind].has(name)) {
-      throw new Error(
-        `Cannot proxy ${kind} "${name}" from namespace "${namespace ?? "unnamed"}": ` +
-          `a ${kind} with that name is already registered.`
-      );
-    }
-    planned[kind].add(name);
-  };
-
-  for (const plan of plans) {
-    for (const tool of plan.tools) {
-      assertFree(
-        "tool",
-        prefixedName(plan.namespace, tool.name),
-        plan.namespace
-      );
-    }
-    for (const resource of plan.resources) {
-      assertFree(
-        "resource",
-        prefixedName(plan.namespace, resource.name),
-        plan.namespace
-      );
-    }
-    for (const prompt of plan.prompts) {
-      assertFree(
-        "prompt",
-        prefixedName(plan.namespace, prompt.name),
-        plan.namespace
+    } catch (error) {
+      proxyDiagnostic(
+        `Failed to introspect resources from upstream MCP server "${namespace}"`,
+        error
       );
     }
   }
+
+  let prompts: ProxyPrompt[] = [];
+  if (supports(connection, "prompts")) {
+    try {
+      prompts = (await connection.listPrompts()).prompts;
+    } catch (error) {
+      proxyDiagnostic(
+        `Failed to introspect prompts from upstream MCP server "${namespace}"`,
+        error
+      );
+    }
+  }
+
+  return { namespace, connection, tools, resources, prompts };
 }
 
 function mountPlan(host: ProxyMountHost, plan: ProxyNamespacePlan): void {
   for (const tool of plan.tools) {
+    const name = prefixedName(plan.namespace, tool.name);
+    if (host.hasTool(name)) {
+      proxyDiagnostic(
+        `Skipping proxied tool "${name}" from upstream "${plan.namespace}" because that name is already registered`
+      );
+      continue;
+    }
     const definition: ToolDefinition = {
-      name: prefixedName(plan.namespace, tool.name),
+      name,
       ...(tool.title !== undefined && { title: tool.title }),
       ...(tool.description !== undefined && { description: tool.description }),
       ...(tool.annotations !== undefined && { annotations: tool.annotations }),
@@ -436,22 +356,32 @@ function mountPlan(host: ProxyMountHost, plan: ProxyNamespacePlan): void {
     ) =>
       plan.connection.callTool(upstreamName, params, {
         signal: ctx.signal,
-        onprogress: async (progress) => {
-          await ctx.reportProgress(
-            progress.progress,
-            progress.total,
-            progress.message
-          );
+        onprogress: (progress) => {
+          void ctx
+            .reportProgress(progress.progress, progress.total, progress.message)
+            .catch((error: unknown) => {
+              proxyDiagnostic(
+                `Failed to forward progress for proxied tool "${definition.name}"`,
+                error
+              );
+            });
         },
       });
     host.registerTool(definition, callback as ToolCallback);
   }
 
   for (const resource of plan.resources) {
+    const name = prefixedName(plan.namespace, resource.name);
+    if (host.hasResource(name)) {
+      proxyDiagnostic(
+        `Skipping proxied resource "${name}" from upstream "${plan.namespace}" because that name is already registered`
+      );
+      continue;
+    }
     const upstreamUri = resource.uri;
     host.registerResource(
       {
-        name: prefixedName(plan.namespace, resource.name),
+        name,
         uri: proxiedResourceUri(plan.namespace, upstreamUri),
         ...(resource.title !== undefined && { title: resource.title }),
         ...(resource.description !== undefined && {
@@ -467,10 +397,17 @@ function mountPlan(host: ProxyMountHost, plan: ProxyNamespacePlan): void {
   }
 
   for (const prompt of plan.prompts) {
+    const name = prefixedName(plan.namespace, prompt.name);
+    if (host.hasPrompt(name)) {
+      proxyDiagnostic(
+        `Skipping proxied prompt "${name}" from upstream "${plan.namespace}" because that name is already registered`
+      );
+      continue;
+    }
     const upstreamName = prompt.name;
     host.registerPrompt(
       {
-        name: prefixedName(plan.namespace, prompt.name),
+        name,
         ...(prompt.title !== undefined && { title: prompt.title }),
         ...(prompt.description !== undefined && {
           description: prompt.description,
@@ -487,23 +424,34 @@ function mountPlan(host: ProxyMountHost, plan: ProxyNamespacePlan): void {
  *
  * @param host - Parent server registration surface.
  * @param connection - Ready `@mcp-use/client` v2 connection.
- * @param options - Optional namespace applied to mounted names.
- *
  * @internal
  */
 export async function mountProxyConnection(
   host: ProxyMountHost,
-  connection: ProxyConnection,
-  options: ProxyOptions = {}
+  connection: ProxyConnection
 ): Promise<void> {
   if (host.isStarted()) {
     throw new Error(
       "Cannot call proxy() after the server has started: register upstream servers before listen()/getHandler()."
     );
   }
-  const plan = await introspect(options.namespace, connection);
-  assertMountable(host, [plan]);
+  const namespace = connection.info.server.name;
+  const plan = await introspect(namespace, connection);
   mountPlan(host, plan);
+}
+
+function toClientConfig(config: ProxyServerConfig): ClientHttpServerConfig {
+  return {
+    url: config.url,
+    ...(config.headers !== undefined && { headers: config.headers }),
+    ...(config.authToken !== undefined && { authToken: config.authToken }),
+    ...(config.timeout !== undefined && { timeout: config.timeout }),
+    ...(config.fetch !== undefined && { fetch: config.fetch }),
+    ...(config.protocolNegotiation !== undefined && {
+      protocolNegotiation: config.protocolNegotiation,
+    }),
+    oauth: false,
+  };
 }
 
 /**
@@ -526,15 +474,28 @@ export async function mountProxyServers(
   }
 
   const { MCPClient } = await loadProxyClient();
-  const owner = new MCPClient({ mcpServers: servers });
+  const clientServers = Object.fromEntries(
+    Object.entries(servers).map(([name, config]) => [
+      name,
+      toClientConfig(config),
+    ])
+  );
+  const owner = new MCPClient({ mcpServers: clientServers });
   try {
-    const connected: Record<string, ClientMCPConnection> =
-      await owner.connectAll();
     const plans: ProxyNamespacePlan[] = [];
-    for (const [namespace, connection] of Object.entries(connected)) {
+    for (const namespace of Object.keys(clientServers)) {
+      let connection: ClientMCPConnection;
+      try {
+        connection = await owner.connect(namespace);
+      } catch (error) {
+        proxyDiagnostic(
+          `Failed to connect to upstream MCP server "${namespace}"`,
+          error
+        );
+        continue;
+      }
       plans.push(await introspect(namespace, connection));
     }
-    assertMountable(host, plans);
     for (const plan of plans) mountPlan(host, plan);
     host.trackOwner(owner);
   } catch (error) {

--- a/libraries/typescript/packages/server/src/proxy.ts
+++ b/libraries/typescript/packages/server/src/proxy.ts
@@ -1,0 +1,549 @@
+import type {
+  CallToolResult,
+  GetPromptResult,
+  InputRequiredResult,
+  JsonSchemaType,
+  PromptArgument,
+  ReadResourceResult,
+  StandardSchemaWithJSON,
+  ToolAnnotations,
+} from "@modelcontextprotocol/server";
+import type {
+  MCPClient as ClientMCPClient,
+  MCPConnection as ClientMCPConnection,
+  ServerConfig as ClientServerConfig,
+} from "@mcp-use/client";
+
+import type { RequestContext } from "./context.js";
+import type { PromptCallback, PromptDefinition } from "./prompts.js";
+import type { ResourceCallback, ResourceDefinition } from "./resources.js";
+import type { ToolCallback, ToolDefinition } from "./tools.js";
+
+/** Automatic OAuth settings forwarded to `@mcp-use/client` v2. */
+export interface ProxyOAuthOptions {
+  /** Prefix used when persisting OAuth state. */
+  storageKeyPrefix?: string;
+  /** OAuth client display name. */
+  clientName?: string;
+  /** OAuth client website URL. */
+  clientUri?: string;
+  /** OAuth client logo URL. */
+  logoUri?: string;
+  /** OAuth callback URL override. */
+  callbackUrl?: string;
+  /** OAuth Client ID Metadata Document URL. */
+  clientMetadataUrl?: string;
+  /** Space-delimited scopes requested during authorization. */
+  scope?: string;
+  /** Preferred loopback callback port in Node.js. */
+  preferredPort?: number;
+  /** Number of additional loopback ports tried after the preferred port. */
+  portRange?: number;
+  /** Maximum time to wait for OAuth completion in milliseconds. */
+  authTimeoutMs?: number;
+  /** Browser-opening callback used by Node.js OAuth flows. */
+  openBrowser?: (url: string) => void | Promise<void>;
+  /** Wait for explicit authentication instead of opening OAuth automatically. */
+  preventAutoAuth?: boolean;
+  /** Use a full-page redirect instead of a popup in browser environments. */
+  useRedirectFlow?: boolean;
+  /** Same-origin OAuth proxy base URL for browser environments. */
+  oauthProxyUrl?: string;
+  /** Route OAuth HTTP requests through `oauthProxyUrl`. */
+  proxyOAuthRequests?: boolean;
+}
+
+/** HTTP connection settings accepted by {@link MCPServer.proxy}. */
+export interface ProxyHttpConfig {
+  /** Upstream MCP endpoint URL. */
+  url: string;
+  /** Extra headers sent on every upstream request. */
+  headers?: Record<string, string>;
+  /** Bearer token sent to the upstream server. */
+  authToken?: string;
+  /** Connection timeout in milliseconds. */
+  timeout?: number;
+  /** Fetch implementation used for upstream HTTP requests. */
+  fetch?: typeof fetch;
+  /** Disable automatic OAuth, or configure the client's automatic OAuth flow. */
+  oauth?: false | ProxyOAuthOptions;
+  /** Protocol negotiation mode forwarded to `@mcp-use/client`. */
+  protocolNegotiation?: "auto" | "legacy" | { pin: string };
+}
+
+/** Node stdio connection settings accepted by {@link MCPServer.proxy}. */
+export interface ProxyStdioConfig {
+  /** Executable that starts the upstream MCP server. */
+  command: string;
+  /** Command-line arguments passed to the executable. */
+  args: string[];
+  /** Environment passed to the child process. */
+  env?: Record<string, string>;
+  /** Working directory for the child process. */
+  cwd?: string;
+  /** Protocol negotiation mode forwarded to `@mcp-use/client`. */
+  protocolNegotiation?: "auto" | "legacy" | { pin: string };
+}
+
+/** Connection settings for one upstream server. */
+export type ProxyServerConfig = ProxyHttpConfig | ProxyStdioConfig;
+
+/** Options for mounting an existing {@link ProxyConnection}. */
+export interface ProxyOptions {
+  /** Prefix applied to mounted capability names. Omit to preserve names. */
+  namespace?: string;
+}
+
+/** Progress payload received while a proxied tool is running. */
+export interface ProxyProgress {
+  /** Completed work units. */
+  progress: number;
+  /** Total work units, when known. */
+  total?: number | undefined;
+  /** Human-readable progress detail. */
+  message?: string | undefined;
+}
+
+/** Request controls used when forwarding calls to an upstream connection. */
+export interface ProxyRequestOptions {
+  /** Aborts the upstream request when the downstream request is cancelled. */
+  signal?: AbortSignal;
+  /** Receives upstream progress notifications. */
+  onprogress?: (progress: ProxyProgress) => void | Promise<void>;
+}
+
+/** Structural connection contract accepted by the low-level proxy overload. */
+export interface ProxyConnection {
+  /** Whether the upstream advertised a named MCP capability. */
+  supports?(capability: string): boolean;
+  /** List upstream tools. */
+  listTools(): Promise<ProxyTool[]>;
+  /** Forward a tool call. */
+  callTool(
+    name: string,
+    args?: Record<string, unknown>,
+    options?: ProxyRequestOptions
+  ): Promise<CallToolResult | InputRequiredResult>;
+  /** List upstream resources, including pagination when supported. */
+  listAllResources?(): Promise<{ resources: ProxyResource[] }>;
+  /** List one page of upstream resources. */
+  listResources?(): Promise<{ resources: ProxyResource[] }>;
+  /** Read an upstream resource. */
+  readResource(
+    uri: string,
+    options?: ProxyRequestOptions
+  ): Promise<ReadResourceResult>;
+  /** List upstream prompts. */
+  listPrompts(): Promise<{ prompts: ProxyPrompt[] }>;
+  /** Render an upstream prompt. */
+  getPrompt(
+    name: string,
+    args: Record<string, unknown>
+  ): Promise<GetPromptResult>;
+}
+
+/** Tool metadata consumed while introspecting an upstream connection. */
+export interface ProxyTool {
+  /** Upstream tool name. */
+  name: string;
+  /** Human-readable tool title. */
+  title?: string | undefined;
+  /** LLM-facing tool description. */
+  description?: string | undefined;
+  /** Upstream input JSON Schema. */
+  inputSchema?: Record<string, unknown> | undefined;
+  /** Upstream output JSON Schema. */
+  outputSchema?: Record<string, unknown> | undefined;
+  /** Upstream behavioral hints. */
+  annotations?: ToolAnnotations | undefined;
+}
+
+/** Resource metadata consumed while introspecting an upstream connection. */
+export interface ProxyResource {
+  /** Upstream resource name. */
+  name: string;
+  /** Original upstream resource URI. */
+  uri: string;
+  /** Human-readable resource title. */
+  title?: string | undefined;
+  /** Human-readable resource description. */
+  description?: string | undefined;
+  /** Resource media type. */
+  mimeType?: string | undefined;
+}
+
+/** Prompt metadata consumed while introspecting an upstream connection. */
+export interface ProxyPrompt {
+  /** Upstream prompt name. */
+  name: string;
+  /** Human-readable prompt title. */
+  title?: string | undefined;
+  /** Human-readable prompt description. */
+  description?: string | undefined;
+  /** String arguments accepted by the prompt. */
+  arguments?: PromptArgument[] | undefined;
+}
+
+/** Registration surface used while mounting proxied capabilities. @internal */
+export interface ProxyMountHost {
+  /** Whether the parent server has mounted its handler. */
+  isStarted(): boolean;
+  /** Whether a tool name is already registered. */
+  hasTool(name: string): boolean;
+  /** Whether a resource name is already registered. */
+  hasResource(name: string): boolean;
+  /** Whether a prompt name is already registered. */
+  hasPrompt(name: string): boolean;
+  /** Register a proxied tool. */
+  registerTool(definition: ToolDefinition, callback: ToolCallback): void;
+  /** Register a proxied resource. */
+  registerResource(
+    definition: ResourceDefinition,
+    callback: ResourceCallback
+  ): void;
+  /** Register a proxied prompt. */
+  registerPrompt(definition: PromptDefinition, callback: PromptCallback): void;
+  /** Track a proxy client owned by the parent server. */
+  trackOwner(owner: { close(): Promise<void> }): void;
+}
+
+interface ProxyNamespacePlan {
+  namespace: string | undefined;
+  connection: ProxyConnection;
+  tools: ProxyTool[];
+  resources: ProxyResource[];
+  prompts: ProxyPrompt[];
+}
+
+interface ProxyClientPackage {
+  MCPClient: typeof ClientMCPClient;
+}
+
+type Assert<T extends true> = T;
+type _ProxyConfigMatchesClient = Assert<
+  ProxyServerConfig extends ClientServerConfig ? true : false
+>;
+type _ClientConnectionMatchesProxy = Assert<
+  ClientMCPConnection extends ProxyConnection ? true : false
+>;
+
+const PROXY_CLIENT_INSTALL_HINT = [
+  "[mcp-use] server.proxy() requires the optional @mcp-use/client package.",
+  "Install it in your project:",
+  "",
+  "  npm install @mcp-use/client",
+].join("\n");
+
+function passthroughJsonSchema(
+  schema: Record<string, unknown>
+): StandardSchemaWithJSON<Record<string, unknown>, Record<string, unknown>> {
+  return {
+    "~standard": {
+      version: 1,
+      vendor: "mcp-use-proxy",
+      validate(value) {
+        return { value: value as Record<string, unknown> };
+      },
+      jsonSchema: {
+        input: () => schema as JsonSchemaType,
+        output: () => schema as JsonSchemaType,
+      },
+    },
+  };
+}
+
+function promptArgsToJsonSchema(
+  args: PromptArgument[] | undefined
+): JsonSchemaType {
+  const properties: Record<string, JsonSchemaType> = {};
+  const required: string[] = [];
+  for (const arg of args ?? []) {
+    properties[arg.name] = {
+      type: "string",
+      ...(arg.description !== undefined && { description: arg.description }),
+    };
+    if (arg.required === true) required.push(arg.name);
+  }
+  return {
+    type: "object",
+    properties,
+    ...(required.length > 0 && { required }),
+  };
+}
+
+function prefixedName(namespace: string | undefined, name: string): string {
+  return namespace === undefined ? name : `${namespace}_${name}`;
+}
+
+function proxiedResourceUri(
+  namespace: string | undefined,
+  uri: string
+): string {
+  if (namespace === undefined) return uri;
+  return `mcp-use-proxy:///${encodeURIComponent(namespace)}/${encodeURIComponent(uri)}`;
+}
+
+function isConnection(value: unknown): value is ProxyConnection {
+  if (value === null || typeof value !== "object") return false;
+  const candidate = value as Partial<ProxyConnection>;
+  return (
+    typeof candidate.listTools === "function" &&
+    typeof candidate.callTool === "function" &&
+    typeof candidate.readResource === "function" &&
+    typeof candidate.listPrompts === "function" &&
+    typeof candidate.getPrompt === "function"
+  );
+}
+
+function isClientPackageMissing(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const code = (error as NodeJS.ErrnoException).code;
+  return (
+    (code === "ERR_MODULE_NOT_FOUND" || code === "MODULE_NOT_FOUND") &&
+    error.message.includes("@mcp-use/client")
+  );
+}
+
+/** Convert a missing optional-client import into the proxy install error. @internal */
+export function proxyClientInstallError(error: unknown): Error | undefined {
+  return isClientPackageMissing(error)
+    ? new Error(PROXY_CLIENT_INSTALL_HINT, { cause: error })
+    : undefined;
+}
+
+async function loadProxyClient(
+  importer: () => Promise<unknown> = () => import("@mcp-use/client")
+): Promise<ProxyClientPackage> {
+  try {
+    return (await importer()) as ProxyClientPackage;
+  } catch (error) {
+    const installError = proxyClientInstallError(error);
+    if (installError !== undefined) throw installError;
+    throw error;
+  }
+}
+
+function supports(
+  connection: ProxyConnection,
+  capability: "tools" | "resources" | "prompts"
+): boolean {
+  return connection.supports?.(capability) !== false;
+}
+
+async function introspect(
+  namespace: string | undefined,
+  connection: ProxyConnection
+): Promise<ProxyNamespacePlan> {
+  try {
+    const tools = supports(connection, "tools")
+      ? await connection.listTools()
+      : [];
+    let resources: ProxyResource[] = [];
+    if (supports(connection, "resources")) {
+      if (connection.listAllResources !== undefined) {
+        resources = (await connection.listAllResources()).resources;
+      } else if (connection.listResources !== undefined) {
+        resources = (await connection.listResources()).resources;
+      }
+    }
+    const prompts = supports(connection, "prompts")
+      ? (await connection.listPrompts()).prompts
+      : [];
+    return { namespace, connection, tools, resources, prompts };
+  } catch (error) {
+    const label = namespace ?? "unnamed";
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Failed to introspect upstream MCP server "${label}": ${message}`,
+      { cause: error }
+    );
+  }
+}
+
+function assertMountable(
+  host: ProxyMountHost,
+  plans: ProxyNamespacePlan[]
+): void {
+  const planned = {
+    tool: new Set<string>(),
+    resource: new Set<string>(),
+    prompt: new Set<string>(),
+  };
+
+  const assertFree = (
+    kind: "tool" | "resource" | "prompt",
+    name: string,
+    namespace: string | undefined
+  ): void => {
+    const exists =
+      kind === "tool"
+        ? host.hasTool(name)
+        : kind === "resource"
+          ? host.hasResource(name)
+          : host.hasPrompt(name);
+    if (exists || planned[kind].has(name)) {
+      throw new Error(
+        `Cannot proxy ${kind} "${name}" from namespace "${namespace ?? "unnamed"}": ` +
+          `a ${kind} with that name is already registered.`
+      );
+    }
+    planned[kind].add(name);
+  };
+
+  for (const plan of plans) {
+    for (const tool of plan.tools) {
+      assertFree(
+        "tool",
+        prefixedName(plan.namespace, tool.name),
+        plan.namespace
+      );
+    }
+    for (const resource of plan.resources) {
+      assertFree(
+        "resource",
+        prefixedName(plan.namespace, resource.name),
+        plan.namespace
+      );
+    }
+    for (const prompt of plan.prompts) {
+      assertFree(
+        "prompt",
+        prefixedName(plan.namespace, prompt.name),
+        plan.namespace
+      );
+    }
+  }
+}
+
+function mountPlan(host: ProxyMountHost, plan: ProxyNamespacePlan): void {
+  for (const tool of plan.tools) {
+    const definition: ToolDefinition = {
+      name: prefixedName(plan.namespace, tool.name),
+      ...(tool.title !== undefined && { title: tool.title }),
+      ...(tool.description !== undefined && { description: tool.description }),
+      ...(tool.annotations !== undefined && { annotations: tool.annotations }),
+      ...(tool.inputSchema !== undefined && {
+        inputSchema: passthroughJsonSchema(tool.inputSchema),
+      }),
+      ...(tool.outputSchema !== undefined && {
+        outputSchema: passthroughJsonSchema(tool.outputSchema),
+      }),
+    };
+    const upstreamName = tool.name;
+    const callback = async (
+      params: Record<string, unknown>,
+      ctx: RequestContext
+    ) =>
+      plan.connection.callTool(upstreamName, params, {
+        signal: ctx.signal,
+        onprogress: async (progress) => {
+          await ctx.reportProgress(
+            progress.progress,
+            progress.total,
+            progress.message
+          );
+        },
+      });
+    host.registerTool(definition, callback as ToolCallback);
+  }
+
+  for (const resource of plan.resources) {
+    const upstreamUri = resource.uri;
+    host.registerResource(
+      {
+        name: prefixedName(plan.namespace, resource.name),
+        uri: proxiedResourceUri(plan.namespace, upstreamUri),
+        ...(resource.title !== undefined && { title: resource.title }),
+        ...(resource.description !== undefined && {
+          description: resource.description,
+        }),
+        ...(resource.mimeType !== undefined && {
+          mimeType: resource.mimeType,
+        }),
+      },
+      async (_uri, ctx) =>
+        plan.connection.readResource(upstreamUri, { signal: ctx.signal })
+    );
+  }
+
+  for (const prompt of plan.prompts) {
+    const upstreamName = prompt.name;
+    host.registerPrompt(
+      {
+        name: prefixedName(plan.namespace, prompt.name),
+        ...(prompt.title !== undefined && { title: prompt.title }),
+        ...(prompt.description !== undefined && {
+          description: prompt.description,
+        }),
+        schema: passthroughJsonSchema(promptArgsToJsonSchema(prompt.arguments)),
+      },
+      async (params) => plan.connection.getPrompt(upstreamName, params)
+    );
+  }
+}
+
+/**
+ * Mount one existing upstream connection on a parent server.
+ *
+ * @param host - Parent server registration surface.
+ * @param connection - Ready `@mcp-use/client` v2 connection.
+ * @param options - Optional namespace applied to mounted names.
+ *
+ * @internal
+ */
+export async function mountProxyConnection(
+  host: ProxyMountHost,
+  connection: ProxyConnection,
+  options: ProxyOptions = {}
+): Promise<void> {
+  if (host.isStarted()) {
+    throw new Error(
+      "Cannot call proxy() after the server has started: register upstream servers before listen()/getHandler()."
+    );
+  }
+  const plan = await introspect(options.namespace, connection);
+  assertMountable(host, [plan]);
+  mountPlan(host, plan);
+}
+
+/**
+ * Connect and mount namespace-keyed upstream servers through
+ * `@mcp-use/client` v2.
+ *
+ * @param host - Parent server registration surface.
+ * @param servers - Namespace-keyed upstream client configuration.
+ *
+ * @internal
+ */
+export async function mountProxyServers(
+  host: ProxyMountHost,
+  servers: Record<string, ProxyServerConfig>
+): Promise<void> {
+  if (host.isStarted()) {
+    throw new Error(
+      "Cannot call proxy() after the server has started: register upstream servers before listen()/getHandler()."
+    );
+  }
+
+  const { MCPClient } = await loadProxyClient();
+  const owner = new MCPClient({ mcpServers: servers });
+  try {
+    const connected: Record<string, ClientMCPConnection> =
+      await owner.connectAll();
+    const plans: ProxyNamespacePlan[] = [];
+    for (const [namespace, connection] of Object.entries(connected)) {
+      plans.push(await introspect(namespace, connection));
+    }
+    assertMountable(host, plans);
+    for (const plan of plans) mountPlan(host, plan);
+    host.trackOwner(owner);
+  } catch (error) {
+    await owner.close().catch(() => undefined);
+    throw error;
+  }
+}
+
+/** Determine whether a proxy argument is an existing connection. @internal */
+export function isProxyConnection(value: unknown): value is ProxyConnection {
+  return isConnection(value);
+}

--- a/libraries/typescript/packages/server/src/server.ts
+++ b/libraries/typescript/packages/server/src/server.ts
@@ -81,6 +81,12 @@ import type {
   TemplateVariableValue,
 } from "./resources.js";
 import type {
+  ProxyConnection,
+  ProxyMountHost,
+  ProxyOptions,
+  ProxyServerConfig,
+} from "./proxy.js";
+import type {
   InferToolInput,
   InferToolName,
   InferToolOutput,
@@ -222,6 +228,8 @@ export class MCPServer<TUser = never> {
   #hostValidated = false;
   readonly #mcpMiddlewares: McpMiddlewareEntry[] = [];
   readonly #mcpEventListeners: McpEventListenerEntry[] = [];
+  /** Client instances created by {@link MCPServer.proxy} and owned by this server. */
+  readonly #proxyOwners: Array<{ close(): Promise<void> }> = [];
 
   /**
    * Create an MCP server from a parsed, bundled OpenAPI document.
@@ -434,6 +442,59 @@ export class MCPServer<TUser = never> {
       >,
     });
     return this;
+  }
+
+  /**
+   * Compose upstream MCP servers into this server.
+   *
+   * A namespace-keyed config creates all upstream connections through the
+   * optional `@mcp-use/client` v2 peer. The namespace prefixes every mounted
+   * tool, resource, and prompt name. You may instead pass an existing ready
+   * {@link ProxyConnection}; that connection remains caller-owned.
+   *
+   * @param servers - Namespace-keyed upstream connection settings.
+   * @throws If `@mcp-use/client` is not installed, an upstream cannot connect
+   * or be introspected, a mounted name collides, or the server already started.
+   *
+   * @example
+   * ```ts
+   * await server.proxy({
+   *   database: { command: "node", args: ["./database.mjs"] },
+   *   weather: { url: "https://weather.example.com/mcp" },
+   * });
+   * ```
+   */
+  async proxy(servers: Record<string, ProxyServerConfig>): Promise<void>;
+  /**
+   * Mount an existing ready `@mcp-use/client` v2 connection.
+   *
+   * @param connection - Ready connection to introspect and forward through.
+   * @param options - Optional namespace. Without one, upstream names and URIs
+   * are preserved.
+   * @throws If introspection fails, a mounted name collides, or the server
+   * already started.
+   *
+   * @example
+   * ```ts
+   * const connection = await client.connect("database");
+   * await server.proxy(connection, { namespace: "database" });
+   * ```
+   */
+  async proxy(
+    connection: ProxyConnection,
+    options?: ProxyOptions
+  ): Promise<void>;
+  async proxy(
+    input: Record<string, ProxyServerConfig> | ProxyConnection,
+    options?: ProxyOptions
+  ): Promise<void> {
+    const { isProxyConnection, mountProxyConnection, mountProxyServers } =
+      await import("./proxy.js");
+    if (isProxyConnection(input)) {
+      await mountProxyConnection(this.#proxyHost(), input, options);
+      return;
+    }
+    await mountProxyServers(this.#proxyHost(), input);
   }
 
   /**
@@ -683,6 +744,8 @@ export class MCPServer<TUser = never> {
    * instance to serve again.
    */
   async close(): Promise<void> {
+    const proxyOwners = this.#proxyOwners.splice(0);
+    await Promise.all(proxyOwners.map((owner) => owner.close()));
     await this.#handler?.close();
     const httpServer = this.#httpServer;
     if (httpServer !== undefined) {
@@ -752,6 +815,48 @@ export class MCPServer<TUser = never> {
           `so register everything before listen()/getHandler().`
       );
     }
+  }
+
+  #proxyHost(): ProxyMountHost {
+    return {
+      isStarted: () => this.#handler !== undefined,
+      hasTool: (name) => this.#tools.has(name),
+      hasResource: (name) => this.#resources.has(name),
+      hasPrompt: (name) => this.#prompts.has(name),
+      registerTool: (definition, callback) => {
+        this.#assertNotStarted("tool", definition.name);
+        this.#tools.set(definition.name, {
+          definition,
+          callback: callback as ToolCallback<
+            Record<string, unknown>,
+            never,
+            TUser,
+            HasOAuth<TUser>
+          >,
+        });
+      },
+      registerResource: (definition, callback) => {
+        this.#assertNotStarted("resource", definition.name);
+        this.#resources.set(definition.name, {
+          definition,
+          callback: callback as ResourceCallback<TUser, HasOAuth<TUser>>,
+        });
+      },
+      registerPrompt: (definition, callback) => {
+        this.#assertNotStarted("prompt", definition.name);
+        this.#prompts.set(definition.name, {
+          definition,
+          callback: callback as PromptCallback<
+            Record<string, unknown>,
+            TUser,
+            HasOAuth<TUser>
+          >,
+        });
+      },
+      trackOwner: (owner) => {
+        this.#proxyOwners.push(owner);
+      },
+    };
   }
 
   /**

--- a/libraries/typescript/packages/server/src/server.ts
+++ b/libraries/typescript/packages/server/src/server.ts
@@ -83,7 +83,6 @@ import type {
 import type {
   ProxyConnection,
   ProxyMountHost,
-  ProxyOptions,
   ProxyServerConfig,
 } from "./proxy.js";
 import type {
@@ -230,6 +229,10 @@ export class MCPServer<TUser = never> {
   readonly #mcpEventListeners: McpEventListenerEntry[] = [];
   /** Client instances created by {@link MCPServer.proxy} and owned by this server. */
   readonly #proxyOwners: Array<{ close(): Promise<void> }> = [];
+  /** Proxy registrations that {@link close} must let finish before cleanup. */
+  readonly #proxyOperations = new Set<Promise<void>>();
+  /** Whether terminal shutdown has begun. */
+  #closed = false;
 
   /**
    * Create an MCP server from a parsed, bundled OpenAPI document.
@@ -447,20 +450,26 @@ export class MCPServer<TUser = never> {
   /**
    * Compose upstream MCP servers into this server.
    *
-   * A namespace-keyed config creates all upstream connections through the
-   * optional `@mcp-use/client` v2 peer. The namespace prefixes every mounted
-   * tool, resource, and prompt name. You may instead pass an existing ready
-   * {@link ProxyConnection}; that connection remains caller-owned.
+   * A name-keyed HTTP config creates upstream connections through the optional
+   * `@mcp-use/client` v2 peer. Each key automatically namespaces its mounted
+   * tools, resources, and prompts. You may instead pass an existing ready
+   * {@link ProxyConnection}; its negotiated server name becomes the namespace
+   * and the connection remains caller-owned.
    *
-   * @param servers - Namespace-keyed upstream connection settings.
-   * @throws If `@mcp-use/client` is not installed, an upstream cannot connect
-   * or be introspected, a mounted name collides, or the server already started.
+   * Connection, introspection, and collision failures are diagnosed and
+   * skipped without discarding capabilities that can be mounted.
+   *
+   * @param servers - Namespace-keyed upstream HTTP connection settings.
+   * @throws If `@mcp-use/client` is not installed or the server already started
+   * or closed.
    *
    * @example
    * ```ts
    * await server.proxy({
-   *   database: { command: "node", args: ["./database.mjs"] },
-   *   weather: { url: "https://weather.example.com/mcp" },
+   *   weather: {
+   *     url: "https://weather.example.com/mcp",
+   *     authToken: process.env.WEATHER_MCP_TOKEN,
+   *   },
    * });
    * ```
    */
@@ -469,32 +478,40 @@ export class MCPServer<TUser = never> {
    * Mount an existing ready `@mcp-use/client` v2 connection.
    *
    * @param connection - Ready connection to introspect and forward through.
-   * @param options - Optional namespace. Without one, upstream names and URIs
-   * are preserved.
-   * @throws If introspection fails, a mounted name collides, or the server
-   * already started.
+   * The connection's negotiated server name automatically namespaces every
+   * mounted capability. Introspection and collision failures are diagnosed and
+   * skipped without discarding capabilities that can be mounted.
+   *
+   * @throws If the server already started or closed.
    *
    * @example
    * ```ts
    * const connection = await client.connect("database");
-   * await server.proxy(connection, { namespace: "database" });
+   * await server.proxy(connection);
    * ```
    */
+  async proxy(connection: ProxyConnection): Promise<void>;
   async proxy(
-    connection: ProxyConnection,
-    options?: ProxyOptions
-  ): Promise<void>;
-  async proxy(
-    input: Record<string, ProxyServerConfig> | ProxyConnection,
-    options?: ProxyOptions
+    input: Record<string, ProxyServerConfig> | ProxyConnection
   ): Promise<void> {
-    const { isProxyConnection, mountProxyConnection, mountProxyServers } =
-      await import("./proxy.js");
-    if (isProxyConnection(input)) {
-      await mountProxyConnection(this.#proxyHost(), input, options);
-      return;
+    if (this.#closed) {
+      throw new Error("Cannot call proxy() after the server has closed.");
     }
-    await mountProxyServers(this.#proxyHost(), input);
+    const operation = (async (): Promise<void> => {
+      const { isProxyConnection, mountProxyConnection, mountProxyServers } =
+        await import("./proxy.js");
+      if (isProxyConnection(input)) {
+        await mountProxyConnection(this.#proxyHost(), input);
+        return;
+      }
+      await mountProxyServers(this.#proxyHost(), input);
+    })();
+    this.#proxyOperations.add(operation);
+    try {
+      await operation;
+    } finally {
+      this.#proxyOperations.delete(operation);
+    }
   }
 
   /**
@@ -744,15 +761,36 @@ export class MCPServer<TUser = never> {
    * instance to serve again.
    */
   async close(): Promise<void> {
+    this.#closed = true;
+    await Promise.allSettled([...this.#proxyOperations]);
+
+    const errors: unknown[] = [];
     const proxyOwners = this.#proxyOwners.splice(0);
-    await Promise.all(proxyOwners.map((owner) => owner.close()));
-    await this.#handler?.close();
+    const ownerResults = await Promise.allSettled(
+      proxyOwners.map((owner) => owner.close())
+    );
+    for (const result of ownerResults) {
+      if (result.status === "rejected") errors.push(result.reason);
+    }
+
+    try {
+      await this.#handler?.close();
+    } catch (error) {
+      errors.push(error);
+    }
     const httpServer = this.#httpServer;
     if (httpServer !== undefined) {
-      await new Promise<void>((resolve, reject) => {
-        httpServer.close((err) => (err ? reject(err) : resolve()));
-      });
-      this.#httpServer = undefined;
+      try {
+        await new Promise<void>((resolve, reject) => {
+          httpServer.close((err) => (err ? reject(err) : resolve()));
+        });
+        this.#httpServer = undefined;
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+    if (errors.length > 0) {
+      throw new AggregateError(errors, "Failed to close MCP server cleanly");
     }
   }
 

--- a/libraries/typescript/packages/server/src/server.ts
+++ b/libraries/typescript/packages/server/src/server.ts
@@ -494,9 +494,7 @@ export class MCPServer<TUser = never> {
   async proxy(
     input: Record<string, ProxyServerConfig> | ProxyConnection
   ): Promise<void> {
-    if (this.#closed) {
-      throw new Error("Cannot call proxy() after the server has closed.");
-    }
+    this.#assertOpen("proxy()");
     const operation = (async (): Promise<void> => {
       const { isProxyConnection, mountProxyConnection, mountProxyServers } =
         await import("./proxy.js");
@@ -537,6 +535,7 @@ export class MCPServer<TUser = never> {
    * ```
    */
   getHandler(options: { bus?: ServerEventBus } = {}): FrameworkHandler {
+    this.#assertOpen("getHandler()");
     const { fetch } = this.#ensureMounted("handler", undefined, options.bus);
     return toFrameworkHandler(fetch);
   }
@@ -687,6 +686,7 @@ export class MCPServer<TUser = never> {
    * already mounted the app without Host validation.
    */
   async listen(port = 3000): Promise<{ port: number; url: string }> {
+    this.#assertOpen("listen()");
     this.#assertListenOAuthConfiguration();
     const { createServer } = await import("node:http");
     const { toNodeHandler } = await import("./node-bridge.js");
@@ -792,6 +792,14 @@ export class MCPServer<TUser = never> {
     if (errors.length > 0) {
       throw new AggregateError(errors, "Failed to close MCP server cleanly");
     }
+  }
+
+  #assertOpen(operation?: string): void {
+    if (!this.#closed) return;
+    if (operation !== undefined) {
+      throw new Error(`Cannot call ${operation} after the server has closed.`);
+    }
+    throw new Error("Cannot use the server after it has closed.");
   }
 
   #basePath(): string {
@@ -936,6 +944,7 @@ export class MCPServer<TUser = never> {
     fetch: FetchHandler;
     handler: McpHttpHandler;
   } {
+    this.#assertOpen();
     if (this.#fetchHandler === undefined || this.#handler === undefined) {
       const { hosts, origins } = this.#validationPolicy(mode);
       const basePath = this.#basePath();

--- a/libraries/typescript/packages/server/tests/budgets/cli-budget.test.ts
+++ b/libraries/typescript/packages/server/tests/budgets/cli-budget.test.ts
@@ -41,6 +41,7 @@ const START_FORBIDDEN_STATIC = [
 describe("published CLI boundaries", () => {
   it("keeps dist/index.js free of static node and toolchain leaks", async () => {
     const index = await readFile(new URL("index.js", DIST), "utf8");
+    const proxyTypes = await readFile(new URL("proxy.d.ts", DIST), "utf8");
 
     for (const { label, pattern } of EDGE_FORBIDDEN_STATIC) {
       expect(index, `index.js must not statically import ${label}`).not.toMatch(
@@ -58,6 +59,17 @@ describe("published CLI boundaries", () => {
     expect(index).toMatch(
       /\bimport\s*\(\s*["'][^"']*public-route[^"']*["']\s*\)/
     );
+    expect(index, "proxying must stay behind its own lazy chunk").toMatch(
+      /\bimport\s*\(\s*["'][^"']*proxy[^"']*["']\s*\)/
+    );
+    expect(
+      index,
+      "the library entry must not resolve the optional client peer"
+    ).not.toContain("@mcp-use/client");
+    expect(
+      proxyTypes,
+      "public declarations must not require the optional client peer"
+    ).not.toMatch(/\bfrom\s+["']@mcp-use\/client["']/);
   });
 
   it("keeps dist/commands/start.js free of toolchain and cross-command leaks", async () => {

--- a/libraries/typescript/packages/server/tests/budgets/cli-budget.test.ts
+++ b/libraries/typescript/packages/server/tests/budgets/cli-budget.test.ts
@@ -101,11 +101,11 @@ describe("published CLI boundaries", () => {
     }
   });
 
-  it("keeps dist/index.js under seventy-three KiB", async () => {
+  it("keeps dist/index.js under seventy-six KiB", async () => {
     const bytes = (await stat(new URL("index.js", DIST))).size;
     // The landing renderer is a lazy sibling entry; the root pays only for
     // HTML negotiation and auth-aware route dispatch.
-    expect(bytes).toBeLessThanOrEqual(73 * 1024);
+    expect(bytes).toBeLessThanOrEqual(76 * 1024);
   });
 
   it("keeps the unpacked framework artifact below five MiB", async () => {

--- a/libraries/typescript/packages/server/tests/mcp-server.test.ts
+++ b/libraries/typescript/packages/server/tests/mcp-server.test.ts
@@ -912,4 +912,29 @@ describe("MCPServer validation policy", () => {
     await expect(server.listen(0)).rejects.toThrow(/after getHandler/);
     await server.close();
   });
+
+  it("keeps a server closed before its first mount", async () => {
+    const server = minimalServer();
+    await server.close();
+
+    expect(() => server.getHandler()).toThrow(
+      "Cannot call getHandler() after the server has closed."
+    );
+    await expect(server.listen(0)).rejects.toThrow(
+      "Cannot call listen() after the server has closed."
+    );
+  });
+
+  it("keeps a previously mounted server closed", async () => {
+    const server = minimalServer();
+    server.getHandler();
+    await server.close();
+
+    expect(() => server.getHandler()).toThrow(
+      "Cannot call getHandler() after the server has closed."
+    );
+    await expect(server.listen(0)).rejects.toThrow(
+      "Cannot call listen() after the server has closed."
+    );
+  });
 });

--- a/libraries/typescript/packages/server/tests/proxy-auth.test.ts
+++ b/libraries/typescript/packages/server/tests/proxy-auth.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { MCPServer } from "../src/index.js";
+
+const clientState = vi.hoisted(() => ({
+  configs: [] as Array<Record<string, unknown>>,
+  closeCalls: 0,
+  connectGate: undefined as Promise<void> | undefined,
+  rejectCloseIndexes: new Set<number>(),
+}));
+
+vi.mock("@mcp-use/client", () => ({
+  MCPClient: class MockMCPClient {
+    readonly index: number;
+
+    constructor(config: Record<string, unknown>) {
+      this.index = clientState.configs.length;
+      clientState.configs.push(config);
+    }
+
+    async connect() {
+      await clientState.connectGate;
+      return {
+        info: { server: { name: "upstream" } },
+        supports: () => false,
+      };
+    }
+
+    async close() {
+      clientState.closeCalls += 1;
+      if (clientState.rejectCloseIndexes.has(this.index)) {
+        throw new Error(`close ${this.index} failed`);
+      }
+    }
+  },
+}));
+
+describe("server.proxy authentication", () => {
+  beforeEach(() => {
+    clientState.configs.length = 0;
+    clientState.closeCalls = 0;
+    clientState.connectGate = undefined;
+    clientState.rejectCloseIndexes.clear();
+  });
+
+  it("forces client auto-OAuth off and never supplies browser options", async () => {
+    const server = new MCPServer({ name: "parent", version: "1.0.0" });
+    try {
+      await server.proxy({
+        upstream: {
+          url: "https://upstream.example/mcp",
+          headers: { Authorization: "Bearer caller-managed" },
+        },
+      });
+      await server.listen(0);
+
+      expect(clientState.configs).toEqual([
+        {
+          mcpServers: {
+            upstream: {
+              url: "https://upstream.example/mcp",
+              headers: { Authorization: "Bearer caller-managed" },
+              oauth: false,
+            },
+          },
+        },
+      ]);
+      expect(JSON.stringify(clientState.configs)).not.toContain("openBrowser");
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("closes an owner created by proxy setup that overlaps shutdown", async () => {
+    let releaseConnection!: () => void;
+    clientState.connectGate = new Promise<void>((resolve) => {
+      releaseConnection = resolve;
+    });
+    const server = new MCPServer({ name: "parent", version: "1.0.0" });
+
+    const proxying = server.proxy({
+      upstream: { url: "https://upstream.example/mcp" },
+    });
+    await vi.waitFor(() => expect(clientState.configs).toHaveLength(1));
+    const closing = server.close();
+    releaseConnection();
+
+    await Promise.all([proxying, closing]);
+    expect(clientState.closeCalls).toBe(1);
+  });
+
+  it("waits for every owned client close when one rejects", async () => {
+    const server = new MCPServer({ name: "parent", version: "1.0.0" });
+    await server.proxy({ first: { url: "https://first.example/mcp" } });
+    await server.proxy({ second: { url: "https://second.example/mcp" } });
+    clientState.rejectCloseIndexes.add(0);
+
+    await expect(server.close()).rejects.toThrow(
+      "Failed to close MCP server cleanly"
+    );
+    expect(clientState.closeCalls).toBe(2);
+  });
+});

--- a/libraries/typescript/packages/server/tests/proxy-optional-peer.test.ts
+++ b/libraries/typescript/packages/server/tests/proxy-optional-peer.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import packageJson from "../package.json";
+import { proxyClientInstallError } from "../src/proxy.js";
+
+describe("server.proxy optional peer", () => {
+  it("declares @mcp-use/client as an optional peer", () => {
+    expect(packageJson.peerDependencies["@mcp-use/client"]).toBe(
+      "^2.0.0-alpha.0"
+    );
+    expect(packageJson.peerDependenciesMeta["@mcp-use/client"]?.optional).toBe(
+      true
+    );
+  });
+
+  it("prints an install hint when config-map proxying cannot load the peer", async () => {
+    const missingClient = new Error(
+      "Cannot find package '@mcp-use/client' imported from mcp-use"
+    ) as NodeJS.ErrnoException;
+    missingClient.code = "ERR_MODULE_NOT_FOUND";
+    expect(proxyClientInstallError(missingClient)?.message).toMatch(
+      /server\.proxy\(\) requires the optional @mcp-use\/client package[\s\S]*npm install @mcp-use\/client/
+    );
+  });
+});

--- a/libraries/typescript/packages/server/tests/proxy.test.ts
+++ b/libraries/typescript/packages/server/tests/proxy.test.ts
@@ -401,12 +401,81 @@ describe("MCPServer.proxy", () => {
         },
       }
     );
-    await vi.waitFor(() =>
-      expect(diagnostics).toHaveBeenCalledWith(
-        expect.stringContaining(
-          'Failed to forward progress for proxied tool "progress_stream"'
-        )
+    expect(diagnostics).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Failed to forward progress for proxied tool "progress_stream"'
       )
     );
+  });
+
+  it("delivers progress in order before settling the proxied tool call", async () => {
+    let mountedTool:
+      | ((params: Record<string, unknown>, ctx: unknown) => Promise<unknown>)
+      | undefined;
+    const host: ProxyMountHost = {
+      isStarted: () => false,
+      hasTool: () => false,
+      hasResource: () => false,
+      hasPrompt: () => false,
+      registerTool: (_definition, callback) => {
+        mountedTool = callback as unknown as typeof mountedTool;
+      },
+      registerResource: () => {
+        throw new Error("unexpected resource registration");
+      },
+      registerPrompt: () => {
+        throw new Error("unexpected prompt registration");
+      },
+      trackOwner: () => {},
+    };
+    const connection: ProxyConnection = {
+      info: { server: { name: "ordered-progress" } },
+      supports: (capability) => capability === "tools",
+      async listTools() {
+        return [{ name: "stream" }];
+      },
+      async callTool(_name, _args, options) {
+        options?.onprogress?.({ progress: 1 });
+        options?.onprogress?.({ progress: 2 });
+        return { content: [] };
+      },
+      async readResource() {
+        return { contents: [] };
+      },
+      async listPrompts() {
+        return { prompts: [] };
+      },
+      async getPrompt() {
+        return { messages: [] };
+      },
+    };
+
+    await mountProxyConnection(host, connection);
+    expect(mountedTool).toBeDefined();
+
+    let releaseFirstProgress: (() => void) | undefined;
+    const firstProgressBlocked = new Promise<void>((resolve) => {
+      releaseFirstProgress = resolve;
+    });
+    const forwarded: number[] = [];
+    let settled = false;
+    const call = mountedTool!(
+      {},
+      {
+        signal: new AbortController().signal,
+        reportProgress: async (progress: number) => {
+          forwarded.push(progress);
+          if (progress === 1) await firstProgressBlocked;
+        },
+      }
+    ).then(() => {
+      settled = true;
+    });
+
+    await vi.waitFor(() => expect(forwarded).toEqual([1]));
+    expect(settled).toBe(false);
+    releaseFirstProgress?.();
+    await call;
+    expect(forwarded).toEqual([1, 2]);
   });
 });

--- a/libraries/typescript/packages/server/tests/proxy.test.ts
+++ b/libraries/typescript/packages/server/tests/proxy.test.ts
@@ -3,10 +3,13 @@ import {
   StreamableHTTPClientTransport,
 } from "@modelcontextprotocol/client";
 import { MCPClient } from "@mcp-use/client";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 
 import { MCPServer } from "../src/index.js";
+import type { ProxyConnection } from "../src/index.js";
+import { mountProxyConnection } from "../src/proxy.js";
+import type { ProxyMountHost } from "../src/proxy.js";
 
 async function connectClient(url: string): Promise<Client> {
   const client = new Client(
@@ -90,6 +93,7 @@ describe("MCPServer.proxy", () => {
   const clients: Array<{ close(): Promise<void> }> = [];
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await Promise.all(clients.splice(0).map((client) => client.close()));
     await Promise.all(servers.splice(0).map((server) => server.close()));
   });
@@ -109,8 +113,8 @@ describe("MCPServer.proxy", () => {
       content: [{ type: "text", text: "local" }],
     }));
     await parent.proxy({
-      alpha: { url: alphaUrl, oauth: false },
-      beta: { url: betaUrl, oauth: false },
+      alpha: { url: alphaUrl },
+      beta: { url: betaUrl },
     });
     const { url: parentUrl } = await parent.listen(0);
 
@@ -199,13 +203,13 @@ describe("MCPServer.proxy", () => {
 
     const parent = new MCPServer({ name: "parent", version: "1.0.0" });
     servers.push(parent);
-    await parent.proxy(connection, { namespace: "custom" });
+    await parent.proxy(connection);
     const { url: parentUrl } = await parent.listen(0);
 
     const client = await connectClient(parentUrl);
     clients.push(client);
     const { tools } = await client.listTools();
-    expect(tools.map((tool) => tool.name)).toContain("custom_greet");
+    expect(tools.map((tool) => tool.name)).toContain("direct_greet");
 
     await parent.close();
     expect(connection.isConnected).toBe(true);
@@ -218,12 +222,12 @@ describe("MCPServer.proxy", () => {
     const { url } = await upstream.listen(0);
     await parent.listen(0);
 
-    await expect(parent.proxy({ late: { url, oauth: false } })).rejects.toThrow(
+    await expect(parent.proxy({ late: { url } })).rejects.toThrow(
       /proxy\(\) after the server has started/i
     );
   });
 
-  it("rejects collisions without partially mounting a namespace", async () => {
+  it("skips collisions while mounting the remaining capabilities", async () => {
     const upstream = buildUpstream("collision");
     const parent = new MCPServer({ name: "parent", version: "1.0.0" });
     servers.push(upstream, parent);
@@ -232,14 +236,177 @@ describe("MCPServer.proxy", () => {
       content: [{ type: "text", text: "local" }],
     }));
 
-    await expect(parent.proxy({ up: { url, oauth: false } })).rejects.toThrow(
-      /Cannot proxy tool "up_greet"/
-    );
+    const diagnostics = vi.spyOn(console, "error").mockImplementation(() => {});
+    await expect(parent.proxy({ up: { url } })).resolves.toBeUndefined();
 
     const { url: parentUrl } = await parent.listen(0);
     const client = await connectClient(parentUrl);
     clients.push(client);
     const { tools } = await client.listTools();
-    expect(tools.map((tool) => tool.name)).toEqual(["up_greet"]);
+    expect(tools.map((tool) => tool.name).sort()).toEqual([
+      "up_fail",
+      "up_greet",
+    ]);
+    expect(diagnostics).toHaveBeenCalledWith(
+      expect.stringContaining('Skipping proxied tool "up_greet"')
+    );
+  });
+
+  it("continues after a configured upstream fails to connect", async () => {
+    const upstream = buildUpstream("healthy");
+    const parent = new MCPServer({ name: "parent", version: "1.0.0" });
+    servers.push(upstream, parent);
+    const { url } = await upstream.listen(0);
+    const diagnostics = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(
+      parent.proxy({
+        offline: {
+          url: "https://offline.example/mcp",
+          fetch: async () => {
+            throw new Error("upstream unavailable");
+          },
+        },
+        healthy: { url },
+      })
+    ).resolves.toBeUndefined();
+
+    const { url: parentUrl } = await parent.listen(0);
+    const client = await connectClient(parentUrl);
+    clients.push(client);
+    const { tools } = await client.listTools();
+    expect(tools.map((tool) => tool.name)).toContain("healthy_greet");
+    expect(diagnostics).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Failed to connect to upstream MCP server "offline"'
+      )
+    );
+  });
+
+  it("keeps other capability kinds when one introspection request fails", async () => {
+    const parent = new MCPServer({ name: "parent", version: "1.0.0" });
+    servers.push(parent);
+    const diagnostics = vi.spyOn(console, "error").mockImplementation(() => {});
+    const connection: ProxyConnection = {
+      info: { server: { name: "partial" } },
+      async listTools() {
+        throw new Error("tools unavailable");
+      },
+      async callTool() {
+        return { content: [] };
+      },
+      async listAllResources() {
+        return {
+          resources: [
+            {
+              name: "notes",
+              uri: "notes://partial",
+              mimeType: "text/plain",
+            },
+          ],
+        };
+      },
+      async readResource(uri) {
+        return { contents: [{ uri, text: "partial notes" }] };
+      },
+      async listPrompts() {
+        return {
+          prompts: [
+            {
+              name: "special",
+              arguments: [{ name: "__proto__", required: true }],
+            },
+          ],
+        };
+      },
+      async getPrompt() {
+        return { messages: [] };
+      },
+    };
+
+    await expect(parent.proxy(connection)).resolves.toBeUndefined();
+    const { url: parentUrl } = await parent.listen(0);
+    const client = await connectClient(parentUrl);
+    clients.push(client);
+
+    expect((await client.listTools()).tools).toEqual([]);
+    expect((await client.listResources()).resources).toEqual([
+      expect.objectContaining({ name: "partial_notes" }),
+    ]);
+    expect((await client.listPrompts()).prompts).toEqual([
+      expect.objectContaining({
+        name: "partial_special",
+        arguments: [expect.objectContaining({ name: "__proto__" })],
+      }),
+    ]);
+    expect(diagnostics).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Failed to introspect tools from upstream MCP server "partial"'
+      )
+    );
+  });
+
+  it("contains rejected downstream progress notifications", async () => {
+    const diagnostics = vi.spyOn(console, "error").mockImplementation(() => {});
+    let mountedTool:
+      | ((params: Record<string, unknown>, ctx: unknown) => Promise<unknown>)
+      | undefined;
+    const host: ProxyMountHost = {
+      isStarted: () => false,
+      hasTool: () => false,
+      hasResource: () => false,
+      hasPrompt: () => false,
+      registerTool: (_definition, callback) => {
+        mountedTool = callback as unknown as typeof mountedTool;
+      },
+      registerResource: () => {
+        throw new Error("unexpected resource registration");
+      },
+      registerPrompt: () => {
+        throw new Error("unexpected prompt registration");
+      },
+      trackOwner: () => {},
+    };
+    const connection: ProxyConnection = {
+      info: { server: { name: "progress" } },
+      supports: (capability) => capability === "tools",
+      async listTools() {
+        return [{ name: "stream" }];
+      },
+      async callTool(_name, _args, options) {
+        expect(
+          options?.onprogress?.({ progress: 1, total: 2, message: "half" })
+        ).toBeUndefined();
+        return { content: [] };
+      },
+      async readResource() {
+        return { contents: [] };
+      },
+      async listPrompts() {
+        return { prompts: [] };
+      },
+      async getPrompt() {
+        return { messages: [] };
+      },
+    };
+
+    await mountProxyConnection(host, connection);
+    expect(mountedTool).toBeDefined();
+    await mountedTool?.(
+      {},
+      {
+        signal: new AbortController().signal,
+        reportProgress: async () => {
+          throw new Error("downstream disconnected");
+        },
+      }
+    );
+    await vi.waitFor(() =>
+      expect(diagnostics).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Failed to forward progress for proxied tool "progress_stream"'
+        )
+      )
+    );
   });
 });

--- a/libraries/typescript/packages/server/tests/proxy.test.ts
+++ b/libraries/typescript/packages/server/tests/proxy.test.ts
@@ -1,0 +1,245 @@
+import {
+  Client,
+  StreamableHTTPClientTransport,
+} from "@modelcontextprotocol/client";
+import { MCPClient } from "@mcp-use/client";
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { MCPServer } from "../src/index.js";
+
+async function connectClient(url: string): Promise<Client> {
+  const client = new Client(
+    { name: "proxy-test-client", version: "1.0.0" },
+    { versionNegotiation: { mode: { pin: "2026-07-28" } } }
+  );
+  await client.connect(new StreamableHTTPClientTransport(new URL(url)));
+  return client;
+}
+
+function buildUpstream(label: string): MCPServer {
+  const upstream = new MCPServer({ name: label, version: "1.0.0" });
+
+  upstream.tool(
+    {
+      name: "greet",
+      description: `Greet through ${label}`,
+      inputSchema: z.object({ name: z.string().describe("Person to greet") }),
+      outputSchema: z.object({ greeting: z.string() }),
+      annotations: { readOnlyHint: true },
+    },
+    async ({ name }) => {
+      const data = { greeting: `${label}: Hello, ${name}!` };
+      return {
+        content: [{ type: "text", text: data.greeting }],
+        structuredContent: data,
+      };
+    }
+  );
+
+  upstream.tool(
+    {
+      name: "fail",
+      inputSchema: z.object({ reason: z.string() }),
+    },
+    async ({ reason }) => ({
+      content: [{ type: "text", text: `${label} failed: ${reason}` }],
+      isError: true,
+    })
+  );
+
+  upstream.resource(
+    {
+      name: "notes",
+      uri: `notes://${label}`,
+      description: `${label} notes`,
+      mimeType: "text/plain",
+    },
+    async (uri) => ({
+      contents: [
+        {
+          uri: uri.href,
+          mimeType: "text/plain",
+          text: `${label} note body`,
+        },
+      ],
+    })
+  );
+
+  upstream.prompt(
+    {
+      name: "summarize",
+      description: `Summarize through ${label}`,
+      schema: z.object({ text: z.string().describe("Text to summarize") }),
+    },
+    async ({ text }) => ({
+      messages: [
+        {
+          role: "user",
+          content: { type: "text", text: `${label}: Summarize ${text}` },
+        },
+      ],
+    })
+  );
+
+  return upstream;
+}
+
+describe("MCPServer.proxy", () => {
+  const servers: MCPServer[] = [];
+  const clients: Array<{ close(): Promise<void> }> = [];
+
+  afterEach(async () => {
+    await Promise.all(clients.splice(0).map((client) => client.close()));
+    await Promise.all(servers.splice(0).map((server) => server.close()));
+  });
+
+  it("proxies multiple configured servers through @mcp-use/client v2", async () => {
+    const alpha = buildUpstream("alpha");
+    const beta = buildUpstream("beta");
+    servers.push(alpha, beta);
+    const [{ url: alphaUrl }, { url: betaUrl }] = await Promise.all([
+      alpha.listen(0),
+      beta.listen(0),
+    ]);
+
+    const parent = new MCPServer({ name: "parent", version: "1.0.0" });
+    servers.push(parent);
+    parent.tool({ name: "local" }, async () => ({
+      content: [{ type: "text", text: "local" }],
+    }));
+    await parent.proxy({
+      alpha: { url: alphaUrl, oauth: false },
+      beta: { url: betaUrl, oauth: false },
+    });
+    const { url: parentUrl } = await parent.listen(0);
+
+    const client = await connectClient(parentUrl);
+    clients.push(client);
+
+    const { tools } = await client.listTools();
+    expect(tools.map((tool) => tool.name).sort()).toEqual([
+      "alpha_fail",
+      "alpha_greet",
+      "beta_fail",
+      "beta_greet",
+      "local",
+    ]);
+    expect(tools.find((tool) => tool.name === "alpha_greet")).toMatchObject({
+      description: "Greet through alpha",
+      annotations: { readOnlyHint: true },
+      inputSchema: {
+        type: "object",
+        required: ["name"],
+        properties: {
+          name: { type: "string", description: "Person to greet" },
+        },
+      },
+      outputSchema: {
+        type: "object",
+        required: ["greeting"],
+      },
+    });
+
+    const alphaGreeting = await client.callTool({
+      name: "alpha_greet",
+      arguments: { name: "Ada" },
+    });
+    expect(alphaGreeting).toMatchObject({
+      content: [{ type: "text", text: "alpha: Hello, Ada!" }],
+      structuredContent: { greeting: "alpha: Hello, Ada!" },
+    });
+
+    const failure = await client.callTool({
+      name: "beta_fail",
+      arguments: { reason: "offline" },
+    });
+    expect(failure).toMatchObject({
+      isError: true,
+      content: [{ type: "text", text: "beta failed: offline" }],
+    });
+
+    const { resources } = await client.listResources();
+    const alphaResource = resources.find(
+      (resource) => resource.name === "alpha_notes"
+    );
+    expect(alphaResource?.uri).toBe(
+      `mcp-use-proxy:///alpha/${encodeURIComponent("notes://alpha")}`
+    );
+    const read = await client.readResource({ uri: alphaResource!.uri });
+    expect(read.contents[0]).toMatchObject({ text: "alpha note body" });
+
+    const { prompts } = await client.listPrompts();
+    expect(prompts.map((prompt) => prompt.name).sort()).toEqual([
+      "alpha_summarize",
+      "beta_summarize",
+    ]);
+    const prompt = await client.getPrompt({
+      name: "beta_summarize",
+      arguments: { text: "this" },
+    });
+    expect(prompt.messages).toEqual([
+      {
+        role: "user",
+        content: { type: "text", text: "beta: Summarize this" },
+      },
+    ]);
+  });
+
+  it("mounts an existing caller-owned MCPConnection", async () => {
+    const upstream = buildUpstream("direct");
+    servers.push(upstream);
+    const { url } = await upstream.listen(0);
+
+    const upstreamClient = new MCPClient({
+      mcpServers: { direct: { url, oauth: false } },
+    });
+    clients.push(upstreamClient);
+    const connection = await upstreamClient.connect("direct");
+
+    const parent = new MCPServer({ name: "parent", version: "1.0.0" });
+    servers.push(parent);
+    await parent.proxy(connection, { namespace: "custom" });
+    const { url: parentUrl } = await parent.listen(0);
+
+    const client = await connectClient(parentUrl);
+    clients.push(client);
+    const { tools } = await client.listTools();
+    expect(tools.map((tool) => tool.name)).toContain("custom_greet");
+
+    await parent.close();
+    expect(connection.isConnected).toBe(true);
+  });
+
+  it("rejects proxy registration after the server starts", async () => {
+    const upstream = buildUpstream("late");
+    const parent = new MCPServer({ name: "parent", version: "1.0.0" });
+    servers.push(upstream, parent);
+    const { url } = await upstream.listen(0);
+    await parent.listen(0);
+
+    await expect(parent.proxy({ late: { url, oauth: false } })).rejects.toThrow(
+      /proxy\(\) after the server has started/i
+    );
+  });
+
+  it("rejects collisions without partially mounting a namespace", async () => {
+    const upstream = buildUpstream("collision");
+    const parent = new MCPServer({ name: "parent", version: "1.0.0" });
+    servers.push(upstream, parent);
+    const { url } = await upstream.listen(0);
+    parent.tool({ name: "up_greet" }, async () => ({
+      content: [{ type: "text", text: "local" }],
+    }));
+
+    await expect(parent.proxy({ up: { url, oauth: false } })).rejects.toThrow(
+      /Cannot proxy tool "up_greet"/
+    );
+
+    const { url: parentUrl } = await parent.listen(0);
+    const client = await connectClient(parentUrl);
+    clients.push(client);
+    const { tools } = await client.listTools();
+    expect(tools.map((tool) => tool.name)).toEqual(["up_greet"]);
+  });
+});

--- a/libraries/typescript/packages/server/tests/type-level.test.ts
+++ b/libraries/typescript/packages/server/tests/type-level.test.ts
@@ -20,6 +20,8 @@ import type {
   InputRequiredResult,
   LandingPageOptions,
   MetaObject,
+  ProxyHttpConfig,
+  ProxyServerConfig,
   ResourceDefinition,
   ResourceTemplateDefinition,
   ServerConfig,
@@ -152,6 +154,32 @@ describe("ToolResult resolution", () => {
       content: [{ type: "text", text: "hi" }],
     };
     expect([structured, error, contentOnly]).toBeDefined(); // compile-time only
+  });
+});
+
+describe("proxy public types", () => {
+  it("exposes only caller-authenticated HTTP config", () => {
+    const config: ProxyHttpConfig = {
+      url: "https://example.com/mcp",
+      authToken: "caller-managed-token",
+    };
+    expectTypeOf(config).toMatchTypeOf<ProxyServerConfig>();
+    expectTypeOf<
+      "command" extends keyof ProxyServerConfig ? true : false
+    >().toEqualTypeOf<false>();
+    expectTypeOf<
+      "oauth" extends keyof ProxyServerConfig ? true : false
+    >().toEqualTypeOf<false>();
+
+    if (false) {
+      const server = new MCPServer({ name: "types", version: "0.0.0" });
+      // @ts-expect-error — stdio is not part of the proxy surface
+      void server.proxy({ local: { command: "node", args: ["server.mjs"] } });
+      // @ts-expect-error — proxy OAuth/browser acquisition is intentionally absent
+      void server.proxy({ remote: { url: config.url, oauth: false } });
+    }
+
+    expect(config.url).toBe("https://example.com/mcp");
   });
 });
 

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -718,6 +718,28 @@ importers:
         specifier: 7.0.1-rc
         version: 7.0.1-rc
 
+  packages/server/examples/proxy:
+    dependencies:
+      '@mcp-use/client':
+        specifier: workspace:*
+        version: link:../../../client
+      mcp-use:
+        specifier: workspace:*
+        version: link:../..
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@types/node':
+        specifier: ^24.13.2
+        version: 24.13.2
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: 7.0.1-rc
+        version: 7.0.1-rc
+
   packages/server/examples/railway:
     dependencies:
       mcp-use:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds `server.proxy()` to compose multiple HTTP MCP upstreams behind one `mcp-use` endpoint. Upstreams are namespaced and their tools, static resources, and prompts are proxied with cancellation and ordered progress; failures are logged without failing the call.

- **New Features**
  - HTTP-only config map with `url`, `authToken`/`headers` (optional `timeout`, `fetch`, protocol negotiation); OAuth/browser flow disabled and stdio not supported.
  - Overload to mount an existing connection from `@mcp-use/client` v2; its negotiated server name becomes the namespace.
  - Namespacing prefixes `<namespace>_`; static resources use `mcp-use-proxy:///`. Forwards tool schemas/results, cancellation, and progress; progress forwarding errors are logged and do not fail the call.
  - Best-effort mounting with diagnostics for connection/introspection failures and name collisions; must be called before `listen()`/`getHandler()` (calling after start or after `close()` errors).
  - Lifecycle: config-created connections are owned and closed in `server.close()`; shutdown waits for in-flight `proxy()` operations and closes all owned clients (aggregates close errors). Caller-supplied connections are not closed. Importing/running without calling `proxy()` does not load the optional `@mcp-use/client` peer; missing peer prints an install hint.
  - Scope: v2 proxies tools, static resources, and prompts; it does not proxy resource templates, completions, subscriptions, or upstream list-change re-sync.

- **Migration**
  - Install `@mcp-use/client` if you use `server.proxy()`: `npm install @mcp-use/client`.
  - Call `server.proxy()` before starting the server.
  - Use bearer tokens or headers for auth; the proxy does not perform OAuth and will never open a browser.
  - Choose unique namespaces; collisions are skipped. Manage the lifecycle if you pass your own connection.

<sup>Written for commit 902a37f0374f5d711f0806d0c12efc868b7c1c50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



