### PR TITLE
feat(server): add generated world example

### DIFF
--- a/libraries/typescript/packages/server/examples/views/README.md
+++ b/libraries/typescript/packages/server/examples/views/README.md
@@ -10,3 +10,7 @@ Sibling examples for MCP Apps views with `mcp-use`:
   [`excalidraw/excalidraw-mcp`](https://github.com/excalidraw/excalidraw-mcp)
   app with `viewConfig.autoResize` / `displayModes`, safe partial parsing until
   the structured result or tool-error latch, fullscreen editing, and checkpoints
+- [`generated-world/`](./generated-world/) — model-authored Three.js environment
+  code delivered by a v2 MCP server and compiled in an ephemeral nested sandbox
+  with deterministic randomness, runtime feedback, scene budgets, animation
+  hooks, and a flying camera

--- a/libraries/typescript/packages/server/examples/views/generated-world/README.md
+++ b/libraries/typescript/packages/server/examples/views/generated-world/README.md
@@ -1,0 +1,90 @@
+# Generated World example
+
+A v2 `mcp-use` MCP App that lets the model author a complete small
+Three.js environment as JavaScript, then gives the user a flying camera to tour
+it. It uses code as a compact scene description and renders viable source
+prefixes while the `render_world` arguments are still streaming.
+
+## Architecture
+
+1. The model calls `read_world_guide`, then writes the body of
+   `async buildWorld({ THREE, scene, random, onFrame })` into `render_world`.
+2. The MCP server enforces only the 180 KiB payload ceiling and returns the
+   source as `structuredContent` without trying to predict whether it will run.
+   `read_world_guide` still tells the model to avoid browser globals, network
+   APIs, imports, timers, and custom render loops; those are prompt-level
+   authoring constraints rather than keyword rejections.
+3. The MCP App immediately creates a long-lived in-memory `blob:` document
+   inside a nested `<iframe sandbox="allow-scripts">` and supplies only
+   Three.js, a scene, seeded randomness, and a bounded animation hook.
+4. As `useToolContext().toolInput.source` grows, the iframe dynamically imports
+   each syntactically complete prefix as an in-memory module. It builds into a
+   fresh scene and atomically swaps successful revisions, leaving the last good
+   scene visible when the current prefix is incomplete.
+5. The exact failure is also written into `ModelContext`, allowing compatible
+   clients to give it back to the agent for the next revision.
+6. A trusted runtime owns WebGL, resize behavior, scene-budget checks, and the
+   flying camera. While source streams, the camera is locked in an elevated
+   three-quarter view of the origin and the model is instructed to build
+   roofless, open-top environments. The runtime removes scene fog so construction
+   and exploration remain unobstructed. A runtime-owned sky and directional fill
+   light guarantee baseline visibility without consuming the generated scene's
+   budgets; model-authored lights remain additive. After the final result builds
+   successfully, the camera moves to the authored spawn; WASD or arrows move,
+   Q/E move vertically, dragging looks, and Shift boosts.
+
+The progressive loader does not execute malformed JavaScript. A streamed prefix
+only becomes visible when it forms a valid function body and constructs at
+least one scene object. Temporary syntax and runtime failures are expected and
+silent during generation; the final source still reports an exact error to the
+view and model context.
+
+## Data flow
+
+There is no asset-upload or persistence endpoint. The source necessarily
+travels through the MCP tool request to whichever server you configure, then
+comes back in that call's result. The example keeps no database, object store,
+checkpoint, or server-side generated file.
+
+- With a local MCP server, the app adds no remote source transfer of its own.
+- With a remote MCP server, the source is transmitted to that server but is not
+  stored by this implementation.
+- The browser downloads the pinned Three.js module from `https://esm.sh`; the
+  generated iframe's CSP allows no other network destination.
+
+The nested sandbox and CSP are intended for cooperative model-authored code,
+not arbitrary hostile JavaScript. Generated code can use browser globals inside
+the sandbox, although network destinations remain restricted. A synchronous
+infinite loop can hang the iframe because JavaScript cannot interrupt it after
+it starts. Production deployments should add isolation appropriate to their
+threat model.
+
+## Runtime limits
+
+- 180 KiB source
+- 1,500 scene objects and 2,400 object additions
+- 1,000,000 triangles and 3,000,000 vertices
+- 32 lights and 64 `onFrame` callbacks
+- 8-second asynchronous construction deadline
+
+Prefer `InstancedMesh` for repeated geometry. Avoid long synchronous loops;
+JavaScript cannot interrupt one after it begins.
+
+## Run locally
+
+From this directory, after installing workspace dependencies from the
+TypeScript monorepo root:
+
+```sh
+pnpm install
+pnpm dev
+```
+
+The MCP endpoint is `http://localhost:3000/mcp`. Open
+`http://localhost:3000/mcp/inspector`, call `read_world_guide`, then call
+`render_world` and inspect the MCP Apps component response.
+
+```sh
+pnpm typecheck
+pnpm build && pnpm start
+```

--- a/libraries/typescript/packages/server/examples/views/generated-world/package.json
+++ b/libraries/typescript/packages/server/examples/views/generated-world/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "mcp-use-example-views-generated-world",
+  "type": "module",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Reference example: model-generated Three.js worlds in an ephemeral sandboxed MCP App view.",
+  "engines": {
+    "node": ">=24.0.0"
+  },
+  "scripts": {
+    "dev": "mcp-use dev",
+    "build": "mcp-use build",
+    "start": "mcp-use start",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "mcp-use": "workspace:*",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "^24.13.2",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "typescript": "7.0.1-rc"
+  }
+}

--- a/libraries/typescript/packages/server/examples/views/generated-world/resources/generated-world/view.css
+++ b/libraries/typescript/packages/server/examples/views/generated-world/resources/generated-world/view.css
@@ -1,0 +1,294 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  background: transparent;
+  color: #f7f4ff;
+  font-family:
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+button {
+  font: inherit;
+}
+
+.world-shell {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  min-height: 320px;
+  overflow: hidden;
+  border-radius: 14px;
+  background:
+    radial-gradient(
+      circle at 52% 42%,
+      rgba(131, 91, 210, 0.2),
+      transparent 35%
+    ),
+    linear-gradient(145deg, #121827, #06070a 72%);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.world-shell.fullscreen {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  width: 100vw;
+  height: 100vh;
+  min-height: 0;
+  aspect-ratio: auto;
+  border-radius: 0;
+}
+
+.world-frame {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  background: #080a0f;
+}
+
+.generation-status {
+  position: absolute;
+  right: 10px;
+  bottom: 10px;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  max-width: min(360px, calc(100% - 20px));
+  padding: 9px 12px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 10px;
+  background: rgba(7, 9, 14, 0.72);
+  backdrop-filter: blur(12px);
+  box-shadow: 0 3px 18px rgba(0, 0, 0, 0.26);
+  pointer-events: none;
+}
+
+.generation-status div {
+  min-width: 0;
+}
+
+.generation-status strong,
+.generation-status span {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.generation-status strong {
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.generation-status div span {
+  margin-top: 2px;
+  color: rgba(255, 255, 255, 0.56);
+  font-size: 10px;
+}
+
+.generation-pulse {
+  width: 8px;
+  height: 8px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: #b890ff;
+  box-shadow: 0 0 14px rgba(184, 144, 255, 0.8);
+  animation: generation-pulse 1.2s ease-in-out infinite alternate;
+}
+
+.outer-status {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 28px;
+  text-align: center;
+  background:
+    radial-gradient(
+      circle at 50% 45%,
+      rgba(152, 104, 235, 0.22),
+      transparent 32%
+    ),
+    linear-gradient(145deg, #141a2a, #07080d 72%);
+}
+
+.outer-status.error {
+  background: linear-gradient(145deg, #311117, #090709 72%);
+}
+
+.outer-status h1 {
+  max-width: 620px;
+  margin: 4px 0 8px;
+  font-size: clamp(22px, 4vw, 38px);
+  line-height: 1.12;
+  letter-spacing: -0.025em;
+}
+
+.outer-status p {
+  max-width: 580px;
+  margin: 0;
+  color: rgba(247, 244, 255, 0.68);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.outer-status .eyebrow {
+  color: #cdb4ff;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.outer-orb {
+  width: 48px;
+  height: 48px;
+  margin-bottom: 18px;
+  border-radius: 50%;
+  background: conic-gradient(from 20deg, #ffd17e, #b890ff, #60d8ff, #ffd17e);
+  box-shadow: 0 0 48px rgba(184, 144, 255, 0.52);
+  animation: outer-spin 1.7s linear infinite;
+}
+
+.world-toolbar {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  opacity: 0.3;
+  transition: opacity 160ms ease;
+}
+
+.world-shell:hover .world-toolbar,
+.world-toolbar:focus-within,
+.world-shell.fullscreen .world-toolbar {
+  opacity: 1;
+}
+
+.world-toolbar button,
+.world-stats {
+  min-height: 30px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 8px;
+  background: rgba(7, 9, 14, 0.62);
+  backdrop-filter: blur(10px);
+  color: rgba(255, 255, 255, 0.88);
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.18);
+}
+
+.world-toolbar button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 9px;
+  cursor: pointer;
+}
+
+.world-toolbar button:hover {
+  background: rgba(22, 26, 38, 0.84);
+  border-color: rgba(255, 255, 255, 0.24);
+}
+
+.world-toolbar svg {
+  width: 15px;
+  height: 15px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.world-stats {
+  display: inline-flex;
+  align-items: center;
+  padding: 5px 9px;
+  color: rgba(255, 255, 255, 0.62);
+  font-size: 10px;
+  letter-spacing: 0.02em;
+}
+
+.runtime-error {
+  position: absolute;
+  left: 10px;
+  right: 10px;
+  top: 10px;
+  z-index: 12;
+  display: flex;
+  align-items: baseline;
+  gap: 9px;
+  padding: 9px 11px;
+  border: 1px solid rgba(255, 115, 127, 0.38);
+  border-radius: 9px;
+  background: rgba(50, 11, 18, 0.88);
+  color: #ffd9dc;
+  font-size: 12px;
+  box-shadow: 0 3px 18px rgba(0, 0, 0, 0.28);
+}
+
+.runtime-error span {
+  overflow: hidden;
+  color: rgba(255, 217, 220, 0.76);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@keyframes outer-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes generation-pulse {
+  to {
+    opacity: 0.35;
+    transform: scale(0.7);
+  }
+}
+
+@media (max-width: 540px) {
+  .world-shell {
+    min-height: 280px;
+  }
+  .world-toolbar button span,
+  .world-stats {
+    display: none;
+  }
+  .world-toolbar button {
+    width: 32px;
+    justify-content: center;
+    padding: 5px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .outer-orb {
+    animation: none;
+  }
+  .generation-pulse {
+    animation: none;
+  }
+}

--- a/libraries/typescript/packages/server/examples/views/generated-world/resources/generated-world/view.tsx
+++ b/libraries/typescript/packages/server/examples/views/generated-world/resources/generated-world/view.tsx
@@ -1,0 +1,890 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  ModelContext,
+  useDisplayMode,
+  useToolContext,
+  type ViewConfig,
+} from "mcp-use/react";
+
+import "./view.css";
+
+const RUNTIME_CHANNEL = "mcp-use-generated-world";
+const THREE_MODULE_URL = "https://esm.sh/three@0.180.0?bundle";
+
+/** Host display modes supported by the generated-world view. */
+export const viewConfig = {
+  displayModes: ["inline", "fullscreen"],
+} satisfies ViewConfig;
+
+type RuntimeState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | {
+      status: "streaming";
+      objects: number;
+      triangles: number;
+      lights: number;
+    }
+  | {
+      status: "ready";
+      objects: number;
+      triangles: number;
+      lights: number;
+    }
+  | { status: "error"; message: string };
+
+interface RuntimeMessage {
+  channel: typeof RUNTIME_CHANNEL;
+  nonce: string;
+  type: "runtime-ready" | "progress" | "ready" | "error";
+  message?: string;
+  stats?: {
+    objects?: number;
+    triangles?: number;
+    lights?: number;
+  };
+}
+
+function isRuntimeMessage(value: unknown): value is RuntimeMessage {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as Partial<RuntimeMessage>;
+  return (
+    candidate.channel === RUNTIME_CHANNEL &&
+    typeof candidate.nonce === "string" &&
+    (candidate.type === "runtime-ready" ||
+      candidate.type === "progress" ||
+      candidate.type === "ready" ||
+      candidate.type === "error")
+  );
+}
+
+interface WorldBuildRequest {
+  title: string;
+  source: string;
+  seed: number;
+  final: boolean;
+}
+
+function serializeForScript(value: unknown): string {
+  return JSON.stringify(value)
+    .replaceAll("<", "\\u003c")
+    .replaceAll(">", "\\u003e")
+    .replaceAll("&", "\\u0026")
+    .replaceAll("\u2028", "\\u2028")
+    .replaceAll("\u2029", "\\u2029");
+}
+
+function getProvisionalSeed(title: string): number {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < title.length; index += 1) {
+    hash ^= title.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+function buildWorldDocument({ nonce }: { nonce: string }): string {
+  const runtimeChannel = serializeForScript(RUNTIME_CHANNEL);
+  const runtimeNonce = serializeForScript(nonce);
+  const moduleUrl = serializeForScript(THREE_MODULE_URL);
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'none'; script-src 'unsafe-inline' blob: https://esm.sh; connect-src https://esm.sh; style-src 'unsafe-inline'; img-src data: blob:; media-src 'none'; font-src 'none'; frame-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'"
+    />
+    <title>Generated 3D world</title>
+    <style>
+      :root { color-scheme: dark; }
+      * { box-sizing: border-box; }
+      html, body { width: 100%; height: 100%; margin: 0; overflow: hidden; background: #080a0f; }
+      body { font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      #stage, canvas { display: block; width: 100%; height: 100%; }
+      canvas { outline: none; touch-action: none; cursor: default; }
+      canvas.controls-enabled { cursor: grab; }
+      canvas.controls-enabled:active { cursor: grabbing; }
+      #status {
+        position: fixed;
+        inset: 0;
+        z-index: 4;
+        display: grid;
+        place-items: center;
+        padding: 28px;
+        background:
+          radial-gradient(circle at 50% 42%, rgba(111, 80, 189, 0.22), transparent 34%),
+          linear-gradient(145deg, #111624, #07080c 68%);
+        color: #f4f0ff;
+        text-align: center;
+        transition: opacity 260ms ease;
+      }
+      #status.hidden { opacity: 0; pointer-events: none; }
+      #status.error { background: linear-gradient(145deg, #2c1015, #090709 72%); }
+      .status-card { max-width: 520px; }
+      .status-orb {
+        width: 44px;
+        height: 44px;
+        margin: 0 auto 16px;
+        border-radius: 50%;
+        background: conic-gradient(from 20deg, #ffca75, #b48cff, #5fd8ff, #ffca75);
+        box-shadow: 0 0 42px rgba(180, 140, 255, 0.48);
+        animation: spin 1.6s linear infinite;
+      }
+      #status.error .status-orb { background: #ff6b79; animation: none; }
+      .status-title { margin: 0; font-size: clamp(20px, 4vw, 32px); font-weight: 650; }
+      .status-copy { margin: 10px 0 0; color: rgba(244, 240, 255, 0.7); font-size: 14px; line-height: 1.5; }
+      #hud {
+        position: fixed;
+        left: 12px;
+        bottom: 12px;
+        z-index: 3;
+        max-width: calc(100% - 24px);
+        padding: 7px 10px;
+        border: 1px solid rgba(255,255,255,0.13);
+        border-radius: 8px;
+        background: rgba(7, 9, 14, 0.58);
+        backdrop-filter: blur(9px);
+        color: rgba(255,255,255,0.76);
+        font-size: 11px;
+        letter-spacing: 0.02em;
+        pointer-events: none;
+        opacity: 0;
+        transition: opacity 240ms ease;
+      }
+      #hud.visible { opacity: 1; }
+      #build-state {
+        position: fixed;
+        top: 12px;
+        left: 12px;
+        z-index: 3;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        max-width: calc(100% - 24px);
+        padding: 7px 10px;
+        border: 1px solid rgba(255,255,255,0.13);
+        border-radius: 999px;
+        background: rgba(7, 9, 14, 0.68);
+        backdrop-filter: blur(9px);
+        color: rgba(255,255,255,0.8);
+        font-size: 11px;
+        pointer-events: none;
+        opacity: 0;
+        transition: opacity 180ms ease;
+      }
+      #build-state.visible { opacity: 1; }
+      #build-state::before {
+        width: 7px;
+        height: 7px;
+        flex: 0 0 auto;
+        border-radius: 50%;
+        background: #b890ff;
+        box-shadow: 0 0 12px rgba(184, 144, 255, 0.8);
+        content: "";
+        animation: pulse 1.2s ease-in-out infinite alternate;
+      }
+      @keyframes spin { to { transform: rotate(360deg); } }
+      @keyframes pulse { to { opacity: 0.35; transform: scale(0.7); } }
+      @media (max-width: 540px) { #hud { font-size: 10px; } }
+      @media (prefers-reduced-motion: reduce) {
+        .status-orb, #build-state::before { animation: none; }
+      }
+    </style>
+  </head>
+  <body>
+    <div id="stage"></div>
+    <div id="status" class="hidden">
+      <div class="status-card">
+        <div class="status-orb"></div>
+        <h1 class="status-title">World failed to render</h1>
+        <p class="status-copy"></p>
+      </div>
+    </div>
+    <div id="build-state">Waiting for world source</div>
+    <div id="hud">WASD move · Q/E rise/fall · drag to look · Shift boost</div>
+
+    <script type="module">
+      {
+      const CHANNEL = ${runtimeChannel};
+      const NONCE = ${runtimeNonce};
+      const MAX_OBJECTS = 1500;
+      const MAX_ADDITIONS = 2400;
+      const MAX_TRIANGLES = 1000000;
+      const MAX_VERTICES = 3000000;
+      const MAX_LIGHTS = 32;
+      const MAX_FRAME_CALLBACKS = 64;
+
+      const stage = document.getElementById("stage");
+      const status = document.getElementById("status");
+      const statusTitle = status.querySelector(".status-title");
+      const statusCopy = status.querySelector(".status-copy");
+      const buildState = document.getElementById("build-state");
+      const hud = document.getElementById("hud");
+
+      const send = (type, payload = {}) => {
+        window.parent.postMessage({ channel: CHANNEL, nonce: NONCE, type, ...payload }, "*");
+      };
+
+      const showError = (error, sendToHost = true) => {
+        const message = error instanceof Error ? error.message : String(error);
+        status.classList.remove("hidden");
+        status.classList.add("error");
+        statusTitle.textContent = "World failed to render";
+        statusCopy.textContent = message;
+        if (sendToHost) send("error", { message });
+      };
+
+      try {
+        const THREE = await import(${moduleUrl});
+        const renderer = new THREE.WebGLRenderer({
+          antialias: true,
+          alpha: false,
+          powerPreference: "high-performance",
+        });
+        renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+        renderer.outputColorSpace = THREE.SRGBColorSpace;
+        renderer.toneMapping = THREE.ACESFilmicToneMapping;
+        renderer.toneMappingExposure = 1.25;
+        renderer.shadowMap.enabled = true;
+        renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+        renderer.domElement.tabIndex = 0;
+        renderer.domElement.setAttribute("aria-label", "Generated 3D flying-camera view");
+        stage.appendChild(renderer.domElement);
+
+        let activeScene = new THREE.Scene();
+        activeScene.background = new THREE.Color(0x111521);
+
+        const camera = new THREE.PerspectiveCamera(65, 4 / 3, 0.05, 1200);
+        camera.rotation.order = "YXZ";
+
+        const toVector = (value, fallback) => {
+          if (!Array.isArray(value) || value.length !== 3 || !value.every(Number.isFinite)) {
+            return new THREE.Vector3(...fallback);
+          }
+          return new THREE.Vector3(value[0], value[1], value[2]);
+        };
+
+        const constructionSpawn = new THREE.Vector3(14, 16, 20);
+        const constructionLookAt = new THREE.Vector3(0, 2, 0);
+        let spawn = constructionSpawn.clone();
+        let lookAt = constructionLookAt.clone();
+        let moveSpeed = 5;
+        let yaw = 0;
+        let pitch = 0;
+        const applyPose = () => {
+          camera.position.copy(spawn);
+          const direction = lookAt.clone().sub(spawn).normalize();
+          yaw = Math.atan2(-direction.x, -direction.z);
+          pitch = Math.asin(THREE.MathUtils.clamp(direction.y, -1, 1));
+          camera.rotation.set(pitch, yaw, 0, "YXZ");
+        };
+        applyPose();
+
+        const disposeScene = (scene) => {
+          scene.traverse((object) => {
+            object.geometry?.dispose?.();
+            const materials = Array.isArray(object.material)
+              ? object.material
+              : object.material
+                ? [object.material]
+                : [];
+            for (const material of materials) {
+              for (const value of Object.values(material)) {
+                if (value?.isTexture) value.dispose();
+              }
+              material.dispose?.();
+            }
+          });
+          if (scene.background?.isTexture) scene.background.dispose();
+          if (scene.environment?.isTexture && scene.environment !== scene.background) {
+            scene.environment.dispose();
+          }
+        };
+
+        const inspectScene = (scene) => {
+          let objects = 0;
+          let triangles = 0;
+          let vertices = 0;
+          let lights = 0;
+          scene.traverse((object) => {
+            if (object !== scene) objects += 1;
+            if (object.isLight) lights += 1;
+            const geometry = object.geometry;
+            if (geometry) {
+              const position = geometry.getAttribute?.("position");
+              const geometryVertices = position?.count ?? 0;
+              const geometryTriangles = geometry.index
+                ? geometry.index.count / 3
+                : geometryVertices / 3;
+              const instances = object.isInstancedMesh ? object.count : 1;
+              vertices += geometryVertices * instances;
+              triangles += geometryTriangles * instances;
+            }
+          });
+          const stats = {
+            objects: Math.round(objects),
+            triangles: Math.round(triangles),
+            vertices: Math.round(vertices),
+            lights: Math.round(lights),
+          };
+          if (stats.objects > MAX_OBJECTS) {
+            throw new Error("World has " + stats.objects + " objects; the limit is " + MAX_OBJECTS + ".");
+          }
+          if (stats.triangles > MAX_TRIANGLES) {
+            throw new Error("World has " + stats.triangles.toLocaleString() + " triangles; the limit is " + MAX_TRIANGLES.toLocaleString() + ".");
+          }
+          if (stats.vertices > MAX_VERTICES) {
+            throw new Error("World has " + stats.vertices.toLocaleString() + " vertices; the limit is " + MAX_VERTICES.toLocaleString() + ".");
+          }
+          if (stats.lights > MAX_LIGHTS) {
+            throw new Error("World has " + stats.lights + " lights; the limit is " + MAX_LIGHTS + ".");
+          }
+          return stats;
+        };
+
+        const addRuntimeLighting = (scene) => {
+          const sky = new THREE.HemisphereLight(0xdde9ff, 0x3a2d24, 1.1);
+          sky.name = "Runtime sky fill";
+          scene.add(sky);
+
+          const sun = new THREE.DirectionalLight(0xfff1d6, 1.4);
+          sun.name = "Runtime sun fill";
+          sun.position.set(10, 16, 12);
+          scene.add(sun);
+        };
+
+        const resize = () => {
+          const width = Math.max(1, stage.clientWidth);
+          const height = Math.max(1, stage.clientHeight);
+          renderer.setSize(width, height, false);
+          camera.aspect = width / height;
+          camera.updateProjectionMatrix();
+        };
+        resize();
+        new ResizeObserver(resize).observe(stage);
+
+        const keys = new Set();
+        let controlsEnabled = false;
+        const controlKeys = new Set([
+          "KeyW", "KeyA", "KeyS", "KeyD", "KeyQ", "KeyE",
+          "ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight",
+          "ShiftLeft", "ShiftRight",
+        ]);
+        window.addEventListener("keydown", (event) => {
+          if (!controlsEnabled) return;
+          if (controlKeys.has(event.code)) event.preventDefault();
+          keys.add(event.code);
+        });
+        window.addEventListener("keyup", (event) => keys.delete(event.code));
+        window.addEventListener("blur", () => keys.clear());
+
+        let dragging = false;
+        let previousX = 0;
+        let previousY = 0;
+        const canvas = renderer.domElement;
+        canvas.addEventListener("pointerdown", (event) => {
+          if (!controlsEnabled) return;
+          dragging = true;
+          previousX = event.clientX;
+          previousY = event.clientY;
+          canvas.setPointerCapture(event.pointerId);
+          canvas.focus();
+        });
+        canvas.addEventListener("pointermove", (event) => {
+          if (!dragging) return;
+          const dx = event.clientX - previousX;
+          const dy = event.clientY - previousY;
+          previousX = event.clientX;
+          previousY = event.clientY;
+          yaw -= dx * 0.003;
+          pitch = THREE.MathUtils.clamp(pitch - dy * 0.003, -1.52, 1.52);
+        });
+        const stopDragging = (event) => {
+          dragging = false;
+          if (canvas.hasPointerCapture(event.pointerId)) {
+            canvas.releasePointerCapture(event.pointerId);
+          }
+        };
+        canvas.addEventListener("pointerup", stopDragging);
+        canvas.addEventListener("pointercancel", stopDragging);
+
+        const clock = new THREE.Clock();
+        const forward = new THREE.Vector3();
+        const right = new THREE.Vector3();
+        const movement = new THREE.Vector3();
+        let frameCallbacks = [];
+        let activeBuildFinal = false;
+        let animationCallbacksHealthy = true;
+
+        const animate = () => {
+          const delta = Math.min(clock.getDelta(), 0.05);
+          const elapsed = clock.elapsedTime;
+
+          camera.rotation.set(pitch, yaw, 0, "YXZ");
+          movement.set(0, 0, 0);
+          forward.set(0, 0, -1).applyQuaternion(camera.quaternion);
+          right.set(1, 0, 0).applyQuaternion(camera.quaternion);
+
+          if (keys.has("KeyW") || keys.has("ArrowUp")) movement.add(forward);
+          if (keys.has("KeyS") || keys.has("ArrowDown")) movement.sub(forward);
+          if (keys.has("KeyD") || keys.has("ArrowRight")) movement.add(right);
+          if (keys.has("KeyA") || keys.has("ArrowLeft")) movement.sub(right);
+          if (keys.has("KeyE")) movement.y += 1;
+          if (keys.has("KeyQ")) movement.y -= 1;
+
+          if (movement.lengthSq() > 0) {
+            const boost = keys.has("ShiftLeft") || keys.has("ShiftRight") ? 3 : 1;
+            camera.position.addScaledVector(movement.normalize(), moveSpeed * boost * delta);
+          }
+
+          if (animationCallbacksHealthy) {
+            try {
+              for (const callback of frameCallbacks) callback(delta, elapsed);
+            } catch (error) {
+              animationCallbacksHealthy = false;
+              if (activeBuildFinal) {
+                showError(error);
+              } else {
+                buildState.textContent = document.title + " · writing animation";
+              }
+            }
+          }
+
+          activeScene.fog = null;
+          renderer.render(activeScene, camera);
+          window.requestAnimationFrame(animate);
+        };
+
+        status.classList.add("hidden");
+        buildState.classList.add("visible");
+        animate();
+        send("runtime-ready");
+
+        let latestBuildId = 0;
+        let queuedBuild = null;
+        let buildLoopRunning = false;
+
+        const runBuild = async (request) => {
+          const candidateScene = new THREE.Scene();
+          candidateScene.background = new THREE.Color(0x111521);
+          const candidateCallbacks = [];
+          let additions = 0;
+          const originalAdd = THREE.Object3D.prototype.add;
+          let timeoutId;
+
+          try {
+            const moduleSource =
+              "export default async function buildWorld({ THREE, scene, random, onFrame }) {\\n" +
+              request.source +
+              "\\n}";
+            const worldModuleUrl = URL.createObjectURL(
+              new Blob([moduleSource], { type: "text/javascript" })
+            );
+            let builder;
+            try {
+              const worldModule = await import(worldModuleUrl);
+              builder = worldModule.default;
+            } finally {
+              URL.revokeObjectURL(worldModuleUrl);
+            }
+
+            let randomState = request.seed || 0x6d2b79f5;
+            const random = () => {
+              randomState = (randomState + 0x6d2b79f5) >>> 0;
+              let value = randomState;
+              value = Math.imul(value ^ (value >>> 15), value | 1);
+              value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+              return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+            };
+            const onFrame = (callback) => {
+              if (typeof callback !== "function") {
+                throw new TypeError("onFrame expects a function.");
+              }
+              if (candidateCallbacks.length >= MAX_FRAME_CALLBACKS) {
+                throw new Error("World exceeded the " + MAX_FRAME_CALLBACKS + " animation callback budget.");
+              }
+              candidateCallbacks.push(callback);
+            };
+
+            THREE.Object3D.prototype.add = function (...objects) {
+              additions += objects.length;
+              if (additions > MAX_ADDITIONS) {
+                throw new Error("World exceeded the " + MAX_ADDITIONS + " object-addition budget.");
+              }
+              return originalAdd.apply(this, objects);
+            };
+
+            const timeout = new Promise((_, reject) => {
+              timeoutId = window.setTimeout(
+                () => reject(new Error("World construction exceeded 8 seconds.")),
+                8000
+              );
+            });
+            const result = await Promise.race([
+              builder(Object.freeze({
+                THREE,
+                scene: candidateScene,
+                random,
+                onFrame,
+              })),
+              timeout,
+            ]);
+            window.clearTimeout(timeoutId);
+            THREE.Object3D.prototype.add = originalAdd;
+
+            if (request.id !== latestBuildId) {
+              disposeScene(candidateScene);
+              return;
+            }
+            if (candidateScene.children.length === 0) {
+              throw new Error("The generated world did not add anything to the scene.");
+            }
+
+            const stats = inspectScene(candidateScene);
+            candidateScene.fog = null;
+            addRuntimeLighting(candidateScene);
+            const previousScene = activeScene;
+            activeScene = candidateScene;
+            frameCallbacks = candidateCallbacks;
+            activeBuildFinal = request.final;
+            animationCallbacksHealthy = true;
+            spawn = request.final
+              ? toVector(result?.spawn, [0, 2.4, 9])
+              : constructionSpawn.clone();
+            lookAt = request.final
+              ? toVector(result?.lookAt, [0, 1.5, 0])
+              : constructionLookAt.clone();
+            moveSpeed = THREE.MathUtils.clamp(
+              Number.isFinite(result?.moveSpeed) ? result.moveSpeed : 5,
+              1,
+              20
+            );
+            applyPose();
+            renderer.render(activeScene, camera);
+            disposeScene(previousScene);
+
+            controlsEnabled = request.final;
+            status.classList.remove("error");
+            status.classList.add("hidden");
+            canvas.classList.toggle("controls-enabled", controlsEnabled);
+            hud.classList.toggle("visible", controlsEnabled);
+            buildState.classList.toggle("visible", !request.final);
+            buildState.textContent = request.title + " · " + stats.objects.toLocaleString() + " objects forming";
+            renderer.domElement.setAttribute(
+              "aria-label",
+              request.title + " 3D flying-camera view"
+            );
+            document.title = request.title;
+            send(request.final ? "ready" : "progress", {
+              stats: {
+                objects: stats.objects,
+                triangles: stats.triangles,
+                lights: stats.lights,
+              },
+            });
+          } catch (error) {
+            window.clearTimeout(timeoutId);
+            THREE.Object3D.prototype.add = originalAdd;
+            disposeScene(candidateScene);
+            if (request.id !== latestBuildId) return;
+            controlsEnabled = false;
+            canvas.classList.remove("controls-enabled");
+            hud.classList.remove("visible");
+            if (request.final) {
+              showError(error);
+            } else {
+              buildState.textContent = request.title + " · writing geometry";
+            }
+          }
+        };
+
+        const drainBuildQueue = async () => {
+          if (buildLoopRunning) return;
+          buildLoopRunning = true;
+          while (queuedBuild !== null) {
+            const request = queuedBuild;
+            queuedBuild = null;
+            await runBuild(request);
+          }
+          buildLoopRunning = false;
+        };
+
+        window.addEventListener("message", (event) => {
+          if (event.source !== window.parent) return;
+          const message = event.data;
+          if (message?.channel !== CHANNEL || message?.nonce !== NONCE) return;
+          if (message.type === "reset") {
+            if (controlsEnabled) applyPose();
+            return;
+          }
+          if (
+            message.type !== "build" ||
+            typeof message.source !== "string" ||
+            typeof message.title !== "string" ||
+            typeof message.seed !== "number" ||
+            typeof message.final !== "boolean"
+          ) {
+            return;
+          }
+          latestBuildId += 1;
+          queuedBuild = { ...message, id: latestBuildId };
+          controlsEnabled = false;
+          keys.clear();
+          canvas.classList.remove("controls-enabled");
+          hud.classList.remove("visible");
+          buildState.textContent = message.title + " · writing geometry";
+          buildState.classList.add("visible");
+          void drainBuildQueue();
+        });
+      } catch (error) {
+        showError(error);
+      }
+      }
+    </script>
+  </body>
+</html>`;
+}
+
+function ExpandIcon() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M9.5 2H14v4.5M14 2 9 7M6.5 14H2V9.5M2 14l5-5" />
+    </svg>
+  );
+}
+
+function ResetIcon() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M3.2 5.6A5.5 5.5 0 1 1 2.5 9M3.2 5.6V2.7M3.2 5.6h2.9" />
+    </svg>
+  );
+}
+
+/** Renders the sandboxed world runtime and its host-level controls. */
+export default function GeneratedWorldView() {
+  const tool = useToolContext<"render_world">();
+  const { displayMode, requestDisplayMode } = useDisplayMode();
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const activeNonceRef = useRef<string | null>(null);
+  const runtimeReadyRef = useRef(false);
+  const latestBuildRef = useRef<WorldBuildRequest | null>(null);
+  const [frameUrl, setFrameUrl] = useState<string | null>(null);
+  const [runtime, setRuntime] = useState<RuntimeState>({ status: "idle" });
+
+  const world = tool.status === "ready" ? tool.toolOutput : undefined;
+
+  useEffect(() => {
+    const nonce = crypto.randomUUID();
+    activeNonceRef.current = nonce;
+    setRuntime({ status: "loading" });
+    const document = buildWorldDocument({ nonce });
+    const url = URL.createObjectURL(
+      new Blob([document], { type: "text/html;charset=utf-8" })
+    );
+    setFrameUrl(url);
+
+    return () => {
+      URL.revokeObjectURL(url);
+      runtimeReadyRef.current = false;
+      activeNonceRef.current = null;
+    };
+  }, []);
+
+  const pendingTitle = tool.toolInput?.title;
+  const pendingSource = tool.toolInput?.source;
+  const pendingSourceLength = pendingSource?.length ?? 0;
+
+  useEffect(() => {
+    const request: WorldBuildRequest | null =
+      tool.status === "ready"
+        ? {
+            title: tool.toolOutput.title,
+            source: tool.toolOutput.source,
+            seed: tool.toolOutput.seed,
+            final: true,
+          }
+        : tool.status === "pending" &&
+            typeof pendingSource === "string" &&
+            pendingSource.length > 0
+          ? {
+              title: pendingTitle ?? "Generated world",
+              source: pendingSource,
+              seed:
+                typeof tool.toolInput?.seed === "number"
+                  ? tool.toolInput.seed
+                  : getProvisionalSeed(pendingTitle ?? "Generated world"),
+              final: false,
+            }
+          : null;
+
+    latestBuildRef.current = request;
+    const target = iframeRef.current?.contentWindow;
+    const nonce = activeNonceRef.current;
+    if (
+      request === null ||
+      !runtimeReadyRef.current ||
+      target === undefined ||
+      target === null ||
+      nonce === null
+    ) {
+      return;
+    }
+    target.postMessage(
+      { channel: RUNTIME_CHANNEL, nonce, type: "build", ...request },
+      "*"
+    );
+  }, [
+    pendingSource,
+    pendingTitle,
+    tool.status,
+    tool.toolInput?.seed,
+    world?.seed,
+    world?.source,
+    world?.title,
+  ]);
+
+  useEffect(() => {
+    const receiveRuntimeMessage = (event: MessageEvent<unknown>) => {
+      if (event.source !== iframeRef.current?.contentWindow) return;
+      if (!isRuntimeMessage(event.data)) return;
+      if (event.data.nonce !== activeNonceRef.current) return;
+
+      if (event.data.type === "runtime-ready") {
+        runtimeReadyRef.current = true;
+        const request = latestBuildRef.current;
+        const nonce = activeNonceRef.current;
+        if (request !== null && nonce !== null) {
+          iframeRef.current?.contentWindow?.postMessage(
+            { channel: RUNTIME_CHANNEL, nonce, type: "build", ...request },
+            "*"
+          );
+        }
+        return;
+      }
+
+      if (event.data.type === "error") {
+        setRuntime({
+          status: "error",
+          message:
+            event.data.message ?? "The generated world failed to render.",
+        });
+        return;
+      }
+
+      setRuntime({
+        status: event.data.type === "progress" ? "streaming" : "ready",
+        objects: Math.max(0, Math.round(event.data.stats?.objects ?? 0)),
+        triangles: Math.max(0, Math.round(event.data.stats?.triangles ?? 0)),
+        lights: Math.max(0, Math.round(event.data.stats?.lights ?? 0)),
+      });
+    };
+
+    window.addEventListener("message", receiveRuntimeMessage);
+    return () => window.removeEventListener("message", receiveRuntimeMessage);
+  }, []);
+
+  const toggleFullscreen = useCallback(async () => {
+    try {
+      await requestDisplayMode({
+        mode: displayMode === "fullscreen" ? "inline" : "fullscreen",
+      });
+    } catch {
+      // The host may decline fullscreen. displayMode remains the source of truth.
+    }
+  }, [displayMode, requestDisplayMode]);
+
+  const resetCamera = useCallback(() => {
+    const target = iframeRef.current?.contentWindow;
+    const nonce = activeNonceRef.current;
+    if (target === undefined || target === null || nonce === null) return;
+    target.postMessage({ channel: RUNTIME_CHANNEL, nonce, type: "reset" }, "*");
+  }, []);
+
+  const shellClass = `world-shell${displayMode === "fullscreen" ? " fullscreen" : ""}`;
+  const modelContext =
+    tool.status === "ready"
+      ? runtime.status === "error"
+        ? `Generated 3D world "${tool.toolOutput.title}" failed in the viewer: ${runtime.message} Revise the source and call render_world again.`
+        : runtime.status === "ready"
+          ? `Generated 3D world "${tool.toolOutput.title}" is displayed (id: ${tool.toolOutput.worldId}). The user can fly with WASD, move vertically with Q/E, drag to look, and hold Shift to boost.`
+          : `Generated 3D world "${tool.toolOutput.title}" is being constructed in the viewer.`
+      : tool.status === "error"
+        ? `Generated 3D world failed: ${tool.error.message}`
+        : "A generated 3D world is being written.";
+
+  return (
+    <main className={shellClass}>
+      <ModelContext content={modelContext} />
+
+      {frameUrl !== null && (
+        <iframe
+          ref={iframeRef}
+          className="world-frame"
+          src={frameUrl}
+          sandbox="allow-scripts"
+          title={world?.title ?? pendingTitle ?? "Generated 3D world"}
+        />
+      )}
+
+      {tool.status === "pending" && (
+        <section className="generation-status" aria-busy="true">
+          <span className="generation-pulse" aria-hidden="true" />
+          <div>
+            <strong>{pendingTitle ?? "Imagining a new world…"}</strong>
+            <span>
+              {pendingSourceLength > 0
+                ? `${pendingSourceLength.toLocaleString()} characters written`
+                : "Waiting for the world source…"}
+            </span>
+          </div>
+        </section>
+      )}
+
+      {tool.status === "error" && (
+        <section className="outer-status error" role="alert">
+          <p className="eyebrow">World rejected</p>
+          <h1>Couldn’t build this environment</h1>
+          <p>{tool.error.message}</p>
+        </section>
+      )}
+
+      {runtime.status === "error" && tool.status === "ready" && (
+        <div className="runtime-error" role="alert">
+          <strong>Runtime error</strong>
+          <span>{runtime.message}</span>
+        </div>
+      )}
+
+      {tool.status === "ready" && (
+        <div className="world-toolbar">
+          {runtime.status === "ready" && (
+            <span className="world-stats">
+              {runtime.objects.toLocaleString()} objects ·{" "}
+              {runtime.triangles.toLocaleString()} triangles
+            </span>
+          )}
+          <button type="button" onClick={resetCamera} title="Reset camera">
+            <ResetIcon />
+            <span>Reset</span>
+          </button>
+          <button
+            type="button"
+            onClick={() => void toggleFullscreen()}
+            title={
+              displayMode === "fullscreen"
+                ? "Exit fullscreen"
+                : "Enter fullscreen"
+            }
+          >
+            <ExpandIcon />
+            <span>{displayMode === "fullscreen" ? "Exit" : "Explore"}</span>
+          </button>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/libraries/typescript/packages/server/examples/views/generated-world/src/css.d.ts
+++ b/libraries/typescript/packages/server/examples/views/generated-world/src/css.d.ts
@@ -1,0 +1,4 @@
+declare module "*.css" {
+  const css: string;
+  export default css;
+}

--- a/libraries/typescript/packages/server/examples/views/generated-world/src/index.ts
+++ b/libraries/typescript/packages/server/examples/views/generated-world/src/index.ts
@@ -1,0 +1,131 @@
+/**
+ * Generated World — model-authored Three.js worlds in an ephemeral sandbox.
+ *
+ * Follows the CLI entry contract: default-export the MCPServer instance;
+ * `mcp-use dev` / `build` / `start` own the socket and view priming.
+ */
+import { createHash } from "node:crypto";
+import { MCPServer } from "mcp-use";
+import { z } from "zod";
+
+import { WORLD_GUIDE } from "./world-guide.js";
+
+const BASE_PATH = "/mcp";
+const MAX_SOURCE_BYTES = 180 * 1024;
+
+const server = new MCPServer({
+  name: "generated-world",
+  version: "1.0.0",
+  title: "Generated World",
+  legacy: "stateless",
+  logging: { level: "debug" },
+  description:
+    "Generate an ephemeral Three.js environment and explore it with a flying camera.",
+  basePath: BASE_PATH,
+});
+
+const worldOutputSchema = z.object({
+  worldId: z.string(),
+  title: z.string(),
+  source: z.string(),
+  seed: z.number().int(),
+});
+
+/** Model-facing reference for the generated-world source contract. */
+export const readWorldGuide = server.tool(
+  {
+    name: "read_world_guide",
+    title: "Read generated-world guide",
+    description:
+      "Read the JavaScript contract and safety limits for render_world. Call this before rendering a world for the first time.",
+    annotations: { readOnlyHint: true },
+  },
+  async () => ({
+    content: [{ type: "text", text: WORLD_GUIDE }],
+  })
+);
+
+/** Returns one ephemeral generated world to its bound MCP App view. */
+export const renderWorld = server.tool(
+  {
+    name: "render_world",
+    title: "Generate 3D world",
+    description: `Render a complete interactive Three.js environment from model-generated JavaScript.
+Call read_world_guide first. Generate the source directly into the source argument.
+Build an open-top environment with absolutely no roofs, ceilings, fog, or other visual obstructions so its streamed construction remains visible from the elevated camera.
+The source is ephemeral: the MCP server returns it in the same tool result and does not persist it or call a separate upload service.
+Syntax and runtime failures are reported by the sandboxed viewer so the world can be revised.
+The user explores with a flying camera (WASD, Q/E, drag to look, Shift to boost).`,
+    inputSchema: z.object({
+      title: z
+        .string()
+        .min(1)
+        .max(120)
+        .describe("Short human-readable name for the generated environment"),
+      source: z
+        .string()
+        .min(1)
+        .describe(
+          "Body of async buildWorld({ THREE, scene, random, onFrame }). Follow read_world_guide: build near the origin with absolutely no roofs, ceilings, fog, or overhead geometry; do not include a function wrapper, imports, exports, markdown, HTML, browser globals, network calls, timers, camera, renderer, or render loop. These are authoring instructions rather than server-side rejections; the viewer reports syntax and runtime failures."
+        ),
+      seed: z
+        .number()
+        .int()
+        .min(0)
+        .max(0xffffffff)
+        .optional()
+        .describe("Optional deterministic unsigned 32-bit random seed"),
+    }),
+    outputSchema: worldOutputSchema,
+    annotations: { readOnlyHint: true },
+    view: {
+      name: "generated-world",
+      description: "Fly through a model-generated Three.js environment",
+      prefersBorder: false,
+      csp: {
+        resourceDomains: ["https://esm.sh"],
+        connectDomains: ["https://esm.sh"],
+        frameDomains: ["blob:"],
+      },
+    },
+  },
+  async ({ title, source, seed }) => {
+    if (Buffer.byteLength(source, "utf8") > MAX_SOURCE_BYTES) {
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text",
+            text: `World source exceeds the ${MAX_SOURCE_BYTES} byte limit.`,
+          },
+        ],
+      };
+    }
+
+    const digest = createHash("sha256")
+      .update(title)
+      .update("\0")
+      .update(source)
+      .digest();
+    const worldId = digest.toString("hex").slice(0, 18);
+    const resolvedSeed = seed ?? digest.readUInt32BE(0);
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Generated world "${title}" was sent to the sandboxed viewer. Viewer errors will identify anything that needs revision. This app did not persist it or send it to a separate upload service.`,
+        },
+      ],
+      structuredContent: {
+        worldId,
+        title,
+        source,
+        seed: resolvedSeed,
+      },
+    };
+  }
+);
+
+/** v2 MCP server used by the generated-world reference app. */
+export default server;

--- a/libraries/typescript/packages/server/examples/views/generated-world/src/tools.d.ts
+++ b/libraries/typescript/packages/server/examples/views/generated-world/src/tools.d.ts
@@ -1,0 +1,7 @@
+declare module "mcp-use/react" {
+  interface Register {
+    tools: typeof import("./index.js");
+  }
+}
+
+export {};

--- a/libraries/typescript/packages/server/examples/views/generated-world/src/world-guide.ts
+++ b/libraries/typescript/packages/server/examples/views/generated-world/src/world-guide.ts
@@ -1,0 +1,85 @@
+/** Model-facing contract and authoring guide for the render_world tool. */
+export const WORLD_GUIDE = `# Generated World source contract
+
+The \`render_world\` tool turns JavaScript into an ephemeral Three.js environment. While the source argument is being written, syntactically complete prefixes are compiled and rendered inside a nested sandboxed iframe. Each viable prefix replaces the previous scene, so write the world in a useful construction order: establish atmosphere and lighting, then major structures, then details and animation. During construction, the camera is locked in an elevated three-quarter view looking toward the origin. The final source switches to the returned spawn and unlocks exploration. Final syntax and runtime failures are shown in the view and added to model context for the next revision. This app does not persist the source or send it to a separate upload service.
+
+## What to send
+
+\`source\` is the BODY of this async function. Do not include the function declaration or markdown fences.
+
+\`\`\`js
+async function buildWorld({ THREE, scene, random, onFrame }) {
+  // Your source is inserted here.
+  return {
+    spawn: [0, 2, 8],
+    lookAt: [0, 1.5, 0],
+    moveSpeed: 5,
+  };
+}
+\`\`\`
+
+## Available values
+
+- \`THREE\`: the complete Three.js module, version 0.180.0.
+- \`scene\`: a new \`THREE.Scene\`. Add every visible object to it.
+- \`random()\`: deterministic seeded random number in [0, 1).
+- \`onFrame(callback)\`: register up to 64 animation callbacks. A callback receives \`(deltaSeconds, elapsedSeconds)\`.
+
+The runtime owns the renderer, camera, resize behavior, flying controls, and a subtle sky-plus-sun lighting rig that keeps the world readable. Add scene-specific lights for mood and emphasis, but do not rely on darkness to hide unfinished geometry. Do not create a renderer, camera, canvas, controls, or render loop.
+
+## Rules
+
+- Build the environment around the world origin so it stays visible from the elevated construction camera.
+- Never add a roof, ceiling, awning, canopy, or other overhead geometry. This rule is absolute: every interior must remain open from above so the user can watch it being built.
+- Never set \`scene.fog\` or create fog effects. The runtime removes scene fog so the world remains unobstructed during construction and exploration.
+- Use no imports or exports.
+- Do not access window, document, globalThis, parent, top, navigator, location, storage, workers, timers, network APIs, eval, or Function.
+- Use \`onFrame\` instead of \`requestAnimationFrame\` or timers.
+- Do not write unbounded loops. Keep the world below 1,500 objects, 1,000,000 triangles, and 32 lights.
+- Prefer reusable helper functions, groups, and \`InstancedMesh\` for repeated geometry.
+- Set \`scene.background\` to complement the environment.
+- Add ambient plus directional/point lighting. The runtime enables shadows.
+- Return a spawn point, look-at point, and optional movement speed. Movement speed is clamped to 1–20.
+
+These are authoring instructions for the model, not server-side keyword checks. The source is still sent to the sandbox if a rule is missed, and the viewer reports syntax or runtime failures for the next revision.
+
+## Tiny example
+
+\`\`\`js
+scene.background = new THREE.Color(0x101426);
+
+scene.add(new THREE.HemisphereLight(0x9db7ff, 0x24180e, 1.6));
+const moon = new THREE.DirectionalLight(0xdde7ff, 2.2);
+moon.position.set(6, 12, 4);
+moon.castShadow = true;
+scene.add(moon);
+
+const ground = new THREE.Mesh(
+  new THREE.CircleGeometry(30, 64),
+  new THREE.MeshStandardMaterial({ color: 0x243322, roughness: 1 })
+);
+ground.rotation.x = -Math.PI / 2;
+ground.receiveShadow = true;
+scene.add(ground);
+
+const crystal = new THREE.Mesh(
+  new THREE.OctahedronGeometry(1.2, 0),
+  new THREE.MeshStandardMaterial({
+    color: 0x875cff,
+    emissive: 0x3a1670,
+    emissiveIntensity: 2,
+  })
+);
+crystal.position.set(0, 1.3, 0);
+crystal.castShadow = true;
+scene.add(crystal);
+
+onFrame((_delta, elapsed) => {
+  crystal.rotation.y = elapsed * 0.45;
+  crystal.position.y = 1.3 + Math.sin(elapsed * 1.4) * 0.15;
+});
+
+return { spawn: [0, 2.4, 9], lookAt: [0, 1.3, 0], moveSpeed: 5 };
+\`\`\`
+
+Build complete, coherent environments rather than isolated objects. For a magical tavern, include an open-top room shell, floor, bar, shelves, bottles, tables, chairs, fireplace, lanterns, windows, signs, atmospheric particles, and warm lighting. Never add its roof or ceiling.`;

--- a/libraries/typescript/packages/server/examples/views/generated-world/tsconfig.json
+++ b/libraries/typescript/packages/server/examples/views/generated-world/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2024", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "types": ["node"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*", "resources/**/*"]
+}

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -124,6 +124,9 @@ importers:
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
+      semver:
+        specifier: ^7.7.3
+        version: 7.8.5
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
@@ -184,14 +187,30 @@ importers:
         specifier: 2.1.11
         version: 2.1.11
 
+  packages/cli:
+    dependencies:
+      mcp-use:
+        specifier: workspace:*
+        version: link:../server
+    devDependencies:
+      rimraf:
+        specifier: ^6.1.3
+        version: 6.1.3
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   packages/client:
     dependencies:
       '@modelcontextprotocol/client':
-        specifier: https://pkg.pr.new/@modelcontextprotocol/client@2501
-        version: https://pkg.pr.new/@modelcontextprotocol/client@2501
+        specifier: https://pkg.pr.new/@modelcontextprotocol/client@f60b40179b0f090f6d64248be1312245a160b5ee
+        version: https://pkg.pr.new/@modelcontextprotocol/client@f60b40179b0f090f6d64248be1312245a160b5ee
       '@modelcontextprotocol/ext-apps':
-        specifier: https://pkg.pr.new/@modelcontextprotocol/ext-apps@712
-        version: https://pkg.pr.new/@modelcontextprotocol/ext-apps@712(@modelcontextprotocol/client@https://pkg.pr.new/@modelcontextprotocol/client@2501)(@modelcontextprotocol/core@2.0.0-beta.4)(@modelcontextprotocol/server@2.0.0-beta.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
+        specifier: https://pkg.pr.new/@modelcontextprotocol/ext-apps@432d42bb02a569078ab31ab6458428df6027809d
+        version: https://pkg.pr.new/@modelcontextprotocol/ext-apps@432d42bb02a569078ab31ab6458428df6027809d(@modelcontextprotocol/client@https://pkg.pr.new/@modelcontextprotocol/client@f60b40179b0f090f6d64248be1312245a160b5ee)(@modelcontextprotocol/core@2.0.0-beta.4)(@modelcontextprotocol/server@2.0.0-beta.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
     devDependencies:
       '@e2b/code-interpreter':
         specifier: ^2.6.1
@@ -479,11 +498,11 @@ importers:
   packages/server:
     dependencies:
       '@modelcontextprotocol/ext-apps':
-        specifier: https://pkg.pr.new/@modelcontextprotocol/ext-apps@712
-        version: https://pkg.pr.new/@modelcontextprotocol/ext-apps@712(@modelcontextprotocol/client@https://pkg.pr.new/@modelcontextprotocol/client@2501)(@modelcontextprotocol/core@https://pkg.pr.new/@modelcontextprotocol/core@2501)(@modelcontextprotocol/server@https://pkg.pr.new/@modelcontextprotocol/server@2501)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
+        specifier: https://pkg.pr.new/@modelcontextprotocol/ext-apps@432d42bb02a569078ab31ab6458428df6027809d
+        version: https://pkg.pr.new/@modelcontextprotocol/ext-apps@432d42bb02a569078ab31ab6458428df6027809d(@modelcontextprotocol/client@https://pkg.pr.new/@modelcontextprotocol/client@f60b40179b0f090f6d64248be1312245a160b5ee)(@modelcontextprotocol/core@https://pkg.pr.new/@modelcontextprotocol/core@f60b40179b0f090f6d64248be1312245a160b5ee)(@modelcontextprotocol/server@https://pkg.pr.new/@modelcontextprotocol/server@f60b40179b0f090f6d64248be1312245a160b5ee)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
       '@modelcontextprotocol/server':
-        specifier: https://pkg.pr.new/@modelcontextprotocol/server@2501
-        version: https://pkg.pr.new/@modelcontextprotocol/server@2501
+        specifier: https://pkg.pr.new/@modelcontextprotocol/server@f60b40179b0f090f6d64248be1312245a160b5ee
+        version: https://pkg.pr.new/@modelcontextprotocol/server@f60b40179b0f090f6d64248be1312245a160b5ee
       '@tailwindcss/vite':
         specifier: ^4.2.0
         version: 4.2.0(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
@@ -504,11 +523,11 @@ importers:
         specifier: workspace:*
         version: link:../client
       '@modelcontextprotocol/client':
-        specifier: https://pkg.pr.new/@modelcontextprotocol/client@2501
-        version: https://pkg.pr.new/@modelcontextprotocol/client@2501
+        specifier: https://pkg.pr.new/@modelcontextprotocol/client@f60b40179b0f090f6d64248be1312245a160b5ee
+        version: https://pkg.pr.new/@modelcontextprotocol/client@f60b40179b0f090f6d64248be1312245a160b5ee
       '@modelcontextprotocol/core':
-        specifier: https://pkg.pr.new/@modelcontextprotocol/core@2501
-        version: https://pkg.pr.new/@modelcontextprotocol/core@2501
+        specifier: https://pkg.pr.new/@modelcontextprotocol/core@f60b40179b0f090f6d64248be1312245a160b5ee
+        version: https://pkg.pr.new/@modelcontextprotocol/core@f60b40179b0f090f6d64248be1312245a160b5ee
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -675,6 +694,19 @@ importers:
       vite:
         specifier: '>=8.0.5'
         version: 8.0.16(@types/node@24.13.2)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+
+  packages/server/examples/openapi:
+    dependencies:
+      mcp-use:
+        specifier: workspace:*
+        version: link:../..
+    devDependencies:
+      '@types/node':
+        specifier: ^24.13.2
+        version: 24.13.2
+      typescript:
+        specifier: 7.0.1-rc
+        version: 7.0.1-rc
 
   packages/server/examples/railway:
     dependencies:
@@ -1614,8 +1646,8 @@ packages:
     resolution: {integrity: sha512-o9z9YCGNxWNdklPdjcD0tr8pocC9OgjdArqgx3OjPMlTe0M/SSPC2olOJs5ueq77HSpz36mND0f0KteqEhKF3A==}
     engines: {node: '>=20'}
 
-  '@modelcontextprotocol/client@https://pkg.pr.new/@modelcontextprotocol/client@2501':
-    resolution: {integrity: sha512-5FvmSf2qWlJXlI9ydf8230f1rsDHMEw9Jgcq2ZUGmA3DJShaYV6t49zKJBuawetMcLOzWBGs8+qDzhZOZTk6Fw==, tarball: https://pkg.pr.new/@modelcontextprotocol/client@2501}
+  '@modelcontextprotocol/client@https://pkg.pr.new/@modelcontextprotocol/client@f60b40179b0f090f6d64248be1312245a160b5ee':
+    resolution: {integrity: sha512-5FvmSf2qWlJXlI9ydf8230f1rsDHMEw9Jgcq2ZUGmA3DJShaYV6t49zKJBuawetMcLOzWBGs8+qDzhZOZTk6Fw==, tarball: https://pkg.pr.new/@modelcontextprotocol/client@f60b40179b0f090f6d64248be1312245a160b5ee}
     version: 2.0.0-beta.4
     engines: {node: '>=20'}
 
@@ -1623,8 +1655,8 @@ packages:
     resolution: {integrity: sha512-nsMXd4wQBKzmph6r+WOhum+mXjDYljTAqwY/XUg3hLtvNOQ8+JVqBSJOVCMJvx9lXhTpTOPrGZ3BuNiaNPjSvg==}
     engines: {node: '>=20'}
 
-  '@modelcontextprotocol/core@https://pkg.pr.new/@modelcontextprotocol/core@2501':
-    resolution: {integrity: sha512-nsMXd4wQBKzmph6r+WOhum+mXjDYljTAqwY/XUg3hLtvNOQ8+JVqBSJOVCMJvx9lXhTpTOPrGZ3BuNiaNPjSvg==, tarball: https://pkg.pr.new/@modelcontextprotocol/core@2501}
+  '@modelcontextprotocol/core@https://pkg.pr.new/@modelcontextprotocol/core@f60b40179b0f090f6d64248be1312245a160b5ee':
+    resolution: {integrity: sha512-nsMXd4wQBKzmph6r+WOhum+mXjDYljTAqwY/XUg3hLtvNOQ8+JVqBSJOVCMJvx9lXhTpTOPrGZ3BuNiaNPjSvg==, tarball: https://pkg.pr.new/@modelcontextprotocol/core@f60b40179b0f090f6d64248be1312245a160b5ee}
     version: 2.0.0-beta.4
     engines: {node: '>=20'}
 
@@ -1633,8 +1665,8 @@ packages:
     version: 2.0.0-beta.4
     engines: {node: '>=20'}
 
-  '@modelcontextprotocol/ext-apps@https://pkg.pr.new/@modelcontextprotocol/ext-apps@712':
-    resolution: {integrity: sha512-ZrbpADXYYPsD21SNE/R5iadnZk6Rn8ZS3yVjSq9cDK++H1awsU93n23czZZ+ruYAFunWtJj9RNkXCVfKw4r2ow==, tarball: https://pkg.pr.new/@modelcontextprotocol/ext-apps@712}
+  '@modelcontextprotocol/ext-apps@https://pkg.pr.new/@modelcontextprotocol/ext-apps@432d42bb02a569078ab31ab6458428df6027809d':
+    resolution: {integrity: sha512-ZrbpADXYYPsD21SNE/R5iadnZk6Rn8ZS3yVjSq9cDK++H1awsU93n23czZZ+ruYAFunWtJj9RNkXCVfKw4r2ow==, tarball: https://pkg.pr.new/@modelcontextprotocol/ext-apps@432d42bb02a569078ab31ab6458428df6027809d}
     version: 1.7.4
     engines: {node: '>=20'}
     peerDependencies:
@@ -1654,8 +1686,8 @@ packages:
     resolution: {integrity: sha512-pjMZcNEt1dOq0aJCcY3b7w1Ayh+qmQN2xlfTELcGV9yiAjEGIczBPBLWWW0k0zzo5T8kiv15jtKPsWeHGxLvLg==}
     engines: {node: '>=20'}
 
-  '@modelcontextprotocol/server@https://pkg.pr.new/@modelcontextprotocol/server@2501':
-    resolution: {integrity: sha512-mI+V52bTdSCHDrsrVG3TeOzgy+apDQXz6l1B4KuwKV/8xbRAsV9LZ2Nf67SEoLszuYYH0as4pZQUG4cCMYP5/g==, tarball: https://pkg.pr.new/@modelcontextprotocol/server@2501}
+  '@modelcontextprotocol/server@https://pkg.pr.new/@modelcontextprotocol/server@f60b40179b0f090f6d64248be1312245a160b5ee':
+    resolution: {integrity: sha512-mI+V52bTdSCHDrsrVG3TeOzgy+apDQXz6l1B4KuwKV/8xbRAsV9LZ2Nf67SEoLszuYYH0as4pZQUG4cCMYP5/g==, tarball: https://pkg.pr.new/@modelcontextprotocol/server@f60b40179b0f090f6d64248be1312245a160b5ee}
     version: 2.0.0-beta.4
     engines: {node: '>=20'}
 
@@ -6611,16 +6643,6 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
-  semver@7.7.4:
-    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
-  semver@7.8.1:
-    resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
@@ -7625,7 +7647,7 @@ snapshots:
       outdent: 0.5.0
       prettier: 2.8.8
       resolve-from: 5.0.0
-      semver: 7.7.4
+      semver: 7.8.5
 
   '@changesets/assemble-release-plan@6.0.9':
     dependencies:
@@ -7634,7 +7656,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
-      semver: 7.7.4
+      semver: 7.8.5
 
   '@changesets/changelog-git@0.2.1':
     dependencies:
@@ -7665,7 +7687,7 @@ snapshots:
       package-manager-detector: 0.2.11
       picocolors: 1.1.1
       resolve-from: 5.0.0
-      semver: 7.7.4
+      semver: 7.8.5
       spawndamnit: 3.0.1
       term-size: 2.2.1
     transitivePeerDependencies:
@@ -7691,7 +7713,7 @@ snapshots:
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.1
-      semver: 7.7.4
+      semver: 7.8.5
 
   '@changesets/get-release-plan@4.0.15':
     dependencies:
@@ -8275,7 +8297,7 @@ snapshots:
       pkce-challenge: 5.0.1
       zod: 4.4.3
 
-  '@modelcontextprotocol/client@https://pkg.pr.new/@modelcontextprotocol/client@2501':
+  '@modelcontextprotocol/client@https://pkg.pr.new/@modelcontextprotocol/client@f60b40179b0f090f6d64248be1312245a160b5ee':
     dependencies:
       '@modelcontextprotocol/core': https://pkg.pr.new/modelcontextprotocol/typescript-sdk/@modelcontextprotocol/core@f60b401
       cross-spawn: 7.0.6
@@ -8289,7 +8311,7 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
-  '@modelcontextprotocol/core@https://pkg.pr.new/@modelcontextprotocol/core@2501':
+  '@modelcontextprotocol/core@https://pkg.pr.new/@modelcontextprotocol/core@f60b40179b0f090f6d64248be1312245a160b5ee':
     dependencies:
       zod: 4.4.3
 
@@ -8297,9 +8319,9 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
-  '@modelcontextprotocol/ext-apps@https://pkg.pr.new/@modelcontextprotocol/ext-apps@712(@modelcontextprotocol/client@https://pkg.pr.new/@modelcontextprotocol/client@2501)(@modelcontextprotocol/core@2.0.0-beta.4)(@modelcontextprotocol/server@2.0.0-beta.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)':
+  '@modelcontextprotocol/ext-apps@https://pkg.pr.new/@modelcontextprotocol/ext-apps@432d42bb02a569078ab31ab6458428df6027809d(@modelcontextprotocol/client@https://pkg.pr.new/@modelcontextprotocol/client@f60b40179b0f090f6d64248be1312245a160b5ee)(@modelcontextprotocol/core@2.0.0-beta.4)(@modelcontextprotocol/server@2.0.0-beta.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)':
     dependencies:
-      '@modelcontextprotocol/client': https://pkg.pr.new/@modelcontextprotocol/client@2501
+      '@modelcontextprotocol/client': https://pkg.pr.new/@modelcontextprotocol/client@f60b40179b0f090f6d64248be1312245a160b5ee
       '@modelcontextprotocol/core': 2.0.0-beta.4
       '@modelcontextprotocol/server': 2.0.0-beta.4
       '@standard-schema/spec': 1.1.0
@@ -8308,11 +8330,11 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@modelcontextprotocol/ext-apps@https://pkg.pr.new/@modelcontextprotocol/ext-apps@712(@modelcontextprotocol/client@https://pkg.pr.new/@modelcontextprotocol/client@2501)(@modelcontextprotocol/core@https://pkg.pr.new/@modelcontextprotocol/core@2501)(@modelcontextprotocol/server@https://pkg.pr.new/@modelcontextprotocol/server@2501)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)':
+  '@modelcontextprotocol/ext-apps@https://pkg.pr.new/@modelcontextprotocol/ext-apps@432d42bb02a569078ab31ab6458428df6027809d(@modelcontextprotocol/client@https://pkg.pr.new/@modelcontextprotocol/client@f60b40179b0f090f6d64248be1312245a160b5ee)(@modelcontextprotocol/core@https://pkg.pr.new/@modelcontextprotocol/core@f60b40179b0f090f6d64248be1312245a160b5ee)(@modelcontextprotocol/server@https://pkg.pr.new/@modelcontextprotocol/server@f60b40179b0f090f6d64248be1312245a160b5ee)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)':
     dependencies:
-      '@modelcontextprotocol/client': https://pkg.pr.new/@modelcontextprotocol/client@2501
-      '@modelcontextprotocol/core': https://pkg.pr.new/@modelcontextprotocol/core@2501
-      '@modelcontextprotocol/server': https://pkg.pr.new/@modelcontextprotocol/server@2501
+      '@modelcontextprotocol/client': https://pkg.pr.new/@modelcontextprotocol/client@f60b40179b0f090f6d64248be1312245a160b5ee
+      '@modelcontextprotocol/core': https://pkg.pr.new/@modelcontextprotocol/core@f60b40179b0f090f6d64248be1312245a160b5ee
+      '@modelcontextprotocol/server': https://pkg.pr.new/@modelcontextprotocol/server@f60b40179b0f090f6d64248be1312245a160b5ee
       '@standard-schema/spec': 1.1.0
       zod: 4.4.3
     optionalDependencies:
@@ -8324,7 +8346,7 @@ snapshots:
       '@modelcontextprotocol/core': 2.0.0-beta.4
       zod: 4.4.3
 
-  '@modelcontextprotocol/server@https://pkg.pr.new/@modelcontextprotocol/server@2501':
+  '@modelcontextprotocol/server@https://pkg.pr.new/@modelcontextprotocol/server@f60b40179b0f090f6d64248be1312245a160b5ee':
     dependencies:
       '@modelcontextprotocol/core': https://pkg.pr.new/modelcontextprotocol/typescript-sdk/@modelcontextprotocol/core@f60b401
       zod: 4.4.3
@@ -9714,7 +9736,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.58.2
       debug: 4.4.3
       minimatch: 10.2.5
-      semver: 7.7.4
+      semver: 7.8.5
       tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -11689,7 +11711,7 @@ snapshots:
 
   is-bun-module@2.0.0:
     dependencies:
-      semver: 7.8.1
+      semver: 7.8.5
 
   is-callable@1.2.7: {}
 
@@ -13476,10 +13498,6 @@ snapshots:
   semifies@1.0.0: {}
 
   semver@6.3.1: {}
-
-  semver@7.7.4: {}
-
-  semver@7.8.1: {}
 
   semver@7.8.5: {}
 

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -124,9 +124,6 @@ importers:
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
-      semver:
-        specifier: ^7.7.3
-        version: 7.8.5
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
@@ -187,30 +184,14 @@ importers:
         specifier: 2.1.11
         version: 2.1.11
 
-  packages/cli:
-    dependencies:
-      mcp-use:
-        specifier: workspace:*
-        version: link:../server
-    devDependencies:
-      rimraf:
-        specifier: ^6.1.3
-        version: 6.1.3
-      tsup:
-        specifier: ^8.5.1
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
-      typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
-
   packages/client:
     dependencies:
       '@modelcontextprotocol/client':
-        specifier: https://pkg.pr.new/@modelcontextprotocol/client@f60b40179b0f090f6d64248be1312245a160b5ee
-        version: https://pkg.pr.new/@modelcontextprotocol/client@f60b40179b0f090f6d64248be1312245a160b5ee
+        specifier: https://pkg.pr.new/@modelcontextprotocol/client@2501
+        version: https://pkg.pr.new/@modelcontextprotocol/client@2501
       '@modelcontextprotocol/ext-apps':
-        specifier: https://pkg.pr.new/@modelcontextprotocol/ext-apps@432d42bb02a569078ab31ab6458428df6027809d
-        version: https://pkg.pr.new/@modelcontextprotocol/ext-apps@432d42bb02a569078ab31ab6458428df6027809d(@modelcontextprotocol/client@https://pkg.pr.new/@modelcontextprotocol/client@f60b40179b0f090f6d64248be1312245a160b5ee)(@modelcontextprotocol/core@2.0.0-beta.4)(@modelcontextprotocol/server@2.0.0-beta.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
+        specifier: https://pkg.pr.new/@modelcontextprotocol/ext-apps@712
+        version: https://pkg.pr.new/@modelcontextprotocol/ext-apps@712(@modelcontextprotocol/client@https://pkg.pr.new/@modelcontextprotocol/client@2501)(@modelcontextprotocol/core@2.0.0-beta.4)(@modelcontextprotocol/server@2.0.0-beta.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
     devDependencies:
       '@e2b/code-interpreter':
         specifier: ^2.6.1
@@ -498,11 +479,11 @@ importers:
   packages/server:
     dependencies:
       '@modelcontextprotocol/ext-apps':
-        specifier: https://pkg.pr.new/@modelcontextprotocol/ext-apps@432d42bb02a569078ab31ab6458428df6027809d
-        version: https://pkg.pr.new/@modelcontextprotocol/ext-apps@432d42bb02a569078ab31ab6458428df6027809d(@modelcontextprotocol/client@https://pkg.pr.new/@modelcontextprotocol/client@f60b40179b0f090f6d64248be1312245a160b5ee)(@modelcontextprotocol/core@https://pkg.pr.new/@modelcontextprotocol/core@f60b40179b0f090f6d64248be1312245a160b5ee)(@modelcontextprotocol/server@https://pkg.pr.new/@modelcontextprotocol/server@f60b40179b0f090f6d64248be1312245a160b5ee)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
+        specifier: https://pkg.pr.new/@modelcontextprotocol/ext-apps@712
+        version: https://pkg.pr.new/@modelcontextprotocol/ext-apps@712(@modelcontextprotocol/client@https://pkg.pr.new/@modelcontextprotocol/client@2501)(@modelcontextprotocol/core@https://pkg.pr.new/@modelcontextprotocol/core@2501)(@modelcontextprotocol/server@https://pkg.pr.new/@modelcontextprotocol/server@2501)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
       '@modelcontextprotocol/server':
-        specifier: https://pkg.pr.new/@modelcontextprotocol/server@f60b40179b0f090f6d64248be1312245a160b5ee
-        version: https://pkg.pr.new/@modelcontextprotocol/server@f60b40179b0f090f6d64248be1312245a160b5ee
+        specifier: https://pkg.pr.new/@modelcontextprotocol/server@2501
+        version: https://pkg.pr.new/@modelcontextprotocol/server@2501
       '@tailwindcss/vite':
         specifier: ^4.2.0
         version: 4.2.0(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
@@ -523,11 +504,11 @@ importers:
         specifier: workspace:*
         version: link:../client
       '@modelcontextprotocol/client':
-        specifier: https://pkg.pr.new/@modelcontextprotocol/client@f60b40179b0f090f6d64248be1312245a160b5ee
-        version: https://pkg.pr.new/@modelcontextprotocol/client@f60b40179b0f090f6d64248be1312245a160b5ee
+        specifier: https://pkg.pr.new/@modelcontextprotocol/client@2501
+        version: https://pkg.pr.new/@modelcontextprotocol/client@2501
       '@modelcontextprotocol/core':
-        specifier: https://pkg.pr.new/@modelcontextprotocol/core@f60b40179b0f090f6d64248be1312245a160b5ee
-        version: https://pkg.pr.new/@modelcontextprotocol/core@f60b40179b0f090f6d64248be1312245a160b5ee
+        specifier: https://pkg.pr.new/@modelcontextprotocol/core@2501
+        version: https://pkg.pr.new/@modelcontextprotocol/core@2501
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -695,19 +676,6 @@ importers:
         specifier: '>=8.0.5'
         version: 8.0.16(@types/node@24.13.2)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
 
-  packages/server/examples/openapi:
-    dependencies:
-      mcp-use:
-        specifier: workspace:*
-        version: link:../..
-    devDependencies:
-      '@types/node':
-        specifier: ^24.13.2
-        version: 24.13.2
-      typescript:
-        specifier: 7.0.1-rc
-        version: 7.0.1-rc
-
   packages/server/examples/railway:
     dependencies:
       mcp-use:
@@ -779,6 +747,34 @@ importers:
       morphdom:
         specifier: ^2.7.8
         version: 2.7.8
+      react:
+        specifier: ^19.2.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.0
+        version: 19.2.4(react@19.2.4)
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@types/node':
+        specifier: ^24.13.2
+        version: 24.13.2
+      '@types/react':
+        specifier: ^19.2.7
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      typescript:
+        specifier: 7.0.1-rc
+        version: 7.0.1-rc
+
+  packages/server/examples/views/generated-world:
+    dependencies:
+      mcp-use:
+        specifier: workspace:*
+        version: link:../../..
       react:
         specifier: ^19.2.0
         version: 19.2.4
@@ -1618,8 +1614,8 @@ packages:
     resolution: {integrity: sha512-o9z9YCGNxWNdklPdjcD0tr8pocC9OgjdArqgx3OjPMlTe0M/SSPC2olOJs5ueq77HSpz36mND0f0KteqEhKF3A==}
     engines: {node: '>=20'}
 
-  '@modelcontextprotocol/client@https://pkg.pr.new/@modelcontextprotocol/client@f60b40179b0f090f6d64248be1312245a160b5ee':
-    resolution: {integrity: sha512-5FvmSf2qWlJXlI9ydf8230f1rsDHMEw9Jgcq2ZUGmA3DJShaYV6t49zKJBuawetMcLOzWBGs8+qDzhZOZTk6Fw==, tarball: https://pkg.pr.new/@modelcontextprotocol/client@f60b40179b0f090f6d64248be1312245a160b5ee}
+  '@modelcontextprotocol/client@https://pkg.pr.new/@modelcontextprotocol/client@2501':
+    resolution: {integrity: sha512-5FvmSf2qWlJXlI9ydf8230f1rsDHMEw9Jgcq2ZUGmA3DJShaYV6t49zKJBuawetMcLOzWBGs8+qDzhZOZTk6Fw==, tarball: https://pkg.pr.new/@modelcontextprotocol/client@2501}
     version: 2.0.0-beta.4
     engines: {node: '>=20'}
 
@@ -1627,8 +1623,8 @@ packages:
     resolution: {integrity: sha512-nsMXd4wQBKzmph6r+WOhum+mXjDYljTAqwY/XUg3hLtvNOQ8+JVqBSJOVCMJvx9lXhTpTOPrGZ3BuNiaNPjSvg==}
     engines: {node: '>=20'}
 
-  '@modelcontextprotocol/core@https://pkg.pr.new/@modelcontextprotocol/core@f60b40179b0f090f6d64248be1312245a160b5ee':
-    resolution: {integrity: sha512-nsMXd4wQBKzmph6r+WOhum+mXjDYljTAqwY/XUg3hLtvNOQ8+JVqBSJOVCMJvx9lXhTpTOPrGZ3BuNiaNPjSvg==, tarball: https://pkg.pr.new/@modelcontextprotocol/core@f60b40179b0f090f6d64248be1312245a160b5ee}
+  '@modelcontextprotocol/core@https://pkg.pr.new/@modelcontextprotocol/core@2501':
+    resolution: {integrity: sha512-nsMXd4wQBKzmph6r+WOhum+mXjDYljTAqwY/XUg3hLtvNOQ8+JVqBSJOVCMJvx9lXhTpTOPrGZ3BuNiaNPjSvg==, tarball: https://pkg.pr.new/@modelcontextprotocol/core@2501}
     version: 2.0.0-beta.4
     engines: {node: '>=20'}
 
@@ -1637,8 +1633,8 @@ packages:
     version: 2.0.0-beta.4
     engines: {node: '>=20'}
 
-  '@modelcontextprotocol/ext-apps@https://pkg.pr.new/@modelcontextprotocol/ext-apps@432d42bb02a569078ab31ab6458428df6027809d':
-    resolution: {integrity: sha512-ZrbpADXYYPsD21SNE/R5iadnZk6Rn8ZS3yVjSq9cDK++H1awsU93n23czZZ+ruYAFunWtJj9RNkXCVfKw4r2ow==, tarball: https://pkg.pr.new/@modelcontextprotocol/ext-apps@432d42bb02a569078ab31ab6458428df6027809d}
+  '@modelcontextprotocol/ext-apps@https://pkg.pr.new/@modelcontextprotocol/ext-apps@712':
+    resolution: {integrity: sha512-ZrbpADXYYPsD21SNE/R5iadnZk6Rn8ZS3yVjSq9cDK++H1awsU93n23czZZ+ruYAFunWtJj9RNkXCVfKw4r2ow==, tarball: https://pkg.pr.new/@modelcontextprotocol/ext-apps@712}
     version: 1.7.4
     engines: {node: '>=20'}
     peerDependencies:
@@ -1658,8 +1654,8 @@ packages:
     resolution: {integrity: sha512-pjMZcNEt1dOq0aJCcY3b7w1Ayh+qmQN2xlfTELcGV9yiAjEGIczBPBLWWW0k0zzo5T8kiv15jtKPsWeHGxLvLg==}
     engines: {node: '>=20'}
 
-  '@modelcontextprotocol/server@https://pkg.pr.new/@modelcontextprotocol/server@f60b40179b0f090f6d64248be1312245a160b5ee':
-    resolution: {integrity: sha512-mI+V52bTdSCHDrsrVG3TeOzgy+apDQXz6l1B4KuwKV/8xbRAsV9LZ2Nf67SEoLszuYYH0as4pZQUG4cCMYP5/g==, tarball: https://pkg.pr.new/@modelcontextprotocol/server@f60b40179b0f090f6d64248be1312245a160b5ee}
+  '@modelcontextprotocol/server@https://pkg.pr.new/@modelcontextprotocol/server@2501':
+    resolution: {integrity: sha512-mI+V52bTdSCHDrsrVG3TeOzgy+apDQXz6l1B4KuwKV/8xbRAsV9LZ2Nf67SEoLszuYYH0as4pZQUG4cCMYP5/g==, tarball: https://pkg.pr.new/@modelcontextprotocol/server@2501}
     version: 2.0.0-beta.4
     engines: {node: '>=20'}
 
@@ -6615,6 +6611,16 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.8.1:
+    resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
@@ -7619,7 +7625,7 @@ snapshots:
       outdent: 0.5.0
       prettier: 2.8.8
       resolve-from: 5.0.0
-      semver: 7.8.5
+      semver: 7.7.4
 
   '@changesets/assemble-release-plan@6.0.9':
     dependencies:
@@ -7628,7 +7634,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
-      semver: 7.8.5
+      semver: 7.7.4
 
   '@changesets/changelog-git@0.2.1':
     dependencies:
@@ -7659,7 +7665,7 @@ snapshots:
       package-manager-detector: 0.2.11
       picocolors: 1.1.1
       resolve-from: 5.0.0
-      semver: 7.8.5
+      semver: 7.7.4
       spawndamnit: 3.0.1
       term-size: 2.2.1
     transitivePeerDependencies:
@@ -7685,7 +7691,7 @@ snapshots:
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.1
-      semver: 7.8.5
+      semver: 7.7.4
 
   '@changesets/get-release-plan@4.0.15':
     dependencies:
@@ -8269,7 +8275,7 @@ snapshots:
       pkce-challenge: 5.0.1
       zod: 4.4.3
 
-  '@modelcontextprotocol/client@https://pkg.pr.new/@modelcontextprotocol/client@f60b40179b0f090f6d64248be1312245a160b5ee':
+  '@modelcontextprotocol/client@https://pkg.pr.new/@modelcontextprotocol/client@2501':
     dependencies:
       '@modelcontextprotocol/core': https://pkg.pr.new/modelcontextprotocol/typescript-sdk/@modelcontextprotocol/core@f60b401
       cross-spawn: 7.0.6
@@ -8283,7 +8289,7 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
-  '@modelcontextprotocol/core@https://pkg.pr.new/@modelcontextprotocol/core@f60b40179b0f090f6d64248be1312245a160b5ee':
+  '@modelcontextprotocol/core@https://pkg.pr.new/@modelcontextprotocol/core@2501':
     dependencies:
       zod: 4.4.3
 
@@ -8291,9 +8297,9 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
-  '@modelcontextprotocol/ext-apps@https://pkg.pr.new/@modelcontextprotocol/ext-apps@432d42bb02a569078ab31ab6458428df6027809d(@modelcontextprotocol/client@https://pkg.pr.new/@modelcontextprotocol/client@f60b40179b0f090f6d64248be1312245a160b5ee)(@modelcontextprotocol/core@2.0.0-beta.4)(@modelcontextprotocol/server@2.0.0-beta.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)':
+  '@modelcontextprotocol/ext-apps@https://pkg.pr.new/@modelcontextprotocol/ext-apps@712(@modelcontextprotocol/client@https://pkg.pr.new/@modelcontextprotocol/client@2501)(@modelcontextprotocol/core@2.0.0-beta.4)(@modelcontextprotocol/server@2.0.0-beta.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)':
     dependencies:
-      '@modelcontextprotocol/client': https://pkg.pr.new/@modelcontextprotocol/client@f60b40179b0f090f6d64248be1312245a160b5ee
+      '@modelcontextprotocol/client': https://pkg.pr.new/@modelcontextprotocol/client@2501
       '@modelcontextprotocol/core': 2.0.0-beta.4
       '@modelcontextprotocol/server': 2.0.0-beta.4
       '@standard-schema/spec': 1.1.0
@@ -8302,11 +8308,11 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@modelcontextprotocol/ext-apps@https://pkg.pr.new/@modelcontextprotocol/ext-apps@432d42bb02a569078ab31ab6458428df6027809d(@modelcontextprotocol/client@https://pkg.pr.new/@modelcontextprotocol/client@f60b40179b0f090f6d64248be1312245a160b5ee)(@modelcontextprotocol/core@https://pkg.pr.new/@modelcontextprotocol/core@f60b40179b0f090f6d64248be1312245a160b5ee)(@modelcontextprotocol/server@https://pkg.pr.new/@modelcontextprotocol/server@f60b40179b0f090f6d64248be1312245a160b5ee)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)':
+  '@modelcontextprotocol/ext-apps@https://pkg.pr.new/@modelcontextprotocol/ext-apps@712(@modelcontextprotocol/client@https://pkg.pr.new/@modelcontextprotocol/client@2501)(@modelcontextprotocol/core@https://pkg.pr.new/@modelcontextprotocol/core@2501)(@modelcontextprotocol/server@https://pkg.pr.new/@modelcontextprotocol/server@2501)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)':
     dependencies:
-      '@modelcontextprotocol/client': https://pkg.pr.new/@modelcontextprotocol/client@f60b40179b0f090f6d64248be1312245a160b5ee
-      '@modelcontextprotocol/core': https://pkg.pr.new/@modelcontextprotocol/core@f60b40179b0f090f6d64248be1312245a160b5ee
-      '@modelcontextprotocol/server': https://pkg.pr.new/@modelcontextprotocol/server@f60b40179b0f090f6d64248be1312245a160b5ee
+      '@modelcontextprotocol/client': https://pkg.pr.new/@modelcontextprotocol/client@2501
+      '@modelcontextprotocol/core': https://pkg.pr.new/@modelcontextprotocol/core@2501
+      '@modelcontextprotocol/server': https://pkg.pr.new/@modelcontextprotocol/server@2501
       '@standard-schema/spec': 1.1.0
       zod: 4.4.3
     optionalDependencies:
@@ -8318,7 +8324,7 @@ snapshots:
       '@modelcontextprotocol/core': 2.0.0-beta.4
       zod: 4.4.3
 
-  '@modelcontextprotocol/server@https://pkg.pr.new/@modelcontextprotocol/server@f60b40179b0f090f6d64248be1312245a160b5ee':
+  '@modelcontextprotocol/server@https://pkg.pr.new/@modelcontextprotocol/server@2501':
     dependencies:
       '@modelcontextprotocol/core': https://pkg.pr.new/modelcontextprotocol/typescript-sdk/@modelcontextprotocol/core@f60b401
       zod: 4.4.3
@@ -9708,7 +9714,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.58.2
       debug: 4.4.3
       minimatch: 10.2.5
-      semver: 7.8.5
+      semver: 7.7.4
       tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -11683,7 +11689,7 @@ snapshots:
 
   is-bun-module@2.0.0:
     dependencies:
-      semver: 7.8.5
+      semver: 7.8.1
 
   is-callable@1.2.7: {}
 
@@ -13470,6 +13476,10 @@ snapshots:
   semifies@1.0.0: {}
 
   semver@6.3.1: {}
+
+  semver@7.7.4: {}
+
+  semver@7.8.1: {}
 
   semver@7.8.5: {}
 


### PR DESCRIPTION
## Summary

- add a model-authored Three.js world generation MCP Apps example
- stream viable source prefixes into an ephemeral sandboxed runtime
- document runtime budgets, controls, and local usage

## Validation

- `pnpm typecheck` in the generated-world example
- direct v2 `mcp-use build` production build
- ESLint and Prettier checks
- React Doctor changed-scope scan: 100/100
- server Vitest suite: 323 tests passed; the existing Deno test is incorrectly collected by the Node runner and remains the sole failed suite

## Scope

The diff is limited to the generated-world example, its views README entry, and its 28-line pnpm lockfile importer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new MCP Apps view that lets the model generate a small Three.js world, progressively compile it while streaming, and explore it with a flying camera. Improves server examples with a sandboxed runtime, strict limits, and a documented tool contract.

- **New Features**
  - New `generated-world` view compiles streamed `render_world` source into a nested `blob:` iframe with deterministic randomness, scene budgets, progressive swaps, and an `onFrame` animation hook.
  - Adds `read_world_guide` and `render_world` tools; returns `structuredContent` only (no persistence) with a 180 KiB source cap.
  - Viewer owns camera, render loop, and baseline lighting; shows build status, surfaces runtime errors via `ModelContext`, and enables WASD/QE + drag (Shift to boost) after a successful final build.
  - Enforces runtime limits (objects, triangle/vertex counts, lights, frame callbacks, 8s build deadline), removes fog, and pins Three.js from `https://esm.sh` under a strict CSP.

- **Dependencies**
  - Adds example `package.json` using `mcp-use`, `react`, `react-dom`, and `zod`; updates the workspace lockfile importer.

<sup>Written for commit e6a3f13175605ede91047cc39dc3a049d2afb0b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

