### PR TITLE
fix(inspector): standalone CDN serving and OAuth callback PKCE

### DIFF
--- a/docs/inspector/integration.mdx
+++ b/docs/inspector/integration.mdx
@@ -6,11 +6,11 @@ icon: "plug-2"
 
 {/* TODO: Add Inspector media when a screenshot or short clip would clarify the workflow. */}
 
-Mount the Inspector when you want it served from the same app as your MCP server. Servers built with `mcp-use/server` mount it automatically at `/inspector`.
+Mount the Inspector when you want it served from the same app as your MCP server. **Prefer `mcp-use/server`** — it mounts a thin HTML shell at `/inspector` and loads the UI bundle from jsDelivr by default (no npm dependency on `@mcp-use/inspector`).
 
 ## Auto-Mounting with mcp-use
 
-When using `mcp-use` to create your MCP server, the Inspector is automatically available at `/inspector`.
+When using `mcp-use` to create your MCP server, the Inspector is automatically available at `/inspector`. The shell loads `dist/cdn/inspector.js` from jsDelivr (`@mcp-use/inspector@beta` by default). Override with `inspector.assetsUrl` or `MCP_USE_INSPECTOR_ASSETS_URL`.
 
 ### Example
 
@@ -34,6 +34,8 @@ server.listen(3000)
 ```
 
 ## Manual Integration
+
+For non-`mcp-use` Hono/Express apps, `mountInspector()` from `@mcp-use/inspector` provides the full inspector server (proxy, OAuth BFF, and UI shell). By default the UI bundle loads from jsDelivr; standalone `npx @mcp-use/inspector` serves `dist/cdn/` locally instead.
 
 ### Hono Integration
 

--- a/libraries/typescript/.changeset/inspector-standalone-oauth.md
+++ b/libraries/typescript/.changeset/inspector-standalone-oauth.md
@@ -1,0 +1,17 @@
+---
+"@mcp-use/inspector": patch
+"@mcp-use/client": patch
+---
+
+Fix standalone Inspector OAuth and CDN delivery.
+
+**@mcp-use/inspector**
+- Serve the built UI from `dist/cdn/` locally in standalone mode (`pnpm start` / `npx`); embedded mounts still default to jsDelivr `@beta`.
+- Point `pnpm start` at `dist/cli.js` so standalone runs the full proxy + OAuth BFF shell.
+- Skip `dev/info` tunnel probes in standalone mode (route exists only under `mcp-use dev`).
+- Simplify e2e matrix: builtin/prod modes rely on in-process static assets instead of a separate CDN fixture server.
+- Document jsDelivr-first embedding vs local standalone in `docs/inspector/integration.mdx`.
+
+**@mcp-use/client**
+- Fix Linear (and other OAuth) redirect flows: do not auto-connect saved MCP servers on `/oauth/callback`, which overwrote the PKCE verifier before token exchange.
+- Stop HEAD health-check polling after a 405/404 from servers that only accept POST (reduces console noise for providers like Linear).

--- a/libraries/typescript/packages/client/src/react/McpClientProvider.tsx
+++ b/libraries/typescript/packages/client/src/react/McpClientProvider.tsx
@@ -1159,31 +1159,38 @@ export function McpClientProvider({
     [serverConfigs, defaultCapabilities, defaultServerConfig]
   );
 
+  // ponytail: OAuth callback must not auto-connect saved servers — a 401 on that
+  // page runs SDK auth() and overwrites the in-flight PKCE verifier before finishAuth.
+  const skipServerConnections =
+    typeof window !== "undefined" &&
+    /\/oauth\/callback\/?$/.test(window.location.pathname);
+
   return (
     <McpClientContext.Provider value={contextValue}>
       {children}
-      {mergedServerConfigs.map((config) => (
-        <McpServerWrapper
-          key={`${config.id}-v${serverRevisions[config.id] ?? 0}`}
-          id={config.id}
-          options={config.options}
-          defaultCallbackUrl={defaultCallbackUrl}
-          defaultOAuthProxyUrl={defaultOAuthProxyUrl}
-          defaultProxyConfig={defaultProxyConfig}
-          defaultAutoProxyFallback={defaultAutoProxyFallback}
-          clientInfo={clientInfoForWrapper}
-          cachedMetadata={cachedMetadataRef.current[config.id]}
-          onUpdate={handleServerUpdate}
-          onUpdateConfig={updateServer}
-          onUpdateDisplayName={(id, displayName) =>
-            updateServerMetadata(id, { name: displayName })
-          }
-          onReconnect={reconnectServer}
-          rpcWrapTransport={rpcWrapTransport}
-          onGlobalSamplingRequest={onSamplingRequest}
-          onGlobalElicitationRequest={onElicitationRequest}
-        />
-      ))}
+      {!skipServerConnections &&
+        mergedServerConfigs.map((config) => (
+          <McpServerWrapper
+            key={`${config.id}-v${serverRevisions[config.id] ?? 0}`}
+            id={config.id}
+            options={config.options}
+            defaultCallbackUrl={defaultCallbackUrl}
+            defaultOAuthProxyUrl={defaultOAuthProxyUrl}
+            defaultProxyConfig={defaultProxyConfig}
+            defaultAutoProxyFallback={defaultAutoProxyFallback}
+            clientInfo={clientInfoForWrapper}
+            cachedMetadata={cachedMetadataRef.current[config.id]}
+            onUpdate={handleServerUpdate}
+            onUpdateConfig={updateServer}
+            onUpdateDisplayName={(id, displayName) =>
+              updateServerMetadata(id, { name: displayName })
+            }
+            onReconnect={reconnectServer}
+            rpcWrapTransport={rpcWrapTransport}
+            onGlobalSamplingRequest={onSamplingRequest}
+            onGlobalElicitationRequest={onElicitationRequest}
+          />
+        ))}
     </McpClientContext.Provider>
   );
 }

--- a/libraries/typescript/packages/client/src/react/useMcp-helpers.ts
+++ b/libraries/typescript/packages/client/src/react/useMcp-helpers.ts
@@ -227,10 +227,15 @@ export function startConnectionHealthMonitoring(params: {
 }): () => void {
   let healthCheckInterval: ReturnType<typeof setInterval> | null = null;
   let lastSuccessfulCheck = Date.now();
+  // ponytail: many MCP servers only accept POST; one 405/404 disables HEAD polling.
+  let headProbeUnsupported = false;
   const healthCheckIntervalMs = params.healthCheckIntervalMs ?? 10000;
   const healthCheckTimeoutMs = params.healthCheckTimeoutMs ?? 30000;
 
   const checkConnectionHealth = async () => {
+    if (headProbeUnsupported) {
+      return;
+    }
     if (!params.isMountedRef.current || params.stateRef.current !== "ready") {
       if (healthCheckInterval) {
         clearInterval(healthCheckInterval);
@@ -253,6 +258,16 @@ export function startConnectionHealthMonitoring(params: {
         headers: { ...params.allHeaders, ...authHeaders },
         signal: AbortSignal.timeout(5000),
       });
+
+      if (response.status === 405 || response.status === 404) {
+        headProbeUnsupported = true;
+        lastSuccessfulCheck = Date.now();
+        if (healthCheckInterval) {
+          clearInterval(healthCheckInterval);
+          healthCheckInterval = null;
+        }
+        return;
+      }
 
       if (response.ok || response.status < 500) {
         lastSuccessfulCheck = Date.now();

--- a/libraries/typescript/packages/inspector/package.json
+++ b/libraries/typescript/packages/inspector/package.json
@@ -58,7 +58,7 @@
     "build:server": "tsup 'src/server/**/*.ts' --format esm --out-dir dist/server && tsc -p tsconfig.server.json --emitDeclarationOnly --declaration",
     "build:cli": "tsup src/server/cli.ts --format esm --out-dir dist/",
     "prepublishOnly": "pnpm --filter @mcp-use/client build && pnpm build",
-    "start": "node dist/server/server.js",
+    "start": "node dist/cli.js --port 3000",
     "preview": "vite preview",
     "type-check": "tsc --noEmit",
     "lint": "eslint .",

--- a/libraries/typescript/packages/inspector/src/client/components/layout/useTunnelControls.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/layout/useTunnelControls.ts
@@ -24,6 +24,15 @@ async function fetchDevInfo(): Promise<DevInfo | null> {
   }
 }
 
+/** `dev/info` exists only under `mcp-use dev`; standalone `pnpm start` has no route. */
+function hasDevCliApi(): boolean {
+  if (typeof window === "undefined") return false;
+  return (
+    (window as { __MCP_INSPECTOR_MODE__?: string }).__MCP_INSPECTOR_MODE__ !==
+    "standalone"
+  );
+}
+
 export function useTunnelControls({
   tunnelUrl,
   setTunnelUrl,
@@ -78,6 +87,10 @@ export function useTunnelControls({
 
   useEffect(() => {
     let cancelled = false;
+    if (!hasDevCliApi()) {
+      setDevFromCli(false);
+      return;
+    }
     (async () => {
       const info = await fetchDevInfo();
       if (cancelled) return;

--- a/libraries/typescript/packages/inspector/src/server/asset-urls.ts
+++ b/libraries/typescript/packages/inspector/src/server/asset-urls.ts
@@ -1,0 +1,68 @@
+/** How the inspector is being served (telemetry + hosted UI behavior). */
+export type InspectorMode = "standalone" | "embedded" | "cloud";
+
+/** npm dist-tag for remote inspector bundles (matches mcp-use server). */
+export const JSDELIVR_INSPECTOR_TAG = "beta";
+
+export const DEFAULT_REMOTE_ASSETS_URL = `https://cdn.jsdelivr.net/npm/@mcp-use/inspector@${JSDELIVR_INSPECTOR_TAG}/dist/cdn/inspector.js`;
+
+/** Derive the stylesheet URL from a bundle script URL. */
+export function inspectorStylesUrl(assetsUrl: string): string {
+  return assetsUrl.replace(/\.js(?=$|[?#])/, ".css");
+}
+
+export type InspectorAssetUrls = {
+  jsUrl: string;
+  cssUrl: string;
+  useLocal: boolean;
+};
+
+export function resolveInspectorAssetUrls(
+  inspectorMode: InspectorMode | undefined,
+  basePath: string
+): InspectorAssetUrls {
+  const envUrl =
+    process.env.INSPECTOR_ASSETS_URL ??
+    process.env.MCP_USE_INSPECTOR_ASSETS_URL;
+  if (envUrl) {
+    return {
+      jsUrl: envUrl,
+      cssUrl: inspectorStylesUrl(envUrl),
+      useLocal: false,
+    };
+  }
+
+  // ponytail: deprecated — INSPECTOR_CDN_BASE was a host base with versioned paths
+  const legacyBase = process.env.INSPECTOR_CDN_BASE;
+  if (legacyBase) {
+    const base = legacyBase.replace(/\/$/, "");
+    if (/\.js(?:$|[?#])/.test(base)) {
+      return {
+        jsUrl: base,
+        cssUrl: inspectorStylesUrl(base),
+        useLocal: false,
+      };
+    }
+    return {
+      jsUrl: `${base}/inspector.js`,
+      cssUrl: `${base}/inspector.css`,
+      useLocal: false,
+    };
+  }
+
+  if (inspectorMode === "standalone") {
+    const prefix = basePath;
+    return {
+      jsUrl: `${prefix}/dist/cdn/inspector.js`,
+      cssUrl: `${prefix}/dist/cdn/inspector.css`,
+      useLocal: true,
+    };
+  }
+
+  const jsUrl = DEFAULT_REMOTE_ASSETS_URL;
+  return {
+    jsUrl,
+    cssUrl: inspectorStylesUrl(jsUrl),
+    useLocal: false,
+  };
+}

--- a/libraries/typescript/packages/inspector/src/server/cdn-shell.ts
+++ b/libraries/typescript/packages/inspector/src/server/cdn-shell.ts
@@ -1,17 +1,13 @@
 import type { Context, Hono } from "hono";
+import { resolveInspectorAssetUrls, type InspectorMode } from "./asset-urls.js";
 import { renderInspectorFaviconLinks } from "./favicon-links.js";
 import { registerInspectorFaviconStatic } from "./favicon-static.js";
+import { registerInspectorStaticAssets } from "./static-assets.js";
 import { getInspectorVersion } from "./version.js";
 
 const INSPECTOR_VERSION = getInspectorVersion();
 
-const CDN_BASE =
-  process.env.INSPECTOR_CDN_BASE ?? "https://inspector-cdn.mcp-use.com";
-const CDN_JS_URL = `${CDN_BASE}/inspector@${INSPECTOR_VERSION}.js`;
-const CDN_CSS_URL = `${CDN_BASE}/inspector@${INSPECTOR_VERSION}.css`;
-
-/** How the inspector is being served (telemetry + hosted UI behavior). */
-export type InspectorMode = "standalone" | "embedded" | "cloud";
+export type { InspectorMode } from "./asset-urls.js";
 
 export type CdnShellConfig = {
   basePath?: string;
@@ -30,7 +26,11 @@ const OAUTH_POPUP_CLOSED_HTML = `<!doctype html>
 <script>try{if(window.opener&&!window.opener.closed)window.opener.postMessage({type:"manufact:oauth-complete"},"*")}catch(e){}try{window.close()}catch(e){}</script>
 </body></html>`;
 
-function generateCdnShellHtml(config?: CdnShellConfig, basePath = ""): string {
+function generateCdnShellHtml(
+  config: CdnShellConfig | undefined,
+  basePath: string,
+  assets: { jsUrl: string; cssUrl: string }
+): string {
   const scripts: string[] = [];
   if (config?.basePath !== undefined) {
     scripts.push(
@@ -76,7 +76,7 @@ function generateCdnShellHtml(config?: CdnShellConfig, basePath = ""): string {
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@400;500;700&display=swap" rel="stylesheet" />
-    <link rel="stylesheet" href="${CDN_CSS_URL}" />
+    <link rel="stylesheet" href="${assets.cssUrl}" />
     <title>Inspector | mcp-use</title>
     <meta name="description" content="Free, open-source MCP Inspector by mcp-use. Connect to any MCP server, test tools, prompts, and resources, inspect RPC logs, and debug MCP apps — all in your browser." />
     <script>window.__INSPECTOR_VERSION__ = ${JSON.stringify(INSPECTOR_VERSION)};</script>
@@ -97,19 +97,20 @@ function generateCdnShellHtml(config?: CdnShellConfig, basePath = ""): string {
       }
     </script>
     <div id="root"></div>
-    <script type="module" src="${CDN_JS_URL}"></script>
+    <script type="module" src="${assets.jsUrl}"></script>
   </body>
 </html>`;
 }
 
 /**
- * Serve the inspector UI from CDN at `${basePath}/inspector`.
+ * Serve the inspector UI at `${basePath}/inspector`.
  */
 export function registerInspectorCdnShell(
   app: Hono,
   config?: CdnShellConfig,
   basePath: string = ""
 ) {
+  const assets = resolveInspectorAssetUrls(config?.inspectorMode, basePath);
   const p = (suffix: string) => `${basePath}${suffix}`;
   const effectiveConfig: CdnShellConfig = {
     ...config,
@@ -124,7 +125,7 @@ export function registerInspectorCdnShell(
   };
 
   const serveShell = (c: Context) =>
-    c.html(generateCdnShellHtml(effectiveConfig, basePath));
+    c.html(generateCdnShellHtml(effectiveConfig, basePath, assets));
 
   registerInspectorFaviconStatic(app, basePath);
 
@@ -153,5 +154,9 @@ export function registerInspectorCdnShell(
       const url = new URL(c.req.url);
       return c.redirect(`${p("/inspector")}${url.search}`);
     });
+  }
+
+  if (assets.useLocal) {
+    registerInspectorStaticAssets(app, basePath);
   }
 }

--- a/libraries/typescript/packages/inspector/src/server/favicon-static.ts
+++ b/libraries/typescript/packages/inspector/src/server/favicon-static.ts
@@ -14,8 +14,9 @@ const CONTENT_TYPES: Record<string, string> = {
 function resolveFaviconDir(): string {
   const here = path.dirname(fileURLToPath(import.meta.url));
   for (const dir of [
-    path.resolve(here, "../cdn"),
-    path.resolve(here, "../../public"),
+    path.resolve(here, "cdn"), // dist/cli.js (bundled)
+    path.resolve(here, "../cdn"), // dist/server/*.js
+    path.resolve(here, "../../public"), // src/server/*.ts (dev)
   ]) {
     if (existsSync(path.join(dir, "favicon-black.svg"))) {
       return dir;

--- a/libraries/typescript/packages/inspector/src/server/static-assets.ts
+++ b/libraries/typescript/packages/inspector/src/server/static-assets.ts
@@ -1,0 +1,55 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { Hono } from "hono";
+
+const CONTENT_TYPES: Record<string, string> = {
+  ".js": "application/javascript",
+  ".css": "text/css",
+  ".svg": "image/svg+xml",
+  ".png": "image/png",
+  ".ico": "image/x-icon",
+  ".webmanifest": "application/manifest+json",
+};
+
+export function resolveDistCdnDir(): string {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  for (const dir of [
+    path.resolve(here, "cdn"), // dist/cli.js (bundled)
+    path.resolve(here, "../cdn"), // dist/server/*.js
+  ]) {
+    if (existsSync(path.join(dir, "inspector.js"))) {
+      return dir;
+    }
+  }
+  throw new Error(
+    "Inspector bundle not found (expected dist/cdn/inspector.js)"
+  );
+}
+
+/** Serve dist/cdn/ at ${basePath}/dist/cdn/* (standalone / npx). */
+export function registerInspectorStaticAssets(
+  app: Hono,
+  basePath: string = ""
+) {
+  const cdnDir = resolveDistCdnDir();
+  const mountPath = `${basePath}/dist/cdn`;
+
+  app.get(`${mountPath}/*`, (c) => {
+    const subPath = c.req.path.slice(mountPath.length);
+    const relative = subPath.startsWith("/") ? subPath.slice(1) : subPath;
+    if (!relative || relative.includes("..")) {
+      return c.notFound();
+    }
+    const file = path.resolve(cdnDir, relative);
+    const root = cdnDir.endsWith(path.sep) ? cdnDir : `${cdnDir}${path.sep}`;
+    if (!file.startsWith(root) || !existsSync(file)) {
+      return c.notFound();
+    }
+    const ext = path.extname(file);
+    return c.body(readFileSync(file), 200, {
+      "Content-Type": CONTENT_TYPES[ext] ?? "application/octet-stream",
+      "Cache-Control": "public, max-age=3600",
+    });
+  });
+}

--- a/libraries/typescript/packages/inspector/tests/e2e/scripts/run-test-matrix.mjs
+++ b/libraries/typescript/packages/inspector/tests/e2e/scripts/run-test-matrix.mjs
@@ -10,10 +10,8 @@
  * - mix: Built server on port 3002, dev inspector on port 3000
  */
 
-import { createServer } from "node:http";
-import { readFileSync } from "node:fs";
 import { spawn } from "node:child_process";
-import { dirname, extname, join, resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import waitOn from "wait-on";
 
@@ -51,30 +49,12 @@ const conformanceServerDir = resolve(
 );
 const builtinPort = Number(process.env.TEST_PORT || 3000);
 
-// Track child processes and servers for cleanup
+// Track child processes for cleanup
 const childProcesses = [];
-let cdnServer = null;
-
-// Simple HTML escape to safely include user input in responses
-function escapeHtml(str) {
-  return String(str)
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
-}
 
 // Cleanup handler
 function cleanup() {
   console.log("\n🧹 Cleaning up processes...");
-  if (cdnServer) {
-    try {
-      cdnServer.close();
-    } catch {
-      /* ignore */
-    }
-  }
   childProcesses.forEach((proc) => {
     try {
       proc.kill("SIGTERM");
@@ -83,70 +63,6 @@ function cleanup() {
     }
   });
   process.exit(0);
-}
-
-/**
- * Start a local static file server for dist/cdn/ so tests don't depend on
- * the real inspector-cdn.mcp-use.com being reachable.
- *
- * Handles versioned filename requests:
- *   /inspector@VERSION.js  → dist/cdn/inspector.js
- *   /inspector@VERSION.css → dist/cdn/inspector.css
- * All other paths are served as-is (favicons, provider images, etc.)
- */
-function startLocalCdnServer(cdnDistDir) {
-  return new Promise((resolveServer, reject) => {
-    const CONTENT_TYPES = {
-      ".js": "application/javascript",
-      ".css": "text/css",
-      ".svg": "image/svg+xml",
-      ".png": "image/png",
-      ".ico": "image/x-icon",
-      ".webmanifest": "application/manifest+json",
-    };
-
-    const server = createServer((req, res) => {
-      let urlPath = (req.url ?? "/").split("?")[0];
-      // /inspector@VERSION.js|css  →  /inspector.js|css
-      urlPath = urlPath.replace(
-        /^\/inspector@.+?(\.(?:js|css))$/,
-        "/inspector$1"
-      );
-      // Normalize path and ensure it stays within cdnDistDir to prevent traversal
-      if (urlPath.startsWith("/")) {
-        urlPath = urlPath.slice(1);
-      }
-      const file = resolve(cdnDistDir, urlPath);
-      const rootWithSep =
-        cdnDistDir.endsWith("/") || cdnDistDir.endsWith("\\")
-          ? cdnDistDir
-          : cdnDistDir + (process.platform === "win32" ? "\\" : "/");
-      if (!file.startsWith(rootWithSep)) {
-        res.writeHead(404);
-        res.end(`Not found: ${escapeHtml(urlPath)}`);
-        return;
-      }
-      try {
-        const data = readFileSync(file);
-        const ct = CONTENT_TYPES[extname(file)] ?? "application/octet-stream";
-        res.writeHead(200, {
-          "Content-Type": ct,
-          "Access-Control-Allow-Origin": "*",
-        });
-        res.end(data);
-      } catch {
-        res.writeHead(404);
-        res.end(`Not found: ${escapeHtml(urlPath)}`);
-      }
-    });
-
-    server.listen(0, "127.0.0.1", () => {
-      const { port } = server.address();
-      resolveServer({ server, port });
-    });
-
-    server.on("error", reject);
-  });
 }
 
 process.on("SIGINT", cleanup);
@@ -257,26 +173,6 @@ async function main() {
         ["--filter", "@mcp-use/client", "build"],
         inspectorDir,
         "Building MCP client"
-      );
-      await runCommand(
-        "pnpm",
-        ["build:cdn"],
-        inspectorDir,
-        "Building built-in inspector bundle"
-      );
-    }
-
-    // Start a local CDN server for modes that use the built inspector (builtin, prod).
-    // This avoids a hard dependency on inspector-cdn.mcp-use.com being reachable in CI,
-    // particularly for canary versions that haven't been deployed to CDN yet.
-    if (mode === "builtin" || mode === "prod") {
-      const cdnDistDir = resolve(inspectorDir, "dist/cdn");
-      const result = await startLocalCdnServer(cdnDistDir);
-      cdnServer = result.server;
-      const cdnPort = result.port;
-      playwrightEnv.INSPECTOR_CDN_BASE = `http://127.0.0.1:${cdnPort}`;
-      console.log(
-        `📦 Local CDN server started at http://127.0.0.1:${cdnPort}\n`
       );
     }
 

--- a/libraries/typescript/packages/inspector/vite.cdn.config.ts
+++ b/libraries/typescript/packages/inspector/vite.cdn.config.ts
@@ -14,13 +14,10 @@ const clientPackageJson = JSON.parse(
  * CDN bundle build config.
  *
  * Produces dist/cdn/inspector.js plus lazy chunks (Shiki grammars, pdfjs, etc.).
- * Published with the npm package and served from inspector-cdn.mcp-use.com —
- * mountInspector() loads the entry via a <script type="module"> tag in a minimal
- * inline HTML shell, so the JS runs in the correct origin context and all
- * /inspector/api/* calls remain same-origin.
- *
- * Dev mode (VITE_DEV=true) proxies to the Vite dev server as before; this
- * bundle is only used in production.
+ * Shipped in the npm package and consumed three ways:
+ * - Standalone (npx / pnpm start): served locally at /dist/cdn/*
+ * - Embedded (mountInspector / mcp-use server): jsDelivr npm mirror by default
+ * - Dev: Vite serves source directly (this bundle is production-only)
  */
 export default defineConfig({
   plugins: [

--- a/libraries/typescript/packages/server/src/inspector-shell.ts
+++ b/libraries/typescript/packages/server/src/inspector-shell.ts
@@ -31,9 +31,9 @@ export const DEFAULT_INSPECTOR_ASSETS_URL = `https://cdn.jsdelivr.net/npm/@mcp-u
 /**
  * Derive the stylesheet URL that accompanies an inspector bundle URL.
  *
- * The CDN build ships as `inspector@{version}.js` + `inspector@{version}.css`
+ * The CDN build ships as dist/cdn/inspector.js + dist/cdn/inspector.css
  * plus sibling lazy chunks referenced by the entry script. The stylesheet URL
- * URL is the script URL with its `.js` suffix swapped for `.css`. Query
+ * is the script URL with its `.js` suffix swapped for `.css`. Query
  * strings and fragments are preserved.
  */
 export function inspectorStylesUrl(assetsUrl: string): string {

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -858,6 +858,34 @@ importers:
         specifier: 7.0.1-rc
         version: 7.0.1-rc
 
+  test_app:
+    dependencies:
+      mcp-use:
+        specifier: workspace:*
+        version: link:../packages/server
+      react:
+        specifier: ^19.2.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.0
+        version: 19.2.4(react@19.2.4)
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@types/node':
+        specifier: ^24.13.2
+        version: 24.13.2
+      '@types/react':
+        specifier: ^19.2.7
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      typescript:
+        specifier: 7.0.1-rc
+        version: 7.0.1-rc
+
 packages:
 
   '@acemir/cssom@0.9.31':


### PR DESCRIPTION
## Summary
- Standalone Inspector (`pnpm start` / `npx`) serves the built UI from local `dist/cdn/`; embedded `mcp-use` / `mountInspector()` still default to jsDelivr `@beta`.
- Fix OAuth redirect flows (e.g. Linear): skip auto-connecting saved MCP servers on `/oauth/callback` so the PKCE verifier is not overwritten before token exchange.
- Reduce standalone console noise: skip `dev/info` probe when not under `mcp-use dev`; stop HEAD health polling after 405/404 from POST-only MCP servers.
- Simplify inspector e2e matrix by removing the separate local CDN fixture server.

## Test plan
- [x] `pnpm start --port 3006` in `@mcp-use/inspector`, connect to `https://mcp.linear.app/mcp`, complete OAuth — reaches `ready`
- [ ] `npx @mcp-use/inspector` loads UI from `/dist/cdn/inspector.js` (no remote CDN dependency)
- [ ] Embedded inspector via `mcp-use dev` still loads jsDelivr bundle by default
- [ ] Inspector e2e builtin/prod matrix passes without local CDN server