### PR TITLE
ci(typescript): align beta checks with Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -587,7 +587,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [24.15.0]
     name: typescript-lint (node-${{ matrix.node-version }})
     defaults:
       run:
@@ -599,9 +599,9 @@ jobs:
           ref: ${{ github.event_name == 'workflow_call' && inputs.ref || github.sha }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         with:
-          version: 10.6.1
+          version: 11.13.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -612,6 +612,9 @@ jobs:
 
       - name: Install Dependencies
         run: pnpm install --no-frozen-lockfile
+
+      - name: Build Client Types
+        run: pnpm build:client
 
       - name: Check Formatting
         run: pnpm format:check
@@ -624,7 +627,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [24.15.0]
     name: typescript-build (node-${{ matrix.node-version }})
     defaults:
       run:
@@ -636,9 +639,9 @@ jobs:
           ref: ${{ github.event_name == 'workflow_call' && inputs.ref || github.sha }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         with:
-          version: 10.6.1
+          version: 11.13.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -664,7 +667,7 @@ jobs:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [24.15.0]
     defaults:
       run:
         working-directory: libraries/typescript
@@ -672,9 +675,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'workflow_call' && inputs.ref || github.sha }}
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@v4
         with:
-          version: 10.6.1
+          version: 11.13.1
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
@@ -713,12 +716,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'workflow_call' && inputs.ref || github.sha }}
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@v4
         with:
-          version: 10.6.1
+          version: 11.13.1
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24.15.0
           cache: "pnpm"
           cache-dependency-path: libraries/typescript/pnpm-lock.yaml
       - name: Install Dependencies
@@ -747,7 +750,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [24.15.0]
     defaults:
       run:
         working-directory: libraries/typescript
@@ -755,9 +758,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'workflow_call' && inputs.ref || github.sha }}
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@v4
         with:
-          version: 10.6.1
+          version: 11.13.1
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
@@ -779,7 +782,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node-version: [20, 22]
+        node-version: [24.15.0]
     defaults:
       run:
         working-directory: libraries/typescript
@@ -787,9 +790,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'workflow_call' && inputs.ref || github.sha }}
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@v4
         with:
-          version: 10.6.1
+          version: 11.13.1
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
@@ -822,14 +825,14 @@ jobs:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         with:
-          version: 10.6.1
+          version: 11.13.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24.15.0
           cache: "pnpm"
           cache-dependency-path: libraries/typescript/pnpm-lock.yaml
 
@@ -860,12 +863,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'workflow_call' && inputs.ref || github.sha }}
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@v4
         with:
-          version: 10.6.1
+          version: 11.13.1
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24.15.0
           cache: "pnpm"
           cache-dependency-path: libraries/typescript/pnpm-lock.yaml
       - name: Install Dependencies
@@ -922,13 +925,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'workflow_call' && inputs.ref || github.sha }}
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@v4
         if: matrix.pm == 'pnpm'
         with:
-          version: 10.6.1
+          version: 11.13.1
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24.15.0
       - name: Setup Yarn
         if: matrix.pm == 'yarn'
         run: corepack enable


### PR DESCRIPTION
## Summary

- run TypeScript CI jobs on Node.js 24.15.0, matching the beta runtime and release workflow
- align CI with pnpm 11.13.1 and `pnpm/action-setup@v4`
- build `@mcp-use/client` declarations before type-aware ESLint runs on a clean checkout

## Root cause

The beta workspace declares pnpm 11.13.1, which requires Node.js 22.13 or newer, while the inherited TypeScript CI matrix still included Node.js 20. pnpm automatically selected the workspace-declared version and failed on Node 20 while loading `node:sqlite`.

After correcting the runtime, clean-checkout linting also required generated client declarations because the server imports types from `@mcp-use/client` through its `dist` exports.

## Impact

Beta CI now uses the same Node.js and pnpm versions as the beta release workflow and can reach formatting, linting, builds, and tests without the install-time runtime mismatch.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm build:client`
- `pnpm format:check`
- `pnpm lint`
- `pnpm build`
- workflow YAML parse
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move TypeScript CI to Node.js 24.15.0 to match the beta runtime and release workflow, fixing install-time mismatches and enabling type-aware linting on clean checkouts.

- **Dependencies**
  - Set all TypeScript CI jobs to Node 24.15.0.
  - Upgrade `pnpm` to 11.13.1 and use `pnpm/action-setup@v4`.

- **Bug Fixes**
  - Build `@mcp-use/client` declarations before ESLint so linting passes on a clean checkout.

<sup>Written for commit 765760d7b95fa43f0604d403b971557e904743f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

