### PR TITLE
feat(server): external view assets, CDN env, and CSP configuration

### DIFF
--- a/docs/typescript/api-reference/cli-reference.mdx
+++ b/docs/typescript/api-reference/cli-reference.mdx
@@ -136,7 +136,7 @@ mcp-use build -p ./my-server
 - The command generates `.mcp-use/tool-registry.d.ts` when it can load the server entry. Type generation errors during `build` are non-blocking.
 - Without `--mcp-dir`, TypeScript is transpiled with esbuild and typechecked with the local `typescript` binary unless `--no-typecheck` is set.
 - With `--mcp-dir`, the host app owns its build. The CLI skips full-project transpilation and records the TypeScript source entry in the manifest.
-- If `MCP_SERVER_URL` is set, widget builds receive that value for server URL and asset path generation.
+- If `MCP_ASSETS_URL` is set at build, manifest asset paths are rewritten to full CDN URLs using `basePath` from the server entry.
 - The `public/` directory is copied to `dist/public/` when it exists.
 
 ## `start`
@@ -626,8 +626,13 @@ mcp-use generate-types --server src/server.ts
 | --- | --- | --- | --- |
 | `PORT` | `start`, server runtime | Server port when `--port` is not provided. `dev` and `start` also set this for the child process. | `3000` |
 | `NODE_ENV` | `dev`, `start`, widget builds | Runtime environment. `dev` sets `development`; `start` sets `production`. | Command-specific |
-| `MCP_URL` | `dev`, `start`, server runtime | Public or local base URL exposed to the server. Preserved when already set. | Local server URL or tunnel URL |
-| `MCP_SERVER_URL` | `build` | Build-time server URL injected into widget assets. | None |
+| `MCP_URL` | `dev`, `start`, server runtime | **Server public origin** (`.origin` only). OAuth resource URL, CSP `connectDomains`, dev HMR websocket. Lower priority than `CSP_URLS`. Preserved when already set. | Local server URL or tunnel URL |
+| `MCP_ASSETS_URL` | `build`, server runtime | **Assets URL prefix** (origin + optional path) for view JS/CSS and `public/`. Falls back to `MCP_URL` origin. When set at build, manifest paths become full CDN URLs (path segment from server `basePath`). | None (falls back to server origin) |
+| `CSP_URLS` | server runtime | Comma-separated CSP domain shortcut — applied to all four MCP Apps categories when per-category vars are unset. Higher priority than `MCP_URL` auto-append. | None |
+| `CSP_CONNECT_DOMAINS` | server runtime | Overrides `CSP_URLS` for `connectDomains` | None |
+| `CSP_RESOURCE_DOMAINS` | server runtime | Overrides `CSP_URLS` for `resourceDomains` | None |
+| `CSP_FRAME_DOMAINS` | server runtime | Overrides `CSP_URLS` for `frameDomains` | None |
+| `CSP_BASE_URI_DOMAINS` | server runtime | Overrides `CSP_URLS` for `baseUriDomains` | None |
 | `MCP_WEB_URL` | `login`, cloud auth | Manufact web URL for auth pages. | `https://manufact.com` |
 | `MCP_API_URL` | `login`, cloud API config | Manufact API URL. The CLI normalizes it to include `/api/v1`. | `https://cloud.manufact.com/api/v1` |
 | `MCP_USE_API_KEY` | `login` | API key for non-interactive login. | None |
@@ -641,7 +646,7 @@ mcp-use generate-types --server src/server.ts
 
 ```bash
 PORT=8080 mcp-use start
-MCP_SERVER_URL=https://my-server.example.com mcp-use build
+MCP_URL=https://my-server.example.com MCP_ASSETS_URL=https://cdn.example.com/bucket mcp-use build
 MCP_USE_API_KEY=mcp_... mcp-use login --org my-org
 MCP_USE_CHROME_PATH=/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
   mcp-use client local screenshot --tool show-board

--- a/docs/typescript/mcp-apps/content-security-policy.mdx
+++ b/docs/typescript/mcp-apps/content-security-policy.mdx
@@ -4,95 +4,94 @@ description: "Configure the domains that MCP Apps widgets can load, call, and em
 icon: "shield"
 ---
 
-Content Security Policy (CSP) controls which domains your widgets can fetch from, load scripts/styles from, and embed. Widgets run in sandboxed iframes, so CSP must explicitly allow any external resources.
+Content Security Policy (CSP) controls which domains your views can fetch from, load scripts/styles from, and embed. Views run in sandboxed iframes, so CSP must explicitly allow any external resources.
 
-## Configure the server origin
+## Server and asset origins
 
-When `baseUrl` is set (via `MCPServer` constructor or `MCP_URL` environment variable), mcp-use automatically configures CSP:
-
-```typescript
-const server = new MCPServer({
-  name: "my-server",
-  version: "1.0.0",
-  baseUrl: process.env.MCP_URL, // Required for production
-});
-```
-
-This ensures:
-
-- Widget URLs use the correct domain
-- CSP includes your server domain
-- Works behind proxies and custom domains
-
-The server origin is auto-injected into each widget's `connectDomains`, `resourceDomains`, and `baseUriDomains`, so you don't need to add it manually.
-
-## Add domains for one widget
-
-For widgets that need additional domains (APIs, CDNs, etc.), configure CSP in your widget metadata.
-
-For file-based widgets, declare CSP with camelCase keys in `metadata.csp` on your exported `widgetMetadata`:
-
-```tsx
-import { type WidgetMetadata } from "mcp-use/react";
-import { z } from "zod";
-
-const propSchema = z.object({
-  city: z.string(),
-  temperature: z.number(),
-});
-
-export const widgetMetadata: WidgetMetadata = {
-  description: "Display weather",
-  props: propSchema,
-  metadata: {
-    csp: {
-      connectDomains: ["https://api.weather.com"],
-      resourceDomains: ["https://cdn.weather.com"],
-      frameDomains: ["https://trusted-embed.com"],
-    },
-  },
-};
-```
-
-<Note>
-Your CSP domains are merged with your server's base URL automatically. For ChatGPT, OpenAI's required domains are also added. Use [Apps SDK compatibility](/typescript/mcp-apps/apps-sdk-compatibility) for ChatGPT-specific host extensions.
-</Note>
-
-## Add domains for every widget
-
-Use `CSP_URLS` when every widget needs the same extra domains.
+Set **`MCP_URL`** to your server's public origin (OAuth resource URL, API calls, CSP `connectDomains`):
 
 ```env
-# Base URL: auto-included in widget CSP
 MCP_URL=https://myserver.com
+```
 
-# Additional domains (comma-separated): appended to widget CSP
+Set **`MCP_ASSETS_URL`** when view JS/CSS and `public/` files are served from a different prefix (CDN, Supabase Storage):
+
+```env
+MCP_ASSETS_URL=https://cdn.example.com/storage/v1/object/public/widgets
+```
+
+When `MCP_ASSETS_URL` is unset, assets use the same origin as `MCP_URL` (or the request origin behind a proxy).
+
+At **`mcp-use build`**, `MCP_ASSETS_URL` rewrites manifest paths to full `https://` URLs for static upload workflows.
+
+## CSP merge order
+
+On each `resources/read`, the framework merges CSP in this order (high → low priority):
+
+1. Author `view.csp` on the bound tool
+2. `CSP_*_DOMAINS` env vars (per category) or the `CSP_URLS` shortcut
+3. MCP auto-append: `MCP_URL` → `connectDomains`; assets origin → `resourceDomains`
+
+`CSP_URLS` and per-category env vars rank **above** MCP auto-append. Duplicate origins keep the higher-priority entry's position.
+
+## Add domains for one view
+
+Declare CSP on the tool's `view:` config:
+
+```typescript
+server.tool(
+  {
+    name: "weather",
+    view: {
+      name: "weather-display",
+      csp: {
+        connectDomains: ["https://api.weather.com"],
+        resourceDomains: ["https://cdn.weather.com"],
+        frameDomains: ["https://trusted-embed.com"],
+      },
+    },
+  },
+  async () => ({ /* ... */ })
+);
+```
+
+MCP Apps CSP fields: `connectDomains`, `resourceDomains`, `frameDomains`, `baseUriDomains`.
+
+## Global CSP env vars
+
+Use `CSP_URLS` when every view needs the same extra domains (shortcut for **all four** categories):
+
+```env
 CSP_URLS=https://api.example.com,https://cdn.example.com
 ```
 
-- **MCP_URL**: Base URL for widget assets and public files. Also used by the server to configure CSP.
-- **CSP_URLS**: (Optional) Additional domains to whitelist. Supports comma-separated list. Required for static deployments where widget assets are served from different domains.
+Override one category without affecting others:
 
-## Static deployments
+```env
+CSP_CONNECT_DOMAINS=https://api.example.com
+CSP_RESOURCE_DOMAINS=https://cdn.example.com
+CSP_FRAME_DOMAINS=https://embed.example.com
+CSP_BASE_URI_DOMAINS=https://myserver.com
+```
 
-When widgets are served from static storage while the MCP server runs elsewhere, configure both origins:
+## Static deployments (Supabase / CDN)
 
-- **MCP_URL**: Where widget assets are stored
-- **MCP_SERVER_URL**: Where the MCP server runs (for API calls)
-- **CSP_URLS**: Domains for storage and API access
+When assets live on static storage and the MCP server runs elsewhere:
 
-See [Supabase deployment](/typescript/server/deployment/supabase) for a complete setup.
+```env
+MCP_URL=https://PROJECT.supabase.co/functions/v1/mcp-server
+MCP_ASSETS_URL=https://PROJECT.supabase.co/storage/v1/object/public/widgets
+CSP_URLS=https://PROJECT.supabase.co
+```
 
-<Tip>
-**Alternative**: Instead of the global `CSP_URLS` environment variable, configure CSP per-widget in `metadata.csp`
-</Tip>
+See [Supabase deployment](/typescript/server/deployment/supabase) for the full workflow.
 
 ## Verify CSP
 
 The mcp-use Inspector provides a **CSP Mode Toggle** for testing:
 
 - **Permissive**: Relaxed CSP for debugging
-- **Widget-Declared**: Enforces the widget's declared CSP (production-like)
+- **Widget-Declared**: Enforces the view's declared CSP (production-like)
 
 <Warning>
 CSP violations are logged in the console. Use Widget-Declared mode to catch CSP issues before production deployment.
@@ -100,6 +99,6 @@ CSP violations are logged in the console. Use Widget-Declared mode to catch CSP 
 
 ## Next Steps
 
-- [MCP Apps](/typescript/mcp-apps): Widget overview and routing
+- [MCP Apps](/typescript/mcp-apps): View overview and routing
 - [Apps SDK compatibility](/typescript/mcp-apps/apps-sdk-compatibility): ChatGPT compatibility and host extensions
 - [Supabase Deployment](/typescript/server/deployment/supabase): Static deployment with CSP

--- a/docs/typescript/server/deployment/supabase.mdx
+++ b/docs/typescript/server/deployment/supabase.mdx
@@ -250,32 +250,31 @@ supabase storage cp -r dist/resources/widgets ss://widgets/ --experimental
 and then set the environment variables for Supabase deployments:
 
 ```bash
-# MCP_URL: Where widget assets (JS/CSS) are stored
-export MCP_URL="https://YOUR_PROJECT_REF.supabase.co/storage/v1/object/public/widgets"
+# MCP_URL: Where the MCP server runs (OAuth resource, API calls, connectDomains CSP)
+export MCP_URL="https://YOUR_PROJECT_REF.supabase.co/functions/v1/YOUR_FUNCTION_NAME"
 
-# MCP_SERVER_URL: Where the MCP server runs (for API calls in widgets)
-export MCP_SERVER_URL="https://YOUR_PROJECT_REF.supabase.co/functions/v1/YOUR_FUNCTION_NAME"
+# MCP_ASSETS_URL: Where view assets (JS/CSS) and public/ files are stored
+export MCP_ASSETS_URL="https://YOUR_PROJECT_REF.supabase.co/storage/v1/object/public/widgets"
 
 # CSP_URLS: Supabase project URL (for Content Security Policy). See [Content Security Policy](/typescript/mcp-apps/content-security-policy) for full CSP docs.
 export CSP_URLS="https://YOUR_PROJECT_REF.supabase.co"
 ```
 
 <Note>
-  **URLs Required**: Supabase deployments need these URLs because widget files
-  are served from static storage while API calls go to the edge function: -
-  `MCP_URL`: Where widget assets are stored - `MCP_SERVER_URL`: Enables
-  build-time URL injection for static deployments - `CSP_URLS`: Whitelists the
-  Supabase project domain in the Content Security Policy (use base URL without
-  path)
+  **URLs Required**: Supabase deployments split server and assets because view files
+  are served from static storage while the MCP server runs on the edge function:
+  - `MCP_URL`: Server origin (edge function)
+  - `MCP_ASSETS_URL`: Asset CDN prefix (Storage bucket); also set at **build** time to rewrite manifest paths
+  - `CSP_URLS`: Whitelists the Supabase project domain in CSP (base URL without path)
 </Note>
 
 ### 5. Build the mcp-use app
 
 ```bash
 echo $MCP_URL
-# should output: https://YOUR_PROJECT_REF.supabase.co/storage/v1/object/public/widgets
-echo $MCP_SERVER_URL
 # should output: https://YOUR_PROJECT_REF.supabase.co/functions/v1/YOUR_FUNCTION_NAME
+echo $MCP_ASSETS_URL
+# should output: https://YOUR_PROJECT_REF.supabase.co/storage/v1/object/public/widgets
 ```
 
 <CodeGroup>
@@ -303,8 +302,11 @@ static_files = [ "./functions/mcp-server/dist/**/*.html", "./functions/mcp-serve
 Set environment variables **before deploying** so the MCP server can configure Content Security Policy (CSP) to allow widgets to make API calls and load assets:
 
 ```bash
-# MCP_URL: Server URL for API calls
+# MCP_URL: Server origin for OAuth/API/CSP connectDomains
 supabase secrets set MCP_URL="https://YOUR_PROJECT_REF.supabase.co/functions/v1/mcp-server" --project-ref YOUR_PROJECT_REF
+
+# MCP_ASSETS_URL: Asset CDN prefix (runtime + must match build-time value)
+supabase secrets set MCP_ASSETS_URL="https://YOUR_PROJECT_REF.supabase.co/storage/v1/object/public/widgets" --project-ref YOUR_PROJECT_REF
 
 # CSP_URLS: Supabase project URL (without path) to allow storage and function access
 supabase secrets set CSP_URLS="https://YOUR_PROJECT_REF.supabase.co" --project-ref YOUR_PROJECT_REF
@@ -312,8 +314,9 @@ supabase secrets set CSP_URLS="https://YOUR_PROJECT_REF.supabase.co" --project-r
 
 <Note>
 **Environment Variables:**
-- `MCP_URL`: Whitelists the edge function domain for API calls from widgets
-- `CSP_URLS`: Whitelists the Supabase project URL (without path) for widget assets (JS/CSS) and storage access. Use the base project URL like `https://nnpumlykjksvxivhywwo.supabase.co` (no `/storage/*` or other paths needed). Supports comma-separated values for multiple domains.
+- `MCP_URL`: Server origin (edge function) — OAuth resource URL and `connectDomains` CSP
+- `MCP_ASSETS_URL`: Asset CDN prefix for view JS/CSS and `public/` URLs
+- `CSP_URLS`: Whitelists the Supabase project URL (without path). Supports comma-separated values.
 
 **Important**: Set these before deploying the function. If you set them after deployment, you must redeploy for the changes to take effect.
 

--- a/libraries/typescript/.changeset/build-v2-external-view-assets.md
+++ b/libraries/typescript/.changeset/build-v2-external-view-assets.md
@@ -1,0 +1,11 @@
+---
+"mcp-use": minor
+---
+
+Revamp the production view build pipeline and deployment env surface.
+
+- **`mcp-use build`** emits hashed view assets on disk (`kind: "external"`) instead of inlining JS/CSS into the manifest; production serves bundles from `${basePath}/_mcp-use/views/<name>/`.
+- Add **`--with-inspector`** so the build manifest records inspector availability for `mcp-use start` (no longer always `true`).
+- Support **`MCP_ASSETS_URL`** at build time (rewrite manifest asset paths to CDN URLs) and runtime (resolve view `publicBase` and asset hrefs separately from **`MCP_URL`** server origin).
+- Add global CSP env: **`CSP_URLS`** (all four MCP Apps categories) and **`CSP_*_DOMAINS`** per-category overrides, merged with author `view.csp` before MCP auto-append.
+- Bundle **`@modelcontextprotocol/client`** as a runtime dependency for the CLI.

--- a/libraries/typescript/packages/server/package.json
+++ b/libraries/typescript/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-use",
   "type": "module",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "description": "MCP framework and CLI built on the official v2 SDK",
   "author": "mcp-use, Inc.",
   "license": "MIT",
@@ -77,7 +77,11 @@
     "typecheck": "tsc -p tsconfig.test.json",
     "doctor": "npx react-doctor@latest"
   },
+  "bundledDependencies": [
+    "@modelcontextprotocol/client"
+  ],
   "dependencies": {
+    "@modelcontextprotocol/client": "https://pkg.pr.new/@modelcontextprotocol/client@f60b40179b0f090f6d64248be1312245a160b5ee",
     "@modelcontextprotocol/ext-apps": "https://pkg.pr.new/@modelcontextprotocol/ext-apps@432d42bb02a569078ab31ab6458428df6027809d",
     "@modelcontextprotocol/server": "https://pkg.pr.new/@modelcontextprotocol/server@f60b40179b0f090f6d64248be1312245a160b5ee",
     "@tailwindcss/vite": "^4.2.0",
@@ -104,7 +108,6 @@
   },
   "devDependencies": {
     "@mcp-use/client": "workspace:*",
-    "@modelcontextprotocol/client": "https://pkg.pr.new/@modelcontextprotocol/client@f60b40179b0f090f6d64248be1312245a160b5ee",
     "@modelcontextprotocol/core": "https://pkg.pr.new/@modelcontextprotocol/core@f60b40179b0f090f6d64248be1312245a160b5ee",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^24.13.2",

--- a/libraries/typescript/packages/server/scripts/env-url-csp-runtime-test.mjs
+++ b/libraries/typescript/packages/server/scripts/env-url-csp-runtime-test.mjs
@@ -1,0 +1,351 @@
+#!/usr/bin/env node
+/**
+ * Runtime report: MCP_URL, MCP_ASSETS_URL, CSP_URLS, per-category CSP env vars.
+ * Run from repo after packing: node scripts/env-url-csp-runtime-test.mjs
+ */
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SERVER_PKG = join(__dirname, "..");
+const FIXTURE = join(SERVER_PKG, "tests/cli/fixtures/views");
+const WORK = "/tmp/mcp-env-url-csp-test";
+const BUILD_DIR = join(WORK, ".mcp-use/build");
+
+const UI_META = {
+  "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+  "io.modelcontextprotocol/clientInfo": { name: "env-test", version: "0.0.0" },
+  "io.modelcontextprotocol/clientCapabilities": {
+    extensions: {
+      "io.modelcontextprotocol/ui": {
+        mimeTypes: ["text/html;profile=mcp-app"],
+      },
+    },
+  },
+};
+
+const report = [];
+
+function log(section, data) {
+  report.push({ section, ...data });
+  console.log(`\n## ${section}`);
+  console.log(data.pass ? "PASS" : "FAIL");
+  for (const [k, v] of Object.entries(data)) {
+    if (k === "section" || k === "pass") continue;
+    console.log(
+      `  ${k}: ${typeof v === "string" ? v : JSON.stringify(v, null, 2)}`
+    );
+  }
+}
+
+async function mcpJson(
+  handler,
+  method,
+  params = {},
+  extraHeaders = {},
+  basePath = "/mcp"
+) {
+  const headers = {
+    "content-type": "application/json",
+    accept: "application/json, text/event-stream",
+    "mcp-protocol-version": "2026-07-28",
+    "mcp-method": method,
+    ...extraHeaders,
+  };
+  if (typeof params.uri === "string") headers["mcp-name"] = params.uri;
+
+  const res = await handler(
+    new Request(`http://127.0.0.1:3000${basePath}`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method,
+        params: { ...params, _meta: UI_META },
+      }),
+    })
+  );
+  return res.json();
+}
+
+function extractUrls(html) {
+  const script = html.match(/<script type="module" src="([^"]+)"/)?.[1];
+  const css = html.match(/<link rel="stylesheet" href="([^"]+)"/)?.[1];
+  const publicBase = html.match(
+    /__mcpUseViewConfig=\{"publicBase":"([^"]+)"/
+  )?.[1];
+  return { script, css, publicBase };
+}
+
+function clearEnv() {
+  delete process.env.MCP_URL;
+  delete process.env.MCP_ASSETS_URL;
+  delete process.env.CSP_URLS;
+  delete process.env.CSP_CONNECT_DOMAINS;
+  delete process.env.CSP_RESOURCE_DOMAINS;
+  delete process.env.CSP_FRAME_DOMAINS;
+  delete process.env.CSP_BASE_URI_DOMAINS;
+}
+
+function patchEntryBasePath(basePath) {
+  const entry = join(WORK, "src/index.ts");
+  const src = readFileSync(entry, "utf8");
+  writeFileSync(
+    entry,
+    src.replace(
+      'new MCPServer({ name: "fixture-views", version: "1.0.0" })',
+      `new MCPServer({ name: "fixture-views", version: "1.0.0", basePath: "${basePath}" })`
+    )
+  );
+}
+
+function setupProject({ basePath } = {}) {
+  rmSync(WORK, { recursive: true, force: true });
+  mkdirSync(WORK, { recursive: true });
+  cpSync(FIXTURE, WORK, { recursive: true });
+  if (basePath) patchEntryBasePath(basePath);
+  writeFileSync(
+    join(WORK, "package.json"),
+    JSON.stringify(
+      {
+        name: "env-url-csp-test",
+        type: "module",
+        dependencies: {
+          "mcp-use": `file:${SERVER_PKG}`,
+          react: "^19.2.4",
+          "react-dom": "^19.2.4",
+          zod: "^4.4.3",
+        },
+      },
+      null,
+      2
+    )
+  );
+  const npm = spawnSync("npm", ["install"], { cwd: WORK, encoding: "utf8" });
+  if (npm.status !== 0) throw new Error(`npm install failed: ${npm.stderr}`);
+  const build = spawnSync("npx", ["mcp-use", "build"], {
+    cwd: WORK,
+    encoding: "utf8",
+    env: { ...process.env },
+  });
+  if (build.status !== 0) throw new Error(`build failed: ${build.stderr}`);
+}
+
+async function loadHandler() {
+  process.chdir(WORK);
+  const entry = join(BUILD_DIR, "index.js");
+  // Bust ESM import cache between scenario rebuilds (same file path).
+  return (
+    await import(`${pathToFileURL(entry).href}?v=${Date.now()}`)
+  ).default.getHandler();
+}
+
+async function readView(handler, extraHeaders = {}, basePath = "/mcp") {
+  const body = await mcpJson(
+    handler,
+    "resources/read",
+    { uri: "ui://views/product-search-result.html" },
+    extraHeaders,
+    basePath
+  );
+  const content = body.result.contents[0];
+  const html = content.text;
+  const csp = content._meta?.ui?.csp;
+  return { html, csp, urls: extractUrls(html) };
+}
+
+async function main() {
+  const build = spawnSync("pnpm", ["run", "build"], {
+    cwd: SERVER_PKG,
+    encoding: "utf8",
+  });
+  if (build.status !== 0) throw new Error(`pnpm build failed: ${build.stderr}`);
+
+  clearEnv();
+  setupProject();
+  let handler = await loadHandler();
+
+  {
+    clearEnv();
+    const { urls, csp } = await readView(handler);
+    const localScript = urls.script?.replace(
+      /^https?:\/\/[^/]+/,
+      "http://127.0.0.1:3000"
+    );
+    const status = localScript
+      ? (await handler(new Request(localScript))).status
+      : 0;
+    log("Default (no env)", {
+      pass:
+        urls.script?.startsWith("http://127.0.0.1:3000/mcp/") &&
+        csp?.connectDomains?.some((d) => d.includes("127.0.0.1")) &&
+        status === 200,
+      scriptUrl: urls.script,
+      publicBase: urls.publicBase,
+      connectDomains: csp?.connectDomains,
+      resourceDomains: csp?.resourceDomains,
+      assetHttpStatus: status,
+    });
+  }
+
+  {
+    clearEnv();
+    process.env.MCP_URL = "https://server.example.com/mcp";
+    const { urls, csp } = await readView(handler);
+    log("MCP_URL only (server origin)", {
+      pass:
+        urls.script?.startsWith("https://server.example.com/mcp/") &&
+        csp?.connectDomains?.includes("https://server.example.com") &&
+        csp?.resourceDomains?.includes("https://server.example.com"),
+      scriptUrl: urls.script,
+      connectDomains: csp?.connectDomains,
+      resourceDomains: csp?.resourceDomains,
+    });
+  }
+
+  {
+    clearEnv();
+    process.env.MCP_URL = "https://server.example.com/mcp";
+    process.env.MCP_ASSETS_URL =
+      "https://cdn.example.com/storage/v1/object/public/widgets";
+    const { urls, csp } = await readView(handler);
+    log("Split MCP_URL + MCP_ASSETS_URL", {
+      pass:
+        urls.script?.startsWith("https://cdn.example.com/") &&
+        csp?.connectDomains?.includes("https://server.example.com") &&
+        csp?.resourceDomains?.includes("https://cdn.example.com") &&
+        !csp?.resourceDomains?.includes("https://server.example.com"),
+      scriptUrl: urls.script,
+      publicBase: urls.publicBase,
+      connectDomains: csp?.connectDomains,
+      resourceDomains: csp?.resourceDomains,
+    });
+  }
+
+  {
+    clearEnv();
+    process.env.CSP_URLS = "https://supabase.co,https://api.example.com";
+    const { csp } = await readView(handler);
+    const allHave = (cat) =>
+      csp?.[cat]?.includes("https://supabase.co") &&
+      csp?.[cat]?.includes("https://api.example.com");
+    log("CSP_URLS shortcut (all four categories)", {
+      pass:
+        allHave("connectDomains") &&
+        allHave("resourceDomains") &&
+        allHave("frameDomains") &&
+        allHave("baseUriDomains"),
+      csp,
+    });
+  }
+
+  {
+    clearEnv();
+    process.env.CSP_URLS = "https://server.example.com";
+    process.env.MCP_URL = "https://server.example.com";
+    const { csp } = await readView(handler);
+    const connect = csp?.connectDomains ?? [];
+    log("CSP_URLS precedence over MCP auto-append", {
+      pass:
+        connect.filter((d) => d === "https://server.example.com").length ===
+          1 && connect[0] === "https://server.example.com",
+      connectDomains: connect,
+    });
+  }
+
+  {
+    clearEnv();
+    process.env.CSP_URLS = "https://a.com,https://b.com";
+    process.env.CSP_CONNECT_DOMAINS = "https://connect-only.example.com";
+    const { csp } = await readView(handler);
+    log("Per-category CSP_CONNECT_DOMAINS override", {
+      pass:
+        csp?.connectDomains?.includes("https://connect-only.example.com") &&
+        !csp?.connectDomains?.includes("https://a.com") &&
+        csp?.frameDomains?.includes("https://a.com"),
+      connectDomains: csp?.connectDomains,
+      frameDomains: csp?.frameDomains,
+    });
+  }
+
+  {
+    clearEnv();
+    const { urls, csp } = await readView(handler, {
+      "x-forwarded-proto": "https",
+      "x-forwarded-host": "fruit.example.com",
+    });
+    log("X-Forwarded-* (no MCP_URL)", {
+      pass:
+        urls.script?.startsWith("https://fruit.example.com/mcp/") &&
+        csp?.resourceDomains?.includes("https://fruit.example.com"),
+      scriptUrl: urls.script,
+      resourceDomains: csp?.resourceDomains,
+    });
+  }
+
+  {
+    clearEnv();
+    process.env.MCP_ASSETS_URL =
+      "https://cdn.example.com/storage/v1/object/public/widgets";
+    rmSync(WORK, { recursive: true, force: true });
+    setupProject();
+    handler = await loadHandler();
+    const { urls } = await readView(handler);
+    log("Build with MCP_ASSETS_URL (CDN manifest)", {
+      pass: urls.script?.startsWith("https://cdn.example.com/"),
+      scriptUrl: urls.script,
+    });
+  }
+
+  {
+    clearEnv();
+    const customBasePath = "/api/mcp";
+    rmSync(WORK, { recursive: true, force: true });
+    setupProject({ basePath: customBasePath });
+    const customHandler = await loadHandler();
+    const { urls, csp } = await readView(customHandler, {}, customBasePath);
+    const localScript = urls.script?.replace(
+      /^https?:\/\/[^/]+/,
+      "http://127.0.0.1:3000"
+    );
+    const status = localScript
+      ? (await customHandler(new Request(localScript))).status
+      : 0;
+    log("Custom basePath (/api/mcp)", {
+      pass:
+        urls.script?.includes("/api/mcp/_mcp-use/views/") &&
+        urls.publicBase?.includes("/api/mcp/_mcp-use/public/") &&
+        csp?.connectDomains?.some((d) => d.includes("127.0.0.1")) &&
+        status === 200,
+      basePath: customBasePath,
+      scriptUrl: urls.script,
+      publicBase: urls.publicBase,
+      connectDomains: csp?.connectDomains,
+      assetHttpStatus: status,
+    });
+  }
+
+  const passed = report.filter((r) => r.pass).length;
+  writeFileSync(
+    join(WORK, "RUNTIME-ENV-REPORT.json"),
+    `${JSON.stringify(report, null, 2)}\n`
+  );
+  console.log(`\n--- ${passed}/${report.length} scenarios passed ---`);
+  console.log(`Report: ${join(WORK, "RUNTIME-ENV-REPORT.json")}`);
+  if (passed < report.length) process.exit(1);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/libraries/typescript/packages/server/specs/CLI_SPEC.md
+++ b/libraries/typescript/packages/server/specs/CLI_SPEC.md
@@ -268,6 +268,8 @@ Writes `.mcp-use/build/manifest.json`:
 
 `buildId` is a random hex id and `createdAt` an ISO timestamp. `start` consumes `entryPoint`; inspector enablement remains solely in the built server's `ServerConfig` and is not duplicated in the manifest. Views extend this manifest with a `views` map (`VIEWS_SPEC.md` § Manifest) and copy the project-root `public/` directory into `build/views/public/` when present.
 
+When `MCP_ASSETS_URL` is set, view manifest asset paths are rewritten to full CDN URLs at build time using `basePath` from the server entry (upload `build/views/` separately). Runtime env: `MCP_URL` (server origin), `MCP_ASSETS_URL` (assets prefix), `CSP_URLS` / `CSP_*_DOMAINS` (global CSP — see `VIEWS_SPEC.md`).
+
 The build is transpile-only and does not run a typecheck. Projects own their `tsc --noEmit` script.
 
 ### `mcp-use dev` (in `src/cli/dev.ts`, dispatched from the bin)

--- a/libraries/typescript/packages/server/specs/VIEWS_SPEC.md
+++ b/libraries/typescript/packages/server/specs/VIEWS_SPEC.md
@@ -450,7 +450,13 @@ Public responses include `Access-Control-Allow-Origin: *`. Hosts render views in
 - **`inline` (production):** emit `<style>` with the CSS (escaping `</style`) and `<script type="module">` with the JS (escaping `</script` → `<\/script` and `<!--` → `\x3C!--`). Keep the `__mcpUseViewConfig` config script (`publicBase` still origin-resolved per request) and `<div id="root">`.
 - **`external` (dev):** `<link>` / `<script type="module" src>` tags for Vite module URLs (current HMR path).
 
-**Origin resolution is request-scoped** — the same posture as capability gating, and the piece v1 got structurally wrong (origin computed once at boot from `MCP_URL`/host:port, then string-patched into HTML). The synthesized document's `publicBase` (and any residual absolute URLs) resolve per request to `<origin>${basePath}/_mcp-use/` where `<origin>` comes from, in order: an explicit override (for deployments whose edge doesn't forward — **shape deliberately unresolved**: whether this is a `publicUrl` config field or v1's `MCP_URL` environment variable is a pending separate discussion, see Open questions), standard `Forwarded`/`X-Forwarded-Proto`+`X-Forwarded-Host` headers, the request URL itself. The v1 mistake was *when* the override was read (boot-time baking), not the override existing; whatever its spelling, it is applied at emission time. No boot-time state — correct behind tunnels/proxies/preview deployments without restarts.
+**Origin resolution is request-scoped** — applied at `resources/read` emission time:
+
+- **`MCP_URL`** — server public origin (`.origin` only): OAuth resource URL, CSP `connectDomains`, dev HMR websocket host.
+- **`MCP_ASSETS_URL`** — assets URL prefix (origin + optional path): view JS/CSS hrefs and `__mcpUseViewConfig.publicBase`. Falls back to `MCP_URL` origin, then `Forwarded` / request origin.
+- **CSP env** — `CSP_URLS` (shortcut for all four MCP Apps categories) and `CSP_*_DOMAINS` per-category overrides merge with author `view.csp` before MCP auto-append. Env vars rank above MCP auto-append.
+
+Build-time: when `MCP_ASSETS_URL` is set, manifest asset paths are rewritten to full CDN URLs; upload `.mcp-use/build/views/` to the asset host.
 
 **srcdoc iframes have no document base URL.** Hosts render view documents via `srcdoc`, so every URL the view still loads over the network (public assets; in **dev**, Vite modules) must be absolute — root-relative paths resolve against the *host page* origin, not the MCP server. Production view JS/CSS need no network URLs (inlined). Dev sets Vite `server.origin` to the dev server's browsable origin so imported assets emit absolute `http://…` URLs. Public assets resolve through a request-scoped config global injected into the synthesized document.
 
@@ -1181,7 +1187,6 @@ The full build/serve contract is "Build system & serving", above; it extends the
 ## Open questions
 
 - Stable `ui://views/<name>.html` vs content-hashed URIs: revisit only with evidence that a target host over-caches by URI (v1's `buildId` existed for ChatGPT; ChatGPT's MCP Apps path may not need it). External evidence: Skybridge appends `?v=<content-hash>` to view URIs in production — a second framework independently concluding hosts over-cache by URI. Expectation is this resolves toward a manifest-driven hash suffix once tested against ChatGPT; still deferred to that test, not decided here.
-- **Origin override: `MCP_URL` vs `publicUrl`.** The request-scoped resolution order is decided (override → forwarded headers → request URL, applied at emission time); the override's surface is not — v1 shipped `MCP_URL` as an environment variable, and what of its v1 role carries into v2 deserves its own discussion. Until then this spec names it only "the override".
 - `ui/download-file` (draft) exposure — as a standalone hook — once a target host ships it.
 - Partial/streamed **tool results**: not in the 2026-07-28 protocol or the apps spec today (see Streaming). When a partial-result channel lands upstream, deliver it as ordinary `useToolContext` re-renders; until then, progressive UIs pull via `useCallTool`.
 - **Vite dev `script-src` / eval:** Vite HMR and some dev transforms use `eval`, which strict host `script-src` policies may block. The MCP Apps CSP shape is origin-lists only — no `'unsafe-eval'` or nonce slot — so this cannot be declared in `view.csp`. If it bites in practice, the fix is Vite-side (jitless deps, no eval-based sourcemaps); dev already auto-appends the HMR websocket origin to `connectDomains` (Serving).

--- a/libraries/typescript/packages/server/src/bin/args.ts
+++ b/libraries/typescript/packages/server/src/bin/args.ts
@@ -23,6 +23,8 @@ export interface ParsedArgs {
   tunnel: boolean;
   /** `false` when `--no-open` was passed (dev only); `true` otherwise. */
   open: boolean;
+  /** Whether `--with-inspector` was passed (build only). */
+  withInspector: boolean;
   /** Whether `--help`/`-h` was passed. */
   help: boolean;
   /** Whether `--version`/`-v` was passed. */
@@ -49,6 +51,7 @@ export function parseArgs(argv: readonly string[]): ParsedArgs {
     host: undefined,
     tunnel: false,
     open: true,
+    withInspector: false,
     help: false,
     version: false,
   };
@@ -102,6 +105,9 @@ export function parseArgs(argv: readonly string[]): ParsedArgs {
         break;
       case "--no-open":
         args.open = false;
+        break;
+      case "--with-inspector":
+        args.withInspector = true;
         break;
       default:
         if (flag.startsWith("-")) {

--- a/libraries/typescript/packages/server/src/bin/main.ts
+++ b/libraries/typescript/packages/server/src/bin/main.ts
@@ -27,6 +27,8 @@ export interface CliCommandOptions {
   tunnel?: boolean;
   /** Auto-open the inspector in a browser at dev startup (`--no-open` disables). */
   open?: boolean;
+  /** Record inspector availability in the build manifest (`--with-inspector`). */
+  withInspector?: boolean;
 }
 
 const HELP = `mcp-use — run MCP servers built with mcp-use
@@ -52,6 +54,7 @@ Options:
   -p, --port <n>     Port to serve on (default: $PORT or 3000)
   --host <host>      Host to bind (dev only)
   --entry <path>     Server entry module (dev/build only)
+  --with-inspector   Record inspector availability in the build manifest (build only)
   --tunnel           Expose the dev server through a public tunnel (dev only)
   --no-open          Do not auto-open the inspector in a browser (dev only)
   -h, --help         Show this help
@@ -181,6 +184,7 @@ async function cliCommand(
     ...(args.host !== undefined && { host: args.host }),
     ...(args.tunnel && { tunnel: true }),
     ...(!args.open && { open: false }),
+    ...(args.withInspector && { withInspector: true }),
   };
 
   try {

--- a/libraries/typescript/packages/server/src/cli/build.ts
+++ b/libraries/typescript/packages/server/src/cli/build.ts
@@ -3,7 +3,7 @@
  * `.mcp-use/build/` workspace directory (CLI_SPEC.md § Commands → build).
  *
  * When views exist (under `resources/<name>/view.tsx`), also runs a client-environment
- * build per view (self-contained inline bundles), validates bindings, and emits a
+ * build per view (hashed assets on disk), validates bindings, and emits a
  * wrapper entry that primes views before re-exporting the server (VIEWS_SPEC.md §
  * Build system).
  *
@@ -16,7 +16,7 @@
 
 import { randomBytes } from "node:crypto";
 import { existsSync } from "node:fs";
-import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { cp, mkdir, rm, writeFile } from "node:fs/promises";
 import { join, relative } from "node:path";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
@@ -24,7 +24,10 @@ import { build } from "vite";
 
 import { discoverEntry } from "./entry.js";
 import { mcpUseViewsPlugin } from "./views-plugin.js";
-import { validateViewBindingsAtBuild } from "./views-bindings.js";
+import {
+  resolveBuildBasePath,
+  validateViewBindingsAtBuild,
+} from "./views-bindings.js";
 import {
   createBindingValidationServer,
   discoverViews,
@@ -33,6 +36,8 @@ import {
 } from "./views.js";
 import { resolveTailwindCss, resolveUserViteConfig } from "./vite-config.js";
 import { resolveWorkspacePaths, type BuildManifest } from "./workspace.js";
+import { normalizeAssetsBaseUrl } from "../views/origin.js";
+import { viewAssetsBasePath } from "../views/document.js";
 import type { ViewsManifest } from "../views/types.js";
 
 /** Fixed filename of the emitted server entry inside `.mcp-use/build/`. */
@@ -58,15 +63,16 @@ export interface BuildOptions {
    * `index.ts`, `server.ts` — first hit wins.
    */
   entry?: string;
+  /**
+   * When true (`mcp-use build --with-inspector`), record `inspector: true`
+   * in the build manifest.
+   */
+  withInspector?: boolean;
 }
 
 /**
  * Emit a short-lived wrapper module under `.mcp-use/cache/` that primes views
  * before re-exporting the user's entry (VIEWS_SPEC.md § Registration mechanism).
- *
- * Production manifests carry full JS/CSS source strings; `JSON.stringify`
- * embeds them as escaped string literals in the generated module (large
- * payloads are accepted — matches the no-fs-on-MCP-path rule).
  */
 async function writeWrapperEntry(
   cacheDir: string,
@@ -89,15 +95,57 @@ async function writeWrapperEntry(
   return wrapperPath;
 }
 
+function readBuildAssetsBase(): string | undefined {
+  const raw = process.env["MCP_ASSETS_URL"];
+  if (raw === undefined || raw.trim() === "") {
+    return undefined;
+  }
+  try {
+    return normalizeAssetsBaseUrl(new URL(raw).href.replace(/\/$/, ""));
+  } catch {
+    return undefined;
+  }
+}
+
+/** Rewrite a view-relative manifest path to a full CDN URL at build time. */
+function toCdnAssetUrl(
+  relativePath: string,
+  viewName: string,
+  assetsBase: string,
+  basePath: string
+): string {
+  const clean = relativePath.replace(/^\/+/, "");
+  return `${assetsBase}${viewAssetsBasePath(basePath, viewName)}${clean}`;
+}
+
+function applyBuildAssetsPrefix(
+  entry: ViewsManifest[string],
+  viewName: string,
+  assetsBase: string,
+  basePath: string
+): ViewsManifest[string] {
+  if (entry.kind !== "external") {
+    return entry;
+  }
+  return {
+    ...entry,
+    entry: toCdnAssetUrl(entry.entry, viewName, assetsBase, basePath),
+    css: entry.css.map((path) =>
+      toCdnAssetUrl(path, viewName, assetsBase, basePath)
+    ),
+    ...(entry.scripts !== undefined && {
+      scripts: entry.scripts.map((path) =>
+        toCdnAssetUrl(path, viewName, assetsBase, basePath)
+      ),
+    }),
+  };
+}
+
 /**
- * Build one view into a self-contained ES module + CSS, then read the emitted
- * text into an inline manifest entry.
- *
- * @param view - Discovered view to build.
- * @param options - Project paths and Vite config.
- * @param emptyOutDir - Whether to wipe the views output directory first.
+ * Build one view into hashed assets on disk, then record view-relative paths
+ * in the manifest (served over HTTP at runtime).
  */
-async function buildInlineView(
+async function buildExternalView(
   view: DiscoveredView,
   options: {
     cwd: string;
@@ -131,7 +179,6 @@ async function buildInlineView(
         input: { [view.name]: virtualViewId(view.name) },
         output: {
           format: "es",
-          // Rolldown: prefer codeSplitting:false over deprecated inlineDynamicImports.
           codeSplitting: false,
           entryFileNames: "assets/[name]-[hash].js",
           assetFileNames: "assets/[name]-[hash][extname]",
@@ -180,13 +227,11 @@ async function buildInlineView(
     );
   }
 
-  const js = await readFile(join(viewOutDir, jsFileName), "utf8");
-  const css =
-    cssFileName !== undefined
-      ? await readFile(join(viewOutDir, cssFileName), "utf8")
-      : "";
-
-  return { kind: "inline", js, css };
+  return {
+    kind: "external",
+    entry: jsFileName.replace(/^\/+/, ""),
+    css: cssFileName !== undefined ? [cssFileName.replace(/^\/+/, "")] : [],
+  };
 }
 
 /**
@@ -218,6 +263,7 @@ export async function runBuild(options: BuildOptions): Promise<void> {
   const paths = resolveWorkspacePaths(options.cwd);
   const views = discoverViews(options.cwd);
   const userViteConfig = resolveUserViteConfig(options.cwd);
+  const inspector = options.withInspector === true;
 
   if (views.length === 0) {
     await build({
@@ -250,7 +296,7 @@ export async function runBuild(options: BuildOptions): Promise<void> {
       buildId: randomBytes(8).toString("hex"),
       entryPoint: BUILD_ENTRY_NAME,
       createdAt: new Date().toISOString(),
-      inspector: true,
+      inspector,
     };
     await mkdir(paths.build, { recursive: true });
     await writeFile(
@@ -266,20 +312,57 @@ export async function runBuild(options: BuildOptions): Promise<void> {
     return;
   }
 
-  // Views build: wipe output, one self-contained client build per view, then SSR wrapper.
   await rm(paths.build, { recursive: true, force: true });
 
   const viewsOutDir = join(paths.build, "views");
   await mkdir(viewsOutDir, { recursive: true });
 
+  const bindingServer = await createBindingValidationServer(
+    options.cwd,
+    paths.cache,
+    false
+  );
+  let buildBasePath: string;
+  try {
+    buildBasePath = await resolveBuildBasePath(
+      bindingServer.environments.ssr,
+      entry
+    );
+  } catch (error) {
+    await bindingServer.close();
+    throw error;
+  }
+
   const viewsManifest: ViewsManifest = {};
+  const buildAssetsBase = readBuildAssetsBase();
   for (const view of views) {
-    viewsManifest[view.name] = await buildInlineView(view, {
+    let manifestEntry = await buildExternalView(view, {
       cwd: options.cwd,
       cacheDir: paths.cache,
       viewsOutDir,
       userViteConfig,
     });
+    if (buildAssetsBase !== undefined) {
+      manifestEntry = applyBuildAssetsPrefix(
+        manifestEntry,
+        view.name,
+        buildAssetsBase,
+        buildBasePath
+      );
+    }
+    viewsManifest[view.name] = manifestEntry;
+  }
+
+  if (buildAssetsBase !== undefined) {
+    console.log(
+      `[mcp-use] MCP_ASSETS_URL set — manifest uses CDN URLs; upload ` +
+        `${relative(options.cwd, viewsOutDir)}/ to your asset host.`
+    );
+    if (buildBasePath !== "/mcp") {
+      console.log(
+        `[mcp-use] CDN manifest uses basePath ${buildBasePath} from server entry`
+      );
+    }
   }
 
   const publicSrc = join(options.cwd, "public");
@@ -287,11 +370,6 @@ export async function runBuild(options: BuildOptions): Promise<void> {
     await cp(publicSrc, join(viewsOutDir, "public"), { recursive: true });
   }
 
-  const bindingServer = await createBindingValidationServer(
-    options.cwd,
-    paths.cache,
-    false
-  );
   try {
     await validateViewBindingsAtBuild(
       bindingServer.environments.ssr,
@@ -338,8 +416,7 @@ export async function runBuild(options: BuildOptions): Promise<void> {
     buildId: randomBytes(8).toString("hex"),
     entryPoint: BUILD_ENTRY_NAME,
     createdAt: new Date().toISOString(),
-    inspector: true,
-    views: viewsManifest,
+    inspector,
   };
   await mkdir(paths.build, { recursive: true });
   await writeFile(

--- a/libraries/typescript/packages/server/src/cli/views-bindings.ts
+++ b/libraries/typescript/packages/server/src/cli/views-bindings.ts
@@ -6,6 +6,11 @@ import { createServerModuleRunner, type DevEnvironment } from "vite";
 
 import type { ViewsManifest } from "../views/types.js";
 
+const DEFAULT_BASE_PATH = "/mcp";
+
+/** Synthetic origin for entry evaluation when OAuth needs MCP_URL at import. */
+const BUILD_ENTRY_MCP_URL = "http://localhost:3000";
+
 /**
  * Duck-typed server shape needed for binding validation.
  *
@@ -14,6 +19,51 @@ import type { ViewsManifest } from "../views/types.js";
 interface ServerLike {
   getHandler(): unknown;
   __primeViews(views: ViewsManifest, options?: { dev?: boolean }): void;
+  basePath?: string;
+}
+
+/**
+ * Import the server entry and read `basePath` from the default export.
+ *
+ * Does not prime views or call `getHandler()`. Sets a synthetic `MCP_URL` only
+ * when unset so OAuth entries can construct during build introspection.
+ *
+ * @internal
+ */
+export async function resolveBuildBasePath(
+  environment: DevEnvironment,
+  entry: string
+): Promise<string> {
+  const runner = createServerModuleRunner(environment, {
+    hmr: false,
+    sourcemapInterceptor: "node",
+  });
+
+  const previousMcpUrl = process.env["MCP_URL"];
+  try {
+    if (previousMcpUrl === undefined) {
+      process.env["MCP_URL"] = BUILD_ENTRY_MCP_URL;
+    }
+
+    const serverModule = (await runner.import(entry)) as {
+      default?: ServerLike;
+    };
+    const server = serverModule.default;
+    if (server === null || typeof server !== "object") {
+      throw new Error(
+        "The server entry must default-export the MCPServer instance."
+      );
+    }
+
+    return server.basePath ?? DEFAULT_BASE_PATH;
+  } finally {
+    if (previousMcpUrl === undefined) {
+      delete process.env["MCP_URL"];
+    } else {
+      process.env["MCP_URL"] = previousMcpUrl;
+    }
+    await runner.close();
+  }
 }
 
 /**

--- a/libraries/typescript/packages/server/src/cli/workspace.ts
+++ b/libraries/typescript/packages/server/src/cli/workspace.ts
@@ -29,8 +29,6 @@
 
 import { join } from "node:path";
 
-import type { ViewsManifest } from "../views/types.js";
-
 /**
  * Fixed name of the per-project workspace directory.
  *
@@ -63,17 +61,10 @@ export interface BuildManifest {
   /** ISO-8601 timestamp of when the build finished. */
   createdAt: string;
   /**
-   * Whether the built server mounts the inspector shell route. Currently
-   * always written as `true` (not introspected from the server config) and
-   * consumed by nothing — the built server's own `MCPServer` config governs
-   * the route at runtime. Recorded as a known gap in CLI_SPEC.md § build.
+   * Whether the build was created with `mcp-use build --with-inspector`.
+   * Consumed by `mcp-use start` to decide whether to mount the inspector shell.
    */
   inspector: boolean;
-  /**
-   * Built views map (VIEWS_SPEC.md § Manifest). Present only when the project
-   * has view entries under `resources/<name>/view.tsx`.
-   */
-  views?: ViewsManifest;
 }
 
 /**

--- a/libraries/typescript/packages/server/src/server.ts
+++ b/libraries/typescript/packages/server/src/server.ts
@@ -71,14 +71,16 @@ import { resolveToolInputSchema } from "./tools.js";
 import type { ViewResourceFacts } from "./views/types.js";
 import {
   createViewPublicHandler,
+  createViewAssetsHandler,
   registerViews,
-  resolveRequestOrigin,
+  resolveAssetsBase,
   synthesizeViewDocument,
   viewResourceConfig,
   viewResourceUri,
   buildResourceUiMeta,
   buildToolResultUiMeta,
   buildToolUiMeta,
+  type BuildResourceUiMetaOptions,
   type ViewManifestEntry,
   type ViewsManifest,
 } from "./views/index.js";
@@ -780,6 +782,25 @@ export class MCPServer<TUser = never> {
         });
       }
 
+      if (!this.#viewsDevMode) {
+        const viewAssetsHandler = createViewAssetsHandler(
+          basePath,
+          this.#views,
+          { projectRoot: this.#viewsProjectRoot }
+        );
+        if (viewAssetsHandler !== undefined) {
+          routes.push({
+            match: (request) =>
+              request.method === "GET" || request.method === "HEAD"
+                ? new URL(request.url).pathname.startsWith(
+                    `${basePath}/_mcp-use/views/`
+                  )
+                : false,
+            handler: viewAssetsHandler,
+          });
+        }
+      }
+
       const inspectorHandler = createInspectorHandler(this.#config.inspector, {
         serverName: this.#config.name,
         basePath,
@@ -914,8 +935,10 @@ export class MCPServer<TUser = never> {
     );
 
     const request = ctx.requestInfo;
-    const servingOrigin =
-      request !== undefined ? resolveRequestOrigin(request) : "";
+    const viewMetaOptions =
+      request !== undefined
+        ? { request, hmrWs: this.#viewsDevMode }
+        : { hmrWs: this.#viewsDevMode };
     const basePath = this.#basePath();
 
     for (const entry of this.#tools.values()) {
@@ -935,7 +958,7 @@ export class MCPServer<TUser = never> {
         server,
         viewName,
         viewEntry,
-        servingOrigin,
+        viewMetaOptions,
         basePath
       );
     }
@@ -1010,20 +1033,18 @@ export class MCPServer<TUser = never> {
     server: SdkMcpServer,
     viewName: string,
     entry: ViewManifestEntry,
-    servingOrigin: string,
+    metaOptions: { request?: Request; hmrWs?: boolean },
     basePath: string
   ): void {
     const uri = viewResourceUri(viewName);
     const authorFacts = this.#viewResourceFacts(
       this.#viewBindings.get(viewName)?.config
     );
-    const hmrWs = this.#viewsDevMode;
     const resourceConfig = viewResourceConfig(
       viewName,
       entry,
       authorFacts,
-      servingOrigin,
-      { hmrWs }
+      metaOptions
     );
     server.registerResource(
       viewName,
@@ -1031,16 +1052,34 @@ export class MCPServer<TUser = never> {
       resourceConfig,
       async (readUri, ctx) => {
         const req = ctx.http?.req;
-        const origin =
-          req !== undefined ? resolveRequestOrigin(req) : servingOrigin;
-        const html = synthesizeViewDocument(entry, origin, basePath);
+        const readOptions: BuildResourceUiMetaOptions =
+          req !== undefined
+            ? {
+                request: req,
+                ...(metaOptions.hmrWs === true ? { hmrWs: true } : {}),
+              }
+            : metaOptions.hmrWs === true
+              ? { hmrWs: true }
+              : {};
+        const assetsBase =
+          req !== undefined
+            ? resolveAssetsBase(req)
+            : metaOptions.request !== undefined
+              ? resolveAssetsBase(metaOptions.request)
+              : "";
+        const html = synthesizeViewDocument(
+          entry,
+          assetsBase,
+          basePath,
+          viewName
+        );
         return {
           contents: [
             {
               uri: readUri.href,
               mimeType: resourceConfig.mimeType,
               text: html,
-              _meta: buildResourceUiMeta(authorFacts, origin, { hmrWs }),
+              _meta: buildResourceUiMeta(authorFacts, readOptions),
             },
           ],
         };

--- a/libraries/typescript/packages/server/src/views/csp-env.ts
+++ b/libraries/typescript/packages/server/src/views/csp-env.ts
@@ -1,0 +1,154 @@
+import type { McpUiResourceCsp } from "@modelcontextprotocol/ext-apps";
+
+import type { ViewResourceFacts } from "./types.js";
+
+type CspCategory =
+  | "connectDomains"
+  | "resourceDomains"
+  | "frameDomains"
+  | "baseUriDomains";
+
+const CATEGORY_ENV: Record<CspCategory, string> = {
+  connectDomains: "CSP_CONNECT_DOMAINS",
+  resourceDomains: "CSP_RESOURCE_DOMAINS",
+  frameDomains: "CSP_FRAME_DOMAINS",
+  baseUriDomains: "CSP_BASE_URI_DOMAINS",
+};
+
+/** Parse a comma-separated env var into trimmed non-empty domain strings. */
+export function parseDomainList(raw: string | undefined): string[] {
+  if (raw === undefined || raw.trim() === "") {
+    return [];
+  }
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+function readEnvDomains(name: string): string[] | undefined {
+  if (typeof process === "undefined") {
+    return undefined;
+  }
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") {
+    return undefined;
+  }
+  return parseDomainList(raw);
+}
+
+/** Domains from `CSP_URLS` (shortcut for all categories). */
+export function readCspUrlsShortcut(): string[] {
+  return readEnvDomains("CSP_URLS") ?? [];
+}
+
+/** Per-category env override, or `CSP_URLS` when the category var is unset. */
+export function readEnvDomainsForCategory(category: CspCategory): string[] {
+  const perCategory = readEnvDomains(CATEGORY_ENV[category]);
+  if (perCategory !== undefined) {
+    return perCategory;
+  }
+  return readCspUrlsShortcut();
+}
+
+/**
+ * Merge domain lists: earlier segments win on duplicate (higher priority).
+ */
+export function mergeDomainLists(...segments: string[][]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const segment of segments) {
+    for (const domain of segment) {
+      if (!seen.has(domain)) {
+        seen.add(domain);
+        out.push(domain);
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Resolved origins and flags used when merging author, env, and MCP CSP domains.
+ *
+ * @internal
+ */
+export interface BuildCspOptions {
+  /** Public server origin from `MCP_URL` or forwarded request headers. */
+  serverOrigin: string;
+  /** Assets origin derived from `MCP_ASSETS_URL` or the server origin. */
+  assetsOrigin: string;
+  /** When false, server origin is appended to resourceDomains (same-origin assets). */
+  explicitAssetsBase: boolean;
+  /** When true, append the server origin's websocket variant for Vite HMR. */
+  hmrWs?: boolean;
+}
+
+function toWebSocketOrigin(serverOrigin: string): string {
+  if (serverOrigin.startsWith("https://")) {
+    return `wss://${serverOrigin.slice("https://".length)}`;
+  }
+  if (serverOrigin.startsWith("http://")) {
+    return `ws://${serverOrigin.slice("http://".length)}`;
+  }
+  return serverOrigin;
+}
+
+/**
+ * Build final `_meta.ui.csp` from author facts, env vars, and MCP auto-append.
+ *
+ * Precedence (high → low): author → env (`CSP_*_DOMAINS` or `CSP_URLS`) →
+ * MCP auto-append (lowest).
+ */
+export function buildMergedResourceCsp(
+  authorFacts: ViewResourceFacts | undefined,
+  options: BuildCspOptions
+): McpUiResourceCsp {
+  const author = authorFacts?.csp;
+
+  const mcpConnectAuto: string[] = [];
+  if (options.serverOrigin !== "") {
+    mcpConnectAuto.push(options.serverOrigin);
+    if (options.hmrWs === true) {
+      mcpConnectAuto.push(toWebSocketOrigin(options.serverOrigin));
+    }
+  }
+
+  const mcpResourceAuto: string[] = [];
+  const resourceOrigin = options.explicitAssetsBase
+    ? options.assetsOrigin
+    : options.serverOrigin;
+  if (resourceOrigin !== "") {
+    mcpResourceAuto.push(resourceOrigin);
+  }
+
+  const connectDomains = mergeDomainLists(
+    author?.connectDomains ?? [],
+    readEnvDomainsForCategory("connectDomains"),
+    mcpConnectAuto
+  );
+
+  const resourceDomains = mergeDomainLists(
+    author?.resourceDomains ?? [],
+    readEnvDomainsForCategory("resourceDomains"),
+    mcpResourceAuto
+  );
+
+  const frameDomains = mergeDomainLists(
+    author?.frameDomains ?? [],
+    readEnvDomainsForCategory("frameDomains")
+  );
+
+  const baseUriDomains = mergeDomainLists(
+    author?.baseUriDomains ?? [],
+    readEnvDomainsForCategory("baseUriDomains")
+  );
+
+  return {
+    ...author,
+    connectDomains,
+    resourceDomains,
+    frameDomains,
+    baseUriDomains,
+  };
+}

--- a/libraries/typescript/packages/server/src/views/document.ts
+++ b/libraries/typescript/packages/server/src/views/document.ts
@@ -23,14 +23,55 @@ export function resolveAssetUrl(assetPath: string, origin: string): string {
 }
 
 /**
+ * Build the HTTP path prefix for a view's built assets (no origin).
+ *
+ * @param basePath - MCP mount prefix (e.g. `/mcp`).
+ * @param viewName - View directory / manifest key.
+ */
+export function viewAssetsBasePath(basePath: string, viewName: string): string {
+  return `${basePath}/_mcp-use/views/${viewName}/`;
+}
+
+/**
+ * Resolve a production or dev external asset path to an absolute URL.
+ *
+ * @param assetPath - Full CDN URL, origin-absolute dev path (`/…`), or
+ *   view-relative production path (`assets/…`).
+ * @param assetsBase - Assets URL prefix (origin + optional path).
+ * @param basePath - MCP mount prefix.
+ * @param viewName - View directory / manifest key (required for view-relative paths).
+ */
+export function resolveExternalAssetUrl(
+  assetPath: string,
+  assetsBase: string,
+  basePath: string,
+  viewName: string
+): string {
+  if (
+    assetPath.startsWith("http://") ||
+    assetPath.startsWith("https://") ||
+    assetPath.startsWith("data:")
+  ) {
+    return assetPath;
+  }
+  if (assetPath.startsWith("/")) {
+    return resolveAssetUrl(assetPath, assetsBase);
+  }
+  return `${assetsBase}${viewAssetsBasePath(basePath, viewName)}${assetPath.replace(/^\/+/, "")}`;
+}
+
+/**
  * Resolve the absolute URL prefix for the project's `public/` directory.
  *
- * @param origin - Request-resolved public origin.
+ * @param assetsBase - Assets URL prefix (origin + optional path).
  * @param basePath - MCP mount prefix (e.g. `/mcp`).
  * @returns Absolute prefix with trailing slash.
  */
-export function resolvePublicBase(origin: string, basePath: string): string {
-  return `${origin}${basePath}/_mcp-use/public/`;
+export function resolvePublicBase(
+  assetsBase: string,
+  basePath: string
+): string {
+  return `${assetsBase}${basePath}/_mcp-use/public/`;
 }
 
 /**
@@ -66,21 +107,23 @@ function escapeHtml(value: string): string {
 /**
  * Synthesize a complete HTML document for a view from manifest data.
  *
- * Production (`kind: "inline"`) embeds JS and CSS directly so a srcdoc iframe
- * boots with zero network fetches for the view bundle. Dev
- * (`kind: "external"`) loads Vite module URLs for HMR.
+ * Production (`kind: "external"`) loads built assets over HTTP with absolute
+ * URLs. Legacy `kind: "inline"` embeds JS/CSS directly. Dev uses Vite module
+ * URLs (`kind: "external"` with origin-absolute paths).
  *
  * @param entry - Primed manifest entry for the view.
- * @param origin - Request-resolved public origin for absolute asset URLs.
+ * @param assetsBase - Request-resolved assets URL prefix for absolute asset URLs.
  * @param basePath - MCP mount prefix (e.g. `/mcp`).
+ * @param viewName - View directory / manifest key (required for production external paths).
  */
 export function synthesizeViewDocument(
   entry: ViewManifestEntry,
-  origin: string,
-  basePath: string
+  assetsBase: string,
+  basePath: string,
+  viewName?: string
 ): string {
   const viewConfig: McpUseViewConfig = {
-    publicBase: resolvePublicBase(origin, basePath),
+    publicBase: resolvePublicBase(assetsBase, basePath),
   };
   const configScript = `<script>globalThis.__mcpUseViewConfig=${JSON.stringify(viewConfig)};</script>`;
 
@@ -104,21 +147,32 @@ ${moduleScript}
 </html>`;
   }
 
+  if (viewName === undefined) {
+    throw new Error(
+      "viewName is required when synthesizing an external view document."
+    );
+  }
+
   const cssLinks = entry.css
     .map(
       (path) =>
-        `<link rel="stylesheet" href="${escapeHtml(resolveAssetUrl(path, origin))}">`
+        `<link rel="stylesheet" href="${escapeHtml(resolveExternalAssetUrl(path, assetsBase, basePath, viewName))}">`
     )
     .join("\n");
 
   const scriptTags = (entry.scripts ?? [])
     .map(
       (path) =>
-        `<script type="module" src="${escapeHtml(resolveAssetUrl(path, origin))}"></script>`
+        `<script type="module" src="${escapeHtml(resolveExternalAssetUrl(path, assetsBase, basePath, viewName))}"></script>`
     )
     .join("\n");
 
-  const entryUrl = resolveAssetUrl(entry.entry, origin);
+  const entryUrl = resolveExternalAssetUrl(
+    entry.entry,
+    assetsBase,
+    basePath,
+    viewName
+  );
 
   return `<!doctype html>
 <html>

--- a/libraries/typescript/packages/server/src/views/index.ts
+++ b/libraries/typescript/packages/server/src/views/index.ts
@@ -17,8 +17,15 @@ export type {
   ViewsManifest,
 } from "./types.js";
 export { synthesizeViewDocument, resolveAssetUrl } from "./document.js";
-export { resolveRequestOrigin } from "./origin.js";
-export { createViewPublicHandler } from "./routes.js";
+export {
+  resolveRequestOrigin,
+  resolveServerOrigin,
+  resolveAssetsBase,
+  originFromAssetsBase,
+  hasExplicitAssetsBase,
+} from "./origin.js";
+export { parseDomainList, buildMergedResourceCsp } from "./csp-env.js";
+export { createViewPublicHandler, createViewAssetsHandler } from "./routes.js";
 export {
   extractClientCapabilitiesFromBody,
   getStashedClientCapabilities,
@@ -30,4 +37,5 @@ export {
   buildToolResultUiMeta,
   buildToolUiMeta,
   viewResourceConfig,
+  type BuildResourceUiMetaOptions,
 } from "./wire.js";

--- a/libraries/typescript/packages/server/src/views/origin.ts
+++ b/libraries/typescript/packages/server/src/views/origin.ts
@@ -1,17 +1,49 @@
 /**
- * Resolve the public origin for a request — used to build absolute asset URLs
- * in synthesized view documents and CSP metadata.
+ * Resolve public origins and asset URL prefixes for view documents and CSP.
  *
- * Resolution order:
- * 1. Standard `Forwarded` header (`proto` / `host`)
- * 2. `X-Forwarded-Proto` + `X-Forwarded-Host`
- * 3. The request URL's own origin
+ * **Server origin** (`resolveServerOrigin`): MCP endpoint / API base — OAuth
+ * resource identity, `connectDomains`, dev HMR websocket host.
  *
- * @remarks
- * An explicit deployment override (v1's `MCP_URL` / a future `publicUrl`
- * config) is deliberately not implemented — see VIEWS_SPEC.md open questions.
+ * **Assets base** (`resolveAssetsBase`): prefix for view JS/CSS and
+ * `public/` URLs — may include a path (CDN bucket prefix).
  */
-export function resolveRequestOrigin(request: Request): string {
+
+/** Strip trailing slashes from a URL prefix. */
+export function stripTrailingSlashes(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+function readEnv(name: string): string | undefined {
+  if (typeof process === "undefined") {
+    return undefined;
+  }
+  const value = process.env[name];
+  return value !== undefined && value !== "" ? value : undefined;
+}
+
+function parseForwardedHeader(header: string): string | undefined {
+  for (const part of header.split(",")) {
+    const params = new Map<string, string>();
+    for (const token of part.split(";")) {
+      const [key, ...rest] = token.trim().split("=");
+      if (key === undefined || rest.length === 0) {
+        continue;
+      }
+      params.set(key.toLowerCase(), rest.join("=").replace(/^"|"$/g, ""));
+    }
+    const proto = params.get("proto");
+    const host = params.get("host");
+    if (proto !== undefined && host !== undefined) {
+      return `${proto}://${host}`;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Resolve origin from forwarded headers or the request URL (no env override).
+ */
+export function resolveRequestOriginFromHeaders(request: Request): string {
   const forwarded = request.headers.get("forwarded");
   if (forwarded !== null) {
     const fromForwarded = parseForwardedHeader(forwarded);
@@ -37,21 +69,76 @@ export function resolveRequestOrigin(request: Request): string {
   return new URL(request.url).origin;
 }
 
-function parseForwardedHeader(header: string): string | undefined {
-  for (const part of header.split(",")) {
-    const params = new Map<string, string>();
-    for (const token of part.split(";")) {
-      const [key, ...rest] = token.trim().split("=");
-      if (key === undefined || rest.length === 0) {
-        continue;
-      }
-      params.set(key.toLowerCase(), rest.join("=").replace(/^"|"$/g, ""));
-    }
-    const proto = params.get("proto");
-    const host = params.get("host");
-    if (proto !== undefined && host !== undefined) {
-      return `${proto}://${host}`;
+/**
+ * Server public origin — `MCP_URL` when valid, else forwarded/request origin.
+ *
+ * Uses `.origin` only (path suffix on `MCP_URL` is ignored).
+ */
+export function resolveServerOrigin(request: Request): string {
+  const mcpUrl = readEnv("MCP_URL");
+  if (mcpUrl !== undefined) {
+    try {
+      return new URL(mcpUrl).origin;
+    } catch {
+      // Fall through when MCP_URL is malformed.
     }
   }
-  return undefined;
+  return resolveRequestOriginFromHeaders(request);
+}
+
+/**
+ * Extract the origin from an assets URL prefix (origin + optional path).
+ */
+export function originFromAssetsBase(assetsBase: string): string {
+  try {
+    return new URL(assetsBase).origin;
+  } catch {
+    return assetsBase;
+  }
+}
+
+/**
+ * Normalize `MCP_ASSETS_URL` to a URL prefix without trailing slash.
+ */
+export function normalizeAssetsBaseUrl(value: string): string {
+  return stripTrailingSlashes(value);
+}
+
+/**
+ * Assets URL prefix for view JS/CSS and `public/` — `MCP_ASSETS_URL` when set,
+ * else server origin from {@link resolveServerOrigin}.
+ */
+export function resolveAssetsBase(request: Request): string {
+  const assetsUrl = readEnv("MCP_ASSETS_URL");
+  if (assetsUrl !== undefined) {
+    try {
+      return normalizeAssetsBaseUrl(new URL(assetsUrl).href.replace(/\/$/, ""));
+    } catch {
+      // Fall through when MCP_ASSETS_URL is malformed.
+    }
+  }
+  return resolveServerOrigin(request);
+}
+
+/**
+ * @deprecated Alias for {@link resolveServerOrigin} — kept for OAuth callers.
+ */
+export function resolveRequestOrigin(request: Request): string {
+  return resolveServerOrigin(request);
+}
+
+/**
+ * Whether `MCP_ASSETS_URL` is explicitly configured (distinct from server).
+ */
+export function hasExplicitAssetsBase(): boolean {
+  const assetsUrl = readEnv("MCP_ASSETS_URL");
+  if (assetsUrl === undefined) {
+    return false;
+  }
+  try {
+    new URL(assetsUrl);
+    return true;
+  } catch {
+    return false;
+  }
 }

--- a/libraries/typescript/packages/server/src/views/routes.ts
+++ b/libraries/typescript/packages/server/src/views/routes.ts
@@ -7,6 +7,64 @@ import type { ViewManifestEntry } from "./types.js";
 
 const PUBLIC_BUILD_DIR = ".mcp-use/build/views/public";
 const PUBLIC_DEV_DIR = "public";
+const VIEW_ASSETS_BUILD_ROOT = ".mcp-use/build/views";
+
+/**
+ * Fetch handler for built view bundles under
+ * `${basePath}/_mcp-use/views/<name>/…`.
+ *
+ * Production only — dev serves view modules through Vite middleware.
+ *
+ * @param basePath - MCP mount prefix (e.g. `/mcp`).
+ * @param views - Primed view registry; empty skips mounting.
+ * @param options - `projectRoot` defaults to `process.cwd()`.
+ *
+ * @internal
+ */
+export function createViewAssetsHandler(
+  basePath: string,
+  views: ReadonlyMap<string, ViewManifestEntry>,
+  options?: { projectRoot?: string }
+): FetchHandler | undefined {
+  if (views.size === 0) {
+    return undefined;
+  }
+
+  const assetsPrefix = `${basePath}/_mcp-use/views`;
+  const projectRoot = options?.projectRoot ?? process.cwd();
+
+  return async (request) => {
+    if (request.method !== "GET" && request.method !== "HEAD") {
+      return new Response("Method Not Allowed", { status: 405 });
+    }
+    if (!matchesPathPrefix(request, assetsPrefix)) {
+      return new Response("Not Found", { status: 404 });
+    }
+
+    const pathname = pathnameOf(request);
+    const remainder = pathname.slice(assetsPrefix.length + 1);
+    const slash = remainder.indexOf("/");
+    if (slash <= 0 || slash === remainder.length - 1) {
+      return new Response("Not Found", { status: 404 });
+    }
+
+    const viewName = remainder.slice(0, slash);
+    const subpath = remainder.slice(slash + 1);
+    const entry = views.get(viewName);
+    if (entry === undefined || entry.kind !== "external") {
+      return new Response("Not Found", { status: 404 });
+    }
+
+    const [{ join }, { resolvePublicFilePath, servePublicFile }] =
+      await Promise.all([import("node:path"), import("./public-route.js")]);
+    const viewRoot = join(projectRoot, VIEW_ASSETS_BUILD_ROOT, viewName);
+    const diskPath = await resolvePublicFilePath(viewRoot, subpath);
+    if (diskPath === null) {
+      return new Response("Not Found", { status: 404 });
+    }
+    return await servePublicFile(diskPath);
+  };
+}
 
 /**
  * Fetch handler for public view assets under `${basePath}/_mcp-use/public/`.

--- a/libraries/typescript/packages/server/src/views/types.ts
+++ b/libraries/typescript/packages/server/src/views/types.ts
@@ -58,13 +58,16 @@ export interface InlineViewManifestEntry {
 /**
  * Dev manifest entry: Vite client-environment module URLs loaded by the
  * synthesized document (HMR / Fast Refresh).
+ *
+ * Production builds emit the same shape with view-relative asset paths
+ * (`assets/…`) served from `${basePath}/_mcp-use/views/<name>/`.
  */
 export interface ExternalViewManifestEntry {
   /** Discriminant for the dev external-module shape. */
   kind: "external";
   /**
-   * Origin-absolute URL path starting with `/` — the Vite client-env module
-   * URL for the view's virtual entry.
+   * Module entry path. Dev: origin-absolute Vite URL (`/…`). Production:
+   * view-relative path under `.mcp-use/build/views/<name>/` (`assets/…`).
    */
   entry: string;
   /**
@@ -84,8 +87,8 @@ export interface ExternalViewManifestEntry {
 /**
  * One entry in the primed views manifest.
  *
- * Production builds emit {@link InlineViewManifestEntry}; `mcp-use dev` emits
- * {@link ExternalViewManifestEntry}.
+ * Production builds emit {@link ExternalViewManifestEntry} with view-relative
+ * asset paths; `mcp-use dev` emits origin-absolute Vite URLs.
  */
 export type ViewManifestEntry =
   | InlineViewManifestEntry

--- a/libraries/typescript/packages/server/src/views/wire.ts
+++ b/libraries/typescript/packages/server/src/views/wire.ts
@@ -5,6 +5,13 @@ import {
   UI_RESOURCE_URI_META_KEY,
   viewResourceUri,
 } from "./constants.js";
+import { buildMergedResourceCsp, type BuildCspOptions } from "./csp-env.js";
+import {
+  hasExplicitAssetsBase,
+  originFromAssetsBase,
+  resolveAssetsBase,
+  resolveServerOrigin,
+} from "./origin.js";
 
 /**
  * Tool declaration `_meta` for `tools/list`.
@@ -74,76 +81,51 @@ export function buildToolResultUiMeta(
  * @internal
  */
 export interface BuildResourceUiMetaOptions {
+  /** Request used to resolve server/assets origins when not passed explicitly. */
+  request?: Request;
+  /** Explicit server origin (overrides request resolution). */
+  serverOrigin?: string;
+  /** Explicit assets URL prefix (overrides request resolution). */
+  assetsBase?: string;
   /**
-   * When true, append the serving origin's websocket variant
-   * (`http:` → `ws:`, `https:` → `wss:`) to `csp.connectDomains` for Vite
-   * HMR under host-enforced CSP.
+   * When true, append the server origin's websocket variant to
+   * `csp.connectDomains` for Vite HMR under host-enforced CSP.
    */
   hmrWs?: boolean;
 }
 
-/**
- * Derive a websocket origin from an HTTP(S) serving origin.
- *
- * @param servingOrigin - Request-resolved `http://` or `https://` origin.
- * @returns The corresponding `ws://` or `wss://` origin.
- */
-function toWebSocketOrigin(servingOrigin: string): string {
-  if (servingOrigin.startsWith("https://")) {
-    return `wss://${servingOrigin.slice("https://".length)}`;
-  }
-  if (servingOrigin.startsWith("http://")) {
-    return `ws://${servingOrigin.slice("http://".length)}`;
-  }
-  return servingOrigin;
+function resolveCspOptions(
+  options?: BuildResourceUiMetaOptions
+): BuildCspOptions {
+  const request = options?.request;
+  const serverOrigin =
+    options?.serverOrigin ??
+    (request !== undefined ? resolveServerOrigin(request) : "");
+  const assetsBase =
+    options?.assetsBase ??
+    (request !== undefined ? resolveAssetsBase(request) : serverOrigin);
+
+  return {
+    serverOrigin,
+    assetsOrigin: originFromAssetsBase(assetsBase),
+    explicitAssetsBase: hasExplicitAssetsBase(),
+    ...(options?.hmrWs === true ? { hmrWs: true as const } : {}),
+  };
 }
 
 /**
  * Resource `_meta.ui` for a primed view.
  *
- * Emits `csp` by spreading author-declared fields from the bound tool's
- * `view:` config (including `frameDomains` and `baseUriDomains`) with
- * `connectDomains` defaulting to `[]` and the request-derived serving origin
- * appended to `resourceDomains` when non-empty. When `options.hmrWs` is
- * true, the serving origin's websocket variant is appended to
- * `connectDomains` (after author-declared entries, without duplication).
- * `permissions`, `domain`, and `prefersBorder` are included only when the
- * author set them.
- *
- * @param authorFacts - Resource facts from the bound tool's `view:` config, or
- * `undefined` for unbound views (auto CSP only).
- * @param servingOrigin - Request-resolved asset origin appended to
- * `csp.resourceDomains` and, when `options.hmrWs`, used to derive the HMR
- * websocket origin for `csp.connectDomains`.
- * @param options - Optional emission flags (dev HMR websocket origin).
+ * Emits `csp` by merging author `view.csp`, env (`CSP_URLS` / `CSP_*_DOMAINS`),
+ * and MCP auto-append (`MCP_URL` → connect; assets origin → resource).
  */
 export function buildResourceUiMeta(
   authorFacts: ViewResourceFacts | undefined,
-  servingOrigin: string,
   options?: BuildResourceUiMetaOptions
 ): Record<string, unknown> {
-  const authorResourceDomains = authorFacts?.csp?.resourceDomains ?? [];
-  const resourceDomains = [
-    ...authorResourceDomains,
-    ...(servingOrigin !== "" ? [servingOrigin] : []),
-  ];
+  const csp = buildMergedResourceCsp(authorFacts, resolveCspOptions(options));
 
-  const authorConnectDomains = authorFacts?.csp?.connectDomains ?? [];
-  const connectDomains = [...authorConnectDomains];
-  if (options?.hmrWs === true && servingOrigin !== "") {
-    const wsOrigin = toWebSocketOrigin(servingOrigin);
-    if (!connectDomains.includes(wsOrigin)) {
-      connectDomains.push(wsOrigin);
-    }
-  }
-
-  const ui: Record<string, unknown> = {
-    csp: {
-      ...authorFacts?.csp,
-      connectDomains,
-      resourceDomains,
-    },
-  };
+  const ui: Record<string, unknown> = { csp };
 
   if (authorFacts?.permissions !== undefined) {
     ui["permissions"] = authorFacts.permissions;
@@ -160,19 +142,11 @@ export function buildResourceUiMeta(
 
 /**
  * Listing metadata for a primed view resource.
- *
- * @param _viewName - View directory / manifest key (reserved for future use).
- * @param _entry - Primed manifest entry (reserved for future use).
- * @param authorFacts - Resource facts from the bound tool's `view:` config.
- * @param servingOrigin - Request-resolved asset origin for CSP emission.
- * @param options - Optional emission flags forwarded to
- * {@link buildResourceUiMeta}.
  */
 export function viewResourceConfig(
   _viewName: string,
   _entry: ViewManifestEntry,
   authorFacts: ViewResourceFacts | undefined,
-  servingOrigin: string,
   options?: BuildResourceUiMetaOptions
 ): {
   mimeType: string;
@@ -184,6 +158,6 @@ export function viewResourceConfig(
     ...(authorFacts?.description !== undefined && {
       description: authorFacts.description,
     }),
-    _meta: buildResourceUiMeta(authorFacts, servingOrigin, options),
+    _meta: buildResourceUiMeta(authorFacts, options),
   };
 }

--- a/libraries/typescript/packages/server/tests/bin-start.test.ts
+++ b/libraries/typescript/packages/server/tests/bin-start.test.ts
@@ -107,6 +107,11 @@ describe("parseArgs", () => {
     expect(parseArgs(["dev"]).open).toBe(true);
   });
 
+  it("parses --with-inspector for build", () => {
+    expect(parseArgs(["build", "--with-inspector"]).withInspector).toBe(true);
+    expect(parseArgs(["build"]).withInspector).toBe(false);
+  });
+
   it("parses help and version flags", () => {
     expect(parseArgs(["--help"]).help).toBe(true);
     expect(parseArgs(["-h"]).help).toBe(true);

--- a/libraries/typescript/packages/server/tests/budgets/cli-budget.test.ts
+++ b/libraries/typescript/packages/server/tests/budgets/cli-budget.test.ts
@@ -86,9 +86,9 @@ describe("published CLI boundaries", () => {
     }
   });
 
-  it("keeps dist/index.js under sixty KiB", async () => {
+  it("keeps dist/index.js under sixty-one KiB", async () => {
     const bytes = (await stat(new URL("index.js", DIST))).size;
-    expect(bytes).toBeLessThanOrEqual(60 * 1024);
+    expect(bytes).toBeLessThanOrEqual(61 * 1024);
   });
 
   it("keeps the unpacked framework artifact below five MiB", async () => {

--- a/libraries/typescript/packages/server/tests/cli/build.test.ts
+++ b/libraries/typescript/packages/server/tests/cli/build.test.ts
@@ -2,8 +2,8 @@
 import {
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
-  renameSync,
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
@@ -71,6 +71,26 @@ afterAll(() => {
   for (const dir of dirs) removeDir(dir);
 });
 
+function listViewAssets(
+  buildDir: string,
+  viewName: string
+): { entry: string; css: string[] } {
+  const assetsDir = join(buildDir, "views", viewName, "assets");
+  const files = readdirSync(assetsDir);
+  const js = files.find(
+    (file) => file.endsWith(".js") && !file.endsWith(".map.js")
+  );
+  if (js === undefined) {
+    throw new Error(`expected JS asset for view ${viewName}`);
+  }
+  return {
+    entry: `assets/${js}`,
+    css: files
+      .filter((file) => file.endsWith(".css"))
+      .map((file) => `assets/${file}`),
+  };
+}
+
 describe("runBuild", () => {
   it("emits an ESM bundle + manifest to .mcp-use/build and preserves the default export", async () => {
     const cwd = copyFixture("build");
@@ -90,7 +110,8 @@ describe("runBuild", () => {
     expect(manifest.entryPoint).toBe("index.js");
     expect(manifest.buildId).toMatch(/^[0-9a-f]{16}$/);
     expect(new Date(manifest.createdAt).getTime()).not.toBeNaN();
-    expect(manifest.inspector).toBe(true);
+    expect(manifest.inspector).toBe(false);
+    expect("views" in manifest).toBe(false);
 
     // packages:"external" semantics — bare imports stay external, only the
     // user's source is bundled.
@@ -199,25 +220,33 @@ describe("runBuild (views)", () => {
       readFileSync(join(buildDir, BUILD_MANIFEST_NAME), "utf8")
     ) as BuildManifest;
 
-    expect(manifest.views).toBeDefined();
-    const views = manifest.views!;
-    const product = views["product-search-result"];
-    expect(product).toBeDefined();
-    if (product === undefined) {
-      throw new Error("expected product-search-result manifest entry");
+    expect("views" in manifest).toBe(false);
+    const product = listViewAssets(buildDir, "product-search-result");
+    expect(product.entry).toMatch(/^assets\/.+\.js$/);
+    expect(product.css).toEqual(
+      expect.arrayContaining([expect.stringMatching(/^assets\/.+\.css$/)])
+    );
+    expect(product.entry.length).toBeGreaterThan(0);
+
+    const assetPath = join(
+      buildDir,
+      "views",
+      "product-search-result",
+      product.entry
+    );
+    expect(existsSync(assetPath)).toBe(true);
+    const assetJs = readFileSync(assetPath, "utf8");
+    expect(assetJs).toMatch(/bootstrapView|createElement|react/i);
+    if (product.css[0] !== undefined) {
+      const cssPath = join(
+        buildDir,
+        "views",
+        "product-search-result",
+        product.css[0]
+      );
+      expect(existsSync(cssPath)).toBe(true);
+      expect(readFileSync(cssPath, "utf8")).toContain("tailwindcss");
     }
-    expect(product).toMatchObject({
-      kind: "inline",
-      js: expect.any(String),
-      css: expect.any(String),
-    });
-    if (product.kind !== "inline") {
-      throw new Error("expected inline manifest entry");
-    }
-    expect(product.js.length).toBeGreaterThan(0);
-    expect(product.js).toMatch(/bootstrapView|createElement|react/i);
-    expect(product.css).toContain("tailwindcss");
-    expect(product.css).toMatch(/\.grid\{display:grid\}/);
 
     const publicFile = join(buildDir, "views", "public", "test.txt");
     expect(existsSync(publicFile)).toBe(true);
@@ -225,10 +254,9 @@ describe("runBuild (views)", () => {
 
     const entryCode = readFileSync(join(buildDir, "index.js"), "utf8");
     expect(entryCode).toMatch(/registerViews/);
-    // Wrapper bakes the inline JS/CSS strings into the module (no fs on MCP path).
-    // The SSR bundler may reformat the object literal (spaces after `:`).
-    expect(entryCode).toMatch(/"kind"\s*:\s*"inline"/);
-    expect(entryCode).toContain(product.js.slice(0, 40));
+    expect(entryCode).toMatch(/"kind"\s*:\s*"external"/);
+    expect(entryCode.length).toBeLessThan(100_000);
+    expect(entryCode).not.toContain(assetJs.slice(0, 40));
 
     const previousCwd = process.cwd();
     process.chdir(cwd);
@@ -239,9 +267,6 @@ describe("runBuild (views)", () => {
         default: { getHandler(): (request: Request) => Promise<Response> };
       };
       const handler = mod.default.getHandler();
-
-      const assetsBackup = join(buildDir, "views-assets-backup");
-      renameSync(join(buildDir, "views"), assetsBackup);
 
       const listBody = await handlerMcp(handler, "resources/list");
       const resources = (listBody["result"] as { resources: { uri: string }[] })
@@ -256,16 +281,22 @@ describe("runBuild (views)", () => {
       const text = (readBody["result"] as { contents: { text: string }[] })
         .contents[0]!.text;
       expect(text).toContain('id="root"');
-      expect(text).toContain('<script type="module">');
-      expect(text).toContain(product.js.slice(0, 80));
-      expect(text).not.toMatch(/<script[^>]+src=["'][^"']*\/assets\//);
+      expect(text).toMatch(/<script type="module" src="/);
+      expect(text).toContain("/mcp/_mcp-use/views/product-search-result/");
+      expect(text).toContain(product.entry);
+      expect(text).not.toMatch(/<script type="module">[\s\S]{80,}/);
       if (product.css.length > 0) {
-        expect(text).toContain("<style>");
+        expect(text).toMatch(/<link rel="stylesheet" href="/);
       }
 
-      // Public route needs the views/public tree on disk; restore after the
-      // MCP-path-without-fs check above.
-      renameSync(assetsBackup, join(buildDir, "views"));
+      const assetUrlMatch = text.match(/<script type="module" src="([^"]+)"/);
+      expect(assetUrlMatch).not.toBeNull();
+      const assetResponse = await handler(new Request(assetUrlMatch![1]!));
+      expect(assetResponse.status).toBe(200);
+      expect(assetResponse.headers.get("content-type")).toContain("javascript");
+      expect(await assetResponse.text()).toMatch(
+        /bootstrapView|createElement|react/i
+      );
 
       const publicOk = await handler(
         new Request("http://localhost/mcp/_mcp-use/public/test.txt")
@@ -301,9 +332,9 @@ describe("runBuild (views)", () => {
       expect(proxiedReadContent.text).toContain(
         "https://fruit.example.com/mcp/_mcp-use/public/"
       );
-      expect(proxiedReadContent.text).toContain('<script type="module">');
-      expect(proxiedReadContent.text).not.toMatch(
-        /<script[^>]+src=["'][^"']*\/assets\//
+      expect(proxiedReadContent.text).toMatch(/<script type="module" src="/);
+      expect(proxiedReadContent.text).toContain(
+        "https://fruit.example.com/mcp/_mcp-use/views/product-search-result/"
       );
       const readResourceDomains =
         proxiedReadContent._meta?.ui?.csp?.resourceDomains;
@@ -333,7 +364,26 @@ describe("runBuild (views)", () => {
     }
   }, 60_000);
 
-  it("escapes </script> in view source when inlining into the synthesized document", async () => {
+  it("escapes </script> in legacy inline module source", () => {
+    const html = synthesizeViewDocument(
+      {
+        kind: "inline",
+        js: 'const s = "</script>"; console.log(s);',
+        css: "",
+      },
+      "https://example.com",
+      "/mcp"
+    );
+    const moduleMatch = html.match(
+      /<script type="module">([\s\S]*?)<\/script>\s*<\/body>/
+    );
+    expect(moduleMatch).not.toBeNull();
+    const body = moduleMatch![1]!;
+    expect(body).not.toContain("</script>");
+    expect(body).toContain("<\\/script>");
+  });
+
+  it("builds a view that contains </script> in source as external assets", async () => {
     const cwd = copyFixture("build-views-escape", "views");
     dirs.push(cwd);
     mkdirSync(join(cwd, "resources", "escape-view"), { recursive: true });
@@ -347,7 +397,6 @@ describe("runBuild (views)", () => {
         ``,
       ].join("\n")
     );
-    // Bind the escape view so build validation passes (replace product binding).
     const entry = join(cwd, "src", "index.ts");
     const source = readFileSync(entry, "utf8");
     writeFileSync(
@@ -358,35 +407,26 @@ describe("runBuild (views)", () => {
     await runBuild({ cwd });
 
     const buildDir = join(cwd, WORKSPACE_DIR_NAME, "build");
-    const manifest = JSON.parse(
-      readFileSync(join(buildDir, BUILD_MANIFEST_NAME), "utf8")
-    ) as BuildManifest;
-    const escapeEntry = manifest.views?.["escape-view"];
-    expect(escapeEntry?.kind).toBe("inline");
-    if (escapeEntry?.kind !== "inline") {
-      throw new Error("expected inline escape-view entry");
-    }
-    // Bundlers may rewrite the string literal; the synthesized document must
-    // still escape any raw `</script>` sequence that survives into `js`.
-    const html = synthesizeViewDocument(
-      escapeEntry,
-      "http://localhost",
-      "/mcp"
+    expect(listViewAssets(buildDir, "escape-view").entry).toMatch(
+      /^assets\/.+\.js$/
     );
-    const moduleMatch = html.match(
-      /<script type="module">([\s\S]*?)<\/script>\s*<\/body>/
-    );
-    expect(moduleMatch).not.toBeNull();
-    const body = moduleMatch![1]!;
-    expect(body).not.toContain("</script>");
-    // If the bundle retained the closing-tag sequence, it must be escaped.
-    if (
-      escapeEntry.js.includes("</script>") ||
-      escapeEntry.js.includes("<\\/script>")
-    ) {
-      expect(body).toContain("<\\/script>");
-    }
   }, 60_000);
+
+  it("records inspector: true when built with --with-inspector", async () => {
+    const cwd = copyFixture("build");
+    dirs.push(cwd);
+
+    await runBuild({ cwd, withInspector: true });
+
+    const manifest = JSON.parse(
+      readFileSync(
+        join(cwd, WORKSPACE_DIR_NAME, "build", BUILD_MANIFEST_NAME),
+        "utf8"
+      )
+    ) as BuildManifest;
+    expect(manifest.inspector).toBe(true);
+    expect("views" in manifest).toBe(false);
+  });
 
   it("builds a view module that uses browser globals at module scope", async () => {
     const cwd = copyFixture("build-views-browser", "views");
@@ -422,5 +462,61 @@ describe("runBuild (views)", () => {
       )
     ).toBe(true);
     warnSpy.mockRestore();
+  }, 60_000);
+
+  it("rewrites manifest asset paths when MCP_ASSETS_URL is set", async () => {
+    const cwd = copyFixture("build-views-cdn", "views");
+    dirs.push(cwd);
+    const previous = process.env.MCP_ASSETS_URL;
+    process.env.MCP_ASSETS_URL =
+      "https://cdn.example.com/storage/v1/object/public/widgets";
+    try {
+      await runBuild({ cwd });
+      const buildDir = join(cwd, WORKSPACE_DIR_NAME, "build");
+      const entryCode = readFileSync(join(buildDir, "index.js"), "utf8");
+      expect(entryCode).toContain("https://cdn.example.com");
+      expect(entryCode).toContain(
+        "/mcp/_mcp-use/views/product-search-result/assets/"
+      );
+    } finally {
+      if (previous === undefined) {
+        delete process.env.MCP_ASSETS_URL;
+      } else {
+        process.env.MCP_ASSETS_URL = previous;
+      }
+    }
+  }, 60_000);
+
+  it("uses server basePath in CDN manifest when MCP_ASSETS_URL is set", async () => {
+    const cwd = copyFixture("build-views-cdn-basepath", "views");
+    dirs.push(cwd);
+    const indexPath = join(cwd, "src/index.ts");
+    writeFileSync(
+      indexPath,
+      readFileSync(indexPath, "utf8").replace(
+        'new MCPServer({ name: "fixture-views", version: "1.0.0" })',
+        'new MCPServer({ name: "fixture-views", version: "1.0.0", basePath: "/api/mcp" })'
+      )
+    );
+    const previous = process.env.MCP_ASSETS_URL;
+    process.env.MCP_ASSETS_URL =
+      "https://cdn.example.com/storage/v1/object/public/widgets";
+    try {
+      await runBuild({ cwd });
+      const buildDir = join(cwd, WORKSPACE_DIR_NAME, "build");
+      const entryCode = readFileSync(join(buildDir, "index.js"), "utf8");
+      expect(entryCode).toContain(
+        "https://cdn.example.com/storage/v1/object/public/widgets/api/mcp/_mcp-use/views/product-search-result/assets/"
+      );
+      expect(entryCode).not.toContain(
+        "https://cdn.example.com/storage/v1/object/public/widgets/mcp/_mcp-use/"
+      );
+    } finally {
+      if (previous === undefined) {
+        delete process.env.MCP_ASSETS_URL;
+      } else {
+        process.env.MCP_ASSETS_URL = previous;
+      }
+    }
   }, 60_000);
 });

--- a/libraries/typescript/packages/server/tests/views.test.ts
+++ b/libraries/typescript/packages/server/tests/views.test.ts
@@ -8,7 +8,15 @@ import {
 } from "@modelcontextprotocol/client";
 import { mkdirSync, writeFileSync, rmSync, existsSync } from "node:fs";
 import { join } from "node:path";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import { z } from "zod";
 
 import { MCPServer, registerViews } from "../src/index.js";
@@ -226,7 +234,9 @@ describe("views server core (e2e over HTTP)", () => {
     expect(view?.description).toBe("Product search results grid");
     expect(view?._meta?.["ui"]).toMatchObject({
       csp: {
-        connectDomains: [],
+        connectDomains: expect.arrayContaining([
+          expect.stringMatching(/^https?:\/\//),
+        ]),
         resourceDomains: [
           "https://images.example.com",
           expect.stringMatching(/^https?:\/\//),
@@ -247,7 +257,9 @@ describe("views server core (e2e over HTTP)", () => {
     expect(view?.description).toBe("Product search results grid");
     expect(view?._meta?.["ui"]).toMatchObject({
       csp: {
-        connectDomains: [],
+        connectDomains: expect.arrayContaining([
+          expect.stringMatching(/^https?:\/\//),
+        ]),
         resourceDomains: [
           "https://images.example.com",
           expect.stringMatching(/^https?:\/\//),
@@ -276,7 +288,9 @@ describe("views server core (e2e over HTTP)", () => {
     expect(content.text).toContain("/mcp/_mcp-use/public/");
     expect(content._meta?.["ui"]).toMatchObject({
       csp: {
-        connectDomains: [],
+        connectDomains: expect.arrayContaining([
+          expect.stringMatching(/^https?:\/\//),
+        ]),
         resourceDomains: [
           "https://images.example.com",
           expect.stringMatching(/^https?:\/\//),
@@ -295,7 +309,9 @@ describe("views server core (e2e over HTTP)", () => {
     const content = read.contents[0];
     expect(content?._meta?.["ui"]).toMatchObject({
       csp: {
-        connectDomains: [],
+        connectDomains: expect.arrayContaining([
+          expect.stringMatching(/^https?:\/\//),
+        ]),
         resourceDomains: [
           "https://images.example.com",
           expect.stringMatching(/^https?:\/\//),
@@ -329,7 +345,9 @@ describe("views server core (e2e over HTTP)", () => {
       | undefined;
     expect(ui).toMatchObject({
       csp: {
-        connectDomains: [],
+        connectDomains: expect.arrayContaining([
+          expect.stringMatching(/^https?:\/\//),
+        ]),
         resourceDomains: [expect.stringMatching(/^https?:\/\//)],
       },
     });
@@ -344,7 +362,9 @@ describe("views server core (e2e over HTTP)", () => {
     });
     expect(read.contents[0]?._meta?.["ui"]).toMatchObject({
       csp: {
-        connectDomains: [],
+        connectDomains: expect.arrayContaining([
+          expect.stringMatching(/^https?:\/\//),
+        ]),
         resourceDomains: [expect.stringMatching(/^https?:\/\//)],
       },
     });
@@ -379,7 +399,9 @@ describe("views server core (e2e over HTTP)", () => {
     const ui = appOnly?._meta?.["ui"] as Record<string, unknown> | undefined;
     expect(ui).toMatchObject({
       csp: {
-        connectDomains: [],
+        connectDomains: expect.arrayContaining([
+          expect.stringMatching(/^https?:\/\//),
+        ]),
         resourceDomains: [expect.stringMatching(/^https?:\/\//)],
       },
     });
@@ -396,7 +418,9 @@ describe("views server core (e2e over HTTP)", () => {
     expect(orphan?.description).toBeUndefined();
     expect(orphan?._meta?.["ui"]).toMatchObject({
       csp: {
-        connectDomains: [],
+        connectDomains: expect.arrayContaining([
+          expect.stringMatching(/^https?:\/\//),
+        ]),
         resourceDomains: [expect.stringMatching(/^https?:\/\//)],
       },
     });
@@ -839,7 +863,8 @@ describe("views document synthesis", () => {
         scripts: ["/@vite/client"],
       },
       "http://localhost:3000",
-      "/mcp"
+      "/mcp",
+      "demo"
     );
     expect(html).toContain(
       'src="http://localhost:3000/@id/__x00__virtual:mcp-use/views/demo"'
@@ -847,18 +872,34 @@ describe("views document synthesis", () => {
     expect(html).toContain('src="http://localhost:3000/@vite/client"');
   });
 
-  it("rejects non-origin-absolute external manifest paths", () => {
+  it("resolves view-relative production asset paths", () => {
+    const html = synthesizeViewDocument(
+      {
+        kind: "external",
+        entry: "assets/entry.js",
+        css: [],
+      },
+      "http://localhost:3000",
+      "/mcp",
+      "demo-view"
+    );
+    expect(html).toContain(
+      'src="http://localhost:3000/mcp/_mcp-use/views/demo-view/assets/entry.js"'
+    );
+  });
+
+  it("requires viewName for external entries without origin-absolute paths", () => {
     expect(() =>
       synthesizeViewDocument(
         {
           kind: "external",
-          entry: "views/demo/assets/entry.js",
+          entry: "assets/entry.js",
           css: [],
         },
         "http://localhost:3000",
         "/mcp"
       )
-    ).toThrow(/origin-absolute/);
+    ).toThrow(/viewName is required/);
   });
 });
 
@@ -1001,9 +1042,158 @@ describe("views prod CSP (e2e over HTTP)", () => {
     const connectDomains = (
       view?._meta?.["ui"] as { csp?: { connectDomains?: string[] } } | undefined
     )?.csp?.connectDomains;
-    expect(connectDomains).toEqual(["https://api.example.com"]);
+    expect(connectDomains).toEqual(
+      expect.arrayContaining(["https://api.example.com"])
+    );
+    expect(
+      connectDomains?.some(
+        (d) => d.includes("localhost") || d.includes("127.0.0.1")
+      )
+    ).toBe(true);
 
     await client.close();
     await server.close();
+  });
+});
+
+describe("views env URL / CSP (e2e)", () => {
+  const env = process.env;
+
+  const UI_META_ENVELOPE = {
+    "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+    "io.modelcontextprotocol/clientInfo": {
+      name: "env-test",
+      version: "0.0.0",
+    },
+    "io.modelcontextprotocol/clientCapabilities": UI_CAPABILITIES,
+  };
+
+  async function handlerMcp(
+    handler: (request: Request) => Promise<Response>,
+    method: string,
+    params: Record<string, unknown> = {}
+  ): Promise<Record<string, unknown>> {
+    const headers: Record<string, string> = {
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+      "mcp-protocol-version": "2026-07-28",
+      "mcp-method": method,
+    };
+    if (typeof params["uri"] === "string") {
+      headers["mcp-name"] = params["uri"];
+    }
+    const response = await handler(
+      new Request("http://127.0.0.1:3000/mcp", {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method,
+          params: { ...params, _meta: UI_META_ENVELOPE },
+        }),
+      })
+    );
+    return (await response.json()) as Record<string, unknown>;
+  }
+
+  afterEach(() => {
+    process.env = env;
+  });
+
+  it("uses MCP_ASSETS_URL for asset hrefs and MCP_URL for connect CSP", async () => {
+    process.env.MCP_URL = "https://server.example.com/mcp";
+    process.env.MCP_ASSETS_URL =
+      "https://cdn.example.com/storage/v1/object/public/widgets";
+    delete process.env.CSP_URLS;
+
+    const server = new MCPServer({
+      name: "env-split-test",
+      version: "1.0.0",
+      basePath: "/mcp",
+    });
+    server[registerViews]({
+      "product-search-result": {
+        kind: "external",
+        entry: "assets/demo.js",
+        css: ["assets/demo.css"],
+      },
+    });
+    server.tool(
+      {
+        name: "search",
+        inputSchema: z.object({}),
+        outputSchema: z.object({ ok: z.boolean() }),
+        view: { name: "product-search-result" },
+      },
+      async () => ({
+        structuredContent: { ok: true },
+        content: [{ type: "text", text: "ok" }],
+      })
+    );
+
+    const handler = server.getHandler();
+    const readBody = await handlerMcp(handler, "resources/read", {
+      uri: "ui://views/product-search-result.html",
+    });
+    const content = (
+      readBody["result"] as {
+        contents: {
+          text: string;
+          _meta?: { ui?: { csp?: Record<string, string[]> } };
+        }[];
+      }
+    ).contents[0]!;
+    expect(content.text).toContain(
+      "https://cdn.example.com/storage/v1/object/public/widgets/mcp/_mcp-use/views/product-search-result/assets/demo.js"
+    );
+    const csp = content._meta?.ui?.csp;
+    expect(csp?.connectDomains).toContain("https://server.example.com");
+    expect(csp?.resourceDomains).toContain("https://cdn.example.com");
+    expect(csp?.resourceDomains).not.toContain("https://server.example.com");
+  });
+
+  it("applies CSP_URLS to all four categories before MCP auto-append", async () => {
+    process.env.MCP_URL = "https://server.example.com";
+    process.env.CSP_URLS = "https://platform.example.com";
+    delete process.env.MCP_ASSETS_URL;
+
+    const server = new MCPServer({
+      name: "csp-urls-test",
+      version: "1.0.0",
+    });
+    server[registerViews]({
+      demo: { kind: "inline", js: "export {};", css: "" },
+    });
+    server.tool(
+      {
+        name: "t",
+        inputSchema: z.object({}),
+        outputSchema: z.object({ ok: z.boolean() }),
+        view: { name: "demo" },
+      },
+      async () => ({
+        structuredContent: { ok: true },
+        content: [{ type: "text", text: "ok" }],
+      })
+    );
+
+    const handler = server.getHandler();
+    const listBody = await handlerMcp(handler, "resources/list");
+    const view = (
+      listBody["result"] as {
+        resources: {
+          uri: string;
+          _meta?: { ui?: { csp?: Record<string, string[]> } };
+        }[];
+      }
+    ).resources.find((r) => r.uri === "ui://views/demo.html");
+    const viewCsp = view?._meta?.ui?.csp;
+    expect(viewCsp?.connectDomains?.[0]).toBe("https://platform.example.com");
+    expect(viewCsp?.connectDomains).toContain("https://server.example.com");
+    expect(viewCsp?.resourceDomains?.[0]).toBe("https://platform.example.com");
+    expect(viewCsp?.resourceDomains).toContain("https://server.example.com");
+    expect(viewCsp?.frameDomains).toEqual(["https://platform.example.com"]);
+    expect(viewCsp?.baseUriDomains).toEqual(["https://platform.example.com"]);
   });
 });

--- a/libraries/typescript/packages/server/tests/views/csp-env.test.ts
+++ b/libraries/typescript/packages/server/tests/views/csp-env.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  buildMergedResourceCsp,
+  mergeDomainLists,
+  parseDomainList,
+} from "../../src/views/csp-env.js";
+
+describe("parseDomainList", () => {
+  it("splits comma-separated domains", () => {
+    expect(parseDomainList("https://a.com, https://b.com")).toEqual([
+      "https://a.com",
+      "https://b.com",
+    ]);
+  });
+});
+
+describe("mergeDomainLists", () => {
+  it("keeps first occurrence on duplicate", () => {
+    expect(
+      mergeDomainLists(
+        ["https://csp.example.com"],
+        ["https://csp.example.com", "https://mcp.example.com"]
+      )
+    ).toEqual(["https://csp.example.com", "https://mcp.example.com"]);
+  });
+});
+
+describe("buildMergedResourceCsp", () => {
+  const env = process.env;
+
+  afterEach(() => {
+    process.env = env;
+  });
+
+  it("merges author, CSP_URLS, and MCP auto-append with precedence", () => {
+    delete process.env.CSP_CONNECT_DOMAINS;
+    delete process.env.CSP_RESOURCE_DOMAINS;
+    delete process.env.CSP_FRAME_DOMAINS;
+    delete process.env.CSP_BASE_URI_DOMAINS;
+    process.env.CSP_URLS = "https://platform.example.com";
+
+    const csp = buildMergedResourceCsp(
+      {
+        csp: {
+          resourceDomains: ["https://images.example.com"],
+        },
+      },
+      {
+        serverOrigin: "https://platform.example.com",
+        assetsOrigin: "https://platform.example.com",
+        explicitAssetsBase: false,
+      }
+    );
+
+    expect(csp.resourceDomains).toEqual([
+      "https://images.example.com",
+      "https://platform.example.com",
+    ]);
+    expect(csp.connectDomains).toEqual(["https://platform.example.com"]);
+    expect(csp.frameDomains).toEqual(["https://platform.example.com"]);
+    expect(csp.baseUriDomains).toEqual(["https://platform.example.com"]);
+  });
+
+  it("uses per-category env instead of CSP_URLS for that category", () => {
+    process.env.CSP_URLS = "https://a.com,https://b.com";
+    process.env.CSP_CONNECT_DOMAINS = "https://connect-only.example.com";
+
+    const csp = buildMergedResourceCsp(undefined, {
+      serverOrigin: "https://server.example.com",
+      assetsOrigin: "https://cdn.example.com",
+      explicitAssetsBase: true,
+    });
+
+    expect(csp.connectDomains).toEqual([
+      "https://connect-only.example.com",
+      "https://server.example.com",
+    ]);
+    expect(csp.resourceDomains).toEqual([
+      "https://a.com",
+      "https://b.com",
+      "https://cdn.example.com",
+    ]);
+  });
+
+  it("appends assets origin to resourceDomains when MCP_ASSETS_URL is explicit", () => {
+    delete process.env.CSP_URLS;
+    delete process.env.CSP_CONNECT_DOMAINS;
+    delete process.env.CSP_RESOURCE_DOMAINS;
+    delete process.env.CSP_FRAME_DOMAINS;
+    delete process.env.CSP_BASE_URI_DOMAINS;
+    const csp = buildMergedResourceCsp(undefined, {
+      serverOrigin: "https://server.example.com",
+      assetsOrigin: "https://cdn.example.com",
+      explicitAssetsBase: true,
+    });
+
+    expect(csp.connectDomains).toEqual(["https://server.example.com"]);
+    expect(csp.resourceDomains).toEqual(["https://cdn.example.com"]);
+  });
+
+  it("uses server origin for resourceDomains when assets not explicit", () => {
+    delete process.env.CSP_URLS;
+    const csp = buildMergedResourceCsp(undefined, {
+      serverOrigin: "https://server.example.com",
+      assetsOrigin: "https://server.example.com",
+      explicitAssetsBase: false,
+    });
+
+    expect(csp.resourceDomains).toEqual(["https://server.example.com"]);
+  });
+});

--- a/libraries/typescript/packages/server/tests/views/origin.test.ts
+++ b/libraries/typescript/packages/server/tests/views/origin.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  resolveAssetsBase,
+  resolveServerOrigin,
+  resolveRequestOriginFromHeaders,
+} from "../../src/views/origin.js";
+
+function req(url: string, headers: Record<string, string> = {}): Request {
+  return new Request(url, { headers });
+}
+
+describe("resolveServerOrigin", () => {
+  const env = process.env;
+
+  afterEach(() => {
+    process.env = env;
+  });
+
+  it("uses MCP_URL origin only (ignores path suffix)", () => {
+    process.env.MCP_URL = "https://tunnel.example.com/mcp";
+    expect(resolveServerOrigin(req("http://127.0.0.1:3000/mcp"))).toBe(
+      "https://tunnel.example.com"
+    );
+  });
+
+  it("falls back to forwarded headers when MCP_URL is malformed", () => {
+    process.env.MCP_URL = "not-a-url";
+    expect(
+      resolveServerOrigin(
+        req("http://127.0.0.1:3000/mcp", {
+          "x-forwarded-proto": "https",
+          "x-forwarded-host": "proxy.example.com",
+        })
+      )
+    ).toBe("https://proxy.example.com");
+  });
+
+  it("falls back to request origin", () => {
+    delete process.env.MCP_URL;
+    expect(resolveServerOrigin(req("http://127.0.0.1:3000/mcp"))).toBe(
+      "http://127.0.0.1:3000"
+    );
+  });
+});
+
+describe("resolveAssetsBase", () => {
+  const env = process.env;
+
+  afterEach(() => {
+    process.env = env;
+  });
+
+  it("uses MCP_ASSETS_URL prefix with path", () => {
+    process.env.MCP_ASSETS_URL =
+      "https://cdn.example.com/storage/v1/object/public/widgets";
+    expect(resolveAssetsBase(req("http://127.0.0.1:3000/mcp"))).toBe(
+      "https://cdn.example.com/storage/v1/object/public/widgets"
+    );
+  });
+
+  it("falls back to MCP_URL origin when MCP_ASSETS_URL unset", () => {
+    delete process.env.MCP_ASSETS_URL;
+    process.env.MCP_URL = "https://server.example.com/mcp";
+    expect(resolveAssetsBase(req("http://127.0.0.1:3000/mcp"))).toBe(
+      "https://server.example.com"
+    );
+  });
+
+  it("falls back to request origin when no env set", () => {
+    delete process.env.MCP_ASSETS_URL;
+    delete process.env.MCP_URL;
+    expect(resolveAssetsBase(req("http://127.0.0.1:3000/mcp"))).toBe(
+      "http://127.0.0.1:3000"
+    );
+  });
+});
+
+describe("resolveRequestOriginFromHeaders", () => {
+  it("parses Forwarded header", () => {
+    expect(
+      resolveRequestOriginFromHeaders(
+        req("http://127.0.0.1/mcp", {
+          forwarded: "proto=https;host=fruit.example.com",
+        })
+      )
+    ).toBe("https://fruit.example.com");
+  });
+});

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -497,6 +497,9 @@ importers:
 
   packages/server:
     dependencies:
+      '@modelcontextprotocol/client':
+        specifier: https://pkg.pr.new/@modelcontextprotocol/client@f60b40179b0f090f6d64248be1312245a160b5ee
+        version: https://pkg.pr.new/@modelcontextprotocol/client@f60b40179b0f090f6d64248be1312245a160b5ee
       '@modelcontextprotocol/ext-apps':
         specifier: https://pkg.pr.new/@modelcontextprotocol/ext-apps@432d42bb02a569078ab31ab6458428df6027809d
         version: https://pkg.pr.new/@modelcontextprotocol/ext-apps@432d42bb02a569078ab31ab6458428df6027809d(@modelcontextprotocol/client@https://pkg.pr.new/@modelcontextprotocol/client@f60b40179b0f090f6d64248be1312245a160b5ee)(@modelcontextprotocol/core@https://pkg.pr.new/@modelcontextprotocol/core@f60b40179b0f090f6d64248be1312245a160b5ee)(@modelcontextprotocol/server@https://pkg.pr.new/@modelcontextprotocol/server@f60b40179b0f090f6d64248be1312245a160b5ee)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
@@ -522,9 +525,6 @@ importers:
       '@mcp-use/client':
         specifier: workspace:*
         version: link:../client
-      '@modelcontextprotocol/client':
-        specifier: https://pkg.pr.new/@modelcontextprotocol/client@f60b40179b0f090f6d64248be1312245a160b5ee
-        version: https://pkg.pr.new/@modelcontextprotocol/client@f60b40179b0f090f6d64248be1312245a160b5ee
       '@modelcontextprotocol/core':
         specifier: https://pkg.pr.new/@modelcontextprotocol/core@f60b40179b0f090f6d64248be1312245a160b5ee
         version: https://pkg.pr.new/@modelcontextprotocol/core@f60b40179b0f090f6d64248be1312245a160b5ee
@@ -835,6 +835,34 @@ importers:
       mcp-use:
         specifier: workspace:*
         version: link:../../..
+      react:
+        specifier: ^19.2.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.0
+        version: 19.2.4(react@19.2.4)
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@types/node':
+        specifier: ^24.13.2
+        version: 24.13.2
+      '@types/react':
+        specifier: ^19.2.7
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      typescript:
+        specifier: 7.0.1-rc
+        version: 7.0.1-rc
+
+  test_app:
+    dependencies:
+      mcp-use:
+        specifier: workspace:*
+        version: link:../packages/server
       react:
         specifier: ^19.2.0
         version: 19.2.4


### PR DESCRIPTION
## Summary

- Revamp `mcp-use build` to emit hashed view assets on disk (`kind: "external"`) instead of inlining JS/CSS into the manifest; production serves bundles from `${basePath}/_mcp-use/views/<name>/`.
- Add `--with-inspector` so build manifests record inspector availability for `mcp-use start` (no longer always `true`).
- Support `MCP_ASSETS_URL` at build time (rewrite manifest asset paths to CDN URLs) and runtime (resolve view `publicBase` and asset hrefs separately from `MCP_URL` server origin).
- Add global CSP env: `CSP_URLS` (all four MCP Apps categories) and `CSP_*_DOMAINS` per-category overrides, merged with author `view.csp` before MCP auto-append.
- Bundle `@modelcontextprotocol/client` as a runtime dependency for the CLI.

## Test plan

- [x] ESLint passes (`pnpm lint` in `libraries/typescript`)
- [x] Pre-commit hooks (format, lint, typecheck scoped to changed packages)
- [ ] `pnpm --filter mcp-use test:run` in CI
- [ ] Manual: `mcp-use build` with views, verify assets served at `/_mcp-use/views/<name>/`
- [ ] Manual: build with `MCP_ASSETS_URL` set and confirm manifest CDN URLs
- [ ] Manual: deploy with `MCP_URL` + `CSP_URLS` and verify view CSP in `resources/read` metadata

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworked view builds to emit hashed assets served over HTTP, added CDN and CSP env support, and split server (`MCP_URL`) from asset origins. Also adds `--with-inspector` and bundles `@modelcontextprotocol/client`.

- **New Features**
  - Production builds emit hashed JS/CSS to `.mcp-use/build/views/<name>/assets/` and serve them at `${basePath}/_mcp-use/views/<name>/`.
  - `MCP_ASSETS_URL` rewrites manifest asset paths at build and is used at runtime to resolve asset URLs (separate from `MCP_URL`).
  - Global CSP env: `CSP_URLS` plus per-category `CSP_*_DOMAINS`, merged with author `view.csp`; server/websocket origins auto-appended when needed.
  - `--with-inspector` records inspector availability in the build manifest; `mcp-use start` uses it to mount the inspector shell.
  - New asset route and origin resolution respect proxies/CDNs; docs updated.
  - Bundle `@modelcontextprotocol/client` as a runtime dependency.

- **Migration**
  - Set `MCP_URL` to your server origin (e.g., Function/Edge URL).
  - Set `MCP_ASSETS_URL` to your CDN/storage prefix for view assets and `public/`.
  - Upload `.mcp-use/build/views/` (and `public/` if used) to your CDN; or serve assets from `${basePath}/_mcp-use/views/<name>/` without a CDN.
  - Optionally set `CSP_URLS` or per-category `CSP_*_DOMAINS`.
  - For production builds that should expose the inspector, run `mcp-use build --with-inspector`.

<sup>Written for commit 4f11e0394223f2369283d3d3411ec4317fbba74e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

