### PR TITLE
fix(inspector): honor $PORT env var in Docker CMD

### DIFF
--- a/libraries/typescript/.changeset/fix-inspector-dockerfile-honor-port-env.md
+++ b/libraries/typescript/.changeset/fix-inspector-dockerfile-honor-port-env.md
@@ -1,0 +1,9 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Honor `$PORT` env var in the Inspector Docker image `CMD`.
+
+The Dockerfile previously pinned the listen port to 8080 via `--port 8080`, contradicting the neighboring comment that said `$PORT` controls the actual port. Platforms that inject `PORT` and route traffic to it (Cloud Run, Railway, Heroku, Render, etc.) could not run `mcpuse/inspector` without an extra port-mapping layer.
+
+The `CMD` now uses shell form with a default: `sh -c "npx @mcp-use/inspector --port ${PORT:-8080}"`. Behavior is unchanged when `PORT` is unset (still 8080).

--- a/libraries/typescript/packages/inspector/Dockerfile
+++ b/libraries/typescript/packages/inspector/Dockerfile
@@ -16,8 +16,10 @@ RUN npm install -g @mcp-use/inspector@${VERSION}
 ENV NODE_ENV=production
 
 # Expose 8080 (standard alternative HTTP port for production)
-# Note: The actual port is controlled by $PORT env var
+# The actual listen port is controlled by the $PORT env var (defaults to 8080),
+# so PaaS platforms that inject PORT (Cloud Run, Railway, Heroku, Render, etc.)
+# route to the correct port without extra port-mapping layers.
 EXPOSE 8080
 
-# Start the inspector
-CMD ["npx", "@mcp-use/inspector", "--port", "8080"]
+# Start the inspector — shell-form so $PORT expansion works.
+CMD ["sh", "-c", "npx @mcp-use/inspector --port ${PORT:-8080}"]


### PR DESCRIPTION
## Changes

Honor `$PORT` env var in the Inspector Docker image `CMD`, so PaaS platforms that inject `PORT` and route traffic to it (Cloud Run, Railway, Heroku, Render, etc.) can run `mcpuse/inspector` without an extra port-mapping layer.

Implements **Option 1** from the issue (proposed by @ayaangazali when they reported it) — the "honor `$PORT`" direction that makes the existing Dockerfile comment accurate and the image PaaS-friendly.

## Implementation Details

1. Switched the `CMD` from exec form (`["npx", "@mcp-use/inspector", "--port", "8080"]`) to shell form so `$PORT` expansion works: `["sh", "-c", "npx @mcp-use/inspector --port ${PORT:-8080}"]`.
2. Rewrote the `EXPOSE` block's comment so it accurately documents what the image does now instead of what it used to claim.
3. No changes to the Inspector server code — it already reads `--port` from CLI args; this PR just plumbs `$PORT` into that arg via the container entrypoint.

## Example Usage (Before)

```console
$ docker run -d --name port-test -e PORT=9999 mcpuse/inspector:latest
$ docker exec port-test wget -q --spider http://localhost:8080/inspector; echo $?
0                     # still serving on 8080
$ docker exec port-test wget -q --spider -T 3 http://localhost:9999/inspector; echo $?
1                     # nothing on 9999 (connection refused)
```

## Example Usage (After)

```console
$ docker run -d --name port-test -e PORT=9999 mcpuse/inspector:latest
$ docker exec port-test wget -q --spider http://localhost:9999/inspector; echo $?
0                     # now serving on $PORT
$ docker run -d --name default-test mcpuse/inspector:latest    # PORT unset
$ docker exec default-test wget -q --spider http://localhost:8080/inspector; echo $?
0                     # default of 8080 preserved
```

## Documentation Updates

- Fixed the misleading `EXPOSE` comment in `libraries/typescript/packages/inspector/Dockerfile` (the previous comment said `$PORT` controlled the port, which was false).
- Skipped the Self-Hosting docs page mentioned in the issue since that page is being added in #1861 and I didn't want to conflict with that in-flight PR. Happy to follow up once #1861 lands.

## Testing

- Manual repro: rebuilt the image locally, verified the `Before` behavior matches (fails to bind `$PORT`); applied this patch, verified the `After` behavior binds `$PORT` when set and falls back to 8080 when unset. Also confirmed `docker inspect` shows the new `sh -c` entrypoint.
- No unit test coverage was added — the change is in a Dockerfile CMD, not runtime code.

## Backwards Compatibility

Behavior is unchanged when `PORT` is unset (still binds `8080`). Anyone running `docker run mcpuse/inspector` without setting `PORT` sees no difference. The only observable change is that setting `PORT=<n>` now actually takes effect.

## Related Issues

Closes #1868


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Inspector Docker image honor the `$PORT` env var so platforms like Cloud Run, Railway, Heroku, and Render work without extra port mapping. Default remains 8080 when `PORT` is unset.

- **Bug Fixes**
  - Switched `CMD` to shell form: `sh -c "npx @mcp-use/inspector --port ${PORT:-8080}"` to expand `$PORT`.
  - Updated `EXPOSE` comment to document that `$PORT` controls the listen port.

<sup>Written for commit 5c6e0140b7673d71b7320a6b49b4c3f4af7493c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

