### PR TITLE
fix(mcp-use): expose stdio stderr stream

### DIFF
--- a/libraries/typescript/.changeset/soft-stderr-config.md
+++ b/libraries/typescript/.changeset/soft-stderr-config.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Allow stdio server configurations to route spawned-process stderr to a custom writable stream.

--- a/libraries/typescript/packages/mcp-use/src/client.ts
+++ b/libraries/typescript/packages/mcp-use/src/client.ts
@@ -26,6 +26,7 @@ import {
   type MCPClientConfigShape,
   type ServerConfig,
 } from "./config.js";
+import type { Writable } from "node:stream";
 import { loadConfigFile } from "./config-file.js";
 import type { BaseConnector } from "./connectors/base.js";
 import { logger } from "./logging.js";
@@ -529,12 +530,14 @@ export class MCPClient extends BaseMCPClient {
         args: string[];
         env?: Record<string, string>;
         cwd?: string;
+        errlog?: Writable;
       };
       return new StdioConnector({
         command: stdioConfig.command,
         args: stdioConfig.args,
         env: stdioConfig.env,
         cwd: stdioConfig.cwd,
+        errlog: stdioConfig.errlog,
         clientInfo: normalizeClientInfo(merged.clientInfo),
         onSampling: resolved.onSampling,
         onElicitation: resolved.onElicitation,

--- a/libraries/typescript/packages/mcp-use/src/config.ts
+++ b/libraries/typescript/packages/mcp-use/src/config.ts
@@ -6,6 +6,7 @@ import type {
   ElicitResult,
 } from "@modelcontextprotocol/sdk/types.js";
 import type { Notification } from "@modelcontextprotocol/sdk/types.js";
+import type { Writable } from "node:stream";
 import type { BaseConnector, ConnectorInitOptions } from "./connectors/base.js";
 import type { ClientInfo } from "./connectors/http.js";
 import { HttpConnector } from "./connectors/http.js";
@@ -95,6 +96,8 @@ export interface StdioServerConfig extends BaseServerConfig {
   args: string[];
   env?: Record<string, string>;
   cwd?: string;
+  /** Stream that receives stderr from the spawned MCP server. */
+  errlog?: Writable;
 }
 
 /**

--- a/libraries/typescript/packages/mcp-use/tests/unit/client/stdio-errlog-config.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/client/stdio-errlog-config.test.ts
@@ -1,0 +1,30 @@
+import { PassThrough } from "node:stream";
+import { describe, expect, it } from "vitest";
+
+import { MCPClient } from "../../../src/client.js";
+import type { BaseConnector } from "../../../src/connectors/base.js";
+
+class TestMCPClient extends MCPClient {
+  createStdioConnector(
+    config: Record<string, unknown>
+  ): Promise<BaseConnector> {
+    return this.createConnectorFromConfig(config);
+  }
+}
+
+describe("MCPClient stdio configuration", () => {
+  it("passes errlog through to the stdio connector", async () => {
+    const errlog = new PassThrough();
+    const client = new TestMCPClient();
+
+    const connector = await client.createStdioConnector({
+      command: "node",
+      args: ["server.js"],
+      errlog,
+    });
+
+    expect((connector as unknown as { errlog: PassThrough }).errlog).toBe(
+      errlog
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Expose the existing `errlog` stream through `MCPClient` stdio server configuration.
- Preserve the default stderr behavior when no stream is supplied.
- Add regression coverage and the required patch changeset.

## Root cause

`StdioConnector` already accepts a custom stderr stream, but the `MCPClient` configuration path rebuilt the connector without forwarding that option. Applications using server configuration could therefore not capture or redirect spawned MCP server stderr.

## Validation

- `pnpm --filter mcp-use exec vitest run tests/unit/client/stdio-errlog-config.test.ts`
- `pnpm --filter mcp-use test:types`
- `pnpm --filter mcp-use build`
- `pnpm exec prettier --check packages/mcp-use/src/config.ts packages/mcp-use/src/client.ts packages/mcp-use/tests/unit/client/stdio-errlog-config.test.ts`
- `pnpm --filter mcp-use exec eslint src/config.ts src/client.ts tests/unit/client/stdio-errlog-config.test.ts`

Closes #1899

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes `errlog` on stdio server configs so apps can capture or redirect spawned MCP server stderr. Defaults remain unchanged when no stream is provided.

- **Bug Fixes**
  - Fixed: `MCPClient` now forwards `errlog?: Writable` to `StdioConnector` (previously dropped).
  - Added unit test for pass-through and a patch changeset for `mcp-use`.

<sup>Written for commit 2b8483f1a643c0aa0be1d759b3549cfa65612c3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1900?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

