### PR TITLE
feat: auto-generate root tools.d.ts

### DIFF
--- a/libraries/typescript/packages/create-mcp-use-app/src/index.ts
+++ b/libraries/typescript/packages/create-mcp-use-app/src/index.ts
@@ -1105,7 +1105,7 @@ async function main(): Promise<void> {
     console.log("   ├── resources/");
     console.log("   │   └── product-search-result/");
     console.log("   │       └── view.tsx");
-    console.log("   ├── src/register.d.ts");
+    console.log("   ├── tools.d.ts");
     console.log("   ├── index.ts (server entry point)");
     console.log("   ├── package.json");
     console.log("   ├── tsconfig.json");

--- a/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/src/register.d.ts
+++ b/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/src/register.d.ts
@@ -1,7 +1,0 @@
-declare module "mcp-use/react" {
-  interface Register {
-    tools: typeof import("../index.js");
-  }
-}
-
-export {};

--- a/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/tools.d.ts
+++ b/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/tools.d.ts
@@ -1,0 +1,8 @@
+// Created by mcp-use when missing. Existing files are never overwritten.
+declare module "mcp-use/react" {
+  interface Register {
+    tools: typeof import("./index.js");
+  }
+}
+
+export {};

--- a/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/tsconfig.json
+++ b/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/tsconfig.json
@@ -13,6 +13,6 @@
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true
   },
-  "include": ["index.ts", "src/**/*", "resources/**/*"],
+  "include": ["index.ts", "tools.d.ts", "resources/**/*"],
   "exclude": ["node_modules", "dist"]
 }

--- a/libraries/typescript/packages/server/specs/CLI_SPEC.md
+++ b/libraries/typescript/packages/server/specs/CLI_SPEC.md
@@ -246,7 +246,7 @@ Target user `package.json` shape:
 └─ cloud/        ← deploy linkage (link.json)
 ```
 
-This contract writes `build/` (using `cache/` as Vite's `cacheDir`), `state/tunnel.json` during tunneled dev, and `cloud/link.json` after deploy. `generated/` is reserved for the explicit typegen escape hatch. `build/` contains no mutable runtime state, so build output stays reproducible and disposable. Because everything under `.mcp-use/` is gitignored and `rm -rf`-safe, nothing committed ever lives here — scaffolded, committed files (e.g. the `src/register.d.ts` typing shim, `VIEWS_SPEC.md` § Typing) belong in the project source tree instead.
+This contract writes `build/` (using `cache/` as Vite's `cacheDir`), `state/tunnel.json` during tunneled dev, and `cloud/link.json` after deploy. `generated/` is reserved for the explicit typegen escape hatch. `build/` contains no mutable runtime state, so build output stays reproducible and disposable. Because everything under `.mcp-use/` is gitignored and `rm -rf`-safe, nothing committed ever lives here. The root-level `tools.d.ts` typing shim belongs in the project source tree; templates scaffold it, and `dev`/`build` recreate it from the discovered entry path when missing without overwriting an existing file (`VIEWS_SPEC.md` § Typing).
 
 Rules, all inherited from v1 and locked:
 

--- a/libraries/typescript/packages/server/specs/VIEWS_SPEC.md
+++ b/libraries/typescript/packages/server/specs/VIEWS_SPEC.md
@@ -498,7 +498,7 @@ v1 parity: authors drop static files in a project-root `public/` directory and r
 
 ## Typing: `ToolRef` + `Register` (zero codegen)
 
-Exports-based inference is the primary mode; typegen is an explicit escape hatch only, never on the dev/build hot path. The full option space behind this choice (including the rejected alternatives) is preserved in `type_proposals.md`.
+Exports-based inference is the primary mode; tool typegen is an explicit escape hatch only, never on the dev/build hot path. `dev` and `build` only ensure that the constant root `tools.d.ts` shim exists; they do not inspect tools or generate a registry. The full option space behind this choice (including the rejected alternatives) is preserved in `type_proposals.md`.
 
 ### `tool()` return-type change
 
@@ -511,7 +511,7 @@ This ends `server.tool(…).tool(…)` chaining — an acceptable break: nothing
 View bundles must never contain server code, so the ref **value** is never imported by a view. The type crosses in type space only:
 
 ```ts
-// src/register.d.ts — scaffolded once, committed, never regenerated
+// tools.d.ts — scaffolded at the project root; dev/build recreate it if missing
 // (the vite-env.d.ts pattern: configuration, not codegen — it lives in the
 // source tree because .mcp-use/ is gitignored and rm -rf-safe, CLI_SPEC.md)
 declare module "mcp-use/react" {
@@ -523,7 +523,7 @@ declare module "mcp-use/react" {
 
 ```ts
 // in /react
-export interface Register {}  // filled (or not) by the project's register.d.ts
+export interface Register {}  // filled (or not) by the project's tools.d.ts
 
 type RegisteredToolsModule = Register extends { tools: infer M } ? M : Record<never, never>;
 
@@ -584,18 +584,18 @@ Keying by tool name (not view directory name) is deliberate: view names exist on
 
 ### Fallback ladder
 
-1. `useCallTool("name")` — primary; typed via `Register` when the project has `register.d.ts` and the ref is exported.
+1. `useCallTool("name")` — primary; typed via `Register` when the project has `tools.d.ts` and the ref is exported.
 2. `useCallTool(toolRef)` — for contexts where the ref value is legitimately in scope (the inline-JSX stretch path); not for file-based views (value import = server code in the bundle).
 3. `useCallTool<Args, Result>("name")` — explicit generics for dynamically registered tools (statically untypeable in any framework) and unexported refs.
-4. Empty `Register` (no `register.d.ts`) degrades to `(name: string)` — non-scaffolded projects compile untouched.
+4. Empty `Register` (no `tools.d.ts`) degrades to `(name: string)` — non-scaffolded projects compile untouched until `dev` or `build` creates the shim.
 
 A forgotten `export const` silently drops that one tool to rung 3/4 — documented habit; a lint rule is a possible follow-up, not alpha scope.
 
 ### Typegen, demoted
 
-Nothing generates types during `dev`, `build`, or `start` — v1's run-the-server generator (`tool-registry-generator.ts`, `zod-to-ts.ts`) is not ported, and the implemented CLI has no typegen hooks to remove. `mcp-use typegen` (+ `mcp-use check` for CI freshness) is the explicit secondary mode, for consumers with no compile-time path to the server source; if/when built, it is a TS-checker-based static extractor (reads resolved `ToolRef` types; never executes user code), defaulting output to `.mcp-use/generated/`. Not an alpha deliverable.
+No command generates tool-specific types during `dev`, `build`, or `start` — v1's run-the-server generator (`tool-registry-generator.ts`, `zod-to-ts.ts`) is not ported. `dev` and `build` perform one constant-file check: if root `tools.d.ts` is absent, they create it with a type-only import of the discovered server entry; an existing file is never overwritten. `mcp-use typegen` (+ `mcp-use check` for CI freshness) remains the explicit secondary mode, for consumers with no compile-time path to the server source; if/when built, it is a TS-checker-based static extractor (reads resolved `ToolRef` types; never executes user code), defaulting output to `.mcp-use/generated/`. Not an alpha deliverable.
 
-Since v2 `create-mcp-use-app` templates don't exist yet, the handwritten example in this package (planned `examples/views/basic`) is the reference for the `register.d.ts` + exported-refs pattern.
+The v2 `create-mcp-use-app` MCP Apps template is the reference for the root `tools.d.ts` + exported-refs pattern.
 
 ---
 
@@ -766,7 +766,7 @@ The complete alpha surface. Everything here is exported from `mcp-use/react`; ty
 **Types.**
 
 ```ts
-/** Augmented by the project's register.d.ts; empty by default. */
+/** Augmented by the project's tools.d.ts; empty by default. */
 interface Register {}
 
 /** Pre-render runtime configuration — optional named export from a view module. */
@@ -1157,8 +1157,8 @@ Everything result-shaped enters through `useToolContext` (typed by the server's 
 
 The full build/serve contract is "Build system & serving", above; it extends the **implemented** `CLI_SPEC.md` (which scoped views out) and its ground rules hold — reload-not-HMR for the server entry, `start` pays zero toolchain cost, vite reachable only through the lazy `dev`/`build` chunk. Command summary:
 
-- **`mcp-use dev`:** adds the Vite client environment to the existing dev server; public assets and Vite module graph serve through its middleware at `${basePath}/_mcp-use/`. View-file edits get Vite's own HMR (pure client code, sharing the one Vite dev server); server-entry edits follow the existing reload contract and invalidate all three primitive lists over the shared SDK event bus (decision 12). No typegen hooks anywhere.
-- **`mcp-use build`:** one client-environment build over all views into `.mcp-use/build/views/`; writes the manifest `views` map (tooling copy) and bakes it into the generated wrapper entry (runtime copy — Registration mechanism); runs the binding checks (missing view, missing `outputSchema`, duplicate view binding → errors naming both tools; unbound view → warning).
+- **`mcp-use dev`:** ensures root `tools.d.ts` exists without overwriting it, then adds the Vite client environment to the existing dev server; public assets and Vite module graph serve through its middleware at `${basePath}/_mcp-use/`. View-file edits get Vite's own HMR (pure client code, sharing the one Vite dev server); server-entry edits follow the existing reload contract and invalidate all three primitive lists over the shared SDK event bus (decision 12). No tool-inspecting typegen hook runs.
+- **`mcp-use build`:** ensures root `tools.d.ts` exists without overwriting it, then runs one client-environment build over all views into `.mcp-use/build/views/`; writes the manifest `views` map (tooling copy) and bakes it into the generated wrapper entry (runtime copy — Registration mechanism); runs the binding checks (missing view, missing `outputSchema`, duplicate view binding → errors naming both tools; unbound view → warning).
 - **`mcp-use start`:** imports the built wrapper entry (views arrive primed) and serves public assets; no vite, no discovery, no runtime manifest read. View documents are obtained only through `resources/read`.
 
 ## Testing

--- a/libraries/typescript/packages/server/src/cli/build.ts
+++ b/libraries/typescript/packages/server/src/cli/build.ts
@@ -24,6 +24,7 @@ import { build } from "vite";
 
 import { discoverEntry } from "./entry.js";
 import { mcpUseViewsPlugin } from "./views-plugin.js";
+import { ensureToolsDeclaration } from "./tools-declaration.js";
 import {
   resolveBuildBasePath,
   validateViewBindingsAtBuild,
@@ -260,6 +261,9 @@ async function buildExternalView(
 export async function runBuild(options: BuildOptions): Promise<void> {
   const startedAt = performance.now();
   const entry = discoverEntry(options.cwd, options.entry);
+  if (await ensureToolsDeclaration(options.cwd, entry)) {
+    console.log("[mcp-use] created tools.d.ts");
+  }
   const paths = resolveWorkspacePaths(options.cwd);
   const views = discoverViews(options.cwd);
   const userViteConfig = resolveUserViteConfig(options.cwd);

--- a/libraries/typescript/packages/server/src/cli/dev.ts
+++ b/libraries/typescript/packages/server/src/cli/dev.ts
@@ -41,6 +41,7 @@ import { resolvePort } from "./port.js";
 import { resolveTailwindCss, resolveUserViteConfig } from "./vite-config.js";
 import { createDevApiHandler } from "./dev-api.js";
 import { createTunnelManager } from "./tunnel.js";
+import { ensureToolsDeclaration } from "./tools-declaration.js";
 import { resolveWorkspacePaths } from "./workspace.js";
 import { mcpUseViewsPlugin } from "./views-plugin.js";
 import {
@@ -326,6 +327,9 @@ export async function runDev(options: DevOptions): Promise<void> {
       : undefined;
 
   const entry = discoverEntry(options.cwd, options.entry);
+  if (await ensureToolsDeclaration(options.cwd, entry)) {
+    console.log("[mcp-use] created tools.d.ts");
+  }
   let currentViews: DiscoveredView[] = discoverViews(options.cwd);
   // The Vite client environment (views plugin, Fast Refresh, HMR socket,
   // asset origin) is configured once, from this snapshot. `currentViews`

--- a/libraries/typescript/packages/server/src/cli/tools-declaration.ts
+++ b/libraries/typescript/packages/server/src/cli/tools-declaration.ts
@@ -1,0 +1,80 @@
+/**
+ * Root-level tool registry declaration shared by `mcp-use dev` and
+ * `mcp-use build`.
+ *
+ * The file contains no generated tool names. It creates a live type-only edge
+ * to the user's server entry, so exported `ToolRef`s update in TypeScript
+ * without rerunning the CLI.
+ */
+
+import { writeFile } from "node:fs/promises";
+import { extname, join, relative, sep } from "node:path";
+
+/** Filename of the project-owned tool registry declaration. */
+export const TOOLS_DECLARATION_NAME = "tools.d.ts";
+
+function declarationImportPath(cwd: string, entry: string): string {
+  let importPath = relative(cwd, entry).split(sep).join("/");
+  const extension = extname(importPath);
+  const runtimeExtension =
+    extension === ".mts"
+      ? ".mjs"
+      : extension === ".cts"
+        ? ".cjs"
+        : extension === ".ts" || extension === ".tsx"
+          ? ".js"
+          : extension;
+
+  if (extension !== runtimeExtension) {
+    importPath = `${importPath.slice(0, -extension.length)}${runtimeExtension}`;
+  }
+  return importPath.startsWith(".") ? importPath : `./${importPath}`;
+}
+
+/** Build the stable declaration contents for a discovered server entry. */
+export function renderToolsDeclaration(cwd: string, entry: string): string {
+  const importPath = declarationImportPath(cwd, entry);
+  return [
+    "// Created by mcp-use when missing. Existing files are never overwritten.",
+    'declare module "mcp-use/react" {',
+    "  interface Register {",
+    `    tools: typeof import(${JSON.stringify(importPath)});`,
+    "  }",
+    "}",
+    "",
+    "export {};",
+    "",
+  ].join("\n");
+}
+
+/**
+ * Create the root `tools.d.ts` if absent.
+ *
+ * Exclusive-create mode makes this safe when dev and build start together and
+ * guarantees that a user-authored declaration is never truncated or replaced.
+ *
+ * @returns `true` when this invocation created the file.
+ */
+export async function ensureToolsDeclaration(
+  cwd: string,
+  entry: string
+): Promise<boolean> {
+  const declarationPath = join(cwd, TOOLS_DECLARATION_NAME);
+  try {
+    await writeFile(declarationPath, renderToolsDeclaration(cwd, entry), {
+      encoding: "utf8",
+      flag: "wx",
+    });
+    return true;
+  } catch (error) {
+    if (
+      error !== null &&
+      typeof error === "object" &&
+      "code" in error &&
+      error.code === "EEXIST"
+    ) {
+      return false;
+    }
+    throw error;
+  }
+}

--- a/libraries/typescript/packages/server/src/react/types/register.ts
+++ b/libraries/typescript/packages/server/src/react/types/register.ts
@@ -1,6 +1,6 @@
 import type { ToolRef } from "../../tools.js";
 
-/** Augmented by the project's `register.d.ts`; empty by default. */
+/** Augmented by the project's `tools.d.ts`; empty by default. */
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type -- intentional augmentation target
 export interface Register {}
 

--- a/libraries/typescript/packages/server/tests/cli/build.test.ts
+++ b/libraries/typescript/packages/server/tests/cli/build.test.ts
@@ -98,6 +98,11 @@ describe("runBuild", () => {
 
     await runBuild({ cwd });
 
+    const toolsDeclaration = readFileSync(join(cwd, "tools.d.ts"), "utf8");
+    expect(toolsDeclaration).toContain(
+      'tools: typeof import("./src/index.js")'
+    );
+
     const buildDir = join(cwd, WORKSPACE_DIR_NAME, "build");
     const entryFile = join(buildDir, "index.js");
     expect(existsSync(entryFile)).toBe(true);
@@ -170,6 +175,18 @@ describe("runBuild", () => {
     expect(existsSync(join(cwd, WORKSPACE_DIR_NAME, "build", "index.js"))).toBe(
       true
     );
+  });
+
+  it("does not overwrite an existing tools.d.ts", async () => {
+    const cwd = copyFixture("build-existing-tools");
+    dirs.push(cwd);
+    const declarationPath = join(cwd, "tools.d.ts");
+    const existing = "// user-owned tool registry\nexport {};\n";
+    writeFileSync(declarationPath, existing);
+
+    await runBuild({ cwd });
+
+    expect(readFileSync(declarationPath, "utf8")).toBe(existing);
   });
 
   it("fails with the candidate list when no entry exists", async () => {

--- a/libraries/typescript/packages/server/tests/cli/dev.test.ts
+++ b/libraries/typescript/packages/server/tests/cli/dev.test.ts
@@ -2,7 +2,7 @@
  * e2e tests for runDev: a real Vite dev server + module runner serving the
  * fixture over HTTP, including edit-triggered reload and error resilience.
  */
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import {
   Client,
@@ -153,6 +153,20 @@ export default new MCPServer({
 }
 
 describe("runDev", () => {
+  it("creates a missing root tools.d.ts", async () => {
+    const cwd = copyFixture("dev-tools-declaration");
+    cleanups.push(() => removeDir(cwd));
+
+    const port = await getFreePort();
+    const dev = await startDev(cwd, port);
+    cleanups.push(dev.stop);
+
+    expect(existsSync(join(cwd, "tools.d.ts"))).toBe(true);
+    expect(readFileSync(join(cwd, "tools.d.ts"), "utf8")).toContain(
+      'tools: typeof import("./src/index.js")'
+    );
+  });
+
   it("serves the MCP endpoint and reloads on file change", async () => {
     const cwd = copyFixture("dev");
     cleanups.push(() => removeDir(cwd));

--- a/libraries/typescript/packages/server/tests/cli/tools-declaration.test.ts
+++ b/libraries/typescript/packages/server/tests/cli/tools-declaration.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { renderToolsDeclaration } from "../../src/cli/tools-declaration.js";
+
+describe("renderToolsDeclaration", () => {
+  it.each([
+    ["/project/index.ts", "./index.js"],
+    ["/project/src/index.tsx", "./src/index.js"],
+    ["/project/src/index.mts", "./src/index.mjs"],
+    ["/project/src/index.cts", "./src/index.cjs"],
+    ["/project/server.mjs", "./server.mjs"],
+  ])("maps %s to the runtime import %s", (entry, expected) => {
+    expect(renderToolsDeclaration("/project", entry)).toContain(
+      `tools: typeof import(${JSON.stringify(expected)})`
+    );
+  });
+});

--- a/libraries/typescript/packages/server/type_proposals.md
+++ b/libraries/typescript/packages/server/type_proposals.md
@@ -15,7 +15,7 @@ todos:
     content: Strip typegen from server startup/HMR/CLI build hot paths; keep `mcp-use typegen` as optional escape hatch; drop generated d.ts from template tsconfig
     status: pending
   - id: templates
-    content: "Update create-mcp-use-app templates: chosen registration style in index.tsx, constant-content src/register.d.ts (committed, in tsconfig include), views import useCallTool from mcp-use/react directly"
+    content: "Update create-mcp-use-app templates: chosen registration style in index.tsx, constant-content tools.d.ts at the project root (committed, in tsconfig include, recreated by dev/build when missing), views import useCallTool from mcp-use/react directly"
     status: pending
   - id: typed-usewidget
     content: Type useView/ViewProps from the same registry via the tool's view binding (contract in specs/VIEWS_SPEC.md § Typing)
@@ -42,10 +42,10 @@ TypeScript physics: without codegen, a type can cross a module boundary through 
 
 ## Shared machinery (identical in both proposals)
 
-**Distribution — constant-content `register.d.ts` (the `vite-env.d.ts` / `next-env.d.ts` precedent).** The template ships a committed, never-regenerated file in the source tree (`src/register.d.ts` — it cannot live in the gitignored `.mcp-use/`):
+**Distribution — constant-content `tools.d.ts` (the `vite-env.d.ts` / `next-env.d.ts` precedent).** The template ships a committed file at the project root (`tools.d.ts` — it cannot live in the gitignored `.mcp-use/`); `dev` and `build` recreate it from the discovered entry path when missing and never overwrite it:
 
 ```ts
-// src/register.d.ts — content is constant; it names no tools, so it can never go stale
+// tools.d.ts — content is constant; it names no tools, so it can never go stale
 declare module "mcp-use/react" {
   interface Register {
     tools: typeof import("./index.js");
@@ -56,7 +56,7 @@ declare module "mcp-use/react" {
 `typeof import()` is a live edge in TypeScript's type graph (same as `import type`): edit `index.tsx` and every widget's types update instantly in tsserver — no watcher, no dev server, no file writes. This is configuration, not codegen. In `mcp-use/react`:
 
 ```ts
-export interface Register {} // empty; filled by the template's register.d.ts
+export interface Register {} // empty; filled by the project's tools.d.ts
 
 export type RegisteredTools = Register extends { tools: infer M }
   ? ProjectTools<M>   // thin { input; output } projection per tool (see perf notes)
@@ -177,7 +177,7 @@ server.tool({ name: "get-fruit-details", schema, outputSchema }, handler);
 - Choose **C** if zero user-facing ceremony trumps everything, and a dev/build-integrated generation step (with CI freshness check) is an acceptable cost. It is the only option that types bare statements and, later, filesystem facts like widget names.
 - They compose rather than exclude: A can ship first (pure inference core); B can be added later as sugar returning the same ToolRefs; C's generator can arrive afterwards as an *optional enhancement layer* that fills the same `Register` interface for projects that refuse exports — hooks, fallback, and distribution are identical across all three, so no consumer code ever changes.
 
-**Outcome:** A is the contract's primary mode; C is demoted to the explicit `mcp-use typegen` escape hatch, never on the dev/build hot path; B stays available as future sugar. The normative spelling — including the `src/register.d.ts` location (the scaffolded file is committed, so it cannot live in the gitignored `.mcp-use/`) and the absence of any config file — lives in `specs/VIEWS_SPEC.md` § Typing; where this record's sketches differ (e.g. `.mcp-use/register.d.ts` paths, `mcp-use.json`, v1 package file paths below), the spec wins.
+**Outcome:** A is the contract's primary mode; C is demoted to the explicit `mcp-use typegen` escape hatch, never on the dev/build hot path; B stays available as future sugar. The normative spelling — including the root-level `tools.d.ts` location (scaffolded and committed, with missing-file recovery in `dev`/`build`, so it cannot live in the gitignored `.mcp-use/`) and the absence of any config file — lives in `specs/VIEWS_SPEC.md` § Typing; where this record's sketches differ (e.g. `.mcp-use/tools.d.ts` paths, `mcp-use.json`, v1 package file paths below), the spec wins.
 
 ---
 
@@ -208,13 +208,13 @@ server.tool({ name: "get-fruit-details", schema, outputSchema }, handler);
 - `libraries/typescript/packages/mcp-use/src/react/createTypedHooks.ts` — rework to module-type input (cross-repo alternative path).
 - `libraries/typescript/packages/mcp-use/src/server/types/tool-ref.ts` + `mcp-server.ts` — ToolRef output inference (outputSchema, handler-return fallback); strip typegen calls; Proposal B adds `server.tools()` + `tool()` builder here.
 - `libraries/typescript/packages/cli/src/index.ts` — strip typegen from build.
-- `libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/*` — chosen registration style in `index.tsx`, committed `src/register.d.ts` (in tsconfig `include`), views importing hooks from `mcp-use/react`.
+- `libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/*` — chosen registration style in `index.tsx`, committed root-level `tools.d.ts` (in tsconfig `include`, recreated by `dev`/`build` when missing), views importing hooks from `mcp-use/react`.
 - Proposal C only: new `libraries/typescript/packages/cli/src/typegen/` — ts-morph-based extractor (find ToolRef-returning calls, print via `typeToString`), Vite-plugin watcher integration, `mcp-use check` freshness command; replaces `tool-registry-generator.ts` + `zod-to-ts.ts` entirely.
 - Type-level tests with vitest `expectTypeOf` (Skybridge has a good reference suite): literal name union, input/output inference, filtering of non-ToolRef exports, composition (re-exports for A, spread for B), empty-Register fallback.
 
 ## Risks / notes
 
 - A only: forgotten `export const` silently untypes that tool (falls back to loose overload) — template habit + optional lint.
-- `register.d.ts` hardcodes the entry path; renaming the entry surfaces immediately in tsserver and is a one-line fix at scaffold time (there is no config file to keep in sync — CLI_SPEC.md).
+- `tools.d.ts` records the entry path; renaming the entry surfaces immediately in tsserver and is a one-line fix for an existing file (deleting it lets the next `dev`/`build` recreate it from entry discovery; there is no config file to keep in sync — CLI_SPEC.md).
 - TS perf: bounded by the thin `{ input; output }` projection + lazy object-property evaluation (tRPC lesson); Zod inference is the dominant per-tool cost, acceptable.
-- The server entry must resolve within the view TS program — true in the planned template shape (single tsconfig includes the entry, `resources/**`, and `src/register.d.ts`).
+- The server entry must resolve within the view TS program — true in the planned template shape (single tsconfig includes the entry, `resources/**`, and `tools.d.ts`).


### PR DESCRIPTION
## Summary

- rename the MCP Apps typing shim from `src/register.d.ts` to root-level `tools.d.ts`
- have `mcp-use dev` and `mcp-use build` create the shim when it is missing
- derive the type-only import from the discovered server entry, including TS/TSX/MTS/CTS runtime extension mapping
- use exclusive creation so existing user-authored files are never overwritten
- update the scaffold, TypeScript include list, specs, and focused tests

## Why

The declaration is required for exported `ToolRef` inference, but it should not depend solely on the initial scaffold. Recreating the constant shim when missing keeps existing projects recoverable without introducing tool-specific type generation.

## Validation

- `pnpm --filter mcp-use build`
- 19 focused build/declaration tests
- dedicated real `mcp-use dev` generation test
- 20 `create-mcp-use-app` tests
- `pnpm --filter create-mcp-use-app build`
- ESLint, Prettier, and `git diff --check`

## Existing unrelated test limitations

- the full server typecheck currently fails on Deno URL imports/globals
- an existing dev reload watcher timeout reproduces with the new generation hook removed


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-generates a root `tools.d.ts` typing shim that links `mcp-use/react` to the server entry. `mcp-use dev` and `mcp-use build` now create it when missing (never overwrite), and templates/docs/tests are updated.

- **New Features**
  - `mcp-use dev`/`build` create root `tools.d.ts` if absent (exclusive create; existing files are kept).
  - Derives a type-only import from the discovered server entry with runtime extension mapping: `.ts/.tsx → .js`, `.mts → .mjs`, `.cts → .cjs`.
  - `create-mcp-use-app` template moves from `src/register.d.ts` to root `tools.d.ts`; `tsconfig.json` includes `tools.d.ts`.
  - Specs updated (`CLI_SPEC.md`, `VIEWS_SPEC.md`) to document the new shim behavior; tests cover creation and non-overwrite.

- **Migration**
  - If you have `src/register.d.ts`, move to a root `tools.d.ts` or delete it and run `mcp-use dev`/`build` to auto-create.
  - Ensure `tools.d.ts` is included in your `tsconfig.json` so views see the types.

<sup>Written for commit 1c537a95d420e2a06de374e0207c714255011abf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

