### PR TITLE
fix(typescript): pack beta bundles with hoisted linker

### DIFF
--- a/libraries/typescript/scripts/publish-beta.mjs
+++ b/libraries/typescript/scripts/publish-beta.mjs
@@ -46,6 +46,7 @@ try {
   for (const { name, version } of releases) {
     const packed = JSON.parse(
       run("pnpm", [
+        "--config.node-linker=hoisted",
         "--filter",
         name,
         "pack",

--- a/libraries/typescript/scripts/verify-beta-packs.mjs
+++ b/libraries/typescript/scripts/verify-beta-packs.mjs
@@ -29,6 +29,7 @@ try {
   for (const name of packages) {
     const packed = JSON.parse(
       run("pnpm", [
+        "--config.node-linker=hoisted",
         "--filter",
         name,
         "pack",
@@ -54,6 +55,13 @@ try {
         );
     }
     const files = new Set(packed.files.map(({ path }) => path));
+    for (const dependency of manifest.bundledDependencies ?? []) {
+      const prefix = `node_modules/${dependency}/`;
+      if (![...files].some((file) => file.startsWith(prefix)))
+        throw new Error(
+          `${name} is missing bundled dependency ${dependency} from its tarball`
+        );
+    }
     for (const bin of Object.values(manifest.bin ?? {})) {
       const target = bin.replace(/^\.\//, "");
       if (!files.has(target))


### PR DESCRIPTION
## Summary

- pack beta release tarballs with a command-local hoisted linker
- use the same pack configuration for verification and publication
- assert that every declared bundled dependency is present in the generated tarball

## Root cause

pnpm 11 rejects `bundledDependencies` when `pnpm pack` runs with its default isolated linker. This caused the TypeScript Release workflow to fail while packing `mcp-use`, which intentionally bundles `@modelcontextprotocol/client`.

The linker override is scoped to `pnpm pack`, preserving the workspace's isolated install behavior while retaining the bundled runtime dependency and its transitive closure.

## Validation

- `pnpm build`
- `pnpm test:beta-release`
- `pnpm verify:beta-packs`
- `pnpm verify:beta-plan --output beta-release-plan.json`
- `pnpm publish:beta -- --dry-run`
- ESLint and Prettier checks for the changed scripts

Fixes the failure in [TypeScript Release run 29605039975](https://github.com/mcp-use/mcp-use/actions/runs/29605039975).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix beta tarball packaging by running `pnpm pack` with a hoisted linker, so bundled deps are included and the TypeScript release workflow passes. This ensures `mcp-use` correctly bundles `@modelcontextprotocol/client`.

- **Bug Fixes**
  - Run `pnpm pack` with `--config.node-linker=hoisted` in publish and verify scripts.
  - Use the same pack flags for verification and publication.
  - Assert each `bundledDependencies` entry is present in the generated tarball.

<sup>Written for commit 36eba519365094b6dae4f7a3cc6a3e67b01c7bde. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

