### PR TITLE
fix(ci): retarget server typecheck workflow

### DIFF
--- a/.github/workflows/everything-typecheck.yml
+++ b/.github/workflows/everything-typecheck.yml
@@ -1,4 +1,4 @@
-name: Everything Server Type Check
+name: Server Type Check
 
 on:
   workflow_dispatch:
@@ -7,24 +7,28 @@ on:
       - main
       - canary
     paths:
-      - 'libraries/typescript/packages/mcp-use/src/**'
-      - 'libraries/typescript/packages/mcp-use/examples/server/features/everything/**'
-      - '.github/workflows/everything-typecheck.yml'
+      - "libraries/typescript/packages/server/src/**"
+      - "libraries/typescript/packages/server/tests/**"
+      - "libraries/typescript/packages/server/package.json"
+      - "libraries/typescript/packages/server/tsconfig*.json"
+      - ".github/workflows/everything-typecheck.yml"
   pull_request:
     branches:
       - main
       - canary
     paths:
-      - 'libraries/typescript/packages/mcp-use/src/**'
-      - 'libraries/typescript/packages/mcp-use/examples/server/features/everything/**'
-      - '.github/workflows/everything-typecheck.yml'
+      - "libraries/typescript/packages/server/src/**"
+      - "libraries/typescript/packages/server/tests/**"
+      - "libraries/typescript/packages/server/package.json"
+      - "libraries/typescript/packages/server/tsconfig*.json"
+      - ".github/workflows/everything-typecheck.yml"
 
 permissions:
   contents: read
 
 jobs:
   typecheck:
-    name: Type-check everything example
+    name: Type-check server contracts
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -35,12 +39,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: "24.15.0"
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10
+          version: 11.13.1
 
       - name: Install dependencies
         working-directory: libraries/typescript
@@ -50,6 +54,6 @@ jobs:
         working-directory: libraries/typescript
         run: pnpm build
 
-      - name: Type-check everything example
-        working-directory: libraries/typescript/packages/mcp-use/examples/server/features/everything
-        run: pnpm lint
+      - name: Type-check server contracts
+        working-directory: libraries/typescript/packages/server
+        run: pnpm typecheck

--- a/libraries/typescript/packages/server/tsconfig.test.json
+++ b/libraries/typescript/packages/server/tsconfig.test.json
@@ -14,5 +14,6 @@
     "rootDir": "."
   },
   "include": ["src/**/*", "tests/**/*"],
-  "exclude": ["node_modules", "dist", "tests/cli/.tmp"]
+  // Deno URL imports and globals are validated by the dedicated Deno workflow.
+  "exclude": ["node_modules", "dist", "tests/cli/.tmp", "tests/deno"]
 }

--- a/libraries/typescript/packages/server/vitest.config.ts
+++ b/libraries/typescript/packages/server/vitest.config.ts
@@ -8,7 +8,13 @@ export default defineConfig({
     globals: true,
     environment: "node",
     include: ["tests/**/*.test.ts", "tests/**/*.test.tsx"],
-    exclude: ["node_modules/**", "dist/**", "tests/cli/.tmp/**"],
+    // The Deno smoke test uses URL imports and runs in its dedicated workflow.
+    exclude: [
+      "node_modules/**",
+      "dist/**",
+      "tests/cli/.tmp/**",
+      "tests/deno/**",
+    ],
     // Real Vite build/dev servers in tests/cli/*.test.ts (moved from the
     // now-folded-in @mcp-use/devkit package) need more headroom than the rest
     // of this package's tests.


### PR DESCRIPTION
## Summary

- retarget the obsolete Everything Server workflow from the removed v1 example to the v2 server compile-time contracts
- align the workflow with the beta Node.js and pnpm toolchain
- keep the Deno-only smoke test out of Node TypeScript and Vitest runs because it is covered by the dedicated Deno preview workflow

## Root cause

The workflow still used `libraries/typescript/packages/mcp-use/examples/server/features/everything` as its working directory. That v1 example was removed during the beta server migration, so Actions failed before it could run the typecheck.

The v2 replacement is `libraries/typescript/packages/server/tsconfig.test.json`, which typechecks the server source and its compile-time contract tests.

## Validation

- full TypeScript build with Node.js 24.15.0 and pnpm 11.13.1
- `pnpm --filter mcp-use typecheck`
- `pnpm --filter mcp-use test:run` (29 files, 344 tests)
- Prettier and `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the broken server typecheck CI by targeting the v2 server contracts and aligning with the beta Node/pnpm toolchain. Deno-only tests are excluded from Node TypeScript and Vitest runs to avoid false failures.

- **Bug Fixes**
  - Retarget workflow triggers and working dir to `libraries/typescript/packages/server` (source + tests).
  - Run `pnpm typecheck` and rename job to "Type-check server contracts".
  - Update CI to Node 24.15.0 and `pnpm` 11.13.1.
  - Exclude `tests/deno` in `tsconfig.test.json` and `vitest.config.ts` (covered by the Deno workflow).

<sup>Written for commit 6324e437cb70b640d566c7016cf3094597dfd063. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

