### PR TITLE
Fix conformance workflow for beta package layout

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -18,12 +18,14 @@ on:
       - 'libraries/python/mcp_use/server/**'
       - 'libraries/python/mcp_use/client/**'
       - 'libraries/python/pyproject.toml'
-      - 'libraries/typescript/packages/mcp-use/src/server/**'
-      - 'libraries/typescript/packages/mcp-use/package.json'
+      - 'libraries/typescript/packages/server/src/**'
+      - 'libraries/typescript/packages/server/package.json'
+      - 'libraries/typescript/packages/client/src/**'
+      - 'libraries/typescript/packages/client/package.json'
       - 'libraries/python/tests/integration/servers_for_testing/conformance_server.py'
       - 'libraries/python/tests/integration/clients_for_testing/conformance_client.py'
-      - 'libraries/typescript/packages/mcp-use/examples/server/features/conformance/**'
-      - 'libraries/typescript/packages/mcp-use/examples/client/conformance/**'
+      - 'libraries/typescript/packages/server/examples/conformance/**'
+      - 'libraries/typescript/packages/client/examples/conformance/**'
       - '.github/workflows/conformance.yml'
   pull_request:
     branches:
@@ -33,13 +35,14 @@ on:
       - 'libraries/python/mcp_use/server/**'
       - 'libraries/python/mcp_use/client/**'
       - 'libraries/python/pyproject.toml'
-      - 'libraries/typescript/packages/mcp-use/src/server/**'
-      - 'libraries/typescript/packages/mcp-use/src/client/**'
-      - 'libraries/typescript/packages/mcp-use/package.json'
+      - 'libraries/typescript/packages/server/src/**'
+      - 'libraries/typescript/packages/server/package.json'
+      - 'libraries/typescript/packages/client/src/**'
+      - 'libraries/typescript/packages/client/package.json'
       - 'libraries/python/tests/integration/servers_for_testing/conformance_server.py'
       - 'libraries/python/tests/integration/clients_for_testing/conformance_client.py'
-      - 'libraries/typescript/packages/mcp-use/examples/server/features/conformance/**'
-      - 'libraries/typescript/packages/mcp-use/examples/client/conformance/**'
+      - 'libraries/typescript/packages/server/examples/conformance/**'
+      - 'libraries/typescript/packages/client/examples/conformance/**'
       - '.github/workflows/conformance.yml'
 
 permissions:
@@ -118,7 +121,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24.15.0'
 
       - name: Install pnpm
         if: needs.detect-changes.outputs.typescript == 'true'
@@ -143,12 +146,12 @@ jobs:
 
       - name: Install TypeScript conformance server dependencies
         if: needs.detect-changes.outputs.typescript == 'true'
-        working-directory: libraries/typescript/packages/mcp-use/examples/server/features/conformance
+        working-directory: libraries/typescript/packages/server/examples/conformance
         run: pnpm install
 
       - name: Install TypeScript conformance client dependencies
         if: needs.detect-changes.outputs.typescript == 'true'
-        working-directory: libraries/typescript/packages/mcp-use/examples/client/conformance
+        working-directory: libraries/typescript/packages/client/examples/conformance
         run: pnpm install
 
       - name: Build server list
@@ -165,7 +168,7 @@ jobs:
             if [[ $SERVERS != '[' ]]; then
               SERVERS+=','
             fi
-            SERVERS+='{"name":"typescript","start-command":"PORT=3000 npx tsx src/server.ts","url":"http://localhost:3000/mcp","working-directory":"libraries/typescript/packages/mcp-use/examples/server/features/conformance"}'
+            SERVERS+='{"name":"typescript","start-command":"PORT=3000 node ../../dist/bin.js dev --no-open","url":"http://localhost:3000/mcp","working-directory":"libraries/typescript/packages/server/examples/conformance"}'
           fi
           SERVERS+=']'
           echo "servers=$SERVERS" >> $GITHUB_OUTPUT
@@ -184,11 +187,11 @@ jobs:
             if [[ $CLIENTS != '[' ]]; then
               CLIENTS+=','
             fi
-            CLIENTS+='{"name":"typescript-node-client","command":"libraries/typescript/packages/mcp-use/examples/client/conformance/run-conformance-client-node.sh"}'
+            CLIENTS+='{"name":"typescript-node-client","command":"libraries/typescript/packages/client/examples/conformance/run-conformance-client-node.sh"}'
             CLIENTS+=','
-            CLIENTS+='{"name":"typescript-browser-client","command":"libraries/typescript/packages/mcp-use/examples/client/conformance/run-conformance-client-browser.sh"}'
+            CLIENTS+='{"name":"typescript-browser-client","command":"libraries/typescript/packages/client/examples/conformance/run-conformance-client-browser.sh"}'
             CLIENTS+=','
-            CLIENTS+='{"name":"typescript-react-client","command":"libraries/typescript/packages/mcp-use/examples/client/conformance/run-conformance-client-react.sh"}'
+            CLIENTS+='{"name":"typescript-react-client","command":"libraries/typescript/packages/client/examples/conformance/run-conformance-client-react.sh"}'
           fi
           CLIENTS+=']'
           echo "clients=$CLIENTS" >> $GITHUB_OUTPUT

--- a/libraries/typescript/packages/client/examples/conformance/src/conformance-shared.ts
+++ b/libraries/typescript/packages/client/examples/conformance/src/conformance-shared.ts
@@ -2,7 +2,7 @@ import type {
   ElicitRequestFormParams,
   ElicitRequestURLParams,
   ElicitResult,
-} from "@modelcontextprotocol/sdk/types.js";
+} from "@modelcontextprotocol/client";
 import { acceptWithDefaults } from "@mcp-use/client";
 
 type Tool = {

--- a/libraries/typescript/packages/client/examples/conformance/src/oauth-retry-fetch.ts
+++ b/libraries/typescript/packages/client/examples/conformance/src/oauth-retry-fetch.ts
@@ -7,8 +7,8 @@
 import {
   auth,
   extractWWWAuthenticateParams,
-} from "@modelcontextprotocol/sdk/client/auth.js";
-import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
+  type OAuthClientProvider,
+} from "@modelcontextprotocol/client";
 
 export type OAuthRetryFetchOptions = {
   /** Max number of 403 retries (for auth/scope-retry-limit). Omit for scope-step-up. */


### PR DESCRIPTION
## Summary

- update the MCP conformance workflow to the beta TypeScript server/client package layout
- run the relocated conformance server through the beta workspace CLI on Node 24
- migrate conformance-client imports from the removed v1 SDK package to @modelcontextprotocol/client

## Root cause

The workflow still referenced the removed packages/mcp-use/examples tree. Once those paths were corrected, the conformance clients also exposed stale imports from @modelcontextprotocol/sdk, which is no longer present in the beta dependency graph.

## Validation

- pnpm install --frozen-lockfile
- full TypeScript workspace pnpm build
- conformance-client pnpm typecheck
- started the relocated server and completed an MCP initialize request
- ran the Node, browser, and React conformance clients through the initialize scenario
- parsed the workflow YAML and ran formatting, stale-path, and diff checks

The React client continues to emit its existing non-fatal act(...) warnings.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the MCP conformance CI to match the beta TypeScript package layout and remove stale SDK imports. CI now runs the relocated TS conformance server via the workspace CLI on Node 24.

- **Bug Fixes**
  - Point workflow paths and working dirs to `libraries/typescript/packages/server/**` and `libraries/typescript/packages/client/**` examples.
  - Start the TS conformance server with `node ../../dist/bin.js dev --no-open` (replaces `npx tsx src/server.ts`).
  - Bump Actions Node to 24.15.0.
  - Switch conformance client imports from `@modelcontextprotocol/sdk` to `@modelcontextprotocol/client`.

<sup>Written for commit 178f849eef642b8a904f2afb9535f811af980857. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

