### PR TITLE
fix beta preview packaging and docs

### DIFF
--- a/.github/workflows/typescript-pr-preview.yml
+++ b/.github/workflows/typescript-pr-preview.yml
@@ -45,6 +45,8 @@ jobs:
         run: pnpm build
 
       - name: Publish Preview Packages
+        env:
+          PNPM_CONFIG_NODE_LINKER: hoisted
         run: pnpm dlx pkg-pr-new publish './libraries/typescript/packages/*' --pnpm
 
       - name: Get PR Number

--- a/docs/home/mcp101.mdx
+++ b/docs/home/mcp101.mdx
@@ -20,7 +20,8 @@ mcp-use is a fullstack MCP (Model Context Protocol) framework for Python and Typ
 - Python client/agent: `from mcp_use import MCPClient, MCPAgent`
 - TypeScript server: `import { MCPServer } from "mcp-use/server"`
 - TypeScript client/agent: `import { MCPClient } from "@mcp-use/client"` and `import { MCPAgent } from "@mcp-use/agent"`
-  </Visibility>
+
+</Visibility>
 
 ## What is MCP?
 

--- a/docs/typescript/server/deployment/supabase.mdx
+++ b/docs/typescript/server/deployment/supabase.mdx
@@ -45,8 +45,17 @@ cd your-project-name
 ```
 
 <CodeGroup>
-  ```bash npm npm install ``` ```bash pnpm pnpm install ``` ```bash yarn yarn
-  ```
+```bash npm
+npm install
+```
+
+```bash pnpm
+pnpm install
+```
+
+```bash yarn
+yarn install
+```
 </CodeGroup>
 
 ## Initialize Supabase Project


### PR DESCRIPTION
## What changed

- configure the PR preview publisher to use pnpm's hoisted linker
- fix the malformed `Visibility` block in the MCP 101 documentation
- normalize the Supabase dependency-install `CodeGroup` so Mint can parse it

## Why

The PR preview job invokes `pnpm pack` through `pkg-pr-new`. The server package has bundled dependencies, which pnpm cannot pack with the default isolated linker.

The documentation check also failed on malformed MDX. Fixing the first parser error exposed a second malformed code group in the Supabase guide.

## Impact

PR preview packages can be packed again, and the documentation validation can parse the affected pages.

## Validation

- `mint broken-links`
- workflow YAML parse
- `PNPM_CONFIG_NODE_LINKER=hoisted pnpm pack --json` for the server package
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix PR preview packaging by forcing `pnpm` to use the hoisted linker in the workflow, so preview packages pack correctly again. Also fix MDX docs: close the malformed `Visibility` block in MCP 101 and normalize the Supabase install `CodeGroup` so `Mint` parses them and docs checks pass.

<sup>Written for commit b0c8f006497b36352413058e01a777911f63b6cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

