### PR TITLE
docs: escape bare percent signs in changelog prose so mint broken-links stops failing

### DIFF
--- a/docs/python/changelog/1_7_0.mdx
+++ b/docs/python/changelog/1_7_0.mdx
@@ -8,7 +8,7 @@ og:image: "https://mcp-use.com/api/og/release?v=1.7.0"
 import { Contributors } from '/snippets/contributors.jsx'
 
 <Card img="https://mcp-use.com/api/og/release?v=1.7.0" title="Release 1.7.0" href="https://github.com/mcp-use/mcp-use/releases/tag/python-v1.7.0">
-  This release adds the **create-mcp-use CLI** for scaffolding new projects, **conformance test infrastructure**, **auto-retry ports**, and achieves **100% client conformance (20/20)**.
+  This release adds the **create-mcp-use CLI** for scaffolding new projects, **conformance test infrastructure**, **auto-retry ports**, and achieves **`100%` client conformance (20/20)**.
 </Card>
 
 ## New Features
@@ -65,10 +65,10 @@ Switched to `WeakSet` for resource subscriptions to prevent memory leaks on clie
 
 Fixed debug routes to be registered when `debug=True` is passed to `run()`.
 
-### 100% Client Conformance (20/20)
+### `100%` Client Conformance (20/20)
 **[PR #1019](https://github.com/mcp-use/mcp-use/pull/1019) by @pietrozullo**
 
-Achieved 100% client conformance score by fixing SSE retry handling.
+Achieved `100%` client conformance score by fixing SSE retry handling.
 
 ### Deprecated streamablehttp_client Replaced
 **[PR #1017](https://github.com/mcp-use/mcp-use/pull/1017) by @pietrozullo**

--- a/docs/python/changelog/changelog.mdx
+++ b/docs/python/changelog/changelog.mdx
@@ -16,7 +16,7 @@ import { Contributors } from '/snippets/contributors.jsx'
   - **New**: `mcp_logs_only` option to hide non-MCP HTTP access logs ([#1164](https://github.com/mcp-use/mcp-use/pull/1164))
   - **New**: Conformance test infrastructure for server + client ([#1008](https://github.com/mcp-use/mcp-use/pull/1008))
   - **New**: Protocol handlers for logging, completions, subscriptions ([#1004](https://github.com/mcp-use/mcp-use/pull/1004))
-  - **Fix**: 100% client conformance (20/20)  -  SSE retry fix ([#1019](https://github.com/mcp-use/mcp-use/pull/1019))
+  - **Fix**: `100%` client conformance (20/20)  -  SSE retry fix ([#1019](https://github.com/mcp-use/mcp-use/pull/1019))
   - **Fix**: WeakSet for resource subscriptions to prevent memory leak ([#1093](https://github.com/mcp-use/mcp-use/pull/1093))
   - **Fix**: Simplified Optional parameter JSON Schema ([#1141](https://github.com/mcp-use/mcp-use/pull/1141))
   - **Fix**: Respect configured inspector path ([#1176](https://github.com/mcp-use/mcp-use/pull/1176))


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

Check all that apply:
- [ ] TypeScript
- [ ] Python
- [x] Documentation only
- [ ] CI/CD or tooling

## Changes

The `mint broken-links` step in the docs workflow fails on every PR with `URIError: URI malformed` while parsing `python/changelog/1_7_0.mdx`. The current `mint` CLI URI-decodes prose, and a bare `%` in text (as in `100% client conformance`) makes `decodeURI` throw because the `%` is not followed by two hex digits. This wraps the affected `100%` figures in inline code spans so the parser no longer decodes them, while the rendered text is unchanged. The same bare-percent prose also existed on the changelog index page, so it is fixed too. Percent-encoded URL sequences (`%20`) are valid and left untouched.

## Review Readiness

Help maintainers review this quickly:

- [x] The PR is scoped to one issue or one clearly related change
- [x] The PR description explains the user-visible problem and the fix
- [x] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [x] I verified the affected package/docs path with the commands listed below
- [x] I checked for existing open PRs that already solve the same issue

## Implementation Details

1. `docs/python/changelog/1_7_0.mdx`: wrapped the three bare `100%` occurrences (card intro, section heading, section body) in backticks.
2. `docs/python/changelog/changelog.mdx`: wrapped the one bare `100%` occurrence in the v1.7.0 entry in backticks.
3. No workflow, dependency, or code changes; valid `%20` URL encoding elsewhere in the changelog is left as-is.

---

## Example Usage (Before)

```
mint broken-links
error Syntax error - Unable to parse python/changelog/1_7_0.mdx - URIError: URI malformed
```

## Example Usage (After)

```
mint broken-links
# no URIError; broken-links check proceeds normally
```

## Documentation Updates

* `docs/python/changelog/1_7_0.mdx`: escaped bare `%` in the card intro, the "100% Client Conformance" heading, and its body line.
* `docs/python/changelog/changelog.mdx`: escaped the bare `%` in the v1.7.0 "100% client conformance" bullet.

## Testing

Describe how you tested these changes:
- Confirmed the only remaining `%` occurrences in the changelog docs are valid `%20` URL encoding, which `decodeURI` accepts.
- Confirmed the escaped figures now sit inside inline code spans, so `mint` no longer URI-decodes them.

## Backwards Compatibility

Documentation-only change. The rendered pages are unchanged; the figures still read as `100%`.

## Related Issues

Closes #1910


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Escapes bare percent signs in the Python changelog so `mint broken-links` stops failing with a URIError. Wraps `100%` occurrences in inline code without changing rendered text or valid `%20` URLs.

<sup>Written for commit a3fe85cf29b1117312743399d3f08cc46c34673d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

