### PR TITLE
feat(server): add resource template completions

### DIFF
--- a/libraries/typescript/.changeset/resource-template-completion.md
+++ b/libraries/typescript/.changeset/resource-template-completion.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": minor
+---
+
+Add typed static and callback completion providers for resource-template URI variables.

--- a/libraries/typescript/packages/server/examples/resource-template-completion/package.json
+++ b/libraries/typescript/packages/server/examples/resource-template-completion/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "mcp-use-example-resource-template-completion",
+  "type": "module",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Example: static and contextual resource-template completion with mcp-use.",
+  "engines": {
+    "node": ">=24.0.0"
+  },
+  "scripts": {
+    "dev": "mcp-use dev",
+    "build": "mcp-use build",
+    "start": "mcp-use start",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "mcp-use": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^24.13.2",
+    "typescript": "7.0.1-rc",
+    "vite": "^8.0.16"
+  }
+}

--- a/libraries/typescript/packages/server/examples/resource-template-completion/src/index.ts
+++ b/libraries/typescript/packages/server/examples/resource-template-completion/src/index.ts
@@ -1,0 +1,42 @@
+import { MCPServer } from "mcp-use";
+
+const server = new MCPServer({
+  name: "resource-template-completion-example",
+  version: "1.0.0",
+});
+
+const repositories: Record<string, readonly string[]> = {
+  openai: ["codex", "openai-node"],
+  modelcontextprotocol: ["typescript-sdk", "specification"],
+};
+
+server.resourceTemplate(
+  {
+    name: "repository-file",
+    uriTemplate: "repo://{owner}/{repository}/{path}",
+    complete: {
+      owner: ["openai", "modelcontextprotocol"],
+      repository: (value, context) => {
+        const owner = context?.arguments?.owner ?? "";
+        return (repositories[owner] ?? []).filter((repository) =>
+          repository.startsWith(value)
+        );
+      },
+      path: async (value) =>
+        ["README.md", "package.json", "src/index.ts"].filter((path) =>
+          path.startsWith(value)
+        ),
+    },
+  },
+  async (uri, { owner, repository, path }) => ({
+    contents: [
+      {
+        uri: uri.href,
+        mimeType: "text/plain",
+        text: `${String(owner)}/${String(repository)}/${String(path)}`,
+      },
+    ],
+  })
+);
+
+export default server;

--- a/libraries/typescript/packages/server/examples/resource-template-completion/tsconfig.json
+++ b/libraries/typescript/packages/server/examples/resource-template-completion/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2024"],
+    "types": ["node"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}

--- a/libraries/typescript/packages/server/specs/SPEC.md
+++ b/libraries/typescript/packages/server/specs/SPEC.md
@@ -90,9 +90,16 @@ server.resource(
 server.resourceTemplate(
   {
     name: "users",
-    uriTemplate: "db://users/{id}",
+    uriTemplate: "db://users/{region}/{id}",
     annotations: { audience: ["assistant"] },
     _meta: { "db.example/entity": "user" },
+    complete: {
+      region: ["us-east", "us-west"],
+      id: async (value, context) =>
+        listUserIds(context?.arguments?.region).then((ids) =>
+          ids.filter((id) => id.startsWith(value))
+        ),
+    },
   },
   async (uri, params, ctx) => ({
     contents: [{ uri: uri.href, text: String(params.id) }], // params typed from the template
@@ -157,7 +164,8 @@ For the common human-input path, `await ctx.elicit(key, message, schemaOrUrl)` c
 6. `inputSchema`/`outputSchema` accept any Standard Schema validator with JSON Schema support (`StandardSchemaWithJSON`), not just zod (old package: zod peer dep). Tool definitions also accept `schema` as an alias for `inputSchema`. Zod v4 schemas work unchanged; zod is no longer a dependency of this package.
 7. Tools declaring an `outputSchema` must return matching `structuredContent` or an `isError: true` result — content-only returns are a **compile-time** error (old package: compiled, then failed at call time in output validation). Not protocol-forced, but the protocol rule made real in types (`ToolResult<TOutput>` over raw `CallToolResult`); `tests/type-level.test.ts` pins it, including non-object schema roots (`z.array(…)`, `z.number()`).
 8. `resourceTemplate()` uses a `const` type parameter so `uriTemplate` stays a string literal through inference — without it TS widens object-literal properties to `string` and template-param typing silently degrades to `Record<string, string | string[]>` (it had, undetected, before the type-level tests). Template inference handles RFC 6570 operators, comma-separated variable lists, and `*`/`:n` modifiers.
-9. The modern wire is the per-request `_meta` envelope, not a handshake (see the 2026-07-28-first ground rule; 2025-era clients are served through the stateless legacy fallback by default, or rejected under `legacy: "reject"`). The official client connects modern with `versionNegotiation: { mode: { pin: "2026-07-28" } }` (or `'auto'`) — its default is the legacy handshake. Hand-rolled modern requests carry the per-request `_meta` envelope (`protocolVersion`/`clientInfo`/`clientCapabilities` keys) plus `mcp-protocol-version`/`mcp-method` headers, and `mcp-name` mirroring `params.name` on name-addressed methods; modern exchanges answer with a single JSON body (`responseMode: 'auto'`), not SSE framing.
+9. Resource-template completions live in the definition's `complete` map. Literal `uriTemplate` values restrict keys to variables extracted by the same RFC 6570-aware inference used for read params; widened string templates fall back to string keys. A value is either a readonly string array or the official SDK `CompleteResourceTemplateCallback`, so dynamic completion may be synchronous or asynchronous and receives `(currentValue, { arguments?: Record<string, string> })`. Static arrays preserve declaration order and use case-insensitive, untrimmed prefix matching. The SDK owns the protocol result: it truncates `values` to 100, sets `total` to the callback array length, and sets `hasMore` when that length exceeds 100. Missing variable completers return an empty completion, an unknown resource-template URI is an invalid-params error, and callback errors propagate as protocol errors. The SDK does not provide request `ServerContext`, auth, progress, or cancellation to resource-template completion callbacks, so this API does not claim those capabilities. Completions are replayed through the ordinary per-request resource-template registry for both modern and stateless legacy traffic; duplicate names retain the registry's last-registration-wins behavior and registration remains frozen after `listen()`/`getHandler()`.
+10. The modern wire is the per-request `_meta` envelope, not a handshake (see the 2026-07-28-first ground rule; 2025-era clients are served through the stateless legacy fallback by default, or rejected under `legacy: "reject"`). The official client connects modern with `versionNegotiation: { mode: { pin: "2026-07-28" } }` (or `'auto'`) — its default is the legacy handshake. Hand-rolled modern requests carry the per-request `_meta` envelope (`protocolVersion`/`clientInfo`/`clientCapabilities` keys) plus `mcp-protocol-version`/`mcp-method` headers, and `mcp-name` mirroring `params.name` on name-addressed methods; modern exchanges answer with a single JSON body (`responseMode: 'auto'`), not SSE framing.
 
 ### Browser landing page
 

--- a/libraries/typescript/packages/server/src/completable.ts
+++ b/libraries/typescript/packages/server/src/completable.ts
@@ -16,6 +16,26 @@ export type CompletionCallback = (
 ) => string[] | Promise<string[]>;
 
 /**
+ * Build the shared case-insensitive prefix completer used by static values.
+ *
+ * @param values - Values retained in declaration order and stringified once.
+ * @returns A callback that filters the values against an untrimmed prefix.
+ *
+ * @internal
+ */
+export function createPrefixCompletion(
+  values: ReadonlyArray<string | number | boolean>
+): (value: unknown) => string[] {
+  const strings = values.map(String);
+  return (value) => {
+    const prefix = String(value ?? "").toLowerCase();
+    return strings.filter((candidate) =>
+      candidate.toLowerCase().startsWith(prefix)
+    );
+  };
+}
+
+/**
  * Make a schema field completable so clients can request autocomplete
  * suggestions via `completion/complete`.
  *
@@ -47,9 +67,5 @@ export function completable<T extends StandardSchemaV1>(
       complete(String(value ?? ""), context)
     );
   }
-  const values = complete.map(String);
-  return sdkCompletable(schema, (value) => {
-    const prefix = String(value ?? "").toLowerCase();
-    return values.filter((v) => v.toLowerCase().startsWith(prefix));
-  });
+  return sdkCompletable(schema, createPrefixCompletion(complete));
 }

--- a/libraries/typescript/packages/server/src/index.ts
+++ b/libraries/typescript/packages/server/src/index.ts
@@ -142,6 +142,8 @@ export type {
   ResourceCallback,
   ResourceDefinition,
   ResourceTemplateCallback,
+  ResourceTemplateCompleter,
+  ResourceTemplateCompletions,
   ResourceTemplateDefinition,
   TemplateVariableValue,
 } from "./resources.js";

--- a/libraries/typescript/packages/server/src/resource-completion.ts
+++ b/libraries/typescript/packages/server/src/resource-completion.ts
@@ -1,0 +1,28 @@
+import type { CompleteResourceTemplateCallback } from "@modelcontextprotocol/server";
+
+import { createPrefixCompletion } from "./completable.js";
+import type { ResourceTemplateCompleter } from "./resources.js";
+
+/**
+ * Convert public static and callback completions to the SDK callback map.
+ *
+ * @param completions - Public completion providers keyed by template variable.
+ * @returns The callback-only map required by the official SDK.
+ *
+ * @internal
+ */
+export function normalizeCompletions(
+  completions: Readonly<Record<string, ResourceTemplateCompleter | undefined>>
+): Record<string, CompleteResourceTemplateCallback> {
+  const normalized = Object.create(null) as Record<
+    string,
+    CompleteResourceTemplateCallback
+  >;
+  for (const [variable, completer] of Object.entries(completions)) {
+    if (completer === undefined) continue;
+    normalized[variable] = Array.isArray(completer)
+      ? createPrefixCompletion(completer)
+      : (completer as CompleteResourceTemplateCallback);
+  }
+  return normalized;
+}

--- a/libraries/typescript/packages/server/src/resources.ts
+++ b/libraries/typescript/packages/server/src/resources.ts
@@ -1,5 +1,6 @@
 import type {
   Annotations,
+  CompleteResourceTemplateCallback,
   MetaObject,
   ReadResourceResult,
 } from "@modelcontextprotocol/server";
@@ -52,12 +53,52 @@ export type ResourceCallback<
   ctx: RequestContext<TUser, HasOAuth>
 ) => ReadResourceResult | Promise<ReadResourceResult>;
 
-/** Declares a parameterized resource matched by URI template. First argument to {@link MCPServer.resourceTemplate}. */
-export interface ResourceTemplateDefinition {
+/**
+ * A resource-template variable completer accepted by
+ * {@link MCPServer.resourceTemplate}.
+ *
+ * Static values are matched case-insensitively against the beginning of the
+ * current value. Callback completions use the official SDK callback shape and
+ * may inspect the other resolved string arguments in its optional context.
+ * The SDK limits wire results to 100 values and derives `total` and `hasMore`
+ * from the returned array.
+ */
+export type ResourceTemplateCompleter =
+  | readonly string[]
+  | CompleteResourceTemplateCallback;
+
+/**
+ * Per-variable completion map inferred from an RFC 6570 URI template.
+ *
+ * Literal templates accept only variables declared by the template. A
+ * widened `string` template accepts arbitrary string keys because its
+ * variables cannot be known at compile time.
+ *
+ * @typeParam TUriTemplate - URI template whose variables become map keys.
+ */
+export type ResourceTemplateCompletions<TUriTemplate extends string> =
+  string extends TUriTemplate
+    ? Partial<Record<string, ResourceTemplateCompleter>>
+    : Partial<
+        Record<
+          ExtractTemplateVariables<TUriTemplate>,
+          ResourceTemplateCompleter
+        >
+      >;
+
+/**
+ * Declares a parameterized resource matched by URI template.
+ *
+ * @typeParam TUriTemplate - Literal URI template used to infer read variables
+ * and completion keys.
+ */
+export interface ResourceTemplateDefinition<
+  TUriTemplate extends string = string,
+> {
   /** Template display name. */
   name: string;
   /** RFC 6570 URI template with variables, e.g. `"db://users/{id}"`. */
-  uriTemplate: string;
+  uriTemplate: TUriTemplate;
   /** Human-readable title (falls back to `name`). */
   title?: string;
   /** Human-readable description. */
@@ -75,6 +116,14 @@ export interface ResourceTemplateDefinition {
    * metadata must be returned by the callback on each entry's own `_meta`.
    */
   _meta?: MetaObject;
+  /**
+   * Optional completion providers keyed by URI-template variable.
+   *
+   * Static arrays use case-insensitive prefix matching. Dynamic callbacks may
+   * be synchronous or asynchronous and receive the current value plus the
+   * official completion context containing already-resolved arguments.
+   */
+  complete?: ResourceTemplateCompletions<TUriTemplate>;
 }
 
 /** Strip a leading RFC 6570 operator (`+`, `#`, `.`, `/`, `;`, `?`, `&`) from a template expression. */

--- a/libraries/typescript/packages/server/src/server.ts
+++ b/libraries/typescript/packages/server/src/server.ts
@@ -52,6 +52,7 @@ import {
 } from "./inspector-shell.js";
 import { requestLogger } from "./logging.js";
 import { createMcpMount } from "./mount-mcp.js";
+import { normalizeCompletions } from "./resource-completion.js";
 import type { NodeRequestHandler } from "./node-bridge.js";
 import { registerOpenAPITools } from "./openapi/index.js";
 import type { FromOpenAPIOptions } from "./openapi/types.js";
@@ -145,6 +146,8 @@ interface ResourceTemplateEntry<TUser> {
     TUser,
     HasOAuth<TUser>
   >;
+  /** SDK callback map normalized once at author-time registration. */
+  complete?: ReturnType<typeof normalizeCompletions>;
 }
 
 /** Prompt definition and type-erased callback retained for request-time replay. */
@@ -388,17 +391,22 @@ export class MCPServer<TUser = never> {
    * `string`), which is what lets `InferTemplateParams` type the callback's
    * `params` from the template's variables.
    */
-  resourceTemplate<const T extends ResourceTemplateDefinition>(
-    definition: T,
+  resourceTemplate<const TUriTemplate extends string>(
+    definition: ResourceTemplateDefinition<TUriTemplate>,
     callback: ResourceTemplateCallback<
-      InferTemplateParams<T>,
+      InferTemplateParams<{ uriTemplate: TUriTemplate }>,
       TUser,
       HasOAuth<TUser>
     >
   ): this {
     this.#assertNotStarted("resourceTemplate", definition.name);
+    const complete =
+      definition.complete === undefined
+        ? undefined
+        : normalizeCompletions(definition.complete);
     this.#resourceTemplates.set(definition.name, {
       definition,
+      ...(complete !== undefined && { complete }),
       callback: callback as ResourceTemplateCallback<
         Record<string, TemplateVariableValue>,
         TUser,
@@ -1362,10 +1370,11 @@ export class MCPServer<TUser = never> {
 
   #registerResourceTemplate(
     server: SdkMcpServer,
-    { definition, callback }: ResourceTemplateEntry<TUser>
+    { definition, callback, complete }: ResourceTemplateEntry<TUser>
   ): void {
     const template = new ResourceTemplate(definition.uriTemplate, {
       list: undefined,
+      ...(complete !== undefined && { complete }),
     });
     server.registerResource(
       definition.name,

--- a/libraries/typescript/packages/server/tests/resource-template-completion.test.ts
+++ b/libraries/typescript/packages/server/tests/resource-template-completion.test.ts
@@ -1,0 +1,271 @@
+import {
+  Client,
+  StreamableHTTPClientTransport,
+} from "@modelcontextprotocol/client";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { MCPServer } from "../src/index.js";
+import { listenFetch } from "./helpers/listen-fetch.js";
+
+function completionServer(): MCPServer {
+  const server = new MCPServer({
+    name: "resource-template-completion",
+    version: "1.0.0",
+  });
+
+  server.resourceTemplate(
+    {
+      name: "catalog",
+      uriTemplate: "catalog://{region}/{kind}/{item}",
+      complete: {
+        region: ["US-East", "us-west", "eu-central"] as const,
+        kind: (value) =>
+          ["book", "board-game", "film"].filter((kind) =>
+            kind.startsWith(value)
+          ),
+        item: async (value, context) => {
+          await Promise.resolve();
+          const prefix = `${context?.arguments?.region ?? "none"}:`;
+          return [`${prefix}alpha`, `${prefix}beta`].filter((item) =>
+            item.endsWith(value)
+          );
+        },
+      },
+    },
+    async (uri) => ({ contents: [{ uri: uri.href, text: "catalog" }] })
+  );
+
+  server.resourceTemplate(
+    {
+      name: "edge-cases",
+      uriTemplate: "edge://{empty}/{large}/{failure}/{plain}",
+      complete: {
+        empty: [],
+        large: () => Array.from({ length: 125 }, (_, index) => `v${index}`),
+        failure: () => {
+          throw new Error("completion exploded");
+        },
+      },
+    },
+    async (uri) => ({ contents: [{ uri: uri.href, text: "edge" }] })
+  );
+
+  server.resourceTemplate(
+    {
+      name: "duplicate",
+      uriTemplate: "duplicate://{value}",
+      complete: { value: ["first"] },
+    },
+    async (uri) => ({ contents: [{ uri: uri.href, text: "first" }] })
+  );
+  server.resourceTemplate(
+    {
+      name: "duplicate",
+      uriTemplate: "duplicate://{value}",
+      complete: { value: ["second"] },
+    },
+    async (uri) => ({ contents: [{ uri: uri.href, text: "second" }] })
+  );
+
+  return server;
+}
+
+async function connect(url: string, modern: boolean): Promise<Client> {
+  const client = new Client(
+    { name: modern ? "modern-client" : "legacy-client", version: "1.0.0" },
+    modern ? { versionNegotiation: { mode: { pin: "2026-07-28" } } } : undefined
+  );
+  await client.connect(new StreamableHTTPClientTransport(new URL(url)));
+  return client;
+}
+
+describe("resource-template completion over HTTP", () => {
+  const server = completionServer();
+  let url: string;
+  let modern: Client;
+  let legacy: Client;
+
+  beforeAll(async () => {
+    const started = await server.listen(0);
+    url = started.url;
+    [modern, legacy] = await Promise.all([
+      connect(url, true),
+      connect(url, false),
+    ]);
+  });
+
+  afterAll(async () => {
+    await Promise.all([modern.close(), legacy.close()]);
+    await server.close();
+  });
+
+  it("filters static readonly values by an untrimmed case-insensitive prefix", async () => {
+    const matching = await modern.complete({
+      ref: { type: "ref/resource", uri: "catalog://{region}/{kind}/{item}" },
+      argument: { name: "region", value: "us-" },
+    });
+    expect(matching.completion).toEqual({
+      values: ["US-East", "us-west"],
+      total: 2,
+      hasMore: false,
+    });
+
+    const untrimmed = await modern.complete({
+      ref: { type: "ref/resource", uri: "catalog://{region}/{kind}/{item}" },
+      argument: { name: "region", value: " us-" },
+    });
+    expect(untrimmed.completion.values).toEqual([]);
+  });
+
+  it("supports sync and async completers for different variables", async () => {
+    const kind = await modern.complete({
+      ref: { type: "ref/resource", uri: "catalog://{region}/{kind}/{item}" },
+      argument: { name: "kind", value: "bo" },
+    });
+    expect(kind.completion.values).toEqual(["book", "board-game"]);
+
+    const item = await modern.complete({
+      ref: { type: "ref/resource", uri: "catalog://{region}/{kind}/{item}" },
+      argument: { name: "item", value: "alpha" },
+      context: { arguments: { region: "eu" } },
+    });
+    expect(item.completion.values).toEqual(["eu:alpha"]);
+  });
+
+  it("returns empty results for empty providers and variables without a provider", async () => {
+    const empty = await modern.complete({
+      ref: {
+        type: "ref/resource",
+        uri: "edge://{empty}/{large}/{failure}/{plain}",
+      },
+      argument: { name: "empty", value: "" },
+    });
+    expect(empty.completion.values).toEqual([]);
+
+    const plain = await modern.complete({
+      ref: {
+        type: "ref/resource",
+        uri: "edge://{empty}/{large}/{failure}/{plain}",
+      },
+      argument: { name: "plain", value: "anything" },
+    });
+    expect(plain.completion).toEqual({ values: [], hasMore: false });
+
+    const inheritedName = await modern.complete({
+      ref: {
+        type: "ref/resource",
+        uri: "edge://{empty}/{large}/{failure}/{plain}",
+      },
+      argument: { name: "toString", value: "anything" },
+    });
+    expect(inheritedName.completion).toEqual({ values: [], hasMore: false });
+
+    const unknown = await modern.complete({
+      ref: {
+        type: "ref/resource",
+        uri: "edge://{empty}/{large}/{failure}/{plain}",
+      },
+      argument: { name: "unknown", value: "anything" },
+    });
+    expect(unknown.completion).toEqual({ values: [], hasMore: false });
+  });
+
+  it("lets the SDK cap large results and report total and hasMore", async () => {
+    const result = await modern.complete({
+      ref: {
+        type: "ref/resource",
+        uri: "edge://{empty}/{large}/{failure}/{plain}",
+      },
+      argument: { name: "large", value: "" },
+    });
+    expect(result.completion.values).toHaveLength(100);
+    expect(result.completion.total).toBe(125);
+    expect(result.completion.hasMore).toBe(true);
+  });
+
+  it("surfaces unknown refs and callback errors as protocol failures", async () => {
+    await expect(
+      modern.complete({
+        ref: { type: "ref/resource", uri: "missing://{value}" },
+        argument: { name: "value", value: "" },
+      })
+    ).rejects.toThrow(/not found/i);
+
+    await expect(
+      modern.complete({
+        ref: {
+          type: "ref/resource",
+          uri: "edge://{empty}/{large}/{failure}/{plain}",
+        },
+        argument: { name: "failure", value: "" },
+      })
+    ).rejects.toThrow(/completion exploded/);
+  });
+
+  it("keeps request context isolated across concurrent completions", async () => {
+    const results = await Promise.all(
+      ["north", "south", "west"].map((region) =>
+        modern.complete({
+          ref: {
+            type: "ref/resource",
+            uri: "catalog://{region}/{kind}/{item}",
+          },
+          argument: { name: "item", value: "beta" },
+          context: { arguments: { region } },
+        })
+      )
+    );
+    expect(results.map((result) => result.completion.values[0])).toEqual([
+      "north:beta",
+      "south:beta",
+      "west:beta",
+    ]);
+  });
+
+  it("serves the same completion through the stateless legacy path", async () => {
+    const result = await legacy.complete({
+      ref: { type: "ref/resource", uri: "catalog://{region}/{kind}/{item}" },
+      argument: { name: "region", value: "eu" },
+    });
+    expect(result.completion.values).toEqual(["eu-central"]);
+  });
+
+  it("uses the last duplicate registration and freezes after listen", async () => {
+    const result = await modern.complete({
+      ref: { type: "ref/resource", uri: "duplicate://{value}" },
+      argument: { name: "value", value: "" },
+    });
+    expect(result.completion.values).toEqual(["second"]);
+    expect(() =>
+      server.resourceTemplate(
+        {
+          name: "late",
+          uriTemplate: "late://{value}",
+          complete: { value: ["late"] },
+        },
+        async (uri) => ({ contents: [{ uri: uri.href, text: "late" }] })
+      )
+    ).toThrow(/after the server has started/);
+  });
+});
+
+describe("getHandler resource-template completion", () => {
+  it("matches listen() behavior over real HTTP", async () => {
+    const mounted = completionServer();
+    const listener = await listenFetch(mounted.getHandler());
+    const client = await connect(`${listener.url}/mcp`, true);
+    try {
+      const result = await client.complete({
+        ref: {
+          type: "ref/resource",
+          uri: "catalog://{region}/{kind}/{item}",
+        },
+        argument: { name: "region", value: "US" },
+      });
+      expect(result.completion.values).toEqual(["US-East", "us-west"]);
+    } finally {
+      await client.close();
+      await listener.close();
+    }
+  });
+});

--- a/libraries/typescript/packages/server/tests/type-level.test.ts
+++ b/libraries/typescript/packages/server/tests/type-level.test.ts
@@ -285,6 +285,45 @@ describe("template variable inference", () => {
     );
     expect(true).toBe(true); // assertions above are compile-time
   });
+
+  it("infers completion keys and the official callback context", () => {
+    const server = new MCPServer({ name: "types", version: "0.0.0" });
+    server.resourceTemplate(
+      {
+        name: "completed",
+        uriTemplate: "repo://{owner}/{repo}{?ref}",
+        complete: {
+          owner: ["modelcontextprotocol"] as const,
+          repo: async (value, context) => {
+            expectTypeOf(value).toEqualTypeOf<string>();
+            expectTypeOf(context?.arguments).toEqualTypeOf<
+              Record<string, string> | undefined
+            >();
+            // @ts-expect-error The pinned SDK does not expose cancellation here.
+            void context?.signal;
+            // @ts-expect-error The pinned SDK does not expose request auth here.
+            void context?.auth;
+            return [value];
+          },
+          ref: (value) => [value],
+        },
+      },
+      async (uri) => ({ contents: [{ uri: uri.href, text: "ok" }] })
+    );
+
+    server.resourceTemplate(
+      {
+        name: "invalid-completion-key",
+        uriTemplate: "repo://{owner}/{repo}",
+        complete: {
+          // @ts-expect-error "branch" is not a variable in the literal template.
+          branch: ["main"],
+        },
+      },
+      async (uri) => ({ contents: [{ uri: uri.href, text: "ok" }] })
+    );
+    expect(true).toBe(true);
+  });
 });
 
 describe("ToolRef inference", () => {

--- a/libraries/typescript/packages/server/tsup.config.ts
+++ b/libraries/typescript/packages/server/tsup.config.ts
@@ -19,6 +19,9 @@ export default defineConfig([
       // Landing markup stays lazy on the MCP path and directly importable
       // from `mcp-use/landing` without inflating the root runtime entry.
       landing: "src/landing.ts",
+      // Completion normalization is a synchronous internal dependency kept
+      // outside the root entry's independently enforced size budget.
+      "internal/resource-completion": "src/resource-completion.ts",
       // The `mcp-use` bin (package.json "bin"). Its source shebang is
       // preserved by esbuild, so dist/bin.js stays directly executable.
       bin: "src/bin.ts",

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -706,6 +706,22 @@ importers:
         specifier: 7.0.1-rc
         version: 7.0.1-rc
 
+  packages/server/examples/resource-template-completion:
+    dependencies:
+      mcp-use:
+        specifier: workspace:*
+        version: link:../..
+    devDependencies:
+      '@types/node':
+        specifier: ^24.13.2
+        version: 24.13.2
+      typescript:
+        specifier: 7.0.1-rc
+        version: 7.0.1-rc
+      vite:
+        specifier: '>=8.0.5'
+        version: 8.0.16(@types/node@24.13.2)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+
   packages/server/examples/vercel:
     dependencies:
       mcp-use:


### PR DESCRIPTION
## Summary

- add strictly typed per-variable completion providers to v2 resource-template definitions
- support readonly static values plus official synchronous and asynchronous SDK callbacks
- replay completion callbacks through the stateless resource-template registry for modern and legacy clients
- document SDK result limits and context limitations, with a focused example and changeset
- cover inference, invalid keys, prefix behavior, contextual callbacks, errors, large results, concurrency, duplicate registration, and HTTP serving paths

## Validation

- `pnpm --filter mcp-use typecheck`
- `pnpm --filter mcp-use build`
- `pnpm --filter mcp-use exec vitest run --exclude tests/cli/dev.test.ts` — 358 passed
- focused completion/core/budget suite — 47 passed
- `pnpm exec eslint packages/server`
- `pnpm exec prettier --check packages/server .changeset/resource-template-completion.md pnpm-lock.yaml`
- focused example typecheck
- published entry: 62,138 bytes (326 bytes below budget)

## Notes

The pinned official SDK only supplies the current value and already-resolved string arguments to resource-template completers. It does not expose request auth, progress, or cancellation context, and it owns the 100-value truncation plus `total`/`hasMore` calculation.

A full `test:run` attempt also encountered five unrelated CLI development file-watcher timeouts; all non-hot-reload package tests passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add typed per-variable completions for resource-template URIs in the `mcp-use` server, supporting static arrays and sync/async callbacks. Works with modern `_meta` and legacy clients, with docs, example, and tests.

- **New Features**
  - `resourceTemplate({ complete })`: each variable can use a readonly string array or `@modelcontextprotocol/server`’s `CompleteResourceTemplateCallback`.
  - Strong typing: keys are inferred from literal RFC 6570 templates via `ResourceTemplateCompletions<TUriTemplate>`; widened `string` templates fall back to string keys.
  - Behavior: static arrays preserve order and use case-insensitive, untrimmed prefix matching; callbacks receive `(value, { arguments })`; SDK truncates to 100 and sets `total`/`hasMore`; missing providers return empty results; unknown refs and callback errors surface as protocol errors.
  - Transport: completions are normalized to SDK callbacks at registration and served via the per-request registry for modern `_meta` and stateless legacy paths; duplicate names are last-wins; registry locks after `listen()`.
  - Exports and docs: export `ResourceTemplateCompleter` and `ResourceTemplateCompletions`; update `SPEC.md`; add runnable example at `libraries/typescript/packages/server/examples/resource-template-completion`; tests cover inference, invalid keys, prefix behavior, context, errors, large lists, concurrency, duplicates, legacy/modern HTTP; add `internal/resource-completion` build entry to keep normalization outside the root entry’s size budget.

<sup>Written for commit 967eca24b7bd49c854bd0521eb909430a1119ff4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

