### PR TITLE
feat(server): add v2 server branding

### DIFF
--- a/docs/typescript/api-reference/server/server-config.mdx
+++ b/docs/typescript/api-reference/server/server-config.mdx
@@ -81,8 +81,10 @@ public/
 
 ```ts
 import type { Icon, ServerOptions } from "@modelcontextprotocol/server";
+import type { CorsOptions, InspectorOptions, LoggingOptions } from "mcp-use";
+import type { OAuthProvider } from "mcp-use/oauth";
 
-interface ServerConfig<TUser = never> {
+interface BaseServerConfig {
   name: string;
   version: string;
   title?: string;
@@ -101,11 +103,15 @@ interface ServerConfig<TUser = never> {
   inspector?: InspectorOptions;
   logging?: LoggingOptions;
   requestState?: ServerOptions["requestState"];
-  oauth?: OAuthProvider<TUser>;
 }
+
+type ServerConfig<TUser = never> = BaseServerConfig &
+  ([TUser] extends [never]
+    ? { oauth?: undefined }
+    : { oauth: OAuthProvider<TUser> });
 ```
 
-The actual `ServerConfig<TUser>` type conditionally requires `oauth` when `TUser` is not `never`.
+`ServerConfig<TUser>` requires `oauth` when `TUser` is not `never` and rejects it when no authenticated user type is declared.
 
 ## Use branding in browser pages
 

--- a/docs/typescript/api-reference/server/server-config.mdx
+++ b/docs/typescript/api-reference/server/server-config.mdx
@@ -1,128 +1,126 @@
 ---
 title: "ServerConfig"
-description: "ServerConfig API Documentation"
+description: "Configure mcp-use v2 server identity, branding, HTTP routing, inspection, logging, and OAuth."
 icon: "settings"
-github: "https://github.com/mcp-use/mcp-use/blob/main/libraries/typescript/packages/mcp-use/src/server/types/common.ts"
+github: "https://github.com/mcp-use/mcp-use/blob/beta/libraries/typescript/packages/server/src/config.ts"
 ---
 
-<Callout type="info" title="Source Code">
-View the source code for this module on GitHub: <a href='https://github.com/mcp-use/mcp-use/blob/main/libraries/typescript/packages/mcp-use/src/server/types/common.ts' target='_blank' rel='noopener noreferrer'>https://github.com/mcp-use/mcp-use/blob/main/libraries/typescript/packages/mcp-use/src/server/types/common.ts</a>
-</Callout>
+`ServerConfig` is the object you pass to `new MCPServer(...)`. `name` and `version` are required. The v2 server is stateless and fetch-native; there are no Hono or session-store fields on this type.
 
-`ServerConfig` is the configuration object passed to the `new MCPServer({ ... })` constructor. It controls server identity (name, version, title, icons), networking (host, base URL, CORS, DNS rebinding protection), session and stream persistence, OAuth authentication, and the public landing page. `name` and `version` are the only required fields; every other field is optional.
-
-```ts wrap
-import { MCPServer } from "mcp-use/server";
+```ts
+import { MCPServer } from "mcp-use";
 
 const server = new MCPServer({
-  name: "everything-server",
-  title: "Everything Server",
+  name: "catalog-server",
+  title: "Catalog Server",
   version: "1.0.0",
-  baseUrl: process.env.MCP_URL || "http://localhost:3000",
+  description: "Search the product catalog.",
+  websiteUrl: "https://example.com/catalog",
+  icons: [
+    { src: "brand/icon.svg", mimeType: "image/svg+xml" },
+    {
+      src: "brand/icon-32.png",
+      mimeType: "image/png",
+      sizes: ["32x32"],
+    },
+  ],
 });
 ```
 
-## ServerConfig
+## Configuration fields
 
-Configuration for an MCP server. Pass this object to the `new MCPServer({ ... })` constructor.
+> <ParamField body="name" type="string" required={true}>
+>   Machine-readable server name reported during MCP initialization.
+> </ParamField>
 
-```ts
-import { MCPServer } from "mcp-use/server";
+<ParamField body="version" type="string" required={true}>Server version reported during MCP initialization.</ParamField>
+<ParamField body="title" type="string">Human-readable display name. Clients can fall back to `name` when omitted.</ParamField>
+<ParamField body="description" type="string">Human-readable description reported in MCP implementation metadata.</ParamField>
+<ParamField body="websiteUrl" type="string">Absolute HTTP(S) website or documentation URL reported in MCP implementation metadata. Relative, empty, and non-HTTP(S) values throw at construction.</ParamField>
+<ParamField body="icons" type="Icon[]">Official MCP implementation icons. A source can be a path relative to `public/`, an absolute HTTP(S) URL, or an `image/*` data URL. Local paths become request-scoped absolute URLs under `${basePath}/_mcp-use/public/`. An empty array is valid.</ParamField>
+<ParamField body="favicon" type="string">Explicit browser favicon source. It accepts the same source forms as `icons` and overrides favicon inference. The server exposes the selected image at the root-level `/favicon.ico` route.</ParamField>
+<ParamField body="instructions" type="string">Server-wide guidance surfaced to models by MCP clients.</ParamField>
+<ParamField body="basePath" type="string" default="/mcp">Exact MCP endpoint pathname. It must start with `/` and cannot contain whitespace, `//`, a query, a fragment, or a trailing slash except for `/` itself.</ParamField>
+<ParamField body="host" type="string" default="127.0.0.1">Hostname used by `listen()`. Set `"0.0.0.0"` for a public bind. `getHandler()` does not bind a socket.</ParamField>
+<ParamField body="allowedHosts" type="string[]">Additional Host-header allowlist entries. Values are additive to localhost names and enable Host validation for `getHandler()`.</ParamField>
+<ParamField body="allowedOrigins" type="string[]">Additional Origin-header allowlist entries. Values are additive to localhost origins. When omitted, the effective Host allowlist is used. GET and HEAD skip Origin validation.</ParamField>
+<ParamField body="legacy" type='"stateless" | "reject"' default="stateless">Serve 2025-era clients through the stateless compatibility path, or reject them for a modern-only server.</ParamField>
+<ParamField body="publicLandingPage" type="boolean" default="false">Expose the HTML landing page without bearer authentication when OAuth is configured. The page remains available for explicit HTML GET/HEAD navigation and MCP protocol requests stay protected.</ParamField>
+<ParamField body="cors" type="CorsOptions">Add CORS headers to every mcp-use-owned route. Omit it for no CORS headers; use this alongside `allowedOrigins` when serving browser clients.</ParamField>
+<ParamField body="inspector" type="InspectorOptions">Configure the `${basePath}/inspector` shell. It is enabled by default. Use `{ enabled: false }` to disable it or `{ assetsUrl }` to load a self-hosted inspector bundle.</ParamField>
+<ParamField body="logging" type="LoggingOptions">Configure request logging. Logging is enabled at `info` by default; use `{ enabled: false }`, `debug`, or `trace` as needed.</ParamField>
+<ParamField body="requestState" type="ServerOptions['requestState']">Configure integrity verification for `requestState` echoed across `input_required` rounds.</ParamField>
+<ParamField body="oauth" type="OAuthProvider<TUser>">OAuth resource-server provider. When you supply a non-`never` `TUser`, this field becomes required and authenticated callbacks receive `ctx.auth.user`.</ParamField>
+
+## Icon and favicon behavior
+
+When `favicon` is omitted, `icons` selects the browser favicon in this order:
+
+1. ICO by MIME type or URL pathname.
+2. PNG with a declared `16x16` or `32x32` size.
+3. Any PNG by MIME type or URL pathname.
+4. The first icon.
+
+An empty `icons` array selects no favicon. An explicit empty `favicon` is invalid.
+
+`GET /favicon.ico` and `HEAD /favicon.ico` stay at the domain root even when `basePath` is custom or `/`. Local files and data URLs are served directly. HTTP(S) favicon sources return a `307` redirect; mcp-use never fetches the remote image server-side. Missing local files return `404`.
+
+Local files belong under the project `public/` directory:
+
+```text
+public/
+└── brand/
+    ├── favicon.ico
+    ├── icon.svg
+    └── icon-32.png
 ```
 
-The complete set of options accepted by the `MCPServer` constructor. The constructor stores this object on `server.config` and applies the defaults described below. The `new MCPServer(config)` path takes a `ServerConfig` with `name` and `version` required; everything else is optional.
+`mcp-use build` copies `public/` into the production output even when the server has no views. Local paths cannot start with `/` or contain traversal segments, backslashes, queries, fragments, or empty path segments.
 
-**Properties**
+## Type definition
 
-><ParamField body="name" type="string" required={true}>Unique identifier for the MCP server (for example `"my-mcp-server"` or `"product-search-api"`). Required.</ParamField>
-><ParamField body="version" type="string" required={true}>Semantic version of the server (for example `"1.0.0"`). Required.</ParamField>
-><ParamField body="description" type="string">Human-readable description of what the server does. Shown to clients during discovery. Optional, no default.</ParamField>
-><ParamField body="instructions" type="string">Instructions for AI models using this server. Use this for server-wide guidance such as cross-tool workflows, ordering constraints, or safety requirements. Do not repeat individual tool descriptions here. Optional, no default.</ParamField>
-><ParamField body="host" type="string" default="localhost">Hostname for widget URLs and server endpoints. When omitted, the constructor falls back to `"localhost"` (`config.host || "localhost"`).</ParamField>
-><ParamField body="baseUrl" type="string">Full base URL that overrides `host:port` for widget URLs (for example `"https://myserver.com"`). Use when deploying behind a reverse proxy or to a known public URL. Optional, no default.</ParamField>
-><ParamField body="cors" type="Partial<Parameters<typeof cors>[0]>">Custom CORS options for the server, typed against Hono's `cors` middleware options. By default mcp-use enables permissive CORS (`origin: "*"`) for development ergonomics. Set this to customize allowed origins, headers, methods, credentials, etc. Optional, no default.</ParamField>
-><ParamField body="allowedOrigins" type="string[]">Allowed origins for DNS rebinding protection. If not set, protection is disabled (all `Host` values accepted). If set to an empty array, protection is also disabled. If set with one or more origins, `Host` validation is enabled globally for the server. Optional, no default (disabled).</ParamField>
-><ParamField body="sessionIdleTimeoutMs" type="number" default="86400000">Idle timeout for sessions in milliseconds. Defaults to `86400000` (1 day).</ParamField>
-><ParamField body="autoCreateSessionOnInvalidId" type="boolean">Deprecated and slated for removal in a future version. Modern MCP clients send a new `InitializeRequest` after receiving a 404 for a stale session, and the server now follows the spec strictly by returning 404 for invalid session IDs. For session persistence across restarts, use `sessionStore` with a persistent backend instead. Optional, no default.</ParamField>
-><ParamField body="stateless" type="boolean">Enable stateless mode (no session tracking). When left `undefined`, the constructor auto-detects: `true` for Deno (edge runtimes) and `false` for Node.js. In Node.js, mode is further auto-detected per request from the client `Accept` header (`application/json, text/event-stream` selects stateful; `application/json` only selects stateless). Setting `stateless: true` forces stateless mode and ignores the `Accept` header. Stateless mode is required for edge functions where instances do not persist; stateful mode supports sessions, resumability, and notifications.</ParamField>
-><ParamField body="sessionStore" type="SessionStore">Custom session metadata storage backend. Stores serializable session metadata (client capabilities, log level, timestamps); for active SSE stream management use `streamManager` instead. Enables pluggable persistence for metadata survival across restarts, distributed deployments, and horizontal scaling. Defaults to `FileSystemSessionStore` when `NODE_ENV !== "production"` and `InMemorySessionStore` in production mode. Imported as `import("../sessions/stores/index.js").SessionStore`.</ParamField>
-><ParamField body="streamManager" type="StreamManager">Custom stream manager for active SSE connections, separate from `sessionStore` to enable distributed notifications via Redis Pub/Sub. Manages active SSE stream controllers for server-to-client push notifications. Defaults to an in-memory `InMemoryStreamManager` (streams on this server only). Use `RedisStreamManager` for distributed notifications and sampling across multiple instances. Imported as `import("../sessions/streams/index.js").StreamManager`.</ParamField>
-><ParamField body="oauth" type="OAuthProvider">OAuth authentication configuration. When provided, automatically sets up OAuth routes (`/authorize`, `/token`, `.well-known/*`), JWT verification middleware, bearer token authentication on all `/mcp` routes, and user information extraction with context attachment. Build with the provider factory functions `oauthSupabaseProvider()`, `oauthAuth0Provider()`, `oauthKeycloakProvider()`, or `oauthCustomProvider()`. Optional, no default.</ParamField>
-><ParamField body="publicLandingPage" type="boolean" default="false">Expose the HTML MCP landing page without bearer authentication when OAuth is configured. The page is always available at `basePath` for GET/HEAD requests that explicitly accept `text/html`; without OAuth it is public. With OAuth, it requires a token unless this option is `true`. MCP protocol requests remain protected.</ParamField>
-><ParamField body="favicon" type="string">Path to a favicon file relative to the `public/` directory (for example `"favicon.ico"` or `"icons/app-icon.png"`). The favicon is automatically included in all widget pages. If omitted but `icons` is provided, the constructor auto-selects a favicon from `icons`. Optional, no default.</ParamField>
-><ParamField body="title" type="string">Display name for the server, shown in MCP clients and the inspector UI. If not provided, the `name` field is used as the display name. Optional, no default.</ParamField>
-><ParamField body="websiteUrl" type="string">Website URL for the server (for example `"https://myserver.com"`), included in the server info displayed to clients. Optional, no default.</ParamField>
-><ParamField body="icons" type="Array<{ src: string; mimeType?: string; sizes?: string[]; theme?: light | dark }>">Array of server icons in various sizes and formats, used by MCP clients and the inspector UI for server branding. Each entry requires `src` and may include `mimeType`, `sizes`, and `theme` (`"light"` or `"dark"`). Relative `src` values are rewritten to absolute URLs under `${baseUrl}/mcp-use/public/` when `baseUrl` is set. Optional, no default.</ParamField>
+```ts
+import type { Icon, ServerOptions } from "@modelcontextprotocol/server";
 
-**Type definition**
-```ts wrap
-interface ServerConfig {
+interface ServerConfig<TUser = never> {
   name: string;
   version: string;
-  description?: string;
-  instructions?: string;
-  host?: string;
-  baseUrl?: string;
-  cors?: Partial<Parameters<typeof cors>[0]>;
-  allowedOrigins?: string[];
-  sessionIdleTimeoutMs?: number;
-  /** @deprecated removed in a future version */
-  autoCreateSessionOnInvalidId?: boolean;
-  stateless?: boolean;
-  sessionStore?: SessionStore;
-  streamManager?: StreamManager;
-  oauth?: OAuthProvider;
-  publicLandingPage?: boolean;
-  favicon?: string;
   title?: string;
+  description?: string;
   websiteUrl?: string;
-  icons?: Array<{
-    src: string;
-    mimeType?: string;
-    sizes?: string[];
-    theme?: "light" | "dark";
-  }>;
+  icons?: Icon[];
+  favicon?: string;
+  instructions?: string;
+  basePath?: string;
+  host?: string;
+  allowedHosts?: string[];
+  allowedOrigins?: string[];
+  legacy?: "stateless" | "reject";
+  publicLandingPage?: boolean;
+  cors?: CorsOptions;
+  inspector?: InspectorOptions;
+  logging?: LoggingOptions;
+  requestState?: ServerOptions["requestState"];
+  oauth?: OAuthProvider<TUser>;
 }
 ```
 
-## Usage
+The actual `ServerConfig<TUser>` type conditionally requires `oauth` when `TUser` is not `never`.
 
-The `name` and `version` fields are required; everything else is optional. The following example sets a display `title` and a `baseUrl`.
+## Use branding in browser pages
 
-```ts wrap
-import { MCPServer } from "mcp-use/server";
+`server.branding` exposes the immutable normalized `favicon`, `icons`, and `websiteUrl` values. Browser shells should link to `/favicon.ico` instead of duplicating selection logic.
 
-const server = new MCPServer({
-  name: "everything-server",
-  title: "Everything Server",
-  version: "1.0.0",
-  baseUrl: process.env.MCP_URL || "http://localhost:3000",
-});
+```ts
+if (server.branding.favicon) {
+  // Render this in the page head.
+  const faviconLink = '<link rel="icon" href="/favicon.ico">';
+}
 ```
 
-### DNS rebinding protection
-
-Set `allowedOrigins` to enable global `Host` header validation. Leaving it unset (or passing an empty array) disables protection and accepts all `Host` values.
-
-```ts wrap
-import { MCPServer } from "mcp-use/server";
-
-const resolvedAllowedOrigins = process.env.ALLOWED_ORIGINS?.split(",")
-  .map((value) => value.trim())
-  .filter(Boolean);
-
-const server = new MCPServer({
-  name: "dns-rebinding-example",
-  version: "1.0.0",
-  description:
-    "Example server showing localhost auto-protection and explicit allowedOrigins in production.",
-  allowedOrigins:
-    resolvedAllowedOrigins && resolvedAllowedOrigins.length > 0
-      ? resolvedAllowedOrigins
-      : undefined,
-});
-```
+The built-in landing page and inspector add this link automatically. The landing page also displays the selected favicon as its server icon. MCP clients receive `websiteUrl` and `icons` through standard server implementation metadata.
 
 ## See also
 
-- [MCPServer](/typescript/api-reference/server/mcp-server) for the constructor that consumes `ServerConfig`.
+- [MCPServer](/typescript/api-reference/server/mcp-server) for server lifecycle and registration methods.
+- [Authentication](/typescript/server/authentication) for OAuth provider setup.

--- a/libraries/typescript/.changeset/bright-icons-smile.md
+++ b/libraries/typescript/.changeset/bright-icons-smile.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": minor
+---
+
+Add v2 server branding with official MCP `icons` and `websiteUrl` identity metadata, automatic favicon selection, and fetch-native local, data URL, and remote favicon handling.

--- a/libraries/typescript/packages/server/examples/conformance/src/index.ts
+++ b/libraries/typescript/packages/server/examples/conformance/src/index.ts
@@ -33,6 +33,14 @@ const server = new MCPServer({
   version: "1.0.0",
   description:
     "MCP Conformance Test Server implementing all supported features.",
+  websiteUrl: "https://mcp-use.com",
+  icons: [
+    {
+      src: "icon.svg",
+      mimeType: "image/svg+xml",
+      sizes: ["any"],
+    },
+  ],
   logging: { level: "debug" },
   ...(process.env.INSPECTOR_CDN_BASE && {
     inspector: {

--- a/libraries/typescript/packages/server/specs/CLI_SPEC.md
+++ b/libraries/typescript/packages/server/specs/CLI_SPEC.md
@@ -239,7 +239,7 @@ Target user `package.json` shape:
 
 ```
 .mcp-use/
-├─ build/        ← compiled server + manifest.json (this spec); views add build/views/ (assets + public/, VIEWS_SPEC.md)
+├─ build/        ← compiled server + manifest.json; build/views/public/ carries public assets used by views or branding
 ├─ generated/    ← output of the typegen escape-hatch command — reserved (VIEWS_SPEC.md § Typegen, demoted)
 ├─ cache/        ← disposable dev/build scratch (vite cacheDir)
 ├─ state/        ← mutable runtime state (e.g. tunnel.json)
@@ -266,7 +266,7 @@ Writes `.mcp-use/build/manifest.json`:
 { "buildId": "…", "entryPoint": "index.js", "createdAt": "…" }
 ```
 
-`buildId` is a random hex id and `createdAt` an ISO timestamp. `start` consumes `entryPoint`; inspector enablement remains solely in the built server's `ServerConfig` and is not duplicated in the manifest. Views extend this manifest with a `views` map (`VIEWS_SPEC.md` § Manifest) and copy the project-root `public/` directory into `build/views/public/` when present.
+`buildId` is a random hex id and `createdAt` an ISO timestamp. `start` consumes `entryPoint`; inspector enablement remains solely in the built server's `ServerConfig` and is not duplicated in the manifest. Views extend this manifest with a `views` map (`VIEWS_SPEC.md` § Manifest). Every build copies the project-root `public/` directory into `build/views/public/` when present, including tool-only servers whose favicon or MCP icons reference local public files.
 
 When `MCP_ASSETS_URL` is set, view manifest asset paths are rewritten to full CDN URLs at build time using `basePath` from the server entry (upload `build/views/` separately). Runtime env: `MCP_URL` (server origin), `MCP_ASSETS_URL` (assets prefix), `CSP_URLS` / `CSP_*_DOMAINS` (global CSP — see `VIEWS_SPEC.md`).
 

--- a/libraries/typescript/packages/server/specs/SPEC.md
+++ b/libraries/typescript/packages/server/specs/SPEC.md
@@ -43,6 +43,9 @@ const server = new MCPServer({
   version: "1.0.0",
   title: "My Server", // optional
   description: "…", // optional; forwarded as implementation metadata
+  websiteUrl: "https://example.com/my-server", // optional implementation metadata
+  favicon: "brand/favicon.ico", // optional; public/ path, http(s), or image data URL
+  icons: [{ src: "brand/icon.svg", mimeType: "image/svg+xml" }], // optional official Icon[]
   instructions: "…", // optional
   basePath: "/mcp", // optional, default "/mcp"
   host: "127.0.0.1", // optional; "0.0.0.0" for public listen()
@@ -121,6 +124,7 @@ await server.listen(3000); // Node HTTP (default)
 const handler = server.getHandler(); // universal web handler (Vercel, Hono, Workers)
 await server.getNodeHandler(); // Node (req, res) for custom http.Server composition
 server.basePath; // readonly accessor (default "/mcp") — lets tooling introspect the mount point
+server.branding; // immutable normalized favicon/icons/websiteUrl
 ```
 
 ### Mounting in your framework
@@ -147,6 +151,18 @@ Callback context (`ctx`, second parameter): `{ signal, request?, client, elicit,
 
 For the common human-input path, `await ctx.elicit(key, message, schemaOrUrl)` combines correlation and Standard Schema validation. Return `result` when `status === "required"`; accepted form values are inferred from the schema, while decline and cancel remain explicit. Invalid accepted form content produces another `required` result. `ctx.reportProgress(...)` is request-scoped and returns `false` when the caller supplied no progress token.
 
+### Server identity and browser branding
+
+`ServerConfig.websiteUrl?: string` and `ServerConfig.icons?: Icon[]` use the official SDK `Implementation` and `Icon` fields without private `_meta`. `Icon` is re-exported from `mcp-use` and has the canonical shape `{ src: string; mimeType?: string; sizes?: string[]; theme?: "light" | "dark" }`. `websiteUrl` must be a non-empty absolute HTTP(S) URL. `icons` preserves author order on the wire; an empty array is valid and emits `icons: []` while selecting no favicon.
+
+Icon and favicon sources accept exactly three forms: a safe path relative to project `public/`, an absolute HTTP(S) URL, or an `image/*` data URL. Local paths must not start with `/`, contain `..` segments, backslashes, a query, a fragment, or empty path segments. Local icon sources become request-scoped absolute implementation URLs under `<assets-base><basePath>/_mcp-use/public/<encoded-path>` (`basePath: "/"` produces `/_mcp-use/public/…`); HTTP(S) and data sources pass through unchanged. `MCP_ASSETS_URL` and the existing request/proxy origin resolution govern `<assets-base>`, keeping identity metadata aligned with view public assets. Invalid values fail at `MCPServer` construction.
+
+`ServerConfig.favicon?: string` controls the conventional browser route. A present, valid `favicon` always wins. Otherwise a non-empty `icons` list selects the first match in this order: ICO (MIME or URL pathname), PNG declaring `16x16` or `32x32`, any PNG (MIME or URL pathname), then the first icon. URL pathnames are inspected without query strings and MIME declarations participate, a deliberate hardening over v1's case-sensitive `src.endsWith(...)` checks. An empty `icons` array selects nothing. An explicitly empty `favicon` is invalid rather than silently treated as absent.
+
+`GET` and `HEAD /favicon.ico` remain root-level regardless of `basePath`, matching browser discovery and v1. A local source streams the selected file from `public/` in dev/direct use or `.mcp-use/build/views/public/` in production; `mcp-use build` copies `public/` there even for servers without views. An image data URL is decoded and served directly. An HTTP(S) source returns `307` with `Location` and is never fetched server-side. Local/data success uses the selected or extension-derived image MIME, `Cache-Control: public, max-age=31536000, immutable`, and `X-Content-Type-Options: nosniff`; redirects use `public, max-age=300`. Missing local files return `404` with `Cache-Control: no-store`. Unsupported methods return `405` with `Allow: GET, HEAD`. Public-file resolution verifies containment and a regular file after decoding the URL path, rejecting traversal and malformed encodings.
+
+Route order is favicon, public assets, built view assets, inspector, then the exact MCP route; OAuth discovery middleware remains outside this table and the bearer gate still wraps only the exact MCP endpoint. Thus favicon/public assets and `${basePath}/inspector` stay public alongside OAuth metadata. `listen()` and `getHandler()` use the same composed fetch handler. When configured, global `cors` middleware owns the branding responses' CORS headers; otherwise shared view/public assets retain their existing wildcard header. The inspector shell emits `<link rel="icon" href="/favicon.ico">` only when a favicon is selected. The landing page uses the request-resolved absolute `/favicon.ico` URL for both its browser favicon and hero icon. Views obtain server icons and `websiteUrl` through standard MCP initialization metadata; view documents do not invent another branding channel. `MCPServer.branding` exposes the frozen normalized `{ favicon?, icons?, websiteUrl? }` so browser integrations do not duplicate selection or file handling.
+
 **Deltas vs the old package (protocol- or SDK-forced):**
 
 1. `completable(...)` must wrap the _outer_ schema: `.describe()` etc. go on the schema argument (`completable(z.string().describe("…"), values)`), because zod refinements clone the schema and drop the SDK's completion marker. `.optional()` after `completable()` still works (the SDK unwraps optionals).
@@ -163,13 +179,13 @@ For the common human-input path, `await ctx.elicit(key, message, schemaOrUrl)` c
 
 The exact MCP `basePath` also serves a generated HTML landing page for browser navigation. A request is a landing-page request only when its method is `GET` or `HEAD` and an `Accept` media range explicitly names `text/html` with a non-zero quality value. `HEAD` returns the same status and headers as `GET` with no body. Requests with JSON, event-stream, wildcard-only, missing, or other Accept values continue to the MCP mount unchanged; in particular, legacy stateless GET/HEAD probes retain their existing `204`, DELETE retains its existing behavior, and every POST remains MCP protocol traffic.
 
-The document preserves the authoritative v1 landing frontend: the WebGL mesh-gradient hero, rail/card layout, Outfit branding, endpoint copy control, hosted Manufact Inspector deep link, GitHub badge, Claude Code/Cursor/VS Code/VS Code Insiders/ChatGPT tabs, optional Primitives card, and Manufact footer. Its automatic server inputs are `title ?? name`, `version`, `description`, the request-resolved public origin plus `basePath`, and the registered tools, prompts, and static resources. CSS, WebGL, tabs, and copy behavior are inline; the v1 Google Fonts stylesheet and GitHub shields image remain external. Every caller-controlled value is encoded for its destination context: HTML text and attributes are entity-escaped, inline JSON preserves raw metadata while escaping HTML end-tag characters, deep-link query values are URL-encoded, and the copyable Claude Code endpoint is a quoted POSIX shell argument. v1-only `favicon`, `icons`, and `websiteUrl` are not added to `ServerConfig`.
+The document preserves the authoritative v1 landing frontend: the WebGL mesh-gradient hero, rail/card layout, Outfit branding, endpoint copy control, hosted Manufact Inspector deep link, GitHub badge, Claude Code/Cursor/VS Code/VS Code Insiders/ChatGPT tabs, optional Primitives card, and Manufact footer. Its automatic server inputs are `title ?? name`, `version`, `description`, the request-resolved public origin plus `basePath`, the normalized selected favicon when present, and the registered tools, prompts, and static resources. CSS, WebGL, tabs, and copy behavior are inline; the v1 Google Fonts stylesheet and GitHub shields image remain external. Every caller-controlled value is encoded for its destination context: HTML text and attributes are entity-escaped, inline JSON preserves raw metadata while escaping HTML end-tag characters, deep-link query values are URL-encoded, and the copyable Claude Code endpoint is a quoted POSIX shell argument. `favicon`, `icons`, and `websiteUrl` follow the server-identity and browser-branding contract above.
 
 Registration data comes from the same registry that `listen()` or `getHandler()` freezes when it first mounts the app. Late registrations throw, so a page can never advertise primitives that the per-request SDK factory cannot replay.
 
 Without OAuth, the landing page is public. With OAuth, it passes through the exact endpoint bearer gate by default. `ServerConfig.publicLandingPage: true` bypasses bearer authentication only for the classified HTML GET/HEAD request; every protocol-shaped request remains protected. The complete auth interaction is specified in `AUTH_SPEC.md`.
 
-`generateLandingPage(options)` is exported from `mcp-use/landing` for applications that need the same document outside `MCPServer`. It takes one `LandingPageOptions` object instead of v1's positional argument list; the object form keeps optional v2 inputs explicit and extensible, and additionally permits an `iconUrl` for direct rendering. `MCPServer` dynamically imports this sibling entry only for classified HTML navigation, so ordinary MCP requests do not evaluate or inflate the page renderer.
+`generateLandingPage(options)` is exported from `mcp-use/landing` for applications that need the same document outside `MCPServer`. It takes one `LandingPageOptions` object instead of v1's positional argument list; the object form keeps optional v2 inputs explicit and extensible, and additionally permits an `iconUrl` for its favicon link and hero image. The built-in handler supplies the request-resolved absolute `/favicon.ico` URL whenever normalized branding selected a favicon. `MCPServer` dynamically imports this sibling entry only for classified HTML navigation, so ordinary MCP requests do not evaluate or inflate the page renderer.
 
 **Intentionally absent from the core primitive layer:** legacy push-style sampling/roots APIs, telemetry, typegen, and stdio serving. MCP operation middleware (`server.use('mcp:…')`) and observer events (`server.on('mcp:…')`) are implemented; HTTP middleware adapters and custom first-class HTTP routes are not — use your fetch-native framework. OpenAPI import is an integration built on top of `tool()`, described below; it does not add a second registration path. Views are governed by `VIEWS_SPEC.md`. Typed `ctx.elicit` and the raw v2 MRTR primitives (`inputRequired`, `inputResponse`, `acceptedContent`) operate through explicit `input_required` returns without introducing session state.
 
@@ -261,4 +277,3 @@ server.tool(
 
 - Sampling/roots: omit at v2.0 vs `@deprecated` legacy support (elicitation & context phase).
 - `posthog-node`: hard dep with opt-out vs optional (cutover phase).
-- Old `ServerConfig` fields not yet carried (`favicon`, `icons`, `websiteUrl`, OAuth): added with the features that read them.

--- a/libraries/typescript/packages/server/specs/VIEWS_SPEC.md
+++ b/libraries/typescript/packages/server/specs/VIEWS_SPEC.md
@@ -469,7 +469,7 @@ Build-time: when `MCP_ASSETS_URL` is set, manifest asset paths are rewritten to 
 v1 parity: authors drop static files in a project-root `public/` directory and reference them from views with root-relative paths (`/fruits/apple.png`). Two mechanisms coexist:
 
 1. **Imported assets** — `import url from "./file.png"` in a view module. Vite inlines them as data URLs in the self-contained production bundle (`assetsInlineLimit`); in dev they resolve through Vite with absolute URLs via `server.origin`.
-2. **Public folder** — files under `public/` served at `GET ${basePath}/_mcp-use/public/<path…>`. **Build** copies `public/` → `.mcp-use/build/views/public/`. **Dev** and **start** read from `<projectRoot>/public` (dev) or `.mcp-use/build/views/public/` (production). Missing `public/` → route 404s; nothing breaks. Path traversal (`..`, backslashes) is rejected.
+2. **Public folder** — files under `public/` served at `GET ${basePath}/_mcp-use/public/<path…>`. **Build** copies `public/` → `.mcp-use/build/views/public/`, including tool-only builds because server icons use the same route. **Dev** and **start** read from `<projectRoot>/public` (dev) or `.mcp-use/build/views/public/` (production). Missing `public/` → route 404s; nothing breaks. Percent-decoding happens before containment checks; malformed encodings, path traversal (`..`), backslashes, directories, and missing files return `404`. `HEAD` returns the same status and headers as `GET` with no body.
 
 **Runtime resolution.** The synthesized document injects one inline `<script>` before the view module script:
 

--- a/libraries/typescript/packages/server/src/branding.ts
+++ b/libraries/typescript/packages/server/src/branding.ts
@@ -55,8 +55,24 @@ function extensionPath(source: string): string {
   return source.toLowerCase();
 }
 
+function dataUrlMimeType(source: string): string | undefined {
+  if (protocolOf(source) !== "data") {
+    return undefined;
+  }
+  const comma = source.indexOf(",");
+  if (comma < 0) {
+    return undefined;
+  }
+  const mimeType = source.slice(5, comma).split(";", 1)[0]?.toLowerCase();
+  return mimeType === "" ? undefined : mimeType;
+}
+
+function iconMimeType(icon: Icon): string | undefined {
+  return icon.mimeType?.toLowerCase() ?? dataUrlMimeType(icon.src);
+}
+
 function isIco(icon: Icon): boolean {
-  const mimeType = icon.mimeType?.toLowerCase();
+  const mimeType = iconMimeType(icon);
   return (
     mimeType === "image/x-icon" ||
     mimeType === "image/vnd.microsoft.icon" ||
@@ -66,7 +82,7 @@ function isIco(icon: Icon): boolean {
 
 function isPng(icon: Icon): boolean {
   return (
-    icon.mimeType?.toLowerCase() === "image/png" ||
+    iconMimeType(icon) === "image/png" ||
     extensionPath(icon.src).endsWith(".png")
   );
 }

--- a/libraries/typescript/packages/server/src/branding.ts
+++ b/libraries/typescript/packages/server/src/branding.ts
@@ -1,0 +1,414 @@
+import type { Icon } from "@modelcontextprotocol/server";
+
+import type { FetchHandler } from "./fetch-app.js";
+import { resolveAssetsBase } from "./views/origin.js";
+import {
+  resolvePublicFilePath,
+  servePublicFile,
+} from "./views/public-route.js";
+
+const FAVICON_CACHE_CONTROL = "public, max-age=31536000, immutable";
+const FAVICON_REDIRECT_CACHE_CONTROL = "public, max-age=300";
+
+/** Normalized server branding shared by browser and MCP identity surfaces. */
+export interface ServerBranding {
+  /**
+   * Source selected for `/favicon.ico`, after applying explicit-favicon and
+   * icon-ranking precedence.
+   */
+  readonly favicon?: string;
+  /** Icons reported in MCP implementation metadata, in author order. */
+  readonly icons?: readonly Icon[];
+  /** Server website reported in MCP implementation metadata. */
+  readonly websiteUrl?: string;
+}
+
+interface NormalizedServerBranding extends ServerBranding {
+  readonly faviconMimeType?: string;
+}
+
+function protocolOf(value: string): string | undefined {
+  const match = /^([a-z][a-z\d+.-]*):/i.exec(value);
+  return match?.[1]?.toLowerCase();
+}
+
+function publicAssetPath(basePath: string, source: string): string {
+  const prefix = basePath === "/" ? "" : basePath;
+  return `${prefix}/_mcp-use/public/${source
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/")}`;
+}
+
+function isLocalPublicSource(source: string): boolean {
+  return protocolOf(source) === undefined;
+}
+
+function extensionPath(source: string): string {
+  const protocol = protocolOf(source);
+  if (protocol === "data") {
+    return "";
+  }
+  if (protocol === "http" || protocol === "https") {
+    return new URL(source).pathname.toLowerCase();
+  }
+  return source.toLowerCase();
+}
+
+function isIco(icon: Icon): boolean {
+  const mimeType = icon.mimeType?.toLowerCase();
+  return (
+    mimeType === "image/x-icon" ||
+    mimeType === "image/vnd.microsoft.icon" ||
+    extensionPath(icon.src).endsWith(".ico")
+  );
+}
+
+function isPng(icon: Icon): boolean {
+  return (
+    icon.mimeType?.toLowerCase() === "image/png" ||
+    extensionPath(icon.src).endsWith(".png")
+  );
+}
+
+/**
+ * Select the browser favicon from an ordered set of MCP icons.
+ *
+ * Ranking is deterministic: ICO, 16x16/32x32 PNG, any PNG, then the first
+ * icon. MIME declarations and URL pathnames participate alongside filename
+ * suffixes, so absolute URLs with queries and data URLs rank correctly.
+ *
+ * @param icons - Validated, non-empty icon list.
+ * @returns The selected icon.
+ *
+ * @internal
+ */
+export function selectFaviconFromIcons(
+  icons: readonly Icon[]
+): Icon | undefined {
+  return (
+    icons.find(isIco) ??
+    icons.find(
+      (icon) =>
+        isPng(icon) &&
+        icon.sizes?.some((size) => size === "16x16" || size === "32x32")
+    ) ??
+    icons.find(isPng) ??
+    icons[0]
+  );
+}
+
+function assertLocalPublicSource(source: string, field: string): void {
+  if (
+    source.startsWith("/") ||
+    source.includes("\\") ||
+    source.includes("?") ||
+    source.includes("#") ||
+    source.split("/").some((segment) => segment === "" || segment === "..")
+  ) {
+    throw new TypeError(
+      `${field} must be an http(s) URL, image data URL, or safe path relative to public/`
+    );
+  }
+}
+
+interface ParsedDataImage {
+  readonly bytes: Uint8Array<ArrayBuffer>;
+  readonly mimeType: string;
+}
+
+function parseDataImage(source: string, field: string): ParsedDataImage {
+  const comma = source.indexOf(",");
+  if (comma < 0) {
+    throw new TypeError(`${field} must be a valid image data URL`);
+  }
+  const metadata = source.slice(5, comma);
+  const payload = source.slice(comma + 1);
+  const parts = metadata.split(";");
+  const mimeType = parts[0]?.toLowerCase() ?? "";
+  if (!mimeType.startsWith("image/")) {
+    throw new TypeError(`${field} data URL must use an image MIME type`);
+  }
+  try {
+    if (parts.includes("base64")) {
+      const binary = atob(payload);
+      return {
+        mimeType,
+        bytes: Uint8Array.from(binary, (character) => character.charCodeAt(0)),
+      };
+    }
+    return {
+      mimeType,
+      bytes: new TextEncoder().encode(decodeURIComponent(payload)),
+    };
+  } catch {
+    throw new TypeError(`${field} must be a valid image data URL`);
+  }
+}
+
+function assertBrandingSource(source: unknown, field: string): string {
+  if (typeof source !== "string" || source.length === 0) {
+    throw new TypeError(`${field} must be a non-empty string`);
+  }
+  const protocol = protocolOf(source);
+  if (protocol === undefined) {
+    assertLocalPublicSource(source, field);
+    return source;
+  }
+  if (protocol === "data") {
+    parseDataImage(source, field);
+    return source;
+  }
+  if (protocol !== "http" && protocol !== "https") {
+    throw new TypeError(
+      `${field} must be an http(s) URL, image data URL, or safe path relative to public/`
+    );
+  }
+  try {
+    new URL(source);
+  } catch {
+    throw new TypeError(`${field} must be a valid absolute http(s) URL`);
+  }
+  return source;
+}
+
+/**
+ * Validate and freeze the branding fields from server configuration.
+ *
+ * @param config - Untyped-compatible branding input.
+ * @returns Immutable normalized branding and the selected favicon MIME type.
+ *
+ * @internal
+ */
+export function normalizeServerBranding(config: {
+  favicon?: unknown;
+  icons?: unknown;
+  websiteUrl?: unknown;
+}): NormalizedServerBranding {
+  let websiteUrl: string | undefined;
+  if (config.websiteUrl !== undefined) {
+    if (
+      typeof config.websiteUrl !== "string" ||
+      config.websiteUrl.length === 0
+    ) {
+      throw new TypeError(
+        "websiteUrl must be a non-empty absolute http(s) URL"
+      );
+    }
+    let parsed: URL;
+    try {
+      parsed = new URL(config.websiteUrl);
+    } catch {
+      throw new TypeError(
+        "websiteUrl must be a non-empty absolute http(s) URL"
+      );
+    }
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      throw new TypeError(
+        "websiteUrl must be a non-empty absolute http(s) URL"
+      );
+    }
+    websiteUrl = config.websiteUrl;
+  }
+
+  let icons: readonly Icon[] | undefined;
+  if (config.icons !== undefined) {
+    if (!Array.isArray(config.icons)) {
+      throw new TypeError("icons must be an array of MCP Icon objects");
+    }
+    icons = Object.freeze(
+      config.icons.map((value, index): Icon => {
+        if (typeof value !== "object" || value === null) {
+          throw new TypeError(`icons[${index}] must be an MCP Icon object`);
+        }
+        const icon = value as Record<string, unknown>;
+        const src = assertBrandingSource(icon["src"], `icons[${index}].src`);
+        const mimeType = icon["mimeType"];
+        if (
+          mimeType !== undefined &&
+          (typeof mimeType !== "string" ||
+            !mimeType.toLowerCase().startsWith("image/"))
+        ) {
+          throw new TypeError(
+            `icons[${index}].mimeType must be an image MIME type when provided`
+          );
+        }
+        const sizes = icon["sizes"];
+        if (
+          sizes !== undefined &&
+          (!Array.isArray(sizes) ||
+            sizes.some((size) => typeof size !== "string" || size.length === 0))
+        ) {
+          throw new TypeError(
+            `icons[${index}].sizes must be an array of non-empty strings when provided`
+          );
+        }
+        const normalizedSizes =
+          sizes === undefined
+            ? undefined
+            : (sizes as unknown[]).map((size) => size as string);
+        const theme = icon["theme"];
+        if (theme !== undefined && theme !== "light" && theme !== "dark") {
+          throw new TypeError(
+            `icons[${index}].theme must be "light" or "dark" when provided`
+          );
+        }
+        return Object.freeze({
+          src,
+          ...(mimeType !== undefined && { mimeType }),
+          ...(normalizedSizes !== undefined && {
+            sizes: Object.freeze(normalizedSizes) as string[],
+          }),
+          ...(theme !== undefined && { theme }),
+        });
+      })
+    );
+  }
+
+  const explicitFavicon =
+    config.favicon === undefined
+      ? undefined
+      : assertBrandingSource(config.favicon, "favicon");
+  const inferred =
+    explicitFavicon === undefined
+      ? selectFaviconFromIcons(icons ?? [])
+      : undefined;
+  const favicon = explicitFavicon ?? inferred?.src;
+  const faviconMimeType =
+    inferred?.mimeType ??
+    icons?.find((icon) => icon.src === explicitFavicon)?.mimeType;
+
+  return Object.freeze({
+    ...(favicon !== undefined && { favicon }),
+    ...(faviconMimeType !== undefined && { faviconMimeType }),
+    ...(icons !== undefined && { icons }),
+    ...(websiteUrl !== undefined && { websiteUrl }),
+  });
+}
+
+/**
+ * Resolve configured icons for MCP implementation metadata.
+ *
+ * Absolute HTTP(S) and data URLs pass through. Public-relative sources become
+ * request-scoped absolute URLs under `${basePath}/_mcp-use/public/`.
+ *
+ * @param icons - Normalized configured icons.
+ * @param request - HTTP request used to derive the public asset origin.
+ * @param basePath - MCP endpoint base path.
+ * @returns Icons suitable for the official SDK `Implementation` object.
+ *
+ * @internal
+ */
+export function resolveImplementationIcons(
+  icons: readonly Icon[] | undefined,
+  request: Request | undefined,
+  basePath: string
+): Icon[] | undefined {
+  if (icons === undefined) {
+    return undefined;
+  }
+  return icons.map((icon) => ({
+    ...icon,
+    src:
+      request !== undefined && isLocalPublicSource(icon.src)
+        ? `${resolveAssetsBase(request)}${publicAssetPath(basePath, icon.src)}`
+        : icon.src,
+    ...(icon.sizes !== undefined && { sizes: [...icon.sizes] }),
+  }));
+}
+
+/**
+ * Whether any configured branding source needs the local public route.
+ *
+ * @param branding - Normalized branding to inspect.
+ * @returns `true` when the favicon or an MCP icon uses a `public/` path.
+ *
+ * @internal
+ */
+export function hasLocalBrandingAsset(branding: ServerBranding): boolean {
+  return (
+    (branding.favicon !== undefined && isLocalPublicSource(branding.favicon)) ||
+    branding.icons?.some((icon) => isLocalPublicSource(icon.src)) === true
+  );
+}
+
+/**
+ * Create the root-level `/favicon.ico` handler for normalized branding.
+ *
+ * Local public files and data URLs are streamed directly. Absolute HTTP(S)
+ * sources receive a temporary redirect, avoiding server-side remote fetches.
+ *
+ * @param branding - Normalized server branding.
+ * @param options - Public directory resolution mode.
+ * @returns A GET/HEAD handler, or `undefined` when no favicon is configured.
+ *
+ * @internal
+ */
+export function createFaviconHandler(
+  branding: NormalizedServerBranding,
+  options: { dev: boolean; projectRoot: string; deferCors?: boolean }
+): FetchHandler | undefined {
+  const source = branding.favicon;
+  if (source === undefined) {
+    return undefined;
+  }
+
+  return async (request) => {
+    if (request.method !== "GET" && request.method !== "HEAD") {
+      return new Response("Method Not Allowed", {
+        status: 405,
+        headers: { Allow: "GET, HEAD" },
+      });
+    }
+    if (new URL(request.url).pathname !== "/favicon.ico") {
+      return new Response("Not Found", { status: 404 });
+    }
+
+    const protocol = protocolOf(source);
+    if (protocol === "http" || protocol === "https") {
+      return new Response(null, {
+        status: 307,
+        headers: {
+          Location: source,
+          "Cache-Control": FAVICON_REDIRECT_CACHE_CONTROL,
+        },
+      });
+    }
+    if (protocol === "data") {
+      const data = parseDataImage(source, "favicon");
+      return new Response(
+        request.method === "HEAD" ? null : data.bytes.buffer,
+        {
+          status: 200,
+          headers: {
+            "Content-Type": branding.faviconMimeType ?? data.mimeType,
+            "Cache-Control": FAVICON_CACHE_CONTROL,
+            "X-Content-Type-Options": "nosniff",
+          },
+        }
+      );
+    }
+
+    const { join } = await import("node:path");
+    const publicRoot = options.dev
+      ? join(options.projectRoot, "public")
+      : join(options.projectRoot, ".mcp-use/build/views/public");
+    const diskPath = await resolvePublicFilePath(publicRoot, source);
+    if (diskPath === null) {
+      return new Response("Not Found", {
+        status: 404,
+        headers: { "Cache-Control": "no-store" },
+      });
+    }
+    const response = await servePublicFile(diskPath, {
+      ...(options.deferCors === true && { deferCors: true }),
+      ...(request.method === "HEAD" && { head: true }),
+    });
+    response.headers.set("Cache-Control", FAVICON_CACHE_CONTROL);
+    response.headers.set("X-Content-Type-Options", "nosniff");
+    if (branding.faviconMimeType !== undefined) {
+      response.headers.set("Content-Type", branding.faviconMimeType);
+    }
+    return response;
+  };
+}

--- a/libraries/typescript/packages/server/src/cli/build.ts
+++ b/libraries/typescript/packages/server/src/cli/build.ts
@@ -296,6 +296,16 @@ export async function runBuild(options: BuildOptions): Promise<void> {
       },
     });
 
+    // Branding may reference project-public icon files even when the server
+    // has no views. Keep the runtime public-asset location identical in both
+    // shapes so `mcp-use start` and serverless built entries behave alike.
+    const publicSrc = join(options.cwd, "public");
+    if (existsSync(publicSrc)) {
+      await cp(publicSrc, join(paths.build, "views/public"), {
+        recursive: true,
+      });
+    }
+
     const manifest: BuildManifest = {
       buildId: randomBytes(8).toString("hex"),
       entryPoint: BUILD_ENTRY_NAME,

--- a/libraries/typescript/packages/server/src/cli/build.ts
+++ b/libraries/typescript/packages/server/src/cli/build.ts
@@ -49,6 +49,13 @@ const WRAPPER_BASENAME = "entry-wrapper.ts";
 /** Inline imported assets as data URLs up to this byte size (effectively all). */
 const ASSETS_INLINE_LIMIT = 100 * 1024 * 1024;
 
+async function copyPublicAssets(cwd: string, outputDir: string): Promise<void> {
+  const publicSrc = join(cwd, "public");
+  if (existsSync(publicSrc)) {
+    await cp(publicSrc, outputDir, { recursive: true });
+  }
+}
+
 /**
  * Options for {@link runBuild}.
  *
@@ -299,12 +306,7 @@ export async function runBuild(options: BuildOptions): Promise<void> {
     // Branding may reference project-public icon files even when the server
     // has no views. Keep the runtime public-asset location identical in both
     // shapes so `mcp-use start` and serverless built entries behave alike.
-    const publicSrc = join(options.cwd, "public");
-    if (existsSync(publicSrc)) {
-      await cp(publicSrc, join(paths.build, "views/public"), {
-        recursive: true,
-      });
-    }
+    await copyPublicAssets(options.cwd, join(paths.build, "views/public"));
 
     const manifest: BuildManifest = {
       buildId: randomBytes(8).toString("hex"),
@@ -379,10 +381,7 @@ export async function runBuild(options: BuildOptions): Promise<void> {
     }
   }
 
-  const publicSrc = join(options.cwd, "public");
-  if (existsSync(publicSrc)) {
-    await cp(publicSrc, join(viewsOutDir, "public"), { recursive: true });
-  }
+  await copyPublicAssets(options.cwd, join(viewsOutDir, "public"));
 
   try {
     await validateViewBindingsAtBuild(

--- a/libraries/typescript/packages/server/src/config.ts
+++ b/libraries/typescript/packages/server/src/config.ts
@@ -1,4 +1,4 @@
-import type { ServerOptions } from "@modelcontextprotocol/server";
+import type { Icon, ServerOptions } from "@modelcontextprotocol/server";
 
 import type { LoggingOptions } from "./logging.js";
 import type { OAuthProvider } from "./oauth/index.js";
@@ -50,6 +50,74 @@ interface BaseServerConfig {
    * implementation metadata during negotiation.
    */
   description?: string;
+  /**
+   * Browser favicon source.
+   *
+   * Accepts a safe path relative to the project `public/` directory, an
+   * absolute HTTP(S) URL, or an image data URL. The selected image is served
+   * at the root-level `/favicon.ico` route. When omitted, the `icons` field
+   * selects the favicon using ICO, small PNG, any PNG, then first-icon order.
+   * An explicit value always wins; an empty string is invalid.
+   *
+   * @defaultValue Inferred from `icons`, or no favicon when `icons` is absent
+   * or empty.
+   * @throws TypeError When the value is empty, uses an unsupported URL scheme,
+   * or is an unsafe local path.
+   *
+   * @example
+   * ```ts
+   * new MCPServer({
+   *   name: "my-server",
+   *   version: "1.0.0",
+   *   favicon: "brand/favicon.svg",
+   * });
+   * ```
+   */
+  favicon?: string;
+  /**
+   * Server icons reported to clients in MCP implementation metadata.
+   *
+   * Uses the official SDK {@link Icon} shape. Each `src` accepts a safe path
+   * relative to `public/`, an absolute HTTP(S) URL, or an image data URL.
+   * Local paths become request-scoped absolute URLs under
+   * `${basePath}/_mcp-use/public/`; author order is preserved on the wire.
+   * When `favicon` is omitted, these icons also select `/favicon.ico`.
+   * An empty array is valid and selects no favicon.
+   *
+   * @defaultValue `undefined`
+   * @throws TypeError When an icon has an invalid source, MIME type, sizes,
+   * or theme.
+   *
+   * @example
+   * ```ts
+   * new MCPServer({
+   *   name: "my-server",
+   *   version: "1.0.0",
+   *   icons: [
+   *     { src: "brand/icon.svg", mimeType: "image/svg+xml" },
+   *     { src: "brand/icon-32.png", mimeType: "image/png", sizes: ["32x32"] },
+   *   ],
+   * });
+   * ```
+   */
+  icons?: Icon[];
+  /**
+   * Absolute HTTP(S) URL for the server's website or documentation, reported
+   * to clients in MCP implementation metadata.
+   *
+   * @defaultValue `undefined`
+   * @throws TypeError When the value is empty, relative, or not HTTP(S).
+   *
+   * @example
+   * ```ts
+   * new MCPServer({
+   *   name: "my-server",
+   *   version: "1.0.0",
+   *   websiteUrl: "https://example.com/my-server",
+   * });
+   * ```
+   */
+  websiteUrl?: string;
   /** Usage instructions surfaced to the model by clients. */
   instructions?: string;
   /**

--- a/libraries/typescript/packages/server/src/index.ts
+++ b/libraries/typescript/packages/server/src/index.ts
@@ -91,6 +91,9 @@ export type {
 } from "@modelcontextprotocol/server";
 
 export type { InspectorOptions, ServerConfig, CorsOptions } from "./config.js";
+export type { ServerBranding } from "./branding.js";
+/** Official MCP icon shape used by {@link ServerConfig.icons}. */
+export type { Icon } from "@modelcontextprotocol/server";
 export type {
   MiddlewareContext,
   McpCompleteEventListenerFn,

--- a/libraries/typescript/packages/server/src/inspector-shell.ts
+++ b/libraries/typescript/packages/server/src/inspector-shell.ts
@@ -71,6 +71,8 @@ export interface InspectorShellOptions {
   serverName: string;
   /** Route path the MCP endpoint is mounted on (e.g. `/mcp`). */
   basePath: string;
+  /** Browser favicon URL, normally the server's root-level `/favicon.ico`. */
+  faviconHref?: string | undefined;
   /**
    * Full replacement URL for the inspector bundle script. Defaults to
    * {@link DEFAULT_INSPECTOR_ASSETS_URL}.
@@ -114,7 +116,8 @@ function serializeForInlineScript(value: string): string {
  * or JSON-serialized with `<` escaped, so config can't inject markup.
  */
 export function renderInspectorShell(options: InspectorShellOptions): string {
-  const { serverName, basePath, assetsUrl, manufactChatUrl } = options;
+  const { serverName, basePath, faviconHref, assetsUrl, manufactChatUrl } =
+    options;
   const serializedBasePath = serializeForInlineScript(basePath);
   const serializedManufactChatUrl = manufactChatUrl
     ? serializeForInlineScript(manufactChatUrl)
@@ -129,6 +132,7 @@ export function renderInspectorShell(options: InspectorShellOptions): string {
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>${escapeHtml(serverName)} — MCP Inspector</title>
+    ${faviconHref !== undefined ? `<link rel="icon" href="${escapeHtml(faviconHref)}" />` : ""}
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -189,7 +193,7 @@ export function renderInspectorShell(options: InspectorShellOptions): string {
  */
 export function createInspectorHandler(
   inspector: InspectorOptions | undefined,
-  options: { serverName: string; basePath: string }
+  options: { serverName: string; basePath: string; faviconHref?: string }
 ): FetchHandler | undefined {
   if (inspector?.enabled === false) {
     return undefined;
@@ -203,6 +207,9 @@ export function createInspectorHandler(
   const shellOptions: InspectorShellOptions = {
     serverName: options.serverName,
     basePath: options.basePath,
+    ...(options.faviconHref !== undefined && {
+      faviconHref: options.faviconHref,
+    }),
     assetsUrl,
     manufactChatUrl,
   };

--- a/libraries/typescript/packages/server/src/landing-handler.ts
+++ b/libraries/typescript/packages/server/src/landing-handler.ts
@@ -5,6 +5,7 @@ import {
   type LandingPageResource,
   type LandingPageTool,
 } from "./landing.js";
+import type { ServerBranding } from "./branding.js";
 import { resolveServerOrigin } from "./views/origin.js";
 
 /**
@@ -13,6 +14,7 @@ import { resolveServerOrigin } from "./views/origin.js";
  * @param request - Classified HTML GET or HEAD request.
  * @param basePath - Exact MCP endpoint path.
  * @param config - Server identity and description.
+ * @param branding - Normalized browser and MCP identity branding.
  * @param tools - Frozen tool registry values.
  * @param prompts - Frozen prompt registry values.
  * @param resources - Frozen static-resource registry values.
@@ -27,6 +29,7 @@ export function createLandingPageResponse(
     LandingPageOptions,
     "name" | "title" | "version" | "description"
   >,
+  branding: Pick<ServerBranding, "favicon">,
   tools: Iterable<{ definition: LandingPageTool }>,
   prompts: Iterable<{ definition: LandingPagePrompt }>,
   resources: Iterable<{ definition: LandingPageResource }>
@@ -36,6 +39,9 @@ export function createLandingPageResponse(
   const html = generateLandingPage({
     ...config,
     url,
+    ...(branding.favicon !== undefined && {
+      iconUrl: new URL("/favicon.ico", `${origin}/`).href,
+    }),
     tools: Array.from(tools, (entry) => entry.definition),
     prompts: Array.from(prompts, (entry) => entry.definition),
     resources: Array.from(resources, (entry) => entry.definition),

--- a/libraries/typescript/packages/server/src/landing.ts
+++ b/libraries/typescript/packages/server/src/landing.ts
@@ -428,6 +428,7 @@ export function generateLandingPage(options: LandingPageOptions): string {
 <meta name="twitter:card" content="summary">
 <meta name="twitter:title" content="${pageTitle}">
 <meta name="twitter:description" content="${metaDescription}">
+${iconUrl ? `<link rel="icon" href="${escapeHtml(iconUrl)}">` : ""}
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/libraries/typescript/packages/server/src/server.ts
+++ b/libraries/typescript/packages/server/src/server.ts
@@ -14,6 +14,13 @@ import {
 import type { Server as NodeHttpServer } from "node:http";
 import type { AuthInfo } from "@modelcontextprotocol/server";
 
+import {
+  createFaviconHandler,
+  hasLocalBrandingAsset,
+  normalizeServerBranding,
+  resolveImplementationIcons,
+  type ServerBranding,
+} from "./branding.js";
 import { assertServerConfig, type ServerConfig } from "./config.js";
 import {
   toAuthenticatedRequestContext,
@@ -186,6 +193,7 @@ interface NodeHttpListener {
  */
 export class MCPServer<TUser = never> {
   readonly #config: ServerConfig<TUser>;
+  readonly #branding: ReturnType<typeof normalizeServerBranding>;
   readonly #tools = new Map<string, ToolEntry<TUser>>();
   readonly #resources = new Map<string, ResourceEntry<TUser>>();
   readonly #resourceTemplates = new Map<string, ResourceTemplateEntry<TUser>>();
@@ -260,6 +268,7 @@ export class MCPServer<TUser = never> {
   constructor(config: ServerConfig<TUser>) {
     assertServerConfig(config);
     this.#config = config;
+    this.#branding = normalizeServerBranding(config);
     if (config.oauth !== undefined) {
       const mcpUrl =
         typeof process === "undefined" ? undefined : process.env["MCP_URL"];
@@ -283,6 +292,25 @@ export class MCPServer<TUser = never> {
    */
   get basePath(): string {
     return this.#basePath();
+  }
+
+  /**
+   * Immutable normalized branding shared by MCP identity and browser pages.
+   *
+   * `favicon` is the final source after explicit-favicon and icon-selection
+   * precedence. Landing-page integrations can use this accessor and link to
+   * the server's root-level `/favicon.ico` route without reading private
+   * configuration or depending on the inspector/view layers.
+   *
+   * @example
+   * ```ts
+   * if (server.branding.favicon) {
+   *   console.log("Browser favicon: /favicon.ico");
+   * }
+   * ```
+   */
+  get branding(): ServerBranding {
+    return this.#branding;
   }
 
   /**
@@ -881,6 +909,7 @@ export class MCPServer<TUser = never> {
             request,
             basePath,
             this.#config,
+            this.#branding,
             this.#tools.values(),
             this.#prompts.values(),
             this.#resources.values()
@@ -897,9 +926,25 @@ export class MCPServer<TUser = never> {
         handler: FetchHandler;
       }> = [];
 
-      const viewHandler = createViewPublicHandler(basePath, this.#views, {
-        dev: this.#viewsDevMode,
+      const brandingDevMode = this.#viewsPrimed
+        ? this.#viewsDevMode
+        : process.env["NODE_ENV"] !== "production";
+      const faviconHandler = createFaviconHandler(this.#branding, {
+        dev: brandingDevMode,
         projectRoot: this.#viewsProjectRoot,
+        deferCors: deferViewCors,
+      });
+      if (faviconHandler !== undefined) {
+        routes.push({
+          match: (request) => new URL(request.url).pathname === "/favicon.ico",
+          handler: faviconHandler,
+        });
+      }
+
+      const viewHandler = createViewPublicHandler(basePath, this.#views, {
+        dev: this.#viewsPrimed ? this.#viewsDevMode : brandingDevMode,
+        projectRoot: this.#viewsProjectRoot,
+        enabled: hasLocalBrandingAsset(this.#branding),
         deferCors: deferViewCors,
       });
       if (viewHandler !== undefined) {
@@ -936,6 +981,7 @@ export class MCPServer<TUser = never> {
       const inspectorHandler = createInspectorHandler(this.#config.inspector, {
         serverName: this.#config.name,
         basePath,
+        ...(faviconHandler !== undefined && { faviconHref: "/favicon.ico" }),
       });
       if (inspectorHandler !== undefined) {
         routes.push({
@@ -1048,6 +1094,16 @@ export class MCPServer<TUser = never> {
         version,
         ...(title !== undefined && { title }),
         ...(description !== undefined && { description }),
+        ...(this.#branding.websiteUrl !== undefined && {
+          websiteUrl: this.#branding.websiteUrl,
+        }),
+        ...(this.#branding.icons !== undefined && {
+          icons: resolveImplementationIcons(
+            this.#branding.icons,
+            ctx.requestInfo,
+            this.#basePath()
+          ),
+        }),
       },
       {
         capabilities: {

--- a/libraries/typescript/packages/server/src/views/public-route.ts
+++ b/libraries/typescript/packages/server/src/views/public-route.ts
@@ -30,10 +30,14 @@ export async function resolvePublicFilePath(
   publicRoot: string,
   subpath: string
 ): Promise<string | null> {
-  const { existsSync, statSync } = await import("node:fs");
+  const { stat } = await import("node:fs/promises");
   const { resolve, sep } = await import("node:path");
 
-  if (subpath === "" || subpath.includes("..") || subpath.includes("\\")) {
+  if (
+    subpath === "" ||
+    subpath.includes("\\") ||
+    subpath.split("/").some((segment) => segment === "..")
+  ) {
     return null;
   }
   const clean = subpath.replace(/^\/+/, "");
@@ -45,7 +49,11 @@ export async function resolvePublicFilePath(
   if (abs !== root && !abs.startsWith(root + sep)) {
     return null;
   }
-  if (!existsSync(abs) || !statSync(abs).isFile()) {
+  try {
+    if (!(await stat(abs)).isFile()) {
+      return null;
+    }
+  } catch {
     return null;
   }
   return abs;

--- a/libraries/typescript/packages/server/src/views/public-route.ts
+++ b/libraries/typescript/packages/server/src/views/public-route.ts
@@ -30,7 +30,7 @@ export async function resolvePublicFilePath(
   publicRoot: string,
   subpath: string
 ): Promise<string | null> {
-  const { existsSync } = await import("node:fs");
+  const { existsSync, statSync } = await import("node:fs");
   const { resolve, sep } = await import("node:path");
 
   if (subpath === "" || subpath.includes("..") || subpath.includes("\\")) {
@@ -45,7 +45,7 @@ export async function resolvePublicFilePath(
   if (abs !== root && !abs.startsWith(root + sep)) {
     return null;
   }
-  if (!existsSync(abs)) {
+  if (!existsSync(abs) || !statSync(abs).isFile()) {
     return null;
   }
   return abs;
@@ -55,7 +55,8 @@ export async function resolvePublicFilePath(
  * Serve one file from the project's `public/` directory.
  *
  * @param diskPath - Absolute path resolved by {@link resolvePublicFilePath}.
- * @param options - When `deferCors` is true, omit hardcoded `ACAO: *` so global
+ * @param options - `head` returns headers without opening a file stream.
+ *   When `deferCors` is true, omit hardcoded `ACAO: *` so global
  *   {@link ServerConfig.cors} middleware owns CORS headers.
  * @returns A `Response` with `Cache-Control: public, max-age=0, must-revalidate`
  * and optionally `Access-Control-Allow-Origin: *` so cross-origin sandboxed
@@ -65,17 +66,19 @@ export async function resolvePublicFilePath(
  */
 export async function servePublicFile(
   diskPath: string,
-  options: { deferCors?: boolean } = {}
+  options: { deferCors?: boolean; head?: boolean } = {}
 ): Promise<Response> {
   const { createReadStream } = await import("node:fs");
   const { extname } = await import("node:path");
   const { Readable } = await import("node:stream");
 
-  const ext = extname(diskPath);
+  const ext = extname(diskPath).toLowerCase();
   const contentType = PUBLIC_CONTENT_TYPES[ext] ?? "application/octet-stream";
-  const nodeStream = createReadStream(diskPath);
-  const webStream = Readable.toWeb(nodeStream) as ReadableStream;
-  return new Response(webStream, {
+  const body =
+    options.head === true
+      ? null
+      : (Readable.toWeb(createReadStream(diskPath)) as ReadableStream);
+  return new Response(body, {
     status: 200,
     headers: {
       "Content-Type": contentType,

--- a/libraries/typescript/packages/server/src/views/routes.ts
+++ b/libraries/typescript/packages/server/src/views/routes.ts
@@ -63,10 +63,10 @@ export function createViewAssetsHandler(
     if (diskPath === null) {
       return new Response("Not Found", { status: 404 });
     }
-    return await servePublicFile(
-      diskPath,
-      options?.deferCors === true ? { deferCors: true } : {}
-    );
+    return await servePublicFile(diskPath, {
+      ...(options?.deferCors === true && { deferCors: true }),
+      ...(request.method === "HEAD" && { head: true }),
+    });
   };
 }
 
@@ -83,16 +83,22 @@ export function createViewAssetsHandler(
  * @param views - Primed view registry; empty skips mounting.
  * @param options - When `dev` is true, the public route reads from
  *   `<projectRoot>/public` instead of `.mcp-use/build/views/public/`.
- *   `projectRoot` defaults to `process.cwd()`.
+ *   `projectRoot` defaults to `process.cwd()`. `enabled` mounts the shared
+ *   public route for local server branding even when no views are registered.
  *
  * @internal
  */
 export function createViewPublicHandler(
   basePath: string,
   views: ReadonlyMap<string, ViewManifestEntry>,
-  options?: { dev?: boolean; projectRoot?: string; deferCors?: boolean }
+  options?: {
+    dev?: boolean;
+    projectRoot?: string;
+    deferCors?: boolean;
+    enabled?: boolean;
+  }
 ): FetchHandler | undefined {
-  if (views.size === 0) {
+  if (views.size === 0 && options?.enabled !== true) {
     return undefined;
   }
 
@@ -109,7 +115,13 @@ export function createViewPublicHandler(
     }
 
     const pathname = pathnameOf(request);
-    const subpath = pathname.slice(publicPrefix.length + 1);
+    const encodedSubpath = pathname.slice(publicPrefix.length + 1);
+    let subpath: string;
+    try {
+      subpath = decodeURIComponent(encodedSubpath);
+    } catch {
+      return new Response("Not Found", { status: 404 });
+    }
     if (subpath.length === 0) {
       return new Response("Not Found", { status: 404 });
     }
@@ -121,10 +133,10 @@ export function createViewPublicHandler(
     if (diskPath === null) {
       return new Response("Not Found", { status: 404 });
     }
-    return await servePublicFile(
-      diskPath,
-      options?.deferCors === true ? { deferCors: true } : {}
-    );
+    return await servePublicFile(diskPath, {
+      ...(options?.deferCors === true && { deferCors: true }),
+      ...(request.method === "HEAD" && { head: true }),
+    });
   };
 }
 

--- a/libraries/typescript/packages/server/tests/branding.test.ts
+++ b/libraries/typescript/packages/server/tests/branding.test.ts
@@ -1,0 +1,396 @@
+import {
+  Client,
+  StreamableHTTPClientTransport,
+} from "@modelcontextprotocol/client";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { MCPServer, registerViews } from "../src/index.js";
+import { oauthCustomProvider, type OAuthMetadata } from "../src/oauth/index.js";
+
+const temporaryRoots: string[] = [];
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function project(files: Record<string, string>): string {
+  const root = mkdtempSync(join(tmpdir(), "mcp-use-branding-"));
+  temporaryRoots.push(root);
+  for (const [relativePath, contents] of Object.entries(files)) {
+    const file = join(root, "public", relativePath);
+    mkdirSync(join(file, ".."), { recursive: true });
+    writeFileSync(file, contents);
+  }
+  return root;
+}
+
+function primeDev<TUser>(server: MCPServer<TUser>, projectRoot: string): void {
+  server[registerViews]({}, { dev: true, projectRoot });
+}
+
+function makeClient(): Client {
+  return new Client(
+    { name: "branding-test-client", version: "1.0.0" },
+    { versionNegotiation: { mode: { pin: "2026-07-28" } } }
+  );
+}
+
+describe("server branding", () => {
+  it("reports canonical websiteUrl/icons and selects ICO for the favicon", async () => {
+    const root = project({
+      "brand/icon.svg": '<svg xmlns="http://www.w3.org/2000/svg"></svg>',
+      "brand/icon-32.png": "png-32",
+      "brand/favicon.ico": "ico",
+    });
+    const server = new MCPServer({
+      name: "branding-test",
+      version: "1.0.0",
+      websiteUrl: "https://example.com/server",
+      cors: { origin: "https://app.example.test" },
+      icons: [
+        { src: "brand/icon.svg", mimeType: "image/svg+xml" },
+        {
+          src: "brand/icon-32.png",
+          mimeType: "image/png",
+          sizes: ["32x32"],
+        },
+        { src: "brand/favicon.ico", mimeType: "image/x-icon" },
+      ],
+    });
+    primeDev(server, root);
+
+    expect(server.branding.favicon).toBe("brand/favicon.ico");
+    const started = await server.listen(0);
+    const client = makeClient();
+    await client.connect(
+      new StreamableHTTPClientTransport(new URL(started.url))
+    );
+
+    const identity = client.getServerVersion();
+    expect(identity?.websiteUrl).toBe("https://example.com/server");
+    expect(identity?.icons).toEqual([
+      {
+        src: `${new URL(started.url).origin}/mcp/_mcp-use/public/brand/icon.svg`,
+        mimeType: "image/svg+xml",
+      },
+      {
+        src: `${new URL(started.url).origin}/mcp/_mcp-use/public/brand/icon-32.png`,
+        mimeType: "image/png",
+        sizes: ["32x32"],
+      },
+      {
+        src: `${new URL(started.url).origin}/mcp/_mcp-use/public/brand/favicon.ico`,
+        mimeType: "image/x-icon",
+      },
+    ]);
+
+    const favicon = await fetch(`${new URL(started.url).origin}/favicon.ico`);
+    expect(favicon.status).toBe(200);
+    expect(favicon.headers.get("content-type")).toBe("image/x-icon");
+    expect(favicon.headers.get("cache-control")).toBe(
+      "public, max-age=31536000, immutable"
+    );
+    expect(favicon.headers.get("access-control-allow-origin")).toBe(
+      "https://app.example.test"
+    );
+    expect(await favicon.text()).toBe("ico");
+
+    const head = await fetch(`${new URL(started.url).origin}/favicon.ico`, {
+      method: "HEAD",
+    });
+    expect(head.status).toBe(200);
+    expect(head.headers.get("content-type")).toBe("image/x-icon");
+    expect(await head.text()).toBe("");
+
+    const publicIcon = await fetch(identity!.icons![0]!.src);
+    expect(publicIcon.status).toBe(200);
+    expect(publicIcon.headers.get("content-type")).toBe("image/svg+xml");
+    expect(publicIcon.headers.get("access-control-allow-origin")).toBe(
+      "https://app.example.test"
+    );
+
+    const landing = await fetch(started.url, {
+      headers: { Accept: "text/html" },
+    });
+    const landingHtml = await landing.text();
+    const faviconUrl = `${new URL(started.url).origin}/favicon.ico`;
+    expect(landingHtml).toContain(`<link rel="icon" href="${faviconUrl}">`);
+    expect(landingHtml).toContain(`<img src="${faviconUrl}"`);
+
+    const inspector = await fetch(
+      `${new URL(started.url).origin}/mcp/inspector`
+    );
+    expect(await inspector.text()).toContain(
+      '<link rel="icon" href="/favicon.ico" />'
+    );
+
+    await client.close();
+    await server.close();
+  });
+
+  it("lets an explicit local favicon override icon selection", async () => {
+    const root = project({
+      "explicit.svg": "<svg></svg>",
+      "preferred.ico": "ico",
+    });
+    const server = new MCPServer({
+      name: "override-test",
+      version: "1.0.0",
+      favicon: "explicit.svg",
+      icons: [
+        { src: "preferred.ico", mimeType: "image/x-icon" },
+        { src: "explicit.svg", mimeType: "image/svg+xml" },
+      ],
+    });
+    primeDev(server, root);
+    const handler = server.getHandler();
+
+    expect(server.branding.favicon).toBe("explicit.svg");
+    const response = await handler(new Request("http://localhost/favicon.ico"));
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/svg+xml");
+    expect(await response.text()).toBe("<svg></svg>");
+
+    const unsupported = await handler(
+      new Request("http://localhost/favicon.ico", { method: "POST" })
+    );
+    expect(unsupported.status).toBe(405);
+    expect(unsupported.headers.get("allow")).toBe("GET, HEAD");
+
+    await server.close();
+  });
+
+  it("ranks small PNG ahead of other PNG and SVG icons", () => {
+    const server = new MCPServer({
+      name: "png-rank-test",
+      version: "1.0.0",
+      icons: [
+        { src: "icon.svg", mimeType: "image/svg+xml" },
+        { src: "large.png", mimeType: "image/png", sizes: ["512x512"] },
+        { src: "small.png", mimeType: "image/png", sizes: ["32x32"] },
+      ],
+    });
+    expect(server.branding.favicon).toBe("small.png");
+
+    const queriedIco = new MCPServer({
+      name: "queried-ico-rank-test",
+      version: "1.0.0",
+      icons: [
+        { src: "small.png", mimeType: "image/png", sizes: ["32x32"] },
+        { src: "https://cdn.example.com/favicon.ico?v=2" },
+      ],
+    });
+    expect(queriedIco.branding.favicon).toBe(
+      "https://cdn.example.com/favicon.ico?v=2"
+    );
+  });
+
+  it("serves data favicons and redirects absolute favicons without fetching", async () => {
+    const dataServer = new MCPServer({
+      name: "data-favicon",
+      version: "1.0.0",
+      icons: [
+        {
+          src: "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3C%2Fsvg%3E",
+          mimeType: "image/svg+xml",
+        },
+      ],
+    });
+    const dataResponse = await dataServer.getHandler()(
+      new Request("http://localhost/favicon.ico")
+    );
+    expect(dataResponse.status).toBe(200);
+    expect(dataResponse.headers.get("content-type")).toBe("image/svg+xml");
+    expect(await dataResponse.text()).toContain("<svg");
+    await dataServer.close();
+
+    const remoteServer = new MCPServer({
+      name: "remote-favicon",
+      version: "1.0.0",
+      favicon: "https://cdn.example.com/favicon.png?v=2",
+    });
+    const handler = remoteServer.getHandler();
+    for (const method of ["GET", "HEAD"]) {
+      const response = await handler(
+        new Request("http://localhost/favicon.ico", { method })
+      );
+      expect(response.status).toBe(307);
+      expect(response.headers.get("location")).toBe(
+        "https://cdn.example.com/favicon.png?v=2"
+      );
+      expect(response.headers.get("cache-control")).toBe("public, max-age=300");
+    }
+    await remoteServer.close();
+  });
+
+  it("treats empty icons as no favicon and returns 404 for missing files", async () => {
+    const empty = new MCPServer({
+      name: "empty-icons",
+      version: "1.0.0",
+      icons: [],
+    });
+    expect(empty.branding.icons).toEqual([]);
+    expect(empty.branding.favicon).toBeUndefined();
+    expect(
+      (await empty.getHandler()(new Request("http://localhost/favicon.ico")))
+        .status
+    ).toBe(404);
+    await empty.close();
+
+    const missing = new MCPServer({
+      name: "missing-icon",
+      version: "1.0.0",
+      favicon: "missing.svg",
+    });
+    const missingResponse = await missing.getHandler()(
+      new Request("http://localhost/favicon.ico")
+    );
+    expect(missingResponse.status).toBe(404);
+    expect(missingResponse.headers.get("cache-control")).toBe("no-store");
+    await missing.close();
+  });
+
+  it("rejects invalid branding values at construction", () => {
+    const cases: Array<Record<string, unknown>> = [
+      { favicon: "" },
+      { favicon: "../secret.png" },
+      { favicon: "/root.png" },
+      { favicon: "ftp://example.com/icon.png" },
+      { favicon: "data:text/html,not-an-image" },
+      { websiteUrl: "/relative" },
+      { websiteUrl: "file:///tmp/site" },
+      { icons: "icon.png" },
+      { icons: [{}] },
+      { icons: [{ src: "icon.png", mimeType: "text/plain" }] },
+      { icons: [{ src: "icon.png", sizes: [16] }] },
+      { icons: [{ src: "icon.png", theme: "auto" }] },
+    ];
+    for (const config of cases) {
+      expect(
+        () =>
+          new MCPServer({
+            name: "invalid-branding",
+            version: "1.0.0",
+            ...config,
+          } as never)
+      ).toThrow(TypeError);
+    }
+  });
+
+  it("keeps favicon root-level while local icon URLs follow custom and root basePath", async () => {
+    for (const basePath of ["/api/mcp", "/"] as const) {
+      const root = project({ "icon.png": "png" });
+      const server = new MCPServer({
+        name: `base-path-${basePath}`,
+        version: "1.0.0",
+        basePath,
+        icons: [{ src: "icon.png", mimeType: "image/png" }],
+      });
+      primeDev(server, root);
+      const started = await server.listen(0);
+      const client = makeClient();
+      await client.connect(
+        new StreamableHTTPClientTransport(new URL(started.url))
+      );
+      const expectedPublicPath =
+        basePath === "/"
+          ? "/_mcp-use/public/icon.png"
+          : `${basePath}/_mcp-use/public/icon.png`;
+      expect(client.getServerVersion()?.icons?.[0]?.src).toBe(
+        `${new URL(started.url).origin}${expectedPublicPath}`
+      );
+      expect(
+        (await fetch(`${new URL(started.url).origin}/favicon.ico`)).status
+      ).toBe(200);
+      expect(
+        (await fetch(`${new URL(started.url).origin}${expectedPublicPath}`))
+          .status
+      ).toBe(200);
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it("coexists with OAuth metadata while the exact MCP route stays gated", async () => {
+    const root = project({ "oauth-icon.svg": "<svg></svg>" });
+    const oauth = oauthCustomProvider({
+      resource: "https://canonical.example.test/api/mcp",
+      createTokenVerifier: (resource) => ({
+        verifyAccessToken: async (token) => ({
+          token,
+          clientId: "test-client",
+          scopes: [],
+          expiresAt: Date.now() / 1000 + 60,
+          resource,
+        }),
+      }),
+      oauthMetadata: {
+        issuer: "https://issuer.example.test",
+      } as OAuthMetadata,
+      mapAuthInfo: () => ({
+        user: { id: "user-1" },
+        payload: { sub: "user-1" },
+        permissions: [],
+      }),
+    });
+    const server = new MCPServer({
+      name: "oauth-branding",
+      version: "1.0.0",
+      basePath: "/api/mcp",
+      publicLandingPage: true,
+      icons: [{ src: "oauth-icon.svg", mimeType: "image/svg+xml" }],
+      oauth,
+    });
+    primeDev(server, root);
+    const handler = server.getHandler();
+
+    expect(
+      (await handler(new Request("https://request.example/favicon.ico"))).status
+    ).toBe(200);
+    expect(
+      (
+        await handler(
+          new Request(
+            "https://request.example/api/mcp/_mcp-use/public/oauth-icon.svg"
+          )
+        )
+      ).status
+    ).toBe(200);
+    expect(
+      (
+        await handler(
+          new Request(
+            "https://request.example/.well-known/oauth-protected-resource/api/mcp"
+          )
+        )
+      ).status
+    ).toBe(200);
+    expect(
+      (
+        await handler(
+          new Request("https://request.example/api/mcp", { method: "POST" })
+        )
+      ).status
+    ).toBe(401);
+    expect(
+      (await handler(new Request("https://request.example/api/mcp/inspector")))
+        .status
+    ).toBe(200);
+    const landing = await handler(
+      new Request("https://request.example/api/mcp", {
+        headers: { Accept: "text/html" },
+      })
+    );
+    expect(landing.status).toBe(200);
+    expect(await landing.text()).toContain(
+      '<link rel="icon" href="https://request.example/favicon.ico">'
+    );
+
+    await server.close();
+  });
+});

--- a/libraries/typescript/packages/server/tests/branding.test.ts
+++ b/libraries/typescript/packages/server/tests/branding.test.ts
@@ -188,6 +188,17 @@ describe("server branding", () => {
     expect(queriedIco.branding.favicon).toBe(
       "https://cdn.example.com/favicon.ico?v=2"
     );
+
+    const dataIco = "data:image/x-icon;base64,aWNv";
+    const inferredDataMime = new MCPServer({
+      name: "data-mime-rank-test",
+      version: "1.0.0",
+      icons: [
+        { src: "small.png", mimeType: "image/png", sizes: ["32x32"] },
+        { src: dataIco },
+      ],
+    });
+    expect(inferredDataMime.branding.favicon).toBe(dataIco);
   });
 
   it("serves data favicons and redirects absolute favicons without fetching", async () => {
@@ -253,6 +264,24 @@ describe("server branding", () => {
     expect(missingResponse.status).toBe(404);
     expect(missingResponse.headers.get("cache-control")).toBe("no-store");
     await missing.close();
+  });
+
+  it("serves safe local filenames containing consecutive dots", async () => {
+    const root = project({ "brand/icon..png": "png" });
+    const server = new MCPServer({
+      name: "consecutive-dots",
+      version: "1.0.0",
+      favicon: "brand/icon..png",
+    });
+    primeDev(server, root);
+
+    const response = await server.getHandler()(
+      new Request("http://localhost/favicon.ico")
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/png");
+    expect(await response.text()).toBe("png");
+    await server.close();
   });
 
   it("rejects invalid branding values at construction", () => {

--- a/libraries/typescript/packages/server/tests/budgets/cli-budget.test.ts
+++ b/libraries/typescript/packages/server/tests/budgets/cli-budget.test.ts
@@ -89,11 +89,13 @@ describe("published CLI boundaries", () => {
     }
   });
 
-  it("keeps dist/index.js under seventy-three KiB", async () => {
+  it("keeps dist/index.js under eighty-five KiB", async () => {
     const bytes = (await stat(new URL("index.js", DIST))).size;
     // The landing renderer is a lazy sibling entry; the root pays only for
-    // HTML negotiation and auth-aware route dispatch.
-    expect(bytes).toBeLessThanOrEqual(73 * 1024);
+    // HTML negotiation and auth-aware route dispatch. Branding adds strict
+    // constructor validation, MCP identity URL normalization, and favicon /
+    // public-asset routing; keep the allowance close to the measured bundle.
+    expect(bytes).toBeLessThanOrEqual(85 * 1024);
   });
 
   it("keeps the unpacked framework artifact below five MiB", async () => {

--- a/libraries/typescript/packages/server/tests/cli/build.test.ts
+++ b/libraries/typescript/packages/server/tests/cli/build.test.ts
@@ -95,6 +95,11 @@ describe("runBuild", () => {
   it("emits an ESM bundle + manifest to .mcp-use/build and preserves the default export", async () => {
     const cwd = copyFixture("build");
     dirs.push(cwd);
+    mkdirSync(join(cwd, "public"), { recursive: true });
+    writeFileSync(
+      join(cwd, "public", "icon.svg"),
+      '<svg xmlns="http://www.w3.org/2000/svg"></svg>'
+    );
 
     await runBuild({ cwd });
 
@@ -117,6 +122,9 @@ describe("runBuild", () => {
     expect(new Date(manifest.createdAt).getTime()).not.toBeNaN();
     expect(manifest.inspector).toBe(false);
     expect("views" in manifest).toBe(false);
+    expect(
+      readFileSync(join(buildDir, "views", "public", "icon.svg"), "utf8")
+    ).toContain("<svg");
 
     // packages:"external" semantics — bare imports stay external, only the
     // user's source is bundled.

--- a/libraries/typescript/packages/server/tests/type-level.test.ts
+++ b/libraries/typescript/packages/server/tests/type-level.test.ts
@@ -17,6 +17,7 @@ import { MCPServer } from "../src/index.js";
 import type {
   Annotations,
   CallToolResult,
+  Icon,
   InputRequiredResult,
   LandingPageOptions,
   MetaObject,
@@ -28,6 +29,38 @@ import type {
   ToolResult,
 } from "../src/index.js";
 import type { FileMetadata, UseFilesResult } from "../src/react/index.js";
+
+describe("server branding config", () => {
+  it("uses the official MCP Icon shape", () => {
+    const icon: Icon = {
+      src: "brand/icon.svg",
+      mimeType: "image/svg+xml",
+      sizes: ["any"],
+      theme: "dark",
+    };
+    const config: ServerConfig = {
+      name: "branding-types",
+      version: "1.0.0",
+      websiteUrl: "https://example.com",
+      favicon: "brand/favicon.ico",
+      icons: [icon],
+    };
+    expectTypeOf(config.icons).toEqualTypeOf<Icon[] | undefined>();
+
+    const invalid: ServerConfig = {
+      name: "invalid-branding-types",
+      version: "1.0.0",
+      icons: [
+        {
+          src: "icon.svg",
+          // @ts-expect-error — theme is the official light/dark union
+          theme: "auto",
+        },
+      ],
+    };
+    expect([config, invalid]).toBeDefined();
+  });
+});
 
 const outputSchema = z.object({ answer: z.number() });
 


### PR DESCRIPTION
## Summary

- add `favicon`, official MCP `icons`, and `websiteUrl` to the v2 `ServerConfig`
- emit `icons` and `websiteUrl` through the official SDK `Implementation` fields
- select and serve a root-level `/favicon.ico` through the fetch-native router, with GET/HEAD support for local public files, image data URLs, and remote redirects
- expose normalized immutable branding through `server.branding`
- copy project `public/` assets in tool-only production builds and harden shared public-file MIME, HEAD, and path handling
- document the contract, add a changeset and conformance example, and cover runtime and type-level behavior

## v1 behavior and precedence

The v1 audit confirmed that a truthy explicit `favicon` wins. Otherwise a non-empty `icons` array selects the first `.ico`, then a 16x16/32x32 PNG, then any PNG, then the first icon. An empty icon array selects no favicon.

The v2 port preserves that useful order while making selection MIME-aware and query-safe. It deliberately validates empty/unsafe values at construction, serves image data URLs directly, redirects HTTP(S) favicon sources instead of treating them as local files, and resolves local MCP icon URLs from the request/public asset origin.

## Landing page and CORS integration

- the merged landing page consumes normalized branding through its existing `iconUrl` input and uses the request-resolved `/favicon.ico` URL for both the browser favicon and hero image
- `publicLandingPage` and OAuth bearer-gate behavior are unchanged; branding routes remain public while protocol traffic remains protected
- the inspector shell links the same root favicon
- global `ServerConfig.cors` continues to own response headers when enabled; otherwise shared public/view assets retain their existing wildcard CORS behavior
- no middleware/CORS implementation files are changed

## Validation

- `pnpm --filter @mcp-use/client build`
- `pnpm --filter mcp-use build` (`dist/index.js` 83.77 KiB)
- `pnpm --filter mcp-use typecheck`
- strict ESLint and Prettier checks
- focused cross-feature suite: 8 files, 108 tests passed
- post-stage branding/landing/CORS/middleware suite: 4 files, 30 tests passed
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds v2 server branding to `mcp-use`: official MCP `icons` and `websiteUrl`, automatic favicon selection, and a root `/favicon.ico` route with strict validation and correct GET/HEAD behavior. Hardened public asset handling, normalized identity metadata, and landing/inspector integration improve browser branding without affecting MCP traffic.

- **New Features**
  - `ServerConfig` adds `icons`, `favicon`, and `websiteUrl` (validated: safe `public/` path, http(s), or `image/*` data URL). Re-exports `Icon` and `ServerBranding`.
  - Emits `icons` and `websiteUrl` in MCP implementation metadata; local `icons` resolve to `${basePath}/_mcp-use/public/...` with the request origin.
  - New `server.branding` exposes normalized, readonly favicon/icons/websiteUrl.
  - Root `/favicon.ico`: explicit-or-derived selection (ICO → small PNG → PNG → first), GET/HEAD, 405 with `Allow`, local/data served directly, http(s) 307 redirect with short caching, correct MIME, `nosniff`, and cache headers.
  - `mcp-use build` always copies `public/` to `.mcp-use/build/views/public/`; public-file serving hardened (percent-decoding before containment, traversal/backslash rejection, file-only checks, HEAD).
  - Landing page uses the request-resolved `/favicon.ico` for favicon/hero when selected; inspector links the same root favicon; global `cors` continues to own headers when enabled.

- **Migration**
  - Place branding assets under `public/` and reference them with relative paths (no leading `/`, no `..`, backslashes, queries, fragments, or empty segments).
  - Use `icons` and optional `favicon`; empty/unsafe values now throw at construction.
  - Treat the favicon as `/favicon.ico` at the domain root; update any hardcoded paths.

<sup>Written for commit 36bdbd24470ebe33e13778f8d9969baff53e0066. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

