### PR TITLE
feat(server): add Better Auth OAuth provider

### DIFF
--- a/docs/typescript/api-reference/server/auth-providers.mdx
+++ b/docs/typescript/api-reference/server/auth-providers.mdx
@@ -97,46 +97,43 @@ server.listen();
 Create a Better Auth OAuth provider for an MCP server.
 
 ```ts
-import { oauthBetterAuthProvider } from "mcp-use/server";
+import { oauthBetterAuthProvider } from "mcp-use/oauth/better-auth";
 ```
 
-Builds an `OAuthProvider` backed by Better Auth's OAuth Provider plugin. The MCP server only verifies tokens and serves metadata; clients discover Better Auth's endpoints via `.well-known` passthrough (`/oauth2/authorize`, `/oauth2/token`, `/oauth2/register`, `/jwks`) and talk to Better Auth directly. `authURL` falls back to `MCP_USE_OAUTH_BETTER_AUTH_URL`. Throws `Error` if `authURL` is missing (`"Better Auth authURL is required."`). The `config` argument is `Partial<BetterAuthProviderConfig>` and defaults to an empty object.
+Builds an `OAuthProvider` backed by Better Auth's OAuth Provider plugin. The MCP server advertises Better Auth's `/oauth2/authorize`, `/oauth2/token`, and `/oauth2/register` endpoints and verifies access-token JWTs against `/jwks`. Your application creates and mounts Better Auth separately.
 
 **Parameters**
 
-> <ParamField
->   body="config"
->   type="Partial<BetterAuthProviderConfig>"
->   default="{}"
-> >
+> <ParamField body="options" type="BetterAuthOAuthProviderOptions">
 >   {" "}
->   Optional Better Auth configuration. Values passed here override the
->   corresponding environment variables.{" "}
+>   Better Auth issuer URL and optional MCP resource metadata.{" "}
 > </ParamField>
 
 **Returns**
 
-> <ResponseField name="returns" type="OAuthProvider" />
+> <ResponseField name="returns" type="OAuthProvider<BetterAuthOAuthUser>" />
 
 **Signature**
 
 ```ts wrap
 function oauthBetterAuthProvider(
-  config?: Partial<BetterAuthProviderConfig>,
-): OAuthProvider;
+  options: BetterAuthOAuthProviderOptions,
+): OAuthProvider<BetterAuthOAuthUser>;
 ```
 
 **Example**
 
 ```ts wrap
-import { MCPServer, oauthBetterAuthProvider, object } from "mcp-use/server";
+import { MCPServer } from "mcp-use";
+import { oauthBetterAuthProvider } from "mcp-use/oauth/better-auth";
 
 const server = new MCPServer({
   name: "better-auth-oauth-example",
   version: "1.0.0",
   description: "MCP server with Better Auth OAuth authentication",
   oauth: oauthBetterAuthProvider({
-    authURL: "http://localhost:3000/api/auth",
+    authURL: "http://localhost:61843/api/auth",
+    resource: "http://localhost:43127/mcp",
   }),
 });
 ```
@@ -563,49 +560,33 @@ interface Auth0ProviderConfig {
 }
 ```
 
-### BetterAuthProviderConfig
+### BetterAuthOAuthProviderOptions
 
 Configuration for `oauthBetterAuthProvider`.
 
 ```ts
-import type { BetterAuthProviderConfig } from "mcp-use/server";
+import type { BetterAuthOAuthProviderOptions } from "mcp-use/oauth/better-auth";
 ```
 
-Configuration for the Better Auth provider. `authURL` falls back to `MCP_USE_OAUTH_BETTER_AUTH_URL`. The optional `getUserInfo` callback maps the verified JWT payload to a `UserInfo` object (sync or async). Note the `getUserInfo` parameter is typed `Record<string, unknown>`, which contains a curly brace; see the signature fence below.
+Configuration for the Better Auth provider. It includes the shared OAuth resource options (`resource`, `requiredScopes`, `scopesSupported`, `resourceName`, and `serviceDocumentationUrl`).
 
 **Properties**
 
 > <ParamField body="authURL" type="string" required="True">
 >   {" "}
 >   Base URL of the Better Auth OAuth server, e.g.
->   `http://localhost:3000/api/auth`.{" "}
-> </ParamField>
-> <ParamField body="verifyJwt" type="boolean">
->   {" "}
->   Whether to verify the JWT signature.{" "}
+>   `http://localhost:61843/api/auth`. This may be a different origin from the
+>   MCP resource server.{" "}
 > </ParamField>
 > <ParamField body="scopesSupported" type="string[]">
 >   {" "}
 >   Scopes advertised in metadata.{" "}
 > </ParamField>
-> <ParamField
->   body="getUserInfo"
->   type="(payload) => UserInfo | Promise<UserInfo>"
-> >
->   {" "}
->   Optional callback mapping a verified payload to user info.{" "}
-> </ParamField>
-
-**Signature**
+> **Signature**
 
 ```ts wrap
-interface BetterAuthProviderConfig {
-  authURL: string;
-  verifyJwt?: boolean;
-  scopesSupported?: string[];
-  getUserInfo?: (
-    payload: Record<string, unknown>,
-  ) => UserInfo | Promise<UserInfo>;
+interface BetterAuthOAuthProviderOptions extends OAuthResourceOptions {
+  authURL: URL | string;
 }
 ```
 

--- a/docs/typescript/server/authentication/providers/better-auth.mdx
+++ b/docs/typescript/server/authentication/providers/better-auth.mdx
@@ -1,227 +1,104 @@
 ---
 title: "Better Auth Provider"
-description: "Configure Better Auth OAuth Provider authentication for a TypeScript MCP server."
+description: "Use Better Auth's OAuth Provider plugin with a TypeScript MCP server."
 icon: "/images/icons/better-auth.svg"
 ---
 
-Use the Better Auth provider when your app owns the authorization server. Better Auth handles login, consent, token issuance, and JWKS. Your MCP server mounts the Better Auth routes and verifies the resulting access tokens.
+Use Better Auth when your application owns the OAuth authorization server.
+Better Auth handles registration, sign-in, consent, and token issuance;
+`mcp-use` advertises those endpoints and verifies the access-token JWTs.
 
-This guide covers the mcp-use setup path with the Better Auth OAuth Provider plugin. Use the [auth providers API reference](/typescript/api-reference/server/auth-providers#oauthbetterauthprovider) for exact `oauthBetterAuthProvider()` options, defaults, and errors.
+## Configure the MCP resource server
 
-## Install Better Auth
-
-```bash
-npm install better-auth @better-auth/oauth-provider better-sqlite3
-```
-
-Use the database package that matches your Better Auth deployment. The example below uses SQLite for local development.
-
-## Configure Better Auth
-
-Create an auth module with the OAuth Provider plugin and JWT plugin.
+Pass the full Better Auth issuer URL, including its base path:
 
 ```typescript
-// auth.ts
-import { oauthProvider } from "@better-auth/oauth-provider";
-import Database from "better-sqlite3";
-import { betterAuth } from "better-auth";
-import { jwt } from "better-auth/plugins";
-
-export const auth = betterAuth({
-  baseURL: "http://localhost:3000",
-  basePath: "/api/auth",
-  secret: process.env.BETTER_AUTH_SECRET!,
-  database: new Database("./sqlite.db"),
-  socialProviders: {
-    github: {
-      clientId: process.env.GITHUB_CLIENT_ID!,
-      clientSecret: process.env.GITHUB_CLIENT_SECRET!,
-    },
-  },
-  plugins: [
-    jwt(),
-    oauthProvider({
-      loginPage: "/sign-in",
-      consentPage: "/consent",
-      allowDynamicClientRegistration: true,
-      allowUnauthenticatedClientRegistration: true,
-      validAudiences: ["http://localhost:3000/mcp"],
-      customAccessTokenClaims: async ({ user }) => ({
-        email: user?.email,
-        name: user?.name,
-        picture: user?.image,
-      }),
-    }),
-  ],
-});
-```
-
-The JWT plugin is required because mcp-use verifies access-token signatures.
-
-## Prepare the database
-
-```bash
-npx auth@latest generate
-npx auth@latest migrate
-```
-
-## Mount Better Auth on the MCP server
-
-Mount Better Auth's auth routes and metadata routes on the same Hono app as the MCP server.
-
-```typescript
-// server.ts
-import {
-  oauthProviderAuthServerMetadata,
-  oauthProviderOpenIdConfigMetadata,
-} from "@better-auth/oauth-provider";
-import { MCPServer, oauthBetterAuthProvider } from "mcp-use/server";
-import { auth } from "./auth.js";
+import { MCPServer } from "mcp-use";
+import { oauthBetterAuthProvider } from "mcp-use/oauth/better-auth";
 
 const server = new MCPServer({
   name: "better-auth-server",
   version: "1.0.0",
   oauth: oauthBetterAuthProvider({
-    authURL: "http://localhost:3000/api/auth",
+    authURL: "http://localhost:61843/api/auth",
+    resource: "http://localhost:43127/mcp",
   }),
 });
 
-server.app.on(["GET", "POST"], "/api/auth/**", (c) => auth.handler(c.req.raw));
-
-const corsHeaders = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Methods": "GET",
-};
-
-const authServerMetadata = oauthProviderAuthServerMetadata(auth, {
-  headers: corsHeaders,
-});
-server.app.get("/.well-known/oauth-authorization-server", (c) =>
-  authServerMetadata(c.req.raw),
-);
-server.app.get("/.well-known/oauth-authorization-server/api/auth", (c) =>
-  authServerMetadata(c.req.raw),
-);
-
-const openIdConfig = oauthProviderOpenIdConfigMetadata(auth, {
-  headers: corsHeaders,
-});
-server.app.get("/.well-known/openid-configuration", (c) =>
-  openIdConfig(c.req.raw),
-);
-server.app.get("/.well-known/openid-configuration/api/auth", (c) =>
-  openIdConfig(c.req.raw),
-);
-
-await server.listen(3000);
+export default server;
 ```
 
-Browser-based MCP clients need the CORS headers on metadata responses.
+The provider does not create or mount Better Auth. It derives Better Auth's
+`/oauth2/authorize`, `/oauth2/token`, `/oauth2/register`, and `/jwks` endpoints
+from `authURL`, then verifies JWT issuer, signature, expiration, and MCP
+resource audience.
 
-## Add login and consent routes
+## Run Better Auth as a separate Hono app
 
-Better Auth redirects users to your login and consent pages during OAuth. These routes can be simple for local development, but production pages should match your app's auth UX.
+The authorization server can be a separate application and origin. The normal
+`mcp-use` server above owns `/mcp` and its protected-resource metadata; the Hono
+app only mounts Better Auth, its discovery routes, and your login and consent
+pages.
 
 ```typescript
-server.app.get("/sign-in", (c) => {
-  const queryString = new URL(c.req.url).search;
+import { serve } from "@hono/node-server";
+import { Hono } from "hono";
 
-  return c.html(`<!DOCTYPE html>
-<html>
-<body>
-  <button onclick="signIn()">Sign in with GitHub</button>
-  <script>
-    async function signIn() {
-      const res = await fetch('/api/auth/sign-in/social', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({
-          provider: 'github',
-          callbackURL: '/api/auth/oauth2/authorize${queryString}',
-        }),
-      });
-      const data = await res.json();
-      if (data.url) window.location.href = data.url;
-    }
-  </script>
-</body>
-</html>`);
-});
+import { auth } from "./auth.js";
 
-server.app.get("/consent", (c) => {
-  const scope = new URL(c.req.url).searchParams.get("scope") || "openid";
+const app = new Hono();
 
-  return c.html(`<!DOCTYPE html>
-<html>
-<body>
-  <p>Requested scopes: ${scope}</p>
-  <button onclick="consent(true)">Allow</button>
-  <button onclick="consent(false)">Deny</button>
-  <script>
-    async function consent(accept) {
-      const res = await fetch('/api/auth/oauth2/consent', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({
-          accept,
-          oauth_query: window.location.search.slice(1),
-        }),
-      });
-      const data = await res.json();
-      if (data.url) window.location.href = data.url;
-    }
-  </script>
-</body>
-</html>`);
-});
+app.on(["GET", "POST"], "/api/auth/*", (c) => auth.handler(c.req.raw));
+serve({ fetch: app.fetch, port: 61843 });
 ```
 
-Use Better Auth's OAuth Provider docs for production login and consent-page behavior.
+Because the issuer contains `/api/auth`, also route Better Auth's RFC 8414
+path-insertion metadata endpoint
+`/.well-known/oauth-authorization-server/api/auth` to `auth.handler` or
+`oauthProviderAuthServerMetadata(auth)`. Better Auth's OAuth Provider guide
+documents the required discovery, login, and consent routes. If browser-based
+MCP clients call this separate origin directly, configure Hono CORS for the MCP
+origin and include that origin in Better Auth's `trustedOrigins`.
 
-## Set environment variables
+## Credential-free anonymous example
 
-```bash
-BETTER_AUTH_SECRET=your-secret-change-in-production
-GITHUB_CLIENT_ID=your-github-client-id
-GITHUB_CLIENT_SECRET=your-github-client-secret
+The repository's [runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/auth/better-auth)
+runs a regular `mcp-use dev` process on port 43127 and a separate Hono/Better
+Auth process on port 61843. It uses anonymous sign-in, so it requires no
+Google/GitHub credentials, email service, or password UI.
+
+For easy local setup, the example omits a database. Better Auth then uses
+stateless cookie sessions and its memory adapter. Anonymous users, dynamic
+clients, codes, and consent reset whenever the process restarts; configure a
+persistent Better Auth database before using the pattern in production.
+
+## Access the verified identity
+
+```typescript
+server.tool({ name: "whoami" }, async (_params, ctx) => ({
+  content: [
+    {
+      type: "text",
+      text: JSON.stringify({
+        id: ctx.auth.user.id,
+        isAnonymous: ctx.auth.user.isAnonymous,
+        scopes: ctx.auth.scopes,
+      }),
+    },
+  ],
+}));
 ```
 
-Set the GitHub callback URL to:
+Profile and application-specific access-token fields must be added with Better
+Auth's `customAccessTokenClaims`. The built-in mapper recognizes `email`,
+`name`, `picture`, `email_verified`, `sid`, `is_anonymous`/`isAnonymous`,
+`roles`, and `permissions` when present.
 
-```text
-http://localhost:3000/api/auth/callback/github
-```
-
-## Verify the setup
-
-Run the server and connect with an OAuth-capable MCP client.
-
-```bash
-npm run dev
-```
-
-Confirm these cases:
-
-- The client discovers Better Auth OAuth metadata.
-- The user can sign in and approve consent.
-- Authenticated tool calls include `ctx.auth.user.userId`.
-- Invalid or unsigned tokens are rejected.
-
-## Next steps
-
-<CardGroup cols={2}>
-  <Card title="Runnable Better Auth example" icon="github" href="https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/better-auth">
-    Compare your setup with a working mcp-use Better Auth server.
-  </Card>
-  <Card title="Better Auth OAuth Provider" icon="book-open" href="https://better-auth.com/docs/plugins/oauth-provider">
-    Review Better Auth's OAuth Provider plugin.
-  </Card>
-  <Card title="User Context" icon="user" href="/typescript/server/authentication/user-context">
-    Use Better Auth user claims inside tools.
-  </Card>
-  <Card title="Better Auth provider API reference" icon="terminal" href="/typescript/api-reference/server/auth-providers#oauthbetterauthprovider">
-    Look up exact provider options and defaults.
-  </Card>
-</CardGroup>
+<Card
+  title="Better Auth OAuth Provider"
+  icon="book-open"
+  href="https://better-auth.com/docs/plugins/oauth-provider"
+>
+  Configure Better Auth's OAuth server, discovery routes, claims, and
+  persistence.
+</Card>

--- a/examples/README.md
+++ b/examples/README.md
@@ -84,7 +84,7 @@ When you clone this repository locally, you'll find `python/` and `typescript/` 
   - [DNS Rebinding](../libraries/typescript/packages/mcp-use/examples/server/features/dns-rebinding/) - DNS rebinding protection
 - **[OAuth Examples](../libraries/typescript/packages/mcp-use/examples/server/oauth/)** - OAuth implementations
   - [Auth0](../libraries/typescript/packages/mcp-use/examples/server/oauth/auth0/)
-  - [Better Auth](../libraries/typescript/packages/mcp-use/examples/server/oauth/better-auth/)
+  - [Better Auth (v2 + Hono)](../libraries/typescript/packages/server/examples/auth/better-auth/)
   - [Supabase](../libraries/typescript/packages/mcp-use/examples/server/oauth/supabase/)
   - [WorkOS](../libraries/typescript/packages/mcp-use/examples/server/oauth/workos/)
 - **[Deployment](../libraries/typescript/packages/mcp-use/examples/server/deployment/)** - Deployment examples

--- a/libraries/typescript/.changeset/better-auth-v2-provider.md
+++ b/libraries/typescript/.changeset/better-auth-v2-provider.md
@@ -1,0 +1,7 @@
+---
+"mcp-use": minor
+---
+
+Add the v2 `oauthBetterAuthProvider({ authURL })` resource-server adapter and a
+credential-free Hono example using Better Auth anonymous sign-in with stateless
+cookie sessions.

--- a/libraries/typescript/packages/server/examples/auth/README.md
+++ b/libraries/typescript/packages/server/examples/auth/README.md
@@ -7,6 +7,7 @@ These examples use direct external authorization servers:
 - [WorkOS](./workos/)
 - [Supabase](./supabase/)
 - [Keycloak](./keycloak/)
+- [Better Auth](./better-auth/)
 
 Each server exposes only the `get-user-info` tool. It never issues, proxies, or
 forwards access tokens. For public deployments, set `MCP_URL` to the server
@@ -32,6 +33,7 @@ canonical origin. The shared handler uses `legacy: "stateless"`. Public and
 tunnel deployments must set `MCP_URL` to the server origin. Copy the provider
 `.env.example` to `.env` and configure it before starting the server.
 
-The Supabase example is an exception: it runs a standalone Hono app (via
-`tsx`) because it hosts Supabase's consent UI alongside the MCP endpoint, and
-therefore cannot use the `mcp-use` CLI.
+The Supabase example is an exception: it runs one standalone Hono app because
+it hosts auth routes alongside the MCP endpoint. The Better Auth example keeps
+the regular `mcp-use` server and runs its Hono authorization server as a second
+process.

--- a/libraries/typescript/packages/server/examples/auth/better-auth/.env.example
+++ b/libraries/typescript/packages/server/examples/auth/better-auth/.env.example
@@ -1,0 +1,3 @@
+BETTER_AUTH_SECRET=replace-with-at-least-32-random-characters
+BETTER_AUTH_URL=http://localhost:61843/api/auth
+MCP_URL=http://localhost:43127

--- a/libraries/typescript/packages/server/examples/auth/better-auth/README.md
+++ b/libraries/typescript/packages/server/examples/auth/better-auth/README.md
@@ -1,0 +1,61 @@
+# Better Auth + Hono
+
+This example runs two independent applications:
+
+- a regular `mcp-use` server at `http://localhost:43127/mcp`
+- a Hono authorization server running Better Auth at
+  `http://localhost:61843/api/auth`
+
+The MCP server only receives `authURL` and verifies the access tokens issued by
+the separate authorization server. The Hono app owns Better Auth, discovery,
+dynamic client registration, anonymous sign-in, consent, and token issuance.
+
+Better Auth is intentionally configured without a database. That enables its
+stateless cookie-session mode and uses its in-memory adapter for anonymous
+users, dynamically registered OAuth clients, authorization codes, and consent.
+Everything resets when the auth process restarts, which is convenient for this
+demo but not appropriate for a multi-instance or persistent deployment.
+
+## Run it
+
+Start the authorization server in one terminal:
+
+```sh
+pnpm dev:auth
+```
+
+Start the normal `mcp-use` development server in another:
+
+```sh
+pnpm dev
+```
+
+Connect an OAuth-capable MCP client to `http://localhost:43127/mcp`. The browser
+flow is sent to the Hono app on port 61843, where it asks you to continue
+anonymously and approve access. The MCP server's `whoami` tool then returns the
+verified Better Auth subject.
+
+`BETTER_AUTH_SECRET` is optional for local use. Copy `.env.example` to `.env`
+and replace the secret before adapting the example for a deployment. Keep
+`BETTER_AUTH_URL` identical in both processes, and set `MCP_URL` to the MCP
+server's public origin. The auth process appends `/mcp` for the token audience,
+matching the `mcp-use` CLI convention.
+
+## File layout
+
+```text
+src/index.ts        Regular MCPServer default export used by mcp-use dev
+src/auth-server.ts  Standalone Hono authorization server and login/consent UI
+src/auth.ts         Better Auth configuration
+```
+
+## What the integration owns
+
+- `oauthBetterAuthProvider({ authURL })` advertises the external Better Auth
+  endpoints and verifies its access-token JWTs.
+- `mcp-use dev` hosts only the MCP resource server and its protected-resource
+  metadata.
+- The separate Hono process mounts Better Auth and its authorization-server
+  discovery routes.
+- Your application remains responsible for Better Auth plugins, persistence,
+  login, consent UX, and cross-origin policy.

--- a/libraries/typescript/packages/server/examples/auth/better-auth/package.json
+++ b/libraries/typescript/packages/server/examples/auth/better-auth/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "mcp-use-example-auth-better-auth",
+  "type": "module",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Example: a mcp-use server authenticated by a standalone Hono and Better Auth OAuth server.",
+  "engines": {
+    "node": ">=24.0.0"
+  },
+  "scripts": {
+    "dev": "mcp-use dev --port 43127",
+    "dev:auth": "tsx watch src/auth-server.ts",
+    "build": "mcp-use build",
+    "start": "mcp-use start --port 43127",
+    "start:auth": "tsx src/auth-server.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@better-auth/oauth-provider": "^1.6.2",
+    "@hono/node-server": "^1.19.13",
+    "better-auth": "^1.6.2",
+    "hono": "^4.12.27",
+    "mcp-use": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^24.13.2",
+    "tsx": "^4.21.0",
+    "typescript": "7.0.1-rc"
+  }
+}

--- a/libraries/typescript/packages/server/examples/auth/better-auth/src/auth-server.ts
+++ b/libraries/typescript/packages/server/examples/auth/better-auth/src/auth-server.ts
@@ -1,0 +1,171 @@
+import {
+  oauthProviderAuthServerMetadata,
+  oauthProviderOpenIdConfigMetadata,
+} from "@better-auth/oauth-provider";
+import { serve } from "@hono/node-server";
+import { Hono } from "hono";
+import { cors } from "hono/cors";
+
+import { createAuth } from "./auth.js";
+
+if (process.env["NODE_ENV"] !== "production") {
+  try {
+    process.loadEnvFile(".env");
+  } catch {
+    // The example also runs without an .env file.
+  }
+}
+
+const authURL = new URL(
+  process.env["BETTER_AUTH_URL"] ?? "http://localhost:61843/api/auth"
+);
+if (authURL.pathname.replace(/\/$/, "") !== "/api/auth") {
+  throw new Error("BETTER_AUTH_URL must use the /api/auth path");
+}
+
+const port = Number(
+  authURL.port !== "" ? authURL.port : authURL.protocol === "https:" ? 443 : 80
+);
+const origin = authURL.origin;
+const mcpURL = new URL(process.env["MCP_URL"] ?? "http://localhost:43127");
+if (mcpURL.pathname !== "/" || mcpURL.search !== "" || mcpURL.hash !== "") {
+  throw new Error("MCP_URL must be an origin without a path, query, or hash");
+}
+const resource = new URL("/mcp", mcpURL).href;
+const resourceOrigin = mcpURL.origin;
+
+const auth = createAuth({ origin, resource });
+const app = new Hono();
+
+// Browser-based MCP clients call registration and token endpoints from the
+// MCP server's origin, so the standalone authorization server allows it.
+app.use(
+  "*",
+  cors({
+    origin: resourceOrigin,
+    allowHeaders: ["Authorization", "Content-Type", "MCP-Protocol-Version"],
+    allowMethods: ["GET", "HEAD", "POST", "OPTIONS"],
+    credentials: true,
+  })
+);
+
+const metadataHeaders = {
+  "Access-Control-Allow-Origin": resourceOrigin,
+  "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
+};
+const authServerMetadata = oauthProviderAuthServerMetadata(auth, {
+  headers: metadataHeaders,
+});
+const openIdConfiguration = oauthProviderOpenIdConfigMetadata(auth, {
+  headers: metadataHeaders,
+});
+
+app.get("/", (c) =>
+  c.text(
+    `Better Auth authorization server\nIssuer: ${authURL.href}\nMCP resource: ${resource}\n`
+  )
+);
+
+// Better Auth's issuer contains a path, so expose both RFC 8414 discovery
+// forms and the OIDC issuer-appended form before mounting its catch-all API.
+app.get("/.well-known/oauth-authorization-server/api/auth", (c) =>
+  authServerMetadata(c.req.raw)
+);
+app.get("/api/auth/.well-known/oauth-authorization-server", (c) =>
+  authServerMetadata(c.req.raw)
+);
+app.get("/api/auth/.well-known/openid-configuration", (c) =>
+  openIdConfiguration(c.req.raw)
+);
+app.on(["GET", "POST"], "/api/auth/*", (c) => auth.handler(c.req.raw));
+
+app.get("/sign-in", (c) => c.html(signInPage));
+app.get("/consent", (c) => c.html(consentPage));
+
+serve({ fetch: app.fetch, port }, ({ port: boundPort }) => {
+  console.log(`Better Auth: http://localhost:${boundPort}/api/auth`);
+  console.log(`MCP resource: ${resource}`);
+});
+
+const signInPage = `<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8"><title>Anonymous sign in</title></head>
+  <body>
+    <main>
+      <h1>Sign in anonymously</h1>
+      <p>No email, password, or social provider is required.</p>
+      <button id="sign-in">Continue</button>
+      <p id="error" role="alert"></p>
+    </main>
+    <script>
+      const button = document.querySelector('#sign-in');
+      const error = document.querySelector('#error');
+
+      button.addEventListener('click', async () => {
+        button.disabled = true;
+        error.textContent = '';
+
+        try {
+          const response = await fetch('/api/auth/sign-in/anonymous', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            credentials: 'include',
+            body: JSON.stringify({
+              oauth_query: window.location.search.slice(1),
+            }),
+          });
+          const data = await response.json();
+
+          if (response.ok && data.url) {
+            window.location.replace(data.url);
+            return;
+          }
+
+          error.textContent = data.message || 'Anonymous sign-in failed';
+        } catch (cause) {
+          error.textContent = cause instanceof Error
+            ? cause.message
+            : 'Anonymous sign-in failed';
+        } finally {
+          button.disabled = false;
+        }
+      });
+    </script>
+  </body>
+</html>`;
+
+const consentPage = `<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8"><title>Authorize MCP client</title></head>
+  <body>
+    <main>
+      <h1>Authorize MCP client</h1>
+      <p>The client is requesting access to this MCP server.</p>
+      <button data-accept="false">Deny</button>
+      <button data-accept="true">Allow</button>
+      <p id="error" role="alert"></p>
+    </main>
+    <script>
+      document.querySelectorAll('[data-accept]').forEach((button) => {
+        button.addEventListener('click', async () => {
+          const oauthQuery = window.location.search.slice(1);
+          const response = await fetch('/api/auth/oauth2/consent', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            credentials: 'include',
+            body: JSON.stringify({
+              accept: button.dataset.accept === 'true',
+              oauth_query: oauthQuery,
+            }),
+          });
+          const data = await response.json();
+          if (response.ok && data.url) {
+            window.location.href = data.url;
+            return;
+          }
+          document.querySelector('#error').textContent = data.message || 'Authorization failed';
+        });
+      });
+    </script>
+  </body>
+</html>`;

--- a/libraries/typescript/packages/server/examples/auth/better-auth/src/auth.ts
+++ b/libraries/typescript/packages/server/examples/auth/better-auth/src/auth.ts
@@ -1,0 +1,39 @@
+import { oauthProvider } from "@better-auth/oauth-provider";
+import { betterAuth } from "better-auth";
+import { anonymous, jwt } from "better-auth/plugins";
+
+export interface CreateAuthOptions {
+  origin: string;
+  resource: string;
+}
+
+export function createAuth({ origin, resource }: CreateAuthOptions) {
+  return betterAuth({
+    baseURL: origin,
+    basePath: "/api/auth",
+    trustedOrigins: [new URL(resource).origin],
+    secret:
+      process.env["BETTER_AUTH_SECRET"] ??
+      "development-only-secret-change-before-deploying",
+
+    // With no database, Better Auth stores sessions in signed cookies and
+    // uses its in-memory adapter for this demo's users and OAuth records.
+    plugins: [
+      anonymous(),
+      jwt(),
+      oauthProvider({
+        loginPage: "/sign-in",
+        consentPage: "/consent",
+        allowDynamicClientRegistration: true,
+        allowUnauthenticatedClientRegistration: true,
+        validAudiences: [resource],
+        customAccessTokenClaims: ({ user }) => ({
+          email: user?.email,
+          name: user?.name,
+          is_anonymous: user?.isAnonymous ?? false,
+        }),
+        silenceWarnings: { oauthAuthServerConfig: true },
+      }),
+    ],
+  });
+}

--- a/libraries/typescript/packages/server/examples/auth/better-auth/src/index.ts
+++ b/libraries/typescript/packages/server/examples/auth/better-auth/src/index.ts
@@ -1,0 +1,38 @@
+import { MCPServer } from "mcp-use";
+import { oauthBetterAuthProvider } from "mcp-use/oauth/better-auth";
+
+const authURL =
+  process.env["BETTER_AUTH_URL"] ?? "http://localhost:61843/api/auth";
+
+const server = new MCPServer({
+  name: "better-auth-anonymous-example",
+  version: "1.0.0",
+  oauth: oauthBetterAuthProvider({ authURL }),
+});
+
+server.tool(
+  {
+    name: "whoami",
+    description: "Return the verified Better Auth identity for this request.",
+  },
+  async (_params, ctx) => ({
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(
+          {
+            id: ctx.auth.user.id,
+            name: ctx.auth.user.name,
+            isAnonymous: ctx.auth.user.isAnonymous,
+            scopes: ctx.auth.scopes,
+          },
+          null,
+          2
+        ),
+      },
+    ],
+  })
+);
+
+// The mcp-use CLI imports this server and owns the MCP socket.
+export default server;

--- a/libraries/typescript/packages/server/examples/auth/better-auth/tsconfig.json
+++ b/libraries/typescript/packages/server/examples/auth/better-auth/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2024", "DOM"],
+    "types": ["node"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}

--- a/libraries/typescript/packages/server/package.json
+++ b/libraries/typescript/packages/server/package.json
@@ -57,6 +57,10 @@
       "types": "./dist/oauth/keycloak.d.ts",
       "import": "./dist/oauth/keycloak.js"
     },
+    "./oauth/better-auth": {
+      "types": "./dist/oauth/better-auth.d.ts",
+      "import": "./dist/oauth/better-auth.js"
+    },
     "./node": {
       "types": "./dist/node-bridge.d.ts",
       "import": "./dist/node-bridge.js"

--- a/libraries/typescript/packages/server/specs/AUTH_IMPLEMENTATION.md
+++ b/libraries/typescript/packages/server/specs/AUTH_IMPLEMENTATION.md
@@ -128,6 +128,7 @@ oauthAuth0Provider(...)
 oauthWorkOSProvider(...)
 oauthSupabaseProvider(...)
 oauthKeycloakProvider(...)
+oauthBetterAuthProvider(...)
 oauthCustomProvider(...)
 ```
 
@@ -412,13 +413,14 @@ Those adapters are conveniences for normal and custom composition. A framework-s
 
 ## Port provider adapters after the seam
 
-The first implementation phase supplies the resource-server seam. The next phase ports five v1 provider adapters:
+The first implementation phase supplies the resource-server seam. Provider adapters are:
 
 1. Clerk with `oauthClerkProvider`
 2. Auth0 with `oauthAuth0Provider`
 3. WorkOS with `oauthWorkOSProvider`
 4. Supabase with `oauthSupabaseProvider`
 5. Keycloak with `oauthKeycloakProvider`
+6. Better Auth with `oauthBetterAuthProvider`
 
 Each adapter verifies tokens, maps verified claims to a typed `user`, preserves the verified payload, provides normalized permissions, and advertises its authorization-server metadata. Each adapter must map claims rather than cast decoded payloads. No adapter offers `verifyJwt: false`.
 
@@ -426,7 +428,7 @@ JWT adapters share a `jose` implementation for remote JWKS caching and signature
 
 In direct mode, clients use the external authorization server's registration, authorization, and token endpoints. mcp-use serves protected-resource metadata, advertises the external authorization server, and verifies the resulting access token. The external authorization server must be advertised for the canonical resource and issue a token specifically bound to that resource, including the RFC 8707 `resource` indicator when applicable. mcp-use never handles authorization codes or client secrets in direct mode.
 
-Better Auth is explicitly deferred. Do not port `oauthBetterAuthProvider` as part of the resource-server adapter phase. Its v2 integration will be designed separately so a Better Auth instance can compose with `MCPServer` more directly than the v1 provider wrapper. The custom provider escape hatch remains available in the meantime, but its shape does not constrain the future first-class Better Auth API.
+Better Auth is integrated as a resource-server adapter via `oauthBetterAuthProvider({ authURL })`. The application owns the Better Auth instance and mounts its routes; the adapter advertises its OAuth endpoints and verifies its access-token JWTs.
 
 ## Meet the SDK dependency prerequisite
 
@@ -452,7 +454,7 @@ Acceptance coverage must include:
 Migrate provider concepts and public context compatibility, not deferred behavior:
 
 - Port the Clerk, Auth0, WorkOS, Supabase, and Keycloak provider concepts and their typed user mappings.
-- Defer Better Auth to a separate integration design; do not carry the v1 provider API forward by default.
+- Keep Better Auth instance creation and route mounting application-owned; the provider accepts only the external `authURL` plus shared resource options.
 - Deferred behavior is excluded from this implementation phase.
 - Preserve `user`, `payload`, `accessToken`, `scopes`, and `permissions` on `ctx.auth`.
 - In direct mode, `accessToken` aliases verified SDK `AuthInfo.token`.

--- a/libraries/typescript/packages/server/specs/AUTH_SPEC.md
+++ b/libraries/typescript/packages/server/specs/AUTH_SPEC.md
@@ -421,6 +421,7 @@ oauthAuth0Provider(...)
 oauthWorkOSProvider(...)
 oauthSupabaseProvider(...)
 oauthKeycloakProvider(...)
+oauthBetterAuthProvider(...)
 oauthCustomProvider(...)
 ```
 
@@ -735,13 +736,14 @@ Those adapters are conveniences for normal and custom composition. A framework-s
 
 ## Port provider adapters after the seam
 
-The first implementation phase supplies only the resource-server seam. The next phase ports five v1 provider adapters:
+The first implementation phase supplies only the resource-server seam. Provider adapters are:
 
 1. Clerk with `oauthClerkProvider`
 2. Auth0 with `oauthAuth0Provider`
 3. WorkOS with `oauthWorkOSProvider`
 4. Supabase with `oauthSupabaseProvider`
 5. Keycloak with `oauthKeycloakProvider`
+6. Better Auth with `oauthBetterAuthProvider`
 
 Each adapter verifies tokens, maps verified claims to a typed `user`, preserves the verified payload, provides normalized permissions, and advertises its authorization-server metadata. Each adapter must map claims rather than cast decoded payloads. No adapter offers `verifyJwt: false`.
 
@@ -749,7 +751,7 @@ JWT adapters share a `jose` implementation for remote JWKS caching and signature
 
 In direct mode, clients use the external authorization server's registration, authorization, and token endpoints. mcp-use serves protected-resource metadata, advertises the external authorization server, and verifies the resulting access token. The external authorization server must be advertised for the canonical resource and issue a token specifically bound to that resource, including the RFC 8707 `resource` indicator when applicable. mcp-use never handles authorization codes or client secrets in direct mode.
 
-Better Auth is explicitly deferred. Do not port `oauthBetterAuthProvider` as part of the resource-server adapter phase. Its v2 integration will be designed separately so a Better Auth instance can compose with `MCPServer` more directly than the v1 provider wrapper. The custom provider escape hatch remains available in the meantime, but its shape does not constrain the future first-class Better Auth API.
+Better Auth is integrated as a resource-server adapter via `oauthBetterAuthProvider({ authURL })`. The application owns the Better Auth instance and mounts its routes; the adapter advertises its OAuth endpoints and verifies its access-token JWTs.
 
 ## Use proxy mode as a local authorization server
 
@@ -931,7 +933,7 @@ Acceptance coverage must include:
 Migrate provider concepts and public context compatibility, not proxy behavior:
 
 - Port the Clerk, Auth0, WorkOS, Supabase, and Keycloak provider concepts and their typed user mappings.
-- Defer Better Auth to a separate integration design; do not carry the v1 provider API forward by default.
+- Keep Better Auth instance creation and route mounting application-owned; the provider accepts only the external `authURL` plus shared resource options.
 - Do not port or preserve v1 proxy behavior. Implement the explicit local authorization-server proxy design in this document.
 - Preserve `user`, `payload`, `accessToken`, `scopes`, and `permissions` on `ctx.auth`.
 - In direct mode, `accessToken` aliases verified SDK `AuthInfo.token`. In proxy mode, it is the signed local MCP JWT and never an upstream token.

--- a/libraries/typescript/packages/server/src/oauth/better-auth.ts
+++ b/libraries/typescript/packages/server/src/oauth/better-auth.ts
@@ -1,0 +1,120 @@
+import type { AuthInfo, OAuthMetadata } from "@modelcontextprotocol/server";
+
+import {
+  booleanValue,
+  createJwtVerifier,
+  invalidToken,
+  normalizedStrings,
+  normalizedProviderUrl,
+  payloadFromAuthInfo,
+  providerEndpoint,
+  requiredString,
+  stringValue,
+} from "./jwt.js";
+import {
+  oauthCustomProvider,
+  type OAuthProvider,
+  type OAuthResourceOptions,
+} from "./provider.js";
+
+/** Verified Better Auth claims exposed to authenticated MCP callbacks. */
+export interface BetterAuthOAuthUser {
+  id: string;
+  email?: string;
+  name?: string;
+  picture?: string;
+  emailVerified?: boolean;
+  sessionId?: string;
+  isAnonymous?: boolean;
+  roles: string[];
+}
+
+/** Configures Better Auth JWT verification and protected-resource metadata. */
+export interface BetterAuthOAuthProviderOptions extends OAuthResourceOptions {
+  /** Full Better Auth issuer URL, including its base path. */
+  authURL: URL | string;
+}
+
+/**
+ * Creates a provider for Better Auth's OAuth 2.1 Provider plugin.
+ *
+ * Better Auth owns registration, authorization, consent, and token issuance.
+ * mcp-use advertises those endpoints and verifies the resulting access-token
+ * JWTs against Better Auth's JWKS endpoint.
+ *
+ * @param options - Better Auth issuer URL and resource-server settings.
+ * @returns A provider that rejects tokens not issued for the resolved MCP resource.
+ */
+export function oauthBetterAuthProvider(
+  options: BetterAuthOAuthProviderOptions
+): OAuthProvider<BetterAuthOAuthUser> {
+  const issuer = normalizedProviderUrl(
+    options.authURL,
+    "Better Auth authURL"
+  ).href.replace(/\/$/, "");
+
+  return oauthCustomProvider<BetterAuthOAuthUser>({
+    ...options,
+    createTokenVerifier: (resource) =>
+      createJwtVerifier({
+        issuer,
+        jwksUrl: new URL(providerEndpoint(issuer, "jwks")),
+        resource,
+      }),
+    oauthMetadata: metadata(issuer, options.scopesSupported),
+    mapAuthInfo: mapUser,
+  });
+}
+
+function metadata(
+  issuer: string,
+  scopesSupported: readonly string[] | undefined
+): OAuthMetadata {
+  return {
+    issuer,
+    authorization_endpoint: providerEndpoint(issuer, "oauth2/authorize"),
+    token_endpoint: providerEndpoint(issuer, "oauth2/token"),
+    registration_endpoint: providerEndpoint(issuer, "oauth2/register"),
+    jwks_uri: providerEndpoint(issuer, "jwks"),
+    response_types_supported: ["code"],
+    grant_types_supported: [
+      "authorization_code",
+      "client_credentials",
+      "refresh_token",
+    ],
+    code_challenge_methods_supported: ["S256"],
+    scopes_supported:
+      scopesSupported === undefined
+        ? ["openid", "profile", "email", "offline_access"]
+        : [...scopesSupported],
+  };
+}
+
+function mapUser(authInfo: AuthInfo) {
+  const payload = payloadFromAuthInfo(authInfo);
+  const id = requiredString(payload, "sub");
+  if (id === undefined) throw invalidToken("Missing Better Auth subject");
+
+  return {
+    user: {
+      id,
+      ...optional("email", stringValue(payload, "email")),
+      ...optional("name", stringValue(payload, "name")),
+      ...optional("picture", stringValue(payload, "picture")),
+      ...optional("emailVerified", booleanValue(payload, "email_verified")),
+      ...optional("sessionId", stringValue(payload, "sid")),
+      ...optional(
+        "isAnonymous",
+        booleanValue(payload, "is_anonymous") ??
+          booleanValue(payload, "isAnonymous")
+      ),
+      roles: normalizedStrings(payload["roles"]),
+    },
+    payload,
+    permissions: normalizedStrings(payload["permissions"]),
+  };
+}
+
+function optional<T>(key: string, value: T | undefined): Record<string, T> {
+  return value === undefined ? {} : { [key]: value };
+}

--- a/libraries/typescript/packages/server/tests/oauth-direct-providers.test.ts
+++ b/libraries/typescript/packages/server/tests/oauth-direct-providers.test.ts
@@ -2,6 +2,7 @@ import { exportJWK, generateKeyPair, SignJWT } from "jose";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { oauthAuth0Provider } from "../src/oauth/auth0.js";
+import { oauthBetterAuthProvider } from "../src/oauth/better-auth.js";
 import { oauthClerkProvider } from "../src/oauth/clerk.js";
 import { wrapOAuthTokenVerifier } from "../src/oauth/internal.js";
 import { oauthKeycloakProvider } from "../src/oauth/keycloak.js";
@@ -17,6 +18,83 @@ afterEach(() => {
 });
 
 describe("direct OAuth providers", () => {
+  it("verifies Better Auth JWTs and preserves issuer path prefixes", async () => {
+    const { privateKey, publicKey } = await generateKeyPair("EdDSA");
+    const jwk = await exportJWK(publicKey);
+    jwk.kid = "better-auth-key";
+    globalThis.fetch = jwksFixture(jwk);
+
+    const issuer = "https://auth.example.test/platform/api/auth";
+    const provider = oauthBetterAuthProvider({ authURL: `${issuer}/` });
+    expect(provider.oauthMetadata).toMatchObject({
+      issuer,
+      authorization_endpoint: `${issuer}/oauth2/authorize`,
+      token_endpoint: `${issuer}/oauth2/token`,
+      registration_endpoint: `${issuer}/oauth2/register`,
+      jwks_uri: `${issuer}/jwks`,
+      code_challenge_methods_supported: ["S256"],
+    });
+
+    await expect(
+      wrapOAuthTokenVerifier(provider, protectedResource).verifyAccessToken(
+        await signedToken(
+          privateKey,
+          "better-auth-key",
+          issuer,
+          protectedResource.href,
+          {
+            sub: "anonymous-user-1",
+            azp: "mcp-client-1",
+            scope: "openid tools:read",
+            name: "Anonymous",
+            is_anonymous: true,
+            roles: ["guest"],
+            permissions: ["tools:read"],
+            sid: "session-1",
+          },
+          "EdDSA"
+        )
+      )
+    ).resolves.toMatchObject({
+      clientId: "mcp-client-1",
+      scopes: ["openid", "tools:read"],
+      extra: {
+        user: {
+          id: "anonymous-user-1",
+          name: "Anonymous",
+          isAnonymous: true,
+          roles: ["guest"],
+          sessionId: "session-1",
+        },
+        permissions: ["tools:read"],
+      },
+    });
+  });
+
+  it("validates Better Auth authURL and token audience", async () => {
+    expect(() =>
+      oauthBetterAuthProvider({ authURL: "http://auth.example.test/api/auth" })
+    ).toThrow(/HTTPS|localhost/);
+
+    const { privateKey, publicKey } = await generateKeyPair("RS256");
+    const jwk = await exportJWK(publicKey);
+    jwk.kid = "better-auth-key";
+    globalThis.fetch = jwksFixture(jwk);
+    const issuer = "http://localhost:3000/api/auth";
+    const provider = oauthBetterAuthProvider({ authURL: issuer });
+    const token = await signedToken(
+      privateKey,
+      "better-auth-key",
+      issuer,
+      "http://localhost:3000/other",
+      { sub: "user-1", azp: "client-1" }
+    );
+
+    await expect(
+      provider.createTokenVerifier(protectedResource).verifyAccessToken(token)
+    ).rejects.toMatchObject({ code: "invalid_token" });
+  });
+
   it("verifies Auth0 JWTs with cached remote JWKS and maps claims", async () => {
     const { privateKey, publicKey } = await generateKeyPair("RS256");
     const jwk = await exportJWK(publicKey);
@@ -414,10 +492,11 @@ function signedToken(
   kid: string,
   issuer: string,
   audience: string | undefined,
-  claims: Record<string, unknown>
+  claims: Record<string, unknown>,
+  algorithm = "RS256"
 ): Promise<string> {
   const token = new SignJWT(claims)
-    .setProtectedHeader({ alg: "RS256", kid })
+    .setProtectedHeader({ alg: algorithm, kid })
     .setIssuer(issuer)
     .setIssuedAt(now())
     .setExpirationTime(now() + 60);

--- a/libraries/typescript/packages/server/tests/oauth-wiring-types.test.ts
+++ b/libraries/typescript/packages/server/tests/oauth-wiring-types.test.ts
@@ -2,6 +2,10 @@ import { MCPServer } from "../src/index.js";
 import { toAuthenticatedRequestContext } from "../src/context.js";
 import type { OAuthProvider } from "../src/oauth/index.js";
 import { oauthAuth0Provider, type Auth0OAuthUser } from "../src/oauth/auth0.js";
+import {
+  oauthBetterAuthProvider,
+  type BetterAuthOAuthUser,
+} from "../src/oauth/better-auth.js";
 import { oauthClerkProvider, type ClerkOAuthUser } from "../src/oauth/clerk.js";
 import {
   oauthKeycloakProvider,
@@ -103,6 +107,22 @@ function verifyOAuthCallbackTyping(): void {
     name: "clerk",
     version: "1.0.0",
     oauth: oauthClerkProvider({ frontendApiUrl: "https://clerk.example.com" }),
+  });
+
+  const betterAuth = new MCPServer({
+    name: "better-auth",
+    version: "1.0.0",
+    oauth: oauthBetterAuthProvider({
+      authURL: "https://auth.example.com/api/auth",
+    }),
+  });
+  betterAuth.tool({ name: "better-auth-user" }, (_params, ctx) => {
+    const auth: OAuthAuth<BetterAuthOAuthUser> = ctx.auth;
+    const user: BetterAuthOAuthUser = ctx.auth.user;
+    const isAnonymous: boolean | undefined = ctx.auth.user.isAnonymous;
+    assertOAuthAuthFields(auth);
+    void [user, isAnonymous];
+    return { content: [] };
   });
   clerk.tool({ name: "clerk-user" }, (_params, ctx) => {
     const auth: OAuthAuth<ClerkOAuthUser> = ctx.auth;

--- a/libraries/typescript/packages/server/tsup.config.ts
+++ b/libraries/typescript/packages/server/tsup.config.ts
@@ -12,6 +12,7 @@ export default defineConfig([
       "oauth/workos": "src/oauth/workos.ts",
       "oauth/supabase": "src/oauth/supabase.ts",
       "oauth/keycloak": "src/oauth/keycloak.ts",
+      "oauth/better-auth": "src/oauth/better-auth.ts",
       // Keep the OpenAPI integration in a sibling chunk. `MCPServer` imports
       // it synchronously so `fromOpenAPI()` stays a synchronous constructor,
       // while the root entry retains its independently enforced size budget.

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -560,6 +560,34 @@ importers:
         specifier: 7.0.1-rc
         version: 7.0.1-rc
 
+  packages/server/examples/auth/better-auth:
+    dependencies:
+      '@better-auth/oauth-provider':
+        specifier: ^1.6.2
+        version: 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.23(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))))(better-call@1.3.7(zod@4.4.3))
+      '@hono/node-server':
+        specifier: ^1.19.13
+        version: 1.19.13(hono@4.12.27)
+      better-auth:
+        specifier: '>=1.6.2'
+        version: 1.6.23(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
+      hono:
+        specifier: '>=4.12.27'
+        version: 4.12.27
+      mcp-use:
+        specifier: workspace:*
+        version: link:../../..
+    devDependencies:
+      '@types/node':
+        specifier: ^24.13.2
+        version: 24.13.2
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: 7.0.1-rc
+        version: 7.0.1-rc
+
   packages/server/examples/auth/clerk:
     dependencies:
       mcp-use:
@@ -1054,6 +1082,94 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@better-auth/core@1.6.23':
+    resolution: {integrity: sha512-beEhOs0uVeOxYOZKUfIEBd/nQV2Bd4/6wyLxZ0OFkn6CMTK2Vi+hXuZLnyPBeB6RdHpebEoJWiHqwHxBIxgPDQ==}
+    peerDependencies:
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      '@cloudflare/workers-types': '>=4'
+      '@opentelemetry/api': ^1.9.0
+      better-call: 1.3.7
+      jose: ^6.1.0
+      kysely: ^0.28.5 || ^0.29.0
+      nanostores: ^1.0.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+
+  '@better-auth/drizzle-adapter@1.6.23':
+    resolution: {integrity: sha512-2+/PTVfIP9E7iz6af8TB3lhnowHUj9ljC66kECmHaFEdUqPgzHoWux9epotKwO7XDg2ui4ttWQ8CMeNFLvQeKQ==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.23
+      '@better-auth/utils': 0.4.2
+      drizzle-orm: ^0.45.2
+    peerDependenciesMeta:
+      drizzle-orm:
+        optional: true
+
+  '@better-auth/kysely-adapter@1.6.23':
+    resolution: {integrity: sha512-zbNJsMbG09exfkGyvFqBLLqWoMPAUWjxCuUnEK5AsjbYoZeIjj/QGZgdf4CapVWryKxjA9Q6Jlr6fbiPpC3VAg==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.23
+      '@better-auth/utils': 0.4.2
+      kysely: ^0.28.17 || ^0.29.0
+    peerDependenciesMeta:
+      kysely:
+        optional: true
+
+  '@better-auth/memory-adapter@1.6.23':
+    resolution: {integrity: sha512-krIiR0pIVkaKlAzm690n5bcMW4NGbqeMg0HQSD9fz/KcQF/eWLqcq9gG/BhHTj2i/y96qH+W5JWPmaSOS5iTgQ==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.23
+      '@better-auth/utils': 0.4.2
+
+  '@better-auth/mongo-adapter@1.6.23':
+    resolution: {integrity: sha512-7+QdevitGlKBbP6JbiSk5SBnzPsKV/mDrQBGBn8hwByQLeJwqpqbuBPw7ZI8vzUlFfAAnyFiqwP3Eb8mxnp7pA==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.23
+      '@better-auth/utils': 0.4.2
+      mongodb: ^6.0.0 || ^7.0.0
+    peerDependenciesMeta:
+      mongodb:
+        optional: true
+
+  '@better-auth/oauth-provider@1.6.23':
+    resolution: {integrity: sha512-1sDN+N4Sztmpk8ziCU3MXicxOTfvYoHvHvhJMQ7PSfr+pLXnYN+dJFI9S3zBRwstmTeJx/OhRIZWrwFJ0TgBnA==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.23
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      better-auth: '>=1.6.2'
+      better-call: 1.3.7
+
+  '@better-auth/prisma-adapter@1.6.23':
+    resolution: {integrity: sha512-2qSdzidq4tkb1eS5TTqb4Nzg0mdZWm3Qky9SYeXeb8PpVQbC2sxqJhEM5mK7y12uU6I8hc64wO9f7AFVNL+6UQ==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.23
+      '@better-auth/utils': 0.4.2
+      '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
+      prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
+    peerDependenciesMeta:
+      '@prisma/client':
+        optional: true
+      prisma:
+        optional: true
+
+  '@better-auth/telemetry@1.6.23':
+    resolution: {integrity: sha512-/R2Kb+z2BpDOOWwVHqOk+c0VNpuwfCv4Hp5Yr9003WIZPax/zyNraGLB9CFE8qF2gZW8Dsz419k4I8CPrGzpDA==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.23
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+
+  '@better-auth/utils@0.4.2':
+    resolution: {integrity: sha512-AUxrvu+HaaODsUyzDxFgwd/8RZ1yZaYo42LXKSrU2oGgR38pS1ij8nqQKNgtTWoYGpNevNXtCfgTy6loHveW9A==}
+
+  '@better-fetch/fetch@1.3.1':
+    resolution: {integrity: sha512-ABkD1WhyfPZprKRQI3bhATjeiFuNWC9PXhfGWqL+sg/gKrM977oFrYkdb4msM3hgUGonr7KlOsOFT5TU2rht9g==}
 
   '@braintree/sanitize-url@6.0.2':
     resolution: {integrity: sha512-Tbsj02wXCbqGmzdnXNk0SOF19ChhRU70BsroIi4Pm6Ehp56in6vch94mfbdQ17DozxkL3BAVjbZ4Qc1a0HFRAg==}
@@ -1682,6 +1798,10 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@noble/ciphers@2.2.0':
+    resolution: {integrity: sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==}
+    engines: {node: '>= 20.19.0'}
 
   '@noble/hashes@2.2.0':
     resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
@@ -3732,6 +3852,76 @@ packages:
     resolution: {integrity: sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==}
     engines: {node: '>= 0.8'}
 
+  better-auth@1.6.23:
+    resolution: {integrity: sha512-4vOaRd9UiKGKm9R+ej0jjU1es3MiJIiNc9Qq3VCnYqOZ4/nb5272QqTxWYoDxyUXl5x6A2x2we5KZKQO9teTQQ==}
+    peerDependencies:
+      '@lynx-js/react': '*'
+      '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
+      '@sveltejs/kit': ^2.0.0
+      '@tanstack/react-start': ^1.0.0
+      '@tanstack/solid-start': ^1.0.0
+      better-sqlite3: ^12.0.0
+      drizzle-kit: '>=0.31.4'
+      drizzle-orm: ^0.45.2
+      mongodb: ^6.0.0 || ^7.0.0
+      mysql2: ^3.0.0
+      next: ^14.0.0 || ^15.0.0 || ^16.0.0
+      pg: ^8.0.0
+      prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
+      react: ^19.2.0
+      react-dom: ^19.2.0
+      solid-js: ^1.0.0
+      svelte: ^4.0.0 || ^5.0.0
+      vitest: '>=4.1.9'
+      vue: ^3.0.0
+    peerDependenciesMeta:
+      '@lynx-js/react':
+        optional: true
+      '@prisma/client':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      '@tanstack/react-start':
+        optional: true
+      '@tanstack/solid-start':
+        optional: true
+      better-sqlite3:
+        optional: true
+      drizzle-kit:
+        optional: true
+      drizzle-orm:
+        optional: true
+      mongodb:
+        optional: true
+      mysql2:
+        optional: true
+      next:
+        optional: true
+      pg:
+        optional: true
+      prisma:
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      solid-js:
+        optional: true
+      svelte:
+        optional: true
+      vitest:
+        optional: true
+      vue:
+        optional: true
+
+  better-call@1.3.7:
+    resolution: {integrity: sha512-Al51/hjp2SSp6CRTa3F2ptcx4yQVS1xWKoY6jcVXqNYOap6mHFP2jUBn5EwIL4iIed1/Sq4hlQ+Umm6EflZG+w==}
+    peerDependencies:
+      zod: 4.4.3
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
@@ -4209,6 +4399,9 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
   delaunator@5.1.0:
     resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
@@ -5218,6 +5411,10 @@ packages:
       '@types/node': '>=18'
       typescript: '>=5.0.4 <7'
 
+  kysely@0.29.3:
+    resolution: {integrity: sha512-VHtBdW6XB/pgoTSqraM3UAa2rYoYdNXqnNPpX+8XXP+cwYbVEFuAp3HyPt1vpNfU9l7Y2kpUrA9QDPsy8uUqOQ==}
+    engines: {node: '>=22.0.0'}
+
   langchain@1.2.16:
     resolution: {integrity: sha512-gVLSNhP8It6vDMribkqyKIiq79F2kCPAk3L4nGRUzKvIK2XD0J1y6UkuzEKwJ48w5rEKYHI729qthBteXQHOmA==}
     engines: {node: '>=20'}
@@ -5630,6 +5827,10 @@ packages:
     resolution: {integrity: sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==}
     engines: {node: ^18 || >=20}
     hasBin: true
+
+  nanostores@1.4.0:
+    resolution: {integrity: sha512-i0tloweeudshAEuddpDxcg9Ik6pkPfVsHIgKyf143JrgG7/MOh0+q7BypdLXZPoOP7fOYt1eTcwGkyiVmhJFkA==}
+    engines: {node: ^20.0.0 || >=22.0.0}
 
   napi-postinstall@0.3.4:
     resolution: {integrity: sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==}
@@ -6200,6 +6401,9 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rou3@0.7.12:
+    resolution: {integrity: sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==}
+
   roughjs@4.6.4:
     resolution: {integrity: sha512-s6EZ0BntezkFYMf/9mGn7M8XGIoaav9QQBCnJROWB3brUWQ683Q2LbRD/hq0Z3bAJ/9NVpU/5LpiTWvQMyLDhw==}
 
@@ -6275,6 +6479,9 @@ packages:
 
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
+
+  set-cookie-parser@3.1.2:
+    resolution: {integrity: sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -7184,6 +7391,69 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
+  '@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0)':
+    dependencies:
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      '@opentelemetry/semantic-conventions': 1.41.1
+      '@standard-schema/spec': 1.1.0
+      better-call: 1.3.7(zod@4.4.3)
+      jose: 6.1.3
+      kysely: 0.29.3
+      nanostores: 1.4.0
+      zod: 4.4.3
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@better-auth/drizzle-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)':
+    dependencies:
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0)
+      '@better-auth/utils': 0.4.2
+
+  '@better-auth/kysely-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(kysely@0.29.3)':
+    dependencies:
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0)
+      '@better-auth/utils': 0.4.2
+    optionalDependencies:
+      kysely: 0.29.3
+
+  '@better-auth/memory-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)':
+    dependencies:
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0)
+      '@better-auth/utils': 0.4.2
+
+  '@better-auth/mongo-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)':
+    dependencies:
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0)
+      '@better-auth/utils': 0.4.2
+
+  '@better-auth/oauth-provider@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.23(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))))(better-call@1.3.7(zod@4.4.3))':
+    dependencies:
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0)
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      better-auth: 1.6.23(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
+      better-call: 1.3.7(zod@4.4.3)
+      jose: 6.1.3
+      zod: 4.4.3
+
+  '@better-auth/prisma-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)':
+    dependencies:
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0)
+      '@better-auth/utils': 0.4.2
+
+  '@better-auth/telemetry@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
+    dependencies:
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0)
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+
+  '@better-auth/utils@0.4.2':
+    dependencies:
+      '@noble/hashes': 2.2.0
+
+  '@better-fetch/fetch@1.3.1': {}
+
   '@braintree/sanitize-url@6.0.2': {}
 
   '@braintree/sanitize-url@7.1.2': {}
@@ -7917,8 +8187,9 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
-  '@noble/hashes@2.2.0':
-    optional: true
+  '@noble/ciphers@2.2.0': {}
+
+  '@noble/hashes@2.2.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -9627,6 +9898,42 @@ snapshots:
     dependencies:
       safe-buffer: 5.1.2
 
+  better-auth@1.6.23(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))):
+    dependencies:
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0)
+      '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
+      '@better-auth/kysely-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(kysely@0.29.3)
+      '@better-auth/memory-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
+      '@better-auth/mongo-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
+      '@better-auth/prisma-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
+      '@better-auth/telemetry': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      '@noble/ciphers': 2.2.0
+      '@noble/hashes': 2.2.0
+      better-call: 1.3.7(zod@4.4.3)
+      defu: 6.1.7
+      jose: 6.1.3
+      kysely: 0.29.3
+      nanostores: 1.4.0
+      zod: 4.4.3
+    optionalDependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - '@opentelemetry/api'
+
+  better-call@1.3.7(zod@4.4.3):
+    dependencies:
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      rou3: 0.7.12
+      set-cookie-parser: 3.1.2
+    optionalDependencies:
+      zod: 4.4.3
+
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
@@ -10132,6 +10439,8 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  defu@6.1.7: {}
 
   delaunator@5.1.0:
     dependencies:
@@ -11328,6 +11637,8 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
+  kysely@0.29.3: {}
+
   langchain@1.2.16(@langchain/core@1.1.18(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(openai@6.17.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(openai@6.17.0(ws@8.21.0)(zod@4.4.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(ws@8.21.0)(zod-to-json-schema@3.25.1(zod@4.4.3)):
     dependencies:
       '@langchain/core': 1.1.18(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(openai@6.17.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
@@ -11661,6 +11972,8 @@ snapshots:
   nanoid@3.3.12: {}
 
   nanoid@5.1.16: {}
+
+  nanostores@1.4.0: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -12345,6 +12658,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.1
       fsevents: 2.3.3
 
+  rou3@0.7.12: {}
+
   roughjs@4.6.4:
     dependencies:
       hachure-fill: 0.5.2
@@ -12448,6 +12763,8 @@ snapshots:
       - supports-color
 
   set-cookie-parser@2.7.2: {}
+
+  set-cookie-parser@3.1.2: {}
 
   set-function-length@1.2.2:
     dependencies:


### PR DESCRIPTION
## Summary
- add the v2 `oauthBetterAuthProvider` with Better Auth JWT/JWKS verification
- add a split example with a normal `mcp-use` server and a standalone Hono/Better Auth authorization server
- use anonymous, sessionless sign-in so the example needs no external identity provider
- add exports, tests, docs, and a changeset

## Why
This ports the v1 app-owned Better Auth integration while keeping the MCP resource server separate from the authorization server. Users supply `authURL` and retain control of their Better Auth setup.

## Validation
- `pnpm build` in `packages/client`
- `pnpm build` in `packages/server`
- `pnpm typecheck` in the Better Auth example
- `pnpm vitest run tests/oauth-direct-providers.test.ts tests/oauth-wiring-types.test.ts tests/budgets/cli-budget.test.ts` (20 tests)
- live authorization-code flow through anonymous sign-in, consent, token exchange, and authenticated `whoami`

## Notes
The Inspector proxy workaround from the final debugging turn was reverted after confirming the flow works in another client.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a v2 Better Auth OAuth provider for MCP servers and a split example that runs a standalone `Hono`/Better Auth authorization server. The provider advertises Better Auth endpoints and verifies access‑token JWTs via JWKS, with an anonymous sign‑in demo.

- **New Features**
  - Added `oauthBetterAuthProvider({ authURL, ... })` in `mcp-use/oauth/better-auth` that advertises Better Auth `/oauth2/authorize`, `/oauth2/token`, `/oauth2/register`, and `/jwks`, and verifies JWT issuer/signature/exp and resource audience; maps claims to `BetterAuthOAuthUser`.
  - New runnable example: separate `Hono` Better Auth server at `http://localhost:61843/api/auth` and a normal `mcp-use` server at `http://localhost:43127/mcp`, using anonymous sign‑in with stateless cookies; includes discovery routes and CORS setup.
  - Updated docs and API reference; added tests for Better Auth issuer path handling, JWKS verification, and typing; minor changeset.

- **Migration**
  - Import from `mcp-use/oauth/better-auth` and call `oauthBetterAuthProvider({ authURL })`.
  - Pass the full issuer including base path (e.g., `http://localhost:61843/api/auth`); set `resource` if your MCP endpoint isn’t `/mcp`.
  - Run Better Auth as a separate app; allow the MCP origin via CORS and set Better Auth `trustedOrigins` accordingly; use persistent storage for production.

<sup>Written for commit 8a61b13017aed2d0ecbcade36b690e4949650867. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

