### PR TITLE
fix(docs): reword changelog heading that breaks mint broken-links with URIError

### DIFF
--- a/docs/python/changelog/1_7_0.mdx
+++ b/docs/python/changelog/1_7_0.mdx
@@ -65,7 +65,7 @@ Switched to `WeakSet` for resource subscriptions to prevent memory leaks on clie
 
 Fixed debug routes to be registered when `debug=True` is passed to `run()`.
 
-### 100% Client Conformance (20/20)
+### Full Client Conformance (20/20)
 **[PR #1019](https://github.com/mcp-use/mcp-use/pull/1019) by @pietrozullo**
 
 Achieved 100% client conformance score by fixing SSE retry handling.


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

Check all that apply:
- [ ] TypeScript
- [ ] Python
- [x] Documentation only
- [ ] CI/CD or tooling

## Changes

Closes #1911.

The "Generate and validate API documentation" CI job currently fails on **every PR** with:

```
error Syntax error - Unable to parse python/changelog/1_7_0.mdx - URIError: URI malformed
```

The current `mint` CLI (installed fresh in CI each run) throws generating the anchor slug for the heading `### 100% Client Conformance (20/20)` — a bare `%` followed by a non-hex character breaks `decodeURI`. The file is from March; the mint version changed, which is why old content breaks current CI.

One-line fix: reword to `### Full Client Conformance (20/20)`.

## Review Readiness

- [x] The PR is scoped to one issue or one clearly related change
- [x] The PR description explains the user-visible problem and the fix
- [x] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [x] I verified the affected package/docs path with the commands listed below
- [x] I checked for existing open PRs that already solve the same issue

## Testing

- Bisect-verified locally on Node 22 with `mint@latest`:
  - unmodified main → `URIError: URI malformed` on that file
  - this one-line reword → `success no broken links found` across the entire docs tree
- Prose occurrences of `%` elsewhere in the file are harmless (only headings feed anchor generation).

## Backwards Compatibility

Docs-only. The heading's anchor changes (`#100-client-conformance-2020` → `#full-client-conformance-2020`) — grepped the repo for links to the old anchor: none exist.

## Related Issues

Closes #1911. Unblocks the docs check currently red on all open PRs (e.g. #1902's run).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworded a changelog heading to prevent `mint` from throwing a URIError during anchor generation, unblocking the docs broken-links job. Changed `### 100% Client Conformance (20/20)` to `### Full Client Conformance (20/20)`.

<sup>Written for commit 06ad4ed7a2037f8285f9921b0a3968e38018d496. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

