### PR TITLE
feat(server): enhance client SDK loading and installation process

### DIFF
--- a/libraries/typescript/.changeset/client-cli-auto-install.md
+++ b/libraries/typescript/.changeset/client-cli-auto-install.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": minor
+---
+
+Auto-install `@mcp-use/client` when `mcp-use client` or `mcp-use screenshot` needs it and the package is missing. Installs into the nearest project when a `package.json` exists; otherwise uses a global sandbox at `~/.mcp-use/client-sdk/`. Fixes `npx mcp-use client connect …` without a separate client install step.

--- a/libraries/typescript/packages/server/specs/CLI_SPEC.md
+++ b/libraries/typescript/packages/server/specs/CLI_SPEC.md
@@ -73,6 +73,7 @@ All global CLI state lives under `~/.mcp-use/`; project state lives under the pr
 - `~/.mcp-use/config.json` is owned by cloud commands and contains only the cloud API key plus active organization id/name/slug. `MCP_USE_CLOUD_API_URL` and `MCP_USE_CLOUD_WEB_URL` override endpoints for the process and are never persisted.
 - `~/.mcp-use/client/servers.json` is owned by `client` and stores non-secret connection metadata keyed by explicit server name. There is no active/default client.
 - `~/.mcp-use/client/credentials/<sha256-of-server-name>.json` stores static headers or OAuth material used by `@mcp-use/client`. Removing a saved server removes its credential file; `client <name> auth logout` removes only the OAuth material while retaining non-OAuth connection metadata.
+- `~/.mcp-use/client-sdk/` is owned by `client` and `screenshot` when `@mcp-use/client` is auto-installed outside a project (for example `npx mcp-use client connect …` from a directory with no `package.json`). It holds a private `package.json` and `node_modules` for the client SDK only.
 - `.mcp-use/cloud/link.json` is owned by `deploy` and contains non-secret organization/server linkage for the current project. It is the only project-local cloud state.
 - Directories are created with mode `0700`, secret-bearing files with `0600`, and writes use temp-file-plus-rename. Commands never print API keys, bearer tokens, OAuth tokens, cookies, or secret environment values, including under `--json`.
 
@@ -156,6 +157,7 @@ mcp-use client <name> auth logout [--yes]
 
 - v2 alpha client commands support HTTP(S) MCP servers; stdio, interactive REPL, resource subscriptions, implicit active sessions, and forced OAuth refresh are omitted. Every operation names a saved server.
 - `connect` validates a unique filesystem-safe name, connects before saving, and attempts OAuth on an authorization challenge unless `--no-oauth`. Repeated headers are stored as credentials, not metadata. Reusing a name requires removing it first.
+- `client` and `screenshot` dynamic-import `@mcp-use/client`. When it is missing, the CLI installs it automatically: into the nearest project `package.json` when one exists, otherwise into `~/.mcp-use/client-sdk/`.
 - Tool/prompt arguments accept either one JSON object or `key=value` pairs; `key:=<json>` supplies typed JSON values. Mixing the full-object and pair forms is usage error `2`. Calls time out with exit `1`; tool `isError` results are operation failures and retain their protocol content in JSON error details.
 - Default human output renders borderless terminal lists and readable MCP content. `--json` emits the raw protocol result envelope for calls, reads, and prompts, and arrays for lists.
 

--- a/libraries/typescript/packages/server/src/commands/load-client.ts
+++ b/libraries/typescript/packages/server/src/commands/load-client.ts
@@ -1,10 +1,26 @@
-import { UsageError } from "./shared.js";
+import { spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { chmod, mkdir } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import {
+  CommandError,
+  GLOBAL_STATE_DIR,
+  pathExists,
+  UsageError,
+  writePrivateJson,
+} from "./shared.js";
 
 /** Runtime surface loaded from the independently published client SDK. */
 export type ClientPackage = typeof import("@mcp-use/client");
 
+const CLIENT_SDK_DIR = join(GLOBAL_STATE_DIR, "client-sdk");
+const CLIENT_PACKAGE = "@mcp-use/client";
+const DEFAULT_PEER_RANGE = "^2.0.0-alpha.0";
+
 const INSTALL_HINT = [
-  "[mcp-use] @mcp-use/client is not installed.",
+  `[mcp-use] ${CLIENT_PACKAGE} is not installed.`,
   "The `mcp-use client` and `mcp-use screenshot` commands require it.",
   "Install it in your project:",
   "",
@@ -16,21 +32,135 @@ const INSTALL_HINT = [
 ].join("\n");
 
 /**
+ * Walk upward from `startDir` for the nearest directory containing
+ * `package.json`.
+ */
+export async function findProjectRoot(
+  startDir: string
+): Promise<string | undefined> {
+  let current = resolve(startDir);
+  for (;;) {
+    if (await pathExists(join(current, "package.json"))) return current;
+    const parent = dirname(current);
+    if (parent === current) return undefined;
+    current = parent;
+  }
+}
+
+/**
  * Load `@mcp-use/client` on demand so the framework library entry does not
  * pull the client SDK (or legacy v1 transitive deps) into every install.
  *
- * @throws {@link UsageError} When the package is not installed, with install
- * instructions for npm, pnpm, and bun.
+ * @throws {@link UsageError} When the package is not installed and auto-install
+ * fails or the retry import still cannot resolve it.
  */
 export async function loadClientPackage(): Promise<ClientPackage> {
   try {
-    return await import("@mcp-use/client");
+    return await importClientModule();
   } catch (error) {
-    if (isClientPackageMissing(error)) {
-      throw new UsageError(INSTALL_HINT);
+    if (!isClientPackageMissing(error)) throw error;
+
+    const location = await installClientPackage();
+    try {
+      return location === "sandbox"
+        ? await importSandboxClientModule()
+        : await importClientModule();
+    } catch (retryError) {
+      if (isClientPackageMissing(retryError)) {
+        throw new UsageError(INSTALL_HINT);
+      }
+      throw retryError;
     }
-    throw error;
   }
+}
+
+async function installClientPackage(): Promise<"project" | "sandbox"> {
+  const versionSpec = readClientPeerRange();
+  const dependency = `${CLIENT_PACKAGE}@${versionSpec}`;
+  const projectRoot = await findProjectRoot(process.cwd());
+
+  process.stderr.write(`[mcp-use] installing ${CLIENT_PACKAGE}…\n`);
+
+  if (projectRoot !== undefined) {
+    const [command, args] = packageManagerInstallArgs(dependency);
+    const code = await spawnAndWait(command, args, projectRoot);
+    if (code !== 0) {
+      throw new CommandError(
+        "client_install_failed",
+        `Failed to install ${CLIENT_PACKAGE}.`
+      );
+    }
+    return "project";
+  }
+
+  await mkdir(CLIENT_SDK_DIR, { recursive: true, mode: 0o700 });
+  await chmod(CLIENT_SDK_DIR, 0o700);
+  const manifestPath = join(CLIENT_SDK_DIR, "package.json");
+  if (!(await pathExists(manifestPath))) {
+    await writePrivateJson(manifestPath, {
+      private: true,
+      dependencies: {
+        [CLIENT_PACKAGE]: versionSpec,
+      },
+    });
+  }
+  const code = await spawnAndWait(
+    "npm",
+    ["install", dependency],
+    CLIENT_SDK_DIR
+  );
+  if (code !== 0) {
+    throw new CommandError(
+      "client_install_failed",
+      `Failed to install ${CLIENT_PACKAGE}.`
+    );
+  }
+  return "sandbox";
+}
+
+function packageManagerInstallArgs(dependency: string): [string, string[]] {
+  const userAgent = process.env["npm_config_user_agent"] ?? "";
+  if (userAgent.startsWith("pnpm/")) {
+    return ["pnpm", ["add", dependency]];
+  }
+  if (userAgent.startsWith("bun/")) {
+    return ["bun", ["add", dependency]];
+  }
+  return ["npm", ["install", dependency]];
+}
+
+function readClientPeerRange(): string {
+  for (const relative of ["../package.json", "../../package.json"]) {
+    try {
+      const raw = readFileSync(new URL(relative, import.meta.url), "utf8");
+      const pkg = JSON.parse(raw) as {
+        name?: unknown;
+        peerDependencies?: Record<string, string>;
+      };
+      if (pkg.name !== "mcp-use") continue;
+      const range = pkg.peerDependencies?.[CLIENT_PACKAGE];
+      if (typeof range === "string" && range.length > 0) return range;
+    } catch {
+      // Try the next candidate layout.
+    }
+  }
+  return DEFAULT_PEER_RANGE;
+}
+
+async function importClientModule(): Promise<ClientPackage> {
+  return import("@mcp-use/client");
+}
+
+async function importSandboxClientModule(): Promise<ClientPackage> {
+  const entry = join(
+    CLIENT_SDK_DIR,
+    "node_modules",
+    CLIENT_PACKAGE,
+    "dist",
+    "index.js"
+  );
+  const mod = (await import(pathToFileURL(entry).href)) as ClientPackage;
+  return mod;
 }
 
 function isClientPackageMissing(error: unknown): boolean {
@@ -38,9 +168,27 @@ function isClientPackageMissing(error: unknown): boolean {
   const code = (error as NodeJS.ErrnoException).code;
   if (code === "ERR_MODULE_NOT_FOUND" || code === "MODULE_NOT_FOUND") {
     return (
-      error.message.includes("@mcp-use/client") ||
+      error.message.includes(CLIENT_PACKAGE) ||
       error.message.includes("Cannot find package")
     );
   }
   return false;
+}
+
+function spawnAndWait(
+  command: string,
+  args: string[],
+  cwd: string
+): Promise<number> {
+  return new Promise((resolveCode, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      stdio: "inherit",
+      shell: process.platform === "win32",
+    });
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      resolveCode(signal === "SIGINT" ? 130 : (code ?? 1));
+    });
+  });
 }


### PR DESCRIPTION
- Added dynamic import for `@mcp-use/client` in the CLI commands.
- Implemented automatic installation of the client SDK when missing, with support for project and sandbox environments.
- Introduced `findProjectRoot` function to locate the nearest `package.json`.
- Updated tests to cover new functionality for loading the client package and finding the project root.

# Pull Request Description

## Language / Project Scope

Check all that apply:
- [ ] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

Describe the changes introduced by this PR in a concise manner.

## Review Readiness

Help maintainers review this quickly:

- [ ] The PR is scoped to one issue or one clearly related change
- [ ] The PR description explains the user-visible problem and the fix
- [ ] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [ ] I verified the affected package/docs path with the commands listed below
- [ ] I checked for existing open PRs that already solve the same issue

## Implementation Details

1. List the specific implementation details
2. Include code organization, architectural decisions
3. Note any dependencies that were added or modified

---

## TypeScript Checklist

> Complete this section if your PR includes TypeScript changes

### Packages Modified

Check all packages that were modified:
- [ ] `docs`
- [ ] `tests`
- [ ] `cli`
- [ ] `create-mcp-use-app`
- [ ] `mcp-use` (server)
- [ ] `mcp-use` (client)
- [ ] `inspector`

### Pre-commit Checklist

Ensure all of the following have been completed:
- [ ] Ran `pnpm lint:fix` to auto-fix linting issues
- [ ] Ran `pnpm format` to format code with Prettier
- [ ] Ran `pnpm build` and build succeeds without errors
- [ ] Ran `pnpm changeset` to create a changeset (if this PR includes user-facing changes)
- [ ] Added or updated tests if needed
- [ ] Updated documentation in `docs/` folder if needed

---

## Python Checklist

> Complete this section if your PR includes Python changes

### Pre-commit Checklist

Ensure all of the following have been completed:
- [ ] Code formatted with `ruff format`
- [ ] Linting passes with `ruff check`
- [ ] Added or updated tests if needed
- [ ] Updated documentation if needed

---

## Example Usage (Before)

```
# Include example code showing how things worked before (if applicable)
# Use the appropriate language syntax (python, typescript, bash, etc.)
```

## Example Usage (After)

```
# Include example code showing how things work after your changes
# Use the appropriate language syntax (python, typescript, bash, etc.)
```

## Documentation Updates

* List any documentation files that were updated
* Explain what was changed in each file

## Testing

Describe how you tested these changes:
- Unit tests added/modified
- Integration tests added/modified
- Manual testing performed
- Edge cases considered

## Backwards Compatibility

Explain whether these changes are backwards compatible. If not, describe what users will need to do to adapt to these changes.

## Related Issues

Closes #[issue_number]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-installs and dynamically loads `@mcp-use/client` for CLI commands so `mcp-use client` and `mcp-use screenshot` work without a manual install, including when run via `npx`.

- New Features
  - Dynamic import of `@mcp-use/client`; installs on first use if missing.
  - Installs into the nearest project with a `package.json` (uses npm/pnpm/bun), otherwise into a sandbox at `~/.mcp-use/client-sdk/`.
  - Added `findProjectRoot` and version selection from `mcp-use` peerDependency (fallback `^2.0.0-alpha.0`).
  - Updated CLI spec and tests.

<sup>Written for commit 889930654a59483a3bd83cb58a325d872d198e9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

