### PR TITLE
fix(server): improve mcp-use client CLI UX after auto-install

### DIFF
--- a/libraries/typescript/.changeset/cli-client-ux-fixes.md
+++ b/libraries/typescript/.changeset/cli-client-ux-fixes.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Fix `mcp-use client` UX after auto-installing `@mcp-use/client`: the connect command now continues in the same run by importing the client SDK from the project install location instead of the npx cache. OAuth connect prompts before opening a browser in a TTY (`--open` / `--no-open` override). `mcp-use client --help` prints client-specific usage instead of the top-level command list.

--- a/libraries/typescript/packages/server/specs/CLI_SPEC.md
+++ b/libraries/typescript/packages/server/specs/CLI_SPEC.md
@@ -58,7 +58,7 @@ There are no `ls`, `rm`, `switch`, or `install` aliases in v2 alpha. The accepte
 
 ### Cross-command conventions
 
-- `--help` and `--version` write to stdout and exit `0`. Unknown commands/options, missing arguments, invalid enum/numeric values, mutually exclusive options, and a destructive command without confirmation in a non-TTY write one concise error plus a usage hint to stderr and exit `2`.
+- `--help` and `--version` write to stdout and exit `0`. Bare `mcp-use --help` prints the top-level command summary; `mcp-use <command> --help` prints that command's usage. Unknown commands/options, missing arguments, invalid enum/numeric values, mutually exclusive options, and a destructive command without confirmation in a non-TTY write one concise error plus a usage hint to stderr and exit `2`.
 - Successful finite commands exit `0`; empty lists and idempotent `logout`/`remove` operations are successful. Authentication, authorization, network, API, filesystem, build, MCP, browser, and remote-operation failures exit `1`. SIGINT exits `130`.
 - Human output is concise UTF-8 text on stdout. Errors and warnings go to stderr. ANSI styling is used only for a TTY and honors `NO_COLOR`; machine-readable output never contains ANSI.
 - Every finite data-returning command accepts `--json`. It emits exactly one JSON value followed by `\n`; errors emit `{"error":{"code":"...","message":"...","details":...}}` to stderr. Streaming `deployments logs --follow` emits JSON Lines when `--json` is set. Prompts are disabled under `--json` and whenever stdin is not a TTY.
@@ -141,7 +141,7 @@ mcp-use deploy [path] [--org <id-or-slug>] [--name <name>]
 ```text
 mcp-use client connect <name> <url> [-H, --header <"Key: Value">...]
   [--no-oauth] [--auth-timeout <ms>] [--protocol <auto|2026-07-28|2025-11-25>]
-  [--json]
+  [--open] [--no-open] [--json]
 mcp-use client list [--json]
 mcp-use client remove <name> [--yes]
 mcp-use client <name> tools list [--json]
@@ -156,8 +156,8 @@ mcp-use client <name> auth logout [--yes]
 ```
 
 - v2 alpha client commands support HTTP(S) MCP servers; stdio, interactive REPL, resource subscriptions, implicit active sessions, and forced OAuth refresh are omitted. Every operation names a saved server.
-- `connect` validates a unique filesystem-safe name, connects before saving, and attempts OAuth on an authorization challenge unless `--no-oauth`. Repeated headers are stored as credentials, not metadata. Reusing a name requires removing it first.
-- `client` and `screenshot` dynamic-import `@mcp-use/client`. When it is missing, the CLI installs it automatically: into the nearest project `package.json` when one exists, otherwise into `~/.mcp-use/client-sdk/`.
+- `connect` validates a unique filesystem-safe name, connects before saving, and attempts OAuth on an authorization challenge unless `--no-oauth`. On OAuth, the CLI prints the authorization URL; in a TTY it prompts before opening the browser unless `--open` or `--no-open` is set. `--open` auto-opens without prompting; `--no-open`, non-TTY, and `--json` print the URL only while the loopback callback still waits. Repeated headers are stored as credentials, not metadata. Reusing a name requires removing it first.
+- `client` and `screenshot` dynamic-import `@mcp-use/client`. When it is missing, the CLI installs it automatically: into the nearest project `package.json` when one exists, otherwise into `~/.mcp-use/client-sdk/`. Auto-install continues the current command in-process and imports from the install location.
 - Tool/prompt arguments accept either one JSON object or `key=value` pairs; `key:=<json>` supplies typed JSON values. Mixing the full-object and pair forms is usage error `2`. Calls time out with exit `1`; tool `isError` results are operation failures and retain their protocol content in JSON error details.
 - Default human output renders borderless terminal lists and readable MCP content. `--json` emits the raw protocol result envelope for calls, reads, and prompts, and arrays for lists.
 

--- a/libraries/typescript/packages/server/src/bin/main.ts
+++ b/libraries/typescript/packages/server/src/bin/main.ts
@@ -75,8 +75,11 @@ export async function main(argv: readonly string[]): Promise<number> {
     return 0;
   }
   if (argv.some((token) => token === "--help" || token === "-h")) {
-    console.log(HELP);
-    return 0;
+    const command = argv[0];
+    if (command === undefined || command === "--help" || command === "-h") {
+      console.log(HELP);
+      return 0;
+    }
   }
 
   const command = argv[0];

--- a/libraries/typescript/packages/server/src/commands/client.ts
+++ b/libraries/typescript/packages/server/src/commands/client.ts
@@ -36,8 +36,42 @@ interface SavedCredentials {
 const CLIENT_DIR = join(GLOBAL_STATE_DIR, "client");
 const SERVERS_PATH = join(CLIENT_DIR, "servers.json");
 
+const CLIENT_HELP = `Usage: mcp-use client <command> [options]
+
+Commands:
+  connect <name> <url>   Connect and save an HTTP(S) MCP server
+  list                   List saved servers
+  remove <name>          Remove a saved server
+  <name>                 Invoke tools/resources/prompts on a saved server
+
+Connect options:
+  -H, --header <"Key: Value">   Static header (repeatable)
+  --no-oauth                    Skip OAuth on authorization challenges
+  --auth-timeout <ms>           OAuth wait timeout (default: 300000)
+  --protocol <auto|2026-07-28|2025-11-25>
+  --open                        Open the OAuth URL in a browser without prompting
+  --no-open                     Print the OAuth URL only
+  --json                        Emit machine-readable output
+
+Saved server commands:
+  mcp-use client <name> tools list|describe|call ...
+  mcp-use client <name> resources list|read ...
+  mcp-use client <name> prompts list|get ...
+  mcp-use client <name> auth status|logout
+
+Examples:
+  mcp-use client connect linear https://mcp.linear.app/mcp
+  mcp-use client linear tools list
+  mcp-use client linear tools call search_issues query="open bugs"`;
+
+type BrowserMode = "ask" | "always" | "never";
+
 /** Run the `mcp-use client` command family. */
 export async function runClient(argv: readonly string[]): Promise<number> {
+  if (argv.includes("--help") || argv.includes("-h")) {
+    console.log(CLIENT_HELP);
+    return 0;
+  }
   const json = wantsJson(argv);
   try {
     const first = argv[0];
@@ -69,9 +103,14 @@ async function connect(
       "no-oauth": { type: "boolean" },
       "auth-timeout": { type: "string" },
       protocol: { type: "string", default: "auto" },
+      open: { type: "boolean" },
+      "no-open": { type: "boolean" },
       json: { type: "boolean" },
     },
   });
+  if (values.open === true && values["no-open"] === true) {
+    throw new UsageError("Cannot combine --open and --no-open.");
+  }
   if (positionals.length !== 2) {
     throw new UsageError("Usage: mcp-use client connect <name> <url>");
   }
@@ -100,7 +139,12 @@ async function connect(
     name,
     definition,
     credentials,
-    timeout
+    timeout,
+    resolveBrowserMode({
+      open: values.open === true,
+      noOpen: values["no-open"] === true,
+      json,
+    })
   );
   await connection.disconnect();
   saved.servers[name] = definition;
@@ -328,7 +372,8 @@ async function openConnection(
   name: string,
   definition: SavedServer,
   credentials: SavedCredentials,
-  authTimeoutMs: number
+  authTimeoutMs: number,
+  browserMode: BrowserMode = process.stdin.isTTY ? "ask" : "never"
 ): Promise<MCPConnection> {
   const { createOAuthProvider, MCPClient } = await loadClientPackage();
   const oauthBase = oauthDirectory(name);
@@ -337,8 +382,16 @@ async function openConnection(
         baseDir: oauthBase,
         authTimeoutMs,
         storageKeyPrefix: `mcp-use-cli:${name}`,
-        openBrowser: (url: string) => {
+        openBrowser: async (url: string) => {
           process.stderr.write(`Open this URL to authenticate:\n${url}\n`);
+          if (browserMode === "never") return;
+          if (browserMode === "ask") {
+            const accepted = await confirm("Open in browser?", {
+              yes: false,
+              json: false,
+            });
+            if (!accepted) return;
+          }
           openBrowser(url);
         },
         // Conditional exports select NodeOAuthOptions at runtime. TypeScript
@@ -432,6 +485,16 @@ export function parseMcpArguments(
     result[key] = typed >= 0 ? (JSON.parse(raw) as unknown) : raw;
   }
   return result;
+}
+
+function resolveBrowserMode(options: {
+  open: boolean;
+  noOpen: boolean;
+  json: boolean;
+}): BrowserMode {
+  if (options.json || options.noOpen || !process.stdin.isTTY) return "never";
+  if (options.open) return "always";
+  return "ask";
 }
 
 function parseHeaders(values: readonly string[]): Record<string, string> {

--- a/libraries/typescript/packages/server/src/commands/load-client.ts
+++ b/libraries/typescript/packages/server/src/commands/load-client.ts
@@ -47,6 +47,12 @@ export async function findProjectRoot(
   }
 }
 
+/** Where `@mcp-use/client` was auto-installed. */
+interface InstallLocation {
+  location: "project" | "sandbox";
+  projectRoot?: string;
+}
+
 /**
  * Load `@mcp-use/client` on demand so the framework library entry does not
  * pull the client SDK (or legacy v1 transitive deps) into every install.
@@ -60,11 +66,11 @@ export async function loadClientPackage(): Promise<ClientPackage> {
   } catch (error) {
     if (!isClientPackageMissing(error)) throw error;
 
-    const location = await installClientPackage();
+    const installed = await installClientPackage();
     try {
-      return location === "sandbox"
+      return installed.location === "sandbox"
         ? await importSandboxClientModule()
-        : await importClientModule();
+        : await importProjectClientModule(installed.projectRoot!);
     } catch (retryError) {
       if (isClientPackageMissing(retryError)) {
         throw new UsageError(INSTALL_HINT);
@@ -74,7 +80,7 @@ export async function loadClientPackage(): Promise<ClientPackage> {
   }
 }
 
-async function installClientPackage(): Promise<"project" | "sandbox"> {
+async function installClientPackage(): Promise<InstallLocation> {
   const versionSpec = readClientPeerRange();
   const dependency = `${CLIENT_PACKAGE}@${versionSpec}`;
   const projectRoot = await findProjectRoot(process.cwd());
@@ -90,7 +96,7 @@ async function installClientPackage(): Promise<"project" | "sandbox"> {
         `Failed to install ${CLIENT_PACKAGE}.`
       );
     }
-    return "project";
+    return { location: "project", projectRoot };
   }
 
   await mkdir(CLIENT_SDK_DIR, { recursive: true, mode: 0o700 });
@@ -115,7 +121,7 @@ async function installClientPackage(): Promise<"project" | "sandbox"> {
       `Failed to install ${CLIENT_PACKAGE}.`
     );
   }
-  return "sandbox";
+  return { location: "sandbox" };
 }
 
 function packageManagerInstallArgs(dependency: string): [string, string[]] {
@@ -149,6 +155,15 @@ function readClientPeerRange(): string {
 
 async function importClientModule(): Promise<ClientPackage> {
   return import("@mcp-use/client");
+}
+
+/** @internal Imported from project `node_modules` after auto-install. */
+export async function importProjectClientModule(
+  projectRoot: string
+): Promise<ClientPackage> {
+  const parent = pathToFileURL(join(projectRoot, "package.json")).href;
+  const resolved = await import.meta.resolve(CLIENT_PACKAGE, parent);
+  return import(resolved) as Promise<ClientPackage>;
 }
 
 async function importSandboxClientModule(): Promise<ClientPackage> {

--- a/libraries/typescript/packages/server/tests/bin-start.test.ts
+++ b/libraries/typescript/packages/server/tests/bin-start.test.ts
@@ -241,6 +241,14 @@ describe("main", () => {
     expect(logs.mock.calls.flat().join("\n")).toContain("Usage: mcp-use");
   });
 
+  it("prints client help for client --help", async () => {
+    const logs = vi.spyOn(console, "log").mockImplementation(() => {});
+    await expect(main(["client", "--help"])).resolves.toBe(0);
+    const output = logs.mock.calls.flat().join("\n");
+    expect(output).toContain("mcp-use client connect");
+    expect(output).not.toContain("mcp-use deploy");
+  });
+
   it("dispatches build through its dedicated command module", async () => {
     const errors = vi.spyOn(console, "error").mockImplementation(() => {});
     await expect(main(["build", "--entry", "nope.ts"])).resolves.toBe(1);

--- a/libraries/typescript/packages/server/tests/commands/load-client.test.ts
+++ b/libraries/typescript/packages/server/tests/commands/load-client.test.ts
@@ -1,10 +1,26 @@
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { describe, expect, it } from "vitest";
 
-import { loadClientPackage } from "../../src/commands/load-client.js";
+import {
+  importProjectClientModule,
+  loadClientPackage,
+} from "../../src/commands/load-client.js";
+
+const SERVER_PACKAGE_ROOT = join(
+  fileURLToPath(new URL("../..", import.meta.url))
+);
 
 describe("loadClientPackage", () => {
   it("loads @mcp-use/client when installed", async () => {
     const mod = await loadClientPackage();
+    expect(mod.MCPClient).toBeTypeOf("function");
+    expect(mod.createOAuthProvider).toBeTypeOf("function");
+  });
+
+  it("imports @mcp-use/client from a project root after auto-install", async () => {
+    const mod = await importProjectClientModule(SERVER_PACKAGE_ROOT);
     expect(mod.MCPClient).toBeTypeOf("function");
     expect(mod.createOAuthProvider).toBeTypeOf("function");
   });


### PR DESCRIPTION
## Summary
- Auto-install of `@mcp-use/client` now imports from the project install location so `client connect` completes in the same run (fixes npx one-shot failure)
- OAuth connect prompts before opening a browser in a TTY; `--open` / `--no-open` override
- `mcp-use client --help` prints client-specific usage instead of top-level help

## Test plan
- [x] `pnpm test:run` in `libraries/typescript/packages/server` (445 tests pass)
- [ ] `npx mcp-use@beta client connect …` from a project with no client installed completes in one run
- [ ] `npx mcp-use@beta client --help` shows connect/list/remove usage

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `mcp-use client` auto-install flow so `client connect` completes in one run, and improves OAuth and help behavior for a smoother CLI experience.

- **Bug Fixes**
  - After auto-install, import `@mcp-use/client` from the project install location so the current command continues; fixes npx one-shot connect failure.
  - OAuth: print the auth URL and, in a TTY, prompt before opening the browser; `--open`/`--no-open` override; `--json` and non‑TTY never auto-open.
  - Help: `mcp-use client --help` now shows client-specific usage; bare `mcp-use --help` still shows the top-level summary.

<sup>Written for commit 4810321ca576378af18b6f31d9314810865388dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

