### PR TITLE
fix(ci): retry beta npm verify after publish

### DIFF
--- a/.github/workflows/typescript-release.yml
+++ b/.github/workflows/typescript-release.yml
@@ -685,25 +685,51 @@ jobs:
         run: pnpm publish:beta
 
       - name: Verify npm versions and dist-tags
+        if: steps.publication.outputs.needed == 'true'
         working-directory: libraries/typescript
+        env:
+          VERIFY_ATTEMPTS: 12
+          VERIFY_DELAY_SECONDS: 10
         run: |
-          pnpm verify:beta-plan --output beta-release-after.json
-          node - <<'NODE'
-          const fs = require('fs')
+          set -euo pipefail
+          verify_release() {
+            pnpm verify:beta-plan --output beta-release-after.json
+            node - <<'NODE'
+          const fs = require('node:fs')
           const before = JSON.parse(fs.readFileSync('beta-release-plan.json', 'utf8'))
           const after = JSON.parse(fs.readFileSync('beta-release-after.json', 'utf8'))
           for (const release of after.releases) {
             const previous = before.releases.find((item) => item.name === release.name)
-            if (!release.published) throw new Error(`${release.name}@${release.version} is missing from npm`)
-            if (release.betaBefore !== release.version) throw new Error(`${release.name} beta tag is ${release.betaBefore}, expected ${release.version}`)
-            if (release.latestBefore !== previous.latestBefore) throw new Error(`${release.name} latest tag changed`)
+            if (!release.published) {
+              throw new Error(`${release.name}@${release.version} is missing from npm`)
+            }
+            if (release.betaBefore !== release.version) {
+              throw new Error(`${release.name} beta tag is ${release.betaBefore}, expected ${release.version}`)
+            }
+            if (release.latestBefore !== previous.latestBefore) {
+              throw new Error(`${release.name} latest tag changed`)
+            }
             if (JSON.stringify(release.nonBetaTagsBefore) !== JSON.stringify(previous.nonBetaTagsBefore)) {
               throw new Error(`${release.name} non-beta dist-tags changed: ${JSON.stringify({ before: previous.nonBetaTagsBefore, after: release.nonBetaTagsBefore })}`)
             }
           }
           NODE
+          }
+          for attempt in $(seq 1 "$VERIFY_ATTEMPTS"); do
+            if verify_release; then
+              echo "npm registry verified on attempt ${attempt}/${VERIFY_ATTEMPTS}"
+              exit 0
+            fi
+            if [ "$attempt" -eq "$VERIFY_ATTEMPTS" ]; then
+              echo "npm registry never caught up after ${VERIFY_ATTEMPTS} attempts"
+              exit 1
+            fi
+            echo "npm registry not ready (attempt ${attempt}/${VERIFY_ATTEMPTS}), retrying in ${VERIFY_DELAY_SECONDS}s..."
+            sleep "$VERIFY_DELAY_SECONDS"
+          done
 
       - name: Create and push package tags
+        if: steps.publication.outputs.needed == 'true'
         working-directory: libraries/typescript
         run: |
           pnpm changeset tag


### PR DESCRIPTION
## Summary

- Retry post-publish npm verification up to 12 times (10s apart) to tolerate registry replication lag
- Skip verify and tag steps when no packages were published in the run

## Context

The beta release on #1927 published successfully but failed verify because `@mcp-use/inspector@20.0.0-beta.3` was not yet visible on the registry when the check ran immediately after publish.

## Test plan

- [ ] Next beta release with pending changesets completes with green `Verify npm versions and dist-tags`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a retry loop to post-publish npm verification in the beta workflow and skips verify/tag steps when no packages were published. This reduces false failures caused by npm registry replication lag.

- **Bug Fixes**
  - Retry verification up to 12 times with 10s delay using `VERIFY_ATTEMPTS` and `VERIFY_DELAY_SECONDS`.
  - Gate verify and tag steps with `steps.publication.outputs.needed == 'true'` to avoid no-op runs.

<sup>Written for commit 856d90626e4ffe3383b22de3e0a80849a8081e77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

