### PR TITLE
Stream Inspector tool call input in real time

### DIFF
--- a/libraries/typescript/.changeset/stream-inspector-tool-input.md
+++ b/libraries/typescript/.changeset/stream-inspector-tool-input.md
@@ -1,0 +1,7 @@
+---
+"@mcp-use/inspector": patch
+"@mcp-use/client": patch
+"@mcp-use/agent": patch
+---
+
+Stream partial tool-call arguments into the Inspector drawer and MCP App view while the model is generating them. Anthropic tool requests now opt into eager input streaming, partial JSON healing handles code and SVG strings correctly, hosted chat accepts tool-call start/delta frames, and the view host no longer overwrites newer partial input with a stale complete-input notification.

--- a/libraries/typescript/packages/agent/src/llm/__tests__/anthropic-tool-streaming.test.ts
+++ b/libraries/typescript/packages/agent/src/llm/__tests__/anthropic-tool-streaming.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { streamChat } from "../providers/anthropic.js";
+
+describe("Anthropic tool streaming", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("requests eager input streaming for every streamed tool", async () => {
+    const sse = [
+      {
+        type: "content_block_start",
+        index: 0,
+        content_block: {
+          type: "tool_use",
+          id: "tool_1",
+          name: "create_view",
+          input: {},
+        },
+      },
+      {
+        type: "content_block_delta",
+        index: 0,
+        delta: {
+          type: "input_json_delta",
+          partial_json: '{"elements":"<svg>',
+        },
+      },
+      {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "input_json_delta", partial_json: '</svg>"}' },
+      },
+      { type: "content_block_stop", index: 0 },
+      { type: "message_stop" },
+    ]
+      .map((event) => `data: ${JSON.stringify(event)}\n\n`)
+      .join("");
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(sse, {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const events = [];
+    for await (const event of streamChat({
+      config: {
+        provider: "anthropic",
+        model: "claude-test",
+        apiKey: "test-key",
+      },
+      messages: [{ role: "user", content: "draw something" }],
+      tools: [
+        {
+          name: "create_view",
+          description: "Render a view",
+          inputSchema: {
+            type: "object",
+            properties: { elements: { type: "string" } },
+          },
+        },
+      ],
+    })) {
+      events.push(event);
+    }
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(String(init.body));
+
+    expect(body.stream).toBe(true);
+    expect(body.tools).toEqual([
+      expect.objectContaining({
+        name: "create_view",
+        eager_input_streaming: true,
+      }),
+    ]);
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: "tool-call-start",
+        toolCallId: "tool_1",
+      }),
+      expect.objectContaining({
+        type: "tool-call-args-delta",
+        argsDelta: '{"elements":"<svg>',
+      }),
+      expect.objectContaining({
+        type: "tool-call-args-delta",
+        argsDelta: '</svg>"}',
+      }),
+      expect.objectContaining({
+        type: "tool-call-ready",
+        args: { elements: "<svg></svg>" },
+      }),
+      { type: "done" },
+    ]);
+  });
+});

--- a/libraries/typescript/packages/agent/src/llm/providers/anthropic.ts
+++ b/libraries/typescript/packages/agent/src/llm/providers/anthropic.ts
@@ -147,6 +147,12 @@ function buildBody(params: ChatParams, stream: boolean) {
       name: t.name,
       description: t.description,
       input_schema: t.inputSchema,
+      // Anthropic buffers each parameter value by default. That makes a tool
+      // with one large string argument (code, SVG, a document, etc.) appear to
+      // have no input until the whole value has finished generating. Request
+      // eager input only for streaming calls so input_json_delta events arrive
+      // while the model is still writing the value.
+      ...(stream ? { eager_input_streaming: true } : {}),
     }));
   }
   return body;

--- a/libraries/typescript/packages/client/src/react/view/ViewRenderer.tsx
+++ b/libraries/typescript/packages/client/src/react/view/ViewRenderer.tsx
@@ -148,6 +148,8 @@ function ViewRendererBase({
   onMessageRef.current = onMessage;
   const toolInputRef = useRef(toolInput);
   toolInputRef.current = toolInput;
+  const partialToolInputRef = useRef(partialToolInput);
+  partialToolInputRef.current = partialToolInput;
   const toolOutputRef = useRef(toolOutput);
   toolOutputRef.current = toolOutput;
   const customPropsRef = useRef(customProps);
@@ -499,11 +501,18 @@ function ViewRendererBase({
         setInitCount((c) => c + 1);
         onLifecycleChangeRef.current?.({ status: "initialized" });
 
-        const mergedArgs = {
-          ...toolInputRef.current,
-          ...parseCustomProps(customPropsRef.current),
-        };
-        bridge.sendToolInput({ arguments: mergedArgs });
+        const currentPartialToolInput = partialToolInputRef.current;
+        if (currentPartialToolInput) {
+          bridge.sendToolInputPartial({
+            arguments: currentPartialToolInput,
+          });
+        } else {
+          const mergedArgs = {
+            ...toolInputRef.current,
+            ...parseCustomProps(customPropsRef.current),
+          };
+          bridge.sendToolInput({ arguments: mergedArgs });
+        }
         const toolResultPayload = buildToolResultPayload(
           toolOutputRef.current,
           customPropsRef.current
@@ -575,13 +584,13 @@ function ViewRendererBase({
   // Tool input + custom props
   useEffect(() => {
     const bridge = bridgeRef.current;
-    if (!bridge || initCount === 0) return;
+    if (!bridge || initCount === 0 || partialToolInput) return;
     const mergedArgs = {
       ...toolInput,
       ...parseCustomProps(customProps),
     };
     bridge.sendToolInput({ arguments: mergedArgs });
-  }, [initCount, toolInput, customProps]);
+  }, [initCount, toolInput, partialToolInput, customProps]);
 
   // Tool output
   useEffect(() => {

--- a/libraries/typescript/packages/inspector/src/client/components/chat/MessageList.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/MessageList.tsx
@@ -19,6 +19,7 @@ interface Message {
     type: "text" | "tool-invocation";
     text?: string;
     toolInvocation?: {
+      toolCallId?: string;
       toolName: string;
       args: Record<string, unknown>;
       result?: any;
@@ -215,7 +216,7 @@ export const MessageList = memo(
                     const partKey =
                       part.type === "text"
                         ? `${message.id}-text-${partIndex}`
-                        : `${message.id}-tool-${part.toolInvocation?.toolName}-${partIndex}`;
+                        : `${message.id}-tool-${part.toolInvocation?.toolCallId ?? `${part.toolInvocation?.toolName}-${partIndex}`}`;
 
                     if (part.type === "text") {
                       return (

--- a/libraries/typescript/packages/inspector/src/client/components/chat/ToolResultRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/ToolResultRenderer.tsx
@@ -68,7 +68,6 @@ export function ToolResultRenderer({
     ? ((toolMeta?.ui?.resourceUri as string | undefined) ?? null)
     : null;
 
-  const memoizedToolArgs = useMemo(() => toolArgs, [toolName, parsedResult]);
   const memoizedResult = useMemo(() => parsedResult, [toolName, parsedResult]);
 
   const hostProps = useViewHostProps({
@@ -76,7 +75,7 @@ export function ToolResultRenderer({
     viewId: toolCallId,
     resourceUri: resourceUri ?? "",
     toolName,
-    toolInput: memoizedToolArgs,
+    toolInput: toolArgs,
     toolOutput: memoizedResult,
     toolMetadata: toolMeta,
     readResource: readResource ?? (async () => ({})),
@@ -88,7 +87,7 @@ export function ToolResultRenderer({
         <ViewRenderer
           viewId={toolCallId}
           toolName={toolName}
-          toolInput={memoizedToolArgs}
+          toolInput={toolArgs}
           toolOutput={memoizedResult}
           partialToolInput={partialToolArgs}
           cancelled={cancelled}

--- a/libraries/typescript/packages/inspector/src/client/components/chat/__tests__/partialToolArgs.test.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/__tests__/partialToolArgs.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { parsePartialToolArgs } from "../partialToolArgs";
+
+describe("parsePartialToolArgs", () => {
+  it("returns complete argument objects unchanged", () => {
+    expect(parsePartialToolArgs('{"query":"weather"}')).toEqual({
+      query: "weather",
+    });
+  });
+
+  it("heals a truncated string value", () => {
+    expect(parsePartialToolArgs('{"query":"wea')).toEqual({ query: "wea" });
+  });
+
+  it("ignores braces and brackets inside streamed code or SVG strings", () => {
+    expect(
+      parsePartialToolArgs(
+        '{"view":"<svg><style>.node { fill: blue; }</style><text>[draft]'
+      )
+    ).toEqual({
+      view: "<svg><style>.node { fill: blue; }</style><text>[draft]",
+    });
+  });
+
+  it("preserves escaped quotes in a partial string", () => {
+    expect(parsePartialToolArgs('{"view":"<text id=\\"label\\">hel')).toEqual({
+      view: '<text id="label">hel',
+    });
+  });
+
+  it("omits a dangling escape only from the healed snapshot", () => {
+    expect(parsePartialToolArgs('{"code":"line\\nnext\\')).toEqual({
+      code: "line\nnext",
+    });
+  });
+
+  it("waits when an object key is not parseable yet", () => {
+    expect(parsePartialToolArgs('{"que')).toBeUndefined();
+  });
+});

--- a/libraries/typescript/packages/inspector/src/client/components/chat/partialToolArgs.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/partialToolArgs.ts
@@ -1,0 +1,66 @@
+/**
+ * Parse an in-progress JSON object emitted by an LLM tool call.
+ *
+ * Tool arguments frequently contain code, SVG, or JSON-as-a-string. Counting
+ * braces with a regular expression breaks for those inputs because braces
+ * inside a JSON string are data, not structure. This scanner only heals
+ * delimiters outside strings and closes a trailing string when possible.
+ */
+export function parsePartialToolArgs(
+  raw: string
+): Record<string, unknown> | undefined {
+  if (!raw) return undefined;
+
+  const complete = parseObject(raw);
+  if (complete) return complete;
+
+  const stack: Array<"}" | "]"> = [];
+  let inString = false;
+  let escaping = false;
+
+  for (const char of raw) {
+    if (inString) {
+      if (escaping) {
+        escaping = false;
+      } else if (char === "\\") {
+        escaping = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+    } else if (char === "{") {
+      stack.push("}");
+    } else if (char === "[") {
+      stack.push("]");
+    } else if (char === "}" || char === "]") {
+      if (stack[stack.length - 1] === char) stack.pop();
+    }
+  }
+
+  let healed = raw;
+  // A fragment may stop between the backslash and the escaped character. The
+  // backslash remains in the real buffer; omit it only from this renderable
+  // snapshot so JSON.parse can close the current string.
+  if (inString && escaping) healed = healed.slice(0, -1);
+  if (inString) healed += '"';
+  healed += [...stack].reverse().join("");
+
+  return parseObject(healed);
+}
+
+function parseObject(value: string): Record<string, unknown> | undefined {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return parsed !== null &&
+      !Array.isArray(parsed) &&
+      typeof parsed === "object"
+      ? (parsed as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/libraries/typescript/packages/inspector/src/client/components/chat/types.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/types.ts
@@ -18,6 +18,7 @@ export interface Message {
     type: "text" | "tool-invocation";
     text?: string;
     toolInvocation?: {
+      toolCallId?: string;
       toolName: string;
       args: Record<string, unknown>;
       result?: any;

--- a/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessages.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessages.ts
@@ -26,6 +26,7 @@ import {
   managedNoticeFromHttpResponse,
   type ManagedChatNotice,
 } from "./managedChatNotice";
+import { parsePartialToolArgs } from "./partialToolArgs";
 
 interface WidgetModelContext {
   content?: Array<{ type: string; text: string }>;
@@ -314,10 +315,12 @@ export function useChatMessages({
           type: "text" | "tool-invocation";
           text?: string;
           toolInvocation?: {
+            toolCallId: string;
             toolName: string;
             args: Record<string, unknown>;
             result?: any;
-            state?: "pending" | "result" | "error";
+            state?: "pending" | "streaming" | "result" | "error";
+            partialArgs?: Record<string, unknown>;
           };
         }> = [];
 
@@ -370,15 +373,68 @@ export function useChatMessages({
           }
           updateParts();
         };
+        // Streaming protocol state shared by data-stream and Inspector SSE.
+        const toolCallIdToIndex = new Map<string, number>();
+        const toolCallArgBuffers = new Map<string, string>();
+
+        const appendToolCallStart = (toolCallId: string, toolName: string) => {
+          if (currentTextPart) currentTextPart = "";
+          if (toolCallIdToIndex.has(toolCallId)) return;
+          parts.push({
+            type: "tool-invocation",
+            toolInvocation: {
+              toolCallId,
+              toolName,
+              args: {},
+              state: "streaming",
+              partialArgs: {},
+            },
+          });
+          toolCallIdToIndex.set(toolCallId, parts.length - 1);
+          toolCallArgBuffers.set(toolCallId, "");
+          updateParts();
+        };
+        const appendToolCallDelta = (toolCallId: string, argsDelta: string) => {
+          const idx = toolCallIdToIndex.get(toolCallId);
+          if (idx === undefined || !argsDelta) return;
+          const accumulated =
+            (toolCallArgBuffers.get(toolCallId) ?? "") + argsDelta;
+          toolCallArgBuffers.set(toolCallId, accumulated);
+          const partialArgs = parsePartialToolArgs(accumulated);
+          const invocation = parts[idx]?.toolInvocation;
+          if (!partialArgs || !invocation) return;
+          invocation.partialArgs = partialArgs;
+          updateParts();
+        };
         const appendToolCall = (
+          toolCallId: string,
           toolName: string,
           args: Record<string, unknown>
         ) => {
           if (currentTextPart) currentTextPart = "";
-          parts.push({
-            type: "tool-invocation",
-            toolInvocation: { toolName, args, state: "pending" },
-          });
+          const existingIndex = toolCallIdToIndex.get(toolCallId);
+          const existingInvocation =
+            existingIndex === undefined
+              ? undefined
+              : parts[existingIndex]?.toolInvocation;
+          if (existingInvocation) {
+            existingInvocation.toolName = toolName;
+            existingInvocation.args = args;
+            existingInvocation.state = "pending";
+            existingInvocation.partialArgs = undefined;
+          } else {
+            parts.push({
+              type: "tool-invocation",
+              toolInvocation: {
+                toolCallId,
+                toolName,
+                args,
+                state: "pending",
+              },
+            });
+            toolCallIdToIndex.set(toolCallId, parts.length - 1);
+          }
+          toolCallArgBuffers.delete(toolCallId);
           updateParts();
         };
         const resolveToolResult = (
@@ -406,9 +462,6 @@ export function useChatMessages({
             updateParts();
           }
         };
-
-        // data-stream protocol state: maps toolCallId → parts array index
-        const toolCallIdToIndex = new Map<string, number>();
 
         let buffer = "";
         while (true) {
@@ -448,6 +501,30 @@ export function useChatMessages({
                     appendText(delta);
                     break;
                   }
+                  case "b": {
+                    const tc = val as Record<string, unknown>;
+                    const toolCallId = String(
+                      tc.toolCallId ?? `tool-${parts.length}`
+                    );
+                    const toolName = String(tc.toolName ?? "");
+                    recordTrace({
+                      type: "tool-call-start",
+                      toolCallId,
+                      toolName,
+                      raw: val,
+                    });
+                    appendToolCallStart(toolCallId, toolName);
+                    break;
+                  }
+                  case "c": {
+                    const tc = val as Record<string, unknown>;
+                    const toolCallId = String(tc.toolCallId ?? "");
+                    const argsDelta = String(
+                      tc.argsTextDelta ?? tc.argsDelta ?? ""
+                    );
+                    appendToolCallDelta(toolCallId, argsDelta);
+                    break;
+                  }
                   case "9": {
                     const tc = val as Record<string, unknown>;
                     // Unwrap LangChain-style { input: "<json>" } args
@@ -468,12 +545,14 @@ export function useChatMessages({
                       tc.toolCallId ?? `tool-${parts.length}`
                     );
                     const toolName = String(tc.toolName ?? "");
-                    recordTrace({
-                      type: "tool-call-start",
-                      toolCallId,
-                      toolName,
-                      raw: val,
-                    });
+                    if (!toolCallIdToIndex.has(toolCallId)) {
+                      recordTrace({
+                        type: "tool-call-start",
+                        toolCallId,
+                        toolName,
+                        raw: val,
+                      });
+                    }
                     recordTrace({
                       type: "tool-call-args",
                       toolCallId,
@@ -481,13 +560,7 @@ export function useChatMessages({
                       args,
                       raw: val,
                     });
-                    appendToolCall(toolName, args);
-                    if (tc.toolCallId) {
-                      toolCallIdToIndex.set(
-                        tc.toolCallId as string,
-                        parts.length - 1
-                      );
-                    }
+                    appendToolCall(toolCallId, toolName, args);
                     break;
                   }
                   case "a": {
@@ -572,7 +645,7 @@ export function useChatMessages({
                     raw: event,
                   });
                   appendText(event.content);
-                } else if (event.type === "tool-call") {
+                } else if (event.type === "tool-call-start") {
                   const toolCallId = event.toolCallId ?? `tool-${parts.length}`;
                   recordTrace({
                     type: "tool-call-start",
@@ -580,6 +653,25 @@ export function useChatMessages({
                     toolName: event.toolName,
                     raw: event,
                   });
+                  appendToolCallStart(toolCallId, event.toolName);
+                } else if (
+                  event.type === "tool-call-delta" ||
+                  event.type === "tool-call-args-delta"
+                ) {
+                  appendToolCallDelta(
+                    event.toolCallId,
+                    event.argsDelta ?? event.argsTextDelta ?? ""
+                  );
+                } else if (event.type === "tool-call") {
+                  const toolCallId = event.toolCallId ?? `tool-${parts.length}`;
+                  if (!toolCallIdToIndex.has(toolCallId)) {
+                    recordTrace({
+                      type: "tool-call-start",
+                      toolCallId,
+                      toolName: event.toolName,
+                      raw: event,
+                    });
+                  }
                   recordTrace({
                     type: "tool-call-args",
                     toolCallId,
@@ -587,7 +679,7 @@ export function useChatMessages({
                     args: event.args,
                     raw: event,
                   });
-                  appendToolCall(event.toolName, event.args);
+                  appendToolCall(toolCallId, event.toolName, event.args);
                 } else if (event.type === "tool-result") {
                   recordTrace({
                     type: "tool-result",
@@ -597,8 +689,11 @@ export function useChatMessages({
                     isError: event.isError ?? event.result?.isError,
                     raw: event,
                   });
+                  const resultIndex = toolCallIdToIndex.get(event.toolCallId);
                   resolveToolResult(
-                    { by: "toolName", toolName: event.toolName },
+                    resultIndex === undefined
+                      ? { by: "toolName", toolName: event.toolName }
+                      : { by: "index", index: resultIndex },
                     event.result
                   );
                 } else if (event.type === "done") {
@@ -646,7 +741,8 @@ export function useChatMessages({
           for (const part of parts) {
             if (
               part.type === "tool-invocation" &&
-              part.toolInvocation?.state === "pending"
+              (part.toolInvocation?.state === "pending" ||
+                part.toolInvocation?.state === "streaming")
             ) {
               part.toolInvocation.state = "error";
               part.toolInvocation.result = "Cancelled by user";

--- a/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessagesClientSide.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessagesClientSide.ts
@@ -21,6 +21,7 @@ import {
   managedNoticeFromLlmError,
   type ManagedChatNotice,
 } from "./managedChatNotice";
+import { parsePartialToolArgs } from "./partialToolArgs";
 
 // Type alias for backward compatibility
 type MCPConnection = McpServer;
@@ -121,6 +122,7 @@ export function useChatMessagesClientSide({
           type: "text" | "tool-invocation";
           text?: string;
           toolInvocation?: {
+            toolCallId: string;
             toolName: string;
             args: Record<string, unknown>;
             result?: any;
@@ -132,7 +134,7 @@ export function useChatMessagesClientSide({
         // Per-tool-call accumulated JSON for partial-args rendering.
         const toolCallArgBuffers = new Map<
           string,
-          { name: string; accumulatedJson: string }
+          { accumulatedJson: string }
         >();
 
         // Throttled yield: allows React to flush re-renders during streaming.
@@ -210,54 +212,6 @@ export function useChatMessagesClientSide({
           autoInitialize: true,
         });
 
-        // Helper: best-effort parse of accumulated tool-args JSON so the UI
-        // can render the tool input progressively before the call completes.
-        const tryParseArgs = (
-          raw: string
-        ): Record<string, unknown> | undefined => {
-          try {
-            return JSON.parse(raw);
-          } catch {
-            // Try to close unclosed strings/brackets/braces.
-            const strategies: Array<() => unknown> = [
-              () => {
-                let r = raw;
-                const quotes = (r.match(/(?<!\\)"/g) || []).length;
-                if (quotes % 2 !== 0) r += '"';
-                const ob =
-                  (r.match(/{/g) || []).length - (r.match(/}/g) || []).length;
-                const oq =
-                  (r.match(/\[/g) || []).length - (r.match(/]/g) || []).length;
-                for (let i = 0; i < oq; i++) r += "]";
-                for (let i = 0; i < ob; i++) r += "}";
-                return JSON.parse(r);
-              },
-              () => {
-                let r = raw;
-                r = r.replace(/,\s*"[^"]*"?\s*:\s*("([^"\\]|\\.)*)?$/, "");
-                r = r.replace(/,\s*"[^"]*$/, "");
-                const quotes = (r.match(/(?<!\\)"/g) || []).length;
-                if (quotes % 2 !== 0) r += '"';
-                const ob =
-                  (r.match(/{/g) || []).length - (r.match(/}/g) || []).length;
-                const oq =
-                  (r.match(/\[/g) || []).length - (r.match(/]/g) || []).length;
-                for (let i = 0; i < oq; i++) r += "]";
-                for (let i = 0; i < ob; i++) r += "}";
-                return JSON.parse(r);
-              },
-            ];
-            for (const strat of strategies) {
-              try {
-                return strat() as Record<string, unknown>;
-              } catch {
-                // next
-              }
-            }
-            return undefined;
-          }
-        };
-
         const commitMessageParts = () => {
           setMessages((prev) =>
             prev.map((msg) =>
@@ -308,12 +262,12 @@ export function useChatMessagesClientSide({
             });
             if (currentTextPart) currentTextPart = "";
             toolCallArgBuffers.set(ev.toolCallId, {
-              name: ev.toolName,
               accumulatedJson: "",
             });
             parts.push({
               type: "tool-invocation",
               toolInvocation: {
+                toolCallId: ev.toolCallId,
                 toolName: ev.toolName,
                 args: {},
                 state: "streaming",
@@ -325,32 +279,16 @@ export function useChatMessagesClientSide({
             const buf = toolCallArgBuffers.get(ev.toolCallId);
             if (buf) {
               buf.accumulatedJson += ev.argsDelta;
-              const partial = tryParseArgs(buf.accumulatedJson);
+              const partial = parsePartialToolArgs(buf.accumulatedJson);
               if (partial) {
                 const toolPart = parts.find(
                   (p) =>
                     p.type === "tool-invocation" &&
                     p.toolInvocation?.state === "streaming" &&
-                    p.toolInvocation?.toolName === buf.name
+                    p.toolInvocation?.toolCallId === ev.toolCallId
                 );
                 if (toolPart && toolPart.toolInvocation) {
-                  const prev = toolPart.toolInvocation.partialArgs;
-                  const prevKeys = prev ? Object.keys(prev) : [];
-                  const newKeys = Object.keys(partial);
-                  const prevTotal = prevKeys.reduce(
-                    (s, k) => s + String(prev![k] ?? "").length,
-                    0
-                  );
-                  const newTotal = newKeys.reduce(
-                    (s, k) => s + String(partial[k] ?? "").length,
-                    0
-                  );
-                  if (
-                    newKeys.length > prevKeys.length ||
-                    newTotal >= prevTotal
-                  ) {
-                    toolPart.toolInvocation.partialArgs = partial;
-                  }
+                  toolPart.toolInvocation.partialArgs = partial;
                   commitMessageParts();
                   await maybeYield();
                 }
@@ -370,15 +308,17 @@ export function useChatMessagesClientSide({
               (p) =>
                 p.type === "tool-invocation" &&
                 p.toolInvocation?.state === "streaming" &&
-                p.toolInvocation?.toolName === ev.toolName
+                p.toolInvocation?.toolCallId === ev.toolCallId
             );
             if (streamingPart && streamingPart.toolInvocation) {
               streamingPart.toolInvocation.args = ev.args;
               streamingPart.toolInvocation.state = "pending";
+              streamingPart.toolInvocation.partialArgs = undefined;
             } else {
               parts.push({
                 type: "tool-invocation",
                 toolInvocation: {
+                  toolCallId: ev.toolCallId,
                   toolName: ev.toolName,
                   args: ev.args,
                   state: "pending",
@@ -398,7 +338,7 @@ export function useChatMessagesClientSide({
             const toolPart = parts.find(
               (p) =>
                 p.type === "tool-invocation" &&
-                p.toolInvocation?.toolName === ev.toolName &&
+                p.toolInvocation?.toolCallId === ev.toolCallId &&
                 !p.toolInvocation?.result
             );
             if (toolPart && toolPart.toolInvocation) {
@@ -419,7 +359,8 @@ export function useChatMessagesClientSide({
           for (const part of parts) {
             if (
               part.type === "tool-invocation" &&
-              part.toolInvocation?.state === "pending"
+              (part.toolInvocation?.state === "pending" ||
+                part.toolInvocation?.state === "streaming")
             ) {
               part.toolInvocation.state = "error";
               part.toolInvocation.result = "Cancelled by user";


### PR DESCRIPTION
## Summary

- stream partial tool-call arguments into the Inspector details drawer while the model is generating them
- forward partial input into MCP App views so they can render before the tool call completes
- opt Anthropic streaming requests into eager tool input delivery
- support tool start/delta frames in both client-side and hosted chat paths
- track concurrent calls by stable tool-call ID and heal partial JSON safely when arguments contain code, SVG, or JSON strings

## Root cause

Anthropic buffers each parameter value by default. A call such as `create_view`, whose payload is one large string, therefore emitted a tool start but no useful input deltas until the value was complete. The Inspector also needed end-to-end partial-argument state for the hosted stream path, and its previous best-effort parser counted braces inside string values.

## Impact

The tool input now fills in live while the call is marked streaming, and MCP App views receive those partial inputs immediately so they can render progressively.

## Validation

- live Helium test with `draw a cow`: tool arguments and Excalidraw view streamed progressively
- agent unit suite: 125 passed, 4 skipped
- Inspector partial-argument tests: 6 passed
- client unit suite: 211 passed
- agent, client, and full Inspector production builds passed
- ESLint, Prettier, staged diff checks, and repository pre-commit hooks passed


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stream partial tool-call arguments into the Inspector drawer and MCP App views in real time so the UI can render while the model writes. Anthropic streaming now opts into eager input, and both client-side and hosted chat paths handle tool start/delta frames.

- **New Features**
  - End-to-end support for `tool-call-start`, `tool-call-args-delta`, and `tool-call-ready` events.
  - Partial JSON healing for code/SVG/JSON-in-string args via `parsePartialToolArgs`.
  - Track concurrent calls by stable `toolCallId` and use it for rendering keys.
  - View host sends `partialToolInput` immediately and streams updates progressively.

- **Bug Fixes**
  - Prevent stale complete-input notifications from overwriting newer partial input in `ViewRenderer`.
  - Correctly parse deltas when braces appear inside strings; reduces flicker.
  - Route tool results to the right invocation using `toolCallId`, even with repeated tool names.

<sup>Written for commit a20f4b7b3ba3e1ead4c748a55e13d64346934cd1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

