### PR TITLE
fix(server): omit schema dialect from tool descriptors

### DIFF
--- a/libraries/typescript/packages/server/src/server.ts
+++ b/libraries/typescript/packages/server/src/server.ts
@@ -179,6 +179,33 @@ interface NodeHttpListener {
   address(): { port: number } | string | null;
 }
 
+function omitRootSchemaDialect<T>(schema: T): T {
+  if (
+    typeof schema !== "object" ||
+    schema === null ||
+    Array.isArray(schema) ||
+    !("$schema" in schema)
+  ) {
+    return schema;
+  }
+
+  const emittedSchema = { ...schema } as T & Record<string, unknown>;
+  delete emittedSchema["$schema"];
+  return emittedSchema;
+}
+
+function omitToolSchemaDialects(
+  tools: McpMiddlewareResult<"tools/list">
+): McpMiddlewareResult<"tools/list"> {
+  return tools.map((tool) => ({
+    ...tool,
+    inputSchema: omitRootSchemaDialect(tool.inputSchema),
+    ...(tool.outputSchema === undefined
+      ? {}
+      : { outputSchema: omitRootSchemaDialect(tool.outputSchema) }),
+  }));
+}
+
 /**
  * MCP server with declarative tool/resource/prompt registration, served
  * statelessly over a composed fetch handler.
@@ -1359,11 +1386,19 @@ export class MCPServer<TUser = never> {
       return;
     }
 
-    const wrapListMethod = <
-      M extends "tools/list" | "resources/list" | "prompts/list",
-    >(
+    type ListMethod = "tools/list" | "resources/list" | "prompts/list";
+    type ListResultKey<M extends ListMethod> = M extends "tools/list"
+      ? "tools"
+      : M extends "resources/list"
+        ? "resources"
+        : "prompts";
+
+    const wrapListMethod = <M extends ListMethod>(
       method: M,
-      resultKey: "tools" | "resources" | "prompts"
+      resultKey: ListResultKey<NoInfer<M>>,
+      transform?: (
+        items: McpMiddlewareResult<NoInfer<M>>
+      ) => McpMiddlewareResult<NoInfer<M>>
     ) => {
       const original = handlers.get(method);
       if (original === undefined) {
@@ -1406,16 +1441,17 @@ export class MCPServer<TUser = never> {
             `[mcp-use] ${method} middleware must return a ${resultKey} array`
           );
         }
+        const emitted = transform?.(filtered) ?? filtered;
         return {
           ...originalEnvelope,
-          [resultKey]: filtered,
+          [resultKey]: emitted,
         };
       };
       (wrapped as { __mcpListWrapped?: boolean }).__mcpListWrapped = true;
       handlers.set(method, wrapped);
     };
 
-    wrapListMethod("tools/list", "tools");
+    wrapListMethod("tools/list", "tools", omitToolSchemaDialects);
     wrapListMethod("resources/list", "resources");
     wrapListMethod("prompts/list", "prompts");
   }

--- a/libraries/typescript/packages/server/tests/middleware.e2e.test.ts
+++ b/libraries/typescript/packages/server/tests/middleware.e2e.test.ts
@@ -251,6 +251,60 @@ describe("MCP middleware — result validation", () => {
   });
 });
 
+describe("MCP middleware — tool schema emission", () => {
+  it("strips root schema dialects introduced by tools/list middleware", async () => {
+    const server = new MCPServer({
+      name: "schema-emission-test-server",
+      version: "1.0.0",
+    });
+    const draft07 = "http://json-schema.org/draft-07/schema#";
+
+    server.use("mcp:tools/list", async (_ctx, next) => {
+      const tools = await next();
+      return tools.map((tool) => ({
+        ...tool,
+        inputSchema: { ...tool.inputSchema, $schema: draft07 },
+        ...(tool.outputSchema === undefined
+          ? {}
+          : {
+              outputSchema: { ...tool.outputSchema, $schema: draft07 },
+            }),
+      }));
+    });
+
+    server.tool(
+      {
+        name: "typed-echo",
+        inputSchema: z.object({ message: z.string() }),
+        outputSchema: z.object({ echoed: z.string() }),
+      },
+      async ({ message }) => ({
+        content: [{ type: "text", text: message }],
+        structuredContent: { echoed: message },
+      })
+    );
+
+    const { url } = await server.listen(0);
+    const transport = new StreamableHTTPClientTransport(new URL(url));
+    const client = new Client({
+      name: "schema-emission-test-client",
+      version: "1.0.0",
+    });
+    await client.connect(transport);
+
+    try {
+      const result = await client.listTools();
+      const tool = result.tools.find(({ name }) => name === "typed-echo");
+      expect(tool).toBeDefined();
+      expect(tool?.inputSchema).not.toHaveProperty("$schema");
+      expect(tool?.outputSchema).not.toHaveProperty("$schema");
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+});
+
 describe("getHandler() framework mounting", () => {
   it("accepts a raw Request", async () => {
     const server = new MCPServer({ name: "handler-test", version: "1.0.0" });


### PR DESCRIPTION
## Summary

- omit root-level `$schema` markers from `inputSchema` and `outputSchema` in `tools/list`
- keep extracted tools typed as the SDK's `Tool[]` through middleware and wire sanitization
- apply sanitization after `mcp:tools/list` middleware so added or modified tools are normalized too
- preserve `_meta`, `nextCursor`, and future list-result envelope fields
- add an HTTP regression where middleware reintroduces draft-07 `$schema` on both schemas

## Why

The official SDK's Standard Schema conversion accepts and preserves schema dialect markers. Without a final wire-boundary normalization, draft-07 `$schema` values can leak into emitted tool descriptors, including values introduced by middleware.

## Stack

Depends on #1932, which makes exact-method MCP middleware type-safe by method.

## Validation

- `pnpm --filter mcp-use typecheck`
- `pnpm --filter mcp-use exec vitest run tests/mcp-middleware.test.ts tests/type-level.test.ts tests/middleware.e2e.test.ts` — 51 passed
- `pnpm --filter mcp-use build`
- focused ESLint
- `git diff --check`

The authored-schema `tests-review` regression remains on `beta-tests`.
