### PR TITLE
fix: refresh OAuth tokens with resource

### DIFF
--- a/libraries/typescript/.changeset/fresh-oauth-refresh-v1.md
+++ b/libraries/typescript/.changeset/fresh-oauth-refresh-v1.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Refresh expiring OAuth access tokens with the discovered protected-resource URL, retain rotated refresh tokens, and never reuse an expired token after refresh fails.

--- a/libraries/typescript/packages/mcp-use/src/auth/browser-provider.ts
+++ b/libraries/typescript/packages/mcp-use/src/auth/browser-provider.ts
@@ -400,6 +400,11 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
     return this.session.getTokenEndpoint();
   }
 
+  /** Return the canonical protected-resource URL for server-side refresh. */
+  getResource(): Promise<string | null> {
+    return this.session.getResource();
+  }
+
   /**
    * Return the stored OAuth client credentials (DCR or static). Lets consumers
    * persist the `client_id`/`client_secret` for server-side refresh. Returns

--- a/libraries/typescript/packages/mcp-use/src/auth/oauth-session-store.ts
+++ b/libraries/typescript/packages/mcp-use/src/auth/oauth-session-store.ts
@@ -65,6 +65,7 @@ export class OAuthSessionStore {
   private store: KVStore;
   private _cachedAuthServerUrl: string | null = null;
   private _cachedMetadata: AuthorizationServerMetadata | null = null;
+  private _cachedResource: URL | null = null;
   private _refreshPromise: Promise<OAuthTokens | null> | null = null;
 
   constructor(
@@ -129,19 +130,26 @@ export class OAuthSessionStore {
     if (!data) return undefined;
     try {
       const tokens = JSON.parse(data) as OAuthTokens;
-      if (tokens.access_token && tokens.refresh_token) {
+      if (tokens.access_token) {
+        let expiresAt: number | undefined;
         try {
           const payload = JSON.parse(atob(tokens.access_token.split(".")[1]));
-          if (payload.exp && Date.now() >= (payload.exp - 30) * 1000) {
-            console.log("[tokens] Access token expiring soon, refreshing...");
-            const refreshed = await this._dedupedRefresh(tokens);
-            if (refreshed) {
-              console.log("[tokens] Refreshed successfully");
-              return refreshed;
-            }
-          }
+          expiresAt =
+            typeof payload.exp === "number" ? payload.exp * 1000 : undefined;
         } catch {
           // Can't decode JWT, return as-is
+          return tokens;
+        }
+        if (expiresAt && Date.now() >= expiresAt - 30_000) {
+          if (!tokens.refresh_token) return undefined;
+          console.log("[tokens] Access token expiring soon, refreshing...");
+          const refreshed = await this._dedupedRefresh(tokens);
+          if (refreshed) {
+            console.log("[tokens] Refreshed successfully");
+            return refreshed;
+          }
+          // Never return a token that is already expired (or about to be).
+          return undefined;
         }
       }
       return tokens;
@@ -306,6 +314,7 @@ export class OAuthSessionStore {
         if (!metadata) return null;
         this._cachedAuthServerUrl = authServerUrl;
         this._cachedMetadata = metadata as AuthorizationServerMetadata;
+        this._cachedResource = this.resourceUrl(resourceMetadata.resource);
       }
 
       const clientInfo = await this.clientInformation();
@@ -315,9 +324,16 @@ export class OAuthSessionStore {
         metadata: this._cachedMetadata,
         clientInformation: clientInfo,
         refreshToken: tokens.refresh_token!,
+        resource: this._cachedResource ?? undefined,
       });
-      await this.saveTokens(newTokens);
-      return newTokens;
+      // Some authorization servers do not return a refresh_token on every
+      // exchange. Keep the existing one in that case; persist a rotated one.
+      const persistedTokens = {
+        ...newTokens,
+        refresh_token: newTokens.refresh_token ?? tokens.refresh_token,
+      };
+      await this.saveTokens(persistedTokens);
+      return persistedTokens;
     } catch {
       return null;
     }
@@ -400,11 +416,35 @@ export class OAuthSessionStore {
       if (!metadata?.token_endpoint) return null;
       this._cachedAuthServerUrl = authServerUrl;
       this._cachedMetadata = metadata as AuthorizationServerMetadata;
+      this._cachedResource = this.resourceUrl(resourceMetadata.resource);
       await this.store.set(
         this.getKey("token_endpoint"),
         metadata.token_endpoint
       );
       return metadata.token_endpoint;
+    } catch {
+      return null;
+    }
+  }
+
+  /** Return the canonical protected-resource URL used for token exchanges. */
+  async getResource(): Promise<string | null> {
+    if (this._cachedResource) return this._cachedResource.href;
+    try {
+      const resourceMetadata = await discoverOAuthProtectedResourceMetadata(
+        this.serverUrl
+      );
+      this._cachedResource = this.resourceUrl(resourceMetadata.resource);
+      return this._cachedResource?.href ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  private resourceUrl(resource: unknown): URL | null {
+    if (typeof resource !== "string") return null;
+    try {
+      return new URL(resource);
     } catch {
       return null;
     }

--- a/libraries/typescript/packages/mcp-use/src/react/token-expiry.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/token-expiry.ts
@@ -1,0 +1,18 @@
+/**
+ * Resolve an OAuth token's absolute expiry. JWT `exp` is authoritative when
+ * available; `expires_in` is only a fallback for opaque tokens.
+ */
+export function getOAuthTokenExpiry(tokens: {
+  access_token?: string;
+  expires_in?: unknown;
+}): number | undefined {
+  try {
+    const payload = JSON.parse(atob(tokens.access_token?.split(".")[1] ?? ""));
+    if (typeof payload.exp === "number") return payload.exp * 1000;
+  } catch {
+    // Opaque tokens do not contain a JWT expiry claim.
+  }
+  return typeof tokens.expires_in === "number"
+    ? Date.now() + tokens.expires_in * 1000
+    : undefined;
+}

--- a/libraries/typescript/packages/mcp-use/src/react/types.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/types.ts
@@ -359,6 +359,8 @@ export type UseMcpOptions = {
     clientSecret?: string;
     /** OAuth scope string included in the authorize request. */
     scope?: string;
+    /** Canonical protected-resource URL required by some token refresh flows. */
+    resource?: string;
   };
   /**
    * Initial server info to use from cache (internal use).

--- a/libraries/typescript/packages/mcp-use/src/react/useMcp.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/useMcp.ts
@@ -34,6 +34,7 @@ import {
   USE_MCP_SERVER_NAME,
 } from "./useMcp-helpers.js";
 import type { UseMcpOptions, UseMcpResult } from "./types.js";
+import { getOAuthTokenExpiry } from "./token-expiry.js";
 
 const DEFAULT_RECONNECT_DELAY = 3000;
 const DEFAULT_RETRY_DELAY = 5000;
@@ -48,6 +49,7 @@ type UseMcpAuthProvider = OAuthClientProvider & {
   clearStorage?: () => number;
   getLastAttemptedAuthUrl?: () => string | null | undefined;
   getTokenEndpoint?: () => Promise<string | null>;
+  getResource?: () => Promise<string | null>;
   getClientCredentials?: () => Promise<{
     client_id: string;
     client_secret?: string;
@@ -1079,15 +1081,13 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
             return "failed";
           }
           if (tokens?.access_token) {
-            // Calculate expires_at from expires_in if available
-            const expiresAt = tokens.expires_in
-              ? Date.now() + tokens.expires_in * 1000
-              : undefined;
+            const expiresAt = getOAuthTokenExpiry(tokens);
 
             // Best-effort: resolve the OAuth token endpoint + client credentials
             // so consumers can persist them for server-side proactive refresh.
             // Never blocks auth.
             let tokenEndpoint: string | null = null;
+            let resource: string | null = null;
             let clientCreds: {
               client_id: string;
               client_secret?: string;
@@ -1097,6 +1097,12 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
                 (await authProviderRef.current.getTokenEndpoint?.()) ?? null;
             } catch {
               tokenEndpoint = null;
+            }
+            try {
+              resource =
+                (await authProviderRef.current.getResource?.()) ?? null;
+            } catch {
+              resource = null;
             }
             try {
               clientCreds =
@@ -1117,6 +1123,7 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
               refresh_token: tokens.refresh_token,
               scope: tokens.scope,
               ...(tokenEndpoint ? { token_endpoint: tokenEndpoint } : {}),
+              ...(resource ? { resource } : {}),
               ...(clientCreds?.client_id
                 ? { client_id: clientCreds.client_id }
                 : {}),

--- a/libraries/typescript/packages/mcp-use/tests/unit/auth/oauth-session-store.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/auth/oauth-session-store.test.ts
@@ -175,6 +175,7 @@ describe("OAuthSessionStore", () => {
 
       discoverOAuthProtectedResourceMetadata.mockResolvedValue({
         authorization_servers: ["https://auth.example.com"],
+        resource: "https://mcp.example.com",
       });
       discoverAuthorizationServerMetadata.mockResolvedValue({
         issuer: "https://auth.example.com",
@@ -184,11 +185,17 @@ describe("OAuthSessionStore", () => {
       const result = await session.tokens();
       expect(refreshAuthorization).toHaveBeenCalledTimes(1);
       expect(result).toEqual(refreshed);
+      expect(refreshAuthorization).toHaveBeenCalledWith(
+        "https://auth.example.com",
+        expect.objectContaining({
+          resource: new URL("https://mcp.example.com"),
+        })
+      );
       // Refreshed tokens should be persisted via saveTokens()
       expect(kv.get(session.getKey("tokens"))).toBe(JSON.stringify(refreshed));
     });
 
-    it("returns the original tokens when refresh fails", async () => {
+    it("does not return an expired token when refresh fails", async () => {
       const { session, kv } = createStore();
       const tokens = {
         access_token: buildJwt({ exp: Math.floor(Date.now() / 1000) + 5 }),
@@ -205,9 +212,7 @@ describe("OAuthSessionStore", () => {
       );
 
       const result = await session.tokens();
-      // _refresh swallows errors and returns null, so tokens() falls through
-      // and returns the (still-cached) tokens unchanged.
-      expect(result).toEqual(tokens);
+      expect(result).toBeUndefined();
     });
 
     it("dedupes concurrent refresh calls into a single SDK invocation", async () => {

--- a/libraries/typescript/packages/mcp-use/tests/unit/react/token-expiry.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/react/token-expiry.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest";
+import { getOAuthTokenExpiry } from "../../../src/react/token-expiry.js";
+
+function jwt(exp: number): string {
+  const encode = (value: Record<string, unknown>) =>
+    Buffer.from(JSON.stringify(value)).toString("base64url");
+  return `${encode({ alg: "none" })}.${encode({ exp })}.sig`;
+}
+
+describe("getOAuthTokenExpiry", () => {
+  it("prefers JWT exp over expires_in", () => {
+    const exp = 1_800_000_000;
+    expect(
+      getOAuthTokenExpiry({ access_token: jwt(exp), expires_in: 60 })
+    ).toBe(exp * 1000);
+  });
+
+  it("uses expires_in for opaque tokens", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    expect(
+      getOAuthTokenExpiry({ access_token: "opaque", expires_in: 60 })
+    ).toBe(Date.now() + 60_000);
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary

Fix v1 OAuth refreshes for protected resource servers.

- Send the discovered OAuth resource indicator during refresh.
- Preserve rotated refresh tokens and never reuse an expired access token after a failed refresh.
- Expose resource and authoritative JWT expiry through React auth tokens.

## Validation

- `pnpm exec vitest run tests/unit/auth/oauth-session-store.test.ts tests/unit/react/token-expiry.test.ts` (30 passing)
- Full TypeScript check remains blocked by pre-existing missing generated `src/version.js` files and unrelated type errors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix v1 OAuth refresh in `mcp-use` for protected resource servers. Sends the discovered resource during refresh, keeps rotated refresh tokens, and avoids returning expired tokens; React now surfaces `resource` and JWT-based expiry.

- **Bug Fixes**
  - Include the protected-resource URL in refresh requests.
  - Preserve rotated `refresh_token` when the server doesn’t return one.
  - Never return an expired (or about-to-expire) access token if refresh fails.
  - React: expose `resource` in auth tokens and compute expiry using JWT `exp` via `getOAuthTokenExpiry`.

<sup>Written for commit 272a2111d1c14c1e71af74d325001a9d5f894d92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

