### PR TITLE
fix: expose OAuth resource in client tokens

### DIFF
--- a/libraries/typescript/.changeset/fresh-oauth-resource-v2.md
+++ b/libraries/typescript/.changeset/fresh-oauth-resource-v2.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/client": patch
+---
+
+Expose the OAuth protected-resource URL with React auth tokens for consumers that perform server-side token refresh.

--- a/libraries/typescript/packages/client/src/auth/browser.ts
+++ b/libraries/typescript/packages/client/src/auth/browser.ts
@@ -417,6 +417,11 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
     return this.session.getTokenEndpoint();
   }
 
+  /** Return the protected-resource URL selected during OAuth discovery. */
+  getResource(): Promise<string | null> {
+    return this.session.getResource();
+  }
+
   /**
    * Return the stored public OAuth client ID. Browser providers do not retain
    * client secrets.

--- a/libraries/typescript/packages/client/src/auth/session-store.ts
+++ b/libraries/typescript/packages/client/src/auth/session-store.ts
@@ -418,4 +418,13 @@ export class OAuthSessionStore {
         ?.token_endpoint ?? null
     );
   }
+
+  /**
+   * Return the protected-resource URL selected during OAuth discovery.
+   * Consumers can persist it and reuse it for server-side refresh exchanges.
+   */
+  async getResource(): Promise<string | null> {
+    const resource = (await this.discoveryState())?.resourceMetadata?.resource;
+    return typeof resource === "string" ? resource : null;
+  }
 }

--- a/libraries/typescript/packages/client/src/react/types.ts
+++ b/libraries/typescript/packages/client/src/react/types.ts
@@ -448,6 +448,8 @@ export type UseMcpResult = {
     expires_at?: number;
     refresh_token?: string;
     scope?: string;
+    /** Canonical protected-resource URL required by some token refresh flows. */
+    resource?: string;
     /**
      * OAuth token endpoint resolved during discovery (when available). Lets
      * consumers persist it so a backend can proactively refresh the token.

--- a/libraries/typescript/packages/client/src/react/useMcp.ts
+++ b/libraries/typescript/packages/client/src/react/useMcp.ts
@@ -50,6 +50,7 @@ type UseMcpAuthProvider = OAuthClientProvider & {
   clearStorage?: () => number;
   getLastAttemptedAuthUrl?: () => string | null | undefined;
   getTokenEndpoint?: () => Promise<string | null>;
+  getResource?: () => Promise<string | null>;
   getClientCredentials?: () => Promise<{
     client_id: string;
     client_secret?: string;
@@ -1063,6 +1064,7 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
             // so consumers can persist them for server-side proactive refresh.
             // Never blocks auth.
             let tokenEndpoint: string | null = null;
+            let resource: string | null = null;
             let clientCreds: {
               client_id: string;
               client_secret?: string;
@@ -1072,6 +1074,12 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
                 (await authProviderRef.current.getTokenEndpoint?.()) ?? null;
             } catch {
               tokenEndpoint = null;
+            }
+            try {
+              resource =
+                (await authProviderRef.current.getResource?.()) ?? null;
+            } catch {
+              resource = null;
             }
             try {
               clientCreds =
@@ -1092,6 +1100,7 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
               refresh_token: tokens.refresh_token,
               scope: tokens.scope,
               ...(tokenEndpoint ? { token_endpoint: tokenEndpoint } : {}),
+              ...(resource ? { resource } : {}),
               ...(clientCreds?.client_id
                 ? { client_id: clientCreds.client_id }
                 : {}),

--- a/libraries/typescript/packages/client/tests/unit/auth/oauth-session-store.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/auth/oauth-session-store.test.ts
@@ -254,6 +254,23 @@ describe("OAuthSessionStore", () => {
     });
   });
 
+  describe("getResource()", () => {
+    it("returns the protected-resource URL from persisted discovery state", async () => {
+      const { session } = createStore();
+      await session.saveDiscoveryState({
+        authorizationServerUrl: "https://auth.example.com",
+        resourceMetadata: { resource: "https://mcp.example.com" },
+      } as never);
+
+      expect(await session.getResource()).toBe("https://mcp.example.com");
+    });
+
+    it("returns null when discovery has no protected-resource URL", async () => {
+      const { session } = createStore();
+      expect(await session.getResource()).toBeNull();
+    });
+  });
+
   describe("codeVerifier() / saveCodeVerifier()", () => {
     it("round-trips the verifier through KVStore", async () => {
       const { session, kv } = createStore();

--- a/libraries/typescript/packages/client/tests/unit/react/useMcp-connection-metadata.test.tsx
+++ b/libraries/typescript/packages/client/tests/unit/react/useMcp-connection-metadata.test.tsx
@@ -150,4 +150,22 @@ describe("useMcp connection metadata", () => {
       })
     );
   });
+
+  it("exposes the discovered OAuth resource with auth tokens", async () => {
+    authProvider.tokens.mockResolvedValue({
+      access_token: "access-token",
+      token_type: "Bearer",
+      refresh_token: "refresh-token",
+    });
+    authProvider.getResource = vi
+      .fn()
+      .mockResolvedValue("https://mcp.example.com");
+
+    const { result } = await renderFor("modern");
+
+    expect(result.authTokens).toMatchObject({
+      access_token: "access-token",
+      resource: "https://mcp.example.com",
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Expose the OAuth protected-resource URL from v2 client discovery through React auth tokens.

The pinned MCP client continues to own refresh behavior; this gives hosted consumers the canonical resource for server-side refresh.

## Validation

- `pnpm exec vitest run tests/unit/auth/oauth-session-store.test.ts tests/unit/react/useMcp-connection-metadata.test.tsx` (37 passing)
- `pnpm exec tsc --noEmit`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose the OAuth protected-resource URL from v2 discovery in React auth tokens so backends can perform server-side refresh. The MCP client still handles client-side refresh; this only surfaces the canonical `resource` value.

- **New Features**
  - Adds `resource` to `UseMcpResult.authTokens` when discovered via v2 in `@mcp-use/client`.
  - Implements `getResource()` in the session store and browser provider, and wires it through `useMcp`; tests updated.

<sup>Written for commit c5865b6e44ca708704e7e23219303863e3cbf3f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

