### PR TITLE
Canary

### DIFF
--- a/.changeset/brown-poets-clean.md
+++ b/.changeset/brown-poets-clean.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Remove a leftover debug `console.log` that printed `resourceCallbacks undefined` on every resource template registration

--- a/libraries/python/README.md
+++ b/libraries/python/README.md
@@ -92,7 +92,7 @@ mcp-use for Python provides three main capabilities:
     <td>Build your own agents with any framework using the LangChain adapter or create new adapters</td>
   </tr>
   <tr>
-    <td>❓ <a href="https://mcp-use.com/what-should-we-build-next"><strong>What should we build next</strong></a></td>
+    <td>❓ <a href="https://github.com/mcp-use/mcp-use/issues"><strong>What should we build next</strong></a></td>
     <td>Let us know what you'd like us to build next</td>
   </tr>
 </table>

--- a/libraries/typescript/.changeset/fix-auto-proxy-fallback-host.md
+++ b/libraries/typescript/.changeset/fix-auto-proxy-fallback-host.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Fix `useMcp` auto proxy fallback pointing at a retired host. The default `autoProxyFallback` proxy address was `https://inspector.mcp-use.com/inspector/api/proxy`, which now 301-redirects to `inspector.manufact.com`. Browsers treat a redirect on a CORS preflight as a hard failure, so the automatic direct→proxy fallback could never connect (it would retry through a dead URL and fail). The default now points at the live `https://inspector.manufact.com/inspector/api/proxy`.

--- a/libraries/typescript/.changeset/fix-dead-doc-links.md
+++ b/libraries/typescript/.changeset/fix-dead-doc-links.md
@@ -1,0 +1,6 @@
+---
+"@mcp-use/inspector": patch
+"mcp-use": patch
+---
+
+Fix dead documentation links flagged by the link checker: the CLI client example and inspector README pointed at docs pages that no longer exist.

--- a/libraries/typescript/.changeset/fresh-oauth-refresh-v1.md
+++ b/libraries/typescript/.changeset/fresh-oauth-refresh-v1.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Refresh expiring OAuth access tokens with the discovered protected-resource URL, retain rotated refresh tokens, and never reuse an expired token after refresh fails.

--- a/libraries/typescript/.changeset/pre.json
+++ b/libraries/typescript/.changeset/pre.json
@@ -7,5 +7,7 @@
     "@mcp-use/inspector": "12.0.3",
     "mcp-use": "1.34.3"
   },
-  "changesets": []
+  "changesets": [
+    "fix-dead-doc-links"
+  ]
 }

--- a/libraries/typescript/.changeset/pre.json
+++ b/libraries/typescript/.changeset/pre.json
@@ -8,6 +8,7 @@
     "mcp-use": "1.34.3"
   },
   "changesets": [
+    "fix-auto-proxy-fallback-host",
     "fix-dead-doc-links"
   ]
 }

--- a/libraries/typescript/.changeset/pre.json
+++ b/libraries/typescript/.changeset/pre.json
@@ -1,0 +1,11 @@
+{
+  "mode": "pre",
+  "tag": "canary",
+  "initialVersions": {
+    "@mcp-use/cli": "3.6.4",
+    "create-mcp-use-app": "0.14.17",
+    "@mcp-use/inspector": "12.0.3",
+    "mcp-use": "1.34.3"
+  },
+  "changesets": []
+}

--- a/libraries/typescript/packages/cli/CHANGELOG.md
+++ b/libraries/typescript/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @mcp-use/cli
 
+## 3.6.5-canary.1
+
+### Patch Changes
+
+- Updated dependencies [79df5e4]
+  - mcp-use@1.34.4-canary.1
+  - @mcp-use/inspector@12.0.4-canary.1
+
 ## 3.6.5-canary.0
 
 ### Patch Changes

--- a/libraries/typescript/packages/cli/CHANGELOG.md
+++ b/libraries/typescript/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @mcp-use/cli
 
+## 3.6.5-canary.0
+
+### Patch Changes
+
+- Updated dependencies [199365c]
+  - @mcp-use/inspector@12.0.4-canary.0
+  - mcp-use@1.34.4-canary.0
+
 ## 3.6.4
 
 ### Patch Changes

--- a/libraries/typescript/packages/cli/package.json
+++ b/libraries/typescript/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-use/cli",
   "type": "module",
-  "version": "3.6.4",
+  "version": "3.6.5-canary.0",
   "description": "The mcp-use CLI is a tool for building and deploying MCP servers with support for ChatGPT Apps, Code Mode, OAuth, Notifications, Sampling, Observability and more.",
   "author": "mcp-use, Inc.",
   "license": "MIT",

--- a/libraries/typescript/packages/cli/package.json
+++ b/libraries/typescript/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-use/cli",
   "type": "module",
-  "version": "3.6.5-canary.0",
+  "version": "3.6.5-canary.1",
   "description": "The mcp-use CLI is a tool for building and deploying MCP servers with support for ChatGPT Apps, Code Mode, OAuth, Notifications, Sampling, Observability and more.",
   "author": "mcp-use, Inc.",
   "license": "MIT",

--- a/libraries/typescript/packages/inspector/CHANGELOG.md
+++ b/libraries/typescript/packages/inspector/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @mcp-use/inspector
 
+## 12.0.4-canary.0
+
+### Patch Changes
+
+- 199365c: Fix dead documentation links flagged by the link checker: the CLI client example and inspector README pointed at docs pages that no longer exist.
+- Updated dependencies [199365c]
+  - mcp-use@1.34.4-canary.0
+
 ## 12.0.3
 
 ### Patch Changes

--- a/libraries/typescript/packages/inspector/CHANGELOG.md
+++ b/libraries/typescript/packages/inspector/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @mcp-use/inspector
 
+## 12.0.4-canary.1
+
+### Patch Changes
+
+- Updated dependencies [79df5e4]
+  - mcp-use@1.34.4-canary.1
+
 ## 12.0.4-canary.0
 
 ### Patch Changes

--- a/libraries/typescript/packages/inspector/README.md
+++ b/libraries/typescript/packages/inspector/README.md
@@ -413,7 +413,6 @@ See our [contributing guide](https://github.com/mcp-use/mcp-use/blob/main/CONTRI
 ## 📚 Learn More
 
 - [Inspector Documentation](https://mcp-use.com/docs/inspector) - Complete usage guide and tutorials
-- [Self-Hosting Guide](https://mcp-use.com/docs/inspector/self-hosting) - Deploy your own instance
 - [mcp-use Documentation](https://mcp-use.com/docs) - Full framework documentation
 - [Model Context Protocol](https://modelcontextprotocol.io) - Official MCP specification
 - [GitHub Repository](https://github.com/mcp-use/mcp-use) - Source code and examples

--- a/libraries/typescript/packages/inspector/package.json
+++ b/libraries/typescript/packages/inspector/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-use/inspector",
   "type": "module",
-  "version": "12.0.4-canary.0",
+  "version": "12.0.4-canary.1",
   "description": "MCP Inspector - A tool for inspecting and debugging MCP servers",
   "author": "",
   "license": "MIT",

--- a/libraries/typescript/packages/inspector/package.json
+++ b/libraries/typescript/packages/inspector/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-use/inspector",
   "type": "module",
-  "version": "12.0.3",
+  "version": "12.0.4-canary.0",
   "description": "MCP Inspector - A tool for inspecting and debugging MCP servers",
   "author": "",
   "license": "MIT",
@@ -80,7 +80,7 @@
   },
   "peerDependencies": {
     "express": "^4.21.2 || ^5.0.0",
-    "mcp-use": ">=1.34.3-canary.0",
+    "mcp-use": ">=1.34.4-canary.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
     "react-router": "^7.12.0"

--- a/libraries/typescript/packages/mcp-use/CHANGELOG.md
+++ b/libraries/typescript/packages/mcp-use/CHANGELOG.md
@@ -1,5 +1,14 @@
 # mcp-use
 
+## 1.34.4-canary.0
+
+### Patch Changes
+
+- 199365c: Fix dead documentation links flagged by the link checker: the CLI client example and inspector README pointed at docs pages that no longer exist.
+- Updated dependencies [199365c]
+  - @mcp-use/inspector@12.0.4-canary.0
+  - @mcp-use/cli@3.6.5-canary.0
+
 ## 1.34.3
 
 ### Patch Changes

--- a/libraries/typescript/packages/mcp-use/CHANGELOG.md
+++ b/libraries/typescript/packages/mcp-use/CHANGELOG.md
@@ -1,5 +1,13 @@
 # mcp-use
 
+## 1.34.4-canary.1
+
+### Patch Changes
+
+- 79df5e4: Fix `useMcp` auto proxy fallback pointing at a retired host. The default `autoProxyFallback` proxy address was `https://inspector.mcp-use.com/inspector/api/proxy`, which now 301-redirects to `inspector.manufact.com`. Browsers treat a redirect on a CORS preflight as a hard failure, so the automatic direct→proxy fallback could never connect (it would retry through a dead URL and fail). The default now points at the live `https://inspector.manufact.com/inspector/api/proxy`.
+  - @mcp-use/cli@3.6.5-canary.1
+  - @mcp-use/inspector@12.0.4-canary.1
+
 ## 1.34.4-canary.0
 
 ### Patch Changes

--- a/libraries/typescript/packages/mcp-use/examples/client/cli/CLI.md
+++ b/libraries/typescript/packages/mcp-use/examples/client/cli/CLI.md
@@ -195,6 +195,6 @@ Check that:
 
 ## Next Steps
 
-- Read the full [CLI Client documentation](https://mcp-use.com/docs/typescript/client/cli)
+- Read the full [CLI Client documentation](https://docs.mcp-use.com/typescript/tooling/client-cli)
 - Explore [MCP Server examples](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server)
 - Learn about [MCP Agents](https://mcp-use.com/docs/typescript/agent)

--- a/libraries/typescript/packages/mcp-use/package.json
+++ b/libraries/typescript/packages/mcp-use/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-use",
   "type": "module",
-  "version": "1.34.3",
+  "version": "1.34.4-canary.0",
   "packageManager": "pnpm@10.26.0+sha512.3b3f6c725ebe712506c0ab1ad4133cf86b1f4b687effce62a9b38b4d72e3954242e643190fc51fa1642949c735f403debd44f5cb0edd657abe63a8b6a7e1e402",
   "description": "Opinionated MCP Framework for TypeScript (@modelcontextprotocol/sdk compatible) - Build MCP Agents, Clients and Servers with support for ChatGPT Apps, Code Mode, OAuth, Notifications, Sampling, Observability and more.",
   "author": "mcp-use, Inc.",

--- a/libraries/typescript/packages/mcp-use/package.json
+++ b/libraries/typescript/packages/mcp-use/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-use",
   "type": "module",
-  "version": "1.34.4-canary.0",
+  "version": "1.34.4-canary.1",
   "packageManager": "pnpm@10.26.0+sha512.3b3f6c725ebe712506c0ab1ad4133cf86b1f4b687effce62a9b38b4d72e3954242e643190fc51fa1642949c735f403debd44f5cb0edd657abe63a8b6a7e1e402",
   "description": "Opinionated MCP Framework for TypeScript (@modelcontextprotocol/sdk compatible) - Build MCP Agents, Clients and Servers with support for ChatGPT Apps, Code Mode, OAuth, Notifications, Sampling, Observability and more.",
   "author": "mcp-use, Inc.",

--- a/libraries/typescript/packages/mcp-use/src/auth/browser-provider.ts
+++ b/libraries/typescript/packages/mcp-use/src/auth/browser-provider.ts
@@ -400,6 +400,11 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
     return this.session.getTokenEndpoint();
   }
 
+  /** Return the canonical protected-resource URL for server-side refresh. */
+  getResource(): Promise<string | null> {
+    return this.session.getResource();
+  }
+
   /**
    * Return the stored OAuth client credentials (DCR or static). Lets consumers
    * persist the `client_id`/`client_secret` for server-side refresh. Returns

--- a/libraries/typescript/packages/mcp-use/src/auth/oauth-session-store.ts
+++ b/libraries/typescript/packages/mcp-use/src/auth/oauth-session-store.ts
@@ -65,6 +65,7 @@ export class OAuthSessionStore {
   private store: KVStore;
   private _cachedAuthServerUrl: string | null = null;
   private _cachedMetadata: AuthorizationServerMetadata | null = null;
+  private _cachedResource: URL | null = null;
   private _refreshPromise: Promise<OAuthTokens | null> | null = null;
 
   constructor(
@@ -129,19 +130,26 @@ export class OAuthSessionStore {
     if (!data) return undefined;
     try {
       const tokens = JSON.parse(data) as OAuthTokens;
-      if (tokens.access_token && tokens.refresh_token) {
+      if (tokens.access_token) {
+        let expiresAt: number | undefined;
         try {
           const payload = JSON.parse(atob(tokens.access_token.split(".")[1]));
-          if (payload.exp && Date.now() >= (payload.exp - 30) * 1000) {
-            console.log("[tokens] Access token expiring soon, refreshing...");
-            const refreshed = await this._dedupedRefresh(tokens);
-            if (refreshed) {
-              console.log("[tokens] Refreshed successfully");
-              return refreshed;
-            }
-          }
+          expiresAt =
+            typeof payload.exp === "number" ? payload.exp * 1000 : undefined;
         } catch {
           // Can't decode JWT, return as-is
+          return tokens;
+        }
+        if (expiresAt && Date.now() >= expiresAt - 30_000) {
+          if (!tokens.refresh_token) return undefined;
+          console.log("[tokens] Access token expiring soon, refreshing...");
+          const refreshed = await this._dedupedRefresh(tokens);
+          if (refreshed) {
+            console.log("[tokens] Refreshed successfully");
+            return refreshed;
+          }
+          // Never return a token that is already expired (or about to be).
+          return undefined;
         }
       }
       return tokens;
@@ -306,6 +314,7 @@ export class OAuthSessionStore {
         if (!metadata) return null;
         this._cachedAuthServerUrl = authServerUrl;
         this._cachedMetadata = metadata as AuthorizationServerMetadata;
+        this._cachedResource = this.resourceUrl(resourceMetadata.resource);
       }
 
       const clientInfo = await this.clientInformation();
@@ -315,9 +324,16 @@ export class OAuthSessionStore {
         metadata: this._cachedMetadata,
         clientInformation: clientInfo,
         refreshToken: tokens.refresh_token!,
+        resource: this._cachedResource ?? undefined,
       });
-      await this.saveTokens(newTokens);
-      return newTokens;
+      // Some authorization servers do not return a refresh_token on every
+      // exchange. Keep the existing one in that case; persist a rotated one.
+      const persistedTokens = {
+        ...newTokens,
+        refresh_token: newTokens.refresh_token ?? tokens.refresh_token,
+      };
+      await this.saveTokens(persistedTokens);
+      return persistedTokens;
     } catch {
       return null;
     }
@@ -400,11 +416,35 @@ export class OAuthSessionStore {
       if (!metadata?.token_endpoint) return null;
       this._cachedAuthServerUrl = authServerUrl;
       this._cachedMetadata = metadata as AuthorizationServerMetadata;
+      this._cachedResource = this.resourceUrl(resourceMetadata.resource);
       await this.store.set(
         this.getKey("token_endpoint"),
         metadata.token_endpoint
       );
       return metadata.token_endpoint;
+    } catch {
+      return null;
+    }
+  }
+
+  /** Return the canonical protected-resource URL used for token exchanges. */
+  async getResource(): Promise<string | null> {
+    if (this._cachedResource) return this._cachedResource.href;
+    try {
+      const resourceMetadata = await discoverOAuthProtectedResourceMetadata(
+        this.serverUrl
+      );
+      this._cachedResource = this.resourceUrl(resourceMetadata.resource);
+      return this._cachedResource?.href ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  private resourceUrl(resource: unknown): URL | null {
+    if (typeof resource !== "string") return null;
+    try {
+      return new URL(resource);
     } catch {
       return null;
     }

--- a/libraries/typescript/packages/mcp-use/src/react/token-expiry.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/token-expiry.ts
@@ -1,0 +1,18 @@
+/**
+ * Resolve an OAuth token's absolute expiry. JWT `exp` is authoritative when
+ * available; `expires_in` is only a fallback for opaque tokens.
+ */
+export function getOAuthTokenExpiry(tokens: {
+  access_token?: string;
+  expires_in?: unknown;
+}): number | undefined {
+  try {
+    const payload = JSON.parse(atob(tokens.access_token?.split(".")[1] ?? ""));
+    if (typeof payload.exp === "number") return payload.exp * 1000;
+  } catch {
+    // Opaque tokens do not contain a JWT expiry claim.
+  }
+  return typeof tokens.expires_in === "number"
+    ? Date.now() + tokens.expires_in * 1000
+    : undefined;
+}

--- a/libraries/typescript/packages/mcp-use/src/react/types.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/types.ts
@@ -359,6 +359,8 @@ export type UseMcpOptions = {
     clientSecret?: string;
     /** OAuth scope string included in the authorize request. */
     scope?: string;
+    /** Canonical protected-resource URL required by some token refresh flows. */
+    resource?: string;
   };
   /**
    * Initial server info to use from cache (internal use).

--- a/libraries/typescript/packages/mcp-use/src/react/types.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/types.ts
@@ -69,7 +69,7 @@ export type UseMcpOptions = {
    * automatically retries using the proxy configuration
    *
    * Can be:
-   * - `true`: Enable with default proxy (https://inspector.mcp-use.com/inspector/api/proxy)
+   * - `true`: Enable with default proxy (https://inspector.manufact.com/inspector/api/proxy)
    * - `false`: Disable automatic fallback (default)
    * - `{ enabled: boolean, proxyAddress?: string }`: Custom configuration
    *

--- a/libraries/typescript/packages/mcp-use/src/react/useMcp.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/useMcp.ts
@@ -34,6 +34,7 @@ import {
   USE_MCP_SERVER_NAME,
 } from "./useMcp-helpers.js";
 import type { UseMcpOptions, UseMcpResult } from "./types.js";
+import { getOAuthTokenExpiry } from "./token-expiry.js";
 
 const DEFAULT_RECONNECT_DELAY = 3000;
 const DEFAULT_RETRY_DELAY = 5000;
@@ -48,6 +49,7 @@ type UseMcpAuthProvider = OAuthClientProvider & {
   clearStorage?: () => number;
   getLastAttemptedAuthUrl?: () => string | null | undefined;
   getTokenEndpoint?: () => Promise<string | null>;
+  getResource?: () => Promise<string | null>;
   getClientCredentials?: () => Promise<{
     client_id: string;
     client_secret?: string;
@@ -1079,15 +1081,13 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
             return "failed";
           }
           if (tokens?.access_token) {
-            // Calculate expires_at from expires_in if available
-            const expiresAt = tokens.expires_in
-              ? Date.now() + tokens.expires_in * 1000
-              : undefined;
+            const expiresAt = getOAuthTokenExpiry(tokens);
 
             // Best-effort: resolve the OAuth token endpoint + client credentials
             // so consumers can persist them for server-side proactive refresh.
             // Never blocks auth.
             let tokenEndpoint: string | null = null;
+            let resource: string | null = null;
             let clientCreds: {
               client_id: string;
               client_secret?: string;
@@ -1097,6 +1097,12 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
                 (await authProviderRef.current.getTokenEndpoint?.()) ?? null;
             } catch {
               tokenEndpoint = null;
+            }
+            try {
+              resource =
+                (await authProviderRef.current.getResource?.()) ?? null;
+            } catch {
+              resource = null;
             }
             try {
               clientCreds =
@@ -1117,6 +1123,7 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
               refresh_token: tokens.refresh_token,
               scope: tokens.scope,
               ...(tokenEndpoint ? { token_endpoint: tokenEndpoint } : {}),
+              ...(resource ? { resource } : {}),
               ...(clientCreds?.client_id
                 ? { client_id: clientCreds.client_id }
                 : {}),

--- a/libraries/typescript/packages/mcp-use/src/react/useMcp.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/useMcp.ts
@@ -37,6 +37,11 @@ import type { UseMcpOptions, UseMcpResult } from "./types.js";
 
 const DEFAULT_RECONNECT_DELAY = 3000;
 const DEFAULT_RETRY_DELAY = 5000;
+// Live hosted inspector proxy. The former inspector.mcp-use.com host now
+// 301-redirects here, which breaks browser CORS preflights (redirects on a
+// preflight are a hard failure), so the default must point at the live host.
+const DEFAULT_PROXY_FALLBACK_ADDRESS =
+  "https://inspector.manufact.com/inspector/api/proxy";
 
 // Define Transport types literal for clarity
 type TransportType = "http" | "sse";
@@ -239,14 +244,13 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
     if (typeof autoProxyFallback === "boolean") {
       return {
         enabled: autoProxyFallback,
-        proxyAddress: "https://inspector.mcp-use.com/inspector/api/proxy",
+        proxyAddress: DEFAULT_PROXY_FALLBACK_ADDRESS,
       };
     }
     return {
       enabled: autoProxyFallback.enabled !== false,
       proxyAddress:
-        autoProxyFallback.proxyAddress ||
-        "https://inspector.mcp-use.com/inspector/api/proxy",
+        autoProxyFallback.proxyAddress || DEFAULT_PROXY_FALLBACK_ADDRESS,
     };
   }, [autoProxyFallback]);
 

--- a/libraries/typescript/packages/mcp-use/src/server/resources/index.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/resources/index.ts
@@ -358,8 +358,6 @@ export function registerResourceTemplate(
           | ResourceTemplateDefinitionWithoutCallback
       ).resourceTemplate.callbacks;
 
-  console.log("resourceCallbacks", resourceCallbacks);
-
   // Create ResourceTemplate instance from SDK
   const template = new ResourceTemplate(uriTemplate, {
     complete: toResourceTemplateCompleteCallbacks(resourceCallbacks?.complete), // Optional: callback for auto-completion

--- a/libraries/typescript/packages/mcp-use/tests/unit/auth/oauth-session-store.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/auth/oauth-session-store.test.ts
@@ -175,6 +175,7 @@ describe("OAuthSessionStore", () => {
 
       discoverOAuthProtectedResourceMetadata.mockResolvedValue({
         authorization_servers: ["https://auth.example.com"],
+        resource: "https://mcp.example.com",
       });
       discoverAuthorizationServerMetadata.mockResolvedValue({
         issuer: "https://auth.example.com",
@@ -184,11 +185,17 @@ describe("OAuthSessionStore", () => {
       const result = await session.tokens();
       expect(refreshAuthorization).toHaveBeenCalledTimes(1);
       expect(result).toEqual(refreshed);
+      expect(refreshAuthorization).toHaveBeenCalledWith(
+        "https://auth.example.com",
+        expect.objectContaining({
+          resource: new URL("https://mcp.example.com"),
+        })
+      );
       // Refreshed tokens should be persisted via saveTokens()
       expect(kv.get(session.getKey("tokens"))).toBe(JSON.stringify(refreshed));
     });
 
-    it("returns the original tokens when refresh fails", async () => {
+    it("does not return an expired token when refresh fails", async () => {
       const { session, kv } = createStore();
       const tokens = {
         access_token: buildJwt({ exp: Math.floor(Date.now() / 1000) + 5 }),
@@ -205,9 +212,7 @@ describe("OAuthSessionStore", () => {
       );
 
       const result = await session.tokens();
-      // _refresh swallows errors and returns null, so tokens() falls through
-      // and returns the (still-cached) tokens unchanged.
-      expect(result).toEqual(tokens);
+      expect(result).toBeUndefined();
     });
 
     it("dedupes concurrent refresh calls into a single SDK invocation", async () => {

--- a/libraries/typescript/packages/mcp-use/tests/unit/react/token-expiry.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/react/token-expiry.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest";
+import { getOAuthTokenExpiry } from "../../../src/react/token-expiry.js";
+
+function jwt(exp: number): string {
+  const encode = (value: Record<string, unknown>) =>
+    Buffer.from(JSON.stringify(value)).toString("base64url");
+  return `${encode({ alg: "none" })}.${encode({ exp })}.sig`;
+}
+
+describe("getOAuthTokenExpiry", () => {
+  it("prefers JWT exp over expires_in", () => {
+    const exp = 1_800_000_000;
+    expect(
+      getOAuthTokenExpiry({ access_token: jwt(exp), expires_in: 60 })
+    ).toBe(exp * 1000);
+  });
+
+  it("uses expires_in for opaque tokens", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    expect(
+      getOAuthTokenExpiry({ access_token: "opaque", expires_in: 60 })
+    ).toBe(Date.now() + 60_000);
+    vi.useRealTimers();
+  });
+});

--- a/lychee.toml
+++ b/lychee.toml
@@ -31,6 +31,15 @@ exclude = [
 
 ]
 
+# Skip generated changelogs - historical release notes reference docs URLs
+# that were valid at release time; rewriting them is misleading
+exclude_path = [
+  "libraries/typescript/packages/cli/CHANGELOG\\.md$",
+  "libraries/typescript/packages/create-mcp-use-app/CHANGELOG\\.md$",
+  "libraries/typescript/packages/inspector/CHANGELOG\\.md$",
+  "libraries/typescript/packages/mcp-use/CHANGELOG\\.md$",
+]
+
 exclude_loopback = true
 exclude_link_local = true
 # Maximum number of redirects to follow

--- a/skills/chatgpt-app-builder/SKILL.md
+++ b/skills/chatgpt-app-builder/SKILL.md
@@ -217,7 +217,7 @@ Load these before diving into tools/resources/widgets sections.
 
   Add `--device-scale-factor 2` for Retina output, or `--cdp-url <ws>` plus `--inspector <publicly-reachable-url>` to drive a remote Chromium (e.g. Notte) from a sandbox without a local Chrome install.
 
-Both commands are documented in full at [docs/typescript/client/cli](https://docs.mcp-use.com/typescript/client/cli).
+Both commands are documented in full at [docs/typescript/tooling/client-cli](https://docs.mcp-use.com/typescript/tooling/client-cli).
 
 ---
 

--- a/skills/mcp-apps-builder/SKILL.md
+++ b/skills/mcp-apps-builder/SKILL.md
@@ -217,7 +217,7 @@ Load these before diving into tools/resources/widgets sections.
 
   Add `--device-scale-factor 2` for Retina output, or `--cdp-url <ws>` plus `--inspector <publicly-reachable-url>` to drive a remote Chromium (e.g. Notte) from a sandbox without a local Chrome install.
 
-Both commands are documented in full at [docs/typescript/client/cli](https://docs.mcp-use.com/typescript/client/cli).
+Both commands are documented in full at [docs/typescript/tooling/client-cli](https://docs.mcp-use.com/typescript/tooling/client-cli).
 
 ---
 

--- a/skills/mcp-builder/SKILL.md
+++ b/skills/mcp-builder/SKILL.md
@@ -217,7 +217,7 @@ Load these before diving into tools/resources/widgets sections.
 
   Add `--device-scale-factor 2` for Retina output, or `--cdp-url <ws>` plus `--inspector <publicly-reachable-url>` to drive a remote Chromium (e.g. Notte) from a sandbox without a local Chrome install.
 
-Both commands are documented in full at [docs/typescript/client/cli](https://docs.mcp-use.com/typescript/client/cli).
+Both commands are documented in full at [docs/typescript/tooling/client-cli](https://docs.mcp-use.com/typescript/tooling/client-cli).
 
 ---
 

--- a/skills/openapi-to-mcp/references/testing.md
+++ b/skills/openapi-to-mcp/references/testing.md
@@ -40,7 +40,7 @@ If you don't see your tool list, you missed a step in the operations loop in `in
 
 ## 2. Layer 1 — `mcp-use client` CLI (primary)
 
-The `mcp-use` package ships a CLI client that connects to any streamable-HTTP MCP server, handles session and auth bookkeeping, and gives a clean `tools list` / `tools call` / `interactive` surface from the terminal. This is the first thing to reach for. Full docs at <https://docs.mcp-use.com/typescript/client/cli>.
+The `mcp-use` package ships a CLI client that connects to any streamable-HTTP MCP server, handles session and auth bookkeeping, and gives a clean `tools list` / `tools call` / `interactive` surface from the terminal. This is the first thing to reach for. Full docs at <https://docs.mcp-use.com/typescript/tooling/client-cli>.
 
 ### Connect once, then run commands against the name
 


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

Check all that apply:
- [ ] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

Describe the changes introduced by this PR in a concise manner.

## Review Readiness

Help maintainers review this quickly:

- [ ] The PR is scoped to one issue or one clearly related change
- [ ] The PR description explains the user-visible problem and the fix
- [ ] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [ ] I verified the affected package/docs path with the commands listed below
- [ ] I checked for existing open PRs that already solve the same issue

## Implementation Details

1. List the specific implementation details
2. Include code organization, architectural decisions
3. Note any dependencies that were added or modified

---

## TypeScript Checklist

> Complete this section if your PR includes TypeScript changes

### Packages Modified

Check all packages that were modified:
- [ ] `docs`
- [ ] `tests`
- [ ] `cli`
- [ ] `create-mcp-use-app`
- [ ] `mcp-use` (server)
- [ ] `mcp-use` (client)
- [ ] `inspector`

### Pre-commit Checklist

Ensure all of the following have been completed:
- [ ] Ran `pnpm lint:fix` to auto-fix linting issues
- [ ] Ran `pnpm format` to format code with Prettier
- [ ] Ran `pnpm build` and build succeeds without errors
- [ ] Ran `pnpm changeset` to create a changeset (if this PR includes user-facing changes)
- [ ] Added or updated tests if needed
- [ ] Updated documentation in `docs/` folder if needed

---

## Python Checklist

> Complete this section if your PR includes Python changes

### Pre-commit Checklist

Ensure all of the following have been completed:
- [ ] Code formatted with `ruff format`
- [ ] Linting passes with `ruff check`
- [ ] Added or updated tests if needed
- [ ] Updated documentation if needed

---

## Example Usage (Before)

```
# Include example code showing how things worked before (if applicable)
# Use the appropriate language syntax (python, typescript, bash, etc.)
```

## Example Usage (After)

```
# Include example code showing how things work after your changes
# Use the appropriate language syntax (python, typescript, bash, etc.)
```

## Documentation Updates

* List any documentation files that were updated
* Explain what was changed in each file

## Testing

Describe how you tested these changes:
- Unit tests added/modified
- Integration tests added/modified
- Manual testing performed
- Edge cases considered

## Backwards Compatibility

Explain whether these changes are backwards compatible. If not, describe what users will need to do to adapt to these changes.

## Related Issues

Closes #[issue_number]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves OAuth token refresh reliability and restores `useMcp` automatic proxy fallback to fix browser connection failures. Also removes noisy debug logging and repairs broken docs links.

- **New Features**
  - React: expose OAuth `resource` and token expiry; added `getOAuthTokenExpiry()` and `BrowserOAuthClientProvider.getResource()`.

- **Bug Fixes**
  - `useMcp` auto proxy fallback now targets https://inspector.manufact.com/inspector/api/proxy to avoid CORS preflight redirect failures.
  - OAuth: refresh with the protected-resource URL, keep rotated refresh tokens, and never return an expired token if refresh fails.
  - Remove stray `console.log` from resource template registration.
  - Fix dead links in the CLI example, inspector README, skills, and Python README; update link-checker config to ignore generated changelogs.

<sup>Written for commit c341e7a250227dca0957a0f5da0cfbb09328e979. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

