### PR TITLE
fix(ci): use Node 24 for TypeScript releases

### DIFF
--- a/.github/workflows/typescript-release.yml
+++ b/.github/workflows/typescript-release.yml
@@ -40,7 +40,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 23
+          # npm 12 (used for trusted publishing) requires Node 22.22+, 24.15+,
+          # or 26+. Pin the current LTS line rather than the unsupported Node 23.
+          node-version: 24
           cache: "pnpm"
           cache-dependency-path: libraries/typescript/pnpm-lock.yaml
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
## Summary

Run the TypeScript release workflow on Node 24 LTS so npm 12 can be installed for trusted publishing.

## Root cause

The workflow pinned Node 23, which npm 12 does not support. npm 12 requires Node 22.22+, 24.15+, or 26+.

## Validation

- Reviewed the failed release log and workflow configuration.
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin the TypeScript release workflow to Node 24 LTS to enable `npm` 12 for trusted publishing. Fixes release failures caused by Node 23 being incompatible with `npm` 12.

<sup>Written for commit e84b4f74d2798d2e82eaab8d9025e4e4558bb6be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1946?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

