### PR TITLE
fix(mcp-use): stop leaking parent process env to stdio servers

### DIFF
--- a/.changeset/stdio-env-leak.md
+++ b/.changeset/stdio-env-leak.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Stop leaking the full parent process environment to stdio MCP servers. When a server is configured with its own `env`, the connector now layers those variables on top of the SDK's `getDefaultEnvironment()` safe base (`HOME`, `PATH`, ...) instead of copying all of `process.env`, matching the default behaviour of the underlying `@modelcontextprotocol/sdk` transport.

--- a/libraries/typescript/packages/mcp-use/src/connectors/stdio.ts
+++ b/libraries/typescript/packages/mcp-use/src/connectors/stdio.ts
@@ -1,6 +1,7 @@
 import type { StdioServerParameters } from "@modelcontextprotocol/sdk/client/stdio.js";
 import type { Writable } from "node:stream";
 
+import { getDefaultEnvironment } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import process from "node:process";
 import type { ConnectorInitOptions } from "./base.js";
@@ -12,6 +13,25 @@ import type { ClientInfo } from "./http.js";
 
 interface StdioConnectorOptions extends ConnectorInitOptions {
   clientInfo?: ClientInfo;
+}
+
+/**
+ * Build the environment for the spawned stdio server process.
+ *
+ * Returns `undefined` when no variables are configured, letting the transport
+ * apply its own default. Otherwise the caller's variables are layered on top of
+ * `getDefaultEnvironment()` from the underlying `@modelcontextprotocol/sdk`
+ * transport: a minimal safe allowlist (`HOME`, `PATH`, ...) rather than the full
+ * parent environment. Configuring one server-specific variable therefore no
+ * longer leaks every secret in `process.env` to the spawned server.
+ */
+export function buildStdioEnv(
+  env: Record<string, string> | undefined
+): Record<string, string> | undefined {
+  if (!env) {
+    return undefined;
+  }
+  return { ...getDefaultEnvironment(), ...env };
 }
 
 export class StdioConnector extends BaseConnector {
@@ -58,20 +78,7 @@ export class StdioConnector extends BaseConnector {
     logger.debug(`Connecting to MCP implementation via stdio: ${this.command}`);
     try {
       // 1. Build server parameters for the transport
-
-      // Merge env with process.env, filtering out undefined values
-      let mergedEnv: Record<string, string> | undefined;
-      if (this.env) {
-        mergedEnv = {};
-        // First add process.env values (excluding undefined)
-        for (const [key, value] of Object.entries(process.env)) {
-          if (value !== undefined) {
-            mergedEnv[key] = value;
-          }
-        }
-        // Then override with provided env
-        Object.assign(mergedEnv, this.env);
-      }
+      const mergedEnv = buildStdioEnv(this.env);
 
       const serverParams: StdioServerParameters = {
         command: this.command,

--- a/libraries/typescript/packages/mcp-use/tests/unit/connectors/stdio-env.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/connectors/stdio-env.test.ts
@@ -1,0 +1,41 @@
+import { getDefaultEnvironment } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { buildStdioEnv } from "../../../src/connectors/stdio.js";
+
+const SECRET_KEY = "MCP_USE_STDIO_ENV_LEAK_PROBE";
+
+describe("buildStdioEnv", () => {
+  beforeEach(() => {
+    process.env[SECRET_KEY] = "super-secret";
+  });
+
+  afterEach(() => {
+    delete process.env[SECRET_KEY];
+  });
+
+  it("returns undefined when no env is configured", () => {
+    expect(buildStdioEnv(undefined)).toBeUndefined();
+  });
+
+  it("does not leak arbitrary parent process env into the child", () => {
+    const result = buildStdioEnv({ MY_SERVER_VAR: "1" });
+
+    expect(result).toBeDefined();
+    expect(result).not.toHaveProperty(SECRET_KEY);
+  });
+
+  it("keeps the caller-provided variables", () => {
+    const result = buildStdioEnv({ MY_SERVER_VAR: "1" });
+
+    expect(result?.MY_SERVER_VAR).toBe("1");
+  });
+
+  it("uses the SDK default safe environment as the base", () => {
+    const result = buildStdioEnv({ MY_SERVER_VAR: "1" });
+
+    for (const key of Object.keys(getDefaultEnvironment())) {
+      expect(result).toHaveProperty(key);
+    }
+  });
+});


### PR DESCRIPTION
## Language / Project Scope

- [x] TypeScript

## Changes

Addresses the STDIO environment variable leak from #1901 (the first of the three items in that report).

The stdio connector built the child process environment by copying the entire parent `process.env` and then layering the caller's `env` on top. So the moment a user configured even one server-specific variable, every secret in the parent environment (API keys, tokens, cloud credentials) was handed to the spawned MCP server.

This restores parity with the underlying `@modelcontextprotocol/sdk` transport, which deliberately does not inherit the full parent env: when no `env` is provided it starts from `getDefaultEnvironment()`, a minimal allowlist (`HOME`, `PATH`, `SHELL`, ...). The connector now uses that same safe base when the caller does provide `env`.

## Review Readiness

- [x] The PR is scoped to one issue or one clearly related change
- [x] The PR description explains the user-visible problem and the fix
- [x] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [x] I verified the affected package with the commands listed below
- [x] I checked for existing open PRs that already solve the same issue

## Implementation Details

1. Extracted the env construction into a small pure `buildStdioEnv()` helper in `connectors/stdio.ts` so the security-relevant logic is directly unit-testable.
2. The helper returns `undefined` when no `env` is configured (unchanged, lets the transport apply its own default) and otherwise returns `{ ...getDefaultEnvironment(), ...env }`.
3. No new dependencies. `getDefaultEnvironment` is imported from `@modelcontextprotocol/sdk/client/stdio.js`, already a dependency and the source of `StdioServerParameters` used here.

Verified with:

```
pnpm run test:types
pnpm exec eslint src/connectors/stdio.ts tests/unit/connectors/stdio-env.test.ts
pnpm build && pnpm run test:unit   # 626 passed
```

Added `tests/unit/connectors/stdio-env.test.ts` covering: no leak of arbitrary parent env, caller variables preserved, the safe default base is present, and the `undefined` passthrough. The leak test fails against the previous behaviour and passes with this change.

## TypeScript Checklist

### Packages Modified

- [x] `mcp-use`

Added a changeset (`mcp-use`: patch).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop leaking the full parent process environment to stdio MCP servers in `mcp-use`. The connector now uses the SDK’s safe defaults plus the provided `env`, preventing secret exposure and matching `@modelcontextprotocol/sdk` behavior.

- Bug Fixes
  - Build child env as `{ ...getDefaultEnvironment(), ...env }`; no longer copies `process.env`.
  - If no `env` is set, pass `undefined` so the transport applies its default.
  - Extracted `buildStdioEnv()` and added unit tests for non-leakage and default base.

<sup>Written for commit 2238fa0fd53aa9519d2d30e6ec6c6ce635d474aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

