### PR TITLE
fix(auth): handle proxied OAuth resource mismatch

### DIFF
--- a/libraries/typescript/.changeset/fix-proxied-oauth-resource.md
+++ b/libraries/typescript/.changeset/fix-proxied-oauth-resource.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Fix proxied browser OAuth resource validation and surface discovery failures immediately instead of waiting for a popup timeout.

--- a/libraries/typescript/packages/mcp-use/src/auth/browser-provider.ts
+++ b/libraries/typescript/packages/mcp-use/src/auth/browser-provider.ts
@@ -1,5 +1,9 @@
 // browser-provider.ts
 import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
+import {
+  checkResourceAllowed,
+  resourceUrlFromServerUrl,
+} from "@modelcontextprotocol/sdk/shared/auth-utils.js";
 import type {
   OAuthClientInformation,
   OAuthClientMetadata,
@@ -389,6 +393,60 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
     scope: "all" | "client" | "tokens" | "verifier"
   ): Promise<void> {
     return this.session.invalidateCredentials(scope);
+  }
+
+  /**
+   * Validate the protected resource discovered through the OAuth proxy.
+   *
+   * The proxy rewrites protected-resource metadata to the MCP connection URL
+   * so transport-anchored discovery remains valid. Manual authentication is
+   * anchored on the upstream MCP URL instead, so accept that rewrite and
+   * return the original upstream resource that the authorization server
+   * protects.
+   */
+  async validateResourceURL(
+    serverUrl: string | URL,
+    resource?: string
+  ): Promise<URL | undefined> {
+    if (!resource) return undefined;
+
+    const requestedResource = resourceUrlFromServerUrl(serverUrl);
+    if (
+      checkResourceAllowed({
+        requestedResource,
+        configuredResource: resource,
+      })
+    ) {
+      return new URL(resource);
+    }
+
+    const isConnectionResource =
+      this.connectionUrl &&
+      checkResourceAllowed({
+        requestedResource: resourceUrlFromServerUrl(this.connectionUrl),
+        configuredResource: resource,
+      });
+
+    if (isConnectionResource) {
+      const upstreamResource = resourceUrlFromServerUrl(
+        this._lastOriginalResource ?? this.serverUrl
+      );
+
+      // `_original_resource` comes from a proxied response. Never return it
+      // unless it is also valid for the upstream MCP URL supplied to auth().
+      if (
+        checkResourceAllowed({
+          requestedResource,
+          configuredResource: upstreamResource,
+        })
+      ) {
+        return upstreamResource;
+      }
+    }
+
+    throw new Error(
+      `Protected resource ${resource} does not match expected ${requestedResource} (or origin)`
+    );
   }
 
   /**

--- a/libraries/typescript/packages/mcp-use/src/react/useMcp.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/useMcp.ts
@@ -1631,6 +1631,7 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
         const parsedUrl = new URL(url);
         const baseUrl =
           parsedUrl.origin + parsedUrl.pathname.replace(/\/+$/, "");
+        let authFlowError: Error | null = null;
         try {
           await auth(freshAuthProvider, {
             serverUrl: baseUrl,
@@ -1638,17 +1639,29 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
           });
           addLog("info", "OAuth flow completed (tokens obtained)");
         } catch (err: unknown) {
-          // This is expected when auth opens popup/redirect - the flow continues there
+          // This may be the expected popup/redirect handoff, or a real
+          // discovery/validation failure. The popup handle and stored auth URL
+          // below distinguish the two cases.
+          authFlowError = err instanceof Error ? err : new Error(String(err));
           addLog(
             "info",
             "OAuth flow initiated (popup/redirect):",
-            err instanceof Error ? err.message : "Redirecting..."
+            authFlowError.message
           );
         }
 
         // Update authUrl with the new URL from the fresh provider
         // This is critical for the fallback link when popup is blocked
         const newAuthUrl = freshAuthProvider.getLastAttemptedAuthUrl?.();
+
+        if (authFlowError && !capturedPopup && !newAuthUrl) {
+          failConnection(
+            `Authentication failed: ${authFlowError.message}`,
+            authFlowError
+          );
+          return;
+        }
+
         if (newAuthUrl) {
           setAuthUrl(newAuthUrl);
           addLog("info", "Updated auth URL for fallback:", newAuthUrl);

--- a/libraries/typescript/packages/mcp-use/tests/unit/auth/browser-provider-resource-validation.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/auth/browser-provider-resource-validation.test.ts
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BrowserOAuthClientProvider } from "../../../src/auth/browser-provider.js";
+
+const SERVER_URL = "https://www.cubic.dev/api/mcp";
+const CONNECTION_URL = "https://inspector.manufact.com/inspector/api/proxy";
+const PROXY_URL = "https://inspector.manufact.com/inspector/api/oauth";
+
+function makeProvider(options: Record<string, unknown> = {}) {
+  return new BrowserOAuthClientProvider(SERVER_URL, {
+    callbackUrl: "https://app.example.com/oauth/callback",
+    ...options,
+  });
+}
+
+function makeStorage(): Storage {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => values.set(key, String(value)),
+    removeItem: (key: string) => values.delete(key),
+    clear: () => values.clear(),
+    key: (index: number) => Array.from(values.keys())[index] ?? null,
+    get length() {
+      return values.size;
+    },
+  } as Storage;
+}
+
+describe("BrowserOAuthClientProvider.validateResourceURL", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", makeStorage());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("omits the resource when discovery does not provide one", async () => {
+    const provider = makeProvider();
+    await expect(
+      provider.validateResourceURL(SERVER_URL, undefined)
+    ).resolves.toBeUndefined();
+  });
+
+  it("returns a resource allowed for the requested server URL", async () => {
+    const provider = makeProvider();
+    const result = await provider.validateResourceURL(
+      SERVER_URL,
+      "https://www.cubic.dev/api"
+    );
+
+    expect(result?.toString()).toBe("https://www.cubic.dev/api");
+  });
+
+  it("accepts a connection URL rewrite and returns the upstream server resource", async () => {
+    const provider = makeProvider({ connectionUrl: CONNECTION_URL });
+    const result = await provider.validateResourceURL(
+      SERVER_URL,
+      CONNECTION_URL
+    );
+
+    expect(result?.toString()).toBe(SERVER_URL);
+  });
+
+  it("handles a root-path upstream server resource", async () => {
+    const serverUrl = "https://mcp.predictleads.com/";
+    const provider = new BrowserOAuthClientProvider(serverUrl, {
+      callbackUrl: "https://app.example.com/oauth/callback",
+      connectionUrl: CONNECTION_URL,
+    });
+
+    const result = await provider.validateResourceURL(
+      serverUrl,
+      CONNECTION_URL
+    );
+    expect(result?.toString()).toBe(serverUrl);
+  });
+
+  it("returns a validated original resource captured from proxied metadata", async () => {
+    const provider = makeProvider({
+      connectionUrl: CONNECTION_URL,
+      oauthProxyUrl: PROXY_URL,
+    });
+    const baseFetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            resource: CONNECTION_URL,
+            authorization_servers: ["https://as.example.com"],
+            _original_resource: "https://www.cubic.dev/api",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    ) as unknown as typeof fetch;
+
+    await provider.getProxyFetch(baseFetch)!(
+      "https://www.cubic.dev/.well-known/oauth-protected-resource/api/mcp"
+    );
+
+    const result = await provider.validateResourceURL(
+      SERVER_URL,
+      CONNECTION_URL
+    );
+    expect(result?.toString()).toBe("https://www.cubic.dev/api");
+  });
+
+  it("rejects an untrusted original resource returned by the proxy", async () => {
+    const provider = makeProvider({
+      connectionUrl: CONNECTION_URL,
+      oauthProxyUrl: PROXY_URL,
+    });
+    const baseFetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            resource: CONNECTION_URL,
+            authorization_servers: ["https://as.example.com"],
+            _original_resource: "https://evil.example.com/mcp",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    ) as unknown as typeof fetch;
+
+    await provider.getProxyFetch(baseFetch)!(
+      "https://www.cubic.dev/.well-known/oauth-protected-resource/api/mcp"
+    );
+
+    await expect(
+      provider.validateResourceURL(SERVER_URL, CONNECTION_URL)
+    ).rejects.toThrow(/does not match expected/);
+  });
+
+  it("rejects a genuinely foreign discovered resource", async () => {
+    const provider = makeProvider({ connectionUrl: CONNECTION_URL });
+
+    await expect(
+      provider.validateResourceURL(SERVER_URL, "https://evil.example.com/mcp")
+    ).rejects.toThrow(/does not match expected/);
+  });
+});

--- a/libraries/typescript/packages/mcp-use/tests/unit/react/useMcp-auth-flow-error.test.tsx
+++ b/libraries/typescript/packages/mcp-use/tests/unit/react/useMcp-auth-flow-error.test.tsx
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { act, create } from "react-test-renderer";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const auth = vi.fn();
+  const runAuthPopup = vi.fn();
+  const provider = {
+    serverUrl: "https://mcp.example.com/mcp",
+    serverUrlHash: "server-hash",
+    clearStorage: vi.fn().mockReturnValue(0),
+    getLastAttemptedAuthUrl: vi.fn().mockReturnValue(null),
+    getProxyFetch: vi.fn().mockReturnValue(undefined),
+    getKey: vi.fn((suffix: string) => `oauth:${suffix}`),
+    tokens: vi.fn().mockResolvedValue(undefined),
+  };
+  const session = {
+    on: vi.fn(),
+    initialize: vi.fn(),
+  };
+  const client = {
+    addServer: vi.fn(),
+    createSession: vi.fn().mockResolvedValue(session),
+    getSession: vi.fn().mockReturnValue(null),
+    closeSession: vi.fn().mockResolvedValue(undefined),
+    listSessions: vi.fn().mockReturnValue([]),
+  };
+  const createBrowserOAuthProvider = vi.fn(() => ({
+    provider,
+    oauthProxyUrl: "https://inspector.example.com/oauth",
+  }));
+
+  return {
+    auth,
+    runAuthPopup,
+    provider,
+    session,
+    client,
+    createBrowserOAuthProvider,
+  };
+});
+
+vi.mock("@modelcontextprotocol/sdk/client/auth.js", () => ({
+  auth: mocks.auth,
+}));
+
+vi.mock("../../../src/client/browser.js", () => ({
+  BrowserMCPClient: vi.fn(function () {
+    return mocks.client;
+  }),
+}));
+
+vi.mock("../../../src/react/useMcp-helpers.js", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("../../../src/react/useMcp-helpers.js")
+  >()),
+  createBrowserOAuthProvider: mocks.createBrowserOAuthProvider,
+}));
+
+vi.mock("../../../src/auth/popup-runner.js", () => ({
+  runAuthPopup: mocks.runAuthPopup,
+  MCP_AUTH_BROADCAST_CHANNEL: "mcp_auth_callback",
+  MCP_AUTH_CALLBACK_MESSAGE_TYPE: "mcp_auth_callback",
+}));
+
+vi.mock("../../../src/telemetry/telemetry-browser.js", () => ({
+  Tel: {
+    getInstance: () => ({
+      trackUseMcpConnection: vi.fn().mockResolvedValue(undefined),
+      trackUseMcpToolCall: vi.fn().mockResolvedValue(undefined),
+    }),
+  },
+}));
+
+vi.mock("../../../src/utils/favicon-detector.js", () => ({
+  detectFavicon: vi.fn().mockResolvedValue(null),
+}));
+
+function makeStorage(): Storage {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => values.set(key, String(value)),
+    removeItem: (key: string) => values.delete(key),
+    clear: () => values.clear(),
+    key: (index: number) => Array.from(values.keys())[index] ?? null,
+    get length() {
+      return values.size;
+    },
+  } as Storage;
+}
+
+describe("useMcp manual authentication failures", () => {
+  let useMcp: typeof import("../../../src/react/useMcp.js").useMcp;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.stubGlobal("localStorage", makeStorage());
+    mocks.provider.getLastAttemptedAuthUrl.mockReturnValue(null);
+    mocks.session.initialize.mockRejectedValue(
+      Object.assign(new Error("401 Unauthorized"), { code: 401 })
+    );
+    mocks.auth.mockRejectedValue(
+      new Error(
+        "Protected resource https://proxy.example.com does not match expected https://mcp.example.com/mcp (or origin)"
+      )
+    );
+
+    vi.resetModules();
+    ({ useMcp } = await import("../../../src/react/useMcp.js"));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("surfaces auth errors that did not create a popup or authorization URL", async () => {
+    let latest: ReturnType<typeof useMcp> | undefined;
+
+    function TestComponent() {
+      latest = useMcp({
+        url: "https://mcp.example.com/mcp",
+        autoProxyFallback: false,
+        autoReconnect: false,
+        autoRetry: false,
+        logLevel: "silent",
+      });
+      return null;
+    }
+
+    let renderer: ReturnType<typeof create>;
+    await act(async () => {
+      renderer = create(<TestComponent />);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(latest?.state).toBe("pending_auth");
+
+    await act(async () => {
+      await latest!.authenticate();
+    });
+
+    expect(latest?.state).toBe("failed");
+    expect(latest?.error).toContain("Protected resource");
+    expect(mocks.runAuthPopup).not.toHaveBeenCalled();
+
+    await act(async () => {
+      renderer!.unmount();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- validate OAuth protected-resource metadata against both the upstream MCP URL and the proxy connection URL
- return `_original_resource` only after validating it against the upstream MCP URL
- surface OAuth discovery/validation errors immediately when no popup or authorization URL was created
- add a patch changeset for `mcp-use`

## Root cause
The OAuth proxy rewrites protected-resource metadata to the connection URL so transport-anchored discovery succeeds. Manual `authenticate()` is anchored on the upstream MCP URL, so the SDK can reject that rewritten resource before the existing authorization-URL rewrite runs. `useMcp` then treated the exception as a popup handoff and waited for a popup that did not exist.

## Impact
Proxied browser OAuth flows such as Cubic and PredictLeads can authenticate against the intended upstream resource, while foreign or malformed proxy-provided original resources remain rejected. Real discovery failures move the connection to `failed` immediately with the actionable error.

Supersedes #1853 with the unresolved `_original_resource` validation finding addressed.

## Validation
- targeted OAuth + React regression tests: 8 passed
- complete `mcp-use` unit suite: 629 passed, 6 skipped
- `npm run build` in `packages/mcp-use`
- ESLint and Prettier on changed source/tests
- `changeset status` confirms a patch bump

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes proxied OAuth resource validation in `mcp-use` so auth targets the upstream MCP server and fails fast on real discovery errors when no popup is created.

- **Bug Fixes**
  - Validate protected-resource metadata against both the upstream MCP URL and the proxy connection URL.
  - Return `_original_resource` only after confirming it matches the upstream MCP URL.
  - In `useMcp`, immediately surface discovery/validation errors if no popup or authorization URL was created.

<sup>Written for commit 99021aafddb35456bdfd8de7d19b2341b52099fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

