### PR TITLE
fix(client): surface manual OAuth failures

### DIFF
--- a/.github/workflows/server-examples.yml
+++ b/.github/workflows/server-examples.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+        with:
+          version: 11.13.1
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/.github/workflows/server-examples.yml
+++ b/.github/workflows/server-examples.yml
@@ -25,8 +25,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 11.13.1
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/.github/workflows/typescript-pr-preview.yml
+++ b/.github/workflows/typescript-pr-preview.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - canary
+      - beta
       - v2
     paths:
       - "libraries/typescript/**"

--- a/libraries/typescript/.changeset/friendly-dots-fail.md
+++ b/libraries/typescript/.changeset/friendly-dots-fail.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/client": patch
+---
+
+Surface manual browser OAuth failures immediately instead of treating them as popup handoffs.

--- a/libraries/typescript/packages/client/src/react/useMcp.ts
+++ b/libraries/typescript/packages/client/src/react/useMcp.ts
@@ -1499,20 +1499,23 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
         const parsedUrl = new URL(url);
         const baseUrl =
           parsedUrl.origin + parsedUrl.pathname.replace(/\/+$/, "");
-        try {
-          await auth(freshAuthProvider, {
-            serverUrl: baseUrl,
-            fetchFn: freshAuthProvider.getProxyFetch?.(),
-          });
+        const authResult = await auth(freshAuthProvider, {
+          serverUrl: baseUrl,
+          fetchFn: freshAuthProvider.getProxyFetch?.(),
+        });
+
+        if (authResult === "AUTHORIZED") {
           addLog("info", "OAuth flow completed (tokens obtained)");
-        } catch (err: unknown) {
-          // This is expected when auth opens popup/redirect - the flow continues there
-          addLog(
-            "info",
-            "OAuth flow initiated (popup/redirect):",
-            err instanceof Error ? err.message : "Redirecting..."
-          );
+          connectingRef.current = false;
+          connectRef.current?.();
+          return;
         }
+
+        if (authResult !== "REDIRECT") {
+          throw new Error(`Unexpected OAuth auth() result: ${authResult}`);
+        }
+
+        addLog("info", "OAuth authorization redirect initiated");
 
         // Update authUrl with the new URL from the fresh provider
         // This is critical for the fallback link when popup is blocked
@@ -1594,11 +1597,9 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
         }
       } catch (authError) {
         if (!isMountedRef.current) return;
-        setState("pending_auth"); // Go back to pending state on error
-        addLog(
-          "error",
-          `Manual authentication failed: ${authError instanceof Error ? authError.message : String(authError)}`
-        );
+        const error =
+          authError instanceof Error ? authError : new Error(String(authError));
+        failConnection(`Manual authentication failed: ${error.message}`, error);
       }
     } else if (currentState === "authenticating") {
       addLog(

--- a/libraries/typescript/packages/client/tests/unit/react/useMcp-auth-flow-error.test.tsx
+++ b/libraries/typescript/packages/client/tests/unit/react/useMcp-auth-flow-error.test.tsx
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { act, create } from "react-test-renderer";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const auth = vi.fn();
+  const runAuthPopup = vi.fn();
+  const provider = {
+    serverUrl: "https://mcp.example.com/mcp",
+    serverUrlHash: "server-hash",
+    clearStorage: vi.fn().mockReturnValue(0),
+    getLastAttemptedAuthUrl: vi.fn().mockReturnValue(null),
+    getProxyFetch: vi.fn().mockReturnValue(undefined),
+    getKey: vi.fn((suffix: string) => `oauth:${suffix}`),
+    tokens: vi.fn().mockResolvedValue(undefined),
+  };
+  const client = {
+    addServer: vi.fn(),
+    removeServer: vi.fn().mockResolvedValue(undefined),
+    connect: vi.fn(),
+    getSession: vi.fn().mockReturnValue(null),
+    closeSession: vi.fn().mockResolvedValue(undefined),
+    listSessions: vi.fn().mockReturnValue([]),
+  };
+  const createBrowserOAuthProvider = vi.fn(() => ({
+    provider,
+    oauthProxyUrl: "https://inspector.example.com/oauth",
+  }));
+
+  return {
+    auth,
+    runAuthPopup,
+    provider,
+    client,
+    createBrowserOAuthProvider,
+  };
+});
+
+vi.mock("@modelcontextprotocol/client", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  auth: mocks.auth,
+}));
+
+vi.mock("../../../src/core/browser.js", () => ({
+  BrowserMCPClient: vi.fn(function () {
+    return mocks.client;
+  }),
+}));
+
+vi.mock("../../../src/react/useMcp-helpers.js", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("../../../src/react/useMcp-helpers.js")
+  >()),
+  createBrowserOAuthProvider: mocks.createBrowserOAuthProvider,
+}));
+
+vi.mock("../../../src/auth/popup.js", () => ({
+  runAuthPopup: mocks.runAuthPopup,
+  MCP_AUTH_BROADCAST_CHANNEL: "mcp_auth_callback",
+  MCP_AUTH_CALLBACK_MESSAGE_TYPE: "mcp_auth_callback",
+}));
+
+vi.mock("../../../src/telemetry/telemetry-browser.js", () => ({
+  Tel: {
+    getInstance: () => ({
+      trackUseMcpConnection: vi.fn().mockResolvedValue(undefined),
+      trackUseMcpToolCall: vi.fn().mockResolvedValue(undefined),
+      trackUseMcpResourceRead: vi.fn().mockResolvedValue(undefined),
+    }),
+  },
+}));
+
+vi.mock("../../../src/utils/favicon.js", () => ({
+  detectFavicon: vi.fn().mockResolvedValue(null),
+}));
+
+function makeStorage(): Storage {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => values.set(key, String(value)),
+    removeItem: (key: string) => values.delete(key),
+    clear: () => values.clear(),
+    key: (index: number) => Array.from(values.keys())[index] ?? null,
+    get length() {
+      return values.size;
+    },
+  } as Storage;
+}
+
+describe("useMcp manual authentication failures", () => {
+  let useMcp: typeof import("../../../src/react/useMcp.js").useMcp;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.stubGlobal("localStorage", makeStorage());
+    mocks.provider.getLastAttemptedAuthUrl.mockReturnValue(null);
+    mocks.client.connect.mockRejectedValue(
+      Object.assign(new Error("401 Unauthorized"), { code: 401 })
+    );
+    mocks.auth.mockRejectedValue(
+      new Error("Protected resource metadata does not match the MCP server")
+    );
+
+    vi.resetModules();
+    ({ useMcp } = await import("../../../src/react/useMcp.js"));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("surfaces pre-redirect auth errors without starting the popup runner", async () => {
+    let latest: ReturnType<typeof useMcp> | undefined;
+
+    function TestComponent() {
+      latest = useMcp({
+        url: "https://mcp.example.com/mcp",
+        autoProxyFallback: false,
+        autoReconnect: false,
+        autoRetry: false,
+        logLevel: "silent",
+      });
+      return null;
+    }
+
+    let renderer: ReturnType<typeof create>;
+    await act(async () => {
+      renderer = create(<TestComponent />);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(latest?.state).toBe("pending_auth");
+
+    await act(async () => {
+      await latest!.authenticate();
+    });
+
+    expect(latest?.state).toBe("failed");
+    expect(latest?.error).toContain("Protected resource metadata");
+    expect(mocks.runAuthPopup).not.toHaveBeenCalled();
+
+    await act(async () => {
+      renderer!.unmount();
+    });
+  });
+});


### PR DESCRIPTION
## Changes

- handle the upstream OAuth client's explicit `AUTHORIZED` and `REDIRECT` outcomes in `useMcp.authenticate()`
- reconnect immediately when authorization is already complete
- surface discovery and validation exceptions as connection failures instead of waiting for a popup that was never opened
- add React regression coverage and a patch changeset for `@mcp-use/client`
- enable TypeScript package previews for PRs targeting the current `beta` branch

## Why

The beta hook inherited the old assumption that `auth()` throws to hand control to a popup or redirect. The pinned v2 MCP client now returns `REDIRECT` for that handoff and reserves exceptions for real failures. Catching every exception made pre-redirect errors look like an in-progress OAuth flow and could leave the UI waiting for the popup timeout.

## Impact

This does not change the upstream-client-owned refresh or RFC 8707 resource flow. It only corrects the React manual-auth state machine so failures are visible immediately and successful authorization outcomes reconnect correctly.

## Checks

- `pnpm run build` in `packages/client`
- `NODE_OPTIONS=--no-experimental-webstorage pnpm run test:run -- --pool=threads --maxWorkers=2` (214 tests)
- Prettier and ESLint on changed source and tests
- `pnpm exec changeset status --since=origin/beta`
- TypeScript PR Preview, including Deno validation

## Known beta CI issue

The server-example check fails before verification because its root-level pnpm setup cannot see the `packageManager` declaration under `libraries/typescript`. A temporary pin confirmed that the runner also has existing example-bin relinking and Next.js typing failures, so that broader CI repair is intentionally not bundled here.
