### PR TITLE
fix(mcp-use): validate MCP connection URLs in the HTTP connector

### DIFF
--- a/.changeset/http-connector-ssrf.md
+++ b/.changeset/http-connector-ssrf.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Validate MCP connection URLs in the HTTP connector. The `baseUrl` (and gateway URL) are now checked to be well formed and to use the `http`/`https` scheme before any request is made, rejecting SSRF vectors such as `file:`, `gopher:` and `data:` URLs. Loopback and private hosts (`http://localhost`, `http://127.0.0.1`, ...) remain allowed, since connecting to a local or LAN MCP server is a common, legitimate use case.

--- a/libraries/typescript/packages/mcp-use/src/connectors/http.ts
+++ b/libraries/typescript/packages/mcp-use/src/connectors/http.ts
@@ -8,6 +8,7 @@ import {
 } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { logger } from "../logging.js";
 import { SseConnectionManager } from "../task_managers/sse.js";
+import { assertValidConnectionUrl } from "../utils/url-sanitize.js";
 import type { ConnectorInitOptions } from "./base.js";
 import { BaseConnector } from "./base.js";
 
@@ -69,6 +70,7 @@ export class HttpConnector extends BaseConnector {
 
     // Store original URL before any gateway transformation
     const originalUrl = baseUrl.replace(/\/$/, "");
+    assertValidConnectionUrl(originalUrl);
 
     // Gateway support: When using gateway, use gateway URL as the primary baseUrl
     // and store original URL in headers for proxy routing
@@ -76,6 +78,7 @@ export class HttpConnector extends BaseConnector {
     this.serverId = opts.serverId;
 
     if (this.gatewayUrl) {
+      assertValidConnectionUrl(this.gatewayUrl);
       // When using gateway, the transport should connect to gateway URL
       // and forward requests to original URL via X-Target-URL header
       this.baseUrl = this.gatewayUrl.replace(/\/$/, "");

--- a/libraries/typescript/packages/mcp-use/src/utils/url-sanitize.ts
+++ b/libraries/typescript/packages/mcp-use/src/utils/url-sanitize.ts
@@ -8,6 +8,36 @@
  */
 
 /**
+ * Validates a URL used to open an MCP connection.
+ *
+ * The URL must be well formed and use the `http:` or `https:` scheme; anything
+ * else (`file:`, `gopher:`, `data:`, ...) is rejected before a request is ever
+ * made. Unlike {@link sanitizeUrl}, the URL is only validated, never rewritten,
+ * because connection endpoints must be forwarded to the transport unchanged.
+ *
+ * Private and loopback hosts are intentionally allowed: connecting to a local
+ * or LAN MCP server (`http://localhost`, `http://127.0.0.1`, ...) is a primary,
+ * legitimate use case.
+ *
+ * @param raw - The connection URL to validate
+ * @throws Error if the URL is malformed or uses an unsupported protocol
+ */
+export function assertValidConnectionUrl(raw: string): void {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new Error(`Invalid MCP connection URL: ${raw}`);
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error(
+      `Unsupported protocol "${url.protocol}" for MCP connection URL: ${raw}. Only http and https are allowed.`
+    );
+  }
+}
+
+/**
  * Sanitizes a URL string by encoding all components and validating the protocol.
  *
  * @param raw - The raw URL string to sanitize

--- a/libraries/typescript/packages/mcp-use/tests/unit/connectors/http-url-validation.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/connectors/http-url-validation.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { HttpConnector } from "../../../src/connectors/http.js";
+
+describe("HttpConnector connection URL validation", () => {
+  it("rejects non-http(s) schemes (SSRF hardening)", () => {
+    expect(() => new HttpConnector("file:///etc/passwd")).toThrow();
+    expect(() => new HttpConnector("gopher://internal:70/_")).toThrow();
+  });
+
+  it("rejects malformed URLs", () => {
+    expect(() => new HttpConnector("not a url")).toThrow();
+  });
+
+  it("accepts http and https URLs", () => {
+    expect(
+      () => new HttpConnector("https://api.example.com/mcp")
+    ).not.toThrow();
+    expect(() => new HttpConnector("http://example.com/mcp")).not.toThrow();
+  });
+
+  it("still accepts localhost and private hosts (legitimate local MCP servers)", () => {
+    expect(() => new HttpConnector("http://localhost:3000/mcp")).not.toThrow();
+    expect(() => new HttpConnector("http://127.0.0.1:8080")).not.toThrow();
+    expect(() => new HttpConnector("http://192.168.1.10:3000")).not.toThrow();
+  });
+});

--- a/libraries/typescript/packages/mcp-use/tests/unit/utils/url-sanitize-connection.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/utils/url-sanitize-connection.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { assertValidConnectionUrl } from "../../../src/utils/url-sanitize.js";
+
+describe("assertValidConnectionUrl", () => {
+  it("accepts http and https", () => {
+    expect(() =>
+      assertValidConnectionUrl("http://example.com/mcp")
+    ).not.toThrow();
+    expect(() =>
+      assertValidConnectionUrl("https://example.com/mcp")
+    ).not.toThrow();
+  });
+
+  it("allows loopback and private hosts", () => {
+    expect(() =>
+      assertValidConnectionUrl("http://localhost:3000")
+    ).not.toThrow();
+    expect(() =>
+      assertValidConnectionUrl("http://127.0.0.1:8080/mcp")
+    ).not.toThrow();
+    expect(() => assertValidConnectionUrl("http://10.0.0.5")).not.toThrow();
+  });
+
+  it("rejects non-http(s) schemes", () => {
+    expect(() => assertValidConnectionUrl("file:///etc/passwd")).toThrow(
+      /protocol/i
+    );
+    expect(() => assertValidConnectionUrl("ftp://host/x")).toThrow(/protocol/i);
+    expect(() => assertValidConnectionUrl("gopher://host:70/_")).toThrow(
+      /protocol/i
+    );
+    expect(() => assertValidConnectionUrl("data:text/plain,hi")).toThrow(
+      /protocol/i
+    );
+  });
+
+  it("rejects malformed URLs", () => {
+    expect(() => assertValidConnectionUrl("not a url")).toThrow(
+      /Invalid MCP connection URL/
+    );
+    expect(() => assertValidConnectionUrl("")).toThrow(
+      /Invalid MCP connection URL/
+    );
+  });
+});


### PR DESCRIPTION
## Language / Project Scope

- [x] TypeScript

## Changes

Addresses the HTTP transport SSRF item from #1901 (the second of the three in that report).

The HTTP connector stored the user-provided `baseUrl` (and the gateway URL) with no validation, so a `file:`, `gopher:`, or `data:` URL would be accepted and handed to the transport. The repo already ships `sanitizeUrl()` in `utils/url-sanitize.ts` that restricts `open()` targets to `http`/`https`, but that policy was never applied to MCP connection URLs.

This adds an `assertValidConnectionUrl()` to the same module and calls it in the `HttpConnector` constructor for both the target URL and the gateway URL.

**Deliberately not blocking private/loopback hosts.** Connecting to a local or LAN MCP server (`http://localhost:3000/mcp`, `http://127.0.0.1`, ...) is one of the most common ways people run this library, so a blanket private-IP block would break normal usage. The scope here is protocol/well-formedness validation, which is non-breaking and closes the `file:`/`gopher:`/`data:` disclosure and smuggling vectors.

## Review Readiness

- [x] The PR is scoped to one issue or one clearly related change
- [x] The PR description explains the user-visible problem and the fix
- [x] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [x] I verified the affected package with the commands listed below
- [x] I checked for existing open PRs that already solve the same issue

## Implementation Details

1. Added `assertValidConnectionUrl(raw)` to `utils/url-sanitize.ts`: parses with `new URL()` (throws a clear error on malformed input) and requires the `http:`/`https:` scheme. Unlike `sanitizeUrl()`, it validates without rewriting, since a connection endpoint must reach the transport unchanged.
2. Called it in the `HttpConnector` constructor for the target URL and, when configured, the gateway URL.
3. No new dependencies.

Verified with:

```
pnpm run test:types
pnpm exec eslint <changed files>
pnpm build && pnpm run test:unit   # 630 passed
```

Added `tests/unit/utils/url-sanitize-connection.test.ts` (unit tests for the validator) and `tests/unit/connectors/http-url-validation.test.ts` (constructor rejects `file:`/`gopher:`/malformed, still accepts http/https and localhost/private hosts). The reject cases fail against the previous behaviour and pass with this change.

## TypeScript Checklist

### Packages Modified

- [x] `mcp-use`

Added a changeset (`mcp-use`: patch).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate MCP connection URLs in the HTTP connector to block SSRF via non-http schemes. Enforces http/https for `baseUrl` and gateway URL in `mcp-use` without blocking localhost or private networks.

- Bug Fixes
  - Added `assertValidConnectionUrl()` and invoked it for `baseUrl` and optional gateway.
  - Allow only `http`/`https`; reject `file:`, `gopher:`, `data:`, and malformed URLs.
  - Keep loopback/private hosts allowed for local MCP servers.
  - Added unit tests; no new dependencies; patch changeset for `mcp-use`.

<sup>Written for commit 4ca38b12de9756c459ed286c729eda624dc6718b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

