### PR TITLE
Standardize OAuth environment variables across auth examples

### DIFF
--- a/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/index.ts
+++ b/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/index.ts
@@ -20,8 +20,10 @@ const server = new MCPServer({
   // The MCP server is by default served at /mcp, to customise
   // basePath: "/mcp",
 
-  // mcp-use has 1 line adapter for OAuth, import from mcp-use/oauth/*
-  // oauth: oauthClerkProvider(), // zero-config via MCP_USE_OAUTH_CLERK_FRONTEND_API_URL, import from mcp-use/oauth/*
+  // Import oauthClerkProvider from mcp-use/oauth/clerk to enable OAuth.
+  // oauth: oauthClerkProvider({
+  //   frontendApiUrl: process.env.MCP_USE_OAUTH_CLERK_FRONTEND_API_URL!,
+  // }),
 
   // When OAuth is on, the HTML landing page (/mcp) is protected by default, set to true to keep the landing page public while /mcp stays bearer-protected.
   // publicLandingPage: true,

--- a/libraries/typescript/packages/server/examples/auth/auth0/.env.example
+++ b/libraries/typescript/packages/server/examples/auth/auth0/.env.example
@@ -1,8 +1,8 @@
 # Auth0 tenant issuer URL, including https://
-AUTH0_DOMAIN=https://your-tenant.us.auth0.com
+MCP_USE_OAUTH_AUTH0_DOMAIN=https://your-tenant.us.auth0.com
 
 # Auth0 API Identifier. This must match the audience in issued access tokens.
-AUTH0_AUDIENCE=https://api.example.com
+MCP_USE_OAUTH_AUTH0_AUDIENCE=https://api.example.com
 
 # Public origin only, with no path. Required when the server runs publicly.
 # MCP_URL=https://mcp.example.com

--- a/libraries/typescript/packages/server/examples/auth/auth0/README.md
+++ b/libraries/typescript/packages/server/examples/auth/auth0/README.md
@@ -7,7 +7,7 @@ It does not send the access token to Auth0 or any other service.
 ## Configure Auth0
 
 1. In Auth0, create an API for this MCP server. Set its API Identifier to the
-   value you will use for `AUTH0_AUDIENCE`, such as
+   value you will use for `MCP_USE_OAUTH_AUTH0_AUDIENCE`, such as
    `https://api.example.com`.
 2. Define the API permissions that your MCP client needs. The client must
    request those scopes during authorization. The example exposes verified
@@ -22,17 +22,17 @@ It does not send the access token to Auth0 or any other service.
    `resource` parameter. The requested scopes must be allowed for the API and
    application.
 
-`AUTH0_AUDIENCE` is the Auth0 API Identifier, not the Auth0 Management API
-audience. The server validates the token issuer, signature, and audience before
-the tool runs.
+`MCP_USE_OAUTH_AUTH0_AUDIENCE` is the Auth0 API Identifier, not the Auth0
+Management API audience. The server validates the token issuer, signature, and
+audience before the tool runs.
 
 ## Configure the server
 
 Copy `.env.example` to `.env` and set the required values:
 
 ```sh
-AUTH0_DOMAIN=https://your-tenant.us.auth0.com
-AUTH0_AUDIENCE=https://api.example.com
+MCP_USE_OAUTH_AUTH0_DOMAIN=https://your-tenant.us.auth0.com
+MCP_USE_OAUTH_AUTH0_AUDIENCE=https://api.example.com
 ```
 
 For a public deployment, also set `MCP_URL` to the public origin only:

--- a/libraries/typescript/packages/server/examples/auth/auth0/src/index.ts
+++ b/libraries/typescript/packages/server/examples/auth/auth0/src/index.ts
@@ -18,9 +18,6 @@ const getUserInfoOutputSchema = z.object({
   resource: z.string().nullable(),
 });
 
-const domain = requiredEnvironmentValue("MCP_USE_OAUTH_AUTH0_DOMAIN");
-const audience = requiredEnvironmentValue("MCP_USE_OAUTH_AUTH0_AUDIENCE");
-
 const server = new MCPServer({
   name: "auth0-direct-auth-example",
   version: "1.0.0",
@@ -28,7 +25,10 @@ const server = new MCPServer({
   description:
     "Authenticates Auth0 access tokens directly and returns verified token claims.",
   publicLandingPage: true,
-  oauth: oauthAuth0Provider({ domain, audience }),
+  oauth: oauthAuth0Provider({
+    domain: process.env.MCP_USE_OAUTH_AUTH0_DOMAIN!,
+    audience: process.env.MCP_USE_OAUTH_AUTH0_AUDIENCE!,
+  }),
 });
 
 server.tool(
@@ -62,13 +62,5 @@ server.tool(
     };
   }
 );
-
-function requiredEnvironmentValue(name: string): string {
-  const value = process.env[name]?.trim();
-  if (value === undefined || value.length === 0) {
-    throw new Error(`${name} is required`);
-  }
-  return value;
-}
 
 export default server;

--- a/libraries/typescript/packages/server/examples/auth/auth0/src/index.ts
+++ b/libraries/typescript/packages/server/examples/auth/auth0/src/index.ts
@@ -18,6 +18,9 @@ const getUserInfoOutputSchema = z.object({
   resource: z.string().nullable(),
 });
 
+const domain = requiredEnvironmentValue("MCP_USE_OAUTH_AUTH0_DOMAIN");
+const audience = requiredEnvironmentValue("MCP_USE_OAUTH_AUTH0_AUDIENCE");
+
 const server = new MCPServer({
   name: "auth0-direct-auth-example",
   version: "1.0.0",
@@ -25,7 +28,7 @@ const server = new MCPServer({
   description:
     "Authenticates Auth0 access tokens directly and returns verified token claims.",
   publicLandingPage: true,
-  oauth: oauthAuth0Provider(),
+  oauth: oauthAuth0Provider({ domain, audience }),
 });
 
 server.tool(
@@ -59,5 +62,13 @@ server.tool(
     };
   }
 );
+
+function requiredEnvironmentValue(name: string): string {
+  const value = process.env[name]?.trim();
+  if (value === undefined || value.length === 0) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
 
 export default server;

--- a/libraries/typescript/packages/server/examples/auth/auth0/src/index.ts
+++ b/libraries/typescript/packages/server/examples/auth/auth0/src/index.ts
@@ -34,7 +34,7 @@ const server = new MCPServer({
     "Authenticates Auth0 access tokens directly and returns verified token claims.",
   publicLandingPage: true,
   oauth: oauthAuth0Provider({
-    domain: requireEnv("AUTH0_DOMAIN"),
+    domain: requireEnv("MCP_USE_OAUTH_AUTH0_DOMAIN"),
   }),
 });
 

--- a/libraries/typescript/packages/server/examples/auth/auth0/src/index.ts
+++ b/libraries/typescript/packages/server/examples/auth/auth0/src/index.ts
@@ -18,14 +18,6 @@ const getUserInfoOutputSchema = z.object({
   resource: z.string().nullable(),
 });
 
-function requireEnv(name: string): string {
-  const value = process.env[name]?.trim();
-  if (value === undefined || value === "") {
-    throw new Error(`${name} must be set`);
-  }
-  return value;
-}
-
 const server = new MCPServer({
   name: "auth0-direct-auth-example",
   version: "1.0.0",
@@ -33,9 +25,7 @@ const server = new MCPServer({
   description:
     "Authenticates Auth0 access tokens directly and returns verified token claims.",
   publicLandingPage: true,
-  oauth: oauthAuth0Provider({
-    domain: requireEnv("MCP_USE_OAUTH_AUTH0_DOMAIN"),
-  }),
+  oauth: oauthAuth0Provider(),
 });
 
 server.tool(

--- a/libraries/typescript/packages/server/examples/auth/better-auth/.env.example
+++ b/libraries/typescript/packages/server/examples/auth/better-auth/.env.example
@@ -1,3 +1,4 @@
 BETTER_AUTH_SECRET=replace-with-at-least-32-random-characters
 BETTER_AUTH_URL=http://localhost:61843/api/auth
+MCP_USE_OAUTH_BETTER_AUTH_URL=http://localhost:61843/api/auth
 MCP_URL=http://localhost:43127

--- a/libraries/typescript/packages/server/examples/auth/better-auth/README.md
+++ b/libraries/typescript/packages/server/examples/auth/better-auth/README.md
@@ -37,9 +37,9 @@ verified Better Auth subject.
 
 `BETTER_AUTH_SECRET` is optional for local use. Copy `.env.example` to `.env`
 and replace the secret before adapting the example for a deployment. Keep
-`BETTER_AUTH_URL` identical in both processes, and set `MCP_URL` to the MCP
-server's public origin. The auth process appends `/mcp` for the token audience,
-matching the `mcp-use` CLI convention.
+`BETTER_AUTH_URL` and `MCP_USE_OAUTH_BETTER_AUTH_URL` identical, and set
+`MCP_URL` to the MCP server's public origin. The auth process appends `/mcp`
+for the token audience, matching the `mcp-use` CLI convention.
 
 ## File layout
 

--- a/libraries/typescript/packages/server/examples/auth/better-auth/src/index.ts
+++ b/libraries/typescript/packages/server/examples/auth/better-auth/src/index.ts
@@ -1,12 +1,12 @@
 import { MCPServer } from "mcp-use";
 import { oauthBetterAuthProvider } from "mcp-use/oauth/better-auth";
 
-const authURL = requiredEnvironmentValue("MCP_USE_OAUTH_BETTER_AUTH_URL");
-
 const server = new MCPServer({
   name: "better-auth-anonymous-example",
   version: "1.0.0",
-  oauth: oauthBetterAuthProvider({ authURL }),
+  oauth: oauthBetterAuthProvider({
+    authURL: process.env.MCP_USE_OAUTH_BETTER_AUTH_URL!,
+  }),
 });
 
 server.tool(
@@ -32,14 +32,6 @@ server.tool(
     ],
   })
 );
-
-function requiredEnvironmentValue(name: string): string {
-  const value = process.env[name]?.trim();
-  if (value === undefined || value.length === 0) {
-    throw new Error(`${name} is required`);
-  }
-  return value;
-}
 
 // The mcp-use CLI imports this server and owns the MCP socket.
 export default server;

--- a/libraries/typescript/packages/server/examples/auth/better-auth/src/index.ts
+++ b/libraries/typescript/packages/server/examples/auth/better-auth/src/index.ts
@@ -1,14 +1,10 @@
 import { MCPServer } from "mcp-use";
 import { oauthBetterAuthProvider } from "mcp-use/oauth/better-auth";
 
-const authURL =
-  process.env["MCP_USE_OAUTH_BETTER_AUTH_URL"] ??
-  "http://localhost:61843/api/auth";
-
 const server = new MCPServer({
   name: "better-auth-anonymous-example",
   version: "1.0.0",
-  oauth: oauthBetterAuthProvider({ authURL }),
+  oauth: oauthBetterAuthProvider(),
 });
 
 server.tool(

--- a/libraries/typescript/packages/server/examples/auth/better-auth/src/index.ts
+++ b/libraries/typescript/packages/server/examples/auth/better-auth/src/index.ts
@@ -2,7 +2,8 @@ import { MCPServer } from "mcp-use";
 import { oauthBetterAuthProvider } from "mcp-use/oauth/better-auth";
 
 const authURL =
-  process.env["BETTER_AUTH_URL"] ?? "http://localhost:61843/api/auth";
+  process.env["MCP_USE_OAUTH_BETTER_AUTH_URL"] ??
+  "http://localhost:61843/api/auth";
 
 const server = new MCPServer({
   name: "better-auth-anonymous-example",

--- a/libraries/typescript/packages/server/examples/auth/better-auth/src/index.ts
+++ b/libraries/typescript/packages/server/examples/auth/better-auth/src/index.ts
@@ -1,10 +1,12 @@
 import { MCPServer } from "mcp-use";
 import { oauthBetterAuthProvider } from "mcp-use/oauth/better-auth";
 
+const authURL = requiredEnvironmentValue("MCP_USE_OAUTH_BETTER_AUTH_URL");
+
 const server = new MCPServer({
   name: "better-auth-anonymous-example",
   version: "1.0.0",
-  oauth: oauthBetterAuthProvider(),
+  oauth: oauthBetterAuthProvider({ authURL }),
 });
 
 server.tool(
@@ -30,6 +32,14 @@ server.tool(
     ],
   })
 );
+
+function requiredEnvironmentValue(name: string): string {
+  const value = process.env[name]?.trim();
+  if (value === undefined || value.length === 0) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
 
 // The mcp-use CLI imports this server and owns the MCP socket.
 export default server;

--- a/libraries/typescript/packages/server/examples/auth/clerk/.env.example
+++ b/libraries/typescript/packages/server/examples/auth/clerk/.env.example
@@ -1,8 +1,5 @@
 # Required: Clerk Frontend API URL.
 MCP_USE_OAUTH_CLERK_FRONTEND_API_URL=https://verb-noun-42.clerk.accounts.dev
 
-# Optional: expected access-token audience.
-# MCP_USE_OAUTH_CLERK_AUDIENCE=https://api.example.com
-
 # Optional: public MCP server origin. Do not include /mcp.
 # MCP_URL=https://mcp.example.com

--- a/libraries/typescript/packages/server/examples/auth/clerk/.env.example
+++ b/libraries/typescript/packages/server/examples/auth/clerk/.env.example
@@ -1,8 +1,8 @@
 # Required: Clerk Frontend API URL.
-CLERK_FRONTEND_API_URL=https://verb-noun-42.clerk.accounts.dev
+MCP_USE_OAUTH_CLERK_FRONTEND_API_URL=https://verb-noun-42.clerk.accounts.dev
 
 # Optional: expected access-token audience.
-# CLERK_AUDIENCE=https://api.example.com
+# MCP_USE_OAUTH_CLERK_AUDIENCE=https://api.example.com
 
 # Optional: public MCP server origin. Do not include /mcp.
 # MCP_URL=https://mcp.example.com

--- a/libraries/typescript/packages/server/examples/auth/clerk/README.md
+++ b/libraries/typescript/packages/server/examples/auth/clerk/README.md
@@ -19,10 +19,11 @@ Copy the example environment file and add your Clerk Frontend API URL:
 cp .env.example .env
 ```
 
-Set `CLERK_AUDIENCE` only when your Clerk access-token configuration uses an
-audience. For public and tunnel deployments, set `MCP_URL` to the server
-origin, such as `https://mcp.example.com`, not the `/mcp` endpoint. The CLI
-derives the canonical protected resource as `https://mcp.example.com/mcp`.
+Set `MCP_USE_OAUTH_CLERK_AUDIENCE` only when your Clerk access-token
+configuration uses an audience. For public and tunnel deployments, set
+`MCP_URL` to the server origin, such as `https://mcp.example.com`, not the
+`/mcp` endpoint. The CLI derives the canonical protected resource as
+`https://mcp.example.com/mcp`.
 
 Run the server:
 

--- a/libraries/typescript/packages/server/examples/auth/clerk/README.md
+++ b/libraries/typescript/packages/server/examples/auth/clerk/README.md
@@ -19,11 +19,9 @@ Copy the example environment file and add your Clerk Frontend API URL:
 cp .env.example .env
 ```
 
-Set `MCP_USE_OAUTH_CLERK_AUDIENCE` only when your Clerk access-token
-configuration uses an audience. For public and tunnel deployments, set
-`MCP_URL` to the server origin, such as `https://mcp.example.com`, not the
-`/mcp` endpoint. The CLI derives the canonical protected resource as
-`https://mcp.example.com/mcp`.
+For public and tunnel deployments, set `MCP_URL` to the server origin, such as
+`https://mcp.example.com`, not the `/mcp` endpoint. The CLI derives the
+canonical protected resource as `https://mcp.example.com/mcp`.
 
 Run the server:
 

--- a/libraries/typescript/packages/server/examples/auth/clerk/src/index.ts
+++ b/libraries/typescript/packages/server/examples/auth/clerk/src/index.ts
@@ -20,16 +20,14 @@ const getUserInfoOutputSchema = z.object({
   resource: z.string().nullable(),
 });
 
-const frontendApiUrl = requiredEnvironmentValue(
-  "MCP_USE_OAUTH_CLERK_FRONTEND_API_URL"
-);
-
 const server = new MCPServer({
   name: "clerk-direct-auth-example",
   version: "1.0.0",
   description: "An MCP server that verifies Clerk-issued access tokens.",
   publicLandingPage: true,
-  oauth: oauthClerkProvider({ frontendApiUrl }),
+  oauth: oauthClerkProvider({
+    frontendApiUrl: process.env.MCP_USE_OAUTH_CLERK_FRONTEND_API_URL!,
+  }),
 });
 
 server.tool(
@@ -64,13 +62,5 @@ server.tool(
     };
   }
 );
-
-function requiredEnvironmentValue(name: string): string {
-  const value = process.env[name]?.trim();
-  if (value === undefined || value.length === 0) {
-    throw new Error(`${name} is required`);
-  }
-  return value;
-}
 
 export default server;

--- a/libraries/typescript/packages/server/examples/auth/clerk/src/index.ts
+++ b/libraries/typescript/packages/server/examples/auth/clerk/src/index.ts
@@ -25,9 +25,7 @@ const server = new MCPServer({
   version: "1.0.0",
   description: "An MCP server that verifies Clerk-issued access tokens.",
   publicLandingPage: true,
-  oauth: oauthClerkProvider({
-    frontendApiUrl: requireEnv("MCP_USE_OAUTH_CLERK_FRONTEND_API_URL"),
-  }),
+  oauth: oauthClerkProvider(),
 });
 
 server.tool(
@@ -62,13 +60,5 @@ server.tool(
     };
   }
 );
-
-function requireEnv(name: string): string {
-  const value = process.env[name]?.trim();
-  if (value === undefined || value === "") {
-    throw new Error(`Missing required environment variable: ${name}`);
-  }
-  return value;
-}
 
 export default server;

--- a/libraries/typescript/packages/server/examples/auth/clerk/src/index.ts
+++ b/libraries/typescript/packages/server/examples/auth/clerk/src/index.ts
@@ -26,7 +26,7 @@ const server = new MCPServer({
   description: "An MCP server that verifies Clerk-issued access tokens.",
   publicLandingPage: true,
   oauth: oauthClerkProvider({
-    frontendApiUrl: requireEnv("CLERK_FRONTEND_API_URL"),
+    frontendApiUrl: requireEnv("MCP_USE_OAUTH_CLERK_FRONTEND_API_URL"),
   }),
 });
 

--- a/libraries/typescript/packages/server/examples/auth/clerk/src/index.ts
+++ b/libraries/typescript/packages/server/examples/auth/clerk/src/index.ts
@@ -20,12 +20,16 @@ const getUserInfoOutputSchema = z.object({
   resource: z.string().nullable(),
 });
 
+const frontendApiUrl = requiredEnvironmentValue(
+  "MCP_USE_OAUTH_CLERK_FRONTEND_API_URL"
+);
+
 const server = new MCPServer({
   name: "clerk-direct-auth-example",
   version: "1.0.0",
   description: "An MCP server that verifies Clerk-issued access tokens.",
   publicLandingPage: true,
-  oauth: oauthClerkProvider(),
+  oauth: oauthClerkProvider({ frontendApiUrl }),
 });
 
 server.tool(
@@ -60,5 +64,13 @@ server.tool(
     };
   }
 );
+
+function requiredEnvironmentValue(name: string): string {
+  const value = process.env[name]?.trim();
+  if (value === undefined || value.length === 0) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
 
 export default server;

--- a/libraries/typescript/packages/server/examples/auth/keycloak/.env.example
+++ b/libraries/typescript/packages/server/examples/auth/keycloak/.env.example
@@ -1,10 +1,10 @@
 # Keycloak base URL. Include a legacy /auth path if your deployment uses one.
-KEYCLOAK_SERVER_URL=https://keycloak.example.com
-KEYCLOAK_REALM=mcp
+MCP_USE_OAUTH_KEYCLOAK_SERVER_URL=https://keycloak.example.com
+MCP_USE_OAUTH_KEYCLOAK_REALM=mcp
 
 # Required: the expected access-token audience, typically your API client ID or resource identifier.
 # Configure an Audience mapper in Keycloak to include this value in issued tokens.
-KEYCLOAK_AUDIENCE=mcp-api
+MCP_USE_OAUTH_KEYCLOAK_AUDIENCE=mcp-api
 
 # Public server origin only — do not include the /mcp path. Required in public
 # deployments so OAuth protected-resource metadata advertises the correct resource.

--- a/libraries/typescript/packages/server/examples/auth/keycloak/README.md
+++ b/libraries/typescript/packages/server/examples/auth/keycloak/README.md
@@ -27,16 +27,17 @@ the validated access token.
 
 ### Audience validation
 
-For secure resource-server operation, set `KEYCLOAK_AUDIENCE` to the expected
-audience value (typically the API client ID or resource identifier). The server
-will reject access tokens that do not include this value in their `aud` claim.
+For secure resource-server operation, set
+`MCP_USE_OAUTH_KEYCLOAK_AUDIENCE` to the expected audience value (typically
+the API client ID or resource identifier). The server will reject access
+tokens that do not include this value in their `aud` claim.
 
 To configure Keycloak to include the audience claim:
 
 1. In the Keycloak admin console, navigate to the client scope assigned to
    your MCP client.
 2. Add an Audience protocol mapper with the target audience value matching
-   `KEYCLOAK_AUDIENCE`.
+   `MCP_USE_OAUTH_KEYCLOAK_AUDIENCE`.
 3. Ensure the mapper is included in the issued access tokens.
 
 ## Environment
@@ -44,9 +45,9 @@ To configure Keycloak to include the audience claim:
 Copy `.env.example` to `.env` and configure:
 
 ```sh
-KEYCLOAK_SERVER_URL=https://keycloak.example.com
-KEYCLOAK_REALM=mcp
-KEYCLOAK_AUDIENCE=mcp-api
+MCP_USE_OAUTH_KEYCLOAK_SERVER_URL=https://keycloak.example.com
+MCP_USE_OAUTH_KEYCLOAK_REALM=mcp
+MCP_USE_OAUTH_KEYCLOAK_AUDIENCE=mcp-api
 ```
 
 For deployments, set the same variables in the deployment environment.

--- a/libraries/typescript/packages/server/examples/auth/keycloak/src/index.ts
+++ b/libraries/typescript/packages/server/examples/auth/keycloak/src/index.ts
@@ -20,8 +20,8 @@ const getUserInfoOutputSchema = z.object({
   resource: z.string().nullable(),
 });
 
-const keycloakServerUrl = requireEnv("KEYCLOAK_SERVER_URL");
-const keycloakRealm = requireEnv("KEYCLOAK_REALM");
+const keycloakServerUrl = requireEnv("MCP_USE_OAUTH_KEYCLOAK_SERVER_URL");
+const keycloakRealm = requireEnv("MCP_USE_OAUTH_KEYCLOAK_REALM");
 
 const server = new MCPServer({
   name: "keycloak-auth-example",

--- a/libraries/typescript/packages/server/examples/auth/keycloak/src/index.ts
+++ b/libraries/typescript/packages/server/examples/auth/keycloak/src/index.ts
@@ -20,9 +20,6 @@ const getUserInfoOutputSchema = z.object({
   resource: z.string().nullable(),
 });
 
-const keycloakServerUrl = requireEnv("MCP_USE_OAUTH_KEYCLOAK_SERVER_URL");
-const keycloakRealm = requireEnv("MCP_USE_OAUTH_KEYCLOAK_REALM");
-
 const server = new MCPServer({
   name: "keycloak-auth-example",
   version: "1.0.0",
@@ -30,10 +27,7 @@ const server = new MCPServer({
   description:
     "An MCP resource server that verifies Keycloak access tokens directly.",
   publicLandingPage: true,
-  oauth: oauthKeycloakProvider({
-    serverUrl: keycloakServerUrl,
-    realm: keycloakRealm,
-  }),
+  oauth: oauthKeycloakProvider(),
 });
 
 server.tool(
@@ -69,13 +63,5 @@ server.tool(
     };
   }
 );
-
-function requireEnv(name: string): string {
-  const value = process.env[name]?.trim();
-  if (value === undefined || value === "") {
-    throw new Error(`${name} must be set`);
-  }
-  return value;
-}
 
 export default server;

--- a/libraries/typescript/packages/server/examples/auth/keycloak/src/index.ts
+++ b/libraries/typescript/packages/server/examples/auth/keycloak/src/index.ts
@@ -20,10 +20,6 @@ const getUserInfoOutputSchema = z.object({
   resource: z.string().nullable(),
 });
 
-const serverUrl = requiredEnvironmentValue("MCP_USE_OAUTH_KEYCLOAK_SERVER_URL");
-const realm = requiredEnvironmentValue("MCP_USE_OAUTH_KEYCLOAK_REALM");
-const audience = requiredEnvironmentValue("MCP_USE_OAUTH_KEYCLOAK_AUDIENCE");
-
 const server = new MCPServer({
   name: "keycloak-auth-example",
   version: "1.0.0",
@@ -31,7 +27,11 @@ const server = new MCPServer({
   description:
     "An MCP resource server that verifies Keycloak access tokens directly.",
   publicLandingPage: true,
-  oauth: oauthKeycloakProvider({ serverUrl, realm, audience }),
+  oauth: oauthKeycloakProvider({
+    serverUrl: process.env.MCP_USE_OAUTH_KEYCLOAK_SERVER_URL!,
+    realm: process.env.MCP_USE_OAUTH_KEYCLOAK_REALM!,
+    audience: process.env.MCP_USE_OAUTH_KEYCLOAK_AUDIENCE!,
+  }),
 });
 
 server.tool(
@@ -67,13 +67,5 @@ server.tool(
     };
   }
 );
-
-function requiredEnvironmentValue(name: string): string {
-  const value = process.env[name]?.trim();
-  if (value === undefined || value.length === 0) {
-    throw new Error(`${name} is required`);
-  }
-  return value;
-}
 
 export default server;

--- a/libraries/typescript/packages/server/examples/auth/keycloak/src/index.ts
+++ b/libraries/typescript/packages/server/examples/auth/keycloak/src/index.ts
@@ -20,6 +20,10 @@ const getUserInfoOutputSchema = z.object({
   resource: z.string().nullable(),
 });
 
+const serverUrl = requiredEnvironmentValue("MCP_USE_OAUTH_KEYCLOAK_SERVER_URL");
+const realm = requiredEnvironmentValue("MCP_USE_OAUTH_KEYCLOAK_REALM");
+const audience = requiredEnvironmentValue("MCP_USE_OAUTH_KEYCLOAK_AUDIENCE");
+
 const server = new MCPServer({
   name: "keycloak-auth-example",
   version: "1.0.0",
@@ -27,7 +31,7 @@ const server = new MCPServer({
   description:
     "An MCP resource server that verifies Keycloak access tokens directly.",
   publicLandingPage: true,
-  oauth: oauthKeycloakProvider(),
+  oauth: oauthKeycloakProvider({ serverUrl, realm, audience }),
 });
 
 server.tool(
@@ -63,5 +67,13 @@ server.tool(
     };
   }
 );
+
+function requiredEnvironmentValue(name: string): string {
+  const value = process.env[name]?.trim();
+  if (value === undefined || value.length === 0) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
 
 export default server;

--- a/libraries/typescript/packages/server/examples/auth/supabase/.env.example
+++ b/libraries/typescript/packages/server/examples/auth/supabase/.env.example
@@ -1,15 +1,15 @@
 # Choose one Supabase project identifier:
-SUPABASE_PROJECT_ID=your-project-ref
-# SUPABASE_URL=https://your-project-ref.supabase.co
+MCP_USE_OAUTH_SUPABASE_PROJECT_ID=your-project-ref
+# MCP_USE_OAUTH_SUPABASE_URL=https://your-project-ref.supabase.co
 
 # Publishable key (sb_publishable_...). This is the modern replacement for the
 # legacy anon JWT key. Find it under Project Settings → API Keys.
 # Required by the consent UI hosted at /auth/consent.
-SUPABASE_PUBLISHABLE_KEY=sb_publishable_...
+MCP_USE_OAUTH_SUPABASE_PUBLISHABLE_KEY=sb_publishable_...
 
 # Optional: required only for legacy HS256 Supabase JWTs. It must be at least
 # 32 bytes. When omitted, the server verifies ES256 tokens through Supabase JWKS.
-# SUPABASE_JWT_SECRET=
+# MCP_USE_OAUTH_SUPABASE_JWT_SECRET=
 
 # Public server origin only — do not include the /mcp path. Required outside
 # local development so OAuth protected-resource metadata advertises the correct resource.

--- a/libraries/typescript/packages/server/examples/auth/supabase/README.md
+++ b/libraries/typescript/packages/server/examples/auth/supabase/README.md
@@ -18,18 +18,20 @@ It exposes one read-only tool:
 
 Copy `.env.example` to `.env` and configure one of:
 
-- `SUPABASE_PROJECT_ID` — the project reference, such as `abcd1234`
-- `SUPABASE_URL` — the full project URL, such as
+- `MCP_USE_OAUTH_SUPABASE_PROJECT_ID` — the project reference, such as
+  `abcd1234`
+- `MCP_USE_OAUTH_SUPABASE_URL` — the full project URL, such as
   `https://abcd1234.supabase.co`
 
 Also set:
 
-- `SUPABASE_PUBLISHABLE_KEY` — the publishable key (`sb_publishable_...`) from
-  Project Settings → API Keys. Required by the consent UI.
+- `MCP_USE_OAUTH_SUPABASE_PUBLISHABLE_KEY` — the publishable key
+  (`sb_publishable_...`) from Project Settings → API Keys. Required by the
+  consent UI.
 
-`SUPABASE_JWT_SECRET` is optional and only needed for legacy HS256 Supabase
-JWTs. If set, it must be at least 32 bytes. Without it, this example verifies
-ES256 tokens using the project's Supabase JWKS endpoint.
+`MCP_USE_OAUTH_SUPABASE_JWT_SECRET` is optional and only needed for legacy
+HS256 Supabase JWTs. If set, it must be at least 32 bytes. Without it, this
+example verifies ES256 tokens using the project's Supabase JWKS endpoint.
 
 For a deployed server, set `MCP_URL` to its public origin, for example
 `https://mcp.example.com`. The framework derives the protected resource URL as

--- a/libraries/typescript/packages/server/examples/auth/supabase/src/index.ts
+++ b/libraries/typescript/packages/server/examples/auth/supabase/src/index.ts
@@ -49,6 +49,7 @@ const getUserInfoOutputSchema = z.object({
 
 const projectId = environmentValue("MCP_USE_OAUTH_SUPABASE_PROJECT_ID");
 const supabaseUrlEnv = environmentValue("MCP_USE_OAUTH_SUPABASE_URL");
+const jwtSecret = environmentValue("MCP_USE_OAUTH_SUPABASE_JWT_SECRET");
 const publishableKey = environmentValue(
   "MCP_USE_OAUTH_SUPABASE_PUBLISHABLE_KEY"
 );
@@ -74,7 +75,11 @@ const server = new MCPServer({
   description:
     "Returns verified Supabase identity and authorization metadata for the caller.",
   publicLandingPage: true,
-  oauth: oauthSupabaseProvider(),
+  oauth: oauthSupabaseProvider({
+    ...(projectId !== undefined && { projectId }),
+    ...(supabaseUrlEnv !== undefined && { supabaseUrl: supabaseUrlEnv }),
+    ...(jwtSecret !== undefined && { jwtSecret }),
+  }),
 });
 
 server.tool(

--- a/libraries/typescript/packages/server/examples/auth/supabase/src/index.ts
+++ b/libraries/typescript/packages/server/examples/auth/supabase/src/index.ts
@@ -47,20 +47,22 @@ const getUserInfoOutputSchema = z.object({
   resource: z.string().nullable(),
 });
 
-const projectId = environmentValue("SUPABASE_PROJECT_ID");
-const supabaseUrlEnv = environmentValue("SUPABASE_URL");
-const jwtSecret = environmentValue("SUPABASE_JWT_SECRET");
-const publishableKey = environmentValue("SUPABASE_PUBLISHABLE_KEY");
+const projectId = environmentValue("MCP_USE_OAUTH_SUPABASE_PROJECT_ID");
+const supabaseUrlEnv = environmentValue("MCP_USE_OAUTH_SUPABASE_URL");
+const jwtSecret = environmentValue("MCP_USE_OAUTH_SUPABASE_JWT_SECRET");
+const publishableKey = environmentValue(
+  "MCP_USE_OAUTH_SUPABASE_PUBLISHABLE_KEY"
+);
 
 if (projectId === undefined && supabaseUrlEnv === undefined) {
   throw new Error(
-    "Missing Supabase configuration: set SUPABASE_PROJECT_ID or SUPABASE_URL."
+    "Missing Supabase configuration: set MCP_USE_OAUTH_SUPABASE_PROJECT_ID or MCP_USE_OAUTH_SUPABASE_URL."
   );
 }
 
 if (publishableKey === undefined) {
   throw new Error(
-    "Missing SUPABASE_PUBLISHABLE_KEY environment variable (required for the consent UI)."
+    "Missing MCP_USE_OAUTH_SUPABASE_PUBLISHABLE_KEY environment variable (required for the consent UI)."
   );
 }
 

--- a/libraries/typescript/packages/server/examples/auth/supabase/src/index.ts
+++ b/libraries/typescript/packages/server/examples/auth/supabase/src/index.ts
@@ -49,7 +49,6 @@ const getUserInfoOutputSchema = z.object({
 
 const projectId = environmentValue("MCP_USE_OAUTH_SUPABASE_PROJECT_ID");
 const supabaseUrlEnv = environmentValue("MCP_USE_OAUTH_SUPABASE_URL");
-const jwtSecret = environmentValue("MCP_USE_OAUTH_SUPABASE_JWT_SECRET");
 const publishableKey = environmentValue(
   "MCP_USE_OAUTH_SUPABASE_PUBLISHABLE_KEY"
 );
@@ -75,11 +74,7 @@ const server = new MCPServer({
   description:
     "Returns verified Supabase identity and authorization metadata for the caller.",
   publicLandingPage: true,
-  oauth: oauthSupabaseProvider({
-    ...(projectId !== undefined && { projectId }),
-    ...(supabaseUrlEnv !== undefined && { supabaseUrl: supabaseUrlEnv }),
-    ...(jwtSecret !== undefined && { jwtSecret }),
-  }),
+  oauth: oauthSupabaseProvider(),
 });
 
 server.tool(

--- a/libraries/typescript/packages/server/examples/auth/workos/.env.example
+++ b/libraries/typescript/packages/server/examples/auth/workos/.env.example
@@ -1,8 +1,8 @@
 # Required: your AuthKit subdomain (hostname or HTTPS origin).
-WORKOS_SUBDOMAIN=your-company.authkit.app
+MCP_USE_OAUTH_WORKOS_SUBDOMAIN=your-company.authkit.app
 
 # Optional: expected access-token audience.
-# WORKOS_AUDIENCE=https://api.example.com
+# MCP_USE_OAUTH_WORKOS_AUDIENCE=https://api.example.com
 
 # Optional: the public MCP server origin, for deployments outside localhost.
 # MCP_URL=https://mcp.example.com

--- a/libraries/typescript/packages/server/examples/auth/workos/.env.example
+++ b/libraries/typescript/packages/server/examples/auth/workos/.env.example
@@ -1,8 +1,5 @@
 # Required: your AuthKit subdomain (hostname or HTTPS origin).
 MCP_USE_OAUTH_WORKOS_SUBDOMAIN=your-company.authkit.app
 
-# Optional: expected access-token audience.
-# MCP_USE_OAUTH_WORKOS_AUDIENCE=https://api.example.com
-
 # Optional: the public MCP server origin, for deployments outside localhost.
 # MCP_URL=https://mcp.example.com

--- a/libraries/typescript/packages/server/examples/auth/workos/README.md
+++ b/libraries/typescript/packages/server/examples/auth/workos/README.md
@@ -18,14 +18,14 @@ cp .env.example .env
 ```
 
 ```dotenv
-WORKOS_SUBDOMAIN=your-company.authkit.app
-# WORKOS_AUDIENCE=https://api.example.com
+MCP_USE_OAUTH_WORKOS_SUBDOMAIN=your-company.authkit.app
+# MCP_USE_OAUTH_WORKOS_AUDIENCE=https://api.example.com
 ```
 
-`WORKOS_SUBDOMAIN` may be either the AuthKit hostname or its HTTPS origin.
-Set `WORKOS_AUDIENCE` only when your AuthKit access tokens have a required
-audience. For a public deployment, set `MCP_URL` to the public MCP server
-origin as shown in `.env.example`.
+`MCP_USE_OAUTH_WORKOS_SUBDOMAIN` may be either the AuthKit hostname or its
+HTTPS origin. Set `MCP_USE_OAUTH_WORKOS_AUDIENCE` only when your AuthKit access
+tokens have a required audience. For a public deployment, set `MCP_URL` to the
+public MCP server origin as shown in `.env.example`.
 
 ## Run it
 

--- a/libraries/typescript/packages/server/examples/auth/workos/README.md
+++ b/libraries/typescript/packages/server/examples/auth/workos/README.md
@@ -19,13 +19,11 @@ cp .env.example .env
 
 ```dotenv
 MCP_USE_OAUTH_WORKOS_SUBDOMAIN=your-company.authkit.app
-# MCP_USE_OAUTH_WORKOS_AUDIENCE=https://api.example.com
 ```
 
 `MCP_USE_OAUTH_WORKOS_SUBDOMAIN` may be either the AuthKit hostname or its
-HTTPS origin. Set `MCP_USE_OAUTH_WORKOS_AUDIENCE` only when your AuthKit access
-tokens have a required audience. For a public deployment, set `MCP_URL` to the
-public MCP server origin as shown in `.env.example`.
+HTTPS origin. For a public deployment, set `MCP_URL` to the public MCP server
+origin as shown in `.env.example`.
 
 ## Run it
 

--- a/libraries/typescript/packages/server/examples/auth/workos/README.md
+++ b/libraries/typescript/packages/server/examples/auth/workos/README.md
@@ -25,6 +25,10 @@ MCP_USE_OAUTH_WORKOS_SUBDOMAIN=your-company.authkit.app
 HTTPS origin. For a public deployment, set `MCP_URL` to the public MCP server
 origin as shown in `.env.example`.
 
+In WorkOS, register the full public MCP endpoint, such as
+`https://mcp.example.com/mcp`, as the Resource Indicator. Use the actual MCP
+endpoint rather than the AuthKit hostname or another API identifier.
+
 ## Run it
 
 From this directory:

--- a/libraries/typescript/packages/server/examples/auth/workos/src/index.ts
+++ b/libraries/typescript/packages/server/examples/auth/workos/src/index.ts
@@ -25,6 +25,8 @@ const getUserInfoOutputSchema = z.object({
   }),
 });
 
+const subdomain = requiredEnvironmentValue("MCP_USE_OAUTH_WORKOS_SUBDOMAIN");
+
 const server = new MCPServer({
   name: "workos-auth-example",
   version: "1.0.0",
@@ -32,7 +34,7 @@ const server = new MCPServer({
   description:
     "An MCP server secured by verified WorkOS AuthKit access tokens.",
   publicLandingPage: true,
-  oauth: oauthWorkOSProvider(),
+  oauth: oauthWorkOSProvider({ subdomain }),
 });
 
 server.tool(
@@ -74,5 +76,13 @@ server.tool(
     };
   }
 );
+
+function requiredEnvironmentValue(name: string): string {
+  const value = process.env[name]?.trim();
+  if (value === undefined || value.length === 0) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
 
 export default server;

--- a/libraries/typescript/packages/server/examples/auth/workos/src/index.ts
+++ b/libraries/typescript/packages/server/examples/auth/workos/src/index.ts
@@ -25,8 +25,6 @@ const getUserInfoOutputSchema = z.object({
   }),
 });
 
-const subdomain = requiredEnvironmentValue("MCP_USE_OAUTH_WORKOS_SUBDOMAIN");
-
 const server = new MCPServer({
   name: "workos-auth-example",
   version: "1.0.0",
@@ -34,7 +32,9 @@ const server = new MCPServer({
   description:
     "An MCP server secured by verified WorkOS AuthKit access tokens.",
   publicLandingPage: true,
-  oauth: oauthWorkOSProvider({ subdomain }),
+  oauth: oauthWorkOSProvider({
+    subdomain: process.env.MCP_USE_OAUTH_WORKOS_SUBDOMAIN!,
+  }),
 });
 
 server.tool(
@@ -76,13 +76,5 @@ server.tool(
     };
   }
 );
-
-function requiredEnvironmentValue(name: string): string {
-  const value = process.env[name]?.trim();
-  if (value === undefined || value.length === 0) {
-    throw new Error(`${name} is required`);
-  }
-  return value;
-}
 
 export default server;

--- a/libraries/typescript/packages/server/examples/auth/workos/src/index.ts
+++ b/libraries/typescript/packages/server/examples/auth/workos/src/index.ts
@@ -25,14 +25,6 @@ const getUserInfoOutputSchema = z.object({
   }),
 });
 
-function requireEnv(name: string): string {
-  const value = process.env[name]?.trim();
-  if (value === undefined || value.length === 0) {
-    throw new Error(`${name} is required`);
-  }
-  return value;
-}
-
 const server = new MCPServer({
   name: "workos-auth-example",
   version: "1.0.0",
@@ -40,9 +32,7 @@ const server = new MCPServer({
   description:
     "An MCP server secured by verified WorkOS AuthKit access tokens.",
   publicLandingPage: true,
-  oauth: oauthWorkOSProvider({
-    subdomain: requireEnv("MCP_USE_OAUTH_WORKOS_SUBDOMAIN"),
-  }),
+  oauth: oauthWorkOSProvider(),
 });
 
 server.tool(

--- a/libraries/typescript/packages/server/examples/auth/workos/src/index.ts
+++ b/libraries/typescript/packages/server/examples/auth/workos/src/index.ts
@@ -41,7 +41,7 @@ const server = new MCPServer({
     "An MCP server secured by verified WorkOS AuthKit access tokens.",
   publicLandingPage: true,
   oauth: oauthWorkOSProvider({
-    subdomain: requireEnv("WORKOS_SUBDOMAIN"),
+    subdomain: requireEnv("MCP_USE_OAUTH_WORKOS_SUBDOMAIN"),
   }),
 });
 

--- a/libraries/typescript/packages/server/specs/AUTH_IMPLEMENTATION.md
+++ b/libraries/typescript/packages/server/specs/AUTH_IMPLEMENTATION.md
@@ -22,7 +22,7 @@ const server = new MCPServer({
   name: "acme-tools",
   version: "1.0.0",
   oauth: oauthClerkProvider({
-    frontendApiUrl: process.env.CLERK_FRONTEND_API_URL!,
+    frontendApiUrl: process.env.MCP_USE_OAUTH_CLERK_FRONTEND_API_URL!,
   }),
 });
 ```

--- a/libraries/typescript/packages/server/specs/AUTH_IMPLEMENTATION.md
+++ b/libraries/typescript/packages/server/specs/AUTH_IMPLEMENTATION.md
@@ -138,10 +138,17 @@ Before calling `requireBearerAuth`, mcp-use wraps the provider with
 `wrapOAuthTokenVerifier(provider, expectedResource?)`. The wrapper calls the
 provider verifier, asserts resource binding against the resolved canonical
 resource URL, then returns the final SDK-compatible `AuthInfo` with `extra`
-merged as `{ ...authInfo.extra, ...provider.mapAuthInfo(authInfo) }`. Binding
-succeeds when the token carries an RFC 8707 `resource` claim matching
-`expectedResource`, or when `authInfo.resource` is absent but audience
-validation was proven (an internal marker set by `createJwtVerifier`).
+merged as `{ ...authInfo.extra, ...provider.mapAuthInfo(authInfo) }`.
+
+JWT providers establish resource binding as follows. A token with an RFC 8707
+`resource` claim must match the canonical MCP resource, even when the provider
+has a separate audience configured. Without a `resource` claim, a configured
+provider audience requires `aud` to include that audience; otherwise, `aud`
+must include the canonical MCP resource. After either audience check succeeds,
+the verifier returns the canonical MCP resource in `AuthInfo.resource`. For
+built-in providers that expose an audience setting, an explicit option takes
+precedence over the corresponding
+`MCP_USE_OAUTH_<PROVIDER>_AUDIENCE` environment variable.
 Therefore every successful bearer-gate result has the typed mcp-use values
 before it reaches fetch middleware, `createMcpMount`, or the SDK callback. Custom providers use
 this same wrapper; they cannot omit the public `mapAuthInfo` callback or rely

--- a/libraries/typescript/packages/server/specs/AUTH_SPEC.md
+++ b/libraries/typescript/packages/server/specs/AUTH_SPEC.md
@@ -431,10 +431,17 @@ Before calling `requireBearerAuth`, mcp-use wraps the provider with
 `wrapOAuthTokenVerifier(provider, expectedResource?)`. The wrapper calls the
 provider verifier, asserts resource binding against the resolved canonical
 resource URL, then returns the final SDK-compatible `AuthInfo` with `extra`
-merged as `{ ...authInfo.extra, ...provider.mapAuthInfo(authInfo) }`. Binding
-succeeds when the token carries an RFC 8707 `resource` claim matching
-`expectedResource`, or when `authInfo.resource` is absent but audience
-validation was proven (an internal marker set by `createJwtVerifier`).
+merged as `{ ...authInfo.extra, ...provider.mapAuthInfo(authInfo) }`.
+
+JWT providers establish resource binding as follows. A token with an RFC 8707
+`resource` claim must match the canonical MCP resource, even when the provider
+has a separate audience configured. Without a `resource` claim, a configured
+provider audience requires `aud` to include that audience; otherwise, `aud`
+must include the canonical MCP resource. After either audience check succeeds,
+the verifier returns the canonical MCP resource in `AuthInfo.resource`. For
+built-in providers that expose an audience setting, an explicit option takes
+precedence over the corresponding
+`MCP_USE_OAUTH_<PROVIDER>_AUDIENCE` environment variable.
 Therefore every successful bearer-gate result has the typed mcp-use values
 before it reaches fetch middleware, `createMcpMount`, or the SDK callback. Custom providers use
 this same wrapper; they cannot omit the public `mapAuthInfo` callback or rely

--- a/libraries/typescript/packages/server/specs/AUTH_SPEC.md
+++ b/libraries/typescript/packages/server/specs/AUTH_SPEC.md
@@ -22,7 +22,7 @@ const server = new MCPServer({
   name: "acme-tools",
   version: "1.0.0",
   oauth: oauthClerkProvider({
-    frontendApiUrl: process.env.CLERK_FRONTEND_API_URL!,
+    frontendApiUrl: process.env.MCP_USE_OAUTH_CLERK_FRONTEND_API_URL!,
   }),
 });
 ```

--- a/libraries/typescript/packages/server/src/oauth/auth0.ts
+++ b/libraries/typescript/packages/server/src/oauth/auth0.ts
@@ -12,6 +12,7 @@ import {
   stringValue,
 } from "./jwt.js";
 import {
+  oauthEnvironmentValue,
   oauthCustomProvider,
   type OAuthProvider,
   type OAuthResourceOptions,
@@ -31,7 +32,8 @@ export interface Auth0OAuthUser {
 
 /** Configures Auth0 JWT verification and protected-resource metadata. */
 export interface Auth0OAuthProviderOptions extends OAuthResourceOptions {
-  domain: URL | string;
+  domain?: URL | string;
+  audience?: string;
 }
 
 /**
@@ -41,9 +43,23 @@ export interface Auth0OAuthProviderOptions extends OAuthResourceOptions {
  * @returns A provider that rejects tokens not issued for the resolved MCP resource.
  */
 export function oauthAuth0Provider(
-  options: Auth0OAuthProviderOptions
+  options: Auth0OAuthProviderOptions = {}
 ): OAuthProvider<Auth0OAuthUser> {
-  const issuer = normalizedProviderUrl(options.domain, "Auth0 domain").href;
+  const domain =
+    options.domain ?? oauthEnvironmentValue("MCP_USE_OAUTH_AUTH0_DOMAIN");
+  if (domain === undefined) {
+    throw new Error(
+      "Auth0 domain is required. Set MCP_USE_OAUTH_AUTH0_DOMAIN or pass domain in config."
+    );
+  }
+  const audience =
+    options.audience ?? oauthEnvironmentValue("MCP_USE_OAUTH_AUTH0_AUDIENCE");
+  if (audience === undefined) {
+    throw new Error(
+      "Auth0 audience is required. Set MCP_USE_OAUTH_AUTH0_AUDIENCE or pass audience in config."
+    );
+  }
+  const issuer = normalizedProviderUrl(domain, "Auth0 domain").href;
   return oauthCustomProvider<Auth0OAuthUser>({
     ...options,
     createTokenVerifier: (resource) =>
@@ -51,6 +67,7 @@ export function oauthAuth0Provider(
         issuer,
         jwksUrl: new URL(providerEndpoint(issuer, ".well-known/jwks.json")),
         resource,
+        audience,
       }),
     oauthMetadata: {
       issuer,

--- a/libraries/typescript/packages/server/src/oauth/better-auth.ts
+++ b/libraries/typescript/packages/server/src/oauth/better-auth.ts
@@ -12,6 +12,7 @@ import {
   stringValue,
 } from "./jwt.js";
 import {
+  oauthEnvironmentValue,
   oauthCustomProvider,
   type OAuthProvider,
   type OAuthResourceOptions,
@@ -32,7 +33,7 @@ export interface BetterAuthOAuthUser {
 /** Configures Better Auth JWT verification and protected-resource metadata. */
 export interface BetterAuthOAuthProviderOptions extends OAuthResourceOptions {
   /** Full Better Auth issuer URL, including its base path. */
-  authURL: URL | string;
+  authURL?: URL | string;
 }
 
 /**
@@ -46,10 +47,17 @@ export interface BetterAuthOAuthProviderOptions extends OAuthResourceOptions {
  * @returns A provider that rejects tokens not issued for the resolved MCP resource.
  */
 export function oauthBetterAuthProvider(
-  options: BetterAuthOAuthProviderOptions
+  options: BetterAuthOAuthProviderOptions = {}
 ): OAuthProvider<BetterAuthOAuthUser> {
+  const authURL =
+    options.authURL ?? oauthEnvironmentValue("MCP_USE_OAUTH_BETTER_AUTH_URL");
+  if (authURL === undefined) {
+    throw new Error(
+      "Better Auth authURL is required. Set MCP_USE_OAUTH_BETTER_AUTH_URL or pass authURL in config."
+    );
+  }
   const issuer = normalizedProviderUrl(
-    options.authURL,
+    authURL,
     "Better Auth authURL"
   ).href.replace(/\/$/, "");
 

--- a/libraries/typescript/packages/server/src/oauth/clerk.ts
+++ b/libraries/typescript/packages/server/src/oauth/clerk.ts
@@ -12,6 +12,7 @@ import {
   stringValue,
 } from "./jwt.js";
 import {
+  oauthEnvironmentValue,
   oauthCustomProvider,
   type OAuthProvider,
   type OAuthResourceOptions,
@@ -33,7 +34,7 @@ export interface ClerkOAuthUser {
 
 /** Configures Clerk JWT verification and protected-resource metadata. */
 export interface ClerkOAuthProviderOptions extends OAuthResourceOptions {
-  frontendApiUrl: URL | string;
+  frontendApiUrl?: URL | string;
 }
 
 /**
@@ -43,10 +44,18 @@ export interface ClerkOAuthProviderOptions extends OAuthResourceOptions {
  * @returns A provider that rejects tokens not issued for the resolved MCP resource.
  */
 export function oauthClerkProvider(
-  options: ClerkOAuthProviderOptions
+  options: ClerkOAuthProviderOptions = {}
 ): OAuthProvider<ClerkOAuthUser> {
+  const frontendApiUrl =
+    options.frontendApiUrl ??
+    oauthEnvironmentValue("MCP_USE_OAUTH_CLERK_FRONTEND_API_URL");
+  if (frontendApiUrl === undefined) {
+    throw new Error(
+      "Clerk frontendApiUrl is required. Set MCP_USE_OAUTH_CLERK_FRONTEND_API_URL or pass frontendApiUrl in config."
+    );
+  }
   const issuer = normalizedProviderUrl(
-    options.frontendApiUrl,
+    frontendApiUrl,
     "Clerk frontendApiUrl"
   ).href.replace(/\/$/, "");
   return oauthCustomProvider<ClerkOAuthUser>({

--- a/libraries/typescript/packages/server/src/oauth/jwt.ts
+++ b/libraries/typescript/packages/server/src/oauth/jwt.ts
@@ -21,6 +21,8 @@ export interface JwtVerifierOptions {
   issuer: string;
   jwksUrl: URL;
   resource: URL;
+  /** Provider-specific JWT audience, when it differs from the canonical MCP resource. */
+  audience?: string;
   algorithms?: readonly string[];
   key?: Uint8Array;
 }
@@ -38,6 +40,9 @@ export function createJwtVerifier(
       try {
         const { payload } = await jwtVerify(token, key as JWTVerifyGetKey, {
           issuer: options.issuer,
+          ...(options.audience !== undefined && {
+            audience: options.audience,
+          }),
           ...(options.algorithms !== undefined && {
             algorithms: [...options.algorithms],
           }),
@@ -51,7 +56,11 @@ export function createJwtVerifier(
         const clientId =
           requiredString(claims, "client_id") ?? requiredString(claims, "azp");
         const expiresAt = requiredFutureNumber(claims, "exp");
-        const resource = verifiedResource(claims, configuredResource);
+        const resource = verifiedResource(
+          claims,
+          configuredResource,
+          options.audience !== undefined
+        );
 
         return {
           token,
@@ -199,7 +208,8 @@ export function invalidToken(message: string, cause?: unknown): OAuthError {
 
 function verifiedResource(
   claims: VerifiedPayload,
-  configuredResource: URL
+  configuredResource: URL,
+  providerAudienceWasValidated: boolean
 ): URL {
   const value = claims["resource"];
   if (value !== undefined) {
@@ -212,6 +222,13 @@ function verifiedResource(
         "Token resource claim does not match protected resource"
       );
     }
+    return configuredResource;
+  }
+
+  // The provider-specific audience was already validated by jose. Preserve
+  // the canonical MCP resource for the outer verifier without requiring the
+  // provider's audience identifier to equal the MCP endpoint URL.
+  if (providerAudienceWasValidated) {
     return configuredResource;
   }
 

--- a/libraries/typescript/packages/server/src/oauth/keycloak.ts
+++ b/libraries/typescript/packages/server/src/oauth/keycloak.ts
@@ -14,6 +14,7 @@ import {
   stringValue,
 } from "./jwt.js";
 import {
+  oauthEnvironmentValue,
   oauthCustomProvider,
   type OAuthProvider,
   type OAuthResourceOptions,
@@ -35,8 +36,9 @@ export interface KeycloakOAuthUser {
 
 /** Configures Keycloak JWT verification and protected-resource metadata. */
 export interface KeycloakOAuthProviderOptions extends OAuthResourceOptions {
-  serverUrl: URL | string;
-  realm: string;
+  serverUrl?: URL | string;
+  realm?: string;
+  audience?: string;
 }
 
 /**
@@ -46,22 +48,34 @@ export interface KeycloakOAuthProviderOptions extends OAuthResourceOptions {
  * @returns A provider that rejects tokens not issued for the resolved MCP resource.
  */
 export function oauthKeycloakProvider(
-  options: KeycloakOAuthProviderOptions
+  options: KeycloakOAuthProviderOptions = {}
 ): OAuthProvider<KeycloakOAuthUser> {
-  if (
-    typeof options.realm !== "string" ||
-    options.realm.trim().length === 0 ||
-    /[/?#]/.test(options.realm)
-  ) {
-    throw new TypeError("Keycloak realm is invalid");
+  const serverUrlValue =
+    options.serverUrl ??
+    oauthEnvironmentValue("MCP_USE_OAUTH_KEYCLOAK_SERVER_URL");
+  if (serverUrlValue === undefined) {
+    throw new Error(
+      "Keycloak serverUrl is required. Set MCP_USE_OAUTH_KEYCLOAK_SERVER_URL or pass serverUrl in config."
+    );
   }
-  const serverUrl = normalizedProviderUrl(
-    options.serverUrl,
-    "Keycloak serverUrl"
-  );
+  const realm =
+    options.realm ?? oauthEnvironmentValue("MCP_USE_OAUTH_KEYCLOAK_REALM");
+  if (
+    typeof realm !== "string" ||
+    realm.trim().length === 0 ||
+    /[/?#]/.test(realm)
+  ) {
+    throw new Error(
+      "Keycloak realm is required and must be valid. Set MCP_USE_OAUTH_KEYCLOAK_REALM or pass realm in config."
+    );
+  }
+  const audience =
+    options.audience ??
+    oauthEnvironmentValue("MCP_USE_OAUTH_KEYCLOAK_AUDIENCE");
+  const serverUrl = normalizedProviderUrl(serverUrlValue, "Keycloak serverUrl");
   const issuer = providerEndpoint(
     serverUrl,
-    `realms/${encodeURIComponent(options.realm)}`
+    `realms/${encodeURIComponent(realm)}`
   ).replace(/\/$/, "");
   return oauthCustomProvider<KeycloakOAuthUser>({
     ...options,
@@ -72,6 +86,7 @@ export function oauthKeycloakProvider(
           providerEndpoint(issuer, "protocol/openid-connect/certs")
         ),
         resource,
+        ...(audience !== undefined && { audience }),
       }),
     oauthMetadata: {
       issuer,

--- a/libraries/typescript/packages/server/src/oauth/provider.ts
+++ b/libraries/typescript/packages/server/src/oauth/provider.ts
@@ -45,6 +45,12 @@ export interface CustomOAuthProviderOptions<
 /** OAuth resource-server provider accepted by {@link MCPServer}. */
 export type OAuthProvider<TUser> = CustomOAuthProviderOptions<TUser>;
 
+/** @internal Reads a non-empty OAuth environment variable. */
+export function oauthEnvironmentValue(name: string): string | undefined {
+  const value = process.env[name];
+  return value === undefined || value.trim().length === 0 ? undefined : value;
+}
+
 /**
  * Creates an OAuth provider backed by an external authorization server.
  *

--- a/libraries/typescript/packages/server/src/oauth/supabase.ts
+++ b/libraries/typescript/packages/server/src/oauth/supabase.ts
@@ -12,6 +12,7 @@ import {
   stringValue,
 } from "./jwt.js";
 import {
+  oauthEnvironmentValue,
   oauthCustomProvider,
   type OAuthProvider,
   type OAuthResourceOptions,
@@ -51,16 +52,30 @@ export interface SupabaseOAuthProviderOptions extends OAuthResourceOptions {
  * @returns A provider that rejects tokens without a valid configured Supabase signature and issuer.
  */
 export function oauthSupabaseProvider(
-  options: SupabaseOAuthProviderOptions
+  options: SupabaseOAuthProviderOptions = {}
 ): OAuthProvider<SupabaseOAuthUser> {
-  const supabaseUrl = resolveSupabaseUrl(options);
+  const projectId =
+    options.projectId ??
+    oauthEnvironmentValue("MCP_USE_OAUTH_SUPABASE_PROJECT_ID");
+  const configuredUrl =
+    options.supabaseUrl ?? oauthEnvironmentValue("MCP_USE_OAUTH_SUPABASE_URL");
+  const jwtSecret =
+    options.jwtSecret ??
+    oauthEnvironmentValue("MCP_USE_OAUTH_SUPABASE_JWT_SECRET");
+  const resolvedOptions: SupabaseOAuthProviderOptions = {
+    ...options,
+    ...(projectId !== undefined && { projectId }),
+    ...(configuredUrl !== undefined && { supabaseUrl: configuredUrl }),
+    ...(jwtSecret !== undefined && { jwtSecret }),
+  };
+  const supabaseUrl = resolveSupabaseUrl(resolvedOptions);
   const issuer = providerEndpoint(supabaseUrl, "auth/v1").replace(/\/$/, "");
-  const secret = options.jwtSecret;
+  const secret = resolvedOptions.jwtSecret;
   if (secret !== undefined && new TextEncoder().encode(secret).length < 32) {
     throw new TypeError("Supabase jwtSecret must be at least 32 bytes");
   }
   return oauthCustomProvider<SupabaseOAuthUser>({
-    ...options,
+    ...resolvedOptions,
     createTokenVerifier: (resource) =>
       createJwtVerifier({
         issuer,

--- a/libraries/typescript/packages/server/src/oauth/workos.ts
+++ b/libraries/typescript/packages/server/src/oauth/workos.ts
@@ -12,6 +12,7 @@ import {
   stringValue,
 } from "./jwt.js";
 import {
+  oauthEnvironmentValue,
   oauthCustomProvider,
   type OAuthProvider,
   type OAuthResourceOptions,
@@ -34,7 +35,7 @@ export interface WorkOSOAuthUser {
 
 /** Configures WorkOS JWT verification and protected-resource metadata. */
 export interface WorkOSOAuthProviderOptions extends OAuthResourceOptions {
-  subdomain: string;
+  subdomain?: string;
 }
 
 /**
@@ -44,9 +45,17 @@ export interface WorkOSOAuthProviderOptions extends OAuthResourceOptions {
  * @returns A provider that rejects tokens not issued for the resolved MCP resource.
  */
 export function oauthWorkOSProvider(
-  options: WorkOSOAuthProviderOptions
+  options: WorkOSOAuthProviderOptions = {}
 ): OAuthProvider<WorkOSOAuthUser> {
-  const issuer = workosIssuer(options.subdomain);
+  const subdomain =
+    options.subdomain ??
+    oauthEnvironmentValue("MCP_USE_OAUTH_WORKOS_SUBDOMAIN");
+  if (subdomain === undefined) {
+    throw new Error(
+      "WorkOS subdomain is required. Set MCP_USE_OAUTH_WORKOS_SUBDOMAIN or pass subdomain in config."
+    );
+  }
+  const issuer = workosIssuer(subdomain);
   return oauthCustomProvider<WorkOSOAuthUser>({
     ...options,
     createTokenVerifier: (resource) =>

--- a/libraries/typescript/packages/server/tests/oauth-core.test.ts
+++ b/libraries/typescript/packages/server/tests/oauth-core.test.ts
@@ -232,6 +232,45 @@ describe("OAuth core", () => {
     }
   });
 
+  it("validates a provider audience separately from the protected resource", async () => {
+    const key = new TextEncoder().encode(
+      "a sufficiently long test signing key"
+    );
+    const issuer = "https://issuer.example.test";
+    const providerAudience = "provider-api";
+    const verifier = createJwtVerifier({
+      issuer,
+      jwksUrl: new URL(`${issuer}/.well-known/jwks.json`),
+      key,
+      algorithms: ["HS256"],
+      resource: canonicalResource,
+      audience: providerAudience,
+    });
+    const sign = (claims: Record<string, unknown>) =>
+      new SignJWT({ sub: "user-1", client_id: "client-1", ...claims })
+        .setProtectedHeader({ alg: "HS256" })
+        .setIssuer(issuer)
+        .setExpirationTime(Math.floor(Date.now() / 1000) + 60)
+        .sign(key);
+
+    await expect(
+      verifier.verifyAccessToken(await sign({ aud: providerAudience }))
+    ).resolves.toMatchObject({ resource: canonicalResource });
+
+    await expect(
+      verifier.verifyAccessToken(await sign({ aud: "other-api" }))
+    ).rejects.toMatchObject({ code: OAuthErrorCode.InvalidToken });
+
+    await expect(
+      verifier.verifyAccessToken(
+        await sign({
+          aud: providerAudience,
+          resource: "https://other.example/mcp",
+        })
+      )
+    ).rejects.toMatchObject({ code: OAuthErrorCode.InvalidToken });
+  });
+
   it("rejects verifier output that does not prove resource binding", async () => {
     const expectedResource = new URL("https://api.example.test/mcp");
     const provider = createProvider({

--- a/libraries/typescript/packages/server/tests/oauth-direct-providers.test.ts
+++ b/libraries/typescript/packages/server/tests/oauth-direct-providers.test.ts
@@ -1,5 +1,5 @@
 import { exportJWK, generateKeyPair, SignJWT } from "jose";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { oauthAuth0Provider } from "../src/oauth/auth0.js";
 import { oauthBetterAuthProvider } from "../src/oauth/better-auth.js";
@@ -12,12 +12,76 @@ import { oauthWorkOSProvider } from "../src/oauth/workos.js";
 const now = () => Math.floor(Date.now() / 1000);
 const originalFetch = globalThis.fetch;
 const protectedResource = new URL("https://api.example.test/mcp");
+const oauthEnvironmentNames = [
+  "MCP_USE_OAUTH_AUTH0_DOMAIN",
+  "MCP_USE_OAUTH_AUTH0_AUDIENCE",
+  "MCP_USE_OAUTH_BETTER_AUTH_URL",
+  "MCP_USE_OAUTH_CLERK_FRONTEND_API_URL",
+  "MCP_USE_OAUTH_KEYCLOAK_SERVER_URL",
+  "MCP_USE_OAUTH_KEYCLOAK_REALM",
+  "MCP_USE_OAUTH_KEYCLOAK_AUDIENCE",
+  "MCP_USE_OAUTH_SUPABASE_PROJECT_ID",
+  "MCP_USE_OAUTH_SUPABASE_URL",
+  "MCP_USE_OAUTH_SUPABASE_JWT_SECRET",
+  "MCP_USE_OAUTH_WORKOS_SUBDOMAIN",
+] as const;
+const originalOAuthEnvironment = new Map(
+  oauthEnvironmentNames.map((name) => [name, process.env[name]])
+);
+
+beforeEach(() => {
+  for (const name of oauthEnvironmentNames) delete process.env[name];
+});
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+  for (const name of oauthEnvironmentNames) {
+    const value = originalOAuthEnvironment.get(name);
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  }
 });
 
 describe("direct OAuth providers", () => {
+  it("uses v1 OAuth environment variables after explicit options", () => {
+    process.env["MCP_USE_OAUTH_AUTH0_DOMAIN"] = "env-auth0.example.test";
+    process.env["MCP_USE_OAUTH_AUTH0_AUDIENCE"] = "env-auth0-api";
+    process.env["MCP_USE_OAUTH_BETTER_AUTH_URL"] =
+      "https://env-better-auth.example.test/api/auth";
+    process.env["MCP_USE_OAUTH_CLERK_FRONTEND_API_URL"] =
+      "https://env-clerk.example.test";
+    process.env["MCP_USE_OAUTH_KEYCLOAK_SERVER_URL"] =
+      "https://env-keycloak.example.test";
+    process.env["MCP_USE_OAUTH_KEYCLOAK_REALM"] = "env-realm";
+    process.env["MCP_USE_OAUTH_SUPABASE_PROJECT_ID"] = "env-project";
+    process.env["MCP_USE_OAUTH_WORKOS_SUBDOMAIN"] = "env-workos.authkit.app";
+
+    expect(oauthAuth0Provider().oauthMetadata.issuer).toBe(
+      "https://env-auth0.example.test/"
+    );
+    expect(oauthBetterAuthProvider().oauthMetadata.issuer).toBe(
+      "https://env-better-auth.example.test/api/auth"
+    );
+    expect(oauthClerkProvider().oauthMetadata.issuer).toBe(
+      "https://env-clerk.example.test"
+    );
+    expect(oauthKeycloakProvider().oauthMetadata.issuer).toBe(
+      "https://env-keycloak.example.test/realms/env-realm"
+    );
+    expect(oauthSupabaseProvider().oauthMetadata.issuer).toBe(
+      "https://env-project.supabase.co/auth/v1"
+    );
+    expect(oauthWorkOSProvider().oauthMetadata.issuer).toBe(
+      "https://env-workos.authkit.app"
+    );
+
+    expect(
+      oauthClerkProvider({
+        frontendApiUrl: "https://code-clerk.example.test",
+      }).oauthMetadata.issuer
+    ).toBe("https://code-clerk.example.test");
+  });
+
   it("verifies Better Auth JWTs and preserves issuer path prefixes", async () => {
     const { privateKey, publicKey } = await generateKeyPair("EdDSA");
     const jwk = await exportJWK(publicKey);
@@ -109,6 +173,7 @@ describe("direct OAuth providers", () => {
 
     const provider = oauthAuth0Provider({
       domain: "issuer.example.test",
+      audience: "https://api.example.test/mcp",
       resource: "https://api.example.test/mcp",
     });
     const sign = (claims: Record<string, unknown> = {}) =>
@@ -264,6 +329,7 @@ describe("direct OAuth providers", () => {
     expect(() =>
       oauthAuth0Provider({
         domain: "issuer.example.test",
+        audience: protectedResource.href,
         resource: "http://api.example.test/mcp",
       })
     ).toThrow(/HTTPS|localhost/);
@@ -462,6 +528,7 @@ describe("direct OAuth providers", () => {
     };
     const provider = oauthAuth0Provider({
       domain: "issuer.example.test",
+      audience: protectedResource.href,
     });
     await expect(
       provider.createTokenVerifier(protectedResource).verifyAccessToken(

--- a/libraries/typescript/packages/server/tests/oauth-direct-providers.test.ts
+++ b/libraries/typescript/packages/server/tests/oauth-direct-providers.test.ts
@@ -486,12 +486,13 @@ describe("direct OAuth providers", () => {
     });
   });
 
-  it("accepts Keycloak audience-only tokens when a protected resource is expected", async () => {
+  it("uses the Keycloak audience environment variable for token verification", async () => {
     const { privateKey, publicKey } = await generateKeyPair("RS256");
     const jwk = await exportJWK(publicKey);
     jwk.kid = "keycloak-key";
     globalThis.fetch = jwksFixture(jwk);
     const expectedResource = new URL("https://api.example.test/mcp");
+    process.env["MCP_USE_OAUTH_KEYCLOAK_AUDIENCE"] = "env-mcp-api";
     const provider = oauthKeycloakProvider({
       serverUrl: "https://keycloak.example.test/auth",
       realm: "mcp",
@@ -501,7 +502,7 @@ describe("direct OAuth providers", () => {
       privateKey,
       "keycloak-key",
       "https://keycloak.example.test/auth/realms/mcp",
-      expectedResource.href,
+      "env-mcp-api",
       {
         sub: "keycloak-user",
         client_id: "client",
@@ -519,6 +520,38 @@ describe("direct OAuth providers", () => {
       resource: expectedResource,
       extra: { user: { roles: ["realm-role"] }, permissions: ["api:write"] },
     });
+  });
+
+  it("prefers an explicit Keycloak audience and rejects other audiences", async () => {
+    const { privateKey, publicKey } = await generateKeyPair("RS256");
+    const jwk = await exportJWK(publicKey);
+    jwk.kid = "keycloak-key";
+    globalThis.fetch = jwksFixture(jwk);
+    process.env["MCP_USE_OAUTH_KEYCLOAK_AUDIENCE"] = "env-mcp-api";
+    const issuer = "https://keycloak.example.test/auth/realms/mcp";
+    const provider = oauthKeycloakProvider({
+      serverUrl: "https://keycloak.example.test/auth",
+      realm: "mcp",
+      audience: "explicit-mcp-api",
+    });
+    const verifier = wrapOAuthTokenVerifier(provider, protectedResource);
+    const token = (audience: string) =>
+      signedToken(privateKey, "keycloak-key", issuer, audience, {
+        sub: "keycloak-user",
+        client_id: "client",
+      });
+
+    await expect(
+      verifier.verifyAccessToken(await token("explicit-mcp-api"))
+    ).resolves.toMatchObject({
+      clientId: "client",
+      resource: protectedResource,
+    });
+    for (const audience of ["env-mcp-api", "wrong-mcp-api"]) {
+      await expect(
+        verifier.verifyAccessToken(await token(audience))
+      ).rejects.toMatchObject({ code: "invalid_token" });
+    }
   });
 
   it("leaves unexpected JWKS network errors as ordinary errors", async () => {

--- a/libraries/typescript/packages/server/tests/oauth-wiring-types.test.ts
+++ b/libraries/typescript/packages/server/tests/oauth-wiring-types.test.ts
@@ -138,6 +138,7 @@ function verifyOAuthCallbackTyping(): void {
     version: "1.0.0",
     oauth: oauthAuth0Provider({
       domain: "https://tenant.auth0.com",
+      audience: "https://api.example.test/mcp",
     }),
   });
   auth0.tool({ name: "auth0-user" }, (_params, ctx) => {


### PR DESCRIPTION
## Summary
- Prefix OAuth provider environment variables with `MCP_USE_OAUTH` across Auth0, Better Auth, Clerk, Keycloak, Supabase, and WorkOS examples
- Update example documentation, configuration templates, and auth implementation specs

## Testing
- Not run (not requested)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes OAuth environment variables across `Auth0`, `Better Auth`, `Clerk`, `Keycloak`, `Supabase`, and `WorkOS` examples with `MCP_USE_OAUTH_*` prefixes. Providers now auto-configure from these env vars by default; explicit options are optional and override env. Audience validation is separated from resource binding, with clear, consistent checks.

- **New Features**
  - Auto-resolve provider config from `MCP_USE_OAUTH_*`; missing required env vars throw clear errors. Auth0 requires `domain` and `audience`; Keycloak supports an optional `audience`.
  - JWT handling: provider-specific `audience` is validated separately from the MCP resource. A `resource` claim must match the canonical MCP endpoint; without it, either the provider `audience` or the canonical resource must be in `aud`. Explicit `audience` options override env.
  - Examples simplified to read `MCP_USE_OAUTH_*` directly; removed local env helpers. Updated docs and specs; dropped obsolete audience examples for Clerk and WorkOS, and clarified WorkOS Resource Indicator setup.

- **Migration**
  - Rename env vars to `MCP_USE_OAUTH_*`: `AUTH0_DOMAIN` → `MCP_USE_OAUTH_AUTH0_DOMAIN`; `AUTH0_AUDIENCE` → `MCP_USE_OAUTH_AUTH0_AUDIENCE`; `CLERK_FRONTEND_API_URL` → `MCP_USE_OAUTH_CLERK_FRONTEND_API_URL`; `WORKOS_SUBDOMAIN` → `MCP_USE_OAUTH_WORKOS_SUBDOMAIN`; `KEYCLOAK_*` → `MCP_USE_OAUTH_KEYCLOAK_*`; `SUPABASE_*` → `MCP_USE_OAUTH_SUPABASE_*`; `BETTER_AUTH_URL` → `MCP_USE_OAUTH_BETTER_AUTH_URL`.
  - Remove `CLERK_AUDIENCE` and `WORKOS_AUDIENCE`.

<sup>Written for commit 4aa96ddee841bd093ff3a7fd80f00dd7503ae1a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

