### PR TITLE
Include auth example env files in worktrees

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,5 @@
+libraries/typescript/packages/server/examples/auth/auth0/.env
+libraries/typescript/packages/server/examples/auth/better-auth/.env
+libraries/typescript/packages/server/examples/auth/clerk/.env
+libraries/typescript/packages/server/examples/auth/supabase/.env
+libraries/typescript/packages/server/examples/auth/workos/.env


### PR DESCRIPTION
## Summary

- add a root `.worktreeinclude`
- include local `.env` files for the Auth0, Better Auth, Clerk, Supabase, and WorkOS examples
- leave Keycloak out until its local environment is configured

## Why

The auth example environment files are intentionally Git-ignored, so new worktrees did not carry the configured local provider settings. Listing them in `.worktreeinclude` preserves those local files when creating worktrees without committing credentials or provider configuration.

## Impact

Developers using these configured auth examples can create a new worktree without manually copying the five local environment files. The `.env` contents remain untracked.

## Validation

- redacted validation confirmed every required variable is present, non-empty, and non-placeholder
- `pnpm typecheck` passed for Auth0, Better Auth, Clerk, Supabase, and WorkOS
- pre-commit checks passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a root `.worktreeinclude` to preserve local `.env` files for the Auth0, Better Auth, Clerk, Supabase, and WorkOS auth examples when creating Git worktrees. Keycloak is excluded until its local environment is configured; `.env` files stay untracked.

<sup>Written for commit 7c8a10c17743eec8c1a2c09a94e0ba72cbfeb9f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

