### PR TITLE
fix inspector connection and OAuth routing

### DIFF
--- a/libraries/typescript/.changeset/inspector-connection-mode-proxy-policy.md
+++ b/libraries/typescript/.changeset/inspector-connection-mode-proxy-policy.md
@@ -1,0 +1,7 @@
+---
+"@mcp-use/client": patch
+"@mcp-use/inspector": patch
+"mcp-use": patch
+---
+
+Make Inspector connection modes authoritative for MCP proxy routing. Auto mode now attempts a direct browser connection before falling back to the configured CORS proxy, Direct mode never uses or falls back to the proxy, and Proxy mode uses it immediately. Clear stale proxy settings when an existing Inspector connection changes modes, keep the server's built-in Inspector on direct origin-level OAuth metadata discovery when no proxy backend is mounted, bypass the browser HTTP cache for OAuth metadata so Origin-specific CORS responses cannot be reused across Inspector origins, make the server-tile Authenticate action clear stored OAuth discovery before starting a fresh flow, and discard authorization-server-generated client secrets from public browser DCR results instead of persisting them.

--- a/libraries/typescript/packages/client/src/auth/browser.ts
+++ b/libraries/typescript/packages/client/src/auth/browser.ts
@@ -247,7 +247,7 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
       // their caller-provided cache behavior.
       if (!oauthProxyUrl) {
         return await base(
-          input,
+          isMetadata ? url : input,
           isMetadata ? { ...init, cache: "no-store" } : init
         );
       }

--- a/libraries/typescript/packages/client/src/auth/browser.ts
+++ b/libraries/typescript/packages/client/src/auth/browser.ts
@@ -198,22 +198,22 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
    * therefore never alters fetch behavior for other servers, other
    * connections, or the rest of the page.
    *
-   * When this provider is not configured to proxy OAuth requests (no
-   * `oauthProxyUrl`, or `proxyOAuthRequests` disabled), the provided
-   * `baseFetch` is returned as-is (or `undefined` when none is given, letting
-   * the SDK fall back to its default `fetch`).
+   * OAuth metadata is always fetched with `cache: "no-store"`, including in
+   * direct mode. Authorization servers commonly vary CORS headers by Origin;
+   * bypassing the browser HTTP cache prevents a revalidated response cached
+   * for another localhost origin from poisoning discovery. When OAuth proxying
+   * is disabled or no `oauthProxyUrl` is configured, all requests still go
+   * directly to their original URLs.
    *
    * @param baseFetch - The fetch used for non-OAuth requests and for the
    *   underlying proxy calls. Defaults to the global `fetch`.
    */
   getProxyFetch(baseFetch?: typeof fetch): typeof fetch | undefined {
-    if (!this.proxyOAuthRequests || !this.oauthProxyUrl) {
-      // Nothing to scope — return the caller's base fetch (possibly undefined).
-      return baseFetch;
-    }
-
     const base: typeof fetch = baseFetch ?? globalThis.fetch.bind(globalThis);
-    const oauthProxyUrl = this.oauthProxyUrl;
+    const oauthProxyUrl =
+      this.proxyOAuthRequests && this.oauthProxyUrl
+        ? this.oauthProxyUrl
+        : undefined;
     const discoveredEndpoints = new Set<string>();
     let restoredDiscovery = false;
 
@@ -240,6 +240,18 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
         return await base(input, init);
       }
       const isMetadata = pathname.includes("/.well-known/");
+
+      // Metadata responses can carry Origin-specific CORS headers. Never let
+      // the browser reuse or revalidate a response cached for another origin.
+      // This is scoped to discovery; MCP traffic and OAuth endpoint POSTs keep
+      // their caller-provided cache behavior.
+      if (!oauthProxyUrl) {
+        return await base(
+          input,
+          isMetadata ? { ...init, cache: "no-store" } : init
+        );
+      }
+
       if (!restoredDiscovery) {
         restoredDiscovery = true;
         const metadata = (await this.discoveryState())
@@ -292,6 +304,7 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
         const response = await base(proxyEndpoint, {
           ...init,
           method: "GET",
+          cache: "no-store",
         });
         try {
           const metadata = (await response.clone().json()) as Record<
@@ -378,7 +391,25 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
     // When a pre-registered client_id is configured, never persist DCR results
     // — the static client_id is the source of truth.
     if (this.staticClientInfo) return;
-    return this.session.saveClientInformation(clientInformation, ctx);
+
+    // Browser clients always register as public clients
+    // (`token_endpoint_auth_method: "none"`). Some authorization servers,
+    // including Auth0 DCR, still include a generated client_secret in the
+    // registration response even though the public client must not use or
+    // retain it. Persist only the public portion of the response. Keep the
+    // session store's secret rejection intact as a defense-in-depth guard for
+    // every other browser persistence path.
+    const { client_secret: discardedClientSecret, ...publicClientInformation } =
+      clientInformation;
+    if (discardedClientSecret) {
+      console.info(
+        `[${this.storageKeyPrefix}] Discarded client_secret returned for a public browser OAuth client.`
+      );
+    }
+    return this.session.saveClientInformation(
+      publicClientInformation as OAuthClientInformation,
+      ctx
+    );
   }
 
   codeVerifier(): Promise<string> {

--- a/libraries/typescript/packages/client/src/react/types.ts
+++ b/libraries/typescript/packages/client/src/react/types.ts
@@ -71,9 +71,13 @@ export type UseMcpOptions = {
    */
   oauthProxyUrl?: string;
   /**
-   * Connection policy used by higher-level clients such as the Inspector.
-   * Behavior is controlled by `proxyConfig` and `autoProxyFallback`; this field
-   * is persisted so editors can distinguish Auto, forced Direct, and forced Proxy.
+   * Connection policy for proxy routing.
+   * - `auto`: start direct and use `autoProxyFallback` after a qualifying failure
+   * - `direct`: never use `proxyConfig` and never fall back
+   * - `proxy`: use `proxyConfig` immediately and never fall back
+   *
+   * When omitted, `proxyConfig` retains its legacy immediate-proxy behavior,
+   * except when `autoProxyFallback` explicitly requests a direct-first attempt.
    */
   connectionMode?: "auto" | "direct" | "proxy";
   /**

--- a/libraries/typescript/packages/client/src/react/useMcp.ts
+++ b/libraries/typescript/packages/client/src/react/useMcp.ts
@@ -278,10 +278,19 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
   // Reset runtime fallback when the requested connection changes.
   useEffect(() => {
     setEffectiveProxyConfig(undefined);
-  }, [url, requestedProxyAddress, connectionMode]);
+  }, [
+    url,
+    requestedProxyAddress,
+    connectionMode,
+    autoProxyFallbackConfig.proxyAddress,
+  ]);
 
   const activeProxyConfig = useMemo(() => {
-    if (effectiveProxyConfig?.proxyAddress) {
+    const hasCurrentAutoFallback =
+      autoProxyFallbackConfig.enabled &&
+      effectiveProxyConfig?.proxyAddress ===
+        autoProxyFallbackConfig.proxyAddress;
+    if (hasCurrentAutoFallback && effectiveProxyConfig) {
       const latestHeaders = proxyConfig?.headers ?? {};
       return {
         ...effectiveProxyConfig,
@@ -306,6 +315,7 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
     proxyConfig,
     connectionMode,
     autoProxyFallbackConfig.enabled,
+    autoProxyFallbackConfig.proxyAddress,
   ]);
 
   const gatewayUrl = activeProxyConfig?.proxyAddress;
@@ -1918,6 +1928,7 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
     mergedClientInfo,
     effectiveOAuthUrl, // Triggers reconnection when proxy fallback changes OAuth URL
     proxyConfig, // Triggers reconnection when proxy config (including headers) changes
+    autoProxyFallbackConfig.proxyAddress,
     providedAuthProvider,
   ]);
 

--- a/libraries/typescript/packages/client/src/react/useMcp.ts
+++ b/libraries/typescript/packages/client/src/react/useMcp.ts
@@ -125,6 +125,7 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
     headers: headersOption,
     proxyConfig,
     oauthProxyUrl: oauthProxyUrlOption,
+    connectionMode,
     autoProxyFallback = false,
     logLevel: logLevelOption = "silent",
     autoRetry = false,
@@ -145,6 +146,7 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
     oauth: oauthOptions,
   } = options;
   const transportType: TransportType = "http";
+  const requestedProxyAddress = proxyConfig?.proxyAddress;
 
   const oauthClientId = oauthOptions?.clientId?.trim() || undefined;
   const oauthClientMetadataUrl =
@@ -211,6 +213,11 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
 
   // Parse autoProxyFallback configuration
   const autoProxyFallbackConfig = useMemo(() => {
+    // Explicit Direct and Proxy modes never fall back. Direct must stay direct,
+    // while Proxy already starts on the configured gateway.
+    if (connectionMode === "direct" || connectionMode === "proxy") {
+      return { enabled: false, proxyAddress: undefined };
+    }
     if (!autoProxyFallback) {
       return { enabled: false, proxyAddress: undefined };
     }
@@ -227,7 +234,7 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
       enabled: autoProxyFallback.enabled !== false && Boolean(proxyAddress),
       proxyAddress,
     };
-  }, [autoProxyFallback, proxyConfig]);
+  }, [autoProxyFallback, connectionMode, proxyConfig]);
 
   // Normalize autoReconnect into a consistent config object
   const autoReconnectConfig = useMemo(() => {
@@ -271,22 +278,35 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
   // Reset runtime fallback when the requested connection changes.
   useEffect(() => {
     setEffectiveProxyConfig(undefined);
-  }, [url, proxyConfig]);
+  }, [url, requestedProxyAddress, connectionMode]);
 
   const activeProxyConfig = useMemo(() => {
-    if (!effectiveProxyConfig?.proxyAddress) {
-      return proxyConfig;
+    if (effectiveProxyConfig?.proxyAddress) {
+      const latestHeaders = proxyConfig?.headers ?? {};
+      return {
+        ...effectiveProxyConfig,
+        headers: {
+          ...latestHeaders,
+          ...(effectiveProxyConfig.headers ?? {}),
+        },
+      };
     }
 
-    const latestHeaders = proxyConfig?.headers ?? {};
-    return {
-      ...effectiveProxyConfig,
-      headers: {
-        ...latestHeaders,
-        ...(effectiveProxyConfig.headers ?? {}),
-      },
-    };
-  }, [effectiveProxyConfig, proxyConfig]);
+    // Auto always starts direct, even when proxyConfig supplies the fallback
+    // address. Direct also ignores stale proxyConfig left by older persisted
+    // Inspector configurations. Without an explicit mode, preserve the
+    // low-level API's immediate-proxy behavior unless fallback was requested.
+    const startsDirect =
+      connectionMode === "auto" ||
+      connectionMode === "direct" ||
+      (connectionMode === undefined && autoProxyFallbackConfig.enabled);
+    return startsDirect ? undefined : proxyConfig;
+  }, [
+    effectiveProxyConfig,
+    proxyConfig,
+    connectionMode,
+    autoProxyFallbackConfig.enabled,
+  ]);
 
   const gatewayUrl = activeProxyConfig?.proxyAddress;
   const proxyHeaders = activeProxyConfig?.headers ?? {};
@@ -788,8 +808,9 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
           clientInfo: mergedClientInfo,
           // Pass a fetch that scopes OAuth-proxy routing to this server's
           // transport/auth calls. getProxyFetch wraps `customFetch` (e.g. the
-          // OAuth retry fetch for scope step-up) when proxying, or returns it
-          // unchanged otherwise. Never mutates the global fetch.
+          // OAuth retry fetch for scope step-up), bypasses the browser cache
+          // for OAuth metadata, and optionally routes OAuth through the BFF.
+          // It never mutates the global fetch.
           ...(() => {
             const scopedFetch =
               authProviderRef.current?.getProxyFetch?.(customFetch) ??

--- a/libraries/typescript/packages/client/tests/unit/auth/browser-provider-proxy-fetch.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/auth/browser-provider-proxy-fetch.test.ts
@@ -324,6 +324,24 @@ describe("BrowserOAuthClientProvider — scoped OAuth proxy fetch", () => {
       );
     });
 
+    it("fetches re-anchored metadata directly when OAuth proxying is disabled", async () => {
+      const base = vi.fn(
+        async () => new Response("{}", { status: 200 })
+      ) as unknown as typeof fetch;
+      const scoped = makeProvider({
+        connectionUrl: CONNECTION_URL,
+      }).getProxyFetch(base)!;
+
+      await scoped(
+        "https://inspector.local/.well-known/oauth-protected-resource/inspector/api/proxy"
+      );
+
+      expect(base).toHaveBeenCalledWith(
+        "https://server-a.example.com/.well-known/oauth-protected-resource/mcp",
+        expect.objectContaining({ cache: "no-store" })
+      );
+    });
+
     it("leaves .well-known lookups on unrelated origins untouched", async () => {
       const scoped = makeProxiedProvider().getProxyFetch()!;
 

--- a/libraries/typescript/packages/client/tests/unit/auth/browser-provider-proxy-fetch.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/auth/browser-provider-proxy-fetch.test.ts
@@ -78,6 +78,10 @@ describe("BrowserOAuthClientProvider — scoped OAuth proxy fetch", () => {
     expect(new URL(proxiedUrl).searchParams.get("serverUrl")).toBe(
       "https://server-a.example.com/mcp"
     );
+    expect(globalFetchSpy.mock.calls[1][1]).toMatchObject({
+      cache: "no-store",
+      method: "GET",
+    });
   });
 
   it("does not intercept browser authorization requests", async () => {
@@ -171,7 +175,7 @@ describe("BrowserOAuthClientProvider — scoped OAuth proxy fetch", () => {
     expect(globalFetchSpy).toHaveBeenCalledOnce();
   });
 
-  it("Server B (Direct) gets a plain fetch and never proxies — even while Server A uses a proxy", async () => {
+  it("Server B (Direct) bypasses metadata cache and never proxies — even while Server A uses a proxy", async () => {
     // Server A: "Via Proxy".
     const serverA = new BrowserOAuthClientProvider(
       "https://server-a.example.com/mcp",
@@ -190,12 +194,13 @@ describe("BrowserOAuthClientProvider — scoped OAuth proxy fetch", () => {
     const fetchA = serverA.getProxyFetch();
     expect(fetchA).toBeTypeOf("function");
 
-    // Server B returns the base fetch as-is (no scoping/proxy wrapper).
+    // Server B gets its own scoped wrapper, but still uses its direct base
+    // fetch rather than Server A's proxy.
     const baseFetchB = vi.fn(
       async () => new Response("{}", { status: 200 })
     ) as unknown as typeof fetch;
     const fetchB = serverB.getProxyFetch(baseFetchB);
-    expect(fetchB).toBe(baseFetchB);
+    expect(fetchB).not.toBe(baseFetchB);
 
     // An OAuth-shaped request through Server B's fetch must go DIRECT, not via
     // Server A's proxy.
@@ -206,27 +211,59 @@ describe("BrowserOAuthClientProvider — scoped OAuth proxy fetch", () => {
     expect(String((baseFetchB as any).mock.calls[0][0])).toBe(
       "https://server-b.example.com/.well-known/oauth-authorization-server"
     );
+    expect((baseFetchB as any).mock.calls[0][1]).toMatchObject({
+      cache: "no-store",
+    });
     // The global fetch was never used for Server B's request.
     expect(globalFetchSpy).not.toHaveBeenCalled();
   });
 
-  it("returns the base fetch unchanged when proxyOAuthRequests is disabled", () => {
+  it("bypasses metadata cache when proxyOAuthRequests is disabled", async () => {
     const provider = makeProvider({
       oauthProxyUrl: PROXY_URL,
       proxyOAuthRequests: false,
     });
 
-    const base = vi.fn() as unknown as typeof fetch;
-    expect(provider.getProxyFetch(base)).toBe(base);
-    expect(provider.getProxyFetch()).toBeUndefined();
+    const base = vi.fn(
+      async () => new Response("{}", { status: 200 })
+    ) as unknown as typeof fetch;
+    const scoped = provider.getProxyFetch(base)!;
+
+    await scoped("https://auth.example.com/.well-known/openid-configuration");
+
+    expect(String((base as any).mock.calls[0][0])).toBe(
+      "https://auth.example.com/.well-known/openid-configuration"
+    );
+    expect((base as any).mock.calls[0][1]).toMatchObject({
+      cache: "no-store",
+    });
   });
 
-  it("returns the base fetch unchanged when no OAuth proxy URL is configured", () => {
+  it("uses global fetch with no-store metadata when no base or proxy is configured", async () => {
     const provider = makeProvider();
+    const scoped = provider.getProxyFetch()!;
 
-    const base = vi.fn() as unknown as typeof fetch;
-    expect(provider.getProxyFetch(base)).toBe(base);
-    expect(provider.getProxyFetch()).toBeUndefined();
+    await scoped(
+      "https://auth.example.com/.well-known/oauth-authorization-server"
+    );
+
+    expect(globalFetchSpy).toHaveBeenCalledOnce();
+    expect(globalFetchSpy.mock.calls[0][1]).toMatchObject({
+      cache: "no-store",
+    });
+  });
+
+  it("does not change cache behavior for direct non-metadata requests", async () => {
+    const provider = makeProvider();
+    const base = vi.fn(
+      async () => new Response("{}", { status: 200 })
+    ) as unknown as typeof fetch;
+    const scoped = provider.getProxyFetch(base)!;
+    const init = { headers: { "X-Test": "value" } };
+
+    await scoped("https://server-a.example.com/mcp", init);
+
+    expect(base).toHaveBeenCalledWith("https://server-a.example.com/mcp", init);
   });
 
   it("wraps a provided base fetch (e.g. scope step-up retry) for non-OAuth requests", async () => {

--- a/libraries/typescript/packages/client/tests/unit/auth/browser-provider-static-client.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/auth/browser-provider-static-client.test.ts
@@ -9,6 +9,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { OAuthClientInformation } from "@modelcontextprotocol/client";
 import { BrowserOAuthClientProvider } from "../../../src/auth/browser.js";
 import { installMemoryLocalStorage } from "../../helpers/memory-local-storage.js";
 
@@ -76,6 +77,26 @@ describe("BrowserOAuthClientProvider — pre-registered client_id", () => {
     await provider.saveClientInformation({ client_id: "dcr-registered" });
     const info = await provider.clientInformation();
     expect(info?.client_id).toBe("dcr-registered");
+  });
+
+  it("discards a client secret returned by DCR for a public browser client", async () => {
+    const provider = new BrowserOAuthClientProvider(SERVER_URL, {
+      callbackUrl: "https://app.example.com/oauth/callback",
+    });
+
+    await provider.saveClientInformation({
+      client_id: "dcr-public-client",
+      client_secret: "must-not-be-persisted",
+      token_endpoint_auth_method: "none",
+    } as OAuthClientInformation & { token_endpoint_auth_method: "none" });
+
+    expect(await provider.clientInformation()).toEqual({
+      client_id: "dcr-public-client",
+      token_endpoint_auth_method: "none",
+    });
+    expect(localStorage.getItem(provider.getKey("client_info"))).not.toContain(
+      "must-not-be-persisted"
+    );
   });
 
   it("returns undefined from clientInformation() when neither static nor stored info is present", async () => {

--- a/libraries/typescript/packages/client/tests/unit/react/useMcp-connection-metadata.test.tsx
+++ b/libraries/typescript/packages/client/tests/unit/react/useMcp-connection-metadata.test.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { act, create } from "react-test-renderer";
+import type { UseMcpOptions } from "../../../src/react/types.js";
 
 const initialize = vi.fn();
 const connect = vi.fn();
@@ -66,7 +67,11 @@ function connectionFor(protocolEra: "legacy" | "modern") {
   };
 }
 
-async function renderFor(protocolEra: "legacy" | "modern", views = false) {
+async function renderFor(
+  protocolEra: "legacy" | "modern",
+  views = false,
+  options: Partial<UseMcpOptions> = {}
+) {
   const connection = connectionFor(protocolEra);
   connect.mockResolvedValue(connection);
   let result:
@@ -84,6 +89,7 @@ async function renderFor(protocolEra: "legacy" | "modern", views = false) {
       ...(views && {
         clientOptions: { capabilities: { views: true } },
       }),
+      ...options,
     });
     return null;
   }
@@ -167,5 +173,95 @@ describe("useMcp connection metadata", () => {
       access_token: "access-token",
       resource: "https://mcp.example.com",
     });
+  });
+
+  it.each(["auto", "direct"] as const)(
+    "starts %s mode without the configured proxy gateway",
+    async (connectionMode) => {
+      const proxyAddress = "https://inspector.example.com/api/proxy";
+
+      await renderFor("modern", false, {
+        connectionMode,
+        proxyConfig: { proxyAddress },
+        autoProxyFallback: { enabled: true, proxyAddress },
+      });
+
+      expect(client.addServer).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.not.objectContaining({ gatewayUrl: expect.anything() })
+      );
+    }
+  );
+
+  it("starts proxy mode on the configured proxy gateway", async () => {
+    const proxyAddress = "https://inspector.example.com/api/proxy";
+
+    await renderFor("modern", false, {
+      connectionMode: "proxy",
+      proxyConfig: { proxyAddress },
+      autoProxyFallback: { enabled: true, proxyAddress },
+    });
+
+    expect(client.addServer).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ gatewayUrl: proxyAddress })
+    );
+  });
+
+  it("falls back from a direct Auto attempt to the proxy gateway", async () => {
+    vi.useFakeTimers();
+    const proxyAddress = "https://inspector.example.com/api/proxy";
+    const proxyConfig = { proxyAddress };
+    const autoProxyFallback = { enabled: true, proxyAddress };
+    const connection = connectionFor("modern");
+    connect
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce(connection);
+
+    const { useMcp } = await import("../../../src/react/useMcp.js");
+    let renderer: ReturnType<typeof create> | undefined;
+
+    function TestComponent() {
+      useMcp({
+        url: "https://example.com/mcp",
+        authProvider,
+        connectionMode: "auto",
+        proxyConfig,
+        autoProxyFallback,
+        autoReconnect: false,
+        logLevel: "silent",
+      });
+      return null;
+    }
+
+    try {
+      await act(async () => {
+        renderer = create(<TestComponent />);
+        await Promise.resolve();
+      });
+
+      expect(client.addServer).toHaveBeenNthCalledWith(
+        1,
+        expect.any(String),
+        expect.not.objectContaining({ gatewayUrl: expect.anything() })
+      );
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(client.addServer).toHaveBeenLastCalledWith(
+        expect.any(String),
+        expect.objectContaining({ gatewayUrl: proxyAddress })
+      );
+      expect(connect).toHaveBeenCalledTimes(2);
+    } finally {
+      await act(async () => {
+        renderer?.unmount();
+      });
+      vi.useRealTimers();
+    }
   });
 });

--- a/libraries/typescript/packages/client/tests/unit/react/useMcp-connection-metadata.test.tsx
+++ b/libraries/typescript/packages/client/tests/unit/react/useMcp-connection-metadata.test.tsx
@@ -5,6 +5,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { act, create } from "react-test-renderer";
 import type { UseMcpOptions } from "../../../src/react/types.js";
 
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
 const initialize = vi.fn();
 const connect = vi.fn();
 
@@ -257,6 +261,81 @@ describe("useMcp connection metadata", () => {
         expect.objectContaining({ gatewayUrl: proxyAddress })
       );
       expect(connect).toHaveBeenCalledTimes(2);
+    } finally {
+      await act(async () => {
+        renderer?.unmount();
+      });
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears an active Auto fallback when its configured address changes", async () => {
+    vi.useFakeTimers();
+    const firstProxyAddress = "https://inspector.example.com/api/proxy-one";
+    const secondProxyAddress = "https://inspector.example.com/api/proxy-two";
+    const proxyConfig = { proxyAddress: firstProxyAddress };
+    const connection = connectionFor("modern");
+    connect
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValue(connection);
+
+    const { useMcp } = await import("../../../src/react/useMcp.js");
+    let renderer: ReturnType<typeof create> | undefined;
+
+    function TestComponent({ fallbackAddress }: { fallbackAddress: string }) {
+      const autoProxyFallback = React.useMemo(
+        () => ({ enabled: true, proxyAddress: fallbackAddress }),
+        [fallbackAddress]
+      );
+      useMcp({
+        url: "https://example.com/mcp",
+        authProvider,
+        connectionMode: "auto",
+        proxyConfig,
+        autoProxyFallback,
+        autoReconnect: false,
+        logLevel: "silent",
+      });
+      return null;
+    }
+
+    try {
+      await act(async () => {
+        renderer = create(
+          <TestComponent fallbackAddress={firstProxyAddress} />
+        );
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(client.addServer).toHaveBeenLastCalledWith(
+        expect.any(String),
+        expect.objectContaining({ gatewayUrl: firstProxyAddress })
+      );
+      const callCountBeforeAddressChange = client.addServer.mock.calls.length;
+
+      await act(async () => {
+        renderer!.update(
+          <TestComponent fallbackAddress={secondProxyAddress} />
+        );
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      const gatewayUrlsAfterAddressChange = client.addServer.mock.calls
+        .slice(callCountBeforeAddressChange)
+        .map(([, config]) => config.gatewayUrl);
+      expect(gatewayUrlsAfterAddressChange).toEqual([undefined]);
     } finally {
       await act(async () => {
         renderer?.unmount();

--- a/libraries/typescript/packages/inspector/src/client/components/InspectorDashboard.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/InspectorDashboard.tsx
@@ -853,6 +853,36 @@ export function InspectorDashboard() {
                           <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                           Authenticating...
                         </Button>
+                      ) : connection.authenticate ? (
+                        <Button
+                          data-testid="server-tile-authenticate"
+                          size="sm"
+                          className="bg-yellow-500/20 border-0 dark:bg-yellow-400/10 text-yellow-800 dark:text-yellow-500"
+                          variant="outline"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            // Store connection config so trySessionReconnect() can
+                            // resume after an OAuth redirect (when ?autoConnect is absent).
+                            try {
+                              sessionStorage.setItem(
+                                INSPECTOR_RECONNECT_STORAGE_KEY,
+                                JSON.stringify({
+                                  url: connection.url,
+                                  name:
+                                    connection.name || "Auto-connected Server",
+                                  transportType:
+                                    (connection as any).transportType || "http",
+                                  connectionMode: "auto",
+                                })
+                              );
+                            } catch {
+                              /* sessionStorage unavailable — best-effort */
+                            }
+                            void connection.authenticate();
+                          }}
+                        >
+                          Authenticate
+                        </Button>
                       ) : connection.authUrl ? (
                         <Button
                           data-testid="server-tile-authenticate"

--- a/libraries/typescript/packages/inspector/src/client/utils/__tests__/connectionUpdates.test.ts
+++ b/libraries/typescript/packages/inspector/src/client/utils/__tests__/connectionUpdates.test.ts
@@ -76,3 +76,51 @@ describe("inspector protocol negotiation", () => {
     expect(isAliasOnlyConnectionUpdate(current, forcedLegacy)).toBe(false);
   });
 });
+
+describe("inspector connection modes", () => {
+  const proxyAddress = "https://inspector.example.com/api/proxy";
+
+  it("clears proxy and fallback state in direct mode", () => {
+    const providerConfig = toMcpServerConfig(
+      editable({
+        connectionMode: "direct",
+        proxyConfig: { proxyAddress },
+        autoProxyFallback: { enabled: true, proxyAddress },
+      })
+    );
+
+    expect(providerConfig).toMatchObject({
+      connectionMode: "direct",
+      autoProxyFallback: false,
+    });
+    expect(providerConfig.proxyConfig).toBeUndefined();
+  });
+
+  it("keeps the proxy inactive and available only as fallback in auto mode", () => {
+    const providerConfig = toMcpServerConfig(
+      editable({
+        connectionMode: "auto",
+        autoProxyFallback: { enabled: true, proxyAddress },
+      })
+    );
+
+    expect(providerConfig.proxyConfig).toBeUndefined();
+    expect(providerConfig.autoProxyFallback).toEqual({
+      enabled: true,
+      proxyAddress,
+    });
+  });
+
+  it("uses only the immediate proxy configuration in proxy mode", () => {
+    const providerConfig = toMcpServerConfig(
+      editable({
+        connectionMode: "proxy",
+        proxyConfig: { proxyAddress },
+        autoProxyFallback: { enabled: true, proxyAddress },
+      })
+    );
+
+    expect(providerConfig.proxyConfig).toEqual({ proxyAddress });
+    expect(providerConfig.autoProxyFallback).toBe(false);
+  });
+});

--- a/libraries/typescript/packages/inspector/src/client/utils/connectionUpdates.ts
+++ b/libraries/typescript/packages/inspector/src/client/utils/connectionUpdates.ts
@@ -282,6 +282,12 @@ export function toMcpServerConfig(
     displayName: config.name?.trim() || config.url,
     connectionMode,
     protocolNegotiation: config.protocolNegotiation ?? "auto",
+    // These explicit resets matter when McpClientProvider shallow-merges an
+    // edit into an existing connection. Omitting them would preserve a proxy
+    // or fallback setting from the previous mode.
+    proxyConfig: undefined,
+    headers: undefined,
+    autoProxyFallback: false,
     ...(config.oauth ? { oauth: config.oauth } : {}),
   };
 

--- a/libraries/typescript/packages/server/src/inspector-shell.ts
+++ b/libraries/typescript/packages/server/src/inspector-shell.ts
@@ -279,11 +279,6 @@ ${stylesheetTag}
         };
         // Read by the current inspector bundle to derive its own URLs.
         window.__MCP_BASE_PATH__ = basePath;
-        // The built-in server shell has no Inspector proxy/BFF routes. Disable
-        // the Inspector's standalone proxy default so OAuth discovery stays
-        // direct and resolves against the MCP server's origin-level
-        // /.well-known routes instead of ${basePath}/inspector/api/oauth.
-        window.__MCP_PROXY_URL__ = null;
         ${process.env.MCP_USE_DEV_CLI === "1" ? "window.__MCP_DEV_CLI__ = true;" : ""}
         ${serializedManufactChatUrl ? `window.__MANUFACT_CHAT_URL__ = ${serializedManufactChatUrl};` : ""}
         // The bundle carries Node-flavored dependencies that touch \`process\`

--- a/libraries/typescript/packages/server/src/inspector-shell.ts
+++ b/libraries/typescript/packages/server/src/inspector-shell.ts
@@ -279,6 +279,11 @@ ${stylesheetTag}
         };
         // Read by the current inspector bundle to derive its own URLs.
         window.__MCP_BASE_PATH__ = basePath;
+        // The built-in server shell has no Inspector proxy/BFF routes. Disable
+        // the Inspector's standalone proxy default so OAuth discovery stays
+        // direct and resolves against the MCP server's origin-level
+        // /.well-known routes instead of ${basePath}/inspector/api/oauth.
+        window.__MCP_PROXY_URL__ = null;
         ${process.env.MCP_USE_DEV_CLI === "1" ? "window.__MCP_DEV_CLI__ = true;" : ""}
         ${serializedManufactChatUrl ? `window.__MANUFACT_CHAT_URL__ = ${serializedManufactChatUrl};` : ""}
         // The bundle carries Node-flavored dependencies that touch \`process\`

--- a/libraries/typescript/packages/server/tests/inspector-shell.test.ts
+++ b/libraries/typescript/packages/server/tests/inspector-shell.test.ts
@@ -108,6 +108,9 @@ describe("inspector shell route", () => {
     expect(html).not.toContain("__MCP_DEV_CLI__");
     expect(html).toContain('var basePath = "/mcp";');
     expect(html).toContain("window.location.origin + basePath");
+    // The built-in shell does not mount the standalone Inspector proxy/BFF.
+    // Explicitly disabling it keeps OAuth metadata discovery direct.
+    expect(html).toContain("window.__MCP_PROXY_URL__ = null;");
     // Browser polyfill for the bundle's Node-flavored module-scope code.
     expect(html).toContain("window.process = {");
     // Root node for the bundle to mount into, with the inspector's neutral

--- a/libraries/typescript/packages/server/tests/inspector-shell.test.ts
+++ b/libraries/typescript/packages/server/tests/inspector-shell.test.ts
@@ -108,9 +108,9 @@ describe("inspector shell route", () => {
     expect(html).not.toContain("__MCP_DEV_CLI__");
     expect(html).toContain('var basePath = "/mcp";');
     expect(html).toContain("window.location.origin + basePath");
-    // The built-in shell does not mount the standalone Inspector proxy/BFF.
-    // Explicitly disabling it keeps OAuth metadata discovery direct.
-    expect(html).toContain("window.__MCP_PROXY_URL__ = null;");
+    // Allow the Inspector to use its default proxy now that the server mounts
+    // the proxy/BFF routes again.
+    expect(html).not.toContain("window.__MCP_PROXY_URL__ = null;");
     // Browser polyfill for the bundle's Node-flavored module-scope code.
     expect(html).toContain("window.process = {");
     // Root node for the bundle to mount into, with the inspector's neutral


### PR DESCRIPTION
## Summary

- make Inspector connection modes authoritative: Auto starts direct and falls back to the CORS proxy, Direct never proxies, and Proxy starts through the proxy
- clear stale persisted proxy settings when connection modes change and keep the built-in server Inspector on direct origin-level OAuth discovery when no proxy routes are mounted
- bypass browser HTTP caching for OAuth metadata, make manual Authenticate clear stale OAuth discovery, and discard authorization-server-generated secrets from public browser DCR results

## Root cause

The client always honored a configured proxy before considering the selected connection mode, so every mode effectively started through the proxy. The server tile also navigated to a stored authorization URL instead of invoking the fresh-auth flow, and browser OAuth discovery could reuse stale metadata or reject Auth0 public DCR responses that included an unused generated secret.

## Impact

Auto mode now uses beta's existing Inspector CORS proxy only as fallback, Direct remains direct, and Proxy uses the proxy immediately. OAuth discovery remains fresh, and the Auth0 example completes Google sign-in, consent, callback, token exchange, and authenticated MCP reconnection.

## Validation

- Client: 35 focused tests
- Inspector: 8 focused tests
- Server: 15 Inspector shell tests
- End-to-end Auth0 OAuth flow in the local Inspector
- Pre-commit formatting, lint, and changeset checks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Inspector connection modes authoritative and harden OAuth discovery for reliable sign-in. Auto starts direct and only falls back to the CORS proxy; Direct never proxies; Proxy starts via the proxy.

- **Bug Fixes**
  - Enforce `connectionMode` across client and Inspector; clear stale proxy/fallback settings when modes change.
  - `useMcp`: Auto/Direct start without `gatewayUrl`; Proxy uses `proxyConfig`; Auto falls back only when `autoProxyFallback` is set; clear active fallback when its address changes.
  - `BrowserOAuthClientProvider`: Always fetch OAuth metadata with `cache: "no-store"` (including direct mode), re-anchor `.well-known` discovery to the server origin when needed, and scope any proxying per server; non-OAuth requests remain unchanged.
  - Restore server Inspector proxy/BFF routes so the Inspector can use its default proxy.
  - Inspector UI: “Authenticate” starts a fresh flow and stores reconnect info.
  - Discard `client_secret` from public browser DCR results; persist only public client information.
  - Expanded tests for proxy fetch, metadata cache bypass and re-anchoring, connection modes and fallbacks, Inspector shell, and server behavior.

<sup>Written for commit 8dbe676b62a8ce3b1803f1492d7571081b3ffd31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1965?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

