### PR TITLE
Enable public tunnels for production start

### DIFF
--- a/docs/tunneling/index.mdx
+++ b/docs/tunneling/index.mdx
@@ -14,7 +14,7 @@ https://<subdomain>.local.mcp-use.run/mcp
 
 Keep the terminal process running while you test. The public URL stops working when the process exits.
 
-With `mcp-use dev --tunnel` or `mcp-use start --tunnel`, if the tunnel relay drops the registration while dev is still running, the tunnel is restarted automatically and the same subdomain is reused when possible.
+With `mcp-use dev --tunnel` or `mcp-use start --tunnel`, if the tunnel relay drops the registration while the command is still running, the tunnel restarts automatically and reuses the same subdomain when possible.
 
 ## Start a tunnel with mcp-use
 
@@ -31,19 +31,15 @@ mcp-use build
 mcp-use start --port 3000 --tunnel
 ```
 
-Successful output includes a tunnel endpoint:
+After the production server binds, successful output includes the local and public MCP endpoints:
 
 ```text
-Starting tunnel for port 3000...
-✓ Tunnel established: https://happy-blue.local.mcp-use.run/mcp
-
-Local:    http://localhost:3000
-MCP:      http://localhost:3000/mcp
-Tunnel:   https://happy-blue.local.mcp-use.run/mcp
-Inspector: http://localhost:3000/mcp/inspector?autoConnect=...
+[mcp-use] starting tunnel for port 3000…
+mcp-use server running at http://localhost:3000/mcp
+mcp-use public MCP URL: https://happy-blue.local.mcp-use.run/mcp
 ```
 
-Copy the value after `Tunnel:` into your remote MCP client. Do not copy only `https://happy-blue.local.mcp-use.run`; the client URL must end with `/mcp`.
+Copy the value after `mcp-use public MCP URL:` into your remote MCP client. Do not copy only `https://happy-blue.local.mcp-use.run`; the client URL must end with `/mcp`.
 
 ## Tunnel any server on /mcp
 
@@ -92,7 +88,7 @@ When you started the tunnel with `mcp-use dev --tunnel` or `mcp-use start --tunn
 Tunnels are for local testing before deployment:
 
 - The tunnel is active only while the command is running.
-- With `mcp-use dev --tunnel` or `mcp-use start --tunnel`, a dropped tunnel registration is re-established automatically while dev runs.
+- With `mcp-use dev --tunnel` or `mcp-use start --tunnel`, a dropped tunnel registration is re-established automatically while the command runs.
 - Tunnels expire after 24 hours.
 - Inactive tunnels are cleaned up after 1 hour without activity.
 - Each IP address can create up to 10 tunnels per hour.

--- a/docs/typescript/api-reference/cli-reference.mdx
+++ b/docs/typescript/api-reference/cli-reference.mdx
@@ -189,6 +189,7 @@ mcp-use start [options]
 | `--port <port>`    | Server port.                                             | `PORT`, server config, or `3000`      |
 | `--host <host>`    | Bind address. Use `0.0.0.0` to listen on all interfaces. | `HOST`, server config, or `127.0.0.1` |
 | `--with-inspector` | Mount the bundled Inspector at `${basePath}/inspector`.  | Disabled                              |
+| `--tunnel`         | Create a public tunnel for the production server.        | Disabled                              |
 
 **Examples:**
 
@@ -198,11 +199,13 @@ mcp-use start --port 8080
 mcp-use start --host 0.0.0.0
 mcp-use start --with-inspector
 mcp-use start --path ./my-server
+mcp-use start --tunnel
 ```
 
 **Notes and behavior:**
 
 - Address precedence is CLI flag, environment variable, server configuration, then default: `--port` → `PORT` → `config.port` → `3000`, and `--host` → `HOST` → `config.host` → `127.0.0.1`.
+- `--tunnel` starts the tunnel only after the production server binds. The command prints the public MCP URL and closes the tunnel when the process shuts down.
 - The command requires `.mcp-use/build/manifest.json`; run `mcp-use build` first.
 - It imports the manifest's built `entryPoint` and requires that module to default-export an `MCPServer`.
 - `start` does not rediscover source entries or views. `--entry`, `--mcp-dir`, and `--views-dir` belong to `dev` and `build`.
@@ -212,10 +215,11 @@ mcp-use start --path ./my-server
 
 ## Tunneling reference
 
-`mcp-use dev --tunnel` creates a public URL that forwards to the local MCP server.
+`mcp-use dev --tunnel` and `mcp-use start --tunnel` create a public URL that forwards to the local MCP server.
 
 ```bash
 mcp-use dev --tunnel
+mcp-use start --tunnel
 ```
 
 Tunnel limits and lifecycle:
@@ -672,7 +676,7 @@ mcp-use generate-types --server src/server.ts
 | `MCP_API_URL`               | `login`, cloud API config                 | Manufact API URL. The CLI normalizes it to include `/api/v1`.                                                                                                                                               | `https://cloud.manufact.com/api/v1` |
 | `MCP_USE_API_KEY`           | `login`                                   | API key for non-interactive login.                                                                                                                                                                          | None                                |
 | `MCP_USE_API`               | Tunnel cleanup and local tunnel API calls | Tunnel service API base used by integrated tunnel cleanup paths.                                                                                                                                            | `https://local.mcp-use.run`         |
-| `MCP_USE_TUNNEL_API`        | `dev --tunnel`                            | Tunnel service API base used when creating development tunnels.                                                                                                                                             | `https://local.mcp-use.run`         |
+| `MCP_USE_TUNNEL_API`        | `dev --tunnel`, `start --tunnel`          | Tunnel service API base used when creating local tunnels.                                                                                                                                                   | `https://local.mcp-use.run`         |
 | `MCP_USE_CHROME_PATH`       | `client screenshot`                       | Chrome executable path for screenshots.                                                                                                                                                                     | Auto-detected                       |
 | `PUPPETEER_EXECUTABLE_PATH` | `client screenshot`                       | Fallback Chrome executable path.                                                                                                                                                                            | Auto-detected                       |
 | `CHROME_PATH`               | `client screenshot`                       | Fallback Chrome executable path.                                                                                                                                                                            | Auto-detected                       |

--- a/libraries/typescript/.changeset/start-production-tunnel.md
+++ b/libraries/typescript/.changeset/start-production-tunnel.md
@@ -1,0 +1,6 @@
+---
+"mcp-use": minor
+"@mcp-use/cli": minor
+---
+
+Add `mcp-use start --tunnel` for production builds. The command waits for the server to bind, tunnels the actual port, prints the public MCP URL, reuses saved tunnel state, and releases the tunnel during startup failure or graceful shutdown. It composes with `--host` and `--with-inspector` while keeping tunnel code out of ordinary production startup.

--- a/libraries/typescript/packages/server/specs/CLI_SPEC.md
+++ b/libraries/typescript/packages/server/specs/CLI_SPEC.md
@@ -321,8 +321,9 @@ Tunnel subdomain persistence lives at `.mcp-use/state/tunnel.json` (v1-compatibl
 2. Imports the built entry, takes the default export, serves it via `listen()`.
 3. **Address:** CLI flag / environment variable / built server configuration / default: `--port` / integer `PORT` / `config.port` / `3000`, and `--host` / non-empty `HOST` / `config.host` / `127.0.0.1`. There is no upward port probing (a production port conflict should fail, not silently move). Sets `NODE_ENV=production` only when unset.
 4. **Inspector:** `--with-inspector` lazily imports the bundled `@mcp-use/inspector`, mounts it at `${basePath}/inspector` on the same listener, and leaves the build output and manifest unchanged. The default start path neither imports nor exposes Inspector routes. The listener continues through `MCPServer.listen()` so its Host validation and OAuth resource initialization are identical in both modes; production Inspector proxy routes disallow loopback targets.
+5. **Tunnel:** `--tunnel` dynamically loads the shared tunnel manager only after `listen()` binds successfully, including when `--with-inspector` owns additional routes on that listener. It targets the actual bound port, reuses `.mcp-use/state/tunnel.json`, derives the public MCP endpoint from the server's returned endpoint path, and stops/releases the tunnel before closing the server on normal shutdown, SIGINT, or SIGTERM. A tunnel startup failure closes the already-bound server and fails the command.
 
-Evaluates no Vite, toolchain, or unrelated command chunk. A production image installs `mcp-use` and the app's own runtime dependencies; the regular Vite dependency may be present on disk but is outside the `start` evaluation graph.
+Without `--tunnel`, the tunnel module is not evaluated. `start` evaluates no Vite, toolchain, or unrelated command chunk. A production image installs `mcp-use` and the app's own runtime dependencies; the regular Vite dependency may be present on disk but is outside the `start` evaluation graph.
 
 ## Inspector mounting
 

--- a/libraries/typescript/packages/server/src/bin/args.ts
+++ b/libraries/typescript/packages/server/src/bin/args.ts
@@ -26,7 +26,7 @@ export interface ParsedArgs {
   viewsDir: string | undefined;
   /** Value of `--host`, or `undefined` if the flag was not passed. */
   host: string | undefined;
-  /** Whether `--tunnel` was passed (dev only). */
+  /** Whether `--tunnel` was passed (dev/start only). */
   tunnel: boolean;
   /** `false` when `--no-open` was passed (dev only); `true` otherwise. */
   open: boolean;

--- a/libraries/typescript/packages/server/src/bin/main.ts
+++ b/libraries/typescript/packages/server/src/bin/main.ts
@@ -30,7 +30,7 @@ export interface CliCommandOptions {
   port?: number;
   /** Host override (`--host`). */
   host?: string;
-  /** Start a public tunnel at dev startup (`--tunnel`). */
+  /** Start a public tunnel at dev/start startup (`--tunnel`). */
   tunnel?: boolean;
   /** Auto-open the inspector in a browser at dev startup (`--no-open` disables). */
   open?: boolean;
@@ -73,7 +73,7 @@ Options:
   --inline           Embed view JS and CSS in MCP resources (build only)
   -- <tsc options>   Forward remaining options to TypeScript (typecheck only)
   --with-inspector   Mount Inspector on the production listener (start only)
-  --tunnel           Expose the dev server through a public tunnel (dev only)
+  --tunnel           Expose the server through a public tunnel (dev/start only)
   --no-open          Do not auto-open the inspector in a browser (dev only)
   --no-inspector     Start dev without loading the optional Inspector
   -h, --help         Show this help
@@ -195,6 +195,7 @@ async function startCommand(args: ParsedArgs): Promise<number> {
       port: args.port,
       host: args.host,
       ...(args.inspector === true && { withInspector: true }),
+      tunnel: args.tunnel,
     });
   } catch (error) {
     console.error(error instanceof Error ? error.message : String(error));
@@ -202,8 +203,14 @@ async function startCommand(args: ParsedArgs): Promise<number> {
   }
 
   console.log(`mcp-use server running at ${started.url}`);
+  if (started.tunnelUrl !== undefined) {
+    console.log(`mcp-use public MCP URL: ${started.tunnelUrl}`);
+  }
 
+  let closing = false;
   const shutdown = (): void => {
+    if (closing) return;
+    closing = true;
     started.close().then(
       () => process.exit(0),
       (error: unknown) => {

--- a/libraries/typescript/packages/server/src/bin/start.ts
+++ b/libraries/typescript/packages/server/src/bin/start.ts
@@ -59,6 +59,8 @@ export interface StartOptions {
   host?: string | undefined;
   /** Mount the bundled Inspector on the same production listener. */
   withInspector?: boolean | undefined;
+  /** Start a public tunnel after the production listener binds. */
+  tunnel?: boolean | undefined;
 }
 
 /**
@@ -71,7 +73,9 @@ export interface StartedServer {
   port: number;
   /** URL of the MCP endpoint, as reported by the server's `listen()`. */
   url: string;
-  /** Stop the server (delegates to the instance's `close()`, if present). */
+  /** Public MCP endpoint URL when `--tunnel` was requested. */
+  tunnelUrl?: string;
+  /** Stop the tunnel, when active, then delegate to the server's `close()`. */
   close(): Promise<void>;
 }
 
@@ -82,7 +86,7 @@ export interface StartedServer {
  * Reads the build manifest, sets `NODE_ENV=production` (only if unset),
  * imports the built entry, and calls `listen()` on its default export.
  *
- * @param options - Project root and optional port override.
+ * @param options - Project root and optional address, Inspector, and tunnel settings.
  * @throws Error with an actionable message when the manifest is missing
  * (pointing at `mcp-use build`), malformed, or the entry's default export is
  * not a server.
@@ -158,11 +162,60 @@ export async function runStart(options: StartOptions): Promise<StartedServer> {
       ? result.url
       : `http://localhost:${boundPort}`;
 
+  let tunnel:
+    | {
+        start(port: number): Promise<{ url: string }>;
+        stop(): Promise<void>;
+      }
+    | undefined;
+  let tunnelUrl: string | undefined;
+  if (options.tunnel === true) {
+    try {
+      // Keep the tunnel process/state code outside the ordinary production
+      // start evaluation graph. The listener must bind successfully before a
+      // public route is created for it.
+      const { createTunnelManager } = await import("../cli/tunnel.js");
+      tunnel = createTunnelManager(
+        join(options.cwd, WORKSPACE_DIR_NAME, "state", "tunnel.json")
+      );
+      const tunnelInfo = await tunnel.start(boundPort);
+      const endpoint = new URL(url);
+      tunnelUrl = new URL(
+        `${endpoint.pathname}${endpoint.search}`,
+        `${tunnelInfo.url}/`
+      ).toString();
+    } catch (error) {
+      try {
+        await tunnel?.stop();
+      } catch {
+        // Preserve the tunnel startup error after best-effort cleanup.
+      }
+      try {
+        await candidate.close?.();
+      } catch {
+        // Preserve the tunnel startup error after best-effort cleanup.
+      }
+      throw error;
+    }
+  }
+
   return {
     port: boundPort,
     url,
+    ...(tunnelUrl !== undefined && { tunnelUrl }),
     close: async () => {
-      await candidate.close?.();
+      let cleanupError: unknown;
+      try {
+        await tunnel?.stop();
+      } catch (error) {
+        cleanupError = error;
+      }
+      try {
+        await candidate.close?.();
+      } catch (error) {
+        cleanupError ??= error;
+      }
+      if (cleanupError !== undefined) throw cleanupError;
     },
   };
 }

--- a/libraries/typescript/packages/server/src/cli/tunnel.ts
+++ b/libraries/typescript/packages/server/src/cli/tunnel.ts
@@ -1,5 +1,5 @@
 /**
- * Tunnel lifecycle for `mcp-use dev` — spawns `@mcp-use/tunnel`,
+ * Tunnel lifecycle for `mcp-use dev` and `mcp-use start` — spawns `@mcp-use/tunnel`,
  * parses the public URL from stdout, persists the subdomain under
  * `.mcp-use/state/tunnel.json`, and releases it through the tunnel API before
  * reuse.
@@ -27,8 +27,7 @@ interface TunnelStateFile {
 }
 
 /**
- * Minimal tunnel manager surface used by {@link createDevApiHandler} and
- * {@link runDev}.
+ * Minimal tunnel manager surface used by the dev and production CLI paths.
  */
 export interface TunnelManager {
   /**

--- a/libraries/typescript/packages/server/tests/bin-start.test.ts
+++ b/libraries/typescript/packages/server/tests/bin-start.test.ts
@@ -7,7 +7,25 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+const tunnelMocks = vi.hoisted(() => ({
+  create: vi.fn(),
+  start: vi.fn(),
+  stop: vi.fn(),
+}));
+
+vi.mock("../src/cli/tunnel.js", () => ({
+  createTunnelManager: tunnelMocks.create,
+}));
 
 import { parseArgs, resolveHost, resolvePort } from "../src/bin/args.js";
 import { main } from "../src/bin/main.js";
@@ -126,6 +144,22 @@ afterAll(async () => {
   );
 });
 
+beforeEach(() => {
+  tunnelMocks.start.mockReset();
+  tunnelMocks.stop.mockReset();
+  tunnelMocks.create.mockReset();
+  tunnelMocks.start.mockResolvedValue({
+    url: "https://public-test.local.mcp-use.run",
+    subdomain: "public-test",
+  });
+  tunnelMocks.stop.mockResolvedValue(undefined);
+  tunnelMocks.create.mockReturnValue({
+    start: tunnelMocks.start,
+    stop: tunnelMocks.stop,
+    status: () => ({ url: null }),
+  });
+});
+
 afterEach(() => {
   vi.unstubAllEnvs();
   vi.restoreAllMocks();
@@ -166,7 +200,9 @@ describe("parseArgs", () => {
 
   it("parses --tunnel", () => {
     expect(parseArgs(["dev", "--tunnel"]).tunnel).toBe(true);
+    expect(parseArgs(["start", "--tunnel"]).tunnel).toBe(true);
     expect(parseArgs(["dev"]).tunnel).toBe(false);
+    expect(parseArgs(["start"]).tunnel).toBe(false);
   });
 
   it("parses --no-open (auto-open defaults to on)", () => {
@@ -332,6 +368,76 @@ describe("runStart", () => {
     }
   });
 
+  it("starts a tunnel after binding and closes both resources", async () => {
+    const cwd = await makeProject({ entrySource: HTTP_ENTRY });
+    tunnelMocks.start.mockImplementationOnce(async (port: number) => {
+      const response = await fetch(`http://127.0.0.1:${port}/mcp`);
+      expect(await response.text()).toBe("hello from built server");
+      return {
+        url: "https://public-test.local.mcp-use.run",
+        subdomain: "public-test",
+      };
+    });
+
+    const started = await runStart({ cwd, port: 0, tunnel: true });
+
+    expect(tunnelMocks.create).toHaveBeenCalledWith(
+      join(cwd, ".mcp-use", "state", "tunnel.json")
+    );
+    expect(tunnelMocks.start).toHaveBeenCalledWith(started.port);
+    expect(started.tunnelUrl).toBe("https://public-test.local.mcp-use.run/mcp");
+
+    await started.close();
+    expect(tunnelMocks.stop).toHaveBeenCalledOnce();
+    await expect(fetch(started.url)).rejects.toThrow();
+  });
+
+  it("closes the bound server when tunnel startup fails", async () => {
+    const cwd = await makeProject({ entrySource: HTTP_ENTRY });
+    let boundPort: number | undefined;
+    tunnelMocks.start.mockImplementationOnce(async (port: number) => {
+      boundPort = port;
+      throw new Error("tunnel unavailable");
+    });
+
+    await expect(runStart({ cwd, port: 0, tunnel: true })).rejects.toThrow(
+      "tunnel unavailable"
+    );
+
+    expect(tunnelMocks.stop).toHaveBeenCalledOnce();
+    expect(boundPort).toBeDefined();
+    await expect(
+      fetch(`http://127.0.0.1:${boundPort ?? 0}/mcp`)
+    ).rejects.toThrow();
+  });
+
+  it("coexists with Inspector routing on the production listener", async () => {
+    mountInspector.mockImplementation(
+      () => async () => new Response("inspector")
+    );
+    const cwd = await makeProject({ entrySource: INSPECTOR_ENTRY });
+
+    const started = await runStart({
+      cwd,
+      port: 4568,
+      withInspector: true,
+      tunnel: true,
+    });
+    try {
+      expect(mountInspector).toHaveBeenCalledWith({
+        basePath: "/api/mcp",
+        devMode: false,
+        oauthProxyAllowLoopback: false,
+      });
+      expect(tunnelMocks.start).toHaveBeenCalledWith(4568);
+      expect(started.tunnelUrl).toBe(
+        "https://public-test.local.mcp-use.run/api/mcp"
+      );
+    } finally {
+      await started.close();
+    }
+  });
+
   it("applies address precedence: flags over env over server config over defaults", async () => {
     const cwd = await makeProject({ entrySource: ADDRESS_ENTRY });
 
@@ -385,6 +491,48 @@ describe("main", () => {
     const logs = vi.spyOn(console, "log").mockImplementation(() => {});
     await expect(main(["--help"])).resolves.toBe(0);
     expect(logs.mock.calls.flat().join("\n")).toContain("Usage: mcp-use");
+    expect(logs.mock.calls.flat().join("\n")).toContain(
+      "public tunnel (dev/start only)"
+    );
+  });
+
+  it("prints the public MCP URL and stops the tunnel on a signal", async () => {
+    const cwd = await makeProject({ entrySource: ECHO_ENTRY });
+    const logs = vi.spyOn(console, "log").mockImplementation(() => {});
+    const exit = vi
+      .spyOn(process, "exit")
+      .mockImplementation((() => undefined) as never);
+    const existingSigint = new Set(process.listeners("SIGINT"));
+    const existingSigterm = new Set(process.listeners("SIGTERM"));
+
+    await expect(
+      main(["start", "--path", cwd, "--port", "4567", "--tunnel"])
+    ).resolves.toBe(0);
+
+    expect(logs.mock.calls.flat().join("\n")).toContain(
+      "mcp-use public MCP URL: https://public-test.local.mcp-use.run/mcp"
+    );
+
+    const sigint = process
+      .listeners("SIGINT")
+      .find((listener) => !existingSigint.has(listener));
+    const sigterm = process
+      .listeners("SIGTERM")
+      .find((listener) => !existingSigterm.has(listener));
+    expect(sigint).toBeDefined();
+    expect(sigterm).toBeDefined();
+
+    try {
+      sigint?.("SIGINT");
+      sigterm?.("SIGTERM");
+      await vi.waitFor(() => {
+        expect(exit).toHaveBeenCalledWith(0);
+      });
+      expect(tunnelMocks.stop).toHaveBeenCalledOnce();
+    } finally {
+      if (sigint !== undefined) process.off("SIGINT", sigint);
+      if (sigterm !== undefined) process.off("SIGTERM", sigterm);
+    }
   });
 
   it("prints client help for client --help", async () => {

--- a/libraries/typescript/packages/server/tests/budgets/cli-budget.test.ts
+++ b/libraries/typescript/packages/server/tests/budgets/cli-budget.test.ts
@@ -84,6 +84,11 @@ describe("published CLI boundaries", () => {
         pattern
       );
     }
+
+    expect(
+      start,
+      "the tunnel manager must stay lazy for start without --tunnel"
+    ).toMatch(/\bimport\s*\(\s*["'][^"']*tunnel[^"']*["']\s*\)/);
   });
 
   it("dispatches every substantial command through a dynamic chunk", async () => {


### PR DESCRIPTION
## Summary

- Add `mcp-use start --tunnel` support for production servers.
- Reuse tunnel state and derive the public URL from the server endpoint.
- Ensure tunnel cleanup, startup-failure handling, and Inspector compatibility.
- Update CLI, tunnel, and API documentation.

## Testing

- Added coverage for tunnel lifecycle, cleanup, startup failures, Inspector routing, CLI output, and lazy loading.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `mcp-use start --tunnel` to expose production servers via a public URL. The tunnel starts after the listener binds, prints the public MCP URL, and is released on shutdown or failure.

- **New Features**
  - Adds tunnel support to `start`; lazy-loads the tunnel manager only with `--tunnel` and targets the bound port.
  - Prints the public MCP endpoint as “mcp-use public MCP URL: …”, derived from the server’s endpoint path.
  - Reuses `.mcp-use/state/tunnel.json` for subdomain persistence and aligns behavior with `dev --tunnel`.
  - Ensures cleanup: stops the tunnel before closing the server on exit, SIGINT, or SIGTERM; on tunnel startup failure, closes the bound server and fails the command.
  - Compatible with `--with-inspector`; `@mcp-use/inspector` routes and the tunnel share the same listener.
  - Updates CLI help, docs, and env vars (`MCP_USE_TUNNEL_API` now applies to `start --tunnel`); without `--tunnel`, the tunnel module is not evaluated.

<sup>Written for commit be0c4570e08a68daff283cd24cb59a0227d9accb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1970?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

