### PR TITLE
fix CLI package verification on Windows

### DIFF
--- a/libraries/typescript/.changeset/fix-cli-package-verifier-windows.md
+++ b/libraries/typescript/.changeset/fix-cli-package-verifier-windows.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/cli": patch
+---
+
+Fix CLI package verification on Windows by converting the package file URL to a native path before scanning `dist`.

--- a/libraries/typescript/packages/cli/scripts/verify-package.mjs
+++ b/libraries/typescript/packages/cli/scripts/verify-package.mjs
@@ -1,7 +1,8 @@
 import { readdirSync } from "node:fs";
 import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const root = new URL("../", import.meta.url).pathname;
+const root = fileURLToPath(new URL("../", import.meta.url));
 const files = walk(join(root, "dist"));
 
 if (!files.includes("dist/bin.js")) throw new Error("Missing dist/bin.js");


### PR DESCRIPTION
## Summary

- convert the CLI package verifier's file URL with `fileURLToPath()` before using path utilities
- add a patch changeset for `@mcp-use/cli`

## Why

`URL.pathname` returns paths such as `/D:/a/...` on Windows. Passing that value to Windows path utilities produced `D:\\D:\\a\\...`, so package verification could not scan the built `dist` directory and the Windows CLI CI job failed.

## Impact

CLI package builds can verify their output on Windows without changing package contents or runtime behavior.

## Validation

- `pnpm --filter @mcp-use/cli build`
- `node --check libraries/typescript/packages/cli/scripts/verify-package.mjs`
- `git diff --check origin/beta...HEAD`
- confirmed Windows file URL conversion produces `D:\\a\\...`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Windows CLI package verification by converting the package file URL to a native path before scanning the `dist` directory. This prevents malformed Windows paths and restores CI verification for `@mcp-use/cli`.

- **Bug Fixes**
  - Use `fileURLToPath()` to compute `root` from `import.meta.url` in `scripts/verify-package.mjs`.
  - Add a patch changeset for `@mcp-use/cli`.

<sup>Written for commit 8db84644b2de750917f3e6c0a6d5aee5bea8750a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1973?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

