### PR TITLE
Add pre-approved device code login flow

### DIFF
--- a/docs/typescript/api-reference/cli-reference.mdx
+++ b/docs/typescript/api-reference/cli-reference.mdx
@@ -289,11 +289,13 @@ mcp-use login [options]
 
 **Options:**
 
-| Option                 | Description                                                                | Default             |
-| ---------------------- | -------------------------------------------------------------------------- | ------------------- |
-| `--api-key <key>`      | Save an API key directly. Intended for CI and agent harnesses.             | Browser/device flow |
-| `--org <org>`          | Select an organization by slug, ID, or name without an interactive prompt. | Prompt when needed  |
-| `--device-code <code>` | Redeem a pre-approved device code without opening a browser.               | None                |
+| Option                 | Description                                                | Default             |
+| ---------------------- | ---------------------------------------------------------- | ------------------- |
+| `--api-key <key>`      | Authenticate with an API key.                              | Browser/device flow |
+| `--device-code <code>` | Redeem a short-lived, pre-approved RFC 8628 device code.   | None                |
+| `--org <id-or-slug>`   | Select the active organization by ID or slug.              | Account default     |
+| `--no-open`            | Do not open the verification URL during interactive login. | Opens on a TTY      |
+| `--json`               | Emit one machine-readable JSON result.                     | Human-readable text |
 
 **Examples:**
 
@@ -306,8 +308,10 @@ mcp-use login --api-key mcp_... --org my-org
 **Notes and behavior:**
 
 - Interactive login starts a device-code flow and opens a browser.
-- If the account belongs to multiple organizations and `--org` is omitted, the CLI prompts for an organization.
-- In non-TTY environments, use `--org` to avoid an organization selection prompt.
+- `--device-code` skips the browser and redeems the code through the same token endpoint. The CLI then creates, validates, and stores a persistent API key.
+- `--api-key` and `--device-code` cannot be combined. An explicit `--device-code` takes precedence over `MCP_USE_API_KEY`.
+- The CLI never writes the device code, bearer token, or API key to human-readable or JSON output.
+- If `--org` is omitted, the CLI stores the account-default organization when one is available.
 - `MCP_USE_API_KEY` can provide the API key for non-interactive login.
 
 ### `whoami`

--- a/libraries/typescript/.changeset/cli-device-code-login.md
+++ b/libraries/typescript/.changeset/cli-device-code-login.md
@@ -1,0 +1,6 @@
+---
+"mcp-use": minor
+"@mcp-use/cli": minor
+---
+
+Add `mcp-use login --device-code <code>` for securely redeeming short-lived, pre-approved device codes in non-interactive onboarding flows.

--- a/libraries/typescript/packages/server/specs/CLI_SPEC.md
+++ b/libraries/typescript/packages/server/specs/CLI_SPEC.md
@@ -80,7 +80,7 @@ All global CLI state lives under `~/.mcp-use/`; project state lives under the pr
 ### Cloud identity and organization
 
 ```text
-mcp-use login [--api-key <key>] [--org <id-or-slug>] [--no-open]
+mcp-use login [--api-key <key> | --device-code <code>] [--org <id-or-slug>] [--no-open]
 mcp-use logout [--yes]
 mcp-use whoami [--json]
 mcp-use org list [--json]
@@ -88,7 +88,7 @@ mcp-use org current [--json]
 mcp-use org use <id-or-slug>
 ```
 
-- `login` uses `--api-key` or `MCP_USE_API_KEY` when present; otherwise it runs OAuth device authorization, prints the verification URL/code, and opens the URL unless `--no-open` or non-TTY. It validates the resulting credential before persisting it. `--org` validates and stores the selection; without it, the account default is stored when available. v2 does not expose pre-approved device-code injection.
+- `login` uses `--api-key` or `MCP_USE_API_KEY` when present; otherwise it runs OAuth device authorization, prints the verification URL/code, and opens the URL unless `--no-open` or non-TTY. `--device-code` redeems a short-lived, pre-approved RFC 8628 device code non-interactively through the same token endpoint, then creates and validates a CLI API key before persisting it. `--api-key` and `--device-code` are mutually exclusive; an explicit `--device-code` takes precedence over `MCP_USE_API_KEY`. `--org` validates and stores the selection; without it, the account default is stored when available. Device codes and bearer credentials are never included in output or structured errors.
 - `logout` deletes local cloud credentials and organization selection; remote key revocation remains a web-account action. `whoami` verifies the stored key and returns user plus active organization; missing/expired credentials exit `1` with a `mcp-use login` hint.
 - `org list` returns memberships and marks the active organization. `org current` requires a resolvable active/default organization. `org use` validates membership, updates local state, and best-effort updates the account default; local success is authoritative.
 

--- a/libraries/typescript/packages/server/src/commands/identity.ts
+++ b/libraries/typescript/packages/server/src/commands/identity.ts
@@ -33,11 +33,33 @@ interface DeviceToken {
   error_description?: string;
 }
 
+const DEVICE_CLIENT_ID = "mcp-use-cli";
+const DEVICE_POLL_TIMEOUT = 30 * 60 * 1000;
+
+const LOGIN_HELP = `Usage: mcp-use login [options]
+
+Authenticate the cloud CLI.
+
+Options:
+  --api-key <key>       Authenticate with an API key
+  --device-code <code>  Redeem a pre-approved device code
+  --org <id-or-slug>    Select the active organization
+  --no-open             Do not open the verification URL
+  --json                Emit machine-readable output
+  -h, --help            Show this help`;
+
 /** Run `login`, `logout`, or `whoami`. */
 export async function runIdentity(
   command: "login" | "logout" | "whoami",
   argv: readonly string[]
 ): Promise<number> {
+  if (
+    command === "login" &&
+    argv.some((token) => token === "--help" || token === "-h")
+  ) {
+    process.stdout.write(`${LOGIN_HELP}\n`);
+    return 0;
+  }
   const json = wantsJson(argv);
   try {
     if (command === "login") return await login(argv, json);
@@ -58,16 +80,33 @@ async function login(argv: readonly string[], json: boolean): Promise<number> {
     strict: true,
     options: {
       "api-key": { type: "string" },
+      "device-code": { type: "string" },
       org: { type: "string" },
       "no-open": { type: "boolean" },
       json: { type: "boolean" },
     },
   });
-  let apiKey = values["api-key"] ?? process.env["MCP_USE_API_KEY"];
-  if (apiKey === undefined) {
-    apiKey = await deviceLogin(
-      values["no-open"] === true || !process.stdout.isTTY
+  if (values["api-key"] !== undefined && values["device-code"] !== undefined) {
+    throw new UsageError(
+      "--api-key and --device-code cannot be used together."
     );
+  }
+  const deviceCode = values["device-code"]?.trim();
+  if (values["device-code"] !== undefined && deviceCode === "") {
+    throw new UsageError("--device-code must not be empty.");
+  }
+  // An explicit device code is an intentional re-login and takes precedence
+  // over MCP_USE_API_KEY. An explicit API key remains mutually exclusive so a
+  // typo cannot silently authenticate as a different account.
+  let apiKey =
+    deviceCode === undefined
+      ? (values["api-key"] ?? process.env["MCP_USE_API_KEY"])
+      : undefined;
+  if (apiKey === undefined) {
+    apiKey =
+      deviceCode === undefined
+        ? await deviceLogin(values["no-open"] === true || !process.stdout.isTTY)
+        : await redeemProvidedDeviceCode(deviceCode);
   }
   const identity = await CloudApi.withApiKey(apiKey).identity();
   const selected =
@@ -149,7 +188,7 @@ async function deviceLogin(noOpen: boolean): Promise<string> {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
-      client_id: "mcp-use-cli",
+      client_id: DEVICE_CLIENT_ID,
       scope: "openid profile email",
     }),
   });
@@ -167,17 +206,42 @@ async function deviceLogin(noOpen: boolean): Promise<string> {
   );
   if (!noOpen) openBrowser(verificationUrl);
 
-  const deadline = Date.now() + code.expires_in * 1000;
-  let interval = Math.max(code.interval, 1);
+  return pollForDeviceToken(
+    base,
+    code.device_code,
+    Math.max(code.interval, 1),
+    Date.now() + code.expires_in * 1000
+  );
+}
+
+/** Redeem a device code already approved by the authenticated web onboarding flow. */
+async function redeemProvidedDeviceCode(deviceCode: string): Promise<string> {
+  return pollForDeviceToken(
+    cloudAuthUrl(),
+    deviceCode,
+    2,
+    Date.now() + DEVICE_POLL_TIMEOUT
+  );
+}
+
+async function pollForDeviceToken(
+  base: string,
+  deviceCode: string,
+  initialInterval: number,
+  deadline: number
+): Promise<string> {
+  let interval = initialInterval;
+  let firstAttempt = true;
   while (Date.now() < deadline) {
-    await sleep(interval * 1000);
+    if (!firstAttempt) await sleep(interval * 1000);
+    firstAttempt = false;
     const response = await fetch(`${base}/api/auth/device/token`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         grant_type: "urn:ietf:params:oauth:grant-type:device_code",
-        device_code: code.device_code,
-        client_id: "mcp-use-cli",
+        device_code: deviceCode,
+        client_id: DEVICE_CLIENT_ID,
       }),
     });
     const token = (await response.json()) as DeviceToken;
@@ -210,12 +274,24 @@ async function deviceLogin(noOpen: boolean): Promise<string> {
       interval += 5;
       continue;
     }
-    throw new CommandError(
-      "login_failed",
-      token.error_description ?? token.error ?? "Device login failed."
-    );
+    throw deviceTokenError(token);
   }
   throw new CommandError("login_timeout", "Device login expired.");
+}
+
+function deviceTokenError(token: DeviceToken): CommandError {
+  if (token.error === "access_denied") {
+    return new CommandError("login_failed", "Device login was denied.");
+  }
+  if (token.error === "expired_token") {
+    return new CommandError("login_failed", "Device code has expired.");
+  }
+  // Device codes are bearer credentials. Do not include an untrusted server
+  // diagnostic here: an intermediary may reflect the submitted code.
+  return new CommandError(
+    "login_failed",
+    "Device code is invalid, expired, or has already been redeemed."
+  );
 }
 
 function sleep(milliseconds: number): Promise<void> {

--- a/libraries/typescript/packages/server/tests/commands/identity.test.ts
+++ b/libraries/typescript/packages/server/tests/commands/identity.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { writeCloudConfig, withApiKey } = vi.hoisted(() => {
+  const identity = {
+    userId: "user_1",
+    email: "person@example.com",
+    organizations: [],
+    defaultOrganizationId: null,
+  };
+  return {
+    writeCloudConfig: vi.fn(async () => {}),
+    withApiKey: vi.fn(() => ({ identity: async () => identity })),
+  };
+});
+
+vi.mock("../../src/commands/cloud-api.js", () => ({
+  cloudAuthUrl: () => "https://cloud.example.test",
+  CloudApi: { withApiKey },
+  clearCloudConfig: vi.fn(),
+  readCloudConfig: vi.fn(),
+  resolveOrganization: vi.fn(),
+  writeCloudConfig,
+}));
+
+import { runIdentity } from "../../src/commands/identity.js";
+
+const originalFetch = globalThis.fetch;
+const originalApiKey = process.env.MCP_USE_API_KEY;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalApiKey === undefined) delete process.env.MCP_USE_API_KEY;
+  else process.env.MCP_USE_API_KEY = originalApiKey;
+  writeCloudConfig.mockClear();
+  withApiKey.mockClear();
+  vi.restoreAllMocks();
+});
+
+describe("login --device-code", () => {
+  it("redeems a pre-approved code, validates the resulting key, and never prints either secret", async () => {
+    const deviceCode = "device-secret";
+    const apiKey = "mcp_secret";
+    const requests: Request[] = [];
+    globalThis.fetch = vi.fn(async (input, init) => {
+      requests.push(new Request(input, init));
+      if (String(input).endsWith("/device/token")) {
+        return Response.json({ access_token: "access-secret" });
+      }
+      return Response.json({ key: apiKey });
+    });
+    const stderr = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+    const stdout = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+
+    await expect(
+      runIdentity("login", ["--device-code", deviceCode])
+    ).resolves.toBe(0);
+
+    expect(requests).toHaveLength(2);
+    expect(await requests[0]!.json()).toEqual({
+      grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+      device_code: deviceCode,
+      client_id: "mcp-use-cli",
+    });
+    expect(requests[1]!.headers.get("authorization")).toBe(
+      "Bearer access-secret"
+    );
+    expect(withApiKey).toHaveBeenCalledWith(apiKey);
+    expect(writeCloudConfig).toHaveBeenCalledWith({ apiKey });
+    expect(stderr).not.toHaveBeenCalled();
+    expect(stdout).not.toHaveBeenCalledWith(
+      expect.stringContaining(deviceCode)
+    );
+    expect(stdout).not.toHaveBeenCalledWith(expect.stringContaining(apiKey));
+  });
+
+  it("prefers an explicit device code over MCP_USE_API_KEY", async () => {
+    process.env.MCP_USE_API_KEY = "mcp_env_secret";
+    globalThis.fetch = vi.fn(async (input) =>
+      String(input).endsWith("/device/token")
+        ? Response.json({ access_token: "access-secret" })
+        : Response.json({ key: "mcp_device_secret" })
+    );
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await expect(
+      runIdentity("login", ["--device-code", "device-secret"])
+    ).resolves.toBe(0);
+
+    expect(withApiKey).toHaveBeenCalledWith("mcp_device_secret");
+  });
+
+  it("reports an expired code as a structured error without reflecting the secret", async () => {
+    const deviceCode = "do-not-print-me";
+    globalThis.fetch = vi.fn(async () =>
+      Response.json({ error: "expired_token" })
+    );
+    const stderr = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+
+    await expect(
+      runIdentity("login", ["--device-code", deviceCode, "--json"])
+    ).resolves.toBe(1);
+
+    expect(stderr).toHaveBeenCalledWith(
+      `${JSON.stringify({ error: { code: "login_failed", message: "Device code has expired." } })}\n`
+    );
+    expect(stderr).not.toHaveBeenCalledWith(
+      expect.stringContaining(deviceCode)
+    );
+    expect(writeCloudConfig).not.toHaveBeenCalled();
+  });
+
+  it("redacts server diagnostics for an invalid code", async () => {
+    const deviceCode = "do-not-print-me";
+    globalThis.fetch = vi.fn(async () =>
+      Response.json({
+        error: "invalid_grant",
+        error_description: `bad ${deviceCode}`,
+      })
+    );
+    const stderr = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+
+    await expect(
+      runIdentity("login", ["--device-code", deviceCode])
+    ).resolves.toBe(1);
+
+    expect(stderr).toHaveBeenCalledWith(
+      "Device code is invalid, expired, or has already been redeemed.\n"
+    );
+    expect(stderr).not.toHaveBeenCalledWith(
+      expect.stringContaining(deviceCode)
+    );
+  });
+
+  it("rejects empty and conflicting credentials", async () => {
+    const stderr = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+
+    await expect(
+      runIdentity("login", ["--device-code", "   ", "--json"])
+    ).resolves.toBe(2);
+    await expect(
+      runIdentity("login", [
+        "--api-key",
+        "key",
+        "--device-code",
+        "code",
+        "--json",
+      ])
+    ).resolves.toBe(2);
+
+    expect(stderr).toHaveBeenNthCalledWith(
+      1,
+      `${JSON.stringify({ error: { code: "usage_error", message: "--device-code must not be empty." } })}\n`
+    );
+    expect(stderr).toHaveBeenNthCalledWith(
+      2,
+      `${JSON.stringify({ error: { code: "usage_error", message: "--api-key and --device-code cannot be used together." } })}\n`
+    );
+  });
+
+  it("lists the option in login help", async () => {
+    const stdout = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+
+    await expect(runIdentity("login", ["--help"])).resolves.toBe(0);
+
+    expect(stdout).toHaveBeenCalledWith(
+      expect.stringContaining("--device-code <code>")
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Add `--device-code` support for non-interactive CLI authentication
- Redeem RFC 8628 device codes and persist a validated API key
- Enforce credential precedence and conflict rules
- Redact device codes and bearer credentials from output and errors
- Update CLI documentation and specifications

## Testing

- Add unit coverage for redemption, precedence, validation, redaction, usage errors, and help output

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a pre-approved device-code login flow to the CLI and strengthens credential handling and help. Validates and stores a new API key without opening a browser.

- **New Features**
  - Add `mcp-use login --device-code <code>` to redeem RFC 8628 codes non-interactively and persist a validated API key.
  - Enforce precedence: `--api-key` and `--device-code` are mutually exclusive; explicit `--device-code` overrides `MCP_USE_API_KEY`.
  - Return structured errors for expired/denied/invalid codes; never print device codes, bearer tokens, or API keys in text or JSON output.
  - Update help/docs/specs: `mcp-use login --help` documents `--device-code`, `--no-open`, and `--json`; `--org` stores the account-default when omitted.

<sup>Written for commit 8a5b202766e99f5ee31336fb3fd61a9f25a7c9fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1978?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

