### PR TITLE
Fix Windows CLI build artifact verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -800,7 +800,7 @@ jobs:
         run: pnpm build
       - name: Verify CLI build artifact
         shell: bash
-        run: test -f packages/cli/dist/index.cjs || { echo "::warning::dist/index.cjs missing after pnpm build, rebuilding CLI explicitly"; pnpm --filter @mcp-use/cli build; }
+        run: test -f packages/cli/dist/bin.js || { echo "::warning::dist/bin.js missing after pnpm build, rebuilding CLI explicitly"; pnpm --filter @mcp-use/cli build; }
       - name: Run CLI Tests
         env:
           MCP_USE_ANONYMIZED_TELEMETRY: false

--- a/libraries/typescript/packages/cli/scripts/verify-package.mjs
+++ b/libraries/typescript/packages/cli/scripts/verify-package.mjs
@@ -5,8 +5,12 @@ import { fileURLToPath } from "node:url";
 const root = fileURLToPath(new URL("../", import.meta.url));
 const files = walk(join(root, "dist"));
 
-if (!files.includes("dist/bin.js")) throw new Error("Missing dist/bin.js");
-if (!files.includes("dist/index.js")) throw new Error("Missing dist/index.js");
+if (!files.includes(join("dist", "bin.js"))) {
+  throw new Error("Missing dist/bin.js");
+}
+if (!files.includes(join("dist", "index.js"))) {
+  throw new Error("Missing dist/index.js");
+}
 if (files.some((file) => file.endsWith(".map"))) {
   throw new Error("CLI package must not publish source maps");
 }


### PR DESCRIPTION
## Summary
- Check for the CLI’s `dist/bin.js` artifact in CI.
- Make package verification use platform-independent path joining.

## Testing
- Not run (not requested)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CLI artifact verification in CI and package checks. CI now checks `dist/bin.js`, and the verify script uses platform-safe paths for Windows.

- **Bug Fixes**
  - CI checks for `dist/bin.js` and rebuilds `@mcp-use/cli` if missing.
  - Package verify script uses path.join to check `dist/bin.js` and `dist/index.js`, and still blocks source maps.

<sup>Written for commit fcd438705801f758f210f6235c99b9fcf074c43f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1979?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

