### PR TITLE
fix(agent): native OpenAI e2e + reasoning/mcpServers regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -695,15 +695,16 @@ jobs:
         env:
           MCP_USE_ANONYMIZED_TELEMETRY: false
         run: pnpm --filter mcp-use --if-present test:unit
-      - name: Run mcp-use Agent Integration Tests
+      - name: Run @mcp-use/agent Unit Tests
+        env:
+          MCP_USE_ANONYMIZED_TELEMETRY: false
+        run: pnpm --filter @mcp-use/agent test:unit
+      - name: Run @mcp-use/agent native OpenAI e2e
         if: env.OPENAI_API_KEY != ''
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
-          LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
-          MCP_USE_LANGFUSE: true
           MCP_USE_ANONYMIZED_TELEMETRY: false
-        run: pnpm --filter mcp-use --if-present test:integration:agent
+        run: pnpm --filter @mcp-use/agent test:integration:native-openai
 
   typescript-knip:
     needs: typescript-lint

--- a/libraries/typescript/packages/agent/package.json
+++ b/libraries/typescript/packages/agent/package.json
@@ -58,7 +58,8 @@
     "test:integration:structured": "vitest run tests/integration/agent/test_agent_structured_output.test.ts",
     "test:integration:manager": "vitest run tests/integration/agent/test_server_manager.test.ts",
     "test:integration:observability": "vitest run tests/integration/agent/test_agent_observability.test.ts",
-    "test:integration:codemode": "vitest run tests/integration/agent/test_code_mode.test.ts"
+    "test:integration:codemode": "vitest run tests/integration/agent/test_code_mode.test.ts",
+    "test:integration:native-openai": "vitest run tests/integration/agent/test_agent_native_openai.test.ts"
   },
   "dependencies": {
     "@mcp-use/client": "workspace:*",

--- a/libraries/typescript/packages/agent/src/agents/mcp_agent.ts
+++ b/libraries/typescript/packages/agent/src/agents/mcp_agent.ts
@@ -198,11 +198,6 @@ export class MCPAgent {
     if (this.initialized) return;
 
     if (this.isSimplifiedMode) {
-      if (!this.client && this.mcpServersConfig) {
-        const { MCPClient } = await import("@mcp-use/client");
-        this.client = new MCPClient({ mcpServers: this.mcpServersConfig });
-        this.clientOwnedByAgent = true;
-      }
       if (this.llmString) {
         this.driver = createLlmDriver(
           parseLLMStringToProviderConfig(this.llmString, this.llmConfig)
@@ -210,6 +205,12 @@ export class MCPAgent {
       }
     } else if (this.explicitProviderConfig) {
       this.driver = createLlmDriver(this.explicitProviderConfig);
+    }
+
+    if (!this.client && this.mcpServersConfig && !this.hasLiveConnections()) {
+      const { MCPClient } = await import("@mcp-use/client");
+      this.client = new MCPClient({ mcpServers: this.mcpServersConfig });
+      this.clientOwnedByAgent = true;
     }
 
     if (!this.driver) {

--- a/libraries/typescript/packages/agent/src/llm/__tests__/openai-responses.test.ts
+++ b/libraries/typescript/packages/agent/src/llm/__tests__/openai-responses.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   extractFunctionCalls,
+  responsesReasoningFields,
   seedInputFromMessages,
 } from "../providers/openai-responses";
 import { toolResultToContent } from "../toolResultParts";
@@ -105,6 +106,43 @@ describe("extractFunctionCalls", () => {
         arguments: '{"city":"Paris"}',
       },
     ]);
+  });
+});
+
+describe("responsesReasoningFields", () => {
+  it("omits reasoning params by default", () => {
+    expect(
+      responsesReasoningFields({
+        provider: "openai",
+        model: "gpt-4o-mini",
+        apiKey: "k",
+      })
+    ).toEqual({});
+  });
+
+  it("omits reasoning params when effort is none", () => {
+    expect(
+      responsesReasoningFields({
+        provider: "openai",
+        model: "o3-mini",
+        apiKey: "k",
+        reasoningEffort: "none",
+      })
+    ).toEqual({});
+  });
+
+  it("includes reasoning params when effort is set", () => {
+    expect(
+      responsesReasoningFields({
+        provider: "openai",
+        model: "o3-mini",
+        apiKey: "k",
+        reasoningEffort: "low",
+      })
+    ).toEqual({
+      include: ["reasoning.encrypted_content"],
+      reasoning: { effort: "low" },
+    });
   });
 });
 

--- a/libraries/typescript/packages/agent/src/llm/providers/openai-responses.ts
+++ b/libraries/typescript/packages/agent/src/llm/providers/openai-responses.ts
@@ -177,6 +177,18 @@ export function appendToolOutputsToInput(
   }
 }
 
+function responsesReasoningFields(
+  config: ProviderConfig
+): Record<string, unknown> {
+  const effort = config.reasoningEffort;
+  // ponytail: omit reasoning.* unless caller opts in — most chat models 400 on it
+  if (!effort || effort === "none") return {};
+  return {
+    include: ["reasoning.encrypted_content"],
+    reasoning: { effort },
+  };
+}
+
 function buildResponsesBody(
   params: ResponsesTurnParams,
   stream: boolean
@@ -185,9 +197,8 @@ function buildResponsesBody(
     model: params.config.model,
     input: params.input,
     store: false,
-    include: ["reasoning.encrypted_content"],
-    reasoning: { effort: params.config.reasoningEffort ?? "low" },
     stream,
+    ...responsesReasoningFields(params.config),
   };
   if (params.instructions) body.instructions = params.instructions;
   if (params.tools && params.tools.length > 0) {
@@ -418,4 +429,4 @@ export async function completeResponsesTurn(
   };
 }
 
-export { isToolResultError };
+export { isToolResultError, responsesReasoningFields };

--- a/libraries/typescript/packages/agent/tests/integration/agent/constants.ts
+++ b/libraries/typescript/packages/agent/tests/integration/agent/constants.ts
@@ -1,1 +1,10 @@
 export const OPENAI_MODEL = "gpt-4.1-2025-04-14";
+
+/** Cheaper/faster model for native-provider HTTP e2e (gpt-4o-mini rejects reasoning.effort). */
+export const OPENAI_NATIVE_E2E_MODEL =
+  process.env.OPENAI_MODEL ?? "gpt-4o-mini";
+
+/** Public analytics-demo server used by agent native OpenAI e2e. */
+export const AGENT_E2E_MCP_URL =
+  process.env.MCP_AGENT_E2E_MCP_URL ??
+  "https://fast-forge-tpw2s.run.mcp-use.com/mcp";

--- a/libraries/typescript/packages/agent/tests/integration/agent/test_agent_native_openai.test.ts
+++ b/libraries/typescript/packages/agent/tests/integration/agent/test_agent_native_openai.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Regression: native MCPAgent + OpenAI Responses API + HTTP mcpServers config.
+ *
+ * Guards:
+ * - explicit `llm: ProviderConfig` + `mcpServers: { url }` spawns MCPClient and loads tools
+ * - OpenAI provider omits `reasoning.effort` unless `reasoningEffort` is set (gpt-4o-mini)
+ *
+ * Requires OPENAI_API_KEY (set in GitHub Actions secrets).
+ */
+import { describe, expect, it } from "vitest";
+import { MCPAgent, providerConfigFromOptions } from "../../../src/index.js";
+import { AGENT_E2E_MCP_URL, OPENAI_NATIVE_E2E_MODEL } from "./constants.js";
+
+describe.skipIf(!process.env.OPENAI_API_KEY)(
+  "MCPAgent native OpenAI + HTTP mcpServers",
+  () => {
+    it("calls a remote MCP tool and summarizes the result", async () => {
+      const agent = new MCPAgent({
+        llm: providerConfigFromOptions("openai", OPENAI_NATIVE_E2E_MODEL, {
+          apiKey: process.env.OPENAI_API_KEY!,
+          temperature: 0,
+        }),
+        mcpServers: {
+          analytics: { url: AGENT_E2E_MCP_URL },
+        },
+        maxSteps: 10,
+        autoInitialize: true,
+      });
+
+      try {
+        const result = await agent.run({
+          prompt:
+            "Use the get-metrics tool with empty arguments, then summarize the key numbers in 2-3 sentences.",
+          maxSteps: 10,
+        });
+
+        expect(typeof result).toBe("string");
+        expect(result).toMatch(
+          /totalUsers|activeUsers|revenue|24,?580|24580|metrics/i
+        );
+      } finally {
+        await agent.close();
+      }
+    }, 90_000);
+  }
+);


### PR DESCRIPTION
## Summary
- Fix `@mcp-use/agent` sending `reasoning.effort` by default (400 on `gpt-4o-mini`) — only include reasoning params when `reasoningEffort` is explicitly set
- Fix `MCPAgent` not spawning `MCPClient` when using explicit `llm: ProviderConfig` + `mcpServers: { url }`
- Add OpenAI native e2e integration test (remote analytics-demo MCP) and wire it into CI when `OPENAI_API_KEY` is set

## Test plan
- [x] `pnpm --filter @mcp-use/agent test:unit` (128 passed)
- [x] `pnpm --filter @mcp-use/agent test:integration:native-openai` with `OPENAI_API_KEY` (1 passed, ~5s)
- [ ] CI `Run @mcp-use/agent native OpenAI e2e` on this PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OpenAI Responses defaults and MCP server init in `@mcp-use/agent`, preventing 400s on `gpt-4o-mini` and ensuring tools load with explicit `llm` + `mcpServers` configs. Adds a native OpenAI e2e against the analytics demo MCP and runs it in CI when `OPENAI_API_KEY` is set.

- **Bug Fixes**
  - Omit OpenAI Responses `reasoning.*` unless `reasoningEffort` is set.
  - Spawn `MCPClient` when using explicit `llm: ProviderConfig` with `mcpServers: { url }`.

<sup>Written for commit 44b4387a86971f7059844db405183fd332b44404. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1981?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

