### PR TITLE
Fix client CLI OAuth and JSON behavior

### DIFF
--- a/docs/typescript/api-reference/cli-reference.mdx
+++ b/docs/typescript/api-reference/cli-reference.mdx
@@ -24,7 +24,7 @@ For hands-on workflows, see the [CLI Client guide](/typescript/tooling/client-cl
   </Card>
   <Card title="Client CLI" icon="terminal" href="#client">
     `mcp-use client` saves MCP servers, calls tools, reads resources, gets
-    prompts, handles OAuth, and captures widget screenshots.
+    prompts, and handles OAuth.
   </Card>
   <Card title="Tunnels" icon="train-front-tunnel" href="#tunneling-reference">
     `mcp-use dev --tunnel` exposes a local server through a public URL.
@@ -507,7 +507,7 @@ mcp-use servers env remove API_KEY --server srv_abc123
 
 ## `client`
 
-**Purpose:** Use MCP servers from the terminal. The client command can save server connections, call tools, read resources, get prompts, manage OAuth tokens, and render MCP Apps widgets as PNG screenshots.
+**Purpose:** Save HTTP MCP server connections, call tools, read resources, get prompts, and manage OAuth credentials from the terminal.
 
 **Syntax:**
 
@@ -518,66 +518,46 @@ mcp-use client <name> <scope> <action>
 
 **Top-level subcommands:**
 
-| Command                                | Purpose                                    | Key options                                                       |
-| -------------------------------------- | ------------------------------------------ | ----------------------------------------------------------------- |
-| `connect [name] [url]`                 | Save an MCP server under a short name.     | `--stdio`, `--auth <token>`, `--no-oauth`, `--auth-timeout <ms>`  |
-| `list`                                 | List saved servers.                        | None                                                              |
-| `remove <name>`                        | Remove a saved server.                     | None                                                              |
-| `screenshot --mcp <url> --tool <name>` | Render a widget from an ad-hoc MCP server. | `--mcp <url>`, `-H, --header <header>`, common screenshot options |
+| Command                | Purpose                                | Key options                                                                                        |
+| ---------------------- | -------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `connect <name> <url>` | Verify and save an HTTP(S) MCP server. | `-H, --header`, `--no-oauth`, `--auth-timeout <ms>`, `--protocol <version>`, `--no-open`, `--json` |
+| `list`                 | List saved servers.                    | `--json`                                                                                           |
+| `remove <name>`        | Remove a saved server and credentials. | `--yes`                                                                                            |
 
 **Per-server scopes:**
 
-| Scope                | Actions                                                      |
-| -------------------- | ------------------------------------------------------------ |
-| `tools`              | `list`, `call <tool> [args...]`, `describe <tool>`           |
-| `resources`          | `list`, `read <uri>`, `subscribe <uri>`, `unsubscribe <uri>` |
-| `prompts`            | `list`, `get <prompt> [args...]`                             |
-| `auth`               | `status`, `refresh`, `logout`                                |
-| `screenshot`         | `--tool <name> [args...]`                                    |
-| Top-level per server | `interactive`, `disconnect`                                  |
+| Scope       | Actions                                                             |
+| ----------- | ------------------------------------------------------------------- |
+| `tools`     | `list`, `describe <tool>`, `call <tool> [args...] [--timeout <ms>]` |
+| `resources` | `list`, `read <uri>`                                                |
+| `prompts`   | `list`, `get <prompt> [args...]`                                    |
+| `auth`      | `status`, `logout [--yes]`                                          |
+
+Every action in this table accepts `--json` except where the top-level table does not advertise it.
 
 **Examples:**
 
 ```bash
 mcp-use client connect local http://localhost:3000/mcp
-mcp-use client connect fs "npx -y @modelcontextprotocol/server-filesystem /tmp" --stdio
 mcp-use client list
 mcp-use client local tools list
 mcp-use client local tools call read_file path=/tmp/test.txt
 mcp-use client local resources read "file:///tmp/data.json"
 mcp-use client local prompts get greeting name=Alice
 mcp-use client local auth status
-mcp-use client local screenshot --tool show-board boardId=demo
-mcp-use client screenshot --mcp https://mcp.example.com --tool show-board
-mcp-use client local disconnect
 ```
 
 **Notes and behavior:**
 
-- Saved servers are stored in `~/.mcp-use/cli-sessions.json`.
-- OAuth tokens for saved HTTP servers are stored under `~/.mcp-use/oauth/<urlHash>/`.
-- `connect --auth <token>` stores a static bearer token and skips OAuth.
+- Saved server metadata is stored in `~/.mcp-use/client/servers.json`. Credentials are stored separately under `~/.mcp-use/client/credentials/`.
+- In an interactive TTY, OAuth displays `This server requires OAuth. Press Enter to open your browser.` and opens the browser only after Enter.
+- `--no-open`, `--json`, and non-TTY operation never prompt or open a browser. They print the authorization URL to stderr while the loopback callback continues waiting.
 - `connect --no-oauth` prevents automatic OAuth when the server returns `401`.
+- Repeated `-H, --header <"Key: Value">` options store static headers as credentials.
 - Tool and prompt arguments accept `key=value`, `key:=<json>`, or a single JSON object argument.
-- `tools call --screenshot` captures a widget screenshot when the tool declares a UI resource.
-- `resources subscribe` keeps the process running until interrupted.
-
-Common screenshot options:
-
-| Option                      | Description                                                    | Default                        |
-| --------------------------- | -------------------------------------------------------------- | ------------------------------ |
-| `--tool <name>`             | Tool whose UI resource should be rendered.                     | Required                       |
-| `--width <px>`              | Output image width.                                            | Widget natural width           |
-| `--height <px>`             | Output image height.                                           | Widget natural height          |
-| `--device-scale-factor <n>` | Device pixel ratio. Must be greater than `0` and at most `4`.  | `1`                            |
-| `--inspector <url>`         | Inspector host that serves `/inspector/preview/:view`.         | Auto-spawned                   |
-| `--theme <theme>`           | Rendered color scheme. Accepted values are `light` and `dark`. | `light`                        |
-| `--output <path>`           | Output PNG path.                                               | `./<view>-<timestamp>.png`     |
-| `--wait-for <selector>`     | Readiness selector.                                            | `body[data-view-ready="true"]` |
-| `--delay <ms>`              | Extra wait after readiness.                                    | `0`                            |
-| `--timeout <ms>`            | Navigation and readiness timeout.                              | `30000`                        |
-| `--cdp-url <url>`           | Existing CDP WebSocket URL instead of local Chrome.            | None                           |
-| `--quiet`                   | Suppress development server output.                            | Disabled                       |
+- `--json` may appear anywhere after `client`. Success emits exactly one JSON value to stdout. Errors emit exactly one JSON error envelope to stderr and no stdout value.
+- Calls, resource reads, and prompt gets emit raw MCP result envelopes. Lists emit arrays, and `tools describe` emits one tool object.
+- Tool `isError` results exit `1` and retain the original protocol result in `error.details` under `--json`.
 
 <Card
   title="CLI Client guide"
@@ -585,7 +565,7 @@ Common screenshot options:
   href="/typescript/tooling/client-cli"
 >
   Use the guide for connection workflows, OAuth behavior, argument parsing
-  examples, scripting patterns, and screenshots.
+  examples, and scripting patterns.
 </Card>
 
 ## `skills add`

--- a/docs/typescript/tooling/client-cli.mdx
+++ b/docs/typescript/tooling/client-cli.mdx
@@ -1,29 +1,16 @@
 ---
 title: CLI Client
-description: Connect to MCP servers from the terminal, call tools, read resources, get prompts, manage auth, and capture widget screenshots.
+description: Connect to HTTP MCP servers, call tools, read resources, get prompts, manage OAuth, and produce parseable JSON from the terminal.
 icon: "terminal"
 ---
 
-Use `mcp-use client` when you want to test or automate an MCP server from the terminal. The fastest useful loop is: connect to a server, list its tools, then call one tool.
+Use `mcp-use client` to test or automate an HTTP MCP server from the terminal. Save a server under a name, then use that name for every tool, resource, prompt, and auth command.
 
-For the complete command and flag catalog, see the [CLI reference](/typescript/api-reference/cli-reference#client-commands).
-
-## Install the CLI
-
-Run the CLI with `npx`, or install it globally if you use it often.
-
-```bash
-npx mcp-use client --help
-```
-
-```bash
-npm install -g @mcp-use/cli
-mcp-use client --help
-```
+For the complete command and flag catalog, see the [CLI reference](/typescript/api-reference/cli-reference#client).
 
 ## Connect and call a tool
 
-Save the server under a short name, then use that name in every later command.
+Run the CLI with `npx`, or install `mcp-use` in your project.
 
 ```bash
 npx mcp-use client connect dev http://localhost:3000/mcp
@@ -31,39 +18,53 @@ npx mcp-use client dev tools list
 npx mcp-use client dev tools call get-weather city=Tokyo
 ```
 
-After `connect`, the CLI prints the server name, version, capabilities, and tool count. Use `tools list` as the quick verification step. If the command returns the tools you expect, the server is reachable and initialized.
+`connect` supports HTTP and HTTPS MCP URLs. It verifies the connection before saving it. The CLI stores saved server metadata under `~/.mcp-use/client/`.
 
-Use any short name that helps you remember the target, such as `dev`, `staging`, `prod`, or `filesystem`.
-
-## Connect to HTTP or stdio servers
-
-HTTP servers use a URL. The saved name comes before the URL.
-
-```bash
-npx mcp-use client connect dev http://localhost:3000/mcp
-```
-
-Stdio servers use `--stdio`. Quote the command so the CLI can split it into the executable and arguments.
-
-```bash
-npx mcp-use client connect fs "npx -y @modelcontextprotocol/server-filesystem /tmp" --stdio
-```
-
-List saved servers when you need to confirm the names you have available.
+List or remove saved servers with these commands:
 
 ```bash
 npx mcp-use client list
-```
-
-Remove a saved server when you no longer need it.
-
-```bash
 npx mcp-use client remove dev
 ```
 
+## Authenticate with OAuth
+
+When a server requires OAuth in an interactive terminal, the CLI displays this prompt:
+
+```text
+This server requires OAuth. Press Enter to open your browser.
+```
+
+Press Enter to open the authorization page. The command keeps waiting for the loopback callback, then verifies and saves the connection.
+
+Use `--no-open` to authenticate without launching a browser:
+
+```bash
+npx mcp-use client connect prod https://mcp.example.com/mcp --no-open
+```
+
+With `--no-open`, `--json`, or non-interactive stdin, the CLI never prompts or opens a browser. It prints the authorization URL to stderr and continues waiting for the loopback callback. Open that URL yourself to finish authentication.
+
+Use `--no-oauth` for a public server or when an authorization challenge should fail instead of starting OAuth. Repeated `-H` or `--header` options add static request headers.
+
+```bash
+npx mcp-use client connect public https://mcp.example.com/mcp --no-oauth
+npx mcp-use client connect private https://mcp.example.com/mcp \
+  -H "Authorization: Bearer $TOKEN" --no-oauth
+```
+
+Check or clear saved OAuth credentials with auth commands:
+
+```bash
+npx mcp-use client prod auth status
+npx mcp-use client prod auth logout
+```
+
+`auth logout` removes OAuth material but keeps the saved server and its non-OAuth connection metadata.
+
 ## Call tools
 
-Start with `tools list`, then inspect a tool schema before calling tools with required inputs.
+List tools, inspect a tool schema, then call the tool with its required inputs.
 
 ```bash
 npx mcp-use client dev tools list
@@ -71,21 +72,15 @@ npx mcp-use client dev tools describe get-weather
 npx mcp-use client dev tools call get-weather city=Tokyo
 ```
 
-Tool arguments can be passed as `key=value` pairs. Use `key:=<json>` for nested values, or pass one JSON object.
+Tool and prompt arguments accept `key=value` pairs. Use `key:=<json>` for typed or nested values, or pass one JSON object.
 
 ```bash
-npx mcp-use client dev tools call search query=shoes limit=5
+npx mcp-use client dev tools call search query=shoes limit:=5
 npx mcp-use client dev tools call search filters:='{"color":"black","inStock":true}'
 npx mcp-use client dev tools call search '{"query":"shoes","limit":5}'
 ```
 
-Use `--json` when another command or script needs to parse the result.
-
-```bash
-npx mcp-use client dev tools call get-weather city=Tokyo --json
-```
-
-Use `--timeout <ms>` for slow tools.
+Use `--timeout <ms>` for slow tools. The default is `30000` milliseconds.
 
 ```bash
 npx mcp-use client dev tools call generate-report topic=sales --timeout 60000
@@ -93,139 +88,55 @@ npx mcp-use client dev tools call generate-report topic=sales --timeout 60000
 
 ## Read resources
 
-Resources are server-provided content identified by URI. List resources first, then read the URI you need.
+Resources are server-provided content identified by URI. List resources, then read the URI you need.
 
 ```bash
 npx mcp-use client dev resources list
 npx mcp-use client dev resources read "file:///tmp/data.json"
 ```
 
-If a resource supports updates, subscribe to stream changes until you stop the process.
-
-```bash
-npx mcp-use client dev resources subscribe "file:///tmp/data.json"
-```
-
 ## Get prompts
 
-Prompts are reusable message templates exposed by the server. List prompts, then get one with its arguments.
+Prompts are reusable message templates exposed by the server. Prompt arguments use the same forms as tool arguments.
 
 ```bash
 npx mcp-use client dev prompts list
 npx mcp-use client dev prompts get greeting name=Alice
-npx mcp-use client dev prompts get greeting '{"name":"Alice"}' --json
+npx mcp-use client dev prompts get greeting '{"name":"Alice"}'
 ```
 
-Prompt arguments use the same simple forms as tool arguments.
+## Produce parseable JSON
 
-## Check OAuth status
-
-For HTTP servers that require OAuth, `connect` starts the browser-based OAuth flow when the server returns `401 Unauthorized`. After authentication, the saved server reuses those credentials for tools, resources, prompts, and screenshots.
+Every client command documented with `--json` accepts it anywhere after `client`. The following forms are equivalent:
 
 ```bash
-npx mcp-use client connect prod https://mcp.example.com/mcp
-npx mcp-use client prod auth status
+npx mcp-use client --json dev tools list
+npx mcp-use client dev --json tools list
+npx mcp-use client dev tools list --json
 ```
 
-Use `auth refresh` when you want to force a token refresh, and `auth logout` when you want to clear stored OAuth tokens for that server URL.
+Successful commands write exactly one JSON value followed by a newline to stdout. Calls, resource reads, and prompt gets return the raw MCP result envelope. Lists return arrays. Errors write one envelope to stderr and do not write a result to stdout:
 
-```bash
-npx mcp-use client prod auth refresh
-npx mcp-use client prod auth logout
+```json
+{ "error": { "code": "usage_error", "message": "Tool not found: missing" } }
 ```
 
-Auth commands apply only to HTTP servers authenticated through OAuth. For a static bearer token, pass `--auth` when connecting.
-
-```bash
-npx mcp-use client connect prod https://mcp.example.com/mcp --auth "$TOKEN"
-```
-
-Pass `--no-oauth` when you want the CLI to fail on `401 Unauthorized` instead of starting OAuth.
-
-```bash
-npx mcp-use client connect prod https://mcp.example.com/mcp --no-oauth
-```
-
-## Capture widget screenshots
-
-Use screenshots to verify MCP Apps widgets from a terminal or an automated test. The saved-server form reuses the auth from `connect`.
-
-```bash
-npx mcp-use client dev screenshot --tool show-board boardId=demo --output ./board.png
-```
-
-You can also call a tool and save its widget screenshot in one command.
-
-```bash
-npx mcp-use client dev tools call show-board boardId=demo --screenshot
-```
-
-For one-off captures without saving a server first, use the ad-hoc form with `--mcp`.
-
-```bash
-npx mcp-use client screenshot --mcp http://localhost:3000/mcp --tool show-board boardId=demo
-```
-
-Authenticated ad-hoc screenshots can pass HTTP headers. Header flags apply only to the ad-hoc form.
-
-```bash
-npx mcp-use client screenshot \
-  --mcp https://mcp.example.com/mcp \
-  -H "Authorization: Bearer $TOKEN" \
-  --tool show-board boardId=demo
-```
-
-Common screenshot options include `--output`, `--width`, `--height`, `--device-scale-factor`, `--theme`, `--wait-for`, `--delay`, `--timeout`, and `--cdp-url`. See the [CLI reference](/typescript/api-reference/cli-reference#client-commands) for the full screenshot option list.
-
-## Use interactive mode
-
-Interactive mode opens a small REPL for one saved server. Use it when you want to explore tools, resources, and prompts without repeating the full command prefix.
-
-```bash
-npx mcp-use client dev interactive
-```
-
-```text
-mcp> tools list
-mcp> tools describe get-weather
-mcp> tools call get-weather
-Arguments (JSON, or press Enter for none): {"city":"Tokyo"}
-mcp> exit
-```
-
-## Script common checks
-
-Use `--json` and stable saved names when scripting. This keeps stdout parseable while status messages stay on stderr.
+OAuth authorization URLs and dependency-install status are operational messages on stderr, so stdout remains parseable under `--json`.
 
 ```bash
 #!/usr/bin/env bash
 set -euo pipefail
 
-npx mcp-use client connect dev http://localhost:3000/mcp
+npx mcp-use client connect dev http://localhost:3000/mcp --no-oauth --json >/dev/null
 npx mcp-use client dev tools list --json | jq -r '.[].name'
 npx mcp-use client dev tools call get-weather city=Tokyo --json | jq '.content'
 ```
 
-For local development, a compact smoke test is enough: connect, list tools, describe the tool you changed, then call it once.
+## Troubleshoot commands
 
-```bash
-npx mcp-use client connect dev http://localhost:3000/mcp
-npx mcp-use client dev tools list
-npx mcp-use client dev tools describe my-tool
-npx mcp-use client dev tools call my-tool input=value
-```
+- `Unknown saved server: <name>`: run `npx mcp-use client list`, or reconnect with `npx mcp-use client connect <name> <url>`.
+- `Tool not found: <name>`: run `tools list` against the same saved server.
+- An OAuth command waits without opening a browser: open the authorization URL printed to stderr, then complete authorization before the configured timeout.
+- A tool returns an error: under `--json`, inspect `error.details` for the original MCP tool result.
 
-## When a command fails
-
-Most failures can be diagnosed from the command you just ran:
-
-- `Server '<name>' not found`: run `npx mcp-use client list`, or reconnect with `npx mcp-use client connect <name> <url>`.
-- `This tool requires arguments`: run `tools describe <tool>` and pass the required inputs.
-- `Tool '<name>' not found`: run `tools list` against the same saved server.
-- OAuth refresh fails: run `mcp-use client connect <name> <url>` again to re-authenticate.
-
-For exhaustive flags, command shapes, and storage details, use the [CLI reference](/typescript/api-reference/cli-reference#client-commands).
-
-## Next steps
-
-Use the [TypeScript server overview](/typescript/server) to build a server that exposes tools, resources, prompts, and widgets. Use the [MCP Apps guide](/typescript/mcp-apps) when your tools should return interactive React widgets.
+For exhaustive command shapes, flags, and storage details, use the [CLI reference](/typescript/api-reference/cli-reference#client).

--- a/libraries/typescript/packages/client/src/auth/flow.ts
+++ b/libraries/typescript/packages/client/src/auth/flow.ts
@@ -3,6 +3,7 @@ import {
   UnauthorizedError,
   type OAuthClientProvider,
 } from "@modelcontextprotocol/client";
+import type { NodeOAuthAuthorizationResponse } from "./node.js";
 import { runAuthPopup } from "./popup.js";
 
 const DEFAULT_AUTH_TIMEOUT_MS = 5 * 60_000;
@@ -11,6 +12,7 @@ const DEFAULT_AUTH_TIMEOUT_MS = 5 * 60_000;
 type FlowProvider = OAuthClientProvider & {
   serverUrlHash?: string;
   hasPendingFlow?: boolean;
+  getAuthorizationResponse?: () => Promise<NodeOAuthAuthorizationResponse>;
   getAuthorizationCode?: () => Promise<string>;
   getProxyFetch?: (baseFetch?: typeof fetch) => typeof fetch | undefined;
   getKey?: (keySuffix: string) => string;
@@ -70,11 +72,18 @@ export async function completeOAuthFlow(
     }
   }
 
-  if (typeof flowProvider.getAuthorizationCode === "function") {
-    const code = await flowProvider.getAuthorizationCode();
+  if (
+    typeof flowProvider.getAuthorizationResponse === "function" ||
+    typeof flowProvider.getAuthorizationCode === "function"
+  ) {
+    const response =
+      typeof flowProvider.getAuthorizationResponse === "function"
+        ? await flowProvider.getAuthorizationResponse()
+        : { code: await flowProvider.getAuthorizationCode!() };
     await auth(provider, {
       serverUrl,
-      authorizationCode: code,
+      authorizationCode: response.code,
+      ...(response.iss !== undefined ? { iss: response.iss } : {}),
       fetchFn,
     });
     return;

--- a/libraries/typescript/packages/client/src/auth/node.ts
+++ b/libraries/typescript/packages/client/src/auth/node.ts
@@ -44,6 +44,14 @@ export class OAuthFlowError extends Error {
   }
 }
 
+/** Authorization response captured by the Node loopback callback. */
+export interface NodeOAuthAuthorizationResponse {
+  /** Authorization code returned by the authorization server. */
+  code: string;
+  /** RFC 9207 authorization-server issuer, when present in the callback. */
+  iss?: string;
+}
+
 interface Deferred<T> {
   promise: Promise<T>;
   resolve: (value: T) => void;
@@ -125,9 +133,9 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
 
   private server: Server | null = null;
   /** Currently in-flight deferred — used to prevent overlapping flows. */
-  private pending: Deferred<string> | null = null;
-  /** Latest deferred (settled or in-flight) — what `getAuthorizationCode()` returns. */
-  private lastFlow: Deferred<string> | null = null;
+  private pending: Deferred<NodeOAuthAuthorizationResponse> | null = null;
+  /** Latest deferred (settled or in-flight) for the loopback response. */
+  private lastFlow: Deferred<NodeOAuthAuthorizationResponse> | null = null;
   private pendingTimer: NodeJS.Timeout | null = null;
 
   private constructor(
@@ -286,7 +294,7 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
 
     await this.startLoopback();
 
-    this.pending = createDeferred<string>();
+    this.pending = createDeferred<NodeOAuthAuthorizationResponse>();
     this.lastFlow = this.pending;
     // Swallow unhandled rejections — callers may not subscribe before the
     // callback fires, but `getAuthorizationCode()` still returns the same
@@ -317,15 +325,26 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
 
   /**
    * Resolves with the authorization code captured by the loopback callback.
+   *
+   * @remarks This compatibility method omits the RFC 9207 issuer. OAuth flow
+   * orchestrators should use {@link getAuthorizationResponse} when available.
    * Must be called after `redirectToAuthorization()`. Returns the same
    * promise whether the callback has fired or not — callers may subscribe
    * before or after.
    */
   getAuthorizationCode(): Promise<string> {
+    return this.getAuthorizationResponse().then((response) => response.code);
+  }
+
+  /**
+   * Resolves with the authorization code and RFC 9207 issuer captured by the
+   * loopback callback.
+   */
+  getAuthorizationResponse(): Promise<NodeOAuthAuthorizationResponse> {
     if (!this.lastFlow) {
       return Promise.reject(
         new Error(
-          "NodeOAuthClientProvider.getAuthorizationCode() called before redirectToAuthorization()"
+          "NodeOAuthClientProvider.getAuthorizationResponse() called before redirectToAuthorization()"
         )
       );
     }
@@ -387,11 +406,11 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
     }
   }
 
-  private resolvePending(code: string): void {
+  private resolvePending(response: NodeOAuthAuthorizationResponse): void {
     const p = this.pending;
     this.pending = null;
     this.stopLoopback();
-    p?.resolve(code);
+    p?.resolve(response);
   }
 
   private rejectPending(err: Error): void {
@@ -415,6 +434,7 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
 
     const code = url.searchParams.get("code");
     const state = url.searchParams.get("state");
+    const iss = url.searchParams.get("iss") ?? undefined;
     const err = url.searchParams.get("error");
     const errDesc = url.searchParams.get("error_description") ?? undefined;
 
@@ -436,7 +456,7 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
     res.statusCode = 200;
     res.setHeader("content-type", "text/html; charset=utf-8");
     res.end(SUCCESS_HTML);
-    this.resolvePending(code);
+    this.resolvePending({ code, ...(iss !== undefined ? { iss } : {}) });
   }
 }
 

--- a/libraries/typescript/packages/client/src/index.ts
+++ b/libraries/typescript/packages/client/src/index.ts
@@ -14,6 +14,7 @@ export {
   createOAuthProvider,
   NodeOAuthClientProvider,
   OAuthFlowError,
+  type NodeOAuthAuthorizationResponse,
   type NodeOAuthOptions,
   type OAuthProviderOptions,
 } from "./auth/node.js";

--- a/libraries/typescript/packages/client/src/react/useMcp.ts
+++ b/libraries/typescript/packages/client/src/react/useMcp.ts
@@ -1287,11 +1287,16 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
                 });
 
                 if (authResult === "REDIRECT") {
-                  // Step 2: Get the authorization code that was captured during redirectToAuthorization
-                  const authCode = await (
-                    authProviderRef.current as any
-                  ).getAuthorizationCode?.();
-                  if (!authCode) {
+                  // Step 2: Get the authorization response captured during
+                  // redirectToAuthorization, including RFC 9207 `iss` when
+                  // the provider exposes it.
+                  const flowProvider = authProviderRef.current as any;
+                  const authResponse =
+                    await flowProvider.getAuthorizationResponse?.();
+                  const authCode =
+                    authResponse?.code ??
+                    (await flowProvider.getAuthorizationCode?.());
+                  if (typeof authCode !== "string") {
                     throw new Error(
                       "Authorization code not captured by headless provider"
                     );
@@ -1301,6 +1306,9 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
                   await auth(authProviderRef.current, {
                     serverUrl: url,
                     authorizationCode: authCode,
+                    ...(authResponse?.iss !== undefined
+                      ? { iss: authResponse.iss }
+                      : {}),
                     fetchFn: authProviderRef.current.getProxyFetch?.(),
                   });
                 }

--- a/libraries/typescript/packages/client/tests/unit/auth/flow.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/auth/flow.test.ts
@@ -58,6 +58,31 @@ describe("completeOAuthFlow", () => {
     );
   });
 
+  it("preserves the callback issuer from getAuthorizationResponse", async () => {
+    vi.mocked(auth)
+      .mockResolvedValueOnce("REDIRECT")
+      .mockResolvedValueOnce("AUTHORIZED");
+    const getAuthorizationResponse = vi.fn(async () => ({
+      code: "auth-code",
+      iss: "https://auth.example.com",
+    }));
+    const provider = {
+      getAuthorizationResponse,
+    } as unknown as OAuthClientProvider;
+
+    await completeOAuthFlow(provider, "https://example.com/mcp");
+
+    expect(getAuthorizationResponse).toHaveBeenCalledOnce();
+    expect(auth).toHaveBeenLastCalledWith(
+      provider,
+      expect.objectContaining({
+        serverUrl: "https://example.com/mcp",
+        authorizationCode: "auth-code",
+        iss: "https://auth.example.com",
+      })
+    );
+  });
+
   it("skips the first auth() when hasPendingFlow is set", async () => {
     vi.mocked(auth).mockResolvedValueOnce("AUTHORIZED");
     const getAuthorizationCode = vi.fn(async () => "auth-code");

--- a/libraries/typescript/packages/client/tests/unit/auth/node-provider.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/auth/node-provider.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  NodeOAuthClientProvider,
+  type NodeOAuthAuthorizationResponse,
+} from "../../../src/auth/node.js";
+import type { KVStore } from "../../../src/auth/storage.js";
+
+class MemoryKVStore implements KVStore {
+  private readonly values = new Map<string, string>();
+
+  get(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  set(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+
+  remove(key: string): void {
+    this.values.delete(key);
+  }
+
+  keys(): string[] {
+    return [...this.values.keys()];
+  }
+}
+
+describe("NodeOAuthClientProvider", () => {
+  it("preserves RFC 9207 iss from the loopback callback", async () => {
+    const openBrowser = vi.fn();
+    const provider = await NodeOAuthClientProvider.create(
+      "https://mcp.example.com/mcp",
+      {
+        authTimeoutMs: 5_000,
+        kvStore: new MemoryKVStore(),
+        openBrowser,
+        preferredPort: 35_000 + (process.pid % 1_000),
+        portRange: 100,
+      }
+    );
+    const authorizationUrl = new URL("https://auth.example.com/authorize");
+    authorizationUrl.searchParams.set("state", "test-state");
+
+    await provider.redirectToAuthorization(authorizationUrl);
+    const responsePromise: Promise<NodeOAuthAuthorizationResponse> =
+      provider.getAuthorizationResponse();
+    const legacyCodePromise = provider.getAuthorizationCode();
+    const callback = new URL(
+      `http://127.0.0.1:${provider.callbackPort}/callback`
+    );
+    callback.searchParams.set("code", "authorization-code");
+    callback.searchParams.set("state", "test-state");
+    callback.searchParams.set("iss", "https://auth.example.com");
+
+    const callbackResponse = await fetch(callback);
+
+    expect(callbackResponse.status).toBe(200);
+    await expect(responsePromise).resolves.toEqual({
+      code: "authorization-code",
+      iss: "https://auth.example.com",
+    });
+    await expect(legacyCodePromise).resolves.toBe("authorization-code");
+    expect(openBrowser).toHaveBeenCalledOnce();
+  });
+});

--- a/libraries/typescript/packages/server/specs/CLI_SPEC.md
+++ b/libraries/typescript/packages/server/specs/CLI_SPEC.md
@@ -141,7 +141,7 @@ mcp-use deploy [path] [--org <id-or-slug>] [--name <name>]
 ```text
 mcp-use client connect <name> <url> [-H, --header <"Key: Value">...]
   [--no-oauth] [--auth-timeout <ms>] [--protocol <auto|2026-07-28|2025-11-25>]
-  [--open] [--no-open] [--json]
+  [--no-open] [--json]
 mcp-use client list [--json]
 mcp-use client remove <name> [--yes]
 mcp-use client <name> tools list [--json]
@@ -152,14 +152,14 @@ mcp-use client <name> resources read <uri> [--json]
 mcp-use client <name> prompts list [--json]
 mcp-use client <name> prompts get <prompt> [args...] [--json]
 mcp-use client <name> auth status [--json]
-mcp-use client <name> auth logout [--yes]
+mcp-use client <name> auth logout [--yes] [--json]
 ```
 
 - v2 alpha client commands support HTTP(S) MCP servers; stdio, interactive REPL, resource subscriptions, implicit active sessions, and forced OAuth refresh are omitted. Every operation names a saved server.
-- `connect` validates a unique filesystem-safe name, connects before saving, and attempts OAuth on an authorization challenge unless `--no-oauth`. On OAuth, the CLI prints the authorization URL; in a TTY it prompts before opening the browser unless `--open` or `--no-open` is set. `--open` auto-opens without prompting; `--no-open`, non-TTY, and `--json` print the URL only while the loopback callback still waits. Repeated headers are stored as credentials, not metadata. Reusing a name requires removing it first.
+- `connect` validates a unique filesystem-safe name, connects before saving, and attempts OAuth on an authorization challenge unless `--no-oauth`. In an interactive TTY, OAuth prints `This server requires OAuth. Press Enter to open your browser.`, waits for Enter, and then opens the browser. `--no-open`, `--json`, and non-TTY operation never prompt or open a browser; they print the authorization URL to stderr while the loopback callback continues to wait. Repeated headers are stored as credentials, not metadata. Reusing a name requires removing it first.
 - `client` and `screenshot` dynamic-import `@mcp-use/client`. When it is missing, the CLI installs it automatically: into the nearest project `package.json` when one exists, otherwise into `~/.mcp-use/client-sdk/`. Auto-install continues the current command in-process and imports from the install location.
 - Tool/prompt arguments accept either one JSON object or `key=value` pairs; `key:=<json>` supplies typed JSON values. Mixing the full-object and pair forms is usage error `2`. Calls time out with exit `1`; tool `isError` results are operation failures and retain their protocol content in JSON error details.
-- Default human output renders borderless terminal lists and readable MCP content. `--json` emits the raw protocol result envelope for calls, reads, and prompts, and arrays for lists.
+- Default human output renders borderless terminal lists and readable MCP content; tool lists format described tools as `<name> - <description>`. Every client command that advertises `--json` accepts it anywhere after `client`. `--json` emits exactly one value to stdout: the raw protocol result envelope for calls, reads, and prompts; the described tool object for `tools describe`; arrays for lists; and command result objects for connect and auth commands. Errors emit exactly one JSON error envelope to stderr and no stdout value.
 
 ### Screenshot
 

--- a/libraries/typescript/packages/server/src/commands/client.ts
+++ b/libraries/typescript/packages/server/src/commands/client.ts
@@ -1,12 +1,14 @@
 import { createHash } from "node:crypto";
 import { rm } from "node:fs/promises";
 import { join } from "node:path";
+import { createInterface } from "node:readline/promises";
 import { parseArgs } from "node:util";
 
 import type { MCPConnection } from "@mcp-use/client";
 
 import { loadClientPackage } from "./load-client.js";
 import {
+  CommandError,
   confirm,
   GLOBAL_STATE_DIR,
   openBrowser,
@@ -40,8 +42,8 @@ const CLIENT_HELP = `Usage: mcp-use client <command> [options]
 
 Commands:
   connect <name> <url>   Connect and save an HTTP(S) MCP server
-  list                   List saved servers
-  remove <name>          Remove a saved server
+  list [--json]          List saved servers
+  remove <name> [--yes]  Remove a saved server
   <name>                 Invoke tools/resources/prompts on a saved server
 
 Connect options:
@@ -49,22 +51,26 @@ Connect options:
   --no-oauth                    Skip OAuth on authorization challenges
   --auth-timeout <ms>           OAuth wait timeout (default: 300000)
   --protocol <auto|2026-07-28|2025-11-25>
-  --open                        Open the OAuth URL in a browser without prompting
   --no-open                     Print the OAuth URL only
   --json                        Emit machine-readable output
 
 Saved server commands:
-  mcp-use client <name> tools list|describe|call ...
-  mcp-use client <name> resources list|read ...
-  mcp-use client <name> prompts list|get ...
-  mcp-use client <name> auth status|logout
+  mcp-use client <name> tools list [--json]
+  mcp-use client <name> tools describe <tool> [--json]
+  mcp-use client <name> tools call <tool> [args...] [--timeout <ms>] [--json]
+  mcp-use client <name> resources list [--json]
+  mcp-use client <name> resources read <uri> [--json]
+  mcp-use client <name> prompts list [--json]
+  mcp-use client <name> prompts get <prompt> [args...] [--json]
+  mcp-use client <name> auth status [--json]
+  mcp-use client <name> auth logout [--yes] [--json]
 
 Examples:
   mcp-use client connect linear https://mcp.linear.app/mcp
   mcp-use client linear tools list
   mcp-use client linear tools call search_issues query="open bugs"`;
 
-type BrowserMode = "ask" | "always" | "never";
+type BrowserMode = "ask" | "never";
 
 /** Run the `mcp-use client` command family. */
 export async function runClient(argv: readonly string[]): Promise<number> {
@@ -73,15 +79,17 @@ export async function runClient(argv: readonly string[]): Promise<number> {
     return 0;
   }
   const json = wantsJson(argv);
+  const normalizedArgv = argv.filter((token) => token !== "--json");
   try {
-    const first = argv[0];
-    if (first === "connect") return await connect(argv.slice(1), json);
-    if (first === "list") return await list(argv.slice(1), json);
-    if (first === "remove") return await remove(argv.slice(1), json);
+    const first = normalizedArgv[0];
+    if (first === "connect")
+      return await connect(normalizedArgv.slice(1), json);
+    if (first === "list") return await list(normalizedArgv.slice(1), json);
+    if (first === "remove") return await remove(normalizedArgv.slice(1), json);
     if (first === undefined) {
       throw new UsageError("Usage: mcp-use client <connect|list|remove|name>");
     }
-    return await savedServerCommand(first, argv.slice(1), json);
+    return await savedServerCommand(first, normalizedArgv.slice(1), json);
   } catch (error) {
     return reportError(
       error instanceof TypeError ? new UsageError(error.message) : error,
@@ -103,14 +111,9 @@ async function connect(
       "no-oauth": { type: "boolean" },
       "auth-timeout": { type: "string" },
       protocol: { type: "string", default: "auto" },
-      open: { type: "boolean" },
       "no-open": { type: "boolean" },
-      json: { type: "boolean" },
     },
   });
-  if (values.open === true && values["no-open"] === true) {
-    throw new UsageError("Cannot combine --open and --no-open.");
-  }
   if (positionals.length !== 2) {
     throw new UsageError("Usage: mcp-use client connect <name> <url>");
   }
@@ -141,7 +144,6 @@ async function connect(
     credentials,
     timeout,
     resolveBrowserMode({
-      open: values.open === true,
       noOpen: values["no-open"] === true,
       json,
     })
@@ -179,7 +181,7 @@ async function remove(argv: readonly string[], json: boolean): Promise<number> {
     args: [...argv],
     allowPositionals: true,
     strict: true,
-    options: { yes: { type: "boolean" }, json: { type: "boolean" } },
+    options: { yes: { type: "boolean" } },
   });
   const name = one(positionals, "mcp-use client remove <name>");
   if (
@@ -228,7 +230,7 @@ async function savedServerCommand(
         args: [...argv.slice(2)],
         allowPositionals: true,
         strict: true,
-        options: { yes: { type: "boolean" }, json: { type: "boolean" } },
+        options: { yes: { type: "boolean" } },
       });
       if (positionals.length !== 0) {
         throw new UsageError(`Usage: mcp-use client ${name} auth logout`);
@@ -255,7 +257,8 @@ async function savedServerCommand(
     name,
     definition,
     credentials,
-    300_000
+    300_000,
+    resolveBrowserMode({ noOpen: false, json })
   );
   try {
     if (family === "tools") {
@@ -266,7 +269,11 @@ async function savedServerCommand(
           tools,
           json,
           tools
-            .map((tool) => `${tool.name}\t${tool.description ?? ""}`)
+            .map((tool) =>
+              tool.description
+                ? `${tool.name} - ${tool.description}`
+                : tool.name
+            )
             .join("\n")
         );
         return 0;
@@ -350,7 +357,6 @@ async function callTool(
     strict: true,
     options: {
       timeout: { type: "string", default: "30000" },
-      json: { type: "boolean" },
     },
   });
   const timeout = parsePositiveInteger(values.timeout, "--timeout");
@@ -360,8 +366,10 @@ async function callTool(
     { timeout }
   );
   if (result.isError === true) {
-    throw new Error(
-      `Tool ${tool} returned an error: ${JSON.stringify(result)}`
+    throw new CommandError(
+      "tool_error",
+      `Tool ${tool} returned an error.`,
+      result
     );
   }
   printResult(result, json);
@@ -383,15 +391,11 @@ async function openConnection(
         authTimeoutMs,
         storageKeyPrefix: `mcp-use-cli:${name}`,
         openBrowser: async (url: string) => {
-          process.stderr.write(`Open this URL to authenticate:\n${url}\n`);
-          if (browserMode === "never") return;
-          if (browserMode === "ask") {
-            const accepted = await confirm("Open in browser?", {
-              yes: false,
-              json: false,
-            });
-            if (!accepted) return;
+          if (browserMode === "never") {
+            process.stderr.write(`Open this URL to authenticate:\n${url}\n`);
+            return;
           }
+          await waitForOAuthEnter();
           openBrowser(url);
         },
         // Conditional exports select NodeOAuthOptions at runtime. TypeScript
@@ -488,13 +492,25 @@ export function parseMcpArguments(
 }
 
 function resolveBrowserMode(options: {
-  open: boolean;
   noOpen: boolean;
   json: boolean;
 }): BrowserMode {
   if (options.json || options.noOpen || !process.stdin.isTTY) return "never";
-  if (options.open) return "always";
   return "ask";
+}
+
+async function waitForOAuthEnter(): Promise<void> {
+  const prompt = createInterface({
+    input: process.stdin,
+    output: process.stderr,
+  });
+  try {
+    await prompt.question(
+      "This server requires OAuth. Press Enter to open your browser."
+    );
+  } finally {
+    prompt.close();
+  }
 }
 
 function parseHeaders(values: readonly string[]): Record<string, string> {
@@ -557,7 +573,7 @@ function parseJsonOnly(argv: readonly string[]): void {
     args: [...argv],
     allowPositionals: false,
     strict: true,
-    options: { json: { type: "boolean" } },
+    options: {},
   });
 }
 

--- a/libraries/typescript/packages/server/src/commands/client.ts
+++ b/libraries/typescript/packages/server/src/commands/client.ts
@@ -80,12 +80,18 @@ export async function runClient(argv: readonly string[]): Promise<number> {
   }
   const json = wantsJson(argv);
   const normalizedArgv = argv.filter((token) => token !== "--json");
+  const first = normalizedArgv[0];
+  const reportJson = json && first !== "remove";
   try {
-    const first = normalizedArgv[0];
     if (first === "connect")
       return await connect(normalizedArgv.slice(1), json);
     if (first === "list") return await list(normalizedArgv.slice(1), json);
-    if (first === "remove") return await remove(normalizedArgv.slice(1), json);
+    if (first === "remove") {
+      if (json) {
+        throw new UsageError("mcp-use client remove does not support --json.");
+      }
+      return await remove(normalizedArgv.slice(1));
+    }
     if (first === undefined) {
       throw new UsageError("Usage: mcp-use client <connect|list|remove|name>");
     }
@@ -93,7 +99,7 @@ export async function runClient(argv: readonly string[]): Promise<number> {
   } catch (error) {
     return reportError(
       error instanceof TypeError ? new UsageError(error.message) : error,
-      json
+      reportJson
     );
   }
 }
@@ -176,7 +182,7 @@ async function list(argv: readonly string[], json: boolean): Promise<number> {
   return 0;
 }
 
-async function remove(argv: readonly string[], json: boolean): Promise<number> {
+async function remove(argv: readonly string[]): Promise<number> {
   const { values, positionals } = parseArgs({
     args: [...argv],
     allowPositionals: true,
@@ -187,7 +193,7 @@ async function remove(argv: readonly string[], json: boolean): Promise<number> {
   if (
     !(await confirm(`Remove saved server ${name}?`, {
       yes: values.yes === true,
-      json,
+      json: false,
     }))
   ) {
     return 0;
@@ -196,7 +202,7 @@ async function remove(argv: readonly string[], json: boolean): Promise<number> {
   delete saved.servers[name];
   await writePrivateJson(SERVERS_PATH, saved);
   await rm(credentialsDirectory(name), { recursive: true, force: true });
-  printResult({ removed: name }, json, `Removed ${name}.`);
+  printResult({ removed: name }, false, `Removed ${name}.`);
   return 0;
 }
 

--- a/libraries/typescript/packages/server/tests/bin-start.test.ts
+++ b/libraries/typescript/packages/server/tests/bin-start.test.ts
@@ -542,6 +542,8 @@ describe("main", () => {
     await expect(main(["client", "--help"])).resolves.toBe(0);
     const output = logs.mock.calls.flat().join("\n");
     expect(output).toContain("mcp-use client connect");
+    expect(output).toContain("--no-open");
+    expect(output).not.toContain("  --open");
     expect(output).not.toContain("mcp-use deploy");
   });
 

--- a/libraries/typescript/packages/server/tests/commands/client.test.ts
+++ b/libraries/typescript/packages/server/tests/commands/client.test.ts
@@ -1,0 +1,343 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const AUTHORIZATION_URL = "https://auth.example.com/authorize?state=test";
+
+const mocks = vi.hoisted(() => ({
+  closePrompt: vi.fn(),
+  config: undefined as
+    | { mcpServers: Record<string, { authProvider?: unknown }> }
+    | undefined,
+  createInterface: vi.fn(),
+  loadClientPackage: vi.fn(),
+  openBrowser: vi.fn(),
+  question: vi.fn(),
+  triggerOAuth: false,
+}));
+
+vi.mock("node:readline/promises", () => ({
+  createInterface: mocks.createInterface,
+}));
+
+vi.mock("../../src/commands/load-client.js", () => ({
+  loadClientPackage: mocks.loadClientPackage,
+}));
+
+vi.mock("../../src/commands/shared.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../src/commands/shared.js")>();
+  return { ...actual, openBrowser: mocks.openBrowser };
+});
+
+const connection = {
+  callTool: vi.fn(),
+  disconnect: vi.fn(),
+  getPrompt: vi.fn(),
+  listPrompts: vi.fn(),
+  listResources: vi.fn(),
+  listTools: vi.fn(),
+  readResource: vi.fn(),
+};
+
+let homeDirectory: string;
+let runClient: (argv: readonly string[]) => Promise<number>;
+let stdout = "";
+let stderr = "";
+let stdinTtyDescriptor: PropertyDescriptor | undefined;
+
+beforeEach(async () => {
+  vi.resetAllMocks();
+  vi.resetModules();
+  mocks.config = undefined;
+  mocks.triggerOAuth = false;
+  homeDirectory = await mkdtemp(join(tmpdir(), "mcp-use-client-"));
+  vi.stubEnv("HOME", homeDirectory);
+  stdinTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+  setStdinTty(false);
+
+  stdout = "";
+  stderr = "";
+  vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+    stdout += String(chunk);
+    return true;
+  });
+  vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+    stderr += String(chunk);
+    return true;
+  });
+
+  connection.callTool.mockResolvedValue({
+    content: [{ type: "text", text: "called" }],
+  });
+  connection.disconnect.mockResolvedValue(undefined);
+  connection.getPrompt.mockResolvedValue({
+    messages: [{ role: "user", content: { type: "text", text: "Hello, Ada" } }],
+  });
+  connection.listPrompts.mockResolvedValue([{ name: "hello" }]);
+  connection.listResources.mockResolvedValue([{ uri: "file:///notes.txt" }]);
+  connection.listTools.mockResolvedValue([
+    { name: "echo", description: "Echo input" },
+  ]);
+  connection.readResource.mockResolvedValue({
+    contents: [{ uri: "file:///notes.txt", text: "notes" }],
+  });
+
+  mocks.question.mockResolvedValue("");
+  mocks.createInterface.mockReturnValue({
+    close: mocks.closePrompt,
+    question: mocks.question,
+  });
+  mocks.loadClientPackage.mockResolvedValue({
+    createOAuthProvider: async (
+      _url: string,
+      options: { openBrowser: (url: string) => Promise<void> }
+    ) => ({ options }),
+    MCPClient: class {
+      constructor(config: {
+        mcpServers: Record<string, { authProvider?: unknown }>;
+      }) {
+        mocks.config = config;
+      }
+
+      async connect(name: string): Promise<typeof connection> {
+        const provider = mocks.config?.mcpServers[name]?.authProvider as
+          | { options: { openBrowser: (url: string) => Promise<void> } }
+          | undefined;
+        if (mocks.triggerOAuth && provider !== undefined) {
+          await provider.options.openBrowser(AUTHORIZATION_URL);
+        }
+        return connection;
+      }
+    },
+  });
+
+  ({ runClient } = await import("../../src/commands/client.js"));
+});
+
+afterEach(async () => {
+  if (stdinTtyDescriptor === undefined) {
+    Reflect.deleteProperty(process.stdin, "isTTY");
+  } else {
+    Object.defineProperty(process.stdin, "isTTY", stdinTtyDescriptor);
+  }
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+  await rm(homeDirectory, { recursive: true, force: true });
+});
+
+describe("client JSON output", () => {
+  it("accepts --json throughout every data-returning command", async () => {
+    await expect(
+      runClient([
+        "connect",
+        "demo",
+        "https://mcp.example.com/mcp",
+        "--no-oauth",
+      ])
+    ).resolves.toBe(0);
+
+    const cases: Array<{ argv: string[]; expected: unknown }> = [
+      {
+        argv: ["--json", "list"],
+        expected: [
+          {
+            name: "demo",
+            oauth: false,
+            protocol: "auto",
+            url: "https://mcp.example.com/mcp",
+          },
+        ],
+      },
+      {
+        argv: ["demo", "--json", "tools", "list"],
+        expected: [{ name: "echo", description: "Echo input" }],
+      },
+      {
+        argv: ["demo", "tools", "--json", "describe", "echo"],
+        expected: { name: "echo", description: "Echo input" },
+      },
+      {
+        argv: ["demo", "tools", "call", "echo", '{"value":1}', "--json"],
+        expected: { content: [{ type: "text", text: "called" }] },
+      },
+      {
+        argv: ["demo", "resources", "list", "--json"],
+        expected: [{ uri: "file:///notes.txt" }],
+      },
+      {
+        argv: ["demo", "resources", "--json", "read", "file:///notes.txt"],
+        expected: {
+          contents: [{ uri: "file:///notes.txt", text: "notes" }],
+        },
+      },
+      {
+        argv: ["demo", "prompts", "list", "--json"],
+        expected: [{ name: "hello" }],
+      },
+      {
+        argv: ["demo", "prompts", "get", "--json", "hello", "name=Ada"],
+        expected: {
+          messages: [
+            {
+              role: "user",
+              content: { type: "text", text: "Hello, Ada" },
+            },
+          ],
+        },
+      },
+      {
+        argv: ["--json", "demo", "auth", "status"],
+        expected: { name: "demo", oauth: false, authenticated: false },
+      },
+      {
+        argv: ["demo", "auth", "logout", "--yes", "--json"],
+        expected: { loggedOut: "demo" },
+      },
+    ];
+
+    for (const testCase of cases) {
+      stdout = "";
+      stderr = "";
+      await expect(runClient(testCase.argv)).resolves.toBe(0);
+      expect(stdout.endsWith("\n")).toBe(true);
+      expect(stdout.match(/\n/g)).toHaveLength(1);
+      expect(JSON.parse(stdout)).toEqual(testCase.expected);
+      expect(stderr).toBe("");
+    }
+  });
+
+  it("emits one JSON error envelope without stdout", async () => {
+    await runClient([
+      "connect",
+      "demo",
+      "https://mcp.example.com/mcp",
+      "--no-oauth",
+    ]);
+    stdout = "";
+    stderr = "";
+
+    await expect(
+      runClient(["demo", "tools", "describe", "missing", "--json"])
+    ).resolves.toBe(2);
+
+    expect(stdout).toBe("");
+    expect(JSON.parse(stderr)).toEqual({
+      error: { code: "usage_error", message: "Tool not found: missing" },
+    });
+    expect(stderr.match(/\n/g)).toHaveLength(1);
+  });
+
+  it("retains a failed tool result in JSON error details", async () => {
+    await runClient([
+      "connect",
+      "demo",
+      "https://mcp.example.com/mcp",
+      "--no-oauth",
+    ]);
+    const result = {
+      content: [{ type: "text", text: "bad input" }],
+      isError: true,
+    };
+    connection.callTool.mockResolvedValueOnce(result);
+    stdout = "";
+    stderr = "";
+
+    await expect(
+      runClient(["--json", "demo", "tools", "call", "echo"])
+    ).resolves.toBe(1);
+
+    expect(stdout).toBe("");
+    expect(JSON.parse(stderr)).toEqual({
+      error: {
+        code: "tool_error",
+        message: "Tool echo returned an error.",
+        details: result,
+      },
+    });
+  });
+});
+
+describe("client human-readable output", () => {
+  it("separates tool names and descriptions with a hyphen", async () => {
+    await expect(
+      runClient([
+        "connect",
+        "human-output",
+        "https://mcp.example.com/mcp",
+        "--no-oauth",
+      ])
+    ).resolves.toBe(0);
+    stdout = "";
+
+    await expect(runClient(["human-output", "tools", "list"])).resolves.toBe(0);
+
+    expect(stdout).toBe("echo - Echo input\n");
+    expect(stderr).toBe("");
+  });
+});
+
+describe("client OAuth browser UX", () => {
+  it("waits for Enter before opening a browser in an interactive TTY", async () => {
+    setStdinTty(true);
+    mocks.triggerOAuth = true;
+
+    await expect(
+      runClient(["connect", "oauth", "https://mcp.example.com/mcp"])
+    ).resolves.toBe(0);
+
+    expect(mocks.question).toHaveBeenCalledOnce();
+    expect(mocks.question).toHaveBeenCalledWith(
+      "This server requires OAuth. Press Enter to open your browser."
+    );
+    expect(mocks.openBrowser).toHaveBeenCalledWith(AUTHORIZATION_URL);
+    expect(mocks.question.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.openBrowser.mock.invocationCallOrder[0]!
+    );
+    expect(stderr).toBe("");
+  });
+
+  it.each([
+    { label: "non-TTY", tty: false, before: [], after: [] },
+    { label: "--no-open", tty: true, before: [], after: ["--no-open"] },
+    { label: "--json", tty: true, before: ["--json"], after: [] },
+  ])(
+    "prints the URL without prompting or opening under $label",
+    async (mode) => {
+      setStdinTty(mode.tty);
+      mocks.triggerOAuth = true;
+
+      await expect(
+        runClient([
+          ...mode.before,
+          "connect",
+          `oauth-${mode.label.replace(/[^a-z]/gi, "")}`,
+          "https://mcp.example.com/mcp",
+          ...mode.after,
+        ])
+      ).resolves.toBe(0);
+
+      expect(mocks.question).not.toHaveBeenCalled();
+      expect(mocks.openBrowser).not.toHaveBeenCalled();
+      expect(stderr).toBe(
+        `Open this URL to authenticate:\n${AUTHORIZATION_URL}\n`
+      );
+      if (mode.label === "--json") {
+        expect(JSON.parse(stdout)).toMatchObject({
+          protocol: "auto",
+          url: "https://mcp.example.com/mcp",
+        });
+        expect(stdout.match(/\n/g)).toHaveLength(1);
+      }
+    }
+  );
+});
+
+function setStdinTty(value: boolean): void {
+  Object.defineProperty(process.stdin, "isTTY", {
+    configurable: true,
+    value,
+  });
+}

--- a/libraries/typescript/packages/server/tests/commands/client.test.ts
+++ b/libraries/typescript/packages/server/tests/commands/client.test.ts
@@ -277,6 +277,42 @@ describe("client human-readable output", () => {
     expect(stdout).toBe("echo - Echo input\n");
     expect(stderr).toBe("");
   });
+
+  it("rejects --json for remove in every position", async () => {
+    await expect(
+      runClient([
+        "connect",
+        "remove-json",
+        "https://mcp.example.com/mcp",
+        "--no-oauth",
+      ])
+    ).resolves.toBe(0);
+
+    for (const argv of [
+      ["--json", "remove", "remove-json", "--yes"],
+      ["remove", "--json", "remove-json", "--yes"],
+      ["remove", "remove-json", "--yes", "--json"],
+    ]) {
+      stdout = "";
+      stderr = "";
+
+      await expect(runClient(argv)).resolves.toBe(2);
+
+      expect(stdout).toBe("");
+      expect(stderr).toBe("mcp-use client remove does not support --json.\n");
+    }
+
+    stdout = "";
+    stderr = "";
+    await expect(runClient(["list", "--json"])).resolves.toBe(0);
+    expect(JSON.parse(stdout)).toContainEqual({
+      name: "remove-json",
+      oauth: false,
+      protocol: "auto",
+      url: "https://mcp.example.com/mcp",
+    });
+    expect(stderr).toBe("");
+  });
 });
 
 describe("client OAuth browser UX", () => {


### PR DESCRIPTION
## Summary

- remove `--open` and make interactive OAuth wait for Enter before opening the browser
- keep `--no-open`, JSON, and non-TTY flows non-interactive while preserving loopback waiting
- accept `--json` in every advertised client-command position and emit clean single-value success/error output
- preserve the RFC 9207 `iss` parameter from Node loopback callbacks so issuer validation succeeds
- format human-readable tool listings as `<name> - <description>`
- update the CLI spec, help, and documentation for the v2 behavior

## Why

The v2 client CLI had inconsistent JSON flag parsing and browser-opening behavior. Its Node OAuth callback also discarded the authorization response issuer before the MCP SDK validated it, causing OAuth servers that advertise RFC 9207 support to fail with an issuer mismatch.

## Impact

Interactive users get one predictable OAuth prompt, automation stays non-interactive and parseable, and OAuth connections such as Manufact can complete issuer validation correctly. Existing providers that expose only `getAuthorizationCode()` remain supported through the compatibility fallback.

## Validation

- client Vitest suite: 39 files, 233 tests passed
- focused client CLI suite: 8 tests passed
- client, CLI, and server builds passed
- client TypeScript and targeted ESLint checks passed
- repository pre-commit formatting, lint, and changeset checks passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OAuth UX and JSON output in the v2 client CLI and preserves the OAuth issuer for validation. Interactive OAuth waits for Enter before opening a browser; non‑interactive runs never open a browser; `--json` works across commands that advertise it and emits exactly one value.

- **Bug Fixes**
  - OAuth: removed `--open`; in a TTY the prompt waits for Enter, while `--no-open`, `--json`, and non‑TTY runs print the auth URL to stderr and never open a browser (for connect and later commands).
  - JSON: `--json` may appear anywhere after `client` for commands that support it; `remove` rejects `--json` in any position. Stdout emits exactly one JSON value; errors emit one JSON envelope to stderr; tool `isError` results exit `1` with the original result in `error.details`; lists emit arrays; `tools describe` emits one tool object; `connect` and `auth` commands return objects.
  - Issuer validation: Node loopback now exposes `getAuthorizationResponse()`; `completeOAuthFlow` and React `useMcp` pass RFC 9207 `iss` to `auth`, fixing issuer mismatch failures.
  - Output: human-readable tool lists render as "<name> - <description>".
  - Docs/spec/tests: updated CLI docs and spec; added unit and CLI tests; dynamic import of `@mcp-use/client` unchanged.

<sup>Written for commit 4a53feb634aba5e00e1d2ed16c187d18e759cf12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

