### PR TITLE
Pin create app templates to stable beta

### DIFF
--- a/libraries/typescript/packages/create-mcp-use-app/TESTING.md
+++ b/libraries/typescript/packages/create-mcp-use-app/TESTING.md
@@ -101,12 +101,12 @@ cat package.json | grep "mcp-use"
 # Should show: "mcp-use": "canary"
 ```
 
-**Test default (latest versions):**
+**Test default (pinned beta version):**
 ```bash
-npx --yes --package=./create-mcp-use-app-0.4.3.tgz create-mcp-use-app test-latest --template ui
-cd test-latest
+npx --yes --package=./create-mcp-use-app-0.4.3.tgz create-mcp-use-app test-beta --template mcp-apps
+cd test-beta
 cat package.json | grep "mcp-use"
-# Should show: "mcp-use": "latest" or a specific version like "^1.2.3"
+# Should show the exact pinned beta, with no tag or semver range.
 ```
 
 ### 4. Test All Templates
@@ -184,7 +184,7 @@ You can also manually trigger the workflow from the GitHub Actions tab.
 
 - ✅ `--dev` flag creates projects with `workspace:*` versions
 - ✅ `--sdk-version <version>` flag pins `mcp-use` to the given npm version or dist-tag
-- ✅ Default (no flag) creates projects with `latest` or specific versions
+- ✅ Default (no flag) creates projects with the exact pinned beta version
 - ✅ All package dependencies use correct version format
 
 ### Cross-Platform

--- a/libraries/typescript/packages/create-mcp-use-app/src/index.ts
+++ b/libraries/typescript/packages/create-mcp-use-app/src/index.ts
@@ -293,6 +293,8 @@ const packageJson = JSON.parse(
   readFileSync(join(__dirname, "../package.json"), "utf-8")
 );
 
+const DEFAULT_MCP_USE_VERSION = "2.0.0-beta.25";
+
 function getCurrentPackageVersions(
   isDevelopment: boolean = false,
   sdkVersion?: string
@@ -302,7 +304,7 @@ function getCurrentPackageVersions(
       "mcp-use": "workspace:*",
     };
   }
-  const requestedSdk = sdkVersion ?? "latest";
+  const requestedSdk = sdkVersion ?? DEFAULT_MCP_USE_VERSION;
   return {
     "mcp-use": requestedSdk,
   };
@@ -326,7 +328,7 @@ function processTemplateFile(
 
   const mcpUseVersion = isDevelopment
     ? "workspace:*"
-    : versions["mcp-use"] || "latest";
+    : versions["mcp-use"] || DEFAULT_MCP_USE_VERSION;
 
   if (isDevelopment) {
     processedContent = processedContent.replace(

--- a/libraries/typescript/packages/create-mcp-use-app/test-cli.sh
+++ b/libraries/typescript/packages/create-mcp-use-app/test-cli.sh
@@ -12,6 +12,8 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
+EXPECTED_DEFAULT_MCP_USE_VERSION="2.0.0-beta.25"
+
 # Get script directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TEST_DIR="${TEST_DIR:-/tmp/create-mcp-use-app-test-$$}"
@@ -184,14 +186,14 @@ run_test() {
                 fi
                 echo -e "${GREEN}   ✓ Verified sdk version: $mcp_use_version${NC}"
             else
-                # Check for latest or specific versions (not workspace:* or canary)
+                # The default must be an exact, immutable beta version.
                 local mcp_use_version=$(jq -r '.dependencies."mcp-use"' "$package_json")
-                if [[ "$mcp_use_version" == "workspace:"* ]] || [[ "$mcp_use_version" == "canary" ]]; then
-                    echo -e "${RED}❌ FAILED: Expected latest/specific version, got: $mcp_use_version${NC}"
+                if [[ "$mcp_use_version" != "$EXPECTED_DEFAULT_MCP_USE_VERSION" ]]; then
+                    echo -e "${RED}❌ FAILED: Expected pinned mcp-use@$EXPECTED_DEFAULT_MCP_USE_VERSION, got: $mcp_use_version${NC}"
                     TESTS_FAILED=$((TESTS_FAILED + 1))
                     return 1
                 fi
-                echo -e "${GREEN}   ✓ Verified latest/specific versions${NC}"
+                echo -e "${GREEN}   ✓ Verified pinned mcp-use@$mcp_use_version${NC}"
             fi
 
             if ! grep -q "\-\-dev" <<< "$flag"; then
@@ -254,7 +256,11 @@ run_test "Version-Sdk-Canary" npm mcp-server "--sdk-version canary" ""
 echo ""
 run_test "Version-Sdk-Semver" npm mcp-server "--sdk-version 1.0.0" ""
 echo ""
-run_test "Version-Latest" npm mcp-server "" ""
+run_test "Version-Pinned-Beta-Server" npm mcp-server "" ""
+echo ""
+run_test "Version-Pinned-Beta-Apps" npm mcp-apps "" ""
+echo ""
+run_test "Version-Pinned-Beta-Blank" npm blank "" ""
 echo ""
 
 # Optional: Test with installation (slower)


### PR DESCRIPTION
## Summary

- default generated projects to the exact `mcp-use@2.0.0-beta.25` release
- keep `--dev` workspace linking and explicit `--sdk-version` overrides unchanged
- tighten CLI coverage so all three bundled templates reject moving tags and semver ranges
- update the testing documentation to describe the pinned-beta behavior

## Why

`create-mcp-use-app@2.0.0-beta.9` currently resolves the template SDK dependency through the moving `latest` tag. That produces stable `mcp-use` projects instead of projects aligned with the beta scaffolder, and the resulting dependency can change between scaffolds.

`2.0.0-beta.25` was selected because it was the newest `mcp-use` beta published more than 24 hours before this change. Using the exact version makes generated projects reproducible.

## Validation

- `pnpm test` — 20 tests passed
- `pnpm lint` — passed
- `pnpm build` — passed
- packaged CLI output manually confirmed `"mcp-use": "2.0.0-beta.25"`

The full `test:cli` script currently stops on an existing upstream assertion that expects `@mcp-use/inspector` in `devDependencies`; the rebased templates no longer include that package. This is unrelated to the SDK pin and occurs after the generated package has been confirmed to contain the exact beta version.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `create-mcp-use-app` to generate projects with an exact `mcp-use` `2.0.0-beta.25` by default for reproducible, beta-aligned scaffolds. `--dev` and `--sdk-version` behavior is unchanged; CLI tests now require an exact beta (no tags or semver ranges) across all templates, and docs were updated.

<sup>Written for commit d7a9321957af265f54b53eb2826c2b3ccfabd376. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

