### PR TITLE
fix(create-app): align bundled Inspector checks

### DIFF
--- a/libraries/typescript/.changeset/clean-create-app-inspector-deps.md
+++ b/libraries/typescript/.changeset/clean-create-app-inspector-deps.md
@@ -2,4 +2,4 @@
 "create-mcp-use-app": patch
 ---
 
-Align the scaffold CLI checks and documentation with the bundled Inspector. Generated projects only depend on `mcp-use`; users no longer need to add `@mcp-use/inspector` themselves.
+Align the scaffold CLI checks and documentation with the bundled Inspector. Generated projects rely solely on `mcp-use` for the CLI and built-in Inspector; users no longer need to add `@mcp-use/inspector` themselves.

--- a/libraries/typescript/.changeset/clean-create-app-inspector-deps.md
+++ b/libraries/typescript/.changeset/clean-create-app-inspector-deps.md
@@ -1,0 +1,5 @@
+---
+"create-mcp-use-app": patch
+---
+
+Align the scaffold CLI checks and documentation with the bundled Inspector. Generated projects only depend on `mcp-use`; users no longer need to add `@mcp-use/inspector` themselves.

--- a/libraries/typescript/packages/create-mcp-use-app/README.md
+++ b/libraries/typescript/packages/create-mcp-use-app/README.md
@@ -203,14 +203,11 @@ The scaffolded project includes these dependencies:
 
 ### Core Dependencies
 
-- `mcp-use` - The MCP framework
-- `@mcp-use/cli` - Build and development tool
-- `@mcp-use/inspector` - Web-based debugger
+- `mcp-use` - The MCP framework, including its CLI and built-in Inspector
 
 ### Development Dependencies
 
 - `typescript` - TypeScript compiler
-- `tsx` - TypeScript executor for development
 - `@types/node` - Node.js type definitions
 
 ### Template-Specific Dependencies

--- a/libraries/typescript/packages/create-mcp-use-app/test-cli.sh
+++ b/libraries/typescript/packages/create-mcp-use-app/test-cli.sh
@@ -139,7 +139,7 @@ run_test() {
         # Verify package versions based on flags
         if command -v jq > /dev/null 2>&1; then
             local package_json="$app_name/package.json"
-            if [[ "$(jq -r '(.dependencies // {}) + (.devDependencies // {}) + (.optionalDependencies // {}) | ."@mcp-use/inspector" // empty' "$package_json")" != "" ]]; then
+            if [[ "$(jq -r '(.dependencies // {}) + (.devDependencies // {}) + (.optionalDependencies // {}) + (.peerDependencies // {}) | ."@mcp-use/inspector" // empty' "$package_json")" != "" ]]; then
                 echo -e "${RED}❌ FAILED: Inspector is bundled by mcp-use and must not be a direct dependency${NC}"
                 TESTS_FAILED=$((TESTS_FAILED + 1))
                 return 1

--- a/libraries/typescript/packages/create-mcp-use-app/test-cli.sh
+++ b/libraries/typescript/packages/create-mcp-use-app/test-cli.sh
@@ -24,7 +24,6 @@ echo ""
 echo -e "${YELLOW}📦 Building package...${NC}"
 cd "$SCRIPT_DIR"
 pnpm build
-SCAFFOLDER_VERSION=$(node -p "require('./package.json').version")
 PACKAGE_PATH=$(npm pack --json | jq -r '.[0].filename')
 
 if [ ! -f "$PACKAGE_PATH" ]; then
@@ -140,14 +139,8 @@ run_test() {
         # Verify package versions based on flags
         if command -v jq > /dev/null 2>&1; then
             local package_json="$app_name/package.json"
-            local inspector_version=$(jq -r '.devDependencies."@mcp-use/inspector" // empty' "$package_json")
-            if [[ -z "$inspector_version" ]]; then
-                echo -e "${RED}❌ FAILED: Expected @mcp-use/inspector in devDependencies${NC}"
-                TESTS_FAILED=$((TESTS_FAILED + 1))
-                return 1
-            fi
-            if [[ "$(jq -r '.dependencies."@mcp-use/inspector" // empty' "$package_json")" != "" ]]; then
-                echo -e "${RED}❌ FAILED: Inspector must not be a production dependency${NC}"
+            if [[ "$(jq -r '(.dependencies // {}) + (.devDependencies // {}) + (.optionalDependencies // {}) | ."@mcp-use/inspector" // empty' "$package_json")" != "" ]]; then
+                echo -e "${RED}❌ FAILED: Inspector is bundled by mcp-use and must not be a direct dependency${NC}"
                 TESTS_FAILED=$((TESTS_FAILED + 1))
                 return 1
             fi
@@ -157,11 +150,6 @@ run_test() {
                 local mcp_use_version=$(jq -r '.dependencies."mcp-use"' "$package_json")
                 if [[ "$mcp_use_version" != "workspace:"* ]]; then
                     echo -e "${RED}❌ FAILED: Expected workspace:* version with --dev, got: $mcp_use_version${NC}"
-                    TESTS_FAILED=$((TESTS_FAILED + 1))
-                    return 1
-                fi
-                if [[ "$inspector_version" != "workspace:"* ]]; then
-                    echo -e "${RED}❌ FAILED: Expected workspace:* Inspector with --dev, got: $inspector_version${NC}"
                     TESTS_FAILED=$((TESTS_FAILED + 1))
                     return 1
                 fi
@@ -194,18 +182,7 @@ run_test() {
                 echo -e "${GREEN}   ✓ Verified latest/specific versions${NC}"
             fi
 
-            if ! grep -q "\-\-dev" <<< "$flag"; then
-                local expected_inspector="latest"
-                if [[ "$SCAFFOLDER_VERSION" == *-* ]] || grep -q "\-\-sdk-version canary" <<< "$flag"; then
-                    expected_inspector="beta"
-                fi
-                if [[ "$inspector_version" != "$expected_inspector" ]]; then
-                    echo -e "${RED}❌ FAILED: Expected Inspector $expected_inspector, got: $inspector_version${NC}"
-                    TESTS_FAILED=$((TESTS_FAILED + 1))
-                    return 1
-                fi
-                echo -e "${GREEN}   ✓ Verified Inspector dev dependency: $inspector_version${NC}"
-            fi
+            echo -e "${GREEN}   ✓ Verified Inspector is provided by mcp-use${NC}"
         fi
         
         echo -e "${GREEN}✅ PASSED${NC}"


### PR DESCRIPTION
## Summary

- update the create-app CLI integration checks to reject a direct `@mcp-use/inspector` dependency
- document that `mcp-use` now provides the CLI and built-in Inspector
- remove the obsolete `tsx` dependency from the generated-dependency documentation
- add a patch changeset for `create-mcp-use-app`

## Why

The Inspector is now a regular dependency of `mcp-use`, but the create-app test script and README still described and enforced the previous project-local dev dependency. That stale expectation could suggest users install `@mcp-use/inspector` themselves even though beta 36 provides it transitively.

Generated projects continue to depend only on `mcp-use`; users get the matching CLI and Inspector automatically.

## Validation

- `bash -n packages/create-mcp-use-app/test-cli.sh`
- `pnpm --filter create-mcp-use-app test` (20 tests passed)
- `pnpm --filter create-mcp-use-app build`
- recreated an `mcp-apps` project with `create-mcp-use-app@beta` and `mcp-use@2.0.0-beta.36`
- verified `npm run dev` exposes `/mcp/inspector` with HTTP 200 and no missing-Inspector warning
- verified generated-project typecheck and production build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align the create-app scaffold with the Inspector now bundled in `mcp-use`. Generated apps no longer add `@mcp-use/inspector`; tests and docs reflect that `mcp-use` provides both the CLI and Inspector.

- **Bug Fixes**
  - Update `test-cli.sh` to fail if `@mcp-use/inspector` appears in any dependency field; drop version/workspace checks and confirm it’s provided by `mcp-use`.
  - Update README: replace separate `@mcp-use/cli` and `@mcp-use/inspector` entries with a single `mcp-use` entry; remove the obsolete `tsx` dev dependency.
  - Add a patch changeset for `create-mcp-use-app`.

<sup>Written for commit 9230f12852a37be846b91e285b70f2e11cd8cc9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

