### PR TITLE
fix(create-app): pin beta scaffolds to beta 36

### DIFF
--- a/libraries/typescript/.changeset/pin-create-app-beta36.md
+++ b/libraries/typescript/.changeset/pin-create-app-beta36.md
@@ -1,0 +1,5 @@
+---
+"create-mcp-use-app": patch
+---
+
+Pin beta scaffolds to `mcp-use@2.0.0-beta.36` by default while preserving `--dev` and explicit `--sdk-version` overrides.

--- a/libraries/typescript/packages/create-mcp-use-app/src/index.ts
+++ b/libraries/typescript/packages/create-mcp-use-app/src/index.ts
@@ -293,6 +293,9 @@ const packageJson = JSON.parse(
   readFileSync(join(__dirname, "../package.json"), "utf-8")
 );
 
+// TODO(stable release): Change this back to "latest" before publishing create-mcp-use-app 2.0.0.
+const DEFAULT_MCP_USE_VERSION = "2.0.0-beta.36";
+
 function getCurrentPackageVersions(
   isDevelopment: boolean = false,
   sdkVersion?: string
@@ -302,7 +305,7 @@ function getCurrentPackageVersions(
       "mcp-use": "workspace:*",
     };
   }
-  const requestedSdk = sdkVersion ?? "latest";
+  const requestedSdk = sdkVersion ?? DEFAULT_MCP_USE_VERSION;
   return {
     "mcp-use": requestedSdk,
   };
@@ -326,7 +329,7 @@ function processTemplateFile(
 
   const mcpUseVersion = isDevelopment
     ? "workspace:*"
-    : versions["mcp-use"] || "latest";
+    : versions["mcp-use"] || DEFAULT_MCP_USE_VERSION;
 
   if (isDevelopment) {
     processedContent = processedContent.replace(

--- a/libraries/typescript/packages/create-mcp-use-app/test-cli.sh
+++ b/libraries/typescript/packages/create-mcp-use-app/test-cli.sh
@@ -12,6 +12,8 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
+EXPECTED_DEFAULT_MCP_USE_VERSION="2.0.0-beta.36"
+
 # Get script directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TEST_DIR="${TEST_DIR:-/tmp/create-mcp-use-app-test-$$}"
@@ -172,14 +174,14 @@ run_test() {
                 fi
                 echo -e "${GREEN}   ✓ Verified sdk version: $mcp_use_version${NC}"
             else
-                # Check for latest or specific versions (not workspace:* or canary)
+                # The beta scaffolder must default to the exact beta SDK pin.
                 local mcp_use_version=$(jq -r '.dependencies."mcp-use"' "$package_json")
-                if [[ "$mcp_use_version" == "workspace:"* ]] || [[ "$mcp_use_version" == "canary" ]]; then
-                    echo -e "${RED}❌ FAILED: Expected latest/specific version, got: $mcp_use_version${NC}"
+                if [[ "$mcp_use_version" != "$EXPECTED_DEFAULT_MCP_USE_VERSION" ]]; then
+                    echo -e "${RED}❌ FAILED: Expected mcp-use@$EXPECTED_DEFAULT_MCP_USE_VERSION, got: $mcp_use_version${NC}"
                     TESTS_FAILED=$((TESTS_FAILED + 1))
                     return 1
                 fi
-                echo -e "${GREEN}   ✓ Verified latest/specific versions${NC}"
+                echo -e "${GREEN}   ✓ Verified mcp-use@$mcp_use_version default${NC}"
             fi
 
             echo -e "${GREEN}   ✓ Verified Inspector is provided by mcp-use${NC}"
@@ -231,7 +233,11 @@ run_test "Version-Sdk-Canary" npm mcp-server "--sdk-version canary" ""
 echo ""
 run_test "Version-Sdk-Semver" npm mcp-server "--sdk-version 1.0.0" ""
 echo ""
-run_test "Version-Latest" npm mcp-server "" ""
+run_test "Version-Default-Beta-Server" npm mcp-server "" ""
+echo ""
+run_test "Version-Default-Beta-Apps" npm mcp-apps "" ""
+echo ""
+run_test "Version-Default-Beta-Blank" npm blank "" ""
 echo ""
 
 # Optional: Test with installation (slower)


### PR DESCRIPTION
## Summary

- default beta scaffolds to the exact `mcp-use@2.0.0-beta.36` SDK
- preserve `--dev` workspace linking and explicit `--sdk-version` overrides
- verify the exact default across the `mcp-server`, `mcp-apps`, and `blank` templates
- add a patch changeset for `create-mcp-use-app`

## Why

`create-mcp-use-app@2.0.0-beta.10` still falls back to the `latest` dist-tag when no SDK version is supplied. During the v2 beta, that generates projects against the stable v1 SDK instead of the beta SDK that includes the bundled CLI and Inspector behavior we are testing.

The beta scaffolder should be deterministic and beta-aligned, so its temporary default is pinned to `mcp-use@2.0.0-beta.36`.

## Stable-release TODO

The source includes an explicit TODO next to `DEFAULT_MCP_USE_VERSION`: change the default back to `latest` before publishing stable `create-mcp-use-app@2.0.0`.

## Validation

- `bash -n packages/create-mcp-use-app/test-cli.sh`
- `pnpm --filter create-mcp-use-app test` — 20 tests passed
- `pnpm --filter create-mcp-use-app build`
- `pnpm --filter create-mcp-use-app test:cli` — 10/10 packaged CLI cases passed
- confirmed all three bundled templates generate `"mcp-use": "2.0.0-beta.36"` by default
- confirmed `--dev`, `--sdk-version canary`, and `--sdk-version 1.0.0` still override the default

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin `create-mcp-use-app` beta scaffolds to `mcp-use@2.0.0-beta.36` by default so new projects use the v2 beta SDK instead of falling back to stable v1. Overrides via --dev and --sdk-version still work.

- **Bug Fixes**
  - Default SDK version set to `2.0.0-beta.36` across `mcp-server`, `mcp-apps`, and `blank` templates.
  - Preserve workspace linking (--dev) and explicit --sdk-version (e.g., canary or semver).
  - Updated CLI tests to assert the exact default; added patch changeset for `create-mcp-use-app`.
  - Added TODO to revert default to `latest` for the stable 2.0.0 release.

<sup>Written for commit cae72d73614aca493e53fa0df0f3c7f02cb1e5e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

