### PR TITLE
fix(release): rebuild prereleases after versioning

### DIFF
--- a/.github/workflows/typescript-release.yml
+++ b/.github/workflows/typescript-release.yml
@@ -104,6 +104,11 @@ jobs:
           git commit -m "chore(typescript): version packages (canary)" || echo "No changes to commit"
           git push
 
+      - name: Build versioned packages (Canary)
+        if: github.ref == 'refs/heads/canary' && steps.has-changesets.outputs.has_changesets == 'true'
+        working-directory: libraries/typescript
+        run: pnpm build
+
       - name: Publish packages (Canary)
         if: github.ref == 'refs/heads/canary' && steps.has-changesets.outputs.has_changesets == 'true'
         working-directory: libraries/typescript
@@ -647,6 +652,11 @@ jobs:
         run: |
           git branch --force main origin/main
           pnpm version:beta
+
+      - name: Build versioned beta packages
+        if: steps.changesets.outputs.pending == 'true'
+        working-directory: libraries/typescript
+        run: pnpm build
 
       - name: Commit beta versions
         if: steps.changesets.outputs.pending == 'true'

--- a/libraries/typescript/.changeset/rebuild-prerelease-after-versioning.md
+++ b/libraries/typescript/.changeset/rebuild-prerelease-after-versioning.md
@@ -1,0 +1,6 @@
+---
+"mcp-use": patch
+---
+
+Report the published package version in anonymous SDK usage metrics by rebuilding
+prerelease artifacts after package versioning and before publication.


### PR DESCRIPTION
## Summary

- rebuild canary packages after Changesets updates their prerelease versions
- rebuild beta packages after `pnpm version:beta` and before commit/pack/publish
- add an `mcp-use` patch changeset so the corrected beta is published and can be verified

## Root cause

The prerelease workflows built packages before versioning them. `mcp-use@2.0.0-beta.37` therefore had the correct manifest and npm dist-tag, but its compiled usage event still contained the previous build-time constant, `sdk_version=2.0.0-beta.36`.

## Impact

Published beta and canary artifacts will now embed the same version shown in their package manifest. Stable publishing already builds from a separately committed version and is unchanged.

## Validation

- YAML parses successfully
- asserted canary order: version → build → publish
- asserted beta order: version → build → publish
- changeset formatting and staged diff checks pass
- reproduced against the published npm tarball and PostHog validation run `published-beta37-20260723`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuild prerelease packages after versioning so compiled artifacts embed the same version as the manifest. Fixes mismatched version constants in canary and beta builds.

- **Bug Fixes**
  - Canary: build after Changesets versioning and before publish.
  - Beta: build after `pnpm version:beta` and before commit/pack/publish.
  - Added a patch changeset for `mcp-use` to republish the corrected beta.

<sup>Written for commit b42726658d7cdecef2b888996a4c2eaef775ceef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

