### PR TITLE
fix(inspector): use OAuth for hosted chat sign-in

### DIFF
--- a/libraries/typescript/.changeset/sour-socks-approve.md
+++ b/libraries/typescript/.changeset/sour-socks-approve.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Use the standard OAuth consent flow when signing in to hosted Inspector chat.

--- a/libraries/typescript/packages/inspector/src/client/auth/manufact-auth.ts
+++ b/libraries/typescript/packages/inspector/src/client/auth/manufact-auth.ts
@@ -124,10 +124,6 @@ function sharedAppOrigin(origin: string): string {
   return `${url.protocol}//manufact.com`;
 }
 
-function sharedLoginUrl(origin: string): string {
-  return `${sharedAppOrigin(origin)}/login`;
-}
-
 function sharedSignOutUrl(origin: string): string {
   return `${sharedAppOrigin(origin)}/auth/embedded-sign-out`;
 }
@@ -514,28 +510,6 @@ export async function authorizeManufact(
   );
   if (!popup) throw new Error("Allow popups to sign in with Manufact");
   emit(origin, { authorizing: true });
-  if (canShareManufactSession(window.location.href, origin)) {
-    popup.location.href = sharedLoginUrl(origin);
-    const sessionPoll = window.setInterval(async () => {
-      if (popup.closed) {
-        window.clearInterval(sessionPoll);
-        emit(origin, { authorizing: false });
-        return;
-      }
-      const user = await fetchSessionUser(origin);
-      if (!user) return;
-      window.clearInterval(sessionPoll);
-      popup.close();
-      emit(origin, {
-        loaded: true,
-        authorizing: false,
-        accessToken: null,
-        user,
-        mode: "session",
-      });
-    }, 1000);
-    return;
-  }
   try {
     const metadata = await discover(origin);
     const client = await getClient(origin, metadata);

--- a/libraries/typescript/packages/inspector/tests/unit/manufact-auth.test.ts
+++ b/libraries/typescript/packages/inspector/tests/unit/manufact-auth.test.ts
@@ -72,6 +72,10 @@ describe("Manufact Inspector OAuth", () => {
     localStorage.clear();
     popup.location.href = "";
     popup.closed = false;
+    Object.assign(window.location, {
+      origin: "http://localhost:3005",
+      href: "http://localhost:3005/inspector",
+    });
     vi.clearAllMocks();
   });
 
@@ -151,6 +155,43 @@ describe("Manufact Inspector OAuth", () => {
         authOrigin: "https://cloud.example",
       },
       "http://localhost:3005"
+    );
+  });
+
+  it("uses OAuth consent from a hosted Manufact Inspector", async () => {
+    Object.assign(window.location, {
+      origin: "https://inspector.dev.manufact.com",
+      href: "https://inspector.dev.manufact.com/inspector",
+    });
+    const fetchMock = vi.fn(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input);
+        if (url.endsWith("openid-configuration")) {
+          return Response.json(metadata);
+        }
+        if (url === metadata.registration_endpoint) {
+          expect(init?.method).toBe("POST");
+          return Response.json(
+            { client_id: "hosted-inspector-client" },
+            { status: 201 }
+          );
+        }
+        throw new Error(`Unexpected request: ${url}`);
+      }
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await authorizeManufact(
+      "https://cloud.dev.manufact.com/api/v1/inspector/chat/stream"
+    );
+
+    const authorizationUrl = new URL(popup.location.href);
+    expect(authorizationUrl.origin + authorizationUrl.pathname).toBe(
+      metadata.authorization_endpoint
+    );
+    expect(authorizationUrl.searchParams.get("prompt")).toBe("consent");
+    expect(authorizationUrl.searchParams.get("client_id")).toBe(
+      "hosted-inspector-client"
     );
   });
 


### PR DESCRIPTION
## What changed

- Always start the standard PKCE OAuth flow when a user clicks hosted-chat **Sign in**.
- Keep passive shared-session discovery for users who already have a valid same-environment session.
- Add a regression test for `inspector.dev.manufact.com` → `cloud.dev.manufact.com`.
- Add an Inspector patch changeset.

## Why

The dev Inspector treated every `*.manufact.com` pairing as a shareable session, opened the production `manufact.com/login`, then polled the dev Cloud session endpoint. The dev endpoint returned no user, so the Inspector continued showing **Sign in** instead of the avatar.

## Verification

- `vitest run tests/unit/manufact-auth.test.ts` (10 passed)
- Inspector lint on changed files
- Inspector type-check after building workspace dependencies
- Full `@mcp-use/inspector` production build and package verification

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch hosted Inspector chat sign-in to the standard OAuth PKCE consent flow. Fixes the dev Inspector staying on “Sign in” by avoiding prod login with dev session polling.

- **Bug Fixes**
  - Always start OAuth consent from hosted Inspector; remove shared-session login path.
  - Keep passive shared-session discovery for trusted same-environment sessions.
  - Add a regression test for inspector.dev.manufact.com → cloud.dev.manufact.com OAuth consent and dynamic client registration.
  - Add a patch changeset for `@mcp-use/inspector`.

<sup>Written for commit 936744060238482fe1361dcdea1a8843b9063ec3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

