### PR TITLE
fix(inspector): harden MCP Apps host policies

### DIFF
--- a/libraries/typescript/packages/client/src/react/view/ViewRenderer.tsx
+++ b/libraries/typescript/packages/client/src/react/view/ViewRenderer.tsx
@@ -37,20 +37,15 @@ import {
   useViewDisplayModeControls,
   VIEW_DIMENSIONS,
 } from "./use-display-mode.js";
+import {
+  assertAppCanCallTool,
+  buildDefaultHostCapabilities,
+  resolveRequestedDisplayMode,
+} from "./view-host-policy.js";
 
 const DEFAULT_HOST_INFO = { name: "mcp-use-client", version: "2.0.0" } as const;
 const DEFAULT_TOOL_CALL_TIMEOUT = 600_000;
 const SANDBOX_PROXY_READY = "ui/notifications/sandbox-proxy-ready";
-const DEFAULT_HOST_CAPABILITIES: McpUiHostCapabilities = {
-  openLinks: {},
-  serverTools: {},
-  serverResources: {},
-  logging: {},
-  updateModelContext: { text: {} },
-  // ponytail: always advertised; bridge.onmessage no-ops when onMessage unset
-  message: { text: {} },
-};
-
 function CloseIcon() {
   return (
     <svg
@@ -171,6 +166,18 @@ function ViewRendererBase({
   const [internalDisplayMode, setInternalDisplayMode] =
     useState<ViewDisplayMode>("inline");
   const displayMode = displayModeProp ?? internalDisplayMode;
+  const effectiveHostCapabilities = useMemo<McpUiHostCapabilities>(
+    () => ({
+      ...buildDefaultHostCapabilities({
+        hasConnection: source.kind === "live",
+        hasMessageHandler: onMessage !== undefined,
+        hasModelContextHandler: onModelContextUpdate !== undefined,
+        hasLogHandler: onLog !== undefined,
+      }),
+      ...hostCapabilities,
+    }),
+    [hostCapabilities, onLog, onMessage, onModelContextUpdate, source.kind]
+  );
 
   // Guest hostContext must track the shell's displayMode even when the parent
   // only uses ViewRenderer's internal state (e.g. inspector chat).
@@ -441,7 +448,7 @@ function ViewRendererBase({
         if (disposed) return;
 
         const capabilities: McpUiHostCapabilities = {
-          ...(hostCapabilities ?? DEFAULT_HOST_CAPABILITIES),
+          ...effectiveHostCapabilities,
           sandbox: {
             csp: cspMode === "permissive" ? undefined : resolved.csp,
             permissions: resolved.permissions,
@@ -452,84 +459,101 @@ function ViewRendererBase({
           hostContext: hostContextRef.current,
         });
 
-        bridge.onmessage = async ({
-          content,
-        }: McpUiMessageRequest["params"]) => {
-          if (content.length > 0 && onMessageRef.current) {
-            onMessageRef.current(content);
-          }
-          return {};
-        };
+        if (capabilities.message) {
+          bridge.onmessage = async ({
+            content,
+          }: McpUiMessageRequest["params"]) => {
+            if (!onMessageRef.current) {
+              throw new Error("This host surface does not support ui/message");
+            }
+            if (content.length > 0) {
+              onMessageRef.current(content);
+            }
+            return {};
+          };
+        }
 
         bridge.onopenlink = async ({ url }: McpUiOpenLinkRequest["params"]) => {
           if (url) window.open(url, "_blank", "noopener,noreferrer");
           return {};
         };
 
-        bridge.oncalltool = (async ({
-          name,
-          arguments: args,
-        }: CallToolRequest["params"]) => {
-          const conn = connectionRef.current;
-          if (!conn) throw new Error("Server connection not available");
-          try {
-            return await conn.callTool(name, args || {}, {
-              timeout: toolCallTimeout,
-              resetTimeoutOnProgress: true,
-            });
-          } catch (error) {
-            bridge?.sendToolCancelled({
-              reason: error instanceof Error ? error.message : String(error),
-            });
-            throw error;
-          }
-        }) as typeof bridge.oncalltool;
+        if (capabilities.serverTools) {
+          bridge.oncalltool = (async ({
+            name,
+            arguments: args,
+          }: CallToolRequest["params"]) => {
+            const conn = connectionRef.current;
+            if (!conn) throw new Error("Server connection not available");
+            assertAppCanCallTool(conn.tools, name);
+            try {
+              return await conn.callTool(name, args || {}, {
+                timeout: toolCallTimeout,
+                resetTimeoutOnProgress: true,
+              });
+            } catch (error) {
+              bridge?.sendToolCancelled({
+                reason: error instanceof Error ? error.message : String(error),
+              });
+              throw error;
+            }
+          }) as typeof bridge.oncalltool;
+        }
 
-        bridge.onreadresource = (async ({
-          uri,
-        }: ReadResourceRequest["params"]) => {
-          const conn = connectionRef.current;
-          if (!conn) throw new Error("Server connection not available");
-          return (await conn.readResource(uri)) as object;
-        }) as NonNullable<AppBridge["onreadresource"]>;
+        if (capabilities.serverResources) {
+          bridge.onreadresource = (async ({
+            uri,
+          }: ReadResourceRequest["params"]) => {
+            const conn = connectionRef.current;
+            if (!conn) throw new Error("Server connection not available");
+            return (await conn.readResource(uri)) as object;
+          }) as NonNullable<AppBridge["onreadresource"]>;
 
-        bridge.onlistresources = (async () => {
-          const conn = connectionRef.current;
-          if (!conn) throw new Error("Server connection not available");
-          return { resources: [...(conn.resources ?? [])] } as object;
-        }) as NonNullable<AppBridge["onlistresources"]>;
+          bridge.onlistresources = (async () => {
+            const conn = connectionRef.current;
+            if (!conn) throw new Error("Server connection not available");
+            return { resources: [...(conn.resources ?? [])] } as object;
+          }) as NonNullable<AppBridge["onlistresources"]>;
+        }
 
         bridge.onrequestdisplaymode = async ({
           mode,
         }: McpUiRequestDisplayModeRequest["params"]) => {
           const requested = (mode ?? "inline") as ViewDisplayMode;
-          const available = hostContextRef.current?.availableDisplayModes ?? [
-            "inline",
-            "pip",
-            "fullscreen",
-          ];
-          const effective = available.includes(requested)
-            ? requested
-            : displayModeRef.current;
+          const effective = resolveRequestedDisplayMode({
+            requested,
+            current: displayModeRef.current,
+            hostAvailable: hostContextRef.current?.availableDisplayModes,
+            appAvailable: bridge?.getAppCapabilities()?.availableDisplayModes,
+          });
           await handleDisplayModeChangeRef.current(effective);
           return { mode: effective };
         };
 
-        bridge.onupdatemodelcontext = async ({
-          content,
-          structuredContent,
-        }: McpUiUpdateModelContextRequest["params"]) => {
-          onModelContextUpdateRef.current?.({ content, structuredContent });
-          return {};
-        };
+        if (capabilities.updateModelContext) {
+          bridge.onupdatemodelcontext = async ({
+            content,
+            structuredContent,
+          }: McpUiUpdateModelContextRequest["params"]) => {
+            if (!onModelContextUpdateRef.current) {
+              throw new Error(
+                "This host surface does not support model context updates"
+              );
+            }
+            onModelContextUpdateRef.current({ content, structuredContent });
+            return {};
+          };
+        }
 
-        bridge.onloggingmessage = async ({
-          level,
-          data,
-        }: LoggingMessageNotificationParams) => {
-          onLogRef.current?.({ level, data });
-          return {};
-        };
+        if (capabilities.logging) {
+          bridge.onloggingmessage = async ({
+            level,
+            data,
+          }: LoggingMessageNotificationParams) => {
+            onLogRef.current?.({ level, data });
+            return {};
+          };
+        }
 
         bridge.onsizechange = async ({
           height,
@@ -625,7 +649,7 @@ function ViewRendererBase({
     resolved,
     activeSandboxUrl,
     hostInfo,
-    hostCapabilities,
+    effectiveHostCapabilities,
     cspMode,
     viewId,
     wrapTransport,

--- a/libraries/typescript/packages/client/src/react/view/types.ts
+++ b/libraries/typescript/packages/client/src/react/view/types.ts
@@ -25,6 +25,14 @@ export interface ViewConnection {
     options?: { timeout?: number; resetTimeoutOnProgress?: boolean }
   ) => Promise<unknown>;
   readResource: (uri: string) => Promise<unknown>;
+  tools?: readonly {
+    name: string;
+    _meta?: {
+      ui?: {
+        visibility?: readonly ("model" | "app")[];
+      };
+    };
+  }[];
   resources?: readonly { uri: string; _meta?: { ui?: unknown } }[];
 }
 

--- a/libraries/typescript/packages/client/src/react/view/view-host-policy.test.ts
+++ b/libraries/typescript/packages/client/src/react/view/view-host-policy.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertAppCanCallTool,
+  buildDefaultHostCapabilities,
+  resolveRequestedDisplayMode,
+} from "./view-host-policy.js";
+
+describe("buildDefaultHostCapabilities", () => {
+  it("advertises only capabilities backed by the current surface", () => {
+    expect(
+      buildDefaultHostCapabilities({
+        hasConnection: false,
+        hasMessageHandler: false,
+        hasModelContextHandler: false,
+        hasLogHandler: false,
+      })
+    ).toEqual({ openLinks: {} });
+
+    expect(
+      buildDefaultHostCapabilities({
+        hasConnection: true,
+        hasMessageHandler: true,
+        hasModelContextHandler: true,
+        hasLogHandler: true,
+      })
+    ).toEqual({
+      openLinks: {},
+      serverTools: {},
+      serverResources: {},
+      logging: {},
+      updateModelContext: { text: {} },
+      message: { text: {} },
+    });
+  });
+});
+
+describe("resolveRequestedDisplayMode", () => {
+  it("allows a mode supported by both host and app", () => {
+    expect(
+      resolveRequestedDisplayMode({
+        requested: "fullscreen",
+        current: "inline",
+        hostAvailable: ["inline", "pip", "fullscreen"],
+        appAvailable: ["inline", "fullscreen"],
+      })
+    ).toBe("fullscreen");
+  });
+
+  it("returns the current mode when the app did not declare the request", () => {
+    expect(
+      resolveRequestedDisplayMode({
+        requested: "pip",
+        current: "inline",
+        hostAvailable: ["inline", "pip", "fullscreen"],
+        appAvailable: ["inline", "fullscreen"],
+      })
+    ).toBe("inline");
+  });
+
+  it("defaults missing mode declarations to inline only", () => {
+    expect(
+      resolveRequestedDisplayMode({
+        requested: "fullscreen",
+        current: "inline",
+      })
+    ).toBe("inline");
+  });
+});
+
+describe("assertAppCanCallTool", () => {
+  const tools = [
+    { name: "default-visible" },
+    { name: "app-only", _meta: { ui: { visibility: ["app"] } } },
+    {
+      name: "shared",
+      _meta: { ui: { visibility: ["model", "app"] } },
+    },
+    { name: "model-only", _meta: { ui: { visibility: ["model"] } } },
+  ] as const;
+
+  it.each(["default-visible", "app-only", "shared"])("allows %s", (name) => {
+    expect(() => assertAppCanCallTool(tools, name)).not.toThrow();
+  });
+
+  it.each(["model-only", "missing"])("rejects %s", (name) => {
+    expect(() => assertAppCanCallTool(tools, name)).toThrow(
+      `Tool "${name}" is not available to this app`
+    );
+  });
+});

--- a/libraries/typescript/packages/client/src/react/view/view-host-policy.ts
+++ b/libraries/typescript/packages/client/src/react/view/view-host-policy.ts
@@ -1,0 +1,62 @@
+import type { McpUiHostCapabilities } from "./ext-apps-bridge.js";
+import type { ViewConnection, ViewDisplayMode } from "./types.js";
+
+type CapabilityInputs = {
+  hasConnection: boolean;
+  hasMessageHandler: boolean;
+  hasModelContextHandler: boolean;
+  hasLogHandler: boolean;
+};
+
+export function buildDefaultHostCapabilities({
+  hasConnection,
+  hasMessageHandler,
+  hasModelContextHandler,
+  hasLogHandler,
+}: CapabilityInputs): McpUiHostCapabilities {
+  return {
+    openLinks: {},
+    ...(hasConnection
+      ? {
+          serverTools: {},
+          serverResources: {},
+        }
+      : {}),
+    ...(hasLogHandler ? { logging: {} } : {}),
+    ...(hasModelContextHandler ? { updateModelContext: { text: {} } } : {}),
+    ...(hasMessageHandler ? { message: { text: {} } } : {}),
+  };
+}
+
+export function resolveRequestedDisplayMode({
+  requested,
+  current,
+  hostAvailable,
+  appAvailable,
+}: {
+  requested: ViewDisplayMode;
+  current: ViewDisplayMode;
+  hostAvailable?: readonly ViewDisplayMode[];
+  appAvailable?: readonly ViewDisplayMode[];
+}): ViewDisplayMode {
+  const hostModes = hostAvailable ?? ["inline"];
+  const appModes = appAvailable ?? ["inline"];
+  return hostModes.includes(requested) && appModes.includes(requested)
+    ? requested
+    : current;
+}
+
+export function assertAppCanCallTool(
+  tools: ViewConnection["tools"],
+  name: string
+): void {
+  const tool = tools?.find((candidate) => candidate.name === name);
+  if (!tool) {
+    throw new Error(`Tool "${name}" is not available to this app`);
+  }
+
+  const visibility = tool._meta?.ui?.visibility;
+  if (visibility && !visibility.includes("app")) {
+    throw new Error(`Tool "${name}" is not available to this app`);
+  }
+}

--- a/libraries/typescript/packages/inspector/src/client/components/mcp-apps/McpAppsViewPanel.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/mcp-apps/McpAppsViewPanel.tsx
@@ -102,11 +102,15 @@ export function McpAppsViewPanel({
       partialToolInput={partialToolInput}
       cancelled={cancelled}
       className={viewRendererClassName}
-      onMessage={(content) => {
-        if (content.length > 0 && onSendFollowUp) {
-          onSendFollowUp(content as MessageContentBlock[]);
-        }
-      }}
+      onMessage={
+        onSendFollowUp
+          ? (content) => {
+              if (content.length > 0) {
+                onSendFollowUp(content as MessageContentBlock[]);
+              }
+            }
+          : undefined
+      }
       onInlineHeightChange={
         displayMode === "inline" ? onWidgetHeightChange : undefined
       }

--- a/libraries/typescript/packages/inspector/src/client/components/tools/ToolResultDisplay.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/tools/ToolResultDisplay.tsx
@@ -21,8 +21,6 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { toast } from "sonner";
-import type { MessageContentBlock } from "@/client/types/message-content-block";
 import { getViewResourceUri, isViewTool } from "@mcp-use/client/react";
 import { McpAppsViewPanel } from "../mcp-apps/McpAppsViewPanel";
 import { MCPAppsDebugControls } from "../MCPAppsDebugControls";
@@ -464,34 +462,6 @@ export function ToolResultDisplay({
     [readResource]
   );
 
-  // Memoize onSendFollowUp to prevent infinite re-render loop
-  // This callback is used in MCPAppsRenderer's effect dependency array
-  const memoizedOnSendFollowUp = useCallback(
-    (content: MessageContentBlock[]) => {
-      const text = content
-        .filter(
-          (c): c is { type: "text"; text: string } =>
-            c.type === "text" && "text" in c
-        )
-        .map((c) => c.text)
-        .join("\n");
-      const imageCount = content.filter((c) => c.type === "image").length;
-      const resourceCount = content.filter((c) => c.type === "resource").length;
-      const extras = [
-        imageCount > 0 && `${imageCount} image${imageCount > 1 ? "s" : ""}`,
-        resourceCount > 0 &&
-          `${resourceCount} resource${resourceCount > 1 ? "s" : ""}`,
-      ]
-        .filter(Boolean)
-        .join(", ");
-      toast.info("Widget follow-up", {
-        description: [text, extras].filter(Boolean).join(" — "),
-        duration: 5000,
-      });
-    },
-    []
-  );
-
   // Detect widget protocol (MCP Apps only)
   // IMPORTANT: These hooks must be called before any early returns
   const widgetProtocol = useMemo(
@@ -836,7 +806,6 @@ export function ToolResultDisplay({
                           customProps={activeProps || undefined}
                           displayMode={mcpAppsDisplayMode}
                           onDisplayModeChange={setMcpAppsDisplayMode}
-                          onSendFollowUp={memoizedOnSendFollowUp}
                           onWidgetHeightChange={
                             onWidgetHeightChange
                               ? (height) => onWidgetHeightChange(height)

--- a/libraries/typescript/packages/inspector/src/client/components/tools/__tests__/tool-metadata.test.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/tools/__tests__/tool-metadata.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { mergeToolMetadata } from "../tool-metadata";
+
+describe("mergeToolMetadata", () => {
+  it("retains MCP Apps metadata when a result adds unrelated metadata", () => {
+    expect(
+      mergeToolMetadata(
+        {
+          ui: {
+            resourceUri: "ui://example/widget",
+            visibility: ["model", "app"],
+          },
+          "ui/resourceUri": "ui://example/widget",
+        },
+        {
+          "vendor/analytics": {
+            distinctId: "test-session",
+          },
+        }
+      )
+    ).toEqual({
+      ui: {
+        resourceUri: "ui://example/widget",
+        visibility: ["model", "app"],
+      },
+      "ui/resourceUri": "ui://example/widget",
+      "vendor/analytics": {
+        distinctId: "test-session",
+      },
+    });
+  });
+
+  it("lets result metadata override matching fields without dropping nested UI fields", () => {
+    expect(
+      mergeToolMetadata(
+        {
+          ui: {
+            resourceUri: "ui://old",
+            visibility: ["model"],
+          },
+        },
+        {
+          ui: {
+            resourceUri: "ui://new",
+          },
+        }
+      )
+    ).toEqual({
+      ui: {
+        resourceUri: "ui://new",
+        visibility: ["model"],
+      },
+    });
+  });
+});

--- a/libraries/typescript/packages/inspector/src/client/components/tools/tool-metadata.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/tools/tool-metadata.ts
@@ -1,0 +1,35 @@
+type ToolMetadata = Record<string, unknown>;
+
+/**
+ * Tool-result metadata augments the tool definition metadata. It must not erase
+ * the definition's MCP Apps resource URI when a server returns unrelated
+ * result metadata such as analytics or tracing fields.
+ */
+export function mergeToolMetadata(
+  definitionMetadata: ToolMetadata | undefined,
+  resultMetadata: ToolMetadata | undefined
+): ToolMetadata | undefined {
+  if (!definitionMetadata) return resultMetadata;
+  if (!resultMetadata) return definitionMetadata;
+
+  const definitionUi =
+    definitionMetadata.ui &&
+    typeof definitionMetadata.ui === "object" &&
+    !Array.isArray(definitionMetadata.ui)
+      ? (definitionMetadata.ui as ToolMetadata)
+      : undefined;
+  const resultUi =
+    resultMetadata.ui &&
+    typeof resultMetadata.ui === "object" &&
+    !Array.isArray(resultMetadata.ui)
+      ? (resultMetadata.ui as ToolMetadata)
+      : undefined;
+
+  return {
+    ...definitionMetadata,
+    ...resultMetadata,
+    ...(definitionUi || resultUi
+      ? { ui: { ...definitionUi, ...resultUi } }
+      : {}),
+  };
+}

--- a/libraries/typescript/packages/inspector/src/client/components/tools/useToolExecution.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/tools/useToolExecution.ts
@@ -6,6 +6,7 @@ import {
 import { copyToClipboard } from "@/client/utils/browser";
 import { useCallback, useMemo, useState } from "react";
 import type { ToolResult } from "./ToolResultDisplay";
+import { mergeToolMetadata } from "./tool-metadata";
 
 export function useToolExecution({
   selectedTool,
@@ -75,7 +76,10 @@ export function useToolExecution({
         signal: controller.signal,
       });
       const duration = Date.now() - startTime;
-      const updatedToolMeta = (result as any)?._meta ?? toolMeta;
+      const updatedToolMeta = mergeToolMetadata(
+        toolMeta,
+        (result as any)?._meta
+      );
 
       captureInspectorEvent(
         new MCPToolExecutionEvent({

--- a/libraries/typescript/packages/inspector/src/client/context/WidgetDebugContext.tsx
+++ b/libraries/typescript/packages/inspector/src/client/context/WidgetDebugContext.tsx
@@ -102,7 +102,7 @@ const WidgetDebugContext = createContext<WidgetDebugContextType | undefined>(
 const DEFAULT_PLAYGROUND_SETTINGS: PlaygroundSettings = {
   deviceType: "desktop",
   customViewport: { width: 768, height: 1024 },
-  cspMode: "permissive",
+  cspMode: "widget-declared",
   displayModeOverride: null,
   capabilities: { hover: true, touch: false },
   safeAreaInsets: { top: 0, right: 0, bottom: 0, left: 0 },

--- a/libraries/typescript/packages/inspector/src/client/hooks/__tests__/useMcpAppsHostContext.test.ts
+++ b/libraries/typescript/packages/inspector/src/client/hooks/__tests__/useMcpAppsHostContext.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { buildLightDarkValue } from "../useMcpAppsHostContext";
+
+describe("buildLightDarkValue", () => {
+  it("builds a CSS light-dark pair", () => {
+    expect(
+      buildLightDarkValue("oklch(1 0 0)", "oklch(0.141 0.005 285.823)")
+    ).toBe("light-dark(oklch(1 0 0), oklch(0.141 0.005 285.823))");
+  });
+
+  it("falls back when one side is unavailable", () => {
+    expect(buildLightDarkValue("white", "")).toBe("white");
+    expect(buildLightDarkValue("", "black")).toBe("black");
+  });
+});

--- a/libraries/typescript/packages/inspector/src/client/hooks/useMcpAppsHostContext.ts
+++ b/libraries/typescript/packages/inspector/src/client/hooks/useMcpAppsHostContext.ts
@@ -6,6 +6,7 @@ import { useMemo } from "react";
 import type { McpUiHostContext } from "@mcp-use/client/react";
 import type { Tool } from "@mcp-use/client/react";
 import type { PlaygroundSettings } from "../context/WidgetDebugContext";
+import { getPackageVersion } from "../telemetry/utils";
 
 type DisplayMode = "inline" | "pip" | "fullscreen";
 
@@ -28,48 +29,94 @@ function readCssVar(styles: CSSStyleDeclaration, name: string): string {
   return styles.getPropertyValue(name).trim();
 }
 
+const THEME_COLOR_VARIABLES = [
+  "--background",
+  "--foreground",
+  "--card",
+  "--muted",
+  "--muted-foreground",
+  "--primary",
+  "--primary-foreground",
+  "--secondary",
+  "--accent",
+  "--accent-foreground",
+  "--destructive",
+  "--border",
+  "--ring",
+] as const;
+
+function readThemeValues(
+  theme: "light" | "dark"
+): Record<(typeof THEME_COLOR_VARIABLES)[number], string> {
+  const probe = document.createElement("div");
+  probe.className = `mcp-apps-host-theme-probe-${theme}`;
+  probe.hidden = true;
+  (document.body ?? document.documentElement).appendChild(probe);
+  const styles = getComputedStyle(probe);
+  const values = Object.fromEntries(
+    THEME_COLOR_VARIABLES.map((name) => [name, readCssVar(styles, name)])
+  ) as Record<(typeof THEME_COLOR_VARIABLES)[number], string>;
+  probe.remove();
+  return values;
+}
+
+export function buildLightDarkValue(
+  lightValue: string,
+  darkValue: string
+): string {
+  if (!lightValue) return darkValue;
+  if (!darkValue) return lightValue;
+  return `light-dark(${lightValue}, ${darkValue})`;
+}
+
 function buildHostStyleVariables(): Record<string, string> {
   if (typeof window === "undefined") return {};
 
   const styles = getComputedStyle(document.documentElement);
+  const lightValues = readThemeValues("light");
+  const darkValues = readThemeValues("dark");
   const variables: Record<string, string> = {};
   const add = (name: string, value: string) => {
     if (value) variables[name] = value;
   };
+  const addThemeColor = (
+    name: string,
+    cssVariable: string,
+    fallbackCssVariable?: string
+  ) => {
+    const light =
+      lightValues[cssVariable as keyof typeof lightValues] ||
+      (fallbackCssVariable
+        ? lightValues[fallbackCssVariable as keyof typeof lightValues]
+        : "");
+    const dark =
+      darkValues[cssVariable as keyof typeof darkValues] ||
+      (fallbackCssVariable
+        ? darkValues[fallbackCssVariable as keyof typeof darkValues]
+        : "");
+    add(name, buildLightDarkValue(light, dark));
+  };
 
-  const background = readCssVar(styles, "--background");
-  const foreground = readCssVar(styles, "--foreground");
-  const card = readCssVar(styles, "--card");
-  const muted = readCssVar(styles, "--muted");
-  const mutedForeground = readCssVar(styles, "--muted-foreground");
-  const primary = readCssVar(styles, "--primary");
-  const primaryForeground = readCssVar(styles, "--primary-foreground");
-  const secondary = readCssVar(styles, "--secondary");
-  const accent = readCssVar(styles, "--accent");
-  const accentForeground = readCssVar(styles, "--accent-foreground");
-  const destructive = readCssVar(styles, "--destructive");
-  const border = readCssVar(styles, "--border");
-  const ring = readCssVar(styles, "--ring");
   const radius = readCssVar(styles, "--radius");
 
-  add("--color-background-primary", background);
-  add("--color-background-secondary", card || secondary);
-  add("--color-background-tertiary", muted || accent);
-  add("--color-background-inverse", primary);
-  add("--color-background-ghost", accent || muted);
-  add("--color-background-danger", destructive);
+  addThemeColor("--color-background-primary", "--background");
+  addThemeColor("--color-background-secondary", "--card", "--secondary");
+  addThemeColor("--color-background-tertiary", "--muted", "--accent");
+  addThemeColor("--color-background-inverse", "--primary");
+  addThemeColor("--color-background-ghost", "--accent", "--muted");
+  addThemeColor("--color-background-danger", "--destructive");
 
-  add("--color-text-primary", foreground);
-  add("--color-text-secondary", mutedForeground);
-  add("--color-text-tertiary", mutedForeground);
-  add("--color-text-inverse", primaryForeground);
-  add("--color-text-ghost", accentForeground || mutedForeground);
-  add("--color-text-danger", destructive);
+  addThemeColor("--color-text-primary", "--foreground");
+  addThemeColor("--color-text-secondary", "--muted-foreground");
+  addThemeColor("--color-text-tertiary", "--muted-foreground");
+  addThemeColor("--color-text-inverse", "--primary-foreground");
+  addThemeColor("--color-text-ghost", "--accent-foreground");
+  addThemeColor("--color-text-danger", "--destructive");
 
-  add("--color-border-primary", border);
-  add("--color-border-secondary", border);
-  add("--color-border-tertiary", border);
-  add("--color-ring-primary", ring || border);
+  addThemeColor("--color-border-primary", "--border");
+  addThemeColor("--color-border-secondary", "--border");
+  addThemeColor("--color-border-tertiary", "--border");
+  addThemeColor("--color-ring-primary", "--ring", "--border");
 
   add("--border-radius-sm", radius);
   add("--border-radius-md", radius);
@@ -108,7 +155,7 @@ export function useMcpAppsHostContext({
       locale: playground.locale,
       timeZone: playground.timeZone,
       platform: deviceType === "mobile" ? "mobile" : "web",
-      userAgent: "mcp-use-inspector/0.16.2",
+      userAgent: `mcp-use-inspector/${getPackageVersion()}`,
       deviceCapabilities: playground.capabilities,
       safeAreaInsets: playground.safeAreaInsets,
       styles: { variables: buildHostStyleVariables() as any },

--- a/libraries/typescript/packages/inspector/src/client/hooks/useViewHostProps.tsx
+++ b/libraries/typescript/packages/inspector/src/client/hooks/useViewHostProps.tsx
@@ -17,9 +17,14 @@ import { useTheme } from "@/client/context/ThemeContext";
 import { useWidgetDebug } from "@/client/context/WidgetDebugContext";
 import { useDeviceViewport } from "@/client/hooks/useDeviceViewport";
 import { useMcpAppsHostContext } from "@/client/hooks/useMcpAppsHostContext";
+import { buildCspAuditRecord } from "@/client/mcp-apps/csp-audit";
+import { getPackageVersion } from "@/client/telemetry/utils";
 import { getServerDisplayName, getServerIconUrl } from "@/client/utils/servers";
 
-const HOST_INFO = { name: "mcp-use-inspector", version: "11.0.0" } as const;
+const HOST_INFO = {
+  name: "mcp-use-inspector",
+  version: getPackageVersion(),
+} as const;
 
 function useStableViewConnection(
   server: ReturnType<typeof useMcpClient>["servers"][number] | undefined,
@@ -38,6 +43,9 @@ function useStableViewConnection(
       readResource: (uri) => readResourceRef.current(uri),
       get resources() {
         return serverRef.current?.resources;
+      },
+      get tools() {
+        return serverRef.current?.tools;
       },
     };
   }, [server?.id]);
@@ -159,6 +167,17 @@ export function useViewHostProps(options: {
       });
 
       const declared = resolved.declaredCsp;
+      const auditRecord = buildCspAuditRecord({
+        viewId,
+        mode: cspMode,
+        declared,
+      });
+      console.info("[MCP Apps CSP]", auditRecord);
+      consoleLogBus.publish({
+        level: "info",
+        args: ["[MCP Apps CSP]", auditRecord],
+        timestamp: new Date().toISOString(),
+      });
       let effectivePolicy: string | undefined;
       if (cspMode === "permissive") {
         effectivePolicy = [

--- a/libraries/typescript/packages/inspector/src/client/index.css
+++ b/libraries/typescript/packages/inspector/src/client/index.css
@@ -181,7 +181,8 @@
   }
 }
 
-:root {
+:root,
+.mcp-apps-host-theme-probe-light {
   --radius: 0.625rem;
   --cmdk-shadow: 0 16px 70px rgb(0 0 0 / 20%);
   --background: oklch(1 0 0);
@@ -291,7 +292,8 @@
     0 48px 48px -24px var(--shadow-color), 0 96px 96px -48px var(--shadow-color);
 }
 
-.dark {
+.dark,
+.mcp-apps-host-theme-probe-dark {
   --cmdk-shadow: 0 16px 70px rgb(0 0 0 / 50%);
   --background: oklch(0.141 0.005 285.823);
   --foreground: oklch(0.985 0 0);

--- a/libraries/typescript/packages/inspector/src/client/mcp-apps/__tests__/csp-audit.test.ts
+++ b/libraries/typescript/packages/inspector/src/client/mcp-apps/__tests__/csp-audit.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { buildCspAuditRecord } from "../csp-audit";
+
+describe("buildCspAuditRecord", () => {
+  it("records the effective mode and declared domain origins", () => {
+    expect(
+      buildCspAuditRecord({
+        viewId: "widget-1",
+        mode: "widget-declared",
+        declared: {
+          connectDomains: ["https://api.example.com/path?token=secret"],
+          resourceDomains: ["https://cdn.example.com/assets#section"],
+          frameDomains: ["https://frames.example.com"],
+          baseUriDomains: ["https://app.example.com/base"],
+        },
+      })
+    ).toEqual({
+      event: "mcp-apps-csp-applied",
+      viewId: "widget-1",
+      mode: "widget-declared",
+      source: "widget-metadata",
+      domains: {
+        connect: ["https://api.example.com"],
+        resource: ["https://cdn.example.com"],
+        frame: ["https://frames.example.com"],
+        baseUri: ["https://app.example.com"],
+      },
+    });
+  });
+
+  it("marks permissive mode as an explicit debug override", () => {
+    expect(
+      buildCspAuditRecord({
+        viewId: "widget-2",
+        mode: "permissive",
+        declared: undefined,
+      })
+    ).toMatchObject({
+      mode: "permissive",
+      source: "debug-override",
+    });
+  });
+});

--- a/libraries/typescript/packages/inspector/src/client/mcp-apps/csp-audit.ts
+++ b/libraries/typescript/packages/inspector/src/client/mcp-apps/csp-audit.ts
@@ -1,0 +1,38 @@
+import type { ViewCspMode } from "@mcp-use/client/react";
+import type { WidgetDeclaredCsp } from "@/client/context/WidgetDebugContext";
+
+function sanitizeDomain(value: string): string {
+  try {
+    const url = new URL(value);
+    return url.origin;
+  } catch {
+    return value.split(/[?#]/, 1)[0];
+  }
+}
+
+function sanitizeDomains(values: string[] | undefined): string[] {
+  return (values ?? []).map(sanitizeDomain);
+}
+
+export function buildCspAuditRecord({
+  viewId,
+  mode,
+  declared,
+}: {
+  viewId: string;
+  mode: ViewCspMode;
+  declared: WidgetDeclaredCsp | undefined;
+}) {
+  return {
+    event: "mcp-apps-csp-applied",
+    viewId,
+    mode,
+    source: mode === "permissive" ? "debug-override" : "widget-metadata",
+    domains: {
+      connect: sanitizeDomains(declared?.connectDomains),
+      resource: sanitizeDomains(declared?.resourceDomains),
+      frame: sanitizeDomains(declared?.frameDomains),
+      baseUri: sanitizeDomains(declared?.baseUriDomains),
+    },
+  } as const;
+}


### PR DESCRIPTION
## What changed

- derive MCP Apps host capabilities from the handlers mounted by each Inspector surface
- keep `ui/message` available in Chat while removing the non-durable Tools notification path
- enforce the intersection of host-supported and app-declared display modes
- guard app-originated server tool calls using tool visibility metadata
- preserve tool-definition UI metadata when result metadata adds unrelated fields
- report the Inspector package version consistently in host metadata
- provide paired light/dark theme variables to embedded apps
- use widget-declared CSP by default and emit a sanitized policy audit event

## Why

The shared MCP Apps renderer previously advertised behavior that was not always available on the mounted Inspector surface. Tool-result metadata could also replace definition metadata, and display/CSP behavior did not consistently reflect app declarations.

These changes make the host contract match the active surface and keep embedded app policy decisions explicit.

## Impact

Chat retains its real conversation integration. Tools no longer reports successful follow-up handling when no conversation exists. Embedded apps receive more accurate capabilities, theme values, display-mode negotiation, tool visibility enforcement, and CSP behavior.

## Validation

- `pnpm --filter @mcp-use/client test:run` — 254 tests passed
- `pnpm --filter @mcp-use/inspector test:unit` — 143 tests passed
- `pnpm --filter @mcp-use/inspector type-check`
- `pnpm --filter @mcp-use/inspector lint`
- `pnpm --filter @mcp-use/client build`
- `pnpm --filter @mcp-use/inspector build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened MCP Apps host policies to only advertise supported capabilities, enforce tool visibility and display mode negotiation, and default to widget-declared CSP with audit logging. Keeps Chat follow-ups working and aligns embedded app behavior with the active Inspector surface.

- **Bug Fixes**
  - Derive host capabilities from the active surface; expose `serverTools`, `serverResources`, `logging`, `updateModelContext`, and `message` only when handlers/connection exist.
  - Keep `ui/message` in Chat; remove the non-durable Tools follow-up path.
  - Enforce the intersection of host-supported and app-declared display modes.
  - Guard server tool calls using `_meta.ui.visibility`; reject tools not visible to apps.
  - Merge result metadata with tool definition metadata without dropping MCP Apps UI fields.
  - Report the `@mcp-use/inspector` version consistently via host info and `userAgent`.

- **New Features**
  - Provide paired light/dark theme variables to widgets using CSS `light-dark(...)`.
  - Default to widget-declared CSP and emit a sanitized CSP audit record.

<sup>Written for commit 4500c462e120f40325ea99500661dfe4bdce15e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

