### PR TITLE
Remove confirmation from the client remove command

### DIFF
--- a/libraries/typescript/.changeset/client-remove-without-confirmation.md
+++ b/libraries/typescript/.changeset/client-remove-without-confirmation.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Remove saved client servers immediately without confirmation and reject unsupported `--yes` and `--json` flags.

--- a/libraries/typescript/packages/server/specs/CLI_SPEC.md
+++ b/libraries/typescript/packages/server/specs/CLI_SPEC.md
@@ -143,7 +143,7 @@ mcp-use client connect <name> <url> [-H, --header <"Key: Value">...]
   [--no-oauth] [--auth-timeout <ms>] [--protocol <auto|2026-07-28|2025-11-25>]
   [--no-open] [--json]
 mcp-use client list [--json]
-mcp-use client remove <name> [--yes]
+mcp-use client remove <name>
 mcp-use client <name> tools list [--json]
 mcp-use client <name> tools describe <tool> [--json]
 mcp-use client <name> tools call <tool> [args...] [--timeout <ms>] [--json]
@@ -159,6 +159,7 @@ mcp-use client <name> auth logout [--yes] [--json]
 - `connect` validates a unique filesystem-safe name, connects before saving, and attempts OAuth on an authorization challenge unless `--no-oauth`. In an interactive TTY, OAuth prints `This server requires OAuth. Press Enter to open your browser.`, waits for Enter, and then opens the browser. `--no-open`, `--json`, and non-TTY operation never prompt or open a browser; they print the authorization URL to stderr while the loopback callback continues to wait. Repeated headers are stored as credentials, not metadata. Reusing a name requires removing it first.
 - `client` and `screenshot` dynamic-import `@mcp-use/client`. When it is missing, the CLI installs it automatically: into the nearest project `package.json` when one exists, otherwise into `~/.mcp-use/client-sdk/`. Auto-install continues the current command in-process and imports from the install location.
 - Tool/prompt arguments accept either one JSON object or `key=value` pairs; `key:=<json>` supplies typed JSON values. Mixing the full-object and pair forms is usage error `2`. Calls time out with exit `1`; tool `isError` results are operation failures and retain their protocol content in JSON error details.
+- `client remove` immediately and idempotently deletes the named local server metadata and credentials. It does not prompt, and `--yes` is not a supported option.
 - Default human output renders borderless terminal lists and readable MCP content; tool lists format described tools as `<name> - <description>`. Every client command that advertises `--json` accepts it anywhere after `client`. `--json` emits exactly one value to stdout: the raw protocol result envelope for calls, reads, and prompts; the described tool object for `tools describe`; arrays for lists; and command result objects for connect and auth commands. Errors emit exactly one JSON error envelope to stderr and no stdout value.
 
 ### Screenshot

--- a/libraries/typescript/packages/server/src/commands/client.ts
+++ b/libraries/typescript/packages/server/src/commands/client.ts
@@ -43,7 +43,7 @@ const CLIENT_HELP = `Usage: mcp-use client <command> [options]
 Commands:
   connect <name> <url>   Connect and save an HTTP(S) MCP server
   list [--json]          List saved servers
-  remove <name> [--yes]  Remove a saved server
+  remove <name>          Remove a saved server
   <name>                 Invoke tools/resources/prompts on a saved server
 
 Connect options:
@@ -87,10 +87,8 @@ export async function runClient(argv: readonly string[]): Promise<number> {
       return await connect(normalizedArgv.slice(1), json);
     if (first === "list") return await list(normalizedArgv.slice(1), json);
     if (first === "remove") {
-      if (json) {
-        throw new UsageError("mcp-use client remove does not support --json.");
-      }
-      return await remove(normalizedArgv.slice(1));
+      const commandIndex = argv.indexOf("remove");
+      return await remove(argv.filter((_, index) => index !== commandIndex));
     }
     if (first === undefined) {
       throw new UsageError("Usage: mcp-use client <connect|list|remove|name>");
@@ -183,21 +181,13 @@ async function list(argv: readonly string[], json: boolean): Promise<number> {
 }
 
 async function remove(argv: readonly string[]): Promise<number> {
-  const { values, positionals } = parseArgs({
+  const { positionals } = parseArgs({
     args: [...argv],
     allowPositionals: true,
     strict: true,
-    options: { yes: { type: "boolean" } },
+    options: {},
   });
   const name = one(positionals, "mcp-use client remove <name>");
-  if (
-    !(await confirm(`Remove saved server ${name}?`, {
-      yes: values.yes === true,
-      json: false,
-    }))
-  ) {
-    return 0;
-  }
   const saved = await readServers();
   delete saved.servers[name];
   await writePrivateJson(SERVERS_PATH, saved);

--- a/libraries/typescript/packages/server/tests/bin-start.test.ts
+++ b/libraries/typescript/packages/server/tests/bin-start.test.ts
@@ -545,6 +545,8 @@ describe("main", () => {
     await expect(main(["client", "--help"])).resolves.toBe(0);
     const output = logs.mock.calls.flat().join("\n");
     expect(output).toContain("mcp-use client connect");
+    expect(output).toContain("remove <name>");
+    expect(output).not.toContain("remove <name> [--yes]");
     expect(output).toContain("--no-open");
     expect(output).not.toContain("  --open");
     expect(output).not.toContain("mcp-use deploy");

--- a/libraries/typescript/packages/server/tests/commands/client.test.ts
+++ b/libraries/typescript/packages/server/tests/commands/client.test.ts
@@ -278,7 +278,7 @@ describe("client human-readable output", () => {
     expect(stderr).toBe("");
   });
 
-  it("rejects --json for remove in every position", async () => {
+  it("removes without confirmation and rejects unsupported flags", async () => {
     await expect(
       runClient([
         "connect",
@@ -287,11 +287,23 @@ describe("client human-readable output", () => {
         "--no-oauth",
       ])
     ).resolves.toBe(0);
+    stdout = "";
+
+    await expect(runClient(["remove", "remove-json"])).resolves.toBe(0);
+    expect(stdout).toBe("Removed remove-json.\n");
+    expect(stderr).toBe("");
+
+    await runClient([
+      "connect",
+      "remove-flags",
+      "https://mcp.example.com/mcp",
+      "--no-oauth",
+    ]);
 
     for (const argv of [
-      ["--json", "remove", "remove-json", "--yes"],
-      ["remove", "--json", "remove-json", "--yes"],
-      ["remove", "remove-json", "--yes", "--json"],
+      ["--json", "remove", "remove-flags"],
+      ["remove", "--json", "remove-flags"],
+      ["remove", "remove-flags", "--json"],
     ]) {
       stdout = "";
       stderr = "";
@@ -299,14 +311,22 @@ describe("client human-readable output", () => {
       await expect(runClient(argv)).resolves.toBe(2);
 
       expect(stdout).toBe("");
-      expect(stderr).toBe("mcp-use client remove does not support --json.\n");
+      expect(stderr).toContain("Unknown option '--json'");
+      expect(stderr).not.toContain("does not support --json");
     }
 
     stdout = "";
     stderr = "";
+    await expect(runClient(["remove", "remove-flags", "--yes"])).resolves.toBe(
+      2
+    );
+    expect(stdout).toBe("");
+    expect(stderr).toContain("Unknown option '--yes'");
+
+    stderr = "";
     await expect(runClient(["list", "--json"])).resolves.toBe(0);
     expect(JSON.parse(stdout)).toContainEqual({
-      name: "remove-json",
+      name: "remove-flags",
       oauth: false,
       protocol: "auto",
       url: "https://mcp.example.com/mcp",


### PR DESCRIPTION
## Summary

- Make `client remove <name>` delete saved server metadata and credentials immediately and idempotently
- Reject deprecated `--yes` and unsupported `--json` flags
- Update CLI help, specification, and command tests

## Testing

- Added and updated unit tests covering deletion, help output, and unsupported flags

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `mcp-use client remove <name>` delete saved server metadata and credentials immediately with no confirmation, and be safe to run multiple times. Reject `--yes` and `--json`, update CLI help/spec/tests, and add a changeset for a patch release.

<sup>Written for commit 29509902116f438ea007b6f23acbe3ed1e10c448. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/1998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

