### PR TITLE
Fix zero-view build and dev behavior

### DIFF
--- a/libraries/typescript/.changeset/fix-zero-view-cli.md
+++ b/libraries/typescript/.changeset/fix-zero-view-cli.md
@@ -1,0 +1,11 @@
+---
+"mcp-use": patch
+"@mcp-use/cli": patch
+---
+
+Allow tool-only servers to build and run without a views directory or React
+view component.
+
+`mcp-use build` and `mcp-use dev` now prime and validate an empty view registry,
+log when the views directory is not configured, and preserve the precise
+view-binding error when a tool references a view that does not exist.

--- a/libraries/typescript/packages/server/src/cli/build.ts
+++ b/libraries/typescript/packages/server/src/cli/build.ts
@@ -41,6 +41,7 @@ import {
 import {
   createBindingValidationServer,
   discoverViews,
+  resolveViewsDir,
   virtualViewId,
   type DiscoveredView,
 } from "./views.js";
@@ -358,6 +359,9 @@ export async function runBuild(options: BuildOptions): Promise<void> {
   const viewsDirectory =
     options.viewsDir ??
     (options.mcpDir === undefined ? undefined : join(options.mcpDir, "views"));
+  if (!existsSync(resolveViewsDir(options.cwd, viewsDirectory))) {
+    console.log("[mcp-use] views directory not configured.");
+  }
   const discoveredViews = discoverViews(options.cwd, viewsDirectory, {
     includeLegacy: true,
   });
@@ -393,7 +397,24 @@ export async function runBuild(options: BuildOptions): Promise<void> {
   }
 
   if (views.length === 0) {
+    bindingServer ??= await createBindingValidationServer(
+      options.cwd,
+      paths.cache,
+      false
+    );
     try {
+      await validateViewBindingsAtBuild(
+        bindingServer.environments.ssr,
+        entry,
+        {},
+        views
+      );
+      const wrapperEntry = await writeWrapperEntry(
+        paths.cache,
+        entry,
+        {},
+        views
+      );
       await build({
         root: options.cwd,
         configFile: false,
@@ -407,7 +428,7 @@ export async function runBuild(options: BuildOptions): Promise<void> {
         },
         plugins: [nextStandaloneCompatPlugin(options.cwd)],
         build: {
-          ssr: entry,
+          ssr: wrapperEntry,
           outDir: paths.build,
           emptyOutDir: true,
           target: "node22",

--- a/libraries/typescript/packages/server/src/cli/dev.ts
+++ b/libraries/typescript/packages/server/src/cli/dev.ts
@@ -17,8 +17,9 @@
  * so library consumers and production startup never evaluate Vite.
  */
 
-import { createServer as createNodeServer } from "node:http";
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { existsSync } from "node:fs";
+import { createServer as createNodeServer } from "node:http";
 import { networkInterfaces } from "node:os";
 import { join, resolve } from "node:path";
 import tailwindcss from "@tailwindcss/vite";
@@ -65,6 +66,7 @@ import {
   buildDevViewsManifest,
   discoverViews,
   isViewPath,
+  resolveViewsDir,
   type DiscoveredView,
 } from "./views.js";
 import type { ViewsManifest } from "../views/types.js";
@@ -374,6 +376,9 @@ export async function runDev(options: DevOptions): Promise<void> {
   const viewsDirectory =
     options.viewsDir ??
     (options.mcpDir === undefined ? undefined : join(options.mcpDir, "views"));
+  if (!existsSync(resolveViewsDir(options.cwd, viewsDirectory))) {
+    console.log("[mcp-use] views directory not configured.");
+  }
   let currentViews: DiscoveredView[] = discoverViews(
     options.cwd,
     viewsDirectory,
@@ -435,6 +440,9 @@ export async function runDev(options: DevOptions): Promise<void> {
       // upgrade handler to our server, so no dedicated HMR port exists to
       // collide when several dev processes run side by side.
       hmr: viewsAtStartup ? { server: httpServer } : false,
+      // Vite 8's Environment API keeps its WebSocket transport enabled when
+      // only `hmr: false` is set. Zero-view servers need no socket at all.
+      ...(!viewsAtStartup && { ws: false }),
     },
     ssr: {
       ...nextStandaloneSsrOptions(options.cwd),
@@ -468,33 +476,31 @@ export async function runDev(options: DevOptions): Promise<void> {
         includeLegacy: legacyViewsEnabled,
       });
 
-      if (currentViews.length > 0) {
-        const legacyViews = currentViews.filter((view) => view.legacy === true);
-        if (legacyViews.length > 0) {
-          if (typeof server.__registerLegacyViews !== "function") {
-            throw new Error(
-              "Legacy resources/*/widget.tsx views require the temporary mcp-use/server compatibility entry."
-            );
-          }
-          const legacyModules: Record<string, unknown> = {};
-          for (const view of legacyViews) {
-            legacyModules[view.name] = await runner.import(
-              legacyWidgetMetadataId(view.entryPath)
-            );
-          }
-          server.__registerLegacyViews(legacyModules);
-        }
-        const viewsManifest = buildDevViewsManifest(currentViews);
-        if (typeof server.__primeViews !== "function") {
+      const legacyViews = currentViews.filter((view) => view.legacy === true);
+      if (legacyViews.length > 0) {
+        if (typeof server.__registerLegacyViews !== "function") {
           throw new Error(
-            "Loaded MCPServer instance does not support __primeViews."
+            "Legacy resources/*/widget.tsx views require the temporary mcp-use/server compatibility entry."
           );
         }
-        server.__primeViews(viewsManifest, {
-          dev: true,
-          projectRoot: options.cwd,
-        });
+        const legacyModules: Record<string, unknown> = {};
+        for (const view of legacyViews) {
+          legacyModules[view.name] = await runner.import(
+            legacyWidgetMetadataId(view.entryPath)
+          );
+        }
+        server.__registerLegacyViews(legacyModules);
       }
+      const viewsManifest = buildDevViewsManifest(currentViews);
+      if (typeof server.__primeViews !== "function") {
+        throw new Error(
+          "Loaded MCPServer instance does not support __primeViews."
+        );
+      }
+      server.__primeViews(viewsManifest, {
+        dev: true,
+        projectRoot: options.cwd,
+      });
 
       return server;
     };

--- a/libraries/typescript/packages/server/src/cli/views-bindings.ts
+++ b/libraries/typescript/packages/server/src/cli/views-bindings.ts
@@ -155,9 +155,13 @@ export async function validateViewBindingsAtBuild(
     sourcemapInterceptor: "node",
   });
   const previousCliImport = process.env["MCP_USE_CLI_IMPORT"];
+  const previousMcpUrl = process.env["MCP_URL"];
 
   try {
     process.env["MCP_USE_CLI_IMPORT"] = "1";
+    if (previousMcpUrl === undefined) {
+      process.env["MCP_URL"] = BUILD_ENTRY_MCP_URL;
+    }
     delete (globalThis as Record<string, unknown>)[COMPAT_GLOBAL];
     const serverModule = (await runner.import(entry)) as {
       default?: ServerLike;
@@ -183,6 +187,11 @@ export async function validateViewBindingsAtBuild(
       delete process.env["MCP_USE_CLI_IMPORT"];
     } else {
       process.env["MCP_USE_CLI_IMPORT"] = previousCliImport;
+    }
+    if (previousMcpUrl === undefined) {
+      delete process.env["MCP_URL"];
+    } else {
+      process.env["MCP_URL"] = previousMcpUrl;
     }
     await runner.close();
   }

--- a/libraries/typescript/packages/server/src/cli/views.ts
+++ b/libraries/typescript/packages/server/src/cli/views.ts
@@ -230,7 +230,7 @@ export async function createBindingValidationServer(
       legacyWidgetMetadataPlugin(),
       react(),
     ],
-    server: { middlewareMode: true, hmr: false },
+    server: { middlewareMode: true, hmr: false, ws: false },
     ssr: {
       ...nextStandaloneSsrOptions(cwd),
     },

--- a/libraries/typescript/packages/server/tests/cli/build.test.ts
+++ b/libraries/typescript/packages/server/tests/cli/build.test.ts
@@ -19,7 +19,7 @@ import {
 import { mcpUseViewsPlugin } from "../../src/cli/views-plugin.js";
 import { VIRTUAL_VIEW_RESOLVED_PREFIX } from "../../src/cli/views.js";
 import { synthesizeViewDocument } from "../../src/views/document.js";
-import { copyFixture, removeDir } from "./helpers.js";
+import { bindBasicToolToView, copyFixture, removeDir } from "./helpers.js";
 
 const UI_META = {
   "io.modelcontextprotocol/protocolVersion": "2026-07-28",
@@ -103,7 +103,19 @@ describe("runBuild", () => {
       '<svg xmlns="http://www.w3.org/2000/svg"></svg>'
     );
 
-    await runBuild({ cwd });
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      await runBuild({ cwd });
+      expect(
+        logSpy.mock.calls.some(
+          (call) =>
+            call.length === 1 &&
+            call[0] === "[mcp-use] views directory not configured."
+        )
+      ).toBe(true);
+    } finally {
+      logSpy.mockRestore();
+    }
 
     const envDeclaration = readFileSync(join(cwd, "mcp-env.d.ts"), "utf8");
     expect(envDeclaration).toContain('tools: typeof import("./src/index.js")');
@@ -175,6 +187,46 @@ describe("runBuild", () => {
     expect(await response.json()).toMatchObject({
       result: { content: [{ type: "text", text: "3" }] },
     });
+  });
+
+  it.each([
+    ["an empty views directory", false],
+    ["a view directory without a React component", true],
+  ])("builds a tool-only server with %s", async (_label, nestedDirectory) => {
+    const cwd = copyFixture(`build-zero-views-${String(nestedDirectory)}`);
+    dirs.push(cwd);
+    const viewsDir = nestedDirectory
+      ? join(cwd, "views", "unfinished")
+      : join(cwd, "views");
+    mkdirSync(viewsDir, { recursive: true });
+
+    await expect(runBuild({ cwd })).resolves.toBeUndefined();
+    const manifest = JSON.parse(
+      readFileSync(
+        join(cwd, WORKSPACE_DIR_NAME, "build", BUILD_MANIFEST_NAME),
+        "utf8"
+      )
+    ) as BuildManifest;
+    expect(manifest.views).toEqual({});
+  });
+
+  it("fails precisely when a tool binds a view and no view component exists", async () => {
+    const cwd = copyFixture("build-zero-views-bound");
+    dirs.push(cwd);
+    mkdirSync(join(cwd, "views", "unfinished"), { recursive: true });
+    bindBasicToolToView(cwd, "does-not-exist");
+
+    let error: unknown;
+    try {
+      await runBuild({ cwd });
+    } catch (caught) {
+      error = caught;
+    }
+    expect(error).toBeInstanceOf(Error);
+    expect(String(error)).toContain(
+      'Tool "add" is bound to view "does-not-exist" which is not in the primed views registry.'
+    );
+    expect(String(error)).not.toContain("no views were primed");
   });
 
   it("honors an --entry override", async () => {

--- a/libraries/typescript/packages/server/tests/cli/dev.test.ts
+++ b/libraries/typescript/packages/server/tests/cli/dev.test.ts
@@ -12,6 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { runDev } from "../../src/cli/index.js";
 import {
+  bindBasicToolToView,
   copyFixture,
   getFreePort,
   listToolNames,
@@ -335,6 +336,46 @@ export default server;`
         : undefined
     );
     expect(await listToolNames(dev.url)).toEqual(["add", "subtract"]);
+  });
+
+  it("runs a tool-only server without a views directory", async () => {
+    const cwd = copyFixture("dev-zero-views-missing");
+    cleanups.push(() => removeDir(cwd));
+
+    const dev = await startDev(cwd, await getFreePort(), undefined, false);
+    cleanups.push(dev.stop);
+    expect(await listToolNames(dev.url)).toEqual(["add"]);
+    expect(dev.logs).toContain("[mcp-use] views directory not configured.");
+    expect(dev.logs.join("\n")).not.toContain("no views were primed");
+  });
+
+  it.each([
+    ["an empty views directory", false],
+    ["a view directory without a React component", true],
+  ])("runs a tool-only server with %s", async (_label, nestedDirectory) => {
+    const cwd = copyFixture(`dev-zero-views-${String(nestedDirectory)}`);
+    cleanups.push(() => removeDir(cwd));
+    const viewsDir = nestedDirectory
+      ? join(cwd, "views", "unfinished")
+      : join(cwd, "views");
+    mkdirSync(viewsDir, { recursive: true });
+
+    const dev = await startDev(cwd, await getFreePort(), undefined, false);
+    cleanups.push(dev.stop);
+    expect(await listToolNames(dev.url)).toEqual(["add"]);
+    expect(dev.logs).not.toContain("[mcp-use] views directory not configured.");
+    expect(dev.logs.join("\n")).not.toContain("no views were primed");
+  });
+
+  it("fails precisely when a tool binds a view and no view component exists", async () => {
+    const cwd = copyFixture("dev-zero-views-bound");
+    cleanups.push(() => removeDir(cwd));
+    mkdirSync(join(cwd, "views", "unfinished"), { recursive: true });
+    bindBasicToolToView(cwd, "does-not-exist");
+
+    await expect(runDev({ cwd, port: await getFreePort() })).rejects.toThrow(
+      'Tool "add" is bound to view "does-not-exist" which is not in the primed views registry.'
+    );
   });
 
   it("notifies connected clients after server catalog reloads", async () => {

--- a/libraries/typescript/packages/server/tests/cli/helpers.ts
+++ b/libraries/typescript/packages/server/tests/cli/helpers.ts
@@ -1,6 +1,12 @@
 /** Shared test helpers: fixture copying, raw 2026-07-28 MCP requests, polling. */
 import { randomBytes } from "node:crypto";
-import { cpSync, mkdirSync, rmSync } from "node:fs";
+import {
+  cpSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { createServer, type Server } from "node:net";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -42,6 +48,23 @@ export function copyFixture(
 /** Remove a scratch dir, ignoring failures. */
 export function removeDir(dir: string): void {
   rmSync(dir, { recursive: true, force: true });
+}
+
+/** Bind the basic fixture's add tool to a named view for CLI error tests. */
+export function bindBasicToolToView(cwd: string, viewName: string): void {
+  const entry = join(cwd, "src", "index.ts");
+  const source = readFileSync(entry, "utf8");
+  writeFileSync(
+    entry,
+    source.replace(
+      'description: "Add two numbers",',
+      [
+        'description: "Add two numbers",',
+        "    outputSchema: z.object({ result: z.number() }),",
+        `    view: { name: ${JSON.stringify(viewName)} },`,
+      ].join("\n")
+    )
+  );
 }
 
 /** The per-request _meta envelope required by the stateless 2026-07-28 wire. */


### PR DESCRIPTION
## Summary

- treat missing, empty, and component-less views directories as a valid empty view registry
- log `[mcp-use] views directory not configured.` when the resolved directory is absent
- prime and validate empty registries in both `mcp-use build` and `mcp-use dev`
- preserve precise compilation/startup failures when a tool binds a nonexistent view
- disable unused Vite WebSocket listeners for zero-view dev and build-time validation

## Root cause

Build had a special zero-view path that skipped view-binding validation and emitted an unprimed server entry. Dev similarly skipped registry priming when discovery returned no views. A tool-only server could therefore be treated as though the CLI had never prepared views, producing the misleading `no views were primed` failure, while missing bindings were not validated consistently between build and dev.

## Impact

Tool-only servers now build and run without requiring a views directory or React component. Broken tool-to-view bindings still fail early with the exact missing registry entry, and build/dev follow the same empty-registry contract. The fix is integrated with beta's v1 compatibility and legacy-widget discovery paths.

## Validation

- `pnpm --filter mcp-use exec vitest run tests/cli/build.test.ts` — 24 passed
- focused zero-view dev regressions — 4 passed
- `pnpm --filter mcp-use typecheck`
- ESLint and pre-commit formatting/lint checks