### PR TITLE
fix(server): separate provider audiences from MCP resources

### DIFF
--- a/libraries/typescript/.changeset/separate-oauth-audiences.md
+++ b/libraries/typescript/.changeset/separate-oauth-audiences.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Keep provider-specific JWT audiences separate from the canonical MCP resource. Restore Supabase's `authenticated` audience and Clerk's optional audience/issuer-bound token verification while continuing to reject mismatched explicit resource claims.

--- a/libraries/typescript/packages/server/examples/auth/clerk/.env.example
+++ b/libraries/typescript/packages/server/examples/auth/clerk/.env.example
@@ -1,8 +1,5 @@
 # Required: Clerk Frontend API URL.
 CLERK_FRONTEND_API_URL=https://verb-noun-42.clerk.accounts.dev
 
-# Optional: expected access-token audience.
-# CLERK_AUDIENCE=https://api.example.com
-
 # Optional: public MCP server origin. Do not include /mcp.
 # MCP_URL=https://mcp.example.com

--- a/libraries/typescript/packages/server/examples/auth/clerk/.env.example
+++ b/libraries/typescript/packages/server/examples/auth/clerk/.env.example
@@ -1,5 +1,9 @@
 # Required: Clerk Frontend API URL.
 CLERK_FRONTEND_API_URL=https://verb-noun-42.clerk.accounts.dev
 
+# Optional: set this to the exact `aud` emitted by audience-bearing Clerk
+# access tokens. When omitted, the provider uses issuer-bound verification.
+# CLERK_AUDIENCE=
+
 # Optional: public MCP server origin. Do not include /mcp.
 # MCP_URL=https://mcp.example.com

--- a/libraries/typescript/packages/server/examples/auth/clerk/README.md
+++ b/libraries/typescript/packages/server/examples/auth/clerk/README.md
@@ -20,9 +20,12 @@ cp .env.example .env
 ```
 
 Set `CLERK_AUDIENCE` only when your Clerk access-token configuration uses an
-audience. For public and tunnel deployments, set `MCP_URL` to the server
-origin, such as `https://mcp.example.com`, not the `/mcp` endpoint. The CLI
-derives the canonical protected resource as `https://mcp.example.com/mcp`.
+audience. When omitted, the provider uses Clerk's issuer-bound access-token
+model. In either mode, a token that carries an explicit RFC 8707 `resource`
+claim must match the canonical MCP resource. For public and tunnel
+deployments, set `MCP_URL` to the server origin, such as
+`https://mcp.example.com`, not the `/mcp` endpoint. The CLI derives the
+canonical protected resource as `https://mcp.example.com/mcp`.
 
 Run the server:
 

--- a/libraries/typescript/packages/server/examples/auth/clerk/README.md
+++ b/libraries/typescript/packages/server/examples/auth/clerk/README.md
@@ -19,11 +19,16 @@ Copy the example environment file and add your Clerk Frontend API URL:
 cp .env.example .env
 ```
 
-This example uses Clerk's issuer-bound access-token model. A token that carries
-an explicit RFC 8707 `resource` claim must match the canonical MCP resource.
-For public and tunnel deployments, set `MCP_URL` to the server origin, such as
-`https://mcp.example.com`, not the `/mcp` endpoint. The CLI derives the
-canonical protected resource as `https://mcp.example.com/mcp`.
+By default, this example uses Clerk's issuer-bound access-token model. If your
+Clerk access tokens include an audience, set `CLERK_AUDIENCE` to the exact
+`aud` value. The example passes that value to `oauthClerkProvider` as its
+`audience` option.
+
+A token that carries an explicit RFC 8707 `resource` claim must match the
+canonical MCP resource. For public and tunnel deployments, set `MCP_URL` to
+the server origin, such as `https://mcp.example.com`, not the `/mcp` endpoint.
+The CLI derives the canonical protected resource as
+`https://mcp.example.com/mcp`.
 
 Run the server:
 

--- a/libraries/typescript/packages/server/examples/auth/clerk/README.md
+++ b/libraries/typescript/packages/server/examples/auth/clerk/README.md
@@ -19,11 +19,9 @@ Copy the example environment file and add your Clerk Frontend API URL:
 cp .env.example .env
 ```
 
-Set `CLERK_AUDIENCE` only when your Clerk access-token configuration uses an
-audience. When omitted, the provider uses Clerk's issuer-bound access-token
-model. In either mode, a token that carries an explicit RFC 8707 `resource`
-claim must match the canonical MCP resource. For public and tunnel
-deployments, set `MCP_URL` to the server origin, such as
+This example uses Clerk's issuer-bound access-token model. A token that carries
+an explicit RFC 8707 `resource` claim must match the canonical MCP resource.
+For public and tunnel deployments, set `MCP_URL` to the server origin, such as
 `https://mcp.example.com`, not the `/mcp` endpoint. The CLI derives the
 canonical protected resource as `https://mcp.example.com/mcp`.
 

--- a/libraries/typescript/packages/server/examples/auth/clerk/src/index.ts
+++ b/libraries/typescript/packages/server/examples/auth/clerk/src/index.ts
@@ -2,8 +2,6 @@ import { MCPServer } from "mcp-use";
 import { oauthClerkProvider } from "mcp-use/oauth/clerk";
 import { z } from "zod";
 
-const audience = process.env.CLERK_AUDIENCE?.trim();
-
 const getUserInfoOutputSchema = z.object({
   user: z.object({
     id: z.string(),
@@ -29,7 +27,6 @@ const server = new MCPServer({
   publicLandingPage: true,
   oauth: oauthClerkProvider({
     frontendApiUrl: requireEnv("CLERK_FRONTEND_API_URL"),
-    ...(audience && { audience }),
   }),
 });
 

--- a/libraries/typescript/packages/server/examples/auth/clerk/src/index.ts
+++ b/libraries/typescript/packages/server/examples/auth/clerk/src/index.ts
@@ -2,6 +2,8 @@ import { MCPServer } from "mcp-use";
 import { oauthClerkProvider } from "mcp-use/oauth/clerk";
 import { z } from "zod";
 
+const audience = process.env.CLERK_AUDIENCE?.trim();
+
 const getUserInfoOutputSchema = z.object({
   user: z.object({
     id: z.string(),
@@ -27,6 +29,7 @@ const server = new MCPServer({
   publicLandingPage: true,
   oauth: oauthClerkProvider({
     frontendApiUrl: requireEnv("CLERK_FRONTEND_API_URL"),
+    ...(audience && { audience }),
   }),
 });
 

--- a/libraries/typescript/packages/server/examples/auth/clerk/src/index.ts
+++ b/libraries/typescript/packages/server/examples/auth/clerk/src/index.ts
@@ -20,6 +20,8 @@ const getUserInfoOutputSchema = z.object({
   resource: z.string().nullable(),
 });
 
+const audience = optionalEnv("CLERK_AUDIENCE");
+
 const server = new MCPServer({
   name: "clerk-direct-auth-example",
   version: "1.0.0",
@@ -27,6 +29,7 @@ const server = new MCPServer({
   publicLandingPage: true,
   oauth: oauthClerkProvider({
     frontendApiUrl: requireEnv("CLERK_FRONTEND_API_URL"),
+    ...(audience !== undefined && { audience }),
   }),
 });
 
@@ -64,11 +67,16 @@ server.tool(
 );
 
 function requireEnv(name: string): string {
-  const value = process.env[name]?.trim();
-  if (value === undefined || value === "") {
+  const value = optionalEnv(name);
+  if (value === undefined) {
     throw new Error(`Missing required environment variable: ${name}`);
   }
   return value;
+}
+
+function optionalEnv(name: string): string | undefined {
+  const value = process.env[name]?.trim();
+  return value === undefined || value === "" ? undefined : value;
 }
 
 export default server;

--- a/libraries/typescript/packages/server/examples/auth/supabase/.env.example
+++ b/libraries/typescript/packages/server/examples/auth/supabase/.env.example
@@ -11,6 +11,11 @@ SUPABASE_PUBLISHABLE_KEY=sb_publishable_...
 # 32 bytes. When omitted, the server verifies ES256 tokens through Supabase JWKS.
 # SUPABASE_JWT_SECRET=
 
+# Optional: expected JWT audience. Supabase OAuth access tokens use
+# "authenticated" by default; set this only when a Custom Access Token Hook
+# emits a different audience.
+# SUPABASE_AUDIENCE=authenticated
+
 # Public server origin only — do not include the /mcp path. Required outside
 # local development so OAuth protected-resource metadata advertises the correct resource.
 # MCP_URL=https://mcp.example.com

--- a/libraries/typescript/packages/server/examples/auth/supabase/.env.example
+++ b/libraries/typescript/packages/server/examples/auth/supabase/.env.example
@@ -11,6 +11,10 @@ SUPABASE_PUBLISHABLE_KEY=sb_publishable_...
 # 32 bytes. When omitted, the server verifies ES256 tokens through Supabase JWKS.
 # SUPABASE_JWT_SECRET=
 
+# Optional: set this to the exact `aud` emitted by a Custom Access Token Hook.
+# When omitted, the provider expects Supabase's default `authenticated` audience.
+# SUPABASE_AUDIENCE=
+
 # Public server origin only — do not include the /mcp path. Required outside
 # local development so OAuth protected-resource metadata advertises the correct resource.
 # MCP_URL=https://mcp.example.com

--- a/libraries/typescript/packages/server/examples/auth/supabase/.env.example
+++ b/libraries/typescript/packages/server/examples/auth/supabase/.env.example
@@ -11,11 +11,6 @@ SUPABASE_PUBLISHABLE_KEY=sb_publishable_...
 # 32 bytes. When omitted, the server verifies ES256 tokens through Supabase JWKS.
 # SUPABASE_JWT_SECRET=
 
-# Optional: expected JWT audience. Supabase OAuth access tokens use
-# "authenticated" by default; set this only when a Custom Access Token Hook
-# emits a different audience.
-# SUPABASE_AUDIENCE=authenticated
-
 # Public server origin only — do not include the /mcp path. Required outside
 # local development so OAuth protected-resource metadata advertises the correct resource.
 # MCP_URL=https://mcp.example.com

--- a/libraries/typescript/packages/server/examples/auth/supabase/README.md
+++ b/libraries/typescript/packages/server/examples/auth/supabase/README.md
@@ -31,6 +31,12 @@ Also set:
 JWTs. If set, it must be at least 32 bytes. Without it, this example verifies
 ES256 tokens using the project's Supabase JWKS endpoint.
 
+Supabase OAuth access tokens use `aud: "authenticated"` by default, and the
+provider validates that audience without conflating it with the MCP resource
+URL. Set `SUPABASE_AUDIENCE` only when a Custom Access Token Hook emits a
+different audience. A token that carries an explicit RFC 8707 `resource` claim
+must still match the canonical MCP resource.
+
 For a deployed server, set `MCP_URL` to its public origin, for example
 `https://mcp.example.com`. The framework derives the protected resource URL as
 `https://mcp.example.com/mcp`, advertises resource metadata there, and checks a

--- a/libraries/typescript/packages/server/examples/auth/supabase/README.md
+++ b/libraries/typescript/packages/server/examples/auth/supabase/README.md
@@ -31,10 +31,14 @@ Also set:
 JWTs. If set, it must be at least 32 bytes. Without it, this example verifies
 ES256 tokens using the project's Supabase JWKS endpoint.
 
-Supabase OAuth access tokens use `aud: "authenticated"` by default, and the
-provider validates that audience without conflating it with the MCP resource
-URL. A token that carries an explicit RFC 8707 `resource` claim must still
-match the canonical MCP resource.
+Supabase OAuth access tokens use `aud: "authenticated"` by default. If a
+Custom Access Token Hook changes `aud`, set `SUPABASE_AUDIENCE` to the exact
+audience string emitted by the hook. The example passes that value to
+`oauthSupabaseProvider` as its `audience` option.
+
+The provider validates the Supabase audience without conflating it with the MCP
+resource URL. A token that carries an explicit RFC 8707 `resource` claim must
+still match the canonical MCP resource.
 
 For a deployed server, set `MCP_URL` to its public origin, for example
 `https://mcp.example.com`. The framework derives the protected resource URL as

--- a/libraries/typescript/packages/server/examples/auth/supabase/README.md
+++ b/libraries/typescript/packages/server/examples/auth/supabase/README.md
@@ -33,9 +33,8 @@ ES256 tokens using the project's Supabase JWKS endpoint.
 
 Supabase OAuth access tokens use `aud: "authenticated"` by default, and the
 provider validates that audience without conflating it with the MCP resource
-URL. Set `SUPABASE_AUDIENCE` only when a Custom Access Token Hook emits a
-different audience. A token that carries an explicit RFC 8707 `resource` claim
-must still match the canonical MCP resource.
+URL. A token that carries an explicit RFC 8707 `resource` claim must still
+match the canonical MCP resource.
 
 For a deployed server, set `MCP_URL` to its public origin, for example
 `https://mcp.example.com`. The framework derives the protected resource URL as

--- a/libraries/typescript/packages/server/examples/auth/supabase/src/index.ts
+++ b/libraries/typescript/packages/server/examples/auth/supabase/src/index.ts
@@ -44,6 +44,7 @@ const getUserInfoOutputSchema = z.object({
 const projectId = environmentValue("SUPABASE_PROJECT_ID");
 const supabaseUrlEnv = environmentValue("SUPABASE_URL");
 const jwtSecret = environmentValue("SUPABASE_JWT_SECRET");
+const audience = environmentValue("SUPABASE_AUDIENCE");
 const publishableKey = environmentValue("SUPABASE_PUBLISHABLE_KEY");
 
 if (projectId === undefined && supabaseUrlEnv === undefined) {
@@ -71,6 +72,7 @@ const server = new MCPServer({
     ...(projectId !== undefined && { projectId }),
     ...(supabaseUrlEnv !== undefined && { supabaseUrl: supabaseUrlEnv }),
     ...(jwtSecret !== undefined && { jwtSecret }),
+    ...(audience !== undefined && { audience }),
   }),
 });
 

--- a/libraries/typescript/packages/server/examples/auth/supabase/src/index.ts
+++ b/libraries/typescript/packages/server/examples/auth/supabase/src/index.ts
@@ -44,7 +44,6 @@ const getUserInfoOutputSchema = z.object({
 const projectId = environmentValue("SUPABASE_PROJECT_ID");
 const supabaseUrlEnv = environmentValue("SUPABASE_URL");
 const jwtSecret = environmentValue("SUPABASE_JWT_SECRET");
-const audience = environmentValue("SUPABASE_AUDIENCE");
 const publishableKey = environmentValue("SUPABASE_PUBLISHABLE_KEY");
 
 if (projectId === undefined && supabaseUrlEnv === undefined) {
@@ -72,7 +71,6 @@ const server = new MCPServer({
     ...(projectId !== undefined && { projectId }),
     ...(supabaseUrlEnv !== undefined && { supabaseUrl: supabaseUrlEnv }),
     ...(jwtSecret !== undefined && { jwtSecret }),
-    ...(audience !== undefined && { audience }),
   }),
 });
 

--- a/libraries/typescript/packages/server/specs/AUTH_IMPLEMENTATION.md
+++ b/libraries/typescript/packages/server/specs/AUTH_IMPLEMENTATION.md
@@ -142,8 +142,10 @@ provider verifier, asserts resource binding against the resolved canonical
 resource URL, then returns the final SDK-compatible `AuthInfo` with `extra`
 merged as `{ ...authInfo.extra, ...provider.mapAuthInfo(authInfo) }`. Binding
 succeeds when the token carries an RFC 8707 `resource` claim matching
-`expectedResource`, or when `authInfo.resource` is absent but audience
-validation was proven (an internal marker set by `createJwtVerifier`).
+`expectedResource`; otherwise a provider-specific audience validated by
+`createJwtVerifier`, an explicitly issuer-bound provider token model, or an
+`aud` claim containing the canonical MCP resource establishes the binding.
+Provider audience identifiers remain separate from the canonical resource URL.
 Therefore every successful bearer-gate result has the typed mcp-use values
 before it reaches fetch middleware, `createMcpMount`, or the SDK callback. Custom providers use
 this same wrapper; they cannot omit the public `mapAuthInfo` callback or rely
@@ -423,7 +425,7 @@ The first implementation phase supplies the resource-server seam. Provider adapt
 
 Each adapter verifies tokens, maps verified claims to a typed `user`, preserves the verified payload, provides normalized permissions, and advertises its authorization-server metadata. Each adapter must map claims rather than cast decoded payloads. No adapter offers `verifyJwt: false`.
 
-JWT adapters share a `jose` implementation for remote JWKS caching and signature verification. They always validate issuer and expiry, validate audience when the provider issues audience-bound tokens, and apply SDK resource-binding checks when the token carries a resource. Opaque-token adapters use RFC 7662 introspection and map the response into the same `AuthInfo` contract. Verifiers throw `OAuthError` with `OAuthErrorCode.InvalidToken` for rejected credentials so the core gate returns the correct challenge.
+JWT adapters share a `jose` implementation for remote JWKS caching and signature verification. They always validate issuer and expiry, validate provider-specific audiences when configured, and keep those audience identifiers separate from the canonical MCP resource. A token with an RFC 8707 `resource` claim must match the canonical resource. Providers without a separate audience require the token audience to contain the canonical resource unless their access-token model is explicitly issuer-bound. Opaque-token adapters use RFC 7662 introspection and map the response into the same `AuthInfo` contract. Verifiers throw `OAuthError` with `OAuthErrorCode.InvalidToken` for rejected credentials so the core gate returns the correct challenge.
 
 In direct mode, clients use the external authorization server's registration, authorization, and token endpoints. mcp-use serves protected-resource metadata, advertises the external authorization server, and verifies the resulting access token. The external authorization server must be advertised for the canonical resource and issue a token specifically bound to that resource, including the RFC 8707 `resource` indicator when applicable. mcp-use never handles authorization codes or client secrets in direct mode.
 

--- a/libraries/typescript/packages/server/specs/AUTH_SPEC.md
+++ b/libraries/typescript/packages/server/specs/AUTH_SPEC.md
@@ -447,8 +447,10 @@ provider verifier, asserts resource binding against the resolved canonical
 resource URL, then returns the final SDK-compatible `AuthInfo` with `extra`
 merged as `{ ...authInfo.extra, ...provider.mapAuthInfo(authInfo) }`. Binding
 succeeds when the token carries an RFC 8707 `resource` claim matching
-`expectedResource`, or when `authInfo.resource` is absent but audience
-validation was proven (an internal marker set by `createJwtVerifier`).
+`expectedResource`; otherwise a provider-specific audience validated by
+`createJwtVerifier`, an explicitly issuer-bound provider token model, or an
+`aud` claim containing the canonical MCP resource establishes the binding.
+Provider audience identifiers remain separate from the canonical resource URL.
 Therefore every successful bearer-gate result has the typed mcp-use values
 before it reaches fetch middleware, `createMcpMount`, or the SDK callback. Custom providers use
 this same wrapper; they cannot omit the public `mapAuthInfo` callback or rely
@@ -758,7 +760,7 @@ The first implementation phase supplies only the resource-server seam. Provider 
 
 Each adapter verifies tokens, maps verified claims to a typed `user`, preserves the verified payload, provides normalized permissions, and advertises its authorization-server metadata. Each adapter must map claims rather than cast decoded payloads. No adapter offers `verifyJwt: false`.
 
-JWT adapters share a `jose` implementation for remote JWKS caching and signature verification. They always validate issuer and expiry and establish that every token was issued for the canonical MCP resource by validating its audience or RFC 8707 resource binding; a token for which the provider cannot establish that binding is rejected. Opaque-token adapters use RFC 7662 introspection and likewise require the introspection result to establish the canonical MCP resource before mapping it into the same `AuthInfo` contract. Verifiers throw `OAuthError` with `OAuthErrorCode.InvalidToken` for rejected credentials so the core gate returns the correct challenge.
+JWT adapters share a `jose` implementation for remote JWKS caching and signature verification. They always validate issuer and expiry and establish binding using the provider's configured audience, an explicitly issuer-bound provider token model, or the canonical MCP resource in `aud` or an RFC 8707 `resource` claim. Provider-specific audience identifiers do not have to equal the canonical MCP URL. A token with an explicit `resource` claim must match that URL, and a token for which the provider cannot establish any supported binding is rejected. Opaque-token adapters use RFC 7662 introspection and likewise require the introspection result to establish the canonical MCP resource before mapping it into the same `AuthInfo` contract. Verifiers throw `OAuthError` with `OAuthErrorCode.InvalidToken` for rejected credentials so the core gate returns the correct challenge.
 
 In direct mode, clients use the external authorization server's registration, authorization, and token endpoints. mcp-use serves protected-resource metadata, advertises the external authorization server, and verifies the resulting access token. The external authorization server must be advertised for the canonical resource and issue a token specifically bound to that resource, including the RFC 8707 `resource` indicator when applicable. mcp-use never handles authorization codes or client secrets in direct mode.
 

--- a/libraries/typescript/packages/server/src/oauth/clerk.ts
+++ b/libraries/typescript/packages/server/src/oauth/clerk.ts
@@ -34,17 +34,26 @@ export interface ClerkOAuthUser {
 /** Configures Clerk JWT verification and protected-resource metadata. */
 export interface ClerkOAuthProviderOptions extends OAuthResourceOptions {
   frontendApiUrl: URL | string;
+  /** Expected Clerk access-token audience, when the application emits one. */
+  audience?: string;
 }
 
 /**
  * Creates a provider that verifies Clerk access tokens and maps their claims.
  *
- * @param options - Clerk frontend API URL and resource-server settings.
- * @returns A provider that rejects tokens not issued for the resolved MCP resource.
+ * @param options - Clerk frontend API URL, optional token audience, and resource-server settings.
+ * @returns A provider that verifies Clerk-issued access tokens and explicit resource claims.
  */
 export function oauthClerkProvider(
   options: ClerkOAuthProviderOptions
 ): OAuthProvider<ClerkOAuthUser> {
+  if (
+    options.audience !== undefined &&
+    (typeof options.audience !== "string" ||
+      options.audience.trim().length === 0)
+  ) {
+    throw new TypeError("Clerk audience must be non-empty");
+  }
   const issuer = normalizedProviderUrl(
     options.frontendApiUrl,
     "Clerk frontendApiUrl"
@@ -56,6 +65,9 @@ export function oauthClerkProvider(
         issuer,
         jwksUrl: new URL(providerEndpoint(issuer, ".well-known/jwks.json")),
         resource,
+        ...(options.audience !== undefined
+          ? { audience: options.audience }
+          : { issuerBoundAccessTokens: true }),
       }),
     oauthMetadata: metadata(issuer),
     mapAuthInfo: (authInfo) => mapUser(authInfo),

--- a/libraries/typescript/packages/server/src/oauth/jwt.ts
+++ b/libraries/typescript/packages/server/src/oauth/jwt.ts
@@ -21,6 +21,14 @@ export interface JwtVerifierOptions {
   issuer: string;
   jwksUrl: URL;
   resource: URL;
+  /** Provider-specific JWT audience, when it differs from the MCP resource. */
+  audience?: string | string[];
+  /**
+   * Treat successful issuer validation as the provider's resource binding.
+   * Use only for providers whose access-token model is scoped by issuer rather
+   * than an aud/resource claim.
+   */
+  issuerBoundAccessTokens?: boolean;
   algorithms?: readonly string[];
   key?: Uint8Array;
 }
@@ -32,12 +40,24 @@ export function createJwtVerifier(
   // jose overloads key material vs JWKS getters; runtime accepts either.
   const key = options.key ?? createRemoteJWKSet(options.jwksUrl);
   const configuredResource = canonicalUrl(options.resource);
+  const configuredAudience = verifierAudience(options.audience);
+  if (
+    configuredAudience !== undefined &&
+    options.issuerBoundAccessTokens === true
+  ) {
+    throw new TypeError(
+      "JWT verifier cannot combine audience and issuer-bound access tokens"
+    );
+  }
 
   return {
     async verifyAccessToken(token: string): Promise<AuthInfo> {
       try {
         const { payload } = await jwtVerify(token, key as JWTVerifyGetKey, {
           issuer: options.issuer,
+          ...(configuredAudience !== undefined && {
+            audience: configuredAudience,
+          }),
           ...(options.algorithms !== undefined && {
             algorithms: [...options.algorithms],
           }),
@@ -51,7 +71,12 @@ export function createJwtVerifier(
         const clientId =
           requiredString(claims, "client_id") ?? requiredString(claims, "azp");
         const expiresAt = requiredFutureNumber(claims, "exp");
-        const resource = verifiedResource(claims, configuredResource);
+        const resource = verifiedResource(
+          claims,
+          configuredResource,
+          configuredAudience !== undefined ||
+            options.issuerBoundAccessTokens === true
+        );
 
         return {
           token,
@@ -199,7 +224,8 @@ export function invalidToken(message: string, cause?: unknown): OAuthError {
 
 function verifiedResource(
   claims: VerifiedPayload,
-  configuredResource: URL
+  configuredResource: URL,
+  providerBindingWasValidated: boolean
 ): URL {
   const value = claims["resource"];
   if (value !== undefined) {
@@ -215,6 +241,14 @@ function verifiedResource(
     return configuredResource;
   }
 
+  // A provider-specific audience validated by jose, or an explicitly
+  // issuer-bound provider verifier, proves that the token targets the
+  // configured API. Preserve the canonical MCP resource separately so
+  // provider identifiers are not conflated with RFC 8707 resource URLs.
+  if (providerBindingWasValidated) {
+    return configuredResource;
+  }
+
   const audience = claims["aud"];
   if (!validAudience(audience)) {
     throw invalidToken("Token audience claim must be a string or string array");
@@ -226,6 +260,27 @@ function verifiedResource(
     );
   }
   return configuredResource;
+}
+
+function verifierAudience(
+  value: JwtVerifierOptions["audience"]
+): string | string[] | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value;
+  }
+  if (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    value.every(
+      (audience) => typeof audience === "string" && audience.trim().length > 0
+    )
+  ) {
+    return [...value];
+  }
+  throw new TypeError(
+    "JWT verifier audience must be a non-empty string or string array"
+  );
 }
 
 function validAudience(value: unknown): value is string | string[] {

--- a/libraries/typescript/packages/server/src/oauth/supabase.ts
+++ b/libraries/typescript/packages/server/src/oauth/supabase.ts
@@ -42,12 +42,14 @@ export interface SupabaseOAuthProviderOptions extends OAuthResourceOptions {
   projectId?: string;
   supabaseUrl?: URL | string;
   jwtSecret?: string;
+  /** Expected access-token audience. Defaults to Supabase's `authenticated`. */
+  audience?: string;
 }
 
 /**
  * Creates a provider that verifies Supabase access tokens and maps their claims.
  *
- * @param options - Supabase project or URL, optional JWT secret, and resource-server settings.
+ * @param options - Supabase project or URL, optional JWT secret/audience, and resource-server settings.
  * @returns A provider that rejects tokens without a valid configured Supabase signature and issuer.
  */
 export function oauthSupabaseProvider(
@@ -56,6 +58,10 @@ export function oauthSupabaseProvider(
   const supabaseUrl = resolveSupabaseUrl(options);
   const issuer = providerEndpoint(supabaseUrl, "auth/v1").replace(/\/$/, "");
   const secret = options.jwtSecret;
+  const audience = options.audience ?? "authenticated";
+  if (typeof audience !== "string" || audience.trim().length === 0) {
+    throw new TypeError("Supabase audience must be non-empty");
+  }
   if (secret !== undefined && new TextEncoder().encode(secret).length < 32) {
     throw new TypeError("Supabase jwtSecret must be at least 32 bytes");
   }
@@ -71,6 +77,7 @@ export function oauthSupabaseProvider(
           ? { key: new TextEncoder().encode(secret), algorithms: ["HS256"] }
           : { algorithms: ["ES256"] }),
         resource,
+        audience,
       }),
     oauthMetadata: {
       issuer,

--- a/libraries/typescript/packages/server/tests/oauth-core.test.ts
+++ b/libraries/typescript/packages/server/tests/oauth-core.test.ts
@@ -232,6 +232,45 @@ describe("OAuth core", () => {
     }
   });
 
+  it("keeps provider audiences separate from the protected resource", async () => {
+    const key = new TextEncoder().encode(
+      "a sufficiently long test signing key"
+    );
+    const issuer = "https://issuer.example.test";
+    const verifier = createJwtVerifier({
+      issuer,
+      jwksUrl: new URL(`${issuer}/.well-known/jwks.json`),
+      key,
+      algorithms: ["HS256"],
+      resource: canonicalResource,
+      audience: "provider-api",
+    });
+    const sign = (claims: Record<string, unknown>) =>
+      new SignJWT({ sub: "user-1", client_id: "client-1", ...claims })
+        .setProtectedHeader({ alg: "HS256" })
+        .setIssuer(issuer)
+        .setExpirationTime(Math.floor(Date.now() / 1000) + 60)
+        .sign(key);
+
+    await expect(
+      verifier.verifyAccessToken(await sign({ aud: "provider-api" }))
+    ).resolves.toMatchObject({ resource: canonicalResource });
+    await expect(
+      verifier.verifyAccessToken(await sign({ aud: "other-api" }))
+    ).rejects.toMatchObject({ code: OAuthErrorCode.InvalidToken });
+    await expect(
+      verifier.verifyAccessToken(
+        await sign({
+          aud: "provider-api",
+          resource: "https://other.example/mcp",
+        })
+      )
+    ).rejects.toMatchObject({
+      code: OAuthErrorCode.InvalidToken,
+      message: "Token resource claim does not match protected resource",
+    });
+  });
+
   it("rejects verifier output that does not prove resource binding", async () => {
     const expectedResource = new URL("https://api.example.test/mcp");
     const provider = createProvider({

--- a/libraries/typescript/packages/server/tests/oauth-direct-providers.test.ts
+++ b/libraries/typescript/packages/server/tests/oauth-direct-providers.test.ts
@@ -175,8 +175,13 @@ describe("direct OAuth providers", () => {
       jwtSecret: secret,
     });
     const verifier = provider.createTokenVerifier(protectedResource);
-    const token = (issuer: string, audience: string, exp: number) =>
-      new SignJWT({ sub: "user-1", client_id: "client-1" })
+    const token = (
+      issuer: string,
+      audience: string,
+      exp: number,
+      claims: Record<string, unknown> = {}
+    ) =>
+      new SignJWT({ sub: "user-1", client_id: "client-1", ...claims })
         .setProtectedHeader({ alg: "HS256" })
         .setIssuer(issuer)
         .setAudience(audience)
@@ -187,13 +192,13 @@ describe("direct OAuth providers", () => {
       verifier.verifyAccessToken(
         await token(
           "https://example-project.supabase.co/auth/v1",
-          protectedResource.href,
+          "authenticated",
           now() + 60
         )
       )
     ).resolves.toMatchObject({ clientId: "client-1" });
     const invalidTokens: readonly [string, string, number][] = [
-      ["https://other.supabase.co/auth/v1", protectedResource.href, now() + 60],
+      ["https://other.supabase.co/auth/v1", "authenticated", now() + 60],
       ["https://example-project.supabase.co/auth/v1", "other", now() + 60],
       [
         "https://example-project.supabase.co/auth/v1",
@@ -208,6 +213,42 @@ describe("direct OAuth providers", () => {
         code: "invalid_token",
       });
     }
+    await expect(
+      verifier.verifyAccessToken(
+        await token(
+          "https://example-project.supabase.co/auth/v1",
+          "authenticated",
+          now() + 60,
+          { resource: "https://other.example/mcp" }
+        )
+      )
+    ).rejects.toMatchObject({
+      code: "invalid_token",
+      message: "Token resource claim does not match protected resource",
+    });
+
+    const customAudienceProvider = oauthSupabaseProvider({
+      projectId: "example-project",
+      jwtSecret: secret,
+      audience: "mcp-api",
+    });
+    await expect(
+      customAudienceProvider
+        .createTokenVerifier(protectedResource)
+        .verifyAccessToken(
+          await token(
+            "https://example-project.supabase.co/auth/v1",
+            "mcp-api",
+            now() + 60
+          )
+        )
+    ).resolves.toMatchObject({ resource: protectedResource });
+    expect(() =>
+      oauthSupabaseProvider({
+        projectId: "example-project",
+        audience: " ",
+      })
+    ).toThrow(/audience/);
   });
 
   it("uses empty clientId for Supabase tokens without client_id", async () => {
@@ -219,7 +260,7 @@ describe("direct OAuth providers", () => {
     const token = await new SignJWT({ sub: "user-1" })
       .setProtectedHeader({ alg: "HS256" })
       .setIssuer("https://example-project.supabase.co/auth/v1")
-      .setAudience(protectedResource.href)
+      .setAudience("authenticated")
       .setExpirationTime(now() + 60)
       .sign(new TextEncoder().encode(secret));
 
@@ -249,7 +290,7 @@ describe("direct OAuth providers", () => {
     })
       .setProtectedHeader({ alg: "HS256" })
       .setIssuer("http://localhost:54321/platform/auth/v1")
-      .setAudience(protectedResource.href)
+      .setAudience("authenticated")
       .setExpirationTime(now() + 60)
       .sign(new TextEncoder().encode(secret));
     await expect(
@@ -269,7 +310,7 @@ describe("direct OAuth providers", () => {
     ).toThrow(/HTTPS|localhost/);
   });
 
-  it("maps Clerk claims and retains issuer path prefixes in endpoints", async () => {
+  it("supports Clerk issuer-bound and configured-audience access tokens", async () => {
     const { privateKey, publicKey } = await generateKeyPair("RS256");
     const jwk = await exportJWK(publicKey);
     jwk.kid = "clerk-key";
@@ -290,7 +331,7 @@ describe("direct OAuth providers", () => {
           privateKey,
           "clerk-key",
           "https://clerk.example.test/tenant",
-          protectedResource.href,
+          undefined,
           {
             sub: "clerk-user",
             client_id: "client",
@@ -305,6 +346,63 @@ describe("direct OAuth providers", () => {
         permissions: ["read"],
       },
     });
+
+    const audienceProvider = oauthClerkProvider({
+      frontendApiUrl: "https://clerk.example.test/tenant",
+      audience: "clerk-api",
+    });
+    await expect(
+      wrapOAuthTokenVerifier(
+        audienceProvider,
+        protectedResource
+      ).verifyAccessToken(
+        await signedToken(
+          privateKey,
+          "clerk-key",
+          "https://clerk.example.test/tenant",
+          "clerk-api",
+          { sub: "clerk-user", client_id: "client" }
+        )
+      )
+    ).resolves.toMatchObject({ resource: protectedResource });
+    await expect(
+      wrapOAuthTokenVerifier(
+        audienceProvider,
+        protectedResource
+      ).verifyAccessToken(
+        await signedToken(
+          privateKey,
+          "clerk-key",
+          "https://clerk.example.test/tenant",
+          "other-api",
+          { sub: "clerk-user", client_id: "client" }
+        )
+      )
+    ).rejects.toMatchObject({ code: "invalid_token" });
+    await expect(
+      wrapOAuthTokenVerifier(provider, protectedResource).verifyAccessToken(
+        await signedToken(
+          privateKey,
+          "clerk-key",
+          "https://clerk.example.test/tenant",
+          undefined,
+          {
+            sub: "clerk-user",
+            client_id: "client",
+            resource: "https://other.example/mcp",
+          }
+        )
+      )
+    ).rejects.toMatchObject({
+      code: "invalid_token",
+      message: "Token resource claim does not match protected resource",
+    });
+    expect(() =>
+      oauthClerkProvider({
+        frontendApiUrl: "https://clerk.example.test/tenant",
+        audience: " ",
+      })
+    ).toThrow(/audience/);
   });
 
   it("normalizes WorkOS hosts without appending a second suffix and maps claims", async () => {


### PR DESCRIPTION
## What changed

- Restore provider-specific JWT audience verification without treating that audience as the canonical MCP resource.
- Default Supabase access-token verification to `aud: authenticated`, with an override for custom access-token hooks.
- Support Clerk's issuer-bound access tokens when no audience is configured, while retaining optional explicit audience validation.
- Continue rejecting any explicit RFC 8707 `resource` claim that does not match the protected MCP resource.
- Update the Clerk and Supabase examples, authentication specs, regression tests, and package changeset.

## Why

The resource-binding hardening introduced in `6d266c9e6` removed provider-specific audience validation and required `aud` to contain the MCP URL. Supabase emits `aud: authenticated`, while Clerk access tokens may omit `aud`, so valid tokens from both providers were rejected even though their issuer and signature were valid.

This keeps provider token binding and RFC 8707 MCP resource binding as separate concepts while preserving the explicit resource-mismatch protection.

## Impact

Clerk and Supabase OAuth access tokens now work with their native audience models. Providers that use the canonical MCP URL as their audience keep the existing behavior.

## Validation

- `pnpm --filter mcp-use exec vitest run tests/oauth-core.test.ts tests/oauth-direct-providers.test.ts` — 29 tests passed
- `pnpm --filter mcp-use typecheck`
- `pnpm --filter mcp-use-example-auth-clerk --filter mcp-use-example-auth-supabase typecheck`
- Live Clerk authenticated `get-user-info` call succeeded
- Fresh Supabase sign-in, consent, token exchange, MCP initialization, and authenticated `get-user-info` call succeeded

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Separate provider-specific JWT audiences from the canonical MCP resource so Clerk and Supabase tokens verify correctly. Explicit RFC 8707 `resource` claims are still enforced against the MCP resource.

- **Bug Fixes**
  - Validate provider `aud` without using it as the MCP resource; support issuer‑bound tokens.
  - Supabase: default `aud` is `authenticated`; optional `audience` override (`SUPABASE_AUDIENCE`).
  - Clerk: issuer‑bound by default; optional `audience` config (`CLERK_AUDIENCE`).
  - Reject tokens with mismatched explicit `resource`; examples/docs updated and tests expanded.

- **Migration**
  - No changes for most setups.
  - Supabase: set `SUPABASE_AUDIENCE` only if a Custom Access Token Hook changes the audience.
  - Clerk: omit `CLERK_AUDIENCE` unless your tokens include an audience.

<sup>Written for commit 9ff0a5cc4b69c10c974b2f7f7f14936e6ebca471. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2001?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

