### PR TITLE
fix(cli): use named protocol modes

### DIFF
--- a/docs/typescript/api-reference/cli-reference.mdx
+++ b/docs/typescript/api-reference/cli-reference.mdx
@@ -522,11 +522,11 @@ mcp-use client <name> <scope> <action>
 
 **Top-level subcommands:**
 
-| Command                | Purpose                                | Key options                                                                                        |
-| ---------------------- | -------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `connect <name> <url>` | Verify and save an HTTP(S) MCP server. | `-H, --header`, `--no-oauth`, `--auth-timeout <ms>`, `--protocol <version>`, `--no-open`, `--json` |
-| `list`                 | List saved servers.                    | `--json`                                                                                           |
-| `remove <name>`        | Remove a saved server and credentials. | `--yes`                                                                                            |
+| Command                | Purpose                                | Key options                                                                                                     |
+| ---------------------- | -------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `connect <name> <url>` | Verify and save an HTTP(S) MCP server. | `-H, --header`, `--no-oauth`, `--auth-timeout <ms>`, `--protocol <auto\|legacy\|modern>`, `--no-open`, `--json` |
+| `list`                 | List saved servers.                    | `--json`                                                                                                        |
+| `remove <name>`        | Remove a saved server and credentials. | `--yes`                                                                                                         |
 
 **Per-server scopes:**
 
@@ -557,6 +557,9 @@ mcp-use client local auth status
 - In an interactive TTY, OAuth displays `This server requires OAuth. Press Enter to open your browser.` and opens the browser only after Enter.
 - `--no-open`, `--json`, and non-TTY operation never prompt or open a browser. They print the authorization URL to stderr while the loopback callback continues waiting.
 - `connect --no-oauth` prevents automatic OAuth when the server returns `401`.
+- `--protocol auto` prefers the modern wire and falls back to legacy. `legacy`
+  selects only the legacy wire. `modern` selects the stateless, sessionless
+  modern wire with no fallback.
 - Repeated `-H, --header <"Key: Value">` options store static headers as credentials.
 - Tool and prompt arguments accept `key=value`, `key:=<json>`, or a single JSON object argument.
 - `--json` may appear anywhere after `client`. Success emits exactly one JSON value to stdout. Errors emit exactly one JSON error envelope to stderr and no stdout value.

--- a/docs/typescript/tooling/client-cli.mdx
+++ b/docs/typescript/tooling/client-cli.mdx
@@ -27,6 +27,23 @@ npx mcp-use client list
 npx mcp-use client remove dev
 ```
 
+## Choose a protocol mode
+
+The default `--protocol auto` mode prefers the modern MCP wire and falls back
+to the legacy wire when the server does not support modern negotiation.
+
+Use `legacy` or `modern` when you need strict compatibility testing:
+
+```bash
+npx mcp-use client connect old-server https://old.example.com/mcp \
+  --protocol legacy
+npx mcp-use client connect modern-server https://modern.example.com/mcp \
+  --protocol modern
+```
+
+`legacy` uses only the legacy wire. `modern` uses the stateless, sessionless
+modern wire with no fallback.
+
 ## Authenticate with OAuth
 
 When a server requires OAuth in an interactive terminal, the CLI displays this prompt:
@@ -136,6 +153,8 @@ npx mcp-use client dev tools call get-weather city=Tokyo --json | jq '.content'
 
 - `Unknown saved server: <name>`: run `npx mcp-use client list`, or reconnect with `npx mcp-use client connect <name> <url>`.
 - `Tool not found: <name>`: run `tools list` against the same saved server.
+- `protocol_mismatch`: reconnect with `--protocol auto`, or choose the protocol
+  mode the server supports.
 - An OAuth command waits without opening a browser: open the authorization URL printed to stderr, then complete authorization before the configured timeout.
 - A tool returns an error: under `--json`, inspect `error.details` for the original MCP tool result.
 

--- a/libraries/typescript/.changeset/client-cli-protocol-modes.md
+++ b/libraries/typescript/.changeset/client-cli-protocol-modes.md
@@ -1,0 +1,7 @@
+---
+"mcp-use": patch
+---
+
+Replace date-based `mcp-use client --protocol` values with `auto`, `legacy`,
+and `modern`. The named modes select automatic negotiation, the legacy wire,
+or the stateless and sessionless modern wire without fallback.

--- a/libraries/typescript/packages/client/examples/_demo-servers/v2-http.ts
+++ b/libraries/typescript/packages/client/examples/_demo-servers/v2-http.ts
@@ -3,6 +3,7 @@
  * Uses @modelcontextprotocol/server + createMcpHandler.
  *
  *   PORT=3102 pnpm v2
+ *   PORT=3102 LEGACY=reject pnpm v2
  */
 import { serve } from "@hono/node-server";
 import { McpServer, createMcpHandler } from "@modelcontextprotocol/server";
@@ -11,6 +12,11 @@ import { cors } from "hono/cors";
 import { z } from "zod";
 
 const PORT = Number(process.env.PORT ?? 3102);
+const LEGACY = process.env.LEGACY ?? "stateless";
+
+if (LEGACY !== "stateless" && LEGACY !== "reject") {
+  throw new Error('LEGACY must be either "stateless" or "reject"');
+}
 
 function buildServer(): McpServer {
   const server = new McpServer({
@@ -65,9 +71,11 @@ app.use(
     exposeHeaders: ["mcp-session-id"],
   })
 );
-const handler = createMcpHandler(buildServer, { legacy: "stateless" });
+const handler = createMcpHandler(buildServer, { legacy: LEGACY });
 app.all("/mcp", (c) => handler.fetch(c.req.raw));
 
 serve({ fetch: app.fetch, port: PORT, hostname: "127.0.0.1" }, (info) => {
-  console.log(`[demo-v2] http://127.0.0.1:${info.port}/mcp`);
+  console.log(
+    `[demo-v2] http://127.0.0.1:${info.port}/mcp (legacy: ${LEGACY})`
+  );
 });

--- a/libraries/typescript/packages/client/examples/cli/CLI.md
+++ b/libraries/typescript/packages/client/examples/cli/CLI.md
@@ -20,6 +20,19 @@ mcp-use client list
 mcp-use client remove demo
 ```
 
+Protocol selection:
+
+```bash
+# Prefer modern and fall back to legacy (default)
+mcp-use client connect compatible http://127.0.0.1:3102/mcp --protocol auto --no-oauth
+
+# Require the legacy wire
+mcp-use client connect legacy http://127.0.0.1:3101/mcp --protocol legacy --no-oauth
+
+# Require the stateless, sessionless modern wire with no fallback
+mcp-use client connect modern http://127.0.0.1:3102/mcp --protocol modern --no-oauth
+```
+
 Stdio:
 
 ```bash

--- a/libraries/typescript/packages/server/specs/CLI_SPEC.md
+++ b/libraries/typescript/packages/server/specs/CLI_SPEC.md
@@ -148,7 +148,7 @@ mcp-use deploy [path] [--org <id-or-slug>] [--name <name>]
 
 ```text
 mcp-use client connect <name> <url> [-H, --header <"Key: Value">...]
-  [--no-oauth] [--auth-timeout <ms>] [--protocol <auto|2026-07-28|2025-11-25>]
+  [--no-oauth] [--auth-timeout <ms>] [--protocol <auto|legacy|modern>]
   [--no-open] [--json]
 mcp-use client list [--json]
 mcp-use client remove <name>
@@ -165,6 +165,8 @@ mcp-use client <name> auth logout [--yes] [--json]
 
 - v2 alpha client commands support HTTP(S) MCP servers; stdio, interactive REPL, resource subscriptions, implicit active sessions, and forced OAuth refresh are omitted. Every operation names a saved server.
 - `connect` validates a unique filesystem-safe name, connects before saving, and attempts OAuth on an authorization challenge unless `--no-oauth`. In an interactive TTY, OAuth prints `This server requires OAuth. Press Enter to open your browser.`, waits for Enter, and then opens the browser. `--no-open`, `--json`, and non-TTY operation never prompt or open a browser; they print the authorization URL to stderr while the loopback callback continues to wait. Repeated headers are stored as credentials, not metadata. Reusing a name requires removing it first.
+- `--protocol auto` prefers the modern wire and falls back to legacy. `--protocol legacy` selects only the legacy wire. `--protocol modern` selects the stateless, sessionless modern wire with no fallback. Saved metadata stores these names, never protocol revision dates.
+- A strict protocol mismatch exits `1` with code `protocol_mismatch`. User-facing mismatch messages name `legacy` or `modern` and do not expose protocol revision dates.
 - `client` and `screenshot` dynamic-import `@mcp-use/client`. When it is missing, the CLI installs it automatically: into the nearest project `package.json` when one exists, otherwise into `~/.mcp-use/client-sdk/`. Auto-install continues the current command in-process and imports from the install location.
 - Tool/prompt arguments accept either one JSON object or `key=value` pairs; `key:=<json>` supplies typed JSON values. Mixing the full-object and pair forms is usage error `2`. Calls time out with exit `1`; tool `isError` results are operation failures and retain their protocol content in JSON error details.
 - `client remove` immediately and idempotently deletes the named local server metadata and credentials. It does not prompt, and `--yes` is not a supported option.

--- a/libraries/typescript/packages/server/src/commands/client.ts
+++ b/libraries/typescript/packages/server/src/commands/client.ts
@@ -24,7 +24,7 @@ import {
 interface SavedServer {
   url: string;
   oauth: boolean;
-  protocol: "auto" | "2026-07-28" | "2025-11-25";
+  protocol: "auto" | "legacy" | "modern";
 }
 
 interface SavedServers {
@@ -50,7 +50,10 @@ Connect options:
   -H, --header <"Key: Value">   Static header (repeatable)
   --no-oauth                    Skip OAuth on authorization challenges
   --auth-timeout <ms>           OAuth wait timeout (default: 300000)
-  --protocol <auto|2026-07-28|2025-11-25>
+  --protocol <auto|legacy|modern>  Protocol mode (default: auto)
+                                  auto: prefer modern, fall back to legacy
+                                  legacy: legacy wire only
+                                  modern: stateless/sessionless, no fallback
   --no-open                     Print the OAuth URL only
   --json                        Emit machine-readable output
 
@@ -75,7 +78,7 @@ type BrowserMode = "ask" | "never";
 /** Run the `mcp-use client` command family. */
 export async function runClient(argv: readonly string[]): Promise<number> {
   if (argv.includes("--help") || argv.includes("-h")) {
-    console.log(CLIENT_HELP);
+    process.stdout.write(`${CLIENT_HELP}\n`);
     return 0;
   }
   const json = wantsJson(argv);
@@ -398,8 +401,21 @@ async function openConnection(
         // resolves the package's browser-default declaration in this build.
       } as unknown as Parameters<typeof createOAuthProvider>[1])
     : undefined;
-  const protocolNegotiation =
-    definition.protocol === "auto" ? "auto" : { pin: definition.protocol };
+  const protocolConfig =
+    definition.protocol === "auto"
+      ? { protocolNegotiation: "auto" as const }
+      : definition.protocol === "modern"
+        ? {
+            protocolNegotiation: {
+              pin: "2026-07-28",
+            },
+          }
+        : {
+            protocolNegotiation: "legacy" as const,
+            clientOptions: {
+              supportedProtocolVersions: ["2025-11-25"],
+            },
+          };
   const client = new MCPClient({
     mcpServers: {
       [name]: {
@@ -408,11 +424,15 @@ async function openConnection(
           ? { headers: credentials.headers }
           : {}),
         ...(authProvider !== undefined ? { authProvider } : { oauth: false }),
-        protocolNegotiation,
+        ...protocolConfig,
       },
     },
   });
-  return client.connect(name);
+  try {
+    return await client.connect(name);
+  } catch (error) {
+    throw normalizeProtocolConnectionError(error, definition.protocol);
+  }
 }
 
 /**
@@ -522,8 +542,8 @@ function parseHeaders(values: readonly string[]): Record<string, string> {
 }
 
 function parseProtocol(value: string | undefined): SavedServer["protocol"] {
-  if (value !== "auto" && value !== "2026-07-28" && value !== "2025-11-25") {
-    throw new UsageError(`Invalid protocol: ${value}`);
+  if (value !== "auto" && value !== "legacy" && value !== "modern") {
+    throw new UsageError("Invalid protocol. Expected auto, legacy, or modern.");
   }
   return value;
 }
@@ -545,7 +565,61 @@ function validateName(name: string): void {
 }
 
 async function readServers(): Promise<SavedServers> {
-  return readJson(SERVERS_PATH, { servers: {} });
+  const saved = await readJson<{
+    servers: Record<
+      string,
+      Omit<SavedServer, "protocol"> & { protocol?: unknown }
+    >;
+  }>(SERVERS_PATH, { servers: {} });
+  const normalized: SavedServers = { servers: {} };
+  let migrated = false;
+
+  for (const [name, server] of Object.entries(saved.servers)) {
+    const protocol = normalizeSavedProtocol(server.protocol);
+    normalized.servers[name] = { ...server, protocol };
+    migrated ||= protocol !== server.protocol;
+  }
+
+  if (migrated) {
+    await writePrivateJson(SERVERS_PATH, normalized);
+  }
+  return normalized;
+}
+
+function normalizeSavedProtocol(value: unknown): SavedServer["protocol"] {
+  if (value === "auto" || value === "legacy" || value === "modern") {
+    return value;
+  }
+  if (value === undefined) return "auto";
+  if (value === "2025-11-25") return "legacy";
+  if (value === "2026-07-28") return "modern";
+  throw new UsageError(
+    "Saved server has an invalid protocol setting. Remove and reconnect it."
+  );
+}
+
+function normalizeProtocolConnectionError(
+  error: unknown,
+  protocol: SavedServer["protocol"]
+): unknown {
+  if (
+    protocol === "auto" ||
+    !(error instanceof Error) ||
+    (!error.message.includes("Unsupported protocol version") &&
+      !error.message.includes("pinned protocol version"))
+  ) {
+    return error;
+  }
+  if (protocol === "legacy") {
+    return new CommandError(
+      "protocol_mismatch",
+      "Server does not support the requested legacy protocol."
+    );
+  }
+  return new CommandError(
+    "protocol_mismatch",
+    "Server does not support the requested modern protocol (stateless/sessionless, no fallback)."
+  );
 }
 
 function credentialsDirectory(name: string): string {

--- a/libraries/typescript/packages/server/tests/commands/client.test.ts
+++ b/libraries/typescript/packages/server/tests/commands/client.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -8,8 +8,18 @@ const AUTHORIZATION_URL = "https://auth.example.com/authorize?state=test";
 
 const mocks = vi.hoisted(() => ({
   closePrompt: vi.fn(),
+  connectError: undefined as unknown,
   config: undefined as
-    | { mcpServers: Record<string, { authProvider?: unknown }> }
+    | {
+        mcpServers: Record<
+          string,
+          {
+            authProvider?: unknown;
+            clientOptions?: { supportedProtocolVersions?: string[] };
+            protocolNegotiation?: "auto" | "legacy" | { pin: "2026-07-28" };
+          }
+        >;
+      }
     | undefined,
   createInterface: vi.fn(),
   loadClientPackage: vi.fn(),
@@ -52,6 +62,7 @@ beforeEach(async () => {
   vi.resetAllMocks();
   vi.resetModules();
   mocks.config = undefined;
+  mocks.connectError = undefined;
   mocks.triggerOAuth = false;
   homeDirectory = await mkdtemp(join(tmpdir(), "mcp-use-client-"));
   vi.stubEnv("HOME", homeDirectory);
@@ -103,6 +114,7 @@ beforeEach(async () => {
       }
 
       async connect(name: string): Promise<typeof connection> {
+        if (mocks.connectError !== undefined) throw mocks.connectError;
         const provider = mocks.config?.mcpServers[name]?.authProvider as
           | { options: { openBrowser: (url: string) => Promise<void> } }
           | undefined;
@@ -333,6 +345,157 @@ describe("client human-readable output", () => {
     });
     expect(stderr).toBe("");
   });
+});
+
+describe("client protocol selection", () => {
+  it.each([
+    {
+      protocol: "auto",
+      expected: {
+        protocolNegotiation: "auto",
+      },
+    },
+    {
+      protocol: "modern",
+      expected: {
+        protocolNegotiation: { pin: "2026-07-28" },
+      },
+    },
+    {
+      protocol: "legacy",
+      expected: {
+        clientOptions: {
+          supportedProtocolVersions: ["2025-11-25"],
+        },
+        protocolNegotiation: "legacy",
+      },
+    },
+  ] as const)(
+    "maps --protocol $protocol to the official SDK negotiation options",
+    async ({ protocol, expected }) => {
+      await expect(
+        runClient([
+          "connect",
+          `protocol-${protocol}`,
+          "https://mcp.example.com/mcp",
+          "--no-oauth",
+          "--protocol",
+          protocol,
+        ])
+      ).resolves.toBe(0);
+
+      expect(mocks.config?.mcpServers[`protocol-${protocol}`]).toMatchObject(
+        expected
+      );
+    }
+  );
+
+  it("advertises only named protocol modes in help and validation errors", async () => {
+    await expect(runClient(["--help"])).resolves.toBe(0);
+    expect(stdout).toContain("--protocol <auto|legacy|modern>");
+    expect(stdout).not.toMatch(/\d{4}-\d{2}-\d{2}/);
+
+    for (const value of ["2025-11-25", "2026-07-28", "invalid"]) {
+      stdout = "";
+      stderr = "";
+      await expect(
+        runClient([
+          "connect",
+          "invalid-protocol",
+          "https://mcp.example.com/mcp",
+          "--no-oauth",
+          "--protocol",
+          value,
+        ])
+      ).resolves.toBe(2);
+      expect(stdout).toBe("");
+      expect(stderr).toBe(
+        "Invalid protocol. Expected auto, legacy, or modern.\n"
+      );
+    }
+  });
+
+  it("migrates saved revision values before listing or reconnecting", async () => {
+    const { GLOBAL_STATE_DIR } = await import("../../src/commands/shared.js");
+    const clientDirectory = join(GLOBAL_STATE_DIR, "client");
+    const serversPath = join(clientDirectory, "servers.json");
+    await mkdir(clientDirectory, { recursive: true });
+    await writeFile(
+      serversPath,
+      JSON.stringify({
+        servers: {
+          old: {
+            url: "https://old.example.com/mcp",
+            oauth: false,
+            protocol: "2025-11-25",
+          },
+          new: {
+            url: "https://new.example.com/mcp",
+            oauth: false,
+            protocol: "2026-07-28",
+          },
+        },
+      })
+    );
+
+    await expect(runClient(["list", "--json"])).resolves.toBe(0);
+    expect(JSON.parse(stdout)).toEqual([
+      {
+        name: "old",
+        url: "https://old.example.com/mcp",
+        oauth: false,
+        protocol: "legacy",
+      },
+      {
+        name: "new",
+        url: "https://new.example.com/mcp",
+        oauth: false,
+        protocol: "modern",
+      },
+    ]);
+    expect(await readFile(serversPath, "utf8")).not.toMatch(
+      /\d{4}-\d{2}-\d{2}/
+    );
+    await rm(clientDirectory, { recursive: true, force: true });
+  });
+
+  it.each([
+    {
+      protocol: "legacy",
+      upstream:
+        "Unsupported protocol version: 2025-11-25; supported: 2026-07-28",
+      message: "Server does not support the requested legacy protocol.",
+    },
+    {
+      protocol: "modern",
+      upstream: "The server did not offer pinned protocol version 2026-07-28",
+      message:
+        "Server does not support the requested modern protocol (stateless/sessionless, no fallback).",
+    },
+  ] as const)(
+    "reports a named mismatch error for strict $protocol mode",
+    async ({ protocol, upstream, message }) => {
+      mocks.connectError = new Error(upstream);
+
+      await expect(
+        runClient([
+          "connect",
+          `mismatch-${protocol}`,
+          "https://mcp.example.com/mcp",
+          "--no-oauth",
+          "--protocol",
+          protocol,
+          "--json",
+        ])
+      ).resolves.toBe(1);
+
+      expect(stdout).toBe("");
+      expect(JSON.parse(stderr)).toEqual({
+        error: { code: "protocol_mismatch", message },
+      });
+      expect(stderr).not.toMatch(/\d{4}-\d{2}-\d{2}/);
+    }
+  );
 });
 
 describe("client OAuth browser UX", () => {


### PR DESCRIPTION
## Summary

- replace date-based client protocol flags with `auto`, `legacy`, and `modern`
- map named modes to official SDK negotiation and migrate saved date-valued metadata
- add stable protocol mismatch errors and official v2 demo strict-mode coverage
- update CLI docs, examples, specification, tests, and changeset

## Root cause

The CLI passed both date flags as SDK pin objects, but the official SDK only accepts pins for modern protocol revisions. Legacy selection requires `mode: "legacy"` plus `supportedProtocolVersions`.

## Validation

- exercised the complete official-server compatibility matrix with `v2-http.ts` and `v1-http.ts`; successful cases connected, listed tools, called and verified a tool, then cleaned up
- verified incompatible modes fail deterministically with exit code 1 and revision-free `protocol_mismatch` errors
- `pnpm exec vitest run tests/commands/client.test.ts` (16 tests)
- server typecheck and build
- client build and full suite (45 files, 272 tests)
- CLI build and standalone test
- formatting and `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces date-based client protocol flags with named modes `auto`, `legacy`, and `modern` for clearer selection and better SDK compatibility. Adds clear `protocol_mismatch` errors and updates docs, examples, and tests.

- **New Features**
  - `--protocol <auto|legacy|modern>` replaces dates.
  - Maps modes to the official SDK: `auto`, `legacy` with `supportedProtocolVersions`, and `modern` pinned to the latest revision.
  - Deterministic `protocol_mismatch` errors for strict modes with exit code 1 and no revision dates in messages.
  - v2 demo server supports strict mode via `LEGACY=stateless|reject`.

- **Migration**
  - Saved servers auto-migrate from date revisions to named modes on first read/write.
  - Help, docs, examples, spec, and tests updated; only `auto|legacy|modern` are accepted.

<sup>Written for commit add5137521893787de02771e3590ef940ce883ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

