### PR TITLE
Add scoped help for mcp-use client commands

### DIFF
--- a/libraries/typescript/.changeset/scoped-client-command-help.md
+++ b/libraries/typescript/.changeset/scoped-client-command-help.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Add scoped `--help` and `-h` pages for every `mcp-use client` command family and leaf without loading saved connections or the client SDK.

--- a/libraries/typescript/packages/server/src/commands/client-help.ts
+++ b/libraries/typescript/packages/server/src/commands/client-help.ts
@@ -1,0 +1,248 @@
+/** Lightweight, side-effect-free help text for the `mcp-use client` tree. */
+
+interface HelpPage {
+  usage: string;
+  summary: string;
+  commands?: readonly [syntax: string, description: string][];
+  options?: readonly [syntax: string, description: string][];
+  notes?: readonly string[];
+}
+
+/**
+ * Result of resolving a client help request.
+ *
+ * @internal
+ */
+export interface ClientHelpResult {
+  /** Rendered help, or `undefined` when the command path is not public. */
+  text?: string;
+  /** Invalid command path, suitable for a concise usage error. */
+  error?: string;
+}
+
+const HELP: [string, string] = ["-h, --help", "Show this help"];
+const JSON: [string, string] = [
+  "--json",
+  "Emit machine-readable JSON (accepted anywhere after client)",
+];
+const pages = new Map<string, HelpPage>();
+
+function page(path: string, value: HelpPage): void {
+  pages.set(path, value);
+}
+
+page("", {
+  usage: "mcp-use client <command>",
+  summary: "Connect to and invoke saved HTTP(S) MCP servers.",
+  commands: [
+    ["connect <name> <url>", "Connect and save a server"],
+    ["list", "List saved servers"],
+    ["remove <name>", "Remove a saved server"],
+    ["<name>", "Invoke a saved server"],
+  ],
+  options: [HELP],
+});
+
+page("connect", {
+  usage: "mcp-use client connect <name> <url> [options]",
+  summary: "Connect to and save an HTTP(S) MCP server.",
+  options: [
+    ['-H, --header <"Key: Value">', "Static header (repeatable)"],
+    ["--no-oauth", "Skip OAuth on authorization challenges"],
+    ["--auth-timeout <ms>", "OAuth wait timeout (default: 300000)"],
+    [
+      "--protocol <auto|legacy|modern>",
+      "Protocol mode (default: auto; modern is stateless/sessionless)",
+    ],
+    ["--no-open", "Print the OAuth URL without opening a browser"],
+    JSON,
+    HELP,
+  ],
+});
+
+page("list", {
+  usage: "mcp-use client list [options]",
+  summary: "List saved MCP servers.",
+  options: [JSON, HELP],
+});
+
+page("remove", {
+  usage: "mcp-use client remove <name> [options]",
+  summary: "Immediately remove a saved server and its credentials.",
+  options: [HELP],
+});
+
+page("<name>", {
+  usage: "mcp-use client <name> <command>",
+  summary: "Invoke a saved MCP server.",
+  commands: [
+    ["tools", "List, describe, or call tools"],
+    ["resources", "List or read resources"],
+    ["prompts", "List or get prompts"],
+    ["auth", "Inspect or clear saved OAuth state"],
+  ],
+  options: [HELP],
+});
+
+page("<name> tools", {
+  usage: "mcp-use client <name> tools <command>",
+  summary: "Use tools on a saved MCP server.",
+  commands: [
+    ["list", "List tools"],
+    ["describe <tool>", "Show a tool definition"],
+    ["call <tool> [args...]", "Call a tool"],
+  ],
+  options: [HELP],
+});
+
+page("<name> tools list", {
+  usage: "mcp-use client <name> tools list [options]",
+  summary: "List tools on a saved MCP server.",
+  options: [JSON, HELP],
+});
+
+page("<name> tools describe", {
+  usage: "mcp-use client <name> tools describe <tool> [options]",
+  summary: "Show one tool definition.",
+  options: [JSON, HELP],
+});
+
+page("<name> tools call", {
+  usage: "mcp-use client <name> tools call <tool> [args...] [options]",
+  summary: "Call a tool on a saved MCP server.",
+  options: [["--timeout <ms>", "Call timeout (default: 30000)"], JSON, HELP],
+  notes: [
+    "Arguments are one JSON object or key=value/key:=<json> pairs; do not mix forms.",
+  ],
+});
+
+page("<name> resources", {
+  usage: "mcp-use client <name> resources <command>",
+  summary: "Use resources on a saved MCP server.",
+  commands: [
+    ["list", "List resources"],
+    ["read <uri>", "Read a resource"],
+  ],
+  options: [HELP],
+});
+
+page("<name> resources list", {
+  usage: "mcp-use client <name> resources list [options]",
+  summary: "List resources on a saved MCP server.",
+  options: [JSON, HELP],
+});
+
+page("<name> resources read", {
+  usage: "mcp-use client <name> resources read <uri> [options]",
+  summary: "Read one resource.",
+  options: [JSON, HELP],
+});
+
+page("<name> prompts", {
+  usage: "mcp-use client <name> prompts <command>",
+  summary: "Use prompts on a saved MCP server.",
+  commands: [
+    ["list", "List prompts"],
+    ["get <prompt> [args...]", "Get a prompt"],
+  ],
+  options: [HELP],
+});
+
+page("<name> prompts list", {
+  usage: "mcp-use client <name> prompts list [options]",
+  summary: "List prompts on a saved MCP server.",
+  options: [JSON, HELP],
+});
+
+page("<name> prompts get", {
+  usage: "mcp-use client <name> prompts get <prompt> [args...] [options]",
+  summary: "Get a prompt from a saved MCP server.",
+  options: [JSON, HELP],
+  notes: [
+    "Arguments are one JSON object or key=value/key:=<json> pairs; do not mix forms.",
+  ],
+});
+
+page("<name> auth", {
+  usage: "mcp-use client <name> auth <command>",
+  summary: "Manage saved OAuth state.",
+  commands: [
+    ["status", "Show OAuth status"],
+    ["logout", "Delete saved OAuth credentials"],
+  ],
+  options: [HELP],
+});
+
+page("<name> auth status", {
+  usage: "mcp-use client <name> auth status [options]",
+  summary: "Show saved OAuth status.",
+  options: [JSON, HELP],
+});
+
+page("<name> auth logout", {
+  usage: "mcp-use client <name> auth logout [options]",
+  summary: "Delete saved OAuth credentials but keep the server.",
+  options: [["--yes", "Skip the confirmation prompt"], JSON, HELP],
+});
+
+/**
+ * Resolve and render a `client` argv vector containing `--help` or `-h`.
+ *
+ * The resolver uses command positions only, so help never reads saved
+ * connections, loads the Client SDK, opens a browser, or performs MCP work.
+ *
+ * @param argv - Arguments following `mcp-use client`.
+ * @returns Scoped help or a concise invalid-path error.
+ *
+ * @internal
+ */
+export function resolveClientHelp(argv: readonly string[]): ClientHelpResult {
+  const path = argv.filter(
+    (token) => token !== "--help" && token !== "-h" && token !== "--json"
+  );
+  const first = path[0];
+  if (first === undefined) return { text: render(pages.get("")!) };
+
+  if (first === "connect" || first === "list" || first === "remove") {
+    return { text: render(pages.get(first)!) };
+  }
+
+  const family = path[1];
+  if (family === undefined) return { text: render(pages.get("<name>")!) };
+  if (!["tools", "resources", "prompts", "auth"].includes(family)) {
+    return { error: `Unknown client command family: ${family}` };
+  }
+
+  const operation = path[2];
+  const familyKey = `<name> ${family}`;
+  if (operation === undefined) return { text: render(pages.get(familyKey)!) };
+
+  const key = `${familyKey} ${operation}`;
+  const selected = pages.get(key);
+  if (selected === undefined) {
+    return { error: `Unknown client ${family} command: ${operation}` };
+  }
+  return { text: render(selected) };
+}
+
+function render(value: HelpPage): string {
+  const sections = [`Usage: ${value.usage}`, value.summary];
+  if (value.commands !== undefined) {
+    sections.push(renderRows("Commands", value.commands));
+  }
+  if (value.options !== undefined) {
+    sections.push(renderRows("Options", value.options));
+  }
+  if (value.notes !== undefined) sections.push(value.notes.join("\n"));
+  return sections.join("\n\n");
+}
+
+function renderRows(
+  heading: string,
+  rows: readonly [syntax: string, description: string][]
+): string {
+  const width = Math.max(...rows.map(([syntax]) => syntax.length));
+  return `${heading}:\n${rows
+    .map(([syntax, description]) => `  ${syntax.padEnd(width)}  ${description}`)
+    .join("\n")}`;
+}

--- a/libraries/typescript/packages/server/src/commands/client.ts
+++ b/libraries/typescript/packages/server/src/commands/client.ts
@@ -6,6 +6,7 @@ import { parseArgs } from "node:util";
 
 import type { MCPConnection } from "@mcp-use/client";
 
+import { resolveClientHelp } from "./client-help.js";
 import { loadClientPackage } from "./load-client.js";
 import {
   CommandError,
@@ -38,48 +39,18 @@ interface SavedCredentials {
 const CLIENT_DIR = join(GLOBAL_STATE_DIR, "client");
 const SERVERS_PATH = join(CLIENT_DIR, "servers.json");
 
-const CLIENT_HELP = `Usage: mcp-use client <command> [options]
-
-Commands:
-  connect <name> <url>   Connect and save an HTTP(S) MCP server
-  list [--json]          List saved servers
-  remove <name>          Remove a saved server
-  <name>                 Invoke tools/resources/prompts on a saved server
-
-Connect options:
-  -H, --header <"Key: Value">   Static header (repeatable)
-  --no-oauth                    Skip OAuth on authorization challenges
-  --auth-timeout <ms>           OAuth wait timeout (default: 300000)
-  --protocol <auto|legacy|modern>  Protocol mode (default: auto)
-                                  auto: prefer modern, fall back to legacy
-                                  legacy: legacy wire only
-                                  modern: stateless/sessionless, no fallback
-  --no-open                     Print the OAuth URL only
-  --json                        Emit machine-readable output
-
-Saved server commands:
-  mcp-use client <name> tools list [--json]
-  mcp-use client <name> tools describe <tool> [--json]
-  mcp-use client <name> tools call <tool> [args...] [--timeout <ms>] [--json]
-  mcp-use client <name> resources list [--json]
-  mcp-use client <name> resources read <uri> [--json]
-  mcp-use client <name> prompts list [--json]
-  mcp-use client <name> prompts get <prompt> [args...] [--json]
-  mcp-use client <name> auth status [--json]
-  mcp-use client <name> auth logout [--yes] [--json]
-
-Examples:
-  mcp-use client connect linear https://mcp.linear.app/mcp
-  mcp-use client linear tools list
-  mcp-use client linear tools call search_issues query="open bugs"`;
-
 type BrowserMode = "ask" | "never";
 
 /** Run the `mcp-use client` command family. */
 export async function runClient(argv: readonly string[]): Promise<number> {
   if (argv.includes("--help") || argv.includes("-h")) {
-    process.stdout.write(`${CLIENT_HELP}\n`);
-    return 0;
+    const help = resolveClientHelp(argv);
+    if (help.text !== undefined) {
+      process.stdout.write(`${help.text}\n`);
+      return 0;
+    }
+    process.stderr.write(`${help.error}\n`);
+    return 2;
   }
   const json = wantsJson(argv);
   const normalizedArgv = argv.filter((token) => token !== "--json");

--- a/libraries/typescript/packages/server/tests/bin-start.test.ts
+++ b/libraries/typescript/packages/server/tests/bin-start.test.ts
@@ -541,14 +541,15 @@ describe("main", () => {
   });
 
   it("prints client help for client --help", async () => {
-    const logs = vi.spyOn(console, "log").mockImplementation(() => {});
+    const stdout = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
     await expect(main(["client", "--help"])).resolves.toBe(0);
-    const output = logs.mock.calls.flat().join("\n");
-    expect(output).toContain("mcp-use client connect");
+    const output = stdout.mock.calls.flat().join("");
+    expect(output).toContain("connect <name> <url>");
     expect(output).toContain("remove <name>");
     expect(output).not.toContain("remove <name> [--yes]");
-    expect(output).toContain("--no-open");
-    expect(output).not.toContain("  --open");
+    expect(output).toContain("-h, --help");
     expect(output).not.toContain("mcp-use deploy");
   });
 

--- a/libraries/typescript/packages/server/tests/commands/client-help.test.ts
+++ b/libraries/typescript/packages/server/tests/commands/client-help.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { main } from "../../src/bin/main.js";
+
+const helpTree: readonly [path: readonly string[], usage: string][] = [
+  [[], "mcp-use client <command>"],
+  [["connect"], "mcp-use client connect <name> <url> [options]"],
+  [["list"], "mcp-use client list [options]"],
+  [["remove"], "mcp-use client remove <name> [options]"],
+  [["demo"], "mcp-use client <name> <command>"],
+  [["demo", "tools"], "mcp-use client <name> tools <command>"],
+  [["demo", "tools", "list"], "mcp-use client <name> tools list [options]"],
+  [
+    ["demo", "tools", "describe"],
+    "mcp-use client <name> tools describe <tool> [options]",
+  ],
+  [
+    ["demo", "tools", "call"],
+    "mcp-use client <name> tools call <tool> [args...] [options]",
+  ],
+  [["demo", "resources"], "mcp-use client <name> resources <command>"],
+  [
+    ["demo", "resources", "list"],
+    "mcp-use client <name> resources list [options]",
+  ],
+  [
+    ["demo", "resources", "read"],
+    "mcp-use client <name> resources read <uri> [options]",
+  ],
+  [["demo", "prompts"], "mcp-use client <name> prompts <command>"],
+  [["demo", "prompts", "list"], "mcp-use client <name> prompts list [options]"],
+  [
+    ["demo", "prompts", "get"],
+    "mcp-use client <name> prompts get <prompt> [args...] [options]",
+  ],
+  [["demo", "auth"], "mcp-use client <name> auth <command>"],
+  [["demo", "auth", "status"], "mcp-use client <name> auth status [options]"],
+  [["demo", "auth", "logout"], "mcp-use client <name> auth logout [options]"],
+];
+
+afterEach(() => vi.restoreAllMocks());
+
+function runClientHelp(argv: readonly string[]): Promise<number> {
+  return main(["client", ...argv]);
+}
+
+describe("client help tree", () => {
+  it.each(helpTree)(
+    "prints scoped long and short help for %s",
+    async (path, usage) => {
+      for (const flag of ["--help", "-h"]) {
+        const stdout = vi
+          .spyOn(process.stdout, "write")
+          .mockImplementation(() => true);
+        const stderr = vi
+          .spyOn(process.stderr, "write")
+          .mockImplementation(() => true);
+
+        await expect(runClientHelp([...path, flag])).resolves.toBe(0);
+
+        const output = stdout.mock.calls.flat().join("");
+        expect(output).toContain(`Usage: ${usage}`);
+        expect(output).toContain("-h, --help");
+        expect(stderr).not.toHaveBeenCalled();
+        vi.restoreAllMocks();
+      }
+    }
+  );
+
+  it("resolves leaf help without saved-server or MCP side effects", async () => {
+    const stdout = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    const stderr = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+
+    await expect(
+      runClientHelp([
+        "--json",
+        "not-saved",
+        "tools",
+        "call",
+        "not-a-tool",
+        "--help",
+      ])
+    ).resolves.toBe(0);
+
+    const output = stdout.mock.calls.flat().join("");
+    expect(output).toContain(
+      "Usage: mcp-use client <name> tools call <tool> [args...] [options]"
+    );
+    expect(output).toContain("--timeout <ms>");
+    expect(output).toContain("--json");
+    expect(stderr).not.toHaveBeenCalled();
+  });
+
+  it("keeps invalid nested help paths as usage errors", async () => {
+    const stdout = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    const stderr = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+
+    await expect(
+      runClientHelp(["demo", "tools", "frobnicate", "--help"])
+    ).resolves.toBe(2);
+
+    expect(stdout).not.toHaveBeenCalled();
+    expect(stderr.mock.calls.flat().join("")).toContain(
+      "Unknown client tools command: frobnicate"
+    );
+  });
+
+  it("documents current connect and removal behavior", async () => {
+    const stdout = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+
+    await runClientHelp(["connect", "--help"]);
+    const connect = stdout.mock.calls.flat().join("");
+    expect(connect).toContain("--protocol <auto|legacy|modern>");
+    expect(connect).toContain("--no-open");
+    expect(connect).not.toMatch(/\d{4}-\d{2}-\d{2}/);
+    expect(connect).not.toContain("  --open");
+
+    stdout.mockClear();
+    await runClientHelp(["remove", "--help"]);
+    const remove = stdout.mock.calls.flat().join("");
+    expect(remove).not.toContain("--yes");
+    expect(remove).not.toContain("--json");
+
+    stdout.mockClear();
+    await runClientHelp(["demo", "auth", "logout", "--help"]);
+    const logout = stdout.mock.calls.flat().join("");
+    expect(logout).toContain("--yes");
+    expect(logout).toContain("--json");
+  });
+});

--- a/libraries/typescript/packages/server/tests/commands/client.test.ts
+++ b/libraries/typescript/packages/server/tests/commands/client.test.ts
@@ -391,7 +391,7 @@ describe("client protocol selection", () => {
   );
 
   it("advertises only named protocol modes in help and validation errors", async () => {
-    await expect(runClient(["--help"])).resolves.toBe(0);
+    await expect(runClient(["connect", "--help"])).resolves.toBe(0);
     expect(stdout).toContain("--protocol <auto|legacy|modern>");
     expect(stdout).not.toMatch(/\d{4}-\d{2}-\d{2}/);
 


### PR DESCRIPTION
## Summary

- add side-effect-free, scoped help pages for all 18 `mcp-use client` command, family, and leaf paths
- keep `--help` and `-h` aligned with current flags, defaults, positionals, JSON behavior, protocol modes, and confirmation rules
- reject unknown nested help paths without reading saved state or loading the client SDK
- add a patch changeset for `mcp-use`

## Why

Nested client help previously returned the same broad client page regardless of the requested path. That hid required positionals and leaf-specific options such as `--timeout`, `--json`, and `--yes`.

## User impact

Users can append `--help` or `-h` at any client hierarchy level and receive help for exactly that command. Help remains side-effect-free and does not connect to an MCP server, read saved connections, open a browser, or load the client SDK.

## Validation

- 18/18 built-CLI help paths passed for both `--help` and `-h`
- 74 focused client/help/bin tests passed
- server typecheck passed
- client, agent, Inspector, server, and CLI builds passed
- ESLint, Prettier, changeset validation, and `git diff --check` passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds scoped, side-effect-free help for every `mcp-use client` command so users see exact usage, options, and leaf-specific flags. Help does not connect to servers or read saved state.

- **New Features**
  - Scoped `--help`/`-h` for all 18 `mcp-use client` paths.
  - Help aligns with current flags and defaults: `--json`, `--timeout`, `--yes`, `--protocol <auto|legacy|modern>`.
  - Unknown nested paths return concise errors without loading the client SDK or opening a browser.

- **Bug Fixes**
  - Nested client help no longer shows a generic page; it now displays the correct leaf-specific help.

<sup>Written for commit a10fdb0fea5da5bcb4e821b800b20276110b7aae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

