### PR TITLE
Handle Inspector sampling by negotiated MCP protocol

### DIFF
--- a/libraries/typescript/.changeset/inspector-legacy-sampling.md
+++ b/libraries/typescript/.changeset/inspector-legacy-sampling.md
@@ -1,0 +1,7 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Enable server-to-client sampling for legacy stateful MCP connections. Hide the
+sampling content, disable its navigation tab with an explanatory tooltip, and
+omit the sampling client capability on modern stateless connections.

--- a/libraries/typescript/packages/inspector/src/client/App.tsx
+++ b/libraries/typescript/packages/inspector/src/client/App.tsx
@@ -20,6 +20,7 @@ import {
   getDefaultInspectorProxyAddress,
   InspectorConnectionStorageProvider,
 } from "./utils/connectionUpdates";
+import { wrapTransportForLegacySampling } from "./utils/samplingProtocol";
 
 /**
  * Syncs the active tab from InspectorContext into a ref readable by
@@ -135,6 +136,7 @@ function App() {
             defaultServerConfig={{
               preventAutoAuth: true,
               useRedirectFlow: true,
+              wrapTransport: wrapTransportForLegacySampling,
             }}
             clientInfo={{
               name: "mcp-use Inspector",

--- a/libraries/typescript/packages/inspector/src/client/components/Layout.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/Layout.tsx
@@ -26,6 +26,7 @@ import {
   toMcpServerConfig,
   type EditableConnectionConfig,
 } from "@/client/utils/connectionUpdates";
+import { isInspectorSamplingAvailable } from "@/client/utils/samplingProtocol";
 import { getServerDisplayName } from "@/client/utils/servers";
 import { useMcpClient, type McpServer } from "@mcp-use/client/react";
 import {
@@ -262,6 +263,21 @@ export function Layout({ children }: LayoutProps) {
     [setActiveTab, navigate, location.search]
   );
 
+  // A bookmarked sampling URL can be restored before protocol negotiation
+  // finishes. Once a modern connection is known, move to a supported tab.
+  useEffect(() => {
+    const selectedServer = connections.find(
+      (connection) => connection.id === selectedServerId
+    );
+    if (
+      activeTab === "sampling" &&
+      selectedServer &&
+      !isInspectorSamplingAvailable(selectedServer)
+    ) {
+      handleTabChange("tools");
+    }
+  }, [activeTab, connections, selectedServerId, handleTabChange]);
+
   // Listen for custom navigation events from toast (for sampling and elicitation requests)
   useEffect(() => {
     const handleNavigateToSampling = (event: globalThis.Event) => {
@@ -270,8 +286,16 @@ export function Layout({ children }: LayoutProps) {
       }>;
       const requestId = customEvent.detail.requestId;
 
-      // Switch to sampling tab and auto-select the request
-      if (selectedServerId) {
+      const selectedServer = connections.find(
+        (connection) => connection.id === selectedServerId
+      );
+
+      // Modern connections neither advertise nor expose legacy sampling.
+      if (
+        selectedServerId &&
+        selectedServer &&
+        isInspectorSamplingAvailable(selectedServer)
+      ) {
         navigateToItem(selectedServerId, "sampling", requestId);
       }
     };
@@ -327,7 +351,7 @@ export function Layout({ children }: LayoutProps) {
         handleNavigateToToolResult
       );
     };
-  }, [selectedServerId, handleTabChange, navigateToItem]);
+  }, [selectedServerId, connections, handleTabChange, navigateToItem]);
 
   // Refs for search inputs in tabs
   const toolsSearchRef = useRef<{

--- a/libraries/typescript/packages/inspector/src/client/components/LayoutContent.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/LayoutContent.tsx
@@ -12,6 +12,7 @@ import { ServerMetadataTab } from "@/client/components/ServerMetadataTab";
 import { ToolsTab } from "@/client/components/ToolsTab";
 import { useInspector } from "@/client/context/InspectorContext";
 import type { TabType } from "@/client/context/InspectorContext";
+import { isInspectorSamplingAvailable } from "@/client/utils/samplingProtocol";
 import { isLocalhostServerUrl } from "@/client/utils/servers";
 import {
   buildManagedAuthHeaders,
@@ -179,6 +180,9 @@ export function LayoutContent({
 
   // Helper to check if a tab should be rendered
   const isTabVisible = (tab: TabType): boolean => {
+    if (tab === "sampling" && !isInspectorSamplingAvailable(selectedServer)) {
+      return false;
+    }
     if (!embeddedConfig.visibleTabs) return true;
     return embeddedConfig.visibleTabs.includes(tab);
   };

--- a/libraries/typescript/packages/inspector/src/client/components/LayoutHeader.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/LayoutHeader.tsx
@@ -9,6 +9,10 @@ import {
   isLocalhostServerUrl,
 } from "@/client/utils/servers";
 import { getBasePath } from "@/client/utils/basePath";
+import {
+  isInspectorSamplingAvailable,
+  STATELESS_SAMPLING_UNSUPPORTED_MESSAGE,
+} from "@/client/utils/samplingProtocol";
 import { ChevronDown, Plus } from "lucide-react";
 import type { McpServer } from "@mcp-use/client/react";
 import { useState } from "react";
@@ -290,15 +294,23 @@ export function LayoutHeader({
                   .filter((tab) => tab.id !== "separator")
                   .map((tab) => {
                     const count = getTabCount(tab.id, selectedServer);
+                    const isDisabled =
+                      tab.id === "sampling" &&
+                      !isInspectorSamplingAvailable(selectedServer);
 
-                    return (
+                    const trigger = (
                       <TabsTrigger
-                        key={tab.id}
                         value={tab.id}
+                        disabled={isDisabled}
+                        disabledTooltip={
+                          isDisabled
+                            ? STATELESS_SAMPLING_UNSUPPORTED_MESSAGE
+                            : undefined
+                        }
                         data-testid={`tab-${tab.id}`}
                         icon={tab.icon}
                         iconOnly
-                        title={tab.label}
+                        title={isDisabled ? undefined : tab.label}
                         badge={
                           count > 0 ? (
                             <TabCountBadge
@@ -312,6 +324,12 @@ export function LayoutHeader({
                       >
                         <span className="sr-only">{tab.label}</span>
                       </TabsTrigger>
+                    );
+
+                    return (
+                      <span key={tab.id} className="contents">
+                        {trigger}
+                      </span>
                     );
                   })}
               </TabsList>

--- a/libraries/typescript/packages/inspector/src/client/components/layout/sidebar/InspectorSidebarNav.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/layout/sidebar/InspectorSidebarNav.tsx
@@ -1,5 +1,9 @@
 import { cn } from "@/client/lib/utils";
 import type { TabType } from "@/client/context/InspectorContext";
+import {
+  isInspectorSamplingAvailable,
+  STATELESS_SAMPLING_UNSUPPORTED_MESSAGE,
+} from "@/client/utils/samplingProtocol";
 import type { McpServer } from "@mcp-use/client/react";
 import {
   Tooltip,
@@ -71,21 +75,33 @@ export function InspectorSidebarNav({
         const showDot = shouldShowDot(tab.id, count, collapsed);
         const Icon = tab.icon;
         const isActive = activeTab === tab.id;
+        const isDisabled =
+          tab.id === "sampling" &&
+          !isInspectorSamplingAvailable(selectedServer);
         const hasTrailing = count > 0 || showDot;
 
         const row = (
           <button
             ref={getRowRef(tab.id)}
             type="button"
+            aria-disabled={isDisabled || undefined}
+            tabIndex={isDisabled ? -1 : undefined}
             data-testid={`tab-${tab.id}`}
             data-active={isActive ? true : undefined}
-            onClick={() => onTabChange(tab.id)}
+            title={
+              isDisabled ? STATELESS_SAMPLING_UNSUPPORTED_MESSAGE : undefined
+            }
+            onClick={() => {
+              if (!isDisabled) onTabChange(tab.id);
+            }}
             className={cn(
               sidebarMenuButtonClass,
               collapsed
                 ? "size-8! w-8! max-w-8! shrink-0 justify-center gap-0 p-0!"
                 : "w-full max-w-full sidebar-nav-pill-bleed-x pl-(--sidebar-nav-icon-pl-bleed) pr-(--sidebar-nav-pr-bleed)",
-              hasTrailing && !collapsed && sidebarNavRowTrailingPaddingClass
+              hasTrailing && !collapsed && sidebarNavRowTrailingPaddingClass,
+              "aria-disabled:cursor-not-allowed aria-disabled:opacity-50",
+              isDisabled && "pointer-events-none"
             )}
           >
             <Icon className="size-4 shrink-0" />
@@ -98,11 +114,29 @@ export function InspectorSidebarNav({
             key={tab.id}
             className={cn("group/menu-item relative", index === 0 && "mt-4")}
           >
-            {collapsed ? (
+            {collapsed || isDisabled ? (
               <Tooltip delayDuration={0}>
-                <TooltipTrigger render={row} nativeButton />
+                <TooltipTrigger
+                  render={
+                    isDisabled ? (
+                      <span
+                        className="block cursor-not-allowed"
+                        title={STATELESS_SAMPLING_UNSUPPORTED_MESSAGE}
+                      >
+                        {row}
+                      </span>
+                    ) : (
+                      row
+                    )
+                  }
+                  nativeButton={!isDisabled}
+                />
                 <TooltipContent side="right">
-                  {count > 0 ? `${tab.label} (${count})` : tab.label}
+                  {isDisabled
+                    ? STATELESS_SAMPLING_UNSUPPORTED_MESSAGE
+                    : count > 0
+                      ? `${tab.label} (${count})`
+                      : tab.label}
                 </TooltipContent>
               </Tooltip>
             ) : (

--- a/libraries/typescript/packages/inspector/src/client/components/ui/tabs.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ui/tabs.tsx
@@ -274,6 +274,8 @@ interface TabsTriggerProps {
   value: string;
   className?: string;
   disabled?: boolean;
+  /** Tooltip shown for an aria-disabled tab. */
+  disabledTooltip?: string;
   icon?: LucideIcon;
   title?: string;
   showDot?: boolean;
@@ -299,7 +301,11 @@ const ConditionalTooltip = ({
     <TooltipProvider>
       <Tooltip>
         <TooltipTrigger
-          render={<span className="contents">{children}</span>}
+          render={
+            <span className="inline-flex" title={title}>
+              {children}
+            </span>
+          }
           nativeButton={false}
         />
         <TooltipContent>{title}</TooltipContent>
@@ -330,6 +336,7 @@ const TabsTrigger = React.forwardRef<
       value,
       className,
       disabled,
+      disabledTooltip,
       icon: Icon,
       title: titleProp,
       showDot = false,
@@ -349,25 +356,28 @@ const TabsTrigger = React.forwardRef<
     const showLabel = !iconOnly && (!collapsed || isActive || alwaysExpanded);
     const badgeOnIcon = iconOnly || (collapsed && !showLabel);
 
-    // Use title prop when provided (for collapsed mode tooltips)
-    const title = collapsed && !showLabel && titleProp ? titleProp : undefined;
+    const tooltipTitle = disabled ? disabledTooltip : titleProp;
+    const showTooltip =
+      Boolean(disabled && disabledTooltip) || (collapsed && !showLabel);
+    const title =
+      !disabled && collapsed && !showLabel && titleProp ? titleProp : undefined;
 
     return (
-      <ConditionalTooltip
-        title={titleProp as string}
-        collapsed={collapsed && !showLabel}
-      >
+      <ConditionalTooltip title={tooltipTitle} collapsed={showTooltip}>
         <button
           ref={ref}
-          disabled={disabled}
-          onClick={() => handleValueChange(value)}
+          aria-disabled={disabled || undefined}
+          tabIndex={disabled ? -1 : undefined}
+          onClick={() => {
+            if (!disabled) handleValueChange(value);
+          }}
           data-tab-value={value}
           data-tab-active={isActive}
           role="tab"
           aria-selected={isActive ? "true" : "false"}
-          title={title}
+          title={disabled && disabledTooltip ? disabledTooltip : title}
           className={cn(
-            "relative z-10 inline-flex items-center justify-center whitespace-nowrap text-sm font-medium ring-offset-background transition-all duration-[250ms] ease-in-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 cursor-pointer",
+            "relative z-10 inline-flex items-center justify-center whitespace-nowrap text-sm font-medium ring-offset-background transition-all duration-[250ms] ease-in-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 cursor-pointer",
             iconOnly ? "size-9 shrink-0 flex-none rounded-full p-0" : "flex-1",
             variant === "default" && !iconOnly && "py-2.5",
             variant === "default" && !iconOnly && "rounded-md px-4",

--- a/libraries/typescript/packages/inspector/src/client/utils/__tests__/samplingProtocol.test.ts
+++ b/libraries/typescript/packages/inspector/src/client/utils/__tests__/samplingProtocol.test.ts
@@ -1,0 +1,99 @@
+import type { JSONRPCMessage, Transport } from "@mcp-use/client/react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  isInspectorSamplingAvailable,
+  STATELESS_SAMPLING_UNSUPPORTED_MESSAGE,
+  stripModernSamplingCapability,
+  wrapTransportForLegacySampling,
+} from "../samplingProtocol";
+
+const clientCapabilitiesKey = "io.modelcontextprotocol/clientCapabilities";
+
+describe("Inspector sampling protocol behavior", () => {
+  it("keeps sampling in a legacy initialize request", () => {
+    const message = {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-11-25",
+        capabilities: { roots: {}, sampling: {} },
+        clientInfo: { name: "Inspector", version: "1.0.0" },
+      },
+    };
+
+    expect(stripModernSamplingCapability(message as JSONRPCMessage)).toBe(
+      message
+    );
+    expect(message.params.capabilities).toEqual({
+      roots: {},
+      sampling: {},
+    });
+  });
+
+  it("removes sampling from a modern capability envelope", () => {
+    const message = {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "server/discover",
+      params: {
+        _meta: {
+          [clientCapabilitiesKey]: {
+            roots: { listChanged: true },
+            sampling: {},
+            extensions: { "io.modelcontextprotocol/ui": {} },
+          },
+        },
+      },
+    };
+
+    const stripped = stripModernSamplingCapability(
+      message as JSONRPCMessage
+    ) as typeof message;
+
+    expect(stripped.params._meta[clientCapabilitiesKey]).toEqual({
+      roots: { listChanged: true },
+      extensions: { "io.modelcontextprotocol/ui": {} },
+    });
+    expect(message.params._meta[clientCapabilitiesKey]).toHaveProperty(
+      "sampling"
+    );
+  });
+
+  it("strips modern sampling before forwarding through the transport", async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const transport = {
+      start: vi.fn(),
+      send,
+      close: vi.fn(),
+    } as unknown as Transport;
+    const wrapped = wrapTransportForLegacySampling(transport);
+
+    await wrapped.send({
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+      params: {
+        _meta: {
+          [clientCapabilitiesKey]: { sampling: {}, roots: {} },
+        },
+      },
+    } as JSONRPCMessage);
+
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: {
+          _meta: {
+            [clientCapabilitiesKey]: { roots: {} },
+          },
+        },
+      }),
+      undefined
+    );
+  });
+
+  it("shows sampling only when the connection is not modern", () => {
+    expect(isInspectorSamplingAvailable({ protocolEra: "legacy" })).toBe(true);
+    expect(isInspectorSamplingAvailable({ protocolEra: "modern" })).toBe(false);
+    expect(STATELESS_SAMPLING_UNSUPPORTED_MESSAGE).toContain("2026-07-28");
+  });
+});

--- a/libraries/typescript/packages/inspector/src/client/utils/samplingProtocol.ts
+++ b/libraries/typescript/packages/inspector/src/client/utils/samplingProtocol.ts
@@ -1,0 +1,116 @@
+import type {
+  JSONRPCMessage,
+  McpServer,
+  Transport,
+} from "@mcp-use/client/react";
+
+const CLIENT_CAPABILITIES_META_KEY =
+  "io.modelcontextprotocol/clientCapabilities";
+
+export const STATELESS_SAMPLING_UNSUPPORTED_MESSAGE =
+  "Sampling is not supported by the stateless MCP protocol (2026-07-28).";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * Sampling in the Inspector is the legacy server-to-client reverse-RPC
+ * feature. Modern MCP uses stateless input_required exchanges instead, so the
+ * Inspector must not claim the legacy capability in modern metadata.
+ */
+export function stripModernSamplingCapability(
+  message: JSONRPCMessage
+): JSONRPCMessage {
+  const messageRecord = message as unknown as Record<string, unknown>;
+  const params = messageRecord.params;
+  if (!isRecord(params)) return message;
+
+  const meta = params._meta;
+  if (!isRecord(meta)) return message;
+
+  const capabilities = meta[CLIENT_CAPABILITIES_META_KEY];
+  if (!isRecord(capabilities) || !Object.hasOwn(capabilities, "sampling")) {
+    return message;
+  }
+
+  const { sampling: _sampling, ...modernCapabilities } = capabilities;
+
+  return {
+    ...messageRecord,
+    params: {
+      ...params,
+      _meta: {
+        ...meta,
+        [CLIENT_CAPABILITIES_META_KEY]: modernCapabilities,
+      },
+    },
+  } as unknown as JSONRPCMessage;
+}
+
+/**
+ * Preserve sampling in the legacy initialize capability object while removing
+ * it from modern server/discover and per-request metadata envelopes.
+ */
+export function wrapTransportForLegacySampling(
+  transport: Transport
+): Transport {
+  const wrapper: Transport = {
+    get sessionId() {
+      return transport.sessionId;
+    },
+    set sessionId(value: string | undefined) {
+      transport.sessionId = value;
+    },
+    setProtocolVersion: transport.setProtocolVersion
+      ? (version: string) => transport.setProtocolVersion?.(version)
+      : undefined,
+    async start() {
+      return transport.start();
+    },
+    async send(message, options) {
+      return transport.send(stripModernSamplingCapability(message), options);
+    },
+    async close() {
+      return transport.close();
+    },
+    onclose: undefined,
+    onerror: undefined,
+    onmessage: undefined,
+  };
+
+  Object.defineProperties(wrapper, {
+    onmessage: {
+      configurable: true,
+      enumerable: true,
+      get: () => transport.onmessage,
+      set: (handler: Transport["onmessage"]) => {
+        transport.onmessage = handler;
+      },
+    },
+    onclose: {
+      configurable: true,
+      enumerable: true,
+      get: () => transport.onclose,
+      set: (handler: Transport["onclose"]) => {
+        transport.onclose = handler;
+      },
+    },
+    onerror: {
+      configurable: true,
+      enumerable: true,
+      get: () => transport.onerror,
+      set: (handler: Transport["onerror"]) => {
+        transport.onerror = handler;
+      },
+    },
+  });
+
+  return wrapper;
+}
+
+export function isInspectorSamplingAvailable(
+  server: Pick<McpServer, "protocolEra">
+): boolean {
+  return server.protocolEra !== "modern";
+}


### PR DESCRIPTION
## What changed

- preserve the legacy sampling capability for stateful MCP `2025-11-25` connections
- strip sampling from modern stateless `2026-07-28` client capability metadata
- keep the Sampling navigation item visible but disabled for modern connections
- explain the disabled state with the shared tooltip component: “Sampling is not supported by the stateless MCP protocol (2026-07-28).”
- guard bookmarked and event-driven navigation from opening unsupported sampling content
- add protocol behavior unit coverage and a patch changeset for `@mcp-use/inspector`

## Why

The Inspector was treating sampling as unavailable across both protocol eras. Sampling is supported by the legacy stateful protocol, but the modern stateless protocol should neither receive the advertised capability nor expose active sampling controls.

The disabled tooltip initially did not open because the tooltip trigger was attached directly to an `aria-disabled` control. The trigger now wraps the disabled control and owns pointer interaction while the button remains non-interactive.

## Impact

Legacy servers can use server-initiated sampling through the Inspector. Modern stateless servers see a disabled Sampling tab with a clear protocol-specific explanation and do not receive sampling capability advertisement.

## Validation

- `pnpm --filter @mcp-use/client build`
- `pnpm --filter @mcp-use/inspector type-check`
- ESLint on all changed TypeScript files
- `pnpm --filter @mcp-use/inspector test:unit` (37 files, 158 tests)
- `pnpm --filter @mcp-use/inspector build`
- manual hover verification in Helium against the sampling example server

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Inspector sampling protocol-aware. Legacy MCP (`2025-11-25`) keeps server-initiated sampling; modern stateless MCP (`2026-07-28`) removes the capability and shows a disabled Sampling tab with a clear tooltip.

- **New Features**
  - Protocol-aware capability handling: `wrapTransportForLegacySampling` keeps legacy sampling in `initialize` and strips it from modern capability envelopes.
  - UI updates: Sampling tab stays visible but disabled for modern connections; sampling content is hidden; tooltip explains “Sampling is not supported by the stateless MCP protocol (2026-07-28).”
  - Navigation guards: prevent deep-link and toast-driven navigation to Sampling on modern connections and fallback to Tools.
  - Tests and release: Added unit tests for protocol behavior and a patch changeset for `@mcp-use/inspector`.

- **Bug Fixes**
  - Tooltips on disabled controls now render by wrapping the `aria-disabled` trigger, so the message appears while the button remains non-interactive.

<sup>Written for commit 64a2d25f7bb505b94702c39fe17e95e37073e54f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

