### PR TITLE
perf(server): reduce Node runtime overhead

### DIFF
--- a/libraries/typescript/.changeset/faster-node-runtime.md
+++ b/libraries/typescript/.changeset/faster-node-runtime.md
@@ -1,0 +1,8 @@
+---
+"mcp-use": patch
+---
+
+Reduce v2 Node server startup and request overhead with a conditioned,
+self-contained Node entry, buffered JSON response writes, and narrower
+JSON-RPC response guards. Preserve the Node-free edge entry, streaming
+responses, middleware behavior, and protocol validation.

--- a/libraries/typescript/knip.json
+++ b/libraries/typescript/knip.json
@@ -25,6 +25,7 @@
       ],
       "project": ["src/**/*.{ts,tsx}", "tests/**/*.{ts,tsx}"],
       "ignoreBinaries": ["npx"],
+      "ignoreUnresolved": ["#mcp-use-node-http"],
       "ignoreDependencies": ["mcp-use"]
     },
     "packages/agent": {

--- a/libraries/typescript/packages/server/package.json
+++ b/libraries/typescript/packages/server/package.json
@@ -20,9 +20,20 @@
     "server",
     "typescript"
   ],
+  "imports": {
+    "#mcp-use-node-http": {
+      "workerd": "./dist/internal/node-http-unavailable.js",
+      "browser": "./dist/internal/node-http-unavailable.js",
+      "node": "./dist/internal/node-http.js",
+      "default": "./dist/internal/node-http-unavailable.js"
+    }
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "workerd": "./dist/index.js",
+      "browser": "./dist/index.js",
+      "node": "./dist/index-node.js",
       "import": "./dist/index.js"
     },
     "./server": {

--- a/libraries/typescript/packages/server/src/buffered-response.ts
+++ b/libraries/typescript/packages/server/src/buffered-response.ts
@@ -1,0 +1,67 @@
+const bufferedResponses = new WeakSet<Response>();
+const bufferedSources = new WeakMap<Request, Response>();
+
+/**
+ * Mark a framework-owned response whose body is already buffered in memory.
+ *
+ * @internal
+ */
+export function markBufferedResponse(response: Response): Response {
+  if (response.body !== null) {
+    bufferedResponses.add(response);
+  }
+  return response;
+}
+
+/**
+ * Associate a known-buffered SDK response with the request that produced it.
+ *
+ * Keeping the source response lets the Node bridge recognize framework-owned
+ * header wrappers by body identity without trusting a content type. If any
+ * middleware clones or replaces the body, the identity check fails closed.
+ *
+ * @internal
+ */
+export function trackBufferedResponse(
+  request: Request,
+  response: Response
+): Response {
+  markBufferedResponse(response);
+  bufferedSources.set(request, response);
+  return response;
+}
+
+/** Whether a response body is covered by the framework's buffered contract. */
+export function isBufferedResponse(
+  response: Response,
+  request?: Request
+): boolean {
+  if (response.body === null) {
+    return false;
+  }
+  if (bufferedResponses.has(response)) {
+    return true;
+  }
+  const source =
+    request === undefined ? undefined : bufferedSources.get(request);
+  return (
+    source !== undefined &&
+    source.body !== null &&
+    source.body === response.body
+  );
+}
+
+/**
+ * Preserve the marker across a framework-owned, header-only response wrapper.
+ *
+ * Body-transforming user middleware does not call this helper, so replacing a
+ * response still drops the buffered contract automatically.
+ *
+ * @internal
+ */
+export function inheritBufferedResponse(
+  source: Response,
+  target: Response
+): Response {
+  return isBufferedResponse(source) ? markBufferedResponse(target) : target;
+}

--- a/libraries/typescript/packages/server/src/internal-imports.d.ts
+++ b/libraries/typescript/packages/server/src/internal-imports.d.ts
@@ -1,0 +1,3 @@
+declare module "#mcp-use-node-http" {
+  export const createServer: typeof import("node:http").createServer;
+}

--- a/libraries/typescript/packages/server/src/middleware/cors.ts
+++ b/libraries/typescript/packages/server/src/middleware/cors.ts
@@ -1,3 +1,4 @@
+import { inheritBufferedResponse } from "../buffered-response.js";
 import type { CorsOptions } from "../config.js";
 import type { FetchMiddleware } from "../fetch-app.js";
 
@@ -72,11 +73,14 @@ function mergeCorsHeaders(response: Response, headers: HeadersInit): Response {
   corsHeaders.forEach((value, key) => {
     merged.set(key, value);
   });
-  return new Response(response.body, {
-    status: response.status,
-    statusText: response.statusText,
-    headers: merged,
-  });
+  return inheritBufferedResponse(
+    response,
+    new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: merged,
+    })
+  );
 }
 
 /**

--- a/libraries/typescript/packages/server/src/mount-mcp.ts
+++ b/libraries/typescript/packages/server/src/mount-mcp.ts
@@ -6,6 +6,7 @@ import {
   type McpServerFactory,
 } from "@modelcontextprotocol/server";
 
+import { trackBufferedResponse } from "./buffered-response.js";
 import { getRequestBag, matchesPath, type FetchHandler } from "./fetch-app.js";
 import {
   extractClientCapabilitiesFromBody,
@@ -102,10 +103,20 @@ export function createMcpMount(
     }
 
     const authInfo = getAuthInfo?.(request) ?? bag.authInfo;
-    return handler.fetch(request, {
+    const response = await handler.fetch(request, {
       ...(parsedBody !== undefined && { parsedBody }),
       ...(authInfo !== undefined && { authInfo }),
     });
+    // The SDK currently constructs JSON replies with Response.json(), so these
+    // bodies are fully buffered. Record that contract at the SDK boundary
+    // instead of inferring it later from a content type that custom handlers
+    // may also use for genuinely streaming JSON.
+    return response.headers
+      .get("content-type")
+      ?.toLowerCase()
+      .includes("application/json")
+      ? trackBufferedResponse(request, response)
+      : response;
   };
 
   return { handler, fetch };

--- a/libraries/typescript/packages/server/src/node-bridge.ts
+++ b/libraries/typescript/packages/server/src/node-bridge.ts
@@ -2,7 +2,8 @@
  * Vendored from `@modelcontextprotocol/node` `toNodeHandler.ts` (SDK 2.0.0-beta.4).
  * ponytail: track upstream SSE/backpressure fixes when bumping `@modelcontextprotocol/server`.
  *
- * @internal Lazy-imported from `listen()` and `mcp-use dev` only.
+ * @internal Bundled into the Node root; remains free of runtime Node imports
+ * so the generic edge graph can reuse the response adapter safely.
  */
 import type {
   AuthInfo,
@@ -102,6 +103,29 @@ export function toNodeHandler(
     if (response.body === null) {
       finished = true;
       res.end();
+      return;
+    }
+
+    // MCP request/response payloads are ordinary buffered JSON. Avoid routing
+    // those through the async ReadableStream iterator used for SSE and other
+    // streaming responses: it adds a promise turn and backpressure bookkeeping
+    // for every chunk on the hottest server path.
+    if (
+      response.headers
+        .get("content-type")
+        ?.toLowerCase()
+        .includes("application/json")
+    ) {
+      try {
+        const bytes = new Uint8Array(await response.arrayBuffer());
+        finished = true;
+        res.end(bytes);
+      } catch {
+        // Match the streaming path below: an aborted upstream body closes the
+        // Node response without turning it into an unhandled rejection.
+        finished = true;
+        res.end();
+      }
       return;
     }
 

--- a/libraries/typescript/packages/server/src/node-bridge.ts
+++ b/libraries/typescript/packages/server/src/node-bridge.ts
@@ -10,6 +10,8 @@ import type {
   McpHandlerRequestOptions,
 } from "@modelcontextprotocol/server";
 
+import { isBufferedResponse } from "./buffered-response.js";
+
 /** Minimal duck-typed shape of a Node.js `IncomingMessage`. */
 export interface NodeIncomingMessageLike extends AsyncIterable<
   Uint8Array | string
@@ -75,9 +77,10 @@ export function toNodeHandler(
       abort.abort();
     }
 
+    let request: Request | undefined;
     let response: Response;
     try {
-      const request = await toWebRequest(req, parsedBody, {
+      request = await toWebRequest(req, parsedBody, {
         signal: abort.signal,
       });
       response = await handler.fetch(request, {
@@ -106,16 +109,10 @@ export function toNodeHandler(
       return;
     }
 
-    // MCP request/response payloads are ordinary buffered JSON. Avoid routing
-    // those through the async ReadableStream iterator used for SSE and other
-    // streaming responses: it adds a promise turn and backpressure bookkeeping
-    // for every chunk on the hottest server path.
-    if (
-      response.headers
-        .get("content-type")
-        ?.toLowerCase()
-        .includes("application/json")
-    ) {
+    // Framework-owned SDK replies carry an explicit buffered-body marker.
+    // Avoid the async iterator overhead for those known single-buffer bodies;
+    // arbitrary application/json responses remain on the streaming path.
+    if (isBufferedResponse(response, request)) {
       try {
         const bytes = new Uint8Array(await response.arrayBuffer());
         finished = true;

--- a/libraries/typescript/packages/server/src/node-http-unavailable.ts
+++ b/libraries/typescript/packages/server/src/node-http-unavailable.ts
@@ -1,0 +1,12 @@
+import type { createServer as NodeCreateServer } from "node:http";
+
+/**
+ * Non-Node target for the internal conditional Node HTTP import.
+ *
+ * Fetch-based runtimes never call `listen()`. Keeping this as a runtime error
+ * preserves a Node-free package graph for Workers and browser-oriented
+ * bundlers while Node resolves the same internal specifier to `node:http`.
+ */
+export const createServer: typeof NodeCreateServer = () => {
+  throw new Error("MCPServer.listen() requires a Node.js runtime");
+};

--- a/libraries/typescript/packages/server/src/node-http.ts
+++ b/libraries/typescript/packages/server/src/node-http.ts
@@ -1,0 +1,2 @@
+/** @internal Node target for the package's conditional HTTP import. */
+export { createServer } from "node:http";

--- a/libraries/typescript/packages/server/src/oauth/errors.ts
+++ b/libraries/typescript/packages/server/src/oauth/errors.ts
@@ -1,0 +1,10 @@
+import { OAuthError, OAuthErrorCode } from "@modelcontextprotocol/server";
+
+/** @internal Creates an OAuth invalid-token error with an optional cause. */
+export function invalidToken(message: string, cause?: unknown): OAuthError {
+  const error = new OAuthError(OAuthErrorCode.InvalidToken, message);
+  if (cause !== undefined) {
+    error.cause = cause;
+  }
+  return error;
+}

--- a/libraries/typescript/packages/server/src/oauth/internal.ts
+++ b/libraries/typescript/packages/server/src/oauth/internal.ts
@@ -9,7 +9,7 @@ import {
   isRecord,
   parseAbsoluteUrl,
 } from "./guards.js";
-import { invalidToken } from "./jwt.js";
+import { invalidToken } from "./errors.js";
 import type { OAuthExtra, OAuthProvider } from "./provider.js";
 
 export {

--- a/libraries/typescript/packages/server/src/oauth/jwt.ts
+++ b/libraries/typescript/packages/server/src/oauth/jwt.ts
@@ -1,6 +1,5 @@
 import {
   OAuthError,
-  OAuthErrorCode,
   type AuthInfo,
   type OAuthTokenVerifier,
 } from "@modelcontextprotocol/server";
@@ -11,7 +10,10 @@ import {
   type JWTVerifyGetKey,
 } from "jose";
 
+import { invalidToken } from "./errors.js";
 import { isLocalhost, isRecord } from "./guards.js";
+
+export { invalidToken } from "./errors.js";
 
 /** @internal Record of claims extracted from a verified JWT. */
 export type VerifiedPayload = Record<string, unknown>;
@@ -186,15 +188,6 @@ export function requiredFutureNumber(
     throw invalidToken(`Missing or expired ${name} claim`);
   }
   return value;
-}
-
-/** @internal Creates an OAuth invalid-token error with an optional cause. */
-export function invalidToken(message: string, cause?: unknown): OAuthError {
-  const error = new OAuthError(OAuthErrorCode.InvalidToken, message);
-  if (cause !== undefined) {
-    error.cause = cause;
-  }
-  return error;
 }
 
 function verifiedResource(

--- a/libraries/typescript/packages/server/src/server.ts
+++ b/libraries/typescript/packages/server/src/server.ts
@@ -16,6 +16,7 @@ import {
   type ServerContext,
   type StandardSchemaWithJSON,
 } from "@modelcontextprotocol/server";
+import { createServer as createNodeHttpServer } from "#mcp-use-node-http";
 import type { Server as NodeHttpServer } from "node:http";
 import { Hono, type Env, type MiddlewareHandler } from "hono";
 
@@ -28,6 +29,7 @@ import {
 } from "./branding.js";
 import { assertServerConfig, type ServerConfig } from "./config.js";
 import { resolveListenHost, resolveListenPort } from "./listen-address.js";
+import { toNodeHandler } from "./node-bridge.js";
 import {
   toAuthenticatedRequestContext,
   toRequestContext,
@@ -104,7 +106,7 @@ import type {
   ToolViewConfig,
 } from "./tools.js";
 import { resolveToolInputSchema } from "./tools.js";
-import { recordUsage } from "./usage.js";
+import { isUsageDisabled, recordUsage } from "./usage.js";
 import { supportsViews } from "./views/capabilities.js";
 import type { ViewResourceFacts } from "./views/types.js";
 import {
@@ -950,8 +952,6 @@ export class MCPServer<TUser = never, TEnv extends Env = Env> {
     options: ListenOptions = {}
   ): Promise<{ port: number; url: string }> {
     this.#assertOpen("listen()");
-    const { createServer } = await import("node:http");
-    const { toNodeHandler } = await import("./node-bridge.js");
     const host = resolveListenHost(options.host, this.#config.host);
     const requestedPort = resolveListenPort(port, this.#config.port);
     this.#assertListenOAuthConfiguration(host);
@@ -988,7 +988,7 @@ export class MCPServer<TUser = never, TEnv extends Env = Env> {
       const nodeHandler = toNodeHandler({
         fetch: async (request) => (await fetchReady)(request),
       });
-      const server = createServer((req, res) => {
+      const server = createNodeHttpServer((req, res) => {
         void nodeHandler(req, res);
       }) as NodeHttpListener;
 
@@ -1553,7 +1553,7 @@ export class MCPServer<TUser = never, TEnv extends Env = Env> {
     }
   }
 
-  /** Build a fresh SDK server from the registry (runs once per request). */
+  /** Build a fully registered SDK server from the immutable registry. */
   #buildSdkServer(ctx: McpRequestContext): SdkMcpServer {
     const { name, version, title, description, instructions } = this.#config;
     const authInfo = ctx.authInfo;
@@ -1643,6 +1643,28 @@ export class MCPServer<TUser = never, TEnv extends Env = Env> {
     ctx: MiddlewareContext<M, TEnv>,
     innerFn: () => Promise<McpMiddlewareResult<M>>
   ): Promise<McpMiddlewareResult<M>> {
+    // The upstream SDK validates every tools/call result against
+    // CallToolResultSchema before it reaches the transport. When there are no
+    // middleware entries or observers, running the middleware pipeline would
+    // only repeat that full schema parse.
+    const runOperation =
+      method === "tools/call" &&
+      this.#mcpMiddlewares.length === 0 &&
+      this.#mcpEventListeners.length === 0
+        ? innerFn
+        : () =>
+            runMcpOperation(
+              this.#mcpMiddlewares,
+              this.#mcpEventListeners,
+              method,
+              ctx,
+              innerFn
+            );
+
+    if (isUsageDisabled()) {
+      return runOperation();
+    }
+
     const startedAt = performance.now();
     const matchedMiddleware = this.#mcpMiddlewares.filter((entry) =>
       matchesPattern(entry.pattern, method)
@@ -1682,13 +1704,7 @@ export class MCPServer<TUser = never, TEnv extends Env = Env> {
         }
       );
     };
-    return runMcpOperation(
-      this.#mcpMiddlewares,
-      this.#mcpEventListeners,
-      method,
-      ctx,
-      innerFn
-    ).then(
+    return runOperation().then(
       (result) => {
         const outcome = isInputRequiredResult(result)
           ? "input_required"

--- a/libraries/typescript/packages/server/src/usage.ts
+++ b/libraries/typescript/packages/server/src/usage.ts
@@ -67,6 +67,11 @@ function disabled(): boolean {
   }
 }
 
+/** Whether anonymous usage capture is disabled in the current runtime. @internal */
+export function isUsageDisabled(): boolean {
+  return disabled();
+}
+
 function clean(properties: Properties): Properties {
   return Object.fromEntries(
     Object.entries(properties).filter(([key, value]) => {

--- a/libraries/typescript/packages/server/tests/budgets/cli-budget.test.ts
+++ b/libraries/typescript/packages/server/tests/budgets/cli-budget.test.ts
@@ -25,11 +25,13 @@ describe("published CLI boundaries", () => {
       "the edge graph must not reach command chunks"
     ).toEqual([]);
     expect(
-      [...graph.dynamicSpecifiers].some((specifier) =>
-        specifier.includes("node-bridge")
-      ),
-      "listen() must lazy-load the Node HTTP adapter"
-    ).toBe(true);
+      [...graph.files.values()].join("\n"),
+      "the edge graph must include the edge-safe Node response bridge"
+    ).toContain("toNodeHandler");
+    expect(
+      graph.staticPackages,
+      "listen() must resolve Node HTTP through the package condition map"
+    ).toContain("#mcp-use-node-http");
     expect(
       [...graph.dynamicSpecifiers].some((specifier) =>
         specifier.includes("public-route")

--- a/libraries/typescript/packages/server/tests/budgets/runtime-boundary.test.ts
+++ b/libraries/typescript/packages/server/tests/budgets/runtime-boundary.test.ts
@@ -25,13 +25,19 @@ describe("runtime package boundaries", () => {
     expectForbiddenRuntimeModules(resolutions);
   });
 
-  it("allows only the official SDK process shim under default Node conditions", async () => {
+  it("loads only the SDK process shim and listen HTTP adapter under Node conditions", async () => {
     const resolutions = await traceImport([]);
     const builtins = builtinResolutions(resolutions);
 
-    expect(builtins.map(({ url }) => url)).toEqual(["node:process"]);
-    expect(builtins[0]?.parentURL).toMatch(
-      /@modelcontextprotocol\/server\/dist\/shimsNode\.mjs$/
+    expect(builtins.map(({ url }) => url)).toEqual([
+      "node:process",
+      "node:http",
+    ]);
+    expect(
+      builtins.find(({ url }) => url === "node:process")?.parentURL
+    ).toMatch(/@modelcontextprotocol\/server\/dist\/shimsNode\.mjs$/);
+    expect(builtins.find(({ url }) => url === "node:http")?.parentURL).toMatch(
+      /dist\/internal\/node-http\.js$/
     );
     expectForbiddenRuntimeModules(resolutions);
   });

--- a/libraries/typescript/packages/server/tests/cors.test.ts
+++ b/libraries/typescript/packages/server/tests/cors.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
 
+import {
+  isBufferedResponse,
+  markBufferedResponse,
+} from "../src/buffered-response.js";
 import { composeFetch } from "../src/fetch-app.js";
 import { corsFetchMiddleware } from "../src/middleware/cors.js";
 
@@ -45,6 +49,22 @@ describe("corsFetchMiddleware", () => {
     expect(response.headers.get("Access-Control-Allow-Origin")).toBe(
       "https://app.example.com"
     );
+  });
+
+  it("preserves the buffered marker across its header-only wrapper", async () => {
+    const fetch = composeFetch(
+      async () => markBufferedResponse(Response.json({ ok: true })),
+      corsFetchMiddleware({ origin: "https://app.example.com" })
+    );
+
+    const response = await fetch(
+      new Request("http://localhost/mcp", {
+        method: "POST",
+        headers: { Origin: "https://app.example.com" },
+      })
+    );
+
+    expect(isBufferedResponse(response)).toBe(true);
   });
 
   it("does not override responses that already set ACAO", async () => {

--- a/libraries/typescript/packages/server/tests/mcp-server.test.ts
+++ b/libraries/typescript/packages/server/tests/mcp-server.test.ts
@@ -10,6 +10,7 @@ import {
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 
+import { isBufferedResponse } from "../src/buffered-response.js";
 import { MCPServer, completable } from "../src/index.js";
 import type {
   MetaObject,
@@ -741,38 +742,38 @@ describe("MCPServer fetch handler (no network)", () => {
     }));
     const handler = server.fetch;
 
-    const response = await handler(
-      new Request("http://localhost/api/mcp", {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          accept: "application/json, text/event-stream",
-          "mcp-protocol-version": "2026-07-28",
-          "mcp-method": "tools/call",
-          "mcp-name": "ping",
-        },
-        body: JSON.stringify({
-          jsonrpc: "2.0",
-          id: 1,
-          method: "tools/call",
-          params: {
-            name: "ping",
-            arguments: {},
-            // The stateless 2026-07-28 wire replaces the initialize handshake
-            // with a per-request _meta envelope; these three keys are required.
-            _meta: {
-              "io.modelcontextprotocol/protocolVersion": "2026-07-28",
-              "io.modelcontextprotocol/clientInfo": {
-                name: "raw-request",
-                version: "0.0.0",
-              },
-              "io.modelcontextprotocol/clientCapabilities": {},
+    const request = new Request("http://localhost/api/mcp", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+        "mcp-protocol-version": "2026-07-28",
+        "mcp-method": "tools/call",
+        "mcp-name": "ping",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "ping",
+          arguments: {},
+          // The stateless 2026-07-28 wire replaces the initialize handshake
+          // with a per-request _meta envelope; these three keys are required.
+          _meta: {
+            "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+            "io.modelcontextprotocol/clientInfo": {
+              name: "raw-request",
+              version: "0.0.0",
             },
+            "io.modelcontextprotocol/clientCapabilities": {},
           },
-        }),
-      })
-    );
+        },
+      }),
+    });
+    const response = await handler(request);
     expect(response.status).toBe(200);
+    expect(isBufferedResponse(response, request)).toBe(true);
     // Modern (2026-07-28) exchanges answer with a single JSON body unless the
     // handler streams a related message first (responseMode 'auto').
     const body: unknown = await response.json();

--- a/libraries/typescript/packages/server/tests/node-bridge.test.ts
+++ b/libraries/typescript/packages/server/tests/node-bridge.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 
+import { markBufferedResponse } from "../src/buffered-response.js";
 import { listenFetch, type ListenFetchResult } from "./helpers/listen-fetch.js";
 
 describe("Node response bridge", () => {
@@ -12,7 +13,9 @@ describe("Node response bridge", () => {
 
   it("serves buffered JSON responses intact", async () => {
     listener = await listenFetch(async () =>
-      Response.json({ jsonrpc: "2.0", id: 1, result: { ok: true } })
+      markBufferedResponse(
+        Response.json({ jsonrpc: "2.0", id: 1, result: { ok: true } })
+      )
     );
 
     const response = await fetch(listener.url);
@@ -22,6 +25,48 @@ describe("Node response bridge", () => {
       jsonrpc: "2.0",
       id: 1,
       result: { ok: true },
+    });
+  });
+
+  it("streams unmarked JSON responses without waiting for completion", async () => {
+    const encoder = new TextEncoder();
+    let controller: ReadableStreamDefaultController<Uint8Array> | undefined;
+    listener = await listenFetch(async () => {
+      const body = new ReadableStream<Uint8Array>({
+        start(streamController) {
+          controller = streamController;
+          streamController.enqueue(encoder.encode('{"first":'));
+        },
+      });
+      return new Response(body, {
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    const responsePromise = fetch(listener.url);
+    const outcome = await Promise.race([
+      responsePromise.then(() => "response" as const),
+      new Promise<"timeout">((resolve) =>
+        setTimeout(() => resolve("timeout"), 250)
+      ),
+    ]);
+    if (outcome === "timeout") {
+      controller?.close();
+    }
+    expect(outcome).toBe("response");
+
+    const response = await responsePromise;
+    const reader = response.body!.getReader();
+    const first = await reader.read();
+    expect(new TextDecoder().decode(first.value)).toBe('{"first":');
+
+    controller?.enqueue(encoder.encode("true}"));
+    controller?.close();
+    const second = await reader.read();
+    expect(new TextDecoder().decode(second.value)).toBe("true}");
+    await expect(reader.read()).resolves.toEqual({
+      done: true,
+      value: undefined,
     });
   });
 

--- a/libraries/typescript/packages/server/tests/node-bridge.test.ts
+++ b/libraries/typescript/packages/server/tests/node-bridge.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { listenFetch, type ListenFetchResult } from "./helpers/listen-fetch.js";
+
+describe("Node response bridge", () => {
+  let listener: ListenFetchResult | undefined;
+
+  afterEach(async () => {
+    await listener?.close();
+    listener = undefined;
+  });
+
+  it("serves buffered JSON responses intact", async () => {
+    listener = await listenFetch(async () =>
+      Response.json({ jsonrpc: "2.0", id: 1, result: { ok: true } })
+    );
+
+    const response = await fetch(listener.url);
+
+    expect(response.headers.get("content-type")).toContain("application/json");
+    await expect(response.json()).resolves.toEqual({
+      jsonrpc: "2.0",
+      id: 1,
+      result: { ok: true },
+    });
+  });
+
+  it("preserves streaming responses", async () => {
+    const encoder = new TextEncoder();
+    listener = await listenFetch(async () => {
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(encoder.encode("data: first\n\n"));
+          controller.enqueue(encoder.encode("data: second\n\n"));
+          controller.close();
+        },
+      });
+      return new Response(body, {
+        headers: { "content-type": "text/event-stream" },
+      });
+    });
+
+    const response = await fetch(listener.url);
+
+    expect(response.headers.get("content-type")).toBe("text/event-stream");
+    await expect(response.text()).resolves.toBe(
+      "data: first\n\ndata: second\n\n"
+    );
+  });
+});

--- a/libraries/typescript/packages/server/tests/sdk-jsonrpc-guards.test.ts
+++ b/libraries/typescript/packages/server/tests/sdk-jsonrpc-guards.test.ts
@@ -1,0 +1,44 @@
+import {
+  isJSONRPCErrorResponse,
+  isJSONRPCResultResponse,
+} from "@modelcontextprotocol/server";
+import { describe, expect, it } from "vitest";
+
+describe("patched SDK JSON-RPC response guards", () => {
+  it("accepts valid result and error responses", () => {
+    expect(
+      isJSONRPCResultResponse({
+        jsonrpc: "2.0",
+        id: 1,
+        result: { ok: true },
+      })
+    ).toBe(true);
+    expect(
+      isJSONRPCErrorResponse({
+        jsonrpc: "2.0",
+        id: "request-1",
+        error: { code: -32600, message: "Invalid Request" },
+      })
+    ).toBe(true);
+  });
+
+  it("rejects requests, notifications, primitives, and malformed responses", () => {
+    const values = [
+      undefined,
+      null,
+      1,
+      "response",
+      [],
+      { jsonrpc: "2.0", id: 1, method: "tools/call", params: {} },
+      { jsonrpc: "2.0", method: "notifications/initialized" },
+      { jsonrpc: "2.0", id: 1 },
+      { jsonrpc: "2.0", id: 1, result: undefined },
+      { jsonrpc: "2.0", id: 1, error: { code: "bad", message: "no" } },
+    ];
+
+    for (const value of values) {
+      expect(isJSONRPCResultResponse(value)).toBe(false);
+      expect(isJSONRPCErrorResponse(value)).toBe(false);
+    }
+  });
+});

--- a/libraries/typescript/packages/server/tsup.config.ts
+++ b/libraries/typescript/packages/server/tsup.config.ts
@@ -77,11 +77,12 @@ export default defineConfig([
     splitting: false,
     sourcemap: false,
     clean: false,
-    external: ["@mcp-use/client", "@mcp-use/cli", "zod"],
+    external: ["@mcp-use/client", "@mcp-use/cli"],
     noExternal: [
       "hono",
       "@modelcontextprotocol/core",
       "@modelcontextprotocol/server",
+      "zod",
     ],
     define: packageVersionDefine,
     esbuildOptions(options) {

--- a/libraries/typescript/packages/server/tsup.config.ts
+++ b/libraries/typescript/packages/server/tsup.config.ts
@@ -5,6 +5,20 @@ const frameworkPackage = JSON.parse(
   readFileSync(new URL("./package.json", import.meta.url), "utf8")
 ) as { version: string };
 
+const packageVersionDefine = {
+  __MCP_USE_PACKAGE_VERSION__: JSON.stringify(frameworkPackage.version),
+};
+
+function minifyFrameworkOutput(options: {
+  minifySyntax?: boolean;
+  minifyWhitespace?: boolean;
+  minifyIdentifiers?: boolean;
+}): void {
+  options.minifySyntax = true;
+  options.minifyWhitespace = true;
+  options.minifyIdentifiers = false;
+}
+
 export default defineConfig([
   {
     entry: {
@@ -34,6 +48,8 @@ export default defineConfig([
       // commands to the separately installed @mcp-use/cli package.
       bin: "src/bin.ts",
       "node-bridge": "src/node-bridge.ts",
+      "internal/node-http": "src/node-http.ts",
+      "internal/node-http-unavailable": "src/node-http-unavailable.ts",
       "next/index": "src/next/index.ts",
     },
     // ESM-only: the v2 @modelcontextprotocol/* packages ship no CJS entry, so a
@@ -44,14 +60,36 @@ export default defineConfig([
     splitting: true,
     sourcemap: false,
     clean: true,
-    external: ["@mcp-use/client", "@mcp-use/cli"],
-    define: {
-      __MCP_USE_PACKAGE_VERSION__: JSON.stringify(frameworkPackage.version),
+    external: ["@mcp-use/client", "@mcp-use/cli", "#mcp-use-node-http"],
+    define: packageVersionDefine,
+    esbuildOptions: minifyFrameworkOutput,
+  },
+  // Node gets a self-contained root bundle. Inlining Hono and the v2 SDK
+  // removes module-linking overhead from cold process starts, while the
+  // generic root above stays split and free of Node builtins for Workers.
+  {
+    entry: {
+      "index-node": "src/index.ts",
     },
+    format: ["esm"],
+    target: "node22",
+    dts: false,
+    splitting: false,
+    sourcemap: false,
+    clean: false,
+    external: ["@mcp-use/client", "@mcp-use/cli", "zod"],
+    noExternal: [
+      "hono",
+      "@modelcontextprotocol/core",
+      "@modelcontextprotocol/server",
+    ],
+    define: packageVersionDefine,
     esbuildOptions(options) {
-      options.minifySyntax = true;
-      options.minifyWhitespace = true;
-      options.minifyIdentifiers = false;
+      minifyFrameworkOutput(options);
+      options.alias = {
+        ...options.alias,
+        "#mcp-use-node-http": "node:http",
+      };
     },
   },
   // Deprecated v1 bridge. Uses splitting so compat-v1.js stays a thin entry,
@@ -68,7 +106,7 @@ export default defineConfig([
     minify: true,
     sourcemap: false,
     clean: false,
-    external: ["@mcp-use/client", "@mcp-use/cli"],
+    external: ["@mcp-use/client", "@mcp-use/cli", "#mcp-use-node-http"],
   },
   // Browser-only view runtime (`mcp-use/react`). Must not be reachable
   // from the `.` export or `bin` graphs — same invariant as the cli chunk above.
@@ -83,9 +121,7 @@ export default defineConfig([
     splitting: false,
     sourcemap: false,
     clean: false,
-    define: {
-      __MCP_USE_PACKAGE_VERSION__: JSON.stringify(frameworkPackage.version),
-    },
+    define: packageVersionDefine,
     external: [
       "react",
       "react-dom",

--- a/libraries/typescript/patches/@modelcontextprotocol__server@2.0.0-beta.5.patch
+++ b/libraries/typescript/patches/@modelcontextprotocol__server@2.0.0-beta.5.patch
@@ -1,0 +1,42 @@
+diff --git a/dist/src-BX_fm-dB.cjs b/dist/src-BX_fm-dB.cjs
+index e972f8f41d00c2bda03237e0d0667b2d0f7da0d9..a1adb82b5d151ebe48f75e09004b5e3410f15e52 100644
+--- a/dist/src-BX_fm-dB.cjs
++++ b/dist/src-BX_fm-dB.cjs
+@@ -4419,14 +4419,14 @@ const isJSONRPCNotification = (value) => _modelcontextprotocol_core_internal.JSO
+ *
+ * @returns True if the value is a valid {@linkcode JSONRPCResultResponse}, false otherwise.
+ */
+-const isJSONRPCResultResponse = (value) => _modelcontextprotocol_core_internal.JSONRPCResultResponseSchema.safeParse(value).success;
++const isJSONRPCResultResponse = (value) => typeof value === "object" && value !== null && Object.hasOwn(value, "result") && _modelcontextprotocol_core_internal.JSONRPCResultResponseSchema.safeParse(value).success;
+ /**
+ * Checks if a value is a valid {@linkcode JSONRPCErrorResponse}.
+ * @param value - The value to check.
+ *
+ * @returns True if the value is a valid {@linkcode JSONRPCErrorResponse}, false otherwise.
+ */
+-const isJSONRPCErrorResponse = (value) => _modelcontextprotocol_core_internal.JSONRPCErrorResponseSchema.safeParse(value).success;
++const isJSONRPCErrorResponse = (value) => typeof value === "object" && value !== null && Object.hasOwn(value, "error") && _modelcontextprotocol_core_internal.JSONRPCErrorResponseSchema.safeParse(value).success;
+ /**
+ * Checks if a value is a valid {@linkcode JSONRPCResponse} (either a result or error response).
+ * @param value - The value to check.
+diff --git a/dist/src-D86MbS1I.mjs b/dist/src-D86MbS1I.mjs
+index fecce52cb9f86ea7c2a43e696781785f1ac73470..e1f893308afc4008518a512c3fb51dc2801dbc2d 100644
+--- a/dist/src-D86MbS1I.mjs
++++ b/dist/src-D86MbS1I.mjs
+@@ -4418,14 +4418,14 @@ const isJSONRPCNotification = (value) => JSONRPCNotificationSchema.safeParse(val
+ *
+ * @returns True if the value is a valid {@linkcode JSONRPCResultResponse}, false otherwise.
+ */
+-const isJSONRPCResultResponse = (value) => JSONRPCResultResponseSchema.safeParse(value).success;
++const isJSONRPCResultResponse = (value) => typeof value === "object" && value !== null && Object.hasOwn(value, "result") && JSONRPCResultResponseSchema.safeParse(value).success;
+ /**
+ * Checks if a value is a valid {@linkcode JSONRPCErrorResponse}.
+ * @param value - The value to check.
+ *
+ * @returns True if the value is a valid {@linkcode JSONRPCErrorResponse}, false otherwise.
+ */
+-const isJSONRPCErrorResponse = (value) => JSONRPCErrorResponseSchema.safeParse(value).success;
++const isJSONRPCErrorResponse = (value) => typeof value === "object" && value !== null && Object.hasOwn(value, "error") && JSONRPCErrorResponseSchema.safeParse(value).success;
+ /**
+ * Checks if a value is a valid {@linkcode JSONRPCResponse} (either a result or error response).
+ * @param value - The value to check.

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -66,6 +66,9 @@ overrides:
   nanoid@<3.3.8: ^3.3.8
   nanoid@>=4.0.0 <5.0.9: ^5.0.9
 
+patchedDependencies:
+  '@modelcontextprotocol/server@2.0.0-beta.5': 48cb4d93becd715ebef39d3c2e439caa77bb77a36a299c0798d49e5f816c6c11
+
 importers:
 
   .:
@@ -214,7 +217,7 @@ importers:
     devDependencies:
       '@modelcontextprotocol/server':
         specifier: 2.0.0-beta.5
-        version: 2.0.0-beta.5
+        version: 2.0.0-beta.5(patch_hash=48cb4d93becd715ebef39d3c2e439caa77bb77a36a299c0798d49e5f816c6c11)
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
@@ -235,7 +238,7 @@ importers:
         version: 2.0.0-beta.5
       '@modelcontextprotocol/ext-apps':
         specifier: npm:@mcp-use/ext-apps@1.7.4-pr720.0
-        version: '@mcp-use/ext-apps@1.7.4-pr720.0(@modelcontextprotocol/client@2.0.0-beta.5)(@modelcontextprotocol/core@2.0.0-beta.5)(@modelcontextprotocol/server@2.0.0-beta.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)'
+        version: '@mcp-use/ext-apps@1.7.4-pr720.0(@modelcontextprotocol/client@2.0.0-beta.5)(@modelcontextprotocol/core@2.0.0-beta.5)(@modelcontextprotocol/server@2.0.0-beta.5(patch_hash=48cb4d93becd715ebef39d3c2e439caa77bb77a36a299c0798d49e5f816c6c11))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)'
     devDependencies:
       '@e2b/code-interpreter':
         specifier: ^2.6.1
@@ -521,10 +524,10 @@ importers:
         version: 2.0.0-beta.5
       '@modelcontextprotocol/ext-apps':
         specifier: npm:@mcp-use/ext-apps@1.7.4-pr720.0
-        version: '@mcp-use/ext-apps@1.7.4-pr720.0(@modelcontextprotocol/client@2.0.0-beta.5)(@modelcontextprotocol/core@2.0.0-beta.5)(@modelcontextprotocol/server@2.0.0-beta.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)'
+        version: '@mcp-use/ext-apps@1.7.4-pr720.0(@modelcontextprotocol/client@2.0.0-beta.5)(@modelcontextprotocol/core@2.0.0-beta.5)(@modelcontextprotocol/server@2.0.0-beta.5(patch_hash=48cb4d93becd715ebef39d3c2e439caa77bb77a36a299c0798d49e5f816c6c11))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)'
       '@modelcontextprotocol/server':
         specifier: 2.0.0-beta.5
-        version: 2.0.0-beta.5
+        version: 2.0.0-beta.5(patch_hash=48cb4d93becd715ebef39d3c2e439caa77bb77a36a299c0798d49e5f816c6c11)
       hono:
         specifier: '>=4.12.27'
         version: 4.12.27
@@ -8711,14 +8714,14 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mcp-use/ext-apps@1.7.4-pr720.0(@modelcontextprotocol/client@2.0.0-beta.5)(@modelcontextprotocol/core@2.0.0-beta.5)(@modelcontextprotocol/server@2.0.0-beta.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)':
+  '@mcp-use/ext-apps@1.7.4-pr720.0(@modelcontextprotocol/client@2.0.0-beta.5)(@modelcontextprotocol/core@2.0.0-beta.5)(@modelcontextprotocol/server@2.0.0-beta.5(patch_hash=48cb4d93becd715ebef39d3c2e439caa77bb77a36a299c0798d49e5f816c6c11))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)':
     dependencies:
       '@modelcontextprotocol/core': 2.0.0-beta.5
       '@standard-schema/spec': 1.1.0
       zod: 4.4.3
     optionalDependencies:
       '@modelcontextprotocol/client': 2.0.0-beta.5
-      '@modelcontextprotocol/server': 2.0.0-beta.5
+      '@modelcontextprotocol/server': 2.0.0-beta.5(patch_hash=48cb4d93becd715ebef39d3c2e439caa77bb77a36a299c0798d49e5f816c6c11)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
@@ -8753,7 +8756,7 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
-  '@modelcontextprotocol/server@2.0.0-beta.5':
+  '@modelcontextprotocol/server@2.0.0-beta.5(patch_hash=48cb4d93becd715ebef39d3c2e439caa77bb77a36a299c0798d49e5f816c6c11)':
     dependencies:
       '@modelcontextprotocol/core': 2.0.0-beta.5
       zod: 4.4.3

--- a/libraries/typescript/pnpm-workspace.yaml
+++ b/libraries/typescript/pnpm-workspace.yaml
@@ -103,3 +103,6 @@ allowBuilds:
   # sharp dependency must not run a native build in CI.
   sharp: false
   unrs-resolver: true
+
+patchedDependencies:
+  "@modelcontextprotocol/server@2.0.0-beta.5": patches/@modelcontextprotocol__server@2.0.0-beta.5.patch


### PR DESCRIPTION
## Summary

- add a conditioned, self-contained Node root bundle while preserving the Node-free workerd/browser entry and the deprecated v1 compatibility build
- avoid eager JOSE loading on the canonical server import path
- write buffered JSON responses directly while preserving the existing SSE streaming path
- skip duplicate middleware/result work only when telemetry is disabled and no middleware or observers are registered
- add a narrow patch to the Official SDK v2 JSON-RPC response guards that checks required keys before retaining the original Zod validation
- add a patch changeset for `mcp-use`

## Why

CPU profiling and controlled MCP Drill runs showed cold module linking, buffered-response bridging, and repeated broad JSON-RPC guard validation on the hot path. The retained changes reduce those costs without bypassing request validation, tool input validation, middleware transformations, OAuth behavior, or streaming semantics.

In the expanded local benchmark, mcp-use v2 was the fastest Node v2 implementation tested at a median 9,694.5 ops/s and the fastest Node cold launch at 73.842 ms. This is deliberately not an overall-win claim: tmcp led throughput and rmcp led tail latency and cross-runtime process launch. Results are localhost framework-overhead measurements, not universal production throughput claims.

## Validation

Run after rebasing onto the latest `origin/beta`:

- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm --filter mcp-use test:run`: 57 files, 609 tests passed
- `pnpm format:check`
- `pnpm lint`
- `pnpm test:release-versioning`: 4 tests passed
- `pnpm --filter @mcp-use/client test:run`: 46 files, 274 tests passed
- `pnpm --filter @mcp-use/agent test:unit`: 15 files, 130 passed, 1 skipped
- `pnpm verify:examples`: all deterministic examples passed; credential/deployment-dependent live checks skipped by the verifier as designed
- `pnpm changeset status --since=origin/beta`
- `git diff --check`

The ignored generated `test_app` workspace and verifier-generated `mcp-env.d.ts` artifacts were excluded from the branch and PR diff.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce Node startup and request overhead for the v2 server by shipping a self-contained Node bundle and adding a safe buffered-response fast path for JSON replies. Streaming, middleware behavior, and protocol validation stay the same; edge/browser builds remain Node-free.

- **Performance**
  - Add a safe fast path in the Node bridge: detect SDK-owned buffered JSON and write it directly; keep SSE and genuinely streaming JSON untouched, and handle aborts gracefully.
  - Skip the middleware pipeline for `tools/call` when none are registered; bypass usage capture when disabled.
  - Defer JOSE loading on the main server path.

- **Dependencies**
  - Ship a self-contained Node entry via the `node` export (`index-node.js`) that inlines `hono` and the v2 SDK; keep `workerd`/`browser` exports and the v1 compatibility build.
  - Add a package `imports` map for `#mcp-use-node-http` and update build/tests to resolve it (`node:http` in Node, guarded stub elsewhere).
  - Patch `@modelcontextprotocol/server@2.0.0-beta.5` JSON-RPC response guards to check required keys before Zod.

<sup>Written for commit fbf3e0602a5812f58c1977268648344e7f062d83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

