### PR TITLE
fix(release): account for optimized Node bundle

### DIFF
--- a/libraries/typescript/.changeset/release-node-bundle-budget.md
+++ b/libraries/typescript/.changeset/release-node-bundle-budget.md
@@ -1,0 +1,7 @@
+---
+"mcp-use": patch
+---
+
+Ship the self-contained, Node-optimized runtime entry with package-size
+verification calibrated for the additional Node bundle and coverage that
+prevents undeclared runtime dependencies from escaping the bundle.

--- a/libraries/typescript/packages/server/tests/budgets/cli-budget.test.ts
+++ b/libraries/typescript/packages/server/tests/budgets/cli-budget.test.ts
@@ -2,6 +2,7 @@ import { isBuiltin } from "node:module";
 import { readdir, readFile, stat } from "node:fs/promises";
 import { init, parse } from "es-module-lexer";
 import { describe, expect, it } from "vitest";
+import packageJson from "../../package.json";
 
 const DIST = new URL("../../dist/", import.meta.url);
 const CLI_DIST = new URL("../../../cli/dist/", import.meta.url);
@@ -108,7 +109,33 @@ describe("published CLI boundaries", () => {
   it("keeps the unpacked framework artifact below five MiB", async () => {
     expect(await directoryBytes(DIST)).toBeLessThanOrEqual(5 * 1024 * 1024);
   });
+
+  it("declares every external package used by the Node bundle", async () => {
+    const graph = await buildStaticGraph(new URL("index-node.js", DIST));
+    const declaredRuntimePackages = new Set([
+      ...Object.keys(packageJson.dependencies),
+      ...Object.keys(packageJson.peerDependencies),
+    ]);
+    const undeclared = [...graph.staticPackages].filter(
+      (specifier) =>
+        !isBuiltin(specifier) &&
+        !declaredRuntimePackages.has(packageName(specifier))
+    );
+
+    expect(undeclared).toEqual([]);
+    expect(graph.staticPackages).not.toContain("zod");
+    expect(graph.staticPackages).not.toContain("zod/v4");
+  });
 });
+
+function packageName(specifier: string): string {
+  if (!specifier.startsWith("@")) {
+    const separator = specifier.indexOf("/");
+    return separator === -1 ? specifier : specifier.slice(0, separator);
+  }
+  const separator = specifier.indexOf("/", specifier.indexOf("/") + 1);
+  return separator === -1 ? specifier : specifier.slice(0, separator);
+}
 
 function expectForbiddenPackages(
   graph: ModuleGraph,

--- a/libraries/typescript/scripts/verify-beta-packs.mjs
+++ b/libraries/typescript/scripts/verify-beta-packs.mjs
@@ -131,9 +131,11 @@ function verifyFrameworkPack(packed, manifest, files) {
     if (manifest.dependencies?.[dependency] === undefined)
       throw new Error(`mcp-use must depend on ${dependency}`);
   }
-  if (packedBytes > 250_000)
+  // The package includes a Node-optimized root alongside the edge-safe graph.
+  // Keep enough headroom for small SDK changes without allowing silent growth.
+  if (packedBytes > 375_000)
     throw new Error(`mcp-use packed budget exceeded: ${packedBytes} bytes`);
-  if (unpackedBytes > 1_000_000)
+  if (unpackedBytes > 1_500_000)
     throw new Error(`mcp-use unpacked budget exceeded: ${unpackedBytes} bytes`);
   if (files.size > 150)
     throw new Error(`mcp-use file budget exceeded: ${files.size} files`);


### PR DESCRIPTION
## Summary

- keep Zod bundled in the optimized Node entry; externalizing it would reintroduce strict-layout risk unless declared directly and measured about 19 ms slower in a 30-run local cold-import comparison
- update the framework tarball budgets to 375 KB packed and 1.5 MB unpacked for the intentionally duplicated Node-optimized graph
- add a Node-bundle boundary test that rejects undeclared external runtime packages and verifies Zod remains bundled

## Evidence

- failed release artifact: 352,786 bytes packed
- current local artifact: 353,493 bytes packed / 1,392,636 bytes unpacked / 125 files
- bundled Zod cold import median: 56.1 ms
- external Zod cold import median: 74.8 ms

## Verification

- `pnpm build`
- `pnpm verify:beta-packs`
- `pnpm test:beta-release`
- `pnpm --filter mcp-use test:run` (57 files, 613 tests)
- `pnpm format:check`
- `pnpm lint`
- `pnpm knip`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures the Node-optimized bundle keeps `zod` bundled and updates `mcp-use` release budgets for the duplicated graph. Prevents strict-layout issues, keeps cold imports fast, and blocks undeclared runtime deps.

- **Bug Fixes**
  - Keep `zod` bundled in the Node entry and add a boundary test that rejects undeclared externals; verifies `zod` is not in the external graph.
  - Raise `mcp-use` pack limits to 375 KB (packed) and 1.5 MB (unpacked); keep the 150-file cap and update pack verification to enforce the new budgets.
  - Add a changeset to publish a patch for `mcp-use` that documents the Node-optimized entry and calibrated size checks.

<sup>Written for commit 1dd88c20d0c98b73799aadf75fd820c6ac83bb2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

