### PR TITLE
Fix Inspector zero-dependency bundle

### DIFF
--- a/libraries/typescript/.changeset/tidy-inspector-runtime.md
+++ b/libraries/typescript/.changeset/tidy-inspector-runtime.md
@@ -1,0 +1,8 @@
+---
+"@mcp-use/inspector": patch
+"@mcp-use/client": patch
+---
+
+Expose the dependency-free sandbox document builder as a focused client
+subpath and bundle it into the Inspector's Node entry so the zero-dependency
+Inspector package loads in clean installations.

--- a/libraries/typescript/packages/client/package.json
+++ b/libraries/typescript/packages/client/package.json
@@ -39,6 +39,10 @@
     "./react": {
       "types": "./dist/react/index.d.ts",
       "import": "./dist/react/index.js"
+    },
+    "./sandbox": {
+      "types": "./dist/sandbox.d.ts",
+      "import": "./dist/sandbox.js"
     }
   },
   "module": "./dist/index.js",

--- a/libraries/typescript/packages/client/src/sandbox.ts
+++ b/libraries/typescript/packages/client/src/sandbox.ts
@@ -1,0 +1,1 @@
+export { buildSandboxProxyBlobHtml } from "./react/view/sandbox-blob-url.js";

--- a/libraries/typescript/packages/client/tsup.config.ts
+++ b/libraries/typescript/packages/client/tsup.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     index: "src/index.ts",
     "index-browser": "src/index-browser.ts",
     "react/index": "src/react/index.ts",
+    sandbox: "src/sandbox.ts",
   },
   // ESM-only: @mcp-use/client targets Node 22+ ESM natively and the package exports
   // map has no "require" condition, so CJS output is unnecessary.

--- a/libraries/typescript/packages/inspector/src/server/inspector-shell.ts
+++ b/libraries/typescript/packages/inspector/src/server/inspector-shell.ts
@@ -2,7 +2,7 @@ import type { Context, Hono } from "hono";
 import { renderInspectorFaviconLinks } from "./favicon-links.js";
 import { registerInspectorStaticAssets } from "./static-assets.js";
 import { getInspectorVersion } from "./version.js";
-import { buildSandboxProxyBlobHtml } from "@mcp-use/client/react";
+import { buildSandboxProxyBlobHtml } from "@mcp-use/client/sandbox";
 
 const INSPECTOR_VERSION = getInspectorVersion();
 type InspectorMode = "standalone" | "embedded" | "cloud";

--- a/libraries/typescript/packages/inspector/tsup.server.ts
+++ b/libraries/typescript/packages/inspector/tsup.server.ts
@@ -4,6 +4,7 @@ import { defineConfig } from "tsup";
 const bundledServerDependencies = [
   "hono",
   "@hono/node-server",
+  "@mcp-use/client",
   "open",
   "rate-limiter-flexible",
 ];

--- a/libraries/typescript/scripts/verify-beta-packs.mjs
+++ b/libraries/typescript/scripts/verify-beta-packs.mjs
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import { mkdtempSync, mkdirSync, readdirSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 
 const root = process.cwd();
 const packages = [
@@ -87,7 +88,10 @@ try {
 }
 
 function verifyInspectorPack(packed, manifest, files) {
-  const { packedBytes, unpackedBytes } = packMetrics(packed, "inspector");
+  const { packedBytes, unpackedBytes, unpackedPackage } = packMetrics(
+    packed,
+    "inspector"
+  );
 
   if (Object.keys(manifest.dependencies ?? {}).length !== 0)
     throw new Error("@mcp-use/inspector must have zero regular dependencies");
@@ -99,6 +103,18 @@ function verifyInspectorPack(packed, manifest, files) {
     );
   if (files.size > 40)
     throw new Error(`Inspector file budget exceeded: ${files.size} files`);
+
+  const entry = pathToFileURL(
+    join(unpackedPackage, "dist/server/index.js")
+  ).href;
+  run(process.execPath, [
+    "--input-type=module",
+    "--eval",
+    `const inspector = await import(${JSON.stringify(entry)});
+if (typeof inspector.mountInspector !== "function") {
+  throw new Error("packed Inspector does not export mountInspector()");
+}`,
+  ]);
 }
 
 function verifyCliPack(packed, manifest, files) {
@@ -151,6 +167,7 @@ function packMetrics(packed, label) {
   return {
     packedBytes,
     unpackedBytes: directorySize(join(unpackDirectory, "package")),
+    unpackedPackage: join(unpackDirectory, "package"),
   };
 }
 


### PR DESCRIPTION
## What changed

- expose the dependency-free sandbox document builder through a focused `@mcp-use/client/sandbox` subpath
- bundle that subpath into the Inspector Node entry
- import the packed Inspector entry during beta pack verification so workspace dependencies cannot mask missing runtime imports
- add patch changesets for `@mcp-use/client` and `@mcp-use/inspector`

## Why

The optimized Inspector package moved its runtime packages to optional peers, but its Node entry retained an external import of `@mcp-use/client/react`. Fresh generated apps therefore reported that the built-in Inspector was unavailable even though the Inspector package was installed.

The focused subpath keeps the sandbox implementation shared while preserving the Inspector's zero-dependency and package-size constraints.

## Validation

- `pnpm build`
- `pnpm verify:beta-packs`
- `pnpm --filter @mcp-use/inspector test:unit -- --run` (158 tests)
- isolated packed-artifact import: `mountInspector` loads without installed dependencies
- packed Inspector: 1,079,970 bytes, within the 1,100,000-byte budget

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Inspector’s zero-dependency Node bundle by exposing a dependency-free sandbox subpath in `@mcp-use/client` and bundling it into the Inspector entry. Fresh installs can now load the built-in Inspector without extra dependencies, and the pack check imports the built artifact to prevent regressions.

- **Bug Fixes**
  - Added `@mcp-use/client/sandbox` subpath that exports the sandbox document builder.
  - Switched Inspector to import from `@mcp-use/client/sandbox` instead of `@mcp-use/client/react`.
  - Bundled `@mcp-use/client` into the Inspector server build to keep zero runtime deps.
  - Updated beta pack verification to import `dist/server/index.js` and assert `mountInspector()` is present.

<sup>Written for commit be2dd8e5593009703b1108ecfbf1eb704647cad7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

