### PR TITLE
docs: split TypeScript V1 and V2 documentation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -15,6 +15,11 @@
     }
   },
   "favicon": "/favicon.svg",
+  "banner": {
+    "content": "mcp-use v2 is in beta and the API is subject to change.",
+    "dismissible": false,
+    "type": "warning"
+  },
   "contextual": {
     "options": [
       "copy",
@@ -63,250 +68,428 @@
       },
       {
         "product": "TypeScript SDK",
-        "description": "TypeScript SDK description",
+        "description": "TypeScript SDK documentation for V1 and V2",
         "icon": "/images/typescriptlogo.svg",
-        "tabs": [
+        "versions": [
           {
-            "tab": "Docs",
-            "icon": "book",
-            "groups": [
+            "version": "V1",
+            "default": true,
+            "tabs": [
               {
-                "group": "Get Started",
-                "pages": [
-                  "typescript/getting-started/welcome",
-                  "typescript/getting-started/quickstart",
-                  "typescript/getting-started/installation",
-                  "typescript/changelog/changelog",
-                  "inspector/changelog"
-                ]
-              },
-              {
-                "group": "MCP Server",
-                "icon": "server",
-                "pages": [
-                  "typescript/server/index",
-                  "typescript/server/examples",
+                "tab": "Docs",
+                "icon": "book",
+                "groups": [
                   {
-                    "group": "Core Components",
-                    "icon": "box",
+                    "group": "Get Started",
                     "pages": [
-                      "typescript/server/tools",
-                      "typescript/server/resources",
-                      "typescript/server/prompts",
-                      "typescript/server/response-helpers"
+                      "typescript/getting-started/welcome",
+                      "typescript/getting-started/quickstart",
+                      "typescript/getting-started/installation",
+                      "typescript/changelog/changelog",
+                      "inspector/changelog"
                     ]
                   },
                   {
-                    "group": "Session Management",
-                    "icon": "key-round",
+                    "group": "MCP Server",
+                    "icon": "server",
                     "pages": [
-                      "typescript/server/session-management/memory-storage",
-                      "typescript/server/session-management/filesystem-storage",
-                      "typescript/server/session-management/redis-storage"
-                    ]
-                  },
-                  {
-                    "group": "Authorization",
-                    "icon": "shield",
-                    "pages": [
-                      "typescript/server/authentication/index",
-                      "typescript/server/authentication/user-context",
+                      "typescript/server/index",
+                      "typescript/server/examples",
                       {
-                        "group": "OAuth Providers",
-                        "icon": "plug",
+                        "group": "Core Components",
+                        "icon": "box",
                         "pages": [
-                          "typescript/server/authentication/providers/auth0",
-                          "typescript/server/authentication/providers/better-auth",
-                          "typescript/server/authentication/providers/clerk",
-                          "typescript/server/authentication/providers/keycloak",
-                          "typescript/server/authentication/providers/supabase",
-                          "typescript/server/authentication/providers/workos",
-                          "typescript/server/authentication/providers/oauth-proxy",
-                          "typescript/server/authentication/providers/custom"
+                          "typescript/server/tools",
+                          "typescript/server/resources",
+                          "typescript/server/prompts",
+                          "typescript/server/response-helpers"
+                        ]
+                      },
+                      {
+                        "group": "Session Management",
+                        "icon": "key-round",
+                        "pages": [
+                          "typescript/server/session-management/memory-storage",
+                          "typescript/server/session-management/filesystem-storage",
+                          "typescript/server/session-management/redis-storage"
+                        ]
+                      },
+                      {
+                        "group": "Authorization",
+                        "icon": "shield",
+                        "pages": [
+                          "typescript/server/authentication/index",
+                          "typescript/server/authentication/user-context",
+                          {
+                            "group": "OAuth Providers",
+                            "icon": "plug",
+                            "pages": [
+                              "typescript/server/authentication/providers/auth0",
+                              "typescript/server/authentication/providers/better-auth",
+                              "typescript/server/authentication/providers/clerk",
+                              "typescript/server/authentication/providers/keycloak",
+                              "typescript/server/authentication/providers/supabase",
+                              "typescript/server/authentication/providers/workos",
+                              "typescript/server/authentication/providers/oauth-proxy",
+                              "typescript/server/authentication/providers/custom"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "group": "Deployment",
+                        "icon": "rocket",
+                        "pages": [
+                          "typescript/server/deployment/mcp-use",
+                          "typescript/server/deployment/google",
+                          "typescript/server/deployment/supabase"
+                        ]
+                      },
+                      "typescript/server/proxy",
+                      "typescript/server/openapi",
+                      "typescript/server/nextjs-drop-in",
+                      {
+                        "group": "Advanced Features",
+                        "icon": "sparkle",
+                        "pages": [
+                          "typescript/server/middleware",
+                          "typescript/server/elicitation",
+                          "typescript/server/sampling",
+                          "typescript/server/subscriptions",
+                          "typescript/server/notifications"
                         ]
                       }
                     ]
                   },
                   {
-                    "group": "Deployment",
-                    "icon": "rocket",
+                    "group": "MCP Apps",
+                    "icon": "app-window-mac",
                     "pages": [
-                      "typescript/server/deployment/mcp-use",
-                      "typescript/server/deployment/google",
-                      "typescript/server/deployment/supabase"
+                      "typescript/mcp-apps",
+                      "typescript/mcp-apps/quickstart",
+                      "typescript/mcp-apps/widgets",
+                      "typescript/mcp-apps/model-context",
+                      "typescript/mcp-apps/interactivity",
+                      "typescript/mcp-apps/apps-sdk-compatibility",
+                      "typescript/mcp-apps/content-security-policy"
                     ]
                   },
-                  "typescript/server/proxy",
-                  "typescript/server/openapi",
-                  "typescript/server/nextjs-drop-in",
                   {
-                    "group": "Advanced Features",
-                    "icon": "sparkle",
+                    "group": "MCP Client",
+                    "icon": "router",
                     "pages": [
-                      "typescript/server/middleware",
-                      "typescript/server/elicitation",
-                      "typescript/server/sampling",
-                      "typescript/server/subscriptions",
-                      "typescript/server/notifications"
+                      "typescript/client/index",
+                      "typescript/client/environments",
+                      {
+                        "group": "Core Components",
+                        "icon": "box",
+                        "pages": [
+                          "typescript/client/tools",
+                          "typescript/client/resources",
+                          "typescript/client/prompts"
+                        ]
+                      },
+                      {
+                        "group": "Advanced Features",
+                        "icon": "sparkle",
+                        "pages": [
+                          "typescript/client/sampling",
+                          "typescript/client/elicitation",
+                          "typescript/client/completion",
+                          "typescript/client/notifications"
+                        ]
+                      },
+                      "typescript/client/authentication",
+                      "typescript/client/usemcp",
+                      "typescript/client/code-mode"
+                    ]
+                  },
+                  {
+                    "group": "MCP Agent",
+                    "icon": "brain",
+                    "pages": [
+                      "typescript/agent/index",
+                      "typescript/agent/llm-integration",
+                      "typescript/agent/memory-management",
+                      "typescript/agent/server-manager",
+                      "typescript/agent/structured-output",
+                      "typescript/agent/streaming",
+                      "typescript/agent/observability"
+                    ]
+                  },
+                  {
+                    "group": "Tooling",
+                    "icon": "wrench",
+                    "pages": [
+                      "typescript/tooling/client-cli",
+                      {
+                        "group": "Inspector",
+                        "icon": "bug-play",
+                        "pages": [
+                          "inspector/index",
+                          "inspector/cli",
+                          "inspector/connection-settings",
+                          "inspector/url-parameters",
+                          "inspector/keyboard-shortcuts",
+                          "inspector/command-palette",
+                          "inspector/integration",
+                          "inspector/self-hosting",
+                          "inspector/debugging-chatgpt-apps"
+                        ]
+                      },
+                      "tunneling/index"
                     ]
                   }
                 ]
               },
               {
-                "group": "MCP Apps",
-                "icon": "app-window-mac",
-                "pages": [
-                  "typescript/mcp-apps",
-                  "typescript/mcp-apps/quickstart",
-                  "typescript/mcp-apps/widgets",
-                  "typescript/mcp-apps/model-context",
-                  "typescript/mcp-apps/interactivity",
-                  "typescript/mcp-apps/apps-sdk-compatibility",
-                  "typescript/mcp-apps/content-security-policy"
-                ]
-              },
-              {
-                "group": "MCP Client",
-                "icon": "router",
-                "pages": [
-                  "typescript/client/index",
-                  "typescript/client/environments",
+                "tab": "API Reference",
+                "icon": "terminal",
+                "groups": [
                   {
-                    "group": "Core Components",
-                    "icon": "box",
+                    "group": "Overview",
                     "pages": [
-                      "typescript/client/tools",
-                      "typescript/client/resources",
-                      "typescript/client/prompts"
+                      "typescript/api-reference/overview",
+                      "typescript/api-reference/cli-reference"
                     ]
                   },
                   {
-                    "group": "Advanced Features",
-                    "icon": "sparkle",
+                    "group": "Server",
+                    "icon": "server",
                     "pages": [
-                      "typescript/client/sampling",
-                      "typescript/client/elicitation",
-                      "typescript/client/completion",
-                      "typescript/client/notifications"
+                      "typescript/api-reference/server/mcp-server",
+                      "typescript/api-reference/server/server-config",
+                      {
+                        "group": "Tools, resources & prompts",
+                        "icon": "box",
+                        "pages": [
+                          "typescript/api-reference/server/tools",
+                          "typescript/api-reference/server/resources",
+                          "typescript/api-reference/server/prompts"
+                        ]
+                      },
+                      "typescript/api-reference/server/tool-context",
+                      "typescript/api-reference/server/response-helpers",
+                      "typescript/api-reference/server/elicitation-schemas",
+                      {
+                        "group": "Authentication",
+                        "icon": "shield",
+                        "pages": [
+                          "typescript/api-reference/server/auth",
+                          "typescript/api-reference/server/auth-providers"
+                        ]
+                      },
+                      "typescript/api-reference/server/sessions",
+                      "typescript/api-reference/server/middleware",
+                      "typescript/api-reference/server/widgets"
                     ]
                   },
-                  "typescript/client/authentication",
-                  "typescript/client/usemcp",
-                  "typescript/client/code-mode"
-                ]
-              },
-              {
-                "group": "MCP Agent",
-                "icon": "brain",
-                "pages": [
-                  "typescript/agent/index",
-                  "typescript/agent/llm-integration",
-                  "typescript/agent/memory-management",
-                  "typescript/agent/server-manager",
-                  "typescript/agent/structured-output",
-                  "typescript/agent/streaming",
-                  "typescript/agent/observability"
-                ]
-              },
-              {
-                "group": "Tooling",
-                "icon": "wrench",
-                "pages": [
-                  "typescript/tooling/client-cli",
                   {
-                    "group": "Inspector",
-                    "icon": "bug-play",
+                    "group": "React",
+                    "icon": "atom",
                     "pages": [
-                      "inspector/index",
-                      "inspector/cli",
-                      "inspector/connection-settings",
-                      "inspector/url-parameters",
-                      "inspector/keyboard-shortcuts",
-                      "inspector/command-palette",
-                      "inspector/integration",
-                      "inspector/self-hosting",
-                      "inspector/debugging-chatgpt-apps"
+                      "typescript/api-reference/react/usewidget",
+                      "typescript/api-reference/react/usecalltool",
+                      "typescript/api-reference/react/usefiles",
+                      "typescript/api-reference/react/mcpuseprovider",
+                      "typescript/api-reference/react/widgetcontrols",
+                      "typescript/api-reference/react/themeprovider",
+                      "typescript/api-reference/react/errorboundary",
+                      "typescript/api-reference/react/image",
+                      "typescript/api-reference/react/modelcontext"
                     ]
                   },
-                  "tunneling/index"
+                  {
+                    "group": "Client",
+                    "icon": "router",
+                    "pages": [
+                      "typescript/api-reference/client/mcp-client",
+                      "typescript/api-reference/client/mcp-session",
+                      "typescript/api-reference/client/code-mode",
+                      "typescript/api-reference/client/react-client",
+                      "typescript/api-reference/client/inspector-chat-components"
+                    ]
+                  },
+                  {
+                    "group": "Agent",
+                    "icon": "brain",
+                    "pages": [
+                      "typescript/api-reference/agent/mcp-agent"
+                    ]
+                  }
                 ]
               }
             ]
           },
           {
-            "tab": "API Reference",
-            "icon": "terminal",
-            "groups": [
+            "version": "V2",
+            "tag": "Beta",
+            "tabs": [
               {
-                "group": "Overview",
-                "pages": [
-                  "typescript/api-reference/overview",
-                  "typescript/api-reference/cli-reference"
-                ]
-              },
-              {
-                "group": "Server",
-                "icon": "server",
-                "pages": [
-                  "typescript/api-reference/server/mcp-server",
-                  "typescript/api-reference/server/server-config",
+                "tab": "Docs",
+                "icon": "book",
+                "groups": [
                   {
-                    "group": "Tools, resources & prompts",
-                    "icon": "box",
+                    "group": "Get Started",
                     "pages": [
-                      "typescript/api-reference/server/tools",
-                      "typescript/api-reference/server/resources",
-                      "typescript/api-reference/server/prompts"
+                      "v2/typescript/getting-started/welcome",
+                      "v2/typescript/getting-started/quickstart"
                     ]
                   },
-                  "typescript/api-reference/server/tool-context",
-                  "typescript/api-reference/server/response-helpers",
-                  "typescript/api-reference/server/elicitation-schemas",
                   {
-                    "group": "Authentication",
-                    "icon": "shield",
+                    "group": "MCP Server",
+                    "icon": "server",
                     "pages": [
-                      "typescript/api-reference/server/auth",
-                      "typescript/api-reference/server/auth-providers"
+                      "v2/typescript/server/index",
+                      "v2/typescript/server/migration",
+                      "v2/typescript/server/examples",
+                      {
+                        "group": "Core Components",
+                        "icon": "box",
+                        "pages": [
+                          "v2/typescript/server/tools",
+                          "v2/typescript/server/resources",
+                          "v2/typescript/server/prompts"
+                        ]
+                      },
+                      {
+                        "group": "Authorization",
+                        "icon": "shield",
+                        "pages": [
+                          "v2/typescript/server/authentication/index",
+                          "v2/typescript/server/authentication/user-context",
+                          {
+                            "group": "OAuth Providers",
+                            "icon": "plug",
+                            "pages": [
+                              "v2/typescript/server/authentication/providers/auth0",
+                              "v2/typescript/server/authentication/providers/better-auth",
+                              "v2/typescript/server/authentication/providers/clerk",
+                              "v2/typescript/server/authentication/providers/keycloak",
+                              "v2/typescript/server/authentication/providers/supabase",
+                              "v2/typescript/server/authentication/providers/workos",
+                              "v2/typescript/server/authentication/providers/custom"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "group": "Deployment",
+                        "icon": "rocket",
+                        "pages": [
+                          "v2/typescript/server/deployment/mcp-use",
+                          "v2/typescript/server/deployment/google",
+                          "v2/typescript/server/deployment/supabase"
+                        ]
+                      },
+                      "v2/typescript/server/proxy",
+                      "v2/typescript/server/openapi",
+                      "v2/typescript/server/nextjs-drop-in",
+                      {
+                        "group": "Advanced Features",
+                        "icon": "sparkle",
+                        "pages": [
+                          "v2/typescript/server/middleware",
+                          "v2/typescript/server/elicitation",
+                          "v2/typescript/server/subscriptions",
+                          "v2/typescript/server/notifications"
+                        ]
+                      }
                     ]
                   },
-                  "typescript/api-reference/server/sessions",
-                  "typescript/api-reference/server/middleware",
-                  "typescript/api-reference/server/widgets"
+                  {
+                    "group": "MCP Apps",
+                    "icon": "app-window-mac",
+                    "pages": [
+                      "v2/typescript/mcp-apps",
+                      "v2/typescript/mcp-apps/quickstart",
+                      "v2/typescript/mcp-apps/widgets",
+                      "v2/typescript/mcp-apps/model-context",
+                      "v2/typescript/mcp-apps/interactivity",
+                      "v2/typescript/mcp-apps/apps-sdk-compatibility",
+                      "v2/typescript/mcp-apps/content-security-policy"
+                    ]
+                  },
+                  {
+                    "group": "MCP Client",
+                    "icon": "router",
+                    "pages": [
+                      "v2/typescript/client/index",
+                      "v2/typescript/client/migration",
+                      "v2/typescript/client/environments",
+                      {
+                        "group": "Core Components",
+                        "icon": "box",
+                        "pages": [
+                          "v2/typescript/client/tools",
+                          "v2/typescript/client/resources",
+                          "v2/typescript/client/prompts"
+                        ]
+                      },
+                      {
+                        "group": "Advanced Features",
+                        "icon": "sparkle",
+                        "pages": [
+                          "v2/typescript/client/sampling",
+                          "v2/typescript/client/elicitation",
+                          "v2/typescript/client/completion",
+                          "v2/typescript/client/notifications"
+                        ]
+                      },
+                      "v2/typescript/client/authentication",
+                      "v2/typescript/client/usemcp",
+                      "v2/typescript/client/code-mode"
+                    ]
+                  },
+                  {
+                    "group": "MCP Agent",
+                    "icon": "brain",
+                    "pages": [
+                      "v2/typescript/agent/index",
+                      "v2/typescript/agent/llm-providers",
+                      "v2/typescript/agent/memory-management",
+                      "v2/typescript/agent/streaming",
+                      {
+                        "group": "LangChain integration",
+                        "pages": [
+                          "v2/typescript/agent/langchain/index",
+                          "v2/typescript/agent/langchain/structured-output",
+                          "v2/typescript/agent/langchain/server-manager",
+                          "v2/typescript/agent/langchain/observability"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Tooling",
+                    "icon": "wrench",
+                    "pages": [
+                      "v2/typescript/tooling/client-cli",
+                      "v2/typescript/api-reference/cli-reference",
+                      {
+                        "group": "Inspector",
+                        "icon": "bug-play",
+                        "pages": [
+                          "inspector/index",
+                          "inspector/cli",
+                          "inspector/connection-settings",
+                          "inspector/url-parameters",
+                          "inspector/keyboard-shortcuts",
+                          "inspector/command-palette",
+                          "inspector/integration",
+                          "inspector/self-hosting",
+                          "inspector/debugging-chatgpt-apps"
+                        ]
+                      },
+                      "tunneling/index"
+                    ]
+                  }
                 ]
               },
               {
-                "group": "React",
-                "icon": "atom",
-                "pages": [
-                  "typescript/api-reference/react/usewidget",
-                  "typescript/api-reference/react/usecalltool",
-                  "typescript/api-reference/react/usefiles",
-                  "typescript/api-reference/react/mcpuseprovider",
-                  "typescript/api-reference/react/widgetcontrols",
-                  "typescript/api-reference/react/themeprovider",
-                  "typescript/api-reference/react/errorboundary",
-                  "typescript/api-reference/react/image",
-                  "typescript/api-reference/react/modelcontext"
-                ]
-              },
-              {
-                "group": "Client",
-                "icon": "router",
-                "pages": [
-                  "typescript/api-reference/client/mcp-client",
-                  "typescript/api-reference/client/mcp-session",
-                  "typescript/api-reference/client/code-mode",
-                  "typescript/api-reference/client/react-client",
-                  "typescript/api-reference/client/inspector-chat-components"
-                ]
-              },
-              {
-                "group": "Agent",
-                "icon": "brain",
-                "pages": [
-                  "typescript/api-reference/agent/mcp-agent"
-                ]
+                "tab": "API Reference",
+                "icon": "terminal",
+                "href": "https://api-reference.mcp-use.com"
               }
             ]
           }
@@ -695,6 +878,7 @@
         "product": "Inspector",
         "description": "Debug and test MCP Apps & Servers",
         "icon": "/images/inspector-logo.svg",
+        "href": "/inspector/index",
         "groups": [
           {
             "group": "Inspector",
@@ -715,6 +899,22 @@
     ]
   },
   "redirects": [
+    {
+      "source": "/v2/typescript/agent/llm-integration",
+      "destination": "/v2/typescript/agent/llm-providers"
+    },
+    {
+      "source": "/v2/typescript/agent/structured-output",
+      "destination": "/v2/typescript/agent/langchain/structured-output"
+    },
+    {
+      "source": "/v2/typescript/agent/server-manager",
+      "destination": "/v2/typescript/agent/langchain/server-manager"
+    },
+    {
+      "source": "/v2/typescript/agent/observability",
+      "destination": "/v2/typescript/agent/langchain/observability"
+    },
     {
       "source": "/typescript/getting-started",
       "destination": "/typescript/getting-started/quickstart"

--- a/docs/fonts.css
+++ b/docs/fonts.css
@@ -3,16 +3,17 @@
  * © 2009-2025 Adobe Systems Incorporated. All Rights Reserved.
  */
 
-@import url('https://p.typekit.net/p.css?s=1&k=zmy3zmk&ht=tk&f=55314&a=164646275&app=typekit&e=css');
+@import url("https://p.typekit.net/p.css?s=1&k=zmy3zmk&ht=tk&f=55314&a=164646275&app=typekit&e=css");
 
 @font-face {
-  font-family: 'inter-variable';
-  src: url('https://use.typekit.net/af/250efc/00000000000000007750957d/31/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3')
-      format('woff2'),
-    url('https://use.typekit.net/af/250efc/00000000000000007750957d/31/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3')
-      format('woff'),
-    url('https://use.typekit.net/af/250efc/00000000000000007750957d/31/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3')
-      format('opentype');
+  font-family: "inter-variable";
+  src:
+    url("https://use.typekit.net/af/250efc/00000000000000007750957d/31/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3")
+      format("woff2"),
+    url("https://use.typekit.net/af/250efc/00000000000000007750957d/31/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3")
+      format("woff"),
+    url("https://use.typekit.net/af/250efc/00000000000000007750957d/31/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3")
+      format("opentype");
   font-display: auto;
   font-style: normal;
   font-weight: 100 900;
@@ -20,10 +21,60 @@
 }
 
 body {
-  font-family: 'inter-variable', sans-serif;
+  font-family: "inter-variable", sans-serif;
 }
 
 #sidebar-content ul li a img {
   background: none !important;
 }
 
+html:not([data-current-path^="/v2/typescript/"]) {
+  --banner-height: 0px !important;
+}
+
+html:not([data-current-path^="/v2/typescript/"]) #banner {
+  min-height: 0 !important;
+  height: 0 !important;
+  padding: 0 !important;
+  overflow: hidden !important;
+  visibility: hidden !important;
+  pointer-events: none !important;
+}
+
+html[data-current-path^="/v2/typescript/"] #banner {
+  background: #60a5fa !important;
+}
+
+[data-component-part="products-selector-trigger"] {
+  order: 1;
+}
+
+div:has(> [data-component-part="version-select-trigger"]) {
+  order: 2;
+}
+
+html[data-current-path^="/v2/typescript/"]
+  [data-component-part="version-select-trigger"]
+  > span::after {
+  content: "Beta";
+  display: inline-flex;
+  align-items: center;
+  margin-left: 0.5rem;
+  padding: 0 0.25rem;
+  border: 0;
+  border-radius: 4px;
+  background: #f5f5f4;
+  color: #57534e;
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1rem;
+  letter-spacing: normal;
+  vertical-align: middle;
+}
+
+html.dark[data-current-path^="/v2/typescript/"]
+  [data-component-part="version-select-trigger"]
+  > span::after {
+  background: #44403c;
+  color: #a8a29e;
+}

--- a/docs/inspector/cli.mdx
+++ b/docs/inspector/cli.mdx
@@ -17,6 +17,7 @@ npx @mcp-use/inspector
 ```
 
 This will:
+
 - Start the inspector server on an available port (default: 8080)
 - Automatically open your browser to the inspector interface
 - Display the URL in the terminal
@@ -57,6 +58,14 @@ You can combine it with other flags:
 npx @mcp-use/inspector --url http://localhost:3000/mcp --port 9000 --no-open
 ```
 
+### `--version, -v`
+
+Print the installed Inspector version and exit.
+
+```bash
+npx @mcp-use/inspector --version
+```
+
 ### `--help, -h`
 
 Display help information and available options.
@@ -64,66 +73,6 @@ Display help information and available options.
 ```bash
 npx @mcp-use/inspector --help
 ```
-
-## Environment Variables
-
-### `MCP_INSPECTOR_FRAME_ANCESTORS`
-
-Configure which origins can embed the inspector widget in iframes. This is useful when embedding the inspector into your own application or when testing widgets from different domains.
-
-**Default behavior:**
-- **Development mode**: `*` (allows all origins for easier development)
-- **Production mode**: `'self'` (same-origin only for security)
-
-**Format:** Space-separated list of origins or `*` for all origins
-
-**Examples:**
-
-```bash
-# Allow embedding from specific domains
-MCP_INSPECTOR_FRAME_ANCESTORS="https://app.example.com https://dev.example.com" npx @mcp-use/inspector
-
-# Allow embedding from any domain (useful for development)
-MCP_INSPECTOR_FRAME_ANCESTORS="*" npx @mcp-use/inspector
-
-# Multiple origins with wildcards
-MCP_INSPECTOR_FRAME_ANCESTORS="https://*.example.com http://localhost:*" npx @mcp-use/inspector
-```
-
-<Note>
-In production deployments, it's recommended to explicitly list allowed origins rather than using `*` to prevent unauthorized embedding.
-</Note>
-
-<Tip>
-When running in development mode (`npm run dev`), the inspector automatically allows all origins by default, so you don't need to set this variable unless you want to test production CSP policies.
-</Tip>
-
-### `MCP_URL`
-
-Set the external base URL for your MCP server. This is useful when running behind a reverse proxy (ngrok, E2B sandboxes, Cloudflare tunnels) where the public URL differs from `localhost`.
-
-When set, the CLI will use this URL for widget asset URLs and Vite HMR WebSocket connections, ensuring everything works correctly through the proxy.
-
-**Default behavior:**
-- If not set, the CLI generates a `localhost` URL automatically
-- If set, the CLI preserves your value and does not overwrite it
-
-**Examples:**
-
-```bash
-# ngrok tunnel
-MCP_URL=https://abc123.ngrok.io npx @mcp-use/cli dev
-
-# E2B sandbox
-MCP_URL=https://3000-abc123.e2b.app npx @mcp-use/cli dev
-
-# Cloudflare tunnel
-MCP_URL=https://my-tunnel.trycloudflare.com npx @mcp-use/cli dev
-```
-
-<Tip>
-When using a reverse proxy, set `MCP_URL` to the public-facing URL. This ensures widget hot-reload (HMR) and asset loading work correctly through the proxy.
-</Tip>
 
 ## Related Documentation
 

--- a/docs/inspector/connection-settings.mdx
+++ b/docs/inspector/connection-settings.mdx
@@ -6,17 +6,35 @@ icon: "settings"
 
 {/* TODO: Add Inspector media when a screenshot or short clip would clarify the workflow. */}
 
-Most servers work with only a transport and URL. Change connection settings when the browser cannot reach the server directly, when you want clearer names for saved servers, when OAuth needs pre-registered credentials, or when long-running tools need more time.
+Most servers work with only an HTTP endpoint URL. The Inspector uses HTTP transport and defaults to **Auto** connection and protocol modes. Change settings when the browser cannot reach the server directly, when you need a particular protocol compatibility mode, when OAuth needs pre-registered credentials, or when long-running tools need more time.
 
-## Choose Auto, Direct, or Via Proxy
+## Choose a connection mode
 
 The Inspector uses **Auto** mode by default: it tries a direct browser connection first, then falls back to the configured Inspector proxy if direct access fails because of CORS or network policy.
 
-| Connection mode | Use it when | Avoid it when |
-| --- | --- | --- |
-| **Auto** | You want the Inspector to try Direct first and fall back to the proxy when needed. | You need to test one specific connection path. |
-| **Direct** | The server is local, public, or reachable from your browser. | The browser blocks the request because of CORS or network policy. |
-| **Via Proxy** | The browser is blocked by CORS, or you need to test proxy behavior. | The server works directly; proxying adds another moving part. |
+| Connection mode | Use it when                                                                        | Avoid it when                                                     |
+| --------------- | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| **Auto**        | You want the Inspector to try Direct first and fall back to the proxy when needed. | You need to test one specific connection path.                    |
+| **Direct**      | The server is local, public, or reachable from your browser.                       | The browser blocks the request because of CORS or network policy. |
+| **Proxy**       | The browser is blocked by CORS, or you need to test proxy behavior.                | The server works directly; proxying adds another moving part.     |
+
+## Choose a protocol mode
+
+The Protocol control defaults to **Auto (recommended)**. It probes for the current protocol and falls back to the legacy initialize flow when necessary.
+
+| Protocol option           | Behavior                                                                              |
+| ------------------------- | ------------------------------------------------------------------------------------- |
+| **Auto (recommended)**    | Probe for the current protocol, then fall back to the legacy initialize flow.         |
+| **Force v1 (2024/2025)**  | Use the legacy protocol only. The connection fails if the server is incompatible.     |
+| **Force v2 (2026-07-28)** | Pin the protocol to `2026-07-28`. The connection fails if the server is incompatible. |
+
+## Set the proxy endpoint
+
+**Proxy Endpoint** is the Inspector proxy URL. It defaults to the proxy route configured for the Inspector instance.
+
+- In **Proxy** mode, every MCP request uses this endpoint.
+- In **Auto** mode, the Inspector uses it only after the direct connection fails.
+- In **Direct** mode, the Inspector bypasses it.
 
 ## Name saved servers
 
@@ -28,36 +46,53 @@ Changing only the display name updates labels in the dashboard, server list, hea
 
 Use custom headers for server-specific requirements such as bearer tokens, API keys, or version headers.
 
-Header values are stored in browser storage for that Inspector instance. Prefer OAuth when the server supports it.
+Header values are used for the live connection only. They are intentionally not
+saved or restored after a reload, so supply them again at runtime. Prefer OAuth
+when the server supports it.
 
 <Warning>
-  Custom headers are stored in browser storage. Never include sensitive credentials that should not be stored locally. Use OAuth for secure authentication instead.
+  Copy Config includes current form values. Remove OAuth tokens, API keys, and
+  other secrets before sharing exported configuration.
 </Warning>
 
 ## Configure OAuth
 
-By default the inspector relies on Dynamic Client Registration (DCR), so no credentials are needed. Use the Authentication dialog when the upstream auth server doesn't expose `registration_endpoint` (common for proxy-mode servers fronting Slack, WorkOS, or GitHub) or when the provider requires a confidential client without PKCE.
+Leave the Authentication fields empty when the authorization server supports Dynamic Client Registration (DCR). The Inspector then registers as needed with the authorization server. OAuth does not start automatically: when authentication is required, click **Authenticate** and complete the provider flow.
 
-| Field | When to set it |
-| --- | --- |
-| Client ID | Use a pre-registered OAuth client instead of DCR. |
+Use the Authentication dialog to provide a pre-registered client when the authorization server does not expose a `registration_endpoint`. This is common for servers backed by providers such as Slack, WorkOS, or GitHub. Client secrets are runtime-only and are not restored after a reload.
+
+| Field         | When to set it                                                                    |
+| ------------- | --------------------------------------------------------------------------------- |
+| Client ID     | Use a pre-registered OAuth client instead of DCR.                                 |
 | Client Secret | Use a confidential client; the SDK switches token endpoint auth away from `none`. |
-| Scope | Request a provider-specific space-separated scope list. |
+| Scope         | Request a provider-specific space-separated scope list.                           |
 
 When a server requires OAuth, the connection enters `pending_auth`. Click **Authenticate**, complete the provider flow, and return to the Inspector. If a popup is blocked, use the open-auth-page fallback link.
 
+Browser OAuth session values are encrypted at rest with AES-256-GCM. The
+non-extractable origin key is kept in IndexedDB, while versioned ciphertext
+envelopes remain in localStorage so popup storage events and reload persistence
+continue to work.
+
 ## Configuration Import/Export
 
-Use **Copy Config** to export the current connection form as JSON. Paste JSON into the URL field to populate the form in another Inspector instance.
+Use **Copy Config** to export the current connection form as JSON. Paste the JSON into the URL field to populate a form in another Inspector instance. The export always identifies the transport as `http`; `name` is included only when you set an alias.
 
 Example configuration:
 
 ```json
 {
   "url": "https://mcp.example.com/mcp",
+  "name": "Example MCP server",
   "transportType": "http",
   "connectionMode": "auto",
-  "headers": {
+  "protocolNegotiation": "auto",
+  "connectionType": "Direct",
+  "autoProxyFallback": {
+    "enabled": true,
+    "proxyAddress": "https://inspector.example.com/mcp/inspector/api/proxy"
+  },
+  "customHeaders": {
     "Authorization": "Bearer token123"
   },
   "requestTimeout": 10000,
@@ -71,8 +106,27 @@ Example configuration:
 }
 ```
 
+The export has this shape:
+
+| Field                    | Included when                    | Meaning                                                                   |
+| ------------------------ | -------------------------------- | ------------------------------------------------------------------------- |
+| `url`                    | Always                           | MCP endpoint URL.                                                         |
+| `name`                   | An alias is set                  | Display name.                                                             |
+| `transportType`          | Always                           | Always `http`.                                                            |
+| `connectionMode`         | Always                           | `auto`, `direct`, or `proxy`.                                             |
+| `protocolNegotiation`    | Always                           | `auto`, `legacy` for Force v1, or `{ "pin": "2026-07-28" }` for Force v2. |
+| `connectionType`         | Always                           | `Direct` or `Via Proxy`; retained in copied configs for compatibility.    |
+| `proxyConfig`            | Proxy mode with a proxy endpoint | Contains `proxyAddress` and `customHeaders`.                              |
+| `autoProxyFallback`      | Auto mode with a proxy endpoint  | Contains `enabled` and `proxyAddress`.                                    |
+| `customHeaders`          | Always                           | Custom MCP request headers.                                               |
+| `requestTimeout`         | Always                           | Per-request timeout in milliseconds.                                      |
+| `resetTimeoutOnProgress` | Always                           | Whether progress notifications reset the request timeout.                 |
+| `maxTotalTimeout`        | Always                           | Maximum total time in milliseconds.                                       |
+| `oauth`                  | A client ID or scope is set      | OAuth `clientId`, optional `clientSecret`, and `scope`.                   |
+
 <Note>
-  The paste detection only works in the URL field. Remove OAuth tokens, API keys, and other secrets before sharing a copied config.
+  The paste detection only works in the URL field. Remove OAuth tokens, API
+  keys, and other secrets before sharing a copied config.
 </Note>
 
 ## URL and tabs
@@ -83,9 +137,10 @@ The Inspector keeps the active tab in the page URL (`?tab=...`). Switching tabs 
 
 Use timeout settings only when a valid tool call or resource read needs more time.
 
-| Setting | Default | What it controls |
-| --- | --- | --- |
-| Request timeout | `10000` ms | Time allowed for one request. |
-| Maximum total timeout | `60000` ms | Total time allowed across retries and progress updates. |
+| Setting                   | Default    | What it controls                                                                                                                                       |
+| ------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Request timeout           | `10000` ms | Time allowed for one request.                                                                                                                          |
+| Reset timeout on progress | `true`     | Reset the request timeout whenever the server sends a progress notification. This also sends the progress token needed to receive those notifications. |
+| Maximum total timeout     | `60000` ms | Total time allowed across retries and progress updates.                                                                                                |
 
 If a request times out, first confirm the server eventually responds. Then raise the timeout to match the expected tool runtime.

--- a/docs/inspector/debugging-chatgpt-apps.mdx
+++ b/docs/inspector/debugging-chatgpt-apps.mdx
@@ -18,7 +18,7 @@ Run your mcp-use app locally:
 npm run dev
 ```
 
-Open `http://localhost:3000/inspector` and connect to `http://localhost:3000/mcp`.
+Open `http://localhost:3000/mcp/inspector` and connect to `http://localhost:3000/mcp`.
 
 If the server is remote, connect to its MCP endpoint instead. Use **Direct** first, then try **Via Proxy** only when the browser cannot reach the server directly.
 

--- a/docs/inspector/index.mdx
+++ b/docs/inspector/index.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Inspector"
-description: "Connect to an MCP server, run tools, inspect resources and prompts, and debug widgets."
+description: "Connect to an MCP server, run tools, inspect resources and prompts, and debug MCP App views."
 icon: "monitor"
 ---
 
-Use the Inspector when you need to test an MCP server from the browser. It lets you connect to a server, call tools with typed inputs, inspect resources and prompts, try chat, preview widgets, and copy client setup commands.
+Use the Inspector when you need to test an MCP server from the browser. It lets you connect to an HTTP MCP endpoint, call tools with typed inputs, inspect server metadata, resources, and prompts, try chat, preview MCP App views, and copy client setup commands.
 
 [![Try this live](/images/UseLiveSmall.svg)](https://inspector.mcp-use.com)
 
@@ -23,16 +23,16 @@ npm run dev
 
 The default local URLs are:
 
-| URL | Purpose |
-| --- | --- |
-| `http://localhost:3000/mcp` | MCP endpoint |
-| `http://localhost:3000/inspector` | Inspector UI |
+| URL                                   | Purpose      |
+| ------------------------------------- | ------------ |
+| `http://localhost:3000/mcp`           | MCP endpoint |
+| `http://localhost:3000/mcp/inspector` | Inspector UI |
 
 You can also open the hosted Inspector at [inspector.mcp-use.com](https://inspector.mcp-use.com) or run it with [`npx @mcp-use/inspector`](/inspector/cli).
 
 ## Connect to a server
 
-Add a server from the dashboard. Choose the transport, enter the MCP endpoint URL, and click **Connect**.
+Add a server from the dashboard, enter its HTTP or HTTPS MCP endpoint URL, and click **Connect**. The connection UI supports HTTP endpoints only; it does not offer an SSE transport selector.
 
 <Frame caption="Connection form">
   <img
@@ -41,13 +41,13 @@ Add a server from the dashboard. Choose the transport, enter the MCP endpoint UR
   />
 </Frame>
 
-For most local and public HTTP servers, use **Direct**. Use **Via Proxy** only when the browser cannot reach the server directly because of CORS or network policy. See [Connection settings](/inspector/connection-settings) for the short decision guide.
+Connection mode defaults to **Auto**. It tries a direct browser connection first, then falls back to the configured proxy when direct access fails. Choose **Direct** to test only the browser path, or **Proxy** to always route through the proxy. See [Connection settings](/inspector/connection-settings) for the decision guide.
 
-When a server requires OAuth, the Inspector starts the auth flow for you. Complete the provider approval and return to the Inspector; the server card changes to the connected state after auth finishes.
+When a server requires OAuth, it enters a pending authentication state. Click **Authenticate**, complete the provider approval, and return to the Inspector. The server connects after authentication finishes.
 
 ## Run a tool
 
-Open a connected server and select the **Tools** tab. Choose a tool, fill the generated form, and run it.
+Open a connected server and select **Tools**. Choose a tool, fill the generated form, and run it.
 
 <Frame caption="Server tools">
   <img
@@ -56,7 +56,7 @@ Open a connected server and select the **Tools** tab. Choose a tool, fill the ge
   />
 </Frame>
 
-The Inspector shows the tool result, structured content, errors, and any widget returned by the tool. Use this view to verify schema validation, result shape, and widget data before testing the same server from a client.
+The Inspector shows the tool result, structured content, errors, and any MCP App view associated with the tool. Use this view to verify schema validation, result shape, and view data before testing the same server from a client.
 
 ## Inspect resources and prompts
 
@@ -64,23 +64,27 @@ Use **Resources** to read server-provided content by URI. Use **Prompts** to tes
 
 These tabs are useful when a client reports missing context. They show what the server actually exposes after connection and auth.
 
+## Navigate a connected server
+
+The connected-server navigation uses these views: **Server Metadata**, **Chat**, **Tools**, **Prompts**, **Resources**, **Sampling**, **Elicitation**, **Notifications**, and **Connection Settings**. Availability depends on the server's capabilities and connection type; for example, **Sampling** is available for compatible stateful connections.
+
 ## Try chat
 
 Use **Chat** to test how an LLM calls your server's tools in a conversation. The chat view can use hosted chat where available or a provider key stored in your browser.
 
-Keep chat testing focused on end-to-end behavior. Use the Tools tab first when you need to isolate input schemas, tool errors, or widget rendering.
+Keep chat testing focused on end-to-end behavior. Use the Tools tab first when you need to isolate input schemas, tool errors, or view rendering.
 
-## Debug widgets
+## Debug MCP App views
 
-When a tool returns an MCP App widget, the Inspector renders it below the tool result and exposes widget debug controls.
+When a tool has an MCP App view, the Inspector renders it below the tool result and exposes view debug controls.
 
-Use the widget view to check:
+Use the view debug controls to check:
 
-- the `props`, `output`, and metadata passed to the widget
+- the tool result, structured content, and app metadata passed to the view
 - inline, picture-in-picture, and fullscreen display modes
-- desktop, tablet, and mobile layout behavior
+- desktop, mobile, and custom viewport behavior
 - theme, locale, timezone, hover, touch, and safe-area settings
-- Content Security Policy behavior before trying the widget in a host
+- Content Security Policy behavior before trying the view in a host
 
 See [Debug widgets in the Inspector](/inspector/debugging-chatgpt-apps) for the full workflow.
 
@@ -109,11 +113,19 @@ For the full shortcut list, see [Keyboard shortcuts](/inspector/keyboard-shortcu
   <Card title="CLI usage" icon="terminal" href="/inspector/cli">
     Run the Inspector from the command line and auto-connect to a server.
   </Card>
-  <Card title="Connection settings" icon="settings" href="/inspector/connection-settings">
-    Choose Direct or Via Proxy and tune connection details only when needed.
+  <Card
+    title="Connection settings"
+    icon="settings"
+    href="/inspector/connection-settings"
+  >
+    Choose Auto, Direct, or Proxy and tune connection details only when needed.
   </Card>
-  <Card title="Debug widgets" icon="bug" href="/inspector/debugging-chatgpt-apps">
-    Test MCP Apps widgets, layout behavior, CSP, and display modes.
+  <Card
+    title="Debug MCP App views"
+    icon="bug"
+    href="/inspector/debugging-chatgpt-apps"
+  >
+    Test MCP App views, layout behavior, CSP, and display modes.
   </Card>
   <Card title="Mount the Inspector" icon="plug-2" href="/inspector/integration">
     Serve the Inspector from an Express, Hono, or mcp-use server.

--- a/docs/inspector/integration.mdx
+++ b/docs/inspector/integration.mdx
@@ -6,74 +6,115 @@ icon: "plug-2"
 
 {/* TODO: Add Inspector media when a screenshot or short clip would clarify the workflow. */}
 
-Mount the Inspector when you want it served from the same app as your MCP server. Servers built with `mcp-use/server` mount it automatically at `/inspector`.
+The Inspector is built-in local development tooling. `mcp-use` installs its prebuilt package, and `mcp-use dev` mounts it on the development listener at `/mcp/inspector`.
 
 ## Auto-Mounting with mcp-use
 
-When using `mcp-use` to create your MCP server, the Inspector is automatically available at `/inspector`.
+When using a generated `mcp-use` project, run `npm run dev`. The CLI loads the Inspector supplied by `mcp-use`, serves its bundled UI locally, and opens `/mcp/inspector`. No extra dependency or CDN is involved. Production stays Inspector-free by default; use `mcp-use start --with-inspector` to mount it on the built server's existing listener.
 
 ### Example
 
-The Inspector is automatically mounted when using `mcp-use/server`. No additional configuration is needed.
+Generated and existing projects receive the Inspector through `mcp-use`. Add `@mcp-use/inspector` directly only when overriding the framework-supplied version or mounting it without `mcp-use`.
 
 ```typescript
-import { MCPServer } from 'mcp-use/server'
+import { MCPServer } from "mcp-use";
 
 const server = new MCPServer({
-  name: 'my-server',
-  version: '1.0.0',
-})
+  name: "my-server",
+  version: "1.0.0",
+});
 
-// Add your tools, resources, prompts...
-server.tool(/* ... */)
-
-// Start the server
-server.listen(3000)
-
-// Inspector is available at http://localhost:3000/inspector
+export default server;
 ```
 
+Then run `mcp-use dev`; the Inspector is available at `http://localhost:3000/mcp/inspector`. Use `--no-inspector` for a headless development run.
+
+To inspect the production build locally, build once and opt in when starting it:
+
+```bash
+mcp-use build
+mcp-use start --with-inspector
+```
+
+This changes neither the build output nor its manifest. Treat a production Inspector as an internal tool: it can invoke MCP tools and proxy OAuth flows.
+
 ## Manual Integration
+
+For custom development servers, `mountInspector()` from `@mcp-use/inspector` provides the complete local Inspector: packaged UI, proxy, OAuth BFF, and callbacks. It can register on Hono/Express or return a framework-neutral Fetch handler.
+
+### Fetch handler integration
+
+Dispatch Inspector paths to the handler and all other paths to your server.
+This complete example uses the same listener for the MCP endpoint and
+Inspector:
+
+```typescript
+import { MCPServer } from "mcp-use";
+import { mountInspector, type InspectorFetchHandler } from "@mcp-use/inspector";
+
+const basePath = "/mcp";
+const inspectorPath = `${basePath}/inspector`;
+
+const server = new MCPServer({
+  name: "my-server",
+  version: "1.0.0",
+  basePath,
+});
+
+const inspector = mountInspector({
+  basePath,
+  autoConnectUrl: "http://localhost:3000/mcp",
+});
+
+export const fetch: InspectorFetchHandler = async (request) => {
+  const pathname = new URL(request.url).pathname;
+
+  if (pathname === inspectorPath || pathname.startsWith(`${inspectorPath}/`)) {
+    return inspector(request);
+  }
+
+  return server.fetch(request);
+};
+```
+
+When the public origin is not known in advance, omit `autoConnectUrl`. The
+handler then derives the connection URL from the request origin and `basePath`.
 
 ### Hono Integration
 
 Mount the Inspector on a Hono application:
 
 ```typescript
-import { Hono } from 'hono'
-import { mountInspector } from '@mcp-use/inspector'
+import { Hono } from "hono";
+import { mountInspector } from "@mcp-use/inspector";
 
-const app = new Hono()
+const app = new Hono();
 
 // Your Hono routes
-app.get('/api/health', (c) => {
-  return c.json({ status: 'ok' })
-})
+app.get("/api/health", (c) => {
+  return c.json({ status: "ok" });
+});
 
-// Mount inspector at /inspector
-mountInspector(app)
+// Mount inspector at /mcp/inspector
+mountInspector(app, { basePath: "/mcp" });
 
 // Start server with your Hono adapter
-export default app
+export default app;
 ```
 
 ## Path Customization
 
-The Inspector is mounted at `/inspector` by default. To serve it under another prefix, mount it on a sub-app and route that sub-app from your main app.
+`basePath` defaults to `/mcp`, so the Inspector lives at `/mcp/inspector`. Set `basePath: ''` for `/inspector`, or use another MCP prefix.
 
 ### Hono with Custom Path
 
 ```typescript
-import { Hono } from 'hono'
-import { mountInspector } from '@mcp-use/inspector'
+import { Hono } from "hono";
+import { mountInspector } from "@mcp-use/inspector";
 
-const app = new Hono()
+const app = new Hono();
 
-// Create sub-app for inspector
-const inspectorApp = new Hono()
-mountInspector(inspectorApp)
-
-app.route('/debug', inspectorApp)
+mountInspector(app, { basePath: "/debug" });
 // Inspector now available at http://localhost:3000/debug/inspector
 ```
 
@@ -84,27 +125,38 @@ app.route('/debug', inspectorApp)
 Pass options only when the default mount behavior is not enough.
 
 ```typescript
-import { mountInspector } from '@mcp-use/inspector'
+import { mountInspector } from "@mcp-use/inspector";
 
 mountInspector(app, {
-  autoConnectUrl: 'http://localhost:3000/mcp',
-  sandboxOrigin: 'https://sandbox.example.com',
-})
+  basePath: "/mcp",
+  autoConnectUrl: "http://localhost:3000/mcp",
+  manufactChatUrl: "https://chat.example.com",
+  sandboxOrigin: "https://sandbox.example.com",
+  oauthProxyAllowedOrigins: ["https://admin.example.com"],
+});
 ```
 
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `autoConnectUrl` | `string \| null` | `undefined` | MCP server URL to auto-connect on load |
-| `devMode` | `boolean` | `true` if not production | Enables same-origin sandbox for MCP Apps widgets (no subdomain required) |
-| `sandboxOrigin` | `string \| null` | `undefined` | Override the sandbox origin for MCP Apps widgets |
+| Option                     | Type                | Default                             | Description                                                                         |
+| -------------------------- | ------------------- | ----------------------------------- | ----------------------------------------------------------------------------------- |
+| `basePath`                 | `string`            | `'/mcp'`                            | MCP prefix; Inspector mounts at `${basePath}/inspector`                             |
+| `autoConnectUrl`           | `string \| null`    | Current request origin + `basePath` | MCP server URL to auto-connect on load; `null` disables                             |
+| `manufactChatUrl`          | `string \| null`    | `undefined`                         | Manufact Chat URL made available to the Inspector UI                                |
+| `devMode`                  | `boolean`           | `true`                              | Enables the same-origin sandbox for MCP App views                                   |
+| `sandboxOrigin`            | `string \| null`    | `undefined`                         | Overrides the sandbox origin for MCP App views                                      |
+| `oauthProxyAllowedOrigins` | `readonly string[]` | `[]`                                | Explicit cross-origin callers allowed to use the OAuth BFF; same-origin is implicit |
+| `oauthProxyAllowLoopback`  | `boolean`           | `true`                              | Permit local proxy/OAuth access to loopback targets                                 |
 
 ## Protect mounted Inspector routes
 
-The Inspector can call tools, read resources, and inspect prompts on any connected server. If you mount it outside local development, put it behind the same access controls you use for internal tools.
+The Inspector can call tools, read resources, and inspect prompts on any connected server. Keep it in local development. If a custom integration exposes it on a network, disable loopback proxying and put it behind the same access controls as other internal tools.
+
+Each mounted Inspector also applies process-local limits of 120 proxy/OAuth
+requests and 600 asset requests per minute. Exhausted routes return `429 Too
+Many Requests` with `Retry-After`; these limits complement, rather than replace,
+network-edge authentication and rate limiting.
 
 ## Related Documentation
 
 - [Getting Started](/inspector/index) - Basic inspector usage
 - [CLI Usage](/inspector/cli) - Standalone inspector usage
-- [Inspector chat components](/typescript/api-reference/client/inspector-chat-components) - API reference for exported chat UI
 - [Debug widgets in the Inspector](/inspector/debugging-chatgpt-apps) - Test widget rendering and host behavior

--- a/docs/inspector/keyboard-shortcuts.mdx
+++ b/docs/inspector/keyboard-shortcuts.mdx
@@ -10,28 +10,29 @@ Use keyboard shortcuts to move between Inspector views without leaving the curre
 
 ## Shortcuts
 
-| Shortcut | Action | Works while typing? |
-| --- | --- | --- |
-| `Cmd/Ctrl + K` | Open the command palette. | Yes |
-| `Cmd/Ctrl + O` | Start a new chat. | No |
-| `Esc` | Close overlays, close dialogs, or blur the focused element. | Yes |
-| `t` | Open the Tools tab. | No |
-| `p` | Open the Prompts tab. | No |
-| `r` | Open the Resources tab. | No |
-| `c` | Open the Chat tab. | No |
-| `h` | Return to the dashboard. | No |
-| `f` | Focus search in the current tab when the tab has search. | No |
+| Shortcut           | Action                                                   | Works while typing? |
+| ------------------ | -------------------------------------------------------- | ------------------- |
+| `Cmd/Ctrl + K`     | Open the command palette.                                | Yes                 |
+| `Cmd/Ctrl + O`     | Start a new chat when Chat is available.                 | Yes                 |
+| `Cmd/Ctrl + Enter` | Run the selected tool or prompt.                         | Yes                 |
+| `Esc`              | Cancel a running tool, or clear the focused UI state.    | Yes                 |
+| `t`                | Open the Tools tab.                                      | No                  |
+| `p`                | Open the Prompts tab.                                    | No                  |
+| `r`                | Open the Resources tab.                                  | No                  |
+| `c`                | Open the Chat tab.                                       | No                  |
+| `h`                | Return to the dashboard.                                 | No                  |
+| `f`                | Focus search in the current tab when the tab has search. | No                  |
 
-`Cmd/Ctrl + K` is the only shortcut that intentionally works while an input field is focused. Single-letter shortcuts are disabled while you type in inputs, textareas, and content-editable elements.
+Modifier shortcuts work while an input field is focused. Single-letter shortcuts are disabled while you type in inputs, textareas, and content-editable elements. The command palette handles `Esc` itself to close the palette.
 
 ## Command palette keys
 
 After opening the command palette:
 
-| Key | Action |
-| --- | --- |
-| `Up` / `Down` | Move through results. |
-| `Enter` | Open the selected result or run the selected command. |
-| `Esc` | Close the command palette. |
+| Key           | Action                                                |
+| ------------- | ----------------------------------------------------- |
+| `Up` / `Down` | Move through results.                                 |
+| `Enter`       | Open the selected result or run the selected command. |
+| `Esc`         | Close the command palette.                            |
 
 See [Command Palette](/inspector/command-palette) for what you can search and open.

--- a/docs/inspector/self-hosting.mdx
+++ b/docs/inspector/self-hosting.mdx
@@ -17,7 +17,11 @@ docker run -d -p 127.0.0.1:8080:8080 --name mcp-inspector mcpuse/inspector:lates
 Then open `http://localhost:8080` to access your self-hosted Inspector.
 
 <Warning>
-Anyone who can reach the Inspector can use it to connect to and call your MCP servers. The examples bind to `127.0.0.1` so the Inspector is only reachable from the host itself. If you need remote access, put it behind a reverse proxy with authentication and TLS, or restrict access with firewall rules — don't publish port 8080 on all interfaces.
+  Anyone who can reach the Inspector can use it to connect to and call your MCP
+  servers. The examples bind to `127.0.0.1` so the Inspector is only reachable
+  from the host itself. If you need remote access, put it behind a reverse proxy
+  with authentication and TLS, or restrict access with firewall rules — don't
+  publish port 8080 on all interfaces.
 </Warning>
 
 ## Deployment options
@@ -40,7 +44,7 @@ Anyone who can reach the Inspector can use it to connect to and call your MCP se
           - "127.0.0.1:8080:8080"
         restart: unless-stopped
         healthcheck:
-          test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/inspector"]
+          test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/inspector/health"]
           interval: 30s
           timeout: 10s
           retries: 3
@@ -49,7 +53,8 @@ Anyone who can reach the Inspector can use it to connect to and call your MCP se
 </Tabs>
 
 <Note>
-The image is based on `node:20-alpine`, which ships `wget` (BusyBox) but not `curl` — use `wget` in healthchecks.
+  The image is based on `node:22-alpine`, which ships `wget` (BusyBox) but not
+  `curl` — use `wget` in healthchecks.
 </Note>
 
 ## Ports
@@ -76,17 +81,20 @@ docker load -i mcp-inspector.tar
 ```
 
 <Note>
-When connecting from a self-hosted Inspector to an MCP server on another host, the browser must be able to reach the server directly, or you can use the proxy connection mode. See [Connection settings](/inspector/connection-settings) for when to use each.
+  When connecting from a self-hosted Inspector to an MCP server on another host,
+  the browser must be able to reach the server directly, or you can use the
+  proxy connection mode. See [Connection settings](/inspector/connection-settings)
+  for when to use each.
 </Note>
 
 ## Alternatives
 
 Self-hosting is one of three ways to run the Inspector:
 
-| Option | Command | Best for |
-| --- | --- | --- |
-| Hosted | [inspector.mcp-use.com](https://inspector.mcp-use.com) | Quick testing, no install |
-| Local CLI | `npx @mcp-use/inspector` | Local development |
-| Self-hosted | `docker run mcpuse/inspector:latest` | Production, enterprise, air-gapped |
+| Option      | Command                                                | Best for                                          |
+| ----------- | ------------------------------------------------------ | ------------------------------------------------- |
+| Hosted      | [inspector.mcp-use.com](https://inspector.mcp-use.com) | Quick testing, no install                         |
+| Local CLI   | `npx @mcp-use/inspector`                               | Local development                                 |
+| Self-hosted | `docker run mcpuse/inspector:latest`                   | Controlled, enterprise, or air-gapped deployments |
 
-Servers built with `mcp-use` also auto-mount the Inspector at `/inspector` — see the [Inspector overview](/inspector/index).
+`mcp-use dev` mounts the Inspector at `/mcp/inspector` by default. Production starts do not mount it unless you opt in with `mcp-use start --with-inspector`; when enabled, it uses the same integrated route. Treat that route as an internal tool and apply the access controls described above.

--- a/docs/inspector/url-parameters.mdx
+++ b/docs/inspector/url-parameters.mdx
@@ -10,14 +10,14 @@ Use URL parameters when you need a link that opens the Inspector on a specific s
 
 ## Parameters
 
-| Parameter | Purpose | Values |
-| --- | --- | --- |
-| `server` | Select an existing connection by server ID or URL. If no saved connection matches and the value is an HTTP(S) URL, connect to it. | Connection ID or URL string |
-| `autoConnect` | Connect to a server when the Inspector loads. | URL string or URL-encoded JSON config |
-| `tab` | Open a specific server tab. | `tools`, `prompts`, `resources`, `chat`, `sampling`, `elicitation`, `notifications`, `playground` |
-| `tunnelUrl` | Preserve a tunnel URL while navigating. Usually set by the CLI. | URL string |
-| `embedded` | Use embedded mode with reduced page chrome. | `true` |
-| `embeddedConfig` | Configure embedded styling. | URL-encoded JSON config |
+| Parameter        | Purpose                                                                                                                           | Values                                                                                                                        |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `server`         | Select an existing connection by server ID or URL. If no saved connection matches and the value is an HTTP(S) URL, connect to it. | Connection ID or URL string                                                                                                   |
+| `autoConnect`    | Connect to a server when the Inspector loads.                                                                                     | URL string or URL-encoded JSON config                                                                                         |
+| `tab`            | Open a specific server tab.                                                                                                       | `tools`, `prompts`, `resources`, `chat`, `sampling`, `elicitation`, `notifications`, `server-metadata`, `connection-settings` |
+| `tunnelUrl`      | Preserve a tunnel URL while navigating. Usually set by the CLI.                                                                   | URL string                                                                                                                    |
+| `embedded`       | Use embedded mode with reduced page chrome.                                                                                       | `true`                                                                                                                        |
+| `embeddedConfig` | Configure embedded styling.                                                                                                       | URL-encoded JSON config                                                                                                       |
 
 ## Select or connect to a server
 
@@ -45,14 +45,20 @@ For advanced connection options, pass a URL-encoded JSON object. The `url` field
   "name": "Example server",
   "transportType": "http",
   "connectionMode": "auto",
-  "connectionType": "Direct"
+  "connectionType": "Direct",
+  "protocolNegotiation": "auto"
 }
 ```
 
-Supported JSON fields are `url` (required), `name`, `transportType` (`"http"` or `"sse"`), `connectionMode` (`"auto"`, `"direct"`, or `"proxy"`), `autoProxyFallback`, `connectionType` (`"Direct"` or `"Via Proxy"` for older links), `customHeaders`, `auth`, `requestTimeout`, `resetTimeoutOnProgress`, and `maxTotalTimeout`.
+Supported JSON fields are `url` (required), `name`, `transportType` (`"http"` or `"sse"`), `connectionMode` (`"auto"`, `"direct"`, or `"proxy"`), `autoProxyFallback`, `protocolNegotiation`, `connectionType`, `customHeaders`, `auth`, `requestTimeout`, `resetTimeoutOnProgress`, and `maxTotalTimeout`.
+
+Use `"auto"` for `protocolNegotiation`, `"legacy"` for the legacy protocol, or `{ "pin": "<protocol-version>" }` to pin a protocol version. The older `connectionType` field maps `"Via Proxy"` to Proxy mode and `"Direct"` to Auto mode.
+
+`auth` supplies an existing OAuth token to an auto-connect link. It requires `access_token` and accepts `token_type`, `expires_at`, `refresh_token`, and `scope`. This differs from the `oauth` static-client settings in a configuration copied from the connection form.
 
 <Tip>
-  When passing a JSON object for **autoConnect**, URL-encode the value so special characters are valid in the query string.
+  When passing a JSON object for **autoConnect**, URL-encode the value so
+  special characters are valid in the query string.
 </Tip>
 
 ## Open a tab
@@ -73,25 +79,55 @@ Use `embedded=true` when the Inspector is hosted inside another UI, such as an i
 /?embedded=true
 ```
 
-Use `embeddedConfig` with a URL-encoded JSON object when the embedded host needs styling overrides.
+Use `embeddedConfig` with a URL-encoded JSON object to configure the embedded Inspector. `defaultTab` takes precedence over the `tab` query parameter.
 
 ```json
 {
   "backgroundColor": "#f5f5f5",
-  "padding": "16px"
+  "padding": "16px",
+  "visibleTabs": ["chat"],
+  "defaultTab": "chat"
 }
 ```
+
+`embeddedConfig` accepts these fields:
+
+| Field                         | Type                                                  | Purpose                                                                                                                         |
+| ----------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `backgroundColor`             | string                                                | Embedded container background color.                                                                                            |
+| `padding`                     | string                                                | Embedded container padding (ignored when `singleTab` is `true`).                                                                |
+| `singleTab`                   | boolean                                               | Show one tab without the header or tab chrome.                                                                                  |
+| `visibleTabs`                 | array of tab IDs                                      | Limit visible tabs. Use the tab IDs listed above.                                                                               |
+| `defaultTab`                  | tab ID                                                | Initial tab; overrides `tab`.                                                                                                   |
+| `chatApiUrl`                  | string                                                | API URL for server-side chat streaming.                                                                                         |
+| `chatStreamProtocol`          | `"sse"` or `"data-stream"`                            | Wire protocol for `chatApiUrl`.                                                                                                 |
+| `chatCredentials`             | fetch credentials value                               | Credentials policy for chat requests.                                                                                           |
+| `managedLlmConfig`            | object                                                | Externally managed chat configuration: `provider`, `apiKey`, `model`, and optional `temperature`, `baseUrl`, and `credentials`. |
+| `chatEnableFreeTierUpgrade`   | boolean                                               | Enable the chat free-tier sign-in and upgrade UI.                                                                               |
+| `chatHideTitle`               | boolean                                               | Hide the Chat title.                                                                                                            |
+| `chatHideModelBadge`          | boolean                                               | Hide the model badge.                                                                                                           |
+| `chatHideServerUrl`           | boolean                                               | Hide the MCP server URL.                                                                                                        |
+| `chatHideConfigButton`        | boolean                                               | Hide chat provider/API-key configuration.                                                                                       |
+| `chatClearButtonLabel`        | string                                                | Label for the clear/new-chat button.                                                                                            |
+| `chatClearButtonHideIcon`     | boolean                                               | Hide the clear/new-chat button icon.                                                                                            |
+| `chatClearButtonHideShortcut` | boolean                                               | Hide the shortcut label on the clear/new-chat button.                                                                           |
+| `chatClearButtonVariant`      | `"default"`, `"secondary"`, `"ghost"`, or `"outline"` | Button style.                                                                                                                   |
+| `chatQuickQuestions`          | array of strings                                      | Initial questions below the landing input.                                                                                      |
+| `chatFollowups`               | array of strings                                      | Initial follow-up suggestions above the input.                                                                                  |
+| `chatHideClearButton`         | boolean                                               | Hide the clear/new-chat button.                                                                                                 |
+| `chatHideToolSelector`        | boolean                                               | Hide the tool selector in chat input.                                                                                           |
+| `forceConnected`              | boolean                                               | Render Chat as connected without a client-side MCP server; use with `chatApiUrl` when the backend manages MCP connections.      |
 
 ## Example links
 
 Open the hosted Inspector and connect to a server:
 
 ```text
-https://inspector.mcp-use.com/inspect?autoConnect=https://your-server.com/mcp
+https://inspector.mcp-use.com/inspector?autoConnect=https://your-server.com/mcp
 ```
 
 Open the hosted Inspector, connect to a server, and show Tools:
 
 ```text
-https://inspector.mcp-use.com/inspect?server=https://your-server.com/mcp&tab=tools
+https://inspector.mcp-use.com/inspector?server=https://your-server.com/mcp&tab=tools
 ```

--- a/docs/tunneling/index.mdx
+++ b/docs/tunneling/index.mdx
@@ -1,20 +1,36 @@
 ---
 title: "MCP Server Tunneling"
-description: "Expose a local MCP server through a public /mcp URL for testing in ChatGPT, Claude, and other remote MCP clients."
+description: "Expose a local HTTP MCP endpoint through a public HTTPS tunnel for testing in ChatGPT, Claude, and other remote MCP clients."
 icon: "train-front-tunnel"
 ---
 
 Use a tunnel when ChatGPT, Claude, or another remote MCP client needs to reach a server running on your machine. The tunnel gives you a public HTTPS URL that forwards to your local MCP endpoint.
 
-With `mcp-use`, start the server with `--tunnel`, then copy the printed `Tunnel` URL. The URL you give to clients must include `/mcp`.
+The tunnel URL is a public **origin**, not necessarily the MCP endpoint. Give
+clients the public origin plus an MCP path that the tunnel permits. The default
+`mcp-use` endpoint is `/mcp`:
 
 ```text
 https://<subdomain>.local.mcp-use.run/mcp
 ```
 
+The hosted tunnel service forwards paths beginning with `/mcp` or `/mcp-use`.
+For example, a server with `basePath: "/mcp/private"` has this public endpoint:
+
+```text
+https://<subdomain>.local.mcp-use.run/mcp/private
+```
+
+Other paths require a tunnel deployment configured to permit them.
+
 Keep the terminal process running while you test. The public URL stops working when the process exits.
 
-## Start a tunnel with mcp-use
+## Tunnel a TypeScript server with the mcp-use CLI
+
+The `mcp-use dev` and `mcp-use start` commands below are the TypeScript CLI
+workflow. They create the public tunnel after the local listener is ready and
+print the complete public MCP endpoint, including the server's configured base
+path.
 
 Use `mcp-use dev --tunnel` while you are developing:
 
@@ -29,23 +45,28 @@ mcp-use build
 mcp-use start --port 3000 --tunnel
 ```
 
-Successful output includes a tunnel endpoint:
+In development, successful output includes the local and public MCP endpoints:
 
 ```text
-Starting tunnel for port 3000...
-✓ Tunnel established: https://happy-blue.local.mcp-use.run/mcp
-
-Local:    http://localhost:3000
-MCP:      http://localhost:3000/mcp
-Tunnel:   https://happy-blue.local.mcp-use.run/mcp
-Inspector: http://localhost:3000/inspector?autoConnect=...
+[mcp-use] dev server ready
+  ➜ MCP endpoint:  http://localhost:3000/mcp
+  ➜ Inspector:     http://localhost:3000/mcp/inspector
+  ➜ Tunnel:        https://happy-blue.local.mcp-use.run/mcp
 ```
 
-Copy the value after `Tunnel:` into your remote MCP client. Do not copy only `https://happy-blue.local.mcp-use.run`; the client URL must end with `/mcp`.
+Copy the value after `Tunnel:` into your remote MCP client. `mcp-use start
+--tunnel` reports the same endpoint after `mcp-use public MCP URL:`. Both
+commands print the server's configured path. Paths outside `/mcp**` and
+`/mcp-use**` require a tunnel deployment configured to permit them.
 
-## Tunnel any server on /mcp
+If the tunnel relay drops while either CLI command is still running, the CLI
+restarts it and reuses the same subdomain when possible.
 
-Use the standalone tunnel package when your local MCP server is not started by `mcp-use`. The server must already be running locally and serving MCP over HTTP at `/mcp`.
+## Tunnel another local HTTP server
+
+Use the standalone tunnel package when your local MCP server is not started by
+the TypeScript CLI. The package forwards the local HTTP service on the port you
+pass and prints its public origin.
 
 For a server on port `3000`, run:
 
@@ -53,24 +74,27 @@ For a server on port `3000`, run:
 npx @mcp-use/tunnel 3000
 ```
 
-Successful output prints a public URL:
+On success, the command reports the public origin:
 
 ```text
-╭────────────────────────────────────╮
-│  Tunnel Created Successfully!      │
-╰────────────────────────────────────╯
+✔ Local MCP server available at
 
-Public URL:
-  https://happy-blue.local.mcp-use.run/mcp
-
-Local Port: 3000
+  https://happy-blue.local.mcp-use.run
 ```
 
-Copy the full public URL, including `/mcp`, into ChatGPT, Claude, or your other remote MCP client.
+The published standalone tunnel defaults to allowing `/mcp**` and
+`/mcp-use**` paths. Combine the public origin with an allowed MCP path that your
+local server exposes. For example, if the local endpoint is
+`http://localhost:3000/mcp/private`, connect the remote client to
+`https://happy-blue.local.mcp-use.run/mcp/private`.
+
+If your MCP endpoint uses another path, use a tunnel deployment configured to
+permit it.
 
 ## Verify the tunnel
 
-Verify the public URL with the `mcp-use client` CLI:
+For a TypeScript CLI workflow, verify the public MCP endpoint with
+`mcp-use client`:
 
 ```bash
 npx mcp-use client connect tunnel-test https://happy-blue.local.mcp-use.run/mcp
@@ -90,15 +114,14 @@ When you started the tunnel with `mcp-use dev --tunnel` or `mcp-use start --tunn
 Tunnels are for local testing before deployment:
 
 - The tunnel is active only while the command is running.
+- With `mcp-use dev --tunnel` or `mcp-use start --tunnel`, a dropped tunnel registration is re-established automatically while the command runs.
 - Tunnels expire after 24 hours.
 - Inactive tunnels are cleaned up after 1 hour without activity.
-- Each IP address can create up to 10 tunnels per hour.
-- Each IP address can have up to 5 active tunnels at a time.
 
 For a stable public URL, deploy the server instead of relying on a local tunnel.
 
 ## Next steps
 
-- Use the [TypeScript quickstart](/typescript/getting-started/quickstart) to create a local MCP server.
-- Use [Build your first MCP App](/typescript/mcp-apps/quickstart) to test widgets in a remote client.
-- Use [Deploy to Manufact Cloud](/typescript/server/deployment/mcp-use) when you are ready for a hosted MCP endpoint.
+- Use the [TypeScript quickstart](/v2/typescript/getting-started/quickstart) to create a server for the `mcp-use` CLI workflow.
+- Use the [Python quickstart](/python/getting-started/quickstart) to create and run a Python server, then tunnel its listening port with the standalone package.
+- Use [Build your first MCP App](/v2/typescript/mcp-apps/quickstart) to test TypeScript Views in a remote client.

--- a/docs/v2/typescript/agent/index.mdx
+++ b/docs/v2/typescript/agent/index.mdx
@@ -1,0 +1,116 @@
+---
+title: "Introduction"
+description: "Build a TypeScript MCP agent that calls tools from MCP servers."
+icon: "list-start"
+---
+
+`MCPAgent` from `@mcp-use/agent` connects a model to MCP tools, runs a bounded tool-calling loop, and returns the model's final answer.
+
+## Install the agent
+
+<CodeGroup>
+```bash npm
+npm install @mcp-use/agent @mcp-use/client
+```
+
+```bash pnpm
+pnpm add @mcp-use/agent @mcp-use/client
+```
+
+```bash bun
+bun add @mcp-use/agent @mcp-use/client
+```
+</CodeGroup>
+
+`@mcp-use/agent` requires Node.js 22.22.2 or later.
+
+## Run your first agent
+
+Set `OPENAI_API_KEY`, then run this example from a directory the filesystem server may read.
+
+```typescript
+import { MCPAgent } from "@mcp-use/agent";
+
+async function main() {
+  const agent = new MCPAgent({
+    llm: "openai/gpt-4o",
+    mcpServers: {
+      filesystem: {
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-filesystem", "./"],
+      },
+    },
+  });
+
+  try {
+    await agent.initialize();
+
+    const result = await agent.run({
+      prompt: "List the files in this directory, then summarize what the project does.",
+    });
+
+    console.log(result);
+  } finally {
+    await agent.close();
+  }
+}
+
+main().catch(console.error);
+```
+
+A successful run prints a text answer based on the files the MCP server returned.
+
+<Note>
+  Initialization is manual by default. Call `await agent.initialize()` before
+  `run()`, `stream()`, or `streamEvents()`. Set `autoInitialize: true` only when
+  you want the first call to initialize the agent for you.
+</Note>
+
+## Understand the runtime defaults
+
+`maxSteps` defaults to `10`. Override it for the agent or for one call:
+
+```typescript
+const agent = new MCPAgent({
+  llm: "openai/gpt-4o",
+  mcpServers,
+  maxSteps: 15,
+});
+
+await agent.initialize();
+const result = await agent.run({ prompt: "Complete the audit.", maxSteps: 20 });
+await agent.close();
+```
+
+Conversation memory is enabled by default. Memory stores the user prompt and final assistant text from successful `run()` and `stream()` calls. It does not store tool transcripts or `streamEvents()` output.
+
+When you pass `mcpServers`, the agent creates and owns its `MCPClient`; `close()` closes those sessions. If you pass an existing client or connectors, their lifecycle remains under your control.
+
+## Choose the next guide
+
+<CardGroup cols={2}>
+  <Card
+    title="LLM providers"
+    icon="brain-circuit"
+    href="/v2/typescript/agent/llm-providers"
+  >
+    Configure OpenAI, Anthropic, Google, OpenRouter, Ollama, or an OpenAI-compatible endpoint.
+  </Card>
+  <Card
+    title="Memory management"
+    icon="memory-stick"
+    href="/v2/typescript/agent/memory-management"
+  >
+    Inspect, disable, and clear conversation history.
+  </Card>
+  <Card title="Streaming" icon="wifi" href="/v2/typescript/agent/streaming">
+    Stream tool steps or provider-neutral events.
+  </Card>
+  <Card
+    title="LangChain integration"
+    icon="link"
+    href="/v2/typescript/agent/langchain/index"
+  >
+    Add LangChain models, structured output, Server Manager, and callbacks.
+  </Card>
+</CardGroup>

--- a/docs/v2/typescript/agent/langchain/index.mdx
+++ b/docs/v2/typescript/agent/langchain/index.mdx
@@ -1,0 +1,109 @@
+---
+title: "Overview"
+description: "Set up LangChainMCPAgent with a LangChain chat model and MCP tools."
+icon: "link"
+---
+
+`LangChainMCPAgent` connects LangChain chat models and callbacks to MCP tools. Import it from `@mcp-use/agent/langchain`.
+
+## When to use LangChainMCPAgent
+
+Use `LangChainMCPAgent` when you need at least one of these capabilities:
+
+- an existing LangChain chat model or custom LangChain tool;
+- Zod structured-output conversion after an agent run;
+- LangChain `StreamEvent` output or `prettyStreamEvents()`;
+- Server Manager for on-demand access to one MCP server's tools; or
+- LangChain callbacks, Langfuse tracing, metadata, and tags.
+
+## Install LangChainMCPAgent
+
+Install the agent package, LangChain core packages, and the provider package for your model.
+
+<CodeGroup>
+```bash npm
+npm install @mcp-use/agent @mcp-use/client langchain @langchain/core @langchain/openai
+```
+
+```bash pnpm
+pnpm add @mcp-use/agent @mcp-use/client langchain @langchain/core @langchain/openai
+```
+
+```bash bun
+bun add @mcp-use/agent @mcp-use/client langchain @langchain/core @langchain/openai
+```
+</CodeGroup>
+
+Add `zod` for structured output. Add `langfuse` and `langfuse-langchain` for built-in Langfuse tracing.
+
+## Run a LangChain agent
+
+Set `OPENAI_API_KEY`, then run:
+
+```typescript
+import { ChatOpenAI } from "@langchain/openai";
+import { MCPClient } from "@mcp-use/client";
+import { LangChainMCPAgent } from "@mcp-use/agent/langchain";
+
+async function main() {
+  const client = new MCPClient({
+    mcpServers: {
+      filesystem: {
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-filesystem", "./"],
+      },
+    },
+  });
+
+  const agent = new LangChainMCPAgent({
+    llm: new ChatOpenAI({ model: "gpt-4o", temperature: 0 }),
+    client,
+  });
+
+  try {
+    await agent.initialize();
+    const result = await agent.run({
+      prompt: "Read package.json and summarize the project scripts.",
+    });
+    console.log(result);
+  } finally {
+    await agent.close();
+  }
+}
+
+main().catch(console.error);
+```
+
+A successful run prints a text answer based on `package.json`. `LangChainMCPAgent` defaults to `5` model-call steps.
+
+<Warning>
+  `LangChainMCPAgent.close()` closes its MCP client even when you supplied that
+  client. Do not share the client with work that must continue after the agent
+  closes.
+</Warning>
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card
+    title="Structured output"
+    icon="braces"
+    href="/v2/typescript/agent/langchain/structured-output"
+  >
+    Convert final text into validated Zod data.
+  </Card>
+  <Card
+    title="Server Manager"
+    icon="server"
+    href="/v2/typescript/agent/langchain/server-manager"
+  >
+    Load one server's tools on demand.
+  </Card>
+  <Card
+    title="Observability"
+    icon="eye"
+    href="/v2/typescript/agent/langchain/observability"
+  >
+    Trace runs with Langfuse or custom callbacks.
+  </Card>
+</CardGroup>

--- a/docs/v2/typescript/agent/langchain/observability.mdx
+++ b/docs/v2/typescript/agent/langchain/observability.mdx
@@ -1,0 +1,152 @@
+---
+title: "Observability"
+description: "Trace LangChainMCPAgent runs with Langfuse or custom LangChain callbacks."
+icon: "eye"
+---
+
+`LangChainMCPAgent` passes callbacks, metadata, and tags into LangChain agent execution. Use the built-in Langfuse integration or provide your own LangChain callbacks.
+
+## Trace a run with Langfuse
+
+Install both Langfuse packages:
+
+```bash
+npm install langfuse langfuse-langchain
+```
+
+Set credentials before the process imports `@mcp-use/agent/langchain`:
+
+```bash
+export LANGFUSE_PUBLIC_KEY="pk-lf-..."
+export LANGFUSE_SECRET_KEY="sk-lf-..."
+export LANGFUSE_HOST="https://cloud.langfuse.com"
+```
+
+Then initialize and run the agent:
+
+```typescript
+import { ChatOpenAI } from "@langchain/openai";
+import { MCPClient } from "@mcp-use/client";
+import { LangChainMCPAgent } from "@mcp-use/agent/langchain";
+
+async function main() {
+  const client = new MCPClient({
+    mcpServers: {
+      filesystem: {
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-filesystem", "./"],
+      },
+    },
+  });
+
+  const agent = new LangChainMCPAgent({
+    llm: new ChatOpenAI({ model: "gpt-4o", temperature: 0 }),
+    client,
+  });
+
+  agent.setMetadata({
+    trace_name: "project-audit",
+    session_id: "session-123",
+    user_id: "user-456",
+    environment: "production",
+  });
+  agent.setTags(["docs", "project-audit"]);
+
+  try {
+    await agent.initialize();
+    const result = await agent.run({
+      prompt: "Inspect package.json and summarize the project scripts.",
+    });
+    console.log(result);
+  } finally {
+    await agent.flush();
+    await agent.close();
+  }
+}
+
+main().catch(console.error);
+```
+
+Initialization auto-detects Langfuse only when both keys are present and `langfuse-langchain` can be imported. If no handler is available, the agent still runs without traces.
+
+## Add metadata and tags
+
+`setMetadata()` merges new values into existing metadata. `setTags()` appends tags and removes duplicates. Both apply to later `stream()` and `streamEvents()` executions.
+
+Two metadata keys also control LangChain and Langfuse behavior:
+
+- `trace_name` sets the LangChain run name. The default is `mcp-use-agent`.
+- `session_id` is forwarded as the Langfuse session ID.
+
+The built-in Langfuse handler also recognizes `user_id`, adds MCP server metadata during initialization, and adds environment and agent tags when configured.
+
+Metadata keys replace characters outside letters, numbers, underscores, and hyphens with `_`. Arrays keep only primitive values. Serializable objects longer than 1,000 characters are stored as truncated strings. Unsupported or circular values are skipped.
+
+Tags allow letters, numbers, underscores, colons, and hyphens. Invalid characters become `_`, and tags longer than 50 characters are removed.
+
+## Use custom callbacks
+
+Constructor callbacks replace auto-detected callbacks; they are not merged with the built-in Langfuse handler.
+
+```typescript
+import { ChatOpenAI } from "@langchain/openai";
+import { CallbackHandler } from "langfuse-langchain";
+import { MCPClient } from "@mcp-use/client";
+import { LangChainMCPAgent } from "@mcp-use/agent/langchain";
+
+const callback = new CallbackHandler({
+  publicKey: process.env.LANGFUSE_PUBLIC_KEY,
+  secretKey: process.env.LANGFUSE_SECRET_KEY,
+  baseUrl: process.env.LANGFUSE_HOST,
+});
+
+const agent = new LangChainMCPAgent({
+  llm: new ChatOpenAI({ model: "gpt-4o" }),
+  client: new MCPClient({ mcpServers }),
+  callbacks: [callback],
+});
+
+try {
+  await agent.initialize();
+  console.log(await agent.run({ prompt: "Complete the traced task." }));
+} finally {
+  await agent.flush();
+  await agent.close();
+}
+```
+
+Custom callback objects receive normal LangChain lifecycle events. If a callback implements `flushAsync()`, `agent.flush()` calls it. During `agent.close()`, the observability manager flushes again, then calls `shutdownAsync()` or `shutdown()` when implemented.
+
+## Flush and clean up
+
+Call `await agent.flush()` before a serverless function or short-lived process exits. It waits for each configured callback's `flushAsync()` method when present.
+
+Always call `await agent.close()` for full cleanup. Closing:
+
+1. flushes and shuts down observability callbacks;
+2. clears the LangChain executor and tool list;
+3. closes the MCP client or direct connectors; and
+4. marks the agent uninitialized.
+
+## Disable callback discovery
+
+Set `observe: false` to disable all observability callbacks, including custom callbacks:
+
+```typescript
+const agent = new LangChainMCPAgent({
+  llm,
+  client,
+  observe: false,
+});
+
+await agent.initialize();
+console.log((await agent.observabilityManager.getStatus()).enabled); // false
+await agent.close();
+```
+
+Set `MCP_USE_LANGFUSE=false` when you want callbacks in general but do not want built-in Langfuse auto-detection.
+
+## Next steps
+
+- [Use structured output](/v2/typescript/agent/langchain/structured-output)
+- [Route tools with Server Manager](/v2/typescript/agent/langchain/server-manager)

--- a/docs/v2/typescript/agent/langchain/server-manager.mdx
+++ b/docs/v2/typescript/agent/langchain/server-manager.mdx
@@ -1,0 +1,114 @@
+---
+title: "Server Manager"
+description: "Let LangChainMCPAgent load one MCP server's tools on demand."
+icon: "server"
+---
+
+Server Manager gives `LangChainMCPAgent` management tools first, then exposes the active MCP server's tools after the model selects a server. Use it when loading every tool from every configured server would create an oversized or confusing tool list.
+
+## Enable Server Manager
+
+Server Manager requires explicit mode with an `MCPClient`. It cannot run with connectors alone.
+
+```typescript
+import { ChatOpenAI } from "@langchain/openai";
+import { MCPClient } from "@mcp-use/client";
+import { LangChainMCPAgent } from "@mcp-use/agent/langchain";
+
+async function main() {
+  const client = new MCPClient({
+    mcpServers: {
+      filesystem: {
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+      },
+      browser: {
+        command: "npx",
+        args: ["@playwright/mcp@latest"],
+      },
+    },
+  });
+
+  const agent = new LangChainMCPAgent({
+    llm: new ChatOpenAI({ model: "gpt-4o", temperature: 0 }),
+    client,
+    useServerManager: true,
+    maxSteps: 12,
+  });
+
+  try {
+    await agent.initialize();
+    const result = await agent.run({
+      prompt:
+        "List the available MCP servers, select the filesystem server, and summarize /tmp.",
+    });
+    console.log(result);
+  } finally {
+    await agent.close();
+  }
+}
+
+main().catch(console.error);
+```
+
+A successful run lists the configured servers, activates `filesystem`, and uses its tools. The agent rebuilds its LangChain executor when the active tool set changes.
+
+## Understand the management tools
+
+| Tool | Behavior |
+| --- | --- |
+| `list_mcp_servers` | Lists configured server names and cached item counts. Counts can be zero before tools are loaded or prefetched. |
+| `connect_to_mcp_server` | Reuses or creates a session, activates the server, and loads its tools, resources, and prompts when not cached. |
+| `get_active_mcp_server` | Reports the selected active server without changing it. |
+| `disconnect_from_mcp_server` | Releases the active selection so its cached tools are no longer exposed. |
+| `add_mcp_server_from_config` | Adds a server, creates its session, loads its tools, and makes it active. |
+
+Only one server is active at a time. The five management tools remain available alongside the active server's cached tools.
+
+<Note>
+  `add_mcp_server_from_config` loads tools only.
+  `connect_to_mcp_server` loads tools, resources, and prompts when it first
+  caches a configured server.
+</Note>
+
+## Release a server without closing its session
+
+Despite its tool name, `disconnect_from_mcp_server` does not close the underlying MCP session. It sets the active server to `null`; the session and cached tools remain available for later selection.
+
+Use `await agent.close()` to finish the agent lifecycle. `LangChainMCPAgent` shuts down observability, clears its executor and tools, and closes the `MCPClient` sessions.
+
+## Customize the manager
+
+Import `ServerManager` and `LangChainAdapter` from the LangChain subpath. Use `serverManagerFactory` when you need to prefetch tools or provide a custom manager instance.
+
+```typescript
+import {
+  LangChainAdapter,
+  LangChainMCPAgent,
+  ServerManager,
+} from "@mcp-use/agent/langchain";
+
+const agent = new LangChainMCPAgent({
+  llm,
+  client,
+  useServerManager: true,
+  serverManagerFactory: (managerClient) => {
+    const adapter = new LangChainAdapter();
+    return new ServerManager(managerClient, adapter);
+  },
+});
+
+await agent.initialize();
+await agent.close();
+```
+
+`prefetchServerTools()` caches tools, resources, and prompts for configured servers. It can create sessions and leaves those sessions open until client cleanup.
+
+## Know when to skip it
+
+For one or two small servers, load tools normally. Server Manager adds a model decision before the first server tool call and can restart execution when the exposed tool set changes.
+
+## Next steps
+
+- [Set up LangChainMCPAgent](/v2/typescript/agent/langchain/index)
+- [Trace Server Manager runs](/v2/typescript/agent/langchain/observability)

--- a/docs/v2/typescript/agent/langchain/structured-output.mdx
+++ b/docs/v2/typescript/agent/langchain/structured-output.mdx
@@ -1,0 +1,143 @@
+---
+title: "Structured output"
+description: "Convert LangChainMCPAgent results into validated Zod data."
+icon: "braces"
+---
+
+Pass a Zod `schema` to `LangChainMCPAgent` when you need validated data. The agent completes the task first, then asks the model to convert the final text and validates the result with Zod.
+
+## Return a typed result
+
+Install `zod`, set `OPENAI_API_KEY`, and run:
+
+```typescript
+import { ChatOpenAI } from "@langchain/openai";
+import { MCPClient } from "@mcp-use/client";
+import { LangChainMCPAgent } from "@mcp-use/agent/langchain";
+import { z } from "zod";
+
+const ProjectSummary = z.object({
+  packageName: z.string().nullable(),
+  scripts: z.array(z.string()),
+  hasTests: z.boolean(),
+  notes: z.string(),
+});
+
+async function main() {
+  const client = new MCPClient({
+    mcpServers: {
+      filesystem: {
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-filesystem", "./"],
+      },
+    },
+  });
+
+  const agent = new LangChainMCPAgent({
+    llm: new ChatOpenAI({ model: "gpt-4o", temperature: 0 }),
+    client,
+    maxSteps: 8,
+  });
+
+  try {
+    await agent.initialize();
+    const summary = await agent.run({
+      prompt: "Inspect package.json and summarize the project.",
+      schema: ProjectSummary,
+    });
+
+    console.log(summary.scripts);
+  } finally {
+    await agent.close();
+  }
+}
+
+main().catch(console.error);
+```
+
+A successful call returns `z.infer<typeof ProjectSummary>`. It does not return the raw final text.
+
+## Choose a structured-output method
+
+| Method | During agent execution | Structured result | Conversion failure |
+| --- | --- | --- | --- |
+| `run()` | Does not yield progress | Resolves to the validated value | Rejects with `Failed to generate structured output: ...` |
+| `stream()` | Yields tool-call `AgentStep` values | Returns the validated value from the generator | Throws from the generator |
+| `streamEvents()` | Yields LangChain v2 events | Emits `on_structured_output` after the LangChain stream | Emits `on_structured_output_error`; it does not return the value |
+
+`run()` consumes `stream()` internally, so both methods use the same conversion path.
+
+## Read the return value from `stream()`
+
+A `for await` loop cannot read an async generator's return value. Call `next()` until `done` when you need the validated result:
+
+```typescript
+const stream = agent.stream({
+  prompt: "Inspect package.json and summarize the project.",
+  schema: ProjectSummary,
+});
+
+while (true) {
+  const next = await stream.next();
+
+  if (next.done) {
+    console.log(next.value.scripts);
+    break;
+  }
+
+  console.log(`Called ${next.value.action.tool}`);
+}
+```
+
+Tool steps are yielded before conversion. Conversion begins only after the agent produces non-empty final text.
+
+## Handle structured events
+
+`streamEvents()` adds the schema description to the task so the agent gathers the required fields. It yields the underlying LangChain v2 events first, then custom conversion events:
+
+```typescript
+for await (const event of agent.streamEvents({
+  prompt: "Inspect package.json and summarize the project.",
+  schema: ProjectSummary,
+})) {
+  if (event.event === "on_structured_output_progress") {
+    console.log(event.data?.message);
+  }
+
+  if (event.event === "on_structured_output") {
+    const summary = ProjectSummary.parse(event.data?.output);
+    console.log(summary.scripts);
+  }
+
+  if (event.event === "on_structured_output_error") {
+    throw new Error(String(event.data?.error));
+  }
+}
+```
+
+Progress events are emitted every two seconds while conversion is still running. `streamEvents()` returns `void`; store the `on_structured_output` payload yourself.
+
+## Handle validation boundaries
+
+`LangChainMCPAgent` uses `withStructuredOutput(schema)` when the model implements it. Otherwise, it prompts the same model to format JSON. It validates the result and retries conversion up to three times, including the previous validation error in later attempts.
+
+After three failures, the conversion error includes:
+
+```text
+Failed to generate valid structured output after 3 attempts. Last error: ...
+```
+
+`run()` and `stream()` wrap that message in `Failed to generate structured output: ...`. `streamEvents()` emits the message in `on_structured_output_error`.
+
+Required fields fail validation when they are `null`, `undefined`, an empty string, or an empty array, even if a broad Zod schema would otherwise accept the empty value. Mark genuinely missing values as optional or nullable.
+
+<Warning>
+  Conversion runs only when the agent produces non-empty final text. If no final
+  text exists, `run()` and `stream()` currently return `"No output generated"`
+  even when `schema` is set. Treat that string as an unsuccessful structured
+  result.
+</Warning>
+
+## Next steps
+
+- [Trace LangChain runs](/v2/typescript/agent/langchain/observability)

--- a/docs/v2/typescript/agent/llm-providers.mdx
+++ b/docs/v2/typescript/agent/llm-providers.mdx
@@ -1,0 +1,106 @@
+---
+title: "LLM providers"
+description: "Configure MCPAgent for OpenAI, Anthropic, Google, OpenRouter, Ollama, or an OpenAI-compatible endpoint."
+icon: "brain-circuit"
+---
+
+`MCPAgent` supports OpenAI, Anthropic, Google, OpenRouter, Ollama, and OpenAI-compatible endpoints. Configure a provider with a `"provider/model"` string or a `ProviderConfig`.
+
+## Choose a provider
+
+| Provider prefix     | API key lookup                                     | Configuration note                                    |
+| ------------------- | -------------------------------------------------- | ----------------------------------------------------- |
+| `openai`            | `OPENAI_API_KEY`                                   | Uses the built-in OpenAI provider.                    |
+| `anthropic`         | `ANTHROPIC_API_KEY`                                | Uses the built-in Anthropic provider.                 |
+| `google`            | `GOOGLE_API_KEY` or `GOOGLE_GENERATIVE_AI_API_KEY` | Uses the built-in Google provider.                    |
+| `openrouter`        | `OPENROUTER_API_KEY`                               | Model names may contain `/`, such as `openai/gpt-4o`. |
+| `ollama`            | No key required                                    | Defaults to `http://localhost:11434`.                 |
+| `openai-compatible` | `OPENAI_API_KEY` or `llmConfig.apiKey`             | Requires the endpoint in `llmConfig.baseUrl`.         |
+
+## Configure a provider string
+
+Set the provider's environment variable before starting the process. The agent resolves the key when it initializes.
+
+```typescript
+import { MCPAgent } from "@mcp-use/agent";
+
+async function main() {
+  const agent = new MCPAgent({
+    llm: "anthropic/claude-sonnet-4-6",
+    llmConfig: {
+      temperature: 0.2,
+      maxTokens: 1_000,
+    },
+    mcpServers: {
+      filesystem: {
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-filesystem", "./"],
+      },
+    },
+  });
+
+  try {
+    await agent.initialize();
+    const result = await agent.run({
+      prompt: "Read package.json and list the available scripts.",
+    });
+    console.log(result);
+  } finally {
+    await agent.close();
+  }
+}
+
+main().catch(console.error);
+```
+
+A successful run prints scripts found through the filesystem MCP server.
+
+The string parser accepts model names that contain `/`. For example, `openrouter/openai/gpt-4o` selects the `openrouter` provider and passes `openai/gpt-4o` as the model name.
+
+## Connect an OpenAI-compatible endpoint
+
+Use `openai-compatible` for an endpoint that implements OpenAI chat-completions semantics. Supply the full API base URL and any required headers.
+
+```typescript
+import { MCPAgent, type ProviderConfig } from "@mcp-use/agent";
+
+const provider: ProviderConfig = {
+  provider: "openai-compatible",
+  model: "my-tool-calling-model",
+  apiKey: process.env.COMPATIBLE_API_KEY ?? "local",
+  baseUrl: "http://localhost:8000/v1",
+  extraHeaders: {
+    "X-Workspace": "docs-example",
+  },
+};
+
+const agent = new MCPAgent({ llm: provider, mcpServers });
+
+try {
+  await agent.initialize();
+  const result = await agent.run({
+    prompt: "Call one available tool and report its result.",
+  });
+  console.log(result);
+} finally {
+  await agent.close();
+}
+```
+
+Verify that the selected model supports tool calling. A reachable text-only model cannot use MCP tools.
+
+## Handle configuration errors
+
+Initialization throws when:
+
+- a provider string is not in `provider/model` form;
+- the provider prefix is unsupported;
+- a required API key is missing; or
+- no model driver can be created.
+
+Keep provider-specific tuning in `llmConfig` or `ProviderConfig`. See the [MCPAgent API reference](https://mcp-use-typescript-api-reference.vercel.app/modules/_mcp-use_agent.index.html#mcpagent) for the complete option types.
+
+## Next steps
+
+- [Build an MCP agent](/v2/typescript/agent/index)
+- [Stream agent output](/v2/typescript/agent/streaming)

--- a/docs/v2/typescript/agent/memory-management.mdx
+++ b/docs/v2/typescript/agent/memory-management.mdx
@@ -1,0 +1,109 @@
+---
+title: "Memory management"
+description: "Inspect, disable, persist, and clear MCPAgent conversation history."
+icon: "memory-stick"
+---
+
+`MCPAgent` keeps conversation history in memory by default. Successful `run()` and `stream()` calls store the user prompt and final assistant text as `ProviderMessage[]`.
+
+## Keep conversation context
+
+This example completes two turns, inspects the stored messages, and then clears them.
+
+```typescript
+import { MCPAgent, type ProviderMessage } from "@mcp-use/agent";
+
+async function main() {
+  const agent = new MCPAgent({
+    llm: "openai/gpt-4o",
+    mcpServers: {
+      filesystem: {
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-filesystem", "./"],
+      },
+    },
+  });
+
+  try {
+    await agent.initialize();
+
+    await agent.run({ prompt: "My project codename is Cedar." });
+    const answer = await agent.run({ prompt: "What is the project codename?" });
+    console.log(answer);
+
+    const history: ProviderMessage[] = agent.getConversationHistory();
+    console.log(history.map(({ role, content }) => ({ role, content })));
+
+    agent.clearConversationHistory();
+    console.log(agent.getConversationHistory().length); // 0
+  } finally {
+    await agent.close();
+  }
+}
+
+main().catch(console.error);
+```
+
+After two successful calls, history normally contains four messages: one user and one assistant message for each turn.
+
+## Know what is stored
+
+Conversation history uses the provider-neutral `ProviderMessage` shape. Each message has a `role` and `content`; provider messages can also represent tool calls and results.
+
+The agent's automatic memory is narrower:
+
+- `run()` and `stream()` append the prompt and final assistant text after a successful call.
+- Tool calls and tool results are not appended to automatic memory.
+- `streamEvents()` does not append any conversation history.
+- Per-call `messages` and `externalHistory` affect that call but are not copied into stored history.
+- A failed or aborted call does not append the prompt as a completed turn.
+
+`getConversationHistory()` returns a new array. Changing that array does not replace agent memory, although message objects inside it are not deep-cloned.
+
+## Disable memory
+
+Set `memoryEnabled: false` when every call must start with only the system prompt, per-call messages, and current prompt.
+
+```typescript
+const agent = new MCPAgent({
+  llm: "openai/gpt-4o",
+  mcpServers,
+  memoryEnabled: false,
+});
+
+await agent.initialize();
+await agent.run({ prompt: "Remember the number 42." });
+const result = await agent.run({ prompt: "What number did I give you?" });
+console.log(result);
+await agent.close();
+```
+
+With memory disabled, the second call does not receive the first turn from agent memory.
+
+## Persist history outside the agent
+
+History lives only on the `MCPAgent` instance. It is not written to disk or restored after a process restart.
+
+Store `getConversationHistory()` in your application if you need durable conversations. Pass restored `ProviderMessage` values through `messages` for a later call:
+
+```typescript
+const savedHistory: ProviderMessage[] = agent.getConversationHistory();
+
+const result = await anotherAgent.run({
+  messages: savedHistory,
+  prompt: "Continue from the saved conversation.",
+});
+```
+
+Passing `messages` provides context for that call. It does not seed `anotherAgent`'s internal history.
+
+## Clear a conversation
+
+`clearConversationHistory()` removes all stored conversation messages immediately. The system prompt is held separately, so clearing history does not change it.
+
+Closing an agent does not clear its in-memory history. If you initialize the same instance again, its stored conversation remains until you clear it or discard the instance.
+
+## Next steps
+
+- [Stream agent output](/v2/typescript/agent/streaming)
+- [Configure an LLM provider](/v2/typescript/agent/llm-providers)

--- a/docs/v2/typescript/agent/streaming.mdx
+++ b/docs/v2/typescript/agent/streaming.mdx
@@ -1,0 +1,157 @@
+---
+title: "Streaming"
+description: "Stream MCPAgent tool steps and provider-neutral LLM events."
+icon: "arrow-up-down"
+---
+
+`MCPAgent` provides two streaming APIs. Use `stream()` for tool-step progress and a final string. Use `streamEvents()` for provider-neutral token, tool, usage, error, and completion events.
+
+| Method | Use it for | Output |
+| --- | --- | --- |
+| `stream()` | Tool progress and a final answer | Yields `AgentStep`; returns the final string |
+| `streamEvents()` | Token UIs and detailed tool lifecycle state | Yields `LlmStreamEvent`; returns `void` |
+
+## Stream tool steps
+
+Read the generator directly when you need both yielded steps and its final return value.
+
+```typescript
+import { MCPAgent } from "@mcp-use/agent";
+
+async function main() {
+  const agent = new MCPAgent({
+    llm: "openai/gpt-4o",
+    mcpServers: {
+      filesystem: {
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-filesystem", "./"],
+      },
+    },
+  });
+
+  try {
+    await agent.initialize();
+    const stream = agent.stream({
+      prompt: "Inspect package.json and summarize the project scripts.",
+    });
+
+    while (true) {
+      const next = await stream.next();
+
+      if (next.done) {
+        console.log("Final answer:", next.value);
+        break;
+      }
+
+      console.log(`Tool: ${next.value.action.tool}`);
+      console.log(`Input: ${JSON.stringify(next.value.action.toolInput)}`);
+      if (next.value.observation) {
+        console.log(`Result: ${next.value.observation}`);
+      }
+    }
+  } finally {
+    await agent.close();
+  }
+}
+
+main().catch(console.error);
+```
+
+For each tool call, `stream()` can yield an initial step with an empty `observation`, followed by another step containing the tool result. A `for await` loop receives the steps but does not expose the generator's final return value.
+
+## Stream provider-neutral events
+
+`streamEvents()` uses the same `LlmStreamEvent` variants for every supported provider.
+
+```typescript
+import { MCPAgent, type LlmStreamEvent } from "@mcp-use/agent";
+
+async function main() {
+  const agent = new MCPAgent({
+    llm: "openai/gpt-4o",
+    mcpServers: {
+      filesystem: {
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-filesystem", "./"],
+      },
+    },
+  });
+
+  let answer = "";
+
+  try {
+    await agent.initialize();
+
+    for await (const event of agent.streamEvents({
+      prompt: "List the TypeScript files and summarize their purpose.",
+    })) {
+      handleEvent(event);
+      if (event.type === "text-delta") {
+        answer += event.delta;
+      }
+    }
+
+    console.log("\nFinal answer:", answer);
+  } finally {
+    await agent.close();
+  }
+}
+
+function handleEvent(event: LlmStreamEvent) {
+  switch (event.type) {
+    case "tool-call-ready":
+      console.log(`\nCalling ${event.toolName}`, event.args);
+      break;
+    case "tool-result":
+      console.log(`\n${event.toolName} finished; error=${event.isError}`);
+      break;
+    case "error":
+      console.error(`\nModel error: ${event.message}`);
+      break;
+  }
+}
+
+main().catch(console.error);
+```
+
+Accumulate `text-delta` values when your UI needs the complete final answer. `streamEvents()` itself returns no result and does not write the streamed turn to conversation memory.
+
+## Handle every event variant
+
+| `type` | Meaning |
+| --- | --- |
+| `text-delta` | A text fragment from the model |
+| `tool-call-start` | The model started producing a tool call |
+| `tool-call-args-delta` | A partial JSON argument fragment; concatenate fragments before parsing |
+| `tool-call-ready` | A complete tool name and parsed argument object |
+| `tool-result` | The tool result, with `isError` indicating tool failure |
+| `usage` | Provider token usage, when available |
+| `error` | A model-loop error message |
+| `done` | The tool loop finished |
+
+Tool execution failures are emitted as `tool-result` with `isError: true`. Other streaming failures can appear as `error`. Decide whether your UI should show a partial answer, retry, or fail the request.
+
+## Cancel a stream
+
+Pass an `AbortSignal` through the run options:
+
+```typescript
+const controller = new AbortController();
+const timeout = setTimeout(() => controller.abort(), 5_000);
+
+try {
+  for await (const event of agent.streamEvents({
+    prompt: "Perform a long audit.",
+    signal: controller.signal,
+  })) {
+    console.log(event.type);
+  }
+} finally {
+  clearTimeout(timeout);
+}
+```
+
+## Next steps
+
+- [Manage conversation memory](/v2/typescript/agent/memory-management)
+- [Configure an LLM provider](/v2/typescript/agent/llm-providers)

--- a/docs/v2/typescript/api-reference/cli-reference.mdx
+++ b/docs/v2/typescript/api-reference/cli-reference.mdx
@@ -1,0 +1,654 @@
+---
+title: "CLI Reference"
+description: "Command reference for the @mcp-use/cli package and mcp-use executable."
+icon: "terminal"
+---
+
+The `mcp-use` package installs the `mcp-use` executable and includes the prebuilt `@mcp-use/cli` implementation. Use this page as the exhaustive command reference for local development, production builds, cloud deploys, saved MCP client sessions, and CLI environment variables.
+
+For hands-on workflows, see the [CLI Client guide](/v2/typescript/tooling/client-cli), [Tunneling guide](/tunneling/index), and [Manufact Cloud deployment guide](/v2/typescript/server/deployment/mcp-use).
+
+## Command map
+
+<CardGroup cols={2}>
+  <Card title="Run locally" icon="flame" href="#dev">
+    `mcp-use dev` starts the development server, view watcher, and Inspector.
+  </Card>
+  <Card title="Build and start" icon="box" href="#build">
+    `mcp-use build` writes production artifacts. `mcp-use start` runs the built
+    server.
+  </Card>
+  <Card title="Deploy" icon="cloud-upload" href="#deploy">
+    `mcp-use deploy`, `mcp-use deployments`, and `mcp-use servers` manage
+    Manufact Cloud resources.
+  </Card>
+  <Card title="Client CLI" icon="terminal" href="#client">
+    `mcp-use client` saves MCP servers, calls tools, reads resources, gets
+    prompts, and handles OAuth.
+  </Card>
+  <Card title="Tunnels" icon="train-front-tunnel" href="#tunneling-reference">
+    `mcp-use dev --tunnel` exposes a local server through a public URL.
+  </Card>
+  <Card title="Typecheck" icon="wand" href="#typecheck">
+    `mcp-use typecheck` refreshes MCP view types and runs the project's own
+    TypeScript compiler.
+  </Card>
+</CardGroup>
+
+## Install the CLI
+
+Most projects install the framework, CLI, and Inspector together:
+
+```bash
+npm install mcp-use
+```
+
+The CLI package can also be installed directly:
+
+```bash
+npm install -g @mcp-use/cli
+```
+
+```bash
+npx @mcp-use/cli dev
+```
+
+```bash
+npm install --save-dev @mcp-use/cli
+```
+
+<Tip>
+  `create-mcp-use-app` installs `mcp-use`, which supplies the CLI and Inspector
+  at matching versions.
+</Tip>
+
+## `dev`
+
+**Purpose:** Start a development server with TypeScript watching, view builds, automatic reloads, and the Inspector.
+
+**Syntax:**
+
+```bash
+mcp-use dev [options]
+```
+
+**Options:**
+
+| Option              | Description                                                              | Default                        |
+| ------------------- | ------------------------------------------------------------------------ | ------------------------------ |
+| `--path <path>`     | Project root used for entry/view discovery, `.env`, and `tsconfig.json`. | Current directory              |
+| `--entry <file>`    | MCP server entry file, relative to the project.                          | Auto-detected                  |
+| `--mcp-dir <dir>`   | MCP source directory containing the entry and `views/`.                  | None                           |
+| `--views-dir <dir>` | View directory, relative to the project root.                            | `views/` or `<mcp-dir>/views/` |
+| `--port <port>`     | Server port.                                                             | `PORT` or `3000`               |
+| `--host <host>`     | Bind address. Use `0.0.0.0` to listen on all interfaces.                 | `HOST` or `127.0.0.1`          |
+| `--no-open`         | Do not open the Inspector automatically.                                 | Opens by default               |
+| `--no-inspector`    | Run without loading the project-local Inspector.                         | Inspector enabled              |
+| `--tunnel`          | Create a public tunnel for the local server.                             | Disabled                       |
+
+**Examples:**
+
+```bash
+mcp-use dev
+mcp-use dev --port 8080
+mcp-use dev --host 127.0.0.1 --no-open
+mcp-use dev --mcp-dir src/mcp
+mcp-use dev --entry src/server.ts --views-dir src/views
+mcp-use dev --path apps/web --entry ../mcp/src/server.ts --views-dir ../mcp/src/views
+mcp-use dev --tunnel
+```
+
+**Notes and behavior:**
+
+- The MCP endpoint is served at `/mcp`.
+- Address precedence is `--port` / `--host`, then `PORT` / `HOST`, then the defaults. `dev` does not import the server until after its listener is chosen, so it cannot use a server-configured address.
+- The Inspector supplied by `mcp-use` is mounted at `/mcp/inspector` and opens automatically unless `--no-open` is set.
+- Inspector UI, proxy, and OAuth routes remain local-only. A public tunnel exposes the MCP endpoint but returns `404` for `/mcp/inspector`.
+- The command sets `NODE_ENV=development`, sets `PORT`, and sets `MCP_URL` to the tunnel URL or local server URL when `MCP_URL` is not already set.
+- Source changes reload the exported server without dropping the long-lived HTTP listener. View modules use Vite HMR when views exist at startup.
+- Adding the first view to a project that started with none requires restarting `mcp-use dev`.
+- `mcp-use dev` writes development session metadata to `.mcp-use/sessions.json`.
+- See [Tunneling reference](#tunneling-reference) for the lifecycle and limits of `--tunnel`.
+
+## `typecheck`
+
+**Purpose:** Refresh the managed `mcp-env.d.ts` declaration for the discovered server entry, then run the project's installed TypeScript compiler with `--noEmit`.
+
+**Syntax:**
+
+```bash
+mcp-use typecheck [options] [-- <tsc-options>]
+```
+
+The command accepts `--path`, `--entry`, and `--mcp-dir` with the same meanings as `dev` and `build`. Arguments after `--` are forwarded to TypeScript:
+
+```bash
+mcp-use typecheck
+mcp-use typecheck --entry src/server.ts
+mcp-use typecheck -- --project tsconfig.check.json --pretty false
+```
+
+`mcp-env.d.ts` is scaffolded into new projects, so editors and plain `tsc --noEmit` work before the first CLI run. The command refreshes declarations carrying an mcp-use generated header when the entry changes and never overwrites a user-owned declaration. TypeScript must be installed in the selected project.
+
+## `build`
+
+**Purpose:** Build the exported MCP server and its views into `.mcp-use/build/`.
+
+**Syntax:**
+
+```bash
+mcp-use build [options]
+```
+
+**Options:**
+
+| Option              | Description                                                              | Default                        |
+| ------------------- | ------------------------------------------------------------------------ | ------------------------------ |
+| `--path <path>`     | Project root used for entry/view discovery, `.env`, and `tsconfig.json`. | Current directory              |
+| `--entry <file>`    | MCP server entry file, relative to the project.                          | Auto-detected                  |
+| `--mcp-dir <dir>`   | MCP source directory containing the entry and `views/`.                  | None                           |
+| `--views-dir <dir>` | View directory, relative to the project root.                            | `views/` or `<mcp-dir>/views/` |
+| `--source-maps`     | Emit source maps for server and external view bundles.                   | Disabled                       |
+| `--inline`          | Embed each view's bundled JavaScript and CSS in its MCP resource.        | Disabled                       |
+
+**Examples:**
+
+```bash
+mcp-use build
+mcp-use build --inline
+mcp-use build --mcp-dir src/mcp
+mcp-use build --entry src/server.ts --views-dir src/views
+mcp-use build --path ./my-server
+```
+
+**Notes and behavior:**
+
+- The command bundles the default-exported server as `.mcp-use/build/index.js` and writes `.mcp-use/build/manifest.json`.
+- Each `views/<name>/view.tsx` builds to hashed external assets under `.mcp-use/build/views/<name>/` by default.
+- Pass `--inline` to embed each view's bundled JavaScript and CSS directly in the HTML returned by `resources/read`. There is no `--no-inline`; omit `--inline` to use external assets.
+- The build is transpile-only. Run `mcp-use typecheck` as a separate project script when type checking is required.
+- TypeScript path aliases come from the selected project's `tsconfig.json`.
+- If `MCP_ASSETS_URL` is set for an external build, view paths are rewritten to that asset origin using the server's `basePath`. Inline view bundles are not rewritten.
+- The selected project's `public/` directory is copied to `.mcp-use/build/views/public/`.
+
+## `start`
+
+**Purpose:** Run the production server previously written to `.mcp-use/build/`.
+
+**Syntax:**
+
+```bash
+mcp-use start [options]
+```
+
+**Options:**
+
+| Option             | Description                                              | Default                               |
+| ------------------ | -------------------------------------------------------- | ------------------------------------- |
+| `--path <path>`    | Project root containing `.mcp-use/build/`.               | Current directory                     |
+| `--port <port>`    | Server port.                                             | `PORT`, server config, or `3000`      |
+| `--host <host>`    | Bind address. Use `0.0.0.0` to listen on all interfaces. | `HOST`, server config, or `127.0.0.1` |
+| `--with-inspector` | Mount the bundled Inspector at `${basePath}/inspector`.  | Disabled                              |
+| `--tunnel`         | Create a public tunnel for the production server.        | Disabled                              |
+
+**Examples:**
+
+```bash
+mcp-use start
+mcp-use start --port 8080
+mcp-use start --host 0.0.0.0
+mcp-use start --with-inspector
+mcp-use start --path ./my-server
+mcp-use start --tunnel
+```
+
+**Notes and behavior:**
+
+- Address precedence is CLI flag, environment variable, server configuration, then default: `--port` → `PORT` → `config.port` → `3000`, and `--host` → `HOST` → `config.host` → `127.0.0.1`.
+- `--tunnel` starts the tunnel only after the production server binds. The command prints the public MCP URL and closes the tunnel when the process shuts down.
+- The command requires `.mcp-use/build/manifest.json`; run `mcp-use build` first.
+- It imports the manifest's built `entryPoint` and requires that module to default-export an `MCPServer`.
+- `start` does not rediscover source entries or views. `--entry`, `--mcp-dir`, and `--views-dir` belong to `dev` and `build`.
+- The command sets `NODE_ENV=production` when it is not already defined and loads the selected project's production `.env` values before importing the built entry.
+- The build manifest never records Inspector state. `--with-inspector` is a runtime-only opt-in that mounts the Inspector on the same listener; it does not rebuild or alter `.mcp-use/build`.
+- The Inspector can call tools and proxy OAuth flows. Keep `--with-inspector` behind access controls when serving beyond localhost.
+
+## Tunneling reference
+
+`mcp-use dev --tunnel` and `mcp-use start --tunnel` create a public URL that forwards to the local MCP server.
+
+```bash
+mcp-use dev --tunnel
+mcp-use start --tunnel
+```
+
+Tunnel limits and lifecycle:
+
+| Limit or behavior       | Value                                        |
+| ----------------------- | -------------------------------------------- |
+| Tunnel lifetime         | Expires 24 hours after creation              |
+| Inactive tunnel cleanup | 1 hour of no activity                        |
+| Creation rate limit     | 10 tunnel creations per IP per hour          |
+| Active tunnel limit     | 5 active tunnels per IP                      |
+| Close behavior          | The tunnel closes when the CLI process exits |
+
+The standalone package is also available:
+
+```bash
+npx @mcp-use/tunnel 3000
+```
+
+See the [Tunneling guide](/tunneling/index) for client setup and testing workflows.
+
+## `deploy`
+
+**Purpose:** Create or update a Manufact Cloud deployment for an MCP server.
+
+**Syntax:**
+
+```bash
+mcp-use deploy [options]
+```
+
+**Options:**
+
+| Option                    | Description                                                                            | Default            |
+| ------------------------- | -------------------------------------------------------------------------------------- | ------------------ |
+| `--open`                  | Open the deployment in a browser after a successful deploy.                            | Disabled           |
+| `--name <name>`           | Deployment or server name.                                                             | Auto-generated     |
+| `--port <port>`           | Server port used by the deployed process.                                              | `3000`             |
+| `--runtime <runtime>`     | Runtime, either `node` or `python`.                                                    | Auto-detected      |
+| `--new`                   | Create a new deployment instead of reusing the linked project.                         | Disabled           |
+| `--env <key=value...>`    | Environment variable assignment. Repeatable.                                           | None               |
+| `--env-file <path>`       | Load environment variables from a `.env` file.                                         | None               |
+| `--branch <name>`         | Branch to deploy. Also scopes env sync to that branch preview environment.             | Current git branch |
+| `--root-dir <path>`       | Root directory inside the repository for monorepos.                                    | Repository root    |
+| `--org <slug-or-id>`      | Target organization.                                                                   | Active org         |
+| `-y, --yes`               | Skip confirmation prompts.                                                             | Disabled           |
+| `--region <region>`       | Deployment region: `US`, `EU`, or `APAC`.                                              | `US`               |
+| `--build-command <cmd>`   | Build command override.                                                                | Auto-detected      |
+| `--start-command <cmd>`   | Start command override.                                                                | Auto-detected      |
+| `--dockerfile <path>`     | Non-default Dockerfile path, relative to `--root-dir` or repository root.              | None               |
+| `--watch-paths <glob...>` | Only auto-deploy when matching files change. Set on new-server creation for monorepos. | All changes        |
+| `--wait-for-ci`           | Hold GitHub auto-deploys until other check runs pass. Set on new-server creation.      | Disabled           |
+| `--no-github`             | Upload local source without connecting GitHub.                                         | Disabled           |
+
+**Examples:**
+
+```bash
+mcp-use deploy
+mcp-use deploy --no-github
+mcp-use deploy --name my-server --open
+mcp-use deploy --env DATABASE_URL=postgres://... --env API_KEY=secret
+mcp-use deploy --env-file .env.production
+mcp-use deploy --runtime python
+mcp-use deploy --root-dir apps/mcp-server
+mcp-use deploy --root-dir apps/mcp-server --watch-paths "apps/mcp-server/**" "packages/shared/**"
+mcp-use deploy --new --name my-server-v2
+mcp-use deploy --org manufact-inc --region EU --yes
+```
+
+**Notes and behavior:**
+
+- The default path deploys from GitHub and prompts to install or connect the GitHub App when needed.
+- `--no-github` packs and uploads local source to a platform-managed repository.
+- Redeploys of a project already linked to a platform-managed server auto-detect the upload path. `--no-github` is only required on the first deploy for that path.
+- The command writes `.mcp-use/project.json` to link the local project to the cloud server.
+- The CLI adds `.mcp-use/` to `.gitignore` when it writes a project link.
+- Environment variables passed through `--env` and `--env-file` are synced to the target branch preview environment when `--branch` is set.
+
+## Authentication commands
+
+Authentication commands manage the user-level Manufact Cloud credentials in `~/.mcp-use/config.json`.
+
+### `login`
+
+**Purpose:** Authenticate the CLI with Manufact Cloud.
+
+**Syntax:**
+
+```bash
+mcp-use login [options]
+```
+
+**Options:**
+
+| Option                 | Description                                                | Default             |
+| ---------------------- | ---------------------------------------------------------- | ------------------- |
+| `--api-key <key>`      | Authenticate with an API key.                              | Browser/device flow |
+| `--device-code <code>` | Redeem a short-lived, pre-approved RFC 8628 device code.   | None                |
+| `--org <id-or-slug>`   | Select the active organization by ID or slug.              | Account default     |
+| `--no-open`            | Do not open the verification URL during interactive login. | Opens on a TTY      |
+| `--json`               | Emit one machine-readable JSON result.                     | Human-readable text |
+
+**Examples:**
+
+```bash
+mcp-use login
+mcp-use login --device-code ABC123
+mcp-use login --api-key mcp_... --org my-org
+```
+
+**Notes and behavior:**
+
+- Interactive login starts a device-code flow and opens a browser.
+- `--device-code` skips the browser and redeems the code through the same token endpoint. The CLI then creates, validates, and stores a persistent API key.
+- `--api-key` and `--device-code` cannot be combined. An explicit `--device-code` takes precedence over `MCP_USE_API_KEY`.
+- The CLI never writes the device code, bearer token, or API key to human-readable or JSON output.
+- If `--org` is omitted, the CLI stores the account-default organization when one is available.
+- `MCP_USE_API_KEY` can provide the API key for non-interactive login.
+
+### `whoami`
+
+**Purpose:** Print the current authentication status and user information.
+
+**Syntax:**
+
+```bash
+mcp-use whoami
+```
+
+**Options:** None.
+
+**Examples:**
+
+```bash
+mcp-use whoami
+```
+
+**Notes and behavior:** The command reads `~/.mcp-use/config.json`.
+
+### `logout`
+
+**Purpose:** Remove saved Manufact Cloud credentials.
+
+**Syntax:**
+
+```bash
+mcp-use logout
+```
+
+**Options:** None.
+
+**Examples:**
+
+```bash
+mcp-use logout
+```
+
+**Notes and behavior:** The command removes credentials from `~/.mcp-use/config.json`.
+
+## Organization commands
+
+Organization commands control the active Manufact Cloud organization for cloud commands.
+
+| Command       | Purpose                                                 | Syntax                |
+| ------------- | ------------------------------------------------------- | --------------------- |
+| `org list`    | List organizations available to the authenticated user. | `mcp-use org list`    |
+| `org current` | Show the active organization.                           | `mcp-use org current` |
+| `org switch`  | Select a different active organization interactively.   | `mcp-use org switch`  |
+
+**Notes and behavior:**
+
+- `deploy`, `deployments`, and `servers` use the active organization unless `--org` overrides it.
+- For CI or agent runs, pass `--org <org>` to `login`, `deploy`, `servers`, or `deployments` commands instead of switching global state. The value can be an organization slug, ID, or name.
+
+## Deployment management commands
+
+**Purpose:** Inspect and manage existing Manufact Cloud deployments.
+
+**Syntax:**
+
+```bash
+mcp-use deployments <subcommand> [options]
+```
+
+**Subcommands:**
+
+| Subcommand                                      | Purpose                                      | Options                                                 |
+| ----------------------------------------------- | -------------------------------------------- | ------------------------------------------------------- |
+| `list` / `ls`                                   | List deployments.                            | `--limit <n>`, `--skip <n>`, `--sort <field:direction>` |
+| `get <deployment-id>`                           | Show deployment details.                     | None                                                    |
+| `logs <deployment-id>`                          | View runtime logs.                           | `-b, --build`, `-f, --follow`                           |
+| `restart <deployment-id>`                       | Trigger a new deployment on the same server. | `-f, --follow`, `--branch <name>`                       |
+| `stop <deployment-id>`                          | Stop a running deployment.                   | None                                                    |
+| `start <deployment-id>`                         | Start a stopped deployment.                  | None                                                    |
+| `delete <deployment-id>` / `rm <deployment-id>` | Delete a deployment.                         | `-y, --yes`                                             |
+
+**Examples:**
+
+```bash
+mcp-use deployments list
+mcp-use deployments get dep_abc123
+mcp-use deployments logs dep_abc123 --build --follow
+mcp-use deployments restart dep_abc123 --branch main --follow
+mcp-use deployments stop dep_abc123
+mcp-use deployments start dep_abc123
+mcp-use deployments delete dep_abc123 --yes
+```
+
+**Notes and behavior:**
+
+- `logs` shows runtime logs by default. Use `--build` for build logs.
+- `restart` redeploys the same server and uses the deployment branch unless `--branch` is set.
+- `delete` prompts for confirmation unless `--yes` is set.
+
+## Server management commands
+
+**Purpose:** Manage cloud servers, which are long-lived Git-backed deploy targets that own deployments.
+
+**Syntax:**
+
+```bash
+mcp-use servers <subcommand> [options]
+```
+
+**Subcommands:**
+
+| Subcommand                              | Purpose                                     | Options                                                                                                                                                                                                                                                |
+| --------------------------------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `list` / `ls`                           | List servers for an organization.           | `--org <slug-or-id>`, `--limit <n>`, `--skip <n>`, `--sort <field:direction>`                                                                                                                                                                          |
+| `get <id-or-slug>`                      | Show server details and recent deployments. | `--org <slug-or-id>`                                                                                                                                                                                                                                   |
+| `update <id-or-slug>`                   | Update server configuration.                | `--branch <name>`, `--name <name>`, `--description <text>`, `--build-command <cmd>`, `--start-command <cmd>`, `--root-dir <path>`, `--watch-paths <glob...>`, `--deploy-branches <glob...>`, `--wait-for-ci`, `--no-wait-for-ci`, `--org <slug-or-id>` |
+| `delete <server-id>` / `rm <server-id>` | Delete a server and its deployments.        | `-y, --yes`, `--org <slug-or-id>`                                                                                                                                                                                                                      |
+| `env <subcommand>`                      | Manage server environment variables.        | See [Server environment commands](#server-environment-commands).                                                                                                                                                                                       |
+
+**Examples:**
+
+```bash
+mcp-use servers list
+mcp-use servers get srv_abc123
+mcp-use servers update srv_abc123 --branch main
+mcp-use servers update srv_abc123 --build-command "npm run build"
+mcp-use servers update srv_abc123 --watch-paths "apps/api/**" "packages/shared/**" --deploy-branches "release/*"
+mcp-use servers delete srv_abc123 --yes
+```
+
+**Notes and behavior:**
+
+- `servers update --branch` changes the production branch for future production deploys.
+- Pass an empty string to `--build-command`, `--start-command`, `--root-dir`, `--watch-paths`, or `--deploy-branches` to clear that setting.
+- `--wait-for-ci` and `--no-wait-for-ci` control whether auto-deploys wait for other check runs before deploying.
+- `servers delete` prompts for confirmation unless `--yes` is set.
+
+## Server environment commands
+
+**Purpose:** List, add, update, and remove environment variables on a cloud server.
+
+**Syntax:**
+
+```bash
+mcp-use servers env <subcommand> [options]
+```
+
+**Subcommands:**
+
+| Subcommand                              | Purpose                                        | Required options | Other options                                                                                 |
+| --------------------------------------- | ---------------------------------------------- | ---------------- | --------------------------------------------------------------------------------------------- |
+| `list` / `ls`                           | List environment variables.                    | `--server <id>`  | `--branch <name>`, `--show-values`                                                            |
+| `add <KEY=VALUE>`                       | Add an environment variable.                   | `--server <id>`  | `--env <environments>`, `--branch <name>`, `--sensitive`                                      |
+| `update <key-or-id>`                    | Update an environment variable by key or UUID. | `--server <id>`  | `--value <value>`, `--env <environments>`, `--branch <name>`, `--sensitive`, `--no-sensitive` |
+| `remove <key-or-id>` / `rm <key-or-id>` | Remove an environment variable by key or UUID. | `--server <id>`  | `--branch <name>`                                                                             |
+
+**Examples:**
+
+```bash
+mcp-use servers env list --server srv_abc123
+mcp-use servers env list --server srv_abc123 --show-values
+mcp-use servers env add --server srv_abc123 API_KEY=secret --sensitive
+mcp-use servers env add --server srv_abc123 FEATURE_FLAG=true --env preview,development
+mcp-use servers env update API_KEY --server srv_abc123 --value new-secret --sensitive
+mcp-use servers env remove API_KEY --server srv_abc123
+```
+
+**Notes and behavior:**
+
+- Values are masked by default. `--show-values` reveals non-sensitive values.
+- `--env <environments>` accepts comma-separated `production`, `preview`, and `development`.
+- `env add --env` defaults to all three environments when omitted.
+- `--branch <name>` scopes preview environment variables to a branch. Omit `--branch` for production resolution.
+- `env update` and `env remove` accept either a variable key or UUID.
+
+## `client`
+
+**Purpose:** Save HTTP MCP server connections, call tools, read resources, get prompts, and manage OAuth credentials from the terminal.
+
+**Syntax:**
+
+```bash
+mcp-use client <subcommand>
+mcp-use client <name> <scope> <action>
+```
+
+**Top-level subcommands:**
+
+| Command                | Purpose                                | Key options                                                                                                     |
+| ---------------------- | -------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `connect <name> <url>` | Verify and save an HTTP(S) MCP server. | `-H, --header`, `--no-oauth`, `--auth-timeout <ms>`, `--protocol <auto\|legacy\|modern>`, `--no-open`, `--json` |
+| `list`                 | List saved servers.                    | `--json`                                                                                                        |
+| `remove <name>`        | Remove a saved server and credentials. | `--yes`                                                                                                         |
+
+**Per-server scopes:**
+
+| Scope       | Actions                                                             |
+| ----------- | ------------------------------------------------------------------- |
+| `tools`     | `list`, `describe <tool>`, `call <tool> [args...] [--timeout <ms>]` |
+| `resources` | `list`, `read <uri>`                                                |
+| `prompts`   | `list`, `get <prompt> [args...]`                                    |
+| `auth`      | `status`, `logout [--yes]`                                          |
+
+Every action in this table accepts `--json` except where the top-level table does not advertise it.
+
+**Examples:**
+
+```bash
+mcp-use client connect local http://localhost:3000/mcp
+mcp-use client list
+mcp-use client local tools list
+mcp-use client local tools call read_file path=/tmp/test.txt
+mcp-use client local resources read "file:///tmp/data.json"
+mcp-use client local prompts get greeting name=Alice
+mcp-use client local auth status
+```
+
+**Notes and behavior:**
+
+- Saved server metadata is stored in `~/.mcp-use/client/servers.json`. Credentials are stored separately under `~/.mcp-use/client/credentials/`.
+- In an interactive TTY, OAuth displays `This server requires OAuth. Press Enter to open your browser.` and opens the browser only after Enter.
+- `--no-open`, `--json`, and non-TTY operation never prompt or open a browser. They print the authorization URL to stderr while the loopback callback continues waiting.
+- `connect --no-oauth` prevents automatic OAuth when the server returns `401`.
+- `--protocol auto` prefers the modern wire and falls back to legacy. `legacy`
+  selects only the legacy wire. `modern` selects the stateless, sessionless
+  modern wire with no fallback.
+- Repeated `-H, --header <"Key: Value">` options store static headers as credentials.
+- Tool and prompt arguments accept `key=value`, `key:=<json>`, or a single JSON object argument.
+- `--json` may appear anywhere after `client`. Success emits exactly one JSON value to stdout. Errors emit exactly one JSON error envelope to stderr and no stdout value.
+- Calls, resource reads, and prompt gets emit raw MCP result envelopes. Lists emit arrays, and `tools describe` emits one tool object.
+- Tool `isError` results exit `1` and retain the original protocol result in `error.details` under `--json`.
+
+<Card
+  title="CLI Client guide"
+  icon="terminal"
+  href="/v2/typescript/tooling/client-cli"
+>
+  Use the guide for connection workflows, OAuth behavior, argument parsing
+  examples, and scripting patterns.
+</Card>
+
+## `generate-types`
+
+**Purpose:** Generate TypeScript module augmentation for MCP tool schemas.
+
+**Syntax:**
+
+```bash
+mcp-use generate-types [options]
+```
+
+**Options:**
+
+| Option              | Description        | Default           |
+| ------------------- | ------------------ | ----------------- |
+| `-p, --path <path>` | Project directory. | Current directory |
+| `--server <file>`   | Server entry file. | `index.ts`        |
+
+**Examples:**
+
+```bash
+mcp-use generate-types
+mcp-use generate-types -p ./my-server
+mcp-use generate-types --server src/server.ts
+```
+
+**Notes and behavior:**
+
+- The command writes `.mcp-use/tool-registry.d.ts`.
+- `mcp-use dev` runs type generation automatically.
+- `mcp-use build` also attempts type generation when it can find a server entry, but build-time generation failures are non-blocking.
+- Include `.mcp-use/**/*` in `tsconfig.json` so widget code can see generated types.
+
+```json
+{
+  "include": ["index.ts", "src/**/*", "resources/**/*", ".mcp-use/**/*"]
+}
+```
+
+## Environment variables
+
+| Variable                    | Used by                                   | Description                                                                                                                                                                                                 | Default                             |
+| --------------------------- | ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| `PORT`                      | `dev`, `start`, server runtime            | Server port when `--port` is not provided. `dev` sets it to the resolved listener port before importing the entry; `start` reads it before importing the built entry.                                       | `3000`                              |
+| `HOST`                      | `dev`, `start`, server runtime            | Bind host when `--host` is not provided. `start` and direct `listen()` fall back to `config.host` before `127.0.0.1`.                                                                                       | `127.0.0.1`                         |
+| `NODE_ENV`                  | `dev`, `start`, widget builds             | Runtime environment. `dev` sets `development`; `start` sets `production`.                                                                                                                                   | Command-specific                    |
+| `MCP_URL`                   | `dev`, `start`, server runtime            | **Server public origin** (`.origin` only). OAuth resource URL, CSP `connectDomains`, dev HMR websocket. Lower priority than `CSP_URLS`. Preserved when already set.                                         | Local server URL or tunnel URL      |
+| `MCP_ASSETS_URL`            | `build`, server runtime                   | **Assets URL prefix** (origin + optional path) for view JS/CSS and `public/`. Falls back to `MCP_URL` origin. When set at build, manifest paths become full CDN URLs (path segment from server `basePath`). | None (falls back to server origin)  |
+| `CSP_URLS`                  | server runtime                            | Comma-separated CSP domain shortcut — applied to all four MCP Apps categories when per-category vars are unset. Higher priority than `MCP_URL` auto-append.                                                 | None                                |
+| `CSP_CONNECT_DOMAINS`       | server runtime                            | Overrides `CSP_URLS` for `connectDomains`                                                                                                                                                                   | None                                |
+| `CSP_RESOURCE_DOMAINS`      | server runtime                            | Overrides `CSP_URLS` for `resourceDomains`                                                                                                                                                                  | None                                |
+| `CSP_FRAME_DOMAINS`         | server runtime                            | Overrides `CSP_URLS` for `frameDomains`                                                                                                                                                                     | None                                |
+| `CSP_BASE_URI_DOMAINS`      | server runtime                            | Overrides `CSP_URLS` for `baseUriDomains`                                                                                                                                                                   | None                                |
+| `MCP_WEB_URL`               | `login`, cloud auth                       | Manufact web URL for auth pages.                                                                                                                                                                            | `https://manufact.com`              |
+| `MCP_API_URL`               | `login`, cloud API config                 | Manufact API URL. The CLI normalizes it to include `/api/v1`.                                                                                                                                               | `https://cloud.manufact.com/api/v1` |
+| `MCP_USE_API_KEY`           | `login`                                   | API key for non-interactive login.                                                                                                                                                                          | None                                |
+| `MCP_USE_API`               | Tunnel cleanup and local tunnel API calls | Tunnel service API base used by integrated tunnel cleanup paths.                                                                                                                                            | `https://local.mcp-use.run`         |
+| `MCP_USE_TUNNEL_API`        | `dev --tunnel`, `start --tunnel`          | Tunnel service API base used when creating local tunnels.                                                                                                                                                   | `https://local.mcp-use.run`         |
+| `MCP_USE_CHROME_PATH`       | `client screenshot`                       | Chrome executable path for screenshots.                                                                                                                                                                     | Auto-detected                       |
+| `PUPPETEER_EXECUTABLE_PATH` | `client screenshot`                       | Fallback Chrome executable path.                                                                                                                                                                            | Auto-detected                       |
+| `CHROME_PATH`               | `client screenshot`                       | Fallback Chrome executable path.                                                                                                                                                                            | Auto-detected                       |
+
+**Examples:**
+
+```bash
+PORT=8080 mcp-use start
+MCP_URL=https://my-server.example.com MCP_ASSETS_URL=https://cdn.example.com/bucket mcp-use build
+MCP_USE_API_KEY=mcp_... mcp-use login --org my-org
+MCP_USE_CHROME_PATH=/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
+  mcp-use client local screenshot --tool show-board
+```
+
+## Related references
+
+- [CLI Client guide](/v2/typescript/tooling/client-cli)
+- [Tunneling guide](/tunneling/index)
+- [Manufact Cloud deployment guide](/v2/typescript/server/deployment/mcp-use)
+- [ServerConfig API reference](https://mcp-use-typescript-api-reference.vercel.app/modules/mcp-use.index.html#serverconfig)

--- a/docs/v2/typescript/changelog/changelog.mdx
+++ b/docs/v2/typescript/changelog/changelog.mdx
@@ -1,0 +1,1523 @@
+---
+title: "Updates"
+description: "New updates and improvements"
+icon: "sparkles"
+tag: "New"
+rss: true
+---
+
+<Update label="v1.34.1" description="July 2026">
+  ## Hosted OAuth discovery through the proxy
+  Patch release fixing the Authenticate button on gateway-hosted OAuth servers when MCP traffic is proxied for CORS.
+
+- **Fix** (auth): `BrowserOAuthClientProvider` re-anchors proxy-origin `.well-known` OAuth discovery onto the actual MCP server. When MCP is tunneled through the inspector/gateway proxy, the SDK derived discovery URLs from the proxy origin whenever no `WWW-Authenticate` hint was available (SSE transport, token refresh) — discovery failed on the proxy origin and the server was misclassified as "does not support OAuth". Lookups are now rewritten to the server origin (including the RFC 8414 §3.1 / RFC 9728 §3.1 path-insertion form), so MCP traffic can stay behind the proxy while OAuth still resolves (`#1843`)
+</Update>
+
+<Update label="v1.34.0" description="July 2026">
+  <Frame>
+    <img src="https://mcp-use.com/api/og/release?v=1.34.0&title=OAuth%20proxy%20URL%20%26%20hosted%20auth%20reliability&date=2026-07&lang=typescript" alt="Release 1.34.0" />
+  </Frame>
+  ## OAuth proxy URL & hosted auth reliability
+  Minor release wiring `oauthProxyUrl` for transparent OAuth-only proxying and fixing false "Server does not support OAuth" failures on gateway-hosted servers.
+
+- **New** (react): `UseMcpOptions.oauthProxyUrl` routes OAuth discovery, DCR, and token exchange through a transparent server-side proxy while MCP traffic stays direct — takes precedence over the URL derived from `proxyConfig.proxyAddress`, preserves RFC 8414 issuer validation, and fixes gateway-fronted servers where proxying MCP anchored OAuth discovery on the wrong origin (`#1840`)
+- **Fix** (react): when OAuth discovery already succeeded and `preventAutoAuth` is set, a later failure (token refresh, SSE fallback, metadata probe on transport origin) surfaces `pending_auth` with the Authenticate button instead of `failed` / "Server does not support OAuth" (`#1840`)
+- **Enhancement** (@mcp-use/inspector): picks up mcp-use v1.34.0 OAuth fixes — see inspector changelog
+- **Update**: Updated @mcp-use/cli to v3.6.1
+- **Update**: Updated @mcp-use/inspector to v12.0.0
+</Update>
+
+<Update label="v1.33.0" description="June 2026">
+  <Frame>
+    <img src="https://mcp-use.com/api/og/release?v=1.33.0&title=MCP%20Apps%20primary%20widget%20runtime&date=2026-06&lang=typescript" alt="Release 1.33.0" />
+  </Frame>
+  ## MCP Apps runtime, Auto connections & monorepo deploy triggers
+  Minor release making MCP Apps the primary widget runtime (with an Apps SDK compatibility fallback), enforcing `outputSchema` at the tool return position, adding monorepo auto-deploy controls to the CLI, and improving Inspector connection fallback behavior. Inspector ships major v11.0.0 (see inspector changelog).
+
+- **New** (react): MCP Apps is now the primary widget runtime — `useWidget` connects the MCP Apps bridge in any hosted iframe (including ChatGPT) and applies host context style variables, while `window.openai` is kept for extension APIs such as file upload/download (`#1739`)
+- **Fix** (react): widgets on Apps SDK-only hosts no longer hang on the loading spinner — `useWidget` falls back to `window.openai` data and actions when the MCP Apps bridge does not connect, and a connected bridge still takes priority (`#1794`)
+- **Fix** (react/auth): OAuth proxy fetch is scoped to the selected server's provider instead of mutating global `fetch`, so Via Proxy connections no longer affect Direct connections or unrelated requests (`#1770`)
+- **Fix** (react): automatic proxy fallback applies the runtime proxy config before deriving gateway URLs and headers, so fallback retries route through the configured Inspector proxy (`#1795`)
+- **New** (server): a tool's `outputSchema` is now type-checked at the return position — returning a shape that does not match is a compile-time error, while content-only helpers (`text()`, `markdown()`, `image()`, …) stay allowed; the Apps SDK adapter auto-derives `openai/widgetDescription` from the widget description (`#1772`)
+- **Enhancement** (connectors): the `stdio` connector exposes a `cwd` argument for the spawned server process (`#1785`)
+- **New** (@mcp-use/cli): monorepo auto-deploy trigger config — `mcp-use deploy` gains `--watch-paths` and `--wait-for-ci`, and `servers update` gains `--watch-paths`, `--deploy-branches`, `--wait-for-ci` / `--no-wait-for-ci`, and `--root-dir`; `servers get` / `update` print the effective trigger config (`#1793`)
+- **Enhancement** (@mcp-use/cli): `deploy` surfaces the GitHub App installation URL up front when the app is not connected or lacks repo access, and exits cleanly in non-interactive contexts instead of hanging on a prompt (`#1761`)
+- **Fix** (@mcp-use/cli): `deployments list` preserves the API's ordering instead of re-sorting by creation date client-side (`#1752`)
+- **Fix** (@mcp-use/cli): Codex skills install to `.agents/skills` instead of the unsupported `.agent/skills` path (`#1756`)
+- **New** (create-mcp-use-app): the `starter` and `mcp-apps` templates score 100% on the publishing checklist — tools declare a `title` and `outputSchema` and return matching `structuredContent` (`#1772`)
+- **Enhancement** (@mcp-use/inspector): new connections default to Auto mode, trying Direct first and falling back to the configured proxy when browser connection errors can be resolved through the proxy; see inspector changelog (`#1795`)
+- **Documentation** (@mcp-use/cli): the new monorepo deploy flags are documented in the CLI reference, deployment guide, and package README (`#1793`)
+- **Update**: Bumped `hono` to 4.12.25 (`#1755`) and `vite` to 8.0.16 (`#1742`)
+- **Update**: Updated @mcp-use/cli to v3.6.0
+- **Update**: Updated create-mcp-use-app to v0.14.17
+- **Update**: Updated @mcp-use/inspector to v11.0.0
+</Update>
+
+<Update label="v1.32.1" description="June 2026">
+  ## OAuth proxy callbacks, deploy fixes & hosted localhost chat
+  Patch release for OAuth proxy callback routing, server notification logs, dev-widget noise reduction, and CLI deploy/env fixes. Inspector ships v10.0.1 with hosted-localhost chat fallback and a chat scroll helper (see inspector changelog).
+
+- **Fix** (server/oauth): OAuth proxy mode brokers the upstream provider callback through the server's own `/oauth/callback`, so providers only need one registered redirect URI per server while MCP clients keep their own redirect URI and state (`#1728`)
+- **Fix** (server/oauth): OAuth metadata discovery now mounts the RFC 8414 canonical `/.well-known/oauth-authorization-server{issuer-path}` route for authorization servers with path-suffix issuers (`#1684`)
+- **New** (server): outgoing notifications log sent and failed deliveries with session identifiers and error details (`#1674`)
+- **Fix** (server/widgets): dev mode no longer prints widget mounting, serving, or watcher logs when a project has no widgets; the watcher still detects widgets created later (`#1730`)
+- **Enhancement** (@mcp-use/cli): `mcp-use deploy --dockerfile <path>` selects a non-default Dockerfile relative to `--root-dir` or the repo root while keeping root `Dockerfile` auto-detection (`#1746`)
+- **Enhancement** (@mcp-use/cli): REPL/interactive tool calls support `--screenshot`, and resource subscription mode unsubscribes cleanly on Ctrl+C (`#1592`, `#1687`)
+- **Fix** (@mcp-use/cli): sensitive env vars returned without values render as `<sensitive>` and `EnvVariable.value` accepts `null`; remote API calls use the `manufact.com` base URL (`#1717`, `#1745`)
+- **Fix** (@mcp-use/cli): deploy repo-access checks use the backend's authoritative per-installation repo endpoint, avoiding false "GitHub App cannot access repository" failures on large or multi-installation orgs (`#1737`)
+- **Update**: Bumped `esbuild` to v0.28.1 (`#1734`)
+- **Update**: Updated @mcp-use/cli to v3.5.2
+- **Update**: Updated @mcp-use/inspector to v10.0.1
+</Update>
+
+<Update label="v1.32.0" description="June 2026">
+  <Frame>
+    <img src="https://mcp-use.com/api/og/release?v=1.32.0&title=OAuth%20token%20endpoint%20discovery&date=2026-06&lang=typescript" alt="Release 1.32.0" />
+  </Frame>
+  ## OAuth token endpoint discovery
+  Minor release exposing the resolved OAuth `token_endpoint` and client credentials on `useMcp().authTokens` so backends can persist everything needed for proactive server-side token refresh.
+
+- **New** (auth): `getTokenEndpoint()` on `BrowserOAuthClientProvider` and `OAuthSessionStore` — resolves and caches the OAuth token endpoint via PRM → authorization-server metadata discovery; persisted in storage for consumers (`#1714`)
+- **New** (auth): `getClientCredentials()` returns stored `client_id` / `client_secret` from Dynamic Client Registration or a static client — most token endpoints require `client_id` on refresh (`#1714`)
+- **Enhancement** (react): `useMcp().authTokens` includes optional `token_endpoint`, `client_id`, and `client_secret` after auth — best-effort resolution that never blocks the auth flow (`#1714`)
+- **Update**: Updated @mcp-use/inspector to v10.0.0
+</Update>
+
+<Update label="v1.31.1" description="June 2026">
+  ## Servers update & branch-scoped deploy env
+  Patch release for workspace dependency alignment; `@mcp-use/cli` minor adds `servers update` and branch-scoped environment and deploy management.
+
+- **New** (@mcp-use/cli): `mcp-use servers update <id-or-slug>` mutates server config in place (production branch, name, description, build/start commands) without delete/recreate — preserving the URL slug and env vars; `--branch` maps to `productionBranch`; pass an empty string to `--build-command`/`--start-command` to clear overrides (`#1711`)
+- **New** (@mcp-use/cli): `deploy --branch <name>` defaults to the current git branch and scopes `--env`/`--env-file` sync to that branch's preview environment (`#1711`)
+- **Enhancement** (@mcp-use/cli): `servers env list/add/update/rm` gain `--branch` for branch-scoped variables; `update`/`rm` accept a variable KEY (resolved within the branch scope) in addition to a UUID (`#1711`)
+- **Enhancement** (@mcp-use/cli): `deployments restart` gains `--branch <name>` (defaults to the deployment's branch) (`#1711`)
+- **Documentation** (@mcp-use/cli): `servers update` and branch-scoped deploy/env flags in the package README and mcp-apps-builder deploy skill reference (`#1711`)
+- **Update**: Updated @mcp-use/cli to v3.5.0
+- **Update**: Updated @mcp-use/inspector to v9.0.1
+</Update>
+
+<Update label="v1.31.0" description="June 2026">
+  <Frame>
+    <img src="https://mcp-use.com/api/og/release?v=1.31.0&title=OAuth%20popup%20reliability%20%26%20credential%20lifecycle&date=2026-06&lang=typescript" alt="Release 1.31.0" />
+  </Frame>
+  ## OAuth popup reliability & credential lifecycle
+  Minor release fixing browser OAuth popup flows that stranded connections in "Authenticating…", preserving credentials across routine React lifecycle churn, and clarifying platform-managed deploy feedback in the CLI. Inspector ships major v9.0.0 tracking the new peer dependency (see inspector changelog).
+
+- **New**: `runAuthPopup()` exported from `mcp-use/auth` — opener-owned popup runner that settles on a `state`-matched postMessage or BroadcastChannel result, popup close, a `storage` event for persisted tokens, or a timeout; close and timeout paths check storage before declaring cancelled so a missed message with landed tokens still succeeds (`#1703`)
+- **Enhancement**: `runAuthPopup()` keeps message and storage listeners alive for a grace window (default 20s) after `popup.closed` reports true without tokens — tolerates COOP browsing-context-group swaps that sever `window.opener` while the consent window is still open (`#1703`)
+- **Fix** (react): `useMcp().authenticate()` awaits `runAuthPopup()` and owns every terminal transition — success reconnects, cancelled/timeout return to `pending_auth` (re-enabling Authenticate), error fails the connection instead of hanging indefinitely (`#1703`)
+- **Fix** (auth): OAuth callback detects popup flow from stored `flowType` (not only `window.name`) and always broadcasts the result; result payloads carry the originating `state` and `serverUrlHash` so listeners scope to the right server and late failures do not clobber an already-`ready` connection (`#1703`)
+- **Enhancement** (auth): `renderCloseWindowMessage()` accepts an optional `returnUrl` link for tab-mode fallbacks when the popup cannot auto-close (`#1703`)
+- **Fix** (react): `McpClientProvider.removeServer()` no longer clears OAuth storage by default — pass `{ clearCredentials: true }` for explicit logout; `updateServer()` and `useMcp` unmount no longer wipe credentials on routine lifecycle churn (`#1703`)
+- **Fix**: move `chalk` from optionalDependencies to dependencies — statically imported by server logging/lifecycle code, so `pnpm install --no-optional` no longer fails at module load (`#1702`)
+- **Enhancement** (@mcp-use/cli): after `deploy --no-github`, print a note that source lives in a private platform-managed repository and link to the dashboard to view or migrate to GitHub (`#1703`)
+- **Enhancement** (@mcp-use/cli): `servers get` shows `mcp-use-managed (private)` when the connected repo has no exposed GitHub full name (`#1703`)
+- **Fix** (@mcp-use/inspector): delete-server passes `{ clearCredentials: true }` on explicit removal — see inspector changelog (`#1703`)
+- **Update**: Updated @mcp-use/inspector to v9.0.0
+- **Update**: Updated @mcp-use/cli to v3.4.2
+</Update>
+
+<Update label="v1.30.2" description="June 2026">
+  ## Chalk CJS compatibility
+  Patch release restoring CommonJS startup compatibility for server bundles on Node 22 and newer; Inspector ships v8.0.2 with the same `mcp-use` peer update.
+
+- **Fix**: downgrade chalk to v4 — chalk 5 is ESM-only and kept external by tsup, so the CJS bundle's `require("chalk")` on Node 22 and newer returned the module namespace instead of the chalk instance, crashing CJS-built backends (e.g. the Next.js template) on startup with `TypeError: import_chalk.default.gray is not a function` (`#1701`)
+- **Update**: Updated @mcp-use/inspector to v8.0.2
+- **Update**: Updated @mcp-use/cli to v3.4.1
+</Update>
+
+<Update label="v1.30.1" description="June 2026">
+  ## Deploy without GitHub, device-code login & widget iframe fixes
+  Patch release for `McpUseProvider` zero-height collapse, `useMcp` disconnect/reconnect race fixes, and clearer not-ready errors; `@mcp-use/cli` minor adds tarball deploy without a user GitHub repo and non-interactive device-code login for web onboarding.
+
+- **Enhancement** (@mcp-use/cli): `mcp-use deploy --no-github` packs the local project into a tarball and uploads it to the platform-managed org so first deploy works without connecting GitHub; redeploys of a linked platform-managed server auto-detect from `connectedRepository.isManaged` (`#1691`)
+- **New** (@mcp-use/cli): `mcp-use login --device-code <code>` authenticates with a pre-approved OAuth device code for non-interactive flows (web onboarding), skipping the browser step (`#1691`)
+- **Fix**: `McpUseProvider` with `autoSize` now notifies zero height when a widget renders `null`, so host iframes collapse instead of keeping the last non-zero height (`#1693`)
+- **Fix** (react): `useMcp` stale `disconnect()` after a URL change or a manual disconnect racing a reconnect no longer nulls `clientRef` or resets hook state to `discovering` when superseded by a newer `connect()` (`connectEpochRef`) — fixes "MCP client is not ready (current state: ready)" and similar races in the inspector and other embeds (`#1528`)
+- **Fix** (client): `BaseMCPClient.closeSession()` only deletes a session slot when it still references the closing session, so a parallel `createSession()` from a reconnect is not wiped — fixes "No active session found" on the next tool call after reconnect (`#1528`)
+- **Enhancement** (react): clearer "MCP client is not ready" errors via `formatMcpNotReadyReason`, distinguishing a missing client (`client disconnected`) from a non-ready state (`#1528`)
+- **Fix** (@mcp-use/inspector): MCP Apps / Apps SDK status labels no longer intercept iframe pointer events  -  see inspector changelog (`#1694`, `#1678`)
+- **Documentation**: tip on `<McpUseProvider />` for widgets that conditionally return `null` with `autoSize`
+- **Documentation**: `deploy --no-github`, `login --device-code`, and dual deploy paths in the CLI reference and Manufact Cloud deployment guide
+- **Update**: Updated @mcp-use/inspector to v8.0.1
+- **Update**: Updated @mcp-use/cli to v3.4.0
+</Update>
+
+<Update label="v1.30.0" description="June 2026">
+  <Frame>
+    <img src="https://mcp-use.com/api/og/release?v=1.30.0&title=OpenAPI%20server%20generation%20%26%20MCP%20instructions&date=2026-06&lang=typescript" alt="Release 1.30.0" />
+  </Frame>
+  ## OpenAPI server generation & MCP instructions
+  Minor release adding `MCPServer.fromOpenAPI()` for generating MCP tools from OpenAPI documents, server-wide `instructions` returned during MCP initialization, idle session ref cleanup, and CLI fixes for paginated cloud lists and multi-installation GitHub repo access. Inspector ships major v8.0.0 tracking the new `mcp-use` peer dependency (see inspector changelog).
+
+- **New**: `MCPServer.fromOpenAPI()`  -  create an MCP server from a parsed OpenAPI document; each included operation registers as a tool with generated input schemas and HTTP request handling (`baseUrl`, bearer token, and static header auth supported); ships with an `openapi` server example against live `api.weather.gov` (`#1583`)
+- **New**: `instructions` option on `MCPServer`  -  server-wide model instructions returned during MCP initialization for cross-tool workflows and constraints that do not belong in individual tool descriptions (`#1601`)
+- **New** (create-mcp-use-app): `starter` and `mcp-apps` templates scaffold with an `instructions` placeholder (`#1601`)
+- **Fix**: idle session cleanup releases registered refs for expired sessions instead of leaving stale registrations behind (`#1624`)
+- **Fix**: escape backslashes before double quotes when converting Zod string literals and enums to TypeScript in `zod-to-ts`, so generated `.d.ts` output stays valid when literal values contain `\` or `"` (`#1661`)
+- **Update**: bump `hono` to `4.12.23` for [CVE-2026-47674](https://github.com/advisories/GHSA-xrhx-7g5j-rcj5)  -  non-canonical IPv6 forms could bypass static deny rules in the `ip-restriction` middleware (`#1663`)
+- **Enhancement** (@mcp-use/cli): `servers list` and `deployments list` handle paginated Cloud API responses with a default page size of 30 and next-page guidance (`#1619`)
+- **Fix** (@mcp-use/cli): deploy repo access check aggregates repos across all GitHub App installations linked to the organization instead of only the first one, so deploys no longer fail with "GitHub App doesn't have access" when the repo belongs to a different installation (`#1629`, MCP-2358)
+- **Documentation**: OpenAPI server generation guide and `examples/server/features/openapi` (`#1583`)
+- **Documentation**: MCP server `instructions` in configuration, quickstart, and installation docs (`#1601`)
+- **Update**: Updated @mcp-use/inspector to v8.0.0
+- **Update**: Updated @mcp-use/cli to v3.3.2
+- **Update**: Updated create-mcp-use-app to v0.14.15
+</Update>
+
+<Update label="v1.29.1" description="June 2026">
+  ## OAuth transport auth hardening & security dependency bumps
+  Patch release hardening OAuth-protected MCP transport routes and resolving open Dependabot security advisories across the TypeScript workspace.
+
+- **Fix**: Harden authentication coverage for OAuth-protected MCP transport endpoints and advertise path-scoped protected-resource metadata where required by OAuth clients (`#1628`)
+- **Update**: Bump `hono` to `^4.12.18` and raise `pnpm.overrides` floors for `axios`, `protobufjs`, `ws`, `uuid`, `fast-uri`, `postcss`, `langsmith`, `dompurify`, `qs`, `react-router`, `better-auth`, and other flagged transitive deps so the lockfile resolves to patched versions within current majors (`#1615`, `#1626`)
+- **Update**: Updated @mcp-use/inspector to v7.0.1
+- **Update**: Updated @mcp-use/cli to v3.3.1
+</Update>
+
+<Update label="v1.29.0" description="June 2026">
+  <Frame>
+    <img src="https://mcp-use.com/api/og/release?v=1.29.0&title=Public%20landing%20pages%2C%20OAuth%20callback%20hardening%20%26%20Supabase%20URL%20override&date=2026-06&lang=typescript" alt="Release 1.29.0" />
+  </Frame>
+  ## Public landing pages and Ollama chat support
+  Minor release adding a public browser landing page for OAuth-protected servers, a Supabase URL override for local/self-hosted instances, Claude UI-resource domain hashing, and a round of OAuth callback and React-provider hardening. Inspector ships a major v7.0.0 with local LLM (Ollama) chat and image tool results (see inspector changelog).
+
+- **New**: `publicLandingPage` option on `MCPServer`  -  keep the browser landing page (`GET` + `Accept: text/html`) reachable without authentication while the MCP endpoint stays OAuth-protected; ships with a `public-landing-page` server example (`#1550`)
+- **New**: `supabaseUrl` override on `oauthSupabaseProvider`  -  point the provider at a local or self-hosted Supabase (e.g. `http://localhost:54321`) instead of the hosted `https://${projectId}.supabase.co`; set via the `supabaseUrl` config option or `MCP_USE_OAUTH_SUPABASE_URL`, and `projectId` becomes optional when it is set (`#1517`)
+- **New**: Claude UI-resource domain hashing  -  when a Claude client requests a widget/UI resource that declares a `ui.domain`, the server rewrites it to a stable `<sha256-prefix>.claudemcpcontent.com` content domain (`#1599`)
+- **Breaking**: `mcp-use/browser` no longer exports the LangChain agents (`MCPAgent`, `RemoteAgent`, adapters, observability, AI SDK utils)  -  they moved to `mcp-use/browser/agent`, so client bundles that only need `MCPClient` no longer pull in `@langchain/*` (`#1580`)
+- **Fix**: browser OAuth popup callback edge cases in `onMcpAuthorization()`  -  popups whose `window.opener` was severed by COOP / cross-origin redirects now render an in-place close-window message and broadcast over a same-origin `BroadcastChannel("mcp_auth_callback")` so `useMcp` no longer hangs in `authenticating`; repeat invocations in one page load (HMR, strict-mode double render) reuse a cached promise instead of re-exchanging the code (`#1580`)
+- **Fix**: redact OAuth token-verification errors from client responses while logging the details server-side (`#1573`)
+- **Fix**: normalize the issuer trailing slash before appending `/.well-known/oauth-authorization-server` in the DCR-direct metadata proxy, fixing the double-slash 404 against providers like Auth0 (`#1483`)
+- **Fix**: normalize `0.0.0.0` and `::` to `localhost` in the inspector autoConnect URL so OAuth-protected `mcp-use dev` flows match the published resource metadata and pass the SDK's strict origin check (`#1552`)
+- **Fix** (react): `McpClientProvider.removeServer` / `updateServer` no longer trigger React's "cannot update a component while rendering a different component" warning  -  teardown side effects (`disconnect()`, `clearStorage()`) now run after the state updaters instead of inside them (`#1561`)
+- **Fix** (react): treat `name` as a meaningful change in `McpServerWrapper` so alias-only edits propagate through `onUpdate` and the inspector tile heading updates immediately (`#1539`)
+- **Fix**: pin published dependency versions in `mcp-use`'s `package.json` (`#1610`)
+- **New** (@mcp-use/cli): `mcp-use client screenshot` auto-sizes captures to the widget's natural rendered dimensions when `--width`/`--height` are omitted, and now handles external MCP server URIs like `ui://excalidraw/mcp-app.html` (flattened to `<server>-<name>`) that previously broke the preview route (`#1579`)
+- **Fix** (@mcp-use/cli): widget assets resolve correctly when `MCP_URL` is set at build time  -  Vite `base` and `window.__getFile` now point at `${MCP_URL}/mcp-use/widgets/{widget}/`, matching the production static route (`#1560`)
+- **Fix** (create-mcp-use-app): move the `mcp-apps` template's pnpm settings into `pnpm-workspace.yaml` so scaffolded apps install cleanly under pnpm 10 (`#1602`)
+- **Enhancement** (@mcp-use/inspector): local LLM provider (Ollama) chat, MCP image tool results forwarded as real image content, an MCP-server reconnect banner, and widget fullscreen / display-mode fixes (see inspector changelog)
+- **Documentation**: clarify the "Inspector: Skipped in production" log and the `start` CLI reference so users rebuild with `mcp-use build --with-inspector` instead of passing the flag to `mcp-use start` (`#1505`)
+- **Chore**: prune 187 unused exports and delete unused source files flagged by Knip across the workspace, and enforce Knip in CI (`#1511`, `#1476`, `#1510`, `#1512`)
+- **Update**: Updated @mcp-use/inspector to v7.0.0
+- **Update**: Updated @mcp-use/cli to v3.3.0
+- **Update**: Updated create-mcp-use-app to v0.14.13
+</Update>
+
+<Update label="v1.28.0" description="May 2026">
+  <Frame>
+    <img src="https://mcp-use.com/api/og/release?v=1.28.0&title=Node%20OAuth%20%26%20widget%20screenshot&date=2026-05&lang=typescript" alt="Release 1.28.0" />
+  </Frame>
+  ## Node OAuth & widget screenshot
+  Minor release adding a Node OAuth client provider and widget screenshot improvements.
+
+- **New**: `mcp-use/auth/node` entrypoint — `NodeOAuthClientProvider`, `FileKVStore`, the `KVStore` type, and re-exports of the SDK's `auth` and `UnauthorizedError`; the provider owns a localhost OAuth loopback (preferred port 33418, walks up to 33427 on conflict) and persists tokens, client info, and code verifiers to `~/.mcp-use/oauth/<urlHash>/` with `0o600` perms and atomic-rename writes (`#1452`)
+- **Refactor**: `OAuthSessionStore` extracted from `BrowserOAuthClientProvider` — platform-neutral helper parameterised over a `KVStore` that owns token storage, JWT-expiry-driven refresh (with deduplication), client-info validation, code-verifier handling, and authorization-state persistence; the browser provider now delegates the SDK `OAuthClientProvider` methods to it, no behavior change (`#1451`)
+- **Fix**: `forceRefresh()` now actually exchanges the refresh token via `OAuthSessionStore.forceRefresh()` instead of zeroing `access_token` and re-reading via `tokens()` (which gated the refresh path on a truthy `access_token` and silently returned stale tokens); the loopback failure page also HTML-escapes `error` and `error_description` (`#1452`)
+- **Documentation**: `MCPServer.tool()` JSDoc `@example` blocks now include the matching `import { ... } from "mcp-use/server"` line and name the response helpers (`text`, `object`, `image`, `markdown`, `html`, `error`, `widget`, …); the `create-mcp-use-app` blank template's commented tool/resource/prompt blocks gain the same import breadcrumbs (`#1474`)
+- **Fix** (@mcp-use/cli): tests no longer touch the developer's real `~/.mcp-use` directory — `session-storage.test.ts` mocks `node:os.homedir` and `cli-integration.test.ts` spawns the CLI with `HOME`/`USERPROFILE` set to per-test temp dirs (`#1494`)
+- **Update** (@mcp-use/cli): rename "mcp-use cloud" to "Manufact cloud" in `mcp-use login --help` and the body banner, matching the existing wording in `logout` and `deploy` (`#1488`)
+- **Enhancement** (@mcp-use/inspector): new `ViewPreview` component and `/preview/:view` route, dark-mode aware scrollbars (see inspector changelog)
+- **Fix**: resolved duplicate exports flagged by Knip — annotated the `Tel` alias for `Telemetry` with `@alias`, unified the canonical source path for telemetry exports in `src/telemetry/index.ts` (Node default, tsup substitutes the browser implementation in browser bundles), and removed the redundant default export of `JsonRpcLoggerView` in `@mcp-use/inspector`; named exports unchanged (`#1453`)
+- **Chore**: drop unused dependencies and devDependencies flagged by `knip` across the workspace; declare `jsdom` and `@vitest/coverage-v8` as explicit devDependencies on `mcp-use` (`@vitest/coverage-v8` pinned to `~4.0.18` to match `vitest`) (`#1458`, `#1454`)
+- **Documentation**: refreshed CLI references in the docs site (`#1488`)
+- **Update**: Updated @mcp-use/inspector to v6.0.0
+- **Update**: Updated @mcp-use/cli to v3.2.0
+- **Update**: Updated create-mcp-use-app to v0.14.12
+</Update>
+
+<Update label="v1.27.1" description="May 2026">
+  ## ChatGPT App metadata & inspector MCP App width fix
+  Patch release surfacing tool `outputSchema` in `tools/list`, adding tool annotations and `outputSchema` to the `create-mcp-use-app` mcp-apps template, and fixing MCP App width in inspector chat.
+
+- **Fix**: Forward `outputSchema` from tool definitions into the MCP SDK so `tools/list` exposes output JSON Schema for clients  -  required for ChatGPT App Store metadata validation (`#1466`)
+- **New** (create-mcp-use-app): MCP tool `annotations` (`readOnlyHint`, `openWorldHint`, `destructiveHint`) and widget `outputSchema` in the `mcp-apps` template; tool annotations in the `starter` template; MCP Apps docs aligned with ChatGPT App Store metadata expectations (`#1466`)
+- **Fix** (@mcp-use/inspector): MCP App width is pinned in chat  -  only height responds to widget-reported sizes, so the chat panel no longer collapses when a widget reports narrower content (`#1462`) (see inspector changelog)
+- **Documentation**: Clerk and WorkOS OAuth example READMEs now link to live pages  -  Clerk Dashboard `/sign-in` (200 instead of 404) and WorkOS `/docs/authkit` (`#1470`)
+- **Update**: Updated @mcp-use/inspector to v5.0.1
+- **Update**: Updated @mcp-use/cli to v3.1.4
+- **Update**: Updated create-mcp-use-app to v0.14.11
+</Update>
+
+<Update label="v1.27.0" description="May 2026">
+  <Frame>
+    <img src="https://mcp-use.com/api/og/release?v=1.27.0&title=Clerk%20OAuth%2C%20pre-registered%20client%20IDs%20%26%20inspector%20providers&date=2026-05&lang=typescript" alt="Release 1.27.0" />
+  </Frame>
+  ## Clerk OAuth, pre-registered client IDs & inspector providers
+  Minor release adding a Clerk OAuth provider, pre-registered OAuth client credentials for proxy-mode flows, OpenRouter and OpenAI-compatible providers in the Inspector chat, browser-side telemetry env-var honoring, and a CLI fix for env propagation on redeploys.
+
+- **New**: `oauthClerkProvider` for using Clerk as an OAuth authorization server in MCP servers  -  DCR-direct mode where MCP clients register and authenticate directly with Clerk and the server verifies Clerk-issued JWTs via JWKS; default scopes are `["profile", "email", "offline_access"]` and `openid` is excluded by default because it requires OIDC to be explicitly enabled in the Clerk Dashboard (`#1429`)
+- **New**: Pre-registered OAuth client credentials in proxy mode  -  `UseMcpOptions` / `McpServerOptions` accept `oauth: { clientId?, clientSecret?, scope? }`; with `clientId` set, `BrowserOAuthClientProvider` returns it from `clientInformation()` so the SDK skips Dynamic Client Registration (required for providers like Slack or WorkOS that strip `registration_endpoint` from metadata); with `clientSecret` set, the SDK auto-switches token-endpoint auth from `none` to `client_secret_basic`/`client_secret_post` (`#1400`)
+- **Fix**: `MCP_USE_ANONYMIZED_TELEMETRY=false` now disables the in-browser `useMcp` `posthog-js` init  -  the inspector server mirrors the env var into a per-page runtime flag (`window.__MCP_USE_ANONYMIZED_TELEMETRY__`) before the client bundle runs, so a single env var disables every telemetry path (Node-side, server-side proxy, and browser); the flag is page-scoped so unsetting the env var fully restores defaults on the next page load (`#1443`)
+- **Fix** (@mcp-use/cli): `mcp-use deploy --env`/`--env-file` propagates env vars on redeploys  -  previously only forwarded on initial server creation, now upserts each entry against the env-variables API (`PATCH` for existing keys, `POST` for new keys) before triggering the deployment (`#1433`)
+- **Enhancement** (@mcp-use/inspector): OpenRouter and OpenAI-compatible providers in chat configuration; `Client ID` / `Client Secret` / `Scope` fields in the Authentication dialog (see inspector changelog)
+- **Update**: Updated @mcp-use/inspector to v5.0.0
+- **Update**: Updated @mcp-use/cli to v3.1.3
+</Update>
+
+<Update label="v1.25.2" description="April 2026">
+  ## Debug log tiers & widget dev first render
+  Patch release adding tiered `MCP_DEBUG_LEVEL` logging for MCP servers, pre-warming Vite widget entries in dev to avoid first-render 504s, and Inspector 3.0.2 (see inspector changelog).
+
+- **New**: `MCP_DEBUG_LEVEL` environment variable on MCP servers  -  `info` (default), `debug`, or `trace`  -  tiered framework logging with clearer precedence than legacy truthy `DEBUG` (`#1430`)
+- **Fix**: Widget dev server pre-warms Vite entries before tool registration so the first widget render does not time out with HTTP 504 (`#1425`)
+- **Fix** (@mcp-use/inspector): Command palette e2e tests updated for the Settings dropdown trigger (`#1428`) (see inspector changelog)
+- **Update**: Updated @mcp-use/inspector to v3.0.2
+- **Update**: Updated @mcp-use/cli to v3.1.2
+- **Update**: Updated create-mcp-use-app to v0.14.10
+</Update>
+
+<Update label="v1.25.1" description="April 2026">
+  ## OAuth error handling, Supabase endpoints & CLI bundling
+  Patch release fixing OAuth error redirects, Supabase OAuth 2.1 endpoints, CLI bundling for Node ESM, bun build compatibility, `create-mcp-use-app` dot-directory init, and Inspector 3.0.1 (see inspector changelog).
+
+- **Fix**: OAuth callback redirects back to the inspector with error parameters when authorization fails (user denies, server error) instead of surfacing a raw error page with stack traces; the inspector surfaces these as a persistent toast (`#1381`)
+- **Fix**: `SupabaseOAuthProvider` endpoint getters now return OAuth 2.1 paths (`/auth/v1/oauth/authorize`, `/auth/v1/oauth/token`) instead of the legacy `/auth/v1/authorize` and `/auth/v1/token` (`#1422`)
+- **Fix** (@mcp-use/cli): `mcp-use build` is non-fatal under the bun runtime  -  detects bun, skips `tsx/esm/api` type-generation with a warning, wraps the build in try/catch, and runs `tsc` via `process.execPath` instead of hardcoded `node` (`#1382`)
+- **Fix** (@mcp-use/cli): bundle each server entry with esbuild (`bundle: true`, `packages: "external"`) so extensionless relative TypeScript imports resolve under plain Node ESM without `ERR_MODULE_NOT_FOUND` (`#1357`)
+- **Fix** (create-mcp-use-app): allow `.` as project name to initialize in the current directory; errors if the directory is not empty (`#1413`)
+- **Enhancement** (@mcp-use/inspector): OAuth single-tab redirect, session-storage reconnect, Hono duck-type detection, widget z-index, free-tier embed UI, managed LLM embed chrome (see inspector changelog)
+- **Update**: Updated @mcp-use/inspector to v3.0.1
+- **Update**: Updated @mcp-use/cli to v3.1.1
+- **Update**: Updated create-mcp-use-app to v0.14.10
+</Update>
+
+<Update label="v1.25.0" description="April 2026">
+  <Frame>
+    <img src="https://mcp-use.com/api/og/release?v=1.25.0&title=OAuth%20DCR-direct%2C%20Next.js%20drop-in%20%26%20CLI%203.1&date=2026-04&lang=typescript" alt="Release 1.25.0" />
+  </Frame>
+  ## OAuth DCR-direct, Next.js drop-in & CLI 3.1
+  Minor release refactoring built-in OAuth providers to DCR-direct by default, adding a Next.js MCP drop-in via `--mcp-dir`, CLI 3.1 with better org and session handling, and Inspector 3.0 (see inspector changelog).
+
+- **New**: `oauthProxy` helper for building proxy-mode providers (Google, GitHub, or any upstream authorization server that does not support Dynamic Client Registration)  -  complements the new DCR-direct default (`#1321`)
+- **New**: `jwksVerifier` helper for JWKS-based token verification inside custom providers (`#1321`)
+- **New**: Auth0 OAuth proxy example under `examples/server/oauth/auth0-proxy` demonstrating the new proxy pattern
+- **Update**: Built-in providers (Auth0, WorkOS, Supabase, Keycloak, Better Auth) now only support DCR-direct  -  clients talk to upstream authorization servers directly, and provider configurations no longer accept `clientId` / `clientSecret` (`#1321`)
+- **Update**: `verifyToken` is now a required function on custom providers (`#1321`)
+- **Fix**: OAuth `authenticate()` preserves the pathname component (for example `/api/auth`) when the authorization server uses a `basePath`, instead of collapsing the URL to its origin (`#1360`)
+- **New**: Next.js drop-in  -  `mcp-use dev/build/start --mcp-dir <dir>` lets a Next.js app colocate an MCP server (default `src/mcp/`), share `@/*` aliases, Tailwind, and the app's component library; the CLI auto-shims Next.js server-runtime modules (`server-only`, `client-only`, `next/cache`, `next/headers`, `next/navigation`, `next/server`) when `next` is detected, loads the Next.js env cascade in the MCP server process, and widget builds fail fast when a widget transitively imports a server-only module (`#1332`)
+- **New** (@mcp-use/cli): `mcp-use login --org <slug|id|name>` for non-interactive org selection; login fails fast without a TTY and no `--org` instead of hanging on stdin (`#1379`)
+- **New** (@mcp-use/cli): ORG column in `mcp-use deployments list` output (`#1378`)
+- **Fix** (@mcp-use/cli): `mcp-use deploy --org <org>` now respects the flag when `.mcp-use/project.json` links to a server in a different org  -  CLI warns and creates a new server in the requested org instead of silently redeploying to the linked one (`#1380`)
+- **Fix** (@mcp-use/cli): `mcp-use login` validates the stored API key against the backend before short-circuiting with "already logged in"; expired or revoked keys drop into device-auth automatically, and authenticated commands (`whoami`, `org`, `servers`, `deployments`, `env`) funnel 401s through a shared handler with a "session expired  -  run `npx mcp-use login`" hint (`#1383`)
+- **Fix** (@mcp-use/cli): `mcp-use start` auto-discovers an available port when the default port is in use (`#1377`)
+- **Enhancement** (@mcp-use/inspector): Inline elicitation in the chat thread, Open Graph and Twitter Card meta tags on the hosted inspector (see inspector changelog)
+- **Enhancement** (create-mcp-use-app): Only copy the `mcp-apps-builder` skill into new projects; skip the deprecated `mcp-builder` and `chatgpt-app-builder` skills (`#1375`)
+- **Documentation**: New `oauth-proxy` provider guide and refactored provider pages (Auth0, WorkOS, Supabase, Keycloak, Better Auth, custom); new Next.js drop-in guide; updated CLI reference
+- **Update**: Updated @mcp-use/inspector to v3.0.0
+- **Update**: Updated @mcp-use/cli to v3.1.0
+- **Update**: Updated create-mcp-use-app to v0.14.9
+</Update>
+
+<Update label="v1.24.2" description="April 2026">
+  ## Landing deeplinks, `colorScheme` & Inspector 2.2
+  Patch release adding optional `colorScheme` on `McpUseProvider`, a server landing deeplink to the hosted inspector, stronger deploy behavior in `@mcp-use/cli`, cloud server environment-variable commands, and Inspector 2.2 (see inspector changelog).
+
+- **New**: `colorScheme` on `McpUseProvider` (default `false`)  -  when `false`, `ThemeProvider` does not set `color-scheme` on the document root so transparent iframe backgrounds stay transparent; opt in with `true` for native scrollbars / `light-dark()` in widgets
+- **Fix**: Server landing routes include a deeplink to open the MCP server in the hosted manufact inspector
+- **New** (@mcp-use/cli): `mcp-use servers env` subcommands to list, create, update, and delete environment variables on cloud servers (`#1372`)
+- **Fix** (@mcp-use/cli): `mcp-use deploy` surfaces failures from mutating git commands (init, commit, push), normalizes the default branch to `main` before push, verifies a commit exists, and shell-quotes commit messages (`#1354`)
+- **Update** (@mcp-use/cli): Deploy treats HTTP 401 as an invalid or expired API session and prompts re-authentication instead of misreporting GitHub App connection state (`#1356`)
+- **Enhancement** (@mcp-use/inspector): Hosted chat configuration, copy/export chat, inspector LLM stack without LangChain, OAuth popup close page, and related UX (see inspector changelog)
+- **Update**: Updated @mcp-use/inspector to v2.2.0
+- **Update**: Updated @mcp-use/cli to v3.0.2
+</Update>
+
+<Update label="v1.24.1" description="April 2026">
+  ## OAuth fetch cleanup when switching transports
+  Patch release fixing OAuth in the embedded inspector when switching from Via Proxy to Direct  -  `BrowserOAuthClientProvider` restores `window.fetch` when `useMcp` unmounts so a stale proxy interceptor cannot break direct flows.
+
+- **Fix**: Restore the `window.fetch` interceptor installed by `BrowserOAuthClientProvider` when `useMcp` unmounts  -  resolves "Protected resource does not match" after switching from Via Proxy to Direct
+- **Fix** (@mcp-use/inspector): Same fetch lifecycle in the inspector client (see inspector changelog)
+- **Update**: Updated @mcp-use/inspector to v2.1.0
+- **Update**: Updated @mcp-use/cli to v3.0.1
+</Update>
+
+<Update label="v1.24.0" description="April 2026">
+  <Frame>
+    <img src="https://mcp-use.com/api/og/release?v=1.24.0&title=OAuth%20scopes%2C%20telemetry%2C%20CLI%203%20%26%20device%20flow&date=2026-04&lang=typescript" alt="Release 1.24.0" />
+  </Frame>
+  ## OAuth scopes, telemetry & CLI 3
+  Minor release for `mcp-use` with OAuth scope customization, telemetry, sub-path OAuth routing, and a Generative-AI JSON Schema fix; major `@mcp-use/cli` release with device-flow auth and manufact API alignment; Inspector 2.0 (see inspector changelog).
+
+- **New**: Configurable OAuth scopes  -  `scopesSupported` on shared OAuth config and built-in providers
+- **Fix**: `CustomProviderConfig` matches documented fields (`jwksUrl`, `scopesSupported`, `userInfoEndpoint`, `clientId`, `clientSecret`, `mode`, `audience`); optional `getClientId()`, `getUserInfoEndpoint()`, and `getAudience()` on `OAuthProvider`; OAuth routes use those accessors instead of unsafe casts
+- **New**: Telemetry support with browser and Node implementations and related dependency updates
+- **New**: `defaultCallbackUrl` on `McpClientProvider` so OAuth redirect URLs stay correct when the UI is mounted under a path basename (for example embedded inspector at `/inspector`)
+- **Fix**: Google provider tool schemas  -  use `z.object({}).catchall()` instead of `z.record()` so emitted JSON Schema omits `propertyNames`, which Google's API rejects
+- **Fix**: Windows path handling in server and tooling code paths
+- **Enhancement**: Several internal log lines moved from info to debug to reduce noise in normal operation
+- **Fix** (@mcp-use/inspector): OAuth callback URL when the inspector basename is `/inspector`; thinking indicator after streamed assistant messages; tab persistence across refresh (see inspector changelog)
+- **New** (@mcp-use/cli): Device-flow authentication for login and session refresh against the cloud
+- **Update** (@mcp-use/cli): CLI refactored to new manufact cloud APIs across deploy, auth, organization, and server commands
+- **Fix** (@mcp-use/cli): Deployment flow when linking GitHub repositories (`#1331`)
+- **Update**: Updated @mcp-use/inspector to v2.0.0
+- **Update**: Updated @mcp-use/cli to v3.0.0
+</Update>
+
+<Update label="v1.23.1" description="April 2026">
+  ## Embedded inspector without LangChain
+  Patch release fixing embedded inspector when the agent graph is not installed, and clearer diagnostics when mounting the inspector UI fails.
+
+- **Fix**: Export `telFetch` from `mcp-use/telemetry/tel-fetch` (tsup build) so inspector server code does not import the root `mcp-use` entry, which eagerly loads the agent stack  -  fixes embedded inspector when `langchain` is not installed
+- **Fix**: Log inspector UI mount failures in development or when `MCP_USE_DEBUG` is set (production remains quiet)
+- **Fix** (@mcp-use/inspector): `telFetch` import uses the telemetry subpath (see inspector changelog)
+- **Update**: Updated @mcp-use/inspector to v1.0.1
+- **Update**: Updated @mcp-use/cli to v2.21.4
+</Update>
+
+<Update label="v1.23.0" description="April 2026">
+  <Frame>
+    <img src="https://mcp-use.com/api/og/release?v=1.23.0&title=Better%20Auth%2C%20Server%20Metadata%20%26%20Inspector%201.0&date=2026-04&lang=typescript" alt="Release 1.23.0" />
+  </Frame>
+  ## Better Auth, server metadata & Inspector 1.0
+  Minor release adding a Better Auth OAuth provider, metadata-only client updates, dependency hardening, and a major Inspector release.
+
+- **New**: Better Auth OAuth provider for MCP servers  -  see authentication docs and `examples/server/oauth/better-auth`
+- **New**: `updateServerMetadata()` on `McpClientProvider` updates display metadata without reconnecting; connection-affecting changes still use `updateServer()`
+- **Fix**: Windows-compatible ESM import paths for dev and tooling
+- **Enhancement** (@mcp-use/inspector): Stream protocol in chat, `disabledTools`, editable server aliases with shared display-name resolution, tab persistence and URL sync, tool-invocation serialization and screenshots (see inspector changelog)
+- **Update**: Vite 8.0.5, Hono 4.12.12, `@hono/node-server` 1.19.13 across the TypeScript workspace
+- **Fix**: Tighter `pnpm` overrides and lockfile refresh for `pnpm audit`; `lodash` override in the mcp-apps scaffold template for standalone installs
+- **Documentation**: `updateServerMetadata` in the `useMcpClient` API reference; authentication overview links to the Better Auth guide
+- **Update**: Updated @mcp-use/inspector to v1.0.0
+- **Update**: Updated @mcp-use/cli to v2.21.3
+- **Update**: Updated create-mcp-use-app to v0.14.8
+</Update>
+
+<Update label="v1.22.3" description="March 2026">
+  ## Inspector dependency & bundling alignment
+  Patch release adjusting how `@mcp-use/inspector` depends on `mcp-use` so bundling and shared types both work.
+
+- **Fix** (@mcp-use/inspector): Restore `mcp-use` as both a `dependency` and `peerDependency`  -  needed to bundle non-React subpaths (`mcp-use/auth`, `mcp-use/browser`) with transitive deps (e.g. LangChain), while `peerDependency` keeps `mcp-use`/`react` types aligned with the host app
+- **Update**: Updated @mcp-use/inspector to v0.26.1
+- **Update**: Updated @mcp-use/cli to v2.21.2
+- **Update**: Updated create-mcp-use-app to v0.14.7
+</Update>
+
+<Update label="v1.22.2" description="March 2026">
+  ## Type Compatibility & Peer Dependency Alignment
+  Patch release focused on pnpm peer-variant type compatibility, inspector dependency alignment, and template dependency cleanup.
+
+- **Fix**: Resolved TypeScript nominal type conflicts when `mcp-use` is installed as multiple pnpm peer-variant copies  -  moved internal client-init tracking off class surface to avoid `.d.ts` incompatibilities
+- **Fix**: Reverted `stripInternal`/`@internal` approach that degraded downstream tool handler type inference; keeps type safety while preserving consumer inference behavior
+- **Fix** (@mcp-use/inspector): Moved `mcp-use` from `dependencies` to `peerDependencies` so consumers share a single `mcp-use` type instance (addresses TS2322 duplicate-type scenarios)
+- **Update** (@mcp-use/inspector): Upgraded `@mcp-ui/client` to v7; replaced removed legacy renderer path with sandboxed iframe handling for `ui://` resources and removed remote-dom usage
+- **Update**: Updated @mcp-use/inspector to v0.26.0
+- **Update**: Updated @mcp-use/cli to v2.21.1
+- **Update**: Updated create-mcp-use-app to v0.14.7
+</Update>
+
+<Update label="v1.22.1" description="March 2026">
+  ## CLI Organizations, Non-Interactive Deploy & Typed Middleware
+  Patch release with CLI org management, non-interactive deployments, improved middleware/tool context propagation, typed middleware ergonomics, and ErrorBoundary customization.
+
+- **New** (@mcp-use/cli): Organization commands  -  `mcp-use org list`, `mcp-use org switch`, `mcp-use org current`; login prompts for org selection when multiple; `whoami` shows active organization; org preference persisted in `~/.mcp-use/config.json`
+- **Enhancement** (@mcp-use/cli): Deploy to a specific org with `mcp-use deploy --org <slug-or-id>`; all org-scoped API requests include `x-profile-id`
+- **New** (@mcp-use/cli): Non-interactive deploy with `-y` / `--yes`  -  skips confirmations; replaces “Press Enter” with polling; errors if not logged in (requires `mcp-use login`)
+- **Fix**: Context propagation into tool handlers  -  singleton AsyncLocalStorage via `globalThis`, safe Hono context extraction, and forwarding middleware `ctx.auth` / `ctx.state` into enhanced tool context
+- **Fix**: `ctx.auth` typing is now `AuthInfo | undefined` when OAuth isn’t configured (enables `if (!ctx.auth) ...` guards)
+- **Enhancement**: Typed MCP middleware context  -  `server.use("mcp:tools/call" | "mcp:resources/read" | "mcp:prompts/get", ...)` now narrows `ctx.params` to method-specific shapes; `mcp:*` remains generic
+- **Enhancement**: `outputSchema` tools can return response helpers (`text()`, `markdown()`, `mix()`, etc.) without type errors
+- **Enhancement**: `server.resourceTemplate()` supports an optional Zod `schema` to type `params` as `z.infer<schema>`
+- **Enhancement**: `ErrorBoundary` now supports `fallback` (node or `(error) => node`) and `onError` for reporting (default UI unchanged)
+- **Update**: Updated @mcp-use/inspector to v0.25.1
+- **Update**: Updated @mcp-use/cli to v2.21.0
+</Update>
+
+<Update label="v1.22.0" description="March 2026">
+  <Frame>
+    <img src="https://mcp-use.com/api/og/release?v=1.22.0&title=Vite%208%2C%20MCP%20Middleware%20%26%20Model%20Context&date=2026-03&lang=typescript" alt="Release 1.22.0" />
+  </Frame>
+  ## Vite 8, MCP Middleware & Model Context
+  Minor release with Vite 8 across tooling, MCP operation middleware, files and model context APIs, elicit and adapter fixes, and Inspector tunnel controls.
+
+- **New**: MCP operation-level middleware  -  `server.use("mcp:*", ...)` and specific patterns (`mcp:tools/call`, `mcp:tools/list`, `mcp:resources/read`, `mcp:resources/list`, `mcp:prompts/get`, `mcp:prompts/list`) with typed `MiddlewareContext` (`method`, `params`, `session`, `auth`, `state`)
+- **New**: `useFiles` React hook with `isSupported` and `modelVisible` for file attachments; `ModelContext` component and `modelContext` imperative API for server-side model context injection
+- **Enhancement**: Vite 8.0 with Rolldown bundler and `@vitejs/plugin-react` 6 across packages, examples, and CLI/inspector tooling
+- **Enhancement**: Conformance client  -  pass `reconnectionOptions` so SDK-level SSE reconnection behaves correctly when `autoReconnect` is disabled
+- **Fix**: Elicit  -  map `result.content` to `result.data` for Zod validation; spec-compliant clients use `content`; backward-compatible fallback to `data`
+- **Fix**: LangChainAdapter  -  tool name collisions when exposing resources/prompts as tools; `reserveName` resolves prefixed names with a numeric suffix when needed; prompt names sanitized like resource names
+- **Enhancement** (@mcp-use/inspector): Start/stop the `mcp-use dev` tunnel from the Inspector (see inspector changelog)
+- **Update**: Updated @mcp-use/inspector to v0.25.0
+- **Update**: Updated @mcp-use/cli to v2.20.0
+</Update>
+
+<Update label="v1.21.5" description="March 2026">
+  ## Zod Peer Dep, Esbuild Build & Windows Fix
+  Patch release with Zod peer dependency, esbuild transpilation, TypeGen Zod v4 fixes, and Windows path handling.
+
+- **Fix**: Move zod from dependencies to peerDependencies  -  prevents duplicate type trees when users have a different Zod v4 version; avoids type errors or OOM during `mcp-use build`
+- **Fix**: TypeGen crash with Zod v4 enum schemas  -  `zod-to-ts` now handles Zod v4 `ZodEnum` (`_def.entries`), `ZodDiscriminatedUnion`; CLI reports success/failure of type generation instead of silently failing
+- **Fix** (@mcp-use/cli): Windows crash in `mcp-use dev` and `mcp-use generate-types`  -  use `file://` URL in tsImport instead of raw OS paths (fixes `ERR_UNSUPPORTED_ESM_URL_SCHEME`)
+- **Fix**: Dependabot security alerts  -  updated flatted, tar, hono, express-rate-limit, dompurify, minimatch, rollup, form-data, lodash, and other transitive deps
+- **Enhancement** (@mcp-use/cli): `mcp-use build` uses esbuild for transpilation instead of tsc  -  avoids OOM on complex type graphs (Zod v4, Prisma); type checking runs separately via `tsc --noEmit`; add `--no-typecheck` to skip type checking for faster builds
+- **Update**: Updated @mcp-use/inspector to v0.24.5
+- **Update**: Updated @mcp-use/cli to v2.19.0
+- **Update**: Updated create-mcp-use-app to v0.14.6
+</Update>
+
+<Update label="v1.21.4" description="March 2026">
+  ## Request Context, CLI Build & README Fixes
+  Patch release fixing request context propagation, CLI build hang, and stale monorepo references.
+
+- **Fix**: `ctx.auth` and other request context properties were `undefined` in tool callbacks; `mountMcp()` now wraps `transport.handleRequest()` with `runWithContext()` so `getRequestContext()` is populated
+- **Fix** (@mcp-use/cli): `mcp-use build` no longer hangs  -  add `process.exit(0)` on success (tsImport creates active handles)
+- **Fix**: Update stale mcp-use-ts references in README badges, image URLs, eslint config to mcp-use monorepo
+- **Update**: Updated @mcp-use/inspector to v0.24.4
+- **Update**: Updated @mcp-use/cli to v2.18.3
+</Update>
+
+<Update label="v1.21.3" description="March 2026">
+  ## Inspector Sandbox Host Fix
+  Patch release fixing sandbox host derivation for cloud-embedded inspector pages.
+
+- **Fix** (@mcp-use/inspector): Sandbox host derivation for cloud-embedded pages  -  apex hosts (e.g. manufact.com) now resolve to `sandbox-inspector.{domain}` instead of `sandbox-{domain}`
+- **Update**: Updated @mcp-use/inspector to v0.24.3
+- **Update**: Updated @mcp-use/cli to v2.18.2
+</Update>
+
+<Update label="v1.21.2" description="March 2026">
+  ## Inspector Proxy Fix for Embedded Servers
+  Patch release fixing inspector auto-connect when served from MCP server (Python, etc.).
+
+- **Fix** (@mcp-use/inspector): Skip proxy when inspector is served from the MCP server itself  -  auto-connect no longer routes through missing `/inspector/api/proxy` on embedded servers
+- **Fix** (@mcp-use/inspector): Detect proxy availability via runtime config injection; disable autoProxyFallback when no proxy is available
+- **Update**: Updated @mcp-use/inspector to v0.24.2
+- **Update**: Updated @mcp-use/cli to v2.18.1
+</Update>
+
+<Update label="v1.21.1" description="March 2026">
+  ## Session Persistence & CLI Improvements
+  Patch release with session recovery fix, CLI enhancements, and create-mcp-use-app install improvements.
+
+- **Fix**: Session recovery after restart returns 400 fix; distributed SSE stream routing via Redis Pub/Sub
+- **Enhancement** (@mcp-use/cli): `mcp-use build` runs tool registry type generation before TypeScript compilation when server file exists
+- **Enhancement** (@mcp-use/cli): `--root-dir` option for deploy command for monorepo support
+- **Fix** (create-mcp-use-app): Remove flickering behaviour from `npm i`
+- **Update**: Updated @mcp-use/inspector to v0.24.1
+- **Update**: Updated @mcp-use/cli to v2.18.0
+- **Update**: Updated create-mcp-use-app to v0.14.4
+</Update>
+
+<Update label="v1.21.0" description="March 2026">
+  <Frame>
+    <img src="https://mcp-use.com/api/og/release?v=1.21.0&title=Proxy%20Servers%20%26%20Client%20Completion&date=2026-03&lang=typescript" alt="Release 1.21.0" />
+  </Frame>
+  ## Proxy Servers & Client Completion
+  Minor release with server composition, client-side completion, user context, and Express middleware types.
+
+- **New**: `MCPServer.proxy()` for composing multiple MCP servers into a single aggregator  -  automatic orchestration, schema translation, namespacing, list-changed multiplexing
+- **New**: Client-side completion support  -  `complete()` on BaseConnector, MCPSession, and `useMcp`; `refreshResourceTemplates()`; prompt argument and resource template URI autocomplete
+- **New**: `ctx.client.user()` for per-invocation end-user metadata (`subject`, `conversationId`) from tools/call params
+- **Enhancement**: `ctx.client.supportsApps()` now correctly returns true for MCP Apps clients (fixed ClientCapabilitiesSchema `extensions` stripping)
+- **Enhancement**: `autoReconnect` options  -  configurable health check interval, reconnection delay, timeout via `reconnectionOptions`
+- **Enhancement**: `sendFollowUpMessage` accepts `MessageContentBlock` arrays (text, image, resource blocks) per SEP-1865
+- **Enhancement**: Host info and capabilities  -  `hostInfo`, `hostCapabilities` in `useWidget`; `getHostInfo`, `getHostCapabilities` on `McpAppsBridge`
+- **Fix**: Express middleware types  -  proper TypeScript types for `server.use()` with Express middleware (auto-detected and adapted)
+- **Fix**: Session isolation  -  `findSessionContext` no longer falls back to arbitrary session, preventing metadata leakage
+- **Fix**: Remove deprecated `@types/tar`; update tar to latest (cli, create-mcp-use-app)
+- **Update**: Updated @mcp-use/inspector to v0.24.0
+- **Update**: Updated @mcp-use/cli to v2.17.0
+- **Update**: Updated create-mcp-use-app to v0.14.3
+- **Documentation**: Per-server elicitation and sampling callbacks examples; proxy servers section
+</Update>
+
+<Update label="v1.20.5" description="February 2026">
+  ## CLI Tunnel Support
+  Patch release adding tunnel flag for ChatGPT HMR.
+
+- **New** (@mcp-use/cli): Support for `--tunnel` flag with full ChatGPT HMR
+- **Update**: Updated @mcp-use/inspector to v0.23.1
+- **Update**: Updated @mcp-use/cli to v2.16.0
+</Update>
+
+<Update label="v1.20.4" description="February 2026">
+  ## Inspector Embedded Chat
+  Patch release with inspector embedded chat improvements.
+
+- **Enhancement** (@mcp-use/inspector): Improved embedded chat
+- **Update**: Updated @mcp-use/inspector to v0.23.0
+- **Update**: Updated @mcp-use/cli to v2.15.4
+</Update>
+
+<Update label="v1.20.3" description="February 2026">
+  ## Inspector Standalone Deployment Fix
+  Patch release fixing inspector standalone deployment version import.
+
+- **Fix** (@mcp-use/inspector): Standalone deployment was importing the version from the wrong path
+- **Update**: Updated @mcp-use/inspector to v0.22.3
+- **Update**: Updated @mcp-use/cli to v2.15.3
+</Update>
+
+<Update label="v1.20.2" description="February 2026">
+  ## Health Monitoring & MCPAgentOptions
+  Patch release with dynamic auth headers for health checks and MCPAgentOptions for chat agent.
+
+- **Enhancement**: `getAuthHeaders` parameter to `startConnectionHealthMonitoring` for customizable authentication headers during health checks; HEAD requests allowed without authentication
+- **Enhancement**: `exposeResourcesAsTools` and `exposePromptsAsTools` options in MCPAgentOptions (both default to `true`); inspector chat tab sets both to `false` so agent only exposes actual MCP tools
+- **Update**: Updated @mcp-use/inspector to v0.22.2
+- **Update**: Updated @mcp-use/cli to v2.15.2
+</Update>
+
+<Update label="v1.20.1" description="February 2026">
+  ## Widget Status Texts & CSP Handling
+  Patch release with widget metadata enhancements and CSP improvements.
+
+- **New**: `invoking` and `invoked` properties in widget metadata for customizable status messages during tool execution
+- **Breaking**: McpUseProvider no longer includes BrowserRouter; add it explicitly if your widget uses react-router
+- **Enhancement**: MCPAppsDebugControls CSP mode violation indicators; sandbox-proxy strips existing CSP meta tags before injecting permissive CSP
+- **Fix** (create-mcp-use-app): Unify logo display across all CLI entry paths
+- **Update**: Updated @mcp-use/inspector to v0.22.1
+- **Update**: Updated @mcp-use/cli to v2.15.1
+</Update>
+
+<Update label="v1.20.0" description="February 2026">
+  <Frame>
+    <img src="https://mcp-use.com/api/og/release?v=1.20.0&title=Widget%20Debug%20%26%20CSP%20Improvements&date=2026-02&lang=typescript" alt="Release 1.20.0" />
+  </Frame>
+  ## Widget Debug & CSP Improvements
+  Minor release with Iframe Console enhancements, MCP Apps debug controls, and CSP handling.
+
+- **New**: CLI update check notifies when a newer mcp-use release is available
+- **Fix**: CLI TSC build uses node with increased heap; avoid npx installing wrong package
+- **Fix**: CLI fallback MCP_URL when tunnel is unavailable
+- **New** (create-mcp-use-app): @types/react and @types/react-dom in template devDependencies
+- **Enhancement**: Slim down generated READMEs; improve mcp-apps template (Carousel, product-search-result widget); include .mcp-use in tsconfig; fix postinstall script
+- **Fix**: create-mcp-use-app product-search-result template styling and CSP metadata
+- **Enhancement**: Iframe Console with expandable logs, level filter, search, resizable height
+- **New**: Widget debug context for chat; MCP Apps debug controls (tool props JSON view, required props hint, SEP-1865 semantics)
+- **New**: CDN build for inspector; CSP violations panel with clear action; widget re-execution on CSP mode change; CSP mode for Apps SDK
+- **Fix**: useSyncExternalStore first-render handling; reconnect logic; Tools tab only sends explicitly set fields; resource annotations include `_meta`
+- **Fix**: mcp-use widget CSP fallback from tool metadata; protocol and mount-widgets-dev improvements
+- **Enhancement**: useWidget merges props from toolInput and structuredContent per SEP-1865
+- **New**: updateModelContext and useMcp clientOptions
+- **Fix**: WorkOS subdomain config to accept full AuthKit domain (e.g., `name.authkit.app`)
+- **Update**: Updated @mcp-use/inspector to v0.22.0
+- **Update**: Updated @mcp-use/cli to v2.15.0
+</Update>
+
+<Update label="v1.19.3" description="February 2026">
+  ## CLI Skills & Template Updates
+  Patch release with CLI skills commands and create-mcp-use-app template improvements.
+
+- **New** (@mcp-use/cli): `mcp-use skills add` and `mcp-use skills install` commands to install AI agent skills (Cursor, Claude Code, Codex) from the mcp-use repository
+- **Enhancement** (create-mcp-use-app): Add @types/react and @types/react-dom to template devDependencies
+- **Update**: Updated @mcp-use/inspector to v0.21.1
+- **Update**: Updated @mcp-use/cli to v2.14.0
+</Update>
+
+<Update label="v1.19.2" description="February 2026">
+  ## Tool Schema & Type Testing Improvements
+  Patch release with nested input schema fixes and compile-time type regression testing.
+
+- **Fix**: Correctly convert nested input schema args for tools
+- **New**: Added everything-server example for compile-time type regression testing
+- **Update**: Updated @mcp-use/inspector to v0.21.0
+- **Update**: Updated @mcp-use/cli to v2.13.10
+</Update>
+
+<Update label="v1.19.1" description="February 2026">
+  ## MCPApps & Widget Loading Enhancements
+  Patch release improving widget loading logic and iframe handling.
+
+- **Enhancement**: Improved MCPAppsRenderer loading logic with better state management
+- **Enhancement**: Enhanced useWidget for iframe handling
+- **Update**: Updated @mcp-use/inspector to v0.20.1
+- **Update**: Updated @mcp-use/cli to v2.13.9
+</Update>
+
+<Update label="v1.19.0" description="February 2026">
+  <Frame>
+    <img src="https://mcp-use.com/api/og/release?v=1.19.0&title=Client%20Conformance%20%26%20Type%20Safety%20Improvements&date=2026-02&lang=typescript" alt="Release 1.19.0" />
+  </Frame>
+  ## Client Conformance & Type Safety Improvements
+  Minor release with full MCP client conformance, direct stdio connector support, and type inference fixes.
+
+- **New**: Client implementation is now 100% conformant with the MCP spec
+- **Enhancement**: Node.js client handles stdio connector directly with command/argument configuration
+- **Fix**: `error()` return type now compatible with tool callbacks using `outputSchema`
+- **Fix**: Fixed `TypedCallToolResult` type inference with explicit properties instead of Omit
+- **Fix**: Enhanced `prompt()` method generic type inference to match `tool()` pattern
+- **Enhancement**: Console output routes through Logger class with improved consistency; added tests for logLevel
+- **Enhancement**: Added support for additional Vitest file extensions in config
+- **Fix**: Correct MIME type for mcp_apps resource counting; disabled telemetry in local tests
+- **Update**: Updated @mcp-use/inspector to v0.20.0
+- **Update**: Updated @mcp-use/cli to v2.13.8
+
+### @mcp-use/cli v2.13.8
+
+- **Enhancement**: Improved loading states with spinner component
+- **Fix**: Correct MIME type for mcp_apps resource counting
+
+### create-mcp-use-app v0.13.0
+
+- **New**: Interactive prompts for optional skills installation (claude-code, cursor, codex)
+- **New**: `--install` and `--no-install` CLI flags for non-interactive mode
+- **Fix**: Corrected template reference in test-cli.sh
+</Update>
+
+<Update label="v1.18.0" description="February 2026">
+  <Frame>
+    <img src="https://mcp-use.com/api/og/release?v=1.18.0&title=DNS%20Rebinding%20%26%20Deferred%20Callbacks&date=2026-02&lang=typescript" alt="Release 1.18.0" />
+  </Frame>
+  ## DNS Rebinding Protection & Deferred Client Callbacks
+  Minor release adding DNS rebinding protection and deferred React client callbacks.
+
+- **New**: `allowedOrigins` configuration on `MCPServer` for DNS rebinding protection and host validation; docs and example (curl tests) added
+- **Enhancement**: `McpClientProvider` defers `onServerAdded` and `onServerStateChange` callbacks via `queueMicrotask` to avoid render-phase updates and improve stability
+- **Update**: Updated @mcp-use/inspector to v0.19.0
+- **Update**: Updated @mcp-use/cli to v2.13.7
+</Update>
+
+<Update label="v1.17.4" description="February 2026">
+  ## Widget Resource Propagation & Log Noise Reduction
+  Patch release improving HMR reliability for widget resources and reducing dev server log noise.
+
+- **Fix**: Reduced noisy logs in the dev server
+- **Fix**: Propagated widget resources and resource templates to already-connected MCP sessions during HMR to avoid `Resource ui://widget/... not found` errors without reconnecting
+- **Update**: Updated @mcp-use/inspector to v0.18.9
+- **Update**: Updated @mcp-use/cli to v2.13.6
+</Update>
+
+<Update label="v1.17.3" description="February 2026">
+  ## Inspector Reliability Alignment
+  Patch release aligning TypeScript packages with the latest inspector reliability fixes.
+
+- **Enhancement**: Pulled in inspector fixes for widget readiness resets and safer iframe global update handling
+- **Update**: Updated @mcp-use/inspector to v0.18.8
+- **Update**: Updated @mcp-use/cli to v2.13.5
+</Update>
+
+<Update label="v1.17.2" description="February 2026">
+  ## UI Resource Metadata & CSP Injection Fixes
+  Patch release improving server-origin metadata enrichment for UI resources.
+
+- **Fix**: UI resource metadata enrichment now guarantees metadata initialization before applying origin-based updates
+- **Enhancement**: Server origin is now consistently injected into widget CSP fields (`resourceDomains`, `connectDomains`, `baseUriDomains`)
+- **Update**: Updated @mcp-use/inspector to v0.18.7
+- **Update**: Updated @mcp-use/cli to v2.13.4
+</Update>
+
+<Update label="v1.17.1" description="February 2026">
+  ## useWidget Type Inference Improvements
+  Patch release improving `useWidget` typing precision for pending vs ready states.
+
+- **Enhancement**: `UseWidgetResult` now uses a discriminated union on `isPending` for more accurate TypeScript inference
+- **Enhancement**: Added `UseWidgetResultBase` to separate shared fields from pending-state-specific props
+- **Update**: Updated @mcp-use/inspector to v0.18.6
+- **Update**: Updated @mcp-use/cli to v2.13.3
+</Update>
+
+<Update label="v1.17.0" description="February 2026">
+  <Frame>
+    <img src="https://mcp-use.com/api/og/release?v=1.17.0&title=Resource%20Template%20Completion%20%26%20Reverse%20Proxy%20Support&date=2026-02&lang=typescript" alt="Release 1.17.0" />
+  </Frame>
+  ## Resource Template Completion & Reverse Proxy Support
+  Minor release adding resource template variable completion, custom route HMR, and comprehensive reverse proxy support.
+
+### Resource Template Completion
+
+- **New**: Resource template variable completion  -  templates can define `callbacks.complete` per variable (string array or callback) for client-side autocomplete of URI template variables
+- **New**: `toResourceTemplateCompleteCallbacks` utility for normalizing completion definitions
+- **New**: MCP servers now publish completion capabilities
+
+### HMR & Reverse Proxy Improvements
+
+- **New**: Custom HTTP route HMR  -  routes registered via `server.get()`, `server.post()`, etc. now hot-swap without restart
+- **New**: Widget tool protection during HMR  -  tools tagged with `_meta["mcp-use/widget"]` preserved during sync
+- **New**: Dynamic widget creation  -  `resources/` directory auto-created, dev server watches for new widgets even if none exist at startup
+- **New**: Vite HMR WebSocket proxy for hot-reload through reverse proxies (ngrok, E2B, Cloudflare tunnels)
+- **New**: `MCP_URL` environment variable can be pre-set by users for external proxy URLs; CLI will not overwrite it
+- **New**: `window.__mcpServerUrl` global injected into widget HTML for dynamic API URL construction
+- **Enhancement**: List-changed notifications now fire on removal, not just add/update
+- **Enhancement**: Pre-initialized request handlers prevent `-32601 Method not found` errors on dynamic tool registration
+- **Enhancement**: Widget type default changed to `mcpApps` (dual-protocol) instead of `appsSdk`
+
+### Dependencies
+
+- **Update**: Updated @mcp-use/inspector to v0.18.5
+- **Update**: Updated @mcp-use/cli to v2.13.2
+</Update>
+
+<Update label="v1.16.4" description="February 2026">
+  <Frame>
+    <img src="https://mcp-use.com/api/og/release?v=1.16.4&title=HMR%20Improvements%20%26%20Widget%20Enhancements&date=2026-02&lang=typescript" alt="Release 1.16.4" />
+  </Frame>
+  ## HMR Improvements & Widget Enhancements
+  Patch release with Hot Module Reload improvements, widget lifecycle enhancements, and CLI build system improvements.
+
+### HMR & Server Improvements
+
+- **Fix**: Tool schema preservation during HMR now uses Zod schemas directly instead of converting to params
+- **Fix**: Empty schema changed from `{}` to `z.object({})` to ensure `safeParseAsync` works correctly
+- **Enhancement**: Prompts now support tool response helpers (`text()`, `object()`, `image()`, etc.) via automatic conversion to `GetPromptResult`
+- **Enhancement**: Resources now support tool response helpers via automatic conversion to `ReadResourceResult`
+- **Enhancement**: Widget resources (`ui://widget/*`) and resource templates preserved during HMR
+- **Enhancement**: Enhanced prompt conversion to handle edge cases (single content objects, bare content items, mixed content arrays)
+
+### CLI Build Improvements
+
+- **New**: Build manifest with `entryPoint` tracking written to `dist/mcp-use.json` for reliable server location
+- **Enhancement**: Support for multiple TypeScript output paths (dist/index.js, dist/src/index.js, custom paths)
+- **Enhancement**: Start command reads `entryPoint` from manifest for accurate server location
+- **Enhancement**: Clear error messages when no built server file is found, listing all attempted locations
+
+### Widget Improvements
+
+- **Fix**: Widget pending state now correctly emulated to reflect ChatGPT behavior
+- **Enhancement**: Immediate widget rendering during pending states
+- **Enhancement**: Enhanced widget lifecycle management with better tool output handling
+- **New**: Delayed weather tool example (`get-weather-delayed`) in conformance server for testing widget lifecycle
+
+### Dependencies
+
+- **Update**: Updated @modelcontextprotocol/sdk to v1.26.0 (with Zod 4 compatibility patch)
+- **Update**: Updated @mcp-use/inspector to v0.18.4
+- **Update**: Updated @mcp-use/cli to v2.13.1
+- **Update**: Updated create-mcp-use-app to v0.12.3
+</Update>
+
+<Update label="v1.16.3" description="February 2026">
+  <Frame>
+    <img src="https://mcp-use.com/api/og/release?v=1.16.3&title=CLI%20Manufact%20Rebrand&date=2026-02&lang=typescript" alt="Release 1.16.3" />
+  </Frame>
+  ## CLI Manufact Rebrand
+  Minor release with CLI branding updates and authentication improvements.
+
+### CLI Rebrand
+
+- **Enhancement**: Updated CLI branding from "mcp-use" to "Manufact"
+- **Enhancement**: Changed default web URL from `mcp-use.com` to `manufact.com` for login flow
+- **Fix**: Fixed 431 "Request Header Fields Too Large" error by increasing callback server header limit to 16KB
+- **Enhancement**: Updated dashboard, inspector, and settings URLs to use `manufact.com` domain
+- **Enhancement**: Gateway domain remains `run.mcp-use.com` for backward compatibility with existing deployments
+
+### Dependencies
+
+- **Update**: Updated @mcp-use/cli to v2.13.0
+- **Update**: Updated @mcp-use/inspector to v0.18.3
+</Update>
+
+<Update label="v1.16.2" description="January 2026">
+  ## Widget Behavior Fix
+  Patch release fixing widget pending state emulation.
+
+- **Fix**: Widget pending state now correctly emulated to reflect ChatGPT behavior
+- **Update**: Updated @mcp-use/inspector to v0.18.2
+- **Update**: Updated @mcp-use/cli to v2.12.6
+</Update>
+
+<Update label="v1.16.1" description="January 2026">
+  ## Widget CSP Enhancement
+  Patch release fixing widget Content Security Policy configuration.
+
+- **Fix**: Auto-inject server origin into `connectDomains` CSP
+- **Enhancement**: Widgets can now make fetch/XHR/WebSocket calls back to the MCP server without explicitly declaring the domain
+- **Fix**: Corrected oversight where CHANGELOG mentioned connectDomains injection but it was not implemented
+</Update>
+
+<Update label="v1.16.0" description="January 2026">
+  <Frame>
+    <img src="https://mcp-use.com/api/og/release?v=1.16.0&title=Prompt%20Autocomplete%20%26%20Dynamic%20CSP&date=2026-01&lang=typescript" alt="Release 1.16.0" />
+  </Frame>
+  ## Prompt Autocomplete & Dynamic CSP
+  Minor release introducing prompt argument autocomplete and dynamic CSP domain injection for widgets.
+
+### New Features
+
+- **New**: `completable()` helper for prompt argument autocomplete
+- **New**: Dynamic CSP domain injection for widgets at tools/list time
+
+### Enhancements
+
+- **Enhancement**: Request origin (from X-Forwarded-Host or Host header) now automatically added to `connectDomains` and `resourceDomains` in tool metadata
+- **Enhancement**: Widgets now work correctly when accessed through proxies like ngrok, Cloudflare tunnels, or other reverse proxies
+- **Enhancement**: Server origin automatically enriched in widget CSP metadata
+
+### Dependencies
+
+- **Update**: Updated @mcp-use/inspector to v0.18.0
+- **Update**: Updated @mcp-use/cli to v2.12.4
+</Update>
+
+<Update label="v1.15.3" description="January 2026">
+  ## HMR & Theme Fixes
+  Patch release fixing Hot Module Reloading edge cases and theme functionality.
+
+- **Fix**: HMR not working when server starts with 0 tools initially
+- **Fix**: Dark mode can now be enabled through theme URL parameter
+- **Update**: Updated @mcp-use/inspector to v0.17.3
+- **Update**: Updated @mcp-use/cli to v2.12.3
+</Update>
+
+<Update label="v1.15.2" description="January 2026">
+  ## HMR File Watcher Fix
+  Patch release fixing file watcher resource exhaustion in containerized environments.
+
+- **Fix**: HMR file watcher exhausting inotify limits by properly ignoring node_modules
+- **Fix**: Prevented ENOSPC errors in containerized environments caused by watching files inside `node_modules/` despite ignore patterns
+- **Update**: Updated @mcp-use/inspector to v0.17.2
+- **Update**: Updated @mcp-use/cli to v2.12.2
+</Update>
+
+<Update label="v1.15.1" description="January 2026">
+  ## CLI Deployment Enhancement
+  Patch release with CLI deployment improvements.
+
+- **Enhancement**: CLI `getMcpServerUrl()` function for improved deployment URL handling
+- **Update**: Updated @mcp-use/cli to v2.12.1
+- **Update**: Updated @mcp-use/inspector to v0.17.1
+</Update>
+
+<Update label="v1.15.0" description="January 2026">
+  <Frame>
+    <img src="https://mcp-use.com/api/og/release?v=1.15.0&title=MCP%20Apps%20Support%20%26%20Landing%20Pages&date=2026-01&lang=typescript" alt="Release 1.15.0" />
+  </Frame>
+  ## MCP Apps Support & Landing Pages
+  Major release introducing MCP Apps support with dual-protocol widget rendering and HTML landing pages for MCP server endpoints.
+
+### MCP Apps Support
+
+- **New**: Dual-protocol support enabling widgets to work with both MCP Apps and ChatGPT Apps SDK
+- **New**: `MCPAppsRenderer` component for advanced debugging and visualization
+- **New**: `MCPAppsDebugControls` component for widget debugging
+- **New**: Sandboxed iframe support with console logging and safe area insets for isolated widget rendering
+- **New**: Widget adapters (MCP Apps, Apps SDK) with protocol helpers for seamless cross-protocol compatibility
+- **New**: MCP Apps documentation and example server
+
+### Landing Pages
+
+- **New**: `generateLandingPage()` function that generates styled HTML landing pages for browser GET requests
+- **New**: Connection instructions for Claude Code, Cursor, VS Code, VS Code Insiders, and ChatGPT on landing pages
+- **Enhancement**: Browser host normalization for server connections in CLI
+
+### Bug Fixes & Security
+
+- **Fix**: MCP server landing now shows the external URL instead of the internal URL
+- **Fix**: Zod JIT compilation to prevent CSP violations in sandboxed environments
+- **Security**: Fixed vulnerabilities in dependencies
+
+### Dependencies
+
+- **Update**: Updated @mcp-use/inspector to v0.17.0
+- **Update**: Updated @mcp-use/cli to v2.12.0
+</Update>
+
+<Update label="v1.14.2" description="January 2026">
+  ## Widget Rendering & Session Management Improvements
+  Patch release with widget rendering fixes, session timeout adjustments, and CLI deployment enhancements.
+
+### Widget Rendering & Session Management
+
+- **Fix**: Widget iframe reload by adding timestamp query parameter to force refresh when widget data changes
+- **Fix**: Retry logic with exponential backoff for dev widget fetching to handle Vite dev server cold starts
+- **Fix**: Default session idle timeout changed from 5 minutes to 1 day (86400000ms) to prevent premature session expiration
+- **Fix**: Session lastAccessedAt tracking now updates both persistent store and in-memory map
+- **Fix**: \_meta merging now preserves existing fields (e.g., openai/outputTemplate) when updating tools and widgets
+- **Enhancement**: Support for frame_domains and redirect_domains in widget CSP metadata
+
+### CLI Improvements
+
+- **Fix**: Environment variables, build command, start command, and port configuration now properly passed during redeployment
+
+### Documentation
+
+- **Fix**: Updated sessionIdleTimeoutMs default value documentation from 5 minutes to 1 day across multiple files
+</Update>
+
+<Update label="v1.14.1" description="January 2026">
+  ## Dependency Updates
+  Patch release with dependency updates.
+
+- **Update**: Updated dependencies to @mcp-use/inspector v0.16.1 and @mcp-use/cli v2.11.1
+</Update>
+
+<Update label="v1.14.0" description="January 2026">
+  <Frame>
+    <img src="https://mcp-use.com/api/og/release?v=1.14.0&title=Server%20Metadata%20%26%20Widget%20Enhancements&date=2026-01&lang=typescript" alt="Release 1.14.0" />
+  </Frame>
+  ## Server Metadata & Widget Enhancements
+  Release introducing server metadata configuration and enhanced widget development experience.
+
+### Server Metadata & Configuration
+
+- **New**: Server metadata support with `title`, `websiteUrl`, and `icons` fields in MCP server configuration
+- **New**: Inspector UI displays server website URLs and icons for better branding
+- **Deprecated**: `autoCreateSessionOnInvalidId` config option - use `sessionStore` for persistent sessions
+- **Enhancement**: Dynamic project name support in server configurations
+
+### Widget & Development Experience
+
+- **Enhancement**: HMR support for widget tool management - widgets update immediately without server restart
+- **Enhancement**: Parallel widget building for improved development performance
+- **Enhancement**: ReDoS attack prevention in widget name slugification with input length validation
+- **Enhancement**: Improved widget lifecycle documentation with loading state guidance
+
+### CLI Improvements
+
+- **New**: `MCP_URL` environment variable automatically set in server process for easy access to server URL
+- **Enhancement**: Server process environment now includes `MCP_URL` in both development and production modes
+- **Enhancement**: CLI now displays all 4 package versions (`@mcp-use/cli`, `mcp-use`, `@mcp-use/inspector`, `create-mcp-use-app`) in `dev` and `build` commands with `mcp-use` highlighted for clarity
+
+### API & Protocol
+
+- **New**: HEAD request support in `mountMcp` function
+- **Enhancement**: Improved input schema handling in tool registration with better defaults
+
+### MCP Proxy Middleware
+
+- **Enhancement**: Improved error logging with better context for debugging
+- **Enhancement**: Connection refused errors now logged as warnings instead of errors
+- **Enhancement**: Error responses include target URL to help identify failing proxy requests
+- **Enhancement**: More detailed error messages for proxy request failures
+
+### Bug Fixes
+
+- **Fix**: Anthropic `tool_use.id` error resolved with LangChain package updates
+- **Fix**: Telemetry shutdown method compatibility with posthog-node v5.22.0
+- **Fix**: Input schema initialization now defaults to empty object when not provided
+
+### Dependencies
+
+- **Update**: `@langchain/anthropic` to 1.3.10 (fixes tool_call ID generation)
+- **Update**: `@langchain/core` to 1.1.15
+- **Update**: `langchain` to 1.2.10
+- **Update**: `react-resizable-panels` to 4.4.1
+</Update>
+
+<Update label="v1.13.5" description="January 2026">
+  ## CLI Documentation Enhancement
+  Patch release adding comprehensive CLI documentation.
+
+- **Enhancement**: Added `.gitignore` file to CLI package to exclude `.mcp-use` directory from version control
+- **Enhancement**: Added `CLAUDE.md` to CLI package with comprehensive guidance on usage, development commands, architecture details, and deployment instructions
+- **Enhancement**: Improved CSRF protection in authentication flow
+- **Enhancement**: Enhanced error handling for GitHub integration in deploy command
+</Update>
+
+<Update label="v1.13.4" description="January 2026">
+  ## OAuth Proxy URL Handling Improvements
+  Patch release improving OAuth proxy URL handling and connection logic.
+
+- **Refactor**: Changed `connectionUrl` from `let` to `const` to enforce immutability
+- **Enhancement**: Enhanced logic for deriving `oauthProxyUrl` from callback URL, including handling cases where callback is at root path
+- **Enhancement**: Updated comments to clarify distinction between `oauthProxyUrl` and `connectionUrl`
+- **Fix**: Removed clearing of OAuth storage before connecting to maintain valid tokens across sessions
+</Update>
+
+<Update label="v1.13.3" description="January 2026">
+  ## Telemetry & Inspector Enhancements
+  Patch release with telemetry improvements and inspector URL validation enhancements.
+
+- **Fix**: Enhanced localStorage checks in Telemetry class to verify both existence and functional methods (getItem, setItem, removeItem)
+- **Enhancement**: Added error handling to throw exception if localStorage is not available or functional
+- **Enhancement**: Inspector now automatically prepends "https://" to URLs without protocol for better user experience
+- **Enhancement**: Improved error handling for invalid URLs in Inspector dashboard and server connection modal
+- **Enhancement**: Added localStorage clearing functionality in Inspector for troubleshooting
+</Update>
+
+<Update label="v1.13.2" description="January 2026">
+  ## Dependency Updates & CLI Enhancements
+  Minor release with dependency updates and CLI improvements for deployment workflows.
+
+- **Fix**: Updated dependency `hono` to 4.11.4
+- **Enhancement**: CLI login command with improved error handling and user feedback
+- **Enhancement**: CLI deployment command now prompts for login if not authenticated
+- **Enhancement**: Added git uncommitted changes check before deployment
+- **Fix**: Removed `fromSource` option from CLI deployment command
+- **Enhancement**: Simplified authentication UI in Inspector
+</Update>
+
+<Update label="v1.13.1" description="January 2026">
+  ## Edge Runtime Fix
+  Patch release improving edge runtime compatibility.
+
+- **Fix**: Enable JSON response in stateless mode for edge runtimes (Deno, Cloudflare Workers)
+- **Enhancement**: Improved reliability of API in various deployment scenarios
+</Update>
+
+<Update label="v1.13.0" description="January 2026">
+  <Frame>
+    <img src="https://mcp-use.com/api/og/release?v=1.13.0&title=Hot%20Module%20Reloading%20%26%20OAuth%20Enhancements&date=2026-01&lang=typescript" alt="Release 1.13.0" />
+  </Frame>
+  ## Hot Module Reloading & OAuth Enhancements
+  Release introducing Hot Module Reloading for development and enhanced OAuth capabilities.
+
+### Hot Module Reloading (HMR)
+
+- **New**: HMR support for `mcp-use dev` command - tools, prompts, and resources update instantly without server restart
+- **New**: Connected clients receive `list_changed` notifications and auto-refresh
+- **New**: Syntax errors during reload caught gracefully without crashing server
+- **New**: Comprehensive test suite for HMR functionality with integration tests
+- **Enhancement**: CLI uses `chokidar` to watch file changes with automatic module re-import
+- **Enhancement**: Session persistence during HMR - no client disconnections
+
+### OAuth & Client Info
+
+- **New**: Enhanced OAuth proxy to support gateway/proxy scenarios (e.g., Supabase MCP servers)
+- **New**: `clientInfo` configuration prop for OAuth registration with client metadata (name, version, icons, website)
+- **New**: Server metadata caching with `CachedServerMetadata` interface for instant display on reconnect
+- **Enhancement**: OAuth metadata URL rewriting from gateway URLs to actual server URLs
+- **Enhancement**: Client info displayed on OAuth consent pages
+- **Enhancement**: Extended `StorageProvider` interface with metadata methods
+
+### Inspector & Favicon
+
+- **Enhancement**: Enhanced favicon detector to try all subdomain levels (e.g., mcp.supabase.com → supabase.com)
+- **Enhancement**: Detection of default vs custom favicons using JSON API response
+- **Enhancement**: Improved logging middleware for API routes
+- **Enhancement**: X-Forwarded-Host support for proxy URL construction in dev
+
+### Bug Fixes
+
+- **Fix**: Remove import from "mcp-use" which causes langchain import in server
+- **Fix**: Enhanced synchronization for tools, prompts, and resources during HMR
+</Update>
+
+<Update label="v1.12.4" description="January 2026">
+  ## Connection Fix
+  Patch release fixing autoconnect configuration parsing.
+
+- **Fix**: Autoconnect now correctly parses config objects in addition to string URLs
+</Update>
+
+<Update label="v1.12.3" description="January 2026">
+  ## Security Fixes & OAuth Improvements
+  Patch release addressing multiple security vulnerabilities and fixing OAuth flow issues.
+
+### Security Fixes
+
+- **Security**: Fixed 13 vulnerabilities (3 moderate, 10 high)
+- **Security**: Updated `langchain` to 1.2.3 (fixes serialization injection vulnerability)
+- **Security**: Updated `@langchain/core` to 1.1.8 (fixes serialization injection vulnerability)
+- **Security**: Updated `react-router` to 7.12.0 (fixes XSS and CSRF vulnerabilities)
+- **Security**: Added override for `qs` to >=6.14.1 (fixes DoS vulnerability)
+- **Security**: Added override for `preact` to >=10.28.2 (fixes JSON VNode injection)
+
+### OAuth & Connection Improvements
+
+- **Fix**: Resolved OAuth flow looping issue by removing duplicate fallback logic
+- **Enhancement**: Simplified connection handling with consolidated state management
+- **Enhancement**: Enhanced OAuth authentication flow with improved connection settings
+- **Enhancement**: Improved auto-connect functionality with better proxy handling and error management
+- **Enhancement**: Enhanced theme toggling with dropdown menu for better UX and accessibility
+</Update>
+
+<Update label="v1.12.2" description="January 2026">
+  <Frame>
+    <img src="https://mcp-use.com/api/og/release?v=1.12.2&title=Automatic%20Proxy%20Fallback%20%26%20API%20Improvements&date=2026-01&lang=typescript" alt="Release 1.12.2" />
+  </Frame>
+  ## Automatic Proxy Fallback & API Improvements
+  Release with automatic proxy fallback, OAuth proxy support, and API naming improvements.
+
+### Breaking Changes (with Deprecation Warnings)
+
+- **Breaking**: Renamed `customHeaders` to `headers` across all APIs for consistency. Old name still works but shows deprecation warnings.
+- **Breaking**: Renamed `samplingCallback` to `onSampling` for consistency with event handler patterns. Old name still works but shows deprecation warnings.
+- **Deprecated**: `clientConfig` option in favor of deriving configuration from `clientInfo`
+
+### New Features
+
+- **New**: Automatic Proxy Fallback - `autoProxyFallback` option automatically retries failed connections through proxy on CORS/4xx errors
+- **New**: Provider-level proxy defaults with `defaultProxyConfig` and `defaultAutoProxyFallback` props in `McpClientProvider`
+- **New**: OAuth Proxy Support - `oauthProxyUrl` configuration to route OAuth discovery and token requests through backend proxy
+- **New**: Configurable `clientInfo` for MCP connection initialization with full metadata (name, title, version, description, icons, website URL)
+- **New**: Reconnect functionality for failed connections with reconnect button in Inspector UI
+
+### Improvements
+
+- **Enhancement**: Better detection of OAuth discovery failures, CORS errors, and connection issues
+- **Enhancement**: OAuth provider uses original target URL for discovery, not proxy URL
+- **Enhancement**: Improved session cleanup to avoid noisy warning logs
+- **Enhancement**: Type safety with deprecation notices in TypeScript types
+- **Enhancement**: Proxy header support - `proxyConfig` now accepts a `headers` field for custom headers
+
+### Bug Fixes
+
+- **Fix**: Custom headers now correctly included when copying connection configuration from saved tiles
+- **Fix**: HttpConnector automatic reconnection disabled, shifting responsibility to higher-level logic
+
+### Refactoring
+
+- **Refactor**: Removed `oauth-helper.ts` (521 lines), consolidated into `browser-provider.ts`
+- **Refactor**: Major `useMcp` hook refactor with automatic retry, better error handling, and proxy fallback support
+</Update>
+
+<Update label="v1.12.1" description="January 2026">
+  ## Security Update
+  Patch release with security fixes and build improvements.
+
+- **Security**: Updated `@modelcontextprotocol/sdk` to 1.25.2 (fixes ReDoS vulnerability in UriTemplate regex patterns)
+- **Fix**: Updated building script to correctly export types for inspector/client components
+</Update>
+
+<Update label="v1.12.0" description="January 2026">
+  <Frame>
+    <img src="https://mcp-use.com/api/og/release?v=1.12.0&title=Browser%20Compatibility%20%26%20Multi-Server%20Support&date=2026-01&lang=typescript" alt="Release 1.12.0" />
+  </Frame>
+  ## Browser Compatibility & Multi-Server Support
+  Release focusing on browser compatibility, multi-server management, and improved React architecture.
+
+### Breaking Changes
+
+- **Breaking**: Removed `winston` dependency. The logging system now uses a simple console logger that works in both browser and Node.js environments.
+
+### Browser Runtime Support
+
+- **New**: Full browser compatibility - removed Node.js-specific dependencies from browser builds
+- **New**: Enhanced `browser.ts` entry point with improved browser-specific utilities
+- **New**: Browser utilities:
+  - `utils/favicon-detector.ts` - Detect and extract favicons from URLs
+  - `utils/proxy-config.ts` - Proxy configuration utilities for browser environments
+  - `utils/mcpClientUtils.ts` - MCP client utilities moved from client package
+- **New**: `MCPAgent` exported for browser usage with `BrowserMCPClient` instance or through `RemoteAgent`
+- **Enhancement**: Comprehensive test suite to ensure `mcp-use/react` and `mcp-use/browser` do not import Node.js dependencies
+
+### Multi-Server Support
+
+- **New**: `McpClientProvider` component to manage multiple MCP server connections in React applications
+- **New**: Pluggable storage system with `LocalStorageProvider` and `MemoryStorageProvider` for flexible server configuration persistence
+- **New**: Dynamic addition and removal of servers in React applications
+- **New**: Multi-server React example demonstrating new capabilities
+- **Enhancement**: Refactored `useMcp` hook for better multi-server support
+- **Enhancement**: Removed obsolete `McpContext` (replaced with `McpClientProvider`)
+
+### Server Middleware
+
+- **New**: MCP Proxy Middleware (`server/middleware/mcp-proxy.ts`) - Hono middleware for proxying MCP server requests with optional authentication and request validation
+
+### Inspector Enhancements
+
+- **Enhancement**: Improved UI responsiveness with enhanced mobile and tablet layouts and adaptive component visibility
+- **Enhancement**: Better server management with refactored server connection handling, improved icon display, and status tracking
+- **Enhancement**: Enhanced debugging with detailed logging in Layout and useAutoConnect components for better monitoring of server connection states
+- **Enhancement**: Simplified connection settings by removing deprecated transport types
+- **Enhancement**: Enhanced inspector components for better browser compatibility
+- **Enhancement**: Improved server icon support and component interactions
+- **Enhancement**: Added embedded mode support
+- **Enhancement**: Better configuration handling and MCP proxy integration
+
+### RPC Logging
+
+- **New**: Enhanced RPC logging with new `rpc-logger` module and filtering capabilities to reduce noisy endpoint logging (telemetry, RPC streams).
+
+### Architecture Improvements
+
+- **Refactor**: Separated telemetry into `telemetry-browser.ts` (browser) and `telemetry-node.ts` (Node.js) for better environment-specific implementations
+- **Refactor**: Replaced Winston with `SimpleConsoleLogger` that works across all environments. See the [ServerConfig API reference](https://mcp-use-typescript-api-reference.vercel.app/modules/mcp-use.index.html#serverconfig) for server environment settings.
+- **Refactor**: Updated `tsup.config.ts` to exclude Node.js-specific dependencies (`winston`, `posthog-node`) from browser builds
+- **Refactor**: Updated components across inspector for cleaner architecture and imports
+
+### Bug Fixes
+
+- **Fix**: Prevent rendering loop when autoretry is true in React hooks
+- **Fix**: Respect options timeout in HTTP connector (reduced default timeout from 30 seconds to 10 seconds)
+- **Fix**: Add client SDKs to add to client dropdown in inspector
+- **Fix**: Server connection retrieval in `OpenAIComponentRenderer` to directly access connections array
+- **Fix**: Linux patch for watch mode
+- **Fix**: Query URL handling in built mode to preserve arguments
+- **Fix**: Enhanced Zod version mapping in TypeScript PR preview workflow
+- **Fix**: Pinned Zod version to 3.24.4 for compatibility with modelcontextprotocol/sdk
+- **Fix**: Updated modelcontextprotocol-sdk references to new package name
+
+### Documentation
+
+- **New**: Added troubleshooting section for Zod version conflicts in Supabase deployment
+- **Enhancement**: Updated Supabase deployment documentation with improved compatibility information
+</Update>
+
+<Update label="v1.11.2" description="December 2025">
+  ## Documentation Updates - **Enhancement**: Updated examples and documentation
+  to use preferred methods and APIs
+</Update>
+
+<Update label="v1.11.1" description="December 2025">
+  ## Bug Fixes - **Fix**: Widget props not picked up when using Zod schemas
+</Update>
+
+<Update label="v1.11.0" description="December 2025">
+  <Frame>
+    <img src="https://mcp-use.com/api/og/release?v=1.11.0&title=Session%20Management%20Architecture&date=2025-12&lang=typescript" alt="Release 1.11.0" />
+  </Frame>
+  ## Session Management Architecture
+  Release introducing distributed session management with Redis support.
+
+### Breaking Changes
+
+- **Breaking**: WebSocket transport support removed. Use streamable HTTP or SSE transports instead.
+- **Breaking**: LangChain adapter moved from main entry point to `mcp-use/adapters` subpath. `@langchain/core` and `langchain` are now optional peer dependencies.
+- **Deprecated**: `autoCreateSessionOnInvalidId` server config option. Now follows MCP spec strictly (returns 404 for invalid sessions).
+
+### Session Management Features
+
+- **New**: Pluggable session management architecture separating metadata storage (`SessionStore`) from active connections (`StreamManager`)
+- **New**: `RedisSessionStore` for persistent, distributed session metadata storage
+- **New**: `RedisStreamManager` for cross-server notifications via Redis Pub/Sub
+- **New**: `FileSystemSessionStore` (dev mode default) persists sessions to `.mcp-use/sessions.json` for hot reload support
+- **New**: `InMemorySessionStore` and `InMemoryStreamManager` (production defaults)
+- **New**: Automatic 404 handling and re-initialization in clients per MCP spec
+- **New**: Convenience methods: `sendToolsListChanged()`, `sendResourcesListChanged()`, `sendPromptsListChanged()`
+- **Enhancement**: Auto-detection of stateless/stateful mode based on client `Accept` header
+- **Enhancement**: Sessions survive server restarts in dev mode with filesystem storage
+- **Enhancement**: Auto-cleanup of expired sessions (>24 hours)
+
+### Client Improvements
+
+- **New**: Auto-refresh tools/resources/prompts when receiving list change notifications
+- **New**: Manual refresh methods: `refreshTools()`, `refreshResources()`, `refreshPrompts()`, `refreshAll()`
+- **New**: Automatic 404 handling and re-initialization per MCP spec
+- **Enhancement**: Deprecated `sse` transport type in React (use `http` or `auto`)
+
+### Additional Features
+
+- **New**: CommonJS module support - full compatibility with `require()` syntax
+- **New**: Favicon support for widget pages with automatic serving and long-term caching
+- **New**: Enhanced session methods: `callTool()` defaults args to empty object, new `requireSession()` method
+- **New**: Session architecture documentation with ARCHITECTURE.md
+- **New**: Comparison guide with other MCP implementations (tmcp, FastMCP, xmcp, official SDK)
+- **New**: Comprehensive environments guide (Node.js, Browser, React)
+
+### Documentation
+
+- **New**: Session Management guide with storage provider documentation (Memory, FileSystem, Redis)
+- **New**: Environments guide explaining usage across different JavaScript runtimes
+- **New**: Comparison documentation analyzing mcp-use vs other implementations
+- **Enhancement**: Major documentation restructuring for better organization
+- **Enhancement**: Removed/consolidated outdated guides (direct-tool-calls, sandbox, connection-types)
+- **Enhancement**: Updated agent documentation with improved examples
+
+### Widget Improvements
+
+- **Enhancement**: Automatic cleanup of stale widget directories in `.mcp-use` folder
+- **Enhancement**: Dev mode watches for widget file/directory deletions and cleans up build artifacts
+- **Fix**: Fixed widget styling isolation - widgets no longer pick up mcp-use styles
+- **Fix**: Fixed favicon URL generator for proper asset resolution
+- **Fix**: Fixed transport cleanup when session becomes idle
+
+### Testing & Quality
+
+- **New**: Comprehensive test suite for session stores (498 lines)
+- **New**: Stream managers test suite (478 lines)
+- **New**: Widget data flow tests (496 lines)
+- **New**: CLI integration tests (242 lines)
+- **New**: CommonJS compatibility tests (256 lines)
+- **New**: Documentation example tests (agent, prompts, tools)
+- **New**: Client 404 re-initialization tests
+- **Enhancement**: Improved test coverage across all major features
+
+### Dependencies & Compatibility
+
+- **Enhancement**: Added support for Node.js >= 18
+- **Enhancement**: CommonJS builds for all entry points
+- **Enhancement**: Migrated from `react-router-dom` to `react-router` for better compatibility
+- **Enhancement**: Repository metadata added to package.json
+- **Enhancement**: Dependency updates and optimizations
+
+### Fixes
+
+- **Fix**: Agent access to resources and prompts
+- **Fix**: Import paths in CLI to avoid mixing dependencies
+- **Fix**: UUID generation and URL handling improvements
+- **Fix**: Various formatting and linting improvements
+</Update>
+
+<Update label="v1.10.0" description="December 2025">
+  <Frame>
+    <img src="https://mcp-use.com/api/og/release?v=1.10.0&title=API%20Improvements%20%26%20Session%20Management&date=2025-12&lang=typescript" alt="Release 1.10.0" />
+  </Frame>
+  ## API Improvements & Session Management
+  Enhanced APIs with better type safety and improved session management capabilities.
+
+### Breaking Changes
+
+- **Breaking**: Renamed `createMCPServer()` factory function to `MCPServer` class constructor. Factory function still available for backward compatibility but new code should use `new MCPServer({ name, ... })`.
+- **Breaking**: Replaced `session.connector.tools`, `session.connector.callTool()`, etc. with direct session methods: `session.tools`, `session.callTool()`, `session.listResources()`, `session.readResource()`, etc.
+- **Breaking**: Standardized OAuth environment variables to `MCP_USE_OAUTH_*` prefix (e.g., `AUTH0_DOMAIN` → `MCP_USE_OAUTH_AUTH0_DOMAIN`).
+
+### New Features
+
+- **New**: Client Capabilities API with `ctx.client.can()` and `ctx.client.capabilities()` to check client capabilities in tool callbacks
+- **New**: Session Notifications API with `ctx.sendNotification()` and `ctx.sendNotificationToSession()` for sending notifications from tool callbacks
+- **New**: Session Info API with `ctx.session.sessionId` to access current session ID in tool callbacks
+- **New**: Resource Template Flat Structure support with `uriTemplate` directly on definition (in addition to nested structure)
+- **New**: Resource Template Callback Signatures now support multiple signatures: `()`, `(uri)`, `(uri, params)`, `(uri, params, ctx)`
+- **New**: Type Exports for `CallToolResult`, `Tool`, `ToolAnnotations`, `PromptResult`, `GetPromptResult` types
+
+### Improvements
+
+- **Enhancement**: Enhanced type inference for resource template callbacks with better overload support
+- **Enhancement**: Server now captures and stores client capabilities during initialization
+- **Enhancement**: Added convenience methods to `MCPSession` for all MCP operations (listResources, readResource, subscribeToResource, listPrompts, getPrompt, etc.)
+- **Enhancement**: Major documentation refactoring and restructuring for better organization
+
+### Fixes (v1.10.1 - v1.10.6)
+
+- **Fix**: Stateless mode for Deno runtime
+- **Fix**: Added CORS support to `getHandler()` method
+- **Fix**: Deno 5 compatibility improvements
+- **Fix**: Deno 3 compatibility fixes
+- **Fix**: Zod error handling improvements
+- **Fix**: Zod import in official SDK
+- **Fix**: Clear transport when session becomes idle
+- **Fix**: Allow agent to access resources and prompts
+- **Enhancement**: Added repository metadata in package.json
+</Update>
+
+<Update label="v1.9.0" description="December 2025">
+  <Frame>
+    <img src="https://mcp-use.com/api/og/release?v=1.9.0&title=Elicitation%20Support&date=2025-12&lang=typescript" alt="Release 1.9.0" />
+  </Frame>
+  ## Elicitation Support
+  Added comprehensive elicitation support following MCP specification, enabling servers to request user input through clients.
+
+- **New**: Simplified API with `ctx.elicit(message, zodSchema)` and `ctx.elicit(message, url)` with automatic mode detection
+- **New**: Form Mode for structured data collection with Zod schema validation and full TypeScript type inference
+- **New**: URL Mode to direct users to external URLs for sensitive operations (OAuth, credentials)
+- **New**: Server-side validation with automatic Zod validation and clear error messages
+- **New**: Client support via `elicitationCallback` to MCPClient and `onElicitation` to React `useMcp` hook
+- **Enhancement**: Type-safe return types automatically inferred from Zod schemas
+- **Enhancement**: Configurable timeout with 5-minute default for user interactions
+- **Fix**: Transport bug fixes
+</Update>
+
+<Update label="v1.8.0" description="November 2025">
+  <Frame>
+    <img src="https://mcp-use.com/api/og/release?v=1.8.0&title=Sampling%20Support&date=2025-11&lang=typescript" alt="Release 1.8.0" />
+  </Frame>
+  ## Sampling Support
+  Added sampling support in inspector with improved timeout handling for long-running requests.
+
+- **New**: LLM sampling capabilities in inspector
+- **Fix**: Long running sampling requests no longer timeout after 60 seconds
+- **Enhancement**: Better handling of extended sampling operations
+</Update>
+
+<Update label="v1.7.0" description="November 2025">
+  <Frame>
+    <img src="https://mcp-use.com/api/og/release?v=1.7.0&title=OAuth%20Authentication%20System&date=2025-11&lang=typescript" alt="Release 1.7.0" />
+  </Frame>
+  ## OAuth Authentication System
+  Complete OAuth 2.0 support with built-in providers and enhanced server capabilities.
+
+- **New**: Complete OAuth 2.0 authentication framework with built-in providers (Auth0, WorkOS, Supabase, Keycloak)
+- **New**: OAuth middleware and routes for server-side OAuth flow handling with automatic token management
+- **New**: OAuth callback component in inspector for authentication flows
+- **New**: Context storage with async local storage for request-scoped context in servers
+- **New**: Response helpers for standardized HTTP responses and error handling
+- **New**: Runtime detection utilities for Node.js, Bun, and Deno environments
+- **New**: Server authentication examples for Auth0, WorkOS, and Supabase
+- **Enhancement**: Enhanced useMcp hook with improved connection management and OAuth support
+- **Enhancement**: Enhanced inspector dashboard with OAuth configuration UI
+- **Enhancement**: Better authentication flow handling with OAuth integration
+- **Enhancement**: Enhanced HTTP connectors with OAuth token handling
+- **Fix**: Dependency optimizations and AI SDK updates
+</Update>
+
+<Update label="v1.6.0" description="November 2025">
+  <Frame>
+    <img src="https://mcp-use.com/api/og/release?v=1.6.0&title=Notifications%20%26%20Sampling&date=2025-11&lang=typescript" alt="Release 1.6.0" />
+  </Frame>
+  ## Notifications & Sampling
+  Bidirectional notification support and LLM sampling capabilities.
+
+- **New**: Bidirectional notification support between clients and servers with handler registration
+- **New**: LLM sampling allowing MCP tools to request completions from connected clients
+- **New**: Widget build ID support for cache busting in widget UI resources
+- **New**: Inspector notifications tab with real-time display
+- **New**: Server capabilities modal showing supported MCP features
+- **Enhancement**: Refactored HTTP transport to reuse sessions across requests with configurable idle timeout
+- **Enhancement**: Session management with tracking and automatic cleanup
+- **Enhancement**: Roots support in connectors and session API
+- **Enhancement**: Session event handling API for notification registration
+- **Enhancement**: Server methods for session management and targeted notifications
+- **Enhancement**: Enhanced search_tools with metadata (total_tools, namespaces, result_count)
+- **Enhancement**: RPC message logging support in inspector
+</Update>
+
+<Update label="v1.5.0" description="October 2025">
+  <Frame>
+    <img src="https://mcp-use.com/api/og/release?v=1.5.0&title=OpenAI%20Apps%20SDK%20Integration&date=2025-10&lang=typescript" alt="Release 1.5.0" />
+  </Frame>
+  ## OpenAI Apps SDK Integration
+  Release with comprehensive OpenAI Apps SDK support and widget system.
+
+- **New**: McpUseProvider component combining React setup (StrictMode, ThemeProvider, BrowserRouter, ErrorBoundary)
+- **New**: WidgetControls component with debug overlay and view controls (fullscreen, PIP)
+- **New**: useWidget hook for type-safe React adapter to OpenAI Apps SDK API
+- **New**: ErrorBoundary component for graceful error handling
+- **New**: Image component handling data URLs and public file paths
+- **New**: ThemeProvider for consistent theme management
+- **New**: WidgetInspectorControls for inspector-specific debugging
+- **New**: Console proxy toggle for iframe console logs
+- **New**: Product search result widget template with carousel and accordion components
+- **New**: Folder-based widget support with automatic detection
+- **New**: Public folder support for static assets
+- **Enhancement**: Enhanced SSR configuration with proper Vite settings
+- **Enhancement**: Improved OpenAI component renderer with better height calculation
+- **Enhancement**: Enhanced tool result display with multiple content types
+- **Enhancement**: Resizable panels with collapse support
+- **Enhancement**: Better widget security headers and CSP configuration
+</Update>
+
+<Update label="v1.4.0" description="October 2025">
+  <Frame>
+    <img src="https://mcp-use.com/api/og/release?v=1.4.0&title=Code%20Mode&date=2025-10&lang=typescript" alt="Release 1.4.0" />
+  </Frame>
+  ## Code Mode
+  Introduced code execution capabilities for agents.
+
+- **New**: Code Mode feature allowing agents to execute code using MCP tools
+- **New**: VMCodeExecutor for local execution environments
+- **New**: E2BCodeExecutor for remote execution in cloud sandboxes
+- **New**: CodeModeConnector for tool discovery and execution
+- **Enhancement**: Enhanced MCPClient with code execution configuration
+- **Enhancement**: Comprehensive tests for code execution functionality
+</Update>
+
+<Update label="v1.3.0" description="October 2025">
+  <Frame>
+    <img src="https://mcp-use.com/api/og/release?v=1.3.0&title=Edge%20Runtime%20Support&date=2025-10&lang=typescript" alt="Release 1.3.0" />
+  </Frame>
+  ## Edge Runtime Support
+  Migrated to Hono framework for edge runtime compatibility.
+
+- **Major**: Migrated from Express to Hono framework for edge runtime support (Cloudflare Workers, Deno Deploy, Supabase)
+- **New**: Runtime detection for Deno and Node.js environments
+- **New**: Connect middleware adapter for compatibility
+- **New**: `getHandler()` method for edge deployment
+- **New**: Supabase deployment documentation and templates
+- **Enhancement**: Improved MCPAgent message detection with robust helpers for different LangChain formats
+- **Enhancement**: Fixed server base URL handling for proper connection and routing
+- **Enhancement**: Better auto-connection logic with error handling and retry mechanisms
+- **Enhancement**: Enhanced useMcp hook with improved connection state management
+</Update>
+
+<Update label="v1.2.0" description="October 2025">
+  <Frame>
+    <img src="https://mcp-use.com/api/og/release?v=1.2.0&title=LangChain%201.0.0%20Support&date=2025-10&lang=typescript" alt="Release 1.2.0" />
+  </Frame>
+  ## LangChain 1.0.0 Support
+  Updated to support LangChain 1.0.0 with improved compatibility.
+
+- **Major**: Support for LangChain 1.0.0
+- **Fix**: Model type compatibility for LangChain 1.0.0
+- **Fix**: Apps SDK metadata setup from widget build
+- **Enhancement**: Set CLI and inspector as dependencies
+</Update>
+
+<Update label="v1.1.0" description="October 2025">
+  <Frame>
+    <img src="https://mcp-use.com/api/og/release?v=1.1.0&title=Apps%20SDK%20Initial%20Integration&date=2025-10&lang=typescript" alt="Release 1.1.0" />
+  </Frame>
+  ## Apps SDK Initial Integration
+  First integration of OpenAI Apps SDK support.
+
+- **New**: OpenAI Apps SDK integration with UI resource type
+- **New**: Enhanced MCP-UI adapter for Apps SDK metadata
+- **New**: Resource URI format supporting `ui://widget/` scheme
+- **New**: Tool definitions with Apps SDK-specific metadata
+- **Enhancement**: Comprehensive test suite for Apps SDK resources
+- **Refactor**: Renamed `fn` to `cb` in tool and prompt definitions for consistency
+- **Refactor**: Updated resource definitions to use `readCallback`
+</Update>

--- a/docs/v2/typescript/client/authentication.mdx
+++ b/docs/v2/typescript/client/authentication.mdx
@@ -1,0 +1,232 @@
+---
+title: "Authentication"
+description: "OAuth and bearer tokens for MCP client connections"
+icon: "shield"
+---
+
+HTTP connections support automatic OAuth, pre-registered public clients,
+bearer tokens, custom headers, and custom authentication providers.
+
+## Automatic OAuth with `MCPClient`
+
+`MCPClient` creates an OAuth provider for an HTTP server unless the server
+configuration already supplies an `authProvider`, `authToken`, `oauth: false`,
+or an `Authorization` header.
+
+```typescript
+import { MCPClient } from "@mcp-use/client";
+
+const client = new MCPClient({
+  mcpServers: {
+    demo: { url: "https://api.example.com/mcp" },
+  },
+});
+
+try {
+  await client.connect("demo");
+} finally {
+  await client.close();
+}
+```
+
+In Node.js, the default provider opens a browser and waits for its loopback
+callback. In the browser build, the default provider opens a popup; set
+`useRedirectFlow: true` inside the server's `oauth` options to use a full-page
+redirect.
+
+Pass a custom `authProvider` when your application owns the authorization flow.
+
+## React: explicit authentication
+
+React connection APIs use an explicit authorization step by default.
+`preventAutoAuth` defaults to `true`, so an unauthorized connection enters
+`pending_auth` until the user calls `authenticate()`.
+
+```tsx
+import { useMcp } from "@mcp-use/client/react";
+
+export function ProtectedConnection() {
+  const mcp = useMcp({
+    url: "https://api.example.com/mcp",
+  });
+
+  if (mcp.state === "pending_auth") {
+    return <button onClick={() => void mcp.authenticate()}>Sign in</button>;
+  }
+
+  return <p>Connection state: {mcp.state}</p>;
+}
+```
+
+Set `preventAutoAuth: false` on `useMcp` or a
+`McpClientProvider` server configuration to start authorization automatically.
+Popup mode is the default; set the top-level React option
+`useRedirectFlow: true` for a full-page redirect.
+
+On your callback route, import `onMcpAuthorization` from
+`@mcp-use/client/react`. See
+[React integration](/v2/typescript/client/usemcp#oauth-callback).
+
+## Pre-registered clients
+
+The `MCPClient` configuration uses
+`oauth.staticClientInfo.client_id`:
+
+```typescript
+import { MCPClient } from "@mcp-use/client";
+
+const client = new MCPClient({
+  mcpServers: {
+    slack: {
+      url: "https://mcp.example.com/mcp",
+      oauth: {
+        staticClientInfo: {
+          client_id: "my-client-id",
+        },
+        clientMetadataUrl:
+          "https://app.example.com/.well-known/oauth-client-metadata.json",
+        scope: "openid profile",
+      },
+    },
+  },
+});
+```
+
+React uses a different, UI-oriented shape:
+
+```tsx
+import { useMcp } from "@mcp-use/client/react";
+
+const mcp = useMcp({
+  url: "https://mcp.example.com/mcp",
+  oauth: {
+    clientId: "my-client-id",
+    clientMetadataUrl:
+      "https://app.example.com/.well-known/oauth-client-metadata.json",
+    scope: "openid profile",
+  },
+});
+```
+
+Browser OAuth clients are public PKCE clients. Do not put a `client_secret` in
+browser configuration; `BrowserOAuthClientProvider` rejects one in
+`staticClientInfo`.
+
+## OAuth proxy in the browser
+
+Use an OAuth proxy when the authorization server's metadata, token, or
+registration endpoints do not support browser CORS:
+
+```tsx
+import { useMcp } from "@mcp-use/client/react";
+
+const mcp = useMcp({
+  url: "https://mcp.example.com/mcp",
+  oauthProxyUrl: "https://app.example.com/api/mcp-oauth",
+});
+```
+
+For the browser `MCPClient`, `oauth.oauthProxyUrl` configures the proxy and
+`oauth.proxyOAuthRequests` controls whether OAuth HTTP requests use it. The
+latter defaults to `true` when the browser provider is created. React routes its
+OAuth requests through the configured `oauthProxyUrl`; it does not expose
+`proxyOAuthRequests` as a `useMcp` option.
+
+## Manual browser authorization
+
+Construct a `BrowserOAuthClientProvider` with `preventAutoAuth: true` and pass it
+to the browser client when you need to present the authorization URL yourself:
+
+```typescript
+import {
+  BrowserOAuthClientProvider,
+  isUnauthorized,
+  MCPClient,
+} from "@mcp-use/client";
+
+const authProvider = new BrowserOAuthClientProvider(
+  "https://api.example.com/mcp",
+  { preventAutoAuth: true }
+);
+const client = new MCPClient({
+  mcpServers: {
+    api: {
+      url: "https://api.example.com/mcp",
+      authProvider,
+    },
+  },
+});
+
+try {
+  await client.connect("api");
+} catch (error) {
+  if (!isUnauthorized(error)) throw error;
+
+  const authorizationUrl = authProvider.getLastAttemptedAuthUrl();
+  if (authorizationUrl) {
+    window.location.assign(authorizationUrl);
+  }
+}
+```
+
+`getLastAttemptedAuthUrl()` returns the URL for the current provider instance.
+It is kept in memory only, so start a new authorization attempt after a page
+reload. The auto-provisioned browser provider also accepts
+`oauth.preventAutoAuth`, but an explicit provider gives your application access
+to the prepared URL.
+
+## Bearer tokens
+
+```typescript
+import { MCPClient } from "@mcp-use/client";
+
+const client = new MCPClient({
+  mcpServers: {
+    api: {
+      url: "https://api.example.com/mcp",
+      authToken: process.env.API_KEY,
+    },
+  },
+});
+```
+
+An explicit `Authorization` header also disables automatic OAuth:
+
+```typescript
+import { MCPClient } from "@mcp-use/client";
+
+const client = new MCPClient({
+  mcpServers: {
+    api: {
+      url: "https://api.example.com/mcp",
+      headers: {
+        Authorization: `Bearer ${process.env.API_KEY}`,
+      },
+    },
+  },
+});
+```
+
+## `MCPClient` server fields
+
+| Field | Description |
+| ----- | ----------- |
+| `authToken` | Bearer token |
+| `headers` | Custom HTTP headers |
+| `oauth` | Automatic OAuth options, or `false` to disable automatic OAuth |
+| `authProvider` | Custom SDK-compatible provider |
+
+## Node OAuth helpers
+
+```typescript
+import {
+  createOAuthProvider,
+  NodeOAuthClientProvider,
+  completeOAuthFlow,
+  isUnauthorized,
+  FileKVStore,
+} from "@mcp-use/client";
+```
+
+Use these exports for headless scripts, custom storage, or an authorization flow
+you manage directly.

--- a/docs/v2/typescript/client/code-mode.mdx
+++ b/docs/v2/typescript/client/code-mode.mdx
@@ -1,0 +1,66 @@
+---
+title: "Code Mode"
+description: "Let agents write code to call MCP tools"
+icon: "code"
+---
+
+Code mode exposes `execute_code` and `search_tools` so agents run JavaScript with access to connected MCP tools instead of making individual tool calls. Node.js only.
+
+## Enable
+
+```typescript
+import { MCPClient } from "@mcp-use/client";
+
+const client = new MCPClient(
+  {
+    mcpServers: {
+      fs: {
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-filesystem", "./data"],
+      },
+    },
+  },
+  { codeMode: true },
+);
+
+const result = await client.executeCode(`
+  const files = await fs.list_directory({ path: "." });
+  return files.length;
+`);
+
+console.log(result.result, result.logs, result.error);
+await client.close();
+```
+
+## Executors
+
+| Executor                             | Use case                                                           |
+| ------------------------------------ | ------------------------------------------------------------------ |
+| `"vm"` (default)                     | Local Node.js VM — fast, trusted environments                      |
+| `"e2b"`                              | Cloud sandbox — untrusted code (`@e2b/code-interpreter` + API key) |
+| Custom function / `BaseCodeExecutor` | Your own runtime                                                   |
+
+```typescript
+{ codeMode: {
+    enabled: true,
+    executor: "e2b",
+    executorOptions: { apiKey: process.env.E2B_API_KEY!, timeoutMs: 300_000 },
+}}
+```
+
+## Agent integration
+
+Use with `@mcp-use/agent` and `PROMPTS.CODE_MODE`:
+
+```typescript
+import { MCPAgent, PROMPTS } from "@mcp-use/agent";
+
+const agent = new MCPAgent({ llm, client, systemPrompt: PROMPTS.CODE_MODE });
+await agent.run("List all files and count them");
+```
+
+## Reference
+
+[Client API reference](https://mcp-use-typescript-api-reference.vercel.app/modules/_mcp-use_client.index.html) — config types, `searchTools`, and `ExecutionResult`.
+
+[Anthropic: Code execution with MCP](https://www.anthropic.com/engineering/code-execution-with-mcp)

--- a/docs/v2/typescript/client/completion.mdx
+++ b/docs/v2/typescript/client/completion.mdx
@@ -1,0 +1,43 @@
+---
+title: "Completions"
+description: "Autocomplete for prompt and resource template arguments"
+icon: "wand-magic-sparkles"
+---
+
+Request suggestions for prompt arguments or resource template URI variables:
+
+```typescript
+import { MCPClient } from "@mcp-use/client";
+
+const client = new MCPClient({
+  mcpServers: { demo: { url: "http://localhost:3000/mcp" } },
+});
+
+try {
+  const conn = await client.connect("demo");
+
+  const result = await conn.complete({
+    ref: { type: "ref/prompt", name: "code-review" },
+    argument: { name: "language", value: "py" },
+  });
+
+  console.log(result.completion.values); // e.g. ["python", "pytorch"]
+} finally {
+  await client.close();
+}
+```
+
+## React
+
+```tsx
+const mcp = useMcp({ url: "http://localhost:3000/mcp" });
+
+const result = await mcp.complete({
+  ref: { type: "ref/resource", uri: "file:///{path}" },
+  argument: { name: "path", value: "/tmp" },
+});
+```
+
+## Reference
+
+[`MCPConnection`](https://mcp-use-typescript-api-reference.vercel.app/modules/_mcp-use_client.index.html#mcpconnection) — `complete()`.

--- a/docs/v2/typescript/client/elicitation.mdx
+++ b/docs/v2/typescript/client/elicitation.mdx
@@ -1,0 +1,60 @@
+---
+title: "Elicitation"
+description: "Handle interactive user input requests from MCP servers"
+icon: "check"
+---
+
+Servers can ask the client for user input mid-tool-call via `elicitation/create`. Two modes:
+
+- **Form** — structured fields with a JSON schema
+- **URL** — redirect the user to an external page (required for credentials/OAuth)
+
+## Setup
+
+```typescript
+import {
+  acceptWithDefaults,
+  MCPClient,
+  type OnElicitationCallback,
+} from "@mcp-use/client";
+
+const onElicitation: OnElicitationCallback = async (params) => {
+  if (params.mode === "url") {
+    console.log(`Visit: ${params.url}`);
+    return { action: "accept" };
+  }
+  // Form mode — collect fields from params.requestedSchema
+  return acceptWithDefaults(params);
+};
+
+const client = new MCPClient(config, { onElicitation });
+```
+
+## Helpers
+
+Import from `@mcp-use/client`:
+
+| Helper | Purpose |
+| ------ | ------- |
+| `acceptWithDefaults(params)` | Accept using schema defaults |
+| `accept(content)` | Accept with user content |
+| `decline()`, `cancel()` | Reject or dismiss |
+| `validate(params, content)` | Client-side validation |
+| `getDefaults`, `applyDefaults` | Work with schema defaults |
+
+## React
+
+```tsx
+const mcp = useMcp({
+  url: "http://localhost:3000/mcp",
+  onElicitation: (params) => acceptWithDefaults(params),
+});
+```
+
+With the provider, use `pendingElicitationRequests` and `approveElicitation` / `rejectElicitation`.
+
+Without an `onElicitation` handler, tool calls that require input will fail.
+
+## Reference
+
+Server-side: [Elicitation](/v2/typescript/server/elicitation)

--- a/docs/v2/typescript/client/environments.mdx
+++ b/docs/v2/typescript/client/environments.mdx
@@ -1,0 +1,90 @@
+---
+title: "Environments"
+description: "Use the MCP client in Node.js, browser, and React"
+icon: "container"
+---
+
+The root `@mcp-use/client` import uses package conditions to select its runtime
+implementation. Node gets the Node entry; browsers and other default
+environments get the browser-safe entry. React connection management is
+available from a separate entry point.
+
+| Environment | Import | HTTP | Stdio | Config files | Code Mode |
+| ----------- | ------ | ---- | ----- | ------------ | --------- |
+| Node.js `>=22.22.2` | `@mcp-use/client` | Yes | Yes | Yes | Yes |
+| Browser | `@mcp-use/client` | Yes | No | No | No |
+| React | `@mcp-use/client/react` | Yes | No | No | No |
+
+## Node.js
+
+The Node entry includes HTTP and stdio transports, filesystem configuration,
+Code Mode, and Node OAuth helpers.
+
+```typescript
+import { MCPClient, loadConfigFile } from "@mcp-use/client";
+
+const client = new MCPClient({
+  mcpServers: {
+    api: { url: "https://api.example.com/mcp" },
+    fs: {
+      command: "npx",
+      args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+    },
+  },
+});
+
+const clientFromFile = new MCPClient(loadConfigFile("./mcp-config.json"));
+
+try {
+  const connections = await client.connectAll();
+  await connections.api.callTool("ping", {});
+} finally {
+  await Promise.all([client.close(), clientFromFile.close()]);
+}
+```
+
+## Browser
+
+The browser entry exposes the HTTP connection API and browser OAuth support. It
+does not include process spawning, filesystem configuration, or local code
+execution.
+
+```typescript
+import { MCPClient } from "@mcp-use/client";
+
+const client = new MCPClient({
+  mcpServers: {
+    api: { url: "https://api.example.com/mcp" },
+  },
+});
+
+try {
+  const connection = await client.connect("api");
+  await connection.callTool("tool", {});
+} finally {
+  await client.close();
+}
+```
+
+<Warning>
+  Do not hardcode secrets in browser bundles. Use OAuth or a backend proxy.
+</Warning>
+
+## React
+
+Install the client and your application's supported React version:
+
+```bash
+npm install @mcp-use/client@beta react
+```
+
+`@mcp-use/client/react` provides connection-management APIs such as `useMcp`,
+`McpClientProvider`, `useMcpClient`, and `useMcpServer`. It also exports
+`ViewRenderer` for hosts that render an MCP App View.
+
+Code running inside a View uses the View APIs from `mcp-use/react`, including
+`useToolContext`, `useCallTool`, and `useViewState`. These hooks communicate
+with the host; they do not create or manage MCP server connections.
+
+See [React integration](/v2/typescript/client/usemcp) for connection setup and
+[MCP Apps](/v2/typescript/mcp-apps) for building and hosting Views.

--- a/docs/v2/typescript/client/index.mdx
+++ b/docs/v2/typescript/client/index.mdx
@@ -1,0 +1,105 @@
+---
+title: "MCP Client"
+sidebarTitle: "Overview"
+description: "Connect a TypeScript app to MCP servers and call tools, resources, and prompts."
+icon: "router"
+---
+
+`@mcp-use/client` connects your app to one or more MCP servers. It negotiates the
+server's supported MCP protocol automatically and exposes the same connection
+API across sessionful and sessionless servers.
+
+## Install
+
+```bash
+npm install @mcp-use/client@beta
+```
+
+The package requires Node.js `>=22.22.2` for Node applications and is ESM-only.
+
+## Quick start
+
+```typescript
+import { MCPClient } from "@mcp-use/client";
+
+const client = new MCPClient({
+  mcpServers: {
+    demo: { url: "http://localhost:3000/mcp" },
+  },
+});
+
+try {
+  const connection = await client.connect("demo");
+
+  const tools = await connection.listTools();
+  console.log(tools.map((tool) => tool.name));
+
+  const result = await connection.callTool("echo", { message: "hello" });
+  const text = result.content.find((block) => block.type === "text");
+  if (text?.type === "text") {
+    console.log(text.text);
+  }
+} finally {
+  await client.close();
+}
+```
+
+`connect(name)` returns a ready `MCPConnection`. Always close the client when
+your application is finished so its active connections and transports are
+released.
+
+## Core types
+
+- **`MCPClient`** — holds server configuration and opens connections.
+- **`MCPConnection`** — calls tools, reads resources, and fetches prompts.
+  `connection.info` exposes the negotiated protocol, server metadata,
+  capabilities, and instructions.
+- **`MCPSession`** — deprecated compatibility alias for `MCPConnection`.
+
+Use `client.connect(name)` for one configured server or `client.connectAll()` to
+connect to every configured server.
+
+## Configure servers
+
+```typescript
+import { MCPClient } from "@mcp-use/client";
+
+const client = new MCPClient({
+  mcpServers: {
+    remote: {
+      url: "https://api.example.com/mcp",
+      authToken: process.env.MCP_TOKEN,
+    },
+    local: {
+      command: "npx",
+      args: ["-y", "@modelcontextprotocol/server-filesystem", "./"],
+    },
+  },
+});
+```
+
+HTTP servers support automatic OAuth, bearer tokens, and custom headers. Stdio
+connections are available only in Node.js.
+
+Migrating existing client code? Follow the
+[client migration guide](/v2/typescript/client/migration).
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Tools" icon="wrench" href="/v2/typescript/client/tools">
+    List and call server tools.
+  </Card>
+  <Card title="Migration guide" icon="arrow-right-left" href="/v2/typescript/client/migration">
+    Update packages, imports, configuration, and connection code.
+  </Card>
+  <Card title="Authentication" icon="shield" href="/v2/typescript/client/authentication">
+    Configure OAuth and bearer tokens.
+  </Card>
+  <Card title="React" icon="react" href="/v2/typescript/client/usemcp">
+    Manage connections with `McpClientProvider` and hooks.
+  </Card>
+  <Card title="Environments" icon="container" href="/v2/typescript/client/environments">
+    Compare Node, browser, and React support.
+  </Card>
+</CardGroup>

--- a/docs/v2/typescript/client/migration.mdx
+++ b/docs/v2/typescript/client/migration.mdx
@@ -1,0 +1,310 @@
+---
+title: "Client migration"
+description: "Migrate client, agent, and React connection code from mcp-use 1.x"
+icon: "arrow-right-left"
+---
+
+This guide updates applications from the mcp-use 1.x client surface to the
+current beta packages. It covers client, agent, and React connection code.
+
+<Warning>
+  Server and interactive UI APIs also have breaking changes. Do not assume that
+  existing server or widget code can be carried forward unchanged. Follow the
+  [server guide](/v2/typescript/server) and
+  [MCP Apps guide](/v2/typescript/mcp-apps) for those parts of your application.
+</Warning>
+
+## 1. Update the runtime and packages
+
+The current client and agent packages require Node.js `>=22.22.2` and are
+ESM-only.
+
+```bash
+npm install @mcp-use/client@beta @mcp-use/agent@beta
+```
+
+Keep `mcp-use@beta` when the same project builds a server or MCP App View:
+
+```bash
+npm install mcp-use@beta
+```
+
+Ensure your project emits ESM and your bundler respects the package's `node` and
+`browser` export conditions.
+
+## 2. Move imports to their package entry points
+
+| 1.x surface | Current import | Purpose |
+| ----------- | -------------- | ------- |
+| `MCPClient`, connectors, OAuth, and sessions from `mcp-use` | `@mcp-use/client` | Node or browser MCP client |
+| `useMcp` and `McpClientProvider` from `mcp-use/react` | `@mcp-use/client/react` | React connection management |
+| `MCPAgent` and `PROMPTS` from `mcp-use` | `@mcp-use/agent` | Native agent |
+| LangChain agent compatibility and `ServerManager` | `@mcp-use/agent/langchain` | Optional LangChain integration |
+| Widget compatibility hooks | `mcp-use/react` View hooks | Code running inside MCP App Views |
+| `MCPServer` and server capabilities | `mcp-use` | MCP server |
+
+```typescript
+import { MCPClient } from "@mcp-use/client";
+import { MCPAgent, PROMPTS } from "@mcp-use/agent";
+```
+
+For the optional LangChain compatibility layer:
+
+```typescript
+import {
+  LangChainMCPAgent,
+  ServerManager,
+} from "@mcp-use/agent/langchain";
+```
+
+The native `MCPAgent` and the LangChain compatibility agent are separate public
+entry points. Import `ServerManager` only from the LangChain entry.
+
+### Removed client subpaths
+
+The client package exports only its conditional root and `./react` entry.
+Replace these removed imports:
+
+| Removed import | Use instead |
+| -------------- | ----------- |
+| `@mcp-use/client/browser` | `@mcp-use/client` in a browser build |
+| `@mcp-use/client/auth` | `@mcp-use/client` |
+| `@mcp-use/client/auth/node` | Node OAuth helpers from `@mcp-use/client` |
+
+The root entry resolves to the Node build under the `node` condition and to the
+browser-safe build under the `browser` or default condition.
+
+## 3. Update the connection API
+
+Use `connect()` and `connectAll()`:
+
+```typescript
+import {
+  MCPClient,
+  type MCPConnection,
+} from "@mcp-use/client";
+
+const client = new MCPClient({
+  mcpServers: {
+    demo: { url: "https://api.example.com/mcp" },
+  },
+});
+
+try {
+  const connection: MCPConnection = await client.connect("demo");
+  await connection.callTool("echo", { message: "hello" });
+} finally {
+  await client.close();
+}
+```
+
+`createSession()` and `createAllSessions()` remain as deprecated compatibility
+aliases. `MCPSession` is a deprecated runtime and type alias for
+`MCPConnection`.
+
+Every connection exposes the negotiated server information:
+
+```typescript
+console.log(connection.info.protocolEra);
+console.log(connection.info.protocolVersion);
+console.log(connection.info.capabilities);
+console.log(connection.info.instructions);
+```
+
+## 4. Configure protocol negotiation
+
+The public configuration field is `protocolNegotiation`, not
+`versionNegotiation`.
+
+HTTP connections default to `protocolNegotiation: "auto"`: they probe the
+sessionless protocol and fall back to the sessionful protocol. Stdio defaults to
+`"legacy"` to avoid probing a process that may be launched for one invocation.
+
+```typescript
+import { MCPClient } from "@mcp-use/client";
+
+const client = new MCPClient({
+  mcpServers: {
+    compatible: {
+      url: "https://api.example.com/mcp",
+      protocolNegotiation: "auto",
+    },
+  },
+});
+```
+
+The client CLI uses the same three modes:
+
+```bash
+mcp-use client connect demo https://api.example.com/mcp --protocol auto
+mcp-use client connect legacy https://legacy.example.com/mcp --protocol legacy
+mcp-use client connect modern https://modern.example.com/mcp --protocol modern
+```
+
+The accepted values are `auto`, `legacy`, and `modern`. There is no
+`--negotiate` flag.
+
+## 5. Rename client configuration
+
+Search your client configuration for the removed 1.x names and update them:
+
+| 1.x name | Current name |
+| -------- | ------------ |
+| `samplingCallback` | `onSampling` |
+| `elicitationCallback` | `onElicitation` |
+| `auth_token` | `authToken` |
+| `customHeaders` | `headers` |
+| `clientConfig` | `clientInfo` |
+| `debug` | `logLevel` |
+| `BrowserTelemetry` | `Telemetry` |
+| `ResourceTemplate` client type | `ResourceTemplateType` |
+
+Sampling, elicitation, and notification callbacks can be set as global client
+defaults or on an individual server configuration. Per-server callbacks take
+precedence.
+
+## 6. Update authentication behavior
+
+`MCPClient` automatically creates an OAuth provider for HTTP servers that do not
+already configure an `authProvider`, `authToken`, `oauth: false`, or an
+`Authorization` header.
+
+- Node OAuth opens a browser and waits for its loopback callback.
+- The browser root client opens a popup by default and can use a redirect.
+- `useMcp` and `McpClientProvider` default to
+  `preventAutoAuth: true`. Handle `pending_auth` and call `authenticate()`.
+
+```tsx
+import { useMcpServer } from "@mcp-use/client/react";
+
+export function ServerAuth() {
+  const server = useMcpServer("demo");
+
+  if (server?.state === "pending_auth") {
+    return (
+      <button onClick={() => void server.authenticate()}>
+        Sign in
+      </button>
+    );
+  }
+
+  return null;
+}
+```
+
+For a React OAuth callback route, import `onMcpAuthorization` from
+`@mcp-use/client/react`. A non-React browser build can use the browser
+conditional root export.
+
+Pre-registered clients also have different configuration shapes:
+
+- `MCPClient`: `oauth.staticClientInfo.client_id`
+- React: `oauth.clientId`
+
+See [Authentication](/v2/typescript/client/authentication) for complete Node,
+browser, React, proxy, and public-client examples.
+
+## 7. Update React connection code and Views
+
+Move connection management to `@mcp-use/client/react`:
+
+| 1.x usage | Current usage |
+| --------- | ------------- |
+| `useMcp` from `mcp-use/react` | `useMcp` from `@mcp-use/client/react` |
+| `McpServerOptions` | `McpServerConfig` (`McpServerOptions` is deprecated) |
+| Server config `name` used as a display label | `displayName` |
+| Displayed `server.name` | Negotiated `server.serverInfo?.name` |
+
+`@mcp-use/client/react` also exports `ViewRenderer` for a host application that
+renders MCP App Views.
+
+Code running inside a View stays in `mcp-use/react`, but should use focused View
+hooks such as `useToolContext`, `useCallTool`, and `useViewState`. Compatibility
+hooks such as `useWidget` are deprecated.
+
+## 8. Replace removed low-level exports
+
+The client root no longer re-exports the old Zod `*Schema` constants or
+`JSONSchemaToZod`.
+
+- Import protocol types from `@modelcontextprotocol/client`.
+- Use `ResourceTemplateType` for the protocol resource-template type.
+- Use Zod 4's `z.fromJSONSchema()` when you need to convert JSON Schema.
+
+The current telemetry implementation does not bundle the PostHog browser or
+Node SDKs. If you used the old telemetry override, note that `telFetch` is now a
+non-throwing `(url, init) => Promise<void>` helper.
+
+Do not remove `@modelcontextprotocol/ext-apps` based on the old migration notes;
+the current client still uses it for MCP Apps bridging.
+
+## 9. Review server and MCP App changes
+
+The server is now built around the root `mcp-use` entry, a stateless
+`MCPServer`, and standard protocol result envelopes. Review tool, resource,
+prompt, middleware, authentication, and deployment APIs against the
+[server guide](/v2/typescript/server).
+
+Interactive results use MCP Apps Views. Bind a View to a tool, return
+model-facing `content` and View props in `structuredContent`, and consume the
+result with focused hooks such as `useToolContext`. Deprecated widget helpers
+exist only for compatibility. Follow the
+[MCP Apps guide](/v2/typescript/mcp-apps) before updating interactive UI code.
+
+## 10. Check Inspector callback URLs
+
+The standalone Inspector OAuth callback resolves relative to the configured
+Inspector base path. With the normal `/inspector` base, the callback is
+`/inspector/oauth/callback`; deployments under another base use that base's
+`/oauth/callback`.
+
+If you run a custom OAuth proxy, continue to bind upstream targets to
+SDK-discovered metadata. The Inspector proxy rejects arbitrary upstream target
+URLs.
+
+## Migration checklist
+
+<Steps>
+  <Step title="Update the runtime and packages">
+    Use Node.js `>=22.22.2`, install the beta package tags, and confirm ESM output.
+  </Step>
+  <Step title="Fix imports">
+    Search for client and agent imports from `mcp-use`, removed
+    `@mcp-use/client/*` subpaths, and connection hooks from `mcp-use/react`.
+  </Step>
+  <Step title="Separate native and LangChain agents">
+    Keep `MCPAgent` and `PROMPTS` on `@mcp-use/agent`; move
+    `ServerManager` and LangChain compatibility imports to
+    `@mcp-use/agent/langchain`.
+  </Step>
+  <Step title="Rename configuration">
+    Search for `versionNegotiation`, `samplingCallback`,
+    `elicitationCallback`, `auth_token`, `customHeaders`, `clientConfig`, and
+    `debug`.
+  </Step>
+  <Step title="Use the connection API">
+    Replace `createSession` and `createAllSessions` calls with `connect` and
+    `connectAll`; replace `MCPSession` annotations with `MCPConnection`.
+  </Step>
+  <Step title="Update OAuth UI">
+    Handle React's `pending_auth` state, use the correct pre-registered client
+    shape for each API, and verify callback and proxy URLs.
+  </Step>
+  <Step title="Update Views">
+    Separate React connection management from code that runs inside an MCP App
+    View, then replace deprecated widget compatibility hooks.
+  </Step>
+  <Step title="Verify each environment">
+    Type-check Node, browser, and React entry points independently, then connect
+    to one sessionful and one sessionless server if your application supports
+    both.
+  </Step>
+</Steps>
+
+## Related
+
+- [Client overview](/v2/typescript/client/index)
+- [Authentication](/v2/typescript/client/authentication)
+- [React integration](/v2/typescript/client/usemcp)
+- [Server guide](/v2/typescript/server)
+- [MCP Apps guide](/v2/typescript/mcp-apps)

--- a/docs/v2/typescript/client/migration.mdx
+++ b/docs/v2/typescript/client/migration.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Client migration"
+title: "Migrating to v2"
 description: "Migrate client, agent, and React connection code from mcp-use 1.x"
 icon: "arrow-right-left"
 ---

--- a/docs/v2/typescript/client/notifications.mdx
+++ b/docs/v2/typescript/client/notifications.mdx
@@ -1,0 +1,91 @@
+---
+title: "Notifications"
+description: "Handle one-way updates from MCP servers"
+icon: "bell"
+---
+
+MCP notifications are one-way JSON-RPC messages with no response. Register a
+handler when your application needs to react to server updates.
+
+## Receive server notifications
+
+Set a default handler on the client:
+
+```typescript
+import { MCPClient } from "@mcp-use/client";
+
+const client = new MCPClient({
+  mcpServers: {
+    demo: { url: "http://localhost:3000/mcp" },
+  },
+  onNotification: async (notification) => {
+    console.log(notification.method, notification.params);
+  },
+});
+```
+
+An individual server configuration can provide its own `onNotification`
+callback. Per-server callbacks take precedence over the global default.
+
+You can also register a handler on a connection:
+
+```typescript
+const connection = await client.connect("demo");
+
+connection.on("notification", async (notification) => {
+  if (notification.method === "notifications/tools/list_changed") {
+    await connection.listTools();
+  }
+});
+```
+
+The standard list-change method names are:
+
+- `notifications/tools/list_changed`
+- `notifications/resources/list_changed`
+- `notifications/prompts/list_changed`
+
+The client automatically refreshes its tool cache for tool list changes. Refresh
+resources or prompts when your application needs their updated values.
+
+## React
+
+Each server managed by `McpClientProvider` exposes:
+
+- `notifications`, the stored notification entries
+- `unreadNotificationCount`
+- `markNotificationRead`, `markAllNotificationsRead`, and
+  `clearNotifications`
+
+Set `onNotificationReceived` on a server configuration to run custom logic when
+the provider receives and stores a notification.
+
+## Roots compatibility
+
+`setRoots()` and `getRoots()` are compatibility APIs for sessionful servers.
+Roots are not part of the current sessionless protocol.
+
+For a compatible server, pass initial roots in its client configuration:
+
+```typescript
+import { MCPClient } from "@mcp-use/client";
+
+const client = new MCPClient({
+  mcpServers: {
+    legacy: {
+      url: "http://localhost:3000/mcp",
+      roots: [{ uri: "file:///home/user/project", name: "Project" }],
+    },
+  },
+});
+```
+
+Calling `connection.setRoots(roots)` replaces the cached roots and sends
+`notifications/roots/list_changed` when connected. `connection.getRoots()`
+returns the current cached list. Use these methods only for a server that
+negotiated the sessionful protocol and requests roots.
+
+## Related
+
+Server-side notification sending is covered in
+[Notifications](/v2/typescript/server/notifications).

--- a/docs/v2/typescript/client/prompts.mdx
+++ b/docs/v2/typescript/client/prompts.mdx
@@ -1,0 +1,77 @@
+---
+title: "Prompts"
+description: "Fetch server-defined prompt templates"
+icon: "message-square"
+---
+
+Prompts are server-defined message templates. List the available prompts, then
+request one by name with its arguments.
+
+```typescript
+import { MCPClient } from "@mcp-use/client";
+
+const client = new MCPClient({
+  mcpServers: {
+    demo: { url: "http://localhost:3000/mcp" },
+  },
+});
+
+try {
+  const connection = await client.connect("demo");
+
+  const { prompts } = await connection.listPrompts();
+  for (const prompt of prompts) {
+    console.log(prompt.name, prompt.description);
+  }
+
+  const result = await connection.getPrompt("plan_trip", {
+    destination: "Japan",
+    days: "7",
+  });
+
+  console.log(result.description);
+  for (const message of result.messages) {
+    if (message.content.type === "text") {
+      console.log(message.role, message.content.text);
+    }
+  }
+} finally {
+  await client.close();
+}
+```
+
+`listPrompts()` returns `{ prompts }`. `getPrompt(name, args)` returns a prompt
+result with an optional `description` and a `messages` array. Each message has a
+`role` and one MCP content block.
+
+## React
+
+```tsx
+import { useMcpServer } from "@mcp-use/client/react";
+
+export function LoadPromptButton() {
+  const server = useMcpServer("demo");
+
+  async function handleLoad() {
+    if (server?.state !== "ready") return;
+
+    const result = await server.getPrompt("code_review", {
+      language: "ts",
+    });
+    console.log(result.messages);
+  }
+
+  return (
+    <button disabled={server?.state !== "ready"} onClick={handleLoad}>
+      Load prompt
+    </button>
+  );
+}
+```
+
+The React `getPrompt` arguments are optional and use string values.
+
+## Reference
+
+[`MCPConnection`](https://mcp-use-typescript-api-reference.vercel.app/modules/_mcp-use_client.index.html#mcpconnection) —
+`listPrompts` and `getPrompt`.

--- a/docs/v2/typescript/client/resources.mdx
+++ b/docs/v2/typescript/client/resources.mdx
@@ -1,0 +1,123 @@
+---
+title: "Resources"
+description: "List and read MCP server resources"
+icon: "folder-open"
+---
+
+Resources are URI-addressed content exposed by MCP servers.
+
+```typescript
+import { MCPClient } from "@mcp-use/client";
+
+const client = new MCPClient({
+  mcpServers: {
+    demo: { url: "http://localhost:3000/mcp" },
+  },
+});
+
+try {
+  const connection = await client.connect("demo");
+
+  const { resources } = await connection.listAllResources();
+  for (const resource of resources) {
+    console.log(resource.uri, resource.name, resource.mimeType);
+  }
+
+  const result = await connection.readResource("file:///config.json");
+  for (const content of result.contents) {
+    if ("text" in content) {
+      console.log(content.text);
+    }
+  }
+} finally {
+  await client.close();
+}
+```
+
+Use `listAllResources()` when you want the complete resource list. It follows
+pagination cursors for you and returns `{ resources }`.
+
+## Paginate resources
+
+`listResources(cursor?)` returns an envelope with `resources` and an optional
+`nextCursor`. Handle the cursor yourself when you want to process one page at a
+time:
+
+```typescript
+import type { MCPConnection } from "@mcp-use/client";
+
+async function logResourcePages(connection: MCPConnection): Promise<void> {
+  let cursor: string | undefined;
+
+  do {
+    const page = await connection.listResources(cursor);
+    for (const resource of page.resources) {
+      console.log(resource.uri);
+    }
+    cursor = page.nextCursor;
+  } while (cursor);
+}
+```
+
+## Resource templates
+
+Parameterized URIs such as `db://users/{id}` are discovered with
+`listResourceTemplates()`. Its result contains `resourceTemplates` and may
+contain `nextCursor`. The current `MCPConnection` method retrieves the first
+template page and does not accept a cursor argument.
+
+```typescript
+const page = await connection.listResourceTemplates();
+
+for (const template of page.resourceTemplates) {
+  console.log(template.uriTemplate, template.name);
+}
+```
+
+Resolve a template to a concrete URI in your application, then pass that URI to
+`readResource(uri)`.
+
+## Subscribe to updates
+
+If the server supports resource subscriptions, subscribe and unsubscribe with
+the same concrete URI:
+
+```typescript
+await connection.subscribeToResource("file:///config.json");
+
+// Receive notifications/resources/updated through your notification handler.
+
+await connection.unsubscribeFromResource("file:///config.json");
+```
+
+## React
+
+`useMcpServer` exposes the resource contents envelope returned by
+`readResource(uri)`:
+
+```tsx
+import { useMcpServer } from "@mcp-use/client/react";
+
+export function ReadResourceButton({ uri }: { uri: string }) {
+  const server = useMcpServer("demo");
+
+  async function handleRead() {
+    if (server?.state !== "ready") return;
+
+    const { contents } = await server.readResource(uri);
+    console.log(contents);
+  }
+
+  return (
+    <button disabled={server?.state !== "ready"} onClick={handleRead}>
+      Read resource
+    </button>
+  );
+}
+```
+
+## Reference
+
+[`MCPConnection`](https://mcp-use-typescript-api-reference.vercel.app/modules/_mcp-use_client.index.html#mcpconnection) —
+`listResources`, `listAllResources`, `listResourceTemplates`, `readResource`,
+`subscribeToResource`, and `unsubscribeFromResource`.

--- a/docs/v2/typescript/client/sampling.mdx
+++ b/docs/v2/typescript/client/sampling.mdx
@@ -1,0 +1,100 @@
+---
+title: "Sampling compatibility"
+description: "Handle sampling requests from compatible MCP server flows"
+icon: "pipette"
+---
+
+Sampling is a compatibility capability, not a primary capability of the current
+sessionless MCP protocol. Configure it only when a server flow requires the
+client to provide model output.
+
+The client can invoke `onSampling` in two cases:
+
+- A legacy sessionful server sends a `sampling/createMessage` request.
+- A sessionless server enters the temporary `input_required` multi-round-trip
+  compatibility flow.
+
+Sampling is deprecated by the current sessionless protocol. Prefer server and
+tool designs that do not depend on client-provided sampling when you control
+both sides.
+
+## Handle a request
+
+```typescript
+import {
+  MCPClient,
+  type OnSamplingCallback,
+  type SamplingCreateMessageParams,
+} from "@mcp-use/client";
+
+async function completeWithModel(
+  params: SamplingCreateMessageParams
+): Promise<string> {
+  // Send params.messages and the other sampling constraints to your model.
+  throw new Error(`Connect a model for ${params.messages.length} messages`);
+}
+
+const onSampling: OnSamplingCallback = async (params) => {
+  const text = await completeWithModel(params);
+
+  return {
+    role: "assistant",
+    content: { type: "text", text },
+    model: "your-model",
+    stopReason: "endTurn",
+  };
+};
+
+const client = new MCPClient({
+  mcpServers: {
+    demo: {
+      url: "http://localhost:3000/mcp",
+      onSampling,
+    },
+  },
+});
+
+try {
+  await client.connect("demo");
+  // A compatible server flow can now call onSampling.
+} finally {
+  await client.close();
+}
+```
+
+`OnSamplingCallback` receives the protocol parameters for
+`sampling/createMessage` and must return a
+`SamplingCreateMessageResult`. Setting the callback also advertises the
+sampling capability where the negotiated protocol supports it.
+
+## Global and per-server handlers
+
+Set `onSampling` at the top level of the `MCPClient` configuration to use it as
+a global default. An `onSampling` callback on an individual server
+configuration takes precedence over that default. The Node client also accepts
+the global callback in its second constructor argument.
+
+## React
+
+`useMcp({ onSampling })` handles compatible requests directly with your
+callback.
+
+`McpClientProvider` instead installs a handler that queues each request on the
+managed server:
+
+- `server.pendingSamplingRequests` contains the requests awaiting a decision.
+- `server.approveSampling(requestId, result)` resolves a request with a complete
+  `SamplingCreateMessageResult`.
+- `server.rejectSampling(requestId, error?)` rejects it.
+- `onSamplingRequest` on the server configuration can notify your UI when a
+  request is added to the queue.
+
+Queued requests remain pending until they are approved, rejected, disconnected,
+or timed out.
+
+## Runnable example
+
+The maintained
+[sampling client example](https://github.com/mcp-use/mcp-use/blob/main/libraries/typescript/packages/client/examples/node/communication/sampling-client.ts)
+exercises both the legacy push request and the sessionless
+`input_required` compatibility flow.

--- a/docs/v2/typescript/client/tools.mdx
+++ b/docs/v2/typescript/client/tools.mdx
@@ -1,0 +1,69 @@
+---
+title: "Tools"
+description: "List and call MCP server tools"
+icon: "wrench"
+---
+
+Use a ready `MCPConnection` to list and call tools.
+
+```typescript
+import { MCPClient } from "@mcp-use/client";
+
+const client = new MCPClient({
+  mcpServers: { demo: { url: "http://localhost:3000/mcp" } },
+});
+
+try {
+  const conn = await client.connect("demo");
+
+  const tools = await conn.listTools();
+  for (const tool of tools) {
+    console.log(tool.name, tool.description);
+  }
+
+  const result = await conn.callTool("read_file", { path: "/tmp/a.txt" });
+
+  if (result.isError) {
+    console.error(result.content);
+  } else {
+    for (const block of result.content) {
+      if (block.type === "text") console.log(block.text);
+    }
+  }
+} finally {
+  await client.close();
+}
+```
+
+## Timeouts
+
+Pass MCP request options as the third argument:
+
+```typescript
+const abortController = new AbortController();
+
+await conn.callTool(
+  "long_task",
+  { input: "data" },
+  {
+    timeout: 300_000,
+    resetTimeoutOnProgress: true,
+    maxTotalTimeout: 900_000,
+    signal: abortController.signal,
+  },
+);
+```
+
+## Lazy connect
+
+```typescript
+let conn = client.getSession("demo");
+if (!conn) conn = await client.connect("demo");
+await conn.callTool("echo", { message: "hello" });
+```
+
+`getSession` returns `null` when not connected. `requireSession` throws.
+
+## Reference
+
+[`MCPConnection`](https://mcp-use-typescript-api-reference.vercel.app/modules/_mcp-use_client.index.html#mcpconnection) — `listTools`, `callTool`, and request options.

--- a/docs/v2/typescript/client/usemcp.mdx
+++ b/docs/v2/typescript/client/usemcp.mdx
@@ -1,0 +1,149 @@
+---
+title: "React Integration"
+description: "React hooks and providers for MCP client connections"
+icon: "react"
+---
+
+Import from `@mcp-use/client/react`:
+
+```typescript
+import {
+  McpClientProvider,
+  useMcpClient,
+  useMcpServer,
+  useMcp,
+  onMcpAuthorization,
+} from "@mcp-use/client/react";
+```
+
+Use **`McpClientProvider`** for multi-server apps. Use standalone **`useMcp`** only for a single server.
+
+## Provider setup
+
+```tsx
+function App() {
+  return (
+    <McpClientProvider defaultAutoProxyFallback>
+      <Dashboard />
+    </McpClientProvider>
+  );
+}
+
+function Dashboard() {
+  const { addServer, servers } = useMcpClient();
+
+  useEffect(() => {
+    addServer("demo", {
+      url: "http://localhost:3000/mcp",
+      displayName: "Demo",
+    });
+  }, [addServer]);
+
+  return servers.map((s) => <ServerPanel key={s.id} serverId={s.id} />);
+}
+
+function ServerPanel({ serverId }: { serverId: string }) {
+  const server = useMcpServer(serverId);
+  if (!server || server.state !== "ready") {
+    return <div>{server?.state ?? "loading"}…</div>;
+  }
+
+  return (
+    <div>
+      <h3>{server.displayName}</h3>
+      <p>{server.tools.length} tools</p>
+      <button onClick={() => server.callTool("echo", { msg: "hi" })}>
+        Call echo
+      </button>
+    </div>
+  );
+}
+```
+
+## Connection states
+
+| State            | Meaning                                       |
+| ---------------- | --------------------------------------------- |
+| `discovering`    | Connecting                                    |
+| `pending_auth`   | OAuth required — call `server.authenticate()` |
+| `authenticating` | OAuth in progress                             |
+| `ready`          | Connected                                     |
+| `failed`         | Error — call `server.retry()`                 |
+
+OAuth does not auto-start by default (`preventAutoAuth: true`). Show a sign-in button when `state === "pending_auth"`.
+
+## OAuth callback
+
+Create a route (default: `/oauth/callback`):
+
+```tsx
+import { onMcpAuthorization } from "@mcp-use/client/react";
+import { useEffect } from "react";
+
+export default function OAuthCallback() {
+  useEffect(() => {
+    void onMcpAuthorization();
+  }, []);
+  return <div>Completing sign-in…</div>;
+}
+```
+
+Override with `defaultCallbackUrl` on the provider or `callbackUrl` per server.
+
+## Proxy fallback
+
+When direct browser connections fail (CORS / FastMCP), retry through a proxy:
+
+```tsx
+<McpClientProvider
+  defaultProxyConfig={{ proxyAddress: "https://app.example.com/api/proxy" }}
+  defaultOAuthProxyUrl="https://app.example.com/api/oauth"
+  defaultAutoProxyFallback
+>
+  <App />
+</McpClientProvider>
+```
+
+MCP traffic and OAuth use separate proxy URLs so resource identity stays the upstream MCP URL.
+
+## Persistence
+
+```tsx
+import { LocalStorageProvider } from "@mcp-use/client/react";
+
+<McpClientProvider storageProvider={new LocalStorageProvider("my-servers")}>
+  <App />
+</McpClientProvider>;
+```
+
+Built-in providers persist only non-secret connection settings. Supply bearer
+tokens, request headers, and proxy headers again at runtime after a reload.
+Browser OAuth tokens remain persistent by default and are encrypted with
+AES-256-GCM using a non-extractable origin key stored in IndexedDB.
+
+## Standalone `useMcp`
+
+For one server without the provider:
+
+```tsx
+const mcp = useMcp({ url: "http://localhost:3000/mcp" });
+
+if (mcp.state === "pending_auth") {
+  return <button onClick={mcp.authenticate}>Sign in</button>;
+}
+if (mcp.state !== "ready") return <div>Connecting…</div>;
+
+return <pre>{mcp.tools.map((t) => t.name).join("\n")}</pre>;
+```
+
+## Types
+
+- **`McpServerConfig`** — server options passed to `addServer` (replaces deprecated `McpServerOptions`).
+- **`displayName`** — your label for the server in UI.
+- **`serverInfo.name`** — name returned by the server at init.
+
+Sampling, elicitation, and notifications are queued on each `McpServer` (`pendingSamplingRequests`, `pendingElicitationRequests`, `notifications`). See [Sampling](/v2/typescript/client/sampling) and [Elicitation](/v2/typescript/client/elicitation).
+
+## Reference
+
+[React client API reference](https://mcp-use-typescript-api-reference.vercel.app/modules/_mcp-use_client.react.html) — provider props, hook return values, and storage types.

--- a/docs/v2/typescript/context7.json
+++ b/docs/v2/typescript/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/websites/mcp-use_typescript",
+  "public_key": "pk_DHbfCHmtCxcbCOAR8Q9HX"
+}

--- a/docs/v2/typescript/getting-started/quickstart.mdx
+++ b/docs/v2/typescript/getting-started/quickstart.mdx
@@ -1,0 +1,252 @@
+---
+title: "Quickstart"
+description: "Scaffold, run, and test an MCP App with mcp-use."
+icon: "rocket"
+---
+
+<Visibility for="agents">
+  For the complete documentation index, see
+  [llms.txt](https://mcp-use.com/docs/llms.txt).
+</Visibility>
+
+Create an mcp-use app, run it locally, and render its View in the Inspector. The
+generated project includes a server, two tools, and a React View.
+
+<Note>
+  This quickstart uses the `mcp-apps` template. To build a tool-only server, use
+  `--template mcp-server`. For an MCP client or agent, start with the [MCP
+  Client](/v2/typescript/client/index) or [MCP
+  Agent](/v2/typescript/agent/index) documentation.
+</Note>
+
+## Prerequisites
+
+- Node.js 22.22.2 or later
+- npm, pnpm, or Bun
+
+## Scaffold an mcp-use app
+
+<CodeGroup>
+```bash npm
+npx create-mcp-use-app@beta my-mcp-app --template mcp-apps
+```
+
+```bash pnpm
+pnpm dlx create-mcp-use-app@beta my-mcp-app --template mcp-apps
+```
+
+```bash bun
+bunx create-mcp-use-app@beta my-mcp-app --template mcp-apps
+```
+
+</CodeGroup>
+
+The scaffolder can install dependencies and the `mcp-apps-builder` coding-agent
+skill. Accept the defaults when prompted.
+
+## Run the development server
+
+<CodeGroup>
+```bash npm
+cd my-mcp-app
+npm run dev
+```
+
+```bash pnpm
+cd my-mcp-app
+pnpm dev
+```
+
+```bash bun
+cd my-mcp-app
+bun run dev
+```
+
+</CodeGroup>
+
+`mcp-use dev` serves the MCP endpoint at `http://localhost:3000/mcp` and the
+Inspector at `http://localhost:3000/mcp/inspector`. The Inspector opens
+automatically in an interactive terminal.
+
+## Explore the generated project
+
+```text
+my-mcp-app/
+├── public/
+│   ├── icon.svg
+│   └── logo-mcp-use.svg
+├── views/
+│   └── my-view/
+│       ├── view.tsx
+│       ├── view.css
+│       ├── icons.tsx
+│       ├── MeshGradient.tsx
+│       └── Tooltip.tsx
+├── index.ts
+├── mcp-env.d.ts
+├── package.json
+└── tsconfig.json
+```
+
+- `index.ts` creates the server and registers the `show-app` and `say-hello`
+  tools.
+- `views/my-view/view.tsx` contains the React View rendered by `show-app`.
+- `mcp-env.d.ts` connects exported tool definitions to typed React hooks.
+- `public/` contains assets served by the framework.
+
+## Understand the View-bound tool
+
+The generated `show-app` tool imports from `mcp-use`, declares `inputSchema` and
+`outputSchema`, and binds the View with `view: { name: "my-view" }`.
+
+```typescript index.ts
+import { MCPServer } from "mcp-use";
+import { z } from "zod";
+
+const server = new MCPServer({
+  name: "my-mcp-app",
+  version: "1.0.0",
+});
+
+export const showApp = server.tool(
+  {
+    name: "show-app",
+    description: "Display the starter MCP App",
+    inputSchema: z.object({
+      appName: z.string().optional().describe("Title shown in the MCP App"),
+    }),
+    outputSchema: z.object({
+      message: z.string().describe("Message displayed by the View"),
+    }),
+    view: {
+      name: "my-view",
+      description: "Starter MCP App View",
+    },
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      openWorldHint: false,
+    },
+  },
+  async ({ appName }) => {
+    const data = {
+      message: `The MCP App for ${appName ?? "my project"} is ready!`,
+    };
+
+    return {
+      content: [{ type: "text", text: data.message }],
+      structuredContent: data,
+    };
+  },
+);
+
+export default server;
+```
+
+Assign statically declared tools to exported constants. The generated
+`mcp-env.d.ts` uses those exports to type View hooks. Export the server as the
+default value so the CLI can run, build, and deploy it.
+
+## Read tool results in the View
+
+The View directory must match `view.name`. Use `useToolContext()` to read the
+invocation that rendered the View:
+
+```tsx views/my-view/view.tsx
+import { useToolContext } from "mcp-use/react";
+
+export default function MyView() {
+  const view = useToolContext<"show-app">();
+
+  if (view.status === "pending") {
+    return <p>Loading the app…</p>;
+  }
+
+  if (view.status === "error") {
+    return <p role="alert">{view.error.message}</p>;
+  }
+
+  return <h2>{view.toolOutput.message}</h2>;
+}
+```
+
+When the tool succeeds, `view.toolOutput` is the typed value returned in
+`structuredContent`. The host and model receive the text in `content`.
+
+## Check the project
+
+Run the generated type check after changing tools or Views:
+
+<CodeGroup>
+```bash npm
+npm run typecheck
+```
+
+```bash pnpm
+pnpm typecheck
+```
+
+```bash bun
+bun run typecheck
+```
+
+</CodeGroup>
+
+The command refreshes `mcp-env.d.ts` and runs TypeScript without emitting build
+files.
+
+You can also call the server from the terminal:
+
+```bash
+npx mcp-use client connect local http://localhost:3000/mcp
+npx mcp-use client local tools list
+```
+
+## Deploy the project
+
+Deploy the generated project to Manufact Cloud:
+
+<CodeGroup>
+```bash npm
+npm run deploy
+```
+
+```bash pnpm
+pnpm deploy
+```
+
+```bash bun
+bun run deploy
+```
+
+</CodeGroup>
+
+The first deployment signs you in and links the local project. See the
+[Manufact deployment guide](/v2/typescript/server/deployment/mcp-use) for
+environment variables, regions, and subsequent deployments.
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Tools" icon="wrench" href="/v2/typescript/server/tools">
+    Define validated inputs, outputs, annotations, and View-bound results.
+  </Card>
+  <Card title="MCP Apps" icon="app-window-mac" href="/v2/typescript/mcp-apps">
+    Build production Views and integrate with MCP hosts.
+  </Card>
+  <Card title="Inspector" icon="bug-play" href="/inspector/index">
+    Test and debug your server interactively.
+  </Card>
+  <Card
+    title="Deployment"
+    icon="rocket"
+    href="/v2/typescript/server/deployment/mcp-use"
+  >
+    Publish the server and configure production environments.
+  </Card>
+</CardGroup>
+
+<Tip>
+  **Need help?** Join our [Discord](https://discord.gg/XkNkSkMz3V) or visit
+  [GitHub](https://github.com/mcp-use/mcp-use).
+</Tip>

--- a/docs/v2/typescript/getting-started/welcome.mdx
+++ b/docs/v2/typescript/getting-started/welcome.mdx
@@ -1,0 +1,115 @@
+---
+title: "Welcome"
+description: "Build MCP servers, apps, clients, and agents with mcp-use for TypeScript."
+icon: "heart-handshake"
+---
+
+<Visibility for="agents">
+  For the complete documentation index, see
+  [llms.txt](https://mcp-use.com/docs/llms.txt).
+</Visibility>
+
+**mcp-use** is the full-stack MCP framework for TypeScript. Build MCP servers,
+MCP Apps that render interactive Views in ChatGPT and Claude, MCP clients, and
+tool-calling agents with end-to-end type safety.
+
+## Get started
+
+Scaffold an mcp-use app with the release of `create-mcp-use-app`:
+
+```bash
+npx create-mcp-use-app@beta my-mcp-app
+```
+
+### Build a server and View
+
+<CodeGroup>
+```typescript index.ts
+import { MCPServer } from "mcp-use";
+import { z } from "zod";
+
+const server = new MCPServer({
+  name: "greeter",
+  version: "1.0.0",
+});
+
+export const greet = server.tool(
+  {
+    name: "greet",
+    description: "Greet someone by name",
+    inputSchema: z.object({
+      name: z.string().describe("Name of the person to greet"),
+    }),
+    outputSchema: z.object({
+      greeting: z.string(),
+    }),
+    view: { name: "greeting" },
+  },
+  async ({ name }) => {
+    const data = { greeting: `Hello, ${name}!` };
+
+    return {
+      content: [{ type: "text", text: data.greeting }],
+      structuredContent: data,
+    };
+  },
+);
+
+export default server;
+```
+
+```tsx views/greeting/view.tsx
+import { useToolContext } from "mcp-use/react";
+
+export default function Greeting() {
+  const view = useToolContext<"greet">();
+
+  if (view.status === "pending") return <p>Loading…</p>;
+  if (view.status === "error") return <p>{view.error.message}</p>;
+
+  return <h1>👋 {view.toolOutput.greeting}</h1>;
+}
+```
+</CodeGroup>
+
+The default server export lets `mcp-use dev`, `mcp-use build`, and
+`mcp-use start` manage the server lifecycle. The View directory name must match
+the tool's `view.name`.
+
+<Callout color='#bccad1' icon={<svg xmlns="http://www.w3.org/2000/svg" className='min-w-[20px] mt-0 flex-shrink-0' viewBox="0 0 128 128"><linearGradient id="python-original-a" gradientUnits="userSpaceOnUse" x1="70.252" y1="1237.476" x2="170.659" y2="1151.089" gradientTransform="matrix(.563 0 0 -.568 -29.215 707.817)"><stop offset="0" stop-color="#5A9FD4"/><stop offset="1" stop-color="#306998"/></linearGradient><linearGradient id="python-original-b" gradientUnits="userSpaceOnUse" x1="209.474" y1="1098.811" x2="173.62" y2="1149.537" gradientTransform="matrix(.563 0 0 -.568 -29.215 707.817)"><stop offset="0" stop-color="#FFD43B"/><stop offset="1" stop-color="#FFE873"/></linearGradient><path fill="url(#python-original-a)" d="M63.391 1.988c-4.222.02-8.252.379-11.8 1.007-10.45 1.846-12.346 5.71-12.346 12.837v9.411h24.693v3.137H29.977c-7.176 0-13.46 4.313-15.426 12.521-2.268 9.405-2.368 15.275 0 25.096 1.755 7.311 5.947 12.519 13.124 12.519h8.491V67.234c0-8.151 7.051-15.34 15.426-15.34h24.665c6.866 0 12.346-5.654 12.346-12.548V15.833c0-6.693-5.646-11.72-12.346-12.837-4.244-.706-8.645-1.027-12.866-1.008zM50.037 9.557c2.55 0 4.634 2.117 4.634 4.721 0 2.593-2.083 4.69-4.634 4.69-2.56 0-4.633-2.097-4.633-4.69-.001-2.604 2.073-4.721 4.633-4.721z" transform="translate(0 10.26)"/><path fill="url(#python-original-b)" d="M91.682 28.38v10.966c0 8.5-7.208 15.655-15.426 15.655H51.591c-6.756 0-12.346 5.783-12.346 12.549v23.515c0 6.691 5.818 10.628 12.346 12.547 7.816 2.297 15.312 2.713 24.665 0 6.216-1.801 12.346-5.423 12.346-12.547v-9.412H63.938v-3.138h37.012c7.176 0 9.852-5.005 12.348-12.519 2.578-7.735 2.467-15.174 0-25.096-1.774-7.145-5.161-12.521-12.348-12.521h-9.268zM77.809 87.927c2.561 0 4.634 2.097 4.634 4.692 0 2.602-2.074 4.719-4.634 4.719-2.55 0-4.633-2.117-4.633-4.719 0-2.595 2.083-4.692 4.633-4.692z" transform="translate(0 10.26)"/><radialGradient id="python-original-c" cx="1825.678" cy="444.45" r="26.743" gradientTransform="matrix(0 -.24 -1.055 0 532.979 557.576)" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#B8B8B8" stop-opacity=".498"/><stop offset="1" stop-color="#7F7F7F" stop-opacity="0"/></radialGradient><path opacity=".444" fill="url(#python-original-c)" d="M97.309 119.597c0 3.543-14.816 6.416-33.091 6.416-18.276 0-33.092-2.873-33.092-6.416 0-3.544 14.815-6.417 33.092-6.417 18.275 0 33.091 2.872 33.091 6.417z"/></svg>}>
+  Looking for the **Python** docs? Start with the [Python quickstart](/python/getting-started/quickstart).
+</Callout>
+
+<Card title="New to MCP?" icon="brain" href="/home/mcp101">
+  Learn how MCP clients, servers, agents, tools, resources, and prompts fit
+  together.
+</Card>
+
+## Choose your next step
+
+<CardGroup cols={2}>
+  <Card
+    title="Build your first project"
+    icon="rocket"
+    href="/v2/typescript/getting-started/quickstart"
+  >
+    Scaffold an MCP App, run it locally, and test its View.
+  </Card>
+  <Card title="MCP Server" icon="server" href="/v2/typescript/server">
+    Define tools, resources, prompts, authentication, and deployment.
+  </Card>
+  <Card title="MCP Apps" icon="app-window-mac" href="/v2/typescript/mcp-apps">
+    Build interactive Views for ChatGPT, Claude, and other MCP hosts.
+  </Card>
+  <Card title="MCP Client" icon="router" href="/v2/typescript/client/index">
+    Connect to MCP servers programmatically.
+  </Card>
+  <Card title="MCP Agent" icon="brain" href="/v2/typescript/agent/index">
+    Build agents that call tools through MCP connections.
+  </Card>
+</CardGroup>
+
+<Tip>
+  **Need help?** Join our [Discord](https://discord.gg/XkNkSkMz3V) or visit
+  [GitHub](https://github.com/mcp-use/mcp-use).
+</Tip>

--- a/docs/v2/typescript/mcp-apps.mdx
+++ b/docs/v2/typescript/mcp-apps.mdx
@@ -1,0 +1,193 @@
+---
+title: "Overview"
+description: "Understand how MCP tools render interactive UI with mcp-use."
+icon: "blocks"
+---
+
+MCP Apps let your tools render interactive UI inside AI conversations. Build a View when users need to explore data, complete a form, review a preview, or act on a tool result.
+
+An MCP App combines three parts:
+
+- an `MCPServer`
+- a tool bound to a View
+- a React component under `views/`
+
+<video
+  alt="Interactive MCP App View"
+  style={{
+    maxWidth: "600px",
+    borderRadius: "8px",
+    marginBottom: "1.5rem",
+    boxShadow: "0 2px 12px rgba(0,0,0,0.08)",
+  }}
+  muted
+  autoPlay
+  loop
+>
+  <source src="/images/widget.mp4" type="video/mp4" />
+</video>
+
+## How a tool renders a View
+
+Add `view: { name }` to a tool definition. The name must match a directory under `views/`.
+
+```text
+product-search/
+├── index.ts
+├── views/
+│   └── product-results/
+│       └── view.tsx
+├── public/
+├── mcp-env.d.ts
+└── package.json
+```
+
+The View-bound tool must declare an `outputSchema`. Its handler returns a normal MCP tool result with matching `structuredContent`.
+
+```typescript
+import { MCPServer } from "mcp-use";
+import { z } from "zod";
+
+const server = new MCPServer({
+  name: "product-search",
+  version: "1.0.0",
+});
+
+const productResultsSchema = z.object({
+  query: z.string(),
+  results: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+    }),
+  ),
+});
+
+const products = [
+  { id: "starter-kit", name: "Starter kit" },
+  { id: "travel-kit", name: "Travel kit" },
+];
+
+export const searchProducts = server.tool(
+  {
+    name: "search-products",
+    inputSchema: z.object({
+      query: z.string(),
+    }),
+    outputSchema: productResultsSchema,
+    view: {
+      name: "product-results",
+      description: "Product search results",
+      prefersBorder: true,
+    },
+  },
+  async ({ query }) => {
+    const results = products.filter(({ name }) =>
+      name.toLowerCase().includes(query.toLowerCase()),
+    );
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Found ${results.length} products matching "${query}".`,
+        },
+      ],
+      structuredContent: {
+        query,
+        results,
+      },
+    };
+  },
+);
+
+export default server;
+```
+
+Each View can be bound to at most one tool. Export the tool reference so mcp-use can infer its input and output types inside the View.
+
+## Read the tool result in the View
+
+A View default-exports a React component. The component receives no React props. Read the tool lifecycle and result with `useToolContext()`.
+
+```tsx
+import { useToolContext } from "mcp-use/react";
+
+export default function ProductResults() {
+  const { status, toolInput, toolOutput, error } =
+    useToolContext<"search-products">();
+
+  if (status === "error") {
+    return <p>{error.message}</p>;
+  }
+
+  if (status === "pending") {
+    return <p>Searching for {toolInput?.query ?? "products"}…</p>;
+  }
+
+  return (
+    <main>
+      <h2>Results for “{toolOutput.query}”</h2>
+      <ul>
+        {toolOutput.results.map(({ id, name }) => (
+          <li key={id}>{name}</li>
+        ))}
+      </ul>
+    </main>
+  );
+}
+```
+
+## Choose what the model and View receive
+
+MCP tool results provide separate channels for conversation output, structured data, and View-only metadata.
+
+| Channel             | Model receives it? | View receives it?    | Use it for                                                        |
+| ------------------- | ------------------ | -------------------- | ----------------------------------------------------------------- |
+| `content`           | Yes                | Yes, as `content`    | A concise result for the conversation and text-only clients       |
+| `structuredContent` | Yes                | Yes, as `toolOutput` | Typed data that the model can reason over and the View can render |
+| `_meta`             | No                 | Yes, as `meta`       | Data that is not visible to the model                             |
+
+Do not place secrets in any result channel. A View runs on the client and can read its result data.
+
+Clients that do not render MCP Apps can still use the tool's `content` and `structuredContent`. Use `ctx.client.supportsViews()` only when a text-only client needs materially different output.
+
+## Continue building
+
+<CardGroup cols={2}>
+  <Card
+    title="Build your first MCP App"
+    icon="rocket"
+    href="/v2/typescript/mcp-apps/quickstart"
+  >
+    Create a project, run it locally, and render its View in the Inspector.
+  </Card>
+  <Card
+    title="Build Views"
+    icon="panel-top"
+    href="/v2/typescript/mcp-apps/widgets"
+  >
+    Bind a tool to a React component and handle its result.
+  </Card>
+  <Card
+    title="Interactivity"
+    icon="mouse-pointer-click"
+    href="/v2/typescript/mcp-apps/interactivity"
+  >
+    Call tools, open links, send follow-up messages, and change display modes.
+  </Card>
+  <Card
+    title="Model context"
+    icon="brain"
+    href="/v2/typescript/mcp-apps/model-context"
+  >
+    Expose View state and visible UI information to future model turns.
+  </Card>
+  <Card
+    title="Content Security Policy"
+    icon="shield"
+    href="/v2/typescript/mcp-apps/content-security-policy"
+  >
+    Allow the external APIs, assets, and embedded content your View needs.
+  </Card>
+</CardGroup>

--- a/docs/v2/typescript/mcp-apps/apps-sdk-compatibility.mdx
+++ b/docs/v2/typescript/mcp-apps/apps-sdk-compatibility.mdx
@@ -1,0 +1,42 @@
+---
+title: "Apps SDK compatibility"
+description: "Understand how MCP Apps run in ChatGPT and how mcp-use handles Apps SDK compatibility."
+icon: "openai"
+---
+
+ChatGPT supports MCP Apps. That means a widget built with the MCP Apps bridge can run in ChatGPT and in other MCP Apps-compatible hosts.
+
+`mcp-use` handles the compatibility details for you. Build the widget with the standard `mcp-use` server and React APIs; `mcp-use` emits the metadata ChatGPT needs and maps host behavior through the same hooks you use everywhere else.
+
+## How ChatGPT fits in
+
+OpenAI's Apps SDK remains supported, and ChatGPT also implements the MCP Apps UI standard. `mcp-use` generates MCP Apps metadata and ChatGPT compatibility metadata from the same widget definitions.
+
+In practice:
+
+- Use `widget: { name }` and `widget({ props, output })` on the server.
+- Use `useToolContext()`, `useViewState()`, and `useCallTool()` in React views.
+- Let `mcp-use` translate compatibility metadata for ChatGPT.
+- Reach for Apps SDK extensions only when a ChatGPT-specific capability has no shared MCP Apps equivalent yet.
+
+## What mcp-use abstracts
+
+The same widget code should work across supported hosts:
+
+| Widget behavior                                           | mcp-use API         |
+| --------------------------------------------------------- | ------------------- |
+| Read tool input, structured output, content, and metadata | `useToolContext()`  |
+| Read host environment data                                | `useHostContext()`  |
+| Call MCP tools from the widget                            | `useCallTool()`     |
+| Update model-visible view state                           | `useViewState()`    |
+| Describe visible UI                                       | `ModelContext`      |
+| Send a follow-up user message                             | `useSendFollowUp()` |
+| Request inline, fullscreen, or picture-in-picture display | `useDisplayMode()`  |
+
+These APIs keep widget code focused on behavior instead of host-specific bridge details.
+
+## Next steps
+
+- Use [Build widgets](/v2/typescript/mcp-apps/widgets) for the normal MCP Apps workflow.
+- Use [Model context](/v2/typescript/mcp-apps/model-context) to decide what the model and widget should see.
+- Use [Interactivity](/v2/typescript/mcp-apps/interactivity) for tool calls, state, follow-up messages, and display controls.

--- a/docs/v2/typescript/mcp-apps/content-security-policy.mdx
+++ b/docs/v2/typescript/mcp-apps/content-security-policy.mdx
@@ -1,0 +1,104 @@
+---
+title: "Content Security Policy"
+description: "Configure the domains that MCP Apps widgets can load, call, and embed."
+icon: "shield"
+---
+
+Content Security Policy (CSP) controls which domains your views can fetch from, load scripts/styles from, and embed. Views run in sandboxed iframes, so CSP must explicitly allow any external resources.
+
+## Server and asset origins
+
+Set **`MCP_URL`** to your server's public origin (OAuth resource URL, API calls, CSP `connectDomains`):
+
+```env
+MCP_URL=https://myserver.com
+```
+
+Set **`MCP_ASSETS_URL`** when view JS/CSS and `public/` files are served from a different prefix (CDN, Supabase Storage):
+
+```env
+MCP_ASSETS_URL=https://cdn.example.com/storage/v1/object/public/widgets
+```
+
+When `MCP_ASSETS_URL` is unset, assets use the same origin as `MCP_URL` (or the request origin behind a proxy).
+
+At **`mcp-use build`**, `MCP_ASSETS_URL` rewrites manifest paths to full `https://` URLs for static upload workflows.
+
+## CSP merge order
+
+On each `resources/read`, the framework merges CSP in this order (high → low priority):
+
+1. Author `view.csp` on the bound tool
+2. `CSP_*_DOMAINS` env vars (per category) or the `CSP_URLS` shortcut
+3. MCP auto-append: `MCP_URL` → `connectDomains`; assets origin → `resourceDomains`
+
+`CSP_URLS` and per-category env vars rank **above** MCP auto-append. Duplicate origins keep the higher-priority entry's position.
+
+## Add domains for one view
+
+Declare CSP on the tool's `view:` config:
+
+```typescript
+server.tool(
+  {
+    name: "weather",
+    view: {
+      name: "weather-display",
+      csp: {
+        connectDomains: ["https://api.weather.com"],
+        resourceDomains: ["https://cdn.weather.com"],
+        frameDomains: ["https://trusted-embed.com"],
+      },
+    },
+  },
+  async () => ({ /* ... */ })
+);
+```
+
+MCP Apps CSP fields: `connectDomains`, `resourceDomains`, `frameDomains`, `baseUriDomains`.
+
+## Global CSP env vars
+
+Use `CSP_URLS` when every view needs the same extra domains (shortcut for **all four** categories):
+
+```env
+CSP_URLS=https://api.example.com,https://cdn.example.com
+```
+
+Override one category without affecting others:
+
+```env
+CSP_CONNECT_DOMAINS=https://api.example.com
+CSP_RESOURCE_DOMAINS=https://cdn.example.com
+CSP_FRAME_DOMAINS=https://embed.example.com
+CSP_BASE_URI_DOMAINS=https://myserver.com
+```
+
+## Static deployments (Supabase / CDN)
+
+When assets live on static storage and the MCP server runs elsewhere:
+
+```env
+MCP_URL=https://PROJECT.supabase.co/functions/v1/mcp-server
+MCP_ASSETS_URL=https://PROJECT.supabase.co/storage/v1/object/public/widgets
+CSP_URLS=https://PROJECT.supabase.co
+```
+
+See [Supabase deployment](/v2/typescript/server/deployment/supabase) for the full workflow.
+
+## Verify CSP
+
+The mcp-use Inspector provides a **CSP Mode Toggle** for testing:
+
+- **Permissive**: Relaxed CSP for debugging
+- **Widget-Declared**: Enforces the view's declared CSP (production-like)
+
+<Warning>
+CSP violations are logged in the console. Use Widget-Declared mode to catch CSP issues before production deployment.
+</Warning>
+
+## Next Steps
+
+- [MCP Apps](/v2/typescript/mcp-apps): View overview and routing
+- [Apps SDK compatibility](/v2/typescript/mcp-apps/apps-sdk-compatibility): ChatGPT compatibility and host extensions
+- [Supabase Deployment](/v2/typescript/server/deployment/supabase): Static deployment with CSP

--- a/docs/v2/typescript/mcp-apps/interactivity.mdx
+++ b/docs/v2/typescript/mcp-apps/interactivity.mdx
@@ -1,0 +1,132 @@
+---
+title: "Interactivity"
+description: "Add tool calls, widget state, follow-up messages, and display controls to MCP Apps widgets."
+icon: "mouse-pointer-click"
+---
+
+Interactive widgets can call tools, save UI state, send follow-up messages, and request a larger display mode. Use these APIs for user actions that should happen inside the widget instead of requiring another prompt.
+
+This guide assumes your widget already renders with `useWidget()`. See [Build widgets](/v2/typescript/mcp-apps/widgets) first if you still need the server and widget setup.
+
+## Call tools from a widget
+
+Use `useCallTool()` when a button or form should call another MCP tool. The hook gives you loading, success, and error state.
+
+```tsx
+import { useCallTool } from "mcp-use/react";
+
+function DetailsButton({ productId }: { productId: string }) {
+  const { callTool, data, isPending, isError } = useCallTool("get-product");
+
+  return (
+    <section>
+      <button onClick={() => callTool({ productId })} disabled={isPending}>
+        {isPending ? "Loading..." : "View details"}
+      </button>
+
+      {isError && <p>Could not load product details.</p>}
+      {data && <pre>{JSON.stringify(data.structuredContent, null, 2)}</pre>}
+    </section>
+  );
+}
+```
+
+Prefer `useCallTool()` for user-facing actions. Use `useWidget().callTool` only for small one-off calls where you do not need hook-managed state.
+
+## Save widget state
+
+Use `setState` for UI state that should survive re-renders and be available to future model turns.
+
+```tsx
+import { useWidget } from "mcp-use/react";
+
+type FavoritesState = {
+  favorites: string[];
+};
+
+function FavoriteButton({ id }: { id: string }) {
+  const { state, setState } = useWidget<{}, FavoritesState>();
+  const favorites = state?.favorites ?? [];
+  const isFavorite = favorites.includes(id);
+
+  async function toggleFavorite() {
+    await setState({
+      favorites: isFavorite
+        ? favorites.filter((favoriteId) => favoriteId !== id)
+        : [...favorites, id],
+    });
+  }
+
+  return (
+    <button onClick={toggleFavorite}>
+      {isFavorite ? "Remove favorite" : "Save favorite"}
+    </button>
+  );
+}
+```
+
+Use widget state for view state and user choices. Do not use widget state as your database.
+
+## Send a follow-up message
+
+Use `sendFollowUpMessage` when a widget action should ask the model to continue the conversation.
+
+```tsx
+import { useWidget } from "mcp-use/react";
+
+function ExplainButton({ productName }: { productName: string }) {
+  const { sendFollowUpMessage } = useWidget();
+
+  return (
+    <button
+      onClick={() =>
+        sendFollowUpMessage(`Compare ${productName} with similar products.`)
+      }
+    >
+      Compare
+    </button>
+  );
+}
+```
+
+Follow-up messages create a new model turn. Use them for actions that need model reasoning, not for local UI updates.
+
+## Request display modes
+
+Use `requestDisplayMode` when a widget needs more room.
+
+```tsx
+import { useWidget } from "mcp-use/react";
+
+function DisplayModeControls() {
+  const { displayMode, requestDisplayMode } = useWidget();
+  const expanded = displayMode === "fullscreen" || displayMode === "pip";
+
+  return (
+    <button
+      onClick={() => requestDisplayMode(expanded ? "inline" : "fullscreen")}
+    >
+      {expanded ? "Exit" : "Expand"}
+    </button>
+  );
+}
+```
+
+The host may grant a different mode than requested. Read `displayMode` for the actual current mode.
+
+## Combine actions carefully
+
+A single click should usually do one main thing. For example:
+
+- call a tool to fetch more data
+- update widget state after a user choice
+- send a follow-up message for model reasoning
+- request fullscreen for a larger view
+
+If one action must do multiple things, update local widget state first so the UI responds immediately, then call the tool or send the follow-up message.
+
+## Next steps
+
+- Use [Model context](/v2/typescript/mcp-apps/model-context) to decide what the model should know about these interactions.
+- Use [`useCallTool()`](https://mcp-use-typescript-api-reference.vercel.app/modules/mcp-use.react.html#usecalltool) for full call state and typing details.
+- Use [`useWidget()`](https://mcp-use-typescript-api-reference.vercel.app/modules/mcp-use.react.html#usewidget) for all host actions and display-mode behavior.

--- a/docs/v2/typescript/mcp-apps/model-context.mdx
+++ b/docs/v2/typescript/mcp-apps/model-context.mdx
@@ -1,0 +1,116 @@
+---
+title: "Model context"
+description: "Choose what the model sees from tool results, structured view state, and the currently visible UI."
+icon: "brain"
+---
+
+Use model context to give the next model turn the information it needs without duplicating every value rendered by the view. Tool results establish the initial context; `useViewState` and `ModelContext` update it as the user interacts.
+
+## Choose the right channel
+
+| Need                                          | Use                                                            |
+| --------------------------------------------- | -------------------------------------------------------------- |
+| Return a concise tool result                  | A text `content` block                                         |
+| Send structured render data to the view       | Tool-result `structuredContent`, read through `useToolContext` |
+| Keep structured user choices model-visible    | `useViewState`                                                 |
+| Describe what the user currently sees         | `<ModelContext>`                                               |
+| Keep ephemeral UI state private to the iframe | React `useState`                                               |
+| Persist durable business data                 | Your backend                                                   |
+
+## Keep structured choices in view state
+
+Use `useViewState` for selections, filters, drafts, and progress that future model turns should understand.
+
+```tsx
+import { useViewState } from "mcp-use/react";
+
+function Filters() {
+  const [state, setState] = useViewState({
+    selectedCategory: "all",
+    sort: "newest",
+  });
+
+  return (
+    <button onClick={() => setState({ ...state, sort: "price" })}>
+      Sort by price
+    </button>
+  );
+}
+```
+
+The root state value must be a JSON-serializable object. All components in one mounted view share it. Separate view instances remain isolated.
+
+ChatGPT restores the state through `window.openai.widgetState`. Other MCP Apps hosts keep it for the current iframe lifetime until the protocol provides a restoration channel.
+
+## Describe visible UI
+
+Use `ModelContext` for natural-language descriptions that follow the React component lifecycle.
+
+```tsx
+import { ModelContext } from "mcp-use/react";
+
+function Dashboard() {
+  return (
+    <ModelContext content="Dashboard">
+      <ModelContext content="Revenue chart is visible" />
+      <ModelContext content="Three alerts are unresolved" />
+    </ModelContext>
+  );
+}
+```
+
+Nested components serialize into an indented tree:
+
+```text
+- Dashboard
+  - Revenue chart is visible
+  - Three alerts are unresolved
+```
+
+For annotations produced by event handlers or other callbacks, store the
+description in React state and render it declaratively:
+
+```tsx
+function ProductPicker() {
+  const [selection, setSelection] = useState<string | null>(null);
+
+  return (
+    <>
+      {selection && <ModelContext content={`Selected ${selection}`} />}
+      <button onClick={() => setSelection("Wireless Headphones")}>
+        Select headphones
+      </button>
+    </>
+  );
+}
+```
+
+## Understand the merged snapshot
+
+The runtime merges structured state and the serialized context tree into one complete object:
+
+```json
+{
+  "selectedCategory": "audio",
+  "sort": "price",
+  "_uiContext": "- Dashboard\n  - Revenue chart is visible"
+}
+```
+
+`_uiContext` is a reserved model-visible field. `useViewState` filters it from application state and rejects developer state containing the same key.
+
+Every write sends the complete snapshot. On MCP Apps hosts, mcp-use sends the object as `structuredContent` and a JSON text block as `content` through `ui/update-model-context`. On ChatGPT, mcp-use writes the object to `modelContent` with `window.openai.setWidgetState`.
+
+## Keep ephemeral values local
+
+Use React `useState` for transient details that the model does not need, such as hover state, open tooltips, or animation progress.
+
+```tsx
+const [hoveredId, setHoveredId] = useState<string | null>(null);
+```
+
+## Next steps
+
+- Read the [`useViewState` API reference](https://mcp-use-typescript-api-reference.vercel.app/modules/mcp-use.react.html#useviewstate) for signatures, errors, and host behavior.
+- Read the [`ModelContext` API reference](https://mcp-use-typescript-api-reference.vercel.app/modules/mcp-use.react.html#modelcontext) for lifecycle and nesting.
+- Use [Interactivity](/v2/typescript/mcp-apps/interactivity) for tool calls and follow-up messages.

--- a/docs/v2/typescript/mcp-apps/quickstart.mdx
+++ b/docs/v2/typescript/mcp-apps/quickstart.mdx
@@ -1,0 +1,186 @@
+---
+title: "Build your first MCP App"
+description: "Create, run, and verify an MCP App with a view-bound tool."
+icon: "rocket"
+---
+
+Create a TypeScript MCP App, run it locally, and verify that a tool returns a React view in the Inspector.
+
+If you want a plain MCP server without views, use the [TypeScript quickstart](/v2/typescript/getting-started/quickstart) instead.
+
+## What you'll build
+
+This guide creates a local server with:
+
+- an MCP endpoint at `http://localhost:3000/mcp`
+- an Inspector at `http://localhost:3000/mcp/inspector`
+- a `search-fruits` tool that returns a view
+- a React view at `views/product-search-result/view.tsx`
+
+## Prerequisites
+
+- Node.js 22.22.2 or higher
+- Basic TypeScript and React knowledge
+
+## Create the project
+
+Run the MCP Apps template:
+
+```bash
+npx create-mcp-use-app my-widget-server --template mcp-apps
+cd my-widget-server
+npm install
+```
+
+The template creates more files for assets, view components, and local tooling. These are the files you edit most often:
+
+```text
+my-widget-server/
+├── index.ts
+├── mcp-env.d.ts
+├── views/
+│   └── product-search-result/
+│       ├── view.tsx
+│       ├── view.css
+│       ├── components/
+│       └── hooks/
+├── public/
+│   ├── favicon.ico
+│   ├── icon.svg
+│   └── fruits/
+├── package.json
+└── tsconfig.json
+```
+
+## Run the server
+
+Start the development server:
+
+```bash
+npm run dev
+```
+
+This starts the MCP server, view build pipeline, and Inspector. Keep the process running while you test the app.
+
+## Inspect the view tool
+
+Open `index.ts` and find the `search-fruits` tool. The template includes server branding, 16 fruits, a loading delay demo, and a second `get-fruit-details` tool. This excerpt shows the view-bound path you need to understand first.
+
+```typescript
+// index.ts excerpt; server, fruits, and z are defined above.
+export const searchFruits = server.tool(
+  {
+    name: "search-fruits",
+    title: "Search fruits",
+    description: "Search for fruits and display the results in a view",
+    inputSchema: z.object({
+      query: z.string().optional().describe("Search query to filter fruits"),
+    }),
+    outputSchema: z.object({
+      query: z.string(),
+      results: z.array(
+        z.object({
+          fruit: z.string(),
+          color: z.string(),
+        }),
+      ),
+    }),
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      openWorldHint: false,
+    },
+    view: {
+      name: "product-search-result",
+      description: "Product search results with carousel and details",
+      prefersBorder: true,
+    },
+  },
+  async ({ query = "" }, ctx) => {
+    const results = fruits.filter(
+      (fruit) =>
+        query === "" || fruit.fruit.toLowerCase().includes(query.toLowerCase()),
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    const data = { query, results };
+
+    if (!ctx.client.supportsViews()) {
+      return {
+        content: [{ type: "text", text: renderAsMarkdownTable(results) }],
+        structuredContent: data,
+      };
+    }
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Found ${results.length} fruits matching "${query || "all"}"`,
+        },
+      ],
+      structuredContent: data,
+    };
+  },
+);
+
+export default server;
+```
+
+`view.name` must match the folder under `views/`. In this template, `product-search-result` maps to `views/product-search-result/view.tsx`.
+
+The `structuredContent` object becomes view rendering data via `useToolContext()`. The `content` array is the short text result the model can read.
+
+## Inspect the React view
+
+Open `views/product-search-result/view.tsx`. The view reads the tool result with `useToolContext()`.
+
+The generated view includes a carousel, detail panel, display-mode controls, favorites, and tool calls. This excerpt shows the core data access pattern.
+
+```tsx
+import { useToolContext } from "mcp-use/react";
+
+export default function ProductSearchResult() {
+  const view = useToolContext<"search-fruits">();
+
+  if (view.status === "pending") {
+    return <div className="p-4">Searching…</div>;
+  }
+
+  if (view.status === "error") {
+    return <div className="p-4">{view.error.message}</div>;
+  }
+
+  const { query, results } = view.toolOutput;
+
+  return (
+    <div className="p-4">
+      <h2>
+        Results for "{query || "all"}" ({results.length})
+      </h2>
+      {/* carousel, details, accordion … */}
+    </div>
+  );
+}
+```
+
+Views can render before the tool finishes. Check `view.status === "pending"` before reading `view.toolOutput`.
+
+## Verify in the Inspector
+
+Use the Inspector to confirm that the server and view work.
+
+1. Open `http://localhost:3000/mcp/inspector`.
+2. Go to the **Tools** tab.
+3. Select `search-fruits`.
+4. Run the tool with `{ "query": "a" }` or `{}`.
+5. Confirm that the view renders below the tool result after the loading skeleton.
+
+If the tool runs but no view appears, check that `view.name` exactly matches the folder under `views/` and that the handler returns `structuredContent`.
+
+## Next steps
+
+- Use [`useToolContext()`](https://mcp-use-typescript-api-reference.vercel.app/modules/mcp-use.react.html#usetoolcontext) to read tool input, output, and lifecycle status.
+- Use [`useCallTool()`](https://mcp-use-typescript-api-reference.vercel.app/modules/mcp-use.react.html#usecalltool) when a view needs to call another MCP tool.
+- Configure [Content Security Policy](/v2/typescript/mcp-apps/content-security-policy) before loading external APIs, images, scripts, embeds, or static assets.

--- a/docs/v2/typescript/mcp-apps/widgets.mdx
+++ b/docs/v2/typescript/mcp-apps/widgets.mdx
@@ -1,0 +1,157 @@
+---
+title: "Build widgets"
+description: "Create a React widget and return it from an MCP tool."
+icon: "panel-top"
+---
+
+Build a widget when a tool result needs an interactive UI. In `mcp-use`, a widget has two parts: a React file under `resources/` and a tool that returns `widget({ props, output })`.
+
+## Create the widget file
+
+Create a folder under `resources/`. The folder name becomes the widget name you use from the server.
+
+```text
+resources/
+└── product-results/
+    └── widget.tsx
+```
+
+Define the widget metadata and component in `widget.tsx`:
+
+```tsx
+import { McpUseProvider, useWidget, type WidgetMetadata } from "mcp-use/react";
+import { z } from "zod";
+
+const propSchema = z.object({
+  query: z.string(),
+  results: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+      price: z.number(),
+    }),
+  ),
+});
+
+type ProductResultsProps = z.infer<typeof propSchema>;
+
+export const widgetMetadata: WidgetMetadata = {
+  description: "Display product search results",
+  props: propSchema,
+  exposeAsTool: false,
+};
+
+export default function ProductResults() {
+  const { props, isPending } = useWidget<ProductResultsProps>();
+
+  if (isPending) {
+    return <McpUseProvider>Loading products...</McpUseProvider>;
+  }
+
+  return (
+    <McpUseProvider>
+      <main>
+        <h2>Results for {props.query}</h2>
+        <ul>
+          {props.results.map((product) => (
+            <li key={product.id}>
+              {product.name} - ${product.price}
+            </li>
+          ))}
+        </ul>
+      </main>
+    </McpUseProvider>
+  );
+}
+```
+
+Always guard required `props` behind `isPending`. Widgets mount before the tool result is available.
+
+## Return the widget from a tool
+
+In `index.ts`, add a tool whose `widget.name` matches the folder under `resources/`.
+
+```typescript
+import { MCPServer, text, widget } from "mcp-use/server";
+import { z } from "zod";
+
+const productSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  price: z.number(),
+});
+
+const productResultsSchema = z.object({
+  query: z.string(),
+  results: z.array(productSchema),
+});
+
+const server = new MCPServer({
+  name: "product-search",
+  version: "1.0.0",
+});
+
+async function searchProducts(query: string) {
+  return [{ id: "sku_123", name: `${query} starter kit`, price: 29 }];
+}
+
+server.tool(
+  {
+    name: "search-products",
+    description: "Search products and show the results in a widget",
+    schema: z.object({
+      query: z.string().describe("Search query"),
+    }),
+    outputSchema: productResultsSchema,
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      openWorldHint: true,
+    },
+    widget: {
+      name: "product-results",
+      invoking: "Searching products...",
+      invoked: "Products loaded",
+    },
+  },
+  async ({ query }) => {
+    const results = await searchProducts(query);
+
+    return widget({
+      props: { query, results },
+      output: text(`Found ${results.length} products matching "${query}".`),
+    });
+  },
+);
+```
+
+`props` becomes the widget's rendering data. `output` becomes the text result the model can read in the conversation.
+
+## Keep schemas aligned
+
+The server `outputSchema` should describe the same shape that the widget expects in `props`.
+
+Use a shared schema when the widget and server live in the same package. If you duplicate schemas, keep the field names and optional fields identical.
+
+## Verify the widget
+
+Run the dev server and call the tool in the Inspector:
+
+```bash
+npm run dev
+```
+
+Open `http://localhost:3000/mcp/inspector`, run `search-products`, and confirm the widget renders below the tool result.
+
+If the tool succeeds but no widget renders, check these two values first:
+
+- `widget.name` in `index.ts`
+- the folder name under `resources/`
+
+They must match exactly.
+
+## Next steps
+
+- Use [Model context](/v2/typescript/mcp-apps/model-context) to decide what the model should know about widget state.
+- Use [Interactivity](/v2/typescript/mcp-apps/interactivity) when the widget needs buttons, state, tool calls, or follow-up messages.
+- Use the [`useWidget()` API reference](https://mcp-use-typescript-api-reference.vercel.app/modules/mcp-use.react.html#usewidget) for all hook fields and defaults.

--- a/docs/v2/typescript/server/authentication/index.mdx
+++ b/docs/v2/typescript/server/authentication/index.mdx
@@ -1,0 +1,107 @@
+---
+title: "OAuth"
+description: "Choose and configure OAuth authentication for MCP servers."
+icon: "shield-check"
+---
+
+Configure an OAuth provider when an MCP server must identify callers or authorize access by user, organization, role, scope, or permission. `MCPServer` protects the transport, publishes discovery metadata, verifies bearer tokens, and exposes the verified identity on `ctx.auth`.
+
+## Choose a provider
+
+mcp-use supports resource-server providers whose authorization server supports Dynamic Client Registration (DCR).
+
+| Identity system                          | Provider                                                                  |
+| ---------------------------------------- | ------------------------------------------------------------------------- |
+| Auth0                                    | [Auth0](/v2/typescript/server/authentication/providers/auth0)             |
+| Better Auth                              | [Better Auth](/v2/typescript/server/authentication/providers/better-auth) |
+| Clerk                                    | [Clerk](/v2/typescript/server/authentication/providers/clerk)             |
+| Keycloak                                 | [Keycloak](/v2/typescript/server/authentication/providers/keycloak)       |
+| Supabase                                 | [Supabase](/v2/typescript/server/authentication/providers/supabase)       |
+| WorkOS                                   | [WorkOS](/v2/typescript/server/authentication/providers/workos)           |
+| Another DCR-capable authorization server | [Custom Provider](/v2/typescript/server/authentication/providers/custom)  |
+
+The MCP client registers and performs the authorization flow directly with the authorization server. Your MCP server does not handle authorization codes or exchange them for tokens.
+
+## Configure the server
+
+Import the server from `mcp-use` and the provider from its dedicated OAuth entry point. Provider configuration is explicit; mcp-use does not read provider-specific environment variables.
+
+```typescript
+import { MCPServer } from "mcp-use";
+import { oauthAuth0Provider } from "mcp-use/oauth/auth0";
+
+const domain = process.env.AUTH0_DOMAIN;
+if (!domain) throw new Error("AUTH0_DOMAIN is required");
+
+const server = new MCPServer({
+  name: "secure-server",
+  version: "1.0.0",
+  oauth: oauthAuth0Provider({ domain }),
+});
+
+export default server;
+```
+
+The provider binds token verification to the resolved MCP resource. Set `MCP_URL` to the public server origin in production, or pass the provider's `resource` option when you need an explicit canonical MCP endpoint.
+
+## Authorize a tool
+
+An OAuth-configured server gives tool callbacks a provider-specific `ctx.auth.user`. All providers normalize the stable subject to `id`; additional fields depend on the provider.
+
+```typescript
+server.tool(
+  {
+    name: "get_profile",
+    description: "Return the authenticated caller.",
+  },
+  async (_args, ctx) => {
+    const profile = {
+      id: ctx.auth.user.id,
+      email: ctx.auth.user.email ?? null,
+      scopes: ctx.auth.scopes,
+      permissions: ctx.auth.permissions,
+    };
+
+    return {
+      content: [{ type: "text", text: JSON.stringify(profile) }],
+    };
+  },
+);
+```
+
+`scopes` come from the verified SDK auth information. `permissions` and `user` come from the provider's verified claim mapping. Use [User Context](/v2/typescript/server/authentication/user-context) for the complete shape and authorization patterns.
+
+## What OAuth changes
+
+When `oauth` is configured:
+
+- protected-resource and authorization-server metadata are published for clients;
+- MCP transport requests require a bearer token;
+- invalid, expired, incorrectly resourced tokens, and tokens missing configured `requiredScopes` are rejected before tool code runs;
+- callbacks receive the verified access token, identity, scopes, permissions, expiry, client ID when present, and resource.
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card
+    title="User Context"
+    icon="user"
+    href="/v2/typescript/server/authentication/user-context"
+  >
+    Use verified identity and authorization data inside callbacks.
+  </Card>
+  <Card
+    title="Custom Provider"
+    icon="code"
+    href="/v2/typescript/server/authentication/providers/custom"
+  >
+    Integrate another DCR-capable authorization server.
+  </Card>
+  <Card
+    title="Client Authentication"
+    icon="router"
+    href="/v2/typescript/client/authentication"
+  >
+    Connect a TypeScript MCP client to an OAuth-protected server.
+  </Card>
+</CardGroup>

--- a/docs/v2/typescript/server/authentication/providers/auth0.mdx
+++ b/docs/v2/typescript/server/authentication/providers/auth0.mdx
@@ -1,0 +1,100 @@
+---
+title: "Auth0 Provider"
+description: "Configure Auth0 Dynamic Client Registration authentication for an MCP server."
+icon: "/images/icons/auth0.svg"
+---
+
+Use `oauthAuth0Provider` when Auth0 is the authorization server. MCP clients register directly with Auth0, and mcp-use verifies Auth0 access tokens against the resolved MCP resource.
+
+## Configure Auth0
+
+In the [Auth0 Dashboard](https://manage.auth0.com):
+
+1. Enable the Resource Parameter Compatibility Profile.
+2. Promote the login connections MCP clients may use to domain-level connections.
+3. Create an API whose identifier is the canonical MCP resource, such as `https://mcp.example.com/mcp`.
+4. Use the `rfc9068_profile_authz` token dialect if tools need Auth0 permissions in access tokens.
+
+The API identifier must match the resource that mcp-use resolves for token verification. Auth0 provider options do not include a separate `audience`.
+
+## Configure the server
+
+Treat the environment variable as application configuration and pass `domain` explicitly.
+
+```bash
+AUTH0_DOMAIN=https://your-tenant.us.auth0.com
+MCP_URL=https://mcp.example.com
+```
+
+```typescript
+import { MCPServer } from "mcp-use";
+import { oauthAuth0Provider } from "mcp-use/oauth/auth0";
+
+const domain = process.env.AUTH0_DOMAIN;
+if (!domain) throw new Error("AUTH0_DOMAIN is required");
+
+const server = new MCPServer({
+  name: "auth0-server",
+  version: "1.0.0",
+  oauth: oauthAuth0Provider({ domain }),
+});
+
+export default server;
+```
+
+## Use Auth0 identity and permissions
+
+Auth0 normalizes the subject to `ctx.auth.user.id`. It also maps optional `email`, `name`, `nickname`, `picture`, `emailVerified`, and `updatedAt` fields plus `roles`. Token permissions are available at top-level `ctx.auth.permissions`.
+
+```typescript
+import { z } from "zod";
+
+server.tool(
+  {
+    name: "delete_document",
+    description: "Delete a document with the Auth0 permission.",
+    inputSchema: z.object({ documentId: z.string() }),
+  },
+  async ({ documentId }, ctx) => {
+    if (!ctx.auth.permissions.includes("delete:documents")) {
+      return {
+        isError: true,
+        content: [{ type: "text", text: "Forbidden" }],
+      };
+    }
+
+    await db.documents.delete({ id: documentId });
+    return {
+      content: [{ type: "text", text: `Deleted for ${ctx.auth.user.id}` }],
+    };
+  },
+);
+```
+
+## Verify the setup
+
+Confirm that the client registers with Auth0, the token audience is the resolved MCP resource, invalid tokens are rejected, and permission-protected tools reject callers without the required permission.
+
+<CardGroup cols={2}>
+  <Card
+    title="Runnable Auth0 example"
+    icon="github"
+    href="https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/auth/auth0"
+  >
+    Compare with the maintained Auth0 example.
+  </Card>
+  <Card
+    title="Auth0 MCP Authorization Guide"
+    icon="book-open"
+    href="https://auth0.com/ai/docs/mcp/get-started/authorization-for-your-mcp-server"
+  >
+    Configure Auth0 for MCP authorization.
+  </Card>
+  <Card
+    title="User Context"
+    icon="user"
+    href="/v2/typescript/server/authentication/user-context"
+  >
+    Use normalized Auth0 identity and permissions.
+  </Card>
+</CardGroup>

--- a/docs/v2/typescript/server/authentication/providers/better-auth.mdx
+++ b/docs/v2/typescript/server/authentication/providers/better-auth.mdx
@@ -1,0 +1,104 @@
+---
+title: "Better Auth Provider"
+description: "Use Better Auth's OAuth Provider plugin with an MCP server."
+icon: "/images/icons/better-auth.svg"
+---
+
+Use Better Auth when your application owns the OAuth authorization server.
+Better Auth handles registration, sign-in, consent, and token issuance;
+`mcp-use` advertises those endpoints and verifies the access-token JWTs.
+
+## Configure the MCP resource server
+
+Pass the full Better Auth issuer URL, including its base path:
+
+```typescript
+import { MCPServer } from "mcp-use";
+import { oauthBetterAuthProvider } from "mcp-use/oauth/better-auth";
+
+const server = new MCPServer({
+  name: "better-auth-server",
+  version: "1.0.0",
+  oauth: oauthBetterAuthProvider({
+    authURL: "http://localhost:61843/api/auth",
+    resource: "http://localhost:43127/mcp",
+  }),
+});
+
+export default server;
+```
+
+The provider does not create or mount Better Auth. It derives Better Auth's
+`/oauth2/authorize`, `/oauth2/token`, `/oauth2/register`, and `/jwks` endpoints
+from `authURL`, then verifies JWT issuer, signature, expiration, and MCP
+resource audience.
+
+## Run Better Auth as a separate Hono app
+
+The authorization server can be a separate application and origin. The normal
+`mcp-use` server above owns `/mcp` and its protected-resource metadata; the Hono
+app only mounts Better Auth, its discovery routes, and your login and consent
+pages.
+
+```typescript
+import { serve } from "@hono/node-server";
+import { Hono } from "hono";
+
+import { auth } from "./auth.js";
+
+const app = new Hono();
+
+app.on(["GET", "POST"], "/api/auth/*", (c) => auth.handler(c.req.raw));
+serve({ fetch: app.fetch, port: 61843 });
+```
+
+Because the issuer contains `/api/auth`, also route Better Auth's RFC 8414
+path-insertion metadata endpoint
+`/.well-known/oauth-authorization-server/api/auth` to `auth.handler` or
+`oauthProviderAuthServerMetadata(auth)`. Better Auth's OAuth Provider guide
+documents the required discovery, login, and consent routes. If browser-based
+MCP clients call this separate origin directly, configure Hono CORS for the MCP
+origin and include that origin in Better Auth's `trustedOrigins`.
+
+## Credential-free anonymous example
+
+The repository's [runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/auth/better-auth)
+runs a regular `mcp-use dev` process on port 43127 and a separate Hono/Better
+Auth process on port 61843. It uses anonymous sign-in, so it requires no
+Google/GitHub credentials, email service, or password UI.
+
+For easy local setup, the example omits a database. Better Auth then uses
+stateless cookie sessions and its memory adapter. Anonymous users, dynamic
+clients, codes, and consent reset whenever the process restarts; configure a
+persistent Better Auth database before using the pattern in production.
+
+## Access the verified identity
+
+```typescript
+server.tool({ name: "whoami" }, async (_params, ctx) => ({
+  content: [
+    {
+      type: "text",
+      text: JSON.stringify({
+        id: ctx.auth.user.id,
+        isAnonymous: ctx.auth.user.isAnonymous,
+        scopes: ctx.auth.scopes,
+      }),
+    },
+  ],
+}));
+```
+
+Profile and application-specific access-token fields must be added with Better
+Auth's `customAccessTokenClaims`. The built-in mapper recognizes `email`,
+`name`, `picture`, `email_verified`, `sid`, `is_anonymous`/`isAnonymous`,
+`roles`, and `permissions` when present.
+
+<Card
+  title="Better Auth OAuth Provider"
+  icon="book-open"
+  href="https://better-auth.com/docs/plugins/oauth-provider"
+>
+  Configure Better Auth's OAuth server, discovery routes, claims, and
+  persistence.
+</Card>

--- a/docs/v2/typescript/server/authentication/providers/clerk.mdx
+++ b/docs/v2/typescript/server/authentication/providers/clerk.mdx
@@ -1,0 +1,103 @@
+---
+title: "Clerk Provider"
+description: "Configure Clerk OAuth authentication for an MCP server."
+icon: "/images/icons/clerk.svg"
+---
+
+Use `oauthClerkProvider` when Clerk is the authorization server. MCP clients register directly with Clerk, and mcp-use verifies Clerk-issued access tokens.
+
+## Configure Clerk
+
+In the [Clerk Dashboard](https://dashboard.clerk.com/), enable Dynamic Client Registration for the application and copy its Frontend API URL. Enable and request `user:org:read` when tools need organization context.
+
+Pass the Frontend API URL explicitly:
+
+```bash
+CLERK_FRONTEND_API_URL=https://verb-noun-42.clerk.accounts.dev
+# Optional when Clerk emits a dedicated access-token audience:
+# CLERK_AUDIENCE=https://api.example.com
+```
+
+```typescript
+import { MCPServer } from "mcp-use";
+import { oauthClerkProvider } from "mcp-use/oauth/clerk";
+
+const frontendApiUrl = process.env.CLERK_FRONTEND_API_URL;
+if (!frontendApiUrl) {
+  throw new Error("CLERK_FRONTEND_API_URL is required");
+}
+
+const server = new MCPServer({
+  name: "clerk-server",
+  version: "1.0.0",
+  oauth: oauthClerkProvider({
+    frontendApiUrl,
+    ...(process.env.CLERK_AUDIENCE
+      ? { audience: process.env.CLERK_AUDIENCE }
+      : {}),
+    scopesSupported: ["profile", "email", "offline_access", "user:org:read"],
+  }),
+});
+
+export default server;
+```
+
+`audience` is optional. Set it only when Clerk emits that exact `aud`; when omitted, the provider uses issuer-bound access-token verification.
+
+## Use organization context
+
+Clerk maps `org_id`, `org_role`, and `org_slug` to `organizationId`, `organizationRole`, and `organizationSlug`. Organization permissions are top-level `ctx.auth.permissions`.
+
+```typescript
+server.tool(
+  {
+    name: "list_documents",
+    description: "List documents for the Clerk organization.",
+  },
+  async (_args, ctx) => {
+    const organizationId = ctx.auth.user.organizationId;
+    if (
+      !organizationId ||
+      !ctx.auth.permissions.includes("org:documents:read")
+    ) {
+      return {
+        isError: true,
+        content: [{ type: "text", text: "Organization access required" }],
+      };
+    }
+
+    const documents = await db.documents.findMany({
+      where: { organizationId },
+    });
+    return {
+      content: [{ type: "text", text: JSON.stringify(documents) }],
+    };
+  },
+);
+```
+
+The mapped user also includes `id`, optional `email`, `name`, `username`, `picture`, and `emailVerified`, plus `roles`.
+
+<CardGroup cols={2}>
+  <Card
+    title="Runnable Clerk example"
+    icon="github"
+    href="https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/auth/clerk"
+  >
+    Compare with the maintained Clerk example.
+  </Card>
+  <Card
+    title="Clerk OAuth documentation"
+    icon="book-open"
+    href="https://clerk.com/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth"
+  >
+    Review Clerk OAuth and DCR behavior.
+  </Card>
+  <Card
+    title="User Context"
+    icon="user"
+    href="/v2/typescript/server/authentication/user-context"
+  >
+    Use Clerk identity, organization, and permissions.
+  </Card>
+</CardGroup>

--- a/docs/v2/typescript/server/authentication/providers/custom.mdx
+++ b/docs/v2/typescript/server/authentication/providers/custom.mdx
@@ -1,0 +1,148 @@
+---
+title: "Custom Provider"
+description: "Integrate a DCR-capable OAuth authorization server with an MCP server."
+icon: "code"
+---
+
+Use `oauthCustomProvider` when your authorization server supports Dynamic Client Registration (DCR) but mcp-use does not provide a built-in adapter. The MCP client registers upstream; your server publishes metadata, verifies access tokens, and maps verified claims into application identity.
+
+## Required contract
+
+Import `MCPServer` from `mcp-use` and the provider contract from `mcp-use/oauth`.
+
+```typescript
+import { MCPServer } from "mcp-use";
+import {
+  oauthCustomProvider,
+  type OAuthAuthInfo,
+  type OAuthMetadata,
+} from "mcp-use/oauth";
+import { createRemoteJWKSet, jwtVerify } from "jose";
+
+const issuer = "https://auth.example.com";
+const jwks = createRemoteJWKSet(new URL(`${issuer}/.well-known/jwks.json`));
+
+const oauthMetadata = {
+  issuer,
+  authorization_endpoint: `${issuer}/oauth/authorize`,
+  token_endpoint: `${issuer}/oauth/token`,
+  registration_endpoint: `${issuer}/oauth/register`,
+  response_types_supported: ["code"],
+  grant_types_supported: ["authorization_code", "refresh_token"],
+  code_challenge_methods_supported: ["S256"],
+} satisfies OAuthMetadata;
+
+type AppUser = {
+  id: string;
+  email?: string;
+  organizationId?: string;
+};
+
+const server = new MCPServer({
+  name: "custom-auth-server",
+  version: "1.0.0",
+  oauth: oauthCustomProvider<AppUser>({
+    oauthMetadata,
+
+    createTokenVerifier(resource) {
+      return {
+        async verifyAccessToken(token) {
+          const { payload } = await jwtVerify(token, jwks, {
+            issuer,
+            audience: resource.href,
+          });
+
+          if (!payload.sub || !payload.exp) {
+            throw new Error("Token is missing sub or exp");
+          }
+
+          const scopes =
+            typeof payload.scope === "string"
+              ? payload.scope.split(/\s+/).filter(Boolean)
+              : [];
+
+          return {
+            token,
+            clientId:
+              typeof payload.client_id === "string"
+                ? payload.client_id
+                : typeof payload.azp === "string"
+                  ? payload.azp
+                  : "",
+            scopes,
+            expiresAt: payload.exp,
+            resource,
+            extra: { payload: payload as Record<string, unknown> },
+          };
+        },
+      };
+    },
+
+    mapAuthInfo(authInfo: OAuthAuthInfo) {
+      const payload = authInfo.extra?.payload as Record<string, unknown>;
+      if (typeof payload.sub !== "string") {
+        throw new Error("Verified token is missing sub");
+      }
+
+      return {
+        user: {
+          id: payload.sub,
+          email: typeof payload.email === "string" ? payload.email : undefined,
+          organizationId:
+            typeof payload.organization_id === "string"
+              ? payload.organization_id
+              : undefined,
+        },
+        payload,
+        permissions: Array.isArray(payload.permissions)
+          ? payload.permissions.filter(
+              (value): value is string => typeof value === "string",
+            )
+          : [],
+      };
+    },
+  }),
+});
+
+export default server;
+```
+
+`createTokenVerifier(resource)` receives the resolved canonical MCP resource. The verifier must validate token signature or introspection, issuer, expiry, and that resource, then return SDK auth information including `scopes`, `expiresAt`, and the validated `resource`.
+
+`oauthMetadata` is the authorization server's RFC 8414 metadata. It must describe the actual upstream endpoints and include the `registration_endpoint` used by MCP clients.
+
+`mapAuthInfo(authInfo)` receives only verified SDK auth information. It must return:
+
+- `user`: your provider-specific normalized user, with `id` as the stable subject;
+- `payload`: the verified claims or introspection response;
+- `permissions`: application permissions derived from verified data.
+
+The server exposes those values as `ctx.auth.user`, `ctx.auth.payload`, and `ctx.auth.permissions`. `ctx.auth.scopes` remains the verifier's verified `authInfo.scopes`.
+
+## Verify the integration
+
+Test that:
+
+- the client discovers metadata containing the correct registration endpoint;
+- client registration, PKCE authorization, and token exchange happen upstream;
+- tokens with the wrong issuer, expiry, signature, or MCP resource are rejected;
+- mapped identity and permissions contain only verified data.
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card
+    title="User Context"
+    icon="user"
+    href="/v2/typescript/server/authentication/user-context"
+  >
+    Use the mapped user, scopes, and permissions in callbacks.
+  </Card>
+  <Card
+    title="OAuth overview"
+    icon="shield-check"
+    href="/v2/typescript/server/authentication/index"
+  >
+    Compare built-in providers.
+  </Card>
+</CardGroup>

--- a/docs/v2/typescript/server/authentication/providers/keycloak.mdx
+++ b/docs/v2/typescript/server/authentication/providers/keycloak.mdx
@@ -1,0 +1,102 @@
+---
+title: "Keycloak Provider"
+description: "Configure Keycloak Dynamic Client Registration authentication for an MCP server."
+icon: "/images/icons/keycloak.svg"
+---
+
+Use `oauthKeycloakProvider` when a Keycloak realm is the authorization server. MCP clients register directly with Keycloak, and mcp-use verifies realm-issued access tokens against the resolved MCP resource.
+
+## Prepare Keycloak
+
+Configure Dynamic Client Registration for the hosts used by your MCP clients. Keep redirect URI policies strict, and add browser client origins when browser-based clients require them.
+
+For production, only require Initial Access Tokens after confirming that every intended MCP client can send one during registration. The mcp-use provider verifies tokens; it does not perform registration on the client's behalf.
+
+## Configure the server
+
+`serverUrl` and `realm` are required. They are not read from the environment by the provider.
+
+```bash
+KEYCLOAK_SERVER_URL=https://keycloak.example.com
+KEYCLOAK_REALM=mcp
+MCP_URL=https://mcp.example.com
+```
+
+```typescript
+import { MCPServer } from "mcp-use";
+import { oauthKeycloakProvider } from "mcp-use/oauth/keycloak";
+
+const serverUrl = process.env.KEYCLOAK_SERVER_URL;
+const realm = process.env.KEYCLOAK_REALM;
+if (!serverUrl || !realm) {
+  throw new Error("KEYCLOAK_SERVER_URL and KEYCLOAK_REALM are required");
+}
+
+const server = new MCPServer({
+  name: "keycloak-server",
+  version: "1.0.0",
+  oauth: oauthKeycloakProvider({ serverUrl, realm }),
+});
+
+export default server;
+```
+
+There is no Keycloak provider `audience` option. Verification is bound to the resolved MCP resource, so configure Keycloak to issue access tokens for that resource.
+
+## Use roles and permissions
+
+Realm roles are `ctx.auth.user.roles`. Resource roles are flattened into top-level permissions as `resource:role`.
+
+```typescript
+server.tool(
+  {
+    name: "admin_action",
+    description: "Run an operation for a Keycloak resource administrator.",
+  },
+  async (_args, ctx) => {
+    if (!ctx.auth.permissions.includes("mcp-api:admin")) {
+      return {
+        isError: true,
+        content: [{ type: "text", text: "Forbidden" }],
+      };
+    }
+
+    return {
+      content: [{ type: "text", text: `Allowed ${ctx.auth.user.id}` }],
+    };
+  },
+);
+```
+
+The mapped user also includes optional profile fields and the raw `realmAccess` and `resourceAccess` objects. Prefer normalized `roles` and `permissions`; inspect raw access objects only when the flattened form is insufficient.
+
+## Production checks
+
+- Serve both Keycloak and the MCP server over HTTPS.
+- Configure token audience/resource claims for the canonical MCP endpoint.
+- Restrict DCR according to the capabilities of your MCP clients.
+- Decide whether each tool uses realm roles, flattened resource permissions, or both.
+
+<CardGroup cols={2}>
+  <Card
+    title="Runnable Keycloak example"
+    icon="github"
+    href="https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/auth/keycloak"
+  >
+    Compare with the maintained Keycloak example.
+  </Card>
+  <Card
+    title="Keycloak Client Registration"
+    icon="book-open"
+    href="https://www.keycloak.org/securing-apps/client-registration"
+  >
+    Configure Dynamic Client Registration.
+  </Card>
+  <Card
+    title="User Context"
+    icon="user"
+    href="/v2/typescript/server/authentication/user-context"
+  >
+    Use Keycloak user fields, roles, and permissions.
+  </Card>
+</CardGroup>

--- a/docs/v2/typescript/server/authentication/providers/oauth-proxy.mdx
+++ b/docs/v2/typescript/server/authentication/providers/oauth-proxy.mdx
@@ -1,0 +1,18 @@
+---
+title: "OAuth Proxy support boundary"
+description: "Understand the support boundary for fixed-client OAuth providers."
+icon: "shuffle"
+---
+
+mcp-use does not provide a server-side OAuth proxy factory or implement authorization, callback, token-exchange, or fixed-client brokering routes. This page is intentionally excluded from navigation.
+
+If your identity provider supports Dynamic Client Registration, use a [built-in provider](/v2/typescript/server/authentication/index) or [Custom Provider](/v2/typescript/server/authentication/providers/custom). The MCP client then registers directly with the authorization server, while mcp-use acts only as the protected resource server.
+
+If the provider gives you only a fixed `clientId` and `clientSecret`, deploy a standards-compliant external authorization server or broker that:
+
+- publishes OAuth authorization-server metadata, including a registration endpoint;
+- registers MCP clients and enforces redirect URI and PKCE requirements;
+- performs the upstream authorization and token exchange without exposing the fixed secret;
+- issues or validates tokens bound to the MCP resource.
+
+Point a custom provider at that external authorization server and implement resource-bound token verification. mcp-use has no server-side fixed-client brokering equivalent.

--- a/docs/v2/typescript/server/authentication/providers/supabase.mdx
+++ b/docs/v2/typescript/server/authentication/providers/supabase.mdx
@@ -1,0 +1,133 @@
+---
+title: "Supabase Provider"
+description: "Configure Supabase OAuth 2.1 server authentication for an MCP server."
+icon: "/images/icons/supabase.svg"
+---
+
+Use `oauthSupabaseProvider` when Supabase Auth is the authorization server. Supabase handles login, consent, client registration, and token issuance; mcp-use verifies the resulting access token.
+
+## Configure Supabase
+
+In the [Supabase Dashboard](https://app.supabase.com/):
+
+1. Enable the OAuth 2.1 server and Dynamic OAuth Apps.
+2. Configure a consent-screen route implemented by your application.
+3. Enable at least one user sign-in method.
+4. Copy the project ID and publishable key.
+
+The maintained example includes a consent route and is the best starting point for a complete application.
+
+## Configure the server
+
+Pass either `projectId` for hosted Supabase or `supabaseUrl` for local or self-hosted Supabase. Environment names belong to your application; the provider does not read them.
+
+```bash
+SUPABASE_PROJECT_ID=your-project-ref
+SUPABASE_PUBLISHABLE_KEY=sb_publishable_...
+```
+
+```typescript
+import { MCPServer } from "mcp-use";
+import { oauthSupabaseProvider } from "mcp-use/oauth/supabase";
+
+const projectId = process.env.SUPABASE_PROJECT_ID;
+if (!projectId) throw new Error("SUPABASE_PROJECT_ID is required");
+
+const server = new MCPServer({
+  name: "supabase-server",
+  version: "1.0.0",
+  oauth: oauthSupabaseProvider({ projectId }),
+});
+
+export default server;
+```
+
+By default the provider expects audience `authenticated`. Modern Supabase tokens use ES256 and are verified through the project JWKS. For a legacy HS256 project, pass its secret explicitly:
+
+```typescript
+oauthSupabaseProvider({
+  supabaseUrl: process.env.SUPABASE_URL!,
+  jwtSecret: process.env.SUPABASE_JWT_SECRET,
+  // audience: "authenticated",
+});
+```
+
+`jwtSecret` selects HS256 verification and must be at least 32 bytes. Without it, the provider selects ES256/JWKS verification.
+
+## Use mapped identity
+
+Supabase maps the subject to `id` and can map `email`, `name`, `fullName`, `username`, `avatarUrl`, `role`, `aal`, `amr`, and `sessionId`. It maps the assurance level to top-level permission `aal:<level>`.
+
+## Use Row Level Security
+
+Create the Supabase client per request with the verified access token:
+
+```typescript
+import { createClient } from "@supabase/supabase-js";
+
+const supabaseUrl =
+  process.env.SUPABASE_URL ??
+  `https://${process.env.SUPABASE_PROJECT_ID}.supabase.co`;
+
+server.tool(
+  {
+    name: "list_notes",
+    description: "Return notes visible under Supabase RLS.",
+  },
+  async (_args, ctx) => {
+    const supabase = createClient(
+      supabaseUrl,
+      process.env.SUPABASE_PUBLISHABLE_KEY!,
+      {
+        auth: {
+          persistSession: false,
+          autoRefreshToken: false,
+          detectSessionInUrl: false,
+        },
+        global: {
+          headers: {
+            Authorization: `Bearer ${ctx.auth.accessToken}`,
+          },
+        },
+      },
+    );
+
+    const { data, error } = await supabase.from("notes").select();
+    if (error) {
+      return {
+        isError: true,
+        content: [{ type: "text", text: error.message }],
+      };
+    }
+    return {
+      content: [{ type: "text", text: JSON.stringify(data) }],
+    };
+  },
+);
+```
+
+Use this token-forwarding pattern only for user-scoped operations. Server-owned operations should use a separate credential and explicit authorization.
+
+<CardGroup cols={2}>
+  <Card
+    title="Runnable Supabase example"
+    icon="github"
+    href="https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/auth/supabase"
+  >
+    Start from the maintained server and consent UI.
+  </Card>
+  <Card
+    title="Supabase MCP Authentication"
+    icon="book-open"
+    href="https://supabase.com/docs/guides/auth/oauth-server/mcp-authentication"
+  >
+    Configure Supabase OAuth for MCP.
+  </Card>
+  <Card
+    title="User Context"
+    icon="user"
+    href="/v2/typescript/server/authentication/user-context"
+  >
+    Use mapped Supabase identity and token metadata.
+  </Card>
+</CardGroup>

--- a/docs/v2/typescript/server/authentication/providers/workos.mdx
+++ b/docs/v2/typescript/server/authentication/providers/workos.mdx
@@ -1,0 +1,97 @@
+---
+title: "WorkOS Provider"
+description: "Configure WorkOS AuthKit authentication for an MCP server."
+icon: "/images/workos.svg"
+---
+
+Use `oauthWorkOSProvider` when WorkOS AuthKit is the authorization server. MCP clients register with WorkOS, and mcp-use verifies AuthKit access tokens against the resolved MCP resource.
+
+## Configure WorkOS
+
+In the [WorkOS Dashboard](https://dashboard.workos.com/):
+
+1. Enable Dynamic Client Registration.
+2. Enable Client ID Metadata Document if your MCP clients use it.
+3. Add the canonical MCP endpoint as a Resource Indicator.
+
+For example, if the deployed origin is `https://mcp.example.com` and the default base path is `/mcp`, the resource is `https://mcp.example.com/mcp`.
+
+## Configure the server
+
+Pass the AuthKit subdomain explicitly. The provider does not read WorkOS environment variables and does not accept a separate `audience` option.
+
+```bash
+WORKOS_SUBDOMAIN=your-company.authkit.app
+MCP_URL=https://mcp.example.com
+```
+
+```typescript
+import { MCPServer } from "mcp-use";
+import { oauthWorkOSProvider } from "mcp-use/oauth/workos";
+
+const subdomain = process.env.WORKOS_SUBDOMAIN;
+if (!subdomain) throw new Error("WORKOS_SUBDOMAIN is required");
+
+const server = new MCPServer({
+  name: "workos-server",
+  version: "1.0.0",
+  oauth: oauthWorkOSProvider({ subdomain }),
+});
+
+export default server;
+```
+
+## Scope data by organization
+
+WorkOS maps `org_id` to `organizationId` and the subject to `id`.
+
+```typescript
+server.tool(
+  {
+    name: "list_documents",
+    description: "List documents for the WorkOS organization.",
+  },
+  async (_args, ctx) => {
+    const organizationId = ctx.auth.user.organizationId;
+    if (!organizationId) {
+      return {
+        isError: true,
+        content: [{ type: "text", text: "Organization context required" }],
+      };
+    }
+
+    const documents = await db.documents.findMany({
+      where: { organizationId },
+    });
+    return {
+      content: [{ type: "text", text: JSON.stringify(documents) }],
+    };
+  },
+);
+```
+
+The mapped user also includes optional `email`, `emailVerified`, `name`, `preferredUsername`, `firstName`, `lastName`, `picture`, and `sessionId`, plus `roles`. Verified WorkOS permissions are top-level `ctx.auth.permissions`.
+
+<CardGroup cols={2}>
+  <Card
+    title="Runnable WorkOS example"
+    icon="github"
+    href="https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/auth/workos"
+  >
+    Compare with the maintained WorkOS example.
+  </Card>
+  <Card
+    title="WorkOS AuthKit MCP guide"
+    icon="book-open"
+    href="https://workos.com/docs/authkit/mcp"
+  >
+    Configure AuthKit for MCP.
+  </Card>
+  <Card
+    title="User Context"
+    icon="user"
+    href="/v2/typescript/server/authentication/user-context"
+  >
+    Use WorkOS identity, organization, and permissions.
+  </Card>
+</CardGroup>

--- a/docs/v2/typescript/server/authentication/user-context.mdx
+++ b/docs/v2/typescript/server/authentication/user-context.mdx
@@ -1,0 +1,217 @@
+---
+title: "User Context"
+description: "Use verified OAuth identity inside MCP server callbacks."
+icon: "user"
+---
+
+On a server configured with `oauth`, tool, resource, and prompt callbacks receive verified authentication data on `ctx.auth`. The provider determines the static type of `ctx.auth.user`; there is no generic `UserInfo` shape.
+
+## Auth shape
+
+Every provider exposes this top-level shape:
+
+```typescript
+type OAuthAuth<TUser> = {
+  user: TUser;
+  payload: Record<string, unknown>;
+  accessToken: string;
+  scopes: string[];
+  permissions: string[];
+  clientId?: string;
+  expiresAt: number;
+  resource?: URL;
+};
+```
+
+- `user` is the provider's normalized user type.
+- `payload` contains the verified token claims or introspection data.
+- `accessToken` is the verified bearer token. Forward it only when calling an upstream API on behalf of the user.
+- `scopes` are copied from the auth information returned by the token verifier.
+- `permissions` are produced by the provider's mapping.
+- `clientId` is present when the token has a client identifier.
+- `expiresAt` is a Unix timestamp in seconds.
+- `resource` is the protected resource validated by the verifier.
+
+## Use provider-specific fields
+
+All built-in users have `id`. Optional profile and organization fields vary:
+
+| Provider | Selected normalized fields                                                                                      |
+| -------- | --------------------------------------------------------------------------------------------------------------- |
+| Auth0    | `id`, `email`, `name`, `nickname`, `picture`, `emailVerified`, `updatedAt`, `roles`                             |
+| Clerk    | `id`, `email`, `name`, `username`, `organizationId`, `organizationRole`, `organizationSlug`, `roles`            |
+| Keycloak | `id`, `email`, `name`, `preferredUsername`, `givenName`, `familyName`, `roles`, `realmAccess`, `resourceAccess` |
+| Supabase | `id`, `email`, `name`, `fullName`, `username`, `avatarUrl`, `role`, `aal`, `amr`, `sessionId`                   |
+| WorkOS   | `id`, `email`, `name`, `preferredUsername`, `firstName`, `lastName`, `roles`, `organizationId`, `sessionId`     |
+
+```typescript
+server.tool(
+  {
+    name: "list_documents",
+    description: "List documents for the caller's Clerk organization.",
+  },
+  async (_args, ctx) => {
+    const organizationId = ctx.auth.user.organizationId;
+    if (!organizationId) {
+      return {
+        isError: true,
+        content: [{ type: "text", text: "Organization context required" }],
+      };
+    }
+
+    const documents = await db.documents.findMany({
+      where: { organizationId },
+    });
+    return {
+      content: [{ type: "text", text: JSON.stringify(documents) }],
+    };
+  },
+);
+```
+
+Use normalized fields for application logic. Read `payload` only when you deliberately need a provider claim that is not mapped.
+
+## Check scopes and permissions
+
+Scopes describe OAuth grants. Permissions describe provider-mapped application authorization.
+
+```typescript
+import { z } from "zod";
+
+server.tool(
+  {
+    name: "delete_document",
+    description: "Delete a document when the caller has permission.",
+    inputSchema: z.object({ documentId: z.string() }),
+  },
+  async ({ documentId }, ctx) => {
+    if (!ctx.auth.permissions.includes("documents:delete")) {
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text",
+            text: "Forbidden: documents:delete permission required",
+          },
+        ],
+      };
+    }
+
+    await db.documents.delete({ id: documentId });
+    return { content: [{ type: "text", text: "Document deleted" }] };
+  },
+);
+```
+
+Provider mappings differ: Auth0 and WorkOS map their permission claim, Clerk maps organization permissions, Keycloak flattens resource roles as `client:role`, and Supabase maps AAL to `aal:<level>`.
+
+## Map custom claims
+
+For another authorization server, `oauthCustomProvider` separates verification from application mapping:
+
+```typescript
+import { MCPServer } from "mcp-use";
+import {
+  oauthCustomProvider,
+  type OAuthAuthInfo,
+  type OAuthMetadata,
+} from "mcp-use/oauth";
+
+type AppUser = {
+  id: string;
+  email?: string;
+  organizationId?: string;
+};
+
+const demoAccessToken = process.env.DEMO_ACCESS_TOKEN;
+if (!demoAccessToken) throw new Error("DEMO_ACCESS_TOKEN is required");
+
+const oauthMetadata = {
+  issuer: "https://auth.example.com",
+  authorization_endpoint: "https://auth.example.com/oauth/authorize",
+  token_endpoint: "https://auth.example.com/oauth/token",
+  registration_endpoint: "https://auth.example.com/oauth/register",
+  response_types_supported: ["code"],
+  code_challenge_methods_supported: ["S256"],
+} satisfies OAuthMetadata;
+
+const server = new MCPServer({
+  name: "custom-auth-server",
+  version: "1.0.0",
+  oauth: oauthCustomProvider<AppUser>({
+    oauthMetadata,
+    createTokenVerifier: (resource) => ({
+      async verifyAccessToken(token) {
+        if (token !== demoAccessToken) {
+          throw new Error("Invalid access token");
+        }
+
+        return {
+          token,
+          clientId: "demo-client",
+          scopes: ["profile"],
+          expiresAt: Math.floor(Date.now() / 1000) + 3600,
+          resource,
+          extra: {
+            payload: {
+              sub: "user-123",
+              email: "user@example.com",
+              organization_id: "org-123",
+              permissions: ["documents:read"],
+            },
+          },
+        };
+      },
+    }),
+    mapAuthInfo(authInfo: OAuthAuthInfo) {
+      const payload = authInfo.extra?.payload as Record<string, unknown>;
+      return {
+        user: {
+          id: String(payload.sub),
+          email: typeof payload.email === "string" ? payload.email : undefined,
+          organizationId:
+            typeof payload.organization_id === "string"
+              ? payload.organization_id
+              : undefined,
+        },
+        payload,
+        permissions: Array.isArray(payload.permissions)
+          ? payload.permissions.filter(
+              (value): value is string => typeof value === "string",
+            )
+          : [],
+      };
+    },
+  }),
+});
+```
+
+This fixed-token verifier keeps the example small and is only suitable for local testing. In production, validate the token signature, issuer, expiry, and MCP resource, or introspect an opaque token with the authorization server.
+
+`createTokenVerifier` receives the canonical MCP resource. `mapAuthInfo` runs only after SDK auth information has been verified and must return `{ user, payload, permissions }`. It does not rewrite `ctx.auth.scopes`; those come from the verifier's verified auth info.
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card
+    title="Authentication"
+    icon="shield-check"
+    href="/v2/typescript/server/authentication/index"
+  >
+    Choose and configure an OAuth provider.
+  </Card>
+  <Card
+    title="Custom Provider"
+    icon="code"
+    href="/v2/typescript/server/authentication/providers/custom"
+  >
+    Implement resource-bound token verification and claim mapping.
+  </Card>
+  <Card
+    title="Middleware"
+    icon="layers"
+    href="/v2/typescript/server/middleware"
+  >
+    Apply shared authorization checks.
+  </Card>
+</CardGroup>

--- a/docs/v2/typescript/server/deployment/google.mdx
+++ b/docs/v2/typescript/server/deployment/google.mdx
@@ -1,0 +1,306 @@
+---
+title: "Google Cloud Run"
+description: "Deploy an MCP server to Google Cloud Run"
+icon: "google"
+---
+
+Cloud Run can run a `mcp-use` server as a long-lived Node process. The
+generated CLI scripts build the default-exported server and own the HTTP
+listener.
+
+Cloud Run requires the process to listen on `0.0.0.0` and injects the port in
+`PORT`. The configuration below satisfies both parts of that container
+contract.
+
+## Create the project
+
+Create the server from the beta template:
+
+```bash
+npx create-mcp-use-app@beta zoo-cloud-run \
+  --template mcp-server \
+  --npm \
+  --install \
+  --no-skills
+cd zoo-cloud-run
+```
+
+The generated `package.json` includes these scripts:
+
+```json
+{
+  "scripts": {
+    "build": "mcp-use build",
+    "dev": "mcp-use dev",
+    "start": "mcp-use start",
+    "deploy": "mcp-use deploy",
+    "typecheck": "mcp-use typecheck"
+  }
+}
+```
+
+Replace `index.ts` with this small zoo server:
+
+```typescript
+import { MCPServer } from "mcp-use";
+import { z } from "zod";
+
+const animalSchema = z.object({
+  name: z.string(),
+  species: z.string(),
+  age: z.number().int().nonnegative(),
+  enclosure: z.string(),
+});
+
+type Animal = z.infer<typeof animalSchema>;
+
+const animals: Animal[] = [
+  { name: "Leo", species: "lion", age: 7, enclosure: "Big Cat Plains" },
+  { name: "Nala", species: "lion", age: 6, enclosure: "Big Cat Plains" },
+  { name: "Chilly", species: "penguin", age: 3, enclosure: "Arctic Exhibit" },
+];
+
+const server = new MCPServer({
+  name: "zoo-cloud-run",
+  version: "1.0.0",
+  description: "Look up animals at a fictional zoo",
+  host: "0.0.0.0",
+});
+
+server.tool(
+  {
+    name: "get-animals-by-species",
+    description: "Return all zoo animals of one species",
+    inputSchema: z.object({ species: z.string() }),
+    outputSchema: z.object({ animals: z.array(animalSchema) }),
+  },
+  async ({ species }) => {
+    const matches = animals.filter(
+      (animal) => animal.species.toLowerCase() === species.toLowerCase(),
+    );
+    const result = { animals: matches };
+    return {
+      content: [{ type: "text", text: JSON.stringify(result) }],
+      structuredContent: result,
+    };
+  },
+);
+
+server.tool(
+  {
+    name: "get-animal-details",
+    description: "Return one animal by name",
+    inputSchema: z.object({ name: z.string() }),
+    outputSchema: z.object({ animal: animalSchema.nullable() }),
+    view: { name: "animal-card" },
+  },
+  async ({ name }) => {
+    const animal =
+      animals.find(
+        (candidate) => candidate.name.toLowerCase() === name.toLowerCase(),
+      ) ?? null;
+    const result = { animal };
+    return {
+      content: [
+        {
+          type: "text",
+          text:
+            animal === null
+              ? `No animal named ${name}`
+              : JSON.stringify(animal),
+        },
+      ],
+      structuredContent: result,
+    };
+  },
+);
+
+export default server;
+```
+
+There is no top-level `listen()` call. `npm run dev` and `npm start` import the
+default export and own the listener. At runtime, `mcp-use start` reads Cloud
+Run's `PORT` before falling back to the server configuration.
+
+## Optional: add a View
+
+The `mcp-server` template intentionally has no React UI. Install the View
+dependencies:
+
+```bash
+npm install react react-dom
+npm install --save-dev @types/react @types/react-dom
+```
+
+Create `views/animal-card/view.tsx`:
+
+```tsx
+import { useToolContext } from "mcp-use/react";
+
+export default function AnimalCard() {
+  const view = useToolContext<"get-animal-details">();
+
+  if (view.status === "pending") return <p>Loading animal…</p>;
+  if (view.status === "error") return <p>{view.error.message}</p>;
+  if (view.toolOutput.animal === null) return <p>Animal not found.</p>;
+
+  const animal = view.toolOutput.animal;
+  return (
+    <article>
+      <h2>{animal.name}</h2>
+      <p>
+        {animal.species}, age {animal.age}
+      </p>
+      <p>Enclosure: {animal.enclosure}</p>
+    </article>
+  );
+}
+```
+
+The tool's `view.name` matches the directory under `views/`. A view-bound tool
+must declare `outputSchema` and return matching `structuredContent`; the View
+reads that typed result through `useToolContext`.
+
+Validate the project locally:
+
+```bash
+npm run typecheck
+npm run build
+PORT=8080 npm start
+```
+
+The local endpoint is `http://localhost:8080/mcp`.
+
+## Add a Dockerfile
+
+Create `Dockerfile`:
+
+```dockerfile
+FROM node:22-slim
+
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run typecheck && npm run build
+
+ENV NODE_ENV=production
+CMD ["npm", "start"]
+```
+
+Create `.dockerignore`:
+
+```text
+node_modules
+.git
+.env
+.env.*
+.mcp-use
+```
+
+`npm start` serves `.mcp-use/build/`, binds to the server's `0.0.0.0`
+configuration, and uses the injected `PORT`.
+
+## Configure Google Cloud
+
+Select a project and enable the source-deployment services:
+
+```bash
+gcloud config set project YOUR_PROJECT_ID
+gcloud services enable \
+  run.googleapis.com \
+  artifactregistry.googleapis.com \
+  cloudbuild.googleapis.com
+```
+
+Create a dedicated runtime service account:
+
+```bash
+gcloud iam service-accounts create zoo-mcp-runtime \
+  --display-name="Zoo MCP Cloud Run runtime"
+```
+
+Set the values used by every deploy:
+
+```bash
+PROJECT_ID="$(gcloud config get-value project)"
+REGION="us-central1"
+RUNTIME_SA="zoo-mcp-runtime@${PROJECT_ID}.iam.gserviceaccount.com"
+```
+
+## Deploy a private service
+
+Deploy from source and require an authenticated Cloud Run invoker:
+
+```bash
+gcloud run deploy zoo-mcp-server \
+  --source=. \
+  --region="${REGION}" \
+  --service-account="${RUNTIME_SA}" \
+  --no-allow-unauthenticated
+```
+
+For later revisions, run the same command with the same `--region`,
+`--service-account`, and `--no-allow-unauthenticated` flags. Keeping the
+security-sensitive flags in the repeatable deploy command makes the intended
+IAM posture explicit.
+
+Grant your current Google identity permission to invoke the service:
+
+```bash
+ACCOUNT="$(gcloud config get-value account)"
+gcloud run services add-iam-policy-binding zoo-mcp-server \
+  --region="${REGION}" \
+  --member="user:${ACCOUNT}" \
+  --role="roles/run.invoker"
+```
+
+## Connect with a materialized ID token
+
+Cloud Run ID tokens expire. Generate the settings file immediately before
+starting the client rather than putting shell variable names inside JSON:
+
+```bash
+SERVICE_URL="$(
+  gcloud run services describe zoo-mcp-server \
+    --region="${REGION}" \
+    --format="value(status.url)"
+)"
+ID_TOKEN="$(gcloud auth print-identity-token)"
+mkdir -p "${HOME}/.gemini"
+jq -n \
+  --arg url "${SERVICE_URL}/mcp" \
+  --arg token "${ID_TOKEN}" \
+  '{
+    mcpServers: {
+      "zoo-cloud-run": {
+        httpUrl: $url,
+        headers: { Authorization: ("Bearer " + $token) }
+      }
+    }
+  }' > "${HOME}/.gemini/settings.json"
+```
+
+`jq` writes the actual URL and token values. If the client later receives
+`401 Unauthorized`, generate a fresh token and regenerate the file.
+
+## Verify
+
+Read recent service logs without relying on a fixed log format:
+
+```bash
+gcloud run services logs read zoo-mcp-server \
+  --region="${REGION}" \
+  --limit=20
+```
+
+For lifecycle or resource removal, use the Cloud Run and Google Cloud project
+controls appropriate to your account. This guide intentionally does not run
+broad cleanup commands.
+
+## Platform references
+
+- [Deploy Cloud Run services from source](https://cloud.google.com/run/docs/deploying-source-code)
+- [Cloud Run container runtime contract](https://cloud.google.com/run/docs/container-contract)
+- [Authenticate developers to private services](https://cloud.google.com/run/docs/authenticating/developers)
+- [Bind a View to a tool](/v2/typescript/server/tools#bind-a-view)

--- a/docs/v2/typescript/server/deployment/mcp-use.mdx
+++ b/docs/v2/typescript/server/deployment/mcp-use.mdx
@@ -1,0 +1,195 @@
+---
+title: "Deploy to Manufact Cloud"
+description: "Deploy an MCP server from GitHub to Manufact Cloud"
+icon: "/images/logo-mcp-use.svg"
+---
+
+Manufact Cloud deploys a GitHub-backed `mcp-use` server and provides its
+hosted MCP URL, deployments, logs, environment variables, and client
+connection settings.
+
+## Prerequisites
+
+Before deploying:
+
+- Build the server with `mcp-use`.
+- Commit it to an existing Git repository.
+- Configure `origin` as a supported GitHub repository.
+- Push the branch you intend to deploy.
+- Install the Manufact GitHub App with access to that repository.
+- Sign in to a Manufact organization.
+
+Projects created with `create-mcp-use-app@beta` already contain the `mcp-use`
+executable and a `deploy` script. In another project, install the package:
+
+```bash
+npm install mcp-use@beta
+```
+
+Confirm the repository and branch before deploying:
+
+```bash
+git remote get-url origin
+git branch --show-current
+git status --short
+```
+
+The CLI does not initialize Git, create a repository, commit, push, install
+the GitHub App, or upload local source. Configure those prerequisites first.
+
+## Sign in
+
+```bash
+npx mcp-use login
+npx mcp-use whoami
+```
+
+For a non-interactive environment, use one supported credential flow:
+
+```bash
+npx mcp-use login --api-key "${MCP_USE_API_KEY}" --org YOUR_ORG
+```
+
+or:
+
+```bash
+npx mcp-use login --device-code YOUR_PREAPPROVED_CODE --org YOUR_ORG
+```
+
+`--api-key` and `--device-code` are mutually exclusive.
+
+## Start the first deployment
+
+Run from the server project directory:
+
+```bash
+npx mcp-use deploy --name my-server
+```
+
+The first deploy:
+
+1. Resolves the GitHub repository from `origin`.
+2. Confirms that the Manufact GitHub App can access it.
+3. Creates a Git-backed cloud server and starts a deployment.
+4. Writes the non-secret project link to `.mcp-use/cloud/link.json`.
+5. Prints the server ID, deployment ID, pending status, and dashboard URL.
+
+The command starts the deployment; it does not wait for the build to finish.
+
+<Note>
+  `.mcp-use/cloud/link.json` is the only project-local cloud linkage. Later
+  deploys reuse its organization and server IDs.
+</Note>
+
+## Follow the build
+
+Use the deployment ID printed by `deploy`:
+
+```bash
+npx mcp-use deployments get DEPLOYMENT_ID
+npx mcp-use deployments logs DEPLOYMENT_ID --build --follow
+```
+
+Build-log following is a separate command. Once the deployment is running,
+read its recent runtime logs with:
+
+```bash
+npx mcp-use deployments logs DEPLOYMENT_ID
+```
+
+List deployments when you need to recover an ID:
+
+```bash
+npx mcp-use deployments list --server SERVER_ID
+```
+
+## Redeploy and create another server
+
+With a link file present, this starts another deployment on the linked server:
+
+```bash
+npx mcp-use deploy
+```
+
+Pass `--new` to ignore the existing link and create a separate cloud server:
+
+```bash
+npx mcp-use deploy --new
+```
+
+Use `--yes` only when intentionally accepting non-interactive confirmations:
+
+```bash
+npx mcp-use deploy --new --yes
+```
+
+## Implemented deploy flags
+
+The command accepts:
+
+| Flag                        | Purpose                                              |
+| --------------------------- | ---------------------------------------------------- |
+| `[path]`                    | Project directory; defaults to the current directory |
+| `--org <id-or-slug>`        | Select the Manufact organization                     |
+| `--name <name>`             | Set the server name on creation                      |
+| `--branch <name>`           | Deploy a branch instead of the current branch        |
+| `--root-dir <path>`         | Repository-relative app root                         |
+| `--region <region>`         | Select an API-supported region                       |
+| `--env <KEY=VALUE>`         | Add an environment value; repeatable                 |
+| `--env-file <path>`         | Load environment values from a file                  |
+| `--build-command <command>` | Override the detected build command                  |
+| `--start-command <command>` | Override the detected start command                  |
+| `--dockerfile <path>`       | Use a repository-relative Dockerfile                 |
+| `--new`                     | Create a new server instead of reusing the link      |
+| `--open`                    | Open the dashboard after deployment starts           |
+| `--yes`                     | Accept confirmation prompts                          |
+| `--json`                    | Emit machine-readable output                         |
+
+`--root-dir` and `--dockerfile` must stay inside the repository. Repeated
+`--env` entries override duplicate keys loaded from `--env-file`, and the CLI
+does not echo uploaded values.
+
+Creation settings are applied when a server is created. For an existing
+server, use `mcp-use servers update` for supported mutable settings and
+`mcp-use servers env set` or `unset` for environment changes.
+
+Deployments always use the configured GitHub repository. The command does not
+create a platform-managed repository or upload a local source archive.
+
+## Monorepo example
+
+Deploy one app from an existing GitHub monorepo:
+
+```bash
+npx mcp-use deploy \
+  --name inventory-mcp \
+  --root-dir apps/inventory \
+  --build-command "npm run build" \
+  --start-command "npm start"
+```
+
+Repository-relative paths are resolved from the Git root even when the command
+is run inside the app directory.
+
+## Connect a client
+
+After the deployment is running, copy the exact generated MCP URL from the
+Manufact dashboard. Do not infer a hostname from the server slug; the
+dashboard is authoritative for generated and custom domains.
+
+```bash
+export MCP_URL="PASTE_THE_GENERATED_MCP_URL"
+npx mcp-use client connect production "${MCP_URL}"
+npx mcp-use client production tools list
+```
+
+Use that same exact URL in any other MCP client configuration.
+
+## More cloud operations
+
+- [Creating servers](https://docs.manufact.com/dashboard/servers)
+- [Deployments](https://docs.manufact.com/dashboard/deployments)
+- [Build and runtimes](https://docs.manufact.com/dashboard/build-runtimes)
+- [Environment variables](https://docs.manufact.com/dashboard/environment-variables)
+- [Runtime logs](https://docs.manufact.com/dashboard/logs)
+- [Connecting clients](https://docs.manufact.com/dashboard/connect-clients)

--- a/docs/v2/typescript/server/deployment/supabase.mdx
+++ b/docs/v2/typescript/server/deployment/supabase.mdx
@@ -1,0 +1,288 @@
+---
+title: "Supabase"
+description: "Deploy an MCP server on Supabase Edge Functions"
+icon: "/images/icons/supabase.svg"
+---
+
+Supabase Edge Functions run on a Deno-compatible runtime. `MCPServer` exposes
+the Web-standard `fetch(Request)` boundary needed by that runtime; an Edge
+Function forwards requests to `server.fetch` and does not call `listen()`.
+
+This guide deploys the CLI build output at `.mcp-use/build/index.js`.
+
+## Prerequisites
+
+- A TypeScript MCP server built with `mcp-use`.
+- The Supabase CLI, authenticated with `supabase login`.
+- A Supabase project reference.
+- Node.js 22.22.2 or later to run the `mcp-use` build.
+- Docker only when you choose local Supabase bundling or local function
+  serving. Supabase can also bundle through its API.
+
+Initialize and link Supabase from the server project:
+
+```bash
+supabase init
+supabase login
+supabase link --project-ref YOUR_PROJECT_REF
+supabase functions new mcp-server
+```
+
+## Author the server
+
+The public Edge Function URL contains the gateway prefix
+`/functions/v1/mcp-server`. Give the MCP server a matching full base path so
+the request path seen by `server.fetch` and the client endpoint agree:
+
+```typescript
+// index.ts
+import { MCPServer } from "mcp-use";
+import { z } from "zod";
+
+const server = new MCPServer({
+  name: "supabase-edge-mcp",
+  version: "1.0.0",
+  basePath: "/functions/v1/mcp-server/mcp",
+});
+
+server.tool(
+  {
+    name: "get-city",
+    description: "Return the configured demo city",
+    outputSchema: z.object({ city: z.string() }),
+  },
+  async () => {
+    const result = { city: "San Francisco" };
+    return {
+      content: [{ type: "text", text: result.city }],
+      structuredContent: result,
+    };
+  },
+);
+
+export default server;
+```
+
+The callback returns the raw MCP result envelope. The exported server is
+mounted through `server.fetch` later in this guide.
+
+<Note>
+  If your gateway or custom domain rewrites the function prefix before the
+  request reaches the Edge Function, change `basePath` to the pathname the
+  handler actually receives and use that same pathname in the client URL.
+</Note>
+
+## Build for the Edge Function
+
+The build creates:
+
+```text
+.mcp-use/build/
+├── index.js
+├── manifest.json
+└── views/
+    ├── <view-name>/...
+    └── public/...
+```
+
+If the server has no Views, build normally:
+
+```bash
+npm run typecheck
+npm run build
+```
+
+If it has Views, create a public Supabase Storage bucket such as `widgets`.
+Set its public URL prefix while building so the generated View manifest points
+at Storage:
+
+```bash
+PROJECT_REF="YOUR_PROJECT_REF"
+ASSETS_URL="https://${PROJECT_REF}.supabase.co/storage/v1/object/public/widgets"
+MCP_ASSETS_URL="${ASSETS_URL}" npm run build
+```
+
+Copy the generated server build into the Edge Function:
+
+```bash
+mkdir -p supabase/functions/mcp-server/.mcp-use
+cp -R .mcp-use/build supabase/functions/mcp-server/.mcp-use/
+```
+
+The deployed import target is
+`supabase/functions/mcp-server/.mcp-use/build/index.js`, not a `dist`
+artifact.
+
+## Map npm imports in Deno
+
+The built entry keeps its package imports external. Replace
+`supabase/functions/mcp-server/deno.json` with:
+
+```json
+{
+  "imports": {
+    "mcp-use": "npm:mcp-use@beta",
+    "mcp-use/": "npm:mcp-use@beta/",
+    "zod": "npm:zod@^4.4.3"
+  }
+}
+```
+
+The import map makes Deno resolve the built server's `mcp-use` imports through
+the `npm:mcp-use@beta` package entry point.
+
+Pin the `npm:mcp-use` version to the same version used by the project when
+reproducible builds are required.
+
+## Forward requests to `server.fetch`
+
+Replace `supabase/functions/mcp-server/index.ts`:
+
+```typescript
+import server from "./.mcp-use/build/index.js";
+
+Deno.serve((request) => server.fetch(request));
+```
+
+`server.fetch` returns a Web `Response`, so no Node listener, adapter, or port
+is involved.
+
+## Upload View and public assets
+
+With the default MCP path above, Storage must preserve the URL hierarchy
+embedded by `mcp-use build`:
+
+```text
+widgets/
+└── functions/v1/mcp-server/mcp/
+    └── _mcp-use/
+        ├── views/<view-name>/...
+        └── public/...
+```
+
+For a View named `animal-card`, upload its built files and the public assets:
+
+```bash
+supabase storage cp -r \
+  .mcp-use/build/views/animal-card/ \
+  "ss:///widgets/functions/v1/mcp-server/mcp/_mcp-use/views/animal-card/" \
+  --experimental
+
+supabase storage cp -r \
+  .mcp-use/build/views/public/ \
+  "ss:///widgets/functions/v1/mcp-server/mcp/_mcp-use/public/" \
+  --experimental
+```
+
+Repeat the first command for each View directory. You can use the Supabase
+Dashboard or another supported Storage client instead; the required part is
+the object layout:
+
+- View bundles load from `<basePath>/_mcp-use/views/<name>/...`.
+- Files from the project's `public/` directory load from
+  `<basePath>/_mcp-use/public/...`.
+
+Keep these generated paths intact rather than flattening View and public
+assets into generic bucket directories.
+
+## Build-time, runtime, and CSP values
+
+The three concerns are distinct:
+
+| Value                           | When              | Responsibility                                                                                                                                                                                  |
+| ------------------------------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MCP_ASSETS_URL`                | Build and runtime | CDN/Storage prefix. At build time it rewrites View manifest URLs; at runtime it supplies the public asset base and its origin is added to `resourceDomains`. Use the same value in both places. |
+| `MCP_URL`                       | Runtime           | Public server origin only, such as `https://PROJECT.supabase.co`. It is used for server-origin resolution and added to View `connectDomains`. The endpoint path comes from `basePath`.          |
+| View `csp` or `CSP_*` variables | Authoring/runtime | Allow additional APIs, images, frames, or base URIs used by the View. The server and asset origins do not authorize unrelated external domains.                                                 |
+
+Set the runtime values:
+
+```bash
+supabase secrets set \
+  MCP_URL="https://YOUR_PROJECT_REF.supabase.co" \
+  MCP_ASSETS_URL="https://YOUR_PROJECT_REF.supabase.co/storage/v1/object/public/widgets" \
+  --project-ref YOUR_PROJECT_REF
+```
+
+Use `CSP_URLS` only when intentionally granting the same extra origins to all
+four CSP categories. Prefer the tool's `view.csp` or a category-specific
+variable such as `CSP_CONNECT_DOMAINS` for narrower access.
+
+## Choose gateway authentication
+
+Supabase gateway authentication and MCP authentication are separate layers.
+For a public demo, disable Supabase's gateway JWT check explicitly:
+
+```toml
+[functions.mcp-server]
+verify_jwt = false
+```
+
+For a protected function, keep the gateway check enabled and configure the
+MCP client to send the required Supabase authorization headers. Do not put a
+service-role key in a browser or public MCP client.
+
+## Test and deploy
+
+Check the Deno entry before deployment:
+
+```bash
+deno check supabase/functions/mcp-server/index.ts
+```
+
+Serve locally when Docker is available:
+
+```bash
+supabase functions serve mcp-server
+```
+
+The local MCP endpoint is:
+
+```text
+http://127.0.0.1:54321/functions/v1/mcp-server/mcp
+```
+
+Deploy with the Supabase CLI:
+
+```bash
+supabase functions deploy mcp-server
+```
+
+Use `--use-docker` to force local bundling, or `--use-api` to force
+server-side bundling. Docker is not unconditionally required for deployment.
+
+The hosted endpoint is:
+
+```text
+https://YOUR_PROJECT_REF.supabase.co/functions/v1/mcp-server/mcp
+```
+
+Connect the included MCP client to the same path:
+
+```bash
+MCP_ENDPOINT="https://YOUR_PROJECT_REF.supabase.co/functions/v1/mcp-server/mcp"
+npx mcp-use client connect supabase-edge "${MCP_ENDPOINT}" --no-oauth
+npx mcp-use client supabase-edge tools list
+```
+
+When gateway JWT verification is enabled, pass its authorization header to
+`client connect` with `-H "Authorization: Bearer TOKEN"`.
+
+## Troubleshooting
+
+- **Function 404:** verify the project reference, function name, and that
+  `basePath` matches the full request pathname received by the Edge Function.
+- **MCP route 404:** make sure the client includes the final `/mcp`.
+- **View asset 404:** compare the Storage object hierarchy with
+  `<basePath>/_mcp-use/views/` and `<basePath>/_mcp-use/public/`.
+- **View CSP violation:** add only the missing external origin to `view.csp`
+  or the corresponding `CSP_*` runtime variable, then redeploy.
+- **Bundle too large:** inspect it with `deno info` and try local bundling with
+  `supabase functions deploy mcp-server --use-docker`.
+
+## Platform references
+
+- [Supabase Edge Functions quickstart](https://supabase.com/docs/guides/functions/quickstart)
+- [Supabase function configuration](https://supabase.com/docs/guides/local-development/cli/config)
+- [Supabase Storage public URLs](https://supabase.com/docs/guides/storage/serving/downloads)
+- [MCP Apps Content Security Policy](/v2/typescript/mcp-apps/content-security-policy)

--- a/docs/v2/typescript/server/elicitation.mdx
+++ b/docs/v2/typescript/server/elicitation.mdx
@@ -1,0 +1,153 @@
+---
+title: "Elicitation"
+description: "Request user input from MCP tools with form and URL flows."
+icon: "check"
+---
+
+Elicitation lets a tool return an `input_required` result. A capable client
+collects input and retries the original tool call; the callback runs again with
+the response in its request context.
+
+Use form mode for ordinary structured input and URL mode when values must stay
+on an external site.
+
+## Handle the input-required round
+
+Every call has a stable correlation key, a user-facing message, and either a
+Standard Schema form schema or a URL:
+
+```typescript
+import { MCPServer } from "mcp-use";
+import { z } from "zod";
+
+const server = new MCPServer({
+  name: "deployment-server",
+  version: "1.0.0",
+});
+
+const approvalSchema = z.object({
+  approve: z.boolean().describe("Approve this deployment"),
+  note: z.string().max(200).optional(),
+});
+
+server.tool(
+  {
+    name: "deploy",
+    inputSchema: z.object({
+      environment: z.enum(["staging", "production"]),
+    }),
+    outputSchema: z.object({
+      environment: z.string(),
+      deployed: z.boolean(),
+    }),
+  },
+  async ({ environment }, ctx) => {
+    const approval = await ctx.elicit(
+      "deployment-approval",
+      `Deploy to ${environment}?`,
+      approvalSchema,
+    );
+
+    if (approval.status === "required") {
+      return approval.result;
+    }
+
+    if (approval.status !== "accept" || !approval.data.approve) {
+      return {
+        isError: true,
+        content: [{ type: "text", text: "Deployment was not approved." }],
+      };
+    }
+
+    // Side effects belong after accepted input. This callback ran once before
+    // input was required and now runs again with ctx.inputResponses.
+    await deployments.start(environment, approval.data.note);
+
+    const data = { environment, deployed: true };
+    return {
+      content: [{ type: "text", text: JSON.stringify(data) }],
+      structuredContent: data,
+    };
+  },
+);
+
+export default server;
+```
+
+The stable key correlates the embedded request with the matching value in
+`ctx.inputResponses`. `ctx.elicit()` reads and validates that response for you.
+Invalid accepted form data produces another `required` round.
+
+The result statuses are:
+
+| Status     | Meaning                                                           |
+| ---------- | ----------------------------------------------------------------- |
+| `required` | Return `result` directly so the client can collect input          |
+| `accept`   | Valid form data is available as `data`; URL mode has no form data |
+| `decline`  | The user explicitly refused                                       |
+| `cancel`   | The user dismissed or interrupted the flow                        |
+
+## Form mode
+
+Form mode accepts a Standard Schema that can be converted to JSON Schema. Keep
+forms flat and use primitive fields, enums, and arrays of enum values. Add
+descriptions and refinements before passing the schema to `ctx.elicit()`.
+
+Do not collect passwords, API keys, payment details, or OAuth secrets in form
+mode. Submitted form values pass through the MCP client.
+
+## URL mode
+
+Pass an absolute URL string as the third argument. Keep the external flow's
+state in a trusted backend and look it up with a stable, unguessable handle
+from the original tool input:
+
+```typescript
+const flow = await githubAuth.getOrCreateFlow(connectionId);
+
+const authorization = await ctx.elicit(
+  "github-authorization",
+  "Authorize GitHub access",
+  flow.authorizationUrl,
+);
+
+if (authorization.status === "required") {
+  return authorization.result;
+}
+
+if (authorization.status !== "accept") {
+  return {
+    isError: true,
+    content: [{ type: "text", text: "Authorization was not completed." }],
+  };
+}
+
+const connection = await githubAuth.requireCompleted(flow.id);
+```
+
+URL mode asks the client to open an external flow; it does not return secrets or
+prove that the flow succeeded. `getOrCreateFlow` must return the same
+server-stored flow when the callback reruns with `connectionId`. Verify callback
+state and completion on your own backend before performing a protected action.
+
+## Keep multi-round workflows safe
+
+Because the callback re-runs for each input-required round:
+
+- Perform reads and validation before elicitation as needed.
+- Perform irreversible side effects only after the relevant `accept`.
+- Use a different stable key for each distinct question.
+- Use verified `requestState` when a multi-step workflow needs trusted state.
+- Treat bare `ctx.inputResponses` as untrusted client input if you read it
+  directly.
+
+## Run and test the example
+
+```bash
+cd libraries/typescript/packages/server/examples/elicitation
+pnpm dev
+```
+
+Connect a client that supports form and URL elicitation to
+`http://localhost:3000/mcp`. Test accept, decline, cancel, an invalid form
+response that triggers another round, and the URL callback-verification path.

--- a/docs/v2/typescript/server/examples.mdx
+++ b/docs/v2/typescript/server/examples.mdx
@@ -1,0 +1,80 @@
+---
+title: "Examples"
+description: "Browse maintained MCP server examples by feature."
+icon: "code"
+---
+
+Canonical examples live under
+[`libraries/typescript/packages/server/examples`](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples).
+They use the `mcp-use` package root. The repository's example registry declares
+which projects receive automated client or configuration verification.
+
+## Core protocol and lifecycle
+
+| Example                                                                                                                                                   | What it demonstrates                                                         |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| [`basic`](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/basic)                                               | Tools, a resource, and a prompt                                              |
+| [`conformance`](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/conformance)                                   | Protocol conformance fixtures; use focused examples for application patterns |
+| [`middleware`](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/middleware)                                     | Request-scoped MCP middleware                                                |
+| [`notifications`](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/notifications)                               | `subscriptions/listen` invalidations                                         |
+| [`sampling`](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/sampling)                                         | The stateless server-side sampling boundary                                  |
+| [`security`](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/security)                                         | Host and origin validation                                                   |
+| [`sessionless-lifecycle`](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/sessionless-lifecycle)               | Request-scoped context without session affinity                              |
+| [`elicitation`](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/elicitation)                                   | Form and URL input-required rounds                                           |
+| [`resource-template-completion`](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/resource-template-completion) | Resource-template autocomplete                                               |
+| [`events`](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/events)                                             | Read-only request observers                                                  |
+| [`proxy`](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/proxy)                                               | Composing upstream MCP servers                                               |
+
+## Views
+
+The `views` directory contains complete MCP Apps examples:
+
+- [`views/basic`](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/views/basic)
+- [`views/excalidraw`](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/views/excalidraw)
+- [`views/file-upload`](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/views/file-upload)
+- [`views/story-writer`](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/views/story-writer)
+- [`views/tic-tac-toe`](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/views/tic-tac-toe)
+- [`views/view-state`](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/views/view-state)
+
+## Authentication
+
+Provider examples are under `examples/auth`:
+
+- [`auth0`](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/auth/auth0)
+- [`better-auth`](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/auth/better-auth)
+- [`clerk`](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/auth/clerk)
+- [`keycloak`](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/auth/keycloak)
+- [`supabase`](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/auth/supabase)
+- [`workos`](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/auth/workos)
+
+These projects require credentials and provider tenants, so repository
+verification checks their configuration rather than contacting live providers.
+
+## Runtime and deployment
+
+| Example                                                                                                                             | Target                          |
+| ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| [`nextjs`](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/nextjs)                       | Drop-in Next.js route           |
+| [`nextjs-standalone`](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/nextjs-standalone) | Standalone Next.js application  |
+| [`vercel`](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/vercel)                       | Serverless Web `fetch` handler  |
+| [`railway`](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/railway)                     | Railway deployment              |
+| [`openapi`](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/openapi)                     | Generated tools for weather.gov |
+| [`public-landing`](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/public-landing)       | Public server landing page      |
+
+## Create a project
+
+Choose the template explicitly:
+
+```bash
+npx create-mcp-use-app@beta my-server --template mcp-server
+npx create-mcp-use-app@beta my-app --template mcp-apps
+```
+
+Use `mcp-server` for a protocol server without a view and `mcp-apps` for an
+interactive MCP App.
+
+## External showcases
+
+Community and product showcases are not canonical repository fixtures. Check
+their source, ownership, deployment status, and hosted endpoint before relying
+on them; a repository example is the maintained reference for server behavior.

--- a/docs/v2/typescript/server/index.mdx
+++ b/docs/v2/typescript/server/index.mdx
@@ -1,0 +1,169 @@
+---
+title: "Overview"
+description: "Build MCP servers with tools, resources, prompts, auth, and deployments."
+icon: "list-start"
+---
+
+mcp-use is a full-stack TypeScript framework for MCP Apps. Every app is powered by a stateless `MCPServer` that exposes capabilities to AI clients and can render interactive React Views.
+
+Use this page to understand how the server and Views work together, configure protocol compatibility, and find the guide for each capability.
+
+## What the mcp-use framework provides
+
+- **Stateless request handling:** each MCP request runs independently, so server state belongs in your application storage instead of an MCP session.
+- **Typed server primitives:** tool inputs, tool outputs, and prompt arguments accept Standard Schema-compatible validators with JSON Schema conversion.
+- **MCP App Views:** bind React Views to tools and render interactive results in Claude and ChatGPT.
+- **Authentication and middleware:** verify callers with OAuth and apply shared behavior around HTTP requests or MCP operations.
+- **Inspector-first development:** run, inspect, and hot-reload tools, resources, prompts, and Views locally.
+
+Zod, ArkType, and Valibot implement the required Standard Schema interfaces. Generated projects use Zod, but you can bring another compatible validation library without changing the mcp-use registration API.
+
+## How an MCP App fits together
+
+An MCP App combines server capabilities and Views in one project:
+
+1. `MCPServer` registers tools, resources, prompts, authentication, and middleware.
+2. An AI client such as Claude or ChatGPT calls a tool.
+3. The tool returns model-readable `content` and optional typed `structuredContent`.
+4. When the tool has a `view` binding, the client renders the matching React View with the tool result.
+
+A View is an optional presentation layer for a tool, not a separate project type. The same MCP App can contain tools that render Views and tools that return data without a user interface.
+
+Scaffold the complete MCP App stack:
+
+```bash
+npx create-mcp-use-app@beta inventory-app --template mcp-apps
+```
+
+The [TypeScript quickstart](/v2/typescript/getting-started/quickstart) walks through the generated server, tools, and View. Use [Build your first MCP App](/v2/typescript/mcp-apps/quickstart) for the complete View workflow.
+
+## Build the server foundation
+
+Import `MCPServer` from `mcp-use`, register callbacks separately from their definitions, return MCP wire results, and default-export the server for the CLI.
+
+```typescript
+import { MCPServer } from "mcp-use";
+import { z } from "zod";
+
+const server = new MCPServer({
+  name: "weather-server",
+  version: "1.0.0",
+  description: "Look up the weather for a city",
+  legacy: "stateless",
+});
+
+export const getWeather = server.tool(
+  {
+    name: "get-weather",
+    description: "Return the current weather for a city",
+    inputSchema: z.object({
+      city: z.string().describe("City name, such as Paris"),
+    }),
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      openWorldHint: true,
+    },
+  },
+  async ({ city }) => ({
+    content: [
+      {
+        type: "text",
+        text: `The weather in ${city} is sunny.`,
+      },
+    ],
+  }),
+);
+
+export default server;
+```
+
+`mcp-use dev`, `mcp-use build`, and `mcp-use start` use the default export and own the HTTP listener. A standalone Node.js script can call `await server.listen()` instead.
+
+### Choose protocol compatibility
+
+Set `legacy` on `MCPServer` to decide whether the endpoint accepts older MCP protocol requests.
+
+| Value         | Behavior                                                                                                                                                         |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `"stateless"` | Default. Accept modern requests and serve each 2025-era request independently without creating a session. Legacy GET and DELETE session operations return `405`. |
+| `"reject"`    | Accept only the modern protocol. Older requests fail with an unsupported-protocol-version error.                                                                 |
+
+Use `"stateless"` while clients are migrating. Use `"reject"` when every client connecting to the endpoint supports the modern protocol.
+
+See [`ServerConfig`](https://mcp-use-typescript-api-reference.vercel.app/modules/mcp-use.index.html#serverconfig) for the complete configuration surface.
+
+## Explore server capabilities
+
+| Capability | Use it for                                                                       | Guide                                                        |
+| ---------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| Tools      | Actions, lookups, and workflows with validated inputs and outputs                | [Tools](/v2/typescript/server/tools)                         |
+| Resources  | Discoverable content that clients read by URI                                    | [Resources](/v2/typescript/server/resources)                 |
+| Prompts    | Reusable model instructions with validated arguments                             | [Prompts](/v2/typescript/server/prompts)                     |
+| Views      | Interactive MCP App interfaces rendered from tool results in Claude and ChatGPT  | [MCP Apps](/v2/typescript/mcp-apps)                          |
+| OAuth      | Verified user identity, scopes, and permissions on `ctx.auth`                    | [Authentication](/v2/typescript/server/authentication/index) |
+| Middleware | Shared authorization, logging, rate limiting, request shaping, and observability | [Middleware](/v2/typescript/server/middleware)               |
+
+Tools and prompts accept Standard Schema-compatible validation libraries. Views use exported tool references and `useToolContext()` to infer their input and output types.
+
+## Develop locally
+
+Run the development server from a scaffolded project:
+
+```bash
+npm run dev
+```
+
+The development server starts:
+
+| Route            | Purpose                                                    |
+| ---------------- | ---------------------------------------------------------- |
+| `/mcp`           | MCP endpoint for clients                                   |
+| `/mcp/inspector` | Inspector for testing tools, resources, prompts, and Views |
+
+Keep the Inspector open while editing `index.ts` and files under `views/`. The development server reloads MCP registrations and View assets as they change.
+
+Run the project type check after changing schemas or exported tool references:
+
+```bash
+npm run typecheck
+```
+
+## Next steps
+
+<CardGroup cols={3}>
+  <Card
+    title="TypeScript quickstart"
+    icon="rocket"
+    href="/v2/typescript/getting-started/quickstart"
+  >
+    Scaffold, run, inspect, and deploy a v2 project.
+  </Card>
+  <Card title="Tools" icon="wrench" href="/v2/typescript/server/tools">
+    Define validated tool inputs, outputs, and behavior.
+  </Card>
+  <Card title="MCP Apps" icon="app-window-mac" href="/v2/typescript/mcp-apps">
+    Return interactive React Views from tools.
+  </Card>
+  <Card
+    title="Authentication"
+    icon="shield-check"
+    href="/v2/typescript/server/authentication/index"
+  >
+    Protect the server and access verified caller identity.
+  </Card>
+  <Card
+    title="Middleware"
+    icon="layers"
+    href="/v2/typescript/server/middleware"
+  >
+    Add shared behavior around HTTP and MCP operations.
+  </Card>
+  <Card
+    title="ServerConfig"
+    icon="cog"
+    href="https://mcp-use-typescript-api-reference.vercel.app/modules/mcp-use.index.html#serverconfig"
+  >
+    Configure protocol compatibility, routing, logging, and CORS.
+  </Card>
+</CardGroup>

--- a/docs/v2/typescript/server/middleware.mdx
+++ b/docs/v2/typescript/server/middleware.mdx
@@ -1,0 +1,262 @@
+---
+title: "Middleware"
+description: "Add request-scoped protocol and HTTP middleware to MCP servers."
+icon: "layers"
+---
+
+Middleware runs shared logic around MCP operations and HTTP requests. Use it
+for logging, authorization, request shaping, rate limiting, headers, custom
+routes, and other cross-cutting behavior.
+
+This guide explains where each middleware layer fits and how to apply common
+patterns.
+
+## Choose MCP middleware or Hono middleware
+
+Use MCP middleware when logic depends on a parsed MCP operation. Use Hono
+middleware when logic belongs at the HTTP layer before MCP parsing.
+
+| Need                                                | Use             |
+| --------------------------------------------------- | --------------- |
+| Check which tool is being called                    | MCP middleware  |
+| Filter tool, resource, or prompt lists              | MCP middleware  |
+| Require OAuth scopes for an MCP operation           | MCP middleware  |
+| Add CORS, request logging, or HTTP headers          | Hono middleware |
+| Add health checks, webhooks, or other custom routes | Hono routes     |
+
+MCP middleware patterns use the `mcp:` prefix. Hono middleware uses normal
+`server.use(...)` calls. Both layers are request-scoped, and there is no
+transport session affinity between calls.
+
+## Wrap MCP tool calls
+
+Register MCP middleware with `server.use("mcp:<method>", handler)`. The handler
+receives the parsed operation context and a `next()` function.
+
+```typescript
+import { MCPServer } from "mcp-use";
+import { z } from "zod";
+
+const server = new MCPServer({
+  name: "middleware-server",
+  version: "1.0.0",
+});
+
+server.use("mcp:tools/call", async (ctx, next) => {
+  const startedAt = Date.now();
+  const result = await next();
+  console.log(`${ctx.params.name}: ${Date.now() - startedAt}ms`);
+  return result;
+});
+
+server.tool(
+  {
+    name: "greet",
+    description: "Say hello.",
+    inputSchema: z.object({ name: z.string() }),
+  },
+  async ({ name }) => ({
+    content: [{ type: "text", text: `Hello, ${name}!` }],
+  }),
+);
+
+export default server;
+```
+
+Call `next()` to continue to the next middleware or the operation handler.
+Return its result unless you intentionally replace the response.
+
+## Match the right operation
+
+Use the narrowest pattern that covers the behavior:
+
+| Pattern              | Use it for                                |
+| -------------------- | ----------------------------------------- |
+| `mcp:tools/call`     | Tool execution                            |
+| `mcp:tools/list`     | Tool discovery                            |
+| `mcp:resources/read` | Resource reads                            |
+| `mcp:resources/list` | Resource discovery                        |
+| `mcp:prompts/get`    | Prompt requests                           |
+| `mcp:prompts/list`   | Prompt discovery                          |
+| `mcp:*`              | Every operation wrapped by MCP middleware |
+
+Exact middleware can inspect or replace its method-specific result. The
+`mcp:*` wildcard is pass-through: call `next()` or throw, and do not replace
+the downstream result.
+
+MCP middleware does not wrap initialization, completion, log-level changes,
+or subscription listener requests.
+
+## Read the originating HTTP request
+
+`ctx.request` is the originating Hono `HonoRequest` when the operation came
+from HTTP. Read headers with `ctx.request.header(name)`, the path with
+`ctx.request.path`, and the underlying Web `Request` with `ctx.request.raw`.
+
+```typescript
+server.use("mcp:tools/list", async (ctx, next) => {
+  console.log(ctx.request?.header("user-agent"));
+  return next();
+});
+```
+
+Values set by Hono middleware with `c.set()` are available through `ctx.get()`.
+Client metadata and middleware state belong to the current request only.
+
+## Add an OAuth scope guard
+
+Configure OAuth before reading `ctx.auth`. Middleware on an authenticated
+server receives verified provider identity and scopes.
+
+```typescript
+import { oauthAuth0Provider } from "mcp-use/oauth/auth0";
+
+const domain = process.env.AUTH0_DOMAIN;
+if (!domain) throw new Error("AUTH0_DOMAIN is required");
+
+const authenticatedServer = new MCPServer({
+  name: "protected-server",
+  version: "1.0.0",
+  oauth: oauthAuth0Provider({ domain }),
+});
+
+authenticatedServer.use("mcp:tools/call", async (ctx, next) => {
+  const requiredScope = `tools:call:${ctx.params.name}`;
+
+  if (
+    !ctx.auth.scopes.includes(requiredScope) &&
+    !ctx.auth.scopes.includes("tools:*")
+  ) {
+    throw new Error(`Insufficient scope. Required: ${requiredScope}`);
+  }
+
+  return next();
+});
+```
+
+Use [server authentication](/v2/typescript/server/authentication/index) to
+verify bearer tokens before relying on `ctx.auth`.
+
+## Rate-limit expensive operations
+
+Use middleware when the limit applies to a class of operations instead of one
+tool. Key limits by a verified identity and store distributed counters in a
+shared backend.
+
+```typescript
+authenticatedServer.use("mcp:tools/call", async (ctx, next) => {
+  const key = `user:${ctx.auth.user.id}`;
+
+  if (!(await rateLimiter.take(key, 30, "1m"))) {
+    throw new Error("Rate limit exceeded.");
+  }
+
+  return next();
+});
+```
+
+Use `ctx.auth.clientId` when the limit should apply to an OAuth client rather
+than an end user. Never use a transport session ID, self-reported client
+metadata, or an unverified header as an authorization or rate-limit key.
+
+## Filter discovery results
+
+List middleware receives the item array rather than the protocol envelope:
+
+```typescript
+server.use("mcp:tools/list", async (_ctx, next) => {
+  const tools = await next();
+  return tools.filter((tool) => !tool.name.startsWith("_"));
+});
+```
+
+Keep filtering rules predictable. Hidden tools should not be required for
+normal user workflows.
+
+## Order middleware deliberately
+
+Middleware runs in registration order. The first registered handler is the
+outermost wrapper.
+
+```typescript
+server.use("mcp:*", loggingMiddleware);
+server.use("mcp:tools/call", authorizationMiddleware);
+server.use("mcp:tools/call", rateLimitMiddleware);
+```
+
+A practical order is logging, authorization, rate limiting, then
+operation-specific validation. Logging can observe rejected requests while
+the remaining middleware rejects expensive work early.
+
+## Use Hono middleware and routes
+
+`MCPServer` exposes its Hono application as `server.app`. It also provides
+bound helpers such as `server.use`, `server.get`, `server.post`, and
+`server.delete`.
+
+```typescript
+server.use("*", async (c, next) => {
+  const startedAt = Date.now();
+  const requestId = crypto.randomUUID();
+  await next();
+  c.header("x-request-id", requestId);
+  console.log(`${c.req.method} ${c.req.path}: ${Date.now() - startedAt}ms`);
+});
+
+server.get("/health", (c) => c.json({ ok: true }));
+
+server.app.post("/webhooks/orders", async (c) => {
+  const payload = await c.req.json();
+  await processOrderWebhook(payload);
+  return c.json({ accepted: true }, 202);
+});
+```
+
+Use Hono middleware for raw HTTP policy and custom routes. Use MCP middleware
+when you need `ctx.method`, parsed `ctx.params`, verified `ctx.auth`, or a
+method-specific MCP result.
+
+## Test middleware locally
+
+Run the development server:
+
+```bash
+npx mcp-use dev
+```
+
+Open `http://localhost:3000/mcp/inspector`, then call tools, list resources,
+and request prompts. Verify both allowed and rejected paths, transformed list
+results, response headers, and custom Hono routes.
+
+The
+[maintained middleware example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/middleware)
+includes a runnable tool-call wrapper and a protected discovery request.
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card
+    title="Authentication"
+    icon="shield-check"
+    href="/v2/typescript/server/authentication/index"
+  >
+    Configure OAuth before relying on verified middleware identity.
+  </Card>
+  <Card title="Tools" icon="wrench" href="/v2/typescript/server/tools">
+    Design the tool callbacks that MCP middleware wraps.
+  </Card>
+  <Card
+    title="Notifications"
+    icon="bell"
+    href="/v2/typescript/server/notifications"
+  >
+    Send request-scoped progress, logs, and protocol notifications.
+  </Card>
+  <Card
+    title="Middleware example"
+    icon="github"
+    href="https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/middleware"
+  >
+    Run the maintained middleware server and verification scenario.
+  </Card>
+</CardGroup>

--- a/docs/v2/typescript/server/migration.mdx
+++ b/docs/v2/typescript/server/migration.mdx
@@ -1,0 +1,625 @@
+---
+title: "Migrate a v1 server to v2"
+description: "Migrate mcp-use 1.x servers, widgets, and runtime behavior to the v2 beta."
+icon: "arrow-right-left"
+---
+
+Upgrade an existing `mcp-use` 1.x server by updating the runtime, server entry,
+registrations, request context, security configuration, and widgets.
+
+Most server registrations keep the same concepts and require small syntax
+changes. Widgets require a complete rewrite as MCP App Views.
+
+<Warning>
+  v2 is in beta. Some v1 capabilities do not have v2 equivalents yet. Review the
+  current limitations before upgrading a production server.
+</Warning>
+
+## Migration checklist
+
+<Steps>
+  <Step title="Update the runtime and server entry">
+    Upgrade to Node.js `>=22.22.2`, use ESM, import from `mcp-use`, and
+    default-export the server.
+  </Step>
+  <Step title="Update server registrations">
+    Convert tools, resources, resource templates, and prompts to the
+    definition-plus-callback API and return raw MCP results.
+  </Step>
+  <Step title="Update runtime behavior">
+    Replace session assumptions, request context fields, authentication,
+    notifications, elicitation, middleware, and deployment adapters.
+  </Step>
+  <Step title="Rebuild widgets as Views">
+    Replace the widget file layout, tool binding, result helper, provider,
+    generated helpers, hooks, state model, and asset paths.
+  </Step>
+  <Step title="Review beta limitations and verify">
+    Check whether a missing v1 capability affects the server, then typecheck,
+    build, run, and exercise the migrated project.
+  </Step>
+</Steps>
+
+## Update the runtime and entry point
+
+The current v2 beta requires Node.js `>=22.22.2` and ESM.
+
+```bash
+npm install mcp-use@beta
+```
+
+Import server APIs from `mcp-use`:
+
+```typescript
+import { MCPServer } from "mcp-use";
+
+const server = new MCPServer({
+  name: "inventory-server",
+  version: "2.0.0",
+});
+
+export default server;
+```
+
+Default-export the server from `index.ts`.
+
+## Export every static tool
+
+Assign every statically declared tool to an exported constant. If tools live in
+other modules, re-export them from the server entry:
+
+```typescript
+export const search = server.tool(definition, callback);
+export { getDetails } from "./tools/get-details.js";
+```
+
+Apply this rule to all static tools, not only tools currently bound to or called
+by a View.
+
+The root `mcp-env.d.ts` declaration registers
+`typeof import("<server-entry>")`. Only exported `ToolRef` values participate in
+View typing. This is a live type-only import, not the v1 tool-registry
+generator. `mcp-use dev`, `build`, and `typecheck` create or refresh the
+declaration, but they do not execute the server to generate tool-specific
+types.
+
+If the v1 server registers a tool from a loop, runtime configuration, or an
+OpenAPI document, it cannot export a static `ToolRef`. Call that tool from a
+View with explicit types:
+
+```tsx
+import { useDynamicTool } from "mcp-use/react";
+
+const lookup = useDynamicTool<{ id: string }, { value: string }>("lookup");
+const result = await lookup.callTool({ id: "item-1" });
+```
+
+<Warning>
+  Do not import a server-side `ToolRef` value into a file-based View. The View
+  bundle must not include server code.
+</Warning>
+
+## Migrate tools
+
+Move the callback to the second argument, replace `schema` with
+`inputSchema`, and return a raw MCP result.
+
+```typescript
+// v1
+import { MCPServer, text } from "mcp-use/server";
+
+server.tool({
+  name: "weather",
+  schema: z.object({ city: z.string() }),
+  cb: async ({ city }) => text(await getWeather(city)),
+});
+```
+
+```typescript
+// v2
+import { MCPServer } from "mcp-use";
+
+export const weather = server.tool(
+  {
+    name: "weather",
+    inputSchema: z.object({ city: z.string() }),
+    outputSchema: z.object({ forecast: z.string() }),
+  },
+  async ({ city }) => {
+    const result = { forecast: await getWeather(city) };
+
+    return {
+      content: [{ type: "text", text: JSON.stringify(result) }],
+      structuredContent: result,
+    };
+  },
+);
+```
+
+`schema` remains an alias for `inputSchema` in the current beta, but
+`inputSchema` matches the MCP wire field and is the migration target.
+
+Follow these result rules:
+
+- A successful tool with `outputSchema` must return matching
+  `structuredContent`.
+- An error result may return `isError: true` without structured output.
+- For object-shaped structured output, include a text fallback in `content`.
+- Replace `inputs[]` with a Standard Schema-compatible input schema.
+- Do not chain `server.tool(...).tool(...)`; `tool()` returns a `ToolRef`.
+
+Response helpers such as `text()`, `object()`, `array()`, `image()`, and
+`error()` remain as deprecated upgrade shims. Prefer raw `CallToolResult`,
+`ReadResourceResult`, and `GetPromptResult` envelopes. Native `array()` does not
+preserve the v1 `{ data }` wrapper.
+
+## Migrate resources and templates
+
+Pass the reader as the second argument. A static resource callback receives
+`(uri, ctx)` and returns `contents`:
+
+```typescript
+server.resource(
+  {
+    name: "settings",
+    uri: "app://settings",
+    mimeType: "application/json",
+  },
+  async (uri) => ({
+    contents: [
+      {
+        uri: uri.href,
+        mimeType: "application/json",
+        text: JSON.stringify({ theme: "dark" }),
+      },
+    ],
+  }),
+);
+```
+
+Remove inline `readCallback` and `callbacks` fields.
+
+For resource templates:
+
+- replace nested `resourceTemplate` with top-level `uriTemplate`
+- move `callbacks.complete` to top-level `complete`
+- pass the reader separately as `(uri, params, ctx)`
+- handle inferred template values as `string | string[]`
+- return raw `contents`
+
+```typescript
+server.resourceTemplate(
+  {
+    name: "user",
+    uriTemplate: "users://{id}",
+    complete: {
+      id: async (value) =>
+        ["alice", "bob"].filter((id) => id.startsWith(value)),
+    },
+  },
+  async (uri, { id }) => ({
+    contents: [{ uri: uri.href, text: `User ${String(id)}` }],
+  }),
+);
+```
+
+## Migrate prompts
+
+Keep `schema` for prompt arguments, pass the callback separately, and return
+raw `messages`:
+
+```typescript
+server.prompt(
+  {
+    name: "review",
+    schema: z.object({ code: z.string() }),
+  },
+  async ({ code }) => ({
+    messages: [
+      {
+        role: "user",
+        content: { type: "text", text: `Review this code:\n${code}` },
+      },
+    ],
+  }),
+);
+```
+
+Replace v1 `args[]` and inline `cb`. `completable()` supplies suggestions but
+does not constrain valid values. Apply field refinements before wrapping a
+schema with `completable()`.
+
+## Update request context
+
+v2 request context exists only for the current request. Remove session
+assumptions from client metadata, logging, progress, notifications, and
+elicitation.
+
+| v1                          | v2                                            |
+| --------------------------- | --------------------------------------------- |
+| `ctx.req`                   | `ctx.request`                                 |
+| Node/Web request access     | `ctx.request.raw` for the Web `Request`       |
+| `ctx.log(...)`              | `ctx.sendLog(...)`                            |
+| `ctx.client.supportsApps()` | `ctx.client.supportsViews()`                  |
+| `ctx.user`                  | provider-specific `ctx.auth.user`             |
+| session metadata            | current request's `ctx.client` snapshot       |
+| blocking `ctx.elicit(...)`  | keyed input-required round trip               |
+| `ctx.sample(...)`           | no server-side equivalent in the current beta |
+
+`ctx.client.info()`, `capabilities()`, `can()`, `extension()`, and `user()`
+return client-declared request hints. Never use them for authorization. Use
+verified `ctx.auth` data for identity and permissions.
+
+### Send notifications on the correct channel
+
+v2 supports custom notifications during an active request:
+
+```typescript
+await ctx.sendNotification("com.example/import-status", {
+  status: "started",
+});
+```
+
+Await the notification before the callback returns. It travels on the
+originating request's response stream and cannot notify that client after the
+request finishes.
+
+Use the standard request-scoped and subscription APIs for their specific jobs:
+
+```typescript
+await ctx.reportProgress(50, 100, "Halfway");
+await ctx.sendLog("info", "Import is halfway complete");
+
+await server.notifyToolsChanged();
+await server.notifyPromptsChanged();
+await server.notifyResourcesChanged();
+await server.notifyResourceUpdated("app://settings");
+```
+
+The server helpers notify matching active subscription listeners. They do not
+provide arbitrary broadcast or session-targeted push.
+
+### Make elicitation replay-safe
+
+v2 elicitation returns an input-required result and re-runs the handler when
+the client supplies input:
+
+```typescript
+const response = await ctx.elicit(
+  "confirm-booking",
+  "Book this flight?",
+  z.object({ confirmed: z.boolean() }),
+);
+
+if (response.status === "required") {
+  return response.result;
+}
+
+if (response.status !== "accept" || !response.data.confirmed) {
+  return { content: [{ type: "text", text: "Cancelled" }] };
+}
+
+// Perform the side effect only after accepted, validated input is present.
+```
+
+Use a stable key. Assume the handler can run more than once. Do not perform a
+side effect before accepted input is available.
+
+## Rebuild widgets as MCP App Views
+
+Legacy widgets require a full UI migration. File discovery, binding, tool
+results, component lifecycle, hooks, state, assets, and typing all changed.
+
+### Move the files and binding
+
+| v1                            | v2                                                |
+| ----------------------------- | ------------------------------------------------- |
+| `resources/<name>/widget.tsx` | `views/<name>/view.tsx`                           |
+| tool `widget: { name, ... }`  | tool `view: { name, ... }`                        |
+| `widget(...)` result helper   | raw `{ content, structuredContent, _meta? }`      |
+| `widget({ props })`           | result `_meta`, read with `useToolContext().meta` |
+| manual `uiResource`           | generated MCP App resource                        |
+| `McpUseProvider`              | framework bootstrap; no aggregate provider        |
+| `generateHelpers()`           | exported `ToolRef` values through `mcp-env.d.ts`  |
+
+Move data previously passed as `props` to the tool result's `_meta` field.
+Access it from `useToolContext().meta` in the View. `_meta` is View-only and is
+not validated or typed by `outputSchema`; validate or narrow it before use.
+
+Keep `structuredContent` for output that matches `outputSchema` and should also
+be visible to the model.
+
+The bound tool must:
+
+- export its `ToolRef`
+- declare an `outputSchema`
+- return matching `structuredContent`
+- move v1 `widget({ props })` data to result `_meta`
+- return useful text `content` for the model and text-only hosts
+- bind to exactly one View with `view: { name }`
+
+Each View can bind to at most one server tool. Create another View when a
+second tool needs a rendered result. Keep helper tools viewless and call them
+from the View with `useCallTool()`.
+
+Move resource facts such as `description`, `csp`, `permissions`, `domain`, and
+`prefersBorder` into the bound tool's `view` configuration. Remove v1
+`invoking`, `invoked`, and `widgetAccessible`; the native View configuration
+does not emit those OpenAI-specific overlay fields.
+
+```typescript
+export const search = server.tool(
+  {
+    name: "search",
+    inputSchema: z.object({ query: z.string() }),
+    outputSchema: z.object({
+      count: z.number(),
+    }),
+    view: {
+      name: "results",
+      description: "Search results",
+      prefersBorder: true,
+    },
+  },
+  async ({ query }) => {
+    const items = await searchItems(query);
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Found ${items.length} matching items`,
+        },
+      ],
+      structuredContent: { count: items.length },
+      _meta: { items },
+    };
+  },
+);
+```
+
+### Replace widget hooks
+
+Default-export the View component. It mounts once while the host connects and
+while tool input and result notifications arrive.
+
+```tsx
+import { useToolContext } from "mcp-use/react";
+
+type ResultsMeta = {
+  items: Array<{ id: string; name: string }>;
+};
+
+export default function ResultsView() {
+  const view = useToolContext<"search">();
+
+  if (view.status === "pending") {
+    return <div>Searching for {view.toolInput?.query ?? "items"}…</div>;
+  }
+
+  if (view.status === "error") {
+    return <div role="alert">{view.error.message}</div>;
+  }
+
+  const meta = view.meta as ResultsMeta | undefined;
+  const items = meta?.items ?? [];
+
+  return (
+    <ul>
+      {items.map((item) => (
+        <li key={item.id}>{item.name}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+Use the focused v2 surface:
+
+| v1                                 | v2                                                            |
+| ---------------------------------- | ------------------------------------------------------------- |
+| `useWidget()` / `useWidgetProps()` | `useToolContext<"tool-name">()`                               |
+| `useWidgetState()`                 | `useViewState(objectDefault)`                                 |
+| `useWidgetTheme()`                 | `useViewTheme()`                                              |
+| `WidgetControls`                   | `ViewControls`                                                |
+| widget `callTool`                  | `useCallTool()`                                               |
+| widget `sendFollowUpMessage`       | `useSendFollowUp()`                                           |
+| widget `openExternal`              | `useOpenExternal()`                                           |
+| widget display mode fields         | `useDisplayMode()`                                            |
+| `<McpUseProvider autoSize>`        | remove the provider; automatic resizing is enabled by default |
+
+`viewConfig` supports `autoResize` and `displayModes`. Both values below are
+the defaults, so omit the export when they are correct for the View:
+
+```tsx
+import type { ViewConfig } from "mcp-use/react";
+
+export const viewConfig = {
+  autoResize: true,
+  displayModes: ["inline", "fullscreen", "pip"],
+} satisfies ViewConfig;
+```
+
+`displayModes` must include `"inline"`. Use `useSendSizeChanged()` only when
+`autoResize` is `false` and the View reports its size manually.
+
+Compose optional presentation components such as `ThemeProvider`,
+`ViewControls`, and your own error boundary. The framework owns the connection,
+bootstrap, and required top-level error boundary.
+
+### Migrate View state and model context
+
+`useViewState()` requires an object default and shares one JSON-serializable
+snapshot across the mounted View. The state is model-visible.
+
+ChatGPT can restore View state across View lifetimes. Other MCP Apps hosts keep
+the state only for the current iframe lifetime.
+
+Use `ModelContext` or `modelContext` for model-visible natural-language context.
+Use `useSendFollowUp()` to trigger a new model turn. Keep presentation-only
+state in ordinary React state.
+
+`useFiles()` keeps the upload/download capability check, but it no longer
+accepts the v1 `modelVisible` option or mutates widget state automatically.
+
+### Update View assets
+
+Native View documents are generated MCP resources. Do not register
+`uiResource()` or serve a separate HTML document.
+
+| Asset                   | v2 location                             |
+| ----------------------- | --------------------------------------- |
+| View source             | `views/<name>/view.tsx`                 |
+| Production View bundles | `${basePath}/_mcp-use/views/<name>/...` |
+| Public files            | `${basePath}/_mcp-use/public/...`       |
+| View resource URI       | `ui://views/<name>.html`                |
+
+Move existing widget CSP domains to `view.csp`.
+
+## Update authentication, proxies, and security
+
+Native v2 acts as an OAuth resource server backed by an external authorization
+server. Import provider adapters from `mcp-use/oauth/*`, supply their required
+locator options, and use the provider-specific `ctx.auth.user` type.
+
+Replace generic `userId` assumptions with the provider's mapped field, commonly
+`id`. Replace `getAuth`, `hasScope`, and `requireScope` with verified
+`ctx.auth`, scopes, permissions, and application authorization checks.
+
+OAuth proxy or authorization-server mode has no native v2 migration. Do not
+translate `oauthProxy`, `jwksVerifier`, or `mountOAuthProxy` as resource-server
+configuration.
+
+v2 upstream composition accepts HTTP remotes or a ready compatible client
+connection. A v1 stdio child-process proxy requires an architecture change.
+
+### Preserve security semantics explicitly
+
+The name `allowedOrigins` changed meaning:
+
+| Security control                         | v1                       | v2               |
+| ---------------------------------------- | ------------------------ | ---------------- |
+| Host-header and DNS-rebinding allowlist  | `allowedOrigins`         | `allowedHosts`   |
+| Reject untrusted browser request origins | Not separate             | `allowedOrigins` |
+| Browser response access                  | Permissive CORS behavior | Explicit `cors`  |
+
+Map v1 CORS `allowMethods` and `allowHeaders` to v2 `methods` and
+`allowedHeaders`. Test Host rejection, Origin rejection, and CORS separately.
+
+Use `basePath` for the MCP route. Set `MCP_URL` for the externally visible
+server origin.
+
+## Review current beta limitations
+
+The following v1 capabilities do not currently have direct v2 equivalents.
+Update the application design where one of these limitations affects your
+server.
+
+### Server lifecycle and transport
+
+- Session stores, active-session registries, stream managers, session recovery,
+  and session affinity are not part of v2.
+- Arbitrary session-targeted and post-response push are not available.
+  Request-scoped custom notifications and subscription invalidations remain
+  available.
+- Server-to-client sampling through `ctx.sample()` is not available.
+- The v1 roots-changed callback surface is not available.
+- Express and Connect adapters are not available. Use Hono or `server.fetch`.
+- Stdio serving and stdio child-process proxy configuration do not have a
+  native migration path.
+- CommonJS and unsupported Node.js versions are intentional compatibility
+  breaks, not beta bugs.
+
+Move durable state to application storage keyed by verified user, tenant, or an
+explicit domain handle. Do not key business state to an MCP transport session.
+
+### OAuth, proxy, and OpenAPI
+
+- OAuth proxy and authorization-server mode are deferred. Direct
+  resource-server authentication is implemented.
+- Unsigned token bypasses such as `verifyJwt: false` are not supported.
+- Verify proxy requirements for upstream OAuth, templates, completions,
+  subscriptions, list synchronization, sampling, and elicitation before
+  migrating.
+- Verify OpenAPI servers that depend on external references, cookies, non-JSON
+  request bodies, callbacks, webhooks, or automatic security-scheme discovery.
+
+### Views
+
+- Each View can bind to at most one server tool.
+- A bound tool requires `outputSchema` and matching `structuredContent`.
+- Static typing sees exported `ToolRef` values only.
+- Cross-lifetime `useViewState()` restoration is host-specific.
+- `useFiles()` is host-specific and must be capability-checked.
+- View resource facts are static per bound tool. v2 has no supported hook for
+  rewriting `domain` or other View resource metadata per client.
+- Raw `uiResource`, `@mcp-ui/server` adapters, `exposeAsTool`, and a shared View
+  bound to multiple server tools have no native equivalent.
+
+## Use the compatibility bridge only for staging
+
+Existing servers can temporarily keep:
+
+```typescript
+import { MCPServer, text } from "mcp-use/server";
+```
+
+The deprecated bridge supports common v1 tools, resources, prompts, middleware,
+direct built-in OAuth providers, OpenAPI servers, response helpers, and one
+tool per legacy widget.
+
+The bridge does not provide sessions, sampling, post-response or
+session-targeted notifications, blocking elicitation, OAuth proxying, stdio
+proxying, raw UI resources, array-style schemas, unsigned-token bypasses, or a
+widget shared by multiple bound tools.
+
+Treat every bridge import as unfinished migration work. The bridge is planned
+for removal in mcp-use v3.
+
+## Verify the migration
+
+<Steps>
+  <Step title="Run a real TypeScript check">
+    Run `mcp-use typecheck`, `npm run typecheck`, or the project's actual `tsc
+    --noEmit` command. `mcp-use build` bundles code but does not prove that v1
+    APIs are type-compatible.
+  </Step>
+  <Step title="Build and start the production output">
+    Run the project's production build, start the built server, and confirm the
+    expected MCP route and public asset routes.
+  </Step>
+  <Step title="Exercise server primitives">
+    Call at least one tool, read a static resource, complete and read a resource
+    template, and get a prompt with a real client.
+  </Step>
+  <Step title="Render every View state">
+    Verify pending, ready, and error states; matching structured output; theme;
+    display mode; sizing; CSP; and public assets in a capable host.
+  </Step>
+  <Step title="Test security and authentication">
+    Check a valid token, missing or invalid scopes, mapped user data, Host
+    rejection, Origin rejection, and browser CORS behavior.
+  </Step>
+  <Step title="Preserve behavioral coverage">
+    Keep existing runtime assertions as runtime assertions. If v2 does not
+    support a tested behavior, leave that limitation explicit instead of
+    replacing the test with source-text or artifact assertions.
+  </Step>
+  <Step title="Remove v1 leftovers">
+    Remove remaining v1 imports, helpers, widget files, session APIs, sampling
+    calls, stdio proxy configuration, and old security fields. Keep a
+    `mcp-use/server` import only when you intentionally use the temporary
+    compatibility bridge.
+  </Step>
+</Steps>
+
+## Continue with the v2 guides
+
+- [Server overview](/v2/typescript/server) explains the stateless server model.
+- [Tools](/v2/typescript/server/tools), [Resources](/v2/typescript/server/resources),
+  and [Prompts](/v2/typescript/server/prompts) cover each registration API.
+- [MCP Apps](/v2/typescript/mcp-apps) covers View authoring and host behavior.
+- [Authentication](/v2/typescript/server/authentication/index) covers direct
+  OAuth resource-server configuration.
+- [Notifications](/v2/typescript/server/notifications) separates request-scoped
+  messages from subscription invalidations.

--- a/docs/v2/typescript/server/migration.mdx
+++ b/docs/v2/typescript/server/migration.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Migrate a v1 server to v2"
+title: "Migrating to v2"
 description: "Migrate mcp-use 1.x servers, widgets, and runtime behavior to the v2 beta."
 icon: "arrow-right-left"
 ---

--- a/docs/v2/typescript/server/nextjs-drop-in.mdx
+++ b/docs/v2/typescript/server/nextjs-drop-in.mdx
@@ -1,0 +1,201 @@
+---
+title: Next.js
+description: Run mcp-use inside a Next.js route or beside a Next.js application as a standalone server.
+icon: "layers"
+---
+
+mcp-use supports two intentionally separate Next.js topologies:
+
+| Topology   | HTTP owner            | Choose it when                                                  |
+| ---------- | --------------------- | --------------------------------------------------------------- |
+| Embedded   | Next.js Route Handler | The website and MCP endpoint should deploy as one application.  |
+| Standalone | `mcp-use dev/start`   | MCP needs its own process, port, deployment, or scaling policy. |
+
+Both use the same V2 `MCPServer`, tool, and view APIs. Neither requires an MCP configuration file.
+
+## Embedded in Next.js
+
+The Next.js adapter mounts MCP at a Route Handler. `withMcpUse` integrates view compilation, public assets, output tracing, and CORS with the Next.js build; `createNextHandler` exposes the server over HTTP. Restart `next dev` after changing the MCP server or a view so its startup build runs again.
+
+<Steps>
+  <Step title="Install mcp-use">
+
+    ```bash
+    pnpm add mcp-use zod
+    ```
+
+  </Step>
+  <Step title="Export the MCP server">
+
+    ```typescript mcp-server.ts
+    import { MCPServer } from "mcp-use";
+    import { z } from "zod";
+
+    const server = new MCPServer({
+      name: "my-next-app",
+      version: "1.0.0",
+      basePath: "/api/mcp",
+    });
+
+    server.tool(
+      {
+        name: "greet",
+        description: "Greet a person",
+        inputSchema: z.object({ name: z.string() }),
+      },
+      async ({ name }) => ({
+        content: [{ type: "text", text: `Hello, ${name}!` }],
+      }),
+    );
+
+    export default server;
+    ```
+
+    Export the server without calling `listen()`. Next.js owns the HTTP listener.
+
+  </Step>
+  <Step title="Enable the Next.js integration">
+
+    ```typescript next.config.ts
+    import type { NextConfig } from "next";
+    import { withMcpUse } from "mcp-use/next";
+
+    const nextConfig: NextConfig = {};
+
+    export default withMcpUse(nextConfig, {
+      entry: "./mcp-server.ts",
+      basePath: "/api/mcp",
+    });
+    ```
+
+  </Step>
+  <Step title="Add the Route Handler">
+
+    Use an optional catch-all because mcp-use serves the MCP endpoint and nested view assets from the same subtree:
+
+    ```typescript app/api/mcp/[[...path]]/route.ts
+    import server from "@/mcp-server";
+    import { createNextHandler } from "mcp-use/next";
+
+    export const { GET, POST, DELETE, OPTIONS } = createNextHandler(server);
+    ```
+
+    If the server is at the project root and your `@/*` alias only maps `src/*`, use the appropriate relative import or move the server under `src/`.
+
+  </Step>
+</Steps>
+
+Use normal Next.js scripts:
+
+```json package.json
+{
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  }
+}
+```
+
+Run `pnpm dev`, open the Next.js page, and connect an MCP client to `http://localhost:3000/api/mcp`.
+
+The complete example at [`packages/server/examples/nextjs`](https://github.com/mcp-use/mcp-use/tree/beta/libraries/typescript/packages/server/examples/nextjs) also shows a view that imports a component used by the Next.js landing page and an image from the application's `public` directory.
+
+## Standalone beside Next.js
+
+The generic standalone CLI can run inside any TypeScript project, including a Next.js monorepo. It uses the project `tsconfig.json`, so the MCP server and its views can reuse project aliases, ordinary services, and browser-safe components.
+
+<Steps>
+  <Step title="Create an MCP source directory">
+
+    ```text
+    src/
+    ├── app/
+    ├── components/
+    ├── lib/
+    └── mcp/
+        ├── server.ts
+        └── views/
+            └── status-card/
+                └── view.tsx
+    ```
+
+  </Step>
+  <Step title="Export the server">
+
+    ```typescript src/mcp/server.ts
+    import { MCPServer } from "mcp-use";
+    import { getStatus } from "@/lib/status-service";
+
+    const server = new MCPServer({
+      name: "my-next-app",
+      version: "1.0.0",
+    });
+
+    // Register tools and views. Tool code may call ordinary shared services.
+
+    export default server;
+    ```
+
+    Do not call `listen()`. The mcp-use CLI owns the standalone listener.
+
+  </Step>
+  <Step title="Add separate scripts">
+
+    ```json package.json
+    {
+      "scripts": {
+        "next:dev": "next dev --port 3000",
+        "next:build": "next build",
+        "next:start": "next start --port 3000",
+        "mcp:dev": "mcp-use dev --mcp-dir src/mcp --port 3001",
+        "mcp:build": "mcp-use build --mcp-dir src/mcp",
+        "mcp:start": "mcp-use start"
+      }
+    }
+    ```
+
+  </Step>
+</Steps>
+
+Run `pnpm next:dev` and `pnpm mcp:dev` in separate terminals. The website is available at `http://localhost:3000`; the independent MCP endpoint is available at `http://localhost:3001/mcp`.
+
+### Split monorepo
+
+When the MCP source is outside the Next.js package, select the host project explicitly:
+
+```bash
+mcp-use dev \
+  --path apps/web \
+  --entry ../mcp/src/server.ts \
+  --views-dir ../mcp/src/views \
+  --port 3001
+```
+
+`--path` selects the project root used for `package.json`, `.env`, and `tsconfig.json`. `--entry` and `--views-dir` are resolved relative to that root. The same flags work with `mcp-use build`; start the generated production server with `mcp-use start --path apps/web`.
+
+The complete example is at [`packages/server/examples/nextjs-standalone`](https://github.com/mcp-use/mcp-use/tree/beta/libraries/typescript/packages/server/examples/nextjs-standalone).
+
+## Sharing code safely
+
+When the standalone CLI detects a Next.js host project, it loads the Next.js environment cascade and provides compatibility shims for common server-only imports. Shared services that import `server-only`, `next/cache`, or `next/headers` can load, but the shims do not invent a website request: `headers()` and `cookies()` are empty, and cache invalidation is a no-op. Pass required identity or request data through MCP authentication and request context.
+
+MCP App views run in a browser iframe. A view may import browser-safe components from the Next.js project, but it must not import Server Components or modules that depend on `server-only`, `next/headers`, a database client, the filesystem, or other server-only APIs. Fetch data in the tool and return it to the view as `structuredContent`.
+
+## CLI discovery
+
+`--mcp-dir src/mcp` discovers the first supported server entry in that directory and uses `src/mcp/views` for views. An explicit `--entry` overrides entry discovery; `--views-dir` overrides the view directory. The project does not need `mcp.config.ts`.
+
+## Verification
+
+For either topology, verify the complete contract rather than only checking that a port is open:
+
+1. Build the project in production mode.
+2. Initialize an MCP session with `@mcp-use/client`.
+3. List tools and confirm the expected names and schemas.
+4. Call every example tool and assert its text and `structuredContent`.
+5. Read each view URI from tool metadata and assert that its HTML resource loads.
+6. Load every generated JavaScript, stylesheet, and public asset referenced by the view.
+7. For embedded mode, also request the Next.js landing page and verify browser CORS preflight against `/api/mcp`.
+
+Both repository examples expose `pnpm verify`, which performs their MCP assertions with the mcp-use client. The embedded example additionally verifies its Next.js landing page and nested public asset route; the standalone example should also pass `pnpm next:build`.

--- a/docs/v2/typescript/server/notifications.mdx
+++ b/docs/v2/typescript/server/notifications.mdx
@@ -1,0 +1,151 @@
+---
+title: "Notifications"
+description: "Send request-scoped and subscription notifications from MCP servers."
+icon: "bell"
+---
+
+Notifications are one-way MCP messages. In the stateless 2026 protocol, a
+server can send notifications related to an active request or publish the
+standard list and resource changes that clients requested through
+`subscriptions/listen`.
+
+There is no session-targeted or arbitrary post-response push channel. Keep
+custom status notifications inside the tool, resource, or prompt callback that
+owns the active response stream.
+
+## Choose the notification path
+
+| Need                                                  | Use                                 |
+| ----------------------------------------------------- | ----------------------------------- |
+| Send a custom notification during the current request | `ctx.sendNotification(...)`         |
+| Report progress for the current request               | `ctx.reportProgress(...)`           |
+| Send a request-scoped MCP log message                 | `ctx.sendLog(...)`                  |
+| Tell subscribed clients that tools changed            | `server.notifyToolsChanged()`       |
+| Tell subscribed clients that prompts changed          | `server.notifyPromptsChanged()`     |
+| Tell subscribed clients that resources changed        | `server.notifyResourcesChanged()`   |
+| Tell subscribed clients that one resource changed     | `server.notifyResourceUpdated(uri)` |
+
+## Notify the current client
+
+Use `ctx.sendNotification(method, params?)` inside a callback. It preserves the
+v1 method-and-params signature while using the official v2 request notification
+channel.
+
+Use an application namespace for custom methods so clients can route them
+without colliding with standard MCP notifications.
+
+```typescript
+server.tool(
+  {
+    name: "run-import",
+    description: "Run an import and report its status to the caller.",
+  },
+  async (_params, ctx) => {
+    await ctx.sendNotification("com.example/import-status", {
+      status: "started",
+      startedAt: new Date().toISOString(),
+    });
+
+    await runImport();
+
+    await ctx.sendNotification("com.example/import-status", {
+      status: "completed",
+    });
+
+    return {
+      content: [{ type: "text", text: "Import complete." }],
+    };
+  },
+);
+```
+
+The notification is delivered on the originating request's response stream
+before its final result. Await it before returning from the callback. It cannot
+be saved and reused to notify that client after the request finishes.
+
+The receiving client registers a handler for the same custom method:
+
+```typescript
+import { Client } from "@modelcontextprotocol/client";
+import { z } from "zod";
+
+const client = new Client({ name: "import-client", version: "1.0.0" });
+
+client.setNotificationHandler(
+  "com.example/import-status",
+  { params: z.object({ status: z.string() }) },
+  (params) => {
+    console.log(params.status);
+  },
+);
+```
+
+## Publish list and resource changes
+
+Cross-request invalidations use the server's subscription-backed helpers. Only
+clients with an active `subscriptions/listen` request for the corresponding
+notification type receive them.
+
+```typescript
+await server.notifyToolsChanged();
+await server.notifyPromptsChanged();
+await server.notifyResourcesChanged();
+await server.notifyResourceUpdated("config://settings");
+```
+
+These helpers are for registry and resource changes, not arbitrary custom
+messages.
+
+## Report progress
+
+Use `ctx.reportProgress` when the current request has stages the client should
+see. It returns `false` without sending anything when the caller did not supply
+a progress token.
+
+```typescript
+server.tool({ name: "process-data" }, async (_params, ctx) => {
+  await ctx.reportProgress(0, 100, "Starting");
+  await processStageOne();
+  await ctx.reportProgress(50, 100, "Halfway");
+  await processStageTwo();
+  await ctx.reportProgress(100, 100, "Complete");
+
+  return { content: [{ type: "text", text: "Done." }] };
+});
+```
+
+## Send an MCP log message
+
+`ctx.sendLog(level, data, logger?)` sends the standard
+`notifications/message` notification on the active request. Modern clients
+must opt in with a request log level; otherwise the SDK suppresses the message.
+
+```typescript
+await ctx.sendLog("info", { imported: 42 }, "import-worker");
+```
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card
+    title="Tool context API reference"
+    icon="box"
+    href="https://mcp-use-typescript-api-reference.vercel.app/modules/mcp-use.index.html#requestcontext"
+  >
+    Look up `ctx.sendNotification`, `ctx.reportProgress`, and `ctx.sendLog`.
+  </Card>
+  <Card
+    title="Resource subscriptions"
+    icon="rss"
+    href="/v2/typescript/server/subscriptions"
+  >
+    Notify clients that subscribed resource content changed.
+  </Card>
+  <Card
+    title="Client notifications"
+    icon="monitor"
+    href="/v2/typescript/client/notifications"
+  >
+    Handle standard and custom notifications in a TypeScript MCP client.
+  </Card>
+</CardGroup>

--- a/docs/v2/typescript/server/openapi.mdx
+++ b/docs/v2/typescript/server/openapi.mdx
@@ -1,0 +1,116 @@
+---
+title: "OpenAPI"
+description: "Generate MCP tools from a bundled OpenAPI document."
+icon: "braces"
+---
+
+`MCPServer.fromOpenAPI()` registers each included OpenAPI operation as a tool
+that calls the matching HTTP endpoint.
+
+## Create the server
+
+Pass a parsed, bundled OpenAPI 3.x document and default-export the server:
+
+```typescript
+import { MCPServer, type OpenAPIDocument } from "mcp-use";
+
+const response = await fetch("https://api.example.com/openapi.json");
+if (!response.ok) {
+  throw new Error(`Failed to load OpenAPI: ${response.status}`);
+}
+
+const spec = (await response.json()) as OpenAPIDocument;
+
+const server = MCPServer.fromOpenAPI({
+  spec,
+  baseUrl: "https://api.example.com",
+  headers: { "x-client": "inventory-mcp" },
+  auth: {
+    type: "bearer",
+    token: process.env.INVENTORY_TOKEN,
+  },
+});
+
+export default server;
+```
+
+`baseUrl` overrides `spec.servers[0].url`. One of them is required when the
+document contains operations. The loader does not fetch external `$ref`
+targets, so bundle external references into local `#/...` references before
+creating the server.
+
+## Select operations
+
+`tags` includes operations that have at least one exact matching tag.
+`exclude` is applied afterward. All fields in one exclusion rule are ANDed;
+the `tags` field matches when the operation has any listed tag.
+
+```typescript
+const server = MCPServer.fromOpenAPI({
+  spec,
+  tags: ["public", "inventory"],
+  exclude: [
+    { operationId: /^admin/, method: "POST" },
+    { path: "/internal/status" },
+  ],
+});
+```
+
+String `operationId` and `path` matches are exact. Use a `RegExp` for pattern
+matching. Methods are case-insensitive.
+
+## Understand generated inputs
+
+Path, query, and header parameters become tool inputs. Cookie parameters are
+ignored. Operation-level parameters replace path-level parameters with the
+same location and name.
+
+Name collisions are resolved deterministically:
+
+- Parameters with the same name receive location suffixes such as
+  `id_path` and `id_query`.
+- A parameter named `body` is also location-suffixed when a JSON request body
+  exists.
+- Further collisions receive numeric suffixes such as `_2`.
+
+Only JSON-compatible request bodies are exposed, under the `body` input.
+Supported media types are `application/json`, `application/*+json`, and
+specific media types containing `+json`. Other body encodings are not sent.
+
+Array query values are serialized as repeated keys:
+`?tag=one&tag=two`. OpenAPI query serialization styles such as comma-separated
+or deep-object encoding are not interpreted.
+
+## Understand tool names
+
+An operation's `operationId` is preferred. Otherwise the method and path form a
+fallback such as `get_reports_id`. Names are trimmed, unsupported characters
+become underscores, repeated underscores collapse, and the result is capped at
+64 characters. Collisions receive `_2`, `_3`, and later suffixes while
+remaining within the cap.
+
+## Understand results and errors
+
+Generated tools return raw MCP results:
+
+- Successful JSON becomes a JSON text block plus the parsed value in
+  `structuredContent`.
+- Successful text and invalid JSON bodies become a text block.
+- Non-success HTTP responses become `{ isError: true, content: [...] }` with
+  the upstream response text.
+
+This mapping does not use response helpers and does not derive an
+`outputSchema` from OpenAPI response definitions.
+
+## Run the maintained example
+
+The repository example loads a focused subset of the National Weather Service
+document:
+
+```bash
+cd libraries/typescript/packages/server/examples/openapi
+pnpm dev
+```
+
+It requires network access while starting. The default command runs
+`mcp-use dev`, which serves the default export and built-in inspector.

--- a/docs/v2/typescript/server/prompts.mdx
+++ b/docs/v2/typescript/server/prompts.mdx
@@ -1,0 +1,148 @@
+---
+title: "Prompts"
+description: "Create reusable MCP prompt templates with typed arguments."
+icon: "message-square"
+---
+
+Prompts package repeatable model instructions. Use a prompt when a client should
+request model-ready messages; use a tool when the server should perform work.
+
+## Register a prompt
+
+Prompt schemas are Standard Schema-compatible. Zod is one option:
+
+```typescript
+import { MCPServer } from "mcp-use";
+import { z } from "zod";
+
+const server = new MCPServer({
+  name: "review-server",
+  version: "1.0.0",
+});
+
+server.prompt(
+  {
+    name: "review-code",
+    description: "Create a focused code-review request.",
+    schema: z.object({
+      language: z.string(),
+      code: z.string(),
+    }),
+  },
+  async ({ language, code }) => ({
+    messages: [
+      {
+        role: "user",
+        content: {
+          type: "text",
+          text: `Review this ${language} code for correctness and security:\n\n${code}`,
+        },
+      },
+    ],
+  }),
+);
+
+export default server;
+```
+
+Prefer the raw `{ messages: [...] }` result. Each message has a role and one
+MCP content block.
+
+## Add argument suggestions
+
+`completable()` supplies suggestions to clients. It does not constrain valid
+values; the wrapped schema still decides what input is valid.
+
+Apply descriptions, defaults, and refinements before wrapping the field:
+
+```typescript
+import { completable } from "mcp-use";
+
+server.prompt(
+  {
+    name: "summarize-project",
+    schema: z.object({
+      team: completable(z.string().min(1).describe("Owning team"), [
+        "platform",
+        "sales",
+        "support",
+      ]),
+      projectId: completable(
+        z.string().min(1).describe("Project identifier"),
+        async (value, context) => {
+          const team = context?.arguments?.team as string | undefined;
+          return (await projects.search({ team, query: value })).map(
+            (project) => project.id,
+          );
+        },
+      ),
+    }),
+  },
+  async ({ team, projectId }) => ({
+    messages: [
+      {
+        role: "user",
+        content: {
+          type: "text",
+          text: `Summarize project ${projectId} for the ${team} team.`,
+        },
+      },
+    ],
+  }),
+);
+```
+
+Use an enum when only a fixed set is valid. Use `completable(z.string(), ...)`
+when other strings remain acceptable.
+
+## Use verified authentication context
+
+Configure OAuth before reading `ctx.auth`. The authenticated callback type then
+contains the provider's mapped user:
+
+```typescript
+import { MCPServer } from "mcp-use";
+import { oauthAuth0Provider } from "mcp-use/oauth/auth0";
+
+const authenticatedServer = new MCPServer({
+  name: "personal-prompts",
+  version: "1.0.0",
+  oauth: oauthAuth0Provider({
+    domain: process.env.AUTH0_DOMAIN!,
+  }),
+});
+
+authenticatedServer.prompt({ name: "weekly-summary" }, async (_args, ctx) => ({
+  messages: [
+    {
+      role: "user",
+      content: {
+        type: "text",
+        text: `Create a weekly summary for user ${ctx.auth.user.id}.`,
+      },
+    },
+  ],
+}));
+```
+
+Use app-owned configuration validation in production rather than a non-null
+assertion. Client-reported metadata is not an authentication substitute.
+
+## Notify prompt-list listeners
+
+Register prompts while constructing the server, before it starts handling
+requests. When application state changes what clients should consider
+available, publish a prompt-list invalidation:
+
+```typescript
+await server.notifyPromptsChanged();
+```
+
+Active subscription listeners can then request `prompts/list` again. The
+server registry itself is not designed for late prompt registration after
+startup.
+
+## Test prompts
+
+Run `mcp-use dev`, open the built-in inspector, and verify listing, argument
+validation, completions, and the exact generated messages.

--- a/docs/v2/typescript/server/proxy.mdx
+++ b/docs/v2/typescript/server/proxy.mdx
@@ -1,0 +1,109 @@
+---
+title: "Compose MCP servers"
+description: "Proxy multiple MCP servers through one MCP endpoint with server.proxy() and the optional @mcp-use/client package."
+icon: "git-merge"
+---
+
+`server.proxy()` connects to multiple upstream HTTP MCP servers and exposes their tools, static resources, and prompts through one endpoint. Config-map keys and negotiated server names automatically namespace proxied capabilities.
+
+## Install the optional client
+
+Proxying requires `@mcp-use/client` v2. The package is an optional peer of `mcp-use`, so applications that do not call `server.proxy()` do not need to install it.
+
+```bash
+npm install mcp-use @mcp-use/client
+```
+
+If you call `server.proxy()` without the client installed, mcp-use throws an error with the install command. Importing or running a server without calling `proxy()` does not load the client package.
+
+## Proxy multiple servers
+
+Pass an object whose keys identify upstreams and whose values contain HTTP connection settings. The keys automatically become capability namespaces.
+
+```typescript
+import { MCPServer } from "mcp-use";
+
+const server = new MCPServer({
+  name: "gateway",
+  version: "1.0.0",
+});
+
+await server.proxy({
+  weather: {
+    url: "https://weather.example.com/mcp",
+  },
+  internal: {
+    url: "https://internal.example.com/mcp",
+    authToken: process.env.INTERNAL_MCP_TOKEN,
+  },
+});
+
+server.tool({ name: "gateway_status" }, async () => ({
+  content: [{ type: "text", text: "Gateway is running" }],
+}));
+
+await server.listen(3000);
+```
+
+The gateway exposes upstream names with a `<namespace>_` prefix:
+
+| Upstream capability            | Gateway capability  |
+| ------------------------------ | ------------------- |
+| `weather` prompt `forecast`    | `weather_forecast`  |
+| `internal` resource `handbook` | `internal_handbook` |
+
+Static resource URIs use the `mcp-use-proxy` scheme. The gateway maps each proxy URI back to the original upstream URI when a client reads it.
+
+Call `proxy()` before `listen()` or the first `server.fetch` request. Registration is best-effort: a connection failure skips that upstream, an introspection failure skips only the affected capability kind, and a name collision skips only the colliding capability. Each failure is written to the server's diagnostics while other upstreams and capabilities remain available.
+
+Proxy config deliberately supports bearer tokens and explicit authentication headers, but not automatic OAuth. `server.proxy()` disables the client's browser-based OAuth flow, so starting the gateway never opens a browser. Obtain and refresh credentials in your application, then pass them with `authToken` or `headers`.
+
+## Mount an existing connection
+
+Pass a ready `MCPConnection` when your application creates the client itself. The upstream's negotiated server name automatically becomes the namespace.
+
+```typescript
+import { MCPClient } from "@mcp-use/client";
+import { MCPServer } from "mcp-use";
+
+const client = new MCPClient({
+  mcpServers: {
+    secure_database: {
+      url: "https://database.example.com/mcp",
+      authToken: process.env.DATABASE_MCP_TOKEN,
+      oauth: false,
+    },
+  },
+});
+
+const connection = await client.connect("secure_database");
+
+const server = new MCPServer({
+  name: "gateway",
+  version: "1.0.0",
+});
+
+await server.proxy(connection);
+await server.listen(3000);
+```
+
+The parent server owns connections it creates from a config object and closes them in `server.close()`. Your application remains responsible for an explicitly supplied connection:
+
+```typescript
+await server.close();
+await client.close();
+```
+
+## Forwarded behavior
+
+The proxy introspects each upstream once during setup and forwards:
+
+- Tool metadata, input and output JSON Schemas, calls, structured content, error results, cancellation, and progress
+- Static resource metadata and reads
+- Prompt metadata, argument schemas, and prompt requests
+
+The initial v2 implementation does not proxy resource templates, completions, subscriptions, upstream list-change re-synchronization, or legacy push-style sampling and elicitation callbacks.
+
+## Run the complete example
+
+The [multiple-server proxy example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/proxy) starts two local upstream servers and proxies both through one gateway.

--- a/docs/v2/typescript/server/resources.mdx
+++ b/docs/v2/typescript/server/resources.mdx
@@ -1,0 +1,131 @@
+---
+title: "Resources"
+description: "Expose readable content with static resources and resource templates."
+icon: "folder-open"
+---
+
+Resources expose content clients can discover and read by URI. Use a static
+resource for one stable URI and a resource template for a family of URIs.
+
+## Register a static resource
+
+A static callback receives the requested `URL` and request context:
+
+```typescript
+import { MCPServer } from "mcp-use";
+
+const server = new MCPServer({
+  name: "inventory-server",
+  version: "1.0.0",
+});
+
+server.resource(
+  {
+    name: "inventory-summary",
+    uri: "inventory://summary",
+    mimeType: "application/json",
+  },
+  async (uri, ctx) => ({
+    contents: [
+      {
+        uri: uri.href,
+        mimeType: "application/json",
+        text: JSON.stringify({
+          lowStock: await inventory.lowStock({ signal: ctx.signal }),
+        }),
+      },
+    ],
+  }),
+);
+
+export default server;
+```
+
+Return the raw `{ contents: [...] }` resource envelope. Each entry identifies
+its own URI and contains either text or a base64 blob with an appropriate MIME
+type.
+
+## Register a resource template
+
+A template callback receives `(uri, params, ctx)`. Inferred template values
+are `string | string[]` because RFC 6570 expressions can expand one or many
+values.
+
+```typescript
+server.resourceTemplate(
+  {
+    name: "customer-profile",
+    uriTemplate: "customer://{customerId}/profile",
+    complete: {
+      customerId: async (value) =>
+        (await customers.search(value)).map((customer) => customer.id),
+    },
+  },
+  async (uri, { customerId }, ctx) => {
+    const id = Array.isArray(customerId) ? customerId[0] : customerId;
+    const customer = await customers.get(id, { signal: ctx.signal });
+
+    return {
+      contents: [
+        {
+          uri: uri.href,
+          mimeType: "application/json",
+          text: JSON.stringify(customer),
+        },
+      ],
+    };
+  },
+);
+```
+
+Completion providers belong in the definition's top-level `complete` map.
+Use a string array for fixed suggestions or a callback for live lookup.
+
+## Return several content entries
+
+One resource read may return several entries:
+
+```typescript
+async (uri) => ({
+  contents: [
+    {
+      uri: uri.href,
+      mimeType: "text/markdown",
+      text: report.summary,
+    },
+    {
+      uri: `${uri.href}/chart`,
+      mimeType: "image/png",
+      blob: report.chartBase64,
+    },
+  ],
+});
+```
+
+Deprecated response-helper results are accepted as conversion inputs, but raw
+resource envelopes are the direct return path and make URIs and MIME types
+explicit.
+
+## Notify listeners
+
+Publish a list invalidation when the available resources or templates change:
+
+```typescript
+await server.notifyResourcesChanged();
+```
+
+Publish a URI invalidation when existing content changes:
+
+```typescript
+await server.notifyResourceUpdated("inventory://summary");
+```
+
+Clients with an active subscription listener re-read the authoritative
+resource. Delivery is non-durable; see
+[Resource Subscriptions](/v2/typescript/server/subscriptions).
+
+## Test resources
+
+Run `mcp-use dev`, then use the built-in inspector to list resources, read
+static and templated URIs, exercise autocomplete, and verify successful and
+not-found results.

--- a/docs/v2/typescript/server/sampling.mdx
+++ b/docs/v2/typescript/server/sampling.mdx
@@ -1,0 +1,95 @@
+---
+title: "Sampling"
+description: "Design tools when model generation belongs in the MCP host."
+icon: "pipette"
+---
+
+Model generation belongs in the MCP host. The stateless TypeScript server does
+not expose `ctx.sample()`, so a tool callback cannot pause an HTTP request to
+ask the connected host to run a model completion.
+
+## Keep generation in the host
+
+Design the workflow so the host or model performs generation first, then calls
+a deterministic tool with the generated or selected value:
+
+1. A prompt or tool description tells the model what to generate.
+2. The host runs the model according to its own policy and credentials.
+3. The host calls a tool with the result.
+4. The tool validates the input and performs deterministic server work.
+
+```typescript
+import { MCPServer } from "mcp-use";
+import { z } from "zod";
+
+const server = new MCPServer({
+  name: "review-server",
+  version: "1.0.0",
+});
+
+server.tool(
+  {
+    name: "save-review",
+    description:
+      "Save a review after the host has drafted it. Pass the completed review text.",
+    inputSchema: z.object({
+      documentId: z.string(),
+      review: z.string().min(1),
+    }),
+  },
+  async ({ documentId, review }) => {
+    await reviews.save({ documentId, review });
+    return {
+      content: [{ type: "text", text: `Saved review for ${documentId}.` }],
+    };
+  },
+);
+
+export default server;
+```
+
+This keeps model choice, approval, credentials, and generation policy with the
+host. It also makes the server behavior reproducible and testable.
+
+## Report progress for the active request
+
+Long-running tool work can still report request-scoped progress.
+`ctx.reportProgress()` returns `false` when the caller did not supply a progress
+token.
+
+```typescript
+server.tool(
+  {
+    name: "index-documents",
+    inputSchema: z.object({ collectionId: z.string() }),
+  },
+  async ({ collectionId }, ctx) => {
+    await ctx.reportProgress(0, 100, "Starting");
+    await indexCollection(collectionId, async (completed, total) => {
+      await ctx.reportProgress(completed, total, "Indexing");
+    });
+    await ctx.reportProgress(100, 100, "Complete");
+
+    return {
+      content: [{ type: "text", text: "Index complete." }],
+    };
+  },
+);
+```
+
+Progress notifications travel on the active response stream and must be sent
+before the callback returns. They are not a background push channel.
+
+## Run the example
+
+The maintained example exposes a deterministic tool that explains this
+boundary:
+
+```bash
+cd libraries/typescript/packages/server/examples/sampling
+pnpm dev
+```
+
+Use [Prompts](/v2/typescript/server/prompts) to package reusable model
+instructions and [Elicitation](/v2/typescript/server/elicitation) when a tool
+needs explicit user input.

--- a/docs/v2/typescript/server/subscriptions.mdx
+++ b/docs/v2/typescript/server/subscriptions.mdx
@@ -1,0 +1,98 @@
+---
+title: "Resource Subscriptions"
+description: "Publish resource invalidations to active MCP listeners."
+icon: "rss"
+---
+
+Subscriptions let a client keep a live `subscriptions/listen` request open and
+receive list or resource invalidations. After an invalidation, the client reads
+the affected resource again to obtain current content.
+
+Delivery is listener-bound and non-durable. The stateless HTTP transport does
+not store subscriptions in a session, queue missed events, or provide replay
+after a listener disconnects.
+
+## Publish resource changes
+
+Define a resource with a stable URI, update its backing data, and publish the
+appropriate invalidation:
+
+```typescript
+import { MCPServer } from "mcp-use";
+import { z } from "zod";
+
+const server = new MCPServer({
+  name: "settings-server",
+  version: "1.0.0",
+});
+
+const settingsUri = "settings://app";
+let theme = "light";
+
+server.resource({ name: "app-settings", uri: settingsUri }, async (uri) => ({
+  contents: [
+    {
+      uri: uri.href,
+      mimeType: "application/json",
+      text: JSON.stringify({ theme }),
+    },
+  ],
+}));
+
+server.tool(
+  {
+    name: "set-theme",
+    inputSchema: z.object({ theme: z.enum(["light", "dark"]) }),
+  },
+  async ({ theme: nextTheme }) => {
+    theme = nextTheme;
+    await server.notifyResourceUpdated(settingsUri);
+
+    return {
+      content: [{ type: "text", text: `Theme changed to ${theme}.` }],
+    };
+  },
+);
+
+export default server;
+```
+
+`notifyResourceUpdated(uri)` tells listeners that the representation at one
+URI changed; it does not send the new body. Use
+`notifyResourcesChanged()` when the discoverable resource or template list
+changes:
+
+```typescript
+await server.notifyResourcesChanged();
+```
+
+The related helpers are `notifyToolsChanged()` and
+`notifyPromptsChanged()`.
+
+## Design for missed events
+
+Treat notifications as cache invalidations:
+
+- Keep the resource itself authoritative.
+- Make reads safe to repeat.
+- Do not depend on every intermediate invalidation being delivered.
+- Store durable job state, audit history, and workflow progress outside the
+  subscription stream.
+
+Use request-scoped custom notifications for status emitted during one active
+tool call. See [Notifications](/v2/typescript/server/notifications).
+
+## Test a live listener
+
+Run the maintained notifications example:
+
+```bash
+cd libraries/typescript/packages/server/examples/notifications
+pnpm dev
+```
+
+Connect a current MCP client that supports `subscriptions/listen`, keep the
+listener request open, and read `example://status`. Call `publish-changes`,
+verify that the listener receives the resource invalidation, and read the
+resource again. Disconnect the listener and verify that later events are not
+replayed when a new listener connects.

--- a/docs/v2/typescript/server/tools.mdx
+++ b/docs/v2/typescript/server/tools.mdx
@@ -1,0 +1,170 @@
+---
+title: "Tools"
+description: "Design and register MCP tools with validated inputs and typed results."
+icon: "wrench"
+---
+
+Tools let a model call server-side code. Give each tool a focused description,
+validate its input, declare its behavioral annotations, and return an official
+MCP `CallToolResult`.
+
+## Register a tool
+
+`inputSchema` accepts a Standard Schema implementation that can produce JSON
+Schema. Zod is one option; ArkType and Valibot are also supported.
+
+```typescript
+import { MCPServer } from "mcp-use";
+import { z } from "zod";
+
+const server = new MCPServer({
+  name: "inventory-server",
+  version: "1.0.0",
+});
+
+server.tool(
+  {
+    name: "lookup-inventory",
+    description: "Return available inventory for one SKU.",
+    inputSchema: z.object({
+      sku: z.string().describe("Inventory SKU"),
+    }),
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      openWorldHint: true,
+    },
+  },
+  async ({ sku }) => {
+    const count = await inventory.count(sku);
+    return {
+      content: [{ type: "text", text: `${count} units available.` }],
+    };
+  },
+);
+
+export default server;
+```
+
+Field descriptions become hints for clients and models. The schema validates
+input before the callback runs and supplies the callback's inferred TypeScript
+type.
+
+## Return structured output
+
+Declare `outputSchema` when clients need a typed structured result. Every
+successful result from a schema-backed tool must include matching
+`structuredContent`. An error result may instead set `isError: true`.
+
+```typescript
+const availabilitySchema = z.object({
+  sku: z.string(),
+  available: z.number().int(),
+});
+
+server.tool(
+  {
+    name: "inventory-status",
+    inputSchema: z.object({ sku: z.string() }),
+    outputSchema: availabilitySchema,
+  },
+  async ({ sku }) => {
+    const data = { sku, available: await inventory.count(sku) };
+    return {
+      content: [{ type: "text", text: JSON.stringify(data) }],
+      structuredContent: data,
+    };
+  },
+);
+```
+
+Prefer raw results:
+
+| Need             | Return                                                     |
+| ---------------- | ---------------------------------------------------------- |
+| Text             | `{ content: [{ type: "text", text }] }`                    |
+| Typed JSON       | `{ content, structuredContent: data }` with `outputSchema` |
+| Expected failure | `{ isError: true, content: [{ type: "text", text }] }`     |
+| Several blocks   | `{ content: [/* content blocks */] }`                      |
+
+## Bind a View
+
+Export the tool reference from the server entry so `mcp-env.d.ts` can expose
+its input and output types to View code. Place the React entry at
+`views/<name>/view.tsx`, set `view.name` to that directory name, and return its
+data in `structuredContent`.
+
+```typescript
+export const searchProducts = server.tool(
+  {
+    name: "search-products",
+    inputSchema: z.object({ query: z.string() }),
+    outputSchema: z.object({
+      query: z.string(),
+      results: z.array(z.object({ id: z.string(), name: z.string() })),
+    }),
+    view: { name: "product-search-result" },
+  },
+  async ({ query }) => {
+    const data = { query, results: await products.search(query) };
+    return {
+      content: [
+        { type: "text", text: `Found ${data.results.length} products.` },
+      ],
+      structuredContent: data,
+    };
+  },
+);
+```
+
+A view-bound tool must declare `outputSchema`, and one View can bind to only
+one tool. The view reads the structured data while the model reads `content`.
+
+## Use request context
+
+The second callback argument is scoped to the current request. It includes an
+abort signal, client-reported capability metadata, progress and logging
+methods, and the originating Hono request when HTTP context exists.
+
+```typescript
+server.tool({ name: "request-info" }, async (_input, ctx) => {
+  const data = {
+    client: ctx.client.info().name ?? "unknown",
+    supportsViews: ctx.client.supportsViews(),
+    aborted: ctx.signal.aborted,
+  };
+  return {
+    content: [{ type: "text", text: JSON.stringify(data) }],
+    structuredContent: data,
+  };
+});
+```
+
+Client metadata is self-reported and must not be used for authorization.
+`ctx.auth` is available only when the server has an OAuth provider; use its
+verified provider user for access control.
+
+## Notify tool-list listeners
+
+Publish a tool-list invalidation when the tools clients can discover have
+changed:
+
+```typescript
+await server.notifyToolsChanged();
+```
+
+Clients with an active subscription listener can then request `tools/list`
+again. This notification does not register or replace tools; register tools
+while constructing the server, before it starts handling requests.
+
+## Test tools
+
+Run `mcp-use dev`, open the built-in inspector, and test valid inputs, schema
+failures, error results, and structured output:
+
+```bash
+npx mcp-use dev
+```
+
+For view-bound tools, also verify that the View renders the returned
+`structuredContent`.

--- a/docs/v2/typescript/tooling/client-cli.mdx
+++ b/docs/v2/typescript/tooling/client-cli.mdx
@@ -1,0 +1,161 @@
+---
+title: CLI Client
+description: Connect to HTTP MCP servers, call tools, read resources, get prompts, manage OAuth, and produce parseable JSON from the terminal.
+icon: "terminal"
+---
+
+Use `mcp-use client` to test or automate an HTTP MCP server from the terminal. Save a server under a name, then use that name for every tool, resource, prompt, and auth command.
+
+For the complete command and flag catalog, see the [CLI reference](/v2/typescript/api-reference/cli-reference#client).
+
+## Connect and call a tool
+
+Run the CLI with `npx`, or install `mcp-use` in your project.
+
+```bash
+npx mcp-use client connect dev http://localhost:3000/mcp
+npx mcp-use client dev tools list
+npx mcp-use client dev tools call get-weather city=Tokyo
+```
+
+`connect` supports HTTP and HTTPS MCP URLs. It verifies the connection before saving it. The CLI stores saved server metadata under `~/.mcp-use/client/`.
+
+List or remove saved servers with these commands:
+
+```bash
+npx mcp-use client list
+npx mcp-use client remove dev
+```
+
+## Choose a protocol mode
+
+The default `--protocol auto` mode prefers the modern MCP wire and falls back
+to the legacy wire when the server does not support modern negotiation.
+
+Use `legacy` or `modern` when you need strict compatibility testing:
+
+```bash
+npx mcp-use client connect old-server https://old.example.com/mcp \
+  --protocol legacy
+npx mcp-use client connect modern-server https://modern.example.com/mcp \
+  --protocol modern
+```
+
+`legacy` uses only the legacy wire. `modern` uses the stateless, sessionless
+modern wire with no fallback.
+
+## Authenticate with OAuth
+
+When a server requires OAuth in an interactive terminal, the CLI displays this prompt:
+
+```text
+This server requires OAuth. Press Enter to open your browser.
+```
+
+Press Enter to open the authorization page. The command keeps waiting for the loopback callback, then verifies and saves the connection.
+
+Use `--no-open` to authenticate without launching a browser:
+
+```bash
+npx mcp-use client connect prod https://mcp.example.com/mcp --no-open
+```
+
+With `--no-open`, `--json`, or non-interactive stdin, the CLI never prompts or opens a browser. It prints the authorization URL to stderr and continues waiting for the loopback callback. Open that URL yourself to finish authentication.
+
+Use `--no-oauth` for a public server or when an authorization challenge should fail instead of starting OAuth. Repeated `-H` or `--header` options add static request headers.
+
+```bash
+npx mcp-use client connect public https://mcp.example.com/mcp --no-oauth
+npx mcp-use client connect private https://mcp.example.com/mcp \
+  -H "Authorization: Bearer $TOKEN" --no-oauth
+```
+
+Check or clear saved OAuth credentials with auth commands:
+
+```bash
+npx mcp-use client prod auth status
+npx mcp-use client prod auth logout
+```
+
+`auth logout` removes OAuth material but keeps the saved server and its non-OAuth connection metadata.
+
+## Call tools
+
+List tools, inspect a tool schema, then call the tool with its required inputs.
+
+```bash
+npx mcp-use client dev tools list
+npx mcp-use client dev tools describe get-weather
+npx mcp-use client dev tools call get-weather city=Tokyo
+```
+
+Tool and prompt arguments accept `key=value` pairs. Use `key:=<json>` for typed or nested values, or pass one JSON object.
+
+```bash
+npx mcp-use client dev tools call search query=shoes limit:=5
+npx mcp-use client dev tools call search filters:='{"color":"black","inStock":true}'
+npx mcp-use client dev tools call search '{"query":"shoes","limit":5}'
+```
+
+Use `--timeout <ms>` for slow tools. The default is `30000` milliseconds.
+
+```bash
+npx mcp-use client dev tools call generate-report topic=sales --timeout 60000
+```
+
+## Read resources
+
+Resources are server-provided content identified by URI. List resources, then read the URI you need.
+
+```bash
+npx mcp-use client dev resources list
+npx mcp-use client dev resources read "file:///tmp/data.json"
+```
+
+## Get prompts
+
+Prompts are reusable message templates exposed by the server. Prompt arguments use the same forms as tool arguments.
+
+```bash
+npx mcp-use client dev prompts list
+npx mcp-use client dev prompts get greeting name=Alice
+npx mcp-use client dev prompts get greeting '{"name":"Alice"}'
+```
+
+## Produce parseable JSON
+
+Every client command documented with `--json` accepts it anywhere after `client`. The following forms are equivalent:
+
+```bash
+npx mcp-use client --json dev tools list
+npx mcp-use client dev --json tools list
+npx mcp-use client dev tools list --json
+```
+
+Successful commands write exactly one JSON value followed by a newline to stdout. Calls, resource reads, and prompt gets return the raw MCP result envelope. Lists return arrays. Errors write one envelope to stderr and do not write a result to stdout:
+
+```json
+{ "error": { "code": "usage_error", "message": "Tool not found: missing" } }
+```
+
+OAuth authorization URLs and dependency-install status are operational messages on stderr, so stdout remains parseable under `--json`.
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+npx mcp-use client connect dev http://localhost:3000/mcp --no-oauth --json >/dev/null
+npx mcp-use client dev tools list --json | jq -r '.[].name'
+npx mcp-use client dev tools call get-weather city=Tokyo --json | jq '.content'
+```
+
+## Troubleshoot commands
+
+- `Unknown saved server: <name>`: run `npx mcp-use client list`, or reconnect with `npx mcp-use client connect <name> <url>`.
+- `Tool not found: <name>`: run `tools list` against the same saved server.
+- `protocol_mismatch`: reconnect with `--protocol auto`, or choose the protocol
+  mode the server supports.
+- An OAuth command waits without opening a browser: open the authorization URL printed to stderr, then complete authorization before the configured timeout.
+- A tool returns an error: under `--json`, inspect `error.details` for the original MCP tool result.
+
+For exhaustive command shapes, flags, and storage details, use the [CLI reference](/v2/typescript/api-reference/cli-reference#client).


### PR DESCRIPTION
## Summary
- preserve the existing `/typescript/...` routes from `main` as the V1 documentation set
- add the V2 TypeScript documentation under `/v2/typescript/...`
- add V1/V2 navigation, V2 Beta labeling, and V2-scoped redirects
- align the shared Inspector and tunneling documentation used by both versions

## Scope
This PR is documentation-only. Its diff is limited to `docs/**`.

Excluded from the rebased branch:
- TypeScript product/library/application source changes
- tests and examples
- package manifests, lockfiles, changesets, and generated API build inputs
- CI, deployment, and unrelated infrastructure changes
- unused media and internal migration worklists

The V2 API Reference tab links to the existing external API reference; this PR does not add TypeDoc build/deployment wiring that depends on beta-only package structure.

## Impact
- V1 URLs and V1 content remain based on current `main`.
- V2 documentation is independently navigable and labeled Beta.
- Shared Inspector and tunneling pages remain unversioned.

## Validation
- `mint validate`
- `mint broken-links`
- `jq empty docs/docs.json`
- verified all 57 configured V2 navigation entries resolve to documentation files
- verified the complete `main...HEAD` diff contains only `docs/**`
