### PR TITLE
fix(typescript): stabilize dev view runtime

### DIFF
--- a/libraries/typescript/.changeset/calm-views-no-eval.md
+++ b/libraries/typescript/.changeset/calm-views-no-eval.md
@@ -1,0 +1,6 @@
+---
+"mcp-use": patch
+"@mcp-use/cli": patch
+---
+
+Keep managed views on one deduplicated React runtime and configure Zod's supported jitless mode before view dependencies evaluate. This prevents invalid hook calls in development and removes the caught `eval` CSP violation without weakening the view sandbox policy.

--- a/libraries/typescript/packages/server/src/cli/views-plugin.ts
+++ b/libraries/typescript/packages/server/src/cli/views-plugin.ts
@@ -13,6 +13,8 @@ import {
 
 const VIRTUAL_TAILWIND_ID = "virtual:mcp-use/tailwind.css";
 const VIRTUAL_TAILWIND_RESOLVED_ID = `\0${VIRTUAL_TAILWIND_ID}`;
+const VIRTUAL_CSP_RUNTIME_ID = "virtual:mcp-use/csp-runtime";
+const VIRTUAL_CSP_RUNTIME_RESOLVED_ID = `\0${VIRTUAL_CSP_RUNTIME_ID}`;
 
 /**
  * Options for {@link mcpUseViewsPlugin}.
@@ -52,10 +54,22 @@ export interface McpUseViewsPluginOptions {
 export function mcpUseViewsPlugin(options: McpUseViewsPluginOptions): Plugin {
   return {
     name: "mcp-use-views",
+    config() {
+      return {
+        // Vite may otherwise resolve the view source and the pre-bundled
+        // mcp-use/react entry to versioned and unversioned React URLs. Those
+        // are distinct browser modules and trigger React's invalid-hook-call
+        // guard even though they originate from the same installed package.
+        resolve: { dedupe: ["react", "react-dom"] },
+      };
+    },
     applyToEnvironment(environment) {
       return environment.name === "client";
     },
     resolveId(id) {
+      if (id === VIRTUAL_CSP_RUNTIME_ID) {
+        return VIRTUAL_CSP_RUNTIME_RESOLVED_ID;
+      }
       if (id === VIRTUAL_TAILWIND_ID) {
         return VIRTUAL_TAILWIND_RESOLVED_ID;
       }
@@ -65,6 +79,17 @@ export function mcpUseViewsPlugin(options: McpUseViewsPluginOptions): Plugin {
       return `\0${id}`;
     },
     load(id) {
+      if (id === VIRTUAL_CSP_RUNTIME_RESOLVED_ID) {
+        // Zod 4 deliberately exposes this global configuration object so
+        // strict-CSP hosts can opt out of its new Function capability probe
+        // before Zod evaluates. The probe is caught by Zod, but browsers still
+        // report it as a CSP violation.
+        return [
+          "globalThis.__zod_globalConfig ??= {};",
+          "globalThis.__zod_globalConfig.jitless = true;",
+          "",
+        ].join("\n");
+      }
       if (id === VIRTUAL_TAILWIND_RESOLVED_ID) {
         // Host theme is applied via ext-apps applyDocumentTheme (data-theme on
         // html) and optional .dark wrappers — not OS prefers-color-scheme.
@@ -82,10 +107,13 @@ export function mcpUseViewsPlugin(options: McpUseViewsPluginOptions): Plugin {
         return undefined;
       }
       const lines: string[] = [];
+      // This side-effect module must evaluate before the view and all of its
+      // dependencies so strict-CSP configuration is in place before Zod loads.
+      lines.push(`import ${JSON.stringify(VIRTUAL_CSP_RUNTIME_ID)};`);
       if (options.dev?.reactRefresh === true) {
-        // Must be the first import: the preamble hooks the refresh runtime
-        // into the window before react-dom (via the bootstrap import below)
-        // or any refresh-wrapped view module evaluates.
+        // Must precede component imports: the preamble hooks the refresh
+        // runtime into the window before react-dom (via the bootstrap import
+        // below) or any refresh-wrapped view module evaluates.
         lines.push(`import "@vitejs/plugin-react/preamble";`);
       }
       lines.push(`import ${JSON.stringify(VIRTUAL_TAILWIND_ID)};`);

--- a/libraries/typescript/packages/server/tests/cli/build.test.ts
+++ b/libraries/typescript/packages/server/tests/cli/build.test.ts
@@ -340,7 +340,7 @@ describe("runBuild", () => {
 });
 
 describe("runBuild (views)", () => {
-  it("virtual entry imports the full view module for named viewConfig", () => {
+  it("configures a single React runtime and CSP-safe view evaluation", async () => {
     const plugin = mcpUseViewsPlugin({
       getViews: () => [
         {
@@ -349,10 +349,35 @@ describe("runBuild (views)", () => {
         },
       ],
     });
+
+    const config = plugin.config;
+    expect(config).toBeTypeOf("function");
+    const resolvedConfig = await (
+      config as () => Promise<Record<string, unknown>> | Record<string, unknown>
+    )();
+    expect(resolvedConfig).toMatchObject({
+      resolve: { dedupe: ["react", "react-dom"] },
+    });
+
+    const resolveId = plugin.resolveId;
+    expect(resolveId).toBeTypeOf("function");
+    const cspRuntimeId = (resolveId as (id: string) => string | undefined)(
+      "virtual:mcp-use/csp-runtime"
+    );
+    expect(cspRuntimeId).toBe("\0virtual:mcp-use/csp-runtime");
+
     const load = plugin.load;
     expect(load).toBeTypeOf("function");
+    const cspRuntime = (load as (id: string) => string | undefined)(
+      cspRuntimeId!
+    );
+    expect(cspRuntime).toContain("__zod_globalConfig.jitless = true");
+
     const source = (load as (id: string) => string | undefined)(
       `${VIRTUAL_VIEW_RESOLVED_PREFIX}demo`
+    );
+    expect(source?.split("\n")[0]).toBe(
+      'import "virtual:mcp-use/csp-runtime";'
     );
     expect(source).toContain(
       'import * as viewModule from "/abs/views/demo/view.tsx"'


### PR DESCRIPTION
## Summary

- deduplicate `react` and `react-dom` in the managed Vite view pipeline so view source and `mcp-use/react` share one dispatcher
- configure Zod 4's supported global `jitless` mode before view dependencies evaluate, removing the caught `new Function` CSP violation without adding `unsafe-eval`
- add regression coverage and a patch changeset for `mcp-use` and `@mcp-use/cli`

## Verification

- `pnpm --filter mcp-use exec vitest run tests/cli/build.test.ts` (24 passed)
- `pnpm --filter mcp-use typecheck`
- ESLint and Prettier checks
- built `@mcp-use/client`, `mcp-use`, `@mcp-use/agent`, `@mcp-use/inspector`, and `@mcp-use/cli`
- installed the packed CLI into a clean `mcp-use@2.0.0-beta.56` scaffold and executed `show-app` in the built-in Inspector: view rendered, browser errors were empty, and no `script-src: eval` CSP warning was emitted

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the dev view runtime under strict CSP. Ensures a single React runtime and removes the eval CSP warning without weakening policy.

- **Bug Fixes**
  - Deduplicates `react` and `react-dom` in the Vite view pipeline so view code and `mcp-use/react` share one runtime, preventing invalid hook calls in dev.
  - Preloads a CSP runtime that sets `globalThis.__zod_globalConfig.jitless = true` before dependencies load, avoiding `new Function` probes and the `script-src: eval` warning.

<sup>Written for commit 998b5381701c0d9aa51dd842bf48ca532925d4c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

