### PR TITLE
fix(typescript): keep one React view runtime

### DIFF
--- a/libraries/typescript/.changeset/bright-views-one-react.md
+++ b/libraries/typescript/.changeset/bright-views-one-react.md
@@ -1,0 +1,6 @@
+---
+"mcp-use": patch
+"@mcp-use/cli": patch
+---
+
+Keep `mcp-use/react` out of Vite's dependency bundle while explicitly optimizing its CommonJS React dependencies, and apply React deduplication at the dev server's final config layer. This makes dependency and view imports share one React dispatcher.

--- a/libraries/typescript/packages/server/src/cli/dev.ts
+++ b/libraries/typescript/packages/server/src/cli/dev.ts
@@ -57,7 +57,11 @@ import { isInspectorPath, isInspectorRequest } from "./inspector-route.js";
 import { createTunnelManager } from "./tunnel.js";
 import { syncMcpEnvDeclaration } from "./mcp-env-declaration.js";
 import { resolveWorkspacePaths } from "./workspace.js";
-import { mcpUseViewsPlugin } from "./views-plugin.js";
+import {
+  mcpUseViewsPlugin,
+  VIEW_REACT_DEDUPE,
+  VIEW_REACT_OPTIMIZE_DEPS,
+} from "./views-plugin.js";
 import {
   legacyWidgetMetadataId,
   legacyWidgetMetadataPlugin,
@@ -412,7 +416,16 @@ export async function runDev(options: DevOptions): Promise<void> {
     resolve: {
       tsconfigPaths: true,
       alias: { tailwindcss: resolveTailwindCss() },
+      // Inline Vite config is applied after plugin config hooks. Keep this
+      // invariant at the final merge layer so the optimizer and transformed
+      // view source cannot receive distinct React module URLs.
+      dedupe: VIEW_REACT_DEDUPE,
     },
+    // Pre-bundling mcp-use/react makes its internal React import resolve to an
+    // unversioned optimizer URL while view source receives a versioned URL.
+    // Serving the framework entry as ESM keeps both imports on one dispatcher;
+    // its CommonJS ReactDOM dependency still needs explicit optimization.
+    optimizeDeps: VIEW_REACT_OPTIMIZE_DEPS,
     oxc: { jsx: { runtime: "automatic" } },
     plugins: viewsAtStartup
       ? [

--- a/libraries/typescript/packages/server/src/cli/views-plugin.ts
+++ b/libraries/typescript/packages/server/src/cli/views-plugin.ts
@@ -16,6 +16,18 @@ const VIRTUAL_TAILWIND_RESOLVED_ID = `\0${VIRTUAL_TAILWIND_ID}`;
 const VIRTUAL_CSP_RUNTIME_ID = "virtual:mcp-use/csp-runtime";
 const VIRTUAL_CSP_RUNTIME_RESOLVED_ID = `\0${VIRTUAL_CSP_RUNTIME_ID}`;
 
+/** React packages that must resolve to one browser module in managed views. */
+export const VIEW_REACT_DEDUPE = ["react", "react-dom"];
+
+/**
+ * Keep the framework's ESM view runtime out of Vite's dependency bundle while
+ * pre-bundling the CommonJS React entry points it imports.
+ */
+export const VIEW_REACT_OPTIMIZE_DEPS = {
+  exclude: ["mcp-use/react"],
+  include: ["react", "react-dom", "react-dom/client"],
+};
+
 /**
  * Options for {@link mcpUseViewsPlugin}.
  *
@@ -60,7 +72,8 @@ export function mcpUseViewsPlugin(options: McpUseViewsPluginOptions): Plugin {
         // mcp-use/react entry to versioned and unversioned React URLs. Those
         // are distinct browser modules and trigger React's invalid-hook-call
         // guard even though they originate from the same installed package.
-        resolve: { dedupe: ["react", "react-dom"] },
+        resolve: { dedupe: VIEW_REACT_DEDUPE },
+        optimizeDeps: VIEW_REACT_OPTIMIZE_DEPS,
       };
     },
     applyToEnvironment(environment) {

--- a/libraries/typescript/packages/server/tests/cli/build.test.ts
+++ b/libraries/typescript/packages/server/tests/cli/build.test.ts
@@ -357,6 +357,10 @@ describe("runBuild (views)", () => {
     )();
     expect(resolvedConfig).toMatchObject({
       resolve: { dedupe: ["react", "react-dom"] },
+      optimizeDeps: {
+        exclude: ["mcp-use/react"],
+        include: ["react", "react-dom", "react-dom/client"],
+      },
     });
 
     const resolveId = plugin.resolveId;


### PR DESCRIPTION
## Summary

Follow-up to #2011 after verification against the published beta exposed that Vite's dependency optimizer still served React under versioned and unversioned URLs on the first render.

- keep the ESM `mcp-use/react` entry out of Vite's dependency bundle
- explicitly optimize its CommonJS `react`, `react-dom`, and `react-dom/client` dependencies
- enforce React deduplication in the final inline dev-server config, where user/plugin config can no longer change the optimizer boundary
- add regression coverage and a patch changeset for `mcp-use` and `@mcp-use/cli`

## Verification

- `vitest run tests/cli/build.test.ts tests/cli/dev.test.ts` (49 passed)
- `mcp-use` typecheck, ESLint, Prettier, and changeset status
- packed the updated CLI into a clean public `mcp-use@2.0.0-beta.57` scaffold with no user Vite config and an empty `.mcp-use` cache
- executed `show-app` in the built-in Inspector: the app rendered, browser errors were empty, Vite's forwarded server console had no invalid-hook errors, and the CSP `eval` warning remained absent

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure React loads only once in managed views by deduping `react`/`react-dom` and keeping the `mcp-use/react` ESM entry out of Vite’s pre-bundle. This fixes invalid hook calls caused by mixed versioned and unversioned React URLs on first render.

- **Bug Fixes**
  - Exclude `mcp-use/react` from `optimizeDeps`; explicitly include `react`, `react-dom`, and `react-dom/client`.
  - Enforce React deduplication in both the views plugin and the final inline dev-server config to lock optimizer boundaries.
  - Add regression test; publish patch changesets for `mcp-use` and `@mcp-use/cli`.

<sup>Written for commit 7f15238fcde9065184760f09a2599a60058aaa86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

