### PR TITLE
fix: remove starter view control overlap

### DIFF
--- a/libraries/typescript/.changeset/calm-cards-float.md
+++ b/libraries/typescript/.changeset/calm-cards-float.md
@@ -1,0 +1,8 @@
+---
+"create-mcp-use-app": patch
+"mcp-use": patch
+---
+
+Refine the MCP Apps starter display modes by removing its picture-in-picture exit control and moving the mcp-use badge to the top in fullscreen.
+
+Show a centered, CSS-only `Compiling...` indicator while a view's entry module loads, and remove it before rendering the app.

--- a/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/views/my-view/icons.tsx
+++ b/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/views/my-view/icons.tsx
@@ -31,23 +31,6 @@ export function PipIcon() {
   );
 }
 
-export function CloseIcon() {
-  return (
-    <svg
-      width="14"
-      height="14"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      aria-hidden
-    >
-      <line x1="18" y1="6" x2="6" y2="18" />
-      <line x1="6" y1="6" x2="18" y2="18" />
-    </svg>
-  );
-}
-
 export function SunIcon() {
   return (
     <svg

--- a/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/views/my-view/view.tsx
+++ b/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/views/my-view/view.tsx
@@ -16,7 +16,6 @@ import { useState } from "react";
 import { z } from "zod";
 
 import {
-  CloseIcon,
   ExpandIcon,
   ExternalLinkIcon,
   MonitorIcon,
@@ -124,65 +123,47 @@ export default function McpApp() {
                 </span>
               </Tooltip>
             </div>
-            <div className="flex items-center gap-2">
-              {!isFullscreen && !isPip && (
-                <>
-                  {availableDisplayModes.includes("pip") && (
-                    <Tooltip
-                      label="MCP Apps display mode: picture-in-picture"
-                      multiline
-                    >
-                      <button
-                        type="button"
-                        className="cursor-pointer rounded-full border border-neutral-300 p-2 text-neutral-900 transition-colors hover:bg-neutral-100 dark:border-neutral-600 dark:text-neutral-100 dark:hover:bg-neutral-800"
-                        aria-label="Picture-in-picture"
-                        onClick={() => void requestDisplayMode({ mode: "pip" })}
-                      >
-                        <PipIcon />
-                      </button>
-                    </Tooltip>
-                  )}
-                  {availableDisplayModes.includes("fullscreen") && (
-                    <Tooltip
-                      label="MCP Apps display mode: fullscreen"
-                      multiline
-                    >
-                      <button
-                        type="button"
-                        className="cursor-pointer rounded-full border border-neutral-300 p-2 text-neutral-900 transition-colors hover:bg-neutral-100 dark:border-neutral-600 dark:text-neutral-100 dark:hover:bg-neutral-800"
-                        aria-label="Fullscreen"
-                        onClick={() =>
-                          void requestDisplayMode({ mode: "fullscreen" })
-                        }
-                      >
-                        <ExpandIcon />
-                      </button>
-                    </Tooltip>
-                  )}
-                </>
-              )}
-              {(isFullscreen || isPip) && (
-                <Tooltip
-                  label="MCP Apps display mode: return to inline"
-                  multiline
-                >
-                  <button
-                    type="button"
-                    className="cursor-pointer rounded-full border border-neutral-300 p-2 text-neutral-900 transition-colors hover:bg-neutral-100 dark:border-neutral-600 dark:text-neutral-100 dark:hover:bg-neutral-800"
-                    aria-label="Exit"
-                    onClick={() => void requestDisplayMode({ mode: "inline" })}
+            {!isPip && (
+              <div className="flex items-center gap-2">
+                {availableDisplayModes.includes("pip") && (
+                  <Tooltip
+                    label="MCP Apps display mode: picture-in-picture"
+                    multiline
                   >
-                    <CloseIcon />
-                  </button>
-                </Tooltip>
-              )}
-            </div>
+                    <button
+                      type="button"
+                      className="cursor-pointer rounded-full border border-neutral-300 p-2 text-neutral-900 transition-colors hover:bg-neutral-100 dark:border-neutral-600 dark:text-neutral-100 dark:hover:bg-neutral-800"
+                      aria-label="Picture-in-picture"
+                      onClick={() => void requestDisplayMode({ mode: "pip" })}
+                    >
+                      <PipIcon />
+                    </button>
+                  </Tooltip>
+                )}
+                {availableDisplayModes.includes("fullscreen") && (
+                  <Tooltip label="MCP Apps display mode: fullscreen" multiline>
+                    <button
+                      type="button"
+                      className="cursor-pointer rounded-full border border-neutral-300 p-2 text-neutral-900 transition-colors hover:bg-neutral-100 dark:border-neutral-600 dark:text-neutral-100 dark:hover:bg-neutral-800"
+                      aria-label="Fullscreen"
+                      onClick={() =>
+                        void requestDisplayMode({ mode: "fullscreen" })
+                      }
+                    >
+                      <ExpandIcon />
+                    </button>
+                  </Tooltip>
+                )}
+              </div>
+            )}
           </div>
         )}
         {!isMobile && (
           <button
             type="button"
-            className="absolute bottom-6 left-1/2 z-20 flex -translate-x-1/2 cursor-pointer flex-col items-center gap-1 border-0 bg-transparent p-0 text-neutral-900 transition-opacity hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-50"
+            className={`absolute left-1/2 z-20 flex -translate-x-1/2 cursor-pointer flex-col items-center gap-1 border-0 bg-transparent p-0 text-neutral-900 transition-opacity hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-50 ${
+              isFullscreen ? "top-6" : "bottom-6"
+            }`}
             disabled={!canOpenExternal}
             title="mcp-use on GitHub"
             onClick={() =>
@@ -202,7 +183,7 @@ export default function McpApp() {
         <div
           className={`relative z-10 flex flex-col items-center text-center ${
             isFullscreen
-              ? "min-h-0 flex-1 justify-center overflow-y-auto px-6 py-8"
+              ? "min-h-0 flex-1 justify-center overflow-y-auto px-6 pt-24 pb-8"
               : isMobile
                 ? "px-6 py-10"
                 : "min-h-[400px] px-8 py-8 pb-16 sm:min-h-[440px] sm:px-10 sm:py-10 sm:pb-16"

--- a/libraries/typescript/packages/server/specs/VIEWS_SPEC.md
+++ b/libraries/typescript/packages/server/specs/VIEWS_SPEC.md
@@ -475,7 +475,7 @@ By default, both static routes include `Access-Control-Allow-Origin: *`; an expl
 - **`external` (dev):** resolve origin-absolute Vite paths, including `/@vite/client` and the virtual view entry, against the request-derived assets base. Emit the same external tags.
 - **`inline` (production opt-in):** emit `<style>` and inline `<script type="module">` tags with HTML-end-tag escaping. `mcp-use build --inline` emits this entry kind.
 
-Every branch includes `__mcpUseViewConfig`, whose `publicBase` is resolved per request, and a `<div id="root">`. Production split chunks are loaded by relative imports from the entry module and require no additional document tags.
+Every branch includes `__mcpUseViewConfig`, whose `publicBase` is resolved per request, and a `<div id="root" data-mcp-use-loading>`. A framework-owned, CSS-only `Compiling...` indicator is centered while the entry module loads. The bootstrap removes `data-mcp-use-loading` immediately before calling `root.render`, so the indicator cannot overlap the app and requires no additional asset request. Production split chunks are loaded by relative imports from the entry module and require no additional document tags.
 
 **Origin resolution is request-scoped** — applied at `resources/read` emission time:
 

--- a/libraries/typescript/packages/server/src/react/runtime/bootstrap-view.tsx
+++ b/libraries/typescript/packages/server/src/react/runtime/bootstrap-view.tsx
@@ -70,6 +70,9 @@ function configsEqual(
 }
 
 function renderView(mounted: MountedView, View: ComponentType): void {
+  document
+    .getElementById(mounted.rootId)
+    ?.removeAttribute("data-mcp-use-loading");
   mounted.root.render(
     <ErrorBoundary>
       <ViewRuntimeProvider runtime={mounted.runtime}>

--- a/libraries/typescript/packages/server/src/views/document.ts
+++ b/libraries/typescript/packages/server/src/views/document.ts
@@ -104,9 +104,21 @@ function escapeHtml(value: string): string {
     .replaceAll(">", "&gt;");
 }
 
-/** Transparent iframe canvas before React mounts (rounded views show host bg). */
-const TRANSPARENT_IFRAME_STYLE =
-  "<style>html,body,#root{background:transparent}</style>";
+/**
+ * Transparent iframe canvas plus a zero-dependency loading indicator.
+ *
+ * The bootstrap removes the loading attribute immediately before React
+ * renders, so the indicator cannot overlap the mounted app.
+ */
+const VIEW_BOOTSTRAP_STYLE = `<style>
+html,body,#root{background:transparent}
+html,body{margin:0}
+#root[data-mcp-use-loading]{display:flex;min-height:100vh;align-items:center;justify-content:center;flex-direction:column;gap:10px}
+#root[data-mcp-use-loading]::before{width:24px;height:24px;box-sizing:border-box;border:2px solid rgba(127,127,127,.28);border-top-color:rgba(127,127,127,.9);border-radius:50%;content:"";animation:mcp-use-view-spin .7s linear infinite}
+#root[data-mcp-use-loading]::after{color:rgba(127,127,127,.9);content:"Compiling...";font:500 13px/1.2 ui-sans-serif,system-ui,sans-serif}
+@keyframes mcp-use-view-spin{to{transform:rotate(360deg)}}
+@media (prefers-reduced-motion:reduce){#root[data-mcp-use-loading]::before{animation-duration:1.4s}}
+</style>`;
 
 /**
  * Synthesize a complete HTML document for a view from registry data.
@@ -142,11 +154,11 @@ export function synthesizeViewDocument(
 <head>
 <meta charset="utf-8">
 ${configScript}
-${TRANSPARENT_IFRAME_STYLE}
+${VIEW_BOOTSTRAP_STYLE}
 ${styleTag}
 </head>
 <body>
-<div id="root"></div>
+<div id="root" data-mcp-use-loading></div>
 ${moduleScript}
 </body>
 </html>`;
@@ -184,11 +196,11 @@ ${moduleScript}
 <head>
 <meta charset="utf-8">
 ${configScript}
-${TRANSPARENT_IFRAME_STYLE}
+${VIEW_BOOTSTRAP_STYLE}
 ${cssLinks}
 </head>
 <body>
-<div id="root"></div>
+<div id="root" data-mcp-use-loading></div>
 ${scriptTags}
 <script type="module" src="${escapeHtml(entryUrl)}"></script>
 </body>

--- a/libraries/typescript/packages/server/tests/react-bridge.test.tsx
+++ b/libraries/typescript/packages/server/tests/react-bridge.test.tsx
@@ -2864,6 +2864,32 @@ describe("react bridge runtime", () => {
     expect(startCount).toBe(1);
   });
 
+  it("removes the compiling indicator before the app renders", async () => {
+    resetRuntime();
+    const { init } = await startHost();
+    const container = document.createElement("div");
+    container.id = "root";
+    container.setAttribute("data-mcp-use-loading", "");
+    document.body.appendChild(container);
+    let loadingAttributeDuringRender: boolean | undefined;
+
+    function Probe() {
+      loadingAttributeDuringRender = container.hasAttribute(
+        "data-mcp-use-loading"
+      );
+      return <div data-testid="probe">ready</div>;
+    }
+
+    bootstrapView({ default: Probe as ComponentType });
+
+    expect(container.hasAttribute("data-mcp-use-loading")).toBe(false);
+    await init;
+    await waitFor(() => {
+      expect(screen.getByTestId("probe").textContent).toBe("ready");
+    });
+    expect(loadingAttributeDuringRender).toBe(false);
+  });
+
   it("changed HMR viewConfig warns and keeps the original config", async () => {
     resetRuntime();
     const { init } = await startHost();

--- a/libraries/typescript/packages/server/tests/views.test.ts
+++ b/libraries/typescript/packages/server/tests/views.test.ts
@@ -1233,9 +1233,11 @@ describe("views document synthesis", () => {
     expect(html).not.toMatch(/<script[^>]+src=/);
     expect(html).not.toMatch(/<link[^>]+stylesheet/);
     expect(html).toContain("__mcpUseViewConfig");
-    expect(html).toContain(
-      "<style>html,body,#root{background:transparent}</style>"
-    );
+    expect(html).toContain("html,body,#root{background:transparent}");
+    expect(html).toContain('<div id="root" data-mcp-use-loading></div>');
+    expect(html).toContain("#root[data-mcp-use-loading]");
+    expect(html).toContain('content:"Compiling..."');
+    expect(html).toContain("@keyframes mcp-use-view-spin");
   });
 
   it("escapes </script> inside inlined module source so the document does not terminate early", () => {
@@ -1275,6 +1277,7 @@ describe("views document synthesis", () => {
       'src="http://localhost:3000/@id/__x00__virtual:mcp-use/views/demo"'
     );
     expect(html).toContain('src="http://localhost:3000/@vite/client"');
+    expect(html).toContain('<div id="root" data-mcp-use-loading></div>');
   });
 
   it("resolves view-relative production asset paths", () => {


### PR DESCRIPTION
## What changed

- remove the starter app-owned PIP exit control
- move the Built with mcp-use badge to the top in fullscreen
- show a CSS-only `Compiling...` indicator while view modules load
- remove the indicator synchronously before React renders

## Why

The dev card loads an external Vite module graph. The old `:empty`-based loader could briefly remain composited as the app mounted. The explicit loading attribute is cleared immediately before `root.render()`.

## Validation

- 115 focused server runtime/document tests
- server typecheck and build
- 20 create-mcp-use-app tests
- changeset validation
- local Inspector display-mode verification

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix overlapping controls in the MCP Apps starter by removing the app-owned picture-in-picture exit button and adding a centered, CSS-only “Compiling...” indicator that is cleared just before React renders. In fullscreen, the `mcp-use` badge is moved to the top; changes apply to `create-mcp-use-app` templates and the server view bootstrap.

<sup>Written for commit 34a5c810cb6049b64699e08c52aaf8d3780d2f3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

