### PR TITLE
fix: publish stable inspector image to Docker Hub

### DIFF
--- a/.github/workflows/publish-inspector-docker.yml
+++ b/.github/workflows/publish-inspector-docker.yml
@@ -1,0 +1,91 @@
+name: Publish Inspector Docker image
+
+on:
+  workflow_run:
+    workflows: [TypeScript Release]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: publish-inspector-docker-${{ github.event.workflow_run.head_sha || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish stable Inspector image
+    # Manual runs republish npm's current stable Inspector version. Automatic
+    # runs start only after a successful TypeScript release on main.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || 'main' }}
+          fetch-depth: 0
+
+      - name: Determine stable Inspector version
+        id: version
+        run: |
+          set -euo pipefail
+
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            # A manual recovery must resolve the registry's current latest
+            # dist-tag, not a cached npm metadata response.
+            npm cache clean --force
+            VERSION=$(npm view --prefer-online '@mcp-use/inspector@latest' version)
+          else
+            git fetch --tags --force
+            INSPECTOR_TAG=$(git tag --points-at HEAD | grep -E '^@mcp-use/inspector@[0-9]+\.[0-9]+\.[0-9]+$' || true)
+            if [ -z "$INSPECTOR_TAG" ]; then
+              echo "publish=false" >> "$GITHUB_OUTPUT"
+              echo "No stable @mcp-use/inspector release in this workflow run."
+              exit 0
+            fi
+
+            if [ "$(printf '%s\n' "$INSPECTOR_TAG" | wc -l | tr -d ' ')" != "1" ]; then
+              echo "Expected exactly one stable Inspector tag, found: $INSPECTOR_TAG" >&2
+              exit 1
+            fi
+
+            VERSION="${INSPECTOR_TAG#@mcp-use/inspector@}"
+          fi
+
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Expected a stable x.y.z Inspector version, received: $VERSION" >&2
+            exit 1
+          fi
+
+          echo "publish=true" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        if: steps.version.outputs.publish == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        if: steps.version.outputs.publish == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Publish stable Inspector Docker image
+        if: steps.version.outputs.publish == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: libraries/typescript/packages/inspector
+          push: true
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
+          tags: |
+            mcpuse/inspector:${{ steps.version.outputs.version }}
+            mcpuse/inspector:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

- Add a standalone Docker Hub workflow triggered after successful `TypeScript Release` runs on `main`.
- Detect a stable Inspector package tag on the released commit, then publish `mcpuse/inspector:<version>` and `mcpuse/inspector:latest`.
- Support manual dispatch to idempotently republish npm's current `@mcp-use/inspector@latest` version.

## Why

Docker Hub is currently outside the Inspector release path. Keeping it in a separate workflow means Docker Hub failures cannot interrupt npm publication or the TypeScript release workflow, while manual dispatch can repair a stale image.

## Validation

- Parsed the workflow as YAML.
- Ran `git diff --check`.
- Confirmed npm's current `@mcp-use/inspector@latest` version matches the stable-version validation.