### PR TITLE
Fix beta release CI

### DIFF
--- a/libraries/typescript/packages/agent/examples/_shared.ts
+++ b/libraries/typescript/packages/agent/examples/_shared.ts
@@ -37,7 +37,11 @@ export function filesystemServerConfig(root = process.cwd()) {
     mcpServers: {
       filesystem: {
         command: "npx",
-        args: ["-y", "@modelcontextprotocol/server-filesystem", path.resolve(root)],
+        args: [
+          "-y",
+          "@modelcontextprotocol/server-filesystem",
+          path.resolve(root),
+        ],
       },
     },
   };

--- a/libraries/typescript/packages/agent/examples/advanced/observability.ts
+++ b/libraries/typescript/packages/agent/examples/advanced/observability.ts
@@ -39,7 +39,8 @@ async function main() {
 
   try {
     const result = await agent.run({
-      prompt: "Use the add tool to calculate 9 + 11. Reply with the number only.",
+      prompt:
+        "Use the add tool to calculate 9 + 11. Reply with the number only.",
     });
     console.log("Result:", result);
     await agent.flush();

--- a/libraries/typescript/packages/agent/examples/advanced/stream_example.ts
+++ b/libraries/typescript/packages/agent/examples/advanced/stream_example.ts
@@ -18,7 +18,8 @@ async function streamStepsExample() {
   });
 
   try {
-    const prompt = "Use the add tool to calculate 12 + 30. Reply with just the number.";
+    const prompt =
+      "Use the add tool to calculate 12 + 30. Reply with just the number.";
     console.log("Query:", prompt, "\n");
 
     let stepNumber = 1;

--- a/libraries/typescript/packages/agent/examples/basic/chat_example.ts
+++ b/libraries/typescript/packages/agent/examples/basic/chat_example.ts
@@ -41,7 +41,9 @@ async function runMemoryChat() {
   const question = (prompt: string) =>
     new Promise<string>((resolve) => rl.question(prompt, resolve));
 
-  console.error("Interactive MCP chat — type exit to quit, clear to reset memory");
+  console.error(
+    "Interactive MCP chat — type exit to quit, clear to reset memory"
+  );
 
   try {
     while (true) {

--- a/libraries/typescript/packages/agent/examples/frameworks/ai_sdk_example.ts
+++ b/libraries/typescript/packages/agent/examples/frameworks/ai_sdk_example.ts
@@ -17,7 +17,9 @@ async function* streamEventsToAISDK(
 ): AsyncGenerator<string, void, void> {
   for await (const event of streamEvents) {
     if (event.event === "on_chat_model_stream") {
-      const chunk = event.data?.chunk as { text?: string; content?: string } | undefined;
+      const chunk = event.data?.chunk as
+        | { text?: string; content?: string }
+        | undefined;
       const text =
         typeof chunk?.text === "string"
           ? chunk.text

--- a/libraries/typescript/packages/agent/examples/server-management/multi_server_example.ts
+++ b/libraries/typescript/packages/agent/examples/server-management/multi_server_example.ts
@@ -20,11 +20,7 @@ async function main() {
       },
       filesystem: {
         command: "npx",
-        args: [
-          "-y",
-          "@modelcontextprotocol/server-filesystem",
-          process.cwd(),
-        ],
+        args: ["-y", "@modelcontextprotocol/server-filesystem", process.cwd()],
       },
     },
     maxSteps: 20,

--- a/libraries/typescript/packages/agent/tests/docs/agent-quick-start.test.ts
+++ b/libraries/typescript/packages/agent/tests/docs/agent-quick-start.test.ts
@@ -9,10 +9,7 @@ import { fileURLToPath } from "node:url";
 import { OPENAI_MODEL } from "../integration/agent/constants.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const simpleServerPath = resolve(
-  __dirname,
-  "../servers/simple_server.ts"
-);
+const simpleServerPath = resolve(__dirname, "../servers/simple_server.ts");
 
 describe.skipIf(!process.env.OPENAI_API_KEY)(
   "Documentation Example: MCPAgent Quick Start",

--- a/libraries/typescript/packages/agent/tests/servers/simple_server.ts
+++ b/libraries/typescript/packages/agent/tests/servers/simple_server.ts
@@ -44,7 +44,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const b = Number(request.params.arguments?.b);
   if (Number.isNaN(a) || Number.isNaN(b)) {
     return {
-      content: [{ type: "text", text: "Error: both arguments must be numbers" }],
+      content: [
+        { type: "text", text: "Error: both arguments must be numbers" },
+      ],
       isError: true,
     };
   }

--- a/libraries/typescript/pnpm-workspace.yaml
+++ b/libraries/typescript/pnpm-workspace.yaml
@@ -10,6 +10,10 @@ packages:
   - packages/create-mcp-use-app/src/templates/**/*
   # tests
   - test_app
+
+catalog:
+  "@modelcontextprotocol/sdk": ">=1.25.2"
+
 onlyBuiltDependencies:
   - "@tailwindcss/oxide"
   - esbuild


### PR DESCRIPTION
## Summary

- define the default pnpm catalog entry used by the Agent package
- format the eight Agent example and test files reported by TypeScript CI

## Root cause

`@mcp-use/agent` declared `@modelcontextprotocol/sdk` with the `catalog:` protocol, but `pnpm-workspace.yaml` did not define the corresponding default catalog entry. Frozen installation succeeded from the existing lockfile, while `pnpm pack` failed during beta tarball verification with `ERR_PNPM_CATALOG_ENTRY_NOT_FOUND_FOR_SPEC`.

The lint job separately failed because eight newly added Agent files were not Prettier-compliant.

## Impact

The beta release workflow can pack and verify all publishable TypeScript packages, and the TypeScript formatting check is clean.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm format:check`
- `pnpm build`
- `pnpm verify:beta-packs`
- `git diff --check`
- repository pre-commit formatting, lint, and changeset checks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes beta release CI by adding a default pnpm `catalog` entry for `@modelcontextprotocol/sdk` used by `@mcp-use/agent`, and formatting Agent examples/tests. Beta packs now verify cleanly and formatting checks pass.

- **Dependencies**
  - Add workspace `catalog` mapping in `pnpm-workspace.yaml`: `@modelcontextprotocol/sdk` → `>=1.25.2`, resolving `ERR_PNPM_CATALOG_ENTRY_NOT_FOUND_FOR_SPEC` during `pnpm pack`.

- **Bug Fixes**
  - Prettier-format eight Agent example/test files to make the lint job pass.

<sup>Written for commit b6fd23262ea0b39637fac6c96b29be552b5019fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2024?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

