### PR TITLE
docs: fix V2 API reference navigation link

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -489,7 +489,7 @@
               {
                 "tab": "API Reference",
                 "icon": "terminal",
-                "href": "https://docs.mcp-use.com/v2/api-reference"
+                "href": "https://api-reference.mcp-use.com"
               }
             ]
           }


### PR DESCRIPTION
## Summary

- point the V2 TypeScript SDK API Reference navigation tab to `https://api-reference.mcp-use.com`
- leave V1 API-reference navigation and links unchanged

## Why

The V2 tab previously pointed to the unavailable `https://docs.mcp-use.com/v2/api-reference` route. The TypeDoc reference has a dedicated intended hostname, so V2 navigation should use that destination.

## Impact

V2 documentation users are routed to the intended TypeDoc API reference destination. V1 documentation behavior is unaffected.

## Validation

- `python3 -m json.tool docs/docs.json`
- `git diff --check`
- Mintlify local preview rendered the updated V2 navigation at `http://localhost:3000`

## Deployment note

The target hostname currently returns `ERR_NAME_NOT_RESOLVED`, so its DNS/deployment still needs to become publicly available.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the V2 docs navigation to point the API Reference tab to https://api-reference.mcp-use.com (the intended TypeDoc host). V1 API reference links remain unchanged.

- **Migration**
  - Ensure DNS/deployment for api-reference.mcp-use.com is live; the link will fail until it resolves.

<sup>Written for commit 0b2719dc8c04a5bc3ddc25c8bf2abde65e8d8aab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2034?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

