### PR TITLE
docs: refine V2 banner and header controls

### DIFF
--- a/docs/fonts.css
+++ b/docs/fonts.css
@@ -41,6 +41,18 @@ html:not([data-current-path^="/v2/typescript/"]) #banner {
   pointer-events: none !important;
 }
 
+html[data-current-path^="/v2/typescript/"] #banner {
+  background: #60a5fa !important;
+}
+
+[data-component-part="products-selector-trigger"] {
+  order: 1;
+}
+
+div:has(> [data-component-part="version-select-trigger"]) {
+  order: 2;
+}
+
 html[data-current-path^="/v2/typescript/"]
   [data-component-part="version-select-trigger"]
   > span::after {


### PR DESCRIPTION
## Summary
- use a darker blue V2 beta banner in both light and dark modes
- order the TypeScript header controls as wordmark, library selector, then version selector

## Validation
- `mint validate`
- `mint broken-links`
- local Mintlify preview in light and dark modes

Stacked on #2010.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refines the V2 TypeScript docs header: uses a darker blue beta banner in light and dark modes and reorders controls so the library selector appears before the version selector. Changes apply only to V2 TypeScript pages.

<sup>Written for commit 2907bd8488e5038241beb508d8c765d017ce6a36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

