### PR TITLE
Resolve beta scaffold SDK version at runtime

### DIFF
--- a/libraries/typescript/.changeset/fresh-beta-scaffolds.md
+++ b/libraries/typescript/.changeset/fresh-beta-scaffolds.md
@@ -1,0 +1,5 @@
+---
+"create-mcp-use-app": patch
+---
+
+Resolve the current `mcp-use` beta dist-tag when scaffolding a project so generated package manifests no longer pin a stale beta version.

--- a/libraries/typescript/packages/create-mcp-use-app/src/index.ts
+++ b/libraries/typescript/packages/create-mcp-use-app/src/index.ts
@@ -293,24 +293,6 @@ const packageJson = JSON.parse(
   readFileSync(join(__dirname, "../package.json"), "utf-8")
 );
 
-// TODO(stable release): Change this back to "latest" before publishing create-mcp-use-app 2.0.0.
-const DEFAULT_MCP_USE_VERSION = "2.0.0-beta.36";
-
-function getCurrentPackageVersions(
-  isDevelopment: boolean = false,
-  sdkVersion?: string
-): Record<string, string> {
-  if (isDevelopment) {
-    return {
-      "mcp-use": "workspace:*",
-    };
-  }
-  const requestedSdk = sdkVersion ?? DEFAULT_MCP_USE_VERSION;
-  return {
-    "mcp-use": requestedSdk,
-  };
-}
-
 function processTemplateFile(
   filePath: string,
   versions: Record<string, string>,
@@ -327,9 +309,7 @@ function processTemplateFile(
     );
   }
 
-  const mcpUseVersion = isDevelopment
-    ? "workspace:*"
-    : versions["mcp-use"] || DEFAULT_MCP_USE_VERSION;
+  const mcpUseVersion = isDevelopment ? "workspace:*" : versions["mcp-use"];
 
   if (isDevelopment) {
     processedContent = processedContent.replace(
@@ -914,14 +894,42 @@ async function main(): Promise<void> {
       );
       process.exit(1);
     }
+  }
 
+  let mcpUseVersion: string;
+  if (options.dev) {
+    mcpUseVersion = "workspace:*";
+  } else if (options.sdkVersion) {
+    mcpUseVersion = options.sdkVersion;
+  } else {
+    const response = await fetch("https://registry.npmjs.org/mcp-use", {
+      headers: { Accept: "application/vnd.npm.install-v1+json" },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!response.ok) {
+      throw new Error(
+        `Failed to resolve the mcp-use beta dist-tag from npm (${response.status})`
+      );
+    }
+
+    const metadata = (await response.json()) as {
+      "dist-tags"?: { beta?: string };
+    };
+    const betaVersion = metadata["dist-tags"]?.beta;
+    if (!betaVersion) {
+      throw new Error("npm did not return a beta version for mcp-use");
+    }
+    mcpUseVersion = betaVersion;
+  }
+  const versions = { "mcp-use": mcpUseVersion };
+
+  if (!useCurrentDir) {
     mkdirSync(projectPath, { recursive: true });
   }
 
   console.log(ansi.cyan(`🚀 Creating MCP server "${displayName}"...`));
 
   const validatedTemplate = validateTemplateName(selectedTemplate);
-  const versions = getCurrentPackageVersions(options.dev, options.sdkVersion);
 
   await copyTemplate(projectPath, validatedTemplate, versions, options.dev);
 

--- a/libraries/typescript/packages/create-mcp-use-app/test-cli.sh
+++ b/libraries/typescript/packages/create-mcp-use-app/test-cli.sh
@@ -12,7 +12,7 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
-EXPECTED_DEFAULT_MCP_USE_VERSION="2.0.0-beta.36"
+EXPECTED_DEFAULT_MCP_USE_VERSION="$(node -e 'fetch("https://registry.npmjs.org/mcp-use", { headers: { Accept: "application/vnd.npm.install-v1+json" } }).then(response => { if (!response.ok) throw new Error(`npm registry returned ${response.status}`); return response.json(); }).then(metadata => process.stdout.write(metadata["dist-tags"].beta))')"
 
 # Get script directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
## What changed

- Fetch the abbreviated npm packument from `https://registry.npmjs.org/mcp-use` in the default scaffold flow and use `dist-tags.beta`.
- Keep a 10-second timeout, reject non-success HTTP responses, and fail if the beta tag is missing.
- Preserve explicit `--sdk-version` overrides and `--dev` workspace behavior without a registry request.
- Resolve before creating a new destination directory so lookup failures do not leave a partial scaffold.
- Update the CLI integration expectation to read the same public registry response instead of retaining a stale hard-coded version.
- Add a patch changeset scoped to `create-mcp-use-app`.

## Why

`create-mcp-use-app` embedded a fixed beta SDK version, so published beta scaffolds could generate projects pinned to an older `mcp-use` beta after the dist-tag advanced. Reading the canonical npm tag at scaffold time keeps generated projects aligned with the current beta train.

## Validation

- `pnpm exec changeset status` (patch: `create-mcp-use-app` only)
- `pnpm --filter create-mcp-use-app test` (20 tests)
- `pnpm --filter create-mcp-use-app build`
- `pnpm --filter create-mcp-use-app lint`
- `pnpm --filter create-mcp-use-app test:cli` (10 scaffold cases, including default beta, `--dev`, and explicit overrides)
- `git diff --check`