### PR TITLE
feat(excalidraw): add in-place drawing edits

### DIFF
--- a/libraries/typescript/packages/server/examples/views/excalidraw/README.md
+++ b/libraries/typescript/packages/server/examples/views/excalidraw/README.md
@@ -24,6 +24,10 @@ export to excalidraw.com.
   invalid JSON.
 - **Model context** — `<ModelContext>` plus imperative `modelContext.set` for
   user edit summaries from fullscreen.
+- **In-place model edits** — the mounted view registers `edit_drawing` with
+  `useViewTool`. Structured create/update/move/delete/replace operations apply
+  to the current scene, update the same checkpoint, and keep the same iframe
+  and canvas mounted.
 - **External assets CSP** — Excalidraw CSS/fonts load from `https://esm.sh`
   via `view.csp`.
 
@@ -39,9 +43,31 @@ replace the diagram or checkpoint id.
 | --- | --- | --- |
 | `read_me` | model | Element format cheat sheet (call before drawing) |
 | `create_view` | model + view | Stream/render diagram; returns `checkpointId` |
+| `edit_drawing` | model (view tool) | Edit the currently mounted canvas in place |
 | `export_to_excalidraw` | app | Upload encrypted scene to excalidraw.com |
 | `save_checkpoint` | app | Persist fullscreen user edits |
 | `read_checkpoint` | app | Restore checkpoint base while streaming |
+
+## Create, then refine the same canvas
+
+Start with a prompt that creates the initial view:
+
+> Draw a three-step checkout flow in Excalidraw.
+
+Once it is visible, refinements should use the canvas's `edit_drawing` view
+tool rather than calling `create_view` again:
+
+> On this same canvas, move the payment step 80px to the right, make it light
+> yellow, and add a red "Payment failed" branch.
+
+> Keep this drawing open and rename the selected box to "Fraud review".
+
+The edit tool accepts up to 100 sequential operations per call. Each operation
+can create shorthand elements, update safe visual/geometry fields, move targets
+by a delta, delete targets, or replace targets. Targets use the stable IDs from
+the initial drawing and can also include the user's current fullscreen
+selection with `selected: true`. A successful call saves the complete updated
+scene under the original checkpoint before it reports success.
 
 ## Run locally
 

--- a/libraries/typescript/packages/server/examples/views/excalidraw/src/index.ts
+++ b/libraries/typescript/packages/server/examples/views/excalidraw/src/index.ts
@@ -59,9 +59,9 @@ export const createView = server.tool(
   {
     name: "create_view",
     title: "Draw Diagram",
-    description: `Renders a hand-drawn diagram using Excalidraw elements.
+    description: `Creates a new hand-drawn diagram using Excalidraw elements.
 Elements stream in one by one with draw-on animations.
-Call read_me first to learn the element format.`,
+Call read_me first to learn the element format. After the drawing is displayed, refine that same canvas with its edit_drawing view tool instead of calling create_view again.`,
     inputSchema: z.object({
       elements: z
         .string()
@@ -190,11 +190,8 @@ Call read_me first to learn the element format.`,
           type: "text",
           text: `Diagram displayed! Checkpoint id: "${checkpointId}".
 If the user asks to create a new diagram, simply start a new one from scratch.
-If the user instead wants to edit this diagram ("${checkpointId}"), first check this conversation for a "User edited diagram (checkpoint: ${checkpointId})…" note — the view automatically reports any manual edits the user made in fullscreen as extra context here, with no tool call needed on your part. If no such note is present, no manual edits were made.
-Then decide whether you want to make a new diagram from scratch OR use this one as your starting checkpoint:
-  simply start from the first element [{"type":"restoreCheckpoint","id":"${checkpointId}"}, ...your new elements...]
-  this restores the same diagram state the user currently sees, including any manual edits reported above, allowing you to add elements on top.
-  To remove elements, use: {"type":"delete","ids":"<id1>,<id2>"}${ratioHint}`,
+If the user wants to refine or edit this diagram, call the edit_drawing view tool registered by this live canvas. It can create, update, move, delete, or replace elements by their stable IDs and persists this same checkpoint. Do NOT call create_view again for a refinement, because that creates a replacement view.
+Before editing, check this conversation for a "User edited diagram (checkpoint: ${checkpointId})…" note — the view automatically reports manual fullscreen edits as extra context. The edit_drawing tool always applies to the latest live scene, including those manual edits.${ratioHint}`,
         },
       ],
       structuredContent: { checkpointId },

--- a/libraries/typescript/packages/server/examples/views/excalidraw/views/excalidraw/edit-context.ts
+++ b/libraries/typescript/packages/server/examples/views/excalidraw/views/excalidraw/edit-context.ts
@@ -112,6 +112,47 @@ export function getLatestEditedElements(): Record<string, unknown>[] | null {
 }
 
 /**
+ * Persist a model-authored scene immediately and make it the new manual-edit
+ * baseline.
+ *
+ * Unlike the debounced fullscreen handler, a view-tool call must not report
+ * success until the existing checkpoint contains the same scene as the live
+ * canvas.
+ *
+ * @param elements - Complete non-deleted Excalidraw scene after the edit.
+ * @throws When the initial drawing has not produced a checkpoint yet.
+ */
+export async function commitModelEditedElements(
+  elements: readonly Record<string, unknown>[]
+): Promise<void> {
+  if (!checkpointId || !saveCheckpointFn) {
+    throw new Error("The drawing checkpoint is not ready yet.");
+  }
+
+  if (timer) {
+    clearTimeout(timer);
+    timer = null;
+  }
+
+  const live = [...elements].filter((element) => !element.isDeleted);
+  latestEditedElements = live;
+  captureInitialElements(live);
+
+  if (storageKey) {
+    try {
+      localStorage.setItem(storageKey, JSON.stringify(live));
+    } catch {
+      // The server checkpoint remains authoritative if local storage is full.
+    }
+  }
+
+  await saveCheckpointFn({
+    id: checkpointId,
+    data: JSON.stringify({ elements: live }),
+  });
+}
+
+/**
  * Excalidraw onChange handler. Persists to localStorage, syncs checkpoint to
  * the server, and reports a compact edit summary to the owning React view.
  */

--- a/libraries/typescript/packages/server/examples/views/excalidraw/views/excalidraw/edit-operations.ts
+++ b/libraries/typescript/packages/server/examples/views/excalidraw/views/excalidraw/edit-operations.ts
@@ -1,0 +1,462 @@
+import { z } from "zod";
+
+const finiteNumber = z.number().finite();
+const elementId = z.string().trim().min(1).max(128);
+const color = z.string().trim().min(1).max(64);
+
+const bindingSchema = z
+  .object({
+    elementId,
+    focus: finiteNumber.optional(),
+    gap: finiteNumber.optional(),
+    fixedPoint: z.tuple([finiteNumber, finiteNumber]).nullable().optional(),
+  })
+  .strict();
+
+const labelSchema = z
+  .object({
+    text: z.string().max(2_000),
+    fontSize: finiteNumber.min(8).max(96).optional(),
+  })
+  .strict();
+
+const commonElementFields = {
+  id: elementId,
+  x: finiteNumber,
+  y: finiteNumber,
+  strokeColor: color.optional(),
+  backgroundColor: color.optional(),
+  fillStyle: z.enum(["hachure", "cross-hatch", "solid", "zigzag"]).optional(),
+  strokeWidth: finiteNumber.min(0.5).max(20).optional(),
+  strokeStyle: z.enum(["solid", "dashed", "dotted"]).optional(),
+  roughness: finiteNumber.min(0).max(2).optional(),
+  opacity: finiteNumber.min(1).max(100).optional(),
+  angle: finiteNumber.optional(),
+};
+
+const shapeElementSchema = z
+  .object({
+    ...commonElementFields,
+    type: z.enum(["rectangle", "ellipse", "diamond"]),
+    width: finiteNumber.positive().max(20_000),
+    height: finiteNumber.positive().max(20_000),
+    roundness: z
+      .object({ type: z.union([z.literal(1), z.literal(2), z.literal(3)]) })
+      .strict()
+      .optional(),
+    label: labelSchema.optional(),
+  })
+  .strict();
+
+const textElementSchema = z
+  .object({
+    ...commonElementFields,
+    type: z.literal("text"),
+    text: z.string().max(10_000),
+    fontSize: finiteNumber.min(8).max(96).optional(),
+    textAlign: z.enum(["left", "center", "right"]).optional(),
+    verticalAlign: z.enum(["top", "middle", "bottom"]).optional(),
+  })
+  .strict();
+
+const arrowElementSchema = z
+  .object({
+    ...commonElementFields,
+    type: z.literal("arrow"),
+    width: finiteNumber.optional(),
+    height: finiteNumber.optional(),
+    points: z
+      .array(z.tuple([finiteNumber, finiteNumber]))
+      .min(2)
+      .max(100),
+    startArrowhead: z
+      .enum(["arrow", "bar", "dot", "triangle"])
+      .nullable()
+      .optional(),
+    endArrowhead: z
+      .enum(["arrow", "bar", "dot", "triangle"])
+      .nullable()
+      .optional(),
+    startBinding: bindingSchema.nullable().optional(),
+    endBinding: bindingSchema.nullable().optional(),
+    label: labelSchema.optional(),
+  })
+  .strict();
+
+/** Structured shorthand accepted when a model creates or replaces elements. */
+export const editableElementSchema = z.discriminatedUnion("type", [
+  shapeElementSchema,
+  textElementSchema,
+  arrowElementSchema,
+]);
+
+const targetSchema = z
+  .object({
+    ids: z.array(elementId).min(1).max(100).optional(),
+    selected: z
+      .boolean()
+      .optional()
+      .describe("Also target elements selected in the fullscreen editor."),
+  })
+  .strict()
+  .refine((target) => target.ids !== undefined || target.selected === true, {
+    message: "Provide ids or set selected to true.",
+  });
+
+const elementPatchSchema = z
+  .object({
+    x: finiteNumber.optional(),
+    y: finiteNumber.optional(),
+    width: finiteNumber.positive().max(20_000).optional(),
+    height: finiteNumber.positive().max(20_000).optional(),
+    angle: finiteNumber.optional(),
+    strokeColor: color.optional(),
+    backgroundColor: color.optional(),
+    fillStyle: z.enum(["hachure", "cross-hatch", "solid", "zigzag"]).optional(),
+    strokeWidth: finiteNumber.min(0.5).max(20).optional(),
+    strokeStyle: z.enum(["solid", "dashed", "dotted"]).optional(),
+    roughness: finiteNumber.min(0).max(2).optional(),
+    opacity: finiteNumber.min(1).max(100).optional(),
+    roundness: z
+      .object({ type: z.union([z.literal(1), z.literal(2), z.literal(3)]) })
+      .strict()
+      .optional(),
+    points: z
+      .array(z.tuple([finiteNumber, finiteNumber]))
+      .min(2)
+      .max(100)
+      .optional(),
+    startArrowhead: z
+      .enum(["arrow", "bar", "dot", "triangle"])
+      .nullable()
+      .optional(),
+    endArrowhead: z
+      .enum(["arrow", "bar", "dot", "triangle"])
+      .nullable()
+      .optional(),
+    startBinding: bindingSchema.nullable().optional(),
+    endBinding: bindingSchema.nullable().optional(),
+    text: z.string().max(10_000).optional(),
+    fontSize: finiteNumber.min(8).max(96).optional(),
+    textAlign: z.enum(["left", "center", "right"]).optional(),
+    verticalAlign: z.enum(["top", "middle", "bottom"]).optional(),
+    label: labelSchema.optional(),
+  })
+  .strict()
+  .refine((patch) => Object.keys(patch).length > 0, {
+    message: "Update patch cannot be empty.",
+  });
+
+const createChangeSchema = z
+  .object({
+    type: z.literal("create"),
+    elements: z.array(editableElementSchema).min(1).max(50),
+  })
+  .strict();
+
+const updateChangeSchema = z
+  .object({
+    type: z.literal("update"),
+    target: targetSchema,
+    patch: elementPatchSchema,
+  })
+  .strict();
+
+const moveChangeSchema = z
+  .object({
+    type: z.literal("move"),
+    target: targetSchema,
+    deltaX: finiteNumber,
+    deltaY: finiteNumber,
+  })
+  .strict();
+
+const deleteChangeSchema = z
+  .object({
+    type: z.literal("delete"),
+    target: targetSchema,
+  })
+  .strict();
+
+const replaceChangeSchema = z
+  .object({
+    type: z.literal("replace"),
+    target: targetSchema,
+    elements: z.array(editableElementSchema).min(1).max(50),
+  })
+  .strict();
+
+/** Input contract for the live `edit_drawing` view tool. */
+export const editDrawingInputSchema = z
+  .object({
+    changes: z
+      .array(
+        z.discriminatedUnion("type", [
+          createChangeSchema,
+          updateChangeSchema,
+          moveChangeSchema,
+          deleteChangeSchema,
+          replaceChangeSchema,
+        ])
+      )
+      .min(1)
+      .max(100)
+      .describe("Changes are applied sequentially and atomically."),
+  })
+  .strict();
+
+/** Result contract returned to the model after an in-place canvas edit. */
+export const editDrawingOutputSchema = z.object({
+  checkpointId: z.string(),
+  appliedChanges: z.number().int().nonnegative(),
+  elementIds: z.array(z.string()),
+});
+
+/** Parsed input accepted by {@link applyDrawingChanges}. */
+export type EditDrawingInput = z.infer<typeof editDrawingInputSchema>;
+
+/** Minimal scene element shape used by the edit reducer. */
+export type SceneElement = Record<string, unknown> & {
+  id: string;
+  type?: string;
+  x?: number;
+  y?: number;
+  version?: number;
+  containerId?: string | null;
+};
+
+/** Successful output from {@link applyDrawingChanges}. */
+export interface AppliedDrawingChanges {
+  /** Complete live scene after all changes. */
+  elements: SceneElement[];
+  /** IDs directly or indirectly touched by the changes. */
+  changedIds: string[];
+}
+
+type ConvertElements = (
+  elements: z.infer<typeof editableElementSchema>[]
+) => SceneElement[];
+
+function touched(element: SceneElement, patch: Record<string, unknown>) {
+  return {
+    ...element,
+    ...patch,
+    version: (element.version ?? 0) + 1,
+    versionNonce: Math.floor(Math.random() * 2 ** 31),
+    updated: Date.now(),
+  } satisfies SceneElement;
+}
+
+function targetIds(
+  target: z.infer<typeof targetSchema>,
+  selectedIds: readonly string[]
+): string[] {
+  return [
+    ...new Set([
+      ...(target.ids ?? []),
+      ...(target.selected === true ? selectedIds : []),
+    ]),
+  ];
+}
+
+function assertTargetsExist(elements: SceneElement[], ids: string[]): void {
+  if (ids.length === 0) {
+    throw new Error("No elements are selected.");
+  }
+  const existing = new Set(elements.map((element) => element.id));
+  const missing = ids.filter((id) => !existing.has(id));
+  if (missing.length > 0) {
+    throw new Error(`Element IDs not found: ${missing.join(", ")}.`);
+  }
+}
+
+function removeElements(
+  elements: SceneElement[],
+  ids: string[]
+): SceneElement[] {
+  const removed = new Set(ids);
+  for (const element of elements) {
+    if (
+      typeof element.containerId === "string" &&
+      removed.has(element.containerId)
+    ) {
+      removed.add(element.id);
+    }
+  }
+
+  return elements
+    .filter((element) => !removed.has(element.id))
+    .map((element) => {
+      if (!Array.isArray(element.boundElements)) return element;
+      const boundElements = element.boundElements.filter(
+        (binding): binding is { id: string; type: string } =>
+          typeof binding === "object" &&
+          binding !== null &&
+          "id" in binding &&
+          typeof binding.id === "string" &&
+          !removed.has(binding.id)
+      );
+      return boundElements.length === element.boundElements.length
+        ? element
+        : touched(element, { boundElements });
+    });
+}
+
+function addElements(
+  elements: SceneElement[],
+  raw: z.infer<typeof editableElementSchema>[],
+  convertElements: ConvertElements
+): { elements: SceneElement[]; addedIds: string[] } {
+  const converted = convertElements(raw);
+  const existing = new Set(elements.map((element) => element.id));
+  const duplicate = converted.find((element) => existing.has(element.id));
+  if (duplicate) {
+    throw new Error(
+      `Element ID "${duplicate.id}" already exists. Use update or replace, or choose a new ID.`
+    );
+  }
+  const addedIds = converted.map((element) => element.id);
+  if (new Set(addedIds).size !== addedIds.length) {
+    throw new Error("Created elements contain duplicate IDs.");
+  }
+  return { elements: [...elements, ...converted], addedIds };
+}
+
+/**
+ * Apply bounded model-authored changes to an existing Excalidraw scene.
+ *
+ * The reducer is atomic: validation or a missing target throws before the
+ * returned scene can replace the live canvas. Generated label elements are
+ * supplied by the same shorthand converter used for the initial drawing.
+ *
+ * @param currentElements - Current non-deleted Excalidraw scene.
+ * @param input - Validated structured edit request.
+ * @param selectedIds - Current fullscreen selection, if any.
+ * @param convertElements - Existing shorthand-to-Excalidraw converter.
+ * @returns The complete updated scene and touched element IDs.
+ */
+export function applyDrawingChanges(
+  currentElements: readonly SceneElement[],
+  input: EditDrawingInput,
+  selectedIds: readonly string[],
+  convertElements: ConvertElements
+): AppliedDrawingChanges {
+  let elements = currentElements.map((element) => ({ ...element }));
+  const changedIds = new Set<string>();
+
+  for (const change of input.changes) {
+    if (change.type === "create") {
+      const added = addElements(elements, change.elements, convertElements);
+      elements = added.elements;
+      added.addedIds.forEach((id) => changedIds.add(id));
+      continue;
+    }
+
+    const ids = targetIds(change.target, selectedIds);
+    assertTargetsExist(elements, ids);
+
+    if (change.type === "delete") {
+      const before = new Set(elements.map((element) => element.id));
+      elements = removeElements(elements, ids);
+      const after = new Set(elements.map((element) => element.id));
+      for (const id of before) {
+        if (!after.has(id)) changedIds.add(id);
+      }
+      continue;
+    }
+
+    if (change.type === "replace") {
+      const withoutTargets = removeElements(elements, ids);
+      const added = addElements(
+        withoutTargets,
+        change.elements,
+        convertElements
+      );
+      elements = added.elements;
+      ids.forEach((id) => changedIds.add(id));
+      added.addedIds.forEach((id) => changedIds.add(id));
+      continue;
+    }
+
+    if (change.type === "move") {
+      const movedIds = new Set(ids);
+      for (const element of elements) {
+        if (
+          typeof element.containerId === "string" &&
+          movedIds.has(element.containerId)
+        ) {
+          movedIds.add(element.id);
+        }
+      }
+      elements = elements.map((element) => {
+        if (!movedIds.has(element.id)) return element;
+        changedIds.add(element.id);
+        return touched(element, {
+          x: (element.x ?? 0) + change.deltaX,
+          y: (element.y ?? 0) + change.deltaY,
+        });
+      });
+      continue;
+    }
+
+    const { label, ...patch } = change.patch;
+    const idSet = new Set(ids);
+    const originalById = new Map(
+      elements.map((element) => [element.id, element] as const)
+    );
+    elements = elements.map((element) => {
+      if (!idSet.has(element.id)) return element;
+      changedIds.add(element.id);
+      return touched(element, patch);
+    });
+
+    for (const id of ids) {
+      const original = originalById.get(id);
+      if (!original) continue;
+      const updated = elements.find((element) => element.id === id);
+      const deltaX = (updated?.x ?? 0) - (original.x ?? 0);
+      const deltaY = (updated?.y ?? 0) - (original.y ?? 0);
+      const boundLabels = elements.filter(
+        (element) => element.type === "text" && element.containerId === id
+      );
+
+      if (label !== undefined && boundLabels.length === 0) {
+        throw new Error(
+          `Element "${id}" has no bound label. Replace it with a labeled element instead.`
+        );
+      }
+
+      if (deltaX !== 0 || deltaY !== 0 || label !== undefined) {
+        elements = elements.map((element) => {
+          if (
+            element.type !== "text" ||
+            element.containerId !== id ||
+            idSet.has(element.id)
+          ) {
+            return element;
+          }
+          changedIds.add(element.id);
+          return touched(element, {
+            ...(deltaX !== 0 || deltaY !== 0
+              ? {
+                  x: (element.x ?? 0) + deltaX,
+                  y: (element.y ?? 0) + deltaY,
+                }
+              : {}),
+            ...(label !== undefined
+              ? {
+                  text: label.text,
+                  originalText: label.text,
+                  ...(label.fontSize !== undefined
+                    ? { fontSize: label.fontSize }
+                    : {}),
+                }
+              : {}),
+          });
+        });
+      }
+    }
+  }
+
+  return { elements, changedIds: [...changedIds] };
+}

--- a/libraries/typescript/packages/server/examples/views/excalidraw/views/excalidraw/view.tsx
+++ b/libraries/typescript/packages/server/examples/views/excalidraw/views/excalidraw/view.tsx
@@ -25,11 +25,13 @@ import {
   useHostContext,
   useOpenExternal,
   useToolContext,
+  useViewTool,
   type ViewConfig,
 } from "mcp-use/react";
 import { initPencilAudio, playStroke } from "./pencil-audio.js";
 import {
   captureInitialElements,
+  commitModelEditedElements,
   onEditorChange,
   setStorageKey,
   loadPersistedElements,
@@ -37,6 +39,12 @@ import {
   setCheckpointId,
   setSaveCheckpoint,
 } from "./edit-context.js";
+import {
+  applyDrawingChanges,
+  editDrawingInputSchema,
+  editDrawingOutputSchema,
+  type SceneElement,
+} from "./edit-operations.js";
 import "./view.css";
 
 /**
@@ -1116,6 +1124,108 @@ export default function ExcalidrawView() {
       setUserEdits(persisted);
     }
   }, [checkpointId]);
+
+  useViewTool(
+    {
+      name: "edit_drawing",
+      title: "Edit current Excalidraw drawing",
+      description:
+        "Modify the currently displayed Excalidraw canvas in place. Apply sequential create, update, move, delete, or replace changes using the stable element IDs from create_view. Target selected:true to operate on the user's current fullscreen selection. Use this tool for refinements; do not call create_view again.",
+      inputSchema: editDrawingInputSchema,
+      outputSchema: editDrawingOutputSchema,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+      },
+      enabled: checkpointId !== undefined,
+    },
+    async (input) => {
+      if (!checkpointId) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: "The initial drawing is still loading. Wait for create_view to finish before editing it.",
+            },
+          ],
+        };
+      }
+
+      try {
+        const currentElements = (
+          excalidrawApi?.getSceneElements() ??
+          getLatestEditedElements() ??
+          elementsRef.current
+        ).filter(
+          (element: SceneElement) => !element.isDeleted
+        ) as SceneElement[];
+        const selectedIds = excalidrawApi
+          ? Object.entries(excalidrawApi.getAppState().selectedElementIds ?? {})
+              .filter(([, selected]) => selected)
+              .map(([id]) => id)
+          : [];
+        const applied = applyDrawingChanges(
+          currentElements,
+          input,
+          selectedIds,
+          (rawElements) =>
+            convertRawElements(rawElements).filter(
+              (element) =>
+                element.type !== "cameraUpdate" &&
+                element.type !== "delete" &&
+                element.type !== "restoreCheckpoint"
+            ) as SceneElement[]
+        );
+        const normalized = restore(
+          { elements: applied.elements as any },
+          null,
+          null,
+          { refreshDimensions: true }
+        ).elements as unknown as SceneElement[];
+
+        // Persist before reporting success so the live scene and the original
+        // checkpoint always advance together.
+        await commitModelEditedElements(normalized);
+
+        elementsRef.current = normalized;
+        setElements(normalized);
+        setUserEdits(normalized);
+        if (excalidrawApi) {
+          excalidrawApi.updateScene({
+            elements: normalized,
+            captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+          });
+        }
+
+        const elementIds = normalized.map((element) => element.id);
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Updated the current canvas in place with ${input.changes.length} change${input.changes.length === 1 ? "" : "s"}. The view and checkpoint "${checkpointId}" were preserved. Current element IDs: ${elementIds.join(", ") || "(none)"}.`,
+            },
+          ],
+          structuredContent: {
+            checkpointId,
+            appliedChanges: input.changes.length,
+            elementIds,
+          },
+        };
+      } catch (error) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: `Could not edit the current canvas: ${(error as Error).message}`,
+            },
+          ],
+        };
+      }
+    }
+  );
 
   useEffect(() => {
     const mq = window.matchMedia("(max-width: 640px)");

--- a/libraries/typescript/packages/server/tests/excalidraw-edit-operations.test.ts
+++ b/libraries/typescript/packages/server/tests/excalidraw-edit-operations.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applyDrawingChanges,
+  editDrawingInputSchema,
+  type SceneElement,
+} from "../examples/views/excalidraw/views/excalidraw/edit-operations.js";
+
+const convertElements = (elements: readonly Record<string, unknown>[]) =>
+  elements.map((element) => ({
+    ...element,
+    version: 1,
+  })) as SceneElement[];
+
+describe("Excalidraw in-place edit operations", () => {
+  it("applies sequential updates, bound-label moves, creates, and deletes", () => {
+    const current: SceneElement[] = [
+      {
+        id: "box",
+        type: "rectangle",
+        x: 10,
+        y: 20,
+        width: 160,
+        height: 80,
+        version: 1,
+        boundElements: [{ id: "box-label", type: "text" }],
+      },
+      {
+        id: "box-label",
+        type: "text",
+        x: 50,
+        y: 45,
+        text: "Old",
+        originalText: "Old",
+        containerId: "box",
+        version: 1,
+      },
+      {
+        id: "obsolete",
+        type: "ellipse",
+        x: 300,
+        y: 20,
+        width: 80,
+        height: 80,
+        version: 1,
+      },
+    ];
+    const input = editDrawingInputSchema.parse({
+      changes: [
+        {
+          type: "update",
+          target: { ids: ["box"] },
+          patch: {
+            x: 30,
+            backgroundColor: "#fff3bf",
+            label: { text: "New" },
+          },
+        },
+        {
+          type: "move",
+          target: { ids: ["box"] },
+          deltaX: 10,
+          deltaY: 15,
+        },
+        {
+          type: "create",
+          elements: [
+            {
+              type: "arrow",
+              id: "new-arrow",
+              x: 200,
+              y: 60,
+              points: [
+                [0, 0],
+                [80, 0],
+              ],
+            },
+          ],
+        },
+        { type: "delete", target: { ids: ["obsolete"] } },
+      ],
+    });
+
+    const result = applyDrawingChanges(current, input, [], convertElements);
+
+    expect(result.elements.map((element) => element.id)).toEqual([
+      "box",
+      "box-label",
+      "new-arrow",
+    ]);
+    expect(
+      result.elements.find((element) => element.id === "box")
+    ).toMatchObject({
+      x: 40,
+      y: 35,
+      backgroundColor: "#fff3bf",
+    });
+    expect(
+      result.elements.find((element) => element.id === "box-label")
+    ).toMatchObject({
+      x: 80,
+      y: 60,
+      text: "New",
+      originalText: "New",
+    });
+    expect(result.changedIds).toEqual(
+      expect.arrayContaining(["box", "box-label", "new-arrow", "obsolete"])
+    );
+  });
+
+  it("targets the current fullscreen selection", () => {
+    const current: SceneElement[] = [
+      { id: "one", type: "rectangle", x: 0, y: 0, version: 1 },
+      { id: "two", type: "rectangle", x: 20, y: 20, version: 1 },
+    ];
+    const input = editDrawingInputSchema.parse({
+      changes: [
+        {
+          type: "move",
+          target: { selected: true },
+          deltaX: 5,
+          deltaY: -10,
+        },
+      ],
+    });
+
+    const result = applyDrawingChanges(
+      current,
+      input,
+      ["two"],
+      convertElements
+    );
+
+    expect(result.elements[0]).toMatchObject({ id: "one", x: 0, y: 0 });
+    expect(result.elements[1]).toMatchObject({ id: "two", x: 25, y: 10 });
+  });
+
+  it("removes bound labels when replacing their container", () => {
+    const current: SceneElement[] = [
+      {
+        id: "old",
+        type: "rectangle",
+        x: 0,
+        y: 0,
+        boundElements: [{ id: "old-label", type: "text" }],
+      },
+      {
+        id: "old-label",
+        type: "text",
+        x: 20,
+        y: 20,
+        containerId: "old",
+      },
+    ];
+    const input = editDrawingInputSchema.parse({
+      changes: [
+        {
+          type: "replace",
+          target: { ids: ["old"] },
+          elements: [
+            {
+              type: "ellipse",
+              id: "replacement",
+              x: 0,
+              y: 0,
+              width: 100,
+              height: 100,
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = applyDrawingChanges(current, input, [], convertElements);
+
+    expect(result.elements.map((element) => element.id)).toEqual([
+      "replacement",
+    ]);
+  });
+
+  it("rejects unsafe or ambiguous updates at the schema boundary", () => {
+    expect(() =>
+      editDrawingInputSchema.parse({
+        changes: [
+          {
+            type: "update",
+            target: { ids: ["box"] },
+            patch: { id: "renamed" },
+          },
+        ],
+      })
+    ).toThrow();
+
+    expect(() =>
+      editDrawingInputSchema.parse({
+        changes: [
+          {
+            type: "delete",
+            target: {},
+          },
+        ],
+      })
+    ).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- Add a live `edit_drawing` view tool to the Excalidraw MCP App.
- Apply bounded, sequential create/update/move/delete/replace operations against stable element IDs or the active fullscreen selection.
- Update the same mounted scene and checkpoint before reporting success, preserving the existing iframe/canvas and manual-edit state.
- Add reducer/schema tests and document the create → refine workflow.

## Validation

- Focused Excalidraw reducer/schema tests: 4/4 passed.
- Prettier checks passed for the six changed files.
- The original implementation task also passed the Excalidraw TypeScript check, server/test TypeScript check, ESLint, production build, and focused tests.
- Full validation in this isolated checkout was limited by missing linked dependencies and sandbox restrictions that prevented pnpm from materializing them.

## Scope

This branch contains only the in-place editing feature. The later PiP enhancement from the source task was intentionally excluded.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds in-place editing to the Excalidraw view. The live `edit_drawing` tool refines the current canvas with sequential operations while preserving the existing checkpoint and mounted iframe/canvas.

- **New Features**
  - Registers `edit_drawing` via `useViewTool` with strict input/output schemas; targets stable element IDs and `selected: true`.
  - Applies changes atomically with `applyDrawingChanges` (create/update/move/delete/replace), including bound label moves and safe validation.
  - Persists the updated scene to the same checkpoint before success using `commitModelEditedElements`, preserving user manual edits.
  - Updates `create_view` guidance and README to “create, then refine” with `edit_drawing`; adds focused reducer/schema tests.

<sup>Written for commit bd5e396d100b9f4a8b47344c567b11fc623ce1f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

