### PR TITLE
Remove ctx.elicit compatibility API

### DIFF
--- a/libraries/typescript/packages/server/examples/conformance/src/index.ts
+++ b/libraries/typescript/packages/server/examples/conformance/src/index.ts
@@ -6,7 +6,13 @@
  *
  * Default-export the server; `mcp-use dev` / `build` / `start` own the socket.
  */
-import { completable, inputRequired, inputResponse, MCPServer } from "mcp-use";
+import {
+  acceptedContent,
+  completable,
+  inputRequired,
+  inputResponse,
+  MCPServer,
+} from "mcp-use";
 import { z } from "zod";
 
 const sleep = (ms: number) =>
@@ -250,29 +256,43 @@ server.tool(
     description: "A tool that uses elicitation to get user input",
   },
   async (_input, ctx) => {
-    const form = await ctx.elicit(
-      "elicitation",
-      "Please provide your information",
-      z.object({
-        name: z.string().default("Anonymous"),
-        age: z.number().default(0),
-      })
-    );
-    if (form.status === "required") return form.result;
-    if (form.status === "accept") {
+    const schema = z.object({
+      name: z.string().default("Anonymous"),
+      age: z.number().default(0),
+    });
+    const response = inputResponse(ctx.inputResponses, "elicitation");
+    if (response.kind === "elicit" && response.action !== "accept") {
       return {
         content: [
           {
             type: "text",
-            text: `Received: ${form.data.name}, age ${form.data.age}`,
+            text:
+              response.action === "decline"
+                ? "User declined"
+                : "Operation cancelled",
           },
         ],
       };
     }
-    if (form.status === "decline") {
-      return { content: [{ type: "text", text: "User declined" }] };
+    const form = acceptedContent(ctx.inputResponses, "elicitation", schema);
+    if (form === undefined) {
+      return inputRequired({
+        inputRequests: {
+          elicitation: inputRequired.elicit({
+            message: "Please provide your information",
+            requestedSchema: schema,
+          }),
+        },
+      });
     }
-    return { content: [{ type: "text", text: "Operation cancelled" }] };
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Received: ${form.name}, age ${form.age}`,
+        },
+      ],
+    };
   }
 );
 
@@ -283,37 +303,46 @@ server.tool(
       "A tool that uses elicitation with default values for all primitive types (SEP-1034)",
   },
   async (_input, ctx) => {
-    const form = await ctx.elicit(
-      "elicitation-sep1034",
-      "Please provide your information",
-      z.object({
-        name: z.string().default("John Doe"),
-        age: z.number().int().default(30),
-        score: z.number().default(95.5),
-        status: z.enum(["active", "inactive", "pending"]).default("active"),
-        verified: z.boolean().default(true),
-      })
-    );
-    if (form.status === "required") return form.result;
-    if (form.status === "accept") {
+    const schema = z.object({
+      name: z.string().default("John Doe"),
+      age: z.number().int().default(30),
+      score: z.number().default(95.5),
+      status: z.enum(["active", "inactive", "pending"]).default("active"),
+      verified: z.boolean().default(true),
+    });
+    const response = inputResponse(ctx.inputResponses, "elicitation-sep1034");
+    if (response.kind === "elicit" && response.action !== "accept") {
       return {
         content: [
           {
             type: "text",
-            text: `Elicitation completed: action=accept, content=${JSON.stringify(form.data)}`,
+            text: `Elicitation completed: action=${response.action}`,
           },
         ],
       };
     }
-    if (form.status === "decline") {
-      return {
-        content: [
-          { type: "text", text: "Elicitation completed: action=decline" },
-        ],
-      };
+    const form = acceptedContent(
+      ctx.inputResponses,
+      "elicitation-sep1034",
+      schema
+    );
+    if (form === undefined) {
+      return inputRequired({
+        inputRequests: {
+          "elicitation-sep1034": inputRequired.elicit({
+            message: "Please provide your information",
+            requestedSchema: schema,
+          }),
+        },
+      });
     }
     return {
-      content: [{ type: "text", text: "Elicitation completed: action=cancel" }],
+      content: [
+        {
+          type: "text",
+          text: `Elicitation completed: action=accept, content=${JSON.stringify(form)}`,
+        },
+      ],
     };
   }
 );
@@ -326,37 +355,46 @@ server.tool(
   },
   async (_input, ctx) => {
     // ponytail: z.enum stand-ins for v1 enumSchema variants; titles/names not preserved
-    const form = await ctx.elicit(
-      "elicitation-sep1330",
-      "Please choose your options",
-      z.object({
-        untitledSingle: z.enum(["option1", "option2", "option3"]),
-        titledSingle: z.enum(["value1", "value2", "value3"]),
-        legacyEnum: z.enum(["opt1", "opt2", "opt3"]),
-        untitledMulti: z.array(z.enum(["option1", "option2", "option3"])),
-        titledMulti: z.array(z.enum(["value1", "value2", "value3"])),
-      })
-    );
-    if (form.status === "required") return form.result;
-    if (form.status === "accept") {
+    const schema = z.object({
+      untitledSingle: z.enum(["option1", "option2", "option3"]),
+      titledSingle: z.enum(["value1", "value2", "value3"]),
+      legacyEnum: z.enum(["opt1", "opt2", "opt3"]),
+      untitledMulti: z.array(z.enum(["option1", "option2", "option3"])),
+      titledMulti: z.array(z.enum(["value1", "value2", "value3"])),
+    });
+    const response = inputResponse(ctx.inputResponses, "elicitation-sep1330");
+    if (response.kind === "elicit" && response.action !== "accept") {
       return {
         content: [
           {
             type: "text",
-            text: `Elicitation completed: action=accept, content=${JSON.stringify(form.data)}`,
+            text: `Elicitation completed: action=${response.action}`,
           },
         ],
       };
     }
-    if (form.status === "decline") {
-      return {
-        content: [
-          { type: "text", text: "Elicitation completed: action=decline" },
-        ],
-      };
+    const form = acceptedContent(
+      ctx.inputResponses,
+      "elicitation-sep1330",
+      schema
+    );
+    if (form === undefined) {
+      return inputRequired({
+        inputRequests: {
+          "elicitation-sep1330": inputRequired.elicit({
+            message: "Please choose your options",
+            requestedSchema: schema,
+          }),
+        },
+      });
     }
     return {
-      content: [{ type: "text", text: "Elicitation completed: action=cancel" }],
+      content: [
+        {
+          type: "text",
+          text: `Elicitation completed: action=accept, content=${JSON.stringify(form)}`,
+        },
+      ],
     };
   }
 );

--- a/libraries/typescript/packages/server/examples/elicitation/src/index.ts
+++ b/libraries/typescript/packages/server/examples/elicitation/src/index.ts
@@ -1,4 +1,9 @@
-import { MCPServer } from "mcp-use";
+import {
+  acceptedContent,
+  inputRequired,
+  inputResponse,
+  MCPServer,
+} from "mcp-use";
 import { z } from "zod";
 
 const server = new MCPServer({
@@ -37,25 +42,14 @@ server.tool(
     annotations: { destructiveHint: true },
   },
   async ({ environment }, ctx) => {
-    const confirmation = await ctx.elicit(
-      "deployment-approval",
-      `Deploy to ${environment}?`,
-      deploymentApproval
-    );
-
-    // On the first invocation this is an InputRequiredResult. The client
-    // collects input and retries this same tool call with the response.
-    if (confirmation.status === "required") {
-      return confirmation.result;
-    }
-
-    if (confirmation.status !== "accept") {
+    const response = inputResponse(ctx.inputResponses, "deployment-approval");
+    if (response.kind === "elicit" && response.action !== "accept") {
       return {
         content: [
           {
             type: "text",
             text:
-              confirmation.status === "decline"
+              response.action === "decline"
                 ? "Deployment declined by the user."
                 : "Deployment cancelled by the user.",
           },
@@ -64,7 +58,24 @@ server.tool(
       };
     }
 
-    if (!confirmation.data.approve) {
+    const confirmation = acceptedContent(
+      ctx.inputResponses,
+      "deployment-approval",
+      deploymentApproval
+    );
+
+    if (confirmation === undefined) {
+      return inputRequired({
+        inputRequests: {
+          "deployment-approval": inputRequired.elicit({
+            message: `Deploy to ${environment}?`,
+            requestedSchema: deploymentApproval,
+          }),
+        },
+      });
+    }
+
+    if (!confirmation.approve) {
       return {
         content: [{ type: "text", text: "Deployment was not approved." }],
         isError: true,
@@ -76,8 +87,8 @@ server.tool(
     const result = {
       environment,
       deployed: true,
-      ...(confirmation.data.note !== undefined && {
-        note: confirmation.data.note,
+      ...(confirmation.note !== undefined && {
+        note: confirmation.note,
       }),
     };
 
@@ -102,23 +113,25 @@ server.tool(
     const authorizationUrl = new URL("https://example.com/authorize");
     authorizationUrl.searchParams.set("service", service);
 
-    const authorization = await ctx.elicit(
-      "service-authorization",
-      `Authorize access to ${service}`,
-      authorizationUrl.href
-    );
-
-    if (authorization.status === "required") {
-      return authorization.result;
+    const response = inputResponse(ctx.inputResponses, "service-authorization");
+    if (response.kind === "missing") {
+      return inputRequired({
+        inputRequests: {
+          "service-authorization": inputRequired.elicitUrl({
+            message: `Authorize access to ${service}`,
+            url: authorizationUrl.href,
+          }),
+        },
+      });
     }
 
-    if (authorization.status !== "accept") {
+    if (response.kind !== "elicit" || response.action !== "accept") {
       return {
         content: [
           {
             type: "text",
             text:
-              authorization.status === "decline"
+              response.kind === "elicit" && response.action === "decline"
                 ? "Authorization declined by the user."
                 : "Authorization cancelled by the user.",
           },

--- a/libraries/typescript/packages/server/examples/views/basic/src/index.ts
+++ b/libraries/typescript/packages/server/examples/views/basic/src/index.ts
@@ -4,7 +4,13 @@
  * Follows the CLI entry contract: default-export the MCPServer instance;
  * `mcp-use dev` / `build` / `start` own the socket and view priming.
  */
-import { completable, inputRequired, inputResponse, MCPServer } from "mcp-use";
+import {
+  acceptedContent,
+  completable,
+  inputRequired,
+  inputResponse,
+  MCPServer,
+} from "mcp-use";
 import { z } from "zod";
 
 const BASE_PATH = "/mcp";
@@ -268,29 +274,36 @@ export const collectUserInfo = server.tool(
     outputSchema: z.object({ name: z.string(), age: z.number() }),
   },
   async (_input, ctx) => {
-    const form = await ctx.elicit(
-      "profile",
-      "Provide a profile for the client example",
-      z.object({
-        name: z.string().default("Anonymous"),
-        age: z.number().default(0),
-      })
-    );
-    if (form.status === "required") return form.result;
-    if (form.status === "accept") {
+    const schema = z.object({
+      name: z.string().default("Anonymous"),
+      age: z.number().default(0),
+    });
+    const response = inputResponse(ctx.inputResponses, "profile");
+    if (response.kind === "elicit" && response.action !== "accept") {
       return {
-        content: [
-          {
-            type: "text",
-            text: `Received ${form.data.name}, age ${form.data.age}`,
-          },
-        ],
-        structuredContent: form.data,
+        isError: true,
+        content: [{ type: "text", text: `Input ${response.action}` }],
       };
     }
+    const form = acceptedContent(ctx.inputResponses, "profile", schema);
+    if (form === undefined) {
+      return inputRequired({
+        inputRequests: {
+          profile: inputRequired.elicit({
+            message: "Provide a profile for the client example",
+            requestedSchema: schema,
+          }),
+        },
+      });
+    }
     return {
-      isError: true,
-      content: [{ type: "text", text: `Input ${form.status}` }],
+      content: [
+        {
+          type: "text",
+          text: `Received ${form.name}, age ${form.age}`,
+        },
+      ],
+      structuredContent: form,
     };
   }
 );

--- a/libraries/typescript/packages/server/src/context.ts
+++ b/libraries/typescript/packages/server/src/context.ts
@@ -1,16 +1,11 @@
 import {
   CLIENT_CAPABILITIES_META_KEY,
   CLIENT_INFO_META_KEY,
-  inputRequired,
-  inputResponse,
   type AuthInfo,
   type ClientCapabilities,
   type Implementation,
-  type InputRequest,
-  type InputRequiredResult,
   type RequestStateAccessor,
   type ServerContext,
-  type StandardSchemaWithJSON,
 } from "@modelcontextprotocol/server";
 import type { Context, Env, HonoRequest as HonoRequestType } from "hono";
 import { HonoRequest } from "hono/request";
@@ -149,54 +144,6 @@ export interface RequestClientContext {
 }
 
 /**
- * Result of a {@link Elicit} call.
- *
- * `required` means the callback must return `result`; the client then gathers
- * input and retries the tool. Accepted form results carry schema-validated,
- * inferred `data`. URL acceptances and declined/cancelled results carry no
- * data.
- */
-export type ElicitationResult<T = never> =
-  | { status: "required"; result: InputRequiredResult }
-  | { status: "decline" | "cancel" }
-  | ([T] extends [never]
-      ? { status: "accept" }
-      : { status: "accept"; data: T });
-
-/**
- * Requests or reads one keyed elicitation in a multi-round-trip tool callback.
- *
- * The explicit key correlates the request with the client's response on
- * re-entry. On the first entry, or after an invalid form response, this returns
- * `{ status: "required", result }`; return that result from the tool. On
- * re-entry it returns `accept`, `decline`, or `cancel` and validates accepted
- * Standard Schema form data before exposing it. Validation may be synchronous
- * or asynchronous.
- *
- * @example
- * ```ts
- * const confirmation = await ctx.elicit(
- *   "confirm",
- *   "Deploy to production?",
- *   schema,
- * );
- * if (confirmation.status === "required") {
- *   return confirmation.result;
- * }
- * ```
- */
-export interface Elicit {
-  /** Request or read a typed form-mode elicitation. */
-  <S extends StandardSchemaWithJSON>(
-    key: string,
-    message: string,
-    schema: S
-  ): Promise<ElicitationResult<StandardSchemaWithJSON.InferOutput<S>>>;
-  /** Request or read a URL-mode elicitation. */
-  (key: string, message: string, url: string): Promise<ElicitationResult>;
-}
-
-/**
  * Per-request context passed to tool/resource/prompt callbacks.
  */
 export type OAuthAuth<TUser> = {
@@ -235,8 +182,6 @@ type RequestContextBase<TEnv extends Env> = Omit<Context<TEnv>, "req"> & {
   req?: HonoRequestType;
   /** Per-request client capability queries. */
   client: RequestClientContext;
-  /** Request or read a keyed form- or URL-mode elicitation. */
-  elicit: Elicit;
   /**
    * Bare responses supplied when the client retries an `input_required`
    * round. Values are client input; validate them before use.
@@ -443,59 +388,6 @@ function toClientContext(ctx: ServerContext): RequestClientContext {
   };
 }
 
-function createElicit(
-  inputResponses: ServerContext["mcpReq"]["inputResponses"]
-): Elicit {
-  return async function elicit(
-    key: string,
-    message: string,
-    schemaOrUrl?: StandardSchemaWithJSON | string
-  ): Promise<ElicitationResult<unknown> | ElicitationResult> {
-    let request: InputRequest;
-    let formSchema: StandardSchemaWithJSON | undefined;
-
-    if (typeof schemaOrUrl === "string") {
-      request = inputRequired.elicitUrl({
-        message,
-        url: schemaOrUrl,
-      });
-    } else if (schemaOrUrl !== undefined) {
-      formSchema = schemaOrUrl;
-      request = inputRequired.elicit({
-        message,
-        requestedSchema: schemaOrUrl,
-      });
-    } else {
-      throw new TypeError(
-        "ctx.elicit(key, message, value) requires a form schema or URL string"
-      );
-    }
-
-    const response = inputResponse(inputResponses, key);
-    if (response.kind === "elicit") {
-      if (response.action !== "accept") {
-        return { status: response.action };
-      }
-      if (formSchema === undefined) {
-        return { status: "accept" };
-      }
-      if (response.content !== undefined) {
-        const outcome = await formSchema["~standard"].validate(
-          response.content
-        );
-        if (outcome.issues === undefined) {
-          return { status: "accept", data: outcome.value };
-        }
-      }
-    }
-
-    return {
-      status: "required",
-      result: inputRequired({ inputRequests: { [key]: request } }),
-    };
-  } as Elicit;
-}
-
 /**
  * Derive the callback-facing {@link RequestContext} from the SDK's
  * per-request `ServerContext`.
@@ -522,7 +414,6 @@ export function toRequestContext<TEnv extends Env = Env>(
       inputResponses: ctx.mcpReq.inputResponses,
     }),
     client: toClientContext(ctx),
-    elicit: createElicit(ctx.mcpReq.inputResponses),
     requestState: <T = unknown>() => ctx.mcpReq.requestState<T>(),
     async sendNotification(
       method: string,

--- a/libraries/typescript/packages/server/src/index.ts
+++ b/libraries/typescript/packages/server/src/index.ts
@@ -131,8 +131,6 @@ export type {
   OpenAPIExcludeRule,
 } from "./openapi/index.js";
 export type {
-  Elicit,
-  ElicitationResult,
   OAuthAuth,
   RequestClientContext,
   RequestContext,

--- a/libraries/typescript/packages/server/tests/elicitation.test.ts
+++ b/libraries/typescript/packages/server/tests/elicitation.test.ts
@@ -8,20 +8,16 @@ import {
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { z } from "zod";
 
-import { MCPServer } from "../src/index.js";
+import {
+  acceptedContent,
+  inputRequired,
+  inputResponse,
+  MCPServer,
+} from "../src/index.js";
 
 const confirmationSchema = z.object({ confirm: z.boolean() });
-const asyncConfirmationSchema = confirmationSchema.superRefine(
-  async ({ confirm }, refinement) => {
-    await Promise.resolve();
-    if (!confirm) {
-      refinement.addIssue({
-        code: "custom",
-        message: "Confirmation is required",
-      });
-    }
-  }
-);
+const projectSchema = z.object({ project: z.string() });
+const regionSchema = z.object({ region: z.string() });
 
 describe("elicitation and input_required", () => {
   const seenRequests: Array<{
@@ -40,7 +36,7 @@ describe("elicitation and input_required", () => {
     version: "1.0.0",
   });
   let client: Client;
-  let asyncFormAttempts = 0;
+  let batchedToolEntries = 0;
   let invalidFormAttempts = 0;
 
   server.tool(
@@ -53,25 +49,31 @@ describe("elicitation and input_required", () => {
       }),
     },
     async ({ environment }, ctx) => {
-      const confirmation = await ctx.elicit(
-        "confirm",
-        `Deploy to ${environment}?`,
-        environment === "async-invalid-first"
-          ? asyncConfirmationSchema
-          : confirmationSchema
-      );
-      if (confirmation.status === "required") {
-        return confirmation.result;
-      }
-      if (confirmation.status !== "accept") {
+      const response = inputResponse(ctx.inputResponses, "confirm");
+      if (response.kind === "elicit" && response.action !== "accept") {
         return {
-          content: [
-            { type: "text", text: `Deployment ${confirmation.status}` },
-          ],
+          content: [{ type: "text", text: `Deployment ${response.action}` }],
           isError: true,
         };
       }
-      if (confirmation.data.confirm !== true) {
+
+      const confirmation = acceptedContent(
+        ctx.inputResponses,
+        "confirm",
+        confirmationSchema
+      );
+
+      if (confirmation === undefined) {
+        return inputRequired({
+          inputRequests: {
+            confirm: inputRequired.elicit({
+              message: `Deploy to ${environment}?`,
+              requestedSchema: confirmationSchema,
+            }),
+          },
+        });
+      }
+      if (confirmation.confirm !== true) {
         return {
           content: [{ type: "text", text: "Deployment not confirmed" }],
           isError: true,
@@ -87,25 +89,64 @@ describe("elicitation and input_required", () => {
   );
 
   server.tool({ name: "link-account" }, async (_params, ctx) => {
-    const authorization = await ctx.elicit(
-      "authorize",
-      "Sign in to link your account",
-      "https://example.com/authorize"
-    );
-    if (authorization.status === "required") {
-      return authorization.result;
+    const response = inputResponse(ctx.inputResponses, "authorize");
+    if (response.kind === "missing") {
+      return inputRequired({
+        inputRequests: {
+          authorize: inputRequired.elicitUrl({
+            message: "Sign in to link your account",
+            url: "https://example.com/authorize",
+          }),
+        },
+      });
     }
     return {
       content: [
         {
           type: "text",
           text:
-            authorization.status === "accept"
+            response.kind === "elicit" && response.action === "accept"
               ? "Account linked"
               : "Account not linked",
         },
       ],
-      ...(authorization.status !== "accept" ? { isError: true as const } : {}),
+      ...(response.kind !== "elicit" || response.action !== "accept"
+        ? { isError: true as const }
+        : {}),
+    };
+  });
+
+  server.tool({ name: "batch-profile" }, async (_params, ctx) => {
+    batchedToolEntries += 1;
+    const project = acceptedContent(
+      ctx.inputResponses,
+      "project",
+      projectSchema
+    );
+    const region = acceptedContent(ctx.inputResponses, "region", regionSchema);
+
+    if (project === undefined || region === undefined) {
+      return inputRequired({
+        inputRequests: {
+          project: inputRequired.elicit({
+            message: "Project name?",
+            requestedSchema: projectSchema,
+          }),
+          region: inputRequired.elicit({
+            message: "Deployment region?",
+            requestedSchema: regionSchema,
+          }),
+        },
+      });
+    }
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Provision ${project.project} in ${region.region}`,
+        },
+      ],
     };
   });
 
@@ -144,11 +185,11 @@ describe("elicitation and input_required", () => {
           ? { action: "accept", content: { confirm: "yes" } }
           : { action: "accept", content: { confirm: true } };
       }
-      if (request.params.message === "Deploy to async-invalid-first?") {
-        asyncFormAttempts += 1;
-        return asyncFormAttempts === 1
-          ? { action: "accept", content: { confirm: false } }
-          : { action: "accept", content: { confirm: true } };
+      if (request.params.message === "Project name?") {
+        return { action: "accept", content: { project: "apollo" } };
+      }
+      if (request.params.message === "Deployment region?") {
+        return { action: "accept", content: { region: "us-west-2" } };
       }
       return { action: "accept", content: { confirm: true } };
     });
@@ -172,7 +213,7 @@ describe("elicitation and input_required", () => {
     await server.close();
   });
 
-  it("round-trips a v1-style form elicitation and returns the final tool result", async () => {
+  it("round-trips a form input_required result and returns the final tool result", async () => {
     const result = await client.callTool({
       name: "deploy",
       arguments: { environment: "production" },
@@ -190,7 +231,7 @@ describe("elicitation and input_required", () => {
     );
   });
 
-  it("round-trips a v1-style URL elicitation", async () => {
+  it("round-trips a URL input_required result", async () => {
     const result = await client.callTool({ name: "link-account" });
 
     expect(result.content).toContainEqual({
@@ -203,6 +244,28 @@ describe("elicitation and input_required", () => {
         message: "Sign in to link your account",
         url: "https://example.com/authorize",
       })
+    );
+  });
+
+  it("fulfills multiple input requests in one round before re-entering the tool", async () => {
+    const entriesBefore = batchedToolEntries;
+    const requestsBefore = seenRequests.length;
+
+    const result = await client.callTool({ name: "batch-profile" });
+
+    expect(result.content).toContainEqual({
+      type: "text",
+      text: "Provision apollo in us-west-2",
+    });
+    expect(batchedToolEntries - entriesBefore).toBe(2);
+    expect(seenRequests.slice(requestsBefore)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ mode: "form", message: "Project name?" }),
+        expect.objectContaining({
+          mode: "form",
+          message: "Deployment region?",
+        }),
+      ])
     );
   });
 
@@ -250,18 +313,5 @@ describe("elicitation and input_required", () => {
       deployed: true,
     });
     expect(invalidFormAttempts).toBe(2);
-  });
-
-  it("awaits asynchronous Standard Schema validation", async () => {
-    const result = await client.callTool({
-      name: "deploy",
-      arguments: { environment: "async-invalid-first" },
-    });
-
-    expect(result.structuredContent).toEqual({
-      environment: "async-invalid-first",
-      deployed: true,
-    });
-    expect(asyncFormAttempts).toBe(2);
   });
 });

--- a/libraries/typescript/packages/server/tests/type-level.test.ts
+++ b/libraries/typescript/packages/server/tests/type-level.test.ts
@@ -19,8 +19,10 @@ import type {
 } from "@modelcontextprotocol/server";
 
 import {
+  acceptedContent,
   createMcpEventListenerEntry,
   createMcpMiddlewareEntry,
+  inputRequired,
   MCPServer,
   text,
 } from "../src/index.js";
@@ -308,22 +310,26 @@ describe("tool registration return-position checks", () => {
       isError: true,
     }));
     server.tool({ name: "interactive", outputSchema }, async (_params, ctx) => {
-      const answer = await ctx.elicit(
+      const answerSchema = z.object({ answer: z.number() });
+      const answer = acceptedContent(
+        ctx.inputResponses,
         "answer",
-        "Provide an answer",
-        z.object({ answer: z.number() })
+        answerSchema
       );
-      if (answer.status === "required") return answer.result;
-      if (answer.status !== "accept") {
-        return {
-          content: [{ type: "text", text: answer.status }],
-          isError: true,
-        };
+      if (answer === undefined) {
+        return inputRequired({
+          inputRequests: {
+            answer: inputRequired.elicit({
+              message: "Provide an answer",
+              requestedSchema: answerSchema,
+            }),
+          },
+        });
       }
-      expectTypeOf(answer.data).toEqualTypeOf<{ answer: number }>();
+      expectTypeOf(answer).toEqualTypeOf<{ answer: number }>();
       return {
-        content: [{ type: "text", text: String(answer.data.answer) }],
-        structuredContent: answer.data,
+        content: [{ type: "text", text: String(answer.answer) }],
+        structuredContent: answer,
       };
     });
     expect(true).toBe(true); // assertions above are compile-time
@@ -382,27 +388,36 @@ describe("tool registration return-position checks", () => {
   });
 });
 
-describe("elicitation context", () => {
-  it("infers form data and supports URL mode", () => {
+describe("input_required context", () => {
+  it("infers form data, supports URL mode, and omits ctx.elicit", () => {
     const server = new MCPServer({ name: "types", version: "0.0.0" });
     server.tool({ name: "elicit-types" }, async (_params, ctx) => {
-      const form = await ctx.elicit(
+      const profileSchema = z.object({ name: z.string() });
+      const form = acceptedContent(
+        ctx.inputResponses,
         "profile",
-        "Your profile",
-        z.object({ name: z.string() })
+        profileSchema
       );
-      const url = await ctx.elicit(
-        "signin",
-        "Sign in",
-        "https://example.com/sign-in"
-      );
-      if (form.status === "accept") {
-        expectTypeOf(form.data).toEqualTypeOf<{ name: string }>();
+      expectTypeOf(form).toEqualTypeOf<{ name: string } | undefined>();
+
+      // @ts-expect-error — ctx.elicit was removed; use input_required helpers.
+      void ctx.elicit;
+
+      if (form !== undefined) {
+        return { content: [{ type: "text", text: form.name }] };
       }
-      expect(url).toBeDefined();
-      return form.status === "required"
-        ? form.result
-        : { content: [{ type: "text", text: form.status }] };
+      return inputRequired({
+        inputRequests: {
+          profile: inputRequired.elicit({
+            message: "Your profile",
+            requestedSchema: profileSchema,
+          }),
+          signin: inputRequired.elicitUrl({
+            message: "Sign in",
+            url: "https://example.com/sign-in",
+          }),
+        },
+      });
     });
     expect(true).toBe(true);
   });

--- a/libraries/typescript/packages/server/typedoc.json
+++ b/libraries/typescript/packages/server/typedoc.json
@@ -29,9 +29,6 @@
   },
   "treatWarningsAsErrors": true,
   "intentionallyNotDocumented": [
-    "index.ElicitationResult.__type.data",
-    "index.ElicitationResult.__type.result",
-    "index.ElicitationResult.__type.status",
     "index.InferPromptInput.__type.schema",
     "index.InferTemplateParams.__type.uriTemplate",
     "index.InferToolInput.__type.inputSchema",


### PR DESCRIPTION
## Summary

- remove `ctx.elicit()` from `RequestContext` and its runtime projection
- remove the public `Elicit` and `ElicitationResult` compatibility types
- make the direct v2 stateless primitives the supported elicitation path
- migrate server examples and conformance coverage to `inputRequired`, `inputResponse`, and `acceptedContent`
- add focused coverage for multiple input requests fulfilled in one round

## Why

`ctx.elicit()` preserved a v1-shaped convenience API around the v2 multi-round-trip protocol. Although it returned an explicit `required` result, the `await ctx.elicit(...)` shape obscured the important v2 behavior: the handler returns, the client collects input, and the original operation is retried with `inputResponses`.

Removing the compatibility helper exposes the actual stateless control flow and keeps batching, response discrimination, and request-state handling visible to server authors.

This is intentionally breaking. Callers using `ctx.elicit()`, `Elicit`, or `ElicitationResult` must migrate to the direct v2 API. `ctx.inputResponses`, `ctx.requestState()`, `ServerConfig.requestState`, `inputRequired`, `inputResponse`, `acceptedContent`, and `createRequestStateCodec` remain supported.

## Recommended direct v2 pattern

```ts
const schema = z.object({ confirm: z.boolean() });
const response = inputResponse(ctx.inputResponses, "confirm");

if (response.kind === "elicit" && response.action !== "accept") {
  return {
    content: [{ type: "text", text: `Deployment ${response.action}.` }],
    isError: true,
  };
}

const answer = acceptedContent(ctx.inputResponses, "confirm", schema);
if (answer === undefined) {
  return inputRequired({
    inputRequests: {
      confirm: inputRequired.elicit({
        message: "Deploy to production?",
        requestedSchema: schema,
      }),
    },
  });
}

return answer.confirm
  ? { content: [{ type: "text", text: "Deployed." }] }
  : { content: [{ type: "text", text: "Not approved." }], isError: true };
```

## Batched input requests

Independent inputs can be requested together. The client fulfills both embedded requests before retrying the tool once:

```ts
const project = acceptedContent(ctx.inputResponses, "project", projectSchema);
const region = acceptedContent(ctx.inputResponses, "region", regionSchema);

if (project === undefined || region === undefined) {
  return inputRequired({
    inputRequests: {
      project: inputRequired.elicit({
        message: "Project name?",
        requestedSchema: projectSchema,
      }),
      region: inputRequired.elicit({
        message: "Deployment region?",
        requestedSchema: regionSchema,
      }),
    },
  });
}

return {
  content: [
    { type: "text", text: `Provision ${project.project} in ${region.region}` },
  ],
};
```

For sequential rounds, use `requestState` protected by `createRequestStateCodec`; `inputResponses` contains only the current round.

## Validation

- targeted ESLint for all changed TypeScript files
- `pnpm --filter mcp-use build`
- `pnpm --filter mcp-use typecheck`
- `pnpm --filter mcp-use test --run tests/elicitation.test.ts tests/type-level.test.ts` — 38 tests passed
- typechecks for the elicitation, conformance, and basic views examples
- built and ran the migrated elicitation example over HTTP with a client pinned to `2026-07-28`; form and URL flows both completed successfully through `input_required` retries

No Markdown documentation files are changed in this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `ctx.elicit` compatibility API and related types, and migrated server examples/tests to the v2 stateless `input_required` flow using `inputRequired`, `inputResponse`, and `acceptedContent`. This is a breaking change that makes the multi-round control flow explicit in tool handlers.

- **Refactors**
  - Removed `ctx.elicit`, `Elicit`, and `ElicitationResult` from the server package.
  - Updated examples (`conformance`, `elicitation`, `views/basic`) to the v2 pattern.
  - Added focused test coverage for batching multiple input requests in one round.
  - Tidied `typedoc.json` to drop removed types.

- **Migration**
  - Replace `await ctx.elicit(key, message, schema)` with:
    - Check `inputResponse(ctx.inputResponses, key)` for `decline`/`cancel`.
    - Read validated data via `acceptedContent(ctx.inputResponses, key, schema)`.
    - If missing, return `inputRequired({ inputRequests: { [key]: inputRequired.elicit({ message, requestedSchema: schema }) } })`.
  - For URL prompts, use `inputRequired.elicitUrl({ message, url })`.
  - Batch independent inputs by including multiple entries under `inputRequests`.
  - Use `ctx.requestState()` (with `createRequestStateCodec`) for multi-round state; `ctx.inputResponses` only covers the current round.

<sup>Written for commit b6982d9485ad63a156bf8162b190462717a04b3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

