### PR TITLE
fix(oauth): restore v1 environment variable contract

### DIFF
--- a/libraries/typescript/packages/server/specs/AUTH_SPEC.md
+++ b/libraries/typescript/packages/server/specs/AUTH_SPEC.md
@@ -446,6 +446,25 @@ oauthBetterAuthProvider(...)
 oauthCustomProvider(...)
 ```
 
+The built-in provider factories also preserve the v1 zero-config environment
+contract. Explicit options take precedence over environment values:
+
+- Auth0: `MCP_USE_OAUTH_AUTH0_DOMAIN` and
+  `MCP_USE_OAUTH_AUTH0_AUDIENCE`
+- Clerk: `MCP_USE_OAUTH_CLERK_FRONTEND_API_URL`
+- Keycloak: `MCP_USE_OAUTH_KEYCLOAK_SERVER_URL`,
+  `MCP_USE_OAUTH_KEYCLOAK_REALM`, and `MCP_USE_OAUTH_KEYCLOAK_AUDIENCE`
+- Supabase: `MCP_USE_OAUTH_SUPABASE_PROJECT_ID`,
+  `MCP_USE_OAUTH_SUPABASE_URL`, and
+  `MCP_USE_OAUTH_SUPABASE_JWT_SECRET`
+- WorkOS: `MCP_USE_OAUTH_WORKOS_SUBDOMAIN`
+- Better Auth: `MCP_USE_OAUTH_BETTER_AUTH_URL`
+
+For Auth0 and Keycloak, the v1 audience environment value supplies the
+provider's configured `resource` only when an explicit `resource` is absent.
+It does not weaken or replace v2 token verification or canonical resource
+binding. No environment setting enables `verifyJwt: false`.
+
 `oauthCustomProvider` validates the provider options and defensively copies array configuration. The verifier must return verified SDK-native fields, including `token`, `clientId`, `scopes`, and a valid future numeric `expiresAt`. Decode-only tokens, `verifyJwt: false`, and equivalent bypasses are forbidden.
 
 Before calling `requireBearerAuth`, mcp-use wraps the provider with

--- a/libraries/typescript/packages/server/src/compat-v1/oauth.ts
+++ b/libraries/typescript/packages/server/src/compat-v1/oauth.ts
@@ -29,10 +29,10 @@ import {
   oauthWorkOSProvider as nativeWorkOSProvider,
   type WorkOSOAuthProviderOptions,
 } from "../oauth/workos.js";
+import { oauthEnvironmentValue } from "../oauth/environment.js";
 
 function env(name: string): string | undefined {
-  const value = process.env[name];
-  return value === undefined || value.trim() === "" ? undefined : value;
+  return oauthEnvironmentValue(name);
 }
 
 function rejectVerifyJwt(options: unknown): void {

--- a/libraries/typescript/packages/server/src/oauth/auth0.ts
+++ b/libraries/typescript/packages/server/src/oauth/auth0.ts
@@ -6,6 +6,7 @@
 
 import type { AuthInfo, OAuthMetadata } from "@modelcontextprotocol/server";
 
+import { oauthEnvironmentValue } from "./environment.js";
 import {
   booleanValue,
   createJwtVerifier,
@@ -45,16 +46,20 @@ export interface Auth0OAuthUser {
 
 /** Configures Auth0 JWT verification and protected-resource metadata. */
 export interface Auth0OAuthProviderOptions extends OAuthResourceOptions {
-  /** Auth0 tenant domain or issuer URL. */
-  domain: URL | string;
+  /**
+   * Auth0 tenant domain or issuer URL.
+   *
+   * @defaultValue `MCP_USE_OAUTH_AUTH0_DOMAIN`
+   */
+  domain?: URL | string;
 }
 
 /**
  * Creates a provider that verifies Auth0 access tokens and maps their claims.
  *
- * @param options - Auth0 domain and resource-server settings.
+ * @param options - Auth0 domain and resource-server settings. Defaults to v1 environment variables.
  * @returns A provider that rejects tokens not issued for the resolved MCP resource.
- * @throws A `TypeError` if `domain` is not a valid HTTP or HTTPS URL.
+ * @throws An `Error` if no domain is configured, or a `TypeError` if it is not a valid HTTP or HTTPS URL.
  *
  * @example
  * ```ts
@@ -66,11 +71,22 @@ export interface Auth0OAuthProviderOptions extends OAuthResourceOptions {
  * ```
  */
 export function oauthAuth0Provider(
-  options: Auth0OAuthProviderOptions
+  options: Auth0OAuthProviderOptions = {}
 ): OAuthProvider<Auth0OAuthUser> {
-  const issuer = normalizedProviderUrl(options.domain, "Auth0 domain").href;
-  return oauthCustomProvider<Auth0OAuthUser>({
+  const domain =
+    options.domain ?? oauthEnvironmentValue("MCP_USE_OAUTH_AUTH0_DOMAIN");
+  const audience = oauthEnvironmentValue("MCP_USE_OAUTH_AUTH0_AUDIENCE");
+  if (domain === undefined) {
+    throw new Error("Auth0 domain is required.");
+  }
+  const resolvedOptions = {
     ...options,
+    ...(options.resource === undefined &&
+      audience !== undefined && { resource: audience }),
+  };
+  const issuer = normalizedProviderUrl(domain, "Auth0 domain").href;
+  return oauthCustomProvider<Auth0OAuthUser>({
+    ...resolvedOptions,
     createTokenVerifier: (resource) =>
       createJwtVerifier({
         issuer,

--- a/libraries/typescript/packages/server/src/oauth/better-auth.ts
+++ b/libraries/typescript/packages/server/src/oauth/better-auth.ts
@@ -6,6 +6,7 @@
 
 import type { AuthInfo, OAuthMetadata } from "@modelcontextprotocol/server";
 
+import { oauthEnvironmentValue } from "./environment.js";
 import {
   booleanValue,
   createJwtVerifier,
@@ -45,8 +46,12 @@ export interface BetterAuthOAuthUser {
 
 /** Configures Better Auth JWT verification and protected-resource metadata. */
 export interface BetterAuthOAuthProviderOptions extends OAuthResourceOptions {
-  /** Full Better Auth issuer URL, including its base path. */
-  authURL: URL | string;
+  /**
+   * Full Better Auth issuer URL, including its base path.
+   *
+   * @defaultValue `MCP_USE_OAUTH_BETTER_AUTH_URL`
+   */
+  authURL?: URL | string;
 }
 
 /**
@@ -56,9 +61,9 @@ export interface BetterAuthOAuthProviderOptions extends OAuthResourceOptions {
  * mcp-use advertises those endpoints and verifies the resulting access-token
  * JWTs against Better Auth's JWKS endpoint.
  *
- * @param options - Better Auth issuer URL and resource-server settings.
+ * @param options - Better Auth issuer URL and resource-server settings. Defaults to v1 environment variables.
  * @returns A provider that rejects tokens not issued for the resolved MCP resource.
- * @throws A `TypeError` if `authURL` is not a valid HTTP or HTTPS URL.
+ * @throws An `Error` if no issuer URL is configured, or a `TypeError` if it is not a valid HTTP or HTTPS URL.
  *
  * @example
  * ```ts
@@ -70,10 +75,15 @@ export interface BetterAuthOAuthProviderOptions extends OAuthResourceOptions {
  * ```
  */
 export function oauthBetterAuthProvider(
-  options: BetterAuthOAuthProviderOptions
+  options: BetterAuthOAuthProviderOptions = {}
 ): OAuthProvider<BetterAuthOAuthUser> {
+  const authURL =
+    options.authURL ?? oauthEnvironmentValue("MCP_USE_OAUTH_BETTER_AUTH_URL");
+  if (authURL === undefined) {
+    throw new Error("Better Auth authURL is required.");
+  }
   const issuer = normalizedProviderUrl(
-    options.authURL,
+    authURL,
     "Better Auth authURL"
   ).href.replace(/\/$/, "");
 

--- a/libraries/typescript/packages/server/src/oauth/clerk.ts
+++ b/libraries/typescript/packages/server/src/oauth/clerk.ts
@@ -6,6 +6,7 @@
 
 import type { AuthInfo, OAuthMetadata } from "@modelcontextprotocol/server";
 
+import { oauthEnvironmentValue } from "./environment.js";
 import {
   booleanValue,
   createJwtVerifier,
@@ -49,8 +50,12 @@ export interface ClerkOAuthUser {
 
 /** Configures Clerk JWT verification and protected-resource metadata. */
 export interface ClerkOAuthProviderOptions extends OAuthResourceOptions {
-  /** Clerk Frontend API URL used as the token issuer. */
-  frontendApiUrl: URL | string;
+  /**
+   * Clerk Frontend API URL used as the token issuer.
+   *
+   * @defaultValue `MCP_USE_OAUTH_CLERK_FRONTEND_API_URL`
+   */
+  frontendApiUrl?: URL | string;
   /** Expected Clerk access-token audience, when the application emits one. */
   audience?: string;
 }
@@ -58,9 +63,9 @@ export interface ClerkOAuthProviderOptions extends OAuthResourceOptions {
 /**
  * Creates a provider that verifies Clerk access tokens and maps their claims.
  *
- * @param options - Clerk frontend API URL, optional token audience, and resource-server settings.
+ * @param options - Clerk frontend API URL, optional token audience, and resource-server settings. Defaults to v1 environment variables.
  * @returns A provider that verifies Clerk-issued access tokens and explicit resource claims.
- * @throws A `TypeError` if `frontendApiUrl` is invalid or `audience` is empty.
+ * @throws An `Error` if no frontend API URL is configured, or a `TypeError` if it is invalid or `audience` is empty.
  *
  * @example
  * ```ts
@@ -72,7 +77,7 @@ export interface ClerkOAuthProviderOptions extends OAuthResourceOptions {
  * ```
  */
 export function oauthClerkProvider(
-  options: ClerkOAuthProviderOptions
+  options: ClerkOAuthProviderOptions = {}
 ): OAuthProvider<ClerkOAuthUser> {
   if (
     options.audience !== undefined &&
@@ -81,8 +86,14 @@ export function oauthClerkProvider(
   ) {
     throw new TypeError("Clerk audience must be non-empty");
   }
+  const frontendApiUrl =
+    options.frontendApiUrl ??
+    oauthEnvironmentValue("MCP_USE_OAUTH_CLERK_FRONTEND_API_URL");
+  if (frontendApiUrl === undefined) {
+    throw new Error("Clerk frontendApiUrl is required.");
+  }
   const issuer = normalizedProviderUrl(
-    options.frontendApiUrl,
+    frontendApiUrl,
     "Clerk frontendApiUrl"
   ).href.replace(/\/$/, "");
   return oauthCustomProvider<ClerkOAuthUser>({

--- a/libraries/typescript/packages/server/src/oauth/environment.ts
+++ b/libraries/typescript/packages/server/src/oauth/environment.ts
@@ -1,0 +1,4 @@
+/** Reads an OAuth provider setting using the v1 environment contract. */
+export function oauthEnvironmentValue(name: string): string | undefined {
+  return process.env[name];
+}

--- a/libraries/typescript/packages/server/src/oauth/keycloak.ts
+++ b/libraries/typescript/packages/server/src/oauth/keycloak.ts
@@ -6,6 +6,7 @@
 
 import type { AuthInfo, OAuthMetadata } from "@modelcontextprotocol/server";
 
+import { oauthEnvironmentValue } from "./environment.js";
 import { isRecord } from "./guards.js";
 import {
   booleanValue,
@@ -51,18 +52,26 @@ export interface KeycloakOAuthUser {
 
 /** Configures Keycloak JWT verification and protected-resource metadata. */
 export interface KeycloakOAuthProviderOptions extends OAuthResourceOptions {
-  /** Base URL of the Keycloak server. */
-  serverUrl: URL | string;
-  /** Keycloak realm that issues accepted access tokens. */
-  realm: string;
+  /**
+   * Base URL of the Keycloak server.
+   *
+   * @defaultValue `MCP_USE_OAUTH_KEYCLOAK_SERVER_URL`
+   */
+  serverUrl?: URL | string;
+  /**
+   * Keycloak realm that issues accepted access tokens.
+   *
+   * @defaultValue `MCP_USE_OAUTH_KEYCLOAK_REALM`
+   */
+  realm?: string;
 }
 
 /**
  * Creates a provider that verifies Keycloak access tokens and maps their claims.
  *
- * @param options - Keycloak server URL, realm, and resource-server settings.
+ * @param options - Keycloak server URL, realm, and resource-server settings. Defaults to v1 environment variables.
  * @returns A provider that rejects tokens not issued for the resolved MCP resource.
- * @throws A `TypeError` if `serverUrl` or `realm` is invalid.
+ * @throws An `Error` if the server URL or realm is missing, or a `TypeError` if either is invalid.
  *
  * @example
  * ```ts
@@ -75,25 +84,36 @@ export interface KeycloakOAuthProviderOptions extends OAuthResourceOptions {
  * ```
  */
 export function oauthKeycloakProvider(
-  options: KeycloakOAuthProviderOptions
+  options: KeycloakOAuthProviderOptions = {}
 ): OAuthProvider<KeycloakOAuthUser> {
+  const serverUrlValue =
+    options.serverUrl ??
+    oauthEnvironmentValue("MCP_USE_OAUTH_KEYCLOAK_SERVER_URL");
+  const realm =
+    options.realm ?? oauthEnvironmentValue("MCP_USE_OAUTH_KEYCLOAK_REALM");
+  const audience = oauthEnvironmentValue("MCP_USE_OAUTH_KEYCLOAK_AUDIENCE");
+  if (serverUrlValue === undefined || realm === undefined) {
+    throw new Error("Keycloak serverUrl and realm are required.");
+  }
   if (
-    typeof options.realm !== "string" ||
-    options.realm.trim().length === 0 ||
-    /[/?#]/.test(options.realm)
+    typeof realm !== "string" ||
+    realm.trim().length === 0 ||
+    /[/?#]/.test(realm)
   ) {
     throw new TypeError("Keycloak realm is invalid");
   }
-  const serverUrl = normalizedProviderUrl(
-    options.serverUrl,
-    "Keycloak serverUrl"
-  );
+  const resolvedOptions = {
+    ...options,
+    ...(options.resource === undefined &&
+      audience !== undefined && { resource: audience }),
+  };
+  const serverUrl = normalizedProviderUrl(serverUrlValue, "Keycloak serverUrl");
   const issuer = providerEndpoint(
     serverUrl,
-    `realms/${encodeURIComponent(options.realm)}`
+    `realms/${encodeURIComponent(realm)}`
   ).replace(/\/$/, "");
   return oauthCustomProvider<KeycloakOAuthUser>({
-    ...options,
+    ...resolvedOptions,
     createTokenVerifier: (resource) =>
       createJwtVerifier({
         issuer,

--- a/libraries/typescript/packages/server/src/oauth/supabase.ts
+++ b/libraries/typescript/packages/server/src/oauth/supabase.ts
@@ -6,6 +6,7 @@
 
 import type { AuthInfo, OAuthMetadata } from "@modelcontextprotocol/server";
 
+import { oauthEnvironmentValue } from "./environment.js";
 import { isRecord } from "./guards.js";
 import {
   createJwtVerifier,
@@ -57,11 +58,23 @@ export interface SupabaseAmr {
 
 /** Configures Supabase JWT verification and protected-resource metadata. */
 export interface SupabaseOAuthProviderOptions extends OAuthResourceOptions {
-  /** Supabase project identifier used to derive `supabaseUrl`. */
+  /**
+   * Supabase project identifier used to derive `supabaseUrl`.
+   *
+   * @defaultValue `MCP_USE_OAUTH_SUPABASE_PROJECT_ID`
+   */
   projectId?: string;
-  /** Full Supabase project URL. Takes precedence over `projectId`. */
+  /**
+   * Full Supabase project URL. Takes precedence over `projectId`.
+   *
+   * @defaultValue `MCP_USE_OAUTH_SUPABASE_URL`
+   */
   supabaseUrl?: URL | string;
-  /** Legacy HS256 JWT secret. Omit to verify ES256 tokens against project JWKS. */
+  /**
+   * Legacy HS256 JWT secret. Omit to verify ES256 tokens against project JWKS.
+   *
+   * @defaultValue `MCP_USE_OAUTH_SUPABASE_JWT_SECRET`
+   */
   jwtSecret?: string;
   /**
    * Expected access-token audience.
@@ -74,7 +87,7 @@ export interface SupabaseOAuthProviderOptions extends OAuthResourceOptions {
 /**
  * Creates a provider that verifies Supabase access tokens and maps their claims.
  *
- * @param options - Supabase project or URL, optional JWT secret/audience, and resource-server settings.
+ * @param options - Supabase project or URL, optional JWT secret/audience, and resource-server settings. Defaults to v1 environment variables.
  * @returns A provider that rejects tokens without a valid configured Supabase signature and issuer.
  * @throws A `TypeError` if project settings are invalid, `audience` is empty,
  * or `jwtSecret` is shorter than 32 bytes.
@@ -89,12 +102,28 @@ export interface SupabaseOAuthProviderOptions extends OAuthResourceOptions {
  * ```
  */
 export function oauthSupabaseProvider(
-  options: SupabaseOAuthProviderOptions
+  options: SupabaseOAuthProviderOptions = {}
 ): OAuthProvider<SupabaseOAuthUser> {
-  const supabaseUrl = resolveSupabaseUrl(options);
+  const projectId =
+    options.projectId ??
+    oauthEnvironmentValue("MCP_USE_OAUTH_SUPABASE_PROJECT_ID");
+  const configuredSupabaseUrl =
+    options.supabaseUrl ?? oauthEnvironmentValue("MCP_USE_OAUTH_SUPABASE_URL");
+  const jwtSecret =
+    options.jwtSecret ??
+    oauthEnvironmentValue("MCP_USE_OAUTH_SUPABASE_JWT_SECRET");
+  const resolvedOptions = {
+    ...options,
+    ...(projectId !== undefined && { projectId }),
+    ...(configuredSupabaseUrl !== undefined && {
+      supabaseUrl: configuredSupabaseUrl,
+    }),
+    ...(jwtSecret !== undefined && { jwtSecret }),
+  };
+  const supabaseUrl = resolveSupabaseUrl(resolvedOptions);
   const issuer = providerEndpoint(supabaseUrl, "auth/v1").replace(/\/$/, "");
-  const secret = options.jwtSecret;
-  const audience = options.audience ?? "authenticated";
+  const secret = resolvedOptions.jwtSecret;
+  const audience = resolvedOptions.audience ?? "authenticated";
   if (typeof audience !== "string" || audience.trim().length === 0) {
     throw new TypeError("Supabase audience must be non-empty");
   }
@@ -102,7 +131,7 @@ export function oauthSupabaseProvider(
     throw new TypeError("Supabase jwtSecret must be at least 32 bytes");
   }
   return oauthCustomProvider<SupabaseOAuthUser>({
-    ...options,
+    ...resolvedOptions,
     createTokenVerifier: (resource) =>
       createJwtVerifier({
         issuer,

--- a/libraries/typescript/packages/server/src/oauth/workos.ts
+++ b/libraries/typescript/packages/server/src/oauth/workos.ts
@@ -6,6 +6,7 @@
 
 import type { AuthInfo, OAuthMetadata } from "@modelcontextprotocol/server";
 
+import { oauthEnvironmentValue } from "./environment.js";
 import {
   booleanValue,
   createJwtVerifier,
@@ -51,16 +52,20 @@ export interface WorkOSOAuthUser {
 
 /** Configures WorkOS JWT verification and protected-resource metadata. */
 export interface WorkOSOAuthProviderOptions extends OAuthResourceOptions {
-  /** AuthKit subdomain, with or without the `https://` scheme. */
-  subdomain: string;
+  /**
+   * AuthKit subdomain, with or without the `https://` scheme.
+   *
+   * @defaultValue `MCP_USE_OAUTH_WORKOS_SUBDOMAIN`
+   */
+  subdomain?: string;
 }
 
 /**
  * Creates a provider that verifies WorkOS access tokens and maps their claims.
  *
- * @param options - WorkOS AuthKit origin and resource-server settings.
+ * @param options - WorkOS AuthKit origin and resource-server settings. Defaults to v1 environment variables.
  * @returns A provider that rejects tokens not issued for the resolved MCP resource.
- * @throws A `TypeError` if `subdomain` is empty or uses a non-HTTPS URL.
+ * @throws An `Error` if no subdomain is configured, or a `TypeError` if it is empty or uses a non-HTTPS URL.
  *
  * @example
  * ```ts
@@ -72,9 +77,15 @@ export interface WorkOSOAuthProviderOptions extends OAuthResourceOptions {
  * ```
  */
 export function oauthWorkOSProvider(
-  options: WorkOSOAuthProviderOptions
+  options: WorkOSOAuthProviderOptions = {}
 ): OAuthProvider<WorkOSOAuthUser> {
-  const issuer = workosIssuer(options.subdomain);
+  const subdomain =
+    options.subdomain ??
+    oauthEnvironmentValue("MCP_USE_OAUTH_WORKOS_SUBDOMAIN");
+  if (subdomain === undefined) {
+    throw new Error("WorkOS subdomain is required.");
+  }
+  const issuer = workosIssuer(subdomain);
   return oauthCustomProvider<WorkOSOAuthUser>({
     ...options,
     createTokenVerifier: (resource) =>

--- a/libraries/typescript/packages/server/tests/oauth-direct-providers.test.ts
+++ b/libraries/typescript/packages/server/tests/oauth-direct-providers.test.ts
@@ -1,5 +1,5 @@
 import { exportJWK, generateKeyPair, SignJWT } from "jose";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { oauthAuth0Provider } from "../src/oauth/auth0.js";
 import { oauthBetterAuthProvider } from "../src/oauth/better-auth.js";
@@ -15,9 +15,87 @@ const protectedResource = new URL("https://api.example.test/mcp");
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+  vi.unstubAllEnvs();
 });
 
 describe("direct OAuth providers", () => {
+  it("restores the v1 zero-config provider environment contract", () => {
+    vi.stubEnv("MCP_USE_OAUTH_AUTH0_DOMAIN", "env.auth0.example");
+    vi.stubEnv("MCP_USE_OAUTH_AUTH0_AUDIENCE", "https://api.example.test/mcp");
+    vi.stubEnv(
+      "MCP_USE_OAUTH_KEYCLOAK_SERVER_URL",
+      "https://keycloak.example.test"
+    );
+    vi.stubEnv("MCP_USE_OAUTH_KEYCLOAK_REALM", "env-realm");
+    vi.stubEnv(
+      "MCP_USE_OAUTH_KEYCLOAK_AUDIENCE",
+      "https://keycloak-api.example.test/mcp"
+    );
+    vi.stubEnv(
+      "MCP_USE_OAUTH_CLERK_FRONTEND_API_URL",
+      "https://env.clerk.accounts.dev"
+    );
+    vi.stubEnv("MCP_USE_OAUTH_WORKOS_SUBDOMAIN", "env-company.authkit.app");
+    vi.stubEnv(
+      "MCP_USE_OAUTH_BETTER_AUTH_URL",
+      "https://auth.example.test/api/auth"
+    );
+    vi.stubEnv("MCP_USE_OAUTH_SUPABASE_PROJECT_ID", "env-project");
+    vi.stubEnv(
+      "MCP_USE_OAUTH_SUPABASE_JWT_SECRET",
+      "0123456789abcdef0123456789abcdef"
+    );
+
+    expect(oauthAuth0Provider()).toMatchObject({
+      resource: "https://api.example.test/mcp",
+      oauthMetadata: { issuer: "https://env.auth0.example/" },
+    });
+    expect(oauthKeycloakProvider()).toMatchObject({
+      resource: "https://keycloak-api.example.test/mcp",
+      oauthMetadata: {
+        issuer: "https://keycloak.example.test/realms/env-realm",
+      },
+    });
+    expect(oauthClerkProvider().oauthMetadata.issuer).toBe(
+      "https://env.clerk.accounts.dev"
+    );
+    expect(oauthWorkOSProvider().oauthMetadata.issuer).toBe(
+      "https://env-company.authkit.app"
+    );
+    expect(oauthBetterAuthProvider().oauthMetadata.issuer).toBe(
+      "https://auth.example.test/api/auth"
+    );
+    expect(oauthSupabaseProvider().oauthMetadata.issuer).toBe(
+      "https://env-project.supabase.co/auth/v1"
+    );
+  });
+
+  it("keeps explicit provider config ahead of v1 environment fallbacks", () => {
+    vi.stubEnv("MCP_USE_OAUTH_AUTH0_DOMAIN", "env.auth0.example");
+    vi.stubEnv(
+      "MCP_USE_OAUTH_AUTH0_AUDIENCE",
+      "https://env-api.example.test/mcp"
+    );
+    vi.stubEnv("MCP_USE_OAUTH_SUPABASE_PROJECT_ID", "env-project");
+    vi.stubEnv("MCP_USE_OAUTH_SUPABASE_URL", "https://env-project.supabase.co");
+
+    expect(
+      oauthAuth0Provider({
+        domain: "explicit.auth0.example",
+        resource: "https://explicit-api.example.test/mcp",
+      })
+    ).toMatchObject({
+      resource: "https://explicit-api.example.test/mcp",
+      oauthMetadata: { issuer: "https://explicit.auth0.example/" },
+    });
+    expect(
+      oauthSupabaseProvider({
+        projectId: "explicit-project",
+        supabaseUrl: "http://localhost:54321",
+      }).oauthMetadata.issuer
+    ).toBe("http://localhost:54321/auth/v1");
+  });
+
   it("verifies Better Auth JWTs and preserves issuer path prefixes", async () => {
     const { privateKey, publicKey } = await generateKeyPair("EdDSA");
     const jwk = await exportJWK(publicKey);


### PR DESCRIPTION
## Summary

Restore the authoritative mcp-use v1 zero-config environment-variable contract in the current beta OAuth provider factories:

- Auth0: `MCP_USE_OAUTH_AUTH0_DOMAIN`, `MCP_USE_OAUTH_AUTH0_AUDIENCE`
- Clerk: `MCP_USE_OAUTH_CLERK_FRONTEND_API_URL`
- Keycloak: `MCP_USE_OAUTH_KEYCLOAK_SERVER_URL`, `MCP_USE_OAUTH_KEYCLOAK_REALM`, `MCP_USE_OAUTH_KEYCLOAK_AUDIENCE`
- Supabase: `MCP_USE_OAUTH_SUPABASE_PROJECT_ID`, `MCP_USE_OAUTH_SUPABASE_URL`, `MCP_USE_OAUTH_SUPABASE_JWT_SECRET`
- WorkOS: `MCP_USE_OAUTH_WORKOS_SUBDOMAIN`
- Better Auth: `MCP_USE_OAUTH_BETTER_AUTH_URL`

Explicit provider options continue to take precedence over environment values. Native beta factories can once again be called without an options object, and the temporary v1 compatibility entry uses the same v1 environment lookup behavior.

## Security and behavior preserved

This is intentionally limited to the environment contract and provider config resolution. It does not restore the stale JWT/audience/resource-binding implementation from the closed PR #1962.

- JWT verification remains mandatory; `verifyJwt: false` is still rejected.
- Current beta issuer, endpoint, claim mapping, and provider semantics are unchanged.
- Current beta canonical MCP resource binding remains enforced.
- For Auth0 and Keycloak, legacy audience environment values only seed `resource` when an explicit `resource` is absent.
- Removed v1 proxy/client-ID/API-key behavior is not reintroduced.

## Validation

- `pnpm exec vitest run` across the nine OAuth/compat suites: **62 tests passed**
- Strict standalone TypeScript check for every changed source file: passed
- Repository pre-commit formatting, lint, and changeset checks: passed
- `git diff --check`: passed
- Package JavaScript bundles built successfully

The full package declaration build remains blocked by unrelated existing workspace setup/type failures involving missing `@mcp-use/client` and inspector build artifacts. Those failures predate and do not touch this OAuth change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the v1 zero-config environment-variable contract for all OAuth provider factories so they can be created without options again. Explicit options still take precedence; security and verification behavior are unchanged.

- **Bug Fixes**
  - Re-enable env defaults for: Auth0 (`MCP_USE_OAUTH_AUTH0_DOMAIN`, `MCP_USE_OAUTH_AUTH0_AUDIENCE`), Clerk (`MCP_USE_OAUTH_CLERK_FRONTEND_API_URL`), Keycloak (`MCP_USE_OAUTH_KEYCLOAK_SERVER_URL`, `MCP_USE_OAUTH_KEYCLOAK_REALM`, `MCP_USE_OAUTH_KEYCLOAK_AUDIENCE`), Supabase (`MCP_USE_OAUTH_SUPABASE_PROJECT_ID`, `MCP_USE_OAUTH_SUPABASE_URL`, `MCP_USE_OAUTH_SUPABASE_JWT_SECRET`), WorkOS (`MCP_USE_OAUTH_WORKOS_SUBDOMAIN`), Better Auth (`MCP_USE_OAUTH_BETTER_AUTH_URL`).
  - For Auth0 and Keycloak, the audience env var seeds `resource` only if `resource` is not set.
  - Added shared `oauthEnvironmentValue`, tests for env fallbacks and precedence, and updated `AUTH_SPEC.md`. JWT verification remains required and canonical MCP resource binding is unchanged.

<sup>Written for commit 3f9b781762a2dabe1de1bf27d89c952a0db09c23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

