### PR TITLE
test(server): exercise direct v2 elicitation flows

### DIFF
--- a/libraries/typescript/packages/server/examples/conformance/src/index.ts
+++ b/libraries/typescript/packages/server/examples/conformance/src/index.ts
@@ -6,7 +6,13 @@
  *
  * Default-export the server; `mcp-use dev` / `build` / `start` own the socket.
  */
-import { completable, inputRequired, inputResponse, MCPServer } from "mcp-use";
+import {
+  acceptedContent,
+  completable,
+  inputRequired,
+  inputResponse,
+  MCPServer,
+} from "mcp-use";
 import { z } from "zod";
 
 const sleep = (ms: number) =>
@@ -250,29 +256,47 @@ server.tool(
     description: "A tool that uses elicitation to get user input",
   },
   async (_input, ctx) => {
-    const form = await ctx.elicit(
-      "elicitation",
-      "Please provide your information",
-      z.object({
-        name: z.string().default("Anonymous"),
-        age: z.number().default(0),
-      })
-    );
-    if (form.status === "required") return form.result;
-    if (form.status === "accept") {
+    const schema = z.object({
+      name: z.string().default("Anonymous"),
+      age: z.number().default(0),
+    });
+    // A stateless callback starts from the top for both initial calls and
+    // retries, so handle decline/cancel before deciding input is still needed.
+    const response = inputResponse(ctx.inputResponses, "elicitation");
+    if (response.kind === "elicit" && response.action !== "accept") {
       return {
         content: [
           {
             type: "text",
-            text: `Received: ${form.data.name}, age ${form.data.age}`,
+            text:
+              response.action === "decline"
+                ? "User declined"
+                : "Operation cancelled",
           },
         ],
       };
     }
-    if (form.status === "decline") {
-      return { content: [{ type: "text", text: "User declined" }] };
+    const form = acceptedContent(ctx.inputResponses, "elicitation", schema);
+    // Missing or invalid accepted data means this round must request it.
+    if (form === undefined) {
+      return inputRequired({
+        inputRequests: {
+          elicitation: inputRequired.elicit({
+            message: "Please provide your information",
+            requestedSchema: schema,
+          }),
+        },
+      });
     }
-    return { content: [{ type: "text", text: "Operation cancelled" }] };
+    // Produce the successful result only from accepted, validated input.
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Received: ${form.name}, age ${form.age}`,
+        },
+      ],
+    };
   }
 );
 
@@ -283,37 +307,49 @@ server.tool(
       "A tool that uses elicitation with default values for all primitive types (SEP-1034)",
   },
   async (_input, ctx) => {
-    const form = await ctx.elicit(
-      "elicitation-sep1034",
-      "Please provide your information",
-      z.object({
-        name: z.string().default("John Doe"),
-        age: z.number().int().default(30),
-        score: z.number().default(95.5),
-        status: z.enum(["active", "inactive", "pending"]).default("active"),
-        verified: z.boolean().default(true),
-      })
-    );
-    if (form.status === "required") return form.result;
-    if (form.status === "accept") {
+    const schema = z.object({
+      name: z.string().default("John Doe"),
+      age: z.number().int().default(30),
+      score: z.number().default(95.5),
+      status: z.enum(["active", "inactive", "pending"]).default("active"),
+      verified: z.boolean().default(true),
+    });
+    // Each invocation may be the initial call or a retry; inspect this round's
+    // response before falling back to input_required.
+    const response = inputResponse(ctx.inputResponses, "elicitation-sep1034");
+    if (response.kind === "elicit" && response.action !== "accept") {
       return {
         content: [
           {
             type: "text",
-            text: `Elicitation completed: action=accept, content=${JSON.stringify(form.data)}`,
+            text: `Elicitation completed: action=${response.action}`,
           },
         ],
       };
     }
-    if (form.status === "decline") {
-      return {
-        content: [
-          { type: "text", text: "Elicitation completed: action=decline" },
-        ],
-      };
+    const form = acceptedContent(
+      ctx.inputResponses,
+      "elicitation-sep1034",
+      schema
+    );
+    // Re-request when accepted content is absent or fails schema validation.
+    if (form === undefined) {
+      return inputRequired({
+        inputRequests: {
+          "elicitation-sep1034": inputRequired.elicit({
+            message: "Please provide your information",
+            requestedSchema: schema,
+          }),
+        },
+      });
     }
     return {
-      content: [{ type: "text", text: "Elicitation completed: action=cancel" }],
+      content: [
+        {
+          type: "text",
+          text: `Elicitation completed: action=accept, content=${JSON.stringify(form)}`,
+        },
+      ],
     };
   }
 );
@@ -326,37 +362,49 @@ server.tool(
   },
   async (_input, ctx) => {
     // ponytail: z.enum stand-ins for v1 enumSchema variants; titles/names not preserved
-    const form = await ctx.elicit(
-      "elicitation-sep1330",
-      "Please choose your options",
-      z.object({
-        untitledSingle: z.enum(["option1", "option2", "option3"]),
-        titledSingle: z.enum(["value1", "value2", "value3"]),
-        legacyEnum: z.enum(["opt1", "opt2", "opt3"]),
-        untitledMulti: z.array(z.enum(["option1", "option2", "option3"])),
-        titledMulti: z.array(z.enum(["value1", "value2", "value3"])),
-      })
-    );
-    if (form.status === "required") return form.result;
-    if (form.status === "accept") {
+    const schema = z.object({
+      untitledSingle: z.enum(["option1", "option2", "option3"]),
+      titledSingle: z.enum(["value1", "value2", "value3"]),
+      legacyEnum: z.enum(["opt1", "opt2", "opt3"]),
+      untitledMulti: z.array(z.enum(["option1", "option2", "option3"])),
+      titledMulti: z.array(z.enum(["value1", "value2", "value3"])),
+    });
+    // Stateless retries re-enter here, so consume any terminal response before
+    // deciding that this round still needs user input.
+    const response = inputResponse(ctx.inputResponses, "elicitation-sep1330");
+    if (response.kind === "elicit" && response.action !== "accept") {
       return {
         content: [
           {
             type: "text",
-            text: `Elicitation completed: action=accept, content=${JSON.stringify(form.data)}`,
+            text: `Elicitation completed: action=${response.action}`,
           },
         ],
       };
     }
-    if (form.status === "decline") {
-      return {
-        content: [
-          { type: "text", text: "Elicitation completed: action=decline" },
-        ],
-      };
+    const form = acceptedContent(
+      ctx.inputResponses,
+      "elicitation-sep1330",
+      schema
+    );
+    // Only missing or schema-invalid accepted data should request another round.
+    if (form === undefined) {
+      return inputRequired({
+        inputRequests: {
+          "elicitation-sep1330": inputRequired.elicit({
+            message: "Please choose your options",
+            requestedSchema: schema,
+          }),
+        },
+      });
     }
     return {
-      content: [{ type: "text", text: "Elicitation completed: action=cancel" }],
+      content: [
+        {
+          type: "text",
+          text: `Elicitation completed: action=accept, content=${JSON.stringify(form)}`,
+        },
+      ],
     };
   }
 );

--- a/libraries/typescript/packages/server/examples/elicitation/src/index.ts
+++ b/libraries/typescript/packages/server/examples/elicitation/src/index.ts
@@ -1,4 +1,9 @@
-import { MCPServer } from "mcp-use";
+import {
+  acceptedContent,
+  inputRequired,
+  inputResponse,
+  MCPServer,
+} from "mcp-use";
 import { z } from "zod";
 
 const server = new MCPServer({
@@ -37,25 +42,16 @@ server.tool(
     annotations: { destructiveHint: true },
   },
   async ({ environment }, ctx) => {
-    const confirmation = await ctx.elicit(
-      "deployment-approval",
-      `Deploy to ${environment}?`,
-      deploymentApproval
-    );
-
-    // On the first invocation this is an InputRequiredResult. The client
-    // collects input and retries this same tool call with the response.
-    if (confirmation.status === "required") {
-      return confirmation.result;
-    }
-
-    if (confirmation.status !== "accept") {
+    // A stateless handler starts from the top on both the initial call and
+    // every retry. Inspect this round's response before deciding to ask again.
+    const response = inputResponse(ctx.inputResponses, "deployment-approval");
+    if (response.kind === "elicit" && response.action !== "accept") {
       return {
         content: [
           {
             type: "text",
             text:
-              confirmation.status === "decline"
+              response.action === "decline"
                 ? "Deployment declined by the user."
                 : "Deployment cancelled by the user.",
           },
@@ -64,20 +60,38 @@ server.tool(
       };
     }
 
-    if (!confirmation.data.approve) {
+    const confirmation = acceptedContent(
+      ctx.inputResponses,
+      "deployment-approval",
+      deploymentApproval
+    );
+    // Missing or invalid accepted content means this invocation still needs
+    // input, so return input_required instead of continuing.
+    if (confirmation === undefined) {
+      return inputRequired({
+        inputRequests: {
+          "deployment-approval": inputRequired.elicit({
+            message: `Deploy to ${environment}?`,
+            requestedSchema: deploymentApproval,
+          }),
+        },
+      });
+    }
+
+    if (!confirmation.approve) {
       return {
         content: [{ type: "text", text: "Deployment was not approved." }],
         isError: true,
       };
     }
 
-    // Put side effects after elicitation is accepted: the callback runs again
-    // for every input_required round.
+    // Side effects belong after accepted, validated input because every
+    // input_required round invokes this callback again from the beginning.
     const result = {
       environment,
       deployed: true,
-      ...(confirmation.data.note !== undefined && {
-        note: confirmation.data.note,
+      ...(confirmation.note !== undefined && {
+        note: confirmation.note,
       }),
     };
 
@@ -102,23 +116,16 @@ server.tool(
     const authorizationUrl = new URL("https://example.com/authorize");
     authorizationUrl.searchParams.set("service", service);
 
-    const authorization = await ctx.elicit(
-      "service-authorization",
-      `Authorize access to ${service}`,
-      authorizationUrl.href
-    );
-
-    if (authorization.status === "required") {
-      return authorization.result;
-    }
-
-    if (authorization.status !== "accept") {
+    // This is either the initial call (missing) or a fresh retry. Resolve the
+    // retry response first; only the missing case should request input.
+    const response = inputResponse(ctx.inputResponses, "service-authorization");
+    if (response.kind === "elicit" && response.action !== "accept") {
       return {
         content: [
           {
             type: "text",
             text:
-              authorization.status === "decline"
+              response.action === "decline"
                 ? "Authorization declined by the user."
                 : "Authorization cancelled by the user.",
           },
@@ -127,9 +134,25 @@ server.tool(
       };
     }
 
-    return {
-      content: [{ type: "text", text: `Connected ${service}.` }],
-    };
+    if (response.kind === "elicit" && response.action === "accept") {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Authorization page opened for ${service}. Verify the backend callback before treating the service as connected.`,
+          },
+        ],
+      };
+    }
+
+    return inputRequired({
+      inputRequests: {
+        "service-authorization": inputRequired.elicitUrl({
+          message: `Authorize access to ${service}`,
+          url: authorizationUrl.href,
+        }),
+      },
+    });
   }
 );
 

--- a/libraries/typescript/packages/server/examples/views/basic/src/index.ts
+++ b/libraries/typescript/packages/server/examples/views/basic/src/index.ts
@@ -4,7 +4,13 @@
  * Follows the CLI entry contract: default-export the MCPServer instance;
  * `mcp-use dev` / `build` / `start` own the socket and view priming.
  */
-import { completable, inputRequired, inputResponse, MCPServer } from "mcp-use";
+import {
+  acceptedContent,
+  completable,
+  inputRequired,
+  inputResponse,
+  MCPServer,
+} from "mcp-use";
 import { z } from "zod";
 
 const BASE_PATH = "/mcp";
@@ -268,29 +274,40 @@ export const collectUserInfo = server.tool(
     outputSchema: z.object({ name: z.string(), age: z.number() }),
   },
   async (_input, ctx) => {
-    const form = await ctx.elicit(
-      "profile",
-      "Provide a profile for the client example",
-      z.object({
-        name: z.string().default("Anonymous"),
-        age: z.number().default(0),
-      })
-    );
-    if (form.status === "required") return form.result;
-    if (form.status === "accept") {
+    const schema = z.object({
+      name: z.string().default("Anonymous"),
+      age: z.number().default(0),
+    });
+    // The handler is re-entered from the top, so first determine whether this
+    // invocation is the initial call or a retry with a terminal response.
+    const response = inputResponse(ctx.inputResponses, "profile");
+    if (response.kind === "elicit" && response.action !== "accept") {
       return {
-        content: [
-          {
-            type: "text",
-            text: `Received ${form.data.name}, age ${form.data.age}`,
-          },
-        ],
-        structuredContent: form.data,
+        isError: true,
+        content: [{ type: "text", text: `Input ${response.action}` }],
       };
     }
+    const form = acceptedContent(ctx.inputResponses, "profile", schema);
+    // Ask only when this round has no accepted, schema-valid profile.
+    if (form === undefined) {
+      return inputRequired({
+        inputRequests: {
+          profile: inputRequired.elicit({
+            message: "Provide a profile for the client example",
+            requestedSchema: schema,
+          }),
+        },
+      });
+    }
+    // Successful work happens only after the response has been validated.
     return {
-      isError: true,
-      content: [{ type: "text", text: `Input ${form.status}` }],
+      content: [
+        {
+          type: "text",
+          text: `Received ${form.name}, age ${form.age}`,
+        },
+      ],
+      structuredContent: form,
     };
   }
 );

--- a/libraries/typescript/packages/server/tests/elicitation.test.ts
+++ b/libraries/typescript/packages/server/tests/elicitation.test.ts
@@ -8,20 +8,28 @@ import {
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { z } from "zod";
 
-import { MCPServer } from "../src/index.js";
+import {
+  acceptedContent,
+  createRequestStateCodec,
+  inputRequired,
+  inputResponse,
+  isInputRequiredResult,
+  MCPServer,
+} from "../src/index.js";
 
 const confirmationSchema = z.object({ confirm: z.boolean() });
-const asyncConfirmationSchema = confirmationSchema.superRefine(
-  async ({ confirm }, refinement) => {
-    await Promise.resolve();
-    if (!confirm) {
-      refinement.addIssue({
-        code: "custom",
-        message: "Confirmation is required",
-      });
-    }
-  }
-);
+const projectSchema = z.object({ project: z.string() });
+const regionSchema = z.object({ region: z.string() });
+
+type DeployRequestState = {
+  phase: "awaiting-confirmation";
+  environment: string;
+};
+
+const requestStateCodec = createRequestStateCodec<DeployRequestState>({
+  key: new Uint8Array(32).fill(7),
+  ttlSeconds: 60,
+});
 
 describe("elicitation and input_required", () => {
   const seenRequests: Array<{
@@ -38,10 +46,15 @@ describe("elicitation and input_required", () => {
   const server = new MCPServer({
     name: "elicitation-test",
     version: "1.0.0",
+    requestState: { verify: requestStateCodec.verify },
   });
   let client: Client;
-  let asyncFormAttempts = 0;
+  let manualClient: Client;
+  let batchedToolEntries = 0;
+  let cancelledBatchRequests = 0;
+  let cancelledFormAttempts = 0;
   let invalidFormAttempts = 0;
+  let statefulToolEntries = 0;
 
   server.tool(
     {
@@ -53,31 +66,42 @@ describe("elicitation and input_required", () => {
       }),
     },
     async ({ environment }, ctx) => {
-      const confirmation = await ctx.elicit(
-        "confirm",
-        `Deploy to ${environment}?`,
-        environment === "async-invalid-first"
-          ? asyncConfirmationSchema
-          : confirmationSchema
-      );
-      if (confirmation.status === "required") {
-        return confirmation.result;
-      }
-      if (confirmation.status !== "accept") {
+      // This callback starts over for every stateless round. Inspect the current
+      // round first so decline/cancel is terminal rather than re-requested.
+      const response = inputResponse(ctx.inputResponses, "confirm");
+      if (response.kind === "elicit" && response.action !== "accept") {
         return {
-          content: [
-            { type: "text", text: `Deployment ${confirmation.status}` },
-          ],
+          content: [{ type: "text", text: `Deployment ${response.action}` }],
           isError: true,
         };
       }
-      if (confirmation.data.confirm !== true) {
+
+      const confirmation = acceptedContent(
+        ctx.inputResponses,
+        "confirm",
+        confirmationSchema
+      );
+
+      // Initial and schema-invalid rounds both return input_required.
+      if (confirmation === undefined) {
+        return inputRequired({
+          inputRequests: {
+            confirm: inputRequired.elicit({
+              message: `Deploy to ${environment}?`,
+              requestedSchema: confirmationSchema,
+            }),
+          },
+        });
+      }
+      if (confirmation.confirm !== true) {
         return {
           content: [{ type: "text", text: "Deployment not confirmed" }],
           isError: true,
         };
       }
 
+      // Keep side effects after accepted, validated input: this line can run
+      // only on the final handler entry.
       const result = { environment, deployed: true };
       return {
         content: [{ type: "text", text: JSON.stringify(result) }],
@@ -87,27 +111,180 @@ describe("elicitation and input_required", () => {
   );
 
   server.tool({ name: "link-account" }, async (_params, ctx) => {
-    const authorization = await ctx.elicit(
-      "authorize",
-      "Sign in to link your account",
-      "https://example.com/authorize"
-    );
-    if (authorization.status === "required") {
-      return authorization.result;
+    // Resolve a retry before asking again; URL accept has no form content.
+    const response = inputResponse(ctx.inputResponses, "authorize");
+    if (response.kind === "elicit") {
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              response.action === "accept"
+                ? "Authorization page opened"
+                : "Account not linked",
+          },
+        ],
+        ...(response.action !== "accept" ? { isError: true as const } : {}),
+      };
     }
-    return {
-      content: [
-        {
-          type: "text",
-          text:
-            authorization.status === "accept"
-              ? "Account linked"
-              : "Account not linked",
-        },
-      ],
-      ...(authorization.status !== "accept" ? { isError: true as const } : {}),
-    };
+
+    return inputRequired({
+      inputRequests: {
+        authorize: inputRequired.elicitUrl({
+          message: "Sign in to link your account",
+          url: "https://example.com/authorize",
+        }),
+      },
+    });
   });
+
+  server.tool(
+    {
+      name: "batch-profile",
+      inputSchema: z.object({
+        cancel: z.boolean().optional().default(false),
+      }),
+    },
+    async ({ cancel }, ctx) => {
+      batchedToolEntries += 1;
+
+      // inputResponses contains only the requests fulfilled for this round.
+      // Read every batched response before deciding whether the flow stopped.
+      const projectResponse = inputResponse(ctx.inputResponses, "project");
+      const regionResponse = inputResponse(ctx.inputResponses, "region");
+      const stoppedResponse = [projectResponse, regionResponse].find(
+        (response) => response.kind === "elicit" && response.action !== "accept"
+      );
+      if (
+        stoppedResponse?.kind === "elicit" &&
+        stoppedResponse.action !== "accept"
+      ) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Batch ${stoppedResponse.action}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const project = acceptedContent(
+        ctx.inputResponses,
+        "project",
+        projectSchema
+      );
+      const region = acceptedContent(
+        ctx.inputResponses,
+        "region",
+        regionSchema
+      );
+
+      // If either value is missing or invalid, request the complete batch again:
+      // accepted values from this round are not implicit state for the next one.
+      if (project === undefined || region === undefined) {
+        return inputRequired({
+          inputRequests: {
+            project: inputRequired.elicit({
+              message: cancel
+                ? "Project name for cancelled batch?"
+                : "Project name?",
+              requestedSchema: projectSchema,
+            }),
+            region: inputRequired.elicit({
+              message: cancel
+                ? "Deployment region for cancelled batch?"
+                : "Deployment region?",
+              requestedSchema: regionSchema,
+            }),
+          },
+        });
+      }
+
+      // Provisioning is safe only after both responses in the batch validate.
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Provision ${project.project} in ${region.region}`,
+          },
+        ],
+      };
+    }
+  );
+
+  server.tool(
+    {
+      name: "stateful-deploy",
+      inputSchema: z.object({ environment: z.string() }),
+    },
+    async ({ environment }, ctx) => {
+      statefulToolEntries += 1;
+      // Both channels are per-invocation: inputResponses answers this round,
+      // while verified requestState carries trusted workflow data across rounds.
+      const response = inputResponse(ctx.inputResponses, "stateful-confirm");
+      const state = ctx.requestState<DeployRequestState>();
+
+      // A decline or cancellation is terminal even though the handler restarted.
+      if (response.kind === "elicit" && response.action !== "accept") {
+        return {
+          content: [
+            { type: "text", text: `Stateful deployment ${response.action}` },
+          ],
+          isError: true,
+        };
+      }
+
+      if (
+        state !== undefined &&
+        (state.phase !== "awaiting-confirmation" ||
+          state.environment !== environment)
+      ) {
+        return {
+          content: [
+            { type: "text", text: "Confirmation does not match deployment" },
+          ],
+          isError: true,
+        };
+      }
+
+      const confirmation = acceptedContent(
+        ctx.inputResponses,
+        "stateful-confirm",
+        confirmationSchema
+      );
+
+      // Initial, missing, or schema-invalid rounds request input and mint the
+      // stage needed by whichever replica receives the next invocation.
+      if (state === undefined || confirmation === undefined) {
+        return inputRequired({
+          inputRequests: {
+            "stateful-confirm": inputRequired.elicit({
+              message: `Statefully deploy to ${environment}?`,
+              requestedSchema: confirmationSchema,
+            }),
+          },
+          requestState: await requestStateCodec.mint({
+            phase: "awaiting-confirmation",
+            environment,
+          }),
+        });
+      }
+
+      if (confirmation.confirm !== true) {
+        return {
+          content: [{ type: "text", text: "Stateful deployment not approved" }],
+          isError: true,
+        };
+      }
+
+      // Side effects would go here, after verified state and validated consent.
+      return {
+        content: [{ type: "text", text: `Statefully deployed ${environment}` }],
+      };
+    }
+  );
 
   server.tool({ name: "emit-log" }, async (_params, ctx) => {
     await ctx.sendLog("info", { operation: "emit-log" }, "elicitation-test");
@@ -138,17 +315,29 @@ describe("elicitation and input_required", () => {
       if (request.params.message === "Deploy to decline?") {
         return { action: "decline" };
       }
+      if (request.params.message === "Deploy to cancel?") {
+        cancelledFormAttempts += 1;
+        return { action: "cancel" };
+      }
       if (request.params.message === "Deploy to invalid-first?") {
         invalidFormAttempts += 1;
         return invalidFormAttempts === 1
           ? { action: "accept", content: { confirm: "yes" } }
           : { action: "accept", content: { confirm: true } };
       }
-      if (request.params.message === "Deploy to async-invalid-first?") {
-        asyncFormAttempts += 1;
-        return asyncFormAttempts === 1
-          ? { action: "accept", content: { confirm: false } }
-          : { action: "accept", content: { confirm: true } };
+      if (request.params.message === "Project name?") {
+        return { action: "accept", content: { project: "apollo" } };
+      }
+      if (request.params.message === "Deployment region?") {
+        return { action: "accept", content: { region: "us-west-2" } };
+      }
+      if (request.params.message === "Project name for cancelled batch?") {
+        cancelledBatchRequests += 1;
+        return { action: "cancel" };
+      }
+      if (request.params.message === "Deployment region for cancelled batch?") {
+        cancelledBatchRequests += 1;
+        return { action: "accept", content: { region: "us-east-1" } };
       }
       return { action: "accept", content: { confirm: true } };
     });
@@ -165,14 +354,26 @@ describe("elicitation and input_required", () => {
     await client.connect(
       new StreamableHTTPClientTransport(new URL(started.url))
     );
+    manualClient = new Client(
+      { name: "elicitation-manual-client", version: "1.0.0" },
+      {
+        capabilities: { elicitation: { form: {}, url: {} } },
+        versionNegotiation: { mode: { pin: "2026-07-28" } },
+        inputRequired: { autoFulfill: false },
+      }
+    );
+    await manualClient.connect(
+      new StreamableHTTPClientTransport(new URL(started.url))
+    );
   });
 
   afterAll(async () => {
+    await manualClient.close();
     await client.close();
     await server.close();
   });
 
-  it("round-trips a v1-style form elicitation and returns the final tool result", async () => {
+  it("round-trips a form input_required result and returns the final tool result", async () => {
     const result = await client.callTool({
       name: "deploy",
       arguments: { environment: "production" },
@@ -190,12 +391,12 @@ describe("elicitation and input_required", () => {
     );
   });
 
-  it("round-trips a v1-style URL elicitation", async () => {
+  it("round-trips a URL input_required result", async () => {
     const result = await client.callTool({ name: "link-account" });
 
     expect(result.content).toContainEqual({
       type: "text",
-      text: "Account linked",
+      text: "Authorization page opened",
     });
     expect(seenRequests).toContainEqual(
       expect.objectContaining({
@@ -239,6 +440,123 @@ describe("elicitation and input_required", () => {
     });
   });
 
+  it("surfaces a cancelled elicitation without re-requesting it", async () => {
+    const attemptsBefore = cancelledFormAttempts;
+    const result = await client.callTool({
+      name: "deploy",
+      arguments: { environment: "cancel" },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContainEqual({
+      type: "text",
+      text: "Deployment cancel",
+    });
+    expect(cancelledFormAttempts - attemptsBefore).toBe(1);
+  });
+
+  it("fulfills multiple input requests in one round before re-entering the tool", async () => {
+    const entriesBefore = batchedToolEntries;
+    const requestsBefore = seenRequests.length;
+
+    const result = await client.callTool({
+      name: "batch-profile",
+      arguments: {},
+    });
+
+    expect(result.content).toContainEqual({
+      type: "text",
+      text: "Provision apollo in us-west-2",
+    });
+    expect(batchedToolEntries - entriesBefore).toBe(2);
+    expect(seenRequests.slice(requestsBefore)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ mode: "form", message: "Project name?" }),
+        expect.objectContaining({
+          mode: "form",
+          message: "Deployment region?",
+        }),
+      ])
+    );
+  });
+
+  it("stops a batched flow when one input request is cancelled", async () => {
+    const entriesBefore = batchedToolEntries;
+    const requestsBefore = cancelledBatchRequests;
+
+    const result = await client.callTool({
+      name: "batch-profile",
+      arguments: { cancel: true },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContainEqual({
+      type: "text",
+      text: "Batch cancel",
+    });
+    expect(batchedToolEntries - entriesBefore).toBe(2);
+    expect(cancelledBatchRequests - requestsBefore).toBe(2);
+  });
+
+  it("round-trips verified requestState across handler entries", async () => {
+    const entriesBefore = statefulToolEntries;
+
+    const result = await client.callTool({
+      name: "stateful-deploy",
+      arguments: { environment: "production" },
+    });
+
+    expect(result.content).toContainEqual({
+      type: "text",
+      text: "Statefully deployed production",
+    });
+    expect(statefulToolEntries - entriesBefore).toBe(2);
+  });
+
+  it("rejects tampered requestState before handler re-entry", async () => {
+    const initial = await manualClient.callTool(
+      {
+        name: "stateful-deploy",
+        arguments: { environment: "production" },
+      },
+      { allowInputRequired: true }
+    );
+
+    expect(isInputRequiredResult(initial)).toBe(true);
+    if (
+      !isInputRequiredResult(initial) ||
+      initial.inputRequests === undefined ||
+      initial.requestState === undefined
+    ) {
+      throw new Error("Expected an input_required result with requestState");
+    }
+
+    const [responseKey] = Object.keys(initial.inputRequests);
+    if (responseKey === undefined) {
+      throw new Error("Expected a stateful confirmation response key");
+    }
+
+    type RetriedCall = Parameters<Client["callTool"]>[0] & {
+      inputResponses: Record<string, unknown>;
+      requestState: string;
+    };
+    const retriedCall: RetriedCall = {
+      name: "stateful-deploy",
+      arguments: { environment: "production" },
+      inputResponses: {
+        [responseKey]: {
+          action: "accept",
+          content: { confirm: true },
+        },
+      },
+      requestState: `${initial.requestState}tampered`,
+    };
+
+    await expect(
+      manualClient.callTool(retriedCall, { allowInputRequired: true })
+    ).rejects.toThrow(/requestState/i);
+  });
+
   it("re-requests form input that fails Standard Schema validation", async () => {
     const result = await client.callTool({
       name: "deploy",
@@ -250,18 +568,5 @@ describe("elicitation and input_required", () => {
       deployed: true,
     });
     expect(invalidFormAttempts).toBe(2);
-  });
-
-  it("awaits asynchronous Standard Schema validation", async () => {
-    const result = await client.callTool({
-      name: "deploy",
-      arguments: { environment: "async-invalid-first" },
-    });
-
-    expect(result.structuredContent).toEqual({
-      environment: "async-invalid-first",
-      deployed: true,
-    });
-    expect(asyncFormAttempts).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary

- migrate the executable conformance, elicitation, and basic Views examples from the compatibility API to the direct v2 `inputRequired`, `inputResponse`, and `acceptedContent` helpers
- explain the deliberately retry-first handler ordering: every invocation may be an initial request or a stateless retry, terminal decline/cancel responses are handled first, missing or invalid input returns `input_required`, and side effects remain below accepted, validated input
- add focused coverage for cancellation, one-round batching, verified cross-round `requestState`, and tampered-state rejection
- keep URL elicitation wording aligned with accept meaning that the authorization page was opened, not that the backend flow completed

## Relationship to #2046

This follow-up targets `beta` directly and is self-contained rather than stacked. It exercises the direct v2 surface that remains when #2046 removes `ctx.elicit`, so the runnable examples and tests do not depend on the compatibility helper. No Markdown documentation is changed.

## Validation

- `pnpm exec prettier --write packages/server/examples/conformance/src/index.ts packages/server/examples/elicitation/src/index.ts packages/server/examples/views/basic/src/index.ts packages/server/tests/elicitation.test.ts`
- `pnpm --filter mcp-use typecheck`
- `pnpm --filter mcp-use exec vitest run tests/elicitation.test.ts` — 11 tests passed
- `pnpm verify:examples` — all deterministic example checks passed; credential/deployment-dependent live checks were skipped by the verifier as designed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates server examples and tests to direct v2 elicitation in `mcp-use` using `inputRequired`, `inputResponse`, and `acceptedContent`, and removes reliance on the compatibility `ctx.elicit`. Expands coverage to URL flows, batch cancel, and verified `requestState` round-trips with tamper protection.

- **Refactors**
  - Rewrote conformance, elicitation, and basic views examples to use direct v2 helpers and schemas.
  - Adopted a stateless-retry handler pattern: handle decline/cancel first, request input only when accepted content is missing/invalid, and run side effects after validated input.
  - Clarified URL semantics: accept means the authorization page opened; examples/tests now reflect this.
  - Expanded tests: decline/cancel surfaces without re-request (single and batched), one-round batched fulfillment, verified `requestState` round-trip with tamper rejection via `createRequestStateCodec`, schema re-validation, and request-scoped logs and custom notifications.

<sup>Written for commit 6319254de1757c530211d5130468ad59f7ccec9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2051?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

