### PR TITLE
docs: tip main README toward beta v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@
 </p>
 </div>
 
+> [!TIP]
+> **Try the new beta v2** with [`create-mcp-use-app@beta`](https://www.npmjs.com/package/create-mcp-use-app): `npx create-mcp-use-app@beta`. See the [beta README](https://github.com/mcp-use/mcp-use/blob/beta/README.md).
+
 ##  About
 
   <b>mcp-use</b> is the fullstack MCP framework


### PR DESCRIPTION
## Summary
- Add a tip callout under the README hero pointing readers to try TypeScript v2 beta via `npx create-mcp-use-app@beta`
- Link to the [beta README](https://github.com/mcp-use/mcp-use/blob/beta/README.md) for the full v2 docs surface

## Test plan
- [ ] Confirm the tip renders correctly on the GitHub README preview
- [ ] Confirm the beta README link opens the `beta` branch README
- [ ] Confirm `npx create-mcp-use-app@beta` is the command shown

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a TIP callout under the README hero to promote the v2 beta. It links to the beta README and shows the command `npx create-mcp-use-app@beta` for `create-mcp-use-app@beta`.

<sup>Written for commit 398ae711ff1ac891a1785e1d167be4a4d3108c40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

