### PR TITLE
Point beta README at /prompt@beta.md and v2 docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   </p>
 
   <p>
-    <a href="https://mcp-use.com/docs/typescript/getting-started/quickstart"><strong>Documentation</strong></a>
+    <a href="https://docs.mcp-use.com/v2/typescript/getting-started/welcome"><strong>Documentation</strong></a>
     · <a href="https://inspector.mcp-use.com/inspector"><strong>Inspector</strong></a>
     · <a href="#examples"><strong>Examples</strong></a>
     · <a href="https://manufact.com"><strong>Deploy</strong></a>
@@ -62,10 +62,10 @@
 ### Start with your agent
 
 ```text
-Build an MCP server: https://mcp-use.com/prompt.md
+Build an MCP server: https://mcp-use.com/prompt@beta.md
 ```
 
-[Read the prompt →](https://mcp-use.com/prompt.md)
+[Read the prompt →](https://mcp-use.com/prompt@beta.md)
 
 ### Start with code
 
@@ -75,7 +75,7 @@ npx -y create-mcp-use-app@beta
 
 Run `npm run dev` in the generated project · open [`http://localhost:3000/mcp/inspector`](http://localhost:3000/mcp/inspector)
 
-[TS Docs](https://mcp-use.com/docs/typescript/getting-started/quickstart)
+[TS Docs](https://docs.mcp-use.com/v2/typescript/getting-started/welcome)
 
 ## Everything you need to ship MCP
 


### PR DESCRIPTION
## Summary
- Update the beta README agent onboarding link from `/prompt.md` to `/prompt@beta.md` (mcp-use v2 / `@beta` packages).
- Point Documentation / TS Docs links at the [v2 TypeScript getting-started welcome](https://docs.mcp-use.com/v2/typescript/getting-started/welcome).

## Test plan
- [ ] Confirm https://mcp-use.com/prompt@beta.md serves the beta prompt once cloud is deployed
- [ ] Open the PR README preview and click the prompt + docs links
- [ ] Confirm `npx create-mcp-use-app@beta` section is unchanged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the beta README to use the v2 onboarding flow: switch the agent prompt to https://mcp-use.com/prompt@beta.md and point docs to https://docs.mcp-use.com/v2/typescript/getting-started/welcome. This keeps beta users on the v2 path and avoids linking to the v1 prompt/docs.

<sup>Written for commit d1f2952a1ab74d72420967241dc45c410525730d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2053?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

