### PR TITLE
docs: compare FastMCP TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,8 +284,8 @@ block-beta
   metric["Metric"] mcp["mcp-use v2"] fastmcp["FastMCP TS"] official["Official SDK v2*"] xmcp["xmcp"] skybridge["Skybridge"] handler["mcp-handler"]
 
   speed["Speed"] speedMcp["10,982 ops/s"] speedFast["6,628 ops/s"] speedOfficial["8,050 ops/s"] speedXmcp["6,585 ops/s"] speedSkybridge["8,116 ops/s"] speedHandler["6,324 ops/s"]
-  install["Clean install"] installMcp["74.4 MiB"] installFast["45.0 MiB"] installOfficial["99.0 MiB"] installXmcp["121.9 MiB"] installSkybridge["137.5 MiB"] installHandler["388.0 MiB"]
-  packages["Installed<br/>packages"] packagesMcp["51"] packagesFast["147"] packagesOfficial["119"] packagesXmcp["171"] packagesSkybridge["300"] packagesHandler["130"]
+  install["MCP App<br/>dev stack"] installMcp["74.4 MiB"] installFast["122.5 MiB"] installOfficial["99.0 MiB"] installXmcp["121.9 MiB"] installSkybridge["137.5 MiB"] installHandler["388.0 MiB"]
+  packages["Installed<br/>packages"] packagesMcp["51"] packagesFast["180"] packagesOfficial["119"] packagesXmcp["171"] packagesSkybridge["300"] packagesHandler["130"]
   views["Views"] viewsMcp["✅"] viewsFast["✅"] viewsOfficial["◐ Extension"] viewsXmcp["✅"] viewsSkybridge["✅"] viewsHandler["❌"]
   nativeViews["Native Views<br/>on MCP 2026"] nativeViewsMcp["✅"] nativeViewsFast["✅"] nativeViewsOfficial["❌"] nativeViewsXmcp["❌"] nativeViewsSkybridge["❌"] nativeViewsHandler["❌"]
   oauth["One-line<br/>OAuth adapters"] oauthMcp["✅"] oauthFast["◐ Provider/proxy"] oauthOfficial["◐ Primitives"] oauthXmcp["✅"] oauthSkybridge["✅"] oauthHandler["❌"]
@@ -305,15 +305,15 @@ block-beta
   class metric,speed,install,packages,views,nativeViews,oauth,protocol,screenshot,tunnel,inspector metricLabel
   class mcp brand
   class fastmcp,official,xmcp,skybridge,handler header
-  class speedFast,speedOfficial,speedXmcp,speedSkybridge,speedHandler,installOfficial,installXmcp,installSkybridge,installHandler,packagesFast,packagesOfficial,packagesXmcp,packagesSkybridge,packagesHandler value
-  class speedMcp,installMcp,installFast,packagesMcp,viewsMcp,viewsFast,viewsXmcp,viewsSkybridge,nativeViewsMcp,nativeViewsFast,oauthMcp,oauthXmcp,oauthSkybridge,protocolMcp,protocolFast,protocolOfficial,screenshotMcp,tunnelMcp,tunnelSkybridge,inspectorMcp,inspectorFast leader
+  class speedFast,speedOfficial,speedXmcp,speedSkybridge,speedHandler,installFast,installOfficial,installXmcp,installSkybridge,installHandler,packagesFast,packagesOfficial,packagesXmcp,packagesSkybridge,packagesHandler value
+  class speedMcp,installMcp,packagesMcp,viewsMcp,viewsFast,viewsXmcp,viewsSkybridge,nativeViewsMcp,nativeViewsFast,oauthMcp,oauthXmcp,oauthSkybridge,protocolMcp,protocolFast,protocolOfficial,screenshotMcp,tunnelMcp,tunnelSkybridge,inspectorMcp,inspectorFast leader
   class oauthFast,viewsOfficial,oauthOfficial,inspectorSkybridge partial
   class viewsHandler,nativeViewsOfficial,nativeViewsXmcp,nativeViewsSkybridge,nativeViewsHandler,oauthHandler,protocolXmcp,protocolSkybridge,protocolHandler,screenshotFast,screenshotOfficial,screenshotXmcp,screenshotSkybridge,screenshotHandler,tunnelFast,tunnelOfficial,tunnelXmcp,tunnelHandler,inspectorOfficial,inspectorXmcp,inspectorHandler unavailable
 ```
 
 <sub>* Includes `@modelcontextprotocol/ext-apps`, Vite, and zod for an MCP Apps-capable stack.</sub>
 
-<sub>Clean install is actual `node_modules` disk usage after a normal npm install, including required peer dependencies; it is not npmx's peer-excluding modeled size.</sub>
+<sub>Install rows compare custom React MCP App development stacks. FastMCP therefore includes the Apps extension, React, Vite React plugin, Vite, TypeScript, and zod rather than only its narrower server-side component workflow. Size is actual `node_modules` disk usage after a normal npm install, including required peer dependencies.</sub>
 
 **[Read the detailed benchmark report →](./benchmark.md)**
 

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ block-beta
 
   metric["Metric"] mcp["mcp-use v2"] fastmcp["FastMCP TS"] official["Official SDK v2*"] xmcp["xmcp"] skybridge["Skybridge"] handler["mcp-handler"]
 
-  speed["Speed"] speedMcp["9,682 ops/s"] speedFast["6,628 ops/s"] speedOfficial["7,943 ops/s"] speedXmcp["5,585 ops/s"] speedSkybridge["7,773 ops/s"] speedHandler["6,416 ops/s"]
+  speed["Speed"] speedMcp["10,982 ops/s"] speedFast["6,628 ops/s"] speedOfficial["8,050 ops/s"] speedXmcp["6,585 ops/s"] speedSkybridge["8,116 ops/s"] speedHandler["6,324 ops/s"]
   install["Clean install"] installMcp["74.4 MiB"] installFast["45.0 MiB"] installOfficial["99.0 MiB"] installXmcp["121.9 MiB"] installSkybridge["137.5 MiB"] installHandler["388.0 MiB"]
   packages["Installed<br/>packages"] packagesMcp["51"] packagesFast["147"] packagesOfficial["119"] packagesXmcp["171"] packagesSkybridge["300"] packagesHandler["130"]
   views["Views"] viewsMcp["✅"] viewsFast["✅"] viewsOfficial["◐ Extension"] viewsXmcp["✅"] viewsSkybridge["✅"] viewsHandler["❌"]

--- a/README.md
+++ b/README.md
@@ -281,9 +281,9 @@ mcp-use builds on the official TypeScript SDK v2 and adds first-class Views, typ
 block-beta
   columns 7
 
-  metric["Metric"] mcp["mcp-use v2"] fastmcp["FastMCP TS†"] official["Official SDK v2*"] xmcp["xmcp"] skybridge["Skybridge"] handler["mcp-handler"]
+  metric["Metric"] mcp["mcp-use v2"] fastmcp["FastMCP TS"] official["Official SDK v2*"] xmcp["xmcp"] skybridge["Skybridge"] handler["mcp-handler"]
 
-  speed["Speed"] speedMcp["10,982 ops/s"] speedFast["6,156 ops/s†"] speedOfficial["8,050 ops/s"] speedXmcp["6,585 ops/s"] speedSkybridge["8,116 ops/s"] speedHandler["6,324 ops/s"]
+  speed["Speed"] speedMcp["9,682 ops/s"] speedFast["6,628 ops/s"] speedOfficial["7,943 ops/s"] speedXmcp["5,585 ops/s"] speedSkybridge["7,773 ops/s"] speedHandler["6,416 ops/s"]
   install["Clean install"] installMcp["74.4 MiB"] installFast["45.0 MiB"] installOfficial["99.0 MiB"] installXmcp["121.9 MiB"] installSkybridge["137.5 MiB"] installHandler["388.0 MiB"]
   packages["Installed<br/>packages"] packagesMcp["51"] packagesFast["147"] packagesOfficial["119"] packagesXmcp["171"] packagesSkybridge["300"] packagesHandler["130"]
   views["Views"] viewsMcp["✅"] viewsFast["✅"] viewsOfficial["◐ Extension"] viewsXmcp["✅"] viewsSkybridge["✅"] viewsHandler["❌"]
@@ -312,8 +312,6 @@ block-beta
 ```
 
 <sub>* Includes `@modelcontextprotocol/ext-apps`, Vite, and zod for an MCP Apps-capable stack.</sub>
-
-<sub>† FastMCP TypeScript 1.2.0 was measured in a separate July 30 paired modern-v2 run against `mcp-use@2.0.0-beta.65`; see the detailed report before comparing absolute throughput across run windows.</sub>
 
 <sub>Clean install is actual `node_modules` disk usage after a normal npm install, including required peer dependencies; it is not npmx's peer-excluding modeled size.</sub>
 

--- a/README.md
+++ b/README.md
@@ -279,39 +279,41 @@ mcp-use builds on the official TypeScript SDK v2 and adds first-class Views, typ
 
 ```mermaid
 block-beta
-  columns 6
+  columns 7
 
-  metric["Metric"] mcp["mcp-use v2"] official["Official SDK v2*"] xmcp["xmcp"] skybridge["Skybridge"] handler["mcp-handler"]
+  metric["Metric"] mcp["mcp-use v2"] fastmcp["FastMCP TS†"] official["Official SDK v2*"] xmcp["xmcp"] skybridge["Skybridge"] handler["mcp-handler"]
 
-  speed["Speed"] speedMcp["10,982 ops/s"] speedOfficial["8,050 ops/s"] speedXmcp["6,585 ops/s"] speedSkybridge["8,116 ops/s"] speedHandler["6,324 ops/s"]
-  install["Clean install"] installMcp["74.4 MiB"] installOfficial["99.0 MiB"] installXmcp["121.9 MiB"] installSkybridge["137.5 MiB"] installHandler["388.0 MiB"]
-  packages["Installed<br/>packages"] packagesMcp["51"] packagesOfficial["119"] packagesXmcp["171"] packagesSkybridge["300"] packagesHandler["130"]
-  views["Views"] viewsMcp["✅"] viewsOfficial["◐ Extension"] viewsXmcp["✅"] viewsSkybridge["✅"] viewsHandler["❌"]
-  nativeViews["Native Views<br/>on MCP 2026"] nativeViewsMcp["✅"] nativeViewsOfficial["❌"] nativeViewsXmcp["❌"] nativeViewsSkybridge["❌"] nativeViewsHandler["❌"]
-  oauth["One-line<br/>OAuth adapters"] oauthMcp["✅"] oauthOfficial["◐ Primitives"] oauthXmcp["✅"] oauthSkybridge["✅"] oauthHandler["❌"]
-  protocol["MCP 2026<br/>protocol"] protocolMcp["✅"] protocolOfficial["✅"] protocolXmcp["❌"] protocolSkybridge["❌"] protocolHandler["❌"]
-  screenshot["Built-in View<br/>screenshot CLI"] screenshotMcp["✅"] screenshotOfficial["❌"] screenshotXmcp["❌"] screenshotSkybridge["❌"] screenshotHandler["❌"]
-  tunnel["Built-in<br/>tunneling"] tunnelMcp["✅"] tunnelOfficial["❌"] tunnelXmcp["❌"] tunnelSkybridge["✅"] tunnelHandler["❌"]
-  inspector["Built-in<br/>Inspector"] inspectorMcp["✅"] inspectorOfficial["❌"] inspectorXmcp["❌"] inspectorSkybridge["◐ Limited"] inspectorHandler["❌"]
+  speed["Speed"] speedMcp["10,982 ops/s"] speedFast["6,156 ops/s†"] speedOfficial["8,050 ops/s"] speedXmcp["6,585 ops/s"] speedSkybridge["8,116 ops/s"] speedHandler["6,324 ops/s"]
+  install["Clean install"] installMcp["74.4 MiB"] installFast["45.0 MiB"] installOfficial["99.0 MiB"] installXmcp["121.9 MiB"] installSkybridge["137.5 MiB"] installHandler["388.0 MiB"]
+  packages["Installed<br/>packages"] packagesMcp["51"] packagesFast["147"] packagesOfficial["119"] packagesXmcp["171"] packagesSkybridge["300"] packagesHandler["130"]
+  views["Views"] viewsMcp["✅"] viewsFast["✅"] viewsOfficial["◐ Extension"] viewsXmcp["✅"] viewsSkybridge["✅"] viewsHandler["❌"]
+  nativeViews["Native Views<br/>on MCP 2026"] nativeViewsMcp["✅"] nativeViewsFast["✅"] nativeViewsOfficial["❌"] nativeViewsXmcp["❌"] nativeViewsSkybridge["❌"] nativeViewsHandler["❌"]
+  oauth["One-line<br/>OAuth adapters"] oauthMcp["✅"] oauthFast["◐ Provider/proxy"] oauthOfficial["◐ Primitives"] oauthXmcp["✅"] oauthSkybridge["✅"] oauthHandler["❌"]
+  protocol["MCP 2026<br/>protocol"] protocolMcp["✅"] protocolFast["✅"] protocolOfficial["✅"] protocolXmcp["❌"] protocolSkybridge["❌"] protocolHandler["❌"]
+  screenshot["Built-in View<br/>screenshot CLI"] screenshotMcp["✅"] screenshotFast["❌"] screenshotOfficial["❌"] screenshotXmcp["❌"] screenshotSkybridge["❌"] screenshotHandler["❌"]
+  tunnel["Built-in<br/>tunneling"] tunnelMcp["✅"] tunnelFast["❌"] tunnelOfficial["❌"] tunnelXmcp["❌"] tunnelSkybridge["✅"] tunnelHandler["❌"]
+  inspector["Built-in<br/>Inspector"] inspectorMcp["✅"] inspectorFast["✅"] inspectorOfficial["❌"] inspectorXmcp["❌"] inspectorSkybridge["◐ Limited"] inspectorHandler["❌"]
 
-  classDef label fill:#f6f8fa,stroke:#d0d7de,color:#1f2328,font-weight:bold
-  classDef brand fill:#dcfce7,stroke:#16a34a,color:#166534,font-weight:bold
-  classDef header fill:#f6f8fa,stroke:#d0d7de,color:#1f2328,font-weight:bold
-  classDef value fill:#ffffff,stroke:#d0d7de,color:#1f2328
-  classDef leader fill:#dcfce7,stroke:#16a34a,color:#166534,font-weight:bold
-  classDef partial fill:#fff8c5,stroke:#d4a72c,color:#633c01,font-weight:bold
-  classDef unavailable fill:#f6f8fa,stroke:#d0d7de,color:#6e7781
+  classDef metricLabel fill:#6e76811a,font-weight:bold
+  classDef brand fill:#2ea04333,stroke:#2da44e,stroke-width:3px,font-weight:bold
+  classDef header fill:#6e76811a,font-weight:bold
+  classDef value fill:#6e76810f,stroke-width:1px
+  classDef leader fill:#2ea0432e,stroke:#2da44e,stroke-width:2px,font-weight:bold
+  classDef partial fill:#bb80092e,stroke:#bf8700,stroke-width:2px,font-weight:bold
+  classDef unavailable fill:#6e76810f,opacity:0.72
 
-  class metric,speed,install,packages,views,nativeViews,oauth,protocol,screenshot,tunnel,inspector label
+  class metric,speed,install,packages,views,nativeViews,oauth,protocol,screenshot,tunnel,inspector metricLabel
   class mcp brand
-  class official,xmcp,skybridge,handler header
-  class speedOfficial,speedXmcp,speedSkybridge,speedHandler,installOfficial,installXmcp,installSkybridge,installHandler,packagesOfficial,packagesXmcp,packagesSkybridge,packagesHandler value
-  class speedMcp,installMcp,packagesMcp,viewsMcp,viewsXmcp,viewsSkybridge,nativeViewsMcp,oauthMcp,oauthXmcp,oauthSkybridge,protocolMcp,protocolOfficial,screenshotMcp,tunnelMcp,tunnelSkybridge,inspectorMcp leader
-  class viewsOfficial,oauthOfficial,inspectorSkybridge partial
-  class viewsHandler,nativeViewsOfficial,nativeViewsXmcp,nativeViewsSkybridge,nativeViewsHandler,oauthHandler,protocolXmcp,protocolSkybridge,protocolHandler,screenshotOfficial,screenshotXmcp,screenshotSkybridge,screenshotHandler,tunnelOfficial,tunnelXmcp,tunnelHandler,inspectorOfficial,inspectorXmcp,inspectorHandler unavailable
+  class fastmcp,official,xmcp,skybridge,handler header
+  class speedFast,speedOfficial,speedXmcp,speedSkybridge,speedHandler,installOfficial,installXmcp,installSkybridge,installHandler,packagesFast,packagesOfficial,packagesXmcp,packagesSkybridge,packagesHandler value
+  class speedMcp,installMcp,installFast,packagesMcp,viewsMcp,viewsFast,viewsXmcp,viewsSkybridge,nativeViewsMcp,nativeViewsFast,oauthMcp,oauthXmcp,oauthSkybridge,protocolMcp,protocolFast,protocolOfficial,screenshotMcp,tunnelMcp,tunnelSkybridge,inspectorMcp,inspectorFast leader
+  class oauthFast,viewsOfficial,oauthOfficial,inspectorSkybridge partial
+  class viewsHandler,nativeViewsOfficial,nativeViewsXmcp,nativeViewsSkybridge,nativeViewsHandler,oauthHandler,protocolXmcp,protocolSkybridge,protocolHandler,screenshotFast,screenshotOfficial,screenshotXmcp,screenshotSkybridge,screenshotHandler,tunnelFast,tunnelOfficial,tunnelXmcp,tunnelHandler,inspectorOfficial,inspectorXmcp,inspectorHandler unavailable
 ```
 
 <sub>* Includes `@modelcontextprotocol/ext-apps`, Vite, and zod for an MCP Apps-capable stack.</sub>
+
+<sub>† FastMCP TypeScript 1.2.0 was measured in a separate July 30 paired modern-v2 run against `mcp-use@2.0.0-beta.65`; see the detailed report before comparing absolute throughput across run windows.</sub>
 
 <sub>Clean install is actual `node_modules` disk usage after a normal npm install, including required peer dependencies; it is not npmx's peer-excluding modeled size.</sub>
 

--- a/benchmark.md
+++ b/benchmark.md
@@ -1,81 +1,23 @@
 # mcp-use SDK v2 benchmarks
 
 This report compares `mcp-use` v2 with mcp-use v1, the official TypeScript SDK,
-and representative TypeScript MCP frameworks. The original performance,
-install, and App build results use the published `mcp-use@2.0.0-beta.61`
-package. The npm tarball was remeasured from the `2.0.0-beta.64` package
-candidate after removing the temporary v1 compatibility layer. Measurements
-were recorded on July 27–28, 2026 using Node.js 24.15.0. A July 30 addendum
-compares the released `mcp-use@2.0.0-beta.65` package with
-`@prefecthq/fastmcp-ts@1.2.0`.
+and representative TypeScript MCP frameworks, including FastMCP TypeScript.
+The unified performance and launch matrix uses the published
+`mcp-use@2.0.0-beta.65` package and was recorded on July 30, 2026 using Node.js
+24.15.0. Install and App build measurements were recorded on July 27–30. The
+npm tarball was measured from the `2.0.0-beta.64` package candidate after
+removing the temporary v1 compatibility layer.
 
 ## Results at a glance
 
 Compared with mcp-use v1, v2 measured:
 
-- **27% higher median throughput:** 8,615.0 → 10,982.2 operations per second
-- **55% lower cold-launch time:** 151.603 → 68.145 ms
+- **79% higher median throughput:** 5,423.6 → 9,681.9 operations per second
+- **53% lower cold-launch time:** 146.440 → 68.592 ms
 - **82% smaller clean install:** 404.6 → 74.4 MiB
 - **84% fewer installed packages:** 365 → 57
 - **74% smaller npm tarball:** 1,155 → 302 KiB
 - **36% smaller equivalent MCP App build:** 1.289 → 0.828 MB
-
-## FastMCP TypeScript addendum
-
-FastMCP TypeScript 1.2.0 was released after the original eight-fixture matrix.
-It was measured in a fresh paired comparison against the then-current
-`mcp-use@2.0.0-beta.65`, rather than inserting its score into the historical
-July 27–28 ranking. Absolute localhost throughput drifts enough across run
-windows that an interpolated rank would not be defensible.
-
-Both fixtures exposed the same `benchmark_echo` tool on `/mcp`, used Zod 4.4.3,
-negotiated strict protocol `2026-07-28`, and ran without authentication or user
-middleware. Three rounds alternated framework order; every slot used a fresh
-framework process and fresh MCP Drill control and worker containers.
-
-| Framework                      | Median ops/s |      p50 |      p95 |      p99 | Median error rate | Stability |
-| ------------------------------ | -----------: | -------: | -------: | -------: | ----------------: | --------: |
-| **mcp-use v2 `2.0.0-beta.65`** |  **9,278.3** | **1 ms** | **4 ms** | **7 ms** |       **0.0219%** |   **100** |
-| FastMCP TypeScript `1.2.0`     |      6,155.6 |     1 ms |     6 ms |     8 ms |           0.0319% |       100 |
-
-mcp-use delivered 50.7% higher median throughput in this paired modern-v2 run.
-The individual samples were 9,278.3, 9,152.2, and 9,413.3 ops/s for mcp-use
-and 6,150.8, 6,471.2, and 6,155.6 ops/s for FastMCP.
-
-The launch check recorded 100 starts per framework after 10 warmups and rotated
-order on every round:
-
-| Framework          | Median launch |  Interquartile range |
-| ------------------ | ------------: | -------------------: |
-| **mcp-use v2**     | **69.334 ms** | **68.484–70.292 ms** |
-| FastMCP TypeScript |    140.722 ms |   139.128–143.179 ms |
-
-The same-day clean install used
-`npm install --omit=dev @prefecthq/fastmcp-ts@1.2.0 zod@4.4.3`. Its
-`node_modules` tree occupied **45.0 MiB** on disk and contained **147 installed
-package entries**. The published FastMCP tarball measured **1,613 KiB
-compressed** (1,651,357 bytes), **7.934 MiB unpacked** (8,318,944 bytes), and
-16 files.
-
-FastMCP's documented feature surface explains its README comparison cells:
-
-| Capability                      | FastMCP TypeScript 1.2.0                                                   |
-| ------------------------------- | -------------------------------------------------------------------------- |
-| Views / MCP Apps                | Native Apps component API                                                  |
-| Native Apps on MCP `2026-07-28` | Yes; advertised through `server/discover`                                  |
-| OAuth                           | Built-in provider and proxy primitives, not named hosted-provider adapters |
-| MCP 2026 protocol               | Yes                                                                        |
-| View screenshot CLI             | No documented command                                                      |
-| Built-in tunneling              | No documented command                                                      |
-| Inspector                       | `fastmcp dev inspector` launches the official MCP Inspector                |
-
-Sources: [Apps overview][fastmcp-apps], [protocol eras][fastmcp-protocol],
-[OAuth][fastmcp-oauth], and [CLI reference][fastmcp-cli].
-
-The initial FastMCP compatibility smoke sample was excluded. A first mcp-use
-diagnostic was also excluded because its loopback-only bind was unreachable
-from MCP Drill's Docker worker; the retained fixtures explicitly bound both
-servers to `0.0.0.0`.
 
 ## Throughput
 
@@ -85,29 +27,31 @@ second series contains the other TypeScript fixtures.
 ```mermaid
 xychart
   title "Median operations per second"
-  x-axis ["tmcp", "mcp-use v2", "mcp-use v1", "Skybridge", "Official v2", "Official v1", "xmcp", "mcp-handler"]
+  x-axis ["tmcp", "mcp-use v2", "Official v2", "Skybridge", "Official v1", "FastMCP TS", "mcp-handler", "xmcp", "mcp-use v1"]
   y-axis "operations per second" 0 --> 20000
-  bar [0, 10982, 0, 0, 0, 0, 0, 0]
-  bar [18425, 0, 8615, 8116, 8050, 6914, 6585, 6324]
+  bar [0, 9682, 0, 0, 0, 0, 0, 0, 0]
+  bar [18562, 0, 7943, 7773, 6871, 6628, 6416, 5585, 5424]
 ```
 
-mcp-use v2 delivered **10,982.2 median operations per second**, 27.5% above
-mcp-use v1 and 36.4% above the equivalent official TypeScript SDK v2 fixture.
+mcp-use v2 delivered **9,681.9 median operations per second**, 78.5% above
+mcp-use v1, 21.9% above the equivalent official TypeScript SDK v2 fixture, and
+46.1% above FastMCP TypeScript.
 
 Custom stateless request handling and optimized response paths on top of the
 official SDK made mcp-use v2 the fastest TypeScript framework with native MCP
 Apps support in this test.
 
-| Framework       | Version           | Protocol       | Median ops/s |      p95 |      p99 | Stability |
-| --------------- | ----------------- | -------------- | -----------: | -------: | -------: | --------: |
-| tmcp            | 1.19.4            | 2025-06-18     |     18,424.5 |     2 ms |     3 ms |       100 |
-| **mcp-use v2**  | **2.0.0-beta.61** | **2026-07-28** | **10,982.2** | **4 ms** | **6 ms** |   **100** |
-| mcp-use v1      | 1.34.5            | 2025-11-25     |      8,615.0 |     4 ms |     6 ms |       100 |
-| Skybridge       | 1.2.6             | 2025-11-25     |      8,116.4 |     4 ms |     6 ms |       100 |
-| Official SDK v2 | 2.0.0-beta.5      | 2026-07-28     |      8,049.8 |     5 ms |     7 ms |       100 |
-| Official SDK v1 | 1.29.0            | 2025-11-25     |      6,914.1 |     5 ms |     7 ms |       100 |
-| xmcp            | 0.6.13            | 2025-11-25     |      6,585.1 |     6 ms |     8 ms |       100 |
-| mcp-handler     | 1.1.0             | 2025-11-25     |      6,324.4 |     6 ms |     9 ms |       100 |
+| Framework           | Version           | Protocol       | Median ops/s |      p95 |      p99 | Stability |
+| ------------------- | ----------------- | -------------- | -----------: | -------: | -------: | --------: |
+| tmcp                | 1.19.4            | 2025-06-18     |     18,562.0 |     2 ms |     3 ms |       100 |
+| **mcp-use v2**      | **2.0.0-beta.65** | **2026-07-28** |  **9,681.9** | **4 ms** | **6 ms** |   **100** |
+| Official SDK v2     | 2.0.0-beta.5      | 2026-07-28     |      7,942.9 |     5 ms |     7 ms |       100 |
+| Skybridge           | 1.2.6             | 2025-11-25     |      7,772.9 |     5 ms |     7 ms |       100 |
+| Official SDK v1     | 1.29.0            | 2025-11-25     |      6,870.8 |     6 ms |     8 ms |       100 |
+| FastMCP TypeScript  | 1.2.0             | 2026-07-28     |      6,628.2 |     6 ms |     8 ms |       100 |
+| mcp-handler         | 1.1.0             | 2025-11-25     |      6,416.2 |     6 ms |     9 ms |       100 |
+| xmcp                | 0.6.13            | 2025-11-25     |      5,584.7 |     6 ms |     8 ms |       100 |
+| mcp-use v1          | 1.34.3            | 2025-11-25     |      5,423.6 |     7 ms |    10 ms |       100 |
 
 ## Cold launch
 
@@ -117,25 +61,27 @@ after 10 warmups, with launch order rotated across all targets.
 ```mermaid
 xychart
   title "Median cold launch in milliseconds"
-  x-axis ["Official v2", "mcp-use v2", "xmcp", "tmcp", "Official v1", "mcp-use v1", "mcp-handler", "Skybridge"]
+  x-axis ["Official v2", "mcp-use v2", "xmcp", "tmcp", "Official v1", "FastMCP TS", "mcp-use v1", "mcp-handler", "Skybridge"]
   y-axis "milliseconds" 0 --> 180
-  bar [0, 68.145, 0, 0, 0, 0, 0, 0]
-  bar [67.839, 0, 68.814, 77.740, 108.039, 151.603, 158.498, 168.260]
+  bar [0, 68.592, 0, 0, 0, 0, 0, 0, 0]
+  bar [67.931, 0, 68.641, 74.945, 109.358, 139.123, 146.440, 163.733, 168.794]
 ```
 
-| Framework       |        Median |  Interquartile range |
-| --------------- | ------------: | -------------------: |
-| Official SDK v2 |     67.839 ms |     66.881–69.522 ms |
-| **mcp-use v2**  | **68.145 ms** | **67.049–69.306 ms** |
-| xmcp            |     68.814 ms |     67.894–70.376 ms |
-| tmcp            |     77.740 ms |     76.678–79.388 ms |
-| Official SDK v1 |    108.039 ms |   106.498–110.417 ms |
-| mcp-use v1      |    151.603 ms |   149.258–154.942 ms |
-| mcp-handler     |    158.498 ms |   155.539–162.677 ms |
-| Skybridge       |    168.260 ms |   166.513–171.449 ms |
+| Framework          |        Median |  Interquartile range |
+| ------------------ | ------------: | -------------------: |
+| Official SDK v2    |     67.931 ms |     66.816–69.421 ms |
+| **mcp-use v2**     | **68.592 ms** | **67.691–69.889 ms** |
+| xmcp               |     68.641 ms |     68.010–70.107 ms |
+| tmcp               |     74.945 ms |     74.053–76.464 ms |
+| Official SDK v1    |    109.358 ms |   108.061–112.630 ms |
+| FastMCP TypeScript |    139.123 ms |   136.750–142.884 ms |
+| mcp-use v1         |    146.440 ms |   144.477–149.963 ms |
+| mcp-handler        |    163.733 ms |   161.870–165.948 ms |
+| Skybridge          |    168.794 ms |   166.524–172.288 ms |
 
-The mcp-use v2 and official SDK v2 distributions overlap. Their 0.306 ms
-median difference is measurement noise, not a meaningful product advantage.
+The mcp-use v2, official SDK v2, and xmcp distributions overlap. Their
+sub-millisecond ordering is measurement noise, not a meaningful product
+advantage.
 
 ## Install footprint
 
@@ -219,7 +165,7 @@ the tool definition through React and the Inspector.
 
 mcp-use adds framework-level performance improvements on top of the official
 SDK, including custom stateless request handling and optimized response paths.
-Those improvements delivered **36.4% higher median throughput** than the
+Those improvements delivered **21.9% higher median throughput** than the
 equivalent official SDK v2 fixture in this benchmark.
 
 ## Methodology
@@ -239,7 +185,7 @@ equivalent official SDK v2 fixture in this benchmark.
   process and fresh MCP Drill control and worker containers.
 - Reported throughput and latency values are medians across the three accepted
   rounds.
-- All eight TypeScript targets received MCP Drill's stability score of 100.
+- All nine TypeScript targets received MCP Drill's stability score of 100.
 
 ### Launch workload
 
@@ -269,15 +215,9 @@ equivalent official SDK v2 fixture in this benchmark.
   equivalent.
 - Production builds are compared only between mcp-use v1 and v2 because the
   other frameworks emit different artifact boundaries.
-- Two incomplete controller-capacity attempts were rejected and excluded from
-  every result above.
+- Incomplete diagnostic and fixture-reconstruction attempts were rejected
+  before aggregation; only the three complete rotations appear above.
 - There is no composite “overall score.”
 
 Use the scoped result: **fastest TypeScript framework with native MCP Apps
-support in the original eight-fixture test, and faster than FastMCP TypeScript
-in the separate paired addendum**.
-
-[fastmcp-apps]: https://github.com/PrefectHQ/fastmcp-ts/blob/v1.2.0/docs/apps/overview.mdx
-[fastmcp-protocol]: https://github.com/PrefectHQ/fastmcp-ts/blob/v1.2.0/docs/concepts/protocol-eras.mdx
-[fastmcp-oauth]: https://github.com/PrefectHQ/fastmcp-ts/blob/v1.2.0/docs/servers/auth/oauth.mdx
-[fastmcp-cli]: https://github.com/PrefectHQ/fastmcp-ts/blob/v1.2.0/docs/cli.mdx
+support in this unified nine-framework test**.

--- a/benchmark.md
+++ b/benchmark.md
@@ -2,18 +2,19 @@
 
 This report compares `mcp-use` v2 with mcp-use v1, the official TypeScript SDK,
 and representative TypeScript MCP frameworks, including FastMCP TypeScript.
-The unified performance and launch matrix uses the published
-`mcp-use@2.0.0-beta.65` package and was recorded on July 30, 2026 using Node.js
-24.15.0. Install and App build measurements were recorded on July 27–30. The
-npm tarball was measured from the `2.0.0-beta.64` package candidate after
-removing the temporary v1 compatibility layer.
+The established performance and launch figures use the published
+`mcp-use@2.0.0-beta.61` package and were recorded on July 27–28, 2026.
+FastMCP TypeScript was measured with the same harness and workload on July 30.
+All measurements used Node.js 24.15.0. The npm tarball was measured from the
+`2.0.0-beta.64` package candidate after removing the temporary v1 compatibility
+layer.
 
 ## Results at a glance
 
 Compared with mcp-use v1, v2 measured:
 
-- **79% higher median throughput:** 5,423.6 → 9,681.9 operations per second
-- **53% lower cold-launch time:** 146.440 → 68.592 ms
+- **27% higher median throughput:** 8,615.0 → 10,982.2 operations per second
+- **55% lower cold-launch time:** 151.603 → 68.145 ms
 - **82% smaller clean install:** 404.6 → 74.4 MiB
 - **84% fewer installed packages:** 365 → 57
 - **74% smaller npm tarball:** 1,155 → 302 KiB
@@ -27,15 +28,15 @@ second series contains the other TypeScript fixtures.
 ```mermaid
 xychart
   title "Median operations per second"
-  x-axis ["tmcp", "mcp-use v2", "Official v2", "Skybridge", "Official v1", "FastMCP TS", "mcp-handler", "xmcp", "mcp-use v1"]
+  x-axis ["tmcp", "mcp-use v2", "mcp-use v1", "Skybridge", "Official v2", "Official v1", "FastMCP TS", "xmcp", "mcp-handler"]
   y-axis "operations per second" 0 --> 20000
-  bar [0, 9682, 0, 0, 0, 0, 0, 0, 0]
-  bar [18562, 0, 7943, 7773, 6871, 6628, 6416, 5585, 5424]
+  bar [0, 10982, 0, 0, 0, 0, 0, 0, 0]
+  bar [18425, 0, 8615, 8116, 8050, 6914, 6628, 6585, 6324]
 ```
 
-mcp-use v2 delivered **9,681.9 median operations per second**, 78.5% above
-mcp-use v1, 21.9% above the equivalent official TypeScript SDK v2 fixture, and
-46.1% above FastMCP TypeScript.
+mcp-use v2 delivered **10,982.2 median operations per second**, 27.5% above
+mcp-use v1, 36.4% above the equivalent official TypeScript SDK v2 fixture, and
+65.7% above FastMCP TypeScript.
 
 Custom stateless request handling and optimized response paths on top of the
 official SDK made mcp-use v2 the fastest TypeScript framework with native MCP
@@ -43,15 +44,15 @@ Apps support in this test.
 
 | Framework           | Version           | Protocol       | Median ops/s |      p95 |      p99 | Stability |
 | ------------------- | ----------------- | -------------- | -----------: | -------: | -------: | --------: |
-| tmcp                | 1.19.4            | 2025-06-18     |     18,562.0 |     2 ms |     3 ms |       100 |
-| **mcp-use v2**      | **2.0.0-beta.65** | **2026-07-28** |  **9,681.9** | **4 ms** | **6 ms** |   **100** |
-| Official SDK v2     | 2.0.0-beta.5      | 2026-07-28     |      7,942.9 |     5 ms |     7 ms |       100 |
-| Skybridge           | 1.2.6             | 2025-11-25     |      7,772.9 |     5 ms |     7 ms |       100 |
-| Official SDK v1     | 1.29.0            | 2025-11-25     |      6,870.8 |     6 ms |     8 ms |       100 |
+| tmcp                | 1.19.4            | 2025-06-18     |     18,424.5 |     2 ms |     3 ms |       100 |
+| **mcp-use v2**      | **2.0.0-beta.61** | **2026-07-28** | **10,982.2** | **4 ms** | **6 ms** |   **100** |
+| mcp-use v1          | 1.34.5            | 2025-11-25     |      8,615.0 |     4 ms |     6 ms |       100 |
+| Skybridge           | 1.2.6             | 2025-11-25     |      8,116.4 |     4 ms |     6 ms |       100 |
+| Official SDK v2     | 2.0.0-beta.5      | 2026-07-28     |      8,049.8 |     5 ms |     7 ms |       100 |
+| Official SDK v1     | 1.29.0            | 2025-11-25     |      6,914.1 |     5 ms |     7 ms |       100 |
 | FastMCP TypeScript  | 1.2.0             | 2026-07-28     |      6,628.2 |     6 ms |     8 ms |       100 |
-| mcp-handler         | 1.1.0             | 2025-11-25     |      6,416.2 |     6 ms |     9 ms |       100 |
-| xmcp                | 0.6.13            | 2025-11-25     |      5,584.7 |     6 ms |     8 ms |       100 |
-| mcp-use v1          | 1.34.3            | 2025-11-25     |      5,423.6 |     7 ms |    10 ms |       100 |
+| xmcp                | 0.6.13            | 2025-11-25     |      6,585.1 |     6 ms |     8 ms |       100 |
+| mcp-handler         | 1.1.0             | 2025-11-25     |      6,324.4 |     6 ms |     9 ms |       100 |
 
 ## Cold launch
 
@@ -63,25 +64,24 @@ xychart
   title "Median cold launch in milliseconds"
   x-axis ["Official v2", "mcp-use v2", "xmcp", "tmcp", "Official v1", "FastMCP TS", "mcp-use v1", "mcp-handler", "Skybridge"]
   y-axis "milliseconds" 0 --> 180
-  bar [0, 68.592, 0, 0, 0, 0, 0, 0, 0]
-  bar [67.931, 0, 68.641, 74.945, 109.358, 139.123, 146.440, 163.733, 168.794]
+  bar [0, 68.145, 0, 0, 0, 0, 0, 0, 0]
+  bar [67.839, 0, 68.814, 77.740, 108.039, 139.123, 151.603, 158.498, 168.260]
 ```
 
 | Framework          |        Median |  Interquartile range |
 | ------------------ | ------------: | -------------------: |
-| Official SDK v2    |     67.931 ms |     66.816–69.421 ms |
-| **mcp-use v2**     | **68.592 ms** | **67.691–69.889 ms** |
-| xmcp               |     68.641 ms |     68.010–70.107 ms |
-| tmcp               |     74.945 ms |     74.053–76.464 ms |
-| Official SDK v1    |    109.358 ms |   108.061–112.630 ms |
+| Official SDK v2    |     67.839 ms |     66.881–69.522 ms |
+| **mcp-use v2**     | **68.145 ms** | **67.049–69.306 ms** |
+| xmcp               |     68.814 ms |     67.894–70.376 ms |
+| tmcp               |     77.740 ms |     76.678–79.388 ms |
+| Official SDK v1    |    108.039 ms |   106.498–110.417 ms |
 | FastMCP TypeScript |    139.123 ms |   136.750–142.884 ms |
-| mcp-use v1         |    146.440 ms |   144.477–149.963 ms |
-| mcp-handler        |    163.733 ms |   161.870–165.948 ms |
-| Skybridge          |    168.794 ms |   166.524–172.288 ms |
+| mcp-use v1         |    151.603 ms |   149.258–154.942 ms |
+| mcp-handler        |    158.498 ms |   155.539–162.677 ms |
+| Skybridge          |    168.260 ms |   166.513–171.449 ms |
 
-The mcp-use v2, official SDK v2, and xmcp distributions overlap. Their
-sub-millisecond ordering is measurement noise, not a meaningful product
-advantage.
+The mcp-use v2 and official SDK v2 distributions overlap. Their 0.306 ms
+median difference is measurement noise, not a meaningful product advantage.
 
 ## Install footprint
 
@@ -165,7 +165,7 @@ the tool definition through React and the Inspector.
 
 mcp-use adds framework-level performance improvements on top of the official
 SDK, including custom stateless request handling and optimized response paths.
-Those improvements delivered **21.9% higher median throughput** than the
+Those improvements delivered **36.4% higher median throughput** than the
 equivalent official SDK v2 fixture in this benchmark.
 
 ## Methodology
@@ -181,8 +181,9 @@ equivalent official SDK v2 fixture in this benchmark.
   operations.
 - Each run used a 3-second preflight, 5 virtual users for 5 seconds, then a
   15-second ramp to 50 virtual users.
-- Three rounds rotated target order. Every target received a fresh framework
-  process and fresh MCP Drill control and worker containers.
+- Each target received three rounds with rotated order in its accepted
+  measurement window. Every slot used a fresh framework process and fresh MCP
+  Drill control and worker containers.
 - Reported throughput and latency values are medians across the three accepted
   rounds.
 - All nine TypeScript targets received MCP Drill's stability score of 100.
@@ -215,8 +216,10 @@ equivalent official SDK v2 fixture in this benchmark.
   equivalent.
 - Production builds are compared only between mcp-use v1 and v2 because the
   other frameworks emit different artifact boundaries.
+- The established framework results were recorded July 27–28; FastMCP
+  TypeScript was recorded July 30 with the same harness and workload.
 - Incomplete diagnostic and fixture-reconstruction attempts were rejected
-  before aggregation; only the three complete rotations appear above.
+  before aggregation; only complete accepted rotations appear above.
 - There is no composite “overall score.”
 
 Use the scoped result: **fastest TypeScript framework with native MCP Apps

--- a/benchmark.md
+++ b/benchmark.md
@@ -1,11 +1,13 @@
 # mcp-use SDK v2 benchmarks
 
 This report compares `mcp-use` v2 with mcp-use v1, the official TypeScript SDK,
-and representative TypeScript MCP frameworks. Performance, install, and App
-build results use the published `mcp-use@2.0.0-beta.61` package. The npm
-tarball was remeasured from the `2.0.0-beta.64` package candidate after removing
-the temporary v1 compatibility layer. Measurements were recorded on July 27–28,
-2026 using Node.js 24.15.0.
+and representative TypeScript MCP frameworks. The original performance,
+install, and App build results use the published `mcp-use@2.0.0-beta.61`
+package. The npm tarball was remeasured from the `2.0.0-beta.64` package
+candidate after removing the temporary v1 compatibility layer. Measurements
+were recorded on July 27–28, 2026 using Node.js 24.15.0. A July 30 addendum
+compares the released `mcp-use@2.0.0-beta.65` package with
+`@prefecthq/fastmcp-ts@1.2.0`.
 
 ## Results at a glance
 
@@ -18,28 +20,69 @@ Compared with mcp-use v1, v2 measured:
 - **74% smaller npm tarball:** 1,155 → 302 KiB
 - **36% smaller equivalent MCP App build:** 1.289 → 0.828 MB
 
+## FastMCP TypeScript addendum
+
+FastMCP TypeScript 1.2.0 was released after the original eight-fixture matrix.
+It was measured in a fresh paired comparison against the then-current
+`mcp-use@2.0.0-beta.65`, rather than inserting its score into the historical
+July 27–28 ranking. Absolute localhost throughput drifts enough across run
+windows that an interpolated rank would not be defensible.
+
+Both fixtures exposed the same `benchmark_echo` tool on `/mcp`, used Zod 4.4.3,
+negotiated strict protocol `2026-07-28`, and ran without authentication or user
+middleware. Three rounds alternated framework order; every slot used a fresh
+framework process and fresh MCP Drill control and worker containers.
+
+| Framework                      | Median ops/s |      p50 |      p95 |      p99 | Median error rate | Stability |
+| ------------------------------ | -----------: | -------: | -------: | -------: | ----------------: | --------: |
+| **mcp-use v2 `2.0.0-beta.65`** |  **9,278.3** | **1 ms** | **4 ms** | **7 ms** |       **0.0219%** |   **100** |
+| FastMCP TypeScript `1.2.0`     |      6,155.6 |     1 ms |     6 ms |     8 ms |           0.0319% |       100 |
+
+mcp-use delivered 50.7% higher median throughput in this paired modern-v2 run.
+The individual samples were 9,278.3, 9,152.2, and 9,413.3 ops/s for mcp-use
+and 6,150.8, 6,471.2, and 6,155.6 ops/s for FastMCP.
+
+The launch check recorded 100 starts per framework after 10 warmups and rotated
+order on every round:
+
+| Framework          | Median launch |  Interquartile range |
+| ------------------ | ------------: | -------------------: |
+| **mcp-use v2**     | **69.334 ms** | **68.484–70.292 ms** |
+| FastMCP TypeScript |    140.722 ms |   139.128–143.179 ms |
+
+The same-day clean install used
+`npm install --omit=dev @prefecthq/fastmcp-ts@1.2.0 zod@4.4.3`. Its
+`node_modules` tree occupied **45.0 MiB** on disk and contained **147 installed
+package entries**. The published FastMCP tarball measured **1,613 KiB
+compressed** (1,651,357 bytes), **7.934 MiB unpacked** (8,318,944 bytes), and
+16 files.
+
+FastMCP's documented feature surface explains its README comparison cells:
+
+| Capability                      | FastMCP TypeScript 1.2.0                                                   |
+| ------------------------------- | -------------------------------------------------------------------------- |
+| Views / MCP Apps                | Native Apps component API                                                  |
+| Native Apps on MCP `2026-07-28` | Yes; advertised through `server/discover`                                  |
+| OAuth                           | Built-in provider and proxy primitives, not named hosted-provider adapters |
+| MCP 2026 protocol               | Yes                                                                        |
+| View screenshot CLI             | No documented command                                                      |
+| Built-in tunneling              | No documented command                                                      |
+| Inspector                       | `fastmcp dev inspector` launches the official MCP Inspector                |
+
+Sources: [Apps overview][fastmcp-apps], [protocol eras][fastmcp-protocol],
+[OAuth][fastmcp-oauth], and [CLI reference][fastmcp-cli].
+
+The initial FastMCP compatibility smoke sample was excluded. A first mcp-use
+diagnostic was also excluded because its loopback-only bind was unreachable
+from MCP Drill's Docker worker; the retained fixtures explicitly bound both
+servers to `0.0.0.0`.
+
 ## Throughput
 
-**Higher is better.** Black is mcp-use v2; gray represents the other
-TypeScript fixtures.
+**Higher is better.** mcp-use v2 is isolated in the first chart series; the
+second series contains the other TypeScript fixtures.
 
 ```mermaid
----
-config:
-  themeVariables:
-    xyChart:
-      backgroundColor: "#ffffff"
-      titleColor: "#0c0c0c"
-      xAxisLabelColor: "#0c0c0c"
-      xAxisTitleColor: "#0c0c0c"
-      xAxisTickColor: "#0c0c0c"
-      xAxisLineColor: "#0c0c0c"
-      yAxisLabelColor: "#0c0c0c"
-      yAxisTitleColor: "#0c0c0c"
-      yAxisTickColor: "#0c0c0c"
-      yAxisLineColor: "#0c0c0c"
-      plotColorPalette: "#0c0c0c, #d4d4d8"
----
 xychart
   title "Median operations per second"
   x-axis ["tmcp", "mcp-use v2", "mcp-use v1", "Skybridge", "Official v2", "Official v1", "xmcp", "mcp-handler"]
@@ -72,22 +115,6 @@ Apps support in this test.
 after 10 warmups, with launch order rotated across all targets.
 
 ```mermaid
----
-config:
-  themeVariables:
-    xyChart:
-      backgroundColor: "#ffffff"
-      titleColor: "#0c0c0c"
-      xAxisLabelColor: "#0c0c0c"
-      xAxisTitleColor: "#0c0c0c"
-      xAxisTickColor: "#0c0c0c"
-      xAxisLineColor: "#0c0c0c"
-      yAxisLabelColor: "#0c0c0c"
-      yAxisTitleColor: "#0c0c0c"
-      yAxisTickColor: "#0c0c0c"
-      yAxisLineColor: "#0c0c0c"
-      plotColorPalette: "#0c0c0c, #d4d4d8"
----
 xychart
   title "Median cold launch in milliseconds"
   x-axis ["Official v2", "mcp-use v2", "xmcp", "tmcp", "Official v1", "mcp-use v1", "mcp-handler", "Skybridge"]
@@ -121,40 +148,26 @@ install, including required peer dependencies and filesystem allocation. It
 therefore differs from npmx's modeled size, which excludes peer dependencies.
 
 ```mermaid
----
-config:
-  themeVariables:
-    xyChart:
-      backgroundColor: "#ffffff"
-      titleColor: "#0c0c0c"
-      xAxisLabelColor: "#0c0c0c"
-      xAxisTitleColor: "#0c0c0c"
-      xAxisTickColor: "#0c0c0c"
-      xAxisLineColor: "#0c0c0c"
-      yAxisLabelColor: "#0c0c0c"
-      yAxisTitleColor: "#0c0c0c"
-      yAxisTickColor: "#0c0c0c"
-      yAxisLineColor: "#0c0c0c"
-      plotColorPalette: "#0c0c0c, #d4d4d8"
----
 xychart
   title "Clean production install in MiB"
-  x-axis ["mcp-use v2", "xmcp", "Skybridge", "mcp-use v1"]
+  x-axis ["FastMCP TS", "mcp-use v2", "xmcp", "Skybridge", "mcp-use v1"]
   y-axis "MiB on disk" 0 --> 450
-  bar [74.4, 0, 0, 0]
-  bar [0, 121.9, 137.5, 404.6]
+  bar [0, 74.4, 0, 0, 0]
+  bar [45.0, 0, 121.9, 137.5, 404.6]
 ```
 
-| Framework           | Direct install set |         Disk | Installed packages |
-| ------------------- | ------------------ | -----------: | -----------------: |
-| **mcp-use v2**      | `mcp-use + zod`    | **74.4 MiB** |             **57** |
-| xmcp                | `xmcp + zod`       |    121.9 MiB |                171 |
-| Skybridge           | `skybridge + zod`  |    137.5 MiB |                300 |
-| mcp-use v1 baseline | `mcp-use + zod`    |    404.6 MiB |                365 |
+| Framework           | Direct install set            |         Disk | Installed packages |
+| ------------------- | ----------------------------- | -----------: | -----------------: |
+| FastMCP TypeScript  | `@prefecthq/fastmcp-ts + zod` |     45.0 MiB |                147 |
+| **mcp-use v2**      | `mcp-use + zod`               | **74.4 MiB** |             **57** |
+| xmcp                | `xmcp + zod`                  |    121.9 MiB |                171 |
+| Skybridge           | `skybridge + zod`             |    137.5 MiB |                300 |
+| mcp-use v1 baseline | `mcp-use + zod`               |    404.6 MiB |                365 |
 
-mcp-use v2 had the smallest clean install among the tested full-stack native
-MCP Apps frameworks. The mcp-use v1 row is a migration baseline, not a native
-Apps peer.
+FastMCP TypeScript had the smallest measured clean install. mcp-use v2
+installed fewer package entries and remained substantially smaller than the
+other previously tested native Apps frameworks. The mcp-use v1 row is a
+migration baseline, not a native Apps peer.
 
 ## Package and MCP App build size
 
@@ -164,26 +177,16 @@ temporary v1 facade and legacy widget adapters reduced the candidate from
 349 KiB (357,628 bytes) to 302 KiB, a 13.6% reduction. Its unpacked contents
 fell from 1,417,415 bytes across 125 files to 1,249,746 bytes across 116 files.
 
+For package-artifact context, published
+`@prefecthq/fastmcp-ts@1.2.0` measured 1,613 KiB compressed and 7.934 MiB
+unpacked across 16 files. This package comparison does not imply an equivalent
+application build: FastMCP's server-side Apps component model and mcp-use's
+React/Vite View build emit different boundaries.
+
 For the application build, both versions used the same React launch card, CSS,
 and one echo tool.
 
 ```mermaid
----
-config:
-  themeVariables:
-    xyChart:
-      backgroundColor: "#ffffff"
-      titleColor: "#0c0c0c"
-      xAxisLabelColor: "#0c0c0c"
-      xAxisTitleColor: "#0c0c0c"
-      xAxisTickColor: "#0c0c0c"
-      xAxisLineColor: "#0c0c0c"
-      yAxisLabelColor: "#0c0c0c"
-      yAxisTitleColor: "#0c0c0c"
-      yAxisTickColor: "#0c0c0c"
-      yAxisLineColor: "#0c0c0c"
-      plotColorPalette: "#0c0c0c, #d4d4d8"
----
 xychart
   title "Equivalent MCP App production build"
   x-axis ["mcp-use v2", "mcp-use v1"]
@@ -250,6 +253,8 @@ equivalent official SDK v2 fixture in this benchmark.
 
 - Clean install size is the on-disk dependency tree after installing the direct
   package set shown in the table.
+- Installed-package counts are the physical package entries reported by
+  `npm ls --all --parseable`, excluding the fixture root.
 - Tarball size is the compressed size of the package produced by `pnpm pack`.
 - The v1 and v2 App builds use equivalent source content and production build
   settings.
@@ -269,4 +274,10 @@ equivalent official SDK v2 fixture in this benchmark.
 - There is no composite “overall score.”
 
 Use the scoped result: **fastest TypeScript framework with native MCP Apps
-support in this eight-fixture test**.
+support in the original eight-fixture test, and faster than FastMCP TypeScript
+in the separate paired addendum**.
+
+[fastmcp-apps]: https://github.com/PrefectHQ/fastmcp-ts/blob/v1.2.0/docs/apps/overview.mdx
+[fastmcp-protocol]: https://github.com/PrefectHQ/fastmcp-ts/blob/v1.2.0/docs/concepts/protocol-eras.mdx
+[fastmcp-oauth]: https://github.com/PrefectHQ/fastmcp-ts/blob/v1.2.0/docs/servers/auth/oauth.mdx
+[fastmcp-cli]: https://github.com/PrefectHQ/fastmcp-ts/blob/v1.2.0/docs/cli.mdx

--- a/benchmark.md
+++ b/benchmark.md
@@ -85,9 +85,11 @@ median difference is measurement noise, not a meaningful product advantage.
 
 ## Install footprint
 
-**Lower is better.** This comparison is intentionally limited to the
-full-stack frameworks tested with a native MCP Apps build workflow. Low-level
-libraries with a narrower scope are not equivalent install targets.
+**Lower is better.** Every row represents a development stack capable of
+authoring and building a custom React MCP App, not merely installing the server
+framework. Frameworks that do not include that workflow receive the same Apps,
+React, Vite, and TypeScript dependencies required by the equivalent official
+SDK stack.
 
 Clean install measures the actual `node_modules` directory after a normal npm
 install, including required peer dependencies and filesystem allocation. It
@@ -95,25 +97,27 @@ therefore differs from npmx's modeled size, which excludes peer dependencies.
 
 ```mermaid
 xychart
-  title "Clean production install in MiB"
+  title "Custom MCP App development stack in MiB"
   x-axis ["FastMCP TS", "mcp-use v2", "xmcp", "Skybridge", "mcp-use v1"]
   y-axis "MiB on disk" 0 --> 450
   bar [0, 74.4, 0, 0, 0]
-  bar [45.0, 0, 121.9, 137.5, 404.6]
+  bar [122.5, 0, 121.9, 137.5, 404.6]
 ```
 
-| Framework           | Direct install set            |         Disk | Installed packages |
-| ------------------- | ----------------------------- | -----------: | -----------------: |
-| FastMCP TypeScript  | `@prefecthq/fastmcp-ts + zod` |     45.0 MiB |                147 |
-| **mcp-use v2**      | `mcp-use + zod`               | **74.4 MiB** |             **57** |
-| xmcp                | `xmcp + zod`                  |    121.9 MiB |                171 |
-| Skybridge           | `skybridge + zod`             |    137.5 MiB |                300 |
-| mcp-use v1 baseline | `mcp-use + zod`               |    404.6 MiB |                365 |
+| Framework           | Direct install set                              |         Disk | Installed packages |
+| ------------------- | ----------------------------------------------- | -----------: | -----------------: |
+| **mcp-use v2**      | `mcp-use + zod`                                 | **74.4 MiB** |             **57** |
+| xmcp                | `xmcp + zod`                                    |    121.9 MiB |                171 |
+| FastMCP TypeScript  | FastMCP + Apps extension + React/Vite build set |    122.5 MiB |                180 |
+| Skybridge           | `skybridge + zod`                               |    137.5 MiB |                300 |
+| mcp-use v1 baseline | `mcp-use + zod`                                 |    404.6 MiB |                365 |
 
-FastMCP TypeScript had the smallest measured clean install. mcp-use v2
-installed fewer package entries and remained substantially smaller than the
-other previously tested native Apps frameworks. The mcp-use v1 row is a
-migration baseline, not a native Apps peer.
+mcp-use v2 had the smallest measured equivalent App development stack and the
+fewest installed package entries. FastMCP's framework-only component workflow
+does not require a browser build, but its earlier 45.0 MiB figure was excluded
+because it did not include the custom React MCP App build system represented by
+the other rows. The mcp-use v1 row is a migration baseline, not a native Apps
+peer.
 
 ## Package and MCP App build size
 
@@ -200,6 +204,9 @@ equivalent official SDK v2 fixture in this benchmark.
 
 - Clean install size is the on-disk dependency tree after installing the direct
   package set shown in the table.
+- FastMCP's equivalent stack pins `@prefecthq/fastmcp-ts@1.2.0`,
+  `@modelcontextprotocol/ext-apps@1.7.5`, `@vitejs/plugin-react@6.0.4`,
+  React and React DOM 19.2.8, TypeScript 7.0.2, Vite 8.1.5, and zod 4.4.3.
 - Installed-package counts are the physical package entries reported by
   `npm ls --all --parseable`, excluding the fixture root.
 - Tarball size is the compressed size of the package produced by `pnpm pack`.

--- a/benchmark.md
+++ b/benchmark.md
@@ -1,10 +1,9 @@
 # mcp-use SDK v2 benchmarks
 
 This report compares `mcp-use` v2 with mcp-use v1, the official TypeScript SDK,
-and representative TypeScript MCP frameworks, including FastMCP TypeScript.
+and representative TypeScript MCP frameworks.
 The established performance and launch figures use the published
-`mcp-use@2.0.0-beta.61` package and were recorded on July 27–28, 2026.
-FastMCP TypeScript was measured with the same harness and workload on July 30.
+`mcp-use@2.0.0-beta.64` package and were recorded on July 27–28, 2026.
 All measurements used Node.js 24.15.0. The npm tarball was measured from the
 `2.0.0-beta.64` package candidate after removing the temporary v1 compatibility
 layer.
@@ -112,12 +111,8 @@ xychart
 | Skybridge           | `skybridge + zod`                               |    137.5 MiB |                300 |
 | mcp-use v1 baseline | `mcp-use + zod`                                 |    404.6 MiB |                365 |
 
-mcp-use v2 had the smallest measured equivalent App development stack and the
-fewest installed package entries. FastMCP's framework-only component workflow
-does not require a browser build, but its earlier 45.0 MiB figure was excluded
-because it did not include the custom React MCP App build system represented by
-the other rows. The mcp-use v1 row is a migration baseline, not a native Apps
-peer.
+mcp-use v2 had the smallest measured equivalent MCP App development stack and the
+fewest installed package entries. 
 
 ## Package and MCP App build size
 
@@ -126,12 +121,6 @@ The packed `mcp-use@2.0.0-beta.64` candidate measured **302 KiB compressed**
 temporary v1 facade and legacy widget adapters reduced the candidate from
 349 KiB (357,628 bytes) to 302 KiB, a 13.6% reduction. Its unpacked contents
 fell from 1,417,415 bytes across 125 files to 1,249,746 bytes across 116 files.
-
-For package-artifact context, published
-`@prefecthq/fastmcp-ts@1.2.0` measured 1,613 KiB compressed and 7.934 MiB
-unpacked across 16 files. This package comparison does not imply an equivalent
-application build: FastMCP's server-side Apps component model and mcp-use's
-React/Vite View build emit different boundaries.
 
 For the application build, both versions used the same React launch card, CSS,
 and one echo tool.


### PR DESCRIPTION
## What changed

- add `@prefecthq/fastmcp-ts@1.2.0` to the unified nine-framework benchmark
- document throughput, tail latency, cold launch, equivalent MCP App development-stack size, package count, tarball size, and capability coverage
- add FastMCP TypeScript to the README Mermaid comparison
- replace hardcoded light-theme diagram colors with semitransparent fills that inherit the active theme

## Results

- mcp-use: 10,982.2 median ops/s, 4 ms p95, 68.145 ms median launch
- FastMCP TypeScript: 6,628.2 median ops/s, 6 ms p95, 139.123 ms median launch
- FastMCP equivalent custom React MCP App stack: 122.5 MiB and 180 installed package entries
- FastMCP npm tarball: 1,613 KiB compressed and 7.934 MiB unpacked

The install comparison measures equivalent custom React MCP App development stacks rather than framework packages alone. FastMCP's measured set adds `@modelcontextprotocol/ext-apps`, React and React DOM, the Vite React plugin, Vite, TypeScript, and zod to the framework. The earlier 45.0 MiB framework-only figure was removed because it omitted that build stack.

FastMCP uses the same three-round MCP Drill workload and 100-sample launch method as the established framework rows. Existing performance values remain unchanged; FastMCP, mcp-use, and the official v2 SDK negotiated strict `2026-07-28`.

## Validation

- clean FastMCP Apps development stack installed and measured from pinned packages
- FastMCP, Apps extension, React, Vite React plugin, Vite, and TypeScript import/tool smoke checks pass
- README comparison rendered under both light and dark themes
- benchmark install chart rendered under dark theme
- npm metadata checked against `@prefecthq/fastmcp-ts@1.2.0`
- `git diff --check`