### PR TITLE
feat(react): expose public base URL

### DIFF
--- a/libraries/typescript/packages/server/examples/views/basic/README.md
+++ b/libraries/typescript/packages/server/examples/views/basic/README.md
@@ -153,6 +153,17 @@ Static files in the project-root `public/` folder are served under
 synthesized view document injects the request-resolved public base so URLs stay
 absolute inside `srcdoc` iframes (which have no document base URL).
 
+For other public files, use `getPublicBaseUrl()` and append a path without a
+leading slash. The returned URL always has a trailing slash:
+
+```tsx
+import { getPublicBaseUrl } from "mcp-use/react";
+
+const publicBaseUrl = getPublicBaseUrl();
+const stylesheetUrl = `${publicBaseUrl}assets/vendor.css`;
+const wasmUrl = `${publicBaseUrl}wasm/module.wasm`;
+```
+
 This example keeps fruit WebP images in `public/fruits/` and references them as
 `<Image src={`/fruits/${id}.webp`} …>`. Same-origin public assets are
 automatically covered by the framework's serving-origin CSP entry on view

--- a/libraries/typescript/packages/server/specs/VIEWS_SPEC.md
+++ b/libraries/typescript/packages/server/specs/VIEWS_SPEC.md
@@ -512,7 +512,7 @@ v1 parity: authors drop static files in a project-root `public/` directory and r
 </script>
 ```
 
-`publicBase` is request-scoped (computed per request), not boot-time baked — the v1 mistake of baking origin at startup remains dead. `<Image>` reads this global (the one public consumer; the internal `publicAsset()` resolver is not exported — v1 shipped the same posture, an `<Image>` component over injected globals with no standalone resolver): root-relative `src` values resolve to `${publicBase}<path-without-leading-slash>`; absolute `http(s):` and `data:` URLs pass through; fully-relative paths (no leading `/`) are left alone. Non-`<img>` consumers (CSS backgrounds, `<video>`) can be served by exporting the resolver later — additive, deferred until asked for. `import.meta.url` relative resolution was rejected for public assets because the dev virtual entry URL (`/@id/__x00__virtual:mcp-use/views/<name>`) has no stable sibling `public/` segment — the injected config works identically in dev and production.
+`publicBase` is request-scoped (computed per request), not boot-time baked — the v1 mistake of baking origin at startup remains dead. `getPublicBaseUrl()` exposes that absolute, trailing-slash URL from `mcp-use/react` so non-image consumers can append public-folder paths without depending on framework globals. It returns `""` outside a synthesized browser view document. `<Image>` reads the same base through the internal `publicAsset()` resolver: root-relative `src` values resolve to `${publicBase}<path-without-leading-slash>`; absolute `http(s):` and `data:` URLs pass through; fully-relative paths (no leading `/`) are left alone. `import.meta.url` relative resolution was rejected for public assets because the dev virtual entry URL (`/@id/__x00__virtual:mcp-use/views/<name>`) has no stable sibling `public/` segment — the injected config works identically in dev and production.
 
 ### Dev
 
@@ -909,6 +909,9 @@ function useToolContext<
 **Helpers**
 
 ```ts
+/** Request-resolved URL for the project's public folder, with a trailing slash. */
+function getPublicBaseUrl(): string;
+
 /** Concatenated text content of a tool result, or undefined when it has none. */
 function toolResultText(
   result: Pick<CallToolResult, "content">
@@ -1208,6 +1211,7 @@ Everything result-shaped enters through `useToolContext` (typed by the server's 
 | `<ModelContext>` / `modelContext` | kept; nested text tree merges under `_uiContext` beside `useViewState` | `App.updateModelContext` or ChatGPT `setWidgetState` |
 | `<ErrorBoundary>` | kept (bootstrap provides the required top-level boundary) | unchanged |
 | `<Image>` | kept — resolves root-relative `src` via `__mcpUseViewConfig.publicBase` (Public assets) | `<img>` with absolute URL |
+| _(no v1 equivalent)_ | `getPublicBaseUrl()` — request-resolved, trailing-slash URL for scripts, stylesheets, WASM, and other project-public files | `__mcpUseViewConfig.publicBase` |
 | `generateHelpers()` | dropped | subsumed by `Register` typing |
 
 ### Host-specific gaps
@@ -1245,7 +1249,7 @@ The full build/serve contract is "Build system & serving", above; it extends the
 8. `window.openai` is consumed only for capabilities without a standard restoration channel: files and ChatGPT-persisted `useViewState`. All other baseline view behavior continues through MCP Apps.
 9. Tool config `invoking`/`invoked`/`widgetAccessible` removed (openai overlay, no spec equivalent; `visibility` covers app/model narrowing).
 10. Views work against the stateless 2026-07-28 wire; nothing view-related depends on sessions.
-11. Asset routes move from `${basePath}/mcp-use/widgets/…` to two framework-owned spaces: `${basePath}/_mcp-use/views/<name>/…` for default hashed production bundles and `${basePath}/_mcp-use/public/…` for project-public files. Each view has an independent client build with no shared chunks. Hosts obtain the HTML document only through `resources/read`; by default it loads external JS/CSS from the view route or full CDN URLs embedded when `MCP_ASSETS_URL` is set at build time, while `build --inline` places JS/CSS directly in the document. `MCP_URL` selects the server origin, while `MCP_ASSETS_URL` selects the external asset prefix and may include a path. One request-scoped `globalThis.__mcpUseViewConfig` supplies `publicBase`; no origin is baked into that runtime config at server startup.
+11. Asset routes move from `${basePath}/mcp-use/widgets/…` to two framework-owned spaces: `${basePath}/_mcp-use/views/<name>/…` for default hashed production bundles and `${basePath}/_mcp-use/public/…` for project-public files. Each view has an independent client build with no shared chunks. Hosts obtain the HTML document only through `resources/read`; by default it loads external JS/CSS from the view route or full CDN URLs embedded when `MCP_ASSETS_URL` is set at build time, while `build --inline` places JS/CSS directly in the document. `MCP_URL` selects the server origin, while `MCP_ASSETS_URL` selects the external asset prefix and may include a path. One request-scoped `globalThis.__mcpUseViewConfig` supplies `publicBase`; `getPublicBaseUrl()` exposes it to view code, and no origin is baked into that runtime config at server startup.
 12. Registration no longer happens inside `listen()` or first-request setup (v1's async `mountWidgets` → `server.uiResource()`): the build primes the instance through a generated wrapper entry, and `resources/read` synthesizes the document from embedded registry data instead of reading built HTML from disk. `server.uiResource()` has no v2 equivalent, and neither do v1's `exposeAsTool` / hand-built `uiResource` registrations — at most one tool binds a view via `view: { name }`, and an unbound view warns (decision 10).
 13. Ambient hooks split by concern: `useHostContext()`, `useSendFollowUp()`, `useOpenExternal()`, `useDisplayMode()`, `useSendSizeChanged()` — split-by-concern is the design; each hook rerenders only on its channel (action hooks return stable runtime-owned callbacks). v1's aggregate `<McpUseProvider autoSize>` is replaced by `viewConfig.autoResize` plus direct composition of `ThemeProvider` / `ViewControls`.
 

--- a/libraries/typescript/packages/server/src/react/index.ts
+++ b/libraries/typescript/packages/server/src/react/index.ts
@@ -18,6 +18,7 @@ export { Image } from "./components/image.js";
 export { ModelContext } from "./components/model-context.js";
 export { ThemeProvider } from "./components/theme-provider.js";
 export { ViewControls } from "./components/view-controls.js";
+export { getPublicBaseUrl } from "./public-assets.js";
 export {
   useCallTool,
   useDynamicTool,

--- a/libraries/typescript/packages/server/src/react/public-assets.ts
+++ b/libraries/typescript/packages/server/src/react/public-assets.ts
@@ -25,14 +25,30 @@ declare global {
 }
 
 /**
- * Read the injected public asset base URL, if present.
+ * Return the request-resolved base URL for files in the project's `public/`
+ * directory.
  *
- * @returns The request-resolved `publicBase`, or an empty string outside a
- *   synthesized view document.
+ * @remarks
+ * The returned URL always includes a trailing slash. Append public-folder
+ * paths without a leading slash. The URL is resolved for the current request,
+ * so it remains correct behind proxies, tunnels, and `MCP_ASSETS_URL`.
  *
- * @internal
+ * Outside a synthesized browser view document, the function returns an empty
+ * string.
+ *
+ * @example
+ * ```ts
+ * import { getPublicBaseUrl } from "mcp-use/react";
+ *
+ * const publicBaseUrl = getPublicBaseUrl();
+ * const stylesheetUrl = `${publicBaseUrl}assets/vendor.css`;
+ * const wasmUrl = `${publicBaseUrl}doom/websockets-doom.wasm`;
+ * ```
+ *
+ * @returns The absolute public-folder base URL with a trailing slash, or an
+ *   empty string when no injected view configuration is available.
  */
-export function getPublicBase(): string {
+export function getPublicBaseUrl(): string {
   if (typeof globalThis === "undefined") {
     return "";
   }
@@ -67,7 +83,7 @@ export function publicAsset(path: string): string {
     return path;
   }
   if (path.startsWith("/")) {
-    const publicBase = getPublicBase();
+    const publicBase = getPublicBaseUrl();
     if (publicBase === "") {
       return path;
     }

--- a/libraries/typescript/packages/server/tests/react-bridge.test.tsx
+++ b/libraries/typescript/packages/server/tests/react-bridge.test.tsx
@@ -8,6 +8,7 @@ import { useState, type ComponentType, type SetStateAction } from "react";
 import {
   bootstrapView,
   disposeView,
+  getPublicBaseUrl,
   Image,
   ModelContext,
   ToolError,
@@ -2670,6 +2671,25 @@ describe("react bridge runtime", () => {
     expect(screen.getByTestId("absolute").getAttribute("src")).toBe(
       "https://cdn.example.com/logo.svg"
     );
+  });
+
+  it("exposes the request-resolved public base URL", () => {
+    const previousConfig = globalThis.__mcpUseViewConfig;
+
+    try {
+      globalThis.__mcpUseViewConfig = {
+        publicBase: "https://assets.example.com/mcp/_mcp-use/public/",
+      };
+
+      expect(getPublicBaseUrl()).toBe(
+        "https://assets.example.com/mcp/_mcp-use/public/"
+      );
+
+      globalThis.__mcpUseViewConfig = undefined;
+      expect(getPublicBaseUrl()).toBe("");
+    } finally {
+      globalThis.__mcpUseViewConfig = previousConfig;
+    }
   });
 
   it("same-root HMR bootstrap reuses the runtime without reconnecting", async () => {


### PR DESCRIPTION
## Summary

- rename the internal `getPublicBase()` helper to `getPublicBaseUrl()`
- export `getPublicBaseUrl()` from `mcp-use/react`
- document that the request-resolved URL always includes a trailing slash
- update the views contract and basic example for scripts, stylesheets, WASM, and other public files
- add runtime coverage for the public barrel export and empty-context fallback

## Why

MCP App documents render through `srcdoc`, so root-relative asset URLs resolve against the host page instead of the MCP server. `<Image>` already consumes the injected request-scoped public base internally, but non-image consumers had no supported API for accessing it. This left applications depending on private globals for vendor scripts, stylesheets, WASM modules, and related assets.

## Developer impact

View code can now compose public-file URLs without reading framework globals:

```ts
import { getPublicBaseUrl } from "mcp-use/react";

const publicBaseUrl = getPublicBaseUrl();
const wasmUrl = `${publicBaseUrl}doom/websockets-doom.wasm`;
```

The getter returns an empty string outside a synthesized browser view and an absolute, trailing-slash URL inside one.

## Validation

- `pnpm --filter mcp-use build`
- `pnpm --filter mcp-use typecheck`
- `pnpm --filter mcp-use exec vitest run tests/react-bridge.test.tsx` — 59 passed
- `pnpm --filter mcp-use test:run` — 65 files, 696 tests passed
- targeted ESLint and Prettier checks
- verified `getPublicBaseUrl` is present in the generated `dist/react/index.d.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose `getPublicBaseUrl()` from `mcp-use/react` so views can build absolute URLs for public files (scripts, styles, WASM) inside `srcdoc` iframes. It returns a trailing-slash, request-scoped URL or an empty string outside a synthesized view.

- **New Features**
  - Exported `getPublicBaseUrl` and renamed the internal helper; `publicAsset()` now uses it.
  - Updated specs and the basic views example to document the trailing-slash base and path-append pattern.
  - Added tests for the public barrel export and empty-context fallback.

<sup>Written for commit 6f16ea5b15e2029412e4559b840b9c798407ec65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2061?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

