### PR TITLE
Feature/reliability recovery clean

### DIFF
--- a/libraries/python/examples/reliability_recovery_example.py
+++ b/libraries/python/examples/reliability_recovery_example.py
@@ -16,7 +16,6 @@ Issue #2054
 """
 
 import asyncio
-from typing import Dict, Optional
 
 
 class SyntheticDestinationServer:
@@ -25,7 +24,7 @@ class SyntheticDestinationServer:
     """
 
     def __init__(self):
-        self.database: Dict[str, dict] = {}
+        self.database: dict[str, dict] = {}
         self.total_tool_calls: int = 0
         self.total_mutations: int = 0
 
@@ -77,7 +76,7 @@ class SyntheticDestinationServer:
     async def read_back(
         self,
         operation_marker: str,
-    ) -> Optional[dict]:
+    ) -> dict | None:
         """
         Checks whether mutation already happened.
         """

--- a/libraries/python/examples/reliability_recovery_example.py
+++ b/libraries/python/examples/reliability_recovery_example.py
@@ -1,34 +1,34 @@
 """
 Reliability & Recovery Example: Multi-Server Mutation Recovery
 
-Demonstrates how to safely handle ambiguous tool failures:
-- Destination server commits a mutation
-- Response is lost
-- Client does NOT blindly retry
-- Client verifies using read-back before retrying
+Demonstrates how to safely handle ambiguous tool failures where a mutation
+succeeds on the destination server but the response is lost due to network
+failure.
+
+Workflow comparison:
+1. Unguarded Path:
+   Retry immediately after ambiguous failure -> duplicate mutation.
+
+2. Guarded Path:
+   Verify external state using operation marker -> recover without duplicate.
 
 Issue #2054
 """
 
 import asyncio
-from typing import Any, Dict, Optional
-
-from mcp_use import MCPClient
+from typing import Dict, Optional
 
 
 class SyntheticDestinationServer:
     """
-    Synthetic destination MCP server.
-
-    Simulates an external system with:
-    - create_item mutation tool
-    - read_back verification tool
+    Simulates a duplicate-sensitive destination MCP server.
     """
 
     def __init__(self):
-        self.database: dict[str, dict] = {}
-        self.total_tool_calls = 0
-        self.total_mutations = 0
+        self.database: Dict[str, dict] = {}
+        self.total_tool_calls: int = 0
+        self.total_mutations: int = 0
+
 
     async def create_item(
         self,
@@ -36,6 +36,9 @@ class SyntheticDestinationServer:
         item_name: str,
         simulate_network_drop: bool = False,
     ) -> dict:
+        """
+        Mutating tool that creates an item.
+        """
 
         self.total_tool_calls += 1
         self.total_mutations += 1
@@ -46,184 +49,198 @@ class SyntheticDestinationServer:
             "name": item_name,
         }
 
+
+        # Store mutation result
         if operation_marker in self.database:
+
+            # Duplicate mutation created
             self.database[
-                f"{operation_marker}_duplicate_{self.total_mutations}"
+                f"{operation_marker}_dup_{self.total_mutations}"
             ] = item
+
         else:
+
             self.database[operation_marker] = item
 
+
         if simulate_network_drop:
+
             raise ConnectionResetError(
-                "Transport connection dropped post-commit "
-                "(Ambiguous Success)"
+                "Transport connection dropped post-commit (Ambiguous Success)"
             )
+
 
         return item
 
+
+
     async def read_back(
         self,
-        operation_marker: str
-    ) -> dict | None:
+        operation_marker: str,
+    ) -> Optional[dict]:
+        """
+        Checks whether mutation already happened.
+        """
 
         self.total_tool_calls += 1
 
         return self.database.get(operation_marker)
 
 
-class LocalMCPToolClient:
+
+async def run_unguarded_workflow(
+    server: SyntheticDestinationServer,
+):
     """
-    Small adapter representing MCPClient tool calls.
-
-    The example keeps the fixture local and deterministic while exposing
-    MCP-style call_tool behaviour.
+    Unguarded retry workflow.
+    Creates duplicate mutation.
     """
 
-    def __init__(self, server: SyntheticDestinationServer):
-        self.server = server
+    op_marker = "op_unguarded_101"
 
-    async def call_tool(
-        self,
-        tool_name: str,
-        arguments: dict,
-    ) -> Any:
-
-        if tool_name == "create_item":
-
-            return await self.server.create_item(
-                arguments["operation_marker"],
-                arguments["item_name"],
-                arguments.get(
-                    "simulate_network_drop",
-                    False,
-                ),
-            )
-
-        if tool_name == "read_back":
-
-            return await self.server.read_back(
-                arguments["operation_marker"]
-            )
-
-        raise ValueError(
-            f"Unknown tool: {tool_name}"
-        )
-
-
-async def run_unguarded_workflow(client: LocalMCPToolClient):
-
-    marker = "op_unguarded_101"
 
     print(
-        "\n--- 1. UNGUARDED WORKFLOW "
-        "(Naive Retry) ---"
+        "\n--- 1. UNGUARDED WORKFLOW (Naive Retry) ---"
     )
+
 
     try:
-        await client.call_tool(
-            "create_item",
-            {
-                "operation_marker": marker,
-                "item_name": "Widget A",
-                "simulate_network_drop": True,
-            },
-        )
-
-    except ConnectionResetError as error:
 
         print(
-            f"[Unguarded] Error: {error}"
+            f"[Unguarded] Calling create_item(marker='{op_marker}')..."
         )
 
-    await client.call_tool(
-        "create_item",
-        {
-            "operation_marker": marker,
-            "item_name": "Widget A",
-            "simulate_network_drop": False,
-        },
+
+        await server.create_item(
+            op_marker,
+            "Widget A",
+            simulate_network_drop=True,
+        )
+
+
+    except ConnectionResetError as e:
+
+        print(
+            f"[Unguarded] Ambiguous error encountered: {e}"
+        )
+
+
+    # Unsafe retry
+    print(
+        f"[Unguarded] Retrying create_item(marker='{op_marker}')..."
     )
+
+
+    await server.create_item(
+        op_marker,
+        "Widget A",
+        simulate_network_drop=False,
+    )
+
 
     print(
-        "[Unguarded] Retry completed"
+        "[Unguarded] Naive retry finished."
     )
 
 
-async def run_guarded_workflow(client: LocalMCPToolClient):
 
-    marker = "op_guarded_202"
+async def run_guarded_workflow(
+    server: SyntheticDestinationServer,
+):
+    """
+    Guarded recovery workflow.
+    Prevents duplicate mutation.
+    """
+
+    op_marker = "op_guarded_202"
+
 
     print(
-        "\n--- 2. GUARDED WORKFLOW "
-        "(Read-Back Verification) ---"
+        "\n--- 2. GUARDED WORKFLOW (Read-Back Verification) ---"
     )
+
 
     status = "UNKNOWN"
 
+
     try:
 
-        await client.call_tool(
-            "create_item",
-            {
-                "operation_marker": marker,
-                "item_name": "Widget B",
-                "simulate_network_drop": True,
-            },
+        print(
+            f"[Guarded] Calling create_item(marker='{op_marker}')..."
         )
+
+
+        await server.create_item(
+            op_marker,
+            "Widget B",
+            simulate_network_drop=True,
+        )
+
 
         status = "SUCCESS"
 
-    except ConnectionResetError as error:
+
+    except ConnectionResetError as e:
 
         print(
-            f"[Guarded] Error: {error}"
+            f"[Guarded] Ambiguous error caught: {e}"
         )
+
 
         status = "EXTERNAL_RESULT_UNCERTAIN"
 
+
+
     if status == "EXTERNAL_RESULT_UNCERTAIN":
 
+
         print(
-            "[Guarded] Checking read_back..."
+            f"[Guarded] Checking read_back for marker '{op_marker}'..."
         )
 
-        item = await client.call_tool(
-            "read_back",
-            {
-                "operation_marker": marker
-            },
+
+        recovered_item = await server.read_back(
+            op_marker
         )
 
-        if item:
+
+        if recovered_item:
+
 
             print(
-                f"[Guarded] Found committed item: {item}"
+                f"[Guarded] SUCCESS: Found committed item: {recovered_item}"
             )
 
+
             print(
-                "[Guarded] Duplicate mutation prevented"
+                "[Guarded] Skipping retry. Duplicate mutation prevented!"
             )
+
 
         else:
 
+
             print(
-                "[Guarded] Item missing. "
-                "Safe retry."
+                "[Guarded] Item not found. Safe retry."
             )
 
-            await client.call_tool(
-                "create_item",
-                {
-                    "operation_marker": marker,
-                    "item_name": "Widget B",
-                },
+
+            await server.create_item(
+                op_marker,
+                "Widget B",
+                simulate_network_drop=False,
             )
+
 
 
 def print_reliability_report(
-    unguarded_server,
-    guarded_server,
+    unguarded_server: SyntheticDestinationServer,
+    guarded_server: SyntheticDestinationServer,
 ):
+    """
+    Prints reliability comparison report.
+    """
+
 
     print(
         "\n=========================================================="
@@ -237,10 +254,69 @@ def print_reliability_report(
         "=========================================================="
     )
 
+
     print(
-        "NOTE: This demonstrates duplicate-resistant recovery, "
+        f"{'Metric':<35} | "
+        f"{'Unguarded':<12} | "
+        f"{'Guarded':<12}"
+    )
+
+
+    print("-" * 65)
+
+
+
+    unguarded_duplicates = (
+        len(unguarded_server.database) - 1
+    )
+
+
+    guarded_duplicates = max(
+        0,
+        guarded_server.total_mutations
+        - len(guarded_server.database),
+    )
+
+
+
+    print(
+        f"{'Total Tool Calls':<35} | "
+        f"{unguarded_server.total_tool_calls:<12} | "
+        f"{guarded_server.total_tool_calls:<12}"
+    )
+
+
+    print(
+        f"{'Total Mutations Committed':<35} | "
+        f"{unguarded_server.total_mutations:<12} | "
+        f"{guarded_server.total_mutations:<12}"
+    )
+
+
+    print(
+        f"{'Duplicate Count':<35} | "
+        f"{unguarded_duplicates:<12} | "
+        f"{guarded_duplicates:<12}"
+    )
+
+
+    print(
+        f"{'Recovery Verification':<35} | "
+        f"{'FAILED':<12} | "
+        f"{'SUCCESS':<12}"
+    )
+
+
+    print(
+        "=========================================================="
+    )
+
+
+    print(
+        "NOTE: Demonstrates duplicate-resistant recovery, "
         "not exactly-once execution."
     )
+
 
 
 async def main():
@@ -250,38 +326,38 @@ async def main():
     )
 
     print(
-        " MCP Multi-Server Mutation Recovery Example (#2054)"
+        "  MCP Multi-Server Mutation Recovery Example (#2054)"
     )
 
     print(
         "=========================================================="
     )
 
-    config = {
-        "mcpServers": {}
-    }
 
-    MCPClient.from_dict(config)
+
+    # Unguarded test
 
     unguarded_server = SyntheticDestinationServer()
 
-    unguarded_client = LocalMCPToolClient(
+
+    await run_unguarded_workflow(
         unguarded_server
     )
 
-    await run_unguarded_workflow(
-        unguarded_client
-    )
+
+
+    # Guarded test
 
     guarded_server = SyntheticDestinationServer()
 
-    guarded_client = LocalMCPToolClient(
+
+    await run_guarded_workflow(
         guarded_server
     )
 
-    await run_guarded_workflow(
-        guarded_client
-    )
+
+
+    # Report
 
     print_reliability_report(
         unguarded_server,
@@ -289,5 +365,7 @@ async def main():
     )
 
 
+
 if __name__ == "__main__":
+
     asyncio.run(main())

--- a/libraries/python/examples/reliability_recovery_example.py
+++ b/libraries/python/examples/reliability_recovery_example.py
@@ -1,32 +1,42 @@
 """
 Reliability & Recovery Example: Multi-Server Mutation Recovery
 
-Demonstrates how to safely handle ambiguous tool failures (when a mutating write succeeds
-on the destination server, but the network connection/response is lost before reaching the caller).
-
-Workflow comparison:
-1. Unguarded Path: Naive retry after an ambiguous drop -> creates duplicate mutations.
-2. Guarded Path: Catches EXTERNAL_RESULT_UNCERTAIN -> queries read_back tool using an operation marker -> recovers committed state without duplicate writes.
+Demonstrates how to safely handle ambiguous tool failures:
+- Destination server commits a mutation
+- Response is lost
+- Client does NOT blindly retry
+- Client verifies using read-back before retrying
 
 Issue #2054
 """
 
 import asyncio
-from typing import Dict, Optional, Any
+from typing import Any, Dict, Optional
+
+from mcp_use import MCPClient
 
 
 class SyntheticDestinationServer:
-    """Simulates a duplicate-sensitive destination MCP server with a read-back verification tool."""
+    """
+    Synthetic destination MCP server.
+
+    Simulates an external system with:
+    - create_item mutation tool
+    - read_back verification tool
+    """
 
     def __init__(self):
-        self.database: Dict[str, dict] = {}
-        self.total_tool_calls: int = 0
-        self.total_mutations: int = 0
+        self.database: dict[str, dict] = {}
+        self.total_tool_calls = 0
+        self.total_mutations = 0
 
-    async def create_item(self, operation_marker: str, item_name: str, simulate_network_drop: bool = False) -> dict:
-        """
-        Mutating tool that creates an item in external storage.
-        """
+    async def create_item(
+        self,
+        operation_marker: str,
+        item_name: str,
+        simulate_network_drop: bool = False,
+    ) -> dict:
+
         self.total_tool_calls += 1
         self.total_mutations += 1
 
@@ -36,106 +46,247 @@ class SyntheticDestinationServer:
             "name": item_name,
         }
 
-        # Record item in database
         if operation_marker in self.database:
-            # Duplicate entry detected!
-            self.database[f"{operation_marker}_dup_{self.total_mutations}"] = item
+            self.database[
+                f"{operation_marker}_duplicate_{self.total_mutations}"
+            ] = item
         else:
             self.database[operation_marker] = item
 
         if simulate_network_drop:
-            # Simulate external write committing, but response getting lost over transport
-            raise ConnectionResetError("Transport connection dropped post-commit (Ambiguous Success)")
+            raise ConnectionResetError(
+                "Transport connection dropped post-commit "
+                "(Ambiguous Success)"
+            )
 
         return item
 
-    async def read_back(self, operation_marker: str) -> Optional[dict]:
-        """Read-back tool keyed by opaque operation marker to check post-condition."""
+    async def read_back(
+        self,
+        operation_marker: str
+    ) -> dict | None:
+
         self.total_tool_calls += 1
+
         return self.database.get(operation_marker)
 
 
-async def run_unguarded_workflow(server: SyntheticDestinationServer):
-    """Scenario 1: Unguarded Retry — results in duplicate mutation."""
-    op_marker = "op_unguarded_101"
-    print("\n--- 1. UNGUARDED WORKFLOW (Naive Retry) ---")
+class LocalMCPToolClient:
+    """
+    Small adapter representing MCPClient tool calls.
 
-    # Step 1: Initial call commits mutation, but transport drops response
+    The example keeps the fixture local and deterministic while exposing
+    MCP-style call_tool behaviour.
+    """
+
+    def __init__(self, server: SyntheticDestinationServer):
+        self.server = server
+
+    async def call_tool(
+        self,
+        tool_name: str,
+        arguments: dict,
+    ) -> Any:
+
+        if tool_name == "create_item":
+
+            return await self.server.create_item(
+                arguments["operation_marker"],
+                arguments["item_name"],
+                arguments.get(
+                    "simulate_network_drop",
+                    False,
+                ),
+            )
+
+        if tool_name == "read_back":
+
+            return await self.server.read_back(
+                arguments["operation_marker"]
+            )
+
+        raise ValueError(
+            f"Unknown tool: {tool_name}"
+        )
+
+
+async def run_unguarded_workflow(client: LocalMCPToolClient):
+
+    marker = "op_unguarded_101"
+
+    print(
+        "\n--- 1. UNGUARDED WORKFLOW "
+        "(Naive Retry) ---"
+    )
+
     try:
-        print(f"[Unguarded] Calling create_item(marker='{op_marker}')...")
-        await server.create_item(op_marker, "Widget A", simulate_network_drop=True)
-    except ConnectionResetError as e:
-        print(f"[Unguarded] Ambiguous error encountered: '{e}'")
+        await client.call_tool(
+            "create_item",
+            {
+                "operation_marker": marker,
+                "item_name": "Widget A",
+                "simulate_network_drop": True,
+            },
+        )
 
-    # Step 2: Naive retry issued without verification
-    print(f"[Unguarded] Retrying create_item(marker='{op_marker}')...")
-    await server.create_item(op_marker, "Widget A", simulate_network_drop=False)
-    print("[Unguarded] Naive retry finished.")
+    except ConnectionResetError as error:
+
+        print(
+            f"[Unguarded] Error: {error}"
+        )
+
+    await client.call_tool(
+        "create_item",
+        {
+            "operation_marker": marker,
+            "item_name": "Widget A",
+            "simulate_network_drop": False,
+        },
+    )
+
+    print(
+        "[Unguarded] Retry completed"
+    )
 
 
-async def run_guarded_workflow(server: SyntheticDestinationServer):
-    """Scenario 2: Guarded Recovery — verifies state before retrying, preventing duplicates."""
-    op_marker = "op_guarded_202"
-    print("\n--- 2. GUARDED WORKFLOW (Read-Back Verification) ---")
+async def run_guarded_workflow(client: LocalMCPToolClient):
 
-    recovered_item: Optional[dict] = None
-    status: str = "UNKNOWN"
+    marker = "op_guarded_202"
 
-    # Step 1: Initial call commits mutation, but transport drops response
+    print(
+        "\n--- 2. GUARDED WORKFLOW "
+        "(Read-Back Verification) ---"
+    )
+
+    status = "UNKNOWN"
+
     try:
-        print(f"[Guarded] Calling create_item(marker='{op_marker}')...")
-        await server.create_item(op_marker, "Widget B", simulate_network_drop=True)
+
+        await client.call_tool(
+            "create_item",
+            {
+                "operation_marker": marker,
+                "item_name": "Widget B",
+                "simulate_network_drop": True,
+            },
+        )
+
         status = "SUCCESS"
-    except ConnectionResetError as e:
-        print(f"[Guarded] Ambiguous error caught: '{e}'")
+
+    except ConnectionResetError as error:
+
+        print(
+            f"[Guarded] Error: {error}"
+        )
+
         status = "EXTERNAL_RESULT_UNCERTAIN"
 
-    # Step 2: Guarded recovery using operation marker read-back
     if status == "EXTERNAL_RESULT_UNCERTAIN":
-        print(f"[Guarded] Result uncertain. Querying read_back tool for marker '{op_marker}'...")
-        recovered_item = await server.read_back(op_marker)
 
-        if recovered_item:
-            print(f"[Guarded] SUCCESS: Found committed item: {recovered_item}")
-            print("[Guarded] Bypassing re-execution of create_item. Duplicate mutation prevented!")
+        print(
+            "[Guarded] Checking read_back..."
+        )
+
+        item = await client.call_tool(
+            "read_back",
+            {
+                "operation_marker": marker
+            },
+        )
+
+        if item:
+
+            print(
+                f"[Guarded] Found committed item: {item}"
+            )
+
+            print(
+                "[Guarded] Duplicate mutation prevented"
+            )
+
         else:
-            print("[Guarded] Item not found. Safe to proceed with create_item retry.")
-            recovered_item = await server.create_item(op_marker, "Widget B", simulate_network_drop=False)
+
+            print(
+                "[Guarded] Item missing. "
+                "Safe retry."
+            )
+
+            await client.call_tool(
+                "create_item",
+                {
+                    "operation_marker": marker,
+                    "item_name": "Widget B",
+                },
+            )
 
 
-def print_reliability_report(unguarded_server: SyntheticDestinationServer, guarded_server: SyntheticDestinationServer):
-    """Prints compact reliability report detailing tool counts, mutations, and duplicate resistance."""
-    print("\n==========================================================")
-    print("              COMPACT RELIABILITY REPORT                  ")
-    print("==========================================================")
-    print(f"{'Metric':<28} | {'Unguarded':<12} | {'Guarded':<12}")
-    print("-" * 60)
-    print(f"{'Total Tool Calls':<28} | {unguarded_server.total_tool_calls:<12} | {guarded_server.total_tool_calls:<12}")
-    print(f"{'Total Mutations Committed':<28} | {unguarded_server.total_mutations:<12} | {guarded_server.total_mutations:<12}")
-    
-    unguarded_dups = len(unguarded_server.database) - 1
-    guarded_dups = max(0, guarded_server.total_mutations - len(guarded_server.database))
-    
-    print(f"{'Duplicate Count':<28} | {unguarded_dups:<12} | {guarded_dups:<12}")
-    print(f"{'Duplicate-Resistant Guarantee':<28} | {'FAILED':<12} | {'PASSED':<12}")
-    print("==========================================================\n")
+def print_reliability_report(
+    unguarded_server,
+    guarded_server,
+):
+
+    print(
+        "\n=========================================================="
+    )
+
+    print(
+        "              COMPACT RELIABILITY REPORT"
+    )
+
+    print(
+        "=========================================================="
+    )
+
+    print(
+        "NOTE: This demonstrates duplicate-resistant recovery, "
+        "not exactly-once execution."
+    )
 
 
 async def main():
-    print("==========================================================")
-    print("  MCP Multi-Server Mutation Recovery Example (#2054)")
-    print("==========================================================")
 
-    # Run unguarded scenario
+    print(
+        "=========================================================="
+    )
+
+    print(
+        " MCP Multi-Server Mutation Recovery Example (#2054)"
+    )
+
+    print(
+        "=========================================================="
+    )
+
+    config = {
+        "mcpServers": {}
+    }
+
+    MCPClient.from_dict(config)
+
     unguarded_server = SyntheticDestinationServer()
-    await run_unguarded_workflow(unguarded_server)
 
-    # Run guarded scenario
+    unguarded_client = LocalMCPToolClient(
+        unguarded_server
+    )
+
+    await run_unguarded_workflow(
+        unguarded_client
+    )
+
     guarded_server = SyntheticDestinationServer()
-    await run_guarded_workflow(guarded_server)
 
-    # Print summary report
-    print_reliability_report(unguarded_server, guarded_server)
+    guarded_client = LocalMCPToolClient(
+        guarded_server
+    )
+
+    await run_guarded_workflow(
+        guarded_client
+    )
+
+    print_reliability_report(
+        unguarded_server,
+        guarded_server,
+    )
 
 
 if __name__ == "__main__":

--- a/libraries/python/examples/reliability_recovery_example.py
+++ b/libraries/python/examples/reliability_recovery_example.py
@@ -11,8 +11,12 @@ Issue #2054
 """
 
 import asyncio
+import sys
+from pathlib import Path
 
 from mcp_use import MCPClient
+
+SERVER_SCRIPT = Path(__file__).parent / "synthetic_destination_server.py"
 
 
 async def run_unguarded_workflow(session):
@@ -20,7 +24,6 @@ async def run_unguarded_workflow(session):
     Unsafe retry workflow.
     Demonstrates duplicate mutation.
     """
-
     op_marker = "op_unguarded_101"
 
     print("\n--- 1. UNGUARDED WORKFLOW (Naive Retry) ---")
@@ -34,8 +37,10 @@ async def run_unguarded_workflow(session):
         },
     )
 
-    if result.content[0].text == "AMBIGUOUS_SUCCESS":
+    if not result.isError and result.content[0].text == "AMBIGUOUS_SUCCESS":
         print("[Unguarded] Ambiguous result received.")
+    elif result.isError:
+        print(f"[Unguarded] Tool call failed: {result.content[0].text}")
 
     print(f"[Unguarded] Retrying create_item(marker='{op_marker}')...")
 
@@ -56,11 +61,9 @@ async def run_guarded_workflow(session):
     Safe recovery workflow.
     Verifies external state before retrying.
     """
-
     op_marker = "op_guarded_202"
 
     print("\n--- 2. GUARDED WORKFLOW (Read-Back Verification) ---")
-
     print(f"[Guarded] Calling create_item(marker='{op_marker}')...")
 
     result = await session.call_tool(
@@ -72,9 +75,10 @@ async def run_guarded_workflow(session):
         },
     )
 
-    status = "UNKNOWN"
-
-    if result.content[0].text == "AMBIGUOUS_SUCCESS":
+    if result.isError:
+        status = "TOOL_ERROR"
+        print(f"[Guarded] create_item failed: {result.content[0].text}")
+    elif result.content[0].text == "AMBIGUOUS_SUCCESS":
         status = "EXTERNAL_RESULT_UNCERTAIN"
     else:
         status = "SUCCESS"
@@ -89,16 +93,18 @@ async def run_guarded_workflow(session):
             },
         )
 
+        if result.isError:
+            print(f"[Guarded] read_back failed: {result.content[0].text}")
+            print("[Guarded] Cannot confirm state. Not retrying automatically.")
+            return
+
         recovered_item = result.content[0].text
 
         if recovered_item and recovered_item != "None":
             print(f"[Guarded] SUCCESS: Found committed item: {recovered_item}")
-
             print("[Guarded] Skipping retry. Duplicate mutation prevented!")
-
         else:
             print("[Guarded] Item not found. Safe retry.")
-
             await session.call_tool(
                 name="create_item",
                 arguments={
@@ -110,7 +116,6 @@ async def run_guarded_workflow(session):
 
 
 async def main():
-
     print("=" * 58)
     print("  MCP Multi-Server Mutation Recovery Example (#2054)")
     print("=" * 58)
@@ -118,13 +123,8 @@ async def main():
     config = {
         "mcpServers": {
             "destination": {
-                "command": (
-                    r"C:\Users\PAVAN\AppData\Local\Programs"
-                    r"\Python\Python313\python.exe"
-                ),
-                "args": [
-                    "libraries/python/examples/synthetic_destination_server.py",
-                ],
+                "command": sys.executable,
+                "args": [str(SERVER_SCRIPT)],
             }
         }
     }
@@ -133,13 +133,10 @@ async def main():
 
     try:
         await client.create_all_sessions()
-
         session = client.get_session("destination")
 
         await run_unguarded_workflow(session)
-
         await run_guarded_workflow(session)
-
     finally:
         await client.close_all_sessions()
 

--- a/libraries/python/examples/reliability_recovery_example.py
+++ b/libraries/python/examples/reliability_recovery_example.py
@@ -1,370 +1,148 @@
 """
 Reliability & Recovery Example: Multi-Server Mutation Recovery
 
-Demonstrates how to safely handle ambiguous tool failures where a mutation
-succeeds on the destination server but the response is lost due to network
-failure.
-
-Workflow comparison:
-1. Unguarded Path:
-   Retry immediately after ambiguous failure -> duplicate mutation.
-
-2. Guarded Path:
-   Verify external state using operation marker -> recover without duplicate.
+Demonstrates safe recovery from ambiguous MCP tool failures where:
+- The destination server commits a mutation.
+- The client receives an ambiguous result.
+- A naive retry creates a duplicate.
+- A guarded workflow verifies state before retrying.
 
 Issue #2054
 """
 
 import asyncio
 
+from mcp_use import MCPClient
 
-class SyntheticDestinationServer:
+
+async def run_unguarded_workflow(session):
     """
-    Simulates a duplicate-sensitive destination MCP server.
-    """
-
-    def __init__(self):
-        self.database: dict[str, dict] = {}
-        self.total_tool_calls: int = 0
-        self.total_mutations: int = 0
-
-
-    async def create_item(
-        self,
-        operation_marker: str,
-        item_name: str,
-        simulate_network_drop: bool = False,
-    ) -> dict:
-        """
-        Mutating tool that creates an item.
-        """
-
-        self.total_tool_calls += 1
-        self.total_mutations += 1
-
-        item = {
-            "id": f"item_{self.total_mutations}",
-            "operation_marker": operation_marker,
-            "name": item_name,
-        }
-
-
-        # Store mutation result
-        if operation_marker in self.database:
-
-            # Duplicate mutation created
-            self.database[
-                f"{operation_marker}_dup_{self.total_mutations}"
-            ] = item
-
-        else:
-
-            self.database[operation_marker] = item
-
-
-        if simulate_network_drop:
-
-            raise ConnectionResetError(
-                "Transport connection dropped post-commit (Ambiguous Success)"
-            )
-
-
-        return item
-
-
-
-    async def read_back(
-        self,
-        operation_marker: str,
-    ) -> dict | None:
-        """
-        Checks whether mutation already happened.
-        """
-
-        self.total_tool_calls += 1
-
-        return self.database.get(operation_marker)
-
-
-
-async def run_unguarded_workflow(
-    server: SyntheticDestinationServer,
-):
-    """
-    Unguarded retry workflow.
-    Creates duplicate mutation.
+    Unsafe retry workflow.
+    Demonstrates duplicate mutation.
     """
 
     op_marker = "op_unguarded_101"
 
+    print("\n--- 1. UNGUARDED WORKFLOW (Naive Retry) ---")
 
-    print(
-        "\n--- 1. UNGUARDED WORKFLOW (Naive Retry) ---"
+    result = await session.call_tool(
+        name="create_item",
+        arguments={
+            "operation_marker": op_marker,
+            "item_name": "Widget A",
+            "simulate_network_drop": True,
+        },
     )
 
+    if result.content[0].text == "AMBIGUOUS_SUCCESS":
+        print("[Unguarded] Ambiguous result received.")
 
-    try:
+    print(f"[Unguarded] Retrying create_item(marker='{op_marker}')...")
 
-        print(
-            f"[Unguarded] Calling create_item(marker='{op_marker}')..."
-        )
-
-
-        await server.create_item(
-            op_marker,
-            "Widget A",
-            simulate_network_drop=True,
-        )
-
-
-    except ConnectionResetError as e:
-
-        print(
-            f"[Unguarded] Ambiguous error encountered: {e}"
-        )
-
-
-    # Unsafe retry
-    print(
-        f"[Unguarded] Retrying create_item(marker='{op_marker}')..."
+    await session.call_tool(
+        name="create_item",
+        arguments={
+            "operation_marker": op_marker,
+            "item_name": "Widget A",
+            "simulate_network_drop": False,
+        },
     )
 
-
-    await server.create_item(
-        op_marker,
-        "Widget A",
-        simulate_network_drop=False,
-    )
+    print("[Unguarded] Naive retry finished.")
 
 
-    print(
-        "[Unguarded] Naive retry finished."
-    )
-
-
-
-async def run_guarded_workflow(
-    server: SyntheticDestinationServer,
-):
+async def run_guarded_workflow(session):
     """
-    Guarded recovery workflow.
-    Prevents duplicate mutation.
+    Safe recovery workflow.
+    Verifies external state before retrying.
     """
 
     op_marker = "op_guarded_202"
 
+    print("\n--- 2. GUARDED WORKFLOW (Read-Back Verification) ---")
 
-    print(
-        "\n--- 2. GUARDED WORKFLOW (Read-Back Verification) ---"
+    print(f"[Guarded] Calling create_item(marker='{op_marker}')...")
+
+    result = await session.call_tool(
+        name="create_item",
+        arguments={
+            "operation_marker": op_marker,
+            "item_name": "Widget B",
+            "simulate_network_drop": True,
+        },
     )
-
 
     status = "UNKNOWN"
 
-
-    try:
-
-        print(
-            f"[Guarded] Calling create_item(marker='{op_marker}')..."
-        )
-
-
-        await server.create_item(
-            op_marker,
-            "Widget B",
-            simulate_network_drop=True,
-        )
-
-
+    if result.content[0].text == "AMBIGUOUS_SUCCESS":
+        status = "EXTERNAL_RESULT_UNCERTAIN"
+    else:
         status = "SUCCESS"
 
-
-    except ConnectionResetError as e:
-
-        print(
-            f"[Guarded] Ambiguous error caught: {e}"
-        )
-
-
-        status = "EXTERNAL_RESULT_UNCERTAIN"
-
-
-
     if status == "EXTERNAL_RESULT_UNCERTAIN":
+        print(f"[Guarded] Checking read_back for marker '{op_marker}'...")
 
-
-        print(
-            f"[Guarded] Checking read_back for marker '{op_marker}'..."
+        result = await session.call_tool(
+            name="read_back",
+            arguments={
+                "operation_marker": op_marker,
+            },
         )
 
+        recovered_item = result.content[0].text
 
-        recovered_item = await server.read_back(
-            op_marker
-        )
+        if recovered_item and recovered_item != "None":
+            print(f"[Guarded] SUCCESS: Found committed item: {recovered_item}")
 
-
-        if recovered_item:
-
-
-            print(
-                f"[Guarded] SUCCESS: Found committed item: {recovered_item}"
-            )
-
-
-            print(
-                "[Guarded] Skipping retry. Duplicate mutation prevented!"
-            )
-
+            print("[Guarded] Skipping retry. Duplicate mutation prevented!")
 
         else:
+            print("[Guarded] Item not found. Safe retry.")
 
-
-            print(
-                "[Guarded] Item not found. Safe retry."
+            await session.call_tool(
+                name="create_item",
+                arguments={
+                    "operation_marker": op_marker,
+                    "item_name": "Widget B",
+                    "simulate_network_drop": False,
+                },
             )
-
-
-            await server.create_item(
-                op_marker,
-                "Widget B",
-                simulate_network_drop=False,
-            )
-
-
-
-def print_reliability_report(
-    unguarded_server: SyntheticDestinationServer,
-    guarded_server: SyntheticDestinationServer,
-):
-    """
-    Prints reliability comparison report.
-    """
-
-
-    print(
-        "\n=========================================================="
-    )
-
-    print(
-        "              COMPACT RELIABILITY REPORT"
-    )
-
-    print(
-        "=========================================================="
-    )
-
-
-    print(
-        f"{'Metric':<35} | "
-        f"{'Unguarded':<12} | "
-        f"{'Guarded':<12}"
-    )
-
-
-    print("-" * 65)
-
-
-
-    unguarded_duplicates = (
-        len(unguarded_server.database) - 1
-    )
-
-
-    guarded_duplicates = max(
-        0,
-        guarded_server.total_mutations
-        - len(guarded_server.database),
-    )
-
-
-
-    print(
-        f"{'Total Tool Calls':<35} | "
-        f"{unguarded_server.total_tool_calls:<12} | "
-        f"{guarded_server.total_tool_calls:<12}"
-    )
-
-
-    print(
-        f"{'Total Mutations Committed':<35} | "
-        f"{unguarded_server.total_mutations:<12} | "
-        f"{guarded_server.total_mutations:<12}"
-    )
-
-
-    print(
-        f"{'Duplicate Count':<35} | "
-        f"{unguarded_duplicates:<12} | "
-        f"{guarded_duplicates:<12}"
-    )
-
-
-    print(
-        f"{'Recovery Verification':<35} | "
-        f"{'FAILED':<12} | "
-        f"{'SUCCESS':<12}"
-    )
-
-
-    print(
-        "=========================================================="
-    )
-
-
-    print(
-        "NOTE: Demonstrates duplicate-resistant recovery, "
-        "not exactly-once execution."
-    )
-
 
 
 async def main():
 
-    print(
-        "=========================================================="
-    )
+    print("=" * 58)
+    print("  MCP Multi-Server Mutation Recovery Example (#2054)")
+    print("=" * 58)
 
-    print(
-        "  MCP Multi-Server Mutation Recovery Example (#2054)"
-    )
+    config = {
+        "mcpServers": {
+            "destination": {
+                "command": (
+                    r"C:\Users\PAVAN\AppData\Local\Programs"
+                    r"\Python\Python313\python.exe"
+                ),
+                "args": [
+                    "libraries/python/examples/synthetic_destination_server.py",
+                ],
+            }
+        }
+    }
 
-    print(
-        "=========================================================="
-    )
+    client = MCPClient.from_dict(config)
 
+    try:
+        await client.create_all_sessions()
 
+        session = client.get_session("destination")
 
-    # Unguarded test
+        await run_unguarded_workflow(session)
 
-    unguarded_server = SyntheticDestinationServer()
+        await run_guarded_workflow(session)
 
-
-    await run_unguarded_workflow(
-        unguarded_server
-    )
-
-
-
-    # Guarded test
-
-    guarded_server = SyntheticDestinationServer()
-
-
-    await run_guarded_workflow(
-        guarded_server
-    )
-
-
-
-    # Report
-
-    print_reliability_report(
-        unguarded_server,
-        guarded_server,
-    )
-
+    finally:
+        await client.close_all_sessions()
 
 
 if __name__ == "__main__":
-
     asyncio.run(main())

--- a/libraries/python/examples/reliability_recovery_example.py
+++ b/libraries/python/examples/reliability_recovery_example.py
@@ -1,0 +1,142 @@
+"""
+Reliability & Recovery Example: Multi-Server Mutation Recovery
+
+Demonstrates how to safely handle ambiguous tool failures (when a mutating write succeeds
+on the destination server, but the network connection/response is lost before reaching the caller).
+
+Workflow comparison:
+1. Unguarded Path: Naive retry after an ambiguous drop -> creates duplicate mutations.
+2. Guarded Path: Catches EXTERNAL_RESULT_UNCERTAIN -> queries read_back tool using an operation marker -> recovers committed state without duplicate writes.
+
+Issue #2054
+"""
+
+import asyncio
+from typing import Dict, Optional, Any
+
+
+class SyntheticDestinationServer:
+    """Simulates a duplicate-sensitive destination MCP server with a read-back verification tool."""
+
+    def __init__(self):
+        self.database: Dict[str, dict] = {}
+        self.total_tool_calls: int = 0
+        self.total_mutations: int = 0
+
+    async def create_item(self, operation_marker: str, item_name: str, simulate_network_drop: bool = False) -> dict:
+        """
+        Mutating tool that creates an item in external storage.
+        """
+        self.total_tool_calls += 1
+        self.total_mutations += 1
+
+        item = {
+            "id": f"item_{self.total_mutations}",
+            "operation_marker": operation_marker,
+            "name": item_name,
+        }
+
+        # Record item in database
+        if operation_marker in self.database:
+            # Duplicate entry detected!
+            self.database[f"{operation_marker}_dup_{self.total_mutations}"] = item
+        else:
+            self.database[operation_marker] = item
+
+        if simulate_network_drop:
+            # Simulate external write committing, but response getting lost over transport
+            raise ConnectionResetError("Transport connection dropped post-commit (Ambiguous Success)")
+
+        return item
+
+    async def read_back(self, operation_marker: str) -> Optional[dict]:
+        """Read-back tool keyed by opaque operation marker to check post-condition."""
+        self.total_tool_calls += 1
+        return self.database.get(operation_marker)
+
+
+async def run_unguarded_workflow(server: SyntheticDestinationServer):
+    """Scenario 1: Unguarded Retry — results in duplicate mutation."""
+    op_marker = "op_unguarded_101"
+    print("\n--- 1. UNGUARDED WORKFLOW (Naive Retry) ---")
+
+    # Step 1: Initial call commits mutation, but transport drops response
+    try:
+        print(f"[Unguarded] Calling create_item(marker='{op_marker}')...")
+        await server.create_item(op_marker, "Widget A", simulate_network_drop=True)
+    except ConnectionResetError as e:
+        print(f"[Unguarded] Ambiguous error encountered: '{e}'")
+
+    # Step 2: Naive retry issued without verification
+    print(f"[Unguarded] Retrying create_item(marker='{op_marker}')...")
+    await server.create_item(op_marker, "Widget A", simulate_network_drop=False)
+    print("[Unguarded] Naive retry finished.")
+
+
+async def run_guarded_workflow(server: SyntheticDestinationServer):
+    """Scenario 2: Guarded Recovery — verifies state before retrying, preventing duplicates."""
+    op_marker = "op_guarded_202"
+    print("\n--- 2. GUARDED WORKFLOW (Read-Back Verification) ---")
+
+    recovered_item: Optional[dict] = None
+    status: str = "UNKNOWN"
+
+    # Step 1: Initial call commits mutation, but transport drops response
+    try:
+        print(f"[Guarded] Calling create_item(marker='{op_marker}')...")
+        await server.create_item(op_marker, "Widget B", simulate_network_drop=True)
+        status = "SUCCESS"
+    except ConnectionResetError as e:
+        print(f"[Guarded] Ambiguous error caught: '{e}'")
+        status = "EXTERNAL_RESULT_UNCERTAIN"
+
+    # Step 2: Guarded recovery using operation marker read-back
+    if status == "EXTERNAL_RESULT_UNCERTAIN":
+        print(f"[Guarded] Result uncertain. Querying read_back tool for marker '{op_marker}'...")
+        recovered_item = await server.read_back(op_marker)
+
+        if recovered_item:
+            print(f"[Guarded] SUCCESS: Found committed item: {recovered_item}")
+            print("[Guarded] Bypassing re-execution of create_item. Duplicate mutation prevented!")
+        else:
+            print("[Guarded] Item not found. Safe to proceed with create_item retry.")
+            recovered_item = await server.create_item(op_marker, "Widget B", simulate_network_drop=False)
+
+
+def print_reliability_report(unguarded_server: SyntheticDestinationServer, guarded_server: SyntheticDestinationServer):
+    """Prints compact reliability report detailing tool counts, mutations, and duplicate resistance."""
+    print("\n==========================================================")
+    print("              COMPACT RELIABILITY REPORT                  ")
+    print("==========================================================")
+    print(f"{'Metric':<28} | {'Unguarded':<12} | {'Guarded':<12}")
+    print("-" * 60)
+    print(f"{'Total Tool Calls':<28} | {unguarded_server.total_tool_calls:<12} | {guarded_server.total_tool_calls:<12}")
+    print(f"{'Total Mutations Committed':<28} | {unguarded_server.total_mutations:<12} | {guarded_server.total_mutations:<12}")
+    
+    unguarded_dups = len(unguarded_server.database) - 1
+    guarded_dups = max(0, guarded_server.total_mutations - len(guarded_server.database))
+    
+    print(f"{'Duplicate Count':<28} | {unguarded_dups:<12} | {guarded_dups:<12}")
+    print(f"{'Duplicate-Resistant Guarantee':<28} | {'FAILED':<12} | {'PASSED':<12}")
+    print("==========================================================\n")
+
+
+async def main():
+    print("==========================================================")
+    print("  MCP Multi-Server Mutation Recovery Example (#2054)")
+    print("==========================================================")
+
+    # Run unguarded scenario
+    unguarded_server = SyntheticDestinationServer()
+    await run_unguarded_workflow(unguarded_server)
+
+    # Run guarded scenario
+    guarded_server = SyntheticDestinationServer()
+    await run_guarded_workflow(guarded_server)
+
+    # Print summary report
+    print_reliability_report(unguarded_server, guarded_server)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/libraries/python/examples/synthetic_destination_server.py
+++ b/libraries/python/examples/synthetic_destination_server.py
@@ -1,0 +1,118 @@
+"""
+Synthetic MCP destination server for reliability recovery example.
+
+Provides:
+- create_item mutation tool
+- read_back verification tool
+
+Demonstrates ambiguous success recovery.
+"""
+
+import asyncio
+
+from mcp import types
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+
+database: dict[str, dict] = {}
+total_mutations = 0
+
+
+server = Server("synthetic_destination")
+
+
+@server.list_tools()
+async def list_tools():
+
+    return [
+        types.Tool(
+            name="create_item",
+            description="Create an item using an operation marker",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "operation_marker": {"type": "string"},
+                    "item_name": {"type": "string"},
+                    "simulate_network_drop": {"type": "boolean"},
+                },
+                "required": [
+                    "operation_marker",
+                    "item_name",
+                ],
+            },
+        ),
+        types.Tool(
+            name="read_back",
+            description="Read an item using operation marker",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "operation_marker": {"type": "string"},
+                },
+                "required": [
+                    "operation_marker",
+                ],
+            },
+        ),
+    ]
+
+
+@server.call_tool()
+async def call_tool(name, arguments):
+
+    global total_mutations
+
+    if name == "create_item":
+        total_mutations += 1
+
+        item = {
+            "id": f"item_{total_mutations}",
+            "operation_marker": arguments["operation_marker"],
+            "name": arguments["item_name"],
+        }
+
+        # Commit mutation first
+        database[arguments["operation_marker"]] = item
+
+        # Simulate ambiguous success:
+        # Mutation succeeds, but client receives an error response.
+        if arguments.get("simulate_network_drop", False):
+            return [
+                types.TextContent(
+                    type="text",
+                    text="AMBIGUOUS_SUCCESS",
+                )
+            ]
+
+        return [
+            types.TextContent(
+                type="text",
+                text=str(item),
+            )
+        ]
+
+    if name == "read_back":
+        item = database.get(arguments["operation_marker"])
+
+        return [
+            types.TextContent(
+                type="text",
+                text=str(item),
+            )
+        ]
+
+    raise ValueError(f"Unknown tool {name}")
+
+
+async def main():
+
+    async with stdio_server() as streams:
+        await server.run(
+            streams[0],
+            streams[1],
+            server.create_initialization_options(),
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Language / Project Scope
 Python
Summary

Adds a Python example showing how to safely recover from ambiguous MCP mutation failures — cases where a mutation might have succeeded on the server but the client never got the response.

What's included
A synthetic MCP server (synthetic_destination_server.py) with a create_item mutation tool and a read_back verification tool, used to simulate the ambiguous-success scenario.
An unguarded (unsafe) retry workflow that shows how blind retries can create duplicate mutations.
A guarded (safe) recovery workflow that verifies state via read_back before deciding whether to retry.
Files changed

Added: libraries/python/examples/synthetic_destination_server.py
Simulates a server that commits a mutation but doesn't reliably confirm it back to the client, so you can test recovery logic against it.

Updated: libraries/python/examples/reliability_recovery_example.py
Adds two workflows:

Unguarded — retries immediately after an ambiguous failure, without checking if the original mutation already went through. Demonstrates the duplicate-mutation risk.
Guarded — uses an operation marker as an idempotency key, calls read_back to check if the mutation already committed, and only retries if it didn't.
Testing

Ran locally:

ruff format libraries/python/examples/reliability_recovery_example.py libraries/python/examples/synthetic_destination_server.py
ruff check libraries/python/examples/reliability_recovery_example.py libraries/python/examples/synthetic_destination_server.py
python libraries/python/examples/reliability_recovery_example.py

Both files pass formatting and lint. Verified actual script output:

--- 1. UNGUARDED WORKFLOW (Naive Retry) ---
[Unguarded] Ambiguous result received.
[Unguarded] Retrying create_item(marker='op_unguarded_101')...
[Unguarded] Naive retry finished.

--- 2. GUARDED WORKFLOW (Read-Back Verification) ---
[Guarded] Calling create_item(marker='op_guarded_202')...
[Guarded] Checking read_back for marker 'op_guarded_202'...
[Guarded] SUCCESS: Found committed item: {'id': 'item_3', 'operation_marker': 'op_guarded_202', 'name': 'Widget B'}
[Guarded] Skipping retry. Duplicate mutation prevented!
Backwards compatibility

No existing APIs touched. Pure addition of a new example.

Related issue

Closes #2054

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Python example that shows how to recover safely from ambiguous MCP mutation results, using read-back verification to avoid duplicate writes. Implements the recovery pattern requested in #2054.

- **New Features**
  - Adds `libraries/python/examples/synthetic_destination_server.py`: Synthetic MCP server with `create_item` and `read_back`; can simulate ambiguous success via `simulate_network_drop`.
  - Adds `libraries/python/examples/reliability_recovery_example.py`: Demonstrates naive retry vs guarded recovery using an operation marker as an idempotency key plus `read_back` before retrying.
  - No API changes; standalone examples only.

- **Bug Fixes**
  - Check `isError` before interpreting tool results to avoid misclassifying failures as ambiguous success.
  - Use `sys.executable` in the client config instead of a hardcoded interpreter path.

<sup>Written for commit da3ce21c0b838c5aa59b9e01da60f2875e7fef62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

