### PR TITLE
chore(typescript): add public base URL changeset

### DIFF
--- a/libraries/typescript/.changeset/expose-public-base-url.md
+++ b/libraries/typescript/.changeset/expose-public-base-url.md
@@ -1,0 +1,6 @@
+---
+"mcp-use": patch
+---
+
+Expose `getPublicBaseUrl()` from `mcp-use/react` for resolving public scripts,
+stylesheets, WASM modules, and other static assets inside MCP App views.


### PR DESCRIPTION
## Summary

- add a fresh patch Changeset for `mcp-use`
- describe the new `getPublicBaseUrl()` export delivered by #2061

## Why

PR #2061 merged the implementation into `beta` without a Changeset. The TypeScript release workflow therefore completed successfully but found no pending release, so package versioning and npm publication were skipped.

## Developer impact

Merging this PR lets the beta release workflow version the current `beta` branch, including #2061, and publish the next `mcp-use` beta.

## Validation

- confirmed `expose-public-base-url` is absent from `.changeset/pre.json`
- confirmed the Changeset targets `mcp-use` with a patch bump
- `pnpm exec prettier --check .changeset/expose-public-base-url.md`
- `git diff --check`
- repository pre-commit checks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a patch Changeset for `mcp-use` to release the new `getPublicBaseUrl()` export from `mcp-use/react` for resolving public asset URLs in MCP App views. This ensures the next beta is versioned and published.

<sup>Written for commit ec1e44c65178ea35667005601f1416479bba2597. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

