### PR TITLE
fix: add guarded v1 maintenance releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,9 +48,9 @@ permissions:
 
 on:
   push:
-    branches: [main, canary]
+    branches: [main, canary, v1]
   pull_request:
-    branches: [main, canary]
+    branches: [main, canary, v1]
   workflow_call:
     inputs:
       ref:
@@ -833,7 +833,7 @@ jobs:
         run: |
           if [ -n "$(ls -A .changeset/*.md 2>/dev/null | grep -v README.md)" ]; then
             echo "✅ Changeset found"
-            pnpm changeset status --since=origin/main
+            pnpm changeset status --since="origin/${GITHUB_BASE_REF}"
           else
             echo "⚠️ No changeset found. If this PR includes changes that should be published, please add a changeset:"
             echo "  pnpm changeset"

--- a/.github/workflows/typescript-release.yml
+++ b/.github/workflows/typescript-release.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - canary
+      - v1
     paths:
       - "libraries/typescript/**"
       - ".github/workflows/typescript-release.yml"
@@ -21,6 +22,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   release:
     name: Release
+    if: github.ref != 'refs/heads/v1'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -568,3 +570,66 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_CHANNEL_WEBHOOK_URL }}
+
+  release-v1:
+    name: Release v1 maintenance
+    if: github.ref == 'refs/heads/v1'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Checkout v1
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.30.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: "pnpm"
+          cache-dependency-path: libraries/typescript/pnpm-lock.yaml
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Update npm for trusted publishing
+        run: npm install --global npm@latest
+
+      - name: Install dependencies
+        working-directory: libraries/typescript
+        run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        working-directory: libraries/typescript
+        run: pnpm build
+
+      - name: Create or update v1 version PR
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          cwd: libraries/typescript
+          version: pnpm version
+          commit: "chore(release-v1): version packages"
+          title: "chore(release-v1): version packages"
+          createGithubReleases: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Plan v1 publication
+        if: steps.changesets.outputs.hasChangesets == 'false'
+        working-directory: libraries/typescript
+        run: node scripts/v1-release.mjs plan
+
+      - name: Publish and verify v1 packages
+        if: steps.changesets.outputs.hasChangesets == 'false'
+        working-directory: libraries/typescript
+        env:
+          VERIFY_ATTEMPTS: 12
+          VERIFY_DELAY_SECONDS: 10
+        run: node scripts/v1-release.mjs publish

--- a/libraries/typescript/.changeset/README.md
+++ b/libraries/typescript/.changeset/README.md
@@ -29,6 +29,16 @@ We have a quick list of common questions to get you started engaging with this p
 2. Push to canary branch
 3. CI automatically publishes as `x.y.z-canary.N`
 
+#### V1 Branch (Maintenance Releases)
+
+1. Branch from `v1` and add a patch changeset
+2. Open a pull request back to `v1`
+3. CI creates or updates the v1 version pull request
+4. Merge the version pull request to publish with the `v1` npm dist-tag
+
+V1 publication verifies that every other npm dist-tag, including `latest`,
+remains unchanged. Do not publish v1 packages manually.
+
 ---
 
 ## Quick Start

--- a/libraries/typescript/.changeset/config.json
+++ b/libraries/typescript/.changeset/config.json
@@ -5,7 +5,7 @@
   "fixed": [],
   "linked": [],
   "access": "public",
-  "baseBranch": "main",
+  "baseBranch": "v1",
   "updateInternalDependencies": "patch",
   "ignore": [],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {

--- a/libraries/typescript/.changeset/tiny-inspector-version-help.md
+++ b/libraries/typescript/.changeset/tiny-inspector-version-help.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Show the installed Inspector version in the CLI help heading.

--- a/libraries/typescript/packages/inspector/src/server/cli.ts
+++ b/libraries/typescript/packages/inspector/src/server/cli.ts
@@ -53,7 +53,7 @@ for (let i = 0; i < args.length; i++) {
     process.exit(0);
   } else if (args[i] === "--help" || args[i] === "-h") {
     console.log(`
-MCP Inspector - Inspect and debug MCP servers
+MCP Inspector v${getInspectorVersion()} - Inspect and debug MCP servers
 
 Usage:
   npx @mcp-use/inspector [options]

--- a/libraries/typescript/scripts/v1-release.mjs
+++ b/libraries/typescript/scripts/v1-release.mjs
@@ -1,0 +1,252 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const root = process.cwd();
+const planFile = join(root, "v1-release-plan.json");
+const packageDirectory = join(root, "packages");
+const allowedLines = new Map([
+  ["mcp-use", /^1\./],
+  ["@mcp-use/cli", /^3\./],
+  ["@mcp-use/inspector", /^12\./],
+  ["create-mcp-use-app", /^0\.14\./],
+]);
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: root,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    ...options,
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(
+      `${command} ${args.join(" ")} failed:\n${result.stdout}${result.stderr}`
+    );
+  }
+  return result.stdout.trim();
+}
+
+function npmJson(args, fallback) {
+  const result = spawnSync("npm", args, {
+    cwd: root,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.status !== 0) return fallback;
+  const output = result.stdout.trim();
+  return output ? JSON.parse(output) : fallback;
+}
+
+function manifestAt(revision, relativePath) {
+  const result = spawnSync(
+    "git",
+    ["show", `${revision}:libraries/typescript/${relativePath}`],
+    {
+      cwd: root,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }
+  );
+  if (result.status !== 0) return undefined;
+  return JSON.parse(result.stdout);
+}
+
+function currentManifest(relativePath) {
+  return JSON.parse(readFileSync(join(root, relativePath), "utf8"));
+}
+
+function packagePathsChangedByReleaseCommit() {
+  const paths = run("git", [
+    "diff",
+    "--relative",
+    "--name-only",
+    "HEAD^",
+    "HEAD",
+    "--",
+    "packages/*/package.json",
+  ])
+    .split("\n")
+    .filter(Boolean);
+
+  return paths.filter((relativePath) => {
+    const before = manifestAt("HEAD^", relativePath);
+    const after = currentManifest(relativePath);
+    return before?.version !== after.version;
+  });
+}
+
+function assertMaintenanceState() {
+  if (existsSync(join(root, ".changeset", "pre.json"))) {
+    throw new Error("v1 releases must not run in Changesets prerelease mode");
+  }
+  if (process.env.GITHUB_REF && process.env.GITHUB_REF !== "refs/heads/v1") {
+    throw new Error(`refusing v1 release from ${process.env.GITHUB_REF}`);
+  }
+}
+
+function createPlan() {
+  assertMaintenanceState();
+  const releases = packagePathsChangedByReleaseCommit().map((relativePath) => {
+    const manifest = currentManifest(relativePath);
+    const line = allowedLines.get(manifest.name);
+    if (!line) {
+      throw new Error(
+        `package ${manifest.name} is not in the v1 release allowlist`
+      );
+    }
+    if (!line.test(manifest.version)) {
+      throw new Error(
+        `${manifest.name}@${manifest.version} is outside its v1 maintenance line`
+      );
+    }
+
+    const publishedVersion = npmJson(
+      ["view", `${manifest.name}@${manifest.version}`, "version", "--json"],
+      undefined
+    );
+    return {
+      name: manifest.name,
+      version: manifest.version,
+      relativePath,
+      published: publishedVersion === manifest.version,
+      tagsBefore: npmJson(["view", manifest.name, "dist-tags", "--json"], {}),
+    };
+  });
+
+  writeFileSync(planFile, `${JSON.stringify({ releases }, null, 2)}\n`);
+  console.log(JSON.stringify({ releases }, null, 2));
+  return releases;
+}
+
+function sleep(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function sameNonV1Tags(before, after) {
+  const withoutV1 = (tags) =>
+    Object.fromEntries(
+      Object.entries(tags)
+        .filter(([tag]) => tag !== "v1")
+        .sort(([left], [right]) => left.localeCompare(right))
+    );
+  return JSON.stringify(withoutV1(before)) === JSON.stringify(withoutV1(after));
+}
+
+async function verifyRelease(release) {
+  const attempts = Number.parseInt(process.env.VERIFY_ATTEMPTS ?? "1", 10);
+  const delaySeconds = Number.parseInt(
+    process.env.VERIFY_DELAY_SECONDS ?? "0",
+    10
+  );
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    const version = npmJson(
+      ["view", `${release.name}@${release.version}`, "version", "--json"],
+      undefined
+    );
+    const tags = npmJson(["view", release.name, "dist-tags", "--json"], {});
+    if (
+      version === release.version &&
+      tags.v1 === release.version &&
+      sameNonV1Tags(release.tagsBefore, tags)
+    ) {
+      return;
+    }
+    if (attempt === attempts) {
+      throw new Error(
+        `registry verification failed for ${release.name}@${release.version}: ` +
+          JSON.stringify({
+            version,
+            tagsBefore: release.tagsBefore,
+            tagsAfter: tags,
+          })
+      );
+    }
+    await sleep(delaySeconds * 1000);
+  }
+}
+
+function packageTag({ name, version }) {
+  return `${name}@${version}`;
+}
+
+async function publishPlan() {
+  assertMaintenanceState();
+  const { releases } = JSON.parse(readFileSync(planFile, "utf8"));
+  if (releases.length === 0) {
+    console.log(
+      "No package versions changed in this commit; nothing to publish."
+    );
+    return;
+  }
+
+  const directory = mkdtempSync(join(tmpdir(), "mcp-use-v1-publish-"));
+  try {
+    for (const release of releases) {
+      if (!release.published) {
+        const packed = JSON.parse(
+          run("pnpm", [
+            "--filter",
+            release.name,
+            "pack",
+            "--pack-destination",
+            directory,
+            "--json",
+          ])
+        );
+        if (
+          packed.name !== release.name ||
+          packed.version !== release.version
+        ) {
+          throw new Error(
+            `packed identity mismatch for ${release.name}@${release.version}`
+          );
+        }
+        console.log(`publishing ${release.name}@${release.version} under v1`);
+        run("npm", [
+          "publish",
+          packed.filename,
+          "--tag",
+          "v1",
+          "--access",
+          "public",
+          "--provenance",
+        ]);
+      }
+
+      await verifyRelease(release);
+
+      const tag = packageTag(release);
+      try {
+        execFileSync("git", ["rev-parse", "--verify", `refs/tags/${tag}`], {
+          cwd: root,
+          stdio: "ignore",
+        });
+      } catch {
+        run("git", ["tag", "-a", tag, "-m", tag]);
+      }
+      run("git", ["push", "origin", `refs/tags/${tag}`]);
+      console.log(`verified ${release.name}@${release.version}`);
+    }
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+const command = process.argv[2];
+if (command === "plan") {
+  createPlan();
+} else if (command === "publish") {
+  await publishPlan();
+} else {
+  throw new Error("usage: node scripts/v1-release.mjs <plan|publish>");
+}


### PR DESCRIPTION
## What changed

- add a protected v1 Changesets release lane to the existing trusted TypeScript workflow
- restrict v1 publication to the current v1 package lines
- publish changed versions only under the `v1` npm dist-tag
- verify every non-`v1` dist-tag, including `latest`, is unchanged
- show the installed Inspector version in CLI help as a harmless patch-release proof

## Release behavior

Merging this PR into `v1` creates a version PR. Changesets correctly cascades this Inspector patch to the v1 dependents, planning:

- `@mcp-use/inspector@12.0.6`
- `@mcp-use/cli@3.6.7`
- `mcp-use@1.34.6`

No package is published by this PR itself.

## Validation

- full TypeScript workspace build
- Inspector unit tests: 60 passed
- workflow validated with actionlint 1.7.12
- simulated Changesets version commit and registry plan
- clean packed-consumer install showed `MCP Inspector v12.0.6` in `--help`
- no npm publication was performed during local validation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a guarded v1 maintenance release lane for TypeScript packages that only publishes under the `v1` dist-tag and verifies other tags remain unchanged. Also shows the installed version in the `@mcp-use/inspector` CLI help.

- **New Features**
  - Adds `release-v1` workflow that runs only on `v1`, updates a Changesets version PR, then plans/publishes changed packages with the `v1` tag.
  - Restricts v1 publication to: `mcp-use@1.x`, `@mcp-use/cli@3.x`, `@mcp-use/inspector@12.x`, `create-mcp-use-app@0.14.x`; refuses anything else.
  - Verifies registry state: non-`v1` dist-tags (including `latest`) stay the same; pushes annotated git tags for released versions.
  - Sets Changesets `baseBranch` to `v1` and updates docs.
  - `@mcp-use/inspector`: CLI `--help` now shows `MCP Inspector v{version}`.

- **Migration**
  - Branch from `v1`, add a patch changeset, open a PR back to `v1`.
  - Merge the auto-created version PR to publish under `v1`. Do not publish manually.

<sup>Written for commit 0ce27bc55cfbe64b6a6bc20a6a6b24490a9cff69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

