### PR TITLE
fix: run v1 version script explicitly

### DIFF
--- a/.github/workflows/typescript-release.yml
+++ b/.github/workflows/typescript-release.yml
@@ -614,7 +614,7 @@ jobs:
         uses: changesets/action@v1
         with:
           cwd: libraries/typescript
-          version: pnpm version
+          version: pnpm run version
           commit: "chore(release-v1): version packages"
           title: "chore(release-v1): version packages"
           createGithubReleases: false


### PR DESCRIPTION
## Root cause

The first guarded v1 release run stopped before publication because `changesets/action` invoked `pnpm version`, which pnpm treated as its built-in runtime-version command. It therefore created no version files and could not open a version PR.

## Fix

Invoke the repository lifecycle script explicitly with `pnpm run version`. That script runs `changeset version` and refreshes the lockfile.

## Safety

- the failed run skipped both publication steps
- npm dist-tags remain unchanged
- the generated release plan was already simulated locally as Inspector 12.0.6, CLI 3.6.7, and mcp-use 1.34.6
- workflow syntax passes actionlint

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the v1 TypeScript release workflow by calling the repo’s version script with `pnpm run version`, so `changesets` creates version files and opens the version PR. Avoids pnpm’s built-in `version` command, which previously halted the run.

- **Bug Fixes**
  - Switch `version: pnpm version` to `version: pnpm run version` in `.github/workflows/typescript-release.yml` to execute the script that runs `changeset version` and refreshes the lockfile.
  - Prevents early stop and does not trigger publishing or alter npm dist-tags.

<sup>Written for commit 960dc008ee1071eda41067b08b1a287e3d0474ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2065?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

