### PR TITLE
fix: use valid npm tag for v1 releases

### DIFF
--- a/libraries/typescript/.changeset/README.md
+++ b/libraries/typescript/.changeset/README.md
@@ -34,10 +34,11 @@ We have a quick list of common questions to get you started engaging with this p
 1. Branch from `v1` and add a patch changeset
 2. Open a pull request back to `v1`
 3. CI creates or updates the v1 version pull request
-4. Merge the version pull request to publish with the `v1` npm dist-tag
+4. Merge the version pull request to publish with the `legacy-v1` npm dist-tag
 
 V1 publication verifies that every other npm dist-tag, including `latest`,
-remains unchanged. Do not publish v1 packages manually.
+remains unchanged. (`v1` itself cannot be an npm dist-tag because npm treats it
+as a semantic-version range.) Do not publish v1 packages manually.
 
 ---
 

--- a/libraries/typescript/scripts/v1-release.mjs
+++ b/libraries/typescript/scripts/v1-release.mjs
@@ -11,6 +11,7 @@ import { join } from "node:path";
 
 const root = process.cwd();
 const planFile = join(root, "v1-release-plan.json");
+const distTag = "legacy-v1";
 const packageDirectory = join(root, "packages");
 const allowedLines = new Map([
   ["mcp-use", /^1\./],
@@ -131,14 +132,17 @@ function sleep(milliseconds) {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
-function sameNonV1Tags(before, after) {
-  const withoutV1 = (tags) =>
+function sameNonMaintenanceTags(before, after) {
+  const withoutMaintenanceTag = (tags) =>
     Object.fromEntries(
       Object.entries(tags)
-        .filter(([tag]) => tag !== "v1")
+        .filter(([tag]) => tag !== distTag)
         .sort(([left], [right]) => left.localeCompare(right))
     );
-  return JSON.stringify(withoutV1(before)) === JSON.stringify(withoutV1(after));
+  return (
+    JSON.stringify(withoutMaintenanceTag(before)) ===
+    JSON.stringify(withoutMaintenanceTag(after))
+  );
 }
 
 async function verifyRelease(release) {
@@ -156,8 +160,8 @@ async function verifyRelease(release) {
     const tags = npmJson(["view", release.name, "dist-tags", "--json"], {});
     if (
       version === release.version &&
-      tags.v1 === release.version &&
-      sameNonV1Tags(release.tagsBefore, tags)
+      tags[distTag] === release.version &&
+      sameNonMaintenanceTags(release.tagsBefore, tags)
     ) {
       return;
     }
@@ -211,12 +215,14 @@ async function publishPlan() {
             `packed identity mismatch for ${release.name}@${release.version}`
           );
         }
-        console.log(`publishing ${release.name}@${release.version} under v1`);
+        console.log(
+          `publishing ${release.name}@${release.version} under ${distTag}`
+        );
         run("npm", [
           "publish",
           packed.filename,
           "--tag",
-          "v1",
+          distTag,
           "--access",
           "public",
           "--provenance",


### PR DESCRIPTION
The npm registry rejects `v1` because it parses as a SemVer range. Use the explicit `legacy-v1` maintenance channel instead while preserving every other dist-tag.\n\nVerified with an npm publish dry run for Inspector 12.0.6; no package was published by the failed run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch v1 maintenance publishes to the `legacy-v1` npm dist-tag because `npm` treats `v1` as a SemVer range. This prevents publish rejections and keeps all other dist-tags unchanged.

- **Bug Fixes**
  - Release script now publishes and verifies using `legacy-v1`.
  - Preserves and compares all non-maintenance dist-tags (e.g., `latest`) to ensure they remain unchanged.
  - Updated README to document the new tag and explain why `v1` cannot be used.

<sup>Written for commit 55d18fae5e86678fbc7013cacea0a2c542742ee7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

