### PR TITLE
fix(inspector): remove local chat URL from dev script

### DIFF
--- a/libraries/typescript/packages/inspector/package.json
+++ b/libraries/typescript/packages/inspector/package.json
@@ -39,7 +39,7 @@
     "dist"
   ],
   "scripts": {
-    "dev": "rimraf node_modules/.vite && VITE_MANUFACT_CHAT_URL=${VITE_MANUFACT_CHAT_URL:-http://localhost:8000/api/v1/inspector/chat/stream} vite --strictPort",
+    "dev": "rimraf node_modules/.vite && vite --strictPort",
     "dev:client": "pnpm run dev",
     "dev:server": "VITE_DEV=true tsx watch src/server/server.ts",
     "dev:standalone": "tsx watch src/server/server.ts",


### PR DESCRIPTION
## Summary

- remove the hard-coded `localhost:8000` Manufact chat URL fallback from the Inspector `dev` script
- allow local Vite development to use the existing hosted Manufact fallback when no environment override is supplied

## Why

The dev-script fallback was a leftover from local Manufact backend development. When that backend was not running, the Inspector still derived its OAuth discovery endpoint from `localhost:8000`, causing the Sign in action to fail with `Failed to fetch`.

Developers can still explicitly set `VITE_MANUFACT_CHAT_URL` or `MANUFACT_CHAT_URL` when they need a custom or local backend.

## Validation

- package JSON parsed successfully
- repository pre-commit checks passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the hard-coded local chat URL from the Inspector dev script so Vite uses the hosted Manufact default unless overridden. This prevents sign-in failures when the local backend isn’t running.

- **Bug Fixes**
  - Dev script no longer forces a local URL; uses hosted default unless `VITE_MANUFACT_CHAT_URL` or `MANUFACT_CHAT_URL` is set.
  - Fixes OAuth discovery/sign-in failing with “Failed to fetch” during local development without a running backend.

<sup>Written for commit 9702d33da2faecb100c562c52731c2a2d201e889. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

