### PR TITLE
fix(ci): pin ruff in python-lint so releases cannot change the check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ruff
+          # Pinned so a new ruff release cannot change what this job checks.
+          # 0.16.0 began formatting fenced code blocks inside Markdown, which
+          # turned every libraries/python PR red on README examples that were
+          # never covered before. Bump deliberately, alongside any reformat.
+          pip install ruff==0.15.22
       - name: Lint with ruff
         run: |
           ruff check .


### PR DESCRIPTION
## Problem

`python-lint` installs ruff unpinned:

```yaml
pip install ruff
```

so the job always resolves to the newest release. ruff **0.16.0** began formatting fenced code blocks inside Markdown, which pulled `libraries/python/README.md` into `ruff format --check .` for the first time. That README's quickstart examples were never formatted that way, so the job now fails on **every PR touching `libraries/python`**, whatever the change is.

Reproducible on a clean checkout of current main, no PR changes involved:

```
cd libraries/python
uvx ruff@0.16.0  format --check .   # 1 file would be reformatted, 228 files already formatted
uvx ruff@0.15.22 format --check .   # 224 files already formatted
```

The version difference is the whole failure. Live examples: #1856 (Python 3.13/3.14 support) and #1996 both show `python-lint` red for this reason, on the README rather than on anything either PR touches.

## Change

Pin to `ruff==0.15.22`, the newest release that passes both `ruff check .` and `ruff format --check .` on current main, with a comment explaining why the pin exists.

This matches how the rest of the repo already handles tool versions. `.pre-commit-config.yaml` pins `ruff-pre-commit` to `v0.3.2`, and CI pins pnpm to 10.6.1 and Node to 20. python-lint was the odd one out.

## Why pin rather than reformat the README

Running `ruff format` on the README collapses readable multi-line examples into single long lines, for instance the `config = {...}` dict in the quickstart becomes one 100+ character line. That seemed like a docs regression to make on your behalf, and it is a separate decision from getting CI reproducible again.

Two alternatives if you would rather go a different way, happy to switch this PR to either:

1. **Scope CI to Python files.** `.pre-commit-config.yaml` already limits both ruff hooks to `^libraries/python/.*\.py$` with `types: [python]`, while CI checks `.`, so the two disagree about what ruff is meant to cover. Aligning CI to Python files would fix this class of drift permanently rather than until the next bump.
2. **Adopt 0.16.0 and reformat**, accepting the Markdown reformat as intended.

## Verification

Ran the exact job steps locally at the pinned version against current main:

```
uvx ruff@0.15.22 check .          # All checks passed!
uvx ruff@0.15.22 format --check . # 224 files already formatted
```

`ci.yml` parses as valid YAML. No source or docs files touched.

Refs #1856

---
Freshman dev here, still learning this codebase. I used Claude Code to help investigate and draft this, and reproduced the version difference myself before filing. Please push back on anything off and I will fix it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pinned `ruff` to `0.15.22` in the `python-lint` CI job to make linting reproducible and prevent new releases from changing what the check covers. This avoids failures from `ruff` 0.16.0 formatting fenced Markdown code blocks, which pulled `libraries/python/README.md` into `ruff format --check .`.

<sup>Written for commit 76895efbbf8fa884e71603963357bcc9e7e0c799. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2069?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

