### PR TITLE
fix: normalize npm JSON responses in v1 publisher

### DIFF
--- a/libraries/typescript/scripts/v1-release.mjs
+++ b/libraries/typescript/scripts/v1-release.mjs
@@ -44,7 +44,9 @@ function npmJson(args, fallback) {
   });
   if (result.status !== 0) return fallback;
   const output = result.stdout.trim();
-  return output ? JSON.parse(output) : fallback;
+  if (!output) return fallback;
+  const parsed = JSON.parse(output);
+  return Array.isArray(parsed) && parsed.length === 1 ? parsed[0] : parsed;
 }
 
 function manifestAt(revision, relativePath) {


### PR DESCRIPTION
npm 11 can return single-result JSON as a one-element array. Normalize that shape before registry verification.\n\nThe current recovery plan marks CLI 3.6.7 as already published and selects Inspector 12.0.6 plus mcp-use 1.34.6 as still unpublished, so rerunning cannot republish CLI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize `npm` JSON output in the v1 publisher to handle npm 11 returning a one-item array for single results. This ensures registry verification gets the expected object and prevents incorrect publish decisions on reruns.

<sup>Written for commit 17e66e21f6d5cf324ec2debd68a8f0f734f384ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2071?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

