### PR TITLE
fix: parse pnpm pack lifecycle output in v1 publisher

### DIFF
--- a/libraries/typescript/scripts/v1-release.mjs
+++ b/libraries/typescript/scripts/v1-release.mjs
@@ -51,7 +51,9 @@ function npmJson(args, fallback) {
 
 function packJson(output) {
   const objectStart = output.lastIndexOf("\n{");
-  return JSON.parse(objectStart === -1 ? output : output.slice(objectStart + 1));
+  return JSON.parse(
+    objectStart === -1 ? output : output.slice(objectStart + 1)
+  );
 }
 
 function manifestAt(revision, relativePath) {

--- a/libraries/typescript/scripts/v1-release.mjs
+++ b/libraries/typescript/scripts/v1-release.mjs
@@ -49,6 +49,11 @@ function npmJson(args, fallback) {
   return Array.isArray(parsed) && parsed.length === 1 ? parsed[0] : parsed;
 }
 
+function packJson(output) {
+  const objectStart = output.lastIndexOf("\n{");
+  return JSON.parse(objectStart === -1 ? output : output.slice(objectStart + 1));
+}
+
 function manifestAt(revision, relativePath) {
   const result = spawnSync(
     "git",
@@ -230,7 +235,7 @@ async function publishPlan() {
   try {
     for (const release of releases) {
       if (!release.published) {
-        const packed = JSON.parse(
+        const packed = packJson(
           run("pnpm", [
             "--filter",
             release.name,


### PR DESCRIPTION
A package prepare script can write lifecycle output before pnpm's final JSON pack result. Parse the trailing JSON object rather than the entire mixed stream.\n\nThe recovery plan now verifies CLI 3.6.7 and Inspector 12.0.6 as already published, with only mcp-use 1.34.6 still unpublished.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `pnpm pack` parsing in the v1 publisher by reading only the final JSON object. This prevents parse errors from prepare-script logs and restores reliable publishing.

- **Bug Fixes**
  - Added a `packJson()` helper to parse the trailing JSON from mixed `pnpm pack` output.
  - Recovery plan: `CLI 3.6.7` and `Inspector 12.0.6` are confirmed published; only `mcp-use 1.34.6` remains unpublished.

- **Refactors**
  - Formatted the v1 publisher script for consistency; no functional changes.

<sup>Written for commit 812a80de2d49a5301a24f7f9653bdc1f8d8dae18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2072?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

