### PR TITLE
fix: scan trailing pnpm pack JSON in v1 publisher

### DIFF
--- a/libraries/typescript/scripts/v1-release.mjs
+++ b/libraries/typescript/scripts/v1-release.mjs
@@ -36,6 +36,10 @@ function run(command, args, options = {}) {
   return result.stdout.trim();
 }
 
+function singleJsonValue(parsed) {
+  return Array.isArray(parsed) && parsed.length === 1 ? parsed[0] : parsed;
+}
+
 function npmJson(args, fallback) {
   const result = spawnSync("npm", args, {
     cwd: root,
@@ -45,15 +49,23 @@ function npmJson(args, fallback) {
   if (result.status !== 0) return fallback;
   const output = result.stdout.trim();
   if (!output) return fallback;
-  const parsed = JSON.parse(output);
-  return Array.isArray(parsed) && parsed.length === 1 ? parsed[0] : parsed;
+  return singleJsonValue(JSON.parse(output));
 }
 
 function packJson(output) {
-  const objectStart = output.lastIndexOf("\n{");
-  return JSON.parse(
-    objectStart === -1 ? output : output.slice(objectStart + 1)
-  );
+  const lineStarts = [0];
+  for (let index = output.indexOf("\n"); index !== -1; ) {
+    lineStarts.push(index + 1);
+    index = output.indexOf("\n", index + 1);
+  }
+  for (const start of lineStarts.reverse()) {
+    try {
+      return singleJsonValue(JSON.parse(output.slice(start).trim()));
+    } catch {
+      // Lifecycle output may precede pnpm's final JSON result.
+    }
+  }
+  throw new Error("pnpm pack did not produce a trailing JSON result");
 }
 
 function manifestAt(revision, relativePath) {


### PR DESCRIPTION
Handle both object and one-item array pack metadata after multiline lifecycle output. Package name/version identity checks remain unchanged.\n\nValidated both output shapes locally. The live recovery plan continues to mark CLI 3.6.7 and Inspector 12.0.6 as published, with only mcp-use 1.34.6 pending.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix v1 publisher parsing of `pnpm pack` output. We now reliably read the final JSON result (object or single-item array) even when lifecycle logs come before it.

- Bug Fixes
  - Parse from the end of `pnpm pack` output, trying each line start until JSON parses.
  - Normalize parsed value via `singleJsonValue`; also reused in `npmJson`.
  - Keep package name/version identity checks unchanged.

<sup>Written for commit 8a9cba4932e7daea5c3747a4bf47502d9e9c62bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

