### PR TITLE
fix: disable pack lifecycle scripts in v1 publisher

### DIFF
--- a/libraries/typescript/scripts/v1-release.mjs
+++ b/libraries/typescript/scripts/v1-release.mjs
@@ -251,6 +251,7 @@ async function publishPlan() {
       if (!release.published) {
         const packed = packJson(
           run("pnpm", [
+            "--config.ignore-scripts=true",
             "--filter",
             release.name,
             "pack",


### PR DESCRIPTION
The release job already builds all packages before packing. Disable pnpm pack lifecycle scripts so prepare output cannot replace the JSON pack metadata.\n\nValidated with pnpm 10.30.0 against mcp-use. The live recovery plan has only mcp-use 1.34.6 unpublished; CLI and Inspector remain verification-only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable pack lifecycle scripts in the v1 publisher by passing `--config.ignore-scripts=true` to `pnpm pack`. This prevents `prepare` scripts from overwriting JSON pack metadata, since builds already happen in the release job.

<sup>Written for commit f3e4a7bbfc0cc480838ea0b55996eebecabf2fcc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2074?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

