### PR TITLE
fix(server): bind OAuth proxy registrations to redirect URIs

### DIFF
--- a/docs/typescript/api-reference/server/auth-providers.mdx
+++ b/docs/typescript/api-reference/server/auth-providers.mdx
@@ -14,7 +14,7 @@ These factory functions build the `oauth` value you pass to [`new MCPServer({ ..
 There are two integration modes:
 
 - **DCR-direct providers** (`oauthAuth0Provider`, `oauthBetterAuthProvider`, `oauthClerkProvider`, `oauthKeycloakProvider`, `oauthSupabaseProvider`, `oauthWorkOSProvider`, `oauthCustomProvider`). The MCP server proxies metadata discovery to the upstream authorization server and verifies tokens. Clients communicate directly with the upstream for authorize, token, and register.
-- **Proxy mode** (`oauthProxy`) for providers without Dynamic Client Registration support (Google, GitHub, Okta, Microsoft Entra ID, and enterprise IdPs). The server mediates the flow: it exposes a `/register` endpoint returning the configured `clientId`, injects `clientId`/`clientSecret` at token exchange, and passes upstream tokens through without minting its own.
+- **Proxy mode** (`oauthProxy`) for providers without Dynamic Client Registration support (Google, GitHub, Okta, Microsoft Entra ID, and enterprise IdPs). The server mediates the flow: it issues local public client registrations bound to their redirect URIs, injects the private upstream `clientId`/`clientSecret` at token exchange, and passes upstream tokens through without minting its own.
 
 All factories import from `mcp-use/server`.
 
@@ -324,7 +324,7 @@ Create an OAuth proxy for providers without Dynamic Client Registration.
 import { oauthProxy, jwksVerifier } from "mcp-use/server"
 ```
 
-Builds an `OAuthProxy` for providers that lack DCR support (Google OAuth, GitHub OAuth, Okta, Microsoft Entra ID, and enterprise IdPs). The proxy exposes a `/register` endpoint that returns the configured `clientId`, injects `clientId`/`clientSecret` at token exchange, verifies tokens via the supplied `verifyToken` function, and passes upstream tokens through without minting its own. `scopes` defaults to `["openid", "email", "profile"]` and `grantTypes` defaults to `["authorization_code", "refresh_token"]`. When `getUserInfo` is omitted, a default extractor reads the standard OIDC claims (`sub`, `email`, `name`, `picture`) and splits the `scope` claim into `scopes`.
+Builds an `OAuthProxy` for providers that lack DCR support (Google OAuth, GitHub OAuth, Okta, Microsoft Entra ID, and enterprise IdPs). The proxy exposes a `/register` endpoint that issues a signed local public client ID, validates exact registered redirect URIs at `/authorize`, injects the private upstream `clientId`/`clientSecret` at token exchange, verifies tokens via the supplied `verifyToken` function, and passes upstream tokens through without minting its own. `scopes` defaults to `["openid", "email", "profile"]` and `grantTypes` defaults to `["authorization_code", "refresh_token"]`. When `getUserInfo` is omitted, a default extractor reads the standard OIDC claims (`sub`, `email`, `name`, `picture`) and splits the `scope` claim into `scopes`.
 
 Throws `Error` if any of `authEndpoint`, `tokenEndpoint`, `issuer`, `clientId`, or `verifyToken` is missing. The verifyToken error message points you to `jwksVerifier()` for JWT/JWKS providers.
 
@@ -617,12 +617,13 @@ The proxy-mode provider returned by `oauthProxy`.
 import type { OAuthProxy } from "mcp-use/server"
 ```
 
-Extends `OAuthProvider` with proxy-specific fields for providers without DCR support. Implements the full provider interface (the getter methods plus `verifyToken`/`getUserInfo`) and adds a `type` discriminator, pre-registered client credentials, and optional extra authorize params. The proxy exposes a `/register` endpoint returning the configured `clientId`, injects `clientId`/`clientSecret` at token exchange, and passes upstream JWTs through without minting tokens.
+Extends `OAuthProvider` with proxy-specific fields for providers without DCR support. Implements the full provider interface (the getter methods plus `verifyToken`/`getUserInfo`) and adds a `type` discriminator, pre-registered client credentials, and optional extra authorize params. The proxy exposes a `/register` endpoint that issues local public client IDs bound to the client's redirect URIs, keeps the configured upstream credentials private, injects them at token exchange, and passes upstream JWTs through without minting tokens.
 
 **Properties**
 ><ParamField body="type" type='"proxy"' required="True" >   Discriminator used to detect proxy providers in the provider union. </ParamField>
 ><ParamField body="clientId" type="string" required="True" >   Pre-registered OAuth client ID. </ParamField>
 ><ParamField body="clientSecret" type="string" >   Pre-registered OAuth client secret (optional for public clients). </ParamField>
+><ParamField body="registrationSecret" type="string" >   Secret used to sign stateless local client registrations. Defaults to a key derived from `clientSecret`; set it explicitly for upstream public clients that must work across restarts or multiple instances. </ParamField>
 ><ParamField body="extraAuthorizeParams" type="Record<string, string>" >   Extra parameters appended to authorize requests. </ParamField>
 
 **Signature**
@@ -666,6 +667,7 @@ interface OAuthProxyConfig {
   verifyToken: VerifyToken
   clientId: string
   clientSecret?: string
+  registrationSecret?: string
   scopes?: string[]
   grantTypes?: string[]
   extraAuthorizeParams?: Record<string, string>

--- a/docs/typescript/server/authentication/providers/oauth-proxy.mdx
+++ b/docs/typescript/server/authentication/providers/oauth-proxy.mdx
@@ -94,15 +94,20 @@ Use `jwksVerifier` only for providers that issue JWT access tokens and publish a
 In proxy mode, the MCP server acts as the OAuth-facing server for MCP clients.
 
 1. The MCP client calls the MCP server's `/register` endpoint.
-2. The MCP server returns the pre-registered upstream `clientId`.
+2. The MCP server issues a local public `client_id` bound to the client's registered redirect URIs. The upstream client credentials remain private.
 3. The client starts PKCE authorization through the MCP server's `/authorize` endpoint.
-4. The upstream provider redirects to the MCP server's `/oauth/callback`.
+4. The MCP server verifies that the authorization redirect exactly matches the local client registration, then replaces it with the MCP server's `/oauth/callback` before redirecting upstream.
 5. The MCP server forwards the authorization code to the client's original redirect URI.
 6. During token exchange, the MCP server injects the upstream `clientId` and `clientSecret`.
 7. The client calls `/mcp/*` with the upstream access token.
 8. The MCP server verifies the token with your `verifyToken` function.
 
 The proxy passes upstream tokens through. It does not mint its own access tokens.
+
+When the upstream application has a `clientSecret`, `oauthProxy` derives the
+local-registration signing key from it, so registrations work across restarts
+and server instances. For an upstream public client without a secret, set
+`registrationSecret` to the same private value on every server instance.
 
 ## Handle opaque tokens
 

--- a/libraries/typescript/.changeset/fix-proxied-oauth-resource.md
+++ b/libraries/typescript/.changeset/fix-proxied-oauth-resource.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Fix proxied browser OAuth resource validation and surface discovery failures immediately instead of waiting for a popup timeout.

--- a/libraries/typescript/.changeset/pre.json
+++ b/libraries/typescript/.changeset/pre.json
@@ -7,5 +7,7 @@
     "@mcp-use/inspector": "12.0.4",
     "mcp-use": "1.34.4"
   },
-  "changesets": []
+  "changesets": [
+    "fix-proxied-oauth-resource"
+  ]
 }

--- a/libraries/typescript/.changeset/pre.json
+++ b/libraries/typescript/.changeset/pre.json
@@ -1,0 +1,11 @@
+{
+  "mode": "pre",
+  "tag": "canary",
+  "initialVersions": {
+    "@mcp-use/cli": "3.6.5",
+    "create-mcp-use-app": "0.14.17",
+    "@mcp-use/inspector": "12.0.4",
+    "mcp-use": "1.34.4"
+  },
+  "changesets": []
+}

--- a/libraries/typescript/.changeset/signed-proxy-registrations.md
+++ b/libraries/typescript/.changeset/signed-proxy-registrations.md
@@ -1,0 +1,8 @@
+---
+"mcp-use": patch
+---
+
+Fix `oauthProxy` Dynamic Client Registration by issuing local public client IDs,
+binding authorization redirects to the registered URIs, keeping upstream client
+credentials private, and continuing to send only the MCP server callback URI to
+the upstream provider.

--- a/libraries/typescript/packages/cli/CHANGELOG.md
+++ b/libraries/typescript/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @mcp-use/cli
 
+## 3.6.6-canary.0
+
+### Patch Changes
+
+- Updated dependencies [de5ff9c]
+  - mcp-use@1.34.5-canary.0
+  - @mcp-use/inspector@12.0.5-canary.0
+
 ## 3.6.5
 
 ### Patch Changes

--- a/libraries/typescript/packages/cli/package.json
+++ b/libraries/typescript/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-use/cli",
   "type": "module",
-  "version": "3.6.5",
+  "version": "3.6.6-canary.0",
   "description": "The mcp-use CLI is a tool for building and deploying MCP servers with support for ChatGPT Apps, Code Mode, OAuth, Notifications, Sampling, Observability and more.",
   "author": "mcp-use, Inc.",
   "license": "MIT",

--- a/libraries/typescript/packages/inspector/CHANGELOG.md
+++ b/libraries/typescript/packages/inspector/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @mcp-use/inspector
 
+## 12.0.5-canary.0
+
+### Patch Changes
+
+- Updated dependencies [de5ff9c]
+  - mcp-use@1.34.5-canary.0
+
 ## 12.0.4
 
 ### Patch Changes

--- a/libraries/typescript/packages/inspector/package.json
+++ b/libraries/typescript/packages/inspector/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-use/inspector",
   "type": "module",
-  "version": "12.0.4",
+  "version": "12.0.5-canary.0",
   "description": "MCP Inspector - A tool for inspecting and debugging MCP servers",
   "author": "",
   "license": "MIT",
@@ -80,7 +80,7 @@
   },
   "peerDependencies": {
     "express": "^4.21.2 || ^5.0.0",
-    "mcp-use": ">=1.34.4-canary.0",
+    "mcp-use": ">=1.34.5-canary.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
     "react-router": "^7.12.0"

--- a/libraries/typescript/packages/mcp-use/CHANGELOG.md
+++ b/libraries/typescript/packages/mcp-use/CHANGELOG.md
@@ -1,5 +1,13 @@
 # mcp-use
 
+## 1.34.5-canary.0
+
+### Patch Changes
+
+- de5ff9c: Fix proxied browser OAuth resource validation and surface discovery failures immediately instead of waiting for a popup timeout.
+  - @mcp-use/cli@3.6.6-canary.0
+  - @mcp-use/inspector@12.0.5-canary.0
+
 ## 1.34.4
 
 ### Patch Changes

--- a/libraries/typescript/packages/mcp-use/package.json
+++ b/libraries/typescript/packages/mcp-use/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-use",
   "type": "module",
-  "version": "1.34.4",
+  "version": "1.34.5-canary.0",
   "packageManager": "pnpm@10.26.0+sha512.3b3f6c725ebe712506c0ab1ad4133cf86b1f4b687effce62a9b38b4d72e3954242e643190fc51fa1642949c735f403debd44f5cb0edd657abe63a8b6a7e1e402",
   "description": "Opinionated MCP Framework for TypeScript (@modelcontextprotocol/sdk compatible) - Build MCP Agents, Clients and Servers with support for ChatGPT Apps, Code Mode, OAuth, Notifications, Sampling, Observability and more.",
   "author": "mcp-use, Inc.",

--- a/libraries/typescript/packages/mcp-use/src/auth/browser-provider.ts
+++ b/libraries/typescript/packages/mcp-use/src/auth/browser-provider.ts
@@ -1,5 +1,9 @@
 // browser-provider.ts
 import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
+import {
+  checkResourceAllowed,
+  resourceUrlFromServerUrl,
+} from "@modelcontextprotocol/sdk/shared/auth-utils.js";
 import type {
   OAuthClientInformation,
   OAuthClientMetadata,
@@ -389,6 +393,60 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
     scope: "all" | "client" | "tokens" | "verifier"
   ): Promise<void> {
     return this.session.invalidateCredentials(scope);
+  }
+
+  /**
+   * Validate the protected resource discovered through the OAuth proxy.
+   *
+   * The proxy rewrites protected-resource metadata to the MCP connection URL
+   * so transport-anchored discovery remains valid. Manual authentication is
+   * anchored on the upstream MCP URL instead, so accept that rewrite and
+   * return the original upstream resource that the authorization server
+   * protects.
+   */
+  async validateResourceURL(
+    serverUrl: string | URL,
+    resource?: string
+  ): Promise<URL | undefined> {
+    if (!resource) return undefined;
+
+    const requestedResource = resourceUrlFromServerUrl(serverUrl);
+    if (
+      checkResourceAllowed({
+        requestedResource,
+        configuredResource: resource,
+      })
+    ) {
+      return new URL(resource);
+    }
+
+    const isConnectionResource =
+      this.connectionUrl &&
+      checkResourceAllowed({
+        requestedResource: resourceUrlFromServerUrl(this.connectionUrl),
+        configuredResource: resource,
+      });
+
+    if (isConnectionResource) {
+      const upstreamResource = resourceUrlFromServerUrl(
+        this._lastOriginalResource ?? this.serverUrl
+      );
+
+      // `_original_resource` comes from a proxied response. Never return it
+      // unless it is also valid for the upstream MCP URL supplied to auth().
+      if (
+        checkResourceAllowed({
+          requestedResource,
+          configuredResource: upstreamResource,
+        })
+      ) {
+        return upstreamResource;
+      }
+    }
+
+    throw new Error(
+      `Protected resource ${resource} does not match expected ${requestedResource} (or origin)`
+    );
   }
 
   /**

--- a/libraries/typescript/packages/mcp-use/src/react/useMcp.ts
+++ b/libraries/typescript/packages/mcp-use/src/react/useMcp.ts
@@ -1631,6 +1631,7 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
         const parsedUrl = new URL(url);
         const baseUrl =
           parsedUrl.origin + parsedUrl.pathname.replace(/\/+$/, "");
+        let authFlowError: Error | null = null;
         try {
           await auth(freshAuthProvider, {
             serverUrl: baseUrl,
@@ -1638,17 +1639,29 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
           });
           addLog("info", "OAuth flow completed (tokens obtained)");
         } catch (err: unknown) {
-          // This is expected when auth opens popup/redirect - the flow continues there
+          // This may be the expected popup/redirect handoff, or a real
+          // discovery/validation failure. The popup handle and stored auth URL
+          // below distinguish the two cases.
+          authFlowError = err instanceof Error ? err : new Error(String(err));
           addLog(
             "info",
             "OAuth flow initiated (popup/redirect):",
-            err instanceof Error ? err.message : "Redirecting..."
+            authFlowError.message
           );
         }
 
         // Update authUrl with the new URL from the fresh provider
         // This is critical for the fallback link when popup is blocked
         const newAuthUrl = freshAuthProvider.getLastAttemptedAuthUrl?.();
+
+        if (authFlowError && !capturedPopup && !newAuthUrl) {
+          failConnection(
+            `Authentication failed: ${authFlowError.message}`,
+            authFlowError
+          );
+          return;
+        }
+
         if (newAuthUrl) {
           setAuthUrl(newAuthUrl);
           addLog("info", "Updated auth URL for fallback:", newAuthUrl);

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/oauth-proxy.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/oauth-proxy.ts
@@ -9,8 +9,104 @@
  * IdPs that require pre-registered applications.
  */
 
-import { jwtVerify, createRemoteJWKSet } from "jose";
+import { SignJWT, jwtVerify, createRemoteJWKSet } from "jose";
 import type { OAuthProxy, UserInfo } from "./providers/types.js";
+
+const CLIENT_REGISTRATION_ISSUER = "urn:mcp-use:oauth-proxy";
+const CLIENT_REGISTRATION_KEY_CONTEXT =
+  "mcp-use/oauth-proxy/client-registration/v1";
+
+interface OAuthProxyClientRegistration {
+  redirectUris: string[];
+}
+
+const clientRegistrationKeys = new WeakMap<OAuthProxy, Promise<Uint8Array>>();
+
+async function deriveClientRegistrationKey(
+  secret: string | Uint8Array,
+  upstreamClientId: string
+): Promise<Uint8Array> {
+  const secretBytes =
+    typeof secret === "string" ? new TextEncoder().encode(secret) : secret;
+  const contextBytes = new TextEncoder().encode(
+    `${CLIENT_REGISTRATION_KEY_CONTEXT}\0${upstreamClientId}\0`
+  );
+  const keyMaterial = new Uint8Array(contextBytes.length + secretBytes.length);
+  keyMaterial.set(contextBytes);
+  keyMaterial.set(secretBytes, contextBytes.length);
+  return new Uint8Array(await crypto.subtle.digest("SHA-256", keyMaterial));
+}
+
+function getClientRegistrationKey(oauth: OAuthProxy): Promise<Uint8Array> {
+  const existing = clientRegistrationKeys.get(oauth);
+  if (existing) return existing;
+
+  const ephemeralSecret = crypto.getRandomValues(new Uint8Array(32));
+  const key = deriveClientRegistrationKey(
+    oauth.clientSecret ?? ephemeralSecret,
+    oauth.clientId
+  );
+  clientRegistrationKeys.set(oauth, key);
+  return key;
+}
+
+/**
+ * Issue a signed local client ID whose claims contain the redirect
+ * URIs accepted during Dynamic Client Registration.
+ *
+ * This keeps proxy registration stateless and prevents the configured
+ * upstream client ID from being exposed as the local public client ID.
+ * @internal
+ */
+export async function createOAuthProxyClientRegistration(
+  oauth: OAuthProxy,
+  baseUrl: string,
+  redirectUris: string[]
+): Promise<string> {
+  return new SignJWT({ redirect_uris: redirectUris })
+    .setProtectedHeader({
+      alg: "HS256",
+      typ: "oauth-client-registration+jwt",
+    })
+    .setIssuer(CLIENT_REGISTRATION_ISSUER)
+    .setAudience(baseUrl)
+    .setIssuedAt()
+    .setJti(crypto.randomUUID())
+    .sign(await getClientRegistrationKey(oauth));
+}
+
+/**
+ * Verify and decode a local proxy client ID.
+ * @internal
+ */
+export async function verifyOAuthProxyClientRegistration(
+  oauth: OAuthProxy,
+  baseUrl: string,
+  clientId: string
+): Promise<OAuthProxyClientRegistration | null> {
+  try {
+    const { payload } = await jwtVerify(
+      clientId,
+      await getClientRegistrationKey(oauth),
+      {
+        algorithms: ["HS256"],
+        issuer: CLIENT_REGISTRATION_ISSUER,
+        audience: baseUrl,
+      }
+    );
+    const redirectUris = payload.redirect_uris;
+    if (
+      !Array.isArray(redirectUris) ||
+      redirectUris.length === 0 ||
+      redirectUris.some((value) => typeof value !== "string")
+    ) {
+      return null;
+    }
+    return { redirectUris };
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Token verification function.
@@ -59,6 +155,15 @@ export interface OAuthProxyConfig {
    * Pre-registered OAuth client secret (optional for public clients)
    */
   clientSecret?: string;
+
+  /**
+   * Secret used to sign stateless local Dynamic Client Registration records.
+   *
+   * Defaults to a key derived from `clientSecret`. Set this explicitly when
+   * the upstream client has no secret and registrations must survive restarts
+   * or validate across multiple server instances.
+   */
+  registrationSecret?: string;
 
   /**
    * OAuth scopes to request
@@ -182,7 +287,8 @@ function defaultGetUserInfo(payload: Record<string, unknown>): UserInfo {
  * Create an OAuth proxy for providers without DCR support
  *
  * The proxy:
- * - Exposes a /register endpoint that returns the configured clientId
+ * - Exposes a /register endpoint that issues a signed local public client ID
+ * - Binds each local client ID to its registered redirect URIs
  * - Injects clientId/clientSecret at token exchange
  * - Verifies tokens via the supplied `verifyToken` function
  * - Passes through upstream tokens (no token minting)
@@ -230,6 +336,9 @@ export function oauthProxy(config: OAuthProxyConfig): OAuthProxy {
       "oauthProxy: verifyToken is required (use `jwksVerifier()` for JWT/JWKS providers)"
     );
   }
+  if (config.registrationSecret !== undefined && !config.registrationSecret) {
+    throw new Error("oauthProxy: registrationSecret must not be empty");
+  }
 
   const scopes = config.scopes ?? ["openid", "email", "profile"];
   const grantTypes = config.grantTypes ?? [
@@ -238,7 +347,7 @@ export function oauthProxy(config: OAuthProxyConfig): OAuthProxy {
   ];
   const customGetUserInfo = config.getUserInfo ?? defaultGetUserInfo;
 
-  return {
+  const proxy: OAuthProxy = {
     // Proxy-specific fields
     type: "proxy",
     clientId: config.clientId,
@@ -258,4 +367,15 @@ export function oauthProxy(config: OAuthProxyConfig): OAuthProxy {
       return customGetUserInfo(payload);
     },
   };
+
+  const registrationSecret =
+    config.registrationSecret ??
+    config.clientSecret ??
+    crypto.getRandomValues(new Uint8Array(32));
+  clientRegistrationKeys.set(
+    proxy,
+    deriveClientRegistrationKey(registrationSecret, config.clientId)
+  );
+
+  return proxy;
 }

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/providers/types.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/providers/types.ts
@@ -79,7 +79,8 @@ export interface OAuthProvider {
  * OAuthProxy:
  * - Implements the full OAuthProvider interface (getter methods)
  * - Adds proxy-specific fields: type, clientId, clientSecret, extraAuthorizeParams
- * - Exposes /register endpoint returning the configured clientId
+ * - Exposes /register endpoint issuing a signed local public client ID
+ * - Keeps the configured upstream client credentials private
  * - Injects clientId/clientSecret at token exchange
  * - Passes through upstream JWT tokens (no token minting)
  */

--- a/libraries/typescript/packages/mcp-use/src/server/oauth/routes.ts
+++ b/libraries/typescript/packages/mcp-use/src/server/oauth/routes.ts
@@ -9,7 +9,8 @@
  *
  * 2. **Proxy mode (OAuthProxy):** For providers that don't support DCR
  *    (e.g., Google, GitHub). The MCP server:
- *    - Exposes /register returning the configured clientId
+ *    - Exposes /register issuing local public client registrations
+ *    - Binds /authorize redirects to those registrations
  *    - Redirects /authorize to upstream, brokering the callback through its
  *      own /oauth/callback so only `<baseUrl>/oauth/callback` needs to be
  *      registered with the upstream provider
@@ -20,6 +21,10 @@
 import type { Context, Hono, Next } from "hono";
 import { cors } from "hono/cors";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
+import {
+  createOAuthProxyClientRegistration,
+  verifyOAuthProxyClientRegistration,
+} from "./oauth-proxy.js";
 import type { OAuthProvider, OAuthProxy } from "./providers/types.js";
 import {
   buildLocalOAuthAuthorizationServerPath,
@@ -46,6 +51,8 @@ export function isOAuthProxy(
  * stateless — it survives restarts and multi-instance deployments.
  */
 interface CallbackTxn {
+  /** Signed local client registration ID */
+  clientId: string;
   /** Client's original redirect_uri */
   redirectUri: string;
   /** Client's original state, if any */
@@ -79,12 +86,14 @@ function decodeCallbackTxn(value: string): CallbackTxn | null {
   try {
     const parsed = JSON.parse(base64UrlDecode(value));
     if (
+      typeof parsed?.clientId !== "string" ||
       typeof parsed?.redirectUri !== "string" ||
       !isValidRedirectUri(parsed.redirectUri)
     ) {
       return null;
     }
     return {
+      clientId: parsed.clientId,
       redirectUri: parsed.redirectUri,
       state: typeof parsed.state === "string" ? parsed.state : undefined,
     };
@@ -96,7 +105,16 @@ function decodeCallbackTxn(value: string): CallbackTxn | null {
 function isValidRedirectUri(value: string): boolean {
   try {
     const url = new URL(value);
-    return url.protocol === "http:" || url.protocol === "https:";
+    const scheme = url.protocol.slice(0, -1).toLowerCase();
+    if (url.hash) return false;
+    if (
+      ["javascript", "data", "file", "vbscript", "about", "blob"].includes(
+        scheme
+      )
+    ) {
+      return false;
+    }
+    return /^[a-z][a-z0-9+.-]*$/.test(scheme);
   } catch {
     return false;
   }
@@ -152,10 +170,31 @@ function createAuthorizeHandler(
       return c.json(
         {
           error: "invalid_request",
-          error_description: "redirect_uri must be a valid http(s) URL",
+          error_description: "redirect_uri must be a valid absolute URI",
         },
         400
       );
+    }
+
+    if (isOAuthProxy(oauth)) {
+      const registration = await verifyOAuthProxyClientRegistration(
+        oauth,
+        baseUrl,
+        clientId as string
+      );
+      if (
+        !registration ||
+        !registration.redirectUris.includes(redirectUri as string)
+      ) {
+        return c.json(
+          {
+            error: "invalid_request",
+            error_description:
+              "redirect_uri does not match the client registration",
+          },
+          400
+        );
+      }
     }
 
     // Get authorization endpoint - uniform for both provider and proxy
@@ -181,6 +220,7 @@ function createAuthorizeHandler(
       authUrl.searchParams.set(
         "state",
         encodeCallbackTxn({
+          clientId: clientId as string,
           redirectUri: redirectUri as string,
           state: state ? (state as string) : undefined,
         })
@@ -222,10 +262,10 @@ function createAuthorizeHandler(
  *
  * @returns Hono handler that redirects back to the MCP client's callback
  */
-function createCallbackHandler(): (
-  c: Context,
-  next: Next
-) => Promise<Response | void> {
+function createCallbackHandler(
+  oauth: OAuthProxy,
+  baseUrl: string
+): (c: Context, next: Next) => Promise<Response | void> {
   return async (c: Context, next: Next) => {
     const query = c.req.query();
 
@@ -237,6 +277,21 @@ function createCallbackHandler(): (
       // the proxy to handle this redirect, the upstream provider isn't
       // echoing back the `state` the proxy sent at /authorize.
       return next();
+    }
+
+    const registration = await verifyOAuthProxyClientRegistration(
+      oauth,
+      baseUrl,
+      txn.clientId
+    );
+    if (!registration || !registration.redirectUris.includes(txn.redirectUri)) {
+      return c.json(
+        {
+          error: "invalid_request",
+          error_description: "OAuth callback client registration is invalid",
+        },
+        400
+      );
     }
 
     const redirect = new URL(txn.redirectUri);
@@ -361,7 +416,7 @@ function createTokenHandler(
  * - /authorize and /token are dormant (clients reach upstream directly)
  *
  * **Proxy mode (OAuthProxy):**
- * - POST /register - Returns configured clientId (fake DCR endpoint)
+ * - POST /register - Issues a signed local public client ID
  * - GET/POST /authorize - Redirects to upstream, brokering the callback locally
  * - GET /oauth/callback - Receives the upstream redirect and forwards the
  *   code to the MCP client's original redirect_uri
@@ -419,15 +474,15 @@ export function setupOAuthRoutes(
   app.post("/authorize", handleAuthorize);
   app.post("/token", createTokenHandler(oauth, baseUrl));
 
-  // In proxy mode, add /register endpoint that returns the configured clientId
-  // This allows MCP clients to "register" even though the client is pre-registered
+  // In proxy mode, add a local DCR endpoint. The downstream client registration
+  // is separate from the fixed upstream application credentials.
   if (proxyMode) {
     const proxy = oauth as OAuthProxy;
 
     // Brokered upstream callback. This is a top-level browser navigation
     // (no CORS needed) — register `<baseUrl>/oauth/callback` as the only
     // redirect URI on the upstream provider.
-    app.get("/oauth/callback", createCallbackHandler());
+    app.get("/oauth/callback", createCallbackHandler(proxy, baseUrl));
 
     app.use(
       "/register",
@@ -441,19 +496,44 @@ export function setupOAuthRoutes(
 
     app.post("/register", async (c: Context) => {
       const body = await c.req.json().catch(() => ({}));
+      const redirectUris = Array.isArray(body.redirect_uris)
+        ? body.redirect_uris
+        : [];
 
-      // Return a fake registration response with the configured clientId
-      // This satisfies MCP clients that expect DCR to work
+      if (
+        redirectUris.length === 0 ||
+        redirectUris.some(
+          (redirectUri: unknown) =>
+            typeof redirectUri !== "string" || !isValidRedirectUri(redirectUri)
+        )
+      ) {
+        return c.json(
+          {
+            error: "invalid_client_metadata",
+            error_description:
+              "redirect_uris must contain valid absolute URIs without fragments",
+          },
+          400
+        );
+      }
+
+      const localClientId = await createOAuthProxyClientRegistration(
+        proxy,
+        baseUrl,
+        redirectUris
+      );
+
+      // The downstream MCP client is public. The proxy keeps the upstream
+      // confidential credentials private and injects them only when it
+      // forwards the token request.
       return c.json(
         {
-          client_id: proxy.clientId,
+          client_id: localClientId,
           client_name: body.client_name || "MCP Client",
-          redirect_uris: body.redirect_uris || [],
+          redirect_uris: redirectUris,
           grant_types: oauth.getGrantTypesSupported(),
           response_types: ["code"],
-          token_endpoint_auth_method: proxy.clientSecret
-            ? "client_secret_post"
-            : "none",
+          token_endpoint_auth_method: "none",
         },
         201
       );
@@ -461,7 +541,6 @@ export function setupOAuthRoutes(
   }
 
   const synthesizeProxyMetadata = () => {
-    const proxy = oauth as OAuthProxy;
     console.log(`[OAuth] Returning proxy mode metadata`);
 
     return {
@@ -472,9 +551,7 @@ export function setupOAuthRoutes(
       scopes_supported: oauth.getScopesSupported(),
       response_types_supported: ["code"],
       grant_types_supported: oauth.getGrantTypesSupported(),
-      token_endpoint_auth_methods_supported: proxy.clientSecret
-        ? ["client_secret_post", "none"]
-        : ["none"],
+      token_endpoint_auth_methods_supported: ["none"],
       code_challenge_methods_supported: ["S256"],
     };
   };

--- a/libraries/typescript/packages/mcp-use/tests/server/oauth.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/server/oauth.test.ts
@@ -21,6 +21,23 @@ import { oauthCustomProvider } from "../../src/server/oauth/providers.js";
 // the verification path (routes, metadata, registration).
 const stubVerifyToken = async () => ({ payload: {} });
 
+async function registerOAuthProxyClient(
+  baseUrl: string,
+  redirectUris: string[]
+): Promise<{ client_id: string; token_endpoint_auth_method: string }> {
+  const response = await fetch(`${baseUrl}/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      client_name: "Test MCP Client",
+      redirect_uris: redirectUris,
+      token_endpoint_auth_method: "none",
+    }),
+  });
+  expect(response.status).toBe(201);
+  return response.json();
+}
+
 async function listenOnRandomPort(
   app: Hono
 ): Promise<{ baseUrl: string; close: () => void }> {
@@ -70,6 +87,7 @@ describe("server OAuth integration", () => {
     expect(metadata.authorization_endpoint).toBe(`${svc.baseUrl}/authorize`);
     expect(metadata.token_endpoint).toBe(`${svc.baseUrl}/token`);
     expect(metadata.registration_endpoint).toBe(`${svc.baseUrl}/register`);
+    expect(metadata.token_endpoint_auth_methods_supported).toEqual(["none"]);
     // In proxy mode, the issuer is the local server URL
     expect(metadata.issuer).toBe(svc.baseUrl);
   });
@@ -157,12 +175,15 @@ describe("server OAuth integration", () => {
 
     setupOAuthRoutes(app, proxy, svc.baseUrl);
 
+    const clientRedirectUri =
+      "https://client.example.com/inspector/oauth/callback?session=42";
+    const registration = await registerOAuthProxyClient(svc.baseUrl, [
+      clientRedirectUri,
+    ]);
+
     const authorizeUrl = new URL(`${svc.baseUrl}/authorize`);
-    authorizeUrl.searchParams.set("client_id", "dcr-cached-client");
-    authorizeUrl.searchParams.set(
-      "redirect_uri",
-      "https://client.example.com/inspector/oauth/callback?session=42"
-    );
+    authorizeUrl.searchParams.set("client_id", registration.client_id);
+    authorizeUrl.searchParams.set("redirect_uri", clientRedirectUri);
     authorizeUrl.searchParams.set("response_type", "code");
     authorizeUrl.searchParams.set("code_challenge", "challenge-abc");
     authorizeUrl.searchParams.set("code_challenge_method", "S256");
@@ -217,12 +238,14 @@ describe("server OAuth integration", () => {
 
     setupOAuthRoutes(app, proxy, svc.baseUrl);
 
+    const clientRedirectUri = "https://client.example.com/callback";
+    const registration = await registerOAuthProxyClient(svc.baseUrl, [
+      clientRedirectUri,
+    ]);
+
     const authorizeUrl = new URL(`${svc.baseUrl}/authorize`);
-    authorizeUrl.searchParams.set("client_id", "client");
-    authorizeUrl.searchParams.set(
-      "redirect_uri",
-      "https://client.example.com/callback"
-    );
+    authorizeUrl.searchParams.set("client_id", registration.client_id);
+    authorizeUrl.searchParams.set("redirect_uri", clientRedirectUri);
     authorizeUrl.searchParams.set("response_type", "code");
     authorizeUrl.searchParams.set("code_challenge", "challenge");
     authorizeUrl.searchParams.set("state", "client-state");
@@ -604,7 +627,7 @@ describe("server OAuth integration", () => {
     });
   });
 
-  it("returns configured clientId from /register endpoint", async () => {
+  it("returns a local public client registration from /register", async () => {
     const app = new Hono();
 
     const proxy = oauthProxy({
@@ -633,8 +656,201 @@ describe("server OAuth integration", () => {
     expect(response.status).toBe(201);
 
     const registration = await response.json();
-    expect(registration.client_id).toBe("pre-registered-client-id");
+    expect(registration.client_id).not.toBe("pre-registered-client-id");
     expect(registration.client_name).toBe("My MCP Client");
-    expect(registration.token_endpoint_auth_method).toBe("client_secret_post");
+    expect(registration.client_secret).toBeUndefined();
+    expect(registration.token_endpoint_auth_method).toBe("none");
+  });
+
+  it("brokers a dynamically registered MCP client without upstream redirect allowlisting", async () => {
+    const tokenSpy = vi.fn();
+    const upstream = new Hono();
+    upstream.post("/oauth/token", async (c) => {
+      tokenSpy(await c.req.parseBody());
+      return c.json({
+        access_token: "upstream-access-token",
+        token_type: "Bearer",
+      });
+    });
+    const upstreamSvc = await listenOnRandomPort(upstream);
+    closers.push(upstreamSvc.close);
+
+    const app = new Hono();
+
+    const proxy = oauthProxy({
+      issuer: upstreamSvc.baseUrl,
+      authEndpoint: `${upstreamSvc.baseUrl}/oauth/authorize`,
+      tokenEndpoint: `${upstreamSvc.baseUrl}/oauth/token`,
+      clientId: "upstream-pre-registered-client",
+      clientSecret: "upstream-client-secret",
+      verifyToken: stubVerifyToken,
+    });
+
+    const svc = await listenOnRandomPort(app);
+    closers.push(svc.close);
+
+    setupOAuthRoutes(app, proxy, svc.baseUrl);
+
+    const clientRedirectUri =
+      "https://new-mcp-client.example.com/oauth/callback";
+    const registrationResponse = await fetch(`${svc.baseUrl}/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        client_name: "Previously Unknown MCP Client",
+        redirect_uris: [clientRedirectUri],
+        token_endpoint_auth_method: "none",
+      }),
+    });
+
+    expect(registrationResponse.status).toBe(201);
+    const registration = await registrationResponse.json();
+    expect(registration.client_id).not.toBe("upstream-pre-registered-client");
+    expect(registration.client_secret).toBeUndefined();
+    expect(registration.token_endpoint_auth_method).toBe("none");
+
+    const authorizeUrl = new URL(`${svc.baseUrl}/authorize`);
+    authorizeUrl.searchParams.set("client_id", registration.client_id);
+    authorizeUrl.searchParams.set("redirect_uri", clientRedirectUri);
+    authorizeUrl.searchParams.set("response_type", "code");
+    authorizeUrl.searchParams.set("code_challenge", "client-pkce-challenge");
+    authorizeUrl.searchParams.set("code_challenge_method", "S256");
+    authorizeUrl.searchParams.set("state", "client-state");
+
+    const authorizeResponse = await fetch(authorizeUrl, {
+      redirect: "manual",
+    });
+    expect(authorizeResponse.status).toBe(302);
+
+    const upstreamAuthorizeUrl = new URL(
+      authorizeResponse.headers.get("location")!
+    );
+    expect(upstreamAuthorizeUrl.searchParams.get("client_id")).toBe(
+      "upstream-pre-registered-client"
+    );
+    expect(upstreamAuthorizeUrl.searchParams.get("redirect_uri")).toBe(
+      `${svc.baseUrl}/oauth/callback`
+    );
+
+    const callbackUrl = new URL(`${svc.baseUrl}/oauth/callback`);
+    callbackUrl.searchParams.set("code", "upstream-code");
+    callbackUrl.searchParams.set(
+      "state",
+      upstreamAuthorizeUrl.searchParams.get("state")!
+    );
+    const callbackResponse = await fetch(callbackUrl, {
+      redirect: "manual",
+    });
+
+    expect(callbackResponse.status).toBe(302);
+    const finalRedirect = new URL(callbackResponse.headers.get("location")!);
+    expect(finalRedirect.origin + finalRedirect.pathname).toBe(
+      clientRedirectUri
+    );
+    expect(finalRedirect.searchParams.get("code")).toBe("upstream-code");
+    expect(finalRedirect.searchParams.get("state")).toBe("client-state");
+
+    const tokenResponse = await fetch(`${svc.baseUrl}/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        client_id: registration.client_id,
+        code: "upstream-code",
+        code_verifier: "client-pkce-verifier",
+        redirect_uri: clientRedirectUri,
+      }),
+    });
+    expect(tokenResponse.status).toBe(200);
+    expect(await tokenResponse.json()).toMatchObject({
+      access_token: "upstream-access-token",
+    });
+    expect(tokenSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        grant_type: "authorization_code",
+        client_id: "upstream-pre-registered-client",
+        client_secret: "upstream-client-secret",
+        code: "upstream-code",
+        code_verifier: "client-pkce-verifier",
+        redirect_uri: `${svc.baseUrl}/oauth/callback`,
+      })
+    );
+
+    const mismatchedAuthorizeUrl = new URL(authorizeUrl);
+    mismatchedAuthorizeUrl.searchParams.set(
+      "redirect_uri",
+      "https://attacker.example.com/callback"
+    );
+    const mismatchedResponse = await fetch(mismatchedAuthorizeUrl, {
+      redirect: "manual",
+    });
+    expect(mismatchedResponse.status).toBe(400);
+    expect(await mismatchedResponse.json()).toMatchObject({
+      error: "invalid_request",
+    });
+
+    const nativeRedirectUri = "cursor://anysphere.cursor-mcp/oauth/callback";
+    const nativeRegistration = await registerOAuthProxyClient(svc.baseUrl, [
+      nativeRedirectUri,
+    ]);
+    const nativeAuthorizeUrl = new URL(`${svc.baseUrl}/authorize`);
+    nativeAuthorizeUrl.searchParams.set(
+      "client_id",
+      nativeRegistration.client_id
+    );
+    nativeAuthorizeUrl.searchParams.set("redirect_uri", nativeRedirectUri);
+    nativeAuthorizeUrl.searchParams.set("response_type", "code");
+    nativeAuthorizeUrl.searchParams.set(
+      "code_challenge",
+      "native-client-challenge"
+    );
+
+    const nativeAuthorizeResponse = await fetch(nativeAuthorizeUrl, {
+      redirect: "manual",
+    });
+    expect(nativeAuthorizeResponse.status).toBe(302);
+  });
+
+  it("validates stateless registrations across proxy instances", async () => {
+    const baseUrl = "https://mcp.example.com";
+    const createProxy = () =>
+      oauthProxy({
+        issuer: "https://issuer.example.com",
+        authEndpoint: "https://issuer.example.com/oauth/authorize",
+        tokenEndpoint: "https://issuer.example.com/oauth/token",
+        clientId: "upstream-public-client",
+        registrationSecret: "shared-registration-secret",
+        verifyToken: stubVerifyToken,
+      });
+
+    const registrationApp = new Hono();
+    setupOAuthRoutes(registrationApp, createProxy(), baseUrl);
+    const registrationResponse = await registrationApp.request(
+      `${baseUrl}/register`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          client_name: "Distributed MCP Client",
+          redirect_uris: ["https://client.example.com/callback"],
+        }),
+      }
+    );
+    expect(registrationResponse.status).toBe(201);
+    const registration = await registrationResponse.json();
+
+    const authorizationApp = new Hono();
+    setupOAuthRoutes(authorizationApp, createProxy(), baseUrl);
+    const authorizeUrl = new URL(`${baseUrl}/authorize`);
+    authorizeUrl.searchParams.set("client_id", registration.client_id);
+    authorizeUrl.searchParams.set(
+      "redirect_uri",
+      "https://client.example.com/callback"
+    );
+    authorizeUrl.searchParams.set("response_type", "code");
+    authorizeUrl.searchParams.set("code_challenge", "challenge");
+
+    const authorizeResponse = await authorizationApp.request(authorizeUrl);
+    expect(authorizeResponse.status).toBe(302);
   });
 });

--- a/libraries/typescript/packages/mcp-use/tests/unit/auth/browser-provider-resource-validation.test.ts
+++ b/libraries/typescript/packages/mcp-use/tests/unit/auth/browser-provider-resource-validation.test.ts
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BrowserOAuthClientProvider } from "../../../src/auth/browser-provider.js";
+
+const SERVER_URL = "https://www.cubic.dev/api/mcp";
+const CONNECTION_URL = "https://inspector.manufact.com/inspector/api/proxy";
+const PROXY_URL = "https://inspector.manufact.com/inspector/api/oauth";
+
+function makeProvider(options: Record<string, unknown> = {}) {
+  return new BrowserOAuthClientProvider(SERVER_URL, {
+    callbackUrl: "https://app.example.com/oauth/callback",
+    ...options,
+  });
+}
+
+function makeStorage(): Storage {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => values.set(key, String(value)),
+    removeItem: (key: string) => values.delete(key),
+    clear: () => values.clear(),
+    key: (index: number) => Array.from(values.keys())[index] ?? null,
+    get length() {
+      return values.size;
+    },
+  } as Storage;
+}
+
+describe("BrowserOAuthClientProvider.validateResourceURL", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", makeStorage());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("omits the resource when discovery does not provide one", async () => {
+    const provider = makeProvider();
+    await expect(
+      provider.validateResourceURL(SERVER_URL, undefined)
+    ).resolves.toBeUndefined();
+  });
+
+  it("returns a resource allowed for the requested server URL", async () => {
+    const provider = makeProvider();
+    const result = await provider.validateResourceURL(
+      SERVER_URL,
+      "https://www.cubic.dev/api"
+    );
+
+    expect(result?.toString()).toBe("https://www.cubic.dev/api");
+  });
+
+  it("accepts a connection URL rewrite and returns the upstream server resource", async () => {
+    const provider = makeProvider({ connectionUrl: CONNECTION_URL });
+    const result = await provider.validateResourceURL(
+      SERVER_URL,
+      CONNECTION_URL
+    );
+
+    expect(result?.toString()).toBe(SERVER_URL);
+  });
+
+  it("handles a root-path upstream server resource", async () => {
+    const serverUrl = "https://mcp.predictleads.com/";
+    const provider = new BrowserOAuthClientProvider(serverUrl, {
+      callbackUrl: "https://app.example.com/oauth/callback",
+      connectionUrl: CONNECTION_URL,
+    });
+
+    const result = await provider.validateResourceURL(
+      serverUrl,
+      CONNECTION_URL
+    );
+    expect(result?.toString()).toBe(serverUrl);
+  });
+
+  it("returns a validated original resource captured from proxied metadata", async () => {
+    const provider = makeProvider({
+      connectionUrl: CONNECTION_URL,
+      oauthProxyUrl: PROXY_URL,
+    });
+    const baseFetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            resource: CONNECTION_URL,
+            authorization_servers: ["https://as.example.com"],
+            _original_resource: "https://www.cubic.dev/api",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    ) as unknown as typeof fetch;
+
+    await provider.getProxyFetch(baseFetch)!(
+      "https://www.cubic.dev/.well-known/oauth-protected-resource/api/mcp"
+    );
+
+    const result = await provider.validateResourceURL(
+      SERVER_URL,
+      CONNECTION_URL
+    );
+    expect(result?.toString()).toBe("https://www.cubic.dev/api");
+  });
+
+  it("rejects an untrusted original resource returned by the proxy", async () => {
+    const provider = makeProvider({
+      connectionUrl: CONNECTION_URL,
+      oauthProxyUrl: PROXY_URL,
+    });
+    const baseFetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            resource: CONNECTION_URL,
+            authorization_servers: ["https://as.example.com"],
+            _original_resource: "https://evil.example.com/mcp",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    ) as unknown as typeof fetch;
+
+    await provider.getProxyFetch(baseFetch)!(
+      "https://www.cubic.dev/.well-known/oauth-protected-resource/api/mcp"
+    );
+
+    await expect(
+      provider.validateResourceURL(SERVER_URL, CONNECTION_URL)
+    ).rejects.toThrow(/does not match expected/);
+  });
+
+  it("rejects a genuinely foreign discovered resource", async () => {
+    const provider = makeProvider({ connectionUrl: CONNECTION_URL });
+
+    await expect(
+      provider.validateResourceURL(SERVER_URL, "https://evil.example.com/mcp")
+    ).rejects.toThrow(/does not match expected/);
+  });
+});

--- a/libraries/typescript/packages/mcp-use/tests/unit/react/useMcp-auth-flow-error.test.tsx
+++ b/libraries/typescript/packages/mcp-use/tests/unit/react/useMcp-auth-flow-error.test.tsx
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { act, create } from "react-test-renderer";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const auth = vi.fn();
+  const runAuthPopup = vi.fn();
+  const provider = {
+    serverUrl: "https://mcp.example.com/mcp",
+    serverUrlHash: "server-hash",
+    clearStorage: vi.fn().mockReturnValue(0),
+    getLastAttemptedAuthUrl: vi.fn().mockReturnValue(null),
+    getProxyFetch: vi.fn().mockReturnValue(undefined),
+    getKey: vi.fn((suffix: string) => `oauth:${suffix}`),
+    tokens: vi.fn().mockResolvedValue(undefined),
+  };
+  const session = {
+    on: vi.fn(),
+    initialize: vi.fn(),
+  };
+  const client = {
+    addServer: vi.fn(),
+    createSession: vi.fn().mockResolvedValue(session),
+    getSession: vi.fn().mockReturnValue(null),
+    closeSession: vi.fn().mockResolvedValue(undefined),
+    listSessions: vi.fn().mockReturnValue([]),
+  };
+  const createBrowserOAuthProvider = vi.fn(() => ({
+    provider,
+    oauthProxyUrl: "https://inspector.example.com/oauth",
+  }));
+
+  return {
+    auth,
+    runAuthPopup,
+    provider,
+    session,
+    client,
+    createBrowserOAuthProvider,
+  };
+});
+
+vi.mock("@modelcontextprotocol/sdk/client/auth.js", () => ({
+  auth: mocks.auth,
+}));
+
+vi.mock("../../../src/client/browser.js", () => ({
+  BrowserMCPClient: vi.fn(function () {
+    return mocks.client;
+  }),
+}));
+
+vi.mock("../../../src/react/useMcp-helpers.js", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("../../../src/react/useMcp-helpers.js")
+  >()),
+  createBrowserOAuthProvider: mocks.createBrowserOAuthProvider,
+}));
+
+vi.mock("../../../src/auth/popup-runner.js", () => ({
+  runAuthPopup: mocks.runAuthPopup,
+  MCP_AUTH_BROADCAST_CHANNEL: "mcp_auth_callback",
+  MCP_AUTH_CALLBACK_MESSAGE_TYPE: "mcp_auth_callback",
+}));
+
+vi.mock("../../../src/telemetry/telemetry-browser.js", () => ({
+  Tel: {
+    getInstance: () => ({
+      trackUseMcpConnection: vi.fn().mockResolvedValue(undefined),
+      trackUseMcpToolCall: vi.fn().mockResolvedValue(undefined),
+    }),
+  },
+}));
+
+vi.mock("../../../src/utils/favicon-detector.js", () => ({
+  detectFavicon: vi.fn().mockResolvedValue(null),
+}));
+
+function makeStorage(): Storage {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => values.set(key, String(value)),
+    removeItem: (key: string) => values.delete(key),
+    clear: () => values.clear(),
+    key: (index: number) => Array.from(values.keys())[index] ?? null,
+    get length() {
+      return values.size;
+    },
+  } as Storage;
+}
+
+describe("useMcp manual authentication failures", () => {
+  let useMcp: typeof import("../../../src/react/useMcp.js").useMcp;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.stubGlobal("localStorage", makeStorage());
+    mocks.provider.getLastAttemptedAuthUrl.mockReturnValue(null);
+    mocks.session.initialize.mockRejectedValue(
+      Object.assign(new Error("401 Unauthorized"), { code: 401 })
+    );
+    mocks.auth.mockRejectedValue(
+      new Error(
+        "Protected resource https://proxy.example.com does not match expected https://mcp.example.com/mcp (or origin)"
+      )
+    );
+
+    vi.resetModules();
+    ({ useMcp } = await import("../../../src/react/useMcp.js"));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("surfaces auth errors that did not create a popup or authorization URL", async () => {
+    let latest: ReturnType<typeof useMcp> | undefined;
+
+    function TestComponent() {
+      latest = useMcp({
+        url: "https://mcp.example.com/mcp",
+        autoProxyFallback: false,
+        autoReconnect: false,
+        autoRetry: false,
+        logLevel: "silent",
+      });
+      return null;
+    }
+
+    let renderer: ReturnType<typeof create>;
+    await act(async () => {
+      renderer = create(<TestComponent />);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(latest?.state).toBe("pending_auth");
+
+    await act(async () => {
+      await latest!.authenticate();
+    });
+
+    expect(latest?.state).toBe("failed");
+    expect(latest?.error).toContain("Protected resource");
+    expect(mocks.runAuthPopup).not.toHaveBeenCalled();
+
+    await act(async () => {
+      renderer!.unmount();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- issue signed local public client IDs from the OAuth proxy registration endpoint instead of exposing the fixed upstream client ID
- bind each local registration to its declared redirect URIs and validate the binding at authorization and callback time
- keep upstream client credentials private while continuing to rewrite upstream authorize and token requests to the MCP server's `/oauth/callback`
- advertise downstream clients as public with `token_endpoint_auth_method: none`
- support registered native-app callback schemes such as `cursor://`
- add `registrationSecret` for stateless registrations across restarts and multiple instances when the upstream client has no secret
- document the corrected proxy flow and add a patch changeset

## Root cause

Proxy mode presented a fake Dynamic Client Registration endpoint that returned the same pre-registered upstream client ID to every MCP client. It did not bind the downstream client's declared redirects to that registration, while `/authorize` accepted any valid HTTP(S) redirect. Applications therefore had to override framework-owned OAuth routes and maintain hardcoded client allowlists.

The upstream redirect rewrite was already correct: the identity provider only needs the MCP server's `/oauth/callback`. This change fixes the downstream registration model so applications can rely on the framework routes without vendor-specific callback lists.

## Impact

MCP clients receive a signed local client ID bound to their registered callbacks. The upstream provider continues to see only the MCP server callback and fixed upstream credentials. Existing deployments with an upstream client secret require no new configuration. Upstream public-client deployments should configure a stable `registrationSecret` for registrations to survive restarts or work across instances.

## Validation

- reproduced the original failure against a clean `main` snapshot
- `pnpm --dir libraries/typescript/packages/mcp-use test:unit` — 632 passed, 6 skipped
- `pnpm --dir libraries/typescript/packages/mcp-use build`
- focused OAuth regression suite — 17 passed
- Context MCP temporary migration without its custom allowlist or `/register` override — 14 passed


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Secures OAuth proxy registrations by issuing signed local public client IDs bound to redirect URIs and keeping upstream credentials private. This fixes the DCR proxy model, removes brittle allowlists, and supports native-app schemes.

- **Bug Fixes**
  - `/register` now returns a signed local public `client_id`; upstream `client_id`/`client_secret` stay private and are injected only at `/token`.
  - Validates exact `redirect_uri` at `/authorize` and `/oauth/callback` against the client’s registration.
  - Continues rewriting upstream redirects to the server’s `/oauth/callback` only.
  - Allows registered native schemes (e.g., `cursor://`) and rejects unsafe schemes or fragment URIs.
  - Sets metadata `token_endpoint_auth_methods_supported: ["none"]` and returns `token_endpoint_auth_method: "none"` in registrations.
  - Adds tests and updates docs for the corrected proxy flow in `mcp-use`.

- **Migration**
  - If the upstream client is public (no secret), set `registrationSecret` on `oauthProxy` so registrations persist across restarts and instances.

<sup>Written for commit 1aa9c328265816c0554d05914ea521261cbd1c8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

