### PR TITLE
fix(client): escape server and tool names in code-mode shim generation

### DIFF
--- a/libraries/typescript/.changeset/tidy-shims-quote-names.md
+++ b/libraries/typescript/.changeset/tidy-shims-quote-names.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/client": patch
+---
+
+Fix code-mode shim generation for server and tool names containing quotes or other special characters.

--- a/libraries/typescript/packages/client/src/code-mode/executor-e2b.ts
+++ b/libraries/typescript/packages/client/src/code-mode/executor-e2b.ts
@@ -135,22 +135,29 @@ global.search_tools = async (query, detailLevel = 'full') => {
       // Create safe server name for JS identifier (replace hyphens etc)
       const safeServerName = serverName.replace(/[^a-zA-Z0-9_]/g, "_");
 
+      // Serialize names so quotes and other special characters stay valid in the generated code
+      const escapedServerName = JSON.stringify(serverName);
+      const escapedSafeServerName = JSON.stringify(safeServerName);
+
       shim += `
-global['${serverName}'] = {`;
+global[${escapedServerName}] = {`;
 
       for (const tool of serverTools) {
+        const escapedToolName = JSON.stringify(tool.name);
         shim += `
-    '${tool.name}': async (args) => await global.__callMcpTool('${serverName}', '${tool.name}', args),`;
+    [${escapedToolName}]: async (args) => await global.__callMcpTool(${escapedServerName}, ${escapedToolName}, args),`;
       }
 
       shim += `
 };
-
-// Also expose as safe name if different
-if ('${safeServerName}' !== '${serverName}') {
-    global['${safeServerName}'] = global['${serverName}'];
-}
 `;
+
+      if (safeServerName !== serverName) {
+        shim += `
+// Also expose as safe name if different
+global[${escapedSafeServerName}] = global[${escapedServerName}];
+`;
+      }
     }
 
     return shim;

--- a/libraries/typescript/packages/client/tests/unit/client/executor-e2b-shim.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/client/executor-e2b-shim.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import type { Tool } from "@modelcontextprotocol/client";
+import { E2BCodeExecutor } from "../../../src/code-mode/executor-e2b.js";
+import type { MCPClient } from "../../../src/core/node.js";
+
+function makeTool(name: string): Tool {
+  return {
+    name,
+    description: "a tool",
+    inputSchema: { type: "object", properties: {} },
+  } as Tool;
+}
+
+/**
+ * Evaluates the generated shim in a sandboxed function scope with a stubbed
+ * `global.__callMcpTool`, so we can inspect what namespaces/keys it produces.
+ */
+function evalShim(shim: string) {
+  const calls: Array<{ server: string; tool: string; args: unknown }> = [];
+  const global: Record<string, any> = {
+    __callMcpTool: async (server: string, tool: string, args: unknown) => {
+      calls.push({ server, tool, args });
+      return { ok: true };
+    },
+  };
+
+  // eslint-disable-next-line no-new-func
+  const run = new Function("global", "console", shim);
+  run(global, { log: () => {} });
+
+  return { global, calls };
+}
+
+describe("E2BCodeExecutor shim generation", () => {
+  const executor = new E2BCodeExecutor({} as MCPClient, { apiKey: "test" });
+
+  it("generates valid shim code for names with special characters", () => {
+    const weirdToolName = "it's a {weird}\\ name'";
+    const tools: Record<string, Tool[]> = {
+      "my-server": [makeTool(weirdToolName)],
+    };
+
+    const shim = (executor as any).generateShim(tools);
+
+    // The generated code should be syntactically valid JavaScript.
+    // eslint-disable-next-line no-new-func
+    expect(() => new Function(shim)).not.toThrow();
+
+    const { global } = evalShim(shim);
+
+    expect(global["my-server"]).toBeDefined();
+    expect(typeof global["my-server"][weirdToolName]).toBe("function");
+  });
+
+  it("exposes a safe alias when the server name differs from its safe form", () => {
+    const tools: Record<string, Tool[]> = {
+      "my-server": [makeTool("do_thing")],
+    };
+
+    const shim = (executor as any).generateShim(tools);
+    // eslint-disable-next-line no-new-func
+    expect(() => new Function(shim)).not.toThrow();
+
+    const { global } = evalShim(shim);
+
+    expect(global["my-server"]).toBeDefined();
+    expect(global["my_server"]).toBeDefined();
+    expect(global["my_server"]).toBe(global["my-server"]);
+  });
+
+  it("does not emit an alias line when the server name is already safe", () => {
+    const tools: Record<string, Tool[]> = {
+      my_server: [makeTool("do_thing")],
+    };
+
+    const shim = (executor as any).generateShim(tools);
+    // eslint-disable-next-line no-new-func
+    expect(() => new Function(shim)).not.toThrow();
+
+    // No conditional alias re-assignment should be generated for a name that
+    // is already a valid identifier.
+    expect(shim).not.toContain("Also expose as safe name");
+
+    const { global } = evalShim(shim);
+    expect(global["my_server"]).toBeDefined();
+  });
+});


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

Check all that apply:
- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

The code-mode E2B shim generator built the sandbox bootstrap JavaScript by interpolating server and tool names directly into string literals (e.g. `global['${serverName}'] = {`). Any server or tool name containing a single quote, backslash, brace, or other special character produced syntactically invalid JavaScript in the generated shim, causing sandbox execution to fail for those names.

This PR fixes `generateShim` in `packages/client/src/code-mode/executor-e2b.ts` to serialize all dynamic names with `JSON.stringify` before interpolation, and to use computed property names (`global[escapedName]`, `[escapedToolName]: async (...) => ...`) instead of raw string literals. The safe-alias check (whether the sanitized identifier differs from the raw server name) is now done at generation time in TypeScript rather than emitted as a runtime `if` comparing string literals, so no alias line is emitted at all when the two are equal.

## Review Readiness

- [x] The PR is scoped to one issue or one clearly related change
- [x] The PR description explains the user-visible problem and the fix
- [x] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [x] I verified the affected package/docs path with the commands listed below
- [x] I checked for existing open PRs that already solve the same issue

## Implementation Details

1. `escapedServerName` / `escapedSafeServerName` / `escapedToolName` are computed with `JSON.stringify` and interpolated as computed property keys (`global[escapedServerName] = { [escapedToolName]: ... }`), so quotes/backslashes/braces in names round-trip through valid JS string literals.
2. The `if (safeServerName !== serverName)` alias check now happens at shim-generation time (plain TS comparison) instead of being emitted into the generated shim as a runtime string comparison — removing one more spot where raw names were interpolated.
3. No dependencies added or modified.

---

## TypeScript Checklist

> Complete this section if your PR includes TypeScript changes

### Packages Modified

Check all packages that were modified:
- [ ] `docs`
- [ ] `tests`
- [ ] `cli`
- [ ] `create-mcp-use-app`
- [ ] `mcp-use` (server)
- [x] `mcp-use` (client)
- [ ] `inspector`

### Pre-commit Checklist

Ensure all of the following have been completed:
- [x] Ran `pnpm lint:fix` to auto-fix linting issues
- [x] Ran `pnpm format` to format code with Prettier
- [x] Ran `pnpm build` and build succeeds without errors
- [x] Ran `pnpm changeset` to create a changeset (if this PR includes user-facing changes)
- [x] Added or updated tests if needed
- [ ] Updated documentation in `docs/` folder if needed (not applicable — internal shim generation)

---

## Example Usage (Before)

```js
// serverName = `it's a server`
global['it's a server'] = {   // <-- invalid JS, unterminated string
    ...
};
```

## Example Usage (After)

```js
// serverName = `it's a server`
global["it's a server"] = {   // JSON.stringify picks a valid quoting
    ...
};
```

## Documentation Updates

None — this is an internal code-mode implementation detail with no public API change.

## Testing

- Added `packages/client/tests/unit/client/executor-e2b-shim.test.ts`, which:
  - Generates a shim for a server/tool name containing single quotes, backslashes, and braces, asserts `new Function(shim)` does not throw, and evaluates the shim to confirm the odd tool name ends up as a key on `global['my-server']`.
  - Confirms a safe alias (`global['my_server']`) is emitted and points at the same object when the raw server name differs from its sanitized identifier form.
  - Confirms no alias line is emitted when the server name is already a valid identifier.
- `pnpm vitest run` for the affected test files: 2 files / 8 tests passed.
- `pnpm build` for `@mcp-use/client`: succeeds.
- `eslint` and `prettier --check` on changed files: clean.

## Backwards Compatibility

Fully backwards compatible. Generated shim behavior for names that were already valid JS identifiers is unchanged; only names with special characters (which previously produced invalid JavaScript) are affected, and they now work correctly.

## Related Issues

N/A

https://claude.ai/code/session_01RynQDRJ93ZRCaPm2pHAMW2


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Escapes server and tool names in code-mode shim generation so names with quotes, backslashes, or braces produce valid JavaScript. Shims now run reliably and only emit safe aliases when needed.

- **Bug Fixes**
  - Updated `@mcp-use/client` `generateShim` to `JSON.stringify` names and use computed property keys.
  - Moved safe-alias check to generation time; emit alias only if the sanitized name differs.
  - Added unit tests for special-character names and alias behavior; no API or dependency changes.

<sup>Written for commit dd0824c61bae7d9e376cd94d7eb3dca7c6d701e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2076?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

