### PR TITLE
fix(python): cap mcp below 2.0 so imports keep working

### DIFF
--- a/libraries/python/DEPENDENCY_POLICY.md
+++ b/libraries/python/DEPENDENCY_POLICY.md
@@ -12,15 +12,15 @@ This document describes how mcp-use manages its dependencies for the Python SDK.
 
 The `mcp` package is our core dependency — it provides the MCP protocol implementation.
 
-- **Current minimum**: `mcp>=1.24.0`
+- **Current constraint**: `mcp>=1.24.0,<2`
 - **Update policy**: We bump the minimum when we adopt new MCP SDK features (e.g., `streamable_http_client` introduced in 1.24.0). Minimum version bumps are documented in the changelog.
-- **Breaking changes**: If a new MCP SDK version introduces breaking changes, we release a new minor version of mcp-use with the updated minimum and document the migration in the changelog.
+- **Breaking changes**: If a new MCP SDK version introduces breaking changes, we release a new minor version of mcp-use with the updated minimum and document the migration in the changelog. The upper bound exists because mcp 2.0 removed `RequestContext` from `mcp.shared.context`, which `mcp_use` imports; it comes off with the 2.x migration.
 
 ## Core Dependencies
 
 | Package | Version Constraint | Update Policy |
 |---------|-------------------|---------------|
-| `mcp` | `>=1.24.0` | Bump minimum when adopting new features |
+| `mcp` | `>=1.24.0,<2` | Bump minimum when adopting new features; capped until the 2.x migration |
 | `langchain` | `>=1.0.0` | Follow LangChain major versions |
 | `httpx` | `>=0.27.1` | Update for security patches and new features |
 | `pydantic` | `>=2.11.0,<3.0.0` | Stay within Pydantic v2; v3 migration will be a major release |

--- a/libraries/python/pyproject.toml
+++ b/libraries/python/pyproject.toml
@@ -20,7 +20,10 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "mcp>=1.24.0",
+    # Capped below 2.0: mcp 2.0.0 removed RequestContext from mcp.shared.context,
+    # which mcp_use imports in client/connectors/base.py, so a fresh install
+    # fails at import time. Lift the cap together with the v2 migration.
+    "mcp>=1.24.0,<2",
     "langchain>=1.0.0",
     "websockets>=15.0",
     "httpx>=0.27.1",


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

- [ ] TypeScript
- [x] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

`mcp 2.0.0` shipped and removed `RequestContext` from `mcp.shared.context`. `mcp_use` imports that symbol in `client/connectors/base.py:21`, and `pyproject.toml` asks for `mcp>=1.24.0` with no upper bound, so a fresh install resolves to 2.0.0 and then fails at import:

```
ImportError: cannot import name 'RequestContext' from 'mcp.shared.context'
```

That breaks new installs of the Python package, and it is what turned the python test jobs red on `main` earlier today (the run at 22:40 UTC failed this way; the 19:09 one was green).

This caps the dependency at `mcp>=1.24.0,<2` so resolution stays on the 1.x line.

## Review Readiness

- [x] The PR is scoped to one issue or one clearly related change
- [x] The PR description explains the user-visible problem and the fix
- [x] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [x] I verified the affected path with the commands listed below
- [x] I checked for existing open PRs that already solve the same issue

## Implementation Details

One dependency line plus a comment saying why the cap exists and when to lift it. I deliberately did not try to migrate the import: 2.0 replaces `RequestContext` with a different context model (`BaseContext`, `DispatchContext`, `TransportContext`), and the sampling callback signature in `base.py` would have to change with it, which affects the public API. That is a real migration and should be its own PR with its own review. The cap is the small reversible step that unbreaks installs today.

## Testing

Reproduced and verified in a clean Python 3.12 venv:

```
# what the current constraint resolves to
$ pip install "mcp>=1.24.0"
  mcp 2.0.0
  BROKEN: cannot import name 'RequestContext' from 'mcp.shared.context'

# what this PR's constraint resolves to
$ pip install "mcp>=1.24.0,<2"
  mcp 1.29.0
  import OK
```

Also confirmed `mcp 2.0.0` genuinely no longer exports the symbol anywhere obvious:

```
mcp.shared.context exports: ['Any', 'BaseContext', 'CallOptions', 'DispatchContext',
  'Generic', 'Mapping', 'RequestParamsMeta', 'TransportContext', 'TransportT', 'TypeVar', 'anyio']
mcp.client.session has RequestContext: False
```

`ruff check .` and `ruff format --check .` both clean (`224 files already formatted`).

## Backwards Compatibility

No API change. Users already on mcp 1.x are unaffected. Anyone who had resolved to 2.0.0 and hit the ImportError moves back to a working 1.x.

## Related Issues

None open that I could find for this. Happy to file one if you would rather track the 2.0 migration separately.

---
Freshman dev here, still learning this codebase. I used Claude Code to help investigate and I verified the resolution behavior myself in a clean venv. Please push back on anything off and I will fix it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cap the Python `mcp` dependency to >=1.24.0,<2.0 to prevent import failures after `mcp` 2.0 removed `RequestContext` from `mcp.shared.context`. This unblocks fresh installs and keeps tests green until we migrate to v2.

- **Dependencies**
  - Documented the upper bound and rationale in `libraries/python/DEPENDENCY_POLICY.md` to match `pyproject.toml`.

<sup>Written for commit c962e437c77a3edf3c90aa79678553936138c9ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

