### PR TITLE
docs: add two missing v2 pages to the navigation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -368,6 +368,7 @@
                               "v2/typescript/server/authentication/providers/keycloak",
                               "v2/typescript/server/authentication/providers/supabase",
                               "v2/typescript/server/authentication/providers/workos",
+                              "v2/typescript/server/authentication/providers/oauth-proxy",
                               "v2/typescript/server/authentication/providers/custom"
                             ]
                           }
@@ -391,6 +392,7 @@
                         "pages": [
                           "v2/typescript/server/middleware",
                           "v2/typescript/server/elicitation",
+                          "v2/typescript/server/sampling",
                           "v2/typescript/server/subscriptions",
                           "v2/typescript/server/notifications"
                         ]


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

- [ ] TypeScript
- [ ] Python
- [x] Documentation only
- [ ] CI/CD or tooling

## Changes

Two pages under `docs/v2/` exist and are finished but are not listed in `docs.json`, so there is no path to them from the v2 docs:

- `docs/v2/typescript/server/sampling.mdx` (95 lines)
- `docs/v2/typescript/server/authentication/providers/oauth-proxy.mdx` (18 lines)

Both have v1 counterparts that *are* in the navigation, and in both cases the surrounding v2 group already lists every other sibling, which is why these read as misses from when the v2 nav was assembled rather than deliberate omissions.

## Review Readiness

- [x] The PR is scoped to one issue or one clearly related change
- [x] The PR description explains the user-visible problem and the fix
- [x] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [x] I verified the affected path with the commands listed below
- [x] I checked for existing open PRs that already solve the same issue

## Implementation Details

Two lines added, placed where their v1 versions sit so ordering stays consistent:

| Page | v2 group before | Inserted |
|---|---|---|
| `server/sampling` | middleware, elicitation, subscriptions, notifications | between elicitation and subscriptions (matches v1) |
| `providers/oauth-proxy` | auth0, better-auth, clerk, keycloak, supabase, workos, custom | between workos and custom (matches v1) |

I edited the file as text rather than reserializing the JSON, so nothing else in `docs.json` moved.

## Testing

```
$ cd docs && npx mint broken-links
success no broken links found
```

And a check for v2 pages that exist on disk but are absent from `docs.json`:

```
before: 3 orphans  (sampling, oauth-proxy, changelog)
after:  1 orphan   (changelog)
```

## One I left alone

`docs/v2/typescript/changelog/changelog.mdx` is also unreferenced, but I did not add it. The v2 Get Started group currently has only `welcome` and `quickstart`, while v1 also carries `installation` and both changelogs, so v2 looks deliberately slimmer there and I did not want to guess. Happy to add it if it was an oversight too.

## Backwards Compatibility

Navigation only. No page content touched, v1 navigation untouched.

## Related Issues

None.

---
Freshman dev here, still learning this codebase. I used Claude Code to help with this and verified the navigation and the mint check myself. Please push back on anything off and I will fix it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add two missing v2 docs pages to the navigation so they are reachable: `v2/typescript/server/sampling` and `v2/typescript/server/authentication/providers/oauth-proxy`. Placed to match v1 ordering (sampling between `elicitation` and `subscriptions`; oauth-proxy between `workos` and `custom`).

<sup>Written for commit 8054f56ea52411d0e6af18f5dc3131b14cfe7376. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

