### PR TITLE
fix(create-mcp-use-app): drop stale main field and give templates distinct descriptions

### DIFF
--- a/libraries/typescript/.changeset/template-main-and-descriptions.md
+++ b/libraries/typescript/.changeset/template-main-and-descriptions.md
@@ -1,0 +1,9 @@
+---
+"create-mcp-use-app": patch
+---
+
+Drop the stale `main` field from the scaffolded package.json and give each template its own description.
+
+`main` still pointed at `dist/index.js`, which v2 never produces since builds now go to `.mcp-use/build`. The templates are applications started with `mcp-use start` rather than importable packages, so the field is removed instead of repointed at a gitignored build directory.
+
+All three templates also shared the description "an mcp-use server", which made `--list-templates` useless for telling them apart and put the same string in every generated project.

--- a/libraries/typescript/.changeset/template-main-and-descriptions.md
+++ b/libraries/typescript/.changeset/template-main-and-descriptions.md
@@ -7,3 +7,5 @@ Drop the stale `main` field from the scaffolded package.json and give each templ
 `main` still pointed at `dist/index.js`, which v2 never produces since builds now go to `.mcp-use/build`. The templates are applications started with `mcp-use start` rather than importable packages, so the field is removed instead of repointed at a gitignored build directory.
 
 All three templates also shared the description "an mcp-use server", which made `--list-templates` useless for telling them apart and put the same string in every generated project.
+
+Scaffolding also stopped discarding those descriptions. `updatePackageJson` overwrote `description` with a generic `"<name>: an mcp-use server"` on every run, so a generated project never kept the description of the template it came from. It now only fills that in when the template has no description of its own.

--- a/libraries/typescript/packages/create-mcp-use-app/src/__tests__/dot-directory.test.ts
+++ b/libraries/typescript/packages/create-mcp-use-app/src/__tests__/dot-directory.test.ts
@@ -194,6 +194,29 @@ describe("template file updates against a tmpdir fixture", () => {
     expect(indexContent).not.toContain("{{PROJECT_NAME}}");
   });
 
+  it("keeps the template's description instead of overwriting it", () => {
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify(
+        {
+          name: "placeholder",
+          description:
+            "an mcp-use server with example tools and zod validated input",
+        },
+        null,
+        2
+      )
+    );
+
+    updatePackageJson(dir, "my-app");
+
+    const pkg = JSON.parse(readFileSync(join(dir, "package.json"), "utf-8"));
+    expect(pkg.name).toBe("my-app");
+    expect(pkg.description).toBe(
+      "an mcp-use server with example tools and zod validated input"
+    );
+  });
+
   it("regression: a basename with quotes flows the sanitized name into index.ts (not the raw one)", () => {
     // Before the fix, updateIndexTs received the raw displayName, so a cwd
     // basename like 'My "App"' produced index.ts content `name: "My "App""` —

--- a/libraries/typescript/packages/create-mcp-use-app/src/templates/blank/package.json
+++ b/libraries/typescript/packages/create-mcp-use-app/src/templates/blank/package.json
@@ -5,7 +5,7 @@
     "node": ">=22.22.2"
   },
   "version": "1.0.0",
-  "description": "an mcp-use server",
+  "description": "a minimal mcp-use server with no tools registered, ready to add your own",
   "author": "mcp-use",
   "license": "MIT",
   "homepage": "https://github.com/mcp-use/mcp-use",
@@ -18,7 +18,6 @@
     "mcp-use",
     "manufact"
   ],
-  "main": "dist/index.js",
   "scripts": {
     "build": "mcp-use build",
     "dev": "mcp-use dev",

--- a/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/package.json
+++ b/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-apps/package.json
@@ -5,7 +5,7 @@
     "node": ">=22.22.2"
   },
   "version": "1.0.0",
-  "description": "an mcp-use server",
+  "description": "an mcp-use server with React views for MCP Apps",
   "author": "mcp-use",
   "license": "MIT",
   "homepage": "https://github.com/mcp-use/mcp-use",
@@ -18,7 +18,6 @@
     "mcp-use",
     "manufact"
   ],
-  "main": "dist/index.js",
   "scripts": {
     "build": "mcp-use build",
     "dev": "mcp-use dev",

--- a/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-server/package.json
+++ b/libraries/typescript/packages/create-mcp-use-app/src/templates/mcp-server/package.json
@@ -5,7 +5,7 @@
     "node": ">=22.22.2"
   },
   "version": "1.0.0",
-  "description": "an mcp-use server",
+  "description": "an mcp-use server with example tools and zod validated input",
   "author": "mcp-use",
   "license": "MIT",
   "homepage": "https://github.com/mcp-use/mcp-use",
@@ -18,7 +18,6 @@
     "mcp-use",
     "manufact"
   ],
-  "main": "dist/index.js",
   "scripts": {
     "build": "mcp-use build",
     "dev": "mcp-use dev",

--- a/libraries/typescript/packages/create-mcp-use-app/src/utils.ts
+++ b/libraries/typescript/packages/create-mcp-use-app/src/utils.ts
@@ -94,7 +94,11 @@ export function updatePackageJson(projectPath: string, projectName: string) {
   const packageJsonContent = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
 
   packageJsonContent.name = projectName;
-  packageJsonContent.description = `${projectName}: an mcp-use server`;
+  // Keep the template's own description so a generated project says what it
+  // actually is. Only templates without one fall back to the generic string.
+  if (!packageJsonContent.description) {
+    packageJsonContent.description = `${projectName}: an mcp-use server`;
+  }
 
   writeFileSync(packageJsonPath, JSON.stringify(packageJsonContent, null, 2));
 }


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

**Targets `beta`, not `main`.**

## Changes

Closes #2080. Closes #2081.

Two things in the scaffolded `package.json` that every generated project inherits.

**`main` points at a path v2 never creates.** All three templates ship `"main": "dist/index.js"`, but v2 builds emit `.mcp-use/build`. Nothing ever writes `dist/`, so the field never resolves. This was correct in v1, which really did emit `dist/index.js`, and it did not move when the build output did.

**All three templates share one description.** Every template says `"description": "an mcp-use server"`. `--list-templates` reads that field straight off the template's package.json, so the three are indistinguishable from the CLI, and the same string ends up in every generated project.

## Review Readiness

- [x] The PR is scoped to one issue or one clearly related change
- [x] The PR description explains the user-visible problem and the fix
- [x] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [x] I verified the affected package/docs path with the commands listed below
- [x] I checked for existing open PRs that already solve the same issue

## Implementation Details

Three files, one line each, plus a changeset.

For `main` I dropped the field rather than repointing it at `.mcp-use/build/index.js`. Two reasons, and I am happy to switch if you would rather keep it:

- These templates are applications you run with `mcp-use start`, not packages anyone imports, so nothing reads `main`.
- `.mcp-use/` is in the template's own gitignore as build output, so pointing `main` there would name a path that does not exist until after a build. Next.js scaffolds do not carry a `main` either, which seemed like the model here.

Descriptions now reflect what each template actually contains:

| template | description | why |
|---|---|---|
| blank | a minimal mcp-use server with no tools registered, ready to add your own | deps: `mcp-use`, no primitives registered |
| mcp-server | an mcp-use server with example tools and zod validated input | deps: `mcp-use`, `zod`, two registrations in `index.ts` |
| mcp-apps | an mcp-use server with React views for MCP Apps | deps add `react`, `react-dom`, plus a `views/` directory |

## Testing

Verified against `origin/beta` at `91e1b019`, not main:

```
blank       package.json  "main": "dist/index.js"   "description": "an mcp-use server"
mcp-apps    package.json  "main": "dist/index.js"   "description": "an mcp-use server"
mcp-server  package.json  "main": "dist/index.js"   "description": "an mcp-use server"
```

Confirmed `--list-templates` sources the string it prints from `templatePackageJson.description` in `create-mcp-use-app/src/index.ts`, so this one change fixes both the CLI listing and the generated project. Confirmed no template emits `dist/` anywhere on beta, and that `.mcp-use/` is listed under "Build output" in each template's gitignore. All three files still parse as JSON after the edit.

## Backwards Compatibility

Only affects newly scaffolded projects. Existing projects are untouched. Dropping `main` is safe for an app; if any tooling you have does read it, repointing at `.mcp-use/build/index.js` is a one line change from here.

## Related Issues

Closes #2080, Closes #2081.

---
Freshman dev here, still learning this codebase. I used Claude Code to help with this and verified everything against the beta branch myself. Please push back on anything off and I will fix it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix `create-mcp-use-app` by removing the stale `main` field, giving each template a distinct description, and keeping that description in generated projects. This prevents broken entry points and makes `--list-templates` and new apps clearer.

- **Bug Fixes**
  - Remove `"main"` from template `package.json` files; v2 builds to `.mcp-use/build` and these are apps run with `mcp-use start`.
  - Give each template a distinct description so `--list-templates` is informative.
  - Preserve the template description during scaffolding; only fill a generic one if the template has none.

<sup>Written for commit 50b2ee3113131621694cef8c4625a1a176da4313. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2085?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

