### PR TITLE
fix(python): initialize base connector state in WebSocketConnector

### DIFF
--- a/libraries/python/mcp_use/client/connectors/websocket.py
+++ b/libraries/python/mcp_use/client/connectors/websocket.py
@@ -264,6 +264,14 @@ class WebSocketConnector(BaseConnector):
 
         WebSocketConnector manages the connection over raw WebSocket messages
         rather than an MCP ClientSession, so unlike the base implementation this
-        does not depend on ``client_session``.
+        does not depend on ``client_session``. It also checks that the receiver
+        task is still running: ``_receive_messages`` catches its own exceptions
+        and returns without resetting ``_connected``, so a dropped connection
+        would otherwise still report as connected until ``disconnect()`` is
+        called explicitly.
         """
-        return self._connected
+        if not self._connected:
+            return False
+        if self._receiver_task is None or self._receiver_task.done():
+            return False
+        return True

--- a/libraries/python/mcp_use/client/connectors/websocket.py
+++ b/libraries/python/mcp_use/client/connectors/websocket.py
@@ -42,6 +42,8 @@ class WebSocketConnector(BaseConnector):
                 - A dict: Not supported for WebSocket (will log warning)
                 - An httpx.Auth object: Not supported for WebSocket (will log warning)
         """
+        super().__init__()
+
         self.url = url
         self.headers = headers or {}
 
@@ -255,3 +257,13 @@ class WebSocketConnector(BaseConnector):
     def public_identifier(self) -> str:
         """Get the identifier for the connector."""
         return f"websocket:{self.url}"
+
+    @property
+    def is_connected(self) -> bool:
+        """Check if the connector is actually connected.
+
+        WebSocketConnector manages the connection over raw WebSocket messages
+        rather than an MCP ClientSession, so unlike the base implementation this
+        does not depend on ``client_session``.
+        """
+        return self._connected

--- a/libraries/python/tests/unit/test_websocket_connector.py
+++ b/libraries/python/tests/unit/test_websocket_connector.py
@@ -2,7 +2,7 @@
 Unit tests for the WebSocketConnector class.
 """
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -37,16 +37,39 @@ class TestWebSocketConnectorInitialization:
 
         assert connector.is_connected is False
 
-    def test_is_connected_reflects_connected_flag(self):
+    def test_is_connected_reflects_connected_flag_with_running_receiver(self):
         """WebSocketConnector doesn't populate client_session (it speaks the MCP
         protocol directly over raw WebSocket messages), so is_connected must be
         derived from its own _connected flag rather than the inherited
         client_session-based check."""
         connector = WebSocketConnector(url="ws://localhost:8765")
-
         connector._connected = True
+        connector._receiver_task = MagicMock()
+        connector._receiver_task.done.return_value = False
+
         assert connector.client_session is None
         assert connector.is_connected is True
 
         connector._connected = False
+        assert connector.is_connected is False
+
+    def test_is_connected_false_without_receiver_task(self):
+        """_connected=True alone must not be enough; a receiver task must
+        actually be running for the connection to be considered live."""
+        connector = WebSocketConnector(url="ws://localhost:8765")
+        connector._connected = True
+        connector._receiver_task = None
+
+        assert connector.is_connected is False
+
+    def test_is_connected_false_after_receiver_task_dies(self):
+        """Regression test: _receive_messages catches its own exceptions
+        internally and returns without resetting _connected, so a dropped
+        connection must be detected via the receiver task having finished
+        rather than via _connected alone."""
+        connector = WebSocketConnector(url="ws://localhost:8765")
+        connector._connected = True
+        connector._receiver_task = MagicMock()
+        connector._receiver_task.done.return_value = True
+
         assert connector.is_connected is False

--- a/libraries/python/tests/unit/test_websocket_connector.py
+++ b/libraries/python/tests/unit/test_websocket_connector.py
@@ -1,0 +1,52 @@
+"""
+Unit tests for the WebSocketConnector class.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from mcp_use.client.connectors.websocket import WebSocketConnector
+
+
+@pytest.fixture(autouse=True)
+def mock_logger():
+    """Mock the logger to prevent errors during tests."""
+    with patch("mcp_use.client.connectors.websocket.logger") as mock_logger:
+        yield mock_logger
+
+
+class TestWebSocketConnectorInitialization:
+    """Tests for WebSocketConnector initialization."""
+
+    def test_init_sets_base_connector_attributes(self):
+        """Base attributes such as client_session must be initialized, not just the
+        WebSocket-specific ones, so inherited BaseConnector methods don't crash with
+        AttributeError."""
+        connector = WebSocketConnector(url="ws://localhost:8765")
+
+        assert connector.client_session is None
+        assert connector._connection_manager is None
+        assert connector._tools is None
+        assert connector._connected is False
+
+    def test_is_connected_does_not_raise_before_connecting(self):
+        """Regression test: accessing is_connected on a freshly constructed
+        WebSocketConnector must not raise AttributeError."""
+        connector = WebSocketConnector(url="ws://localhost:8765")
+
+        assert connector.is_connected is False
+
+    def test_is_connected_reflects_connected_flag(self):
+        """WebSocketConnector doesn't populate client_session (it speaks the MCP
+        protocol directly over raw WebSocket messages), so is_connected must be
+        derived from its own _connected flag rather than the inherited
+        client_session-based check."""
+        connector = WebSocketConnector(url="ws://localhost:8765")
+
+        connector._connected = True
+        assert connector.client_session is None
+        assert connector.is_connected is True
+
+        connector._connected = False
+        assert connector.is_connected is False


### PR DESCRIPTION
## Changes
`WebSocketConnector.__init__` never called `super().__init__()`, so `client_session` and other `BaseConnector` attributes were never set. Accessing `is_connected` raised `AttributeError`, and any inherited method this connector doesn't override (e.g. `list_prompts`/`get_prompt`/`set_roots`) would fail the same way.

## Implementation Details
1. Call `super().__init__()` at the top of `WebSocketConnector.__init__` so all `BaseConnector` attributes are initialized.
2. Override `is_connected` on `WebSocketConnector` to use its own `_connected` flag instead of the inherited `client_session`-based check — this connector speaks the MCP protocol directly over raw WebSocket messages and never populates `client_session`, so the inherited check would otherwise always report "not connected" even while actually connected.

## Example Usage (Before)
```python
connector = WebSocketConnector(url="ws://localhost:8765")
connector.is_connected  # AttributeError: 'WebSocketConnector' object has no attribute 'client_session'
```

## Example Usage (After)
```python
connector = WebSocketConnector(url="ws://localhost:8765")
connector.is_connected  # False, no crash
```

## Documentation Updates
None needed — internal bugfix, no public API change.

## Testing
- Added `tests/unit/test_websocket_connector.py` covering: base attributes are initialized, `is_connected` doesn't raise before connecting, and `is_connected` correctly tracks the connector's own `_connected` flag.
- `pytest tests/unit` passes (307 passed; the 1 pre-existing failure is an unrelated missing optional `e2b` dependency in the test env, unaffected by this change).
- `ruff check` / `ruff format --check` pass on changed files.

## Backwards Compatibility
Not breaking. Constructor signature is unchanged; this only fixes attribute initialization and connection-state reporting.

## Related Issues
Closes #2088

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `WebSocketConnector` initialization so base state is set and connection status is accurate, including detecting when the receiver task has died. Prevents AttributeError when accessing `is_connected` and inherited methods, and avoids stale "connected" after drops.

- **Bug Fixes**
  - Call `super().__init__()` in `WebSocketConnector.__init__` to initialize `BaseConnector` attributes.
  - Override `is_connected` to use `_connected` and verify the receiver task is running; stop relying on `client_session`.
  - Add unit tests for initialization and connection state, including receiver task death.

<sup>Written for commit 65e8f7d57a8c3581bcddbf45c2bef104fae652b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

