### PR TITLE
fix(python): remove invalid print() kwargs from sandbox logger calls

### DIFF
--- a/libraries/python/mcp_use/client/connectors/sandbox.py
+++ b/libraries/python/mcp_use/client/connectors/sandbox.py
@@ -148,12 +148,12 @@ class SandboxConnector(BaseConnector):
     def _handle_stdout(self, data: str) -> None:
         """Handle stdout data from the sandbox process."""
         self.stdout_lines.append(data)
-        logger.debug(f"[SANDBOX STDOUT] {data}", end="", flush=True)
+        logger.debug(f"[SANDBOX STDOUT] {data}")
 
     def _handle_stderr(self, data: str) -> None:
         """Handle stderr data from the sandbox process."""
         self.stderr_lines.append(data)
-        logger.debug(f"[SANDBOX STDERR] {data}", file=self.errlog, end="", flush=True)
+        logger.debug(f"[SANDBOX STDERR] {data}")
 
     async def wait_for_server_response(self, base_url: str, timeout: int = 30) -> bool:
         """Wait for the server to respond to HTTP requests.

--- a/libraries/python/tests/unit/test_sandbox_connector.py
+++ b/libraries/python/tests/unit/test_sandbox_connector.py
@@ -2,6 +2,7 @@
 Unit tests for the SandboxConnector class.
 """
 
+import logging
 import os
 import sys
 from unittest.mock import ANY, AsyncMock, MagicMock, Mock, patch
@@ -220,6 +221,30 @@ class TestSandboxConnectorConnection:
 
         # Verify state
         assert connector._connected is False
+
+
+class TestSandboxConnectorLogging:
+    """Tests for SandboxConnector stdout/stderr logging callbacks."""
+
+    def test_handle_stdout_and_stderr_do_not_raise_with_debug_logging(self, mock_sandbox_modules):
+        """Regression test: _handle_stdout/_handle_stderr used to call
+        logger.debug(msg, end="", flush=True) / logger.debug(msg, file=..., end="", flush=True),
+        passing print()-style kwargs that logging.Logger.debug() doesn't accept. That only
+        surfaces once the logger's effective level lets DEBUG records through, so this test
+        uses a real Logger with DEBUG enabled rather than the module's autouse mock."""
+        sandbox_options = SandboxOptions(api_key="test-api-key")
+        connector = SandboxConnector("npx", ["test-command"], e2b_options=sandbox_options)
+
+        real_logger = logging.getLogger("mcp_use_sandbox_connector_test")
+        real_logger.setLevel(logging.DEBUG)
+        real_logger.addHandler(logging.NullHandler())
+
+        with patch("mcp_use.client.connectors.sandbox.logger", real_logger):
+            connector._handle_stdout("some output\n")
+            connector._handle_stderr("some error\n")
+
+        assert connector.stdout_lines == ["some output\n"]
+        assert connector.stderr_lines == ["some error\n"]
 
 
 class TestSandboxConnectorCleanup:


### PR DESCRIPTION
## Changes
`SandboxConnector._handle_stdout`/`_handle_stderr` called `logger.debug(msg, end="", flush=True)` and `logger.debug(msg, file=self.errlog, end="", flush=True)`. `logger` is a standard `logging.Logger`; `end`/`flush`/`file` are `print()` kwargs, not accepted by `Logger.debug()`.

## Implementation Details
1. Drop the invalid `end`/`flush`/`file` kwargs from both `logger.debug()` calls in `mcp_use/client/connectors/sandbox.py`.

## Example Usage (Before)
With debug logging enabled (`MCP_USE_DEBUG=2`), any stdout/stderr line from a sandboxed MCP server process (these are registered directly as E2B's `on_stdout`/`on_stderr` callbacks) raised:
```
TypeError: Logger.debug() got an unexpected keyword argument 'end'
```

## Example Usage (After)
Sandboxed process output is logged normally with no exception.

## Documentation Updates
None needed — internal bugfix, no public API change.

## Testing
- Added `TestSandboxConnectorLogging` in `tests/unit/test_sandbox_connector.py`, using a real (non-mocked) `logging.Logger` with `DEBUG` enabled, since the module's autouse logger mock would silently accept any kwargs and mask the bug. Verified the new test fails against the pre-fix code and passes after the fix.
- `pytest tests/unit` passes (all sandbox connector tests green; the one pre-existing unrelated failure in this env is a missing optional `e2b` import, unaffected by this change).
- `ruff check` / `ruff format --check` pass on changed files.

## Backwards Compatibility
Not breaking. Internal logging call fix only.

## Related Issues
Closes #2089

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a TypeError when debug logging is enabled by removing print-style kwargs from `logger.debug()` in the sandbox connector. Stdout/stderr from sandboxed processes now log without errors.

- **Bug Fixes**
  - Drop `end`/`flush`/`file` kwargs from `logger.debug()` in `libraries/python/mcp_use/client/connectors/sandbox.py`.
  - Add a unit test using a real `logging.Logger` to ensure `_handle_stdout` and `_handle_stderr` do not raise.

<sup>Written for commit 069eb49a9c9b7c9330803ca072b10b5627f94cc0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

