### PR TITLE
fix(python): correct inverted required-field detection in structured output

### DIFF
--- a/libraries/python/mcp_use/agents/mcpagent.py
+++ b/libraries/python/mcp_use/agents/mcpagent.py
@@ -596,7 +596,7 @@ class MCPAgent:
 
         try:
             for field_name, field_info in output_schema.model_fields.items():
-                required = not hasattr(field_info, "default") or field_info.default is None
+                required = field_info.is_required()
                 if required:
                     value = getattr(structured_result, field_name, None)
                     if value is None or (isinstance(value, str) and not value.strip()):
@@ -616,7 +616,7 @@ class MCPAgent:
         try:
             for field_name, field_info in output_schema.model_fields.items():
                 description = getattr(field_info, "description", "") or field_name
-                required = not hasattr(field_info, "default") or field_info.default is None
+                required = field_info.is_required()
                 schema_fields.append(f"- {field_name}: {description} {'(required)' if required else '(optional)'}")
 
             schema_description = "\n".join(schema_fields)
@@ -889,7 +889,7 @@ class MCPAgent:
                     schema_fields = []
                     for field_name, field_info in output_schema.model_fields.items():
                         description = getattr(field_info, "description", "") or field_name
-                        required = not hasattr(field_info, "default") or field_info.default is None
+                        required = field_info.is_required()
                         schema_fields.append(
                             f"- {field_name}: {description} " + ("(required)" if required else "(optional)")
                         )

--- a/libraries/python/tests/unit/test_agent.py
+++ b/libraries/python/tests/unit/test_agent.py
@@ -2,11 +2,12 @@
 Unit tests for the MCPAgent class.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from langchain_core.agents import AgentFinish
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from pydantic import BaseModel
 
 from mcp_use.agents.mcpagent import MCPAgent
 from mcp_use.client import MCPClient
@@ -383,3 +384,63 @@ class TestMCPAgentStreamEvents:
         assert any(isinstance(message, AIMessage) and message.content == ai_message.content for message in history), (
             "Final AI message should be stored by stream_events()"
         )
+
+
+class SampleOutputSchema(BaseModel):
+    """Schema with one required field (no default) and one optional field (default=None),
+    used to verify required-field detection is not inverted."""
+
+    name: str
+    nickname: str | None = None
+
+
+class TestMCPAgentStructuredOutputRequiredFields:
+    """Tests for MCPAgent's required-vs-optional field detection in structured output."""
+
+    def _mock_llm(self):
+        llm = MagicMock()
+        llm._llm_type = "test-provider"
+        llm._identifying_params = {"model": "test-model"}
+        return llm
+
+    def test_enhance_query_with_schema_marks_fields_correctly(self):
+        """A field with no default must be marked required; a field with default=None
+        must be marked optional."""
+        agent = MCPAgent(llm=self._mock_llm(), client=MagicMock(spec=MCPClient))
+
+        enhanced = agent._enhance_query_with_schema("do the task", SampleOutputSchema)
+
+        assert "- name: name (required)" in enhanced
+        assert "- nickname: nickname (optional)" in enhanced
+
+    @pytest.mark.asyncio
+    async def test_attempt_structured_output_accepts_missing_optional_field(self):
+        """A missing optional field (nickname=None) must not raise, since it isn't required."""
+        agent = MCPAgent(llm=self._mock_llm(), client=MagicMock(spec=MCPClient))
+        structured_llm = MagicMock()
+        structured_llm.ainvoke = AsyncMock(return_value=SampleOutputSchema(name="Ada", nickname=None))
+
+        result = await agent._attempt_structured_output(
+            raw_result="Ada",
+            structured_llm=structured_llm,
+            output_schema=SampleOutputSchema,
+            schema_description="- name: name (required)\n- nickname: nickname (optional)",
+        )
+
+        assert result.name == "Ada"
+        assert result.nickname is None
+
+    @pytest.mark.asyncio
+    async def test_attempt_structured_output_rejects_missing_required_field(self):
+        """A missing required field (empty name) must raise so retry logic kicks in."""
+        agent = MCPAgent(llm=self._mock_llm(), client=MagicMock(spec=MCPClient))
+        structured_llm = MagicMock()
+        structured_llm.ainvoke = AsyncMock(return_value=SampleOutputSchema(name="", nickname="Ace"))
+
+        with pytest.raises(ValueError, match="Required field 'name' is missing or empty"):
+            await agent._attempt_structured_output(
+                raw_result="",
+                structured_llm=structured_llm,
+                output_schema=SampleOutputSchema,
+                schema_description="- name: name (required)\n- nickname: nickname (optional)",
+            )


### PR DESCRIPTION
## Changes
`MCPAgent._attempt_structured_output`, `_enhance_query_with_schema`, and a third occurrence later in `mcpagent.py` all computed required-ness for structured-output schema fields as:
```python
required = not hasattr(field_info, "default") or field_info.default is None
```
Pydantic's `FieldInfo` always has a `.default` attribute, so `hasattr(...)` is always `True`, collapsing the expression to `field_info.default is None`. A genuinely required field (no default) has `default = PydanticUndefined`, not `None` — so it was incorrectly treated as **optional**. A field explicitly declared `Optional[str] = None` was incorrectly treated as **required**.

## Implementation Details
1. Replaced all three occurrences of the buggy expression with pydantic's own `FieldInfo.is_required()`, which correctly distinguishes "no default" from "default is None".

## Example Usage (Before)
```python
class Output(BaseModel):
    name: str                    # required, no default
    nickname: str | None = None  # optional

# name missing -> silently passes validation (wrong)
# nickname missing -> incorrectly raises "Required field 'nickname' is missing" (wrong)
```

## Example Usage (After)
```python
# name missing -> raises "Required field 'name' is missing or empty" (correct)
# nickname missing -> passes validation (correct)
```

## Documentation Updates
None needed — internal bugfix, no public API change.

## Testing
- Added `TestMCPAgentStructuredOutputRequiredFields` in `tests/unit/test_agent.py`: verifies `_enhance_query_with_schema` labels fields correctly, and that `_attempt_structured_output` accepts a missing optional field but rejects a missing required field.
- Verified all 3 new tests fail against the pre-fix code and pass after the fix.
- `pytest tests/unit` passes (307 passed; the 1 pre-existing failure is an unrelated missing optional `e2b` dependency in the test env).
- `ruff check` / `ruff format --check` pass on changed files.

## Backwards Compatibility
Not breaking. This only fixes validation correctness; no public API change.

## Related Issues
Closes #2090

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes required-field detection in `MCPAgent` structured output so fields without defaults are treated as required and `Optional[...] = None` fields are optional. This corrects validation and schema hints.

- **Bug Fixes**
  - Use `pydantic` `FieldInfo.is_required()` in `_attempt_structured_output`, `_enhance_query_with_schema`, and `stream()` schema hints.
  - Validation now errors on missing required fields and allows missing optional fields.
  - Added unit tests covering both cases; they fail pre-fix and pass after the change.

<sup>Written for commit 6be138e9a9eef71b42b40fd0778be563851d1486. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2094?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

