### PR TITLE
fix(python): return all resource content blocks, handle empty contents

### DIFF
--- a/libraries/python/mcp_use/agents/adapters/langchain_adapter.py
+++ b/libraries/python/mcp_use/agents/adapters/langchain_adapter.py
@@ -233,14 +233,15 @@ class LangChainAdapter(BaseAdapter[BaseTool]):
                 logger.debug(f'Resource tool: "{self.name}" called')
                 try:
                     result = await self.tool_connector.read_resource(mcp_resource.uri)
+                    parts = []
                     for content in result.contents:
                         # Attempt to decode bytes if necessary
                         if isinstance(content, bytes):
-                            content_decoded = content.decode()
+                            parts.append(content.decode())
                         else:
-                            content_decoded = str(content)
+                            parts.append(str(content))
 
-                    return content_decoded
+                    return "\n".join(parts)
                 except Exception as e:
                     if self.handle_tool_error:
                         return format_error(e, tool=self.name)  # Format the error to make LLM understand it

--- a/libraries/python/tests/unit/test_langchain_adapter.py
+++ b/libraries/python/tests/unit/test_langchain_adapter.py
@@ -9,6 +9,8 @@ from mcp.types import (
     CallToolResult,
     EmbeddedResource,
     ImageContent,
+    ReadResourceResult,
+    Resource,
     TextContent,
     TextResourceContents,
     Tool,
@@ -112,3 +114,44 @@ class TestLangChainAdapterToolExecution:
         assert result["details"] == "tool failed"
         assert result["tool"] == "failing_tool"
         assert result["tool_content"] == "tool failed"
+
+    @pytest.mark.asyncio
+    async def test_resource_tool_returns_all_content_blocks(self):
+        """Regression test: previously the resource tool's _arun loop overwrote its
+        accumulator each iteration, so only the last content block survived and earlier
+        blocks were silently dropped."""
+        adapter = LangChainAdapter()
+        connector = MagicMock()
+        connector.read_resource = AsyncMock(
+            return_value=ReadResourceResult(
+                contents=[
+                    TextResourceContents(uri="file:///tmp/doc.txt", text="page 1"),
+                    TextResourceContents(uri="file:///tmp/doc.txt", text="page 2"),
+                    TextResourceContents(uri="file:///tmp/doc.txt", text="page 3"),
+                ]
+            )
+        )
+
+        resource = Resource(uri="file:///tmp/doc.txt", name="doc")
+        resource_tool = adapter._convert_resource(resource, connector)
+
+        result = await resource_tool._arun()
+
+        assert "page 1" in result
+        assert "page 2" in result
+        assert "page 3" in result
+
+    @pytest.mark.asyncio
+    async def test_resource_tool_empty_contents_returns_empty_string(self):
+        """Regression test: an empty contents list used to raise UnboundLocalError
+        instead of returning gracefully."""
+        adapter = LangChainAdapter()
+        connector = MagicMock()
+        connector.read_resource = AsyncMock(return_value=ReadResourceResult(contents=[]))
+
+        resource = Resource(uri="file:///tmp/empty.txt", name="empty")
+        resource_tool = adapter._convert_resource(resource, connector)
+
+        result = await resource_tool._arun()
+
+        assert result == ""


### PR DESCRIPTION
## Changes
Fixes the two bugs described in #1625: `ResourceTool._arun` in the LangChain adapter (`mcp_use/agents/adapters/langchain_adapter.py`) overwrote its accumulator variable on every loop iteration, so only the last content block of a multi-block resource was ever returned — earlier blocks were silently dropped. An empty `contents` list also raised `UnboundLocalError` since the accumulator was never assigned.

## Implementation Details
1. Accumulate each decoded content block into a list and `"\n".join(...)` them at the end, per the fix already suggested in #1625.

## Example Usage (Before)
```python
# resource.contents == ["page 1", "page 2", "page 3"]
await resource_tool._arun()  # -> "page 3" (data loss)

# resource.contents == []
await resource_tool._arun()  # -> UnboundLocalError
```

## Example Usage (After)
```python
# resource.contents == ["page 1", "page 2", "page 3"]
await resource_tool._arun()  # -> "page 1\npage 2\npage 3"

# resource.contents == []
await resource_tool._arun()  # -> ""
```

## Documentation Updates
None needed — internal bugfix, no public API change.

## Testing
- Added `test_resource_tool_returns_all_content_blocks` and `test_resource_tool_empty_contents_returns_empty_string` in `tests/unit/test_langchain_adapter.py`.
- Verified both new tests fail against the pre-fix code and pass after the fix.
- `pytest tests/unit` passes (306 passed; the 1 pre-existing failure is an unrelated missing optional `e2b` dependency in the test env).
- `ruff check` / `ruff format --check` pass on changed files.

## Backwards Compatibility
Not breaking. Return value for multi-block resources changes from a single (wrong, truncated) block to the full joined content, which is the intended/expected behavior per #1625.

## Related Issues
Closes #1625

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return all resource content blocks in the Python LangChain adapter and handle empty resources. Previously only the last block was returned and empty contents crashed with UnboundLocalError; now we decode, collect, and join parts with newlines, returning an empty string when empty.

<sup>Written for commit 7c3a0f21582539d744600ce3292321e456fd2777. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2095?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

