### PR TITLE
fix(python): make telemetry() decorator await async methods

### DIFF
--- a/libraries/python/mcp_use/telemetry/telemetry.py
+++ b/libraries/python/mcp_use/telemetry/telemetry.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 import platform
@@ -53,6 +54,54 @@ def telemetry(event_name: str, additional_properties: dict[str, Any] | None = No
     """Decorator to automatically track feature usage"""
 
     def decorator(func: Callable) -> Callable:
+        def _capture(self, success: bool, error_type: str | None, start_time: float) -> None:
+            execution_time_ms = int((time.time() - start_time) * 1000)
+
+            telemetry_client = None
+            if hasattr(self, "telemetry"):
+                telemetry_client = self.telemetry
+            elif hasattr(self, "_telemetry"):
+                telemetry_client = self._telemetry
+            else:
+                telemetry_client = Telemetry()
+
+            if telemetry_client:
+                telemetry_client.capture(
+                    event=GenericTelemetryEvent(
+                        EVENT_NAME=event_name,
+                        **{
+                            **(additional_properties or {}),
+                            "success": success,
+                            "execution_time_ms": execution_time_ms,
+                            "error_type": error_type,
+                        },
+                    )
+                )
+
+        if asyncio.iscoroutinefunction(func):
+
+            @wraps(func)
+            async def async_wrapper(self, *args, **kwargs):
+                # Check if telemetry is disabled on this instance
+                record_telemetry = getattr(self, "_record_telemetry", None)
+                if record_telemetry is not None and not record_telemetry:
+                    return await func(self, *args, **kwargs)
+
+                start_time = time.time()
+                success = True
+                error_type = None
+
+                try:
+                    return await func(self, *args, **kwargs)
+                except Exception as e:
+                    success = False
+                    error_type = type(e).__name__
+                    raise
+                finally:
+                    _capture(self, success, error_type, start_time)
+
+            return async_wrapper
+
         @wraps(func)
         def wrapper(self, *args, **kwargs):
             # Check if telemetry is disabled on this instance
@@ -65,35 +114,13 @@ def telemetry(event_name: str, additional_properties: dict[str, Any] | None = No
             error_type = None
 
             try:
-                result = func(self, *args, **kwargs)
-                return result
+                return func(self, *args, **kwargs)
             except Exception as e:
                 success = False
                 error_type = type(e).__name__
                 raise
             finally:
-                execution_time_ms = int((time.time() - start_time) * 1000)
-
-                telemetry = None
-                if hasattr(self, "telemetry"):
-                    telemetry = self.telemetry
-                elif hasattr(self, "_telemetry"):
-                    telemetry = self._telemetry
-                else:
-                    telemetry = Telemetry()
-
-                if telemetry:
-                    telemetry.capture(
-                        event=GenericTelemetryEvent(
-                            EVENT_NAME=event_name,
-                            **{
-                                **(additional_properties or {}),
-                                "success": success,
-                                "execution_time_ms": execution_time_ms,
-                                "error_type": error_type,
-                            },
-                        )
-                    )
+                _capture(self, success, error_type, start_time)
 
         return wrapper
 

--- a/libraries/python/mcp_use/telemetry/telemetry.py
+++ b/libraries/python/mcp_use/telemetry/telemetry.py
@@ -93,7 +93,11 @@ def telemetry(event_name: str, additional_properties: dict[str, Any] | None = No
 
                 try:
                     return await func(self, *args, **kwargs)
-                except Exception as e:
+                except (Exception, asyncio.CancelledError) as e:
+                    # asyncio.CancelledError is a BaseException, not an Exception, so it
+                    # must be listed explicitly or a cancelled call is recorded as a
+                    # success. It's re-raised unconditionally below, so cancellation
+                    # still propagates normally.
                     success = False
                     error_type = type(e).__name__
                     raise

--- a/libraries/python/tests/unit/test_telemetry.py
+++ b/libraries/python/tests/unit/test_telemetry.py
@@ -28,6 +28,10 @@ class DummyAsyncTarget:
         await asyncio.sleep(0.05)
         raise ValueError("boom")
 
+    @telemetry("test_async_event_cancel")
+    async def do_slow_work(self) -> None:
+        await asyncio.sleep(10)
+
 
 class DummySyncTarget:
     """A stand-in for sync methods decorated with @telemetry(...), to guard
@@ -87,6 +91,28 @@ class TestTelemetryDecoratorAsync:
         assert event.EVENT_NAME == "test_async_event_error"
         assert event.success is False
         assert event.error_type == "ValueError"
+
+    @pytest.mark.asyncio
+    async def test_async_cancellation_is_captured_as_failure_and_propagates(self):
+        """Regression test: asyncio.CancelledError is a BaseException, not an
+        Exception, so a bare `except Exception` silently misses it and would
+        record a cancelled call as a success. Cancellation must still
+        propagate to the caller."""
+        target = DummyAsyncTarget()
+
+        task = asyncio.ensure_future(target.do_slow_work())
+        await asyncio.sleep(0)  # let the task actually start
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert task.cancelled()
+        target.telemetry.capture.assert_called_once()
+        event = target.telemetry.capture.call_args.kwargs["event"]
+        assert event.EVENT_NAME == "test_async_event_cancel"
+        assert event.success is False
+        assert event.error_type == "CancelledError"
 
 
 class TestTelemetryDecoratorSync:

--- a/libraries/python/tests/unit/test_telemetry.py
+++ b/libraries/python/tests/unit/test_telemetry.py
@@ -1,0 +1,115 @@
+"""
+Unit tests for the telemetry() decorator.
+"""
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from mcp_use.telemetry.telemetry import telemetry
+
+
+class DummyAsyncTarget:
+    """A stand-in for classes like MCPSession/BaseConnector whose async methods
+    are decorated with @telemetry(...)."""
+
+    def __init__(self):
+        self._record_telemetry = True
+        self.telemetry = MagicMock()
+
+    @telemetry("test_async_event")
+    async def do_work(self, value: int) -> int:
+        await asyncio.sleep(0.05)
+        return value * 2
+
+    @telemetry("test_async_event_error")
+    async def do_fail(self) -> None:
+        await asyncio.sleep(0.05)
+        raise ValueError("boom")
+
+
+class DummySyncTarget:
+    """A stand-in for sync methods decorated with @telemetry(...), to guard
+    against regressing existing sync behavior."""
+
+    def __init__(self):
+        self._record_telemetry = True
+        self.telemetry = MagicMock()
+
+    @telemetry("test_sync_event")
+    def do_work(self, value: int) -> int:
+        return value * 2
+
+    @telemetry("test_sync_event_error")
+    def do_fail(self) -> None:
+        raise ValueError("boom")
+
+
+class TestTelemetryDecoratorAsync:
+    """Regression tests: the telemetry() decorator's wrapper must itself be a
+    coroutine function when wrapping an async method, so the wrapped method's
+    body actually runs (and can be awaited/timed/exception-caught) before the
+    telemetry event is captured."""
+
+    @pytest.mark.asyncio
+    async def test_async_method_still_awaitable_and_returns_result(self):
+        target = DummyAsyncTarget()
+
+        result = await target.do_work(21)
+
+        assert result == 42
+
+    @pytest.mark.asyncio
+    async def test_async_success_captured_after_coroutine_actually_runs(self):
+        target = DummyAsyncTarget()
+
+        await target.do_work(1)
+
+        target.telemetry.capture.assert_called_once()
+        event = target.telemetry.capture.call_args.kwargs["event"]
+        assert event.EVENT_NAME == "test_async_event"
+        assert event.success is True
+        assert event.error_type is None
+        # do_work() sleeps 50ms before returning; a wrapper that captures
+        # timing before actually awaiting the coroutine would report ~0ms.
+        assert event.execution_time_ms >= 40
+
+    @pytest.mark.asyncio
+    async def test_async_exception_propagates_and_is_captured(self):
+        target = DummyAsyncTarget()
+
+        with pytest.raises(ValueError, match="boom"):
+            await target.do_fail()
+
+        target.telemetry.capture.assert_called_once()
+        event = target.telemetry.capture.call_args.kwargs["event"]
+        assert event.EVENT_NAME == "test_async_event_error"
+        assert event.success is False
+        assert event.error_type == "ValueError"
+
+
+class TestTelemetryDecoratorSync:
+    """Regression guard: sync methods must keep working exactly as before."""
+
+    def test_sync_success_captured(self):
+        target = DummySyncTarget()
+
+        result = target.do_work(21)
+
+        assert result == 42
+        target.telemetry.capture.assert_called_once()
+        event = target.telemetry.capture.call_args.kwargs["event"]
+        assert event.success is True
+        assert event.error_type is None
+
+    def test_sync_exception_propagates_and_is_captured(self):
+        target = DummySyncTarget()
+
+        with pytest.raises(ValueError, match="boom"):
+            target.do_fail()
+
+        target.telemetry.capture.assert_called_once()
+        event = target.telemetry.capture.call_args.kwargs["event"]
+        assert event.success is False
+        assert event.error_type == "ValueError"


### PR DESCRIPTION
## Changes
The `telemetry()` decorator's `wrapper` was always a plain `def`, even when decorating an `async def` method (e.g. `MCPSession.initialize`/`call_tool`, `BaseConnector.call_tool`/`list_tools`, `OAuth.initialize`/`authenticate`/`refresh_token`). Calling `func(self, *args, **kwargs)` on an async method just constructs a coroutine object without running its body. The decorator's `finally` block then recorded `success=True` and near-zero `execution_time_ms` immediately — before the wrapped method's body ever actually ran — and its `except` block could never catch real errors from the call, since those only surface later when the caller awaits the returned coroutine.

## Implementation Details
1. `telemetry()` now checks `asyncio.iscoroutinefunction(func)` and, for async methods, returns a proper `async def` wrapper that `await`s the wrapped coroutine before capturing the event.
2. Extracted the event-capture logic (looking up `self.telemetry`/`self._telemetry`, building `GenericTelemetryEvent`) into a shared `_capture` helper used by both the sync and async wrappers, to avoid duplicating that logic.
3. The sync path is otherwise unchanged.

## Example Usage (Before)
```python
@telemetry("server_initialize")
async def initialize(self):
    await asyncio.sleep(2)  # real work
    raise RuntimeError("connection refused")

# Telemetry recorded: success=True, execution_time_ms≈0, error_type=None
# (fabricated — the real exception surfaces later, uncaught by the decorator)
```

## Example Usage (After)
```python
# Telemetry recorded: success=False, execution_time_ms≈2000, error_type="RuntimeError"
```

## Documentation Updates
None needed — internal bugfix, no public API change.

## Testing
- Added `tests/unit/test_telemetry.py` covering both async and sync decorated methods: successful execution, exception propagation + capture, and that `execution_time_ms` reflects the coroutine's actual runtime (guards against the bug where timing was captured before the coroutine ran).
- Verified 2 of the 3 new async tests fail against the pre-fix code (timing ≈0ms, exceptions not correctly captured as failures) and all pass after the fix.
- `pytest tests/unit` passes (309 passed; the 1 pre-existing failure is an unrelated missing optional `e2b` dependency in the test env).
- `ruff check` / `ruff format --check` pass on changed files.

## Backwards Compatibility
Not breaking. Decorated async methods remain awaitable with the same return value/exception behavior from the caller's perspective; only the accuracy of the telemetry data captured internally changes.

## Related Issues
Closes #2091

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `telemetry()` decorator to await async methods so timing and errors reflect real execution. Also records cancellations (`CancelledError`) as failures while still propagating them; sync methods are unchanged.

- **Bug Fixes**
  - Use `asyncio.iscoroutinefunction` to return an async wrapper that `await`s the method, capturing real runtime, exceptions, and cancellations (treat `CancelledError` as failure and re-raise).

- **Refactors**
  - Extracted event capture into a shared `_capture` helper used by both async and sync wrappers.

<sup>Written for commit d72d02f2ca55602b794996f73c993ad754325169. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2096?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

