### PR TITLE
fix(python): don't default missing config auth to an empty dict

### DIFF
--- a/libraries/python/mcp_use/client/config.py
+++ b/libraries/python/mcp_use/client/config.py
@@ -113,7 +113,7 @@ def create_connector_from_config(
         return HttpConnector(
             base_url=server_config["url"],
             headers=server_config.get("headers", None),
-            auth=server_config.get("auth", {}),
+            auth=server_config.get("auth"),
             timeout=server_config.get("timeout", 5),
             sse_read_timeout=server_config.get("sse_read_timeout", 60 * 5),
             sampling_callback=sampling_callback,
@@ -136,7 +136,7 @@ def create_connector_from_config(
         return WebSocketConnector(
             url=server_config["ws_url"],
             headers=server_config.get("headers", None),
-            auth=server_config.get("auth", {}),
+            auth=server_config.get("auth"),
         )
 
     raise ValueError("Cannot determine connector type from config")

--- a/libraries/python/tests/unit/test_config.py
+++ b/libraries/python/tests/unit/test_config.py
@@ -95,6 +95,10 @@ class TestConnectorCreation(unittest.TestCase):
         self.assertEqual(connector.base_url, "http://test.com")
         self.assertEqual(connector.headers, {})
         self.assertIsNone(connector._auth)
+        # Regression: omitting "auth" from config must not implicitly construct
+        # an OAuth object (previously config.py defaulted auth to {} instead of
+        # None, and HttpConnector treats any non-None dict as OAuth config).
+        self.assertIsNone(connector._oauth)
 
     def test_create_websocket_connector(self):
         """Test creating a WebSocket connector from config."""
@@ -143,6 +147,17 @@ class TestConnectorCreation(unittest.TestCase):
         self.assertIsInstance(connector, WebSocketConnector)
         self.assertEqual(connector.url, "ws://test.com")
         self.assertEqual(connector.headers, {})
+
+    def test_create_websocket_connector_minimal_does_not_warn_about_auth(self):
+        """Regression: omitting "auth" from config must not implicitly pass an
+        empty dict to WebSocketConnector, which would hit its "only supports
+        bearer token authentication" warning path for a non-None, non-str auth."""
+        server_config = {"ws_url": "ws://test.com"}
+
+        with patch("mcp_use.client.connectors.websocket.logger") as mock_logger:
+            create_connector_from_config(server_config)
+
+        mock_logger.warning.assert_not_called()
 
     def test_create_stdio_connector(self):
         """Test creating a stdio connector from config."""


### PR DESCRIPTION
## Changes
`create_connector_from_config` passed `auth=server_config.get("auth", {})` for both HTTP and WebSocket connectors. Omitting `auth` from config is not the same as `None` to either connector:
- `HttpConnector._set_auth` treats any non-`None` dict as OAuth config, so an empty dict still constructs a real `OAuth` object, and `connect()` checks `if self._oauth:` (always truthy for an instance) — triggering OAuth discovery probes on every connect for a plain unauthenticated server.
- `WebSocketConnector.__init__` treats any non-`None`, non-`str` auth as unsupported and logs `"WebSocket connector only supports bearer token authentication"`, so minimal WS configs spuriously warn.

## Implementation Details
1. Changed both `server_config.get("auth", {})` call sites in `mcp_use/client/config.py` to `server_config.get("auth")`, which defaults to `None` — matching what both connectors already treat as "no auth configured".

## Example Usage (Before)
```python
# {"mcpServers": {"s": {"url": "http://localhost:8000"}}}  (no "auth" key)
connector._oauth is not None  # True — unwanted OAuth object constructed
```

## Example Usage (After)
```python
connector._oauth is None  # True
```

## Documentation Updates
None needed — internal bugfix, no public API change.

## Testing
- Extended `test_create_http_connector_minimal` in `tests/unit/test_config.py` to assert `connector._oauth is None`.
- Added `test_create_websocket_connector_minimal_does_not_warn_about_auth`, asserting the WebSocket connector's auth warning isn't logged for a minimal config.
- Verified both assertions fail against the pre-fix code and pass after the fix.
- `pytest tests/unit` passes (305 passed; the 1 pre-existing failure is an unrelated missing optional `e2b` dependency in the test env).
- `ruff check` / `ruff format --check` pass on changed files.

## Backwards Compatibility
Not breaking. Configs that explicitly set `auth` are unaffected; configs that omit it now correctly get no auth/OAuth behavior instead of an implicitly-constructed one.

## Related Issues
Closes #1817

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed auth handling in the Python client config: when the `auth` key is missing, we now pass `None` instead of `{}`. This prevents unintended OAuth discovery in `HttpConnector` and removes the bogus auth warning in `WebSocketConnector` for minimal configs.

- **Bug Fixes**
  - Updated `create_connector_from_config` to use `server_config.get("auth")` for both connectors.
  - Added unit tests to ensure no OAuth object is created and no auth warning is logged for minimal configs.

<sup>Written for commit 3aba49598c34311b96e0e78c1b0330c14b8dc902. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2097?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

