### PR TITLE
fix(cli): report success from `mcp-use typecheck`

### DIFF
--- a/libraries/typescript/.changeset/typecheck-success-line.md
+++ b/libraries/typescript/.changeset/typecheck-success-line.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Print `[mcp-use] no type errors (<duration>ms)` when `mcp-use typecheck` passes. `tsc --noEmit` writes nothing on a clean project, so the command used to exit `0` with no output at all, which was indistinguishable from a hang or a silent failure. Failing runs are unchanged and still show only the compiler's own diagnostics.

--- a/libraries/typescript/packages/server/specs/CLI_SPEC.md
+++ b/libraries/typescript/packages/server/specs/CLI_SPEC.md
@@ -264,7 +264,7 @@ Rules, all inherited from v1 and locked:
 
 ### `mcp-use typecheck` (in `src/cli/typecheck.ts`, dispatched from the bin)
 
-Discovers the server entry with the same `--path`, `--entry`, and `--mcp-dir` rules as `dev`/`build`, reconciles the managed root `mcp-env.d.ts`, then resolves `typescript` from the selected project and invokes its `tsc` binary with `--noEmit`. This preserves the project's compiler version and plugins; the CLI does not bundle TypeScript. Arguments after `--` are forwarded to `tsc`, and the command returns the compiler's exit code. Missing TypeScript or entry discovery failures exit `1` with an actionable error.
+Discovers the server entry with the same `--path`, `--entry`, and `--mcp-dir` rules as `dev`/`build`, reconciles the managed root `mcp-env.d.ts`, then resolves `typescript` from the selected project and invokes its `tsc` binary with `--noEmit`. This preserves the project's compiler version and plugins; the CLI does not bundle TypeScript. Arguments after `--` are forwarded to `tsc`, and the command returns the compiler's exit code. A clean run prints `[mcp-use] no type errors (<duration>ms)` to stdout, because `tsc --noEmit` is otherwise silent on success and a silent exit is indistinguishable from a hang. Failing runs add nothing to the compiler's own diagnostics. Missing TypeScript or entry discovery failures exit `1` with an actionable error.
 
 The command does not inspect or execute the server and does not generate tool-specific types. Its only type preparation is keeping the constant `typeof import("./entry.js")` bridge current. Templates commit that bridge, so editor typechecking and a direct `tsc --noEmit` also work before any mcp-use command has run. No install or postinstall lifecycle hook is involved.
 

--- a/libraries/typescript/packages/server/src/cli/typecheck.ts
+++ b/libraries/typescript/packages/server/src/cli/typecheck.ts
@@ -23,11 +23,15 @@ export interface TypecheckOptions {
  * Refresh the MCP environment declaration and run the project's own
  * TypeScript compiler with emission disabled.
  *
+ * TypeScript prints nothing when a project is clean, so a success line is
+ * written on exit code `0` to distinguish a passing run from a hung one.
+ *
  * @returns The exit code returned by TypeScript.
  * @throws If the entry cannot be found, TypeScript is not installed in the
  * project, or the compiler process cannot be started.
  */
 export async function runTypecheck(options: TypecheckOptions): Promise<number> {
+  const startedAt = performance.now();
   const sourceRoot =
     options.mcpDir === undefined
       ? options.cwd
@@ -44,7 +48,16 @@ export async function runTypecheck(options: TypecheckOptions): Promise<number> {
   }
 
   const compiler = resolveProjectTypeScript(options.cwd);
-  return runCompiler(compiler, options.cwd, options.tscArgs ?? []);
+  const exitCode = await runCompiler(
+    compiler,
+    options.cwd,
+    options.tscArgs ?? []
+  );
+  if (exitCode === 0) {
+    const duration = Math.round(performance.now() - startedAt);
+    console.log(`[mcp-use] no type errors (${duration}ms)`);
+  }
+  return exitCode;
 }
 
 /** Resolve the `tsc` binary from the selected project's TypeScript package. */

--- a/libraries/typescript/packages/server/tests/cli/typecheck.test.ts
+++ b/libraries/typescript/packages/server/tests/cli/typecheck.test.ts
@@ -1,6 +1,6 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { afterAll, describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it, vi } from "vitest";
 
 import { runTypecheck } from "../../src/cli/typecheck.js";
 import { copyFixture, removeDir } from "./helpers.js";
@@ -10,6 +10,22 @@ const dirs: string[] = [];
 afterAll(() => {
   for (const dir of dirs) removeDir(dir);
 });
+
+/** Minimal strict tsconfig for a scratch fixture. */
+function writeTsconfig(cwd: string, include: string[]): void {
+  writeFileSync(
+    join(cwd, "tsconfig.json"),
+    JSON.stringify({
+      compilerOptions: {
+        module: "NodeNext",
+        moduleResolution: "NodeNext",
+        strict: true,
+        skipLibCheck: true,
+      },
+      include,
+    })
+  );
+}
 
 describe("runTypecheck", () => {
   it("creates mcp-env.d.ts before tsc checks unexported tool refs", async () => {
@@ -30,18 +46,7 @@ describe("runTypecheck", () => {
         'useCallTool("add");',
       ].join("\n")
     );
-    writeFileSync(
-      join(cwd, "tsconfig.json"),
-      JSON.stringify({
-        compilerOptions: {
-          module: "NodeNext",
-          moduleResolution: "NodeNext",
-          strict: true,
-          skipLibCheck: true,
-        },
-        include: ["src/**/*", "view.ts", "mcp-env.d.ts"],
-      })
-    );
+    writeTsconfig(cwd, ["src/**/*", "view.ts", "mcp-env.d.ts"]);
 
     await expect(
       runTypecheck({ cwd, tscArgs: ["--pretty", "false"] })
@@ -52,5 +57,46 @@ describe("runTypecheck", () => {
     expect(readFileSync(join(cwd, "mcp-env.d.ts"), "utf8")).toContain(
       'import "mcp-use/vite-client"'
     );
+  });
+
+  it("reports success on stdout when the project is clean", async () => {
+    const cwd = copyFixture("typecheck-clean");
+    dirs.push(cwd);
+    writeTsconfig(cwd, ["src/**/*", "mcp-env.d.ts"]);
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    try {
+      await expect(
+        runTypecheck({ cwd, tscArgs: ["--pretty", "false"] })
+      ).resolves.toBe(0);
+      const lines = log.mock.calls.map((call) => String(call[0]));
+      expect(lines).toContainEqual(
+        expect.stringMatching(/^\[mcp-use] no type errors \(\d+ms\)$/)
+      );
+    } finally {
+      log.mockRestore();
+    }
+  });
+
+  it("stays silent about success when tsc reports errors", async () => {
+    const cwd = copyFixture("typecheck-errors");
+    dirs.push(cwd);
+    writeFileSync(join(cwd, "bad.ts"), "export const port: number = 'nope';\n");
+    writeTsconfig(cwd, ["src/**/*", "bad.ts", "mcp-env.d.ts"]);
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    try {
+      const exitCode = await runTypecheck({
+        cwd,
+        tscArgs: ["--pretty", "false"],
+      });
+      expect(exitCode).not.toBe(0);
+      const lines = log.mock.calls.map((call) => String(call[0]));
+      expect(lines).not.toContainEqual(
+        expect.stringContaining("no type errors")
+      );
+    } finally {
+      log.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
## Changes

`mcp-use typecheck` now prints a success line when the project is clean:

```
$ mcp-use typecheck
[mcp-use] no type errors (102ms)
$ echo $?
0
```

Closes #2083.

## Implementation Details

1. `runTypecheck` (`packages/server/src/cli/typecheck.ts`) awaits the compiler's exit code and, on `0`, logs `[mcp-use] no type errors (<duration>ms)`.
2. Format follows the existing `build` convention (`[mcp-use] built <entry> → <out> (<duration>ms)`), so the two toolchain commands read the same. No checkmark glyph, since nothing else in the CLI uses one, and no ANSI, so the line is safe in logs.
3. Failing runs are untouched: no extra line, only `tsc`'s own diagnostics, and the compiler's exit code is still returned verbatim.
4. `specs/CLI_SPEC.md` §`mcp-use typecheck` updated in the same change, per the package's spec-is-contract rule.

The duration is there rather than a file count because `tsc --noEmit` does not report how many files it checked without a second pass (`--listFiles`), and the point of the issue is "did this actually run" — a timing figure answers that at zero cost. Happy to swap it for a plain `[mcp-use] no type errors` if you'd rather keep the line fixed-width.

## Example Usage (Before)

```
$ bun run typecheck
$ mcp-use typecheck
$ echo $?
0
```

## Example Usage (After)

```
$ bun run typecheck
$ mcp-use typecheck
[mcp-use] no type errors (102ms)
$ echo $?
0
```

## Documentation Updates

- `libraries/typescript/packages/server/specs/CLI_SPEC.md` — the `typecheck` contract now states the success line and that failing runs add nothing to the compiler's diagnostics.
- Changeset added (`typecheck-success-line.md`, patch on `mcp-use`).

## Testing

Two tests added to `packages/server/tests/cli/typecheck.test.ts` (the shared tsconfig writer was factored out of the existing test, which is otherwise unchanged):

- `reports success on stdout when the project is clean` — asserts exit `0` and a `console.log` matching `/^\[mcp-use] no type errors \(\d+ms\)$/`.
- `stays silent about success when tsc reports errors` — a project with a real type error exits non-zero and logs no success line.

Verified red-without-fix: stashing only the `src/cli/typecheck.ts` change makes the first test fail, and restoring it makes it pass.

```
$ pnpm vitest run tests/cli tests/budgets tests/commands
 Test Files  24 passed (24)
      Tests  241 passed (241)
```

`pnpm typecheck` on the package is clean, and `pnpm lint` passes at the workspace root.

End to end against a real project, using the built bin in `packages/server/examples/basic`:

```
$ node ../../dist/bin.js typecheck
[mcp-use] created mcp-env.d.ts
[mcp-use] no type errors (102ms)
exit=0
```

## Backwards Compatibility

Additive stdout only. The exit code contract is unchanged, and nothing machine-readable is affected (`typecheck` has no `--json` mode). A script that asserted this command produces zero output would see the new line, which is the reported bug.

## Related Issues

Closes #2083

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`mcp-use typecheck` now prints a success line on clean runs, making it clear the command completed and matching the `build` output format. Exit codes and failing run behavior are unchanged. Closes #2083.

- **Bug Fixes**
  - Print `[mcp-use] no type errors (<duration>ms)` when `tsc --noEmit` exits 0; no ANSI or glyphs.
  - Failing runs add nothing beyond `tsc` diagnostics and return the same exit code; spec and tests updated.

<sup>Written for commit 045d51f695f6419cb89444d8d8905e773f48aba7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2099?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

