### PR TITLE
feat(server): add Skills over MCP

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -349,7 +349,8 @@
                         "pages": [
                           "v2/typescript/server/tools",
                           "v2/typescript/server/resources",
-                          "v2/typescript/server/prompts"
+                          "v2/typescript/server/prompts",
+                          "v2/typescript/server/skills"
                         ]
                       },
                       {

--- a/docs/v2/typescript/server/skills.mdx
+++ b/docs/v2/typescript/server/skills.mdx
@@ -1,0 +1,109 @@
+---
+title: "Skills over MCP"
+description: "Ship Agent Skills with your MCP server using automatic directory discovery."
+---
+
+<Warning>
+  Skills over MCP follows the draft SEP-2640 extension. The wire contract may
+  change before the extension becomes final. Only serve skills you trust, and
+  hosts should require user approval before activating a skill or its allowed
+  tools.
+</Warning>
+
+Skills let an MCP server ship its operating manual alongside its tools. Hosts
+can first inspect the small skill catalog, then read `SKILL.md` and only the
+supporting references, scripts, templates, or assets needed for the task.
+
+## Zero-configuration setup
+
+Create a conventional `skills/` directory next to your server project. Its
+presence enables Skills over MCP automatically; no server option is required.
+
+```text
+skills/
+  refunds/
+    SKILL.md
+    references/
+      policy.md
+    templates/
+      confirmation.md
+```
+
+```ts
+import { MCPServer } from "mcp-use";
+
+const server = new MCPServer({
+  name: "shop",
+  version: "1.0.0",
+});
+
+export default server;
+```
+
+Every skill needs a `SKILL.md` whose `name` matches its directory:
+
+```md
+---
+name: refunds
+description: Check eligibility and process customer refunds safely
+license: Apache-2.0
+compatibility: Requires the shop refund tools
+metadata:
+  owner: support-platform
+---
+
+# Refund orders
+
+Read `references/policy.md` before deciding whether an order is eligible.
+Use `templates/confirmation.md` when the refund succeeds.
+```
+
+All frontmatter fields are preserved. Supporting text, scripts, data, and
+binary files are exposed as individual MCP resources with raw-byte SHA-256
+digests. Nested directories containing their own `SKILL.md` are published as
+independent skills as well as supporting content of their parent skill.
+
+## Configure discovery
+
+```ts
+// Require the conventional skills/ directory to exist.
+new MCPServer({ name: "shop", version: "1.0.0", skills: true });
+
+// Ignore skills/ even when it exists.
+new MCPServer({ name: "shop", version: "1.0.0", skills: false });
+
+// Require a project-relative custom directory.
+new MCPServer({
+  name: "shop",
+  version: "1.0.0",
+  skills: { directory: "server-skills" },
+});
+```
+
+With `mcp-use dev --mcp-dir src/mcp`, the conventional directory becomes
+`src/mcp/skills`. An explicit `skills.directory` remains relative to the
+project root. Missing directories are silent only for automatic discovery;
+`true`, `{}`, and custom configuration fail with an actionable error.
+
+## What hosts discover
+
+When skills are enabled the server declares
+`io.modelcontextprotocol/skills` with directory reads. Hosts use:
+
+- `skills/list` for the deterministic skill catalog and complete digest sets.
+- `skills/get` to refresh or retrieve one skill by its `SKILL.md` URI.
+- `resources/read` for individual text or binary files.
+- `resources/directory/read` to inspect one directory level at a time.
+
+The SDK does not inject skill text into server instructions or tool
+descriptions. Progressive disclosure and activation remain host decisions.
+
+`mcp-use dev` revalidates skills while the server runs and keeps the last
+valid server when an edit is invalid. `mcp-use build` embeds the validated
+snapshot, so the production server does not need the source skill directory.
+
+## Specifications
+
+- [Skills over MCP Working Group](https://modelcontextprotocol.io/community/working-groups/skills-over-mcp)
+- [SEP-2640 draft](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640)
+- [Agent Skills specification](https://agentskills.io/specification)

--- a/libraries/typescript/.changeset/soft-skills-travel.md
+++ b/libraries/typescript/.changeset/soft-skills-travel.md
@@ -1,0 +1,7 @@
+---
+"mcp-use": minor
+---
+
+Add experimental server authoring support for Skills over MCP with automatic
+`skills/` discovery, explicit disable and directory configuration, SEP-2640
+resource methods, development reloads, and build-time embedding.

--- a/libraries/typescript/packages/server/package.json
+++ b/libraries/typescript/packages/server/package.json
@@ -118,8 +118,7 @@
     "@modelcontextprotocol/ext-apps": "npm:@mcp-use/ext-apps@1.7.4-pr720.1",
     "@modelcontextprotocol/server": "2.0.0",
     "hono": "^4.12.27",
-    "jose": "^6.1.3",
-    "yaml": "^2.8.3"
+    "jose": "^6.1.3"
   },
   "peerDependencies": {
     "@mcp-use/client": "^2.0.0-alpha.0",
@@ -154,6 +153,7 @@
     "typescript": "^7.0.2",
     "vite": "^8.0.16",
     "vitest": "^4.1.9",
+    "yaml": "^2.8.3",
     "zod": "^4.4.3"
   },
   "publishConfig": {

--- a/libraries/typescript/packages/server/package.json
+++ b/libraries/typescript/packages/server/package.json
@@ -26,6 +26,12 @@
       "browser": "./dist/internal/node-http-unavailable.js",
       "node": "./dist/internal/node-http.js",
       "default": "./dist/internal/node-http-unavailable.js"
+    },
+    "#mcp-use-skills-loader": {
+      "workerd": "./dist/internal/skills-loader-unavailable.js",
+      "browser": "./dist/internal/skills-loader-unavailable.js",
+      "node": "./dist/internal/skills-loader.js",
+      "default": "./dist/internal/skills-loader-unavailable.js"
     }
   },
   "exports": {
@@ -112,7 +118,8 @@
     "@modelcontextprotocol/ext-apps": "npm:@mcp-use/ext-apps@1.7.4-pr720.1",
     "@modelcontextprotocol/server": "2.0.0",
     "hono": "^4.12.27",
-    "jose": "^6.1.3"
+    "jose": "^6.1.3",
+    "yaml": "^2.8.3"
   },
   "peerDependencies": {
     "@mcp-use/client": "^2.0.0-alpha.0",

--- a/libraries/typescript/packages/server/specs/CLI_SPEC.md
+++ b/libraries/typescript/packages/server/specs/CLI_SPEC.md
@@ -4,6 +4,26 @@
 **Scope:** the complete first-party `mcp-use` CLI: `dev`, `build`, `typecheck`, `start`, cloud auth, organizations, servers, deployments, deploy, client, and screenshot; plus optional Inspector mounting in `dev` and production `start`.
 **Package:** `mcp-use@2`, published from `packages/server`. The package owns the bin, runtime, command chunks, and toolchain. The development Inspector remains independently published. There is no separate CLI implementation, devkit, or config package. `@mcp-use/cli@4` is a compatibility-only proxy for the historical install command.
 
+## Skills lifecycle
+
+`dev` and `build` resolve the conventional skills directory alongside the MCP
+source root: `skills/` normally and `<mcp-dir>/skills` with `--mcp-dir`.
+Explicit `ServerConfig.skills.directory` values remain relative to the project
+root. The CLI imports the entry, lets the server apply config precedence, and
+validates a complete static snapshot before mounting or emitting output.
+
+Development watches skill content as server input. A valid change swaps the
+whole server generation and publishes the ordinary resources-list change event;
+an invalid edit reports the validation error and retains the last valid
+handler. A present empty directory warns and still enables an empty catalog.
+
+Build wrappers prime the server with JSON-safe metadata, UTF-8 text, and
+base64 binary contents. The emitted server must continue serving identical
+skills after the source directory is removed. Builds fail for a missing forced
+directory, invalid YAML or Agent Skills metadata, unsafe configuration, or an
+invalid discovered file tree. Generated project templates do not create a
+skills directory by default.
+
 ## Goals
 
 - `npm install mcp-use` is sufficient for `mcp-use dev`, `mcp-use build`, and `mcp-use start`; users do not install Vite separately.

--- a/libraries/typescript/packages/server/specs/SPEC.md
+++ b/libraries/typescript/packages/server/specs/SPEC.md
@@ -1,6 +1,6 @@
 # mcp-use v2 — server framework contract
 
-**Status:** Core MCP primitives, request logging, landing page, direct resource-server auth, views, and the complete CLI are implemented.
+**Status:** Core MCP primitives, request logging, landing page, direct resource-server auth, views, experimental Skills over MCP, and the complete CLI are implemented.
 **Package:** `mcp-use@2`, published from `packages/server`.
 **Branch target:** `v2`.
 
@@ -29,6 +29,37 @@ Greenfield framework on the official v2 SDK (`@modelcontextprotocol/server`, sta
 - **No registry return-type accumulation.** `MCPServer<TUser, TEnv>` uses generics only for OAuth user data and Hono environment/bindings; registration methods never return `MCPServer<TTools & {...}>` (the tRPC/Hono/Skybridge pattern). The official v2 SDK does it on neither side (`registerTool` returns a `RegisteredTool` handle; client `callTool` is untyped), our client's primary job is connecting to _third-party_ servers (no server type to import), and accumulation only sees literal chained calls — it structurally cannot type loop/conditional registration or OpenAPI-imported tools. Typed hooks use exported `ToolRef` handles instead. Callback types are plain function types (no bivariance hack); narrow-to-wide erasure happens at the registry `.set()` boundary via contained casts.
 
 ## Phase 1 — basic MCP pieces ✅
+
+### Experimental Skills over MCP
+
+`ServerConfig.skills` is `boolean | { directory?: string }`. Omission is
+convention-first: a project `skills/` directory enables the extension when it
+exists and is otherwise ignored. `false` always disables it. `true` and object
+forms force discovery and fail when the effective directory is missing. A
+custom `directory` is a safe project-root-relative path. With CLI `--mcp-dir`,
+only the default convention moves to `<mcp-dir>/skills`; explicit directories
+remain project-root-relative.
+
+Discovery recursively finds every `SKILL.md`, validates Agent Skills YAML,
+name, description, and directory matching, skips symlinks, and rejects paths
+outside the project. Each skill includes every regular descendant file,
+including nested skills, scripts, data, and binary assets. Frontmatter is
+preserved as JSON. Files receive appropriate MIME types and a
+`sha256:<lowercase hex>` digest of their raw bytes. Discovery produces one
+immutable snapshot before serving; development replaces the entire server on
+a valid edit and production builds embed the snapshot.
+
+An enabled snapshot advertises `io.modelcontextprotocol/skills` with
+`directoryRead: true`, implements deterministic `skills/list` and
+URI-addressed `skills/get`, serves files through `resources/read`, and provides
+non-recursive `resources/directory/read`. Unknown skills and directories return
+`-32602`. No index resource, archive, aggregate digest, automatic instruction
+injection, or tool-description rewriting exists. The extension is advertised
+for an existing but empty directory and `skills/list` returns an empty array.
+
+Node source execution discovers on first mount. Browser/workerd entries contain
+no filesystem, YAML, hashing, or MIME discovery code; those runtimes require a
+snapshot primed by the build wrapper.
 
 Scope: server identity, tools, resources, resource templates, prompts, completion, and HTTP serving. Files: `src/server.ts` (MCPServer), `src/mount-mcp.ts` (fetch-native MCP mount), `src/config.ts` (ServerConfig), `src/context.ts` (RequestContext), one file per primitive's types (`src/tools.ts`, `src/resources.ts`, `src/prompts.ts`), and `src/completable.ts`. The bin, toolchain, and optional development Inspector integration (`src/cli/inspector.ts`) are governed by `CLI_SPEC.md`. Callbacks prefer raw SDK result shapes (see ground rules); deprecated response helpers and a small resource/prompt conversion layer remain for upgrade compatibility. Types-plus-tests typecheck runs via `tsconfig.test.json` (`pnpm typecheck`, part of `test:run`); compile-time contracts are pinned by `tests/type-level.test.ts` (`@ts-expect-error` + `expectTypeOf`).
 

--- a/libraries/typescript/packages/server/src/cli/build.ts
+++ b/libraries/typescript/packages/server/src/cli/build.ts
@@ -30,6 +30,7 @@ import {
 import { mcpUseViewsPlugin } from "./views-plugin.js";
 import { syncMcpEnvDeclaration } from "./mcp-env-declaration.js";
 import {
+  discoverSkillsAtBuild,
   resolveBuildBasePath,
   validateViewBindingsAtBuild,
 } from "./views-bindings.js";
@@ -45,6 +46,7 @@ import { resolveWorkspacePaths, type BuildManifest } from "./workspace.js";
 import { normalizeAssetsBaseUrl } from "../views/origin.js";
 import { viewAssetsBasePath } from "../views/document.js";
 import type { ViewsManifest } from "../views/types.js";
+import type { SkillsSnapshot } from "../skills/types.js";
 
 /** Fixed filename of the emitted server entry inside `.mcp-use/build/`. */
 const BUILD_ENTRY_NAME = "index.js";
@@ -97,17 +99,20 @@ export interface BuildOptions {
 async function writeWrapperEntry(
   cacheDir: string,
   userEntry: string,
-  viewsManifest: ViewsManifest
+  viewsManifest: ViewsManifest,
+  skillsSnapshot: SkillsSnapshot | undefined
 ): Promise<string> {
   const wrapperPath = join(cacheDir, WRAPPER_BASENAME);
   await mkdir(cacheDir, { recursive: true });
   const manifestJson = JSON.stringify(viewsManifest);
+  const skillsJson = JSON.stringify(skillsSnapshot);
   await writeFile(
     wrapperPath,
     [
       `import server from ${JSON.stringify(userEntry)};`,
-      `import { registerViews } from "mcp-use";`,
+      `import { registerSkills, registerViews } from "mcp-use";`,
       `server[registerViews](${manifestJson});`,
+      `server[registerSkills](${skillsJson});`,
       `export default server;`,
       "",
     ].join("\n")
@@ -335,6 +340,8 @@ export async function runBuild(options: BuildOptions): Promise<void> {
   let bindingServer:
     | Awaited<ReturnType<typeof createBindingValidationServer>>
     | undefined;
+  const conventionalSkillsDirectory =
+    options.mcpDir === undefined ? "skills" : join(options.mcpDir, "skills");
 
   if (views.length === 0) {
     bindingServer ??= await createBindingValidationServer(
@@ -342,13 +349,25 @@ export async function runBuild(options: BuildOptions): Promise<void> {
       paths.cache,
       false
     );
+    const skillsSnapshot = await discoverSkillsAtBuild(
+      bindingServer.environments.ssr,
+      entry,
+      options.cwd,
+      conventionalSkillsDirectory
+    );
     try {
       await validateViewBindingsAtBuild(
         bindingServer.environments.ssr,
         entry,
-        {}
+        {},
+        skillsSnapshot
       );
-      const wrapperEntry = await writeWrapperEntry(paths.cache, entry, {});
+      const wrapperEntry = await writeWrapperEntry(
+        paths.cache,
+        entry,
+        {},
+        skillsSnapshot
+      );
       await build({
         root: options.cwd,
         configFile: false,
@@ -421,6 +440,12 @@ export async function runBuild(options: BuildOptions): Promise<void> {
   );
   let buildBasePath: string;
   const viewsManifest: ViewsManifest = {};
+  const skillsSnapshot = await discoverSkillsAtBuild(
+    bindingServer.environments.ssr,
+    entry,
+    options.cwd,
+    conventionalSkillsDirectory
+  );
   const buildAssetsBase = readBuildAssetsBase();
   try {
     buildBasePath = await resolveBuildBasePath(
@@ -469,7 +494,8 @@ export async function runBuild(options: BuildOptions): Promise<void> {
     await validateViewBindingsAtBuild(
       bindingServer.environments.ssr,
       entry,
-      viewsManifest
+      viewsManifest,
+      skillsSnapshot
     );
   } finally {
     await bindingServer.close();
@@ -478,7 +504,8 @@ export async function runBuild(options: BuildOptions): Promise<void> {
   const wrapperEntry = await writeWrapperEntry(
     paths.cache,
     entry,
-    viewsManifest
+    viewsManifest,
+    skillsSnapshot
   );
 
   await build({

--- a/libraries/typescript/packages/server/src/cli/dev.ts
+++ b/libraries/typescript/packages/server/src/cli/dev.ts
@@ -70,6 +70,7 @@ import {
   type DiscoveredView,
 } from "./views.js";
 import type { ViewsManifest } from "../views/types.js";
+import type { SkillsSnapshot } from "../skills/types.js";
 
 /** Canonical Web handler exposed by `MCPServer.fetch`. */
 type WebHandler = (request: Request) => Promise<Response>;
@@ -89,6 +90,10 @@ interface ServerLike {
     views: ViewsManifest,
     options?: { dev?: boolean; projectRoot?: string }
   ): void;
+  __discoverSkills(
+    projectRoot: string,
+    conventionalDirectory?: string
+  ): Promise<SkillsSnapshot | undefined>;
 }
 
 /**
@@ -370,6 +375,8 @@ export async function runDev(options: DevOptions): Promise<void> {
   const viewsDirectory =
     options.viewsDir ??
     (options.mcpDir === undefined ? undefined : join(options.mcpDir, "views"));
+  const conventionalSkillsDirectory =
+    options.mcpDir === undefined ? "skills" : join(options.mcpDir, "skills");
   if (!existsSync(resolveViewsDir(options.cwd, viewsDirectory))) {
     console.log("[mcp-use] views directory not configured.");
   }
@@ -462,6 +469,7 @@ export async function runDev(options: DevOptions): Promise<void> {
         unknown
       >;
       const server = serverFrom(moduleExports);
+      await server.__discoverSkills(options.cwd, conventionalSkillsDirectory);
       const viewsManifest = buildDevViewsManifest(currentViews);
       if (typeof server.__primeViews !== "function") {
         throw new Error(
@@ -590,6 +598,19 @@ export async function runDev(options: DevOptions): Promise<void> {
 
   const onSsrFileEvent = (file: string): void => {
     if (isViewPath(file, options.cwd, viewsDirectory)) {
+      return;
+    }
+    const normalizedFile = file.replaceAll("\\", "/");
+    const normalizedConventional = resolve(
+      options.cwd,
+      conventionalSkillsDirectory
+    ).replaceAll("\\", "/");
+    if (
+      normalizedFile === normalizedConventional ||
+      normalizedFile.startsWith(`${normalizedConventional}/`) ||
+      normalizedFile.endsWith("/SKILL.md")
+    ) {
+      reload();
       return;
     }
     const modules = ssrEnvironment.moduleGraph.getModulesByFile(file);

--- a/libraries/typescript/packages/server/src/cli/views-bindings.ts
+++ b/libraries/typescript/packages/server/src/cli/views-bindings.ts
@@ -5,6 +5,7 @@
 import { createServerModuleRunner, type DevEnvironment } from "vite";
 
 import type { ViewsManifest } from "../views/types.js";
+import type { SkillsOptions, SkillsSnapshot } from "../skills/types.js";
 
 const DEFAULT_BASE_PATH = "/mcp";
 
@@ -19,7 +20,51 @@ const BUILD_ENTRY_MCP_URL = "http://localhost:3000";
 interface ServerLike {
   __mount(): void;
   __primeViews(views: ViewsManifest, options?: { dev?: boolean }): void;
+  __primeSkills(snapshot: SkillsSnapshot | undefined): void;
+  __discoverSkills(
+    projectRoot: string,
+    conventionalDirectory?: string
+  ): Promise<SkillsSnapshot | undefined>;
+  __skillsConfig(): boolean | SkillsOptions | undefined;
   basePath?: string;
+}
+
+/** Discover and validate the entry's configured skills for embedding. */
+export async function discoverSkillsAtBuild(
+  environment: DevEnvironment,
+  entry: string,
+  projectRoot: string,
+  conventionalDirectory: string
+): Promise<SkillsSnapshot | undefined> {
+  const runner = createServerModuleRunner(environment, {
+    hmr: false,
+    sourcemapInterceptor: "node",
+  });
+  try {
+    const serverModule = (await runner.import(entry)) as {
+      default?: ServerLike;
+    };
+    const server = serverModule.default;
+    if (server === null || typeof server !== "object") {
+      throw new Error(
+        "The server entry must default-export the MCPServer instance."
+      );
+    }
+    if (typeof server.__skillsConfig !== "function") {
+      throw new Error(
+        "The entry's default export does not support Skills over MCP."
+      );
+    }
+    const { discoverConfiguredSkills } =
+      await import("../skills/node-loader.js");
+    return discoverConfiguredSkills(
+      server.__skillsConfig(),
+      projectRoot,
+      conventionalDirectory
+    );
+  } finally {
+    await runner.close();
+  }
 }
 
 /**
@@ -95,7 +140,8 @@ export async function resolveBuildBasePath(
 export async function validateViewBindingsAtBuild(
   environment: DevEnvironment,
   entry: string,
-  viewsManifest: ViewsManifest
+  viewsManifest: ViewsManifest,
+  skillsSnapshot?: SkillsSnapshot
 ): Promise<void> {
   const runner = createServerModuleRunner(environment, {
     hmr: false,
@@ -123,6 +169,7 @@ export async function validateViewBindingsAtBuild(
       );
     }
     server.__primeViews(viewsManifest);
+    server.__primeSkills(skillsSnapshot);
     server.__mount();
   } finally {
     if (previousMcpUrl === undefined) {

--- a/libraries/typescript/packages/server/src/config.ts
+++ b/libraries/typescript/packages/server/src/config.ts
@@ -2,6 +2,7 @@ import type { Icon, ServerOptions } from "@modelcontextprotocol/server";
 
 import type { LoggingOptions } from "./logging.js";
 import type { OAuthProvider } from "./oauth/index.js";
+import type { SkillsOptions } from "./skills/types.js";
 
 /**
  * Common server identity and behavior, passed to `new MCPServer(...)`.
@@ -176,6 +177,26 @@ interface BaseServerConfig {
    */
   logging?: LoggingOptions;
   /**
+   * Experimental Agent Skills discovery.
+   *
+   * Omit this field to automatically serve a conventional `skills/`
+   * directory when present. Set `false` to disable discovery even when that
+   * directory exists, `true` to require it, or provide an object to require a
+   * custom project-relative directory.
+   *
+   * @defaultValue Automatic discovery of `skills/` when present
+   *
+   * @example
+   * ```ts
+   * new MCPServer({
+   *   name: "shop",
+   *   version: "1.0.0",
+   *   skills: { directory: "server-skills" },
+   * });
+   * ```
+   */
+  skills?: boolean | SkillsOptions;
+  /**
    * Integrity verification for `requestState` echoed across
    * `input_required` rounds.
    *
@@ -237,11 +258,13 @@ export interface CorsOptions {
  *
  * @throws TypeError When `basePath` is present but not an absolute URL
  * pathname without empty segments, trailing slash, query, fragment, or
- * whitespace.
+ * whitespace, or when `skills` is not a boolean or valid configuration
+ * object.
  */
 export function assertServerConfig(config: {
   basePath?: unknown;
   port?: unknown;
+  skills?: unknown;
 }): void {
   if (config.basePath !== undefined) {
     if (typeof config.basePath !== "string") {
@@ -271,6 +294,19 @@ export function assertServerConfig(config: {
       config.port > 65535)
   ) {
     throw new TypeError("port must be an integer between 0 and 65535");
+  }
+  if (config.skills !== undefined && typeof config.skills !== "boolean") {
+    if (
+      typeof config.skills !== "object" ||
+      config.skills === null ||
+      Array.isArray(config.skills)
+    ) {
+      throw new TypeError("skills must be a boolean or configuration object");
+    }
+    const directory = (config.skills as Record<string, unknown>)["directory"];
+    if (directory !== undefined && typeof directory !== "string") {
+      throw new TypeError("skills.directory must be a string when provided");
+    }
   }
 }
 

--- a/libraries/typescript/packages/server/src/index.ts
+++ b/libraries/typescript/packages/server/src/index.ts
@@ -86,6 +86,14 @@ export type {
 } from "@modelcontextprotocol/server";
 
 export type { ServerConfig, CorsOptions } from "./config.js";
+export { registerSkills, SKILLS_EXTENSION_ID } from "./skills/types.js";
+export type {
+  SkillsOptions,
+  SkillsSnapshot,
+  SkillDirectorySnapshot,
+  SkillSnapshotEntry,
+  SkillResourceSnapshot,
+} from "./skills/types.js";
 export type { ServerBranding } from "./branding.js";
 /** Official MCP icon shape used by {@link ServerConfig.icons}. */
 export type { Icon } from "@modelcontextprotocol/server";

--- a/libraries/typescript/packages/server/src/internal-imports.d.ts
+++ b/libraries/typescript/packages/server/src/internal-imports.d.ts
@@ -1,3 +1,11 @@
 declare module "#mcp-use-node-http" {
   export const createServer: typeof import("node:http").createServer;
 }
+
+declare module "#mcp-use-skills-loader" {
+  export function discoverConfiguredSkills(
+    config: boolean | import("./skills/types.js").SkillsOptions | undefined,
+    projectRoot: string,
+    conventionalDirectory?: string
+  ): import("./skills/types.js").SkillsSnapshot | undefined;
+}

--- a/libraries/typescript/packages/server/src/server.ts
+++ b/libraries/typescript/packages/server/src/server.ts
@@ -107,6 +107,13 @@ import type {
 } from "./tools.js";
 import { resolveToolInputSchema } from "./tools.js";
 import { isUsageDisabled, recordUsage } from "./usage.js";
+import { registerSkillsRuntime } from "./skills/runtime.js";
+import {
+  registerSkills,
+  SKILLS_EXTENSION_ID,
+  type SkillsOptions,
+  type SkillsSnapshot,
+} from "./skills/types.js";
 import { supportsViews } from "./views/capabilities.js";
 import type { ViewResourceFacts } from "./views/types.js";
 import {
@@ -350,6 +357,9 @@ export class MCPServer<TUser = never, TEnv extends Env = Env> {
   >();
   readonly #prompts = new Map<string, PromptEntry<TUser, TEnv>>();
   readonly #views = new Map<string, ViewManifestEntry>();
+  #skills: SkillsSnapshot | undefined;
+  #skillsPrimed = false;
+  #skillsDiscovery: Promise<void> | undefined;
   /**
    * One-to-one tool→view bindings. Each view name maps to the single tool
    * that bound it; that tool's `view:` config is the sole source of
@@ -488,6 +498,7 @@ export class MCPServer<TUser = never, TEnv extends Env = Env> {
     this.delete = this.app.delete.bind(this.app) as Hono<TEnv>["delete"];
     this.all = this.app.all.bind(this.app) as Hono<TEnv>["all"];
     this.fetch = async (request, env, executionCtx) => {
+      await this.#ensureSkillsPrimed();
       this.#ensureMounted("handler");
       return this.#httpApp!.fetch(request, env, executionCtx);
     };
@@ -640,6 +651,62 @@ export class MCPServer<TUser = never, TEnv extends Env = Env> {
     options?: { dev?: boolean; projectRoot?: string }
   ): void {
     this[registerViews](views, options);
+  }
+
+  /**
+   * Prime an immutable Skills over MCP snapshot before the server starts.
+   *
+   * @param snapshot - Validated snapshot, or `undefined` when convention
+   * discovery found no skills directory.
+   * @throws If the server already started.
+   *
+   * @internal
+   */
+  [registerSkills](snapshot: SkillsSnapshot | undefined): void {
+    this.#assertNotStarted("skills", "snapshot");
+    this.#skills = snapshot;
+    this.#skillsPrimed = true;
+  }
+
+  /** String-keyed tooling alias for {@link registerSkills}. */
+  __primeSkills(snapshot: SkillsSnapshot | undefined): void {
+    this[registerSkills](snapshot);
+  }
+
+  /**
+   * Discover, validate, and prime skills using this server's configuration.
+   *
+   * @param projectRoot - Project root used for custom directory overrides.
+   * @param conventionalDirectory - Effective conventional directory, including
+   * an optional CLI `--mcp-dir` prefix.
+   * @returns The snapshot embedded by build tooling.
+   *
+   * @internal
+   */
+  __discoverSkills(
+    projectRoot: string,
+    conventionalDirectory = "skills"
+  ): Promise<SkillsSnapshot | undefined> {
+    return this.#discoverSkills(projectRoot, conventionalDirectory);
+  }
+
+  /** Return file-discovery configuration to Node build tooling. @internal */
+  __skillsConfig(): boolean | SkillsOptions | undefined {
+    return this.#config.skills;
+  }
+
+  async #discoverSkills(
+    projectRoot: string,
+    conventionalDirectory: string
+  ): Promise<SkillsSnapshot | undefined> {
+    const { discoverConfiguredSkills } = await import("#mcp-use-skills-loader");
+    const snapshot = discoverConfiguredSkills(
+      this.#config.skills,
+      projectRoot,
+      conventionalDirectory
+    );
+    this[registerSkills](snapshot);
+    return snapshot;
   }
 
   /** Register a static resource readable at `definition.uri`. */
@@ -876,6 +943,11 @@ export class MCPServer<TUser = never, TEnv extends Env = Env> {
 
   /** Mount and validate the Hono/MCP application without serving a request. @internal */
   __mount(): void {
+    if (!this.#skillsPrimed) {
+      throw new Error(
+        "Cannot mount before skills discovery. CLI tooling must call __discoverSkills first."
+      );
+    }
     this.#ensureMounted("handler");
   }
 
@@ -888,6 +960,7 @@ export class MCPServer<TUser = never, TEnv extends Env = Env> {
    * ```
    */
   async notifyToolsChanged(): Promise<void> {
+    await this.#ensureSkillsPrimed();
     await this.#ensureMounted("handler").handler.notify.toolsChanged();
   }
 
@@ -900,6 +973,7 @@ export class MCPServer<TUser = never, TEnv extends Env = Env> {
    * ```
    */
   async notifyPromptsChanged(): Promise<void> {
+    await this.#ensureSkillsPrimed();
     await this.#ensureMounted("handler").handler.notify.promptsChanged();
   }
 
@@ -912,6 +986,7 @@ export class MCPServer<TUser = never, TEnv extends Env = Env> {
    * ```
    */
   async notifyResourcesChanged(): Promise<void> {
+    await this.#ensureSkillsPrimed();
     await this.#ensureMounted("handler").handler.notify.resourcesChanged();
   }
 
@@ -926,6 +1001,7 @@ export class MCPServer<TUser = never, TEnv extends Env = Env> {
    * ```
    */
   async notifyResourceUpdated(uri: string): Promise<void> {
+    await this.#ensureSkillsPrimed();
     await this.#ensureMounted("handler").handler.notify.resourceUpdated(uri);
   }
 
@@ -959,6 +1035,7 @@ export class MCPServer<TUser = never, TEnv extends Env = Env> {
     url: string;
   }> {
     this.#assertOpen("listen()");
+    await this.#ensureSkillsPrimed();
     const host = resolveListenHost(options.host, this.#config.host);
     const requestedPort = resolveListenPort(port, this.#config.port);
     this.#assertListenOAuthConfiguration(host);
@@ -1250,6 +1327,15 @@ export class MCPServer<TUser = never, TEnv extends Env = Env> {
         this.#proxyPromptsDiscovered += prompts;
       },
     };
+  }
+
+  async #ensureSkillsPrimed(): Promise<void> {
+    if (this.#skillsPrimed) return;
+    this.#skillsDiscovery ??= this.#discoverSkills(
+      typeof process === "undefined" ? "." : process.cwd(),
+      "skills"
+    ).then(() => undefined);
+    await this.#skillsDiscovery;
   }
 
   /**
@@ -1592,6 +1678,11 @@ export class MCPServer<TUser = never, TEnv extends Env = Env> {
           tools: { listChanged: true },
           prompts: { listChanged: true },
           resources: { listChanged: true, subscribe: true },
+          ...(this.#skills !== undefined && {
+            extensions: {
+              [SKILLS_EXTENSION_ID]: { directoryRead: true },
+            },
+          }),
         },
         ...(instructions !== undefined && { instructions }),
         ...(authInfo !== undefined && { authInfo }),
@@ -1628,6 +1719,9 @@ export class MCPServer<TUser = never, TEnv extends Env = Env> {
         viewMetaOptions,
         basePath
       );
+    }
+    if (this.#skills !== undefined) {
+      registerSkillsRuntime(server, this.#skills);
     }
     this.#wrapListHandlers(server);
     return server;

--- a/libraries/typescript/packages/server/src/skills/node-loader-unavailable.ts
+++ b/libraries/typescript/packages/server/src/skills/node-loader-unavailable.ts
@@ -1,0 +1,20 @@
+import type { SkillsOptions, SkillsSnapshot } from "./types.js";
+
+/**
+ * Filesystem discovery is unavailable in non-Node runtimes. Build-time
+ * tooling primes an embedded snapshot before the server starts.
+ *
+ * @internal
+ */
+export function discoverConfiguredSkills(
+  config: boolean | SkillsOptions | undefined,
+  _projectRoot: string,
+  _conventionalDirectory = "skills"
+): SkillsSnapshot | undefined {
+  if (config === true || (typeof config === "object" && config !== null)) {
+    throw new Error(
+      "Skills filesystem discovery is unavailable in this runtime. Run `mcp-use build` to embed the configured skills directory."
+    );
+  }
+  return undefined;
+}

--- a/libraries/typescript/packages/server/src/skills/node-loader.ts
+++ b/libraries/typescript/packages/server/src/skills/node-loader.ts
@@ -1,0 +1,251 @@
+import { createHash } from "node:crypto";
+import { existsSync, lstatSync, readdirSync, readFileSync } from "node:fs";
+import { basename, isAbsolute, relative, resolve, sep } from "node:path";
+import { parseDocument } from "yaml";
+
+import type {
+  SkillResourceSnapshot,
+  SkillsOptions,
+  SkillsSnapshot,
+} from "./types.js";
+
+const SKILL_NAME = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+function assertSafeDirectory(projectRoot: string, directory: string): string {
+  if (directory.trim() === "" || isAbsolute(directory)) {
+    throw new TypeError(
+      "skills.directory must be a non-empty project-relative path"
+    );
+  }
+  const root = resolve(projectRoot);
+  const resolved = resolve(root, directory);
+  const rel = relative(root, resolved);
+  if (rel === ".." || rel.startsWith(`..${sep}`) || isAbsolute(rel)) {
+    throw new TypeError("skills.directory must stay within the project root");
+  }
+  return resolved;
+}
+
+function mimeType(path: string): string {
+  const extension = path.slice(path.lastIndexOf(".") + 1).toLowerCase();
+  return (
+    (
+      {
+        md: "text/markdown",
+        txt: "text/plain",
+        json: "application/json",
+        yaml: "application/yaml",
+        yml: "application/yaml",
+        js: "text/javascript",
+        mjs: "text/javascript",
+        cjs: "text/javascript",
+        ts: "text/typescript",
+        py: "text/x-python",
+        sh: "text/x-shellscript",
+        html: "text/html",
+        css: "text/css",
+        csv: "text/csv",
+        xml: "application/xml",
+        svg: "image/svg+xml",
+        png: "image/png",
+        jpg: "image/jpeg",
+        jpeg: "image/jpeg",
+        gif: "image/gif",
+        webp: "image/webp",
+        pdf: "application/pdf",
+        zip: "application/zip",
+      } as Record<string, string>
+    )[extension] ?? "application/octet-stream"
+  );
+}
+
+function isTextMime(value: string): boolean {
+  return (
+    value.startsWith("text/") ||
+    value === "application/json" ||
+    value === "application/yaml" ||
+    value === "application/xml" ||
+    value === "image/svg+xml"
+  );
+}
+
+function walk(root: string): { files: string[]; directories: string[] } {
+  const files: string[] = [];
+  const directories: string[] = [root];
+  const visit = (directory: string): void => {
+    for (const entry of readdirSync(directory, { withFileTypes: true }).sort(
+      (left, right) => left.name.localeCompare(right.name)
+    )) {
+      const path = resolve(directory, entry.name);
+      const stat = lstatSync(path);
+      if (stat.isSymbolicLink()) continue;
+      if (stat.isDirectory()) {
+        directories.push(path);
+        visit(path);
+      } else if (stat.isFile()) files.push(path);
+    }
+  };
+  visit(root);
+  return { files, directories };
+}
+
+function skillUri(skillsRoot: string, skillRoot: string, file: string): string {
+  const skillSegments = relative(skillsRoot, skillRoot)
+    .split(sep)
+    .map(encodeURIComponent);
+  const fileSegments = relative(skillRoot, file)
+    .split(sep)
+    .map(encodeURIComponent);
+  const [authority, ...path] = [...skillSegments, ...fileSegments];
+  return `skill://${authority ?? ""}/${path.join("/")}`;
+}
+
+function frontmatter(path: string): Record<string, unknown> {
+  const source = readFileSync(path, "utf8");
+  const match = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/.exec(source);
+  if (match?.[1] === undefined) {
+    throw new Error(`${path}: SKILL.md must begin with YAML frontmatter`);
+  }
+  const document = parseDocument(match[1], { prettyErrors: true });
+  if (document.errors.length > 0) {
+    throw new Error(
+      `${path}: invalid YAML frontmatter: ${document.errors[0]?.message}`
+    );
+  }
+  const value: unknown = document.toJSON();
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${path}: frontmatter must be a YAML mapping`);
+  }
+  const result = value as Record<string, unknown>;
+  const name = result["name"];
+  const description = result["description"];
+  if (
+    typeof name !== "string" ||
+    name.length < 1 ||
+    name.length > 64 ||
+    !SKILL_NAME.test(name)
+  ) {
+    throw new Error(
+      `${path}: name must be 1-64 lowercase letters, digits, or single hyphens`
+    );
+  }
+  if (name !== basename(resolve(path, ".."))) {
+    throw new Error(
+      `${path}: frontmatter name must match its parent directory`
+    );
+  }
+  if (
+    typeof description !== "string" ||
+    description.trim() === "" ||
+    description.length > 1024
+  ) {
+    throw new Error(
+      `${path}: description must be a non-empty string of at most 1024 characters`
+    );
+  }
+  return result;
+}
+
+/**
+ * Discover and validate a static Skills over MCP snapshot from disk.
+ *
+ * @param config - Convention, explicit disable, or directory override.
+ * @param projectRoot - Root against which the directory is resolved.
+ * @returns A snapshot, or `undefined` when convention discovery finds no directory.
+ * @throws When forced discovery is missing or any discovered skill is invalid.
+ *
+ * @internal
+ */
+export function discoverConfiguredSkills(
+  config: boolean | SkillsOptions | undefined,
+  projectRoot: string,
+  conventionalDirectory = "skills"
+): SkillsSnapshot | undefined {
+  if (config === false) return undefined;
+  const forced =
+    config === true || (typeof config === "object" && config !== null);
+  const directory =
+    typeof config === "object" && config !== null
+      ? (config.directory ?? "skills")
+      : conventionalDirectory;
+  const skillsRoot = assertSafeDirectory(projectRoot, directory);
+  if (!existsSync(skillsRoot)) {
+    if (!forced) return undefined;
+    throw new Error(`Skills directory not found: ${skillsRoot}`);
+  }
+  if (!lstatSync(skillsRoot).isDirectory()) {
+    throw new Error(`Skills path is not a directory: ${skillsRoot}`);
+  }
+
+  const { files: allFiles, directories: allDirectories } = walk(skillsRoot);
+  const skillFiles = allFiles.filter((file) => basename(file) === "SKILL.md");
+  if (skillFiles.length === 0) {
+    console.warn(`[mcp-use] Skills directory is empty: ${skillsRoot}`);
+  }
+  const resourcesByUri = new Map<string, SkillResourceSnapshot>();
+  const directoriesByUri = new Map<string, { uri: string; name: string }>();
+  const skills = skillFiles.map((skillFile) => {
+    const skillRoot = resolve(skillFile, "..");
+    if (skillRoot === skillsRoot) {
+      throw new Error(
+        `${skillFile}: SKILL.md must be inside a named child directory`
+      );
+    }
+    const metadata = frontmatter(skillFile);
+    const files = allFiles.filter(
+      (file) => file === skillRoot || file.startsWith(`${skillRoot}${sep}`)
+    );
+    const resources = files.map((file) => {
+      const bytes = readFileSync(file);
+      const uri = skillUri(skillsRoot, skillRoot, file);
+      const type = mimeType(file);
+      const digest = `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+      if (!resourcesByUri.has(uri)) {
+        resourcesByUri.set(uri, {
+          uri,
+          name: basename(file),
+          mimeType: type,
+          digest,
+          ...(isTextMime(type)
+            ? { text: bytes.toString("utf8") }
+            : { blob: bytes.toString("base64") }),
+        });
+      }
+      return { uri, digest };
+    });
+    const root = skillUri(skillsRoot, skillRoot, skillFile).replace(
+      /\/SKILL\.md$/,
+      ""
+    );
+    for (const directoryPath of allDirectories.filter(
+      (directoryPath) =>
+        directoryPath === skillRoot ||
+        directoryPath.startsWith(`${skillRoot}${sep}`)
+    )) {
+      const rel = relative(skillRoot, directoryPath);
+      const uri =
+        rel === ""
+          ? root
+          : `${root}/${rel.split(sep).map(encodeURIComponent).join("/")}`;
+      directoriesByUri.set(uri, {
+        uri,
+        name: rel === "" ? basename(skillRoot) : basename(directoryPath),
+      });
+    }
+    return {
+      uri: skillUri(skillsRoot, skillRoot, skillFile),
+      frontmatter: metadata,
+      resources,
+    };
+  });
+  skills.sort((left, right) => left.uri.localeCompare(right.uri));
+  return {
+    skills,
+    resources: [...resourcesByUri.values()].sort((left, right) =>
+      left.uri.localeCompare(right.uri)
+    ),
+    directories: [...directoriesByUri.values()].sort((left, right) =>
+      left.uri.localeCompare(right.uri)
+    ),
+  };
+}

--- a/libraries/typescript/packages/server/src/skills/runtime.ts
+++ b/libraries/typescript/packages/server/src/skills/runtime.ts
@@ -1,0 +1,162 @@
+import {
+  INVALID_PARAMS,
+  ProtocolError,
+  type McpServer,
+  type StandardSchemaV1,
+} from "@modelcontextprotocol/server";
+
+import type { SkillsSnapshot } from "./types.js";
+
+function schema<T>(
+  validateValue: (value: unknown) => T
+): StandardSchemaV1<unknown, T> {
+  return {
+    "~standard": {
+      version: 1,
+      vendor: "mcp-use",
+      validate(value) {
+        try {
+          return { value: validateValue(value) };
+        } catch (error) {
+          return {
+            issues: [
+              {
+                message: error instanceof Error ? error.message : String(error),
+              },
+            ],
+          };
+        }
+      },
+    },
+  };
+}
+
+function object(value: unknown): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new TypeError("params must be an object");
+  }
+  return value as Record<string, unknown>;
+}
+
+const listParams = schema<{ cursor?: string }>((value) => {
+  const params = object(value);
+  const cursor = params["cursor"];
+  if (cursor !== undefined && typeof cursor !== "string") {
+    throw new TypeError("cursor must be a string");
+  }
+  return cursor === undefined ? {} : { cursor };
+});
+const uriParams = schema<{ uri: string; cursor?: string }>((value) => {
+  const params = object(value);
+  if (typeof params["uri"] !== "string") {
+    throw new TypeError("uri must be a string");
+  }
+  if (params["cursor"] !== undefined && typeof params["cursor"] !== "string") {
+    throw new TypeError("cursor must be a string");
+  }
+  return {
+    uri: params["uri"],
+    ...(typeof params["cursor"] === "string" && { cursor: params["cursor"] }),
+  };
+});
+const anyResult = schema<Record<string, unknown>>((value) => object(value));
+
+/**
+ * Register SEP-2640 handlers and skill resources on one SDK server.
+ *
+ * @param server - Fresh request-scoped SDK server.
+ * @param snapshot - Immutable skill metadata and contents.
+ *
+ * @internal
+ */
+export function registerSkillsRuntime(
+  server: McpServer,
+  snapshot: SkillsSnapshot
+): void {
+  const skills = new Map(snapshot.skills.map((skill) => [skill.uri, skill]));
+  for (const resource of snapshot.resources) {
+    server.registerResource(
+      resource.name,
+      resource.uri,
+      { mimeType: resource.mimeType },
+      async () => ({
+        contents: [
+          {
+            uri: resource.uri,
+            mimeType: resource.mimeType,
+            ...(resource.text !== undefined
+              ? { text: resource.text }
+              : { blob: resource.blob ?? "" }),
+          },
+        ],
+      })
+    );
+  }
+
+  server.server.setRequestHandler(
+    "skills/list",
+    { params: listParams, result: anyResult },
+    async () => ({ skills: snapshot.skills })
+  );
+  server.server.setRequestHandler(
+    "skills/get",
+    { params: uriParams, result: anyResult },
+    async ({ uri }) => {
+      const skill = skills.get(uri);
+      if (skill === undefined) {
+        throw new ProtocolError(INVALID_PARAMS, `Unknown skill: ${uri}`);
+      }
+      return { skill };
+    }
+  );
+  server.server.setRequestHandler(
+    "resources/directory/read",
+    { params: uriParams, result: anyResult },
+    async ({ uri }) => {
+      const normalized = uri.replace(/\/$/, "");
+      const knownDirectories = new Set(
+        snapshot.directories.map((item) => item.uri)
+      );
+      const prefix = `${normalized}/`;
+      const children = new Map<
+        string,
+        { uri: string; name: string; mimeType: string }
+      >();
+      for (const resource of snapshot.resources) {
+        if (!resource.uri.startsWith(prefix)) continue;
+        const remainder = resource.uri.slice(prefix.length);
+        const [name] = remainder.split("/");
+        if (name === undefined || name === "") continue;
+        const childUri = `${normalized}/${name}`;
+        children.set(childUri, {
+          uri: childUri,
+          name: decodeURIComponent(name),
+          mimeType: remainder.includes("/")
+            ? "inode/directory"
+            : resource.mimeType,
+        });
+      }
+      for (const directory of snapshot.directories) {
+        if (!directory.uri.startsWith(prefix)) continue;
+        const remainder = directory.uri.slice(prefix.length);
+        if (remainder === "" || remainder.includes("/")) continue;
+        children.set(directory.uri, {
+          uri: directory.uri,
+          name: directory.name,
+          mimeType: "inode/directory",
+        });
+      }
+      if (!knownDirectories.has(normalized)) {
+        throw new ProtocolError(
+          INVALID_PARAMS,
+          `Unknown skill directory: ${uri}`
+        );
+      }
+      return {
+        resources: [...children.values()].sort((left, right) =>
+          left.uri.localeCompare(right.uri)
+        ),
+      };
+    }
+  );
+}

--- a/libraries/typescript/packages/server/src/skills/types.ts
+++ b/libraries/typescript/packages/server/src/skills/types.ts
@@ -1,0 +1,59 @@
+/** Identifier negotiated for the experimental Skills over MCP extension. */
+export const SKILLS_EXTENSION_ID = "io.modelcontextprotocol/skills" as const;
+
+/** Configuration for file-based Agent Skills discovery. */
+export interface SkillsOptions {
+  /**
+   * Skill source directory, relative to the project root.
+   *
+   * @defaultValue `"skills"`
+   */
+  directory?: string;
+}
+
+/** One immutable file exposed by a skill snapshot. */
+export interface SkillResourceSnapshot {
+  /** Absolute MCP resource URI. */
+  uri: string;
+  /** File basename advertised as resource metadata. */
+  name: string;
+  /** MIME type advertised and returned for the resource. */
+  mimeType: string;
+  /** SHA-256 digest of the raw file bytes. */
+  digest: string;
+  /** UTF-8 contents for text resources. */
+  text?: string;
+  /** Base64 contents for binary resources. */
+  blob?: string;
+}
+
+/** A SEP-2640 skill entry and its complete resource manifest. */
+export interface SkillSnapshotEntry {
+  /** URI of the skill's root `SKILL.md`. */
+  uri: string;
+  /** Verbatim YAML frontmatter rendered as JSON. */
+  frontmatter: Record<string, unknown>;
+  /** Complete, deterministic file set for this skill. */
+  resources: Array<{ uri: string; digest: string }>;
+}
+
+/** One directory resource retained for scoped directory reads. */
+export interface SkillDirectorySnapshot {
+  /** Absolute directory resource URI without a trailing slash. */
+  uri: string;
+  /** Final decoded path segment advertised to hosts. */
+  name: string;
+}
+
+/** Static Skills over MCP snapshot embedded or discovered before serving. */
+export interface SkillsSnapshot {
+  /** Skill entries in URI order. */
+  skills: SkillSnapshotEntry[];
+  /** Unique resource contents in URI order. */
+  resources: SkillResourceSnapshot[];
+  /** Directory resources, including empty directories, in URI order. */
+  directories: SkillDirectorySnapshot[];
+}
+
+/** Symbol used by tooling to prime an {@link MCPServer} with a snapshot. */
+export const registerSkills = Symbol.for("mcp-use.registerSkills");

--- a/libraries/typescript/packages/server/tests/budgets/cli-budget.test.ts
+++ b/libraries/typescript/packages/server/tests/budgets/cli-budget.test.ts
@@ -119,6 +119,20 @@ describe("published CLI boundaries", () => {
     expect(await directoryBytes(DIST)).toBeLessThanOrEqual(5 * 1024 * 1024);
   });
 
+  it("keeps skill discovery self-contained without a runtime dependency", async () => {
+    expect(packageJson.dependencies).not.toHaveProperty("yaml");
+
+    const graph = await buildStaticGraph(
+      new URL("internal/skills-loader.js", DIST)
+    );
+    expect(
+      [...graph.staticPackages].filter((specifier) => !isBuiltin(specifier))
+    ).toEqual([]);
+    const source = [...graph.files.values()].join("\n");
+    expect(source).not.toContain('from"yaml"');
+    expect(source).not.toContain("Dynamic require");
+  });
+
   it("declares every external package used by the Node bundle", async () => {
     const graph = await buildStaticGraph(new URL("index-node.js", DIST));
     const declaredRuntimePackages = new Set([

--- a/libraries/typescript/packages/server/tests/cli/build.test.ts
+++ b/libraries/typescript/packages/server/tests/cli/build.test.ts
@@ -4,6 +4,7 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
+  rmSync,
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
@@ -94,6 +95,36 @@ function listViewAssets(
 }
 
 describe("runBuild", () => {
+  it("embeds skills so the built server survives source removal", async () => {
+    const cwd = copyFixture("build-skills");
+    dirs.push(cwd);
+    const skillDir = join(cwd, "skills", "refunds");
+    mkdirSync(join(skillDir, "references"), { recursive: true });
+    writeFileSync(
+      join(skillDir, "SKILL.md"),
+      "---\nname: refunds\ndescription: Process refunds safely\n---\n# Refunds\n"
+    );
+    writeFileSync(join(skillDir, "references", "policy.md"), "Policy v1\n");
+
+    await runBuild({ cwd });
+    rmSync(join(cwd, "skills"), { recursive: true, force: true });
+
+    const entryFile = join(cwd, WORKSPACE_DIR_NAME, "build", "index.js");
+    const mod = (await import(`${pathToFileURL(entryFile).href}?skills=1`)) as {
+      default: { fetch(request: Request): Promise<Response> };
+    };
+    expect(await handlerMcp(mod.default.fetch, "skills/list")).toMatchObject({
+      result: { skills: [{ uri: "skill://refunds/SKILL.md" }] },
+    });
+    expect(
+      await handlerMcp(mod.default.fetch, "resources/read", {
+        uri: "skill://refunds/references/policy.md",
+      })
+    ).toMatchObject({
+      result: { contents: [{ text: "Policy v1\n" }] },
+    });
+  });
+
   it("emits an ESM bundle + manifest to .mcp-use/build and preserves the default export", async () => {
     const cwd = copyFixture("build");
     dirs.push(cwd);

--- a/libraries/typescript/packages/server/tests/cli/dev.test.ts
+++ b/libraries/typescript/packages/server/tests/cli/dev.test.ts
@@ -222,6 +222,50 @@ describe("runDev", () => {
     expect(process.listeners("SIGINT")).not.toContain(sigint);
   });
 
+  it("reloads skill edits and keeps the last valid snapshot", async () => {
+    const cwd = copyFixture("dev-skills");
+    const skillDir = join(cwd, "skills", "refunds");
+    mkdirSync(skillDir, { recursive: true });
+    const skillFile = join(skillDir, "SKILL.md");
+    writeFileSync(
+      skillFile,
+      "---\nname: refunds\ndescription: Process refunds\n---\n# v1\n"
+    );
+    const dev = await startDev(cwd, await getFreePort(), undefined, false);
+    cleanups.push(dev.stop, () => removeDir(cwd));
+
+    expect(await mcpRequest(dev.url, "skills/list")).toMatchObject({
+      result: { skills: [{ uri: "skill://refunds/SKILL.md" }] },
+    });
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    writeFileSync(skillFile, "---\nname: wrong\ndescription: Invalid\n---\n");
+    await waitFor(async () =>
+      errorSpy.mock.calls.some((call) =>
+        String(call[0]).includes("reload failed")
+      )
+        ? true
+        : undefined
+    );
+    expect(await mcpRequest(dev.url, "skills/list")).toMatchObject({
+      result: { skills: [{ frontmatter: { name: "refunds" } }] },
+    });
+
+    writeFileSync(
+      skillFile,
+      "---\nname: refunds\ndescription: Updated refunds\n---\n# v2\n"
+    );
+    await waitFor(async () => {
+      const body = await mcpRequest(dev.url, "skills/list");
+      const result = body["result"] as {
+        skills?: Array<{ frontmatter?: { description?: string } }>;
+      };
+      return result.skills?.[0]?.frontmatter?.description === "Updated refunds"
+        ? true
+        : undefined;
+    });
+  });
+
   it("mounts the project-local Inspector on the existing dev listener", async () => {
     const cwd = copyFixture("dev-inspector-installed");
     cleanups.push(() => removeDir(cwd));

--- a/libraries/typescript/packages/server/tests/skills.test.ts
+++ b/libraries/typescript/packages/server/tests/skills.test.ts
@@ -1,0 +1,365 @@
+import { createHash } from "node:crypto";
+import { mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  Client,
+  StreamableHTTPClientTransport,
+} from "@modelcontextprotocol/client";
+import type { StandardSchemaV1 } from "@modelcontextprotocol/server";
+
+import { MCPServer, registerSkills, type ServerConfig } from "../src/index.js";
+import { discoverConfiguredSkills } from "../src/skills/node-loader.js";
+import type { SkillsSnapshot } from "../src/skills/types.js";
+import { listenFetch } from "./helpers/listen-fetch.js";
+
+const dirs: string[] = [];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const directory of dirs.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function project(): string {
+  const directory = join(
+    tmpdir(),
+    `mcp-use-skills-${process.pid}-${Math.random().toString(16).slice(2)}`
+  );
+  mkdirSync(directory, { recursive: true });
+  dirs.push(directory);
+  return directory;
+}
+
+function writeSkill(
+  root: string,
+  path: string,
+  name: string,
+  extra = "license: Apache-2.0"
+): string {
+  const directory = join(root, "skills", path);
+  mkdirSync(directory, { recursive: true });
+  writeFileSync(
+    join(directory, "SKILL.md"),
+    `---\nname: ${name}\ndescription: Use the ${name} workflow\n${extra}\n---\n# ${name}\n`
+  );
+  return directory;
+}
+
+async function request(
+  server: MCPServer,
+  method: string,
+  params: Record<string, unknown> = {}
+): Promise<Record<string, unknown>> {
+  const uri = typeof params["uri"] === "string" ? params["uri"] : undefined;
+  const response = await server.fetch(
+    new Request("http://localhost/mcp", {
+      method: "POST",
+      headers: {
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+        "mcp-protocol-version": "2026-07-28",
+        "mcp-method": method,
+        ...(uri !== undefined && { "mcp-name": uri }),
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method,
+        params: {
+          ...params,
+          _meta: {
+            "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+            "io.modelcontextprotocol/clientInfo": {
+              name: "skills-test",
+              version: "1.0.0",
+            },
+            "io.modelcontextprotocol/clientCapabilities": {},
+          },
+        },
+      }),
+    })
+  );
+  return (await response.json()) as Record<string, unknown>;
+}
+
+describe("skill discovery", () => {
+  it("auto-enables when skills exists and can be explicitly disabled", () => {
+    const cwd = project();
+    writeSkill(cwd, "refunds", "refunds");
+    expect(discoverConfiguredSkills(undefined, cwd)?.skills).toHaveLength(1);
+    expect(discoverConfiguredSkills(false, cwd)).toBeUndefined();
+  });
+
+  it("silently disables an absent convention but errors when forced", () => {
+    const cwd = project();
+    expect(discoverConfiguredSkills(undefined, cwd)).toBeUndefined();
+    expect(() => discoverConfiguredSkills(true, cwd)).toThrow(
+      /Skills directory not found/
+    );
+    expect(() => discoverConfiguredSkills({}, cwd)).toThrow(
+      /Skills directory not found/
+    );
+  });
+
+  it("resolves custom and mcp-dir conventions with project path safety", () => {
+    const cwd = project();
+    writeSkill(join(cwd, "src", "mcp"), "refunds", "refunds");
+    expect(
+      discoverConfiguredSkills(undefined, cwd, "src/mcp/skills")?.skills
+    ).toHaveLength(1);
+
+    const custom = join(cwd, "manuals", "shipping");
+    mkdirSync(custom, { recursive: true });
+    writeFileSync(
+      join(custom, "SKILL.md"),
+      "---\nname: shipping\ndescription: Ship orders\n---\n"
+    );
+    expect(
+      discoverConfiguredSkills({ directory: "manuals" }, cwd)?.skills
+    ).toHaveLength(1);
+    expect(() =>
+      discoverConfiguredSkills({ directory: "../outside" }, cwd)
+    ).toThrow(/within the project root/);
+  });
+
+  it("preserves frontmatter, nests manifests, hashes bytes, and excludes symlinks", () => {
+    const cwd = project();
+    const parent = writeSkill(
+      cwd,
+      "billing",
+      "billing",
+      "metadata:\n  version: 2"
+    );
+    const nested = writeSkill(cwd, "billing/refunds", "refunds");
+    writeFileSync(join(parent, "policy.md"), "policy\n");
+    const binary = Buffer.from([0, 1, 2, 255]);
+    writeFileSync(join(nested, "logo.png"), binary);
+    symlinkSync(join(parent, "policy.md"), join(parent, "linked.md"));
+
+    const snapshot = discoverConfiguredSkills(undefined, cwd)!;
+    expect(snapshot.skills.map((skill) => skill.uri)).toEqual([
+      "skill://billing/refunds/SKILL.md",
+      "skill://billing/SKILL.md",
+    ]);
+    const parentSkill = snapshot.skills.find(
+      (skill) => skill.uri === "skill://billing/SKILL.md"
+    );
+    expect(parentSkill?.frontmatter).toMatchObject({
+      name: "billing",
+      metadata: { version: 2 },
+    });
+    expect(parentSkill?.resources.map((item) => item.uri)).toContain(
+      "skill://billing/refunds/logo.png"
+    );
+    expect(
+      snapshot.resources.some((item) => item.uri.endsWith("linked.md"))
+    ).toBe(false);
+    expect(
+      snapshot.resources.find((item) => item.uri.endsWith("logo.png"))
+    ).toMatchObject({
+      mimeType: "image/png",
+      blob: binary.toString("base64"),
+      digest: `sha256:${createHash("sha256").update(binary).digest("hex")}`,
+    });
+  });
+
+  it("validates YAML and Agent Skills names", () => {
+    const cwd = project();
+    writeSkill(cwd, "refunds", "wrong-name");
+    expect(() => discoverConfiguredSkills(undefined, cwd)).toThrow(
+      /must match its parent directory/
+    );
+  });
+
+  it("rejects invalid untyped skills configuration", () => {
+    expect(
+      () =>
+        new MCPServer({
+          name: "invalid",
+          version: "1.0.0",
+          skills: "yes",
+        } as unknown as ServerConfig)
+    ).toThrow(/skills must be a boolean or configuration object/);
+  });
+});
+
+describe("Skills over MCP wire", () => {
+  function serverWith(snapshot: SkillsSnapshot | undefined): MCPServer {
+    const server = new MCPServer({ name: "skills", version: "1.0.0" });
+    server[registerSkills](snapshot);
+    return server;
+  }
+
+  it("serves list, get, text/binary reads, and non-recursive directories", async () => {
+    const cwd = project();
+    const directory = writeSkill(cwd, "refunds", "refunds");
+    mkdirSync(join(directory, "templates", "regional"), { recursive: true });
+    mkdirSync(join(directory, "templates", "empty"), { recursive: true });
+    writeFileSync(join(directory, "templates", "email.md"), "hello\n");
+    writeFileSync(join(directory, "templates", "regional", "eu.md"), "eu\n");
+    writeFileSync(join(directory, "image.png"), Buffer.from([0, 255]));
+    const server = serverWith(discoverConfiguredSkills(undefined, cwd));
+
+    const listed = await request(server, "skills/list");
+    expect(listed).toMatchObject({
+      result: {
+        skills: [
+          {
+            uri: "skill://refunds/SKILL.md",
+            frontmatter: { name: "refunds" },
+          },
+        ],
+      },
+    });
+    expect(
+      await request(server, "skills/get", { uri: "skill://refunds/SKILL.md" })
+    ).toMatchObject({
+      result: { skill: { uri: "skill://refunds/SKILL.md" } },
+    });
+    expect(
+      await request(server, "resources/read", {
+        uri: "skill://refunds/templates/email.md",
+      })
+    ).toMatchObject({
+      result: { contents: [{ mimeType: "text/markdown", text: "hello\n" }] },
+    });
+    expect(
+      await request(server, "resources/read", {
+        uri: "skill://refunds/image.png",
+      })
+    ).toMatchObject({ result: { contents: [{ blob: "AP8=" }] } });
+    expect(
+      await request(server, "resources/directory/read", {
+        uri: "skill://refunds/templates",
+      })
+    ).toMatchObject({
+      result: {
+        resources: [
+          { name: "email.md", mimeType: "text/markdown" },
+          { name: "empty", mimeType: "inode/directory" },
+          { name: "regional", mimeType: "inode/directory" },
+        ],
+      },
+    });
+    expect(
+      await request(server, "resources/directory/read", {
+        uri: "skill://refunds/templates/empty",
+      })
+    ).toMatchObject({ result: { resources: [] } });
+  });
+
+  it("negotiates the extension and custom methods through the official v2 client", async () => {
+    const snapshot: SkillsSnapshot = {
+      skills: [
+        {
+          uri: "skill://refunds/SKILL.md",
+          frontmatter: { name: "refunds", description: "Refund orders" },
+          resources: [
+            {
+              uri: "skill://refunds/SKILL.md",
+              digest: `sha256:${"0".repeat(64)}`,
+            },
+          ],
+        },
+      ],
+      resources: [
+        {
+          uri: "skill://refunds/SKILL.md",
+          name: "SKILL.md",
+          mimeType: "text/markdown",
+          digest: `sha256:${"0".repeat(64)}`,
+          text: "---\nname: refunds\ndescription: Refund orders\n---\n",
+        },
+      ],
+      directories: [{ uri: "skill://refunds", name: "refunds" }],
+    };
+    const server = serverWith(snapshot);
+    const listening = await listenFetch(server.fetch);
+    const client = new Client(
+      { name: "skills-client", version: "1.0.0" },
+      { versionNegotiation: { mode: { pin: "2026-07-28" } } }
+    );
+    const resultSchema: StandardSchemaV1<unknown, { skills: unknown[] }> = {
+      "~standard": {
+        version: 1,
+        vendor: "skills-test",
+        validate(value) {
+          const skills =
+            typeof value === "object" && value !== null
+              ? (value as { skills?: unknown }).skills
+              : undefined;
+          return Array.isArray(skills)
+            ? { value: { skills } }
+            : { issues: [{ message: "skills must be an array" }] };
+        },
+      },
+    };
+    try {
+      await client.connect(
+        new StreamableHTTPClientTransport(new URL("/mcp", listening.url))
+      );
+      expect(client.getServerCapabilities()?.extensions).toMatchObject({
+        "io.modelcontextprotocol/skills": { directoryRead: true },
+      });
+      const result = await client.request(
+        { method: "skills/list", params: {} },
+        resultSchema
+      );
+      expect(result.skills).toHaveLength(1);
+    } finally {
+      await client.close();
+      await listening.close();
+    }
+  });
+
+  it("returns -32602 for unknown skills and does not expose an index resource", async () => {
+    const server = serverWith({ skills: [], resources: [], directories: [] });
+    expect(
+      await request(server, "skills/get", { uri: "skill://missing/SKILL.md" })
+    ).toMatchObject({
+      error: { code: -32602 },
+    });
+    expect(
+      await request(server, "resources/read", { uri: "skill://index.json" })
+    ).toHaveProperty("error");
+  });
+
+  it("auto-discovers during direct Node serving and honors false", async () => {
+    const cwd = project();
+    writeSkill(cwd, "refunds", "refunds");
+    const previous = process.cwd();
+    process.chdir(cwd);
+    try {
+      const automatic = new MCPServer({ name: "auto", version: "1.0.0" });
+      expect(await request(automatic, "skills/list")).toMatchObject({
+        result: { skills: [{ uri: "skill://refunds/SKILL.md" }] },
+      });
+
+      const disabled = new MCPServer({
+        name: "disabled",
+        version: "1.0.0",
+        skills: false,
+      });
+      expect(await request(disabled, "skills/list")).toMatchObject({
+        error: { code: -32601 },
+      });
+    } finally {
+      process.chdir(previous);
+    }
+  });
+});
+
+const configExamples: ServerConfig[] = [
+  { name: "auto", version: "1.0.0" },
+  { name: "off", version: "1.0.0", skills: false },
+  { name: "forced", version: "1.0.0", skills: true },
+  {
+    name: "custom",
+    version: "1.0.0",
+    skills: { directory: "server-skills" },
+  },
+];
+void configExamples;

--- a/libraries/typescript/packages/server/tsup.config.ts
+++ b/libraries/typescript/packages/server/tsup.config.ts
@@ -9,6 +9,22 @@ const packageVersionDefine = {
   __MCP_USE_PACKAGE_VERSION__: JSON.stringify(frameworkPackage.version),
 };
 
+const yamlLicense = `/*!
+ * yaml 2.8.3, Copyright Eemeli Aro <eemeli@gmail.com>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+ * SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+ * OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */`;
+
 function minifyFrameworkOutput(options: {
   minifySyntax?: boolean;
   minifyWhitespace?: boolean;
@@ -50,7 +66,6 @@ export default defineConfig([
       "node-bridge": "src/node-bridge.ts",
       "internal/node-http": "src/node-http.ts",
       "internal/node-http-unavailable": "src/node-http-unavailable.ts",
-      "internal/skills-loader": "src/skills/node-loader.ts",
       "internal/skills-loader-unavailable":
         "src/skills/node-loader-unavailable.ts",
       "next/index": "src/next/index.ts",
@@ -69,6 +84,29 @@ export default defineConfig([
       "#mcp-use-node-http",
       "#mcp-use-skills-loader",
     ],
+    define: packageVersionDefine,
+    esbuildOptions: minifyFrameworkOutput,
+  },
+  // Discovery remains a Node-only implementation detail. Bundle the YAML
+  // parser here so consumers do not install an extra runtime dependency and
+  // the edge graph cannot reach filesystem or parser code.
+  {
+    entry: {
+      "internal/skills-loader": "src/skills/node-loader.ts",
+    },
+    format: ["esm"],
+    // Resolve yaml's ESM default export while leaving Node builtins external.
+    // The package's Node condition is CommonJS and cannot be embedded in this
+    // ESM-only loader without a runtime require shim.
+    platform: "neutral",
+    target: "node22",
+    dts: false,
+    splitting: false,
+    sourcemap: false,
+    clean: false,
+    external: ["node:*"],
+    noExternal: ["yaml"],
+    banner: { js: yamlLicense },
     define: packageVersionDefine,
     esbuildOptions: minifyFrameworkOutput,
   },

--- a/libraries/typescript/packages/server/tsup.config.ts
+++ b/libraries/typescript/packages/server/tsup.config.ts
@@ -50,6 +50,9 @@ export default defineConfig([
       "node-bridge": "src/node-bridge.ts",
       "internal/node-http": "src/node-http.ts",
       "internal/node-http-unavailable": "src/node-http-unavailable.ts",
+      "internal/skills-loader": "src/skills/node-loader.ts",
+      "internal/skills-loader-unavailable":
+        "src/skills/node-loader-unavailable.ts",
       "next/index": "src/next/index.ts",
     },
     // ESM-only: the v2 @modelcontextprotocol/* packages ship no CJS entry, so a
@@ -60,7 +63,12 @@ export default defineConfig([
     splitting: true,
     sourcemap: false,
     clean: true,
-    external: ["@mcp-use/client", "@mcp-use/cli", "#mcp-use-node-http"],
+    external: [
+      "@mcp-use/client",
+      "@mcp-use/cli",
+      "#mcp-use-node-http",
+      "#mcp-use-skills-loader",
+    ],
     define: packageVersionDefine,
     esbuildOptions: minifyFrameworkOutput,
   },
@@ -77,7 +85,7 @@ export default defineConfig([
     splitting: false,
     sourcemap: false,
     clean: false,
-    external: ["@mcp-use/client", "@mcp-use/cli"],
+    external: ["@mcp-use/client", "@mcp-use/cli", "#mcp-use-skills-loader"],
     noExternal: [
       "hono",
       "@modelcontextprotocol/core",

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -533,6 +533,9 @@ importers:
       jose:
         specifier: ^6.1.3
         version: 6.1.3
+      yaml:
+        specifier: '>=2.8.3'
+        version: 2.8.3
     devDependencies:
       '@mcp-use/client':
         specifier: workspace:*

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -533,9 +533,6 @@ importers:
       jose:
         specifier: ^6.1.3
         version: 6.1.3
-      yaml:
-        specifier: '>=2.8.3'
-        version: 2.8.3
     devDependencies:
       '@mcp-use/client':
         specifier: workspace:*
@@ -585,6 +582,9 @@ importers:
       vitest:
         specifier: '>=4.1.9'
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@22.20.1)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      yaml:
+        specifier: '>=2.8.3'
+        version: 2.8.3
       zod:
         specifier: 4.4.3
         version: 4.4.3

--- a/skills/chatgpt-app-builder/SKILL.md
+++ b/skills/chatgpt-app-builder/SKILL.md
@@ -21,3 +21,11 @@ Consult the TSDoc bundled in the installed package and the TypeScript source
 comments on disk. Inspect the project's installed `mcp-use` version, generated
 types, and existing ChatGPT-specific integrations before choosing APIs or
 patterns.
+
+## Agent Skills
+
+Put reusable agent workflows in `skills/<name>/SKILL.md`; the directory is
+served automatically, so normally omit the `skills` server option. Use
+`skills: false` to disable it or `skills: { directory: "server-skills" }` to
+override the project-relative directory. Keep supporting references, scripts,
+templates, and assets in the skill instead of inflating tool descriptions.

--- a/skills/mcp-apps-builder/SKILL.md
+++ b/skills/mcp-apps-builder/SKILL.md
@@ -20,3 +20,11 @@ Follow the guides at <https://docs.mcp-use.com/v2>.
 Consult the TSDoc bundled in the installed package and the TypeScript source
 comments on disk. Inspect the project's installed `mcp-use` version, generated
 types, and existing Views before choosing APIs or patterns.
+
+## Agent Skills
+
+Put reusable agent workflows in `skills/<name>/SKILL.md`; the directory is
+served automatically, so normally omit the `skills` server option. Use
+`skills: false` to disable it or `skills: { directory: "server-skills" }` to
+override the project-relative directory. Keep supporting references, scripts,
+templates, and assets in the skill instead of inflating tool descriptions.

--- a/skills/mcp-builder/SKILL.md
+++ b/skills/mcp-builder/SKILL.md
@@ -7,7 +7,7 @@ description: Build, modify, debug, or review TypeScript MCP servers with mcp-use
 
 mcp-use is the full stack TypeScript framework for building MCP servers and MCP apps to plug-ins and Claude connectors
 
-Use it to build fully typed MCP servers with tools, resources, prompts, 1 line oauth authentication adapters, middleware, production transports, a built-in Inspector, and headless tooling.
+Use it to build fully typed MCP servers with tools, resources, prompts, Agent Skills, 1 line oauth authentication adapters, middleware, production transports, a built-in Inspector, and headless tooling.
 
 mcp-use has native first class support for MCP Apps with support for HMR both at the server and MCP App level to live preview the changes on clients like ChatGPT
 
@@ -20,3 +20,14 @@ Follow the guides at <https://docs.mcp-use.com/v2>.
 Consult the TSDoc bundled in the installed package and the TypeScript source
 comments on disk. Inspect the project's installed `mcp-use` version and nearby
 code before choosing APIs or patterns.
+
+## Agent Skills
+
+When a server needs reusable workflow instructions, prefer the conventional
+`skills/<name>/SKILL.md` layout. The directory enables Skills over MCP
+automatically, so omit `skills` from `new MCPServer(...)` in the normal case.
+Use `skills: false` only to ignore an existing directory, `skills: true` to
+require the convention, or `skills: { directory: "server-skills" }` for a
+project-relative override. Keep detailed references, scripts, templates, and
+assets beside `SKILL.md`; do not copy their contents into tool descriptions or
+server instructions.


### PR DESCRIPTION
## Summary

- add convention-first Agent Skills discovery through `ServerConfig.skills`
- implement Skills over MCP methods and resource mapping
- embed validated skill snapshots in production builds and reload them safely in development
- keep skill discovery self-contained without adding a consumer runtime dependency
- document configuration, protocol behavior, examples, and agent-authoring guidance

## Behavior

Skills are enabled automatically when the conventional `skills/` directory exists. Authors can set `skills: false`, require the convention with `skills: true`, or configure a project-relative directory.

The server exposes validated nested skills, text and binary supporting resources, raw-byte SHA-256 digests, and non-recursive directory reads. Filesystem and YAML discovery remain lazy, bundled, and Node-only; built servers receive an embedded snapshot and do not read source skills at runtime.

## Validation

- `pnpm test:run` — 66 files and 712 tests passed
- changed-file ESLint passed with zero warnings
- server and CLI package builds passed
- runtime and CLI package-boundary budgets passed
- packed tarball installed, imported, and discovered nested YAML metadata from a clean consumer without a `yaml` runtime dependency
- build coverage proves skills remain available after source removal

## Specification references

- [Skills over MCP Working Group](https://modelcontextprotocol.io/community/working-groups/skills-over-mcp)
- [SEP-2640: Skills Extension](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640)
- [Agent Skills specification](https://agentskills.io/specification)
