### PR TITLE
fix: close v2 beta release blockers

### DIFF
--- a/docs/home/index.mdx
+++ b/docs/home/index.mdx
@@ -92,7 +92,7 @@ npx create-mcp-use-app@latest
 Or create a server manually:
 
 ```typescript
-import { MCPServer, text } from "mcp-use/server";
+import { MCPServer } from "mcp-use";
 import { z } from "zod";
 
 const server = new MCPServer({
@@ -104,15 +104,23 @@ server.tool(
   {
     name: "get_weather",
     description: "Get weather for a city",
-    schema: z.object({ city: z.string() }),
+    inputSchema: z.object({ city: z.string() }),
+    outputSchema: z.object({
+      temperature: z.number(),
+      conditions: z.string(),
+      city: z.string(),
+    }),
   },
   async ({ city }) => {
-    return text(`Temperature: 72°F, Condition: sunny, City: ${city}`);
+    const weather = { temperature: 72, conditions: "Sunny", city };
+    return {
+      content: [{ type: "text", text: JSON.stringify(weather) }],
+      structuredContent: weather,
+    };
   },
 );
 
-await server.listen(3000);
-// Inspector at http://localhost:3000/mcp/inspector
+export default server;
 ```
 
 <Card title="Full TypeScript Server Documentation" icon="arrow-right" href="/typescript/server" horizontal />
@@ -150,10 +158,10 @@ server.run(transport="streamable-http", port=8000)
 
 ## MCP Apps
 
-MCP Apps let you build interactive widgets that work across Claude, ChatGPT, and other MCP clients - write once, run everywhere.
+MCP Apps let you build interactive views that work across Claude, ChatGPT, and other MCP clients—write once, run everywhere.
 
 ```typescript
-import { MCPServer, widget } from "mcp-use/server";
+import { MCPServer } from "mcp-use";
 import { z } from "zod";
 
 const server = new MCPServer({ name: "weather-app", version: "1.0.0" });
@@ -162,21 +170,27 @@ server.tool(
   {
     name: "get-weather",
     description: "Get weather for a city",
-    schema: z.object({ city: z.string() }),
-    widget: "weather-display", // references resources/weather-display/widget.tsx
+    inputSchema: z.object({ city: z.string() }),
+    outputSchema: z.object({
+      city: z.string(),
+      temperature: z.number(),
+      conditions: z.string(),
+    }),
+    view: { name: "weather-display" }, // views/weather-display/view.tsx
   },
   async ({ city }) => {
-    return widget({
-      props: { city, temperature: 22, conditions: "Sunny" },
-      message: `Weather in ${city}: Sunny, 22°C`,
-    });
+    const weather = { city, temperature: 22, conditions: "Sunny" };
+    return {
+      content: [{ type: "text", text: `Weather in ${city}: Sunny, 22°C` }],
+      structuredContent: weather,
+    };
   },
 );
 
-await server.listen(3000);
+export default server;
 ```
 
-Widgets in `resources/` are **auto-discovered** - no manual registration needed.
+Views in `views/` are auto-discovered and receive typed tool results through `useToolContext()`.
 
 <CardGroup cols={2}>
   <Card
@@ -184,7 +198,7 @@ Widgets in `resources/` are **auto-discovered** - no manual registration needed.
     icon="app-window-mac"
     href="/typescript/mcp-apps"
   >
-    Build widgets with React, auto-discovery, and client-side hooks.
+    Build views with React, auto-discovery, and client-side hooks.
   </Card>
   <Card
     title="Apps SDK compatibility"

--- a/docs/typescript/client/index.mdx
+++ b/docs/typescript/client/index.mdx
@@ -16,13 +16,13 @@ Node.js 20+ required. The package is ESM-only.
 
 ## Entry points
 
-| Building | Import | Transports |
-| -------- | ------ | ---------- |
-| Node script, service, or agent | `@mcp-use/client` | HTTP, stdio |
-| Browser (no React) | `@mcp-use/client` | HTTP |
-| React app | `@mcp-use/client/react` | HTTP |
+| Building                       | Import                  | Transports  |
+| ------------------------------ | ----------------------- | ----------- |
+| Node script, service, or agent | `@mcp-use/client`       | HTTP, stdio |
+| Browser (no React)             | `@mcp-use/client`       | HTTP        |
+| React app                      | `@mcp-use/client/react` | HTTP        |
 
-Widget UI hooks (`useWidget`, `useCallTool`, …) live in `mcp-use/react`, not the client package.
+MCP App view hooks (`useToolContext`, `useCallTool`, …) live in `mcp-use/react`, not the client package.
 
 ## Quick start
 
@@ -84,16 +84,28 @@ Upgrading from v1? See the [v2 migration guide](/typescript/client/migration).
   <Card title="Tools" icon="wrench" href="/typescript/client/tools">
     List and call server tools.
   </Card>
-  <Card title="v2 Migration" icon="arrow-right-left" href="/typescript/client/migration">
+  <Card
+    title="v2 Migration"
+    icon="arrow-right-left"
+    href="/typescript/client/migration"
+  >
     Breaking changes and upgrade checklist.
   </Card>
-  <Card title="Authentication" icon="shield" href="/typescript/client/authentication">
+  <Card
+    title="Authentication"
+    icon="shield"
+    href="/typescript/client/authentication"
+  >
     OAuth and bearer tokens.
   </Card>
   <Card title="React" icon="react" href="/typescript/client/usemcp">
     `McpClientProvider` and hooks.
   </Card>
-  <Card title="Environments" icon="container" href="/typescript/client/environments">
+  <Card
+    title="Environments"
+    icon="container"
+    href="/typescript/client/environments"
+  >
     Node, browser, and React differences.
   </Card>
 </CardGroup>

--- a/docs/typescript/getting-started/installation.mdx
+++ b/docs/typescript/getting-started/installation.mdx
@@ -5,9 +5,8 @@ icon: "download"
 ---
 
 <Info>
-  **Prerequisites**:
-  - Install [Node.js](https://nodejs.org/) (version 22.22.2 or higher)
-  - npm, pnpm, or Bun package manager
+  **Prerequisites**: - Install [Node.js](https://nodejs.org/) (version 22.22.2
+  or higher) - npm, pnpm, or Bun package manager
 </Info>
 
 ### MCP Servers
@@ -32,9 +31,11 @@ bunx create-mcp-use-app my-mcp-server
 cd my-mcp-server
 bun run dev
 ```
+
 </CodeGroup>
 
 This command will:
+
 - Create a new directory with your project name
 - Initialize a TypeScript project with mcp-use configured
 - Set up a basic MCP server template with example tools
@@ -42,7 +43,8 @@ This command will:
 - Optionally install skills for agent support
 
 <Tip>
-Check out [UI Widgets](/typescript/mcp-apps) with support to MCP-UI and OpenAI Apps SDK for ChatGPT.
+  Check out [UI Widgets](/typescript/mcp-apps) with support to MCP-UI and OpenAI
+  Apps SDK for ChatGPT.
 </Tip>
 
 ### Server Metadata
@@ -56,6 +58,7 @@ The generated project includes pre-configured server metadata that is visible in
 - **Favicon**: Included for browser display
 
 These settings appear in:
+
 - MCP Inspector UI (server dropdown and "View server info" modal)
 - MCP clients that support server metadata
 - ChatGPT when using your server as an app
@@ -66,28 +69,34 @@ Open `index.ts` in your project to customize:
 
 ```typescript
 const server = new MCPServer({
-  name: 'my-project',          // Set by create-mcp-use-app
-  title: 'My Custom Title',    // display name - shown in clients
-  version: '1.0.0',
-  description: 'My awesome server',
-  instructions: 'Use lookup tools before write tools; ask for confirmation before changes.',
-  websiteUrl: 'https://my-site.com',  // Your website or docs
-  favicon: 'favicon.ico',      // Already in public/ folder
+  name: "my-project", // Set by create-mcp-use-app
+  title: "My Custom Title", // display name - shown in clients
+  version: "1.0.0",
+  description: "My awesome server",
+  instructions:
+    "Use lookup tools before write tools; ask for confirmation before changes.",
+  websiteUrl: "https://my-site.com", // Your website or docs
+  favicon: "favicon.ico", // Already in public/ folder
   icons: [
     {
-      src: 'my-icon.svg',      // Add custom icon to public/ folder
-      mimeType: 'image/svg+xml',
-      sizes: ['512x512']
-    }
-  ]
-})
+      src: "my-icon.svg", // Add custom icon to public/ folder
+      mimeType: "image/svg+xml",
+      sizes: ["512x512"],
+    },
+  ],
+});
 ```
 
-**Note:** Icon paths (like `icon.svg`) are automatically converted to absolute URLs (e.g., `http://localhost:3000/mcp-use/public/icon.svg`) when `baseUrl` is configured.
+**Note:** Icon paths (like `icon.svg`) are resolved from `public/` against the
+incoming request origin. With `basePath: "/mcp"`, for example, `icon.svg` is
+served from `http://localhost:3000/mcp/_mcp-use/public/icon.svg`. In hosted
+environments, `MCP_URL` sets the public origin while `basePath` continues to
+own the endpoint path.
 
 ---
 
 You can also install mcp-use as a library and build your own MCP server from scratch.
+
 <CodeGroup>
 ```bash npm
 npm install mcp-use
@@ -100,10 +109,11 @@ pnpm add mcp-use
 ```bash bun
 bun add mcp-use
 ```
+
 </CodeGroup>
 
 ```typescript
-import { MCPServer } from "mcp-use/server";
+import { MCPServer } from "mcp-use";
 import { z } from "zod";
 
 const server = new MCPServer({
@@ -117,21 +127,33 @@ const server = new MCPServer({
     {
       src: "icon.svg",
       mimeType: "image/svg+xml",
-      sizes: ["512x512"]
-    }
-  ]
+      sizes: ["512x512"],
+    },
+  ],
 });
 
 // Define a tool
-server.tool({
-  name: "get_weather",
-  description: "Get weather for a city",
-  schema: z.object({
-    city: z.string().describe("City name"),
-  }),
-}, async ({ city }) => {
-  return { temperature: 72, condition: "sunny", city };
-});
+server.tool(
+  {
+    name: "get_weather",
+    description: "Get weather for a city",
+    inputSchema: z.object({
+      city: z.string().describe("City name"),
+    }),
+    outputSchema: z.object({
+      temperature: z.number(),
+      condition: z.string(),
+      city: z.string(),
+    }),
+  },
+  async ({ city }) => {
+    const weather = { temperature: 72, condition: "sunny", city };
+    return {
+      content: [{ type: "text", text: JSON.stringify(weather) }],
+      structuredContent: weather,
+    };
+  },
+);
 
 // Start the MCP server
 server.listen(3000);
@@ -140,26 +162,27 @@ server.listen(3000);
 For the local Inspector, run `mcp-use dev`; to mount it on a production build
 for internal testing, use `mcp-use start --with-inspector`.
 
-Check out the examples [here](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server).
+Check out the examples [here](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples).
 
 Visit the [MCP Server](/typescript/server) documentation for more details.
 
 ### MCP Agent & Client
 
-Install mcp_use using your preferred package manager:
+Install the client and Agent packages using your preferred package manager:
 
 <CodeGroup>
 ```bash npm
-npm install mcp-use
+npm install @mcp-use/client @mcp-use/agent
 ```
 
 ```bash pnpm
-pnpm add mcp-use
+pnpm add @mcp-use/client @mcp-use/agent
 ```
 
 ```bash bun
-bun add mcp-use
+bun add @mcp-use/client @mcp-use/agent
 ```
+
 </CodeGroup>
 
 ## Next Steps
@@ -172,10 +195,12 @@ bun add mcp-use
     A full featured MCP Client implementation for TypeScript
   </Card>
   <Card title="Server" icon="server" href="/typescript/server">
-    The MCP Server framework implementation for TypeScript, with Apps SDK and MCP-UI support
+    The MCP Server framework implementation for TypeScript, with Apps SDK and
+    MCP-UI support
   </Card>
 </CardGroup>
 
 <Tip>
-**Need Help?** Join our [Discord](https://discord.gg/XkNkSkMz3V) or [Github](https://github.com/mcp-use/mcp-use) communities.
+  **Need Help?** Join our [Discord](https://discord.gg/XkNkSkMz3V) or
+  [Github](https://github.com/mcp-use/mcp-use) communities.
 </Tip>

--- a/docs/typescript/getting-started/quickstart.mdx
+++ b/docs/typescript/getting-started/quickstart.mdx
@@ -61,7 +61,7 @@ npm run dev
 
 - serves the MCP endpoint at `http://localhost:3000/mcp`
 - opens the **Inspector** at `http://localhost:3000/mcp/inspector`
-- hot-reloads tools, resources, prompts, and widgets as you edit, with no restart and no dropped connections
+- hot-reloads tools, resources, prompts, and views as you edit; the next stateless request uses the refreshed server
 
 Open the Inspector, go to the **Tools** tab, and run a tool to see it respond. With the `mcp-apps` template, calling `search-tools` renders the widget inline.
 
@@ -78,57 +78,59 @@ The first command saves the server under the name `local`; later commands addres
 
 ```
 my-server/
-├── resources/                  # React widgets, auto-discovered
+├── views/                      # React MCP App views, auto-discovered
 │   └── greeting-card/
-│       └── widget.tsx
+│       └── view.tsx
 ├── public/                     # Static assets (icons, images)
 ├── index.ts                    # Server entry: tools, resources, prompts
-├── mcp-env.d.ts                # Managed server-to-widget typing bridge
+├── mcp-env.d.ts                # Managed server-to-view typing bridge
 ├── package.json
 └── tsconfig.json
 ```
 
-`index.ts` is where you register your tools, resources, and prompts. Each folder under `resources/` is a widget; its folder name matches the `widget.name` a tool references.
+`index.ts` is where you register your tools, resources, and prompts. Each folder under `views/` is an MCP App view; its folder name matches the `view.name` a tool references.
 
 ## Add a tool
 
-Open `index.ts` and add a tool to the existing `server`. `text`, `widget`, and `z` are already imported at the top of the file:
+Open `index.ts` and add a tool to the existing `server`:
 
 ```typescript
 export const greetingCard = server.tool(
   {
     name: "greeting-card",
     description: "Create a greeting card for someone",
-    schema: z.object({
+    inputSchema: z.object({
       name: z.string().describe("Who to greet"),
       message: z.string().describe("The message inside the card"),
     }),
-    widget: {
+    outputSchema: z.object({
+      name: z.string(),
+      message: z.string(),
+    }),
+    view: {
       name: "greeting-card",
-      invoking: "Designing the card...",
-      invoked: "Card ready",
+      description: "An interactive greeting card",
     },
   },
-  async ({ name, message }) =>
-    widget({
-      props: { name, message },
-      output: text(`Made a card for ${name}`),
-    }),
+  async ({ name, message }) => ({
+    content: [{ type: "text", text: `Made a card for ${name}` }],
+    structuredContent: { name, message },
+  }),
 );
 ```
 
 Keep statically declared tools in exported constants. The generated `mcp-env.d.ts` uses those exported tool refs to type calls from your widget, so TypeScript will flag a `useCallTool("greeting-card")` call when its matching ref is not exported.
 
-Run `npm run typecheck` after editing tools or widgets. The scaffolded script refreshes `mcp-env.d.ts` for the server entry, then runs the project's own TypeScript compiler with `--noEmit`.
+Run `npm run typecheck` after editing tools or views. The scaffolded script refreshes `mcp-env.d.ts` for the server entry, then runs the project's own TypeScript compiler with `--noEmit`.
 
-Instead of returning plain text, this tool returns a widget. `widget.name` (`greeting-card`) points at a folder under `resources/`, and `widget({ props })` passes that data to the widget's `useWidget().props`. The widget doesn't exist yet, so build it next.
+The tool's `view.name` points at a folder under `views/`. Its validated `structuredContent` becomes the view's typed tool output.
 
-## Add a widget
+## Add a view
 
-Create `resources/greeting-card/widget.tsx`. The folder name must match the tool's `widget.name`:
+Create `views/greeting-card/view.tsx`. The folder name must match the tool's `view.name`:
 
 ```tsx
-import { McpUseProvider, useWidget } from "mcp-use/react";
+import { ThemeProvider, useToolContext } from "mcp-use/react";
 
 interface GreetingCardProps {
   name: string;
@@ -136,20 +138,25 @@ interface GreetingCardProps {
 }
 
 export default function GreetingCard() {
-  const { props } = useWidget<GreetingCardProps>();
+  const view = useToolContext<"greeting-card">();
+
+  if (view.status === "pending") return <p>Designing the card…</p>;
+  if (view.status === "error") return <p>{view.error.message}</p>;
+
+  const card = view.toolOutput as GreetingCardProps;
 
   return (
-    <McpUseProvider autoSize>
+    <ThemeProvider>
       <div style={{ padding: "2rem", textAlign: "center" }}>
-        <h2>Hello, {props.name}!</h2>
-        <p>{props.message}</p>
+        <h2>Hello, {card.name}!</h2>
+        <p>{card.message}</p>
       </div>
-    </McpUseProvider>
+    </ThemeProvider>
   );
 }
 ```
 
-Save the file. The dev server discovers the new widget and hot-reloads, so reload the **Tools** tab in the Inspector and call `greeting-card` with `{ name: "Ada", message: "Welcome aboard!" }`. The card renders inline.
+Save the file. The dev server discovers the new view and hot-reloads it. Call `greeting-card` with `{ name: "Ada", message: "Welcome aboard!" }`; the card renders inline.
 
 <Tip>
   See [Tools](/typescript/server/tools),

--- a/docs/typescript/getting-started/welcome.mdx
+++ b/docs/typescript/getting-started/welcome.mdx
@@ -5,65 +5,137 @@ icon: "heart-handshake"
 ---
 
 <Visibility for="agents">
-For the complete documentation index, see [llms.txt](https://mcp-use.com/docs/llms.txt).
+  For the complete documentation index, see
+  [llms.txt](https://mcp-use.com/docs/llms.txt).
 </Visibility>
 
 **mcp-use** is the fullstack MCP framework for TypeScript. Build MCP Servers, MCP Apps (interactive widgets that run inside ChatGPT and Claude), MCP Agents, and MCP Clients with end-to-end type safety.
 
 <CodeGroup>
 ```typescript server.ts
-import { MCPServer, widget } from "mcp-use/server";
+import { MCPServer } from "mcp-use";
 import { z } from "zod";
 
 const server = new MCPServer({
-  name: "greeter",
-  version: "1.0.0",
+name: "greeter",
+version: "1.0.0",
 });
 
 export const greet = server.tool(
   {
     name: "greet",
     description: "Greet someone by name",
-    schema: z.object({ name: z.string().describe("Who to greet") }),
-    widget: { name: "greeting" },
+    inputSchema: z.object({ name: z.string().describe("Who to greet") }),
+    outputSchema: z.object({ greeting: z.string() }),
+    view: { name: "greeting" },
   },
-  async ({ name }) =>
-    widget({
-      props: { name },
-      message: `Said hello to ${name}`,
-    })
+  async ({ name }) => ({
+    content: [{ type: "text", text: `Said hello to ${name}` }],
+    structuredContent: { greeting: `Hello, ${name}!` },
+  }),
 );
 
 await server.listen(3000);
-```
-```tsx resources/greeting/widget.tsx
-import { useWidget } from "mcp-use/react";
+
+````
+```tsx views/greeting/view.tsx
+import { useToolContext } from "mcp-use/react";
 
 export default function Greeting() {
-  const { props, isPending } = useWidget<{ name: string }>();
-
-  if (isPending) return <p>Loading…</p>;
-
-  return <h1>👋 Hello, {props.name}!</h1>;
+  const view = useToolContext<"greet">();
+  if (view.status === "pending") return <p>Loading…</p>;
+  if (view.status === "error") return <p>{view.error.message}</p>;
+  return <h1>👋 {view.toolOutput.greeting}</h1>;
 }
-```
+````
+
 </CodeGroup>
 
-<Callout color='#bccad1' icon={<svg xmlns="http://www.w3.org/2000/svg" className='min-w-[20px] mt-0 flex-shrink-0' viewBox="0 0 128 128"><linearGradient id="python-original-a" gradientUnits="userSpaceOnUse" x1="70.252" y1="1237.476" x2="170.659" y2="1151.089" gradientTransform="matrix(.563 0 0 -.568 -29.215 707.817)"><stop offset="0" stop-color="#5A9FD4"/><stop offset="1" stop-color="#306998"/></linearGradient><linearGradient id="python-original-b" gradientUnits="userSpaceOnUse" x1="209.474" y1="1098.811" x2="173.62" y2="1149.537" gradientTransform="matrix(.563 0 0 -.568 -29.215 707.817)"><stop offset="0" stop-color="#FFD43B"/><stop offset="1" stop-color="#FFE873"/></linearGradient><path fill="url(#python-original-a)" d="M63.391 1.988c-4.222.02-8.252.379-11.8 1.007-10.45 1.846-12.346 5.71-12.346 12.837v9.411h24.693v3.137H29.977c-7.176 0-13.46 4.313-15.426 12.521-2.268 9.405-2.368 15.275 0 25.096 1.755 7.311 5.947 12.519 13.124 12.519h8.491V67.234c0-8.151 7.051-15.34 15.426-15.34h24.665c6.866 0 12.346-5.654 12.346-12.548V15.833c0-6.693-5.646-11.72-12.346-12.837-4.244-.706-8.645-1.027-12.866-1.008zM50.037 9.557c2.55 0 4.634 2.117 4.634 4.721 0 2.593-2.083 4.69-4.634 4.69-2.56 0-4.633-2.097-4.633-4.69-.001-2.604 2.073-4.721 4.633-4.721z" transform="translate(0 10.26)"/><path fill="url(#python-original-b)" d="M91.682 28.38v10.966c0 8.5-7.208 15.655-15.426 15.655H51.591c-6.756 0-12.346 5.783-12.346 12.549v23.515c0 6.691 5.818 10.628 12.346 12.547 7.816 2.297 15.312 2.713 24.665 0 6.216-1.801 12.346-5.423 12.346-12.547v-9.412H63.938v-3.138h37.012c7.176 0 9.852-5.005 12.348-12.519 2.578-7.735 2.467-15.174 0-25.096-1.774-7.145-5.161-12.521-12.348-12.521h-9.268zM77.809 87.927c2.561 0 4.634 2.097 4.634 4.692 0 2.602-2.074 4.719-4.634 4.719-2.55 0-4.633-2.117-4.633-4.719 0-2.595 2.083-4.692 4.633-4.692z" transform="translate(0 10.26)"/><radialGradient id="python-original-c" cx="1825.678" cy="444.45" r="26.743" gradientTransform="matrix(0 -.24 -1.055 0 532.979 557.576)" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#B8B8B8" stop-opacity=".498"/><stop offset="1" stop-color="#7F7F7F" stop-opacity="0"/></radialGradient><path opacity=".444" fill="url(#python-original-c)" d="M97.309 119.597c0 3.543-14.816 6.416-33.091 6.416-18.276 0-33.092-2.873-33.092-6.416 0-3.544 14.815-6.417 33.092-6.417 18.275 0 33.091 2.872 33.091 6.417z"/></svg>}>
-Looking for the **Python** docs? They're [here](/python/getting-started/quickstart).
+<Callout
+  color="#bccad1"
+  icon={
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      className="min-w-[20px] mt-0 flex-shrink-0"
+      viewBox="0 0 128 128"
+    >
+      <linearGradient
+        id="python-original-a"
+        gradientUnits="userSpaceOnUse"
+        x1="70.252"
+        y1="1237.476"
+        x2="170.659"
+        y2="1151.089"
+        gradientTransform="matrix(.563 0 0 -.568 -29.215 707.817)"
+      >
+        <stop offset="0" stop-color="#5A9FD4" />
+        <stop offset="1" stop-color="#306998" />
+      </linearGradient>
+      <linearGradient
+        id="python-original-b"
+        gradientUnits="userSpaceOnUse"
+        x1="209.474"
+        y1="1098.811"
+        x2="173.62"
+        y2="1149.537"
+        gradientTransform="matrix(.563 0 0 -.568 -29.215 707.817)"
+      >
+        <stop offset="0" stop-color="#FFD43B" />
+        <stop offset="1" stop-color="#FFE873" />
+      </linearGradient>
+      <path
+        fill="url(#python-original-a)"
+        d="M63.391 1.988c-4.222.02-8.252.379-11.8 1.007-10.45 1.846-12.346 5.71-12.346 12.837v9.411h24.693v3.137H29.977c-7.176 0-13.46 4.313-15.426 12.521-2.268 9.405-2.368 15.275 0 25.096 1.755 7.311 5.947 12.519 13.124 12.519h8.491V67.234c0-8.151 7.051-15.34 15.426-15.34h24.665c6.866 0 12.346-5.654 12.346-12.548V15.833c0-6.693-5.646-11.72-12.346-12.837-4.244-.706-8.645-1.027-12.866-1.008zM50.037 9.557c2.55 0 4.634 2.117 4.634 4.721 0 2.593-2.083 4.69-4.634 4.69-2.56 0-4.633-2.097-4.633-4.69-.001-2.604 2.073-4.721 4.633-4.721z"
+        transform="translate(0 10.26)"
+      />
+      <path
+        fill="url(#python-original-b)"
+        d="M91.682 28.38v10.966c0 8.5-7.208 15.655-15.426 15.655H51.591c-6.756 0-12.346 5.783-12.346 12.549v23.515c0 6.691 5.818 10.628 12.346 12.547 7.816 2.297 15.312 2.713 24.665 0 6.216-1.801 12.346-5.423 12.346-12.547v-9.412H63.938v-3.138h37.012c7.176 0 9.852-5.005 12.348-12.519 2.578-7.735 2.467-15.174 0-25.096-1.774-7.145-5.161-12.521-12.348-12.521h-9.268zM77.809 87.927c2.561 0 4.634 2.097 4.634 4.692 0 2.602-2.074 4.719-4.634 4.719-2.55 0-4.633-2.117-4.633-4.719 0-2.595 2.083-4.692 4.633-4.692z"
+        transform="translate(0 10.26)"
+      />
+      <radialGradient
+        id="python-original-c"
+        cx="1825.678"
+        cy="444.45"
+        r="26.743"
+        gradientTransform="matrix(0 -.24 -1.055 0 532.979 557.576)"
+        gradientUnits="userSpaceOnUse"
+      >
+        <stop offset="0" stop-color="#B8B8B8" stop-opacity=".498" />
+        <stop offset="1" stop-color="#7F7F7F" stop-opacity="0" />
+      </radialGradient>
+      <path
+        opacity=".444"
+        fill="url(#python-original-c)"
+        d="M97.309 119.597c0 3.543-14.816 6.416-33.091 6.416-18.276 0-33.092-2.873-33.092-6.416 0-3.544 14.815-6.417 33.092-6.417 18.275 0 33.091 2.872 33.091 6.417z"
+      />
+    </svg>
+  }
+>
+  Looking for the **Python** docs? They're
+  [here](/python/getting-started/quickstart).
 </Callout>
 
 <Card title="New to MCP?" icon="brain" href="/home/mcp101">
-  Start with MCP 101  -  principles of the protocol, its three primitives, and how clients, servers, and agents fit together.
+  Start with MCP 101 - principles of the protocol, its three primitives, and how
+  clients, servers, and agents fit together.
 </Card>
 
 ## Next Steps
 
 <CardGroup cols={2}>
-  <Card title="Quickstart" icon="rocket" href="/typescript/getting-started/quickstart">
+  <Card
+    title="Quickstart"
+    icon="rocket"
+    href="/typescript/getting-started/quickstart"
+  >
     Build your first MCP server in under 5 minutes.
   </Card>
-  <Card title="Installation" icon="download" href="/typescript/getting-started/installation">
+  <Card
+    title="Installation"
+    icon="download"
+    href="/typescript/getting-started/installation"
+  >
     Set up your Node project.
   </Card>
   <Card title="MCP Server" icon="server" href="/typescript/server">
@@ -81,5 +153,6 @@ Looking for the **Python** docs? They're [here](/python/getting-started/quicksta
 </CardGroup>
 
 <Tip>
-**Need help?** Join our [Discord](https://discord.gg/XkNkSkMz3V) or check out [GitHub](https://github.com/mcp-use/mcp-use).
+  **Need help?** Join our [Discord](https://discord.gg/XkNkSkMz3V) or check out
+  [GitHub](https://github.com/mcp-use/mcp-use).
 </Tip>

--- a/docs/typescript/mcp-apps.mdx
+++ b/docs/typescript/mcp-apps.mdx
@@ -1,127 +1,52 @@
 ---
-title: "Overview"
-description: "Understand when to build MCP Apps with mcp-use and where to go next."
-icon: "blocks"
+title: "MCP Apps"
+description: "Build interactive MCP App views with mcp-use."
+icon: "app-window"
 ---
 
-MCP Apps bring rich, interactive interfaces into AI conversations. With `mcp-use`, your MCP tools can render React widgets for search results, dashboards, forms, previews, workflows, and any experience where users should act directly on structured data.
+An MCP App pairs a tool with a React view. Views live under `views/<name>/view.tsx`; the bound tool declares `view: { name }` and an `outputSchema`.
 
-In `mcp-use`, an MCP App is a TypeScript MCP server plus React widget files in `resources/`. The `mcp-apps` template wires up the server, widget build, local development tooling, and compatibility metadata for hosts such as ChatGPT.
+```ts
+import { MCPServer } from "mcp-use";
+import { z } from "zod";
 
-<video
-  alt="MCP Apps Widget Example"
-  style={{
-    maxWidth: "600px",
-    borderRadius: "8px",
-    marginBottom: "1.5rem",
-    boxShadow: "0 2px 12px rgba(0,0,0,0.08)",
-  }}
-  muted
-  autoPlay
-  loop
->
-  <source src="/images/widget.mp4" type="video/mp4" />
-</video>
+const server = new MCPServer({ name: "catalog", version: "1.0.0" });
 
-## What MCP Apps do
+export const showProduct = server.tool(
+  {
+    name: "show-product",
+    inputSchema: z.object({ id: z.string() }),
+    outputSchema: z.object({ id: z.string(), name: z.string() }),
+    view: { name: "product" },
+  },
+  async ({ id }) => {
+    const data = { id, name: "Example product" };
+    return {
+      content: [{ type: "text", text: JSON.stringify(data) }],
+      structuredContent: data,
+    };
+  },
+);
 
-An MCP App lets a tool return a widget alongside the model-visible answer. The model receives a concise text result, and the widget receives structured data for rendering.
-
-This separation keeps large UI data out of the model context while still giving the user an interactive view.
-
-```typescript
-return widget({
-  props: { query, results }, // widget rendering data
-  output: text(`Found ${results.length} products.`), // model-visible text
-});
+export default server;
 ```
 
-The matching React widget lives at `resources/product-search-result/widget.tsx` and reads `props` with `useWidget()`.
+The matching `views/product/view.tsx` reads the request lifecycle and typed result with `useToolContext()`:
 
-## How mcp-use structures an app
+```tsx
+import { ThemeProvider, useToolContext } from "mcp-use/react";
 
-The `mcp-apps` template keeps server code and widget code in one TypeScript project. These are the files you edit most often:
+export default function ProductView() {
+  const view = useToolContext<"show-product">();
+  if (view.status === "pending") return <p>Loading…</p>;
+  if (view.status === "error") return <p>{view.error.message}</p>;
 
-```text
-my-widget-server/
-├── index.ts
-├── resources/
-│   ├── product-search-result/
-│   │   └── widget.tsx
-│   └── styles.css
-├── public/
-├── ...
-├── package.json
-└── tsconfig.json
+  return (
+    <ThemeProvider>
+      <h2>{view.toolOutput.name}</h2>
+    </ThemeProvider>
+  );
+}
 ```
 
-The tool definition in `index.ts` chooses the widget with `widget: { name }`. The tool handler returns `widget({ props, output })`.
-
-The widget file uses `useWidget()` to read `props`, pending state, host context, widget state, and host actions.
-
-## What the model sees
-
-MCP tool results separate model-visible output from widget-only data.
-
-| Field | Model sees it? | Widget sees it? | Use it for |
-| --- | --- | --- | --- |
-| `content` | Yes | Yes | Short text summary for the conversation |
-| `structuredContent` | No | Yes, as `props` | Data the widget renders |
-| `_meta` | No | Yes, as `metadata` | Extra widget metadata |
-
-Use `output: text(...)` for the model-visible answer. Use `props` for widget rendering data.
-
-For a deeper explanation of widget state, model-visible context, and the `useWidget()` data model, see the [useWidget API reference](/typescript/api-reference/react/usewidget).
-
-## Compatibility
-
-`mcp-use` uses the normal widget APIs to emit the metadata and bridge behavior ChatGPT needs, so the same widget code can run in ChatGPT and MCP Apps hosts.
-
-Apps SDK APIs remain useful for ChatGPT-specific host extensions that are not part of the shared MCP Apps spec yet. Use [Apps SDK compatibility](/typescript/mcp-apps/apps-sdk-compatibility) when you need to understand that boundary.
-
-## Start here
-
-<CardGroup cols={2}>
-  <Card
-    title="Build your first MCP App"
-    icon="rocket"
-    href="/typescript/mcp-apps/quickstart"
-  >
-    Create a TypeScript MCP App, run it locally, and render the template widget.
-  </Card>
-  <Card
-    title="Build widgets"
-    icon="panel-top"
-    href="/typescript/mcp-apps/widgets"
-  >
-    Create a React widget and return it from a TypeScript MCP tool.
-  </Card>
-  <Card
-    title="Model context"
-    icon="brain"
-    href="/typescript/mcp-apps/model-context"
-  >
-    Decide what the model sees, what the widget sees, and what state persists.
-  </Card>
-  <Card
-    title="Interactivity"
-    icon="mouse-pointer-click"
-    href="/typescript/mcp-apps/interactivity"
-  >
-    Add tool calls, state, follow-up messages, and display controls.
-  </Card>
-  <Card
-    title="Apps SDK compatibility"
-    icon="openai"
-    href="/typescript/mcp-apps/apps-sdk-compatibility"
-  >
-    Understand how MCP Apps run in ChatGPT and when Apps SDK extensions matter.
-  </Card>
-  <Card
-    title="Content Security Policy"
-    icon="shield"
-    href="/typescript/mcp-apps/content-security-policy"
-  >
-    Allow widget API calls, assets, embeds, and static deployments.
-  </Card>
-</CardGroup>
+Use focused hooks such as `useHostContext`, `useCallTool`, `useViewState`, `useDisplayMode`, and `useSendFollowUp` when the view needs host data or actions. See [Build views](/typescript/mcp-apps/widgets), [Interactivity](/typescript/mcp-apps/interactivity), and [Content security policy](/typescript/mcp-apps/content-security-policy).

--- a/docs/typescript/mcp-apps/apps-sdk-compatibility.mdx
+++ b/docs/typescript/mcp-apps/apps-sdk-compatibility.mdx
@@ -14,7 +14,7 @@ OpenAI's Apps SDK remains supported, and ChatGPT also implements the MCP Apps UI
 
 In practice:
 
-- Use `widget: { name }` and `widget({ props, output })` on the server.
+- Bind the tool with `view: { name }`, declare `outputSchema`, and return raw `content` plus `structuredContent`.
 - Use `useToolContext()`, `useViewState()`, and `useCallTool()` in React views.
 - Let `mcp-use` translate compatibility metadata for ChatGPT.
 - Reach for Apps SDK extensions only when a ChatGPT-specific capability has no shared MCP Apps equivalent yet.

--- a/docs/typescript/mcp-apps/interactivity.mdx
+++ b/docs/typescript/mcp-apps/interactivity.mdx
@@ -1,130 +1,40 @@
 ---
-title: "Interactivity"
-description: "Add tool calls, widget state, follow-up messages, and display controls to MCP Apps widgets."
+title: "View interactivity"
+description: "Use focused hooks for MCP App state, tools, and host actions."
 icon: "mouse-pointer-click"
 ---
 
-Interactive widgets can call tools, save UI state, send follow-up messages, and request a larger display mode. Use these APIs for user actions that should happen inside the widget instead of requiring another prompt.
+`useToolContext()` owns the rendering tool lifecycle. Add focused hooks only for the capabilities a view needs:
 
-This guide assumes your widget already renders with `useWidget()`. See [Build widgets](/typescript/mcp-apps/widgets) first if you still need the server and widget setup.
-
-## Call tools from a widget
-
-Use `useCallTool()` when a button or form should call another MCP tool. The hook gives you loading, success, and error state.
+- `useCallTool()` calls an exported server tool and exposes pending, data, and error state.
+- `useViewState()` stores an object snapshot and restores it on hosts that support persisted view state.
+- `useHostContext()` reads locale, platform, display mode, and advertised capabilities.
+- `useDisplayMode()` requests inline, picture-in-picture, or fullscreen presentation.
+- `useSendFollowUp()` sends a user-visible follow-up message through a capable host.
+- `useOpenExternal()` asks the host to open an external URL.
 
 ```tsx
-import { useCallTool } from "mcp-use/react";
+import { useCallTool, useToolContext, useViewState } from "mcp-use/react";
 
-function DetailsButton({ productId }: { productId: string }) {
-  const { callTool, data, isPending, isError } = useCallTool("get-product");
+export default function CounterView() {
+  const view = useToolContext<"show-counter">();
+  const [state, setState] = useViewState({ clicks: 0 });
+  const reset = useCallTool("reset-counter");
+
+  if (view.status !== "ready") return <p>Loading…</p>;
 
   return (
-    <section>
-      <button onClick={() => callTool({ productId })} disabled={isPending}>
-        {isPending ? "Loading..." : "View details"}
+    <main>
+      <p>{state.clicks} local clicks</p>
+      <button onClick={() => setState({ clicks: state.clicks + 1 })}>
+        Add
       </button>
-
-      {isError && <p>Could not load product details.</p>}
-      {data && <pre>{JSON.stringify(data.structuredContent, null, 2)}</pre>}
-    </section>
+      <button onClick={() => void reset.callTool({})}>
+        Reset server counter
+      </button>
+    </main>
   );
 }
 ```
 
-Prefer `useCallTool()` for user-facing actions. Use `useWidget().callTool` only for small one-off calls where you do not need hook-managed state.
-
-## Save widget state
-
-Use `setState` for UI state that should survive re-renders and be available to future model turns.
-
-```tsx
-import { useWidget } from "mcp-use/react";
-
-type FavoritesState = {
-  favorites: string[];
-};
-
-function FavoriteButton({ id }: { id: string }) {
-  const { state, setState } = useWidget<{}, FavoritesState>();
-  const favorites = state?.favorites ?? [];
-  const isFavorite = favorites.includes(id);
-
-  async function toggleFavorite() {
-    await setState({
-      favorites: isFavorite
-        ? favorites.filter((favoriteId) => favoriteId !== id)
-        : [...favorites, id],
-    });
-  }
-
-  return (
-    <button onClick={toggleFavorite}>
-      {isFavorite ? "Remove favorite" : "Save favorite"}
-    </button>
-  );
-}
-```
-
-Use widget state for view state and user choices. Do not use widget state as your database.
-
-## Send a follow-up message
-
-Use `sendFollowUpMessage` when a widget action should ask the model to continue the conversation.
-
-```tsx
-import { useWidget } from "mcp-use/react";
-
-function ExplainButton({ productName }: { productName: string }) {
-  const { sendFollowUpMessage } = useWidget();
-
-  return (
-    <button
-      onClick={() =>
-        sendFollowUpMessage(`Compare ${productName} with similar products.`)
-      }
-    >
-      Compare
-    </button>
-  );
-}
-```
-
-Follow-up messages create a new model turn. Use them for actions that need model reasoning, not for local UI updates.
-
-## Request display modes
-
-Use `requestDisplayMode` when a widget needs more room.
-
-```tsx
-import { useWidget } from "mcp-use/react";
-
-function DisplayModeControls() {
-  const { displayMode, requestDisplayMode } = useWidget();
-  const expanded = displayMode === "fullscreen" || displayMode === "pip";
-
-  return (
-    <button onClick={() => requestDisplayMode(expanded ? "inline" : "fullscreen")}>
-      {expanded ? "Exit" : "Expand"}
-    </button>
-  );
-}
-```
-
-The host may grant a different mode than requested. Read `displayMode` for the actual current mode.
-
-## Combine actions carefully
-
-A single click should usually do one main thing. For example:
-
-- call a tool to fetch more data
-- update widget state after a user choice
-- send a follow-up message for model reasoning
-- request fullscreen for a larger view
-
-If one action must do multiple things, update local widget state first so the UI responds immediately, then call the tool or send the follow-up message.
-
-## Next steps
-
-- Use [Model context](/typescript/mcp-apps/model-context) to decide what the model should know about these interactions.
-- Use [`useCallTool()`](/typescript/api-reference/react/usecalltool) for full call state and typing details.
-- Use [`useWidget()`](/typescript/api-reference/react/usewidget) for all host actions and display-mode behavior.
+Feature-detect host capabilities before showing optional actions. Keep model-visible state explicit with `ModelContext`; ordinary React state is private to the mounted iframe.

--- a/docs/typescript/mcp-apps/widgets.mdx
+++ b/docs/typescript/mcp-apps/widgets.mdx
@@ -1,159 +1,55 @@
 ---
-title: "Build widgets"
-description: "Create a React widget and return it from a TypeScript MCP tool."
-icon: "panel-top"
+title: "Build views"
+description: "Bind a tool result to a React MCP App view."
+icon: "panels-top-left"
 ---
 
-Build a widget when a tool result needs an interactive UI. In `mcp-use`, a widget has two parts: a React file under `resources/` and a tool that returns `widget({ props, output })`.
+Create one default-exported React component at `views/<name>/view.tsx`. Bind it from exactly one tool with `view: { name }`; every view-bound tool must declare an `outputSchema`.
 
-## Create the widget file
-
-Create a folder under `resources/`. The folder name becomes the widget name you use from the server.
-
-```text
-resources/
-└── product-results/
-    └── widget.tsx
-```
-
-Define the widget metadata and component in `widget.tsx`:
-
-```tsx
-import { McpUseProvider, useWidget, type WidgetMetadata } from "mcp-use/react";
-import { z } from "zod";
-
-const propSchema = z.object({
-  query: z.string(),
-  results: z.array(
-    z.object({
-      id: z.string(),
-      name: z.string(),
-      price: z.number(),
-    }),
-  ),
-});
-
-type ProductResultsProps = z.infer<typeof propSchema>;
-
-export const widgetMetadata: WidgetMetadata = {
-  description: "Display product search results",
-  props: propSchema,
-  exposeAsTool: false,
-};
-
-export default function ProductResults() {
-  const { props, isPending } = useWidget<ProductResultsProps>();
-
-  if (isPending) {
-    return <McpUseProvider>Loading products...</McpUseProvider>;
-  }
-
-  return (
-    <McpUseProvider>
-      <main>
-        <h2>Results for {props.query}</h2>
-        <ul>
-          {props.results.map((product) => (
-            <li key={product.id}>
-              {product.name} - ${product.price}
-            </li>
-          ))}
-        </ul>
-      </main>
-    </McpUseProvider>
-  );
-}
-```
-
-Always guard required `props` behind `isPending`. Widgets mount before the tool result is available.
-
-## Return the widget from a tool
-
-In `index.ts`, add a tool whose `widget.name` matches the folder under `resources/`.
-
-```typescript
-import { MCPServer, text, widget } from "mcp-use/server";
-import { z } from "zod";
-
-const productSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  price: z.number(),
-});
-
-const productResultsSchema = z.object({
-  query: z.string(),
-  results: z.array(productSchema),
-});
-
-const server = new MCPServer({
-  name: "product-search",
-  version: "1.0.0",
-});
-
-async function searchProducts(query: string) {
-  return [
-    { id: "sku_123", name: `${query} starter kit`, price: 29 },
-  ];
-}
-
-server.tool(
+```ts
+export const searchProducts = server.tool(
   {
     name: "search-products",
-    description: "Search products and show the results in a widget",
-    schema: z.object({
-      query: z.string().describe("Search query"),
+    inputSchema: z.object({ query: z.string() }),
+    outputSchema: z.object({
+      query: z.string(),
+      items: z.array(z.object({ id: z.string(), name: z.string() })),
     }),
-    outputSchema: productResultsSchema,
-    annotations: {
-      readOnlyHint: true,
-      destructiveHint: false,
-      openWorldHint: true,
-    },
-    widget: {
+    view: {
       name: "product-results",
-      invoking: "Searching products...",
-      invoked: "Products loaded",
+      description: "Interactive product search results",
+      csp: { connectDomains: ["https://api.example.com"] },
     },
   },
   async ({ query }) => {
-    const results = await searchProducts(query);
-
-    return widget({
-      props: { query, results },
-      output: text(`Found ${results.length} products matching "${query}".`),
-    });
+    const data = { query, items: [] };
+    return {
+      content: [{ type: "text", text: JSON.stringify(data) }],
+      structuredContent: data,
+    };
   },
 );
 ```
 
-`props` becomes the widget's rendering data. `output` becomes the text result the model can read in the conversation.
+```tsx
+// views/product-results/view.tsx
+import { ThemeProvider, useToolContext } from "mcp-use/react";
 
-## Keep schemas aligned
+export default function ProductResults() {
+  const view = useToolContext<"search-products">();
+  if (view.status === "pending") return <p>Searching…</p>;
+  if (view.status === "error") return <p>{view.error.message}</p>;
 
-The server `outputSchema` should describe the same shape that the widget expects in `props`.
-
-Use a shared schema when the widget and server live in the same package. If you duplicate schemas, keep the field names and optional fields identical.
-
-## Verify the widget
-
-Run the dev server and call the tool in the Inspector:
-
-```bash
-npm run dev
+  return (
+    <ThemeProvider>
+      <ul>
+        {view.toolOutput.items.map((item) => (
+          <li key={item.id}>{item.name}</li>
+        ))}
+      </ul>
+    </ThemeProvider>
+  );
+}
 ```
 
-Open `http://localhost:3000/mcp/inspector`, run `search-products`, and confirm the widget renders below the tool result.
-
-If the tool succeeds but no widget renders, check these two values first:
-
-- `widget.name` in `index.ts`
-- the folder name under `resources/`
-
-They must match exactly.
-
-## Next steps
-
-- Use [Model context](/typescript/mcp-apps/model-context) to decide what the model should know about widget state.
-- Use [Interactivity](/typescript/mcp-apps/interactivity) when the widget needs buttons, state, tool calls, or follow-up messages.
-- Use the [`useWidget()` API reference](/typescript/api-reference/react/usewidget) for all hook fields and defaults.
+Export tool refs from the server entry so `mcp-env.d.ts` can type view calls. Public files belong under `public/`; reference them with root-relative paths in view code. Run `mcp-use typecheck` and exercise the tool in the Inspector.

--- a/docs/typescript/server/authentication/index.mdx
+++ b/docs/typescript/server/authentication/index.mdx
@@ -12,12 +12,12 @@ This guide helps you choose the right authentication path. Use the [auth provide
 
 Most MCP servers should use a Dynamic Client Registration provider. Use OAuth Proxy only when the upstream identity provider cannot register MCP clients dynamically.
 
-| Situation | Use |
-| --- | --- |
-| You use Auth0, Better Auth, Clerk, Keycloak, Supabase, or WorkOS | A built-in provider |
-| Your provider advertises a `registration_endpoint` | [Custom Provider](/typescript/server/authentication/providers/custom) |
+| Situation                                                            | Use                                                                    |
+| -------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| You use Auth0, Better Auth, Clerk, Keycloak, Supabase, or WorkOS     | A built-in provider                                                    |
+| Your provider advertises a `registration_endpoint`                   | [Custom Provider](/typescript/server/authentication/providers/custom)  |
 | Your provider only gives you one fixed `clientId` and `clientSecret` | [OAuth Proxy](/typescript/server/authentication/providers/oauth-proxy) |
-| You only need local development without identity | No OAuth provider |
+| You only need local development without identity                     | No OAuth provider                                                      |
 
 With a Dynamic Client Registration provider, clients register directly with the upstream identity provider. Your MCP server exposes discovery metadata and verifies bearer tokens. It does not handle the authorization code or token exchange.
 
@@ -40,7 +40,8 @@ Choose the provider that matches your identity system:
 Pass the selected provider to `MCPServer`.
 
 ```typescript
-import { MCPServer, oauthAuth0Provider } from "mcp-use/server";
+import { MCPServer } from "mcp-use";
+import { oauthAuth0Provider } from "mcp-use/oauth/auth0";
 
 const server = new MCPServer({
   name: "secure-server",
@@ -58,7 +59,7 @@ Provider pages show the required dashboard steps and environment variables. The 
 When OAuth is configured and the request is authenticated, tools can read `ctx.auth`.
 
 ```typescript
-import { error, object } from "mcp-use/server";
+import { error, object } from "mcp-use";
 
 server.tool(
   {
@@ -96,16 +97,32 @@ Keep provider-specific setup in the provider page. Keep authorization decisions 
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="User Context" icon="user" href="/typescript/server/authentication/user-context">
+  <Card
+    title="User Context"
+    icon="user"
+    href="/typescript/server/authentication/user-context"
+  >
     Read identity, scopes, roles, and permissions inside tools.
   </Card>
-  <Card title="Auth providers API reference" icon="terminal" href="/typescript/api-reference/server/auth-providers">
+  <Card
+    title="Auth providers API reference"
+    icon="terminal"
+    href="/typescript/api-reference/server/auth-providers"
+  >
     Look up exact provider options, defaults, and verification behavior.
   </Card>
-  <Card title="Client Authentication" icon="router" href="/typescript/client/authentication">
+  <Card
+    title="Client Authentication"
+    icon="router"
+    href="/typescript/client/authentication"
+  >
     Connect a TypeScript MCP client to an OAuth-protected server.
   </Card>
-  <Card title="OAuth Proxy" icon="shuffle" href="/typescript/server/authentication/providers/oauth-proxy">
+  <Card
+    title="OAuth Proxy"
+    icon="shuffle"
+    href="/typescript/server/authentication/providers/oauth-proxy"
+  >
     Bridge providers that do not support Dynamic Client Registration.
   </Card>
 </CardGroup>

--- a/docs/typescript/server/authentication/providers/auth0.mdx
+++ b/docs/typescript/server/authentication/providers/auth0.mdx
@@ -52,7 +52,8 @@ The domain is your Auth0 tenant domain. The audience must match the API identifi
 ## Configure the MCP server
 
 ```typescript
-import { MCPServer, oauthAuth0Provider } from "mcp-use/server";
+import { MCPServer } from "mcp-use";
+import { oauthAuth0Provider } from "mcp-use/oauth/auth0";
 
 const server = new MCPServer({
   name: "auth0-server",
@@ -77,14 +78,14 @@ oauth: oauthAuth0Provider({
 Auth0 permissions are available on `ctx.auth.permissions` when they are present in the access token.
 
 ```typescript
-import { error, text } from "mcp-use/server";
+import { error, text } from "mcp-use";
 import { z } from "zod";
 
 server.tool(
   {
     name: "delete_document",
     description: "Delete a document when the caller has Auth0 permission.",
-    schema: z.object({
+    inputSchema: z.object({
       documentId: z.string(),
     }),
   },
@@ -123,16 +124,32 @@ Confirm these cases:
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Runnable Auth0 example" icon="github" href="https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/auth0">
+  <Card
+    title="Runnable Auth0 example"
+    icon="github"
+    href="https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/auth0"
+  >
     Compare your setup with a working mcp-use Auth0 server.
   </Card>
-  <Card title="Auth0 MCP Authorization Guide" icon="book-open" href="https://auth0.com/ai/docs/mcp/get-started/authorization-for-your-mcp-server">
+  <Card
+    title="Auth0 MCP Authorization Guide"
+    icon="book-open"
+    href="https://auth0.com/ai/docs/mcp/get-started/authorization-for-your-mcp-server"
+  >
     Review Auth0's MCP authorization setup.
   </Card>
-  <Card title="User Context" icon="user" href="/typescript/server/authentication/user-context">
+  <Card
+    title="User Context"
+    icon="user"
+    href="/typescript/server/authentication/user-context"
+  >
     Read Auth0 user and permission data inside tools.
   </Card>
-  <Card title="Auth0 provider API reference" icon="terminal" href="/typescript/api-reference/server/auth-providers#oauthauth0provider">
+  <Card
+    title="Auth0 provider API reference"
+    icon="terminal"
+    href="/typescript/api-reference/server/auth-providers#oauthauth0provider"
+  >
     Look up exact provider options and defaults.
   </Card>
 </CardGroup>

--- a/docs/typescript/server/authentication/providers/clerk.mdx
+++ b/docs/typescript/server/authentication/providers/clerk.mdx
@@ -34,7 +34,8 @@ MCP_USE_OAUTH_CLERK_FRONTEND_API_URL=https://verb-noun-42.clerk.accounts.dev
 ## Configure the MCP server
 
 ```typescript
-import { MCPServer, oauthClerkProvider } from "mcp-use/server";
+import { MCPServer } from "mcp-use";
+import { oauthClerkProvider } from "mcp-use/oauth/clerk";
 
 const server = new MCPServer({
   name: "clerk-server",
@@ -67,7 +68,7 @@ oauth: oauthClerkProvider({
 When you use Clerk Organizations, Clerk can include `org_id` in the token. This requires Organizations to be enabled, the `user:org:read` scope to be available to the OAuth app, and the client to request that scope.
 
 ```typescript
-import { error, object } from "mcp-use/server";
+import { error, object } from "mcp-use";
 
 server.tool(
   {
@@ -115,16 +116,32 @@ Confirm these cases:
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Runnable Clerk example" icon="github" href="https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/clerk">
+  <Card
+    title="Runnable Clerk example"
+    icon="github"
+    href="https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/clerk"
+  >
     Compare your setup with a working mcp-use Clerk server.
   </Card>
-  <Card title="Clerk OAuth documentation" icon="book-open" href="https://clerk.com/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth">
+  <Card
+    title="Clerk OAuth documentation"
+    icon="book-open"
+    href="https://clerk.com/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth"
+  >
     Review Clerk's OAuth behavior.
   </Card>
-  <Card title="User Context" icon="user" href="/typescript/server/authentication/user-context">
+  <Card
+    title="User Context"
+    icon="user"
+    href="/typescript/server/authentication/user-context"
+  >
     Use Clerk identity and organization data inside tools.
   </Card>
-  <Card title="Clerk provider API reference" icon="terminal" href="/typescript/api-reference/server/auth-providers#oauthclerkprovider">
+  <Card
+    title="Clerk provider API reference"
+    icon="terminal"
+    href="/typescript/api-reference/server/auth-providers#oauthclerkprovider"
+  >
     Look up exact provider options and defaults.
   </Card>
 </CardGroup>

--- a/docs/typescript/server/authentication/providers/custom.mdx
+++ b/docs/typescript/server/authentication/providers/custom.mdx
@@ -36,7 +36,8 @@ Your custom provider must verify access tokens and return the verified payload.
 
 ```typescript
 import { createRemoteJWKSet, jwtVerify } from "jose";
-import { MCPServer, oauthCustomProvider } from "mcp-use/server";
+import { MCPServer } from "mcp-use";
+import { oauthCustomProvider } from "mcp-use/oauth";
 
 const issuer = "https://auth.example.com";
 const jwks = createRemoteJWKSet(new URL(`${issuer}/.well-known/jwks.json`));
@@ -108,13 +109,25 @@ Confirm these cases:
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="OAuth Proxy" icon="shuffle" href="/typescript/server/authentication/providers/oauth-proxy">
+  <Card
+    title="OAuth Proxy"
+    icon="shuffle"
+    href="/typescript/server/authentication/providers/oauth-proxy"
+  >
     Use a provider that does not support Dynamic Client Registration.
   </Card>
-  <Card title="User Context" icon="user" href="/typescript/server/authentication/user-context">
+  <Card
+    title="User Context"
+    icon="user"
+    href="/typescript/server/authentication/user-context"
+  >
     Use normalized user claims inside tools.
   </Card>
-  <Card title="Custom provider API reference" icon="terminal" href="/typescript/api-reference/server/auth-providers#oauthcustomprovider">
+  <Card
+    title="Custom provider API reference"
+    icon="terminal"
+    href="/typescript/api-reference/server/auth-providers#oauthcustomprovider"
+  >
     Look up exact custom provider options and contracts.
   </Card>
   <Card title="jose" icon="key" href="https://github.com/panva/jose">

--- a/docs/typescript/server/authentication/providers/keycloak.mdx
+++ b/docs/typescript/server/authentication/providers/keycloak.mdx
@@ -41,7 +41,8 @@ If you set an audience but Keycloak does not emit that `aud` value, valid-lookin
 ## Configure the MCP server
 
 ```typescript
-import { MCPServer, oauthKeycloakProvider } from "mcp-use/server";
+import { MCPServer } from "mcp-use";
+import { oauthKeycloakProvider } from "mcp-use/oauth/keycloak";
 
 const server = new MCPServer({
   name: "keycloak-server",
@@ -66,7 +67,7 @@ oauth: oauthKeycloakProvider({
 The provider maps Keycloak realm roles onto `ctx.auth.user.roles`. It maps resource roles onto `ctx.auth.user.permissions` as `client:role` strings.
 
 ```typescript
-import { error, text } from "mcp-use/server";
+import { error, text } from "mcp-use";
 
 server.tool(
   {
@@ -116,16 +117,32 @@ Before deploying:
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Runnable Keycloak example" icon="github" href="https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/keycloak">
+  <Card
+    title="Runnable Keycloak example"
+    icon="github"
+    href="https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/keycloak"
+  >
     Compare your setup with a working mcp-use Keycloak server.
   </Card>
-  <Card title="Keycloak Client Registration" icon="book-open" href="https://www.keycloak.org/securing-apps/client-registration">
+  <Card
+    title="Keycloak Client Registration"
+    icon="book-open"
+    href="https://www.keycloak.org/securing-apps/client-registration"
+  >
     Review Keycloak Dynamic Client Registration.
   </Card>
-  <Card title="User Context" icon="user" href="/typescript/server/authentication/user-context">
+  <Card
+    title="User Context"
+    icon="user"
+    href="/typescript/server/authentication/user-context"
+  >
     Use Keycloak roles and permissions inside tools.
   </Card>
-  <Card title="Keycloak provider API reference" icon="terminal" href="/typescript/api-reference/server/auth-providers#oauthkeycloakprovider">
+  <Card
+    title="Keycloak provider API reference"
+    icon="terminal"
+    href="/typescript/api-reference/server/auth-providers#oauthkeycloakprovider"
+  >
     Look up exact provider options and defaults.
   </Card>
 </CardGroup>

--- a/docs/typescript/server/authentication/providers/supabase.mdx
+++ b/docs/typescript/server/authentication/providers/supabase.mdx
@@ -41,7 +41,8 @@ MCP_USE_OAUTH_SUPABASE_URL=http://localhost:54321
 ## Configure the MCP server
 
 ```typescript
-import { MCPServer, oauthSupabaseProvider } from "mcp-use/server";
+import { MCPServer } from "mcp-use";
+import { oauthSupabaseProvider } from "mcp-use/oauth/supabase";
 
 const server = new MCPServer({
   name: "supabase-server",
@@ -74,7 +75,7 @@ npm install @supabase/supabase-js
 
 ```typescript
 import { createClient } from "@supabase/supabase-js";
-import { error, object } from "mcp-use/server";
+import { error, object } from "mcp-use";
 
 const supabaseUrl =
   process.env.MCP_USE_OAUTH_SUPABASE_URL ??
@@ -136,16 +137,32 @@ Confirm these cases:
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Supabase OAuth template" icon="github" href="https://github.com/mcp-use/mcp-oauth-supabase-template">
+  <Card
+    title="Supabase OAuth template"
+    icon="github"
+    href="https://github.com/mcp-use/mcp-oauth-supabase-template"
+  >
     Start from a consent UI wired for mcp-use and Supabase.
   </Card>
-  <Card title="Supabase MCP Authentication" icon="book-open" href="https://supabase.com/docs/guides/auth/oauth-server/mcp-authentication">
+  <Card
+    title="Supabase MCP Authentication"
+    icon="book-open"
+    href="https://supabase.com/docs/guides/auth/oauth-server/mcp-authentication"
+  >
     Review Supabase's MCP authentication guide.
   </Card>
-  <Card title="User Context" icon="user" href="/typescript/server/authentication/user-context">
+  <Card
+    title="User Context"
+    icon="user"
+    href="/typescript/server/authentication/user-context"
+  >
     Use Supabase user data inside tools.
   </Card>
-  <Card title="Supabase provider API reference" icon="terminal" href="/typescript/api-reference/server/auth-providers#oauthsupabaseprovider">
+  <Card
+    title="Supabase provider API reference"
+    icon="terminal"
+    href="/typescript/api-reference/server/auth-providers#oauthsupabaseprovider"
+  >
     Look up exact provider options and defaults.
   </Card>
 </CardGroup>

--- a/docs/typescript/server/authentication/providers/workos.mdx
+++ b/docs/typescript/server/authentication/providers/workos.mdx
@@ -35,7 +35,8 @@ Use the full AuthKit domain as the subdomain value.
 ## Configure the MCP server
 
 ```typescript
-import { MCPServer, oauthWorkOSProvider } from "mcp-use/server";
+import { MCPServer } from "mcp-use";
+import { oauthWorkOSProvider } from "mcp-use/oauth/workos";
 
 const server = new MCPServer({
   name: "workos-server",
@@ -61,7 +62,7 @@ If your tools call the WorkOS Management API, store that API key separately. It 
 WorkOS can include organization context in the token. Use it to filter tenant-specific data.
 
 ```typescript
-import { error, object } from "mcp-use/server";
+import { error, object } from "mcp-use";
 
 server.tool(
   {
@@ -109,16 +110,32 @@ Confirm these cases:
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Runnable WorkOS example" icon="github" href="https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/workos">
+  <Card
+    title="Runnable WorkOS example"
+    icon="github"
+    href="https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/workos"
+  >
     Compare your setup with a working mcp-use WorkOS server.
   </Card>
-  <Card title="WorkOS AuthKit MCP guide" icon="book-open" href="https://workos.com/docs/authkit/mcp">
+  <Card
+    title="WorkOS AuthKit MCP guide"
+    icon="book-open"
+    href="https://workos.com/docs/authkit/mcp"
+  >
     Review WorkOS AuthKit MCP setup.
   </Card>
-  <Card title="User Context" icon="user" href="/typescript/server/authentication/user-context">
+  <Card
+    title="User Context"
+    icon="user"
+    href="/typescript/server/authentication/user-context"
+  >
     Use WorkOS identity and organization data inside tools.
   </Card>
-  <Card title="WorkOS provider API reference" icon="terminal" href="/typescript/api-reference/server/auth-providers#oauthworkosprovider">
+  <Card
+    title="WorkOS provider API reference"
+    icon="terminal"
+    href="/typescript/api-reference/server/auth-providers#oauthworkosprovider"
+  >
     Look up exact provider options and defaults.
   </Card>
 </CardGroup>

--- a/docs/typescript/server/authentication/user-context.mdx
+++ b/docs/typescript/server/authentication/user-context.mdx
@@ -13,14 +13,14 @@ This guide focuses on access-control patterns. Use the [Auth API reference](/typ
 Return an authorization error before doing work that requires a user.
 
 ```typescript
-import { error, text } from "mcp-use/server";
+import { error, text } from "mcp-use";
 import { z } from "zod";
 
 server.tool(
   {
     name: "create_document",
     description: "Create a document owned by the authenticated user.",
-    schema: z.object({
+    inputSchema: z.object({
       title: z.string(),
       content: z.string(),
     }),
@@ -65,7 +65,7 @@ Do not assume `email`, `name`, or provider-specific fields are always present. C
 Use scopes for OAuth grants and permissions for application authorization. mcp-use exposes both on `ctx.auth`.
 
 ```typescript
-import { error, text } from "mcp-use/server";
+import { error, text } from "mcp-use";
 
 server.tool(
   {
@@ -94,7 +94,7 @@ Providers map claims differently. Check the provider page for claim conventions 
 Many providers add organization or tenant claims to `ctx.auth.user`. Narrow custom fields before using them.
 
 ```typescript
-import { error, object } from "mcp-use/server";
+import { error, object } from "mcp-use";
 
 server.tool(
   {
@@ -128,7 +128,8 @@ Use provider-specific claim names consistently in your app. For example, Clerk a
 Use a provider's `getUserInfo` option when the token uses custom claim names or when you want normalized user fields across providers.
 
 ```typescript
-import { MCPServer, oauthCustomProvider } from "mcp-use/server";
+import { MCPServer } from "mcp-use";
+import { oauthCustomProvider } from "mcp-use/oauth";
 
 const server = new MCPServer({
   name: "secure-server",
@@ -157,16 +158,28 @@ Fields returned from `getUserInfo` live under `ctx.auth.user`. Top-level `ctx.au
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Authentication" icon="shield-check" href="/typescript/server/authentication/index">
+  <Card
+    title="Authentication"
+    icon="shield-check"
+    href="/typescript/server/authentication/index"
+  >
     Choose and configure an OAuth provider.
   </Card>
-  <Card title="Auth API reference" icon="terminal" href="/typescript/api-reference/server/auth">
+  <Card
+    title="Auth API reference"
+    icon="terminal"
+    href="/typescript/api-reference/server/auth"
+  >
     Look up `AuthInfo`, `UserInfo`, and authorization helpers.
   </Card>
   <Card title="Middleware" icon="layers" href="/typescript/server/middleware">
     Apply shared authorization checks across tools.
   </Card>
-  <Card title="Auth providers API reference" icon="plug" href="/typescript/api-reference/server/auth-providers">
+  <Card
+    title="Auth providers API reference"
+    icon="plug"
+    href="/typescript/api-reference/server/auth-providers"
+  >
     Look up provider-specific `getUserInfo` options.
   </Card>
 </CardGroup>

--- a/docs/typescript/server/deployment/mcp-use.mdx
+++ b/docs/typescript/server/deployment/mcp-use.mdx
@@ -15,7 +15,7 @@ The `mcp-use` TypeScript SDK is the framework you use to build the server. Manuf
 - The `mcp-use` executable. Projects created with `create-mcp-use-app` include it. For other projects, install the CLI:
 
 ```bash
-npm install -g @mcp-use/cli
+npm install -g mcp-use
 ```
 
 Log in before your first deploy:

--- a/docs/typescript/server/elicitation.mdx
+++ b/docs/typescript/server/elicitation.mdx
@@ -12,10 +12,10 @@ This guide focuses on when to use elicitation and how to handle the user respons
 
 Use form mode for non-sensitive structured input. Use URL mode for sensitive or external flows.
 
-| Need | Mode |
-| --- | --- |
-| Ask for preferences, labels, confirmation fields, or non-sensitive details | Form mode |
-| Send the user through OAuth, payment, credential entry, or another sensitive flow | URL mode |
+| Need                                                                              | Mode      |
+| --------------------------------------------------------------------------------- | --------- |
+| Ask for preferences, labels, confirmation fields, or non-sensitive details        | Form mode |
+| Send the user through OAuth, payment, credential entry, or another sensitive flow | URL mode  |
 
 Never collect credentials, API keys, payment details, or OAuth secrets through form mode. Form responses pass through the MCP client.
 
@@ -26,7 +26,7 @@ Keep form schemas flat and simple. Use top-level primitive fields, enum fields, 
 Only use elicitation when the connected client supports the mode you need. Provide a fallback for clients that do not advertise that support.
 
 ```typescript
-import { error, text } from "mcp-use/server";
+import { error, text } from "mcp-use";
 import { z } from "zod";
 
 server.tool(
@@ -51,7 +51,9 @@ server.tool(
       return text("No contact details were provided.");
     }
 
-    return text(`Follow-up will go to ${result.data.name} at ${result.data.email}.`);
+    return text(
+      `Follow-up will go to ${result.data.name} at ${result.data.email}.`,
+    );
   },
 );
 ```
@@ -138,7 +140,10 @@ server.tool(
     }
 
     const authRequest = await githubAuth.createAuthorizationRequest();
-    const result = await ctx.elicit("Authorize GitHub access to continue.", authRequest.url);
+    const result = await ctx.elicit(
+      "Authorize GitHub access to continue.",
+      authRequest.url,
+    );
 
     if (result.action !== "accept") {
       return error("GitHub authorization was not completed.");
@@ -176,7 +181,9 @@ try {
 
   return text(`Deploying to ${result.data.environment}.`);
 } catch (err) {
-  return error(`Could not collect deployment input: ${err instanceof Error ? err.message : String(err)}`);
+  return error(
+    `Could not collect deployment input: ${err instanceof Error ? err.message : String(err)}`,
+  );
 }
 ```
 
@@ -197,16 +204,29 @@ Then open the Inspector, call a tool that uses elicitation, and verify accept, d
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Tool context API reference" icon="terminal" href="/typescript/api-reference/server/tool-context#elicit">
-    Look up `ctx.elicit()` overloads, result types, timeout options, and validation behavior.
+  <Card
+    title="Tool context API reference"
+    icon="terminal"
+    href="/typescript/api-reference/server/tool-context#elicit"
+  >
+    Look up `ctx.elicit()` overloads, result types, timeout options, and
+    validation behavior.
   </Card>
-  <Card title="Elicitation schemas (v1 migration)" icon="list-checks" href="/typescript/api-reference/server/elicitation-schemas">
+  <Card
+    title="Elicitation schemas (v1 migration)"
+    icon="list-checks"
+    href="/typescript/api-reference/server/elicitation-schemas"
+  >
     Map removed v1 enum helpers to Zod form schemas.
   </Card>
   <Card title="Sampling" icon="pipette" href="/typescript/server/sampling">
     Ask the client LLM for a completion during tool execution.
   </Card>
-  <Card title="Client elicitation" icon="monitor" href="/typescript/client/elicitation">
+  <Card
+    title="Client elicitation"
+    icon="monitor"
+    href="/typescript/client/elicitation"
+  >
     Handle elicitation requests in a TypeScript MCP client.
   </Card>
 </CardGroup>

--- a/docs/typescript/server/examples.mdx
+++ b/docs/typescript/server/examples.mdx
@@ -4,7 +4,7 @@ description: "Explore TypeScript MCP server examples with live demos, source rep
 icon: "code"
 ---
 
-Use these examples when you want a complete TypeScript MCP server to try, deploy, or remix. Each example is built with `mcp-use/server`, exposes one or more tools, and includes a live MCP endpoint.
+Use these examples when you want a complete TypeScript MCP server to try, deploy, or remix. Each example imports from `mcp-use`, exposes one or more tools, and includes a live MCP endpoint.
 
 Use a demo URL in the [Inspector](/inspector/index) to call its tools before cloning the repo.
 

--- a/docs/typescript/server/index.mdx
+++ b/docs/typescript/server/index.mdx
@@ -1,251 +1,108 @@
 ---
 title: "Overview"
-description: "Build TypeScript MCP servers with tools, resources, prompts, widgets, auth, sessions, and deployments."
+description: "Build stateless TypeScript MCP servers with tools, resources, prompts, authentication, and MCP App views."
 icon: "list-start"
 ---
 
-Use the mcp-use TypeScript server framework when you want to build an MCP server with tools, resources, prompts, or interactive MCP App widgets.
+Use the mcp-use TypeScript server framework to expose tools, resources, prompts, or interactive MCP App views. Start with the [quickstart](/typescript/getting-started/quickstart), or see the [v1 migration guide](/typescript/server/migration).
 
-If you are starting from scratch, use the [TypeScript quickstart](/typescript/getting-started/quickstart) to scaffold a server. Use [Build your first MCP App](/typescript/mcp-apps/quickstart) when the server should return React widgets.
+## Create a server
 
-## What mcp-use adds
-
-- **One-command scaffolding:** `npx create-mcp-use-app` creates a runnable server with scripts, TypeScript config, examples, and optional widgets.
-- **Inspector-first development:** `npm run dev` serves the MCP endpoint and Inspector so you can test tools, resources, prompts, and widgets locally.
-- **Hot reload:** tools, resources, prompts, and widgets update during development without restarting the server or dropping client sessions.
-- **Typed server primitives:** tools, prompts, and resource templates use Zod schemas for validation and TypeScript inference.
-- **MCP Apps support:** create interactive experiences in MCP Apps-compatible clients and ChatGPT.
-
-## Core server concepts
-
-### Server instance
-
-Create one `MCPServer` instance in your entry file. It owns MCP registration, the Hono app, the HTTP transport, session handling, and local development routes.
-
-```typescript
-import { MCPServer } from "mcp-use/server";
+```ts
+import { MCPServer } from "mcp-use";
 
 const server = new MCPServer({
   name: "inventory-server",
-  title: "Inventory Server",
   version: "1.0.0",
-  description: "Look up products and prepare inventory summaries",
-  instructions:
-    "Call search-products before get-product-details. Confirm availability before preparing an order.",
-  baseUrl: process.env.MCP_URL || "http://localhost:3000",
+  description: "Look up products and inventory",
+  basePath: "/mcp",
 });
+
+export default server;
 ```
 
-`instructions` are returned during MCP initialization. Use them for server-wide workflow guidance that does not belong in a single tool description.
+`server.fetch` is the Web-standard deployment handler. `server.listen()` uses the same application for local Node serving. The protocol runtime is stateless: registrations are replayed into a fresh SDK server for each request, so register everything before the first request.
 
-### Tools
+## Register a tool
 
-Tools are functions clients can invoke. Use tools for actions, lookups, and workflows.
+Schemas implement Standard Schema; Zod 4 is the documented example.
 
-```typescript
-import { text } from "mcp-use/server";
+```ts
 import { z } from "zod";
 
 export const getTime = server.tool(
   {
     name: "get-time",
-    description: "Return the current server time as an ISO timestamp",
-    schema: z.object({}),
-    annotations: {
-      readOnlyHint: true,
-      destructiveHint: false,
-      openWorldHint: false,
-    },
+    description: "Return the current server time",
+    inputSchema: z.object({}),
+    outputSchema: z.object({ timestamp: z.string() }),
   },
-  async () => text(new Date().toISOString()),
+  async () => {
+    const data = { timestamp: new Date().toISOString() };
+    return {
+      content: [{ type: "text", text: data.timestamp }],
+      structuredContent: data,
+    };
+  },
 );
 ```
 
-Learn more in [Tools](/typescript/server/tools).
+Prefer raw MCP result envelopes. Deprecated response helpers remain available for migration, but new tools with `outputSchema` should return matching `structuredContent` and model-visible `content`.
 
-### Resources
+## Add an MCP App view
 
-Resources expose readable content by URI. Use resources for configuration, documents, generated data, or files that clients should inspect.
-
-```typescript
-import { object } from "mcp-use/server";
-
-server.resource(
-  {
-    name: "inventory-summary",
-    uri: "inventory://summary",
-    title: "Inventory Summary",
-    description: "Current warehouse inventory totals",
-  },
-  async () =>
-    object({
-      warehouses: 3,
-      products: 1284,
-      lowStockItems: 17,
-    }),
-);
-```
-
-Learn more in [Resources](/typescript/server/resources).
-
-### Prompts
-
-Prompts are reusable templates for model interactions. Use prompts when you want clients to reuse a structured model instruction with typed arguments.
-
-```typescript
-import { text } from "mcp-use/server";
-import { z } from "zod";
-
-server.prompt(
-  {
-    name: "summarize-inventory",
-    description: "Create an inventory summary for a specific audience",
-    schema: z.object({
-      audience: z.enum(["operations", "finance", "support"]),
-      timeframe: z.string().describe("Reporting period, such as today or Q2"),
-    }),
-  },
-  async ({ audience, timeframe }) =>
-    text(
-      `Summarize inventory changes for ${audience} during ${timeframe}. Include risks, causes, and next actions.`,
-    ),
-);
-```
-
-Learn more in [Prompts](/typescript/server/prompts).
-
-### MCP Apps
-
-MCP Apps are React components rendered from MCP tool results. Put the component in `resources/<widget-name>/widget.tsx`, read data with `useWidget()`, and handle the initial loading state before reading props.
+Put the component at `views/<name>/view.tsx`, bind exactly one tool with `view: { name }`, and declare its `outputSchema`. The view reads pending, error, and ready states through `useToolContext()`.
 
 ```tsx
-// resources/product-search-result/widget.tsx
-import React from "react";
-import { useWidget } from "mcp-use/react";
+import { useToolContext } from "mcp-use/react";
 
-type ProductSearchResultProps = {
-  query: string;
-  results: { id: string; name: string }[];
-};
-
-const ProductSearchResult: React.FC = () => {
-  const { props, isPending } = useWidget<ProductSearchResultProps>();
-
-  if (isPending) {
-    return <div className="p-4">Loading...</div>;
-  }
-
-  const query = props.query ?? "";
-  const results = props.results ?? [];
-
-  return (
-    <div className="p-4">
-      <h3>Results for "{query}"</h3>
-      <ul>
-        {results.map((result) => (
-          <li key={result.id}>{result.name}</li>
-        ))}
-      </ul>
-    </div>
-  );
-};
-
-export default ProductSearchResult;
+export default function InventoryView() {
+  const view = useToolContext<"show-inventory">();
+  if (view.status === "pending") return <p>Loading…</p>;
+  if (view.status === "error") return <p>{view.error.message}</p>;
+  return <pre>{JSON.stringify(view.toolOutput, null, 2)}</pre>;
+}
 ```
 
-The recommended server pattern is to define a custom tool with a `widget: { name }` config and return `widget({ props, output })` from the handler.
+See [MCP Apps](/typescript/mcp-apps) for binding, assets, CSP, and host hooks.
 
-```typescript
-import { text, widget } from "mcp-use/server";
-import { z } from "zod";
-
-export const searchProducts = server.tool(
-  {
-    name: "search-products",
-    description: "Search products and display the results in a widget",
-    schema: z.object({
-      query: z.string().describe("Search term"),
-    }),
-    outputSchema: z.object({
-      query: z.string(),
-      results: z.array(z.object({ id: z.string(), name: z.string() })),
-    }),
-    annotations: {
-      readOnlyHint: true,
-      destructiveHint: false,
-      openWorldHint: true,
-    },
-    widget: {
-      name: "product-search-result",
-      invoking: "Searching...",
-      invoked: "Results loaded",
-    },
-  },
-  async ({ query }) => {
-    const results = await searchProducts(query);
-
-    return widget({
-      props: { query, results },
-      output: text(`Found ${results.length} products for "${query}"`),
-    });
-  },
-);
-```
-
-Learn more in [MCP Apps](/typescript/mcp-apps) and [useWidget()](/typescript/api-reference/react/usewidget).
-
-## Local development loop
-
-Run the dev server from a scaffolded project:
+## Develop locally
 
 ```bash
 npm run dev
 ```
 
-By default, local development gives you:
+The default scaffold serves MCP at `http://localhost:3000/mcp` and opens the Inspector at `http://localhost:3000/mcp/inspector`. Successful server reloads swap the handler used by subsequent requests; view edits use Vite hot module replacement.
 
-| URL                               | Purpose                                                          |
-| --------------------------------- | ---------------------------------------------------------------- |
-| `http://localhost:3000/mcp`       | MCP endpoint for clients.                                        |
-| `http://localhost:3000/mcp/inspector` | Inspector UI for testing tools, resources, prompts, and widgets. |
-
-Keep the Inspector open while editing `index.ts` and files under `resources/`. The dev server hot-reloads registrations and widget assets.
-
-## Next steps
-
-<CardGroup cols={3}>
-  <Card
-    title="TypeScript quickstart"
-    icon="rocket"
-    href="/typescript/getting-started/quickstart"
-  >
-    Create and verify a TypeScript MCP server.
-  </Card>
+<CardGroup cols={2}>
   <Card title="Tools" icon="wrench" href="/typescript/server/tools">
-    Build executable functions with parameters and validation.
+    Define typed model actions.
   </Card>
   <Card
     title="Resources"
     icon="folder-open"
     href="/typescript/server/resources"
   >
-    Expose static and dynamic content by URI.
+    Expose readable URI content.
   </Card>
   <Card title="Prompts" icon="message-square" href="/typescript/server/prompts">
-    Create reusable prompt templates.
+    Publish reusable prompt templates.
   </Card>
   <Card
-    title="MCP Apps"
-    icon="app-window-mac"
-    href="/typescript/mcp-apps"
+    title="Authentication"
+    icon="shield"
+    href="/typescript/server/authentication/index"
   >
-    Return interactive React widgets from tools.
+    Protect the MCP endpoint.
+  </Card>
+  <Card title="OpenAPI" icon="file-code" href="/typescript/server/openapi">
+    Generate tools from an API document.
   </Card>
   <Card
-    title="Configuration"
-    icon="cog"
-    href="/typescript/api-reference/server/server-config"
+    title="Deployment"
+    icon="rocket"
+    href="/typescript/server/deployment/mcp-use"
   >
-    Configure transport, sessions, middleware, CORS, and production settings.
+    Build and deploy the server.
   </Card>
 </CardGroup>

--- a/docs/typescript/server/middleware.mdx
+++ b/docs/typescript/server/middleware.mdx
@@ -27,7 +27,7 @@ MCP middleware patterns use the `mcp:` prefix. Register Hono middleware directly
 Register MCP middleware with `server.use("mcp:<pattern>", handler)`. The handler receives a context object and a `next()` function.
 
 ```typescript
-import { MCPServer, text } from "mcp-use/server";
+import { MCPServer, text } from "mcp-use";
 import { z } from "zod";
 
 const server = new MCPServer({ name: "my-server", version: "1.0.0" });
@@ -43,7 +43,7 @@ server.tool(
   {
     name: "greet",
     description: "Say hello.",
-    schema: z.object({ name: z.string() }),
+    inputSchema: z.object({ name: z.string() }),
   },
   async ({ name }) => text(`Hello, ${name}!`),
 );

--- a/docs/typescript/server/migration.mdx
+++ b/docs/typescript/server/migration.mdx
@@ -1,0 +1,76 @@
+---
+title: "Migrate a v1 server"
+description: "Move a TypeScript mcp-use server and its widgets to the stateless v2 API."
+icon: "arrow-right-left"
+---
+
+Version 2 is a stateless server framework built on the current MCP SDK. Server code imports from the package root, every request gets a fresh protocol server instance, and MCP App UIs are views backed by standard MCP resources.
+
+## Update imports and commands
+
+Import server APIs from `mcp-use` instead of `mcp-use/server`. The `mcp-use` package also provides the `dev`, `build`, `start`, `typecheck`, and client commands; remove a direct `@mcp-use/cli` dependency.
+
+```ts
+import { MCPServer } from "mcp-use";
+```
+
+Register every tool, resource, and prompt before `listen()` or the first `server.fetch()` request. Session stores and registration synchronization are not part of the stateless runtime.
+
+## Return wire results
+
+Prefer raw MCP result envelopes. A tool with an `outputSchema` returns matching `structuredContent`; include text content as a model-visible fallback.
+
+```ts
+const data = { greeting: "Hello" };
+return {
+  content: [{ type: "text", text: JSON.stringify(data) }],
+  structuredContent: data,
+};
+```
+
+The old response helpers remain deprecated compatibility shims, but new code should not depend on `widget()` or helper-specific result shapes.
+
+## Move widgets to views
+
+Move `resources/<name>/widget.tsx` to `views/<name>/view.tsx`. Replace a tool's `widget:` definition with `view:` and declare an `outputSchema`.
+
+```ts
+export const showGreeting = server.tool(
+  {
+    name: "show-greeting",
+    inputSchema: z.object({ name: z.string() }),
+    outputSchema: z.object({ greeting: z.string() }),
+    view: { name: "greeting" },
+  },
+  async ({ name }) => {
+    const data = { greeting: `Hello, ${name}` };
+    return {
+      content: [{ type: "text", text: data.greeting }],
+      structuredContent: data,
+    };
+  },
+);
+```
+
+Inside the view, replace `useWidget()` with `useToolContext()`. Replace `McpUseProvider` with direct composition such as `ThemeProvider`; use `useHostContext`, `useCallTool`, and the other focused hooks for optional host behavior.
+
+```tsx
+import { ThemeProvider, useToolContext } from "mcp-use/react";
+
+export default function GreetingView() {
+  const view = useToolContext<"show-greeting">();
+  if (view.status === "pending") return <p>Loading…</p>;
+  if (view.status === "error") return <p>{view.error.message}</p>;
+  return <ThemeProvider>{view.toolOutput.greeting}</ThemeProvider>;
+}
+```
+
+## Review runtime changes
+
+- Use `inputSchema`, not the v1 `schema` alias, in new definitions.
+- Use `ctx.auth` only for identity verified by configured server authentication. Client metadata is self-declared and must not authorize requests.
+- Sampling through a long-lived server session is unsupported. Use elicitation and request-state primitives for multi-round workflows.
+- `MCP_URL` selects the public server origin. `MCP_ASSETS_URL` independently selects the asset prefix and may include a path. `basePath` owns the MCP endpoint path.
+- Legacy clients are served statelessly by default. Set `legacy: "reject"` for a modern-only endpoint.
+
+Run `mcp-use typecheck`, then test tool calls and rendered views through the Inspector before deploying.

--- a/docs/typescript/server/openapi.mdx
+++ b/docs/typescript/server/openapi.mdx
@@ -7,7 +7,10 @@ icon: "file-code"
 `MCPServer.fromOpenAPI()` creates an MCP server from a parsed OpenAPI document. Each included OpenAPI operation is registered as an MCP tool that calls the matching HTTP endpoint.
 
 <Tip>
-We do not recommend mapping a production API directly to MCP without review. LLMs usually perform better with a deliberately crafted MCP server: focused tools, clear names, model-friendly descriptions, and workflows that match the tasks users actually ask for. 
+  We do not recommend mapping a production API directly to MCP without review.
+  LLMs usually perform better with a deliberately crafted MCP server: focused
+  tools, clear names, model-friendly descriptions, and workflows that match the
+  tasks users actually ask for.
 </Tip>
 
 ## Basic Usage
@@ -15,7 +18,7 @@ We do not recommend mapping a production API directly to MCP without review. LLM
 Load or import an OpenAPI document, then pass it to `MCPServer.fromOpenAPI()`:
 
 ```typescript
-import { MCPServer, type OpenAPIDocument } from "mcp-use/server";
+import { MCPServer, type OpenAPIDocument } from "mcp-use";
 
 const response = await fetch("https://api.example.com/openapi.json");
 
@@ -100,7 +103,9 @@ const server = MCPServer.fromOpenAPI({
 ```
 
 <Note>
-The `auth` and `headers` options authenticate requests from your MCP server to the upstream API. They do not add authentication to the MCP server itself. To protect the MCP endpoint, configure server authentication separately.
+  The `auth` and `headers` options authenticate requests from your MCP server to
+  the upstream API. They do not add authentication to the MCP server itself. To
+  protect the MCP endpoint, configure server authentication separately.
 </Note>
 
 ## Request and Response Mapping
@@ -115,7 +120,7 @@ Generated tools flatten OpenAPI parameters into a single input object:
 
 For example, an operation like `GET /users/{userId}/projects?limit=10` becomes a tool with `userId` and `limit` inputs.
 
-JSON responses are returned with the `object()` response helper. Non-JSON responses are returned as text. If the upstream API returns a non-2xx response, the generated tool returns an MCP error response containing the upstream response text.
+JSON responses are returned as raw MCP results with JSON text content and `structuredContent`. Non-JSON responses are returned as text content. If the upstream API returns a non-2xx response, the generated tool returns an MCP error result containing the upstream response text.
 
 ## Naming and Descriptions
 
@@ -145,17 +150,17 @@ type FromOpenAPIOptions = {
 };
 ```
 
-| Option | Description |
-| --- | --- |
-| `spec` | Parsed OpenAPI document. This is required. |
+| Option    | Description                                                            |
+| --------- | ---------------------------------------------------------------------- |
+| `spec`    | Parsed OpenAPI document. This is required.                             |
 | `baseUrl` | Upstream API base URL. Defaults to `spec.servers[0].url` when present. |
-| `name` | MCP server name. Defaults to `spec.info.title`. |
-| `version` | MCP server version. Defaults to `spec.info.version` or `1.0.0`. |
-| `auth` | Bearer token or static header auth for upstream API requests. |
-| `headers` | Static headers sent with every upstream API request. |
-| `tags` | Include only operations with one of these OpenAPI tags. |
-| `exclude` | Exclude operations by operation ID, path, method, or tag. |
-| `fetch` | Custom fetch implementation, useful for tests or custom transports. |
+| `name`    | MCP server name. Defaults to `spec.info.title`.                        |
+| `version` | MCP server version. Defaults to `spec.info.version` or `1.0.0`.        |
+| `auth`    | Bearer token or static header auth for upstream API requests.          |
+| `headers` | Static headers sent with every upstream API request.                   |
+| `tags`    | Include only operations with one of these OpenAPI tags.                |
+| `exclude` | Exclude operations by operation ID, path, method, or tag.              |
+| `fetch`   | Custom fetch implementation, useful for tests or custom transports.    |
 
 ## Limitations
 
@@ -171,15 +176,21 @@ If you run into these limits, use the generated server as a reference and move t
 
 ## Example
 
-<Card title="OpenAPI Server Example" icon="github" href="https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/features/openapi">
-  Complete runnable example that generates MCP tools from the National Weather Service OpenAPI document.
+<Card
+  title="OpenAPI Server Example"
+  icon="github"
+  href="https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/openapi"
+>
+  Complete runnable example that generates MCP tools from the National Weather
+  Service OpenAPI document.
 </Card>
 
 ## Next Steps
 
 <CardGroup cols={2}>
   <Card title="Tools" icon="wrench" href="/typescript/server/tools">
-    Learn how to create hand-crafted MCP tools with Zod schemas and custom handlers.
+    Learn how to create hand-crafted MCP tools with Zod schemas and custom
+    handlers.
   </Card>
   <Card title="Examples" icon="folder-code" href="/typescript/server/examples">
     Browse runnable server examples, including the OpenAPI feature example.

--- a/docs/typescript/server/prompts.mdx
+++ b/docs/typescript/server/prompts.mdx
@@ -12,12 +12,12 @@ This guide focuses on prompt design and common patterns. Use the [Prompts API re
 
 Use prompts when the client needs a structured instruction with optional arguments. Use tools when the server should run code, call an API, or change state.
 
-| Need | Use |
-| --- | --- |
-| Generate a repeatable model instruction | Prompt |
-| Run server-side logic or call an API | Tool |
-| Expose readable content by URI | Resource |
-| Display interactive UI | [Tool with an MCP App widget](/typescript/mcp-apps) |
+| Need                                    | Use                                                 |
+| --------------------------------------- | --------------------------------------------------- |
+| Generate a repeatable model instruction | Prompt                                              |
+| Run server-side logic or call an API    | Tool                                                |
+| Expose readable content by URI          | Resource                                            |
+| Display interactive UI                  | [Tool with an MCP App widget](/typescript/mcp-apps) |
 
 A good prompt has a task-shaped name, a clear description, typed arguments, and output that is ready for the model.
 
@@ -26,7 +26,7 @@ A good prompt has a task-shaped name, a clear description, typed arguments, and 
 Define a prompt with `server.prompt()`. The schema describes arguments the client can collect before requesting the prompt.
 
 ```typescript
-import { MCPServer, text } from "mcp-use/server";
+import { MCPServer, text } from "mcp-use";
 import { z } from "zod";
 
 const server = new MCPServer({
@@ -85,7 +85,7 @@ server.prompt(
 For simple prompts, response helpers keep the callback shorter:
 
 ```typescript
-import { mix, object, text } from "mcp-use/server";
+import { mix, object, text } from "mcp-use";
 
 server.prompt(
   {
@@ -115,7 +115,7 @@ schema: z.object({
   tone: z.enum(["concise", "technical", "executive"]).default("concise"),
   audience: z.string().describe("Who will read the generated content"),
   includeRisks: z.boolean().default(true),
-})
+});
 ```
 
 Avoid using prompt arguments as hidden configuration. If the value affects model behavior, make the field name and description visible.
@@ -125,7 +125,7 @@ Avoid using prompt arguments as hidden configuration. If the value affects model
 Use `completable()` when clients can suggest valid values while the user fills in prompt arguments.
 
 ```typescript
-import { completable } from "mcp-use/server";
+import { completable } from "mcp-use";
 
 server.prompt(
   {
@@ -152,7 +152,7 @@ Use list-based completion for small fixed sets. Use callback-based completion wh
 When OAuth is configured, prompt callbacks can read verified user information from `ctx.auth`.
 
 ```typescript
-import { text } from "mcp-use/server";
+import { text } from "mcp-use";
 
 server.prompt(
   {
@@ -205,16 +205,29 @@ Open `http://localhost:3000/mcp/inspector`, select the Prompts tab, enter argume
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Prompts API reference" icon="terminal" href="/typescript/api-reference/server/prompts">
-    Look up prompt definitions, callback signatures, completion helpers, and return types.
+  <Card
+    title="Prompts API reference"
+    icon="terminal"
+    href="/typescript/api-reference/server/prompts"
+  >
+    Look up prompt definitions, callback signatures, completion helpers, and
+    return types.
   </Card>
-  <Card title="Response Helpers" icon="drill" href="/typescript/server/response-helpers">
+  <Card
+    title="Response Helpers"
+    icon="drill"
+    href="/typescript/server/response-helpers"
+  >
     Choose helpers for text, JSON, Markdown, and mixed prompt content.
   </Card>
   <Card title="Tools" icon="wrench" href="/typescript/server/tools">
     Use tools when the server should run code or call external systems.
   </Card>
-  <Card title="Resources" icon="folder-open" href="/typescript/server/resources">
+  <Card
+    title="Resources"
+    icon="folder-open"
+    href="/typescript/server/resources"
+  >
     Expose readable content by URI.
   </Card>
 </CardGroup>

--- a/docs/typescript/server/resources.mdx
+++ b/docs/typescript/server/resources.mdx
@@ -12,11 +12,11 @@ This guide focuses on when and how to register resources. Use the [Resources API
 
 Use a static resource for one known URI. Use a resource template when the URI contains a variable segment.
 
-| Need | Use |
-| --- | --- |
-| Current app settings, service status, latest report | `server.resource()` |
-| Files by path, users by ID, records by key | `server.resourceTemplate()` |
-| Interactive UI rendered in a client | [MCP Apps](/typescript/mcp-apps) |
+| Need                                                | Use                               |
+| --------------------------------------------------- | --------------------------------- |
+| Current app settings, service status, latest report | `server.resource()`               |
+| Files by path, users by ID, records by key          | `server.resourceTemplate()`       |
+| Interactive UI rendered in a client                 | [MCP Apps](/typescript/mcp-apps)  |
 | An operation that changes state or calls a workflow | [Tools](/typescript/server/tools) |
 
 Resources are best for readable content. If the model should decide to perform work, use a tool instead.
@@ -26,7 +26,7 @@ Resources are best for readable content. If the model should decide to perform w
 Register a static resource when the URI is fixed and the callback can return the current content for that URI.
 
 ```typescript
-import { MCPServer, object } from "mcp-use/server";
+import { MCPServer, object } from "mcp-use";
 
 const server = new MCPServer({
   name: "inventory-server",
@@ -56,7 +56,7 @@ Use stable URI schemes that describe your domain, such as `inventory://`, `docs:
 Register a resource template when clients should read many related resources through one URI pattern.
 
 ```typescript
-import { text } from "mcp-use/server";
+import { text } from "mcp-use";
 
 server.resourceTemplate(
   {
@@ -79,7 +79,7 @@ Template parameters are extracted from the URI and passed to the callback. Keep 
 Use completion callbacks when a client can help users choose valid URI values.
 
 ```typescript
-import { text } from "mcp-use/server";
+import { text } from "mcp-use";
 
 server.resourceTemplate(
   {
@@ -111,7 +111,7 @@ Use list-based completion for small fixed sets. Use callback-based completion wh
 Use response helpers to return resource content. They set the MCP-compatible content shape and MIME metadata for common cases.
 
 ```typescript
-import { image, markdown, mix, object } from "mcp-use/server";
+import { image, markdown, mix, object } from "mcp-use";
 
 server.resource(
   {
@@ -161,13 +161,26 @@ Open `http://localhost:3000/mcp/inspector`, select the Resources tab, read each 
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Resources API reference" icon="terminal" href="/typescript/api-reference/server/resources">
-    Look up resource definitions, callback signatures, template types, and annotations.
+  <Card
+    title="Resources API reference"
+    icon="terminal"
+    href="/typescript/api-reference/server/resources"
+  >
+    Look up resource definitions, callback signatures, template types, and
+    annotations.
   </Card>
-  <Card title="Response Helpers" icon="drill" href="/typescript/server/response-helpers">
+  <Card
+    title="Response Helpers"
+    icon="drill"
+    href="/typescript/server/response-helpers"
+  >
     Choose helpers for text, JSON, Markdown, media, and mixed content.
   </Card>
-  <Card title="Resource Subscriptions" icon="rss" href="/typescript/server/subscriptions">
+  <Card
+    title="Resource Subscriptions"
+    icon="rss"
+    href="/typescript/server/subscriptions"
+  >
     Notify subscribed clients when resource content changes.
   </Card>
   <Card title="Tools" icon="wrench" href="/typescript/server/tools">

--- a/docs/typescript/server/sampling.mdx
+++ b/docs/typescript/server/sampling.mdx
@@ -14,11 +14,11 @@ Sampling is useful when the connected client already has the right model, creden
 
 Good fits:
 
-| Need | Why sampling fits |
-| --- | --- |
-| Summarize text returned by a tool | The client model can transform the result before the tool responds. |
-| Classify or rank user-provided content | The server avoids a separate LLM provider dependency. |
-| Generate a draft that depends on client policy | The client's model and policy stay in control. |
+| Need                                           | Why sampling fits                                                   |
+| ---------------------------------------------- | ------------------------------------------------------------------- |
+| Summarize text returned by a tool              | The client model can transform the result before the tool responds. |
+| Classify or rank user-provided content         | The server avoids a separate LLM provider dependency.               |
+| Generate a draft that depends on client policy | The client's model and policy stay in control.                      |
 
 Do not use sampling for deterministic server logic, authorization decisions, or work that must succeed in clients without sampling support.
 
@@ -27,7 +27,7 @@ Do not use sampling for deterministic server logic, authorization decisions, or 
 Only call `ctx.sample()` when the client advertises the `sampling` capability. Provide a deterministic fallback.
 
 ```typescript
-import { MCPServer, text } from "mcp-use/server";
+import { MCPServer, text } from "mcp-use";
 import { z } from "zod";
 
 const server = new MCPServer({
@@ -45,14 +45,19 @@ server.tool(
   },
   async ({ text: input }, ctx) => {
     if (!ctx.client.can("sampling")) {
-      return text(`Received ${input.length} characters. Sampling is not available.`);
+      return text(
+        `Received ${input.length} characters. Sampling is not available.`,
+      );
     }
 
     const response = await ctx.sample(
       `Classify this text as positive, negative, or neutral. Return one word.\n\n${input}`,
     );
-    const content = Array.isArray(response.content) ? response.content[0] : response.content;
-    const sentiment = content?.type === "text" ? content.text.trim() : "unknown";
+    const content = Array.isArray(response.content)
+      ? response.content[0]
+      : response.content;
+    const sentiment =
+      content?.type === "text" ? content.text.trim() : "unknown";
 
     return text(`Sentiment: ${sentiment}`);
   },
@@ -125,8 +130,12 @@ Sampling can fail when the client rejects the request, disconnects, times out, o
 
 ```typescript
 try {
-  const response = await ctx.sample("Summarize this text in one sentence:\n\n" + input);
-  const content = Array.isArray(response.content) ? response.content[0] : response.content;
+  const response = await ctx.sample(
+    "Summarize this text in one sentence:\n\n" + input,
+  );
+  const content = Array.isArray(response.content)
+    ? response.content[0]
+    : response.content;
 
   if (content?.type !== "text") {
     return text("The client returned a non-text sampling result.");
@@ -134,7 +143,9 @@ try {
 
   return text(content.text);
 } catch (err) {
-  return text(`Sampling was unavailable: ${err instanceof Error ? err.message : String(err)}`);
+  return text(
+    `Sampling was unavailable: ${err instanceof Error ? err.message : String(err)}`,
+  );
 }
 ```
 
@@ -155,16 +166,29 @@ In the Inspector, call the sampling tool, approve the sampling request, and veri
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Tool context API reference" icon="terminal" href="/typescript/api-reference/server/tool-context#sample">
-    Look up `ctx.sample()` overloads, options, progress behavior, and return shapes.
+  <Card
+    title="Tool context API reference"
+    icon="terminal"
+    href="/typescript/api-reference/server/tool-context#sample"
+  >
+    Look up `ctx.sample()` overloads, options, progress behavior, and return
+    shapes.
   </Card>
   <Card title="Elicitation" icon="check" href="/typescript/server/elicitation">
     Ask the user for input during tool execution.
   </Card>
-  <Card title="Notifications" icon="bell" href="/typescript/server/notifications">
+  <Card
+    title="Notifications"
+    icon="bell"
+    href="/typescript/server/notifications"
+  >
     Send status, progress, and custom notifications to connected clients.
   </Card>
-  <Card title="Client sampling" icon="monitor" href="/typescript/client/sampling">
+  <Card
+    title="Client sampling"
+    icon="monitor"
+    href="/typescript/client/sampling"
+  >
     Configure sampling support in a TypeScript MCP client.
   </Card>
 </CardGroup>

--- a/docs/typescript/server/subscriptions.mdx
+++ b/docs/typescript/server/subscriptions.mdx
@@ -12,12 +12,12 @@ This guide focuses on the server workflow. Use the [MCPServer API reference](/ty
 
 Subscriptions are for resource content changes, not general status events.
 
-| Need | Use |
-| --- | --- |
-| Tell clients a known resource URI changed | Resource subscription |
-| Broadcast a job status event | [Notifications](/typescript/server/notifications) |
-| Tell clients the resource list changed | `server.sendResourcesListChanged()` |
-| Return fresh data immediately | A tool or resource read |
+| Need                                      | Use                                               |
+| ----------------------------------------- | ------------------------------------------------- |
+| Tell clients a known resource URI changed | Resource subscription                             |
+| Broadcast a job status event              | [Notifications](/typescript/server/notifications) |
+| Tell clients the resource list changed    | `server.sendResourcesListChanged()`               |
+| Return fresh data immediately             | A tool or resource read                           |
 
 Clients subscribe to a resource URI. Your server notifies subscribers after that resource changes. Clients then read the resource again.
 
@@ -26,7 +26,7 @@ Clients subscribe to a resource URI. Your server notifies subscribers after that
 Start with a resource that returns the current content for a stable URI.
 
 ```typescript
-import { MCPServer, object, text } from "mcp-use/server";
+import { MCPServer, object, text } from "mcp-use";
 import { z } from "zod";
 
 const server = new MCPServer({
@@ -61,7 +61,7 @@ server.tool(
   {
     name: "update_settings",
     description: "Update application settings.",
-    schema: z.object({
+    inputSchema: z.object({
       theme: z.enum(["light", "dark"]).optional(),
       language: z.string().optional(),
     }),
@@ -133,16 +133,32 @@ Verify these cases:
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Resources" icon="folder-open" href="/typescript/server/resources">
+  <Card
+    title="Resources"
+    icon="folder-open"
+    href="/typescript/server/resources"
+  >
     Create static resources and resource templates.
   </Card>
-  <Card title="Notifications" icon="bell" href="/typescript/server/notifications">
+  <Card
+    title="Notifications"
+    icon="bell"
+    href="/typescript/server/notifications"
+  >
     Send custom status, progress, and list-changed notifications.
   </Card>
-  <Card title="MCPServer API reference" icon="server" href="/typescript/api-reference/server/mcp-server">
+  <Card
+    title="MCPServer API reference"
+    icon="server"
+    href="/typescript/api-reference/server/mcp-server"
+  >
     Look up `notifyResourceUpdated()` and resource notification methods.
   </Card>
-  <Card title="MCP resources specification" icon="book-open" href="https://modelcontextprotocol.io/specification/2025-11-25/server/resources#subscriptions">
+  <Card
+    title="MCP resources specification"
+    icon="book-open"
+    href="https://modelcontextprotocol.io/specification/2025-11-25/server/resources#subscriptions"
+  >
     Read the protocol-level subscription behavior.
   </Card>
 </CardGroup>

--- a/libraries/typescript/.changeset/final-v2-release-guards.md
+++ b/libraries/typescript/.changeset/final-v2-release-guards.md
@@ -1,0 +1,11 @@
+---
+"mcp-use": patch
+"@mcp-use/agent": patch
+"@mcp-use/inspector": patch
+---
+
+Harden the v2 beta release train and package boundaries before GA.
+
+- Reject prerelease plans that would reuse or lag an npm beta version, and keep Inspector versioned with the exact `mcp-use` beta it supports.
+- Use the modern Langfuse LangChain adapter so the Agent's optional LangChain and observability peers resolve together.
+- Keep Inspector framework peers optional for standalone installs and refresh public v2 server and MCP Apps documentation.

--- a/libraries/typescript/README.md
+++ b/libraries/typescript/README.md
@@ -46,16 +46,15 @@ mcp-use for TypeScript provides the complete MCP stack:
 - **[Main Repository](../../README.md)** - Overview of the entire mcp-use ecosystem
 - **[Python Version](../python/README.md)** - Python implementation for agents and clients
 - **[Inspector Documentation](./packages/inspector/README.md)** - Debug your MCP servers
-- **[CLI Documentation](./packages/cli/README.md)** - Build tool for MCP apps
+- **[Server and CLI Documentation](https://mcp-use.com/docs/typescript/server)** - Build and run MCP apps
 
 ## 📦 Packages Overview
 
-| Package                                       | Description                                   | Version                                                                                                         | Downloads                                                                                                        |
-| --------------------------------------------- | --------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| **[mcp-use](#mcp-use-core-framework)**        | Core framework for MCP clients and servers    | [![npm](https://img.shields.io/npm/v/mcp-use.svg)](https://www.npmjs.com/package/mcp-use)                       | [![npm](https://img.shields.io/npm/dw/mcp-use.svg)](https://www.npmjs.com/package/mcp-use)                       |
-| **[@mcp-use/cli](#mcp-use-cli)**              | Build tool with hot reload and auto-inspector | [![npm](https://img.shields.io/npm/v/@mcp-use/cli.svg)](https://www.npmjs.com/package/@mcp-use/cli)             | [![npm](https://img.shields.io/npm/dw/@mcp-use/cli.svg)](https://www.npmjs.com/package/@mcp-use/cli)             |
-| **[@mcp-use/inspector](#mcp-use-inspector)**  | Web-based debugger for MCP servers            | [![npm](https://img.shields.io/npm/v/@mcp-use/inspector.svg)](https://www.npmjs.com/package/@mcp-use/inspector) | [![npm](https://img.shields.io/npm/dw/@mcp-use/inspector.svg)](https://www.npmjs.com/package/@mcp-use/inspector) |
-| **[create-mcp-use-app](#create-mcp-use-app)** | Project scaffolding tool                      | [![npm](https://img.shields.io/npm/v/create-mcp-use-app.svg)](https://www.npmjs.com/package/create-mcp-use-app) | [![npm](https://img.shields.io/npm/dw/create-mcp-use-app.svg)](https://www.npmjs.com/package/create-mcp-use-app) |
+| Package                                       | Description                                | Version                                                                                                         | Downloads                                                                                                        |
+| --------------------------------------------- | ------------------------------------------ | --------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| **[mcp-use](#mcp-use-core-framework)**        | Core framework for MCP clients and servers | [![npm](https://img.shields.io/npm/v/mcp-use.svg)](https://www.npmjs.com/package/mcp-use)                       | [![npm](https://img.shields.io/npm/dw/mcp-use.svg)](https://www.npmjs.com/package/mcp-use)                       |
+| **[@mcp-use/inspector](#mcp-use-inspector)**  | Web-based debugger for MCP servers         | [![npm](https://img.shields.io/npm/v/@mcp-use/inspector.svg)](https://www.npmjs.com/package/@mcp-use/inspector) | [![npm](https://img.shields.io/npm/dw/@mcp-use/inspector.svg)](https://www.npmjs.com/package/@mcp-use/inspector) |
+| **[create-mcp-use-app](#create-mcp-use-app)** | Project scaffolding tool                   | [![npm](https://img.shields.io/npm/v/create-mcp-use-app.svg)](https://www.npmjs.com/package/create-mcp-use-app) | [![npm](https://img.shields.io/npm/dw/create-mcp-use-app.svg)](https://www.npmjs.com/package/create-mcp-use-app) |
 
 ---
 
@@ -321,7 +320,7 @@ export default function AnalyticsDashboard() {
 
 ---
 
-### @mcp-use/cli
+### mcp-use CLI
 
 Powerful build and development tool for MCP applications with integrated inspector.
 
@@ -627,7 +626,6 @@ git commit -m "feat: your feature description"
 ```bash
 # Install canary versions
 npm install mcp-use@canary
-npm install @mcp-use/cli@canary
 ```
 
 ---

--- a/libraries/typescript/packages/agent/package.json
+++ b/libraries/typescript/packages/agent/package.json
@@ -66,9 +66,9 @@
     "@langchain/anthropic": "^1.3.0",
     "@langchain/core": "^1.1.0",
     "@langchain/openai": "^1.2.0",
+    "@langfuse/langchain": "~5.9.0",
     "langchain": "^1.2.10",
     "langfuse": "^3.38.6",
-    "langfuse-langchain": "^3.38.6",
     "zod": "^4.0.0"
   },
   "peerDependenciesMeta": {
@@ -81,13 +81,13 @@
     "@langchain/openai": {
       "optional": true
     },
+    "@langfuse/langchain": {
+      "optional": true
+    },
     "langchain": {
       "optional": true
     },
     "langfuse": {
-      "optional": true
-    },
-    "langfuse-langchain": {
       "optional": true
     },
     "zod": {

--- a/libraries/typescript/packages/agent/src/observability/langfuse.ts
+++ b/libraries/typescript/packages/agent/src/observability/langfuse.ts
@@ -56,10 +56,12 @@ async function initializeLangfuse(
 ): Promise<void> {
   try {
     // Dynamically import to avoid errors if package not installed
-    const langfuseModule = await import("langfuse-langchain").catch(() => null);
+    const langfuseModule = await import("@langfuse/langchain").catch(
+      () => null
+    );
     if (!langfuseModule) {
       logger.debug(
-        "Langfuse package not installed - tracing disabled. Install with: npm install langfuse-langchain"
+        "Langfuse package not installed - tracing disabled. Install with: npm install @langfuse/langchain"
       );
       return;
     }

--- a/libraries/typescript/packages/agent/src/observability/types.d.ts
+++ b/libraries/typescript/packages/agent/src/observability/types.d.ts
@@ -3,7 +3,7 @@
  * These modules may not be installed, so we provide minimal type definitions.
  */
 
-declare module "langfuse-langchain" {
+declare module "@langfuse/langchain" {
   export class CallbackHandler {
     constructor(config?: any);
     verbose?: boolean;

--- a/libraries/typescript/packages/agent/tests/package_contract.test.ts
+++ b/libraries/typescript/packages/agent/tests/package_contract.test.ts
@@ -1,0 +1,18 @@
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, it } from "vitest";
+
+describe("optional peer dependency contract", () => {
+  it("uses the modern Langfuse adapter compatible with LangChain 1.x", async () => {
+    const manifest = JSON.parse(
+      await readFile(new URL("../package.json", import.meta.url), "utf8")
+    );
+
+    expect(manifest.peerDependencies["@langfuse/langchain"]).toBe("~5.9.0");
+    expect(manifest.peerDependenciesMeta["@langfuse/langchain"]?.optional).toBe(
+      true
+    );
+    expect(manifest.peerDependencies["langfuse-langchain"]).toBeUndefined();
+    expect(manifest.peerDependenciesMeta["langfuse-langchain"]).toBeUndefined();
+  });
+});

--- a/libraries/typescript/packages/client/README.md
+++ b/libraries/typescript/packages/client/README.md
@@ -92,34 +92,33 @@ See [React integration](https://mcp-use.com/docs/typescript/client/usemcp).
 
 ## Features
 
-| Feature | Description |
-| --- | --- |
-| **HTTP + stdio** | Streamable HTTP everywhere; stdio on Node |
-| **Protocol negotiation** | Automatic legacy / modern MCP handling |
-| **OAuth** | Browser and Node providers, callback helpers |
-| **React** | `useMcp`, `McpClientProvider`, storage adapters |
-| **Code mode** | Optional sandboxed tool execution (VM / E2B) |
-| **Callbacks** | Sampling, elicitation, notifications |
+| Feature                  | Description                                     |
+| ------------------------ | ----------------------------------------------- |
+| **HTTP + stdio**         | Streamable HTTP everywhere; stdio on Node       |
+| **Protocol negotiation** | Automatic legacy / modern MCP handling          |
+| **OAuth**                | Browser and Node providers, callback helpers    |
+| **React**                | `useMcp`, `McpClientProvider`, storage adapters |
+| **Code mode**            | Optional sandboxed tool execution (VM / E2B)    |
+| **Callbacks**            | Sampling, elicitation, notifications            |
 
 ---
 
 ## Package entry points
 
-| Import | Environment |
-| --- | --- |
-| `@mcp-use/client` | Node (HTTP + stdio, code mode, file config) |
-| `@mcp-use/client` (browser bundlers) | Browser / workers (HTTP only) |
-| `@mcp-use/client/react` | React hooks and provider |
+| Import                               | Environment                                 |
+| ------------------------------------ | ------------------------------------------- |
+| `@mcp-use/client`                    | Node (HTTP + stdio, code mode, file config) |
+| `@mcp-use/client` (browser bundlers) | Browser / workers (HTTP only)               |
+| `@mcp-use/client/react`              | React hooks and provider                    |
 
 ---
 
 ## Related packages
 
-| Package | Description |
-| --- | --- |
-| [mcp-use](https://www.npmjs.com/package/mcp-use) | Full framework (server + agent + client re-exports) |
-| [@mcp-use/inspector](https://www.npmjs.com/package/@mcp-use/inspector) | Web-based MCP debugger |
-| [@mcp-use/cli](https://www.npmjs.com/package/@mcp-use/cli) | Dev server and widget build tool |
+| Package                                                                | Description              |
+| ---------------------------------------------------------------------- | ------------------------ |
+| [mcp-use](https://www.npmjs.com/package/mcp-use)                       | Server framework and CLI |
+| [@mcp-use/inspector](https://www.npmjs.com/package/@mcp-use/inspector) | Web-based MCP debugger   |
 
 ---
 

--- a/libraries/typescript/packages/create-mcp-use-app/README.md
+++ b/libraries/typescript/packages/create-mcp-use-app/README.md
@@ -27,8 +27,7 @@
 
 | Package                                                                                                    | Description             | Version                                                                                                         |
 | ---------------------------------------------------------------------------------------------------------- | ----------------------- | --------------------------------------------------------------------------------------------------------------- |
-| [mcp-use](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use)              | Core MCP framework      | [![npm](https://img.shields.io/npm/v/mcp-use.svg)](https://www.npmjs.com/package/mcp-use)                       |
-| [@mcp-use/cli](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/cli)             | Build tool for MCP apps | [![npm](https://img.shields.io/npm/v/@mcp-use/cli.svg)](https://www.npmjs.com/package/@mcp-use/cli)             |
+| [mcp-use](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server)               | MCP framework and CLI   | [![npm](https://img.shields.io/npm/v/mcp-use.svg)](https://www.npmjs.com/package/mcp-use)                       |
 | [@mcp-use/inspector](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/inspector) | Web-based MCP inspector | [![npm](https://img.shields.io/npm/v/@mcp-use/inspector.svg)](https://www.npmjs.com/package/@mcp-use/inspector) |
 
 ---
@@ -66,16 +65,16 @@ my-mcp-server/
 
 ### Pre-configured Features
 
-| Feature                 | Description                                       |
-| ----------------------- | ------------------------------------------------- |
-| **📝 TypeScript**       | Full TypeScript setup with proper types           |
-| **🔥 Hot Reload**       | Auto-restart on code changes during development   |
-| **🔍 Auto Inspector**   | Inspector UI opens automatically in dev mode      |
-| **🎨 MCP Apps Views**   | React views discovered and bundled by the CLI      |
-| **🛠️ Example Tools**    | Sample MCP tools, resources, and prompts          |
-| **📦 Build Scripts**    | Ready-to-use development and production scripts   |
+| Feature                 | Description                                          |
+| ----------------------- | ---------------------------------------------------- |
+| **📝 TypeScript**       | Full TypeScript setup with proper types              |
+| **🔥 Hot Reload**       | Auto-restart on code changes during development      |
+| **🔍 Auto Inspector**   | Inspector UI opens automatically in dev mode         |
+| **🎨 MCP Apps Views**   | React views discovered and bundled by the CLI        |
+| **🛠️ Example Tools**    | Sample MCP tools, resources, and prompts             |
+| **📦 Build Scripts**    | Ready-to-use development and production scripts      |
 | **✅ Type Checking**    | Refreshes MCP view types, then runs local TypeScript |
-| **🚀 Production Ready** | Optimized build configuration                     |
+| **🚀 Production Ready** | Optimized build configuration                        |
 
 ---
 
@@ -507,8 +506,8 @@ See our [contributing guide](https://github.com/mcp-use/mcp-use/blob/main/CONTRI
 
 - [mcp-use Documentation](https://github.com/mcp-use/mcp-use)
 - [Model Context Protocol Spec](https://modelcontextprotocol.io)
-- [Creating MCP Tools](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use#-mcp-server-framework)
-- [Building UI Widgets](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/cli#-creating-ui-widgets)
+- [Creating MCP Tools](https://mcp-use.com/docs/typescript/server/tools)
+- [Building MCP App Views](https://mcp-use.com/docs/typescript/mcp-apps)
 - [Using the Inspector](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/inspector)
 - [Supabase Edge Functions](https://supabase.com/docs/guides/functions)
 

--- a/libraries/typescript/packages/inspector/package.json
+++ b/libraries/typescript/packages/inspector/package.json
@@ -122,6 +122,9 @@
     "markdown-to-jsx": {
       "optional": true
     },
+    "mcp-use": {
+      "optional": true
+    },
     "motion": {
       "optional": true
     },

--- a/libraries/typescript/packages/inspector/scripts/verify-package.mjs
+++ b/libraries/typescript/packages/inspector/scripts/verify-package.mjs
@@ -6,6 +6,19 @@ const root = new URL("../", import.meta.url).pathname;
 const dist = join(root, "dist");
 const files = walk(dist);
 const manifest = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
+if (Object.keys(manifest.dependencies ?? {}).length !== 0) {
+  throw new Error(
+    "Inspector package must not install framework runtime dependencies"
+  );
+}
+for (const peer of ["mcp-use", "@mcp-use/client", "@mcp-use/agent"]) {
+  if (manifest.peerDependencies?.[peer] === undefined) {
+    throw new Error(`Missing framework peer declaration: ${peer}`);
+  }
+  if (manifest.peerDependenciesMeta?.[peer]?.optional !== true) {
+    throw new Error(`Framework peer must be optional: ${peer}`);
+  }
+}
 for (const file of files) {
   if (
     file.startsWith("dist/web/") ||

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -146,6 +146,9 @@ importers:
       '@langchain/core':
         specifier: ^1.1.8
         version: 1.1.18(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(openai@6.17.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
+      '@langfuse/langchain':
+        specifier: ~5.9.0
+        version: 5.9.1(@langchain/core@1.1.18(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(openai@6.17.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(@opentelemetry/api@1.9.1)
       '@mcp-use/client':
         specifier: workspace:*
         version: link:../client
@@ -158,9 +161,6 @@ importers:
       langfuse:
         specifier: ^3.38.6
         version: 3.38.6
-      langfuse-langchain:
-        specifier: ^3.38.6
-        version: 3.38.6(langchain@1.2.16(@langchain/core@1.1.18(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(openai@6.17.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(openai@6.17.0(ws@8.21.0)(zod@4.4.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(ws@8.21.0)(zod-to-json-schema@3.25.1(zod@4.4.3)))
     devDependencies:
       '@langchain/anthropic':
         specifier: ^1.0.0
@@ -2268,6 +2268,23 @@ packages:
     engines: {node: '>=20'}
     peerDependencies:
       '@langchain/core': ^1.1.8
+
+  '@langfuse/core@5.9.1':
+    resolution: {integrity: sha512-KvyAskAO+2ixJwr9wy148ttR/Zn3oapvOJ2Br4Xcp6zhDpjSIIGB4jW/jkp53/KU9MyEHj0RSFPK/yKoxLC4KA==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+
+  '@langfuse/langchain@5.9.1':
+    resolution: {integrity: sha512-Qv5Wn8EO2cRiVTBlb/zQwRhjD+93rVjD02in9L0+hyg9OBvc2rzqTfr8zKVDv9pgpsDfWD7Wm/sXyo7vGZmsTA==}
+    peerDependencies:
+      '@langchain/core': ^1.1.8
+      '@opentelemetry/api': ^1.9.0
+
+  '@langfuse/tracing@5.9.1':
+    resolution: {integrity: sha512-tJRyVAv1JkuOPh4Uz5eWUNH8U4jcJVtK2F5QNy5cZUzXCSrXobCSHusPbxY6VFZcLcFgtpDtSaxL7ev1tV2JNQ==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -6056,12 +6073,6 @@ packages:
     resolution: {integrity: sha512-EcZXa+DK9FJdi1I30+u19eKjuBJ04du6j2Nybk19KKCuraLczg/ppkTQcGvc4QOk//OAi3qUHrajUuV74RXsBQ==}
     engines: {node: '>=18'}
 
-  langfuse-langchain@3.38.6:
-    resolution: {integrity: sha512-XY7M1R/G7bzihm1cCT1CXKlTLfjHfTiWCPOVm/Ko039Cr3Nz945+HOynqUngjhQUdqH0gAwDsFUZookosARJSw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      langchain: ^1.2.3
-
   langfuse@3.38.6:
     resolution: {integrity: sha512-mtwfsNGIYvObRh+NYNGlJQJDiBN+Wr3Hnr++wN25mxuOpSTdXX+JQqVCyAqGL5GD2TAXRZ7COsN42Vmp9krYmg==}
     engines: {node: '>=18'}
@@ -8872,6 +8883,22 @@ snapshots:
       zod: 4.4.3
     transitivePeerDependencies:
       - ws
+
+  '@langfuse/core@5.9.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@langfuse/langchain@5.9.1(@langchain/core@1.1.18(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(openai@6.17.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@langchain/core': 1.1.18(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(openai@6.17.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
+      '@langfuse/core': 5.9.1(@opentelemetry/api@1.9.1)
+      '@langfuse/tracing': 5.9.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/api': 1.9.1
+
+  '@langfuse/tracing@5.9.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@langfuse/core': 5.9.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/api': 1.9.1
 
   '@manypkg/find-root@1.1.0':
     dependencies:
@@ -12505,12 +12532,6 @@ snapshots:
   langfuse-core@3.38.6:
     dependencies:
       mustache: 4.2.0
-
-  langfuse-langchain@3.38.6(langchain@1.2.16(@langchain/core@1.1.18(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(openai@6.17.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(openai@6.17.0(ws@8.21.0)(zod@4.4.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(ws@8.21.0)(zod-to-json-schema@3.25.1(zod@4.4.3))):
-    dependencies:
-      langchain: 1.2.16(@langchain/core@1.1.18(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(openai@6.17.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(openai@6.17.0(ws@8.21.0)(zod@4.4.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(ws@8.21.0)(zod-to-json-schema@3.25.1(zod@4.4.3))
-      langfuse: 3.38.6
-      langfuse-core: 3.38.6
 
   langfuse@3.38.6:
     dependencies:

--- a/libraries/typescript/scripts/beta-version-guard.mjs
+++ b/libraries/typescript/scripts/beta-version-guard.mjs
@@ -1,0 +1,81 @@
+import { readFileSync } from "node:fs";
+
+import semver from "semver";
+
+function fail(message) {
+  throw new Error(`[beta-release] ${message}`);
+}
+
+/**
+ * Rejects a prerelease plan that cannot produce a new npm beta version.
+ *
+ * This check runs before Changesets mutates manifests or marks changesets as
+ * applied. A published source manifest is a valid starting point, but every
+ * planned version must still be a new version beyond the registry's beta tag.
+ */
+export function validateBetaVersionPlan({ manifests, metadata, releases }) {
+  for (const release of releases) {
+    const manifest = manifests.get(release.name);
+    if (!manifest) fail(`Changesets planned unknown package ${release.name}`);
+
+    const current = semver.parse(manifest.version);
+    const planned = semver.parse(release.newVersion);
+    if (
+      !planned ||
+      planned.prerelease[0] !== "beta" ||
+      !Number.isInteger(planned.prerelease[1])
+    ) {
+      fail(
+        `${release.name} planned ${release.newVersion}, which is not an x.y.z-beta.N version`
+      );
+    }
+
+    if (
+      current?.prerelease[0] === "beta" &&
+      !semver.gt(release.newVersion, manifest.version)
+    ) {
+      fail(
+        `${release.name} planned ${release.newVersion} from ${manifest.version}; a pending changeset must advance the source beta version`
+      );
+    }
+
+    const registry = metadata.get(release.name);
+    if (registry?.versions?.[release.newVersion]) {
+      fail(
+        `${release.name}@${release.newVersion} is already published; refusing to consume pending changesets without a new version`
+      );
+    }
+
+    const betaTag = registry?.["dist-tags"]?.beta;
+    if (betaTag && !semver.gt(release.newVersion, betaTag)) {
+      fail(
+        `${release.name}@${release.newVersion} would not advance the current beta tag ${betaTag}`
+      );
+    }
+  }
+}
+
+export async function fetchRegistryMetadata(names) {
+  if (process.env.BETA_RELEASE_REGISTRY_METADATA_PATH) {
+    const fixture = JSON.parse(
+      readFileSync(process.env.BETA_RELEASE_REGISTRY_METADATA_PATH, "utf8")
+    );
+    return new Map(names.map((name) => [name, fixture[name]]));
+  }
+
+  const metadata = new Map();
+  for (const name of names) {
+    const response = await fetch(
+      `https://registry.npmjs.org/${encodeURIComponent(name)}`,
+      { headers: { accept: "application/vnd.npm.install-v1+json" } }
+    );
+    if (response.status === 404) {
+      metadata.set(name, undefined);
+      continue;
+    }
+    if (!response.ok)
+      fail(`npm registry returned ${response.status} for ${name}`);
+    metadata.set(name, await response.json());
+  }
+  return metadata;
+}

--- a/libraries/typescript/scripts/version-packages.mjs
+++ b/libraries/typescript/scripts/version-packages.mjs
@@ -11,6 +11,11 @@ import { join } from "node:path";
 
 import semver from "semver";
 
+import {
+  fetchRegistryMetadata,
+  validateBetaVersionPlan,
+} from "./beta-version-guard.mjs";
+
 const workspaceRoot = process.cwd();
 const changesetDirectory = join(workspaceRoot, ".changeset");
 const packageDirectory = join(workspaceRoot, "packages");
@@ -73,6 +78,41 @@ function normalizedWorkspaceRange(range, dependencyVersion) {
   return workspaceRange;
 }
 
+function addInspectorSyncChangeset(plan) {
+  const frameworkRelease = plan.releases.find(
+    (release) => release.name === "mcp-use"
+  );
+  const inspectorRelease = plan.releases.some(
+    (release) => release.name === "@mcp-use/inspector"
+  );
+  if (!frameworkRelease || inspectorRelease) return false;
+
+  const inspector = readJson(
+    join(packageDirectory, "inspector", "package.json")
+  );
+  const current = semver.parse(inspector.version);
+  if (!current)
+    throw new Error(`invalid Inspector version ${inspector.version}`);
+  const newVersion =
+    current.prerelease[0] === "beta" && Number.isInteger(current.prerelease[1])
+      ? `${current.major}.${current.minor}.${current.patch}-beta.${current.prerelease[1] + 1}`
+      : `${semver.inc(inspector.version, "patch")}-beta.0`;
+
+  const id = `inspector-sync-${frameworkRelease.newVersion.replaceAll(".", "-")}`;
+  writeFileSync(
+    join(changesetDirectory, `${id}.md`),
+    `---\n"@mcp-use/inspector": patch\n---\n\nKeep Inspector synchronized with mcp-use ${frameworkRelease.newVersion}.\n`
+  );
+  plan.releases.push({
+    name: "@mcp-use/inspector",
+    type: "patch",
+    oldVersion: inspector.version,
+    changesets: [id],
+    newVersion,
+  });
+  return true;
+}
+
 function updateInternalPeerRanges(releases, mode) {
   const manifests = packageManifests();
   const packages = new Map(
@@ -95,18 +135,30 @@ function updateInternalPeerRanges(releases, mode) {
       const release = releases.get(dependency);
 
       if (mode === "pre" && release && semver.prerelease(release.newVersion)) {
-        const parsed = semver.parse(release.newVersion);
-        const stableTarget = `${parsed.major}.${parsed.minor}.${parsed.patch}`;
-        const comparableRange = normalizedWorkspaceRange(
-          baseRange,
-          internalDependency.manifest.version
-        );
+        // workspace:* is packed as an exact internal version. After the first
+        // beta bump, keep advancing that exact prerelease instead of stripping
+        // it as though it were a temporary compatibility suffix.
         if (
-          semver.satisfies(stableTarget, comparableRange) &&
-          !semver.satisfies(release.newVersion, comparableRange)
+          currentRange.startsWith("workspace:") ||
+          (baseRange === "" && semver.prerelease(currentRange) !== null)
         ) {
-          desiredRange = `${baseRange} || ${release.newVersion}`;
+          desiredRange = release.newVersion;
+        } else {
+          const parsed = semver.parse(release.newVersion);
+          const stableTarget = `${parsed.major}.${parsed.minor}.${parsed.patch}`;
+          const comparableRange = normalizedWorkspaceRange(
+            baseRange,
+            internalDependency.manifest.version
+          );
+          if (
+            semver.satisfies(stableTarget, comparableRange) &&
+            !semver.satisfies(release.newVersion, comparableRange)
+          ) {
+            desiredRange = `${baseRange} || ${release.newVersion}`;
+          }
         }
+      } else if (mode === "exit" && baseRange === "") {
+        desiredRange = "workspace:*";
       }
 
       if (desiredRange !== currentRange) {
@@ -136,6 +188,27 @@ if (preState?.mode === "pre") {
   }
   try {
     const plan = readJson(planFile);
+    const manifests = new Map(
+      packageManifests().map((file) => {
+        const manifest = readJson(file);
+        return [manifest.name, manifest];
+      })
+    );
+    const metadata = await fetchRegistryMetadata(
+      plan.releases.map((release) => release.name)
+    );
+    validateBetaVersionPlan({ manifests, metadata, releases: plan.releases });
+    if (addInspectorSyncChangeset(plan)) {
+      const inspectorRelease = plan.releases.at(-1);
+      const inspectorMetadata = await fetchRegistryMetadata([
+        inspectorRelease.name,
+      ]);
+      validateBetaVersionPlan({
+        manifests,
+        metadata: inspectorMetadata,
+        releases: [inspectorRelease],
+      });
+    }
     updateInternalPeerRanges(
       new Map(plan.releases.map((release) => [release.name, release])),
       "pre"

--- a/libraries/typescript/tests/release-versioning.test.mjs
+++ b/libraries/typescript/tests/release-versioning.test.mjs
@@ -13,6 +13,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 
+import { validateBetaVersionPlan } from "../scripts/beta-version-guard.mjs";
+
 const workspaceRoot = new URL("../", import.meta.url).pathname;
 const versionScript = new URL(
   "../scripts/version-packages.mjs",
@@ -36,7 +38,18 @@ const initialVersions = {
   "create-mcp-use-app": "1.0.0",
 };
 
-function setup(type, clientVersion) {
+function emptyRegistryFixture(directory) {
+  const file = join(directory, "registry-metadata.json");
+  writeFileSync(file, "{}\n");
+  return file;
+}
+
+function setup(
+  type,
+  version,
+  packageName = "@mcp-use/client",
+  releases = [{ name: packageName, newVersion: version }]
+) {
   const directory = mkdtempSync(join(tmpdir(), "mcp-use-version-test-"));
   cpSync(workspaceRoot, directory, {
     recursive: true,
@@ -62,20 +75,19 @@ function setup(type, clientVersion) {
   }
   writeFileSync(
     join(directory, ".changeset", "synthetic-client.md"),
-    `---\n"@mcp-use/client": ${type}\n---\n\nSynthetic Client ${type}.\n`
+    `---\n"${packageName}": ${type}\n---\n\nSynthetic ${packageName} ${type}.\n`
   );
   execFileSync(changesetBin, ["pre", "enter", "beta"], {
     cwd: directory,
     stdio: "ignore",
   });
   const planFile = join(directory, "synthetic-plan.json");
-  writeFileSync(
+  writeFileSync(planFile, JSON.stringify({ releases }));
+  return {
+    directory,
     planFile,
-    JSON.stringify({
-      releases: [{ name: "@mcp-use/client", newVersion: clientVersion }],
-    })
-  );
-  return { directory, planFile };
+    registryFile: emptyRegistryFixture(directory),
+  };
 }
 
 function manifest(directory, packageDirectory) {
@@ -86,6 +98,105 @@ function manifest(directory, packageDirectory) {
     )
   );
 }
+
+test("accepts an unpublished plan that advances the published source beta", () => {
+  assert.doesNotThrow(() =>
+    validateBetaVersionPlan({
+      manifests: new Map([["mcp-use", { version: "2.0.0-beta.67" }]]),
+      metadata: new Map([
+        [
+          "mcp-use",
+          {
+            "dist-tags": { beta: "2.0.0-beta.67" },
+            versions: { "2.0.0-beta.67": {} },
+          },
+        ],
+      ]),
+      releases: [{ name: "mcp-use", newVersion: "2.0.0-beta.68" }],
+    })
+  );
+});
+
+test("rejects a pending changeset that plans an already-published beta", () => {
+  assert.throws(
+    () =>
+      validateBetaVersionPlan({
+        manifests: new Map([["mcp-use", { version: "2.0.0-beta.67" }]]),
+        metadata: new Map([
+          [
+            "mcp-use",
+            {
+              "dist-tags": { beta: "2.0.0-beta.67" },
+              versions: { "2.0.0-beta.67": {} },
+            },
+          ],
+        ]),
+        releases: [{ name: "mcp-use", newVersion: "2.0.0-beta.67" }],
+      }),
+    /pending changeset must advance the source beta version/
+  );
+});
+
+test("rejects a stale plan behind the registry beta tag", () => {
+  assert.throws(
+    () =>
+      validateBetaVersionPlan({
+        manifests: new Map([["mcp-use", { version: "2.0.0-beta.67" }]]),
+        metadata: new Map([
+          [
+            "mcp-use",
+            {
+              "dist-tags": { beta: "2.0.0-beta.69" },
+              versions: { "2.0.0-beta.69": {} },
+            },
+          ],
+        ]),
+        releases: [{ name: "mcp-use", newVersion: "2.0.0-beta.68" }],
+      }),
+    /would not advance the current beta tag 2\.0\.0-beta\.69/
+  );
+});
+
+test("stops before Changesets consumes a colliding planned version", () => {
+  const { directory, planFile, registryFile } = setup("patch", "2.0.1-beta.0");
+  try {
+    writeFileSync(
+      registryFile,
+      `${JSON.stringify({
+        "@mcp-use/client": {
+          "dist-tags": { beta: "2.0.1-beta.0" },
+          versions: { "2.0.1-beta.0": {} },
+        },
+      })}\n`
+    );
+
+    assert.throws(
+      () =>
+        execFileSync(process.execPath, [versionScript], {
+          cwd: directory,
+          env: {
+            ...process.env,
+            BETA_RELEASE_REGISTRY_METADATA_PATH: registryFile,
+            CHANGESETS_RELEASE_PLAN_PATH: planFile,
+          },
+          stdio: "pipe",
+        }),
+      (error) =>
+        error.stderr.includes(
+          "@mcp-use/client@2.0.1-beta.0 is already published"
+        )
+    );
+    assert.equal(manifest(directory, "client").version, "2.0.0");
+    assert.equal(
+      JSON.parse(
+        readFileSync(join(directory, ".changeset", "pre.json"), "utf8")
+      ).changesets.includes("synthetic-client"),
+      false
+    );
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
 
 test("produces the exact initial beta package versions", () => {
   const directory = mkdtempSync(join(tmpdir(), "mcp-use-initial-beta-test-"));
@@ -145,7 +256,11 @@ test("produces the exact initial beta package versions", () => {
     );
     execFileSync(process.execPath, [versionScript], {
       cwd: directory,
-      env: { ...process.env, CHANGESETS_RELEASE_PLAN_PATH: planFile },
+      env: {
+        ...process.env,
+        BETA_RELEASE_REGISTRY_METADATA_PATH: emptyRegistryFixture(directory),
+        CHANGESETS_RELEASE_PLAN_PATH: planFile,
+      },
       stdio: "ignore",
     });
     for (const [packageDirectory, [, version]] of Object.entries(expected)) {
@@ -182,11 +297,18 @@ for (const scenario of [
   },
 ]) {
   test(`avoids false dependent majors for a Client ${scenario.type} beta`, () => {
-    const { directory, planFile } = setup(scenario.type, scenario.client);
+    const { directory, planFile, registryFile } = setup(
+      scenario.type,
+      scenario.client
+    );
     try {
       execFileSync(process.execPath, [versionScript], {
         cwd: directory,
-        env: { ...process.env, CHANGESETS_RELEASE_PLAN_PATH: planFile },
+        env: {
+          ...process.env,
+          BETA_RELEASE_REGISTRY_METADATA_PATH: registryFile,
+          CHANGESETS_RELEASE_PLAN_PATH: planFile,
+        },
         stdio: "ignore",
       });
       assert.equal(manifest(directory, "client").version, scenario.client);
@@ -206,6 +328,10 @@ for (const scenario of [
         });
         execFileSync(process.execPath, [versionScript], {
           cwd: directory,
+          env: {
+            ...process.env,
+            BETA_RELEASE_REGISTRY_METADATA_PATH: registryFile,
+          },
           stdio: "ignore",
         });
         assert.equal(manifest(directory, "client").version, "2.1.0");
@@ -225,3 +351,63 @@ for (const scenario of [
     }
   });
 }
+
+test("bumps Inspector with an optional mcp-use peer on each mcp-use beta", () => {
+  const { directory, planFile, registryFile } = setup(
+    "patch",
+    "2.0.1-beta.0",
+    "mcp-use"
+  );
+  try {
+    execFileSync(process.execPath, [versionScript], {
+      cwd: directory,
+      env: {
+        ...process.env,
+        BETA_RELEASE_REGISTRY_METADATA_PATH: registryFile,
+        CHANGESETS_RELEASE_PLAN_PATH: planFile,
+      },
+      stdio: "ignore",
+    });
+
+    assert.equal(manifest(directory, "server").version, "2.0.1-beta.0");
+    assert.equal(manifest(directory, "inspector").version, "20.0.1-beta.0");
+    assert.equal(
+      manifest(directory, "inspector").peerDependencies["mcp-use"],
+      "2.0.1-beta.0"
+    );
+    assert.equal(
+      manifest(directory, "inspector").peerDependenciesMeta["mcp-use"].optional,
+      true
+    );
+
+    writeFileSync(
+      join(directory, ".changeset", "synthetic-server-second.md"),
+      `---\n"mcp-use": patch\n---\n\nSynthetic second framework beta.\n`
+    );
+    const secondPlanFile = join(directory, "synthetic-second-plan.json");
+    writeFileSync(
+      secondPlanFile,
+      JSON.stringify({
+        releases: [{ name: "mcp-use", newVersion: "2.0.1-beta.1" }],
+      })
+    );
+    execFileSync(process.execPath, [versionScript], {
+      cwd: directory,
+      env: {
+        ...process.env,
+        BETA_RELEASE_REGISTRY_METADATA_PATH: registryFile,
+        CHANGESETS_RELEASE_PLAN_PATH: secondPlanFile,
+      },
+      stdio: "ignore",
+    });
+
+    assert.equal(manifest(directory, "server").version, "2.0.1-beta.1");
+    assert.equal(manifest(directory, "inspector").version, "20.0.1-beta.1");
+    assert.equal(
+      manifest(directory, "inspector").peerDependencies["mcp-use"],
+      "2.0.1-beta.1"
+    );
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## What

Closes the four v2 beta release blockers found in the final readiness review:

- rejects beta version plans that collide with or lag npm
- keeps Inspector in every `mcp-use` beta release and pins its peer to that exact beta
- replaces the legacy Agent Langfuse adapter with the modern optional `@langfuse/langchain` peer
- makes Inspector framework peers optional for a true standalone install
- refreshes the public v2 server, MCP Apps, client, and onboarding docs and adds a migration guide

A single changeset advances the planned beta versions to:

- `mcp-use@2.0.0-beta.68`
- `@mcp-use/agent@2.0.0-beta.22`
- `@mcp-use/inspector@20.0.0-beta.60`

## Why

The beta workflow could consume a pending changeset whose planned version had already been published. Inspector could also drift from the framework version it embeds, while a normal Inspector install pulled framework peers despite its zero-runtime-dependency package boundary. Agent observability still referenced the legacy Langfuse adapter, and public v2 examples taught removed package subpaths and older MCP Apps result patterns.

## Validation

- full TypeScript workspace build, including Inspector package verification
- beta release suite: 9 release-versioning cases, 277 Client tests, 134 Agent tests, CLI smoke, and 22 scaffold tests
- strict ESLint and Prettier checks
- packed artifact verification for all six TypeScript packages
- clean packed Agent consumer with latest LangChain 1.5.4 / core 1.2.4 and Langfuse adapter 5.9.1
- clean standard Inspector install: only Inspector installed; `mcp-use` was not auto-installed; root import passed
- frozen lockfile install and supply-chain policy checks
- Changesets plan and live beta-tag verification
- Knip completed with the existing unused-export/configuration inventory; no new dependency issue was reported
- documented runtime imports verified against the built package exports

`verify:release-install` currently reaches its dependency-graph assertion and reports an unrelated registry-resolution duplicate of `lightningcss` 1.32.0/1.33.0. That verifier does not install Agent, and the duplicate is outside this PR's package changes. The focused packed Agent and Inspector consumer checks pass.

Deployment behavior was intentionally not exercised in this pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the v2 beta release process and finalized package boundaries, plus refreshed v2 docs with a migration guide for the stateless server and MCP App views. This closes GA blockers by preventing bad beta versions, pinning Inspector to the matching `mcp-use` beta, modernizing Agent Langfuse support, and making Inspector peers optional.

- **Bug Fixes**
  - Block prerelease plans that reuse or lag the npm `beta` tag; add Inspector sync to each `mcp-use` beta.
  - Pin Inspector’s `mcp-use` peer to the exact beta and enforce all framework peers as optional; verify in package checks.

- **Migration**
  - If you trace Agent runs with LangChain/Langfuse: install `@langfuse/langchain@~5.9` and remove `langfuse-langchain`.
  - Import server APIs from `mcp-use` (not `mcp-use/server`), and use `inputSchema`/`outputSchema` for tools.
  - Switch MCP App “widgets” to “views”: bind with `view: { name }`, declare `outputSchema`, and return `content` + `structuredContent`.

<sup>Written for commit 8929b2be83053e6d2d50847108cdc47c9f83c312. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

