### PR TITLE
fix: publish create-app release channel resolution

### DIFF
--- a/libraries/typescript/.changeset/stable-release-channel-resolution.md
+++ b/libraries/typescript/.changeset/stable-release-channel-resolution.md
@@ -1,0 +1,5 @@
+---
+"create-mcp-use-app": patch
+---
+
+Resolve the default SDK and bundled MCP Apps skill from the matching release channel: beta builds use npm `beta` and the beta branch, while stable builds use npm `latest` and the main branch.


### PR DESCRIPTION
Adds a fresh create-mcp-use-app patch changeset for the stable release-channel code merged in #2106. The previous changeset ID had already been consumed by #2105, so the beta workflow skipped versioning.

This should publish create-mcp-use-app@2.0.0-beta.16 before beta is integrated into main.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a new patch changeset for `create-mcp-use-app` to publish the release-channel resolution fix. Ensures the default SDK and bundled MCP Apps skill use the matching channel (beta uses npm beta + beta branch; stable uses npm latest + main), and unblocks publishing `create-mcp-use-app@2.0.0-beta.16`.

<sup>Written for commit b2834a75c4806d029edd08f6d549554cf2249731. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

