### PR TITLE
chore(release): publish npm README metadata hotfix

### DIFF
--- a/.github/workflows/typescript-release.yml
+++ b/.github/workflows/typescript-release.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
     inputs:
       force_publish:
-        description: 'Force publish packages'
+        description: "Force publish packages"
         required: false
         type: boolean
         default: false
@@ -116,6 +116,7 @@ jobs:
         working-directory: libraries/typescript
         run: |
           # Using npm trusted publishing (OIDC) - no token needed
+          node scripts/package-readme.mjs prepare
           pnpm changeset publish
           echo "✅ Published canary packages to npm using trusted publishing"
 
@@ -125,11 +126,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -e
-          
+
           # Ensure we're on the latest commit (commits were pushed in previous step)
           git fetch --tags --force
           git pull origin canary
-          
+
           cd libraries/typescript
           pnpm changeset tag
           cd ../..
@@ -359,8 +360,8 @@ jobs:
 
       - name: Publish packages (Main)
         if: github.ref == 'refs/heads/main' &&
-            steps.check-prerelease.outputs.in_prerelease == 'false' &&
-            steps.check-release.outputs.should_publish == 'true'
+          steps.check-prerelease.outputs.in_prerelease == 'false' &&
+          steps.check-release.outputs.should_publish == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -375,21 +376,22 @@ jobs:
           git fetch --tags --force
           git checkout main
           git pull origin main
-          
+
           # Publish to npm using trusted publishing (OIDC) - no token needed
           cd libraries/typescript
+          node scripts/package-readme.mjs prepare
           pnpm changeset publish
           pnpm changeset tag
 
           # Capture new tags created by changeset before pushing
           cd ../..
           NEW_TAGS=$(git tag --points-at HEAD)
-          
+
           if [ -z "$NEW_TAGS" ]; then
             echo "❌ No tags were created by changeset tag - packages were published to npm but tagging failed"
             exit 1
           fi
-          
+
           echo "📦 Tags created: $NEW_TAGS"
 
           # Save tags to a file for the next step
@@ -407,16 +409,16 @@ jobs:
 
       - name: Create deployment marker (Main)
         if: github.ref == 'refs/heads/main' &&
-            steps.check-prerelease.outputs.in_prerelease == 'false' &&
-            steps.check-release.outputs.should_publish == 'true'
+          steps.check-prerelease.outputs.in_prerelease == 'false' &&
+          steps.check-release.outputs.should_publish == 'true'
         run: |
           echo "packages_published=true" > .railway-deploy-marker
           echo "branch=main" >> .railway-deploy-marker
 
       - name: Upload deployment marker (Main)
         if: github.ref == 'refs/heads/main' &&
-            steps.check-prerelease.outputs.in_prerelease == 'false' &&
-            steps.check-release.outputs.should_publish == 'true'
+          steps.check-prerelease.outputs.in_prerelease == 'false' &&
+          steps.check-release.outputs.should_publish == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: railway-deploy-marker

--- a/libraries/typescript/packages/inspector/CHANGELOG.md
+++ b/libraries/typescript/packages/inspector/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @mcp-use/inspector
 
+## 20.0.2
+
+### Patch Changes
+
+- Prepare the package README before publication so npm records and displays the stable documentation metadata.
+- Updated dependencies
+  - mcp-use@2.0.2
+
 ## 20.0.1
 
 ### Patch Changes

--- a/libraries/typescript/packages/inspector/package.json
+++ b/libraries/typescript/packages/inspector/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-use/inspector",
   "type": "module",
-  "version": "20.0.1",
+  "version": "20.0.2",
   "description": "MCP Inspector - A tool for inspecting and debugging MCP servers",
   "author": "",
   "license": "MIT",

--- a/libraries/typescript/packages/server/CHANGELOG.md
+++ b/libraries/typescript/packages/server/CHANGELOG.md
@@ -1,5 +1,13 @@
 # mcp-use
 
+## 2.0.2
+
+### Patch Changes
+
+- Prepare the package README before publication so npm records and displays the stable documentation metadata.
+- Updated dependencies
+  - @mcp-use/inspector@20.0.2
+
 ## 2.0.1
 
 ### Patch Changes

--- a/libraries/typescript/packages/server/package.json
+++ b/libraries/typescript/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-use",
   "type": "module",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "MCP framework and CLI built on the official v2 SDK",
   "author": "mcp-use, Inc.",
   "license": "MIT",


### PR DESCRIPTION
## What changed

- prepare the generated package README before Changesets starts npm publication
- publish `mcp-use@2.0.2` and aligned `@mcp-use/inspector@20.0.2`
- apply the same timing fix to canary publication

## Why

`mcp-use@2.0.1` contains the correct README in its tarball, but npm captures website README metadata before the package-level `prepack` lifecycle. Preparing it before `changeset publish` ensures both the tarball and registry metadata contain the README.

## Verification

- README exists before publication begins
- packed README matches the repository root byte-for-byte
- packed server depends on Inspector 20.0.2
- packed Inspector peer-depends exactly on mcp-use 2.0.2
- release-versioning tests: 9/9 passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes npm README metadata by preparing the package README before publishing. Also publishes `mcp-use@2.0.2` and `@mcp-use/inspector@20.0.2`, and applies the fix to canary builds.

- **Bug Fixes**
  - Run `node scripts/package-readme.mjs prepare` before `changeset publish` in main and canary workflows so npm records and displays the correct README.

- **Dependencies**
  - Published `mcp-use@2.0.2` and `@mcp-use/inspector@20.0.2`; versions aligned.

<sup>Written for commit fc0e6f20518839a72e5631646e1374a0d6fa6068. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

