### PR TITLE
Fix npm README image and repository links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   <a href="https://mcp-use.com">
-    <img alt="mcp-use" src="./docs/logo/banner-mcp-use.webp" width="100%">
+    <img alt="mcp-use" src="https://raw.githubusercontent.com/mcp-use/mcp-use/main/docs/logo/banner-mcp-use.webp" width="100%">
   </a>
   <br /><br />
 
@@ -216,7 +216,7 @@ export default function WeatherCard() {
 </td></tr></table>
 
 <p align="center">
-  <img src="./static/readme/chatgpt-hello-world.jpg" alt="Hello World MCP App rendered in a ChatGPT conversation" width="100%" />
+  <img src="https://raw.githubusercontent.com/mcp-use/mcp-use/main/static/readme/chatgpt-hello-world.jpg" alt="Hello World MCP App rendered in a ChatGPT conversation" width="100%" />
   <br />
   <sub>Build interactive UI experiences within ChatGPT with mcp-use.</sub>
 </p>
@@ -240,7 +240,7 @@ npm run dev
 ```
 
 <p align="center">
-  <img src="./static/readme/inspector-hello-world.jpg" alt="Hello World MCP App rendered in the mcp-use Inspector" width="100%" />
+  <img src="https://raw.githubusercontent.com/mcp-use/mcp-use/main/static/readme/inspector-hello-world.jpg" alt="Hello World MCP App rendered in the mcp-use Inspector" width="100%" />
   <br />
   <sub>Invoke tools, validate inputs, and inspect interactive Views in the same development loop.</sub>
 </p>
@@ -313,7 +313,7 @@ block-beta
 
 <sub>Install rows compare custom React MCP App development stacks. FastMCP therefore includes the Apps extension, React, Vite React plugin, Vite, TypeScript, and zod rather than only its narrower server-side component workflow. Size is actual `node_modules` disk usage after a normal npm install, including required peer dependencies.</sub>
 
-**[Read the detailed benchmark report →](./benchmark.md)**
+**[Read the detailed benchmark report →](https://github.com/mcp-use/mcp-use/blob/main/benchmark.md)**
 
 ## Examples
 
@@ -325,7 +325,7 @@ Remix a complete MCP App, inspect the source, or deploy it as a starting point:
 | <img src="https://raw.githubusercontent.com/mcp-use/mcp-diagram-builder/main/repo-assets/demo.gif" alt="Diagram Builder demo" width="280"> | [Diagram Builder](https://github.com/mcp-use/mcp-diagram-builder) | Create and edit diagrams through MCP tools · [Open demo](https://lucky-darkness-402ph.run.mcp-use.com/mcp) |
 | <img src="https://raw.githubusercontent.com/mcp-use/mcp-maps-explorer/main/repo-assets/demo.gif" alt="Maps Explorer demo" width="280"> | [Maps Explorer](https://github.com/mcp-use/mcp-maps-explorer) | Search, detail tools, and an interactive map view · [Open demo](https://super-night-ttde2.run.mcp-use.com/mcp) |
 
-[Browse all TypeScript examples →](./libraries/typescript/packages/server/examples)
+[Browse all TypeScript examples →](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples)
 
 ## Ecosystem
 
@@ -363,12 +363,12 @@ Remix a complete MCP App, inspect the source, or deploy it as a starting point:
 
 ## Security and community
 
-- [Security policy](./SECURITY.md)
-- [Contribution guide](./CONTRIBUTING.md)
+- [Security policy](https://github.com/mcp-use/mcp-use/blob/main/SECURITY.md)
+- [Contribution guide](https://github.com/mcp-use/mcp-use/blob/main/CONTRIBUTING.md)
 - [GitHub issues](https://github.com/mcp-use/mcp-use/issues)
 - [Discord community](https://discord.gg/XkNkSkMz3V)
 - [Manufact](https://manufact.com)
-- [MIT license](./LICENSE)
+- [MIT license](https://github.com/mcp-use/mcp-use/blob/main/LICENSE)
 
 ## Contributors
 

--- a/libraries/typescript/packages/inspector/CHANGELOG.md
+++ b/libraries/typescript/packages/inspector/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @mcp-use/inspector
 
+## 20.0.4
+
+### Patch Changes
+
+- Use stable absolute URLs for README images and repository links so npm renders the published package documentation correctly.
+- Updated dependencies
+  - mcp-use@2.0.4
+
 ## 20.0.3
 
 ### Patch Changes

--- a/libraries/typescript/packages/inspector/package.json
+++ b/libraries/typescript/packages/inspector/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-use/inspector",
   "type": "module",
-  "version": "20.0.3",
+  "version": "20.0.4",
   "description": "MCP Inspector - A tool for inspecting and debugging MCP servers",
   "author": "",
   "license": "MIT",

--- a/libraries/typescript/packages/server/CHANGELOG.md
+++ b/libraries/typescript/packages/server/CHANGELOG.md
@@ -1,5 +1,13 @@
 # mcp-use
 
+## 2.0.4
+
+### Patch Changes
+
+- Use stable absolute URLs for README images and repository links so npm renders the published package documentation correctly.
+- Updated dependencies
+  - @mcp-use/inspector@20.0.4
+
 ## 2.0.3
 
 ### Patch Changes

--- a/libraries/typescript/packages/server/README.md
+++ b/libraries/typescript/packages/server/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   <a href="https://mcp-use.com">
-    <img alt="mcp-use" src="./docs/logo/banner-mcp-use.webp" width="100%">
+    <img alt="mcp-use" src="https://raw.githubusercontent.com/mcp-use/mcp-use/main/docs/logo/banner-mcp-use.webp" width="100%">
   </a>
   <br /><br />
 
@@ -216,7 +216,7 @@ export default function WeatherCard() {
 </td></tr></table>
 
 <p align="center">
-  <img src="./static/readme/chatgpt-hello-world.jpg" alt="Hello World MCP App rendered in a ChatGPT conversation" width="100%" />
+  <img src="https://raw.githubusercontent.com/mcp-use/mcp-use/main/static/readme/chatgpt-hello-world.jpg" alt="Hello World MCP App rendered in a ChatGPT conversation" width="100%" />
   <br />
   <sub>Build interactive UI experiences within ChatGPT with mcp-use.</sub>
 </p>
@@ -240,7 +240,7 @@ npm run dev
 ```
 
 <p align="center">
-  <img src="./static/readme/inspector-hello-world.jpg" alt="Hello World MCP App rendered in the mcp-use Inspector" width="100%" />
+  <img src="https://raw.githubusercontent.com/mcp-use/mcp-use/main/static/readme/inspector-hello-world.jpg" alt="Hello World MCP App rendered in the mcp-use Inspector" width="100%" />
   <br />
   <sub>Invoke tools, validate inputs, and inspect interactive Views in the same development loop.</sub>
 </p>
@@ -313,7 +313,7 @@ block-beta
 
 <sub>Install rows compare custom React MCP App development stacks. FastMCP therefore includes the Apps extension, React, Vite React plugin, Vite, TypeScript, and zod rather than only its narrower server-side component workflow. Size is actual `node_modules` disk usage after a normal npm install, including required peer dependencies.</sub>
 
-**[Read the detailed benchmark report →](./benchmark.md)**
+**[Read the detailed benchmark report →](https://github.com/mcp-use/mcp-use/blob/main/benchmark.md)**
 
 ## Examples
 
@@ -325,7 +325,7 @@ Remix a complete MCP App, inspect the source, or deploy it as a starting point:
 | <img src="https://raw.githubusercontent.com/mcp-use/mcp-diagram-builder/main/repo-assets/demo.gif" alt="Diagram Builder demo" width="280"> | [Diagram Builder](https://github.com/mcp-use/mcp-diagram-builder) | Create and edit diagrams through MCP tools · [Open demo](https://lucky-darkness-402ph.run.mcp-use.com/mcp) |
 | <img src="https://raw.githubusercontent.com/mcp-use/mcp-maps-explorer/main/repo-assets/demo.gif" alt="Maps Explorer demo" width="280"> | [Maps Explorer](https://github.com/mcp-use/mcp-maps-explorer) | Search, detail tools, and an interactive map view · [Open demo](https://super-night-ttde2.run.mcp-use.com/mcp) |
 
-[Browse all TypeScript examples →](./libraries/typescript/packages/server/examples)
+[Browse all TypeScript examples →](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples)
 
 ## Ecosystem
 
@@ -363,12 +363,12 @@ Remix a complete MCP App, inspect the source, or deploy it as a starting point:
 
 ## Security and community
 
-- [Security policy](./SECURITY.md)
-- [Contribution guide](./CONTRIBUTING.md)
+- [Security policy](https://github.com/mcp-use/mcp-use/blob/main/SECURITY.md)
+- [Contribution guide](https://github.com/mcp-use/mcp-use/blob/main/CONTRIBUTING.md)
 - [GitHub issues](https://github.com/mcp-use/mcp-use/issues)
 - [Discord community](https://discord.gg/XkNkSkMz3V)
 - [Manufact](https://manufact.com)
-- [MIT license](./LICENSE)
+- [MIT license](https://github.com/mcp-use/mcp-use/blob/main/LICENSE)
 
 ## Contributors
 

--- a/libraries/typescript/packages/server/package.json
+++ b/libraries/typescript/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-use",
   "type": "module",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "MCP framework and CLI built on the official v2 SDK",
   "author": "mcp-use, Inc.",
   "license": "MIT",


### PR DESCRIPTION
## What changed

- replaces package-subdirectory-relative README image paths with stable `raw.githubusercontent.com` URLs
- replaces other repository-relative README links with absolute GitHub URLs
- keeps the repository and packaged `mcp-use` README files byte-for-byte identical
- versions `mcp-use` to 2.0.4 and `@mcp-use/inspector` to 20.0.4 so Inspector continues to pin the matching server release

## Why

npm resolves relative README paths from the package's declared repository directory (`libraries/typescript/packages/server`). The prior paths therefore pointed at files below that subdirectory and rendered as broken images on npm.

## Validation

- all three absolute image URLs return HTTP 200
- README synchronization verifier passes
- release-versioning suite passes (9/9)
- Client, Agent, Inspector, CLI, and server builds pass in dependency order
- packed `mcp-use@2.0.4` contains the exact root README
- packed metadata resolves `@mcp-use/inspector` to 20.0.4, and Inspector resolves its `mcp-use` peer to 2.0.4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken images and links in the npm README by switching to stable absolute GitHub URLs. Publishes `mcp-use@2.0.4` and `@mcp-use/inspector@20.0.4` while keeping READMEs in sync.

- **Bug Fixes**
  - Replaced README image paths with `raw.githubusercontent.com` URLs so npm renders images.
  - Converted repository-relative README links to absolute GitHub URLs; kept root and packaged `mcp-use` READMEs byte-for-byte identical.

- **Dependencies**
  - Bumped `mcp-use` to 2.0.4 and `@mcp-use/inspector` to 20.0.4 to pin Inspector to the matching server release.

<sup>Written for commit bfc0d9f696b76a54a48be81ec0c68d9b5463eaa9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

