### PR TITLE
docs: fix TypeScript README links into the removed mcp-use package

### DIFF
--- a/libraries/typescript/README.md
+++ b/libraries/typescript/README.md
@@ -1,8 +1,8 @@
 <div align="center" style="margin: 0 auto; max-width: 80%;">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="./packages/mcp-use/static/logo_white.svg">
-    <source media="(prefers-color-scheme: light)" srcset="./packages/mcp-use/static/logo_black.svg">
-    <img alt="mcp use logo" src="./packages/mcp-use/static/logo_white.svg" width="80%" style="margin: 20px auto;">
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/mcp-use/mcp-use/main/static/logo_white.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/mcp-use/mcp-use/main/static/logo_black.svg">
+    <img alt="mcp use logo" src="https://raw.githubusercontent.com/mcp-use/mcp-use/main/static/logo_white.svg" width="80%" style="margin: 20px auto;">
   </picture>
 </div>
 
@@ -316,7 +316,7 @@ export default function AnalyticsDashboard() {
 }
 ```
 
-[**Full mcp-use Documentation →**](./packages/mcp-use)
+[**Full mcp-use Documentation →**](./packages/server)
 
 ---
 


### PR DESCRIPTION
## Changes

The v2 merge (`06ff3075 release: merge v2 beta into main`) deleted `libraries/typescript/packages/mcp-use`, but `libraries/typescript/README.md` still points at it in four places. The logo at the very top of the page is currently broken, and the documentation link at the bottom is dead.

```
$ git ls-files libraries/typescript/packages/mcp-use | wc -l
0
```

## Implementation Details

1. **Logo, lines 3 to 5.** Was `./packages/mcp-use/static/logo_white.svg` and `logo_black.svg` in the `<picture>` sources and the `<img>` fallback. Now the absolute `https://raw.githubusercontent.com/mcp-use/mcp-use/main/static/logo_{white,black}.svg`.

   This is the convention the rest of the repo already uses, not a new one. Every sibling package README does it this way:

   ```
   $ git grep -l "raw.githubusercontent.com/mcp-use/mcp-use/main/static/logo_white.svg" -- '*.md'
   libraries/typescript/packages/agent/README.md
   libraries/typescript/packages/client/README.md
   libraries/typescript/packages/create-mcp-use-app/README.md
   libraries/typescript/packages/inspector/README.md
   ```

   `libraries/typescript/README.md` was the only file left on the relative path:

   ```
   $ git grep -l "packages/mcp-use/static/logo" -- '*.md'
   libraries/typescript/README.md
   ```

   Both targets resolve, and the files are tracked at the repo root (`static/logo_white.svg`, `static/logo_black.svg`):

   ```
   $ curl -s -o /dev/null -w "%{http_code}\n" https://raw.githubusercontent.com/mcp-use/mcp-use/main/static/logo_white.svg
   200
   $ curl -s -o /dev/null -w "%{http_code}\n" https://raw.githubusercontent.com/mcp-use/mcp-use/main/static/logo_black.svg
   200
   ```

   A relative `../../static/logo_white.svg` would also render on GitHub, but I matched the siblings instead so the whole TypeScript tree is consistent.

2. **Docs link, line 319.** `[**Full mcp-use Documentation →**](./packages/mcp-use)` now points at `./packages/server`, which is where the `mcp-use` package lives in v2. Same target the other READMEs already use for it:

   ```
   libraries/typescript/packages/create-mcp-use-app/README.md:30: ... /tree/main/libraries/typescript/packages/server) | MCP framework and CLI
   libraries/typescript/packages/inspector/README.md:46:      ... /tree/main/libraries/typescript/packages/server) | MCP framework and CLI
   ```

## Testing

Audited every relative link in the file, not just the ones I touched, resolving each against the tracked tree:

```
before -> relative links: 10  broken: 1  ['./packages/mcp-use']
after  -> relative links: 10  broken: 0  []
```

(The three logo paths are `srcset`/`src` attributes rather than markdown links, hence the separate count. All four references are gone: `git grep "packages/mcp-use" libraries/typescript/README.md` returns nothing.)

`ci-preflight` exit 0.

## Backwards Compatibility

Documentation only. No source, build, or published artifact changes.

## Note on a related but separate problem

`examples/README.md` has 26 links into the same deleted directory (`../libraries/typescript/packages/mcp-use/examples/...`). I left those out of this PR deliberately: about half have an unambiguous v2 home (`examples/server/features/proxy` to `packages/server/examples/proxy`, and so on) but the rest have no v2 equivalent at all, so fixing them means deciding whether to drop the entry or point somewhere approximate. That is a content call rather than a mechanical repoint, so I would rather ask than guess. Happy to send it as a follow-up once you say which way you want those handled.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix broken logo sources and docs link in `libraries/typescript/README.md` after the removal of `libraries/typescript/packages/mcp-use`. Use `https://raw.githubusercontent.com/mcp-use/mcp-use/main/static/...` for the logo and point docs to `./packages/server` to align with other TypeScript package READMEs.

<sup>Written for commit 0c46b3394312bec7716cb69d555aa0336e3211cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

