### PR TITLE
fix(ci): pin pnpm in the docs workflow so the job can start

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,6 +49,8 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: 11.13.1
 
       - name: Set up Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Changes

Adds `version: 11.13.1` to the `pnpm/action-setup@v4` step in `.github/workflows/docs.yml`. The `Generate and validate API documentation` check is currently red on every branch, including `main`, and it never reaches the docs generation at all.

## Root cause

The job dies in `Set up pnpm`:

```
Set up pnpm  Error: No pnpm version is specified.
Please specify it by one of the following ways:
  - in the GitHub Action config with the key "version"
  - in the package.json with the key "packageManager"
```

With no `version:`, `pnpm/action-setup@v4` falls back to reading `packageManager` from `package_json_file`, which defaults to `package.json` at the repository root. This repo has no root `package.json`:

```
$ git ls-files package.json
(nothing)
```

So the step has no version from either source and aborts. Nothing about a given PR's diff affects it.

## Evidence it is repo-wide, not branch-specific

Same job, same error, on `main`:

```
$ gh run view 30821461990 --json headBranch,createdAt,jobs
branch: main
at:     2026-08-03T14:10:51Z
jobs:   [{ name: "Generate and validate API documentation", c: "failure" }]

$ gh run view 30821461990 --log-failed | grep "No pnpm version is specified"
Generate and validate API documentation  Error: No pnpm version is specified.
```

It fails identically on maintainer branches (`fix/npm-readme-assets`, `agent/npm-readme-committed-hotfix`) and on mine, which is what surfaced it.

## Why 11.13.1

It is the version the repo already standardises on, so this is not a new choice:

```
$ grep -A2 "action-setup@v4" .github/workflows/ci.yml | grep "version:" | sort -u
          version: 11.13.1
```

All nine uses in `ci.yml` pin it, and it matches the workspace's own declaration:

```
libraries/typescript/package.json:76:  "packageManager": "pnpm@11.13.1+sha512.b2fc7683..."
```

## Why the fix is sufficient, not just moving the failure

Every later pnpm step already sets `working-directory: libraries/typescript`, which is where the `package.json` and `pnpm-lock.yaml` actually live:

```yaml
      - name: Install TypeScript dependencies
        working-directory: libraries/typescript
        run: pnpm install --frozen-lockfile

      - name: Generate TypeScript API documentation
        working-directory: libraries/typescript
        run: pnpm docs:api
```

So once pnpm exists, the job runs in the right place. Only the setup step was missing an input.

## One workflow deliberately left alone

`bump-mcp-use-reusable.yml` also calls `action-setup@v4` without `version:`, and that one is correct. It documents why in place, and it is a reusable workflow for consumer repos that pin pnpm through their own `packageManager`, where passing `version` too would trigger `ERR_PNPM_BAD_PM_VERSION`. I checked it rather than applying the change everywhere the pattern matched.

## Testing

I cannot run GitHub Actions from a fork, so I am not claiming a green run I have not seen. What I verified:

- The failure is in the setup step, before any docs work, from the job log.
- No root `package.json` exists, so the fallback path cannot resolve.
- `main` fails with the identical error, so it is not diff-specific.
- The pinned version matches `ci.yml` and `libraries/typescript/package.json`.
- `ci-preflight` exit 0.

The docs workflow only triggers on `libraries/**` and `docs/**` paths, and this PR touches neither, so its own check will skip. The real confirmation is the next run on `main` after merge.

## Backwards Compatibility

CI configuration only. No source, docs content, or published artifact changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pinned `pnpm` to 11.13.1 in the docs CI so the "Generate and validate API documentation" job can start and run. Fixes the setup failure when no version is specified and no root `package.json` is present.

- **Bug Fixes**
  - Set `version: 11.13.1` on `pnpm/action-setup@v4` in `.github/workflows/docs.yml`.
  - Aligns with `ci.yml` and `libraries/typescript/package.json` and resolves "No pnpm version is specified".

<sup>Written for commit 70c140413a9106281d49b06a7a48f5d77dc2be2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

