### PR TITLE
chore(deps): update @hono/node-server to 2.0.10

### DIFF
--- a/libraries/typescript/.changeset/update-hono-node-server-v2.md
+++ b/libraries/typescript/.changeset/update-hono-node-server-v2.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Updated `@hono/node-server` to 2.0.10.

--- a/libraries/typescript/packages/client/examples/_demo-servers/package.json
+++ b/libraries/typescript/packages/client/examples/_demo-servers/package.json
@@ -11,7 +11,7 @@
     "v2": "pnpm official:v2"
   },
   "dependencies": {
-    "@hono/node-server": "^1.19.0",
+    "@hono/node-server": "^2.0.10",
     "@modelcontextprotocol/sdk": "^1.25.0",
     "@modelcontextprotocol/server": "2.0.0",
     "express": "^5.1.0",

--- a/libraries/typescript/packages/inspector/package.json
+++ b/libraries/typescript/packages/inspector/package.json
@@ -150,7 +150,7 @@
   },
   "devDependencies": {
     "@base-ui/react": "^1.6.0",
-    "@hono/node-server": "^1.19.13",
+    "@hono/node-server": "^2.0.10",
     "@mcp-use/agent": "workspace:*",
     "@mcp-use/client": "workspace:*",
     "@playwright/test": "^1.58.2",

--- a/libraries/typescript/packages/server/examples/auth/better-auth/package.json
+++ b/libraries/typescript/packages/server/examples/auth/better-auth/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@better-auth/oauth-provider": "^1.6.2",
-    "@hono/node-server": "^1.19.13",
+    "@hono/node-server": "^2.0.10",
     "better-auth": "^1.6.2",
     "hono": "^4.12.27",
     "mcp-use": "workspace:*"

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -8960,7 +8960,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.27)
+      '@hono/node-server': 2.0.10(hono@4.12.27)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -11386,7 +11386,7 @@ snapshots:
 
   emulate@0.5.0(hono@4.12.27):
     dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.27)
+      '@hono/node-server': 2.0.10(hono@4.12.27)
       commander: 14.0.3
       picocolors: 1.1.1
       yaml: 2.8.3

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -402,8 +402,8 @@ importers:
         specifier: ^1.6.0
         version: 1.6.0(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@hono/node-server':
-        specifier: ^1.19.13
-        version: 1.19.13(hono@4.12.27)
+        specifier: ^2.0.10
+        version: 2.0.10(hono@4.12.27)
       '@mcp-use/agent':
         specifier: workspace:*
         version: link:../agent
@@ -608,8 +608,8 @@ importers:
         specifier: ^1.6.2
         version: 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.23(@opentelemetry/api@1.9.1)(next@16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@22.20.1)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))))(better-call@1.3.7(zod@4.4.3))
       '@hono/node-server':
-        specifier: ^1.19.13
-        version: 1.19.13(hono@4.12.27)
+        specifier: ^2.0.10
+        version: 2.0.10(hono@4.12.27)
       better-auth:
         specifier: '>=1.6.2'
         version: 1.6.23(@opentelemetry/api@1.9.1)(next@16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@22.20.1)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
@@ -2009,11 +2009,11 @@ packages:
   '@hapi/topo@6.0.2':
     resolution: {integrity: sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==}
 
-  '@hono/node-server@1.19.13':
-    resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
-    engines: {node: '>=18.14.1'}
+  '@hono/node-server@2.0.10':
+    resolution: {integrity: sha512-ZcnNVhKTmyDJeg0UlnZjvM73JBsTAuhrH/J4fjwGOw59PwOW51r4J+p6CsKZWXdKSme4MFqU62CZMOsdDrU4CA==}
+    engines: {node: '>=20'}
     peerDependencies:
-      hono: '>=4.12.27'
+      hono: '>=4.12.21'
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -8669,7 +8669,7 @@ snapshots:
     dependencies:
       '@hapi/hoek': 11.0.7
 
-  '@hono/node-server@1.19.13(hono@4.12.27)':
+  '@hono/node-server@2.0.10(hono@4.12.27)':
     dependencies:
       hono: 4.12.27
 


### PR DESCRIPTION
## Summary

- update `@hono/node-server` to `2.0.10` across the current v2 canary consumers
- refresh the pnpm lockfile
- add an Inspector patch changeset

This replaces the stale v1 Dependabot update after the v2 release. Version 2.0.10 includes the upstream WebSocket handshake memory-leak fix and requires Node 20+, which is compatible with the current canary runtime requirements.

## Validation

- confirmed the branch is based directly on current `canary`
- verified all lockfile references resolve to `2.0.10`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `@hono/node-server` to 2.0.10 across v2 canary packages and examples to pick up the WebSocket handshake memory-leak fix. Requires Node 20+, which matches the canary runtime.

- **Dependencies**
  - Bumped `@hono/node-server` to `^2.0.10` in demo servers, `inspector`, and the `better-auth` example.
  - Refreshed `pnpm-lock.yaml` and snapshots for 2.0.10.
  - Added a patch changeset for `@mcp-use/inspector`.

<sup>Written for commit b2e385cb4894ced12994735749a77800f754c50a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

