### PR TITLE
fix(client): stop leaking parent env to stdio servers

### DIFF
--- a/libraries/typescript/.changeset/stdio-env-leak.md
+++ b/libraries/typescript/.changeset/stdio-env-leak.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/client": patch
+---
+
+Stop leaking the full parent process environment to stdio MCP servers when explicit environment variables are configured.

--- a/libraries/typescript/packages/client/src/transport/stdio.ts
+++ b/libraries/typescript/packages/client/src/transport/stdio.ts
@@ -89,24 +89,12 @@ export class StdioConnector extends BaseConnector {
     try {
       // 1. Build server parameters for the transport
 
-      // Merge env with process.env, filtering out undefined values
-      let mergedEnv: Record<string, string> | undefined;
-      if (this.env) {
-        mergedEnv = {};
-        // First add process.env values (excluding undefined)
-        for (const [key, value] of Object.entries(process.env)) {
-          if (value !== undefined) {
-            mergedEnv[key] = value;
-          }
-        }
-        // Then override with provided env
-        Object.assign(mergedEnv, this.env);
-      }
-
       const serverParams: StdioServerParameters = {
         command: this.command,
         args: this.args,
-        env: mergedEnv,
+        // The SDK layers explicit values over getDefaultEnvironment(). Passing
+        // the configured env through avoids exposing unrelated parent secrets.
+        env: this.env,
         cwd: this.cwd,
       };
 

--- a/libraries/typescript/packages/client/tests/unit/transport/stdio-env.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/transport/stdio-env.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { StdioConnector } from "../../../src/transport/stdio.js";
+
+const SECRET_KEY = "MCP_USE_STDIO_ENV_LEAK_PROBE";
+const EXPLICIT_KEY = "MCP_USE_STDIO_EXPLICIT_PROBE";
+const previousSecret = process.env[SECRET_KEY];
+
+const envProbeServer = String.raw`
+const readline = require("node:readline");
+
+const lines = readline.createInterface({ input: process.stdin });
+lines.on("line", (line) => {
+  const request = JSON.parse(line);
+  if (request.id === undefined) return;
+
+  let result;
+  if (request.method === "initialize") {
+    const secretState = process.env.${SECRET_KEY} === undefined ? "absent" : "present";
+    const explicitState = process.env.${EXPLICIT_KEY} === "configured" ? "present" : "absent";
+    result = {
+      protocolVersion: request.params.protocolVersion,
+      capabilities: {},
+      serverInfo: {
+        name: "secret-" + secretState + "-explicit-" + explicitState,
+        version: "1.0.0"
+      }
+    };
+  } else if (request.method === "tools/list") {
+    result = { tools: [] };
+  } else {
+    return;
+  }
+
+  process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: request.id, result }) + "\n");
+});
+`;
+
+afterEach(() => {
+  if (previousSecret === undefined) {
+    delete process.env[SECRET_KEY];
+  } else {
+    process.env[SECRET_KEY] = previousSecret;
+  }
+});
+
+describe("StdioConnector environment", () => {
+  it("passes explicit variables without leaking unrelated parent variables", async () => {
+    process.env[SECRET_KEY] = "super-secret";
+    const connector = new StdioConnector({
+      command: process.execPath,
+      args: ["-e", envProbeServer],
+      env: { [EXPLICIT_KEY]: "configured" },
+    });
+
+    try {
+      await connector.connect();
+      await connector.initialize();
+
+      expect(connector.serverInfo?.name).toBe("secret-absent-explicit-present");
+    } finally {
+      await connector.disconnect();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- port the STDIO environment fix from #1949 to the v2 `@mcp-use/client` package
- pass configured environment variables directly to the v2 SDK transport so it can layer them over its safe default environment
- add a real child-process regression test proving unrelated parent secrets are absent while explicitly configured variables are preserved
- add a patch changeset for `@mcp-use/client`

## Root cause

The TypeScript connector copied all of `process.env` whenever a server configured any `env` value. That bypassed the MCP SDK's restricted default environment and exposed unrelated parent-process secrets to the spawned MCP server.

## Credit

Ported from #1949 by @VihaanAgarwal. Vihaan is also credited as a co-author on the commit.

This addresses the STDIO environment item reported in #1901. It does not close the broader issue because the other reported items have separate threat-model considerations.

## Validation

- `pnpm --filter @mcp-use/client test:run` — 48 files, 278 tests passed
- `pnpm --filter @mcp-use/client build`
- targeted ESLint for the connector and regression test
- targeted Prettier check for all changed files
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents leaking parent environment variables to STDIO MCP servers in v2 `@mcp-use/client`. Only explicitly configured variables are sent; the SDK applies them over its safe defaults.

- **Bug Fixes**
  - Stop copying `process.env` when `env` is provided; pass `env` directly to the transport.
  - Add a regression test to confirm parent secrets are excluded and explicit vars are preserved.
  - Add a patch changeset for `@mcp-use/client`.

<sup>Written for commit 86083e04b5e929258397aad57b82b74288785380. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

