### PR TITLE
fix(client): bound conformance auth scenarios

### DIFF
--- a/libraries/typescript/packages/client/examples/conformance/src/conformance-client-browser.ts
+++ b/libraries/typescript/packages/client/examples/conformance/src/conformance-client-browser.ts
@@ -7,9 +7,10 @@ import { MCPClient } from "@mcp-use/client";
 import {
   handleElicitation,
   isAuthScenario,
-  isScopeStepUpScenario,
   parseConformanceContext,
+  requiresOAuthRetryFetch,
   runScenario,
+  runWithScenarioTimeout,
   type ConformanceSession,
 } from "./conformance-shared.js";
 import { createOAuthRetryFetch } from "./oauth-retry-fetch.js";
@@ -39,9 +40,9 @@ async function main(): Promise<void> {
   if (authProvider) {
     serverConfig.authProvider = authProvider;
 
-    if (isScopeStepUpScenario(scenario)) {
-      // Do not pre-authenticate for scope-step-up so the first token has only
-      // the scope from the initial 401; the OAuth retry fetch handles 401 and 403.
+    if (requiresOAuthRetryFetch(scenario)) {
+      // Preserve a scope advertised by the initial 401; pre-authentication
+      // would not receive the WWW-Authenticate header that contains it.
       serverConfig.fetch = createOAuthRetryFetch(
         fetch,
         serverUrl,
@@ -80,7 +81,10 @@ async function main(): Promise<void> {
   }
 }
 
-main().catch((err) => {
+runWithScenarioTimeout(
+  process.env.MCP_CONFORMANCE_SCENARIO || "",
+  main()
+).catch((err) => {
   console.error(err);
   process.exit(1);
 });

--- a/libraries/typescript/packages/client/examples/conformance/src/conformance-client-node.ts
+++ b/libraries/typescript/packages/client/examples/conformance/src/conformance-client-node.ts
@@ -7,9 +7,10 @@ import { MCPClient } from "@mcp-use/client";
 import {
   handleElicitation,
   isAuthScenario,
-  isScopeStepUpScenario,
   parseConformanceContext,
+  requiresOAuthRetryFetch,
   runScenario,
+  runWithScenarioTimeout,
   type ConformanceSession,
 } from "./conformance-shared.js";
 import { createOAuthRetryFetch } from "./oauth-retry-fetch.js";
@@ -34,12 +35,10 @@ async function main(): Promise<void> {
   if (authProvider) {
     serverConfig.authProvider = authProvider;
 
-    if (isScopeStepUpScenario(scenario)) {
-      // Do NOT pre-authenticate for scope-step-up: the first token must have
-      // only the scope from the initial 401 (mcp:basic). Pre-auth would get
-      // a token with all PRM scopes (mcp:basic mcp:write), so tools/call would
-      // never get 403 and the client would never make a second auth request.
-      // The OAuth retry fetch handles both 401 (initial) and 403 (escalation).
+    if (requiresOAuthRetryFetch(scenario)) {
+      // Preserve a scope advertised by the initial 401. Pre-authentication
+      // cannot see WWW-Authenticate, so it would request an incomplete token.
+      // The retry fetch handles the initial 401 and any later 403 escalation.
       serverConfig.fetch = createOAuthRetryFetch(
         fetch,
         serverUrl,
@@ -86,7 +85,10 @@ async function main(): Promise<void> {
   }
 }
 
-main().catch((err) => {
+runWithScenarioTimeout(
+  process.env.MCP_CONFORMANCE_SCENARIO || "",
+  main()
+).catch((err) => {
   console.error(err);
   process.exit(1);
 });

--- a/libraries/typescript/packages/client/examples/conformance/src/conformance-client-react.ts
+++ b/libraries/typescript/packages/client/examples/conformance/src/conformance-client-react.ts
@@ -13,9 +13,10 @@ import TestRenderer, { act } from "react-test-renderer";
 import {
   handleElicitation,
   isAuthScenario,
-  isScopeStepUpScenario,
   parseConformanceContext,
+  requiresOAuthRetryFetch,
   runScenario,
+  runWithScenarioTimeout,
   type ConformanceSession,
 } from "./conformance-shared.js";
 import { createOAuthRetryFetch } from "./oauth-retry-fetch.js";
@@ -151,15 +152,15 @@ async function main(): Promise<void> {
         preRegistrationContext: parseConformanceContext(),
       })
     : undefined;
-  // For scope-step-up we do not pre-auth; the OAuth retry fetch obtains the
-  // first token from the initial 401 so it has only mcp:basic, then handles 403.
+  // The retry fetch sees scopes carried by the initial WWW-Authenticate response
+  // and handles later 403 scope escalation without pre-authentication.
   const mcpServers: Record<string, any> = {
     test: {
       name: "test",
       url: serverUrl,
       authProvider,
       ...(authProvider &&
-        isScopeStepUpScenario(scenario) && {
+        requiresOAuthRetryFetch(scenario) && {
           fetch: createOAuthRetryFetch(fetch, serverUrl, authProvider, {
             max403Retries:
               scenario === "auth/scope-retry-limit" ? 3 : undefined,
@@ -212,7 +213,7 @@ async function main(): Promise<void> {
   }
 }
 
-main()
+runWithScenarioTimeout(process.env.MCP_CONFORMANCE_SCENARIO || "", main())
   .then(() => process.exit(0))
   .catch((err) => {
     console.error(err);

--- a/libraries/typescript/packages/client/examples/conformance/src/conformance-shared.ts
+++ b/libraries/typescript/packages/client/examples/conformance/src/conformance-shared.ts
@@ -53,6 +53,47 @@ export function isScopeStepUpScenario(scenario: string): boolean {
   );
 }
 
+/**
+ * Scenarios whose initial 401 carries the requested OAuth scope in
+ * WWW-Authenticate. They must let the retry fetch observe that response;
+ * pre-authenticating would lose the scope before the first MCP request.
+ */
+export function requiresOAuthRetryFetch(scenario: string): boolean {
+  return (
+    isScopeStepUpScenario(scenario) ||
+    scenario === "auth/scope-from-www-authenticate"
+  );
+}
+
+const CONFORMANCE_SCENARIO_TIMEOUT_MS = 45_000;
+
+/**
+ * Keep a broken fixture from consuming the workflow-level timeout. The process
+ * exits after this rejects, so a still-pending connection cannot keep CI alive.
+ */
+export async function runWithScenarioTimeout<T>(
+  scenario: string,
+  run: Promise<T>,
+  timeoutMs = CONFORMANCE_SCENARIO_TIMEOUT_MS
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(
+        new Error(
+          `Conformance scenario ${scenario || "unknown"} exceeded ${timeoutMs}ms`
+        )
+      );
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([run, timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 export async function handleElicitation(
   params: ElicitRequestFormParams | ElicitRequestURLParams
 ): Promise<ElicitResult> {


### PR DESCRIPTION
## Summary

- preserve OAuth scopes supplied by the initial `WWW-Authenticate` response in all conformance client fixtures
- route `auth/scope-from-www-authenticate` through the existing OAuth retry flow instead of pre-authenticating
- cap each fixture scenario at 45 seconds so an unresolved auth state fails fast rather than consuming the workflow's 20-minute job timeout

## Root cause

The scope-from-WWW-Authenticate fixture pre-authenticated before its first MCP request, losing the scoped 401 response. The React runner then remained unresolved in the auth lifecycle, while the conformance action had no subprocess deadline.

## Validation

- `pnpm --dir packages/client/examples/conformance typecheck`
- `auth/scope-from-www-authenticate` conformance scenario passed for the Node, browser, and React fixtures (16/16 checks each)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OAuth scope handling in conformance clients and caps each scenario at 45s to fail fast and avoid CI timeouts. `auth/scope-from-www-authenticate` now uses the OAuth retry flow so the client sees the scoped 401 and handles 403 step-up correctly.

- **Bug Fixes**
  - Preserve scopes from the initial `WWW-Authenticate` 401 by using the OAuth retry fetch for scope step-up and `auth/scope-from-www-authenticate`.
  - Route `auth/scope-from-www-authenticate` through the existing retry flow instead of pre-authenticating.
  - Add a 45s per-scenario timeout via `runWithScenarioTimeout` to prevent hanging runs across Node, browser, and React fixtures.

<sup>Written for commit 36f1dcde814121c0b27bfe48437adbae826094cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

