### PR TITLE
fix(agent): count Anthropic cache tokens and stop message_delta erasing usage

### DIFF
--- a/libraries/typescript/.changeset/anthropic-cache-usage-agent.md
+++ b/libraries/typescript/.changeset/anthropic-cache-usage-agent.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/agent": patch
+---
+
+Count Anthropic cache tokens in usage totals, and stop `message_delta` erasing the input and cache counters captured at `message_start`. Anthropic reports `cache_read_input_tokens` and `cache_creation_input_tokens` outside `input_tokens` and bills all of them, so a total of input plus output undercounts what the call cost. OpenAI's cached tokens sit inside `prompt_tokens`, so they are left alone.

--- a/libraries/typescript/.changeset/anthropic-cache-usage-inspector.md
+++ b/libraries/typescript/.changeset/anthropic-cache-usage-inspector.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Keep `cacheCreationInputTokens` visible in the inspector: it now survives aggregation, the LLM span usage, and the aggregate `tokenUsage` written to the raw-chat payload. The token total also no longer double-counts OpenAI cache reads. The fallback total adds only the Anthropic-shaped `cache_read_input_tokens`, since OpenAI's cached tokens are already inside `inputTokens`.

--- a/libraries/typescript/packages/agent/src/llm/__tests__/anthropic-usage-streaming.test.ts
+++ b/libraries/typescript/packages/agent/src/llm/__tests__/anthropic-usage-streaming.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+
+import { streamChat } from "../providers/anthropic.js";
+
+describe("Anthropic streamed usage", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps the message_start counters and bills the cache", async () => {
+    // The real event sequence. message_start carries the input side including both cache
+    // counters; message_delta carries output_tokens and nothing else.
+    const sse = [
+      {
+        type: "message_start",
+        message: {
+          usage: {
+            input_tokens: 3,
+            cache_read_input_tokens: 20000,
+            cache_creation_input_tokens: 1500,
+            output_tokens: 1,
+          },
+        },
+      },
+      { type: "message_delta", usage: { output_tokens: 120 } },
+      { type: "message_stop" },
+    ]
+      .map((event) => `data: ${JSON.stringify(event)}\n\n`)
+      .join("");
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(sse, {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const events = [];
+    for await (const event of streamChat({
+      config: {
+        provider: "anthropic",
+        model: "claude-test",
+        apiKey: "test-key",
+      },
+      messages: [{ role: "user", content: "hello" }],
+    })) {
+      events.push(event);
+    }
+
+    const usageEvent = events.find((e) => e.type === "usage");
+    expect(usageEvent).toBeDefined();
+    expect(usageEvent).toMatchObject({
+      type: "usage",
+      usage: {
+        inputTokens: 3,
+        cachedInputTokens: 20000,
+        cacheCreationInputTokens: 1500,
+        outputTokens: 120,
+        // 3 + 20000 + 1500 + 120. Before this change the input side was undefined by the
+        // time message_stop ran, and the total was 123.
+        totalTokens: 21623,
+      },
+    });
+  });
+});

--- a/libraries/typescript/packages/agent/src/llm/__tests__/usage.test.ts
+++ b/libraries/typescript/packages/agent/src/llm/__tests__/usage.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { tokenUsageFromRecord } from "../usage.js";
+import { mergeTokenUsage, tokenUsageFromRecord } from "../usage.js";
 
 describe("tokenUsageFromRecord", () => {
   it("maps exact counters from common provider shapes", () => {
@@ -33,5 +33,62 @@ describe("tokenUsageFromRecord", () => {
 
   it("does not fabricate usage when counters are absent", () => {
     expect(tokenUsageFromRecord({ duration_ms: 42 })).toBeUndefined();
+  });
+});
+
+describe("Anthropic cache counters", () => {
+  it("counts every billed input token in totalTokens", () => {
+    // Anthropic reports input_tokens NET of the cache and bills all three counters, so
+    // input_tokens + output_tokens is not what the call is charged on.
+    expect(
+      tokenUsageFromRecord({
+        input_tokens: 3,
+        cache_read_input_tokens: 20000,
+        cache_creation_input_tokens: 1500,
+        output_tokens: 120,
+      })
+    ).toMatchObject({
+      inputTokens: 3,
+      outputTokens: 120,
+      cachedInputTokens: 20000,
+      cacheCreationInputTokens: 1500,
+      totalTokens: 21623,
+    });
+  });
+
+  it("does not add OpenAI cached tokens, which are already inside prompt_tokens", () => {
+    expect(
+      tokenUsageFromRecord({
+        prompt_tokens: 10,
+        completion_tokens: 4,
+        input_tokens_details: { cached_tokens: 3 },
+      })
+    ).toMatchObject({ cachedInputTokens: 3, totalTokens: 14 });
+  });
+});
+
+describe("mergeTokenUsage", () => {
+  it("keeps counters that the later record does not mention", () => {
+    // Anthropic's streaming message_delta carries output_tokens only. A spread merge
+    // overwrote inputTokens and cachedInputTokens with undefined, because
+    // tokenUsageFromRecord returns every key and sets the absent ones to undefined.
+    const start = tokenUsageFromRecord({
+      input_tokens: 3,
+      cache_read_input_tokens: 20000,
+      output_tokens: 1,
+    });
+    const delta = tokenUsageFromRecord({ output_tokens: 500 });
+
+    expect(mergeTokenUsage(start, delta)).toMatchObject({
+      inputTokens: 3,
+      cachedInputTokens: 20000,
+      outputTokens: 500,
+    });
+  });
+
+  it("returns whichever side is present when the other is undefined", () => {
+    const only = tokenUsageFromRecord({ output_tokens: 7 });
+    expect(mergeTokenUsage(undefined, only)).toBe(only);
+    expect(mergeTokenUsage(only, undefined)).toBe(only);
   });
 });

--- a/libraries/typescript/packages/agent/src/llm/__tests__/usage.test.ts
+++ b/libraries/typescript/packages/agent/src/llm/__tests__/usage.test.ts
@@ -75,13 +75,17 @@ describe("mergeTokenUsage", () => {
     const start = tokenUsageFromRecord({
       input_tokens: 3,
       cache_read_input_tokens: 20000,
+      cache_creation_input_tokens: 1500,
       output_tokens: 1,
     });
     const delta = tokenUsageFromRecord({ output_tokens: 500 });
 
+    // Cache creation is billed above the base rate, so it has to survive the merge for the
+    // same reason cache reads do.
     expect(mergeTokenUsage(start, delta)).toMatchObject({
       inputTokens: 3,
       cachedInputTokens: 20000,
+      cacheCreationInputTokens: 1500,
       outputTokens: 500,
     });
   });

--- a/libraries/typescript/packages/agent/src/llm/providers/anthropic.ts
+++ b/libraries/typescript/packages/agent/src/llm/providers/anthropic.ts
@@ -210,18 +210,8 @@ export async function* streamChat(
         // and cache counters captured at `message_start` with `undefined`, because
         // `tokenUsageFromRecord` returns every key and sets absent ones to `undefined`.
         usage = mergeTokenUsage(usage, deltaUsage);
-        if (usage) {
-          // Anthropic reports the cache counters outside `input_tokens` and bills all of
-          // them, so the total is the sum of every billed component.
-          usage = {
-            ...usage,
-            totalTokens:
-              (usage.inputTokens ?? 0) +
-              (usage.cachedInputTokens ?? 0) +
-              (usage.cacheCreationInputTokens ?? 0) +
-              (usage.outputTokens ?? 0),
-          };
-        }
+        // The total is deliberately not recomputed here. `message_stop` owns it, so there
+        // is one place that knows how Anthropic bills rather than two that can drift.
       }
     } else if (t === "content_block_start") {
       const idx = parsed.index as number;
@@ -296,11 +286,19 @@ export async function* streamChat(
       }
     } else if (t === "message_stop") {
       if (usage) {
+        // Anthropic reports the cache counters alongside `input_tokens` and bills all of
+        // them, so input + output understates the call. `message_delta` revises
+        // `output_tokens` after `message_start` set a total, so the earlier total is stale
+        // by this point and is recomputed rather than trusted.
+        const billed =
+          (usage.inputTokens ?? 0) +
+          (usage.cachedInputTokens ?? 0) +
+          (usage.cacheCreationInputTokens ?? 0) +
+          (usage.outputTokens ?? 0);
         const totalTokens =
-          usage.totalTokens ??
-          (usage.inputTokens !== undefined && usage.outputTokens !== undefined
-            ? usage.inputTokens + usage.outputTokens
-            : undefined);
+          usage.inputTokens === undefined && usage.outputTokens === undefined
+            ? usage.totalTokens
+            : billed;
         yield { type: "usage", usage: { ...usage, totalTokens } };
       }
     } else if (t === "error") {

--- a/libraries/typescript/packages/agent/src/llm/providers/anthropic.ts
+++ b/libraries/typescript/packages/agent/src/llm/providers/anthropic.ts
@@ -8,7 +8,7 @@ import type {
   ProviderTool,
   TokenUsage,
 } from "../types.js";
-import { tokenUsageFromRecord } from "../usage.js";
+import { mergeTokenUsage, tokenUsageFromRecord } from "../usage.js";
 
 interface ChatParams {
   config: ProviderConfig;
@@ -205,7 +205,24 @@ export async function* streamChat(
       usage = tokenUsageFromRecord(parsed?.message?.usage);
     } else if (t === "message_delta") {
       const deltaUsage = tokenUsageFromRecord(parsed?.usage);
-      if (deltaUsage) usage = { ...usage, ...deltaUsage };
+      if (deltaUsage) {
+        // `message_delta` carries `output_tokens` only. A spread merge replaced the input
+        // and cache counters captured at `message_start` with `undefined`, because
+        // `tokenUsageFromRecord` returns every key and sets absent ones to `undefined`.
+        usage = mergeTokenUsage(usage, deltaUsage);
+        if (usage) {
+          // Anthropic reports the cache counters outside `input_tokens` and bills all of
+          // them, so the total is the sum of every billed component.
+          usage = {
+            ...usage,
+            totalTokens:
+              (usage.inputTokens ?? 0) +
+              (usage.cachedInputTokens ?? 0) +
+              (usage.cacheCreationInputTokens ?? 0) +
+              (usage.outputTokens ?? 0),
+          };
+        }
+      }
     } else if (t === "content_block_start") {
       const idx = parsed.index as number;
       const cb = parsed.content_block ?? {};

--- a/libraries/typescript/packages/agent/src/llm/types.ts
+++ b/libraries/typescript/packages/agent/src/llm/types.ts
@@ -114,6 +114,8 @@ export interface TokenUsage {
   totalTokens?: number;
   /** Input tokens served from a provider cache. */
   cachedInputTokens?: number;
+  /** Input tokens written to a provider cache. Billed, and on Anthropic above base rate. */
+  cacheCreationInputTokens?: number;
   /** Tokens used for model reasoning. */
   reasoningTokens?: number;
 }

--- a/libraries/typescript/packages/agent/src/llm/usage.ts
+++ b/libraries/typescript/packages/agent/src/llm/usage.ts
@@ -33,10 +33,23 @@ export function tokenUsageFromRecord(raw: unknown): TokenUsage | undefined {
     "candidatesTokenCount",
     "eval_count"
   );
+  // Anthropic reports cache counters ALONGSIDE input_tokens and bills all of them, so
+  // input_tokens alone is not what the call is charged on. OpenAI reports cached_tokens
+  // INSIDE prompt_tokens, so adding that one would double count. Only the Anthropic-shaped
+  // keys are summed here.
+  const cacheReadOutsideInput = numberAt(usage, "cache_read_input_tokens");
+  const cacheCreationInputTokens = numberAt(
+    usage,
+    "cacheCreationInputTokens",
+    "cache_creation_input_tokens"
+  );
+  const uncountedCache =
+    (cacheReadOutsideInput ?? 0) + (cacheCreationInputTokens ?? 0);
+
   const totalTokens =
     numberAt(usage, "totalTokens", "total_tokens", "totalTokenCount") ??
     (inputTokens !== undefined && outputTokens !== undefined
-      ? inputTokens + outputTokens
+      ? inputTokens + outputTokens + uncountedCache
       : undefined);
 
   const inputDetails =
@@ -60,6 +73,7 @@ export function tokenUsageFromRecord(raw: unknown): TokenUsage | undefined {
     outputTokens === undefined &&
     totalTokens === undefined &&
     cachedInputTokens === undefined &&
+    cacheCreationInputTokens === undefined &&
     reasoningTokens === undefined
   ) {
     return undefined;
@@ -70,6 +84,35 @@ export function tokenUsageFromRecord(raw: unknown): TokenUsage | undefined {
     outputTokens,
     totalTokens,
     cachedInputTokens,
+    cacheCreationInputTokens,
     reasoningTokens,
   };
+}
+
+/**
+ * Merge later counters over earlier ones without letting an absent field erase a present one.
+ *
+ * `tokenUsageFromRecord` returns every key and sets the ones it did not find to `undefined`,
+ * so a spread merge overwrites good values with `undefined`. Anthropic's streaming
+ * `message_delta` carries `output_tokens` only, which made a spread wipe the input and cache
+ * counters captured at `message_start`.
+ *
+ * This deliberately does not recompute `totalTokens`. Whether a cache counter is additive
+ * depends on the provider (Anthropic reports it outside `input_tokens`, OpenAI inside
+ * `prompt_tokens`), and that distinction is gone by the time usage has been normalised. The
+ * caller knows its provider and owns the total.
+ */
+export function mergeTokenUsage(
+  base: TokenUsage | undefined,
+  next: TokenUsage | undefined
+): TokenUsage | undefined {
+  if (!base) return next;
+  if (!next) return base;
+  const merged: TokenUsage = { ...base };
+  for (const [key, value] of Object.entries(next)) {
+    if (value !== undefined) {
+      (merged as Record<string, unknown>)[key] = value;
+    }
+  }
+  return merged;
 }

--- a/libraries/typescript/packages/inspector/src/client/components/chat/__tests__/trace.test.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/__tests__/trace.test.ts
@@ -93,6 +93,75 @@ describe("trace accumulator", () => {
     ).toBeLessThanOrEqual(121);
   });
 
+  it("adds Anthropic cache counters to the total but not OpenAI's", () => {
+    // Anthropic reports cache_read_input_tokens and cache_creation_input_tokens OUTSIDE
+    // input_tokens and bills all of them, so both are added back into the total.
+    expect(
+      inspectorTokenUsageFromUnknown({
+        input_tokens: 3,
+        cache_read_input_tokens: 20000,
+        cache_creation_input_tokens: 1500,
+        output_tokens: 120,
+      })
+    ).toEqual({
+      inputTokens: 3,
+      outputTokens: 120,
+      totalTokens: 21623,
+      cachedInputTokens: 20000,
+      cacheCreationInputTokens: 1500,
+      reasoningTokens: undefined,
+    });
+
+    // A normalized OpenAI record: cachedInputTokens is already inside inputTokens, so it
+    // must NOT be added again. Total is 10 + 4 = 14, not 17.
+    expect(
+      inspectorTokenUsageFromUnknown({
+        inputTokens: 10,
+        outputTokens: 4,
+        cachedInputTokens: 3,
+      })
+    ).toMatchObject({
+      inputTokens: 10,
+      outputTokens: 4,
+      totalTokens: 14,
+      cachedInputTokens: 3,
+    });
+  });
+
+  it("keeps cacheCreationInputTokens through aggregation and the LLM span", () => {
+    const events = [
+      event({ type: "request", request: { model: "test" } }, 1),
+      event(
+        {
+          type: "usage",
+          usage: {
+            inputTokens: 3,
+            outputTokens: 120,
+            totalTokens: 21623,
+            cachedInputTokens: 20000,
+            cacheCreationInputTokens: 1500,
+          },
+        },
+        2
+      ),
+      event(
+        {
+          type: "usage",
+          usage: { cacheCreationInputTokens: 500 },
+        },
+        3
+      ),
+      event({ type: "done" }, 4),
+    ];
+    const state = events.reduce(appendTraceEvent, EMPTY_TRACE_STATE);
+
+    // Survives in the aggregate state...
+    expect(state.usage?.cacheCreationInputTokens).toBe(2000);
+    // ...and on the LLM span's own usage.
+    const llmSpan = state.spans.find((span) => span.kind === "llm");
+    expect(llmSpan?.usage?.cacheCreationInputTokens).toBe(2000);
+  });
+
   it("redacts secrets without hiding token counts", () => {
     expect(
       redactSensitiveRequestFields({

--- a/libraries/typescript/packages/inspector/src/client/components/chat/trace.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/trace.ts
@@ -86,7 +86,10 @@ export function inspectorTokenUsageFromUnknown(
   // Anthropic reports these alongside input_tokens and bills all of them, so a total of
   // input + output understates what the call cost. OpenAI's cached_tokens sits inside
   // prompt_tokens, so only the Anthropic-shaped keys are added here.
-  const cachedInputTokens = number("cachedInputTokens", "cache_read_input_tokens");
+  const cachedInputTokens = number(
+    "cachedInputTokens",
+    "cache_read_input_tokens"
+  );
   const cacheCreationInputTokens = number(
     "cacheCreationInputTokens",
     "cache_creation_input_tokens"

--- a/libraries/typescript/packages/inspector/src/client/components/chat/trace.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/trace.ts
@@ -95,8 +95,14 @@ export function inspectorTokenUsageFromUnknown(
     "cache_creation_input_tokens"
   );
   const reasoningTokens = number("reasoningTokens", "thoughtsTokenCount");
+  // Only the Anthropic-shaped keys sit OUTSIDE inputTokens and must be added back into the
+  // total. cachedInputTokens is provider-neutral, and on OpenAI those tokens are already
+  // inside inputTokens, so adding it here would double count. It is still parsed above for
+  // observability; the total is computed from cache_read_input_tokens only, mirroring the
+  // provider-safe behaviour in agent/src/llm/usage.ts.
+  const cacheReadOutsideInput = number("cache_read_input_tokens");
   const uncountedCache =
-    (cachedInputTokens ?? 0) + (cacheCreationInputTokens ?? 0);
+    (cacheReadOutsideInput ?? 0) + (cacheCreationInputTokens ?? 0);
   const totalTokens =
     number("totalTokens", "total_tokens") ??
     (inputTokens !== undefined && outputTokens !== undefined
@@ -197,6 +203,10 @@ function addUsage(
     outputTokens: sum(current?.outputTokens, next.outputTokens),
     totalTokens: sum(current?.totalTokens, next.totalTokens),
     cachedInputTokens: sum(current?.cachedInputTokens, next.cachedInputTokens),
+    cacheCreationInputTokens: sum(
+      current?.cacheCreationInputTokens,
+      next.cacheCreationInputTokens
+    ),
     reasoningTokens: sum(current?.reasoningTokens, next.reasoningTokens),
   };
 }

--- a/libraries/typescript/packages/inspector/src/client/components/chat/trace.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/trace.ts
@@ -3,6 +3,7 @@ export interface InspectorTokenUsage {
   outputTokens?: number;
   totalTokens?: number;
   cachedInputTokens?: number;
+  cacheCreationInputTokens?: number;
   reasoningTokens?: number;
 }
 
@@ -82,19 +83,43 @@ export function inspectorTokenUsageFromUnknown(
     "output_tokens",
     "completionTokens"
   );
+  // Anthropic reports these alongside input_tokens and bills all of them, so a total of
+  // input + output understates what the call cost. OpenAI's cached_tokens sits inside
+  // prompt_tokens, so only the Anthropic-shaped keys are added here.
+  const cachedInputTokens = number("cachedInputTokens", "cache_read_input_tokens");
+  const cacheCreationInputTokens = number(
+    "cacheCreationInputTokens",
+    "cache_creation_input_tokens"
+  );
+  const reasoningTokens = number("reasoningTokens", "thoughtsTokenCount");
+  const uncountedCache =
+    (cachedInputTokens ?? 0) + (cacheCreationInputTokens ?? 0);
   const totalTokens =
     number("totalTokens", "total_tokens") ??
     (inputTokens !== undefined && outputTokens !== undefined
-      ? inputTokens + outputTokens
+      ? inputTokens + outputTokens + uncountedCache
       : undefined);
   if (
     inputTokens === undefined &&
     outputTokens === undefined &&
-    totalTokens === undefined
+    totalTokens === undefined &&
+    cachedInputTokens === undefined &&
+    cacheCreationInputTokens === undefined &&
+    reasoningTokens === undefined
   ) {
     return undefined;
   }
-  return { inputTokens, outputTokens, totalTokens };
+  // cachedInputTokens and reasoningTokens were declared on InspectorTokenUsage and read by
+  // the trace view, but this function never returned them, so both have always rendered as
+  // absent no matter what the provider sent.
+  return {
+    inputTokens,
+    outputTokens,
+    totalTokens,
+    cachedInputTokens,
+    cacheCreationInputTokens,
+    reasoningTokens,
+  };
 }
 
 const SECRET_REQUEST_KEYS = new Set([


### PR DESCRIPTION
Two token counting bugs on the Anthropic path. Both are silent: the number comes out wrong and nothing raises.

### 1. `totalTokens` leaves out the cache counters

Anthropic reports `input_tokens` net of the prompt cache, and bills `cache_read_input_tokens` and `cache_creation_input_tokens` on top of it. It never sends `total_tokens`, so the computed branch in `tokenUsageFromRecord` is always the one that runs.

```
input_tokens 3  +  cache_read 20,000  +  cache_creation 1,500  +  output 120
main reports totalTokens: 123      actual billed: 21,623
```

`cache_creation_input_tokens` was not read anywhere in the repository, so cache writes were invisible, and Anthropic bills those above the base rate.

OpenAI is the opposite shape: its `cached_tokens` sits *inside* `prompt_tokens`, so adding it would double count. Only the Anthropic-shaped keys are summed, and there is a test pinning the OpenAI case at 14 so this cannot regress into a double count.

### 2. `message_delta` erased the counters from `message_start`

`tokenUsageFromRecord` returns every key and sets the ones it did not find to `undefined`. Anthropic's streaming `message_delta` carries `output_tokens` only, so:

```js
usage = { ...usage, ...deltaUsage }
```

overwrote `inputTokens` and `cachedInputTokens` with `undefined`.

```
after message_start : {"inputTokens":3,"outputTokens":1,"totalTokens":4,"cachedInputTokens":20000}
after message_delta : {"outputTokens":500}
```

After any streamed call the entire input side of the accounting was gone.

`mergeTokenUsage` merges only defined values. It deliberately does not recompute `totalTokens`: whether a cache counter is additive is a provider question, and that information is gone once usage has been normalised, so the caller owns the total. `streamChat` in the Anthropic provider does that sum itself, where the semantics are known.

### Tests

Added to `src/llm/__tests__/usage.test.ts`. **Three of them fail on `main`**, the fourth is the OpenAI regression guard and passes on both. The two existing assertions in that file still pass unchanged.

Happy to split this into two PRs if you would rather review them separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Anthropic token accounting across `agent` and `inspector`. Totals now include cache read/write tokens, streaming keeps prior counters, and the inspector aggregates cache writes while avoiding OpenAI double-counts.

- **Bug Fixes**
  - Count Anthropic `cache_read_input_tokens` and `cache_creation_input_tokens` in totals (and trace); add `cacheCreationInputTokens` to `TokenUsage`; OpenAI unaffected.
  - Streaming: use `mergeTokenUsage` so `message_delta` doesn’t erase inputs; recompute the billed total once at `message_stop` to avoid drift.
  - `inspector`: aggregate `cacheCreationInputTokens` across events and the LLM span; compute the fallback total by adding only Anthropic-shaped cache counters, not OpenAI’s `cached_tokens`; surface `cachedInputTokens`, `cacheCreationInputTokens`, and `reasoningTokens`.

- **Refactors**
  - Prettier formatting in `inspector` trace to satisfy lint; no behavior change.

<sup>Written for commit db1daa19f1e65dd8d84bcf0f1132dc2c18e5ad7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

