### PR TITLE
fix(conformance): preserve OAuth metadata paths

### DIFF
--- a/libraries/typescript/packages/client/examples/conformance/src/conformance-client-browser.ts
+++ b/libraries/typescript/packages/client/examples/conformance/src/conformance-client-browser.ts
@@ -7,6 +7,7 @@ import { MCPClient } from "@mcp-use/client";
 import {
   handleElicitation,
   isAuthScenario,
+  isLegacyOAuthMetadataScenario,
   parseConformanceContext,
   requiresOAuthRetryFetch,
   runScenario,
@@ -54,12 +55,14 @@ async function main(): Promise<void> {
     } else {
       const authResult = await auth(authProvider, {
         serverUrl,
+        skipIssuerMetadataValidation: isLegacyOAuthMetadataScenario(scenario),
       });
       if (authResult === "REDIRECT") {
         const authCode = await authProvider.getAuthorizationCode();
         await auth(authProvider, {
           serverUrl,
           authorizationCode: authCode,
+          skipIssuerMetadataValidation: isLegacyOAuthMetadataScenario(scenario),
         });
       }
     }

--- a/libraries/typescript/packages/client/examples/conformance/src/conformance-client-node.ts
+++ b/libraries/typescript/packages/client/examples/conformance/src/conformance-client-node.ts
@@ -7,6 +7,7 @@ import { MCPClient } from "@mcp-use/client";
 import {
   handleElicitation,
   isAuthScenario,
+  isLegacyOAuthMetadataScenario,
   parseConformanceContext,
   requiresOAuthRetryFetch,
   runScenario,
@@ -51,12 +52,14 @@ async function main(): Promise<void> {
       // Pre-authenticate for other auth scenarios
       const authResult = await auth(authProvider, {
         serverUrl,
+        skipIssuerMetadataValidation: isLegacyOAuthMetadataScenario(scenario),
       });
       if (authResult === "REDIRECT") {
         const authCode = await authProvider.getAuthorizationCode();
         await auth(authProvider, {
           serverUrl,
           authorizationCode: authCode,
+          skipIssuerMetadataValidation: isLegacyOAuthMetadataScenario(scenario),
         });
       }
     }

--- a/libraries/typescript/packages/client/examples/conformance/src/conformance-client-react.ts
+++ b/libraries/typescript/packages/client/examples/conformance/src/conformance-client-react.ts
@@ -8,11 +8,13 @@
 
 import React, { useEffect, useRef } from "react";
 import { JSDOM } from "jsdom";
+import { auth } from "@modelcontextprotocol/client";
 import { McpClientProvider, useMcpClient } from "@mcp-use/client/react";
 import TestRenderer, { act } from "react-test-renderer";
 import {
   handleElicitation,
   isAuthScenario,
+  isLegacyOAuthMetadataScenario,
   parseConformanceContext,
   requiresOAuthRetryFetch,
   runScenario,
@@ -152,6 +154,19 @@ async function main(): Promise<void> {
         preRegistrationContext: parseConformanceContext(),
       })
     : undefined;
+  if (authProvider && isLegacyOAuthMetadataScenario(scenario)) {
+    const authResult = await auth(authProvider, {
+      serverUrl,
+      skipIssuerMetadataValidation: true,
+    });
+    if (authResult === "REDIRECT") {
+      await auth(authProvider, {
+        serverUrl,
+        authorizationCode: await authProvider.getAuthorizationCode(),
+        skipIssuerMetadataValidation: true,
+      });
+    }
+  }
   // The retry fetch sees scopes carried by the initial WWW-Authenticate response
   // and handles later 403 scope escalation without pre-authentication.
   const mcpServers: Record<string, any> = {

--- a/libraries/typescript/packages/client/examples/conformance/src/conformance-shared.ts
+++ b/libraries/typescript/packages/client/examples/conformance/src/conformance-shared.ts
@@ -61,8 +61,16 @@ export function isScopeStepUpScenario(scenario: string): boolean {
 export function requiresOAuthRetryFetch(scenario: string): boolean {
   return (
     isScopeStepUpScenario(scenario) ||
-    scenario === "auth/scope-from-www-authenticate"
+    scenario === "auth/scope-from-www-authenticate" ||
+    // This scenario only advertises its non-standard PRM endpoint in the
+    // initial challenge. Discovering before the first MCP request loses the
+    // tenant-qualified authorization-server URL and falls back to /register.
+    scenario === "auth/metadata-var3"
   );
+}
+
+export function isLegacyOAuthMetadataScenario(scenario: string): boolean {
+  return scenario === "auth/2025-03-26-oauth-metadata-backcompat";
 }
 
 const CONFORMANCE_SCENARIO_TIMEOUT_MS = 45_000;

--- a/libraries/typescript/packages/client/examples/conformance/src/oauth-retry-fetch.ts
+++ b/libraries/typescript/packages/client/examples/conformance/src/oauth-retry-fetch.ts
@@ -13,6 +13,8 @@ import {
 export type OAuthRetryFetchOptions = {
   /** Max number of 403 retries (for auth/scope-retry-limit). Omit for scope-step-up. */
   max403Retries?: number;
+  /** Accept legacy authorization metadata whose issuer is path-qualified. */
+  skipIssuerMetadataValidation?: boolean;
 };
 
 type AuthProviderWithCode = OAuthClientProvider & {
@@ -28,12 +30,14 @@ async function runAuthFlow(
   provider: AuthProviderWithCode,
   serverUrl: string | URL,
   resourceMetadataUrl: URL | undefined,
-  scope: string | undefined
+  scope: string | undefined,
+  skipIssuerMetadataValidation = false
 ): Promise<void> {
   const authResult = await auth(provider, {
     serverUrl: typeof serverUrl === "string" ? serverUrl : serverUrl.toString(),
     resourceMetadataUrl,
     scope,
+    skipIssuerMetadataValidation,
   });
   if (authResult === "REDIRECT") {
     const authCode = await provider.getAuthorizationCode();
@@ -42,6 +46,7 @@ async function runAuthFlow(
         typeof serverUrl === "string" ? serverUrl : serverUrl.toString(),
       resourceMetadataUrl,
       scope,
+      skipIssuerMetadataValidation,
       authorizationCode: authCode,
     });
   }
@@ -57,7 +62,7 @@ export function createOAuthRetryFetch(
   authProvider: AuthProviderWithCode,
   options: OAuthRetryFetchOptions = {}
 ): typeof fetch {
-  const { max403Retries } = options;
+  const { max403Retries, skipIssuerMetadataValidation } = options;
 
   return async function oauthRetryFetch(
     input: RequestInfo | URL,
@@ -114,7 +119,13 @@ export function createOAuthRetryFetch(
       const { resourceMetadataUrl, scope } =
         extractWWWAuthenticateParams(response);
 
-      await runAuthFlow(authProvider, serverUrl, resourceMetadataUrl, scope);
+      await runAuthFlow(
+        authProvider,
+        serverUrl,
+        resourceMetadataUrl,
+        scope,
+        skipIssuerMetadataValidation
+      );
 
       const tokens = await authProvider.tokens();
       const accessToken = tokens?.access_token;

--- a/libraries/typescript/packages/server/examples/conformance/src/index.ts
+++ b/libraries/typescript/packages/server/examples/conformance/src/index.ts
@@ -530,7 +530,7 @@ let subscribableResourceValue = "Initial value";
 server.resource(
   {
     name: "subscribable_resource",
-    uri: "test://subscribable",
+    uri: "test://watched-resource",
     title: "Subscribable Resource",
     description: "A resource that supports subscriptions and can be updated",
     mimeType: "text/plain",
@@ -556,7 +556,7 @@ server.tool(
   },
   async ({ newValue }) => {
     subscribableResourceValue = newValue;
-    await server.notifyResourceUpdated("test://subscribable");
+    await server.notifyResourceUpdated("test://watched-resource");
     return {
       content: [{ type: "text", text: `Resource updated to: ${newValue}` }],
     };


### PR DESCRIPTION
## Summary

- let `auth/metadata-var3` obtain its custom protected-resource metadata from the initial OAuth challenge, preserving the tenant-qualified registration path
- accept the legacy issuer shape required by `auth/2025-03-26-oauth-metadata-backcompat` across Node, browser, and React fixtures
- align the subscribable resource URI with the conformance scenario

## Validation

- `pnpm build`
- fixture typechecks (client and server)
- official conformance: Node + browser `auth/metadata-var3`; Node + React `auth/2025-03-26-oauth-metadata-backcompat` (all passed)

Companion action fix: mcp-use/mcp-conformance-action PR will make reported conformance failures fail CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves path-qualified OAuth metadata from the initial challenge and adds legacy issuer support across Node, browser, and React conformance clients. Also updates the subscribable resource URI to match the scenario.

- **Bug Fixes**
  - Use initial WWW-Authenticate metadata for `auth/metadata-var3` via retry-fetch to keep tenant-qualified registration paths; updates `requiresOAuthRetryFetch`.
  - Add `skipIssuerMetadataValidation` to the OAuth retry flow and apply it for `auth/2025-03-26-oauth-metadata-backcompat` in Node, browser, and React; React pre-authenticates for this case.
  - Align resource URI to `test://watched-resource` and update notifications.

<sup>Written for commit 874b04d7adfb0e878cc031fcba902c908048bdae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

