### PR TITLE
ci: schedule SDK agentic evals

### DIFF
--- a/.github/workflows/sdk-evals-synthesis.yml
+++ b/.github/workflows/sdk-evals-synthesis.yml
@@ -1,0 +1,150 @@
+name: SDK eval weekly synthesis
+
+on:
+  schedule:
+    # Sunday 13:00 UTC, after the week's final Friday eval batch.
+    - cron: "0 13 * * 0"
+  workflow_dispatch:
+    inputs:
+      days:
+        description: "Window size in days"
+        required: false
+        type: string
+        default: "7"
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  synthesize:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check credentials
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          set -euo pipefail
+          [ -n "$OPENAI_API_KEY" ] || { echo "::error::OPENAI_API_KEY is required for GPT-5.6 Sol synthesis."; exit 1; }
+
+      - name: Check out the evaluator
+        uses: actions/checkout@v4
+        with:
+          repository: mcp-use/mcp-use-evals
+          ref: main
+          path: evaluator
+
+      - name: Download recent evaluation artifacts
+        uses: actions/github-script@v7
+        env:
+          DAYS: ${{ github.event.inputs.days || '7' }}
+        with:
+          script: |
+            const fs = require("fs");
+            const path = require("path");
+            const days = Number(process.env.DAYS);
+            if (!Number.isFinite(days) || days <= 0) {
+              core.setFailed(`Invalid window size: ${process.env.DAYS}`);
+              return;
+            }
+
+            // Fetch the current and preceding windows so synthesis can
+            // calculate week-over-week comparisons.
+            const since = new Date(Date.now() - days * 2 * 86_400_000);
+            const runs = await github.paginate(
+              github.rest.actions.listWorkflowRuns,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: "sdk-evals.yml",
+                status: "completed",
+                created: `>=${since.toISOString().slice(0, 10)}`,
+                per_page: 100,
+              }
+            );
+
+            const outDir = path.join(process.env.GITHUB_WORKSPACE, "eval-artifacts");
+            fs.mkdirSync(outDir, { recursive: true });
+            let downloaded = 0;
+
+            for (const run of runs) {
+              const artifacts = await github.paginate(
+                github.rest.actions.listWorkflowRunArtifacts,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  run_id: run.id,
+                  per_page: 100,
+                }
+              );
+
+              for (const artifact of artifacts) {
+                if (artifact.expired || !artifact.name.startsWith("sdk-evals-")) {
+                  continue;
+                }
+                const archive = await github.rest.actions.downloadArtifact({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  artifact_id: artifact.id,
+                  archive_format: "zip",
+                });
+                fs.writeFileSync(
+                  path.join(outDir, `${artifact.id}-${artifact.name}.zip`),
+                  Buffer.from(archive.data)
+                );
+                downloaded += 1;
+              }
+            }
+
+            core.info(`Downloaded ${downloaded} evaluation artifact(s) from ${runs.length} completed workflow run(s).`);
+            if (downloaded === 0) {
+              core.setFailed("No unexpired SDK evaluation artifacts were found for the synthesis windows.");
+            }
+
+      - name: Assemble evaluator result history
+        run: |
+          set -euo pipefail
+          mkdir -p synthesis-input/runs
+          for archive in eval-artifacts/*.zip; do
+            artifact="$(basename "$archive" .zip)"
+            extracted="$(mktemp -d)"
+            unzip -q "$archive" -d "$extracted"
+            while IFS= read -r -d '' manifest; do
+              run_dir="$(dirname "$manifest")"
+              run_name="$(basename "$run_dir")"
+              cp -R "$run_dir" "synthesis-input/runs/${artifact}--${run_name}"
+            done < <(find "$extracted" -name run.json -print0)
+          done
+          count="$(find synthesis-input/runs -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')"
+          [ "$count" -gt 0 ] || { echo "::error::Downloaded artifacts contained no run.json files."; exit 1; }
+          echo "Assembled $count evaluator run(s)."
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Install evaluator dependencies
+        working-directory: evaluator
+        run: corepack prepare --activate "$(node -p "require('./package.json').packageManager")" && pnpm install --frozen-lockfile
+
+      - name: Run GPT-5.6 Sol synthesis
+        working-directory: evaluator
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          pnpm synthesize \
+            --days "${{ github.event.inputs.days || '7' }}" \
+            --results-dir ../synthesis-input/runs \
+            --model gpt-5.6-sol
+
+      - name: Upload synthesis report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdk-eval-synthesis-${{ github.run_id }}
+          path: evaluator/results/synthesis/*.md
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/sdk-evals.yml
+++ b/.github/workflows/sdk-evals.yml
@@ -1,0 +1,88 @@
+name: SDK agentic evals
+
+on:
+  schedule:
+    # Mon/Wed/Fri 14:00 UTC
+    - cron: "0 14 * * 1,3,5"
+  workflow_dispatch:
+    inputs:
+      tasks:
+        description: "Comma-separated task ids (blank = all)"
+        required: false
+        type: string
+      trials:
+        description: "Fresh trials per task"
+        required: false
+        type: string
+        default: "1"
+
+permissions:
+  contents: read
+
+jobs:
+  eval:
+    name: eval (Codex · ${{ matrix.task }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        task:
+          - v2-01-basic-tool-server
+          - v2-02-stateful-ticket-queue
+          - v2-03-docs-lookup-server
+          - v2-06-project-board-composition
+          - v2-07-debug-inventory-server
+          - v2-08-openapi-order-service
+          - v2-09-raw-input-required-approval
+          - v2-10-multi-view-incident-console
+          - v2-11-middleware-protected-audit
+    steps:
+      - name: Check credentials and task selection
+        id: gate
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          REQUESTED_TASKS: ${{ github.event.inputs.tasks }}
+        run: |
+          set -euo pipefail
+          if [ -z "$OPENAI_API_KEY" ]; then
+            echo "::error::OPENAI_API_KEY is required for the Codex agent and GPT judge."
+            exit 1
+          fi
+          if [ -n "$REQUESTED_TASKS" ]; then
+            IFS=',' read -ra TASKS <<< "$REQUESTED_TASKS"
+            for task in "${TASKS[@]}"; do
+              task="${task#"${task%%[![:space:]]*}"}"
+              task="${task%"${task##*[![:space:]]}"}"
+              if [ "$task" = "${{ matrix.task }}" ]; then
+                echo "run=true" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            done
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "run=true" >> "$GITHUB_OUTPUT"
+
+      - name: Run evaluator
+        id: eval
+        if: steps.gate.outputs.run == 'true'
+        uses: mcp-use/mcp-use-evals@main
+        timeout-minutes: 150
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          agent: codex
+          tasks: ${{ matrix.task }}
+          conditions: noskill+blank
+          trials: ${{ github.event.inputs.trials || '1' }}
+          batch-id: ${{ github.run_id }}-${{ github.run_attempt }}
+
+      - name: Upload evaluation result
+        if: always() && steps.gate.outputs.run == 'true' && steps.eval.outputs.run-dir != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdk-evals-${{ matrix.task }}-${{ github.run_id }}
+          path: |
+            ${{ steps.eval.outputs.run-dir }}
+            !${{ steps.eval.outputs.run-dir }}/**/workspace/**
+          retention-days: 30


### PR DESCRIPTION
## Terms

- **Task:** one fixed evaluation assignment from the v2 suite. A task defines the prompt, starting inputs, and deterministic contract checks used to decide whether the result passes.
- **Scenario:** the configuration under which a task is attempted. This workflow uses only `noskill+blank`: Codex receives no task-specific skill and starts from the blank scaffold.
- **Trial:** one fresh, independent attempt to complete one task in one scenario.

## Tasks

| Task | What it tests |
| --- | --- |
| `v2-01-basic-tool-server` | The SDK happy path: creating a single typed tool, serving it over streamable HTTP, and honoring the configured `PORT`. |
| `v2-02-stateful-ticket-queue` | Shared in-memory state across four CRUD tools, including sequenced lifecycle calls, count reporting, and the required “not found” error behavior. |
| `v2-03-docs-lookup-server` | A read-only documentation server with an index resource, parameterized per-slug resource reads, and search over seeded content. |
| `v2-06-project-board-composition` | Composition of tools and live resources over shared state; after a tool mutates the project board, a subsequent resource read must reflect that change. |
| `v2-07-debug-inventory-server` | Diagnosing and repairing an existing behaviorally broken inventory server supplied as a starter project. |
| `v2-08-openapi-order-service` | Generating the required order-service tool surface from a bundled OpenAPI document and connecting it to a local upstream service. |
| `v2-09-raw-input-required-approval` | Implementing a multi-round deployment approval flow using only the SDK’s raw `input_required` helpers. |
| `v2-10-multi-view-incident-console` | Building and serving two independently bound MCP Apps views, including listing and reading the views and calling their associated tools. |
| `v2-11-middleware-protected-audit` | Protocol-level authorization middleware, correct error results for unauthorized access, and an audit resource updated after protected tool calls. |

## How it works

This PR adds two scheduled workflows for the v2 SDK eval suite.

### Evaluation runs (Monday, Wednesday, and Friday)

At 14:00 UTC on Monday, Wednesday, and Friday, `.github/workflows/sdk-evals.yml` fans out one job per task and runs `mcp-use/mcp-use-evals@main` with:

- the Codex agent
- the `noskill+blank` scenario
- every task listed above
- one fresh trial per task

Each trial is contract-graded by the harness, and the per-trial judge writes an evidence-backed memo. Each task job uploads its complete evaluator run directory as a GitHub Actions artifact, excluding only `workspace/**` snapshots. The artifact includes `run.json`, `report.md`, transcripts, and judge memos and is retained for 30 days.

Nothing from an evaluation run is committed to the repository or to a results branch.

The workflow can also be dispatched manually with a comma-separated task subset and a trial-count override.

### Weekly synthesis (Sunday)

At 13:00 UTC on Sunday, `.github/workflows/sdk-evals-synthesis.yml`:

1. finds completed evaluation workflow runs covering the current and immediately preceding seven-day windows
2. downloads every unexpired `sdk-evals-*` artifact from those runs
3. assembles their evaluator run directories
4. runs the harness's GPT-5.6 Sol synthesis over the current seven-day window, with the preceding window available for comparison
5. uploads the generated Markdown report as a GitHub Actions artifact retained for 30 days

The downloaded artifacts give the weekly job access to the complete transcripts and judge outputs retained by the evaluation workflow. The current synthesis command computes statistics from `run.json` and builds its qualitative report from the per-trial judge memos.

For this initial rollout, the report is not committed or posted automatically. It is available only as a workflow artifact for manual review. Linear or Slack delivery can be added after the report format and findings are proven useful.

## Configuration

- `OPENAI_API_KEY` is required for evaluation, per-trial judging, and weekly synthesis.
- The weekly workflow needs read access to Actions artifacts.
- A manual workflow dispatch should be used to verify the repository secret, published action path, artifact discovery, and synthesis output before relying on the schedule.
