### PR TITLE
Skip default skills for the blank template

### DIFF
--- a/libraries/typescript/.changeset/blank-template-no-skills.md
+++ b/libraries/typescript/.changeset/blank-template-no-skills.md
@@ -1,0 +1,5 @@
+---
+"create-mcp-use-app": patch
+---
+
+Default the blank template to skip installing skills unless explicitly requested.

--- a/libraries/typescript/packages/create-mcp-use-app/src/index.ts
+++ b/libraries/typescript/packages/create-mcp-use-app/src/index.ts
@@ -946,7 +946,7 @@ async function main(): Promise<void> {
       install = false;
     }
     if (skills === undefined) {
-      skills = true;
+      skills = validatedTemplate !== "blank";
     }
   } else if (!interactive) {
     if (install === undefined) {


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

Check all that apply:

* [x] TypeScript
* [ ] Python
* [ ] Documentation only
* [ ] CI/CD or tooling

## Changes

This PR updates the default behavior for the `blank` template in `create-mcp-use-app`.

Previously, when creating a project with `--template blank`, skills were installed by default if neither `--skills` nor `--no-skills` was provided. With this change, the blank template no longer installs skills by default.

The behavior for all other templates remains unchanged, and the `--skills` and `--no-skills` flags continue to work as expected.

## Review Readiness

* [x] The PR is scoped to one issue or one clearly related change
* [x] The PR description explains the user-visible problem and the fix
* [x] The diff avoids unrelated formatting, generated files, and bulk rewrites
* [x] I verified the affected package/docs path with the commands listed below
* [x] I checked for existing open PRs that already solve the same issue

## Implementation Details

* Updated the default value assigned to `skills` when a template is explicitly provided.
* The default now depends on the selected template:

  * `blank` → skills are disabled by default.
  * All other templates → existing default behavior is preserved.
* Explicit `--skills` and `--no-skills` flags continue to override the default.
* Interactive mode is unchanged.

---

## TypeScript Checklist

### Packages Modified

Check all packages that were modified:

* [ ] `docs`
* [ ] `tests`
* [ ] `cli`
* [x] `create-mcp-use-app`
* [ ] `mcp-use` (server)
* [ ] `mcp-use` (client)
* [ ] `inspector`

### Pre-commit Checklist

* [x] Ran `pnpm lint:fix` (via the pre-commit hook)
* [x] Ran `pnpm format` (via the pre-commit hook)
* [x] Ran `pnpm --filter create-mcp-use-app build` and verified it completed successfully
* [x] Ran `pnpm changeset` and added a changeset
* [ ] Added or updated tests if needed
* [ ] Updated documentation in the `docs/` folder if needed

---

## Python Checklist

Not applicable.

---

## Example Usage (Before)

```bash
create-mcp-use-app my-app --template blank
```

Result:

* Skills were installed by default.

## Example Usage (After)

```bash
create-mcp-use-app my-app --template blank
```

Result:

* Skills are no longer installed by default.

To install skills explicitly:

```bash
create-mcp-use-app my-app --template blank --skills
```

---

## Documentation Updates

No documentation updates were required.

## Testing

* Ran:

  ```bash
  pnpm --filter create-mcp-use-app test
  ```

  Result: **24 tests passed**.

* Ran:

  ```bash
  pnpm --filter create-mcp-use-app build
  ```

  Result: Build completed successfully.

* Verified that the blank template no longer installs skills by default.

* Verified that explicitly passing `--skills` still enables skill installation.

## Backwards Compatibility

This change is backwards compatible.

It only changes the default behavior for the `blank` template when neither `--skills` nor `--no-skills` is provided. Existing behavior for all other templates and explicit CLI flags remains unchanged.

## Related Issues

Closes #2082


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip installing skills by default when using the `blank` template in `create-mcp-use-app`, so blank projects stay minimal. Other templates are unchanged; passing `--skills` or `--no-skills` still overrides the default, and interactive mode is unchanged.

<sup>Written for commit e071cd80c288828467cefab2e178793f92fa6265. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

