### PR TITLE
docs: repoint examples README at the v2 example directories

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -60,33 +60,33 @@ When you clone this repository locally, you'll find `python/` and `typescript/` 
 
 ### Client Examples
 - **[Node HTTP Client](../libraries/typescript/packages/mcp-use/examples/client/node/full-features-example.ts)** - Node/HTTP client with tool calls, sampling, elicitation, notifications
-- **[CommonJS Example](../libraries/typescript/packages/mcp-use/examples/client/browser/commonjs/commonjs_example.cjs)** - CommonJS usage
-- **[CLI Examples](../libraries/typescript/packages/mcp-use/examples/client/cli/)** - Command-line interface examples
-- **[React Integration](../libraries/typescript/packages/mcp-use/examples/client/browser/react/)** - React client examples
-- **[Notifications Client](../libraries/typescript/packages/mcp-use/examples/client/node/communication/notification-client.ts)** - Notification handling
-- **[Sampling Client](../libraries/typescript/packages/mcp-use/examples/client/node/communication/sampling-client.ts)** - Sampling configuration
+- **[CommonJS Example](../libraries/typescript/packages/client/examples/browser/commonjs/commonjs_example.cjs)** - CommonJS usage
+- **[CLI Examples](../libraries/typescript/packages/client/examples/cli/)** - Command-line interface examples
+- **[React Integration](../libraries/typescript/packages/client/examples/browser/react/)** - React client examples
+- **[Notifications Client](../libraries/typescript/packages/client/examples/node/communication/notification-client.ts)** - Notification handling
+- **[Sampling Client](../libraries/typescript/packages/client/examples/node/communication/sampling-client.ts)** - Sampling configuration
 
 ### Server Examples
-- **[Basic Server](../libraries/typescript/packages/mcp-use/examples/server/basic/simple/)** - Simple server implementation
-- **[Server Features](../libraries/typescript/packages/mcp-use/examples/server/features/)** - Advanced features
+- **[Basic Server](../libraries/typescript/packages/server/examples/basic/)** - Simple server implementation
+- **[Server Features](../libraries/typescript/packages/server/examples/)** - Advanced features
   - [Everything](../libraries/typescript/packages/mcp-use/examples/server/features/everything/) - All MCP primitives in one server
-  - [Conformance](../libraries/typescript/packages/mcp-use/examples/server/features/conformance/) - MCP conformance test server
-  - [Elicitation](../libraries/typescript/packages/mcp-use/examples/server/features/elicitation/) - Form and URL elicitation
-  - [Sampling](../libraries/typescript/packages/mcp-use/examples/server/features/sampling/) - Server-initiated LLM sampling
-  - [Notifications](../libraries/typescript/packages/mcp-use/examples/server/features/notifications/) - Bidirectional notifications
+  - [Conformance](../libraries/typescript/packages/server/examples/conformance/) - MCP conformance test server
+  - [Elicitation](../libraries/typescript/packages/server/examples/elicitation/) - Form and URL elicitation
+  - [Sampling](../libraries/typescript/packages/server/examples/sampling/) - Server-initiated LLM sampling
+  - [Notifications](../libraries/typescript/packages/server/examples/notifications/) - Bidirectional notifications
   - [Completion](../libraries/typescript/packages/mcp-use/examples/server/features/completion/) - Autocomplete for prompt args
   - [Streaming Props](../libraries/typescript/packages/mcp-use/examples/server/features/streaming-props/) - Stream tool props to widgets
-  - [Middleware](../libraries/typescript/packages/mcp-use/examples/server/features/middleware/) - Built-in middleware pipeline
+  - [Middleware](../libraries/typescript/packages/server/examples/middleware/) - Built-in middleware pipeline
   - [Express Middleware](../libraries/typescript/packages/mcp-use/examples/server/features/express-middleware/) - Express/Hono integration
   - [Session Management](../libraries/typescript/packages/mcp-use/examples/server/features/session-management/) - Memory, filesystem, Redis storage
-  - [Proxy](../libraries/typescript/packages/mcp-use/examples/server/features/proxy/) - Proxy MCP server
+  - [Proxy](../libraries/typescript/packages/server/examples/proxy/) - Proxy MCP server
   - [Client Info](../libraries/typescript/packages/mcp-use/examples/server/features/client-info/) - Access client capabilities
   - [DNS Rebinding](../libraries/typescript/packages/mcp-use/examples/server/features/dns-rebinding/) - DNS rebinding protection
-- **[OAuth Examples](../libraries/typescript/packages/mcp-use/examples/server/oauth/)** - OAuth implementations
-  - [Auth0](../libraries/typescript/packages/mcp-use/examples/server/oauth/auth0/)
+- **[OAuth Examples](../libraries/typescript/packages/server/examples/auth/)** - OAuth implementations
+  - [Auth0](../libraries/typescript/packages/server/examples/auth/auth0/)
   - [Better Auth (v2 + Hono)](../libraries/typescript/packages/server/examples/auth/better-auth/)
-  - [Supabase](../libraries/typescript/packages/mcp-use/examples/server/oauth/supabase/)
-  - [WorkOS](../libraries/typescript/packages/mcp-use/examples/server/oauth/workos/)
+  - [Supabase](../libraries/typescript/packages/server/examples/auth/supabase/)
+  - [WorkOS](../libraries/typescript/packages/server/examples/auth/workos/)
 - **[Deployment](../libraries/typescript/packages/mcp-use/examples/server/deployment/)** - Deployment examples
 - **[MCP Apps view examples](../libraries/typescript/packages/server/examples/views/)** — current `view` API and React hooks
   - **[Basic](../libraries/typescript/packages/server/examples/views/basic/)** - Typed tool output, view tools, host context, and display modes


### PR DESCRIPTION
## Changes

The v2 merge deleted `libraries/typescript/packages/mcp-use`, and `examples/README.md` still links into it. Of its 86 relative links, 26 are dead. This fixes the 17 that have an exact home in the v2 tree and deliberately leaves the other 9 alone.

Follow-up to #2114, where I flagged this file and said I would rather ask than guess on the ambiguous half. This is the half that needs no decision.

## The mapping

Three mechanical moves, nothing renamed by judgement:

| From | To |
| --- | --- |
| `packages/mcp-use/examples/client/…` | `packages/client/examples/…` |
| `packages/mcp-use/examples/server/features/<x>/` | `packages/server/examples/<x>/` |
| `packages/mcp-use/examples/server/oauth/<x>/` | `packages/server/examples/auth/<x>/` |

Every target was resolved against the tracked tree before editing, so none of these are guesses. Two are a rename rather than a pure move, and I want to name them explicitly rather than bury them:

* `server/basic/simple/` to `server/examples/basic/` — v2 dropped the `simple` nesting.
* `server/features/` (the parent bullet, "Advanced features") to `server/examples/` — v2 has no `features/` grouping, the examples sit at the root.

Veto either of those on its own if you would rather they read differently.

The file already contained correct v2 paths for Better Auth, the views examples and the agent examples, so this brings the rest into line with what was already there.

## What I left broken, and why

These 9 have no v2 counterpart, so fixing them means either deleting the entry or pointing it somewhere approximate. That is a content call, not a repoint:

```
client/node/full-features-example.ts
server/features/everything/
server/features/completion/
server/features/streaming-props/
server/features/express-middleware/
server/features/session-management/
server/features/client-info/
server/features/dns-rebinding/
server/deployment/
```

Two I specifically did not want to guess at:

* `completion` looks like it maps to `resource-template-configuration`… except v2's example is `resource-template-completion`, which is completion for resource template arguments, while this bullet says "Autocomplete for prompt args". Different feature, so I left it.
* `dns-rebinding` might be covered by v2's `security` example, but I have not verified that it demonstrates the same protection, so I did not point at it on a hunch.

Tell me whether you want the survivors repointed to the nearest v2 example or the entries dropped, and I will send that as a second small PR.

## Verification

Resolved every relative link in the file against the tracked tree, before and after:

```
before:  total ../ links: 86   broken: 26
after:   total ../ links: 86   broken: 9
```

The 9 remaining are exactly the list above, so nothing was missed and nothing else moved. `ci-preflight` exit 0.

## Backwards Compatibility

Documentation only. No source, build, or published artifact changes.

## Related

Follow-up to #2114.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix broken links in `examples/README.md` after the v2 restructure. Repointed 17 links to `packages/client/examples` and `packages/server/examples`; left 9 without v2 equivalents unchanged.

- **Bug Fixes**
  - Mapped client links from `packages/mcp-use/examples/client/...` to `packages/client/examples/...`.
  - Mapped server links by dropping `features/` to `packages/server/examples/...`; moved `basic/simple/` to `examples/basic/`; renamed `oauth/` to `auth/`.
  - Verified updated links resolve; 9 ambiguous entries remain for follow-up.

<sup>Written for commit 6b524351985eeff51af29dbb2bc9063761d653e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

