### PR TITLE
fix: point context7 at the v2 example directories

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -21,7 +21,8 @@
     "docs/tunneling",
     "examples",
     "libraries/python/examples",
-    "libraries/typescript/packages/mcp-use/examples"
+    "libraries/typescript/packages/client/examples",
+    "libraries/typescript/packages/server/examples"
   ],
   "excludeFolders": [
     "docs/snippets",
@@ -29,7 +30,7 @@
     "docs/home/redirects",
     "docs/typescript/changelog",
     "docs/python/changelog",
-    "libraries/typescript/packages/mcp-use/examples/client/conformance",
+    "libraries/typescript/packages/client/examples/conformance",
     "**/dist",
     "**/build",
     "**/coverage",


### PR DESCRIPTION
## Changes

`context7.json` still indexes `libraries/typescript/packages/mcp-use/examples`, which the v2 merge deleted. Context7 therefore serves no TypeScript examples for this repo at all.

```
$ git ls-files libraries/typescript/packages/mcp-use/examples | wc -l
0
```

v2 split those examples across two packages, so the single `folders` entry becomes two, and the `excludeFolders` entry for the conformance client moves with them.

```diff
   "folders": [
     ...
-    "libraries/typescript/packages/mcp-use/examples"
+    "libraries/typescript/packages/client/examples",
+    "libraries/typescript/packages/server/examples"
   ],
   "excludeFolders": [
     ...
-    "libraries/typescript/packages/mcp-use/examples/client/conformance",
+    "libraries/typescript/packages/client/examples/conformance",
```

## Why it matters

This file is what Context7 uses to build the docs it serves to coding agents asking about mcp-use. A dead path is not a broken link a reader notices; it silently drops the whole TypeScript examples corpus from that index, so agents get the docs tree without any of the runnable examples.

## Verification

All three new paths exist on `main`, and the old one does not:

```
EXISTS  libraries/typescript/packages/client/examples
EXISTS  libraries/typescript/packages/server/examples
EXISTS  libraries/typescript/packages/client/examples/conformance
GONE    libraries/typescript/packages/mcp-use/examples
```

The file still parses as JSON (`json.load` clean), and no reference to the deleted package remains in it. `ci-preflight` exit 0.

I kept this to repointing dead paths. I did not touch the `rules` block, though it still tells agents to import from `mcp-use/server` and `mcp-use/react`, which is worth a separate look now that v2 has `@mcp-use/client` and the server package owns `mcp-use`. Happy to send that separately if you want it updated, but it is a content call about how you want agents steered rather than a broken path.

## Backwards Compatibility

Configuration for an external docs indexer. No source, build, or published artifact changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Context7 indexing by pointing TypeScript example paths to the v2 directories, restoring the examples in the docs. Updates folder entries and the conformance exclusion in `context7.json`.

- **Bug Fixes**
  - Replaced `libraries/typescript/packages/mcp-use/examples` with `libraries/typescript/packages/client/examples` and `libraries/typescript/packages/server/examples`.
  - Updated exclusion to `libraries/typescript/packages/client/examples/conformance`.

<sup>Written for commit 0df877e281daa9f3f221d3e83a89a42b0b0ce940. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

