### PR TITLE
fix(inspector): block loopback proxy targets by default

### DIFF
--- a/libraries/typescript/.changeset/inspector-proxy-loopback-default.md
+++ b/libraries/typescript/.changeset/inspector-proxy-loopback-default.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Block loopback proxy targets by default. `mountInspector` now defaults `oauthProxyAllowLoopback` to `false` (previously `true`), so a publicly reachable embedded/hosted Inspector no longer proxies requests to the host's loopback services (SSRF). The standalone CLI keeps allowing loopback for local development, but defaults to blocking it when `NODE_ENV=production` (which the published Docker image sets); set `INSPECTOR_ALLOW_LOOPBACK=true` to override either way.

--- a/libraries/typescript/packages/inspector/src/server/cli.ts
+++ b/libraries/typescript/packages/inspector/src/server/cli.ts
@@ -85,10 +85,19 @@ app.use(
     exposeHeaders: ["*"],
   })
 );
+// The CLI is primarily local dev tooling, where proxying to localhost MCP
+// servers is the main use case — but the published Docker image runs this same
+// CLI with NODE_ENV=production on a public port, where loopback proxying is
+// SSRF into the container's own services. Allow loopback outside production;
+// INSPECTOR_ALLOW_LOOPBACK overrides either way.
+const allowLoopback = process.env.INSPECTOR_ALLOW_LOOPBACK
+  ? process.env.INSPECTOR_ALLOW_LOOPBACK === "true"
+  : process.env.NODE_ENV !== "production";
+
 registerInspectorProxyRoutes(app, {
   autoConnectUrl: mcpUrl,
   oauthProxyAllowedOrigins: [],
-  oauthProxyAllowLoopback: true,
+  oauthProxyAllowLoopback: allowLoopback,
 });
 
 registerInspectorShell(app, {

--- a/libraries/typescript/packages/inspector/src/server/middleware.ts
+++ b/libraries/typescript/packages/inspector/src/server/middleware.ts
@@ -126,9 +126,10 @@ function registerInspectorRoutes(
 ): void {
   const routesConfig: InspectorProxyRoutesConfig = {
     oauthProxyAllowedOrigins: options?.oauthProxyAllowedOrigins ?? [],
-    // mountInspector is development tooling. Loopback is therefore useful and
-    // safe by default, while callers embedding it elsewhere can opt out.
-    oauthProxyAllowLoopback: options?.oauthProxyAllowLoopback ?? true,
+    // A mounted inspector can end up publicly reachable (hosted deployments),
+    // where loopback proxying is SSRF into the host's own services. Default to
+    // blocking loopback; local dev tooling opts in explicitly.
+    oauthProxyAllowLoopback: options?.oauthProxyAllowLoopback ?? false,
   };
   if (options?.autoConnectUrl !== undefined) {
     routesConfig.autoConnectUrl = options.autoConnectUrl;

--- a/libraries/typescript/packages/inspector/tests/unit/mount-inspector.test.ts
+++ b/libraries/typescript/packages/inspector/tests/unit/mount-inspector.test.ts
@@ -88,6 +88,34 @@ describe("mountInspector", () => {
     }
   });
 
+  it("blocks loopback proxy targets by default and allows them on explicit opt-in", async () => {
+    const secure = mountInspector({ basePath: "" });
+    const blocked = await secure(
+      new Request("http://localhost/inspector/api/proxy", {
+        method: "POST",
+        headers: { "X-Target-URL": "http://127.0.0.1:8080/" },
+      })
+    );
+    expect(blocked.status).toBe(403);
+    expect(await blocked.json()).toMatchObject({
+      error: "Invalid target URL",
+    });
+
+    // Explicit opt-in (local dev tooling): the request proceeds to the fetch
+    // layer and fails to connect (port 1 refuses) instead of being rejected.
+    const permissive = mountInspector({
+      basePath: "",
+      oauthProxyAllowLoopback: true,
+    });
+    const attempted = await permissive(
+      new Request("http://localhost/inspector/api/proxy", {
+        method: "POST",
+        headers: { "X-Target-URL": "http://127.0.0.1:1/" },
+      })
+    );
+    expect(attempted.status).not.toBe(403);
+  });
+
   it("can still register routes directly on a Hono app", async () => {
     const app = new Hono();
     app.get("/application", (c) => c.text("application route"));
@@ -164,7 +192,8 @@ describe("mountInspector", () => {
 
   it("keeps the Express adapter scoped to Inspector routes", async () => {
     const app = express();
-    mountInspector(app, { basePath: "/mcp" });
+    // Loopback opt-in: this test proxies to its own 127.0.0.1 echo server.
+    mountInspector(app, { basePath: "/mcp", oauthProxyAllowLoopback: true });
     app.get("/application", (_req, res) => res.send("application route"));
     app.post("/echo", express.text({ type: "*/*" }), (_req, res) =>
       res.type("text/plain").send("through-express")


### PR DESCRIPTION
## Summary

Security audit finding (confirmed live against the hosted dev inspector): the Inspector MCP proxy blocks RFC1918, CGNAT, link-local/metadata, `.internal` hosts, and IP-encoding bypasses — but **loopback was allowed**, because:

1. `mountInspector` defaulted `oauthProxyAllowLoopback` to `true` (`?? true`), and
2. the standalone CLI hardcoded `true` — and the published **Docker image runs the CLI with `NODE_ENV=production` on a public port**.

Reproduced on the dev deployment: `GET /inspector/api/proxy` with `X-Target-URL: http://127.0.0.1:8080/` returned the inspector's own UI through the unauthenticated public proxy.

## Fix

- `mountInspector`: default is now `false`; embedders doing local dev opt in explicitly.
- CLI: allows loopback only when `NODE_ENV !== "production"`; `INSPECTOR_ALLOW_LOOPBACK=true/false` overrides either way. Local `npx mcp-inspect` usage (inspecting localhost MCP servers) is unchanged; the Docker/hosted path flips to safe.
- Changeset included (patch).

## Test plan

- [x] New regression test: default mount rejects `http://127.0.0.1:8080/` with 403; explicit opt-in proceeds to the fetch layer
- [x] Existing Express-adapter test updated to opt in (it proxies to its own 127.0.0.1 echo server)
- [x] Full inspector unit suite: 38/38 pass; server typecheck clean
- [ ] After the hosted inspector picks this up: `curl -H 'X-Target-URL: http://127.0.0.1:8080/' https://inspector.dev.manufact.com/inspector/api/proxy` → expect 403

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Block loopback proxy targets (localhost/127.0.0.1) in the Inspector by default to prevent SSRF. `mountInspector` now defaults `oauthProxyAllowLoopback` to false; the CLI only allows loopback outside production, overridable via `INSPECTOR_ALLOW_LOOPBACK`.

- **Bug Fixes**
  - Default block in middleware (`oauthProxyAllowLoopback: false`); CLI uses `NODE_ENV !== "production"` with `INSPECTOR_ALLOW_LOOPBACK` override.
  - Added regression test; updated Express adapter test to opt in.

- **Migration**
  - Embedders needing localhost during dev: call `mountInspector({ oauthProxyAllowLoopback: true })`.
  - Docker/hosted CLI: no change needed for safety; to allow, set `INSPECTOR_ALLOW_LOOPBACK=true`.

<sup>Written for commit 50be50618b3014dd5cbc0af72e43ca56130d4e2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

