### PR TITLE
fix: keep prerelease versioning visible to Knip

### DIFF
--- a/.github/workflows/typescript-release.yml
+++ b/.github/workflows/typescript-release.yml
@@ -298,7 +298,7 @@ jobs:
 
           # Version packages
           echo "Versioning packages..."
-          node scripts/version-packages.mjs
+          pnpm version:exit-prerelease
 
           # changeset version updates workspace dependency metadata. Refresh the
           # lockfile now so the release PR is reproducible and main remains clean.

--- a/libraries/typescript/knip.json
+++ b/libraries/typescript/knip.json
@@ -13,6 +13,7 @@
   ],
   "workspaces": {
     ".": {
+      "entry": ["scripts/version-packages.mjs"],
       "project": ["*.{js,ts}"]
     },
     "packages/server": {

--- a/libraries/typescript/package.json
+++ b/libraries/typescript/package.json
@@ -35,6 +35,7 @@
     "prepare": "cd ../.. && husky libraries/typescript/.husky",
     "changeset": "changeset",
     "version": "changeset version && pnpm install --no-frozen-lockfile",
+    "version:exit-prerelease": "node scripts/version-packages.mjs",
     "release": "pnpm build && changeset publish",
     "version:check": "changeset status",
     "verify:release-install": "node scripts/verify-release-install.mjs",


### PR DESCRIPTION
## Summary

- expose the retained exit-prerelease versioning script through a purpose-specific package command
- call that package command from the stable release workflow
- register the script as a root Knip entry point

## Why

The preceding beta-release cleanup removes the beta scripts and tests that previously made `scripts/version-packages.mjs` reachable to Knip. The script is still required when main exits prerelease mode, so Knip incorrectly reports its `semver` dependency as unused unless the real entry point is declared.

## Impact

This clears the blocking Knip dependency finding without suppressing it or removing the stable exit-prerelease normalization.

## Validation

- `pnpm exec knip --no-progress` — exits 0; existing export/type warnings remain warning-only
- Prettier check for the modified files
- `git diff --check`

## Stack

Depends on #2141.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the prerelease versioning script visible to `knip` and standardize how it’s run in the TypeScript release workflow. Prevents false “unused” reports and keeps prerelease versioning working during releases.

- **Bug Fixes**
  - Added `entry: ["scripts/version-packages.mjs"]` to `libraries/typescript/knip.json` so `knip` tracks the script.
  - Added `version:exit-prerelease` script in `libraries/typescript/package.json` and switched the release workflow to call `pnpm version:exit-prerelease` instead of running the Node script directly.

<sup>Written for commit a92df93bb3797d199a2e948145122428c9e5ae84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

