### PR TITLE
docs: the v1 compatibility bridge no longer exists in v2

### DIFF
--- a/docs/v2/typescript/server/migration.mdx
+++ b/docs/v2/typescript/server/migration.mdx
@@ -551,25 +551,26 @@ explicit domain handle. Do not key business state to an MCP transport session.
 - Raw `uiResource`, `@mcp-ui/server` adapters, `exposeAsTool`, and a shared View
   bound to multiple server tools have no native equivalent.
 
-## Use the compatibility bridge only for staging
+## The compatibility bridge is gone
 
-Existing servers can temporarily keep:
+Earlier v2 betas shipped a deprecated `mcp-use/server` export that kept common
+v1 shapes working while you migrated. That bridge was removed before v2 became
+stable, along with the legacy v1 server facade, so the import no longer
+resolves:
 
 ```typescript
+// No longer available. mcp-use has no "server" subpath in v2.
 import { MCPServer, text } from "mcp-use/server";
 ```
 
-The deprecated bridge supports common v1 tools, resources, prompts, middleware,
-direct built-in OAuth providers, OpenAPI servers, response helpers, and one
-tool per legacy widget.
+Import from the package root instead:
 
-The bridge does not provide sessions, sampling, post-response or
-session-targeted notifications, blocking elicitation, OAuth proxying, stdio
-proxying, raw UI resources, array-style schemas, unsigned-token bypasses, or a
-widget shared by multiple bound tools.
+```typescript
+import { MCPServer, text } from "mcp-use";
+```
 
-Treat every bridge import as unfinished migration work. The bridge is planned
-for removal in mcp-use v3.
+There is no staged path onto v2. Every v1 import has to move before the server
+will start.
 
 ## Verify the migration
 
@@ -602,9 +603,8 @@ for removal in mcp-use v3.
   </Step>
   <Step title="Remove v1 leftovers">
     Remove remaining v1 imports, helpers, widget files, session APIs, sampling
-    calls, stdio proxy configuration, and old security fields. Keep a
-    `mcp-use/server` import only when you intentionally use the temporary
-    compatibility bridge.
+    calls, stdio proxy configuration, and old security fields. No
+    `mcp-use/server` import can stay: that subpath does not exist in v2.
   </Step>
 </Steps>
 

--- a/docs/v2/typescript/server/migration.mdx
+++ b/docs/v2/typescript/server/migration.mdx
@@ -551,27 +551,6 @@ explicit domain handle. Do not key business state to an MCP transport session.
 - Raw `uiResource`, `@mcp-ui/server` adapters, `exposeAsTool`, and a shared View
   bound to multiple server tools have no native equivalent.
 
-## The compatibility bridge is gone
-
-Earlier v2 betas shipped a deprecated `mcp-use/server` export that kept common
-v1 shapes working while you migrated. That bridge was removed before v2 became
-stable, along with the legacy v1 server facade, so the import no longer
-resolves:
-
-```typescript
-// No longer available. mcp-use has no "server" subpath in v2.
-import { MCPServer, text } from "mcp-use/server";
-```
-
-Import from the package root instead:
-
-```typescript
-import { MCPServer, text } from "mcp-use";
-```
-
-There is no staged path onto v2. Every v1 import has to move before the server
-will start.
-
 ## Verify the migration
 
 <Steps>


### PR DESCRIPTION
## Changes

`docs/v2/typescript/server/migration.mdx` has a section titled **"Use the compatibility bridge only for staging"** telling people they can keep this while migrating:

```typescript
import { MCPServer, text } from "mcp-use/server";
```

That export was removed before v2 went stable, so the import does not resolve. A user following the guide hits a resolution error on the one step the guide presents as the safe, incremental option.

## Evidence

The package has no `server` subpath. Full `exports` map on `main`:

```
.            ./react      ./vite-client   ./landing
./oauth      ./oauth/clerk  ./oauth/auth0  ./oauth/workos
./oauth/supabase  ./oauth/keycloak  ./oauth/better-auth
./node       ./next
```

And the removal is recorded in the package changelog:

```
$ git show origin/main:libraries/typescript/packages/server/CHANGELOG.md | grep -n "mcp-use/server"
151:  - Add deprecated `mcp-use/server` export backed by the native stateless v2 server …
258:  - Remove the `mcp-use/server` export and legacy v1 server facade.
```

So the bridge was added during the beta and then deliberately removed. The guide still describes it as present, and even says it is "planned for removal in mcp-use v3", which is now two versions out of date.

## What changed

1. The staging section now says the bridge is gone, shows the import that no longer works and the package-root import that does, and states plainly that there is no staged path onto v2.
2. The "Remove v1 leftovers" step no longer carves out an exception for keeping a `mcp-use/server` import.

I deliberately left line 104 alone:

```typescript
// v1
import { MCPServer, text } from "mcp-use/server";
```

That one is a labelled before/after contrast, so it is correct as written.

## Verification

- `mcp-use` root exports `MCPServer` (`packages/server/src/index.ts:8`), and the entry contract in `CLI_SPEC.md` uses `import { MCPServer } from "mcp-use"`, so the replacement import is the documented one.
- `grep -rn "compatibility bridge" docs/v2` returns only this file, so no other page repeats the claim.
- `ci-preflight` exit 0.

## Backwards Compatibility

Documentation only. No source, build, or published artifact changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the obsolete v1 compatibility bridge section from the v2 migration guide to avoid advising a non-existent `mcp-use/server` import and prevent broken migrations.

- **Bug Fixes**
  - Dropped the "Use the compatibility bridge only for staging" section.
  - Updated the cleanup step to state that `mcp-use/server` does not exist in v2 and must be removed.

<sup>Written for commit 45e2e07e977ec05b615cfc887b3331fb2313017e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

