### PR TITLE
fix: stop context7 telling agents to import from mcp-use/server

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -58,7 +58,7 @@
     "For views, prefer the MCP Apps flow using useToolContext, useViewState, useCallTool, useFiles, and ModelContext from mcp-use/react.",
     "For server examples, prefer MCPServer tools, resources, prompts, response helpers, OAuth providers, middleware, session management, Inspector, and deployment docs.",
     "Every tool should set explicit annotations readOnlyHint, openWorldHint, and destructiveHint; add outputSchema when returning structured content or widget props.",
-    "Import server APIs from mcp-use/server and React hooks/components from mcp-use/react; avoid internal package paths unless docs explicitly require them.",
+    "Import server APIs from the mcp-use package root and React hooks/components from mcp-use/react; there is no mcp-use/server subpath in v2. Avoid internal package paths unless docs explicitly require them.",
     "For new TypeScript MCP servers or apps, scaffold with npx create-mcp-use-app instead of hand-rolling MCPServer boilerplate, package.json, or widget build setup.",
     "Tool handlers should use Zod schemas with describe fields and return response helpers such as text(), object(), widget(), and error() instead of raw objects or thrown errors.",
     "Views should use useToolContext<Name>() and branch on pending, ready, or error before reading structured output.",


### PR DESCRIPTION
## Changes

The `rules` block in `context7.json` tells coding agents:

> Import server APIs from `mcp-use/server` and React hooks/components from `mcp-use/react`

`mcp-use/react` is correct. `mcp-use/server` is not: that subpath was removed before v2 went stable, so an agent following this rule emits an import that fails to resolve.

This is the follow-up I offered in #2133, where I fixed the dead example paths in the same file and flagged the rules block as a separate content call.

## Evidence

No `server` subpath in the package's `exports`:

```
.            ./react      ./vite-client   ./landing
./oauth      ./oauth/clerk  ./oauth/auth0  ./oauth/workos
./oauth/supabase  ./oauth/keycloak  ./oauth/better-auth
./node       ./next
```

Removal is in the changelog:

```
258:  - Remove the `mcp-use/server` export and legacy v1 server facade.
```

And the root export is what the docs actually use:

```
libraries/typescript/packages/server/src/index.ts:8:export { MCPServer } from "./server.js";
specs/CLI_SPEC.md:  import { MCPServer } from "mcp-use";
```

## Wording

```diff
-"Import server APIs from mcp-use/server and React hooks/components from mcp-use/react; avoid internal package paths unless docs explicitly require them."
+"Import server APIs from the mcp-use package root and React hooks/components from mcp-use/react; there is no mcp-use/server subpath in v2. Avoid internal package paths unless docs explicitly require them."
```

I said the subpath is gone rather than only naming the right one on purpose. This rule is competing with a large amount of v1 example code that models have already been trained on, so a plain negative is worth the extra clause. Trim it if you would rather keep the rules terse.

## Verification

- File still parses as JSON.
- No `mcp-use/server` reference remains in `context7.json`.
- `ci-preflight` exit 0.

## Related

`docs/v2/typescript/server/migration.mdx` has the same problem in prose, telling migrating users they can stage on `mcp-use/server`. That is #2145, kept separate since it is user-facing docs rather than agent-index config.

## Backwards Compatibility

Configuration for an external docs indexer. No source, build, or published artifact changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update context7 rule to import server APIs from `mcp-use` (package root) instead of the removed `mcp-use/server`. This stops agents from emitting broken imports in v2.

<sup>Written for commit d38bc730fad479e316e8256f4098c612f5ddc56b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

