### PR TITLE
fix(server): support MCP v2 prompt and schema results

### DIFF
--- a/libraries/typescript/.changeset/calm-owls-prompt.md
+++ b/libraries/typescript/.changeset/calm-owls-prompt.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Fix MCP v2 server responses by preserving tool JSON Schema dialects and accepting input-required prompt results.

--- a/libraries/typescript/packages/server/src/prompts.ts
+++ b/libraries/typescript/packages/server/src/prompts.ts
@@ -1,6 +1,7 @@
 import type {
   CallToolResult,
   GetPromptResult,
+  InputRequiredResult,
   StandardSchemaWithJSON,
 } from "@modelcontextprotocol/server";
 import type { Env } from "hono";
@@ -32,6 +33,7 @@ export type InferPromptInput<T> = T extends {
 
 /**
  * Prompt execution callback. Prefer the SDK's raw {@link GetPromptResult}.
+ * Interactive prompts may return an {@link InputRequiredResult}.
  *
  * Deprecated response helpers that return a {@link CallToolResult} are still
  * accepted and converted at registration time.
@@ -56,4 +58,5 @@ export type PromptCallback<
 ) =>
   | GetPromptResult
   | CallToolResult
-  | Promise<GetPromptResult | CallToolResult>;
+  | InputRequiredResult
+  | Promise<GetPromptResult | CallToolResult | InputRequiredResult>;

--- a/libraries/typescript/packages/server/src/response-conversion.ts
+++ b/libraries/typescript/packages/server/src/response-conversion.ts
@@ -3,10 +3,12 @@ import type {
   CallToolResult,
   ContentBlock,
   GetPromptResult,
+  InputRequiredResult,
   PromptMessage,
   ReadResourceResult,
   TextResourceContents,
 } from "@modelcontextprotocol/server";
+import { isInputRequiredResult } from "@modelcontextprotocol/server";
 
 type ResourceContentsEntry = TextResourceContents | BlobResourceContents;
 
@@ -120,19 +122,20 @@ function contentBlockToResourceContents(
 }
 
 /**
- * Convert a helper/`CallToolResult` (or pass through a raw prompt result) to
- * {@link GetPromptResult}.
+ * Convert a helper/`CallToolResult` (or pass through a raw prompt or
+ * input-required result) to the prompt handler result.
  *
  * Each tool {@link ContentBlock} becomes a `user` {@link PromptMessage}
  * (prompt messages already accept the same content-block union).
  *
- * @param result - Tool-shaped or prompt result from a prompt callback.
- * @returns Official prompt get envelope.
+ * @param result - Tool-shaped, prompt, or input-required result from a
+ * prompt callback.
+ * @returns Official completed or input-required prompt envelope.
  */
 export function toPromptResult(
-  result: CallToolResult | GetPromptResult
-): GetPromptResult {
-  if (isGetPromptResult(result)) {
+  result: CallToolResult | GetPromptResult | InputRequiredResult
+): GetPromptResult | InputRequiredResult {
+  if (isInputRequiredResult(result) || isGetPromptResult(result)) {
     return result;
   }
 

--- a/libraries/typescript/packages/server/src/server.ts
+++ b/libraries/typescript/packages/server/src/server.ts
@@ -277,33 +277,6 @@ export interface ListenOptions {
   host?: string;
 }
 
-function omitRootSchemaDialect<T>(schema: T): T {
-  if (
-    typeof schema !== "object" ||
-    schema === null ||
-    Array.isArray(schema) ||
-    !("$schema" in schema)
-  ) {
-    return schema;
-  }
-
-  const emittedSchema = { ...schema } as T & Record<string, unknown>;
-  delete emittedSchema["$schema"];
-  return emittedSchema;
-}
-
-function omitToolSchemaDialects(
-  tools: McpMiddlewareResult<"tools/list">
-): McpMiddlewareResult<"tools/list"> {
-  return tools.map((tool) => ({
-    ...tool,
-    inputSchema: omitRootSchemaDialect(tool.inputSchema),
-    ...(tool.outputSchema === undefined
-      ? {}
-      : { outputSchema: omitRootSchemaDialect(tool.outputSchema) }),
-  }));
-}
-
 function registerFetchMiddleware<TEnv extends Env>(
   app: Hono<TEnv>,
   middleware: FetchMiddleware
@@ -1850,7 +1823,9 @@ export class MCPServer<TUser = never, TEnv extends Env = Env> {
       handlers.set(method, wrapped);
     };
 
-    wrapListMethod("tools/list", "tools", omitToolSchemaDialects);
+    // JSON Schema's root `$schema` declaration selects the dialect used for
+    // validation. Do not normalize it away from a tool descriptor.
+    wrapListMethod("tools/list", "tools");
     wrapListMethod("resources/list", "resources");
     wrapListMethod("prompts/list", "prompts");
   }

--- a/libraries/typescript/packages/server/tests/mcp-server.test.ts
+++ b/libraries/typescript/packages/server/tests/mcp-server.test.ts
@@ -57,6 +57,7 @@ const echoInput: StandardSchemaWithJSON<
     },
     jsonSchema: {
       input: () => ({
+        $schema: "https://json-schema.org/draft/2020-12/schema",
         type: "object",
         properties: {
           message: { type: "string", description: "Text to echo back" },
@@ -214,7 +215,7 @@ function buildServer(): MCPServer {
           "python",
           "typescript",
           "go",
-        ]),
+        ]).optional(),
         code: z.string().describe("The code to review"),
       }),
     },
@@ -346,6 +347,7 @@ describe("MCPServer (phase 1, e2e over HTTP)", () => {
     const echo = tools.find((t) => t.name === "echo");
     // inputSchema advertised via the schema's own ~standard.jsonSchema converter.
     expect(echo?.inputSchema).toMatchObject({
+      $schema: "https://json-schema.org/draft/2020-12/schema",
       type: "object",
       required: ["message"],
       properties: {

--- a/libraries/typescript/packages/server/tests/middleware.e2e.test.ts
+++ b/libraries/typescript/packages/server/tests/middleware.e2e.test.ts
@@ -302,7 +302,7 @@ describe("MCP middleware — result validation", () => {
 });
 
 describe("MCP middleware — tool schema emission", () => {
-  it("strips root schema dialects introduced by tools/list middleware", async () => {
+  it("preserves root schema dialects introduced by tools/list middleware", async () => {
     const server = new MCPServer({
       name: "schema-emission-test-server",
       version: "1.0.0",
@@ -346,8 +346,8 @@ describe("MCP middleware — tool schema emission", () => {
       const result = await client.listTools();
       const tool = result.tools.find(({ name }) => name === "typed-echo");
       expect(tool).toBeDefined();
-      expect(tool?.inputSchema).not.toHaveProperty("$schema");
-      expect(tool?.outputSchema).not.toHaveProperty("$schema");
+      expect(tool?.inputSchema).toHaveProperty("$schema", draft07);
+      expect(tool?.outputSchema).toHaveProperty("$schema", draft07);
     } finally {
       await client.close();
       await server.close();

--- a/libraries/typescript/packages/server/tests/response-helpers.test.ts
+++ b/libraries/typescript/packages/server/tests/response-helpers.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { inputRequired } from "@modelcontextprotocol/server";
 
 import {
   toPromptResult,
@@ -158,6 +159,21 @@ describe("toPromptResult", () => {
         },
       ],
     };
+    expect(toPromptResult(raw)).toBe(raw);
+  });
+
+  it("passes through InputRequiredResult", () => {
+    const raw = inputRequired({
+      inputRequests: {
+        follow_up: inputRequired.createMessage({
+          messages: [
+            { role: "user", content: { type: "text", text: "Need more?" } },
+          ],
+          maxTokens: 32,
+        }),
+      },
+    });
+
     expect(toPromptResult(raw)).toBe(raw);
   });
 

--- a/libraries/typescript/packages/server/tests/type-level.test.ts
+++ b/libraries/typescript/packages/server/tests/type-level.test.ts
@@ -693,3 +693,25 @@ describe("deprecated helper returns on resource/prompt callbacks", () => {
     expect(server).toBeDefined();
   });
 });
+
+describe("prompt input_required return-position checks", () => {
+  it("accepts InputRequiredResult from a prompt callback", () => {
+    const server = new MCPServer({ name: "types", version: "0.0.0" });
+    server.prompt({ name: "interactive-prompt" }, async () =>
+      inputRequired({
+        inputRequests: {
+          follow_up: inputRequired.createMessage({
+            messages: [
+              {
+                role: "user",
+                content: { type: "text", text: "Need more context" },
+              },
+            ],
+            maxTokens: 32,
+          }),
+        },
+      })
+    );
+    expect(server).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

- preserve root JSON Schema `$schema` declarations in `tools/list`
- allow prompt callbacks to return MCP `InputRequiredResult`
- pass prompt input-required results through response conversion unchanged
- add runtime, middleware, and type-level regression coverage

## Why

The MCP 2026-07-28 protocol exercises JSON Schema dialect selection and multi-round input from non-tool requests. The server previously removed the root schema dialect and narrowed prompt callbacks to completed prompt/tool-shaped results.

## Impact

Tool schemas now retain their declared JSON Schema dialect, and interactive prompts can request additional client input using the same input-required protocol supported by tools.

## Validation

- `pnpm --filter mcp-use build`
- focused server Vitest suite: 100 tests passed
- server conformance validation on the complete stack: 40 scenarios, 114 checks passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds MCP v2 support for prompts and tool schemas: prompt handlers can return `InputRequiredResult`, and `tools/list` preserves root JSON Schema `$schema` dialects. This enables interactive prompts and keeps validation aligned with each tool’s declared dialect.

- **New Features**
  - Prompt callbacks can return `InputRequiredResult`; response conversion passes these through unchanged.

- **Bug Fixes**
  - `tools/list` preserves root `$schema` on `inputSchema` and `outputSchema` so each tool’s JSON Schema dialect is retained.

<sup>Written for commit d20a5344756f3428b4ec39a080d4f510ebd31d4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

