### PR TITLE
test(conformance): add MCP v2 TypeScript coverage

### DIFF
--- a/.github/workflows/conformance-comment.yml
+++ b/.github/workflows/conformance-comment.yml
@@ -20,6 +20,8 @@ jobs:
 
     steps:
       - name: Download conformance results
+        id: download-results
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           name: conformance-results
@@ -28,6 +30,7 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
 
       - name: Post comment using action
+        if: steps.download-results.outcome == 'success'
         uses: mcp-use/mcp-conformance-action@v1
         with:
           mode: comment

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -95,10 +95,13 @@ jobs:
             echo "typescript=$FILTER_TYPESCRIPT" >> $GITHUB_OUTPUT
           fi
 
-  conformance-test:
-    name: Run Conformance Tests
+  python-conformance-test:
+    # mcp-conformance-action@v1 is pinned here to
+    # @modelcontextprotocol/conformance 0.1.16. Keep Python on that stable
+    # runner until its v2 coverage is migrated deliberately.
+    name: Python Conformance Tests (v1)
     needs: detect-changes
-    if: needs.detect-changes.outputs.python == 'true' || needs.detect-changes.outputs.typescript == 'true'
+    if: needs.detect-changes.outputs.python == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -118,92 +121,128 @@ jobs:
         with:
           version: "latest"
 
-      - name: Set up Node.js
+      - name: Set up Node.js for the v1 conformance runner
         uses: actions/setup-node@v4
         with:
           node-version: '22.23.1'
 
-      - name: Install pnpm
-        if: needs.detect-changes.outputs.typescript == 'true'
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10
-
       - name: Prepare Python
-        if: needs.detect-changes.outputs.python == 'true'
         working-directory: libraries/python
         run: |
           uv venv
           source .venv/bin/activate
           uv pip install -e ".[dev]"
 
-      - name: Prepare TypeScript server
-        if: needs.detect-changes.outputs.typescript == 'true'
-        working-directory: libraries/typescript
-        run: |
-          pnpm install
-          pnpm build
-
-      - name: Install TypeScript conformance server dependencies
-        if: needs.detect-changes.outputs.typescript == 'true'
-        working-directory: libraries/typescript/packages/server/examples/conformance
-        run: pnpm install
-
-      - name: Install TypeScript conformance client dependencies
-        if: needs.detect-changes.outputs.typescript == 'true'
-        working-directory: libraries/typescript/packages/client/examples/conformance
-        run: pnpm install
-
-      - name: Build server list
-        id: build-servers
-        env:
-          NEEDS_PYTHON: ${{ needs.detect-changes.outputs.python }}
-          NEEDS_TYPESCRIPT: ${{ needs.detect-changes.outputs.typescript }}
-        run: |
-          SERVERS='['
-          if [ "$NEEDS_PYTHON" = "true" ]; then
-            SERVERS+='{"name":"python","start-command":"source .venv/bin/activate && python tests/integration/servers_for_testing/conformance_server.py --transport streamable-http --port 8000","url":"http://127.0.0.1:8000/mcp","working-directory":"libraries/python"}'
-          fi
-          if [ "$NEEDS_TYPESCRIPT" = "true" ]; then
-            if [[ $SERVERS != '[' ]]; then
-              SERVERS+=','
-            fi
-            SERVERS+='{"name":"typescript","start-command":"PORT=3000 node ../../dist/bin.js dev --no-open","url":"http://localhost:3000/mcp","working-directory":"libraries/typescript/packages/server/examples/conformance"}'
-          fi
-          SERVERS+=']'
-          echo "servers=$SERVERS" >> $GITHUB_OUTPUT
-
-      - name: Build client list
-        id: build-clients
-        env:
-          NEEDS_PYTHON: ${{ needs.detect-changes.outputs.python }}
-          NEEDS_TYPESCRIPT: ${{ needs.detect-changes.outputs.typescript }}
-        run: |
-          CLIENTS='['
-          if [ "$NEEDS_PYTHON" = "true" ]; then
-            CLIENTS+='{"name":"python-client","command":".venv/bin/python tests/integration/clients_for_testing/conformance_client.py","working-directory":"libraries/python"}'
-          fi
-          if [ "$NEEDS_TYPESCRIPT" = "true" ]; then
-            if [[ $CLIENTS != '[' ]]; then
-              CLIENTS+=','
-            fi
-            CLIENTS+='{"name":"typescript-node-client","command":"libraries/typescript/packages/client/examples/conformance/run-conformance-client-node.sh"}'
-            CLIENTS+=','
-            CLIENTS+='{"name":"typescript-browser-client","command":"libraries/typescript/packages/client/examples/conformance/run-conformance-client-browser.sh"}'
-            CLIENTS+=','
-            CLIENTS+='{"name":"typescript-react-client","command":"libraries/typescript/packages/client/examples/conformance/run-conformance-client-react.sh"}'
-          fi
-          CLIENTS+=']'
-          echo "clients=$CLIENTS" >> $GITHUB_OUTPUT
-
-      - name: Run conformance tests
+      - name: Run Python conformance tests
         uses: mcp-use/mcp-conformance-action@v1
         env:
           MCP_USE_ANONYMIZED_TELEMETRY: false
         with:
           mode: test
           test-type: both
-          servers: ${{ steps.build-servers.outputs.servers }}
-          clients: ${{ steps.build-clients.outputs.clients }}
+          conformance-version: '0.1.16'
+          servers: '[{"name":"python","start-command":"source .venv/bin/activate && python tests/integration/servers_for_testing/conformance_server.py --transport streamable-http --port 8000","url":"http://127.0.0.1:8000/mcp","working-directory":"libraries/python"}]'
+          clients: '[{"name":"python-client","command":".venv/bin/python tests/integration/clients_for_testing/conformance_client.py","working-directory":"libraries/python"}]'
           badge-gist-id: ${{ secrets.CONFORMANCE_GIST_ID }}
           badge-gist-token: ${{ secrets.GIST_SECRET }}
+
+  typescript-v2-conformance-test:
+    name: TypeScript Conformance Tests (v2)
+    needs: detect-changes
+    if: needs.detect-changes.outputs.typescript == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.23.1'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Prepare TypeScript conformance examples
+        working-directory: libraries/typescript
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm build
+
+      - name: Run TypeScript v2 conformance tests
+        env:
+          # Pin the v2 runner independently from the v1 action used above.
+          CONFORMANCE_RUNNER: '@modelcontextprotocol/conformance@0.2.0-alpha.10'
+          SPEC_VERSION: '2026-07-28'
+        run: |
+          set +e
+          exit_code=0
+          results_dir=conformance-results/typescript
+          mkdir -p "$results_dir"
+
+          (
+            cd libraries/typescript/packages/server/examples/conformance
+            PORT=3000 node ../../dist/bin.js dev --no-open
+          ) > "$results_dir/server.log" 2>&1 &
+          server_pid=$!
+          trap 'kill "$server_pid" 2>/dev/null; wait "$server_pid" 2>/dev/null' EXIT
+
+          server_ready=false
+          for attempt in {1..60}; do
+            if curl --silent --show-error --output /dev/null http://127.0.0.1:3000/mcp; then
+              server_ready=true
+              break
+            fi
+            if ! kill -0 "$server_pid" 2>/dev/null; then
+              echo 'TypeScript conformance server exited before it became ready.'
+              cat "$results_dir/server.log"
+              break
+            fi
+            sleep 1
+          done
+
+          if [ "$server_ready" = true ]; then
+            pnpm dlx "$CONFORMANCE_RUNNER" server \
+              --url http://127.0.0.1:3000/mcp \
+              --suite all \
+              --spec-version "$SPEC_VERSION" \
+              --output-dir "$results_dir/server" || exit_code=1
+          else
+            echo 'TypeScript conformance server did not become ready within 60 seconds.'
+            exit_code=1
+          fi
+
+          pnpm dlx "$CONFORMANCE_RUNNER" client \
+            --command 'cd libraries/typescript/packages/client/examples/conformance && ./run-conformance-client-node.sh' \
+            --suite all \
+            --spec-version "$SPEC_VERSION" \
+            --output-dir "$results_dir/client-node" || exit_code=1
+
+          pnpm dlx "$CONFORMANCE_RUNNER" client \
+            --command 'cd libraries/typescript/packages/client/examples/conformance && ./run-conformance-client-browser.sh' \
+            --suite all \
+            --spec-version "$SPEC_VERSION" \
+            --output-dir "$results_dir/client-browser" || exit_code=1
+
+          pnpm dlx "$CONFORMANCE_RUNNER" client \
+            --command 'cd libraries/typescript/packages/client/examples/conformance && ./run-conformance-client-react.sh' \
+            --suite all \
+            --spec-version "$SPEC_VERSION" \
+            --output-dir "$results_dir/client-react" || exit_code=1
+
+          exit "$exit_code"
+
+      # The Python action continues to publish conformance-results for the
+      # existing PR comment workflow. Keep v2's native reports separate.
+      - name: Upload TypeScript v2 conformance results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: typescript-v2-conformance-results
+          path: conformance-results/typescript
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -147,7 +147,7 @@ jobs:
           badge-gist-token: ${{ secrets.GIST_SECRET }}
 
   typescript-v2-conformance-test:
-    name: TypeScript Conformance Tests (v2)
+    name: TypeScript Conformance Tests (legacy + modern)
     needs: detect-changes
     if: needs.detect-changes.outputs.typescript == 'true'
     runs-on: ubuntu-latest
@@ -173,11 +173,13 @@ jobs:
           pnpm install --frozen-lockfile
           pnpm build
 
-      - name: Run TypeScript v2 conformance tests
+      - name: Run TypeScript conformance tests
         env:
           # Pin the v2 runner independently from the v1 action used above.
           CONFORMANCE_RUNNER: '@modelcontextprotocol/conformance@0.2.0-alpha.10'
-          SPEC_VERSION: '2026-07-28'
+          # Dated versions intentionally exclude off-timeline extensions such as tasks.
+          SPEC_VERSIONS: '2025-11-25 2026-07-28'
+          LEGACY_SERVER_EXPECTED_FAILURES: 'libraries/typescript/packages/server/examples/conformance/expected-failures.yml'
         run: |
           set +e
           exit_code=0
@@ -205,34 +207,62 @@ jobs:
             sleep 1
           done
 
-          if [ "$server_ready" = true ]; then
-            pnpm dlx "$CONFORMANCE_RUNNER" server \
-              --url http://127.0.0.1:3000/mcp \
-              --suite all \
-              --spec-version "$SPEC_VERSION" \
-              --output-dir "$results_dir/server" || exit_code=1
-          else
+          if [ "$server_ready" != true ]; then
             echo 'TypeScript conformance server did not become ready within 60 seconds.'
             exit_code=1
           fi
 
-          pnpm dlx "$CONFORMANCE_RUNNER" client \
-            --command 'cd libraries/typescript/packages/client/examples/conformance && ./run-conformance-client-node.sh' \
-            --suite all \
-            --spec-version "$SPEC_VERSION" \
-            --output-dir "$results_dir/client-node" || exit_code=1
+          for spec_version in $SPEC_VERSIONS; do
+            version_results_dir="$results_dir/$spec_version"
+            mkdir -p "$version_results_dir"
 
-          pnpm dlx "$CONFORMANCE_RUNNER" client \
-            --command 'cd libraries/typescript/packages/client/examples/conformance && ./run-conformance-client-browser.sh' \
-            --suite all \
-            --spec-version "$SPEC_VERSION" \
-            --output-dir "$results_dir/client-browser" || exit_code=1
+            if [ "$server_ready" = true ]; then
+              expected_failure_args=()
+              if [ "$spec_version" = '2025-11-25' ]; then
+                expected_failure_args=(--expected-failures "$LEGACY_SERVER_EXPECTED_FAILURES")
+              fi
 
-          pnpm dlx "$CONFORMANCE_RUNNER" client \
-            --command 'cd libraries/typescript/packages/client/examples/conformance && ./run-conformance-client-react.sh' \
-            --suite all \
-            --spec-version "$SPEC_VERSION" \
-            --output-dir "$results_dir/client-react" || exit_code=1
+              pnpm dlx "$CONFORMANCE_RUNNER" server \
+                --url http://127.0.0.1:3000/mcp \
+                --suite all \
+                --spec-version "$spec_version" \
+                --output-dir "$version_results_dir/server" \
+                "${expected_failure_args[@]}" || exit_code=1
+
+              if [ "$spec_version" = '2025-11-25' ]; then
+                printf '%s\n' \
+                  '### TypeScript legacy server exclusions' \
+                  '' \
+                  '- `tools-call-sampling` — stateless legacy HTTP has no client session for sampling.' \
+                  '- `tools-call-elicitation` — stateless legacy HTTP has no client session for elicitation.' \
+                  '- `elicitation-sep1034-defaults` — stateless legacy HTTP has no client session for elicitation.' \
+                  '- `elicitation-sep1330-enums` — stateless legacy HTTP has no client session for elicitation.' \
+                  '- `server-sse-polling` — stateless legacy HTTP has no session or SSE resumability.' \
+                  '- `server-sse-multiple-streams` — stateless legacy HTTP has no session for multiple SSE streams.' \
+                  '- `resources-subscribe` — stateless legacy HTTP does not retain resource subscriptions.' \
+                  '- `resources-unsubscribe` — stateless legacy HTTP does not retain resource subscriptions.' \
+                  >> "$GITHUB_STEP_SUMMARY"
+              fi
+            fi
+
+            pnpm dlx "$CONFORMANCE_RUNNER" client \
+              --command 'cd libraries/typescript/packages/client/examples/conformance && ./run-conformance-client-node.sh' \
+              --suite all \
+              --spec-version "$spec_version" \
+              --output-dir "$version_results_dir/client-node" || exit_code=1
+
+            pnpm dlx "$CONFORMANCE_RUNNER" client \
+              --command 'cd libraries/typescript/packages/client/examples/conformance && ./run-conformance-client-browser.sh' \
+              --suite all \
+              --spec-version "$spec_version" \
+              --output-dir "$version_results_dir/client-browser" || exit_code=1
+
+            pnpm dlx "$CONFORMANCE_RUNNER" client \
+              --command 'cd libraries/typescript/packages/client/examples/conformance && ./run-conformance-client-react.sh' \
+              --suite all \
+              --spec-version "$spec_version" \
+              --output-dir "$version_results_dir/client-react" || exit_code=1
+          done
 
           exit "$exit_code"
 

--- a/libraries/typescript/.changeset/quiet-lions-connect.md
+++ b/libraries/typescript/.changeset/quiet-lions-connect.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/client": patch
+---
+
+Allow modern MCP connections to remain ready when the server omits optional identity metadata.

--- a/libraries/typescript/.changeset/quiet-lions-connect.md
+++ b/libraries/typescript/.changeset/quiet-lions-connect.md
@@ -1,5 +1,6 @@
 ---
 "@mcp-use/client": patch
+"mcp-use": patch
 ---
 
-Allow modern MCP connections to remain ready when the server omits optional identity metadata.
+Allow modern MCP connections to remain ready when the server omits optional identity metadata. Direct proxy connections now report a clear error when an anonymous upstream cannot provide a namespace.

--- a/libraries/typescript/packages/client/examples/conformance/src/conformance-client-browser.ts
+++ b/libraries/typescript/packages/client/examples/conformance/src/conformance-client-browser.ts
@@ -5,9 +5,11 @@
 import { auth } from "@modelcontextprotocol/client";
 import { MCPClient } from "@mcp-use/client";
 import {
+  conformanceClientOptions,
   handleElicitation,
   isAuthScenario,
   parseConformanceContext,
+  parsePreRegistrationContext,
   requiresOAuthRetryFetch,
   runScenario,
   runWithScenarioTimeout,
@@ -29,11 +31,13 @@ async function main(): Promise<void> {
   const serverConfig: Record<string, unknown> = {
     url: serverUrl,
     onElicitation: handleElicitation,
+    oauth: isAuthScenario(scenario) ? undefined : false,
+    clientOptions: conformanceClientOptions(),
   };
 
   const authProvider = isAuthScenario(scenario)
     ? await createHeadlessConformanceOAuthProvider({
-        preRegistrationContext: parseConformanceContext(),
+        preRegistrationContext: parsePreRegistrationContext(),
       })
     : undefined;
 
@@ -56,10 +60,11 @@ async function main(): Promise<void> {
         serverUrl,
       });
       if (authResult === "REDIRECT") {
-        const authCode = await authProvider.getAuthorizationCode();
+        const { code, iss } = await authProvider.getAuthorizationResponse();
         await auth(authProvider, {
           serverUrl,
-          authorizationCode: authCode,
+          authorizationCode: code,
+          ...(iss !== undefined && { iss }),
         });
       }
     }
@@ -75,7 +80,7 @@ async function main(): Promise<void> {
       listTools: () => session.listTools(),
       callTool: (name, args) => session.callTool(name, args),
     };
-    await runScenario(scenario, conformanceSession);
+    await runScenario(scenario, conformanceSession, parseConformanceContext());
   } finally {
     await client.closeAllSessions();
   }

--- a/libraries/typescript/packages/client/examples/conformance/src/conformance-client-browser.ts
+++ b/libraries/typescript/packages/client/examples/conformance/src/conformance-client-browser.ts
@@ -7,6 +7,7 @@ import { MCPClient } from "@mcp-use/client";
 import {
   conformanceClientOptions,
   handleElicitation,
+  handleSampling,
   isAuthScenario,
   parseConformanceContext,
   parsePreRegistrationContext,
@@ -31,6 +32,7 @@ async function main(): Promise<void> {
   const serverConfig: Record<string, unknown> = {
     url: serverUrl,
     onElicitation: handleElicitation,
+    onSampling: handleSampling,
     oauth: isAuthScenario(scenario) ? undefined : false,
     clientOptions: conformanceClientOptions(),
   };
@@ -79,6 +81,10 @@ async function main(): Promise<void> {
     const conformanceSession: ConformanceSession = {
       listTools: () => session.listTools(),
       callTool: (name, args) => session.callTool(name, args),
+      listResources: async () => (await session.listResources()).resources,
+      readResource: (uri) => session.readResource(uri),
+      listPrompts: async () => (await session.listPrompts()).prompts,
+      getPrompt: (name, args) => session.getPrompt(name, args),
     };
     await runScenario(scenario, conformanceSession, parseConformanceContext());
   } finally {

--- a/libraries/typescript/packages/client/examples/conformance/src/conformance-client-node.ts
+++ b/libraries/typescript/packages/client/examples/conformance/src/conformance-client-node.ts
@@ -7,6 +7,7 @@ import { MCPClient } from "@mcp-use/client";
 import {
   conformanceClientOptions,
   handleElicitation,
+  handleSampling,
   isAuthScenario,
   parseConformanceContext,
   parsePreRegistrationContext,
@@ -77,6 +78,7 @@ async function main(): Promise<void> {
     },
     {
       onElicitation: handleElicitation,
+      onSampling: handleSampling,
     }
   );
 
@@ -85,6 +87,10 @@ async function main(): Promise<void> {
     const conformanceSession: ConformanceSession = {
       listTools: () => session.listTools(),
       callTool: (name, args) => session.callTool(name, args),
+      listResources: async () => (await session.listResources()).resources,
+      readResource: (uri) => session.readResource(uri),
+      listPrompts: async () => (await session.listPrompts()).prompts,
+      getPrompt: (name, args) => session.getPrompt(name, args),
     };
     await runScenario(scenario, conformanceSession, parseConformanceContext());
   } finally {

--- a/libraries/typescript/packages/client/examples/conformance/src/conformance-client-node.ts
+++ b/libraries/typescript/packages/client/examples/conformance/src/conformance-client-node.ts
@@ -5,9 +5,11 @@
 import { auth } from "@modelcontextprotocol/client";
 import { MCPClient } from "@mcp-use/client";
 import {
+  conformanceClientOptions,
   handleElicitation,
   isAuthScenario,
   parseConformanceContext,
+  parsePreRegistrationContext,
   requiresOAuthRetryFetch,
   runScenario,
   runWithScenarioTimeout,
@@ -25,10 +27,14 @@ async function main(): Promise<void> {
 
   const scenario = process.env.MCP_CONFORMANCE_SCENARIO || "";
 
-  const serverConfig: Record<string, unknown> = { url: serverUrl };
+  const serverConfig: Record<string, unknown> = {
+    url: serverUrl,
+    oauth: isAuthScenario(scenario) ? undefined : false,
+    clientOptions: conformanceClientOptions(),
+  };
   const authProvider = isAuthScenario(scenario)
     ? await createHeadlessConformanceOAuthProvider({
-        preRegistrationContext: parseConformanceContext(),
+        preRegistrationContext: parsePreRegistrationContext(),
       })
     : undefined;
 
@@ -53,10 +59,11 @@ async function main(): Promise<void> {
         serverUrl,
       });
       if (authResult === "REDIRECT") {
-        const authCode = await authProvider.getAuthorizationCode();
+        const { code, iss } = await authProvider.getAuthorizationResponse();
         await auth(authProvider, {
           serverUrl,
-          authorizationCode: authCode,
+          authorizationCode: code,
+          ...(iss !== undefined && { iss }),
         });
       }
     }
@@ -79,7 +86,7 @@ async function main(): Promise<void> {
       listTools: () => session.listTools(),
       callTool: (name, args) => session.callTool(name, args),
     };
-    await runScenario(scenario, conformanceSession);
+    await runScenario(scenario, conformanceSession, parseConformanceContext());
   } finally {
     await client.closeAllSessions();
   }

--- a/libraries/typescript/packages/client/examples/conformance/src/conformance-client-react.ts
+++ b/libraries/typescript/packages/client/examples/conformance/src/conformance-client-react.ts
@@ -11,9 +11,11 @@ import { JSDOM } from "jsdom";
 import { McpClientProvider, useMcpClient } from "@mcp-use/client/react";
 import TestRenderer, { act } from "react-test-renderer";
 import {
+  conformanceClientOptions,
   handleElicitation,
   isAuthScenario,
   parseConformanceContext,
+  parsePreRegistrationContext,
   requiresOAuthRetryFetch,
   runScenario,
   runWithScenarioTimeout,
@@ -97,7 +99,7 @@ function ScenarioDriver({ scenario, resolve, reject }: DriverProps): null {
       callTool: (name, args) => server.callTool(name, args),
     };
 
-    runScenario(scenario, conformanceSession)
+    runScenario(scenario, conformanceSession, parseConformanceContext())
       .then(() => {
         doneRef.current = true;
         resolve();
@@ -116,8 +118,6 @@ function setupReactRuntimeDom(): () => void {
     url: "http://localhost:3000/",
   });
 
-  (globalThis as any).window = dom.window;
-  (globalThis as any).document = dom.window.document;
   Object.defineProperty(globalThis, "navigator", {
     value: dom.window.navigator,
     configurable: true,
@@ -128,8 +128,6 @@ function setupReactRuntimeDom(): () => void {
 
   return () => {
     dom.window.close();
-    delete (globalThis as any).window;
-    delete (globalThis as any).document;
     delete (globalThis as any).navigator;
     delete (globalThis as any).localStorage;
     delete (globalThis as any).sessionStorage;
@@ -149,7 +147,7 @@ async function main(): Promise<void> {
   const teardownDom = setupReactRuntimeDom();
   const authProvider = isAuthScenario(scenario)
     ? await createHeadlessConformanceOAuthProvider({
-        preRegistrationContext: parseConformanceContext(),
+        preRegistrationContext: parsePreRegistrationContext(),
       })
     : undefined;
   // The retry fetch sees scopes carried by the initial WWW-Authenticate response
@@ -158,7 +156,10 @@ async function main(): Promise<void> {
     test: {
       name: "test",
       url: serverUrl,
+      callbackUrl: "http://localhost:3000/oauth/callback",
       authProvider,
+      oauth: isAuthScenario(scenario) ? undefined : false,
+      clientOptions: conformanceClientOptions(),
       ...(authProvider &&
         requiresOAuthRetryFetch(scenario) && {
           fetch: createOAuthRetryFetch(fetch, serverUrl, authProvider, {

--- a/libraries/typescript/packages/client/examples/conformance/src/conformance-client-react.ts
+++ b/libraries/typescript/packages/client/examples/conformance/src/conformance-client-react.ts
@@ -97,6 +97,16 @@ function ScenarioDriver({ scenario, resolve, reject }: DriverProps): null {
     const conformanceSession: ConformanceSession = {
       listTools: async () => server.tools as any[],
       callTool: (name, args) => server.callTool(name, args),
+      listResources: async () => {
+        await server.listResources();
+        return server.resources;
+      },
+      readResource: (uri) => server.readResource(uri),
+      listPrompts: async () => {
+        await server.listPrompts();
+        return server.prompts;
+      },
+      getPrompt: (name, args) => server.getPrompt(name, args),
     };
 
     runScenario(scenario, conformanceSession, parseConformanceContext())

--- a/libraries/typescript/packages/client/examples/conformance/src/conformance-shared.ts
+++ b/libraries/typescript/packages/client/examples/conformance/src/conformance-shared.ts
@@ -22,24 +22,58 @@ export type PreRegistrationContext = {
   client_secret: string;
 };
 
-export function parseConformanceContext():
-  | ({ name: string } & PreRegistrationContext)
-  | undefined {
+export type ConformanceToolCall = {
+  name: string;
+  arguments: Record<string, unknown>;
+};
+
+/** Context forwarded by @modelcontextprotocol/conformance. */
+export type ConformanceContext = {
+  name?: string;
+  client_id?: string;
+  client_secret?: string;
+  toolCalls?: ConformanceToolCall[];
+};
+
+export function parseConformanceContext(): ConformanceContext | undefined {
   const raw = process.env.MCP_CONFORMANCE_CONTEXT;
   if (!raw) return undefined;
   try {
     const parsed = JSON.parse(raw);
-    if (
-      parsed?.name === "auth/pre-registration" &&
-      parsed.client_id &&
-      parsed.client_secret
-    ) {
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
       return parsed;
     }
     return undefined;
   } catch {
     return undefined;
   }
+}
+
+export function parsePreRegistrationContext():
+  | ({ name: "auth/pre-registration" } & PreRegistrationContext)
+  | undefined {
+  const context = parseConformanceContext();
+  if (
+    context?.name === "auth/pre-registration" &&
+    typeof context.client_id === "string" &&
+    typeof context.client_secret === "string"
+  ) {
+    return context as {
+      name: "auth/pre-registration";
+    } & PreRegistrationContext;
+  }
+  return undefined;
+}
+
+/**
+ * The runner forwards the resolved --spec-version. Pin the draft revision so
+ * the SDK uses its stateless lifecycle; dated revisions retain initialize.
+ */
+export function conformanceClientOptions(): Record<string, unknown> {
+  const protocolVersion = process.env.MCP_CONFORMANCE_PROTOCOL_VERSION;
+  return protocolVersion === "2026-07-28"
+    ? { versionNegotiation: { mode: { pin: protocolVersion } } }
+    : { versionNegotiation: { mode: "legacy" } };
 }
 
 export function isAuthScenario(scenario: string): boolean {
@@ -54,14 +88,19 @@ export function isScopeStepUpScenario(scenario: string): boolean {
 }
 
 /**
- * Scenarios whose initial 401 carries the requested OAuth scope in
- * WWW-Authenticate. They must let the retry fetch observe that response;
- * pre-authenticating would lose the scope before the first MCP request.
+ * Scenarios whose 401/403 challenge carries OAuth discovery or scope state.
+ * They must let the retry fetch observe that response; pre-authenticating
+ * would lose the challenge before the first MCP request.
  */
 export function requiresOAuthRetryFetch(scenario: string): boolean {
   return (
     isScopeStepUpScenario(scenario) ||
-    scenario === "auth/scope-from-www-authenticate"
+    scenario === "auth/scope-from-www-authenticate" ||
+    scenario === "auth/authorization-server-migration" ||
+    // metadata-var3 advertises the authorization server only from the
+    // resource server's initial 401 challenge. Pre-authentication would
+    // discover the resource origin and incorrectly attempt DCR at /register.
+    scenario === "auth/metadata-var3"
   );
 }
 
@@ -147,9 +186,23 @@ export async function runElicitationDefaults(
   }
 }
 
+async function runContextToolCalls(
+  session: ConformanceSession,
+  context: ConformanceContext | undefined
+): Promise<void> {
+  for (const toolCall of context?.toolCalls ?? []) {
+    await session.callTool(toolCall.name, toolCall.arguments);
+  }
+}
+
+async function runToolsList(session: ConformanceSession): Promise<void> {
+  await session.listTools();
+}
+
 export async function runScenario(
   scenario: string,
-  session: ConformanceSession
+  session: ConformanceSession,
+  context?: ConformanceContext
 ): Promise<void> {
   switch (scenario) {
     case "initialize":
@@ -165,6 +218,26 @@ export async function runScenario(
     case "sse-retry":
       await runToolsCall(session);
       await new Promise((resolve) => setTimeout(resolve, 5000));
+      await runToolsCall(session);
+      return;
+    case "http-custom-headers":
+      // alpha.10 supplies exact values (including unsafe strings and nulls)
+      // in context so header serialization can be checked byte-for-byte.
+      await runContextToolCalls(session, context);
+      return;
+    case "http-invalid-tool-headers":
+      // Listing filters malformed x-mcp-header tools; then only the valid tool
+      // must be called, which is what the ordinary tool loop exercises.
+      await runToolsCall(session);
+      return;
+    case "json-schema-ref-no-deref":
+      // Tool discovery is sufficient. Calling the tool could make an invalid
+      // external $ref look like an argument-validation failure.
+      await runToolsList(session);
+      return;
+    case "request-metadata":
+    case "sep-2322-client-request-state":
+    case "http-standard-headers":
       await runToolsCall(session);
       return;
     default:

--- a/libraries/typescript/packages/client/examples/conformance/src/conformance-shared.ts
+++ b/libraries/typescript/packages/client/examples/conformance/src/conformance-shared.ts
@@ -12,9 +12,24 @@ type Tool = {
   };
 };
 
+type Resource = {
+  uri: string;
+};
+
+type Prompt = {
+  name: string;
+  arguments?: Array<{
+    name: string;
+  }>;
+};
+
 export type ConformanceSession = {
   listTools: () => Promise<Tool[]>;
   callTool: (name: string, args: Record<string, unknown>) => Promise<unknown>;
+  listResources: () => Promise<Resource[]>;
+  readResource: (uri: string) => Promise<unknown>;
+  listPrompts: () => Promise<Prompt[]>;
+  getPrompt: (name: string, args: Record<string, string>) => Promise<unknown>;
 };
 
 export type PreRegistrationContext = {
@@ -139,6 +154,18 @@ export async function handleElicitation(
   return acceptWithDefaults(params);
 }
 
+export async function handleSampling() {
+  return {
+    role: "assistant" as const,
+    content: {
+      type: "text" as const,
+      text: "Conformance sampling response",
+    },
+    model: "mcp-use-conformance",
+    stopReason: "endTurn" as const,
+  };
+}
+
 function buildToolArgs(tool: Tool): Record<string, unknown> {
   const args: Record<string, unknown> = {};
   const properties = tool.inputSchema?.properties || {};
@@ -168,6 +195,39 @@ export async function runToolsCall(session: ConformanceSession): Promise<void> {
       // Some conformance tools intentionally return errors.
     }
   }
+}
+
+async function runResourceCalls(session: ConformanceSession): Promise<void> {
+  const resources = await session.listResources();
+  for (const resource of resources) {
+    try {
+      await session.readResource(resource.uri);
+    } catch {
+      // The request still exercises transport metadata when the fixture rejects a read.
+    }
+  }
+}
+
+async function runPromptCalls(session: ConformanceSession): Promise<void> {
+  const prompts = await session.listPrompts();
+  for (const prompt of prompts) {
+    const args = Object.fromEntries(
+      (prompt.arguments ?? []).map((argument) => [argument.name, "test"])
+    );
+    try {
+      await session.getPrompt(prompt.name, args);
+    } catch {
+      // The request still exercises transport metadata when the fixture rejects arguments.
+    }
+  }
+}
+
+async function runStandardHeaderCalls(
+  session: ConformanceSession
+): Promise<void> {
+  await runToolsCall(session);
+  await runResourceCalls(session);
+  await runPromptCalls(session);
 }
 
 export async function runElicitationDefaults(
@@ -235,9 +295,11 @@ export async function runScenario(
       // external $ref look like an argument-validation failure.
       await runToolsList(session);
       return;
+    case "http-standard-headers":
+      await runStandardHeaderCalls(session);
+      return;
     case "request-metadata":
     case "sep-2322-client-request-state":
-    case "http-standard-headers":
       await runToolsCall(session);
       return;
     default:

--- a/libraries/typescript/packages/client/examples/conformance/src/headless-oauth-provider.ts
+++ b/libraries/typescript/packages/client/examples/conformance/src/headless-oauth-provider.ts
@@ -1,17 +1,38 @@
 import type {
   OAuthClientProvider,
   OAuthClientInformation,
+  OAuthClientInformationContext,
   OAuthClientInformationFull,
   OAuthClientMetadata,
   OAuthTokens,
+  OAuthDiscoveryState,
 } from "@modelcontextprotocol/client";
 import type { PreRegistrationContext } from "./conformance-shared.js";
 
+/** Authorization response captured from the headless redirect. */
+export type HeadlessOAuthAuthorizationResponse = {
+  code: string;
+  /** RFC 9207 authorization-server issuer, when returned by the callback. */
+  iss?: string;
+};
+
 export class HeadlessConformanceOAuthProvider implements OAuthClientProvider {
-  private clientInfo?: OAuthClientInformationFull;
-  private tokenData?: OAuthTokens;
+  /**
+   * Pre-v2 credential storage did not have an issuer key. Keep one unbound
+   * entry only long enough for the SDK to stamp it on the first v2 read.
+   */
+  private legacyClientInfo?: OAuthClientInformationFull;
+  private legacyTokenData?: OAuthTokens;
+  private readonly clientInfoByIssuer = new Map<
+    string,
+    OAuthClientInformationFull
+  >();
+  private readonly tokensByIssuer = new Map<string, OAuthTokens>();
+  private latestTokenData?: OAuthTokens;
+  private savedDiscoveryState?: OAuthDiscoveryState;
   private storedCodeVerifier?: string;
-  private authorizationCode?: string;
+  private authorizationResponse?: HeadlessOAuthAuthorizationResponse;
+  private authorizationState?: string;
 
   constructor(
     private readonly redirectUri: string,
@@ -31,22 +52,75 @@ export class HeadlessConformanceOAuthProvider implements OAuthClientProvider {
     return this.metadataUrl;
   }
 
-  async clientInformation(): Promise<OAuthClientInformation | undefined> {
-    return this.clientInfo;
+  async clientInformation(
+    context?: OAuthClientInformationContext
+  ): Promise<OAuthClientInformation | undefined> {
+    if (!context) {
+      return (
+        this.legacyClientInfo ?? this.clientInfoByIssuer.values().next().value
+      );
+    }
+
+    // Returning the legacy entry here lets the v2 SDK stamp it with the
+    // issuer and re-save it. Once saved with an issuer it is never reused for
+    // a different AS, so a migration triggers fresh registration as required.
+    return this.clientInfoByIssuer.get(context.issuer) ?? this.legacyClientInfo;
   }
 
   async saveClientInformation(
-    clientInformation: OAuthClientInformationFull
+    clientInformation: OAuthClientInformationFull,
+    context?: OAuthClientInformationContext
   ): Promise<void> {
-    this.clientInfo = clientInformation;
+    if (context) {
+      this.clientInfoByIssuer.set(context.issuer, clientInformation);
+      this.legacyClientInfo = undefined;
+      return;
+    }
+
+    this.legacyClientInfo = clientInformation;
   }
 
-  async tokens(): Promise<OAuthTokens | undefined> {
-    return this.tokenData;
+  async tokens(
+    context?: OAuthClientInformationContext
+  ): Promise<OAuthTokens | undefined> {
+    if (!context) {
+      // Transport bearer-token reads are issuer-less. The SDK requires the
+      // most recently issued token in that case.
+      return this.latestTokenData ?? this.legacyTokenData;
+    }
+
+    return this.tokensByIssuer.get(context.issuer) ?? this.legacyTokenData;
   }
 
-  async saveTokens(tokens: OAuthTokens): Promise<void> {
-    this.tokenData = tokens;
+  async saveTokens(
+    tokens: OAuthTokens,
+    context?: OAuthClientInformationContext
+  ): Promise<void> {
+    this.latestTokenData = tokens;
+    if (context) {
+      this.tokensByIssuer.set(context.issuer, tokens);
+      this.legacyTokenData = undefined;
+      return;
+    }
+
+    this.legacyTokenData = tokens;
+  }
+
+  async saveDiscoveryState(state: OAuthDiscoveryState): Promise<void> {
+    // The headless callback happens in-process, but this must be retained
+    // alongside the verifier so the SDK can bind the callback to its issuer.
+    this.savedDiscoveryState = state;
+  }
+
+  async discoveryState(): Promise<OAuthDiscoveryState | undefined> {
+    return this.savedDiscoveryState;
+  }
+
+  async state(): Promise<string> {
+    // A distinct value is generated for each authorization attempt. The
+    // redirect handler verifies the returned value before exposing its code.
+    this.authorizationState = crypto.randomUUID();
+    return this.authorizationState;
   }
 
   async redirectToAuthorization(authorizationUrl: URL): Promise<void> {
@@ -57,18 +131,10 @@ export class HeadlessConformanceOAuthProvider implements OAuthClientProvider {
     const location = response.headers.get("location");
     if (location) {
       const redirected = new URL(location, authorizationUrl);
-      const code = redirected.searchParams.get("code");
-      if (code) {
-        this.authorizationCode = code;
-        return;
-      }
+      if (this.captureAuthorizationResponse(redirected)) return;
     }
 
-    const fallbackCode = new URL(response.url).searchParams.get("code");
-    if (fallbackCode) {
-      this.authorizationCode = fallbackCode;
-      return;
-    }
+    if (this.captureAuthorizationResponse(new URL(response.url))) return;
 
     throw new Error("Headless OAuth flow did not return an authorization code");
   }
@@ -84,11 +150,41 @@ export class HeadlessConformanceOAuthProvider implements OAuthClientProvider {
     return this.storedCodeVerifier;
   }
 
+  async invalidateCredentials(
+    scope: "all" | "client" | "tokens" | "verifier" | "discovery"
+  ): Promise<void> {
+    if (scope === "all" || scope === "client") {
+      this.legacyClientInfo = undefined;
+      this.clientInfoByIssuer.clear();
+    }
+    if (scope === "all" || scope === "tokens") {
+      this.legacyTokenData = undefined;
+      this.latestTokenData = undefined;
+      this.tokensByIssuer.clear();
+    }
+    if (scope === "all" || scope === "verifier") {
+      this.storedCodeVerifier = undefined;
+      this.authorizationResponse = undefined;
+      this.authorizationState = undefined;
+    }
+    if (scope === "all" || scope === "discovery") {
+      this.savedDiscoveryState = undefined;
+    }
+  }
+
   async getAuthorizationCode(): Promise<string> {
-    if (!this.authorizationCode) {
+    return (await this.getAuthorizationResponse()).code;
+  }
+
+  /**
+   * Returns the complete callback response so callers can pass the RFC 9207
+   * `iss` value to the SDK for authorization-server validation.
+   */
+  async getAuthorizationResponse(): Promise<HeadlessOAuthAuthorizationResponse> {
+    if (!this.authorizationResponse) {
       throw new Error("No OAuth authorization code captured");
     }
-    return this.authorizationCode;
+    return this.authorizationResponse;
   }
 
   /**
@@ -96,7 +192,8 @@ export class HeadlessConformanceOAuthProvider implements OAuthClientProvider {
    * This is called by the SDK's auth() function to get the authorization code.
    */
   async prepareTokenRequest(): Promise<URLSearchParams | undefined> {
-    if (!this.authorizationCode) {
+    const authorizationCode = this.authorizationResponse?.code;
+    if (!authorizationCode) {
       return undefined;
     }
     if (!this.storedCodeVerifier) {
@@ -105,10 +202,32 @@ export class HeadlessConformanceOAuthProvider implements OAuthClientProvider {
 
     const params = new URLSearchParams();
     params.set("grant_type", "authorization_code");
-    params.set("code", this.authorizationCode);
+    params.set("code", authorizationCode);
     params.set("code_verifier", this.storedCodeVerifier);
     params.set("redirect_uri", this.redirectUri);
     return params;
+  }
+
+  private captureAuthorizationResponse(callbackUrl: URL): boolean {
+    const code = callbackUrl.searchParams.get("code");
+    if (!code) return false;
+
+    const returnedState = callbackUrl.searchParams.get("state");
+    if (
+      this.authorizationState !== undefined &&
+      returnedState !== this.authorizationState
+    ) {
+      throw new Error(
+        "OAuth callback state did not match the authorization request"
+      );
+    }
+
+    const iss = callbackUrl.searchParams.get("iss") ?? undefined;
+    this.authorizationResponse = {
+      code,
+      ...(iss !== undefined ? { iss } : {}),
+    };
+    return true;
   }
 }
 

--- a/libraries/typescript/packages/client/examples/conformance/src/oauth-retry-fetch.ts
+++ b/libraries/typescript/packages/client/examples/conformance/src/oauth-retry-fetch.ts
@@ -6,8 +6,12 @@
 
 import {
   auth,
+  computeScopeUnion,
   extractWWWAuthenticateParams,
+  isStrictScopeSuperset,
   type OAuthClientProvider,
+  type OAuthDiscoveryState,
+  type OAuthTokens,
 } from "@modelcontextprotocol/client";
 
 export type OAuthRetryFetchOptions = {
@@ -17,6 +21,10 @@ export type OAuthRetryFetchOptions = {
 
 type AuthProviderWithCode = OAuthClientProvider & {
   getAuthorizationCode(): Promise<string>;
+  getAuthorizationResponse?: () => Promise<{
+    code: string;
+    iss?: string;
+  }>;
 };
 
 function isInsufficientScope(response: Response): boolean {
@@ -28,23 +36,91 @@ async function runAuthFlow(
   provider: AuthProviderWithCode,
   serverUrl: string | URL,
   resourceMetadataUrl: URL | undefined,
-  scope: string | undefined
+  scope: string | undefined,
+  forceReauthorization = false
 ): Promise<void> {
   const authResult = await auth(provider, {
     serverUrl: typeof serverUrl === "string" ? serverUrl : serverUrl.toString(),
     resourceMetadataUrl,
     scope,
+    forceReauthorization,
   });
   if (authResult === "REDIRECT") {
-    const authCode = await provider.getAuthorizationCode();
+    // Keep getAuthorizationCode() for existing v0.1-style providers, while
+    // using the full callback response when available so v2 can validate the
+    // RFC 9207 issuer identification parameter.
+    const authorizationResponse = provider.getAuthorizationResponse
+      ? await provider.getAuthorizationResponse()
+      : { code: await provider.getAuthorizationCode() };
     await auth(provider, {
       serverUrl:
         typeof serverUrl === "string" ? serverUrl : serverUrl.toString(),
       resourceMetadataUrl,
       scope,
-      authorizationCode: authCode,
+      forceReauthorization,
+      authorizationCode: authorizationResponse.code,
+      ...(authorizationResponse.iss !== undefined
+        ? { iss: authorizationResponse.iss }
+        : {}),
     });
   }
+}
+
+function issuersMatch(a: string, b: string): boolean {
+  return (
+    a === b ||
+    (a.endsWith("/") && a.slice(0, -1) === b) ||
+    (b.endsWith("/") && b.slice(0, -1) === a)
+  );
+}
+
+function discoveryIssuer(
+  state: OAuthDiscoveryState | undefined
+): string | undefined {
+  return (
+    state?.authorizationServerMetadata?.issuer ?? state?.authorizationServerUrl
+  );
+}
+
+function isSameResourceMetadata(
+  state: OAuthDiscoveryState | undefined,
+  challengeUrl: URL | undefined
+): boolean {
+  return (
+    !challengeUrl ||
+    !state?.resourceMetadataUrl ||
+    state.resourceMetadataUrl === challengeUrl.toString()
+  );
+}
+
+/**
+ * Returns the active token's granted scope only when it is provably associated
+ * with the same authorization server and protected resource as the challenge.
+ * A retry fetch sees issuer-less bearer reads, so this guard prevents a most
+ * recently issued token for another authorization server from leaking scopes
+ * into a new authorization request.
+ */
+async function currentIssuerScope(
+  provider: AuthProviderWithCode,
+  challengeUrl: URL | undefined
+): Promise<{ scope?: string; tokens?: OAuthTokens }> {
+  const [tokens, discoveryState] = await Promise.all([
+    provider.tokens(),
+    provider.discoveryState?.(),
+  ]);
+  const issuer = discoveryIssuer(discoveryState);
+
+  if (
+    !tokens?.scope ||
+    !tokens.issuer ||
+    !issuer ||
+    !issuersMatch(tokens.issuer, issuer) ||
+    !isSameResourceMetadata(discoveryState, challengeUrl)
+  ) {
+    return { tokens };
+  }
+
+  return { scope: tokens.scope, tokens };
 }
 
 /**
@@ -110,11 +186,30 @@ export function createOAuthRetryFetch(
         });
       }
 
+      if (is401) {
+        // A 401 can mean the resource changed its authorization server. Drop
+        // only discovery before auth() so it fetches the current PRM/AS
+        // metadata and resolves issuer-keyed credentials afresh. Client and
+        // token entries stay available for their original issuer.
+        await authProvider.invalidateCredentials?.("discovery");
+      }
+
       await response.text();
       const { resourceMetadataUrl, scope } =
         extractWWWAuthenticateParams(response);
 
-      await runAuthFlow(authProvider, serverUrl, resourceMetadataUrl, scope);
+      const current = is403Scope
+        ? await currentIssuerScope(authProvider, resourceMetadataUrl)
+        : {};
+      const requestedScope = computeScopeUnion(current.scope, scope);
+
+      await runAuthFlow(
+        authProvider,
+        serverUrl,
+        resourceMetadataUrl,
+        requestedScope,
+        isStrictScopeSuperset(requestedScope, current.tokens?.scope)
+      );
 
       const tokens = await authProvider.tokens();
       const accessToken = tokens?.access_token;

--- a/libraries/typescript/packages/client/src/core/session.ts
+++ b/libraries/typescript/packages/client/src/core/session.ts
@@ -51,8 +51,8 @@ export interface MCPConnectionInfo {
   protocolEra: MCPProtocolEra;
   /** Negotiated MCP protocol version. */
   protocolVersion: string;
-  /** Server identity reported during negotiation. */
-  server: MCPServerInfo;
+  /** Server identity reported during negotiation, when provided. */
+  server?: MCPServerInfo;
   /** Capabilities advertised by the server. */
   capabilities: Record<string, unknown>;
   /** Instructions advertised by the server. */
@@ -369,7 +369,7 @@ export class MCPConnection {
     const protocolVersion = this.negotiatedProtocolVersion;
     const server = this.serverInfo;
 
-    if (!protocolEra || !protocolVersion || !server) {
+    if (!protocolEra || !protocolVersion) {
       throw new Error("MCP connection is not initialized");
     }
 
@@ -384,7 +384,7 @@ export class MCPConnection {
     return {
       protocolEra,
       protocolVersion,
-      server,
+      ...(server ? { server } : {}),
       capabilities,
       instructions: this.connector.instructions,
       extensions,

--- a/libraries/typescript/packages/client/src/transport/base.ts
+++ b/libraries/typescript/packages/client/src/transport/base.ts
@@ -35,10 +35,13 @@ const passthroughResultSchema = {
     validate: (value: unknown) => ({ value }),
   },
 };
+
 import type { ConnectionManager } from "./connection-manager.js";
 import type { ConnectorInitEventData } from "../telemetry/events.js";
 import { trackConnectorTelemetry } from "../telemetry/connector-telemetry.js";
 import type { MCPServerInfo } from "../core/session.js";
+
+const SERVER_INFO_META_KEY = "io.modelcontextprotocol/serverInfo";
 
 /**
  * Handles a notification received from an MCP server.
@@ -521,8 +524,20 @@ export abstract class BaseConnector {
     const capabilities = this.client.getServerCapabilities();
     this.capabilitiesCache = (capabilities as Record<string, unknown>) || null;
 
-    // Cache server info from the initialize response
-    const serverInfo = this.client.getServerVersion();
+    // Legacy servers report their identity in the initialize response. Modern
+    // servers report it through server/discover; alpha.10 uses a top-level
+    // field while the current revision places it in result metadata. Prefer
+    // the SDK's normalized accessor when it is available.
+    const discover = this.client.getDiscoverResult() as
+      | {
+          serverInfo?: ReturnType<Client["getServerVersion"]>;
+          _meta?: Record<string, ReturnType<Client["getServerVersion"]>>;
+        }
+      | undefined;
+    const serverInfo =
+      this.client.getServerVersion() ??
+      discover?.serverInfo ??
+      discover?._meta?.[SERVER_INFO_META_KEY];
     this.serverInfoCache = serverInfo
       ? {
           name: serverInfo.name,

--- a/libraries/typescript/packages/client/src/transport/base.ts
+++ b/libraries/typescript/packages/client/src/transport/base.ts
@@ -41,8 +41,6 @@ import type { ConnectorInitEventData } from "../telemetry/events.js";
 import { trackConnectorTelemetry } from "../telemetry/connector-telemetry.js";
 import type { MCPServerInfo } from "../core/session.js";
 
-const SERVER_INFO_META_KEY = "io.modelcontextprotocol/serverInfo";
-
 /**
  * Handles a notification received from an MCP server.
  *
@@ -524,20 +522,9 @@ export abstract class BaseConnector {
     const capabilities = this.client.getServerCapabilities();
     this.capabilitiesCache = (capabilities as Record<string, unknown>) || null;
 
-    // Legacy servers report their identity in the initialize response. Modern
-    // servers report it through server/discover; alpha.10 uses a top-level
-    // field while the current revision places it in result metadata. Prefer
-    // the SDK's normalized accessor when it is available.
-    const discover = this.client.getDiscoverResult() as
-      | {
-          serverInfo?: ReturnType<Client["getServerVersion"]>;
-          _meta?: Record<string, ReturnType<Client["getServerVersion"]>>;
-        }
-      | undefined;
-    const serverInfo =
-      this.client.getServerVersion() ??
-      discover?.serverInfo ??
-      discover?._meta?.[SERVER_INFO_META_KEY];
+    // The SDK normalizes identity from legacy initialize responses and modern
+    // result metadata. Modern servers may remain anonymous.
+    const serverInfo = this.client.getServerVersion();
     this.serverInfoCache = serverInfo
       ? {
           name: serverInfo.name,

--- a/libraries/typescript/packages/client/tests/unit/client/protocol-era.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/client/protocol-era.test.ts
@@ -25,6 +25,7 @@ describe("protocol era exposure", () => {
         extensions: { "com.example/feature": { enabled: true } },
       }),
       getInstructions: () => "Use the server carefully.",
+      listTools: async () => ({ tools: [] }),
     };
     (connector as any).serverInfoCache = server ?? null;
     (connector as any).capabilitiesCache = {
@@ -82,45 +83,17 @@ describe("protocol era exposure", () => {
     expect(session.supports("resources")).toBe(false);
   });
 
-  it.each([
-    {
-      description: "a top-level serverInfo field",
-      discover: (serverInfo: object) => ({ serverInfo }),
-    },
-    {
-      description: "result metadata",
-      discover: (serverInfo: object) => ({
-        _meta: { "io.modelcontextprotocol/serverInfo": serverInfo },
-      }),
-    },
-  ])(
-    "uses $description when a modern client has no server version",
-    async ({ discover }) => {
-      const serverInfo = {
-        name: "conformance",
-        version: "2.0.0",
-        description: "Modern conformance server",
-      };
-      const connector = new BaseConnector();
-      (connector as any).client = {
-        getProtocolEra: () => "modern",
-        getNegotiatedProtocolVersion: () => "2026-07-28",
-        getServerCapabilities: () => ({ tools: {} }),
-        getServerVersion: () => undefined,
-        getDiscoverResult: () => discover(serverInfo),
-        getInstructions: () => undefined,
-        listTools: async () => ({ tools: [] }),
-      };
+  it("treats an anonymous modern server as initialized", async () => {
+    const connector = connectorWithClient("modern", "2026-07-28");
+    await connector.initialize();
+    const info = new MCPSession(connector).info;
 
-      await connector.initialize();
-
-      expect(new MCPSession(connector).info).toMatchObject({
-        protocolEra: "modern",
-        protocolVersion: "2026-07-28",
-        server: serverInfo,
-      });
-    }
-  );
+    expect(info).toMatchObject({
+      protocolEra: "modern",
+      protocolVersion: "2026-07-28",
+    });
+    expect(info).not.toHaveProperty("server");
+  });
 
   it("automatically negotiates the newest supported HTTP protocol", () => {
     const connector = new HttpConnector("https://example.com/mcp");

--- a/libraries/typescript/packages/client/tests/unit/client/protocol-era.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/client/protocol-era.test.ts
@@ -82,6 +82,46 @@ describe("protocol era exposure", () => {
     expect(session.supports("resources")).toBe(false);
   });
 
+  it.each([
+    {
+      description: "a top-level serverInfo field",
+      discover: (serverInfo: object) => ({ serverInfo }),
+    },
+    {
+      description: "result metadata",
+      discover: (serverInfo: object) => ({
+        _meta: { "io.modelcontextprotocol/serverInfo": serverInfo },
+      }),
+    },
+  ])(
+    "uses $description when a modern client has no server version",
+    async ({ discover }) => {
+      const serverInfo = {
+        name: "conformance",
+        version: "2.0.0",
+        description: "Modern conformance server",
+      };
+      const connector = new BaseConnector();
+      (connector as any).client = {
+        getProtocolEra: () => "modern",
+        getNegotiatedProtocolVersion: () => "2026-07-28",
+        getServerCapabilities: () => ({ tools: {} }),
+        getServerVersion: () => undefined,
+        getDiscoverResult: () => discover(serverInfo),
+        getInstructions: () => undefined,
+        listTools: async () => ({ tools: [] }),
+      };
+
+      await connector.initialize();
+
+      expect(new MCPSession(connector).info).toMatchObject({
+        protocolEra: "modern",
+        protocolVersion: "2026-07-28",
+        server: serverInfo,
+      });
+    }
+  );
+
   it("automatically negotiates the newest supported HTTP protocol", () => {
     const connector = new HttpConnector("https://example.com/mcp");
     expect((connector as any).protocolNegotiation).toBe("auto");

--- a/libraries/typescript/packages/server/examples/conformance/expected-failures.yml
+++ b/libraries/typescript/packages/server/examples/conformance/expected-failures.yml
@@ -1,0 +1,16 @@
+server:
+  # Stateless legacy HTTP cannot send server-to-client requests.
+  - tools-call-sampling
+  - tools-call-elicitation
+  - elicitation-sep1034-defaults
+  - elicitation-sep1330-enums
+
+  # Stateless legacy HTTP has no session or SSE resumability.
+  - server-sse-polling:server-sse-polling-session
+  - server-sse-polling:server-sse-priming-event
+  - server-sse-polling:server-sse-retry-field
+  - server-sse-multiple-streams:server-sse-multiple-streams-session
+
+  # Stateless legacy HTTP does not retain resource subscriptions.
+  - resources-subscribe
+  - resources-unsubscribe

--- a/libraries/typescript/packages/server/examples/conformance/src/index.ts
+++ b/libraries/typescript/packages/server/examples/conformance/src/index.ts
@@ -9,6 +9,7 @@
 import {
   acceptedContent,
   completable,
+  createRequestStateCodec,
   inputRequired,
   inputResponse,
   MCPServer,
@@ -34,6 +35,50 @@ const weatherOutputSchema = z.object({
   windSpeed: z.number(),
 });
 
+const conformanceRequestState = createRequestStateCodec<{
+  scenario: string;
+  round: number;
+}>({
+  // This is a deterministic fixture key, not an application secret. Its only
+  // purpose is to exercise the requestState integrity contract.
+  key: new Uint8Array(32).fill(17),
+  ttlSeconds: 60,
+});
+
+const nameSchema = z.object({ name: z.string() });
+const confirmationSchema = z.object({ ok: z.boolean() });
+const colorSchema = z.object({ color: z.string() });
+
+const jsonSchema202012ToolSchema = z
+  .object({
+    name: z.string().optional(),
+    address: z.object({ street: z.string(), city: z.string() }).optional(),
+    contactMethod: z.enum(["phone", "email"]).optional(),
+    phone: z.string().optional(),
+    email: z.string().optional(),
+  })
+  .meta({
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    $defs: {
+      address: {
+        $anchor: "addressDef",
+        type: "object",
+        properties: {
+          street: { type: "string" },
+          city: { type: "string" },
+        },
+      },
+    },
+    allOf: [{ anyOf: [{ required: ["phone"] }, { required: ["email"] }] }],
+    if: {
+      properties: { contactMethod: { const: "phone" } },
+      required: ["contactMethod"],
+    },
+    then: { required: ["phone"] },
+    else: { required: ["email"] },
+    additionalProperties: false,
+  });
+
 const server = new MCPServer({
   name: "ConformanceTestServer",
   version: "1.0.0",
@@ -48,6 +93,7 @@ const server = new MCPServer({
     },
   ],
   logging: { level: "debug" },
+  requestState: { verify: conformanceRequestState.verify },
 });
 
 // =============================================================================
@@ -461,6 +507,430 @@ server.tool(
 );
 
 // =============================================================================
+// STATELESS (2026-07-28) CONFORMANCE FIXTURES
+// =============================================================================
+
+server.tool(
+  {
+    name: "json_schema_2020_12_tool",
+    description: "Tool with JSON Schema 2020-12 features",
+    inputSchema: jsonSchema202012ToolSchema,
+  },
+  async () => ({ content: [{ type: "text", text: "JSON Schema accepted" }] })
+);
+
+server.tool(
+  {
+    name: "test_custom_header",
+    description: "Exercises the x-mcp-header transport parameter fixture",
+    inputSchema: z.object({
+      value: z.string().meta({ "x-mcp-header": "Conformance-Value" }),
+    }),
+  },
+  async ({ value }) => ({
+    content: [{ type: "text", text: `Custom header value: ${value}` }],
+  })
+);
+
+server.tool(
+  {
+    name: "test_input_required_result_elicitation",
+    description:
+      "Requests and validates an elicitation response across retries",
+  },
+  async (_input, ctx) => {
+    const form = acceptedContent(ctx.inputResponses, "user_name", nameSchema);
+    if (form === undefined) {
+      return inputRequired({
+        inputRequests: {
+          user_name: inputRequired.elicit({
+            message: "What is your name?",
+            requestedSchema: nameSchema,
+          }),
+        },
+      });
+    }
+    return { content: [{ type: "text", text: `Hello, ${form.name}!` }] };
+  }
+);
+
+server.tool(
+  {
+    name: "test_input_required_result_sampling",
+    description: "Requests a sampling response through an input_required retry",
+  },
+  async (_input, ctx) => {
+    const response = inputResponse(ctx.inputResponses, "capital_question");
+    if (response.kind !== "sampling") {
+      return inputRequired({
+        inputRequests: {
+          capital_question: inputRequired.createMessage({
+            messages: [
+              {
+                role: "user",
+                content: {
+                  type: "text",
+                  text: "What is the capital of France?",
+                },
+              },
+            ],
+            maxTokens: 100,
+          }),
+        },
+      });
+    }
+    const content = Array.isArray(response.result.content)
+      ? response.result.content
+      : [response.result.content];
+    const text = content
+      .map((block) =>
+        block.type === "text" ? block.text : JSON.stringify(block)
+      )
+      .join("\n");
+    return {
+      content: [{ type: "text", text: text || "No sampling response" }],
+    };
+  }
+);
+
+server.tool(
+  {
+    name: "test_input_required_result_list_roots",
+    description: "Requests the client's roots through an input_required retry",
+  },
+  async (_input, ctx) => {
+    const response = inputResponse(ctx.inputResponses, "client_roots");
+    if (response.kind !== "roots") {
+      return inputRequired({
+        inputRequests: { client_roots: inputRequired.listRoots() },
+      });
+    }
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Received ${response.roots.length} client root(s)`,
+        },
+      ],
+    };
+  }
+);
+
+server.tool(
+  {
+    name: "test_input_required_result_request_state",
+    description: "Verifies integrity-protected requestState round-tripping",
+  },
+  async (_input, ctx) => {
+    const state = ctx.requestState<{ scenario: string; round: number }>();
+    const confirmation = acceptedContent(
+      ctx.inputResponses,
+      "confirm",
+      confirmationSchema
+    );
+    if (
+      state?.scenario !== "request-state" ||
+      state.round !== 1 ||
+      confirmation === undefined
+    ) {
+      return inputRequired({
+        inputRequests: {
+          confirm: inputRequired.elicit({
+            message: "Please confirm",
+            requestedSchema: confirmationSchema,
+          }),
+        },
+        requestState: await conformanceRequestState.mint({
+          scenario: "request-state",
+          round: 1,
+        }),
+      });
+    }
+    return { content: [{ type: "text", text: "state-ok" }] };
+  }
+);
+
+server.tool(
+  {
+    name: "test_input_required_result_multiple_inputs",
+    description: "Requests elicitation, sampling, and roots in one retry",
+  },
+  async (_input, ctx) => {
+    const name = acceptedContent(ctx.inputResponses, "user_name", nameSchema);
+    const sample = inputResponse(ctx.inputResponses, "greeting");
+    const roots = inputResponse(ctx.inputResponses, "client_roots");
+    const state = ctx.requestState<{ scenario: string; round: number }>();
+    if (
+      state?.scenario !== "multiple-inputs" ||
+      name === undefined ||
+      sample.kind !== "sampling" ||
+      roots.kind !== "roots"
+    ) {
+      return inputRequired({
+        inputRequests: {
+          user_name: inputRequired.elicit({
+            message: "What is your name?",
+            requestedSchema: nameSchema,
+          }),
+          greeting: inputRequired.createMessage({
+            messages: [
+              {
+                role: "user",
+                content: { type: "text", text: "Generate a greeting" },
+              },
+            ],
+            maxTokens: 50,
+          }),
+          client_roots: inputRequired.listRoots(),
+        },
+        requestState: await conformanceRequestState.mint({
+          scenario: "multiple-inputs",
+          round: 1,
+        }),
+      });
+    }
+    return { content: [{ type: "text", text: `Hello, ${name.name}!` }] };
+  }
+);
+
+server.tool(
+  {
+    name: "test_input_required_result_multi_round",
+    description: "Runs a two-stage input_required elicitation flow",
+  },
+  async (_input, ctx) => {
+    const state = ctx.requestState<{ scenario: string; round: number }>();
+    if (state?.scenario !== "multi-round" || state.round === 1) {
+      const name = acceptedContent(ctx.inputResponses, "step1", nameSchema);
+      if (name !== undefined && state?.round === 1) {
+        return inputRequired({
+          inputRequests: {
+            step2: inputRequired.elicit({
+              message: "Step 2: What is your favorite color?",
+              requestedSchema: colorSchema,
+            }),
+          },
+          requestState: await conformanceRequestState.mint({
+            scenario: "multi-round",
+            round: 2,
+          }),
+        });
+      }
+      return inputRequired({
+        inputRequests: {
+          step1: inputRequired.elicit({
+            message: "Step 1: What is your name?",
+            requestedSchema: nameSchema,
+          }),
+        },
+        requestState: await conformanceRequestState.mint({
+          scenario: "multi-round",
+          round: 1,
+        }),
+      });
+    }
+    const color = acceptedContent(ctx.inputResponses, "step2", colorSchema);
+    if (color === undefined) {
+      return inputRequired({
+        inputRequests: {
+          step2: inputRequired.elicit({
+            message: "Step 2: What is your favorite color?",
+            requestedSchema: colorSchema,
+          }),
+        },
+        requestState: await conformanceRequestState.mint({
+          scenario: "multi-round",
+          round: 2,
+        }),
+      });
+    }
+    return { content: [{ type: "text", text: `Color: ${color.color}` }] };
+  }
+);
+
+server.tool(
+  {
+    name: "test_input_required_result_tampered_state",
+    description: "Rejects tampered requestState values before completing",
+  },
+  async (_input, ctx) => {
+    const state = ctx.requestState<{ scenario: string; round: number }>();
+    const confirmation = acceptedContent(
+      ctx.inputResponses,
+      "confirm",
+      confirmationSchema
+    );
+    if (
+      state?.scenario !== "tampered-state" ||
+      state.round !== 1 ||
+      confirmation === undefined
+    ) {
+      return inputRequired({
+        inputRequests: {
+          confirm: inputRequired.elicit({
+            message: "Confirm this request",
+            requestedSchema: confirmationSchema,
+          }),
+        },
+        requestState: await conformanceRequestState.mint({
+          scenario: "tampered-state",
+          round: 1,
+        }),
+      });
+    }
+    return { content: [{ type: "text", text: "confirmed" }] };
+  }
+);
+
+server.tool(
+  {
+    name: "test_input_required_result_capabilities",
+    description: "Only requests interactive methods declared by the client",
+  },
+  async (_input, ctx) => {
+    if (ctx.client.can("sampling")) {
+      return inputRequired({
+        inputRequests: {
+          sample: inputRequired.createMessage({
+            messages: [
+              { role: "user", content: { type: "text", text: "Say hello" } },
+            ],
+            maxTokens: 20,
+          }),
+        },
+      });
+    }
+    if (ctx.client.can("elicitation")) {
+      return inputRequired({
+        inputRequests: {
+          name: inputRequired.elicit({
+            message: "What is your name?",
+            requestedSchema: nameSchema,
+          }),
+        },
+      });
+    }
+    return { content: [{ type: "text", text: "No interactive capability" }] };
+  }
+);
+
+server.prompt(
+  {
+    name: "test_input_required_result_prompt",
+    description:
+      "Prompt fixture that requests elicited context before completion",
+  },
+  async (_args, ctx) => {
+    const context = acceptedContent(
+      ctx.inputResponses,
+      "user_context",
+      z.object({ context: z.string() })
+    );
+    if (context === undefined) {
+      return inputRequired({
+        inputRequests: {
+          user_context: inputRequired.elicit({
+            message: "What context should the prompt use?",
+            requestedSchema: z.object({ context: z.string() }),
+          }),
+        },
+      });
+    }
+    return {
+      messages: [
+        { role: "user", content: { type: "text", text: context.context } },
+      ],
+    };
+  }
+);
+
+server.tool(
+  {
+    name: "test_missing_capability",
+    description: "Exercises missing client-capability validation for sampling",
+  },
+  async (_input, ctx) => {
+    // Returning a sampling request delegates the -32021 capability error to
+    // the protocol runtime when this request did not advertise sampling.
+    if (!ctx.client.can("sampling")) {
+      return inputRequired({
+        inputRequests: {
+          sample: inputRequired.createMessage({
+            messages: [
+              {
+                role: "user",
+                content: { type: "text", text: "Capability check" },
+              },
+            ],
+            maxTokens: 20,
+          }),
+        },
+      });
+    }
+    return { content: [{ type: "text", text: "sampling available" }] };
+  }
+);
+
+server.tool(
+  {
+    name: "test_streaming_elicitation",
+    description:
+      "Produces an elicitation input_required result for stream checks",
+  },
+  async (_input, ctx) => {
+    if (
+      acceptedContent(ctx.inputResponses, "stream", nameSchema) === undefined
+    ) {
+      return inputRequired({
+        inputRequests: {
+          stream: inputRequired.elicit({
+            message: "Provide a streaming name",
+            requestedSchema: nameSchema,
+          }),
+        },
+      });
+    }
+    return { content: [{ type: "text", text: "stream completed" }] };
+  }
+);
+
+server.tool(
+  {
+    name: "test_logging_tool",
+    description:
+      "Diagnostic tool that completes without unsolicited log frames",
+  },
+  async (_input, ctx) => {
+    // Deliberately avoid emitting a protocol log here. The stateless scenario
+    // invokes this diagnostic without the per-request log-level descriptor.
+    void ctx;
+    return { content: [{ type: "text", text: "logging complete" }] };
+  }
+);
+
+server.tool(
+  {
+    name: "test_trigger_tool_change",
+    description: "Publishes a tools/list_changed subscription notification",
+  },
+  async () => {
+    await server.notifyToolsChanged();
+    return { content: [{ type: "text", text: "tool list changed" }] };
+  }
+);
+
+server.tool(
+  {
+    name: "test_trigger_prompt_change",
+    description: "Publishes a prompts/list_changed subscription notification",
+  },
+  async () => {
+    await server.notifyPromptsChanged();
+    return { content: [{ type: "text", text: "prompt list changed" }] };
+  }
+);
+
+// =============================================================================
 // RESOURCES
 // =============================================================================
 
@@ -590,8 +1060,8 @@ server.prompt(
     name: "test_prompt_with_arguments",
     description: "A prompt that accepts arguments",
     schema: z.object({
-      arg1: completable(z.string().optional(), () => ["default1"]),
-      arg2: completable(z.string().optional(), () => ["default2"]),
+      arg1: completable(z.string(), () => ["default1"]).optional(),
+      arg2: completable(z.string(), () => ["default2"]).optional(),
     }),
   },
   async ({ arg1 = "default1", arg2 = "default2" }) => ({

--- a/libraries/typescript/packages/server/examples/verify-examples.mjs
+++ b/libraries/typescript/packages/server/examples/verify-examples.mjs
@@ -200,7 +200,7 @@ async function verifyWithClient(cwd, example, packageJson) {
 
 async function assertConnection(connection, example, origin, websiteOrigin) {
   // `info` proves initialize completed through mcp-use's normal negotiation.
-  if (!connection.info.server.name || !connection.info.protocolVersion) {
+  if (!connection.info.server?.name || !connection.info.protocolVersion) {
     throw new Error("Client completed initialization without server metadata.");
   }
   await assertNamed(() => connection.listTools(), example.tools, "tool");

--- a/libraries/typescript/packages/server/src/mcp-proxy.ts
+++ b/libraries/typescript/packages/server/src/mcp-proxy.ts
@@ -59,7 +59,7 @@ export interface ProxyRequestOptions {
 /** Structural connection contract accepted by the low-level proxy overload. */
 export interface ProxyConnection {
   /** Negotiated metadata used to derive the automatic capability namespace. */
-  readonly info: { server: { name: string } };
+  readonly info: { server?: { name: string } };
   /** Whether the upstream advertised a named MCP capability. */
   supports?(capability: string): boolean;
   /** List upstream tools. */
@@ -458,7 +458,12 @@ export async function mountProxyConnection(
       "Cannot call proxy() after the server has started: register upstream servers before listen()/server.fetch."
     );
   }
-  const namespace = connection.info.server.name;
+  const namespace = connection.info.server?.name;
+  if (!namespace) {
+    throw new Error(
+      "Cannot proxy an anonymous MCP connection directly: the upstream server did not report a name for namespace generation."
+    );
+  }
   const plan = await introspect(namespace, connection);
   mountPlan(host, plan);
 }

--- a/libraries/typescript/packages/server/src/server.ts
+++ b/libraries/typescript/packages/server/src/server.ts
@@ -693,7 +693,8 @@ export class MCPServer<TUser = never, TEnv extends Env = Env> {
    * `@mcp-use/client` v2 peer. Each key automatically namespaces its mounted
    * tools, resources, and prompts. You may instead pass an existing ready
    * {@link ProxyConnection}; its negotiated server name becomes the namespace
-   * and the connection remains caller-owned.
+   * and the connection remains caller-owned. Anonymous connections cannot use
+   * this overload because they do not provide a namespace.
    *
    * Connection, introspection, and collision failures are diagnosed and
    * skipped without discarding capabilities that can be mounted.
@@ -718,8 +719,9 @@ export class MCPServer<TUser = never, TEnv extends Env = Env> {
    *
    * @param connection - Ready connection to introspect and forward through.
    * The connection's negotiated server name automatically namespaces every
-   * mounted capability. Introspection and collision failures are diagnosed and
-   * skipped without discarding capabilities that can be mounted.
+   * mounted capability. Anonymous connections are rejected because they do not
+   * provide a namespace. Introspection and collision failures are diagnosed
+   * and skipped without discarding capabilities that can be mounted.
    *
    * @throws If the server already started or closed.
    *

--- a/libraries/typescript/packages/server/tests/proxy.test.ts
+++ b/libraries/typescript/packages/server/tests/proxy.test.ts
@@ -346,6 +346,33 @@ describe("MCPServer.proxy", () => {
     );
   });
 
+  it("rejects a direct anonymous connection without a proxy namespace", async () => {
+    const parent = new MCPServer({ name: "parent", version: "1.0.0" });
+    servers.push(parent);
+    const connection: ProxyConnection = {
+      info: {},
+      async listTools() {
+        return [];
+      },
+      async callTool() {
+        return { content: [] };
+      },
+      async readResource() {
+        return { contents: [] };
+      },
+      async listPrompts() {
+        return { prompts: [] };
+      },
+      async getPrompt() {
+        return { messages: [] };
+      },
+    };
+
+    await expect(parent.proxy(connection)).rejects.toThrow(
+      "Cannot proxy an anonymous MCP connection directly"
+    );
+  });
+
   it("contains rejected downstream progress notifications", async () => {
     const diagnostics = vi.spyOn(console, "error").mockImplementation(() => {});
     let mountedTool:


### PR DESCRIPTION
## Summary

- keep Python conformance on the existing v1 runner, pinned to `0.1.16`
- add a separate TypeScript runner pinned to `@modelcontextprotocol/conformance@0.2.0-alpha.10` and protocol `2026-07-28`
- expand the TypeScript server fixture for all v2 stateless, header, JSON Schema, completion, and multi-round input scenarios
- update Node, browser, and React client adapters for v2 context, headers, protocol negotiation, and OAuth issuer/migration/scope behavior
- publish TypeScript v2 results separately while retaining the existing Python comment flow

## Why

A runner-only version bump was insufficient: Python has not migrated to the v2 SDK, while the TypeScript v2 suite requires explicit protocol pinning and additional scenario contracts. Splitting the runners prevents Python coverage from changing while allowing TypeScript to track the draft v2 protocol.

## Impact

Python behavior remains unchanged on conformance `0.1.16`. TypeScript now runs the complete v2 server and client suites as an independent CI gate.

## Validation

- TypeScript build and both conformance example typechecks passed
- server: 40 scenarios, 114 passed, 0 failed
- Node client: 32 scenarios, 367 passed, 0 failed or warnings
- browser client: 32 scenarios, 367 passed, 0 failed or warnings
- React client: 32 scenarios, 429 passed, 0 failed or warnings
- workflow YAML parsing and `git diff --check` passed

## Stack

Depends on the server framework changes in the parent PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds MCP v2 TypeScript conformance for both legacy (2025-11-25) and modern (2026-07-28) using a separate runner pinned to `@modelcontextprotocol/conformance@0.2.0-alpha.10`; Python stays on the v1 runner at `0.1.16`. Server now accepts anonymous modern clients; direct proxying of anonymous upstreams is rejected with a clear error.

- **New Features**
  - Split CI: Python v1 job only; a TypeScript job runs server plus Node, browser, and React across legacy and modern spec versions. Legacy server exclusions are in `expected-failures.yml`. TypeScript uploads `typescript-v2-conformance-results`. The comment workflow posts only when v1 artifacts exist and skips if missing.
  - V2 server fixture: adds stateless scenarios—request-state integrity (SEP-2322), transport headers (standard + custom), JSON Schema 2020-12 tool, elicitation/sampling/roots, multi-round input_required, prompt elicitation, streaming checks, capability validation, and subscription change notifications.
  - Client examples: add `conformanceClientOptions` for version negotiation, parse conformance context (including header values and `toolCalls`), handle sampling and elicitation, use resources/prompts APIs, disable OAuth when not needed, use pre-registration context, forward RFC 9207 `iss`, and simplify React setup.
  - OAuth: headless provider keys client/tokens by issuer, saves discovery state, verifies `state`, exposes full authorization response, supports granular `invalidateCredentials`, and returns the latest token for issuer-less reads.
  - Retry fetch: unions scopes across 401/403, forces reauth only when needed, drops discovery on 401, and prevents cross-issuer scope leakage.

- **Bug Fixes**
  - Client: allow modern MCP connections to remain ready when the server omits optional identity metadata; unit test added and `@mcp-use/client` patched.
  - Server/Proxy: accept anonymous client connections; reject anonymous upstreams in `proxy()` with a clear namespace error and add coverage.

<sup>Written for commit d47466d0436271b1f0f538122aa635d9bba9b505. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

