### PR TITLE
Add oauthMcpbundlesProvider for MCPBundles Connect Auth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# thinkchainai/mcp-use — Agent Context
+
+Org fork of [mcp-use/mcp-use](https://github.com/mcp-use/mcp-use) for MCPBundles Connect Auth upstream work.
+
+Submodule path in MCPBundles monorepo: `public_github_repos/mcp-use`.
+
+**Execution checklist:** parent repo `product/mcp-connect-auth/coding-plan.md` § P7c.
+
+## Remotes
+
+| Remote | URL | Use |
+|--------|-----|-----|
+| `origin` | `https://github.com/thinkchainai/mcp-use.git` | Push feature branches; open PRs to mcp-use |
+| `upstream` | `https://github.com/mcp-use/mcp-use.git` | Sync before new work |
+
+```bash
+git fetch upstream
+git checkout main
+git merge upstream/main   # or rebase feature branch onto upstream/main
+```
+
+## Target integration
+
+TypeScript **resource-server** OAuth provider for MCP Connect Auth — mirror WorkOS/Auth0 providers:
+
+- `libraries/typescript/packages/server/src/oauth/mcpbundles.ts` — `oauthMcpbundlesProvider()`
+- Tests in `libraries/typescript/packages/server/tests/oauth-direct-providers.test.ts`
+- Example: `libraries/typescript/packages/server/examples/auth/mcpbundles/`
+- Docs: `docs/typescript/server/authentication/providers/mcpbundles.mdx`
+
+Port JWT verify + `public-config` fetch from `@mcpbundles/mcp-connect-auth` (parent submodule `public_github_repos/mcp-connect-auth-js`).
+
+## Workflow
+
+1. Branch: `mcpbundles-connect-provider` (created).
+2. Implement provider + tests + docs + example.
+3. `cd libraries/typescript && pnpm install && pnpm build && pnpm changeset`
+4. Push to **`origin`**; open PR **`mcp-use/mcp-use`** from `thinkchainai/mcp-use:<branch>`.
+5. Parent monorepo bumps submodule SHA on `main` while PR is open.
+
+## Rules
+
+- Follow existing `oauthWorkOSProvider` / `oauthCustomProvider` patterns — DCR-direct flow, JWKS verify.
+- No secrets in examples; federation secret stays on vendor web app only.
+- Integration doc link: `https://www.mcpbundles.com/docs/integrations/mcp-connect-auth`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,8 @@ Org fork of [mcp-use/mcp-use](https://github.com/mcp-use/mcp-use) for MCPBundles
 
 Submodule path in MCPBundles monorepo: `public_github_repos/mcp-use`.
 
-**Execution checklist:** parent repo `product/mcp-connect-auth/coding-plan.md` § P7c.
+**Execution checklist:** parent repo `product/mcp-connect-auth/coding-plan.md` § P7c.  
+**Implementation plan:** `product/mcp-connect-auth/log/2026-08-05-p7c-mcp-use-plan.md`
 
 ## Remotes
 
@@ -23,10 +24,11 @@ git merge upstream/main   # or rebase feature branch onto upstream/main
 
 TypeScript **resource-server** OAuth provider for MCP Connect Auth — mirror WorkOS/Auth0 providers:
 
-- `libraries/typescript/packages/server/src/oauth/mcpbundles.ts` — `oauthMcpbundlesProvider()`
+- `libraries/typescript/packages/server/src/oauth/mcpbundles.ts` — `oauthMcpbundlesProvider()` **implemented locally**
 - Tests in `libraries/typescript/packages/server/tests/oauth-direct-providers.test.ts`
 - Example: `libraries/typescript/packages/server/examples/auth/mcpbundles/`
-- Docs: `docs/typescript/server/authentication/providers/mcpbundles.mdx`
+- Docs: `docs/typescript/.../mcpbundles.mdx` + `docs/v2/.../mcpbundles.mdx`
+- Changeset: `libraries/typescript/.changeset/mcpbundles-oauth-provider.md`
 
 Port JWT verify + `public-config` fetch from `@mcpbundles/mcp-connect-auth` (parent submodule `public_github_repos/mcp-connect-auth-js`).
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -93,6 +93,7 @@
                               "typescript/server/authentication/providers/better-auth",
                               "typescript/server/authentication/providers/clerk",
                               "typescript/server/authentication/providers/keycloak",
+                              "typescript/server/authentication/providers/mcpbundles",
                               "typescript/server/authentication/providers/supabase",
                               "typescript/server/authentication/providers/workos",
                               "typescript/server/authentication/providers/oauth-proxy",
@@ -332,6 +333,7 @@
                               "v2/typescript/server/authentication/providers/better-auth",
                               "v2/typescript/server/authentication/providers/clerk",
                               "v2/typescript/server/authentication/providers/keycloak",
+                              "v2/typescript/server/authentication/providers/mcpbundles",
                               "v2/typescript/server/authentication/providers/supabase",
                               "v2/typescript/server/authentication/providers/workos",
                               "v2/typescript/server/authentication/providers/custom"

--- a/docs/images/icons/mcpbundles.svg
+++ b/docs/images/icons/mcpbundles.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 128 128"><rect width="52" height="52" x="14" y="38" rx="10" fill="#9E9E9E"/><rect width="52" height="52" x="62" y="38" rx="10" fill="#9E9E9E" fill-opacity=".55"/><path fill="#9E9E9E" d="M38 24h52a6 6 0 0 1 6 6v8H32v-8a6 6 0 0 1 6-6Z"/></svg>

--- a/docs/typescript/server/authentication/providers/mcpbundles.mdx
+++ b/docs/typescript/server/authentication/providers/mcpbundles.mdx
@@ -1,9 +1,10 @@
 ---
 title: "MCPBundles Provider"
 description: "Configure MCPBundles Connect Auth for a TypeScript MCP server on the vendor origin."
+icon: "/images/icons/mcpbundles.svg"
 ---
 
-Use `oauthMcpbundlesProvider` when your MCP server is published on MCPBundles with **Connect Auth** enabled and clients authenticate against the MCPBundles tenant authorization server. mcp-use verifies ES256 access tokens against the tenant JWKS and maps Connect Auth claims into `ctx.auth`.
+Use `oauthMcpbundlesProvider` when you manage an MCP server listing on MCPBundles with **Connect Auth** enabled and clients authenticate against the MCPBundles tenant authorization server. mcp-use verifies ES256 access tokens against the tenant JWKS and maps Connect Auth claims into `ctx.auth`.
 
 This guide covers the **vendor origin** path (Path A). Clients may also connect through the MCPBundles bundle proxy at `https://mcp.mcpbundles.com/bundle/{slug}` without running this provider.
 
@@ -13,7 +14,7 @@ See the [auth providers API reference](/typescript/api-reference/server/auth-pro
 
 In the [MCPBundles maintainer dashboard](https://www.mcpbundles.com):
 
-1. Publish your MCP listing with **Connect Auth** enabled.
+1. Create or claim an MCP listing and enable **Connect Auth** in maintainer settings.
 2. Set your federation sign-in URL on the listing.
 3. Save the federation secret on your **web app** (not on this MCP server).
 4. Note your listing slug and ensure the listing **base URL** matches your public MCP origin.
@@ -25,7 +26,7 @@ MCPBUNDLES_LISTING_SLUG=your-listing-slug
 MCP_URL=https://mcp.example.com
 ```
 
-`MCP_URL` is the public MCP server origin. For local development, `mcp-use dev` can supply a trusted localhost origin when `MCP_URL` is omitted.
+`MCP_URL` is the public MCP server origin. When omitted, the provider example uses the listing `origin_resource` from public-config — set `MCP_URL` explicitly when your runtime origin differs from the listing metadata.
 
 ## Configure the MCP server
 
@@ -41,8 +42,12 @@ import {
 const listingSlug = process.env.MCPBUNDLES_LISTING_SLUG;
 if (!listingSlug) throw new Error("MCPBUNDLES_LISTING_SLUG is required");
 
-const baseUrl = process.env.MCP_URL ?? "http://localhost:3000";
 const publicConfig = await fetchMcpbundlesPublicConfig({ listingSlug });
+const explicitBaseUrl = process.env.MCP_URL?.trim();
+const baseUrl =
+  explicitBaseUrl && explicitBaseUrl.length > 0
+    ? explicitBaseUrl
+    : publicConfig.origin_resource;
 
 const server = new MCPServer({
   name: "mcpbundles-server",

--- a/docs/typescript/server/authentication/providers/mcpbundles.mdx
+++ b/docs/typescript/server/authentication/providers/mcpbundles.mdx
@@ -1,0 +1,123 @@
+---
+title: "MCPBundles Provider"
+description: "Configure MCPBundles Connect Auth for a TypeScript MCP server on the vendor origin."
+---
+
+Use `oauthMcpbundlesProvider` when your MCP server is published on MCPBundles with **Connect Auth** enabled and clients authenticate against the MCPBundles tenant authorization server. mcp-use verifies ES256 access tokens against the tenant JWKS and maps Connect Auth claims into `ctx.auth`.
+
+This guide covers the **vendor origin** path (Path A). Clients may also connect through the MCPBundles bundle proxy at `https://mcp.mcpbundles.com/bundle/{slug}` without running this provider.
+
+See the [auth providers API reference](/typescript/api-reference/server/auth-providers) for exact `oauthMcpbundlesProvider()` options, defaults, and errors.
+
+## Configure MCPBundles
+
+In the [MCPBundles maintainer dashboard](https://www.mcpbundles.com):
+
+1. Publish your MCP listing with **Connect Auth** enabled.
+2. Set your federation sign-in URL on the listing.
+3. Save the federation secret on your **web app** (not on this MCP server).
+4. Note your listing slug and ensure the listing **base URL** matches your public MCP origin.
+
+## Set environment variables
+
+```bash
+MCPBUNDLES_LISTING_SLUG=your-listing-slug
+MCP_URL=https://mcp.example.com
+```
+
+`MCP_URL` is the public MCP server origin. For local development, `mcp-use dev` can supply a trusted localhost origin when `MCP_URL` is omitted.
+
+## Configure the MCP server
+
+Load tenant public-config asynchronously, then construct the provider:
+
+```typescript
+import { MCPServer } from "mcp-use";
+import {
+  fetchMcpbundlesPublicConfig,
+  oauthMcpbundlesProvider,
+} from "mcp-use/oauth/mcpbundles";
+
+const listingSlug = process.env.MCPBUNDLES_LISTING_SLUG;
+if (!listingSlug) throw new Error("MCPBUNDLES_LISTING_SLUG is required");
+
+const baseUrl = process.env.MCP_URL ?? "http://localhost:3000";
+const publicConfig = await fetchMcpbundlesPublicConfig({ listingSlug });
+
+const server = new MCPServer({
+  name: "mcpbundles-server",
+  version: "1.0.0",
+  oauth: oauthMcpbundlesProvider({
+    listingSlug,
+    baseUrl,
+    publicConfig,
+  }),
+});
+
+export default server;
+```
+
+## Scope data by organization
+
+Connect Auth may include `organization_id` in the access token. Use it to filter tenant-specific data.
+
+```typescript
+server.tool(
+  {
+    name: "list_documents",
+    description: "List documents for the authenticated organization.",
+  },
+  async (_args, ctx) => {
+    const organizationId = ctx.auth.user.organizationId;
+    if (!organizationId) {
+      return {
+        isError: true,
+        content: [{ type: "text", text: "Organization context required" }],
+      };
+    }
+
+    const documents = await db.documents.findMany({
+      where: { organizationId },
+    });
+    return {
+      content: [{ type: "text", text: JSON.stringify(documents) }],
+    };
+  },
+);
+```
+
+The mapped user includes `id`, optional `organizationId`, optional `email`, and `roles` (empty when omitted). Pass `email` and `roles` in your federation `complete` call to mint them on the access token. The OAuth MCP client id remains on `ctx.auth.clientId`.
+
+For the full cross-framework mapping (FastMCP ↔ mcp-use), see [Tool callback identity](https://www.mcpbundles.com/docs/integrations/mcp-connect-auth#tool-callback-identity) in the MCPBundles integration guide.
+
+## Verify the integration
+
+After deploying, run the MCPBundles doctor against your listing origin surface:
+
+```bash
+mcpbundles connect doctor --listing your-listing-slug --surface origin
+```
+
+<CardGroup cols={2}>
+  <Card
+    title="Runnable MCPBundles example"
+    icon="github"
+    href="https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/auth/mcpbundles"
+  >
+    Compare with the maintained Connect Auth example.
+  </Card>
+  <Card
+    title="MCP Connect Auth integration guide"
+    icon="book-open"
+    href="https://www.mcpbundles.com/docs/integrations/mcp-connect-auth"
+  >
+    Federation, publishing, and bundle URL setup.
+  </Card>
+  <Card
+    title="User Context"
+    icon="user"
+    href="/typescript/server/authentication/user-context"
+  >
+    Use Connect Auth identity in tool callbacks.
+  </Card>
+</CardGroup>

--- a/docs/typescript/server/authentication/providers/mcpbundles.mdx
+++ b/docs/typescript/server/authentication/providers/mcpbundles.mdx
@@ -26,7 +26,7 @@ MCPBUNDLES_LISTING_SLUG=your-listing-slug
 MCP_URL=https://mcp.example.com
 ```
 
-`MCP_URL` is the public MCP server origin. When omitted, the provider example uses the listing `origin_resource` from public-config — set `MCP_URL` explicitly when your runtime origin differs from the listing metadata.
+`MCP_URL` must match the listing `origin_resource` from public-config — `oauthMcpbundlesProvider` validates them at construction and throws if they differ. When omitted, use `origin_resource` from the fetched public-config (as in the example below).
 
 ## Configure the MCP server
 

--- a/docs/v2/typescript/server/authentication/providers/mcpbundles.mdx
+++ b/docs/v2/typescript/server/authentication/providers/mcpbundles.mdx
@@ -1,0 +1,107 @@
+---
+title: "MCPBundles Provider"
+description: "Configure MCPBundles Connect Auth for an MCP server on the vendor origin."
+---
+
+Use `oauthMcpbundlesProvider` when your MCP server is published on MCPBundles with **Connect Auth** enabled. MCP clients register with the MCPBundles tenant authorization server, and mcp-use verifies ES256 access tokens against the tenant JWKS.
+
+This guide covers the **vendor origin** path. Clients may also use the bundle proxy at `https://mcp.mcpbundles.com/bundle/{slug}` without this provider.
+
+## Configure MCPBundles
+
+1. Publish your listing with **Connect Auth** enabled.
+2. Set the federation sign-in URL in the maintainer dashboard.
+3. Save the federation secret on your **web app**, not on this MCP server.
+4. Ensure the listing base URL matches your public MCP origin.
+
+See the [MCP Connect Auth integration guide](https://www.mcpbundles.com/docs/integrations/mcp-connect-auth).
+
+## Configure the server
+
+```bash
+MCPBUNDLES_LISTING_SLUG=your-listing-slug
+MCP_URL=https://mcp.example.com
+```
+
+```typescript
+import { MCPServer } from "mcp-use";
+import {
+  fetchMcpbundlesPublicConfig,
+  oauthMcpbundlesProvider,
+} from "mcp-use/oauth/mcpbundles";
+
+const listingSlug = process.env.MCPBUNDLES_LISTING_SLUG;
+if (!listingSlug) throw new Error("MCPBUNDLES_LISTING_SLUG is required");
+
+const baseUrl = process.env.MCP_URL ?? "http://localhost:3000";
+const publicConfig = await fetchMcpbundlesPublicConfig({ listingSlug });
+
+const server = new MCPServer({
+  name: "mcpbundles-server",
+  version: "1.0.0",
+  oauth: oauthMcpbundlesProvider({
+    listingSlug,
+    baseUrl,
+    publicConfig,
+  }),
+});
+
+export default server;
+```
+
+## Scope data by organization
+
+Connect Auth maps `organization_id` to `organizationId` and the subject to `id`.
+
+```typescript
+server.tool(
+  {
+    name: "list_documents",
+    description: "List documents for the authenticated organization.",
+  },
+  async (_args, ctx) => {
+    const organizationId = ctx.auth.user.organizationId;
+    if (!organizationId) {
+      return {
+        isError: true,
+        content: [{ type: "text", text: "Organization context required" }],
+      };
+    }
+
+    const documents = await db.documents.findMany({
+      where: { organizationId },
+    });
+    return {
+      content: [{ type: "text", text: JSON.stringify(documents) }],
+    };
+  },
+);
+```
+
+Verified scopes are available on `ctx.auth.scopes`. The OAuth MCP client id is on `ctx.auth.clientId`, not on the user object. Optional `email` and `roles` are minted when you pass them to federation `complete`.
+
+See [Tool callback identity](https://www.mcpbundles.com/docs/integrations/mcp-connect-auth#tool-callback-identity) for the FastMCP ↔ mcp-use mapping table.
+
+<CardGroup cols={2}>
+  <Card
+    title="Runnable MCPBundles example"
+    icon="github"
+    href="https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/auth/mcpbundles"
+  >
+    Compare with the maintained Connect Auth example.
+  </Card>
+  <Card
+    title="MCP Connect Auth integration guide"
+    icon="book-open"
+    href="https://www.mcpbundles.com/docs/integrations/mcp-connect-auth"
+  >
+    Federation, publishing, and bundle URL setup.
+  </Card>
+  <Card
+    title="User Context"
+    icon="user"
+    href="/v2/typescript/server/authentication/user-context"
+  >
+    Use Connect Auth identity in tool callbacks.
+  </Card>
+</CardGroup>

--- a/docs/v2/typescript/server/authentication/providers/mcpbundles.mdx
+++ b/docs/v2/typescript/server/authentication/providers/mcpbundles.mdx
@@ -1,15 +1,16 @@
 ---
 title: "MCPBundles Provider"
 description: "Configure MCPBundles Connect Auth for an MCP server on the vendor origin."
+icon: "/images/icons/mcpbundles.svg"
 ---
 
-Use `oauthMcpbundlesProvider` when your MCP server is published on MCPBundles with **Connect Auth** enabled. MCP clients register with the MCPBundles tenant authorization server, and mcp-use verifies ES256 access tokens against the tenant JWKS.
+Use `oauthMcpbundlesProvider` when you manage an MCP server listing on MCPBundles with **Connect Auth** enabled. MCP clients register with the MCPBundles tenant authorization server, and mcp-use verifies ES256 access tokens against the tenant JWKS.
 
 This guide covers the **vendor origin** path. Clients may also use the bundle proxy at `https://mcp.mcpbundles.com/bundle/{slug}` without this provider.
 
 ## Configure MCPBundles
 
-1. Publish your listing with **Connect Auth** enabled.
+1. Create or claim an MCP listing and enable **Connect Auth** in maintainer settings.
 2. Set the federation sign-in URL in the maintainer dashboard.
 3. Save the federation secret on your **web app**, not on this MCP server.
 4. Ensure the listing base URL matches your public MCP origin.
@@ -33,8 +34,12 @@ import {
 const listingSlug = process.env.MCPBUNDLES_LISTING_SLUG;
 if (!listingSlug) throw new Error("MCPBUNDLES_LISTING_SLUG is required");
 
-const baseUrl = process.env.MCP_URL ?? "http://localhost:3000";
 const publicConfig = await fetchMcpbundlesPublicConfig({ listingSlug });
+const explicitBaseUrl = process.env.MCP_URL?.trim();
+const baseUrl =
+  explicitBaseUrl && explicitBaseUrl.length > 0
+    ? explicitBaseUrl
+    : publicConfig.origin_resource;
 
 const server = new MCPServer({
   name: "mcpbundles-server",

--- a/libraries/typescript/.changeset/mcpbundles-oauth-provider.md
+++ b/libraries/typescript/.changeset/mcpbundles-oauth-provider.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": minor
+---
+
+Add `oauthMcpbundlesProvider` for MCPBundles Connect Auth resource-server JWT verification on vendor MCP origins.

--- a/libraries/typescript/packages/server/examples/auth/README.md
+++ b/libraries/typescript/packages/server/examples/auth/README.md
@@ -8,6 +8,7 @@ These examples use direct external authorization servers:
 - [Supabase](./supabase/)
 - [Keycloak](./keycloak/)
 - [Better Auth](./better-auth/)
+- [MCPBundles](./mcpbundles/)
 
 Each server exposes only the `get-user-info` tool. It never issues, proxies, or
 forwards access tokens. For public deployments, set `MCP_URL` to the server

--- a/libraries/typescript/packages/server/examples/auth/mcpbundles/.env.example
+++ b/libraries/typescript/packages/server/examples/auth/mcpbundles/.env.example
@@ -1,0 +1,5 @@
+# Required: published MCPBundles listing slug with Connect Auth enabled.
+MCPBUNDLES_LISTING_SLUG=your-listing-slug
+
+# Optional: public MCP server origin for deployments outside localhost.
+# MCP_URL=https://mcp.example.com

--- a/libraries/typescript/packages/server/examples/auth/mcpbundles/README.md
+++ b/libraries/typescript/packages/server/examples/auth/mcpbundles/README.md
@@ -1,0 +1,62 @@
+# MCPBundles Connect Auth example
+
+This example secures an `mcp-use` MCP server with **MCPBundles Connect Auth** on the
+vendor **origin** path (Path A). It exposes one read-only tool, `get-user-info`, which
+returns the verified Connect Auth identity plus token authorization metadata. It never
+returns the bearer token.
+
+Clients can also connect through the MCPBundles bundle proxy at
+`https://mcp.mcpbundles.com/bundle/{slug}` (Path B) without running this provider on
+their server.
+
+## Configure MCPBundles
+
+1. Publish your MCP server on MCPBundles with **Connect Auth** enabled.
+2. Set your federation sign-in URL and save the federation secret on your **web app**
+   (not in this MCP server).
+3. Copy your listing slug into a local `.env` file:
+
+```sh
+cp .env.example .env
+```
+
+```dotenv
+MCPBUNDLES_LISTING_SLUG=your-listing-slug
+# MCP_URL=https://mcp.example.com
+```
+
+For a public deployment, set `MCP_URL` to the public MCP server origin as shown above.
+
+See the [MCP Connect Auth integration guide](https://www.mcpbundles.com/docs/integrations/mcp-connect-auth)
+for maintainer dashboard steps and federation setup.
+
+## Run it
+
+From this directory:
+
+```sh
+pnpm dev
+```
+
+`mcp-use dev` owns the local socket and serves `server.fetch` from this
+default-exported server. Before importing the entry, it resolves the actual
+local port and, when `MCP_URL` is absent, supplies a scoped trusted local
+canonical origin.
+
+## Authentication flow
+
+The MCP client discovers the tenant authorization server through protected-resource
+metadata served by this MCP server. It registers through DCR, authenticates the user
+with MCPBundles Connect Auth, and obtains an ES256 access token. This server verifies
+the token against the tenant JWKS before `get-user-info` runs.
+
+```text
+MCP client ── discovery / registration / sign-in ──> MCPBundles tenant AS
+MCP client ── verified bearer-token tool call ──────> this MCP server
+```
+
+## Typecheck
+
+```sh
+pnpm typecheck
+```

--- a/libraries/typescript/packages/server/examples/auth/mcpbundles/package.json
+++ b/libraries/typescript/packages/server/examples/auth/mcpbundles/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "mcp-use-example-auth-mcpbundles",
+  "type": "module",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Example: mcp-use with MCPBundles Connect Auth on the vendor MCP origin.",
+  "engines": {
+    "node": ">=22.22.2"
+  },
+  "scripts": {
+    "dev": "mcp-use dev",
+    "build": "mcp-use build",
+    "start": "mcp-use start",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "mcp-use": "workspace:*",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "^22.20.0",
+    "typescript": "^7.0.2"
+  }
+}

--- a/libraries/typescript/packages/server/examples/auth/mcpbundles/src/index.ts
+++ b/libraries/typescript/packages/server/examples/auth/mcpbundles/src/index.ts
@@ -1,0 +1,82 @@
+import { MCPServer } from "mcp-use";
+import {
+  fetchMcpbundlesPublicConfig,
+  oauthMcpbundlesProvider,
+} from "mcp-use/oauth/mcpbundles";
+import { z } from "zod";
+
+const getUserInfoOutputSchema = z.object({
+  user: z.object({
+    id: z.string(),
+    organizationId: z.string().nullable(),
+    email: z.string().nullable(),
+    roles: z.array(z.string()),
+  }),
+  auth: z.object({
+    scopes: z.array(z.string()),
+    clientId: z.string().nullable(),
+    expiresAt: z.number(),
+    resource: z.string().nullable(),
+  }),
+});
+
+function requireEnv(name: string): string {
+  const value = process.env[name]?.trim();
+  if (value === undefined || value.length === 0) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+const listingSlug = requireEnv("MCPBUNDLES_LISTING_SLUG");
+const baseUrl = process.env.MCP_URL?.trim() ?? "http://localhost:3000";
+
+const publicConfig = await fetchMcpbundlesPublicConfig({ listingSlug });
+
+const server = new MCPServer({
+  name: "mcpbundles-auth-example",
+  version: "1.0.0",
+  title: "MCPBundles Connect Auth example",
+  description:
+    "An MCP server secured by MCPBundles Connect Auth access tokens on the vendor origin.",
+  publicLandingPage: true,
+  oauth: oauthMcpbundlesProvider({
+    listingSlug,
+    baseUrl,
+    publicConfig,
+  }),
+});
+
+server.tool(
+  {
+    name: "get-user-info",
+    title: "Get user info",
+    description:
+      "Return the verified Connect Auth identity and authorization details.",
+    outputSchema: getUserInfoOutputSchema,
+    annotations: { readOnlyHint: true },
+  },
+  async (_params, ctx) => {
+    const data = {
+      user: {
+        id: ctx.auth.user.id,
+        organizationId: ctx.auth.user.organizationId ?? null,
+        email: ctx.auth.user.email ?? null,
+        roles: ctx.auth.user.roles,
+      },
+      auth: {
+        scopes: ctx.auth.scopes,
+        clientId: ctx.auth.clientId ?? null,
+        expiresAt: ctx.auth.expiresAt,
+        resource: ctx.auth.resource?.href ?? null,
+      },
+    };
+
+    return {
+      content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+      structuredContent: data,
+    };
+  }
+);
+
+export default server;

--- a/libraries/typescript/packages/server/examples/auth/mcpbundles/src/index.ts
+++ b/libraries/typescript/packages/server/examples/auth/mcpbundles/src/index.ts
@@ -28,10 +28,14 @@ function requireEnv(name: string): string {
   return value;
 }
 
-const listingSlug = requireEnv("MCPBUNDLES_LISTING_SLUG");
-const baseUrl = process.env.MCP_URL?.trim() ?? "http://localhost:3000";
+function optionalEnv(name: string): string | undefined {
+  const value = process.env[name]?.trim();
+  return value && value.length > 0 ? value : undefined;
+}
 
+const listingSlug = requireEnv("MCPBUNDLES_LISTING_SLUG");
 const publicConfig = await fetchMcpbundlesPublicConfig({ listingSlug });
+const baseUrl = optionalEnv("MCP_URL") ?? publicConfig.origin_resource;
 
 const server = new MCPServer({
   name: "mcpbundles-auth-example",

--- a/libraries/typescript/packages/server/examples/auth/mcpbundles/tsconfig.json
+++ b/libraries/typescript/packages/server/examples/auth/mcpbundles/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2024"],
+    "types": ["node"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"]
+}

--- a/libraries/typescript/packages/server/package.json
+++ b/libraries/typescript/packages/server/package.json
@@ -71,6 +71,10 @@
       "types": "./dist/oauth/keycloak.d.ts",
       "import": "./dist/oauth/keycloak.js"
     },
+    "./oauth/mcpbundles": {
+      "types": "./dist/oauth/mcpbundles.d.ts",
+      "import": "./dist/oauth/mcpbundles.js"
+    },
     "./oauth/better-auth": {
       "types": "./dist/oauth/better-auth.d.ts",
       "import": "./dist/oauth/better-auth.js"

--- a/libraries/typescript/packages/server/src/oauth/mcpbundles.ts
+++ b/libraries/typescript/packages/server/src/oauth/mcpbundles.ts
@@ -403,13 +403,32 @@ function buildMcpbundlesJwtVerifier(options: {
   resource: URL;
   audiences: string[];
 }) {
-  return createJwtVerifier({
+  const verifier = createJwtVerifier({
     issuer: options.issuer,
     jwksUrl: options.jwksUrl,
     resource: options.resource,
     audience: options.audiences,
     algorithms: ["ES256"],
   });
+
+  return {
+    async verifyAccessToken(token: string) {
+      const authInfo = await verifier.verifyAccessToken(token);
+      return enforceConnectAuthClientClaim(authInfo);
+    },
+  };
+}
+
+function enforceConnectAuthClientClaim(authInfo: AuthInfo): AuthInfo {
+  const payload = payloadFromAuthInfo(authInfo);
+  const clientId = requiredString(payload, "client_id");
+  if (clientId === undefined || clientId.trim().length === 0) {
+    throw invalidToken("Connect Auth token missing client_id");
+  }
+  if (authInfo.clientId !== clientId) {
+    return { ...authInfo, clientId };
+  }
+  return authInfo;
 }
 
 function mapMcpbundlesUser(

--- a/libraries/typescript/packages/server/src/oauth/mcpbundles.ts
+++ b/libraries/typescript/packages/server/src/oauth/mcpbundles.ts
@@ -421,12 +421,8 @@ function buildMcpbundlesJwtVerifier(options: {
 
 function enforceConnectAuthClientClaim(authInfo: AuthInfo): AuthInfo {
   const payload = payloadFromAuthInfo(authInfo);
-  const clientId = requiredString(payload, "client_id");
-  if (clientId === undefined || clientId.trim().length === 0) {
+  if (requiredString(payload, "client_id") === undefined) {
     throw invalidToken("Connect Auth token missing client_id");
-  }
-  if (authInfo.clientId !== clientId) {
-    return { ...authInfo, clientId };
   }
   return authInfo;
 }

--- a/libraries/typescript/packages/server/src/oauth/mcpbundles.ts
+++ b/libraries/typescript/packages/server/src/oauth/mcpbundles.ts
@@ -267,10 +267,9 @@ export function oauthMcpbundlesProvider(
     );
   }
 
-  const tenantBase = expectedIssuer;
   const audiences = audiencesFromPublicConfig(publicConfig);
   const oauthMetadata = buildTenantOAuthMetadata(
-    tenantBase,
+    publicConfig.issuer,
     publicConfig.scopes_supported
   );
   const documentationUrl = new URL(MCPBUNDLES_INTEGRATION_DOC_URL);

--- a/libraries/typescript/packages/server/src/oauth/mcpbundles.ts
+++ b/libraries/typescript/packages/server/src/oauth/mcpbundles.ts
@@ -1,0 +1,490 @@
+/**
+ * Verify MCPBundles Connect Auth access tokens for an mcp-use resource server.
+ *
+ * @packageDocumentation
+ */
+
+import type { AuthInfo, OAuthMetadata } from "@modelcontextprotocol/server";
+import { errors } from "jose";
+
+import { isRecord } from "./guards.js";
+import {
+  createJwtVerifier,
+  invalidToken,
+  normalizedProviderUrl,
+  normalizedStrings,
+  payloadFromAuthInfo,
+  providerEndpoint,
+  requiredString,
+  stringValue,
+} from "./jwt.js";
+import {
+  oauthCustomProvider,
+  type OAuthExtra,
+  type OAuthProvider,
+  type OAuthResourceOptions,
+} from "./provider.js";
+
+/** Tenant public-config returned by the MCPBundles Connect Auth API. */
+export interface McpbundlesPublicConfig {
+  /** Tenant authorization-server issuer URL. */
+  issuer: string;
+  /** Scopes advertised for this listing. */
+  scopes_supported: string[];
+  /** Canonical vendor MCP origin resource URL. */
+  origin_resource: string;
+  /** MCPBundles bundle proxy resource URL. */
+  bundle_proxy_resource: string;
+  /** Optional origin telemetry ingest URL. */
+  telemetry_ingest_url?: string;
+}
+
+/** Verified Connect Auth identity exposed to authenticated MCP callbacks. */
+export interface McpbundlesOAuthUser {
+  /** Connect Auth subject identifier. */
+  id: string;
+  /** Organization identifier, when present in the access token. */
+  organizationId?: string;
+  /** Primary email from federation, when passed at `complete` and minted on the token. */
+  email?: string;
+  /** Role names from federation, when passed at `complete` and minted on the token. */
+  roles: string[];
+}
+
+/** Configures MCPBundles JWT verification and protected-resource metadata. */
+export interface McpbundlesOAuthProviderOptions extends OAuthResourceOptions {
+  /** Published `/skills` listing slug (Connect Auth tenant id). */
+  listingSlug: string;
+  /** Public vendor MCP origin URL (must match listing `origin_resource`). */
+  baseUrl: URL | string;
+  /** API host for tenant routes. Default: {@link DEFAULT_MCPBUNDLES_API_BASE_URL}. */
+  apiBaseUrl?: string;
+  /** Preloaded public-config from {@link fetchMcpbundlesPublicConfig}. */
+  publicConfig?: McpbundlesPublicConfig;
+}
+
+/** Options for {@link fetchMcpbundlesPublicConfig}. */
+export interface FetchMcpbundlesPublicConfigOptions {
+  /** Published `/skills` listing slug. */
+  listingSlug: string;
+  /** API host override. Default: {@link DEFAULT_MCPBUNDLES_API_BASE_URL}. */
+  apiBaseUrl?: string;
+  /** Fetch implementation for tests. */
+  fetch?: typeof globalThis.fetch;
+  /** Optional abort signal. */
+  signal?: AbortSignal;
+  /** HTTP timeout in seconds. Default: 10. */
+  timeoutSeconds?: number;
+}
+
+/** Raised when tenant public-config cannot be fetched or parsed. */
+export class McpbundlesPublicConfigError extends Error {
+  /** Listing slug from the request. */
+  readonly listingSlug: string;
+  /** Request URL that failed. */
+  readonly url: string;
+  /** Short machine-readable failure reason. */
+  readonly reason: string;
+
+  /** Creates a public-config fetch or validation error. */
+  constructor(options: {
+    listingSlug: string;
+    url: string;
+    reason: string;
+    cause?: unknown;
+  }) {
+    super(
+      `Failed to load MCP Connect Auth public-config for listing "${options.listingSlug}" from ${options.url}: ${options.reason}. See ${MCPBUNDLES_INTEGRATION_DOC_URL}`
+    );
+    this.name = "McpbundlesPublicConfigError";
+    this.listingSlug = options.listingSlug;
+    this.url = options.url;
+    this.reason = options.reason;
+    if (options.cause !== undefined) {
+      this.cause = options.cause;
+    }
+  }
+}
+
+/** MCPBundles Connect Auth integration reference documentation. */
+export const MCPBUNDLES_INTEGRATION_DOC_URL =
+  "https://www.mcpbundles.com/docs/integrations/mcp-connect-auth";
+
+/** Default MCPBundles API base URL. */
+export const DEFAULT_MCPBUNDLES_API_BASE_URL = "https://api.mcpbundles.com";
+
+const DEFAULT_PUBLIC_CONFIG_TIMEOUT_SECONDS = 10;
+
+/**
+ * Resolves the tenant authorization-server base URL.
+ *
+ * @param listingSlug - Published listing slug.
+ * @param apiBaseUrl - Optional API host override.
+ * @returns Tenant Connect Auth base URL without a trailing slash.
+ */
+export function tenantBaseUrl(
+  listingSlug: string,
+  apiBaseUrl?: string
+): string {
+  const slug = normalizeListingSlug(listingSlug);
+  return `${resolveApiBaseUrl(apiBaseUrl)}/connect-auth/tenants/${encodeURIComponent(slug)}`;
+}
+
+/**
+ * Resolves the tenant public-config URL.
+ *
+ * @param listingSlug - Published listing slug.
+ * @param apiBaseUrl - Optional API host override.
+ * @returns Public-config URL.
+ */
+export function publicConfigUrl(
+  listingSlug: string,
+  apiBaseUrl?: string
+): string {
+  return `${tenantBaseUrl(listingSlug, apiBaseUrl)}/public-config`;
+}
+
+/**
+ * Resolves the tenant JWKS URL.
+ *
+ * @param listingSlug - Published listing slug.
+ * @param apiBaseUrl - Optional API host override.
+ * @returns JWKS URL.
+ */
+export function jwksUrl(listingSlug: string, apiBaseUrl?: string): string {
+  return `${tenantBaseUrl(listingSlug, apiBaseUrl)}/.well-known/jwks.json`;
+}
+
+/**
+ * Fetches and validates tenant public-config.
+ *
+ * @param options - Listing slug and optional fetch overrides.
+ * @returns Parsed public-config.
+ * @throws {@link McpbundlesPublicConfigError} when the request or payload is invalid.
+ */
+export async function fetchMcpbundlesPublicConfig(
+  options: FetchMcpbundlesPublicConfigOptions
+): Promise<McpbundlesPublicConfig> {
+  const listingSlug = normalizeListingSlug(options.listingSlug);
+  const url = publicConfigUrl(listingSlug, options.apiBaseUrl);
+  const fetchFn = options.fetch ?? globalThis.fetch;
+  const timeoutSeconds =
+    options.timeoutSeconds ?? DEFAULT_PUBLIC_CONFIG_TIMEOUT_SECONDS;
+  const signal = options.signal ?? AbortSignal.timeout(timeoutSeconds * 1000);
+
+  let response: Response;
+  try {
+    response = await fetchFn(url, {
+      method: "GET",
+      headers: { Accept: "application/json" },
+      signal,
+    });
+  } catch (error) {
+    throw new McpbundlesPublicConfigError({
+      listingSlug,
+      url,
+      reason: error instanceof Error ? error.message : String(error),
+      cause: error,
+    });
+  }
+
+  if (!response.ok) {
+    throw new McpbundlesPublicConfigError({
+      listingSlug,
+      url,
+      reason: `HTTP ${response.status}`,
+    });
+  }
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch (error) {
+    throw new McpbundlesPublicConfigError({
+      listingSlug,
+      url,
+      reason: "response was not valid JSON",
+      cause: error,
+    });
+  }
+
+  return parsePublicConfig(payload, listingSlug, url);
+}
+
+/**
+ * Creates a provider that verifies MCPBundles Connect Auth access tokens.
+ *
+ * @param options - Listing slug, vendor origin URL, and preloaded public-config.
+ * @returns A DCR-direct provider backed by the tenant authorization server.
+ * @throws A `TypeError` when required options or public-config are invalid.
+ *
+ * @example
+ * ```ts
+ * import {
+ *   fetchMcpbundlesPublicConfig,
+ *   oauthMcpbundlesProvider,
+ * } from "mcp-use/oauth/mcpbundles";
+ *
+ * const listingSlug = "my-listing";
+ * const publicConfig = await fetchMcpbundlesPublicConfig({ listingSlug });
+ *
+ * const oauth = oauthMcpbundlesProvider({
+ *   listingSlug,
+ *   baseUrl: "https://mcp.example.com",
+ *   publicConfig,
+ * });
+ * ```
+ */
+export function oauthMcpbundlesProvider(
+  options: McpbundlesOAuthProviderOptions
+): OAuthProvider<McpbundlesOAuthUser> {
+  const listingSlug = normalizeListingSlug(options.listingSlug);
+  const apiBaseUrl = resolveApiBaseUrl(options.apiBaseUrl);
+  const publicConfig = options.publicConfig;
+  if (publicConfig === undefined) {
+    throw new TypeError(
+      "publicConfig is required; await fetchMcpbundlesPublicConfig({ listingSlug }) before constructing oauthMcpbundlesProvider()"
+    );
+  }
+
+  const normalizedBaseUrl = normalizeResourceUrl(options.baseUrl, "baseUrl");
+  const normalizedOrigin = normalizeResourceUrl(
+    publicConfig.origin_resource,
+    "origin_resource"
+  );
+  if (normalizedBaseUrl !== normalizedOrigin) {
+    throw new TypeError(
+      `baseUrl (${normalizedBaseUrl}) does not match listing origin_resource (${normalizedOrigin})`
+    );
+  }
+
+  const expectedIssuer = tenantBaseUrl(listingSlug, apiBaseUrl);
+  if (
+    normalizeIssuer(publicConfig.issuer) !== normalizeIssuer(expectedIssuer)
+  ) {
+    throw new TypeError(
+      `public-config issuer (${publicConfig.issuer}) does not match tenant base URL (${expectedIssuer})`
+    );
+  }
+
+  const tenantBase = expectedIssuer;
+  const audiences = audiencesFromPublicConfig(publicConfig);
+  const oauthMetadata = buildTenantOAuthMetadata(
+    tenantBase,
+    publicConfig.scopes_supported
+  );
+  const documentationUrl = new URL(MCPBUNDLES_INTEGRATION_DOC_URL);
+
+  return oauthCustomProvider<McpbundlesOAuthUser>({
+    ...options,
+    resource: options.resource ?? normalizedBaseUrl,
+    scopesSupported: options.scopesSupported ?? [
+      ...publicConfig.scopes_supported,
+    ],
+    serviceDocumentationUrl:
+      options.serviceDocumentationUrl ?? documentationUrl,
+    createTokenVerifier: (resource) =>
+      createMcpbundlesJwtVerifier({
+        issuer: publicConfig.issuer,
+        jwksUrl: new URL(jwksUrl(listingSlug, apiBaseUrl)),
+        resource,
+        audiences,
+      }),
+    oauthMetadata,
+    mapAuthInfo: mapMcpbundlesUser,
+  });
+}
+
+function parsePublicConfig(
+  payload: unknown,
+  listingSlug: string,
+  url: string
+): McpbundlesPublicConfig {
+  if (!isRecord(payload)) {
+    throw new McpbundlesPublicConfigError({
+      listingSlug,
+      url,
+      reason: "response must be a JSON object",
+    });
+  }
+
+  const missing: string[] = [];
+  for (const field of [
+    "issuer",
+    "origin_resource",
+    "bundle_proxy_resource",
+  ] as const) {
+    if (!isNonEmptyString(payload[field])) {
+      missing.push(field);
+    }
+  }
+  if (missing.length > 0) {
+    throw new McpbundlesPublicConfigError({
+      listingSlug,
+      url,
+      reason: `missing required fields: ${missing.join(", ")}`,
+    });
+  }
+
+  const scopes = payload["scopes_supported"];
+  let scopesSupported: string[];
+  if (scopes === undefined) {
+    scopesSupported = [];
+  } else if (
+    Array.isArray(scopes) &&
+    scopes.every((scope) => typeof scope === "string")
+  ) {
+    scopesSupported = [...scopes];
+  } else {
+    throw new McpbundlesPublicConfigError({
+      listingSlug,
+      url,
+      reason: "scopes_supported must be a string array",
+    });
+  }
+
+  const config: McpbundlesPublicConfig = {
+    issuer: payload["issuer"] as string,
+    origin_resource: payload["origin_resource"] as string,
+    bundle_proxy_resource: payload["bundle_proxy_resource"] as string,
+    scopes_supported: scopesSupported,
+  };
+
+  const telemetryIngestUrl = payload["telemetry_ingest_url"];
+  if (isNonEmptyString(telemetryIngestUrl)) {
+    config.telemetry_ingest_url = telemetryIngestUrl;
+  }
+
+  return config;
+}
+
+function buildTenantOAuthMetadata(
+  tenantBase: string,
+  scopesSupported: readonly string[]
+): OAuthMetadata {
+  return {
+    issuer: tenantBase,
+    authorization_endpoint: providerEndpoint(tenantBase, "o/authorize/"),
+    token_endpoint: providerEndpoint(tenantBase, "o/token/"),
+    registration_endpoint: providerEndpoint(tenantBase, "o/register/"),
+    revocation_endpoint: providerEndpoint(tenantBase, "o/revoke/"),
+    response_types_supported: ["code"],
+    grant_types_supported: ["authorization_code", "refresh_token"],
+    code_challenge_methods_supported: ["S256"],
+    token_endpoint_auth_methods_supported: ["none", "client_secret_post"],
+    scopes_supported: [...scopesSupported],
+  } satisfies OAuthMetadata;
+}
+
+function createMcpbundlesJwtVerifier(options: {
+  issuer: string;
+  jwksUrl: URL;
+  resource: URL;
+  audiences: string[];
+}): ReturnType<typeof createJwtVerifier> {
+  let verifier = buildMcpbundlesJwtVerifier(options);
+  return {
+    async verifyAccessToken(token) {
+      try {
+        return await verifier.verifyAccessToken(token);
+      } catch (error) {
+        if (isJwksKidMiss(error)) {
+          verifier = buildMcpbundlesJwtVerifier(options);
+          return verifier.verifyAccessToken(token);
+        }
+        throw error;
+      }
+    },
+  };
+}
+
+function buildMcpbundlesJwtVerifier(options: {
+  issuer: string;
+  jwksUrl: URL;
+  resource: URL;
+  audiences: string[];
+}) {
+  return createJwtVerifier({
+    issuer: options.issuer,
+    jwksUrl: options.jwksUrl,
+    resource: options.resource,
+    audience: options.audiences,
+    algorithms: ["ES256"],
+  });
+}
+
+function mapMcpbundlesUser(
+  authInfo: AuthInfo
+): OAuthExtra<McpbundlesOAuthUser> {
+  const payload = payloadFromAuthInfo(authInfo);
+  const id = requiredString(payload, "sub");
+  if (id === undefined) {
+    throw invalidToken("Missing Connect Auth subject");
+  }
+  const organizationId = stringValue(payload, "organization_id");
+  const email = stringValue(payload, "email");
+  return {
+    user: {
+      id,
+      ...(organizationId !== undefined ? { organizationId } : {}),
+      ...(email !== undefined ? { email } : {}),
+      roles: normalizedStrings(payload["roles"]),
+    },
+    payload,
+    permissions: [],
+  };
+}
+
+function audiencesFromPublicConfig(config: McpbundlesPublicConfig): string[] {
+  return [
+    normalizeResourceUrl(config.origin_resource, "origin_resource"),
+    normalizeResourceUrl(config.bundle_proxy_resource, "bundle_proxy_resource"),
+  ];
+}
+
+function normalizeListingSlug(value: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new TypeError("listingSlug is required");
+  }
+  return value.trim();
+}
+
+function resolveApiBaseUrl(apiBaseUrl?: string): string {
+  return (apiBaseUrl ?? DEFAULT_MCPBUNDLES_API_BASE_URL).replace(/\/+$/, "");
+}
+
+function normalizeIssuer(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+function normalizeResourceUrl(value: URL | string, name: string): string {
+  const url = normalizedProviderUrl(value, name);
+  url.pathname = url.pathname === "/" ? "/" : url.pathname.replace(/\/+$/, "");
+  return url.href.replace(/\/$/, "");
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isJwksKidMiss(error: unknown): boolean {
+  if (error instanceof errors.JWKSNoMatchingKey) {
+    return true;
+  }
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "cause" in error &&
+    (error as { cause?: unknown }).cause instanceof errors.JWKSNoMatchingKey
+  ) {
+    return true;
+  }
+  if (
+    error instanceof Error &&
+    (error.message.includes("no applicable key") ||
+      error.message.includes("unknown kid"))
+  ) {
+    return true;
+  }
+  return false;
+}

--- a/libraries/typescript/packages/server/tests/fixtures/connect_auth/golden_access_token.json
+++ b/libraries/typescript/packages/server/tests/fixtures/connect_auth/golden_access_token.json
@@ -1,0 +1,52 @@
+{
+  "description": "Golden Connect Auth ES256 access token for cross-framework provider tests.",
+  "issuer": "https://api.example.test/connect-auth/tenants/golden-demo/",
+  "origin_resource": "https://mcp.example.test/mcp",
+  "bundle_proxy_resource": "https://mcp.mcpbundles.test/bundle/golden-demo",
+  "expected": {
+    "user_id": "user-golden-001",
+    "organization_id": "org-golden-001",
+    "email": "builder@example.test",
+    "roles": [
+      "admin",
+      "editor"
+    ],
+    "client_id": "mcp-client-cursor-abc",
+    "scopes": [
+      "read",
+      "write"
+    ]
+  },
+  "claims": {
+    "sub": "user-golden-001",
+    "client_id": "mcp-client-cursor-abc",
+    "organization_id": "org-golden-001",
+    "email": "builder@example.test",
+    "roles": [
+      "admin",
+      "editor"
+    ],
+    "scope": "read write",
+    "iss": "https://api.example.test/connect-auth/tenants/golden-demo/",
+    "aud": [
+      "https://mcp.example.test/mcp",
+      "https://mcp.mcpbundles.test/bundle/golden-demo"
+    ],
+    "iat": 1700000000,
+    "exp": 4102444800
+  },
+  "jwks": {
+    "keys": [
+      {
+        "crv": "P-256",
+        "x": "U73XGcvDNmRgleYIT9jBoma0GelDv8KyekMOeJ91H2Q",
+        "y": "chQya938YoYktWjEmezuVNWpJsG-J4CRVBR0hKbiI0w",
+        "kty": "EC",
+        "kid": "golden-connect-auth-key",
+        "alg": "ES256",
+        "use": "sig"
+      }
+    ]
+  },
+  "token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiIsImtpZCI6ImdvbGRlbi1jb25uZWN0LWF1dGgta2V5In0.eyJzdWIiOiJ1c2VyLWdvbGRlbi0wMDEiLCJjbGllbnRfaWQiOiJtY3AtY2xpZW50LWN1cnNvci1hYmMiLCJvcmdhbml6YXRpb25faWQiOiJvcmctZ29sZGVuLTAwMSIsImVtYWlsIjoiYnVpbGRlckBleGFtcGxlLnRlc3QiLCJyb2xlcyI6WyJhZG1pbiIsImVkaXRvciJdLCJzY29wZSI6InJlYWQgd3JpdGUiLCJpc3MiOiJodHRwczovL2FwaS5leGFtcGxlLnRlc3QvY29ubmVjdC1hdXRoL3RlbmFudHMvZ29sZGVuLWRlbW8vIiwiYXVkIjpbImh0dHBzOi8vbWNwLmV4YW1wbGUudGVzdC9tY3AiLCJodHRwczovL21jcC5tY3BidW5kbGVzLnRlc3QvYnVuZGxlL2dvbGRlbi1kZW1vIl0sImlhdCI6MTcwMDAwMDAwMCwiZXhwIjo0MTAyNDQ0ODAwfQ.YbGFJrLS_3jGroLjk3lzSGrZM7Cqjl-EiXQBJpgNrM9sxShEu7jo4mWErkjTo9V9fHjOPG0yACh8Eg9J4alLIQ"
+}

--- a/libraries/typescript/packages/server/tests/oauth-direct-providers.test.ts
+++ b/libraries/typescript/packages/server/tests/oauth-direct-providers.test.ts
@@ -1,17 +1,39 @@
 import { exportJWK, generateKeyPair, SignJWT } from "jose";
 import { afterEach, describe, expect, it } from "vitest";
 
+import goldenAccessTokenFixture from "./fixtures/connect_auth/golden_access_token.json";
 import { oauthAuth0Provider } from "../src/oauth/auth0.js";
 import { oauthBetterAuthProvider } from "../src/oauth/better-auth.js";
 import { oauthClerkProvider } from "../src/oauth/clerk.js";
 import { wrapOAuthTokenVerifier } from "../src/oauth/internal.js";
 import { oauthKeycloakProvider } from "../src/oauth/keycloak.js";
+import {
+  fetchMcpbundlesPublicConfig,
+  McpbundlesPublicConfigError,
+  oauthMcpbundlesProvider,
+  publicConfigUrl,
+  type McpbundlesPublicConfig,
+} from "../src/oauth/mcpbundles.js";
 import { oauthSupabaseProvider } from "../src/oauth/supabase.js";
 import { oauthWorkOSProvider } from "../src/oauth/workos.js";
 
 const now = () => Math.floor(Date.now() / 1000);
 const originalFetch = globalThis.fetch;
 const protectedResource = new URL("https://api.example.test/mcp");
+
+const SAMPLE_LISTING_SLUG = "connect-auth-demo";
+const SAMPLE_API_BASE = "https://api.mcpbundles.test";
+const SAMPLE_ORIGIN_RESOURCE = "https://vendor.example.test/mcp";
+const SAMPLE_BUNDLE_RESOURCE = `https://mcp.mcpbundles.test/bundle/${SAMPLE_LISTING_SLUG}`;
+const SAMPLE_ISSUER = `${SAMPLE_API_BASE}/connect-auth/tenants/${SAMPLE_LISTING_SLUG}`;
+
+const SAMPLE_PUBLIC_CONFIG: McpbundlesPublicConfig = {
+  issuer: SAMPLE_ISSUER,
+  scopes_supported: ["read", "write"],
+  origin_resource: SAMPLE_ORIGIN_RESOURCE,
+  bundle_proxy_resource: SAMPLE_BUNDLE_RESOURCE,
+  telemetry_ingest_url: `${SAMPLE_ISSUER}/v1/telemetry/handshake`,
+};
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
@@ -553,6 +575,326 @@ describe("direct OAuth providers", () => {
     });
   });
 
+  it("verifies MCPBundles Connect Auth JWTs with dual audience and maps claims", async () => {
+    const { privateKey, publicKey } = await generateKeyPair("ES256");
+    const jwk = await exportJWK(publicKey);
+    jwk.kid = "mcpbundles-key";
+    globalThis.fetch = mcpbundlesFixture(jwk);
+
+    const originResource = new URL(SAMPLE_ORIGIN_RESOURCE);
+    const provider = oauthMcpbundlesProvider({
+      listingSlug: SAMPLE_LISTING_SLUG,
+      baseUrl: SAMPLE_ORIGIN_RESOURCE,
+      apiBaseUrl: SAMPLE_API_BASE,
+      publicConfig: { ...SAMPLE_PUBLIC_CONFIG },
+    });
+
+    expect(provider.oauthMetadata).toMatchObject({
+      issuer: SAMPLE_ISSUER,
+      authorization_endpoint: `${SAMPLE_ISSUER}/o/authorize/`,
+      token_endpoint: `${SAMPLE_ISSUER}/o/token/`,
+      registration_endpoint: `${SAMPLE_ISSUER}/o/register/`,
+      revocation_endpoint: `${SAMPLE_ISSUER}/o/revoke/`,
+      scopes_supported: ["read", "write"],
+    });
+
+    await expect(
+      wrapOAuthTokenVerifier(provider, originResource).verifyAccessToken(
+        await signedToken(
+          privateKey,
+          "mcpbundles-key",
+          SAMPLE_ISSUER,
+          SAMPLE_ORIGIN_RESOURCE,
+          {
+            sub: "user-1",
+            client_id: "client-1",
+            organization_id: "org-1",
+            email: "user@example.com",
+            scope: "read write",
+            roles: ["admin"],
+          },
+          "ES256"
+        )
+      )
+    ).resolves.toMatchObject({
+      clientId: "client-1",
+      scopes: ["read", "write"],
+      extra: {
+        user: {
+          id: "user-1",
+          organizationId: "org-1",
+          email: "user@example.com",
+          roles: ["admin"],
+        },
+      },
+    });
+
+    await expect(
+      wrapOAuthTokenVerifier(provider, originResource).verifyAccessToken(
+        await signedToken(
+          privateKey,
+          "mcpbundles-key",
+          SAMPLE_ISSUER,
+          SAMPLE_BUNDLE_RESOURCE,
+          {
+            sub: "user-2",
+            client_id: "client-2",
+          },
+          "ES256"
+        )
+      )
+    ).resolves.toMatchObject({
+      clientId: "client-2",
+      extra: { user: { id: "user-2" } },
+    });
+  });
+
+  it("maps golden Connect Auth fixture claims to WorkOS-shaped identity", async () => {
+    const fixture = goldenAccessTokenFixture;
+    globalThis.fetch = mcpbundlesFixture(fixture.jwks.keys[0]);
+
+    const provider = oauthMcpbundlesProvider({
+      listingSlug: "golden-demo",
+      baseUrl: fixture.origin_resource,
+      apiBaseUrl: "https://api.example.test",
+      publicConfig: {
+        issuer: fixture.issuer,
+        scopes_supported: ["read", "write"],
+        origin_resource: fixture.origin_resource,
+        bundle_proxy_resource: fixture.bundle_proxy_resource,
+      },
+    });
+
+    await expect(
+      wrapOAuthTokenVerifier(
+        provider,
+        new URL(fixture.origin_resource)
+      ).verifyAccessToken(fixture.token)
+    ).resolves.toMatchObject({
+      clientId: fixture.expected.client_id,
+      scopes: fixture.expected.scopes,
+      extra: {
+        user: {
+          id: fixture.expected.user_id,
+          organizationId: fixture.expected.organization_id,
+          email: fixture.expected.email,
+          roles: fixture.expected.roles,
+        },
+      },
+    });
+  });
+
+  it("rejects MCPBundles tokens with invalid audience or resource claims", async () => {
+    const { privateKey, publicKey } = await generateKeyPair("ES256");
+    const jwk = await exportJWK(publicKey);
+    jwk.kid = "mcpbundles-key";
+    globalThis.fetch = mcpbundlesFixture(jwk);
+    const originResource = new URL(SAMPLE_ORIGIN_RESOURCE);
+    const provider = oauthMcpbundlesProvider({
+      listingSlug: SAMPLE_LISTING_SLUG,
+      baseUrl: SAMPLE_ORIGIN_RESOURCE,
+      apiBaseUrl: SAMPLE_API_BASE,
+      publicConfig: { ...SAMPLE_PUBLIC_CONFIG },
+    });
+    const verifier = wrapOAuthTokenVerifier(provider, originResource);
+
+    await expect(
+      verifier.verifyAccessToken(
+        await signedToken(
+          privateKey,
+          "mcpbundles-key",
+          SAMPLE_ISSUER,
+          "https://other.example.test/mcp",
+          { sub: "user-1", client_id: "client-1" },
+          "ES256"
+        )
+      )
+    ).rejects.toMatchObject({ code: "invalid_token" });
+
+    await expect(
+      verifier.verifyAccessToken(
+        await signedToken(
+          privateKey,
+          "mcpbundles-key",
+          SAMPLE_ISSUER,
+          SAMPLE_ORIGIN_RESOURCE,
+          {
+            sub: "user-1",
+            client_id: "client-1",
+            resource: "https://other.example.test/mcp",
+          },
+          "ES256"
+        )
+      )
+    ).rejects.toMatchObject({ code: "invalid_token" });
+  });
+
+  it("retries MCPBundles JWKS lookup once when the token kid is missing", async () => {
+    const { privateKey, publicKey } = await generateKeyPair("ES256");
+    const jwk = await exportJWK(publicKey);
+    jwk.kid = "rotated-key";
+    let jwksRequests = 0;
+    globalThis.fetch = async (input) => {
+      const url = String(input);
+      if (url.includes("public-config")) {
+        return new Response(JSON.stringify(SAMPLE_PUBLIC_CONFIG), {
+          headers: { "content-type": "application/json" },
+        });
+      }
+      jwksRequests += 1;
+      const kid = jwksRequests === 1 ? "stale-key" : "rotated-key";
+      return new Response(JSON.stringify({ keys: [{ ...jwk, kid }] }), {
+        headers: { "content-type": "application/json" },
+      });
+    };
+
+    const provider = oauthMcpbundlesProvider({
+      listingSlug: SAMPLE_LISTING_SLUG,
+      baseUrl: SAMPLE_ORIGIN_RESOURCE,
+      apiBaseUrl: SAMPLE_API_BASE,
+      publicConfig: { ...SAMPLE_PUBLIC_CONFIG },
+    });
+
+    await expect(
+      wrapOAuthTokenVerifier(
+        provider,
+        new URL(SAMPLE_ORIGIN_RESOURCE)
+      ).verifyAccessToken(
+        await signedToken(
+          privateKey,
+          "rotated-key",
+          SAMPLE_ISSUER,
+          SAMPLE_ORIGIN_RESOURCE,
+          { sub: "user-1", client_id: "client-1" },
+          "ES256"
+        )
+      )
+    ).resolves.toMatchObject({ clientId: "client-1" });
+    expect(jwksRequests).toBe(2);
+  });
+
+  it("keeps OAuth client id on ctx.auth.clientId, not ctx.auth.user", async () => {
+    const { privateKey, publicKey } = await generateKeyPair("ES256");
+    const jwk = await exportJWK(publicKey);
+    jwk.kid = "mcpbundles-key";
+    globalThis.fetch = mcpbundlesFixture(jwk);
+    const provider = oauthMcpbundlesProvider({
+      listingSlug: SAMPLE_LISTING_SLUG,
+      baseUrl: SAMPLE_ORIGIN_RESOURCE,
+      apiBaseUrl: SAMPLE_API_BASE,
+      publicConfig: { ...SAMPLE_PUBLIC_CONFIG },
+    });
+
+    const authInfo = await wrapOAuthTokenVerifier(
+      provider,
+      new URL(SAMPLE_ORIGIN_RESOURCE)
+    ).verifyAccessToken(
+      await signedToken(
+        privateKey,
+        "mcpbundles-key",
+        SAMPLE_ISSUER,
+        SAMPLE_ORIGIN_RESOURCE,
+        {
+          sub: "user-1",
+          client_id: "client-1",
+          organization_id: "org-1",
+        },
+        "ES256"
+      )
+    );
+    expect(authInfo.clientId).toBe("client-1");
+    expect(authInfo.extra?.user).toEqual({
+      id: "user-1",
+      organizationId: "org-1",
+      roles: [],
+    });
+    expect(authInfo.extra?.user).not.toHaveProperty("clientId");
+  });
+
+  it("omits ctx.auth.clientId when the token lacks client_id (Connect Auth always sends it)", async () => {
+    const { privateKey, publicKey } = await generateKeyPair("ES256");
+    const jwk = await exportJWK(publicKey);
+    jwk.kid = "mcpbundles-key";
+    globalThis.fetch = mcpbundlesFixture(jwk);
+    const provider = oauthMcpbundlesProvider({
+      listingSlug: SAMPLE_LISTING_SLUG,
+      baseUrl: SAMPLE_ORIGIN_RESOURCE,
+      apiBaseUrl: SAMPLE_API_BASE,
+      publicConfig: { ...SAMPLE_PUBLIC_CONFIG },
+    });
+
+    await expect(
+      wrapOAuthTokenVerifier(
+        provider,
+        new URL(SAMPLE_ORIGIN_RESOURCE)
+      ).verifyAccessToken(
+        await signedToken(
+          privateKey,
+          "mcpbundles-key",
+          SAMPLE_ISSUER,
+          SAMPLE_ORIGIN_RESOURCE,
+          { sub: "user-1", organization_id: "org-1" },
+          "ES256"
+        )
+      )
+    ).resolves.toMatchObject({ clientId: "" });
+  });
+
+  it("parses MCPBundles public-config and rejects invalid payloads", async () => {
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify(SAMPLE_PUBLIC_CONFIG), {
+        headers: { "content-type": "application/json" },
+      });
+
+    await expect(
+      fetchMcpbundlesPublicConfig({
+        listingSlug: SAMPLE_LISTING_SLUG,
+        apiBaseUrl: SAMPLE_API_BASE,
+      })
+    ).resolves.toEqual({
+      ...SAMPLE_PUBLIC_CONFIG,
+    });
+    expect(publicConfigUrl(SAMPLE_LISTING_SLUG, SAMPLE_API_BASE)).toBe(
+      `${SAMPLE_ISSUER}/public-config`
+    );
+
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ issuer: SAMPLE_ISSUER }), {
+        headers: { "content-type": "application/json" },
+      });
+    await expect(
+      fetchMcpbundlesPublicConfig({
+        listingSlug: SAMPLE_LISTING_SLUG,
+        apiBaseUrl: SAMPLE_API_BASE,
+      })
+    ).rejects.toBeInstanceOf(McpbundlesPublicConfigError);
+  });
+
+  it("requires MCPBundles public-config and validates listing slug and baseUrl", () => {
+    expect(() =>
+      oauthMcpbundlesProvider({
+        listingSlug: "",
+        baseUrl: SAMPLE_ORIGIN_RESOURCE,
+      })
+    ).toThrow(/listingSlug/);
+
+    expect(() =>
+      oauthMcpbundlesProvider({
+        listingSlug: SAMPLE_LISTING_SLUG,
+        baseUrl: SAMPLE_ORIGIN_RESOURCE,
+      })
+    ).toThrow(/publicConfig is required/);
+
+    expect(() =>
+      oauthMcpbundlesProvider({
+        listingSlug: SAMPLE_LISTING_SLUG,
+        baseUrl: "https://other.example.test/mcp",
+        publicConfig: { ...SAMPLE_PUBLIC_CONFIG },
+        apiBaseUrl: SAMPLE_API_BASE,
+      })
+    ).toThrow(/origin_resource/);
+  });
+
   it("leaves unexpected JWKS network errors as ordinary errors", async () => {
     const { privateKey } = await generateKeyPair("RS256");
     globalThis.fetch = async () => {
@@ -583,6 +925,22 @@ function jwksFixture(jwk: Awaited<ReturnType<typeof exportJWK>>): typeof fetch {
     new Response(JSON.stringify({ keys: [jwk] }), {
       headers: { "content-type": "application/json" },
     });
+}
+
+function mcpbundlesFixture(
+  jwk: Awaited<ReturnType<typeof exportJWK>>
+): typeof fetch {
+  return async (input) => {
+    const url = String(input);
+    if (url.includes("public-config")) {
+      return new Response(JSON.stringify(SAMPLE_PUBLIC_CONFIG), {
+        headers: { "content-type": "application/json" },
+      });
+    }
+    return new Response(JSON.stringify({ keys: [jwk] }), {
+      headers: { "content-type": "application/json" },
+    });
+  };
 }
 
 function signedToken(

--- a/libraries/typescript/packages/server/tests/oauth-direct-providers.test.ts
+++ b/libraries/typescript/packages/server/tests/oauth-direct-providers.test.ts
@@ -811,7 +811,7 @@ describe("direct OAuth providers", () => {
     expect(authInfo.extra?.user).not.toHaveProperty("clientId");
   });
 
-  it("omits ctx.auth.clientId when the token lacks client_id (Connect Auth always sends it)", async () => {
+  it("rejects MCPBundles tokens missing client_id", async () => {
     const { privateKey, publicKey } = await generateKeyPair("ES256");
     const jwk = await exportJWK(publicKey);
     jwk.kid = "mcpbundles-key";
@@ -837,7 +837,51 @@ describe("direct OAuth providers", () => {
           "ES256"
         )
       )
-    ).resolves.toMatchObject({ clientId: "" });
+    ).rejects.toMatchObject({ code: "invalid_token" });
+  });
+
+  it("rejects MCPBundles tokens that only carry azp", async () => {
+    const { privateKey, publicKey } = await generateKeyPair("ES256");
+    const jwk = await exportJWK(publicKey);
+    jwk.kid = "mcpbundles-key";
+    globalThis.fetch = mcpbundlesFixture(jwk);
+    const provider = oauthMcpbundlesProvider({
+      listingSlug: SAMPLE_LISTING_SLUG,
+      baseUrl: SAMPLE_ORIGIN_RESOURCE,
+      apiBaseUrl: SAMPLE_API_BASE,
+      publicConfig: { ...SAMPLE_PUBLIC_CONFIG },
+    });
+
+    await expect(
+      wrapOAuthTokenVerifier(
+        provider,
+        new URL(SAMPLE_ORIGIN_RESOURCE)
+      ).verifyAccessToken(
+        await signedToken(
+          privateKey,
+          "mcpbundles-key",
+          SAMPLE_ISSUER,
+          SAMPLE_ORIGIN_RESOURCE,
+          { sub: "user-1", azp: "client-1" },
+          "ES256"
+        )
+      )
+    ).rejects.toMatchObject({ code: "invalid_token" });
+  });
+
+  it("preserves trailing-slash issuer in OAuth metadata", async () => {
+    const issuerWithSlash = `${SAMPLE_ISSUER}/`;
+    const provider = oauthMcpbundlesProvider({
+      listingSlug: SAMPLE_LISTING_SLUG,
+      baseUrl: SAMPLE_ORIGIN_RESOURCE,
+      apiBaseUrl: SAMPLE_API_BASE,
+      publicConfig: {
+        ...SAMPLE_PUBLIC_CONFIG,
+        issuer: issuerWithSlash,
+      },
+    });
+
+    expect(provider.oauthMetadata.issuer).toBe(issuerWithSlash);
   });
 
   it("parses MCPBundles public-config and rejects invalid payloads", async () => {

--- a/libraries/typescript/packages/server/tests/oauth-wiring-types.test.ts
+++ b/libraries/typescript/packages/server/tests/oauth-wiring-types.test.ts
@@ -11,6 +11,10 @@ import {
   oauthKeycloakProvider,
   type KeycloakOAuthUser,
 } from "../src/oauth/keycloak.js";
+import {
+  oauthMcpbundlesProvider,
+  type McpbundlesOAuthUser,
+} from "../src/oauth/mcpbundles.js";
 import { oauthCustomProvider } from "../src/oauth/provider.js";
 import {
   oauthSupabaseProvider,
@@ -160,6 +164,32 @@ function verifyOAuthCallbackTyping(): void {
     const sessionId: string | undefined = ctx.auth.user.sessionId;
     assertOAuthAuthFields(auth);
     void [user, sessionId];
+    return { content: [] };
+  });
+
+  const mcpbundles = new MCPServer({
+    name: "mcpbundles",
+    version: "1.0.0",
+    oauth: oauthMcpbundlesProvider({
+      listingSlug: "demo-listing",
+      baseUrl: "https://vendor.example.test/mcp",
+      publicConfig: {
+        issuer: "https://api.mcpbundles.test/connect-auth/tenants/demo-listing",
+        scopes_supported: ["read"],
+        origin_resource: "https://vendor.example.test/mcp",
+        bundle_proxy_resource:
+          "https://mcp.mcpbundles.test/bundle/demo-listing",
+      },
+    }),
+  });
+  mcpbundles.tool({ name: "mcpbundles-user" }, (_params, ctx) => {
+    const auth: OAuthAuth<McpbundlesOAuthUser> = ctx.auth;
+    const user: McpbundlesOAuthUser = ctx.auth.user;
+    const organizationId: string | undefined = ctx.auth.user.organizationId;
+    const email: string | undefined = ctx.auth.user.email;
+    const roles: string[] = ctx.auth.user.roles;
+    assertOAuthAuthFields(auth);
+    void [user, organizationId, email, roles];
     return { content: [] };
   });
 

--- a/libraries/typescript/packages/server/tsup.config.ts
+++ b/libraries/typescript/packages/server/tsup.config.ts
@@ -31,6 +31,7 @@ export default defineConfig([
       "oauth/workos": "src/oauth/workos.ts",
       "oauth/supabase": "src/oauth/supabase.ts",
       "oauth/keycloak": "src/oauth/keycloak.ts",
+      "oauth/mcpbundles": "src/oauth/mcpbundles.ts",
       "oauth/better-auth": "src/oauth/better-auth.ts",
       // Keep the OpenAPI integration in a sibling chunk. `MCPServer` imports
       // it synchronously so `fromOpenAPI()` stays a synchronous constructor,

--- a/libraries/typescript/packages/server/typedoc.json
+++ b/libraries/typescript/packages/server/typedoc.json
@@ -10,6 +10,7 @@
     "src/oauth/workos.ts",
     "src/oauth/supabase.ts",
     "src/oauth/keycloak.ts",
+    "src/oauth/mcpbundles.ts",
     "src/oauth/better-auth.ts",
     "src/node-bridge.ts",
     "src/next/index.ts"

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -662,6 +662,22 @@ importers:
         specifier: ^7.0.2
         version: 7.0.2
 
+  packages/server/examples/auth/mcpbundles:
+    dependencies:
+      mcp-use:
+        specifier: workspace:*
+        version: link:../../..
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@types/node':
+        specifier: ^22.20.0
+        version: 22.20.1
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
+
   packages/server/examples/auth/supabase:
     dependencies:
       '@supabase/supabase-js':


### PR DESCRIPTION
## Summary

Adds **`oauthMcpbundlesProvider`** for `@mcp-use/server` — verifies MCPBundles Connect Auth ES256 access tokens on vendor MCP origins.

- Fetches tenant `public-config` from MCPBundles API; derives JWKS + issuer from listing slug
- Maps verified tokens into WorkOS-shaped **`McpbundlesOAuthUser`** (`id`, `organizationId`, `email`, `roles`) + OAuth metadata on `ctx.auth` (`clientId`, `scopes`, …) — **no `clientId` on the user object**
- Strict **`client_id` required** on tokens
- Runnable example: `libraries/typescript/packages/server/examples/auth/mcpbundles/`
- Provider docs page + golden fixture tests

Same pattern as existing `oauthWorkOSProvider`, `oauthAuth0Provider`, etc.

## Vendor context

Vendors publish on MCPBundles with Connect Auth enabled. Clients connect via DCR/PKCE against the tenant AS; the vendor MCP server uses this provider to validate JWTs on the origin path.

Integration reference: https://www.mcpbundles.com/docs/integrations/mcp-connect-auth

## Test plan

- [x] `pnpm --filter mcp-use test:run -- oauth-direct-providers` (mcpbundles cases)
- [x] Example builds and typechecks
- [x] Golden fixture covers `email` + `roles` profile claims

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `oauthMcpbundlesProvider` to `@mcp-use/server` for verifying MCPBundles Connect Auth ES256 access tokens on vendor MCP origins. Includes tenant public-config fetch, dual‑audience checks, strict `client_id` enforcement, docs, tests, and an example.

- New Features
  - Verifies JWTs against tenant JWKS (from listing slug), supports both origin and bundle‑proxy audiences, and preserves the tenant issuer from public‑config (including trailing slash) in OAuth discovery metadata.
  - Adds `fetchMcpbundlesPublicConfig` (+ `McpbundlesPublicConfigError`) and validates `baseUrl` equals listing `origin_resource` (throws on mismatch).
  - Enforces `client_id` on tokens (rejects tokens missing it; `azp` alone is not accepted); maps claims to `McpbundlesOAuthUser` and keeps OAuth metadata on `ctx.auth` (`clientId`, `scopes`, `expiresAt`, `resource`).
  - Exported at `mcp-use/oauth/mcpbundles`; example defaults `baseUrl` to listing `origin_resource` when `MCP_URL` is unset; docs added (v1 and v2) with provider icon and note that `MCP_URL` must match `origin_resource`; tests include a golden token and JWKS rotation.

<sup>Written for commit 22c9f637b91d1d60426adfa1f5c1ade4540fb353. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

