### PR TITLE
docs(skills): import server APIs from the mcp-use root

### DIFF
--- a/skills/chatgpt-app-builder/references/authentication/overview.md
+++ b/skills/chatgpt-app-builder/references/authentication/overview.md
@@ -15,7 +15,7 @@ Adding OAuth 2.0/2.1 authentication to your MCP server.
 Pass an OAuth provider to the `oauth` option on `MCPServer`:
 
 ```typescript
-import { MCPServer } from "mcp-use/server";
+import { MCPServer } from "mcp-use";
 
 const server = new MCPServer({
   name: "my-server",

--- a/skills/chatgpt-app-builder/references/foundations/quickstart.md
+++ b/skills/chatgpt-app-builder/references/foundations/quickstart.md
@@ -92,7 +92,7 @@ After scaffolding:
 Open `index.ts` and you'll see a basic server. Let's add a simple tool:
 
 ```typescript
-import { MCPServer, text } from "mcp-use/server";
+import { MCPServer, text } from "mcp-use";
 import { z } from "zod";
 
 const server = new MCPServer({
@@ -177,7 +177,7 @@ server.tool(
 Return structured data with `object()`:
 
 ```typescript
-import { MCPServer, text, object } from "mcp-use/server";
+import { MCPServer, text, object } from "mcp-use";
 
 server.tool(
   {

--- a/skills/chatgpt-app-builder/references/patterns/common-patterns.md
+++ b/skills/chatgpt-app-builder/references/patterns/common-patterns.md
@@ -11,7 +11,7 @@ Complete end-to-end examples showing server + widget implementations for common 
 ### Server (index.ts)
 
 ```typescript
-import { MCPServer, text, widget, object, error } from "mcp-use/server";
+import { MCPServer, text, widget, object, error } from "mcp-use";
 import { z } from "zod";
 
 const server = new MCPServer({
@@ -150,7 +150,7 @@ export default function WeatherDisplay() {
 ### Server (index.ts)
 
 ```typescript
-import { MCPServer, text, widget, object, error } from "mcp-use/server";
+import { MCPServer, text, widget, object, error } from "mcp-use";
 import { z } from "zod";
 
 const server = new MCPServer({
@@ -434,7 +434,7 @@ export default function TodoList() {
 ### Server (index.ts)
 
 ```typescript
-import { MCPServer, widget, text } from "mcp-use/server";
+import { MCPServer, widget, text } from "mcp-use";
 import { z } from "zod";
 
 const server = new MCPServer({

--- a/skills/chatgpt-app-builder/references/server/prompts.md
+++ b/skills/chatgpt-app-builder/references/server/prompts.md
@@ -9,7 +9,7 @@ Prompts are reusable message templates with parameters that help structure AI in
 ## Basic Prompt
 
 ```typescript
-import { MCPServer, text } from "mcp-use/server";
+import { MCPServer, text } from "mcp-use";
 import { z } from "zod";
 
 const server = new MCPServer({
@@ -230,7 +230,7 @@ server.prompt(
 For longer, structured prompts use `markdown()`:
 
 ```typescript
-import { markdown } from "mcp-use/server";
+import { markdown } from "mcp-use";
 
 server.prompt(
   {
@@ -411,7 +411,7 @@ server.prompt(
 Add autocomplete suggestions to prompt arguments using `completable()`:
 
 ```typescript
-import { MCPServer, text, completable } from "mcp-use/server";
+import { MCPServer, text, completable } from "mcp-use";
 import { z } from "zod";
 
 // Static list of suggestions
@@ -537,7 +537,7 @@ server.tool(
 ## Complete Example
 
 ```typescript
-import { MCPServer, text, markdown } from "mcp-use/server";
+import { MCPServer, text, markdown } from "mcp-use";
 import { z } from "zod";
 
 const server = new MCPServer({

--- a/skills/chatgpt-app-builder/references/server/proxy.md
+++ b/skills/chatgpt-app-builder/references/server/proxy.md
@@ -9,7 +9,7 @@ This is extremely useful when you have multiple microservices or specialized MCP
 Pass a configuration object directly to `server.proxy()`. The keys act as the **namespaces** for the child servers to prevent naming collisions.
 
 ```typescript
-import { MCPServer } from "mcp-use/server";
+import { MCPServer } from "mcp-use";
 import path from "node:path";
 
 const server = new MCPServer({ name: "UnifiedServer", version: "1.0.0" });
@@ -46,7 +46,7 @@ In the example above, the `database` tools will be prefixed with `database_` (e.
 For advanced use cases (dynamic auth headers, manual session lifecycles, or custom connectors), you can inject an explicit `MCPSession` directly into the `proxy` method using the `mcp-use/client` SDK.
 
 ```typescript
-import { MCPServer } from "mcp-use/server";
+import { MCPServer } from "mcp-use";
 import { MCPClient } from "@mcp-use/client";
 
 const server = new MCPServer({ name: "UnifiedServer", version: "1.0.0" });

--- a/skills/chatgpt-app-builder/references/server/resources.md
+++ b/skills/chatgpt-app-builder/references/server/resources.md
@@ -9,7 +9,7 @@ Resources expose read-only data that clients can fetch. They don't take input pa
 ## Basic Resource
 
 ```typescript
-import { MCPServer, object, text, markdown } from "mcp-use/server";
+import { MCPServer, object, text, markdown } from "mcp-use";
 
 const server = new MCPServer({
   name: "my-server",
@@ -437,7 +437,7 @@ server.resource(
 ## Complete Example
 
 ```typescript
-import { MCPServer, object, markdown, error } from "mcp-use/server";
+import { MCPServer, object, markdown, error } from "mcp-use";
 
 const server = new MCPServer({
   name: "docs-server",

--- a/skills/chatgpt-app-builder/references/server/tools.md
+++ b/skills/chatgpt-app-builder/references/server/tools.md
@@ -9,7 +9,7 @@ Tools are backend actions the AI can call. They take structured input and return
 ## Basic Tool
 
 ```typescript
-import { MCPServer, text } from "mcp-use/server";
+import { MCPServer, text } from "mcp-use";
 import { z } from "zod";
 
 const server = new MCPServer({
@@ -219,7 +219,7 @@ return object({
 **Always use `error()` helper, don't throw:**
 
 ```typescript
-import { text, error } from "mcp-use/server";
+import { text, error } from "mcp-use";
 
 server.tool(
   { name: "fetch-user", schema: z.object({ id: z.string() }) },
@@ -258,7 +258,7 @@ server.tool(
 When your tool returns visual UI:
 
 ```typescript
-import { widget, text } from "mcp-use/server";
+import { widget, text } from "mcp-use";
 
 server.tool(
   {

--- a/skills/chatgpt-app-builder/references/widgets/basics.md
+++ b/skills/chatgpt-app-builder/references/widgets/basics.md
@@ -29,7 +29,7 @@ Widgets are React components that provide visual UI for MCP tools. They let user
 
 ```typescript
 // index.ts
-import { MCPServer, widget, text } from "mcp-use/server";
+import { MCPServer, widget, text } from "mcp-use";
 import { z } from "zod";
 
 const server = new MCPServer({
@@ -655,7 +655,7 @@ Equivalently, `mcp-use client <name> tools call <tool> ... --screenshot` calls t
 
 ```typescript
 // index.ts
-import { MCPServer, widget, text } from "mcp-use/server";
+import { MCPServer, widget, text } from "mcp-use";
 import { z } from "zod";
 
 const server = new MCPServer({

--- a/skills/mcp-builder/references/authentication/overview.md
+++ b/skills/mcp-builder/references/authentication/overview.md
@@ -15,7 +15,7 @@ Adding OAuth 2.0/2.1 authentication to your MCP server.
 Pass an OAuth provider to the `oauth` option on `MCPServer`:
 
 ```typescript
-import { MCPServer } from "mcp-use/server";
+import { MCPServer } from "mcp-use";
 
 const server = new MCPServer({
   name: "my-server",

--- a/skills/mcp-builder/references/foundations/quickstart.md
+++ b/skills/mcp-builder/references/foundations/quickstart.md
@@ -96,7 +96,7 @@ After scaffolding:
 Open `index.ts` and you'll see a basic server. Let's add a simple tool:
 
 ```typescript
-import { MCPServer, text } from "mcp-use/server";
+import { MCPServer, text } from "mcp-use";
 import { z } from "zod";
 
 const server = new MCPServer({
@@ -181,7 +181,7 @@ export const getWeather = server.tool(
 Return structured data with `object()`:
 
 ```typescript
-import { MCPServer, text, object } from "mcp-use/server";
+import { MCPServer, text, object } from "mcp-use";
 
 export const getWeatherDetailed = server.tool(
   {

--- a/skills/mcp-builder/references/patterns/common-patterns.md
+++ b/skills/mcp-builder/references/patterns/common-patterns.md
@@ -11,7 +11,7 @@ Complete end-to-end examples showing server + widget implementations for common 
 ### Server (index.ts)
 
 ```typescript
-import { MCPServer, text, widget, object, error } from "mcp-use/server";
+import { MCPServer, text, widget, object, error } from "mcp-use";
 import { z } from "zod";
 
 const server = new MCPServer({
@@ -150,7 +150,7 @@ export default function WeatherDisplay() {
 ### Server (index.ts)
 
 ```typescript
-import { MCPServer, text, widget, object, error } from "mcp-use/server";
+import { MCPServer, text, widget, object, error } from "mcp-use";
 import { z } from "zod";
 
 const server = new MCPServer({
@@ -434,7 +434,7 @@ export default function TodoList() {
 ### Server (index.ts)
 
 ```typescript
-import { MCPServer, widget, text } from "mcp-use/server";
+import { MCPServer, widget, text } from "mcp-use";
 import { z } from "zod";
 
 const server = new MCPServer({

--- a/skills/mcp-builder/references/server/prompts.md
+++ b/skills/mcp-builder/references/server/prompts.md
@@ -9,7 +9,7 @@ Prompts are reusable message templates with parameters that help structure AI in
 ## Basic Prompt
 
 ```typescript
-import { MCPServer, text } from "mcp-use/server";
+import { MCPServer, text } from "mcp-use";
 import { z } from "zod";
 
 const server = new MCPServer({
@@ -230,7 +230,7 @@ server.prompt(
 For longer, structured prompts use `markdown()`:
 
 ```typescript
-import { markdown } from "mcp-use/server";
+import { markdown } from "mcp-use";
 
 server.prompt(
   {
@@ -411,7 +411,7 @@ server.prompt(
 Add autocomplete suggestions to prompt arguments using `completable()`:
 
 ```typescript
-import { MCPServer, text, completable } from "mcp-use/server";
+import { MCPServer, text, completable } from "mcp-use";
 import { z } from "zod";
 
 // Static list of suggestions
@@ -537,7 +537,7 @@ server.tool(
 ## Complete Example
 
 ```typescript
-import { MCPServer, text, markdown } from "mcp-use/server";
+import { MCPServer, text, markdown } from "mcp-use";
 import { z } from "zod";
 
 const server = new MCPServer({

--- a/skills/mcp-builder/references/server/proxy.md
+++ b/skills/mcp-builder/references/server/proxy.md
@@ -9,7 +9,7 @@ This is extremely useful when you have multiple microservices or specialized MCP
 Pass a configuration object directly to `server.proxy()`. The keys act as the **namespaces** for the child servers to prevent naming collisions.
 
 ```typescript
-import { MCPServer } from "mcp-use/server";
+import { MCPServer } from "mcp-use";
 import path from "node:path";
 
 const server = new MCPServer({ name: "UnifiedServer", version: "1.0.0" });
@@ -46,7 +46,7 @@ In the example above, the `database` tools will be prefixed with `database_` (e.
 For advanced use cases (dynamic auth headers, manual session lifecycles, or custom connectors), you can inject an explicit `MCPSession` directly into the `proxy` method using the `@mcp-use/client` SDK.
 
 ```typescript
-import { MCPServer } from "mcp-use/server";
+import { MCPServer } from "mcp-use";
 import { MCPClient } from "@mcp-use/client";
 
 const server = new MCPServer({ name: "UnifiedServer", version: "1.0.0" });

--- a/skills/mcp-builder/references/server/resources.md
+++ b/skills/mcp-builder/references/server/resources.md
@@ -9,7 +9,7 @@ Resources expose read-only data that clients can fetch. They don't take input pa
 ## Basic Resource
 
 ```typescript
-import { MCPServer, object, text, markdown } from "mcp-use/server";
+import { MCPServer, object, text, markdown } from "mcp-use";
 
 const server = new MCPServer({
   name: "my-server",
@@ -437,7 +437,7 @@ server.resource(
 ## Complete Example
 
 ```typescript
-import { MCPServer, object, markdown, error } from "mcp-use/server";
+import { MCPServer, object, markdown, error } from "mcp-use";
 
 const server = new MCPServer({
   name: "docs-server",

--- a/skills/mcp-builder/references/server/tools.md
+++ b/skills/mcp-builder/references/server/tools.md
@@ -9,7 +9,7 @@ Tools are backend actions the AI can call. They take structured input and return
 ## Basic Tool
 
 ```typescript
-import { MCPServer, text } from "mcp-use/server";
+import { MCPServer, text } from "mcp-use";
 import { z } from "zod";
 
 const server = new MCPServer({
@@ -223,7 +223,7 @@ return object({
 **Always use `error()` helper, don't throw:**
 
 ```typescript
-import { text, error } from "mcp-use/server";
+import { text, error } from "mcp-use";
 
 export const fetchUserTool = server.tool(
   { name: "fetch-user", schema: z.object({ id: z.string() }) },
@@ -262,7 +262,7 @@ export const fetchUserTool = server.tool(
 When your tool returns visual UI:
 
 ```typescript
-import { widget, text } from "mcp-use/server";
+import { widget, text } from "mcp-use";
 
 export const searchProducts = server.tool(
   {

--- a/skills/mcp-builder/references/widgets/basics.md
+++ b/skills/mcp-builder/references/widgets/basics.md
@@ -29,7 +29,7 @@ Widgets are React components that provide visual UI for MCP tools. They let user
 
 ```typescript
 // index.ts
-import { MCPServer, widget, text } from "mcp-use/server";
+import { MCPServer, widget, text } from "mcp-use";
 import { z } from "zod";
 
 const server = new MCPServer({
@@ -655,7 +655,7 @@ Equivalently, `mcp-use client <name> tools call <tool> ... --screenshot` calls t
 
 ```typescript
 // index.ts
-import { MCPServer, widget, text } from "mcp-use/server";
+import { MCPServer, widget, text } from "mcp-use";
 import { z } from "zod";
 
 const server = new MCPServer({

--- a/skills/openapi-to-mcp/SKILL.md
+++ b/skills/openapi-to-mcp/SKILL.md
@@ -157,7 +157,7 @@ The registration loop is small. Pseudocode:
 
 ```ts
 import "dotenv/config";
-import { MCPServer, text } from "mcp-use/server";
+import { MCPServer, text } from "mcp-use";
 import { operations } from "./src/operations";
 import { callOperation } from "./src/client";
 import { operationToZod } from "./src/schema";

--- a/skills/openapi-to-mcp/references/code-templates.md
+++ b/skills/openapi-to-mcp/references/code-templates.md
@@ -481,7 +481,7 @@ Replace the scaffolded `index.ts` with this — preserving the MCPServer fields 
 
 ```ts
 import "dotenv/config";              // load .env into process.env
-import { MCPServer, text } from "mcp-use/server";
+import { MCPServer, text } from "mcp-use";
 import { operations } from "./src/operations";
 import { callOperation } from "./src/client";
 import { operationToZod } from "./src/schema";


### PR DESCRIPTION
## Changes

The agent skills still teach `import { ... } from "mcp-use/server"`. That subpath was removed before v2 went stable, so an agent following these skills emits code that does not resolve. Same root cause as #2145 and #2146, third and largest surface.

This fixes the 40 import lines whose symbols all exist on the package root, across 18 files in `mcp-builder`, `chatgpt-app-builder` and `openapi-to-mcp`.

## These are not stale-by-design files

Worth saying up front, because the recent pattern has been to delete v1 remnants rather than update them. These skills are already partly on v2:

```
mcp-builder          1 @mcp-use/client   2 mcp-use   35 mcp-use/react   28 mcp-use/server
chatgpt-app-builder  1 @mcp-use/client   2 mcp-use   35 mcp-use/react   28 mcp-use/server
```

The React side is v2 and the client import is v2. Only the server imports were left behind. `skills/mcp-apps-builder`, the one `create-mcp-use-app` actually ships, is already fully clean, which is what made the others stand out.

If you would rather delete these two skills outright, say so and I will close this.

## Verification

Every symbol on a rewritten line was checked against the root entry point:

```
completable  error  markdown  MCPServer  object  text  widget
```

all present in `libraries/typescript/packages/server/src/index.ts`.

The diff is 40 insertions and 40 deletions, and touches nothing but the module specifier:

```
$ git diff -U0 | grep -E "^[+-]" | grep -v "^[+-][+-]" | grep -v 'from "mcp-use'
(no output)
```

`ci-preflight` exit 0.

## What I left alone, and why

18 lines remain on `mcp-use/server` because a blanket rewrite would be wrong:

* **14 lines** import OAuth providers. Those exist in v2 but under subpaths, not the root: `oauthAuth0Provider` is `mcp-use/oauth/auth0`, `oauthClerkProvider` is `mcp-use/oauth/clerk`, and so on, with `oauthCustomProvider` on `mcp-use/oauth`. I verified each one, so this part is mechanical and I can send it as a follow-up.
* **8 lines** import `jwksVerifier` or `oauthProxy`. Neither exists anywhere in the v2 source. `oauthProxy` lines up with your note on #2078 that the OAuth proxy is not implemented in v2 yet. So those skill sections document APIs that are not there, which is a content problem rather than an import fix.

Tell me how you want those handled and I will follow up. I did not want to quietly point them at a plausible-looking module.

## Backwards Compatibility

Documentation only. No source, build, or published artifact changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken v2 server examples by switching imports from `mcp-use/server` to the `mcp-use` package root. Updates 40 import lines across `mcp-builder`, `chatgpt-app-builder`, and `openapi-to-mcp`.

- **Bug Fixes**
  - Replaced `import { ... } from "mcp-use/server"` with `import { ... } from "mcp-use"` in 18 files.
  - Left OAuth provider imports unchanged; in v2 they live under `mcp-use/oauth/*`. `jwksVerifier` and `oauthProxy` have no v2 equivalent.
  - Docs-only change; no source or build impact.

<sup>Written for commit 6b2b077892e92ee07d3c634b0c81a735b599f7be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

