### PR TITLE
docs: update the contributor monorepo layout for v2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,8 +192,10 @@ libraries/typescript/
 ├── package.json          # Root workspace config
 ├── pnpm-workspace.yaml   # Workspace definition
 ├── packages/
-│   ├── mcp-use/          # Core library (npm: mcp-use)
-│   ├── cli/              # CLI tools (npm: @mcp-use/cli)
+│   ├── server/           # MCP framework and CLI (npm: mcp-use)
+│   ├── client/           # MCP client (npm: @mcp-use/client)
+│   ├── agent/            # MCP agent (npm: @mcp-use/agent)
+│   ├── cli/              # CLI shim (npm: @mcp-use/cli)
 │   ├── inspector/        # MCP Inspector (npm: @mcp-use/inspector)
 │   └── create-mcp-use-app/  # Project scaffolding CLI
 ```
@@ -203,7 +205,7 @@ libraries/typescript/
 - All packages share the same `node_modules` at the workspace root (efficient disk usage)
 - Packages can depend on each other using `workspace:*` protocol
 - Running `pnpm install` at the root installs dependencies for all packages
-- Running `pnpm build` builds packages in the correct dependency order (`mcp-use` first, then others)
+- Running `pnpm build` builds packages in the correct dependency order (`@mcp-use/client`, then `mcp-use`, then the rest)
 
 ### Setup
 


### PR DESCRIPTION
## Changes

The "Monorepo Structure" section in `CONTRIBUTING.md` still describes the v1 layout. It lists `packages/mcp-use/`, which the v2 merge deleted, and omits `server`, `client` and `agent`. A new contributor following it goes looking for a directory that is not there and never learns about half the packages.

```diff
 ├── packages/
-│   ├── mcp-use/          # Core library (npm: mcp-use)
-│   ├── cli/              # CLI tools (npm: @mcp-use/cli)
+│   ├── server/           # MCP framework and CLI (npm: mcp-use)
+│   ├── client/           # MCP client (npm: @mcp-use/client)
+│   ├── agent/            # MCP agent (npm: @mcp-use/agent)
+│   ├── cli/              # CLI shim (npm: @mcp-use/cli)
 │   ├── inspector/        # MCP Inspector (npm: @mcp-use/inspector)
 │   └── create-mcp-use-app/  # Project scaffolding CLI
```

## Verification

Directory names and npm names both read off `main` rather than assumed:

```
agent                @mcp-use/agent
cli                  @mcp-use/cli
client               @mcp-use/client
create-mcp-use-app   create-mcp-use-app
inspector            @mcp-use/inspector
server               mcp-use
```

The build order note was also wrong. It said packages build with "`mcp-use` first, then others", but the root script is:

```
build = pnpm run build:client && pnpm run build:mcp-use && pnpm run build:other
```

so `@mcp-use/client` goes first. Corrected to match.

I checked the rest of the file for stale paths and found none: the other references use `pnpm --filter <package-name>`, and every name used is still valid.

`ci-preflight` exit 0.

## One wording call

I described `cli` as a "CLI shim" rather than "CLI tools", following `CLI_SPEC.md`, which says `@mcp-use/cli@4` is a compatibility-only proxy that "owns no command code or behavior". Its own `package.json` description still says "Prebuilt CLI, development server, and build pipeline", which looks like it predates that change. Happy to word it differently if the package description is the one that is current.

## Backwards Compatibility

Documentation only. No source, build, or published artifact changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the "Monorepo Structure" in `CONTRIBUTING.md` for v2 so contributors see the correct packages and build order. Replaces the removed `packages/mcp-use/` with `server`, adds `client` and `agent`, clarifies `cli` as a shim, and fixes the build note to run `@mcp-use/client` first, then `mcp-use`.

<sup>Written for commit 83eb85cb738715944141ffb55e2ab6c7755a783a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

