### PR TITLE
docs(skills): import OAuth providers from their v2 subpaths

### DIFF
--- a/skills/chatgpt-app-builder/references/authentication/auth0.md
+++ b/skills/chatgpt-app-builder/references/authentication/auth0.md
@@ -36,7 +36,8 @@ Auth0's built-in DCR feature is currently in **Early Access**. MCP clients regis
 ### Quick Start
 
 ```typescript
-import { MCPServer, oauthAuth0Provider, object } from "mcp-use/server";
+import { MCPServer, object } from "mcp-use";
+import { oauthAuth0Provider } from "mcp-use/oauth/auth0";
 
 const server = new MCPServer({
   name: "my-server",

--- a/skills/chatgpt-app-builder/references/authentication/better-auth.md
+++ b/skills/chatgpt-app-builder/references/authentication/better-auth.md
@@ -87,7 +87,8 @@ You need three things beyond the standard `MCPServer` setup:
 3. Mount login and consent pages
 
 ```typescript
-import { MCPServer, oauthBetterAuthProvider } from "mcp-use/server";
+import { MCPServer } from "mcp-use";
+import { oauthBetterAuthProvider } from "mcp-use/oauth/better-auth";
 import { auth } from "./auth.js";
 import {
   oauthProviderAuthServerMetadata,

--- a/skills/chatgpt-app-builder/references/authentication/clerk.md
+++ b/skills/chatgpt-app-builder/references/authentication/clerk.md
@@ -9,7 +9,8 @@ Setting up OAuth with Clerk. DCR mode only — MCP clients register themselves d
 ## Quick Start
 
 ```typescript
-import { MCPServer, oauthClerkProvider, object } from "mcp-use/server";
+import { MCPServer, object } from "mcp-use";
+import { oauthClerkProvider } from "mcp-use/oauth/clerk";
 
 const server = new MCPServer({
   name: "my-server",

--- a/skills/chatgpt-app-builder/references/authentication/custom.md
+++ b/skills/chatgpt-app-builder/references/authentication/custom.md
@@ -14,7 +14,8 @@ Two factories cover everything that isn't a built-in provider:
 Use this when your identity provider supports DCR and advertises a `registration_endpoint`. Clients discover the endpoints and register themselves against the upstream.
 
 ```typescript
-import { MCPServer, oauthCustomProvider, object } from "mcp-use/server";
+import { MCPServer, object } from "mcp-use";
+import { oauthCustomProvider } from "mcp-use/oauth";
 import { jwtVerify, createRemoteJWKSet } from "jose";
 
 const JWKS = createRemoteJWKSet(

--- a/skills/chatgpt-app-builder/references/authentication/keycloak.md
+++ b/skills/chatgpt-app-builder/references/authentication/keycloak.md
@@ -9,7 +9,8 @@ Setting up OAuth with Keycloak. Keycloak exposes full OAuth 2.1 + OIDC endpoints
 ## Quick Start
 
 ```typescript
-import { MCPServer, oauthKeycloakProvider, object } from "mcp-use/server";
+import { MCPServer, object } from "mcp-use";
+import { oauthKeycloakProvider } from "mcp-use/oauth/keycloak";
 
 const server = new MCPServer({
   name: "my-server",

--- a/skills/chatgpt-app-builder/references/authentication/supabase.md
+++ b/skills/chatgpt-app-builder/references/authentication/supabase.md
@@ -13,7 +13,8 @@ Setting up OAuth with Supabase's OAuth 2.1 server. Supabase hosts `/authorize`, 
 ## Quick Start
 
 ```typescript
-import { MCPServer, oauthSupabaseProvider, object } from "mcp-use/server";
+import { MCPServer, object } from "mcp-use";
+import { oauthSupabaseProvider } from "mcp-use/oauth/supabase";
 
 const server = new MCPServer({
   name: "my-server",

--- a/skills/chatgpt-app-builder/references/authentication/workos.md
+++ b/skills/chatgpt-app-builder/references/authentication/workos.md
@@ -9,7 +9,8 @@ Setting up OAuth with WorkOS AuthKit. DCR mode only — MCP clients register the
 ## Quick Start
 
 ```typescript
-import { MCPServer, oauthWorkOSProvider, object } from "mcp-use/server";
+import { MCPServer, object } from "mcp-use";
+import { oauthWorkOSProvider } from "mcp-use/oauth/workos";
 
 const server = new MCPServer({
   name: "my-server",

--- a/skills/mcp-builder/references/authentication/auth0.md
+++ b/skills/mcp-builder/references/authentication/auth0.md
@@ -36,7 +36,8 @@ Auth0's built-in DCR feature is currently in **Early Access**. MCP clients regis
 ### Quick Start
 
 ```typescript
-import { MCPServer, oauthAuth0Provider, object } from "mcp-use/server";
+import { MCPServer, object } from "mcp-use";
+import { oauthAuth0Provider } from "mcp-use/oauth/auth0";
 
 const server = new MCPServer({
   name: "my-server",

--- a/skills/mcp-builder/references/authentication/better-auth.md
+++ b/skills/mcp-builder/references/authentication/better-auth.md
@@ -87,7 +87,8 @@ You need three things beyond the standard `MCPServer` setup:
 3. Mount login and consent pages
 
 ```typescript
-import { MCPServer, oauthBetterAuthProvider } from "mcp-use/server";
+import { MCPServer } from "mcp-use";
+import { oauthBetterAuthProvider } from "mcp-use/oauth/better-auth";
 import { auth } from "./auth.js";
 import {
   oauthProviderAuthServerMetadata,

--- a/skills/mcp-builder/references/authentication/clerk.md
+++ b/skills/mcp-builder/references/authentication/clerk.md
@@ -9,7 +9,8 @@ Setting up OAuth with Clerk. DCR mode only — MCP clients register themselves d
 ## Quick Start
 
 ```typescript
-import { MCPServer, oauthClerkProvider, object } from "mcp-use/server";
+import { MCPServer, object } from "mcp-use";
+import { oauthClerkProvider } from "mcp-use/oauth/clerk";
 
 const server = new MCPServer({
   name: "my-server",

--- a/skills/mcp-builder/references/authentication/custom.md
+++ b/skills/mcp-builder/references/authentication/custom.md
@@ -14,7 +14,8 @@ Two factories cover everything that isn't a built-in provider:
 Use this when your identity provider supports DCR and advertises a `registration_endpoint`. Clients discover the endpoints and register themselves against the upstream.
 
 ```typescript
-import { MCPServer, oauthCustomProvider, object } from "mcp-use/server";
+import { MCPServer, object } from "mcp-use";
+import { oauthCustomProvider } from "mcp-use/oauth";
 import { jwtVerify, createRemoteJWKSet } from "jose";
 
 const JWKS = createRemoteJWKSet(

--- a/skills/mcp-builder/references/authentication/keycloak.md
+++ b/skills/mcp-builder/references/authentication/keycloak.md
@@ -9,7 +9,8 @@ Setting up OAuth with Keycloak. Keycloak exposes full OAuth 2.1 + OIDC endpoints
 ## Quick Start
 
 ```typescript
-import { MCPServer, oauthKeycloakProvider, object } from "mcp-use/server";
+import { MCPServer, object } from "mcp-use";
+import { oauthKeycloakProvider } from "mcp-use/oauth/keycloak";
 
 const server = new MCPServer({
   name: "my-server",

--- a/skills/mcp-builder/references/authentication/supabase.md
+++ b/skills/mcp-builder/references/authentication/supabase.md
@@ -13,7 +13,8 @@ Setting up OAuth with Supabase's OAuth 2.1 server. Supabase hosts `/authorize`, 
 ## Quick Start
 
 ```typescript
-import { MCPServer, oauthSupabaseProvider, object } from "mcp-use/server";
+import { MCPServer, object } from "mcp-use";
+import { oauthSupabaseProvider } from "mcp-use/oauth/supabase";
 
 const server = new MCPServer({
   name: "my-server",

--- a/skills/mcp-builder/references/authentication/workos.md
+++ b/skills/mcp-builder/references/authentication/workos.md
@@ -9,7 +9,8 @@ Setting up OAuth with WorkOS AuthKit. DCR mode only — MCP clients register the
 ## Quick Start
 
 ```typescript
-import { MCPServer, oauthWorkOSProvider, object } from "mcp-use/server";
+import { MCPServer, object } from "mcp-use";
+import { oauthWorkOSProvider } from "mcp-use/oauth/workos";
 
 const server = new MCPServer({
   name: "my-server",


### PR DESCRIPTION
## Changes

Follow-up to #2154, which fixed the 40 skill imports whose symbols live on the package root. These 14 lines also pull in an OAuth provider, and those are not on the root, so they needed splitting rather than a specifier swap.

```diff
-import { MCPServer, oauthAuth0Provider, object } from "mcp-use/server";
+import { MCPServer, object } from "mcp-use";
+import { oauthAuth0Provider } from "mcp-use/oauth/auth0";
```

## This is the documented pattern, not my invention

I held these back from #2154 because splitting an import felt like a style call. It is not: the v2 auth docs already do exactly this.

```
docs/v2/typescript/server/authentication/providers/auth0.mdx:30:import { MCPServer } from "mcp-use";
docs/v2/typescript/server/authentication/providers/auth0.mdx:31:import { oauthAuth0Provider } from "mcp-use/oauth/auth0";
```

So this brings the skills in line with the pages they are meant to teach from.

## Mapping, each verified against the source

| Symbol | Module |
| --- | --- |
| `oauthAuth0Provider` | `mcp-use/oauth/auth0` |
| `oauthClerkProvider` | `mcp-use/oauth/clerk` |
| `oauthWorkOSProvider` | `mcp-use/oauth/workos` |
| `oauthSupabaseProvider` | `mcp-use/oauth/supabase` |
| `oauthKeycloakProvider` | `mcp-use/oauth/keycloak` |
| `oauthBetterAuthProvider` | `mcp-use/oauth/better-auth` |
| `oauthCustomProvider` | `mcp-use/oauth` |

The six named providers are each exported from their own `src/oauth/<name>.ts`; `oauthCustomProvider` comes off the `./oauth` index. Every subpath is in the package `exports` map.

## Verification

- 28 insertions, 14 deletions, and the diff touches nothing but `import` lines:

```
$ git diff -U0 | grep -E "^[+-]" | grep -v "^[+-][+-]" | grep -v "^[+-]import "
(no output)
```

- `ci-preflight` exit 0.

## Still left, and still needing your call

4 lines remain on `mcp-use/server`, in `mcp-builder` and `chatgpt-app-builder` under `authentication/auth0.md:109` and `authentication/custom.md:154`. They import `oauthProxy` and `jwksVerifier`, which do not exist anywhere in the v2 source.

That matches what the migration guide already tells users:

> OAuth proxy or authorization-server mode has no native v2 migration. Do not translate `oauthProxy`, `jwksVerifier`, or `mountOAuthProxy` as resource-server configuration.

So those two skill sections teach an API v2 does not have, and the fix is to remove or rewrite them rather than repoint an import. Happy to send that once you say which. After this PR the skills are otherwise fully on v2 imports.

## Backwards Compatibility

Documentation only. No source, build, or published artifact changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update skills docs to import OAuth providers from `mcp-use/oauth/*` and import `MCPServer` and `object` from `mcp-use`. This fixes broken v2 examples and matches the documented pattern.

- **Bug Fixes**
  - Updated providers: `oauthAuth0Provider`, `oauthClerkProvider`, `oauthWorkOSProvider`, `oauthSupabaseProvider`, `oauthKeycloakProvider`, `oauthBetterAuthProvider` (from `mcp-use/oauth/<provider>`), and `oauthCustomProvider` (from `mcp-use/oauth`).
  - Left as-is: `oauthProxy` and `jwksVerifier` examples; v2 has no migration path.
  - Docs-only change; no source or build impact.

<sup>Written for commit e3ec94e12ad3337426d8d00eb9a7bdd8650eb1e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

