### PR TITLE
docs: drop examples README entries whose examples no longer exist

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -59,7 +59,6 @@ When you clone this repository locally, you'll find `python/` and `typescript/` 
 ## TypeScript Examples
 
 ### Client Examples
-- **[Node HTTP Client](../libraries/typescript/packages/mcp-use/examples/client/node/full-features-example.ts)** - Node/HTTP client with tool calls, sampling, elicitation, notifications
 - **[CommonJS Example](../libraries/typescript/packages/client/examples/browser/commonjs/commonjs_example.cjs)** - CommonJS usage
 - **[CLI Examples](../libraries/typescript/packages/client/examples/cli/)** - Command-line interface examples
 - **[React Integration](../libraries/typescript/packages/client/examples/browser/react/)** - React client examples
@@ -69,25 +68,17 @@ When you clone this repository locally, you'll find `python/` and `typescript/` 
 ### Server Examples
 - **[Basic Server](../libraries/typescript/packages/server/examples/basic/)** - Simple server implementation
 - **[Server Features](../libraries/typescript/packages/server/examples/)** - Advanced features
-  - [Everything](../libraries/typescript/packages/mcp-use/examples/server/features/everything/) - All MCP primitives in one server
   - [Conformance](../libraries/typescript/packages/server/examples/conformance/) - MCP conformance test server
   - [Elicitation](../libraries/typescript/packages/server/examples/elicitation/) - Form and URL elicitation
   - [Sampling](../libraries/typescript/packages/server/examples/sampling/) - Server-initiated LLM sampling
   - [Notifications](../libraries/typescript/packages/server/examples/notifications/) - Bidirectional notifications
-  - [Completion](../libraries/typescript/packages/mcp-use/examples/server/features/completion/) - Autocomplete for prompt args
-  - [Streaming Props](../libraries/typescript/packages/mcp-use/examples/server/features/streaming-props/) - Stream tool props to widgets
   - [Middleware](../libraries/typescript/packages/server/examples/middleware/) - Built-in middleware pipeline
-  - [Express Middleware](../libraries/typescript/packages/mcp-use/examples/server/features/express-middleware/) - Express/Hono integration
-  - [Session Management](../libraries/typescript/packages/mcp-use/examples/server/features/session-management/) - Memory, filesystem, Redis storage
   - [Proxy](../libraries/typescript/packages/server/examples/proxy/) - Proxy MCP server
-  - [Client Info](../libraries/typescript/packages/mcp-use/examples/server/features/client-info/) - Access client capabilities
-  - [DNS Rebinding](../libraries/typescript/packages/mcp-use/examples/server/features/dns-rebinding/) - DNS rebinding protection
 - **[OAuth Examples](../libraries/typescript/packages/server/examples/auth/)** - OAuth implementations
   - [Auth0](../libraries/typescript/packages/server/examples/auth/auth0/)
   - [Better Auth (v2 + Hono)](../libraries/typescript/packages/server/examples/auth/better-auth/)
   - [Supabase](../libraries/typescript/packages/server/examples/auth/supabase/)
   - [WorkOS](../libraries/typescript/packages/server/examples/auth/workos/)
-- **[Deployment](../libraries/typescript/packages/mcp-use/examples/server/deployment/)** - Deployment examples
 - **[MCP Apps view examples](../libraries/typescript/packages/server/examples/views/)** — current `view` API and React hooks
   - **[Basic](../libraries/typescript/packages/server/examples/views/basic/)** - Typed tool output, view tools, host context, and display modes
   - [File Upload](../libraries/typescript/packages/server/examples/views/file-upload/) - File-manager view using `useFiles`


### PR DESCRIPTION
## Changes

Finishes what #2132 started. That PR repointed the 17 links with an exact v2 home and left 9 alone because they had none. This removes those 9.

They are not stale paths pointing at moved examples. The examples themselves were not carried into v2, so each bullet advertises something that is not in the tree:

```
client/node/full-features-example.ts
server/features/everything/
server/features/completion/
server/features/streaming-props/
server/features/express-middleware/
server/features/session-management/
server/features/client-info/
server/features/dns-rebinding/
server/deployment/
```

`examples/README.md` now has **zero** broken relative links, down from 26 before #2132:

```
before this PR:  total ../ links: 86   broken: 9
after:           total ../ links: 77   broken: 0
```

## Why delete rather than repoint

I asked on #2132 and did not want to guess, but the guessing is the part I have avoided: pointing a bullet at a loosely similar example would assert an equivalence I cannot verify. Two I looked at specifically and rejected:

* **Completion.** v2 has `resource-template-completion`, but that is completion for resource-template arguments, while this bullet says "Autocomplete for prompt args". Different feature.
* **DNS Rebinding.** v2's `security` example might cover it, but I did not confirm it demonstrates the same protection, so I was not going to point at it on a hunch.

Deleting a false entry is the one change that is true regardless of which replacement you would pick.

## One nuance worth your attention

**Deployment** is the odd one out. The `server/deployment/` directory is gone, but v2 does still ship deployment examples, just reorganised as `vercel`, `railway`, `nextjs` and `nextjs-standalone` at the examples root. So this PR removes a bullet whose subject still exists in another shape.

I did not write a replacement because grouping those four under a new "Deployment" bullet is an editorial choice about how the index should read. Say the word and I will add it, or restore any of the other eight with a target you prefer.

## Verification

Every remaining relative link in the file resolved against the tracked tree, and the surrounding structure re-read to check nothing was orphaned (the `Server Features` and `OAuth Examples` groups still have their parent bullets and remaining children). `ci-preflight` exit 0.

## Backwards Compatibility

Documentation only. No source, build, or published artifact changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove nine dead entries from `examples/README.md` that pointed to examples not carried into v2, eliminating all broken relative links. Completes the cleanup started in #2132.

- **Bug Fixes**
  - Deleted entries for Node HTTP Client, Everything, Completion, Streaming Props, Express Middleware, Session Management, Client Info, DNS Rebinding, and Deployment.
  - Broken relative links drop from 9 to 0 (77 total remain).
  - Chose deletion over repointing to avoid implying parity; “Deployment” exists in v2 as separate examples (`vercel`, `railway`, `nextjs`, `nextjs-standalone`).

<sup>Written for commit 9e39a07a7dd46d105eed57f0e09214cca1475047. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

