### PR TITLE
docs(client): add Parallel Search MCP example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -61,6 +61,7 @@ When you clone this repository locally, you'll find `python/` and `typescript/` 
 ### Client Examples
 - **[CommonJS Example](../libraries/typescript/packages/client/examples/browser/commonjs/commonjs_example.cjs)** - CommonJS usage
 - **[CLI Examples](../libraries/typescript/packages/client/examples/cli/)** - Command-line interface examples
+- **[Parallel Search MCP](../libraries/typescript/packages/client/examples/node/parallel-search.ts)** - Keyless web search with source links
 - **[React Integration](../libraries/typescript/packages/client/examples/browser/react/)** - React client examples
 - **[Notifications Client](../libraries/typescript/packages/client/examples/node/communication/notification-client.ts)** - Notification handling
 - **[Sampling Client](../libraries/typescript/packages/client/examples/node/communication/sampling-client.ts)** - Sampling configuration

--- a/libraries/typescript/packages/client/examples/README.md
+++ b/libraries/typescript/packages/client/examples/README.md
@@ -28,6 +28,7 @@ Run the complete matrix:
 ## Feature examples
 
 - `node/basic-http.ts` — tools + automatic v1/v2 negotiation.
+- `node/parallel-search.ts` — keyless web search with source links through a hosted MCP server.
 - `node/communication/sampling-client.ts` — v1 reverse request and v2
   `input_required` sampling.
 - `node/communication/elicitation-client.ts` — v1 reverse request and v2

--- a/libraries/typescript/packages/client/examples/node/parallel-search.ts
+++ b/libraries/typescript/packages/client/examples/node/parallel-search.ts
@@ -1,0 +1,57 @@
+/**
+ * Search the web with the hosted Parallel Search MCP server.
+ *
+ * This example calls the server directly, so it does not require an LLM, a
+ * Parallel account, or an API key. Search results are printed as returned by
+ * the server so their citations and source URLs remain available.
+ *
+ * Run from packages/client:
+ *   node examples/node/parallel-search.ts "latest Model Context Protocol news"
+ */
+
+import { MCPClient } from "@mcp-use/client";
+
+const SERVER_NAME = "parallel-search";
+const DEFAULT_QUERY = "latest Model Context Protocol news";
+const query = process.argv.slice(2).join(" ").trim() || DEFAULT_QUERY;
+
+async function main(): Promise<void> {
+  const client = new MCPClient({
+    mcpServers: {
+      [SERVER_NAME]: {
+        url: "https://search.parallel.ai/mcp",
+      },
+    },
+  });
+
+  try {
+    const connection = await client.connect(SERVER_NAME);
+    const result = await connection.callTool("web_search", {
+      objective: `Find current, relevant web sources for: ${query}`,
+      search_queries: [query],
+    });
+
+    if (result.isError) {
+      throw new Error(`Search failed: ${JSON.stringify(result.content)}`);
+    }
+
+    let printedResult = false;
+    for (const block of result.content) {
+      if (block.type === "text") {
+        console.log(block.text);
+        printedResult = true;
+      }
+    }
+
+    if (!printedResult) {
+      throw new Error("Search returned no text content");
+    }
+  } finally {
+    await client.close();
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Language / Project Scope

- [x] TypeScript
- [ ] Python
- [x] Documentation only
- [ ] CI/CD or tooling

## Changes

Adds a focused `@mcp-use/client` example for connecting to a hosted Streamable HTTP MCP server and calling a tool without an agent or LLM.

- connects to the keyless Parallel Search MCP endpoint
- accepts a search query from the command line
- calls `web_search` directly and preserves the returned citations and source URLs
- adds the example to both client example indexes

## Review Readiness

- [x] The PR is scoped to one clearly related change
- [x] The PR description explains the user-visible value
- [x] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [x] I verified the affected package and documentation paths
- [x] I checked for existing open PRs that already solve the same issue

## Implementation Details

The example uses the existing `MCPClient` API and the hosted `https://search.parallel.ai/mcp` endpoint. It adds no dependencies, changes no client behavior or defaults, and does not introduce a provider-specific SDK abstraction.

No changeset is included because this is example-only code outside the package's published `dist` files, consistent with recent example-only contributions.

## Example Usage

```bash
cd libraries/typescript/packages/client
node examples/node/parallel-search.ts "latest Model Context Protocol news"
```

## Testing

- `pnpm --filter @mcp-use/client build`
- `pnpm --filter @mcp-use/client test:run` — 49 files and 283 tests passed
- `pnpm exec prettier --check packages/client/examples/node/parallel-search.ts packages/client/examples/README.md ../../examples/README.md`
- `pnpm exec eslint packages/client/examples/node/parallel-search.ts`
- `node --check examples/node/parallel-search.ts`
- live anonymous `web_search` call returned current results with direct source URLs

## Backwards Compatibility

Fully backwards compatible. This only adds a standalone example and two index entries.

## Related Issues

None. Exact searches found no existing Parallel Search MCP issue, PR, endpoint reference, or example in this repository.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a `@mcp-use/client` Node example for calling the hosted Parallel Search MCP (`https://search.parallel.ai/mcp`) directly, enabling keyless web search. No agent or LLM required.

- **New Features**
  - Connects to the `parallel-search` MCP server and calls `web_search` with `MCPClient`.
  - Accepts a query via CLI and prints results while preserving citations and source URLs.
  - Linked in both client example READMEs; no new dependencies or behavior changes.

<sup>Written for commit 903ac8a2bb5f131f62f7ce0ca879480e45c94329. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

