### PR TITLE
docs: list AUTH_IMPLEMENTATION.md in the spec index

### DIFF
--- a/libraries/typescript/packages/server/AGENTS.md
+++ b/libraries/typescript/packages/server/AGENTS.md
@@ -12,6 +12,7 @@ Every design decision lives in the package's `specs/` directory (paths below are
 | `specs/CLI_SPEC.md` | Complete `mcp-use` CLI, lazy command layout, workspace/storage, output/error rules, inspector shell, and budgets | Implemented |
 | `specs/VIEWS_SPEC.md` | Views (MCP Apps): `view()` helper, resources + wire metadata, `mcp-use/react`, typing, build/serve/dev | Alpha implemented |
 | `specs/AUTH_SPEC.md` | OAuth resource-server posture, `ctx.auth`, provider adapters, RFC 9728 discovery | Direct resource-server mode implemented; proxy mode deferred |
+| `specs/AUTH_IMPLEMENTATION.md` | The auth scope being built now: external-authorization-server token verification, no token issuance, storage, refresh, or proxying | Approved implementation scope |
 
 Decision records (`type_proposals.md`, `view_lifecycle_proposals.md` in the package root) preserve the rejected alternatives and evidence behind the specs' choices. They are history, not contract — where they differ from a spec, the spec wins.
 

--- a/libraries/typescript/packages/server/CLAUDE.md
+++ b/libraries/typescript/packages/server/CLAUDE.md
@@ -12,6 +12,7 @@ Every design decision lives in the package's `specs/` directory (paths below are
 | `specs/CLI_SPEC.md` | Complete `mcp-use` CLI, lazy command layout, workspace/storage, output/error rules, inspector shell, and budgets | Implemented |
 | `specs/VIEWS_SPEC.md` | Views (MCP Apps): `view()` helper, resources + wire metadata, `mcp-use/react`, typing, build/serve/dev | Alpha implemented |
 | `specs/AUTH_SPEC.md` | OAuth resource-server posture, `ctx.auth`, provider adapters, RFC 9728 discovery | Direct resource-server mode implemented; proxy mode deferred |
+| `specs/AUTH_IMPLEMENTATION.md` | The auth scope being built now: external-authorization-server token verification, no token issuance, storage, refresh, or proxying | Approved implementation scope |
 
 Decision records (`type_proposals.md`, `view_lifecycle_proposals.md` in the package root) preserve the rejected alternatives and evidence behind the specs' choices. They are history, not contract — where they differ from a spec, the spec wins.
 


### PR DESCRIPTION
## Changes

`packages/server/CLAUDE.md` and `AGENTS.md` open with "Every design decision lives in the package's `specs/` directory" and then a table of what to read before changing anything. The table has four rows. There are five specs.

```
$ git ls-tree --name-only origin/main libraries/typescript/packages/server/specs/
AUTH_IMPLEMENTATION.md
AUTH_SPEC.md
CLI_SPEC.md
SPEC.md
VIEWS_SPEC.md
```

`specs/AUTH_IMPLEMENTATION.md` is the one missing, and it is not a minor omission. `AUTH_SPEC.md` explicitly hands off to it for the mode that is actually built:

> **Status:** Direct resource-server mode implemented. OAuth proxy mode is deferred; its design remains in this document.
>
> **Implementation phase note:** OAuth proxy mode is deferred and must not be implemented in the current auth implementation phase. Direct resource-server mode follows [AUTH_IMPLEMENTATION.md](./AUTH_IMPLEMENTATION.md).

And that document describes itself as the current work:

> **Status:** Approved implementation scope. Implement this document in the current auth phase.

So someone orienting from the index reads the spec whose auth mode is deferred, and never learns about the one governing the auth mode being implemented. In a repo that ships agent skills and leans on these files for onboarding, that gap has teeth.

## The row added

```markdown
| `specs/AUTH_IMPLEMENTATION.md` | The auth scope being built now: external-authorization-server token verification, no token issuance, storage, refresh, or proxying | Approved implementation scope |
```

Governs and Status are both paraphrased from that document's own Status and Scope lines rather than invented.

## Both files, kept in sync

`CLAUDE.md` and `AGENTS.md` are byte-identical, and nothing in the repo enforces that, so it is easy to fix one and let them drift. I changed both and checked:

```
$ cmp -s AGENTS.md CLAUDE.md && echo identical
identical
```

## Verification

- Spec file list read off `main`.
- Quotes taken verbatim from `AUTH_SPEC.md` and `AUTH_IMPLEMENTATION.md`.
- Every relative link inside `specs/` resolved against the tracked tree while I was in there: 2 links, 0 broken. The `AUTH_IMPLEMENTATION.md` reference from `AUTH_SPEC` is intact; it is only the index that was missing it.
- `ci-preflight` exit 0.

## Backwards Compatibility

Contributor documentation only. Not published (`packages/server` ships `files: ["dist"]`). No source or build changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `specs/AUTH_IMPLEMENTATION.md` to the spec index in `packages/server/CLAUDE.md` and `AGENTS.md` so contributors can find the current auth implementation scope (direct resource-server mode) from the index. Both files remain byte-identical.

<sup>Written for commit 5989cbdac8009122366d1e928d86b92e6aacba9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

