### PR TITLE
feat(inspector): enhance URL transition effects and update test file patterns

### DIFF
--- a/libraries/typescript/.changeset/slick-nights-taste.md
+++ b/libraries/typescript/.changeset/slick-nights-taste.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+fix(inspector): avoid inspector tunnel flash

--- a/libraries/typescript/packages/inspector/src/client/components/Layout.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/Layout.tsx
@@ -516,6 +516,7 @@ export function Layout({ children }: LayoutProps) {
   };
 
   const selectedServer = connections.find((c) => c.id === selectedServerId);
+  const displayServerRef = useRef<McpServer | undefined>(undefined);
 
   const isTunnelConnecting = useTunnelConnectionSync({
     tunnelUrl,
@@ -526,6 +527,14 @@ export function Layout({ children }: LayoutProps) {
     updateConnection: updateServer,
     connections,
   });
+
+  useEffect(() => {
+    if (!isTunnelConnecting && selectedServer) {
+      displayServerRef.current = selectedServer;
+    } else if (!isTunnelConnecting) {
+      displayServerRef.current = undefined;
+    }
+  }, [isTunnelConnecting, selectedServer]);
 
   // Aggregate tools, prompts, and resources from all connected servers
   // When a server is selected, use only that server's items
@@ -811,8 +820,7 @@ export function Layout({ children }: LayoutProps) {
     !!urlServerId &&
     !urlServerId.startsWith("http://") &&
     !urlServerId.startsWith("https://");
-  const showBootScreen =
-    isAutoConnecting || isBootstrappingServer || isTunnelConnecting;
+  const showBootScreen = isAutoConnecting || isBootstrappingServer;
   const layoutViewKey = selectedServer?.id ?? "home";
   const viewTransitionKey = showBootScreen ? "boot" : layoutViewKey;
   const [displayKey, setDisplayKey] = useState(viewTransitionKey);
@@ -830,10 +838,21 @@ export function Layout({ children }: LayoutProps) {
   }, [viewTransitionKey, displayKey]);
 
   const showDisplayBoot = displayKey === "boot";
-  const displayServer =
-    showDisplayBoot || displayKey === "home"
-      ? undefined
-      : connections.find((c) => c.id === displayKey);
+  const displayServer = showDisplayBoot
+    ? undefined
+    : displayKey === "home"
+      ? (selectedServer ??
+        (isTunnelConnecting ? displayServerRef.current : undefined))
+      : (connections.find((c) => c.id === displayKey) ??
+        (isTunnelConnecting ? displayServerRef.current : undefined));
+  const displayServerWithStableMetadata =
+    isTunnelConnecting && displayServer && displayServerRef.current
+      ? {
+          ...displayServer,
+          serverInfo:
+            displayServerRef.current.serverInfo ?? displayServer.serverInfo,
+        }
+      : displayServer;
 
   // Apply embedded styling
   const isSingleTab = isEmbedded && embeddedConfig.singleTab;
@@ -855,8 +874,8 @@ export function Layout({ children }: LayoutProps) {
     ? "flex-1 w-full bg-white dark:bg-black p-0 overflow-auto"
     : cn(
         "flex-1 min-h-0 min-w-0 max-w-full w-full bg-white dark:bg-black rounded-2xl border border-zinc-200 dark:border-zinc-700 overflow-x-hidden overflow-y-auto",
-        !displayServer && "lg:mx-4",
-        displayServer && "lg:mr-4"
+        !displayServerWithStableMetadata && "lg:mx-4",
+        displayServerWithStableMetadata && "lg:mr-4"
       );
 
   const bodyClassName = isSingleTab
@@ -865,7 +884,7 @@ export function Layout({ children }: LayoutProps) {
 
   const headerProps = {
     connections,
-    selectedServer: displayServer,
+    selectedServer: displayServerWithStableMetadata,
     activeTab,
     onServerSelect: handleServerSelect,
     onTabChange: handleTabChange,
@@ -891,11 +910,11 @@ export function Layout({ children }: LayoutProps) {
             {!isSingleTab && <LayoutHeader {...headerProps} />}
 
             <div className={bodyClassName}>
-              {displayServer && !isSingleTab && (
+              {displayServerWithStableMetadata && !isSingleTab && (
                 <InspectorSidebar
                   activeTab={activeTab}
                   onTabChange={handleTabChange}
-                  selectedServer={displayServer}
+                  selectedServer={displayServerWithStableMetadata}
                   visibleTabs={embeddedConfig.visibleTabs}
                   collapsed={sidebarCollapsed}
                   onCollapsedChange={setSidebarCollapsed}
@@ -908,7 +927,7 @@ export function Layout({ children }: LayoutProps) {
               )}
               <main className={mainClassName}>
                 <LayoutContent
-                  selectedServer={displayServer}
+                  selectedServer={displayServerWithStableMetadata}
                   activeTab={activeTab}
                   toolsSearchRef={toolsSearchRef}
                   promptsSearchRef={promptsSearchRef}
@@ -918,9 +937,9 @@ export function Layout({ children }: LayoutProps) {
                   {children}
                 </LayoutContent>
               </main>
-              {displayServer && !isSingleTab && (
+              {displayServerWithStableMetadata && !isSingleTab && (
                 <SidebarRpcPanel
-                  serverId={displayServer.id}
+                  serverId={displayServerWithStableMetadata.id}
                   open={rpcLoggerOpen}
                 />
               )}
@@ -931,7 +950,7 @@ export function Layout({ children }: LayoutProps) {
 
       {!isSingleTab && !showDisplayBoot && (
         <MobileInspectorToolbar
-          serverId={displayServer?.id}
+          serverId={displayServerWithStableMetadata?.id}
           rpcLoggerOpen={rpcLoggerOpen}
           onRpcLoggerOpenChange={setRpcLoggerOpen}
         />

--- a/libraries/typescript/packages/inspector/src/client/components/layout/ServerUrlChip.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/layout/ServerUrlChip.tsx
@@ -73,10 +73,29 @@ export function ServerUrlChip({
 }: ServerUrlChipProps) {
   const [copied, setCopied] = useState(false);
   const [showCopiedBanner, setShowCopiedBanner] = useState(false);
+  const [displayUrl, setDisplayUrl] = useState(url);
+  const [previousUrl, setPreviousUrl] = useState<string | null>(null);
+  const [isUrlTransitioning, setIsUrlTransitioning] = useState(false);
 
-  if (!url) return null;
+  useEffect(() => {
+    if (!url || url === displayUrl) return;
+
+    setPreviousUrl(displayUrl);
+    setDisplayUrl(url);
+    setIsUrlTransitioning(true);
+
+    const id = window.setTimeout(() => {
+      setPreviousUrl(null);
+      setIsUrlTransitioning(false);
+    }, 280);
+    return () => window.clearTimeout(id);
+  }, [displayUrl, url]);
 
   const chipLabel = formatUrlChipLabel(url);
+  const displayChipLabel = formatUrlChipLabel(displayUrl);
+  const previousChipLabel = previousUrl
+    ? formatUrlChipLabel(previousUrl)
+    : null;
   const copyTarget = tunnelPopover?.mcpUrl ?? url;
   const isTunnel = !!tunnelPopover;
 
@@ -101,6 +120,8 @@ export function ServerUrlChip({
     return () => clearTimeout(id);
   }, [tunnelPopover?.autoCopyOnOpen]);
 
+  if (!url) return null;
+
   const urlLabel = (
     <>
       {isTunnel ? (
@@ -108,7 +129,24 @@ export function ServerUrlChip({
       ) : (
         <Globe className="size-3.5 shrink-0" />
       )}
-      <span className="truncate max-w-[min(24rem,30vw)]">{chipLabel}</span>
+      <span
+        className="inspector-url-transition min-w-0 max-w-[min(24rem,30vw)]"
+        aria-hidden="true"
+      >
+        {previousChipLabel && isUrlTransitioning && (
+          <span className="inspector-url-transition-out">
+            {previousChipLabel}
+          </span>
+        )}
+        <span
+          className={cn(
+            "inspector-url-transition-in",
+            !isUrlTransitioning && "inspector-url-transition-static"
+          )}
+        >
+          {displayChipLabel}
+        </span>
+      </span>
     </>
   );
 
@@ -128,6 +166,7 @@ export function ServerUrlChip({
             render={
               <button
                 type="button"
+                aria-label={chipLabel}
                 className={cn(urlClasses, "hover:opacity-80")}
               >
                 {urlLabel}

--- a/libraries/typescript/packages/inspector/src/client/index.css
+++ b/libraries/typescript/packages/inspector/src/client/index.css
@@ -2,6 +2,60 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
+.inspector-url-transition {
+  display: inline-grid;
+  overflow: hidden;
+}
+
+.inspector-url-transition > span {
+  grid-area: 1 / 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.inspector-url-transition-out {
+  animation: inspector-url-blur-out 280ms ease both;
+}
+
+.inspector-url-transition-in {
+  animation: inspector-url-blur-in 280ms ease both;
+}
+
+.inspector-url-transition-static {
+  animation: none;
+}
+
+@keyframes inspector-url-blur-out {
+  from {
+    opacity: 1;
+    filter: blur(0);
+  }
+  to {
+    opacity: 0;
+    filter: blur(4px);
+  }
+}
+
+@keyframes inspector-url-blur-in {
+  from {
+    opacity: 0;
+    filter: blur(4px);
+  }
+  to {
+    opacity: 1;
+    filter: blur(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .inspector-url-transition-out,
+  .inspector-url-transition-in {
+    animation: none;
+  }
+}
+
 @custom-variant dark (&:is(.dark *));
 
 @theme {

--- a/libraries/typescript/packages/inspector/vitest.config.ts
+++ b/libraries/typescript/packages/inspector/vitest.config.ts
@@ -5,7 +5,10 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
-    include: ["tests/unit/**/*.test.ts", "src/**/__tests__/**/*.test.ts"],
+    include: [
+      "tests/unit/**/*.test.ts",
+      "src/**/__tests__/**/*.{test,spec}.{ts,tsx}",
+    ],
     exclude: ["node_modules", "dist", "tests/e2e/**"],
     testTimeout: 10000,
     hookTimeout: 10000,


### PR DESCRIPTION
- Added CSS transitions for URL changes in the ServerUrlChip component to improve user experience.
- Updated the vitest configuration to include both `.test.ts` and `.spec.ts` files in the test patterns.
- Refactored Layout component to utilize a reference for stable server metadata during tunnel connections.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes tunnel URL flashing in the inspector by stabilizing UI state during tunnel reconnects. Adds smooth URL change transitions in the `ServerUrlChip` and updates vitest to include `.spec` tests.

- **Bug Fixes**
  - Preserve stable server metadata during tunnel connections using a display ref to prevent header/sidebar/content flicker.
  - Stop showing the boot screen on tunnel reconnect; keep the current view steady.

<sup>Written for commit 13e5a22d53c0af12b902be6800bfa9e5fa145a47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

