### PR TITLE
fix(inspector): populate window.openai compatibility bridge

### DIFF
--- a/libraries/typescript/.changeset/bright-widgets-bridge.md
+++ b/libraries/typescript/.changeset/bright-widgets-bridge.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/client": patch
+---
+
+Populate the Inspector's `window.openai` compatibility bridge with tool lifecycle globals and host actions while preserving the native MCP Apps handshake for V2 views.

--- a/libraries/typescript/packages/client/src/react/view/inject-openai-file-apis.ts
+++ b/libraries/typescript/packages/client/src/react/view/inject-openai-file-apis.ts
@@ -1,3 +1,5 @@
+import { LATEST_PROTOCOL_VERSION } from "@modelcontextprotocol/ext-apps/app-bridge";
+
 const OPENAI_COMPATIBILITY_BRIDGE_SCRIPT = `<script>
 (function () {
   var files = new Map();
@@ -20,6 +22,7 @@ const OPENAI_COMPATIBILITY_BRIDGE_SCRIPT = `<script>
     if (context.theme !== undefined) globals.theme = context.theme;
     if (context.displayMode !== undefined) globals.displayMode = context.displayMode;
     if (context.locale !== undefined) globals.locale = context.locale;
+    if (context.view !== undefined) globals.view = context.view;
     if (context.safeAreaInsets !== undefined) {
       globals.safeArea = { insets: context.safeAreaInsets };
     }
@@ -94,15 +97,22 @@ const OPENAI_COMPATIBILITY_BRIDGE_SCRIPT = `<script>
     var params = message.params || {};
     switch (message.method) {
       case "ui/notifications/tool-input":
-      case "ui/notifications/tool-input-partial":
         markHostConnected();
         dispatchGlobals({ toolInput: params.arguments || {} });
+        break;
+      case "ui/notifications/tool-input-partial":
+        // window.openai has no partial-input global. Do not expose incomplete
+        // or approval-gated arguments as if the final tool input had arrived.
+        markHostConnected();
         break;
       case "ui/notifications/tool-result":
         markHostConnected();
         dispatchGlobals({
-          toolOutput: params,
-          toolResponseMetadata: params._meta || null
+          // OpenAI defines toolOutput as structuredContent, not the complete
+          // CallToolResult envelope. Keep that envelope (including hidden
+          // _meta) in toolResponseMetadata instead.
+          toolOutput: params.structuredContent === undefined ? null : params.structuredContent,
+          toolResponseMetadata: params
         });
         break;
       case "ui/notifications/host-context-changed":
@@ -112,7 +122,7 @@ const OPENAI_COMPATIBILITY_BRIDGE_SCRIPT = `<script>
     }
   });
 
-  api.toolInput = api.toolInput || {};
+  api.toolInput = api.toolInput === undefined ? null : api.toolInput;
   api.toolOutput = api.toolOutput === undefined ? null : api.toolOutput;
   api.toolResponseMetadata =
     api.toolResponseMetadata === undefined ? null : api.toolResponseMetadata;
@@ -146,10 +156,6 @@ const OPENAI_COMPATIBILITY_BRIDGE_SCRIPT = `<script>
   };
   api.setWidgetState = api.setWidgetState || function (state) {
     dispatchGlobals({ widgetState: state });
-    return sendRequest("ui/update-model-context", {
-      structuredContent: state || {},
-      content: [{ type: "text", text: JSON.stringify(state || {}) }]
-    });
   };
   api.notifyIntrinsicHeight = api.notifyIntrinsicHeight || function (height) {
     sendNotification("ui/notifications/size-changed", { height: height });
@@ -177,7 +183,7 @@ const OPENAI_COMPATIBILITY_BRIDGE_SCRIPT = `<script>
     sendRequest("ui/initialize", {
       appCapabilities: {},
       appInfo: { name: "mcp-use-openai-compat", version: "1.0.0" },
-      protocolVersion: "2025-06-18"
+      protocolVersion: ${JSON.stringify(LATEST_PROTOCOL_VERSION)}
     }).then(function (result) {
       markHostConnected(result);
       sendNotification("ui/notifications/initialized", {});
@@ -189,9 +195,11 @@ const OPENAI_COMPATIBILITY_BRIDGE_SCRIPT = `<script>
 </script>`;
 
 /**
- * Prepend a complete ChatGPT Apps SDK compatibility surface for Inspector
- * previews. Native V2 views keep using MCP Apps; legacy useWidget() bundles
- * receive the same tool lifecycle and host actions through window.openai.
+ * Prepend the shared ChatGPT Apps SDK compatibility aliases and
+ * Inspector-supported file helpers. Native V2 views keep using MCP Apps;
+ * legacy useWidget() bundles receive the same tool lifecycle and host actions
+ * through window.openai. Unsupported ChatGPT-only extensions remain absent so
+ * apps can feature-detect them as documented.
  */
 export function injectOpenAiFileApis(html: string): string {
   const headEnd = findOpeningConstructEnd(html, "<head");

--- a/libraries/typescript/packages/client/src/react/view/inject-openai-file-apis.ts
+++ b/libraries/typescript/packages/client/src/react/view/inject-openai-file-apis.ts
@@ -1,37 +1,209 @@
-const OPENAI_FILE_APIS_SCRIPT = `<script>
+const OPENAI_COMPATIBILITY_BRIDGE_SCRIPT = `<script>
 (function () {
   var files = new Map();
-  window.openai = window.openai || {};
-  window.openai.uploadFile = async function (file) {
+  var pendingRequests = new Map();
+  var requestId = 0;
+  var hostConnected = false;
+  var fallbackTimer;
+  var api = window.openai || {};
+
+  function dispatchGlobals(globals) {
+    Object.assign(api, globals);
+    window.dispatchEvent(new CustomEvent("openai:set_globals", {
+      detail: { globals: globals }
+    }));
+  }
+
+  function applyHostContext(context) {
+    if (!context || typeof context !== "object") return;
+    var globals = {};
+    if (context.theme !== undefined) globals.theme = context.theme;
+    if (context.displayMode !== undefined) globals.displayMode = context.displayMode;
+    if (context.locale !== undefined) globals.locale = context.locale;
+    if (context.safeAreaInsets !== undefined) {
+      globals.safeArea = { insets: context.safeAreaInsets };
+    }
+    if (context.containerDimensions && context.containerDimensions.maxHeight !== undefined) {
+      globals.maxHeight = context.containerDimensions.maxHeight;
+    }
+    if (context.platform !== undefined || context.deviceCapabilities !== undefined) {
+      globals.userAgent = {
+        device: {
+          type: context.platform === "mobile" ? "mobile" : "desktop"
+        },
+        capabilities: {
+          hover: !!(context.deviceCapabilities && context.deviceCapabilities.hover),
+          touch: !!(context.deviceCapabilities && context.deviceCapabilities.touch)
+        }
+      };
+    }
+    dispatchGlobals(globals);
+  }
+
+  function markHostConnected(result) {
+    hostConnected = true;
+    clearTimeout(fallbackTimer);
+    if (result && result.hostContext) applyHostContext(result.hostContext);
+  }
+
+  function postMessage(message) {
+    if (window.parent === window) {
+      throw new Error("window.openai compatibility APIs require an iframe host");
+    }
+    window.parent.postMessage(message, "*");
+  }
+
+  function sendRequest(method, params) {
+    var id = "mcp-use-openai-compat-" + (++requestId);
+    return new Promise(function (resolve, reject) {
+      pendingRequests.set(id, { resolve: resolve, reject: reject });
+      postMessage({ jsonrpc: "2.0", id: id, method: method, params: params });
+      window.setTimeout(function () {
+        var pending = pendingRequests.get(id);
+        if (!pending) return;
+        pendingRequests.delete(id);
+        pending.reject(new Error("Request timeout: " + method));
+      }, 30000);
+    });
+  }
+
+  function sendNotification(method, params) {
+    postMessage({ jsonrpc: "2.0", method: method, params: params });
+  }
+
+  window.addEventListener("message", function (event) {
+    if (event.source !== window.parent) return;
+    var message = event.data;
+    if (!message || message.jsonrpc !== "2.0") return;
+
+    if (message.id !== undefined && (message.result !== undefined || message.error !== undefined)) {
+      var pending = pendingRequests.get(message.id);
+      if (pending) {
+        pendingRequests.delete(message.id);
+        if (message.error) pending.reject(new Error(message.error.message || "Host request failed"));
+        else pending.resolve(message.result);
+        return;
+      }
+      if (message.result && (message.result.hostInfo || message.result.hostContext)) {
+        markHostConnected(message.result);
+      }
+      return;
+    }
+
+    if (message.id !== undefined || typeof message.method !== "string") return;
+    var params = message.params || {};
+    switch (message.method) {
+      case "ui/notifications/tool-input":
+      case "ui/notifications/tool-input-partial":
+        markHostConnected();
+        dispatchGlobals({ toolInput: params.arguments || {} });
+        break;
+      case "ui/notifications/tool-result":
+        markHostConnected();
+        dispatchGlobals({
+          toolOutput: params,
+          toolResponseMetadata: params._meta || null
+        });
+        break;
+      case "ui/notifications/host-context-changed":
+        markHostConnected();
+        applyHostContext(params);
+        break;
+    }
+  });
+
+  api.toolInput = api.toolInput || {};
+  api.toolOutput = api.toolOutput === undefined ? null : api.toolOutput;
+  api.toolResponseMetadata =
+    api.toolResponseMetadata === undefined ? null : api.toolResponseMetadata;
+  api.widgetState = api.widgetState === undefined ? null : api.widgetState;
+  api.theme = api.theme || "light";
+  api.displayMode = api.displayMode || "inline";
+  api.safeArea = api.safeArea || {
+    insets: { top: 0, right: 0, bottom: 0, left: 0 }
+  };
+  api.maxHeight = api.maxHeight || 600;
+  api.userAgent = api.userAgent || {
+    device: { type: "desktop" },
+    capabilities: { hover: true, touch: false }
+  };
+  api.locale = api.locale || "en";
+
+  api.callTool = api.callTool || function (name, args) {
+    return sendRequest("tools/call", { name: name, arguments: args || {} });
+  };
+  api.sendFollowUpMessage = api.sendFollowUpMessage || function (request) {
+    return sendRequest("ui/message", {
+      role: "user",
+      content: [{ type: "text", text: request.prompt }]
+    });
+  };
+  api.openExternal = api.openExternal || function (request) {
+    return sendRequest("ui/open-link", { url: request.href });
+  };
+  api.requestDisplayMode = api.requestDisplayMode || function (request) {
+    return sendRequest("ui/request-display-mode", { mode: request.mode });
+  };
+  api.setWidgetState = api.setWidgetState || function (state) {
+    dispatchGlobals({ widgetState: state });
+    return sendRequest("ui/update-model-context", {
+      structuredContent: state || {},
+      content: [{ type: "text", text: JSON.stringify(state || {}) }]
+    });
+  };
+  api.notifyIntrinsicHeight = api.notifyIntrinsicHeight || function (height) {
+    sendNotification("ui/notifications/size-changed", { height: height });
+    return Promise.resolve();
+  };
+  api.uploadFile = api.uploadFile || async function (file) {
     var fileId = crypto.randomUUID();
     files.set(fileId, file);
     return { fileId: fileId };
   };
-  window.openai.getFileDownloadUrl = async function (ref) {
+  api.getFileDownloadUrl = api.getFileDownloadUrl || async function (ref) {
     var file = files.get(ref.fileId);
     if (!file) {
       throw new Error("File not found: " + ref.fileId);
     }
     return { downloadUrl: URL.createObjectURL(file) };
   };
+  window.openai = api;
+
+  // Native V2 views initialize their own MCP Apps bridge. Only initialize this
+  // compatibility bridge when no other guest handshake appears, so the file
+  // helpers remain safe for both V2 views and legacy useWidget() bundles.
+  fallbackTimer = window.setTimeout(function () {
+    if (hostConnected) return;
+    sendRequest("ui/initialize", {
+      appCapabilities: {},
+      appInfo: { name: "mcp-use-openai-compat", version: "1.0.0" },
+      protocolVersion: "2025-06-18"
+    }).then(function (result) {
+      markHostConnected(result);
+      sendNotification("ui/notifications/initialized", {});
+    }).catch(function (error) {
+      console.warn("[window.openai compatibility] Failed to initialize:", error);
+    });
+  }, 1000);
 })();
 </script>`;
 
 /**
- * Prepend ChatGPT-style file helpers so `useFiles()` works in dev hosts
- * (inspector) before the view bundle calls `bootstrapView`.
+ * Prepend a complete ChatGPT Apps SDK compatibility surface for Inspector
+ * previews. Native V2 views keep using MCP Apps; legacy useWidget() bundles
+ * receive the same tool lifecycle and host actions through window.openai.
  */
 export function injectOpenAiFileApis(html: string): string {
   const headEnd = findOpeningConstructEnd(html, "<head");
   if (headEnd !== undefined) {
-    return insertAt(html, headEnd, OPENAI_FILE_APIS_SCRIPT);
+    return insertAt(html, headEnd, OPENAI_COMPATIBILITY_BRIDGE_SCRIPT);
   }
   const htmlEnd = findOpeningConstructEnd(html, "<html");
   if (htmlEnd !== undefined) {
     return insertAt(
       html,
       htmlEnd,
-      "<head>" + OPENAI_FILE_APIS_SCRIPT + "</head>"
+      "<head>" + OPENAI_COMPATIBILITY_BRIDGE_SCRIPT + "</head>"
     );
   }
   const doctypeEnd = findOpeningConstructEnd(html, "<!doctype");
@@ -39,10 +211,10 @@ export function injectOpenAiFileApis(html: string): string {
     return insertAt(
       html,
       doctypeEnd,
-      "<head>" + OPENAI_FILE_APIS_SCRIPT + "</head>"
+      "<head>" + OPENAI_COMPATIBILITY_BRIDGE_SCRIPT + "</head>"
     );
   }
-  return OPENAI_FILE_APIS_SCRIPT + html;
+  return OPENAI_COMPATIBILITY_BRIDGE_SCRIPT + html;
 }
 
 function findOpeningConstructEnd(

--- a/libraries/typescript/packages/client/tests/unit/inject-openai-file-apis.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/inject-openai-file-apis.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { injectOpenAiFileApis } from "../../src/react/view/inject-openai-file-apis.js";
 
@@ -10,7 +10,7 @@ async function runInjectedFileApis(html: string) {
 
   const parsed = new DOMParser().parseFromString(injected, "text/html");
   const script = Array.from(parsed.scripts).find((candidate) =>
-    candidate.textContent?.includes("window.openai.uploadFile")
+    candidate.textContent?.includes("api.uploadFile")
   );
   expect(script?.textContent).toBeTruthy();
   // eslint-disable-next-line no-new-func
@@ -43,6 +43,40 @@ async function runInjectedFileApis(html: string) {
   Reflect.deleteProperty(window, "openai");
 }
 
+function mountInjectedBridge() {
+  const injected = injectOpenAiFileApis(
+    "<html><head></head><body></body></html>"
+  );
+  const parsed = new DOMParser().parseFromString(injected, "text/html");
+  const script = Array.from(parsed.scripts).find((candidate) =>
+    candidate.textContent?.includes("mcp-use-openai-compat")
+  );
+  expect(script?.textContent).toBeTruthy();
+
+  const iframe = document.createElement("iframe");
+  document.body.appendChild(iframe);
+  const guest = iframe.contentWindow!;
+  guest.setTimeout = window.setTimeout.bind(window);
+  guest.clearTimeout = window.clearTimeout.bind(window);
+  Object.defineProperty(guest.URL, "createObjectURL", {
+    configurable: true,
+    value: URL.createObjectURL.bind(URL),
+  });
+
+  guest.Function(script!.textContent!)();
+
+  return {
+    guest,
+    cleanup: () => iframe.remove(),
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  document.body.innerHTML = "";
+});
+
 describe("injectOpenAiFileApis", () => {
   it("injects into head and round-trips upload/download", async () => {
     await runInjectedFileApis("<html><head></head><body></body></html>");
@@ -60,6 +94,183 @@ describe("injectOpenAiFileApis", () => {
     expect(injected.indexOf("uploadFile")).toBeLessThan(
       injected.indexOf("</HeAd>")
     );
+  });
+
+  it("populates the complete window.openai compatibility surface", () => {
+    const { guest, cleanup } = mountInjectedBridge();
+    const openai = (guest as typeof guest & { openai: Record<string, unknown> })
+      .openai;
+
+    expect(openai).toMatchObject({
+      toolInput: {},
+      toolOutput: null,
+      toolResponseMetadata: null,
+      theme: "light",
+      displayMode: "inline",
+      locale: "en",
+    });
+    for (const method of [
+      "callTool",
+      "sendFollowUpMessage",
+      "openExternal",
+      "requestDisplayMode",
+      "setWidgetState",
+      "notifyIntrinsicHeight",
+      "uploadFile",
+      "getFileDownloadUrl",
+    ]) {
+      expect(openai[method]).toBeTypeOf("function");
+    }
+
+    cleanup();
+  });
+
+  it("maps MCP Apps lifecycle notifications to OpenAI globals", () => {
+    const { guest, cleanup } = mountInjectedBridge();
+    const openai = (
+      guest as typeof guest & {
+        openai: {
+          toolInput: unknown;
+          toolOutput: unknown;
+          toolResponseMetadata: unknown;
+          theme: unknown;
+          displayMode: unknown;
+          locale: unknown;
+        };
+      }
+    ).openai;
+    const globalsEvents: Record<string, unknown>[] = [];
+    guest.addEventListener("openai:set_globals", (event) => {
+      globalsEvents.push(
+        (event as CustomEvent<{ globals: Record<string, unknown> }>).detail
+          .globals
+      );
+    });
+
+    guest.dispatchEvent(
+      new guest.MessageEvent("message", {
+        source: guest.parent,
+        data: {
+          jsonrpc: "2.0",
+          method: "ui/notifications/tool-input",
+          params: { arguments: { question: "Choose" } },
+        },
+      })
+    );
+    guest.dispatchEvent(
+      new guest.MessageEvent("message", {
+        source: guest.parent,
+        data: {
+          jsonrpc: "2.0",
+          method: "ui/notifications/tool-result",
+          params: {
+            content: [],
+            structuredContent: { options: ["A", "B"] },
+            _meta: { source: "test" },
+          },
+        },
+      })
+    );
+    guest.dispatchEvent(
+      new guest.MessageEvent("message", {
+        source: guest.parent,
+        data: {
+          jsonrpc: "2.0",
+          method: "ui/notifications/host-context-changed",
+          params: {
+            theme: "dark",
+            displayMode: "fullscreen",
+            locale: "de-CH",
+          },
+        },
+      })
+    );
+
+    expect(openai.toolInput).toEqual({ question: "Choose" });
+    expect(openai.toolOutput).toMatchObject({
+      structuredContent: { options: ["A", "B"] },
+    });
+    expect(openai.toolResponseMetadata).toEqual({ source: "test" });
+    expect(openai.theme).toBe("dark");
+    expect(openai.displayMode).toBe("fullscreen");
+    expect(openai.locale).toBe("de-CH");
+    expect(globalsEvents).toHaveLength(3);
+
+    cleanup();
+  });
+
+  it("does not start a second handshake after a native V2 view connects", async () => {
+    vi.useFakeTimers();
+    const { guest, cleanup } = mountInjectedBridge();
+    const postMessage = vi.spyOn(guest.parent, "postMessage");
+
+    guest.dispatchEvent(
+      new guest.MessageEvent("message", {
+        source: guest.parent,
+        data: {
+          jsonrpc: "2.0",
+          id: 1,
+          result: {
+            hostInfo: { name: "Inspector", version: "test" },
+            hostContext: { theme: "light" },
+          },
+        },
+      })
+    );
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(postMessage).not.toHaveBeenCalledWith(
+      expect.objectContaining({ method: "ui/initialize" }),
+      "*"
+    );
+    cleanup();
+  });
+
+  it("falls back to an MCP Apps handshake for legacy useWidget bundles", async () => {
+    vi.useFakeTimers();
+    const { guest, cleanup } = mountInjectedBridge();
+    const postMessage = vi.spyOn(guest.parent, "postMessage");
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jsonrpc: "2.0",
+        method: "ui/initialize",
+      }),
+      "*"
+    );
+
+    const initialize = postMessage.mock.calls.find(
+      ([message]) => (message as { method?: string }).method === "ui/initialize"
+    )?.[0] as { id: string };
+    guest.dispatchEvent(
+      new guest.MessageEvent("message", {
+        source: guest.parent,
+        data: {
+          jsonrpc: "2.0",
+          id: initialize.id,
+          result: {
+            hostInfo: { name: "Inspector", version: "test" },
+            hostContext: { theme: "dark" },
+          },
+        },
+      })
+    );
+    await Promise.resolve();
+
+    expect(postMessage).toHaveBeenCalledWith(
+      {
+        jsonrpc: "2.0",
+        method: "ui/notifications/initialized",
+        params: {},
+      },
+      "*"
+    );
+    expect(
+      (guest as typeof guest & { openai: { theme: string } }).openai.theme
+    ).toBe("dark");
+
+    cleanup();
   });
 });
 

--- a/libraries/typescript/packages/client/tests/unit/inject-openai-file-apis.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/inject-openai-file-apis.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import { LATEST_PROTOCOL_VERSION } from "@modelcontextprotocol/ext-apps/app-bridge";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { injectOpenAiFileApis } from "../../src/react/view/inject-openai-file-apis.js";
@@ -96,13 +97,13 @@ describe("injectOpenAiFileApis", () => {
     );
   });
 
-  it("populates the complete window.openai compatibility surface", () => {
+  it("populates the shared window.openai aliases and supported extensions", () => {
     const { guest, cleanup } = mountInjectedBridge();
     const openai = (guest as typeof guest & { openai: Record<string, unknown> })
       .openai;
 
     expect(openai).toMatchObject({
-      toolInput: {},
+      toolInput: null,
       toolOutput: null,
       toolResponseMetadata: null,
       theme: "light",
@@ -121,6 +122,15 @@ describe("injectOpenAiFileApis", () => {
     ]) {
       expect(openai[method]).toBeTypeOf("function");
     }
+    for (const unsupportedExtension of [
+      "requestModal",
+      "requestClose",
+      "selectFiles",
+      "setOpenInAppUrl",
+      "requestCheckout",
+    ]) {
+      expect(openai[unsupportedExtension]).toBeUndefined();
+    }
 
     cleanup();
   });
@@ -136,6 +146,7 @@ describe("injectOpenAiFileApis", () => {
           theme: unknown;
           displayMode: unknown;
           locale: unknown;
+          view: unknown;
         };
       }
     ).openai;
@@ -152,22 +163,36 @@ describe("injectOpenAiFileApis", () => {
         source: guest.parent,
         data: {
           jsonrpc: "2.0",
+          method: "ui/notifications/tool-input-partial",
+          params: { arguments: { question: "Cho" } },
+        },
+      })
+    );
+    expect(openai.toolInput).toBeNull();
+    expect(globalsEvents).toHaveLength(0);
+
+    guest.dispatchEvent(
+      new guest.MessageEvent("message", {
+        source: guest.parent,
+        data: {
+          jsonrpc: "2.0",
           method: "ui/notifications/tool-input",
           params: { arguments: { question: "Choose" } },
         },
       })
     );
+    const toolResult = {
+      content: [],
+      structuredContent: { options: ["A", "B"] },
+      _meta: { source: "test" },
+    };
     guest.dispatchEvent(
       new guest.MessageEvent("message", {
         source: guest.parent,
         data: {
           jsonrpc: "2.0",
           method: "ui/notifications/tool-result",
-          params: {
-            content: [],
-            structuredContent: { options: ["A", "B"] },
-            _meta: { source: "test" },
-          },
+          params: toolResult,
         },
       })
     );
@@ -181,20 +206,48 @@ describe("injectOpenAiFileApis", () => {
             theme: "dark",
             displayMode: "fullscreen",
             locale: "de-CH",
+            view: { id: "poll" },
           },
         },
       })
     );
 
     expect(openai.toolInput).toEqual({ question: "Choose" });
-    expect(openai.toolOutput).toMatchObject({
-      structuredContent: { options: ["A", "B"] },
-    });
-    expect(openai.toolResponseMetadata).toEqual({ source: "test" });
+    expect(openai.toolOutput).toEqual({ options: ["A", "B"] });
+    expect(openai.toolResponseMetadata).toEqual(toolResult);
     expect(openai.theme).toBe("dark");
     expect(openai.displayMode).toBe("fullscreen");
     expect(openai.locale).toBe("de-CH");
+    expect(openai.view).toEqual({ id: "poll" });
     expect(globalsEvents).toHaveLength(3);
+
+    cleanup();
+  });
+
+  it("keeps widget state private and updates it synchronously", () => {
+    vi.useFakeTimers();
+    const { guest, cleanup } = mountInjectedBridge();
+    const postMessage = vi.spyOn(guest.parent, "postMessage");
+    const openai = (
+      guest as typeof guest & {
+        openai: {
+          widgetState: unknown;
+          setWidgetState: (state: unknown) => unknown;
+        };
+      }
+    ).openai;
+    const state = {
+      modelContent: "Selected image",
+      privateContent: { selectedId: "private-1" },
+      imageIds: ["file-1"],
+    };
+
+    expect(openai.setWidgetState(state)).toBeUndefined();
+    expect(openai.widgetState).toEqual(state);
+    expect(postMessage).not.toHaveBeenCalledWith(
+      expect.objectContaining({ method: "ui/update-model-context" }),
+      "*"
+    );
 
     cleanup();
   });
@@ -242,7 +295,11 @@ describe("injectOpenAiFileApis", () => {
 
     const initialize = postMessage.mock.calls.find(
       ([message]) => (message as { method?: string }).method === "ui/initialize"
-    )?.[0] as { id: string };
+    )?.[0] as {
+      id: string;
+      params: { protocolVersion: string };
+    };
+    expect(initialize.params.protocolVersion).toBe(LATEST_PROTOCOL_VERSION);
     guest.dispatchEvent(
       new guest.MessageEvent("message", {
         source: guest.parent,


### PR DESCRIPTION
## Summary

- replace Inspector's file-only `window.openai` mock with the documented shared Apps SDK compatibility aliases plus Inspector-supported file helpers
- map final MCP Apps tool input and `structuredContent` to `window.openai`, while preserving the complete MCP result envelope as response metadata
- keep widget state synchronous and widget-scoped instead of exposing private UI state through `ui/update-model-context`
- use the MCP Apps dependency's current protocol version and preserve the native V2 handshake
- leave unsupported ChatGPT-only extensions absent so apps can feature-detect them as documented

## Root cause

Inspector injected `window.openai` with only `uploadFile` and `getFileDownloadUrl`. Legacy mcp-use widgets therefore selected their OpenAI adapter, skipped the MCP Apps guest bridge, and rendered with empty `toolInput` / `toolOutput`. This caused the deployed poll app to crash while reading `options.map`.

## OpenAI documentation alignment

- `window.openai.toolOutput` receives only tool-result `structuredContent`
- approval-gated and partial arguments are not exposed as completed `toolInput`
- `toolResponseMetadata` preserves the full MCP result, including hidden `_meta`
- `setWidgetState` updates synchronously without making private widget state model-visible
- unsupported optional extensions such as modal, close, file-library selection, and checkout remain feature-detectable

References:

- https://developers.openai.com/plugins/reference#windowopenai-component-bridge
- https://developers.openai.com/plugins/build/chatgpt-ui#manage-state
- https://developers.openai.com/plugins/build/chatgpt-ui#prefer-shared-fields-and-methods

## Validation

- `@mcp-use/client` test suite: 49 files, 289 tests passed
- `@mcp-use/client` build
- ESLint and Prettier checks on both changed files
- changeset included

## Companion PR

- Vibe native mcp-use V2 generation: https://github.com/mcp-use/mcp-use-cloud/pull/1394