### PR TITLE
fix(release): enforce monotonic stable and canary versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -837,6 +837,10 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --no-frozen-lockfile
 
+      - name: Prevent canary-to-main version regression
+        if: github.event_name == 'pull_request' && github.base_ref == 'main' && github.head_ref == 'canary'
+        run: pnpm release-channel preflight --channel stable
+
       - name: Check for Changesets
         env:
           BASE_REF: ${{ github.base_ref || 'main' }}

--- a/.github/workflows/typescript-release.yml
+++ b/.github/workflows/typescript-release.yml
@@ -84,13 +84,20 @@ jobs:
         working-directory: libraries/typescript
         id: has-changesets
         run: |
-          if [ -n "$(find .changeset -name '*.md' -not -name 'README.md' -print -quit)" ]; then
+          PENDING="$(pnpm --silent release-channel pending)"
+          if [ -n "$PENDING" ]; then
             echo "has_changesets=true" >> $GITHUB_OUTPUT
-            echo "Found changesets to publish"
+            echo "Found pending changesets:"
+            echo "$PENDING"
           else
             echo "has_changesets=false" >> $GITHUB_OUTPUT
-            echo "No changesets found"
+            echo "No pending changesets found"
           fi
+
+      - name: Verify canary release baseline
+        if: github.ref == 'refs/heads/canary' && steps.has-changesets.outputs.has_changesets == 'true'
+        working-directory: libraries/typescript
+        run: pnpm release-channel preflight --channel canary
 
       - name: Version packages (Canary)
         if: github.ref == 'refs/heads/canary' && steps.has-changesets.outputs.has_changesets == 'true'
@@ -109,13 +116,28 @@ jobs:
         working-directory: libraries/typescript
         run: pnpm build
 
+      - name: Create canary release plan
+        if: github.ref == 'refs/heads/canary' && steps.has-changesets.outputs.has_changesets == 'true'
+        working-directory: libraries/typescript
+        run: pnpm release-channel snapshot --channel canary --output canary-release-plan.json
+
       - name: Publish packages (Canary)
         if: github.ref == 'refs/heads/canary' && steps.has-changesets.outputs.has_changesets == 'true'
+        id: publish-canary
+        continue-on-error: true
         working-directory: libraries/typescript
         run: |
           # Using npm trusted publishing (OIDC) - no token needed
           pnpm changeset publish
           echo "✅ Published canary packages to npm using trusted publishing"
+
+      - name: Verify canary packages and dist-tags
+        if: github.ref == 'refs/heads/canary' && steps.has-changesets.outputs.has_changesets == 'true'
+        working-directory: libraries/typescript
+        env:
+          VERIFY_ATTEMPTS: 12
+          VERIFY_DELAY_SECONDS: 10
+        run: pnpm release-channel verify --plan canary-release-plan.json
 
       - name: Tag + push tags (Canary)
         if: github.ref == 'refs/heads/canary' && steps.has-changesets.outputs.has_changesets == 'true'
@@ -130,19 +152,20 @@ jobs:
 
           cd libraries/typescript
           pnpm changeset tag
+          pnpm release-channel tags --plan canary-release-plan.json --output ../../.release-tags
           cd ../..
 
-          NEW_TAGS=$(git tag --points-at HEAD)
-          if [ -z "$NEW_TAGS" ]; then
-            echo "ℹ️  No tags were created by changeset tag"
+          if [ ! -s .release-tags ]; then
+            echo "ℹ️  Release plan contains no new tags"
             exit 0
           fi
 
+          NEW_TAGS=$(cat .release-tags)
           echo "📦 Tags created: $NEW_TAGS"
-          echo "$NEW_TAGS" > .release-tags
-
-          # Push tags (commits were already pushed in the "Version packages" step)
-          git push --tags
+          while IFS= read -r tag; do
+            git show-ref --verify --quiet "refs/tags/$tag"
+            git push origin "refs/tags/$tag"
+          done < .release-tags
           echo "✅ Pushed tags"
 
       - name: Create GitHub Releases (Canary)
@@ -287,6 +310,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          cd libraries/typescript
+          pnpm release-channel preflight --channel stable
+          cd ../..
+
           # Create new branch (from repo root)
           BRANCH_NAME="release/exit-prerelease-$(date +%s)"
           git checkout -b "$BRANCH_NAME"
@@ -361,9 +388,9 @@ jobs:
           steps.check-release.outputs.should_publish == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        id: publish-main
+        continue-on-error: true
         run: |
-          set -e  # Exit immediately if any command fails
-
           # Configure git identity - changesets creates annotated tags (git tag -m),
           # which fail without user.name/user.email configured
           git config user.name "github-actions[bot]"
@@ -374,34 +401,38 @@ jobs:
           git checkout main
           git pull origin main
 
-          # Publish to npm using trusted publishing (OIDC) - no token needed
           cd libraries/typescript
+          pnpm release-channel preflight --channel stable
+          pnpm release-channel snapshot --channel stable --output stable-release-plan.json
           pnpm changeset publish
+          echo "✅ Stable publish command completed"
+
+      - name: Verify stable packages and dist-tags
+        if: github.ref == 'refs/heads/main' &&
+          steps.check-prerelease.outputs.in_prerelease == 'false' &&
+          steps.check-release.outputs.should_publish == 'true'
+        working-directory: libraries/typescript
+        env:
+          VERIFY_ATTEMPTS: 12
+          VERIFY_DELAY_SECONDS: 10
+        run: pnpm release-channel verify --plan stable-release-plan.json
+
+      - name: Tag and push verified stable packages
+        if: github.ref == 'refs/heads/main' &&
+          steps.check-prerelease.outputs.in_prerelease == 'false' &&
+          steps.check-release.outputs.should_publish == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch --tags --force
+          cd libraries/typescript
           pnpm changeset tag
-
-          # Capture new tags created by changeset before pushing
+          pnpm release-channel tags --plan stable-release-plan.json --output ../../.release-tags
           cd ../..
-          NEW_TAGS=$(git tag --points-at HEAD)
-
-          if [ -z "$NEW_TAGS" ]; then
-            echo "❌ No tags were created by changeset tag - packages were published to npm but tagging failed"
-            exit 1
-          fi
-
-          echo "📦 Tags created: $NEW_TAGS"
-
-          # Save tags to a file for the next step
-          echo "$NEW_TAGS" > .release-tags
-
-          # Push git tags - fail immediately if this doesn't work
-          # Note: Commits should already be pushed from the prerelease exit step
-          if ! git push --tags; then
-            echo "❌ Failed to push tags to remote (git push --tags)"
-            rm -f .release-tags  # Clean up tags file since push failed
-            exit 1
-          fi
-
-          echo "✅ Published packages to npm using trusted publishing and pushed tags"
+          while IFS= read -r tag; do
+            git show-ref --verify --quiet "refs/tags/$tag"
+            git push origin "refs/tags/$tag"
+          done < .release-tags
 
       - name: Create deployment marker (Main)
         if: github.ref == 'refs/heads/main' &&

--- a/libraries/typescript/package.json
+++ b/libraries/typescript/package.json
@@ -36,6 +36,8 @@
     "changeset": "changeset",
     "version": "changeset version && pnpm install --no-frozen-lockfile",
     "version:exit-prerelease": "node scripts/version-packages.mjs",
+    "release-channel": "node scripts/release-channel.mjs",
+    "test:release-channel": "node --test scripts/release-channel.test.mjs",
     "release": "pnpm build && changeset publish",
     "version:check": "changeset status",
     "verify:release-install": "node scripts/verify-release-install.mjs",

--- a/libraries/typescript/packages/inspector/package.json
+++ b/libraries/typescript/packages/inspector/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-use/inspector",
   "type": "module",
-  "version": "20.0.1",
+  "version": "20.0.4",
   "description": "MCP Inspector - A tool for inspecting and debugging MCP servers",
   "author": "",
   "license": "MIT",

--- a/libraries/typescript/packages/server/package.json
+++ b/libraries/typescript/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-use",
   "type": "module",
-  "version": "2.0.1",
+  "version": "2.0.4",
   "description": "MCP framework and CLI built on the official v2 SDK",
   "author": "mcp-use, Inc.",
   "license": "MIT",

--- a/libraries/typescript/scripts/release-channel.mjs
+++ b/libraries/typescript/scripts/release-channel.mjs
@@ -1,0 +1,262 @@
+import { readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import semver from "semver";
+
+const workspaceRoot = process.cwd();
+const packageRoot = join(workspaceRoot, "packages");
+const preFile = join(workspaceRoot, ".changeset", "pre.json");
+
+function readJson(file) {
+  return JSON.parse(readFileSync(file, "utf8"));
+}
+
+function option(name, fallback) {
+  const index = process.argv.indexOf(name);
+  return index === -1 ? fallback : process.argv[index + 1];
+}
+
+function manifests() {
+  return readdirSync(packageRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => join(packageRoot, entry.name, "package.json"))
+    .map(readJson)
+    .filter(
+      (manifest) => !manifest.private && manifest.name && manifest.version
+    );
+}
+
+function prereleaseState() {
+  try {
+    return readJson(preFile);
+  } catch {
+    return undefined;
+  }
+}
+
+function pendingChangesets() {
+  const applied = new Set(prereleaseState()?.changesets ?? []);
+  return readdirSync(join(workspaceRoot, ".changeset"))
+    .filter((file) => file.endsWith(".md") && file !== "README.md")
+    .map((file) => file.slice(0, -3))
+    .filter((id) => !applied.has(id))
+    .sort();
+}
+
+function packageNamesForChangesets(ids) {
+  const names = new Set();
+  for (const id of ids) {
+    const contents = readFileSync(
+      join(workspaceRoot, ".changeset", `${id}.md`),
+      "utf8"
+    );
+    const frontmatter = contents.match(/^---\n([\s\S]*?)\n---/u)?.[1] ?? "";
+    for (const line of frontmatter.split("\n")) {
+      const match = line.match(
+        /^\s*["']?([^"']+?)["']?\s*:\s*(?:patch|minor|major)\s*$/u
+      );
+      if (match) names.add(match[1]);
+    }
+  }
+  return names;
+}
+
+async function registryMetadata(name) {
+  const fixture = option("--registry-file");
+  if (fixture) {
+    const metadata = readJson(fixture)[name];
+    if (!metadata) throw new Error(`Registry fixture has no entry for ${name}`);
+    return metadata;
+  }
+
+  const url = `https://registry.npmjs.org/${encodeURIComponent(name)}?cache=${Date.now()}`;
+  const response = await fetch(url, {
+    headers: { accept: "application/vnd.npm.install-v1+json" },
+    cache: "no-store",
+  });
+  if (!response.ok)
+    throw new Error(`npm registry returned ${response.status} for ${name}`);
+  return response.json();
+}
+
+function compareOrThrow(version, latest, message) {
+  if (latest && semver.lt(version, latest)) {
+    throw new Error(`${message}: ${version} is below npm latest ${latest}`);
+  }
+}
+
+async function preflight(channel) {
+  const pre = prereleaseState();
+  const pending = pendingChangesets();
+  const affected = packageNamesForChangesets(pending);
+
+  if (channel === "canary" && (pre?.mode !== "pre" || pre?.tag !== "canary")) {
+    throw new Error(
+      "Canary verification requires .changeset/pre.json in canary prerelease mode"
+    );
+  }
+
+  for (const manifest of manifests()) {
+    if (channel === "canary" && !affected.has(manifest.name)) continue;
+    const metadata = await registryMetadata(manifest.name);
+    const latest = metadata["dist-tags"]?.latest;
+    const baseline = pre?.initialVersions?.[manifest.name] ?? manifest.version;
+    compareOrThrow(baseline, latest, `${manifest.name} ${channel} baseline`);
+  }
+
+  console.log(
+    `Release-channel preflight passed for ${channel} (${pending.length} pending changeset(s))`
+  );
+}
+
+function sameJson(left, right) {
+  const sortedEntries = (value) =>
+    Object.entries(value ?? {}).sort(([leftKey], [rightKey]) =>
+      leftKey.localeCompare(rightKey)
+    );
+  return (
+    JSON.stringify(sortedEntries(left)) === JSON.stringify(sortedEntries(right))
+  );
+}
+
+async function snapshot(channel, output) {
+  const tag = channel === "stable" ? "latest" : "canary";
+  const releases = [];
+
+  for (const manifest of manifests()) {
+    const metadata = await registryMetadata(manifest.name);
+    const versions = metadata.versions ?? {};
+    const distTags = metadata["dist-tags"] ?? {};
+    const published = Object.hasOwn(versions, manifest.version);
+    const latest = distTags.latest;
+
+    if (!published) {
+      if (channel === "stable" && semver.prerelease(manifest.version)) {
+        throw new Error(
+          `${manifest.name}@${manifest.version} is not a stable version`
+        );
+      }
+      if (
+        channel === "canary" &&
+        semver.prerelease(manifest.version)?.[0] !== "canary"
+      ) {
+        throw new Error(
+          `${manifest.name}@${manifest.version} is not a canary version`
+        );
+      }
+      if (latest && !semver.gt(manifest.version, latest)) {
+        throw new Error(
+          `${manifest.name}@${manifest.version} must be greater than npm latest ${latest}`
+        );
+      }
+    }
+
+    releases.push({
+      name: manifest.name,
+      version: manifest.version,
+      target: !published,
+      channelTag: tag,
+      distTagsBefore: distTags,
+    });
+  }
+
+  const plan = { channel, releases };
+  writeFileSync(output, `${JSON.stringify(plan, null, 2)}\n`);
+  console.log(
+    `Wrote ${channel} release plan with ${releases.filter((item) => item.target).length} target(s) to ${output}`
+  );
+}
+
+async function verifyOnce(plan) {
+  const errors = [];
+  for (const release of plan.releases) {
+    const metadata = await registryMetadata(release.name);
+    const versions = metadata.versions ?? {};
+    const afterTags = metadata["dist-tags"] ?? {};
+
+    if (release.target) {
+      if (!Object.hasOwn(versions, release.version)) {
+        errors.push(`${release.name}@${release.version} is missing from npm`);
+      }
+      if (afterTags[release.channelTag] !== release.version) {
+        errors.push(
+          `${release.name} ${release.channelTag} is ${afterTags[release.channelTag] ?? "missing"}, expected ${release.version}`
+        );
+      }
+      const beforeWithoutChannel = { ...release.distTagsBefore };
+      const afterWithoutChannel = { ...afterTags };
+      delete beforeWithoutChannel[release.channelTag];
+      delete afterWithoutChannel[release.channelTag];
+      if (!sameJson(beforeWithoutChannel, afterWithoutChannel)) {
+        errors.push(`${release.name} unrelated dist-tags changed`);
+      }
+    } else if (!sameJson(release.distTagsBefore, afterTags)) {
+      errors.push(
+        `${release.name} dist-tags changed despite not being in the release plan`
+      );
+    }
+  }
+  if (errors.length) throw new Error(errors.join("\n"));
+}
+
+async function verify(planFile) {
+  const plan = readJson(planFile);
+  const attempts = Number(process.env.VERIFY_ATTEMPTS ?? 12);
+  const delaySeconds = Number(process.env.VERIFY_DELAY_SECONDS ?? 10);
+  let lastError;
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      await verifyOnce(plan);
+      console.log(`Verified npm registry on attempt ${attempt}/${attempts}`);
+      return;
+    } catch (error) {
+      lastError = error;
+      if (attempt < attempts) {
+        console.warn(
+          `${error.message}\nRetrying registry verification (${attempt}/${attempts})`
+        );
+        await new Promise((resolve) =>
+          setTimeout(resolve, delaySeconds * 1000)
+        );
+      }
+    }
+  }
+  throw lastError;
+}
+
+function writeTags(planFile, output) {
+  const plan = readJson(planFile);
+  const tags = plan.releases
+    .filter((release) => release.target)
+    .map((release) => `${release.name}@${release.version}`);
+  writeFileSync(output, tags.length ? `${tags.join("\n")}\n` : "");
+  console.log(tags.join("\n"));
+}
+
+const [command] = process.argv.slice(2);
+
+try {
+  if (command === "pending") {
+    console.log(pendingChangesets().join("\n"));
+  } else if (command === "preflight") {
+    await preflight(option("--channel"));
+  } else if (command === "snapshot") {
+    await snapshot(
+      option("--channel"),
+      option("--output", "release-plan.json")
+    );
+  } else if (command === "verify") {
+    await verify(option("--plan", "release-plan.json"));
+  } else if (command === "tags") {
+    writeTags(
+      option("--plan", "release-plan.json"),
+      option("--output", ".release-tags")
+    );
+  } else {
+    throw new Error(`Unknown command: ${command ?? "(missing)"}`);
+  }
+} catch (error) {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+}

--- a/libraries/typescript/scripts/release-channel.test.mjs
+++ b/libraries/typescript/scripts/release-channel.test.mjs
@@ -1,0 +1,219 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+const script = new URL("./release-channel.mjs", import.meta.url).pathname;
+
+function fixture({ localVersion, latest, canary, published = [] }) {
+  const root = mkdtempSync(join(tmpdir(), "release-channel-test-"));
+  mkdirSync(join(root, "packages", "server"), { recursive: true });
+  mkdirSync(join(root, ".changeset"));
+  writeFileSync(
+    join(root, "packages", "server", "package.json"),
+    JSON.stringify({ name: "mcp-use", version: localVersion })
+  );
+  writeFileSync(join(root, ".changeset", "README.md"), "# Changesets\n");
+  const registry = {
+    "mcp-use": {
+      "dist-tags": { latest, canary },
+      versions: Object.fromEntries(published.map((version) => [version, {}])),
+    },
+  };
+  const registryFile = join(root, "registry.json");
+  writeFileSync(registryFile, JSON.stringify(registry));
+  return { root, registryFile };
+}
+
+function run(root, registryFile, ...args) {
+  return spawnSync(
+    process.execPath,
+    [script, ...args, "--registry-file", registryFile],
+    {
+      cwd: root,
+      encoding: "utf8",
+    }
+  );
+}
+
+test("rejects a stable source version below npm latest", () => {
+  const { root, registryFile } = fixture({
+    localVersion: "2.0.1",
+    latest: "2.0.4",
+    canary: "2.0.2-canary.1",
+    published: ["2.0.1", "2.0.4"],
+  });
+  const result = run(root, registryFile, "preflight", "--channel", "stable");
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /2\.0\.1 is below npm latest 2\.0\.4/u);
+});
+
+test("accepts a canary release above npm latest", () => {
+  const { root, registryFile } = fixture({
+    localVersion: "2.0.5-canary.0",
+    latest: "2.0.4",
+    canary: "2.0.2-canary.1",
+    published: ["2.0.4"],
+  });
+  const output = join(root, "plan.json");
+  execFileSync(
+    process.execPath,
+    [
+      script,
+      "snapshot",
+      "--channel",
+      "canary",
+      "--output",
+      output,
+      "--registry-file",
+      registryFile,
+    ],
+    { cwd: root }
+  );
+  const plan = JSON.parse(readFileSync(output, "utf8"));
+  assert.equal(plan.releases[0].target, true);
+});
+
+test("ignores changesets already applied in prerelease mode", () => {
+  const { root, registryFile } = fixture({
+    localVersion: "2.0.5-canary.0",
+    latest: "2.0.4",
+    canary: "2.0.5-canary.0",
+    published: ["2.0.4", "2.0.5-canary.0"],
+  });
+  writeFileSync(
+    join(root, ".changeset", "done.md"),
+    '---\n"mcp-use": patch\n---\n\nDone.\n'
+  );
+  writeFileSync(
+    join(root, ".changeset", "pre.json"),
+    JSON.stringify({
+      mode: "pre",
+      tag: "canary",
+      initialVersions: { "mcp-use": "2.0.4" },
+      changesets: ["done"],
+    })
+  );
+  const result = run(root, registryFile, "pending");
+  assert.equal(result.status, 0);
+  assert.equal(result.stdout.trim(), "");
+});
+
+test("registry verification accepts a completed target after a publish error", () => {
+  const { root, registryFile } = fixture({
+    localVersion: "2.0.5-canary.0",
+    latest: "2.0.4",
+    canary: "2.0.2-canary.1",
+    published: ["2.0.4"],
+  });
+  const planFile = join(root, "plan.json");
+  execFileSync(
+    process.execPath,
+    [
+      script,
+      "snapshot",
+      "--channel",
+      "canary",
+      "--output",
+      planFile,
+      "--registry-file",
+      registryFile,
+    ],
+    { cwd: root }
+  );
+  writeFileSync(
+    registryFile,
+    JSON.stringify({
+      "mcp-use": {
+        "dist-tags": { latest: "2.0.4", canary: "2.0.5-canary.0" },
+        versions: { "2.0.4": {}, "2.0.5-canary.0": {} },
+      },
+    })
+  );
+  const result = run(root, registryFile, "verify", "--plan", planFile);
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test("registry verification rejects a missing target", () => {
+  const { root, registryFile } = fixture({
+    localVersion: "2.0.5-canary.0",
+    latest: "2.0.4",
+    canary: "2.0.2-canary.1",
+    published: ["2.0.4"],
+  });
+  const planFile = join(root, "plan.json");
+  execFileSync(
+    process.execPath,
+    [
+      script,
+      "snapshot",
+      "--channel",
+      "canary",
+      "--output",
+      planFile,
+      "--registry-file",
+      registryFile,
+    ],
+    { cwd: root }
+  );
+  const result = spawnSync(
+    process.execPath,
+    [script, "verify", "--plan", planFile, "--registry-file", registryFile],
+    {
+      cwd: root,
+      encoding: "utf8",
+      env: { ...process.env, VERIFY_ATTEMPTS: "1" },
+    }
+  );
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /is missing from npm/u);
+});
+
+test("registry verification rejects an unrelated dist-tag change", () => {
+  const { root, registryFile } = fixture({
+    localVersion: "2.0.5-canary.0",
+    latest: "2.0.4",
+    canary: "2.0.2-canary.1",
+    published: ["2.0.4"],
+  });
+  const planFile = join(root, "plan.json");
+  execFileSync(
+    process.execPath,
+    [
+      script,
+      "snapshot",
+      "--channel",
+      "canary",
+      "--output",
+      planFile,
+      "--registry-file",
+      registryFile,
+    ],
+    { cwd: root }
+  );
+  writeFileSync(
+    registryFile,
+    JSON.stringify({
+      "mcp-use": {
+        "dist-tags": {
+          latest: "2.0.3",
+          canary: "2.0.5-canary.0",
+        },
+        versions: { "2.0.4": {}, "2.0.5-canary.0": {} },
+      },
+    })
+  );
+  const result = spawnSync(
+    process.execPath,
+    [script, "verify", "--plan", planFile, "--registry-file", registryFile],
+    {
+      cwd: root,
+      encoding: "utf8",
+      env: { ...process.env, VERIFY_ATTEMPTS: "1" },
+    }
+  );
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /unrelated dist-tags changed/u);
+});


### PR DESCRIPTION
## What changed

- restore the `mcp-use` and Inspector source manifests to the already-published stable versions
- reject stable/canary release plans that regress below npm `latest`
- ignore prerelease changesets already recorded in `pre.json`
- reconcile partial Changesets publication failures against the registry before tagging or resetting canary
- push only the tags belonging to the current release
- block canary-to-main PRs whose stable baseline is stale

## Root cause

The `2.0.1` through `2.0.4` hotfix runs published the intended packages but failed while Changesets tried to republish unchanged sibling versions. That skipped the canary reset. A later squashed canary-to-main PR then replaced the `2.0.4` source manifest with `2.0.1-canary.5`, and the release workflow accepted the already-published `2.0.1` as a successful stable release.

## Validation

- `pnpm test:release-channel`
- ESLint on the new release scripts
- Prettier checks for changed scripts, workflows, and manifests
- YAML parse for both changed workflows
- live stable preflight and registry snapshot: zero packages scheduled for publication
- live registry reconciliation against the zero-publication plan

This PR intentionally has no changeset and does not publish a package.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces monotonic stable and canary versions in the TypeScript release flow. Adds tooling to preflight, snapshot, verify, and tag publishes to prevent version regressions and partial publish issues.

- **Bug Fixes**
  - Restored `mcp-use` and `@mcp-use/inspector` manifests to published `2.0.4`.
  - Reject stable/canary plans that would go below npm `latest`.
  - Ignore prerelease changesets already listed in `.changeset/pre.json`.
  - Reconcile partial publish failures against the registry before tagging or resetting canary.

- **New Features**
  - Added `release-channel` script with commands: `pending`, `preflight`, `snapshot`, `verify`, `tags` (+ tests via `test:release-channel`).
  - Updated workflows to:
    - Block canary-to-main PRs if the stable baseline is stale.
    - Create a release plan, verify npm dist-tags after publish, and push only tags from the current plan.

<sup>Written for commit 7899877cf32dac531873ae011835c3e8b50f08dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

