### PR TITLE
fix(ci): give path filtering full git history

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'workflow_call' && inputs.ref || github.sha }}
+          fetch-depth: 0
       - uses: dorny/paths-filter@v3
         id: filter
         if: github.event_name != 'workflow_call'


### PR DESCRIPTION
The post-merge CI run failed twice because dorny/paths-filter attempted concurrent shallow fetch updates and Git reported `shallow file has changed since we read it`. Check out full history in detect-changes so the action does not mutate the shallow boundary. This is workflow-only and does not publish packages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fetch full git history in CI to prevent `dorny/paths-filter` from failing with shallow file concurrency errors on post-merge runs. Set `actions/checkout@v4` to `fetch-depth: 0` so the action doesn't mutate the shallow boundary.

<sup>Written for commit 689cb5306fd1412356fd7eeb430c47759e9727ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

