### PR TITLE
fix(ci): ignore applied canary changesets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -845,8 +845,18 @@ jobs:
       - name: Check for Changesets
         env:
           BASE_REF: ${{ github.base_ref || 'main' }}
+          HEAD_REF: ${{ github.head_ref }}
         run: |
-          if [ -n "$(ls -A .changeset/*.md 2>/dev/null | grep -v README.md)" ]; then
+          if [ "$BASE_REF" = "main" ] && [ "$HEAD_REF" = "canary" ]; then
+            pending_changesets="$(node scripts/release-channel.mjs pending)"
+            if [ -n "$pending_changesets" ]; then
+              echo "✅ Pending changeset found"
+              printf '%s\n' "$pending_changesets"
+              pnpm changeset status --since="origin/${BASE_REF}"
+            else
+              echo "✅ No pending changesets; prerelease changesets are already applied"
+            fi
+          elif [ -n "$(ls -A .changeset/*.md 2>/dev/null | grep -v README.md)" ]; then
             echo "✅ Changeset found"
             pnpm changeset status --since="origin/${BASE_REF}"
           else


### PR DESCRIPTION
## Summary

- use the release-channel verifier's applied-ID-aware pending changeset list on canary-to-main PRs
- allow a fully published prerelease train to have zero pending changesets
- keep the existing Changesets status validation when genuinely new changesets remain

## Verification

- `pnpm test:release-channel`
- `pnpm exec prettier --check ../../.github/workflows/ci.yml`
- live canary preflight reports zero pending changesets and passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the CI Changesets check for canary-to-main PRs by ignoring prerelease changesets that were already applied. Prevents false failures when a prerelease train is fully published while still flagging real pending changesets.

- **Bug Fixes**
  - For `main` ← `canary` PRs, use `node scripts/release-channel.mjs pending` to detect pending changesets.
  - If none are pending, skip `pnpm changeset status`; if pending exist, print them and run `pnpm changeset status`.
  - Added `HEAD_REF` env and retained the original file-based check for non-canary PRs.

<sup>Written for commit ab18dd9e52209004bb8b4e459a3eca1b9288bf91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

