### PR TITLE
chore(release): sync applied changeset guard to canary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -845,8 +845,18 @@ jobs:
       - name: Check for Changesets
         env:
           BASE_REF: ${{ github.base_ref || 'main' }}
+          HEAD_REF: ${{ github.head_ref }}
         run: |
-          if [ -n "$(ls -A .changeset/*.md 2>/dev/null | grep -v README.md)" ]; then
+          if [ "$BASE_REF" = "main" ] && [ "$HEAD_REF" = "canary" ]; then
+            pending_changesets="$(node scripts/release-channel.mjs pending)"
+            if [ -n "$pending_changesets" ]; then
+              echo "✅ Pending changeset found"
+              printf '%s\n' "$pending_changesets"
+              pnpm changeset status --since="origin/${BASE_REF}"
+            else
+              echo "✅ No pending changesets; prerelease changesets are already applied"
+            fi
+          elif [ -n "$(ls -A .changeset/*.md 2>/dev/null | grep -v README.md)" ]; then
             echo "✅ Changeset found"
             pnpm changeset status --since="origin/${BASE_REF}"
           else


### PR DESCRIPTION
Sync the applied-prerelease-changeset CI fix from main into canary so the existing canary-to-main PR evaluates the same release policy. This changes only CI workflow logic; package versions and registry tags are untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Synced the applied prerelease changeset guard from `main` into `canary` so canary-to-main PRs follow the same release policy. CI-only change; no package versions or registry tags affected.

- **Bug Fixes**
  - Added `HEAD_REF` and a `main`→`canary` conditional to run `node scripts/release-channel.mjs pending`, skipping checks when prerelease changesets are already applied.
  - Kept the existing `.changeset/*.md` detection for other PRs, with status reported via `pnpm changeset status`.

<sup>Written for commit daae62bc8f23b62c26c8d0ad740925e03d33d7be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

