### PR TITLE
Restore Star History section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,10 @@ Remix a complete MCP App, inspect the source, or deploy it as a starting point:
 - [Manufact](https://manufact.com)
 - [MIT license](https://github.com/mcp-use/mcp-use/blob/main/LICENSE)
 
+## Star History
+
+[![Star History Chart](https://star-history.dera.page/svg?repos=mcp-use/mcp-use&type=date&legend=top-left)](https://star-history.dera.page/#mcp-use/mcp-use&type=date&legend=top-left)
+
 ## Contributors
 
 Built by [Pietro](https://github.com/pietrozullo), [Luigi](https://github.com/pederzh), [Enrico](https://github.com/tonxxd), and the mcp-use community.


### PR DESCRIPTION
[The original project is dying](https://www.star-history.com/blog/github-stargazer-api-restriction) so I forked it

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restored the Star History section in the README with a live chart from https://star-history.dera.page to show stars over time. This replaces the broken `star-history.com` widget and re-enables the chart link.

<sup>Written for commit a5e622d7b2640705f946a35d5413378e19dae491. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

