### PR TITLE
Fix Windows workspace and Inspector builds

### DIFF
--- a/libraries/typescript/package.json
+++ b/libraries/typescript/package.json
@@ -21,7 +21,7 @@
     "build:client": "pnpm --filter @mcp-use/client build",
     "build:tunnel": "pnpm --filter @mcp-use/tunnel build",
     "build:mcp-use": "pnpm --filter mcp-use build",
-    "build:other": "pnpm --filter '{packages/*}' --filter '!mcp-use' --filter '!@mcp-use/client' --filter '!@mcp-use/tunnel' build",
+    "build:other": "pnpm --filter \"{packages/*}\" --filter \"!mcp-use\" --filter \"!@mcp-use/client\" --filter \"!@mcp-use/tunnel\" build",
     "test": "pnpm run -r test",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",


### PR DESCRIPTION
## Summary

Fix the two Windows CI failures exposed while #2175 was merging:

- Windows package scripts preserve single quotes literally, causing pnpm to match zero packages in `build:other`; use JSON-escaped double quotes so the workspace selector works in POSIX shells and `cmd.exe`.
- Inspector compression used `URL.pathname` as a filesystem path, producing `D:\D:\...` on Windows; convert the file URL with Node’s cross-platform `fileURLToPath` helper.

## Validation

- `pnpm run build:other` selects and builds the intended four workspace packages
- `pnpm --filter @mcp-use/inspector build`
- `pnpm --filter @mcp-use/cli test:run` (3 Node tests and 271 Vitest tests)
- `pnpm format:check`
- `git diff --check`

No changeset is needed because these changes only correct repository build tooling and do not alter a published API or runtime.