### PR TITLE
Fix TypeScript Windows paths

### DIFF
--- a/libraries/typescript/.changeset/fair-pandas-smile.md
+++ b/libraries/typescript/.changeset/fair-pandas-smile.md
@@ -1,0 +1,6 @@
+---
+"@mcp-use/cli": patch
+---
+
+Use cross-platform filesystem paths for private CLI state, view discovery, and
+public asset tests so the CLI build and test suite work on Windows.

--- a/libraries/typescript/packages/cli/src/cli/dev.ts
+++ b/libraries/typescript/packages/cli/src/cli/dev.ts
@@ -26,7 +26,7 @@ import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
-import { createServer, createServerModuleRunner } from "vite";
+import { createServer, createServerModuleRunner, normalizePath } from "vite";
 // Bundled into the lazy dev chunk; keeping this build input in devDependencies
 // prevents the standalone CLI from installing the full SDK dependency tree.
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -435,6 +435,11 @@ export async function runDev(options: DevOptions): Promise<void> {
       : [nextStandaloneCompatPlugin(options.cwd)],
     server: {
       middlewareMode: true,
+      // Windows file notifications can be coalesced or dropped while Vite is
+      // transforming the same module. Polling keeps dev reloads reliable.
+      ...(process.platform === "win32" && {
+        watch: { usePolling: true, interval: 100 },
+      }),
       // Absolute asset URLs in dev: without `origin`, Vite emits root-relative
       // paths that resolve against the host page inside srcdoc iframes.
       ...(viewsAtStartup && { origin: devOrigin }),
@@ -599,7 +604,9 @@ export async function runDev(options: DevOptions): Promise<void> {
     if (isViewPath(file, options.cwd, viewsDirectory)) {
       return;
     }
-    const modules = ssrEnvironment.moduleGraph.getModulesByFile(file);
+    const modules = ssrEnvironment.moduleGraph.getModulesByFile(
+      normalizePath(file)
+    );
     if (modules === undefined || modules.size === 0) {
       return;
     }

--- a/libraries/typescript/packages/cli/src/cli/views.ts
+++ b/libraries/typescript/packages/cli/src/cli/views.ts
@@ -5,7 +5,7 @@
  */
 
 import { existsSync, readdirSync } from "node:fs";
-import { isAbsolute, join, resolve } from "node:path";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
 import react from "@vitejs/plugin-react";
 import type { ViteDevServer } from "vite";
 
@@ -115,7 +115,11 @@ export function isViewPath(
   override?: string
 ): boolean {
   const viewsDir = resolveViewsDir(cwd, override);
-  return file === viewsDir || file.startsWith(`${viewsDir}/`);
+  const viewRelativePath = relative(viewsDir, resolve(file));
+  return (
+    viewRelativePath === "" ||
+    (!viewRelativePath.startsWith("..") && !isAbsolute(viewRelativePath))
+  );
 }
 
 /**
@@ -129,9 +133,7 @@ export function isViewEntryPath(
   override?: string
 ): boolean {
   const viewsDir = resolveViewsDir(cwd, override);
-  const viewsRel = file.startsWith(`${viewsDir}/`)
-    ? file.slice(viewsDir.length + 1)
-    : file;
+  const viewsRel = relative(viewsDir, resolve(file)).split(sep).join("/");
   return /^[^/]+\/view\.tsx$/.test(viewsRel);
 }
 

--- a/libraries/typescript/packages/cli/src/commands/shared.ts
+++ b/libraries/typescript/packages/cli/src/commands/shared.ts
@@ -9,7 +9,7 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { createInterface } from "node:readline/promises";
 import { openBrowser as launchBrowser } from "../cli/open-browser.js";
 
@@ -180,7 +180,7 @@ export async function writePrivateJson(
   await chmod(parent, 0o700);
   const temporary = join(
     parent,
-    `.${path.slice(path.lastIndexOf("/") + 1)}.${process.pid}.${Date.now()}.tmp`
+    `.${basename(path)}.${process.pid}.${Date.now()}.tmp`
   );
   await writeFile(temporary, `${JSON.stringify(value, null, 2)}\n`, {
     mode: 0o600,

--- a/libraries/typescript/packages/cli/tests/cli/build.test.ts
+++ b/libraries/typescript/packages/cli/tests/cli/build.test.ts
@@ -489,7 +489,9 @@ describe("runBuild (views)", () => {
 
     const publicFile = join(buildDir, "views", "public", "test.txt");
     expect(existsSync(publicFile)).toBe(true);
-    expect(readFileSync(publicFile, "utf8")).toBe("public-fixture\n");
+    expect(readFileSync(publicFile, "utf8")).toBe(
+      readFileSync(join(cwd, "public", "test.txt"), "utf8")
+    );
     expect(existsSync(join(buildDir, "test.txt"))).toBe(false);
     expect(
       existsSync(join(buildDir, "views", "product-search-result", "test.txt"))
@@ -569,7 +571,9 @@ describe("runBuild (views)", () => {
       expect(publicOk.headers.get("cache-control")).toBe(
         "public, max-age=0, must-revalidate"
       );
-      expect(await publicOk.text()).toBe("public-fixture\n");
+      expect(await publicOk.text()).toBe(
+        readFileSync(join(cwd, "public", "test.txt"), "utf8")
+      );
 
       const publicTraversal = await handler(
         new Request("http://localhost/mcp/_mcp-use/public/../index.js")

--- a/libraries/typescript/packages/cli/tests/cli/dev.test.ts
+++ b/libraries/typescript/packages/cli/tests/cli/dev.test.ts
@@ -992,7 +992,9 @@ describe("runDev (views)", () => {
     expect(publicResponse.headers.get("cache-control")).toBe(
       "public, max-age=0, must-revalidate"
     );
-    expect(await publicResponse.text()).toBe("public-fixture\n");
+    expect(await publicResponse.text()).toBe(
+      readFileSync(join(cwd, "public", "test.txt"), "utf8")
+    );
 
     const docConfigMatch =
       /__mcpUseViewConfig=\{[^}]*"publicBase":"([^"]+)"/.exec(docHtml);

--- a/libraries/typescript/packages/cli/tests/commands/client.test.ts
+++ b/libraries/typescript/packages/cli/tests/commands/client.test.ts
@@ -71,6 +71,7 @@ beforeEach(async () => {
   mocks.logger.level = "info";
   homeDirectory = await mkdtemp(join(tmpdir(), "mcp-use-client-"));
   vi.stubEnv("HOME", homeDirectory);
+  vi.stubEnv("USERPROFILE", homeDirectory);
   stdinTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
   setStdinTty(false);
 

--- a/libraries/typescript/packages/cli/tests/commands/deploy.test.ts
+++ b/libraries/typescript/packages/cli/tests/commands/deploy.test.ts
@@ -9,7 +9,7 @@ import {
 } from "node:fs/promises";
 import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, sep } from "node:path";
 import { gunzipSync } from "node:zlib";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -359,7 +359,7 @@ describe("deploy agent contract", () => {
     const entries = await archiveEntries(form.get("sourceFile") as Blob);
     expect(entries).toContain("app/index.ts");
     expect(entries).toContain("app/src/nested.ts");
-    expect(entries).toContain(`app/${longRelativePath}`);
+    expect(entries).toContain(`app/${longRelativePath.split(sep).join("/")}`);
     expect(entries).not.toContain("app/.env");
     expect(entries).not.toContain("app/.envrc");
     expect(entries).not.toContain("app/.pytest_cache/state");
@@ -428,6 +428,9 @@ describe("deploy agent contract", () => {
   });
 
   it("reports unexpected read-only Git probe failures without guessing state", async () => {
+    // This fixture is a POSIX shell wrapper; Windows Git behavior is covered
+    // by the remaining deploy contract tests.
+    if (process.platform === "win32") return;
     const directory = await project("probe-failure");
     initializeRepository(directory);
     const bin = join(directory, "fake-bin");

--- a/libraries/typescript/packages/inspector/scripts/compress-app.mjs
+++ b/libraries/typescript/packages/inspector/scripts/compress-app.mjs
@@ -1,11 +1,12 @@
 import { gzipSync } from "node:zlib";
 import { readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const appDir = new URL("../dist/app/", import.meta.url);
+const appDir = fileURLToPath(new URL("../dist/app/", import.meta.url));
 
 for (const filename of ["inspector.js", "inspector.css"]) {
-  const source = join(appDir.pathname, filename);
+  const source = join(appDir, filename);
   const compressed = gzipSync(readFileSync(source), { level: 9 });
   writeFileSync(`${source}.gz`, compressed);
   unlinkSync(source);

--- a/libraries/typescript/packages/inspector/scripts/verify-package.mjs
+++ b/libraries/typescript/packages/inspector/scripts/verify-package.mjs
@@ -1,8 +1,9 @@
 import { readFileSync, readdirSync } from "node:fs";
-import { join, relative } from "node:path";
+import { join, relative, sep } from "node:path";
+import { fileURLToPath } from "node:url";
 import { gunzipSync } from "node:zlib";
 
-const root = new URL("../", import.meta.url).pathname;
+const root = fileURLToPath(new URL("../", import.meta.url));
 const dist = join(root, "dist");
 const files = walk(dist);
 const manifest = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
@@ -59,6 +60,6 @@ function walk(directory) {
     const absolute = join(directory, entry.name);
     if (entry.isDirectory()) return walk(absolute);
     if (!entry.isFile()) return [];
-    return [relative(root, absolute)];
+    return [relative(root, absolute).split(sep).join("/")];
   });
 }


### PR DESCRIPTION
## Summary

Fix the Windows-only build and test failures exposed after #2176 corrected workspace package selection.

The remaining failures came from a focused set of POSIX assumptions:

- Inspector build scripts used `URL.pathname` directly on Windows file URLs and compared backslash paths with POSIX manifest paths.
- CLI private-state writes extracted filenames using `/` instead of `path.basename`.
- CLI view discovery compared paths using hard-coded separators.
- Windows file notifications did not reliably trigger Vite reloads without polling.
- Tests shared the real Windows user profile, compared platform-specific archive separators, assumed checkout line endings, or used a POSIX-only fake Git script.

The implementation uses Node's cross-platform path helpers, enables Windows watcher polling, isolates the Windows test profile, and keeps platform-specific fixture assertions at their proper boundaries.

## Validation

- `pnpm --filter @mcp-use/inspector build`, including compression and package verification
- `pnpm --filter @mcp-use/cli test:run`: 3 Node tests and 271 Vitest tests
- focused ESLint and Prettier checks
- `git diff --check`
- patch changeset for `@mcp-use/cli`

This is one commit based on current `canary`.