### PR TITLE
fix(inspector): compact embedded layouts

### DIFF
--- a/libraries/typescript/.changeset/clean-inspectors-fit.md
+++ b/libraries/typescript/.changeset/clean-inspectors-fit.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Make embedded Inspector layouts fill their iframe height, remove the empty desktop header gap, and hide standalone sidebar footer controls.

--- a/libraries/typescript/packages/inspector/src/client/components/Layout.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/Layout.tsx
@@ -46,6 +46,7 @@ import { LayoutHeader } from "./LayoutHeader";
 import { InspectorSidebar } from "./layout/sidebar/InspectorSidebar";
 import { SidebarRpcPanel } from "./layout/sidebar/SidebarRpcPanel";
 import { MobileInspectorToolbar } from "./layout/mobile/MobileInspectorToolbar";
+import { getInspectorBodyClassName } from "./layout/inspectorLayoutClasses";
 import { useTunnelConnectionSync } from "./layout/useTunnelConnectionSync";
 
 interface LayoutProps {
@@ -855,7 +856,7 @@ export function Layout({ children }: LayoutProps) {
       : displayServer;
 
   // Apply embedded styling
-  const isSingleTab = isEmbedded && embeddedConfig.singleTab;
+  const isSingleTab = isEmbedded && embeddedConfig.singleTab === true;
 
   const containerStyle: React.CSSProperties = isEmbedded
     ? {
@@ -878,9 +879,7 @@ export function Layout({ children }: LayoutProps) {
         displayServerWithStableMetadata && "lg:mr-4"
       );
 
-  const bodyClassName = isSingleTab
-    ? "flex-1 min-h-0"
-    : "flex min-w-0 flex-1 min-h-0 overflow-hidden";
+  const bodyClassName = getInspectorBodyClassName(isSingleTab);
 
   const headerProps = {
     connections,
@@ -920,6 +919,7 @@ export function Layout({ children }: LayoutProps) {
                   onCollapsedChange={setSidebarCollapsed}
                   rpcLoggerOpen={rpcLoggerOpen}
                   onRpcLoggerOpenChange={setRpcLoggerOpen}
+                  embedded={isEmbedded}
                   onCommandPaletteOpen={() =>
                     handleCommandPaletteOpen("button")
                   }

--- a/libraries/typescript/packages/inspector/src/client/components/LayoutHeader.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/LayoutHeader.tsx
@@ -24,6 +24,7 @@ import { AddToClientDropdown } from "./AddToClientDropdown";
 import LogoAnimated from "./LogoAnimated";
 import { ServerDropdown } from "./ServerDropdown";
 import { getTabCount, isMcpUseTunnelUrl } from "./layout/layoutHeaderUtils";
+import { getInspectorHeaderClassName } from "./layout/inspectorLayoutClasses";
 import { LAYOUT_TABS } from "./layout/layoutTabs";
 import { ServerUrlChip } from "./layout/ServerUrlChip";
 import { TunnelStartButton } from "./layout/TunnelBadge";
@@ -213,7 +214,7 @@ export function LayoutHeader({
     ) : null;
 
   return (
-    <header className="w-full min-w-0 shrink-0 overflow-hidden">
+    <header className={getInspectorHeaderClassName(embedded)}>
       <div className="hidden lg:flex h-(--header-height) items-center justify-between gap-3 px-4 md:pl-0 md:pr-6">
         <div className="flex items-center gap-3 min-w-0 flex-1">
           {!embedded && (

--- a/libraries/typescript/packages/inspector/src/client/components/layout/__tests__/inspectorLayoutClasses.test.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/layout/__tests__/inspectorLayoutClasses.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import {
+  getInspectorBodyClassName,
+  getInspectorHeaderClassName,
+} from "../inspectorLayoutClasses";
+
+describe("embedded Inspector layout classes", () => {
+  it("lets a single-tab main panel fill the iframe height", () => {
+    expect(getInspectorBodyClassName(true).split(" ")).toContain("flex");
+    expect(getInspectorBodyClassName(true).split(" ")).toContain("flex-1");
+  });
+
+  it("hides the empty embedded desktop header", () => {
+    expect(getInspectorHeaderClassName(true).split(" ")).toContain("lg:hidden");
+    expect(getInspectorHeaderClassName(false).split(" ")).not.toContain(
+      "lg:hidden"
+    );
+  });
+});

--- a/libraries/typescript/packages/inspector/src/client/components/layout/inspectorLayoutClasses.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/layout/inspectorLayoutClasses.ts
@@ -1,0 +1,11 @@
+export function getInspectorBodyClassName(isSingleTab: boolean): string {
+  return isSingleTab
+    ? "flex flex-1 min-h-0"
+    : "flex min-w-0 flex-1 min-h-0 overflow-hidden";
+}
+
+export function getInspectorHeaderClassName(embedded: boolean): string {
+  return embedded
+    ? "w-full min-w-0 shrink-0 overflow-hidden lg:hidden"
+    : "w-full min-w-0 shrink-0 overflow-hidden";
+}

--- a/libraries/typescript/packages/inspector/src/client/components/layout/sidebar/InspectorSidebar.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/layout/sidebar/InspectorSidebar.tsx
@@ -15,6 +15,7 @@ interface InspectorSidebarProps {
   onCollapsedChange: (collapsed: boolean) => void;
   rpcLoggerOpen: boolean;
   onRpcLoggerOpenChange: (open: boolean) => void;
+  embedded?: boolean;
   onCommandPaletteOpen: () => void;
 }
 
@@ -27,6 +28,7 @@ export function InspectorSidebar({
   onCollapsedChange,
   rpcLoggerOpen,
   onRpcLoggerOpenChange,
+  embedded = false,
   onCommandPaletteOpen,
 }: InspectorSidebarProps) {
   return (
@@ -52,12 +54,14 @@ export function InspectorSidebar({
           />
         </SidebarProximityNav>
       </div>
-      <InspectorSidebarFooter
-        collapsed={collapsed}
-        rpcLoggerOpen={rpcLoggerOpen}
-        onRpcLoggerOpenChange={onRpcLoggerOpenChange}
-        onCommandPaletteOpen={onCommandPaletteOpen}
-      />
+      {!embedded && (
+        <InspectorSidebarFooter
+          collapsed={collapsed}
+          rpcLoggerOpen={rpcLoggerOpen}
+          onRpcLoggerOpenChange={onRpcLoggerOpenChange}
+          onCommandPaletteOpen={onCommandPaletteOpen}
+        />
+      )}
       <SidebarRail
         collapsed={collapsed}
         onToggle={() => onCollapsedChange(!collapsed)}


### PR DESCRIPTION
## Summary
- make the single-tab chat body a flex container so it fills the iframe height
- hide the empty desktop Inspector header in embedded mode while preserving mobile navigation
- hide standalone sidebar footer controls inside embedded Inspector surfaces
- add focused layout policy tests and an `@mcp-use/inspector` patch changeset

## Root cause
Vibe's iframes were correctly sized. Inside Inspector, the single-tab `<main>` used `flex-1` beneath a non-flex wrapper, so chat collapsed to its 262px content height. Multi-tab embeds also rendered an empty 64px desktop header plus a 16px shell gap, and the standalone sidebar footer was rendered unconditionally.

## Live baseline evidence
At a 1313×1166 iframe viewport:
- chat `<main>` height: 262px instead of 1166px
- Inspector content top: 88px (8px shell padding + 64px empty header + 16px gap)
- sidebar footer: 185px tall and visible

## Validation
- focused Vitest: 2 tests passed
- Inspector TypeScript check
- focused ESLint on changed files
- Inspector production app build

After `pkg.pr.new` is available, the prerelease will be installed into the active Vibe sandbox and verified through screenshots and page measurements.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compact the embedded Inspector layout so content fills the iframe and removes wasted space. Single-tab chat now expands correctly, and embedded surfaces no longer show the empty desktop header or sidebar footer.

- **Bug Fixes**
  - Make single-tab chat `<main>` a flex container to fill iframe height.
  - Hide the desktop header in embedded mode; keep mobile navigation.
  - Hide standalone sidebar footer controls in embedded surfaces.
  - Add header/body class helpers and focused tests; patch release for `@mcp-use/inspector`.

<sup>Written for commit 4574f325fac6dfa190a9af8a203d10edcdf666ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

