### PR TITLE
fix(ci): actually run the release-channel tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -842,6 +842,9 @@ jobs:
         if: github.event_name == 'pull_request' && github.base_ref == 'main' && github.head_ref == 'canary'
         run: pnpm release-channel preflight --channel stable
 
+      - name: Test release-channel helper
+        run: pnpm test:release-channel
+
       - name: Check for Changesets
         env:
           BASE_REF: ${{ github.base_ref || 'main' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ permissions:
 #    ├─ typescript/inspector: Unit tests for inspector package
 #    ├─ typescript/cli: Unit tests for CLI package
 #    ├─ typescript/tunnel: Protocol and local relay integration tests
+#    ├─ typescript-release-channel-test: release-channel helper suite (main + canary PRs)
 #    └─ typescript-changeset-check: PR validation (PRs only)
 #
 # 4. create-mcp-use-app Tests (runs if packages/create-mcp-use-app/** changed)
@@ -86,6 +87,7 @@ jobs:
       python: ${{ steps.out.outputs.python }}
       typescript: ${{ steps.out.outputs.typescript }}
       create-mcp-use-app: ${{ steps.out.outputs.create-mcp-use-app }}
+      release-channel: ${{ steps.out.outputs.release-channel }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -102,6 +104,12 @@ jobs:
               - 'libraries/typescript/**'
             create-mcp-use-app:
               - 'libraries/typescript/packages/create-mcp-use-app/**'
+            release-channel:
+              - 'libraries/typescript/scripts/release-channel.mjs'
+              - 'libraries/typescript/scripts/release-channel.test.mjs'
+              - 'libraries/typescript/package.json'
+              - '.github/workflows/ci.yml'
+              - '.github/workflows/typescript-release.yml'
       - name: Compute outputs
         id: out
         uses: actions/github-script@v7
@@ -118,6 +126,8 @@ jobs:
             core.setOutput('python', String(py));
             core.setOutput('typescript', String(ts));
             core.setOutput('create-mcp-use-app', String(create));
+            const releaseChannel = fromWfCall ? ts : ("${{ steps.filter.outputs.release-channel }}" === 'true');
+            core.setOutput('release-channel', String(releaseChannel));
 
   # Python Jobs
   python-lint:
@@ -843,6 +853,37 @@ jobs:
       - name: Run Tunnel Tests
         run: pnpm --filter @mcp-use/tunnel test:run
 
+  typescript-release-channel-test:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.release-channel == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: libraries/typescript
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_call' && inputs.ref || github.sha }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.13.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.23.1
+          cache: "pnpm"
+          cache-dependency-path: libraries/typescript/pnpm-lock.yaml
+
+      - name: Install Dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Test release-channel helper
+        run: pnpm test:release-channel
+
   typescript-changeset-check:
     needs: detect-changes
     if: ${{ (github.event_name == 'workflow_call' && inputs.run_changeset_check) || (github.event_name == 'pull_request' && github.base_ref != 'canary' && needs.detect-changes.outputs.typescript == 'true') }}
@@ -875,9 +916,6 @@ jobs:
       - name: Prevent canary-to-main version regression
         if: github.event_name == 'pull_request' && github.base_ref == 'main' && github.head_ref == 'canary'
         run: pnpm release-channel preflight --channel stable
-
-      - name: Test release-channel helper
-        run: pnpm test:release-channel
 
       - name: Check for Changesets
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -876,6 +876,9 @@ jobs:
         if: github.event_name == 'pull_request' && github.base_ref == 'main' && github.head_ref == 'canary'
         run: pnpm release-channel preflight --channel stable
 
+      - name: Test release-channel helper
+        run: pnpm test:release-channel
+
       - name: Check for Changesets
         env:
           BASE_REF: ${{ github.base_ref || 'main' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,10 @@ jobs:
             core.setOutput('python', String(py));
             core.setOutput('typescript', String(ts));
             core.setOutput('create-mcp-use-app', String(create));
-            const releaseChannel = fromWfCall ? ts : ("${{ steps.filter.outputs.release-channel }}" === 'true');
+            // The reusable-workflow caller only reports python/typescript/create-app,
+            // so it cannot tell us whether a release workflow changed. The helper test
+            // takes a few seconds, so run it on every workflow_call rather than guess.
+            const releaseChannel = fromWfCall ? true : ("${{ steps.filter.outputs.release-channel }}" === 'true');
             core.setOutput('release-channel', String(releaseChannel));
 
   # Python Jobs


### PR DESCRIPTION
## Changes

#2167 added `scripts/release-channel.test.mjs` and a `test:release-channel` script. Nothing invokes them, so those tests have never run in CI.

The only mention of the script in the entire repo is its own definition:

```
$ git grep -n "test:release-channel"
libraries/typescript/package.json:40:    "test:release-channel": "node --test scripts/release-channel.test.mjs",
```

Compare with the helper itself, which CI leans on heavily:

```
.github/workflows/ci.yml:843               pnpm release-channel preflight --channel stable
.github/workflows/ci.yml:851               node scripts/release-channel.mjs pending
.github/workflows/typescript-release.yml   preflight / snapshot / verify / tags  (x8)
```

So the logic gating every release is exercised in CI, while the tests written to protect it are not.

`pnpm test` does not pick them up either: it is `pnpm run -r test`, which runs each package's own `test` script, not root-level scripts.

## The fix

One step in `typescript-changeset-check`, the job that already owns release-channel concerns and has pnpm and Node set up:

```yaml
      - name: Test release-channel helper
        run: pnpm test:release-channel
```

Placed right after the existing `Prevent canary-to-main version regression` step, which calls the same helper.

I put it in an existing job rather than adding a new one, since it is a sub-second test and a new job would cost a runner and another required check.

## Verification

The tests pass on `main` today, so this wires up a green check rather than a red one:

```
$ node --test scripts/release-channel.test.mjs
✔ rejects a stable source version below npm latest
✔ accepts a canary release above npm latest
✔ ignores changesets already applied in prerelease mode
✔ registry verification accepts a completed target after a publish error
✔ registry verification rejects a missing target
✔ registry verification rejects an unrelated dist-tag change
ℹ pass 6   fail 0   duration_ms 1371
```

The workflow still parses, and the job's step order is as intended:

```
Checkout, Setup pnpm, Setup Node.js, Install Dependencies,
Prevent canary-to-main version regression, Test release-channel helper,
Check for Changesets
```

`ci-preflight` exit 0.

## Note on scope

`typescript-changeset-check` only runs when `base_ref != 'canary'` and TypeScript files changed, so a canary-targeted PR will not run these. If you would rather they run on every TypeScript PR regardless of base, say so and I will move the step to `typescript-build` instead.

## Backwards Compatibility

CI only. Adds one step to an existing job. No source or published artifact changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs the release-channel tests in CI to protect release gating. Previously `scripts/release-channel.test.mjs` never ran; now a dedicated job runs `pnpm test:release-channel` on relevant changes and on reusable workflow calls.

- Adds a `typescript-release-channel-test` job with path filters for the helper, its tests, `libraries/typescript/package.json`, `.github/workflows/ci.yml`, and `.github/workflows/typescript-release.yml`; always runs when invoked via `workflow_call` to cover approved-fork runs.
- Decouples from `typescript-changeset-check`, so it runs on canary-targeted PRs and PRs that only modify CI or release workflows.

<sup>Written for commit 2a5e1e37fe9e541ef56a30e7b37a2cda3984e817. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

