### PR TITLE
Codex/filter iframe console messages

### DIFF
--- a/libraries/typescript/.changeset/quiet-console-routing.md
+++ b/libraries/typescript/.changeset/quiet-console-routing.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/client": patch
+---
+
+Prevent iframe console log records from being parsed as MCP Apps JSON-RPC messages in the Inspector.

--- a/libraries/typescript/packages/client/src/react/view/ViewRenderer.tsx
+++ b/libraries/typescript/packages/client/src/react/view/ViewRenderer.tsx
@@ -436,13 +436,13 @@ function ViewRendererBase({
       }
 
       if (event.data?.type === "iframe-console-log") {
+        // Console records share the iframe postMessage channel with MCP Apps
+        // JSON-RPC. Consume them before PostMessageTransport sees them.
+        event.stopImmediatePropagation();
         onLogRef.current?.({
           level: event.data.level ?? "log",
           data: event.data.args,
         });
-        // Console records share the iframe postMessage channel with MCP Apps
-        // JSON-RPC. Consume them before PostMessageTransport sees them.
-        event.stopImmediatePropagation();
         return;
       }
     };

--- a/libraries/typescript/packages/client/src/react/view/ViewRenderer.tsx
+++ b/libraries/typescript/packages/client/src/react/view/ViewRenderer.tsx
@@ -435,16 +435,20 @@ function ViewRendererBase({
         return;
       }
 
-      if (event.data?.type === "iframe-console-log" && onLogRef.current) {
-        onLogRef.current({
+      if (event.data?.type === "iframe-console-log") {
+        onLogRef.current?.({
           level: event.data.level ?? "log",
           data: event.data.args,
         });
+        // Console records share the iframe postMessage channel with MCP Apps
+        // JSON-RPC. Consume them before PostMessageTransport sees them.
+        event.stopImmediatePropagation();
+        return;
       }
     };
 
-    window.addEventListener("message", handleMessage);
-    return () => window.removeEventListener("message", handleMessage);
+    window.addEventListener("message", handleMessage, true);
+    return () => window.removeEventListener("message", handleMessage, true);
   }, [sandboxOrigin, isBlobSandbox]);
 
   // Bridge lifecycle: sandbox → connect → resource-ready → initialized

--- a/libraries/typescript/packages/client/tests/unit/view-renderer-handler-stability.test.tsx
+++ b/libraries/typescript/packages/client/tests/unit/view-renderer-handler-stability.test.tsx
@@ -10,6 +10,66 @@ import type {
 } from "../../src/react/view/types.js";
 
 describe("ViewRenderer handler stability", () => {
+  it("routes iframe console records without forwarding them to the app bridge", async () => {
+    const source: ViewRendererSource = {
+      kind: "preloaded",
+      html: "<html><body>widget</body></html>",
+    };
+    const sandboxWindow = {} as Window;
+    const onLog = vi.fn();
+    const downstreamListener = vi.fn();
+    let renderer!: ReactTestRenderer;
+
+    window.addEventListener("message", downstreamListener);
+    try {
+      await act(async () => {
+        renderer = create(
+          <ViewRenderer
+            viewId="console-message-test"
+            source={source}
+            sandboxUrl={new URL("https://sandbox.example/widget")}
+            onLog={onLog}
+          />,
+          {
+            createNodeMock: (element) =>
+              element.type === "iframe"
+                ? {
+                    contentWindow: sandboxWindow,
+                    setAttribute: vi.fn(),
+                    src: "",
+                  }
+                : {},
+          }
+        );
+      });
+
+      const event = new MessageEvent("message", {
+        data: {
+          type: "iframe-console-log",
+          level: "error",
+          args: ["widget failure"],
+        },
+        origin: "https://sandbox.example",
+      });
+      Object.defineProperty(event, "source", { value: sandboxWindow });
+
+      await act(async () => {
+        window.dispatchEvent(event);
+      });
+
+      expect(onLog).toHaveBeenCalledWith({
+        level: "error",
+        data: ["widget failure"],
+      });
+      expect(downstreamListener).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener("message", downstreamListener);
+      await act(async () => {
+        renderer?.unmount();
+      });
+    }
+  });
+
   it("does not restart the bridge when a configured handler changes identity", async () => {
     const source: ViewRendererSource = {
       kind: "preloaded",


### PR DESCRIPTION
Fixes MCP-2888

Preserves Inspector iframe console logging while consuming non-JSON-RPC console postMessages before the AppBridge transport.

Validation:
- Focused ViewRenderer Vitest suite (2 tests passed)
- git diff --check