### PR TITLE
fix(skills): use ctx.auth.user.id in mcp-apps-builder auth reference

### DIFF
--- a/skills/mcp-apps-builder/references/auth.md
+++ b/skills/mcp-apps-builder/references/auth.md
@@ -34,7 +34,7 @@ async ({ documentId }, ctx) => {
     };
   }
 
-  await deleteOwnedDocument(documentId, ctx.auth.user.userId);
+  await deleteOwnedDocument(documentId, ctx.auth.user.id);
   return { content: [{ type: "text", text: "Document deleted" }] };
 };
 ```


### PR DESCRIPTION
## Summary

Fixes #2184 — the shipped `mcp-apps-builder` skill's auth reference taught agents to read `ctx.auth.user.userId`, but no v2 OAuth provider exposes `userId`.

Verified against the source: all six built-in providers (`auth0`, `clerk`, `workos`, `supabase`, `keycloak`, `better-auth`) declare `id: string` on the user shape, and `grep -c userId` across `libraries/typescript/packages/server/src/oauth` returns zero matches.

## Impact

This is an **authorization path**: an agent following the doc wrote an ownership check against `undefined`, which reads as working while silently failing closed. The file ships with every scaffolded project (`SKILLS_SPARSE_PATH = "skills/mcp-apps-builder"` in `packages/create-mcp-use-app/src/skills-config.ts`).

## Change

One-token fix in `skills/mcp-apps-builder/references/auth.md:37`:

```diff
-await deleteOwnedDocument(documentId, ctx.auth.user.userId);
+await deleteOwnedDocument(documentId, ctx.auth.user.id);
```

## Scope

Deliberately limited to the shipped `mcp-apps-builder` skill, per the issue's note that the same `userId` pattern in `skills/mcp-builder` and `skills/chatgpt-app-builder` (plus other v1 leftovers) is tracked separately.

Closes #2184

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the `mcp-apps-builder` auth reference to use `ctx.auth.user.id` (not `userId`) to match v2 OAuth providers. Prevents ownership checks from reading `undefined` and silently failing in authorization paths.

<sup>Written for commit 6e4fc3d69fe4d8a0f617751bf49f48bbb028c8a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

