### PR TITLE
fix(cli): preserve quoted stdio connect command arguments

### DIFF
--- a/libraries/typescript/.changeset/stdio-quoted-command.md
+++ b/libraries/typescript/.changeset/stdio-quoted-command.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Preserve quoted paths and arguments in `mcp-use client connect --stdio` by parsing the target with shell-like quoting instead of splitting on raw spaces

--- a/libraries/typescript/packages/server/src/commands/client-help.ts
+++ b/libraries/typescript/packages/server/src/commands/client-help.ts
@@ -33,9 +33,10 @@ function page(path: string, value: HelpPage): void {
 
 page("", {
   usage: "mcp-use client <command>",
-  summary: "Connect to and invoke saved HTTP(S) MCP servers.",
+  summary: "Connect to and invoke saved MCP servers.",
   commands: [
-    ["connect <name> <url>", "Connect and save a server"],
+    ["connect <name> <url>", "Connect and save an HTTP(S) server"],
+    ['connect <name> "<command>" --stdio', "Connect and save a stdio server"],
     ["list", "List saved servers"],
     ["remove <name>", "Remove a saved server"],
     ["<name>", "Invoke a saved server"],
@@ -44,9 +45,10 @@ page("", {
 });
 
 page("connect", {
-  usage: "mcp-use client connect <name> <url> [options]",
-  summary: "Connect to and save an HTTP(S) MCP server.",
+  usage: "mcp-use client connect <name> <url|command> [options]",
+  summary: "Connect to and save an HTTP(S) or stdio MCP server.",
   options: [
+    ["--stdio", "Treat the target as a stdio command instead of a URL"],
     ['-H, --header <"Key: Value">', "Static header (repeatable)"],
     ["--no-oauth", "Skip OAuth on authorization challenges"],
     ["--auth-timeout <ms>", "OAuth wait timeout (default: 300000)"],
@@ -60,6 +62,7 @@ page("connect", {
   ],
   notes: [
     "JSON mode never opens a browser or prints an OAuth URL/state. If new consent is required, it returns oauth_interaction_required with an interactive retry command.",
+    'With --stdio, quote paths and arguments that contain spaces, e.g. `"/opt/MCP Servers/server" "--config=dev env.json"`.',
   ],
 });
 

--- a/libraries/typescript/packages/server/src/commands/client-help.ts
+++ b/libraries/typescript/packages/server/src/commands/client-help.ts
@@ -54,7 +54,7 @@ page("connect", {
     ["--auth-timeout <ms>", "OAuth wait timeout (default: 300000)"],
     [
       "--protocol <auto|legacy|modern>",
-      "Protocol mode (default: auto; modern is stateless/sessionless)",
+      "Protocol mode (HTTP default: auto; stdio default: legacy; modern is stateless/sessionless)",
     ],
     ["--no-open", "Print the OAuth URL without opening a browser"],
     JSON,
@@ -62,7 +62,7 @@ page("connect", {
   ],
   notes: [
     "JSON mode never opens a browser or prints an OAuth URL/state. If new consent is required, it returns oauth_interaction_required with an interactive retry command.",
-    'With --stdio, quote paths and arguments that contain spaces, e.g. `"/opt/MCP Servers/server" "--config=dev env.json"`.',
+    'With --stdio, pass one target string and use quote delimiters for paths/args with spaces, e.g. `"/opt/MCP Servers/server" "--config=dev env.json"` or `"C:\\Program Files\\foo.exe"`. OAuth/header options apply only to URL connects.',
   ],
 });
 

--- a/libraries/typescript/packages/server/src/commands/client-help.ts
+++ b/libraries/typescript/packages/server/src/commands/client-help.ts
@@ -62,7 +62,7 @@ page("connect", {
   ],
   notes: [
     "JSON mode never opens a browser or prints an OAuth URL/state. If new consent is required, it returns oauth_interaction_required with an interactive retry command.",
-    'With --stdio, pass one target string and use quote delimiters for paths/args with spaces, e.g. `"/opt/MCP Servers/server" "--config=dev env.json"` or `"C:\\Program Files\\foo.exe"`. OAuth/header options apply only to URL connects.',
+    'With --stdio, pass one target string (wrap the whole target in outer single quotes so the shell keeps inner quote delimiters), e.g. `\'"/opt/MCP Servers/server" "--config=dev env.json"\'` or `\'"C:\\Program Files\\foo.exe"\'`. OAuth/header options apply only to URL connects.',
   ],
 });
 

--- a/libraries/typescript/packages/server/src/commands/client.ts
+++ b/libraries/typescript/packages/server/src/commands/client.ts
@@ -11,7 +11,7 @@ import { loadClientPackage } from "./load-client.js";
 import {
   CommandError,
   confirm,
-  GLOBAL_STATE_DIR,
+  getGlobalStateDir,
   openBrowser,
   pathExists,
   printResult,
@@ -21,23 +21,44 @@ import {
   wantsJson,
   writePrivateJson,
 } from "./shared.js";
+import { parseStdioTarget } from "./stdio-target.js";
 
-interface SavedServer {
+type ProtocolMode = "auto" | "legacy" | "modern";
+
+interface SavedHttpServer {
   url: string;
   oauth: boolean;
-  protocol: "auto" | "legacy" | "modern";
+  protocol: ProtocolMode;
 }
+
+interface SavedStdioServer {
+  type: "stdio";
+  command: string;
+  args: string[];
+  protocol: ProtocolMode;
+}
+
+type SavedServer = SavedHttpServer | SavedStdioServer;
 
 interface SavedServers {
   servers: Record<string, SavedServer>;
+}
+
+function isStdioServer(server: SavedServer): server is SavedStdioServer {
+  return "type" in server && server.type === "stdio";
 }
 
 interface SavedCredentials {
   headers?: Record<string, string>;
 }
 
-const CLIENT_DIR = join(GLOBAL_STATE_DIR, "client");
-const SERVERS_PATH = join(CLIENT_DIR, "servers.json");
+function clientDir(): string {
+  return join(getGlobalStateDir(), "client");
+}
+
+function serversPath(): string {
+  return join(clientDir(), "servers.json");
+}
 
 type BrowserMode = "ask" | "never";
 
@@ -88,28 +109,74 @@ async function connect(
       "auth-timeout": { type: "string" },
       protocol: { type: "string", default: "auto" },
       "no-open": { type: "boolean" },
+      stdio: { type: "boolean" },
     },
   });
   if (positionals.length !== 2) {
-    throw new UsageError("Usage: mcp-use client connect <name> <url>");
+    throw new UsageError(
+      values.stdio === true
+        ? 'Usage: mcp-use client connect <name> "<command>" --stdio'
+        : "Usage: mcp-use client connect <name> <url>"
+    );
   }
-  const [name, rawUrl] = positionals as [string, string];
+  const [name, target] = positionals as [string, string];
   validateName(name);
-  const url = new URL(rawUrl);
-  if (!["http:", "https:"].includes(url.protocol)) {
-    throw new UsageError("Client URLs must use http or https.");
-  }
   const protocol = parseProtocol(values.protocol);
-  const timeout = parsePositiveInteger(
-    values["auth-timeout"] ?? "300000",
-    "--auth-timeout"
-  );
   const saved = await readServers();
   if (saved.servers[name] !== undefined) {
     throw new UsageError(`Saved server already exists: ${name}`);
   }
+
+  if (values.stdio === true) {
+    let parsed;
+    try {
+      parsed = parseStdioTarget(target);
+    } catch (error) {
+      throw new UsageError(
+        error instanceof Error ? error.message : "Invalid stdio command."
+      );
+    }
+    const definition: SavedStdioServer = {
+      type: "stdio",
+      command: parsed.command,
+      args: parsed.args,
+      protocol,
+    };
+    const connection = await openConnection(
+      name,
+      definition,
+      {},
+      300_000,
+      "never",
+      json
+    );
+    await connection.disconnect();
+    saved.servers[name] = definition;
+    await writePrivateJson(serversPath(), saved);
+    printResult(
+      {
+        name,
+        type: "stdio",
+        command: definition.command,
+        args: definition.args,
+        protocol,
+      },
+      json,
+      `Connected and saved ${name}.`
+    );
+    return 0;
+  }
+
+  const url = new URL(target);
+  if (!["http:", "https:"].includes(url.protocol)) {
+    throw new UsageError("Client URLs must use http or https.");
+  }
+  const timeout = parsePositiveInteger(
+    values["auth-timeout"] ?? "300000",
+    "--auth-timeout"
+  );
   const credentials = { headers: parseHeaders(values.header ?? []) };
-  const definition: SavedServer = {
+  const definition: SavedHttpServer = {
     url: url.href,
     oauth: values["no-oauth"] !== true,
     protocol,
@@ -128,7 +195,7 @@ async function connect(
   );
   await connection.disconnect();
   saved.servers[name] = definition;
-  await writePrivateJson(SERVERS_PATH, saved);
+  await writePrivateJson(serversPath(), saved);
   await writePrivateJson(credentialsPath(name), credentials);
   printResult(
     { name, url: safeUrlForOutput(definition.url), protocol },
@@ -141,15 +208,29 @@ async function connect(
 async function list(argv: readonly string[], json: boolean): Promise<number> {
   parseJsonOnly(argv);
   const saved = await readServers();
-  const result = Object.entries(saved.servers).map(([name, server]) => ({
-    name,
-    ...server,
-    url: safeUrlForOutput(server.url),
-  }));
+  const result = Object.entries(saved.servers).map(([name, server]) => {
+    if (isStdioServer(server)) {
+      return {
+        name,
+        type: "stdio" as const,
+        command: server.command,
+        args: server.args,
+        protocol: server.protocol,
+        target: [server.command, ...server.args].join(" "),
+      };
+    }
+    return {
+      name,
+      type: "http" as const,
+      ...server,
+      url: safeUrlForOutput(server.url),
+      target: safeUrlForOutput(server.url),
+    };
+  });
   printResult(
     result,
     json,
-    result.map((server) => `${server.name}\t${server.url}`).join("\n") ||
+    result.map((server) => `${server.name}\t${server.target}`).join("\n") ||
       "No saved servers."
   );
   return 0;
@@ -165,7 +246,7 @@ async function remove(argv: readonly string[], json: boolean): Promise<number> {
   const name = one(positionals, "mcp-use client remove <name>");
   const saved = await readServers();
   delete saved.servers[name];
-  await writePrivateJson(SERVERS_PATH, saved);
+  await writePrivateJson(serversPath(), saved);
   await rm(credentialsDirectory(name), { recursive: true, force: true });
   printResult({ removed: name }, json, `Removed ${name}.`);
   return 0;
@@ -186,6 +267,11 @@ async function savedServerCommand(
   const family = argv[0];
   const operation = argv[1];
   if (family === "auth") {
+    if (isStdioServer(definition)) {
+      throw new UsageError(
+        `Saved server ${name} uses stdio and does not support OAuth commands.`
+      );
+    }
     if (operation === "status") {
       parseJsonOnly(argv.slice(2));
       const authenticated = await pathExists(oauthDirectory(name));
@@ -221,10 +307,9 @@ async function savedServerCommand(
   }
 
   validateSavedCommandArgs(name, family, operation, argv.slice(2));
-  const credentials = await readJson<SavedCredentials>(
-    credentialsPath(name),
-    {}
-  );
+  const credentials = isStdioServer(definition)
+    ? {}
+    : await readJson<SavedCredentials>(credentialsPath(name), {});
   const connection = await openConnection(
     name,
     definition,
@@ -411,6 +496,20 @@ async function openConnection(
     allowInstall: !quiet,
   });
   if (quiet) logger.level = "silent";
+
+  if (isStdioServer(definition)) {
+    const client = new MCPClient({
+      mcpServers: {
+        [name]: {
+          command: definition.command,
+          args: definition.args,
+          ...stdioProtocolConfig(definition.protocol),
+        },
+      },
+    });
+    return client.connect(name);
+  }
+
   let rejectOAuthInteraction: ((error: CommandError) => void) | undefined;
   const oauthInteractionRequired =
     quiet && definition.oauth
@@ -509,6 +608,21 @@ async function openConnection(
   }
 }
 
+function stdioProtocolConfig(protocol: ProtocolMode): Record<string, unknown> {
+  if (protocol === "auto") {
+    return { protocolNegotiation: "auto" };
+  }
+  if (protocol === "modern") {
+    return { protocolNegotiation: { pin: "2026-07-28" } };
+  }
+  return {
+    protocolNegotiation: "legacy",
+    clientOptions: {
+      supportedProtocolVersions: ["2025-11-25"],
+    },
+  };
+}
+
 /**
  * Open a saved server for another CLI command.
  *
@@ -524,10 +638,9 @@ export async function openSavedConnection(
   if (definition === undefined) {
     throw new UsageError(`Unknown saved server: ${name}`);
   }
-  const credentials = await readJson<SavedCredentials>(
-    credentialsPath(name),
-    {}
-  );
+  const credentials = isStdioServer(definition)
+    ? {}
+    : await readJson<SavedCredentials>(credentialsPath(name), {});
   return openConnection(
     name,
     definition,
@@ -626,7 +739,7 @@ function parseHeaders(values: readonly string[]): Record<string, string> {
   return headers;
 }
 
-function parseProtocol(value: string | undefined): SavedServer["protocol"] {
+function parseProtocol(value: string | undefined): ProtocolMode {
   if (value !== "auto" && value !== "legacy" && value !== "modern") {
     throw new UsageError("Invalid protocol. Expected auto, legacy, or modern.");
   }
@@ -664,27 +777,54 @@ function safeUrlForOutput(raw: string): string {
 
 async function readServers(): Promise<SavedServers> {
   const saved = await readJson<{
-    servers: Record<
-      string,
-      Omit<SavedServer, "protocol"> & { protocol?: unknown }
-    >;
-  }>(SERVERS_PATH, { servers: {} });
+    servers: Record<string, Record<string, unknown>>;
+  }>(serversPath(), { servers: {} });
   const normalized: SavedServers = { servers: {} };
   let migrated = false;
 
   for (const [name, server] of Object.entries(saved.servers)) {
+    if (server.type === "stdio") {
+      if (
+        typeof server.command !== "string" ||
+        !Array.isArray(server.args) ||
+        !server.args.every((arg) => typeof arg === "string")
+      ) {
+        throw new UsageError(
+          `Saved stdio server ${name} is invalid. Remove and reconnect it.`
+        );
+      }
+      const protocol = normalizeSavedProtocol(server.protocol);
+      normalized.servers[name] = {
+        type: "stdio",
+        command: server.command,
+        args: server.args as string[],
+        protocol,
+      };
+      migrated ||= protocol !== server.protocol;
+      continue;
+    }
+
+    if (typeof server.url !== "string") {
+      throw new UsageError(
+        `Saved server ${name} is invalid. Remove and reconnect it.`
+      );
+    }
     const protocol = normalizeSavedProtocol(server.protocol);
-    normalized.servers[name] = { ...server, protocol };
+    normalized.servers[name] = {
+      url: server.url,
+      oauth: server.oauth !== false,
+      protocol,
+    };
     migrated ||= protocol !== server.protocol;
   }
 
   if (migrated) {
-    await writePrivateJson(SERVERS_PATH, normalized);
+    await writePrivateJson(serversPath(), normalized);
   }
   return normalized;
 }
 
-function normalizeSavedProtocol(value: unknown): SavedServer["protocol"] {
+function normalizeSavedProtocol(value: unknown): ProtocolMode {
   if (value === "auto" || value === "legacy" || value === "modern") {
     return value;
   }
@@ -698,7 +838,7 @@ function normalizeSavedProtocol(value: unknown): SavedServer["protocol"] {
 
 function normalizeProtocolConnectionError(
   error: unknown,
-  protocol: SavedServer["protocol"]
+  protocol: ProtocolMode
 ): unknown {
   if (
     protocol === "auto" ||
@@ -722,7 +862,7 @@ function normalizeProtocolConnectionError(
 
 function sanitizeConnectionError(
   error: unknown,
-  definition: SavedServer,
+  definition: SavedHttpServer,
   credentials: SavedCredentials
 ): unknown {
   const secrets = connectionSecrets(definition.url, credentials.headers);
@@ -788,7 +928,7 @@ function redactText(value: string, secrets: ReadonlySet<string>): string {
 
 function credentialsDirectory(name: string): string {
   return join(
-    CLIENT_DIR,
+    clientDir(),
     "credentials",
     createHash("sha256").update(name).digest("hex")
   );

--- a/libraries/typescript/packages/server/src/commands/client.ts
+++ b/libraries/typescript/packages/server/src/commands/client.ts
@@ -21,7 +21,7 @@ import {
   wantsJson,
   writePrivateJson,
 } from "./shared.js";
-import { parseStdioTarget } from "./stdio-target.js";
+import { formatStdioTarget, parseStdioTarget } from "./stdio-target.js";
 
 type ProtocolMode = "auto" | "legacy" | "modern";
 
@@ -107,7 +107,7 @@ async function connect(
       header: { type: "string", short: "H", multiple: true },
       "no-oauth": { type: "boolean" },
       "auth-timeout": { type: "string" },
-      protocol: { type: "string", default: "auto" },
+      protocol: { type: "string" },
       "no-open": { type: "boolean" },
       stdio: { type: "boolean" },
     },
@@ -121,7 +121,13 @@ async function connect(
   }
   const [name, target] = positionals as [string, string];
   validateName(name);
-  const protocol = parseProtocol(values.protocol);
+  // Stdio defaults to legacy: auto probing can stall spawn-per-invocation servers.
+  const protocol =
+    values.protocol !== undefined
+      ? parseProtocol(values.protocol)
+      : values.stdio === true
+        ? "legacy"
+        : "auto";
   const saved = await readServers();
   if (saved.servers[name] !== undefined) {
     throw new UsageError(`Saved server already exists: ${name}`);
@@ -216,7 +222,7 @@ async function list(argv: readonly string[], json: boolean): Promise<number> {
         command: server.command,
         args: server.args,
         protocol: server.protocol,
-        target: [server.command, ...server.args].join(" "),
+        target: formatStdioTarget(server.command, server.args),
       };
     }
     return {
@@ -507,7 +513,11 @@ async function openConnection(
         },
       },
     });
-    return client.connect(name);
+    try {
+      return await client.connect(name);
+    } catch (error) {
+      throw normalizeProtocolConnectionError(error, definition.protocol);
+    }
   }
 
   let rejectOAuthInteraction: ((error: CommandError) => void) | undefined;

--- a/libraries/typescript/packages/server/src/commands/shared.ts
+++ b/libraries/typescript/packages/server/src/commands/shared.ts
@@ -9,7 +9,7 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { createInterface } from "node:readline/promises";
 import { openBrowser as launchBrowser } from "../cli/open-browser.js";
 
@@ -180,7 +180,7 @@ export async function writePrivateJson(
   await chmod(parent, 0o700);
   const temporary = join(
     parent,
-    `.${path.slice(path.lastIndexOf("/") + 1)}.${process.pid}.${Date.now()}.tmp`
+    `.${basename(path)}.${process.pid}.${Date.now()}.tmp`
   );
   await writeFile(temporary, `${JSON.stringify(value, null, 2)}\n`, {
     mode: 0o600,
@@ -196,3 +196,8 @@ export async function removeFile(path: string): Promise<void> {
 
 /** Global mcp-use state directory. */
 export const GLOBAL_STATE_DIR = join(homedir(), ".mcp-use");
+
+/** Resolve the state directory from the current process home (test-friendly). */
+export function getGlobalStateDir(): string {
+  return join(homedir(), ".mcp-use");
+}

--- a/libraries/typescript/packages/server/src/commands/stdio-target.ts
+++ b/libraries/typescript/packages/server/src/commands/stdio-target.ts
@@ -1,0 +1,109 @@
+/**
+ * Parse a saved stdio target string into `{ command, args }`.
+ *
+ * Uses shell-like quoting (single/double quotes and backslash escapes) so
+ * executable paths and arguments that contain spaces survive tokenization.
+ * This intentionally does not execute shell syntax.
+ */
+
+/** Parsed stdio executable and argv from a connect target string. */
+export interface StdioTarget {
+  /** Executable path or program name. */
+  command: string;
+  /** Arguments passed to {@link StdioTarget.command}. */
+  args: string[];
+}
+
+/**
+ * Split a stdio connect target into command and argv.
+ *
+ * @param target - Raw command line from `mcp-use client connect … --stdio`.
+ * @returns Executable plus argument list with quotes removed.
+ */
+export function parseStdioTarget(target: string): StdioTarget {
+  const parts = splitCommandLine(target);
+
+  if (parts.length === 0) {
+    throw new Error("Stdio command cannot be empty");
+  }
+
+  const [command, ...args] = parts;
+  return { command: command!, args };
+}
+
+function splitCommandLine(input: string): string[] {
+  const parts: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | undefined;
+  let tokenStarted = false;
+
+  for (let index = 0; index < input.length; index++) {
+    const char = input[index]!;
+
+    if (char === "\\") {
+      const next = input[index + 1];
+
+      if (next === undefined || quote === "'") {
+        current += char;
+        tokenStarted = true;
+        continue;
+      }
+
+      if (quote === '"' && (next === '"' || next === "\\")) {
+        current += next;
+        tokenStarted = true;
+        index++;
+        continue;
+      }
+
+      if (!quote && /[\s'"\\]/.test(next)) {
+        current += next;
+        tokenStarted = true;
+        index++;
+        continue;
+      }
+
+      current += char;
+      tokenStarted = true;
+      continue;
+    }
+
+    if (quote) {
+      if (char === quote) {
+        quote = undefined;
+      } else {
+        current += char;
+      }
+      tokenStarted = true;
+      continue;
+    }
+
+    if (char === "'" || char === '"') {
+      quote = char;
+      tokenStarted = true;
+      continue;
+    }
+
+    if (/\s/.test(char)) {
+      if (tokenStarted) {
+        parts.push(current);
+        current = "";
+        tokenStarted = false;
+      }
+      continue;
+    }
+
+    current += char;
+    tokenStarted = true;
+  }
+
+  if (quote) {
+    throw new Error("Unterminated quote in stdio command");
+  }
+
+  if (tokenStarted) {
+    parts.push(current);
+  }
+
+  return parts;
+}

--- a/libraries/typescript/packages/server/src/commands/stdio-target.ts
+++ b/libraries/typescript/packages/server/src/commands/stdio-target.ts
@@ -23,12 +23,30 @@ export interface StdioTarget {
 export function parseStdioTarget(target: string): StdioTarget {
   const parts = splitCommandLine(target);
 
-  if (parts.length === 0) {
+  if (parts.length === 0 || parts[0] === "") {
     throw new Error("Stdio command cannot be empty");
   }
 
   const [command, ...args] = parts;
   return { command: command!, args };
+}
+
+/**
+ * Format command/argv for human-readable list output so spaces round-trip
+ * through {@link parseStdioTarget}.
+ */
+export function formatStdioTarget(command: string, args: string[]): string {
+  return [command, ...args].map(shellQuoteToken).join(" ");
+}
+
+function shellQuoteToken(token: string): string {
+  if (token.length === 0) {
+    return '""';
+  }
+  if (!/[\s'"\\]/.test(token)) {
+    return token;
+  }
+  return `"${token.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
 }
 
 function splitCommandLine(input: string): string[] {

--- a/libraries/typescript/packages/server/tests/commands/client-help.test.ts
+++ b/libraries/typescript/packages/server/tests/commands/client-help.test.ts
@@ -4,7 +4,7 @@ import { main } from "../../src/bin/main.js";
 
 const helpTree: readonly [path: readonly string[], usage: string][] = [
   [[], "mcp-use client <command>"],
-  [["connect"], "mcp-use client connect <name> <url> [options]"],
+  [["connect"], "mcp-use client connect <name> <url|command> [options]"],
   [["list"], "mcp-use client list [options]"],
   [["remove"], "mcp-use client remove <name> [options]"],
   [["demo"], "mcp-use client <name> <command>"],

--- a/libraries/typescript/packages/server/tests/commands/client.test.ts
+++ b/libraries/typescript/packages/server/tests/commands/client.test.ts
@@ -6,6 +6,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const AUTHORIZATION_LAUNCHER_URL = "http://127.0.0.1:33418/authorize";
 
+let homeDirectory: string;
+
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return {
+    ...actual,
+    homedir: () => homeDirectory || actual.homedir(),
+  };
+});
+
 const mocks = vi.hoisted(() => ({
   closePrompt: vi.fn(),
   connectCall: vi.fn(),
@@ -19,6 +29,8 @@ const mocks = vi.hoisted(() => ({
             clientOptions?: { supportedProtocolVersions?: string[] };
             protocolNegotiation?: "auto" | "legacy" | { pin: "2026-07-28" };
             url?: string;
+            command?: string;
+            args?: string[];
           }
         >;
       }
@@ -55,7 +67,6 @@ const connection = {
   readResource: vi.fn(),
 };
 
-let homeDirectory: string;
 let runClient: (argv: readonly string[]) => Promise<number>;
 let stdout = "";
 let stderr = "";
@@ -71,6 +82,7 @@ beforeEach(async () => {
   mocks.logger.level = "info";
   homeDirectory = await mkdtemp(join(tmpdir(), "mcp-use-client-"));
   vi.stubEnv("HOME", homeDirectory);
+  vi.stubEnv("USERPROFILE", homeDirectory);
   stdinTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
   setStdinTty(false);
 
@@ -179,6 +191,49 @@ describe("client JSON output", () => {
     expect(stdout).not.toContain("fragment-secret");
   });
 
+  it("preserves quoted stdio command paths and arguments when saving", async () => {
+    await expect(
+      runClient([
+        "connect",
+        "local",
+        '"/opt/MCP Servers/server" "--config=dev env.json"',
+        "--stdio",
+        "--json",
+      ])
+    ).resolves.toBe(0);
+
+    expect(JSON.parse(stdout)).toEqual({
+      name: "local",
+      type: "stdio",
+      command: "/opt/MCP Servers/server",
+      args: ["--config=dev env.json"],
+      protocol: "auto",
+    });
+    expect(mocks.config?.mcpServers.local).toEqual({
+      command: "/opt/MCP Servers/server",
+      args: ["--config=dev env.json"],
+      protocolNegotiation: "auto",
+    });
+    expect(mocks.connectCall).toHaveBeenCalledWith("local");
+
+    const { getGlobalStateDir } = await import("../../src/commands/shared.js");
+    const saved = JSON.parse(
+      await readFile(join(getGlobalStateDir(), "client", "servers.json"), {
+        encoding: "utf8",
+      })
+    ) as {
+      servers: Record<
+        string,
+        { type: string; command: string; args: string[] }
+      >;
+    };
+    expect(saved.servers.local).toMatchObject({
+      type: "stdio",
+      command: "/opt/MCP Servers/server",
+      args: ["--config=dev env.json"],
+    });
+  });
+
   it("returns structured OAuth recovery without URL, state, logs, or browser", async () => {
     mocks.triggerOAuth = true;
 
@@ -234,9 +289,11 @@ describe("client JSON output", () => {
         expected: [
           {
             name: "demo",
+            type: "http",
             oauth: false,
             protocol: "auto",
             url: "https://mcp.example.com/mcp",
+            target: "https://mcp.example.com/mcp",
           },
         ],
       },
@@ -453,9 +510,11 @@ describe("client human-readable output", () => {
     await expect(runClient(["list", "--json"])).resolves.toBe(0);
     expect(JSON.parse(stdout)).toContainEqual({
       name: "remove-flags",
+      type: "http",
       oauth: false,
       protocol: "auto",
       url: "https://mcp.example.com/mcp",
+      target: "https://mcp.example.com/mcp",
     });
     expect(stderr).toBe("");
   });
@@ -530,8 +589,8 @@ describe("client protocol selection", () => {
   });
 
   it("migrates saved revision values before listing or reconnecting", async () => {
-    const { GLOBAL_STATE_DIR } = await import("../../src/commands/shared.js");
-    const clientDirectory = join(GLOBAL_STATE_DIR, "client");
+    const { getGlobalStateDir } = await import("../../src/commands/shared.js");
+    const clientDirectory = join(getGlobalStateDir(), "client");
     const serversPath = join(clientDirectory, "servers.json");
     await mkdir(clientDirectory, { recursive: true });
     await writeFile(
@@ -556,15 +615,19 @@ describe("client protocol selection", () => {
     expect(JSON.parse(stdout)).toEqual([
       {
         name: "old",
+        type: "http",
         url: "https://old.example.com/mcp",
         oauth: false,
         protocol: "legacy",
+        target: "https://old.example.com/mcp",
       },
       {
         name: "new",
+        type: "http",
         url: "https://new.example.com/mcp",
         oauth: false,
         protocol: "modern",
+        target: "https://new.example.com/mcp",
       },
     ]);
     expect(await readFile(serversPath, "utf8")).not.toMatch(

--- a/libraries/typescript/packages/server/tests/commands/client.test.ts
+++ b/libraries/typescript/packages/server/tests/commands/client.test.ts
@@ -207,12 +207,15 @@ describe("client JSON output", () => {
       type: "stdio",
       command: "/opt/MCP Servers/server",
       args: ["--config=dev env.json"],
-      protocol: "auto",
+      protocol: "legacy",
     });
     expect(mocks.config?.mcpServers.local).toEqual({
       command: "/opt/MCP Servers/server",
       args: ["--config=dev env.json"],
-      protocolNegotiation: "auto",
+      protocolNegotiation: "legacy",
+      clientOptions: {
+        supportedProtocolVersions: ["2025-11-25"],
+      },
     });
     expect(mocks.connectCall).toHaveBeenCalledWith("local");
 
@@ -224,13 +227,53 @@ describe("client JSON output", () => {
     ) as {
       servers: Record<
         string,
-        { type: string; command: string; args: string[] }
+        { type: string; command: string; args: string[]; protocol: string }
       >;
     };
     expect(saved.servers.local).toMatchObject({
       type: "stdio",
       command: "/opt/MCP Servers/server",
       args: ["--config=dev env.json"],
+      protocol: "legacy",
+    });
+
+    stdout = "";
+    await expect(runClient(["list", "--json"])).resolves.toBe(0);
+    expect(JSON.parse(stdout)).toEqual([
+      {
+        name: "local",
+        type: "stdio",
+        command: "/opt/MCP Servers/server",
+        args: ["--config=dev env.json"],
+        protocol: "legacy",
+        target: '"/opt/MCP Servers/server" "--config=dev env.json"',
+      },
+    ]);
+  });
+
+  it("reports protocol_mismatch for strict stdio protocol connects", async () => {
+    mocks.connectError = new Error(
+      "Unsupported protocol version: 2025-11-25; supported: 2026-07-28"
+    );
+
+    await expect(
+      runClient([
+        "connect",
+        "stdio-mismatch",
+        "node server.js",
+        "--stdio",
+        "--protocol",
+        "legacy",
+        "--json",
+      ])
+    ).resolves.toBe(1);
+
+    expect(stdout).toBe("");
+    expect(JSON.parse(stderr)).toEqual({
+      error: {
+        code: "protocol_mismatch",
+        message: "Server does not support the requested legacy protocol.",
+      },
     });
   });
 

--- a/libraries/typescript/packages/server/tests/commands/stdio-target.test.ts
+++ b/libraries/typescript/packages/server/tests/commands/stdio-target.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { parseStdioTarget } from "../../src/commands/stdio-target.js";
+import {
+  formatStdioTarget,
+  parseStdioTarget,
+} from "../../src/commands/stdio-target.js";
 
 describe("parseStdioTarget", () => {
   it("keeps simple stdio commands unchanged", () => {
@@ -21,10 +24,20 @@ describe("parseStdioTarget", () => {
     });
   });
 
-  it("preserves Windows backslashes inside quoted command paths", () => {
+  it('preserves Windows paths when using quote delimiters (not \\")', () => {
+    // Quote characters delimit the token. Backslash-escaped quotes outside a
+    // quoted region are literal '"' characters and would still split on spaces.
+    const target = String.raw`"C:\Program Files\nodejs\node.exe" "server path.js" --flag`;
+    expect(parseStdioTarget(target)).toEqual({
+      command: String.raw`C:\Program Files\nodejs\node.exe`,
+      args: ["server path.js", "--flag"],
+    });
     expect(
       parseStdioTarget(
-        String.raw`"C:\Program Files\nodejs\node.exe" "server path.js" --flag`
+        formatStdioTarget(String.raw`C:\Program Files\nodejs\node.exe`, [
+          "server path.js",
+          "--flag",
+        ])
       )
     ).toEqual({
       command: String.raw`C:\Program Files\nodejs\node.exe`,
@@ -47,5 +60,18 @@ describe("parseStdioTarget", () => {
 
   it("rejects an empty command", () => {
     expect(() => parseStdioTarget("   ")).toThrow("cannot be empty");
+  });
+
+  it("rejects an empty quoted executable", () => {
+    expect(() => parseStdioTarget('""')).toThrow("cannot be empty");
+    expect(() => parseStdioTarget('"" --flag')).toThrow("cannot be empty");
+  });
+});
+
+describe("formatStdioTarget", () => {
+  it("shell-quotes tokens so spaces remain unambiguous", () => {
+    expect(
+      formatStdioTarget("/opt/MCP Servers/server", ["--config=dev env.json"])
+    ).toBe('"/opt/MCP Servers/server" "--config=dev env.json"');
   });
 });

--- a/libraries/typescript/packages/server/tests/commands/stdio-target.test.ts
+++ b/libraries/typescript/packages/server/tests/commands/stdio-target.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { parseStdioTarget } from "../../src/commands/stdio-target.js";
+
+describe("parseStdioTarget", () => {
+  it("keeps simple stdio commands unchanged", () => {
+    expect(
+      parseStdioTarget("npx -y @modelcontextprotocol/server-filesystem /tmp")
+    ).toEqual({
+      command: "npx",
+      args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+    });
+  });
+
+  it("preserves quoted command paths and arguments with spaces", () => {
+    expect(
+      parseStdioTarget('"/opt/MCP Servers/server" "--config=dev env.json"')
+    ).toEqual({
+      command: "/opt/MCP Servers/server",
+      args: ["--config=dev env.json"],
+    });
+  });
+
+  it("preserves Windows backslashes inside quoted command paths", () => {
+    expect(
+      parseStdioTarget(
+        String.raw`"C:\Program Files\nodejs\node.exe" "server path.js" --flag`
+      )
+    ).toEqual({
+      command: String.raw`C:\Program Files\nodejs\node.exe`,
+      args: ["server path.js", "--flag"],
+    });
+  });
+
+  it("preserves intentionally empty quoted arguments", () => {
+    expect(parseStdioTarget('node server.js ""')).toEqual({
+      command: "node",
+      args: ["server.js", ""],
+    });
+  });
+
+  it("rejects unterminated quoted commands", () => {
+    expect(() => parseStdioTarget('"node server.js')).toThrow(
+      "Unterminated quote"
+    );
+  });
+
+  it("rejects an empty command", () => {
+    expect(() => parseStdioTarget("   ")).toThrow("cannot be empty");
+  });
+});


### PR DESCRIPTION
﻿## Summary
- Parse `mcp-use client connect --stdio` targets with shell-like quoting instead of splitting on raw spaces, so quoted executable paths and arguments survive as `{ command, args }`.
- Restore stdio connect on the current client CLI (docs/examples still expected it) and cover quoted paths, Windows paths, empty args, and unterminated quotes in unit tests.

Fixes #1815

## Test plan
- [x] `pnpm --dir libraries/typescript/packages/server exec vitest run tests/commands/stdio-target.test.ts tests/commands/client.test.ts tests/commands/client-help.test.ts`
- [ ] Connect with a quoted stdio command whose path/args contain spaces and confirm the saved `{ command, args }` keep those spaces
- [ ] Existing HTTP `mcp-use client connect <name> <url>` flow still works

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CLI parsing for `mcp-use client connect --stdio` to preserve quoted executable paths and args, restores stdio connect support, and clarifies protocol behavior. Users can now save and list stdio servers with commands that include spaces; list output round-trips through `--stdio`.

- **New Features**
  - Support saving stdio servers as `{ type: "stdio", command, args, protocol }`; stdio defaults to `protocol: legacy` (URLs default to `auto`). `client list` shows `type` and a shell-quoted `target` for both URL and stdio; help documents `mcp-use client connect <name> "<command>" --stdio` and notes wrapping the whole target in outer single quotes. OAuth/header options apply only to URL connects; OAuth commands on stdio are usage errors.

- **Bug Fixes**
  - Parse `--stdio` targets with shell-like quoting; reject empty executables and unterminated quotes. Report `protocol_mismatch` cleanly for strict stdio and URL connects.

<sup>Written for commit 3f0bfd5b0c6953938f1d7d74eeb799145ced4d1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

