### PR TITLE
fix(inspector): load provider assets in development

### DIFF
--- a/libraries/typescript/.changeset/bright-inspector-assets.md
+++ b/libraries/typescript/.changeset/bright-inspector-assets.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+fix(inspector): load provider assets from the development server

--- a/libraries/typescript/packages/inspector/src/client/utils/providerAssets.ts
+++ b/libraries/typescript/packages/inspector/src/client/utils/providerAssets.ts
@@ -6,6 +6,9 @@ export function providerAssetUrl(filename: string): string {
       ? undefined
       : (window as unknown as { __MCP_INSPECTOR_MODE__?: string })
           .__MCP_INSPECTOR_MODE__;
+  if (mode === "development") {
+    return `${getInspectorBase()}/providers/${filename}`;
+  }
   if (typeof window !== "undefined" && mode !== "cloud") {
     return `${getInspectorBase()}/assets/providers/${filename}`;
   }

--- a/libraries/typescript/packages/inspector/vite.config.ts
+++ b/libraries/typescript/packages/inspector/vite.config.ts
@@ -45,7 +45,7 @@ export default defineConfig({
       transformIndexHtml(html) {
         return html.replace(
           "</head>",
-          `  <script>window.__INSPECTOR_VERSION__ = "${packageJson.version}";</script>\n  </head>`
+          `  <script>window.__INSPECTOR_VERSION__ = "${packageJson.version}";</script>\n  <script>window.__MCP_INSPECTOR_MODE__ = "development";</script>\n  </head>`
         );
       },
     },


### PR DESCRIPTION
## Summary

- mark the Inspector dev-server page as development mode
- serve provider assets from the Vite development path
- add a patch changeset for `@mcp-use/inspector`

## Why

Provider assets must use the development-server path while running the Inspector locally.

## Validation

- `pnpm --filter @mcp-use/inspector type-check`
- repository pre-commit checks (formatting, lint, and changeset validation)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes provider assets loading in local development by marking the Inspector dev page as development and serving assets from the Vite dev server path. Includes a patch changeset for `@mcp-use/inspector`.

<sup>Written for commit 057070775ead4167b963a4a34ef61db41b6d8240. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

