### PR TITLE
fix(ci): stop knip failing on the skills-loader subpath import

### DIFF
--- a/libraries/typescript/knip.json
+++ b/libraries/typescript/knip.json
@@ -18,7 +18,7 @@
     "packages/server": {
       "entry": ["src/oauth/**/*.ts", "tests/**/*.{ts,tsx}"],
       "project": ["src/**/*.{ts,tsx}", "tests/**/*.{ts,tsx}"],
-      "ignoreUnresolved": ["#mcp-use-node-http"]
+      "ignoreUnresolved": ["#mcp-use-node-http", "#mcp-use-skills-loader"]
     },
     "packages/agent": {
       "entry": ["tests/**/*.ts", "examples/**/*.ts"],


### PR DESCRIPTION
Closes #2189.

`pnpm exec knip` exits 1 on `canary`:

```
Unresolved imports (1)
#mcp-use-skills-loader  packages/server/src/server.ts:658:48
```

Nothing is actually broken. The import is declared and resolves at runtime:

```json
// packages/server/package.json
"#mcp-use-skills-loader": { "node": "@mcp-use/cli/internal/skills-loader", ... }

// packages/cli/package.json
"./internal/skills-loader": { "import": "./dist/internal/skills-loader.js" }
```

built by tsup from `src/skills/node-loader.ts`. knip just cannot follow a subpath import that resolves into another workspace package, which is why its sibling `#mcp-use-node-http` is already in `packages/server.ignoreUnresolved`. The skills-loader entry was never added when that work landed.

That unresolved import is the only knip **error**: `rules.exports` and `rules.types` are `warn`, so the two unused inspector exports and the unused type do not fail the build. Adding the entry is enough.

## Verification

```
$ pnpm exec knip --no-progress   # before
exit 1, Unresolved imports (1)

$ pnpm exec knip --no-progress   # after
exit 0, no Unresolved imports section
```

## Why this is worth a PR rather than leaving it

`typescript-knip` is skipped on canary's own runs, so canary never shows this failure. It surfaces on the next PR that touches TypeScript instead: #2188 changes only `create-mcp-use-app/src/skills-config.ts` and inherited a red `typescript-knip` for it.

## Two things I left alone

knip hints that `#mcp-use-node-http` can now be dropped from `ignoreUnresolved`. That hint appears in my local run but not in CI's, so it resolves differently by environment and removing it would likely turn CI red.

The unused inspector exports (`READ_SKILL_RESOURCE_TOOL`, `supportsSkills`, `SkillContextConnection`) are warnings, not errors, and may be intentional staging for the skills work. Say the word if you want them removed and I will send that separately.

## Note on preflight

`pnpm run lint` fails on this branch and identically on untouched `canary`: 41 problems, 39 errors, all in `packages/cli/src/`. This PR changes one line of `knip.json` and cannot affect eslint.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop `knip` from failing by ignoring the `#mcp-use-skills-loader` subpath import in `packages/server`. The import resolves to `@mcp-use/cli/internal/skills-loader` at runtime; adding it to `ignoreUnresolved` makes `knip` exit 0 again.

<sup>Written for commit ed27ff79e64c9c253f5f2c6e1461b25f8b6cc29f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

