### PR TITLE
fix(next): resolve skills loader in Turbopack

### DIFF
--- a/libraries/typescript/.changeset/fix-next-skills-turbopack.md
+++ b/libraries/typescript/.changeset/fix-next-skills-turbopack.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Fix Turbopack builds for Next.js servers using Skills over MCP.

--- a/libraries/typescript/packages/server/src/next/config.ts
+++ b/libraries/typescript/packages/server/src/next/config.ts
@@ -11,6 +11,18 @@ interface NextHeaderRule {
   headers: NextHeader[];
 }
 
+type TurbopackAliasTarget =
+  | string
+  | string[]
+  | Record<string, string | string[]>;
+
+interface TurbopackConfig {
+  /** Preserve arbitrary Turbopack settings supplied by the application. */
+  [key: string]: unknown;
+  /** Module aliases augmented for the server runtime. */
+  resolveAlias?: Record<string, TurbopackAliasTarget>;
+}
+
 /** Minimal structural Next.js config type, avoiding a runtime Next dependency. */
 export interface NextConfigLike {
   /** Preserve arbitrary Next.js settings while augmenting the fields we use. */
@@ -19,6 +31,8 @@ export interface NextConfigLike {
   headers?: () => NextHeaderRule[] | Promise<NextHeaderRule[]>;
   /** Next.js output tracing globs augmented with compiled MCP view assets. */
   outputFileTracingIncludes?: Record<string, string[]>;
+  /** Turbopack configuration augmented with mcp-use runtime aliases. */
+  turbopack?: TurbopackConfig;
 }
 
 /** Options for {@link withMcpUse}. */
@@ -142,6 +156,8 @@ export function composeNextConfig<T extends NextConfigLike>(
   const originalHeaders = nextConfig.headers?.bind(nextConfig);
   const existingTrace = nextConfig.outputFileTracingIncludes ?? {};
   const routeTrace = existingTrace[basePath] ?? [];
+  const existingTurbopack = nextConfig.turbopack ?? {};
+  const existingResolveAlias = existingTurbopack.resolveAlias ?? {};
 
   return {
     ...nextConfig,
@@ -161,6 +177,15 @@ export function composeNextConfig<T extends NextConfigLike>(
     outputFileTracingIncludes: {
       ...existingTrace,
       [basePath]: [...new Set([...routeTrace, BUILD_TRACE_GLOB])],
+    },
+    turbopack: {
+      ...existingTurbopack,
+      resolveAlias: {
+        ...existingResolveAlias,
+        // Turbopack does not resolve this private package import when it
+        // bundles the server's prebuilt Node entry.
+        "#mcp-use-skills-loader": "@mcp-use/cli/internal/skills-loader",
+      },
     },
   };
 }

--- a/libraries/typescript/packages/server/tests/next-adapter.test.ts
+++ b/libraries/typescript/packages/server/tests/next-adapter.test.ts
@@ -129,6 +129,10 @@ describe("withMcpUse config composition", () => {
           "/api/mcp": ["./already/**/*"],
           "/other": ["./other/**/*"],
         },
+        turbopack: {
+          root: "/example",
+          resolveAlias: { "@app/config": "./config.ts" },
+        },
       },
       "/api/mcp"
     );
@@ -148,6 +152,13 @@ describe("withMcpUse config composition", () => {
     expect(config.outputFileTracingIncludes).toEqual({
       "/api/mcp": ["./already/**/*", "./.mcp-use/build/**/*"],
       "/other": ["./other/**/*"],
+    });
+    expect(config.turbopack).toEqual({
+      root: "/example",
+      resolveAlias: {
+        "@app/config": "./config.ts",
+        "#mcp-use-skills-loader": "@mcp-use/cli/internal/skills-loader",
+      },
     });
   });
 


### PR DESCRIPTION
## Summary

- configure `withMcpUse` to map Turbopack's unresolved private skills-loader specifier to the CLI's exported loader
- preserve existing Turbopack options and user-defined aliases
- cover the config composition with a regression test

## Root cause

Turbopack could not resolve `#mcp-use-skills-loader` when bundling the prebuilt Node entry for a Next.js route, causing the server examples CI check to fail.

## Validation

- `pnpm --filter mcp-use build`
- `pnpm --filter mcp-use-example-nextjs typecheck`
- `pnpm --filter mcp-use exec vitest run tests/next-adapter.test.ts tests/budgets/cli-budget.test.ts`
- `pnpm --filter mcp-use-example-nextjs build` (default Turbopack build)
- `pnpm --filter mcp-use-example-nextjs verify`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Turbopack builds by resolving `#mcp-use-skills-loader` to `@mcp-use/cli/internal/skills-loader` in Next.js server routes. Keeps existing Turbopack settings and aliases intact.

- **Bug Fixes**
  - Add `turbopack.resolveAlias` mapping for `#mcp-use-skills-loader` in the composed Next config.
  - Preserve user-defined Turbopack options and aliases; add a regression test and a changeset for a patch release.

<sup>Written for commit 429942b10d357374129bb2d861c1f300f528f001. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

