### PR TITLE
fix(release): compare Canary plan against origin main

### DIFF
--- a/.github/workflows/typescript-release.yml
+++ b/.github/workflows/typescript-release.yml
@@ -104,7 +104,7 @@ jobs:
         working-directory: libraries/typescript
         run: |
           pnpm release-channel prepare --channel canary
-          pnpm changeset status --output "$RUNNER_TEMP/canary-changeset-status.json"
+          pnpm changeset status --since origin/main --output "$RUNNER_TEMP/canary-changeset-status.json"
           pnpm release-channel validate --channel canary --plan "$RUNNER_TEMP/canary-changeset-status.json"
 
       - name: Version packages (Canary)


### PR DESCRIPTION
## Why

The first live run of the Canary prerelease recovery stopped safely before versioning or publishing. `changeset status` failed because GitHub Actions checks out `canary` as the only local branch, while Changesets tried to resolve the configured base branch as local `main`.

## Fix

Compare the Canary release plan explicitly against `origin/main`, which is available because the release checkout uses full history.

## Verification

- `pnpm changeset status --since origin/main` generated the live seven-package plan
- `pnpm release-channel validate --channel canary` accepted all seven releases
- 10/10 release-channel guard tests passed
- workflow formatting and diff checks passed

The failed run published nothing. Merging this PR will trigger the protected Canary workflow again.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Canary prerelease by comparing the plan against `origin/main`, so `pnpm changeset status` uses the correct base branch in CI. This unblocks canary versioning and publishing.

- **Bug Fixes**
  - Run `pnpm changeset status --since origin/main` in the TypeScript release workflow when preparing the canary plan.

<sup>Written for commit 48d623ed55fed9df83c932ffab2e1f2a128debc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

