### PR TITLE
fix(ci): actually run the inspector unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -772,7 +772,7 @@ jobs:
       - name: Run Inspector Tests
         env:
           MCP_USE_ANONYMIZED_TELEMETRY: false
-        run: pnpm --filter @mcp-use/inspector --if-present test
+        run: pnpm --filter @mcp-use/inspector test:unit
 
   typescript-test-cli:
     needs: typescript-lint


### PR DESCRIPTION
Closes mcp-use/mcp-use#2200.

The "Run Inspector Tests" step runs a script that does not exist:

```yaml
run: pnpm --filter @mcp-use/inspector --if-present test
```

`@mcp-use/inspector` has no `test` script; its unit entry point is `test:unit`. `--if-present` turns a missing script into a silent success, so the step passes having run nothing:

```
$ pnpm --filter @mcp-use/inspector --if-present test
Already up to date
Done in 1.1s
exit 0
```

The tests exist and pass:

```
$ pnpm --filter @mcp-use/inspector test:unit
Test Files  37 passed (37)
Tests       159 passed (159)
Duration    3.61s
```

So 159 unit tests have not been running, and the job reported success throughout. The workflow's own legend at line 34 calls this step *"Unit tests for inspector package"*.

The sibling steps in the same file already use the right script, which is what makes this look like a slip rather than intent:

```
ci.yml:703  pnpm --filter mcp-use --if-present test:unit
ci.yml:707  pnpm --filter @mcp-use/agent test:unit
```

I also dropped `--if-present` here. The script exists, and if it ever stops existing this step should fail rather than go quietly green again.

Costs about 4 seconds and goes green immediately.

`canary` has the same line, so it will want the same change when this syncs across.

---

## Summary by cubic

Fix CI to actually run `@mcp-use/inspector` unit tests by invoking `test:unit` instead of a missing `test` script, and remove `--if-present` so the step fails if it ever disappears. Aligns with sibling steps and restores execution of 159 tests (\~4s).

Written for commit 04c132f5de638cf3bb803fe36c0a758dd5a4f967. Summary will update on new commits.

![Review in cubic](https://camo.githubusercontent.com/bd9efce2efa0a4d0a92a581dc73a4b2dc621085d3ac789eccf3330c974d2dae0/68747470733a2f2f7777772e63756269632e6465762f627574746f6e732f7265766965772d696e2d63756269632d6461726b2e737667)