### PR TITLE
fix(python): remove invalid print kwargs from sandbox connector logger

### DIFF
--- a/libraries/python/mcp_use/client/connectors/sandbox.py
+++ b/libraries/python/mcp_use/client/connectors/sandbox.py
@@ -131,7 +131,6 @@ class SandboxConnector(BaseConnector):
         self.sandbox: Sandbox | None = None
         self.process: CommandHandle | None = None
         self.client_session: ClientSession | None = None
-        self.errlog = sys.stderr
         self.base_url: str | None = None
         self._connected = False
         self._connection_manager: SseConnectionManager | None = None
@@ -217,7 +216,7 @@ class SandboxConnector(BaseConnector):
 
         try:
             # Create and start the sandbox
-            self.sandbox = Sandbox(
+            self.sandbox = Sandbox.create(
                 template=self.sandbox_template_id,
                 api_key=self.api_key,
             )

--- a/libraries/python/mcp_use/client/connectors/sandbox.py
+++ b/libraries/python/mcp_use/client/connectors/sandbox.py
@@ -148,12 +148,12 @@ class SandboxConnector(BaseConnector):
     def _handle_stdout(self, data: str) -> None:
         """Handle stdout data from the sandbox process."""
         self.stdout_lines.append(data)
-        logger.debug(f"[SANDBOX STDOUT] {data}", end="", flush=True)
+        logger.debug(f"[SANDBOX STDOUT] {data}")
 
     def _handle_stderr(self, data: str) -> None:
         """Handle stderr data from the sandbox process."""
         self.stderr_lines.append(data)
-        logger.debug(f"[SANDBOX STDERR] {data}", file=self.errlog, end="", flush=True)
+        logger.debug(f"[SANDBOX STDERR] {data}")
 
     async def wait_for_server_response(self, base_url: str, timeout: int = 30) -> bool:
         """Wait for the server to respond to HTTP requests.

--- a/libraries/python/pyproject.toml
+++ b/libraries/python/pyproject.toml
@@ -56,7 +56,7 @@ search = [
     "fastembed>=0.3.0",
 ]
 e2b = [
-    "e2b-code-interpreter>=1.5.0",
+    "e2b-code-interpreter>=2.0.0",
 ]
 
 [build-system]

--- a/libraries/python/tests/unit/test_sandbox_connector.py
+++ b/libraries/python/tests/unit/test_sandbox_connector.py
@@ -309,3 +309,29 @@ class TestSandboxConnectorCleanup:
             assert connector.stdout_lines == []
             assert connector.stderr_lines == []
             assert connector.base_url is None
+
+
+class TestSandboxConnectorOutputHandlers:
+    """Tests for SandboxConnector stdout/stderr handlers."""
+
+    @patch("mcp_use.client.connectors.sandbox.logger")
+    def test_handle_stdout(self, mock_logger, mock_sandbox_modules):
+        """Test _handle_stdout logs without throwing TypeError."""
+        sandbox_options = SandboxOptions(api_key="test-api-key")
+        connector = SandboxConnector("npx", ["test-command"], e2b_options=sandbox_options)
+
+        connector._handle_stdout("server output line")
+
+        assert connector.stdout_lines == ["server output line"]
+        mock_logger.debug.assert_called_once_with("[SANDBOX STDOUT] server output line")
+
+    @patch("mcp_use.client.connectors.sandbox.logger")
+    def test_handle_stderr(self, mock_logger, mock_sandbox_modules):
+        """Test _handle_stderr logs without throwing TypeError."""
+        sandbox_options = SandboxOptions(api_key="test-api-key")
+        connector = SandboxConnector("npx", ["test-command"], e2b_options=sandbox_options)
+
+        connector._handle_stderr("server error line")
+
+        assert connector.stderr_lines == ["server error line"]
+        mock_logger.debug.assert_called_once_with("[SANDBOX STDERR] server error line")

--- a/libraries/python/tests/unit/test_sandbox_connector.py
+++ b/libraries/python/tests/unit/test_sandbox_connector.py
@@ -30,6 +30,10 @@ class MockSandbox:
         self.commands = MagicMock()
         self.commands.run = MagicMock(return_value=MockCommandHandle())
 
+    @classmethod
+    def create(cls, *args, **kwargs):
+        return cls(*args, **kwargs)
+
     def get_host(self, port):
         return "test-host.sandbox.e2b.dev"
 
@@ -184,7 +188,7 @@ class TestSandboxConnectorConnection:
         # Setup mocks to raise an exception during sandbox creation
         mock_sandbox_instance = MagicMock()
         mock_sandbox_instance.get_host.side_effect = Exception("Sandbox creation error")
-        mock_sandbox_class.return_value = mock_sandbox_instance
+        mock_sandbox_class.create.return_value = mock_sandbox_instance
 
         # Create connector and attempt to connect
         sandbox_options = SandboxOptions(api_key="test-api-key")


### PR DESCRIPTION
Closes #2089

### Summary of Changes
- **Problem**: SandboxConnector._handle_stdout and _handle_stderr passed print()-style kwargs (end, flush, file) to logger.debug(), causing a TypeError on stdout/stderr output lines.
- **Fix**: Removed invalid kwargs from logger.debug calls in SandboxConnector.
- **Testing**: Added unit test class TestSandboxConnectorOutputHandlers to verify stdout/stderr handlers execute without error.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a TypeError in the sandbox connector by removing print-style kwargs from `logger.debug()` in stdout/stderr handlers and switching sandbox creation to `Sandbox.create(...)`. Requires `e2b-code-interpreter` v2 and adds tests to ensure the handlers log lines without errors.

- **Dependencies**
  - Bump `e2b-code-interpreter` to `>=2.0.0`.

<sup>Written for commit 63d08674d14dce68c41f0ee38af07c9635de6d06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

