### PR TITLE
fix(test): update the stale @mcp-use/client peer assertion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -696,7 +696,7 @@ jobs:
       - name: Run mcp-use Unit Tests
         env:
           MCP_USE_ANONYMIZED_TELEMETRY: false
-        run: pnpm --filter mcp-use --if-present test:unit
+        run: pnpm --filter mcp-use test:run
       - name: Run @mcp-use/agent Unit Tests
         env:
           MCP_USE_ANONYMIZED_TELEMETRY: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -696,7 +696,7 @@ jobs:
       - name: Run mcp-use Unit Tests
         env:
           MCP_USE_ANONYMIZED_TELEMETRY: false
-        run: pnpm --filter mcp-use test:run
+        run: pnpm --filter mcp-use --if-present test:unit
       - name: Run @mcp-use/agent Unit Tests
         env:
           MCP_USE_ANONYMIZED_TELEMETRY: false

--- a/libraries/typescript/packages/server/tests/proxy-optional-peer.test.ts
+++ b/libraries/typescript/packages/server/tests/proxy-optional-peer.test.ts
@@ -5,9 +5,7 @@ import { proxyClientInstallError } from "../src/mcp-proxy.js";
 
 describe("server.proxy optional peer", () => {
   it("declares @mcp-use/client as an optional peer", () => {
-    expect(packageJson.peerDependencies["@mcp-use/client"]).toBe(
-      "^2.0.0-alpha.0"
-    );
+    expect(packageJson.peerDependencies["@mcp-use/client"]).toBe("^2.0.1");
     expect(packageJson.peerDependenciesMeta["@mcp-use/client"]?.optional).toBe(
       true
     );


### PR DESCRIPTION
Refs #2203. Scope reduced, see the comment below for why.

`packages/server/tests/proxy-optional-peer.test.ts:8` pins the `@mcp-use/client` peer at `^2.0.0-alpha.0`. `package.json` moved to `^2.0.1` when v2 went stable and the assertion was never updated, so the test has been failing:

```
AssertionError: expected '^2.0.1' to be '^2.0.0-alpha.0'
```

Nobody saw it because the CI step meant to run this suite runs a script that does not exist (`pnpm --filter mcp-use --if-present test:unit`, and there is no `test:unit`), so it silently passes. That part is #2203; this PR is just the assertion.

After this, `pnpm --filter mcp-use test:run` is 704 passed / 704 locally.

## The tradeoff I took

Updated the pinned string, the smallest change that makes the assertion true and keeps the test's intent.

It will drift again at the next peer bump, which is how it broke this time. The alternative is asserting the peer is declared and `optional: true` without pinning a range, matching the test's own name, at the cost of no longer catching an accidental range change. I did not want to quietly change what the test checks, so say the word if you would prefer that.

`canary` carries the same stale assertion.