### PR TITLE
fix production tunnel host forwarding

### DIFF
--- a/libraries/typescript/.changeset/fresh-tunnels-start.md
+++ b/libraries/typescript/.changeset/fresh-tunnels-start.md
@@ -1,0 +1,6 @@
+---
+"@mcp-use/cli": patch
+"@mcp-use/tunnel": patch
+---
+
+Allow production `start --tunnel` traffic through localhost Host validation while preserving the public forwarded origin.

--- a/libraries/typescript/packages/cli/src/bin/start.ts
+++ b/libraries/typescript/packages/cli/src/bin/start.ts
@@ -177,7 +177,13 @@ export async function runStart(options: StartOptions): Promise<StartedServer> {
       // eslint-disable-next-line import/no-extraneous-dependencies
       const { createTunnelManager } = await import("@mcp-use/tunnel");
       tunnel = createTunnelManager(
-        join(options.cwd, WORKSPACE_DIR_NAME, "state", "tunnel.json")
+        join(options.cwd, WORKSPACE_DIR_NAME, "state", "tunnel.json"),
+        {
+          // The authenticated tunnel is the public edge. Keep the original
+          // hostname in X-Forwarded-Host while presenting a loopback Host to
+          // the localhost listener's DNS-rebinding protection.
+          localHostHeader: "localhost",
+        }
       );
       const tunnelInfo = await tunnel.start(boundPort);
       const endpoint = new URL(url);

--- a/libraries/typescript/packages/cli/tests/bin-start.test.ts
+++ b/libraries/typescript/packages/cli/tests/bin-start.test.ts
@@ -407,7 +407,8 @@ describe("runStart", () => {
     const started = await runStart({ cwd, port: 0, tunnel: true });
 
     expect(tunnelMocks.create).toHaveBeenCalledWith(
-      join(cwd, ".mcp-use", "state", "tunnel.json")
+      join(cwd, ".mcp-use", "state", "tunnel.json"),
+      { localHostHeader: "localhost" }
     );
     expect(tunnelMocks.start).toHaveBeenCalledWith(started.port);
     expect(started.tunnelUrl).toBe("https://public-test.local.mcp-use.run/mcp");

--- a/libraries/typescript/packages/tunnel/src/index.ts
+++ b/libraries/typescript/packages/tunnel/src/index.ts
@@ -151,6 +151,11 @@ export interface TunnelManagerOptions {
   relayUrl?: string;
   /** Requested stable tunnel identifier. */
   subdomain?: string;
+  /**
+   * Host header presented to the local origin. The public hostname remains
+   * available through `X-Forwarded-Host`. Defaults to the public hostname.
+   */
+  localHostHeader?: string;
 }
 
 const RESPAWN_BACKOFF_INITIAL_MS = 1_000;
@@ -330,6 +335,7 @@ async function releaseTunnel(
 async function connectTunnel(
   port: number,
   reservation: TunnelReservation,
+  localHostHeader: string | undefined,
   onUnexpectedClose: (event: CloseEvent) => void
 ): Promise<TunnelConnection> {
   const socket = new WebSocket(reservation.connect_url);
@@ -374,7 +380,11 @@ async function connectTunnel(
     }
     const headers = sanitizeHeaders(message.headers, true);
     const forwardedHost = message.headers["x-forwarded-host"];
-    if (typeof forwardedHost === "string") headers.host = forwardedHost;
+    if (localHostHeader !== undefined) {
+      headers.host = localHostHeader;
+    } else if (typeof forwardedHost === "string") {
+      headers.host = forwardedHost;
+    }
     const localRequest = http.request({
       hostname: "127.0.0.1",
       port,
@@ -828,7 +838,7 @@ export function createTunnelManager(
     port: number,
     reservation: TunnelReservation
   ): Promise<TunnelConnection> =>
-    connectTunnel(port, reservation, (event) => {
+    connectTunnel(port, reservation, options.localHostHeader, (event) => {
       connection = undefined;
       currentUrl = null;
       const terminal =

--- a/libraries/typescript/packages/tunnel/tests/e2e.test.ts
+++ b/libraries/typescript/packages/tunnel/tests/e2e.test.ts
@@ -58,6 +58,7 @@ describe("WebSocket tunnel end to end", () => {
   let relay: Awaited<ReturnType<typeof createRelayFixture>>;
   let tunnel: TunnelManager;
   let publicUrl: string;
+  let localPort: number;
   let cancelled: Promise<void>;
 
   beforeEach(async () => {
@@ -78,6 +79,17 @@ describe("WebSocket tunnel end to end", () => {
       }
       if (request.url?.startsWith("/concurrent/")) {
         setTimeout(() => response.end(request.url), 5);
+        return;
+      }
+      if (request.url === "/headers") {
+        response.setHeader("content-type", "application/json");
+        response.end(
+          JSON.stringify({
+            host: request.headers.host,
+            forwardedHost: request.headers["x-forwarded-host"],
+            forwardedProto: request.headers["x-forwarded-proto"],
+          })
+        );
         return;
       }
       const chunks: Buffer[] = [];
@@ -118,7 +130,7 @@ describe("WebSocket tunnel end to end", () => {
       });
     });
 
-    const localPort = await listen(local);
+    localPort = await listen(local);
     relay = await createRelayFixture();
     const statePath = join(
       mkdtempSync(join(tmpdir(), "mcp-use-tunnel-e2e-")),
@@ -181,6 +193,36 @@ describe("WebSocket tunnel end to end", () => {
     await expect(
       webSocketExchange(wsUrl, Buffer.from([1, 2, 3]))
     ).resolves.toEqual(Buffer.from([1, 2, 3]));
+  });
+
+  it("can present a loopback Host while preserving the public forwarded origin", async () => {
+    const defaultHeaders = await fetch(`${publicUrl}/headers`).then(
+      async (response) => response.json()
+    );
+    expect(defaultHeaders).toMatchObject({
+      host: new URL(publicUrl).host,
+      forwardedHost: new URL(publicUrl).host,
+      forwardedProto: "http",
+    });
+
+    await tunnel.stop();
+    const statePath = join(
+      mkdtempSync(join(tmpdir(), "mcp-use-tunnel-local-host-e2e-")),
+      "tunnel.json"
+    );
+    tunnel = createTunnelManager(statePath, {
+      relayUrl: relay.relayBase,
+      localHostHeader: "localhost",
+    });
+    ({ url: publicUrl } = await tunnel.start(localPort));
+
+    await expect(
+      fetch(`${publicUrl}/headers`).then(async (response) => response.json())
+    ).resolves.toMatchObject({
+      host: "localhost",
+      forwardedHost: new URL(publicUrl).host,
+      forwardedProto: "http",
+    });
   });
 
   it("releases the authenticated reservation during graceful shutdown", async () => {

--- a/libraries/typescript/packages/tunnel/tests/relay-fixture.ts
+++ b/libraries/typescript/packages/tunnel/tests/relay-fixture.ts
@@ -148,9 +148,17 @@ export async function createRelayFixture(): Promise<{
           requestId,
           method: request.method ?? "GET",
           path: `${match[1] ?? "/"}${url.search}`,
-          headers: Object.fromEntries(
-            Object.entries(request.headers).filter(([name]) => name !== "host")
-          ),
+          headers: {
+            ...Object.fromEntries(
+              Object.entries(request.headers).filter(
+                ([name]) => name !== "host"
+              )
+            ),
+            ...(request.headers.host !== undefined && {
+              "x-forwarded-host": request.headers.host,
+            }),
+            "x-forwarded-proto": "http",
+          },
         })
       );
       for await (const chunk of request) {


### PR DESCRIPTION
## Summary

- preserve the public origin in forwarded headers while presenting a loopback Host to production localhost listeners
- opt in only from `mcp-use start --tunnel`; standalone tunnel and dev behavior remain unchanged
- add tunnel transport and CLI wiring regression coverage
- add patch changesets for `@mcp-use/cli` and `@mcp-use/tunnel`

## Root cause

`start --tunnel` mounted localhost Host validation before allocating the public tunnel. The authenticated tunnel then forwarded its public Host to the local listener, which correctly rejected it with HTTP 403.

## Validation

- full TypeScript workspace build
- full CLI suite: 22 files, 279 tests
- tunnel suite: 3 files, 13 tests
- workspace lint
- packed release-install verification (68.2 MiB, no dependency additions)
- live production relay: public initialize, tools/list, and tools/call through `start --tunnel`
- standalone multi-frame/bodyless/WebSocket/keepalive tunnel coverage remains green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes production tunnel host forwarding in `mcp-use start --tunnel`. The tunnel now keeps the public origin in `X-Forwarded-Host` while sending `Host: localhost` to the local server so Host validation passes.

- **Bug Fixes**
  - Added optional `localHostHeader` to `@mcp-use/tunnel`; `@mcp-use/cli` sets it to "localhost" only for `start --tunnel`.
  - Local listener sees `Host: localhost`; public host remains in `X-Forwarded-Host`.
  - Added e2e and CLI coverage; standalone tunnel and dev behavior unchanged.

<sup>Written for commit ebecac9cb4ec86802680fa4610e14e305d1afc09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

