### PR TITLE
fix(create-app): sanitize the npm name for named projects, not just "."

### DIFF
--- a/libraries/typescript/.changeset/tidy-pumas-smoke.md
+++ b/libraries/typescript/.changeset/tidy-pumas-smoke.md
@@ -1,0 +1,5 @@
+---
+"create-mcp-use-app": patch
+---
+
+Sanitize the npm package name for named projects, not just `.`. A name like `My "App"` was written verbatim into the template's `index.ts`, producing invalid TypeScript.

--- a/libraries/typescript/packages/create-mcp-use-app/src/__tests__/dot-directory.test.ts
+++ b/libraries/typescript/packages/create-mcp-use-app/src/__tests__/dot-directory.test.ts
@@ -149,6 +149,15 @@ describe("deriveProjectInfo", () => {
     expect(info.displayName).toBe("my-app");
     expect(info.packageName).toBe("my-app");
   });
+
+  it("sanitizes a named project too, keeping the directory as typed", () => {
+    // Only the "." branch used to sanitize, so `create-mcp-use-app 'My "App"'`
+    // put the raw name straight into index.ts and produced invalid TypeScript.
+    const info = deriveProjectInfo('My "App"', "/tmp");
+    expect(info.projectPath).toBe(resolve("/tmp", 'My "App"'));
+    expect(info.displayName).toBe('My "App"');
+    expect(info.packageName).toBe("my--app");
+  });
 });
 
 // End-to-end: simulates the actual file-mutation step the CLI runs against a

--- a/libraries/typescript/packages/create-mcp-use-app/src/utils.ts
+++ b/libraries/typescript/packages/create-mcp-use-app/src/utils.ts
@@ -84,8 +84,10 @@ export function deriveProjectInfo(rawName: string, cwd: string): ProjectInfo {
   return {
     useCurrentDir: false,
     projectPath: resolve(cwd, name),
+    // The directory keeps the name as typed; only the npm identifier is
+    // sanitized, matching how the "." branch above treats the cwd basename.
     displayName: name,
-    packageName: name,
+    packageName: sanitizePackageName(name),
   };
 }
 


### PR DESCRIPTION
### The defect

`deriveProjectInfo` only sanitizes on the `.` branch. A named project returns the raw argument as `packageName`:

```ts
return {
  useCurrentDir: false,
  projectPath: resolve(cwd, name),
  displayName: name,
  packageName: name,   // never sanitized
};
```

That value is what `index.ts` flows into `updatePackageJson` and `updateIndexTs`, so it lands in `package.json` and is substituted for `{{PROJECT_NAME}}` inside a double-quoted string literal in the template's `index.ts`.

The CLI does validate named projects, but only for path separators, `..` and a short list of protected names. Spaces, quotes and capitals all pass.

### The evidence

Running the real functions on `canary` before the change:

```
input "My \"App\"" -> packageName "My \"App\""
   index.ts: name: "My "App"",
input "My App"     -> packageName "My App"
input "MyApp"      -> packageName "MyApp"
```

The first one is not valid TypeScript, so the generated project fails to compile. The other two are valid TypeScript but invalid npm names, and `npm install` rejects them.

The `.` branch is already guarded against exactly this, by a regression test noting that a raw name "produced `name: "My "App""` in index.ts, invalid TypeScript". The named branch never got the same treatment.

### The fix

Sanitize on both branches. The directory keeps the name as typed, only the npm identifier is normalized, which is what the `.` branch already does with the cwd basename.

After:

```
input "My \"App\"" -> packageName "my--app"
input "My App"     -> packageName "my-app"
input "MyApp"      -> packageName "myapp"
```

One test added alongside the existing `deriveProjectInfo` cases. `create-mcp-use-app` suite is 26/26 green.

Targeting `canary` since this is published package source.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitize npm package names for named projects in `create-mcp-use-app`, not just the `.` case. This prevents invalid TypeScript in the template `index.ts` and npm errors when names include spaces, quotes, or capitals.

- **Bug Fixes**
  - Sanitize `packageName` in both branches of `deriveProjectInfo`; directory name and `displayName` stay as typed.
  - Example: input `My "App"` now yields `packageName: "my--app"` instead of writing the raw string into `index.ts`.
  - Added a unit test for named projects.

<sup>Written for commit a13db8a4a306e4cfeabb76df1f9887aaca9de36d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

