### PR TITLE
docs: repoint dead OAuth example links and drop a leaked docs preview domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Ship to [Manufact](https://manufact.com) and get observability, analytics, evals
 npm run deploy
 ```
 
-Prefer to run it yourself? Follow the [self-hosting guide →](https://mcpuse-codex-v1-v2-docs-split.mintlify.site/v2/typescript/server/deployment/runtime-patterns).
+Prefer to run it yourself? Follow the [self-hosting guide →](https://docs.mcp-use.com/typescript/server/deployment/runtime-patterns).
 
 ## How mcp-use compares
 

--- a/libraries/typescript/packages/server/README.md
+++ b/libraries/typescript/packages/server/README.md
@@ -269,7 +269,7 @@ Ship to [Manufact](https://manufact.com) and get observability, analytics, evals
 npm run deploy
 ```
 
-Prefer to run it yourself? Follow the [self-hosting guide →](https://mcpuse-codex-v1-v2-docs-split.mintlify.site/v2/typescript/server/deployment/runtime-patterns).
+Prefer to run it yourself? Follow the [self-hosting guide →](https://docs.mcp-use.com/typescript/server/deployment/runtime-patterns).
 
 ## How mcp-use compares
 

--- a/skills/chatgpt-app-builder/references/authentication/auth0.md
+++ b/skills/chatgpt-app-builder/references/authentication/auth0.md
@@ -5,7 +5,7 @@ Setting up OAuth with Auth0. Two modes depending on whether you have access to A
 - **DCR (built-in)** → use `oauthAuth0Provider`. Requires Auth0's Early Access program.
 - **OAuth proxy** → use `oauthProxy` + `jwksVerifier` with a standard Auth0 Regular Web App. No Early Access required.
 
-**Learn more:** [Auth0 MCP Authorization Guide](https://auth0.com/ai/docs/mcp/get-started/authorization-for-your-mcp-server) · [Standalone starter template](https://github.com/mcp-use/mcp-oauth-auth0-template) · [Runnable DCR example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/auth0) · [Runnable proxy example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/auth0-proxy)
+**Learn more:** [Auth0 MCP Authorization Guide](https://auth0.com/ai/docs/mcp/get-started/authorization-for-your-mcp-server) · [Standalone starter template](https://github.com/mcp-use/mcp-oauth-auth0-template) · [Runnable DCR example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/auth/auth0) · [Runnable proxy example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/auth0-proxy)
 
 ---
 

--- a/skills/chatgpt-app-builder/references/authentication/better-auth.md
+++ b/skills/chatgpt-app-builder/references/authentication/better-auth.md
@@ -2,7 +2,7 @@
 
 Setting up a self-hosted OAuth 2.1 authorization server with Better Auth.
 
-**Learn more:** [Better Auth OAuth Provider Plugin](https://better-auth.com/docs/plugins/oauth-provider) · [Standalone starter template](https://github.com/mcp-use/mcp-oauth-better-auth-template) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/better-auth)
+**Learn more:** [Better Auth OAuth Provider Plugin](https://better-auth.com/docs/plugins/oauth-provider) · [Standalone starter template](https://github.com/mcp-use/mcp-oauth-better-auth-template) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/auth/better-auth)
 
 > Covers the `@better-auth/oauth-provider` plugin. The older Better Auth MCP plugin is deprecated — for legacy users, see the [mcp-use adapter](https://better-auth.com/docs/plugins/mcp#framework-adapters).
 
@@ -129,7 +129,7 @@ Better Auth requires a `/sign-in` page and a `/consent` page mounted on the Hono
 - **Consent page:** POST to `/api/auth/oauth2/consent` with `{ accept: boolean, oauth_query: window.location.search.slice(1) }`.
 - Both must use `credentials: 'include'` on fetch calls.
 
-See the [runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/better-auth) for complete HTML/JS.
+See the [runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/auth/better-auth) for complete HTML/JS.
 
 ---
 

--- a/skills/chatgpt-app-builder/references/authentication/clerk.md
+++ b/skills/chatgpt-app-builder/references/authentication/clerk.md
@@ -2,7 +2,7 @@
 
 Setting up OAuth with Clerk. DCR mode only — MCP clients register themselves directly with Clerk via Dynamic Client Registration; the MCP server only verifies the resulting JWTs against Clerk's JWKS.
 
-**Learn more:** [Clerk OAuth Docs](https://clerk.com/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/clerk)
+**Learn more:** [Clerk OAuth Docs](https://clerk.com/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/auth/clerk)
 
 ---
 

--- a/skills/chatgpt-app-builder/references/authentication/keycloak.md
+++ b/skills/chatgpt-app-builder/references/authentication/keycloak.md
@@ -2,7 +2,7 @@
 
 Setting up OAuth with Keycloak. Keycloak exposes full OAuth 2.1 + OIDC endpoints on every realm, including native [Dynamic Client Registration](https://www.keycloak.org/securing-apps/client-registration) (RFC 7591). MCP clients discover Keycloak via `.well-known` metadata, register themselves, complete a PKCE flow, and send the access token as a bearer on MCP requests — **the MCP server only verifies the JWT against Keycloak's JWKS**.
 
-**Learn more:** [Keycloak Documentation](https://www.keycloak.org/documentation) · [Keycloak DCR](https://www.keycloak.org/securing-apps/client-registration) · [Standalone starter template](https://github.com/mcp-use/mcp-oauth-keycloak-template) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/keycloak)
+**Learn more:** [Keycloak Documentation](https://www.keycloak.org/documentation) · [Keycloak DCR](https://www.keycloak.org/securing-apps/client-registration) · [Standalone starter template](https://github.com/mcp-use/mcp-oauth-keycloak-template) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/auth/keycloak)
 
 ---
 

--- a/skills/chatgpt-app-builder/references/authentication/supabase.md
+++ b/skills/chatgpt-app-builder/references/authentication/supabase.md
@@ -4,7 +4,7 @@ Setting up OAuth with Supabase's OAuth 2.1 server. Supabase hosts `/authorize`, 
 
 **You host the consent UI.** Supabase redirects the browser to a URL you configure, and your route uses the Supabase JS SDK to load authorization details, render sign-in + consent, and submit the decision back to Supabase. mcp-use is not involved in that step — follow Supabase's [OAuth Server — Getting Started guide](https://supabase.com/docs/guides/auth/oauth-server/getting-started).
 
-**Learn more:** [Supabase OAuth Server — MCP Authentication](https://supabase.com/docs/guides/auth/oauth-server/mcp-authentication) · [Standalone starter template](https://github.com/mcp-use/mcp-oauth-supabase-template) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/supabase)
+**Learn more:** [Supabase OAuth Server — MCP Authentication](https://supabase.com/docs/guides/auth/oauth-server/mcp-authentication) · [Standalone starter template](https://github.com/mcp-use/mcp-oauth-supabase-template) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/auth/supabase)
 
 > This targets Supabase's **OAuth 2.1 server** — a different feature from Supabase Auth's social logins. Enable it explicitly in the dashboard under **Authentication → OAuth Server**.
 
@@ -124,7 +124,7 @@ Supabase redirects the browser to the consent screen URL you configured. Your ro
 3. Render approve/deny UI
 4. Submit the decision back to Supabase and redirect to the resulting URL
 
-Follow Supabase's [OAuth Server — Getting Started guide](https://supabase.com/docs/guides/auth/oauth-server/getting-started) for the canonical implementation. See the [runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/supabase) for a wired-up version (look at `auth-routes.ts`).
+Follow Supabase's [OAuth Server — Getting Started guide](https://supabase.com/docs/guides/auth/oauth-server/getting-started) for the canonical implementation. See the [runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/auth/supabase) for a wired-up version (look at `auth-routes.ts`).
 
 ---
 

--- a/skills/chatgpt-app-builder/references/authentication/workos.md
+++ b/skills/chatgpt-app-builder/references/authentication/workos.md
@@ -2,7 +2,7 @@
 
 Setting up OAuth with WorkOS AuthKit. DCR mode only — MCP clients register themselves directly with WorkOS; the MCP server just verifies the resulting tokens.
 
-**Learn more:** [WorkOS AuthKit MCP docs](https://workos.com/docs/authkit/mcp) · [Standalone starter template](https://github.com/mcp-use/mcp-oauth-workos-template) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/workos)
+**Learn more:** [WorkOS AuthKit MCP docs](https://workos.com/docs/authkit/mcp) · [Standalone starter template](https://github.com/mcp-use/mcp-oauth-workos-template) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/auth/workos)
 
 ---
 

--- a/skills/mcp-builder/references/authentication/auth0.md
+++ b/skills/mcp-builder/references/authentication/auth0.md
@@ -5,7 +5,7 @@ Setting up OAuth with Auth0. Two modes depending on whether you have access to A
 - **DCR (built-in)** → use `oauthAuth0Provider`. Requires Auth0's Early Access program.
 - **OAuth proxy** → use `oauthProxy` + `jwksVerifier` with a standard Auth0 Regular Web App. No Early Access required.
 
-**Learn more:** [Auth0 MCP Authorization Guide](https://auth0.com/ai/docs/mcp/get-started/authorization-for-your-mcp-server) · [Standalone starter template](https://github.com/mcp-use/mcp-oauth-auth0-template) · [Runnable DCR example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/auth0) · [Runnable proxy example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/auth0-proxy)
+**Learn more:** [Auth0 MCP Authorization Guide](https://auth0.com/ai/docs/mcp/get-started/authorization-for-your-mcp-server) · [Standalone starter template](https://github.com/mcp-use/mcp-oauth-auth0-template) · [Runnable DCR example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/auth/auth0) · [Runnable proxy example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/auth0-proxy)
 
 ---
 

--- a/skills/mcp-builder/references/authentication/better-auth.md
+++ b/skills/mcp-builder/references/authentication/better-auth.md
@@ -2,7 +2,7 @@
 
 Setting up a self-hosted OAuth 2.1 authorization server with Better Auth.
 
-**Learn more:** [Better Auth OAuth Provider Plugin](https://better-auth.com/docs/plugins/oauth-provider) · [Standalone starter template](https://github.com/mcp-use/mcp-oauth-better-auth-template) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/better-auth)
+**Learn more:** [Better Auth OAuth Provider Plugin](https://better-auth.com/docs/plugins/oauth-provider) · [Standalone starter template](https://github.com/mcp-use/mcp-oauth-better-auth-template) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/auth/better-auth)
 
 > Covers the `@better-auth/oauth-provider` plugin. The older Better Auth MCP plugin is deprecated — for legacy users, see the [mcp-use adapter](https://better-auth.com/docs/plugins/mcp#framework-adapters).
 
@@ -129,7 +129,7 @@ Better Auth requires a `/sign-in` page and a `/consent` page mounted on the Hono
 - **Consent page:** POST to `/api/auth/oauth2/consent` with `{ accept: boolean, oauth_query: window.location.search.slice(1) }`.
 - Both must use `credentials: 'include'` on fetch calls.
 
-See the [runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/better-auth) for complete HTML/JS.
+See the [runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/auth/better-auth) for complete HTML/JS.
 
 ---
 

--- a/skills/mcp-builder/references/authentication/clerk.md
+++ b/skills/mcp-builder/references/authentication/clerk.md
@@ -2,7 +2,7 @@
 
 Setting up OAuth with Clerk. DCR mode only — MCP clients register themselves directly with Clerk via Dynamic Client Registration; the MCP server only verifies the resulting JWTs against Clerk's JWKS.
 
-**Learn more:** [Clerk OAuth Docs](https://clerk.com/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/clerk)
+**Learn more:** [Clerk OAuth Docs](https://clerk.com/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/auth/clerk)
 
 ---
 

--- a/skills/mcp-builder/references/authentication/keycloak.md
+++ b/skills/mcp-builder/references/authentication/keycloak.md
@@ -2,7 +2,7 @@
 
 Setting up OAuth with Keycloak. Keycloak exposes full OAuth 2.1 + OIDC endpoints on every realm, including native [Dynamic Client Registration](https://www.keycloak.org/securing-apps/client-registration) (RFC 7591). MCP clients discover Keycloak via `.well-known` metadata, register themselves, complete a PKCE flow, and send the access token as a bearer on MCP requests — **the MCP server only verifies the JWT against Keycloak's JWKS**.
 
-**Learn more:** [Keycloak Documentation](https://www.keycloak.org/documentation) · [Keycloak DCR](https://www.keycloak.org/securing-apps/client-registration) · [Standalone starter template](https://github.com/mcp-use/mcp-oauth-keycloak-template) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/keycloak)
+**Learn more:** [Keycloak Documentation](https://www.keycloak.org/documentation) · [Keycloak DCR](https://www.keycloak.org/securing-apps/client-registration) · [Standalone starter template](https://github.com/mcp-use/mcp-oauth-keycloak-template) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/auth/keycloak)
 
 ---
 

--- a/skills/mcp-builder/references/authentication/supabase.md
+++ b/skills/mcp-builder/references/authentication/supabase.md
@@ -4,7 +4,7 @@ Setting up OAuth with Supabase's OAuth 2.1 server. Supabase hosts `/authorize`, 
 
 **You host the consent UI.** Supabase redirects the browser to a URL you configure, and your route uses the Supabase JS SDK to load authorization details, render sign-in + consent, and submit the decision back to Supabase. mcp-use is not involved in that step — follow Supabase's [OAuth Server — Getting Started guide](https://supabase.com/docs/guides/auth/oauth-server/getting-started).
 
-**Learn more:** [Supabase OAuth Server — MCP Authentication](https://supabase.com/docs/guides/auth/oauth-server/mcp-authentication) · [Standalone starter template](https://github.com/mcp-use/mcp-oauth-supabase-template) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/supabase)
+**Learn more:** [Supabase OAuth Server — MCP Authentication](https://supabase.com/docs/guides/auth/oauth-server/mcp-authentication) · [Standalone starter template](https://github.com/mcp-use/mcp-oauth-supabase-template) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/auth/supabase)
 
 > This targets Supabase's **OAuth 2.1 server** — a different feature from Supabase Auth's social logins. Enable it explicitly in the dashboard under **Authentication → OAuth Server**.
 
@@ -124,7 +124,7 @@ Supabase redirects the browser to the consent screen URL you configured. Your ro
 3. Render approve/deny UI
 4. Submit the decision back to Supabase and redirect to the resulting URL
 
-Follow Supabase's [OAuth Server — Getting Started guide](https://supabase.com/docs/guides/auth/oauth-server/getting-started) for the canonical implementation. See the [runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/supabase) for a wired-up version (look at `auth-routes.ts`).
+Follow Supabase's [OAuth Server — Getting Started guide](https://supabase.com/docs/guides/auth/oauth-server/getting-started) for the canonical implementation. See the [runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/auth/supabase) for a wired-up version (look at `auth-routes.ts`).
 
 ---
 

--- a/skills/mcp-builder/references/authentication/workos.md
+++ b/skills/mcp-builder/references/authentication/workos.md
@@ -2,7 +2,7 @@
 
 Setting up OAuth with WorkOS AuthKit. DCR mode only — MCP clients register themselves directly with WorkOS; the MCP server just verifies the resulting tokens.
 
-**Learn more:** [WorkOS AuthKit MCP docs](https://workos.com/docs/authkit/mcp) · [Standalone starter template](https://github.com/mcp-use/mcp-oauth-workos-template) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/mcp-use/examples/server/oauth/workos)
+**Learn more:** [WorkOS AuthKit MCP docs](https://workos.com/docs/authkit/mcp) · [Standalone starter template](https://github.com/mcp-use/mcp-oauth-workos-template) · [Runnable example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/auth/workos)
 
 ---
 


### PR DESCRIPTION
### The defect

Two separate causes behind 14 of the 24 errors in #2210.

**1. Dead v1 example paths (12 links).** The skills auth references link runnable examples at:

```
libraries/typescript/packages/mcp-use/examples/server/oauth/<provider>
```

`packages/mcp-use` was deleted in the v2 restructure. Those examples now live at `libraries/typescript/packages/server/examples/auth/<provider>`. Each provider appears twice because `skills/chatgpt-app-builder` and `skills/mcp-builder` carry duplicate copies of these reference files.

Verified every replacement target returns 200 on GitHub: `auth0`, `better-auth`, `clerk`, `keycloak`, `supabase`, `workos`.

**2. A leaked docs preview domain (2 links).** `README.md` and `libraries/typescript/packages/server/README.md`, both line 272, pointed the self-hosting guide at:

```
https://mcpuse-codex-v1-v2-docs-split.mintlify.site/v2/typescript/server/deployment/runtime-patterns
```

That is a Mintlify preview deployment, and it 404s. The server README is published with the `mcp-use` package, so this shipped to npm.

The replacement is `https://docs.mcp-use.com/typescript/server/deployment/runtime-patterns`, which I verified returns 200. Note that I did not use a `/v2/` prefix here on purpose: `/v2/typescript/server/deployment/runtime-patterns` and `/v2/typescript/server/deployment/vercel` are both 404, while `/v2/typescript/server/migration` and `/v2/typescript/getting-started/welcome` are both 200. The deployment pages appear to be reachable only unprefixed, so I used the form I could verify rather than guessing. If the `/v2/` routes are supposed to exist for deployment pages, that is a docs-site routing gap and this link should change once they do.

### What I deliberately left alone

4 links point at `oauth/auth0-proxy`, which has no v2 counterpart: there is no `auth0-proxy` directory under `packages/server/examples/auth`, and the URL 404s. Guessing a target would be worse than leaving it, so those stay broken pending a call on whether to drop the references, point them at the plain `auth0` example, or restore the example. Itemized in #2210.

The other 2 errors are not real. `https://dashboard.clerk.com/` is a live app behind auth that answers 404 to curl, and the `index.html` `/favicon-black.svg?v=4` error is lychee failing to resolve a root-relative link in a local HTML file, which is correct at runtime.

Markdown only, no code changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 14 broken docs links by pointing OAuth example URLs at the v2 examples and replacing a leaked Mintlify preview with the live self‑hosting guide. Aligns docs with the current repository structure.

- **Bug Fixes**
  - Repointed OAuth example links to `libraries/typescript/packages/server/examples/auth/<provider>` for Auth0, Better Auth, Clerk, Keycloak, Supabase, and WorkOS (12 links) in `skills/chatgpt-app-builder` and `skills/mcp-builder`.
  - Updated self-hosting guide in `README.md` and `libraries/typescript/packages/server/README.md` to https://docs.mcp-use.com/typescript/server/deployment/runtime-patterns (2 links).
  - Left `auth0-proxy` example links unchanged; no v2 example exists.

<sup>Written for commit 71981b8134c0702607019117f03d771e01ac285d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

