### PR TITLE
fix(client): make v2 readiness immediate through proxies

### DIFF
--- a/libraries/typescript/.changeset/quick-sse-proxy.md
+++ b/libraries/typescript/.changeset/quick-sse-proxy.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Disable reverse-proxy buffering for open-ended MCP SSE responses so v2 subscription acknowledgements reach clients immediately.

--- a/libraries/typescript/.changeset/quick-sse-proxy.md
+++ b/libraries/typescript/.changeset/quick-sse-proxy.md
@@ -1,5 +1,7 @@
 ---
 "@mcp-use/inspector": patch
+"@mcp-use/client": patch
+"@mcp-use/cli": patch
 ---
 
-Disable reverse-proxy buffering for open-ended MCP SSE responses so v2 subscription acknowledgements reach clients immediately.
+Disable reverse-proxy buffering for open-ended MCP SSE responses so v2 subscription acknowledgements reach clients immediately, and move optional mixed-auth discovery off the connection readiness path while preserving asynchronous React updates and CLI reporting.

--- a/libraries/typescript/packages/cli/src/commands/client.ts
+++ b/libraries/typescript/packages/cli/src/commands/client.ts
@@ -126,6 +126,9 @@ async function connect(
     json,
     `mcp-use client connect ${name} <url> --no-open`
   );
+  // The interactive CLI exits after reporting the connection, so wait for the
+  // optional classification here even though browser clients update lazily.
+  await connection.discoverAuthorization();
   const authorization = connection.authorization;
   await connection.disconnect();
   saved.servers[name] = definition;

--- a/libraries/typescript/packages/cli/tests/commands/client.test.ts
+++ b/libraries/typescript/packages/cli/tests/commands/client.test.ts
@@ -55,6 +55,7 @@ const connection = {
       }
     | undefined,
   callTool: vi.fn(),
+  discoverAuthorization: vi.fn(),
   disconnect: vi.fn(),
   getPrompt: vi.fn(),
   listPrompts: vi.fn(),
@@ -97,6 +98,9 @@ beforeEach(async () => {
   connection.callTool.mockResolvedValue({
     content: [{ type: "text", text: "called" }],
   });
+  connection.discoverAuthorization.mockImplementation(
+    async () => connection.authorization
+  );
   connection.authenticate.mockResolvedValue(undefined);
   connection.authorization = undefined;
   connection.disconnect.mockResolvedValue(undefined);

--- a/libraries/typescript/packages/client/src/core/session.ts
+++ b/libraries/typescript/packages/client/src/core/session.ts
@@ -364,6 +364,11 @@ export class MCPConnection {
     return this.connector.authorization;
   }
 
+  /** Discover optional OAuth metadata without delaying MCP readiness. */
+  async discoverAuthorization(): Promise<MCPAuthorizationInfo | undefined> {
+    return this.connector.discoverAuthorization();
+  }
+
   /** Authenticate an already-connected mixed-auth server. */
   async authenticate(): Promise<void> {
     await this.connector.authenticate();

--- a/libraries/typescript/packages/client/src/react/useMcp.ts
+++ b/libraries/typescript/packages/client/src/react/useMcp.ts
@@ -1238,14 +1238,28 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
 
         successfulTransportRef.current = transportTypeParam;
         setState("ready");
-        const authorizationDiscovery = connection.discoverAuthorization?.();
-        if (authorizationDiscovery) {
-          void authorizationDiscovery.then((discovered) => {
-            if (!discovered || !isMountedRef.current) return;
-            authorizationRef.current = discovered;
-            setAuthorization(discovered);
-          });
-        }
+        // Optional OAuth metadata is not part of anonymous MCP readiness. Give
+        // React a chance to paint the ready state before starting its network
+        // fallbacks, which may legitimately return 404 for public servers.
+        setTimeout(() => {
+          if (!isMountedRef.current || connectionRef.current !== connection) {
+            return;
+          }
+          const authorizationDiscovery = connection.discoverAuthorization?.();
+          if (authorizationDiscovery) {
+            void authorizationDiscovery.then((discovered) => {
+              if (
+                !discovered ||
+                !isMountedRef.current ||
+                connectionRef.current !== connection
+              ) {
+                return;
+              }
+              authorizationRef.current = discovered;
+              setAuthorization(discovered);
+            });
+          }
+        }, 0);
         return "success";
       } catch (err: unknown) {
         const error = err as Error & { code?: number; message?: string };

--- a/libraries/typescript/packages/client/src/react/useMcp.ts
+++ b/libraries/typescript/packages/client/src/react/useMcp.ts
@@ -1238,11 +1238,14 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
 
         successfulTransportRef.current = transportTypeParam;
         setState("ready");
-        void connection.discoverAuthorization().then((discovered) => {
-          if (!discovered || !isMountedRef.current) return;
-          authorizationRef.current = discovered;
-          setAuthorization(discovered);
-        });
+        const authorizationDiscovery = connection.discoverAuthorization?.();
+        if (authorizationDiscovery) {
+          void authorizationDiscovery.then((discovered) => {
+            if (!discovered || !isMountedRef.current) return;
+            authorizationRef.current = discovered;
+            setAuthorization(discovered);
+          });
+        }
         return "success";
       } catch (err: unknown) {
         const error = err as Error & { code?: number; message?: string };

--- a/libraries/typescript/packages/client/src/react/useMcp.ts
+++ b/libraries/typescript/packages/client/src/react/useMcp.ts
@@ -1241,7 +1241,7 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
         // Optional OAuth metadata is not part of anonymous MCP readiness. Give
         // React a chance to paint the ready state before starting its network
         // fallbacks, which may legitimately return 404 for public servers.
-        setTimeout(() => {
+        const discoverAuthorizationAfterReady = () => {
           if (!isMountedRef.current || connectionRef.current !== connection) {
             return;
           }
@@ -1259,7 +1259,14 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
               setAuthorization(discovered);
             });
           }
-        }, 0);
+        };
+        if (typeof globalThis.requestAnimationFrame === "function") {
+          globalThis.requestAnimationFrame(() => {
+            setTimeout(discoverAuthorizationAfterReady, 0);
+          });
+        } else {
+          setTimeout(discoverAuthorizationAfterReady, 0);
+        }
         return "success";
       } catch (err: unknown) {
         const error = err as Error & { code?: number; message?: string };

--- a/libraries/typescript/packages/client/src/react/useMcp.ts
+++ b/libraries/typescript/packages/client/src/react/useMcp.ts
@@ -1238,6 +1238,11 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
 
         successfulTransportRef.current = transportTypeParam;
         setState("ready");
+        void connection.discoverAuthorization().then((discovered) => {
+          if (!discovered || !isMountedRef.current) return;
+          authorizationRef.current = discovered;
+          setAuthorization(discovered);
+        });
         return "success";
       } catch (err: unknown) {
         const error = err as Error & { code?: number; message?: string };

--- a/libraries/typescript/packages/client/src/react/useMcp.ts
+++ b/libraries/typescript/packages/client/src/react/useMcp.ts
@@ -1068,6 +1068,77 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
 
         // Get tools, resources, and prompts through the protocol-neutral connection.
         setTools(connection.tools || []);
+
+        const {
+          server: serverInfo,
+          capabilities,
+          protocolEra,
+          protocolVersion,
+          instructions,
+          extensions,
+          authorization: connectionAuthorization,
+        } = connection.info;
+
+        if (connectionAuthorization) {
+          setAuthorization(connectionAuthorization);
+          authorizationRef.current = connectionAuthorization;
+        }
+        setProtocolEra(protocolEra);
+        setProtocolVersion(protocolVersion);
+        setInstructions(instructions);
+        setExtensions(extensions);
+
+        if (serverInfo) {
+          addLog("debug", "Server info:", serverInfo);
+          setServerInfo(serverInfo);
+          iconLoadingPromiseRef.current = loadServerIcon({
+            serverInfo,
+            url,
+            isMounted: () => isMountedRef.current,
+            setServerInfo,
+            addLog,
+          });
+        }
+        if (capabilities) {
+          addLog("debug", "Server capabilities:", capabilities);
+          setCapabilities(capabilities);
+        }
+
+        // Tools and normalized connection metadata are sufficient for a usable
+        // connection. Auxiliary inventories must populate progressively rather
+        // than extending the ready-state critical path.
+        successfulTransportRef.current = transportTypeParam;
+        setState("ready");
+        // Optional OAuth metadata is not part of anonymous MCP readiness. Give
+        // React a chance to paint the ready state before starting its network
+        // fallbacks, which may legitimately return 404 for public servers.
+        const discoverAuthorizationAfterReady = () => {
+          if (!isMountedRef.current || connectionRef.current !== connection) {
+            return;
+          }
+          const authorizationDiscovery = connection.discoverAuthorization?.();
+          if (authorizationDiscovery) {
+            void authorizationDiscovery.then((discovered) => {
+              if (
+                !discovered ||
+                !isMountedRef.current ||
+                connectionRef.current !== connection
+              ) {
+                return;
+              }
+              authorizationRef.current = discovered;
+              setAuthorization(discovered);
+            });
+          }
+        };
+        if (typeof globalThis.requestAnimationFrame === "function") {
+          globalThis.requestAnimationFrame(() => {
+            setTimeout(discoverAuthorizationAfterReady, 0);
+          });
+        } else {
+          setTimeout(discoverAuthorizationAfterReady, 0);
+        }
+
         // Capability advertisements in the wild are not always granular: a
         // server may support resources/list while returning Method not found
         // for resources/templates/list. Inventory failures must not tear down
@@ -1104,27 +1175,8 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
         setPrompts(promptsResult.prompts || []);
         setResourceTemplates(templatesResult.resourceTemplates || []);
 
-        const {
-          server: serverInfo,
-          capabilities,
-          protocolEra,
-          protocolVersion,
-          instructions,
-          extensions,
-          authorization: connectionAuthorization,
-        } = connection.info;
-
-        if (connectionAuthorization) {
-          setAuthorization(connectionAuthorization);
-          authorizationRef.current = connectionAuthorization;
-        }
-
-        // Surface normalized metadata identically for v1 and v2 servers.
+        // Skills are another auxiliary inventory and populate progressively.
         if (isMountedRef.current) {
-          setProtocolEra(protocolEra);
-          setProtocolVersion(protocolVersion);
-          setInstructions(instructions);
-          setExtensions(extensions);
           if (extensions["io.modelcontextprotocol/skills"] !== undefined) {
             try {
               const result = await connection.listAllSkills();
@@ -1136,32 +1188,6 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
           } else {
             setSkills([]);
           }
-        }
-
-        if (serverInfo) {
-          addLog("debug", "Server info:", serverInfo);
-          if (!isMountedRef.current) {
-            addLog("debug", "Skipping state update - component unmounted");
-            return "failed";
-          }
-          setServerInfo(serverInfo);
-
-          iconLoadingPromiseRef.current = loadServerIcon({
-            serverInfo,
-            url,
-            isMounted: () => isMountedRef.current,
-            setServerInfo,
-            addLog,
-          });
-        }
-
-        if (capabilities) {
-          addLog("debug", "Server capabilities:", capabilities);
-          if (!isMountedRef.current) {
-            addLog("debug", "Skipping state update - component unmounted");
-            return "failed";
-          }
-          setCapabilities(capabilities);
         }
 
         // Get OAuth tokens if authentication was used
@@ -1236,37 +1262,6 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
           }
         }
 
-        successfulTransportRef.current = transportTypeParam;
-        setState("ready");
-        // Optional OAuth metadata is not part of anonymous MCP readiness. Give
-        // React a chance to paint the ready state before starting its network
-        // fallbacks, which may legitimately return 404 for public servers.
-        const discoverAuthorizationAfterReady = () => {
-          if (!isMountedRef.current || connectionRef.current !== connection) {
-            return;
-          }
-          const authorizationDiscovery = connection.discoverAuthorization?.();
-          if (authorizationDiscovery) {
-            void authorizationDiscovery.then((discovered) => {
-              if (
-                !discovered ||
-                !isMountedRef.current ||
-                connectionRef.current !== connection
-              ) {
-                return;
-              }
-              authorizationRef.current = discovered;
-              setAuthorization(discovered);
-            });
-          }
-        };
-        if (typeof globalThis.requestAnimationFrame === "function") {
-          globalThis.requestAnimationFrame(() => {
-            setTimeout(discoverAuthorizationAfterReady, 0);
-          });
-        } else {
-          setTimeout(discoverAuthorizationAfterReady, 0);
-        }
         return "success";
       } catch (err: unknown) {
         const error = err as Error & { code?: number; message?: string };

--- a/libraries/typescript/packages/client/src/transport/base.ts
+++ b/libraries/typescript/packages/client/src/transport/base.ts
@@ -490,6 +490,14 @@ export abstract class BaseConnector {
     return this.authorizationCache;
   }
 
+  /**
+   * Discover optional authorization metadata without delaying connection
+   * readiness. HTTP connectors override this with RFC 9728 discovery.
+   */
+  async discoverAuthorization(): Promise<MCPAuthorizationInfo | undefined> {
+    return this.authorization;
+  }
+
   /** Start optional OAuth for a connected mixed-auth server. */
   async authenticate(): Promise<void> {
     throw new Error("This connector does not support interactive OAuth");

--- a/libraries/typescript/packages/client/src/transport/http.ts
+++ b/libraries/typescript/packages/client/src/transport/http.ts
@@ -10,6 +10,7 @@ import {
   type VersionNegotiationMode,
 } from "@modelcontextprotocol/client";
 import { completeOAuthFlow, isOAuthInteractionRequired } from "../auth/flow.js";
+import type { MCPAuthorizationInfo } from "../core/session.js";
 import { DialectJsonSchemaValidator } from "../utils/json-schema-validator.js";
 import { logger } from "../utils/logging.js";
 import type { ConnectorInitOptions } from "./base.js";
@@ -219,6 +220,9 @@ export class HttpConnector extends BaseConnector {
   private streamableTransport: StreamableHTTPClientTransport | null = null;
   private hadAccessTokenAtConnect = false;
   private pendingOAuthCompletion: Promise<void> | null = null;
+  private authorizationDiscovery: Promise<
+    MCPAuthorizationInfo | undefined
+  > | null = null;
 
   /**
    * Creates an HTTP connector.
@@ -332,14 +336,33 @@ export class HttpConnector extends BaseConnector {
     defaultRequestOptions = this.opts.defaultRequestOptions ?? {}
   ): ReturnType<BaseConnector["initialize"]> {
     const capabilities = await super.initialize(defaultRequestOptions);
+    // Mixed auth is optional metadata layered on top of a valid anonymous MCP
+    // connection. Start discovery eagerly, but never make connection readiness
+    // wait for well-known fallbacks, proxy latency, or their timeout.
+    void this.discoverAuthorization();
+    return capabilities;
+  }
+
+  override async discoverAuthorization(): Promise<
+    MCPAuthorizationInfo | undefined
+  > {
     if (
       !this.detectMixedAuth ||
       !this.oauthProvider ||
       this.hadAccessTokenAtConnect
     ) {
-      return capabilities;
+      return this.authorizationCache;
     }
 
+    if (this.authorizationDiscovery) return this.authorizationDiscovery;
+
+    this.authorizationDiscovery = this.discoverMixedAuthorization();
+    return this.authorizationDiscovery;
+  }
+
+  private async discoverMixedAuthorization(): Promise<
+    MCPAuthorizationInfo | undefined
+  > {
     const controller = new AbortController();
     let timeout: ReturnType<typeof setTimeout> | undefined;
     const discoveryTimeout = new Promise<never>((_, reject) => {
@@ -381,7 +404,7 @@ export class HttpConnector extends BaseConnector {
     } finally {
       if (timeout) clearTimeout(timeout);
     }
-    return capabilities;
+    return this.authorizationCache;
   }
 
   private buildClientOptions(): ClientOptions {

--- a/libraries/typescript/packages/client/src/transport/http.ts
+++ b/libraries/typescript/packages/client/src/transport/http.ts
@@ -901,5 +901,6 @@ export class HttpConnector extends BaseConnector {
       }
     }
     await super.cleanupResources();
+    this.authorizationDiscovery = null;
   }
 }

--- a/libraries/typescript/packages/client/src/transport/http.ts
+++ b/libraries/typescript/packages/client/src/transport/http.ts
@@ -332,17 +332,6 @@ export class HttpConnector extends BaseConnector {
     await this.completeInteractiveAuthorization();
   }
 
-  override async initialize(
-    defaultRequestOptions = this.opts.defaultRequestOptions ?? {}
-  ): ReturnType<BaseConnector["initialize"]> {
-    const capabilities = await super.initialize(defaultRequestOptions);
-    // Mixed auth is optional metadata layered on top of a valid anonymous MCP
-    // connection. Start discovery eagerly, but never make connection readiness
-    // wait for well-known fallbacks, proxy latency, or their timeout.
-    void this.discoverAuthorization();
-    return capabilities;
-  }
-
   override async discoverAuthorization(): Promise<
     MCPAuthorizationInfo | undefined
   > {

--- a/libraries/typescript/packages/client/tests/unit/client/mixed-auth-integration.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/client/mixed-auth-integration.test.ts
@@ -36,9 +36,14 @@ describe("mixed auth over streamable HTTP", () => {
 
   it("connects anonymously and starts OAuth only when a protected tool returns 401", async () => {
     let origin = "";
+    let releaseMetadata!: () => void;
+    const metadataGate = new Promise<void>((resolve) => {
+      releaseMetadata = resolve;
+    });
     const server = createServer(async (request, response) => {
       const path = new URL(request.url ?? "/", origin).pathname;
       if (path === "/.well-known/oauth-protected-resource/mcp") {
+        await metadataGate;
         json(response, {
           resource: `${origin}/mcp`,
           authorization_servers: [origin],
@@ -140,6 +145,9 @@ describe("mixed auth over streamable HTTP", () => {
 
     await connector.connect();
     await connector.initialize();
+    expect(connector.authorization).toBeUndefined();
+    releaseMetadata();
+    await connector.discoverAuthorization();
 
     expect(connector.tools.map((tool) => tool.name)).toEqual(["protected"]);
     expect(connector.authorization).toMatchObject({

--- a/libraries/typescript/packages/client/tests/unit/client/mixed-auth-integration.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/client/mixed-auth-integration.test.ts
@@ -36,6 +36,7 @@ describe("mixed auth over streamable HTTP", () => {
 
   it("connects anonymously and starts OAuth only when a protected tool returns 401", async () => {
     let origin = "";
+    let metadataRequests = 0;
     let releaseMetadata!: () => void;
     const metadataGate = new Promise<void>((resolve) => {
       releaseMetadata = resolve;
@@ -43,6 +44,7 @@ describe("mixed auth over streamable HTTP", () => {
     const server = createServer(async (request, response) => {
       const path = new URL(request.url ?? "/", origin).pathname;
       if (path === "/.well-known/oauth-protected-resource/mcp") {
+        metadataRequests += 1;
         await metadataGate;
         json(response, {
           resource: `${origin}/mcp`,
@@ -146,8 +148,11 @@ describe("mixed auth over streamable HTTP", () => {
     await connector.connect();
     await connector.initialize();
     expect(connector.authorization).toBeUndefined();
+    expect(metadataRequests).toBe(0);
+    const discovery = connector.discoverAuthorization();
+    await vi.waitFor(() => expect(metadataRequests).toBe(1));
     releaseMetadata();
-    await connector.discoverAuthorization();
+    await discovery;
 
     expect(connector.tools.map((tool) => tool.name)).toEqual(["protected"]);
     expect(connector.authorization).toMatchObject({

--- a/libraries/typescript/packages/client/tests/unit/client/mixed-auth.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/client/mixed-auth.test.ts
@@ -74,6 +74,7 @@ describe("mixed OAuth authorization", () => {
     );
 
     await connector.initialize();
+    await connector.discoverAuthorization();
 
     expect(discoverOAuthProtectedResourceMetadata).toHaveBeenCalledWith(
       "https://mcp.example.com/mcp",

--- a/libraries/typescript/packages/client/tests/unit/client/mixed-auth.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/client/mixed-auth.test.ts
@@ -165,25 +165,39 @@ describe("mixed OAuth authorization", () => {
     expect(finishAuth).not.toHaveBeenCalled();
   });
 
-  it("clears discovered authorization metadata on disconnect", async () => {
+  it("rediscovers authorization metadata after reconnect", async () => {
+    vi.mocked(discoverOAuthProtectedResourceMetadata)
+      .mockResolvedValueOnce({
+        resource: "https://mcp.example.com/first",
+        authorization_servers: ["https://auth.example.com"],
+      })
+      .mockResolvedValueOnce({
+        resource: "https://mcp.example.com/second",
+        authorization_servers: ["https://auth.example.com"],
+      });
     const connector = new HttpConnector("https://mcp.example.com/mcp", {
-      detectMixedAuth: false,
+      authProvider: createProvider(),
     });
     attachConnectedClient(
       connector,
       { getProtocolEra: () => "modern" },
       { finishAuth: vi.fn(async () => {}) }
     );
-    Object.assign(connector as object, {
-      authorizationCache: {
-        mode: "mixed",
-        authenticated: false,
-        resource: "https://mcp.example.com/mcp",
-      },
-    });
 
-    expect(connector.authorization).toBeDefined();
+    await expect(connector.discoverAuthorization()).resolves.toMatchObject({
+      resource: "https://mcp.example.com/first",
+    });
     await connector.disconnect();
     expect(connector.authorization).toBeUndefined();
+
+    attachConnectedClient(
+      connector,
+      { getProtocolEra: () => "modern" },
+      { finishAuth: vi.fn(async () => {}) }
+    );
+    await expect(connector.discoverAuthorization()).resolves.toMatchObject({
+      resource: "https://mcp.example.com/second",
+    });
+    expect(discoverOAuthProtectedResourceMetadata).toHaveBeenCalledTimes(2);
   });
 });

--- a/libraries/typescript/packages/client/tests/unit/react/useMcp-connection-metadata.test.tsx
+++ b/libraries/typescript/packages/client/tests/unit/react/useMcp-connection-metadata.test.tsx
@@ -200,6 +200,29 @@ describe("useMcp connection metadata", () => {
     );
   });
 
+  it("exposes tools before auxiliary inventories finish loading", async () => {
+    let releaseInventories!: () => void;
+    const inventoriesPending = new Promise<void>((resolve) => {
+      releaseInventories = resolve;
+    });
+    const { result } = await renderFor("modern", false, {}, (connection) => {
+      connection.listAllResources.mockImplementation(() =>
+        inventoriesPending.then(() => ({ resources: [] }))
+      );
+      connection.listPrompts.mockImplementation(() =>
+        inventoriesPending.then(() => ({ prompts: [] }))
+      );
+    });
+
+    expect(result.state).toBe("ready");
+    expect(result.tools.map((tool) => tool.name)).toEqual(["echo"]);
+
+    await act(async () => {
+      releaseInventories();
+      await inventoriesPending;
+    });
+  });
+
   it("keeps public tools ready when a protected tool triggers OAuth later", async () => {
     const { result, getResult, connection } = await renderFor("modern");
     authProvider.getLastAttemptedAuthUrl.mockReturnValue(

--- a/libraries/typescript/packages/inspector/src/server/proxy/mcp-proxy.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy/mcp-proxy.ts
@@ -398,6 +398,13 @@ async function proxyResponse(response: Response): Promise<Response> {
     response.headers.get("content-length")
   );
   if (isTrueStream) {
+    // Railway's edge and other reverse proxies may buffer an otherwise valid
+    // SSE response until it closes. MCP v2 subscriptions are intentionally
+    // long-lived, so that turns the immediate subscription acknowledgement
+    // into a connection timeout. Explicitly opt this response out of proxy
+    // buffering while preserving the upstream cache policy.
+    responseHeaders["x-accel-buffering"] = "no";
+    responseHeaders["cache-control"] ??= "no-cache, no-transform";
     return new Response(response.body, {
       status: response.status,
       statusText: response.statusText,

--- a/libraries/typescript/packages/inspector/tests/unit/mcp-proxy-security.test.ts
+++ b/libraries/typescript/packages/inspector/tests/unit/mcp-proxy-security.test.ts
@@ -147,4 +147,41 @@ describe("Inspector MCP proxy request isolation", () => {
     );
     expect(response.headers.get("x-accel-buffering")).toBe("no");
   });
+
+  it("preserves upstream cache policy while disabling SSE buffering", async () => {
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("data: ready\n\n"));
+      },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(
+        async () =>
+          new Response(stream, {
+            headers: {
+              "Cache-Control": "private, no-store",
+              "Content-Type": "text/event-stream",
+            },
+          })
+      )
+    );
+    const app = new Hono();
+    mountMcpProxy(app, {
+      path: "/inspector/api/proxy",
+      enableLogging: false,
+    });
+
+    const response = await app.fetch(
+      new Request(proxyUrl, {
+        headers: {
+          "X-Target-URL": "https://93.184.216.34/mcp",
+        },
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+    expect(response.headers.get("x-accel-buffering")).toBe("no");
+  });
 });

--- a/libraries/typescript/packages/inspector/tests/unit/mcp-proxy-security.test.ts
+++ b/libraries/typescript/packages/inspector/tests/unit/mcp-proxy-security.test.ts
@@ -110,4 +110,41 @@ describe("Inspector MCP proxy request isolation", () => {
     expect(response.status).toBe(204);
     expect(await response.text()).toBe("");
   });
+
+  it("disables reverse-proxy buffering for open-ended SSE responses", async () => {
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("data: ready\n\n"));
+      },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(
+        async () =>
+          new Response(stream, {
+            headers: { "Content-Type": "text/event-stream" },
+          })
+      )
+    );
+    const app = new Hono();
+    mountMcpProxy(app, {
+      path: "/inspector/api/proxy",
+      enableLogging: false,
+    });
+
+    const response = await app.fetch(
+      new Request(proxyUrl, {
+        headers: {
+          "X-Target-URL": "https://93.184.216.34/mcp",
+        },
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("text/event-stream");
+    expect(response.headers.get("cache-control")).toBe(
+      "no-cache, no-transform"
+    );
+    expect(response.headers.get("x-accel-buffering")).toBe("no");
+  });
 });


### PR DESCRIPTION
## Summary
- mark open-ended MCP SSE responses as non-bufferable at the Inspector proxy boundary
- preserve upstream cache policy while supplying safe SSE defaults
- add a regression test for the streaming response headers

## Root cause
The MCP v2 client correctly negotiates with `server/discover`, then subscribes to advertised list-change notifications. The upstream server sends `notifications/subscriptions/acknowledged` immediately, but Railway buffers the Inspector proxy response without `X-Accel-Buffering: no`, leaving connection readiness pending until the 120s timeout.

## Validation
- focused Inspector unit tests: 7 passed
- Inspector typecheck after building workspace client/agent: passed
- Inspector production package build + verification: passed
- built CLI proxy returned the upstream acknowledgement immediately with `text/event-stream`, `Cache-Control: no-cache, no-transform`, and `X-Accel-Buffering: no`

Cloud relay header forwarding remains in the Cloud PR; this PR only fixes the Inspector-owned streaming boundary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make MCP v2 subscription acks stream immediately through proxies and reduce client readiness latency. `@mcp-use/client` now defers mixed-auth discovery until after first paint, refreshes it after reconnect, and surfaces tools right away; the CLI waits for discovery before exiting.

- **Bug Fixes**
  - In `@mcp-use/inspector` SSE, set `X-Accel-Buffering: no` and default `Cache-Control: no-cache, no-transform` when missing.
  - Add `discoverAuthorization()`; `useMcp` triggers discovery after first paint and refreshes it after reconnect; `@mcp-use/cli` awaits it before reporting.

- **Performance**
  - Expose tools immediately and load auxiliary inventories (resources, prompts, skills) progressively to mark ready sooner.

<sup>Written for commit 57d8730a2097150a09d4de7eac475a8be3705d66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

