### PR TITLE
fix(ci): actually run the mcp-use unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -700,7 +700,7 @@ jobs:
       - name: Run mcp-use Unit Tests
         env:
           MCP_USE_ANONYMIZED_TELEMETRY: false
-        run: pnpm --filter mcp-use --if-present test:unit
+        run: pnpm --filter mcp-use test:run
       - name: Run @mcp-use/agent Unit Tests
         env:
           MCP_USE_ANONYMIZED_TELEMETRY: false

--- a/libraries/typescript/packages/server/tests/budgets/runtime-boundary.test.ts
+++ b/libraries/typescript/packages/server/tests/budgets/runtime-boundary.test.ts
@@ -29,9 +29,11 @@ describe("runtime package boundaries", () => {
     const resolutions = await traceImport([]);
     const builtins = builtinResolutions(resolutions);
 
-    expect(builtins.map(({ url }) => url)).toEqual([
-      "node:process",
+    // Sorted: the case asserts which builtins load, and resolution order is
+    // not guaranteed between them.
+    expect(builtins.map(({ url }) => url).sort()).toEqual([
       "node:http",
+      "node:process",
     ]);
     expect(
       builtins.find(({ url }) => url === "node:process")?.parentURL

--- a/libraries/typescript/packages/server/tests/usage.test.ts
+++ b/libraries/typescript/packages/server/tests/usage.test.ts
@@ -27,6 +27,10 @@ afterEach(() => {
 });
 
 async function capture(root: string): Promise<void> {
+  // These cases exercise identity persistence, not the opt-out, so they must
+  // not inherit an ambient MCP_USE_ANONYMIZED_TELEMETRY=false. afterEach
+  // already restores this variable.
+  process.env["MCP_USE_ANONYMIZED_TELEMETRY"] = "true";
   process.env["MCP_USE_TELEMETRY_VALIDATION_ID"] = "usage-test";
   const fetch = vi.fn(async () => new Response(null, { status: 202 }));
   vi.stubGlobal("fetch", fetch);


### PR DESCRIPTION
Closes #2203.

### The defect

```yaml
- name: Run mcp-use Unit Tests
  env:
    MCP_USE_ANONYMIZED_TELEMETRY: false
  run: pnpm --filter mcp-use --if-present test:unit
```

The `mcp-use` package has no `test:unit` script. Its scripts are `test`, `test:run` and `typecheck`. With `--if-present`, a missing script is a silent success, so this step has been reporting green while running nothing. 447 tests across 43 files were never executed in CI.

### The evidence

This is the second half of the same problem as #2201, found by auditing every `--if-present` in the workflows.

Enabling the step is not enough on its own, because two real failures were sitting behind the skip. I ran the step's exact command with its exact env before changing anything:

```
MCP_USE_ANONYMIZED_TELEMETRY=false pnpm --filter mcp-use test:run
-> Tests  3 failed | 444 passed (447)
```

**1. `usage.test.ts`, 3 failures.** `expected "vi.fn()" to be called once, but got 0 times`. The step sets `MCP_USE_ANONYMIZED_TELEMETRY=false`, and `src/usage.ts:76` short-circuits on exactly that value, so `recordUsage` never reaches `fetch`. Confirmed by running the file both ways: 3 passed without the variable, 3 failed with it.

These cases are about identity persistence per runtime, not about the opt-out, so `capture()` now sets the variable itself. The file already lists `MCP_USE_ANONYMIZED_TELEMETRY` in `trackedEnvironment` and restores it in `afterEach`, so it was already set up to own this.

**2. `budgets/runtime-boundary.test.ts`.** It compared the builtin list with `toEqual`, which made it depend on the resolution order of `node:process` and `node:http`. It passes locally, but I watched it fail on a real runner with `['node:http','node:process']` against the expected `['node:process','node:http']`. The case is titled "loads only the SDK process shim and listen HTTP adapter", so membership is the point and order is not. Sorted. The two assertions right below it already look their entries up by `url` rather than by position.

### After

```
MCP_USE_ANONYMIZED_TELEMETRY=false pnpm --filter mcp-use test:run
-> Test Files  43 passed (43)
   Tests  447 passed (447)
   exit 0
```

Note that these tests need `pnpm build` first, as CI does. Without it, 85 of them fail on `Cannot find module '#mcp-use-skills-loader'`, which resolves only against `dist`.

### Note on scope

I am deliberately not adding a `test:unit` alias. Pointing the step at the script that already exists keeps it consistent with the `Run client Unit Tests` step directly above it.

No changeset: workflow and test files only, no shipped code change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make CI actually run the `mcp-use` unit tests by calling the correct script and fix the two test issues uncovered. This removes a silent skip and restores coverage for 447 tests.

- **Bug Fixes**
  - CI: run `pnpm --filter mcp-use test:run` instead of the non-existent `test:unit` that was silently passing with `--if-present`.
  - usage.test: set MCP_USE_ANONYMIZED_TELEMETRY=true inside `capture()` to exercise telemetry calls (CI sets it false).
  - runtime-boundary.test: compare a sorted list of builtins to avoid order-dependent failures between `node:process` and `node:http`.
  - Result: 43 files, 447 tests passing under the CI env.

<sup>Written for commit 103797f6dca125db1a759e139303a4891478ebf5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

