### PR TITLE
fix(ci): run the create-mcp-use-app unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ permissions:
 #    └─ typescript-changeset-check: PR validation (PRs only)
 #
 # 4. create-mcp-use-app Tests (runs if packages/create-mcp-use-app/** changed)
-#    ├─ create-mcp-use-app-build: Build and pack the CLI
+#    ├─ create-mcp-use-app-build: Build, unit test, and pack the CLI
 #    └─ create-app-tests: Matrix [3 OS × 3 PM × 3 templates × 2 flags]
 #       - Tests project creation across Ubuntu/macOS/Windows
 #       - Tests npm, yarn, pnpm package managers
@@ -921,6 +921,9 @@ jobs:
       - name: Build All Packages
         working-directory: libraries/typescript
         run: pnpm build
+      - name: Run create-mcp-use-app Unit Tests
+        working-directory: libraries/typescript
+        run: pnpm --filter create-mcp-use-app test
       - name: Pack create-mcp-use-app
         working-directory: libraries/typescript/packages/create-mcp-use-app
         run: npm pack


### PR DESCRIPTION
### The defect

`create-mcp-use-app` has 25 vitest cases in `src/__tests__` (`dot-directory.test.ts`, `skills-config.test.ts`). No workflow runs them.

The package has two jobs, and neither executes vitest:

- `create-mcp-use-app-build` installs, builds, and `npm pack`s the tarball.
- `create-app-tests` takes that tarball and scaffolds a project across 3 OS x 3 package managers x 3 templates, then asserts `test-app/package.json` and `test-app/index.ts` exist and that `dev` starts.

That end-to-end matrix is valuable, but it only proves a project can be created. It never exercises the units those tests cover: `sanitizePackageName`, `deriveProjectInfo`, `findUnsafeEntries`, `updatePackageJson`, `updateIndexTs` and the skills channel mapping.

Confirmed by grep: the only references to the package in any workflow are the `npx`/`yarn dlx`/`pnpm dlx` scaffold invocations and the pack step. There is no `--filter create-mcp-use-app` test step anywhere.

### The fix

Add the step to `create-mcp-use-app-build`, which already installs dependencies and builds, so the tests run before the artifact is packed rather than in a separate job.

```
pnpm --filter create-mcp-use-app test
-> Test Files  2 passed (2)
   Tests  25 passed (25)
   exit 0
```

### Two limits worth stating

- This inherits the job's existing path filter, so the tests run when `packages/create-mcp-use-app/**` changes, not on every PR. That matches how the rest of that job is already gated, and widening the filter is a separate call.
- The package's `test` script is `vitest --run --passWithNoTests`. If the test glob ever stopped matching, this step would go green on zero tests. I left the script alone because it lives in a published package, but it is worth knowing that this step is only as strict as that flag allows.

Workflow file only, no changeset.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run `create-mcp-use-app` unit tests in CI to catch unit failures before packaging. Adds a test step to the `create-mcp-use-app-build` job so `vitest` runs after build and before pack.

- **Bug Fixes**
  - Added "Run create-mcp-use-app Unit Tests" step in `.github/workflows/ci.yml` executing `pnpm --filter create-mcp-use-app test`.
  - Inherits the job’s path filter (runs only when `packages/create-mcp-use-app/**` changes).

<sup>Written for commit 3b48a1b64f4b43733753fd2df60cd45434aaa86c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

