### PR TITLE
docs: remove duplicate migration guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 </div>
 
 > [!NOTE]
-> **Migrating from v1? Give it to your agent:** [Read the migration guide →](https://docs.mcp-use.com/v2/typescript/server/migration)
+> **Migrating from v1? Give it to your agent:**
 >
 > ```text
 > Migrate this mcp-use project to v2 following

--- a/libraries/typescript/packages/server/README.md
+++ b/libraries/typescript/packages/server/README.md
@@ -46,7 +46,7 @@
 </div>
 
 > [!NOTE]
-> **Migrating from v1? Give it to your agent:** [Read the migration guide →](https://docs.mcp-use.com/v2/typescript/server/migration)
+> **Migrating from v1? Give it to your agent:**
 >
 > ```text
 > Migrate this mcp-use project to v2 following


### PR DESCRIPTION
## Summary

- Keep the migration guide link only as the standalone link at the bottom of the migration note.
- Apply the same cleanup to the root README and the TypeScript server package README.

## Why

The migration note previously displayed the same guide link twice, which was redundant for readers.

## Validation

- `git diff --check`
- Pre-commit checks passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the duplicate migration guide link in the migration note to avoid repetition. Applies to `README.md` and `libraries/typescript/packages/server/README.md`; keep only the single link at the bottom of the note.

<sup>Written for commit 0bb0067b47c8ccf320c2f392dfbbb01b6707eee7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

