### PR TITLE
fix: enable Skills tab after HMR

### DIFF
--- a/libraries/typescript/.changeset/fix-hmr-skills-tab.md
+++ b/libraries/typescript/.changeset/fix-hmr-skills-tab.md
@@ -1,0 +1,7 @@
+---
+"@mcp-use/client": patch
+"@mcp-use/inspector": patch
+---
+
+Enable the Inspector Skills tab when a dev-server HMR reload adds skills after
+the initial connection negotiated without the Skills extension.

--- a/libraries/typescript/packages/client/src/react/McpClientProvider.tsx
+++ b/libraries/typescript/packages/client/src/react/McpClientProvider.tsx
@@ -106,6 +106,7 @@ function isSameMcpServer(left: McpServer, right: McpServer): boolean {
     sameSerializedValue(left.resources, right.resources) &&
     sameSerializedValue(left.resourceTemplates, right.resourceTemplates) &&
     sameSerializedValue(left.prompts, right.prompts) &&
+    sameSerializedValue(left.skills, right.skills) &&
     sameSerializedValue(left.notifications, right.notifications) &&
     left.unreadNotificationCount === right.unreadNotificationCount &&
     sameSerializedValue(
@@ -406,6 +407,7 @@ function McpServerWrapper({
     mcp.resources,
     mcp.resourceTemplates,
     mcp.prompts,
+    mcp.skills,
     mcp.serverInfo,
     mcp.capabilities,
     mcp.protocolEra,

--- a/libraries/typescript/packages/client/tests/unit/react/mcp-client-provider-metadata-updates.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/react/mcp-client-provider-metadata-updates.test.ts
@@ -14,6 +14,11 @@ let latestClient: ReturnType<typeof useMcpClient> | null = null;
 let mockProtocolEra: "legacy" | "modern" = "legacy";
 let mockInstructions = "legacy instructions";
 let mockAuthorization: { mode: "mixed"; authenticated: boolean } | undefined;
+let mockSkills: Array<{
+  uri: string;
+  frontmatter: { name: string; description: string };
+  resources: unknown[];
+}> = [];
 
 vi.mock("../../../src/react/useMcp.js", () => {
   const tools: unknown[] = [];
@@ -42,6 +47,7 @@ vi.mock("../../../src/react/useMcp.js", () => {
         resources,
         resourceTemplates,
         prompts,
+        skills: mockSkills,
         serverInfo,
         capabilities,
         state: "ready" as const,
@@ -104,6 +110,7 @@ describe("McpClientProvider metadata-only updates", () => {
     mockProtocolEra = "legacy";
     mockInstructions = "legacy instructions";
     mockAuthorization = undefined;
+    mockSkills = [];
     vi.restoreAllMocks();
   });
 
@@ -212,6 +219,45 @@ describe("McpClientProvider metadata-only updates", () => {
       mode: "mixed",
       authenticated: false,
     });
+  });
+
+  it("propagates refreshed skills to provider consumers", async () => {
+    let renderer: ReturnType<typeof create>;
+    await act(async () => {
+      renderer = create(
+        React.createElement(
+          McpClientProvider,
+          null,
+          React.createElement(TestHarness)
+        )
+      );
+    });
+    await flushUpdates();
+
+    expect(latestClient?.getServer("sandbox")?.skills).toEqual([]);
+    mockSkills = [
+      {
+        uri: "skill://shipping/SKILL.md",
+        frontmatter: {
+          name: "shipping",
+          description: "Track shipments",
+        },
+        resources: [],
+      },
+    ];
+
+    await act(async () => {
+      renderer!.update(
+        React.createElement(
+          McpClientProvider,
+          null,
+          React.createElement(TestHarness)
+        )
+      );
+    });
+    await flushUpdates();
+
+    expect(latestClient?.getServer("sandbox")?.skills).toEqual(mockSkills);
   });
 
   it("persists only serializable server configuration", async () => {

--- a/libraries/typescript/packages/inspector/src/client/components/layout/__tests__/layoutHeaderUtils.test.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/layout/__tests__/layoutHeaderUtils.test.ts
@@ -43,6 +43,17 @@ describe("Skills navigation state", () => {
     expect(getSkillsState(value)).toBe("available");
   });
 
+  it("treats an HMR-populated catalog as available after initial negotiation", () => {
+    const value = server({
+      extensions: {},
+      skills: [{ uri: "skill://refunds/SKILL.md" }] as McpServer["skills"],
+    });
+
+    expect(supportsSkills(value)).toBe(false);
+    expect(getSkillsState(value)).toBe("available");
+    expect(isTabUsable("skills", value)).toBe(true);
+  });
+
   it("announces only the advertised-empty status in the accessible label", () => {
     expect(getSkillsAccessibleLabel("Skills", "empty")).toBe(
       "Skills: advertised but empty"

--- a/libraries/typescript/packages/inspector/src/client/components/layout/layoutHeaderUtils.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/layout/layoutHeaderUtils.ts
@@ -46,10 +46,15 @@ export const SKILLS_EMPTY_CATALOG_MESSAGE =
 
 export type SkillsState = "unsupported" | "empty" | "available";
 
-/** An advertised empty catalog is unavailable until the server supplies skills. */
+/**
+ * An advertised empty catalog is unavailable until the server supplies skills.
+ * A populated catalog is authoritative even if the extension capability was
+ * negotiated before a dev-server HMR reload added a skills directory.
+ */
 export function getSkillsState(server: McpServer): SkillsState {
+  if ((server.skills?.length ?? 0) > 0) return "available";
   if (!supportsSkills(server)) return "unsupported";
-  return (server.skills?.length ?? 0) === 0 ? "empty" : "available";
+  return "empty";
 }
 
 /** Include the advertised-empty status in an otherwise icon-only tab label. */


### PR DESCRIPTION
## Summary

- propagate refreshed Skills catalogs through `McpClientProvider`
- treat a populated catalog as authoritative when a dev-server HMR reload adds Skills after initial capability negotiation
- add client/provider and Inspector state regressions
- add a patch changeset for `@mcp-use/client` and `@mcp-use/inspector`

## Root cause

The client refreshed the Skills catalog after `resources/list_changed`, but the provider omitted `skills` from its update comparison and effect dependencies. After that was fixed, the Inspector still treated the initial connection's missing Skills capability as authoritative even when the refreshed catalog had entries.

## Validation

- `pnpm --dir libraries/typescript/packages/client test:run tests/unit/react/mcp-client-provider-metadata-updates.test.ts`
- `pnpm --dir libraries/typescript/packages/inspector exec vitest run src/client/components/layout/__tests__/layoutHeaderUtils.test.ts`
- `pnpm --dir libraries/typescript/packages/client exec tsc --noEmit`
- `pnpm --dir libraries/typescript/packages/inspector exec tsc --noEmit`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Inspector Skills tab staying disabled after a dev-server HMR reload adds skills. We now propagate refreshed Skills and treat a populated catalog as authoritative even if the initial negotiation didn’t include the Skills extension.

- **Bug Fixes**
  - Include `skills` in `McpClientProvider` equality checks and effect deps to propagate updates.
  - In Inspector, prefer a populated catalog over missing capability ads to enable the Skills tab.
  - Add unit tests for provider propagation and layout header utils.
  - Add patch changesets for `@mcp-use/client` and `@mcp-use/inspector`.

<sup>Written for commit f36f40763e242ad44d61b92212b31bc55afd48c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

