### PR TITLE
fix(create-app): strip leading underscores when sanitizing a package name

### DIFF
--- a/libraries/typescript/.changeset/eighty-moons-shave.md
+++ b/libraries/typescript/.changeset/eighty-moons-shave.md
@@ -1,0 +1,5 @@
+---
+"create-mcp-use-app": patch
+---
+
+Strip leading underscores when sanitizing a project name into an npm package name. `create-mcp-use-app _foo` produced `"name": "_foo"`, which npm publish rejects with "name cannot start with an underscore".

--- a/libraries/typescript/packages/create-mcp-use-app/src/__tests__/dot-directory.test.ts
+++ b/libraries/typescript/packages/create-mcp-use-app/src/__tests__/dot-directory.test.ts
@@ -30,10 +30,13 @@ describe("sanitizePackageName", () => {
     expect(sanitizePackageName("my@project!name")).toBe("my-project-name");
   });
 
-  it("trims leading dots and dashes", () => {
+  it("trims leading dots, dashes and underscores", () => {
     expect(sanitizePackageName("..my-project")).toBe("my-project");
     expect(sanitizePackageName("--my-project")).toBe("my-project");
     expect(sanitizePackageName(".-my-project")).toBe("my-project");
+    // npm publish: "name cannot start with an underscore"
+    expect(sanitizePackageName("__my-project")).toBe("my-project");
+    expect(sanitizePackageName("_.-my-project")).toBe("my-project");
   });
 
   it("trims trailing dots and dashes", () => {
@@ -157,6 +160,13 @@ describe("deriveProjectInfo", () => {
     expect(info.projectPath).toBe(resolve("/tmp", 'My "App"'));
     expect(info.displayName).toBe('My "App"');
     expect(info.packageName).toBe("my--app");
+  });
+
+  it("strips a leading underscore from a named project", () => {
+    const info = deriveProjectInfo("_foo", "/tmp");
+    expect(info.projectPath).toBe(resolve("/tmp", "_foo"));
+    expect(info.displayName).toBe("_foo");
+    expect(info.packageName).toBe("foo");
   });
 });
 

--- a/libraries/typescript/packages/create-mcp-use-app/src/utils.ts
+++ b/libraries/typescript/packages/create-mcp-use-app/src/utils.ts
@@ -48,13 +48,14 @@ export function findUnsafeEntries(dir: string): string[] {
 
 // Sanitize a raw directory name into a valid npm package name.
 // npm names must be lowercase and may not contain spaces, most special chars,
-// or leading dots/dashes.
+// or leading dots, dashes or underscores. npm publish rejects a leading
+// underscore outright: "name cannot start with an underscore".
 export function sanitizePackageName(raw: string): string {
   return (
     raw
       .toLowerCase()
       .replace(/[^a-z0-9_.-]/g, "-")
-      .replace(/^[.-]+/, "")
+      .replace(/^[._-]+/, "")
       .replace(/[.-]+$/, "") || "my-app"
   );
 }


### PR DESCRIPTION
Closes #2219.

### The defect

`sanitizePackageName` stripped leading dots and dashes but not underscores:

```ts
.replace(/^[.-]+/, "")
```

So `create-mcp-use-app _foo` wrote `"name": "_foo"` into the generated `package.json`.

### The evidence

I checked what actually rejects it, because the answer is narrower than "npm rejects it". A local install is fine with the name:

```
$ npm install --dry-run     # package named "_foo"
(no error)
```

Publishing is not:

```
$ npm publish --dry-run
npm error code EINVALIDPACKAGENAME
npm error Invalid package name "_foo" of package "_foo@1.0.0": name cannot start with an underscore.
```

A control run with a valid name produces no error. So the practical impact is that a scaffolded project cannot be published until the name is fixed by hand, which is the same class of problem as #2209 but only bites later.

### The fix

Widen the leading-character class to `[._-]`, per the spec in the issue. Interior and trailing underscores are untouched, since npm allows those and `my_app` is a legitimate name.

Coverage as requested: the sanitizer case now includes `__my-project` and `_.-my-project`, and there is a new `deriveProjectInfo` case for a named project starting with `_`, which asserts the directory is still created as `_foo` while the package name becomes `foo`.

27/27 green in `create-mcp-use-app`.

Credit to cubic for catching this on #2209.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent invalid npm package names in `create-mcp-use-app` by stripping leading underscores during sanitization. This avoids publish failures for names like `_foo`.

- **Bug Fixes**
  - Update `sanitizePackageName` to trim leading dots, dashes, and underscores.
  - Keep interior/trailing underscores (e.g. `my_app`) unchanged.
  - Add tests for `_`-prefixed names; directory remains `_foo`, `package.json` name becomes `foo`.

<sup>Written for commit c75ff7c9fe96c339ed63e3d168198a35e405fed1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

