### PR TITLE
Fix stable release blockers and Inspector container startup

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -279,11 +279,13 @@ jobs:
         env:
           CONFORMANCE_RUNNER: '@modelcontextprotocol/conformance@0.2.0-alpha.10'
           SPEC_VERSIONS: '2025-11-25 2026-07-28'
+          LEGACY_SERVER_EXPECTED_FAILURES: 'libraries/typescript/packages/server/examples/conformance/expected-failures.yml'
         run: |
           node libraries/typescript/scripts/summarize-conformance.mjs \
             conformance-results/typescript \
             --runner "$CONFORMANCE_RUNNER" \
             --spec-versions "$SPEC_VERSIONS" \
+            --expected-failures "$LEGACY_SERVER_EXPECTED_FAILURES" \
             --output conformance-results/typescript/summary.md
 
       - name: Upload TypeScript v2 conformance results

--- a/.github/workflows/typescript-release.yml
+++ b/.github/workflows/typescript-release.yml
@@ -58,6 +58,10 @@ jobs:
         working-directory: libraries/typescript
         run: pnpm build
 
+      - name: Verify packed release installation
+        working-directory: libraries/typescript
+        run: pnpm verify:release-install
+
       # ============================================================================
       # CANARY BRANCH: Prerelease workflow
       # ============================================================================

--- a/docs/inspector/changelog.mdx
+++ b/docs/inspector/changelog.mdx
@@ -6,19 +6,19 @@ rss: true
 tag: "New"
 ---
 
-<Update label="v21.0.0" description="August 2026">
+<Update label="v20.1.0" description="August 2026">
   <Frame>
-    <img src="https://mcp-use.com/api/og/release?v=21.0.0&title=Skills%20over%20MCP%20%26%20Inspector%20runtime&date=2026-08&lang=inspector" alt="Release 21.0.0" />
+    <img src="https://mcp-use.com/api/og/release?v=20.1.0&title=Skills%20over%20MCP%20%26%20Inspector%20runtime&date=2026-08&lang=inspector" alt="Release 20.1.0" />
   </Frame>
   ## Skills over MCP & Inspector runtime
-  Major release paired with `mcp-use` v3.0.0 — typed Skills operations, an integrity-checked file explorer, and development/runtime fixes for the v2 Inspector.
+  Minor release paired with `mcp-use` v2.1.0 — typed Skills operations, an integrity-checked file explorer, and development/runtime fixes for the v2 Inspector.
 
 - **New**: typed Skills over MCP client operations, a capability-gated Inspector file explorer with integrity verification, and removable progressive skill context in Inspector chat
 - **Enhancement**: Skills discovery omits invalid skills from fresh development snapshots
 - **Enhancement**: the `window.openai` compatibility bridge exposes tool lifecycle globals and host actions while preserving the native MCP Apps handshake for v2 views; iframe console records are not parsed as MCP Apps JSON-RPC messages
 - **Fix**: provider assets load from the development server, widget-declared sandbox CSPs can use dynamic compilation within their declared domains, and embedded layouts fill their iframe height without the empty desktop header gap or standalone sidebar footer controls
 - **Fix**: avoid the Inspector tunnel flash while connection state transitions complete
-- **Update**: Updated mcp-use to v3.0.0
+- **Update**: Updated mcp-use to v2.1.0
 </Update>
 
 <Update label="v20.0.4" description="August 2026">

--- a/docs/typescript/changelog/changelog.mdx
+++ b/docs/typescript/changelog/changelog.mdx
@@ -6,12 +6,12 @@ tag: "New"
 rss: true
 ---
 
-<Update label="v3.0.0" description="August 2026">
+<Update label="v2.1.0" description="August 2026">
   <Frame>
-    <img src="https://mcp-use.com/api/og/release?v=3.0.0&title=Skills%20over%20MCP%20%26%20v2%20server%20tooling&date=2026-08&lang=typescript" alt="Release 3.0.0" />
+    <img src="https://mcp-use.com/api/og/release?v=2.1.0&title=Skills%20over%20MCP%20%26%20v2%20server%20tooling&date=2026-08&lang=typescript" alt="Release 2.1.0" />
   </Frame>
   ## Skills over MCP & v2 server tooling
-  Major release adding experimental Skills over MCP authoring to the v2 server and completing the package split around the standalone CLI and Inspector.
+  Minor release adding experimental Skills over MCP authoring to the v2 server and completing the package split around the standalone CLI and Inspector.
 
 - **Fix**: MCP v2 server responses preserve tool JSON Schema dialects and accept input-required prompt results (`#2147`)
 - **Fix**: Modern connections remain ready when optional upstream identity metadata is absent, while anonymous direct-proxy upstreams report a clear namespace error
@@ -23,8 +23,8 @@ rss: true
 - **Fix**: Next.js Turbopack builds resolve the Skills over MCP loader correctly (`#2197`)
 - **Enhancement** (@mcp-use/inspector): typed Skills operations, a capability-gated file explorer with integrity verification, the `window.openai` compatibility bridge, and related runtime fixes; see the Inspector changelog
 - **Fix** (create-mcp-use-app): clear unused TypeScript export surface flagged by Knip without changing published package entry APIs
-- **Update**: Updated @mcp-use/inspector to v21.0.0
-- **Update**: Updated @mcp-use/cli to v5.0.0
+- **Update**: Updated @mcp-use/inspector to v20.1.0
+- **Update**: Updated @mcp-use/cli to v4.1.0
 - **Update**: Updated create-mcp-use-app to v2.0.2
 </Update>
 

--- a/libraries/typescript/.changeset/strict-widgets-stable-release.md
+++ b/libraries/typescript/.changeset/strict-widgets-stable-release.md
@@ -1,0 +1,6 @@
+---
+"@mcp-use/cli": patch
+"@mcp-use/inspector": patch
+---
+
+Keep widget-declared CSPs restrictive by default and make clean release installs resolve a single compatible build-tool dependency graph.

--- a/libraries/typescript/packages/cli/package.json
+++ b/libraries/typescript/packages/cli/package.json
@@ -50,10 +50,10 @@
     "typecheck": "tsc -p tsconfig.test.json"
   },
   "dependencies": {
-    "@tailwindcss/vite": "^4.2.0",
-    "@vitejs/plugin-react": "^6.0.3",
-    "tailwindcss": "^4.2.0",
-    "vite": "^8.0.16"
+    "@tailwindcss/vite": "4.3.3",
+    "@vitejs/plugin-react": "6.0.5",
+    "tailwindcss": "4.3.3",
+    "vite": "8.0.16"
   },
   "peerDependencies": {
     "@mcp-use/client": "^2.0.1 || ^2.1.0-canary.0",

--- a/libraries/typescript/packages/client/src/react/view/sandbox-blob-url.ts
+++ b/libraries/typescript/packages/client/src/react/view/sandbox-blob-url.ts
@@ -75,5 +75,8 @@ export function buildSandboxProxyBlobHtml(search: string): string {
   const escaped = JSON.stringify(search).replace(/</g, "\\u003c");
   const inject =
     "<script>window.__SANDBOX_SEARCH__ = " + escaped + ";</script>";
-  return SANDBOX_PROXY_HTML.replace("<body>", "<body>" + inject);
+  return SANDBOX_PROXY_HTML.replace(
+    `        const scriptSrcParts = ["'unsafe-inline'", "'unsafe-eval'", resourceSrc];\n`,
+    `        const scriptSrcParts = ["'unsafe-inline'", resourceSrc];\n`
+  ).replace("<body>", "<body>" + inject);
 }

--- a/libraries/typescript/packages/client/tests/unit/view-renderer.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/view-renderer.test.ts
@@ -34,7 +34,7 @@ describe("buildViewSandboxBlobUrl", () => {
     );
   });
 
-  it("builds widget-declared CSP with eval and only declared domains", () => {
+  it("builds restrictive widget-declared CSP with only declared domains", () => {
     const dom = new JSDOM(
       buildSandboxProxyBlobHtml("?csp_mode=widget-declared"),
       { runScripts: "dangerously", url: "https://sandbox.example" }
@@ -62,8 +62,9 @@ describe("buildViewSandboxBlobUrl", () => {
 
       const srcdoc = window.document.querySelector("iframe")?.srcdoc;
       expect(srcdoc).toContain(
-        "script-src 'unsafe-inline' 'unsafe-eval' data: blob: https://cdn.example.com"
+        "script-src 'unsafe-inline' data: blob: https://cdn.example.com"
       );
+      expect(srcdoc).not.toContain("script-src 'unsafe-inline' 'unsafe-eval'");
       expect(srcdoc).toContain("connect-src https://api.example.com");
       expect(srcdoc).toContain("frame-src https://frames.example.com");
       expect(srcdoc).toContain("img-src data: blob: https://cdn.example.com");

--- a/libraries/typescript/packages/inspector/Dockerfile
+++ b/libraries/typescript/packages/inspector/Dockerfile
@@ -22,4 +22,4 @@ EXPOSE 8080
 
 # Start the inspector. Shell form so ${PORT:-8080} expands; exec keeps the
 # node process as PID 1 for signal handling.
-CMD ["sh", "-c", "exec npx @mcp-use/inspector --port \"${PORT:-8080}\""]
+CMD ["sh", "-c", "exec npx @mcp-use/inspector --port \"${PORT:-8080}\" --no-open"]

--- a/libraries/typescript/packages/inspector/src/client/mcp-apps/__tests__/csp.test.ts
+++ b/libraries/typescript/packages/inspector/src/client/mcp-apps/__tests__/csp.test.ts
@@ -9,15 +9,16 @@ import {
 } from "../csp";
 
 describe("CSP diagnostics", () => {
-  it("allows eval while retaining widget-declared domain restrictions", () => {
+  it("keeps eval disabled while retaining widget-declared domains", () => {
     const policy = buildCSPString({
       connectDomains: ["https://api.example.com"],
       resourceDomains: ["https://cdn.example.com"],
     });
 
     expect(policy).toContain(
-      "script-src 'unsafe-inline' 'unsafe-eval' data: blob: https://cdn.example.com"
+      "script-src 'unsafe-inline' data: blob: https://cdn.example.com"
     );
+    expect(policy).not.toContain("'unsafe-eval'");
     expect(policy).toContain("connect-src https://api.example.com");
     expect(policy).toContain("frame-src 'none'");
   });

--- a/libraries/typescript/packages/inspector/src/client/mcp-apps/csp.ts
+++ b/libraries/typescript/packages/inspector/src/client/mcp-apps/csp.ts
@@ -43,7 +43,7 @@ export function buildCSPString(csp: WidgetDeclaredCsp): string {
 
   return [
     "default-src 'none'",
-    `script-src 'unsafe-inline' 'unsafe-eval' ${resourceSrc}`,
+    `script-src 'unsafe-inline' ${resourceSrc}`,
     `style-src 'unsafe-inline' ${resourceSrc}`,
     `img-src ${resourceSrc}`,
     `font-src ${resourceSrc}`,

--- a/libraries/typescript/packages/server/examples/conformance/expected-failures.yml
+++ b/libraries/typescript/packages/server/examples/conformance/expected-failures.yml
@@ -7,8 +7,8 @@ server:
 
   # Stateless legacy HTTP has no session or SSE resumability.
   - server-sse-polling:server-sse-polling-session
-  - server-sse-priming-event
-  - server-sse-retry-field
+  - server-sse-polling:server-sse-priming-event
+  - server-sse-polling:server-sse-retry-field
   - server-sse-multiple-streams:server-sse-multiple-streams-session
 
   # Stateless legacy HTTP does not retain resource subscriptions.

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -24,7 +24,7 @@ overrides:
   zod: 4.4.3
   jsondiffpatch: '>=0.7.2'
   esbuild: 0.27.1
-  vite: '>=8.0.5'
+  vite: 8.0.16
   prismjs: '>=1.30.0'
   glob: '>=10.5.0'
   js-yaml: '>=4.1.2'
@@ -211,7 +211,7 @@ importers:
         specifier: 4.3.3
         version: 4.3.3
       vite:
-        specifier: '>=8.0.5'
+        specifier: 8.0.16
         version: 8.0.16(@types/node@22.20.1)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
     devDependencies:
       '@mcp-use/client':
@@ -322,7 +322,7 @@ importers:
         specifier: ^0.12.5
         version: 0.12.5
       vite:
-        specifier: '>=8.0.5'
+        specifier: 8.0.16
         version: 8.0.16(@types/node@25.6.0)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/client/examples/conformance:
@@ -525,7 +525,7 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
-        specifier: '>=8.0.5'
+        specifier: 8.0.16
         version: 8.0.16(@types/node@25.6.0)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: '>=4.1.9'
@@ -734,7 +734,7 @@ importers:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: '>=8.0.5'
+        specifier: 8.0.16
         version: 8.0.16(@types/node@22.20.1)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/server/examples/conformance:
@@ -781,7 +781,7 @@ importers:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: '>=8.0.5'
+        specifier: 8.0.16
         version: 8.0.16(@types/node@22.20.1)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/server/examples/events:
@@ -797,7 +797,7 @@ importers:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: '>=8.0.5'
+        specifier: 8.0.16
         version: 8.0.16(@types/node@22.20.1)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/server/examples/middleware:
@@ -816,7 +816,7 @@ importers:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: '>=8.0.5'
+        specifier: 8.0.16
         version: 8.0.16(@types/node@22.20.1)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/server/examples/nextjs:
@@ -897,7 +897,7 @@ importers:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: '>=8.0.5'
+        specifier: 8.0.16
         version: 8.0.16(@types/node@22.20.1)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/server/examples/openapi:
@@ -980,7 +980,7 @@ importers:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: '>=8.0.5'
+        specifier: 8.0.16
         version: 8.0.16(@types/node@22.20.1)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/server/examples/sampling:
@@ -1104,7 +1104,7 @@ importers:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: '>=8.0.5'
+        specifier: 8.0.16
         version: 8.0.16(@types/node@22.20.1)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/server/examples/vercel:
@@ -3846,12 +3846,12 @@ packages:
   '@tailwindcss/vite@4.2.0':
     resolution: {integrity: sha512-da9mFCaHpoOgtQiWtDGIikTrSpUFBtIZCG3jy/u2BGV+l/X1/pbxzmIUxNt6JWm19N3WtGi4KlJdSH/Si83WOA==}
     peerDependencies:
-      vite: '>=8.0.5'
+      vite: 8.0.16
 
   '@tailwindcss/vite@4.3.3':
     resolution: {integrity: sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==}
     peerDependencies:
-      vite: '>=8.0.5'
+      vite: 8.0.16
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -4431,7 +4431,7 @@ packages:
     peerDependencies:
       '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
       babel-plugin-react-compiler: ^1.0.0
-      vite: '>=8.0.5'
+      vite: 8.0.16
     peerDependenciesMeta:
       '@rolldown/plugin-babel':
         optional: true
@@ -4444,7 +4444,7 @@ packages:
     peerDependencies:
       '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
       babel-plugin-react-compiler: ^1.0.0
-      vite: '>=8.0.5'
+      vite: 8.0.16
     peerDependenciesMeta:
       '@rolldown/plugin-babel':
         optional: true
@@ -4457,7 +4457,7 @@ packages:
     peerDependencies:
       '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
       babel-plugin-react-compiler: ^1.0.0
-      vite: '>=8.0.5'
+      vite: 8.0.16
     peerDependenciesMeta:
       '@rolldown/plugin-babel':
         optional: true
@@ -4480,7 +4480,7 @@ packages:
     resolution: {integrity: sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==}
     peerDependencies:
       msw: ^2.4.9
-      vite: '>=8.0.5'
+      vite: 8.0.16
     peerDependenciesMeta:
       msw:
         optional: true
@@ -7872,7 +7872,7 @@ packages:
       '@vitest/ui': 4.1.9
       happy-dom: '*'
       jsdom: '*'
-      vite: '>=8.0.5'
+      vite: 8.0.16
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -202,14 +202,14 @@ importers:
         specifier: workspace:*
         version: link:../inspector
       '@tailwindcss/vite':
-        specifier: ^4.2.0
-        version: 4.2.0(vite@8.0.16(@types/node@22.20.1)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        specifier: 4.3.3
+        version: 4.3.3(vite@8.0.16(@types/node@22.20.1)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
       '@vitejs/plugin-react':
-        specifier: ^6.0.3
-        version: 6.0.3(vite@8.0.16(@types/node@22.20.1)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        specifier: 6.0.5
+        version: 6.0.5(vite@8.0.16(@types/node@22.20.1)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
       tailwindcss:
-        specifier: ^4.2.0
-        version: 4.2.0
+        specifier: 4.3.3
+        version: 4.3.3
       vite:
         specifier: '>=8.0.5'
         version: 8.0.16(@types/node@22.20.1)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
@@ -3668,8 +3668,17 @@ packages:
   '@tailwindcss/node@4.2.0':
     resolution: {integrity: sha512-Yv+fn/o2OmL5fh/Ir62VXItdShnUxfpkMA4Y7jdeC8O81WPB8Kf6TT6GSHvnqgSwDzlB5iT7kDpeXxLsUS0T6Q==}
 
+  '@tailwindcss/node@4.3.3':
+    resolution: {integrity: sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==}
+
   '@tailwindcss/oxide-android-arm64@4.2.0':
     resolution: {integrity: sha512-F0QkHAVaW/JNBWl4CEKWdZ9PMb0khw5DCELAOnu+RtjAfx5Zgw+gqCHFvqg3AirU1IAd181fwOtJQ5I8Yx5wtw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-android-arm64@4.3.3':
+    resolution: {integrity: sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [android]
@@ -3680,8 +3689,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@tailwindcss/oxide-darwin-arm64@4.3.3':
+    resolution: {integrity: sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@tailwindcss/oxide-darwin-x64@4.2.0':
     resolution: {integrity: sha512-6TmQIn4p09PBrmnkvbYQ0wbZhLtbaksCDx7Y7R3FYYx0yxNA7xg5KP7dowmQ3d2JVdabIHvs3Hx4K3d5uCf8xg==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.3.3':
+    resolution: {integrity: sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [darwin]
@@ -3692,14 +3713,33 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@tailwindcss/oxide-freebsd-x64@4.3.3':
+    resolution: {integrity: sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
   '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.0':
     resolution: {integrity: sha512-7XKkitpy5NIjFZNUQPeUyNJNJn1CJeV7rmMR+exHfTuOsg8rxIO9eNV5TSEnqRcaOK77zQpsyUkBWmPy8FgdSg==}
     engines: {node: '>= 20'}
     cpu: [arm]
     os: [linux]
 
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3':
+    resolution: {integrity: sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
   '@tailwindcss/oxide-linux-arm64-gnu@4.2.0':
     resolution: {integrity: sha512-Mff5a5Q3WoQR01pGU1gr29hHM1N93xYrKkGXfPw/aRtK4bOc331Ho4Tgfsm5WDGvpevqMpdlkCojT3qlCQbCpA==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.3':
+    resolution: {integrity: sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
@@ -3712,6 +3752,13 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
+    resolution: {integrity: sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@tailwindcss/oxide-linux-x64-gnu@4.2.0':
     resolution: {integrity: sha512-/hlXCBqn9K6fi7eAM0RsobHwJYa5V/xzWspVTzxnX+Ft9v6n+30Pz8+RxCn7sQL/vRHHLS30iQPrHQunu6/vJA==}
     engines: {node: '>= 20'}
@@ -3719,8 +3766,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
+    resolution: {integrity: sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
   '@tailwindcss/oxide-linux-x64-musl@4.2.0':
     resolution: {integrity: sha512-lKUaygq4G7sWkhQbfdRRBkaq4LY39IriqBQ+Gk6l5nKq6Ay2M2ZZb1tlIyRNgZKS8cbErTwuYSor0IIULC0SHw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.3':
+    resolution: {integrity: sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
@@ -3738,8 +3799,26 @@ packages:
       - '@emnapi/wasi-threads'
       - tslib
 
+  '@tailwindcss/oxide-wasm32-wasi@4.3.3':
+    resolution: {integrity: sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
   '@tailwindcss/oxide-win32-arm64-msvc@4.2.0':
     resolution: {integrity: sha512-2UU/15y1sWDEDNJXxEIrfWKC2Yb4YgIW5Xz2fKFqGzFWfoMHWFlfa1EJlGO2Xzjkq/tvSarh9ZTjvbxqWvLLXA==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.3':
+    resolution: {integrity: sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [win32]
@@ -3750,12 +3829,27 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.3':
+    resolution: {integrity: sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
   '@tailwindcss/oxide@4.2.0':
     resolution: {integrity: sha512-AZqQzADaj742oqn2xjl5JbIOzZB/DGCYF/7bpvhA8KvjUj9HJkag6bBuwZvH1ps6dfgxNHyuJVlzSr2VpMgdTQ==}
     engines: {node: '>= 20'}
 
+  '@tailwindcss/oxide@4.3.3':
+    resolution: {integrity: sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==}
+    engines: {node: '>= 20'}
+
   '@tailwindcss/vite@4.2.0':
     resolution: {integrity: sha512-da9mFCaHpoOgtQiWtDGIikTrSpUFBtIZCG3jy/u2BGV+l/X1/pbxzmIUxNt6JWm19N3WtGi4KlJdSH/Si83WOA==}
+    peerDependencies:
+      vite: '>=8.0.5'
+
+  '@tailwindcss/vite@4.3.3':
+    resolution: {integrity: sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==}
     peerDependencies:
       vite: '>=8.0.5'
 
@@ -4346,6 +4440,19 @@ packages:
 
   '@vitejs/plugin-react@6.0.3':
     resolution: {integrity: sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      vite: '>=8.0.5'
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+
+  '@vitejs/plugin-react@6.0.5':
+    resolution: {integrity: sha512-BOVzne/NL162sMdResB25mUv+vWMF5NoAjNf09TeGlE7ZpszZWSD3winycicLJw72yeVsoCn/2kOhEuCvEShMA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
@@ -5196,6 +5303,10 @@ packages:
 
   enhanced-resolve@5.19.0:
     resolution: {integrity: sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==}
+    engines: {node: '>=10.13.0'}
+
+  enhanced-resolve@5.24.5:
+    resolution: {integrity: sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==}
     engines: {node: '>=10.13.0'}
 
   enquirer@2.4.1:
@@ -7435,8 +7546,15 @@ packages:
   tailwindcss@4.2.0:
     resolution: {integrity: sha512-yYzTZ4++b7fNYxFfpnberEEKu43w44aqDMNM9MHMmcKuCH7lL8jJ4yJ7LGHv7rSwiqM0nkiobF9I6cLlpS2P7Q==}
 
+  tailwindcss@4.3.3:
+    resolution: {integrity: sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==}
+
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
+    engines: {node: '>=6'}
+
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
   tar@7.5.22:
@@ -9994,40 +10112,86 @@ snapshots:
       source-map-js: 1.2.1
       tailwindcss: 4.2.0
 
+  '@tailwindcss/node@4.3.3':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.24.5
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.3.3
+
   '@tailwindcss/oxide-android-arm64@4.2.0':
+    optional: true
+
+  '@tailwindcss/oxide-android-arm64@4.3.3':
     optional: true
 
   '@tailwindcss/oxide-darwin-arm64@4.2.0':
     optional: true
 
+  '@tailwindcss/oxide-darwin-arm64@4.3.3':
+    optional: true
+
   '@tailwindcss/oxide-darwin-x64@4.2.0':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.3.3':
     optional: true
 
   '@tailwindcss/oxide-freebsd-x64@4.2.0':
     optional: true
 
+  '@tailwindcss/oxide-freebsd-x64@4.3.3':
+    optional: true
+
   '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3':
     optional: true
 
   '@tailwindcss/oxide-linux-arm64-gnu@4.2.0':
     optional: true
 
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.3':
+    optional: true
+
   '@tailwindcss/oxide-linux-arm64-musl@4.2.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
     optional: true
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.0':
     optional: true
 
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
+    optional: true
+
   '@tailwindcss/oxide-linux-x64-musl@4.2.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.3':
     optional: true
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.0':
     optional: true
 
+  '@tailwindcss/oxide-wasm32-wasi@4.3.3':
+    optional: true
+
   '@tailwindcss/oxide-win32-arm64-msvc@4.2.0':
     optional: true
 
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.3':
+    optional: true
+
   '@tailwindcss/oxide-win32-x64-msvc@4.2.0':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.3':
     optional: true
 
   '@tailwindcss/oxide@4.2.0':
@@ -10045,12 +10209,20 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.2.0
       '@tailwindcss/oxide-win32-x64-msvc': 4.2.0
 
-  '@tailwindcss/vite@4.2.0(vite@8.0.16(@types/node@22.20.1)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
-    dependencies:
-      '@tailwindcss/node': 4.2.0
-      '@tailwindcss/oxide': 4.2.0
-      tailwindcss: 4.2.0
-      vite: 8.0.16(@types/node@22.20.1)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+  '@tailwindcss/oxide@4.3.3':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.3.3
+      '@tailwindcss/oxide-darwin-arm64': 4.3.3
+      '@tailwindcss/oxide-darwin-x64': 4.3.3
+      '@tailwindcss/oxide-freebsd-x64': 4.3.3
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.3
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.3
+      '@tailwindcss/oxide-linux-arm64-musl': 4.3.3
+      '@tailwindcss/oxide-linux-x64-gnu': 4.3.3
+      '@tailwindcss/oxide-linux-x64-musl': 4.3.3
+      '@tailwindcss/oxide-wasm32-wasi': 4.3.3
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.3
+      '@tailwindcss/oxide-win32-x64-msvc': 4.3.3
 
   '@tailwindcss/vite@4.2.0(vite@8.0.16(@types/node@25.6.0)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
@@ -10058,6 +10230,13 @@ snapshots:
       '@tailwindcss/oxide': 4.2.0
       tailwindcss: 4.2.0
       vite: 8.0.16(@types/node@25.6.0)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+
+  '@tailwindcss/vite@4.3.3(vite@8.0.16(@types/node@22.20.1)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@tailwindcss/node': 4.3.3
+      '@tailwindcss/oxide': 4.3.3
+      tailwindcss: 4.3.3
+      vite: 8.0.16(@types/node@22.20.1)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -10615,15 +10794,15 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.7
       vite: 8.0.16(@types/node@25.6.0)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
 
-  '@vitejs/plugin-react@6.0.3(vite@8.0.16(@types/node@22.20.1)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
-    dependencies:
-      '@rolldown/pluginutils': 1.0.1
-      vite: 8.0.16(@types/node@22.20.1)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
-
   '@vitejs/plugin-react@6.0.3(vite@8.0.16(@types/node@25.6.0)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.0.16(@types/node@25.6.0)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+
+  '@vitejs/plugin-react@6.0.5(vite@8.0.16(@types/node@22.20.1)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.0.16(@types/node@22.20.1)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/coverage-v8@4.1.10(vitest@4.1.9)':
     dependencies:
@@ -11514,6 +11693,11 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.0
+
+  enhanced-resolve@5.24.5:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
 
   enquirer@2.4.1:
     dependencies:
@@ -14028,7 +14212,11 @@ snapshots:
 
   tailwindcss@4.2.0: {}
 
+  tailwindcss@4.3.3: {}
+
   tapable@2.3.0: {}
+
+  tapable@2.3.3: {}
 
   tar@7.5.22:
     dependencies:

--- a/libraries/typescript/pnpm-workspace.yaml
+++ b/libraries/typescript/pnpm-workspace.yaml
@@ -61,7 +61,7 @@ overrides:
   zod: 4.4.3
   jsondiffpatch: ">=0.7.2"
   esbuild: 0.27.1
-  vite: ">=8.0.5"
+  vite: "8.0.16"
   prismjs: ">=1.30.0"
   glob: ">=10.5.0"
   js-yaml: ">=4.1.2"

--- a/libraries/typescript/scripts/summarize-conformance.mjs
+++ b/libraries/typescript/scripts/summarize-conformance.mjs
@@ -39,6 +39,7 @@ const expectedFailures = expectedFailuresFile
   : [];
 
 function isExpectedOutcome(suite, check) {
+  if (!suite.startsWith("2025-11-25/server/")) return false;
   return expectedFailures.some((entry) => {
     const separator = entry.indexOf(":");
     const scenario = separator === -1 ? entry : entry.slice(0, separator);

--- a/libraries/typescript/scripts/summarize-conformance.mjs
+++ b/libraries/typescript/scripts/summarize-conformance.mjs
@@ -9,10 +9,13 @@ const runner = runnerIndex === -1 ? undefined : args[runnerIndex + 1];
 const specVersionsIndex = args.indexOf("--spec-versions");
 const specVersions =
   specVersionsIndex === -1 ? undefined : args[specVersionsIndex + 1];
+const expectedFailuresIndex = args.indexOf("--expected-failures");
+const expectedFailuresFile =
+  expectedFailuresIndex === -1 ? undefined : args[expectedFailuresIndex + 1];
 
 if (!root) {
   console.error(
-    "Usage: summarize-conformance <results-dir> [--runner <package>] [--spec-versions <versions>] [--output <file>]"
+    "Usage: summarize-conformance <results-dir> [--runner <package>] [--spec-versions <versions>] [--expected-failures <file>] [--output <file>]"
   );
   process.exit(2);
 }
@@ -28,43 +31,82 @@ function filesUnder(directory) {
 const files = statSync(root, { throwIfNoEntry: false }) ? filesUnder(root) : [];
 const rows = [];
 
+const expectedFailures = expectedFailuresFile
+  ? readFileSync(expectedFailuresFile, "utf8")
+      .split("\n")
+      .map((line) => line.match(/^\s*-\s+([^#\s]+)(?:\s+#.*)?$/u)?.[1])
+      .filter(Boolean)
+  : [];
+
+function isExpectedOutcome(suite, check) {
+  return expectedFailures.some((entry) => {
+    const separator = entry.indexOf(":");
+    const scenario = separator === -1 ? entry : entry.slice(0, separator);
+    const checkId = separator === -1 ? undefined : entry.slice(separator + 1);
+    return (
+      suite.includes(`/server/server-${scenario}-`) &&
+      (!checkId || check.id === checkId)
+    );
+  });
+}
+
 for (const file of files.sort()) {
   const checks = JSON.parse(readFileSync(file, "utf8"));
+  const suite = relative(root, file).replace(/\/checks\.json$/u, "");
   const passed = checks.filter((check) => check.status === "SUCCESS").length;
-  const failed = checks.filter((check) => check.status === "FAILURE").length;
-  const warnings = checks.filter((check) => check.status === "WARNING").length;
+  const failures = checks.filter((check) => check.status === "FAILURE");
+  const warningChecks = checks.filter((check) => check.status === "WARNING");
+  const expectedFailuresCount = failures.filter((check) =>
+    isExpectedOutcome(suite, check)
+  ).length;
+  const unexpectedFailures = failures.length - expectedFailuresCount;
+  const expectedWarnings = warningChecks.filter((check) =>
+    isExpectedOutcome(suite, check)
+  ).length;
+  const unexpectedWarnings = warningChecks.length - expectedWarnings;
   rows.push({
-    suite: relative(root, file).replace(/\/checks\.json$/u, ""),
+    suite,
     passed,
-    failed,
-    warnings,
+    expectedFailures: expectedFailuresCount,
+    unexpectedFailures,
+    expectedWarnings,
+    unexpectedWarnings,
     // INFO records describe the scenario and are not test outcomes. Match
     // the conformance runner's score convention: total = passed + failed.
-    total: passed + failed,
+    total: passed + failures.length,
   });
 }
 
 const totals = rows.reduce(
   (result, row) => ({
     passed: result.passed + row.passed,
-    failed: result.failed + row.failed,
-    warnings: result.warnings + row.warnings,
+    expectedFailures: result.expectedFailures + row.expectedFailures,
+    unexpectedFailures: result.unexpectedFailures + row.unexpectedFailures,
+    expectedWarnings: result.expectedWarnings + row.expectedWarnings,
+    unexpectedWarnings: result.unexpectedWarnings + row.unexpectedWarnings,
     total: result.total + row.total,
   }),
-  { passed: 0, failed: 0, warnings: 0, total: 0 }
+  {
+    passed: 0,
+    expectedFailures: 0,
+    unexpectedFailures: 0,
+    expectedWarnings: 0,
+    unexpectedWarnings: 0,
+    total: 0,
+  }
 );
 
 const lines = [
   "**Runner:** `" + (runner ?? "unspecified") + "`",
   "**Spec versions:** `" + (specVersions ?? "unspecified") + "`",
   "",
-  `**Score: ${totals.passed}/${totals.total} passed** (${totals.failed} failed, ${totals.warnings} warnings)`,
+  `**Score: ${totals.passed}/${totals.total} passed** (${totals.expectedFailures} expected failures, ${totals.unexpectedFailures} unexpected failures, ${totals.expectedWarnings} expected warnings, ${totals.unexpectedWarnings} unexpected warnings)`,
   "",
-  "| Suite | Score | Failed | Warnings |",
-  "| --- | ---: | ---: | ---: |",
+  "| Suite | Score | Expected failures | Unexpected failures | Expected warnings | Unexpected warnings |",
+  "| --- | ---: | ---: | ---: | ---: | ---: |",
   ...rows.map(
     (row) =>
-      `| \`${row.suite}\` | ${row.passed}/${row.total} | ${row.failed} | ${row.warnings} |`
+      `| \`${row.suite}\` | ${row.passed}/${row.total} | ${row.expectedFailures} | ${row.unexpectedFailures} | ${row.expectedWarnings} | ${row.unexpectedWarnings} |`
   ),
 ];
 
@@ -72,4 +114,4 @@ const summary = `${lines.join("\n")}\n`;
 if (output) writeFileSync(output, summary);
 else process.stdout.write(summary);
 
-if (totals.failed > 0) process.exitCode = 1;
+if (totals.unexpectedFailures > 0) process.exitCode = 1;

--- a/libraries/typescript/scripts/verify-release-install.mjs
+++ b/libraries/typescript/scripts/verify-release-install.mjs
@@ -326,17 +326,22 @@ function verifyRuntimeImport(directory, conditions) {
         .join("\n")
     );
   } else {
-    assert.ok(
-      builtins.every((url) => url === "node:process"),
-      `unexpected Node builtins: ${builtins.join(", ")}`
-    );
-    const processResolution = resolutions.find(
-      ({ url }) => url === "node:process"
-    );
-    if (processResolution) {
+    const allowedBuiltins = new Map([
+      [
+        "node:process",
+        /(?:@modelcontextprotocol\/server\/dist\/shimsNode|\/mcp-use\/dist\/index-node)\.(?:mjs|js)$/,
+      ],
+      ["node:http", /\/mcp-use\/dist\/index-node\.js$/],
+    ]);
+    for (const resolution of resolutions.filter(({ url }) =>
+      url.startsWith("node:")
+    )) {
+      const allowedParent = allowedBuiltins.get(resolution.url);
+      assert.ok(allowedParent, `unexpected Node builtin: ${resolution.url}`);
       assert.match(
-        processResolution.parentURL ?? "",
-        /@modelcontextprotocol\/server\/dist\/shimsNode\.mjs$/
+        resolution.parentURL ?? "",
+        allowedParent,
+        `${resolution.url} loaded by unexpected parent`
       );
     }
   }


### PR DESCRIPTION
## Summary

- Harden stable-release and conformance validation.
- Update the Inspector container command to pass `--no-open` in production.
- Keep the container listening on Railway's injected `PORT`.

## Root cause

Railway containers are headless. The Inspector server started successfully, but the CLI then attempted to launch a local GUI browser and reported `ENOENT` when no browser executable was available. Passing `--no-open` prevents that non-fatal warning while preserving the remotely accessible `/inspector` endpoint.

## Validation

- `git diff --check`
- Repository pre-commit checks passed.
- Dockerfile syntax validation could not run because the local Docker daemon was unavailable.
- Package type-check was not run from the repository root because this checkout has no root `package.json`; the TypeScript workspace is under `libraries/typescript`.

The branch contains the prior stable-release/conformance fixes already present on `fix/stable-release-blockers`, plus the Inspector container change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stable-release blockers by tightening CSP defaults, pinning build tools, and handling expected conformance outcomes. Also fixes Inspector Docker startup in headless environments by disabling auto-open while still honoring Railway’s `PORT`.

- **Bug Fixes**
  - `@mcp-use/inspector` Dockerfile now passes `--no-open` and keeps `--port "${PORT:-8080}"`.
  - Removes `'unsafe-eval'` from widget-declared CSPs; keeps domain restrictions; tests updated.
  - Conformance summary supports `--expected-failures`, separates expected vs unexpected outcomes, and CI wires in the legacy expected-failures list.

- **Dependencies**
  - Pins build tooling: `vite@8.0.16`, `@tailwindcss/vite@4.3.3`, `tailwindcss@4.3.3`, `@vitejs/plugin-react@6.0.5`.
  - Adds packed release install verification to the TypeScript release workflow and tightens builtin resolution checks.
  - Adds a patch changeset for `@mcp-use/cli` and `@mcp-use/inspector`.

<sup>Written for commit eed945d7b2f27ee4267db1526f8f8a96ef8295a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

