### PR TITLE
Disable browser auto-open in Inspector container

### DIFF
--- a/libraries/typescript/packages/inspector/Dockerfile
+++ b/libraries/typescript/packages/inspector/Dockerfile
@@ -22,4 +22,4 @@ EXPOSE 8080
 
 # Start the inspector. Shell form so ${PORT:-8080} expands; exec keeps the
 # node process as PID 1 for signal handling.
-CMD ["sh", "-c", "exec npx @mcp-use/inspector --port \"${PORT:-8080}\""]
+CMD ["sh", "-c", "exec npx @mcp-use/inspector --port \"${PORT:-8080}\" --no-open"]


### PR DESCRIPTION
## Summary

Pass `--no-open` when starting the Inspector Docker image.

## Why

Railway containers are headless. The Inspector server starts successfully, but the CLI attempts to launch a local GUI browser and logs an `ENOENT` warning when no browser executable is installed. The Inspector remains available remotely at `/inspector`; this flag removes the unnecessary browser-launch attempt.

## Validation

- `git diff --check origin/main...HEAD`
- Confirmed the branch contains exactly one changed file and one line changed relative to `main`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable browser auto-open in the Inspector Docker image by adding `--no-open` to `npx @mcp-use/inspector`. This avoids ENOENT warnings in headless Railway containers; the Inspector remains available at `/inspector`.

<sup>Written for commit 1d1f366bf8f54712c48b9815a1924fb6a64ce5c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

