### PR TITLE
fix(client): surface auth for protected operations

### DIFF
--- a/libraries/typescript/.changeset/protected-operations-auth.md
+++ b/libraries/typescript/.changeset/protected-operations-auth.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/client": patch
+---
+
+Surface mixed-auth state when protected resource, prompt, skill, completion, or refresh operations require OAuth, so React clients retain their ready anonymous connection and can present authentication for every challenged operation.

--- a/libraries/typescript/packages/client/src/react/useMcp-operations.ts
+++ b/libraries/typescript/packages/client/src/react/useMcp-operations.ts
@@ -55,6 +55,20 @@ function requireConnection(params: Params, operation: string): MCPConnection {
   return connection;
 }
 
+async function executeWithAuthorizationSignal<T>(
+  params: Params,
+  operation: () => Promise<T>
+): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    if (isOAuthInteractionRequired(error)) {
+      params.onAuthorizationRequired(error);
+    }
+    throw error;
+  }
+}
+
 export function useMcpOperations(params: Params) {
   const callTool = useCallback<UseMcpResult["callTool"]>(
     async (name, args, options) => {
@@ -62,7 +76,9 @@ export function useMcpOperations(params: Params) {
       params.addLog("info", `Calling tool: ${name}`, args);
       const startedAt = Date.now();
       try {
-        const result = await connection.callTool(name, args || {}, options);
+        const result = await executeWithAuthorizationSignal(params, () =>
+          connection.callTool(name, args || {}, options)
+        );
         params.addLog("info", `Tool "${name}" call successful:`, result);
         Tel.getInstance()
           .trackUseMcpToolCall({
@@ -73,9 +89,6 @@ export function useMcpOperations(params: Params) {
           .catch(() => {});
         return result;
       } catch (error) {
-        if (isOAuthInteractionRequired(error)) {
-          params.onAuthorizationRequired(error);
-        }
         params.addLog("error", `Tool "${name}" call failed:`, error);
         Tel.getInstance()
           .trackUseMcpToolCall({
@@ -94,16 +107,20 @@ export function useMcpOperations(params: Params) {
   const listResources = useCallback(async () => {
     const connection = requireConnection(params, "list resources");
     params.addLog("info", "Listing resources");
-    const result = await connection.listAllResources();
+    const result = await executeWithAuthorizationSignal(params, () =>
+      connection.listAllResources()
+    );
     params.setResources(result.resources || []);
-  }, [params.addLog]);
+  }, [params.addLog, params.onAuthorizationRequired]);
 
   const readResource = useCallback(
     async (uri: string) => {
       const connection = requireConnection(params, "read resource");
       params.addLog("info", `Reading resource: ${uri}`);
       try {
-        const result = await connection.readResource(uri);
+        const result = await executeWithAuthorizationSignal(params, () =>
+          connection.readResource(uri)
+        );
         Tel.getInstance()
           .trackUseMcpResourceRead({ resourceUri: uri, success: true })
           .catch(() => {});
@@ -119,78 +136,96 @@ export function useMcpOperations(params: Params) {
         throw error;
       }
     },
-    [params.addLog]
+    [params.addLog, params.onAuthorizationRequired]
   );
 
   const listSkills = useCallback(async () => {
     const connection = requireConnection(params, "list skills");
     params.addLog("info", "Listing skills");
-    const result = await connection.listAllSkills();
+    const result = await executeWithAuthorizationSignal(params, () =>
+      connection.listAllSkills()
+    );
     params.setSkills(result.skills);
-  }, [params.addLog]);
+  }, [params.addLog, params.onAuthorizationRequired]);
 
   const getSkill = useCallback(
     async (uri: string) => {
       const connection = requireConnection(params, "get skill");
       params.addLog("info", `Getting skill: ${uri}`);
-      return connection.getSkill(uri);
+      return executeWithAuthorizationSignal(params, () =>
+        connection.getSkill(uri)
+      );
     },
-    [params.addLog]
+    [params.addLog, params.onAuthorizationRequired]
   );
 
   const readResourceDirectory = useCallback(
     async (uri: string, cursor?: string) => {
       const connection = requireConnection(params, "read resource directory");
       params.addLog("info", `Reading resource directory: ${uri}`);
-      return connection.readResourceDirectory(uri, cursor);
+      return executeWithAuthorizationSignal(params, () =>
+        connection.readResourceDirectory(uri, cursor)
+      );
     },
-    [params.addLog]
+    [params.addLog, params.onAuthorizationRequired]
   );
 
   const listPrompts = useCallback(async () => {
     const connection = requireConnection(params, "list prompts");
     params.addLog("info", "Listing prompts");
-    const result = await connection.listPrompts();
+    const result = await executeWithAuthorizationSignal(params, () =>
+      connection.listPrompts()
+    );
     params.setPrompts(result.prompts || []);
-  }, [params.addLog]);
+  }, [params.addLog, params.onAuthorizationRequired]);
 
   const refreshTools = useCallback(async () => {
     if (params.stateRef.current !== "ready" || !params.connectionRef.current)
       return;
     try {
-      params.setTools((await params.connectionRef.current.listTools()) || []);
+      params.setTools(
+        (await executeWithAuthorizationSignal(params, () =>
+          params.connectionRef.current!.listTools()
+        )) || []
+      );
     } catch (error) {
       params.addLog("error", "Failed to refresh tools:", error);
     }
-  }, [params.addLog]);
+  }, [params.addLog, params.onAuthorizationRequired]);
 
   const refreshResources = useCallback(async () => {
     if (params.stateRef.current !== "ready" || !params.connectionRef.current)
       return;
     try {
-      const result = await params.connectionRef.current.listAllResources();
+      const result = await executeWithAuthorizationSignal(params, () =>
+        params.connectionRef.current!.listAllResources()
+      );
       params.setResources(result.resources || []);
     } catch (error) {
       params.addLog("warn", "Failed to refresh resources:", error);
     }
-  }, [params.addLog]);
+  }, [params.addLog, params.onAuthorizationRequired]);
 
   const refreshPrompts = useCallback(async () => {
     if (params.stateRef.current !== "ready" || !params.connectionRef.current)
       return;
     try {
-      const result = await params.connectionRef.current.listPrompts();
+      const result = await executeWithAuthorizationSignal(params, () =>
+        params.connectionRef.current!.listPrompts()
+      );
       params.setPrompts(result.prompts || []);
     } catch (error) {
       params.addLog("warn", "Failed to refresh prompts:", error);
     }
-  }, [params.addLog]);
+  }, [params.addLog, params.onAuthorizationRequired]);
 
   const refreshSkills = useCallback(async () => {
     if (params.stateRef.current !== "ready" || !params.connectionRef.current)
       return;
     try {
-      const result = await params.connectionRef.current.listAllSkills();
+      const result = await executeWithAuthorizationSignal(params, () =>
+        params.connectionRef.current!.listAllSkills()
+      );
       params.setSkills(result.skills);
     } catch (error) {
       // A development reload may remove the final skills directory, in which
@@ -200,15 +235,17 @@ export function useMcpOperations(params: Params) {
       params.setSkills([]);
       params.addLog("debug", "Skills are unavailable after refresh:", error);
     }
-  }, [params.addLog]);
+  }, [params.addLog, params.onAuthorizationRequired]);
 
   const refreshResourceTemplates = useCallback(async () => {
     const connection = requireConnection(params, "refresh resource templates");
-    const result = await connection.listResourceTemplates();
+    const result = await executeWithAuthorizationSignal(params, () =>
+      connection.listResourceTemplates()
+    );
     if (params.isMounted()) {
       params.setResourceTemplates(result.resourceTemplates || []);
     }
-  }, [params.addLog]);
+  }, [params.addLog, params.onAuthorizationRequired]);
 
   const refreshAll = useCallback(
     () =>
@@ -224,15 +261,21 @@ export function useMcpOperations(params: Params) {
   const getPrompt = useCallback(
     async (name: string, args?: Record<string, unknown>) => {
       const connection = requireConnection(params, "get prompt");
-      return connection.getPrompt(name, args || {});
+      return executeWithAuthorizationSignal(params, () =>
+        connection.getPrompt(name, args || {})
+      );
     },
-    [params.addLog]
+    [params.addLog, params.onAuthorizationRequired]
   );
 
   const complete = useCallback(
-    async (request: CompleteRequestParams): Promise<CompleteResult> =>
-      requireConnection(params, "request completion").complete(request),
-    [params.addLog]
+    async (request: CompleteRequestParams): Promise<CompleteResult> => {
+      const connection = requireConnection(params, "request completion");
+      return executeWithAuthorizationSignal(params, () =>
+        connection.complete(request)
+      );
+    },
+    [params.addLog, params.onAuthorizationRequired]
   );
 
   return {

--- a/libraries/typescript/packages/client/tests/unit/react/useMcp-auth-flow-error.test.tsx
+++ b/libraries/typescript/packages/client/tests/unit/react/useMcp-auth-flow-error.test.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import { act, create } from "react-test-renderer";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { UnauthorizedError } from "@modelcontextprotocol/client";
 
 const mocks = vi.hoisted(() => {
   const auth = vi.fn();
@@ -208,6 +209,86 @@ describe("useMcp manual authentication failures", () => {
         mode: "mixed",
         authenticated: false,
       });
+
+      await act(async () => {
+        renderer!.unmount();
+      });
+    }
+  );
+
+  it.each([
+    {
+      operation: "resource",
+      invoke: (result: ReturnType<typeof useMcp>) =>
+        result.readResource("resource://private/profile"),
+    },
+    {
+      operation: "prompt",
+      invoke: (result: ReturnType<typeof useMcp>) =>
+        result.getPrompt("private-profile"),
+    },
+  ])(
+    "surfaces OAuth state when a protected $operation operation is challenged",
+    async ({ invoke }) => {
+      const authorizationError = new UnauthorizedError(
+        "Authorization required"
+      );
+      mocks.provider.getLastAttemptedAuthUrl.mockReturnValue(
+        "https://auth.example.com/authorize?state=prepared"
+      );
+      mocks.client.connect.mockResolvedValue({
+        tools: [{ name: "public", inputSchema: { type: "object" } }],
+        info: {
+          protocolEra: "legacy",
+          protocolVersion: "2025-06-18",
+          server: { name: "mixed", version: "1.0.0" },
+          capabilities: { tools: {} },
+          instructions: undefined,
+          extensions: {},
+        },
+        supports: vi.fn().mockReturnValue(false),
+        listAllResources: vi.fn().mockResolvedValue({ resources: [] }),
+        listResourceTemplates: vi
+          .fn()
+          .mockResolvedValue({ resourceTemplates: [] }),
+        listPrompts: vi.fn().mockResolvedValue({ prompts: [] }),
+        readResource: vi.fn().mockRejectedValue(authorizationError),
+        getPrompt: vi.fn().mockRejectedValue(authorizationError),
+      });
+
+      let latest: ReturnType<typeof useMcp> | undefined;
+      function TestComponent() {
+        latest = useMcp({
+          url: "https://mcp.example.com/mcp",
+          autoProxyFallback: false,
+          autoReconnect: false,
+          autoRetry: false,
+          logLevel: "silent",
+        });
+        return null;
+      }
+
+      let renderer: ReturnType<typeof create>;
+      await act(async () => {
+        renderer = create(<TestComponent />);
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(latest?.state).toBe("ready");
+
+      await act(async () => {
+        await expect(invoke(latest!)).rejects.toBe(authorizationError);
+      });
+
+      expect(latest?.state).toBe("ready");
+      expect(latest?.authorization).toEqual({
+        mode: "mixed",
+        authenticated: false,
+      });
+      expect(latest?.authUrl).toBe(
+        "https://auth.example.com/authorize?state=prepared"
+      );
 
       await act(async () => {
         renderer!.unmount();


### PR DESCRIPTION
## What changed

- route OAuth interaction errors from every React client operation through the shared mixed-auth state handler
- cover protected resource and prompt challenges with focused hook regressions
- add a patch changeset for `@mcp-use/client`

## Why

Mixed-auth handling previously updated `authorization` only when `callTool()` was challenged. Protected resources, prompts, skills, completions, and refresh operations rethrew the OAuth error without surfacing an Authenticate action, even though the anonymous MCP connection remained usable.

The shared wrapper now preserves the ready connection while consistently exposing `{ mode: "mixed", authenticated: false }` and the SDK-prepared authorization URL for every challenged operation.

## Validation

- `pnpm --filter @mcp-use/client build`
- `pnpm --filter @mcp-use/client test:run` — 53 files, 325 tests passed
- targeted ESLint with zero warnings
- Prettier check
- release-channel tests — 11 passed
- repository pre-commit checks

Closes the P1 finding in #2216.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface mixed-auth state for all protected operations in the React client so apps can prompt authentication without dropping the active anonymous connection. Addresses P1 #2216 by exposing Authenticate with a prepared URL on OAuth challenges across the board.

- **Bug Fixes**
  - Route OAuth errors from resources, prompts, skills, completions, and refresh calls to the mixed-auth handler.
  - Keep state "ready" and expose `authorization` and `authUrl` for every challenged operation.
  - Add focused tests for protected resource and prompt challenges.
  - Add a patch changeset for `@mcp-use/client`.

<sup>Written for commit b4caaa3516f1df2fbcbd133ef40e08fceda46e4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

