### PR TITLE
fix(inspector): resume mixed-auth chat tools

### DIFF
--- a/libraries/typescript/.changeset/bright-chats-auth.md
+++ b/libraries/typescript/.changeset/bright-chats-auth.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Keep hosted mixed-auth tool calls on the browser MCP connection, pause them in Inspector chat with an amber Authenticate action, resume the same client-side chat turn after popup authorization, and automatically replay an interrupted turn after a full-page OAuth redirect.

--- a/libraries/typescript/packages/inspector/src/client/components/ChatTab.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ChatTab.tsx
@@ -1601,6 +1601,21 @@ export function ChatTab({
               serverBaseUrl={connection.url}
               messagesEndRef={messagesEndRef}
               traceEvents={traceEvents}
+              onAuthenticateTool={
+                effectiveClientSide
+                  ? clientSideChat.authenticatePendingTool
+                  : undefined
+              }
+              authenticatingToolCallId={
+                effectiveClientSide
+                  ? clientSideChat.authenticatingToolCallId
+                  : null
+              }
+              toolAuthorizationError={
+                effectiveClientSide
+                  ? clientSideChat.toolAuthorizationError
+                  : null
+              }
             />
           ) : (
             <ChatRawView events={traceEvents} usage={tokenUsage} />

--- a/libraries/typescript/packages/inspector/src/client/components/LayoutContent.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/LayoutContent.tsx
@@ -105,6 +105,7 @@ export function LayoutContent({
   const useManagedClientSide = selectedServer
     ? shouldUseManagedClientSide({
         isLoopback: isLoopbackServer,
+        isMixedAuth: selectedServer.authorization?.mode === "mixed",
         chatApiUrl: embeddedConfig.chatApiUrl,
         enableFreeTierUpgrade: embeddedConfig.chatEnableFreeTierUpgrade,
       })

--- a/libraries/typescript/packages/inspector/src/client/components/chat/MessageList.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/MessageList.tsx
@@ -24,7 +24,12 @@ interface Message {
       toolName: string;
       args: Record<string, unknown>;
       result?: any;
-      state?: "pending" | "streaming" | "result" | "error";
+      state?:
+        | "pending"
+        | "streaming"
+        | "authorization-required"
+        | "result"
+        | "error";
       partialArgs?: Record<string, unknown>;
     };
   }>;
@@ -55,6 +60,9 @@ interface MessageListProps {
   llmConfig?: LLMConfig | null;
   /** Keep tool-call chrome but omit MCP App result bodies (e.g. chat drawer). */
   renderToolResults?: boolean;
+  onAuthenticateTool?: (toolCallId: string) => Promise<void> | void;
+  authenticatingToolCallId?: string | null;
+  toolAuthorizationError?: string | null;
 }
 
 export const MessageList = memo(
@@ -70,6 +78,9 @@ export const MessageList = memo(
     modelContextScope,
     llmConfig,
     renderToolResults = true,
+    onAuthenticateTool,
+    authenticatingToolCallId,
+    toolAuthorizationError,
   }: MessageListProps) => {
     const widgetMessageInFlightRef = useRef(false);
     const isLoadingRef = useRef(isLoading);
@@ -261,18 +272,33 @@ export const MessageList = memo(
                         <div key={partKey}>
                           <ToolCallDisplay
                             toolName={part.toolInvocation.toolName}
+                            toolCallId={part.toolInvocation.toolCallId}
                             args={part.toolInvocation.args}
                             result={part.toolInvocation.result}
                             state={
-                              part.toolInvocation.state === "error"
-                                ? "error"
-                                : part.toolInvocation.state === "streaming"
-                                  ? "call"
-                                  : part.toolInvocation.state === "pending"
+                              part.toolInvocation.state ===
+                              "authorization-required"
+                                ? "authorization-required"
+                                : part.toolInvocation.state === "error"
+                                  ? "error"
+                                  : part.toolInvocation.state === "streaming"
                                     ? "call"
-                                    : "result"
+                                    : part.toolInvocation.state === "pending"
+                                      ? "call"
+                                      : "result"
                             }
                             partialArgs={part.toolInvocation.partialArgs}
+                            onAuthenticate={onAuthenticateTool}
+                            isAuthenticating={
+                              authenticatingToolCallId ===
+                              part.toolInvocation.toolCallId
+                            }
+                            authorizationError={
+                              part.toolInvocation.state ===
+                              "authorization-required"
+                                ? toolAuthorizationError
+                                : null
+                            }
                           />
                           {/* Render tool result / widget */}
                           {/* Render immediately for widget tools or streaming tools, even if result is null */}

--- a/libraries/typescript/packages/inspector/src/client/components/chat/ToolCallDisplay.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/ToolCallDisplay.tsx
@@ -1,4 +1,4 @@
-import { Check, Copy, Loader2, Wrench, X } from "lucide-react";
+import { Check, Copy, Loader2, LockKeyhole, Wrench, X } from "lucide-react";
 import { Button } from "@/client/components/ui/button";
 import {
   Sheet,
@@ -17,8 +17,12 @@ interface ToolCallDisplayProps {
   toolName: string;
   args: Record<string, unknown>;
   result?: any;
-  state?: "call" | "result" | "error";
+  state?: "call" | "authorization-required" | "result" | "error";
   partialArgs?: Record<string, unknown>;
+  onAuthenticate?: (toolCallId: string) => Promise<void> | void;
+  isAuthenticating?: boolean;
+  authorizationError?: string | null;
+  toolCallId?: string;
 }
 
 export function ToolCallDisplay({
@@ -27,6 +31,10 @@ export function ToolCallDisplay({
   result,
   state = "result",
   partialArgs,
+  onAuthenticate,
+  isAuthenticating = false,
+  authorizationError,
+  toolCallId,
 }: ToolCallDisplayProps) {
   const displayArgs = state === "call" && partialArgs ? partialArgs : args;
 
@@ -35,6 +43,10 @@ export function ToolCallDisplay({
       case "call":
         return (
           <Loader2 className="h-4 w-4 animate-spin text-blue-500 dark:text-blue-400" />
+        );
+      case "authorization-required":
+        return (
+          <LockKeyhole className="h-4 w-4 text-amber-700 dark:text-amber-300" />
         );
       case "result":
         return (
@@ -53,6 +65,8 @@ export function ToolCallDisplay({
     switch (state) {
       case "call":
         return " bg-blue-500/20 dark:bg-blue-500/20";
+      case "authorization-required":
+        return " bg-amber-400/30 dark:bg-amber-500/25";
       case "result":
         return " bg-emerald-500/20 dark:bg-emerald-500/20";
       case "error":
@@ -71,160 +85,197 @@ export function ToolCallDisplay({
   };
 
   return (
-    <Sheet>
-      <SheetTrigger
-        render={
-          <div
-            className="flex max-w-min items-center gap-3 p-1 rounded-full border bg-card hover:bg-accent/50 transition-colors cursor-pointer my-4"
-            data-testid={`chat-tool-call-${toolName}`}
-          >
-            {/* Tool Icon */}
-            <div className="w-8 h-8 rounded-full bg-zinc-100 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 flex items-center justify-center shrink-0">
-              <Wrench className="size-4 text-muted-foreground" />
-            </div>
-
-            {/* Tool Name */}
-            <div className="flex-1 min-w-0">
-              <div className="flex items-center gap-2">
-                <span className="text-sm font-medium truncate">
-                  {toolName}(
-                  {Object.keys(displayArgs).length > 0 ? (
-                    <span className="bg-muted-foreground/20 rounded-full px-1.5 mx-1 py-0.5 text-xs">
-                      {Object.keys(displayArgs).length} args
-                    </span>
-                  ) : (
-                    ""
-                  )}
-                  )
-                </span>
-              </div>
-            </div>
-
-            {/* Status Icon */}
+    <div className="my-4 flex w-fit max-w-full flex-col items-start gap-2">
+      <Sheet>
+        <SheetTrigger
+          render={
             <div
               className={cn(
-                "w-8 h-8 rounded-full flex items-center justify-center",
-                getStatusBg()
+                "flex max-w-min items-center gap-3 rounded-full border p-1 transition-colors cursor-pointer",
+                state === "authorization-required"
+                  ? "border-amber-400/70 bg-amber-50 hover:bg-amber-100 dark:border-amber-500/50 dark:bg-amber-950/40 dark:hover:bg-amber-950/60"
+                  : "bg-card hover:bg-accent/50"
               )}
-              data-testid={`chat-tool-call-status-${state}`}
+              data-testid={`chat-tool-call-${toolName}`}
             >
-              {getStatusIcon()}
-            </div>
-          </div>
-        }
-        nativeButton={false}
-      />
+              {/* Tool Icon */}
+              <div className="w-8 h-8 rounded-full bg-zinc-100 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 flex items-center justify-center shrink-0">
+                <Wrench className="size-4 text-muted-foreground" />
+              </div>
 
-      <SheetContent
-        side="right"
-        className="w-[400px] sm:w-[540px] p-4 overflow-y-auto"
-        data-testid="chat-tool-drawer"
-      >
-        <SheetHeader>
-          <SheetTitle className="flex items-center gap-2">
-            <Wrench className="h-5 w-5" />
-            Tool Call Details
-          </SheetTitle>
-          <SheetDescription className="flex items-center gap-2">
-            {toolName} — {state}
-            {state === "call" && (
-              <span className="flex items-center gap-1 text-blue-500 dark:text-blue-400">
-                <Loader2 className="h-3 w-3 animate-spin" />
-                streaming…
-              </span>
-            )}
-          </SheetDescription>
-        </SheetHeader>
-
-        <div className="flex flex-col gap-6 py-4">
-          {/* Arguments */}
-          <div>
-            <h3 className="text-sm font-medium mb-2">Arguments</h3>
-            <div className="relative" data-testid="chat-tool-drawer-args">
-              <pre className="text-xs bg-muted/50 rounded-lg p-3 overflow-x-auto border font-mono leading-relaxed max-h-48 whitespace-pre-wrap break-words">
-                {formatContent(displayArgs)}
-              </pre>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => copyToClipboard(formatContent(displayArgs))}
-                className="absolute top-2 right-2 h-6 w-6 p-0 opacity-70 hover:opacity-100"
-                title="Copy arguments"
-              >
-                <Copy className="h-3 w-3" />
-              </Button>
-            </div>
-          </div>
-
-          {/* Result */}
-          {result && (
-            <div>
-              <h3 className="text-sm font-medium mb-2">Result</h3>
-              <div className="relative" data-testid="chat-tool-drawer-result">
-                {typeof result === "string" ? (
-                  <div
-                    className={cn(
-                      "p-3 rounded-lg border text-sm leading-relaxed max-h-48 overflow-x-auto whitespace-pre-wrap break-words max-w-full",
-                      state === "error"
-                        ? "bg-destructive/10 border-destructive/20 text-destructive-foreground"
-                        : "bg-muted/30 border-border"
-                    )}
-                  >
-                    {result.startsWith("Error") ? (
-                      <div className="font-mono">
-                        <div className="font-semibold text-destructive mb-1">
-                          Error:
-                        </div>
-                        <div className="whitespace-pre-wrap break-words">
-                          {result.replace(/^Error:\s*/, "")}
-                        </div>
-                      </div>
+              {/* Tool Name */}
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium truncate">
+                    {toolName}(
+                    {Object.keys(displayArgs).length > 0 ? (
+                      <span className="bg-muted-foreground/20 rounded-full px-1.5 mx-1 py-0.5 text-xs">
+                        {Object.keys(displayArgs).length} args
+                      </span>
                     ) : (
-                      <div className="whitespace-pre-wrap font-mono break-words">
-                        {result}
-                      </div>
+                      ""
                     )}
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => copyToClipboard(result)}
-                      className="absolute top-2 right-2 h-6 w-6 p-0 opacity-70 hover:opacity-100"
-                      title="Copy result"
-                    >
-                      <Copy className="h-3 w-3" />
-                    </Button>
-                  </div>
-                ) : (
-                  <div
-                    className={cn(
-                      "p-3 rounded-lg border text-sm leading-relaxed max-h-96 overflow-y-auto max-w-full",
-                      state === "error"
-                        ? "bg-destructive/10 border-destructive/20 text-destructive-foreground"
-                        : "bg-muted/30 border-border"
-                    )}
-                  >
-                    <JSONDisplay
-                      data={result}
-                      filename={`tool-call-${toolName}-result-${Date.now()}.json`}
-                    />
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() =>
-                        copyToClipboard(JSON.stringify(result, null, 2))
-                      }
-                      className="absolute top-2 right-2 h-6 w-6 p-0 opacity-70 hover:opacity-100"
-                      title="Copy result"
-                    >
-                      <Copy className="h-3 w-3" />
-                    </Button>
-                  </div>
+                    )
+                  </span>
+                </div>
+              </div>
+
+              {/* Status Icon */}
+              <div
+                className={cn(
+                  "w-8 h-8 rounded-full flex items-center justify-center",
+                  getStatusBg()
                 )}
+                data-testid={`chat-tool-call-status-${state}`}
+              >
+                {getStatusIcon()}
               </div>
             </div>
+          }
+          nativeButton={false}
+        />
+
+        <SheetContent
+          side="right"
+          className="w-[400px] sm:w-[540px] p-4 overflow-y-auto"
+          data-testid="chat-tool-drawer"
+        >
+          <SheetHeader>
+            <SheetTitle className="flex items-center gap-2">
+              <Wrench className="h-5 w-5" />
+              Tool Call Details
+            </SheetTitle>
+            <SheetDescription className="flex items-center gap-2">
+              {toolName} — {state}
+              {state === "call" && (
+                <span className="flex items-center gap-1 text-blue-500 dark:text-blue-400">
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                  streaming…
+                </span>
+              )}
+              {state === "authorization-required" && (
+                <span className="flex items-center gap-1 text-amber-700 dark:text-amber-300">
+                  <LockKeyhole className="h-3 w-3" />
+                  authentication required
+                </span>
+              )}
+            </SheetDescription>
+          </SheetHeader>
+
+          <div className="flex flex-col gap-6 py-4">
+            {/* Arguments */}
+            <div>
+              <h3 className="text-sm font-medium mb-2">Arguments</h3>
+              <div className="relative" data-testid="chat-tool-drawer-args">
+                <pre className="text-xs bg-muted/50 rounded-lg p-3 overflow-x-auto border font-mono leading-relaxed max-h-48 whitespace-pre-wrap break-words">
+                  {formatContent(displayArgs)}
+                </pre>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => copyToClipboard(formatContent(displayArgs))}
+                  className="absolute top-2 right-2 h-6 w-6 p-0 opacity-70 hover:opacity-100"
+                  title="Copy arguments"
+                >
+                  <Copy className="h-3 w-3" />
+                </Button>
+              </div>
+            </div>
+
+            {/* Result */}
+            {result && (
+              <div>
+                <h3 className="text-sm font-medium mb-2">Result</h3>
+                <div className="relative" data-testid="chat-tool-drawer-result">
+                  {typeof result === "string" ? (
+                    <div
+                      className={cn(
+                        "p-3 rounded-lg border text-sm leading-relaxed max-h-48 overflow-x-auto whitespace-pre-wrap break-words max-w-full",
+                        state === "error"
+                          ? "bg-destructive/10 border-destructive/20 text-destructive-foreground"
+                          : "bg-muted/30 border-border"
+                      )}
+                    >
+                      {result.startsWith("Error") ? (
+                        <div className="font-mono">
+                          <div className="font-semibold text-destructive mb-1">
+                            Error:
+                          </div>
+                          <div className="whitespace-pre-wrap break-words">
+                            {result.replace(/^Error:\s*/, "")}
+                          </div>
+                        </div>
+                      ) : (
+                        <div className="whitespace-pre-wrap font-mono break-words">
+                          {result}
+                        </div>
+                      )}
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => copyToClipboard(result)}
+                        className="absolute top-2 right-2 h-6 w-6 p-0 opacity-70 hover:opacity-100"
+                        title="Copy result"
+                      >
+                        <Copy className="h-3 w-3" />
+                      </Button>
+                    </div>
+                  ) : (
+                    <div
+                      className={cn(
+                        "p-3 rounded-lg border text-sm leading-relaxed max-h-96 overflow-y-auto max-w-full",
+                        state === "error"
+                          ? "bg-destructive/10 border-destructive/20 text-destructive-foreground"
+                          : "bg-muted/30 border-border"
+                      )}
+                    >
+                      <JSONDisplay
+                        data={result}
+                        filename={`tool-call-${toolName}-result-${Date.now()}.json`}
+                      />
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() =>
+                          copyToClipboard(JSON.stringify(result, null, 2))
+                        }
+                        className="absolute top-2 right-2 h-6 w-6 p-0 opacity-70 hover:opacity-100"
+                        title="Copy result"
+                      >
+                        <Copy className="h-3 w-3" />
+                      </Button>
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+        </SheetContent>
+      </Sheet>
+
+      {state === "authorization-required" && toolCallId && onAuthenticate && (
+        <div className="flex flex-col items-start gap-1.5 pl-1">
+          <Button
+            data-testid={`chat-tool-authenticate-${toolCallId}`}
+            size="sm"
+            onClick={() => void onAuthenticate(toolCallId)}
+            disabled={isAuthenticating}
+            className="bg-amber-600 text-white hover:bg-amber-700 focus-visible:ring-amber-600 dark:bg-amber-500 dark:text-amber-950 dark:hover:bg-amber-400"
+          >
+            {isAuthenticating ? (
+              <Loader2 className="size-3.5 animate-spin" aria-hidden />
+            ) : (
+              <LockKeyhole className="size-3.5" aria-hidden />
+            )}
+            {isAuthenticating ? "Authenticating…" : "Authenticate"}
+          </Button>
+          {authorizationError && (
+            <p className="max-w-sm text-xs text-red-700 dark:text-red-300">
+              {authorizationError}
+            </p>
           )}
         </div>
-      </SheetContent>
-    </Sheet>
+      )}
+    </div>
   );
 }

--- a/libraries/typescript/packages/inspector/src/client/components/chat/__tests__/chat-auth-retry.test.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/__tests__/chat-auth-retry.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearPendingChatTurn,
+  readPendingChatTurn,
+  savePendingChatTurn,
+} from "../chat-auth-retry";
+
+function createStorage() {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => values.set(key, value),
+    removeItem: (key: string) => values.delete(key),
+  };
+}
+
+describe("chat auth retry storage", () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it("round-trips a pending chat turn for the matching server", () => {
+    const storage = createStorage();
+    const turn = {
+      serverId: "server-1",
+      userInput: "Read my profile",
+      promptResults: [],
+      attachments: [],
+      baseMessages: [
+        {
+          id: "user-1",
+          role: "user" as const,
+          content: "Read my profile",
+          timestamp: 1,
+        },
+      ],
+    };
+
+    savePendingChatTurn(turn, storage);
+
+    expect(readPendingChatTurn("server-1", storage)).toMatchObject(turn);
+    expect(readPendingChatTurn("server-2", storage)).toBeNull();
+  });
+
+  it("drops expired and explicitly cleared turns", () => {
+    const storage = createStorage();
+    vi.spyOn(Date, "now").mockReturnValue(1_000);
+    savePendingChatTurn(
+      {
+        serverId: "server-1",
+        userInput: "Read my profile",
+        promptResults: [],
+        attachments: [],
+        baseMessages: [],
+      },
+      storage
+    );
+
+    vi.spyOn(Date, "now").mockReturnValue(16 * 60_000);
+    expect(readPendingChatTurn("server-1", storage)).toBeNull();
+
+    vi.spyOn(Date, "now").mockReturnValue(20 * 60_000);
+    savePendingChatTurn(
+      {
+        serverId: "server-1",
+        userInput: "Read my profile",
+        promptResults: [],
+        attachments: [],
+        baseMessages: [],
+      },
+      storage
+    );
+    clearPendingChatTurn("server-1", storage);
+    expect(readPendingChatTurn("server-1", storage)).toBeNull();
+  });
+});

--- a/libraries/typescript/packages/inspector/src/client/components/chat/__tests__/freeTier.test.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/__tests__/freeTier.test.ts
@@ -89,7 +89,17 @@ describe("shouldUseManagedClientSide", () => {
     ).toBe(true);
   });
 
-  it("does not enable managed client-side for remote servers", () => {
+  it("enables managed client-side chat for remote mixed-auth servers", () => {
+    expect(
+      shouldUseManagedClientSide({
+        isLoopback: false,
+        isMixedAuth: true,
+        chatApiUrl: "https://cloud.manufact.com/api/v1/inspector/chat/stream",
+      })
+    ).toBe(true);
+  });
+
+  it("does not enable managed client-side for ordinary remote servers", () => {
     expect(
       shouldUseManagedClientSide({
         isLoopback: false,

--- a/libraries/typescript/packages/inspector/src/client/components/chat/chat-auth-retry.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/chat-auth-retry.ts
@@ -1,0 +1,103 @@
+import type { PromptResult } from "../../hooks/useMCPPrompts";
+import type { Message, MessageAttachment } from "./types";
+
+const PENDING_CHAT_TURN_STORAGE_KEY = "__mcpUseInspectorPendingChatTurn";
+const PENDING_CHAT_TURN_MAX_AGE_MS = 15 * 60_000;
+
+type SessionStorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+/** Serializable chat turn retained across a full-page OAuth redirect. */
+export interface PendingChatTurn {
+  serverId: string;
+  userInput: string;
+  promptResults: PromptResult[];
+  attachments: MessageAttachment[];
+  /** Conversation through the user turn, excluding the interrupted assistant. */
+  baseMessages: Message[];
+  savedAt: number;
+}
+
+function defaultSessionStorage(): SessionStorageLike | undefined {
+  try {
+    return typeof sessionStorage === "undefined" ? undefined : sessionStorage;
+  } catch {
+    return undefined;
+  }
+}
+
+function storageKey(serverId: string): string {
+  return `${PENDING_CHAT_TURN_STORAGE_KEY}:${encodeURIComponent(serverId)}`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isPendingChatTurn(value: unknown): value is PendingChatTurn {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value.serverId === "string" &&
+    typeof value.userInput === "string" &&
+    Array.isArray(value.promptResults) &&
+    Array.isArray(value.attachments) &&
+    Array.isArray(value.baseMessages) &&
+    typeof value.savedAt === "number" &&
+    Number.isFinite(value.savedAt)
+  );
+}
+
+export function readPendingChatTurn(
+  serverId: string,
+  storage: SessionStorageLike | undefined = defaultSessionStorage()
+): PendingChatTurn | null {
+  if (!storage) return null;
+  const key = storageKey(serverId);
+  try {
+    const raw = storage.getItem(key);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      !isPendingChatTurn(parsed) ||
+      parsed.serverId !== serverId ||
+      Date.now() - parsed.savedAt > PENDING_CHAT_TURN_MAX_AGE_MS
+    ) {
+      storage.removeItem(key);
+      return null;
+    }
+    return parsed;
+  } catch {
+    try {
+      storage.removeItem(key);
+    } catch {
+      // Storage is best-effort.
+    }
+    return null;
+  }
+}
+
+export function savePendingChatTurn(
+  turn: Omit<PendingChatTurn, "savedAt">,
+  storage: SessionStorageLike | undefined = defaultSessionStorage()
+): void {
+  if (!storage) return;
+  try {
+    storage.setItem(
+      storageKey(turn.serverId),
+      JSON.stringify({ ...turn, savedAt: Date.now() } satisfies PendingChatTurn)
+    );
+  } catch {
+    // Storage is best-effort; popup OAuth can still resume in memory.
+  }
+}
+
+export function clearPendingChatTurn(
+  serverId: string,
+  storage: SessionStorageLike | undefined = defaultSessionStorage()
+): void {
+  if (!storage) return;
+  try {
+    storage.removeItem(storageKey(serverId));
+  } catch {
+    // Storage is best-effort.
+  }
+}

--- a/libraries/typescript/packages/inspector/src/client/components/chat/freeTier.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/freeTier.ts
@@ -29,16 +29,18 @@ export function shouldShowFreeTierUpgrade({
   return isManaged && enableFreeTierUpgrade && !isAuthenticated;
 }
 
-/** True when localhost MCP should use browser MCPAgent + cloud LLM proxy. */
+/** True when MCP tools must stay in the browser while the cloud proxies only the LLM. */
 export function shouldUseManagedClientSide({
   isLoopback,
+  isMixedAuth = false,
   chatApiUrl,
 }: {
   isLoopback: boolean;
+  isMixedAuth?: boolean;
   chatApiUrl?: string;
   enableFreeTierUpgrade?: boolean;
 }): boolean {
-  return isLoopback && !!chatApiUrl;
+  return (isLoopback || isMixedAuth) && !!chatApiUrl;
 }
 
 /** LLM config for the managed inspector LLM proxy (`/inspector/llm/*`). */

--- a/libraries/typescript/packages/inspector/src/client/components/chat/types.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/types.ts
@@ -22,7 +22,12 @@ export interface Message {
       toolName: string;
       args: Record<string, unknown>;
       result?: any;
-      state?: "pending" | "streaming" | "result" | "error";
+      state?:
+        | "pending"
+        | "streaming"
+        | "authorization-required"
+        | "result"
+        | "error";
       /** Best-effort parsed partial arguments while the LLM is still generating */
       partialArgs?: Record<string, unknown>;
     };
@@ -53,6 +58,8 @@ export type ChatBodyBuilder = (
 export interface SendMessageOptions {
   throwOnError?: boolean;
   onAccepted?: () => void;
+  /** Internal: replay a persisted OAuth-interrupted turn without duplicating its user message. */
+  resumeExistingTurn?: boolean;
 }
 
 export interface LLMConfig {

--- a/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessagesClientSide.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessagesClientSide.ts
@@ -4,7 +4,11 @@ import {
   providerConfigFromOptions,
   type McpConnectionLike,
 } from "@mcp-use/agent";
-import type { McpServer, Skill } from "@mcp-use/client/react";
+import {
+  isOAuthInteractionRequired,
+  type McpServer,
+  type Skill,
+} from "@mcp-use/client/react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { PromptResult } from "../../hooks/useMCPPrompts";
 import {
@@ -40,6 +44,12 @@ import {
   buildSkillSystemContext,
   createSkillContextConnection,
 } from "./skill-context";
+import {
+  clearPendingChatTurn,
+  readPendingChatTurn,
+  savePendingChatTurn,
+  type PendingChatTurn,
+} from "./chat-auth-retry";
 
 // Type alias for backward compatibility
 type MCPConnection = McpServer;
@@ -69,7 +79,13 @@ export function useChatMessagesClientSide({
   systemPrompt = DEFAULT_CHAT_SYSTEM_PROMPT,
   skills = [],
 }: UseChatMessagesClientSideProps) {
-  const [messages, setMessages] = useState<Message[]>(initialMessages ?? []);
+  const retryServerId = connection.id ?? connection.url;
+  const [initialPendingTurn] = useState(() =>
+    readPendingChatTurn(retryServerId)
+  );
+  const [messages, setMessages] = useState<Message[]>(
+    () => initialPendingTurn?.baseMessages ?? initialMessages ?? []
+  );
   const [isLoading, setIsLoading] = useState(false);
   const [attachments, setAttachments] = useState<MessageAttachment[]>([]);
   const [traceState, setTraceState] = useState(EMPTY_TRACE_STATE);
@@ -78,6 +94,22 @@ export function useChatMessagesClientSide({
   const abortControllerRef = useRef<AbortController | null>(null);
   const sendInProgressRef = useRef(false);
   const traceIdRef = useRef(0);
+  const initialPendingTurnRef = useRef(initialPendingTurn);
+  const authorizationGateRef = useRef<{
+    toolCallId: string;
+    resolve: () => void;
+    reject: (error: Error) => void;
+  } | null>(null);
+  const [pendingAuthorization, setPendingAuthorization] = useState<{
+    toolCallId: string;
+    replay: Omit<PendingChatTurn, "savedAt">;
+  } | null>(null);
+  const [authenticatingToolCallId, setAuthenticatingToolCallId] = useState<
+    string | null
+  >(null);
+  const [toolAuthorizationError, setToolAuthorizationError] = useState<
+    string | null
+  >(null);
 
   const recordTrace = useCallback((event: InspectorTraceEventInput) => {
     const next = {
@@ -89,6 +121,7 @@ export function useChatMessagesClientSide({
   }, []);
 
   useEffect(() => {
+    if (initialPendingTurnRef.current) return;
     if (initialMessages !== undefined) {
       setMessages(initialMessages);
     }
@@ -101,7 +134,10 @@ export function useChatMessagesClientSide({
       extraAttachments?: MessageAttachment[],
       options?: SendMessageOptions
     ) => {
-      const allAttachments = [...attachments, ...(extraAttachments ?? [])];
+      const isResuming = options?.resumeExistingTurn === true;
+      const allAttachments = isResuming
+        ? (extraAttachments ?? [])
+        : [...attachments, ...(extraAttachments ?? [])];
       const hasContent =
         userInput.trim() ||
         promptResults.length > 0 ||
@@ -145,7 +181,12 @@ export function useChatMessagesClientSide({
         userMessages.push(userMessage);
       }
 
-      setMessages((prev) => [...prev, ...userMessages]);
+      const baseMessages = isResuming
+        ? messages
+        : [...messages, ...userMessages];
+      if (!isResuming) {
+        setMessages(baseMessages);
+      }
       setIsLoading(true);
       setAttachments([]);
 
@@ -170,7 +211,12 @@ export function useChatMessagesClientSide({
             toolName: string;
             args: Record<string, unknown>;
             result?: any;
-            state?: "pending" | "streaming" | "result" | "error";
+            state?:
+              | "pending"
+              | "streaming"
+              | "authorization-required"
+              | "result"
+              | "error";
             partialArgs?: Record<string, unknown>;
           };
         }> = [];
@@ -203,12 +249,7 @@ export function useChatMessagesClientSide({
           },
         ]);
 
-        const hasImageAttachments = (userMessage.attachments?.length ?? 0) > 0;
-        const historyMessages = [
-          ...messages,
-          ...promptResultsMessages,
-          ...(userInput.trim() || hasImageAttachments ? [userMessage] : []),
-        ];
+        const historyMessages = baseMessages;
 
         const serializedWidgetContext = serializeWidgetModelContexts(
           widgetModelContexts ?? new Map()
@@ -236,6 +277,93 @@ export function useChatMessagesClientSide({
           getSkill: connection.getSkill,
           readResource: connection.readResource,
         });
+        const commitMessageParts = () => {
+          setMessages((prev) =>
+            prev.map((msg) =>
+              msg.id === assistantMessageId
+                ? { ...msg, parts: [...parts] }
+                : msg
+            )
+          );
+        };
+        const replayTurn: Omit<PendingChatTurn, "savedAt"> = {
+          serverId: retryServerId,
+          userInput,
+          promptResults,
+          attachments: allAttachments,
+          baseMessages,
+        };
+        const authAwareConnection: MCPConnection = {
+          ...connection,
+          callTool: async (toolName, args) => {
+            let authorizationAttempts = 0;
+            while (true) {
+              try {
+                return await connection.callTool(toolName, args);
+              } catch (error) {
+                if (
+                  !isOAuthInteractionRequired(error) ||
+                  authorizationAttempts >= 1
+                ) {
+                  throw error;
+                }
+                authorizationAttempts++;
+
+                const toolPart = [...parts]
+                  .reverse()
+                  .find(
+                    (part) =>
+                      part.type === "tool-invocation" &&
+                      part.toolInvocation?.toolName === toolName &&
+                      part.toolInvocation.state === "pending"
+                  );
+                const toolCallId = toolPart?.toolInvocation?.toolCallId;
+                if (!toolPart?.toolInvocation || !toolCallId) throw error;
+
+                toolPart.toolInvocation.state = "authorization-required";
+                setPendingAuthorization({ toolCallId, replay: replayTurn });
+                setToolAuthorizationError(null);
+                commitMessageParts();
+
+                await new Promise<void>((resolve, reject) => {
+                  const signal = abortControllerRef.current?.signal;
+                  const handleAbort = () => {
+                    if (
+                      authorizationGateRef.current?.toolCallId === toolCallId
+                    ) {
+                      authorizationGateRef.current = null;
+                    }
+                    reject(
+                      new DOMException("Chat turn was cancelled", "AbortError")
+                    );
+                  };
+                  const cleanup = () =>
+                    signal?.removeEventListener("abort", handleAbort);
+                  authorizationGateRef.current = {
+                    toolCallId,
+                    resolve: () => {
+                      cleanup();
+                      resolve();
+                    },
+                    reject: (gateError) => {
+                      cleanup();
+                      reject(gateError);
+                    },
+                  };
+                  signal?.addEventListener("abort", handleAbort, {
+                    once: true,
+                  });
+                });
+
+                toolPart.toolInvocation.state = "pending";
+                setPendingAuthorization(null);
+                setToolAuthorizationError(null);
+                clearPendingChatTurn(retryServerId);
+                commitMessageParts();
+              }
+            }
+          },
+        };
         const agent = new MCPAgent({
           llm: providerConfigFromOptions(llmConfig.provider, llmConfig.model, {
             apiKey: llmConfig.apiKey,
@@ -245,7 +373,7 @@ export function useChatMessagesClientSide({
           }),
           mcpServers: [
             ...(skillConnection ? [skillConnection] : []),
-            connection,
+            authAwareConnection,
             ...(appToolConnections ?? []),
           ],
           systemPrompt: `${systemPrompt}${buildSkillSystemContext(
@@ -259,15 +387,6 @@ export function useChatMessagesClientSide({
           maxSteps: 10,
           autoInitialize: true,
         });
-        const commitMessageParts = () => {
-          setMessages((prev) =>
-            prev.map((msg) =>
-              msg.id === assistantMessageId
-                ? { ...msg, parts: [...parts] }
-                : msg
-            )
-          );
-        };
 
         for await (const ev of agent.streamEvents({
           messages: providerMessages,
@@ -526,16 +645,71 @@ export function useChatMessagesClientSide({
       appToolConnections,
       widgetModelContexts,
       recordTrace,
+      retryServerId,
       systemPrompt,
       skills,
     ]
   );
 
+  const authenticatePendingTool = useCallback(
+    async (toolCallId: string) => {
+      if (
+        pendingAuthorization?.toolCallId !== toolCallId ||
+        authenticatingToolCallId
+      ) {
+        return;
+      }
+
+      savePendingChatTurn(pendingAuthorization.replay);
+      setAuthenticatingToolCallId(toolCallId);
+      setToolAuthorizationError(null);
+      try {
+        await connection.authenticate();
+        const gate = authorizationGateRef.current;
+        if (gate?.toolCallId === toolCallId) {
+          authorizationGateRef.current = null;
+          gate.resolve();
+        }
+      } catch (error) {
+        clearPendingChatTurn(retryServerId);
+        setToolAuthorizationError(
+          error instanceof Error ? error.message : "Authentication failed"
+        );
+      } finally {
+        setAuthenticatingToolCallId(null);
+      }
+    },
+    [authenticatingToolCallId, connection, pendingAuthorization, retryServerId]
+  );
+
+  useEffect(() => {
+    const pendingTurn = initialPendingTurnRef.current;
+    if (!pendingTurn || !isConnected || !llmConfig) return;
+
+    initialPendingTurnRef.current = null;
+    clearPendingChatTurn(retryServerId);
+    setMessages(pendingTurn.baseMessages);
+    void sendMessage(
+      pendingTurn.userInput,
+      pendingTurn.promptResults,
+      pendingTurn.attachments,
+      { resumeExistingTurn: true }
+    );
+  }, [isConnected, llmConfig, retryServerId, sendMessage]);
+
   const clearMessages = useCallback(() => {
+    clearPendingChatTurn(retryServerId);
+    authorizationGateRef.current?.reject(
+      new DOMException("Chat turn was cancelled", "AbortError")
+    );
+    authorizationGateRef.current = null;
+    setPendingAuthorization(null);
+    setAuthenticatingToolCallId(null);
+    setToolAuthorizationError(null);
     setMessages([]);
     setTraceState(EMPTY_TRACE_STATE);
     setManagedChatNotice(null);
-  }, []);
+  }, [retryServerId]);
   const clearTrace = useCallback(() => setTraceState(EMPTY_TRACE_STATE), []);
 
   const stop = useCallback(() => {
@@ -598,5 +772,9 @@ export function useChatMessagesClientSide({
     clearTrace,
     traceEvents: traceState.events,
     tokenUsage: traceState.usage,
+    pendingAuthorization,
+    authenticatePendingTool,
+    authenticatingToolCallId,
+    toolAuthorizationError,
   };
 }

--- a/libraries/typescript/packages/inspector/src/client/components/tools/ToolResultDisplay.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/tools/ToolResultDisplay.tsx
@@ -737,6 +737,7 @@ export function ToolResultDisplay({
                       void onAuthenticateAndRerun?.(result.timestamp)
                     }
                     disabled={!canAuthenticateAndRerun || isAuthenticating}
+                    className="bg-amber-600 text-white hover:bg-amber-700 focus-visible:ring-amber-600 dark:bg-amber-500 dark:text-amber-950 dark:hover:bg-amber-400"
                   >
                     {canAuthenticateAndRerun && isAuthenticating ? (
                       <Loader2 className="size-3.5 animate-spin" aria-hidden />


### PR DESCRIPTION
## What changed

- render late mixed-auth challenges in chat as an amber authorization-required tool state with an **Authenticate** action
- pause the active browser-side agent stream, complete OAuth, retry the protected tool once, and continue the same chat turn
- persist interrupted chat turns across full-page OAuth redirects and replay them without duplicating the user message
- route hosted mixed-auth MCP connections through the browser-side agent and existing managed LLM proxy so browser OAuth can complete on the live MCP connection
- use a darker orange action for the Tools-tab **Authenticate and rerun** button
- add an Inspector patch changeset and focused persistence/routing regression tests

## Root cause

The client-side agent loop converted a late OAuth exception into an ordinary tool error. Chat therefore kept the tool call in its streaming/pending presentation and had no browser-owned authorization action. Hosted remote chat compounded this by running MCP tools server-side, where a late browser OAuth flow cannot be completed.

## User impact

Protected tools on mixed-auth servers now pause at the failing call, clearly ask for authentication, and resume automatically after authorization. Anonymous tools and ordinary remote hosted chat retain their existing behavior.

## Validation

- `pnpm --filter @mcp-use/inspector type-check`
- `pnpm --filter @mcp-use/inspector lint`
- `pnpm --filter @mcp-use/inspector test:unit` — 199 tests passed
- `pnpm --filter @mcp-use/inspector build`
- Inspector package verification
- pre-commit formatting, lint, and changeset checks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mixed-auth MCP tool calls in Inspector chat so OAuth-required tools pause, ask for authentication, and resume the same turn. Interrupted turns survive full-page OAuth redirects and replay without duplicating the user message.

- **Bug Fixes**
  - Treat late OAuth as `authorization-required`: pause the tool call, show Authenticate, retry once, then continue the turn.
  - Persist and replay interrupted turns after full-page OAuth, keeping the original user message intact.
  - Route hosted mixed-auth MCP connections through the browser-side agent and managed LLM proxy so browser OAuth can complete on the live MCP connection.

- **New Features**
  - Chat UI shows an amber authorization state with a lock icon and Authenticate button; Tools tab uses a darker orange Authenticate and rerun button.
  - Enable managed client-side chat for remote mixed-auth servers to keep tool calls in the browser.
  - Add a patch changeset for `@mcp-use/inspector` and unit tests covering persistence and routing.

<sup>Written for commit b4de34fb5fce03e19f163a15b1c7b551eccff082. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

