### PR TITLE
fix: harden stable mixed-auth flows

### DIFF
--- a/docs/typescript/api-reference/client/mcp-session.mdx
+++ b/docs/typescript/api-reference/client/mcp-session.mdx
@@ -26,6 +26,7 @@ connection.info.instructions
 connection.info.extensions
 connection.authorization             // optional mixed-auth state
 connection.info.authorization        // same state in the metadata snapshot
+await connection.discoverAuthorization() // populate optional mixed-auth state
 connection.supports("sampling") // capability check
 ```
 
@@ -35,6 +36,7 @@ connection.supports("sampling") // capability check
 | ------ | ----------- |
 | `connect()` | Start transport |
 | `initialize()` | Run MCP init handshake |
+| `discoverAuthorization()` | Discover optional mixed-auth metadata without forcing login |
 | `authenticate()` | Start optional OAuth for a connected mixed-auth server |
 | `disconnect()` | Close transport |
 

--- a/docs/typescript/client/authentication.mdx
+++ b/docs/typescript/client/authentication.mdx
@@ -34,11 +34,9 @@ the client detects this after the anonymous connection succeeds:
 
 ```typescript
 const connection = await client.connect("demo");
+const authorization = await connection.discoverAuthorization();
 
-if (
-  connection.authorization?.mode === "mixed" &&
-  !connection.authorization.authenticated
-) {
+if (authorization?.mode === "mixed" && !authorization.authenticated) {
   console.log("Public operations are available without signing in.");
 
   // Optional: authenticate now instead of waiting for a protected operation.
@@ -46,10 +44,13 @@ if (
 }
 ```
 
-`connection.info.authorization` exposes the same state, including the canonical
+After discovery, `connection.authorization` and `connection.info.authorization`
+expose the same state, including the canonical
 resource and advertised scopes when the metadata provides them. Detection is
-best-effort and defaults to enabled for HTTP servers with an OAuth provider. Set
-`detectMixedAuth: false` on the server configuration to skip it.
+best-effort and defaults to enabled for HTTP servers with an OAuth provider.
+Call `discoverAuthorization()` when using `MCPClient` directly; React performs
+the same discovery after publishing the ready connection. Set `detectMixedAuth:
+false` on the server configuration to skip it.
 
 If you stay anonymous, a later wire-level OAuth challenge from a protected
 operation starts the official SDK flow. Automatic flows retry the operation once

--- a/docs/typescript/client/usemcp.mdx
+++ b/docs/typescript/client/usemcp.mdx
@@ -179,8 +179,8 @@ return (
 - **`McpServerConfig`** — server options passed to `addServer` (replaces deprecated `McpServerOptions`).
 - **`displayName`** — your label for the server in UI.
 - **`serverInfo.name`** — name returned by the server at init.
-- **`authorization`** — optional mixed-auth metadata with `authenticated`,
-  `resource`, and `scopesSupported`.
+- **`authorization`** — optional mixed-auth metadata with `mode`,
+  `authenticated`, `resource`, and `scopesSupported`.
 
 Sampling, elicitation, and notifications are queued on each `McpServer` (`pendingSamplingRequests`, `pendingElicitationRequests`, `notifications`). See [Sampling](/typescript/client/sampling) and [Elicitation](/typescript/client/elicitation).
 

--- a/docs/v2/typescript/client/authentication.mdx
+++ b/docs/v2/typescript/client/authentication.mdx
@@ -48,11 +48,9 @@ When a successfully connected server publishes
 
 ```typescript
 const connection = await client.connect("demo");
+const authorization = await connection.discoverAuthorization();
 
-if (
-  connection.authorization?.mode === "mixed" &&
-  !connection.authorization.authenticated
-) {
+if (authorization?.mode === "mixed" && !authorization.authenticated) {
   console.log("Public operations are available without signing in.");
 
   // Optional: authenticate now instead of waiting for a protected operation.
@@ -60,11 +58,13 @@ if (
 }
 ```
 
-`connection.info.authorization` exposes the same state. It includes `resource`
-and `scopesSupported` when the protected-resource metadata advertises them.
-Mixed-auth discovery is best-effort and defaults to enabled for HTTP servers
-with an OAuth provider. Set `detectMixedAuth: false` on the server configuration
-to skip the discovery request.
+After discovery, `connection.authorization` and `connection.info.authorization`
+expose the same state. It includes `resource` and `scopesSupported` when the
+protected-resource metadata advertises them. Mixed-auth discovery is
+best-effort and defaults to enabled for HTTP servers with an OAuth provider.
+Call `discoverAuthorization()` when using `MCPClient` directly; React performs
+the same discovery after publishing the ready connection. Set `detectMixedAuth:
+false` on the server configuration to skip the discovery request.
 
 If the client stays anonymous, a later wire-level OAuth challenge from a
 protected operation starts the official SDK flow. Automatic flows finish OAuth

--- a/libraries/typescript/.changeset/stable-review-followups.md
+++ b/libraries/typescript/.changeset/stable-review-followups.md
@@ -1,0 +1,8 @@
+---
+"@mcp-use/client": patch
+"@mcp-use/cli": patch
+"@mcp-use/inspector": patch
+"mcp-use": patch
+---
+
+Recover mixed-auth metadata discovery after transient failures, preserve ready React connections when optional token projection fails, report authenticated state after challenged OAuth, correct CLI login recovery, suppress failure results for user-cancelled Inspector tools, and keep the mixed-OAuth example's authorization guard aligned with MCP JSON parsing.

--- a/libraries/typescript/packages/cli/src/commands/client.ts
+++ b/libraries/typescript/packages/cli/src/commands/client.ts
@@ -251,7 +251,10 @@ async function savedServerCommand(
     credentials,
     300_000,
     resolveBrowserMode({ noOpen: false, json }),
-    json
+    json,
+    family === "auth" && operation === "login"
+      ? `mcp-use client ${name} auth login`
+      : undefined
   );
   try {
     if (family === "auth" && operation === "login") {

--- a/libraries/typescript/packages/cli/tests/commands/client.test.ts
+++ b/libraries/typescript/packages/cli/tests/commands/client.test.ts
@@ -450,6 +450,34 @@ describe("client human-readable output", () => {
     });
   });
 
+  it("points JSON auth recovery back to the auth login command", async () => {
+    await runClient([
+      "connect",
+      "mixed-login-json",
+      "https://mcp.example.com/mcp",
+    ]);
+    stdout = "";
+    stderr = "";
+    mocks.triggerOAuth = true;
+
+    await expect(
+      runClient(["mixed-login-json", "auth", "login", "--json"])
+    ).resolves.toBe(1);
+
+    expect(JSON.parse(stderr)).toMatchObject({
+      error: {
+        code: "oauth_interaction_required",
+        details: {
+          nextSteps: [
+            {
+              command: "mcp-use client mixed-login-json auth login",
+            },
+          ],
+        },
+      },
+    });
+  });
+
   it("separates tool names and descriptions with a hyphen", async () => {
     await expect(
       runClient([

--- a/libraries/typescript/packages/client/src/react/useMcp.ts
+++ b/libraries/typescript/packages/client/src/react/useMcp.ts
@@ -47,7 +47,14 @@ type TransportType = "http";
 
 type UseMcpAuthProvider = OAuthClientProvider & {
   tokens?: () => Promise<
-    { access_token?: string; [key: string]: unknown } | undefined
+    | {
+        access_token?: string;
+        token_type?: string;
+        refresh_token?: string;
+        scope?: string;
+        [key: string]: unknown;
+      }
+    | undefined
   >;
   clearStorage?: () => number;
   getLastAttemptedAuthUrl?: () => string | null | undefined;
@@ -1192,7 +1199,17 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
 
         // Get OAuth tokens if authentication was used
         if (authProviderRef.current) {
-          const tokens = await authProviderRef.current.tokens?.();
+          let tokens: Awaited<
+            ReturnType<NonNullable<UseMcpAuthProvider["tokens"]>>
+          >;
+          try {
+            tokens = await authProviderRef.current.tokens?.();
+          } catch (error) {
+            // The MCP connection is already usable. Token projection is
+            // supplemental state and must not tear down a ready connection.
+            addLog("warn", "Failed to read OAuth tokens:", error);
+            tokens = undefined;
+          }
           if (!isMountedRef.current) {
             addLog(
               "debug",

--- a/libraries/typescript/packages/client/src/transport/http.ts
+++ b/libraries/typescript/packages/client/src/transport/http.ts
@@ -289,12 +289,10 @@ export class HttpConnector extends BaseConnector {
         },
       })
         .then(() => {
-          if (this.authorizationCache) {
-            this.authorizationCache = {
-              ...this.authorizationCache,
-              authenticated: true,
-            };
-          }
+          this.authorizationCache = {
+            ...(this.authorizationCache ?? { mode: "mixed" }),
+            authenticated: true,
+          };
         })
         .finally(() => {
           this.pendingOAuthCompletion = null;
@@ -345,7 +343,14 @@ export class HttpConnector extends BaseConnector {
 
     if (this.authorizationDiscovery) return this.authorizationDiscovery;
 
-    this.authorizationDiscovery = this.discoverMixedAuthorization();
+    this.authorizationDiscovery = this.discoverMixedAuthorization().then(
+      (authorization) => {
+        // A missing or temporarily unavailable RFC 9728 endpoint must not be
+        // cached for the lifetime of an otherwise healthy MCP connection.
+        if (!authorization) this.authorizationDiscovery = null;
+        return authorization;
+      }
+    );
     return this.authorizationDiscovery;
   }
 

--- a/libraries/typescript/packages/client/tests/unit/client/mixed-auth.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/client/mixed-auth.test.ts
@@ -109,12 +109,39 @@ describe("mixed OAuth authorization", () => {
       { finishAuth: vi.fn(async () => {}) }
     );
 
-    const initialization = connector.initialize();
+    await connector.initialize();
+    const discovery = connector.discoverAuthorization();
+    expect(discoverOAuthProtectedResourceMetadata).toHaveBeenCalledOnce();
     await vi.runAllTimersAsync();
 
-    await expect(initialization).resolves.toMatchObject({ tools: {} });
+    await expect(discovery).resolves.toBeUndefined();
     expect(connector.tools.map((tool) => tool.name)).toEqual(["public"]);
     expect(connector.authorization).toBeUndefined();
+  });
+
+  it("retries mixed-auth discovery after a transient metadata failure", async () => {
+    vi.mocked(discoverOAuthProtectedResourceMetadata)
+      .mockRejectedValueOnce(new Error("metadata temporarily unavailable"))
+      .mockResolvedValueOnce({
+        resource: "https://mcp.example.com/mcp",
+        authorization_servers: ["https://auth.example.com"],
+      });
+    const connector = new HttpConnector("https://mcp.example.com/mcp", {
+      authProvider: createProvider(),
+    });
+    attachConnectedClient(
+      connector,
+      { getProtocolEra: () => "modern" },
+      { finishAuth: vi.fn(async () => {}) }
+    );
+
+    await expect(connector.discoverAuthorization()).resolves.toBeUndefined();
+    await expect(connector.discoverAuthorization()).resolves.toEqual({
+      mode: "mixed",
+      authenticated: false,
+      resource: "https://mcp.example.com/mcp",
+    });
+    expect(discoverOAuthProtectedResourceMetadata).toHaveBeenCalledTimes(2);
   });
 
   it("finishes SDK-started OAuth and retries a protected operation once", async () => {
@@ -141,6 +168,10 @@ describe("mixed OAuth authorization", () => {
       "https://auth.example.com"
     );
     expect(callTool).toHaveBeenCalledTimes(2);
+    expect(connector.authorization).toEqual({
+      mode: "mixed",
+      authenticated: true,
+    });
   });
 
   it("leaves a protected operation pending when automatic auth is disabled", async () => {

--- a/libraries/typescript/packages/client/tests/unit/react/useMcp-connection-metadata.test.tsx
+++ b/libraries/typescript/packages/client/tests/unit/react/useMcp-connection-metadata.test.tsx
@@ -200,6 +200,18 @@ describe("useMcp connection metadata", () => {
     );
   });
 
+  it("stays ready when optional OAuth token projection fails", async () => {
+    authProvider.tokens.mockRejectedValueOnce(new Error("storage unavailable"));
+
+    const { getResult } = await renderFor("modern");
+
+    expect(getResult().state).toBe("ready");
+    expect(getResult().error).toBeUndefined();
+    expect(getResult().log.map((entry) => entry.message)).toContainEqual(
+      expect.stringContaining("Failed to read OAuth tokens")
+    );
+  });
+
   it("exposes tools before auxiliary inventories finish loading", async () => {
     let releaseInventories!: () => void;
     const inventoriesPending = new Promise<void>((resolve) => {

--- a/libraries/typescript/packages/inspector/src/client/components/InspectorDashboard.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/InspectorDashboard.tsx
@@ -62,7 +62,7 @@ import {
 } from "@/client/utils/localInspectorRecovery";
 import { useLocation, useNavigate } from "react-router";
 import { toast } from "sonner";
-import { INSPECTOR_RECONNECT_STORAGE_KEY } from "@/client/hooks/useAutoConnect";
+import { storeInspectorReconnectSession } from "@/client/hooks/useAutoConnect";
 import type { TabType } from "@/client/context/InspectorContext";
 import { ConnectionSettingsForm } from "./ConnectionSettingsForm";
 import type { CustomHeader } from "./CustomHeadersEditor";
@@ -883,23 +883,7 @@ export function InspectorDashboard() {
                           variant="outline"
                           onClick={(e) => {
                             e.stopPropagation();
-                            // Store connection config so trySessionReconnect() can
-                            // resume after an OAuth redirect (when ?autoConnect is absent).
-                            try {
-                              sessionStorage.setItem(
-                                INSPECTOR_RECONNECT_STORAGE_KEY,
-                                JSON.stringify({
-                                  url: connection.url,
-                                  name:
-                                    connection.name || "Auto-connected Server",
-                                  transportType:
-                                    (connection as any).transportType || "http",
-                                  connectionMode: "auto",
-                                })
-                              );
-                            } catch {
-                              /* sessionStorage unavailable — best-effort */
-                            }
+                            storeInspectorReconnectSession(connection);
                             // Generate a fresh request instead of navigating a
                             // persisted opaque auth URL whose callback and
                             // verifier can no longer be proven current.
@@ -919,23 +903,7 @@ export function InspectorDashboard() {
                               href={connection.authUrl}
                               onClick={(e) => {
                                 e.stopPropagation();
-                                try {
-                                  sessionStorage.setItem(
-                                    INSPECTOR_RECONNECT_STORAGE_KEY,
-                                    JSON.stringify({
-                                      url: connection.url,
-                                      name:
-                                        connection.name ||
-                                        "Auto-connected Server",
-                                      transportType:
-                                        (connection as any).transportType ||
-                                        "http",
-                                      connectionMode: "auto",
-                                    })
-                                  );
-                                } catch {
-                                  /* sessionStorage unavailable — best-effort */
-                                }
+                                storeInspectorReconnectSession(connection);
                               }}
                             />
                           }

--- a/libraries/typescript/packages/inspector/src/client/components/tools/__tests__/useToolExecution.test.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/tools/__tests__/useToolExecution.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+
+import { act, useEffect } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { captureInspectorEvent } from "@/client/telemetry";
+import { useToolExecution } from "../useToolExecution";
+
+vi.mock("@/client/telemetry", () => ({
+  MCPToolExecutionEvent: class {
+    constructor(readonly payload: unknown) {}
+  },
+  captureInspectorEvent: vi.fn(async () => {}),
+}));
+
+describe("useToolExecution cancellation", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does not report a user-cancelled run as a tool failure", async () => {
+    const callTool = vi.fn(
+      async (
+        _name: string,
+        _args: Record<string, unknown>,
+        options?: { signal?: AbortSignal }
+      ) =>
+        new Promise<never>((_resolve, reject) => {
+          options?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("Cancelled", "AbortError"));
+          });
+        })
+    );
+    let latest: ReturnType<typeof useToolExecution> | undefined;
+    let execution: Promise<void> | undefined;
+
+    function TestComponent() {
+      latest = useToolExecution({
+        selectedTool: {
+          name: "slow_tool",
+          inputSchema: { type: "object" },
+        },
+        payloadToSend: {},
+        toolArgs: {},
+        callTool,
+        readResource: vi.fn(async () => ({})),
+        serverId: "server-1",
+        isConnected: true,
+      });
+      useEffect(() => {
+        execution = latest?.executeTool();
+      }, []);
+      return null;
+    }
+
+    const container = document.createElement("div");
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(<TestComponent />);
+      await Promise.resolve();
+    });
+    expect(callTool).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      latest!.cancelExecution();
+      await execution;
+    });
+
+    expect(latest?.results).toEqual([]);
+    expect(captureInspectorEvent).not.toHaveBeenCalled();
+
+    await act(async () => root.unmount());
+  });
+});

--- a/libraries/typescript/packages/inspector/src/client/components/tools/useToolExecution.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/tools/useToolExecution.ts
@@ -77,6 +77,7 @@ export function useToolExecution({
   const [copiedResult, setCopiedResult] = useState<number | null>(null);
   const executingRef = useRef(false);
   const activeExecutionRef = useRef<AbortController | null>(null);
+  const cancelledExecutionsRef = useRef(new WeakSet<AbortController>());
   const shouldResumeAuthorizationRef = useRef(pendingAuthorization !== null);
   const [resumeVersion, setResumeVersion] = useState(0);
 
@@ -157,6 +158,9 @@ export function useToolExecution({
           ]);
         }
       } catch (error) {
+        if (cancelledExecutionsRef.current.has(controller)) {
+          return;
+        }
         const duration = Date.now() - startTime;
         captureInspectorEvent(
           new MCPToolExecutionEvent({
@@ -337,6 +341,7 @@ export function useToolExecution({
   const cancelExecution = useCallback(() => {
     const controller = activeExecutionRef.current;
     if (!controller) return;
+    cancelledExecutionsRef.current.add(controller);
     controller.abort();
     if (activeExecutionRef.current !== controller) return;
     activeExecutionRef.current = null;

--- a/libraries/typescript/packages/server/examples/auth/mixed-oauth/src/index.ts
+++ b/libraries/typescript/packages/server/examples/auth/mixed-oauth/src/index.ts
@@ -46,7 +46,7 @@ server.use("*", honoAdapter(oauthMetadata(provider, resource)));
 // A missing token therefore becomes a real HTTP 401 with resource_metadata in
 // WWW-Authenticate, which lets an OAuth-capable client authenticate and retry.
 server.use("/mcp", async (context, next) => {
-  if (!isProtectedToolCall(context.req.raw)) {
+  if (!(await isProtectedToolCall(context.req.raw))) {
     await next();
     return;
   }
@@ -146,9 +146,16 @@ function honoAdapter(middleware: FetchMiddleware): MiddlewareHandler {
     });
 }
 
-function isProtectedToolCall(request: Request): boolean {
+async function isProtectedToolCall(request: Request): Promise<boolean> {
   if (request.method !== "POST") return false;
-  const parsedBody = getRequestBag(request).parsedBody;
+  let parsedBody = getRequestBag(request).parsedBody;
+  if (parsedBody === undefined) {
+    try {
+      parsedBody = await request.clone().json();
+    } catch {
+      return false;
+    }
+  }
   const messages = Array.isArray(parsedBody) ? parsedBody : [parsedBody];
   return messages.some((message) => {
     if (message === null || typeof message !== "object") return false;


### PR DESCRIPTION
## Summary

Addresses the actionable review findings from #2216 without expanding the stable-release scope:

- retry optional mixed-auth discovery after transient metadata failures and publish authenticated state after challenge-driven OAuth
- keep an otherwise ready React connection usable when optional token projection fails
- point JSON CLI auth recovery at the saved server's `auth login` command
- treat explicit Inspector tool cancellation as cancellation, not a failed execution, and reuse the reconnect-session helper
- parse the mixed-OAuth example guard consistently with the mounted MCP handler
- document explicit authorization discovery for direct `MCPClient` users and the `authorization.mode` field

Includes patch changesets for `@mcp-use/client`, `@mcp-use/cli`, `@mcp-use/inspector`, and `mcp-use`.

## Validation

- `@mcp-use/client` build; 327 tests passed
- `@mcp-use/cli` build, typecheck, proxy package checks; 284 tests passed
- `@mcp-use/inspector` build, typecheck; 200 unit tests passed
- mixed-OAuth example typecheck passed
- changed-file lint and formatting checks passed
- release-channel suite: 11 tests passed

## Scope

This intentionally leaves speculative or already-resolved review suggestions out of the patch, including broad auth-predicate refactors, code-executor auto-connect behavior, renderer cleanup, and comments without a demonstrated failure mode.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens mixed-auth across `@mcp-use/client`, `@mcp-use/cli`, `@mcp-use/inspector`, and `mcp-use` to make OAuth discovery resilient and reduce false failure states. Improves recovery, preserves ready connections, and aligns docs and the mixed-OAuth example.

- **Bug Fixes**
  - Client (HTTP): retry mixed-auth discovery after transient RFC 9728 metadata errors; don’t cache “no metadata”; set `authorization.authenticated = true` after challenge-driven OAuth completes.
  - React `useMcp`: keep the connection ready if `authProvider.tokens()` throws; log a warning instead of tearing down state.
  - CLI: JSON auth recovery now points back to `mcp-use client <name> auth login` in `nextSteps`.
  - Inspector: user-cancelled tool runs aren’t reported as failures; reuse the reconnect-session helper when opening auth URLs.
  - Example server: guard now parses MCP JSON like the runtime (async body read) and only protects relevant tool calls.
  - Docs: added `discoverAuthorization()` to the API and clarified `authorization.mode` and when discovery runs (React auto-discovers; call it explicitly with `MCPClient`).

<sup>Written for commit 8d53762042a05b5c898fcc16fef086734db2e5bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

