### PR TITLE
fix: restore Vibe MCP Apps and state-preserving HMR

### DIFF
--- a/libraries/typescript/.changeset/swift-widgets-refresh.md
+++ b/libraries/typescript/.changeset/swift-widgets-refresh.md
@@ -1,0 +1,7 @@
+---
+"@mcp-use/cli": patch
+"@mcp-use/inspector": patch
+"mcp-use": patch
+---
+
+Restore embedded MCP App rendering in Vibe and preserve React state during remote view HMR updates.

--- a/libraries/typescript/packages/cli/src/cli/dev.ts
+++ b/libraries/typescript/packages/cli/src/cli/dev.ts
@@ -89,6 +89,21 @@ type WebHandler = (request: Request) => Promise<Response>;
 /** Coalesce one editor save burst before reconciling a project generation. */
 const RELOAD_SETTLE_MS = 50;
 
+/** Whether two discovery snapshots describe the same view module graph. */
+function sameDiscoveredViews(
+  left: readonly DiscoveredView[],
+  right: readonly DiscoveredView[]
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every(
+      (view, index) =>
+        view.name === right[index]?.name &&
+        view.entryPath === right[index]?.entryPath
+    )
+  );
+}
+
 /**
  * The duck-typed shape the entry's default export must satisfy: an
  * `MCPServer` instance (checked structurally so the runner may load its own
@@ -247,6 +262,7 @@ function appendVaryOrigin(res: ServerResponse): void {
  * CORS for Vite-served module-graph URLs on the dev listener.
  *
  * Tunnel active → `Access-Control-Allow-Origin: *` (foreign / opaque hosts).
+ * Public/wildcard bind → `*` (the listener is intentionally network-visible).
  * No tunnel on a localhost bind → reflect a validated loopback `Origin`
  * (exact value) and set `Vary: Origin`; reflect `null` for opaque sandbox
  * iframes; foreign or missing Origin get no ACAO.
@@ -266,6 +282,7 @@ function applyViteModuleCors(
     return;
   }
   if (!options.localhostBind) {
+    res.setHeader("Access-Control-Allow-Origin", "*");
     return;
   }
   const originHeader = req.headers.origin;
@@ -446,6 +463,12 @@ export async function runDev(options: DevOptions): Promise<void> {
       : [nextStandaloneCompatPlugin(options.cwd)],
     server: {
       middlewareMode: true,
+      // A public/wildcard bind deliberately accepts hostnames that are only
+      // known to the surrounding platform (for example a sandbox URL). Keep
+      // Vite's own static Host allowlist aligned with the listener boundary;
+      // localhost binds retain the stricter default and our dynamic tunnel
+      // path rewrites an authorized tunnel Host to localhost below.
+      ...(!localhostBind && { allowedHosts: true }),
       // Windows file notifications can be coalesced or dropped while Vite is
       // transforming the same module. Polling keeps dev reloads reliable.
       ...(process.platform === "win32" && {
@@ -606,6 +629,7 @@ export async function runDev(options: DevOptions): Promise<void> {
   let desiredRevision = 0;
   let reconciling = false;
   let reloadTimer: ReturnType<typeof setTimeout> | undefined;
+  let viewsDiscoveryTimer: ReturnType<typeof setTimeout> | undefined;
   let skillsReloadTimer: ReturnType<typeof setTimeout> | undefined;
   const isAborted = (): boolean => options.signal?.aborted === true;
 
@@ -714,12 +738,28 @@ export async function runDev(options: DevOptions): Promise<void> {
     scheduleReconcile();
   };
 
+  const scheduleViewsRediscovery = (): void => {
+    if (viewsDiscoveryTimer !== undefined) clearTimeout(viewsDiscoveryTimer);
+    // Remote editors commonly save by replacing the file, which can surface
+    // as unlink + add instead of change. Let the save burst settle and only
+    // rebuild the MCP server when the discovered view registry actually
+    // changed. Content-only replacements remain on Vite's client HMR path,
+    // preserving the mounted view and its React state.
+    viewsDiscoveryTimer = setTimeout(() => {
+      viewsDiscoveryTimer = undefined;
+      const discovered = discoverViews(options.cwd, viewsDirectory);
+      if (!sameDiscoveredViews(currentViews, discovered)) {
+        scheduleReconcile();
+      }
+    }, RELOAD_SETTLE_MS);
+  };
+
   const onViewFilesystemEvent = (file: string): void => {
     if (!isViewPath(file, options.cwd, viewsDirectory)) {
       return;
     }
 
-    scheduleReconcile();
+    scheduleViewsRediscovery();
   };
 
   const onFileAddOrUnlink = (file: string): void => {
@@ -779,7 +819,8 @@ export async function runDev(options: DevOptions): Promise<void> {
   // URLs (onRequest below) emit `*` while a tunnel is active; without a tunnel,
   // localhost binds reflect a validated loopback Origin (exact value +
   // `Vary: Origin`) so a local MCP host can load the module graph, while
-  // foreign / opaque / missing Origin get no ACAO.
+  // foreign / opaque / missing Origin get no ACAO. Public/wildcard binds are
+  // intentionally network-visible and emit `*`, matching a public tunnel.
   const rejectDisallowedRequest = (
     req: IncomingMessage,
     res: ServerResponse
@@ -812,6 +853,7 @@ export async function runDev(options: DevOptions): Promise<void> {
    */
   const teardown = async (): Promise<void> => {
     if (skillsReloadTimer !== undefined) clearTimeout(skillsReloadTimer);
+    if (viewsDiscoveryTimer !== undefined) clearTimeout(viewsDiscoveryTimer);
     vite.watcher.off("change", onSsrFileEvent);
     vite.watcher.off("add", onFileAddOrUnlink);
     vite.watcher.off("unlink", onFileAddOrUnlink);

--- a/libraries/typescript/packages/cli/tests/cli/dev.test.ts
+++ b/libraries/typescript/packages/cli/tests/cli/dev.test.ts
@@ -1021,6 +1021,34 @@ async function rawGetBody(
 }
 
 describe("runDev (views)", () => {
+  it("serves Vite modules through a public sandbox hostname", async () => {
+    const cwd = copyFixture("dev-views", "views");
+    cleanups.push(() => removeDir(cwd));
+
+    const port = await getFreePort("0.0.0.0");
+    const dev = await startDev(cwd, port, "0.0.0.0");
+    cleanups.push(dev.stop);
+    const base = dev.url.replace(/\/mcp$/, "");
+    const moduleUrl = `${base}/@vite/client`;
+
+    expect(
+      await rawStatus(
+        moduleUrl,
+        {
+          host: "sandbox.example.com",
+          origin: "https://vibe.example.com",
+        },
+        "GET"
+      )
+    ).toBe(200);
+
+    const response = await fetch(moduleUrl, {
+      headers: { origin: "https://vibe.example.com" },
+    });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("access-control-allow-origin")).toBe("*");
+  });
+
   it("shuts down with active MCP subscriptions and HMR WebSockets", async () => {
     const cwd = copyFixture("dev-active-connections-shutdown", "views");
     cleanups.push(() => removeDir(cwd));
@@ -1470,6 +1498,11 @@ describe("runDev (views)", () => {
 
     const viewPath = join(cwd, "views", "product-search-result", "view.tsx");
     const viewSource = readFileSync(viewPath, "utf8");
+    // Vibe's remote filesystem can surface an editor save as unlink + add
+    // rather than a simple change event. This must stay on the client HMR
+    // path: rebuilding the MCP server publishes catalog invalidations, which
+    // remount the Inspector result and wipes component state.
+    rmSync(viewPath);
     writeFileSync(viewPath, viewSource.replace("results", "hot-results"));
 
     const update = await waitFor(async () =>
@@ -1481,6 +1514,10 @@ describe("runDev (views)", () => {
     );
     expect(update).toBeDefined();
     expect(messages.filter((m) => m.type === "full-reload")).toEqual([]);
+    await new Promise((r) => setTimeout(r, 200));
+    expect(
+      dev.logs.filter((line) => line === "[mcp-use] reloaded server entry")
+    ).toEqual([]);
   }, 60_000);
 
   it("runs two dev servers concurrently with HMR on each main port", async () => {

--- a/libraries/typescript/packages/inspector/src/client/components/ChatTab.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ChatTab.tsx
@@ -74,6 +74,20 @@ type MCPConnection = {
 };
 type ChatMessage = import("./chat/types").Message;
 
+export type ChatBridgeMessage = Record<string, unknown> & {
+  type: string;
+};
+
+/**
+ * Optional host-owned bridge used when ChatTab is embedded directly in a React
+ * tree instead of inside an iframe. The default iframe integration continues
+ * to use window.postMessage when this adapter is omitted.
+ */
+export interface ChatBridgeAdapter {
+  subscribe(listener: (message: ChatBridgeMessage) => void): () => void;
+  emit(message: ChatBridgeMessage): void;
+}
+
 export interface ChatTabProps {
   connection: MCPConnection;
   isConnected: boolean;
@@ -156,6 +170,10 @@ export interface ChatTabProps {
   systemPromptProvider?: ChatSystemPromptProvider;
   /** Raise ChatHeader above host chrome (cloud embed). */
   elevatedHeader?: boolean;
+  /** Host bridge for direct React embeds that cannot use parent postMessage. */
+  bridge?: ChatBridgeAdapter;
+  /** Keep a host-managed stream authoritative over persisted Inspector BYOK mode. */
+  lockManagedMode?: boolean;
 }
 
 // Check text up to caret position for " /" or "/" at start of line or textarea
@@ -202,6 +220,8 @@ export function ChatTab({
   defaultView = "conv",
   systemPromptProvider: externalSystemPromptProvider,
   elevatedHeader,
+  bridge,
+  lockManagedMode = false,
 }: ChatTabProps) {
   const isMcpWidgetFullscreen = useMcpWidgetFullscreen();
   const { isEmbedded } = useInspector();
@@ -293,6 +313,7 @@ export function ChatTab({
       useClientSide,
       managedLlmConfig,
       localLlmConfig,
+      lockManagedMode,
     });
 
   const { getModelContexts, getAppToolConnections } = useWidgetDebug();
@@ -750,17 +771,19 @@ export function ChatTab({
 
   const postBridgeEvent = useCallback(
     (type: string, payload: Record<string, unknown> = {}) => {
+      const message: ChatBridgeMessage = {
+        type,
+        serverId,
+        ...payload,
+      };
+      if (bridge) {
+        bridge.emit(message);
+        return;
+      }
       if (typeof window === "undefined" || window.parent === window) return;
-      window.parent.postMessage(
-        {
-          type,
-          serverId,
-          ...payload,
-        },
-        "*"
-      );
+      window.parent.postMessage(message, "*");
     },
-    [serverId]
+    [bridge, serverId]
   );
 
   useEffect(() => {
@@ -794,10 +817,10 @@ export function ChatTab({
   ]);
 
   useEffect(() => {
-    const handleMessage = (event: MessageEvent) => {
-      if (!event.data || typeof event.data !== "object") return;
+    const handleBridgeMessage = (message: ChatBridgeMessage) => {
+      if (!message || typeof message !== "object") return;
 
-      const data = event.data as {
+      const data = message as {
         type?: string;
         requestId?: string;
         serverId?: string;
@@ -905,14 +928,18 @@ export function ChatTab({
           try {
             let target: HTMLElement | null = null;
 
+            const screenshotRoot = messagesAreaRef.current;
+
             if (targetToolCallId) {
-              target = document.querySelector(
+              target = screenshotRoot?.querySelector(
                 `[data-tool-call-id="${targetToolCallId}"]`
-              );
+              ) as HTMLElement | null;
             }
 
-            if (!target) {
-              const widgets = document.querySelectorAll("[data-tool-call-id]");
+            if (!target && screenshotRoot) {
+              const widgets = screenshotRoot.querySelectorAll(
+                "[data-tool-call-id]"
+              );
               if (widgets.length > 0) {
                 target = widgets[widgets.length - 1] as HTMLElement;
               }
@@ -1045,9 +1072,19 @@ export function ChatTab({
       }
     };
 
-    window.addEventListener("message", handleMessage);
-    return () => window.removeEventListener("message", handleMessage);
+    if (bridge) {
+      return bridge.subscribe(handleBridgeMessage);
+    }
+
+    const handleWindowMessage = (event: MessageEvent) => {
+      if (!event.data || typeof event.data !== "object") return;
+      handleBridgeMessage(event.data as ChatBridgeMessage);
+    };
+
+    window.addEventListener("message", handleWindowMessage);
+    return () => window.removeEventListener("message", handleWindowMessage);
   }, [
+    bridge,
     clearChatToLanding,
     dismissLandingShader,
     setMessages,
@@ -1592,7 +1629,7 @@ export function ChatTab({
             <MessageList
               messages={messages}
               isLoading={isLoading}
-              serverId={connection.url}
+              serverId={serverId}
               readResource={readResource}
               tools={connection.tools}
               sendMessage={sendWidgetMessage}

--- a/libraries/typescript/packages/inspector/src/client/components/chat/__tests__/chatModeStorage.test.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/__tests__/chatModeStorage.test.ts
@@ -65,6 +65,12 @@ describe("chatModeStorage", () => {
     expect(resolveInitialForceClientSide(true, null)).toBe(false);
   });
 
+  it("lets an embedded host lock its managed stream over stored BYOK mode", () => {
+    writeStoredChatMode("byok");
+
+    expect(resolveInitialForceClientSide(true, null, true)).toBe(false);
+  });
+
   it("stored managed mode wins over legacy llm-config", () => {
     localStorage.setItem(
       "mcp-inspector-llm-config",

--- a/libraries/typescript/packages/inspector/src/client/components/chat/chatModeStorage.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/chatModeStorage.ts
@@ -23,8 +23,10 @@ export function writeStoredChatMode(mode: ChatMode): void {
 /** Sync read for useState initializers (before localLlmConfig loads from useEffect). */
 export function resolveInitialForceClientSide(
   hostUsesServerManagedStream: boolean,
-  localLlmConfig: { provider: string; model: string } | null
+  localLlmConfig: { provider: string; model: string } | null,
+  lockManagedMode = false
 ): boolean {
+  if (lockManagedMode && hostUsesServerManagedStream) return false;
   const stored = readStoredChatMode();
   if (stored === "byok") return true;
   if (stored === "managed") return false;

--- a/libraries/typescript/packages/inspector/src/client/components/chat/useHostedChatMode.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/useHostedChatMode.ts
@@ -9,29 +9,39 @@ export function useHostedChatMode({
   useClientSide,
   managedLlmConfig,
   localLlmConfig,
+  lockManagedMode,
 }: {
   useClientSide: boolean;
   managedLlmConfig?: LLMConfig | null;
   localLlmConfig: LLMConfig | null;
+  lockManagedMode?: boolean;
 }) {
   const hostUsesServerManagedStream =
     !useClientSide && managedLlmConfig != null;
   const [forceClientSide, setForceClientSideState] = useState(() => {
     return resolveInitialForceClientSide(
       hostUsesServerManagedStream,
-      localLlmConfig
+      localLlmConfig,
+      lockManagedMode
     );
   });
 
-  const setForceClientSide = useCallback((value: boolean) => {
-    writeStoredChatMode(value ? "byok" : "managed");
-    setForceClientSideState(value);
-  }, []);
+  const setForceClientSide = useCallback(
+    (value: boolean) => {
+      if (lockManagedMode && hostUsesServerManagedStream) return;
+      writeStoredChatMode(value ? "byok" : "managed");
+      setForceClientSideState(value);
+    },
+    [hostUsesServerManagedStream, lockManagedMode]
+  );
 
   const effectiveClientSide = hostUsesServerManagedStream
-    ? forceClientSide
+    ? lockManagedMode
+      ? false
+      : forceClientSide
     : useClientSide || forceClientSide || !!localLlmConfig;
-  const isManaged = !!managedLlmConfig && !forceClientSide;
+  const isManaged =
+    !!managedLlmConfig && (lockManagedMode === true || !forceClientSide);
   const llmConfig: LLMConfig | null = isManaged
     ? (managedLlmConfig ?? null)
     : (localLlmConfig ?? managedLlmConfig ?? null);

--- a/libraries/typescript/packages/inspector/src/client/context/WidgetDebugContext.tsx
+++ b/libraries/typescript/packages/inspector/src/client/context/WidgetDebugContext.tsx
@@ -37,6 +37,8 @@ export interface WidgetDeclaredCsp {
   resourceDomains?: string[];
   frameDomains?: string[];
   baseUriDomains?: string[];
+  /** mcp-use development extension for Vite's HMR evaluation runtime. */
+  scriptDirectives?: string[];
 }
 
 export interface WidgetInfo {

--- a/libraries/typescript/packages/inspector/src/client/index.ts
+++ b/libraries/typescript/packages/inspector/src/client/index.ts
@@ -50,7 +50,12 @@ export { PromptsTab, type PromptsTabRef } from "./components/PromptsTab.js";
 // ---------------------------------------------------------------------------
 
 // Main chat orchestrator (top-level entry point for embedding)
-export { ChatTab, type ChatTabProps } from "./components/ChatTab.js";
+export {
+  ChatTab,
+  type ChatBridgeAdapter,
+  type ChatBridgeMessage,
+  type ChatTabProps,
+} from "./components/ChatTab.js";
 
 // Chat sub-components (for consumers who want finer-grained control)
 export { MessageList } from "./components/chat/MessageList.js";

--- a/libraries/typescript/packages/inspector/src/client/mcp-apps/__tests__/csp.test.ts
+++ b/libraries/typescript/packages/inspector/src/client/mcp-apps/__tests__/csp.test.ts
@@ -23,6 +23,17 @@ describe("CSP diagnostics", () => {
     expect(policy).toContain("frame-src 'none'");
   });
 
+  it("reports an explicitly declared Vite development eval directive", () => {
+    const policy = buildCSPString({
+      resourceDomains: ["https://sandbox.example.com"],
+      scriptDirectives: ["'unsafe-eval'"],
+    });
+
+    expect(policy).toContain(
+      "script-src 'unsafe-inline' data: blob: https://sandbox.example.com 'unsafe-eval'"
+    );
+  });
+
   it("diffs requested and effective policies", () => {
     const requested = getRequestedCspPolicy({
       connectDomains: ["https://api.example.com"],

--- a/libraries/typescript/packages/inspector/src/client/mcp-apps/csp.ts
+++ b/libraries/typescript/packages/inspector/src/client/mcp-apps/csp.ts
@@ -30,6 +30,9 @@ export function buildCSPString(csp: WidgetDeclaredCsp): string {
   const baseUriDomains = (csp.baseUriDomains || [])
     .map(sanitize)
     .filter(Boolean);
+  const scriptDirectives = (csp.scriptDirectives || []).filter((directive) =>
+    ["'unsafe-eval'", "'wasm-unsafe-eval'"].includes(directive)
+  );
 
   const connectSrc =
     connectDomains.length > 0 ? connectDomains.join(" ") : "'none'";
@@ -43,7 +46,9 @@ export function buildCSPString(csp: WidgetDeclaredCsp): string {
 
   return [
     "default-src 'none'",
-    `script-src 'unsafe-inline' ${resourceSrc}`,
+    `script-src 'unsafe-inline' ${resourceSrc}${
+      scriptDirectives.length > 0 ? ` ${scriptDirectives.join(" ")}` : ""
+    }`,
     `style-src 'unsafe-inline' ${resourceSrc}`,
     `img-src ${resourceSrc}`,
     `font-src ${resourceSrc}`,

--- a/libraries/typescript/packages/server/src/views/csp-env.ts
+++ b/libraries/typescript/packages/server/src/views/csp-env.ts
@@ -2,6 +2,11 @@ import type { McpUiResourceCsp } from "@modelcontextprotocol/ext-apps";
 
 import type { ViewResourceFacts } from "./types.js";
 
+type McpUseResourceCsp = McpUiResourceCsp & {
+  /** Inspector-host extension used only by the Vite development runtime. */
+  scriptDirectives?: string[];
+};
+
 type CspCategory =
   | "connectDomains"
   | "resourceDomains"
@@ -104,7 +109,7 @@ export function buildMergedResourceCsp(
   authorFacts: ViewResourceFacts | undefined,
   options: BuildCspOptions
 ): McpUiResourceCsp {
-  const author = authorFacts?.csp;
+  const author = authorFacts?.csp as McpUseResourceCsp | undefined;
 
   const mcpConnectAuto: string[] = [];
   if (options.serverOrigin !== "") {
@@ -143,6 +148,10 @@ export function buildMergedResourceCsp(
     author?.baseUriDomains ?? [],
     readEnvDomainsForCategory("baseUriDomains")
   );
+  const scriptDirectives = mergeDomainLists(
+    author?.scriptDirectives ?? [],
+    options.hmrWs === true ? ["'unsafe-eval'"] : []
+  );
 
   return {
     ...author,
@@ -150,5 +159,6 @@ export function buildMergedResourceCsp(
     resourceDomains,
     frameDomains,
     baseUriDomains,
-  };
+    ...(scriptDirectives.length > 0 ? { scriptDirectives } : {}),
+  } as McpUseResourceCsp;
 }

--- a/libraries/typescript/packages/server/tests/views/csp-env.test.ts
+++ b/libraries/typescript/packages/server/tests/views/csp-env.test.ts
@@ -109,4 +109,22 @@ describe("buildMergedResourceCsp", () => {
 
     expect(csp.resourceDomains).toEqual(["https://server.example.com"]);
   });
+
+  it("allows the Vite eval runtime only when HMR is enabled", () => {
+    delete process.env.CSP_URLS;
+    const regular = buildMergedResourceCsp(undefined, {
+      serverOrigin: "https://server.example.com",
+      assetsOrigin: "https://server.example.com",
+      explicitAssetsBase: false,
+    }) as { scriptDirectives?: string[] };
+    const hmr = buildMergedResourceCsp(undefined, {
+      serverOrigin: "https://server.example.com",
+      assetsOrigin: "https://server.example.com",
+      explicitAssetsBase: false,
+      hmrWs: true,
+    }) as { scriptDirectives?: string[] };
+
+    expect(regular.scriptDirectives).toBeUndefined();
+    expect(hmr.scriptDirectives).toEqual(["'unsafe-eval'"]);
+  });
 });


### PR DESCRIPTION
## Summary

- add a direct-embed bridge for Inspector Chat and keep host-managed chat mode authoritative when requested
- pass the real server ID to MCP App rendering and scope widget screenshots to the embedded chat
- allow public sandbox hosts to serve the Vite module graph with the required CORS behavior
- keep remote atomic `view.tsx` replacements on React Fast Refresh instead of rebuilding the MCP server
- propagate the narrowly scoped development CSP directive required by Vite Fast Refresh

## Root cause

Vibe's remote editor can save a view as an `unlink + add` sequence. The CLI treated that as a changed view registry, rebuilt the MCP server, published catalog invalidations, and remounted the widget. That displayed the initial `Compiling...` state and lost React state. Public sandbox hosts and the hosted widget CSP also prevented parts of the Vite module graph from loading reliably.

## Changeset

Patch releases for:

- `@mcp-use/cli`
- `@mcp-use/inspector`
- `mcp-use`

## Validation

- CLI development tests: 34 passed
- Inspector unit tests: 44 files / 202 tests passed
- Inspector type-check and client export build passed
- server view/CSP tests: 60 passed
- server type-check passed
- changed-file ESLint and `git diff --check` passed
- manual Vibe browser acceptance: Inspector and Chat both rendered and interacted with the MCP App; a remote source edit hot-updated in about 244 ms, preserved counter state at 1, retained one iframe with the same URL, and did not show `Compiling...` during the edit

The repository's existing full CLI type-check still reports the unrelated `localHostHeader` / `TunnelManagerOptions` error in `src/bin/start.ts`; that file is unchanged by this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores Vibe’s embedded MCP Apps and makes HMR preserve React state during remote view edits. Adds public sandbox CORS and a scoped dev CSP so Vite’s module graph and Fast Refresh load reliably.

- **Bug Fixes**
  - Keep remote `view.tsx` replacements on client HMR instead of rebuilding the MCP server, preserving widget state and avoiding “Compiling...”.
  - Serve Vite modules on public/wildcard binds with `Access-Control-Allow-Origin: *` and `allowedHosts: true` to support sandbox hostnames.
  - Propagate a scoped `'unsafe-eval'` `script-src` only when HMR is enabled, fixing Fast Refresh under strict CSP.
  - Scope MCP App screenshots to the embedded chat area and pass the real `serverId` to apps.

- **New Features**
  - Added `ChatBridgeAdapter` for direct React embeds (no iframe postMessage), with `ChatBridgeMessage` types exported.
  - Added `lockManagedMode` to keep a host-managed stream authoritative over stored BYOK mode.

<sup>Written for commit 13f9d664a57c38c0941884cb66361d8e301be7b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

