### PR TITLE
feat(server): export createJwtVerifier

### DIFF
--- a/libraries/typescript/.changeset/export-jwt-verifier.md
+++ b/libraries/typescript/.changeset/export-jwt-verifier.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": minor
+---
+
+Export `createJwtVerifier` and `JwtVerifierOptions` from `mcp-use/oauth` so custom OAuth providers can reuse the built-in JWT validation and protected-resource binding.

--- a/libraries/typescript/packages/server/src/oauth/index.ts
+++ b/libraries/typescript/packages/server/src/oauth/index.ts
@@ -22,6 +22,7 @@ export type {
 } from "@modelcontextprotocol/server";
 
 export { bearerAuth, oauthMetadata } from "./adapters.js";
+export { createJwtVerifier, type JwtVerifierOptions } from "./jwt.js";
 export {
   oauthCustomProvider,
   type CustomOAuthProviderOptions,

--- a/libraries/typescript/packages/server/src/oauth/jwt.ts
+++ b/libraries/typescript/packages/server/src/oauth/jwt.ts
@@ -18,10 +18,13 @@ export { invalidToken } from "./errors.js";
 /** @internal Record of claims extracted from a verified JWT. */
 export type VerifiedPayload = Record<string, unknown>;
 
-/** @internal Configures issuer, keys, and claims enforced by a JWT verifier. */
+/** Options for {@link createJwtVerifier}. */
 export interface JwtVerifierOptions {
+  /** Expected value of the JWT `iss` claim. */
   issuer: string;
+  /** Remote JSON Web Key Set used to verify token signatures. */
   jwksUrl: URL;
+  /** Canonical public MCP endpoint that accepted tokens must target. */
   resource: URL;
   /** Provider-specific JWT audience, when it differs from the MCP resource. */
   audience?: string | string[];
@@ -31,11 +34,38 @@ export interface JwtVerifierOptions {
    * than an aud/resource claim.
    */
   issuerBoundAccessTokens?: boolean;
+  /** Allowed JWT signature algorithms. */
   algorithms?: readonly string[];
+  /** Static symmetric verification key to use instead of the remote JWKS. */
   key?: Uint8Array;
 }
 
-/** @internal Creates a verifier that rejects JWTs with invalid signatures or required claims. */
+/**
+ * Creates an OAuth access-token verifier backed by `jose` JWT validation.
+ *
+ * The verifier validates the signature, issuer, expiration, subject, and
+ * protected-resource binding before returning SDK authentication information.
+ *
+ * @param options - Issuer, key source, accepted claims, and MCP resource.
+ * @returns An OAuth token verifier for use with {@link oauthCustomProvider}.
+ * @throws A `TypeError` when audience and issuer-bound validation are combined.
+ *
+ * @example
+ * ```ts
+ * import { createJwtVerifier, oauthCustomProvider } from "mcp-use/oauth";
+ *
+ * const oauth = oauthCustomProvider({
+ *   createTokenVerifier: (resource) =>
+ *     createJwtVerifier({
+ *       issuer: "https://auth.example.com",
+ *       jwksUrl: new URL("https://auth.example.com/.well-known/jwks.json"),
+ *       resource,
+ *     }),
+ *   oauthMetadata,
+ *   mapAuthInfo,
+ * });
+ * ```
+ */
 export function createJwtVerifier(
   options: JwtVerifierOptions
 ): OAuthTokenVerifier {

--- a/libraries/typescript/packages/server/src/oauth/jwt.ts
+++ b/libraries/typescript/packages/server/src/oauth/jwt.ts
@@ -55,7 +55,8 @@ export type JwtVerifierOptions = {
  *
  * @param options - Issuer, key source, accepted claims, and MCP resource.
  * @returns An OAuth token verifier for use with {@link oauthCustomProvider}.
- * @throws A `TypeError` when audience and issuer-bound validation are combined.
+ * @throws A `TypeError` when the key source is missing or ambiguous, or when
+ * audience and issuer-bound validation are combined.
  *
  * @example
  * ```ts
@@ -76,11 +77,22 @@ export type JwtVerifierOptions = {
 export function createJwtVerifier(
   options: JwtVerifierOptions
 ): OAuthTokenVerifier {
-  if (options.key === undefined && options.jwksUrl === undefined) {
-    throw new TypeError("JWT verifier requires either key or jwksUrl");
+  let key: Uint8Array | JWTVerifyGetKey;
+  if (options.key !== undefined) {
+    if (options.jwksUrl !== undefined) {
+      throw new TypeError(
+        "JWT verifier requires exactly one of key or jwksUrl"
+      );
+    }
+    key = options.key;
+  } else {
+    if (options.jwksUrl === undefined) {
+      throw new TypeError(
+        "JWT verifier requires exactly one of key or jwksUrl"
+      );
+    }
+    key = createRemoteJWKSet(options.jwksUrl);
   }
-  // jose overloads key material vs JWKS getters; runtime accepts either.
-  const key = options.key ?? createRemoteJWKSet(options.jwksUrl);
   const configuredResource = canonicalUrl(options.resource);
   const configuredAudience = verifierAudience(options.audience);
   if (

--- a/libraries/typescript/packages/server/src/oauth/jwt.ts
+++ b/libraries/typescript/packages/server/src/oauth/jwt.ts
@@ -19,11 +19,9 @@ export { invalidToken } from "./errors.js";
 export type VerifiedPayload = Record<string, unknown>;
 
 /** Options for {@link createJwtVerifier}. */
-export interface JwtVerifierOptions {
+export type JwtVerifierOptions = {
   /** Expected value of the JWT `iss` claim. */
   issuer: string;
-  /** Remote JSON Web Key Set used to verify token signatures. */
-  jwksUrl: URL;
   /** Canonical public MCP endpoint that accepted tokens must target. */
   resource: URL;
   /** Provider-specific JWT audience, when it differs from the MCP resource. */
@@ -36,9 +34,18 @@ export interface JwtVerifierOptions {
   issuerBoundAccessTokens?: boolean;
   /** Allowed JWT signature algorithms. */
   algorithms?: readonly string[];
-  /** Static symmetric verification key to use instead of the remote JWKS. */
-  key?: Uint8Array;
-}
+} & (
+  | {
+      /** Remote JSON Web Key Set used to verify token signatures. */
+      jwksUrl: URL;
+      key?: never;
+    }
+  | {
+      jwksUrl?: never;
+      /** Static symmetric verification key to use instead of a remote JWKS. */
+      key: Uint8Array;
+    }
+);
 
 /**
  * Creates an OAuth access-token verifier backed by `jose` JWT validation.
@@ -69,6 +76,9 @@ export interface JwtVerifierOptions {
 export function createJwtVerifier(
   options: JwtVerifierOptions
 ): OAuthTokenVerifier {
+  if (options.key === undefined && options.jwksUrl === undefined) {
+    throw new TypeError("JWT verifier requires either key or jwksUrl");
+  }
   // jose overloads key material vs JWKS getters; runtime accepts either.
   const key = options.key ?? createRemoteJWKSet(options.jwksUrl);
   const configuredResource = canonicalUrl(options.resource);

--- a/libraries/typescript/packages/server/src/oauth/supabase.ts
+++ b/libraries/typescript/packages/server/src/oauth/supabase.ts
@@ -106,12 +106,14 @@ export function oauthSupabaseProvider(
     createTokenVerifier: (resource) =>
       createJwtVerifier({
         issuer,
-        jwksUrl: new URL(
-          providerEndpoint(supabaseUrl, "auth/v1/.well-known/jwks.json")
-        ),
         ...(secret !== undefined
           ? { key: new TextEncoder().encode(secret), algorithms: ["HS256"] }
-          : { algorithms: ["ES256"] }),
+          : {
+              jwksUrl: new URL(
+                providerEndpoint(supabaseUrl, "auth/v1/.well-known/jwks.json")
+              ),
+              algorithms: ["ES256"],
+            }),
         resource,
         audience,
       }),

--- a/libraries/typescript/packages/server/tests/oauth-core.test.ts
+++ b/libraries/typescript/packages/server/tests/oauth-core.test.ts
@@ -153,13 +153,22 @@ describe("OAuth core", () => {
     }
   });
 
-  it("rejects verifier options without a key source", () => {
+  it("requires exactly one verifier key source", () => {
+    const baseOptions = {
+      issuer: "https://issuer.example.test",
+      resource: canonicalResource,
+    };
+
+    expect(() =>
+      createJwtVerifier(baseOptions as JwtVerifierOptions)
+    ).toThrowError("JWT verifier requires exactly one of key or jwksUrl");
     expect(() =>
       createJwtVerifier({
-        issuer: "https://issuer.example.test",
-        resource: canonicalResource,
-      } as JwtVerifierOptions)
-    ).toThrowError("JWT verifier requires either key or jwksUrl");
+        ...baseOptions,
+        key: new TextEncoder().encode("a sufficiently long test signing key"),
+        jwksUrl: new URL("https://issuer.example.test/.well-known/jwks.json"),
+      } as unknown as JwtVerifierOptions)
+    ).toThrowError("JWT verifier requires exactly one of key or jwksUrl");
   });
 
   it("accepts JWTs whose audience is the protected resource", async () => {

--- a/libraries/typescript/packages/server/tests/oauth-core.test.ts
+++ b/libraries/typescript/packages/server/tests/oauth-core.test.ts
@@ -11,7 +11,10 @@ import {
   resolveConfiguredOAuthResource,
   wrapOAuthTokenVerifier,
 } from "../src/oauth/internal.js";
-import { createJwtVerifier } from "../src/oauth/jwt.js";
+import {
+  createJwtVerifier,
+  type JwtVerifierOptions,
+} from "../src/oauth/index.js";
 import { oauthCustomProvider } from "../src/oauth/provider.js";
 
 const metadata = {
@@ -201,7 +204,7 @@ describe("OAuth core", () => {
       key,
       algorithms: ["HS256"],
       resource: canonicalResource,
-    });
+    } satisfies JwtVerifierOptions);
     const sign = (claims: Record<string, unknown>) =>
       new SignJWT({ sub: "user-1", client_id: "client-1", ...claims })
         .setProtectedHeader({ alg: "HS256" })

--- a/libraries/typescript/packages/server/tests/oauth-core.test.ts
+++ b/libraries/typescript/packages/server/tests/oauth-core.test.ts
@@ -153,6 +153,15 @@ describe("OAuth core", () => {
     }
   });
 
+  it("rejects verifier options without a key source", () => {
+    expect(() =>
+      createJwtVerifier({
+        issuer: "https://issuer.example.test",
+        resource: canonicalResource,
+      } as JwtVerifierOptions)
+    ).toThrowError("JWT verifier requires either key or jwksUrl");
+  });
+
   it("accepts JWTs whose audience is the protected resource", async () => {
     const key = new TextEncoder().encode(
       "a sufficiently long test signing key"
@@ -162,7 +171,6 @@ describe("OAuth core", () => {
     const issuer = "https://issuer.example.test";
     const verifier = createJwtVerifier({
       issuer,
-      jwksUrl: new URL(`${issuer}/.well-known/jwks.json`),
       key,
       algorithms: ["HS256"],
       resource: expectedResource,
@@ -200,7 +208,6 @@ describe("OAuth core", () => {
     const issuer = "https://issuer.example.test";
     const verifier = createJwtVerifier({
       issuer,
-      jwksUrl: new URL(`${issuer}/.well-known/jwks.json`),
       key,
       algorithms: ["HS256"],
       resource: canonicalResource,
@@ -242,7 +249,6 @@ describe("OAuth core", () => {
     const issuer = "https://issuer.example.test";
     const verifier = createJwtVerifier({
       issuer,
-      jwksUrl: new URL(`${issuer}/.well-known/jwks.json`),
       key,
       algorithms: ["HS256"],
       resource: canonicalResource,
@@ -333,7 +339,6 @@ describe("OAuth core", () => {
     );
     const verifier = createJwtVerifier({
       issuer: "https://issuer.example.test",
-      jwksUrl: new URL("https://issuer.example.test/.well-known/jwks.json"),
       key,
       algorithms: ["HS256"],
       resource: canonicalResource,
@@ -356,7 +361,6 @@ describe("OAuth core", () => {
     );
     const verifier = createJwtVerifier({
       issuer: "https://issuer.example.test",
-      jwksUrl: new URL("https://issuer.example.test/.well-known/jwks.json"),
       key,
       algorithms: ["HS256"],
       resource: canonicalResource,


### PR DESCRIPTION
## Summary

- export `createJwtVerifier` and `JwtVerifierOptions` from `mcp-use/oauth`
- document the newly public helper and all verifier options
- cover the public barrel export in the OAuth core regression tests
- add the required minor changeset for `mcp-use`

## Why

Custom OAuth providers currently have to duplicate the built-in JWT verification logic because the helper is only available through an internal source module. Publishing it from the existing OAuth entrypoint lets consumers reuse the same signature, claim, and protected-resource validation as the bundled providers.

## Impact

Consumers can now import `createJwtVerifier` and `JwtVerifierOptions` directly from `mcp-use/oauth` when implementing `oauthCustomProvider` integrations.

## Validation

- `pnpm --filter mcp-use test:run` (43 files, 448 tests)
- `pnpm build`
- `pnpm lint:strict`
- `pnpm format:check`
- built runtime and declaration entrypoint export checks

Closes #2215

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exported `createJwtVerifier` and `JwtVerifierOptions` from `mcp-use/oauth` so custom OAuth providers can reuse built‑in JWT signature, claim, and protected‑resource validation.

The verifier now requires exactly one key source (`jwksUrl` or `key`) and throws if both or neither are provided; updated the Supabase provider to match, added tests for the new contract, and included a minor `mcp-use` changeset.

<sup>Written for commit 6640776271230a5143aa48850cdcec4dce0a9e09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

