### PR TITLE
fix(inspector): scope loading state by chat session

### DIFF
--- a/libraries/typescript/.changeset/scope-inspector-chat-sessions.md
+++ b/libraries/typescript/.changeset/scope-inspector-chat-sessions.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Give each Inspector chat session one id and one state record, so **New Chat** starts a fresh chat while an earlier one is still streaming. Session state, persistence, and OAuth retry now share that id: `ChatStorageProvider.createChat` accepts it via the new optional `id` param, and providers that already stored it should return the existing chat.

--- a/libraries/typescript/packages/inspector/src/client/chat-history/__tests__/local-storage.test.ts
+++ b/libraries/typescript/packages/inspector/src/client/chat-history/__tests__/local-storage.test.ts
@@ -57,6 +57,26 @@ describe("LocalChatStorageProvider", () => {
     expect(storage.getItem).toHaveBeenCalledWith(STORAGE_KEY);
   });
 
+  it("adopts a caller-supplied id and reuses the chat it already stored", async () => {
+    const provider = new LocalChatStorageProvider();
+
+    const created = await provider.createChat({
+      id: "session-1",
+      agentId: "server-1",
+    });
+    expect(created.id).toBe("session-1");
+
+    // Re-attaching after an OAuth redirect must not fork a duplicate row.
+    const reattached = await provider.createChat({
+      id: "session-1",
+      agentId: "server-1",
+    });
+    expect(reattached.id).toBe("session-1");
+
+    const listed = await provider.listChats({ agentId: "server-1" });
+    expect(listed.total).toBe(1);
+  });
+
   it("round-trips messages and auto-titles from first user message", async () => {
     vi.useFakeTimers();
     const provider = new LocalChatStorageProvider();

--- a/libraries/typescript/packages/inspector/src/client/chat-history/providers/local-storage.ts
+++ b/libraries/typescript/packages/inspector/src/client/chat-history/providers/local-storage.ts
@@ -80,14 +80,21 @@ export class LocalChatStorageProvider implements ChatStorageProvider {
   }
 
   async createChat(params: {
+    id?: string;
     agentId: string;
     title?: string;
     agentName?: string;
   }): Promise<ChatSession> {
     const store = readStore();
+    if (params.id) {
+      // Re-attaching to a known id (e.g. after an OAuth redirect) must reuse the
+      // stored chat rather than fork a duplicate row.
+      const existing = store.sessions.find((s) => s.id === params.id);
+      if (existing) return existing;
+    }
     const ts = nowIso();
     const session: ChatSession = {
-      id: crypto.randomUUID(),
+      id: params.id ?? crypto.randomUUID(),
       title: params.title ?? DEFAULT_TITLE,
       agent_id: params.agentId,
       agent_name: params.agentName ?? "MCP Server",

--- a/libraries/typescript/packages/inspector/src/client/chat-history/types.ts
+++ b/libraries/typescript/packages/inspector/src/client/chat-history/types.ts
@@ -26,6 +26,13 @@ export interface ChatStorageProvider {
   ): Promise<{ items: ChatSession[]; total: number }>;
   getMessages(chatId: string): Promise<Message[]>;
   createChat(params: {
+    /**
+     * Id the caller already uses for this chat session. Providers should adopt
+     * it so runtime and persisted state share one identity, and should return
+     * the existing chat when it is already stored. Providers that must mint
+     * their own id may ignore it — the caller keeps the returned id instead.
+     */
+    id?: string;
     agentId: string;
     title?: string;
     agentName?: string;

--- a/libraries/typescript/packages/inspector/src/client/components/ChatTab.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ChatTab.tsx
@@ -253,7 +253,6 @@ export function ChatTab({
     activeChatId,
     selectChat,
     startNewChat,
-    ensureActiveChat,
     persistSessionMessages,
   } = useChatSessions({
     retryServerId: connection.id ?? connection.url,
@@ -440,18 +439,6 @@ export function ChatTab({
     );
     await startNewChat();
   }, [effectiveChatStorage, startNewChat]);
-
-  // Sending into a chat history has not seen yet shows a placeholder title
-  // until title generation replaces it.
-  const prepareActiveChat = useCallback(() => {
-    if (
-      effectiveChatStorage &&
-      !chatSessions.get(activeSessionId).persistedChatId
-    ) {
-      setInternalChatTitle(CHAT_TITLE_PLACEHOLDER);
-    }
-    return ensureActiveChat();
-  }, [activeSessionId, chatSessions, effectiveChatStorage, ensureActiveChat]);
 
   const handleTitleGenerated = useCallback(
     (chatId: string, title: string) => {
@@ -1298,18 +1285,24 @@ export function ChatTab({
     if (messages.length === 0) {
       dismissLandingShader();
     }
-    void prepareActiveChat().then(() => {
-      sendMessage(inputValue, results);
-      setInputValue("");
-      clearPromptResults();
-    });
+    if (
+      effectiveChatStorage &&
+      !chatSessions.get(activeSessionId).persistedChatId
+    ) {
+      setInternalChatTitle(CHAT_TITLE_PLACEHOLDER);
+    }
+    void sendMessage(inputValue, results);
+    setInputValue("");
+    clearPromptResults();
   }, [
     inputValue,
     results,
     sendMessage,
     clearPromptResults,
     attachments,
-    prepareActiveChat,
+    activeSessionId,
+    chatSessions,
+    effectiveChatStorage,
     messages.length,
     dismissLandingShader,
   ]);

--- a/libraries/typescript/packages/inspector/src/client/components/ChatTab.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ChatTab.tsx
@@ -67,6 +67,7 @@ import { useWidgetDebug } from "../context/WidgetDebugContext";
 import type { ChatBodyBuilder, MessageAttachment } from "./chat/types";
 import { resolveChatToolPolicy } from "./chat/chat-tool-policy";
 import { buildChatCspAudit } from "./chat/csp-bridge";
+import { useChatSessions } from "./chat/useChatSessions";
 
 // Structural type — avoids nominal incompatibility when pnpm creates
 // multiple peer-variant copies of mcp-use with duplicate class declarations.
@@ -240,29 +241,33 @@ export function ChatTab({
       ? localChatStorageRef.current
       : null);
 
-  const [internalActiveChatId, setInternalActiveChatId] = useState<
-    string | null
-  >(null);
-  const activeChatId = controlledActiveChatId ?? internalActiveChatId;
-  const setActiveChatId = useCallback(
-    (chatId: string | null) => {
-      if (onActiveChatIdChange) {
-        onActiveChatIdChange(chatId);
-      } else {
-        setInternalActiveChatId(chatId);
-      }
-    },
-    [onActiveChatIdChange]
-  );
-
   const [showHistoryPanel, setShowHistoryPanel] = useState(false);
   const [historyRefetchKey, setHistoryRefetchKey] = useState(0);
+  const bumpHistoryRefetch = useCallback(() => {
+    setHistoryRefetchKey((k) => k + 1);
+  }, []);
+
+  const {
+    store: chatSessions,
+    activeSessionId,
+    activeChatId,
+    selectChat,
+    startNewChat,
+    ensureActiveChat,
+    persistSessionMessages,
+  } = useChatSessions({
+    retryServerId: connection.id ?? connection.url,
+    agentId: serverId,
+    agentName: connection.displayName || connection.name || "MCP Server",
+    storage: effectiveChatStorage,
+    activeChatId: controlledActiveChatId,
+    onActiveChatIdChange,
+    initialMessages,
+    onChatCreated: bumpHistoryRefetch,
+  });
   const [internalChatTitle, setInternalChatTitle] = useState<
     string | undefined
   >();
-  const [restoredMessages, setRestoredMessages] = useState<
-    import("./chat/types").Message[] | undefined
-  >(undefined);
   const [inputValue, setInputValue] = useState("");
   const [promptsDropdownOpen, setPromptsDropdownOpen] = useState(false);
   const [promptFocusedIndex, setPromptFocusedIndex] = useState(-1);
@@ -331,6 +336,9 @@ export function ChatTab({
 
   // Use client-side or server-side chat implementation
   const chatHookParams = {
+    sessionStore: chatSessions,
+    sessionId: activeSessionId,
+    onMessagesChange: persistSessionMessages,
     connection,
     llmConfig,
     isConnected,
@@ -341,6 +349,9 @@ export function ChatTab({
   };
 
   const serverSideChat = useChatMessages({
+    sessionStore: chatSessions,
+    sessionId: activeSessionId,
+    onMessagesChange: persistSessionMessages,
     mcpServerUrl: connection.url ?? "",
     llmConfig,
     authConfig: userAuthConfig,
@@ -349,7 +360,6 @@ export function ChatTab({
     chatApiUrl,
     waitForChatApiUrl,
     widgetModelContexts,
-    initialMessages: restoredMessages ?? initialMessages,
     disabledTools: effectiveDisabledTools,
     streamProtocol,
     credentials,
@@ -358,7 +368,6 @@ export function ChatTab({
   });
   const clientSideChat = useChatMessagesClientSide({
     ...chatHookParams,
-    initialMessages: restoredMessages ?? initialMessages,
     systemPrompt: resolvedSystemPrompt,
     skills,
   });
@@ -373,7 +382,6 @@ export function ChatTab({
     stop,
     addAttachment,
     removeAttachment,
-    clearTrace,
     traceEvents,
     tokenUsage,
   } = effectiveClientSide ? clientSideChat : serverSideChat;
@@ -412,74 +420,38 @@ export function ChatTab({
   const handleSelectChat = useCallback(
     async (chatId: string) => {
       if (!effectiveChatStorage) return;
-      const [msgs, listed] = await Promise.all([
-        effectiveChatStorage.getMessages(chatId),
-        effectiveChatStorage.listChats({ agentId: serverId }),
-      ]);
-      setRestoredMessages(msgs);
-      clearTrace();
-      setMessages(msgs);
-      setShaderPhase(msgs.length === 0 ? "visible" : "hidden");
-      setActiveChatId(chatId);
+      const listing = effectiveChatStorage.listChats({ agentId: serverId });
+      const session = await selectChat(chatId);
+      setShaderPhase(
+        (session?.messages.length ?? 0) === 0 ? "visible" : "hidden"
+      );
+      const listed = await listing;
       setInternalChatTitle(
-        listed.items.find((session) => session.id === chatId)?.title
+        listed.items.find((entry) => entry.id === chatId)?.title
       );
     },
-    [effectiveChatStorage, clearTrace, setMessages, setActiveChatId, serverId]
+    [effectiveChatStorage, selectChat, serverId]
   );
 
   const handleNewChat = useCallback(async () => {
-    clearMessages();
-    setRestoredMessages([]);
     setShaderPhase("visible");
-    setInternalChatTitle(CHAT_TITLE_PLACEHOLDER);
-    setActiveChatId(null);
-    if (effectiveChatStorage) {
-      const session = await effectiveChatStorage.createChat({
-        agentId: serverId,
-        agentName: connection.displayName || connection.name || "MCP Server",
-      });
-      setActiveChatId(session.id);
-      setHistoryRefetchKey((k) => k + 1);
-    } else {
-      setInternalChatTitle(undefined);
+    setInternalChatTitle(
+      effectiveChatStorage ? CHAT_TITLE_PLACEHOLDER : undefined
+    );
+    await startNewChat();
+  }, [effectiveChatStorage, startNewChat]);
+
+  // Sending into a chat history has not seen yet shows a placeholder title
+  // until title generation replaces it.
+  const prepareActiveChat = useCallback(() => {
+    if (
+      effectiveChatStorage &&
+      !chatSessions.get(activeSessionId).persistedChatId
+    ) {
+      setInternalChatTitle(CHAT_TITLE_PLACEHOLDER);
     }
-  }, [
-    clearMessages,
-    effectiveChatStorage,
-    serverId,
-    connection.displayName,
-    connection.name,
-    setActiveChatId,
-  ]);
-
-  const ensureActiveChat = useCallback(async () => {
-    if (!effectiveChatStorage || activeChatId) return activeChatId;
-    const session = await effectiveChatStorage.createChat({
-      agentId: serverId,
-      agentName: connection.displayName || connection.name || "MCP Server",
-    });
-    setActiveChatId(session.id);
-    setInternalChatTitle(CHAT_TITLE_PLACEHOLDER);
-    setHistoryRefetchKey((k) => k + 1);
-    return session.id;
-  }, [
-    effectiveChatStorage,
-    activeChatId,
-    serverId,
-    connection.displayName,
-    connection.name,
-    setActiveChatId,
-  ]);
-
-  useEffect(() => {
-    if (!effectiveChatStorage?.saveMessages || !activeChatId) return;
-    void effectiveChatStorage.saveMessages(activeChatId, messages);
-  }, [effectiveChatStorage, activeChatId, messages]);
-
-  const bumpHistoryRefetch = useCallback(() => {
-    setHistoryRefetchKey((k) => k + 1);
-  }, []);
+    return ensureActiveChat();
+  }, [activeSessionId, chatSessions, effectiveChatStorage, ensureActiveChat]);
 
   const handleTitleGenerated = useCallback(
     (chatId: string, title: string) => {
@@ -1148,7 +1120,7 @@ export function ChatTab({
   useKeyboardShortcuts(
     enableKeyboardShortcuts
       ? {
-          onNewChat: effectiveChatStorage ? handleNewChat : clearChatToLanding,
+          onNewChat: handleNewChat,
         }
       : {}
   );
@@ -1326,7 +1298,7 @@ export function ChatTab({
     if (messages.length === 0) {
       dismissLandingShader();
     }
-    void ensureActiveChat().then(() => {
+    void prepareActiveChat().then(() => {
       sendMessage(inputValue, results);
       setInputValue("");
       clearPromptResults();
@@ -1337,7 +1309,7 @@ export function ChatTab({
     sendMessage,
     clearPromptResults,
     attachments,
-    ensureActiveChat,
+    prepareActiveChat,
     messages.length,
     dismissLandingShader,
   ]);
@@ -1618,7 +1590,7 @@ export function ChatTab({
         hasMessages={messages.length > 0}
         configDialogOpen={configDialogOpen}
         onConfigDialogOpenChange={setConfigDialogOpen}
-        onClearChat={effectiveChatStorage ? handleNewChat : clearChatToLanding}
+        onClearChat={handleNewChat}
         tempProvider={tempProvider}
         tempModel={tempModel}
         tempApiKey={tempApiKey}

--- a/libraries/typescript/packages/inspector/src/client/components/chat/__tests__/chat-auth-retry.test.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/__tests__/chat-auth-retry.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clearPendingChatTurn,
   readPendingChatTurn,
+  readPendingChatTurnForServer,
   savePendingChatTurn,
 } from "../chat-auth-retry";
 
@@ -9,66 +10,95 @@ function createStorage() {
   const values = new Map<string, string>();
   return {
     getItem: (key: string) => values.get(key) ?? null,
-    setItem: (key: string, value: string) => values.set(key, value),
-    removeItem: (key: string) => values.delete(key),
+    setItem: (key: string, value: string) => {
+      values.set(key, value);
+    },
+    removeItem: (key: string) => {
+      values.delete(key);
+    },
+  };
+}
+
+function turn(serverId: string, sessionId: string) {
+  return {
+    serverId,
+    sessionId,
+    userInput: "Read my profile",
+    promptResults: [],
+    attachments: [],
+    baseMessages: [
+      {
+        id: "user-1",
+        role: "user" as const,
+        content: "Read my profile",
+        timestamp: 1,
+      },
+    ],
   };
 }
 
 describe("chat auth retry storage", () => {
   beforeEach(() => vi.restoreAllMocks());
 
-  it("round-trips a pending chat turn for the matching server", () => {
+  it("round-trips a pending turn for the matching server and session", () => {
     const storage = createStorage();
-    const turn = {
-      serverId: "server-1",
-      userInput: "Read my profile",
-      promptResults: [],
-      attachments: [],
-      baseMessages: [
-        {
-          id: "user-1",
-          role: "user" as const,
-          content: "Read my profile",
-          timestamp: 1,
-        },
-      ],
-    };
+    const pending = turn("server-1", "session-1");
 
-    savePendingChatTurn(turn, storage);
+    savePendingChatTurn(pending, storage);
 
-    expect(readPendingChatTurn("server-1", storage)).toMatchObject(turn);
-    expect(readPendingChatTurn("server-2", storage)).toBeNull();
+    expect(readPendingChatTurn("server-1", "session-1", storage)).toMatchObject(
+      pending
+    );
+    expect(readPendingChatTurn("server-2", "session-1", storage)).toBeNull();
+    expect(readPendingChatTurn("server-1", "session-2", storage)).toBeNull();
+  });
+
+  it("keeps concurrent chats' turns apart", () => {
+    const storage = createStorage();
+    savePendingChatTurn(turn("server-1", "session-1"), storage);
+    savePendingChatTurn(turn("server-1", "session-2"), storage);
+
+    // Authorizing the second chat must not discard the first chat's turn.
+    expect(
+      readPendingChatTurn("server-1", "session-1", storage)
+    ).not.toBeNull();
+
+    clearPendingChatTurn("server-1", "session-2", storage);
+
+    expect(
+      readPendingChatTurn("server-1", "session-1", storage)
+    ).not.toBeNull();
+    expect(readPendingChatTurn("server-1", "session-2", storage)).toBeNull();
+  });
+
+  it("reports which session the redirect interrupted", () => {
+    const storage = createStorage();
+    savePendingChatTurn(turn("server-1", "session-1"), storage);
+    savePendingChatTurn(turn("server-1", "session-2"), storage);
+
+    expect(readPendingChatTurnForServer("server-1", storage)?.sessionId).toBe(
+      "session-2"
+    );
+
+    clearPendingChatTurn("server-1", "session-2", storage);
+
+    // The pointer is cleared with the turn it named, so a stale session id
+    // cannot resurface in a chat the user starts later.
+    expect(readPendingChatTurnForServer("server-1", storage)).toBeNull();
   });
 
   it("drops expired and explicitly cleared turns", () => {
     const storage = createStorage();
     vi.spyOn(Date, "now").mockReturnValue(1_000);
-    savePendingChatTurn(
-      {
-        serverId: "server-1",
-        userInput: "Read my profile",
-        promptResults: [],
-        attachments: [],
-        baseMessages: [],
-      },
-      storage
-    );
+    savePendingChatTurn(turn("server-1", "session-1"), storage);
 
     vi.spyOn(Date, "now").mockReturnValue(16 * 60_000);
-    expect(readPendingChatTurn("server-1", storage)).toBeNull();
+    expect(readPendingChatTurn("server-1", "session-1", storage)).toBeNull();
+    expect(readPendingChatTurnForServer("server-1", storage)).toBeNull();
 
     vi.spyOn(Date, "now").mockReturnValue(20 * 60_000);
-    savePendingChatTurn(
-      {
-        serverId: "server-1",
-        userInput: "Read my profile",
-        promptResults: [],
-        attachments: [],
-        baseMessages: [],
-      },
-      storage
-    );
-    clearPendingChatTurn("server-1", storage);
-    expect(readPendingChatTurn("server-1", storage)).toBeNull();
+    savePendingChatTurn(turn("server-1", "session-1"), storage);
+    clearPendingChatTurn("server-1", "session-1", storage);
+    expect(readPendingChatTurn("server-1", "session-1", storage)).toBeNull();
   });
 });

--- a/libraries/typescript/packages/inspector/src/client/components/chat/__tests__/chat-session-store.test.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/__tests__/chat-session-store.test.ts
@@ -7,26 +7,22 @@ function message(id: string): Message {
 }
 
 describe("ChatSessionStore", () => {
-  it("creates an empty record on first access", () => {
+  it("keeps session state independent while preserving each runtime", () => {
     const store = new ChatSessionStore();
-    expect(store.has("a")).toBe(false);
+    const beforeA = store.get("a");
+    const sessionB = store.get("b");
+    const afterA = store.update("a", {
+      isLoading: true,
+      messages: [message("a1")],
+    });
 
-    const session = store.get("a");
-    expect(session.id).toBe("a");
-    expect(session.messages).toEqual([]);
-    expect(session.isLoading).toBe(false);
-    expect(store.has("a")).toBe(true);
-    expect(store.get("a")).toBe(session);
-  });
-
-  it("keeps each session's state independent", () => {
-    const store = new ChatSessionStore();
-    store.update("a", { isLoading: true, messages: [message("a1")] });
-    store.update("b", { messages: [message("b1")] });
-
-    expect(store.get("a").isLoading).toBe(true);
-    expect(store.get("b").isLoading).toBe(false);
-    expect(store.get("b").messages).toEqual([message("b1")]);
+    expect(beforeA.messages).toEqual([]);
+    expect(beforeA.isLoading).toBe(false);
+    expect(afterA).not.toBe(beforeA);
+    expect(afterA.runtime).toBe(beforeA.runtime);
+    expect(afterA.runtime).not.toBe(sessionB.runtime);
+    expect(sessionB.messages).toEqual([]);
+    expect(sessionB.isLoading).toBe(false);
   });
 
   it("notifies only the subscribers of the session that changed", () => {
@@ -42,28 +38,6 @@ describe("ChatSessionStore", () => {
     expect(onB).not.toHaveBeenCalled();
   });
 
-  it("skips notifying when a patch changes nothing", () => {
-    const store = new ChatSessionStore();
-    const messages = [message("a1")];
-    store.update("a", { messages });
-    const listener = vi.fn();
-    store.subscribe("a", listener);
-
-    const unchanged = store.update("a", { messages });
-
-    expect(listener).not.toHaveBeenCalled();
-    expect(unchanged).toBe(store.get("a"));
-  });
-
-  it("gives every update a new snapshot but one stable runtime", () => {
-    const store = new ChatSessionStore();
-    const before = store.get("a");
-    const after = store.update("a", { isLoading: true });
-
-    expect(after).not.toBe(before);
-    expect(after.runtime).toBe(before.runtime);
-  });
-
   it("seeds only sessions it has not created yet", () => {
     const store = new ChatSessionStore();
     store.seed("a", [message("seed")]);
@@ -71,17 +45,6 @@ describe("ChatSessionStore", () => {
 
     store.seed("a", [message("later")]);
     expect(store.get("a").messages).toEqual([message("seed")]);
-  });
-
-  it("stops notifying an unsubscribed listener", () => {
-    const store = new ChatSessionStore();
-    const listener = vi.fn();
-    const unsubscribe = store.subscribe("a", listener);
-    unsubscribe();
-
-    store.update("a", { isLoading: true });
-
-    expect(listener).not.toHaveBeenCalled();
   });
 
   it("finds a session by its persisted chat id, falling back to its own id", () => {
@@ -93,14 +56,5 @@ describe("ChatSessionStore", () => {
     expect(store.findByPersistedChatId("backend-id")?.id).toBe("runtime-id");
     expect(store.findByPersistedChatId("runtime-id")).toBeUndefined();
     expect(store.findByPersistedChatId("missing")).toBeUndefined();
-  });
-
-  it("drops a deleted session", () => {
-    const store = new ChatSessionStore();
-    store.update("a", { messages: [message("a1")] });
-    store.delete("a");
-
-    expect(store.has("a")).toBe(false);
-    expect(store.get("a").messages).toEqual([]);
   });
 });

--- a/libraries/typescript/packages/inspector/src/client/components/chat/__tests__/chat-session-store.test.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/__tests__/chat-session-store.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from "vitest";
+import { ChatSessionStore } from "../chat-session-store";
+import type { Message } from "../types";
+
+function message(id: string): Message {
+  return { id, role: "user", content: id, timestamp: 0 };
+}
+
+describe("ChatSessionStore", () => {
+  it("creates an empty record on first access", () => {
+    const store = new ChatSessionStore();
+    expect(store.has("a")).toBe(false);
+
+    const session = store.get("a");
+    expect(session.id).toBe("a");
+    expect(session.messages).toEqual([]);
+    expect(session.isLoading).toBe(false);
+    expect(store.has("a")).toBe(true);
+    expect(store.get("a")).toBe(session);
+  });
+
+  it("keeps each session's state independent", () => {
+    const store = new ChatSessionStore();
+    store.update("a", { isLoading: true, messages: [message("a1")] });
+    store.update("b", { messages: [message("b1")] });
+
+    expect(store.get("a").isLoading).toBe(true);
+    expect(store.get("b").isLoading).toBe(false);
+    expect(store.get("b").messages).toEqual([message("b1")]);
+  });
+
+  it("notifies only the subscribers of the session that changed", () => {
+    const store = new ChatSessionStore();
+    const onA = vi.fn();
+    const onB = vi.fn();
+    store.subscribe("a", onA);
+    store.subscribe("b", onB);
+
+    store.update("a", { isLoading: true });
+
+    expect(onA).toHaveBeenCalledTimes(1);
+    expect(onB).not.toHaveBeenCalled();
+  });
+
+  it("skips notifying when a patch changes nothing", () => {
+    const store = new ChatSessionStore();
+    const messages = [message("a1")];
+    store.update("a", { messages });
+    const listener = vi.fn();
+    store.subscribe("a", listener);
+
+    const unchanged = store.update("a", { messages });
+
+    expect(listener).not.toHaveBeenCalled();
+    expect(unchanged).toBe(store.get("a"));
+  });
+
+  it("gives every update a new snapshot but one stable runtime", () => {
+    const store = new ChatSessionStore();
+    const before = store.get("a");
+    const after = store.update("a", { isLoading: true });
+
+    expect(after).not.toBe(before);
+    expect(after.runtime).toBe(before.runtime);
+  });
+
+  it("seeds only sessions it has not created yet", () => {
+    const store = new ChatSessionStore();
+    store.seed("a", [message("seed")]);
+    expect(store.get("a").messages).toEqual([message("seed")]);
+
+    store.seed("a", [message("later")]);
+    expect(store.get("a").messages).toEqual([message("seed")]);
+  });
+
+  it("stops notifying an unsubscribed listener", () => {
+    const store = new ChatSessionStore();
+    const listener = vi.fn();
+    const unsubscribe = store.subscribe("a", listener);
+    unsubscribe();
+
+    store.update("a", { isLoading: true });
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("finds a session by its persisted chat id, falling back to its own id", () => {
+    const store = new ChatSessionStore();
+    store.get("same-id");
+    store.update("runtime-id", { persistedChatId: "backend-id" });
+
+    expect(store.findByPersistedChatId("same-id")?.id).toBe("same-id");
+    expect(store.findByPersistedChatId("backend-id")?.id).toBe("runtime-id");
+    expect(store.findByPersistedChatId("runtime-id")).toBeUndefined();
+    expect(store.findByPersistedChatId("missing")).toBeUndefined();
+  });
+
+  it("drops a deleted session", () => {
+    const store = new ChatSessionStore();
+    store.update("a", { messages: [message("a1")] });
+    store.delete("a");
+
+    expect(store.has("a")).toBe(false);
+    expect(store.get("a").messages).toEqual([]);
+  });
+});

--- a/libraries/typescript/packages/inspector/src/client/components/chat/__tests__/chat-session.test.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/__tests__/chat-session.test.ts
@@ -1,18 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
-import {
-  createChatSession,
-  createChatSessionId,
-  resolveActiveChatId,
-} from "../chat-session";
+import { createChatSessionId } from "../chat-session";
 
 describe("createChatSessionId", () => {
-  it("mints a distinct id per session", () => {
-    const ids = new Set(
-      Array.from({ length: 50 }, () => createChatSessionId())
-    );
-    expect(ids.size).toBe(50);
-  });
-
   it("still mints ids where randomUUID is unavailable", () => {
     vi.stubGlobal("crypto", {});
     try {
@@ -20,34 +9,5 @@ describe("createChatSessionId", () => {
     } finally {
       vi.unstubAllGlobals();
     }
-  });
-});
-
-describe("createChatSession", () => {
-  it("starts idle, with its own runtime", () => {
-    const a = createChatSession("a");
-    const b = createChatSession("b");
-
-    expect(a.isLoading).toBe(false);
-    expect(a.persistedChatId).toBeNull();
-    expect(a.creation).toBeNull();
-    expect(a.runtime).not.toBe(b.runtime);
-    expect(a.runtime.sendInProgress).toBe(false);
-  });
-});
-
-describe("resolveActiveChatId", () => {
-  it("follows the host while controlled, ignoring internal state", () => {
-    expect(resolveActiveChatId(true, "chat-1", "internal-1")).toBe("chat-1");
-    // The host cleared its id, so no chat is active — even though a previous
-    // internal id is still around.
-    expect(resolveActiveChatId(true, undefined, "internal-1")).toBeNull();
-  });
-
-  it("uses internal state when uncontrolled", () => {
-    expect(resolveActiveChatId(false, undefined, "internal-1")).toBe(
-      "internal-1"
-    );
-    expect(resolveActiveChatId(false, undefined, null)).toBeNull();
   });
 });

--- a/libraries/typescript/packages/inspector/src/client/components/chat/__tests__/chat-session.test.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/__tests__/chat-session.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createChatSession,
+  createChatSessionId,
+  resolveActiveChatId,
+} from "../chat-session";
+
+describe("createChatSessionId", () => {
+  it("mints a distinct id per session", () => {
+    const ids = new Set(
+      Array.from({ length: 50 }, () => createChatSessionId())
+    );
+    expect(ids.size).toBe(50);
+  });
+
+  it("still mints ids where randomUUID is unavailable", () => {
+    vi.stubGlobal("crypto", {});
+    try {
+      expect(createChatSessionId()).not.toBe(createChatSessionId());
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});
+
+describe("createChatSession", () => {
+  it("starts idle, with its own runtime", () => {
+    const a = createChatSession("a");
+    const b = createChatSession("b");
+
+    expect(a.isLoading).toBe(false);
+    expect(a.persistedChatId).toBeNull();
+    expect(a.creation).toBeNull();
+    expect(a.runtime).not.toBe(b.runtime);
+    expect(a.runtime.sendInProgress).toBe(false);
+  });
+});
+
+describe("resolveActiveChatId", () => {
+  it("follows the host while controlled, ignoring internal state", () => {
+    expect(resolveActiveChatId(true, "chat-1", "internal-1")).toBe("chat-1");
+    // The host cleared its id, so no chat is active — even though a previous
+    // internal id is still around.
+    expect(resolveActiveChatId(true, undefined, "internal-1")).toBeNull();
+  });
+
+  it("uses internal state when uncontrolled", () => {
+    expect(resolveActiveChatId(false, undefined, "internal-1")).toBe(
+      "internal-1"
+    );
+    expect(resolveActiveChatId(false, undefined, null)).toBeNull();
+  });
+});

--- a/libraries/typescript/packages/inspector/src/client/components/chat/__tests__/useChatMessages.sessions.test.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/__tests__/useChatMessages.sessions.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useChatMessages } from "../useChatMessages";
+import { useChatSessions, type ChatSessions } from "../useChatSessions";
+
+interface Harness {
+  sessions: ChatSessions;
+  chat: ReturnType<typeof useChatMessages>;
+}
+
+describe("useChatMessages session isolation", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let harness: Harness;
+  let streams: ReadableStreamDefaultController<Uint8Array>[];
+
+  function Probe() {
+    const sessions = useChatSessions({
+      retryServerId: "server-1",
+      agentId: "server-1",
+      storage: null,
+    });
+    const chat = useChatMessages({
+      sessionStore: sessions.store,
+      sessionId: sessions.activeSessionId,
+      onMessagesChange: sessions.persistSessionMessages,
+      mcpServerUrl: "https://example.test/mcp",
+      llmConfig: {
+        provider: "openai",
+        apiKey: "test-key",
+        model: "test-model",
+      },
+      authConfig: null,
+      isConnected: true,
+      chatApiUrl: "https://example.test/chat",
+    });
+    harness = { sessions, chat };
+    return null;
+  }
+
+  async function flushAsyncWork() {
+    await Promise.resolve();
+    await Promise.resolve();
+  }
+
+  function finishStream(
+    controller: ReadableStreamDefaultController<Uint8Array>,
+    text: string
+  ) {
+    const encoder = new TextEncoder();
+    controller.enqueue(
+      encoder.encode(
+        `data: ${JSON.stringify({ type: "text", content: text })}\n\n`
+      )
+    );
+    controller.enqueue(
+      encoder.encode(`data: ${JSON.stringify({ type: "done" })}\n\n`)
+    );
+    controller.close();
+  }
+
+  beforeEach(async () => {
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    streams = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        const body = new ReadableStream<Uint8Array>({
+          start(controller) {
+            streams.push(controller);
+          },
+        });
+        return new Response(body, { status: 200 });
+      })
+    );
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => root.render(<Probe />));
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it("lets a new session send while the previous session keeps streaming", async () => {
+    const firstSessionId = harness.sessions.activeSessionId;
+    let firstSend!: Promise<void>;
+    await act(async () => {
+      firstSend = harness.chat.sendMessage("first", []);
+      await flushAsyncWork();
+    });
+
+    expect(harness.chat.isLoading).toBe(true);
+    expect(streams).toHaveLength(1);
+
+    await act(async () => {
+      await harness.sessions.startNewChat();
+    });
+    const secondSessionId = harness.sessions.activeSessionId;
+    expect(secondSessionId).not.toBe(firstSessionId);
+    expect(harness.chat.isLoading).toBe(false);
+
+    let secondSend!: Promise<void>;
+    await act(async () => {
+      secondSend = harness.chat.sendMessage("second", []);
+      await flushAsyncWork();
+    });
+
+    expect(streams).toHaveLength(2);
+    expect(harness.sessions.store.get(firstSessionId).isLoading).toBe(true);
+    expect(harness.chat.isLoading).toBe(true);
+
+    await act(async () => {
+      finishStream(streams[1]!, "second reply");
+      await secondSend;
+      finishStream(streams[0]!, "first reply");
+      await firstSend;
+    });
+
+    expect(harness.sessions.activeSessionId).toBe(secondSessionId);
+    expect(harness.chat.isLoading).toBe(false);
+    expect(
+      harness.sessions.store
+        .get(firstSessionId)
+        .messages.map((message) => message.content)
+    ).toEqual(["first", ""]);
+    expect(
+      harness.sessions.store
+        .get(secondSessionId)
+        .messages.map((message) => message.content)
+    ).toEqual(["second", ""]);
+    expect(
+      harness.sessions.store.get(firstSessionId).messages[1]?.parts?.[0]
+    ).toMatchObject({ type: "text", text: "first reply" });
+    expect(
+      harness.sessions.store.get(secondSessionId).messages[1]?.parts?.[0]
+    ).toMatchObject({ type: "text", text: "second reply" });
+  });
+});

--- a/libraries/typescript/packages/inspector/src/client/components/chat/__tests__/useChatMessagesClientSide.auth.test.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/__tests__/useChatMessagesClientSide.auth.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+import type { McpServer } from "@mcp-use/client/react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { readPendingChatTurn } from "../chat-auth-retry";
+import { useChatMessagesClientSide } from "../useChatMessagesClientSide";
+import { useChatSessions, type ChatSessions } from "../useChatSessions";
+
+const SERVER_ID = "server-1";
+
+interface Harness {
+  sessions: ChatSessions;
+  chat: ReturnType<typeof useChatMessagesClientSide>;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((complete) => {
+    resolve = complete;
+  });
+  return { promise, resolve };
+}
+
+describe("useChatMessagesClientSide authentication", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let harness: Harness;
+  let authenticate: ReturnType<typeof vi.fn>;
+  let connection: McpServer;
+
+  function Probe() {
+    const sessions = useChatSessions({
+      retryServerId: SERVER_ID,
+      agentId: SERVER_ID,
+      storage: null,
+    });
+    const chat = useChatMessagesClientSide({
+      sessionStore: sessions.store,
+      sessionId: sessions.activeSessionId,
+      onMessagesChange: sessions.persistSessionMessages,
+      connection,
+      llmConfig: {
+        provider: "openai",
+        apiKey: "test-key",
+        model: "test-model",
+      },
+      isConnected: true,
+    });
+    harness = { sessions, chat };
+    return null;
+  }
+
+  function prepareAuthorization(creation: Promise<string | null>) {
+    const sessionId = harness.sessions.activeSessionId;
+    harness.sessions.store.update(sessionId, {
+      creation,
+      pendingAuthorization: {
+        toolCallId: "tool-1",
+        replay: {
+          serverId: SERVER_ID,
+          sessionId,
+          userInput: "read my profile",
+          promptResults: [],
+          attachments: [],
+          baseMessages: [],
+        },
+      },
+    });
+    return sessionId;
+  }
+
+  beforeEach(async () => {
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    sessionStorage.clear();
+    authenticate = vi.fn(async () => undefined);
+    connection = {
+      id: SERVER_ID,
+      url: "https://example.test/mcp",
+      authenticate,
+    } as unknown as McpServer;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => root.render(<Probe />));
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  it("authenticates once while chat creation is still resolving", async () => {
+    const creation = deferred<string | null>();
+    let sessionId = "";
+    await act(async () => {
+      sessionId = prepareAuthorization(creation.promise);
+    });
+
+    let first!: Promise<void>;
+    let second!: Promise<void>;
+    await act(async () => {
+      first = harness.chat.authenticatePendingTool("tool-1");
+      second = harness.chat.authenticatePendingTool("tool-1");
+      await Promise.resolve();
+    });
+
+    expect(authenticate).not.toHaveBeenCalled();
+    expect(harness.sessions.store.get(sessionId).authenticatingToolCallId).toBe(
+      "tool-1"
+    );
+
+    await act(async () => {
+      creation.resolve("backend-1");
+      await Promise.all([first, second]);
+    });
+
+    expect(authenticate).toHaveBeenCalledTimes(1);
+    expect(readPendingChatTurn(SERVER_ID, sessionId)?.persistedChatId).toBe(
+      "backend-1"
+    );
+    expect(
+      harness.sessions.store.get(sessionId).authenticatingToolCallId
+    ).toBeNull();
+  });
+
+  it("does not let stalled chat history block authentication", async () => {
+    vi.useFakeTimers();
+    const creation = deferred<string | null>();
+    await act(async () => {
+      prepareAuthorization(creation.promise);
+    });
+
+    let authentication!: Promise<void>;
+    await act(async () => {
+      authentication = harness.chat.authenticatePendingTool("tool-1");
+      await vi.runAllTimersAsync();
+      await authentication;
+    });
+
+    expect(authenticate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libraries/typescript/packages/inspector/src/client/components/chat/__tests__/useChatSessions.test.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/__tests__/useChatSessions.test.tsx
@@ -9,7 +9,7 @@ import type {
 } from "../../../chat-history/types";
 import { savePendingChatTurn } from "../chat-auth-retry";
 import type { ChatSessionState } from "../chat-session";
-import { useChatSession } from "../chat-session-store";
+import { useChatSession, type ChatSessionUpdate } from "../chat-session-store";
 import { useChatSessions, type ChatSessions } from "../useChatSessions";
 import type { Message } from "../types";
 
@@ -75,6 +75,7 @@ class BackendIdChatStorage extends FakeChatStorage {
 interface Harness {
   sessions: ChatSessions;
   session: ChatSessionState;
+  updateSession: (update: ChatSessionUpdate) => ChatSessionState;
 }
 
 function userMessage(text: string): Message {
@@ -90,22 +91,22 @@ function assistantMessage(text: string): Message {
   };
 }
 
-/**
- * Mimics a chat hook's send: the session id is captured when the turn starts,
- * so every later write lands on that session even if the user moves on.
- */
-function startTurn(sessions: ChatSessions, text: string) {
+function startTurn(current: Harness, text: string) {
+  const { sessions, updateSession } = current;
   const sessionId = sessions.activeSessionId;
-  const store = sessions.store;
-  const sent = [...store.get(sessionId).messages, userMessage(text)];
-  store.update(sessionId, { isLoading: true, messages: sent });
-  sessions.persistSessionMessages(sessionId, sent);
+  const sent = updateSession((session) => ({
+    isLoading: true,
+    messages: [...session.messages, userMessage(text)],
+  }));
+  sessions.persistSessionMessages(sessionId, sent.messages);
   return {
     sessionId,
     finish(reply: string) {
-      const done = [...store.get(sessionId).messages, assistantMessage(reply)];
-      store.update(sessionId, { isLoading: false, messages: done });
-      sessions.persistSessionMessages(sessionId, done);
+      const done = updateSession((session) => ({
+        isLoading: false,
+        messages: [...session.messages, assistantMessage(reply)],
+      }));
+      sessions.persistSessionMessages(sessionId, done.messages);
     },
   };
 }
@@ -129,8 +130,11 @@ describe("useChatSessions", () => {
       onActiveChatIdChange: props.onActiveChatIdChange,
       initialMessages: props.initialMessages,
     });
-    const session = useChatSession(sessions.store, sessions.activeSessionId);
-    harness = { sessions, session };
+    const [session, updateSession] = useChatSession(
+      sessions.store,
+      sessions.activeSessionId
+    );
+    harness = { sessions, session, updateSession };
     return null;
   }
 
@@ -175,7 +179,7 @@ describe("useChatSessions", () => {
     const sessionId = harness.sessions.activeSessionId;
 
     await act(async () => {
-      startTurn(harness.sessions, "hello").finish("hi");
+      startTurn(harness, "hello").finish("hi");
     });
 
     expect(storage.createChatCalls).toEqual([sessionId]);
@@ -190,7 +194,7 @@ describe("useChatSessions", () => {
 
     let turn!: ReturnType<typeof startTurn>;
     await act(async () => {
-      turn = startTurn(harness.sessions, "long running");
+      turn = startTurn(harness, "long running");
     });
     expect(harness.session.isLoading).toBe(true);
 
@@ -208,7 +212,7 @@ describe("useChatSessions", () => {
     // The background turn finishes against the chat that started it.
     await act(async () => {
       turn.finish("done");
-      startTurn(harness.sessions, "second chat");
+      startTurn(harness, "second chat");
     });
 
     expect(
@@ -226,7 +230,7 @@ describe("useChatSessions", () => {
 
     let turn!: ReturnType<typeof startTurn>;
     await act(async () => {
-      turn = startTurn(harness.sessions, "first");
+      turn = startTurn(harness, "first");
     });
     await act(async () => {
       await harness.sessions.startNewChat();
@@ -259,7 +263,7 @@ describe("useChatSessions", () => {
 
     let turn!: ReturnType<typeof startTurn>;
     await act(async () => {
-      turn = startTurn(harness.sessions, "streaming");
+      turn = startTurn(harness, "streaming");
     });
     await act(async () => {
       await harness.sessions.startNewChat();
@@ -290,7 +294,7 @@ describe("useChatSessions", () => {
     await render(<ControlledProbe storage={storage} />);
 
     await act(async () => {
-      startTurn(harness.sessions, "first").finish("reply");
+      startTurn(harness, "first").finish("reply");
     });
     const firstSessionId = harness.sessions.activeSessionId;
     expect(harness.sessions.activeChatId).toBe(firstSessionId);
@@ -307,6 +311,33 @@ describe("useChatSessions", () => {
     );
     expect(harness.session.messages).toEqual([]);
     expect(harness.session.isLoading).toBe(false);
+  });
+
+  it("applies controlled messages to the chat selected in the same render", async () => {
+    const storage = new FakeChatStorage();
+    const firstMessages = [userMessage("first")];
+    const secondMessages = [userMessage("second")];
+
+    await render(
+      <Probe
+        storage={storage}
+        activeChatId="chat-1"
+        initialMessages={firstMessages}
+      />
+    );
+    await render(
+      <Probe
+        storage={storage}
+        activeChatId="chat-2"
+        initialMessages={secondMessages}
+      />
+    );
+
+    expect(harness.sessions.activeSessionId).toBe("chat-2");
+    expect(harness.session.messages).toEqual(secondMessages);
+    expect(harness.sessions.store.get("chat-1").messages).toEqual(
+      firstMessages
+    );
   });
 
   it("reopens the session an OAuth redirect interrupted", async () => {
@@ -335,6 +366,36 @@ describe("useChatSessions", () => {
     expect(harness.sessions.activeSessionId).not.toBe(interrupted);
   });
 
+  it("restores a backend-minted chat id after an OAuth redirect", async () => {
+    const storage = new BackendIdChatStorage();
+    await storage.createChat({ agentId: AGENT_ID });
+    storage.createChatCalls = [];
+    savePendingChatTurn({
+      serverId: SERVER_ID,
+      sessionId: "runtime-session",
+      persistedChatId: "backend-1",
+      userInput: "read my profile",
+      promptResults: [],
+      attachments: [],
+      baseMessages: [userMessage("read my profile")],
+    });
+
+    await render(<Probe storage={storage} />);
+    await act(async () => {
+      harness.sessions.persistSessionMessages("runtime-session", [
+        userMessage("resumed"),
+      ]);
+      await Promise.resolve();
+    });
+
+    expect(harness.sessions.activeSessionId).toBe("runtime-session");
+    expect(harness.sessions.activeChatId).toBe("backend-1");
+    expect(storage.createChatCalls).toEqual([]);
+    expect(storage.messages.get("backend-1")?.map((m) => m.content)).toEqual([
+      "resumed",
+    ]);
+  });
+
   it("ignores a restored turn that belongs to another chat in controlled mode", async () => {
     const storage = new FakeChatStorage();
     savePendingChatTurn({
@@ -358,7 +419,7 @@ describe("useChatSessions", () => {
     const sessionId = harness.sessions.activeSessionId;
 
     await act(async () => {
-      startTurn(harness.sessions, "hello").finish("hi");
+      startTurn(harness, "hello").finish("hi");
     });
 
     const chatId = harness.sessions.activeChatId;
@@ -377,6 +438,32 @@ describe("useChatSessions", () => {
     expect(harness.session.messages).toHaveLength(2);
   });
 
+  it("treats a controlled chat id as an existing persisted chat", async () => {
+    const storage = new BackendIdChatStorage();
+    await storage.createChat({ agentId: AGENT_ID });
+    storage.createChatCalls = [];
+
+    await render(
+      <Probe
+        storage={storage}
+        activeChatId="backend-1"
+        initialMessages={[userMessage("existing")]}
+      />
+    );
+
+    await act(async () => {
+      harness.sessions.persistSessionMessages("backend-1", [
+        userMessage("updated"),
+      ]);
+      await Promise.resolve();
+    });
+
+    expect(storage.createChatCalls).toEqual([]);
+    expect(storage.messages.get("backend-1")?.map((m) => m.content)).toEqual([
+      "updated",
+    ]);
+  });
+
   it("creates one chat when a session is written to concurrently", async () => {
     const storage = new FakeChatStorage();
     await render(<Probe storage={storage} />);
@@ -390,11 +477,29 @@ describe("useChatSessions", () => {
         userMessage("a"),
         assistantMessage("b"),
       ]);
-      await sessions.ensureActiveChat();
+      await Promise.resolve();
     });
 
     expect(storage.createChatCalls).toHaveLength(1);
     expect(storage.chats.size).toBe(1);
+  });
+
+  it("persists an empty message list when clearing an existing chat", async () => {
+    const storage = new FakeChatStorage();
+    await render(<Probe storage={storage} />);
+
+    await act(async () => {
+      startTurn(harness, "hello").finish("hi");
+    });
+    const sessionId = harness.sessions.activeSessionId;
+    expect(storage.messages.get(sessionId)).toHaveLength(2);
+
+    await act(async () => {
+      harness.sessions.persistSessionMessages(sessionId, []);
+      await Promise.resolve();
+    });
+
+    expect(storage.messages.get(sessionId)).toEqual([]);
   });
 
   it("works without storage, giving each new chat its own session", async () => {
@@ -402,7 +507,7 @@ describe("useChatSessions", () => {
     const first = harness.sessions.activeSessionId;
 
     await act(async () => {
-      startTurn(harness.sessions, "hello");
+      startTurn(harness, "hello");
     });
     await act(async () => {
       await harness.sessions.startNewChat();

--- a/libraries/typescript/packages/inspector/src/client/components/chat/__tests__/useChatSessions.test.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/__tests__/useChatSessions.test.tsx
@@ -1,0 +1,416 @@
+// @vitest-environment jsdom
+import { act, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type {
+  ChatSession,
+  ChatStorageProvider,
+  ListChatsParams,
+} from "../../../chat-history/types";
+import { savePendingChatTurn } from "../chat-auth-retry";
+import type { ChatSessionState } from "../chat-session";
+import { useChatSession } from "../chat-session-store";
+import { useChatSessions, type ChatSessions } from "../useChatSessions";
+import type { Message } from "../types";
+
+const SERVER_ID = "https://example.test/mcp";
+const AGENT_ID = "agent-1";
+
+/** In-memory provider that adopts the caller's id, like the local provider. */
+class FakeChatStorage implements ChatStorageProvider {
+  readonly chats = new Map<string, ChatSession>();
+  readonly messages = new Map<string, Message[]>();
+  createChatCalls: (string | undefined)[] = [];
+
+  async listChats(_params: ListChatsParams) {
+    const items = [...this.chats.values()];
+    return { items, total: items.length };
+  }
+
+  async getMessages(chatId: string) {
+    return this.messages.get(chatId) ?? [];
+  }
+
+  async createChat(params: { id?: string; agentId: string; title?: string }) {
+    this.createChatCalls.push(params.id);
+    const existing = params.id ? this.chats.get(params.id) : undefined;
+    if (existing) return existing;
+    const id = params.id ?? `generated-${this.chats.size + 1}`;
+    const chat: ChatSession = {
+      id,
+      title: params.title ?? "New Chat",
+      agent_id: params.agentId,
+      agent_name: "Fake",
+      created_at: "2026-01-01T00:00:00.000Z",
+      updated_at: "2026-01-01T00:00:00.000Z",
+    };
+    this.chats.set(id, chat);
+    this.messages.set(id, []);
+    return chat;
+  }
+
+  async updateChat(chatId: string) {
+    return this.chats.get(chatId)!;
+  }
+
+  async deleteChat(chatId: string) {
+    this.chats.delete(chatId);
+  }
+
+  async saveMessages(chatId: string, messages: Message[]) {
+    this.messages.set(chatId, messages);
+  }
+}
+
+/** Provider that mints its own ids, ignoring the session id it is handed. */
+class BackendIdChatStorage extends FakeChatStorage {
+  override async createChat(params: { id?: string; agentId: string }) {
+    return super.createChat({
+      ...params,
+      id: `backend-${this.chats.size + 1}`,
+    });
+  }
+}
+
+interface Harness {
+  sessions: ChatSessions;
+  session: ChatSessionState;
+}
+
+function userMessage(text: string): Message {
+  return { id: `user-${text}`, role: "user", content: text, timestamp: 1 };
+}
+
+function assistantMessage(text: string): Message {
+  return {
+    id: `assistant-${text}`,
+    role: "assistant",
+    content: text,
+    timestamp: 2,
+  };
+}
+
+/**
+ * Mimics a chat hook's send: the session id is captured when the turn starts,
+ * so every later write lands on that session even if the user moves on.
+ */
+function startTurn(sessions: ChatSessions, text: string) {
+  const sessionId = sessions.activeSessionId;
+  const store = sessions.store;
+  const sent = [...store.get(sessionId).messages, userMessage(text)];
+  store.update(sessionId, { isLoading: true, messages: sent });
+  sessions.persistSessionMessages(sessionId, sent);
+  return {
+    sessionId,
+    finish(reply: string) {
+      const done = [...store.get(sessionId).messages, assistantMessage(reply)];
+      store.update(sessionId, { isLoading: false, messages: done });
+      sessions.persistSessionMessages(sessionId, done);
+    },
+  };
+}
+
+describe("useChatSessions", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let harness: Harness;
+
+  function Probe(props: {
+    storage: ChatStorageProvider | null;
+    activeChatId?: string;
+    onActiveChatIdChange?: (chatId: string | null) => void;
+    initialMessages?: Message[];
+  }) {
+    const sessions = useChatSessions({
+      retryServerId: SERVER_ID,
+      agentId: AGENT_ID,
+      storage: props.storage,
+      activeChatId: props.activeChatId,
+      onActiveChatIdChange: props.onActiveChatIdChange,
+      initialMessages: props.initialMessages,
+    });
+    const session = useChatSession(sessions.store, sessions.activeSessionId);
+    harness = { sessions, session };
+    return null;
+  }
+
+  /** Host that owns `activeChatId`, as an embedder in controlled mode would. */
+  function ControlledProbe({ storage }: { storage: ChatStorageProvider }) {
+    const [activeChatId, setActiveChatId] = useState<string | undefined>(
+      undefined
+    );
+    return (
+      <Probe
+        storage={storage}
+        activeChatId={activeChatId}
+        onActiveChatIdChange={(chatId) => setActiveChatId(chatId ?? undefined)}
+      />
+    );
+  }
+
+  async function render(element: React.ReactNode) {
+    await act(async () => {
+      root.render(element);
+    });
+  }
+
+  beforeEach(() => {
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    sessionStorage.clear();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  it("persists a chat under the session id it was created with", async () => {
+    const storage = new FakeChatStorage();
+    await render(<Probe storage={storage} />);
+    const sessionId = harness.sessions.activeSessionId;
+
+    await act(async () => {
+      startTurn(harness.sessions, "hello").finish("hi");
+    });
+
+    expect(storage.createChatCalls).toEqual([sessionId]);
+    expect(storage.chats.has(sessionId)).toBe(true);
+    expect(harness.sessions.activeChatId).toBe(sessionId);
+    expect(storage.messages.get(sessionId)).toHaveLength(2);
+  });
+
+  it("starts a new chat while another session is still streaming", async () => {
+    const storage = new FakeChatStorage();
+    await render(<Probe storage={storage} />);
+
+    let turn!: ReturnType<typeof startTurn>;
+    await act(async () => {
+      turn = startTurn(harness.sessions, "long running");
+    });
+    expect(harness.session.isLoading).toBe(true);
+
+    await act(async () => {
+      await harness.sessions.startNewChat();
+    });
+
+    const streaming = harness.sessions.store.get(turn.sessionId);
+    expect(harness.sessions.activeSessionId).not.toBe(turn.sessionId);
+    expect(streaming.isLoading).toBe(true);
+    // The fresh chat is idle and empty, so it can be sent from immediately.
+    expect(harness.session.isLoading).toBe(false);
+    expect(harness.session.messages).toEqual([]);
+
+    // The background turn finishes against the chat that started it.
+    await act(async () => {
+      turn.finish("done");
+      startTurn(harness.sessions, "second chat");
+    });
+
+    expect(
+      harness.sessions.store.get(turn.sessionId).messages.map((m) => m.content)
+    ).toEqual(["long running", "done"]);
+    expect(harness.session.messages.map((m) => m.content)).toEqual([
+      "second chat",
+    ]);
+    expect(storage.messages.get(turn.sessionId)).toHaveLength(2);
+  });
+
+  it("keeps a live session's state when switching back to it", async () => {
+    const storage = new FakeChatStorage();
+    await render(<Probe storage={storage} />);
+
+    let turn!: ReturnType<typeof startTurn>;
+    await act(async () => {
+      turn = startTurn(harness.sessions, "first");
+    });
+    await act(async () => {
+      await harness.sessions.startNewChat();
+    });
+    await act(async () => {
+      turn.finish("first reply");
+    });
+
+    const secondSessionId = harness.sessions.activeSessionId;
+    await act(async () => {
+      await harness.sessions.selectChat(turn.sessionId);
+    });
+
+    expect(harness.sessions.activeSessionId).toBe(turn.sessionId);
+    expect(harness.session.messages.map((m) => m.content)).toEqual([
+      "first",
+      "first reply",
+    ]);
+
+    await act(async () => {
+      await harness.sessions.selectChat(secondSessionId);
+    });
+    expect(harness.sessions.activeSessionId).toBe(secondSessionId);
+    expect(harness.session.messages).toEqual([]);
+  });
+
+  it("does not overwrite an in-flight session with its persisted snapshot", async () => {
+    const storage = new FakeChatStorage();
+    await render(<Probe storage={storage} />);
+
+    let turn!: ReturnType<typeof startTurn>;
+    await act(async () => {
+      turn = startTurn(harness.sessions, "streaming");
+    });
+    await act(async () => {
+      await harness.sessions.startNewChat();
+    });
+    // Storage still holds only the user turn; the assistant reply is in memory.
+    await act(async () => {
+      harness.sessions.store.update(turn.sessionId, {
+        messages: [
+          ...harness.sessions.store.get(turn.sessionId).messages,
+          assistantMessage("partial"),
+        ],
+      });
+    });
+
+    await act(async () => {
+      await harness.sessions.selectChat(turn.sessionId);
+    });
+
+    expect(harness.session.isLoading).toBe(true);
+    expect(harness.session.messages.map((m) => m.content)).toEqual([
+      "streaming",
+      "partial",
+    ]);
+  });
+
+  it("keeps the new session when a controlled host clears the chat id", async () => {
+    const storage = new FakeChatStorage();
+    await render(<ControlledProbe storage={storage} />);
+
+    await act(async () => {
+      startTurn(harness.sessions, "first").finish("reply");
+    });
+    const firstSessionId = harness.sessions.activeSessionId;
+    expect(harness.sessions.activeChatId).toBe(firstSessionId);
+
+    await act(async () => {
+      await harness.sessions.startNewChat();
+    });
+
+    // The host cleared and then re-set its id; the new session must stay active
+    // rather than snapping back to the chat that was open before.
+    expect(harness.sessions.activeSessionId).not.toBe(firstSessionId);
+    expect(harness.sessions.activeChatId).toBe(
+      harness.sessions.activeSessionId
+    );
+    expect(harness.session.messages).toEqual([]);
+    expect(harness.session.isLoading).toBe(false);
+  });
+
+  it("reopens the session an OAuth redirect interrupted", async () => {
+    const storage = new FakeChatStorage();
+    const interrupted = "session-before-redirect";
+    savePendingChatTurn({
+      serverId: SERVER_ID,
+      sessionId: interrupted,
+      userInput: "read my profile",
+      promptResults: [],
+      attachments: [],
+      baseMessages: [userMessage("read my profile")],
+    });
+
+    await render(<Probe storage={storage} />);
+
+    expect(harness.sessions.activeSessionId).toBe(interrupted);
+    expect(harness.session.messages.map((m) => m.content)).toEqual([
+      "read my profile",
+    ]);
+
+    // Starting a new chat after the redirect must not reuse the restored id.
+    await act(async () => {
+      await harness.sessions.startNewChat();
+    });
+    expect(harness.sessions.activeSessionId).not.toBe(interrupted);
+  });
+
+  it("ignores a restored turn that belongs to another chat in controlled mode", async () => {
+    const storage = new FakeChatStorage();
+    savePendingChatTurn({
+      serverId: SERVER_ID,
+      sessionId: "some-other-session",
+      userInput: "read my profile",
+      promptResults: [],
+      attachments: [],
+      baseMessages: [userMessage("read my profile")],
+    });
+
+    await render(<Probe storage={storage} activeChatId="host-chat" />);
+
+    expect(harness.sessions.activeSessionId).toBe("host-chat");
+    expect(harness.session.messages).toEqual([]);
+  });
+
+  it("tracks a backend-minted chat id without losing the session", async () => {
+    const storage = new BackendIdChatStorage();
+    await render(<Probe storage={storage} />);
+    const sessionId = harness.sessions.activeSessionId;
+
+    await act(async () => {
+      startTurn(harness.sessions, "hello").finish("hi");
+    });
+
+    const chatId = harness.sessions.activeChatId;
+    expect(chatId).toBe("backend-1");
+    expect(chatId).not.toBe(sessionId);
+    expect(storage.messages.get("backend-1")).toHaveLength(2);
+
+    await act(async () => {
+      await harness.sessions.startNewChat();
+    });
+    await act(async () => {
+      await harness.sessions.selectChat("backend-1");
+    });
+
+    expect(harness.sessions.activeSessionId).toBe(sessionId);
+    expect(harness.session.messages).toHaveLength(2);
+  });
+
+  it("creates one chat when a session is written to concurrently", async () => {
+    const storage = new FakeChatStorage();
+    await render(<Probe storage={storage} />);
+
+    await act(async () => {
+      const { sessions } = harness;
+      sessions.persistSessionMessages(sessions.activeSessionId, [
+        userMessage("a"),
+      ]);
+      sessions.persistSessionMessages(sessions.activeSessionId, [
+        userMessage("a"),
+        assistantMessage("b"),
+      ]);
+      await sessions.ensureActiveChat();
+    });
+
+    expect(storage.createChatCalls).toHaveLength(1);
+    expect(storage.chats.size).toBe(1);
+  });
+
+  it("works without storage, giving each new chat its own session", async () => {
+    await render(<Probe storage={null} />);
+    const first = harness.sessions.activeSessionId;
+
+    await act(async () => {
+      startTurn(harness.sessions, "hello");
+    });
+    await act(async () => {
+      await harness.sessions.startNewChat();
+    });
+
+    expect(harness.sessions.activeSessionId).not.toBe(first);
+    expect(harness.sessions.activeChatId).toBeNull();
+    expect(harness.session.messages).toEqual([]);
+    expect(harness.sessions.store.get(first).isLoading).toBe(true);
+  });
+});

--- a/libraries/typescript/packages/inspector/src/client/components/chat/__tests__/useChatSessions.test.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/__tests__/useChatSessions.test.tsx
@@ -396,6 +396,63 @@ describe("useChatSessions", () => {
     ]);
   });
 
+  it("resumes a controlled backend-minted chat using its runtime session", async () => {
+    const storage = new BackendIdChatStorage();
+    const restoredMessages = [userMessage("read my profile")];
+    savePendingChatTurn({
+      serverId: SERVER_ID,
+      sessionId: "runtime-session",
+      persistedChatId: "backend-1",
+      userInput: "read my profile",
+      promptResults: [],
+      attachments: [],
+      baseMessages: restoredMessages,
+    });
+
+    await render(
+      <Probe storage={storage} activeChatId="backend-1" initialMessages={[]} />
+    );
+
+    expect(harness.sessions.activeSessionId).toBe("runtime-session");
+    expect(harness.sessions.activeChatId).toBe("backend-1");
+    expect(harness.session.messages).toEqual(restoredMessages);
+    expect(harness.sessions.store.get("runtime-session").persistedChatId).toBe(
+      "backend-1"
+    );
+  });
+
+  it("reports a restored chat id to a callback-only controlled host", async () => {
+    const storage = new BackendIdChatStorage();
+    const reportedChatIds: (string | null)[] = [];
+    savePendingChatTurn({
+      serverId: SERVER_ID,
+      sessionId: "runtime-session",
+      persistedChatId: "backend-1",
+      userInput: "read my profile",
+      promptResults: [],
+      attachments: [],
+      baseMessages: [userMessage("read my profile")],
+    });
+
+    await render(
+      <Probe
+        storage={storage}
+        onActiveChatIdChange={(chatId) => reportedChatIds.push(chatId)}
+      />
+    );
+
+    expect(harness.sessions.activeSessionId).toBe("runtime-session");
+    expect(reportedChatIds).toEqual(["backend-1"]);
+
+    await render(
+      <Probe
+        storage={storage}
+        onActiveChatIdChange={(chatId) => reportedChatIds.push(chatId)}
+      />
+    );
+    expect(reportedChatIds).toEqual(["backend-1"]);
+  });
+
   it("ignores a restored turn that belongs to another chat in controlled mode", async () => {
     const storage = new FakeChatStorage();
     savePendingChatTurn({

--- a/libraries/typescript/packages/inspector/src/client/components/chat/chat-auth-retry.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/chat-auth-retry.ts
@@ -2,6 +2,8 @@ import type { PromptResult } from "../../hooks/useMCPPrompts";
 import type { Message, MessageAttachment } from "./types";
 
 const PENDING_CHAT_TURN_STORAGE_KEY = "__mcpUseInspectorPendingChatTurn";
+const ACTIVE_PENDING_CHAT_SESSION_STORAGE_KEY =
+  "__mcpUseInspectorActivePendingChatSession";
 const PENDING_CHAT_TURN_MAX_AGE_MS = 15 * 60_000;
 
 type SessionStorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem">;
@@ -9,6 +11,8 @@ type SessionStorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem">;
 /** Serializable chat turn retained across a full-page OAuth redirect. */
 export interface PendingChatTurn {
   serverId: string;
+  /** Chat session that owns the interrupted turn. */
+  sessionId: string;
   userInput: string;
   promptResults: PromptResult[];
   attachments: MessageAttachment[];
@@ -25,8 +29,12 @@ function defaultSessionStorage(): SessionStorageLike | undefined {
   }
 }
 
-function storageKey(serverId: string): string {
-  return `${PENDING_CHAT_TURN_STORAGE_KEY}:${encodeURIComponent(serverId)}`;
+function storageKey(serverId: string, sessionId: string): string {
+  return `${PENDING_CHAT_TURN_STORAGE_KEY}:${encodeURIComponent(serverId)}:${encodeURIComponent(sessionId)}`;
+}
+
+function activeSessionStorageKey(serverId: string): string {
+  return `${ACTIVE_PENDING_CHAT_SESSION_STORAGE_KEY}:${encodeURIComponent(serverId)}`;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -37,6 +45,7 @@ function isPendingChatTurn(value: unknown): value is PendingChatTurn {
   if (!isRecord(value)) return false;
   return (
     typeof value.serverId === "string" &&
+    typeof value.sessionId === "string" &&
     typeof value.userInput === "string" &&
     Array.isArray(value.promptResults) &&
     Array.isArray(value.attachments) &&
@@ -46,28 +55,68 @@ function isPendingChatTurn(value: unknown): value is PendingChatTurn {
   );
 }
 
+function removePendingChatTurn(
+  serverId: string,
+  sessionId: string,
+  storage: SessionStorageLike
+): void {
+  storage.removeItem(storageKey(serverId, sessionId));
+  const activeKey = activeSessionStorageKey(serverId);
+  if (storage.getItem(activeKey) === sessionId) {
+    storage.removeItem(activeKey);
+  }
+}
+
 export function readPendingChatTurn(
   serverId: string,
+  sessionId: string,
   storage: SessionStorageLike | undefined = defaultSessionStorage()
 ): PendingChatTurn | null {
   if (!storage) return null;
-  const key = storageKey(serverId);
   try {
-    const raw = storage.getItem(key);
+    const raw = storage.getItem(storageKey(serverId, sessionId));
     if (!raw) return null;
     const parsed: unknown = JSON.parse(raw);
     if (
       !isPendingChatTurn(parsed) ||
       parsed.serverId !== serverId ||
+      parsed.sessionId !== sessionId ||
       Date.now() - parsed.savedAt > PENDING_CHAT_TURN_MAX_AGE_MS
     ) {
-      storage.removeItem(key);
+      removePendingChatTurn(serverId, sessionId, storage);
       return null;
     }
     return parsed;
   } catch {
     try {
-      storage.removeItem(key);
+      removePendingChatTurn(serverId, sessionId, storage);
+    } catch {
+      // Storage is best-effort.
+    }
+    return null;
+  }
+}
+
+/**
+ * Reads the turn that initiated the current full-page OAuth flow. A redirect
+ * discards in-memory state, so the session id has to come back from storage
+ * for the reloaded tab to reopen the chat the user left.
+ */
+export function readPendingChatTurnForServer(
+  serverId: string,
+  storage: SessionStorageLike | undefined = defaultSessionStorage()
+): PendingChatTurn | null {
+  if (!storage) return null;
+  const activeKey = activeSessionStorageKey(serverId);
+  try {
+    const sessionId = storage.getItem(activeKey);
+    if (!sessionId) return null;
+    const pendingTurn = readPendingChatTurn(serverId, sessionId, storage);
+    if (!pendingTurn) storage.removeItem(activeKey);
+    return pendingTurn;
+  } catch {
+    try {
+      storage.removeItem(activeKey);
     } catch {
       // Storage is best-effort.
     }
@@ -82,9 +131,10 @@ export function savePendingChatTurn(
   if (!storage) return;
   try {
     storage.setItem(
-      storageKey(turn.serverId),
+      storageKey(turn.serverId, turn.sessionId),
       JSON.stringify({ ...turn, savedAt: Date.now() } satisfies PendingChatTurn)
     );
+    storage.setItem(activeSessionStorageKey(turn.serverId), turn.sessionId);
   } catch {
     // Storage is best-effort; popup OAuth can still resume in memory.
   }
@@ -92,11 +142,12 @@ export function savePendingChatTurn(
 
 export function clearPendingChatTurn(
   serverId: string,
+  sessionId: string,
   storage: SessionStorageLike | undefined = defaultSessionStorage()
 ): void {
   if (!storage) return;
   try {
-    storage.removeItem(storageKey(serverId));
+    removePendingChatTurn(serverId, sessionId, storage);
   } catch {
     // Storage is best-effort.
   }

--- a/libraries/typescript/packages/inspector/src/client/components/chat/chat-auth-retry.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/chat-auth-retry.ts
@@ -13,6 +13,8 @@ export interface PendingChatTurn {
   serverId: string;
   /** Chat session that owns the interrupted turn. */
   sessionId: string;
+  /** Persisted id when the storage backend minted one instead of adopting the session id. */
+  persistedChatId?: string;
   userInput: string;
   promptResults: PromptResult[];
   attachments: MessageAttachment[];
@@ -46,6 +48,8 @@ function isPendingChatTurn(value: unknown): value is PendingChatTurn {
   return (
     typeof value.serverId === "string" &&
     typeof value.sessionId === "string" &&
+    (value.persistedChatId === undefined ||
+      typeof value.persistedChatId === "string") &&
     typeof value.userInput === "string" &&
     Array.isArray(value.promptResults) &&
     Array.isArray(value.attachments) &&

--- a/libraries/typescript/packages/inspector/src/client/components/chat/chat-session-store.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/chat-session-store.ts
@@ -101,11 +101,18 @@ export function useChatSessionStore(): ChatSessionStore {
   return storeRef.current;
 }
 
-/** Subscribes to one session; other sessions' updates never re-render here. */
+/**
+ * Subscribes to one session and returns an updater bound to that session id.
+ * An in-flight callback therefore keeps writing to its original session after
+ * the UI switches elsewhere, while unrelated session updates do not re-render.
+ */
 export function useChatSession(
   store: ChatSessionStore,
   sessionId: string
-): ChatSessionState {
+): readonly [
+  ChatSessionState,
+  (update: ChatSessionUpdate) => ChatSessionState,
+] {
   const subscribe = useCallback(
     (onStoreChange: () => void) => store.subscribe(sessionId, onStoreChange),
     [store, sessionId]
@@ -114,29 +121,10 @@ export function useChatSession(
     () => store.get(sessionId),
     [store, sessionId]
   );
-  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
-}
-
-/**
- * `useState`-style setter bound to one field of one session. The session id is
- * captured, so an in-flight turn keeps writing to its own record after the user
- * has moved on to another chat.
- */
-export function useChatSessionField<K extends keyof ChatSessionPatch>(
-  store: ChatSessionStore,
-  sessionId: string,
-  field: K
-): (action: SetStateAction<ChatSessionState[K]>) => void {
-  return useCallback(
-    (action: SetStateAction<ChatSessionState[K]>) => {
-      store.update(
-        sessionId,
-        (session) =>
-          ({
-            [field]: resolveStateAction(session[field], action),
-          }) as ChatSessionPatch
-      );
-    },
-    [field, sessionId, store]
+  const session = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  const updateSession = useCallback(
+    (update: ChatSessionUpdate) => store.update(sessionId, update),
+    [sessionId, store]
   );
+  return [session, updateSession] as const;
 }

--- a/libraries/typescript/packages/inspector/src/client/components/chat/chat-session-store.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/chat-session-store.ts
@@ -1,0 +1,142 @@
+import {
+  useCallback,
+  useRef,
+  useSyncExternalStore,
+  type SetStateAction,
+} from "react";
+import { createChatSession, type ChatSessionState } from "./chat-session";
+
+/** Fields a session update may touch — identity and runtime are fixed per record. */
+export type ChatSessionPatch = Partial<
+  Omit<ChatSessionState, "id" | "runtime">
+>;
+
+export type ChatSessionUpdate =
+  | ChatSessionPatch
+  | ((session: ChatSessionState) => ChatSessionPatch);
+
+export function resolveStateAction<T>(
+  previous: T,
+  action: SetStateAction<T>
+): T {
+  return typeof action === "function"
+    ? (action as (value: T) => T)(previous)
+    : action;
+}
+
+/**
+ * Owns one record per chat session and notifies only the subscribers of the
+ * session that changed. A background turn therefore keeps streaming into its
+ * own record without re-rendering the chat the user is currently looking at.
+ */
+export class ChatSessionStore {
+  private readonly sessions = new Map<string, ChatSessionState>();
+  private readonly listeners = new Map<string, Set<() => void>>();
+
+  /** Returns the session record, creating an empty one on first access. */
+  get(id: string): ChatSessionState {
+    const existing = this.sessions.get(id);
+    if (existing) return existing;
+    const created = createChatSession(id);
+    this.sessions.set(id, created);
+    return created;
+  }
+
+  has(id: string): boolean {
+    return this.sessions.has(id);
+  }
+
+  /** Seeds a session that does not exist yet; live sessions are left alone. */
+  seed(id: string, messages: ChatSessionState["messages"]): ChatSessionState {
+    const existing = this.sessions.get(id);
+    if (existing) return existing;
+    const created = createChatSession(id, messages);
+    this.sessions.set(id, created);
+    return created;
+  }
+
+  update(id: string, update: ChatSessionUpdate): ChatSessionState {
+    const previous = this.get(id);
+    const patch = typeof update === "function" ? update(previous) : update;
+    const keys = Object.keys(patch) as (keyof ChatSessionPatch)[];
+    if (keys.every((key) => Object.is(previous[key], patch[key]))) {
+      return previous;
+    }
+    const next: ChatSessionState = { ...previous, ...patch };
+    this.sessions.set(id, next);
+    for (const listener of this.listeners.get(id) ?? []) listener();
+    return next;
+  }
+
+  subscribe(id: string, listener: () => void): () => void {
+    let listeners = this.listeners.get(id);
+    if (!listeners) {
+      listeners = new Set();
+      this.listeners.set(id, listeners);
+    }
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+      if (listeners.size === 0) this.listeners.delete(id);
+    };
+  }
+
+  /** Drops a session nobody can reach any more (e.g. an untouched draft). */
+  delete(id: string): void {
+    this.sessions.delete(id);
+  }
+
+  /** Session whose persisted chat is `chatId`, if that chat is already loaded. */
+  findByPersistedChatId(chatId: string): ChatSessionState | undefined {
+    for (const session of this.sessions.values()) {
+      if ((session.persistedChatId ?? session.id) === chatId) return session;
+    }
+    return undefined;
+  }
+}
+
+export function useChatSessionStore(): ChatSessionStore {
+  const storeRef = useRef<ChatSessionStore | null>(null);
+  if (!storeRef.current) storeRef.current = new ChatSessionStore();
+  return storeRef.current;
+}
+
+/** Subscribes to one session; other sessions' updates never re-render here. */
+export function useChatSession(
+  store: ChatSessionStore,
+  sessionId: string
+): ChatSessionState {
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => store.subscribe(sessionId, onStoreChange),
+    [store, sessionId]
+  );
+  const getSnapshot = useCallback(
+    () => store.get(sessionId),
+    [store, sessionId]
+  );
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+/**
+ * `useState`-style setter bound to one field of one session. The session id is
+ * captured, so an in-flight turn keeps writing to its own record after the user
+ * has moved on to another chat.
+ */
+export function useChatSessionField<K extends keyof ChatSessionPatch>(
+  store: ChatSessionStore,
+  sessionId: string,
+  field: K
+): (action: SetStateAction<ChatSessionState[K]>) => void {
+  return useCallback(
+    (action: SetStateAction<ChatSessionState[K]>) => {
+      store.update(
+        sessionId,
+        (session) =>
+          ({
+            [field]: resolveStateAction(session[field], action),
+          }) as ChatSessionPatch
+      );
+    },
+    [field, sessionId, store]
+  );
+}

--- a/libraries/typescript/packages/inspector/src/client/components/chat/chat-session.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/chat-session.ts
@@ -1,0 +1,101 @@
+import type { PendingChatTurn } from "./chat-auth-retry";
+import type { ManagedChatNotice } from "./managedChatNotice";
+import { EMPTY_TRACE_STATE, type InspectorTraceState } from "./trace";
+import type { Message, MessageAttachment } from "./types";
+
+/** Holds a tool call open while the user completes an interactive OAuth flow. */
+export interface ChatAuthorizationGate {
+  toolCallId: string;
+  resolve: () => void;
+  reject: (error: Error) => void;
+}
+
+export interface PendingAuthorization {
+  toolCallId: string;
+  replay: Omit<PendingChatTurn, "savedAt">;
+}
+
+export interface McpServerAuthRequired {
+  mcpServerUrl: string;
+  message?: string;
+}
+
+/** Turn machinery that must survive re-renders without triggering them. */
+export interface ChatSessionRuntime {
+  abortController: AbortController | null;
+  sendInProgress: boolean;
+  traceId: number;
+  authorizationGate: ChatAuthorizationGate | null;
+  /** Set once the turn restored from an OAuth redirect has replayed. */
+  pendingTurnResumed: boolean;
+}
+
+/**
+ * Everything one chat session owns.
+ *
+ * `id` is the session's only identity: it is minted when the session is created
+ * and handed to `ChatStorageProvider.createChat`, so runtime state, persistence
+ * and OAuth recovery all name the same chat. `persistedChatId` differs from
+ * `id` only when a storage backend insists on minting its own id.
+ */
+export interface ChatSessionState {
+  readonly id: string;
+  messages: Message[];
+  attachments: MessageAttachment[];
+  isLoading: boolean;
+  trace: InspectorTraceState;
+  managedChatNotice: ManagedChatNotice | null;
+  pendingAuthorization: PendingAuthorization | null;
+  authenticatingToolCallId: string | null;
+  toolAuthorizationError: string | null;
+  mcpServerAuthRequired: McpServerAuthRequired | null;
+  persistedChatId: string | null;
+  /** In-flight `createChat` call, so concurrent writes persist to one chat. */
+  creation: Promise<string | null> | null;
+  readonly runtime: ChatSessionRuntime;
+}
+
+export function createChatSession(
+  id: string,
+  messages: Message[] = []
+): ChatSessionState {
+  return {
+    id,
+    messages,
+    attachments: [],
+    isLoading: false,
+    trace: EMPTY_TRACE_STATE,
+    managedChatNotice: null,
+    pendingAuthorization: null,
+    authenticatingToolCallId: null,
+    toolAuthorizationError: null,
+    mcpServerAuthRequired: null,
+    persistedChatId: null,
+    creation: null,
+    runtime: {
+      abortController: null,
+      sendInProgress: false,
+      traceId: 0,
+      authorizationGate: null,
+      pendingTurnResumed: false,
+    },
+  };
+}
+
+/** Mints the identity a session keeps for its whole lifetime. */
+export function createChatSessionId(): string {
+  const uuid = globalThis.crypto?.randomUUID?.();
+  if (uuid) return uuid;
+  // randomUUID is unavailable outside secure contexts; ids only need to be
+  // unique within this tab, so a timestamp plus randomness is enough.
+  const suffix = Math.random().toString(36).slice(2, 10);
+  return `chat-${Date.now().toString(36)}-${suffix}`;
+}
+
+export function resolveActiveChatId(
+  isControlled: boolean,
+  controlledChatId: string | undefined,
+  internalChatId: string | null
+): string | null {
+  return isControlled ? (controlledChatId ?? null) : internalChatId;
+}

--- a/libraries/typescript/packages/inspector/src/client/components/chat/chat-session.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/chat-session.ts
@@ -91,11 +91,3 @@ export function createChatSessionId(): string {
   const suffix = Math.random().toString(36).slice(2, 10);
   return `chat-${Date.now().toString(36)}-${suffix}`;
 }
-
-export function resolveActiveChatId(
-  isControlled: boolean,
-  controlledChatId: string | undefined,
-  internalChatId: string | null
-): string | null {
-  return isControlled ? (controlledChatId ?? null) : internalChatId;
-}

--- a/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessages.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessages.ts
@@ -38,7 +38,6 @@ import { createChatSessionId } from "./chat-session";
 import {
   resolveStateAction,
   useChatSession,
-  useChatSessionField,
   useChatSessionStore,
   type ChatSessionStore,
 } from "./chat-session-store";
@@ -117,7 +116,7 @@ export function useChatMessages({
     store.seed(activeSessionId, initialMessages);
   }
 
-  const session = useChatSession(store, activeSessionId);
+  const [session, updateSession] = useChatSession(store, activeSessionId);
   const {
     messages,
     isLoading,
@@ -137,24 +136,6 @@ export function useChatMessages({
     },
     [activeSessionId, onMessagesChange, store]
   );
-  const setIsLoading = useChatSessionField(store, activeSessionId, "isLoading");
-  const setAttachments = useChatSessionField(
-    store,
-    activeSessionId,
-    "attachments"
-  );
-  const setTraceState = useChatSessionField(store, activeSessionId, "trace");
-  const setManagedChatNotice = useChatSessionField(
-    store,
-    activeSessionId,
-    "managedChatNotice"
-  );
-  const setMcpServerAuthRequired = useChatSessionField(
-    store,
-    activeSessionId,
-    "mcpServerAuthRequired"
-  );
-
   const recordTrace = useCallback(
     (event: InspectorTraceEventInput) => {
       const next = {
@@ -162,9 +143,11 @@ export function useChatMessages({
         id: `trace-${++runtime.traceId}`,
         timestamp: Date.now(),
       } as InspectorTraceEvent;
-      setTraceState((state) => appendTraceEvent(state, next));
+      updateSession((current) => ({
+        trace: appendTraceEvent(current.trace, next),
+      }));
     },
-    [runtime, setTraceState]
+    [runtime, updateSession]
   );
 
   const sendMessage = useCallback(
@@ -222,10 +205,7 @@ export function useChatMessages({
       }
 
       setMessages((prev) => [...prev, ...userMessages]);
-      setIsLoading(true);
-
-      // Clear attachments after sending
-      setAttachments([]);
+      updateSession({ isLoading: true, attachments: [] });
 
       // Create abort controller for cancellation
       runtime.abortController = new AbortController();
@@ -357,7 +337,7 @@ export function useChatMessages({
               errBody
             );
             if (notice) {
-              setManagedChatNotice(notice);
+              updateSession({ managedChatNotice: notice });
               if (options?.throwOnError) {
                 throw new Error(
                   `Chat request failed with HTTP ${response.status}`
@@ -368,10 +348,13 @@ export function useChatMessages({
           }
           if (response.status === 401) {
             if (errBody?.error === "mcp_auth_required") {
-              setMcpServerAuthRequired({
-                mcpServerUrl:
-                  (errBody.mcpServerUrl as string | undefined) ?? mcpServerUrl,
-                message: errBody.message as string | undefined,
+              updateSession({
+                mcpServerAuthRequired: {
+                  mcpServerUrl:
+                    (errBody.mcpServerUrl as string | undefined) ??
+                    mcpServerUrl,
+                  message: errBody.message as string | undefined,
+                },
               });
               if (options?.throwOnError) {
                 throw new Error("The MCP server requires authentication");
@@ -847,7 +830,9 @@ export function useChatMessages({
         }
 
         if (chatApiUrl && isCloudFetchFailure(error)) {
-          setManagedChatNotice({ kind: "cloud_unavailable" });
+          updateSession({
+            managedChatNotice: { kind: "cloud_unavailable" },
+          });
           if (options?.throwOnError) {
             throw new Error("Chat service is unavailable");
           }
@@ -882,7 +867,7 @@ export function useChatMessages({
           throw new Error(errorDetail);
         }
       } finally {
-        setIsLoading(false);
+        updateSession({ isLoading: false });
         runtime.abortController = null;
         runtime.sendInProgress = false;
       }
@@ -905,45 +890,39 @@ export function useChatMessages({
       bodyBuilder,
       recordTrace,
       runtime,
-      setAttachments,
-      setIsLoading,
-      setManagedChatNotice,
-      setMcpServerAuthRequired,
       setMessages,
+      updateSession,
     ]
   );
 
   const clearMessages = useCallback(() => {
     setMessages([]);
-    setManagedChatNotice(null);
-    setMcpServerAuthRequired(null);
-    setTraceState(EMPTY_TRACE_STATE);
-  }, [
-    setManagedChatNotice,
-    setMcpServerAuthRequired,
-    setMessages,
-    setTraceState,
-  ]);
+    updateSession({
+      managedChatNotice: null,
+      mcpServerAuthRequired: null,
+      trace: EMPTY_TRACE_STATE,
+    });
+  }, [setMessages, updateSession]);
 
   const clearManagedChatNotice = useCallback(() => {
-    setManagedChatNotice(null);
-  }, [setManagedChatNotice]);
+    updateSession({ managedChatNotice: null });
+  }, [updateSession]);
 
   const showManagedChatNotice = useCallback(
     (notice: ManagedChatNotice) => {
-      setManagedChatNotice(notice);
+      updateSession({ managedChatNotice: notice });
     },
-    [setManagedChatNotice]
+    [updateSession]
   );
 
   const clearTrace = useCallback(
-    () => setTraceState(EMPTY_TRACE_STATE),
-    [setTraceState]
+    () => updateSession({ trace: EMPTY_TRACE_STATE }),
+    [updateSession]
   );
 
   const clearMcpServerAuthRequired = useCallback(() => {
-    setMcpServerAuthRequired(null);
-  }, [setMcpServerAuthRequired]);
+    updateSession({ mcpServerAuthRequired: null });
+  }, [updateSession]);
 
   const stop = useCallback(() => {
     runtime.abortController?.abort();
@@ -954,16 +933,16 @@ export function useChatMessages({
       try {
         const attachment = await fileToAttachment(file);
 
-        setAttachments((prev) => {
-          const newAttachments = [...prev, attachment];
+        updateSession((current) => {
+          const newAttachments = [...current.attachments, attachment];
 
           // Check total size
           if (!isValidTotalSize(newAttachments)) {
             alert("Total attachment size exceeds 20MB limit");
-            return prev;
+            return {};
           }
 
-          return newAttachments;
+          return { attachments: newAttachments };
         });
       } catch (error) {
         if (error instanceof Error) {
@@ -973,19 +952,21 @@ export function useChatMessages({
         }
       }
     },
-    [setAttachments]
+    [updateSession]
   );
 
   const removeAttachment = useCallback(
     (index: number) => {
-      setAttachments((prev) => prev.filter((_, i) => i !== index));
+      updateSession((current) => ({
+        attachments: current.attachments.filter((_, i) => i !== index),
+      }));
     },
-    [setAttachments]
+    [updateSession]
   );
 
   const clearAttachments = useCallback(() => {
-    setAttachments([]);
-  }, [setAttachments]);
+    updateSession({ attachments: [] });
+  }, [updateSession]);
 
   return {
     sessionId: activeSessionId,

--- a/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessages.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessages.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useState, type SetStateAction } from "react";
 import { inspectorApi } from "@/client/utils/basePath";
 import type { PromptResult } from "../../hooks/useMCPPrompts";
 import {
@@ -34,8 +34,22 @@ import {
   widgetModelContextProviderMessage,
   type WidgetModelContext,
 } from "./widget-model-context";
+import { createChatSessionId } from "./chat-session";
+import {
+  resolveStateAction,
+  useChatSession,
+  useChatSessionField,
+  useChatSessionStore,
+  type ChatSessionStore,
+} from "./chat-session-store";
 
 interface UseChatMessagesProps {
+  /** Store holding one record per chat session. Defaults to a private store. */
+  sessionStore?: ChatSessionStore;
+  /** Session this hook renders. Defaults to a single private session. */
+  sessionId?: string;
+  /** Fires for every session whose messages change, including background ones. */
+  onMessagesChange?: (sessionId: string, messages: Message[]) => void;
   mcpServerUrl: string;
   llmConfig: LLMConfig | null;
   authConfig: AuthConfig | null;
@@ -48,7 +62,7 @@ interface UseChatMessagesProps {
   waitForChatApiUrl?: () => Promise<string | undefined>;
   /** Active widget model contexts to inject into the LLM conversation */
   widgetModelContexts?: Map<string, WidgetModelContext | undefined>;
-  /** Pre-populate the chat with messages from a previous session (e.g. when restoring history). */
+  /** Seeds the session on first use; a session already in the store is kept. */
   initialMessages?: Message[];
   /** Tool names the user has disabled via the tool selector. Sent to the server so it can exclude them. */
   disabledTools?: Set<string>;
@@ -74,6 +88,9 @@ interface UseChatMessagesProps {
 }
 
 export function useChatMessages({
+  sessionStore,
+  sessionId,
+  onMessagesChange,
   mcpServerUrl,
   llmConfig,
   authConfig,
@@ -89,28 +106,66 @@ export function useChatMessages({
   extraHeaders,
   body: bodyBuilder,
 }: UseChatMessagesProps) {
-  const [messages, setMessages] = useState<Message[]>(initialMessages ?? []);
-  const [isLoading, setIsLoading] = useState(false);
-  const [attachments, setAttachments] = useState<MessageAttachment[]>([]);
-  const [traceState, setTraceState] = useState(EMPTY_TRACE_STATE);
-  const [managedChatNotice, setManagedChatNotice] =
-    useState<ManagedChatNotice | null>(null);
-  const [mcpServerAuthRequired, setMcpServerAuthRequired] = useState<{
-    mcpServerUrl: string;
-    message?: string;
-  } | null>(null);
-  const abortControllerRef = useRef<AbortController | null>(null);
-  const sendInProgressRef = useRef(false);
-  const traceIdRef = useRef(0);
+  const privateStore = useChatSessionStore();
+  const store = sessionStore ?? privateStore;
+  const [privateSessionId] = useState(createChatSessionId);
+  const activeSessionId = sessionId ?? privateSessionId;
 
-  const recordTrace = useCallback((event: InspectorTraceEventInput) => {
-    const next = {
-      ...event,
-      id: `trace-${++traceIdRef.current}`,
-      timestamp: Date.now(),
-    } as InspectorTraceEvent;
-    setTraceState((state) => appendTraceEvent(state, next));
-  }, []);
+  // Seeding is skipped once the session exists, so returning to a chat that is
+  // still streaming never replaces the messages it is writing.
+  if (initialMessages?.length && !store.has(activeSessionId)) {
+    store.seed(activeSessionId, initialMessages);
+  }
+
+  const session = useChatSession(store, activeSessionId);
+  const {
+    messages,
+    isLoading,
+    attachments,
+    managedChatNotice,
+    mcpServerAuthRequired,
+    runtime,
+  } = session;
+  const traceState = session.trace;
+
+  const setMessages = useCallback(
+    (action: SetStateAction<Message[]>) => {
+      const next = store.update(activeSessionId, (current) => ({
+        messages: resolveStateAction(current.messages, action),
+      }));
+      onMessagesChange?.(activeSessionId, next.messages);
+    },
+    [activeSessionId, onMessagesChange, store]
+  );
+  const setIsLoading = useChatSessionField(store, activeSessionId, "isLoading");
+  const setAttachments = useChatSessionField(
+    store,
+    activeSessionId,
+    "attachments"
+  );
+  const setTraceState = useChatSessionField(store, activeSessionId, "trace");
+  const setManagedChatNotice = useChatSessionField(
+    store,
+    activeSessionId,
+    "managedChatNotice"
+  );
+  const setMcpServerAuthRequired = useChatSessionField(
+    store,
+    activeSessionId,
+    "mcpServerAuthRequired"
+  );
+
+  const recordTrace = useCallback(
+    (event: InspectorTraceEventInput) => {
+      const next = {
+        ...event,
+        id: `trace-${++runtime.traceId}`,
+        timestamp: Date.now(),
+      } as InspectorTraceEvent;
+      setTraceState((state) => appendTraceEvent(state, next));
+    },
+    [runtime, setTraceState]
+  );
 
   const sendMessage = useCallback(
     async (
@@ -142,11 +197,11 @@ export function useChatMessages({
         rejectOrReturn("The MCP server is not connected");
         return;
       }
-      if (sendInProgressRef.current) {
+      if (runtime.sendInProgress) {
         rejectOrReturn("Chat is busy with another turn");
         return;
       }
-      sendInProgressRef.current = true;
+      runtime.sendInProgress = true;
 
       const promptResultsMessages =
         convertPromptResultsToMessages(promptResults);
@@ -173,7 +228,7 @@ export function useChatMessages({
       setAttachments([]);
 
       // Create abort controller for cancellation
-      abortControllerRef.current = new AbortController();
+      runtime.abortController = new AbortController();
 
       try {
         // Server-side chat must forward the same OAuth credentials as the browser
@@ -289,7 +344,7 @@ export function useChatMessages({
             "Content-Type": "application/json",
             ...extraHeaders,
           },
-          signal: abortControllerRef.current.signal,
+          signal: runtime.abortController.signal,
           ...(credentials ? { credentials } : {}),
           body: JSON.stringify(requestBody),
         });
@@ -485,7 +540,7 @@ export function useChatMessages({
 
         let buffer = "";
         while (true) {
-          if (abortControllerRef.current?.signal.aborted) {
+          if (runtime.abortController?.signal.aborted) {
             await reader.cancel();
             break;
           }
@@ -757,7 +812,7 @@ export function useChatMessages({
         }
 
         // If aborted, mark any pending tool calls as cancelled
-        if (abortControllerRef.current?.signal.aborted) {
+        if (runtime.abortController?.signal.aborted) {
           for (const part of parts) {
             if (
               part.type === "tool-invocation" &&
@@ -828,8 +883,8 @@ export function useChatMessages({
         }
       } finally {
         setIsLoading(false);
-        abortControllerRef.current = null;
-        sendInProgressRef.current = false;
+        runtime.abortController = null;
+        runtime.sendInProgress = false;
       }
     },
     [
@@ -849,6 +904,12 @@ export function useChatMessages({
       extraHeaders,
       bodyBuilder,
       recordTrace,
+      runtime,
+      setAttachments,
+      setIsLoading,
+      setManagedChatNotice,
+      setMcpServerAuthRequired,
+      setMessages,
     ]
   );
 
@@ -857,61 +918,77 @@ export function useChatMessages({
     setManagedChatNotice(null);
     setMcpServerAuthRequired(null);
     setTraceState(EMPTY_TRACE_STATE);
-  }, []);
+  }, [
+    setManagedChatNotice,
+    setMcpServerAuthRequired,
+    setMessages,
+    setTraceState,
+  ]);
 
   const clearManagedChatNotice = useCallback(() => {
     setManagedChatNotice(null);
-  }, []);
+  }, [setManagedChatNotice]);
 
-  const showManagedChatNotice = useCallback((notice: ManagedChatNotice) => {
-    setManagedChatNotice(notice);
-  }, []);
+  const showManagedChatNotice = useCallback(
+    (notice: ManagedChatNotice) => {
+      setManagedChatNotice(notice);
+    },
+    [setManagedChatNotice]
+  );
 
-  const clearTrace = useCallback(() => setTraceState(EMPTY_TRACE_STATE), []);
+  const clearTrace = useCallback(
+    () => setTraceState(EMPTY_TRACE_STATE),
+    [setTraceState]
+  );
 
   const clearMcpServerAuthRequired = useCallback(() => {
     setMcpServerAuthRequired(null);
-  }, []);
+  }, [setMcpServerAuthRequired]);
 
   const stop = useCallback(() => {
-    if (abortControllerRef.current) {
-      abortControllerRef.current.abort();
-    }
-  }, []);
+    runtime.abortController?.abort();
+  }, [runtime]);
 
-  const addAttachment = useCallback(async (file: File) => {
-    try {
-      const attachment = await fileToAttachment(file);
+  const addAttachment = useCallback(
+    async (file: File) => {
+      try {
+        const attachment = await fileToAttachment(file);
 
-      setAttachments((prev) => {
-        const newAttachments = [...prev, attachment];
+        setAttachments((prev) => {
+          const newAttachments = [...prev, attachment];
 
-        // Check total size
-        if (!isValidTotalSize(newAttachments)) {
-          alert("Total attachment size exceeds 20MB limit");
-          return prev;
+          // Check total size
+          if (!isValidTotalSize(newAttachments)) {
+            alert("Total attachment size exceeds 20MB limit");
+            return prev;
+          }
+
+          return newAttachments;
+        });
+      } catch (error) {
+        if (error instanceof Error) {
+          alert(error.message);
+        } else {
+          alert("Failed to add attachment");
         }
-
-        return newAttachments;
-      });
-    } catch (error) {
-      if (error instanceof Error) {
-        alert(error.message);
-      } else {
-        alert("Failed to add attachment");
       }
-    }
-  }, []);
+    },
+    [setAttachments]
+  );
 
-  const removeAttachment = useCallback((index: number) => {
-    setAttachments((prev) => prev.filter((_, i) => i !== index));
-  }, []);
+  const removeAttachment = useCallback(
+    (index: number) => {
+      setAttachments((prev) => prev.filter((_, i) => i !== index));
+    },
+    [setAttachments]
+  );
 
   const clearAttachments = useCallback(() => {
     setAttachments([]);
-  }, []);
+  }, [setAttachments]);
 
   return {
+    sessionId: activeSessionId,
     messages,
     isLoading,
     attachments,

--- a/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessagesClientSide.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessagesClientSide.ts
@@ -61,6 +61,27 @@ import {
 // Type alias for backward compatibility
 type MCPConnection = McpServer;
 
+// Chat history is optional. Give an in-flight creation a short chance to
+// provide a backend-minted id for redirect recovery, but never let it prevent
+// the user from starting OAuth indefinitely.
+const CHAT_CREATION_AUTH_WAIT_MS = 1_000;
+
+async function waitForPersistedChatId(
+  creation: Promise<string | null>
+): Promise<string | null> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      creation,
+      new Promise<null>((resolve) => {
+        timeout = setTimeout(resolve, CHAT_CREATION_AUTH_WAIT_MS, null);
+      }),
+    ]);
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout);
+  }
+}
+
 interface UseChatMessagesClientSideProps {
   /** Store holding one record per chat session. Defaults to a private store. */
   sessionStore?: ChatSessionStore;
@@ -676,26 +697,31 @@ export function useChatMessagesClientSide({
 
   const authenticatePendingTool = useCallback(
     async (toolCallId: string) => {
+      const currentSession = store.get(activeSessionId);
+      const currentAuthorization = currentSession.pendingAuthorization;
       if (
-        pendingAuthorization?.toolCallId !== toolCallId ||
-        authenticatingToolCallId
+        currentAuthorization?.toolCallId !== toolCallId ||
+        currentSession.authenticatingToolCallId
       ) {
         return;
       }
 
-      const currentSession = store.get(activeSessionId);
-      const persistedChatId =
-        currentSession.persistedChatId ??
-        (currentSession.creation ? await currentSession.creation : null);
-      savePendingChatTurn({
-        ...pendingAuthorization.replay,
-        ...(persistedChatId ? { persistedChatId } : {}),
-      });
+      // Store updates are synchronous, so this is also the lock against rapid
+      // repeated calls before React has had a chance to re-render.
       updateSession({
         authenticatingToolCallId: toolCallId,
         toolAuthorizationError: null,
       });
       try {
+        const persistedChatId =
+          currentSession.persistedChatId ??
+          (currentSession.creation
+            ? await waitForPersistedChatId(currentSession.creation)
+            : null);
+        savePendingChatTurn({
+          ...currentAuthorization.replay,
+          ...(persistedChatId ? { persistedChatId } : {}),
+        });
         await connection.authenticate();
         const gate = runtime.authorizationGate;
         if (gate?.toolCallId === toolCallId) {
@@ -712,16 +738,7 @@ export function useChatMessagesClientSide({
         updateSession({ authenticatingToolCallId: null });
       }
     },
-    [
-      activeSessionId,
-      authenticatingToolCallId,
-      connection,
-      pendingAuthorization,
-      retryServerId,
-      runtime,
-      store,
-      updateSession,
-    ]
+    [activeSessionId, connection, retryServerId, runtime, store, updateSession]
   );
 
   // A full-page OAuth redirect drops the turn that was in flight. The session it

--- a/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessagesClientSide.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessagesClientSide.ts
@@ -9,7 +9,7 @@ import {
   type McpServer,
   type Skill,
 } from "@mcp-use/client/react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState, type SetStateAction } from "react";
 import type { PromptResult } from "../../hooks/useMCPPrompts";
 import {
   convertMessagesToProvider,
@@ -50,11 +50,25 @@ import {
   savePendingChatTurn,
   type PendingChatTurn,
 } from "./chat-auth-retry";
+import { createChatSessionId } from "./chat-session";
+import {
+  resolveStateAction,
+  useChatSession,
+  useChatSessionField,
+  useChatSessionStore,
+  type ChatSessionStore,
+} from "./chat-session-store";
 
 // Type alias for backward compatibility
 type MCPConnection = McpServer;
 
 interface UseChatMessagesClientSideProps {
+  /** Store holding one record per chat session. Defaults to a private store. */
+  sessionStore?: ChatSessionStore;
+  /** Session this hook renders. Defaults to a single private session. */
+  sessionId?: string;
+  /** Fires for every session whose messages change, including background ones. */
+  onMessagesChange?: (sessionId: string, messages: Message[]) => void;
   connection: MCPConnection;
   llmConfig: LLMConfig | null;
   isConnected: boolean;
@@ -62,12 +76,16 @@ interface UseChatMessagesClientSideProps {
   widgetModelContexts?: Map<string, WidgetModelContext | undefined>;
   disabledTools?: Set<string>;
   appToolConnections?: McpConnectionLike[];
+  /** Seeds the session on first use; a session already in the store is kept. */
   initialMessages?: Message[];
   systemPrompt?: string;
   skills?: Skill[];
 }
 
 export function useChatMessagesClientSide({
+  sessionStore,
+  sessionId,
+  onMessagesChange,
   connection,
   llmConfig,
   isConnected,
@@ -80,52 +98,78 @@ export function useChatMessagesClientSide({
   skills = [],
 }: UseChatMessagesClientSideProps) {
   const retryServerId = connection.id ?? connection.url;
-  const [initialPendingTurn] = useState(() =>
-    readPendingChatTurn(retryServerId)
-  );
-  const [messages, setMessages] = useState<Message[]>(
-    () => initialPendingTurn?.baseMessages ?? initialMessages ?? []
-  );
-  const [isLoading, setIsLoading] = useState(false);
-  const [attachments, setAttachments] = useState<MessageAttachment[]>([]);
-  const [traceState, setTraceState] = useState(EMPTY_TRACE_STATE);
-  const [managedChatNotice, setManagedChatNotice] =
-    useState<ManagedChatNotice | null>(null);
-  const abortControllerRef = useRef<AbortController | null>(null);
-  const sendInProgressRef = useRef(false);
-  const traceIdRef = useRef(0);
-  const initialPendingTurnRef = useRef(initialPendingTurn);
-  const authorizationGateRef = useRef<{
-    toolCallId: string;
-    resolve: () => void;
-    reject: (error: Error) => void;
-  } | null>(null);
-  const [pendingAuthorization, setPendingAuthorization] = useState<{
-    toolCallId: string;
-    replay: Omit<PendingChatTurn, "savedAt">;
-  } | null>(null);
-  const [authenticatingToolCallId, setAuthenticatingToolCallId] = useState<
-    string | null
-  >(null);
-  const [toolAuthorizationError, setToolAuthorizationError] = useState<
-    string | null
-  >(null);
+  const privateStore = useChatSessionStore();
+  const store = sessionStore ?? privateStore;
+  const [privateSessionId] = useState(createChatSessionId);
+  const activeSessionId = sessionId ?? privateSessionId;
 
-  const recordTrace = useCallback((event: InspectorTraceEventInput) => {
-    const next = {
-      ...event,
-      id: `trace-${++traceIdRef.current}`,
-      timestamp: Date.now(),
-    } as InspectorTraceEvent;
-    setTraceState((state) => appendTraceEvent(state, next));
-  }, []);
+  // Seeding is skipped once the session exists, so returning to a chat that is
+  // still streaming never replaces the messages it is writing.
+  if (initialMessages?.length && !store.has(activeSessionId)) {
+    store.seed(activeSessionId, initialMessages);
+  }
 
-  useEffect(() => {
-    if (initialPendingTurnRef.current) return;
-    if (initialMessages !== undefined) {
-      setMessages(initialMessages);
-    }
-  }, [initialMessages]);
+  const session = useChatSession(store, activeSessionId);
+  const {
+    messages,
+    isLoading,
+    attachments,
+    managedChatNotice,
+    pendingAuthorization,
+    authenticatingToolCallId,
+    toolAuthorizationError,
+    runtime,
+  } = session;
+  const traceState = session.trace;
+
+  const setMessages = useCallback(
+    (action: SetStateAction<Message[]>) => {
+      const next = store.update(activeSessionId, (current) => ({
+        messages: resolveStateAction(current.messages, action),
+      }));
+      onMessagesChange?.(activeSessionId, next.messages);
+    },
+    [activeSessionId, onMessagesChange, store]
+  );
+  const setIsLoading = useChatSessionField(store, activeSessionId, "isLoading");
+  const setAttachments = useChatSessionField(
+    store,
+    activeSessionId,
+    "attachments"
+  );
+  const setTraceState = useChatSessionField(store, activeSessionId, "trace");
+  const setManagedChatNotice = useChatSessionField(
+    store,
+    activeSessionId,
+    "managedChatNotice"
+  );
+  const setPendingAuthorization = useChatSessionField(
+    store,
+    activeSessionId,
+    "pendingAuthorization"
+  );
+  const setAuthenticatingToolCallId = useChatSessionField(
+    store,
+    activeSessionId,
+    "authenticatingToolCallId"
+  );
+  const setToolAuthorizationError = useChatSessionField(
+    store,
+    activeSessionId,
+    "toolAuthorizationError"
+  );
+
+  const recordTrace = useCallback(
+    (event: InspectorTraceEventInput) => {
+      const next = {
+        ...event,
+        id: `trace-${++runtime.traceId}`,
+        timestamp: Date.now(),
+      } as InspectorTraceEvent;
+      setTraceState((state) => appendTraceEvent(state, next));
+    },
+    [runtime, setTraceState]
+  );
 
   const sendMessage = useCallback(
     async (
@@ -159,11 +203,11 @@ export function useChatMessagesClientSide({
         rejectOrReturn("The MCP server is not connected");
         return;
       }
-      if (sendInProgressRef.current) {
+      if (runtime.sendInProgress) {
         rejectOrReturn("Chat is busy with another turn");
         return;
       }
-      sendInProgressRef.current = true;
+      runtime.sendInProgress = true;
 
       const promptResultsMessages =
         convertPromptResultsToMessages(promptResults);
@@ -190,7 +234,7 @@ export function useChatMessagesClientSide({
       setIsLoading(true);
       setAttachments([]);
 
-      abortControllerRef.current = new AbortController();
+      runtime.abortController = new AbortController();
       const startTime = Date.now();
       let toolCallsCount = 0;
       const assistantMessageId = `assistant-${Date.now()}`;
@@ -288,6 +332,7 @@ export function useChatMessagesClientSide({
         };
         const replayTurn: Omit<PendingChatTurn, "savedAt"> = {
           serverId: retryServerId,
+          sessionId: activeSessionId,
           userInput,
           promptResults,
           attachments: allAttachments,
@@ -326,12 +371,10 @@ export function useChatMessagesClientSide({
                 commitMessageParts();
 
                 await new Promise<void>((resolve, reject) => {
-                  const signal = abortControllerRef.current?.signal;
+                  const signal = runtime.abortController?.signal;
                   const handleAbort = () => {
-                    if (
-                      authorizationGateRef.current?.toolCallId === toolCallId
-                    ) {
-                      authorizationGateRef.current = null;
+                    if (runtime.authorizationGate?.toolCallId === toolCallId) {
+                      runtime.authorizationGate = null;
                     }
                     reject(
                       new DOMException("Chat turn was cancelled", "AbortError")
@@ -339,7 +382,7 @@ export function useChatMessagesClientSide({
                   };
                   const cleanup = () =>
                     signal?.removeEventListener("abort", handleAbort);
-                  authorizationGateRef.current = {
+                  runtime.authorizationGate = {
                     toolCallId,
                     resolve: () => {
                       cleanup();
@@ -358,7 +401,7 @@ export function useChatMessagesClientSide({
                 toolPart.toolInvocation.state = "pending";
                 setPendingAuthorization(null);
                 setToolAuthorizationError(null);
-                clearPendingChatTurn(retryServerId);
+                clearPendingChatTurn(retryServerId, activeSessionId);
                 commitMessageParts();
               }
             }
@@ -390,10 +433,10 @@ export function useChatMessagesClientSide({
 
         for await (const ev of agent.streamEvents({
           messages: providerMessages,
-          signal: abortControllerRef.current?.signal,
+          signal: runtime.abortController?.signal,
         })) {
           markAccepted();
-          if (abortControllerRef.current?.signal.aborted) break;
+          if (runtime.abortController?.signal.aborted) break;
 
           // Keep inspector compatible with an older installed agent build while
           // the additive usage event rolls through workspace package outputs.
@@ -522,7 +565,7 @@ export function useChatMessagesClientSide({
           }
         }
 
-        if (abortControllerRef.current?.signal.aborted) {
+        if (runtime.abortController?.signal.aborted) {
           for (const part of parts) {
             if (
               part.type === "tool-invocation" &&
@@ -630,11 +673,12 @@ export function useChatMessagesClientSide({
         }
       } finally {
         setIsLoading(false);
-        abortControllerRef.current = null;
-        sendInProgressRef.current = false;
+        runtime.abortController = null;
+        runtime.sendInProgress = false;
       }
     },
     [
+      activeSessionId,
       connection,
       llmConfig,
       isConnected,
@@ -646,8 +690,15 @@ export function useChatMessagesClientSide({
       widgetModelContexts,
       recordTrace,
       retryServerId,
+      runtime,
       systemPrompt,
       skills,
+      setAttachments,
+      setIsLoading,
+      setManagedChatNotice,
+      setMessages,
+      setPendingAuthorization,
+      setToolAuthorizationError,
     ]
   );
 
@@ -665,13 +716,13 @@ export function useChatMessagesClientSide({
       setToolAuthorizationError(null);
       try {
         await connection.authenticate();
-        const gate = authorizationGateRef.current;
+        const gate = runtime.authorizationGate;
         if (gate?.toolCallId === toolCallId) {
-          authorizationGateRef.current = null;
+          runtime.authorizationGate = null;
           gate.resolve();
         }
       } catch (error) {
-        clearPendingChatTurn(retryServerId);
+        clearPendingChatTurn(retryServerId, activeSessionId);
         setToolAuthorizationError(
           error instanceof Error ? error.message : "Authentication failed"
         );
@@ -679,15 +730,29 @@ export function useChatMessagesClientSide({
         setAuthenticatingToolCallId(null);
       }
     },
-    [authenticatingToolCallId, connection, pendingAuthorization, retryServerId]
+    [
+      activeSessionId,
+      authenticatingToolCallId,
+      connection,
+      pendingAuthorization,
+      retryServerId,
+      runtime,
+      setAuthenticatingToolCallId,
+      setToolAuthorizationError,
+    ]
   );
 
+  // A full-page OAuth redirect drops the turn that was in flight. The session it
+  // belonged to is reactivated by whoever owns the store, so replay it here once
+  // that session is connected again.
   useEffect(() => {
-    const pendingTurn = initialPendingTurnRef.current;
-    if (!pendingTurn || !isConnected || !llmConfig) return;
+    if (runtime.pendingTurnResumed || !isConnected || !llmConfig) return;
+    runtime.pendingTurnResumed = true;
 
-    initialPendingTurnRef.current = null;
-    clearPendingChatTurn(retryServerId);
+    const pendingTurn = readPendingChatTurn(retryServerId, activeSessionId);
+    if (!pendingTurn) return;
+
+    clearPendingChatTurn(retryServerId, activeSessionId);
     setMessages(pendingTurn.baseMessages);
     void sendMessage(
       pendingTurn.userInput,
@@ -695,67 +760,97 @@ export function useChatMessagesClientSide({
       pendingTurn.attachments,
       { resumeExistingTurn: true }
     );
-  }, [isConnected, llmConfig, retryServerId, sendMessage]);
+  }, [
+    activeSessionId,
+    isConnected,
+    llmConfig,
+    retryServerId,
+    runtime,
+    sendMessage,
+    setMessages,
+  ]);
 
   const clearMessages = useCallback(() => {
-    clearPendingChatTurn(retryServerId);
-    authorizationGateRef.current?.reject(
+    runtime.pendingTurnResumed = true;
+    clearPendingChatTurn(retryServerId, activeSessionId);
+    runtime.authorizationGate?.reject(
       new DOMException("Chat turn was cancelled", "AbortError")
     );
-    authorizationGateRef.current = null;
+    runtime.authorizationGate = null;
     setPendingAuthorization(null);
     setAuthenticatingToolCallId(null);
     setToolAuthorizationError(null);
     setMessages([]);
     setTraceState(EMPTY_TRACE_STATE);
     setManagedChatNotice(null);
-  }, [retryServerId]);
-  const clearTrace = useCallback(() => setTraceState(EMPTY_TRACE_STATE), []);
+  }, [
+    activeSessionId,
+    retryServerId,
+    runtime,
+    setAuthenticatingToolCallId,
+    setManagedChatNotice,
+    setMessages,
+    setPendingAuthorization,
+    setToolAuthorizationError,
+    setTraceState,
+  ]);
+  const clearTrace = useCallback(
+    () => setTraceState(EMPTY_TRACE_STATE),
+    [setTraceState]
+  );
 
   const stop = useCallback(() => {
-    if (abortControllerRef.current) {
-      abortControllerRef.current.abort();
-    }
-  }, []);
+    runtime.abortController?.abort();
+  }, [runtime]);
 
-  const addAttachment = useCallback(async (file: File) => {
-    try {
-      const attachment = await fileToAttachment(file);
+  const addAttachment = useCallback(
+    async (file: File) => {
+      try {
+        const attachment = await fileToAttachment(file);
 
-      setAttachments((prev) => {
-        const newAttachments = [...prev, attachment];
-        if (!isValidTotalSize(newAttachments)) {
-          alert("Total attachment size exceeds 20MB limit");
-          return prev;
+        setAttachments((prev) => {
+          const newAttachments = [...prev, attachment];
+          if (!isValidTotalSize(newAttachments)) {
+            alert("Total attachment size exceeds 20MB limit");
+            return prev;
+          }
+          return newAttachments;
+        });
+      } catch (error) {
+        if (error instanceof Error) {
+          alert(error.message);
+        } else {
+          alert("Failed to add attachment");
         }
-        return newAttachments;
-      });
-    } catch (error) {
-      if (error instanceof Error) {
-        alert(error.message);
-      } else {
-        alert("Failed to add attachment");
       }
-    }
-  }, []);
+    },
+    [setAttachments]
+  );
 
-  const removeAttachment = useCallback((index: number) => {
-    setAttachments((prev) => prev.filter((_, i) => i !== index));
-  }, []);
+  const removeAttachment = useCallback(
+    (index: number) => {
+      setAttachments((prev) => prev.filter((_, i) => i !== index));
+    },
+    [setAttachments]
+  );
 
   const clearAttachments = useCallback(() => {
     setAttachments([]);
-  }, []);
+  }, [setAttachments]);
 
   const clearManagedChatNotice = useCallback(() => {
     setManagedChatNotice(null);
-  }, []);
+  }, [setManagedChatNotice]);
 
-  const showManagedChatNotice = useCallback((notice: ManagedChatNotice) => {
-    setManagedChatNotice(notice);
-  }, []);
+  const showManagedChatNotice = useCallback(
+    (notice: ManagedChatNotice) => {
+      setManagedChatNotice(notice);
+    },
+    [setManagedChatNotice]
+  );
 
   return {
+    sessionId: activeSessionId,
     messages,
     isLoading,
     attachments,

--- a/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessagesClientSide.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessagesClientSide.ts
@@ -54,7 +54,6 @@ import { createChatSessionId } from "./chat-session";
 import {
   resolveStateAction,
   useChatSession,
-  useChatSessionField,
   useChatSessionStore,
   type ChatSessionStore,
 } from "./chat-session-store";
@@ -109,7 +108,7 @@ export function useChatMessagesClientSide({
     store.seed(activeSessionId, initialMessages);
   }
 
-  const session = useChatSession(store, activeSessionId);
+  const [session, updateSession] = useChatSession(store, activeSessionId);
   const {
     messages,
     isLoading,
@@ -131,34 +130,6 @@ export function useChatMessagesClientSide({
     },
     [activeSessionId, onMessagesChange, store]
   );
-  const setIsLoading = useChatSessionField(store, activeSessionId, "isLoading");
-  const setAttachments = useChatSessionField(
-    store,
-    activeSessionId,
-    "attachments"
-  );
-  const setTraceState = useChatSessionField(store, activeSessionId, "trace");
-  const setManagedChatNotice = useChatSessionField(
-    store,
-    activeSessionId,
-    "managedChatNotice"
-  );
-  const setPendingAuthorization = useChatSessionField(
-    store,
-    activeSessionId,
-    "pendingAuthorization"
-  );
-  const setAuthenticatingToolCallId = useChatSessionField(
-    store,
-    activeSessionId,
-    "authenticatingToolCallId"
-  );
-  const setToolAuthorizationError = useChatSessionField(
-    store,
-    activeSessionId,
-    "toolAuthorizationError"
-  );
-
   const recordTrace = useCallback(
     (event: InspectorTraceEventInput) => {
       const next = {
@@ -166,9 +137,11 @@ export function useChatMessagesClientSide({
         id: `trace-${++runtime.traceId}`,
         timestamp: Date.now(),
       } as InspectorTraceEvent;
-      setTraceState((state) => appendTraceEvent(state, next));
+      updateSession((current) => ({
+        trace: appendTraceEvent(current.trace, next),
+      }));
     },
-    [runtime, setTraceState]
+    [runtime, updateSession]
   );
 
   const sendMessage = useCallback(
@@ -231,8 +204,7 @@ export function useChatMessagesClientSide({
       if (!isResuming) {
         setMessages(baseMessages);
       }
-      setIsLoading(true);
-      setAttachments([]);
+      updateSession({ isLoading: true, attachments: [] });
 
       runtime.abortController = new AbortController();
       const startTime = Date.now();
@@ -366,8 +338,10 @@ export function useChatMessagesClientSide({
                 if (!toolPart?.toolInvocation || !toolCallId) throw error;
 
                 toolPart.toolInvocation.state = "authorization-required";
-                setPendingAuthorization({ toolCallId, replay: replayTurn });
-                setToolAuthorizationError(null);
+                updateSession({
+                  pendingAuthorization: { toolCallId, replay: replayTurn },
+                  toolAuthorizationError: null,
+                });
                 commitMessageParts();
 
                 await new Promise<void>((resolve, reject) => {
@@ -399,8 +373,10 @@ export function useChatMessagesClientSide({
                 });
 
                 toolPart.toolInvocation.state = "pending";
-                setPendingAuthorization(null);
-                setToolAuthorizationError(null);
+                updateSession({
+                  pendingAuthorization: null,
+                  toolAuthorizationError: null,
+                });
                 clearPendingChatTurn(retryServerId, activeSessionId);
                 commitMessageParts();
               }
@@ -615,7 +591,7 @@ export function useChatMessagesClientSide({
           ? managedNoticeFromLlmError(error)
           : null;
         if (notice) {
-          setManagedChatNotice(notice);
+          updateSession({ managedChatNotice: notice });
           setMessages((prev) =>
             prev.filter((m) => m.id !== assistantMessageId)
           );
@@ -672,7 +648,7 @@ export function useChatMessagesClientSide({
           throw new Error(errorDetail);
         }
       } finally {
-        setIsLoading(false);
+        updateSession({ isLoading: false });
         runtime.abortController = null;
         runtime.sendInProgress = false;
       }
@@ -693,12 +669,8 @@ export function useChatMessagesClientSide({
       runtime,
       systemPrompt,
       skills,
-      setAttachments,
-      setIsLoading,
-      setManagedChatNotice,
       setMessages,
-      setPendingAuthorization,
-      setToolAuthorizationError,
+      updateSession,
     ]
   );
 
@@ -711,9 +683,18 @@ export function useChatMessagesClientSide({
         return;
       }
 
-      savePendingChatTurn(pendingAuthorization.replay);
-      setAuthenticatingToolCallId(toolCallId);
-      setToolAuthorizationError(null);
+      const currentSession = store.get(activeSessionId);
+      const persistedChatId =
+        currentSession.persistedChatId ??
+        (currentSession.creation ? await currentSession.creation : null);
+      savePendingChatTurn({
+        ...pendingAuthorization.replay,
+        ...(persistedChatId ? { persistedChatId } : {}),
+      });
+      updateSession({
+        authenticatingToolCallId: toolCallId,
+        toolAuthorizationError: null,
+      });
       try {
         await connection.authenticate();
         const gate = runtime.authorizationGate;
@@ -723,11 +704,12 @@ export function useChatMessagesClientSide({
         }
       } catch (error) {
         clearPendingChatTurn(retryServerId, activeSessionId);
-        setToolAuthorizationError(
-          error instanceof Error ? error.message : "Authentication failed"
-        );
+        updateSession({
+          toolAuthorizationError:
+            error instanceof Error ? error.message : "Authentication failed",
+        });
       } finally {
-        setAuthenticatingToolCallId(null);
+        updateSession({ authenticatingToolCallId: null });
       }
     },
     [
@@ -737,8 +719,8 @@ export function useChatMessagesClientSide({
       pendingAuthorization,
       retryServerId,
       runtime,
-      setAuthenticatingToolCallId,
-      setToolAuthorizationError,
+      store,
+      updateSession,
     ]
   );
 
@@ -777,26 +759,18 @@ export function useChatMessagesClientSide({
       new DOMException("Chat turn was cancelled", "AbortError")
     );
     runtime.authorizationGate = null;
-    setPendingAuthorization(null);
-    setAuthenticatingToolCallId(null);
-    setToolAuthorizationError(null);
     setMessages([]);
-    setTraceState(EMPTY_TRACE_STATE);
-    setManagedChatNotice(null);
-  }, [
-    activeSessionId,
-    retryServerId,
-    runtime,
-    setAuthenticatingToolCallId,
-    setManagedChatNotice,
-    setMessages,
-    setPendingAuthorization,
-    setToolAuthorizationError,
-    setTraceState,
-  ]);
+    updateSession({
+      pendingAuthorization: null,
+      authenticatingToolCallId: null,
+      toolAuthorizationError: null,
+      trace: EMPTY_TRACE_STATE,
+      managedChatNotice: null,
+    });
+  }, [activeSessionId, retryServerId, runtime, setMessages, updateSession]);
   const clearTrace = useCallback(
-    () => setTraceState(EMPTY_TRACE_STATE),
-    [setTraceState]
+    () => updateSession({ trace: EMPTY_TRACE_STATE }),
+    [updateSession]
   );
 
   const stop = useCallback(() => {
@@ -808,13 +782,13 @@ export function useChatMessagesClientSide({
       try {
         const attachment = await fileToAttachment(file);
 
-        setAttachments((prev) => {
-          const newAttachments = [...prev, attachment];
+        updateSession((current) => {
+          const newAttachments = [...current.attachments, attachment];
           if (!isValidTotalSize(newAttachments)) {
             alert("Total attachment size exceeds 20MB limit");
-            return prev;
+            return {};
           }
-          return newAttachments;
+          return { attachments: newAttachments };
         });
       } catch (error) {
         if (error instanceof Error) {
@@ -824,29 +798,31 @@ export function useChatMessagesClientSide({
         }
       }
     },
-    [setAttachments]
+    [updateSession]
   );
 
   const removeAttachment = useCallback(
     (index: number) => {
-      setAttachments((prev) => prev.filter((_, i) => i !== index));
+      updateSession((current) => ({
+        attachments: current.attachments.filter((_, i) => i !== index),
+      }));
     },
-    [setAttachments]
+    [updateSession]
   );
 
   const clearAttachments = useCallback(() => {
-    setAttachments([]);
-  }, [setAttachments]);
+    updateSession({ attachments: [] });
+  }, [updateSession]);
 
   const clearManagedChatNotice = useCallback(() => {
-    setManagedChatNotice(null);
-  }, [setManagedChatNotice]);
+    updateSession({ managedChatNotice: null });
+  }, [updateSession]);
 
   const showManagedChatNotice = useCallback(
     (notice: ManagedChatNotice) => {
-      setManagedChatNotice(notice);
+      updateSession({ managedChatNotice: notice });
     },
-    [setManagedChatNotice]
+    [updateSession]
   );
 
   return {

--- a/libraries/typescript/packages/inspector/src/client/components/chat/useChatSessions.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/useChatSessions.ts
@@ -69,15 +69,17 @@ export function useChatSessions({
     const resumable =
       pendingTurnOnMount != null &&
       (!controlledActiveChatId ||
-        pendingTurnOnMount.sessionId === controlledActiveChatId);
+        pendingTurnOnMount.sessionId === controlledActiveChatId ||
+        pendingTurnOnMount.persistedChatId === controlledActiveChatId);
     const sessionId =
-      controlledActiveChatId ??
-      (resumable ? pendingTurnOnMount.sessionId : createChatSessionId());
+      resumable && pendingTurnOnMount
+        ? pendingTurnOnMount.sessionId
+        : (controlledActiveChatId ?? createChatSessionId());
     const seed = resumable ? pendingTurnOnMount.baseMessages : initialMessages;
     store.seed(sessionId, seed ?? []);
-    const persistedChatId =
-      controlledActiveChatId ??
-      (resumable ? pendingTurnOnMount.persistedChatId : undefined);
+    const persistedChatId = resumable
+      ? (pendingTurnOnMount.persistedChatId ?? controlledActiveChatId)
+      : controlledActiveChatId;
     if (persistedChatId) store.update(sessionId, { persistedChatId });
     return sessionId;
   });
@@ -103,6 +105,23 @@ export function useChatSessions({
     },
     [isControlled, onActiveChatIdChange]
   );
+
+  // A callback marks the hook as host-controlled even when the host has not
+  // supplied an id yet. Publish an OAuth-restored persisted id once so that
+  // callback-only hosts can reconnect their external state to the session.
+  const restoredChatReportedRef = useRef(false);
+  useEffect(() => {
+    if (
+      restoredChatReportedRef.current ||
+      controlledActiveChatId !== undefined ||
+      !onActiveChatIdChange ||
+      !pendingTurnOnMount?.persistedChatId
+    ) {
+      return;
+    }
+    restoredChatReportedRef.current = true;
+    onActiveChatIdChange(pendingTurnOnMount.persistedChatId);
+  }, [controlledActiveChatId, onActiveChatIdChange, pendingTurnOnMount]);
 
   // Under host control the chat id names the session; clearing it leaves the
   // session that was just started alone.

--- a/libraries/typescript/packages/inspector/src/client/components/chat/useChatSessions.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/useChatSessions.ts
@@ -1,11 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { ChatStorageProvider } from "../../chat-history/types";
 import { readPendingChatTurnForServer } from "./chat-auth-retry";
-import {
-  createChatSessionId,
-  resolveActiveChatId,
-  type ChatSessionState,
-} from "./chat-session";
+import { createChatSessionId, type ChatSessionState } from "./chat-session";
 import {
   useChatSessionStore,
   type ChatSessionStore,
@@ -37,8 +33,6 @@ export interface ChatSessions {
   selectChat: (chatId: string) => Promise<ChatSessionState | null>;
   /** Switches to a brand new session; in-flight sessions keep running. */
   startNewChat: () => Promise<string>;
-  /** Resolves the chat id backing the active session, creating it if needed. */
-  ensureActiveChat: () => Promise<string | null>;
   /** Writes a session's messages to its own chat, whichever chat is on screen. */
   persistSessionMessages: (sessionId: string, messages: Message[]) => void;
 }
@@ -63,35 +57,41 @@ export function useChatSessions({
   onChatCreated,
 }: UseChatSessionsParams): ChatSessions {
   const store = useChatSessionStore();
+  const isControlled =
+    controlledActiveChatId !== undefined || onActiveChatIdChange !== undefined;
+  const [pendingTurnOnMount] = useState(() =>
+    readPendingChatTurnForServer(retryServerId)
+  );
 
   // A full-page OAuth redirect drops everything in memory, so the session that
   // was interrupted is read back from storage and reopened here.
   const [activeSessionId, setActiveSessionId] = useState(() => {
-    const pendingTurn = readPendingChatTurnForServer(retryServerId);
     const resumable =
-      pendingTurn != null &&
+      pendingTurnOnMount != null &&
       (!controlledActiveChatId ||
-        pendingTurn.sessionId === controlledActiveChatId);
+        pendingTurnOnMount.sessionId === controlledActiveChatId);
     const sessionId =
       controlledActiveChatId ??
-      (resumable ? pendingTurn.sessionId : createChatSessionId());
-    const seed = resumable ? pendingTurn.baseMessages : initialMessages;
-    if (seed?.length) store.seed(sessionId, seed);
+      (resumable ? pendingTurnOnMount.sessionId : createChatSessionId());
+    const seed = resumable ? pendingTurnOnMount.baseMessages : initialMessages;
+    store.seed(sessionId, seed ?? []);
+    const persistedChatId =
+      controlledActiveChatId ??
+      (resumable ? pendingTurnOnMount.persistedChatId : undefined);
+    if (persistedChatId) store.update(sessionId, { persistedChatId });
     return sessionId;
   });
   const activeSessionIdRef = useRef(activeSessionId);
   activeSessionIdRef.current = activeSessionId;
 
-  const isControlled =
-    controlledActiveChatId !== undefined || onActiveChatIdChange !== undefined;
   const [internalActiveChatId, setInternalActiveChatId] = useState<
     string | null
-  >(null);
-  const activeChatId = resolveActiveChatId(
-    isControlled,
-    controlledActiveChatId,
-    internalActiveChatId
+  >(() =>
+    isControlled ? null : (pendingTurnOnMount?.persistedChatId ?? null)
   );
+  const activeChatId = isControlled
+    ? (controlledActiveChatId ?? null)
+    : internalActiveChatId;
 
   const setActiveChatId = useCallback(
     (chatId: string | null) => {
@@ -108,19 +108,40 @@ export function useChatSessions({
   // session that was just started alone.
   useEffect(() => {
     if (!controlledActiveChatId) return;
-    const session = store.findByPersistedChatId(controlledActiveChatId);
-    setActiveSessionId(session?.id ?? controlledActiveChatId);
+    const session =
+      store.findByPersistedChatId(controlledActiveChatId) ??
+      store.update(controlledActiveChatId, {
+        persistedChatId: controlledActiveChatId,
+      });
+    activeSessionIdRef.current = session.id;
+    setActiveSessionId(session.id);
   }, [controlledActiveChatId, store]);
 
-  const hostMessagesRef = useRef(initialMessages);
+  const hostStateRef = useRef({
+    activeChatId: controlledActiveChatId,
+    messages: initialMessages,
+  });
   useEffect(() => {
-    if (hostMessagesRef.current === initialMessages) return;
-    hostMessagesRef.current = initialMessages;
+    const previous = hostStateRef.current;
+    if (
+      previous.activeChatId === controlledActiveChatId &&
+      previous.messages === initialMessages
+    ) {
+      return;
+    }
+    hostStateRef.current = {
+      activeChatId: controlledActiveChatId,
+      messages: initialMessages,
+    };
     if (initialMessages === undefined) return;
-    store.update(activeSessionIdRef.current, { messages: initialMessages });
-  }, [initialMessages, store]);
+    const sessionId = controlledActiveChatId
+      ? (store.findByPersistedChatId(controlledActiveChatId)?.id ??
+        controlledActiveChatId)
+      : activeSessionIdRef.current;
+    store.update(sessionId, { messages: initialMessages });
+  }, [controlledActiveChatId, initialMessages, store]);
 
-  const ensureSessionChat = useCallback(
+  const getOrCreatePersistedChat = useCallback(
     (sessionId: string): Promise<string | null> => {
       if (!storage) return Promise.resolve(null);
       const session = store.get(sessionId);
@@ -157,12 +178,20 @@ export function useChatSessions({
   const persistSessionMessages = useCallback(
     (sessionId: string, messages: Message[]) => {
       const saveMessages = storage?.saveMessages?.bind(storage);
-      if (!saveMessages || messages.length === 0) return;
-      void ensureSessionChat(sessionId).then((chatId) => {
+      if (!saveMessages) return;
+      const session = store.get(sessionId);
+      if (
+        messages.length === 0 &&
+        !session.persistedChatId &&
+        !session.creation
+      ) {
+        return;
+      }
+      void getOrCreatePersistedChat(sessionId).then((chatId) => {
         if (chatId) void saveMessages(chatId, messages);
       });
     },
-    [ensureSessionChat, storage]
+    [getOrCreatePersistedChat, storage, store]
   );
 
   const selectChat = useCallback(
@@ -200,14 +229,9 @@ export function useChatSessions({
     ) {
       store.delete(previous.id);
     }
-    await ensureSessionChat(sessionId);
+    await getOrCreatePersistedChat(sessionId);
     return sessionId;
-  }, [ensureSessionChat, setActiveChatId, store]);
-
-  const ensureActiveChat = useCallback(
-    () => ensureSessionChat(activeSessionId),
-    [activeSessionId, ensureSessionChat]
-  );
+  }, [getOrCreatePersistedChat, setActiveChatId, store]);
 
   return {
     store,
@@ -215,7 +239,6 @@ export function useChatSessions({
     activeChatId,
     selectChat,
     startNewChat,
-    ensureActiveChat,
     persistSessionMessages,
   };
 }

--- a/libraries/typescript/packages/inspector/src/client/components/chat/useChatSessions.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/useChatSessions.ts
@@ -1,0 +1,221 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { ChatStorageProvider } from "../../chat-history/types";
+import { readPendingChatTurnForServer } from "./chat-auth-retry";
+import {
+  createChatSessionId,
+  resolveActiveChatId,
+  type ChatSessionState,
+} from "./chat-session";
+import {
+  useChatSessionStore,
+  type ChatSessionStore,
+} from "./chat-session-store";
+import type { Message } from "./types";
+
+export interface UseChatSessionsParams {
+  /** Server identity the OAuth retry record is filed under. */
+  retryServerId: string;
+  /** Agent the created chats belong to. */
+  agentId: string;
+  agentName?: string;
+  storage: ChatStorageProvider | null;
+  /** Host-controlled chat id; when set, the host decides which chat is open. */
+  activeChatId?: string;
+  onActiveChatIdChange?: (chatId: string | null) => void;
+  /** Replaces the active session's messages whenever the host swaps them. */
+  initialMessages?: Message[];
+  /** Called after a chat row appears, so history listings can refetch. */
+  onChatCreated?: () => void;
+}
+
+export interface ChatSessions {
+  store: ChatSessionStore;
+  /** Session the UI is showing. Also the chat id, unless storage minted its own. */
+  activeSessionId: string;
+  activeChatId: string | null;
+  /** Opens a chat from history, keeping a live session's in-flight state. */
+  selectChat: (chatId: string) => Promise<ChatSessionState | null>;
+  /** Switches to a brand new session; in-flight sessions keep running. */
+  startNewChat: () => Promise<string>;
+  /** Resolves the chat id backing the active session, creating it if needed. */
+  ensureActiveChat: () => Promise<string | null>;
+  /** Writes a session's messages to its own chat, whichever chat is on screen. */
+  persistSessionMessages: (sessionId: string, messages: Message[]) => void;
+}
+
+/**
+ * Owns the chat session lifecycle: identity, the store every session's state
+ * lives in, and the mapping to persisted chat history.
+ *
+ * A session is created with one id and keeps it. That id is handed to
+ * `ChatStorageProvider.createChat`, so the runtime session and the persisted
+ * chat are the same thing; `persistedChatId` only diverges when a storage
+ * backend insists on minting its own id.
+ */
+export function useChatSessions({
+  retryServerId,
+  agentId,
+  agentName,
+  storage,
+  activeChatId: controlledActiveChatId,
+  onActiveChatIdChange,
+  initialMessages,
+  onChatCreated,
+}: UseChatSessionsParams): ChatSessions {
+  const store = useChatSessionStore();
+
+  // A full-page OAuth redirect drops everything in memory, so the session that
+  // was interrupted is read back from storage and reopened here.
+  const [activeSessionId, setActiveSessionId] = useState(() => {
+    const pendingTurn = readPendingChatTurnForServer(retryServerId);
+    const resumable =
+      pendingTurn != null &&
+      (!controlledActiveChatId ||
+        pendingTurn.sessionId === controlledActiveChatId);
+    const sessionId =
+      controlledActiveChatId ??
+      (resumable ? pendingTurn.sessionId : createChatSessionId());
+    const seed = resumable ? pendingTurn.baseMessages : initialMessages;
+    if (seed?.length) store.seed(sessionId, seed);
+    return sessionId;
+  });
+  const activeSessionIdRef = useRef(activeSessionId);
+  activeSessionIdRef.current = activeSessionId;
+
+  const isControlled =
+    controlledActiveChatId !== undefined || onActiveChatIdChange !== undefined;
+  const [internalActiveChatId, setInternalActiveChatId] = useState<
+    string | null
+  >(null);
+  const activeChatId = resolveActiveChatId(
+    isControlled,
+    controlledActiveChatId,
+    internalActiveChatId
+  );
+
+  const setActiveChatId = useCallback(
+    (chatId: string | null) => {
+      if (isControlled) {
+        onActiveChatIdChange?.(chatId);
+      } else {
+        setInternalActiveChatId(chatId);
+      }
+    },
+    [isControlled, onActiveChatIdChange]
+  );
+
+  // Under host control the chat id names the session; clearing it leaves the
+  // session that was just started alone.
+  useEffect(() => {
+    if (!controlledActiveChatId) return;
+    const session = store.findByPersistedChatId(controlledActiveChatId);
+    setActiveSessionId(session?.id ?? controlledActiveChatId);
+  }, [controlledActiveChatId, store]);
+
+  const hostMessagesRef = useRef(initialMessages);
+  useEffect(() => {
+    if (hostMessagesRef.current === initialMessages) return;
+    hostMessagesRef.current = initialMessages;
+    if (initialMessages === undefined) return;
+    store.update(activeSessionIdRef.current, { messages: initialMessages });
+  }, [initialMessages, store]);
+
+  const ensureSessionChat = useCallback(
+    (sessionId: string): Promise<string | null> => {
+      if (!storage) return Promise.resolve(null);
+      const session = store.get(sessionId);
+      if (session.persistedChatId) {
+        return Promise.resolve(session.persistedChatId);
+      }
+      if (session.creation) return session.creation;
+
+      const creation = storage
+        .createChat({ id: sessionId, agentId, agentName })
+        .then((chat) => {
+          store.update(sessionId, {
+            persistedChatId: chat.id,
+            creation: null,
+          });
+          if (activeSessionIdRef.current === sessionId)
+            setActiveChatId(chat.id);
+          onChatCreated?.();
+          return chat.id;
+        })
+        .catch((error: unknown) => {
+          // History is a convenience — a storage failure must not block chatting.
+          store.update(sessionId, { creation: null });
+          console.error("Failed to create chat history entry:", error);
+          return null;
+        });
+
+      store.update(sessionId, { creation });
+      return creation;
+    },
+    [agentId, agentName, onChatCreated, setActiveChatId, storage, store]
+  );
+
+  const persistSessionMessages = useCallback(
+    (sessionId: string, messages: Message[]) => {
+      const saveMessages = storage?.saveMessages?.bind(storage);
+      if (!saveMessages || messages.length === 0) return;
+      void ensureSessionChat(sessionId).then((chatId) => {
+        if (chatId) void saveMessages(chatId, messages);
+      });
+    },
+    [ensureSessionChat, storage]
+  );
+
+  const selectChat = useCallback(
+    async (chatId: string): Promise<ChatSessionState | null> => {
+      if (!storage) return null;
+      // A session still in memory may be mid-stream; reactivate it as it stands
+      // rather than overwrite it with the last persisted snapshot.
+      let session = store.findByPersistedChatId(chatId);
+      if (!session) {
+        const messages = await storage.getMessages(chatId);
+        store.seed(chatId, messages);
+        session = store.update(chatId, { persistedChatId: chatId });
+      }
+      setActiveSessionId(session.id);
+      activeSessionIdRef.current = session.id;
+      setActiveChatId(chatId);
+      return session;
+    },
+    [setActiveChatId, storage, store]
+  );
+
+  const startNewChat = useCallback(async () => {
+    const previous = store.get(activeSessionIdRef.current);
+    const sessionId = createChatSessionId();
+    setActiveSessionId(sessionId);
+    activeSessionIdRef.current = sessionId;
+    setActiveChatId(null);
+    // Nothing ever went into the chat being left, so drop its record instead of
+    // accumulating empty sessions. Anything in flight keeps its own record.
+    if (
+      previous.messages.length === 0 &&
+      !previous.isLoading &&
+      !previous.persistedChatId &&
+      !previous.creation
+    ) {
+      store.delete(previous.id);
+    }
+    await ensureSessionChat(sessionId);
+    return sessionId;
+  }, [ensureSessionChat, setActiveChatId, store]);
+
+  const ensureActiveChat = useCallback(
+    () => ensureSessionChat(activeSessionId),
+    [activeSessionId, ensureSessionChat]
+  );
+
+  return {
+    store,
+    activeSessionId,
+    activeChatId,
+    selectChat,
+    startNewChat,
+    ensureActiveChat,
+    persistSessionMessages,
+  };
+}


### PR DESCRIPTION
## Summary

- scope messages, loading state, attachments, traces, and streaming runtime to each Inspector chat session
- let **New Chat** activate a fresh session without clearing or cancelling the in-flight session
- keep background session updates associated with and persisted to their original chat history entry
- preserve cached in-flight state when switching between chat history entries

## Root cause

The chat hooks owned a single set of React state and runtime refs for the entire `ChatTab`. Starting a new chat only cleared those shared values, while the existing asynchronous stream and send guard continued to use them. The fresh chat therefore inherited the original session's loading state and could not send.

## Validation

- `pnpm --filter @mcp-use/inspector test:unit` (45 files, 201 tests)
- `pnpm --filter @mcp-use/inspector type-check`
- `pnpm lint:strict`
- `pnpm format:check`
- `pnpm build`
- `pnpm changeset status --since=upstream/main`

Closes #2217

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes all Inspector chat state to a per-session id so New Chat opens a fresh session while earlier replies keep streaming. OAuth retries and chat history now resolve by (server, session) to resume the right chat after redirects and avoid duplicate rows.

- Each session owns its messages, loading, attachments, trace, and runtime in a `ChatSessionStore`. `ChatTab` uses `useChatSessions` to activate or switch sessions without cancelling in‑flight turns; selecting history restores persisted messages without overwriting a live stream.
- Persistence uses the same session id: `ChatStorageProvider.createChat(id?)` adopts it; backends that mint their own ids are tracked via `persistedChatId`. Concurrent writes coalesce per session, and empty untouched drafts are dropped when starting a new chat.
- OAuth retry stores the interrupted turn per server+session and records which session initiated the redirect. Use `readPendingChatTurn(serverId, sessionId)`, `readPendingChatTurnForServer(serverId)`, and `clearPendingChatTurn(serverId, sessionId)`. After reload, the interrupted session reopens and replays its turn. Authentication waits briefly for a backend-minted chat id but never blocks on stalled history.
- Controlled hosts are respected: `activeChatId` can be state or callback-only. Restored chats are reported via the callback, and clearing the id does not snap back to the previous session.

**Migration**

- `ChatStorageProvider.createChat` now accepts optional `id`. Providers must adopt it and, when present, return the existing chat instead of creating a duplicate. Providers that mint their own id may ignore it and return their id; callers keep the returned value.

<sup>Written for commit 4c9b7b57d481b4d6552a3d0a3266ff1154e9bdfe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

