### PR TITLE
fix(cli): route Vibe HMR through public origin

### DIFF
--- a/libraries/typescript/.changeset/bright-widgets-connect.md
+++ b/libraries/typescript/.changeset/bright-widgets-connect.md
@@ -1,0 +1,6 @@
+---
+"@mcp-use/cli": patch
+"mcp-use": patch
+---
+
+Route Vite assets and HMR through the configured public MCP origin when the development server runs behind a remote sandbox or proxy.

--- a/libraries/typescript/packages/cli/src/cli/dev-client-endpoint.ts
+++ b/libraries/typescript/packages/cli/src/cli/dev-client-endpoint.ts
@@ -1,0 +1,56 @@
+/** Browser-facing development asset origin and Vite HMR socket address. */
+export interface DevClientEndpoint {
+  origin: string;
+  hmr: {
+    protocol: "ws" | "wss";
+    host: string;
+    clientPort: number;
+  };
+}
+
+function configuredOrigin(mcpUrl: string | undefined): URL | null {
+  if (!mcpUrl) return null;
+  try {
+    const url = new URL(mcpUrl);
+    if (
+      (url.protocol !== "http:" && url.protocol !== "https:") ||
+      url.username ||
+      url.password
+    ) {
+      return null;
+    }
+    return new URL(url.origin);
+  } catch {
+    return null;
+  }
+}
+
+/** Resolve the browser-facing Vite asset and HMR endpoint. */
+export function resolveDevClientEndpoint(
+  host: string,
+  port: number,
+  mcpUrl: string | undefined
+): DevClientEndpoint {
+  const loopbackOrWildcard = ["127.0.0.1", "localhost", "0.0.0.0", "::", "::1"];
+  const browsableHost = loopbackOrWildcard.includes(host) ? "localhost" : host;
+  const fallback = new URL(
+    `http://${
+      browsableHost.includes(":") ? `[${browsableHost}]` : browsableHost
+    }:${port}`
+  );
+  const publicOrigin = configuredOrigin(mcpUrl) ?? fallback;
+  const secure = publicOrigin.protocol === "https:";
+
+  return {
+    origin: publicOrigin.origin,
+    hmr: {
+      protocol: secure ? "wss" : "ws",
+      host: publicOrigin.hostname,
+      clientPort: publicOrigin.port
+        ? Number(publicOrigin.port)
+        : secure
+          ? 443
+          : 80,
+    },
+  };
+}

--- a/libraries/typescript/packages/cli/src/cli/dev.ts
+++ b/libraries/typescript/packages/cli/src/cli/dev.ts
@@ -45,6 +45,7 @@ import {
   resolvePort as resolvePreferredPort,
 } from "../bin/args.js";
 import { discoverEntry } from "./entry.js";
+import { resolveDevClientEndpoint } from "./dev-client-endpoint.js";
 import {
   loadProjectEnv,
   nextStandaloneCompatPlugin,
@@ -419,16 +420,11 @@ export async function runDev(options: DevOptions): Promise<void> {
   const viewsAtStartup = currentViews.length > 0;
   const userViteConfig = resolveUserViteConfig(options.cwd);
 
-  // The bind address is not always a browsable address: `0.0.0.0`/`::`
-  // accept connections on every interface but are not valid request hosts
-  // in every browser, and `127.0.0.1` reads worse than `localhost` in logs.
-  // Anything else (a LAN IP, a hostname) is browsable as itself; bare IPv6
-  // addresses need brackets in URLs.
-  const loopbackOrWildcard = ["127.0.0.1", "localhost", "0.0.0.0", "::", "::1"];
-  const browsableHost = loopbackOrWildcard.includes(host) ? "localhost" : host;
-  const devOrigin = `http://${
-    browsableHost.includes(":") ? `[${browsableHost}]` : browsableHost
-  }:${port}`;
+  const devClientEndpoint = resolveDevClientEndpoint(
+    host,
+    port,
+    process.env["MCP_URL"]
+  );
 
   const vite = await createServer({
     root: options.cwd,
@@ -476,7 +472,7 @@ export async function runDev(options: DevOptions): Promise<void> {
       }),
       // Absolute asset URLs in dev: without `origin`, Vite emits root-relative
       // paths that resolve against the host page inside srcdoc iframes.
-      ...(viewsAtStartup && { origin: devOrigin }),
+      ...(viewsAtStartup && { origin: devClientEndpoint.origin }),
       // CORS on module URLs is owned by onRequest below (permissive ACAO
       // only while the tunnel is active), not by Vite's own middleware —
       // whose default localhost-only policy would block tunnel-rendering
@@ -485,7 +481,9 @@ export async function runDev(options: DevOptions): Promise<void> {
       // View HMR rides the one HTTP listener: Vite attaches its websocket
       // upgrade handler to our server, so no dedicated HMR port exists to
       // collide when several dev processes run side by side.
-      hmr: viewsAtStartup ? { server: httpServer } : false,
+      hmr: viewsAtStartup
+        ? { server: httpServer, ...devClientEndpoint.hmr }
+        : false,
       // Vite 8's Environment API keeps its WebSocket transport enabled when
       // only `hmr: false` is set. Zero-view servers need no socket at all.
       ...(!viewsAtStartup && { ws: false }),
@@ -597,7 +595,7 @@ export async function runDev(options: DevOptions): Promise<void> {
     }
     const mounted = inspectorModule.mountInspector({
       basePath: nextBasePath,
-      autoConnectUrl: `${devOrigin}${nextBasePath}`,
+      autoConnectUrl: `${devClientEndpoint.origin}${nextBasePath}`,
       oauthProxyAllowLoopback: localhostBind || wildcardBind,
       devMode: true,
       manufactChatUrl: process.env["MANUFACT_CHAT_URL"],
@@ -985,9 +983,11 @@ export async function runDev(options: DevOptions): Promise<void> {
       `  ➜ Views:         ${currentViews.map((v) => v.name).join(", ")}`
     );
   }
-  console.log(`  ➜ MCP endpoint:  ${devOrigin}${basePath}`);
+  console.log(`  ➜ MCP endpoint:  ${devClientEndpoint.origin}${basePath}`);
   if (inspectorHandler !== undefined) {
-    console.log(`  ➜ Inspector:     ${devOrigin}${basePath}/inspector`);
+    console.log(
+      `  ➜ Inspector:     ${devClientEndpoint.origin}${basePath}/inspector`
+    );
   } else if (options.inspector !== false) {
     console.warn(
       "[mcp-use] Built-in Inspector is unavailable; reinstall mcp-use to " +
@@ -1025,7 +1025,7 @@ export async function runDev(options: DevOptions): Promise<void> {
     options.open !== false &&
     process.stdout.isTTY === true
   ) {
-    openInBrowser(`${devOrigin}${basePath}/inspector`);
+    openInBrowser(`${devClientEndpoint.origin}${basePath}/inspector`);
   }
 
   // --- Graceful shutdown (SIGINT/SIGTERM or options.signal). ---------------

--- a/libraries/typescript/packages/cli/tests/cli/dev-client-endpoint.test.ts
+++ b/libraries/typescript/packages/cli/tests/cli/dev-client-endpoint.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveDevClientEndpoint } from "../../src/cli/dev-client-endpoint.js";
+
+describe("resolveDevClientEndpoint", () => {
+  it("uses the public MCP origin for remote sandbox assets and HMR", () => {
+    expect(
+      resolveDevClientEndpoint(
+        "0.0.0.0",
+        3000,
+        "https://sb-example.sandbox.dev.manufact.com/mcp"
+      )
+    ).toEqual({
+      origin: "https://sb-example.sandbox.dev.manufact.com",
+      hmr: {
+        protocol: "wss",
+        host: "sb-example.sandbox.dev.manufact.com",
+        clientPort: 443,
+      },
+    });
+  });
+
+  it("keeps local development on the selected listener port", () => {
+    expect(resolveDevClientEndpoint("127.0.0.1", 43127, undefined)).toEqual({
+      origin: "http://localhost:43127",
+      hmr: {
+        protocol: "ws",
+        host: "localhost",
+        clientPort: 43127,
+      },
+    });
+  });
+
+  it("uses explicit non-default public ports", () => {
+    expect(
+      resolveDevClientEndpoint(
+        "0.0.0.0",
+        3000,
+        "https://sandbox.example.test:8443/api/mcp"
+      )
+    ).toMatchObject({
+      origin: "https://sandbox.example.test:8443",
+      hmr: {
+        protocol: "wss",
+        host: "sandbox.example.test",
+        clientPort: 8443,
+      },
+    });
+  });
+
+  it("ignores credential-bearing public URLs", () => {
+    expect(
+      resolveDevClientEndpoint(
+        "0.0.0.0",
+        3000,
+        "https://token@example.test/mcp"
+      )
+    ).toMatchObject({
+      origin: "http://localhost:3000",
+      hmr: { protocol: "ws", host: "localhost", clientPort: 3000 },
+    });
+  });
+});

--- a/libraries/typescript/packages/cli/tests/cli/dev.test.ts
+++ b/libraries/typescript/packages/cli/tests/cli/dev.test.ts
@@ -113,7 +113,7 @@ async function startDev(
       if (startupError !== undefined) throw startupError;
       return lines.find((l) => l.includes("MCP endpoint"));
     });
-    const url = /(http:\/\/\S+)/.exec(endpointLine)?.[1];
+    const url = /(https?:\/\/\S+)/.exec(endpointLine)?.[1];
     if (url === undefined) throw new Error(`no URL in: ${endpointLine}`);
     return {
       url,
@@ -1022,13 +1022,14 @@ async function rawGetBody(
 
 describe("runDev (views)", () => {
   it("serves Vite modules through a public sandbox hostname", async () => {
+    process.env["MCP_URL"] = "https://sandbox.example.com/mcp";
     const cwd = copyFixture("dev-views", "views");
     cleanups.push(() => removeDir(cwd));
 
     const port = await getFreePort("0.0.0.0");
     const dev = await startDev(cwd, port, "0.0.0.0");
     cleanups.push(dev.stop);
-    const base = dev.url.replace(/\/mcp$/, "");
+    const base = `http://127.0.0.1:${port}`;
     const moduleUrl = `${base}/@vite/client`;
 
     expect(
@@ -1047,6 +1048,10 @@ describe("runDev (views)", () => {
     });
     expect(response.status).toBe(200);
     expect(response.headers.get("access-control-allow-origin")).toBe("*");
+    const viteClient = await response.text();
+    expect(viteClient).toContain("sandbox.example.com");
+    expect(viteClient).toContain('const socketProtocol = "wss"');
+    expect(viteClient).toContain("const hmrPort = 443");
   });
 
   it("shuts down with active MCP subscriptions and HMR WebSockets", async () => {


### PR DESCRIPTION
## Summary

- derive browser-facing Vite asset and HMR endpoints from `MCP_URL` when running behind a public sandbox
- keep local and wildcard-host development on the selected local port
- add a patch Changeset for `@mcp-use/cli` and `mcp-use`

## Validation

- `pnpm --filter mcp-use... build`
- `pnpm --filter @mcp-use/cli typecheck`
- `pnpm --filter @mcp-use/cli exec vitest run tests/cli/dev-client-endpoint.test.ts tests/cli/dev.test.ts` (38 tests)
- targeted ESLint and Prettier checks
- `pnpm exec changeset status --since=origin/canary`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes Vite dev assets and HMR through the public MCP origin from MCP_URL when running in a remote sandbox/proxy, fixing broken HMR and module loading. Local and wildcard-host dev continue to use the chosen local port.

- **Bug Fixes**
  - Resolve browser-facing asset origin and HMR socket from `MCP_URL`, with a safe local fallback.
  - Use `wss` and public ports for HTTPS origins; keep `ws` and local port for local dev.
  - Integrate `resolveDevClientEndpoint` into Vite `origin`/`hmr` and Inspector URLs.
  - Add tests for public origin, local dev, explicit non-default ports, and credentialed URL rejection; add patch changeset for `@mcp-use/cli` and `mcp-use`.

<sup>Written for commit 0ecca600498b1f192bca3159babae2afcdd44bb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

