### PR TITLE
feat(server): export createJwtVerifier from mcp-use/oauth

### DIFF
--- a/libraries/typescript/.changeset/olive-pugs-repeat.md
+++ b/libraries/typescript/.changeset/olive-pugs-repeat.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": minor
+---
+
+Export `createJwtVerifier` and its `JwtVerifierOptions` and `VerifiedPayload` types from `mcp-use/oauth`, so a custom OAuth provider built with `oauthCustomProvider` can reuse the built-in JWT verification instead of reimplementing it.

--- a/libraries/typescript/packages/server/src/oauth/index.ts
+++ b/libraries/typescript/packages/server/src/oauth/index.ts
@@ -23,6 +23,11 @@ export type {
 
 export { bearerAuth, oauthMetadata } from "./adapters.js";
 export {
+  createJwtVerifier,
+  type JwtVerifierOptions,
+  type VerifiedPayload,
+} from "./jwt.js";
+export {
   oauthCustomProvider,
   type CustomOAuthProviderOptions,
   type OAuthExtra,

--- a/libraries/typescript/packages/server/src/oauth/jwt.ts
+++ b/libraries/typescript/packages/server/src/oauth/jwt.ts
@@ -15,13 +15,16 @@ import { isLocalhost, isRecord } from "./guards.js";
 
 export { invalidToken } from "./errors.js";
 
-/** @internal Record of claims extracted from a verified JWT. */
+/** Record of claims extracted from a verified JWT. */
 export type VerifiedPayload = Record<string, unknown>;
 
-/** @internal Configures issuer, keys, and claims enforced by a JWT verifier. */
+/** Configures issuer, keys, and claims enforced by a JWT verifier. */
 export interface JwtVerifierOptions {
+  /** Expected `iss` claim. Tokens from any other issuer are rejected. */
   issuer: string;
+  /** JWKS endpoint the signing keys are fetched from and cached. */
   jwksUrl: URL;
+  /** Canonical URL of this MCP resource, matched against the token binding. */
   resource: URL;
   /** Provider-specific JWT audience, when it differs from the MCP resource. */
   audience?: string | string[];
@@ -31,11 +34,23 @@ export interface JwtVerifierOptions {
    * than an aud/resource claim.
    */
   issuerBoundAccessTokens?: boolean;
+  /** Permitted JWS algorithms. Defaults to whatever the JWKS advertises. */
   algorithms?: readonly string[];
+  /** Symmetric key material, for providers that sign without a JWKS. */
   key?: Uint8Array;
 }
 
-/** @internal Creates a verifier that rejects JWTs with invalid signatures or required claims. */
+/**
+ * Creates a verifier that rejects JWTs with invalid signatures or required claims.
+ *
+ * Use this when implementing a custom OAuth provider with
+ * {@link oauthCustomProvider}, so a provider that issues standard JWTs does not
+ * have to reimplement signature, issuer, audience and expiry checking.
+ *
+ * @param options - Issuer, keys, and claims to enforce.
+ * @returns A verifier accepted anywhere an `OAuthTokenVerifier` is taken.
+ * @throws TypeError if `audience` is combined with `issuerBoundAccessTokens`.
+ */
 export function createJwtVerifier(
   options: JwtVerifierOptions
 ): OAuthTokenVerifier {


### PR DESCRIPTION
Closes #2215.

### The gap

`mcp-use/oauth` already exports `oauthCustomProvider` and `CustomOAuthProviderOptions`, so building a custom provider is a supported path. But `createJwtVerifier` stayed internal, so anyone taking that path had to hand-roll signature verification, issuer and audience matching, `exp`/`sub` enforcement and the resource binding, all of which the six built-in providers already share through this one function.

`src/oauth/jwt.ts` is not reachable from any entry point in `package.json`, so there was no way to reach it short of importing from `dist` internals.

### The change

Export `createJwtVerifier` from the `./oauth` barrel, together with the two types you need to call it and to consume its result:

- `JwtVerifierOptions`, the argument type
- `VerifiedPayload`, the claims record

`OAuthTokenVerifier`, the return type, was already exported from that barrel.

All three carried `@internal`, so I removed those tags. The package requires TSDoc on public exports including type properties, so `issuer`, `jwksUrl`, `resource`, `algorithms` and `key` are now documented too, and `createJwtVerifier` gained `@param`, `@returns` and a `@throws` for the case where `audience` is combined with `issuerBoundAccessTokens`.

### Verified

Built and checked the published surface rather than assuming:

```
$ grep createJwtVerifier packages/server/dist/oauth/index.d.ts
export { createJwtVerifier, type JwtVerifierOptions, type VerifiedPayload, } from "./jwt.js";

$ node -e "import('./packages/server/dist/oauth/index.js').then(m=>console.log(typeof m.createJwtVerifier))"
function
```

Server suite: 446 passed. Three failures in `tests/usage.test.ts` are pre-existing on `canary` and unrelated to this change: they only appear when `MCP_USE_ANONYMIZED_TELEMETRY=false` is set, and they fail identically with my diff stashed.

No behavior change, only visibility.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exported `createJwtVerifier` from `mcp-use/oauth` so custom providers built with `oauthCustomProvider` can reuse built-in JWT verification instead of reimplementing it. No runtime behavior changes.

- **New Features**
  - Export `createJwtVerifier`, `JwtVerifierOptions`, and `VerifiedPayload` from `mcp-use/oauth`.
  - Added TSDoc for new public options and removed `@internal` tags.

<sup>Written for commit 440b10040b4ed8f42f77b40b10ae317ce6312f3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

