### PR TITLE
fix(cli): prebundle the Vibe view runtime

### DIFF
--- a/libraries/typescript/.changeset/cold-views-warm.md
+++ b/libraries/typescript/.changeset/cold-views-warm.md
@@ -1,0 +1,6 @@
+---
+"@mcp-use/cli": patch
+"mcp-use": patch
+---
+
+Pre-bundle the non-React MCP Apps view runtime dependencies so cold dev views finish mounting instead of entering a Vite full-reload loop before HMR can take over.

--- a/libraries/typescript/packages/cli/src/cli/dev.ts
+++ b/libraries/typescript/packages/cli/src/cli/dev.ts
@@ -444,7 +444,10 @@ export async function runDev(options: DevOptions): Promise<void> {
     // unversioned optimizer URL while view source receives a versioned URL.
     // Serving the framework entry as ESM keeps both imports on one dispatcher;
     // its CommonJS ReactDOM dependency still needs explicit optimization.
-    optimizeDeps: VIEW_REACT_OPTIMIZE_DEPS,
+    // Tool-only projects do not load a browser view graph. Avoid starting a
+    // dependency optimizer for them: on Windows its background cache commit
+    // can otherwise outlive Vite shutdown and race fixture/project cleanup.
+    ...(viewsAtStartup && { optimizeDeps: VIEW_REACT_OPTIMIZE_DEPS }),
     oxc: { jsx: { runtime: "automatic" } },
     plugins: viewsAtStartup
       ? [

--- a/libraries/typescript/packages/cli/src/cli/views-plugin.ts
+++ b/libraries/typescript/packages/cli/src/cli/views-plugin.ts
@@ -21,7 +21,18 @@ export const VIEW_REACT_DEDUPE = ["react", "react-dom"];
  */
 export const VIEW_REACT_OPTIMIZE_DEPS = {
   exclude: ["mcp-use/react"],
-  include: ["react", "react-dom", "react-dom/client"],
+  include: [
+    "react",
+    "react-dom",
+    "react-dom/client",
+    // The ESM view runtime must stay outside the optimizer so it shares the
+    // view's React dispatcher, but its non-React protocol dependencies are
+    // large enough that discovering them lazily makes Vite emit a full reload
+    // during every cold iframe boot. Pre-bundle those leaves up front so the
+    // first document can finish mounting and subsequent edits use Fast Refresh.
+    "mcp-use > @modelcontextprotocol/ext-apps",
+    "mcp-use > @modelcontextprotocol/server",
+  ],
 };
 
 /**

--- a/libraries/typescript/packages/cli/tests/cli/build.test.ts
+++ b/libraries/typescript/packages/cli/tests/cli/build.test.ts
@@ -404,7 +404,13 @@ describe("runBuild (views)", () => {
       resolve: { dedupe: ["react", "react-dom"] },
       optimizeDeps: {
         exclude: ["mcp-use/react"],
-        include: ["react", "react-dom", "react-dom/client"],
+        include: [
+          "react",
+          "react-dom",
+          "react-dom/client",
+          "mcp-use > @modelcontextprotocol/ext-apps",
+          "mcp-use > @modelcontextprotocol/server",
+        ],
       },
     });
 

--- a/libraries/typescript/packages/cli/tests/cli/dev.test.ts
+++ b/libraries/typescript/packages/cli/tests/cli/dev.test.ts
@@ -1452,6 +1452,21 @@ describe("runDev (views)", () => {
     expect(entryJs).toContain("import * as viewModule from");
     expect(entryJs).toContain("bootstrapView(viewModule)");
 
+    const messages: { type: string; updates?: { path: string }[] }[] = [];
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/`, "vite-hmr");
+    ws.addEventListener("message", (event) => {
+      messages.push(
+        JSON.parse(String(event.data)) as (typeof messages)[number]
+      );
+    });
+    await new Promise<void>((resolve, reject) => {
+      ws.addEventListener("open", () => resolve());
+      ws.addEventListener("error", () =>
+        reject(new Error("HMR websocket failed to connect"))
+      );
+    });
+    cleanups.push(() => ws.close());
+
     // Populate the client module graph the way a browser loading the view
     // document would: fetch each module and, recursively, its static
     // imports. A 504 is Vite's "outdated optimize dep" — retry like a
@@ -1481,24 +1496,11 @@ describe("runDev (views)", () => {
     // Fast Refresh wrapped the view component module.
     expect(await viewModule.text()).toContain("RefreshRuntime");
 
-    const messages: { type: string; updates?: { path: string }[] }[] = [];
-    const ws = new WebSocket(`ws://127.0.0.1:${port}/`, "vite-hmr");
-    ws.addEventListener("message", (event) => {
-      messages.push(
-        JSON.parse(String(event.data)) as (typeof messages)[number]
-      );
-    });
-    await new Promise<void>((resolve, reject) => {
-      ws.addEventListener("open", () => resolve());
-      ws.addEventListener("error", () =>
-        reject(new Error("HMR websocket failed to connect"))
-      );
-    });
-    cleanups.push(() => ws.close());
-
-    // Let any dep-optimizer churn from the initial module loads settle so
-    // the assertion window only contains the edit's own messages.
+    // Cold-loading the view runtime must not ask the iframe to reload. Vibe's
+    // srcdoc guest is torn down by a full reload before its module graph can
+    // finish, so lazy optimizer discovery otherwise becomes a reload loop.
     await new Promise((r) => setTimeout(r, 1000));
+    expect(messages.filter((m) => m.type === "full-reload")).toEqual([]);
     messages.length = 0;
 
     const viewPath = join(cwd, "views", "product-search-result", "view.tsx");


### PR DESCRIPTION
## Summary
- prebundle the MCP Apps protocol dependencies used by `mcp-use/react`
- prevent Vite from emitting a cold-start `full-reload` that tears down Vibe srcdoc guests
- cover the browser ordering by opening HMR before crawling the initial module graph

## Verification
- `pnpm --filter @mcp-use/cli typecheck`
- focused Prettier and ESLint checks
- `pnpm --filter @mcp-use/cli exec vitest run tests/cli/dev-client-endpoint.test.ts tests/cli/dev.test.ts` (38 passed)
- `pnpm changeset status`

Live diagnosis: the public Vite socket connected on the sandbox hostname, then repeatedly received `{type: "full-reload"}` while lazy optimizer discovery reported `@modelcontextprotocol/ext-apps`. The regression test now opens the socket before the cold module crawl and requires zero full reloads.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pre-bundles the Vibe view runtime’s non-React MCP Apps protocol deps and fixes HMR startup ordering to stop cold-start `full-reload` loops. Also skips view optimization when no views load at startup (tool-only dev) to avoid optimizer races on Windows.

- **Bug Fixes**
  - Pre-bundle protocol deps for the view runtime: `mcp-use > @modelcontextprotocol/ext-apps`, `mcp-use > @modelcontextprotocol/server`; keep `mcp-use/react` out of optimization to share the view’s React dispatcher.
  - Open the HMR socket before crawling the initial module graph to prevent `Vite` from emitting `full-reload` during first load of srcdoc guests; tests connect HMR before the crawl, assert zero `full-reload` on cold load, and lock optimizer includes in build tests.
  - Skip starting the view dependency optimizer when no views are present at startup to avoid lingering background cache commits on Windows during tool-only dev.

<sup>Written for commit a334f5bba09270ffecee84f3805168ce497cc978. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

