### PR TITLE
fix(cli): prebundle Zod for Vibe views

### DIFF
--- a/libraries/typescript/.changeset/warm-zebras-compile.md
+++ b/libraries/typescript/.changeset/warm-zebras-compile.md
@@ -1,0 +1,6 @@
+---
+"@mcp-use/cli": patch
+"mcp-use": patch
+---
+
+Pre-bundle Zod for dev views so the published MCP Apps starter does not enter a Vite full-reload loop while its protocol runtime initializes.

--- a/libraries/typescript/packages/cli/src/cli/views-plugin.ts
+++ b/libraries/typescript/packages/cli/src/cli/views-plugin.ts
@@ -32,6 +32,11 @@ export const VIEW_REACT_OPTIMIZE_DEPS = {
     // first document can finish mounting and subsequent edits use Fast Refresh.
     "mcp-use > @modelcontextprotocol/ext-apps",
     "mcp-use > @modelcontextprotocol/server",
+    // The published MCP Apps starter installs Zod at the project root. The
+    // Apps runtime reaches it through a lazy protocol-runtime import, which
+    // Vite's static scan cannot see; discovering it after the HMR socket is
+    // connected otherwise emits a full reload on every iframe cold boot.
+    "zod",
   ],
 };
 

--- a/libraries/typescript/packages/cli/tests/cli/build.test.ts
+++ b/libraries/typescript/packages/cli/tests/cli/build.test.ts
@@ -410,6 +410,7 @@ describe("runBuild (views)", () => {
           "react-dom/client",
           "mcp-use > @modelcontextprotocol/ext-apps",
           "mcp-use > @modelcontextprotocol/server",
+          "zod",
         ],
       },
     });


### PR DESCRIPTION
## Summary

- pre-bundle root `zod` in Vite view development
- cover the optimizer contract in the build configuration test
- publish patch releases for `@mcp-use/cli` and `mcp-use`

## Why

The published MCP Apps starter installs Zod at the project root. Its view reaches Zod through a lazy protocol-runtime import that Vite's initial static scan cannot discover. On the first iframe boot, Vite optimized Zod after the HMR socket was already connected, returning a 504 and broadcasting `full-reload`. In Vibe this leaves the app iframe on **Compiling...** and prevents Fast Refresh.

## Validation

- Exact current starter generated with `create-mcp-use-app@canary --template mcp-apps --sdk-version canary`
- Before: HMR frames `connected`, then `full-reload`; view graph hit HTTP 504; Vite logged `new dependencies found: zod`
- After: full view graph crawled (23 modules), HMR remains connected, 0 full reloads
- `pnpm --filter @mcp-use/cli typecheck`
- Prettier and ESLint on changed files
- `pnpm --filter @mcp-use/cli exec vitest run tests/cli/dev-client-endpoint.test.ts tests/cli/dev.test.ts tests/cli/build.test.ts` (62 passed)
- Changeset status and `git diff --check`
