### PR TITLE
fix(cli): ignore Vibe dev server logs in HMR

### DIFF
--- a/libraries/typescript/.changeset/quiet-pandas-refresh.md
+++ b/libraries/typescript/.changeset/quiet-pandas-refresh.md
@@ -1,0 +1,6 @@
+---
+"@mcp-use/cli": patch
+"mcp-use": patch
+---
+
+Ignore Vibe's managed dev-server log in Vite's file watcher so operational log writes do not trigger endless full reloads instead of view HMR.

--- a/libraries/typescript/packages/cli/src/cli/dev.ts
+++ b/libraries/typescript/packages/cli/src/cli/dev.ts
@@ -462,17 +462,25 @@ export async function runDev(options: DevOptions): Promise<void> {
       : [nextStandaloneCompatPlugin(options.cwd)],
     server: {
       middlewareMode: true,
+      watch: {
+        // Vibe captures the managed dev process output in the project root.
+        // Watching that continuously-written operational file makes Vite
+        // broadcast `full-reload` forever, so srcdoc view guests repeatedly
+        // remount and surface a compiling spinner instead of Fast Refresh.
+        ignored: "**/.dev-server-logs.txt",
+        // Windows file notifications can be coalesced or dropped while Vite
+        // is transforming the same module. Polling keeps dev reloads reliable.
+        ...(process.platform === "win32" && {
+          usePolling: true,
+          interval: 100,
+        }),
+      },
       // A public/wildcard bind deliberately accepts hostnames that are only
       // known to the surrounding platform (for example a sandbox URL). Keep
       // Vite's own static Host allowlist aligned with the listener boundary;
       // localhost binds retain the stricter default and our dynamic tunnel
       // path rewrites an authorized tunnel Host to localhost below.
       ...(!localhostBind && { allowedHosts: true }),
-      // Windows file notifications can be coalesced or dropped while Vite is
-      // transforming the same module. Polling keeps dev reloads reliable.
-      ...(process.platform === "win32" && {
-        watch: { usePolling: true, interval: 100 },
-      }),
       // Absolute asset URLs in dev: without `origin`, Vite emits root-relative
       // paths that resolve against the host page inside srcdoc iframes.
       ...(viewsAtStartup && { origin: devClientEndpoint.origin }),

--- a/libraries/typescript/packages/cli/tests/cli/dev.test.ts
+++ b/libraries/typescript/packages/cli/tests/cli/dev.test.ts
@@ -1503,6 +1503,13 @@ describe("runDev (views)", () => {
     expect(messages.filter((m) => m.type === "full-reload")).toEqual([]);
     messages.length = 0;
 
+    // Vibe writes managed-process output into this root-level file. It is not
+    // application source and must not produce the endless full-reload loop
+    // that tears down the srcdoc guest before Fast Refresh can run.
+    writeFileSync(join(cwd, ".dev-server-logs.txt"), "dev process output\n");
+    await new Promise((r) => setTimeout(r, 300));
+    expect(messages).toEqual([]);
+
     const viewPath = join(cwd, "views", "product-search-result", "view.tsx");
     const viewSource = readFileSync(viewPath, "utf8");
     // Vibe's remote filesystem can surface an editor save as unlink + add


### PR DESCRIPTION
## Summary

- ignore Vibe's managed `.dev-server-logs.txt` in the Vite watcher
- preserve Windows polling while sharing the watcher configuration
- extend the real HMR WebSocket regression test to prove log writes emit no reload and view edits still emit an update
- add patch changesets for `@mcp-use/cli` and `mcp-use`

## Why

Vibe captures the managed dev process output in the project root. Every write was treated as an unrelated file change, causing Vite to broadcast `full-reload` continuously. The srcdoc app guest was repeatedly torn down, surfacing a compiling spinner instead of Fast Refresh.

## Validation

- `pnpm --dir libraries/typescript --filter mcp-use... build`
- `pnpm exec vitest run tests/cli/dev.test.ts -t "hot-updates a view.tsx edit"`
- `pnpm --dir libraries/typescript --filter @mcp-use/cli typecheck`
- Prettier and ESLint on changed files


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignore Vibe’s managed `.dev-server-logs.txt` in the Vite watcher to stop endless full reloads and restore reliable HMR. Keeps Windows polling and adds a test proving log writes don’t reload while view edits still hot-update.

- **Bug Fixes**
  - Ignore `**/.dev-server-logs.txt` in `server.watch` to prevent full-reload loops from log writes.
  - Preserve Windows polling (`usePolling: true`, `interval: 100`) while sharing watcher config.
  - Extend HMR test: log writes emit no reload; view edits still emit update.
  - Add patch changesets for `@mcp-use/cli` and `mcp-use`.

<sup>Written for commit c0605da946dd32449ede4793af9e3f957c3bcc62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

