### PR TITLE
fix(inspector): render streamed MCP App results

### DIFF
--- a/libraries/typescript/.changeset/calm-widgets-render.md
+++ b/libraries/typescript/.changeset/calm-widgets-render.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Forward streamed MCP App tool results when chat providers complete a call by mutating the existing result object.

--- a/libraries/typescript/packages/inspector/src/client/components/chat/ToolResultRenderer.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/ToolResultRenderer.tsx
@@ -6,6 +6,7 @@ import { McpAppsViewPanel } from "@/client/components/mcp-apps/McpAppsViewPanel"
 import { useWidgetDebug } from "../../context/WidgetDebugContext";
 import { Spinner } from "../ui/spinner";
 import type { LLMConfig } from "./types";
+import { useToolResultSnapshot } from "./useToolResultSnapshot";
 
 function ModelContextBadge({ widgetId }: { widgetId: string }) {
   const { getWidget } = useWidgetDebug();
@@ -59,17 +60,18 @@ export function ToolResultRenderer({
 
   const [displayMode, setDisplayMode] = useState<ViewDisplayMode>("inline");
 
+  const resultSnapshot = useToolResultSnapshot(result);
   const parsedResult = useMemo(() => {
-    if (!result) return null;
-    if (typeof result === "string") {
+    if (!resultSnapshot) return null;
+    if (typeof resultSnapshot === "string") {
       try {
-        return JSON.parse(result);
+        return JSON.parse(resultSnapshot);
       } catch {
-        return result;
+        return resultSnapshot;
       }
     }
-    return result;
-  }, [result]);
+    return resultSnapshot;
+  }, [resultSnapshot]);
 
   const isMcpAppsTool = isViewTool(toolMeta);
   const resourceUri = isMcpAppsTool

--- a/libraries/typescript/packages/inspector/src/client/components/chat/__tests__/useToolResultSnapshot.test.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/__tests__/useToolResultSnapshot.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { updateToolResultSnapshot } from "../useToolResultSnapshot";
+
+describe("updateToolResultSnapshot", () => {
+  it("observes a streamed result that is completed by in-place mutation", () => {
+    const result: {
+      content?: Array<{ type: string; text: string }>;
+      structuredContent?: { message: string };
+    } = {};
+    const pendingSnapshot = updateToolResultSnapshot(null, result);
+
+    result.content = [{ type: "text", text: "Ready" }];
+    result.structuredContent = { message: "Ready" };
+    const completedSnapshot = updateToolResultSnapshot(pendingSnapshot, result);
+
+    expect(completedSnapshot).not.toBe(pendingSnapshot);
+    expect(completedSnapshot.value).toEqual({
+      content: [{ type: "text", text: "Ready" }],
+      structuredContent: { message: "Ready" },
+    });
+    expect(pendingSnapshot.value).toEqual({});
+  });
+
+  it("keeps the snapshot stable when the result content has not changed", () => {
+    const result = { structuredContent: { message: "Ready" } };
+    const firstSnapshot = updateToolResultSnapshot(null, result);
+    const secondSnapshot = updateToolResultSnapshot(firstSnapshot, result);
+
+    expect(secondSnapshot).toBe(firstSnapshot);
+  });
+});

--- a/libraries/typescript/packages/inspector/src/client/components/chat/useToolResultSnapshot.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/useToolResultSnapshot.ts
@@ -1,0 +1,50 @@
+import { useRef } from "react";
+
+export interface ToolResultSnapshot<T> {
+  fingerprint: string;
+  value: T;
+}
+
+function fingerprintToolResult(value: unknown): string {
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function cloneToolResult<T>(value: T): T {
+  if (value === null || typeof value !== "object") return value;
+
+  try {
+    return structuredClone(value);
+  } catch {
+    try {
+      return JSON.parse(JSON.stringify(value)) as T;
+    } catch {
+      return value;
+    }
+  }
+}
+
+export function updateToolResultSnapshot<T>(
+  previous: ToolResultSnapshot<T> | null,
+  value: T
+): ToolResultSnapshot<T> {
+  const fingerprint = fingerprintToolResult(value);
+  if (previous?.fingerprint === fingerprint) return previous;
+  return { fingerprint, value: cloneToolResult(value) };
+}
+
+/**
+ * Turn a streamed tool result into an immutable snapshot.
+ *
+ * Some streaming clients complete tool calls by mutating the existing result
+ * object. React's dependency and memo checks cannot observe that mutation, so
+ * the MCP Apps renderer would never forward the completed result to the View.
+ */
+export function useToolResultSnapshot<T>(value: T): T {
+  const snapshotRef = useRef<ToolResultSnapshot<T> | null>(null);
+  snapshotRef.current = updateToolResultSnapshot(snapshotRef.current, value);
+  return snapshotRef.current.value;
+}

--- a/libraries/typescript/packages/inspector/src/client/components/chat/useToolResultSnapshot.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/useToolResultSnapshot.ts
@@ -1,6 +1,6 @@
 import { useRef } from "react";
 
-export interface ToolResultSnapshot<T> {
+interface ToolResultSnapshot<T> {
   fingerprint: string;
   value: T;
 }


### PR DESCRIPTION
## Summary
- snapshot streamed tool results by content so in-place completion is observable by React
- forward completed MCP App results without requiring a page reload
- add regression coverage for mutation and stable rerenders

## Validation
- targeted Vitest regression: 2 passed
- Inspector type-check passed after building client and agent dependencies
- Inspector production build and package verification passed
- targeted ESLint passed

## Runtime evidence
On Vibe dev, an existing result renders after reload, while two newly streamed calls remain pending with the same result object. This change fixes that identity boundary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Inspector so streamed MCP App tool results render as they complete. We snapshot mutated results so React detects updates and forwards the final result without a reload.

- **Bug Fixes**
  - Added `useToolResultSnapshot` to snapshot streamed results and detect in-place mutations.
  - Updated `ToolResultRenderer` to read from the snapshot for stable rerenders and correct JSON parsing.
  - Kept the snapshot type internal and added unit tests for mutation completion and snapshot stability.

<sup>Written for commit ad4dae7506cf251e5666c10c73559be49af83c4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

