### PR TITLE
fix(client): replay MCP App state after guest reinitializes

### DIFF
--- a/libraries/typescript/.changeset/tidy-widgets-render.md
+++ b/libraries/typescript/.changeset/tidy-widgets-render.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/client": patch
+---
+
+Replay MCP App invocation state when a Vite or React development runtime initializes a replacement guest App inside the existing iframe.

--- a/libraries/typescript/packages/client/src/react/view/ViewRenderer.tsx
+++ b/libraries/typescript/packages/client/src/react/view/ViewRenderer.tsx
@@ -28,6 +28,7 @@ import React, {
 } from "react";
 import { parseCustomProps } from "./parse-custom-props.js";
 import { injectOpenAiFileApis } from "./inject-openai-file-apis.js";
+import { installInitializedSync } from "./initialized-sync.js";
 import { resolveViewResource } from "./resolve-view-resource.js";
 import { buildViewSandboxBlobUrl } from "./sandbox-blob-url.js";
 import type {
@@ -81,17 +82,6 @@ function waitForSandboxProxyReady(iframe: HTMLIFrameElement): Promise<void> {
       }
     };
     window.addEventListener("message", listener);
-  });
-}
-
-function hookInitialized(bridge: AppBridge): Promise<void> {
-  const prev = bridge.oninitialized;
-  return new Promise((resolve) => {
-    bridge.oninitialized = (...args: unknown[]) => {
-      resolve();
-      bridge.oninitialized = prev;
-      (prev as ((...a: unknown[]) => void) | undefined)?.(...args);
-    };
   });
 }
 
@@ -654,7 +644,50 @@ function ViewRendererBase({
           }
         );
 
-        const initPromise = hookInitialized(bridge);
+        const syncGuestToolState = async () => {
+          if (!bridge || disposed) return;
+
+          const currentPartialToolInput = partialToolInputRef.current;
+          const hasCompletedToolResult =
+            toolOutputRef.current !== undefined &&
+            toolOutputRef.current !== null;
+          if (currentPartialToolInput && !hasCompletedToolResult) {
+            await bridge.sendToolInputPartial({
+              arguments: currentPartialToolInput,
+            });
+          } else {
+            const mergedArgs = {
+              ...toolInputRef.current,
+              ...parseCustomProps(customPropsRef.current),
+            };
+            await bridge.sendToolInput({ arguments: mergedArgs });
+          }
+
+          const toolResultPayload = buildToolResultPayload(
+            toolOutputRef.current,
+            customPropsRef.current
+          );
+          if (toolResultPayload) {
+            await bridge.sendToolResult(toolResultPayload);
+          }
+        };
+
+        const initPromise = installInitializedSync(
+          bridge,
+          syncGuestToolState,
+          (error) => {
+            if (disposed) return;
+            const message =
+              error instanceof Error
+                ? error.message
+                : "Failed to synchronize view state";
+            onErrorRef.current?.(message);
+            onLifecycleChangeRef.current?.({
+              status: "error",
+              error: message,
+            });
+          }
+        );
         let transport: Transport = new PostMessageTransport(
           iframe.contentWindow!,
           iframe.contentWindow!
@@ -681,27 +714,6 @@ function ViewRendererBase({
 
         await publishAppTools();
 
-        const currentPartialToolInput = partialToolInputRef.current;
-        const hasCompletedToolResult =
-          toolOutputRef.current !== undefined && toolOutputRef.current !== null;
-        if (currentPartialToolInput && !hasCompletedToolResult) {
-          await bridge.sendToolInputPartial({
-            arguments: currentPartialToolInput,
-          });
-        } else {
-          const mergedArgs = {
-            ...toolInputRef.current,
-            ...parseCustomProps(customPropsRef.current),
-          };
-          await bridge.sendToolInput({ arguments: mergedArgs });
-        }
-        const toolResultPayload = buildToolResultPayload(
-          toolOutputRef.current,
-          customPropsRef.current
-        );
-        if (toolResultPayload) {
-          await bridge.sendToolResult(toolResultPayload);
-        }
         onLifecycleChangeRef.current?.({ status: "ready" });
       } catch (err) {
         if (!disposed) {

--- a/libraries/typescript/packages/client/src/react/view/initialized-sync.ts
+++ b/libraries/typescript/packages/client/src/react/view/initialized-sync.ts
@@ -1,0 +1,34 @@
+interface InitializableBridge<TArgs extends unknown[]> {
+  oninitialized: ((...args: TArgs) => void) | undefined;
+}
+
+/**
+ * Synchronize host state after every guest initialize handshake.
+ *
+ * Vite HMR and React development runtimes can replace the guest App instance
+ * inside the same iframe. Each replacement initializes again and needs the
+ * invocation's one-shot input/result notifications replayed.
+ */
+export function installInitializedSync<TArgs extends unknown[]>(
+  bridge: InitializableBridge<TArgs>,
+  synchronize: () => void | Promise<void>,
+  onLaterError: (error: unknown) => void
+): Promise<void> {
+  const previous = bridge.oninitialized;
+  let sawFirstInitialization = false;
+
+  return new Promise<void>((resolve, reject) => {
+    bridge.oninitialized = (...args: TArgs) => {
+      previous?.(...args);
+      const synchronization = Promise.resolve().then(synchronize);
+
+      if (!sawFirstInitialization) {
+        sawFirstInitialization = true;
+        synchronization.then(resolve, reject);
+        return;
+      }
+
+      void synchronization.catch(onLaterError);
+    };
+  });
+}

--- a/libraries/typescript/packages/client/tests/initialized-sync.test.ts
+++ b/libraries/typescript/packages/client/tests/initialized-sync.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import { installInitializedSync } from "../src/react/view/initialized-sync.js";
+
+describe("installInitializedSync", () => {
+  it("replays host state after every guest initialization", async () => {
+    const previous = vi.fn();
+    const synchronize = vi.fn().mockResolvedValue(undefined);
+    const bridge = { oninitialized: previous };
+    const firstSynchronization = installInitializedSync(
+      bridge,
+      synchronize,
+      vi.fn()
+    );
+
+    bridge.oninitialized?.({ generation: 1 });
+    await firstSynchronization;
+    bridge.oninitialized?.({ generation: 2 });
+    await vi.waitFor(() => expect(synchronize).toHaveBeenCalledTimes(2));
+
+    expect(previous).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports replacement failures and keeps synchronizing", async () => {
+    const laterError = new Error("replacement sync failed");
+    const synchronize = vi
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(laterError)
+      .mockResolvedValueOnce(undefined);
+    const onLaterError = vi.fn();
+    const bridge = { oninitialized: undefined };
+    const firstSynchronization = installInitializedSync(
+      bridge,
+      synchronize,
+      onLaterError
+    );
+
+    bridge.oninitialized?.();
+    await firstSynchronization;
+    bridge.oninitialized?.();
+    await vi.waitFor(() =>
+      expect(onLaterError).toHaveBeenCalledWith(laterError)
+    );
+    bridge.oninitialized?.();
+    await vi.waitFor(() => expect(synchronize).toHaveBeenCalledTimes(3));
+  });
+});


### PR DESCRIPTION
## Summary
- keep the host initialized handler active for every guest App initialization, not only the first
- replay the current tool input/result when Vite or React replaces the guest runtime inside the existing iframe
- preserve the iframe so normal HMR updates remain live
- add focused repeated-initialization and recovery coverage plus a client patch changeset

## Root cause
A clean Vibe trace shows the sandbox runtime sending `ui/initialize` twice. The host responds to both, but currently restores its initialized handler after the first handshake and sends the one-shot tool result only once. The replacement guest App therefore remains pending.

## Validation
- client focused unit tests
- client TypeScript and targeted ESLint
- full client package build
- pending pkg.pr.new browser verification in Vibe Chat and direct Inspector