### PR TITLE
fix: lazily provision OAuth for HTTP connections

### DIFF
--- a/libraries/typescript/.changeset/lazy-oauth-state.md
+++ b/libraries/typescript/.changeset/lazy-oauth-state.md
@@ -1,0 +1,6 @@
+---
+"@mcp-use/client": patch
+"@mcp-use/cli": patch
+---
+
+Defer automatic OAuth provider creation until an HTTP server returns 401, avoiding OAuth state writes for public MCP connections while preserving automatic authentication for protected servers.

--- a/libraries/typescript/packages/cli/src/commands/client.ts
+++ b/libraries/typescript/packages/cli/src/commands/client.ts
@@ -444,7 +444,7 @@ async function openConnection(
   quiet = false,
   interactiveCommand = `mcp-use client ${name} tools list`
 ): Promise<MCPConnection> {
-  const { createOAuthProvider, MCPClient, logger } = await loadClientPackage({
+  const { MCPClient, logger } = await loadClientPackage({
     allowInstall: !quiet,
   });
   if (quiet) logger.level = "silent";
@@ -456,8 +456,8 @@ async function openConnection(
         })
       : undefined;
   const oauthBase = oauthDirectory(name);
-  const authProvider = definition.oauth
-    ? await createOAuthProvider(definition.url, {
+  const oauthOptions = definition.oauth
+    ? {
         baseDir: oauthBase,
         authTimeoutMs,
         storageKeyPrefix: `mcp-use-cli:${name}`,
@@ -486,10 +486,8 @@ async function openConnection(
           await waitForOAuthEnter();
           openBrowser(url);
         },
-        // Conditional exports select NodeOAuthOptions at runtime. TypeScript
-        // resolves the package's browser-default declaration in this build.
-      } as unknown as Parameters<typeof createOAuthProvider>[1])
-    : undefined;
+      }
+    : false;
   const protocolConfig =
     definition.protocol === "auto"
       ? { protocolNegotiation: "auto" as const }
@@ -512,7 +510,7 @@ async function openConnection(
         ...(credentials.headers !== undefined
           ? { headers: credentials.headers }
           : {}),
-        ...(authProvider !== undefined ? { authProvider } : { oauth: false }),
+        oauth: oauthOptions,
         ...protocolConfig,
       },
     },
@@ -527,7 +525,6 @@ async function openConnection(
       error instanceof CommandError &&
       error.code === "oauth_interaction_required"
     ) {
-      (authProvider as { dispose?: () => void } | undefined)?.dispose?.();
       await (
         client as typeof client & {
           closeSession?: (serverName: string) => Promise<void>;

--- a/libraries/typescript/packages/cli/tests/commands/client.test.ts
+++ b/libraries/typescript/packages/cli/tests/commands/client.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -15,8 +16,8 @@ const mocks = vi.hoisted(() => ({
         mcpServers: Record<
           string,
           {
-            authProvider?: unknown;
             clientOptions?: { supportedProtocolVersions?: string[] };
+            oauth?: false | { openBrowser: (url: string) => Promise<void> };
             protocolNegotiation?: "auto" | "legacy" | { pin: "2026-07-28" };
             url?: string;
           }
@@ -123,13 +124,12 @@ beforeEach(async () => {
   });
   mocks.loadClientPackage.mockResolvedValue({
     logger: mocks.logger,
-    createOAuthProvider: async (
-      _url: string,
-      options: { openBrowser: (url: string) => Promise<void> }
-    ) => ({ options }),
     MCPClient: class {
       constructor(config: {
-        mcpServers: Record<string, { authProvider?: unknown }>;
+        mcpServers: Record<
+          string,
+          { oauth?: false | { openBrowser: (url: string) => Promise<void> } }
+        >;
       }) {
         mocks.config = config;
       }
@@ -137,11 +137,9 @@ beforeEach(async () => {
       async connect(name: string): Promise<typeof connection> {
         mocks.connectCall(name);
         if (mocks.connectError !== undefined) throw mocks.connectError;
-        const provider = mocks.config?.mcpServers[name]?.authProvider as
-          | { options: { openBrowser: (url: string) => Promise<void> } }
-          | undefined;
-        if (mocks.triggerOAuth && provider !== undefined) {
-          await provider.options.openBrowser(AUTHORIZATION_LAUNCHER_URL);
+        const oauth = mocks.config?.mcpServers[name]?.oauth;
+        if (mocks.triggerOAuth && oauth !== false && oauth !== undefined) {
+          await oauth.openBrowser(AUTHORIZATION_LAUNCHER_URL);
           if (mocks.logger.level === "silent") {
             await new Promise<never>(() => {});
           }
@@ -711,6 +709,37 @@ describe("client protocol selection", () => {
 });
 
 describe("client OAuth browser UX", () => {
+  it("passes the saved connection's OAuth options to MCPClient lazily", async () => {
+    const name = "lazy-options";
+
+    await expect(
+      runClient([
+        "connect",
+        name,
+        "https://mcp.example.com/mcp",
+        "--auth-timeout",
+        "12345",
+      ])
+    ).resolves.toBe(0);
+
+    const oauth = mocks.config?.mcpServers[name]?.oauth;
+    expect(oauth).not.toBe(false);
+    expect(oauth).toMatchObject({
+      authTimeoutMs: 12345,
+      baseDir: expect.stringContaining(
+        join(
+          ".mcp-use",
+          "client",
+          "credentials",
+          createHash("sha256").update(name).digest("hex"),
+          "oauth"
+        )
+      ),
+      storageKeyPrefix: `mcp-use-cli:${name}`,
+      openBrowser: expect.any(Function),
+    });
+  });
+
   it("validates saved command options before connecting or starting OAuth", async () => {
     await runClient([
       "connect",

--- a/libraries/typescript/packages/client/src/core/base.ts
+++ b/libraries/typescript/packages/client/src/core/base.ts
@@ -66,6 +66,9 @@ export abstract class BaseMCPClient {
    */
   protected sessions: Record<string, MCPSession> = {};
 
+  /** Auto-created OAuth providers whose authorization flow is still pending. */
+  private pendingOAuthProviders: Record<string, OAuthClientProvider> = {};
+
   /**
    * List of server names that have active sessions.
    * This array is kept in sync with the sessions map and can be used
@@ -317,19 +320,9 @@ export abstract class BaseMCPClient {
 
     let serverConfig: ServerConfig = { ...servers[serverName] };
     let oauthProvider: OAuthClientProvider | undefined;
+    const shouldCreateOAuthProvider = shouldAutoProvisionOAuth(serverConfig);
 
-    if (shouldAutoProvisionOAuth(serverConfig)) {
-      const oauthOptions =
-        serverConfig.oauth === false ? undefined : (serverConfig.oauth ?? {});
-      oauthProvider = await this.createDefaultOAuthProvider(
-        serverConfig.url,
-        oauthOptions
-      );
-      serverConfig = {
-        ...serverConfig,
-        authProvider: oauthProvider,
-      };
-    } else if (
+    if (
       "authProvider" in serverConfig &&
       serverConfig.authProvider &&
       isOAuthClientProvider(serverConfig.authProvider)
@@ -355,11 +348,24 @@ export abstract class BaseMCPClient {
       const httpConfig = serverConfig as HttpServerConfig;
       if (
         !autoInitialize ||
-        !oauthProvider ||
         !("url" in httpConfig) ||
-        !isUnauthorized(err)
+        !isUnauthorized(err) ||
+        (!oauthProvider && !shouldCreateOAuthProvider)
       ) {
         throw err;
+      }
+      if (!oauthProvider) {
+        const oauthOptions =
+          httpConfig.oauth === false ? undefined : (httpConfig.oauth ?? {});
+        oauthProvider = await this.createDefaultOAuthProvider(
+          httpConfig.url,
+          oauthOptions
+        );
+        serverConfig = {
+          ...serverConfig,
+          authProvider: oauthProvider,
+        };
+        this.pendingOAuthProviders[serverName] = oauthProvider;
       }
       if (
         (
@@ -373,8 +379,27 @@ export abstract class BaseMCPClient {
       logger.info(
         `[MCPClient] Unauthorized connecting to '${serverName}'; completing OAuth…`
       );
-      await completeOAuthFlow(oauthProvider, httpConfig.url);
-      session = await openSession();
+      try {
+        if (httpConfig.fetch) {
+          await completeOAuthFlow(oauthProvider, httpConfig.url, {
+            fetchFn: httpConfig.fetch,
+          });
+        } else {
+          await completeOAuthFlow(oauthProvider, httpConfig.url);
+        }
+        session = await openSession();
+      } catch (error) {
+        if (this.pendingOAuthProviders[serverName] === oauthProvider) {
+          (
+            oauthProvider as OAuthClientProvider & { dispose?: () => void }
+          ).dispose?.();
+          delete this.pendingOAuthProviders[serverName];
+        }
+        throw error;
+      }
+      if (this.pendingOAuthProviders[serverName] === oauthProvider) {
+        delete this.pendingOAuthProviders[serverName];
+      }
     }
 
     this.sessions[serverName] = session;
@@ -562,6 +587,11 @@ export abstract class BaseMCPClient {
    * @see {@link createSession} for creating new sessions
    */
   public async closeSession(serverName: string): Promise<void> {
+    const pendingOAuthProvider = this.pendingOAuthProviders[serverName] as
+      | (OAuthClientProvider & { dispose?: () => void })
+      | undefined;
+    pendingOAuthProvider?.dispose?.();
+    delete this.pendingOAuthProviders[serverName];
     const session = this.sessions[serverName];
     if (!session) {
       logger.warn(

--- a/libraries/typescript/packages/client/src/core/config.ts
+++ b/libraries/typescript/packages/client/src/core/config.ts
@@ -173,6 +173,8 @@ export interface AutoOAuthOptions {
   preferredPort?: number;
   /** Number of Node loopback ports to try. Defaults to `10`. */
   portRange?: number;
+  /** Node: override the on-disk OAuth store directory. */
+  baseDir?: string;
   /** Node loopback callback timeout in milliseconds. Defaults to five minutes. */
   authTimeoutMs?: number;
   /** Node: override browser launch (CLI prints the URL instead). */
@@ -205,7 +207,7 @@ export interface HttpServerConfig extends BaseServerConfig {
   authProvider?: AuthProvider | OAuthClientProvider;
   /**
    * Auto-OAuth options for HTTP servers.
-   * - omit / `{}`: client creates the platform provider on connect
+   * - omit / `{}`: client creates the platform provider after a 401 response
    * - `false`: disable auto-OAuth (e.g. CLI `--no-oauth`)
    * - object: forwarded to `createOAuthProvider`
    *

--- a/libraries/typescript/packages/client/tests/unit/client/auto-oauth.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/client/auto-oauth.test.ts
@@ -1,6 +1,6 @@
 /**
- * MCPClient auto-OAuth: provisions createDefaultOAuthProvider for HTTP servers
- * and completes the 401 dance once before retrying.
+ * MCPClient auto-OAuth: lazily provisions createDefaultOAuthProvider after an
+ * HTTP 401 and completes the OAuth dance once before retrying.
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -104,13 +104,10 @@ describe("BaseMCPClient auto-OAuth createSession", () => {
     vi.mocked(flow.completeOAuthFlow).mockClear();
   });
 
-  it("calls createDefaultOAuthProvider for HTTP without bearer", async () => {
+  it("does not create an OAuth provider for a public HTTP server", async () => {
     const client = new TestClient({
       mcpServers: { demo: { url: "https://example.com/mcp" } },
     });
-    const provider = { server: "provider" } as unknown as OAuthClientProvider;
-    client.createDefaultOAuthProvider.mockResolvedValue(provider);
-
     let seenAuthProvider: unknown;
     client.createConnectorFromConfig.mockImplementation((config) => {
       seenAuthProvider = (config as { authProvider?: unknown }).authProvider;
@@ -119,14 +116,11 @@ describe("BaseMCPClient auto-OAuth createSession", () => {
 
     await client.createSession("demo");
 
-    expect(client.createDefaultOAuthProvider).toHaveBeenCalledWith(
-      "https://example.com/mcp",
-      {}
-    );
-    expect(seenAuthProvider).toBe(provider);
+    expect(client.createDefaultOAuthProvider).not.toHaveBeenCalled();
+    expect(seenAuthProvider).toBeUndefined();
   });
 
-  it("forwards oauth options and skips when oauth: false", async () => {
+  it("does not eagerly provision with oauth options or oauth: false", async () => {
     const withOpts = new TestClient({
       mcpServers: {
         demo: {
@@ -139,10 +133,7 @@ describe("BaseMCPClient auto-OAuth createSession", () => {
       makeConnector(async () => {})
     );
     await withOpts.createSession("demo");
-    expect(withOpts.createDefaultOAuthProvider).toHaveBeenCalledWith(
-      "https://example.com/mcp",
-      { clientName: "app", scope: "openid" }
-    );
+    expect(withOpts.createDefaultOAuthProvider).not.toHaveBeenCalled();
 
     const disabled = new TestClient({
       mcpServers: {
@@ -182,6 +173,115 @@ describe("BaseMCPClient auto-OAuth createSession", () => {
       code: 401,
     });
     let attempts = 0;
+    const seenProviders: unknown[] = [];
+    client.createConnectorFromConfig.mockImplementation((config) => {
+      seenProviders.push((config as { authProvider?: unknown }).authProvider);
+      return makeConnector(async () => {
+        attempts += 1;
+        if (attempts === 1) throw unauthorized;
+      });
+    });
+
+    await client.createSession("demo");
+
+    expect(flow.completeOAuthFlow).toHaveBeenCalledWith(
+      provider,
+      "https://example.com/mcp"
+    );
+    expect(client.createDefaultOAuthProvider).toHaveBeenCalledOnce();
+    expect(seenProviders).toEqual([undefined, provider]);
+    expect(attempts).toBe(2);
+  });
+
+  it("propagates a second 401 without retrying again", async () => {
+    const client = new TestClient({
+      mcpServers: { demo: { url: "https://example.com/mcp" } },
+    });
+    const provider = {} as OAuthClientProvider;
+    client.createDefaultOAuthProvider.mockResolvedValue(provider);
+    const unauthorized = Object.assign(new Error("Unauthorized"), {
+      code: 401,
+    });
+    let attempts = 0;
+    client.createConnectorFromConfig.mockImplementation(() =>
+      makeConnector(async () => {
+        attempts += 1;
+        throw unauthorized;
+      })
+    );
+
+    await expect(client.createSession("demo")).rejects.toBe(unauthorized);
+
+    expect(attempts).toBe(2);
+    expect(client.createDefaultOAuthProvider).toHaveBeenCalledOnce();
+    expect(flow.completeOAuthFlow).toHaveBeenCalledOnce();
+  });
+
+  it("propagates a 401 without provisioning when oauth is disabled", async () => {
+    const client = new TestClient({
+      mcpServers: {
+        demo: { url: "https://example.com/mcp", oauth: false },
+      },
+    });
+    const unauthorized = Object.assign(new Error("Unauthorized"), {
+      code: 401,
+    });
+    let attempts = 0;
+    client.createConnectorFromConfig.mockImplementation(() =>
+      makeConnector(async () => {
+        attempts += 1;
+        throw unauthorized;
+      })
+    );
+
+    await expect(client.createSession("demo")).rejects.toBe(unauthorized);
+
+    expect(attempts).toBe(1);
+    expect(client.createDefaultOAuthProvider).not.toHaveBeenCalled();
+    expect(flow.completeOAuthFlow).not.toHaveBeenCalled();
+  });
+
+  it("forwards oauth options only after a 401", async () => {
+    const client = new TestClient({
+      mcpServers: {
+        demo: {
+          url: "https://example.com/mcp",
+          oauth: { clientName: "app", scope: "openid", baseDir: "/tmp/oauth" },
+        },
+      },
+    });
+    const unauthorized = Object.assign(new Error("Unauthorized"), {
+      code: 401,
+    });
+    let attempts = 0;
+    client.createConnectorFromConfig.mockImplementation(() =>
+      makeConnector(async () => {
+        attempts += 1;
+        if (attempts === 1) throw unauthorized;
+      })
+    );
+
+    await client.createSession("demo");
+
+    expect(client.createDefaultOAuthProvider).toHaveBeenCalledWith(
+      "https://example.com/mcp",
+      { clientName: "app", scope: "openid", baseDir: "/tmp/oauth" }
+    );
+  });
+
+  it("uses the configured fetch implementation for lazy OAuth", async () => {
+    const fetchFn = vi.fn<typeof fetch>();
+    const client = new TestClient({
+      mcpServers: {
+        demo: { url: "https://example.com/mcp", fetch: fetchFn },
+      },
+    });
+    const provider = {} as OAuthClientProvider;
+    client.createDefaultOAuthProvider.mockResolvedValue(provider);
+    const unauthorized = Object.assign(new Error("Unauthorized"), {
+      code: 401,
+    });
+    let attempts = 0;
     client.createConnectorFromConfig.mockImplementation(() =>
       makeConnector(async () => {
         attempts += 1;
@@ -193,9 +293,9 @@ describe("BaseMCPClient auto-OAuth createSession", () => {
 
     expect(flow.completeOAuthFlow).toHaveBeenCalledWith(
       provider,
-      "https://example.com/mcp"
+      "https://example.com/mcp",
+      { fetchFn }
     );
-    expect(attempts).toBe(2);
   });
 
   it("does not retry non-401 errors", async () => {
@@ -212,6 +312,7 @@ describe("BaseMCPClient auto-OAuth createSession", () => {
     );
 
     await expect(client.createSession("demo")).rejects.toThrow("boom");
+    expect(client.createDefaultOAuthProvider).not.toHaveBeenCalled();
     expect(flow.completeOAuthFlow).not.toHaveBeenCalled();
   });
 });

--- a/libraries/typescript/packages/client/tests/unit/client/public-http-no-oauth-state.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/client/public-http-no-oauth-state.test.ts
@@ -1,0 +1,77 @@
+import { existsSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { MCPClient } from "../../../src/core/node.js";
+
+describe("public HTTP OAuth state", () => {
+  const cleanups: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()));
+  });
+
+  it("connects locally without creating the configured OAuth directory", async () => {
+    const root = await mkdtemp(join(tmpdir(), "mcp-use-public-http-"));
+    const oauthBase = join(root, "oauth-must-stay-absent");
+    cleanups.push(() => rm(root, { recursive: true, force: true }));
+
+    const server = createServer(async (request, response) => {
+      const chunks: Buffer[] = [];
+      for await (const chunk of request) chunks.push(Buffer.from(chunk));
+      const message = JSON.parse(Buffer.concat(chunks).toString("utf8")) as {
+        id?: number;
+        method?: string;
+      };
+      if (message.method === "notifications/initialized") {
+        response.writeHead(202).end();
+        return;
+      }
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: message.id,
+          result:
+            message.method === "initialize"
+              ? {
+                  protocolVersion: "2025-11-25",
+                  capabilities: {},
+                  serverInfo: { name: "public-fixture", version: "1.0.0" },
+                }
+              : {},
+        })
+      );
+    });
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve)
+    );
+    cleanups.push(
+      () =>
+        new Promise<void>((resolve, reject) =>
+          server.close((error) => (error ? reject(error) : resolve()))
+        )
+    );
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Fixture did not bind to a TCP port");
+    }
+
+    const client = new MCPClient({
+      mcpServers: {
+        public: {
+          url: `http://127.0.0.1:${address.port}/mcp`,
+          oauth: { baseDir: oauthBase },
+          protocolNegotiation: "legacy",
+        },
+      },
+    });
+
+    await client.connect("public");
+
+    expect(existsSync(oauthBase)).toBe(false);
+    await client.closeAllSessions();
+  });
+});


### PR DESCRIPTION
## What changed

- defer automatic OAuth provider creation until an HTTP MCP server returns 401
- keep public/local connections free of OAuth filesystem state
- preserve explicit providers, bearer tokens, authorization headers, and `oauth: false`
- pass saved CLI OAuth options through the lazy client flow
- forward custom `fetch` implementations and dispose pending auto-created providers
- add a patch changeset for `@mcp-use/client` and `@mcp-use/cli`

## Why

`MCPClient` previously constructed its default Node OAuth provider before the first HTTP handshake. Provider construction creates the OAuth store and persists a loopback port, so even public servers wrote under `~/.mcp-use/oauth` and could fail in read-only sandbox environments.

The first connection attempt is now anonymous. A normalized 401 creates the provider, completes the existing OAuth flow, and retries once.

## Validation

- `pnpm --filter @mcp-use/client test:run` — 328 tests passed
- focused CLI command tests — 23 tests passed
- `pnpm --filter @mcp-use/cli typecheck`
- client build
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make OAuth lazy for HTTP. The client now creates a provider only after a 401 challenge, preventing unwanted `~/.mcp-use/oauth` writes on public/local servers and improving behavior in read-only environments. Also surfaces mixed-auth servers without blocking anonymous use, with optional authentication in React, the CLI, and the Inspector. Closes Linear MCP-2895.

- **New Features**
  - Detect RFC 9728 mixed auth after anonymous connect; expose `authorization` (`MCPAuthorizationInfo`) on `MCPConnection` and React, add `connection.authenticate()` and `detectMixedAuth` (defaults to `true`).
  - CLI: add `mcp-use client <name> auth login`; connect output includes optional `authorization`.
  - Inspector: show “mixed auth” with an Authenticate button; retry protected tools after auth; preserve session across full-page redirects.
  - Server: add runnable mixed OAuth demo under `examples/auth/mixed-oauth`.
  - Docs updated across client, React, CLI, and Inspector.

- **Bug Fixes**
  - `@mcp-use/client`: defer default OAuth provider creation until a 401; keep public/local HTTP connections free of OAuth filesystem state; respect explicit providers, bearer tokens, `Authorization` headers, and `oauth: false`; forward custom `fetch` for the OAuth dance; dispose pending auto-created providers on errors and `closeSession`; support Node `baseDir` in `oauth` options.
  - `@mcp-use/cli`: pass saved OAuth options lazily to the client (no eager provider); preserve `--no-oauth`; keep browser launch behavior.
  - `@mcp-use/inspector`: stream v2 subscription acknowledgements through the proxy; enable Skills tab after HMR; recover stale localhost URLs before the client mounts.
  - `mcp-use` (server): preserve multiple `Set-Cookie` headers through the Node bridge.
  - Code mode: custom executor functions work on first call, `searchTools()` returns expected results, `close()` runs cleanup; fix `detail_level` handling.
  - `create-mcp-use-app`: sanitize package names, including leading underscores.

<sup>Written for commit b1ea6af136ad7110b7470d75e6dffe246d03ae73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



