### PR TITLE
fix(inspector): ship embedded theme styles

### DIFF
--- a/libraries/typescript/.changeset/fuzzy-dodos-style.md
+++ b/libraries/typescript/.changeset/fuzzy-dodos-style.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Ship a canonical client stylesheet containing the Inspector surface, shadow, hover, and active theme contract so embedded dialogs, dropdowns, and selects render with the same styling as the standalone Inspector.

--- a/libraries/typescript/packages/inspector/README.md
+++ b/libraries/typescript/packages/inspector/README.md
@@ -116,6 +116,22 @@ The UI assets, proxy, and OAuth backend all come from the installed package; no 
 
 ## 📖 Usage Guide
 
+### Embedding the React client
+
+Applications that import components from `@mcp-use/inspector/client` must also
+load the Inspector theme contract from their global Tailwind stylesheet:
+
+```css
+@import "tailwindcss";
+@import "@mcp-use/inspector/client/styles.css";
+
+@source "../node_modules/@mcp-use/inspector/dist/client";
+```
+
+The stylesheet supplies the surface, shadow, hover, and active tokens used by
+portaled dialogs, dropdowns, selects, and other Inspector UI primitives. The
+standalone Inspector bundles these styles automatically.
+
 ### Dashboard
 
 The main dashboard is your central hub for managing MCP server connections:

--- a/libraries/typescript/packages/inspector/package.json
+++ b/libraries/typescript/packages/inspector/package.json
@@ -28,6 +28,9 @@
     "./client": {
       "types": "./dist/client/index.d.ts",
       "import": "./dist/client/index.js"
+    },
+    "./client/styles.css": {
+      "default": "./dist/client/styles.css"
     }
   },
   "main": "./dist/server/index.js",
@@ -50,7 +53,7 @@
     "preview:app": "vite preview --config vite.app.config.ts --host 127.0.0.1",
     "serve:app": "pnpm build:app && pnpm preview:app",
     "analyze:app": "ANALYZE=true vite build --config vite.app.config.ts",
-    "build:client-exports": "tsup --config tsup.client.ts",
+    "build:client-exports": "tsup --config tsup.client.ts && node scripts/copy-client-styles.mjs",
     "build:server": "tsup --config tsup.server.ts",
     "verify:package": "node scripts/verify-package.mjs",
     "prepublishOnly": "pnpm --filter @mcp-use/client build && pnpm build",

--- a/libraries/typescript/packages/inspector/scripts/copy-client-styles.mjs
+++ b/libraries/typescript/packages/inspector/scripts/copy-client-styles.mjs
@@ -1,0 +1,10 @@
+import { copyFileSync, mkdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const packageRoot = fileURLToPath(new URL("../", import.meta.url));
+const source = join(packageRoot, "src/client/styles.css");
+const destination = join(packageRoot, "dist/client/styles.css");
+
+mkdirSync(dirname(destination), { recursive: true });
+copyFileSync(source, destination);

--- a/libraries/typescript/packages/inspector/scripts/verify-package.mjs
+++ b/libraries/typescript/packages/inspector/scripts/verify-package.mjs
@@ -36,11 +36,26 @@ for (const required of [
   "dist/server/index.d.ts",
   "dist/client/index.js",
   "dist/client/index.d.ts",
+  "dist/client/styles.css",
   "dist/cli.js",
   "dist/app/inspector.js.gz",
   "dist/app/inspector.css.gz",
 ]) {
   if (!files.includes(required)) throw new Error(`Missing ${required}`);
+}
+
+const clientStyles = readFileSync(join(dist, "client/styles.css"), "utf8");
+for (const requiredToken of [
+  "--color-surface-5",
+  "--surface-5",
+  "--shadow-surface-5",
+  "--shadow-5",
+  "--color-hover",
+  "--color-active",
+]) {
+  if (!clientStyles.includes(requiredToken)) {
+    throw new Error(`Inspector client styles are missing ${requiredToken}`);
+  }
 }
 
 const appJavaScript = gunzipSync(

--- a/libraries/typescript/packages/inspector/src/client/styles.css
+++ b/libraries/typescript/packages/inspector/src/client/styles.css
@@ -1,0 +1,136 @@
+/*
+ * Theme contract for applications embedding @mcp-use/inspector/client.
+ *
+ * Import this file from the host's global Tailwind stylesheet. The standalone
+ * Inspector already owns the same tokens in index.css; embedders need this
+ * smaller asset because the client export contains React components only.
+ */
+
+@theme inline {
+  --color-surface-1: var(--surface-1);
+  --color-surface-2: var(--surface-2);
+  --color-surface-3: var(--surface-3);
+  --color-surface-4: var(--surface-4);
+  --color-surface-5: var(--surface-5);
+  --color-surface-6: var(--surface-6);
+  --color-surface-7: var(--surface-7);
+  --color-surface-8: var(--surface-8);
+  --shadow-surface-1: var(--shadow-1);
+  --shadow-surface-2: var(--shadow-2);
+  --shadow-surface-3: var(--shadow-3);
+  --shadow-surface-4: var(--shadow-4);
+  --shadow-surface-5: var(--shadow-5);
+  --shadow-surface-6: var(--shadow-6);
+  --shadow-surface-7: var(--shadow-7);
+  --shadow-surface-8: var(--shadow-8);
+  --color-dm-drop: var(--dm-drop);
+  --color-dm-ring-high: var(--dm-ring-high);
+  --color-dm-ring-mid: var(--dm-ring-mid);
+  --color-dm-ring-base: var(--dm-ring-base);
+  --color-dm-hi-peak: var(--dm-hi-peak);
+  --color-dm-hi-high: var(--dm-hi-high);
+  --color-dm-hi-mid: var(--dm-hi-mid);
+  --color-dm-hi-base: var(--dm-hi-base);
+  --color-shadow-color: var(--shadow-color);
+  --color-hover: var(--hover);
+  --color-active: var(--active);
+}
+
+:root {
+  --hover: color-mix(in oklch, var(--foreground) 6%, transparent);
+  --active: color-mix(in oklch, var(--foreground) 10%, transparent);
+  --focus-ring: #6b97ff;
+  --surface-1: #fafafa;
+  --surface-2: #fcfcfc;
+  --surface-3: #ffffff;
+  --surface-4: #ffffff;
+  --surface-5: #ffffff;
+  --surface-6: #ffffff;
+  --surface-7: #ffffff;
+  --surface-8: #ffffff;
+  --shadow-color: rgb(0 0 0 / 0.06);
+  --shadow-1: 0 0 0 1px var(--shadow-color);
+  --shadow-2:
+    0 0 0 1px var(--shadow-color), 0 1px 1px -0.5px var(--shadow-color);
+  --shadow-3:
+    0 0 0 1px var(--shadow-color), 0 1px 1px -0.5px var(--shadow-color),
+    0 3px 3px -1.5px var(--shadow-color);
+  --shadow-4:
+    0 0 0 1px var(--shadow-color), 0 1px 1px -0.5px var(--shadow-color),
+    0 3px 3px -1.5px var(--shadow-color), 0 6px 6px -3px var(--shadow-color);
+  --shadow-5:
+    0 0 0 1px var(--shadow-color), 0 1px 1px -0.5px var(--shadow-color),
+    0 3px 3px -1.5px var(--shadow-color), 0 6px 6px -3px var(--shadow-color),
+    0 12px 12px -6px var(--shadow-color);
+  --shadow-6:
+    0 0 0 1px var(--shadow-color), 0 1px 1px -0.5px var(--shadow-color),
+    0 3px 3px -1.5px var(--shadow-color), 0 6px 6px -3px var(--shadow-color),
+    0 12px 12px -6px var(--shadow-color), 0 24px 24px -12px var(--shadow-color);
+  --shadow-7:
+    0 0 0 1px var(--shadow-color), 0 1px 1px -0.5px var(--shadow-color),
+    0 3px 3px -1.5px var(--shadow-color), 0 6px 6px -3px var(--shadow-color),
+    0 12px 12px -6px var(--shadow-color), 0 24px 24px -12px var(--shadow-color),
+    0 48px 48px -24px var(--shadow-color);
+  --shadow-8:
+    0 0 0 1px var(--shadow-color), 0 1px 1px -0.5px var(--shadow-color),
+    0 3px 3px -1.5px var(--shadow-color), 0 6px 6px -3px var(--shadow-color),
+    0 12px 12px -6px var(--shadow-color), 0 24px 24px -12px var(--shadow-color),
+    0 48px 48px -24px var(--shadow-color), 0 96px 96px -48px var(--shadow-color);
+}
+
+.dark,
+.mcp-apps-host-theme-probe-dark {
+  --hover: color-mix(in oklch, var(--foreground) 8%, transparent);
+  --active: color-mix(in oklch, var(--foreground) 12%, transparent);
+  --focus-ring: #6b97ff;
+  --surface-1: #171717;
+  --surface-2: #1e1e1e;
+  --surface-3: #252525;
+  --surface-4: #2c2c2c;
+  --surface-5: #333333;
+  --surface-6: #3a3a3a;
+  --surface-7: #414141;
+  --surface-8: #484848;
+  --dm-hi-base: rgba(255, 255, 255, 0.01);
+  --dm-hi-mid: rgba(255, 255, 255, 0.02);
+  --dm-hi-high: rgba(255, 255, 255, 0.04);
+  --dm-hi-peak: rgba(255, 255, 255, 0.06);
+  --dm-ring-base: rgba(255, 255, 255, 0.02);
+  --dm-ring-mid: rgba(255, 255, 255, 0.04);
+  --dm-ring-high: rgba(255, 255, 255, 0.06);
+  --dm-drop: rgba(0, 0, 0, 0.18);
+  --shadow-1: inset 0 0 0 1px var(--dm-ring-base);
+  --shadow-2:
+    inset 0 1px 0 0 var(--dm-hi-base), inset 0 0 0 1px var(--dm-ring-base),
+    0 1px 1px -0.5px var(--dm-drop);
+  --shadow-3:
+    inset 0 1px 0 0 var(--dm-hi-mid), inset 0 0 0 1px var(--dm-ring-base),
+    0 0 0 1px rgba(0, 0, 0, 0.12), 0 1px 1px -0.5px var(--dm-drop),
+    0 3px 3px -1.5px var(--dm-drop);
+  --shadow-4:
+    inset 0 1px 0 0 var(--dm-hi-mid), inset 0 0 0 1px var(--dm-ring-mid),
+    0 0 0 1px rgba(0, 0, 0, 0.14), 0 1px 1px -0.5px var(--dm-drop),
+    0 3px 3px -1.5px var(--dm-drop), 0 6px 6px -3px var(--dm-drop);
+  --shadow-5:
+    inset 0 1px 0 0 var(--dm-hi-high), inset 0 0 0 1px var(--dm-ring-mid),
+    0 0 0 1px rgba(0, 0, 0, 0.16), 0 1px 1px -0.5px var(--dm-drop),
+    0 3px 3px -1.5px var(--dm-drop), 0 6px 6px -3px var(--dm-drop),
+    0 12px 12px -6px var(--dm-drop);
+  --shadow-6:
+    inset 0 1px 0 0 var(--dm-hi-high), inset 0 0 0 1px var(--dm-ring-high),
+    0 0 0 1px rgba(0, 0, 0, 0.18), 0 1px 1px -0.5px var(--dm-drop),
+    0 3px 3px -1.5px var(--dm-drop), 0 6px 6px -3px var(--dm-drop),
+    0 12px 12px -6px var(--dm-drop), 0 24px 24px -12px var(--dm-drop);
+  --shadow-7:
+    inset 0 1px 0 0 var(--dm-hi-peak), inset 0 0 0 1px var(--dm-ring-high),
+    0 0 0 1px rgba(0, 0, 0, 0.2), 0 1px 1px -0.5px var(--dm-drop),
+    0 3px 3px -1.5px var(--dm-drop), 0 6px 6px -3px var(--dm-drop),
+    0 12px 12px -6px var(--dm-drop), 0 24px 24px -12px var(--dm-drop),
+    0 48px 48px -24px var(--dm-drop);
+  --shadow-8:
+    inset 0 1px 0 0 var(--dm-hi-peak), inset 0 0 0 1px var(--dm-ring-high),
+    0 0 0 1px rgba(0, 0, 0, 0.22), 0 1px 1px -0.5px var(--dm-drop),
+    0 3px 3px -1.5px var(--dm-drop), 0 6px 6px -3px var(--dm-drop),
+    0 12px 12px -6px var(--dm-drop), 0 24px 24px -12px var(--dm-drop),
+    0 48px 48px -24px var(--dm-drop), 0 96px 96px -48px var(--dm-drop);
+}


### PR DESCRIPTION
## Summary

- export a canonical `@mcp-use/inspector/client/styles.css` theme contract
- include the stylesheet in packed Inspector artifacts and verify required surface tokens
- document the required Tailwind import for React embedders
- add a patch changeset for `@mcp-use/inspector`

## Root cause

The standalone Inspector bundles `src/client/index.css`, but `@mcp-use/inspector/client` previously shipped only JavaScript and declarations. Embedded consumers could scan the component class names with Tailwind, but did not receive the Inspector-only surface/shadow/hover theme mappings or values. Portaled dialogs, selects, and dropdowns therefore resolved `bg-surface-*` and `shadow-surface-*` to no CSS.

## Validation

- `pnpm --filter @mcp-use/client build`
- `pnpm --filter @mcp-use/agent build`
- `pnpm --filter @mcp-use/inspector type-check`
- `pnpm --filter @mcp-use/inspector build`
- packed tarball contains `dist/client/styles.css`
- clean Cloud consumer with the packed package passes `pnpm --dir website.mcp-use type-check` and `pnpm --dir website.mcp-use build`
- compiled consumer CSS contains `.bg-surface-5`, `.shadow-surface-5`, and light/dark `--surface-5` values


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ships a canonical theme stylesheet with `@mcp-use/inspector` so embedded React clients get surface, shadow, hover, and active tokens. Fixes missing styles for portaled dialogs, selects, and dropdowns in embedders.

- **Migration**
  - Import `@mcp-use/inspector/client/styles.css` in your global Tailwind CSS (after `tailwindcss`).
  - Add `@source "../node_modules/@mcp-use/inspector/dist/client";` so Tailwind scans the client components.

<sup>Written for commit 76181e8b2566c651e0ee41659fa9c6835549cfab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

