### PR TITLE
feat(inspector): let Vibe agents repair CSP autonomously

### DIFF
--- a/.changeset/tidy-carrots-judge.md
+++ b/.changeset/tidy-carrots-judge.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": minor
+---
+
+Expose CSP mode and audit commands through the embedded Chat bridge so hosts and coding agents can verify MCP Apps in Widget-Declared mode.

--- a/libraries/typescript/packages/inspector/src/client/components/ChatTab.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ChatTab.tsx
@@ -66,6 +66,7 @@ import type { ChatSystemPromptProvider } from "./chat/system-prompt/types";
 import { useWidgetDebug } from "../context/WidgetDebugContext";
 import type { ChatBodyBuilder, MessageAttachment } from "./chat/types";
 import { resolveChatToolPolicy } from "./chat/chat-tool-policy";
+import { buildChatCspAudit } from "./chat/csp-bridge";
 
 // Structural type — avoids nominal incompatibility when pnpm creates
 // multiple peer-variant copies of mcp-use with duplicate class declarations.
@@ -316,7 +317,14 @@ export function ChatTab({
       lockManagedMode,
     });
 
-  const { getModelContexts, getAppToolConnections } = useWidgetDebug();
+  const {
+    getModelContexts,
+    getAppToolConnections,
+    playground,
+    widgets,
+    clearCspViolations,
+    updatePlaygroundSettings,
+  } = useWidgetDebug();
   const modelContextScope = `chat:${serverId}`;
   const widgetModelContexts = getModelContexts(modelContextScope);
   const appToolConnections = getAppToolConnections(modelContextScope);
@@ -795,6 +803,7 @@ export function ChatTab({
         setQuickQuestions: true,
         setFollowups: true,
         loadMessages: true,
+        cspAudit: true,
       },
     });
   }, [postBridgeEvent]);
@@ -828,6 +837,8 @@ export function ChatTab({
         prompt?: string;
         questions?: unknown;
         followups?: unknown;
+        mode?: unknown;
+        toolCallId?: unknown;
       };
 
       if (!data.type?.startsWith("mcp-inspector:chat:")) return;
@@ -915,6 +926,34 @@ export function ChatTab({
         }
         setMessages(rawMessages as ChatMessage[]);
         postResult(true, { count: rawMessages.length });
+        return;
+      }
+
+      if (data.type === "mcp-inspector:chat:set_csp_mode") {
+        if (data.mode !== "permissive" && data.mode !== "widget-declared") {
+          postResult(false, {
+            error: "mode must be permissive or widget-declared",
+          });
+          return;
+        }
+        for (const widgetId of widgets.keys()) clearCspViolations(widgetId);
+        updatePlaygroundSettings({ cspMode: data.mode });
+        postResult(true, { cspMode: data.mode });
+        return;
+      }
+
+      if (data.type === "mcp-inspector:chat:get_csp_audit") {
+        const audit = buildChatCspAudit(
+          playground.cspMode,
+          widgets,
+          typeof data.toolCallId === "string" ? data.toolCallId : undefined
+        );
+        postBridgeEvent("mcp-inspector:chat:csp_audit", {
+          requestId,
+          audit,
+          timestamp: Date.now(),
+        });
+        postResult(true, { cspMode: audit.mode, cspClean: audit.clean });
         return;
       }
 
@@ -1085,6 +1124,7 @@ export function ChatTab({
     return () => window.removeEventListener("message", handleWindowMessage);
   }, [
     bridge,
+    clearCspViolations,
     clearChatToLanding,
     dismissLandingShader,
     setMessages,
@@ -1099,6 +1139,9 @@ export function ChatTab({
     serverId,
     llmConfig,
     isConnected,
+    playground.cspMode,
+    updatePlaygroundSettings,
+    widgets,
   ]);
 
   // Register keyboard shortcuts (only active when ChatTab is mounted and enabled)

--- a/libraries/typescript/packages/inspector/src/client/components/chat/__tests__/csp-bridge.test.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/__tests__/csp-bridge.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import type { WidgetInfo } from "@/client/context/WidgetDebugContext";
+import { buildChatCspAudit } from "../csp-bridge";
+
+describe("buildChatCspAudit", () => {
+  it("reports a clean widget in widget-declared mode", () => {
+    const widgets = new Map<string, WidgetInfo>([
+      [
+        "call-1",
+        {
+          toolName: "show-weather",
+          protocol: "mcp-apps",
+          declaredCsp: {
+            connectDomains: ["https://api.example.com"],
+            resourceDomains: [],
+          },
+          effectivePolicy: "connect-src 'self' https://api.example.com",
+          cspViolations: [],
+        },
+      ],
+    ]);
+
+    expect(buildChatCspAudit("widget-declared", widgets)).toMatchObject({
+      mode: "widget-declared",
+      clean: true,
+      widgets: [
+        {
+          widgetId: "call-1",
+          toolName: "show-weather",
+          violations: [],
+        },
+      ],
+    });
+  });
+
+  it("returns the exact origin suggestion for a blocked connection", () => {
+    const widgets = new Map<string, WidgetInfo>([
+      [
+        "call-2",
+        {
+          toolName: "show-weather",
+          protocol: "mcp-apps",
+          cspViolations: [
+            {
+              directive: "connect-src",
+              effectiveDirective: "connect-src",
+              blockedUri: "https://api.example.com/weather",
+              timestamp: 1,
+            },
+          ],
+        },
+      ],
+    ]);
+
+    const audit = buildChatCspAudit("widget-declared", widgets);
+    expect(audit.clean).toBe(false);
+    expect(audit.widgets[0]?.suggestedFix?.connectDomains).toEqual([
+      "https://api.example.com",
+      "wss://api.example.com",
+    ]);
+    expect(audit.widgets[0]?.agentPrompt).toContain("https://api.example.com");
+  });
+
+  it("does not mark an undeclared widget policy clean", () => {
+    const widgets = new Map<string, WidgetInfo>([
+      [
+        "call-3",
+        {
+          toolName: "show-local-card",
+          protocol: "mcp-apps",
+          cspViolations: [],
+        },
+      ],
+    ]);
+
+    const audit = buildChatCspAudit("widget-declared", widgets);
+    expect(audit.clean).toBe(false);
+    expect(audit.widgets[0]?.findings[0]?.title).toBe("No widget CSP declared");
+  });
+
+  it("audits an explicit widget or the newest widget by default", () => {
+    const widgets = new Map<string, WidgetInfo>([
+      [
+        "old-call",
+        {
+          toolName: "old-tool",
+          protocol: "mcp-apps",
+          cspViolations: [],
+        },
+      ],
+      [
+        "new-call",
+        {
+          toolName: "new-tool",
+          protocol: "mcp-apps",
+          declaredCsp: { connectDomains: [], resourceDomains: [] },
+          cspViolations: [],
+        },
+      ],
+    ]);
+
+    expect(
+      buildChatCspAudit("widget-declared", widgets).widgets[0]?.widgetId
+    ).toBe("new-call");
+    expect(
+      buildChatCspAudit("widget-declared", widgets, "old-call").widgets[0]
+        ?.widgetId
+    ).toBe("old-call");
+  });
+});

--- a/libraries/typescript/packages/inspector/src/client/components/chat/csp-bridge.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/csp-bridge.ts
@@ -1,0 +1,80 @@
+import type {
+  PlaygroundSettings,
+  WidgetInfo,
+} from "@/client/context/WidgetDebugContext";
+import { diagnoseCsp } from "@/client/mcp-apps/csp";
+import {
+  buildAgentCspPrompt,
+  computeSuggestedFix,
+} from "@/client/mcp-apps/debug/csp-suggestions";
+
+export interface ChatCspAuditWidget {
+  widgetId: string;
+  toolName: string;
+  declaredCsp: WidgetInfo["declaredCsp"];
+  effectivePolicy?: string;
+  violations: WidgetInfo["cspViolations"];
+  findings: ReturnType<typeof diagnoseCsp>;
+  suggestedFix: ReturnType<typeof computeSuggestedFix> | null;
+  agentPrompt: string;
+}
+
+export interface ChatCspAudit {
+  mode: PlaygroundSettings["cspMode"];
+  widgets: ChatCspAuditWidget[];
+  clean: boolean;
+}
+
+export function buildChatCspAudit(
+  mode: PlaygroundSettings["cspMode"],
+  widgets: ReadonlyMap<string, WidgetInfo>,
+  widgetId?: string
+): ChatCspAudit {
+  const entries = Array.from(widgets.entries());
+  const selectedEntries = widgetId
+    ? entries.filter(([candidateId]) => candidateId === widgetId)
+    : entries.slice(-1);
+  const audited = selectedEntries.map(([selectedWidgetId, widget]) => {
+    const violations = widget.cspViolations;
+    const suggestedFix =
+      violations.length > 0
+        ? computeSuggestedFix(violations, widget.declaredCsp)
+        : null;
+    return {
+      widgetId: selectedWidgetId,
+      toolName: widget.toolName,
+      declaredCsp: widget.declaredCsp,
+      effectivePolicy: widget.effectivePolicy,
+      violations,
+      findings: diagnoseCsp({
+        mode,
+        declared: widget.declaredCsp,
+        effectivePolicy: widget.effectivePolicy,
+        violations,
+      }),
+      suggestedFix,
+      agentPrompt:
+        violations.length > 0
+          ? buildAgentCspPrompt(
+              widget.declaredCsp,
+              widget.effectivePolicy,
+              violations,
+              suggestedFix
+            )
+          : "",
+    } satisfies ChatCspAuditWidget;
+  });
+
+  return {
+    mode,
+    widgets: audited,
+    clean:
+      mode === "widget-declared" &&
+      audited.length > 0 &&
+      audited.every(
+        (widget) =>
+          widget.violations.length === 0 &&
+          widget.findings.every((finding) => finding.severity === "info")
+      ),
+  };
+}

--- a/skills/mcp-apps-builder/references/verification.md
+++ b/skills/mcp-apps-builder/references/verification.md
@@ -35,6 +35,20 @@ npx mcp-use client dev tools call show-product id=item-1 --screenshot
 
 Reload once to catch state and asset assumptions masked by hot reload.
 
+For Views, finish with a CSP repair loop:
+
+1. Render the tool output in Widget-Declared mode.
+2. Read the CSP audit and runtime errors after the iframe has loaded.
+3. Add only the reported external origins to the correct `view.csp` category.
+4. Render again and repeat until the audit is clean and the View remains usable.
+5. Take a final screenshot in Widget-Declared mode.
+
+When Vibe bridge tools are available, call `chat_set_csp_mode` with
+`widget-declared`, trigger the rendering tool through `chat_send_message`, then
+call `chat_read_csp_audit`, `chat_read_runtime_errors`, and `screenshot_widget`.
+Do not infer CSP success from compilation, an MCP tool result, or Permissive
+mode.
+
 ## Package checks
 
 When changing exports, dependencies, or packaging, pack the relevant package and install it in an empty temporary consumer. Import public entry points there. A workspace build cannot prove the published dependency boundary.

--- a/skills/mcp-apps-builder/references/views.md
+++ b/skills/mcp-apps-builder/references/views.md
@@ -38,7 +38,29 @@ Guard host-specific features with their support signal. Treat tool calls as asyn
 
 ## CSP and assets
 
-Declare external origins in the bound View's `csp` configuration. Keep local View code and CSS inside the View folder. Put shared public assets in `public/` and resolve them through the request-provided public asset base rather than hard-coded localhost URLs.
+Declare every external origin in the bound View's `csp` configuration. Use the
+installed v2 types and the narrow field that matches the browser operation:
+
+- `connectDomains` for `fetch`, EventSource, and WebSocket connections
+- `resourceDomains` for scripts, styles, images, fonts, and media
+- `frameDomains` for embedded frames
+- `baseUriDomains` only when the View intentionally sets an external base URI
+
+Use exact origins such as `https://api.example.com`, not paths. Keep the policy
+least-privilege: never add `*`, leave Inspector in Permissive mode, or weaken the
+host CSP to hide a violation. CORS is a separate server response contract and
+must still be configured for cross-origin requests.
+
+After rendering the View, enforce **Widget-Declared** mode and inspect the CSP
+audit. In Vibe, use `chat_set_csp_mode` and `chat_read_csp_audit`; apply the
+reported exact-origin suggestions to `view.csp`, render again, and repeat until
+the audit reports `clean: true`. Also re-run `chat_read_runtime_errors` and take
+a final screenshot. A successful tool result or a View that only works in
+Permissive mode is not completion.
+
+Keep local View code and CSS inside the View folder. Put shared public assets in
+`public/` and resolve them through the request-provided public asset base rather
+than hard-coded localhost URLs.
 
 ## Type generation
 


### PR DESCRIPTION
## Summary
- expose Widget-Declared CSP mode and machine-readable audit commands through the embedded Chat bridge
- return per-widget findings, violations, effective policy, and exact-origin suggestions
- teach `mcp-apps-builder` to repeat the CSP repair loop until the audit is clean

## Validation
- `pnpm --filter @mcp-use/client build`
- `pnpm --filter @mcp-use/agent build`
- `pnpm --filter @mcp-use/inspector type-check`
- `pnpm exec vitest run src/client/components/chat/__tests__/csp-bridge.test.ts`
- `pnpm --filter @mcp-use/inspector lint`
- `pnpm --filter @mcp-use/inspector build`
- focused Prettier check

Includes a minor changeset for `@mcp-use/inspector`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose Widget-Declared CSP mode control and a machine-readable CSP audit over the embedded Chat bridge so Vibe agents can fix CSP automatically. Adds per-widget findings, effective policy, exact-origin suggestions, and an agent-ready prompt.

- New Features
  - Bridge tools: `chat_set_csp_mode` (`permissive` | `widget-declared`) and `chat_read_csp_audit`; emits `csp_audit` with `requestId` and timestamp; capability advertised via init; switching modes clears stored violations.
  - Audit per widget: violations, effective policy, findings, exact-origin suggestions, and agent prompt; includes a top-level `clean` flag; supports targeting a specific widget by `toolCallId` (defaults to the newest).
  - Unit tests for the audit builder; updates `skills/mcp-apps-builder` docs to run a CSP repair loop in Widget-Declared mode, use exact-origin fields, check runtime errors, and capture a final screenshot.

<sup>Written for commit 5dc5d36992036bac92b96653a72c5c8338b135f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

