### PR TITLE
fix(create-app): install canary SDK and skills on canary

### DIFF
--- a/.changeset/tall-ducks-smile.md
+++ b/.changeset/tall-ducks-smile.md
@@ -1,0 +1,5 @@
+---
+"create-mcp-use-app": patch
+---
+
+Install the canary SDK and mcp-apps-builder skill branch from canary scaffold releases instead of silently falling back to latest and main.

--- a/libraries/typescript/packages/create-mcp-use-app/src/__tests__/skills-config.test.ts
+++ b/libraries/typescript/packages/create-mcp-use-app/src/__tests__/skills-config.test.ts
@@ -10,6 +10,7 @@ import {
 describe("release-channel configuration", () => {
   it.each([
     ["2.0.0-beta.15", "beta", "beta"],
+    ["2.0.1-canary.3", "canary", "canary"],
     ["2.0.0", "latest", "main"],
   ] as const)(
     "maps create-mcp-use-app@%s to npm %s and skill branch %s",

--- a/libraries/typescript/packages/create-mcp-use-app/src/skills-config.ts
+++ b/libraries/typescript/packages/create-mcp-use-app/src/skills-config.ts
@@ -2,12 +2,19 @@ const SKILLS_REPO = "https://github.com/mcp-use/mcp-use.git";
 export const SKILLS_SPARSE_PATH = "skills/mcp-apps-builder";
 export const SKILLS_AGENT_DIRS = [".cursor", ".claude", ".agents"] as const;
 
-export function getDefaultDistTag(packageVersion: string): "beta" | "latest" {
-  return packageVersion.includes("-beta.") ? "beta" : "latest";
+export function getDefaultDistTag(
+  packageVersion: string
+): "beta" | "canary" | "latest" {
+  if (packageVersion.includes("-beta.")) return "beta";
+  if (packageVersion.includes("-canary.")) return "canary";
+  return "latest";
 }
 
-export function getSkillsBranch(packageVersion: string): "beta" | "main" {
-  return getDefaultDistTag(packageVersion) === "beta" ? "beta" : "main";
+export function getSkillsBranch(
+  packageVersion: string
+): "beta" | "canary" | "main" {
+  const channel = getDefaultDistTag(packageVersion);
+  return channel === "latest" ? "main" : channel;
 }
 
 export function getSkillsManualInstallCommand(packageVersion: string): string {


### PR DESCRIPTION
## Summary
- map `create-mcp-use-app` canary versions to the npm `canary` tag
- clone `mcp-apps-builder` from the `canary` branch instead of stale `main`
- add release-channel coverage and a patch changeset

This makes rebuilt Vibe base snapshots actually include the current canary skill.

## Validation
- `pnpm --filter create-mcp-use-app test`
- `pnpm --filter create-mcp-use-app lint`
- `pnpm --filter create-mcp-use-app build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure canary scaffolds install the `canary` SDK and pull the `mcp-apps-builder` skill from the `canary` branch instead of falling back to `latest`/`main`. Keeps snapshots and local scaffolds aligned with current canary skills.

- **Bug Fixes**
  - Map `create-mcp-use-app` versions with `-canary.` to npm `canary` and skills branch `canary` (`latest` → `main`, `beta` → `beta`).
  - Add unit test for canary channel mapping.
  - Include a patch changeset.

<sup>Written for commit be6daadba550cc336529a38dc24f96c637cc9b70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

