### PR TITLE
Skills over MCP Docs fixup

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -311,14 +311,14 @@
                       "v2/typescript/server/index",
                       "v2/typescript/server/migration",
                       "v2/typescript/server/examples",
+                      "v2/typescript/server/skills",
                       {
                         "group": "Core Components",
                         "icon": "box",
                         "pages": [
                           "v2/typescript/server/tools",
                           "v2/typescript/server/resources",
-                          "v2/typescript/server/prompts",
-                          "v2/typescript/server/skills"
+                          "v2/typescript/server/prompts"
                         ]
                       },
                       {

--- a/docs/v2/typescript/server/skills.mdx
+++ b/docs/v2/typescript/server/skills.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Skills over MCP"
 description: "Ship Agent Skills with your MCP server using automatic directory discovery."
+icon: "waypoints"
 ---
 
 <Warning>


### PR DESCRIPTION
Moves the Skills over MCP page out of Core Components and into the MCP Server root navigation.

Adds the `waypoints` icon to better represent skills being transported through MCP.

![Updated MCP Server navigation](https://raw.githubusercontent.com/mcp-use/mcp-use/feature/mcp-2973-skills-over-mcp-docs-fixup/docs/images/mcp-2973-skills-over-mcp-navigation.png)

Validation: pre-commit checks passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the “Skills over MCP” doc from the Core Components group to the MCP Server root navigation and sets its icon to “waypoints” for clarity. Previously nested under Core Components with a “box” icon; now listed with MCP Server topics. URLs are unchanged; no redirects or content edits.

- `docs/docs.json`: moves `v2/typescript/server/skills` into the MCP Server root pages; removes it from “Core Components”.
- `docs/v2/typescript/server/skills.mdx`: adds `icon: "waypoints"`.
- Addresses MCP-2973: improves discoverability.

<sup>Written for commit 9950d28a3495bba16aa751eb064dcc55b127e875. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

