### PR TITLE
fix(client): avoid eager OAuth state writes for public MCP connections

### DIFF
--- a/libraries/typescript/.changeset/lazy-node-oauth-state.md
+++ b/libraries/typescript/.changeset/lazy-node-oauth-state.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/client": patch
+---
+
+Defer Node OAuth store creation and callback port persistence until an authorization flow actually begins.

--- a/libraries/typescript/packages/client/src/auth/node.ts
+++ b/libraries/typescript/packages/client/src/auth/node.ts
@@ -149,6 +149,8 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
   private kv: KVStore;
   private authTimeoutMs: number;
   private openBrowserOverride?: (url: string) => Promise<void> | void;
+  /** Whether the selected callback port still needs to be written to storage. */
+  private shouldPersistSelectedPort: boolean;
 
   private server: Server | null = null;
   /** Provider authorization URL, exposed only through the local redirect route. */
@@ -164,7 +166,8 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
     port: number,
     session: OAuthSessionStore,
     kv: KVStore,
-    options: NodeOAuthOptions
+    options: NodeOAuthOptions,
+    shouldPersistSelectedPort: boolean
   ) {
     this.serverUrl = serverUrl;
     this.port = port;
@@ -172,6 +175,7 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
     this.kv = kv;
     this.authTimeoutMs = options.authTimeoutMs ?? DEFAULT_AUTH_TIMEOUT_MS;
     this.openBrowserOverride = options.openBrowser;
+    this.shouldPersistSelectedPort = shouldPersistSelectedPort;
   }
 
   /**
@@ -215,10 +219,6 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
       });
     }
 
-    if (port !== persistedPort) {
-      await kv.set("port", String(port));
-    }
-
     const callbackUrl = `http://127.0.0.1:${port}/callback`;
     const session = new OAuthSessionStore(
       serverUrl,
@@ -226,7 +226,14 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
       kv
     );
 
-    return new NodeOAuthClientProvider(serverUrl, port, session, kv, options);
+    return new NodeOAuthClientProvider(
+      serverUrl,
+      port,
+      session,
+      kv,
+      options,
+      port !== persistedPort
+    );
   }
 
   // --- Identity passthroughs (parallel to BrowserOAuthClientProvider) ---
@@ -369,6 +376,11 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
       throw new Error(
         "NodeOAuthClientProvider: an authorization is already in progress"
       );
+    }
+
+    if (this.shouldPersistSelectedPort) {
+      await this.kv.set("port", String(this.port));
+      this.shouldPersistSelectedPort = false;
     }
 
     const sanitizedUrl = await this.session.storeAuthorizationState(

--- a/libraries/typescript/packages/client/src/auth/storage-file.ts
+++ b/libraries/typescript/packages/client/src/auth/storage-file.ts
@@ -25,7 +25,8 @@ export class FileKVStore implements KVStore {
   constructor(serverUrlHash: string, baseDir?: string) {
     const root = baseDir ?? join(homedir(), ".mcp-use", "oauth");
     this.dir = join(root, serverUrlHash);
-    this.ensureDir();
+    // Keep construction and reads side-effect free. The directory is created
+    // only by set(), when OAuth state actually needs to be persisted.
   }
 
   private ensureDir(): void {

--- a/libraries/typescript/packages/client/tests/unit/auth/node-provider.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/auth/node-provider.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { createServer as createNetServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import {
   NodeOAuthClientProvider,
@@ -27,6 +31,87 @@ class MemoryKVStore implements KVStore {
 }
 
 describe("NodeOAuthClientProvider", () => {
+  it("prefers the persisted callback port over the configured default", async () => {
+    const probe = createNetServer();
+    await new Promise<void>((resolve) => probe.listen(0, "127.0.0.1", resolve));
+    const address = probe.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Port probe did not bind to a TCP port");
+    }
+    const persistedPort = address.port;
+    await new Promise<void>((resolve, reject) =>
+      probe.close((error) => (error ? reject(error) : resolve()))
+    );
+
+    const kv = new MemoryKVStore();
+    kv.set("port", String(persistedPort));
+    const provider = await NodeOAuthClientProvider.create(
+      "https://mcp.example.com/mcp",
+      {
+        kvStore: kv,
+        preferredPort: persistedPort === 33_418 ? 33_419 : 33_418,
+        portRange: 100,
+      }
+    );
+
+    expect(provider.callbackPort).toBe(persistedPort);
+  });
+
+  it("does not create OAuth state on disk until authorization starts", async () => {
+    const root = mkdtempSync(join(tmpdir(), "mcp-use-node-oauth-"));
+    const baseDir = join(root, "oauth");
+    let provider: NodeOAuthClientProvider | undefined;
+
+    try {
+      provider = await NodeOAuthClientProvider.create(
+        "https://public.example.com/mcp",
+        {
+          baseDir,
+          openBrowser: vi.fn(),
+          preferredPort: 33_000 + (process.pid % 1_000),
+          portRange: 100,
+        }
+      );
+
+      expect(existsSync(baseDir)).toBe(false);
+
+      const authorizationUrl = new URL("https://auth.example.com/authorize");
+      authorizationUrl.searchParams.set("state", "test-state");
+      await provider.redirectToAuthorization(authorizationUrl);
+
+      const portFile = join(baseDir, provider.serverUrlHash, "port");
+      expect(readFileSync(portFile, "utf8")).toBe(
+        String(provider.callbackPort)
+      );
+    } finally {
+      provider?.dispose();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("persists its callback port only when authorization starts", async () => {
+    const kv = new MemoryKVStore();
+    const set = vi.spyOn(kv, "set");
+    const provider = await NodeOAuthClientProvider.create(
+      "https://mcp.example.com/mcp",
+      {
+        kvStore: kv,
+        openBrowser: vi.fn(),
+        preferredPort: 34_000 + (process.pid % 1_000),
+        portRange: 100,
+      }
+    );
+
+    expect(set).not.toHaveBeenCalled();
+
+    const authorizationUrl = new URL("https://auth.example.com/authorize");
+    authorizationUrl.searchParams.set("state", "test-state");
+    await provider.redirectToAuthorization(authorizationUrl);
+
+    expect(set).toHaveBeenCalledWith("port", String(provider.callbackPort));
+    provider.dispose();
+  });
+
   it("preserves RFC 9207 iss from the loopback callback", async () => {
     const openBrowser = vi.fn();
     const provider = await NodeOAuthClientProvider.create(

--- a/libraries/typescript/packages/client/tests/unit/auth/storage.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/auth/storage.test.ts
@@ -7,7 +7,13 @@
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { FileKVStore } from "../../../src/auth/storage-file.js";
-import { mkdtempSync, rmSync, statSync, readdirSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  statSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -24,6 +30,21 @@ afterEach(() => {
 });
 
 describe("FileKVStore", () => {
+  it("does not create its directory until the first write", () => {
+    const dir = join(baseDir, "abc123");
+    const kv = new FileKVStore("abc123", baseDir);
+
+    expect(existsSync(dir)).toBe(false);
+    expect(kv.get("missing")).toBeNull();
+    expect(kv.keys()).toEqual([]);
+    expect(() => kv.remove("missing")).not.toThrow();
+    expect(existsSync(dir)).toBe(false);
+
+    kv.set("tokens", "secret");
+
+    expect(existsSync(dir)).toBe(true);
+  });
+
   it("round-trips simple keys", () => {
     const kv = new FileKVStore("abc123", baseDir);
     kv.set("tokens", '{"access":"x"}');


### PR DESCRIPTION
## Summary

- keep `FileKVStore` construction and read operations side-effect free
- defer callback-port persistence until a Node OAuth authorization flow actually begins
- continue preferring a persisted callback port so cached registrations retain a stable redirect URI
- add focused filesystem and provider regressions

## Root cause

`MCPClient` auto-provisions a Node OAuth provider before its first HTTP handshake. `NodeOAuthClientProvider.create()` constructed `FileKVStore`, whose constructor created the OAuth directory, and immediately persisted the selected loopback port. Consequently, public MCP connections wrote OAuth state before the server indicated that OAuth was required.

This keeps the existing client, transport, cached-token, mixed-auth, and CLI architecture intact. Provider creation may read existing state and select a callback port, but persistent state is created only on the first actual OAuth write.

## Impact

Public and local HTTP MCP connections no longer create OAuth directories or port files. Protected servers retain the existing automatic OAuth flow, and persisted callback ports remain stable across CLI processes.

## Validation

- `pnpm --filter @mcp-use/client build`
- `pnpm --filter @mcp-use/client test:run` — 333 tests passed
- built `@mcp-use/tunnel`, `@mcp-use/client`, and `@mcp-use/cli`
- connected the built CLI to `packages/server/examples/basic` with OAuth enabled
- successfully listed the example's `greet` tool
- verified no OAuth directory or port file was created in an isolated home directory
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers Node OAuth state writes in `@mcp-use/client` until an authorization flow starts. Previously provider creation created the OAuth directory and persisted the loopback port; now construction and reads are side‑effect free and the port is written on first redirect, so public/local HTTP MCP connections stop creating OAuth state while protected servers keep automatic OAuth with stable redirect URIs.

**Reviewer notes**
- `FileKVStore`: no directory creation on construct/read; `set()` creates the directory when first persisting OAuth state.
- `NodeOAuthClientProvider`: prefers a persisted callback port; tracks whether the selected port needs persistence and writes it on first `redirectToAuthorization`.
- Unit tests cover deferred writes and port preference; adds a patch changeset. Addresses Linear MCP-2895.

<sup>Written for commit 43a693a9d828b4513e8990813dda14dc46fe4045. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

