### PR TITLE
fix(client): add atomic OAuth reauthentication

### DIFF
--- a/libraries/typescript/.changeset/atomic-client-reauthentication.md
+++ b/libraries/typescript/.changeset/atomic-client-reauthentication.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/client": minor
+---
+
+Add an atomic React provider API for clearing OAuth credentials, remounting a managed server, and starting fresh authentication.

--- a/libraries/typescript/.changeset/pre.json
+++ b/libraries/typescript/.changeset/pre.json
@@ -10,5 +10,7 @@
     "mcp-use": "2.3.2",
     "@mcp-use/tunnel": "0.2.0"
   },
-  "changesets": []
+  "changesets": [
+    "scaffold-learn-more-link"
+  ]
 }

--- a/libraries/typescript/.changeset/pre.json
+++ b/libraries/typescript/.changeset/pre.json
@@ -1,0 +1,14 @@
+{
+  "mode": "pre",
+  "tag": "canary",
+  "initialVersions": {
+    "@mcp-use/agent": "2.0.9",
+    "@mcp-use/cli": "4.1.6",
+    "@mcp-use/client": "2.2.0",
+    "create-mcp-use-app": "2.0.4",
+    "@mcp-use/inspector": "20.3.1",
+    "mcp-use": "2.3.2",
+    "@mcp-use/tunnel": "0.2.0"
+  },
+  "changesets": []
+}

--- a/libraries/typescript/.changeset/scaffold-learn-more-link.md
+++ b/libraries/typescript/.changeset/scaffold-learn-more-link.md
@@ -1,0 +1,5 @@
+---
+"create-mcp-use-app": patch
+---
+
+Point the scaffold's closing "Learn more" line at `docs.mcp-use.com` instead of `manufact.com/docs`, which now redirects to Manufact's dashboard docs rather than to mcp-use documentation.

--- a/libraries/typescript/packages/client/src/react/McpClientProvider.tsx
+++ b/libraries/typescript/packages/client/src/react/McpClientProvider.tsx
@@ -61,6 +61,15 @@ export interface McpClientContextType {
     id: string,
     options: Partial<McpServerConfig>
   ) => Promise<void>;
+  /**
+   * Disconnect, clear persisted OAuth credentials, and remount a managed
+   * server. The replacement starts a fresh authorization flow as soon as OAuth
+   * discovery reaches an authenticatable state.
+   *
+   * The promise covers preparation of the replacement, not completion of the
+   * browser authorization flow. Observe the server state for the final result.
+   */
+  reauthenticateServer: (id: string) => Promise<void>;
   /** Returns a managed server by ID. */
   getServer: (id: string) => McpServer | undefined;
   /** Whether storage has finished loading (true if no storage provider) */
@@ -169,6 +178,8 @@ interface McpServerWrapperProps {
   ) => Promise<void>;
   onUpdateDisplayName: (id: string, displayName: string) => Promise<void>;
   onReconnect: (id: string) => Promise<void>;
+  reauthenticationRequest?: number;
+  onReauthenticationStarted: (id: string, request: number) => void;
   rpcWrapTransport?: (transport: Transport, serverId: string) => Transport;
   onGlobalSamplingRequest?: (
     request: PendingSamplingRequest,
@@ -215,6 +226,8 @@ function McpServerWrapper({
   onUpdateConfig,
   onUpdateDisplayName,
   onReconnect,
+  reauthenticationRequest,
+  onReauthenticationStarted,
   rpcWrapTransport,
   onGlobalSamplingRequest,
   onGlobalElicitationRequest,
@@ -352,6 +365,37 @@ function McpServerWrapper({
   );
 
   const reconnect = useCallback(() => onReconnect(id), [id, onReconnect]);
+
+  const handledReauthenticationRef = useRef<number | undefined>(undefined);
+  useEffect(() => {
+    if (
+      reauthenticationRequest === undefined ||
+      handledReauthenticationRef.current === reauthenticationRequest
+    ) {
+      return;
+    }
+
+    const canAuthenticate =
+      mcp.state === "pending_auth" ||
+      (mcp.state === "ready" &&
+        mcp.authorization?.mode === "mixed" &&
+        !mcp.authorization.authenticated);
+
+    if (!canAuthenticate) {
+      return;
+    }
+
+    handledReauthenticationRef.current = reauthenticationRequest;
+    onReauthenticationStarted(id, reauthenticationRequest);
+    void mcp.authenticate();
+  }, [
+    id,
+    mcp.state,
+    mcp.authorization,
+    mcp.authenticate,
+    reauthenticationRequest,
+    onReauthenticationStarted,
+  ]);
 
   // Update parent when state changes
   const onUpdateRef = useRef(onUpdate);
@@ -652,6 +696,13 @@ export function McpClientProvider({
   const [serverRevisions, setServerRevisions] = useState<
     Record<string, number>
   >({});
+  const [reauthenticationRequests, setReauthenticationRequests] = useState<
+    Record<string, number>
+  >({});
+  const reauthenticationOperationsRef = useRef(
+    new Map<string, { request: number; promise: Promise<void> }>()
+  );
+  const nextReauthenticationRequestRef = useRef<Record<string, number>>({});
   const [storageLoaded, setStorageLoaded] = useState(false);
   const didLoadInitialServers = useRef(false);
 
@@ -980,9 +1031,18 @@ export function McpClientProvider({
       //    a different component (`McpClientProvider`)".
       const captured = serversRef.current.find((s) => s.id === id);
 
+      // Invalidate preparation before any asynchronous teardown. An older
+      // reauthentication must never remount a server after it was removed.
+      reauthenticationOperationsRef.current.delete(id);
+
       setServers((prev) => prev.filter((s) => s.id !== id));
       setServerConfigs((prev) => prev.filter((s) => s.id !== id));
       setServerRevisions((prev) => {
+        const { [id]: _removed, ...remaining } = prev;
+        return remaining;
+      });
+      setReauthenticationRequests((prev) => {
+        if (prev[id] === undefined) return prev;
         const { [id]: _removed, ...remaining } = prev;
         return remaining;
       });
@@ -1071,6 +1131,91 @@ export function McpClientProvider({
     [serverConfigs]
   );
 
+  const handleReauthenticationStarted = useCallback(
+    (id: string, request: number) => {
+      setReauthenticationRequests((prev) => {
+        if (prev[id] !== request) return prev;
+        const { [id]: _started, ...remaining } = prev;
+        return remaining;
+      });
+    },
+    []
+  );
+
+  const reauthenticateServer = useCallback(
+    (id: string): Promise<void> => {
+      const currentConfig = serverConfigs.find((server) => server.id === id);
+      if (!currentConfig) {
+        return Promise.reject(
+          new Error(`Cannot reauthenticate unknown MCP server "${id}"`)
+        );
+      }
+
+      const existing = reauthenticationOperationsRef.current.get(id);
+      if (existing) {
+        return existing.promise;
+      }
+
+      const captured = serversRef.current.find((server) => server.id === id);
+      if (!captured) {
+        return Promise.reject(
+          new Error(`MCP server "${id}" is not mounted yet`)
+        );
+      }
+
+      const request = (nextReauthenticationRequestRef.current[id] ?? 0) + 1;
+      nextReauthenticationRequestRef.current[id] = request;
+      const operation = { request, promise: Promise.resolve() };
+
+      operation.promise = (async () => {
+        let prepared = false;
+        let invalidated = false;
+        try {
+          // Teardown must finish before credentials are removed and the
+          // replacement wrapper is mounted, or the old connection can race it.
+          await captured.disconnect();
+          captured.clearStorage();
+          prepared = true;
+        } finally {
+          // Removal invalidates the marker. In that case the old operation must
+          // not resurrect the deleted server after its disconnect settles.
+          if (reauthenticationOperationsRef.current.get(id) !== operation) {
+            invalidated = true;
+          } else {
+            // Always remount after a partial teardown failure so callers are
+            // not left with a disconnected wrapper. Only a fully prepared
+            // replacement receives the one-shot interactive OAuth request.
+            setServers((prev) => prev.filter((server) => server.id !== id));
+            setServerRevisions((prev) => ({
+              ...prev,
+              [id]: (prev[id] ?? 0) + 1,
+            }));
+            if (prepared) {
+              setReauthenticationRequests((prev) => ({
+                ...prev,
+                [id]: request,
+              }));
+            }
+          }
+        }
+
+        if (invalidated) {
+          throw new Error(
+            `MCP server "${id}" was removed during reauthentication`
+          );
+        }
+      })().finally(() => {
+        if (reauthenticationOperationsRef.current.get(id) === operation) {
+          reauthenticationOperationsRef.current.delete(id);
+        }
+      });
+
+      reauthenticationOperationsRef.current.set(id, operation);
+      return operation.promise;
+    },
+    [serverConfigs]
+  );
+
   const updateServerMetadata = useCallback(
     async (id: string, metadata: { name: string }) => {
       return new Promise<void>((resolve) => {
@@ -1122,6 +1267,7 @@ export function McpClientProvider({
       removeServer,
       updateServerMetadata,
       updateServer,
+      reauthenticateServer,
       getServer,
       storageLoaded,
     }),
@@ -1131,6 +1277,7 @@ export function McpClientProvider({
       removeServer,
       updateServerMetadata,
       updateServer,
+      reauthenticateServer,
       getServer,
       storageLoaded,
     ]
@@ -1203,6 +1350,8 @@ export function McpClientProvider({
               updateServerMetadata(id, { name: displayName })
             }
             onReconnect={reconnectServer}
+            reauthenticationRequest={reauthenticationRequests[config.id]}
+            onReauthenticationStarted={handleReauthenticationStarted}
             rpcWrapTransport={rpcWrapTransport}
             onGlobalSamplingRequest={onSamplingRequest}
             onGlobalElicitationRequest={onElicitationRequest}

--- a/libraries/typescript/packages/client/tests/unit/react/mcp-client-provider-metadata-updates.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/react/mcp-client-provider-metadata-updates.test.ts
@@ -10,7 +10,9 @@ import { MemoryStorageProvider } from "../../../src/react/storage.js";
 let mountCount = 0;
 const disconnectSpies: Array<ReturnType<typeof vi.fn>> = [];
 const clearStorageSpies: Array<ReturnType<typeof vi.fn>> = [];
+const authenticateSpies: Array<ReturnType<typeof vi.fn>> = [];
 let latestClient: ReturnType<typeof useMcpClient> | null = null;
+let mockState: "discovering" | "pending_auth" | "ready" | "failed" = "ready";
 let mockProtocolEra: "legacy" | "modern" = "legacy";
 let mockInstructions = "legacy instructions";
 let mockAuthorization: { mode: "mixed"; authenticated: boolean } | undefined;
@@ -34,11 +36,16 @@ vi.mock("../../../src/react/useMcp.js", () => {
     useMcp: () => {
       const disconnect = React.useMemo(() => vi.fn(), []);
       const clearStorage = React.useMemo(() => vi.fn(), []);
+      const authenticate = React.useMemo(
+        () => vi.fn().mockResolvedValue(undefined),
+        []
+      );
 
       useEffect(() => {
         mountCount += 1;
         disconnectSpies.push(disconnect);
         clearStorageSpies.push(clearStorage);
+        authenticateSpies.push(authenticate);
       }, [disconnect, clearStorage]);
 
       return {
@@ -50,7 +57,7 @@ vi.mock("../../../src/react/useMcp.js", () => {
         skills: mockSkills,
         serverInfo,
         capabilities,
-        state: "ready" as const,
+        state: mockState,
         error: undefined,
         authUrl: undefined,
         authTokens: undefined,
@@ -65,6 +72,7 @@ vi.mock("../../../src/react/useMcp.js", () => {
         refresh: vi.fn(),
         reconnect: vi.fn(),
         disconnect,
+        authenticate,
         clearStorage,
         client,
       };
@@ -106,12 +114,72 @@ describe("McpClientProvider metadata-only updates", () => {
     mountCount = 0;
     disconnectSpies.length = 0;
     clearStorageSpies.length = 0;
+    authenticateSpies.length = 0;
     latestClient = null;
+    mockState = "ready";
     mockProtocolEra = "legacy";
     mockInstructions = "legacy instructions";
     mockAuthorization = undefined;
     mockSkills = [];
     vi.restoreAllMocks();
+  });
+
+  it("atomically tears down, clears credentials, remounts, and authenticates", async () => {
+    let renderer: ReturnType<typeof create>;
+    await act(async () => {
+      renderer = create(
+        React.createElement(
+          McpClientProvider,
+          null,
+          React.createElement(TestHarness)
+        )
+      );
+    });
+    await flushUpdates();
+
+    const firstDisconnect = disconnectSpies[0];
+    const firstClearStorage = clearStorageSpies[0];
+    const order: string[] = [];
+    firstDisconnect.mockImplementation(async () => {
+      order.push("disconnect:start");
+      await Promise.resolve();
+      order.push("disconnect:end");
+    });
+    firstClearStorage.mockImplementation(() => {
+      order.push("clearStorage");
+    });
+
+    mockState = "discovering";
+    let reauthentication: Promise<void> | undefined;
+    await act(async () => {
+      reauthentication = latestClient!.reauthenticateServer("sandbox");
+      await Promise.resolve();
+    });
+    await flushUpdates();
+    expect(authenticateSpies[1]).not.toHaveBeenCalled();
+
+    mockState = "pending_auth";
+    await act(async () => {
+      renderer!.update(
+        React.createElement(
+          McpClientProvider,
+          null,
+          React.createElement(TestHarness)
+        )
+      );
+    });
+    await act(async () => {
+      await reauthentication;
+    });
+
+    expect(order).toEqual([
+      "disconnect:start",
+      "disconnect:end",
+      "clearStorage",
+    ]);
+    expect(mountCount).toBe(2);
+    expect(authenticateSpies[0]).not.toHaveBeenCalled();
+    expect(authenticateSpies[1]).toHaveBeenCalledTimes(1);
   });
 
   it("updates configured server metadata without reconnecting", async () => {

--- a/libraries/typescript/packages/create-mcp-use-app/CHANGELOG.md
+++ b/libraries/typescript/packages/create-mcp-use-app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # create-mcp-use-app
 
+## 2.0.5-canary.0
+
+### Patch Changes
+
+- 08639bc: Point the scaffold's closing "Learn more" line at `docs.mcp-use.com` instead of `manufact.com/docs`, which now redirects to Manufact's dashboard docs rather than to mcp-use documentation.
+
 ## 2.0.4
 
 ### Patch Changes

--- a/libraries/typescript/packages/create-mcp-use-app/package.json
+++ b/libraries/typescript/packages/create-mcp-use-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-mcp-use-app",
-  "version": "2.0.4",
+  "version": "2.0.5-canary.0",
   "type": "module",
   "description": "Create MCP-Use apps with one command",
   "author": "mcp-use, Inc.",

--- a/libraries/typescript/packages/create-mcp-use-app/src/index.ts
+++ b/libraries/typescript/packages/create-mcp-use-app/src/index.ts
@@ -1137,7 +1137,7 @@ async function main(): Promise<void> {
     );
     console.log("");
   }
-  console.log(ansi.cyan("📚 Learn more: https://manufact.com/docs"));
+  console.log(ansi.cyan("📚 Learn more: https://docs.mcp-use.com"));
   console.log(ansi.gray("💬 For feedback and bug reporting visit:"));
   console.log(
     ansi.gray("   https://github.com/mcp-use/mcp-use or https://manufact.com")


### PR DESCRIPTION
## Summary

Adds reauthenticateServer(id) to the React McpClientProvider so hosts can prepare a clean OAuth reauthentication without coordinating disconnect, credential removal, wrapper remounting, and discovery timing themselves.

## Problem

Consumers currently have to compose clearStorage(), reconnect or wrapper replacement, state observation, and authenticate(). Calling authenticate() while the replacement is still discovering is intentionally ignored, while treating a full-page browser OAuth redirect as a promise that reports final success creates unresolved operations and permanent locks when the page navigates or the user abandons consent.

## Implementation

- disconnect the current wrapper before clearing its persisted OAuth credentials
- unconditionally remount the managed server with a new wrapper revision
- start authentication once the replacement reaches pending_auth or unauthenticated mixed-auth ready
- scope the returned promise to replacement preparation, not browser OAuth completion; consumers observe normal server state for the eventual result
- share concurrent preparation calls for the same server
- invalidate preparation when removeServer removes the server, preventing an older operation from resurrecting it
- remount after partial teardown failure while rejecting the preparation promise
- consume the one-shot authentication request when the replacement starts OAuth
- add one focused regression case and a client changeset

## Example

    const { reauthenticateServer } = useMcpClient();
    await reauthenticateServer(serverId);

## Validation

- [x] Rebased onto current canary
- [x] Focused provider regression: 1 file, 8 tests
- [x] Complete @mcp-use/client suite: 55 files, 340 tests
- [x] @mcp-use/client package and declaration build
- [x] @mcp-use/inspector production build and package verification
- [x] ESLint, Prettier, and git diff --check
- [ ] Final live Linear consent, gateway reconnect, and read-only tool call

The API is additive and existing provider consumers are unchanged.

Companion Cloud dashboard PR: https://github.com/mcp-use/mcp-use-cloud/pull/1452