### PR TITLE
fix(client): avoid blocking on legacy SSE readiness

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -311,14 +311,14 @@
                       "v2/typescript/server/index",
                       "v2/typescript/server/migration",
                       "v2/typescript/server/examples",
+                      "v2/typescript/server/skills",
                       {
                         "group": "Core Components",
                         "icon": "box",
                         "pages": [
                           "v2/typescript/server/tools",
                           "v2/typescript/server/resources",
-                          "v2/typescript/server/prompts",
-                          "v2/typescript/server/skills"
+                          "v2/typescript/server/prompts"
                         ]
                       },
                       {

--- a/docs/v2/typescript/server/skills.mdx
+++ b/docs/v2/typescript/server/skills.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Skills over MCP"
 description: "Ship Agent Skills with your MCP server using automatic directory discovery."
+icon: "waypoints"
 ---
 
 <Warning>

--- a/libraries/typescript/.changeset/client-background-legacy-sse.md
+++ b/libraries/typescript/.changeset/client-background-legacy-sse.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/client": patch
+---
+
+Stop blocking legacy HTTP connection readiness for up to five seconds while the optional standalone SSE stream attaches. Notification and reverse-RPC handlers are now registered before the handshake so request/response operations can proceed immediately without racing inbound messages.

--- a/libraries/typescript/packages/client/src/transport/http.ts
+++ b/libraries/typescript/packages/client/src/transport/http.ts
@@ -650,28 +650,15 @@ export class HttpConnector extends BaseConnector {
         headers: this.headers,
       });
 
-      let markPushStreamReady: (() => void) | undefined;
-      const pushStreamReady = new Promise<void>((resolve) => {
-        markPushStreamReady = resolve;
-      });
       const baseFetch = this.customFetch ?? globalThis.fetch.bind(globalThis);
       const observedFetch: typeof fetch = async (input, init) => {
         const response = await baseFetch(input, init);
-        const method =
-          init?.method ?? (input instanceof Request ? input.method : "GET");
         const requestHeaders = new Headers(
           input instanceof Request ? input.headers : undefined
         );
         new Headers(init?.headers).forEach((value, key) => {
           requestHeaders.set(key, value);
         });
-        if (
-          method.toUpperCase() === "GET" &&
-          response.ok &&
-          response.headers.get("content-type")?.includes("text/event-stream")
-        ) {
-          markPushStreamReady?.();
-        }
         // subscriptions/listen owns its SSE reader and acknowledgement state.
         // Re-wrapping that response breaks the SDK's per-request stream hooks;
         // the progress observer is only for ordinary request/response calls.
@@ -730,8 +717,9 @@ export class HttpConnector extends BaseConnector {
       this.setupRootsHandler();
       this.setupSamplingHandler();
       this.setupElicitationHandler();
+      this.setupNotificationHandler();
       logger.debug(
-        "Roots/sampling/elicitation handlers registered before connect"
+        "Roots/sampling/elicitation/notification handlers registered before connect"
       );
 
       try {
@@ -758,31 +746,12 @@ export class HttpConnector extends BaseConnector {
           if (connectTimeout !== undefined) clearTimeout(connectTimeout);
         });
 
-        // The official SDK opens the v1 standalone GET stream in the
-        // background after initialization. Wait until its response headers
-        // arrive so reverse RPC and notifications cannot race connect().
-        if (
-          (this.client.getProtocolEra?.() ?? "legacy") === "legacy" &&
-          streamableTransport.sessionId
-        ) {
-          let readinessTimeout: ReturnType<typeof setTimeout> | undefined;
-          const attached = await Promise.race([
-            pushStreamReady.then(() => true),
-            new Promise<false>(
-              (resolve) =>
-                (readinessTimeout = setTimeout(
-                  () => resolve(false),
-                  Math.min(this.timeout, 5000)
-                ))
-            ),
-          ]);
-          if (readinessTimeout) clearTimeout(readinessTimeout);
-          if (!attached) {
-            logger.warn(
-              "Legacy server push stream did not attach before connect completed"
-            );
-          }
-        }
+        // The official SDK opens the optional v1 standalone GET stream in the
+        // background after initialization. Do not gate ordinary request/response
+        // readiness on that long-lived stream: proxies may buffer its headers,
+        // while tools/list and other client operations are already usable.
+        // Inbound request and notification handlers are registered above before
+        // connect(), so the stream can attach later without racing handler setup.
 
         // Streamable HTTP servers may optionally assign a session ID.
         const sessionId = streamableTransport.sessionId;
@@ -832,7 +801,6 @@ export class HttpConnector extends BaseConnector {
 
       this.connected = true;
       this.transportType = "streamable-http";
-      this.setupNotificationHandler();
       // Inbound request handlers (roots/sampling/elicitation) were registered before connect()
       logger.debug(
         `Successfully connected to MCP implementation via streamable HTTP: ${baseUrl}`

--- a/libraries/typescript/packages/client/tests/unit/client/connector-callback-ordering.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/client/connector-callback-ordering.test.ts
@@ -4,7 +4,7 @@
  * Run with: pnpm test:run tests/unit/client/connector-callback-ordering.test.ts
  */
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const lifecycle = vi.hoisted(() => ({
   events: [] as string[],
@@ -17,7 +17,18 @@ vi.mock("@modelcontextprotocol/client", async (importOriginal) => {
 
   class MockClient {
     _notificationHandlers = new Map();
-    fallbackNotificationHandler?: (notification: unknown) => Promise<void>;
+    private notificationHandler?: (notification: unknown) => Promise<void>;
+
+    set fallbackNotificationHandler(
+      handler: ((notification: unknown) => Promise<void>) | undefined
+    ) {
+      this.notificationHandler = handler;
+      lifecycle.events.push("handler:notifications");
+    }
+
+    get fallbackNotificationHandler() {
+      return this.notificationHandler;
+    }
 
     constructor() {
       lifecycle.events.push("client:construct");
@@ -71,6 +82,10 @@ describe("HttpConnector inbound handler ordering", () => {
     lifecycle.terminateSession.mockResolvedValue(undefined);
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("registers v1 handlers once before streamable HTTP Client.connect()", async () => {
     const connector = new TestHttpConnector("http://localhost:3000/mcp", {
       onSampling: vi.fn().mockResolvedValue({
@@ -89,6 +104,7 @@ describe("HttpConnector inbound handler ordering", () => {
       "handler:roots/list",
       "handler:sampling/createMessage",
       "handler:elicitation/create",
+      "handler:notifications",
       "client:connect",
     ]);
 
@@ -109,5 +125,24 @@ describe("HttpConnector inbound handler ordering", () => {
       "client:close",
       "transport:close",
     ]);
+  });
+
+  it("does not wait for the optional legacy push stream before becoming ready", async () => {
+    vi.useFakeTimers();
+    const connector = new TestHttpConnector("http://localhost:3000/mcp", {
+      timeout: 10_000,
+    });
+
+    let connected = false;
+    const connecting = connector.connect().then(() => {
+      connected = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(connected).toBe(true);
+    expect(lifecycle.events).toContain("handler:notifications");
+    await connecting;
+    await connector.disconnect();
   });
 });


### PR DESCRIPTION
## Summary

- let the optional legacy standalone SSE stream attach in the background instead of gating HTTP connection readiness for up to five seconds
- register notification handlers before `Client.connect()` alongside the existing reverse-RPC handlers, preserving inbound-message safety without delaying ordinary requests
- add focused regression coverage and a patch changeset for `@mcp-use/client`

## Root cause

After the legacy initialize handshake, `HttpConnector` waited for the standalone GET/SSE response headers before resolving `connect()`. Proxies can buffer that long-lived response even though initialize and normal request/response operations are already usable, causing the client to consume the full five-second fallback before loading tools.

## User impact

Legacy/sessionful HTTP connections can begin `tools/list` and other capability requests immediately after initialization. Reverse RPC and notifications remain safe because their handlers are installed before the transport handshake begins.

## Validation

- `pnpm test:run` in `@mcp-use/client`: 54 files, 330 tests passed
- focused connector lifecycle regression: 3 tests passed
- `pnpm build` in `@mcp-use/client`
- Prettier check and ESLint on the changed source and test
- `pnpm version:check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Avoids blocking `Client.connect()` on legacy SSE readiness. Previously, legacy HTTP waited up to five seconds for standalone SSE headers; now the optional SSE stream attaches in the background, and notification handlers register before connect to keep inbound messages safe while ordinary requests proceed immediately.

**Review notes**
- Remove SSE readiness wait: delete `pushStreamReady` and the 5s race; do not gate connect on SSE headers in legacy era.
- Register `notification` handlers before `connect()`, alongside roots/sampling/elicitation, to prevent inbound message races.
- Add focused unit coverage in `connector-callback-ordering.test.ts` for handler order and readiness without SSE wait.
- Publish a patch changeset for `@mcp-use/client`.

<sup>Written for commit 3d3a08c2bde5fce319eb4ea4315d7d8abeeaf925. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

