### PR TITLE
fix: allow compatible parent OAuth resources

### DIFF
--- a/libraries/typescript/.changeset/inspector-oauth-parent-resource.md
+++ b/libraries/typescript/.changeset/inspector-oauth-parent-resource.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Allow OAuth protected-resource metadata to advertise a resource on the same origin whose path is a segment-aware parent of the MCP endpoint, matching the official MCP TypeScript SDK compatibility policy. Root well-known discovery now validates against the root resource identifier, while cross-origin, sibling-path, credential-bearing, fragmented, and insecure non-loopback resource values remain rejected.

--- a/libraries/typescript/packages/inspector/src/server/proxy/oauth-proxy.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy/oauth-proxy.ts
@@ -33,6 +33,12 @@ type Binding = {
   updatedAt: number;
 };
 
+type ProtectedResourceMetadataTarget = {
+  type: "protected-resource";
+  /** Resource identifier used to construct this RFC 9728 well-known URL. */
+  resourceIdentifier: URL;
+};
+
 type ConfidentialClient = {
   clientSecret: string;
   authMethod: "client_secret_basic" | "client_secret_post";
@@ -225,6 +231,7 @@ export function mountOAuthProxy(
         await bindProtectedResource(
           metadata,
           serverUrl,
+          metadataKind.resourceIdentifier,
           binding,
           allowLoopback
         );
@@ -457,16 +464,18 @@ function classifyMetadataTarget(
   target: URL,
   binding: Binding
 ):
-  | { type: "protected-resource" }
+  | ProtectedResourceMetadataTarget
   | { type: "authorization-server"; issuer: string }
   | undefined {
   const targetUrl = canonicalUrl(target);
-  if (
-    protectedResourceMetadataUrls(serverUrl).some(
-      (candidate) => canonicalUrl(candidate) === targetUrl
-    )
-  ) {
-    return { type: "protected-resource" };
+  const protectedResourceTarget = protectedResourceMetadataTargets(
+    serverUrl
+  ).find((candidate) => canonicalUrl(candidate.url) === targetUrl);
+  if (protectedResourceTarget) {
+    return {
+      type: "protected-resource",
+      resourceIdentifier: protectedResourceTarget.resourceIdentifier,
+    };
   }
   for (const issuer of binding.authorizationServers) {
     if (
@@ -480,11 +489,23 @@ function classifyMetadataTarget(
   return undefined;
 }
 
-function protectedResourceMetadataUrls(serverUrl: URL): URL[] {
+function protectedResourceMetadataTargets(serverUrl: URL): Array<{
+  url: URL;
+  resourceIdentifier: URL;
+}> {
   const path = serverUrl.pathname === "/" ? "" : serverUrl.pathname;
   return [
-    new URL(`/.well-known/oauth-protected-resource${path}`, serverUrl.origin),
-    new URL("/.well-known/oauth-protected-resource", serverUrl.origin),
+    {
+      url: new URL(
+        `/.well-known/oauth-protected-resource${path}`,
+        serverUrl.origin
+      ),
+      resourceIdentifier: serverUrl,
+    },
+    {
+      url: new URL("/.well-known/oauth-protected-resource", serverUrl.origin),
+      resourceIdentifier: new URL(serverUrl.origin),
+    },
   ];
 }
 
@@ -500,13 +521,19 @@ function authorizationServerMetadataUrls(issuer: URL): URL[] {
 async function bindProtectedResource(
   metadata: Record<string, unknown>,
   serverUrl: URL,
+  resourceIdentifier: URL,
   binding: Binding,
   allowLoopback: boolean
 ): Promise<void> {
-  if (
-    typeof metadata.resource !== "string" ||
-    canonicalUrl(new URL(metadata.resource)) !== canonicalUrl(serverUrl)
-  ) {
+  const advertisedResource = parseResourceUrl(metadata.resource, allowLoopback);
+  const matchesDiscoveredResource =
+    advertisedResource !== undefined &&
+    canonicalUrl(advertisedResource) === canonicalUrl(resourceIdentifier);
+  const matchesCompatibleParentResource =
+    advertisedResource !== undefined &&
+    isCompatibleParentResource(serverUrl, advertisedResource);
+
+  if (!matchesDiscoveredResource && !matchesCompatibleParentResource) {
     throw new InvalidUpstreamError(
       "Protected-resource metadata does not match serverUrl"
     );
@@ -533,6 +560,58 @@ async function bindProtectedResource(
   binding.authorizationServers = issuers;
   binding.endpoints.clear();
   binding.tokenEndpointAuthMethods.clear();
+}
+
+/**
+ * Parse an advertised RFC 9728 resource without allowing URI shapes that are
+ * unsafe or invalid as OAuth resource indicators.
+ */
+function parseResourceUrl(
+  value: unknown,
+  allowLoopback: boolean
+): URL | undefined {
+  if (typeof value !== "string" || value.length === 0) return undefined;
+  try {
+    const url = new URL(value);
+    const allowedProtocol =
+      url.protocol === "https:" ||
+      (allowLoopback &&
+        url.protocol === "http:" &&
+        isLoopbackHostname(url.hostname));
+    if (!allowedProtocol || url.username || url.password || url.hash) {
+      return undefined;
+    }
+    return url;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Compatibility policy used by the official MCP TypeScript SDK: an MCP
+ * endpoint may advertise a broader resource on the same origin when the
+ * advertised path is a segment-aware parent of the endpoint path.
+ *
+ * This intentionally rejects cross-origin resources and sibling paths. The
+ * advertised value is not rewritten; the OAuth client sends it verbatim in
+ * authorization, token, and refresh requests.
+ */
+function isCompatibleParentResource(
+  serverUrl: URL,
+  advertisedResource: URL
+): boolean {
+  if (serverUrl.origin !== advertisedResource.origin) return false;
+  if (serverUrl.pathname.length < advertisedResource.pathname.length) {
+    return false;
+  }
+
+  const serverPath = serverUrl.pathname.endsWith("/")
+    ? serverUrl.pathname
+    : `${serverUrl.pathname}/`;
+  const resourcePath = advertisedResource.pathname.endsWith("/")
+    ? advertisedResource.pathname
+    : `${advertisedResource.pathname}/`;
+  return serverPath.startsWith(resourcePath);
 }
 
 async function bindAuthorizationServer(
@@ -575,8 +654,8 @@ async function hydrateBinding(
   timeoutMs: number,
   maxResponseBodyBytes: number
 ): Promise<void> {
-  for (const metadataUrl of protectedResourceMetadataUrls(serverUrl)) {
-    const response = await safeFetch(metadataUrl, {
+  for (const target of protectedResourceMetadataTargets(serverUrl)) {
+    const response = await safeFetch(target.url, {
       method: "GET",
       headers: { Accept: "application/json" },
       redirect: "manual",
@@ -591,6 +670,7 @@ async function hydrateBinding(
     await bindProtectedResource(
       parseObject(await readCapped(response, maxResponseBodyBytes)),
       serverUrl,
+      target.resourceIdentifier,
       binding,
       allowLoopback
     );

--- a/libraries/typescript/packages/inspector/tests/unit/oauth-proxy-resource.test.ts
+++ b/libraries/typescript/packages/inspector/tests/unit/oauth-proxy-resource.test.ts
@@ -1,0 +1,178 @@
+import { Hono } from "hono";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mountOAuthProxy } from "../../src/server/proxy/oauth-proxy";
+
+const inspectorOrigin = "https://inspector.example.com";
+const issuer = "https://93.184.216.35";
+
+function protectedResourceMetadataUrl(serverUrl: string): string {
+  const server = new URL(serverUrl);
+  const path = server.pathname === "/" ? "" : server.pathname;
+  return `${server.origin}/.well-known/oauth-protected-resource${path}`;
+}
+
+function rootProtectedResourceMetadataUrl(serverUrl: string): string {
+  return `${new URL(serverUrl).origin}/.well-known/oauth-protected-resource`;
+}
+
+function metadataRequest(serverUrl: string, targetUrl: string): Request {
+  return new Request(
+    `${inspectorOrigin}/oauth/metadata?serverUrl=${encodeURIComponent(serverUrl)}&url=${encodeURIComponent(targetUrl)}`,
+    { headers: { Origin: inspectorOrigin } }
+  );
+}
+
+async function requestProtectedResourceMetadata(options: {
+  serverUrl: string;
+  metadataUrl?: string;
+  advertisedResource: string;
+  allowLoopback?: boolean;
+}): Promise<Response> {
+  const metadataUrl =
+    options.metadataUrl ?? protectedResourceMetadataUrl(options.serverUrl);
+  vi.stubGlobal(
+    "fetch",
+    vi.fn<typeof fetch>(async (input) => {
+      if (input.toString() === metadataUrl) {
+        return new Response(
+          JSON.stringify({
+            resource: options.advertisedResource,
+            authorization_servers: [issuer],
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }
+        );
+      }
+      return new Response("not found", { status: 404 });
+    })
+  );
+
+  const app = new Hono();
+  mountOAuthProxy(app, {
+    basePath: "/oauth",
+    enableLogging: false,
+    allowLoopback: options.allowLoopback,
+  });
+  return app.fetch(metadataRequest(options.serverUrl, metadataUrl));
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("Inspector OAuth BFF protected-resource binding", () => {
+  it("accepts metadata exactly bound to a path-scoped MCP endpoint", async () => {
+    const serverUrl = "https://93.184.216.34/api/mcp";
+
+    const response = await requestProtectedResourceMetadata({
+      serverUrl,
+      advertisedResource: serverUrl,
+    });
+
+    expect(response.status).toBe(200);
+  });
+
+  it("accepts a same-origin parent resource used by the official MCP SDK", async () => {
+    const serverUrl = "https://93.184.216.34/api/mcp";
+
+    const response = await requestProtectedResourceMetadata({
+      serverUrl,
+      advertisedResource: "https://93.184.216.34/api",
+    });
+
+    expect(response.status).toBe(200);
+  });
+
+  it("accepts an origin resource for a path endpoint for ecosystem compatibility", async () => {
+    const serverUrl = "https://93.184.216.34/api/mcp";
+
+    const response = await requestProtectedResourceMetadata({
+      serverUrl,
+      advertisedResource: "https://93.184.216.34",
+    });
+
+    expect(response.status).toBe(200);
+  });
+
+  it("accepts an origin resource discovered through the root well-known fallback", async () => {
+    const serverUrl = "https://93.184.216.34/api/mcp";
+    const metadataUrl = rootProtectedResourceMetadataUrl(serverUrl);
+
+    const response = await requestProtectedResourceMetadata({
+      serverUrl,
+      metadataUrl,
+      advertisedResource: "https://93.184.216.34",
+    });
+
+    expect(response.status).toBe(200);
+  });
+
+  it("preserves explicit HTTP loopback support for local development", async () => {
+    const serverUrl = "http://127.0.0.1:4321/api/mcp";
+
+    const response = await requestProtectedResourceMetadata({
+      serverUrl,
+      advertisedResource: "http://127.0.0.1:4321",
+      allowLoopback: true,
+    });
+
+    expect(response.status).toBe(200);
+  });
+
+  it("rejects a same-origin sibling resource", async () => {
+    const serverUrl = "https://93.184.216.34/api/mcp";
+
+    const response = await requestProtectedResourceMetadata({
+      serverUrl,
+      advertisedResource: "https://93.184.216.34/other",
+    });
+
+    expect(response.status).toBe(502);
+    expect(await response.json()).toEqual({
+      error: "Protected-resource metadata does not match serverUrl",
+    });
+  });
+
+  it("uses path-segment boundaries when matching parent resources", async () => {
+    const serverUrl = "https://93.184.216.34/api-evil/mcp";
+
+    const response = await requestProtectedResourceMetadata({
+      serverUrl,
+      advertisedResource: "https://93.184.216.34/api",
+    });
+
+    expect(response.status).toBe(502);
+  });
+
+  it("rejects a resource on a different origin", async () => {
+    const serverUrl = "https://93.184.216.34/api/mcp";
+
+    const response = await requestProtectedResourceMetadata({
+      serverUrl,
+      advertisedResource: "https://93.184.216.36/api",
+    });
+
+    expect(response.status).toBe(502);
+  });
+
+  it.each([
+    "http://93.184.216.34/api",
+    "https://user:password@93.184.216.34/api",
+    "https://93.184.216.34/api#fragment",
+    "not a URL",
+  ])(
+    "rejects an unsafe or invalid advertised resource: %s",
+    async (resource) => {
+      const serverUrl = "https://93.184.216.34/api/mcp";
+
+      const response = await requestProtectedResourceMetadata({
+        serverUrl,
+        advertisedResource: resource,
+      });
+
+      expect(response.status).toBe(502);
+    }
+  );
+});


### PR DESCRIPTION
## Summary

- validate RFC 9728 root well-known metadata against the root resource identifier used to construct its discovery URL
- allow same-origin, segment-aware parent resources as a compatibility fallback, matching the official MCP TypeScript SDK's `checkResourceAllowed` policy
- keep cross-origin, sibling-path, path-boundary, credential-bearing, fragmented, malformed, and insecure non-loopback resources blocked
- preserve the existing explicit HTTP loopback exception for local Inspector development

## Root cause

The Inspector OAuth BFF required Protected Resource Metadata `resource` to equal the complete MCP transport URL for every discovery route. That rejected ecosystem servers which expose a transport at a subpath such as `/api/mcp` but advertise an origin- or API-level OAuth resource, even though the official MCP TypeScript SDK accepts those same-origin parent resources. It also failed to distinguish root well-known discovery, where the resource identifier used to construct the metadata URL is the origin rather than the full endpoint.

The compatibility check is intentionally narrower than an arbitrary same-origin relaxation: the advertised path must be a segment-aware ancestor of the MCP endpoint path. `/api` can bind `/api/mcp`, but cannot bind `/api-evil/mcp` or `/other`.

## Validation

- focused OAuth BFF tests: 14 passed
- full Inspector unit suite: 218 passed
- Inspector TypeScript type-check: passed
- Inspector production/package build and `verify:package`: passed
- focused ESLint and `git diff --check`: passed


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts compatible parent OAuth protected resources and correctly validates root well-known metadata in `@mcp-use/inspector`. Previously the OAuth proxy required `metadata.resource` to equal the full MCP transport URL; now it accepts the origin or a segment-aware parent path on the same origin, matching the MCP TypeScript SDK, while still rejecting cross-origin, sibling-path, credential-bearing, fragmented, and insecure non-loopback resources; the HTTP loopback exception for local Inspector development remains.

**Review notes**
- Carries a resource identifier for each protected-resource metadata target (path-scoped and root well-known) and uses it during binding.
- `bindProtectedResource` now checks the advertised resource against the discovered identifier or a compatible same-origin parent; adds `parseResourceUrl` and `isCompatibleParentResource` for safe parsing and segment-aware matching.
- Adds unit tests covering accepted parent/origin cases, root well-known discovery, loopback, and rejection of unsafe/invalid resources.

**Rollout**
- No migration required; servers advertising a parent or origin resource now bind successfully.
- Keep `allowLoopback` disabled in production.

<sup>Written for commit db558236229a1ebdcc97b7741d2d99577f3ed90a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

