### PR TITLE
fix stale browser OAuth discovery

### DIFF
--- a/libraries/typescript/.changeset/fresh-challenges-recover.md
+++ b/libraries/typescript/.changeset/fresh-challenges-recover.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/client": patch
+---
+
+Recover browser OAuth discovery when a fresh MCP `resource_metadata` challenge conflicts with incomplete or stale persisted discovery state.

--- a/libraries/typescript/packages/client/src/auth/browser.ts
+++ b/libraries/typescript/packages/client/src/auth/browser.ts
@@ -1,11 +1,12 @@
 // browser-provider.ts
-import type {
-  OAuthClientInformation,
-  OAuthClientInformationContext,
-  OAuthClientMetadata,
-  OAuthClientProvider,
-  OAuthDiscoveryState,
-  OAuthTokens,
+import {
+  extractWWWAuthenticateParams,
+  type OAuthClientInformation,
+  type OAuthClientInformationContext,
+  type OAuthClientMetadata,
+  type OAuthClientProvider,
+  type OAuthDiscoveryState,
+  type OAuthTokens,
 } from "@modelcontextprotocol/client";
 import { LocalStorageKVStore } from "./storage.js";
 import { OAuthSessionStore } from "./session-store.js";
@@ -99,6 +100,8 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
   private proxyOAuthRequests: boolean;
   private lastAttemptedAuthUrl: string | null = null;
   private authorizationPending = false;
+  /** Latest protected-resource metadata URL advertised by an MCP 401. */
+  private challengedResourceMetadataUrl: string | undefined;
   /** Callback invoked immediately before an authorization popup opens. */
   readonly onPopupWindow:
     | ((
@@ -233,6 +236,12 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
     }
   }
 
+  private rememberResourceMetadataChallenge(response: Response): void {
+    if (response.status !== 401) return;
+    const { resourceMetadataUrl } = extractWWWAuthenticateParams(response);
+    this.challengedResourceMetadataUrl = resourceMetadataUrl?.toString();
+  }
+
   /**
    * Returns a `fetch` function, scoped to this provider, that routes OAuth
    * metadata and non-browser OAuth endpoint requests through the configured
@@ -293,10 +302,12 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
       // This is scoped to discovery; MCP traffic and OAuth endpoint POSTs keep
       // their caller-provided cache behavior.
       if (!oauthProxyUrl) {
-        return await base(
+        const response = await base(
           isMetadata ? url : input,
           isMetadata ? { ...init, cache: "no-store" } : init
         );
+        if (!isMetadata) this.rememberResourceMetadataChallenge(response);
+        return response;
       }
 
       if (!restoredDiscovery) {
@@ -321,7 +332,9 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
         );
 
       if (!isMetadata && !isProxiedEndpoint) {
-        return await base(input, init);
+        const response = await base(input, init);
+        this.rememberResourceMetadataChallenge(response);
+        return response;
       }
 
       // Don't intercept requests already going to our OAuth proxy (avoid circular proxying)
@@ -525,8 +538,28 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
   }
 
   /** Return previously saved OAuth discovery state, or `undefined`. */
-  discoveryState(): Promise<OAuthDiscoveryState | undefined> {
-    return this.session.discoveryState();
+  async discoveryState(): Promise<OAuthDiscoveryState | undefined> {
+    const state = await this.session.discoveryState();
+    const challengedUrl = this.challengedResourceMetadataUrl;
+    this.challengedResourceMetadataUrl = undefined;
+
+    if (
+      challengedUrl &&
+      state &&
+      (state.resourceMetadataUrl !== challengedUrl || !state.resourceMetadata)
+    ) {
+      // A fresh MCP challenge is authoritative. Older clients could persist
+      // authorization-server discovery without successfully resolving the
+      // RFC 9728 document (even while saving its URL), or retain discovery for
+      // a server whose advertised metadata URL changed.
+      // Let the SDK rediscover from the challenge while preserving issuer-keyed
+      // tokens and client registrations until normal issuer validation decides
+      // whether either credential is reusable.
+      await this.session.invalidateCredentials("discovery");
+      return undefined;
+    }
+
+    return state;
   }
 
   /**

--- a/libraries/typescript/packages/client/tests/unit/auth/browser-provider-proxy-fetch.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/auth/browser-provider-proxy-fetch.test.ts
@@ -56,6 +56,80 @@ describe("BrowserOAuthClientProvider — scoped OAuth proxy fetch", () => {
     expect(scoped).not.toBe(globalThis.fetch);
   });
 
+  it("drops incompatible legacy discovery after a fresh resource_metadata challenge", async () => {
+    const resourceMetadataUrl =
+      "https://server-a.example.com/.well-known/oauth-protected-resource/mcp";
+    const provider = makeProvider({ oauthProxyUrl: PROXY_URL });
+    await provider.saveDiscoveryState({
+      authorizationServerUrl: "https://server-a.example.com",
+      // Older discovery saved the challenge URL even when fetching or parsing
+      // the protected-resource document failed, leaving resourceMetadata empty.
+      resourceMetadataUrl,
+      authorizationServerMetadata: {
+        issuer: "https://server-a.example.com",
+        authorization_endpoint: "https://server-a.example.com/authorize",
+        token_endpoint: "https://server-a.example.com/token",
+        response_types_supported: ["code"],
+      },
+    });
+    await provider.saveClientInformation({ client_id: "legacy-client" });
+    await provider.saveTokens({
+      access_token: "existing-token",
+      token_type: "Bearer",
+    });
+    globalFetchSpy.mockResolvedValueOnce(
+      new Response(null, {
+        status: 401,
+        headers: {
+          "www-authenticate": `Bearer resource_metadata="${resourceMetadataUrl}"`,
+        },
+      })
+    );
+
+    await provider.getProxyFetch()!("https://server-a.example.com/mcp");
+
+    expect(await provider.discoveryState()).toBeUndefined();
+    expect(await provider.clientInformation()).toMatchObject({
+      client_id: "legacy-client",
+    });
+    expect(await provider.tokens()).toMatchObject({
+      access_token: "existing-token",
+    });
+  });
+
+  it("keeps discovery that is bound to the current resource_metadata challenge", async () => {
+    const resourceMetadataUrl =
+      "https://server-a.example.com/.well-known/oauth-protected-resource/mcp";
+    const discovery = {
+      authorizationServerUrl: "https://auth.example.com",
+      resourceMetadataUrl,
+      resourceMetadata: {
+        resource: "https://server-a.example.com/mcp",
+        authorization_servers: ["https://auth.example.com"],
+      },
+      authorizationServerMetadata: {
+        issuer: "https://auth.example.com",
+        authorization_endpoint: "https://auth.example.com/authorize",
+        token_endpoint: "https://auth.example.com/token",
+        response_types_supported: ["code"],
+      },
+    };
+    const provider = makeProvider({ oauthProxyUrl: PROXY_URL });
+    await provider.saveDiscoveryState(discovery);
+    globalFetchSpy.mockResolvedValueOnce(
+      new Response(null, {
+        status: 401,
+        headers: {
+          "www-authenticate": `Bearer resource_metadata="${resourceMetadataUrl}"`,
+        },
+      })
+    );
+
+    await provider.getProxyFetch()!("https://server-a.example.com/mcp");
+
+    expect(await provider.discoveryState()).toEqual(discovery);
+  });
+
   it("routes OAuth metadata requests through the proxy without touching non-OAuth requests", async () => {
     const provider = makeProvider({ oauthProxyUrl: PROXY_URL });
     const scoped = provider.getProxyFetch()!;


### PR DESCRIPTION
## Summary

- capture the latest RFC 9728 `resource_metadata` URL from an MCP 401 in the browser provider's scoped fetch
- discard persisted discovery only when it is incompatible with that fresh challenge or lacks resolved protected-resource metadata
- preserve tokens and client registrations while the official SDK rediscovers and applies its normal issuer validation
- add a patch changeset for `@mcp-use/client`

## Root cause

Older browser OAuth attempts could persist fallback authorization-server discovery even when protected-resource metadata resolution failed. A later MCP 401 supplied a valid `resource_metadata` URL, but the official client reused the stale authorization-server entry and skipped RFC 9728 discovery. A strict Inspector OAuth proxy then correctly rejected the unbound root metadata and registration endpoints.

This was reproduced with Bloom: the stale browser namespace requested root authorization metadata and failed with `OAuth endpoint is not bound to this MCP server`, while a fresh namespace requested protected-resource metadata followed by the issuer-specific `/api/auth` metadata and reached authentication successfully.

## Behavior

The fresh MCP challenge is authoritative for discovery. If cached state names another metadata URL or contains no resolved protected-resource document, only discovery state is invalidated. Existing issuer-keyed tokens and client registrations remain available until normal SDK issuer validation determines whether they can be reused.

Compatible persisted discovery is left untouched.

## Validation

- `pnpm eslint packages/client/src/auth/browser.ts packages/client/tests/unit/auth/browser-provider-proxy-fetch.test.ts --max-warnings 0`
- `pnpm --filter @mcp-use/client exec vitest run tests/unit/auth/browser-provider-proxy-fetch.test.ts` — 20 passed
- `pnpm --filter @mcp-use/client test:run` — 336 passed
- `pnpm --filter @mcp-use/client build`
- `pnpm prettier --check packages/client/src/auth/browser.ts packages/client/tests/unit/auth/browser-provider-proxy-fetch.test.ts .changeset/fresh-challenges-recover.md`
- `pnpm changeset status`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale browser OAuth discovery by honoring the latest MCP 401 resource_metadata challenge. Old behavior reused cached authorization-server discovery even when protected-resource metadata was missing, causing auth failures; new behavior invalidates discovery only when it conflicts or lacks protected-resource metadata, while preserving tokens and client registrations.

- Capture the RFC 9728 resource_metadata URL from MCP 401 responses during scoped fetch and remember it for the next discovery lookup.
- In discoveryState(), if the fresh challenge URL differs from cached discovery or the cache lacks resourceMetadata, invalidate only discovery (preserve issuer-keyed tokens and client registrations); otherwise leave discovery untouched.
- Scoped fetch logic is unchanged for routing; it only records 401 challenges on non-metadata requests.
- Add unit tests for dropping incompatible legacy discovery and preserving compatible discovery; add a patch changeset for `@mcp-use/client`.

<sup>Written for commit f3eacde1dcdf3d95789a9f96b5008832b6daa8e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

