### PR TITLE
fix(client): refresh OAuth discovery on every new challenge

### DIFF
--- a/libraries/typescript/.changeset/bright-taxis-refresh.md
+++ b/libraries/typescript/.changeset/bright-taxis-refresh.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/client": patch
+---
+
+Refresh persisted browser OAuth discovery whenever an MCP server sends a new protected-resource metadata challenge, including when the metadata URL is unchanged.

--- a/libraries/typescript/packages/client/src/auth/browser.ts
+++ b/libraries/typescript/packages/client/src/auth/browser.ts
@@ -236,10 +236,12 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
     }
   }
 
-  private rememberResourceMetadataChallenge(response: Response): void {
-    if (response.status !== 401) return;
+  private rememberResourceMetadataChallenge(response: Response): boolean {
+    if (response.status !== 401) return false;
     const { resourceMetadataUrl } = extractWWWAuthenticateParams(response);
-    this.challengedResourceMetadataUrl = resourceMetadataUrl?.toString();
+    if (!resourceMetadataUrl) return false;
+    this.challengedResourceMetadataUrl = resourceMetadataUrl.toString();
+    return true;
   }
 
   /**
@@ -333,7 +335,12 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
 
       if (!isMetadata && !isProxiedEndpoint) {
         const response = await base(input, init);
-        this.rememberResourceMetadataChallenge(response);
+        if (this.rememberResourceMetadataChallenge(response)) {
+          // Endpoints restored before the MCP request may belong to discovery
+          // that the fresh challenge has just made stale. Fresh metadata will
+          // repopulate this routing set as the SDK rediscovers it.
+          discoveredEndpoints.clear();
+        }
         return response;
       }
 
@@ -543,15 +550,11 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
     const challengedUrl = this.challengedResourceMetadataUrl;
     this.challengedResourceMetadataUrl = undefined;
 
-    if (
-      challengedUrl &&
-      state &&
-      (state.resourceMetadataUrl !== challengedUrl || !state.resourceMetadata)
-    ) {
-      // A fresh MCP challenge is authoritative. Older clients could persist
-      // authorization-server discovery without successfully resolving the
-      // RFC 9728 document (even while saving its URL), or retain discovery for
-      // a server whose advertised metadata URL changed.
+    if (challengedUrl && state) {
+      // A fresh MCP challenge is authoritative. RFC 9728 section 5.2 says it
+      // can indicate that protected-resource metadata has changed even when
+      // the metadata URL itself is unchanged. Always rediscover after such a
+      // challenge instead of trusting a complete-but-stale persisted document.
       // Let the SDK rediscover from the challenge while preserving issuer-keyed
       // tokens and client registrations until normal issuer validation decides
       // whether either credential is reusable.

--- a/libraries/typescript/packages/client/tests/unit/auth/browser-provider-proxy-fetch.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/auth/browser-provider-proxy-fetch.test.ts
@@ -97,25 +97,31 @@ describe("BrowserOAuthClientProvider — scoped OAuth proxy fetch", () => {
     });
   });
 
-  it("keeps discovery that is bound to the current resource_metadata challenge", async () => {
+  it("drops complete discovery after a fresh challenge at the same metadata URL", async () => {
     const resourceMetadataUrl =
       "https://server-a.example.com/.well-known/oauth-protected-resource/mcp";
-    const discovery = {
-      authorizationServerUrl: "https://auth.example.com",
+    const staleDiscovery = {
+      authorizationServerUrl: "https://server-a.example.com",
       resourceMetadataUrl,
       resourceMetadata: {
         resource: "https://server-a.example.com/mcp",
-        authorization_servers: ["https://auth.example.com"],
+        authorization_servers: ["https://server-a.example.com"],
       },
       authorizationServerMetadata: {
-        issuer: "https://auth.example.com",
-        authorization_endpoint: "https://auth.example.com/authorize",
-        token_endpoint: "https://auth.example.com/token",
+        issuer: "https://server-a.example.com",
+        authorization_endpoint: "https://server-a.example.com/authorize",
+        token_endpoint: "https://server-a.example.com/token",
+        registration_endpoint: "https://server-a.example.com/register",
         response_types_supported: ["code"],
       },
     };
     const provider = makeProvider({ oauthProxyUrl: PROXY_URL });
-    await provider.saveDiscoveryState(discovery);
+    await provider.saveDiscoveryState(staleDiscovery);
+    await provider.saveClientInformation({ client_id: "existing-client" });
+    await provider.saveTokens({
+      access_token: "existing-token",
+      token_type: "Bearer",
+    });
     globalFetchSpy.mockResolvedValueOnce(
       new Response(null, {
         status: 401,
@@ -127,7 +133,76 @@ describe("BrowserOAuthClientProvider — scoped OAuth proxy fetch", () => {
 
     await provider.getProxyFetch()!("https://server-a.example.com/mcp");
 
-    expect(await provider.discoveryState()).toEqual(discovery);
+    expect(await provider.discoveryState()).toBeUndefined();
+    expect(await provider.clientInformation()).toMatchObject({
+      client_id: "existing-client",
+    });
+    expect(await provider.tokens()).toMatchObject({
+      access_token: "existing-token",
+    });
+
+    const refreshedDiscovery = {
+      ...staleDiscovery,
+      authorizationServerUrl: "https://server-a.example.com/api/auth",
+      resourceMetadata: {
+        ...staleDiscovery.resourceMetadata,
+        authorization_servers: ["https://server-a.example.com/api/auth"],
+      },
+      authorizationServerMetadata: {
+        ...staleDiscovery.authorizationServerMetadata,
+        issuer: "https://server-a.example.com/api/auth",
+        authorization_endpoint:
+          "https://server-a.example.com/api/auth/oauth2/authorize",
+        token_endpoint: "https://server-a.example.com/api/auth/oauth2/token",
+        registration_endpoint:
+          "https://server-a.example.com/api/auth/oauth2/register",
+      },
+    };
+    await provider.saveDiscoveryState(refreshedDiscovery);
+
+    // The challenge is consumed once; freshly persisted discovery is reusable.
+    expect(await provider.discoveryState()).toEqual(refreshedDiscovery);
+  });
+
+  it("stops proxying endpoints restored from discovery after a fresh challenge", async () => {
+    const resourceMetadataUrl =
+      "https://server-a.example.com/.well-known/oauth-protected-resource/mcp";
+    const staleRegistrationEndpoint =
+      "https://server-a.example.com/clients/legacy-enroll";
+    const provider = makeProvider({ oauthProxyUrl: PROXY_URL });
+    await provider.saveDiscoveryState({
+      authorizationServerUrl: "https://server-a.example.com",
+      resourceMetadataUrl,
+      resourceMetadata: {
+        resource: "https://server-a.example.com/mcp",
+        authorization_servers: ["https://server-a.example.com"],
+      },
+      authorizationServerMetadata: {
+        issuer: "https://server-a.example.com",
+        authorization_endpoint: "https://server-a.example.com/authorize",
+        token_endpoint: "https://server-a.example.com/token",
+        registration_endpoint: staleRegistrationEndpoint,
+        response_types_supported: ["code"],
+      },
+    });
+    globalFetchSpy
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 401,
+          headers: {
+            "www-authenticate": `Bearer resource_metadata="${resourceMetadataUrl}"`,
+          },
+        })
+      )
+      .mockResolvedValueOnce(new Response("{}", { status: 200 }));
+    const scoped = provider.getProxyFetch()!;
+
+    await scoped("https://server-a.example.com/mcp");
+    await scoped(staleRegistrationEndpoint, { method: "POST" });
+
+    expect(String(globalFetchSpy.mock.calls[1][0])).toBe(
+      staleRegistrationEndpoint
+    );
   });
 
   it("routes OAuth metadata requests through the proxy without touching non-OAuth requests", async () => {


### PR DESCRIPTION
## Summary

- treat every fresh MCP `401` carrying `resource_metadata` as a signal to rediscover OAuth metadata, even when the URL is unchanged and the persisted document is complete
- preserve issuer-scoped tokens and client registrations so the official SDK can decide whether they remain reusable after rediscovery
- clear OAuth endpoints restored into the scoped proxy routing set when a new challenge makes their discovery state stale
- add a patch changeset for `@mcp-use/client`

## Root cause

The previous stale-discovery recovery in #2256 invalidated persisted state only when the new `resource_metadata` URL differed or the cached protected-resource document was missing. A browser could therefore retain complete-but-stale protected-resource or authorization-server metadata indefinitely when the server changed metadata content at the same URL.

That happened in the Cloud/Bloom flow: a clean Inspector origin discovered the current issuer-specific registration endpoint, while the existing Cloud browser namespace reused an obsolete registration endpoint and the Inspector OAuth BFF correctly rejected it as unbound.

RFC 9728 section 5.2 explicitly allows a new `WWW-Authenticate` challenge to indicate that metadata at the same URL may have changed. This patch consumes each fresh challenge once and forces the official SDK through normal protected-resource and authorization-server rediscovery.

## Impact

Existing browser namespaces recover without requiring users to manually clear localStorage. The endpoint-binding security check remains strict; stale endpoints are removed from the provider's in-memory proxy routing set instead of being allowed through as a workaround.

## Validation

- focused browser OAuth provider suite: 21 tests passed
- complete `@mcp-use/client` suite after package build: 54 files, 337 tests passed
- `@mcp-use/client` production/declaration build passed
- ESLint passed for changed source and test
- Prettier passed for changed source, test, and changeset
- `pnpm changeset status` passed
- `git diff --check` passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes browser OAuth discovery on every new MCP 401 `WWW-Authenticate` challenge that includes `resource_metadata`, even when the metadata URL is unchanged, preventing complete-but-stale discovery from persisting. Clears restored proxied OAuth endpoints on a fresh challenge and preserves issuer-scoped tokens and client registrations for the SDK to decide reuse.

**Review notes**
- In `packages/client/src/auth/browser.ts`, fresh challenges are treated as authoritative: `rememberResourceMetadataChallenge` returns a boolean, the challenge is consumed once, `discoveredEndpoints` is cleared, and rediscovery is always forced when a challenge is present.
- Tests expand coverage to dropping complete discovery at the same URL and stopping proxying of endpoints restored from stale discovery.
- Adds a patch changeset for `@mcp-use/client`; no migration or manual storage clearing is required.
- Behavior change: previously rediscovery only happened when the metadata URL changed or the document was missing; now each fresh challenge triggers rediscovery while keeping existing issuer-scoped tokens and registrations.

<sup>Written for commit 0c822b275e3f2e724d8e687e14f1c160cb8f40c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

