### PR TITLE
fix(inspector): isolate proxy rate limits

### DIFF
--- a/libraries/typescript/.changeset/calm-inspectors-share.md
+++ b/libraries/typescript/.changeset/calm-inspectors-share.md
@@ -1,0 +1,6 @@
+---
+"@mcp-use/client": patch
+"@mcp-use/inspector": patch
+---
+
+Scope hosted Inspector proxy rate limits per MCP server and reduce background health-probe traffic from saved connections.

--- a/libraries/typescript/packages/client/src/auth/browser.ts
+++ b/libraries/typescript/packages/client/src/auth/browser.ts
@@ -365,7 +365,9 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
         ? `${oauthProxyUrl}/metadata?serverUrl=${encodeURIComponent(
             this.serverUrl
           )}&url=${encodeURIComponent(url)}`
-        : `${oauthProxyUrl}/proxy`;
+        : `${oauthProxyUrl}/proxy?serverUrl=${encodeURIComponent(
+            this.serverUrl
+          )}`;
 
       if (isMetadata) {
         const response = await base(proxyEndpoint, {

--- a/libraries/typescript/packages/client/tests/unit/auth/browser-provider-proxy-fetch.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/auth/browser-provider-proxy-fetch.test.ts
@@ -276,7 +276,13 @@ describe("BrowserOAuthClientProvider — scoped OAuth proxy fetch", () => {
       body: new URLSearchParams({ grant_type: "authorization_code" }),
     });
 
-    expect(String(globalFetchSpy.mock.calls[1][0])).toBe(`${PROXY_URL}/proxy`);
+    const proxyEndpoint = new URL(String(globalFetchSpy.mock.calls[1][0]));
+    expect(`${proxyEndpoint.origin}${proxyEndpoint.pathname}`).toBe(
+      `${PROXY_URL}/proxy`
+    );
+    expect(proxyEndpoint.searchParams.get("serverUrl")).toBe(
+      "https://server-a.example.com/mcp"
+    );
     expect(
       JSON.parse(String(globalFetchSpy.mock.calls[1][1]?.body)).serverUrl
     ).toBe("https://server-a.example.com/mcp");
@@ -357,7 +363,13 @@ describe("BrowserOAuthClientProvider — scoped OAuth proxy fetch", () => {
       body: new URLSearchParams({ grant_type: "authorization_code" }),
     });
 
-    expect(String(globalFetchSpy.mock.calls[0][0])).toBe(`${PROXY_URL}/proxy`);
+    const proxyEndpoint = new URL(String(globalFetchSpy.mock.calls[0][0]));
+    expect(`${proxyEndpoint.origin}${proxyEndpoint.pathname}`).toBe(
+      `${PROXY_URL}/proxy`
+    );
+    expect(proxyEndpoint.searchParams.get("serverUrl")).toBe(
+      "https://server-a.example.com/mcp"
+    );
   });
 
   it("fails closed when the OAuth proxy request fails", async () => {

--- a/libraries/typescript/packages/inspector/src/client/App.tsx
+++ b/libraries/typescript/packages/inspector/src/client/App.tsx
@@ -22,6 +22,7 @@ import { getPackageVersion, initInspectorTelemetry } from "@/client/telemetry";
 import { getInspectorBase } from "./utils/basePath";
 import {
   getDefaultInspectorProxyAddress,
+  INSPECTOR_AUTO_RECONNECT_CONFIG,
   InspectorConnectionStorageProvider,
 } from "./utils/connectionUpdates";
 import { wrapTransportForLegacySampling } from "./utils/samplingProtocol";
@@ -138,6 +139,7 @@ function App() {
               proxyAddress ? { enabled: true, proxyAddress } : false
             }
             defaultServerConfig={{
+              autoReconnect: INSPECTOR_AUTO_RECONNECT_CONFIG,
               preventAutoAuth: true,
               useRedirectFlow: true,
               wrapTransport: wrapTransportForLegacySampling,

--- a/libraries/typescript/packages/inspector/src/client/utils/__tests__/connectionUpdates.test.ts
+++ b/libraries/typescript/packages/inspector/src/client/utils/__tests__/connectionUpdates.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { McpServer } from "@mcp-use/client/react";
 import {
+  INSPECTOR_AUTO_RECONNECT_CONFIG,
   MODERN_MCP_PROTOCOL_VERSION,
   InspectorConnectionStorageProvider,
   isAliasOnlyConnectionUpdate,
@@ -10,6 +11,16 @@ import {
   toMcpServerConfig,
   type EditableConnectionConfig,
 } from "../connectionUpdates";
+
+describe("inspector connection health", () => {
+  it("keeps reconnection enabled without probing saved servers every ten seconds", () => {
+    expect(INSPECTOR_AUTO_RECONNECT_CONFIG).toEqual({
+      enabled: true,
+      healthCheckInterval: 60_000,
+      healthCheckTimeout: 180_000,
+    });
+  });
+});
 
 function createLocalStorage(): Storage {
   const values = new Map<string, string>();

--- a/libraries/typescript/packages/inspector/src/client/utils/connectionUpdates.ts
+++ b/libraries/typescript/packages/inspector/src/client/utils/connectionUpdates.ts
@@ -18,6 +18,18 @@ export type ConnectionMode = "auto" | "direct" | "proxy";
 
 export const MODERN_MCP_PROTOCOL_VERSION = "2026-07-28";
 
+/**
+ * Hosted Inspector keeps transport reconnection enabled but probes each saved
+ * server at a deliberately low cadence. A 10-second default multiplied across
+ * saved connections and open tabs creates avoidable upstream traffic and can
+ * consume the proxy rate-limit budget before a real MCP request arrives.
+ */
+export const INSPECTOR_AUTO_RECONNECT_CONFIG = {
+  enabled: true,
+  healthCheckInterval: 60_000,
+  healthCheckTimeout: 180_000,
+} as const;
+
 export type InspectorProtocolMode = "auto" | "v1" | "v2";
 
 type ProtocolNegotiation = NonNullable<McpServerConfig["protocolNegotiation"]>;

--- a/libraries/typescript/packages/inspector/src/server/proxy-routes.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy-routes.ts
@@ -3,6 +3,7 @@ import { RateLimiterMemory } from "rate-limiter-flexible";
 import { mountMcpProxy, mountOAuthProxy } from "./proxy/index.js";
 import {
   INSPECTOR_API_RATE_LIMIT,
+  INSPECTOR_GLOBAL_API_RATE_LIMIT,
   INSPECTOR_RATE_LIMIT_WINDOW_SECONDS,
 } from "./rate-limit.js";
 
@@ -32,6 +33,10 @@ export function registerInspectorProxyRoutes(
     points: INSPECTOR_API_RATE_LIMIT,
     duration: INSPECTOR_RATE_LIMIT_WINDOW_SECONDS,
   });
+  const globalApiRateLimiter = new RateLimiterMemory({
+    points: INSPECTOR_GLOBAL_API_RATE_LIMIT,
+    duration: INSPECTOR_RATE_LIMIT_WINDOW_SECONDS,
+  });
 
   app.get(p("/inspector/health"), (c) => {
     return c.json({
@@ -46,6 +51,7 @@ export function registerInspectorProxyRoutes(
     path: p("/inspector/api/proxy"),
     allowLoopback,
     rateLimiter: apiRateLimiter,
+    globalRateLimiter: globalApiRateLimiter,
   });
 
   if (mountOAuth) {
@@ -56,6 +62,7 @@ export function registerInspectorProxyRoutes(
       allowedOrigins: config?.oauthProxyAllowedOrigins ?? [],
       allowLoopback,
       rateLimiter: apiRateLimiter,
+      globalRateLimiter: globalApiRateLimiter,
     });
   }
 

--- a/libraries/typescript/packages/inspector/src/server/proxy/mcp-proxy.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy/mcp-proxy.ts
@@ -13,8 +13,10 @@ import { logger } from "hono/logger";
 import { RateLimiterMemory } from "rate-limiter-flexible";
 import {
   INSPECTOR_API_RATE_LIMIT,
+  INSPECTOR_GLOBAL_API_RATE_LIMIT,
   INSPECTOR_RATE_LIMIT_WINDOW_SECONDS,
   inspectorRateLimitResponse,
+  inspectorServerRateLimitKey,
 } from "../rate-limit.js";
 // ponytail: vendored from mcp-use/src/server/middleware/mcp-proxy.ts — keep in sync manually.
 import { isSafeProxyTarget } from "./oauth-proxy.js";
@@ -71,8 +73,10 @@ interface McpProxyOptions {
    * @default true
    */
   enableLogging?: boolean;
-  /** Shared process-local limiter for Inspector proxy and OAuth routes. */
+  /** Process-local limiter shared by Inspector proxy and OAuth routes. */
   rateLimiter?: RateLimiterMemory;
+  /** Higher process-wide backstop that prevents target-key rotation abuse. */
+  globalRateLimiter?: RateLimiterMemory;
 }
 
 /** Whether an MCP response must remain streaming instead of being buffered. */
@@ -135,11 +139,18 @@ export function mountMcpProxy(app: Hono, options: McpProxyOptions = {}): void {
       points: INSPECTOR_API_RATE_LIMIT,
       duration: INSPECTOR_RATE_LIMIT_WINDOW_SECONDS,
     });
+  const globalRateLimiter =
+    options.globalRateLimiter ??
+    new RateLimiterMemory({
+      points: INSPECTOR_GLOBAL_API_RATE_LIMIT,
+      duration: INSPECTOR_RATE_LIMIT_WINDOW_SECONDS,
+    });
   const rateLimit = async (c: Context, next: Next) => {
     try {
-      // RateLimiterMemory prefixes and stringifies keys. The Hono request
-      // wrapper therefore maps every request to one mounted-instance budget.
-      await rateLimiter.consume(c.req as unknown as string);
+      await globalRateLimiter.consume("inspector-api:global");
+      await rateLimiter.consume(
+        inspectorServerRateLimitKey("mcp", c.req.header("X-Target-URL"))
+      );
     } catch (error) {
       return inspectorRateLimitResponse(c, error);
     }

--- a/libraries/typescript/packages/inspector/src/server/proxy/oauth-proxy.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy/oauth-proxy.ts
@@ -16,8 +16,10 @@ import type { Context, Hono, Next } from "hono";
 import { RateLimiterMemory } from "rate-limiter-flexible";
 import {
   INSPECTOR_API_RATE_LIMIT,
+  INSPECTOR_GLOBAL_API_RATE_LIMIT,
   INSPECTOR_RATE_LIMIT_WINDOW_SECONDS,
   inspectorRateLimitResponse,
+  inspectorServerRateLimitKey,
 } from "../rate-limit.js";
 
 type OAuthEndpointKind =
@@ -77,8 +79,10 @@ interface OAuthProxyOptions {
     serverUrl: string,
     c: Context
   ) => Promise<boolean> | boolean;
-  /** Shared process-local limiter for Inspector proxy and OAuth routes. */
+  /** Process-local limiter shared by Inspector proxy and OAuth routes. */
   rateLimiter?: RateLimiterMemory;
+  /** Higher process-wide backstop that prevents target-key rotation abuse. */
+  globalRateLimiter?: RateLimiterMemory;
 }
 
 const SAFE_REQUEST_HEADERS = new Set([
@@ -126,15 +130,20 @@ export function mountOAuthProxy(
       points: INSPECTOR_API_RATE_LIMIT,
       duration: INSPECTOR_RATE_LIMIT_WINDOW_SECONDS,
     }),
+    globalRateLimiter = new RateLimiterMemory({
+      points: INSPECTOR_GLOBAL_API_RATE_LIMIT,
+      duration: INSPECTOR_RATE_LIMIT_WINDOW_SECONDS,
+    }),
   } = options;
   const origins = new Set(allowedOrigins.map(normalizeOrigin));
   const bindings = new Map<string, Binding>();
   const confidentialClients = new Map<string, ConfidentialClient>();
   const rateLimit = async (c: Context, next: Next) => {
     try {
-      // RateLimiterMemory prefixes and stringifies keys. The Hono request
-      // wrapper therefore maps every request to one mounted-instance budget.
-      await configuredRateLimiter.consume(c.req as unknown as string);
+      await globalRateLimiter.consume("inspector-api:global");
+      await configuredRateLimiter.consume(
+        inspectorServerRateLimitKey("oauth", c.req.query("serverUrl"))
+      );
     } catch (error) {
       return inspectorRateLimitResponse(c, error);
     }

--- a/libraries/typescript/packages/inspector/src/server/rate-limit.ts
+++ b/libraries/typescript/packages/inspector/src/server/rate-limit.ts
@@ -2,7 +2,37 @@ import type { Context } from "hono";
 
 export const INSPECTOR_ASSET_RATE_LIMIT = 600;
 export const INSPECTOR_API_RATE_LIMIT = 120;
+/** Backstop across every proxied target in one Inspector process. */
+export const INSPECTOR_GLOBAL_API_RATE_LIMIT = 1200;
 export const INSPECTOR_RATE_LIMIT_WINDOW_SECONDS = 60;
+
+/**
+ * Build a process-local limiter key for one logical MCP server.
+ *
+ * Inspector proxy routes are shared by every saved connection and every user
+ * of a hosted Inspector process. Keying the limiter with the Hono request
+ * object stringifies every request to the same value, so one busy server (or
+ * background health probes) can exhaust the budget for unrelated servers.
+ * Keep the query and fragment out of the key: they may contain credentials and
+ * must not let callers evade a server's budget by varying irrelevant values.
+ */
+export function inspectorServerRateLimitKey(
+  namespace: "mcp" | "oauth",
+  serverUrl: string | undefined
+): string {
+  if (!serverUrl) return `${namespace}:unknown`;
+
+  try {
+    const url = new URL(serverUrl);
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      return `${namespace}:unknown`;
+    }
+    const pathname = url.pathname.replace(/\/+$/, "") || "/";
+    return `${namespace}:${url.origin}${pathname}`;
+  } catch {
+    return `${namespace}:unknown`;
+  }
+}
 
 /** Return the standard Inspector response for an exhausted route budget. */
 export function inspectorRateLimitResponse(c: Context, error: unknown) {

--- a/libraries/typescript/packages/inspector/tests/unit/mcp-proxy-security.test.ts
+++ b/libraries/typescript/packages/inspector/tests/unit/mcp-proxy-security.test.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import RateLimiterMemory from "rate-limiter-flexible/lib/RateLimiterMemory.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { mountMcpProxy } from "../../src/server/proxy/mcp-proxy";
 
@@ -9,6 +10,60 @@ afterEach(() => {
 });
 
 describe("Inspector MCP proxy request isolation", () => {
+  it("does not let one MCP target exhaust another target's budget", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () => new Response("ok"))
+    );
+    const app = new Hono();
+    mountMcpProxy(app, {
+      path: "/inspector/api/proxy",
+      enableLogging: false,
+      rateLimiter: new RateLimiterMemory({ points: 1, duration: 60 }),
+      globalRateLimiter: new RateLimiterMemory({ points: 10, duration: 60 }),
+    });
+
+    const request = (target: string) =>
+      app.fetch(
+        new Request(proxyUrl, {
+          headers: { "X-Target-URL": target },
+        })
+      );
+
+    expect((await request("https://93.184.216.34/mcp")).status).toBe(200);
+    expect((await request("https://93.184.216.34/mcp")).status).toBe(429);
+    expect((await request("https://93.184.216.35/mcp")).status).toBe(200);
+  });
+
+  it("retains a global backstop across rotated MCP targets", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () => new Response("ok"))
+    );
+    const app = new Hono();
+    mountMcpProxy(app, {
+      path: "/inspector/api/proxy",
+      enableLogging: false,
+      rateLimiter: new RateLimiterMemory({ points: 10, duration: 60 }),
+      globalRateLimiter: new RateLimiterMemory({ points: 1, duration: 60 }),
+    });
+
+    const first = await app.fetch(
+      new Request(proxyUrl, {
+        headers: { "X-Target-URL": "https://93.184.216.34/mcp" },
+      })
+    );
+    const second = await app.fetch(
+      new Request(proxyUrl, {
+        headers: { "X-Target-URL": "https://93.184.216.35/mcp" },
+      })
+    );
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(429);
+    expect(Number(second.headers.get("Retry-After"))).toBeGreaterThan(0);
+  });
+
   it("does not forward Inspector cookies or browser-origin headers", async () => {
     const fetchFn = vi.fn<typeof fetch>(async (_input, init) => {
       const headers = new Headers(init?.headers);

--- a/libraries/typescript/packages/inspector/tests/unit/rate-limit.test.ts
+++ b/libraries/typescript/packages/inspector/tests/unit/rate-limit.test.ts
@@ -4,7 +4,9 @@ import { describe, expect, it } from "vitest";
 import {
   INSPECTOR_API_RATE_LIMIT,
   INSPECTOR_ASSET_RATE_LIMIT,
+  INSPECTOR_GLOBAL_API_RATE_LIMIT,
   inspectorRateLimitResponse,
+  inspectorServerRateLimitKey,
 } from "../../src/server/rate-limit.js";
 
 describe("Inspector route rate limits", () => {
@@ -62,7 +64,40 @@ describe("Inspector route rate limits", () => {
 
   it("keeps the security patch defaults stable", () => {
     expect(INSPECTOR_API_RATE_LIMIT).toBe(120);
+    expect(INSPECTOR_GLOBAL_API_RATE_LIMIT).toBe(1200);
     expect(INSPECTOR_ASSET_RATE_LIMIT).toBe(600);
+  });
+
+  it("isolates MCP and OAuth budgets by logical server without retaining query secrets", () => {
+    expect(
+      inspectorServerRateLimitKey(
+        "mcp",
+        "https://Example.com:443/mcp/?access_token=secret#fragment"
+      )
+    ).toBe("mcp:https://example.com/mcp");
+    expect(
+      inspectorServerRateLimitKey("oauth", "https://example.com/mcp")
+    ).toBe("oauth:https://example.com/mcp");
+    expect(inspectorServerRateLimitKey("mcp", undefined)).toBe("mcp:unknown");
+    expect(inspectorServerRateLimitKey("oauth", "not a URL")).toBe(
+      "oauth:unknown"
+    );
+  });
+
+  it("lets unrelated targets consume independent per-server budgets", async () => {
+    const limiter = new RateLimiterMemory({ points: 1, duration: 60 });
+    const first = inspectorServerRateLimitKey(
+      "mcp",
+      "https://first.example.com/mcp"
+    );
+    const second = inspectorServerRateLimitKey(
+      "mcp",
+      "https://second.example.com/mcp"
+    );
+
+    await expect(limiter.consume(first)).resolves.toBeDefined();
+    await expect(limiter.consume(first)).rejects.toBeDefined();
+    await expect(limiter.consume(second)).resolves.toBeDefined();
   });
 
   it("uses the fallback Retry-After for non-finite limiter values", async () => {


### PR DESCRIPTION
## Summary

- scope the hosted Inspector MCP and OAuth proxy budgets to each logical MCP server instead of one process-wide key
- retain a higher process-wide backstop so rotating target URLs cannot bypass abuse protection
- include the logical server URL on OAuth endpoint relay requests so token and registration calls use the correct budget
- reduce hosted Inspector health probes from every 10 seconds to every 60 seconds, with a three-minute failure window

## Root cause

The existing in-memory limiter consumed the Hono request object as its key. That object stringified every proxy and OAuth request to the same process-wide bucket, so one busy saved connection could exhaust the 120 requests/minute budget for every unrelated Inspector user and server.

The Inspector also inherited the client's 10-second `HEAD` health-check cadence for every saved connection. In a sampled production incident, 60 of 68 Inspector `429` responses were health probes; the remaining eight were real MCP `POST` requests rejected after the shared budget had already been exhausted.

## Behavior and safety

- each canonical MCP origin + path gets its own 120 requests/minute MCP budget
- OAuth traffic uses a separate namespace for the same logical server
- query strings, fragments, and user info are excluded from limiter keys
- a shared 1,200 requests/minute process backstop remains across MCP and OAuth routes
- automatic reconnect remains enabled; only the Inspector-specific health-check cadence changes

## Verification

- `pnpm --filter @mcp-use/client test:run` — 337 tests passed
- `pnpm --filter @mcp-use/inspector test:unit` — 223 tests passed
- `pnpm --filter @mcp-use/agent build`
- `pnpm --filter @mcp-use/inspector type-check`
- `pnpm --filter @mcp-use/inspector build`
- focused ESLint checks for all changed client and Inspector files
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolates hosted Inspector proxy rate limits per MCP server and reduces background health probes to prevent one busy connection from starving others. Previously, all MCP and OAuth proxy requests shared a process-wide bucket; now each logical server has its own budget with a global backstop.

- Assigns each MCP origin+path its own 120 req/min budget; OAuth for the same server uses a separate namespace. Excludes query/fragment/userinfo from keys. Keeps a 1,200 req/min process-wide backstop.
- Reads `serverUrl` from the OAuth proxy query string; the `@mcp-use/client` browser provider now adds it automatically. If you call the hosted OAuth proxy directly, include `serverUrl` in the query to get isolated limits.
- Keeps auto-reconnect enabled. Changes health checks from every 10s to every 60s with a 3-minute failure window to cut background traffic.

<sup>Written for commit 0cebba70cdfe722fabb42aef8cb01c859cb7ff25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

