### PR TITLE
Surface protocol selection and prioritize configuration settings

### DIFF
--- a/libraries/typescript/.changeset/surface-protocol-selection.md
+++ b/libraries/typescript/.changeset/surface-protocol-selection.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Surface protocol version selection in the connect form and connection settings, and make the configuration options easier to find.

--- a/libraries/typescript/packages/inspector/src/client/components/ConnectionSettingsForm.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ConnectionSettingsForm.tsx
@@ -376,7 +376,31 @@ export function ConnectionSettingsForm({
     />
   );
 
-  const configurationFields = (
+  const protocolFields = (testId: string) => (
+    <div className="space-y-2">
+      <Label className={cn("text-sm", labelClassName)}>Protocol Version</Label>
+      <Select
+        value={protocolMode}
+        onValueChange={(value) =>
+          setProtocolMode(value as InspectorProtocolMode)
+        }
+      >
+        <SelectTrigger
+          className={cn("w-full", inputClassName)}
+          data-testid={testId}
+        >
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="auto">Auto</SelectItem>
+          <SelectItem value="v1">Legacy (2025-11-25)</SelectItem>
+          <SelectItem value="v2">Modern (2026-07-28)</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  );
+
+  const configurationFields = (includeProtocol = true) => (
     <div className="grid gap-4 sm:grid-cols-2">
       <div className="space-y-2">
         <Label className="text-sm">Connection Mode</Label>
@@ -401,31 +425,33 @@ export function ConnectionSettingsForm({
           Direct bypasses the proxy; Proxy always routes through it.
         </p>
       </div>
-      <div className="space-y-2">
-        <Label className="text-sm">Protocol</Label>
-        <Select
-          value={protocolMode}
-          onValueChange={(value) =>
-            setProtocolMode(value as InspectorProtocolMode)
-          }
-        >
-          <SelectTrigger
-            className="w-full"
-            data-testid="config-dialog-protocol-mode-select"
+      {includeProtocol && (
+        <div className="space-y-2">
+          <Label className="text-sm">Protocol Version</Label>
+          <Select
+            value={protocolMode}
+            onValueChange={(value) =>
+              setProtocolMode(value as InspectorProtocolMode)
+            }
           >
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="auto">Auto (recommended)</SelectItem>
-            <SelectItem value="v1">Force v1 (2024/2025)</SelectItem>
-            <SelectItem value="v2">Force v2 (2026-07-28)</SelectItem>
-          </SelectContent>
-        </Select>
-        <p className="text-xs text-muted-foreground">
-          Auto probes for v2 and falls back to the legacy v1 initialize flow.
-          Forced modes fail when the server is incompatible.
-        </p>
-      </div>
+            <SelectTrigger
+              className="w-full"
+              data-testid="connection-settings-protocol-mode-select"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="auto">Auto</SelectItem>
+              <SelectItem value="v1">Legacy (2025-11-25)</SelectItem>
+              <SelectItem value="v2">Modern (2026-07-28)</SelectItem>
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">
+            Auto probes for Modern and falls back to the Legacy initialize flow.
+            Legacy and modern modes fail when the server is incompatible.
+          </p>
+        </div>
+      )}
       <div className="space-y-2">
         <Label className="text-sm">Proxy Endpoint</Label>
         <Input
@@ -556,6 +582,17 @@ export function ConnectionSettingsForm({
         <Card className="border">
           <CardHeader>
             <CardTitle className="text-base font-medium">
+              Configuration
+            </CardTitle>
+            <CardDescription>
+              Connection mode, protocol, proxy, and request timeouts
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="pt-0">{configurationFields()}</CardContent>
+        </Card>
+        <Card className="border">
+          <CardHeader>
+            <CardTitle className="text-base font-medium">
               Authentication
             </CardTitle>
             <CardDescription>OAuth 2.0 client credentials</CardDescription>
@@ -573,17 +610,6 @@ export function ConnectionSettingsForm({
           </CardHeader>
           <CardContent className="pt-0">{headersFields}</CardContent>
         </Card>
-        <Card className="border">
-          <CardHeader>
-            <CardTitle className="text-base font-medium">
-              Configuration
-            </CardTitle>
-            <CardDescription>
-              Connection mode, proxy, and request timeouts
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="pt-0">{configurationFields}</CardContent>
-        </Card>
       </div>
     );
   }
@@ -596,6 +622,9 @@ export function ConnectionSettingsForm({
       {copyConfigButton}
 
       {endpointFields}
+
+      {!inlineSections &&
+        protocolFields("connection-form-protocol-mode-select")}
 
       {inlineSections && !cardSections && (
         <div className="space-y-8 pt-2">
@@ -615,7 +644,7 @@ export function ConnectionSettingsForm({
             <h3 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
               Configuration
             </h3>
-            {configurationFields}
+            {configurationFields()}
           </section>
         </div>
       )}
@@ -718,7 +747,7 @@ export function ConnectionSettingsForm({
                 <DialogTitle>Configuration</DialogTitle>
               </DialogHeader>
               <DialogBody className="space-y-4">
-                {configurationFields}
+                {configurationFields(false)}
                 <div className="flex justify-end">
                   <Button onClick={() => setConfigDialogOpen(false)}>
                     Save

--- a/libraries/typescript/packages/inspector/src/client/components/ConnectionSettingsForm.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ConnectionSettingsForm.tsx
@@ -416,7 +416,7 @@ export function ConnectionSettingsForm({
     </div>
   );
 
-  const configurationFields = (includeProtocol = true) => (
+  const configurationFields = (
     <div className="grid gap-4 sm:grid-cols-2">
       <div className="space-y-2">
         <Label className="text-sm">Connection Mode</Label>
@@ -441,11 +441,10 @@ export function ConnectionSettingsForm({
           Direct bypasses the proxy; Proxy always routes through it.
         </p>
       </div>
-      {includeProtocol &&
-        protocolFields({
-          testId: "connection-settings-protocol-mode-select",
-          showHelpText: true,
-        })}
+      {protocolFields({
+        testId: "connection-settings-protocol-mode-select",
+        showHelpText: true,
+      })}
       <div className="space-y-2">
         <Label className="text-sm">Proxy Endpoint</Label>
         <Input
@@ -582,7 +581,7 @@ export function ConnectionSettingsForm({
               Connection mode, protocol, proxy, and request timeouts
             </CardDescription>
           </CardHeader>
-          <CardContent className="pt-0">{configurationFields()}</CardContent>
+          <CardContent className="pt-0">{configurationFields}</CardContent>
         </Card>
         <Card className="border">
           <CardHeader>
@@ -641,7 +640,7 @@ export function ConnectionSettingsForm({
             <h3 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
               Configuration
             </h3>
-            {configurationFields()}
+            {configurationFields}
           </section>
         </div>
       )}
@@ -744,7 +743,7 @@ export function ConnectionSettingsForm({
                 <DialogTitle>Configuration</DialogTitle>
               </DialogHeader>
               <DialogBody className="space-y-4">
-                {configurationFields(false)}
+                {configurationFields}
                 <div className="flex justify-end">
                   <Button onClick={() => setConfigDialogOpen(false)}>
                     Save

--- a/libraries/typescript/packages/inspector/src/client/components/ConnectionSettingsForm.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ConnectionSettingsForm.tsx
@@ -376,9 +376,19 @@ export function ConnectionSettingsForm({
     />
   );
 
-  const protocolFields = (testId: string) => (
+  const protocolFields = ({
+    testId,
+    styled = false,
+    showHelpText = false,
+  }: {
+    testId: string;
+    styled?: boolean;
+    showHelpText?: boolean;
+  }) => (
     <div className="space-y-2">
-      <Label className={cn("text-sm", labelClassName)}>Protocol Version</Label>
+      <Label className={cn("text-sm", styled && labelClassName)}>
+        Protocol Version
+      </Label>
       <Select
         value={protocolMode}
         onValueChange={(value) =>
@@ -386,7 +396,7 @@ export function ConnectionSettingsForm({
         }
       >
         <SelectTrigger
-          className={cn("w-full", inputClassName)}
+          className={cn("w-full", styled && inputClassName)}
           data-testid={testId}
         >
           <SelectValue />
@@ -397,6 +407,12 @@ export function ConnectionSettingsForm({
           <SelectItem value="v2">Modern (2026-07-28)</SelectItem>
         </SelectContent>
       </Select>
+      {showHelpText && (
+        <p className="text-xs text-muted-foreground">
+          Auto probes for Modern and falls back to the Legacy initialize flow.
+          Legacy and modern modes fail when the server is incompatible.
+        </p>
+      )}
     </div>
   );
 
@@ -425,33 +441,11 @@ export function ConnectionSettingsForm({
           Direct bypasses the proxy; Proxy always routes through it.
         </p>
       </div>
-      {includeProtocol && (
-        <div className="space-y-2">
-          <Label className="text-sm">Protocol Version</Label>
-          <Select
-            value={protocolMode}
-            onValueChange={(value) =>
-              setProtocolMode(value as InspectorProtocolMode)
-            }
-          >
-            <SelectTrigger
-              className="w-full"
-              data-testid="connection-settings-protocol-mode-select"
-            >
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="auto">Auto</SelectItem>
-              <SelectItem value="v1">Legacy (2025-11-25)</SelectItem>
-              <SelectItem value="v2">Modern (2026-07-28)</SelectItem>
-            </SelectContent>
-          </Select>
-          <p className="text-xs text-muted-foreground">
-            Auto probes for Modern and falls back to the Legacy initialize flow.
-            Legacy and modern modes fail when the server is incompatible.
-          </p>
-        </div>
-      )}
+      {includeProtocol &&
+        protocolFields({
+          testId: "connection-settings-protocol-mode-select",
+          showHelpText: true,
+        })}
       <div className="space-y-2">
         <Label className="text-sm">Proxy Endpoint</Label>
         <Input
@@ -624,7 +618,10 @@ export function ConnectionSettingsForm({
       {endpointFields}
 
       {!inlineSections &&
-        protocolFields("connection-form-protocol-mode-select")}
+        protocolFields({
+          testId: "connection-form-protocol-mode-select",
+          styled: isStyled,
+        })}
 
       {inlineSections && !cardSections && (
         <div className="space-y-8 pt-2">

--- a/libraries/typescript/packages/inspector/tests/e2e/connection.test.ts
+++ b/libraries/typescript/packages/inspector/tests/e2e/connection.test.ts
@@ -83,15 +83,17 @@ test.describe("Inspector MCP Server Connections", () => {
     ).toBeVisible();
   });
 
-  test("keeps protocol selection out of the Configuration modal", async ({
+  test("shows protocol selection in the Configuration modal", async ({
     page,
   }) => {
     await page.goto("http://localhost:3000/inspector");
     await page.getByTestId("connection-form-config-button").click();
 
+    const configurationDialog = page.getByRole("dialog");
+    await expect(configurationDialog).toBeVisible();
     await expect(
-      page.getByRole("dialog").getByText("Protocol Version", { exact: true })
-    ).toHaveCount(0);
+      configurationDialog.getByText("Protocol Version", { exact: true })
+    ).toBeVisible();
   });
 
   test("shows Configuration as the second connection settings card", async ({

--- a/libraries/typescript/packages/inspector/tests/e2e/connection.test.ts
+++ b/libraries/typescript/packages/inspector/tests/e2e/connection.test.ts
@@ -90,8 +90,8 @@ test.describe("Inspector MCP Server Connections", () => {
     await page.getByTestId("connection-form-config-button").click();
 
     await expect(
-      page.getByTestId("connection-settings-protocol-mode-select")
-    ).not.toBeVisible();
+      page.getByRole("dialog").getByText("Protocol Version", { exact: true })
+    ).toHaveCount(0);
   });
 
   test("shows Configuration as the second connection settings card", async ({

--- a/libraries/typescript/packages/inspector/tests/e2e/connection.test.ts
+++ b/libraries/typescript/packages/inspector/tests/e2e/connection.test.ts
@@ -67,6 +67,47 @@ test.describe("Inspector MCP Server Connections", () => {
     await expect(page.getByTestId("server-tile-status-ready")).toBeVisible();
   });
 
+  test("shows protocol selection in the connect form", async ({ page }) => {
+    await page.goto("http://localhost:3000/inspector");
+
+    const protocolSelect = page.getByTestId(
+      "connection-form-protocol-mode-select"
+    );
+    await expect(protocolSelect).toContainText("Auto");
+    await protocolSelect.click();
+    await expect(
+      page.getByRole("option", { name: "Legacy (2025-11-25)" })
+    ).toBeVisible();
+    await expect(
+      page.getByRole("option", { name: "Modern (2026-07-28)" })
+    ).toBeVisible();
+  });
+
+  test("keeps protocol selection out of the Configuration modal", async ({
+    page,
+  }) => {
+    await page.goto("http://localhost:3000/inspector");
+    await page.getByTestId("connection-form-config-button").click();
+
+    await expect(
+      page.getByTestId("connection-settings-protocol-mode-select")
+    ).not.toBeVisible();
+  });
+
+  test("shows Configuration as the second connection settings card", async ({
+    page,
+  }) => {
+    await page.goto("http://localhost:3000/inspector");
+    await page.getByTestId("server-tile-settings").click();
+
+    await expect(page.locator('[data-slot="card-title"]')).toHaveAllText([
+      "Endpoint",
+      "Configuration",
+      "Authentication",
+      "Custom Headers",
+    ]);
+  });
+
   test("shows the Skills tab and empty state without the extension", async ({
     page,
   }) => {
@@ -325,19 +366,14 @@ test.describe("Inspector MCP Server Connections", () => {
     await expect(textContent).toContainText("Echo: After settings update");
   });
 
-  test("should persist force-v1 protocol mode and reconnect", async ({
+  test("should persist legacy protocol mode and reconnect", async ({
     page,
   }) => {
     await page.goto("http://localhost:3000/inspector");
 
     await page.getByTestId("server-tile-settings").click();
-    await page.getByTestId("connection-form-config-button").click();
-    await page.getByTestId("config-dialog-protocol-mode-select").click();
-    await page.getByRole("option", { name: "Force v1 (2024/2025)" }).click();
-    await page
-      .getByRole("dialog")
-      .getByRole("button", { name: "Save" })
-      .click();
+    await page.getByTestId("connection-settings-protocol-mode-select").click();
+    await page.getByRole("option", { name: "Legacy (2025-11-25)" }).click();
     await page.getByTestId("connection-form-save-button").click();
 
     await expect(
@@ -362,10 +398,9 @@ test.describe("Inspector MCP Server Connections", () => {
       timeout: 10000,
     });
     await page.getByTestId("server-tile-settings").click();
-    await page.getByTestId("connection-form-config-button").click();
     await expect(
-      page.getByTestId("config-dialog-protocol-mode-select")
-    ).toContainText("Force v1 (2024/2025)");
+      page.getByTestId("connection-settings-protocol-mode-select")
+    ).toContainText("Legacy (2025-11-25)");
   });
 
   test("should show red when URL is invalid, then green after reconnecting from connection settings tab", async ({


### PR DESCRIPTION
## Summary
- Expose protocol version selection directly in connection settings
- Keep protocol selection out of the Configuration modal
- Reorder settings cards so Configuration follows Endpoint
- Update connection E2E coverage for the new layout and legacy protocol flow

## Testing
- Not run (not requested)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces Protocol Version selection in the `inspector` connect form and connection settings, and shows it in the Configuration modal to make protocol control discoverable. Auto now probes Modern and falls back to Legacy; Legacy and Modern modes fail on incompatibility. Reorders settings to prioritize Configuration and centralizes the selector for consistent labels and test IDs.

- Shared selector options: Auto, Legacy (2025-11-25), Modern (2026-07-28). Card order: Endpoint → Configuration → Authentication → Custom Headers. E2E covers connect-form options, modal presence, card order, and legacy-mode persistence. Adds changeset for `@mcp-use/inspector` patch release.

**Required migration**
- Replace `config-dialog-protocol-mode-select` with `connection-form-protocol-mode-select` or `connection-settings-protocol-mode-select`.
- Update labels: “Auto (recommended)” → “Auto”; “Force v1 (2024/2025)” → “Legacy (2025-11-25)”; “Force v2 (2026-07-28)” → “Modern (2026-07-28)”.

<sup>Written for commit 59599b6e68a4bb49f26d8b8f722f87fbdce093ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

