### PR TITLE
Canary

### DIFF
--- a/libraries/typescript/.changeset/pre.json
+++ b/libraries/typescript/.changeset/pre.json
@@ -10,5 +10,7 @@
     "mcp-use": "2.2.2",
     "@mcp-use/tunnel": "0.2.0"
   },
-  "changesets": []
+  "changesets": [
+    "surface-protocol-selection"
+  ]
 }

--- a/libraries/typescript/.changeset/pre.json
+++ b/libraries/typescript/.changeset/pre.json
@@ -1,0 +1,14 @@
+{
+  "mode": "pre",
+  "tag": "canary",
+  "initialVersions": {
+    "@mcp-use/agent": "2.0.6",
+    "@mcp-use/cli": "4.1.4",
+    "@mcp-use/client": "2.1.4",
+    "create-mcp-use-app": "2.0.4",
+    "@mcp-use/inspector": "20.2.2",
+    "mcp-use": "2.2.2",
+    "@mcp-use/tunnel": "0.2.0"
+  },
+  "changesets": []
+}

--- a/libraries/typescript/.changeset/surface-protocol-selection.md
+++ b/libraries/typescript/.changeset/surface-protocol-selection.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Surface protocol version selection in the connect form and connection settings, and make the configuration options easier to find.

--- a/libraries/typescript/packages/cli/package.json
+++ b/libraries/typescript/packages/cli/package.json
@@ -57,7 +57,7 @@
   },
   "peerDependencies": {
     "@mcp-use/client": "^2.0.1 || ^2.1.0 || ^2.1.1 || ^2.1.2 || ^2.1.3 || ^2.1.4",
-    "@mcp-use/inspector": "^20.2.2"
+    "@mcp-use/inspector": "^20.2.2 || ^20.2.3-canary.0"
   },
   "peerDependenciesMeta": {
     "@mcp-use/client": {

--- a/libraries/typescript/packages/inspector/CHANGELOG.md
+++ b/libraries/typescript/packages/inspector/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @mcp-use/inspector
 
+## 20.2.3-canary.0
+
+### Patch Changes
+
+- a8adb05: Surface protocol version selection in the connect form and connection settings, and make the configuration options easier to find.
+  - mcp-use@2.2.3-canary.0
+
 ## 20.2.2
 
 ## 20.2.2-canary.0

--- a/libraries/typescript/packages/inspector/package.json
+++ b/libraries/typescript/packages/inspector/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-use/inspector",
   "type": "module",
-  "version": "20.2.2",
+  "version": "20.2.3-canary.0",
   "description": "MCP Inspector - A tool for inspecting and debugging MCP servers",
   "author": "",
   "license": "MIT",
@@ -92,7 +92,7 @@
     "express": "^4.21.2 || ^5.0.0",
     "lucide-react": "^0.562.0",
     "markdown-to-jsx": "^9.7.4",
-    "mcp-use": "^2.2.2",
+    "mcp-use": "^2.2.3-canary.0",
     "motion": "^12.34.2",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",

--- a/libraries/typescript/packages/inspector/src/client/components/ConnectionSettingsForm.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ConnectionSettingsForm.tsx
@@ -376,6 +376,46 @@ export function ConnectionSettingsForm({
     />
   );
 
+  const protocolFields = ({
+    testId,
+    styled = false,
+    showHelpText = false,
+  }: {
+    testId: string;
+    styled?: boolean;
+    showHelpText?: boolean;
+  }) => (
+    <div className="space-y-2">
+      <Label className={cn("text-sm", styled && labelClassName)}>
+        Protocol Version
+      </Label>
+      <Select
+        value={protocolMode}
+        onValueChange={(value) =>
+          setProtocolMode(value as InspectorProtocolMode)
+        }
+      >
+        <SelectTrigger
+          className={cn("w-full", styled && inputClassName)}
+          data-testid={testId}
+        >
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="auto">Auto</SelectItem>
+          <SelectItem value="v1">Legacy (2025-11-25)</SelectItem>
+          <SelectItem value="v2">Modern (2026-07-28)</SelectItem>
+        </SelectContent>
+      </Select>
+      {showHelpText && (
+        <p className="text-xs text-muted-foreground">
+          Auto probes for Modern and falls back to the Legacy initialize flow.
+          Legacy and modern modes fail when the server is incompatible.
+        </p>
+      )}
+    </div>
+  );
+
   const configurationFields = (
     <div className="grid gap-4 sm:grid-cols-2">
       <div className="space-y-2">
@@ -401,31 +441,10 @@ export function ConnectionSettingsForm({
           Direct bypasses the proxy; Proxy always routes through it.
         </p>
       </div>
-      <div className="space-y-2">
-        <Label className="text-sm">Protocol</Label>
-        <Select
-          value={protocolMode}
-          onValueChange={(value) =>
-            setProtocolMode(value as InspectorProtocolMode)
-          }
-        >
-          <SelectTrigger
-            className="w-full"
-            data-testid="config-dialog-protocol-mode-select"
-          >
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="auto">Auto (recommended)</SelectItem>
-            <SelectItem value="v1">Force v1 (2024/2025)</SelectItem>
-            <SelectItem value="v2">Force v2 (2026-07-28)</SelectItem>
-          </SelectContent>
-        </Select>
-        <p className="text-xs text-muted-foreground">
-          Auto probes for v2 and falls back to the legacy v1 initialize flow.
-          Forced modes fail when the server is incompatible.
-        </p>
-      </div>
+      {protocolFields({
+        testId: "connection-settings-protocol-mode-select",
+        showHelpText: true,
+      })}
       <div className="space-y-2">
         <Label className="text-sm">Proxy Endpoint</Label>
         <Input
@@ -556,6 +575,17 @@ export function ConnectionSettingsForm({
         <Card className="border">
           <CardHeader>
             <CardTitle className="text-base font-medium">
+              Configuration
+            </CardTitle>
+            <CardDescription>
+              Connection mode, protocol, proxy, and request timeouts
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="pt-0">{configurationFields}</CardContent>
+        </Card>
+        <Card className="border">
+          <CardHeader>
+            <CardTitle className="text-base font-medium">
               Authentication
             </CardTitle>
             <CardDescription>OAuth 2.0 client credentials</CardDescription>
@@ -573,17 +603,6 @@ export function ConnectionSettingsForm({
           </CardHeader>
           <CardContent className="pt-0">{headersFields}</CardContent>
         </Card>
-        <Card className="border">
-          <CardHeader>
-            <CardTitle className="text-base font-medium">
-              Configuration
-            </CardTitle>
-            <CardDescription>
-              Connection mode, proxy, and request timeouts
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="pt-0">{configurationFields}</CardContent>
-        </Card>
       </div>
     );
   }
@@ -596,6 +615,12 @@ export function ConnectionSettingsForm({
       {copyConfigButton}
 
       {endpointFields}
+
+      {!inlineSections &&
+        protocolFields({
+          testId: "connection-form-protocol-mode-select",
+          styled: isStyled,
+        })}
 
       {inlineSections && !cardSections && (
         <div className="space-y-8 pt-2">

--- a/libraries/typescript/packages/inspector/tests/e2e/connection.test.ts
+++ b/libraries/typescript/packages/inspector/tests/e2e/connection.test.ts
@@ -67,6 +67,49 @@ test.describe("Inspector MCP Server Connections", () => {
     await expect(page.getByTestId("server-tile-status-ready")).toBeVisible();
   });
 
+  test("shows protocol selection in the connect form", async ({ page }) => {
+    await page.goto("http://localhost:3000/inspector");
+
+    const protocolSelect = page.getByTestId(
+      "connection-form-protocol-mode-select"
+    );
+    await expect(protocolSelect).toContainText("Auto");
+    await protocolSelect.click();
+    await expect(
+      page.getByRole("option", { name: "Legacy (2025-11-25)" })
+    ).toBeVisible();
+    await expect(
+      page.getByRole("option", { name: "Modern (2026-07-28)" })
+    ).toBeVisible();
+  });
+
+  test("shows protocol selection in the Configuration modal", async ({
+    page,
+  }) => {
+    await page.goto("http://localhost:3000/inspector");
+    await page.getByTestId("connection-form-config-button").click();
+
+    const configurationDialog = page.getByRole("dialog");
+    await expect(configurationDialog).toBeVisible();
+    await expect(
+      configurationDialog.getByText("Protocol Version", { exact: true })
+    ).toBeVisible();
+  });
+
+  test("shows Configuration as the second connection settings card", async ({
+    page,
+  }) => {
+    await page.goto("http://localhost:3000/inspector");
+    await page.getByTestId("server-tile-settings").click();
+
+    await expect(page.locator('[data-slot="card-title"]')).toHaveAllText([
+      "Endpoint",
+      "Configuration",
+      "Authentication",
+      "Custom Headers",
+    ]);
+  });
+
   test("shows the Skills tab and empty state without the extension", async ({
     page,
   }) => {
@@ -325,19 +368,14 @@ test.describe("Inspector MCP Server Connections", () => {
     await expect(textContent).toContainText("Echo: After settings update");
   });
 
-  test("should persist force-v1 protocol mode and reconnect", async ({
+  test("should persist legacy protocol mode and reconnect", async ({
     page,
   }) => {
     await page.goto("http://localhost:3000/inspector");
 
     await page.getByTestId("server-tile-settings").click();
-    await page.getByTestId("connection-form-config-button").click();
-    await page.getByTestId("config-dialog-protocol-mode-select").click();
-    await page.getByRole("option", { name: "Force v1 (2024/2025)" }).click();
-    await page
-      .getByRole("dialog")
-      .getByRole("button", { name: "Save" })
-      .click();
+    await page.getByTestId("connection-settings-protocol-mode-select").click();
+    await page.getByRole("option", { name: "Legacy (2025-11-25)" }).click();
     await page.getByTestId("connection-form-save-button").click();
 
     await expect(
@@ -362,10 +400,9 @@ test.describe("Inspector MCP Server Connections", () => {
       timeout: 10000,
     });
     await page.getByTestId("server-tile-settings").click();
-    await page.getByTestId("connection-form-config-button").click();
     await expect(
-      page.getByTestId("config-dialog-protocol-mode-select")
-    ).toContainText("Force v1 (2024/2025)");
+      page.getByTestId("connection-settings-protocol-mode-select")
+    ).toContainText("Legacy (2025-11-25)");
   });
 
   test("should show red when URL is invalid, then green after reconnecting from connection settings tab", async ({

--- a/libraries/typescript/packages/server/CHANGELOG.md
+++ b/libraries/typescript/packages/server/CHANGELOG.md
@@ -1,5 +1,12 @@
 # mcp-use
 
+## 2.2.3-canary.0
+
+### Patch Changes
+
+- Updated dependencies [a8adb05]
+  - @mcp-use/inspector@20.2.3-canary.0
+
 ## 2.2.2
 
 ### Patch Changes

--- a/libraries/typescript/packages/server/package.json
+++ b/libraries/typescript/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-use",
   "type": "module",
-  "version": "2.2.2",
+  "version": "2.2.3-canary.0",
   "description": "MCP framework and CLI built on the official v2 SDK",
   "author": "mcp-use, Inc.",
   "license": "MIT",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Surfaces protocol version selection in `@mcp-use/inspector` and prioritizes Configuration in connection settings to make protocol choice and related options easier to find. Previously protocol was buried and labeled “Force v1/v2”; now the connect form and settings show “Protocol Version” with “Auto”, “Legacy (2025-11-25)”, and “Modern (2026-07-28)”.

- Reorders settings cards to: Endpoint → Configuration → Authentication → Custom Headers; adds inline protocol selector to the connect form; updates help text and labels. Test IDs updated: new `connection-form-protocol-mode-select` and `connection-settings-protocol-mode-select` replace `config-dialog-protocol-mode-select`.
- Enters canary prerelease: `@mcp-use/inspector@20.2.3-canary.0`, `mcp-use@2.2.3-canary.0`. `@mcp-use/cli` peer range now allows `@mcp-use/inspector` canary. No runtime migration is required, but downstream tests must use the new test IDs.

<sup>Written for commit 837513aaf9ba5cb0b2ec980d6c0dadb1ab7cded5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

