### PR TITLE
docs: use createJwtVerifier in the custom OAuth provider guide

### DIFF
--- a/docs/v2/typescript/server/authentication/providers/custom.mdx
+++ b/docs/v2/typescript/server/authentication/providers/custom.mdx
@@ -13,14 +13,13 @@ Import `MCPServer` from `mcp-use` and the provider contract from `mcp-use/oauth`
 ```typescript
 import { MCPServer } from "mcp-use";
 import {
+  createJwtVerifier,
   oauthCustomProvider,
   type OAuthAuthInfo,
   type OAuthMetadata,
 } from "mcp-use/oauth";
-import { createRemoteJWKSet, jwtVerify } from "jose";
 
 const issuer = "https://auth.example.com";
-const jwks = createRemoteJWKSet(new URL(`${issuer}/.well-known/jwks.json`));
 
 const oauthMetadata = {
   issuer,
@@ -45,37 +44,11 @@ const server = new MCPServer({
     oauthMetadata,
 
     createTokenVerifier(resource) {
-      return {
-        async verifyAccessToken(token) {
-          const { payload } = await jwtVerify(token, jwks, {
-            issuer,
-            audience: resource.href,
-          });
-
-          if (!payload.sub || !payload.exp) {
-            throw new Error("Token is missing sub or exp");
-          }
-
-          const scopes =
-            typeof payload.scope === "string"
-              ? payload.scope.split(/\s+/).filter(Boolean)
-              : [];
-
-          return {
-            token,
-            clientId:
-              typeof payload.client_id === "string"
-                ? payload.client_id
-                : typeof payload.azp === "string"
-                  ? payload.azp
-                  : "",
-            scopes,
-            expiresAt: payload.exp,
-            resource,
-            extra: { payload: payload as Record<string, unknown> },
-          };
-        },
-      };
+      return createJwtVerifier({
+        issuer,
+        jwksUrl: new URL(`${issuer}/.well-known/jwks.json`),
+        resource,
+      });
     },
 
     mapAuthInfo(authInfo: OAuthAuthInfo) {
@@ -108,6 +81,10 @@ export default server;
 ```
 
 `createTokenVerifier(resource)` receives the resolved canonical MCP resource. The verifier must validate token signature or introspection, issuer, expiry, and that resource, then return SDK auth information including `scopes`, `expiresAt`, and the validated `resource`.
+
+If your authorization server issues standard JWTs, `createJwtVerifier` does all of that for you, and is the same helper the built-in providers use. Given a `jwksUrl` it checks the signature, the issuer, the required `exp` and `sub` claims, and the resource binding, then returns the auth information in the shape the SDK expects. Pass `audience` when the provider's JWT audience differs from the MCP resource. With no `audience`, the token must carry a matching RFC 8707 `resource` claim or an `aud` claim containing the resource URL.
+
+Write the verifier by hand when the provider does not issue JWTs, for example when you have to call a token introspection endpoint.
 
 `oauthMetadata` is the authorization server's RFC 8414 metadata. It must describe the actual upstream endpoints and include the `registration_endpoint` used by MCP clients.
 


### PR DESCRIPTION
### Why

The custom provider guide tells readers to build the token verifier themselves, with `jose`:

```ts
createTokenVerifier(resource) {
  return {
    async verifyAccessToken(token) {
      const { payload } = await jwtVerify(token, jwks, { issuer, audience: resource.href });
      if (!payload.sub || !payload.exp) throw new Error("Token is missing sub or exp");
      // scope splitting, client_id/azp fallback, expiresAt, resource, extra.payload
    },
  };
}
```

That is 33 lines of security-sensitive code to copy and get right, and it is exactly what #2215 asked about. #2234 exported `createJwtVerifier`, the helper all six built-in providers already use, so the guide can point at it now:

```ts
createTokenVerifier(resource) {
  return createJwtVerifier({
    issuer,
    jwksUrl: new URL(`${issuer}/.well-known/jwks.json`),
    resource,
  });
}
```

### On dropping `audience`

The old snippet passed `audience: resource.href` to `jose`. Omitting it here is not a loosening. With no `audience`, `verifiedResource` requires the token to carry either an RFC 8707 `resource` claim equal to the protected resource, or an `aud` claim that includes the resource URL:

```ts
if (!audiences.includes(configuredResource.href)) {
  throw invalidToken("Token audience does not include the protected resource");
}
```

So it enforces the same binding, plus the `resource` claim the hand-written version ignored. I documented `audience` for providers whose JWT audience differs from the MCP resource, and kept the hand-written path documented for providers that do not issue JWTs, such as introspection-based ones.

### Verified

Extracted the full code block from the page and type-checked it against the built package:

```
npx tsc --noEmit --strict --module nodenext --moduleResolution nodenext --target es2022 doc-example-check.ts
(no output)
```

Also confirmed the export is not just on `main` but in the published package, so this is accurate for readers today: `mcp-use@2.2.3` ships `createJwtVerifier` in `dist/oauth/index.d.ts`.

Only `docs/v2/typescript/` is touched, per the docs guidance that `docs/typescript/` is legacy.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace the custom OAuth provider guide’s hand-rolled `jose` verifier with `createJwtVerifier` from `mcp-use/oauth` to reduce security-sensitive sample code and match the helper used by built-in providers.

**Notes for reviewers**
- The example now imports `createJwtVerifier` and sets `issuer`, `jwksUrl`, and `resource`. Audience enforcement is unchanged.
- Without `audience`, the verifier requires a matching RFC 8707 `resource` claim or an `aud` claim containing the resource URL. Pass `audience` when the provider’s JWT audience differs from the MCP resource.
- Keep the hand-written verifier only for non-JWT providers (for example, introspection-based flows).
- The example type-checks against `mcp-use@2.2.3`. Only `docs/v2/typescript/server/authentication/providers/custom.mdx` changed; legacy docs are untouched.

<sup>Written for commit c7926b80ae057476e00b1c3c43591fd2def2fd96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

