### PR TITLE
fix(ci): report expected-failure entries that no longer match anything

### DIFF
--- a/libraries/typescript/scripts/summarize-conformance.mjs
+++ b/libraries/typescript/scripts/summarize-conformance.mjs
@@ -38,17 +38,27 @@ const expectedFailures = expectedFailuresFile
       .filter(Boolean)
   : [];
 
+// Entries that classified at least one failure or warning. Anything left over
+// no longer describes a real outcome, so it is silently suppressing whatever
+// that check does next.
+const matchedExpectedFailures = new Set();
+
 function isExpectedOutcome(suite, check) {
   if (!suite.startsWith("2025-11-25/server/")) return false;
-  return expectedFailures.some((entry) => {
+  let matched = false;
+  for (const entry of expectedFailures) {
     const separator = entry.indexOf(":");
     const scenario = separator === -1 ? entry : entry.slice(0, separator);
     const checkId = separator === -1 ? undefined : entry.slice(separator + 1);
-    return (
+    if (
       suite.includes(`/server/server-${scenario}-`) &&
       (!checkId || check.id === checkId)
-    );
-  });
+    ) {
+      matchedExpectedFailures.add(entry);
+      matched = true;
+    }
+  }
+  return matched;
 }
 
 for (const file of files.sort()) {
@@ -110,6 +120,19 @@ const lines = [
       `| \`${row.suite}\` | ${row.passed}/${row.total} | ${row.expectedFailures} | ${row.unexpectedFailures} | ${row.expectedWarnings} | ${row.unexpectedWarnings} |`
   ),
 ];
+
+const obsoleteExpectedFailures = expectedFailures.filter(
+  (entry) => !matchedExpectedFailures.has(entry)
+);
+
+if (obsoleteExpectedFailures.length > 0) {
+  lines.push(
+    "",
+    "**Obsolete expected-failure entries.** These matched no failing or warning check in this run, so they are no longer describing a real outcome. Remove them, or they will absorb the next regression of that check. If a run skips the suites they cover, they will show up here too.",
+    "",
+    ...obsoleteExpectedFailures.map((entry) => `- \`${entry}\``)
+  );
+}
 
 const summary = `${lines.join("\n")}\n`;
 if (output) writeFileSync(output, summary);


### PR DESCRIPTION
Closes #2266.

### The defect

`summarize-conformance.mjs` checked observed failures against `expected-failures.yml`, but never checked the list in the other direction. `isExpectedOutcome` was only ever called on checks that had already failed or warned, and the run's only failure condition is `unexpectedFailures > 0`.

So when a listed check starts passing, it is counted in `passed`, the run stays green, and the entry stays in the file. That entry is now a silenced check: if the same check regresses later, it is classified as an expected failure and CI stays green on a real break. The allowlist protects exactly the checks nobody is watching.

### The change

Record which entries classify at least one failure or warning, then list the leftovers under an `Obsolete expected-failure entries` heading in the summary.

Report only, no exit-code change. A run that skips the suites an entry covers would list that entry too, so failing the build on this by default would be wrong. The heading says so explicitly.

### Verified against a real run

I pulled the `typescript-v2-conformance-results` artifact from run 31758544746 on `main` and ran the script against it, rather than guessing at the layout. That also answers the question I left open in #2266: suites are `2025-11-25/server/server-<scenario>-<timestamp>Z`, so the existing matcher's trailing hyphen is correct.

**No false positives.** All 10 current entries match, 6 failures and 4 warnings, which lines up with the reported `6 expected failures, 4 expected warnings`. The generated summary is byte-identical to the one produced before this change:

```
$ diff -q summary-before.md summary-after.md
(no output)
```

**It catches the real cases.** Appending two bad entries to a scratch copy, one for a suite that exists and passes, and one with a check id that does not exist:

```
**Obsolete expected-failure entries.** ...

- `resources-list`
- `tools-call-sampling:no-such-check`
```

Exit code stayed 0 in both runs.

`resources-list` is the exact rot scenario: the suite runs and passes, so under the old code the entry would sit there indefinitely, ready to absorb a future regression.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reports obsolete entries in `expected-failures.yml` in the conformance summary to prevent masking regressions. Previously we only evaluated observed failures; now we track which expected-failure entries matched a failure or warning and list the rest.

- Adds an “Obsolete expected-failure entries” section listing entries that matched no failing or warning check in this run.
- Report only; exit code unchanged. Entries for skipped suites can appear here.
- Required action: remove listed entries from `expected-failures.yml` to avoid silencing future regressions.

<sup>Written for commit 740e84d2651f614cb1d486c5e7048d883efffe2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2267?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

