### PR TITLE
fix(ci): give inspector tests the same timeout as every other package

### DIFF
--- a/libraries/typescript/packages/inspector/vitest.config.ts
+++ b/libraries/typescript/packages/inspector/vitest.config.ts
@@ -10,8 +10,11 @@ export default defineConfig({
       "src/**/__tests__/**/*.{test,spec}.{ts,tsx}",
     ],
     exclude: ["node_modules", "dist", "tests/e2e/**"],
-    testTimeout: 10000,
-    hookTimeout: 10000,
+    // Matches agent, client, cli and server. These cases mount a server and
+    // decompress the bundled app, so a CI runner regularly needs several times
+    // the local wall clock for them.
+    testTimeout: 60000,
+    hookTimeout: 60000,
   },
   resolve: {
     alias: {


### PR DESCRIPTION
### The defect

`typescript/inspector` fails intermittently on `main`, not just on PRs. In run 31758544677 (job 94639889250):

```
❯ tests/unit/compressed-assets.test.ts (1 test | 1 failed) 10837ms
Error: Test timed out in 10000ms.
 ❯ tests/unit/compressed-assets.test.ts:6:3
```

It missed by 8 percent. The same job passed on `main` in run 31758440946, two minutes earlier. Same branch, opposite results, so the test is not broken, the budget is too tight.

### Why 60s

The inspector is the only package capped at 10s:

```
agent:     testTimeout 60000, hookTimeout 60000
client:    testTimeout 60000, hookTimeout 60000
cli:       testTimeout 60000, hookTimeout 60000
server:    testTimeout 60000, hookTimeout 60000
inspector: testTimeout 10000, hookTimeout 10000   <-
```

Nothing about these cases justifies being six times stricter than the rest of the monorepo. They mount a server and decompress the bundled app, which is the slow end of the suite, not the fast end.

For scale: that case takes **2832ms** locally on an idle machine, so CI was already running it close to 4x slower before it tripped the cap. A 10s ceiling leaves almost no headroom for a loaded runner; 60s matches what every sibling package already allows.

### Verified

45 files, 217 tests, all passing after the change, and all five packages now agree on 60000/60000.

### Scope

Only the inspector config. The `typescript/cli (windows-latest)` flake reported alongside this one is a different mechanism: `waitFor timed out after 15000ms` comes from the test helper's own timeout, and `cli` is already at `testTimeout: 60000`, so this change would not affect it. That needs a separate look at the helper rather than a config bump, and I did not want to bundle a speculative fix for it here.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns `typescript/inspector` test and hook timeouts with the rest of the monorepo to eliminate intermittent CI timeouts. The timeout increases from 10s to 60s, matching `agent`, `client`, `cli`, and `server`.

- Scope: Only `libraries/typescript/packages/inspector/vitest.config.ts`; no test logic changes.
- Impact: Reduces flaky failures in CI; tests may take longer to fail if they truly hang.
- Non-impact: Does not affect `typescript/cli` helper timeouts; that requires a separate change.
- Review: Confirm `testTimeout` and `hookTimeout` are set to 60000 and consistent with sibling packages.

<sup>Written for commit 56351a6201276cd61d5d8d0d6fa713ee000d0059. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

