### PR TITLE
fix: register mcp-apps-builder and openapi-to-mcp in the marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,12 +11,14 @@
   "plugins": [
     {
       "name": "all-skills",
-      "description": "Complete collection of mcp-use skills including MCP server building and ChatGPT app development",
+      "description": "Complete collection of mcp-use skills including MCP server building, MCP Apps, OpenAPI-to-MCP, and ChatGPT app development",
       "source": "./",
       "strict": false,
       "skills": [
+        "./skills/mcp-apps-builder",
         "./skills/mcp-builder",
-        "./skills/chatgpt-app-builder"
+        "./skills/chatgpt-app-builder",
+        "./skills/openapi-to-mcp"
       ]
     },
     {
@@ -35,6 +37,24 @@
       "strict": false,
       "skills": [
         "./skills/chatgpt-app-builder"
+      ]
+    },
+    {
+      "name": "mcp-apps-builder",
+      "description": "Build TypeScript MCP servers and interactive MCP Apps with mcp-use v2. Includes tools, resources, prompts, Views, OAuth, middleware, Inspector, and migration guidance.",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/mcp-apps-builder"
+      ]
+    },
+    {
+      "name": "openapi-to-mcp",
+      "description": "Build and deploy an MCP server from an OpenAPI or Swagger spec using the mcp-use TypeScript SDK. Includes spec ingestion, operation-to-tool mapping, auth wiring, and inspector testing.",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/openapi-to-mcp"
       ]
     }
   ]


### PR DESCRIPTION
## Summary
`.claude-plugin/marketplace.json` only listed `mcp-builder` and `chatgpt-app-builder`, so `claude plugin install all-skills@mcp-use` silently dropped `mcp-apps-builder` and `openapi-to-mcp` even though both skills exist on disk.

- Add both missing skills to the `all-skills` plugin
- Add standalone plugin entries for each, matching the existing per-skill pattern
- Leave `mcp-builder` in place (not treated as deprecated)

Closes #2264

## Test plan
- [ ] `claude plugin marketplace add mcp-use/mcp-use` (or this fork) then `claude plugin details all-skills@mcp-use` shows 4 skills
- [ ] `claude plugin install mcp-apps-builder@mcp-use` and `openapi-to-mcp@mcp-use` succeed
- [ ] Existing `mcp-builder` and `chatgpt-app-builder` installs still work

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Registers `mcp-apps-builder` and `openapi-to-mcp` in the marketplace and adds them to `all-skills@mcp-use`, fixing silent drops on install. Previously, `all-skills@mcp-use` installed only `mcp-builder` and `chatgpt-app-builder`; now it installs all four and supports standalone installs for the two missing skills.

- Review: Change is limited to `.claude-plugin/marketplace.json`. Updates the `all-skills` description and skills list, and adds standalone plugin entries for `mcp-apps-builder` and `openapi-to-mcp`.
- Rollout: No change to `mcp-builder`; not deprecated. If you need the new skills, install `mcp-apps-builder@mcp-use` or `openapi-to-mcp@mcp-use`, or reinstall `all-skills@mcp-use`.
- Verification: `claude plugin details all-skills@mcp-use` shows four skills. Standalone installs of `mcp-apps-builder@mcp-use` and `openapi-to-mcp@mcp-use` succeed.

<sup>Written for commit ebb115ca1969e3bc0f1ea872268563ad7f06b42b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

