### PR TITLE
docs(skills): import from the subpaths that actually exist

### DIFF
--- a/skills/chatgpt-app-builder/references/authentication/auth0.md
+++ b/skills/chatgpt-app-builder/references/authentication/auth0.md
@@ -36,7 +36,8 @@ Auth0's built-in DCR feature is currently in **Early Access**. MCP clients regis
 ### Quick Start
 
 ```typescript
-import { MCPServer, oauthAuth0Provider, object } from "mcp-use/server";
+import { MCPServer, object } from "mcp-use";
+import { oauthAuth0Provider } from "mcp-use/oauth/auth0";
 
 const server = new MCPServer({
   name: "my-server",

--- a/skills/chatgpt-app-builder/references/authentication/better-auth.md
+++ b/skills/chatgpt-app-builder/references/authentication/better-auth.md
@@ -87,7 +87,8 @@ You need three things beyond the standard `MCPServer` setup:
 3. Mount login and consent pages
 
 ```typescript
-import { MCPServer, oauthBetterAuthProvider } from "mcp-use/server";
+import { MCPServer } from "mcp-use";
+import { oauthBetterAuthProvider } from "mcp-use/oauth/better-auth";
 import { auth } from "./auth.js";
 import {
   oauthProviderAuthServerMetadata,

--- a/skills/chatgpt-app-builder/references/authentication/clerk.md
+++ b/skills/chatgpt-app-builder/references/authentication/clerk.md
@@ -9,7 +9,8 @@ Setting up OAuth with Clerk. DCR mode only — MCP clients register themselves d
 ## Quick Start
 
 ```typescript
-import { MCPServer, oauthClerkProvider, object } from "mcp-use/server";
+import { MCPServer, object } from "mcp-use";
+import { oauthClerkProvider } from "mcp-use/oauth/clerk";
 
 const server = new MCPServer({
   name: "my-server",

--- a/skills/chatgpt-app-builder/references/authentication/custom.md
+++ b/skills/chatgpt-app-builder/references/authentication/custom.md
@@ -14,7 +14,8 @@ Two factories cover everything that isn't a built-in provider:
 Use this when your identity provider supports DCR and advertises a `registration_endpoint`. Clients discover the endpoints and register themselves against the upstream.
 
 ```typescript
-import { MCPServer, oauthCustomProvider, object } from "mcp-use/server";
+import { MCPServer, object } from "mcp-use";
+import { oauthCustomProvider } from "mcp-use/oauth";
 import { jwtVerify, createRemoteJWKSet } from "jose";
 
 const JWKS = createRemoteJWKSet(

--- a/skills/chatgpt-app-builder/references/authentication/keycloak.md
+++ b/skills/chatgpt-app-builder/references/authentication/keycloak.md
@@ -9,7 +9,8 @@ Setting up OAuth with Keycloak. Keycloak exposes full OAuth 2.1 + OIDC endpoints
 ## Quick Start
 
 ```typescript
-import { MCPServer, oauthKeycloakProvider, object } from "mcp-use/server";
+import { MCPServer, object } from "mcp-use";
+import { oauthKeycloakProvider } from "mcp-use/oauth/keycloak";
 
 const server = new MCPServer({
   name: "my-server",

--- a/skills/chatgpt-app-builder/references/authentication/supabase.md
+++ b/skills/chatgpt-app-builder/references/authentication/supabase.md
@@ -13,7 +13,8 @@ Setting up OAuth with Supabase's OAuth 2.1 server. Supabase hosts `/authorize`, 
 ## Quick Start
 
 ```typescript
-import { MCPServer, oauthSupabaseProvider, object } from "mcp-use/server";
+import { MCPServer, object } from "mcp-use";
+import { oauthSupabaseProvider } from "mcp-use/oauth/supabase";
 
 const server = new MCPServer({
   name: "my-server",

--- a/skills/chatgpt-app-builder/references/authentication/workos.md
+++ b/skills/chatgpt-app-builder/references/authentication/workos.md
@@ -9,7 +9,8 @@ Setting up OAuth with WorkOS AuthKit. DCR mode only — MCP clients register the
 ## Quick Start
 
 ```typescript
-import { MCPServer, oauthWorkOSProvider, object } from "mcp-use/server";
+import { MCPServer, object } from "mcp-use";
+import { oauthWorkOSProvider } from "mcp-use/oauth/workos";
 
 const server = new MCPServer({
   name: "my-server",

--- a/skills/mcp-builder/references/authentication/auth0.md
+++ b/skills/mcp-builder/references/authentication/auth0.md
@@ -36,7 +36,8 @@ Auth0's built-in DCR feature is currently in **Early Access**. MCP clients regis
 ### Quick Start
 
 ```typescript
-import { MCPServer, oauthAuth0Provider, object } from "mcp-use/server";
+import { MCPServer, object } from "mcp-use";
+import { oauthAuth0Provider } from "mcp-use/oauth/auth0";
 
 const server = new MCPServer({
   name: "my-server",

--- a/skills/mcp-builder/references/authentication/better-auth.md
+++ b/skills/mcp-builder/references/authentication/better-auth.md
@@ -87,7 +87,8 @@ You need three things beyond the standard `MCPServer` setup:
 3. Mount login and consent pages
 
 ```typescript
-import { MCPServer, oauthBetterAuthProvider } from "mcp-use/server";
+import { MCPServer } from "mcp-use";
+import { oauthBetterAuthProvider } from "mcp-use/oauth/better-auth";
 import { auth } from "./auth.js";
 import {
   oauthProviderAuthServerMetadata,

--- a/skills/mcp-builder/references/authentication/clerk.md
+++ b/skills/mcp-builder/references/authentication/clerk.md
@@ -9,7 +9,8 @@ Setting up OAuth with Clerk. DCR mode only — MCP clients register themselves d
 ## Quick Start
 
 ```typescript
-import { MCPServer, oauthClerkProvider, object } from "mcp-use/server";
+import { MCPServer, object } from "mcp-use";
+import { oauthClerkProvider } from "mcp-use/oauth/clerk";
 
 const server = new MCPServer({
   name: "my-server",

--- a/skills/mcp-builder/references/authentication/custom.md
+++ b/skills/mcp-builder/references/authentication/custom.md
@@ -14,7 +14,8 @@ Two factories cover everything that isn't a built-in provider:
 Use this when your identity provider supports DCR and advertises a `registration_endpoint`. Clients discover the endpoints and register themselves against the upstream.
 
 ```typescript
-import { MCPServer, oauthCustomProvider, object } from "mcp-use/server";
+import { MCPServer, object } from "mcp-use";
+import { oauthCustomProvider } from "mcp-use/oauth";
 import { jwtVerify, createRemoteJWKSet } from "jose";
 
 const JWKS = createRemoteJWKSet(

--- a/skills/mcp-builder/references/authentication/keycloak.md
+++ b/skills/mcp-builder/references/authentication/keycloak.md
@@ -9,7 +9,8 @@ Setting up OAuth with Keycloak. Keycloak exposes full OAuth 2.1 + OIDC endpoints
 ## Quick Start
 
 ```typescript
-import { MCPServer, oauthKeycloakProvider, object } from "mcp-use/server";
+import { MCPServer, object } from "mcp-use";
+import { oauthKeycloakProvider } from "mcp-use/oauth/keycloak";
 
 const server = new MCPServer({
   name: "my-server",

--- a/skills/mcp-builder/references/authentication/supabase.md
+++ b/skills/mcp-builder/references/authentication/supabase.md
@@ -13,7 +13,8 @@ Setting up OAuth with Supabase's OAuth 2.1 server. Supabase hosts `/authorize`, 
 ## Quick Start
 
 ```typescript
-import { MCPServer, oauthSupabaseProvider, object } from "mcp-use/server";
+import { MCPServer, object } from "mcp-use";
+import { oauthSupabaseProvider } from "mcp-use/oauth/supabase";
 
 const server = new MCPServer({
   name: "my-server",

--- a/skills/mcp-builder/references/authentication/workos.md
+++ b/skills/mcp-builder/references/authentication/workos.md
@@ -9,7 +9,8 @@ Setting up OAuth with WorkOS AuthKit. DCR mode only — MCP clients register the
 ## Quick Start
 
 ```typescript
-import { MCPServer, oauthWorkOSProvider, object } from "mcp-use/server";
+import { MCPServer, object } from "mcp-use";
+import { oauthWorkOSProvider } from "mcp-use/oauth/workos";
 
 const server = new MCPServer({
   name: "my-server",


### PR DESCRIPTION
### The defect

Every authentication reference in both skills bundles imports from `mcp-use/server`, which is not an entry point:

```
$ node -e "import('mcp-use/server')"
ERR_PACKAGE_PATH_NOT_EXPORTED
```

The package exposes `.`, `./react`, `./vite-client`, `./landing`, `./oauth`, `./oauth/{clerk,auth0,workos,supabase,keycloak,better-auth}`, `./node` and `./next`. There is no `./server`.

These files are instructions an agent copies verbatim, so the generated server fails at its first import. The rest of each page is already v2-correct, which is what makes the import line stand out: the env var names match the v2 contract, the providers are called with no arguments the way the env fallbacks expect, and the runnable-example links were repointed at `packages/server/examples/auth/...` in #2211.

### The fix

`MCPServer` and `object` come from `mcp-use`, and each provider from its own oauth subpath:

```ts
import { MCPServer, object } from "mcp-use";
import { oauthClerkProvider } from "mcp-use/oauth/clerk";
```

14 import lines across 14 files, one per provider page in each bundle.

### Verified

I resolved every import in these pages against the built package rather than reading them off:

```
mcp-use:                    MCPServer=OK object=OK
mcp-use/oauth:              oauthCustomProvider=OK
mcp-use/oauth/clerk:        oauthClerkProvider=OK
mcp-use/oauth/auth0:        oauthAuth0Provider=OK
mcp-use/oauth/better-auth:  oauthBetterAuthProvider=OK
mcp-use/oauth/keycloak:     oauthKeycloakProvider=OK
mcp-use/oauth/supabase:     oauthSupabaseProvider=OK
mcp-use/oauth/workos:       oauthWorkOSProvider=OK
```

After the change, every import line in these pages resolves with every symbol present, except the four noted below.

### What I left alone, deliberately

Four lines still import `oauthProxy` and `jwksVerifier` from `mcp-use/server`. Those symbols do not exist anywhere in v2, so there is no correct subpath to move them to. That is a whole documented mode built on v1 API, and porting or deleting it is your call, so I raised it separately in #2274 rather than quietly rewriting or dropping it here.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes auth example imports in both skills bundles to use `mcp-use` subpaths that exist. Previously examples imported from `mcp-use/server` and failed with ERR_PACKAGE_PATH_NOT_EXPORTED; now they import `MCPServer`/`object` from `mcp-use` and providers from `mcp-use/oauth/...`, so copied snippets run.

- Updated 14 import lines across provider pages in both bundles; verified each resolves against the built `mcp-use` (`oauth/{auth0,better-auth,clerk,keycloak,supabase,workos}` and `oauth` for custom).
- Left four `oauthProxy`/`jwksVerifier` lines unchanged; v2 has no equivalents. Tracked in #2274.

**Migration**
- If you copied earlier examples, replace `import ... from "mcp-use/server"` with `import { MCPServer, object } from "mcp-use"` and `import { oauthXProvider } from "mcp-use/oauth/x"`.

<sup>Written for commit 6f58158bbaf39f920789fbcb7418e12d56ffe9f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

