### PR TITLE
docs(skills): read ctx.auth.user.id, not userId

### DIFF
--- a/skills/chatgpt-app-builder/references/authentication/auth0.md
+++ b/skills/chatgpt-app-builder/references/authentication/auth0.md
@@ -48,7 +48,7 @@ server.tool(
   { name: "whoami", description: "Get authenticated user info" },
   async (_args, ctx) =>
     object({
-      userId: ctx.auth.user.userId,
+      userId: ctx.auth.user.id,
       email: ctx.auth.user.email,
       permissions: ctx.auth.permissions,
     })
@@ -165,7 +165,7 @@ server.tool(
   { name: "get-user-info", description: "Get authenticated user info" },
   async (_args, ctx) =>
     object({
-      userId: ctx.auth.user.userId,
+      userId: ctx.auth.user.id,
       email: ctx.auth.user.email,
       name: ctx.auth.user.name,
       nickname: ctx.auth.user.nickname,

--- a/skills/chatgpt-app-builder/references/authentication/better-auth.md
+++ b/skills/chatgpt-app-builder/references/authentication/better-auth.md
@@ -182,7 +182,7 @@ server.tool(
   { name: "get-user-info", description: "Get information about the authenticated user" },
   async (_args, ctx) =>
     object({
-      userId: ctx.auth.user.userId,
+      userId: ctx.auth.user.id,
       email: ctx.auth.user.email,
       name: ctx.auth.user.name,
       scopes: ctx.auth.scopes,

--- a/skills/chatgpt-app-builder/references/authentication/clerk.md
+++ b/skills/chatgpt-app-builder/references/authentication/clerk.md
@@ -21,7 +21,7 @@ server.tool(
   { name: "whoami", description: "Get authenticated user info" },
   async (_args, ctx) =>
     object({
-      userId: ctx.auth.user.userId,
+      userId: ctx.auth.user.id,
       email: ctx.auth.user.email,
       name: ctx.auth.user.name,
     })

--- a/skills/chatgpt-app-builder/references/authentication/keycloak.md
+++ b/skills/chatgpt-app-builder/references/authentication/keycloak.md
@@ -21,7 +21,7 @@ server.tool(
   { name: "whoami", description: "Get authenticated user info" },
   async (_args, ctx) =>
     object({
-      userId: ctx.auth.user.userId,
+      userId: ctx.auth.user.id,
       username: ctx.auth.user.username,
       email: ctx.auth.user.email,
       roles: ctx.auth.user.roles,

--- a/skills/chatgpt-app-builder/references/authentication/overview.md
+++ b/skills/chatgpt-app-builder/references/authentication/overview.md
@@ -45,7 +45,7 @@ server.tool(
   },
   async (_args, ctx) =>
     object({
-      userId: ctx.auth.user.userId,
+      userId: ctx.auth.user.id,
       email: ctx.auth.user.email,
       name: ctx.auth.user.name,
     })

--- a/skills/chatgpt-app-builder/references/authentication/supabase.md
+++ b/skills/chatgpt-app-builder/references/authentication/supabase.md
@@ -25,7 +25,7 @@ server.tool(
   { name: "whoami", description: "Get authenticated user info" },
   async (_args, ctx) =>
     object({
-      userId: ctx.auth.user.userId,
+      userId: ctx.auth.user.id,
       email: ctx.auth.user.email,
     })
 );

--- a/skills/chatgpt-app-builder/references/authentication/workos.md
+++ b/skills/chatgpt-app-builder/references/authentication/workos.md
@@ -21,7 +21,7 @@ server.tool(
   { name: "whoami", description: "Get authenticated user info" },
   async (_args, ctx) =>
     object({
-      userId: ctx.auth.user.userId,
+      userId: ctx.auth.user.id,
       email: ctx.auth.user.email,
       name: ctx.auth.user.name,
     })
@@ -154,7 +154,7 @@ server.tool(
     if (!WORKOS_API_KEY) return error("WorkOS API key not configured");
 
     const res = await fetch(
-      `https://api.workos.com/user_management/users/${ctx.auth.user.userId}`,
+      `https://api.workos.com/user_management/users/${ctx.auth.user.id}`,
       {
         headers: {
           Authorization: `Bearer ${WORKOS_API_KEY}`,

--- a/skills/mcp-builder/references/authentication/auth0.md
+++ b/skills/mcp-builder/references/authentication/auth0.md
@@ -48,7 +48,7 @@ server.tool(
   { name: "whoami", description: "Get authenticated user info" },
   async (_args, ctx) =>
     object({
-      userId: ctx.auth.user.userId,
+      userId: ctx.auth.user.id,
       email: ctx.auth.user.email,
       permissions: ctx.auth.permissions,
     })
@@ -165,7 +165,7 @@ server.tool(
   { name: "get-user-info", description: "Get authenticated user info" },
   async (_args, ctx) =>
     object({
-      userId: ctx.auth.user.userId,
+      userId: ctx.auth.user.id,
       email: ctx.auth.user.email,
       name: ctx.auth.user.name,
       nickname: ctx.auth.user.nickname,

--- a/skills/mcp-builder/references/authentication/better-auth.md
+++ b/skills/mcp-builder/references/authentication/better-auth.md
@@ -182,7 +182,7 @@ server.tool(
   { name: "get-user-info", description: "Get information about the authenticated user" },
   async (_args, ctx) =>
     object({
-      userId: ctx.auth.user.userId,
+      userId: ctx.auth.user.id,
       email: ctx.auth.user.email,
       name: ctx.auth.user.name,
       scopes: ctx.auth.scopes,

--- a/skills/mcp-builder/references/authentication/clerk.md
+++ b/skills/mcp-builder/references/authentication/clerk.md
@@ -21,7 +21,7 @@ server.tool(
   { name: "whoami", description: "Get authenticated user info" },
   async (_args, ctx) =>
     object({
-      userId: ctx.auth.user.userId,
+      userId: ctx.auth.user.id,
       email: ctx.auth.user.email,
       name: ctx.auth.user.name,
     })

--- a/skills/mcp-builder/references/authentication/keycloak.md
+++ b/skills/mcp-builder/references/authentication/keycloak.md
@@ -21,7 +21,7 @@ server.tool(
   { name: "whoami", description: "Get authenticated user info" },
   async (_args, ctx) =>
     object({
-      userId: ctx.auth.user.userId,
+      userId: ctx.auth.user.id,
       username: ctx.auth.user.username,
       email: ctx.auth.user.email,
       roles: ctx.auth.user.roles,

--- a/skills/mcp-builder/references/authentication/overview.md
+++ b/skills/mcp-builder/references/authentication/overview.md
@@ -45,7 +45,7 @@ server.tool(
   },
   async (_args, ctx) =>
     object({
-      userId: ctx.auth.user.userId,
+      userId: ctx.auth.user.id,
       email: ctx.auth.user.email,
       name: ctx.auth.user.name,
     })

--- a/skills/mcp-builder/references/authentication/supabase.md
+++ b/skills/mcp-builder/references/authentication/supabase.md
@@ -25,7 +25,7 @@ server.tool(
   { name: "whoami", description: "Get authenticated user info" },
   async (_args, ctx) =>
     object({
-      userId: ctx.auth.user.userId,
+      userId: ctx.auth.user.id,
       email: ctx.auth.user.email,
     })
 );

--- a/skills/mcp-builder/references/authentication/workos.md
+++ b/skills/mcp-builder/references/authentication/workos.md
@@ -21,7 +21,7 @@ server.tool(
   { name: "whoami", description: "Get authenticated user info" },
   async (_args, ctx) =>
     object({
-      userId: ctx.auth.user.userId,
+      userId: ctx.auth.user.id,
       email: ctx.auth.user.email,
       name: ctx.auth.user.name,
     })
@@ -154,7 +154,7 @@ server.tool(
     if (!WORKOS_API_KEY) return error("WorkOS API key not configured");
 
     const res = await fetch(
-      `https://api.workos.com/user_management/users/${ctx.auth.user.userId}`,
+      `https://api.workos.com/user_management/users/${ctx.auth.user.id}`,
       {
         headers: {
           Authorization: `Bearer ${WORKOS_API_KEY}`,


### PR DESCRIPTION
Extends #2184, which reported this in `mcp-apps-builder`. The same defect is in 18 more places across the other two bundles.

### The defect

The built-in provider user types expose `id`. `userId` is not a field on any of them, so these snippets do not compile. Checked against the built package:

```ts
object({ userId: ctx.auth.user.id, ... })     // compiles
object({ userId: ctx.auth.user.userId, ... }) // error TS2339: Property 'userId' does not exist on type 'ClerkOAuthUser'.
```

`git grep userId -- libraries/typescript/packages/server/src/oauth/` returns nothing, and the Clerk user type for example is `id`, `email`, `name`, `username`, `picture`, `emailVerified`, `organizationId`, `organizationRole`, `organizationSlug`, `roles`.

Only the read changes. The response key stays `userId`, since that is this tool's output field and not tied to the provider type.

### What I left alone, and why

Three exclusions, all deliberate:

- **`mcp-apps-builder/references/auth.md`** is #2185's scope. I did not touch it, so there is nothing to conflict with when that merges.
- **`custom.md` in both bundles** still documents the v1 provider shape, `verifyToken` plus `getUserInfo`, rather than v2's `createTokenVerifier`, `oauthMetadata` and `mapAuthInfo`. There the user object is whatever `getUserInfo` returns, so `userId` may well be right for what that page describes. Changing one field inside an otherwise v1 example would make it look ported when it is not.
- **The `## Mode 2: OAuth Proxy` section of `auth0.md`**, for the same reason: it is built on `oauthProxy` and `jwksVerifier`, which do not exist in v2 at all. That is #2274.

So this covers the pages that are already on the v2 API, where the provider is called the v2 way and the only thing left wrong was the field name.

Pages touched: `clerk`, `keycloak`, `supabase`, `workos`, `better-auth`, `overview`, and the DCR mode plus the user-info section of `auth0`, in both `chatgpt-app-builder` and `mcp-builder`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects docs examples to read ctx.auth.user.id instead of ctx.auth.user.userId so TypeScript snippets compile with v2 provider types. Previously examples read userId from ctx.auth.user; now they read id while still returning a response field named userId.

- Updates provider docs in `chatgpt-app-builder` and `mcp-builder` (Auth0, BetterAuth, Clerk, Keycloak, Supabase, WorkOS, and overview). No runtime or API changes; docs only.
- Leaves v1-only pages unchanged: `custom.md` in both bundles and the "Mode 2: OAuth Proxy" section in `auth0.md`. Also leaves `mcp-apps-builder/references/auth.md` for its own fix.

<sup>Written for commit 8be356b6f37f83aaf12424334e5e21a5f20f63fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

