### PR TITLE
docs: use canonical templates URL

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,7 @@ This directory contains examples for both Python and TypeScript implementations 
 
 ## Templates — ready-to-deploy example apps
 
-If you're looking for **full example apps** you can deploy in one click (Chart Builder, Diagram Builder, Slide Deck, Maps Explorer, Widget Gallery, and more), see the dedicated **[Templates gallery](https://github.com/mcp-use/mcp-use#templates)** in the main README — or browse the [Templates page in the docs](https://mcp-use.com/docs/home/templates). Each template lives in its own repo with a live demo URL and a one-click deploy button.
+If you're looking for **full example apps** you can deploy in one click (Chart Builder, Diagram Builder, Slide Deck, Maps Explorer, Widget Gallery, and more), see the dedicated **[Templates gallery](https://github.com/mcp-use/mcp-use#templates)** in the main README — or browse the [Templates page in the docs](https://docs.mcp-use.com/v2/typescript/getting-started/templates). Each template lives in its own repo with a live demo URL and a one-click deploy button.
 
 The examples below are **in-repo code samples** meant to illustrate specific APIs and patterns — not deployable apps.
 


### PR DESCRIPTION
## Summary
- replace the redirected templates documentation URL in `examples/README.md` with its canonical docs host and v2 TypeScript route

## Verification
- `curl -s -o /dev/null -w ... https://docs.mcp-use.com/v2/typescript/getting-started/templates` - HTTP 200 with 0 redirects
- README canonical-link assertions
- `git diff --check`

Documentation-only change; no code or changeset required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the Templates docs link in `examples/README.md` to the canonical docs host and v2 TypeScript route to remove a redirect and keep the URL stable.

- Old: https://mcp-use.com/docs/home/templates (redirected)
- New: https://docs.mcp-use.com/v2/typescript/getting-started/templates (HTTP 200, no redirects)
- Docs-only change; no code impact or changeset needed.

<sup>Written for commit 776aa400d65b4316da14f84cb3e300490e7d53ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

