### PR TITLE
docs(skills): drop baseUrl from the openapi-to-mcp server config

### DIFF
--- a/skills/openapi-to-mcp/SKILL.md
+++ b/skills/openapi-to-mcp/SKILL.md
@@ -80,7 +80,7 @@ npm install @apidevtools/swagger-parser dotenv
 
 What you get from `blank` (`mcp-apps` is a superset with `resources/` + widget infrastructure):
 
-- `index.ts` at the root with a configured `MCPServer` instance — `name`, `title`, `version`, `description`, `baseUrl`, `favicon`, and an `icons[]` array. Commented-out examples for tools, resources, and prompts. Listens on `process.env.PORT` (default 3000).
+- `index.ts` at the root with a configured `MCPServer` instance — `name`, `title`, `version`, `description`, `favicon`, and an `icons[]` array. Commented-out examples for tools, resources, and prompts. Listens on `process.env.PORT` (default 3000).
 - `package.json` with scripts wired to the `mcp-use` CLI: `dev` (hot reload + inspector), `build`, `start`, `deploy`. `tsx`, `zod`, and `typescript` are already in dev/regular deps; don't reinstall them.
 - `tsconfig.json` pre-configured for ESM (`"type": "module"`).
 - `public/` with a favicon and an SVG icon — served as static assets.
@@ -162,14 +162,13 @@ import { operations } from "./src/operations";
 import { callOperation } from "./src/client";
 import { operationToZod } from "./src/schema";
 
-// Keep the MCPServer fields the scaffold gave you (title, baseUrl, favicon, icons).
+// Keep the MCPServer fields the scaffold gave you (title, favicon, icons).
 // Just adjust `name`, `title`, and `description` to match the API you're wrapping.
 const server = new MCPServer({
   name: "<api-name>",
   title: "<API name>",
   version: "1.0.0",
   description: "MCP server wrapping the <API name> REST API",
-  baseUrl: process.env.MCP_URL || "http://localhost:3000",
   favicon: "favicon.ico",
   icons: [{ src: "icon.svg", mimeType: "image/svg+xml", sizes: ["512x512"] }],
 });

--- a/skills/openapi-to-mcp/references/code-templates.md
+++ b/skills/openapi-to-mcp/references/code-templates.md
@@ -477,7 +477,7 @@ function joinUrl(base: string, path: string): string {
 
 ## 9. `index.ts`
 
-Replace the scaffolded `index.ts` with this — preserving the MCPServer fields the scaffold gave you (title, baseUrl, favicon, icons) and adding the OpenAPI tool registration loop in place of the commented examples.
+Replace the scaffolded `index.ts` with this — preserving the MCPServer fields the scaffold gave you (title, favicon, icons) and adding the OpenAPI tool registration loop in place of the commented examples.
 
 ```ts
 import "dotenv/config";              // load .env into process.env
@@ -491,7 +491,6 @@ const server = new MCPServer({
   title: "OpenAPI MCP",
   version: "1.0.0",
   description: "MCP server wrapping the <API name> REST API",
-  baseUrl: process.env.MCP_URL || "http://localhost:3000",
   favicon: "favicon.ico",
   icons: [{ src: "icon.svg", mimeType: "image/svg+xml", sizes: ["512x512"] }],
 });


### PR DESCRIPTION
### The defect

The `openapi-to-mcp` skill tells readers to configure the server like this:

```ts
const server = new MCPServer({
  name: "<api-name>",
  title: "<API name>",
  version: "1.0.0",
  description: "MCP server wrapping the <API name> REST API",
  baseUrl: process.env.MCP_URL || "http://localhost:3000",
  favicon: "favicon.ico",
  icons: [...],
});
```

`MCPServer` does not accept `baseUrl`:

```
error TS2353: Object literal may only specify known properties,
and 'baseUrl' does not exist in type 'ServerConfig<never>'.
```

The nearest real option is `websiteUrl`, which is the project's website for branding, not a deployment URL. `baseUrl` does exist in `@mcp-use/agent`'s options, which is a different API.

The skill also states twice that this is a field the scaffold provides, in `SKILL.md` and in `references/code-templates.md`:

> preserving the MCPServer fields the scaffold gave you (title, baseUrl, favicon, icons)

It does not. `create-mcp-use-app`'s `templates/mcp-server/index.ts` sets `name`, `title`, `version` and `description`, and nothing else.

### The fix

Drop the line and the two claims about it. I removed rather than renamed because I could not tell which real option was intended: the value is a deployment URL from `MCP_URL`, while `websiteUrl` is a branding link, so renaming would have been a guess that changes behaviour.

The `MCP_URL` guidance elsewhere in the skill is left alone, since that variable is real. `packages/cli/src/cli/dev.ts` sets it, and the skill's advice to name the upstream API's variable something else to avoid colliding with it is still correct.

### Verified

Everything else in that template type-checks. I compiled the full constructor plus the `server.tool({ name, description, schema }, handler)` call and `server.listen()` against the built package: the only error was `baseUrl`, and with it removed the file is clean.

Also ran the repo's own retired-API checker over this bundle, which is clean here:

```
$ node skills/mcp-apps-builder/scripts/check-v2.mjs skills/openapi-to-mcp
No retired mcp-use v1 patterns found.
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the incorrect `baseUrl` field from the `openapi-to-mcp` skill docs and templates because `MCPServer` does not support it. Older guidance caused TS2353 errors and conflated `MCPServer` with `@mcp-use/agent`, which does have a `baseUrl` option.

- Docs now show only supported `MCPServer` fields: `name`, `title`, `version`, `description`, `favicon`, `icons`.
- Keeps existing `MCP_URL` guidance, which the CLI sets and remains relevant.
- Avoids guessing a replacement like `websiteUrl`, which serves branding, not deployment.

**Migration**
- If you copied earlier docs, remove `baseUrl` from your `MCPServer` config.
- Do not replace it with `websiteUrl` unless you need a branding link; keep any `MCP_URL` usage for your API logic or CLI dev setup.

<sup>Written for commit ab37ff5f503c47d863ae2a4b637627475d174d27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

