### PR TITLE
fix(client): preserve legacy widget state promise contract

### DIFF
--- a/libraries/typescript/.changeset/blue-widgets-return.md
+++ b/libraries/typescript/.changeset/blue-widgets-return.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/client": patch
+---
+
+fix the OpenAI compatibility shim to return a promise from `setWidgetState`, preserving the v1 `useWidget()` contract while keeping native v2 MCP Apps behavior unchanged.

--- a/libraries/typescript/packages/client/src/react/view/inject-openai-file-apis.ts
+++ b/libraries/typescript/packages/client/src/react/view/inject-openai-file-apis.ts
@@ -156,6 +156,10 @@ const OPENAI_COMPATIBILITY_BRIDGE_SCRIPT = `<script>
   };
   api.setWidgetState = api.setWidgetState || function (state) {
     dispatchGlobals({ widgetState: state });
+    // The Apps SDK setter is promise-based. Keep the local state update
+    // synchronous, but return a promise so legacy useWidget() code can safely
+    // await or chain .catch() on the compatibility API.
+    return Promise.resolve();
   };
   api.notifyIntrinsicHeight = api.notifyIntrinsicHeight || function (height) {
     sendNotification("ui/notifications/size-changed", { height: height });

--- a/libraries/typescript/packages/client/tests/unit/inject-openai-file-apis.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/inject-openai-file-apis.test.ts
@@ -224,7 +224,7 @@ describe("injectOpenAiFileApis", () => {
     cleanup();
   });
 
-  it("keeps widget state private and updates it synchronously", () => {
+  it("keeps widget state private, updates synchronously, and returns a promise", async () => {
     vi.useFakeTimers();
     const { guest, cleanup } = mountInjectedBridge();
     const postMessage = vi.spyOn(guest.parent, "postMessage");
@@ -232,7 +232,7 @@ describe("injectOpenAiFileApis", () => {
       guest as typeof guest & {
         openai: {
           widgetState: unknown;
-          setWidgetState: (state: unknown) => unknown;
+          setWidgetState: (state: unknown) => Promise<void>;
         };
       }
     ).openai;
@@ -242,7 +242,11 @@ describe("injectOpenAiFileApis", () => {
       imageIds: ["file-1"],
     };
 
-    expect(openai.setWidgetState(state)).toBeUndefined();
+    // v1 useWidget() chains .catch() on this Apps SDK method. The shim must
+    // preserve that promise contract even though the local update is sync.
+    await expect(
+      openai.setWidgetState(state).catch(() => {})
+    ).resolves.toBeUndefined();
     expect(openai.widgetState).toEqual(state);
     expect(postMessage).not.toHaveBeenCalledWith(
       expect.objectContaining({ method: "ui/update-model-context" }),


### PR DESCRIPTION
## Root cause

The injected OpenAI compatibility shim makes `window.openai` available to legacy v1 `useWidget()` bundles. Those bundles select the Apps SDK compatibility path and chain `.catch()` on `window.openai.setWidgetState(...)`.

The shim updated `widgetState` synchronously but returned `undefined`, causing `TypeError: Cannot read properties of undefined (reading catch)`. This explains the same failure in Cloud and hosted Inspector. Native v2 MCP Apps capability negotiation remains unchanged.

## Fix

- Keep the compatibility state update synchronous.
- Return a resolved promise from the injected `setWidgetState` implementation.
- Add a regression test using the exact legacy `.catch()` call pattern.
- Add a patch changeset for `@mcp-use/client`.

## Validation

- `@mcp-use/client` build
- `@mcp-use/client` tests: 54 files, 337 passed
- `@mcp-use/client` targeted injection test: 10 passed
- `@mcp-use/agent` build
- `@mcp-use/inspector` type-check
- `@mcp-use/inspector` app build and unit tests: 46 files, 218 passed

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restore promise-returning contract for the OpenAI compatibility shim’s `setWidgetState` in `@mcp-use/client`. Previously it returned `undefined` (regression), breaking v1 `useWidget()` callers that await or chain `.catch()`. Now it updates state synchronously and returns a resolved promise; native v2 MCP Apps behavior is unchanged.

- Injected bridge: `api.setWidgetState` now returns `Promise.resolve()` after the local `dispatchGlobals` update; no host messaging added.
- Unit test updated to assert a promise is returned while state remains private and sync.
- Patch release for `@mcp-use/client`.

<sup>Written for commit cacc386788ee31fcdb755225963847f2947989c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

