### PR TITLE
docs(skills): drop baseUrl from the openapi-to-mcp server config

### DIFF
--- a/skills/openapi-to-mcp/SKILL.md
+++ b/skills/openapi-to-mcp/SKILL.md
@@ -80,7 +80,7 @@ npm install @apidevtools/swagger-parser dotenv
 
 What you get from `blank` (`mcp-apps` is a superset with `resources/` + widget infrastructure):
 
-- `index.ts` at the root with a configured `MCPServer` instance — `name`, `title`, `version`, `description`, `favicon`, and an `icons[]` array. Commented-out examples for tools, resources, and prompts. Listens on `process.env.PORT` (default 3000).
+- `index.ts` at the root with a configured `MCPServer` instance — `name`, `title`, `version`, `description`. Commented-out examples for tools, resources, and prompts. Listens on `process.env.PORT` (default 3000).
 - `package.json` with scripts wired to the `mcp-use` CLI: `dev` (hot reload + inspector), `build`, `start`, `deploy`. `tsx`, `zod`, and `typescript` are already in dev/regular deps; don't reinstall them.
 - `tsconfig.json` pre-configured for ESM (`"type": "module"`).
 - `public/` with a favicon and an SVG icon — served as static assets.

--- a/skills/openapi-to-mcp/SKILL.md
+++ b/skills/openapi-to-mcp/SKILL.md
@@ -162,7 +162,7 @@ import { operations } from "./src/operations";
 import { callOperation } from "./src/client";
 import { operationToZod } from "./src/schema";
 
-// Keep the MCPServer fields the scaffold gave you (title, favicon, icons).
+// Keep the MCPServer fields from the example (title, favicon, icons).
 // Just adjust `name`, `title`, and `description` to match the API you're wrapping.
 const server = new MCPServer({
   name: "<api-name>",

--- a/skills/openapi-to-mcp/SKILL.md
+++ b/skills/openapi-to-mcp/SKILL.md
@@ -80,7 +80,7 @@ npm install @apidevtools/swagger-parser dotenv
 
 What you get from `blank` (`mcp-apps` is a superset with `resources/` + widget infrastructure):
 
-- `index.ts` at the root with a configured `MCPServer` instance — `name`, `title`, `version`, `description`, `baseUrl`, `favicon`, and an `icons[]` array. Commented-out examples for tools, resources, and prompts. Listens on `process.env.PORT` (default 3000).
+- `index.ts` at the root with a configured `MCPServer` instance — `name`, `title`, `version`, `description`, `favicon`, and an `icons[]` array. Commented-out examples for tools, resources, and prompts. Listens on `process.env.PORT` (default 3000).
 - `package.json` with scripts wired to the `mcp-use` CLI: `dev` (hot reload + inspector), `build`, `start`, `deploy`. `tsx`, `zod`, and `typescript` are already in dev/regular deps; don't reinstall them.
 - `tsconfig.json` pre-configured for ESM (`"type": "module"`).
 - `public/` with a favicon and an SVG icon — served as static assets.
@@ -162,14 +162,13 @@ import { operations } from "./src/operations";
 import { callOperation } from "./src/client";
 import { operationToZod } from "./src/schema";
 
-// Keep the MCPServer fields the scaffold gave you (title, baseUrl, favicon, icons).
+// Keep the MCPServer fields the scaffold gave you (title, favicon, icons).
 // Just adjust `name`, `title`, and `description` to match the API you're wrapping.
 const server = new MCPServer({
   name: "<api-name>",
   title: "<API name>",
   version: "1.0.0",
   description: "MCP server wrapping the <API name> REST API",
-  baseUrl: process.env.MCP_URL || "http://localhost:3000",
   favicon: "favicon.ico",
   icons: [{ src: "icon.svg", mimeType: "image/svg+xml", sizes: ["512x512"] }],
 });

--- a/skills/openapi-to-mcp/references/code-templates.md
+++ b/skills/openapi-to-mcp/references/code-templates.md
@@ -477,7 +477,7 @@ function joinUrl(base: string, path: string): string {
 
 ## 9. `index.ts`
 
-Replace the scaffolded `index.ts` with this — preserving the MCPServer fields the scaffold gave you (title, baseUrl, favicon, icons) and adding the OpenAPI tool registration loop in place of the commented examples.
+Replace the scaffolded `index.ts` with this — preserving the MCPServer fields the scaffold gave you (title, favicon, icons) and adding the OpenAPI tool registration loop in place of the commented examples.
 
 ```ts
 import "dotenv/config";              // load .env into process.env
@@ -491,7 +491,6 @@ const server = new MCPServer({
   title: "OpenAPI MCP",
   version: "1.0.0",
   description: "MCP server wrapping the <API name> REST API",
-  baseUrl: process.env.MCP_URL || "http://localhost:3000",
   favicon: "favicon.ico",
   icons: [{ src: "icon.svg", mimeType: "image/svg+xml", sizes: ["512x512"] }],
 });


### PR DESCRIPTION
Reopening the one piece of #2280 that #2286 did not reach. Everything else you closed was genuinely handled by the rewrite, which I verified rather than assuming, see below.

### Still present

`skills/openapi-to-mcp` tells readers to pass `baseUrl` to `MCPServer`, and that option does not exist. On current `main`, after #2286:

```
error TS2353: Object literal may only specify known properties,
and 'baseUrl' does not exist in type 'ServerConfig<never>'.
```

It appears twice as code, `SKILL.md:172` and `references/code-templates.md:494`, plus two prose claims that the scaffold hands you the field. It does not: `create-mcp-use-app`'s `templates/mcp-server/index.ts` sets `name`, `title`, `version` and `description` only.

The `MCP_URL` guidance in that skill is untouched, since the CLI really does set that variable in `packages/cli/src/cli/dev.ts`.

### Deliberately not touched

`MCPServer.fromOpenAPI()` **does** accept `baseUrl`, `FromOpenAPIOptions` declares it at `dist/openapi/types.d.ts:145`. So the three `advanced-features.md` references to supplying `baseUrl` for `fromOpenAPI` are correct and I left them alone. That distinction is why this is only two files.

### What #2286 did fix

For the record, so the closed PRs stay closed. Counting occurrences across `skills/` on current `main`:

```
from "mcp-use/server"   0   (was 18)   -> #2275 obsolete
ctx.auth.user.userId    0   (was 26)   -> #2277 obsolete
McpUseProvider          0   (was 474)
WidgetMetadata          0   (was 68)
oauthProxy              0              -> #2274 obsolete
jwksVerifier            0              -> #2274 obsolete
useWidget               3              only as migration-table rows mapping it to useToolContext, correct as written
```

I will close #2274 and #2278 as resolved by #2286.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes `baseUrl` from `MCPServer` examples and prose in `skills/openapi-to-mcp` so docs match the API. Previously the docs told readers to set `baseUrl` on `MCPServer` (TS2353 error); examples now omit it.

- Updates `skills/openapi-to-mcp/SKILL.md` and `skills/openapi-to-mcp/references/code-templates.md` to remove `baseUrl` from the server config and the scaffold field list.
- Keeps `baseUrl` guidance for `MCPServer.fromOpenAPI()` (still valid).
- Migration: Remove `baseUrl` from your `MCPServer` config. Use `MCP_URL` where the CLI expects it, or pass `baseUrl` to `MCPServer.fromOpenAPI()` if needed.

<sup>Written for commit 33de7270a1b084fabb614ff91403ad1ae1123cab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

