### PR TITLE
fix(inspector): add a test script so pnpm test covers this package

### DIFF
--- a/libraries/typescript/.changeset/plain-moons-listen.md
+++ b/libraries/typescript/.changeset/plain-moons-listen.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Add a `test` script so the workspace-wide `pnpm test` includes the inspector's unit tests. `pnpm run -r test` skipped the package silently, since only `test:unit` existed.

--- a/libraries/typescript/.changeset/plain-moons-listen.md
+++ b/libraries/typescript/.changeset/plain-moons-listen.md
@@ -1,5 +1,0 @@
----
-"@mcp-use/inspector": patch
----
-
-Add a `test` script so the workspace-wide `pnpm test` includes the inspector's unit tests. `pnpm run -r test` skipped the package silently, since only `test:unit` existed.

--- a/libraries/typescript/packages/inspector/package.json
+++ b/libraries/typescript/packages/inspector/package.json
@@ -72,6 +72,7 @@
     "test:e2e:codegen": "playwright codegen http://localhost:3000/inspector",
     "test:e2e:report": "playwright show-report",
     "test:e2e:python": "node tests/e2e/scripts/run-python-e2e.mjs",
+    "test": "vitest run",
     "test:unit": "vitest run",
     "test:unit:watch": "vitest",
     "test:e2e:tunnel": "node tests/e2e/scripts/run-tunnel-test.mjs",


### PR DESCRIPTION
### The defect

The workspace test script is recursive:

```json
"test": "pnpm run -r test"
```

`@mcp-use/inspector` only defined `test:unit`, and pnpm skips a package with no matching script without saying anything. So the documented `pnpm test` omitted the inspector's unit tests entirely:

```
$ pnpm --filter @mcp-use/inspector test
(no output, exit 0)

$ pnpm --filter @mcp-use/inspector test:unit
Test Files  45 passed (45)
Tests  217 passed (217)
```

217 tests, silently absent from the run contributors are told to use in `CONTRIBUTING.md`.

CI is not affected. Its step calls `test:unit` directly, which is what #2201 wired up. This is only about the workspace-level command.

### The change

One line, `"test": "vitest run"`, which is what `test:unit` already does.

I used run mode rather than aliasing to a watcher on purpose. `test` currently means different things across the workspace: `vitest` in agent, client and mcp-use, `vitest run` in tunnel, `vitest --run --passWithNoTests` in create-mcp-use-app, and `node --test ... && vitest run` in cli. Since `pnpm run -r test` executes packages in series, a watch-mode entry can hold the whole recursive run open in an interactive terminal, so the run-mode form is the safe one to add. Matching `tunnel` seemed the most consistent choice.

### Verified

```
$ pnpm --filter @mcp-use/inspector test
Test Files  45 passed (45)
Tests  217 passed (217)
```

Preflight clean, 0 failing packages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `test` script to `@mcp-use/inspector` so workspace `pnpm test` includes its unit tests instead of silently skipping them. Previously only `test:unit` existed; `test` now runs `vitest` in run mode to avoid blocking recursive runs.

- Adds `"test": "vitest run"` to `@mcp-use/inspector/package.json`.
- `pnpm test` now runs 217 inspector unit tests; CI stays the same (invokes `test:unit`).

<sup>Written for commit ed5ea5077dd3082e8ae2df083656c6c9922a2505. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

