### PR TITLE
fix(ci): give inspector tests the same timeout as every other package (canary)

### DIFF
--- a/libraries/typescript/packages/inspector/vitest.config.ts
+++ b/libraries/typescript/packages/inspector/vitest.config.ts
@@ -10,9 +10,6 @@ export default defineConfig({
       "src/**/__tests__/**/*.{test,spec}.{ts,tsx}",
     ],
     exclude: ["node_modules", "dist", "tests/e2e/**"],
-    // Matches agent, client, cli and server. These cases mount a server and
-    // decompress the bundled app, so a CI runner regularly needs several times
-    // the local wall clock for them.
     testTimeout: 60000,
     hookTimeout: 60000,
   },

--- a/libraries/typescript/packages/inspector/vitest.config.ts
+++ b/libraries/typescript/packages/inspector/vitest.config.ts
@@ -10,8 +10,11 @@ export default defineConfig({
       "src/**/__tests__/**/*.{test,spec}.{ts,tsx}",
     ],
     exclude: ["node_modules", "dist", "tests/e2e/**"],
-    testTimeout: 10000,
-    hookTimeout: 10000,
+    // Matches agent, client, cli and server. These cases mount a server and
+    // decompress the bundled app, so a CI runner regularly needs several times
+    // the local wall clock for them.
+    testTimeout: 60000,
+    hookTimeout: 60000,
   },
   resolve: {
     alias: {


### PR DESCRIPTION
The `canary` twin of #2268, which I offered on that PR and on #2289. Identical one-line change, opened separately because `canary` is red on this independently and the merge-forward would leave it failing in the meantime.

Close whichever of the two you prefer, or this one if you would rather it arrive through `main`.

### Why canary needs it too

`typescript/inspector` is failing on `canary` itself, no PR involved, twice yesterday:

```
run 32053629834   tests/unit/compressed-assets.test.ts   10230ms   Test timed out in 10000ms.
run 32051250836   same test
```

`main` is red on it as well (run 32054211669, `1 failed | 217 passed`), and both branches still carry `testTimeout: 10000`.

Recent margins: **10029ms, 10230ms, 10837ms**, all just over the cap. That is not a broken test, it is a budget with no headroom.

### Why 60s

The inspector is the only package capped at 10s:

```
agent:     testTimeout 60000, hookTimeout 60000
client:    testTimeout 60000, hookTimeout 60000
cli:       testTimeout 60000, hookTimeout 60000
server:    testTimeout 60000, hookTimeout 60000
inspector: testTimeout 10000, hookTimeout 10000   <-
```

Its cases mount a server and decompress the bundled app, which is the slow end of the suite rather than the fast end, so being six times stricter than everything else is backwards. The failing case takes 2832ms locally on an idle machine.

### Verified

45 files, 217 tests pass, and all five packages now agree on 60000/60000. Preflight clean, 0 failing packages.

No changeset: test configuration only, nothing shipped changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns `typescript/inspector` test and hook timeouts with the rest of the repo to stabilize canary CI. Old behavior: 10s `testTimeout`/`hookTimeout` caused flakiness; new behavior: both set to 60s with no runtime impact.

- Update `libraries/typescript/packages/inspector/vitest.config.ts` to `testTimeout: 60000` and `hookTimeout: 60000` (matching agent, client, cli, server).
- Remove the temporary rationale comment from the config.
- Test-only change; no changeset required.

<sup>Written for commit 5fcdec2cf57bc50f0a0c43b945a013a1acef5107. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

