### PR TITLE
feat(client): support RequestOptions for prompt reads

### DIFF
--- a/libraries/typescript/.changeset/quiet-prompts-forward.md
+++ b/libraries/typescript/.changeset/quiet-prompts-forward.md
@@ -1,5 +1,5 @@
 ---
-"@mcp-use/client": patch
+"@mcp-use/client": minor
 ---
 
 Support passing MCP `RequestOptions` through prompt reads.

--- a/libraries/typescript/.changeset/quiet-prompts-forward.md
+++ b/libraries/typescript/.changeset/quiet-prompts-forward.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/client": patch
+---
+
+Support passing MCP `RequestOptions` through prompt reads.

--- a/libraries/typescript/packages/client/src/core/session.ts
+++ b/libraries/typescript/packages/client/src/core/session.ts
@@ -594,6 +594,7 @@ export class MCPConnection {
    *
    * @param name - Name of the prompt to get
    * @param args - Arguments for the prompt
+   * @param options - Per-request timeout, cancellation, and progress options
    * @returns Prompt result
    *
    * @example
@@ -602,8 +603,12 @@ export class MCPConnection {
    * console.log(prompt.messages);
    * ```
    */
-  async getPrompt(name: string, args: Record<string, any>) {
-    return this.connector.getPrompt(name, args);
+  async getPrompt(
+    name: string,
+    args: Record<string, any>,
+    options?: RequestOptions
+  ) {
+    return this.connector.getPrompt(name, args, options);
   }
 
   /**

--- a/libraries/typescript/packages/client/src/transport/base.ts
+++ b/libraries/typescript/packages/client/src/transport/base.ts
@@ -899,16 +899,21 @@ export abstract class BaseConnector {
    *
    * @param name - Prompt name.
    * @param args - Prompt arguments.
+   * @param options - Per-request timeout, cancellation, and progress options.
    * @returns The rendered prompt returned by the server.
    */
-  async getPrompt(name: string, args: Record<string, any>) {
+  async getPrompt(
+    name: string,
+    args: Record<string, any>,
+    options?: RequestOptions
+  ) {
     if (!this.client) {
       throw new Error("MCP client is not connected");
     }
 
     logger.debug(`Getting prompt ${name}`);
     return await this.executeRequest(() =>
-      this.client!.getPrompt({ name, arguments: args })
+      this.client!.getPrompt({ name, arguments: args }, options)
     );
   }
 

--- a/libraries/typescript/packages/client/tests/unit/client/get-prompt.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/client/get-prompt.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+import { MCPConnection } from "../../../src/core/session.js";
+import { BaseConnector } from "../../../src/transport/base.js";
+
+describe("Prompt request options", () => {
+  it("forwards request options from BaseConnector to the SDK client", async () => {
+    const connector = new BaseConnector();
+    const prompt = { messages: [] };
+    const client = {
+      getPrompt: vi.fn().mockResolvedValue(prompt),
+    };
+    const options = { timeout: 5_000 };
+    (connector as any).client = client;
+
+    await expect(
+      connector.getPrompt("greeting", { name: "Ada" }, options)
+    ).resolves.toBe(prompt);
+
+    expect(client.getPrompt).toHaveBeenCalledWith(
+      { name: "greeting", arguments: { name: "Ada" } },
+      options
+    );
+  });
+
+  it("forwards request options from MCPConnection to its connector", async () => {
+    const connector = {
+      getPrompt: vi.fn().mockResolvedValue({ messages: [] }),
+    };
+    const connection = new MCPConnection(connector as never);
+    const options = { timeout: 5_000 };
+
+    await connection.getPrompt("greeting", { name: "Ada" }, options);
+
+    expect(connector.getPrompt).toHaveBeenCalledWith(
+      "greeting",
+      { name: "Ada" },
+      options
+    );
+  });
+});


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

Check all that apply:
- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

Allow prompt reads to accept MCP SDK `RequestOptions`, so callers can apply per-request timeout, cancellation, and progress handling consistently with other client operations.

## Review Readiness

- [x] The PR is scoped to one issue or one clearly related change
- [x] The PR description explains the user-visible problem and the fix
- [x] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [x] I verified the affected package/docs path with the commands listed below
- [x] I checked for existing open PRs that already solve the same issue

## Implementation Details

1. Add an optional `RequestOptions` parameter to `MCPConnection.getPrompt` and `BaseConnector.getPrompt`.
2. Forward the same options object unchanged to the MCP SDK client's `getPrompt` call.
3. Add focused regression tests for both delegation layers and a patch changeset for `@mcp-use/client`.

---

## TypeScript Checklist

### Packages Modified

- [ ] `docs`
- [x] `tests`
- [ ] `cli`
- [ ] `create-mcp-use-app`
- [ ] `mcp-use` (server)
- [x] `mcp-use` (client)
- [ ] `inspector`

### Pre-commit Checklist

- [x] Ran the pre-commit lint fixes successfully on the staged files
- [x] Ran `pnpm format:check`
- [x] Ran `pnpm --filter @mcp-use/client build`
- [x] Added a changeset for the user-facing change
- [x] Added focused tests
- [x] Documentation is covered by the updated public API TSDoc; no separate docs page is needed

## Example Usage (Before)

```typescript
await connection.getPrompt("greeting", { name: "Ada" });
```

## Example Usage (After)

```typescript
await connection.getPrompt("greeting", { name: "Ada" }, {
  timeout: 10_000,
  signal: controller.signal,
});
```

## Documentation Updates

- Updated `getPrompt` TSDoc at the connection and connector layers to document the optional per-request options.

## Testing

- `pnpm --filter @mcp-use/client test:run` (55 files, 339 tests passed)
- `pnpm --filter @mcp-use/client build`
- `pnpm format:check`
- `pnpm exec eslint packages/client/src/core/session.ts packages/client/src/transport/base.ts packages/client/tests/unit/client/get-prompt.test.ts`
- `pnpm changeset status`

The repository-wide `pnpm lint` currently reports pre-existing type-resolution errors under `packages/cli`; the changed client files pass a focused ESLint run.

## Backwards Compatibility

This is backwards compatible. Existing two-argument `getPrompt(name, args)` calls continue to work; the new third argument is optional.

## Related Issues

Closes #2294

Reference: #2292

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional MCP SDK RequestOptions to client prompt reads so callers can set per-request timeout, cancellation, and progress. Previously getPrompt(name, args) accepted no options; now getPrompt(name, args, options?) forwards options to the SDK client with no other behavior changes.

- Updates MCPConnection.getPrompt and BaseConnector.getPrompt to accept and pass through the options object.
- Backward compatible; existing two-argument calls keep working.
- Adds unit tests for both delegation layers.
- Adds a changeset marking `@mcp-use/client` as a minor release.

<sup>Written for commit efd688851ac4e69c02e91341c88ebcf0efbff749. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

