### PR TITLE
feat(inspector): correlate RPC response labels

### DIFF
--- a/libraries/typescript/.changeset/quiet-mails-smile.md
+++ b/libraries/typescript/.changeset/quiet-mails-smile.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Show the correlated request method and latency on JSON-RPC response rows.

--- a/libraries/typescript/packages/inspector/src/client/__tests__/rpc-traffic-correlation.test.ts
+++ b/libraries/typescript/packages/inspector/src/client/__tests__/rpc-traffic-correlation.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import { buildRpcTrafficResponseLabels } from "../rpc-traffic-correlation";
+import type { RpcTrafficEntry } from "../rpc-traffic-store";
+
+const request = ({
+  entryId,
+  rpcId,
+  method,
+  direction = "send",
+  timestamp = "2026-08-19T10:04:12.100Z",
+  source = "mcp",
+  serverId = "server-1",
+  widgetId,
+}: {
+  entryId: string;
+  rpcId: string | number;
+  method: string;
+  direction?: "send" | "receive";
+  timestamp?: string;
+  source?: "mcp" | "widget";
+  serverId?: string;
+  widgetId?: string;
+}): RpcTrafficEntry => ({
+  id: entryId,
+  source,
+  serverId,
+  widgetId,
+  direction,
+  timestamp,
+  message: { jsonrpc: "2.0", id: rpcId, method },
+});
+
+const response = ({
+  entryId,
+  rpcId,
+  direction = "receive",
+  timestamp = "2026-08-19T10:04:12.142Z",
+  source = "mcp",
+  serverId = "server-1",
+  widgetId,
+  error = false,
+}: {
+  entryId: string;
+  rpcId: string | number;
+  direction?: "send" | "receive";
+  timestamp?: string;
+  source?: "mcp" | "widget";
+  serverId?: string;
+  widgetId?: string;
+  error?: boolean;
+}): RpcTrafficEntry => ({
+  id: entryId,
+  source,
+  serverId,
+  widgetId,
+  direction,
+  timestamp,
+  message: error
+    ? { jsonrpc: "2.0", id: rpcId, error: { code: -32603 } }
+    : { jsonrpc: "2.0", id: rpcId, result: {} },
+});
+
+describe("RPC traffic response correlation", () => {
+  it("labels successful responses with the request method and latency", () => {
+    const labels = buildRpcTrafficResponseLabels([
+      request({ entryId: "rpc-1", rpcId: 7, method: "tools/call" }),
+      response({ entryId: "rpc-2", rpcId: 7 }),
+    ]);
+
+    expect(labels.get("rpc-2")).toBe("tools/call · 42 ms");
+  });
+
+  it("keeps correlated error responses distinguishable", () => {
+    const labels = buildRpcTrafficResponseLabels([
+      request({ entryId: "rpc-1", rpcId: 7, method: "tools/call" }),
+      response({ entryId: "rpc-2", rpcId: 7, error: true }),
+    ]);
+
+    expect(labels.get("rpc-2")).toBe("tools/call · 42 ms · error");
+  });
+
+  it("matches simultaneous bidirectional requests with the same id", () => {
+    const labels = buildRpcTrafficResponseLabels([
+      request({ entryId: "rpc-1", rpcId: 1, method: "tools/call" }),
+      request({
+        entryId: "rpc-2",
+        rpcId: 1,
+        method: "sampling/createMessage",
+        direction: "receive",
+        timestamp: "2026-08-19T10:04:12.110Z",
+      }),
+      response({
+        entryId: "rpc-3",
+        rpcId: 1,
+        timestamp: "2026-08-19T10:04:12.150Z",
+      }),
+      response({
+        entryId: "rpc-4",
+        rpcId: 1,
+        direction: "send",
+        timestamp: "2026-08-19T10:04:12.180Z",
+      }),
+    ]);
+
+    expect([...labels]).toEqual([
+      ["rpc-3", "tools/call · 50 ms"],
+      ["rpc-4", "sampling/createMessage · 70 ms"],
+    ]);
+  });
+
+  it("isolates correlations by source, server, widget, and id type", () => {
+    const labels = buildRpcTrafficResponseLabels([
+      request({ entryId: "rpc-1", rpcId: 1, method: "numeric" }),
+      request({ entryId: "rpc-2", rpcId: "1", method: "string" }),
+      request({
+        entryId: "rpc-3",
+        rpcId: 1,
+        method: "other-server",
+        serverId: "server-2",
+      }),
+      request({
+        entryId: "rpc-4",
+        rpcId: 1,
+        method: "widget-call",
+        source: "widget",
+        widgetId: "widget-1",
+      }),
+      response({ entryId: "rpc-5", rpcId: "1" }),
+      response({ entryId: "rpc-6", rpcId: 1, serverId: "server-2" }),
+      response({
+        entryId: "rpc-7",
+        rpcId: 1,
+        source: "widget",
+        widgetId: "widget-1",
+      }),
+      response({ entryId: "rpc-8", rpcId: 1 }),
+    ]);
+
+    expect([...labels.values()]).toEqual([
+      "string · 42 ms",
+      "other-server · 42 ms",
+      "widget-call · 42 ms",
+      "numeric · 42 ms",
+    ]);
+  });
+});

--- a/libraries/typescript/packages/inspector/src/client/__tests__/rpc-traffic-correlation.test.ts
+++ b/libraries/typescript/packages/inspector/src/client/__tests__/rpc-traffic-correlation.test.ts
@@ -61,13 +61,30 @@ const response = ({
 });
 
 describe("RPC traffic response correlation", () => {
+  it("keeps response method, latency, and outcome separate for presentation", () => {
+    const labels = buildRpcTrafficResponseLabels([
+      request({ entryId: "rpc-1", rpcId: 7, method: "tools/call" }),
+      response({ entryId: "rpc-2", rpcId: 7, error: true }),
+    ]);
+
+    expect(labels.get("rpc-2")).toEqual({
+      method: "tools/call",
+      latencyMs: 42,
+      outcome: "error",
+    });
+  });
+
   it("labels successful responses with the request method and latency", () => {
     const labels = buildRpcTrafficResponseLabels([
       request({ entryId: "rpc-1", rpcId: 7, method: "tools/call" }),
       response({ entryId: "rpc-2", rpcId: 7 }),
     ]);
 
-    expect(labels.get("rpc-2")).toBe("tools/call · 42 ms");
+    expect(labels.get("rpc-2")).toEqual({
+      method: "tools/call",
+      latencyMs: 42,
+      outcome: "result",
+    });
   });
 
   it("keeps correlated error responses distinguishable", () => {
@@ -76,7 +93,11 @@ describe("RPC traffic response correlation", () => {
       response({ entryId: "rpc-2", rpcId: 7, error: true }),
     ]);
 
-    expect(labels.get("rpc-2")).toBe("tools/call · 42 ms · error");
+    expect(labels.get("rpc-2")).toEqual({
+      method: "tools/call",
+      latencyMs: 42,
+      outcome: "error",
+    });
   });
 
   it("matches simultaneous bidirectional requests with the same id", () => {
@@ -103,8 +124,15 @@ describe("RPC traffic response correlation", () => {
     ]);
 
     expect([...labels]).toEqual([
-      ["rpc-3", "tools/call · 50 ms"],
-      ["rpc-4", "sampling/createMessage · 70 ms"],
+      ["rpc-3", { method: "tools/call", latencyMs: 50, outcome: "result" }],
+      [
+        "rpc-4",
+        {
+          method: "sampling/createMessage",
+          latencyMs: 70,
+          outcome: "result",
+        },
+      ],
     ]);
   });
 
@@ -137,10 +165,10 @@ describe("RPC traffic response correlation", () => {
     ]);
 
     expect([...labels.values()]).toEqual([
-      "string · 42 ms",
-      "other-server · 42 ms",
-      "widget-call · 42 ms",
-      "numeric · 42 ms",
+      { method: "string", latencyMs: 42, outcome: "result" },
+      { method: "other-server", latencyMs: 42, outcome: "result" },
+      { method: "widget-call", latencyMs: 42, outcome: "result" },
+      { method: "numeric", latencyMs: 42, outcome: "result" },
     ]);
   });
 });

--- a/libraries/typescript/packages/inspector/src/client/components/logging/JsonRpcLoggerView.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/logging/JsonRpcLoggerView.tsx
@@ -15,7 +15,10 @@ import { useRpcLogVirtualizer } from "@/client/hooks/use-rpc-log-virtualizer";
 import { cn } from "@/client/lib/utils";
 import { ensureRpcTrafficBridge } from "@/client/rpc-traffic-bridge";
 import { getRpcTrafficMethod } from "@/client/rpc-traffic-coalesce";
-import { buildRpcTrafficResponseLabels } from "@/client/rpc-traffic-correlation";
+import {
+  buildRpcTrafficResponseLabels,
+  type RpcTrafficResponseLabel,
+} from "@/client/rpc-traffic-correlation";
 import {
   rpcTrafficStore,
   type RpcTrafficEntry,
@@ -318,6 +321,7 @@ export function JsonRpcLoggerView({
                 key={item.id}
                 item={item}
                 method={getMethod(item, responseLabels)}
+                responseLabel={responseLabels.get(item.id)}
                 top={top}
                 height={height}
                 expanded={expanded.has(item.id)}
@@ -335,6 +339,7 @@ export function JsonRpcLoggerView({
 function RpcLogRow({
   item,
   method,
+  responseLabel,
   top,
   height,
   expanded,
@@ -343,6 +348,7 @@ function RpcLogRow({
 }: {
   item: RpcTrafficEntry;
   method: string;
+  responseLabel?: RpcTrafficResponseLabel;
   top: number;
   height: number;
   expanded: boolean;
@@ -400,7 +406,19 @@ function RpcLogRow({
         </Tooltip>
 
         <span className="min-w-0 flex-1 truncate font-mono text-xs text-foreground">
-          {method}
+          {responseLabel ? (
+            <>
+              <span>{responseLabel.method}</span>
+              <span className="ml-1 text-[9px] tabular-nums text-muted-foreground/80">
+                · {responseLabel.latencyMs} ms
+              </span>
+              {responseLabel.outcome === "error" ? (
+                <span className="text-muted-foreground"> · error</span>
+              ) : null}
+            </>
+          ) : (
+            method
+          )}
           {repeatSuffix ? (
             <span className="text-muted-foreground">{repeatSuffix}</span>
           ) : null}
@@ -448,10 +466,13 @@ function RpcLogRow({
 
 function getMethod(
   entry: RpcTrafficEntry,
-  responseLabels: ReadonlyMap<string, string>
+  responseLabels: ReadonlyMap<string, RpcTrafficResponseLabel>
 ): string {
   const responseLabel = responseLabels.get(entry.id);
-  if (responseLabel) return responseLabel;
+  if (responseLabel) {
+    const errorSuffix = responseLabel.outcome === "error" ? " · error" : "";
+    return `${responseLabel.method} · ${responseLabel.latencyMs} ms${errorSuffix}`;
+  }
 
   const fromMessage = getRpcTrafficMethod(entry.message);
   if (fromMessage) return fromMessage;

--- a/libraries/typescript/packages/inspector/src/client/components/logging/JsonRpcLoggerView.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/logging/JsonRpcLoggerView.tsx
@@ -15,6 +15,7 @@ import { useRpcLogVirtualizer } from "@/client/hooks/use-rpc-log-virtualizer";
 import { cn } from "@/client/lib/utils";
 import { ensureRpcTrafficBridge } from "@/client/rpc-traffic-bridge";
 import { getRpcTrafficMethod } from "@/client/rpc-traffic-coalesce";
+import { buildRpcTrafficResponseLabels } from "@/client/rpc-traffic-correlation";
 import {
   rpcTrafficStore,
   type RpcTrafficEntry,
@@ -86,6 +87,11 @@ export function JsonRpcLoggerView({
     return items.filter((item) => serverIdSet.has(item.serverId));
   }, [items, serverIds]);
 
+  const responseLabels = useMemo(
+    () => buildRpcTrafficResponseLabels(items),
+    [items]
+  );
+
   const sourceCheckedIndices = useMemo(() => {
     const indices = new Set<number>();
     if (sourceFilters.has("mcp")) indices.add(0);
@@ -112,7 +118,7 @@ export function JsonRpcLoggerView({
     const queryLower = searchQuery.trim().toLowerCase();
     if (queryLower) {
       result = result.filter((item) => {
-        const method = getMethod(item);
+        const method = getMethod(item, responseLabels);
         return (
           item.serverId.toLowerCase().includes(queryLower) ||
           item.widgetId?.toLowerCase().includes(queryLower) ||
@@ -125,7 +131,7 @@ export function JsonRpcLoggerView({
     }
 
     return [...result].reverse();
-  }, [scopedItems, searchQuery, sourceFilters]);
+  }, [responseLabels, scopedItems, searchQuery, sourceFilters]);
 
   const { totalHeight, visibleItems } = useRpcLogVirtualizer(
     filteredItems,
@@ -311,6 +317,7 @@ export function JsonRpcLoggerView({
               <RpcLogRow
                 key={item.id}
                 item={item}
+                method={getMethod(item, responseLabels)}
                 top={top}
                 height={height}
                 expanded={expanded.has(item.id)}
@@ -327,6 +334,7 @@ export function JsonRpcLoggerView({
 
 function RpcLogRow({
   item,
+  method,
   top,
   height,
   expanded,
@@ -334,13 +342,13 @@ function RpcLogRow({
   onCopy,
 }: {
   item: RpcTrafficEntry;
+  method: string;
   top: number;
   height: number;
   expanded: boolean;
   onToggle: () => void;
   onCopy: () => void;
 }) {
-  const method = getMethod(item);
   const direction = getDirectionLabel(item);
   const repeatSuffix =
     item.repeatCount && item.repeatCount > 1 ? ` ×${item.repeatCount}` : "";
@@ -438,7 +446,13 @@ function RpcLogRow({
   );
 }
 
-function getMethod(entry: RpcTrafficEntry): string {
+function getMethod(
+  entry: RpcTrafficEntry,
+  responseLabels: ReadonlyMap<string, string>
+): string {
+  const responseLabel = responseLabels.get(entry.id);
+  if (responseLabel) return responseLabel;
+
   const fromMessage = getRpcTrafficMethod(entry.message);
   if (fromMessage) return fromMessage;
   const message = entry.message as {

--- a/libraries/typescript/packages/inspector/src/client/rpc-traffic-correlation.ts
+++ b/libraries/typescript/packages/inspector/src/client/rpc-traffic-correlation.ts
@@ -1,0 +1,86 @@
+import { getRpcTrafficMethod } from "./rpc-traffic-coalesce";
+import type { RpcTrafficEntry } from "./rpc-traffic-store";
+
+type RpcRequestId = string | number;
+
+interface PendingRpcRequest {
+  method: string;
+  timestampMs: number;
+}
+
+export function buildRpcTrafficResponseLabels(
+  entries: readonly RpcTrafficEntry[]
+): ReadonlyMap<string, string> {
+  const pendingRequests = new Map<string, PendingRpcRequest>();
+  const responseLabels = new Map<string, string>();
+
+  entries.forEach((entry) => {
+    const message = entry.message as {
+      id?: unknown;
+      result?: unknown;
+      error?: unknown;
+    };
+    const rpcId = getRpcRequestId(message?.id);
+    if (rpcId === null) return;
+
+    const method = getRpcTrafficMethod(entry.message);
+    if (method) {
+      const timestampMs = Date.parse(entry.timestamp);
+      if (Number.isNaN(timestampMs)) return;
+      pendingRequests.set(getRpcCorrelationKey(entry, entry.direction, rpcId), {
+        method,
+        timestampMs,
+      });
+      return;
+    }
+
+    const outcome = getRpcResponseOutcome(message);
+    if (!outcome) return;
+
+    const requestDirection = entry.direction === "send" ? "receive" : "send";
+    const requestKey = getRpcCorrelationKey(entry, requestDirection, rpcId);
+    const request = pendingRequests.get(requestKey);
+    if (!request) return;
+    pendingRequests.delete(requestKey);
+
+    const responseTimestampMs = Date.parse(entry.timestamp);
+    const latencyMs = responseTimestampMs - request.timestampMs;
+    if (Number.isNaN(responseTimestampMs) || latencyMs < 0) return;
+
+    const errorSuffix = outcome === "error" ? " · error" : "";
+    responseLabels.set(
+      entry.id,
+      `${request.method} · ${latencyMs} ms${errorSuffix}`
+    );
+  });
+
+  return responseLabels;
+}
+
+function getRpcRequestId(id: unknown): RpcRequestId | null {
+  return typeof id === "string" || typeof id === "number" ? id : null;
+}
+
+function getRpcResponseOutcome(message: {
+  result?: unknown;
+  error?: unknown;
+}): "result" | "error" | null {
+  if (message.error !== undefined) return "error";
+  if (message.result !== undefined) return "result";
+  return null;
+}
+
+function getRpcCorrelationKey(
+  entry: RpcTrafficEntry,
+  direction: RpcTrafficEntry["direction"],
+  rpcId: RpcRequestId
+): string {
+  return JSON.stringify([
+    entry.source,
+    entry.serverId,
+    entry.widgetId ?? null,
+    direction,
+    typeof rpcId,
+    rpcId,
+  ]);
+}

--- a/libraries/typescript/packages/inspector/src/client/rpc-traffic-correlation.ts
+++ b/libraries/typescript/packages/inspector/src/client/rpc-traffic-correlation.ts
@@ -8,11 +8,17 @@ interface PendingRpcRequest {
   timestampMs: number;
 }
 
+export interface RpcTrafficResponseLabel {
+  method: string;
+  latencyMs: number;
+  outcome: "result" | "error";
+}
+
 export function buildRpcTrafficResponseLabels(
   entries: readonly RpcTrafficEntry[]
-): ReadonlyMap<string, string> {
+): ReadonlyMap<string, RpcTrafficResponseLabel> {
   const pendingRequests = new Map<string, PendingRpcRequest>();
-  const responseLabels = new Map<string, string>();
+  const responseLabels = new Map<string, RpcTrafficResponseLabel>();
 
   entries.forEach((entry) => {
     const message = entry.message as {
@@ -47,11 +53,11 @@ export function buildRpcTrafficResponseLabels(
     const latencyMs = responseTimestampMs - request.timestampMs;
     if (Number.isNaN(responseTimestampMs) || latencyMs < 0) return;
 
-    const errorSuffix = outcome === "error" ? " · error" : "";
-    responseLabels.set(
-      entry.id,
-      `${request.method} · ${latencyMs} ms${errorSuffix}`
-    );
+    responseLabels.set(entry.id, {
+      method: request.method,
+      latencyMs,
+      outcome,
+    });
   });
 
   return responseLabels;


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

Check all that apply:
- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

Correlate JSON-RPC responses with their originating requests in the Inspector traffic log so response rows show the request method and elapsed time. Error responses remain visibly distinguishable, while unmatched responses keep their existing `result` or `error` labels.

This follows the maintainer's proposed presentation in https://github.com/mcp-use/mcp-use/issues/2296#issuecomment-5345466662.

## Review Readiness

Help maintainers review this quickly:

- [x] The PR is scoped to one issue or one clearly related change
- [x] The PR description explains the user-visible problem and the fix
- [x] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [x] I verified the affected package/docs path with the commands listed below
- [x] I checked for existing open PRs that already solve the same issue

## Implementation Details

1. Build response display labels by matching JSON-RPC request and response IDs within the same source, server, widget, and opposite traffic direction.
2. Preserve JSON-RPC ID types during correlation so numeric and string IDs do not collide.
3. Keep correlation display-only: stored traffic entries, copied logs, and downloaded JSON are unchanged.
4. Add focused unit coverage for success, error, bidirectional traffic, source/server/widget isolation, and ID type isolation.
5. Add a patch changeset for `@mcp-use/inspector`.

---

## TypeScript Checklist

> Complete this section if your PR includes TypeScript changes

### Packages Modified

Check all packages that were modified:
- [ ] `docs`
- [ ] `tests`
- [ ] `cli`
- [ ] `create-mcp-use-app`
- [ ] `mcp-use` (server)
- [ ] `mcp-use` (client)
- [x] `inspector`

### Pre-commit Checklist

Ensure all of the following have been completed:
- [ ] Ran `pnpm lint:fix` to auto-fix linting issues
- [ ] Ran `pnpm format` to format code with Prettier
- [x] Ran `pnpm build` and build succeeds without errors
- [x] Ran `pnpm changeset` to create a changeset (if this PR includes user-facing changes)
- [x] Added or updated tests if needed
- [ ] Updated documentation in `docs/` folder if needed

Non-mutating `pnpm lint` and `pnpm format:check` validations pass; no documentation changes are needed for this UI-only fix.

---

## Python Checklist

> Complete this section if your PR includes Python changes

### Pre-commit Checklist

Ensure all of the following have been completed:
- [ ] Code formatted with `ruff format`
- [ ] Linting passes with `ruff check`
- [ ] Added or updated tests if needed
- [ ] Updated documentation if needed

---

## Example Usage (Before)

```text
result
error
```

## Example Usage (After)

```text
tools/call · 42 ms
tools/call · 42 ms · error
```

## Documentation Updates

None. This changes the existing Inspector traffic-row label and does not add a public API or configuration option.

## Testing

- `pnpm exec vitest run --maxWorkers=1` (`47` files, `222` tests)
- Inspector `pnpm type-check`
- Inspector `pnpm lint`
- TypeScript workspace `pnpm format:check`
- Inspector `pnpm build` (including package verification)
- TypeScript workspace `pnpm build`
- TypeScript workspace `pnpm changeset status`

## Backwards Compatibility

This is backwards compatible. It only enriches response labels in the Inspector UI; RPC traffic data and export/copy behavior are unchanged.

## Related Issues

Closes #2296

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Correlates JSON-RPC responses with their originating requests in the Inspector so response rows show the request method and latency. Previously responses displayed only “result” or “error”; now they render “method · N ms” and append “ · error” for failures.

- Match by id within the same source, server, widget, and opposite direction; preserve string vs number ids to avoid collisions.
- Leave unmatched responses as “result”/“error”; storage, copy, and export JSON are unchanged.
- Apply labels in row rendering and search only; no API or data model changes.
- Refine latency label typography for readability.
- Add unit tests and a patch changeset for `@mcp-use/inspector`.

<sup>Written for commit 6413ba8e122d273d17784c2050036dbf5e2e553d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

