### PR TITLE
fix(cli): drop the React plugin from the binding-validation server

### DIFF
--- a/libraries/typescript/.changeset/olive-cats-argue.md
+++ b/libraries/typescript/.changeset/olive-cats-argue.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/cli": patch
+---
+
+Stop loading the React plugin in the binding-validation server. That server only runs for projects with no views, so it has no JSX to transform, and the plugin pulled react, react-dom and the jsx runtimes into `optimizeDeps` where they cannot resolve. A fresh `mcp-server`, `blank` or `starter` project no longer prints four "Failed to resolve dependency" warnings on its first build.

--- a/libraries/typescript/packages/cli/src/cli/views.ts
+++ b/libraries/typescript/packages/cli/src/cli/views.ts
@@ -6,7 +6,6 @@
 
 import { existsSync, readdirSync } from "node:fs";
 import { isAbsolute, join, relative, resolve, sep } from "node:path";
-import react from "@vitejs/plugin-react";
 import type { ViteDevServer } from "vite";
 
 import type { ViewsManifest } from "../views/types.js";
@@ -177,7 +176,10 @@ export async function createBindingValidationServer(
       alias: nextStandaloneAliases(cwd),
     },
     oxc: { jsx: { runtime: "automatic" } },
-    plugins: [nextStandaloneCompatPlugin(cwd), react()],
+    // No React plugin here: this server only runs when the project has no
+    // views, so there is no JSX to transform, and loading it pulls react and
+    // the jsx runtimes into optimizeDeps where they cannot resolve.
+    plugins: [nextStandaloneCompatPlugin(cwd)],
     server: { middlewareMode: true, hmr: false, ws: false },
     ssr: {
       ...nextStandaloneSsrOptions(cwd),

--- a/libraries/typescript/packages/cli/src/cli/views.ts
+++ b/libraries/typescript/packages/cli/src/cli/views.ts
@@ -176,9 +176,6 @@ export async function createBindingValidationServer(
       alias: nextStandaloneAliases(cwd),
     },
     oxc: { jsx: { runtime: "automatic" } },
-    // No React plugin here: this server only runs when the project has no
-    // views, so there is no JSX to transform, and loading it pulls react and
-    // the jsx runtimes into optimizeDeps where they cannot resolve.
     plugins: [nextStandaloneCompatPlugin(cwd)],
     server: { middlewareMode: true, hmr: false, ws: false },
     ssr: {


### PR DESCRIPTION
Closes #2297.

### The defect

A fresh scaffold prints four resolution failures on its very first build:

```
$ npx create-mcp-use-app my-app --template mcp-server --yes
$ cd my-app && npm install && npm run build

[mcp-use] views directory not configured.
Failed to resolve dependency: react, present in client 'optimizeDeps.include'
Failed to resolve dependency: react-dom, present in client 'optimizeDeps.include'
Failed to resolve dependency: react/jsx-dev-runtime, present in client 'optimizeDeps.include'
Failed to resolve dependency: react/jsx-runtime, present in client 'optimizeDeps.include'
[mcp-use] built index.ts → .mcp-use/build/index.js
```

The build succeeds, so this is noise, but it is the first output a new project produces and the template depends only on `mcp-use` and `zod`.

It affects 3 of the 4 templates, everything without a views directory:

| template | views | build | `Failed to resolve dependency` |
| --- | --- | --- | ---: |
| `mcp-server` | no | exit 0 | 4 |
| `blank` | no | exit 0 | 4 |
| `starter` | no | exit 0 | 4 |
| `mcp-apps` | `views/my-view` | exit 0 | 0 |

### The cause

`createBindingValidationServer` loads the React plugin unconditionally, and `build.ts` only calls that helper when there are **no** views:

```ts
if (views.length === 0) {
  bindingServer ??= await createBindingValidationServer(
```

So the one path guaranteed to have no JSX is the one that loads the JSX plugin, and `react()` puts react, react-dom and both jsx runtimes into `optimizeDeps.include`. `react()` had no other use in `views.ts`, so the import goes with it.

### Verified

I asked on the issue whether that server needs React, then tested it rather than waiting.

**Binding validation still works.** The three cases that guard it all pass:

```
tests/cli/build.test.ts   24 passed (24)   incl. "fails precisely when a tool binds a view and no view component exists"
                                           and  "fails when a tool binds a missing view"
tests/cli/dev.test.ts     34 passed (34)   incl. "fails precisely when a tool binds a view and no view component exists"
```

**The warnings are gone and both paths still build**, using a locally built CLI against fresh scaffolds:

```
no views  (mcp-server): [mcp-use] built index.ts → .mcp-use/build/index.js      0 warnings (was 4)
with views (mcp-apps):  [mcp-use] built index.ts + views (my-view) → ...        builds normally
```

One note on the full `pnpm --filter @mcp-use/cli test:run`: it fails locally for me at `tests/proxy.test.mjs` on `'2.2.4' !== '2.3.0'`, which is my stale local `dist` rather than this change. It fails identically with the change stashed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes `@vitejs/plugin-react` from the binding-validation server so fresh projects without views no longer print four Vite resolve warnings. Previously this server always loaded the React plugin, which added `react`, `react-dom`, and JSX runtimes to `optimizeDeps` in projects that don't depend on React; now the warnings are gone with no change to validation behavior.

**Notes for review**
- Change is limited to `views.ts`: drop the React import and remove it from `plugins`.
- Affects templates with no `views/` (`mcp-server`, `blank`, `starter`); `mcp-apps` is unchanged.
- Binding validation still fails when a view is missing and passes otherwise; both build paths work as before.

<sup>Written for commit 874f3ad979e6ff096364e313609b70deeb4fd3ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

