### PR TITLE
fix(client): isolate useMcp connection lifecycles

### DIFF
--- a/libraries/typescript/.changeset/fix-usemcp-lifecycle-races.md
+++ b/libraries/typescript/.changeset/fix-usemcp-lifecycle-races.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/client": patch
+---
+
+Give each `useMcp` connection Effect its own client lifecycle so stale connection attempts, cleanup, OAuth callbacks, proxy fallback, health checks, and inventory refreshes cannot overwrite or disconnect a newer connection.

--- a/libraries/typescript/packages/client/src/react/useMcp-lifecycle.ts
+++ b/libraries/typescript/packages/client/src/react/useMcp-lifecycle.ts
@@ -1,0 +1,212 @@
+import type { OAuthClientProvider } from "@modelcontextprotocol/client";
+import type { BrowserMCPClient } from "../core/browser.js";
+import type { MCPConnection } from "../core/session.js";
+
+/**
+ * The OAuth provider shape used by useMcp.  This lives here because a provider
+ * belongs to one connection lifecycle: replacing the provider (for example
+ * after an OAuth callback) must not change an already-running lifecycle.
+ */
+export type UseMcpAuthProvider = OAuthClientProvider & {
+  tokens?: () => Promise<
+    | {
+        access_token?: string;
+        token_type?: string;
+        refresh_token?: string;
+        scope?: string;
+        [key: string]: unknown;
+      }
+    | undefined
+  >;
+  clearStorage?: () => number;
+  getLastAttemptedAuthUrl?: () => string | null | undefined;
+  getTokenEndpoint?: () => Promise<string | null>;
+  getResource?: () => Promise<string | null>;
+  getClientCredentials?: () => Promise<{
+    client_id: string;
+    client_secret?: string;
+  } | null>;
+  getProxyFetch?: (baseFetch?: typeof fetch) => typeof fetch | undefined;
+  serverUrl?: string;
+  getKey?: (keySuffix: string) => string;
+  serverUrlHash?: string;
+};
+
+/** A lifecycle's transport state, including states in which no session exists. */
+export type ConnectionLifecyclePhase =
+  | "connecting"
+  | "waiting_for_auth"
+  | "authenticating"
+  | "ready"
+  | "failed"
+  | "retiring"
+  | "retired";
+
+/** Why this lifecycle was started. Primarily useful for coalescing and logs. */
+export type ConnectionLifecycleTrigger =
+  | "configuration"
+  | "manual-retry"
+  | "auto-retry"
+  | "oauth-success"
+  | "health-check"
+  | "proxy-fallback";
+
+/**
+ * A complete ownership record for one `useMcp` connection attempt.
+ *
+ * A lifecycle intentionally owns a fresh client.  It is never safe for an old
+ * lifecycle to close or mutate a client owned by a newer lifecycle.
+ */
+export interface ConnectionLifecycle<TSnapshot = unknown> {
+  readonly id: number;
+  readonly trigger: ConnectionLifecycleTrigger;
+  readonly serverName: string;
+  readonly client: BrowserMCPClient;
+  readonly authProvider: UseMcpAuthProvider;
+  readonly snapshot: TSnapshot;
+
+  connection: MCPConnection | null;
+  phase: ConnectionLifecyclePhase;
+  started: boolean;
+  cancelled: boolean;
+  healthCleanup: (() => void) | null;
+  /** Serializes all client closes requested for this lifecycle. */
+  teardownPromise: Promise<void> | null;
+}
+
+export type ConnectionLifecycleRef<TSnapshot = unknown> = {
+  current: ConnectionLifecycle<TSnapshot> | null;
+};
+
+export function createConnectionLifecycle<TSnapshot>(params: {
+  id: number;
+  trigger: ConnectionLifecycleTrigger;
+  serverName: string;
+  client: BrowserMCPClient;
+  authProvider: UseMcpAuthProvider;
+  snapshot: TSnapshot;
+}): ConnectionLifecycle<TSnapshot> {
+  return {
+    ...params,
+    connection: null,
+    phase: "connecting",
+    started: false,
+    cancelled: false,
+    healthCleanup: null,
+    teardownPromise: null,
+  };
+}
+
+/** Whether this lifecycle still exclusively owns hook state. */
+export function isCurrentLifecycle<TSnapshot>(
+  lifecycleRef: ConnectionLifecycleRef<TSnapshot>,
+  lifecycle: ConnectionLifecycle<TSnapshot>
+): boolean {
+  return lifecycleRef.current === lifecycle && !lifecycle.cancelled;
+}
+
+/**
+ * Execute a state commit only while this lifecycle owns the hook.  Returning a
+ * boolean lets callers distinguish a skipped stale commit from a successful
+ * one without reading mutable refs again.
+ */
+export function commitLifecycle<TSnapshot>(
+  lifecycleRef: ConnectionLifecycleRef<TSnapshot>,
+  lifecycle: ConnectionLifecycle<TSnapshot>,
+  commit: () => void
+): boolean {
+  if (!isCurrentLifecycle(lifecycleRef, lifecycle)) {
+    return false;
+  }
+
+  commit();
+  return true;
+}
+
+/** Queue a close after any earlier close, preserving teardown ordering. */
+function queueClientClose<TSnapshot>(
+  lifecycle: ConnectionLifecycle<TSnapshot>
+): Promise<void> {
+  const previous = lifecycle.teardownPromise ?? Promise.resolve();
+  const closePromise = previous
+    // A failed close must not prevent a later-arriving connection from being
+    // closed. The newly queued close remains observable to its caller.
+    .catch(() => undefined)
+    .then(async () => {
+      await lifecycle.client.closeSession(lifecycle.serverName);
+    });
+
+  lifecycle.teardownPromise = closePromise;
+  void closePromise.then(
+    () => {
+      if (lifecycle.teardownPromise === closePromise && lifecycle.cancelled) {
+        lifecycle.phase = "retired";
+      }
+    },
+    () => {
+      if (lifecycle.teardownPromise === closePromise && lifecycle.cancelled) {
+        lifecycle.phase = "retired";
+      }
+    }
+  );
+
+  return closePromise;
+}
+
+/**
+ * Record the connection once `client.connect()` resolves.
+ *
+ * If cancellation happened while connect was pending, a second close is
+ * queued. This is essential: closing a client before it has a session does not
+ * close the session that `connect()` adds later.
+ */
+export function attachLifecycleConnection<TSnapshot>(
+  lifecycle: ConnectionLifecycle<TSnapshot>,
+  connection: MCPConnection
+): Promise<void> | null {
+  lifecycle.connection = connection;
+
+  return lifecycle.cancelled ? queueClientClose(lifecycle) : null;
+}
+
+/**
+ * Close once more when a pending connection attempt settles by rejecting after
+ * retirement. The client may have created a session internally before the
+ * rejected promise became observable to the hook.
+ */
+export function closeRetiredLifecycleAfterConnectFailure<TSnapshot>(
+  lifecycle: ConnectionLifecycle<TSnapshot>
+): Promise<void> | null {
+  return lifecycle.cancelled ? queueClientClose(lifecycle) : null;
+}
+
+/**
+ * Synchronously retire a lifecycle, then asynchronously release its resources.
+ * The operation is idempotent and safe before a pending `connect()` resolves.
+ */
+export function retireLifecycle<TSnapshot>(
+  lifecycle: ConnectionLifecycle<TSnapshot>
+): Promise<void> {
+  if (lifecycle.cancelled) {
+    return lifecycle.teardownPromise ?? queueClientClose(lifecycle);
+  }
+
+  lifecycle.cancelled = true;
+  lifecycle.phase = "retiring";
+
+  try {
+    lifecycle.healthCleanup?.();
+  } finally {
+    lifecycle.healthCleanup = null;
+  }
+
+  // React Strict Mode may retire its preflight Effect before the queued
+  // lifecycle runner starts. No server/session exists in that case, so avoid a
+  // noisy closeSession() call against an untouched client.
+  if (!lifecycle.started) {
+    lifecycle.phase = "retired";
+    return Promise.resolve();
+  }
+
+  return queueClientClose(lifecycle);
+}

--- a/libraries/typescript/packages/client/src/react/useMcp-operations.ts
+++ b/libraries/typescript/packages/client/src/react/useMcp-operations.ts
@@ -28,6 +28,7 @@ type Params = {
   stateRef: RefObject<UseMcpResult["state"]>;
   connectionRef: RefObject<MCPConnection | null>;
   hasClient: () => boolean;
+  isConnectionCurrent: (connection: MCPConnection) => boolean;
   isMounted: () => boolean;
   setTools: Dispatch<SetStateAction<Tool[]>>;
   setResources: Dispatch<SetStateAction<Resource[]>>;
@@ -57,12 +58,16 @@ function requireConnection(params: Params, operation: string): MCPConnection {
 
 async function executeWithAuthorizationSignal<T>(
   params: Params,
+  connection: MCPConnection,
   operation: () => Promise<T>
 ): Promise<T> {
   try {
     return await operation();
   } catch (error) {
-    if (isOAuthInteractionRequired(error)) {
+    if (
+      isOAuthInteractionRequired(error) &&
+      params.isConnectionCurrent(connection)
+    ) {
       params.onAuthorizationRequired(error);
     }
     throw error;
@@ -76,8 +81,10 @@ export function useMcpOperations(params: Params) {
       params.addLog("info", `Calling tool: ${name}`, args);
       const startedAt = Date.now();
       try {
-        const result = await executeWithAuthorizationSignal(params, () =>
-          connection.callTool(name, args || {}, options)
+        const result = await executeWithAuthorizationSignal(
+          params,
+          connection,
+          () => connection.callTool(name, args || {}, options)
         );
         params.addLog("info", `Tool "${name}" call successful:`, result);
         Tel.getInstance()
@@ -107,10 +114,14 @@ export function useMcpOperations(params: Params) {
   const listResources = useCallback(async () => {
     const connection = requireConnection(params, "list resources");
     params.addLog("info", "Listing resources");
-    const result = await executeWithAuthorizationSignal(params, () =>
-      connection.listAllResources()
+    const result = await executeWithAuthorizationSignal(
+      params,
+      connection,
+      () => connection.listAllResources()
     );
-    params.setResources(result.resources || []);
+    if (params.isConnectionCurrent(connection)) {
+      params.setResources(result.resources || []);
+    }
   }, [params.addLog, params.onAuthorizationRequired]);
 
   const readResource = useCallback(
@@ -118,8 +129,10 @@ export function useMcpOperations(params: Params) {
       const connection = requireConnection(params, "read resource");
       params.addLog("info", `Reading resource: ${uri}`);
       try {
-        const result = await executeWithAuthorizationSignal(params, () =>
-          connection.readResource(uri)
+        const result = await executeWithAuthorizationSignal(
+          params,
+          connection,
+          () => connection.readResource(uri)
         );
         Tel.getInstance()
           .trackUseMcpResourceRead({ resourceUri: uri, success: true })
@@ -142,17 +155,21 @@ export function useMcpOperations(params: Params) {
   const listSkills = useCallback(async () => {
     const connection = requireConnection(params, "list skills");
     params.addLog("info", "Listing skills");
-    const result = await executeWithAuthorizationSignal(params, () =>
-      connection.listAllSkills()
+    const result = await executeWithAuthorizationSignal(
+      params,
+      connection,
+      () => connection.listAllSkills()
     );
-    params.setSkills(result.skills);
+    if (params.isConnectionCurrent(connection)) {
+      params.setSkills(result.skills);
+    }
   }, [params.addLog, params.onAuthorizationRequired]);
 
   const getSkill = useCallback(
     async (uri: string) => {
       const connection = requireConnection(params, "get skill");
       params.addLog("info", `Getting skill: ${uri}`);
-      return executeWithAuthorizationSignal(params, () =>
+      return executeWithAuthorizationSignal(params, connection, () =>
         connection.getSkill(uri)
       );
     },
@@ -163,7 +180,7 @@ export function useMcpOperations(params: Params) {
     async (uri: string, cursor?: string) => {
       const connection = requireConnection(params, "read resource directory");
       params.addLog("info", `Reading resource directory: ${uri}`);
-      return executeWithAuthorizationSignal(params, () =>
+      return executeWithAuthorizationSignal(params, connection, () =>
         connection.readResourceDirectory(uri, cursor)
       );
     },
@@ -173,21 +190,29 @@ export function useMcpOperations(params: Params) {
   const listPrompts = useCallback(async () => {
     const connection = requireConnection(params, "list prompts");
     params.addLog("info", "Listing prompts");
-    const result = await executeWithAuthorizationSignal(params, () =>
-      connection.listPrompts()
+    const result = await executeWithAuthorizationSignal(
+      params,
+      connection,
+      () => connection.listPrompts()
     );
-    params.setPrompts(result.prompts || []);
+    if (params.isConnectionCurrent(connection)) {
+      params.setPrompts(result.prompts || []);
+    }
   }, [params.addLog, params.onAuthorizationRequired]);
 
   const refreshTools = useCallback(async () => {
     if (params.stateRef.current !== "ready" || !params.connectionRef.current)
       return;
+    const connection = params.connectionRef.current;
     try {
-      params.setTools(
-        (await executeWithAuthorizationSignal(params, () =>
-          params.connectionRef.current!.listTools()
-        )) || []
+      const tools = await executeWithAuthorizationSignal(
+        params,
+        connection,
+        () => connection.listTools()
       );
+      if (params.isConnectionCurrent(connection)) {
+        params.setTools(tools || []);
+      }
     } catch (error) {
       params.addLog("error", "Failed to refresh tools:", error);
     }
@@ -196,11 +221,16 @@ export function useMcpOperations(params: Params) {
   const refreshResources = useCallback(async () => {
     if (params.stateRef.current !== "ready" || !params.connectionRef.current)
       return;
+    const connection = params.connectionRef.current;
     try {
-      const result = await executeWithAuthorizationSignal(params, () =>
-        params.connectionRef.current!.listAllResources()
+      const result = await executeWithAuthorizationSignal(
+        params,
+        connection,
+        () => connection.listAllResources()
       );
-      params.setResources(result.resources || []);
+      if (params.isConnectionCurrent(connection)) {
+        params.setResources(result.resources || []);
+      }
     } catch (error) {
       params.addLog("warn", "Failed to refresh resources:", error);
     }
@@ -209,11 +239,16 @@ export function useMcpOperations(params: Params) {
   const refreshPrompts = useCallback(async () => {
     if (params.stateRef.current !== "ready" || !params.connectionRef.current)
       return;
+    const connection = params.connectionRef.current;
     try {
-      const result = await executeWithAuthorizationSignal(params, () =>
-        params.connectionRef.current!.listPrompts()
+      const result = await executeWithAuthorizationSignal(
+        params,
+        connection,
+        () => connection.listPrompts()
       );
-      params.setPrompts(result.prompts || []);
+      if (params.isConnectionCurrent(connection)) {
+        params.setPrompts(result.prompts || []);
+      }
     } catch (error) {
       params.addLog("warn", "Failed to refresh prompts:", error);
     }
@@ -222,27 +257,36 @@ export function useMcpOperations(params: Params) {
   const refreshSkills = useCallback(async () => {
     if (params.stateRef.current !== "ready" || !params.connectionRef.current)
       return;
+    const connection = params.connectionRef.current;
     try {
-      const result = await executeWithAuthorizationSignal(params, () =>
-        params.connectionRef.current!.listAllSkills()
+      const result = await executeWithAuthorizationSignal(
+        params,
+        connection,
+        () => connection.listAllSkills()
       );
-      params.setSkills(result.skills);
+      if (params.isConnectionCurrent(connection)) {
+        params.setSkills(result.skills);
+      }
     } catch (error) {
       // A development reload may remove the final skills directory, in which
       // case the replacement server intentionally no longer exposes the
       // extension. Clear the prior snapshot without treating that transition
       // as a connection failure.
-      params.setSkills([]);
+      if (params.isConnectionCurrent(connection)) {
+        params.setSkills([]);
+      }
       params.addLog("debug", "Skills are unavailable after refresh:", error);
     }
   }, [params.addLog, params.onAuthorizationRequired]);
 
   const refreshResourceTemplates = useCallback(async () => {
     const connection = requireConnection(params, "refresh resource templates");
-    const result = await executeWithAuthorizationSignal(params, () =>
-      connection.listResourceTemplates()
+    const result = await executeWithAuthorizationSignal(
+      params,
+      connection,
+      () => connection.listResourceTemplates()
     );
-    if (params.isMounted()) {
+    if (params.isMounted() && params.isConnectionCurrent(connection)) {
       params.setResourceTemplates(result.resourceTemplates || []);
     }
   }, [params.addLog, params.onAuthorizationRequired]);
@@ -261,7 +305,7 @@ export function useMcpOperations(params: Params) {
   const getPrompt = useCallback(
     async (name: string, args?: Record<string, unknown>) => {
       const connection = requireConnection(params, "get prompt");
-      return executeWithAuthorizationSignal(params, () =>
+      return executeWithAuthorizationSignal(params, connection, () =>
         connection.getPrompt(name, args || {})
       );
     },
@@ -271,7 +315,7 @@ export function useMcpOperations(params: Params) {
   const complete = useCallback(
     async (request: CompleteRequestParams): Promise<CompleteResult> => {
       const connection = requireConnection(params, "request completion");
-      return executeWithAuthorizationSignal(params, () =>
+      return executeWithAuthorizationSignal(params, connection, () =>
         connection.complete(request)
       );
     },

--- a/libraries/typescript/packages/client/src/react/useMcp.ts
+++ b/libraries/typescript/packages/client/src/react/useMcp.ts
@@ -1,7 +1,6 @@
 // useMcp.ts
 import { auth } from "@modelcontextprotocol/client";
 import type {
-  OAuthClientProvider,
   Prompt,
   ProtocolEra,
   Resource,
@@ -38,6 +37,16 @@ import { loadServerIcon } from "./useMcp-helpers.js";
 import { useMcpOperations } from "./useMcp-operations.js";
 import { getOAuthTokenExpiry } from "./token-expiry.js";
 import { SKILLS_EXTENSION_ID } from "../core/skills.js";
+import {
+  attachLifecycleConnection,
+  closeRetiredLifecycleAfterConnectFailure,
+  createConnectionLifecycle,
+  isCurrentLifecycle,
+  retireLifecycle,
+  type ConnectionLifecycle,
+  type ConnectionLifecycleTrigger,
+  type UseMcpAuthProvider,
+} from "./useMcp-lifecycle.js";
 
 const DEFAULT_RECONNECT_DELAY = 3000;
 const DEFAULT_RETRY_DELAY = 5000;
@@ -45,38 +54,11 @@ const DEFAULT_RETRY_DELAY = 5000;
 // Streamable HTTP is the only supported remote transport.
 type TransportType = "http";
 
-type UseMcpAuthProvider = OAuthClientProvider & {
-  tokens?: () => Promise<
-    | {
-        access_token?: string;
-        token_type?: string;
-        refresh_token?: string;
-        scope?: string;
-        [key: string]: unknown;
-      }
-    | undefined
-  >;
-  clearStorage?: () => number;
-  getLastAttemptedAuthUrl?: () => string | null | undefined;
-  getTokenEndpoint?: () => Promise<string | null>;
-  getResource?: () => Promise<string | null>;
-  getClientCredentials?: () => Promise<{
-    client_id: string;
-    client_secret?: string;
-  } | null>;
-  /**
-   * Returns a `fetch` scoped to this provider that routes OAuth requests
-   * through the configured OAuth proxy (bypassing CORS) while leaving the
-   * global `fetch` untouched. Passed to the SDK transport / `auth()` so proxy
-   * behavior is confined to this server's connection.
-   */
-  getProxyFetch?: (baseFetch?: typeof fetch) => typeof fetch | undefined;
-  serverUrl?: string;
-  /** localStorage key for a given suffix (e.g. "tokens"). */
-  getKey?: (keySuffix: string) => string;
-  /** Stable hash of the server URL, used to scope OAuth result messages. */
-  serverUrlHash?: string;
+type ConnectionSnapshot = {
+  url: string;
+  gatewayUrl?: string;
 };
+type Lifecycle = ConnectionLifecycle<ConnectionSnapshot>;
 
 type UseMcpInternalOptions = UseMcpOptions & {
   _initialServerInfo?: {
@@ -373,20 +355,23 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
     useState<UseMcpResult["authTokens"]>(undefined);
   const [authorization, setAuthorization] =
     useState<UseMcpResult["authorization"]>(undefined);
+  const [reconnectRequestId, setReconnectRequestId] = useState(0);
 
   const clientRef = useRef<BrowserMCPClient | null>(null);
   const connectionRef = useRef<MCPConnection | null>(null);
+  const lifecycleRef = useRef<Lifecycle | null>(null);
+  const nextLifecycleIdRef = useRef(0);
   const authProviderRef = useRef<UseMcpAuthProvider | null>(
     (providedAuthProvider as UseMcpAuthProvider | undefined) ?? null
   );
   const iconLoadingPromiseRef = useRef<Promise<string | null> | null>(null);
-  const connectingRef = useRef<boolean>(false);
   const isMountedRef = useRef<boolean>(true);
-  const connectAttemptRef = useRef<number>(0);
-  /** Bumped at the start of each connect(); disconnect only clears clientRef if epoch unchanged. */
-  const connectEpochRef = useRef(0);
   const authTimeoutRef = useRef<number | null>(null);
   const retryScheduledRef = useRef<boolean>(false);
+  const reconnectRequestPendingRef = useRef(false);
+  const reconnectTriggerRef =
+    useRef<ConnectionLifecycleTrigger>("configuration");
+  const manuallyDisconnectedRef = useRef(false);
   /**
    * True while a manual `authenticate()` popup flow owns the OAuth result.
    * The always-on `mcp_auth_callback` listener defers to the popup runner
@@ -401,8 +386,6 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
   authorizationRef.current = authorization;
   const autoReconnectRef = useRef(autoReconnect);
   const successfulTransportRef = useRef<TransportType | null>(null);
-  // Forward refs for functions (declared later) to avoid circular dependencies
-  const connectRef = useRef<(() => Promise<void>) | null>(null);
   const failConnectionRef = useRef<
     ((message: string, error?: Error) => void) | null
   >(null);
@@ -463,6 +446,13 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
   }, [state, autoReconnect]);
 
   useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
     authProviderRef.current =
       (providedAuthProvider as UseMcpAuthProvider | undefined) ?? null;
   }, [providedAuthProvider]);
@@ -513,6 +503,44 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
     [instanceLogger]
   );
 
+  /**
+   * Event handlers request a replacement lifecycle by updating a primitive
+   * signal. The main Effect remains the only place that creates clients and
+   * starts connections.
+   */
+  const requestReconnect = useCallback(
+    (reason: ConnectionLifecycleTrigger): boolean => {
+      if (!isMountedRef.current || manuallyDisconnectedRef.current) {
+        return false;
+      }
+      if (reconnectRequestPendingRef.current) {
+        addLog(
+          "debug",
+          `Reconnect request already pending; ignoring ${reason}.`
+        );
+        return false;
+      }
+
+      const lifecycle = lifecycleRef.current;
+      if (
+        lifecycle?.phase === "connecting" &&
+        !(reason === "oauth-success" && lifecycle.trigger !== "oauth-success")
+      ) {
+        addLog(
+          "debug",
+          `Connection lifecycle already starting; coalescing ${reason}.`
+        );
+        return false;
+      }
+
+      reconnectRequestPendingRef.current = true;
+      reconnectTriggerRef.current = reason;
+      setReconnectRequestId((requestId) => requestId + 1);
+      return true;
+    },
+    [addLog]
+  );
+
   const onAuthorizationRequired = useCallback(
     (authError: unknown) => {
       const preparedAuthUrl =
@@ -537,6 +565,14 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
     stateRef,
     connectionRef,
     hasClient: () => clientRef.current !== null,
+    isConnectionCurrent: (connection) => {
+      const lifecycle = lifecycleRef.current;
+      return (
+        lifecycle !== null &&
+        lifecycle.connection === connection &&
+        isCurrentLifecycle(lifecycleRef, lifecycle)
+      );
+    },
     isMounted: () => isMountedRef.current,
     setTools,
     setResources,
@@ -554,44 +590,48 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
   const disconnect = useCallback(
     async (quiet = false) => {
       if (!quiet) addLog("info", "Disconnecting...");
-      connectingRef.current = false;
+      if (!quiet) manuallyDisconnectedRef.current = true;
       if (authTimeoutRef.current) clearTimeout(authTimeoutRef.current);
       authTimeoutRef.current = null;
 
-      const epochAtStart = connectEpochRef.current;
-      const clientToClose = clientRef.current;
-      if (clientToClose) {
+      const lifecycle = lifecycleRef.current;
+      if (lifecycle) {
+        // Invalidate ownership before beginning asynchronous teardown. A late
+        // connect result is attached to this retired lifecycle and closed by
+        // retireLifecycle without being allowed to publish into the hook.
+        if (lifecycleRef.current === lifecycle) lifecycleRef.current = null;
+        if (clientRef.current === lifecycle.client) clientRef.current = null;
+        if (connectionRef.current === lifecycle.connection) {
+          connectionRef.current = null;
+        }
+
+        // Logical disconnection is synchronous. Transport teardown continues
+        // below, but the retired lifecycle can no longer appear ready.
+        if (isMountedRef.current && !quiet) {
+          setState("discovering");
+          setTools([]);
+          setResources([]);
+          setResourceTemplates([]);
+          setPrompts([]);
+          setSkills([]);
+          setError(undefined);
+          setAuthUrl(undefined);
+          setAuthTokens(undefined);
+          setServerInfo(undefined);
+          setCapabilities(undefined);
+          setProtocolEra(undefined);
+          setProtocolVersion(undefined);
+          setInstructions(undefined);
+          setExtensions({});
+        }
         try {
-          const serverName = USE_MCP_SERVER_NAME;
-          const connection =
-            clientToClose === clientRef.current ? connectionRef.current : null;
-
-          // Clean up health check monitoring if it exists
-          if (connection && (connection as any)._healthCheckCleanup) {
-            (connection as any)._healthCheckCleanup();
-            (connection as any)._healthCheckCleanup = null;
-          }
-
-          // Only try to close if a connection exists (avoids noisy warning logs)
-          if (connection) {
-            await clientToClose.closeSession(serverName);
-          }
+          await retireLifecycle(lifecycle);
         } catch (err) {
           if (!quiet) addLog("warn", "Error closing connection:", err);
         }
       }
-      // A newer connect() (e.g. dashboard environment / URL change) may have
-      // bumped the epoch — possibly reusing the same client instance — while
-      // closeSession was in flight. If so, this disconnect is stale: it must
-      // neither null the (now newer) clientRef nor reset the live state.
-      const supersededByNewerConnect = connectEpochRef.current !== epochAtStart;
 
-      if (clientRef.current === clientToClose && !supersededByNewerConnect) {
-        clientRef.current = null;
-        connectionRef.current = null;
-      }
-
-      if (isMountedRef.current && !quiet && !supersededByNewerConnect) {
+      if (isMountedRef.current && !quiet && !lifecycle) {
         setState("discovering");
         setTools([]);
         setResources([]);
@@ -618,7 +658,14 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
    * @returns true if automatic fallback was triggered (caller should not set failed state)
    */
   const failConnection = useCallback(
-    (errorMessage: string, connectionError?: Error): boolean => {
+    (
+      lifecycle: Lifecycle | null,
+      errorMessage: string,
+      connectionError?: Error
+    ): boolean => {
+      if (!lifecycle || !isCurrentLifecycle(lifecycleRef, lifecycle)) {
+        return false;
+      }
       addLog("error", errorMessage, connectionError ?? "");
 
       // Extract HTTP status code from error if available
@@ -666,14 +713,16 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
           `Direct connection failed with ${errorType}. Trying with proxy...`
         );
 
-        // Clear client/auth refs to force fresh initialization with proxy.
-        // Keep externally provided auth providers intact. Synchronous clear;
-        // reconnect is deferred via setTimeout below, so no disconnect race.
-        clientRef.current = null;
+        // Force the replacement Effect to create an OAuth provider configured
+        // for the newly selected gateway. The current lifecycle retains its
+        // captured provider while it is retired.
         if (!providedAuthProvider) {
           authProviderRef.current = null;
         }
-        addLog("debug", "Cleared client and auth provider for proxy fallback");
+        void retireLifecycle(lifecycle).catch((error) => {
+          addLog("warn", "Error retiring direct connection:", error);
+        });
+        addLog("debug", "Retired direct lifecycle for proxy fallback");
 
         // Set proxy configuration and trigger reconnect
         setEffectiveProxyConfig({
@@ -686,22 +735,16 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
           setState("discovering");
         }
 
-        // Trigger reconnection after a brief delay
-        setTimeout(() => {
-          if (isMountedRef.current) {
-            connectRef.current?.();
-          }
-        }, 1000);
-
         return true; // Signal that we're retrying - caller should not set failed state
       }
 
       // Normal failure handling
       if (isMountedRef.current) {
         addLog("info", "Setting state to FAILED:", errorMessage);
+        lifecycle.phase = "failed";
         setState("failed");
         setError(errorMessage);
-        const manualUrl = authProviderRef.current?.getLastAttemptedAuthUrl?.();
+        const manualUrl = lifecycle.authProvider.getLastAttemptedAuthUrl?.();
         if (manualUrl) {
           setAuthUrl(manualUrl);
           addLog(
@@ -711,8 +754,6 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
           );
         }
       }
-      connectingRef.current = false;
-
       // Track failed connection
       if (url) {
         Tel.getInstance()
@@ -721,7 +762,7 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
             transportType: transportType,
             success: false,
             errorType: connectionError?.name || "UnknownError",
-            hasOAuth: !!authProviderRef.current,
+            hasOAuth: !!lifecycle.authProvider,
             hasSampling: hasSamplingCallbackRef.current,
             hasElicitation: hasElicitationCallbackRef.current,
           })
@@ -744,611 +785,583 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
    * Connect to the MCP server over streamable HTTP.
    * @internal
    */
-  const connect = useCallback(async () => {
-    // Don't connect if not enabled or no URL provided
-    if (!enabled || !url) {
-      addLog(
-        "debug",
-        enabled
-          ? "No server URL provided, skipping connection."
-          : "Connection disabled via enabled flag."
-      );
-      return;
-    }
-
-    if (connectingRef.current) {
-      addLog("debug", "Connection attempt already in progress.");
-      return;
-    }
-    if (!isMountedRef.current) {
-      addLog("debug", "Connect called after unmount, aborting.");
-      return;
-    }
-
-    connectingRef.current = true;
-    connectEpochRef.current += 1;
-    connectAttemptRef.current += 1;
-    if (authorizationServerUrlRef.current !== url) {
-      authorizationServerUrlRef.current = url;
-      authorizationRef.current = undefined;
-      setAuthorization(undefined);
-    }
-    setError(undefined);
-    setAuthUrl(undefined);
-    successfulTransportRef.current = null;
-    setState("discovering");
-    setTools([]);
-    setResources([]);
-    setResourceTemplates([]);
-    setPrompts([]);
-    setSkills([]);
-    setServerInfo(undefined);
-    setCapabilities(undefined);
-    setProtocolEra(undefined);
-    setProtocolVersion(undefined);
-    setInstructions(undefined);
-    setExtensions({});
-    addLog(
-      "info",
-      `Connecting attempt #${connectAttemptRef.current} to ${url}...`
-    );
-
-    // NOTE: We intentionally do NOT clear OAuth storage before connecting.
-    // The clearStorage() function clears tokens and client_info which should
-    // persist across connections. Clearing them would force re-authentication
-    // even when valid tokens exist from a previous OAuth flow.
-    //
-    // Stale state/verifier items are cleaned up:
-    // - By the callback handler after successful token exchange
-    // - By the unmount cleanup when OAuth flow is interrupted
-    // - By the state expiry check in the callback handler
-
-    if (!authProviderRef.current) {
-      const { provider, oauthProxyUrl } = createBrowserOAuthProvider({
-        effectiveOAuthUrl,
-        storageKeyPrefix,
-        oauthClientConfig,
-        callbackUrl,
-        preventAutoAuth,
-        useRedirectFlow,
-        gatewayUrl,
-        oauthProxyUrl: oauthProxyUrlOption,
-        onPopupWindow,
-        proxyOAuthRequests: true,
-        staticClientInfo,
-        clientMetadataUrl: oauthClientMetadataUrl,
-        scope: oauthScope,
-      });
-      authProviderRef.current = provider;
-      if (oauthProxyUrl) {
-        addLog("debug", `OAuth BFF enabled: ${oauthProxyUrl}`);
-      }
-      addLog(
-        "debug",
-        `BrowserOAuthClientProvider initialized with URL: ${effectiveOAuthUrl}, proxy: ${oauthProxyUrl ? "enabled" : "disabled"}, gateway: ${gatewayUrl ? "enabled" : "disabled"}`
-      );
-    }
-    if (!clientRef.current) {
-      clientRef.current = new BrowserMCPClient();
-      addLog("debug", "BrowserMCPClient initialized in connect.");
-    } else {
-      addLog("debug", "BrowserMCPClient already exists, reusing.");
-    }
-
-    const tryConnectWithTransport = async (
-      transportTypeParam: TransportType
-    ): Promise<"success" | "fallback" | "auth_redirect" | "failed"> => {
-      // Check if component unmounted
-      if (!isMountedRef.current) {
-        addLog("debug", "Connection attempt aborted - component unmounted");
-        return "failed";
+  const runLifecycle = useCallback(
+    async (lifecycle: Lifecycle) => {
+      // Don't connect if not enabled or no URL provided
+      if (!enabled || !url) {
+        addLog(
+          "debug",
+          enabled
+            ? "No server URL provided, skipping connection."
+            : "Connection disabled via enabled flag."
+        );
+        return;
       }
 
-      addLog(
-        "info",
-        `Attempting connection with transport: ${transportTypeParam}`
-      );
-      addLog(
-        "debug",
-        `Client ref status at start of tryConnectWithTransport: ${clientRef.current ? "initialized" : "NULL"}`
-      );
+      if (!isCurrentLifecycle(lifecycleRef, lifecycle)) {
+        return;
+      }
 
-      try {
-        const serverName = USE_MCP_SERVER_NAME;
+      if (authorizationServerUrlRef.current !== url) {
+        authorizationServerUrlRef.current = url;
+        authorizationRef.current = undefined;
+        setAuthorization(undefined);
+      }
+      setError(undefined);
+      setAuthUrl(undefined);
+      successfulTransportRef.current = null;
+      setState("discovering");
+      setTools([]);
+      setResources([]);
+      setResourceTemplates([]);
+      setPrompts([]);
+      setSkills([]);
+      setServerInfo(undefined);
+      setCapabilities(undefined);
+      setProtocolEra(undefined);
+      setProtocolVersion(undefined);
+      setInstructions(undefined);
+      setExtensions({});
+      addLog("info", `Connecting lifecycle #${lifecycle.id} to ${url}...`);
 
-        // Build server config
-        const serverConfig: any = {
-          url: url, // Use original URL, not transformed proxy URL
-          timeout,
-          clientInfo: mergedClientInfo,
-          // Pass a fetch that scopes OAuth-proxy routing to this server's
-          // transport/auth calls. getProxyFetch wraps `customFetch` (e.g. the
-          // OAuth retry fetch for scope step-up), bypasses the browser cache
-          // for OAuth metadata, and optionally routes OAuth through the BFF.
-          // It never mutates the global fetch.
-          ...(() => {
-            const scopedFetch =
-              authProviderRef.current?.getProxyFetch?.(customFetch) ??
-              customFetch;
-            return scopedFetch ? { fetch: scopedFetch } : {};
-          })(),
-          // Pass clientOptions for custom capabilities (e.g., MCP Apps extension)
-          ...(effectiveClientOptions && {
-            clientOptions: effectiveClientOptions,
-          }),
-          // Protocol era negotiation mode ("legacy" | "auto" | { pin }); the
-          // connector defaults to automatic v1/v2 negotiation.
-          ...(protocolNegotiation !== undefined && { protocolNegotiation }),
-          detectMixedAuth,
-          // Pass user-configurable reconnection options, or when autoReconnect
-          // is disabled, disable SDK transport reconnection to prevent
-          // unwanted GET polling requests
-          ...(reconnectionOptions
-            ? { reconnectionOptions }
-            : autoReconnect === false
-              ? { reconnectionOptions: { maxRetries: 0 } }
-              : {}),
-        };
+      // NOTE: We intentionally do NOT clear OAuth storage before connecting.
+      // The clearStorage() function clears tokens and client_info which should
+      // persist across connections. Clearing them would force re-authentication
+      // even when valid tokens exist from a previous OAuth flow.
+      //
+      // Stale state/verifier items are cleaned up:
+      // - By the callback handler after successful token exchange
+      // - By the unmount cleanup when OAuth flow is interrupted
+      // - By the state expiry check in the callback handler
 
-        // Add gateway URL if using proxy
-        if (gatewayUrl) {
-          serverConfig.gatewayUrl = gatewayUrl;
-          addLog(
-            "debug",
-            `Using proxy gateway: ${gatewayUrl} for target: ${url}`
-          );
-        }
+      const client = lifecycle.client;
+      const authProvider = lifecycle.authProvider;
 
-        // Add custom headers if provided (includes proxy headers)
-        if (allHeaders && Object.keys(allHeaders).length > 0) {
-          serverConfig.headers = allHeaders;
-        }
-
-        // Client should be initialized by the parent connect() function
-        // If it's not AND component is still mounted, this is a programming error
-        if (!clientRef.current) {
-          if (!isMountedRef.current) {
-            addLog(
-              "debug",
-              "Connection aborted - component unmounted, client cleaned up"
-            );
-            return "failed";
-          }
-          const initError = new Error(
-            "Client not initialized - this is a bug in the connection flow"
-          );
-          addLog(
-            "error",
-            "Client ref is null in tryConnectWithTransport but component is still mounted"
-          );
-          throw initError;
-        }
-
-        // Add server to client with OAuth provider.
-        // Pass stable proxies (when a callback is present) so capability
-        // advertisement happens on initial connect, while dispatch always
-        // reaches the latest React handler via refs — even after reconnects
-        // that reuse a connect() closure created with a different identity.
-        clientRef.current.addServer(serverName, {
-          ...serverConfig,
-          authProvider: authProviderRef.current,
-          onSampling: hasSamplingCallbackRef.current
-            ? stableOnSampling
-            : undefined,
-          onElicitation: hasElicitationCallbackRef.current
-            ? stableOnElicitation
-            : undefined,
-          onNotification: (
-            notification: Parameters<typeof stableOnNotification>[0]
-          ) => {
-            addLog(
-              "debug",
-              "Notification received:",
-              notification.method,
-              notification
-            );
-            stableOnNotification(notification);
-
-            if (notification.method === "notifications/tools/list_changed") {
-              addLog("info", "Tools list changed, auto-refreshing...");
-              connectionOperations
-                .refreshTools()
-                .catch((err) =>
-                  addLog("warn", "Auto-refresh tools failed:", err)
-                );
-            } else if (
-              notification.method === "notifications/resources/list_changed"
-            ) {
-              addLog("info", "Resources list changed, auto-refreshing...");
-              const clientInfoExtensions = (
-                mergedClientInfo as {
-                  capabilities?: { extensions?: Record<string, unknown> };
-                }
-              ).capabilities?.extensions;
-              const optionExtensions = (
-                effectiveClientOptions?.capabilities as
-                  | { extensions?: Record<string, unknown> }
-                  | undefined
-              )?.extensions;
-              const supportsSkills =
-                optionExtensions?.[SKILLS_EXTENSION_ID] !== undefined ||
-                clientInfoExtensions?.[SKILLS_EXTENSION_ID] !== undefined;
-              Promise.all([
-                connectionOperations.refreshResources(),
-                ...(supportsSkills
-                  ? [connectionOperations.refreshSkills()]
-                  : []),
-              ]).catch((err) =>
-                addLog("warn", "Auto-refresh resources failed:", err)
-              );
-            } else if (
-              notification.method === "notifications/prompts/list_changed"
-            ) {
-              addLog("info", "Prompts list changed, auto-refreshing...");
-              connectionOperations
-                .refreshPrompts()
-                .catch((err) =>
-                  addLog("warn", "Auto-refresh prompts failed:", err)
-                );
-            }
-          },
-          wrapTransport: wrapTransport
-            ? (transport: Transport) => {
-                addLog(
-                  "debug",
-                  "Applying transport wrapper for server:",
-                  serverName,
-                  "url:",
-                  url
-                );
-                return wrapTransport(transport, serverId ?? url);
-              }
-            : undefined,
-        });
-
-        // MCPClient owns protocol negotiation and any legacy initialization.
-        // Modern connections remain stateless and are not initialized twice.
-        const connection = await clientRef.current.connect(serverName);
-        connectionRef.current = connection;
-
-        if (!isMountedRef.current) {
-          addLog(
-            "debug",
-            "Connection aborted after connection creation - component unmounted"
-          );
+      const tryConnectWithTransport = async (
+        transportTypeParam: TransportType
+      ): Promise<"success" | "fallback" | "auth_redirect" | "failed"> => {
+        if (!isCurrentLifecycle(lifecycleRef, lifecycle)) {
           return "failed";
         }
 
-        addLog("info", "✅ Successfully connected to MCP server");
-        addLog("info", "Server info:", connection.info.server);
-        addLog("info", "Server capabilities:", connection.info.capabilities);
+        addLog(
+          "info",
+          `Attempting connection with transport: ${transportTypeParam}`
+        );
+        addLog(
+          "debug",
+          `Client status at start of tryConnectWithTransport: initialized`
+        );
 
-        // Only set up monitoring if autoReconnect is enabled and health checks are not disabled
-        if (
-          autoReconnectConfig.enabled &&
-          autoReconnectConfig.healthCheckInterval !== false
-        ) {
-          const cleanup = startConnectionHealthMonitoring({
-            gatewayUrl,
-            url,
-            allHeaders,
-            getAuthHeaders: async (): Promise<Record<string, string>> => {
-              try {
-                const tokens = await authProviderRef.current?.tokens?.();
-                if (tokens?.access_token) {
-                  const tokenType = tokens.token_type || "bearer";
-                  return {
-                    Authorization: `${tokenType.charAt(0).toUpperCase() + tokenType.slice(1)} ${tokens.access_token}`,
-                  };
-                }
-              } catch {
-                // Intentionally empty - fall through to return {}
-              }
-              return {};
-            },
-            isMountedRef,
-            stateRef,
-            autoReconnectRef,
-            setState,
-            addLog,
-            connect,
-            defaultReconnectDelay: autoReconnectConfig.initialDelay,
-            healthCheckIntervalMs: autoReconnectConfig.healthCheckInterval,
-            healthCheckTimeoutMs: autoReconnectConfig.healthCheckTimeout,
-          });
+        try {
+          const serverName = USE_MCP_SERVER_NAME;
 
-          // Store cleanup function for later
-          (connection as any)._healthCheckCleanup = cleanup;
-        }
+          // Build server config
+          const serverConfig: any = {
+            url: url, // Use original URL, not transformed proxy URL
+            timeout,
+            clientInfo: mergedClientInfo,
+            // Pass a fetch that scopes OAuth-proxy routing to this server's
+            // transport/auth calls. getProxyFetch wraps `customFetch` (e.g. the
+            // OAuth retry fetch for scope step-up), bypasses the browser cache
+            // for OAuth metadata, and optionally routes OAuth through the BFF.
+            // It never mutates the global fetch.
+            ...(() => {
+              const scopedFetch =
+                authProvider.getProxyFetch?.(customFetch) ?? customFetch;
+              return scopedFetch ? { fetch: scopedFetch } : {};
+            })(),
+            // Pass clientOptions for custom capabilities (e.g., MCP Apps extension)
+            ...(effectiveClientOptions && {
+              clientOptions: effectiveClientOptions,
+            }),
+            // Protocol era negotiation mode ("legacy" | "auto" | { pin }); the
+            // connector defaults to automatic v1/v2 negotiation.
+            ...(protocolNegotiation !== undefined && { protocolNegotiation }),
+            detectMixedAuth,
+            // Pass user-configurable reconnection options, or when autoReconnect
+            // is disabled, disable SDK transport reconnection to prevent
+            // unwanted GET polling requests
+            ...(reconnectionOptions
+              ? { reconnectionOptions }
+              : autoReconnect === false
+                ? { reconnectionOptions: { maxRetries: 0 } }
+                : {}),
+          };
 
-        // Track successful connection
-        Tel.getInstance()
-          .trackUseMcpConnection({
-            url,
-            transportType: transportTypeParam,
-            success: true,
-            hasOAuth: !!authProviderRef.current,
-            hasSampling: hasSamplingCallbackRef.current,
-            hasElicitation: hasElicitationCallbackRef.current,
-          })
-          .catch(() => {});
-
-        // Get tools, resources, and prompts through the protocol-neutral connection.
-        setTools(connection.tools || []);
-
-        const {
-          server: serverInfo,
-          capabilities,
-          protocolEra,
-          protocolVersion,
-          instructions,
-          extensions,
-          authorization: connectionAuthorization,
-        } = connection.info;
-
-        if (connectionAuthorization) {
-          setAuthorization(connectionAuthorization);
-          authorizationRef.current = connectionAuthorization;
-        }
-        setProtocolEra(protocolEra);
-        setProtocolVersion(protocolVersion);
-        setInstructions(instructions);
-        setExtensions(extensions);
-
-        if (serverInfo) {
-          addLog("debug", "Server info:", serverInfo);
-          setServerInfo(serverInfo);
-          iconLoadingPromiseRef.current = loadServerIcon({
-            serverInfo,
-            url,
-            isMounted: () => isMountedRef.current,
-            setServerInfo,
-            addLog,
-          });
-        }
-        if (capabilities) {
-          addLog("debug", "Server capabilities:", capabilities);
-          setCapabilities(capabilities);
-        }
-
-        // Tools and normalized connection metadata are sufficient for a usable
-        // connection. Auxiliary inventories must populate progressively rather
-        // than extending the ready-state critical path.
-        successfulTransportRef.current = transportTypeParam;
-        setState("ready");
-        // Optional OAuth metadata is not part of anonymous MCP readiness. Give
-        // React a chance to paint the ready state before starting its network
-        // fallbacks, which may legitimately return 404 for public servers.
-        const discoverAuthorizationAfterReady = () => {
-          if (!isMountedRef.current || connectionRef.current !== connection) {
-            return;
+          // Add gateway URL if using proxy
+          if (gatewayUrl) {
+            serverConfig.gatewayUrl = gatewayUrl;
+            addLog(
+              "debug",
+              `Using proxy gateway: ${gatewayUrl} for target: ${url}`
+            );
           }
-          const authorizationDiscovery = connection.discoverAuthorization?.();
-          if (authorizationDiscovery) {
-            void authorizationDiscovery.then((discovered) => {
-              if (
-                !discovered ||
-                !isMountedRef.current ||
-                connectionRef.current !== connection
+
+          // Add custom headers if provided (includes proxy headers)
+          if (allHeaders && Object.keys(allHeaders).length > 0) {
+            serverConfig.headers = allHeaders;
+          }
+
+          if (!isCurrentLifecycle(lifecycleRef, lifecycle)) return "failed";
+
+          // Add server to client with OAuth provider.
+          // Pass stable proxies (when a callback is present) so capability
+          // advertisement happens on initial connect, while dispatch always
+          // reaches the latest React handler via refs — even after reconnects
+          // that reuse a connect() closure created with a different identity.
+          client.addServer(serverName, {
+            ...serverConfig,
+            authProvider,
+            onSampling: hasSamplingCallbackRef.current
+              ? async (params) => {
+                  if (!isCurrentLifecycle(lifecycleRef, lifecycle)) {
+                    throw new Error("Connection lifecycle is no longer active");
+                  }
+                  return stableOnSampling(params);
+                }
+              : undefined,
+            onElicitation: hasElicitationCallbackRef.current
+              ? async (params) => {
+                  if (!isCurrentLifecycle(lifecycleRef, lifecycle)) {
+                    throw new Error("Connection lifecycle is no longer active");
+                  }
+                  return stableOnElicitation(params);
+                }
+              : undefined,
+            onNotification: (
+              notification: Parameters<typeof stableOnNotification>[0]
+            ) => {
+              if (!isCurrentLifecycle(lifecycleRef, lifecycle)) return;
+              addLog(
+                "debug",
+                "Notification received:",
+                notification.method,
+                notification
+              );
+              stableOnNotification(notification);
+
+              if (notification.method === "notifications/tools/list_changed") {
+                addLog("info", "Tools list changed, auto-refreshing...");
+                connectionOperations.refreshTools().catch((err) => {
+                  if (isCurrentLifecycle(lifecycleRef, lifecycle)) {
+                    addLog("warn", "Auto-refresh tools failed:", err);
+                  }
+                });
+              } else if (
+                notification.method === "notifications/resources/list_changed"
               ) {
-                return;
+                addLog("info", "Resources list changed, auto-refreshing...");
+                const clientInfoExtensions = (
+                  mergedClientInfo as {
+                    capabilities?: { extensions?: Record<string, unknown> };
+                  }
+                ).capabilities?.extensions;
+                const optionExtensions = (
+                  effectiveClientOptions?.capabilities as
+                    | { extensions?: Record<string, unknown> }
+                    | undefined
+                )?.extensions;
+                const supportsSkills =
+                  optionExtensions?.[SKILLS_EXTENSION_ID] !== undefined ||
+                  clientInfoExtensions?.[SKILLS_EXTENSION_ID] !== undefined;
+                Promise.all([
+                  connectionOperations.refreshResources(),
+                  ...(supportsSkills
+                    ? [connectionOperations.refreshSkills()]
+                    : []),
+                ]).catch((err) => {
+                  if (isCurrentLifecycle(lifecycleRef, lifecycle)) {
+                    addLog("warn", "Auto-refresh resources failed:", err);
+                  }
+                });
+              } else if (
+                notification.method === "notifications/prompts/list_changed"
+              ) {
+                addLog("info", "Prompts list changed, auto-refreshing...");
+                connectionOperations.refreshPrompts().catch((err) => {
+                  if (isCurrentLifecycle(lifecycleRef, lifecycle)) {
+                    addLog("warn", "Auto-refresh prompts failed:", err);
+                  }
+                });
               }
-              authorizationRef.current = discovered;
-              setAuthorization(discovered);
+            },
+            wrapTransport: wrapTransport
+              ? (transport: Transport) => {
+                  addLog(
+                    "debug",
+                    "Applying transport wrapper for server:",
+                    serverName,
+                    "url:",
+                    url
+                  );
+                  return wrapTransport(transport, serverId ?? url);
+                }
+              : undefined,
+          });
+
+          // MCPClient owns protocol negotiation and any legacy initialization.
+          // Modern connections remain stateless and are not initialized twice.
+          if (!isCurrentLifecycle(lifecycleRef, lifecycle)) return "failed";
+          const connection = await client.connect(serverName);
+          const staleClose = attachLifecycleConnection(lifecycle, connection);
+          if (!isCurrentLifecycle(lifecycleRef, lifecycle)) {
+            if (staleClose) void staleClose.catch(() => {});
+            return "failed";
+          }
+          connectionRef.current = connection;
+
+          addLog("info", "✅ Successfully connected to MCP server");
+          addLog("info", "Server info:", connection.info.server);
+          addLog("info", "Server capabilities:", connection.info.capabilities);
+
+          // Only set up monitoring if autoReconnect is enabled and health checks are not disabled
+          if (
+            autoReconnectConfig.enabled &&
+            autoReconnectConfig.healthCheckInterval !== false
+          ) {
+            const lifecycleMountedRef = {
+              get current() {
+                return isCurrentLifecycle(lifecycleRef, lifecycle);
+              },
+            };
+            const cleanup = startConnectionHealthMonitoring({
+              gatewayUrl,
+              url,
+              allHeaders,
+              getAuthHeaders: async (): Promise<Record<string, string>> => {
+                try {
+                  const tokens = await authProvider.tokens?.();
+                  if (!isCurrentLifecycle(lifecycleRef, lifecycle)) return {};
+                  if (tokens?.access_token) {
+                    const tokenType = tokens.token_type || "bearer";
+                    return {
+                      Authorization: `${tokenType.charAt(0).toUpperCase() + tokenType.slice(1)} ${tokens.access_token}`,
+                    };
+                  }
+                } catch {
+                  // Intentionally empty - fall through to return {}
+                }
+                return {};
+              },
+              isMountedRef: lifecycleMountedRef,
+              stateRef,
+              autoReconnectRef,
+              setState: (nextState) => {
+                if (isCurrentLifecycle(lifecycleRef, lifecycle)) {
+                  setState(nextState);
+                }
+              },
+              addLog: (level, message, ...args) => {
+                if (isCurrentLifecycle(lifecycleRef, lifecycle)) {
+                  addLog(level, message, ...args);
+                }
+              },
+              connect: () => {
+                if (isCurrentLifecycle(lifecycleRef, lifecycle)) {
+                  requestReconnect("health-check");
+                }
+              },
+              defaultReconnectDelay: autoReconnectConfig.initialDelay,
+              healthCheckIntervalMs: autoReconnectConfig.healthCheckInterval,
+              healthCheckTimeoutMs: autoReconnectConfig.healthCheckTimeout,
+            });
+
+            lifecycle.healthCleanup = cleanup;
+          }
+
+          // Track successful connection
+          Tel.getInstance()
+            .trackUseMcpConnection({
+              url,
+              transportType: transportTypeParam,
+              success: true,
+              hasOAuth: !!authProvider,
+              hasSampling: hasSamplingCallbackRef.current,
+              hasElicitation: hasElicitationCallbackRef.current,
+            })
+            .catch(() => {});
+
+          // Get tools, resources, and prompts through the protocol-neutral connection.
+          setTools(connection.tools || []);
+
+          const {
+            server: serverInfo,
+            capabilities,
+            protocolEra,
+            protocolVersion,
+            instructions,
+            extensions,
+            authorization: connectionAuthorization,
+          } = connection.info;
+
+          if (connectionAuthorization) {
+            setAuthorization(connectionAuthorization);
+            authorizationRef.current = connectionAuthorization;
+          }
+          setProtocolEra(protocolEra);
+          setProtocolVersion(protocolVersion);
+          setInstructions(instructions);
+          setExtensions(extensions);
+
+          if (serverInfo) {
+            addLog("debug", "Server info:", serverInfo);
+            setServerInfo(serverInfo);
+            iconLoadingPromiseRef.current = loadServerIcon({
+              serverInfo,
+              url,
+              isMounted: () => isCurrentLifecycle(lifecycleRef, lifecycle),
+              setServerInfo,
+              addLog: (level, message, ...args) => {
+                if (isCurrentLifecycle(lifecycleRef, lifecycle)) {
+                  addLog(level, message, ...args);
+                }
+              },
             });
           }
-        };
-        if (typeof globalThis.requestAnimationFrame === "function") {
-          globalThis.requestAnimationFrame(() => {
-            setTimeout(discoverAuthorizationAfterReady, 0);
-          });
-        } else {
-          setTimeout(discoverAuthorizationAfterReady, 0);
-        }
+          if (capabilities) {
+            addLog("debug", "Server capabilities:", capabilities);
+            setCapabilities(capabilities);
+          }
 
-        // Capability advertisements in the wild are not always granular: a
-        // server may support resources/list while returning Method not found
-        // for resources/templates/list. Inventory failures must not tear down
-        // an otherwise healthy MCP connection.
-        const [resourcesResult, promptsResult, templatesResult] =
-          await Promise.all([
-            connection.listAllResources().catch((error) => {
-              addLog("warn", "Failed to load initial resources:", error);
-              return { resources: [] };
-            }),
-            connection.listPrompts().catch((error) => {
-              addLog("warn", "Failed to load initial prompts:", error);
-              return { prompts: [] };
-            }),
-            connection.supports("resources")
-              ? connection.listResourceTemplates().catch((error) => {
-                  addLog(
-                    "warn",
-                    "Failed to load initial resource templates:",
-                    error
-                  );
-                  return { resourceTemplates: [] };
-                })
-              : Promise.resolve({ resourceTemplates: [] }),
-          ]);
-        if (!isMountedRef.current) {
-          addLog(
-            "debug",
-            "Connection aborted after discovery - component unmounted"
-          );
-          return "failed";
-        }
-        setResources(resourcesResult.resources || []);
-        setPrompts(promptsResult.prompts || []);
-        setResourceTemplates(templatesResult.resourceTemplates || []);
-
-        // Skills are another auxiliary inventory and populate progressively.
-        if (isMountedRef.current) {
-          if (extensions["io.modelcontextprotocol/skills"] !== undefined) {
-            try {
-              const result = await connection.listAllSkills();
-              if (isMountedRef.current) setSkills(result.skills);
-            } catch (error) {
-              addLog("warn", "Failed to load initial skills:", error);
-              if (isMountedRef.current) setSkills([]);
+          // Tools and normalized connection metadata are sufficient for a usable
+          // connection. Auxiliary inventories must populate progressively rather
+          // than extending the ready-state critical path.
+          successfulTransportRef.current = transportTypeParam;
+          lifecycle.phase = "ready";
+          setState("ready");
+          // Optional OAuth metadata is not part of anonymous MCP readiness. Give
+          // React a chance to paint the ready state before starting its network
+          // fallbacks, which may legitimately return 404 for public servers.
+          const discoverAuthorizationAfterReady = () => {
+            if (
+              !isCurrentLifecycle(lifecycleRef, lifecycle) ||
+              connectionRef.current !== connection
+            ) {
+              return;
             }
+            const authorizationDiscovery = connection.discoverAuthorization?.();
+            if (authorizationDiscovery) {
+              void authorizationDiscovery.then((discovered) => {
+                if (
+                  !discovered ||
+                  !isCurrentLifecycle(lifecycleRef, lifecycle) ||
+                  connectionRef.current !== connection
+                ) {
+                  return;
+                }
+                authorizationRef.current = discovered;
+                setAuthorization(discovered);
+              });
+            }
+          };
+          if (typeof globalThis.requestAnimationFrame === "function") {
+            globalThis.requestAnimationFrame(() => {
+              setTimeout(discoverAuthorizationAfterReady, 0);
+            });
           } else {
-            setSkills([]);
+            setTimeout(discoverAuthorizationAfterReady, 0);
           }
-        }
 
-        // Get OAuth tokens if authentication was used
-        if (authProviderRef.current) {
-          let tokens: Awaited<
-            ReturnType<NonNullable<UseMcpAuthProvider["tokens"]>>
-          >;
-          try {
-            tokens = await authProviderRef.current.tokens?.();
-          } catch (error) {
-            // The MCP connection is already usable. Token projection is
-            // supplemental state and must not tear down a ready connection.
-            addLog("warn", "Failed to read OAuth tokens:", error);
-            tokens = undefined;
-          }
-          if (!isMountedRef.current) {
-            addLog(
-              "debug",
-              "Connection aborted after token fetch for auth tokens - component unmounted"
-            );
+          // Capability advertisements in the wild are not always granular: a
+          // server may support resources/list while returning Method not found
+          // for resources/templates/list. Inventory failures must not tear down
+          // an otherwise healthy MCP connection.
+          const [resourcesResult, promptsResult, templatesResult] =
+            await Promise.all([
+              connection.listAllResources().catch((error) => {
+                if (isCurrentLifecycle(lifecycleRef, lifecycle)) {
+                  addLog("warn", "Failed to load initial resources:", error);
+                }
+                return { resources: [] };
+              }),
+              connection.listPrompts().catch((error) => {
+                if (isCurrentLifecycle(lifecycleRef, lifecycle)) {
+                  addLog("warn", "Failed to load initial prompts:", error);
+                }
+                return { prompts: [] };
+              }),
+              connection.supports("resources")
+                ? connection.listResourceTemplates().catch((error) => {
+                    if (isCurrentLifecycle(lifecycleRef, lifecycle)) {
+                      addLog(
+                        "warn",
+                        "Failed to load initial resource templates:",
+                        error
+                      );
+                    }
+                    return { resourceTemplates: [] };
+                  })
+                : Promise.resolve({ resourceTemplates: [] }),
+            ]);
+          if (!isCurrentLifecycle(lifecycleRef, lifecycle)) {
             return "failed";
           }
-          if (tokens?.access_token) {
-            if (authorizationRef.current?.mode === "mixed") {
-              const authenticatedAuthorization = {
-                ...authorizationRef.current,
-                authenticated: true,
-              };
-              setAuthorization(authenticatedAuthorization);
-              authorizationRef.current = authenticatedAuthorization;
-            }
-            const expiresAt = getOAuthTokenExpiry(tokens);
+          setResources(resourcesResult.resources || []);
+          setPrompts(promptsResult.prompts || []);
+          setResourceTemplates(templatesResult.resourceTemplates || []);
 
-            // Best-effort: resolve the OAuth token endpoint + client credentials
-            // so consumers can persist them for server-side proactive refresh.
-            // Never blocks auth.
-            let tokenEndpoint: string | null = null;
-            let resource: string | null = null;
-            let clientCreds: {
-              client_id: string;
-              client_secret?: string;
-            } | null = null;
-            try {
-              tokenEndpoint =
-                (await authProviderRef.current.getTokenEndpoint?.()) ?? null;
-            } catch {
-              tokenEndpoint = null;
+          // Skills are another auxiliary inventory and populate progressively.
+          if (isCurrentLifecycle(lifecycleRef, lifecycle)) {
+            if (extensions["io.modelcontextprotocol/skills"] !== undefined) {
+              try {
+                const result = await connection.listAllSkills();
+                if (isCurrentLifecycle(lifecycleRef, lifecycle)) {
+                  setSkills(result.skills);
+                }
+              } catch (error) {
+                if (isCurrentLifecycle(lifecycleRef, lifecycle)) {
+                  addLog("warn", "Failed to load initial skills:", error);
+                  setSkills([]);
+                }
+              }
+            } else {
+              setSkills([]);
             }
-            try {
-              resource =
-                (await authProviderRef.current.getResource?.()) ?? null;
-            } catch {
-              resource = null;
-            }
-            try {
-              clientCreds =
-                (await authProviderRef.current.getClientCredentials?.()) ??
-                null;
-            } catch {
-              clientCreds = null;
-            }
+          }
 
-            if (!isMountedRef.current) {
-              addLog("debug", "Skipping state update - component unmounted");
+          // Get OAuth tokens if authentication was used
+          if (authProvider) {
+            let tokens: Awaited<
+              ReturnType<NonNullable<UseMcpAuthProvider["tokens"]>>
+            >;
+            try {
+              tokens = await authProvider.tokens?.();
+            } catch (error) {
+              // The MCP connection is already usable. Token projection is
+              // supplemental state and must not tear down a ready connection.
+              if (isCurrentLifecycle(lifecycleRef, lifecycle)) {
+                addLog("warn", "Failed to read OAuth tokens:", error);
+              }
+              tokens = undefined;
+            }
+            if (!isCurrentLifecycle(lifecycleRef, lifecycle)) {
               return "failed";
             }
-            setAuthTokens({
-              access_token: tokens.access_token,
-              token_type: tokens.token_type || "Bearer",
-              expires_at: expiresAt,
-              refresh_token: tokens.refresh_token,
-              scope: tokens.scope,
-              ...(tokenEndpoint ? { token_endpoint: tokenEndpoint } : {}),
-              ...(resource ? { resource } : {}),
-              ...(clientCreds?.client_id
-                ? { client_id: clientCreds.client_id }
-                : {}),
-              ...(clientCreds?.client_secret
-                ? { client_secret: clientCreds.client_secret }
-                : {}),
-            });
+            if (tokens?.access_token) {
+              if (authorizationRef.current?.mode === "mixed") {
+                const authenticatedAuthorization = {
+                  ...authorizationRef.current,
+                  authenticated: true,
+                };
+                setAuthorization(authenticatedAuthorization);
+                authorizationRef.current = authenticatedAuthorization;
+              }
+              const expiresAt = getOAuthTokenExpiry(tokens);
+
+              // Best-effort: resolve the OAuth token endpoint + client credentials
+              // so consumers can persist them for server-side proactive refresh.
+              // Never blocks auth.
+              let tokenEndpoint: string | null = null;
+              let resource: string | null = null;
+              let clientCreds: {
+                client_id: string;
+                client_secret?: string;
+              } | null = null;
+              try {
+                tokenEndpoint =
+                  (await authProvider.getTokenEndpoint?.()) ?? null;
+              } catch {
+                tokenEndpoint = null;
+              }
+              if (!isCurrentLifecycle(lifecycleRef, lifecycle)) return "failed";
+              try {
+                resource = (await authProvider.getResource?.()) ?? null;
+              } catch {
+                resource = null;
+              }
+              if (!isCurrentLifecycle(lifecycleRef, lifecycle)) return "failed";
+              try {
+                clientCreds =
+                  (await authProvider.getClientCredentials?.()) ?? null;
+              } catch {
+                clientCreds = null;
+              }
+
+              if (!isCurrentLifecycle(lifecycleRef, lifecycle)) {
+                return "failed";
+              }
+              setAuthTokens({
+                access_token: tokens.access_token,
+                token_type: tokens.token_type || "Bearer",
+                expires_at: expiresAt,
+                refresh_token: tokens.refresh_token,
+                scope: tokens.scope,
+                ...(tokenEndpoint ? { token_endpoint: tokenEndpoint } : {}),
+                ...(resource ? { resource } : {}),
+                ...(clientCreds?.client_id
+                  ? { client_id: clientCreds.client_id }
+                  : {}),
+                ...(clientCreds?.client_secret
+                  ? { client_secret: clientCreds.client_secret }
+                  : {}),
+              });
+            }
           }
-        }
 
-        return "success";
-      } catch (err: unknown) {
-        const error = err as Error & { code?: number; message?: string };
-        const errorMessage = error?.message || String(err);
-
-        // A prepared authorization URL means OAuth discovery already succeeded on
-        // an earlier pass. A later failure (token refresh, SSE fallback, or a
-        // metadata probe that fell back to the transport origin) must NOT be
-        // misclassified as "server does not support OAuth" — that drops us to
-        // `failed` and hides the Authenticate button. When we already have a
-        // stored auth URL and an OAuth provider, surface `pending_auth` instead.
-        const preparedAuthUrl =
-          authProviderRef.current?.getLastAttemptedAuthUrl?.();
-        if (preparedAuthUrl && authProviderRef.current && preventAutoAuth) {
-          addLog(
-            "info",
-            "OAuth already discovered (stored auth URL present); awaiting manual authentication."
-          );
-          if (isMountedRef.current) {
-            setState("pending_auth");
-            setAuthUrl(preparedAuthUrl);
+          return "success";
+        } catch (err: unknown) {
+          if (!isCurrentLifecycle(lifecycleRef, lifecycle)) {
+            void closeRetiredLifecycleAfterConnectFailure(lifecycle)?.catch(
+              () => {}
+            );
+            return "failed";
           }
-          connectingRef.current = false;
-          return "auth_redirect";
-        }
+          const error = err as Error & { code?: number; message?: string };
+          const errorMessage = error?.message || String(err);
 
-        // Check if OAuth discovery failed (indicates server doesn't support OAuth)
-        // This happens when a 401 triggers OAuth discovery but the server has no OAuth endpoints
-        const oauthDiscoveryFailed = isOAuthDiscoveryFailure(err);
+          // A prepared authorization URL means OAuth discovery already succeeded on
+          // an earlier pass. A later failure (token refresh, SSE fallback, or a
+          // metadata probe that fell back to the transport origin) must NOT be
+          // misclassified as "server does not support OAuth" — that drops us to
+          // `failed` and hides the Authenticate button. When we already have a
+          // stored auth URL and an OAuth provider, surface `pending_auth` instead.
+          const preparedAuthUrl = authProvider.getLastAttemptedAuthUrl?.();
+          if (preparedAuthUrl && preventAutoAuth) {
+            addLog(
+              "info",
+              "OAuth already discovered (stored auth URL present); awaiting manual authentication."
+            );
+            if (isMountedRef.current) {
+              lifecycle.phase = "waiting_for_auth";
+              setState("pending_auth");
+              setAuthUrl(preparedAuthUrl);
+            }
+            return "auth_redirect";
+          }
 
-        // Check if this is a 401 error
-        const is401Error = isUnauthorized(err);
+          // Check if OAuth discovery failed (indicates server doesn't support OAuth)
+          // This happens when a 401 triggers OAuth discovery but the server has no OAuth endpoints
+          const oauthDiscoveryFailed = isOAuthDiscoveryFailure(err);
 
-        // If OAuth discovery failed with custom headers provided, this was likely a 401 with wrong credentials
-        // The error message might say "404" (from OAuth endpoint attempts) but the root cause was 401
-        if (
-          oauthDiscoveryFailed &&
-          headers &&
-          Object.keys(headers).length > 0
-        ) {
-          failConnection(
-            "Authentication failed (HTTP 401). Server does not support OAuth. " +
-              "Check your Authorization header value is correct."
-          );
-          return "failed";
-        }
+          // Check if this is a 401 error
+          const is401Error = isUnauthorized(err);
 
-        // If OAuth discovery failed without custom headers, the server likely requires
-        // authentication but doesn't support OAuth discovery
-        // This handles cases where the server returns 401 but the error message shows "404"
-        // from the OAuth endpoint attempts
-        if (
-          oauthDiscoveryFailed &&
-          (!headers || Object.keys(headers).length === 0)
-        ) {
-          failConnection(
-            "Authentication required (HTTP 401). Server does not support OAuth. " +
-              "Add an Authorization header in the Custom Headers section " +
-              "(e.g., Authorization: Bearer YOUR_API_KEY)."
-          );
-          return "failed";
-        }
-
-        // Handle 401 errors
-        if (is401Error) {
-          // If OAuth discovery failed, the server doesn't support OAuth
-          // Show a clear message about this
-          if (oauthDiscoveryFailed) {
-            // No OAuth support and no custom headers - suggest adding API key
+          // If OAuth discovery failed with custom headers provided, this was likely a 401 with wrong credentials
+          // The error message might say "404" (from OAuth endpoint attempts) but the root cause was 401
+          if (
+            oauthDiscoveryFailed &&
+            headers &&
+            Object.keys(headers).length > 0
+          ) {
             failConnection(
+              lifecycle,
+              "Authentication failed (HTTP 401). Server does not support OAuth. " +
+                "Check your Authorization header value is correct."
+            );
+            return "failed";
+          }
+
+          // If OAuth discovery failed without custom headers, the server likely requires
+          // authentication but doesn't support OAuth discovery
+          // This handles cases where the server returns 401 but the error message shows "404"
+          // from the OAuth endpoint attempts
+          if (
+            oauthDiscoveryFailed &&
+            (!headers || Object.keys(headers).length === 0)
+          ) {
+            failConnection(
+              lifecycle,
               "Authentication required (HTTP 401). Server does not support OAuth. " +
                 "Add an Authorization header in the Custom Headers section " +
                 "(e.g., Authorization: Bearer YOUR_API_KEY)."
@@ -1356,210 +1369,236 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
             return "failed";
           }
 
-          // OAuth discovery didn't fail, so OAuth might be available
-          // Check if OAuth provider is configured
-          if (authProviderRef.current) {
-            // OAuth is configured
-            addLog(
-              "info",
-              "Authentication required. OAuth provider available."
-            );
+          // Handle 401 errors
+          if (is401Error) {
+            // If OAuth discovery failed, the server doesn't support OAuth
+            // Show a clear message about this
+            if (oauthDiscoveryFailed) {
+              // No OAuth support and no custom headers - suggest adding API key
+              failConnection(
+                lifecycle,
+                "Authentication required (HTTP 401). Server does not support OAuth. " +
+                  "Add an Authorization header in the Custom Headers section " +
+                  "(e.g., Authorization: Bearer YOUR_API_KEY)."
+              );
+              return "failed";
+            }
 
-            // Check if we should trigger auth automatically or wait for user
-            if (preventAutoAuth) {
-              // Don't trigger auth flow automatically - let the user click "Authenticate"
-              // This prevents unnecessary metadata discovery requests that may fail with CORS/404
+            // OAuth discovery didn't fail, so OAuth might be available
+            // Check if OAuth provider is configured
+            if (authProvider) {
+              // OAuth is configured
               addLog(
                 "info",
-                "Waiting for user to initiate authentication flow..."
+                "Authentication required. OAuth provider available."
               );
 
-              if (isMountedRef.current) {
-                setState("pending_auth");
-                // Retrieve the stored auth URL if it was prepared during OAuth discovery
-                const storedAuthUrl =
-                  authProviderRef.current?.getLastAttemptedAuthUrl?.();
-                if (storedAuthUrl) {
-                  setAuthUrl(storedAuthUrl);
-                  addLog(
-                    "info",
-                    "Retrieved stored auth URL for manual authentication"
-                  );
-                }
-              }
-              connectingRef.current = false;
-              return "auth_redirect";
-            } else {
-              // preventAutoAuth is false - trigger auth flow automatically
-              addLog(
-                "info",
-                "Triggering automatic OAuth authentication flow..."
-              );
+              // Check if we should trigger auth automatically or wait for user
+              if (preventAutoAuth) {
+                // Don't trigger auth flow automatically - let the user click "Authenticate"
+                // This prevents unnecessary metadata discovery requests that may fail with CORS/404
+                addLog(
+                  "info",
+                  "Waiting for user to initiate authentication flow..."
+                );
 
-              try {
-                // The SDK owns protected-resource discovery and parses the
-                // original transport 401. Do not issue a duplicate probe.
-                const authResult = await auth(authProviderRef.current, {
-                  serverUrl: url,
-                  fetchFn: authProviderRef.current.getProxyFetch?.(),
-                });
-
-                if (authResult === "REDIRECT") {
-                  // Step 2: Get the authorization response captured during
-                  // redirectToAuthorization, including RFC 9207 `iss` when
-                  // the provider exposes it.
-                  const flowProvider = authProviderRef.current as any;
-                  const authResponse =
-                    await flowProvider.getAuthorizationResponse?.();
-                  const authCode =
-                    authResponse?.code ??
-                    (await flowProvider.getAuthorizationCode?.());
-                  if (typeof authCode !== "string") {
-                    throw new Error(
-                      "Authorization code not captured by headless provider"
+                if (isMountedRef.current) {
+                  lifecycle.phase = "waiting_for_auth";
+                  setState("pending_auth");
+                  // Retrieve the stored auth URL if it was prepared during OAuth discovery
+                  const storedAuthUrl =
+                    authProvider.getLastAttemptedAuthUrl?.();
+                  if (storedAuthUrl) {
+                    setAuthUrl(storedAuthUrl);
+                    addLog(
+                      "info",
+                      "Retrieved stored auth URL for manual authentication"
                     );
                   }
-
-                  // Step 3: Complete the OAuth flow by exchanging code for tokens
-                  await auth(authProviderRef.current, {
-                    serverUrl: url,
-                    authorizationCode: authCode,
-                    ...(authResponse?.iss !== undefined
-                      ? { iss: authResponse.iss }
-                      : {}),
-                    fetchFn: authProviderRef.current.getProxyFetch?.(),
-                  });
                 }
-
-                addLog("info", "OAuth flow completed, reconnecting...");
-                // Reconnect after successful auth
-                return await tryConnectWithTransport(transportTypeParam);
-              } catch (authError) {
-                const authErrorMessage =
-                  authError instanceof Error
-                    ? authError.message
-                    : String(authError);
-                failConnection(
-                  `Automatic OAuth authentication failed: ${authErrorMessage}`,
-                  authError instanceof Error
-                    ? authError
-                    : new Error(String(authError))
+                return "auth_redirect";
+              } else {
+                // preventAutoAuth is false - trigger auth flow automatically
+                addLog(
+                  "info",
+                  "Triggering automatic OAuth authentication flow..."
                 );
-                return "failed";
+
+                try {
+                  // The SDK owns protected-resource discovery and parses the
+                  // original transport 401. Do not issue a duplicate probe.
+                  lifecycle.phase = "authenticating";
+                  const authResult = await auth(authProvider, {
+                    serverUrl: url,
+                    fetchFn: authProvider.getProxyFetch?.(),
+                  });
+                  if (!isCurrentLifecycle(lifecycleRef, lifecycle)) {
+                    return "failed";
+                  }
+
+                  if (authResult === "REDIRECT") {
+                    // Step 2: Get the authorization response captured during
+                    // redirectToAuthorization, including RFC 9207 `iss` when
+                    // the provider exposes it.
+                    const flowProvider = authProvider as any;
+                    const authResponse =
+                      await flowProvider.getAuthorizationResponse?.();
+                    if (!isCurrentLifecycle(lifecycleRef, lifecycle)) {
+                      return "failed";
+                    }
+                    const authCode =
+                      authResponse?.code ??
+                      (await flowProvider.getAuthorizationCode?.());
+                    if (!isCurrentLifecycle(lifecycleRef, lifecycle)) {
+                      return "failed";
+                    }
+                    if (typeof authCode !== "string") {
+                      throw new Error(
+                        "Authorization code not captured by headless provider"
+                      );
+                    }
+
+                    // Step 3: Complete the OAuth flow by exchanging code for tokens
+                    await auth(authProvider, {
+                      serverUrl: url,
+                      authorizationCode: authCode,
+                      ...(authResponse?.iss !== undefined
+                        ? { iss: authResponse.iss }
+                        : {}),
+                      fetchFn: authProvider.getProxyFetch?.(),
+                    });
+                    if (!isCurrentLifecycle(lifecycleRef, lifecycle)) {
+                      return "failed";
+                    }
+                  }
+
+                  addLog("info", "OAuth flow completed, reconnecting...");
+                  requestReconnect("oauth-success");
+                  return "auth_redirect";
+                } catch (authError) {
+                  const authErrorMessage =
+                    authError instanceof Error
+                      ? authError.message
+                      : String(authError);
+                  failConnection(
+                    lifecycle,
+                    `Automatic OAuth authentication failed: ${authErrorMessage}`,
+                    authError instanceof Error
+                      ? authError
+                      : new Error(String(authError))
+                  );
+                  return "failed";
+                }
               }
             }
-          }
 
-          // Check if custom headers were provided (invalid credentials)
-          if (headers && Object.keys(headers).length > 0) {
+            // Check if custom headers were provided (invalid credentials)
+            if (headers && Object.keys(headers).length > 0) {
+              failConnection(
+                lifecycle,
+                "Authentication failed: Server returned 401 Unauthorized. " +
+                  "Check your Authorization header value is correct."
+              );
+              return "failed";
+            }
+
+            // No OAuth and no custom headers - suggest adding them
             failConnection(
-              "Authentication failed: Server returned 401 Unauthorized. " +
-                "Check your Authorization header value is correct."
+              lifecycle,
+              "Authentication required: Server returned 401 Unauthorized. " +
+                "Add an Authorization header in the Custom Headers section " +
+                "(e.g., Authorization: Bearer YOUR_API_KEY)."
             );
             return "failed";
           }
 
-          // No OAuth and no custom headers - suggest adding them
-          failConnection(
-            "Authentication required: Server returned 401 Unauthorized. " +
-              "Add an Authorization header in the Custom Headers section " +
-              "(e.g., Authorization: Bearer YOUR_API_KEY)."
+          // Handle other errors
+          const isRetryingWithProxy = failConnection(
+            lifecycle,
+            errorMessage,
+            error instanceof Error ? error : new Error(String(error))
           );
-          return "failed";
+          // If failConnection triggered automatic proxy fallback, return a special
+          // status so the caller does not treat this as a hard connection failure
+          return isRetryingWithProxy ? "auth_redirect" : "failed";
         }
+      };
 
-        // Handle other errors
-        const isRetryingWithProxy = failConnection(
-          errorMessage,
-          error instanceof Error ? error : new Error(String(error))
+      let finalStatus: "success" | "auth_redirect" | "failed" | "fallback" =
+        "failed";
+
+      addLog("debug", "Connecting via streamable HTTP");
+      finalStatus = await tryConnectWithTransport("http");
+      if (isCurrentLifecycle(lifecycleRef, lifecycle)) {
+        addLog(
+          "debug",
+          `Connection sequence finished with status: ${finalStatus}`
         );
-        // If failConnection triggered automatic proxy fallback, return a special
-        // status so the caller does not treat this as a hard connection failure
-        return isRetryingWithProxy ? "auth_redirect" : "failed";
       }
-    };
+    },
+    [
+      addLog,
+      failConnection,
+      requestReconnect,
+      url,
+      storageKeyPrefix,
+      callbackUrl,
+      oauthClientConfig.name,
+      oauthClientConfig.version,
+      oauthClientConfig.uri,
+      oauthClientConfig.logo_uri,
+      staticClientInfo,
+      oauthClientMetadataUrl,
+      oauthScope,
+      headers,
+      transportType,
+      preventAutoAuth,
+      detectMixedAuth,
+      useRedirectFlow,
+      onPopupWindow,
+      enabled,
+      timeout,
+      mergedClientInfo,
+      effectiveClientOptions,
+      protocolNegotiation,
+      // IMPORTANT: Include proxy-related dependencies so connect() uses updated values after fallback
+      gatewayUrl,
+      oauthProxyUrlOption,
+      allHeaders,
+      effectiveOAuthUrl,
+      // Stable reverse-request proxies (empty-deps useCallbacks). Listed for
+      // correctness; their identities never change, so they do not reconnect.
+      stableOnSampling,
+      stableOnElicitation,
+      stableOnNotification,
+    ]
+  );
 
-    let finalStatus: "success" | "auth_redirect" | "failed" | "fallback" =
-      "failed";
-
-    addLog("debug", "Connecting via streamable HTTP");
-    finalStatus = await tryConnectWithTransport("http");
-
-    // Reset connecting flag for all terminal states and auth_redirect
-    // auth_redirect needs to reset the flag so the auth callback can reconnect
-    if (
-      finalStatus === "success" ||
-      finalStatus === "failed" ||
-      finalStatus === "auth_redirect"
-    ) {
-      connectingRef.current = false;
-    }
-
-    addLog("debug", `Connection sequence finished with status: ${finalStatus}`);
-  }, [
-    addLog,
-    failConnection,
-    disconnect,
-    url,
-    storageKeyPrefix,
-    callbackUrl,
-    oauthClientConfig.name,
-    oauthClientConfig.version,
-    oauthClientConfig.uri,
-    oauthClientConfig.logo_uri,
-    staticClientInfo,
-    oauthClientMetadataUrl,
-    oauthScope,
-    headers,
-    transportType,
-    preventAutoAuth,
-    detectMixedAuth,
-    useRedirectFlow,
-    onPopupWindow,
-    enabled,
-    timeout,
-    mergedClientInfo,
-    effectiveClientOptions,
-    protocolNegotiation,
-    // IMPORTANT: Include proxy-related dependencies so connect() uses updated values after fallback
-    gatewayUrl,
-    oauthProxyUrlOption,
-    allHeaders,
-    effectiveOAuthUrl,
-    // Stable reverse-request proxies (empty-deps useCallbacks). Listed for
-    // correctness; their identities never change, so they do not reconnect.
-    stableOnSampling,
-    stableOnElicitation,
-    stableOnNotification,
-  ]);
-
-  /**
-   * Effect: Update function refs to prevent stale closures
-   * Used by retry and OAuth callback handlers
-   */
   useEffect(() => {
-    connectRef.current = connect;
-    failConnectionRef.current = failConnection;
-  }, [connect, failConnection]);
+    failConnectionRef.current = (message, error) =>
+      failConnection(lifecycleRef.current, message, error);
+  }, [failConnection]);
 
   /**
    * Retry connection after failure
    * Only works if current state is 'failed'
-   * Note: Uses connectRef to avoid circular dependency with connect
    */
   const retry = useCallback(() => {
-    if (stateRef.current === "failed") {
+    const lifecycle = lifecycleRef.current;
+    if (
+      stateRef.current === "failed" &&
+      lifecycle?.phase === "failed" &&
+      !manuallyDisconnectedRef.current
+    ) {
       addLog("info", "Retry requested...");
-      // Use connectRef to avoid circular dependency
-      // connectRef is kept updated via useEffect
-      connectRef.current?.();
+      requestReconnect("manual-retry");
     } else {
       addLog(
         "warn",
         `Retry called but state is not 'failed' (state: ${stateRef.current}). Ignoring.`
       );
     }
-  }, [addLog]);
+  }, [addLog, requestReconnect]);
 
   /**
    * Trigger manual OAuth authentication flow
@@ -1576,6 +1615,7 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
    */
   const authenticate = useCallback(async () => {
     addLog("info", "Manual authentication requested...");
+    const authenticationLifecycle = lifecycleRef.current;
     const currentState = stateRef.current;
     const isOptionalMixedAuthentication =
       currentState === "ready" && authorizationRef.current?.mode === "mixed";
@@ -1597,6 +1637,9 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
           "Auth Provider not available for manual auth"
         );
         assert(url, "Server URL is required for authentication");
+        if (authenticationLifecycle) {
+          authenticationLifecycle.phase = "authenticating";
+        }
 
         if (providedAuthProvider) {
           addLog(
@@ -1610,7 +1653,12 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
             serverUrl: baseUrl,
             fetchFn: authProviderRef.current.getProxyFetch?.(),
           });
-          connectRef.current?.();
+          if (
+            authenticationLifecycle &&
+            isCurrentLifecycle(lifecycleRef, authenticationLifecycle)
+          ) {
+            requestReconnect("oauth-success");
+          }
           return;
         }
 
@@ -1685,11 +1733,21 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
           serverUrl: baseUrl,
           fetchFn: freshAuthProvider.getProxyFetch?.(),
         });
+        if (
+          !authenticationLifecycle ||
+          !isCurrentLifecycle(lifecycleRef, authenticationLifecycle)
+        ) {
+          return;
+        }
 
         if (authResult === "AUTHORIZED") {
           addLog("info", "OAuth flow completed (tokens obtained)");
-          connectingRef.current = false;
-          connectRef.current?.();
+          if (
+            authenticationLifecycle &&
+            isCurrentLifecycle(lifecycleRef, authenticationLifecycle)
+          ) {
+            requestReconnect("oauth-success");
+          }
           return;
         }
 
@@ -1746,6 +1804,12 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
         }
 
         if (!isMountedRef.current) return;
+        if (
+          !authenticationLifecycle ||
+          !isCurrentLifecycle(lifecycleRef, authenticationLifecycle)
+        ) {
+          return;
+        }
 
         switch (result.kind) {
           case "success":
@@ -1753,8 +1817,7 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
               "info",
               "Authentication succeeded; reconnecting to MCP server..."
             );
-            connectingRef.current = false;
-            connectRef.current?.();
+            requestReconnect("oauth-success");
             break;
           case "cancelled":
             addLog(
@@ -1763,6 +1826,9 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
                 ? "Authentication popup was closed before completing. Public tools remain available."
                 : "Authentication popup was closed before completing. Returning to pending_auth."
             );
+            authenticationLifecycle.phase = isOptionalMixedAuthentication
+              ? "ready"
+              : "waiting_for_auth";
             setState(isOptionalMixedAuthentication ? "ready" : "pending_auth");
             break;
           case "timeout":
@@ -1772,10 +1838,16 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
                 ? "Authentication timed out waiting for the popup. Public tools remain available."
                 : "Authentication timed out waiting for the popup. Returning to pending_auth."
             );
+            authenticationLifecycle.phase = isOptionalMixedAuthentication
+              ? "ready"
+              : "waiting_for_auth";
             setState(isOptionalMixedAuthentication ? "ready" : "pending_auth");
             break;
           case "error":
-            failConnection(`Authentication failed: ${result.error}`);
+            failConnection(
+              authenticationLifecycle,
+              `Authentication failed: ${result.error}`
+            );
             break;
           default:
             // Exhaustive over AuthPopupResult["kind"]; nothing to do.
@@ -1785,7 +1857,11 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
         if (!isMountedRef.current) return;
         const error =
           authError instanceof Error ? authError : new Error(String(authError));
-        failConnection(`Manual authentication failed: ${error.message}`, error);
+        failConnection(
+          authenticationLifecycle,
+          `Manual authentication failed: ${error.message}`,
+          error
+        );
       }
     } else if (currentState === "authenticating") {
       addLog(
@@ -1821,6 +1897,7 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
     callbackUrl,
     mergedClientInfo,
     providedAuthProvider,
+    requestReconnect,
   ]);
 
   /**
@@ -1905,27 +1982,7 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
           "Authentication successful via popup. Reconnecting client..."
         );
 
-        // Check if already connecting
-        if (connectingRef.current) {
-          addLog(
-            "debug",
-            "Connection attempt already in progress, resetting flag to allow reconnection."
-          );
-        }
-
-        // Reset the connecting flag and reconnect since auth just succeeded
-        connectingRef.current = false;
-
-        // Small delay to ensure state is clean before reconnecting
-        setTimeout(() => {
-          if (isMountedRef.current) {
-            addLog(
-              "debug",
-              "Initiating reconnection after successful auth callback."
-            );
-            connectRef.current?.();
-          }
-        }, 100);
+        requestReconnect("oauth-success");
       } else {
         // Don't clobber a connection that already became ready (or moved on):
         // a late/duplicate failure message must not knock a healthy client
@@ -1988,7 +2045,7 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
       }
       if (authTimeoutRef.current) clearTimeout(authTimeoutRef.current);
     };
-  }, [addLog]);
+  }, [addLog, requestReconnect]);
 
   /**
    * Effect: Main connection lifecycle
@@ -1999,7 +2056,10 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
    * - Cleans up on unmount or when URL changes
    */
   useEffect(() => {
-    isMountedRef.current = true;
+    const trigger = reconnectRequestPendingRef.current
+      ? reconnectTriggerRef.current
+      : "configuration";
+    reconnectRequestPendingRef.current = false;
 
     // Skip connection if disabled or no URL provided
     if (!enabled || !url) {
@@ -2010,15 +2070,18 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
           : "Connection disabled via enabled flag."
       );
       setState("discovering");
-      return () => {
-        isMountedRef.current = false;
-      };
+      return;
     }
 
-    addLog("debug", "useMcp mounted, initiating connection.");
-    connectAttemptRef.current = 0;
+    // A manual disconnect suspends only the current Effect scope. A genuine
+    // dependency change or an accepted reconnect request starts a new scope.
+    manuallyDisconnectedRef.current = false;
+    addLog("debug", `Starting connection lifecycle (${trigger}).`);
+
+    let authProvider: UseMcpAuthProvider;
     if (providedAuthProvider) {
-      authProviderRef.current = providedAuthProvider as UseMcpAuthProvider;
+      authProvider = providedAuthProvider as UseMcpAuthProvider;
+      authProviderRef.current = authProvider;
       addLog("debug", "Using externally provided authProvider");
     } else if (
       !authProviderRef.current ||
@@ -2039,7 +2102,8 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
         clientMetadataUrl: oauthClientMetadataUrl,
         scope: oauthScope,
       });
-      authProviderRef.current = provider;
+      authProvider = provider;
+      authProviderRef.current = authProvider;
       if (oauthProxyUrl) {
         addLog("debug", `OAuth proxy URL in effect: ${oauthProxyUrl}`);
       }
@@ -2047,11 +2111,38 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
         "debug",
         `BrowserOAuthClientProvider initialized/updated with URL: ${effectiveOAuthUrl}, proxy: ${oauthProxyUrl ? "enabled" : "disabled"}, gateway: ${gatewayUrl ? "enabled" : "disabled"}`
       );
+    } else {
+      authProvider = authProviderRef.current;
     }
-    connect();
+
+    const lifecycle = createConnectionLifecycle<ConnectionSnapshot>({
+      id: ++nextLifecycleIdRef.current,
+      trigger,
+      serverName: USE_MCP_SERVER_NAME,
+      client: new BrowserMCPClient(),
+      authProvider,
+      snapshot: { url, gatewayUrl },
+    });
+    lifecycleRef.current = lifecycle;
+    clientRef.current = lifecycle.client;
+    connectionRef.current = null;
+    iconLoadingPromiseRef.current = null;
+
+    // Deferring startup lets React Strict Mode retire its development-only
+    // preflight lifecycle before any transport handshake begins.
+    queueMicrotask(() => {
+      if (!isCurrentLifecycle(lifecycleRef, lifecycle)) return;
+      lifecycle.started = true;
+      void runLifecycle(lifecycle);
+    });
+
     return () => {
-      isMountedRef.current = false;
-      addLog("debug", "useMcp unmounting, disconnecting.");
+      addLog("debug", `Retiring connection lifecycle #${lifecycle.id}.`);
+      if (lifecycleRef.current === lifecycle) lifecycleRef.current = null;
+      if (clientRef.current === lifecycle.client) clientRef.current = null;
+      if (connectionRef.current === lifecycle.connection) {
+        connectionRef.current = null;
+      }
 
       // NOTE: We intentionally do NOT clear OAuth storage on unmount, even
       // mid-flow. Wrapper remounts (provider revision changes, route
@@ -2065,7 +2156,11 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
       // reconnects cleanly. Explicit logout still clears storage via
       // `clearStorage()` / `removeServer(id, { clearCredentials: true })`.
 
-      disconnect(true);
+      void retireLifecycle(lifecycle).catch((error) => {
+        if (isMountedRef.current) {
+          addLog("warn", "Error retiring connection lifecycle:", error);
+        }
+      });
     };
   }, [
     url,
@@ -2081,10 +2176,12 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
     oauthScope,
     useRedirectFlow,
     mergedClientInfo,
-    effectiveOAuthUrl, // Triggers reconnection when proxy fallback changes OAuth URL
+    effectiveOAuthUrl,
+    gatewayUrl,
     proxyConfig, // Triggers reconnection when proxy config (including headers) changes
     autoProxyFallbackConfig.proxyAddress,
     providedAuthProvider,
+    reconnectRequestId,
   ]);
 
   /**
@@ -2094,31 +2191,29 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
    * after the specified delay.
    * Uses a ref to prevent duplicate scheduling which can cause render loops.
    */
-  const retryRef = useRef(retry);
-  const addLogRef = useRef(addLog);
-
-  useEffect(() => {
-    retryRef.current = retry;
-    addLogRef.current = addLog;
-  }, [retry, addLog]);
-
   useEffect(() => {
     let retryTimeoutId: number | null = null;
+    const failedLifecycle = lifecycleRef.current;
 
-    if (state === "failed" && autoRetry && connectAttemptRef.current > 0) {
+    if (
+      state === "failed" &&
+      autoRetry &&
+      failedLifecycle?.phase === "failed"
+    ) {
       // Prevent duplicate scheduling - only schedule if not already scheduled
       if (!retryScheduledRef.current) {
         retryScheduledRef.current = true;
         const delay =
           typeof autoRetry === "number" ? autoRetry : DEFAULT_RETRY_DELAY;
-        addLogRef.current(
-          "info",
-          `Connection failed, auto-retrying in ${delay}ms...`
-        );
+        addLog("info", `Connection failed, auto-retrying in ${delay}ms...`);
         retryTimeoutId = setTimeout(() => {
           retryScheduledRef.current = false;
-          if (isMountedRef.current && stateRef.current === "failed") {
-            retryRef.current();
+          if (
+            failedLifecycle === lifecycleRef.current &&
+            isCurrentLifecycle(lifecycleRef, failedLifecycle) &&
+            stateRef.current === "failed"
+          ) {
+            requestReconnect("auto-retry");
           }
         }, delay) as any;
       }
@@ -2133,7 +2228,7 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
         retryScheduledRef.current = false;
       }
     };
-  }, [state, autoRetry]);
+  }, [state, autoRetry, addLog, requestReconnect]);
 
   /**
    * Ensure the server icon is loaded and available

--- a/libraries/typescript/packages/client/tests/unit/react/useMcp-lifecycle-races.test.tsx
+++ b/libraries/typescript/packages/client/tests/unit/react/useMcp-lifecycle-races.test.tsx
@@ -1,0 +1,601 @@
+// @vitest-environment jsdom
+
+/**
+ * Public-behavior regression coverage for the hook's connection ownership.
+ *
+ * These tests deliberately use deferred transport results: React can replace an
+ * Effect while its old asynchronous connection is still in flight. Only the
+ * lifecycle installed by the latest Effect is allowed to publish state.
+ */
+
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, create } from "react-test-renderer";
+import { BrowserMCPClient } from "../../../src/core/browser.js";
+import { useMcp } from "../../../src/react/useMcp.js";
+
+const mocks = vi.hoisted(() => ({
+  auth: vi.fn(),
+  createBrowserOAuthProvider: vi.fn(),
+  startConnectionHealthMonitoring: vi.fn(),
+}));
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function connection(serverName: string) {
+  return {
+    tools: [],
+    info: {
+      protocolEra: "legacy" as const,
+      protocolVersion: "2025-06-18",
+      server: { name: serverName },
+      capabilities: {},
+      extensions: {},
+    },
+    supports: vi.fn().mockReturnValue(false),
+    listAllResources: vi.fn().mockResolvedValue({ resources: [] }),
+    listPrompts: vi.fn().mockResolvedValue({ prompts: [] }),
+    listResourceTemplates: vi.fn().mockResolvedValue({
+      resourceTemplates: [],
+    }),
+  };
+}
+
+type Connection = ReturnType<typeof connection>;
+type ClientPlan = { connect: Promise<Connection> };
+
+const plans: ClientPlan[] = [];
+const clients: Array<{
+  addServer: ReturnType<typeof vi.fn>;
+  connect: ReturnType<typeof vi.fn>;
+  closeSession: ReturnType<typeof vi.fn>;
+  getSession: ReturnType<typeof vi.fn>;
+  listSessions: ReturnType<typeof vi.fn>;
+}> = [];
+
+vi.mock("../../../src/core/browser.js", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  BrowserMCPClient: vi.fn(function () {
+    // A stale failure in the current implementation may incorrectly start an
+    // extra lifecycle. Keep that observable as an extra client instead of
+    // turning it into an unrelated unhandled rejection.
+    const plan = plans.shift() ?? {
+      connect: Promise.resolve(connection("unexpected-lifecycle")),
+    };
+    const client = {
+      addServer: vi.fn().mockResolvedValue(undefined),
+      connect: vi.fn().mockImplementation(() => plan.connect),
+      closeSession: vi.fn().mockResolvedValue(undefined),
+      getSession: vi.fn().mockReturnValue(null),
+      listSessions: vi.fn().mockReturnValue([]),
+    };
+    clients.push(client);
+    return client;
+  }),
+}));
+
+vi.mock("@modelcontextprotocol/client", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  auth: mocks.auth,
+}));
+
+vi.mock("../../../src/telemetry/telemetry-browser.js", () => ({
+  Tel: {
+    getInstance: () => ({
+      trackUseMcpConnection: vi.fn().mockResolvedValue(undefined),
+      trackUseMcpToolCall: vi.fn().mockResolvedValue(undefined),
+    }),
+  },
+}));
+
+vi.mock("../../../src/react/useMcp-helpers.js", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  createBrowserOAuthProvider: mocks.createBrowserOAuthProvider,
+  loadServerIcon: vi.fn().mockResolvedValue(null),
+  startConnectionHealthMonitoring: mocks.startConnectionHealthMonitoring,
+}));
+
+const authProvider = {
+  serverUrl: "http://localhost/a/mcp",
+  tokens: vi.fn().mockResolvedValue(undefined),
+  clearStorage: vi.fn().mockReturnValue(0),
+};
+
+let mountedRenderers: Array<ReturnType<typeof create>> = [];
+
+function mount(element: React.ReactElement) {
+  const renderer = create(element);
+  mountedRenderers.push(renderer);
+  return renderer;
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe("useMcp lifecycle races", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    plans.splice(0);
+    clients.splice(0);
+    authProvider.serverUrl = "http://localhost/a/mcp";
+    mocks.auth.mockReset();
+    mocks.createBrowserOAuthProvider.mockReset();
+    mocks.startConnectionHealthMonitoring.mockReset();
+    mocks.startConnectionHealthMonitoring.mockReturnValue(() => {});
+  });
+
+  afterEach(() => {
+    for (const renderer of mountedRenderers) renderer.unmount();
+    mountedRenderers = [];
+    vi.useRealTimers();
+  });
+
+  it("keeps URL B ready when URL A resolves after B", async () => {
+    const a = deferred<Connection>();
+    const b = deferred<Connection>();
+    plans.push({ connect: a.promise }, { connect: b.promise });
+    let latest: ReturnType<typeof useMcp> | undefined;
+
+    function TestComponent({ url }: { url: string }) {
+      latest = useMcp({
+        url,
+        authProvider,
+        autoProxyFallback: false,
+        autoReconnect: false,
+        logLevel: "silent",
+      });
+      return null;
+    }
+
+    let renderer: ReturnType<typeof create>;
+    await act(async () => {
+      renderer = mount(<TestComponent url="http://localhost/a/mcp" />);
+    });
+    await act(async () => {
+      renderer!.update(<TestComponent url="http://localhost/b/mcp" />);
+    });
+
+    await act(async () => {
+      b.resolve(connection("server-b"));
+      await b.promise;
+    });
+    await flush();
+    expect(latest?.state).toBe("ready");
+    expect(latest?.serverInfo?.name).toBe("server-b");
+
+    await act(async () => {
+      a.resolve(connection("server-a"));
+      await a.promise;
+    });
+    await flush();
+
+    expect(latest?.state).toBe("ready");
+    expect(latest?.serverInfo?.name).toBe("server-b");
+    expect(vi.mocked(BrowserMCPClient)).toHaveBeenCalledTimes(2);
+    expect(clients).toHaveLength(2);
+    expect(clients[0]).not.toBe(clients[1]);
+  });
+
+  it("ignores a stale URL-A failure after URL B is ready", async () => {
+    const a = deferred<Connection>();
+    const b = deferred<Connection>();
+    plans.push({ connect: a.promise }, { connect: b.promise });
+    let latest: ReturnType<typeof useMcp> | undefined;
+
+    function TestComponent({ url }: { url: string }) {
+      latest = useMcp({
+        url,
+        authProvider,
+        autoReconnect: false,
+        autoProxyFallback: {
+          enabled: true,
+          proxyAddress: "http://localhost/proxy",
+        },
+        connectionMode: "auto",
+        logLevel: "silent",
+      });
+      return null;
+    }
+
+    let renderer: ReturnType<typeof create>;
+    await act(async () => {
+      renderer = mount(<TestComponent url="http://localhost/a/mcp" />);
+    });
+    await act(async () => {
+      renderer!.update(<TestComponent url="http://localhost/b/mcp" />);
+    });
+    await act(async () => {
+      b.resolve(connection("server-b"));
+      await b.promise;
+    });
+    await flush();
+
+    await act(async () => {
+      a.reject(new Error("Failed to fetch"));
+      try {
+        await a.promise;
+      } catch {
+        // The hook handles connection errors internally.
+      }
+    });
+    await flush();
+
+    expect(latest?.state).toBe("ready");
+    expect(latest?.serverInfo?.name).toBe("server-b");
+    expect(latest?.error).toBeUndefined();
+    // In particular, a stale direct failure cannot begin a proxy fallback.
+    expect(vi.mocked(BrowserMCPClient)).toHaveBeenCalledTimes(2);
+  });
+
+  it("creates one proxy lifecycle with the fallback gateway after a direct failure", async () => {
+    const direct = deferred<Connection>();
+    const proxied = deferred<Connection>();
+    plans.push({ connect: direct.promise }, { connect: proxied.promise });
+    let latest: ReturnType<typeof useMcp> | undefined;
+
+    function TestComponent() {
+      latest = useMcp({
+        url: "http://localhost/a/mcp",
+        authProvider,
+        autoReconnect: false,
+        autoProxyFallback: {
+          enabled: true,
+          proxyAddress: "http://localhost/proxy",
+        },
+        connectionMode: "auto",
+        logLevel: "silent",
+      });
+      return null;
+    }
+
+    await act(async () => {
+      mount(<TestComponent />);
+    });
+    await act(async () => {
+      direct.reject(new Error("Failed to fetch"));
+      try {
+        await direct.promise;
+      } catch {
+        // The direct transport failure is the condition under test.
+      }
+    });
+    await flush();
+
+    expect(vi.mocked(BrowserMCPClient)).toHaveBeenCalledTimes(2);
+    expect(clients[1].addServer).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ gatewayUrl: "http://localhost/proxy" })
+    );
+
+    await act(async () => {
+      proxied.resolve(connection("proxied-server"));
+      await proxied.promise;
+    });
+    await flush();
+    expect(latest?.state).toBe("ready");
+    expect(latest?.serverInfo?.name).toBe("proxied-server");
+  });
+
+  it("uses the fresh provider installed by authenticate for its replacement lifecycle", async () => {
+    const initial = deferred<Connection>();
+    const reconnected = deferred<Connection>();
+    plans.push({ connect: initial.promise }, { connect: reconnected.promise });
+
+    const initialProvider = {
+      serverUrl: "http://localhost/a/mcp",
+      tokens: vi.fn().mockResolvedValue(undefined),
+      clearStorage: vi.fn().mockReturnValue(0),
+    };
+    const freshProvider = {
+      serverUrl: "http://localhost/a/mcp",
+      tokens: vi.fn().mockResolvedValue(undefined),
+      clearStorage: vi.fn().mockReturnValue(0),
+    };
+    mocks.createBrowserOAuthProvider
+      .mockReturnValueOnce({
+        provider: initialProvider,
+        oauthProxyUrl: undefined,
+      })
+      .mockReturnValueOnce({
+        provider: freshProvider,
+        oauthProxyUrl: undefined,
+      });
+    mocks.auth.mockResolvedValue("AUTHORIZED");
+
+    let latest: ReturnType<typeof useMcp> | undefined;
+    function TestComponent() {
+      latest = useMcp({
+        url: "http://localhost/a/mcp",
+        autoProxyFallback: false,
+        autoReconnect: false,
+        logLevel: "silent",
+      });
+      return null;
+    }
+
+    await act(async () => {
+      mount(<TestComponent />);
+    });
+    await act(async () => {
+      const unauthorized = Object.assign(new Error("Unauthorized"), {
+        code: 401,
+      });
+      initial.reject(unauthorized);
+      try {
+        await initial.promise;
+      } catch {
+        // The hook converts an OAuth-capable 401 into pending_auth.
+      }
+    });
+    await flush();
+    expect(latest?.state).toBe("pending_auth");
+
+    await act(async () => {
+      await latest!.authenticate();
+    });
+    await flush();
+
+    expect(vi.mocked(BrowserMCPClient)).toHaveBeenCalledTimes(2);
+    expect(clients[1].addServer).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ authProvider: freshProvider })
+    );
+
+    await act(async () => {
+      reconnected.resolve(connection("authenticated-server"));
+      await reconnected.promise;
+    });
+    await flush();
+    expect(latest?.state).toBe("ready");
+  });
+
+  it("coalesces duplicate OAuth-success messages into one replacement lifecycle", async () => {
+    const replacement = deferred<Connection>();
+    plans.push(
+      { connect: Promise.resolve(connection("initial-server")) },
+      { connect: replacement.promise }
+    );
+    let latest: ReturnType<typeof useMcp> | undefined;
+
+    function TestComponent() {
+      latest = useMcp({
+        url: "http://localhost/a/mcp",
+        authProvider,
+        autoProxyFallback: false,
+        autoReconnect: false,
+        logLevel: "silent",
+      });
+      return null;
+    }
+
+    await act(async () => {
+      mount(<TestComponent />);
+    });
+    await flush();
+    expect(latest?.state).toBe("ready");
+
+    const callback = new MessageEvent("message", {
+      origin: window.location.origin,
+      data: { type: "mcp_auth_callback", success: true },
+    });
+    await act(async () => {
+      window.dispatchEvent(callback);
+      window.dispatchEvent(callback);
+    });
+    await flush();
+
+    expect(vi.mocked(BrowserMCPClient)).toHaveBeenCalledTimes(2);
+    expect(clients[1].connect).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      replacement.resolve(connection("oauth-server"));
+      await replacement.promise;
+    });
+    await flush();
+    expect(latest?.state).toBe("ready");
+    expect(latest?.serverInfo?.name).toBe("oauth-server");
+  });
+
+  it("coalesces repeated health-style reconnect signals while a replacement is connecting", async () => {
+    const replacement = deferred<Connection>();
+    plans.push(
+      { connect: Promise.resolve(connection("initial-server")) },
+      { connect: replacement.promise }
+    );
+    // A health monitor can report the same unhealthy connection through more
+    // than one signal. Its public contract is a reconnect callback; invoke it
+    // twice after the ready lifecycle has published state.
+    mocks.startConnectionHealthMonitoring.mockImplementationOnce(
+      ({ connect }) => {
+        queueMicrotask(connect);
+        queueMicrotask(connect);
+        return () => {};
+      }
+    );
+    let latest: ReturnType<typeof useMcp> | undefined;
+
+    function TestComponent() {
+      latest = useMcp({
+        url: "http://localhost/a/mcp",
+        authProvider,
+        autoProxyFallback: false,
+        autoReconnect: {
+          enabled: true,
+          healthCheckInterval: 10,
+          healthCheckTimeout: 10,
+        },
+        logLevel: "silent",
+      });
+      return null;
+    }
+
+    await act(async () => {
+      mount(<TestComponent />);
+    });
+    await flush();
+    await flush();
+
+    expect(vi.mocked(BrowserMCPClient)).toHaveBeenCalledTimes(2);
+    expect(clients[1].connect).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      replacement.resolve(connection("replacement-server"));
+      await replacement.promise;
+    });
+    await flush();
+    expect(latest?.state).toBe("ready");
+    expect(latest?.serverInfo?.name).toBe("replacement-server");
+  });
+
+  it("does not reconnect for equivalent omitted or inline-empty headers", async () => {
+    const initial = deferred<Connection>();
+    plans.push({ connect: initial.promise });
+    let latest: ReturnType<typeof useMcp> | undefined;
+
+    function TestComponent({ headers }: { headers?: Record<string, string> }) {
+      latest = useMcp({
+        url: "http://localhost/a/mcp",
+        headers,
+        authProvider,
+        autoProxyFallback: false,
+        autoReconnect: false,
+        logLevel: "silent",
+      });
+      return null;
+    }
+
+    let renderer: ReturnType<typeof create>;
+    await act(async () => {
+      renderer = mount(<TestComponent />);
+      initial.resolve(connection("server-a"));
+      await initial.promise;
+    });
+    await flush();
+    expect(latest?.state).toBe("ready");
+
+    await act(async () => {
+      renderer!.update(<TestComponent headers={{}} />);
+    });
+    await flush();
+
+    expect(latest?.state).toBe("ready");
+    expect(vi.mocked(BrowserMCPClient)).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays disconnected through an unrelated render", async () => {
+    const initial = deferred<Connection>();
+    plans.push({ connect: initial.promise });
+    let latest: ReturnType<typeof useMcp> | undefined;
+
+    function TestComponent({ tick }: { tick: number }) {
+      latest = useMcp({
+        url: "http://localhost/a/mcp",
+        authProvider,
+        autoProxyFallback: false,
+        autoReconnect: false,
+        logLevel: "silent",
+      });
+      return <span>{tick}</span>;
+    }
+
+    let renderer: ReturnType<typeof create>;
+    await act(async () => {
+      renderer = mount(<TestComponent tick={0} />);
+      initial.resolve(connection("server-a"));
+      await initial.promise;
+    });
+    await flush();
+    expect(latest?.state).toBe("ready");
+
+    await act(async () => {
+      await latest!.disconnect();
+    });
+    await flush();
+    expect(latest?.client).toBeNull();
+
+    await act(async () => {
+      renderer!.update(<TestComponent tick={1} />);
+    });
+    await flush();
+
+    expect(latest?.client).toBeNull();
+    expect(vi.mocked(BrowserMCPClient)).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not allow an older StrictMode connection to publish state", async () => {
+    const a = deferred<Connection>();
+    const b = deferred<Connection>();
+    // React StrictMode runs an extra mount Effect in development. Both
+    // preflight lifecycles model URL A; URL B is the subsequent real update.
+    plans.push(
+      { connect: a.promise },
+      { connect: a.promise },
+      { connect: b.promise }
+    );
+    let latest: ReturnType<typeof useMcp> | undefined;
+
+    function TestComponent({ url }: { url: string }) {
+      latest = useMcp({
+        url,
+        authProvider,
+        autoProxyFallback: false,
+        autoReconnect: false,
+        logLevel: "silent",
+      });
+      return null;
+    }
+
+    let renderer: ReturnType<typeof create>;
+    await act(async () => {
+      renderer = mount(
+        <React.StrictMode>
+          <TestComponent url="http://localhost/a/mcp" />
+        </React.StrictMode>
+      );
+    });
+    await act(async () => {
+      renderer!.update(
+        <React.StrictMode>
+          <TestComponent url="http://localhost/b/mcp" />
+        </React.StrictMode>
+      );
+    });
+
+    await act(async () => {
+      b.resolve(connection("server-b"));
+      await b.promise;
+    });
+    await act(async () => {
+      a.resolve(connection("server-a"));
+      await a.promise;
+    });
+    await flush();
+
+    expect(latest?.state).toBe("ready");
+    expect(latest?.serverInfo?.name).toBe("server-b");
+  });
+});

--- a/libraries/typescript/packages/client/tests/unit/react/useMcp-lifecycle.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/react/useMcp-lifecycle.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+import type { BrowserMCPClient } from "../../../src/core/browser.js";
+import type { MCPConnection } from "../../../src/core/session.js";
+import {
+  attachLifecycleConnection,
+  closeRetiredLifecycleAfterConnectFailure,
+  commitLifecycle,
+  createConnectionLifecycle,
+  isCurrentLifecycle,
+  retireLifecycle,
+  type ConnectionLifecycleRef,
+  type UseMcpAuthProvider,
+} from "../../../src/react/useMcp-lifecycle.js";
+
+function makeLifecycle() {
+  const client = {
+    closeSession: vi.fn().mockResolvedValue(undefined),
+  } as unknown as BrowserMCPClient;
+  const authProvider = {} as UseMcpAuthProvider;
+
+  const lifecycle = createConnectionLifecycle({
+    id: 1,
+    trigger: "configuration",
+    serverName: "inspector-server",
+    client,
+    authProvider,
+    snapshot: { url: "https://example.test/mcp" },
+  });
+  lifecycle.started = true;
+  return lifecycle;
+}
+
+describe("useMcp lifecycle ownership", () => {
+  it("does not commit from a retired lifecycle", () => {
+    const lifecycle = makeLifecycle();
+    const ref: ConnectionLifecycleRef<{ url: string }> = { current: lifecycle };
+    const commit = vi.fn();
+
+    expect(isCurrentLifecycle(ref, lifecycle)).toBe(true);
+    expect(commitLifecycle(ref, lifecycle, commit)).toBe(true);
+
+    void retireLifecycle(lifecycle);
+
+    expect(isCurrentLifecycle(ref, lifecycle)).toBe(false);
+    expect(commitLifecycle(ref, lifecycle, commit)).toBe(false);
+    expect(commit).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes again when connect resolves after retirement", async () => {
+    const lifecycle = makeLifecycle();
+    const client = lifecycle.client as unknown as {
+      closeSession: ReturnType<typeof vi.fn>;
+    };
+
+    await retireLifecycle(lifecycle);
+    expect(client.closeSession).toHaveBeenCalledTimes(1);
+
+    const lateConnection = {} as MCPConnection;
+    await attachLifecycleConnection(lifecycle, lateConnection);
+
+    expect(lifecycle.connection).toBe(lateConnection);
+    expect(client.closeSession).toHaveBeenCalledTimes(2);
+    expect(lifecycle.phase).toBe("retired");
+  });
+
+  it("does not duplicate teardown for repeated retirement", async () => {
+    const lifecycle = makeLifecycle();
+    const client = lifecycle.client as unknown as {
+      closeSession: ReturnType<typeof vi.fn>;
+    };
+
+    await Promise.all([retireLifecycle(lifecycle), retireLifecycle(lifecycle)]);
+
+    expect(client.closeSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes again when a pending attempt rejects after retirement", async () => {
+    const lifecycle = makeLifecycle();
+    const client = lifecycle.client as unknown as {
+      closeSession: ReturnType<typeof vi.fn>;
+    };
+
+    await retireLifecycle(lifecycle);
+    await closeRetiredLifecycleAfterConnectFailure(lifecycle);
+
+    expect(client.closeSession).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not close a Strict Mode preflight lifecycle that never started", async () => {
+    const lifecycle = makeLifecycle();
+    const client = lifecycle.client as unknown as {
+      closeSession: ReturnType<typeof vi.fn>;
+    };
+    lifecycle.started = false;
+
+    await retireLifecycle(lifecycle);
+
+    expect(client.closeSession).not.toHaveBeenCalled();
+    expect(lifecycle.phase).toBe("retired");
+  });
+});


### PR DESCRIPTION
## Summary

- give each useMcp connection Effect a fresh client, captured OAuth provider, and explicit lifecycle owner
- prevent retired connection attempts, cleanup, notifications, inventories, OAuth callbacks, health checks, and refresh operations from mutating a newer lifecycle
- route retry, OAuth completion, proxy fallback, and health recovery through a coalesced Effect-driven reconnect signal
- preserve manual disconnect and current header dependency behavior

Closes #1696

## Test plan

- pnpm run build in packages/client
- pnpm exec tsc --noEmit -p packages/client/tsconfig.json
- pnpm exec vitest run tests/unit/react
- pnpm exec vitest run

## Validation

- React tests: 16 files, 94 tests passed
- Full client suite: 56 files, 351 tests passed
- Client build and TypeScript checks passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolates `useMcp` connection lifecycles to remove race conditions during React re-renders. Previously, stale connection attempts and cleanups could overwrite or disconnect a newer connection; now each Effect owns its client and OAuth provider, and only the current lifecycle can publish state.

- Introduces a lifecycle owner in `useMcp`, with a fresh client and captured `UseMcpAuthProvider` per Effect; retired lifecycles cannot mutate current state (cleanup, OAuth callbacks, proxy fallback, health checks, inventories, refreshes).
- Routes retry, OAuth completion, proxy fallback, and health recovery through a single reconnect signal; prevents spurious authorization prompts from retired connections.
- Preserves manual disconnect and existing header dependency behavior; no breaking API changes expected.
- Adds focused lifecycle race tests; fixes Linear #1696; publishes a patch to `@mcp-use/client`.
- Migration: none.

<sup>Written for commit 3babffa15c35e4bc78c70816114207d8be0a0b30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

