### PR TITLE
ci: run the TypeScript jobs when ci.yml itself changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ permissions:
 #    ├─ python-integration-tests: Other integration tests
 #    └─ python-agent-tests: Matrix [4 agent test suites] (requires API keys)
 #
-# 3. TypeScript Tests (runs if libraries/typescript/** changed)
+# 3. TypeScript Tests (runs if libraries/typescript/** or this workflow changed)
 #    ├─ typescript-lint: ESLint checks
 #    ├─ typescript-build: Build all packages
 #    ├─ typescript-knip: Unused code/deps check (fails CI on findings)
@@ -37,7 +37,7 @@ permissions:
 #    ├─ typescript-release-channel-test: release-channel helper suite (main + canary PRs)
 #    └─ typescript-changeset-check: PR validation (PRs only)
 #
-# 4. create-mcp-use-app Tests (runs if packages/create-mcp-use-app/** changed)
+# 4. create-mcp-use-app Tests (runs if that package or this workflow changed)
 #    ├─ create-mcp-use-app-build: Build, unit test, and pack the CLI
 #    └─ create-app-tests: Matrix [3 OS × 3 PM × 3 templates × 2 flags]
 #       - Tests project creation across Ubuntu/macOS/Windows
@@ -103,11 +103,13 @@ jobs:
               - 'libraries/python/**'
             typescript:
               - 'libraries/typescript/**'
+              - '.github/workflows/ci.yml'
             knip:
               - 'libraries/typescript/**'
               - '.github/workflows/ci.yml'
             create-mcp-use-app:
               - 'libraries/typescript/packages/create-mcp-use-app/**'
+              - '.github/workflows/ci.yml'
             release-channel:
               - 'libraries/typescript/scripts/release-channel.mjs'
               - 'libraries/typescript/scripts/release-channel.test.mjs'


### PR DESCRIPTION
## Why

`detect-changes` gates every TypeScript job on the `typescript` path filter, and that filter only matches `libraries/typescript/**`. A pull request that edits nothing but `.github/workflows/ci.yml` matches no filter at all, so `typescript` is `false` and every job the workflow defines is skipped on the very change that defines them.

The practical effect is that a CI fix cannot be verified by its own CI run.

## Evidence

The three most recent workflow-only fixes in `main` are all of the form "this test was never running". Each one merged without the job it was wiring up ever executing:

| PR | what it fixed | the relevant check on its own run |
|----|---------------|-----------------------------------|
| #2201 | actually run the inspector unit tests | `typescript/inspector` **skipped** |
| #2214 | run the create-mcp-use-app unit tests | `typescript/create-app-tests` **skipped**, `typescript/create-mcp-use-app/build` **skipped** |
| #2213 | actually run the mcp-use unit tests | no TypeScript job ran at all |

So the class of bug those PRs fixed is exactly the class their own CI could not catch.

## The change

Add `.github/workflows/ci.yml` to the `typescript` and `create-mcp-use-app` filters, and correct the two overview comments that describe when those groups run.

For a `pull_request` event GitHub uses the pull request's own copy of the workflow, so the jobs that run are the edited ones. That makes this PR self-checking: if the change works, the TypeScript matrix runs here even though no file under `libraries/typescript/` was touched.

## Scope

I left the `python` filter alone. All three demonstrated failures above are TypeScript-side, and the same line can be added there if you want the symmetry. Say the word and I will add it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs the TypeScript and `create-mcp-use-app` jobs when `.github/workflows/ci.yml` changes, so workflow-only edits validate the jobs they define. Previously these jobs ran only when files under `libraries/typescript/**` changed; now they also run on workflow file edits.

- Adds `.github/workflows/ci.yml` to the `typescript` and `create-mcp-use-app` path filters.
- Updates the overview comments to match; the `python` filter stays unchanged.
- On `pull_request` runs, GitHub uses the PR's own workflow, so the edited jobs execute here.

<sup>Written for commit 81f9bc4b49fda23d071bc969ba062626591f3a31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

