### PR TITLE
ci: write the knip findings summary on the runs that have findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -736,8 +736,10 @@ jobs:
       - name: Run Knip
         run: |
           set -o pipefail
-          pnpm exec knip --no-progress 2>&1 | tee /tmp/knip-output.txt
-          status=${PIPESTATUS[0]}
+          # Do not let the failing pipeline abort the step under `bash -e`, or
+          # the findings below are never written on the runs that have any.
+          status=0
+          pnpm exec knip --no-progress 2>&1 | tee /tmp/knip-output.txt || status=$?
           {
             echo "## Knip Findings"
             echo ""


### PR DESCRIPTION
## Why

The `Run Knip` step pipes knip through `tee` so the output can be copied into the job summary, then exits with knip's own status:

```bash
set -o pipefail
pnpm exec knip --no-progress 2>&1 | tee /tmp/knip-output.txt
status=${PIPESTATUS[0]}
{
  echo "## Knip Findings"
  ...
} >> "$GITHUB_STEP_SUMMARY"
exit "$status"
```

Actions runs `run:` blocks under `bash -e`. The script's own `set -o pipefail` makes the pipeline return knip's non-zero status, and under `-e` that aborts the step right there. Everything below it, the summary block and the `exit` line both, never runs.

The net effect is inverted from the intent: **the "Knip Findings" section is written only when knip found nothing, and is missing from exactly the runs someone would open the summary for.**

Worth being straight about the impact: `typescript-knip` has not failed on any of the last 30 PRs, so nobody has lost a report yet. This is the reporting path being broken in advance of the day it is needed.

## Evidence

Running the step's real script, extracted from the workflow with `yaml.safe_load`, with `pnpm exec knip` swapped for a command of each kind:

| | knip result | step exit | summary written |
|---|---|---|---|
| before | fails | 1 | **no** |
| before | passes | 0 | yes |
| after | fails | 1 | **yes** |
| after | passes | 0 | yes |

Identical under `bash -e` and under `bash -eo pipefail`, so the outcome does not depend on which default the runner picks.

## The change

```diff
-          pnpm exec knip --no-progress 2>&1 | tee /tmp/knip-output.txt
-          status=${PIPESTATUS[0]}
+          status=0
+          pnpm exec knip --no-progress 2>&1 | tee /tmp/knip-output.txt || status=$?
```

`|| status=$?` puts the pipeline in a condition list, so `-e` leaves it alone, while `set -o pipefail` still makes `$?` knip's status rather than tee's.

Deleting the `set -o pipefail` line would also work today, since without pipefail the pipeline exits 0 through `tee` and `PIPESTATUS[0]` still holds knip's code. I did not go that way because it silently depends on pipefail being off: adding `shell: bash` to the step, which does set pipefail, would bring the bug straight back. The form above is correct either way.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Writes the `knip` findings summary on runs that have findings. Previously the step aborted under `bash -e` with `set -o pipefail`, so the summary appeared only on success; now it captures the `knip` status with `|| status=$?`, writes the summary, then exits with that status.

- Change limited to `.github/workflows/ci.yml` in the “Run Knip” step.
- Outcome: summaries are always written; CI still fails when `knip` fails.
- No developer action required.

<sup>Written for commit 5461f827c1095d5abb8aa6548910dbe7aa4ebbae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

