### PR TITLE
test(agent): assert in the two tests that assert nothing

### DIFF
--- a/libraries/typescript/packages/agent/tests/stream_events.test.ts
+++ b/libraries/typescript/packages/agent/tests/stream_events.test.ts
@@ -345,8 +345,7 @@ describe("mCPAgent streamEvents()", () => {
       // Just consume events
     }
 
-    // Note: cleanup only happens if initialized in this call and no client
-    // This is hard to test with our current mocking setup, but the logic is there
+    expect(closeSpy).toHaveBeenCalled();
   });
 });
 

--- a/libraries/typescript/packages/agent/tests/unit/telemetry/agent-telemetry.test.ts
+++ b/libraries/typescript/packages/agent/tests/unit/telemetry/agent-telemetry.test.ts
@@ -452,8 +452,12 @@ describe("MCPAgent Telemetry Integration", () => {
         // Expected to fail
       }
 
-      // Telemetry might not be called if initialization fails early
-      // The agent needs to be initialized before tracking
+      const exec = lastExecution();
+      expect(exec).toBeDefined();
+      expect(exec).toMatchObject({
+        success: false,
+        errorType: "execution_error",
+      });
     });
   });
 


### PR DESCRIPTION
## Why

Two tests in `@mcp-use/agent` run their subject and then check nothing. They pass regardless of what the code does, and both leave a comment saying as much.

`tests/stream_events.test.ts`, "should clean up resources on completion" installs a spy on `agent.close()`, consumes the whole stream, and never looks at the spy again:

```ts
const closeSpy = vi.spyOn(agent, "close").mockResolvedValue(undefined);
...
// Note: cleanup only happens if initialized in this call and no client
// This is hard to test with our current mocking setup, but the logic is there
```

`tests/unit/telemetry/agent-telemetry.test.ts`, "should track error type on failure" swallows the error and guesses that telemetry may not have run:

```ts
// Telemetry might not be called if initialization fails early
// The agent needs to be initialized before tracking
```

Both comments are wrong. `close()` is called, and telemetry does record the failure. Printing the captured execution on that path gives:

```json
{"executionMethod":"stream","query":"test query","success":false,
 "errorType":"execution_error","stepsTaken":0,"executionTimeMs":12, ...}
```

So the behaviour the names promise works today, and neither test would notice if it stopped.

## The change

One assertion each, using the same `lastExecution()` helper the sibling telemetry tests already use. No new files, no new cases.

## Verification

A test that only passes is not evidence, so both were run against a deliberately broken source:

| break | result |
|---|---|
| removed the `await this.close()` calls in the cleanup paths | `expected "close" to be called at least once` |
| hardcoded `errorType: null` | `expected { executionMethod: 'stream', … } to match object { success: false, errorType: 'execution_error' }` |

Restored, both files pass: 24 tests across the two.

## Scope

I swept all 1369 `it`/`test` blocks in the workspace for bodies with no assertion. Nine came back, and seven are false positives worth naming so nobody re-runs this: `type-level.test.ts` asserts through `expectTypeOf` and `@ts-expect-error` under `pnpm typecheck`, `tests/deno/basic-server.test.ts` uses Deno's own `assertEquals`/`assertExists`, and the two `inject-openai-file-apis` cases delegate to a helper that asserts eight times. These two were the only real ones.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds assertions to two `@mcp-use/agent` tests that previously passed without checks. Old: tests ran but asserted nothing; new: they verify stream cleanup and failure telemetry, preventing silent regressions.

- tests/stream_events.test.ts: assert the `agent.close()` spy is called after consuming the stream.
- tests/unit/telemetry/agent-telemetry.test.ts: use `lastExecution()` to assert `{ success: false, errorType: "execution_error" }`.

<sup>Written for commit 0514b19323d9b7bd22c4c92fc19163e2622c06fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

