### PR TITLE
ci(docs): run the documentation checks on canary

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,13 +2,13 @@ name: Documentation
 
 on:
   push:
-    branches: [main, monorepo]
+    branches: [main, canary]
     paths:
       - "libraries/python/**"
       - "libraries/typescript/**"
       - "docs/**"
   pull_request:
-    branches: [main, monorepo]
+    branches: [main, canary]
     paths:
       - "libraries/python/**"
       - "libraries/typescript/**"


### PR DESCRIPTION
## Why

The Documentation workflow regenerates the API reference, runs `mint broken-links`, and fails when the committed docs no longer match the source. It triggers on two branches:

```yaml
branches: [main, monorepo]
```

`monorepo` does not exist:

```
$ git ls-remote --heads origin monorepo
$
```

So half the trigger has been dead for a while, and `canary`, where every published package's source lands first, was never covered.

Measured on the four most recent canary-targeted PRs. The `Generate and validate API documentation` check is absent from all of them:

| PR | base | docs check |
|----|------|------------|
| #2316 | canary | **absent** |
| #2312 | canary | **absent** |
| #2309 | canary | **absent** |
| #2307 | canary | **absent** |
| #2314 | main | success |

The consequence is timing. Doc drift and broken links are still caught, but only on the canary-to-main release PR, as one batch, well after the change that caused them.

That matters more once #2312 lands, since it turns `pnpm docs:api` into a gate that actually fails. A gate that cannot run on the branch where the violations are introduced only fires at release time.

## The change

Point the trigger at `canary` instead of the branch that is gone.

## Safety

The job is read-only with respect to the repo. It regenerates docs into the working tree and fails if `git status --porcelain docs/` is non-empty. It pushes nothing and deploys nothing, so running it on canary cannot publish anything.

## Note

This is independent of #2312 and does not depend on it. If you would rather keep `monorepo` listed, say so and I will add `canary` alongside it instead of replacing it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run the documentation workflow on `canary` instead of the nonexistent `monorepo` so we catch API doc drift and broken links on feature PRs. Previously the workflow triggered on `main` and `monorepo`; now it triggers on `main` and `canary`. The job remains read-only and does not publish.

- Update `.github/workflows/docs.yml` branch filters for both `push` and `pull_request` to `[main, canary]`.
- The workflow regenerates docs and fails on uncommitted changes in `docs/`; it does not push or deploy.

<sup>Written for commit 02f4151bba680ec6490ce532bcd86a1ebd4a36f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

