### PR TITLE
docs(server): point the Clerk example at a dashboard URL that resolves

### DIFF
--- a/libraries/typescript/packages/server/examples/auth/clerk/README.md
+++ b/libraries/typescript/packages/server/examples/auth/clerk/README.md
@@ -5,7 +5,7 @@ tool: `get-user-info`.
 
 ## Configure Clerk
 
-1. Create or select an application in the [Clerk Dashboard](https://dashboard.clerk.com/).
+1. Create or select an application in the [Clerk Dashboard](https://dashboard.clerk.com/sign-in).
 2. Enable Clerk OAuth. Enable OpenID Connect if your client requires it.
 3. Under **Configure** > **OAuth Applications**, enable Dynamic Client
    Registration so MCP clients can register directly with Clerk.


### PR DESCRIPTION
## Why

Step 1 of the Clerk direct-auth example sends people to `https://dashboard.clerk.com/`, which returns 404. It is the one genuine error in this week's automated link report, #2317.

I verified it rather than trusting the report, with and without a browser user agent and following redirects:

```
404  https://dashboard.clerk.com/
404  https://dashboard.clerk.com/apps
200  https://dashboard.clerk.com/sign-in
```

Clerk's own homepage still links to the bare root, so the 404 is on their side. `/sign-in` resolves, and an already-signed-in user gets forwarded to the dashboard from there.

## Scope

One line. I have deliberately left the other two things in that report alone:

**The second reported error is a false positive.** `libraries/typescript/packages/inspector/index.html` references `/favicon-black.svg?v=4`, and lychee cannot resolve root-relative links without `--root-dir`. The file exists at `packages/inspector/public/favicon-black.svg` and is served correctly at runtime. Silencing it means changing `links.yml`, and lychee is not installed here so I could not verify such a change locally. Flagging it instead of guessing, since it will keep opening an issue every week.

**The 50 redirects are not a one-line fix either.** Package READMEs link to `mcp-use.com/docs/typescript/...`, which redirects to the legacy `docs.mcp-use.com/typescript/...` tree rather than `/v2/`. I checked all 25 distinct URLs against their `/v2/` equivalents and **9 of them 404**, including `server/configuration`, `server/csp`, `server/ui-widgets`, `client/cli`, `client/client-configuration` and both `api-reference` pages. So the v2 tree has no home for a third of them, and a blanket rewrite would trade working redirects for real 404s. That is a content question for whoever owns the v2 docs, not something to guess at in a link-fixing PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the Clerk direct-auth example to use a dashboard URL that resolves. Previously step 1 linked to https://dashboard.clerk.com/ (404); it now links to https://dashboard.clerk.com/sign-in, which forwards signed-in users to the dashboard and shows sign-in for others.

<sup>Written for commit 9a7494929e2cd6cdc4ae0db6b80554d7ec768c3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

