### PR TITLE
ci(links): stop the weekly link report flagging the Vite entry HTML

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -38,9 +38,14 @@ exclude = [
 
 ]
 
-# Skip generated changelogs - historical release notes reference docs URLs
-# that were valid at release time; rewriting them is misleading
 exclude_path = [
+  # Vite entry HTML. Its `/favicon-black.svg` and `/src/client/main.tsx` are
+  # dev-server paths resolved by Vite, not filesystem paths, so lychee reports
+  # "Cannot resolve root-relative link" for a file that is served fine.
+  "libraries/typescript/packages/inspector/index\\.html$",
+
+  # Skip generated changelogs - historical release notes reference docs URLs
+  # that were valid at release time; rewriting them is misleading
   "libraries/typescript/packages/cli/CHANGELOG\\.md$",
   "libraries/typescript/packages/create-mcp-use-app/CHANGELOG\\.md$",
   "libraries/typescript/packages/inspector/CHANGELOG\\.md$",

--- a/lychee.toml
+++ b/lychee.toml
@@ -49,7 +49,7 @@ exclude_path = [
   "libraries/typescript/packages/cli/CHANGELOG\\.md$",
   "libraries/typescript/packages/create-mcp-use-app/CHANGELOG\\.md$",
   "libraries/typescript/packages/inspector/CHANGELOG\\.md$",
-  "libraries/typescript/packages/mcp-use/CHANGELOG\\.md$",
+  "libraries/typescript/packages/server/CHANGELOG\\.md$",
 ]
 
 exclude_loopback = true


### PR DESCRIPTION
## Why

The Link Checker workflow opens an issue whenever lychee exits non-zero, so a permanent false positive means a fresh issue every Sunday. One of the two errors in this week's report, #2317, is not a broken link:

```
[ERROR] error: (at 5:49) | Cannot resolve root-relative link
'/favicon-black.svg?v=4': To resolve root-relative links in local files,
provide a root dir
```

`packages/inspector/index.html` is a Vite entry document. Its two absolute paths, `/favicon-black.svg?v=4` and `/src/client/main.tsx`, are dev-server paths that Vite resolves from `public/` and `src/`. Both files are present:

```
libraries/typescript/packages/inspector/public/favicon-black.svg
libraries/typescript/packages/inspector/src/client/main.tsx
```

lychee has no web root to resolve them against. A repo-wide `--root-dir` cannot supply one either, and I checked rather than assuming: pointed at the repo root it just fails differently.

```
$ lychee --offline --root-dir "$PWD" .../inspector/index.html
[ERROR] file:///.../mcp-use/favicon-black.svg?v=4 | File not found.
```

`--exclude-file` does not help either, because the failure happens while resolving the path, before URL exclusion is applied.

## The change

Add the file to the `exclude_path` list in `lychee.toml` that already skips generated changelogs, with the reason inline.

Offline run over every tracked markdown and html file:

```
before   612 total, 1 error
after    610 total, 0 errors
```

The two links that stop being counted are exactly the two Vite paths.

## Note

#2322 fixes the other error in that report, the Clerk dashboard 404, which is a genuinely dead URL. Between the two, `#2317` should stop recurring.

I owe a correction on #2322: I wrote there that lychee was not installed locally so I could not verify this. That was wrong, it is installed, and I have posted the correction on that PR. Everything above was measured, not reasoned about.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude the `Vite` entry HTML and fix a broken changelog exclusion in `lychee` to stop the weekly link report from flagging false errors. Previously `lychee` failed on root‑relative dev‑server paths and also scanned `packages/server/CHANGELOG.md` because the exclusion targeted a non-existent `mcp-use` directory; now it ignores the HTML and correctly skips the changelog.

- Add `libraries/typescript/packages/inspector/index.html` to `exclude_path` in `lychee.toml` with an inline rationale.
- Replace `libraries/typescript/packages/mcp-use/CHANGELOG.md` with `libraries/typescript/packages/server/CHANGELOG.md` in `exclude_path`.
- Effect: CI no longer fails on the false positive; checked files drop from 612 to 610; no runtime or docs behavior change.

<sup>Written for commit 3ac50c12318a01331c1c8a716a8a15e47a7257a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

