### PR TITLE
ci: keep both CLI matrix legs running when one fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -783,6 +783,9 @@ jobs:
     name: "typescript/cli (${{ matrix.os }}, node-${{ matrix.node-version }})"
     runs-on: ${{ matrix.os }}
     strategy:
+      # Keep the other OS running when one fails: comparing the two is the
+      # whole reason this job has an os matrix.
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
         node-version: [22.23.1]


### PR DESCRIPTION
## Why

`typescript-test-cli` is the only TypeScript job with more than one matrix leg:

```yaml
    strategy:
      matrix:
        os: [ubuntu-latest, windows-latest]
        node-version: [22.23.1]
```

It leaves `fail-fast` at its default of `true`, so whichever leg fails first cancels the other. That throws away the one thing a two-OS matrix exists to tell you. When Windows goes red the immediate question is whether Ubuntu went red too, and cancelling Ubuntu removes the answer.

## Near miss

Run `32652809882`, last week. The Windows leg failed on a load-sensitive timeout while Ubuntu passed:

| leg | result | completed |
|---|---|---|
| ubuntu-latest | success | 16:51:12Z |
| windows-latest | failure | 16:52:17Z |

Ubuntu finished **65 seconds** before Windows failed. A minute slower and it would have been cancelled, and that failure would have been indistinguishable from a platform-wide one. Being able to say "Ubuntu passed, Windows did not" is what identified it as a timeout budget problem rather than a real regression.

To be straight about it: I could not find a case where a leg was actually cancelled, because failures here are rare and the fast leg has always finished first. This is a one-minute margin, not an outage.

## Consistency

Every other multi-leg matrix in the repo already sets `fail-fast: false`:

```
python-transport-tests       fail-fast=False
python-primitive-tests       fail-fast=False
python-agent-tests           fail-fast=False
create-mcp-use-app-tests     fail-fast=False
typescript-test-cli          default (true)     <- this job
```

The remaining TypeScript matrices are single-leg (`node-version: [22.23.1]` only), so the setting cannot affect them either way. This is the one multi-leg matrix that missed the convention.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep both OS legs running in the `typescript/cli` CI matrix by setting `fail-fast: false`. Previously, the first failing leg cancelled the other; now both Ubuntu and Windows legs complete, improving platform-specific diagnosis at the cost of slightly longer runs when one leg fails.

- Affects only the `typescript/cli` job (Ubuntu + Windows); other TypeScript matrices are single-leg and unaffected.
- Aligns with all other multi-leg jobs in this repo, which already use `fail-fast: false`.

<sup>Written for commit bdd06ce330f441283048aab0e6776fbc58832cba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

