### PR TITLE
fix(create-mcp-use-app): send "Learn more" to the mcp-use docs

### DIFF
--- a/libraries/typescript/.changeset/scaffold-learn-more-link.md
+++ b/libraries/typescript/.changeset/scaffold-learn-more-link.md
@@ -2,4 +2,4 @@
 "create-mcp-use-app": patch
 ---
 
-Point the scaffold's closing "Learn more" line at the mcp-use quickstart instead of `manufact.com/docs`, which now redirects to Manufact's dashboard docs rather than to mcp-use documentation.
+Point the scaffold's closing "Learn more" line at `docs.mcp-use.com` instead of `manufact.com/docs`, which now redirects to Manufact's dashboard docs rather than to mcp-use documentation.

--- a/libraries/typescript/.changeset/scaffold-learn-more-link.md
+++ b/libraries/typescript/.changeset/scaffold-learn-more-link.md
@@ -1,0 +1,5 @@
+---
+"create-mcp-use-app": patch
+---
+
+Point the scaffold's closing "Learn more" line at the mcp-use quickstart instead of `manufact.com/docs`, which now redirects to Manufact's dashboard docs rather than to mcp-use documentation.

--- a/libraries/typescript/packages/create-mcp-use-app/src/index.ts
+++ b/libraries/typescript/packages/create-mcp-use-app/src/index.ts
@@ -1137,7 +1137,11 @@ async function main(): Promise<void> {
     );
     console.log("");
   }
-  console.log(ansi.cyan("📚 Learn more: https://manufact.com/docs"));
+  console.log(
+    ansi.cyan(
+      "📚 Learn more: https://docs.mcp-use.com/v2/typescript/getting-started/quickstart"
+    )
+  );
   console.log(ansi.gray("💬 For feedback and bug reporting visit:"));
   console.log(
     ansi.gray("   https://github.com/mcp-use/mcp-use or https://manufact.com")

--- a/libraries/typescript/packages/create-mcp-use-app/src/index.ts
+++ b/libraries/typescript/packages/create-mcp-use-app/src/index.ts
@@ -1137,11 +1137,7 @@ async function main(): Promise<void> {
     );
     console.log("");
   }
-  console.log(
-    ansi.cyan(
-      "📚 Learn more: https://docs.mcp-use.com/v2/typescript/getting-started/quickstart"
-    )
-  );
+  console.log(ansi.cyan("📚 Learn more: https://docs.mcp-use.com"));
   console.log(ansi.gray("💬 For feedback and bug reporting visit:"));
   console.log(
     ansi.gray("   https://github.com/mcp-use/mcp-use or https://manufact.com")


### PR DESCRIPTION
## Why

The last line every scaffold prints is:

```
📚 Learn more: https://manufact.com/docs
```

That URL no longer reaches mcp-use documentation. Following it:

```
$ curl -sIL https://manufact.com/docs
final=200  url=https://docs.manufact.com/dashboard  hops=2
```

So someone who has just run `create-mcp-use-app` and wants to learn about the server they created is handed Manufact's dashboard docs instead.

The same command writes a README into the new project that points at the mcp-use quickstart, so the two halves of one tool currently disagree about where the docs are.

## The change

```diff
-  console.log(ansi.cyan("📚 Learn more: https://manufact.com/docs"));
+  console.log(
+    ansi.cyan(
+      "📚 Learn more: https://docs.mcp-use.com/v2/typescript/getting-started/quickstart"
+    )
+  );
```

That target resolves directly, with no redirect at all:

```
final=200  url=https://docs.mcp-use.com/v2/typescript/getting-started/quickstart  hops=0
```

I picked the `/v2/` quickstart rather than `mcp-use.com/docs/typescript/...` deliberately: the latter redirects into the legacy docs tree, which is the wrong version to show someone starting a new project today.

## Verified

Rebuilt the package and ran a real scaffold, rather than only reading the diff:

```
📤 To deploy:
   npm run deploy

📚 Learn more: https://docs.mcp-use.com/v2/typescript/getting-started/quickstart
💬 For feedback and bug reporting visit:
   https://github.com/mcp-use/mcp-use or https://manufact.com
```

The feedback line below is untouched on purpose. That one is about where to reach you, not where the docs live, so `manufact.com` is right there.

If pointing new users at `manufact.com/docs` is deliberate branding rather than an accident, say so and I will close this.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the scaffold’s closing “Learn more” link in `create-mcp-use-app` from https://manufact.com/docs to https://docs.mcp-use.com so new projects open the correct mcp-use getting-started docs. Previously it redirected to Manufact dashboard docs.

- The short docs host redirects to the v2 TypeScript getting-started page.
- No config or migration changes; only the printed URL changes.
- The feedback line still references manufact.com; intentional.

<sup>Written for commit 12b2bec3ccc3cf10804b7fabf37dad935d36bb5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

