### PR TITLE
ci: use Knip's native GitHub reporter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ permissions:
 #
 # 1. detect-changes (Always runs first)
 #    - Uses path filters to determine which parts of the codebase changed
-#    - Outputs: python, typescript, typescript-agent, create-mcp-use-app
+#    - Outputs: python, typescript, knip, create-mcp-use-app
 #    - Subsequent jobs use these outputs to conditionally run
 #
 # 2. Python Tests (runs if libraries/python/** changed)
@@ -86,6 +86,7 @@ jobs:
     outputs:
       python: ${{ steps.out.outputs.python }}
       typescript: ${{ steps.out.outputs.typescript }}
+      knip: ${{ steps.out.outputs.knip }}
       create-mcp-use-app: ${{ steps.out.outputs.create-mcp-use-app }}
       release-channel: ${{ steps.out.outputs.release-channel }}
     steps:
@@ -102,6 +103,9 @@ jobs:
               - 'libraries/python/**'
             typescript:
               - 'libraries/typescript/**'
+            knip:
+              - 'libraries/typescript/**'
+              - '.github/workflows/ci.yml'
             create-mcp-use-app:
               - 'libraries/typescript/packages/create-mcp-use-app/**'
             release-channel:
@@ -122,9 +126,11 @@ jobs:
             const fromWfCall = context.eventName === 'workflow_call';
             const py = fromWfCall ? (process.env.CI_INPUT_PYTHON === 'true') : ("${{ steps.filter.outputs.python }}" === 'true');
             const ts = fromWfCall ? (process.env.CI_INPUT_TYPESCRIPT === 'true') : ("${{ steps.filter.outputs.typescript }}" === 'true');
+            const knip = fromWfCall ? (process.env.CI_INPUT_TYPESCRIPT === 'true') : ("${{ steps.filter.outputs.knip }}" === 'true');
             const create = fromWfCall ? (process.env.CI_INPUT_CREATE === 'true') : ("${{ steps.filter.outputs.create-mcp-use-app }}" === 'true');
             core.setOutput('python', String(py));
             core.setOutput('typescript', String(ts));
+            core.setOutput('knip', String(knip));
             core.setOutput('create-mcp-use-app', String(create));
             // The reusable-workflow caller only reports python/typescript/create-app,
             // so it cannot tell us whether a release workflow changed. The helper test
@@ -726,7 +732,8 @@ jobs:
         run: pnpm --filter @mcp-use/agent test:integration:native-openai
 
   typescript-knip:
-    needs: typescript-lint
+    needs: detect-changes
+    if: needs.detect-changes.outputs.knip == 'true'
     name: typescript-knip
     runs-on: ubuntu-latest
     defaults:
@@ -745,20 +752,9 @@ jobs:
           cache: "pnpm"
           cache-dependency-path: libraries/typescript/pnpm-lock.yaml
       - name: Install Dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
       - name: Run Knip
-        run: |
-          set -o pipefail
-          pnpm exec knip --no-progress 2>&1 | tee /tmp/knip-output.txt
-          status=${PIPESTATUS[0]}
-          {
-            echo "## Knip Findings"
-            echo ""
-            echo '```'
-            cat /tmp/knip-output.txt
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
-          exit "$status"
+        run: pnpm exec knip --reporter github-actions
 
   typescript-test-inspector:
     needs: typescript-lint


### PR DESCRIPTION
## Summary

- run Knip with its built-in GitHub Actions reporter for detailed inline annotations
- let Knip's native exit code fail the CI check directly
- give Knip its own path filter so CI workflow changes exercise this job without running the entire TypeScript suite
- install the locked dependency graph in the Knip job

## Why

Supersedes #2315. @ayaangazali correctly identified that the existing bash pipeline exits before writing its summary when Knip fails. Knip already has a GitHub Actions reporter, so this removes the manual summary and relies on GitHub-native annotations instead.

No artifact or follow-up comment workflow is needed: the failing check and inline annotations contain the actionable findings.

## Validation

- actionlint passes after excluding the repository's pre-existing `setup-python@v4` notices
- Prettier and whitespace checks pass
- the native reporter emits GitHub Actions `error` and `warning` annotations with file and line locations
- the Knip job ran successfully on the original PR revision before this annotations-only simplification

## End-to-end test after merge

After this lands on `main`, trigger a fresh CI event on the canary-to-main PR. The Knip job will use the workflow from `main` and expose any findings as inline annotations.
