### PR TITLE
fix(inspector): warn when model tool limit is exceeded

### DIFF
--- a/libraries/typescript/.changeset/warm-tools-warn.md
+++ b/libraries/typescript/.changeset/warm-tools-warn.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Warn in Inspector chat when an MCP server exceeds the documented 128-tool limit for OpenAI or Gemini models.

--- a/libraries/typescript/packages/inspector/src/client/components/ChatTab.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ChatTab.tsx
@@ -58,6 +58,7 @@ import { useChatMessagesClientSide } from "./chat/useChatMessagesClientSide";
 import { useConfig } from "./chat/useConfig";
 import { useHostedChatMode } from "./chat/useHostedChatMode";
 import { McpReconnectBanner } from "./chat/McpReconnectBanner";
+import { ToolLimitWarningBanner } from "./chat/ToolLimitWarningBanner";
 import { ChatManagedNotice } from "./chat/ChatManagedNotice";
 import { ChatRawView, type ChatView } from "./chat/ChatTraceView";
 import { useLocalSystemPrompt } from "./chat/system-prompt/useLocalSystemPrompt";
@@ -607,6 +608,17 @@ export function ChatTab({
           managedCloudModel.selectedModel.provider
         )
       : undefined;
+
+  const toolLimitProvider =
+    isManaged && managedCloudModel?.selectedModel
+      ? managedCloudModel.selectedModel.provider
+      : llmConfig?.provider;
+  const toolLimitWarningNode = (
+    <ToolLimitWarningBanner
+      provider={toolLimitProvider}
+      toolCount={modelVisibleTools.length}
+    />
+  );
 
   const handleSaveManagedCloud = useCallback(() => {
     setForceClientSide(false);
@@ -1527,7 +1539,12 @@ export function ChatTab({
 
         <ChatLandingForm
           serverDisplayName={getServerDisplayName(connection)}
-          composerNotice={managedChatNoticeNode}
+          composerNotice={
+            <>
+              {toolLimitWarningNode}
+              {managedChatNoticeNode}
+            </>
+          }
           inputValue={inputValue}
           isConnected={
             isConnected && !managedChatNotice && !mcpServerAuthRequired
@@ -1678,6 +1695,7 @@ export function ChatTab({
       {llmConfig && (
         <div className="relative shrink-0" data-chat-composer>
           <FullscreenChatOverlay messages={messages} isLoading={isLoading} />
+          {toolLimitWarningNode}
           {managedChatNoticeNode}
           <ChatInputArea
             variant={isMcpWidgetFullscreen ? "fullscreen" : "default"}

--- a/libraries/typescript/packages/inspector/src/client/components/chat/ToolLimitWarningBanner.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/ToolLimitWarningBanner.tsx
@@ -1,0 +1,34 @@
+import { AlertCircle } from "lucide-react";
+import { getToolLimitWarning } from "./tool-limit-warning";
+
+interface ToolLimitWarningBannerProps {
+  provider?: string | null;
+  toolCount: number;
+}
+
+export function ToolLimitWarningBanner({
+  provider,
+  toolCount,
+}: ToolLimitWarningBannerProps) {
+  const warning = getToolLimitWarning(provider, toolCount);
+  if (!warning) return null;
+
+  return (
+    <div className="mb-2 flex w-full items-center justify-center px-2 sm:px-4">
+      <div
+        role="alert"
+        className="flex w-full max-w-3xl items-start gap-3 rounded-md border border-amber-300/60 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-500/40 dark:bg-amber-950/40 dark:text-amber-100"
+      >
+        <AlertCircle className="mt-0.5 size-4 shrink-0" aria-hidden />
+        <div className="min-w-0 flex-1">
+          <div className="font-medium">Tool limit exceeded</div>
+          <div className="text-xs opacity-90">
+            This server has {warning.toolCount} tools, but this model supports
+            up to {warning.limit}. Exceeding this limit may cause unexpected
+            model behavior due to context constraints.
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/libraries/typescript/packages/inspector/src/client/components/chat/__tests__/tool-limit-warning.test.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/__tests__/tool-limit-warning.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { getToolLimitWarning, MODEL_TOOL_LIMITS } from "../tool-limit-warning";
+
+describe("getToolLimitWarning", () => {
+  it.each(["openai", "google"])(
+    "warns when %s receives more than 128 tools",
+    (provider) => {
+      expect(getToolLimitWarning(provider, 128)).toBeNull();
+      expect(getToolLimitWarning(provider, 129)).toEqual({
+        limit: 128,
+        toolCount: 129,
+      });
+    }
+  );
+
+  it("normalizes provider names", () => {
+    expect(getToolLimitWarning(" Google ", 129)?.limit).toBe(
+      MODEL_TOOL_LIMITS.google
+    );
+  });
+
+  it.each(["anthropic", "openrouter", "openai-compatible", "ollama"])(
+    "does not claim an undocumented hard limit for %s",
+    (provider) => {
+      expect(getToolLimitWarning(provider, 10_000)).toBeNull();
+    }
+  );
+});

--- a/libraries/typescript/packages/inspector/src/client/components/chat/tool-limit-warning.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/tool-limit-warning.ts
@@ -1,0 +1,26 @@
+export const MODEL_TOOL_LIMITS = {
+  openai: 128,
+  google: 128,
+} as const;
+
+export interface ToolLimitWarning {
+  limit: number;
+  toolCount: number;
+}
+
+/**
+ * Returns a warning only for providers with a documented hard tool limit.
+ * Anthropic does not document a comparable cap for the Messages API.
+ */
+export function getToolLimitWarning(
+  provider: string | null | undefined,
+  toolCount: number
+): ToolLimitWarning | null {
+  const normalizedProvider = provider?.trim().toLowerCase();
+  if (normalizedProvider !== "openai" && normalizedProvider !== "google") {
+    return null;
+  }
+
+  const limit = MODEL_TOOL_LIMITS[normalizedProvider];
+  return toolCount > limit ? { limit, toolCount } : null;
+}


### PR DESCRIPTION
## Summary

- show a chat warning when OpenAI or Gemini receives more than 128 MCP tools
- place the warning directly above the chat composer
- support both local and managed provider selection
- add focused provider and boundary tests

## Validation

- Inspector unit tests: 260 passed
- TypeScript type-check
- Prettier check

Linear: MCP-3081

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Inspector chat warning when an OpenAI or Gemini model receives more than 128 MCP tools, signaling that exceeding the documented limit may cause unexpected model behavior.

- The banner appears above the chat composer and on the chat landing form, covering both local and managed provider selection.
- The warning only applies to OpenAI and Google providers; Anthropic and other providers have no documented hard limit.
- Provider names are normalized (trimmed, lowercased) before matching.
- Adds unit tests covering the 128-tool boundary, provider normalization, and providers without a documented limit.

<sup>Written for commit 5c1d3ace9e626d489d643d3423b8c8d5d8a6df29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

