### PR TITLE
fix(cli): give dev waitFor more startup budget

### DIFF
--- a/libraries/typescript/packages/cli/tests/cli/helpers.test.ts
+++ b/libraries/typescript/packages/cli/tests/cli/helpers.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { DEFAULT_WAIT_FOR_TIMEOUT_MS, waitFor } from "./helpers.js";
+
+describe("cli test helpers", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("uses a waitFor default timeout close to the test budget", async () => {
+    vi.useFakeTimers();
+
+    const pending = waitFor(async () => undefined, { interval: 1000 });
+    const rejection = expect(pending).rejects.toThrow(
+      `waitFor timed out after ${DEFAULT_WAIT_FOR_TIMEOUT_MS}ms`
+    );
+
+    await vi.advanceTimersByTimeAsync(DEFAULT_WAIT_FOR_TIMEOUT_MS);
+
+    await rejection;
+  });
+});

--- a/libraries/typescript/packages/cli/tests/cli/helpers.ts
+++ b/libraries/typescript/packages/cli/tests/cli/helpers.ts
@@ -14,6 +14,7 @@ import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const serverPackageRoot = join(here, "..", "..", "..", "server");
+export const DEFAULT_WAIT_FOR_TIMEOUT_MS = 45000;
 
 /** Absolute path to the committed basic fixture project. */
 export const FIXTURE_BASIC = join(here, "fixtures", "basic");
@@ -133,7 +134,7 @@ export async function listToolNames(baseUrl: string): Promise<string[]> {
 /** Poll `probe` until it resolves truthy or the timeout elapses. */
 export async function waitFor<T>(
   probe: () => Promise<T | undefined>,
-  { timeout = 15000, interval = 200 } = {}
+  { timeout = DEFAULT_WAIT_FOR_TIMEOUT_MS, interval = 200 } = {}
 ): Promise<T> {
   const deadline = Date.now() + timeout;
   let lastError: unknown;


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

Check all that apply:
- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [x] CI/CD or tooling

## Changes

`waitFor` in the CLI test helpers now uses a 45s default timeout instead of 15s, keeping the polling budget closer to the 60s Vitest timeout used by the same package. This gives dev-server startup probes more room on slow CI runners while preserving the helper's existing `last error` diagnostics.

## Review Readiness

- [x] The PR is scoped to one issue or one clearly related change
- [x] The PR description explains the user-visible problem and the fix
- [x] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [x] I verified the affected package/docs path with the commands listed below
- [x] I checked for existing open PRs that already solve the same issue

## Implementation Details

1. Added `DEFAULT_WAIT_FOR_TIMEOUT_MS = 45000` next to the CLI helper implementation.
2. Switched the `waitFor` default timeout to that constant.
3. Added a fake-timer regression test so the default budget is covered without making the suite wait 45 seconds.

---

## TypeScript Checklist

### Packages Modified

Check all packages that were modified:
- [ ] `docs`
- [x] `tests`
- [x] `cli`
- [ ] `create-mcp-use-app`
- [ ] `mcp-use` (server)
- [ ] `mcp-use` (client)
- [ ] `inspector`

### Pre-commit Checklist

Ensure all of the following have been completed:
- [ ] Ran `pnpm lint:fix` to auto-fix linting issues
- [x] Ran `pnpm format` to format code with Prettier
- [ ] Ran `pnpm build` and build succeeds without errors
- [ ] Ran `pnpm changeset` to create a changeset (if this PR includes user-facing changes)
- [x] Added or updated tests if needed
- [ ] Updated documentation in `docs/` folder if needed

---

## Example Usage (Before)

```text
CI dev-server probes could fail after 15s even though the Vitest test still had 60s available.
```

## Example Usage (After)

```text
The same probes wait up to 45s before failing, still below the surrounding test timeout.
```

## Documentation Updates

No documentation changes. This only affects internal CLI tests.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm --filter @mcp-use/cli exec vitest run tests/cli/helpers.test.ts`
- `pnpm --filter @mcp-use/agent run build`
- `pnpm --filter @mcp-use/inspector run build`
- `pnpm --filter mcp-use run build`
- `pnpm --filter @mcp-use/cli run typecheck`
- `pnpm --filter @mcp-use/cli exec prettier --check tests/cli/helpers.ts tests/cli/helpers.test.ts`
- `pnpm --filter @mcp-use/cli exec vitest run tests/cli/dev.test.ts -t "reloads skill files when the configured skills directory overlaps views"`
- `pnpm --filter @mcp-use/cli exec vitest run tests/cli/helpers.test.ts tests/cli/dev.test.ts`

Risk boundary: this addresses the short polling budget called out in #2273. It does not change the `getFreePort` time-of-check/time-of-use behavior, so a true port race can still need a separate fix.

## Backwards Compatibility

Backwards compatible. This only changes test helper behavior and does not affect published runtime code.

## Related Issues

Closes #2273

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increases the `waitFor` helper's default timeout from 15s to 45s in `@mcp-use/cli` test helpers so dev-server startup probes have more time on slow CI runners, staying under the 60s Vitest test budget. Adds a fake-timer test that covers the default without waiting 45s. Closes #2273.

<sup>Written for commit 2ead93c4bb37788a3b827c34193165ee33b588bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

