### PR TITLE
fix(cli): isolate dev test cleanup failures

### DIFF
--- a/libraries/typescript/packages/cli/tests/cli/dev.test.ts
+++ b/libraries/typescript/packages/cli/tests/cli/dev.test.ts
@@ -62,18 +62,32 @@ beforeEach(() => {
 
 afterEach(async () => {
   tunnelState.url = null;
-  while (cleanups.length > 0) {
-    await cleanups.pop()?.();
+  const errors: unknown[] = [];
+  try {
+    while (cleanups.length > 0) {
+      try {
+        await cleanups.pop()?.();
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+  } finally {
+    if (originalMcpUrl === undefined) {
+      delete process.env["MCP_URL"];
+    } else {
+      process.env["MCP_URL"] = originalMcpUrl;
+    }
+    if (originalPort === undefined) {
+      delete process.env["PORT"];
+    } else {
+      process.env["PORT"] = originalPort;
+    }
   }
-  if (originalMcpUrl === undefined) {
-    delete process.env["MCP_URL"];
-  } else {
-    process.env["MCP_URL"] = originalMcpUrl;
+  if (errors.length === 1) {
+    throw errors[0];
   }
-  if (originalPort === undefined) {
-    delete process.env["PORT"];
-  } else {
-    process.env["PORT"] = originalPort;
+  if (errors.length > 1) {
+    throw new AggregateError(errors, "test cleanup failed");
   }
 });
 

--- a/libraries/typescript/packages/cli/tests/cli/helpers.ts
+++ b/libraries/typescript/packages/cli/tests/cli/helpers.ts
@@ -46,7 +46,16 @@ export function copyFixture(
 
 /** Remove a scratch dir, ignoring failures. */
 export function removeDir(dir: string): void {
-  rmSync(dir, { recursive: true, force: true });
+  try {
+    rmSync(dir, {
+      recursive: true,
+      force: true,
+      maxRetries: 5,
+      retryDelay: 100,
+    });
+  } catch {
+    // best effort: Vite may still be finishing optimizer temp cleanup.
+  }
 }
 
 /** Bind the basic fixture's add tool to a named view for CLI error tests. */


### PR DESCRIPTION
## Summary

Addresses the Ubuntu teardown path discussed in #2273.

This keeps the `waitFor` timeout unchanged and instead isolates cleanup failures so one failed fixture removal cannot leak `MCP_URL`/`PORT` into later dev tests.

Changes:
- restore `MCP_URL` and `PORT` from `afterEach` in a `finally` block
- continue running remaining cleanup callbacks even when one cleanup throws
- make `removeDir` match its best-effort comment by retrying transient recursive removal failures and swallowing the final failure

## Validation

- `pnpm --filter @mcp-use/cli exec vitest run tests/cli/dev.test.ts` - 34 passed
- `pnpm --filter @mcp-use/cli run typecheck` - passed
- `pnpm --filter @mcp-use/cli exec prettier --check tests/cli/helpers.ts tests/cli/dev.test.ts` - passed

## Risk / boundary

This only changes test cleanup behavior. It does not change runtime CLI behavior, port allocation, or the shared `waitFor` timeout. If the Windows watcher issue is still present, it should be handled separately as discussed in #2273.

No changeset: test-only change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dev test cleanup so one failed fixture removal can't leak `MCP_URL` or `PORT` into later tests.

- Restores `MCP_URL` and `PORT` in a `finally` block, so they're reset even when cleanup throws.
- Runs all cleanup callbacks even if one fails, then reports the first error (or an `AggregateError` for multiple).
- Makes `removeDir` retry transient recursive removals and swallow the final failure to match its best-effort intent.

Test-only change; no runtime CLI behavior, port allocation, or shared timeout changes. No changeset required.

<sup>Written for commit a6dacc866d153648d8d09b090063ad1678225df6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

