### PR TITLE
test(cli): let Windows use native file watching

### DIFF
--- a/libraries/typescript/.changeset/windows-native-watch.md
+++ b/libraries/typescript/.changeset/windows-native-watch.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/cli": patch
+---
+
+Use Vite's native file watching on Windows instead of forcing 100ms polling. Polling delays the watcher's initial scan, which can swallow an edit made during startup so no change event is ever emitted.

--- a/libraries/typescript/packages/cli/src/cli/dev.ts
+++ b/libraries/typescript/packages/cli/src/cli/dev.ts
@@ -468,12 +468,6 @@ export async function runDev(options: DevOptions): Promise<void> {
         // broadcast `full-reload` forever, so srcdoc view guests repeatedly
         // remount and surface a compiling spinner instead of Fast Refresh.
         ignored: "**/.dev-server-logs.txt",
-        // Windows file notifications can be coalesced or dropped while Vite
-        // is transforming the same module. Polling keeps dev reloads reliable.
-        ...(process.platform === "win32" && {
-          usePolling: true,
-          interval: 100,
-        }),
       },
       // A public/wildcard bind deliberately accepts hostnames that are only
       // known to the surrounding platform (for example a sandbox URL). Keep

--- a/libraries/typescript/packages/cli/tests/cli/dev.test.ts
+++ b/libraries/typescript/packages/cli/tests/cli/dev.test.ts
@@ -432,7 +432,7 @@ describe("runDev", () => {
       })
     ).toMatchObject({ result: { contents: [{ text: "Guidance v1\n" }] } });
 
-    writeFileSync(guide, "Guidance v2\n");
+    writeFileSync(guide, "Skills Guidance v2\n");
     await waitFor(async () => {
       const body = await mcpRequest(dev.url, "resources/read", {
         uri: "skill://product-search-result/guide.md",
@@ -440,7 +440,9 @@ describe("runDev", () => {
       const result = body["result"] as {
         contents?: Array<{ text?: string }>;
       };
-      return result.contents?.[0]?.text === "Guidance v2\n" ? true : undefined;
+      return result.contents?.[0]?.text === "Skills Guidance v2\n"
+        ? true
+        : undefined;
     });
   });
 


### PR DESCRIPTION
The experiment you asked for in #2273. **The point of this PR is the Windows CI result, not the diff.**

## What it removes

```diff
         ignored: "**/.dev-server-logs.txt",
-        // Windows file notifications can be coalesced or dropped while Vite
-        // is transforming the same module. Polling keeps dev reloads reliable.
-        ...(process.platform === "win32" && {
-          usePolling: true,
-          interval: 100,
-        }),
```

## Why it is worth running

Your reading of it holds up on the parts I could check. Polling makes chokidar's initial scan much slower, and if a test writes a file before that scan finishes, the new contents become the baseline and no change event is ever emitted. That is unfixable by a longer timeout, and it matches the observed signature exactly: a `waitFor` timeout with **no** `; last error:` suffix, meaning the probe never threw, it just never became true.

What I could not check locally is whether the scan is actually still running at that moment on Windows. On macOS with native watching it is not:

```
[probe] at attach: _readyEmitted=true closed=false
[mcp-use] dev server ready
```

So the race does not exist on this platform, which is why this needs the Windows runner rather than my machine.

## How to read the result

- **Windows job green, repeatedly:** native watching is fine here and the override can go for good. This PR becomes the fix.
- **Windows job red in a new way:** the original comment was right about dropped notifications, we keep polling, and the real fix is folding watcher initialisation into the dev server's readiness boundary.

I am happy to close this the moment it has told us which. If you would rather it also print watcher events on Windows to make the answer unambiguous, say so and I will add that.

## Local state

Unaffected, since the override never applied off Windows: `dev.test.ts` 34 passed, 34 total. Preflight clean.

## One thing to flag about the fallback

If the answer turns out to be the readiness boundary, that fix has no public chokidar API behind it. `once("ready")` cannot be used safely, because the event has usually already fired by the time `dev.ts` subscribes, and `_readyEmitted` is private. Worth knowing before anyone starts on it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the Windows-only 100ms polling override in the `@mcp-use/cli` dev server so Windows uses Vite's native file watching, the experiment requested in #2273. Polling slows chokidar's initial scan and can swallow an edit written before the scan finishes, which matches the Windows-only `waitFor` timeouts in `dev.test.ts`; the point of this PR is the Windows CI result, not the diff.

The `dev.test.ts` edit now writes a different-length string so the update is reliably distinguishable from the initial content.

**Reading the Windows CI result**
- Windows green repeatedly: native watching is fine, keep the override removed, and this PR is the fix.
- Windows red in a new way: the dropped-notification concern holds; keep polling and fold watcher initialization into the dev server's readiness boundary.
- The readiness fix has no public chokidar API: `once("ready")` fires before `dev.ts` subscribes, and `_readyEmitted` is private.
- Local run is unaffected since the override never applied off Windows (`dev.test.ts` 34 passed), and a patch changeset is included.

<sup>Written for commit 44ff5ec38381f6ef9de15553253071fd7a938185. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

