### PR TITLE
refactor(server): bind OAuth providers once per mount

### DIFF
--- a/libraries/typescript/.changeset/pre.json
+++ b/libraries/typescript/.changeset/pre.json
@@ -1,0 +1,14 @@
+{
+  "mode": "pre",
+  "tag": "canary",
+  "initialVersions": {
+    "@mcp-use/agent": "2.0.10",
+    "@mcp-use/cli": "4.1.7",
+    "@mcp-use/client": "2.2.1",
+    "create-mcp-use-app": "2.0.5",
+    "@mcp-use/inspector": "20.3.2",
+    "mcp-use": "2.3.3",
+    "@mcp-use/tunnel": "0.2.0"
+  },
+  "changesets": []
+}

--- a/libraries/typescript/packages/server/src/oauth/adapters.ts
+++ b/libraries/typescript/packages/server/src/oauth/adapters.ts
@@ -6,8 +6,12 @@ import {
 } from "@modelcontextprotocol/server";
 
 import { getRequestBag, type FetchMiddleware } from "../fetch-app.js";
-import { getOAuthProviderOptions, wrapOAuthTokenVerifier } from "./internal.js";
-import type { OAuthProvider } from "./provider.js";
+import {
+  bindOAuthProvider,
+  getOAuthProviderOptions,
+  wrapBoundOAuthTokenVerifier,
+} from "./internal.js";
+import type { BoundOAuthProvider, OAuthProvider } from "./provider.js";
 
 /**
  * Fetch middleware that requires a bearer token for a canonical resource.
@@ -20,10 +24,19 @@ export function bearerAuth<TUser>(
   provider: OAuthProvider<TUser>,
   resource: URL
 ): FetchMiddleware {
-  const options = getOAuthProviderOptions(provider);
+  return bearerAuthForBoundProvider(bindOAuthProvider(provider, resource));
+}
+
+/** @internal Creates bearer auth middleware from an existing provider binding. */
+export function bearerAuthForBoundProvider<TUser>(
+  boundProvider: BoundOAuthProvider<TUser>
+): FetchMiddleware {
+  const options = getOAuthProviderOptions(boundProvider.provider);
   const gate = requireBearerAuth({
-    verifier: wrapOAuthTokenVerifier(provider, resource),
-    resourceMetadataUrl: getOAuthProtectedResourceMetadataUrl(resource),
+    verifier: wrapBoundOAuthTokenVerifier(boundProvider),
+    resourceMetadataUrl: getOAuthProtectedResourceMetadataUrl(
+      boundProvider.resource
+    ),
     ...(options.requiredScopes !== undefined && {
       requiredScopes: [...options.requiredScopes],
     }),
@@ -47,6 +60,23 @@ export function bearerAuth<TUser>(
  * @param resource - Canonical public MCP endpoint URL.
  */
 export function oauthMetadata<TUser>(
+  provider: OAuthProvider<TUser>,
+  resource: URL
+): FetchMiddleware {
+  return createOAuthMetadataMiddleware(provider, resource);
+}
+
+/** @internal Creates discovery middleware from an existing provider binding. */
+export function oauthMetadataForBoundProvider<TUser>(
+  boundProvider: BoundOAuthProvider<TUser>
+): FetchMiddleware {
+  return createOAuthMetadataMiddleware(
+    boundProvider.provider,
+    boundProvider.resource
+  );
+}
+
+function createOAuthMetadataMiddleware<TUser>(
   provider: OAuthProvider<TUser>,
   resource: URL
 ): FetchMiddleware {

--- a/libraries/typescript/packages/server/src/oauth/internal.ts
+++ b/libraries/typescript/packages/server/src/oauth/internal.ts
@@ -10,7 +10,11 @@ import {
   parseAbsoluteUrl,
 } from "./guards.js";
 import { invalidToken } from "./errors.js";
-import type { OAuthExtra, OAuthProvider } from "./provider.js";
+import type {
+  BoundOAuthProvider,
+  OAuthExtra,
+  OAuthProvider,
+} from "./provider.js";
 
 export {
   assertSecureHttpUrl,
@@ -80,11 +84,11 @@ export function validateOAuthResource(
   return url;
 }
 
-/** @internal Wraps a provider verifier with mcp-use's verified auth mapping. */
-export function wrapOAuthTokenVerifier<TUser>(
+/** @internal Binds a provider to one canonical resource and creates its verifier. */
+export function bindOAuthProvider<TUser>(
   provider: OAuthProvider<TUser>,
   expectedResource: URL
-): OAuthTokenVerifier {
+): BoundOAuthProvider<TUser> {
   const canonicalResource = normalizeResourceUrl(expectedResource);
   const tokenVerifier = provider.createTokenVerifier(
     new URL(canonicalResource.href)
@@ -98,6 +102,23 @@ export function wrapOAuthTokenVerifier<TUser>(
       "OAuth provider createTokenVerifier must return an OAuthTokenVerifier"
     );
   }
+
+  return {
+    provider,
+    resource: canonicalResource,
+    tokenVerifier,
+  };
+}
+
+/** @internal Wraps a bound verifier with mcp-use's verified auth mapping. */
+export function wrapBoundOAuthTokenVerifier<TUser>(
+  boundProvider: BoundOAuthProvider<TUser>
+): OAuthTokenVerifier {
+  const {
+    provider,
+    resource: canonicalResource,
+    tokenVerifier,
+  } = boundProvider;
 
   return {
     async verifyAccessToken(token: string): Promise<AuthInfo> {
@@ -120,6 +141,20 @@ export function wrapOAuthTokenVerifier<TUser>(
       };
     },
   };
+}
+
+/**
+ * @internal Wraps a provider verifier with mcp-use's verified auth mapping.
+ * Prefer binding once and calling {@link wrapBoundOAuthTokenVerifier} when a
+ * provider is shared by multiple pieces of mount wiring.
+ */
+export function wrapOAuthTokenVerifier<TUser>(
+  provider: OAuthProvider<TUser>,
+  expectedResource: URL
+): OAuthTokenVerifier {
+  return wrapBoundOAuthTokenVerifier(
+    bindOAuthProvider(provider, expectedResource)
+  );
 }
 
 function assertResourceBinding(

--- a/libraries/typescript/packages/server/src/oauth/provider.ts
+++ b/libraries/typescript/packages/server/src/oauth/provider.ts
@@ -45,6 +45,16 @@ export interface CustomOAuthProviderOptions<
 /** OAuth resource-server provider accepted by the mcp-use server constructor. */
 export type OAuthProvider<TUser> = CustomOAuthProviderOptions<TUser>;
 
+/** OAuth provider state bound to one canonical MCP resource. @internal */
+export interface BoundOAuthProvider<TUser> {
+  /** Original provider, retained so callback invocation semantics stay intact. */
+  readonly provider: OAuthProvider<TUser>;
+  /** Canonical protected-resource identity for this server mount. */
+  readonly resource: URL;
+  /** Provider verifier created for {@link resource}. */
+  readonly tokenVerifier: OAuthTokenVerifier;
+}
+
 /**
  * Creates an OAuth provider backed by an external authorization server.
  *

--- a/libraries/typescript/packages/server/src/server.ts
+++ b/libraries/typescript/packages/server/src/server.ts
@@ -69,15 +69,14 @@ import { normalizeCompletions } from "./resource-completion.js";
 import { registerOpenAPITools } from "./openapi/index.js";
 import type { FromOpenAPIOptions } from "./openapi/types.js";
 import {
-  getOAuthProtectedResourceMetadataUrl,
-  requireBearerAuth,
-} from "./oauth/index.js";
-import { authInfoFromRequest, oauthMetadata } from "./oauth/adapters.js";
+  authInfoFromRequest,
+  bearerAuthForBoundProvider,
+  oauthMetadataForBoundProvider,
+} from "./oauth/adapters.js";
 import {
-  getOAuthProviderOptions,
+  bindOAuthProvider,
   resolveConfiguredOAuthResource,
   resolveLocalOAuthResource,
-  wrapOAuthTokenVerifier,
 } from "./oauth/internal.js";
 import type {
   InferPromptInput,
@@ -1390,9 +1389,12 @@ export class MCPServer<TUser = never, TEnv extends Env = Env> {
       this.#validateViewBindingsAtMount();
 
       const resource = this.#resolveOAuthResource(mode, listenPort, listenHost);
-      if (resource !== undefined) {
-        const provider = this.#config.oauth!;
-        middlewares.push(oauthMetadata(provider, resource));
+      const boundOAuthProvider =
+        resource === undefined
+          ? undefined
+          : bindOAuthProvider(this.#config.oauth!, resource);
+      if (boundOAuthProvider !== undefined) {
+        middlewares.push(oauthMetadataForBoundProvider(boundOAuthProvider));
       }
 
       for (const middleware of middlewares) {
@@ -1422,25 +1424,8 @@ export class MCPServer<TUser = never, TEnv extends Env = Env> {
         request: Request,
         next: () => Promise<Response>
       ) => Promise<Response> = async (_request, next) => next();
-      if (resource !== undefined) {
-        const provider = this.#config.oauth!;
-        const providerOptions = getOAuthProviderOptions(provider);
-        const gate = requireBearerAuth({
-          verifier: wrapOAuthTokenVerifier(provider, resource),
-          resourceMetadataUrl: getOAuthProtectedResourceMetadataUrl(resource),
-          ...(providerOptions.requiredScopes !== undefined && {
-            requiredScopes: providerOptions.requiredScopes,
-          }),
-        });
-        protectWithBearer = async (request, next) => {
-          const result = await gate(request);
-          if (result instanceof Response) {
-            return result;
-          }
-          const bag = getRequestBag(request);
-          bag.authInfo = result;
-          return next();
-        };
+      if (boundOAuthProvider !== undefined) {
+        protectWithBearer = bearerAuthForBoundProvider(boundOAuthProvider);
 
         // Authenticate the exact MCP route before the user-owned Hono app
         // runs. This makes verified identity available to route middleware

--- a/libraries/typescript/packages/server/tests/oauth-routes-resource.test.ts
+++ b/libraries/typescript/packages/server/tests/oauth-routes-resource.test.ts
@@ -84,6 +84,58 @@ function challenge(response: Response): string {
 }
 
 describe("OAuth HTTP route acceptance", () => {
+  it("creates one token verifier for the mounted OAuth provider", async () => {
+    let verifierCreations = 0;
+    const structuralProvider = {
+      resource: "https://canonical.example.test/mcp",
+      createTokenVerifier: (resource: URL) => {
+        verifierCreations += 1;
+        return {
+          verifyAccessToken: async (token: string) => ({
+            token,
+            clientId: "test-client",
+            scopes: ["tools:read"],
+            expiresAt: Date.now() / 1000 + 60,
+            resource,
+          }),
+        };
+      },
+      oauthMetadata: { issuer } as OAuthMetadata,
+      mapAuthInfo: () => ({
+        user: { id: "user-1" },
+        payload: { sub: "user-1" },
+        permissions: ["tools:read"],
+      }),
+    };
+    const oauthServer = new MCPServer({
+      name: "oauth-binding-test",
+      version: "1.0.0",
+      oauth: structuralProvider,
+    });
+
+    expect(verifierCreations).toBe(0);
+
+    const metadata = await oauthServer.fetch(
+      request("/.well-known/oauth-protected-resource/mcp")
+    );
+    expect(metadata.status).toBe(200);
+    expect(await metadata.json()).toMatchObject({
+      resource: "https://canonical.example.test/mcp",
+      authorization_servers: [issuer],
+    });
+
+    for (const token of ["first-token", "second-token"]) {
+      const response = await oauthServer.fetch(
+        request("/mcp", {
+          method: "POST",
+          headers: { authorization: `Bearer ${token}` },
+        })
+      );
+      expect(response.status).not.toBe(401);
+    }
+    expect(verifierCreations).toBe(1);
+  });
+
   it("returns OAuth wire errors and a canonical path-aware challenge", async () => {
     const handler = server({
       basePath: "/api/mcp",


### PR DESCRIPTION
## Summary

Foundation for the OAuth Proxy stack. OAuth providers are now bound to the canonical MCP resource once per server mount, so discovery metadata and bearer verification share the same provider instance.

## Review focus

- Introduces the internal bound-provider contract without changing existing provider APIs.
- Avoids constructing token verifiers multiple times during one mount.
- Keeps `wrapOAuthTokenVerifier` available as a compatibility helper.

## Validation

- Added a regression test proving the verifier is created once per mount.
- Included in the full OAuth run: 13 test files, 137 tests.
- Server typecheck, build, ESLint, and Prettier pass.

This is PR 1 of 8 in the OAuth Proxy stack. Next: #2340.
