### PR TITLE
feat(server): add OAuth proxy storage foundation

### DIFF
--- a/libraries/typescript/packages/server/src/oauth/proxy/encryption.ts
+++ b/libraries/typescript/packages/server/src/oauth/proxy/encryption.ts
@@ -1,0 +1,278 @@
+const ENVELOPE_VERSION = 1;
+const ENVELOPE_ALGORITHM = "A256GCM";
+const IV_BYTES = 12;
+const KEY_BYTES = 32;
+const AAD_SCHEMA = "mcp-use/oauth-proxy/byte-payload/v1";
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder("utf-8", { fatal: true });
+
+/** @internal One named, raw AES-256 key in an OAuth proxy encryption keyring. */
+export interface OAuthProxyEncryptionKey {
+  /** Non-empty identifier serialized with ciphertext for later key rotation. */
+  readonly id: string;
+  /** Exactly 32 bytes of raw key material; passphrases are not accepted. */
+  readonly key: Uint8Array;
+}
+
+/** @internal SDK-managed encryption configuration for persisted proxy payloads. */
+export interface OAuthProxyEncryptionOptions {
+  /** Key identifier used for new writes. */
+  readonly primaryKeyId: string;
+  /** Keyring used to encrypt new values and decrypt values written by old keys. */
+  readonly keys: readonly OAuthProxyEncryptionKey[];
+  /** Web Crypto implementation, primarily for isolated runtimes and tests. */
+  readonly crypto?: Pick<Crypto, "getRandomValues" | "subtle">;
+}
+
+/** @internal Byte-oriented persistence codec, independent of OAuth record schemas. */
+export interface OAuthProxyPayloadCodec {
+  /** Encodes a payload, binding it to its stable store key as authenticated data. */
+  encode(storeKey: string, payload: Uint8Array): Promise<Uint8Array>;
+  /** Decodes a payload and fails closed if its envelope or authentication is invalid. */
+  decode(storeKey: string, serialized: Uint8Array): Promise<Uint8Array>;
+}
+
+interface EncryptionEnvelope {
+  readonly v: typeof ENVELOPE_VERSION;
+  readonly alg: typeof ENVELOPE_ALGORITHM;
+  readonly kid: string;
+  readonly iv: string;
+  readonly ciphertext: string;
+}
+
+/** @internal Creates a versioned AES-256-GCM codec from a validated raw-key keyring. */
+export function createOAuthProxyEncryptionCodec(
+  options: OAuthProxyEncryptionOptions
+): OAuthProxyPayloadCodec {
+  const validated = validateOptions(options);
+  const importedKeys = new Map<string, Promise<CryptoKey>>();
+
+  const importKey = (id: string): Promise<CryptoKey> => {
+    let imported = importedKeys.get(id);
+    if (imported !== undefined) {
+      return imported;
+    }
+    const raw = validated.keys.get(id);
+    if (raw === undefined) {
+      return Promise.reject(new Error("Unknown OAuth proxy encryption key"));
+    }
+    imported = validated.crypto.subtle.importKey(
+      "raw",
+      raw,
+      { name: "AES-GCM", length: 256 },
+      false,
+      ["encrypt", "decrypt"]
+    );
+    importedKeys.set(id, imported);
+    return imported;
+  };
+
+  return {
+    async encode(storeKey, payload) {
+      assertStoreKey(storeKey);
+      assertBytes(payload, "payload");
+      const iv = new Uint8Array(IV_BYTES);
+      validated.crypto.getRandomValues(iv);
+      const ciphertext = await validated.crypto.subtle.encrypt(
+        {
+          name: "AES-GCM",
+          iv,
+          additionalData: additionalData(storeKey),
+          tagLength: 128,
+        },
+        await importKey(validated.primaryKeyId),
+        copyToArrayBuffer(payload)
+      );
+      const envelope: EncryptionEnvelope = {
+        v: ENVELOPE_VERSION,
+        alg: ENVELOPE_ALGORITHM,
+        kid: validated.primaryKeyId,
+        iv: encodeBase64Url(iv),
+        ciphertext: encodeBase64Url(new Uint8Array(ciphertext)),
+      };
+      return textEncoder.encode(JSON.stringify(envelope));
+    },
+
+    async decode(storeKey, serialized) {
+      assertStoreKey(storeKey);
+      assertBytes(serialized, "serialized payload");
+      try {
+        const envelope = parseEnvelope(serialized);
+        const key = await importKey(envelope.kid);
+        const plaintext = await validated.crypto.subtle.decrypt(
+          {
+            name: "AES-GCM",
+            iv: decodeBase64Url(envelope.iv),
+            additionalData: additionalData(storeKey),
+            tagLength: 128,
+          },
+          key,
+          decodeBase64Url(envelope.ciphertext)
+        );
+        return new Uint8Array(plaintext);
+      } catch {
+        throw new Error("Unable to decrypt OAuth proxy payload");
+      }
+    },
+  };
+}
+
+/** @internal Pass-through byte codec used only where plaintext storage is safe. */
+export function createOAuthProxyPlaintextCodec(): OAuthProxyPayloadCodec {
+  return {
+    async encode(storeKey, payload) {
+      assertStoreKey(storeKey);
+      assertBytes(payload, "payload");
+      return Uint8Array.from(payload);
+    },
+    async decode(storeKey, serialized) {
+      assertStoreKey(storeKey);
+      assertBytes(serialized, "serialized payload");
+      return Uint8Array.from(serialized);
+    },
+  };
+}
+
+function validateOptions(options: OAuthProxyEncryptionOptions): {
+  readonly primaryKeyId: string;
+  readonly keys: ReadonlyMap<string, Uint8Array<ArrayBuffer>>;
+  readonly crypto: Pick<Crypto, "getRandomValues" | "subtle">;
+} {
+  if (typeof options !== "object" || options === null) {
+    throw new TypeError("OAuth proxy encryption options must be an object");
+  }
+  const primaryKeyId = requireKeyId(options.primaryKeyId, "primaryKeyId");
+  if (!Array.isArray(options.keys) || options.keys.length === 0) {
+    throw new TypeError(
+      "OAuth proxy encryption keys must be a non-empty array"
+    );
+  }
+  const keys = new Map<string, Uint8Array<ArrayBuffer>>();
+  const candidates: readonly unknown[] = options.keys;
+  for (const candidate of candidates) {
+    if (typeof candidate !== "object" || candidate === null) {
+      throw new TypeError("Each OAuth proxy encryption key must be an object");
+    }
+    const record = candidate as Record<string, unknown>;
+    const id = requireKeyId(record.id, "encryption key id");
+    if (keys.has(id)) {
+      throw new TypeError(`Duplicate OAuth proxy encryption key id: ${id}`);
+    }
+    assertBytes(record.key, `encryption key ${id}`);
+    if (record.key.byteLength !== KEY_BYTES) {
+      throw new TypeError(`OAuth proxy encryption key ${id} must be 32 bytes`);
+    }
+    keys.set(id, new Uint8Array(copyToArrayBuffer(record.key)));
+  }
+  if (!keys.has(primaryKeyId)) {
+    throw new TypeError(
+      "OAuth proxy encryption primaryKeyId is not in the keyring"
+    );
+  }
+  const cryptoImplementation = options.crypto ?? globalThis.crypto;
+  if (
+    typeof cryptoImplementation !== "object" ||
+    cryptoImplementation === null ||
+    typeof cryptoImplementation.getRandomValues !== "function" ||
+    typeof cryptoImplementation.subtle !== "object" ||
+    cryptoImplementation.subtle === null
+  ) {
+    throw new TypeError("OAuth proxy encryption requires Web Crypto");
+  }
+  return { primaryKeyId, keys, crypto: cryptoImplementation };
+}
+
+function parseEnvelope(serialized: Uint8Array): EncryptionEnvelope {
+  const value: unknown = JSON.parse(textDecoder.decode(serialized));
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("Malformed OAuth proxy encryption envelope");
+  }
+  const record = value as Record<string, unknown>;
+  if (
+    Object.keys(record).length !== 5 ||
+    record.v !== ENVELOPE_VERSION ||
+    record.alg !== ENVELOPE_ALGORITHM ||
+    typeof record.kid !== "string" ||
+    record.kid.length === 0 ||
+    typeof record.iv !== "string" ||
+    typeof record.ciphertext !== "string"
+  ) {
+    throw new Error("Malformed OAuth proxy encryption envelope");
+  }
+  const iv = decodeBase64Url(record.iv);
+  const ciphertext = decodeBase64Url(record.ciphertext);
+  if (iv.byteLength !== IV_BYTES || ciphertext.byteLength < 16) {
+    throw new Error("Malformed OAuth proxy encryption envelope");
+  }
+  return {
+    v: ENVELOPE_VERSION,
+    alg: ENVELOPE_ALGORITHM,
+    kid: record.kid,
+    iv: record.iv,
+    ciphertext: record.ciphertext,
+  };
+}
+
+function additionalData(storeKey: string): Uint8Array<ArrayBuffer> {
+  return new Uint8Array(
+    copyToArrayBuffer(textEncoder.encode(`${AAD_SCHEMA}\0${storeKey}`))
+  );
+}
+
+function requireKeyId(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new TypeError(`${label} must be a non-empty string`);
+  }
+  return value;
+}
+
+function assertStoreKey(storeKey: string): void {
+  if (typeof storeKey !== "string" || storeKey.length === 0) {
+    throw new TypeError("OAuth proxy store key must be a non-empty string");
+  }
+}
+
+function assertBytes(
+  value: unknown,
+  label: string
+): asserts value is Uint8Array {
+  if (!(value instanceof Uint8Array)) {
+    throw new TypeError(`${label} must be a Uint8Array`);
+  }
+}
+
+function encodeBase64Url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary)
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/u, "");
+}
+
+function decodeBase64Url(value: string): Uint8Array<ArrayBuffer> {
+  if (!/^[A-Za-z0-9_-]+$/u.test(value)) {
+    throw new Error("Invalid base64url value");
+  }
+  const padding = "=".repeat((4 - (value.length % 4)) % 4);
+  const binary = atob(
+    value.replaceAll("-", "+").replaceAll("_", "/") + padding
+  );
+  const result = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    result[index] = binary.charCodeAt(index);
+  }
+  if (encodeBase64Url(result) !== value) {
+    throw new Error("Non-canonical base64url value");
+  }
+  return result;
+}
+
+function copyToArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const result = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(result).set(bytes);
+  return result;
+}

--- a/libraries/typescript/packages/server/src/oauth/proxy/encryption.ts
+++ b/libraries/typescript/packages/server/src/oauth/proxy/encryption.ts
@@ -176,7 +176,10 @@ function validateOptions(options: OAuthProxyEncryptionOptions): {
     cryptoImplementation === null ||
     typeof cryptoImplementation.getRandomValues !== "function" ||
     typeof cryptoImplementation.subtle !== "object" ||
-    cryptoImplementation.subtle === null
+    cryptoImplementation.subtle === null ||
+    typeof cryptoImplementation.subtle.importKey !== "function" ||
+    typeof cryptoImplementation.subtle.encrypt !== "function" ||
+    typeof cryptoImplementation.subtle.decrypt !== "function"
   ) {
     throw new TypeError("OAuth proxy encryption requires Web Crypto");
   }

--- a/libraries/typescript/packages/server/src/oauth/proxy/store.ts
+++ b/libraries/typescript/packages/server/src/oauth/proxy/store.ts
@@ -1,0 +1,596 @@
+import {
+  createOAuthProxyEncryptionCodec,
+  createOAuthProxyPlaintextCodec,
+  type OAuthProxyEncryptionOptions,
+  type OAuthProxyPayloadCodec,
+} from "./encryption.js";
+
+const MAX_KEY_BYTES = 1024;
+const MAX_PAYLOAD_BYTES = 1024 * 1024;
+const MAX_STORED_PAYLOAD_BYTES = 2 * 1024 * 1024;
+const MAX_TRANSACTION_KEYS = 64;
+const MAX_TRANSACTION_KEY_DECLARATIONS = 256;
+const textEncoder = new TextEncoder();
+
+/** @internal Persistence and at-rest secret-protection guarantees of a proxy store. */
+export interface OAuthProxyStoreCapabilities {
+  /** Whether values survive process restart. */
+  readonly persistence: "process-local" | "persistent";
+  /** Whether the store itself encrypts secret payloads before persistence. */
+  readonly secretProtection: "none" | "store-encrypted";
+}
+
+/** @internal Result of creating a new non-overwriting proxy store entry. */
+export type OAuthProxyStoreCreateResult =
+  | { readonly status: "created" }
+  | { readonly status: "conflict" };
+
+/** @internal Result of reading a proxy store entry. */
+export type OAuthProxyStoreReadResult =
+  | { readonly status: "found"; readonly payload: Uint8Array }
+  | { readonly status: "missing" }
+  | { readonly status: "replayed" };
+
+/** @internal Result of atomically consuming a one-time proxy store entry. */
+export type OAuthProxyStoreConsumeResult =
+  | { readonly status: "consumed"; readonly payload: Uint8Array }
+  | { readonly status: "missing" }
+  | { readonly status: "replayed" };
+
+/** @internal Result of replacing an existing live proxy store entry. */
+export type OAuthProxyStoreReplaceResult =
+  | { readonly status: "replaced" }
+  | { readonly status: "missing" }
+  | { readonly status: "replayed" };
+
+/** @internal Operations available inside one serializable proxy store transaction. */
+export interface OAuthProxyStoreTransaction {
+  /** Creates a declared key without overwriting a live value or tombstone. */
+  create(
+    key: string,
+    payload: Uint8Array,
+    expiresAt: number
+  ): Promise<OAuthProxyStoreCreateResult>;
+  /** Reads a declared key without consuming it. */
+  read(key: string): Promise<OAuthProxyStoreReadResult>;
+  /** Replaces a declared live value but never creates or resurrects an entry. */
+  replace(
+    key: string,
+    payload: Uint8Array,
+    expiresAt: number
+  ): Promise<OAuthProxyStoreReplaceResult>;
+  /** Replaces a declared live entry with a tombstone and returns its payload once. */
+  consume(key: string): Promise<OAuthProxyStoreConsumeResult>;
+}
+
+/**
+ * @internal Byte-oriented storage boundary for OAuth proxy secrets. Implementations
+ * must make all operations serializable across every process sharing the store.
+ */
+export interface OAuthProxyStore extends OAuthProxyStoreTransaction {
+  /** Explicit persistence and secret-protection guarantees. */
+  readonly capabilities: OAuthProxyStoreCapabilities;
+  /**
+   * Runs work atomically for the declared keys. Implementations must canonically
+   * order and deduplicate keys before locking, reject undeclared-key access, and
+   * completely roll back when `work` throws.
+   */
+  transaction<T>(
+    keys: readonly string[],
+    work: (transaction: OAuthProxyStoreTransaction) => T | Promise<T>
+  ): Promise<T>;
+}
+
+/** @internal Optional store and SDK encryption inputs resolved by the proxy wrapper. */
+export interface OAuthProxyStoreResolutionOptions {
+  /** Custom or built-in store. Omission creates a fresh private process-local store. */
+  readonly store?: OAuthProxyStore;
+  /** Optional SDK-managed AES-256-GCM keyring for payload encryption. */
+  readonly encryption?: OAuthProxyEncryptionOptions;
+}
+
+/** @internal Validated store plus details of the protection applied at its boundary. */
+export interface ResolvedOAuthProxyStore {
+  /** Store used by the proxy; SDK encryption is applied transparently when configured. */
+  readonly store: OAuthProxyStore;
+  /** Validated capabilities declared by the underlying store. */
+  readonly capabilities: OAuthProxyStoreCapabilities;
+  /** Whether this resolver encrypted payloads before handing them to the store. */
+  readonly sdkEncryption: boolean;
+}
+
+/**
+ * @internal Resolves an optional OAuth proxy store without ever allowing persistent
+ * plaintext secrets. Every omitted-store call receives an isolated in-memory map.
+ */
+export function resolveOAuthProxyStore(
+  options: OAuthProxyStoreResolutionOptions = {}
+): ResolvedOAuthProxyStore {
+  if (typeof options !== "object" || options === null) {
+    throw new TypeError(
+      "OAuth proxy store resolution options must be an object"
+    );
+  }
+  const underlying = options.store ?? inMemoryOAuthStore();
+  const capabilities = validateStore(underlying);
+
+  if (
+    capabilities.persistence === "persistent" &&
+    capabilities.secretProtection === "none" &&
+    options.encryption === undefined
+  ) {
+    throw new TypeError(
+      "Persistent OAuth proxy stores without store encryption require SDK encryption"
+    );
+  }
+
+  const codec =
+    options.encryption === undefined
+      ? createOAuthProxyPlaintextCodec()
+      : createOAuthProxyEncryptionCodec(options.encryption);
+  const sdkEncryption = options.encryption !== undefined;
+
+  return {
+    capabilities,
+    sdkEncryption,
+    store: codecStore(underlying, capabilities, codec),
+  };
+}
+
+type InMemoryEntry =
+  | {
+      readonly kind: "live";
+      readonly payload: Uint8Array;
+      readonly expiresAt: number;
+    }
+  | { readonly kind: "tombstone"; readonly expiresAt: number };
+
+function inMemoryOAuthStore(now: () => number = Date.now): OAuthProxyStore {
+  const entries = new Map<string, InMemoryEntry>();
+  const mutex = asyncMutex();
+
+  const runTransaction = async <T>(
+    keys: readonly string[],
+    work: (transaction: OAuthProxyStoreTransaction) => T | Promise<T>
+  ): Promise<T> => {
+    const canonicalKeys = canonicalizeTransactionKeys(keys);
+    if (typeof work !== "function") {
+      throw new TypeError(
+        "OAuth proxy store transaction work must be a function"
+      );
+    }
+    return mutex(async () => {
+      const declared = new Set(canonicalKeys);
+      const staged = cloneEntries(entries);
+      cleanupExpired(staged, now());
+      const result = await work(mapTransaction(staged, declared, now));
+      entries.clear();
+      for (const [key, entry] of staged) {
+        entries.set(key, cloneEntry(entry));
+      }
+      return result;
+    });
+  };
+
+  return {
+    capabilities: {
+      persistence: "process-local",
+      secretProtection: "none",
+    },
+    transaction: runTransaction,
+    create(key, payload, expiresAt) {
+      return runTransaction([key], (transaction) =>
+        transaction.create(key, payload, expiresAt)
+      );
+    },
+    read(key) {
+      return runTransaction([key], (transaction) => transaction.read(key));
+    },
+    replace(key, payload, expiresAt) {
+      return runTransaction([key], (transaction) =>
+        transaction.replace(key, payload, expiresAt)
+      );
+    },
+    consume(key) {
+      return runTransaction([key], (transaction) => transaction.consume(key));
+    },
+  };
+}
+
+function mapTransaction(
+  entries: Map<string, InMemoryEntry>,
+  declared: ReadonlySet<string>,
+  now: () => number
+): OAuthProxyStoreTransaction {
+  const current = (key: string): InMemoryEntry | undefined => {
+    assertDeclaredKey(key, declared);
+    const entry = entries.get(key);
+    if (entry !== undefined && entry.expiresAt <= now()) {
+      entries.delete(key);
+      return undefined;
+    }
+    return entry;
+  };
+
+  return {
+    async create(key, payload, expiresAt) {
+      assertDeclaredKey(key, declared);
+      assertStoredPayload(payload);
+      assertFutureExpiry(expiresAt, now());
+      if (current(key) !== undefined) {
+        return { status: "conflict" };
+      }
+      entries.set(key, {
+        kind: "live",
+        payload: Uint8Array.from(payload),
+        expiresAt,
+      });
+      return { status: "created" };
+    },
+    async read(key) {
+      const entry = current(key);
+      if (entry === undefined) {
+        return { status: "missing" };
+      }
+      if (entry.kind === "tombstone") {
+        return { status: "replayed" };
+      }
+      return { status: "found", payload: Uint8Array.from(entry.payload) };
+    },
+    async replace(key, payload, expiresAt) {
+      assertDeclaredKey(key, declared);
+      assertStoredPayload(payload);
+      assertFutureExpiry(expiresAt, now());
+      const entry = current(key);
+      if (entry === undefined) {
+        return { status: "missing" };
+      }
+      if (entry.kind === "tombstone") {
+        return { status: "replayed" };
+      }
+      entries.set(key, {
+        kind: "live",
+        payload: Uint8Array.from(payload),
+        expiresAt,
+      });
+      return { status: "replaced" };
+    },
+    async consume(key) {
+      const entry = current(key);
+      if (entry === undefined) {
+        return { status: "missing" };
+      }
+      if (entry.kind === "tombstone") {
+        return { status: "replayed" };
+      }
+      entries.set(key, { kind: "tombstone", expiresAt: entry.expiresAt });
+      return { status: "consumed", payload: Uint8Array.from(entry.payload) };
+    },
+  };
+}
+
+function codecStore(
+  underlying: OAuthProxyStore,
+  capabilities: OAuthProxyStoreCapabilities,
+  codec: OAuthProxyPayloadCodec
+): OAuthProxyStore {
+  const runTransaction = async <T>(
+    keys: readonly string[],
+    work: (transaction: OAuthProxyStoreTransaction) => T | Promise<T>
+  ): Promise<T> => {
+    const canonicalKeys = canonicalizeTransactionKeys(keys);
+    if (typeof work !== "function") {
+      throw new TypeError(
+        "OAuth proxy store transaction work must be a function"
+      );
+    }
+    const declared = new Set(canonicalKeys);
+    return underlying.transaction(canonicalKeys, (transaction) =>
+      work(codecTransaction(transaction, declared, codec))
+    );
+  };
+
+  return {
+    capabilities,
+    transaction: runTransaction,
+    create(key, payload, expiresAt) {
+      return runTransaction([key], (transaction) =>
+        transaction.create(key, payload, expiresAt)
+      );
+    },
+    read(key) {
+      return runTransaction([key], (transaction) => transaction.read(key));
+    },
+    replace(key, payload, expiresAt) {
+      return runTransaction([key], (transaction) =>
+        transaction.replace(key, payload, expiresAt)
+      );
+    },
+    consume(key) {
+      return runTransaction([key], (transaction) => transaction.consume(key));
+    },
+  };
+}
+
+function codecTransaction(
+  underlying: OAuthProxyStoreTransaction,
+  declared: ReadonlySet<string>,
+  codec: OAuthProxyPayloadCodec
+): OAuthProxyStoreTransaction {
+  return {
+    async create(key, payload, expiresAt) {
+      assertDeclaredKey(key, declared);
+      assertPayload(payload);
+      assertFutureExpiry(expiresAt, Date.now());
+      const encoded = await codec.encode(key, payload);
+      const result: unknown = await underlying.create(key, encoded, expiresAt);
+      validateCreateResult(result);
+      return result;
+    },
+    async read(key) {
+      assertDeclaredKey(key, declared);
+      const result: unknown = await underlying.read(key);
+      validateReadResult(result);
+      if (result.status !== "found") {
+        return result;
+      }
+      const payload = await codec.decode(key, result.payload);
+      assertPayload(payload);
+      return {
+        status: "found",
+        payload,
+      };
+    },
+    async replace(key, payload, expiresAt) {
+      assertDeclaredKey(key, declared);
+      assertPayload(payload);
+      assertFutureExpiry(expiresAt, Date.now());
+      const encoded = await codec.encode(key, payload);
+      const result: unknown = await underlying.replace(key, encoded, expiresAt);
+      validateReplaceResult(result);
+      return result;
+    },
+    async consume(key) {
+      assertDeclaredKey(key, declared);
+      const result: unknown = await underlying.consume(key);
+      validateConsumeResult(result);
+      if (result.status !== "consumed") {
+        return result;
+      }
+      const payload = await codec.decode(key, result.payload);
+      assertPayload(payload);
+      return {
+        status: "consumed",
+        payload,
+      };
+    },
+  };
+}
+
+function canonicalizeTransactionKeys(
+  keys: readonly string[]
+): readonly string[] {
+  if (!Array.isArray(keys) || keys.length === 0) {
+    throw new TypeError("OAuth proxy store transaction keys must be non-empty");
+  }
+  if (keys.length > MAX_TRANSACTION_KEY_DECLARATIONS) {
+    throw new TypeError(
+      `OAuth proxy store transactions support at most ${MAX_TRANSACTION_KEY_DECLARATIONS} key declarations`
+    );
+  }
+  const unique = new Set<string>();
+  for (const key of keys as readonly unknown[]) {
+    assertKey(key);
+    unique.add(key);
+  }
+  if (unique.size > MAX_TRANSACTION_KEYS) {
+    throw new TypeError(
+      `OAuth proxy store transactions support at most ${MAX_TRANSACTION_KEYS} keys`
+    );
+  }
+  return [...unique].sort();
+}
+
+function asyncMutex(): <T>(work: () => T | Promise<T>) => Promise<T> {
+  let tail = Promise.resolve();
+  return async <T>(work: () => T | Promise<T>): Promise<T> => {
+    const previous = tail;
+    let release = (): void => undefined;
+    tail = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    try {
+      return await work();
+    } finally {
+      release();
+    }
+  };
+}
+
+function cloneEntries(
+  entries: ReadonlyMap<string, InMemoryEntry>
+): Map<string, InMemoryEntry> {
+  return new Map([...entries].map(([key, entry]) => [key, cloneEntry(entry)]));
+}
+
+function cloneEntry(entry: InMemoryEntry): InMemoryEntry {
+  return entry.kind === "live"
+    ? {
+        kind: "live",
+        payload: Uint8Array.from(entry.payload),
+        expiresAt: entry.expiresAt,
+      }
+    : { kind: "tombstone", expiresAt: entry.expiresAt };
+}
+
+function cleanupExpired(
+  entries: Map<string, InMemoryEntry>,
+  now: number
+): void {
+  for (const [key, entry] of entries) {
+    if (entry.expiresAt <= now) {
+      entries.delete(key);
+    }
+  }
+}
+
+function validateCreateResult(
+  value: unknown
+): asserts value is OAuthProxyStoreCreateResult {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("status" in value) ||
+    (value.status !== "created" && value.status !== "conflict")
+  ) {
+    throw new TypeError("OAuth proxy store returned an invalid create result");
+  }
+}
+
+function validateReadResult(
+  value: unknown
+): asserts value is OAuthProxyStoreReadResult {
+  if (typeof value !== "object" || value === null || !("status" in value)) {
+    throw new TypeError("OAuth proxy store returned an invalid read result");
+  }
+  if (value.status === "missing" || value.status === "replayed") {
+    return;
+  }
+  if (
+    value.status !== "found" ||
+    !("payload" in value) ||
+    !(value.payload instanceof Uint8Array)
+  ) {
+    throw new TypeError("OAuth proxy store returned an invalid read result");
+  }
+  assertStoredPayload(value.payload);
+}
+
+function validateReplaceResult(
+  value: unknown
+): asserts value is OAuthProxyStoreReplaceResult {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("status" in value) ||
+    (value.status !== "replaced" &&
+      value.status !== "missing" &&
+      value.status !== "replayed")
+  ) {
+    throw new TypeError("OAuth proxy store returned an invalid replace result");
+  }
+}
+
+function validateConsumeResult(
+  value: unknown
+): asserts value is OAuthProxyStoreConsumeResult {
+  if (typeof value !== "object" || value === null || !("status" in value)) {
+    throw new TypeError("OAuth proxy store returned an invalid consume result");
+  }
+  if (value.status === "missing" || value.status === "replayed") {
+    return;
+  }
+  if (
+    value.status !== "consumed" ||
+    !("payload" in value) ||
+    !(value.payload instanceof Uint8Array)
+  ) {
+    throw new TypeError("OAuth proxy store returned an invalid consume result");
+  }
+  assertStoredPayload(value.payload);
+}
+
+function validateStore(store: OAuthProxyStore): OAuthProxyStoreCapabilities {
+  if (typeof store !== "object" || store === null) {
+    throw new TypeError("OAuth proxy store must be an object");
+  }
+  const capabilities = store.capabilities;
+  if (typeof capabilities !== "object" || capabilities === null) {
+    throw new TypeError("OAuth proxy store capabilities must be an object");
+  }
+  if (
+    capabilities.persistence !== "process-local" &&
+    capabilities.persistence !== "persistent"
+  ) {
+    throw new TypeError("OAuth proxy store persistence capability is invalid");
+  }
+  if (
+    capabilities.secretProtection !== "none" &&
+    capabilities.secretProtection !== "store-encrypted"
+  ) {
+    throw new TypeError(
+      "OAuth proxy store secretProtection capability is invalid"
+    );
+  }
+  if (
+    typeof store.create !== "function" ||
+    typeof store.read !== "function" ||
+    typeof store.replace !== "function" ||
+    typeof store.consume !== "function" ||
+    typeof store.transaction !== "function"
+  ) {
+    throw new TypeError("OAuth proxy store methods are invalid");
+  }
+  return Object.freeze({
+    persistence: capabilities.persistence,
+    secretProtection: capabilities.secretProtection,
+  });
+}
+
+function assertDeclaredKey(
+  key: unknown,
+  declared: ReadonlySet<string>
+): string {
+  assertKey(key);
+  if (!declared.has(key)) {
+    throw new TypeError(
+      `OAuth proxy store transaction key was not declared: ${key}`
+    );
+  }
+  return key;
+}
+
+function assertKey(key: unknown): asserts key is string {
+  if (typeof key !== "string" || key.length === 0) {
+    throw new TypeError("OAuth proxy store key must be a non-empty string");
+  }
+  if (textEncoder.encode(key).byteLength > MAX_KEY_BYTES) {
+    throw new TypeError(
+      `OAuth proxy store key must not exceed ${MAX_KEY_BYTES} UTF-8 bytes`
+    );
+  }
+}
+
+function assertPayload(payload: unknown): asserts payload is Uint8Array {
+  if (!(payload instanceof Uint8Array)) {
+    throw new TypeError("OAuth proxy store payload must be a Uint8Array");
+  }
+  if (payload.byteLength > MAX_PAYLOAD_BYTES) {
+    throw new TypeError(
+      `OAuth proxy store payload must not exceed ${MAX_PAYLOAD_BYTES} bytes`
+    );
+  }
+}
+
+function assertStoredPayload(payload: unknown): asserts payload is Uint8Array {
+  if (!(payload instanceof Uint8Array)) {
+    throw new TypeError("OAuth proxy store payload must be a Uint8Array");
+  }
+  if (payload.byteLength > MAX_STORED_PAYLOAD_BYTES) {
+    throw new TypeError(
+      `OAuth proxy serialized payload must not exceed ${MAX_STORED_PAYLOAD_BYTES} bytes`
+    );
+  }
+}
+
+function assertFutureExpiry(expiresAt: number, now: number): void {
+  if (typeof expiresAt !== "number" || !Number.isFinite(expiresAt)) {
+    throw new TypeError(
+      "OAuth proxy store expiry must be a finite epoch timestamp"
+    );
+  }
+  if (expiresAt <= now) {
+    throw new TypeError("OAuth proxy store expiry must be in the future");
+  }
+}

--- a/libraries/typescript/packages/server/src/oauth/proxy/store.ts
+++ b/libraries/typescript/packages/server/src/oauth/proxy/store.ts
@@ -10,6 +10,8 @@ const MAX_PAYLOAD_BYTES = 1024 * 1024;
 const MAX_STORED_PAYLOAD_BYTES = 2 * 1024 * 1024;
 const MAX_TRANSACTION_KEYS = 64;
 const MAX_TRANSACTION_KEY_DECLARATIONS = 256;
+const MAX_IN_MEMORY_ENTRIES = 10_000;
+const MAX_IN_MEMORY_PAYLOAD_BYTES = 64 * 1024 * 1024;
 const textEncoder = new TextEncoder();
 
 /** @internal Persistence and at-rest secret-protection guarantees of a proxy store. */
@@ -111,7 +113,8 @@ export function resolveOAuthProxyStore(
       "OAuth proxy store resolution options must be an object"
     );
   }
-  const underlying = options.store ?? inMemoryOAuthStore();
+  const underlying =
+    options.store === undefined ? inMemoryOAuthStore() : options.store;
   const capabilities = validateStore(underlying);
 
   if (
@@ -148,6 +151,7 @@ type InMemoryEntry =
 function inMemoryOAuthStore(now: () => number = Date.now): OAuthProxyStore {
   const entries = new Map<string, InMemoryEntry>();
   const mutex = asyncMutex();
+  let storedPayloadBytes = 0;
 
   const runTransaction = async <T>(
     keys: readonly string[],
@@ -161,12 +165,55 @@ function inMemoryOAuthStore(now: () => number = Date.now): OAuthProxyStore {
     }
     return mutex(async () => {
       const declared = new Set(canonicalKeys);
-      const staged = cloneEntries(entries);
-      cleanupExpired(staged, now());
+      const staged = new Map<string, InMemoryEntry>();
+      const transactionStartedAt = now();
+      for (const key of canonicalKeys) {
+        const entry = entries.get(key);
+        if (entry !== undefined && entry.expiresAt > transactionStartedAt) {
+          staged.set(key, cloneEntry(entry));
+        }
+      }
       const result = await work(mapTransaction(staged, declared, now));
-      entries.clear();
-      for (const [key, entry] of staged) {
-        entries.set(key, cloneEntry(entry));
+
+      const commitTime = now();
+      cleanupExpired(staged, commitTime);
+      let projected = projectedInMemoryUsage(
+        entries,
+        staged,
+        canonicalKeys,
+        storedPayloadBytes
+      );
+      if (
+        projected.entries > MAX_IN_MEMORY_ENTRIES ||
+        projected.payloadBytes > MAX_IN_MEMORY_PAYLOAD_BYTES
+      ) {
+        storedPayloadBytes -= cleanupExpired(entries, commitTime);
+        projected = projectedInMemoryUsage(
+          entries,
+          staged,
+          canonicalKeys,
+          storedPayloadBytes
+        );
+      }
+      if (
+        projected.entries > MAX_IN_MEMORY_ENTRIES ||
+        projected.payloadBytes > MAX_IN_MEMORY_PAYLOAD_BYTES
+      ) {
+        throw new RangeError("OAuth proxy in-memory store capacity exceeded");
+      }
+
+      for (const key of canonicalKeys) {
+        const previous = entries.get(key);
+        if (previous !== undefined) {
+          storedPayloadBytes -= entryPayloadBytes(previous);
+          entries.delete(key);
+        }
+        const next = staged.get(key);
+        if (next !== undefined) {
+          const snapshot = cloneEntry(next);
+          entries.set(key, snapshot);
+          storedPayloadBytes += entryPayloadBytes(snapshot);
+        }
       }
       return result;
     });
@@ -294,16 +341,18 @@ function codecStore(
     capabilities,
     transaction: runTransaction,
     create(key, payload, expiresAt) {
+      const snapshot = snapshotBytes(payload);
       return runTransaction([key], (transaction) =>
-        transaction.create(key, payload, expiresAt)
+        transaction.create(key, snapshot, expiresAt)
       );
     },
     read(key) {
       return runTransaction([key], (transaction) => transaction.read(key));
     },
     replace(key, payload, expiresAt) {
+      const snapshot = snapshotBytes(payload);
       return runTransaction([key], (transaction) =>
-        transaction.replace(key, payload, expiresAt)
+        transaction.replace(key, snapshot, expiresAt)
       );
     },
     consume(key) {
@@ -322,7 +371,7 @@ function codecTransaction(
       assertDeclaredKey(key, declared);
       assertPayload(payload);
       assertFutureExpiry(expiresAt, Date.now());
-      const encoded = await codec.encode(key, payload);
+      const encoded = await codec.encode(key, Uint8Array.from(payload));
       const result: unknown = await underlying.create(key, encoded, expiresAt);
       validateCreateResult(result);
       return result;
@@ -345,7 +394,7 @@ function codecTransaction(
       assertDeclaredKey(key, declared);
       assertPayload(payload);
       assertFutureExpiry(expiresAt, Date.now());
-      const encoded = await codec.encode(key, payload);
+      const encoded = await codec.encode(key, Uint8Array.from(payload));
       const result: unknown = await underlying.replace(key, encoded, expiresAt);
       validateReplaceResult(result);
       return result;
@@ -408,12 +457,6 @@ function asyncMutex(): <T>(work: () => T | Promise<T>) => Promise<T> {
   };
 }
 
-function cloneEntries(
-  entries: ReadonlyMap<string, InMemoryEntry>
-): Map<string, InMemoryEntry> {
-  return new Map([...entries].map(([key, entry]) => [key, cloneEntry(entry)]));
-}
-
 function cloneEntry(entry: InMemoryEntry): InMemoryEntry {
   return entry.kind === "live"
     ? {
@@ -427,12 +470,46 @@ function cloneEntry(entry: InMemoryEntry): InMemoryEntry {
 function cleanupExpired(
   entries: Map<string, InMemoryEntry>,
   now: number
-): void {
+): number {
+  let removedPayloadBytes = 0;
   for (const [key, entry] of entries) {
     if (entry.expiresAt <= now) {
+      removedPayloadBytes += entryPayloadBytes(entry);
       entries.delete(key);
     }
   }
+  return removedPayloadBytes;
+}
+
+function projectedInMemoryUsage(
+  entries: ReadonlyMap<string, InMemoryEntry>,
+  staged: ReadonlyMap<string, InMemoryEntry>,
+  keys: readonly string[],
+  storedPayloadBytes: number
+): { readonly entries: number; readonly payloadBytes: number } {
+  let entryCount = entries.size;
+  let payloadBytes = storedPayloadBytes;
+  for (const key of keys) {
+    const previous = entries.get(key);
+    if (previous !== undefined) {
+      entryCount -= 1;
+      payloadBytes -= entryPayloadBytes(previous);
+    }
+    const next = staged.get(key);
+    if (next !== undefined) {
+      entryCount += 1;
+      payloadBytes += entryPayloadBytes(next);
+    }
+  }
+  return { entries: entryCount, payloadBytes };
+}
+
+function entryPayloadBytes(entry: InMemoryEntry): number {
+  return entry.kind === "live" ? entry.payload.byteLength : 0;
+}
+
+function snapshotBytes(payload: Uint8Array): Uint8Array {
+  return payload instanceof Uint8Array ? Uint8Array.from(payload) : payload;
 }
 
 function validateCreateResult(

--- a/libraries/typescript/packages/server/tests/oauth-proxy-store.test.ts
+++ b/libraries/typescript/packages/server/tests/oauth-proxy-store.test.ts
@@ -1,0 +1,608 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createOAuthProxyEncryptionCodec,
+  type OAuthProxyEncryptionOptions,
+} from "../src/oauth/proxy/encryption.js";
+import {
+  resolveOAuthProxyStore,
+  type OAuthProxyStore,
+  type OAuthProxyStoreCapabilities,
+  type OAuthProxyStoreConsumeResult,
+  type OAuthProxyStoreReadResult,
+  type OAuthProxyStoreTransaction,
+} from "../src/oauth/proxy/store.js";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+const future = () => Date.now() + 60_000;
+
+function bytes(value: string): Uint8Array {
+  return encoder.encode(value);
+}
+
+function text(value: Uint8Array): string {
+  return decoder.decode(value);
+}
+
+function key(fill: number): Uint8Array {
+  return new Uint8Array(32).fill(fill);
+}
+
+function encryption(
+  primaryKeyId = "current",
+  keys: OAuthProxyEncryptionOptions["keys"] = [{ id: "current", key: key(7) }]
+): OAuthProxyEncryptionOptions {
+  return { primaryKeyId, keys };
+}
+
+class TestStore implements OAuthProxyStore {
+  readonly values = new Map<
+    string,
+    | { kind: "live"; payload: Uint8Array; expiresAt: number }
+    | { kind: "tombstone"; expiresAt: number }
+  >();
+  lastTransactionKeys: readonly string[] = [];
+  #tail = Promise.resolve();
+
+  constructor(readonly capabilities: OAuthProxyStoreCapabilities) {}
+
+  create(key: string, payload: Uint8Array, expiresAt: number) {
+    return this.transaction([key], (transaction) =>
+      transaction.create(key, payload, expiresAt)
+    );
+  }
+
+  read(key: string) {
+    return this.transaction([key], (transaction) => transaction.read(key));
+  }
+
+  replace(key: string, payload: Uint8Array, expiresAt: number) {
+    return this.transaction([key], (transaction) =>
+      transaction.replace(key, payload, expiresAt)
+    );
+  }
+
+  consume(key: string) {
+    return this.transaction([key], (transaction) => transaction.consume(key));
+  }
+
+  async transaction<T>(
+    keys: readonly string[],
+    work: (transaction: OAuthProxyStoreTransaction) => T | Promise<T>
+  ): Promise<T> {
+    const previous = this.#tail;
+    let release = (): void => undefined;
+    this.#tail = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    try {
+      const canonical = [...new Set(keys)].sort();
+      this.lastTransactionKeys = canonical;
+      const declared = new Set(canonical);
+      const staged = new Map(
+        [...this.values].map(([key, value]) => [
+          key,
+          value.kind === "live"
+            ? { ...value, payload: Uint8Array.from(value.payload) }
+            : { ...value },
+        ])
+      );
+      const assertDeclared = (key: string) => {
+        if (!declared.has(key)) {
+          throw new TypeError(`undeclared key: ${key}`);
+        }
+      };
+      const transaction: OAuthProxyStoreTransaction = {
+        async create(key, payload, expiresAt) {
+          assertDeclared(key);
+          if (staged.has(key)) {
+            return { status: "conflict" };
+          }
+          staged.set(key, {
+            kind: "live",
+            payload: Uint8Array.from(payload),
+            expiresAt,
+          });
+          return { status: "created" };
+        },
+        async read(key): Promise<OAuthProxyStoreReadResult> {
+          assertDeclared(key);
+          const value = staged.get(key);
+          if (value === undefined) {
+            return { status: "missing" };
+          }
+          return value.kind === "tombstone"
+            ? { status: "replayed" }
+            : { status: "found", payload: Uint8Array.from(value.payload) };
+        },
+        async replace(key, payload, expiresAt) {
+          assertDeclared(key);
+          const value = staged.get(key);
+          if (value === undefined) {
+            return { status: "missing" };
+          }
+          if (value.kind === "tombstone") {
+            return { status: "replayed" };
+          }
+          staged.set(key, {
+            kind: "live",
+            payload: Uint8Array.from(payload),
+            expiresAt,
+          });
+          return { status: "replaced" };
+        },
+        async consume(key): Promise<OAuthProxyStoreConsumeResult> {
+          assertDeclared(key);
+          const value = staged.get(key);
+          if (value === undefined) {
+            return { status: "missing" };
+          }
+          if (value.kind === "tombstone") {
+            return { status: "replayed" };
+          }
+          staged.set(key, {
+            kind: "tombstone",
+            expiresAt: value.expiresAt,
+          });
+          return {
+            status: "consumed",
+            payload: Uint8Array.from(value.payload),
+          };
+        },
+      };
+      const result = await work(transaction);
+      this.values.clear();
+      for (const [key, value] of staged) {
+        this.values.set(key, value);
+      }
+      return result;
+    } finally {
+      release();
+    }
+  }
+}
+
+describe("OAuth proxy store resolution", () => {
+  it("creates isolated process-local stores when store is omitted", async () => {
+    const first = resolveOAuthProxyStore();
+    const second = resolveOAuthProxyStore();
+
+    expect(first.capabilities).toEqual({
+      persistence: "process-local",
+      secretProtection: "none",
+    });
+    expect(first.sdkEncryption).toBe(false);
+    await expect(
+      first.store.create("transaction:a", bytes("secret"), future())
+    ).resolves.toEqual({ status: "created" });
+    await expect(second.store.read("transaction:a")).resolves.toEqual({
+      status: "missing",
+    });
+  });
+
+  it("preserves a custom persistent store across resolver instances", async () => {
+    const persistent = new TestStore({
+      persistence: "persistent",
+      secretProtection: "none",
+    });
+    const first = resolveOAuthProxyStore({
+      store: persistent,
+      encryption: encryption(),
+    });
+    await first.store.create("transaction:a", bytes("secret"), future());
+
+    const afterRestart = resolveOAuthProxyStore({
+      store: persistent,
+      encryption: encryption(),
+    });
+    const result = await afterRestart.store.read("transaction:a");
+    expect(result.status).toBe("found");
+    if (result.status === "found") {
+      expect(text(result.payload)).toBe("secret");
+    }
+  });
+
+  it("enforces the persistent-store protection matrix", () => {
+    expect(() =>
+      resolveOAuthProxyStore({
+        store: new TestStore({
+          persistence: "persistent",
+          secretProtection: "none",
+        }),
+      })
+    ).toThrow(/require SDK encryption/);
+
+    const storeEncrypted = new TestStore({
+      persistence: "persistent",
+      secretProtection: "store-encrypted",
+    });
+    expect(
+      resolveOAuthProxyStore({ store: storeEncrypted }).sdkEncryption
+    ).toBe(false);
+
+    const sdkEncrypted = resolveOAuthProxyStore({
+      store: new TestStore({
+        persistence: "persistent",
+        secretProtection: "none",
+      }),
+      encryption: encryption(),
+    });
+    expect(sdkEncrypted.sdkEncryption).toBe(true);
+  });
+
+  it("rejects malformed or missing runtime capabilities", () => {
+    const base = new TestStore({
+      persistence: "process-local",
+      secretProtection: "none",
+    });
+    for (const capabilities of [
+      undefined,
+      {},
+      { persistence: "disk", secretProtection: "none" },
+      { persistence: "persistent", secretProtection: "maybe" },
+    ]) {
+      expect(() =>
+        resolveOAuthProxyStore({
+          store: Object.assign(Object.create(base), { capabilities }),
+        })
+      ).toThrow(/capabilit/);
+    }
+  });
+});
+
+describe("process-local OAuth proxy store", () => {
+  it("consumes exactly once concurrently and retains an unexpired tombstone", async () => {
+    const { store } = resolveOAuthProxyStore();
+    await store.create("transaction:once", bytes("one-time"), future());
+
+    const results = await Promise.all(
+      Array.from({ length: 20 }, () => store.consume("transaction:once"))
+    );
+    expect(
+      results.filter((result) => result.status === "consumed")
+    ).toHaveLength(1);
+    expect(
+      results.filter((result) => result.status === "replayed")
+    ).toHaveLength(19);
+    await expect(store.read("transaction:once")).resolves.toEqual({
+      status: "replayed",
+    });
+    await expect(
+      store.create("transaction:once", bytes("replacement"), future())
+    ).resolves.toEqual({ status: "conflict" });
+  });
+
+  it("cleans up expired live values and tombstones", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-08-26T12:00:00Z"));
+      const { store } = resolveOAuthProxyStore();
+      await store.create("live", bytes("live"), Date.now() + 1_000);
+      await store.create("used", bytes("used"), Date.now() + 1_000);
+      await store.consume("used");
+
+      vi.advanceTimersByTime(1_001);
+      await expect(store.read("live")).resolves.toEqual({ status: "missing" });
+      await expect(store.consume("used")).resolves.toEqual({
+        status: "missing",
+      });
+      await expect(
+        store.create("used", bytes("new"), Date.now() + 1_000)
+      ).resolves.toEqual({ status: "created" });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("copies payload bytes at the store boundary", async () => {
+    const { store } = resolveOAuthProxyStore();
+    const original = bytes("secret");
+    await store.create("copy", original, future());
+    original.fill(0);
+    const firstRead = await store.read("copy");
+    expect(firstRead.status).toBe("found");
+    if (firstRead.status === "found") {
+      firstRead.payload.fill(0);
+    }
+    const secondRead = await store.read("copy");
+    expect(secondRead.status).toBe("found");
+    if (secondRead.status === "found") {
+      expect(text(secondRead.payload)).toBe("secret");
+    }
+  });
+});
+
+describe("OAuth proxy store transactions", () => {
+  it("commits cross-key work atomically and blocks interleaved operations", async () => {
+    const { store } = resolveOAuthProxyStore();
+    let releaseTransaction = (): void => undefined;
+    const transactionGate = new Promise<void>((resolve) => {
+      releaseTransaction = resolve;
+    });
+    const transaction = store.transaction(
+      ["rotation:new", "rotation:old"],
+      async (tx) => {
+        await tx.create("rotation:old", bytes("old"), future());
+        await transactionGate;
+        await tx.create("rotation:new", bytes("new"), future());
+      }
+    );
+
+    let interleavedReadFinished = false;
+    const interleavedRead = store.read("rotation:old").then((result) => {
+      interleavedReadFinished = true;
+      return result;
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(interleavedReadFinished).toBe(false);
+
+    releaseTransaction();
+    await transaction;
+    await expect(interleavedRead).resolves.toMatchObject({ status: "found" });
+    await expect(store.read("rotation:new")).resolves.toMatchObject({
+      status: "found",
+    });
+  });
+
+  it("rolls back creates, replacements, and consumption when work throws", async () => {
+    const { store } = resolveOAuthProxyStore();
+    await store.create("existing", bytes("original"), future());
+
+    await expect(
+      store.transaction(["existing", "new"], async (tx) => {
+        await tx.consume("existing");
+        await tx.create("new", bytes("created"), future());
+        throw new Error("abort rotation");
+      })
+    ).rejects.toThrow("abort rotation");
+
+    const existing = await store.read("existing");
+    expect(existing.status).toBe("found");
+    if (existing.status === "found") {
+      expect(text(existing.payload)).toBe("original");
+    }
+    await expect(store.read("new")).resolves.toEqual({ status: "missing" });
+  });
+
+  it("allows exactly one concurrent refresh-like rotation", async () => {
+    const { store } = resolveOAuthProxyStore();
+    await store.create("refresh:old", bytes("old-secret"), future());
+
+    const rotate = () =>
+      store.transaction(["refresh:new", "refresh:old"], async (tx) => {
+        const consumed = await tx.consume("refresh:old");
+        if (consumed.status !== "consumed") {
+          return false;
+        }
+        const created = await tx.create(
+          "refresh:new",
+          bytes("new-secret"),
+          future()
+        );
+        if (created.status !== "created") {
+          throw new Error("new refresh key unexpectedly exists");
+        }
+        return true;
+      });
+
+    const results = await Promise.all([rotate(), rotate()]);
+    expect(results.filter(Boolean)).toHaveLength(1);
+    await expect(store.read("refresh:old")).resolves.toEqual({
+      status: "replayed",
+    });
+    const replacement = await store.read("refresh:new");
+    expect(replacement.status).toBe("found");
+  });
+
+  it("replaces live records but never missing records or tombstones", async () => {
+    const { store } = resolveOAuthProxyStore();
+    await store.create("live", bytes("first"), future());
+    await expect(
+      store.replace("live", bytes("second"), future())
+    ).resolves.toEqual({ status: "replaced" });
+    const replaced = await store.read("live");
+    expect(replaced.status).toBe("found");
+    if (replaced.status === "found") {
+      expect(text(replaced.payload)).toBe("second");
+    }
+
+    await store.consume("live");
+    await expect(
+      store.replace("live", bytes("resurrected"), future())
+    ).resolves.toEqual({ status: "replayed" });
+    await expect(
+      store.replace("missing", bytes("created"), future())
+    ).resolves.toEqual({ status: "missing" });
+  });
+
+  it("rejects undeclared keys and forwards canonical lock ordering", async () => {
+    const persistent = new TestStore({
+      persistence: "persistent",
+      secretProtection: "store-encrypted",
+    });
+    const { store } = resolveOAuthProxyStore({ store: persistent });
+
+    await expect(
+      store.transaction(["z", "a", "z"], (tx) => tx.read("outside"))
+    ).rejects.toThrow(/not declared/);
+    expect(persistent.lastTransactionKeys).toEqual(["a", "z"]);
+  });
+
+  it("encrypts every transaction payload using its final key as AAD", async () => {
+    const persistent = new TestStore({
+      persistence: "persistent",
+      secretProtection: "none",
+    });
+    const { store } = resolveOAuthProxyStore({
+      store: persistent,
+      encryption: encryption(),
+    });
+    await store.transaction(["token:a", "token:b"], async (tx) => {
+      await tx.create("token:a", bytes("secret-a"), future());
+      await tx.create("token:b", bytes("secret-b"), future());
+    });
+
+    const rawA = persistent.values.get("token:a");
+    const rawB = persistent.values.get("token:b");
+    expect(rawA?.kind).toBe("live");
+    expect(rawB?.kind).toBe("live");
+    if (rawA?.kind === "live" && rawB?.kind === "live") {
+      expect(text(rawA.payload)).not.toContain("secret-a");
+      expect(text(rawB.payload)).not.toContain("secret-b");
+      persistent.values.set("token:a", {
+        ...rawA,
+        payload: Uint8Array.from(rawB.payload),
+      });
+      await expect(store.read("token:a")).rejects.toThrow(/Unable to decrypt/);
+    }
+  });
+
+  it("rejects expired writes and excessive keys or payloads", async () => {
+    const { store } = resolveOAuthProxyStore();
+    await expect(
+      store.create("expired", bytes("value"), Date.now())
+    ).rejects.toThrow(/future/);
+    await expect(store.read("expired")).resolves.toEqual({ status: "missing" });
+
+    await store.create("live", bytes("original"), future());
+    await expect(
+      store.transaction(["live", "new"], async (tx) => {
+        await tx.replace("live", bytes("changed"), Date.now() - 1);
+        await tx.create("new", bytes("new"), future());
+      })
+    ).rejects.toThrow(/future/);
+    const live = await store.read("live");
+    expect(live.status).toBe("found");
+    if (live.status === "found") {
+      expect(text(live.payload)).toBe("original");
+    }
+
+    await expect(store.read("x".repeat(1025))).rejects.toThrow(/1024/);
+    await expect(
+      store.create("large", new Uint8Array(1024 * 1024 + 1), future())
+    ).rejects.toThrow(/1048576/);
+    await expect(
+      store.transaction(
+        Array.from({ length: 65 }, (_, index) => `key:${index}`),
+        () => undefined
+      )
+    ).rejects.toThrow(/at most 64/);
+  });
+});
+
+describe("OAuth proxy encryption", () => {
+  it("round-trips with random IVs and emits no plaintext", async () => {
+    const codec = createOAuthProxyEncryptionCodec(encryption());
+    const plaintext = bytes("refresh-token-super-secret");
+    const first = await codec.encode("token:user-1", plaintext);
+    const second = await codec.encode("token:user-1", plaintext);
+
+    expect(first).not.toEqual(second);
+    expect(text(first)).not.toContain("refresh-token-super-secret");
+    expect(text(second)).not.toContain("refresh-token-super-secret");
+    await expect(codec.decode("token:user-1", first)).resolves.toEqual(
+      plaintext
+    );
+    await expect(codec.decode("token:user-1", second)).resolves.toEqual(
+      plaintext
+    );
+  });
+
+  it("binds ciphertext to the store key and fails closed on tamper or wrong keys", async () => {
+    const codec = createOAuthProxyEncryptionCodec(encryption());
+    const serialized = await codec.encode(
+      "transaction:correct",
+      bytes("secret")
+    );
+
+    await expect(codec.decode("transaction:wrong", serialized)).rejects.toThrow(
+      /Unable to decrypt/
+    );
+    const envelope = JSON.parse(text(serialized)) as { ciphertext: string };
+    envelope.ciphertext = `${envelope.ciphertext.slice(0, -1)}${
+      envelope.ciphertext.endsWith("A") ? "B" : "A"
+    }`;
+    await expect(
+      codec.decode("transaction:correct", bytes(JSON.stringify(envelope)))
+    ).rejects.toThrow(/Unable to decrypt/);
+    const wrongKey = createOAuthProxyEncryptionCodec(
+      encryption("current", [{ id: "current", key: key(8) }])
+    );
+    await expect(
+      wrongKey.decode("transaction:correct", serialized)
+    ).rejects.toThrow(/Unable to decrypt/);
+  });
+
+  it("supports keyring rotation while writing only with the primary key", async () => {
+    const oldKey = { id: "old", key: key(1) };
+    const newKey = { id: "new", key: key(2) };
+    const oldCodec = createOAuthProxyEncryptionCodec(
+      encryption("old", [oldKey])
+    );
+    const oldCiphertext = await oldCodec.encode("token:1", bytes("old-value"));
+    const rotatedCodec = createOAuthProxyEncryptionCodec(
+      encryption("new", [newKey, oldKey])
+    );
+
+    await expect(
+      rotatedCodec.decode("token:1", oldCiphertext)
+    ).resolves.toEqual(bytes("old-value"));
+    const newCiphertext = await rotatedCodec.encode(
+      "token:2",
+      bytes("new-value")
+    );
+    expect(JSON.parse(text(newCiphertext))).toMatchObject({ v: 1, kid: "new" });
+    await expect(oldCodec.decode("token:2", newCiphertext)).rejects.toThrow(
+      /Unable to decrypt/
+    );
+  });
+
+  it("rejects malformed keyrings before storing anything", () => {
+    const invalidOptions: unknown[] = [
+      { primaryKeyId: "", keys: [{ id: "key", key: key(1) }] },
+      { primaryKeyId: "key", keys: [] },
+      { primaryKeyId: "missing", keys: [{ id: "key", key: key(1) }] },
+      {
+        primaryKeyId: "key",
+        keys: [
+          { id: "key", key: key(1) },
+          { id: "key", key: key(2) },
+        ],
+      },
+      { primaryKeyId: "key", keys: [{ id: "", key: key(1) }] },
+      { primaryKeyId: "key", keys: [{ id: "key", key: new Uint8Array(31) }] },
+      { primaryKeyId: "key", keys: [{ id: "key", key: "passphrase" }] },
+    ];
+    for (const options of invalidOptions) {
+      expect(() =>
+        createOAuthProxyEncryptionCodec(options as OAuthProxyEncryptionOptions)
+      ).toThrow();
+    }
+  });
+
+  it("encrypts before handing plaintext-unprotected persistent stores a payload", async () => {
+    const persistent = new TestStore({
+      persistence: "persistent",
+      secretProtection: "none",
+    });
+    const { store } = resolveOAuthProxyStore({
+      store: persistent,
+      encryption: encryption(),
+    });
+    await store.create("token:user", bytes("access-token-secret"), future());
+
+    const raw = persistent.values.get("token:user");
+    expect(raw?.kind).toBe("live");
+    if (raw?.kind === "live") {
+      expect(text(raw.payload)).not.toContain("access-token-secret");
+      expect(JSON.parse(text(raw.payload))).toMatchObject({
+        v: 1,
+        alg: "A256GCM",
+        kid: "current",
+      });
+    }
+  });
+});

--- a/libraries/typescript/packages/server/tests/oauth-proxy-store.test.ts
+++ b/libraries/typescript/packages/server/tests/oauth-proxy-store.test.ts
@@ -250,6 +250,14 @@ describe("OAuth proxy store resolution", () => {
       ).toThrow(/capabilit/);
     }
   });
+
+  it("rejects null stores instead of silently using process-local storage", () => {
+    expect(() =>
+      resolveOAuthProxyStore({
+        store: null as unknown as OAuthProxyStore,
+      })
+    ).toThrow(/store must be an object/);
+  });
 });
 
 describe("process-local OAuth proxy store", () => {
@@ -311,6 +319,16 @@ describe("process-local OAuth proxy store", () => {
     if (secondRead.status === "found") {
       expect(text(secondRead.payload)).toBe("secret");
     }
+  });
+
+  it("bounds the total number of process-local entries", async () => {
+    const { store } = resolveOAuthProxyStore();
+    for (let index = 0; index < 10_000; index += 1) {
+      await store.create(`bounded:${index}`, new Uint8Array(), future());
+    }
+    await expect(
+      store.create("bounded:overflow", new Uint8Array(), future())
+    ).rejects.toThrow(/capacity exceeded/);
   });
 });
 
@@ -511,6 +529,43 @@ describe("OAuth proxy encryption", () => {
     );
   });
 
+  it("snapshots encrypted payloads before asynchronous work", async () => {
+    const persistent = new TestStore({
+      persistence: "persistent",
+      secretProtection: "none",
+    });
+    const { store } = resolveOAuthProxyStore({
+      store: persistent,
+      encryption: encryption(),
+    });
+    const direct = bytes("direct-secret");
+    const directWrite = store.create("token:direct", direct, future());
+    direct.fill(0);
+    await directWrite;
+
+    await store.transaction(["token:transaction"], async (transaction) => {
+      const transactional = bytes("transaction-secret");
+      const transactionalWrite = transaction.create(
+        "token:transaction",
+        transactional,
+        future()
+      );
+      transactional.fill(0);
+      await transactionalWrite;
+    });
+
+    const directRead = await store.read("token:direct");
+    const transactionalRead = await store.read("token:transaction");
+    expect(directRead).toMatchObject({ status: "found" });
+    expect(transactionalRead).toMatchObject({ status: "found" });
+    if (directRead.status === "found") {
+      expect(text(directRead.payload)).toBe("direct-secret");
+    }
+    if (transactionalRead.status === "found") {
+      expect(text(transactionalRead.payload)).toBe("transaction-secret");
+    }
+  });
+
   it("binds ciphertext to the store key and fails closed on tamper or wrong keys", async () => {
     const codec = createOAuthProxyEncryptionCodec(encryption());
     const serialized = await codec.encode(
@@ -581,6 +636,20 @@ describe("OAuth proxy encryption", () => {
         createOAuthProxyEncryptionCodec(options as OAuthProxyEncryptionOptions)
       ).toThrow();
     }
+  });
+
+  it("rejects incomplete injected Web Crypto implementations", () => {
+    expect(() =>
+      createOAuthProxyEncryptionCodec({
+        ...encryption(),
+        crypto: {
+          getRandomValues: globalThis.crypto.getRandomValues.bind(
+            globalThis.crypto
+          ),
+          subtle: {} as SubtleCrypto,
+        },
+      })
+    ).toThrow(/requires Web Crypto/);
   });
 
   it("encrypts before handing plaintext-unprotected persistent stores a payload", async () => {


### PR DESCRIPTION
## Summary

Adds the OAuth Proxy storage and encryption foundation for registrations, transactions, grants, and tokens.

## Review focus

- Private process-local in-memory store as the zero-config default.
- Byte-oriented custom-store contract with atomic consume/replace and multi-key transactions.
- AES-256-GCM keyring support with key rotation.
- Explicit secret-protection capabilities so persistent stores cannot silently retain plaintext upstream secrets.
- Strict record validation, expiration, and replay-safe consumption.

## Validation

- Tests cover isolated in-memory stores, concurrency, expiration, encryption/key rotation, tamper detection, and persistent-store safety checks.
- Included in the full OAuth run: 13 test files, 137 tests.
- Server typecheck, build, ESLint, and Prettier pass.

PR 3 of 8. Based on #2340; next: #2342.
