### PR TITLE
feat(server): support resource-bound OAuth providers

### DIFF
--- a/libraries/typescript/packages/server/src/oauth/adapters.ts
+++ b/libraries/typescript/packages/server/src/oauth/adapters.ts
@@ -31,7 +31,7 @@ export function bearerAuth<TUser>(
 export function bearerAuthForBoundProvider<TUser>(
   boundProvider: BoundOAuthProvider<TUser>
 ): FetchMiddleware {
-  const options = getOAuthProviderOptions(boundProvider.provider);
+  const options = getOAuthProviderOptions(boundProvider);
   const gate = requireBearerAuth({
     verifier: wrapBoundOAuthTokenVerifier(boundProvider),
     resourceMetadataUrl: getOAuthProtectedResourceMetadataUrl(
@@ -63,6 +63,9 @@ export function oauthMetadata<TUser>(
   provider: OAuthProvider<TUser>,
   resource: URL
 ): FetchMiddleware {
+  if ("bind" in provider) {
+    return oauthMetadataForBoundProvider(bindOAuthProvider(provider, resource));
+  }
   return createOAuthMetadataMiddleware(provider, resource);
 }
 
@@ -70,14 +73,18 @@ export function oauthMetadata<TUser>(
 export function oauthMetadataForBoundProvider<TUser>(
   boundProvider: BoundOAuthProvider<TUser>
 ): FetchMiddleware {
-  return createOAuthMetadataMiddleware(
-    boundProvider.provider,
-    boundProvider.resource
-  );
+  return createOAuthMetadataMiddleware(boundProvider, boundProvider.resource);
 }
 
 function createOAuthMetadataMiddleware<TUser>(
-  provider: OAuthProvider<TUser>,
+  provider: Pick<
+    BoundOAuthProvider<TUser>,
+    | "oauthMetadata"
+    | "requiredScopes"
+    | "scopesSupported"
+    | "resourceName"
+    | "serviceDocumentationUrl"
+  >,
   resource: URL
 ): FetchMiddleware {
   const options = getOAuthProviderOptions(provider);

--- a/libraries/typescript/packages/server/src/oauth/auth0.ts
+++ b/libraries/typescript/packages/server/src/oauth/auth0.ts
@@ -20,7 +20,7 @@ import {
 } from "./jwt.js";
 import {
   oauthCustomProvider,
-  type OAuthProvider,
+  type DirectOAuthProvider,
   type OAuthResourceOptions,
 } from "./provider.js";
 
@@ -72,7 +72,7 @@ export interface Auth0OAuthProviderOptions extends OAuthResourceOptions {
  */
 export function oauthAuth0Provider(
   options: Auth0OAuthProviderOptions = {}
-): OAuthProvider<Auth0OAuthUser> {
+): DirectOAuthProvider<Auth0OAuthUser> {
   const domain =
     options.domain ?? oauthEnvironmentValue("MCP_USE_OAUTH_AUTH0_DOMAIN");
   const audience = oauthEnvironmentValue("MCP_USE_OAUTH_AUTH0_AUDIENCE");

--- a/libraries/typescript/packages/server/src/oauth/better-auth.ts
+++ b/libraries/typescript/packages/server/src/oauth/better-auth.ts
@@ -20,7 +20,7 @@ import {
 } from "./jwt.js";
 import {
   oauthCustomProvider,
-  type OAuthProvider,
+  type DirectOAuthProvider,
   type OAuthResourceOptions,
 } from "./provider.js";
 
@@ -76,7 +76,7 @@ export interface BetterAuthOAuthProviderOptions extends OAuthResourceOptions {
  */
 export function oauthBetterAuthProvider(
   options: BetterAuthOAuthProviderOptions = {}
-): OAuthProvider<BetterAuthOAuthUser> {
+): DirectOAuthProvider<BetterAuthOAuthUser> {
   const authURL =
     options.authURL ?? oauthEnvironmentValue("MCP_USE_OAUTH_BETTER_AUTH_URL");
   if (authURL === undefined) {

--- a/libraries/typescript/packages/server/src/oauth/clerk.ts
+++ b/libraries/typescript/packages/server/src/oauth/clerk.ts
@@ -20,7 +20,7 @@ import {
 } from "./jwt.js";
 import {
   oauthCustomProvider,
-  type OAuthProvider,
+  type DirectOAuthProvider,
   type OAuthResourceOptions,
 } from "./provider.js";
 
@@ -78,7 +78,7 @@ export interface ClerkOAuthProviderOptions extends OAuthResourceOptions {
  */
 export function oauthClerkProvider(
   options: ClerkOAuthProviderOptions = {}
-): OAuthProvider<ClerkOAuthUser> {
+): DirectOAuthProvider<ClerkOAuthUser> {
   if (
     options.audience !== undefined &&
     (typeof options.audience !== "string" ||

--- a/libraries/typescript/packages/server/src/oauth/internal.ts
+++ b/libraries/typescript/packages/server/src/oauth/internal.ts
@@ -14,6 +14,8 @@ import type {
   BoundOAuthProvider,
   OAuthExtra,
   OAuthProvider,
+  OAuthProviderBinding,
+  ResourceBoundOAuthProvider,
 } from "./provider.js";
 
 export {
@@ -90,24 +92,165 @@ export function bindOAuthProvider<TUser>(
   expectedResource: URL
 ): BoundOAuthProvider<TUser> {
   const canonicalResource = normalizeResourceUrl(expectedResource);
-  const tokenVerifier = provider.createTokenVerifier(
-    new URL(canonicalResource.href)
-  );
+  const resourceBoundProvider = isResourceBoundOAuthProvider(provider);
+  if ("bind" in provider && typeof provider.bind !== "function") {
+    throw new TypeError("OAuth provider bind must be a function");
+  }
+
+  const rawBinding: OAuthProviderBinding<TUser> = resourceBoundProvider
+    ? provider.bind(new URL(canonicalResource.href))
+    : {
+        oauthMetadata: provider.oauthMetadata,
+        tokenVerifier: provider.createTokenVerifier(
+          new URL(canonicalResource.href)
+        ),
+        mapAuthInfo: provider.mapAuthInfo,
+        ...(provider.requiredScopes !== undefined && {
+          requiredScopes: provider.requiredScopes,
+        }),
+        ...(provider.scopesSupported !== undefined && {
+          scopesSupported: provider.scopesSupported,
+        }),
+        ...(provider.resourceName !== undefined && {
+          resourceName: provider.resourceName,
+        }),
+        ...(provider.serviceDocumentationUrl !== undefined && {
+          serviceDocumentationUrl: provider.serviceDocumentationUrl,
+        }),
+      };
+
+  assertOAuthProviderBinding(rawBinding, resourceBoundProvider);
+  const tokenVerifier = rawBinding.tokenVerifier;
+  const mapAuthInfo = rawBinding.mapAuthInfo;
+  const mapperOwner: object = resourceBoundProvider ? rawBinding : provider;
+
+  return Object.freeze({
+    resource: canonicalResource,
+    oauthMetadata: snapshotOAuthMetadata(rawBinding.oauthMetadata),
+    tokenVerifier,
+    mapAuthInfo: (authInfo: AuthInfo) =>
+      mapAuthInfo.call(mapperOwner, authInfo),
+    ...(rawBinding.requiredScopes !== undefined && {
+      requiredScopes: Object.freeze([...rawBinding.requiredScopes]),
+    }),
+    ...(rawBinding.scopesSupported !== undefined && {
+      scopesSupported: Object.freeze([...rawBinding.scopesSupported]),
+    }),
+    ...(rawBinding.resourceName !== undefined && {
+      resourceName: rawBinding.resourceName,
+    }),
+    ...(rawBinding.serviceDocumentationUrl !== undefined && {
+      serviceDocumentationUrl: new URL(rawBinding.serviceDocumentationUrl.href),
+    }),
+    ...(rawBinding.middleware !== undefined && {
+      middleware: rawBinding.middleware,
+    }),
+  });
+}
+
+function isResourceBoundOAuthProvider<TUser>(
+  provider: OAuthProvider<TUser>
+): provider is ResourceBoundOAuthProvider<TUser> {
+  return "bind" in provider && typeof provider.bind === "function";
+}
+
+function assertOAuthProviderBinding<TUser>(
+  binding: OAuthProviderBinding<TUser>,
+  resourceBoundProvider: boolean
+): asserts binding is OAuthProviderBinding<TUser> {
+  if (binding === null || typeof binding !== "object") {
+    throw new TypeError("OAuth provider bind must return an object");
+  }
+  assertBindingOAuthMetadata(binding.oauthMetadata);
+  const tokenVerifier = binding.tokenVerifier;
   if (
     tokenVerifier === null ||
     typeof tokenVerifier !== "object" ||
     typeof tokenVerifier.verifyAccessToken !== "function"
   ) {
     throw new TypeError(
-      "OAuth provider createTokenVerifier must return an OAuthTokenVerifier"
+      resourceBoundProvider
+        ? "OAuth provider binding tokenVerifier must be an OAuthTokenVerifier"
+        : "OAuth provider createTokenVerifier must return an OAuthTokenVerifier"
     );
   }
+  if (typeof binding.mapAuthInfo !== "function") {
+    throw new TypeError(
+      "OAuth provider binding mapAuthInfo must be a function"
+    );
+  }
+  assertBindingStringArray(binding.requiredScopes, "requiredScopes");
+  assertBindingStringArray(binding.scopesSupported, "scopesSupported");
+  if (
+    binding.resourceName !== undefined &&
+    (typeof binding.resourceName !== "string" ||
+      binding.resourceName.trim().length === 0)
+  ) {
+    throw new TypeError("resourceName must be a non-empty string");
+  }
+  if (binding.serviceDocumentationUrl !== undefined) {
+    if (!(binding.serviceDocumentationUrl instanceof URL)) {
+      throw new TypeError("serviceDocumentationUrl must be a URL");
+    }
+    assertSecureHttpUrl(
+      binding.serviceDocumentationUrl,
+      "serviceDocumentationUrl"
+    );
+  }
+  if (
+    binding.middleware !== undefined &&
+    typeof binding.middleware !== "function"
+  ) {
+    throw new TypeError("OAuth provider binding middleware must be a function");
+  }
+}
 
-  return {
-    provider,
-    resource: canonicalResource,
-    tokenVerifier,
-  };
+function assertBindingOAuthMetadata(metadata: unknown): void {
+  if (
+    metadata === null ||
+    typeof metadata !== "object" ||
+    !("issuer" in metadata) ||
+    typeof metadata.issuer !== "string"
+  ) {
+    throw new TypeError(
+      "OAuth provider binding oauthMetadata must include a string issuer"
+    );
+  }
+  assertSecureHttpUrl(
+    parseAbsoluteUrl(
+      metadata.issuer,
+      "OAuth provider binding oauthMetadata.issuer"
+    ),
+    "OAuth provider binding oauthMetadata.issuer"
+  );
+}
+
+function assertBindingStringArray(value: unknown, name: string): void {
+  if (
+    value !== undefined &&
+    (!Array.isArray(value) || !value.every((item) => typeof item === "string"))
+  ) {
+    throw new TypeError(
+      `OAuth provider binding ${name} must be an array of strings`
+    );
+  }
+}
+
+function snapshotOAuthMetadata(
+  metadata: BoundOAuthProvider<unknown>["oauthMetadata"]
+): BoundOAuthProvider<unknown>["oauthMetadata"] {
+  return Object.freeze(
+    Object.fromEntries(
+      Object.entries(metadata as Record<string, unknown>).map(
+        ([key, value]) => [
+          key,
+          Array.isArray(value)
+            ? Object.freeze((value as unknown[]).slice())
+            : value,
+        ]
+      )
+    )
+  ) as BoundOAuthProvider<unknown>["oauthMetadata"];
 }
 
 /** @internal Wraps a bound verifier with mcp-use's verified auth mapping. */
@@ -115,9 +258,9 @@ export function wrapBoundOAuthTokenVerifier<TUser>(
   boundProvider: BoundOAuthProvider<TUser>
 ): OAuthTokenVerifier {
   const {
-    provider,
     resource: canonicalResource,
     tokenVerifier,
+    mapAuthInfo,
   } = boundProvider;
 
   return {
@@ -128,7 +271,7 @@ export function wrapBoundOAuthTokenVerifier<TUser>(
 
       let mapped: OAuthExtra<TUser>;
       try {
-        mapped = provider.mapAuthInfo(authInfo);
+        mapped = mapAuthInfo(authInfo);
       } catch (error) {
         throw invalidToken("Token identity mapping failed", error);
       }
@@ -203,9 +346,16 @@ function normalizeResourceUrl(resource: URL): URL {
 
 /** @internal Gets immutable provider metadata for Hono adapter wiring. */
 export function getOAuthProviderOptions<TUser>(
-  provider: OAuthProvider<TUser>
+  provider: Pick<
+    BoundOAuthProvider<TUser>,
+    | "oauthMetadata"
+    | "requiredScopes"
+    | "scopesSupported"
+    | "resourceName"
+    | "serviceDocumentationUrl"
+  >
 ): {
-  oauthMetadata: OAuthProvider<TUser>["oauthMetadata"];
+  oauthMetadata: BoundOAuthProvider<TUser>["oauthMetadata"];
   requiredScopes?: string[];
   scopesSupported?: string[];
   resourceName?: string;

--- a/libraries/typescript/packages/server/src/oauth/keycloak.ts
+++ b/libraries/typescript/packages/server/src/oauth/keycloak.ts
@@ -22,7 +22,7 @@ import {
 } from "./jwt.js";
 import {
   oauthCustomProvider,
-  type OAuthProvider,
+  type DirectOAuthProvider,
   type OAuthResourceOptions,
 } from "./provider.js";
 
@@ -85,7 +85,7 @@ export interface KeycloakOAuthProviderOptions extends OAuthResourceOptions {
  */
 export function oauthKeycloakProvider(
   options: KeycloakOAuthProviderOptions = {}
-): OAuthProvider<KeycloakOAuthUser> {
+): DirectOAuthProvider<KeycloakOAuthUser> {
   const serverUrlValue =
     options.serverUrl ??
     oauthEnvironmentValue("MCP_USE_OAUTH_KEYCLOAK_SERVER_URL");

--- a/libraries/typescript/packages/server/src/oauth/provider.ts
+++ b/libraries/typescript/packages/server/src/oauth/provider.ts
@@ -4,6 +4,7 @@ import type {
   OAuthTokenVerifier,
 } from "@modelcontextprotocol/server";
 
+import type { FetchMiddleware } from "../fetch-app.js";
 import { assertSecureHttpUrl, parseAbsoluteUrl } from "./internal.js";
 
 /** Additional verified identity information exposed by mcp-use callbacks. */
@@ -42,17 +43,62 @@ export interface CustomOAuthProviderOptions<
   mapAuthInfo: (authInfo: OAuthAuthInfo) => OAuthExtra<TUser>;
 }
 
+/** Effective OAuth behavior returned after a provider binds to a resource. */
+export interface OAuthProviderBinding<TUser> {
+  /** RFC 8414 metadata effective for the resolved resource. */
+  readonly oauthMetadata: OAuthMetadata;
+  /** Raw token verifier bound to the resolved resource. */
+  readonly tokenVerifier: OAuthTokenVerifier;
+  /** Maps verified SDK auth information into mcp-use callback identity data. */
+  readonly mapAuthInfo: (authInfo: OAuthAuthInfo) => OAuthExtra<TUser>;
+  /** Endpoint-wide scopes enforced by the SDK bearer gate. */
+  readonly requiredScopes?: readonly string[];
+  /** Scopes advertised by protected-resource metadata. */
+  readonly scopesSupported?: readonly string[];
+  /** Human-readable name advertised by protected-resource metadata. */
+  readonly resourceName?: string;
+  /** Documentation URL advertised by protected-resource metadata. */
+  readonly serviceDocumentationUrl?: URL;
+  /** Provider-owned HTTP middleware installed for this resource. */
+  readonly middleware?: FetchMiddleware;
+}
+
+/** Legacy provider whose metadata and verifier factory are known up front. */
+export type DirectOAuthProvider<TUser> = CustomOAuthProviderOptions<TUser>;
+
+/** Provider whose effective behavior is resolved from the canonical resource. */
+export interface ResourceBoundOAuthProvider<
+  TUser,
+> extends OAuthResourceOptions {
+  /** Resolves resource-dependent OAuth behavior for one server mount. */
+  readonly bind: (resource: URL) => OAuthProviderBinding<TUser>;
+}
+
 /** OAuth resource-server provider accepted by the mcp-use server constructor. */
-export type OAuthProvider<TUser> = CustomOAuthProviderOptions<TUser>;
+export type OAuthProvider<TUser> =
+  | DirectOAuthProvider<TUser>
+  | ResourceBoundOAuthProvider<TUser>;
 
 /** OAuth provider state bound to one canonical MCP resource. @internal */
 export interface BoundOAuthProvider<TUser> {
-  /** Original provider, retained so callback invocation semantics stay intact. */
-  readonly provider: OAuthProvider<TUser>;
   /** Canonical protected-resource identity for this server mount. */
   readonly resource: URL;
-  /** Provider verifier created for {@link resource}. */
+  /** Effective RFC 8414 metadata snapshotted at bind time. */
+  readonly oauthMetadata: OAuthMetadata;
+  /** Raw provider verifier created for {@link resource}. */
   readonly tokenVerifier: OAuthTokenVerifier;
+  /** Effective verified-identity mapper snapshotted at bind time. */
+  readonly mapAuthInfo: (authInfo: OAuthAuthInfo) => OAuthExtra<TUser>;
+  /** Effective endpoint-wide bearer scopes. */
+  readonly requiredScopes?: readonly string[];
+  /** Effective protected-resource metadata scopes. */
+  readonly scopesSupported?: readonly string[];
+  /** Effective protected-resource display name. */
+  readonly resourceName?: string;
+  /** Effective protected-resource documentation URL. */
+  readonly serviceDocumentationUrl?: URL;
+  /** Effective provider-owned HTTP middleware. */
+  readonly middleware?: FetchMiddleware;
 }
 
 /**
@@ -80,7 +126,7 @@ export interface BoundOAuthProvider<TUser> {
  */
 export function oauthCustomProvider<TUser>(
   options: CustomOAuthProviderOptions<TUser>
-): OAuthProvider<TUser> {
+): DirectOAuthProvider<TUser> {
   if (
     options === null ||
     typeof options !== "object" ||
@@ -115,7 +161,7 @@ export function oauthCustomProvider<TUser>(
     );
   }
 
-  const provider: OAuthProvider<TUser> = {
+  const provider: DirectOAuthProvider<TUser> = {
     createTokenVerifier: options.createTokenVerifier,
     oauthMetadata: options.oauthMetadata,
     mapAuthInfo: options.mapAuthInfo,

--- a/libraries/typescript/packages/server/src/oauth/scalekit.ts
+++ b/libraries/typescript/packages/server/src/oauth/scalekit.ts
@@ -18,7 +18,7 @@ import {
 } from "./jwt.js";
 import {
   oauthCustomProvider,
-  type OAuthProvider,
+  type DirectOAuthProvider,
   type OAuthResourceOptions,
 } from "./provider.js";
 
@@ -81,7 +81,7 @@ export interface ScalekitOAuthProviderOptions extends OAuthResourceOptions {
  */
 export function oauthScalekitProvider(
   options: ScalekitOAuthProviderOptions = {}
-): OAuthProvider<ScalekitOAuthUser> {
+): DirectOAuthProvider<ScalekitOAuthUser> {
   if (
     options.audience !== undefined &&
     (typeof options.audience !== "string" ||

--- a/libraries/typescript/packages/server/src/oauth/supabase.ts
+++ b/libraries/typescript/packages/server/src/oauth/supabase.ts
@@ -20,7 +20,7 @@ import {
 } from "./jwt.js";
 import {
   oauthCustomProvider,
-  type OAuthProvider,
+  type DirectOAuthProvider,
   type OAuthResourceOptions,
 } from "./provider.js";
 
@@ -103,7 +103,7 @@ export interface SupabaseOAuthProviderOptions extends OAuthResourceOptions {
  */
 export function oauthSupabaseProvider(
   options: SupabaseOAuthProviderOptions = {}
-): OAuthProvider<SupabaseOAuthUser> {
+): DirectOAuthProvider<SupabaseOAuthUser> {
   const projectId =
     options.projectId ??
     oauthEnvironmentValue("MCP_USE_OAUTH_SUPABASE_PROJECT_ID");

--- a/libraries/typescript/packages/server/src/oauth/workos.ts
+++ b/libraries/typescript/packages/server/src/oauth/workos.ts
@@ -20,7 +20,7 @@ import {
 } from "./jwt.js";
 import {
   oauthCustomProvider,
-  type OAuthProvider,
+  type DirectOAuthProvider,
   type OAuthResourceOptions,
 } from "./provider.js";
 
@@ -78,7 +78,7 @@ export interface WorkOSOAuthProviderOptions extends OAuthResourceOptions {
  */
 export function oauthWorkOSProvider(
   options: WorkOSOAuthProviderOptions = {}
-): OAuthProvider<WorkOSOAuthUser> {
+): DirectOAuthProvider<WorkOSOAuthUser> {
   const subdomain =
     options.subdomain ??
     oauthEnvironmentValue("MCP_USE_OAUTH_WORKOS_SUBDOMAIN");

--- a/libraries/typescript/packages/server/src/server.ts
+++ b/libraries/typescript/packages/server/src/server.ts
@@ -1400,6 +1400,9 @@ export class MCPServer<TUser = never, TEnv extends Env = Env> {
       for (const middleware of middlewares) {
         registerFetchMiddleware(httpApp, middleware);
       }
+      if (boundOAuthProvider?.middleware !== undefined) {
+        registerFetchMiddleware(httpApp, boundOAuthProvider.middleware);
+      }
 
       const { handler, fetch: mcpFetch } = createMcpMount(
         (ctx) => this.#buildSdkServer(ctx),

--- a/libraries/typescript/packages/server/tests/oauth-routes-resource.test.ts
+++ b/libraries/typescript/packages/server/tests/oauth-routes-resource.test.ts
@@ -6,6 +6,7 @@ import {
   OAuthErrorCode,
   oauthCustomProvider,
   type OAuthMetadata,
+  type OAuthProvider,
 } from "../src/oauth/index.js";
 
 const issuer = "https://issuer.example.test";
@@ -134,6 +135,243 @@ describe("OAuth HTTP route acceptance", () => {
       expect(response.status).not.toBe(401);
     }
     expect(verifierCreations).toBe(1);
+  });
+
+  it("uses one immutable resource-bound provider binding for middleware, metadata, and auth", async () => {
+    const order: string[] = [];
+    const effectiveMetadata = {
+      issuer: "https://bound-issuer.example.test",
+      authorization_endpoint:
+        "https://bound-issuer.example.test/oauth/authorize",
+    } as OAuthMetadata;
+    const effectiveRequiredScopes = ["bound:read"];
+    const effectiveSupportedScopes = ["bound:read", "bound:write"];
+    let bindCalls = 0;
+    let boundResource: URL | undefined;
+    let observedAuth:
+      | {
+          user: { id: string };
+          payload: Record<string, unknown>;
+          permissions: string[];
+        }
+      | undefined;
+
+    const resourceBoundProvider: OAuthProvider<{ id: string }> = {
+      resource: "https://canonical.example.test/mcp",
+      bind: (resource) => {
+        bindCalls += 1;
+        boundResource = new URL(resource);
+        resource.hostname = "mutated-by-provider.example.test";
+        return {
+          oauthMetadata: effectiveMetadata,
+          tokenVerifier: {
+            verifyAccessToken: async (token) => ({
+              token,
+              clientId: "bound-client",
+              scopes: ["bound:read"],
+              expiresAt: Date.now() / 1000 + 60,
+              resource: boundResource!,
+              extra: { upstream: true },
+            }),
+          },
+          mapAuthInfo: (authInfo) => ({
+            user: { id: `bound:${authInfo.clientId}` },
+            payload: { token: authInfo.token },
+            permissions: ["bound:permission"],
+          }),
+          requiredScopes: effectiveRequiredScopes,
+          scopesSupported: effectiveSupportedScopes,
+          resourceName: "Bound OAuth server",
+          serviceDocumentationUrl: new URL(
+            "https://bound-issuer.example.test/docs"
+          ),
+          middleware: async (request, next) => {
+            const path = new URL(request.url).pathname;
+            order.push(`provider:before:${path}`);
+            if (path === "/oauth/local") {
+              order.push("provider:handled");
+              return Response.json({ issuer: effectiveMetadata.issuer });
+            }
+            const response = await next();
+            order.push(`provider:after:${path}`);
+            return response;
+          },
+        };
+      },
+    };
+    const oauthServer = new MCPServer({
+      name: "resource-bound-oauth-test",
+      version: "1.0.0",
+      logging: { enabled: false },
+      allowedOrigins: ["https://allowed.example.test"],
+      oauth: resourceBoundProvider,
+    });
+    oauthServer.use("*", async (_context, next) => {
+      order.push("user:before");
+      await next();
+      order.push("user:after");
+    });
+    oauthServer.get("/unrelated", (context) => context.text("unrelated"));
+    oauthServer.tool({ name: "whoami" }, async (_params, context) => {
+      observedAuth = {
+        user: context.auth.user,
+        payload: context.auth.payload,
+        permissions: [...context.auth.permissions],
+      };
+      return { content: [{ type: "text", text: context.auth.user.id }] };
+    });
+
+    const blocked = await oauthServer.fetch(
+      request("/oauth/local", {
+        method: "POST",
+        headers: { origin: "https://blocked.example.test" },
+      })
+    );
+    expect(blocked.status).toBe(403);
+    expect(order).toEqual([]);
+
+    const owned = await oauthServer.fetch(request("/oauth/local"));
+    expect(owned.status).toBe(200);
+    expect(await owned.json()).toEqual({
+      issuer: "https://bound-issuer.example.test",
+    });
+    expect(order).toEqual(["provider:before:/oauth/local", "provider:handled"]);
+    expect(bindCalls).toBe(1);
+    expect(boundResource?.href).toBe("https://canonical.example.test/mcp");
+
+    effectiveMetadata.issuer = "https://mutated.example.test";
+    effectiveRequiredScopes.push("mutated:scope");
+    effectiveSupportedScopes.push("mutated:scope");
+
+    order.length = 0;
+    const metadata = await oauthServer.fetch(
+      request("/.well-known/oauth-protected-resource/mcp")
+    );
+    expect(await metadata.json()).toMatchObject({
+      resource: "https://canonical.example.test/mcp",
+      authorization_servers: ["https://bound-issuer.example.test"],
+      scopes_supported: ["bound:read", "bound:write"],
+      resource_name: "Bound OAuth server",
+    });
+    const authorizationMetadata = await oauthServer.fetch(
+      request("/.well-known/oauth-authorization-server")
+    );
+    expect(await authorizationMetadata.json()).toMatchObject({
+      issuer: "https://bound-issuer.example.test",
+      authorization_endpoint:
+        "https://bound-issuer.example.test/oauth/authorize",
+    });
+    expect(order).toEqual([]);
+
+    const unrelated = await oauthServer.fetch(request("/unrelated"));
+    expect(await unrelated.text()).toBe("unrelated");
+    expect(order).toEqual([
+      "provider:before:/unrelated",
+      "user:before",
+      "user:after",
+      "provider:after:/unrelated",
+    ]);
+
+    order.length = 0;
+    const unauthorized = await oauthServer.fetch(
+      request("/mcp", { method: "POST" })
+    );
+    expect(unauthorized.status).toBe(401);
+    expect(order).toEqual(["provider:before:/mcp", "provider:after:/mcp"]);
+
+    order.length = 0;
+    const authenticated = await oauthServer.fetch(
+      request("/mcp", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer bound-token",
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+          "mcp-protocol-version": "2026-07-28",
+          "mcp-method": "tools/call",
+          "mcp-name": "whoami",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: {
+            name: "whoami",
+            arguments: {},
+            _meta: {
+              "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+              "io.modelcontextprotocol/clientInfo": {
+                name: "bound-provider-test",
+                version: "1.0.0",
+              },
+              "io.modelcontextprotocol/clientCapabilities": {},
+            },
+          },
+        }),
+      })
+    );
+    expect(authenticated.status).toBe(200);
+    expect(observedAuth).toEqual({
+      user: { id: "bound:bound-client" },
+      payload: { token: "bound-token" },
+      permissions: ["bound:permission"],
+    });
+    expect(bindCalls).toBe(1);
+  });
+
+  it("rejects invalid resource-bound provider bindings at mount", async () => {
+    const validBinding = () => ({
+      oauthMetadata: {
+        issuer: "https://bound-issuer.example.test",
+      } as OAuthMetadata,
+      tokenVerifier: {
+        verifyAccessToken: async () => ({
+          token: "token",
+          clientId: "client",
+          scopes: [],
+          expiresAt: Date.now() / 1000 + 60,
+          resource: new URL("https://canonical.example.test/mcp"),
+        }),
+      },
+      mapAuthInfo: () => ({
+        user: { id: "user" },
+        payload: {},
+        permissions: [],
+      }),
+    });
+    const invalidBindings: Array<[string, unknown]> = [
+      ["bind must return an object", null],
+      ["oauthMetadata", { ...validBinding(), oauthMetadata: {} }],
+      ["OAuthTokenVerifier", { ...validBinding(), tokenVerifier: {} }],
+      ["mapAuthInfo", { ...validBinding(), mapAuthInfo: undefined }],
+      ["requiredScopes", { ...validBinding(), requiredScopes: [123] }],
+      ["resourceName", { ...validBinding(), resourceName: "   " }],
+      [
+        "serviceDocumentationUrl",
+        {
+          ...validBinding(),
+          serviceDocumentationUrl: "https://example.test/docs",
+        },
+      ],
+      ["middleware", { ...validBinding(), middleware: {} }],
+    ];
+
+    for (const [message, binding] of invalidBindings) {
+      const invalidProvider: OAuthProvider<{ id: string }> = {
+        resource: "https://canonical.example.test/mcp",
+        bind: () => binding as never,
+      };
+      const invalidServer = new MCPServer({
+        name: "invalid-bound-provider",
+        version: "1.0.0",
+        oauth: invalidProvider,
+      });
+      await expect(
+        invalidServer.fetch(
+          request("/.well-known/oauth-protected-resource/mcp")
+        )
+      ).rejects.toThrow(message);
+    }
   });
 
   it("returns OAuth wire errors and a canonical path-aware challenge", async () => {

--- a/libraries/typescript/packages/server/tests/oauth-wiring-types.test.ts
+++ b/libraries/typescript/packages/server/tests/oauth-wiring-types.test.ts
@@ -52,6 +52,54 @@ function verifyStructuralProviderTyping(
     }),
   };
   void directProvider;
+
+  const resourceBoundProvider: OAuthProvider<TestUser> = {
+    resource: "https://api.example.test/mcp",
+    bind: (resource) => ({
+      oauthMetadata: {
+        issuer: new URL("/oauth", resource.origin).href,
+      } as OAuthMetadata,
+      tokenVerifier,
+      mapAuthInfo: () => ({
+        user: { id: "user-1" },
+        payload: {},
+        permissions: [],
+      }),
+      requiredScopes: ["mcp"],
+      middleware: async (_request, next) => next(),
+    }),
+  };
+  new MCPServer({
+    name: "resource-bound-provider",
+    version: "1.0.0",
+    oauth: resourceBoundProvider,
+  });
+
+  const inferredResourceBoundServer = new MCPServer({
+    name: "inferred-resource-bound-provider",
+    version: "1.0.0",
+    oauth: {
+      resource: "https://api.example.test/mcp",
+      bind: () => ({
+        oauthMetadata,
+        tokenVerifier,
+        mapAuthInfo: () => ({
+          user: { id: "user-1", role: "admin" as const },
+          payload: {},
+          permissions: [],
+        }),
+      }),
+    },
+  });
+  inferredResourceBoundServer.tool(
+    { name: "bound-user" },
+    (_params, context) => {
+      const id: string = context.auth.user.id;
+      const role: "admin" = context.auth.user.role;
+      void [id, role];
+      return { content: [] };
+    }
+  );
 }
 
 function assertOAuthAuthFields<TUser>(auth: OAuthAuth<TUser>): void {


### PR DESCRIPTION
## Summary

Extends the server's internal OAuth provider boundary so a provider can be bound to the canonical protected resource before routes and bearer verification are mounted.

## Review focus

- Adds a resource-bound provider contract needed by the embedded authorization server.
- Adapts all existing first-class providers without changing their public configuration.
- Preserves direct resource-server provider behavior.

## Validation

- Existing direct-provider and OAuth wiring tests remain green.
- Included in the full OAuth run: 13 test files, 137 tests.
- Server typecheck, build, ESLint, and Prettier pass.

PR 4 of 8. Based on #2341; next: #2343.
