### PR TITLE
feat(server): add OAuth proxy authorization routes

### DIFF
--- a/libraries/typescript/packages/server/src/oauth/proxy/authorization-routes.ts
+++ b/libraries/typescript/packages/server/src/oauth/proxy/authorization-routes.ts
@@ -1,0 +1,1194 @@
+import {
+  OAuthClientInformationFullSchema,
+  OAuthClientMetadataSchema,
+  OAuthClientRegistrationErrorSchema,
+  OAuthErrorResponseSchema,
+  OAuthTokenRevocationRequestSchema,
+  OAuthTokensSchema,
+} from "@modelcontextprotocol/core";
+
+import type { FetchMiddleware } from "../../fetch-app.js";
+import {
+  OAuthAuthorizationCore,
+  OAuthAuthorizationCoreError,
+  type LocalOAuthTokenSet,
+} from "./authorization-core.js";
+import type { OAuthProxyJsonObject } from "./authorization-records.js";
+import {
+  UpstreamOAuthClient,
+  UpstreamOAuthError,
+  type UpstreamTokenSet,
+} from "./upstream-client.js";
+
+const DEFAULT_MAX_BODY_BYTES = 64 * 1024;
+const BROWSER_COOKIE = "mcp_oauth_browser";
+const HANDLE_PATTERN = /^[A-Za-z0-9_-]{43}$/u;
+const PKCE_CHALLENGE_PATTERN = /^[A-Za-z0-9_-]{43}$/u;
+const PKCE_VERIFIER_PATTERN = /^[A-Za-z0-9._~-]{43,128}$/u;
+const SCOPE_PATTERN = /^[\u0021\u0023-\u005B\u005D-\u007E]+$/u;
+const encoder = new TextEncoder();
+
+type CryptoImplementation = Pick<Crypto, "getRandomValues">;
+
+/** @internal Provider-specific context for an explicit upstream resource mapping. */
+export interface OAuthProxyUpstreamResourceContext {
+  readonly phase: "authorization" | "refresh";
+  readonly localResource: string;
+  readonly scopes: readonly string[];
+  readonly userPayload?: OAuthProxyJsonObject;
+}
+
+/** @internal Options for the embedded OAuth proxy's Web-standard route middleware. */
+export interface OAuthAuthorizationRoutesOptions {
+  /** Exact local OAuth issuer URL. */
+  readonly issuer: string | URL;
+  /** Exact canonical MCP resource URL accepted from downstream clients. */
+  readonly resource: string | URL;
+  /** Exact route prefix mounted by the caller, for example `/oauth`. */
+  readonly prefix: string;
+  /** Locally grantable downstream scopes. */
+  readonly scopes: readonly string[];
+  /** Persistence-backed local authorization server state machine. */
+  readonly core: OAuthAuthorizationCore;
+  /** Narrow client for the shared upstream OAuth application. */
+  readonly upstreamClient: UpstreamOAuthClient;
+  /** Scopes requested from the upstream provider; defaults to the local scopes. */
+  readonly upstreamScopes?: readonly string[];
+  /** Verifies the upstream access token and returns persistable trusted identity data. */
+  readonly verifyToken: (
+    accessToken: string
+  ) => OAuthProxyJsonObject | Promise<OAuthProxyJsonObject>;
+  /**
+   * Verifies an upstream ID token. Its claims are only used for nonce validation
+   * after this hook has established signature, issuer, and audience trust.
+   */
+  readonly verifyIdToken?: (
+    idToken: string,
+    tokens: UpstreamTokenSet
+  ) =>
+    | Readonly<Record<string, unknown>>
+    | Promise<Readonly<Record<string, unknown>>>;
+  /** Explicit provider-specific mapping; the MCP resource is never forwarded implicitly. */
+  readonly mapUpstreamResource?: (
+    context: OAuthProxyUpstreamResourceContext
+  ) => string | URL | undefined | Promise<string | URL | undefined>;
+  /** Additional redirect policy applied after the secure exact-URI defaults. */
+  readonly validateRedirectUri?: (
+    redirectUri: URL
+  ) => boolean | void | Promise<boolean | void>;
+  /** Web Crypto seam used only for the stable browser-binding cookie. */
+  readonly crypto?: CryptoImplementation;
+  /** Clock seam used for translating upstream token lifetimes. */
+  readonly now?: () => number;
+  /** Maximum accepted registration and form body size. */
+  readonly maxBodyBytes?: number;
+}
+
+interface ResolvedOptions extends Omit<
+  OAuthAuthorizationRoutesOptions,
+  "issuer" | "resource" | "prefix" | "scopes" | "upstreamScopes"
+> {
+  readonly issuer: URL;
+  readonly resource: string;
+  readonly prefix: string;
+  readonly scopes: readonly string[];
+  readonly scopeSet: ReadonlySet<string>;
+  readonly upstreamScopes: readonly string[];
+  readonly callbackUri: string;
+  readonly crypto: CryptoImplementation;
+  readonly now: () => number;
+  readonly maxBodyBytes: number;
+}
+
+/**
+ * @internal Creates the embedded OAuth proxy routes without coupling them to
+ * the public provider factory or Hono. Non-owned paths fall through to `next`.
+ */
+export function createOAuthAuthorizationRoutes(
+  options: OAuthAuthorizationRoutesOptions
+): FetchMiddleware {
+  const resolved = resolveOptions(options);
+  const paths = new Map<string, ReadonlySet<string>>([
+    [`${resolved.prefix}/register`, new Set(["POST"])],
+    [`${resolved.prefix}/authorize`, new Set(["GET", "POST"])],
+    [`${resolved.prefix}/callback`, new Set(["GET"])],
+    [`${resolved.prefix}/token`, new Set(["POST"])],
+    [`${resolved.prefix}/revoke`, new Set(["POST"])],
+  ]);
+
+  return async (request, next) => {
+    const url = new URL(request.url);
+    const methods = paths.get(url.pathname);
+    if (methods === undefined) return next();
+    if (!methods.has(request.method)) {
+      return ownedResponse("Method Not Allowed", {
+        status: 405,
+        headers: { Allow: Array.from(methods).join(", ") },
+      });
+    }
+
+    try {
+      switch (`${request.method} ${url.pathname}`) {
+        case `POST ${resolved.prefix}/register`:
+          return await register(request, resolved);
+        case `GET ${resolved.prefix}/authorize`:
+          return await authorizeGet(request, url, resolved);
+        case `POST ${resolved.prefix}/authorize`:
+          return await authorizePost(request, resolved);
+        case `GET ${resolved.prefix}/callback`:
+          return await callback(request, url, resolved);
+        case `POST ${resolved.prefix}/token`:
+          return await token(request, resolved);
+        case `POST ${resolved.prefix}/revoke`:
+          return await revoke(request, resolved);
+        default:
+          return ownedResponse("Not Found", { status: 404 });
+      }
+    } catch (error) {
+      return routeFailure(error);
+    }
+  };
+}
+
+async function register(
+  request: Request,
+  options: ResolvedOptions
+): Promise<Response> {
+  if (!isMediaType(request, "application/json")) {
+    return registrationError("invalid_client_metadata", 415);
+  }
+  let parsedBody: unknown;
+  try {
+    parsedBody = await readJson(request, options.maxBodyBytes);
+  } catch (error) {
+    if (error instanceof RouteOAuthError) {
+      return registrationError("invalid_client_metadata", error.status);
+    }
+    throw error;
+  }
+  const parsed = OAuthClientMetadataSchema.safeParse(parsedBody);
+  if (!parsed.success) {
+    return registrationError("invalid_client_metadata", 400);
+  }
+  const metadata = parsed.data;
+  if (
+    !hasOnlyKeys(parsedBody, [
+      "redirect_uris",
+      "token_endpoint_auth_method",
+      "grant_types",
+      "response_types",
+      "application_type",
+      "client_name",
+      "client_uri",
+      "logo_uri",
+      "scope",
+      "contacts",
+      "tos_uri",
+      "policy_uri",
+      "software_id",
+      "software_version",
+      "software_statement",
+    ]) ||
+    (metadata.token_endpoint_auth_method !== undefined &&
+      metadata.token_endpoint_auth_method !== "none") ||
+    (metadata.grant_types !== undefined &&
+      !isSupportedSet(metadata.grant_types, [
+        "authorization_code",
+        "refresh_token",
+      ])) ||
+    (metadata.response_types !== undefined &&
+      !isSupportedSet(metadata.response_types, ["code"])) ||
+    (metadata.application_type !== undefined &&
+      metadata.application_type !== "native" &&
+      metadata.application_type !== "web")
+  ) {
+    return registrationError("invalid_client_metadata", 400);
+  }
+
+  const redirectUris = metadata.redirect_uris;
+  if (
+    redirectUris.length === 0 ||
+    redirectUris.length > 32 ||
+    new Set(redirectUris).size !== redirectUris.length
+  ) {
+    return registrationError("invalid_redirect_uri", 400);
+  }
+  try {
+    for (const value of redirectUris) {
+      const redirectUri = validateRedirectUri(value);
+      const hookResult = await options.validateRedirectUri?.(redirectUri);
+      if (hookResult === false) throw new InvalidRedirectUriError();
+    }
+  } catch {
+    return registrationError("invalid_redirect_uri", 400);
+  }
+
+  let registeredScopes: string[];
+  try {
+    registeredScopes =
+      metadata.scope === undefined || metadata.scope === ""
+        ? [...options.scopes]
+        : parseScope(metadata.scope, options.scopeSet);
+  } catch {
+    return registrationError("invalid_client_metadata", 400);
+  }
+  if (metadata.client_name !== undefined) {
+    if (
+      metadata.client_name.length === 0 ||
+      encoder.encode(metadata.client_name).byteLength > 512
+    ) {
+      return registrationError("invalid_client_metadata", 400);
+    }
+  }
+
+  const registered = await options.core.registerClient({
+    redirectUris,
+    ...(metadata.client_name === undefined
+      ? {}
+      : { clientName: metadata.client_name }),
+    ...(registeredScopes.length === 0
+      ? {}
+      : { scope: registeredScopes.join(" ") }),
+  });
+  const output = OAuthClientInformationFullSchema.parse({
+    redirect_uris: registered.redirectUris,
+    token_endpoint_auth_method: "none",
+    grant_types: ["authorization_code", "refresh_token"],
+    response_types: ["code"],
+    ...(registered.clientName === undefined
+      ? {}
+      : { client_name: registered.clientName }),
+    ...(registered.scope === undefined ? {} : { scope: registered.scope }),
+    client_id: registered.clientId,
+    client_id_issued_at: Math.floor(registered.createdAt / 1000),
+  });
+  return jsonResponse(output, 201, true);
+}
+
+async function authorizeGet(
+  _request: Request,
+  url: URL,
+  options: ResolvedOptions
+): Promise<Response> {
+  const params = strictParams(url.searchParams, [
+    "response_type",
+    "client_id",
+    "redirect_uri",
+    "state",
+    "resource",
+    "scope",
+    "code_challenge",
+    "code_challenge_method",
+  ]);
+  if (
+    params.response_type !== "code" ||
+    params.state === undefined ||
+    params.state.length === 0 ||
+    params.state.length > 2048 ||
+    params.client_id === undefined ||
+    !HANDLE_PATTERN.test(params.client_id) ||
+    params.redirect_uri === undefined ||
+    params.resource !== options.resource ||
+    params.code_challenge_method !== "S256" ||
+    params.code_challenge === undefined ||
+    !PKCE_CHALLENGE_PATTERN.test(params.code_challenge)
+  ) {
+    throw new RouteOAuthError("invalid_request", 400);
+  }
+  const client = await options.core.getClient(params.client_id);
+  if (
+    client === undefined ||
+    !client.redirectUris.includes(params.redirect_uri)
+  ) {
+    throw new RouteOAuthError("invalid_client", 400);
+  }
+  const clientScopes = new Set(
+    parseScope(client.scope ?? "", options.scopeSet)
+  );
+  const requestedScopes = parseScope(params.scope ?? "", options.scopeSet);
+  if (requestedScopes.some((scope) => !clientScopes.has(scope))) {
+    throw new RouteOAuthError("invalid_scope", 400);
+  }
+
+  const browser = browserBinding(_request, options);
+  const transaction = await options.core.createConsentTransaction({
+    clientId: client.clientId,
+    redirectUri: params.redirect_uri,
+    resource: options.resource,
+    scopes: requestedScopes,
+    downstreamState: params.state,
+    codeChallenge: params.code_challenge,
+    browserBinding: browser.value,
+  });
+  const html = consentHtml({
+    clientName: client.clientName ?? "MCP client",
+    clientId: client.clientId,
+    resource: options.resource,
+    scopes: requestedScopes,
+    transactionId: transaction.transactionId,
+    csrfToken: transaction.csrfToken,
+    action: `${options.prefix}/authorize`,
+  });
+  const headers = new Headers({
+    "Content-Type": "text/html; charset=utf-8",
+    "Content-Security-Policy":
+      "default-src 'none'; base-uri 'none'; frame-ancestors 'none'; form-action 'self'",
+    "X-Content-Type-Options": "nosniff",
+    "Referrer-Policy": "no-referrer",
+  });
+  if (browser.setCookie !== undefined) {
+    headers.append("Set-Cookie", browser.setCookie);
+  }
+  return ownedResponse(html, { status: 200, headers });
+}
+
+async function authorizePost(
+  request: Request,
+  options: ResolvedOptions
+): Promise<Response> {
+  const form = await readForm(request, options.maxBodyBytes);
+  const params = strictParams(form, [
+    "transaction_id",
+    "csrf_token",
+    "decision",
+  ]);
+  if (
+    params.transaction_id === undefined ||
+    !HANDLE_PATTERN.test(params.transaction_id) ||
+    params.csrf_token === undefined ||
+    !HANDLE_PATTERN.test(params.csrf_token) ||
+    (params.decision !== "approve" && params.decision !== "deny")
+  ) {
+    throw new RouteOAuthError("invalid_request", 400);
+  }
+  const browser = requireBrowserBinding(request);
+  const consent = await options.core.consumeConsentTransaction({
+    transactionId: params.transaction_id,
+    csrfToken: params.csrf_token,
+    browserBinding: browser,
+  });
+  if (params.decision === "deny") {
+    return downstreamRedirect(consent.redirectUri, {
+      error: "access_denied",
+      state: consent.downstreamState,
+    });
+  }
+
+  const upstreamResource = await mapUpstreamResource(options, {
+    phase: "authorization",
+    localResource: consent.resource,
+    scopes: consent.scopes,
+  });
+  const authorization = await options.upstreamClient.createAuthorizationRequest(
+    {
+      redirectUri: options.callbackUri,
+      scopes: options.upstreamScopes,
+      includeNonce: options.verifyIdToken !== undefined,
+      ...(upstreamResource === undefined ? {} : { resource: upstreamResource }),
+    }
+  );
+  await options.core.createUpstreamCallbackTransaction({
+    upstreamState: authorization.transaction.state,
+    clientId: consent.clientId,
+    redirectUri: consent.redirectUri,
+    resource: consent.resource,
+    scopes: consent.scopes,
+    downstreamState: consent.downstreamState,
+    downstreamCodeChallenge: consent.codeChallenge,
+    browserBinding: browser,
+    upstreamCodeVerifier: authorization.transaction.codeVerifier,
+    upstreamRedirectUri: authorization.transaction.redirectUri,
+    ...(authorization.transaction.nonce === undefined
+      ? {}
+      : { upstreamNonce: authorization.transaction.nonce }),
+    ...(authorization.transaction.resource === undefined
+      ? {}
+      : { upstreamResource: authorization.transaction.resource }),
+  });
+  return redirect(authorization.url.toString());
+}
+
+async function callback(
+  request: Request,
+  url: URL,
+  options: ResolvedOptions
+): Promise<Response> {
+  const callbackParams = strictParams(url.searchParams, [
+    "state",
+    "code",
+    "iss",
+    "error",
+    "error_description",
+    "error_uri",
+  ]);
+  if (
+    callbackParams.state === undefined ||
+    !HANDLE_PATTERN.test(callbackParams.state)
+  ) {
+    throw new RouteOAuthError("invalid_request", 400);
+  }
+  const browser = requireBrowserBinding(request);
+  const callbackState = await options.core.consumeUpstreamCallbackTransaction({
+    state: callbackParams.state,
+    browserBinding: browser,
+  });
+  try {
+    const transaction = {
+      state: callbackParams.state,
+      codeVerifier: callbackState.upstreamCodeVerifier,
+      redirectUri: callbackState.upstreamRedirectUri,
+      ...(callbackState.upstreamNonce === undefined
+        ? {}
+        : { nonce: callbackState.upstreamNonce }),
+      ...(callbackState.upstreamResource === undefined
+        ? {}
+        : { resource: callbackState.upstreamResource }),
+    };
+    const tokens = await options.upstreamClient.exchangeAuthorizationCode({
+      authorizationResponse: url.searchParams,
+      transaction,
+      ...(callbackState.upstreamResource === undefined
+        ? {}
+        : { resource: callbackState.upstreamResource }),
+    });
+    if (callbackState.upstreamNonce !== undefined) {
+      if (tokens.idToken === undefined || options.verifyIdToken === undefined) {
+        throw new RouteOAuthError("server_error", 502);
+      }
+      const claims = await options.verifyIdToken(tokens.idToken, tokens);
+      options.upstreamClient.validateVerifiedIdTokenClaims(transaction, claims);
+    }
+    const userPayload = await options.verifyToken(tokens.accessToken);
+    const grant = await options.core.persistGrantAndIssueAuthorizationCode({
+      clientId: callbackState.clientId,
+      redirectUri: callbackState.redirectUri,
+      resource: callbackState.resource,
+      scopes: callbackState.scopes,
+      codeChallenge: callbackState.downstreamCodeChallenge,
+      grant: {
+        tokens: storedTokenSet(tokens, options.now()),
+        userPayload,
+      },
+    });
+    return downstreamRedirect(callbackState.redirectUri, {
+      code: grant.code,
+      state: callbackState.downstreamState,
+    });
+  } catch (error) {
+    return downstreamRedirect(callbackState.redirectUri, {
+      error:
+        error instanceof UpstreamOAuthError && error.code === "access_denied"
+          ? "access_denied"
+          : "server_error",
+      state: callbackState.downstreamState,
+    });
+  }
+}
+
+async function token(
+  request: Request,
+  options: ResolvedOptions
+): Promise<Response> {
+  if (request.headers.has("Authorization")) {
+    throw new RouteOAuthError("invalid_client", 401);
+  }
+  const form = await readForm(request, options.maxBodyBytes);
+  const params = strictParams(form, [
+    "grant_type",
+    "client_id",
+    "client_secret",
+    "code",
+    "redirect_uri",
+    "code_verifier",
+    "refresh_token",
+    "resource",
+  ]);
+  if (
+    params.client_secret !== undefined ||
+    params.client_id === undefined ||
+    !HANDLE_PATTERN.test(params.client_id)
+  ) {
+    throw new RouteOAuthError("invalid_client", 401);
+  }
+  if (params.resource !== options.resource) {
+    throw new RouteOAuthError("invalid_target", 400);
+  }
+  const client = await options.core.getClient(params.client_id);
+  if (client === undefined) throw new RouteOAuthError("invalid_client", 401);
+
+  let result: LocalOAuthTokenSet;
+  if (params.grant_type === "authorization_code") {
+    if (
+      params.code === undefined ||
+      !HANDLE_PATTERN.test(params.code) ||
+      params.redirect_uri === undefined ||
+      params.code_verifier === undefined ||
+      !PKCE_VERIFIER_PATTERN.test(params.code_verifier) ||
+      !client.redirectUris.includes(params.redirect_uri) ||
+      params.refresh_token !== undefined
+    ) {
+      throw new RouteOAuthError("invalid_grant", 400);
+    }
+    result = await options.core.exchangeAuthorizationCode({
+      code: params.code,
+      clientId: params.client_id,
+      redirectUri: params.redirect_uri,
+      resource: options.resource,
+      codeVerifier: params.code_verifier,
+    });
+  } else if (params.grant_type === "refresh_token") {
+    if (
+      params.refresh_token === undefined ||
+      !HANDLE_PATTERN.test(params.refresh_token) ||
+      params.code !== undefined ||
+      params.redirect_uri !== undefined ||
+      params.code_verifier !== undefined
+    ) {
+      throw new RouteOAuthError("invalid_grant", 400);
+    }
+    result = await refresh(params.refresh_token, params.client_id, options);
+  } else {
+    throw new RouteOAuthError("unsupported_grant_type", 400);
+  }
+  const output = OAuthTokensSchema.parse({
+    access_token: result.accessToken,
+    refresh_token: result.refreshToken,
+    token_type: result.tokenType,
+    expires_in: result.expiresIn,
+    scope: result.scope,
+  });
+  return jsonResponse(output, 200, true);
+}
+
+async function refresh(
+  refreshToken: string,
+  clientId: string,
+  options: ResolvedOptions
+): Promise<LocalOAuthTokenSet> {
+  const binding = {
+    refreshToken,
+    clientId,
+    resource: options.resource,
+  };
+  try {
+    return await options.core.rotateRefreshToken(binding);
+  } catch (error) {
+    if (
+      !(error instanceof OAuthAuthorizationCoreError) ||
+      error.code !== "upstream_reauthorization_required"
+    ) {
+      throw error;
+    }
+  }
+
+  const attempt = await options.core.beginUpstreamRefresh(binding);
+  if (attempt.upstreamTokens.refreshToken === undefined) {
+    await options.core.markUpstreamRefreshAmbiguous({
+      attemptToken: attempt.attemptToken,
+    });
+    throw new RouteOAuthError("invalid_grant", 400);
+  }
+  try {
+    const upstreamResource = await mapUpstreamResource(options, {
+      phase: "refresh",
+      localResource: attempt.resource,
+      scopes: attempt.scopes,
+      userPayload: attempt.userPayload,
+    });
+    const tokens = await options.upstreamClient.refreshToken({
+      refreshToken: attempt.upstreamTokens.refreshToken,
+      ...(upstreamResource === undefined ? {} : { resource: upstreamResource }),
+    });
+    const updatedTokens =
+      tokens.scope === undefined && attempt.upstreamTokens.scope !== undefined
+        ? { ...tokens, scope: attempt.upstreamTokens.scope }
+        : tokens;
+    const userPayload = await options.verifyToken(tokens.accessToken);
+    return await options.core.completeUpstreamRefresh({
+      attemptToken: attempt.attemptToken,
+      updatedGrant: {
+        tokens: storedTokenSet(updatedTokens, options.now()),
+        userPayload,
+      },
+    });
+  } catch (error) {
+    await options.core.markUpstreamRefreshAmbiguous({
+      attemptToken: attempt.attemptToken,
+    });
+    throw error;
+  }
+}
+
+async function revoke(
+  request: Request,
+  options: ResolvedOptions
+): Promise<Response> {
+  // RFC 7009 is deliberately enumeration-safe. Malformed token values and
+  // incorrect hints receive the same success response as unknown tokens.
+  if (request.headers.has("Authorization")) {
+    return ownedResponse(null, { status: 200, headers: protocolHeaders(true) });
+  }
+  let form: URLSearchParams;
+  try {
+    form = await readForm(request, options.maxBodyBytes);
+  } catch {
+    return ownedResponse(null, { status: 200, headers: protocolHeaders(true) });
+  }
+  let params: Record<string, string | undefined>;
+  try {
+    params = strictParams(form, ["token", "token_type_hint", "client_id"]);
+  } catch {
+    return ownedResponse(null, { status: 200, headers: protocolHeaders(true) });
+  }
+  const parsed = OAuthTokenRevocationRequestSchema.safeParse({
+    token: params.token,
+    ...(params.token_type_hint === undefined
+      ? {}
+      : { token_type_hint: params.token_type_hint }),
+  });
+  if (
+    parsed.success &&
+    (params.client_id === undefined ||
+      !HANDLE_PATTERN.test(params.client_id) ||
+      (await options.core.getClient(params.client_id)) !== undefined)
+  ) {
+    await options.core.revokeLocalToken({
+      token: parsed.data.token,
+      ...(parsed.data.token_type_hint === undefined
+        ? {}
+        : { tokenTypeHint: parsed.data.token_type_hint }),
+    });
+  }
+  return ownedResponse(null, { status: 200, headers: protocolHeaders(true) });
+}
+
+function resolveOptions(
+  options: OAuthAuthorizationRoutesOptions
+): ResolvedOptions {
+  if (typeof options !== "object" || options === null) {
+    throw new TypeError("OAuth authorization route options must be an object");
+  }
+  const issuer = secureUrl(options.issuer, "issuer");
+  if (issuer.search !== "") {
+    throw new TypeError("OAuth issuer must not contain a query");
+  }
+  const resource = secureUrl(options.resource, "resource").toString();
+  const prefix = normalizePrefix(options.prefix);
+  if (issuer.pathname !== prefix && issuer.pathname !== `${prefix}/`) {
+    throw new TypeError("OAuth issuer pathname must match the route prefix");
+  }
+  const scopes = normalizeConfiguredScopes(options.scopes, "scopes");
+  const upstreamScopes = normalizeConfiguredScopes(
+    options.upstreamScopes ?? scopes,
+    "upstreamScopes"
+  );
+  if (!(options.core instanceof OAuthAuthorizationCore)) {
+    throw new TypeError("core must be an OAuthAuthorizationCore");
+  }
+  if (!(options.upstreamClient instanceof UpstreamOAuthClient)) {
+    throw new TypeError("upstreamClient must be an UpstreamOAuthClient");
+  }
+  if (typeof options.verifyToken !== "function") {
+    throw new TypeError("verifyToken must be a function");
+  }
+  if (
+    options.verifyIdToken !== undefined &&
+    typeof options.verifyIdToken !== "function"
+  ) {
+    throw new TypeError("verifyIdToken must be a function");
+  }
+  if (
+    options.mapUpstreamResource !== undefined &&
+    typeof options.mapUpstreamResource !== "function"
+  ) {
+    throw new TypeError("mapUpstreamResource must be a function");
+  }
+  const crypto = options.crypto ?? globalThis.crypto;
+  if (typeof crypto?.getRandomValues !== "function") {
+    throw new TypeError("OAuth authorization routes require Web Crypto");
+  }
+  const now = options.now ?? Date.now;
+  const maxBodyBytes = positiveInteger(
+    options.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES,
+    "maxBodyBytes"
+  );
+  const callbackUri = new URL(`${prefix}/callback`, issuer.origin).toString();
+  return {
+    ...options,
+    issuer,
+    resource,
+    prefix,
+    scopes,
+    scopeSet: new Set(scopes),
+    upstreamScopes,
+    callbackUri,
+    crypto,
+    now,
+    maxBodyBytes,
+  };
+}
+
+async function mapUpstreamResource(
+  options: ResolvedOptions,
+  context: OAuthProxyUpstreamResourceContext
+): Promise<string | URL | undefined> {
+  return options.mapUpstreamResource?.(context);
+}
+
+function storedTokenSet(tokens: UpstreamTokenSet, now: number) {
+  if (!Number.isSafeInteger(now) || now < 0) {
+    throw new TypeError("OAuth authorization route clock is invalid");
+  }
+  return {
+    accessToken: tokens.accessToken,
+    tokenType: tokens.tokenType,
+    ...(tokens.expiresIn === undefined
+      ? {}
+      : { accessTokenExpiresAt: now + tokens.expiresIn * 1000 }),
+    ...(tokens.refreshToken === undefined
+      ? {}
+      : { refreshToken: tokens.refreshToken }),
+    ...(tokens.scope === undefined ? {} : { scope: tokens.scope }),
+    ...(tokens.idToken === undefined ? {} : { idToken: tokens.idToken }),
+  };
+}
+
+function browserBinding(
+  request: Request,
+  options: ResolvedOptions
+): { value: string; setCookie?: string } {
+  const existing = readCookie(request.headers.get("Cookie"), BROWSER_COOKIE);
+  if (existing !== undefined && HANDLE_PATTERN.test(existing)) {
+    return { value: existing };
+  }
+  const bytes = new Uint8Array(32);
+  options.crypto.getRandomValues(bytes);
+  const value = base64Url(bytes);
+  const secure = options.issuer.protocol === "https:" ? "; Secure" : "";
+  return {
+    value,
+    setCookie: `${BROWSER_COOKIE}=${value}; Path=${options.prefix}; HttpOnly; SameSite=Lax${secure}`,
+  };
+}
+
+function requireBrowserBinding(request: Request): string {
+  const value = readCookie(request.headers.get("Cookie"), BROWSER_COOKIE);
+  if (value === undefined || !HANDLE_PATTERN.test(value)) {
+    throw new RouteOAuthError("invalid_request", 400);
+  }
+  return value;
+}
+
+function readCookie(header: string | null, name: string): string | undefined {
+  if (header === null || header.length > 8192) return undefined;
+  let found: string | undefined;
+  for (const part of header.split(";")) {
+    const index = part.indexOf("=");
+    if (index < 0) continue;
+    if (part.slice(0, index).trim() !== name) continue;
+    if (found !== undefined) return undefined;
+    found = part.slice(index + 1).trim();
+  }
+  return found;
+}
+
+async function readJson(request: Request, limit: number): Promise<unknown> {
+  const text = await readBoundedBody(request, limit);
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    throw new RouteRegistrationError("invalid_client_metadata", 400);
+  }
+}
+
+async function readForm(
+  request: Request,
+  limit: number
+): Promise<URLSearchParams> {
+  if (!isMediaType(request, "application/x-www-form-urlencoded")) {
+    throw new RouteOAuthError("invalid_request", 415);
+  }
+  return new URLSearchParams(await readBoundedBody(request, limit));
+}
+
+async function readBoundedBody(
+  request: Request,
+  limit: number
+): Promise<string> {
+  const declared = request.headers.get("Content-Length");
+  if (declared !== null) {
+    const length = Number(declared);
+    if (!Number.isSafeInteger(length) || length < 0 || length > limit) {
+      throw new RouteOAuthError("invalid_request", 413);
+    }
+  }
+  if (request.body === null) return "";
+  const reader = request.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > limit) {
+        await reader.cancel();
+        throw new RouteOAuthError("invalid_request", 413);
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    throw new RouteOAuthError("invalid_request", 400);
+  }
+}
+
+function strictParams(
+  params: URLSearchParams,
+  allowed: readonly string[]
+): Record<string, string | undefined> {
+  const allowedSet = new Set(allowed);
+  const output: Record<string, string | undefined> = {};
+  for (const [key, value] of params) {
+    if (!allowedSet.has(key) || output[key] !== undefined) {
+      throw new RouteOAuthError("invalid_request", 400);
+    }
+    output[key] = value;
+  }
+  return output;
+}
+
+function parseScope(value: string, supported: ReadonlySet<string>): string[] {
+  if (value === "") return [];
+  if (value.length > 4096) throw new RouteOAuthError("invalid_scope", 400);
+  const scopes = value.split(" ");
+  if (
+    scopes.length > 256 ||
+    scopes.some(
+      (scope) =>
+        scope.length === 0 ||
+        !SCOPE_PATTERN.test(scope) ||
+        !supported.has(scope)
+    ) ||
+    new Set(scopes).size !== scopes.length
+  ) {
+    throw new RouteOAuthError("invalid_scope", 400);
+  }
+  return scopes;
+}
+
+function validateRedirectUri(value: string): URL {
+  if (value.includes("*") || value.length > 4096) {
+    throw new InvalidRedirectUriError();
+  }
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new InvalidRedirectUriError();
+  }
+  if (
+    url.username !== "" ||
+    url.password !== "" ||
+    url.hash !== "" ||
+    url.origin === "null" ||
+    (url.protocol !== "https:" &&
+      !(url.protocol === "http:" && isLoopbackHostname(url.hostname))) ||
+    decodeURIComponentSafely(url.pathname + url.search).includes("*")
+  ) {
+    throw new InvalidRedirectUriError();
+  }
+  return url;
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  if (
+    normalized === "localhost" ||
+    normalized.endsWith(".localhost") ||
+    normalized === "[::1]"
+  ) {
+    return true;
+  }
+  const match = /^127\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/u.exec(normalized);
+  return (
+    match !== null &&
+    match.slice(1).every((part) => Number(part) >= 0 && Number(part) <= 255)
+  );
+}
+
+function secureUrl(value: string | URL, name: string): URL {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new TypeError(`${name} must be an absolute URL`);
+  }
+  if (
+    url.username !== "" ||
+    url.password !== "" ||
+    url.hash !== "" ||
+    url.origin === "null" ||
+    (url.protocol !== "https:" &&
+      !(url.protocol === "http:" && isLoopbackHostname(url.hostname)))
+  ) {
+    throw new TypeError(`${name} must use HTTPS, or HTTP for loopback`);
+  }
+  return url;
+}
+
+function normalizePrefix(value: string): string {
+  if (
+    typeof value !== "string" ||
+    !/^\/(?:[A-Za-z0-9._~-]+(?:\/[A-Za-z0-9._~-]+)*)?$/u.test(value) ||
+    value === "/"
+  ) {
+    throw new TypeError(
+      "prefix must be a non-root absolute path without a trailing slash"
+    );
+  }
+  return value;
+}
+
+function normalizeConfiguredScopes(
+  value: readonly string[],
+  name: string
+): readonly string[] {
+  const candidate: unknown = value;
+  if (!isUnknownArray(candidate) || candidate.length > 256) {
+    throw new TypeError(`${name} must contain unique OAuth scope values`);
+  }
+  const normalized: string[] = [];
+  for (const scope of candidate) {
+    if (
+      typeof scope !== "string" ||
+      scope.length === 0 ||
+      !SCOPE_PATTERN.test(scope)
+    ) {
+      throw new TypeError(`${name} must contain unique OAuth scope values`);
+    }
+    normalized.push(scope);
+  }
+  if (new Set(normalized).size !== normalized.length) {
+    throw new TypeError(`${name} must contain unique OAuth scope values`);
+  }
+  return Object.freeze(normalized);
+}
+
+function isUnknownArray(value: unknown): value is readonly unknown[] {
+  return Array.isArray(value);
+}
+
+function consentHtml(input: {
+  clientName: string;
+  clientId: string;
+  resource: string;
+  scopes: readonly string[];
+  transactionId: string;
+  csrfToken: string;
+  action: string;
+}): string {
+  const scopes =
+    input.scopes.length === 0
+      ? "<li>No additional scopes requested</li>"
+      : input.scopes.map((scope) => `<li>${escapeHtml(scope)}</li>`).join("");
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width"><title>Authorize MCP client</title></head><body><main><h1>Authorize ${escapeHtml(input.clientName)}</h1><p>Client <code>${escapeHtml(input.clientId)}</code> is requesting access to <code>${escapeHtml(input.resource)}</code>.</p><ul>${scopes}</ul><form method="post" action="${escapeHtml(input.action)}"><input type="hidden" name="transaction_id" value="${escapeHtml(input.transactionId)}"><input type="hidden" name="csrf_token" value="${escapeHtml(input.csrfToken)}"><button type="submit" name="decision" value="approve">Allow</button><button type="submit" name="decision" value="deny">Deny</button></form></main></body></html>`;
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/gu, (character) => {
+    switch (character) {
+      case "&":
+        return "&amp;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      case '"':
+        return "&quot;";
+      default:
+        return "&#39;";
+    }
+  });
+}
+
+function downstreamRedirect(
+  redirectUri: string,
+  values: Readonly<Record<string, string>>
+): Response {
+  const url = new URL(redirectUri);
+  for (const [key, value] of Object.entries(values)) {
+    url.searchParams.set(key, value);
+  }
+  return redirect(url.toString());
+}
+
+function redirect(location: string): Response {
+  return ownedResponse(null, {
+    status: 302,
+    headers: { Location: location },
+  });
+}
+
+function routeFailure(error: unknown): Response {
+  if (error instanceof RouteRegistrationError) {
+    return registrationError(error.code, error.status);
+  }
+  if (error instanceof RouteOAuthError) {
+    return oauthError(error.code, error.status);
+  }
+  if (error instanceof OAuthAuthorizationCoreError) {
+    return oauthError(coreErrorCode(error.code), coreErrorStatus(error.code));
+  }
+  if (error instanceof UpstreamOAuthError) {
+    return oauthError("server_error", 502);
+  }
+  return oauthError("server_error", 500);
+}
+
+function coreErrorCode(code: OAuthAuthorizationCoreError["code"]): string {
+  switch (code) {
+    case "invalid_client":
+    case "invalid_request":
+    case "invalid_grant":
+      return code;
+    case "temporarily_unavailable":
+      return "temporarily_unavailable";
+    case "invalid_token":
+    case "upstream_reauthorization_required":
+      return "invalid_grant";
+    default:
+      return "server_error";
+  }
+}
+
+function coreErrorStatus(code: OAuthAuthorizationCoreError["code"]): number {
+  return code === "invalid_client"
+    ? 401
+    : code === "temporarily_unavailable"
+      ? 503
+      : 400;
+}
+
+function oauthError(error: string, status: number): Response {
+  const body = OAuthErrorResponseSchema.parse({ error });
+  return jsonResponse(body, status, true);
+}
+
+function registrationError(error: string, status: number): Response {
+  const body = OAuthClientRegistrationErrorSchema.parse({ error });
+  return jsonResponse(body, status, true);
+}
+
+function jsonResponse(
+  value: unknown,
+  status: number,
+  pragma: boolean
+): Response {
+  return ownedResponse(JSON.stringify(value), {
+    status,
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
+      ...protocolHeaders(pragma),
+    },
+  });
+}
+
+function protocolHeaders(pragma: boolean): Record<string, string> {
+  return {
+    "Cache-Control": "no-store",
+    ...(pragma ? { Pragma: "no-cache" } : {}),
+  };
+}
+
+function ownedResponse(
+  body: BodyInit | null,
+  init: ResponseInit = {}
+): Response {
+  const headers = new Headers(init.headers);
+  headers.set("Cache-Control", "no-store");
+  return new Response(body, { ...init, headers });
+}
+
+function isMediaType(request: Request, expected: string): boolean {
+  const header = request.headers.get("Content-Type");
+  if (header === null) return false;
+  return header.split(";", 1)[0]!.trim().toLowerCase() === expected;
+}
+
+function hasOnlyKeys(value: unknown, allowed: readonly string[]): boolean {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.keys(value).every((key) => allowed.includes(key))
+  );
+}
+
+function isSupportedSet(
+  value: readonly string[],
+  supported: readonly string[]
+): boolean {
+  return (
+    value.length > 0 &&
+    new Set(value).size === value.length &&
+    value.every((item) => supported.includes(item)) &&
+    value.includes(supported[0]!)
+  );
+}
+
+function decodeURIComponentSafely(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    throw new InvalidRedirectUriError();
+  }
+}
+
+function positiveInteger(value: number, name: string): number {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new TypeError(`${name} must be a positive safe integer`);
+  }
+  return value;
+}
+
+function base64Url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary)
+    .replace(/=/gu, "")
+    .replace(/\+/gu, "-")
+    .replace(/\//gu, "_");
+}
+
+class RouteOAuthError extends Error {
+  constructor(
+    readonly code: string,
+    readonly status: number
+  ) {
+    super("OAuth request could not be completed");
+    this.name = "RouteOAuthError";
+  }
+}
+
+class RouteRegistrationError extends Error {
+  constructor(
+    readonly code: string,
+    readonly status: number
+  ) {
+    super("OAuth client registration could not be completed");
+    this.name = "RouteRegistrationError";
+  }
+}
+
+class InvalidRedirectUriError extends Error {}

--- a/libraries/typescript/packages/server/tests/oauth-proxy-authorization-routes.test.ts
+++ b/libraries/typescript/packages/server/tests/oauth-proxy-authorization-routes.test.ts
@@ -1,0 +1,835 @@
+import {
+  OAuthClientInformationFullSchema,
+  OAuthClientRegistrationErrorSchema,
+  OAuthErrorResponseSchema,
+  OAuthTokensSchema,
+} from "@modelcontextprotocol/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { OAuthAuthorizationCore } from "../src/oauth/proxy/authorization-core.js";
+import {
+  createOAuthAuthorizationRoutes,
+  type OAuthAuthorizationRoutesOptions,
+} from "../src/oauth/proxy/authorization-routes.js";
+import { resolveOAuthProxyStore } from "../src/oauth/proxy/store.js";
+import {
+  UpstreamOAuthClient,
+  type UpstreamOAuthClientOptions,
+} from "../src/oauth/proxy/upstream-client.js";
+
+const issuer = "https://mcp.example.test/oauth";
+const resource = "https://mcp.example.test/mcp";
+const redirectUri = "https://client.example.test/callback?existing=value";
+const verifier = "v".repeat(43);
+const fallback = new Response("fallback", { status: 418 });
+
+interface Harness {
+  readonly route: ReturnType<typeof createOAuthAuthorizationRoutes>;
+  readonly core: OAuthAuthorizationCore;
+  readonly fetch: ReturnType<typeof vi.fn<typeof fetch>>;
+  readonly requests: Request[];
+  readonly now: { value: number };
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+async function s256(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(value)
+  );
+  return Buffer.from(digest).toString("base64url");
+}
+
+function createHarness(
+  overrides: Partial<OAuthAuthorizationRoutesOptions> = {},
+  tokenResponses: Array<Response | Error> = [],
+  upstreamOverrides: Partial<UpstreamOAuthClientOptions> = {}
+): Harness {
+  const now = { value: 2_000_000_000_000 };
+  const requests: Request[] = [];
+  const recordingFetch = vi.fn<typeof fetch>(async (input, init) => {
+    const request = new Request(input, init);
+    requests.push(request);
+    const next = tokenResponses.shift();
+    if (next instanceof Error) throw next;
+    return (
+      next ??
+      Response.json({
+        access_token: "provider-access-secret",
+        refresh_token: "provider-refresh-secret",
+        token_type: "Bearer",
+        expires_in: 3600,
+        scope: "profile",
+      })
+    );
+  });
+  const core = new OAuthAuthorizationCore({
+    store: resolveOAuthProxyStore().store,
+    now: () => now.value,
+  });
+  const upstreamClient = new UpstreamOAuthClient({
+    authorizationEndpoint: "https://provider.example.test/authorize",
+    tokenEndpoint: "https://provider.example.test/token",
+    clientId: "shared-upstream-client",
+    clientSecret: "shared-upstream-secret",
+    tokenEndpointAuthMethod: "client_secret_basic",
+    ...upstreamOverrides,
+    fetch: recordingFetch,
+  });
+  return {
+    core,
+    fetch: recordingFetch,
+    requests,
+    now,
+    route: createOAuthAuthorizationRoutes({
+      issuer,
+      resource,
+      prefix: "/oauth",
+      scopes: ["read", "write"],
+      upstreamScopes: ["profile"],
+      core,
+      upstreamClient,
+      now: () => now.value,
+      verifyToken: () => ({ sub: "user-1" }),
+      ...overrides,
+    }),
+  };
+}
+
+async function invoke(route: Harness["route"], request: Request) {
+  return route(request, async () => fallback);
+}
+
+async function registerClient(
+  harness: Harness,
+  metadata: Record<string, unknown> = {}
+) {
+  const response = await invoke(
+    harness.route,
+    new Request(`${issuer}/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        redirect_uris: [redirectUri],
+        token_endpoint_auth_method: "none",
+        grant_types: ["authorization_code", "refresh_token"],
+        response_types: ["code"],
+        client_name: "Test MCP Client",
+        scope: "read write",
+        ...metadata,
+      }),
+    })
+  );
+  expect(response.status).toBe(201);
+  const body: unknown = await response.json();
+  expect(OAuthClientInformationFullSchema.safeParse(body).success).toBe(true);
+  return body as { client_id: string };
+}
+
+async function beginConsent(
+  harness: Harness,
+  clientId: string,
+  query: Array<[string, string]> = []
+) {
+  const challenge = await s256(verifier);
+  const url = new URL(`${issuer}/authorize`);
+  for (const [key, value] of [
+    ["response_type", "code"],
+    ["client_id", clientId],
+    ["redirect_uri", redirectUri],
+    ["state", "downstream-state"],
+    ["resource", resource],
+    ["scope", "read write"],
+    ["code_challenge", challenge],
+    ["code_challenge_method", "S256"],
+    ...query,
+  ] as Array<[string, string]>) {
+    url.searchParams.append(key, value);
+  }
+  const response = await invoke(harness.route, new Request(url));
+  const html = await response.text();
+  const cookie = response.headers.get("Set-Cookie")?.split(";", 1)[0];
+  return {
+    response,
+    html,
+    cookie,
+    transactionId: response.ok ? hidden(html, "transaction_id") : "",
+    csrfToken: response.ok ? hidden(html, "csrf_token") : "",
+    challenge,
+  };
+}
+
+function hidden(html: string, name: string): string {
+  const match = new RegExp(`name="${name}" value="([^"]+)"`, "u").exec(html);
+  if (match === null) throw new Error(`missing ${name}`);
+  return match[1]!;
+}
+
+async function approveConsent(
+  harness: Harness,
+  consent: Awaited<ReturnType<typeof beginConsent>>,
+  decision = "approve"
+) {
+  return invoke(
+    harness.route,
+    new Request(`${issuer}/authorize`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Cookie: consent.cookie!,
+      },
+      body: new URLSearchParams({
+        transaction_id: consent.transactionId,
+        csrf_token: consent.csrfToken,
+        decision,
+      }),
+    })
+  );
+}
+
+async function authorizeThroughCallback(harness: Harness, clientId: string) {
+  const consent = await beginConsent(harness, clientId);
+  const approval = await approveConsent(harness, consent);
+  const providerUrl = new URL(approval.headers.get("Location")!);
+  const callbackUrl = new URL(`${issuer}/callback`);
+  callbackUrl.searchParams.set("code", "provider-code-secret");
+  callbackUrl.searchParams.set("state", providerUrl.searchParams.get("state")!);
+  const callback = await invoke(
+    harness.route,
+    new Request(callbackUrl, { headers: { Cookie: consent.cookie! } })
+  );
+  const downstream = new URL(callback.headers.get("Location")!);
+  return { consent, approval, providerUrl, callback, downstream };
+}
+
+async function exchangeCode(harness: Harness, clientId: string, code: string) {
+  return invoke(
+    harness.route,
+    new Request(`${issuer}/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        client_id: clientId,
+        code,
+        redirect_uri: redirectUri,
+        code_verifier: verifier,
+        resource,
+      }),
+    })
+  );
+}
+
+describe("OAuth proxy authorization routes", () => {
+  it("registers only public exact-redirect clients and returns MCP wire metadata", async () => {
+    const harness = createHarness();
+    const client = await registerClient(harness);
+    expect(client.client_id).toMatch(/^[A-Za-z0-9_-]{43}$/u);
+
+    for (const bad of [
+      { token_endpoint_auth_method: "client_secret_post" },
+      { redirect_uris: ["https://client.example.test/cb#fragment"] },
+      { redirect_uris: ["http://public.example.test/cb"] },
+      { redirect_uris: ["https://user:pass@client.example.test/cb"] },
+      { redirect_uris: ["https://client.example.test/*"] },
+      { redirect_uris: [redirectUri, redirectUri] },
+    ]) {
+      const response = await invoke(
+        harness.route,
+        new Request(`${issuer}/register`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ redirect_uris: [redirectUri], ...bad }),
+        })
+      );
+      expect(response.status).toBe(400);
+      expect(
+        OAuthClientRegistrationErrorSchema.safeParse(await response.json())
+          .success
+      ).toBe(true);
+    }
+  });
+
+  it("defaults an omitted DCR scope to the configured local scope allowlist", async () => {
+    const harness = createHarness();
+    const client = await registerClient(harness, { scope: undefined });
+    const consent = await beginConsent(harness, client.client_id);
+    expect(consent.response.status).toBe(200);
+    expect(consent.html).toContain("<li>read</li><li>write</li>");
+  });
+
+  it("bounds JSON/form bodies and rejects the wrong content type", async () => {
+    const harness = createHarness({ maxBodyBytes: 128 });
+    const wrongType = await invoke(
+      harness.route,
+      new Request(`${issuer}/register`, { method: "POST", body: "{}" })
+    );
+    expect(wrongType.status).toBe(415);
+
+    const oversized = await invoke(
+      harness.route,
+      new Request(`${issuer}/register`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          redirect_uris: [redirectUri],
+          padding: "x".repeat(256),
+        }),
+      })
+    );
+    expect(oversized.status).toBe(413);
+
+    const wrongTokenType = await invoke(
+      harness.route,
+      new Request(`${issuer}/token`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+      })
+    );
+    expect(wrongTokenType.status).toBe(415);
+  });
+
+  it("strictly binds authorize requests and renders escaped, browser-bound consent", async () => {
+    const harness = createHarness();
+    const client = await registerClient(harness, {
+      client_name: '<script>alert("x")</script>',
+    });
+    const consent = await beginConsent(harness, client.client_id);
+    expect(consent.response.status).toBe(200);
+    expect(consent.html).toContain("&lt;script&gt;");
+    expect(consent.html).not.toContain('<script>alert("x")</script>');
+    expect(consent.response.headers.get("Content-Security-Policy")).toContain(
+      "frame-ancestors 'none'"
+    );
+    expect(consent.response.headers.get("Cache-Control")).toBe("no-store");
+    expect(consent.response.headers.get("Set-Cookie")).toContain(
+      "HttpOnly; SameSite=Lax; Secure"
+    );
+
+    for (const duplicate of [
+      ["resource", resource],
+      ["state", "other"],
+      ["code_challenge", consent.challenge],
+    ] as Array<[string, string]>) {
+      const rejected = await beginConsent(harness, client.client_id, [
+        duplicate,
+      ]);
+      expect(rejected.response.status).toBe(400);
+      expect(
+        OAuthErrorResponseSchema.safeParse(JSON.parse(rejected.html)).success
+      ).toBe(true);
+    }
+  });
+
+  it("derives browser cookie security from the canonical issuer behind a proxy", async () => {
+    const harness = createHarness();
+    const client = await registerClient(harness);
+    const challenge = await s256(verifier);
+    const internalUrl = new URL("http://internal.service/oauth/authorize");
+    internalUrl.search = new URLSearchParams({
+      response_type: "code",
+      client_id: client.client_id,
+      redirect_uri: redirectUri,
+      state: "downstream-state",
+      resource,
+      scope: "read",
+      code_challenge: challenge,
+      code_challenge_method: "S256",
+    }).toString();
+
+    const response = await invoke(harness.route, new Request(internalUrl));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Set-Cookie")).toContain(
+      "HttpOnly; SameSite=Lax; Secure"
+    );
+  });
+
+  it("rejects authorize state, redirect, resource, scope, and PKCE mismatches", async () => {
+    const harness = createHarness();
+    const client = await registerClient(harness);
+    const challenge = await s256(verifier);
+    const valid = new URL(`${issuer}/authorize`);
+    valid.search = new URLSearchParams({
+      response_type: "code",
+      client_id: client.client_id,
+      redirect_uri: redirectUri,
+      state: "downstream-state",
+      resource,
+      scope: "read",
+      code_challenge: challenge,
+      code_challenge_method: "S256",
+    }).toString();
+    const mutations: Array<(url: URL) => void> = [
+      (url) => url.searchParams.delete("state"),
+      (url) =>
+        url.searchParams.set(
+          "redirect_uri",
+          "https://client.example.test/other"
+        ),
+      (url) =>
+        url.searchParams.set("resource", "https://other.example.test/mcp"),
+      (url) => url.searchParams.set("scope", "admin"),
+      (url) => url.searchParams.set("code_challenge_method", "plain"),
+      (url) => url.searchParams.set("code_challenge", "short"),
+    ];
+    for (const mutate of mutations) {
+      const url = new URL(valid);
+      mutate(url);
+      const response = await invoke(harness.route, new Request(url));
+      expect(response.status).toBe(400);
+      expect(
+        OAuthErrorResponseSchema.safeParse(await response.json()).success
+      ).toBe(true);
+    }
+  });
+
+  it("one-time consumes consent, supports denial, and enforces CSRF/browser binding", async () => {
+    const harness = createHarness();
+    const client = await registerClient(harness);
+    const consent = await beginConsent(harness, client.client_id);
+    const denied = await approveConsent(harness, consent, "deny");
+    const location = new URL(denied.headers.get("Location")!);
+    expect(location.origin + location.pathname).toBe(
+      "https://client.example.test/callback"
+    );
+    expect(location.searchParams.get("existing")).toBe("value");
+    expect(location.searchParams.get("error")).toBe("access_denied");
+    expect(location.searchParams.get("state")).toBe("downstream-state");
+    expect((await approveConsent(harness, consent)).status).toBe(400);
+
+    const other = await beginConsent(harness, client.client_id);
+    const wrongBrowser = await invoke(
+      harness.route,
+      new Request(`${issuer}/authorize`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          Cookie: "mcp_oauth_browser=" + "z".repeat(43),
+        },
+        body: new URLSearchParams({
+          transaction_id: other.transactionId,
+          csrf_token: other.csrfToken,
+          decision: "approve",
+        }),
+      })
+    );
+    expect(wrongBrowser.status).toBe(400);
+  });
+
+  it("starts a separate upstream PKCE/state transaction without forwarding the MCP resource", async () => {
+    const harness = createHarness();
+    const client = await registerClient(harness);
+    const consent = await beginConsent(harness, client.client_id);
+    const approval = await approveConsent(harness, consent);
+    expect(approval.status).toBe(302);
+    const upstream = new URL(approval.headers.get("Location")!);
+    expect(upstream.origin).toBe("https://provider.example.test");
+    expect(upstream.searchParams.get("client_id")).toBe(
+      "shared-upstream-client"
+    );
+    expect(upstream.searchParams.get("state")).toMatch(/^[A-Za-z0-9_-]{43}$/u);
+    expect(upstream.searchParams.get("code_challenge")).not.toBe(
+      consent.challenge
+    );
+    expect(upstream.searchParams.has("resource")).toBe(false);
+    expect(upstream.searchParams.get("scope")).toBe("profile");
+  });
+
+  it("uses an explicit provider resource hook and validates only verified nonce claims", async () => {
+    const nonceState: { expected?: string } = {};
+    const verifyIdToken = vi.fn(async () => ({ nonce: nonceState.expected }));
+    const harness = createHarness(
+      {
+        mapUpstreamResource: ({ phase }) =>
+          phase === "authorization"
+            ? "https://provider.example.test/api"
+            : undefined,
+        verifyIdToken,
+      },
+      [
+        Response.json({
+          access_token: "provider-access-secret",
+          refresh_token: "provider-refresh-secret",
+          token_type: "Bearer",
+          id_token: "raw-provider-id-token",
+          expires_in: 3600,
+        }),
+      ]
+    );
+    const client = await registerClient(harness);
+    const consent = await beginConsent(harness, client.client_id);
+    const approval = await approveConsent(harness, consent);
+    const upstream = new URL(approval.headers.get("Location")!);
+    nonceState.expected = upstream.searchParams.get("nonce")!;
+    expect(upstream.searchParams.get("resource")).toBe(
+      "https://provider.example.test/api"
+    );
+    const callbackUrl = new URL(`${issuer}/callback`);
+    callbackUrl.searchParams.set("code", "provider-code");
+    callbackUrl.searchParams.set("state", upstream.searchParams.get("state")!);
+    const callback = await invoke(
+      harness.route,
+      new Request(callbackUrl, { headers: { Cookie: consent.cookie! } })
+    );
+    expect(callback.status).toBe(302);
+    expect(verifyIdToken).toHaveBeenCalledWith(
+      "raw-provider-id-token",
+      expect.objectContaining({ accessToken: "provider-access-secret" })
+    );
+  });
+
+  it("binds callbacks to state/browser/issuer and sanitizes upstream errors", async () => {
+    const wrongStateHarness = createHarness();
+    const wrongStateClient = await registerClient(wrongStateHarness);
+    const unknownState = new URL(`${issuer}/callback`);
+    unknownState.searchParams.set("state", "s".repeat(43));
+    unknownState.searchParams.set("code", "provider-code");
+    const unknown = await invoke(
+      wrongStateHarness.route,
+      new Request(unknownState, {
+        headers: { Cookie: "mcp_oauth_browser=" + "b".repeat(43) },
+      })
+    );
+    expect(wrongStateClient.client_id).toBeDefined();
+    expect(unknown.status).toBe(400);
+
+    const browserHarness = createHarness();
+    const browserClient = await registerClient(browserHarness);
+    const browserConsent = await beginConsent(
+      browserHarness,
+      browserClient.client_id
+    );
+    const browserApproval = await approveConsent(
+      browserHarness,
+      browserConsent
+    );
+    const browserCallback = new URL(`${issuer}/callback`);
+    browserCallback.searchParams.set("code", "provider-code");
+    browserCallback.searchParams.set(
+      "state",
+      new URL(browserApproval.headers.get("Location")!).searchParams.get(
+        "state"
+      )!
+    );
+    const wrongBrowser = await invoke(
+      browserHarness.route,
+      new Request(browserCallback, {
+        headers: { Cookie: "mcp_oauth_browser=" + "z".repeat(43) },
+      })
+    );
+    expect(wrongBrowser.status).toBe(400);
+
+    const issuerHarness = createHarness({}, [], {
+      issuer: "https://provider.example.test",
+    });
+    const issuerClient = await registerClient(issuerHarness);
+    const issuerConsent = await beginConsent(
+      issuerHarness,
+      issuerClient.client_id
+    );
+    const issuerApproval = await approveConsent(issuerHarness, issuerConsent);
+    const issuerCallback = new URL(`${issuer}/callback`);
+    issuerCallback.searchParams.set("code", "provider-code");
+    issuerCallback.searchParams.set(
+      "state",
+      new URL(issuerApproval.headers.get("Location")!).searchParams.get(
+        "state"
+      )!
+    );
+    issuerCallback.searchParams.set("iss", "https://evil.example.test");
+    const issuerMismatch = await invoke(
+      issuerHarness.route,
+      new Request(issuerCallback, {
+        headers: { Cookie: issuerConsent.cookie! },
+      })
+    );
+    expect(issuerMismatch.status).toBe(302);
+    const issuerDownstream = new URL(issuerMismatch.headers.get("Location")!);
+    expect(issuerDownstream.searchParams.get("error")).toBe("server_error");
+    expect(issuerDownstream.toString()).not.toContain("evil.example.test");
+
+    const deniedHarness = createHarness();
+    const deniedClient = await registerClient(deniedHarness);
+    const deniedConsent = await beginConsent(
+      deniedHarness,
+      deniedClient.client_id
+    );
+    const deniedApproval = await approveConsent(deniedHarness, deniedConsent);
+    const deniedCallback = new URL(`${issuer}/callback`);
+    deniedCallback.searchParams.set("error", "access_denied");
+    deniedCallback.searchParams.set(
+      "error_description",
+      "provider secret detail"
+    );
+    deniedCallback.searchParams.set(
+      "state",
+      new URL(deniedApproval.headers.get("Location")!).searchParams.get(
+        "state"
+      )!
+    );
+    const deniedResponse = await invoke(
+      deniedHarness.route,
+      new Request(deniedCallback, {
+        headers: { Cookie: deniedConsent.cookie! },
+      })
+    );
+    const deniedDownstream = new URL(deniedResponse.headers.get("Location")!);
+    expect(deniedDownstream.searchParams.get("error")).toBe("access_denied");
+    expect(deniedDownstream.toString()).not.toContain("provider+secret");
+  });
+
+  it("redirects sanitized callback completion failures to the bound client", async () => {
+    const harness = createHarness({
+      verifyToken: () => {
+        throw new Error("provider verification secret");
+      },
+    });
+    const client = await registerClient(harness);
+    const consent = await beginConsent(harness, client.client_id);
+    const approval = await approveConsent(harness, consent);
+    const callbackUrl = new URL(`${issuer}/callback`);
+    callbackUrl.searchParams.set("code", "provider-code");
+    callbackUrl.searchParams.set(
+      "state",
+      new URL(approval.headers.get("Location")!).searchParams.get("state")!
+    );
+
+    const callback = await invoke(
+      harness.route,
+      new Request(callbackUrl, { headers: { Cookie: consent.cookie! } })
+    );
+
+    expect(callback.status).toBe(302);
+    const downstream = new URL(callback.headers.get("Location")!);
+    expect(downstream.origin + downstream.pathname).toBe(
+      "https://client.example.test/callback"
+    );
+    expect(downstream.searchParams.get("error")).toBe("server_error");
+    expect(downstream.searchParams.get("state")).toBe("downstream-state");
+    expect(downstream.toString()).not.toContain("verification");
+  });
+
+  it("exchanges upstream code but returns only local opaque code and tokens downstream", async () => {
+    const harness = createHarness();
+    const client = await registerClient(harness);
+    const flow = await authorizeThroughCallback(harness, client.client_id);
+    expect(flow.callback.status).toBe(302);
+    expect(flow.downstream.searchParams.get("state")).toBe("downstream-state");
+    const code = flow.downstream.searchParams.get("code")!;
+    expect(code).toMatch(/^[A-Za-z0-9_-]{43}$/u);
+    expect(flow.downstream.toString()).not.toContain("provider-access-secret");
+
+    expect(harness.requests).toHaveLength(1);
+    expect(harness.requests[0]!.headers.get("Authorization")).toMatch(
+      /^Basic /u
+    );
+    expect(await harness.requests[0]!.text()).toContain("code_verifier=");
+
+    const response = await exchangeCode(harness, client.client_id, code);
+    expect(response.status).toBe(200);
+    const body: unknown = await response.json();
+    expect(OAuthTokensSchema.safeParse(body).success).toBe(true);
+    expect(JSON.stringify(body)).not.toContain("provider-access-secret");
+    expect(body).toMatchObject({ token_type: "Bearer", scope: "read write" });
+  });
+
+  it("rotates locally, performs one reserved upstream refresh, and makes failures terminal", async () => {
+    const harness = createHarness({}, [
+      Response.json({
+        access_token: "short-provider-access",
+        refresh_token: "rotating-provider-refresh",
+        token_type: "Bearer",
+        expires_in: 2,
+      }),
+      new Error("network secret must not escape"),
+    ]);
+    const client = await registerClient(harness);
+    const flow = await authorizeThroughCallback(harness, client.client_id);
+    const codeResponse = await exchangeCode(
+      harness,
+      client.client_id,
+      flow.downstream.searchParams.get("code")!
+    );
+    const initial = (await codeResponse.json()) as { refresh_token: string };
+    harness.now.value += 3_000;
+
+    const firstRefresh = await invoke(
+      harness.route,
+      refreshRequest(client.client_id, initial.refresh_token)
+    );
+    expect(firstRefresh.status).toBe(502);
+    expect(await firstRefresh.json()).toEqual({ error: "server_error" });
+    const upstreamRefreshRequest = harness.requests[1]!;
+    const upstreamForm = new URLSearchParams(
+      await upstreamRefreshRequest.text()
+    );
+    expect(upstreamForm.get("refresh_token")).toBe("rotating-provider-refresh");
+
+    const replay = await invoke(
+      harness.route,
+      refreshRequest(client.client_id, initial.refresh_token)
+    );
+    expect(replay.status).toBe(400);
+    expect(await replay.json()).toEqual({ error: "invalid_grant" });
+    expect(harness.requests).toHaveLength(2);
+  });
+
+  it("omits scope on refresh and preserves omitted upstream rotation values", async () => {
+    const harness = createHarness({}, [
+      Response.json({
+        access_token: "short-provider-access",
+        refresh_token: "provider-refresh-to-preserve",
+        token_type: "Bearer",
+        expires_in: 2,
+        scope: "read:user",
+      }),
+      Response.json({
+        access_token: "rotated-provider-access-1",
+        token_type: "Bearer",
+        expires_in: 2,
+      }),
+      Response.json({
+        access_token: "rotated-provider-access-2",
+        token_type: "Bearer",
+        expires_in: 3600,
+      }),
+    ]);
+    const client = await registerClient(harness);
+    const flow = await authorizeThroughCallback(harness, client.client_id);
+    const codeResponse = await exchangeCode(
+      harness,
+      client.client_id,
+      flow.downstream.searchParams.get("code")!
+    );
+    const issued = (await codeResponse.json()) as { refresh_token: string };
+
+    const localRotation = await invoke(
+      harness.route,
+      refreshRequest(client.client_id, issued.refresh_token)
+    );
+    expect(localRotation.status).toBe(200);
+    expect(harness.requests).toHaveLength(1);
+    const localTokens = (await localRotation.json()) as {
+      refresh_token: string;
+    };
+
+    harness.now.value += 3_000;
+    const upstreamRotation = await invoke(
+      harness.route,
+      refreshRequest(client.client_id, localTokens.refresh_token)
+    );
+    expect(upstreamRotation.status).toBe(200);
+    const upstreamTokens = (await upstreamRotation.json()) as {
+      refresh_token: string;
+    };
+    const firstUpstreamForm = new URLSearchParams(
+      await harness.requests[1]!.text()
+    );
+    expect(firstUpstreamForm.get("refresh_token")).toBe(
+      "provider-refresh-to-preserve"
+    );
+    expect(firstUpstreamForm.has("scope")).toBe(false);
+
+    harness.now.value += 3_000;
+    const secondUpstreamRotation = await invoke(
+      harness.route,
+      refreshRequest(client.client_id, upstreamTokens.refresh_token)
+    );
+    expect(secondUpstreamRotation.status).toBe(200);
+    const finalTokens = (await secondUpstreamRotation.json()) as {
+      refresh_token: string;
+    };
+    const secondUpstreamForm = new URLSearchParams(
+      await harness.requests[2]!.text()
+    );
+    expect(secondUpstreamForm.get("refresh_token")).toBe(
+      "provider-refresh-to-preserve"
+    );
+    expect(secondUpstreamForm.has("scope")).toBe(false);
+
+    const preserved = await harness.core.beginUpstreamRefresh({
+      refreshToken: finalTokens.refresh_token,
+      clientId: client.client_id,
+      resource,
+    });
+    expect(preserved.upstreamTokens.refreshToken).toBe(
+      "provider-refresh-to-preserve"
+    );
+    expect(preserved.upstreamTokens.scope).toBe("read:user");
+  });
+
+  it("revokes without enumeration and ignores incorrect token hints", async () => {
+    const harness = createHarness();
+    const client = await registerClient(harness);
+    const flow = await authorizeThroughCallback(harness, client.client_id);
+    const codeResponse = await exchangeCode(
+      harness,
+      client.client_id,
+      flow.downstream.searchParams.get("code")!
+    );
+    const tokens = (await codeResponse.json()) as { refresh_token: string };
+    const revoked = await invoke(
+      harness.route,
+      new Request(`${issuer}/revoke`, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          token: tokens.refresh_token,
+          token_type_hint: "access_token",
+          client_id: client.client_id,
+        }),
+      })
+    );
+    expect(revoked.status).toBe(200);
+    expect(revoked.headers.get("Pragma")).toBe("no-cache");
+    const refresh = await invoke(
+      harness.route,
+      refreshRequest(client.client_id, tokens.refresh_token)
+    );
+    expect(refresh.status).toBe(400);
+
+    const malformed = await invoke(
+      harness.route,
+      new Request(`${issuer}/revoke`, {
+        method: "POST",
+        headers: { "Content-Type": "text/plain" },
+        body: "not a token",
+      })
+    );
+    expect(malformed.status).toBe(200);
+  });
+
+  it("returns 405 for matched paths and falls through for unowned paths", async () => {
+    const harness = createHarness();
+    const method = await invoke(
+      harness.route,
+      new Request(`${issuer}/token`, { method: "GET" })
+    );
+    expect(method.status).toBe(405);
+    expect(method.headers.get("Allow")).toBe("POST");
+    const unowned = await invoke(
+      harness.route,
+      new Request(`${issuer}/not-owned`)
+    );
+    expect(unowned.status).toBe(418);
+    expect(await unowned.text()).toBe("fallback");
+  });
+});
+
+function refreshRequest(clientId: string, refreshToken: string): Request {
+  return new Request(`${issuer}/token`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "refresh_token",
+      client_id: clientId,
+      refresh_token: refreshToken,
+      resource,
+    }),
+  });
+}


### PR DESCRIPTION
## Summary

Adds the HTTP authorization-server routes that connect MCP clients to the local OAuth core and the fixed upstream OAuth application.

## Review focus

- Discovery, DCR, authorization/consent, callback, token, and local revocation routes.
- Strict body limits, parameter validation, safe redirect errors, and secure browser binding.
- Separate state and S256 PKCE values for local and upstream flows.
- Explicit provider resource mapping; the downstream MCP `resource` is never forwarded automatically.
- Refresh requests omit upstream `scope` for GitHub compatibility while preserving an omitted stored scope and refresh token.

## Validation

- 16 focused route tests, including callback error sanitization, cookie security, refresh replay, and GitHub-compatible refresh behavior.
- Included in the full OAuth run: 13 test files, 137 tests.
- Server typecheck, build, ESLint, and Prettier pass.

PR 6 of 8. Based on #2343; next: #2345.
