### PR TITLE
feat(server): expose OAuth proxy provider

### DIFF
--- a/libraries/typescript/packages/server/src/context.ts
+++ b/libraries/typescript/packages/server/src/context.ts
@@ -153,6 +153,11 @@ export type OAuthAuth<TUser> = {
   payload: Record<string, unknown>;
   /** Raw bearer token for authenticated downstream requests. */
   accessToken: string;
+  /**
+   * Upstream provider access token when authentication is mediated by
+   * `oauthProxy()`. Never contains an upstream refresh or ID token.
+   */
+  providerAccessToken?: string;
   /** OAuth scopes granted to the access token. */
   scopes: string[];
   /** Provider-normalized permissions granted to the user. */
@@ -503,6 +508,9 @@ export function toAuthenticatedRequestContext<TUser, TEnv extends Env = Env>(
       user: authInfo.extra.user,
       payload: authInfo.extra.payload,
       accessToken: authInfo.token,
+      ...(authInfo.extra.providerAccessToken !== undefined && {
+        providerAccessToken: authInfo.extra.providerAccessToken,
+      }),
       scopes: [...authInfo.scopes],
       permissions: [...authInfo.extra.permissions],
       ...(authInfo.clientId.length > 0 && { clientId: authInfo.clientId }),

--- a/libraries/typescript/packages/server/src/oauth/index.ts
+++ b/libraries/typescript/packages/server/src/oauth/index.ts
@@ -30,7 +30,35 @@ export {
 export {
   oauthCustomProvider,
   type CustomOAuthProviderOptions,
+  type DirectOAuthProvider,
   type OAuthExtra,
   type OAuthProvider,
+  type OAuthProviderBinding,
   type OAuthResourceOptions,
+  type ResourceBoundOAuthProvider,
 } from "./provider.js";
+export {
+  oauthProxy,
+  type OAuthProxyConfig,
+  type OAuthProxyJsonObject,
+  type OAuthProxyJsonValue,
+  type OAuthProxyOptions,
+  type OAuthProxyTokenEndpointAuthMethod,
+  type OAuthProxyUpstreamResourceContext,
+  type OAuthProxyUser,
+  type OAuthProxyVerifiedToken,
+} from "./proxy/provider.js";
+export {
+  inMemoryOAuthStore,
+  type OAuthProxyStore,
+  type OAuthProxyStoreCapabilities,
+  type OAuthProxyStoreConsumeResult,
+  type OAuthProxyStoreCreateResult,
+  type OAuthProxyStoreReadResult,
+  type OAuthProxyStoreReplaceResult,
+  type OAuthProxyStoreTransaction,
+} from "./proxy/store.js";
+export type {
+  OAuthProxyEncryptionKey,
+  OAuthProxyEncryptionOptions,
+} from "./proxy/encryption.js";

--- a/libraries/typescript/packages/server/src/oauth/internal.ts
+++ b/libraries/typescript/packages/server/src/oauth/internal.ts
@@ -409,7 +409,10 @@ function assertMappedExtra<TUser>(
     mapped.user === undefined ||
     !isRecord(mapped.payload) ||
     !Array.isArray(mapped.permissions) ||
-    !mapped.permissions.every((permission) => typeof permission === "string")
+    !mapped.permissions.every((permission) => typeof permission === "string") ||
+    (mapped.providerAccessToken !== undefined &&
+      (typeof mapped.providerAccessToken !== "string" ||
+        mapped.providerAccessToken.length === 0))
   ) {
     throw invalidToken(
       "Token identity mapping must return user, payload, and string permissions"

--- a/libraries/typescript/packages/server/src/oauth/provider.ts
+++ b/libraries/typescript/packages/server/src/oauth/provider.ts
@@ -15,6 +15,11 @@ export type OAuthExtra<TUser> = Record<string, unknown> & {
   payload: Record<string, unknown>;
   /** Verified permissions granted to the user. */
   permissions: string[];
+  /**
+   * Upstream provider access token for proxy-backed API calls. The downstream
+   * bearer token remains available separately as `ctx.auth.accessToken`.
+   */
+  providerAccessToken?: string;
 };
 
 /** Resource-server metadata and bearer-gate configuration. */

--- a/libraries/typescript/packages/server/src/oauth/proxy/authorization-records.ts
+++ b/libraries/typescript/packages/server/src/oauth/proxy/authorization-records.ts
@@ -7,7 +7,7 @@ const MAX_JSON_NODES = 20_000;
 const encoder = new TextEncoder();
 const decoder = new TextDecoder("utf-8", { fatal: true });
 
-/** @internal JSON data that can safely cross the OAuth proxy persistence boundary. */
+/** JSON data that can safely cross the OAuth proxy persistence boundary. */
 export type OAuthProxyJsonValue =
   | null
   | boolean
@@ -16,7 +16,7 @@ export type OAuthProxyJsonValue =
   | readonly OAuthProxyJsonValue[]
   | OAuthProxyJsonObject;
 
-/** @internal Persistable object payload returned by an upstream identity verifier. */
+/** Persistable object payload returned by an upstream identity verifier. */
 export interface OAuthProxyJsonObject {
   readonly [key: string]: OAuthProxyJsonValue;
 }

--- a/libraries/typescript/packages/server/src/oauth/proxy/authorization-routes.ts
+++ b/libraries/typescript/packages/server/src/oauth/proxy/authorization-routes.ts
@@ -30,7 +30,7 @@ const encoder = new TextEncoder();
 
 type CryptoImplementation = Pick<Crypto, "getRandomValues">;
 
-/** @internal Provider-specific context for an explicit upstream resource mapping. */
+/** Provider-specific context for an explicit upstream resource mapping. */
 export interface OAuthProxyUpstreamResourceContext {
   readonly phase: "authorization" | "refresh";
   readonly localResource: string;

--- a/libraries/typescript/packages/server/src/oauth/proxy/encryption.ts
+++ b/libraries/typescript/packages/server/src/oauth/proxy/encryption.ts
@@ -7,7 +7,7 @@ const AAD_SCHEMA = "mcp-use/oauth-proxy/byte-payload/v1";
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder("utf-8", { fatal: true });
 
-/** @internal One named, raw AES-256 key in an OAuth proxy encryption keyring. */
+/** One named, raw AES-256 key in an OAuth proxy encryption keyring. */
 export interface OAuthProxyEncryptionKey {
   /** Non-empty identifier serialized with ciphertext for later key rotation. */
   readonly id: string;
@@ -15,7 +15,7 @@ export interface OAuthProxyEncryptionKey {
   readonly key: Uint8Array;
 }
 
-/** @internal SDK-managed encryption configuration for persisted proxy payloads. */
+/** SDK-managed encryption configuration for persisted OAuth proxy payloads. */
 export interface OAuthProxyEncryptionOptions {
   /** Key identifier used for new writes. */
   readonly primaryKeyId: string;

--- a/libraries/typescript/packages/server/src/oauth/proxy/provider.ts
+++ b/libraries/typescript/packages/server/src/oauth/proxy/provider.ts
@@ -1,0 +1,537 @@
+import type {
+  AuthInfo,
+  OAuthMetadata,
+  OAuthTokenVerifier,
+} from "@modelcontextprotocol/server";
+
+import type {
+  OAuthExtra,
+  OAuthResourceOptions,
+  ResourceBoundOAuthProvider,
+} from "../provider.js";
+import { OAuthAuthorizationCore } from "./authorization-core.js";
+import {
+  cloneOAuthProxyJsonObject,
+  type OAuthProxyJsonObject,
+} from "./authorization-records.js";
+import {
+  createOAuthAuthorizationRoutes,
+  type OAuthProxyUpstreamResourceContext,
+} from "./authorization-routes.js";
+import type { OAuthProxyEncryptionOptions } from "./encryption.js";
+import { resolveOAuthProxyStore, type OAuthProxyStore } from "./store.js";
+import { UpstreamOAuthClient } from "./upstream-client.js";
+
+const DEFAULT_SCOPES = ["openid", "email", "profile"] as const;
+const DEFAULT_AUTHORIZATION_SERVER_PATH = "/oauth";
+const SCOPE_PATTERN = /^[\u0021\u0023-\u005B\u005D-\u007E]+$/u;
+
+/** Default user shape extracted from standard verified identity claims. */
+export interface OAuthProxyUser {
+  readonly id: string;
+  readonly email?: string;
+  readonly name?: string;
+  readonly username?: string;
+  readonly picture?: string;
+}
+
+/** Successful result returned by an OAuth proxy access-token verifier. */
+export interface OAuthProxyVerifiedToken {
+  /** Trusted, JSON-serializable identity data persisted with the local grant. */
+  readonly payload: OAuthProxyJsonObject;
+}
+
+/** Explicit client authentication methods supported at the upstream token endpoint. */
+export type OAuthProxyTokenEndpointAuthMethod =
+  | "client_secret_basic"
+  | "client_secret_post"
+  | "none";
+
+interface OAuthProxyCommonOptions<TUser> extends Omit<
+  OAuthResourceOptions,
+  "scopesSupported"
+> {
+  /** Upstream provider authorization endpoint. */
+  readonly authEndpoint: string | URL;
+  /** Upstream provider token endpoint. */
+  readonly tokenEndpoint: string | URL;
+  /** Expected RFC 9207 upstream authorization-response issuer, when available. */
+  readonly issuer?: string | URL;
+  /** Require the upstream callback to include the configured RFC 9207 issuer. */
+  readonly requireAuthorizationResponseIssuer?: boolean;
+  /** Pre-registered upstream OAuth application client identifier. */
+  readonly clientId: string;
+  /** Scopes grantable to downstream MCP clients. */
+  readonly scopes?: readonly string[];
+  /** Scopes requested upstream; defaults to {@link scopes}. */
+  readonly upstreamScopes?: readonly string[];
+  /** Additional non-reserved parameters added to upstream authorization requests. */
+  readonly extraAuthorizeParams?: Readonly<Record<string, string>>;
+  /** Verifies an upstream access token and returns persistable trusted identity data. */
+  readonly verifyToken: (
+    providerAccessToken: string
+  ) => OAuthProxyVerifiedToken | Promise<OAuthProxyVerifiedToken>;
+  /** Maps trusted identity data into the application user exposed on request context. */
+  readonly getUserInfo?: (payload: OAuthProxyJsonObject) => TUser;
+  /**
+   * Verifies an upstream ID token and returns trusted claims. Supplying this
+   * hook enables nonce generation and validation for the upstream request.
+   */
+  readonly verifyIdToken?: (
+    idToken: string
+  ) =>
+    | Readonly<Record<string, unknown>>
+    | Promise<Readonly<Record<string, unknown>>>;
+  /** Explicit provider-specific resource mapping; the MCP resource is never forwarded. */
+  readonly mapUpstreamResource?: (
+    context: OAuthProxyUpstreamResourceContext
+  ) => string | URL | undefined | Promise<string | URL | undefined>;
+  /** OAuth proxy state store. Omission creates a private process-local store. */
+  readonly store?: OAuthProxyStore;
+  /** SDK-managed encryption for stores that do not encrypt secrets themselves. */
+  readonly encryption?: OAuthProxyEncryptionOptions;
+  /** Local authorization-server route prefix. Defaults to `/oauth`. */
+  readonly authorizationServerPath?: string;
+  /** Fetch implementation used for upstream OAuth calls. */
+  readonly fetch?: typeof fetch;
+  /** Upstream request timeout in milliseconds. */
+  readonly timeoutMs?: number;
+  /** Maximum upstream response size in bytes. */
+  readonly maxResponseBytes?: number;
+  /** Maximum local registration and form body size in bytes. */
+  readonly maxBodyBytes?: number;
+}
+
+type OAuthProxyClientAuthentication =
+  | {
+      readonly tokenEndpointAuthMethod: "none";
+      readonly clientSecret?: never;
+    }
+  | {
+      readonly tokenEndpointAuthMethod:
+        | "client_secret_basic"
+        | "client_secret_post";
+      readonly clientSecret: string;
+    };
+
+/** Options for {@link oauthProxy}. */
+export type OAuthProxyOptions<TUser = OAuthProxyUser> =
+  OAuthProxyCommonOptions<TUser> & OAuthProxyClientAuthentication;
+
+/** Recognizable v1-compatible name for {@link OAuthProxyOptions}. */
+export type OAuthProxyConfig<TUser = OAuthProxyUser> = OAuthProxyOptions<TUser>;
+
+/**
+ * Creates an embedded OAuth authorization server that brokers one fixed
+ * upstream OAuth application for dynamically registered MCP clients.
+ */
+export function oauthProxy<TUser = OAuthProxyUser>(
+  options: OAuthProxyOptions<TUser>
+): ResourceBoundOAuthProvider<TUser> {
+  const resolved = resolveOptions(options);
+  const { store } = resolveOAuthProxyStore({
+    ...(resolved.store === undefined ? {} : { store: resolved.store }),
+    ...(resolved.encryption === undefined
+      ? {}
+      : { encryption: resolved.encryption }),
+  });
+  const core = new OAuthAuthorizationCore({ store });
+  const upstreamClient = new UpstreamOAuthClient({
+    authorizationEndpoint: resolved.authEndpoint,
+    tokenEndpoint: resolved.tokenEndpoint,
+    ...(resolved.issuer === undefined ? {} : { issuer: resolved.issuer }),
+    ...(resolved.requireAuthorizationResponseIssuer === undefined
+      ? {}
+      : {
+          requireAuthorizationResponseIssuer:
+            resolved.requireAuthorizationResponseIssuer,
+        }),
+    clientId: resolved.clientId,
+    ...(resolved.clientSecret === undefined
+      ? {}
+      : { clientSecret: resolved.clientSecret }),
+    tokenEndpointAuthMethod: resolved.tokenEndpointAuthMethod,
+    authorizationParams: resolved.extraAuthorizeParams,
+    ...(resolved.fetch === undefined ? {} : { fetch: resolved.fetch }),
+    ...(resolved.timeoutMs === undefined
+      ? {}
+      : { timeoutMs: resolved.timeoutMs }),
+    ...(resolved.maxResponseBytes === undefined
+      ? {}
+      : { maxResponseBytes: resolved.maxResponseBytes }),
+  });
+
+  let boundResource: string | undefined;
+  const provider: ResourceBoundOAuthProvider<TUser> = {
+    ...(resolved.resource === undefined ? {} : { resource: resolved.resource }),
+    ...(resolved.requiredScopes === undefined
+      ? {}
+      : { requiredScopes: resolved.requiredScopes }),
+    scopesSupported: resolved.scopes,
+    ...(resolved.resourceName === undefined
+      ? {}
+      : { resourceName: resolved.resourceName }),
+    ...(resolved.serviceDocumentationUrl === undefined
+      ? {}
+      : { serviceDocumentationUrl: resolved.serviceDocumentationUrl }),
+    bind(resource) {
+      const canonicalResource = new URL(resource.href);
+      if (
+        boundResource !== undefined &&
+        boundResource !== canonicalResource.href
+      ) {
+        throw new TypeError(
+          "An oauthProxy instance cannot be bound to multiple MCP resources"
+        );
+      }
+
+      const localIssuer = new URL(
+        resolved.authorizationServerPath,
+        canonicalResource.origin
+      );
+      const endpoint = (path: string) =>
+        new URL(
+          `${resolved.authorizationServerPath}/${path}`,
+          localIssuer.origin
+        ).href;
+      if (
+        ["authorize", "callback", "register", "revoke", "token"].some(
+          (path) =>
+            new URL(endpoint(path)).pathname === canonicalResource.pathname
+        )
+      ) {
+        throw new TypeError(
+          "OAuth proxy routes cannot overlap the canonical MCP resource path"
+        );
+      }
+      boundResource = canonicalResource.href;
+      const metadata: OAuthMetadata = {
+        issuer: localIssuer.href,
+        authorization_endpoint: endpoint("authorize"),
+        token_endpoint: endpoint("token"),
+        registration_endpoint: endpoint("register"),
+        revocation_endpoint: endpoint("revoke"),
+        response_types_supported: ["code"],
+        grant_types_supported: ["authorization_code", "refresh_token"],
+        token_endpoint_auth_methods_supported: ["none"],
+        code_challenge_methods_supported: ["S256"],
+        scopes_supported: [...resolved.scopes],
+      };
+      const tokenVerifier: OAuthTokenVerifier = {
+        async verifyAccessToken(token: string): Promise<AuthInfo> {
+          const validated = await core.validateAccessToken(
+            token,
+            canonicalResource.href
+          );
+          return {
+            token,
+            clientId: validated.clientId,
+            scopes: [...validated.scopes],
+            expiresAt: Math.floor(validated.expiresAt / 1000),
+            resource: new URL(validated.resource),
+            extra: {
+              payload: validated.userPayload,
+              providerAccessToken: validated.providerAccessToken,
+            },
+          };
+        },
+      };
+
+      return {
+        oauthMetadata: metadata,
+        tokenVerifier,
+        mapAuthInfo: (authInfo) => mapAuthInfo(authInfo, resolved.getUserInfo),
+        ...(resolved.requiredScopes === undefined
+          ? {}
+          : { requiredScopes: resolved.requiredScopes }),
+        scopesSupported: resolved.scopes,
+        ...(resolved.resourceName === undefined
+          ? {}
+          : { resourceName: resolved.resourceName }),
+        ...(resolved.serviceDocumentationUrl === undefined
+          ? {}
+          : { serviceDocumentationUrl: resolved.serviceDocumentationUrl }),
+        middleware: createOAuthAuthorizationRoutes({
+          issuer: localIssuer,
+          resource: canonicalResource,
+          prefix: resolved.authorizationServerPath,
+          scopes: resolved.scopes,
+          upstreamScopes: resolved.upstreamScopes,
+          core,
+          upstreamClient,
+          verifyToken: async (providerAccessToken) => {
+            const verified = await resolved.verifyToken(providerAccessToken);
+            if (
+              verified === null ||
+              typeof verified !== "object" ||
+              !("payload" in verified)
+            ) {
+              throw new TypeError("verifyToken must return a payload object");
+            }
+            const payload = cloneOAuthProxyJsonObject(verified.payload);
+            validatePermissions(payload);
+            if (resolved.getUserInfo(payload) === undefined) {
+              throw new TypeError("getUserInfo must return a user");
+            }
+            return payload;
+          },
+          ...(resolved.verifyIdToken === undefined
+            ? {}
+            : {
+                verifyIdToken: (idToken: string) =>
+                  resolved.verifyIdToken!(idToken),
+              }),
+          ...(resolved.mapUpstreamResource === undefined
+            ? {}
+            : { mapUpstreamResource: resolved.mapUpstreamResource }),
+          ...(resolved.maxBodyBytes === undefined
+            ? {}
+            : { maxBodyBytes: resolved.maxBodyBytes }),
+        }),
+      };
+    },
+  };
+  return provider;
+}
+
+interface ResolvedOAuthProxyOptions<TUser> extends Omit<
+  OAuthProxyCommonOptions<TUser>,
+  | "resource"
+  | "requiredScopes"
+  | "scopes"
+  | "upstreamScopes"
+  | "extraAuthorizeParams"
+  | "serviceDocumentationUrl"
+  | "authorizationServerPath"
+  | "getUserInfo"
+> {
+  readonly resource?: string | URL;
+  readonly requiredScopes?: readonly string[];
+  readonly scopes: readonly string[];
+  readonly upstreamScopes: readonly string[];
+  readonly extraAuthorizeParams: Readonly<Record<string, string>>;
+  readonly serviceDocumentationUrl?: URL;
+  readonly authorizationServerPath: string;
+  readonly getUserInfo: (payload: OAuthProxyJsonObject) => TUser;
+  readonly tokenEndpointAuthMethod: OAuthProxyTokenEndpointAuthMethod;
+  readonly clientSecret?: string;
+}
+
+function resolveOptions<TUser>(
+  options: OAuthProxyOptions<TUser>
+): ResolvedOAuthProxyOptions<TUser> {
+  if (options === null || typeof options !== "object") {
+    throw new TypeError("oauthProxy options must be an object");
+  }
+  if (typeof options.verifyToken !== "function") {
+    throw new TypeError("oauthProxy verifyToken must be a function");
+  }
+  if (
+    options.getUserInfo !== undefined &&
+    typeof options.getUserInfo !== "function"
+  ) {
+    throw new TypeError("oauthProxy getUserInfo must be a function");
+  }
+  if (
+    options.verifyIdToken !== undefined &&
+    typeof options.verifyIdToken !== "function"
+  ) {
+    throw new TypeError("oauthProxy verifyIdToken must be a function");
+  }
+  if (
+    options.mapUpstreamResource !== undefined &&
+    typeof options.mapUpstreamResource !== "function"
+  ) {
+    throw new TypeError("oauthProxy mapUpstreamResource must be a function");
+  }
+
+  const scopes = configuredScopes(options.scopes ?? DEFAULT_SCOPES, "scopes");
+  const upstreamScopes = configuredScopes(
+    options.upstreamScopes ?? scopes,
+    "upstreamScopes"
+  );
+  const requiredScopes =
+    options.requiredScopes === undefined
+      ? undefined
+      : configuredScopes(options.requiredScopes, "requiredScopes");
+  if (requiredScopes?.some((scope) => !scopes.includes(scope))) {
+    throw new TypeError("oauthProxy requiredScopes must be grantable scopes");
+  }
+  const authorizationServerPath = normalizePath(
+    options.authorizationServerPath ?? DEFAULT_AUTHORIZATION_SERVER_PATH
+  );
+  const extraAuthorizeParams = snapshotStringRecord(
+    options.extraAuthorizeParams,
+    "extraAuthorizeParams"
+  );
+  const getUserInfo =
+    options.getUserInfo ??
+    (defaultUserInfo as (payload: OAuthProxyJsonObject) => TUser);
+  const resource =
+    options.resource instanceof URL
+      ? new URL(options.resource.href)
+      : options.resource;
+
+  return {
+    ...options,
+    ...(resource === undefined ? {} : { resource }),
+    scopes,
+    upstreamScopes,
+    ...(requiredScopes === undefined ? {} : { requiredScopes }),
+    authorizationServerPath,
+    extraAuthorizeParams,
+    getUserInfo,
+    ...(options.serviceDocumentationUrl === undefined
+      ? {}
+      : {
+          serviceDocumentationUrl: new URL(
+            options.serviceDocumentationUrl.href
+          ),
+        }),
+  };
+}
+
+function mapAuthInfo<TUser>(
+  authInfo: AuthInfo,
+  getUserInfo: (payload: OAuthProxyJsonObject) => TUser
+): OAuthExtra<TUser> {
+  const extra = authInfo.extra;
+  if (extra === undefined || typeof extra !== "object") {
+    throw new TypeError("OAuth proxy token is missing trusted identity data");
+  }
+  const payload = cloneOAuthProxyJsonObject(extra["payload"]);
+  const providerAccessToken = extra["providerAccessToken"];
+  if (
+    typeof providerAccessToken !== "string" ||
+    providerAccessToken.length === 0
+  ) {
+    throw new TypeError(
+      "OAuth proxy token is missing its provider access token"
+    );
+  }
+  const user = getUserInfo(payload);
+  if (user === undefined) {
+    throw new TypeError("getUserInfo must return a user");
+  }
+  return {
+    user,
+    payload,
+    permissions: permissionsFromPayload(payload),
+    providerAccessToken,
+  };
+}
+
+function permissionsFromPayload(payload: OAuthProxyJsonObject): string[] {
+  const value = payload["permissions"];
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) {
+    throw new TypeError("Verified OAuth proxy permissions must be strings");
+  }
+  const permissions: string[] = [];
+  for (const item of value as readonly unknown[]) {
+    if (typeof item !== "string") {
+      throw new TypeError("Verified OAuth proxy permissions must be strings");
+    }
+    permissions.push(item);
+  }
+  return permissions;
+}
+
+function validatePermissions(payload: OAuthProxyJsonObject): void {
+  permissionsFromPayload(payload);
+}
+
+function defaultUserInfo(payload: OAuthProxyJsonObject): OAuthProxyUser {
+  const id = optionalString(payload, "sub");
+  if (id === undefined || id.length === 0) {
+    throw new TypeError("Verified OAuth proxy payload must include a subject");
+  }
+  return {
+    id,
+    ...optionalProperty("email", optionalString(payload, "email")),
+    ...optionalProperty("name", optionalString(payload, "name")),
+    ...optionalProperty(
+      "username",
+      optionalString(payload, "preferred_username") ??
+        optionalString(payload, "username")
+    ),
+    ...optionalProperty("picture", optionalString(payload, "picture")),
+  };
+}
+
+function optionalString(
+  payload: OAuthProxyJsonObject,
+  key: string
+): string | undefined {
+  const value = payload[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function optionalProperty<K extends string>(
+  key: K,
+  value: string | undefined
+): Partial<Record<K, string>> {
+  return value === undefined ? {} : ({ [key]: value } as Record<K, string>);
+}
+
+function configuredScopes(
+  value: readonly string[],
+  name: string
+): readonly string[] {
+  if (
+    !Array.isArray(value) ||
+    value.length > 256 ||
+    value.some(
+      (scope) =>
+        typeof scope !== "string" ||
+        scope.length === 0 ||
+        !SCOPE_PATTERN.test(scope)
+    ) ||
+    new Set(value).size !== value.length
+  ) {
+    throw new TypeError(`oauthProxy ${name} must contain unique OAuth scopes`);
+  }
+  return Object.freeze((value as readonly string[]).slice());
+}
+
+function normalizePath(value: string): string {
+  if (
+    typeof value !== "string" ||
+    !/^\/(?:[A-Za-z0-9._~-]+(?:\/[A-Za-z0-9._~-]+)*)?$/u.test(value) ||
+    value === "/"
+  ) {
+    throw new TypeError(
+      "oauthProxy authorizationServerPath must be a non-root absolute path without a trailing slash"
+    );
+  }
+  return value;
+}
+
+function snapshotStringRecord(
+  value: Readonly<Record<string, string>> | undefined,
+  name: string
+): Readonly<Record<string, string>> {
+  if (value === undefined) return Object.freeze({});
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError(`oauthProxy ${name} must be an object of strings`);
+  }
+  const snapshot: Record<string, string> = Object.create(null) as Record<
+    string,
+    string
+  >;
+  for (const [key, entry] of Object.entries(value)) {
+    if (key.length === 0 || typeof entry !== "string") {
+      throw new TypeError(
+        `oauthProxy ${name} must contain non-empty keys and string values`
+      );
+    }
+    snapshot[key] = entry;
+  }
+  return Object.freeze(snapshot);
+}
+
+export type {
+  OAuthProxyJsonObject,
+  OAuthProxyJsonValue,
+} from "./authorization-records.js";
+export type { OAuthProxyUpstreamResourceContext } from "./authorization-routes.js";

--- a/libraries/typescript/packages/server/src/oauth/proxy/store.ts
+++ b/libraries/typescript/packages/server/src/oauth/proxy/store.ts
@@ -14,7 +14,7 @@ const MAX_IN_MEMORY_ENTRIES = 10_000;
 const MAX_IN_MEMORY_PAYLOAD_BYTES = 64 * 1024 * 1024;
 const textEncoder = new TextEncoder();
 
-/** @internal Persistence and at-rest secret-protection guarantees of a proxy store. */
+/** Persistence and at-rest secret-protection guarantees of an OAuth proxy store. */
 export interface OAuthProxyStoreCapabilities {
   /** Whether values survive process restart. */
   readonly persistence: "process-local" | "persistent";
@@ -22,30 +22,30 @@ export interface OAuthProxyStoreCapabilities {
   readonly secretProtection: "none" | "store-encrypted";
 }
 
-/** @internal Result of creating a new non-overwriting proxy store entry. */
+/** Result of creating a new non-overwriting OAuth proxy store entry. */
 export type OAuthProxyStoreCreateResult =
   | { readonly status: "created" }
   | { readonly status: "conflict" };
 
-/** @internal Result of reading a proxy store entry. */
+/** Result of reading an OAuth proxy store entry. */
 export type OAuthProxyStoreReadResult =
   | { readonly status: "found"; readonly payload: Uint8Array }
   | { readonly status: "missing" }
   | { readonly status: "replayed" };
 
-/** @internal Result of atomically consuming a one-time proxy store entry. */
+/** Result of atomically consuming a one-time OAuth proxy store entry. */
 export type OAuthProxyStoreConsumeResult =
   | { readonly status: "consumed"; readonly payload: Uint8Array }
   | { readonly status: "missing" }
   | { readonly status: "replayed" };
 
-/** @internal Result of replacing an existing live proxy store entry. */
+/** Result of replacing an existing live OAuth proxy store entry. */
 export type OAuthProxyStoreReplaceResult =
   | { readonly status: "replaced" }
   | { readonly status: "missing" }
   | { readonly status: "replayed" };
 
-/** @internal Operations available inside one serializable proxy store transaction. */
+/** Operations available inside one serializable OAuth proxy store transaction. */
 export interface OAuthProxyStoreTransaction {
   /** Creates a declared key without overwriting a live value or tombstone. */
   create(
@@ -66,8 +66,8 @@ export interface OAuthProxyStoreTransaction {
 }
 
 /**
- * @internal Byte-oriented storage boundary for OAuth proxy secrets. Implementations
- * must make all operations serializable across every process sharing the store.
+ * Byte-oriented storage boundary for OAuth proxy secrets. Implementations must
+ * make all operations serializable across every process sharing the store.
  */
 export interface OAuthProxyStore extends OAuthProxyStoreTransaction {
   /** Explicit persistence and secret-protection guarantees. */
@@ -148,7 +148,15 @@ type InMemoryEntry =
     }
   | { readonly kind: "tombstone"; readonly expiresAt: number };
 
-function inMemoryOAuthStore(now: () => number = Date.now): OAuthProxyStore {
+/**
+ * Creates an isolated process-local OAuth proxy store.
+ *
+ * Sessions are lost when the process restarts and are not shared with other
+ * processes or server instances. Because values never leave the process, SDK
+ * encryption is optional for this store.
+ */
+export function inMemoryOAuthStore(): OAuthProxyStore {
+  const now = Date.now;
   const entries = new Map<string, InMemoryEntry>();
   const mutex = asyncMutex();
   let storedPayloadBytes = 0;

--- a/libraries/typescript/packages/server/tests/oauth-context-concurrency.test.ts
+++ b/libraries/typescript/packages/server/tests/oauth-context-concurrency.test.ts
@@ -30,6 +30,7 @@ interface CallbackObservation {
   user: TestUser;
   payload: Record<string, unknown>;
   accessToken: string;
+  providerAccessToken?: string | undefined;
   scopes: string[];
   permissions: string[];
   clientId?: string | undefined;
@@ -56,6 +57,7 @@ function createAuthInfo(id: string): AuthInfo {
       user: { id },
       payload: { subject: id, issuer: "https://issuer.example.test" },
       permissions: [`resource:${id}:read`],
+      providerAccessToken: `provider-token-${id}`,
     },
   };
 }
@@ -91,6 +93,7 @@ function observeContext(
     user: callbackContext.auth.user,
     payload: callbackContext.auth.payload,
     accessToken: callbackContext.auth.accessToken,
+    providerAccessToken: callbackContext.auth.providerAccessToken,
     scopes: [...callbackContext.auth.scopes],
     permissions: [...callbackContext.auth.permissions],
     clientId: callbackContext.auth.clientId,
@@ -243,6 +246,9 @@ describe("createMcpMount OAuth request context", () => {
         expect(observation.rawAuthInfo).toBe(expected);
         expect(observation.payload).toEqual(expected.extra!.payload);
         expect(observation.accessToken).toBe(expected.token);
+        expect(observation.providerAccessToken).toBe(
+          expected.extra!.providerAccessToken
+        );
         expect(observation.scopes).toEqual(expected.scopes);
         expect(observation.permissions).toEqual(expected.extra!.permissions);
         expect(observation.clientId).toBe(expected.clientId);

--- a/libraries/typescript/packages/server/tests/oauth-core.test.ts
+++ b/libraries/typescript/packages/server/tests/oauth-core.test.ts
@@ -400,6 +400,25 @@ describe("OAuth core", () => {
       mapAuthInfo: () =>
         ({ user: { id: "user-1" }, payload: {}, permissions: [123] }) as never,
     });
+    const malformedProviderToken = oauthCustomProvider({
+      createTokenVerifier: () => ({
+        verifyAccessToken: async () => ({
+          token: "verified-token",
+          clientId: "client-1",
+          scopes: [],
+          expiresAt: Date.now() / 1000 + 60,
+          resource: canonicalResource,
+        }),
+      }),
+      oauthMetadata: metadata,
+      mapAuthInfo: () =>
+        ({
+          user: { id: "user-1" },
+          payload: {},
+          permissions: [],
+          providerAccessToken: 123,
+        }) as never,
+    });
 
     await expect(
       wrapOAuthTokenVerifier(
@@ -410,6 +429,12 @@ describe("OAuth core", () => {
     await expect(
       wrapOAuthTokenVerifier(
         malformedMapping,
+        canonicalResource
+      ).verifyAccessToken("presented-token")
+    ).rejects.toMatchObject({ code: OAuthErrorCode.InvalidToken });
+    await expect(
+      wrapOAuthTokenVerifier(
+        malformedProviderToken,
         canonicalResource
       ).verifyAccessToken("presented-token")
     ).rejects.toMatchObject({ code: OAuthErrorCode.InvalidToken });

--- a/libraries/typescript/packages/server/tests/oauth-proxy-provider.test.ts
+++ b/libraries/typescript/packages/server/tests/oauth-proxy-provider.test.ts
@@ -1,0 +1,333 @@
+import {
+  OAuthClientInformationFullSchema,
+  OAuthTokensSchema,
+} from "@modelcontextprotocol/core";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  inMemoryOAuthStore,
+  oauthProxy,
+  type OAuthProxyOptions,
+  type OAuthProxyStore,
+} from "../src/oauth/index.js";
+
+const resource = new URL("https://mcp.example.test/mcp");
+const issuer = "https://mcp.example.test/oauth";
+const redirectUri = "https://client.example.test/callback";
+const verifier = "v".repeat(43);
+
+function proxyOptions(
+  overrides: Partial<OAuthProxyOptions> = {}
+): OAuthProxyOptions {
+  return {
+    authEndpoint: "https://provider.example.test/authorize",
+    tokenEndpoint: "https://provider.example.test/token",
+    issuer: "https://provider.example.test",
+    clientId: "shared-upstream-client",
+    clientSecret: "shared-upstream-secret",
+    tokenEndpointAuthMethod: "client_secret_basic",
+    scopes: ["read", "write"],
+    verifyToken: () => ({
+      payload: {
+        sub: "user-1",
+        email: "user@example.test",
+        permissions: ["repository:read"],
+      },
+    }),
+    ...overrides,
+  } as OAuthProxyOptions;
+}
+
+async function invoke(
+  middleware: NonNullable<
+    ReturnType<ReturnType<typeof oauthProxy>["bind"]>["middleware"]
+  >,
+  request: Request
+): Promise<Response> {
+  return middleware(
+    request,
+    async () => new Response("fallback", { status: 418 })
+  );
+}
+
+async function s256(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(value)
+  );
+  return Buffer.from(digest).toString("base64url");
+}
+
+function hidden(html: string, name: string): string {
+  const match = new RegExp(`name="${name}" value="([^"]+)"`, "u").exec(html);
+  if (match === null) throw new Error(`missing ${name}`);
+  return match[1]!;
+}
+
+async function register(
+  middleware: Parameters<typeof invoke>[0]
+): Promise<string> {
+  const response = await invoke(
+    middleware,
+    new Request(`${issuer}/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        redirect_uris: [redirectUri],
+        token_endpoint_auth_method: "none",
+        grant_types: ["authorization_code", "refresh_token"],
+        response_types: ["code"],
+        scope: "read write",
+      }),
+    })
+  );
+  expect(response.status).toBe(201);
+  const body: unknown = await response.json();
+  expect(OAuthClientInformationFullSchema.safeParse(body).success).toBe(true);
+  return (body as { client_id: string }).client_id;
+}
+
+describe("oauthProxy", () => {
+  it("requires explicit coherent upstream client authentication", () => {
+    expect(() =>
+      oauthProxy(
+        proxyOptions({
+          tokenEndpointAuthMethod: "none",
+          clientSecret: "must-not-be-used",
+        } as never)
+      )
+    ).toThrow(/clientSecret must be omitted/u);
+    expect(() =>
+      oauthProxy(
+        proxyOptions({
+          tokenEndpointAuthMethod: "client_secret_post",
+          clientSecret: undefined,
+        } as never)
+      )
+    ).toThrow(/clientSecret/u);
+    expect(() =>
+      oauthProxy(
+        proxyOptions({
+          extraAuthorizeParams: { state: "reserved" },
+        })
+      )
+    ).toThrow(/reserved/u);
+    expect(() =>
+      oauthProxy(proxyOptions({ scopes: ["read"], requiredScopes: ["write"] }))
+    ).toThrow(/requiredScopes/u);
+
+    const persistentPlaintextStore: OAuthProxyStore = {
+      capabilities: {
+        persistence: "persistent",
+        secretProtection: "none",
+      },
+      create: async () => ({ status: "created" }),
+      read: async () => ({ status: "missing" }),
+      replace: async () => ({ status: "missing" }),
+      consume: async () => ({ status: "missing" }),
+      transaction: async (_keys, work) => work(persistentPlaintextStore),
+    };
+    expect(() =>
+      oauthProxy(proxyOptions({ store: persistentPlaintextStore }))
+    ).toThrow(/require SDK encryption/u);
+    expect(() =>
+      oauthProxy(
+        proxyOptions({
+          store: persistentPlaintextStore,
+          encryption: {
+            primaryKeyId: "current",
+            keys: [{ id: "current", key: new Uint8Array(32) }],
+          },
+        })
+      )
+    ).not.toThrow();
+    expect(() =>
+      oauthProxy(
+        proxyOptions({
+          store: {
+            ...persistentPlaintextStore,
+            capabilities: {
+              persistence: "persistent",
+              secretProtection: "store-encrypted",
+            },
+          },
+        })
+      )
+    ).not.toThrow();
+  });
+
+  it("publishes a local public-client authorization server and binds once", () => {
+    expect(inMemoryOAuthStore().capabilities).toEqual({
+      persistence: "process-local",
+      secretProtection: "none",
+    });
+    const provider = oauthProxy(proxyOptions());
+    const binding = provider.bind(resource);
+
+    expect(binding.oauthMetadata).toMatchObject({
+      issuer,
+      authorization_endpoint: `${issuer}/authorize`,
+      token_endpoint: `${issuer}/token`,
+      registration_endpoint: `${issuer}/register`,
+      revocation_endpoint: `${issuer}/revoke`,
+      response_types_supported: ["code"],
+      grant_types_supported: ["authorization_code", "refresh_token"],
+      token_endpoint_auth_methods_supported: ["none"],
+      code_challenge_methods_supported: ["S256"],
+      scopes_supported: ["read", "write"],
+    });
+    expect(binding.middleware).toBeTypeOf("function");
+    expect(() =>
+      provider.bind(new URL("https://mcp.example.test/other"))
+    ).toThrow(/multiple MCP resources/u);
+    expect(() =>
+      oauthProxy(proxyOptions()).bind(
+        new URL("https://mcp.example.test/oauth/token")
+      )
+    ).toThrow(/cannot overlap/u);
+  });
+
+  it("keeps downstream tokens local while mapping the provider token explicitly", async () => {
+    const upstreamRequests: Request[] = [];
+    const upstreamFetch = vi.fn<typeof fetch>(async (input, init) => {
+      upstreamRequests.push(new Request(input, init));
+      return Response.json({
+        access_token: "provider-access-secret",
+        refresh_token: "provider-refresh-secret",
+        token_type: "Bearer",
+        expires_in: 3600,
+        scope: "profile",
+      });
+    });
+    const extraAuthorizeParams = { prompt: "consent" };
+    const provider = oauthProxy(
+      proxyOptions({
+        fetch: upstreamFetch,
+        extraAuthorizeParams,
+      })
+    );
+    extraAuthorizeParams.prompt = "mutated-after-construction";
+    const binding = provider.bind(resource);
+    const middleware = binding.middleware!;
+    const clientId = await register(middleware);
+    const authorizeUrl = new URL(`${issuer}/authorize`);
+    authorizeUrl.search = new URLSearchParams({
+      response_type: "code",
+      client_id: clientId,
+      redirect_uri: redirectUri,
+      state: "downstream-state",
+      resource: resource.href,
+      scope: "read write",
+      code_challenge: await s256(verifier),
+      code_challenge_method: "S256",
+    }).toString();
+    const consent = await invoke(middleware, new Request(authorizeUrl));
+    expect(consent.status).toBe(200);
+    const html = await consent.text();
+    const cookie = consent.headers.get("Set-Cookie")!.split(";", 1)[0]!;
+    const approval = await invoke(
+      middleware,
+      new Request(`${issuer}/authorize`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          Cookie: cookie,
+        },
+        body: new URLSearchParams({
+          transaction_id: hidden(html, "transaction_id"),
+          csrf_token: hidden(html, "csrf_token"),
+          decision: "approve",
+        }),
+      })
+    );
+    const upstreamAuthorization = new URL(approval.headers.get("Location")!);
+    expect(upstreamAuthorization.searchParams.get("prompt")).toBe("consent");
+    expect(upstreamAuthorization.searchParams.has("resource")).toBe(false);
+
+    const callbackUrl = new URL(`${issuer}/callback`);
+    callbackUrl.searchParams.set("code", "provider-code");
+    callbackUrl.searchParams.set(
+      "state",
+      upstreamAuthorization.searchParams.get("state")!
+    );
+    const callback = await invoke(
+      middleware,
+      new Request(callbackUrl, { headers: { Cookie: cookie } })
+    );
+    const downstream = new URL(callback.headers.get("Location")!);
+    const localCode = downstream.searchParams.get("code")!;
+    expect(localCode).not.toContain("provider");
+
+    const tokenResponse = await invoke(
+      middleware,
+      new Request(`${issuer}/token`, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "authorization_code",
+          client_id: clientId,
+          code: localCode,
+          redirect_uri: redirectUri,
+          code_verifier: verifier,
+          resource: resource.href,
+        }),
+      })
+    );
+    expect(tokenResponse.status).toBe(200);
+    const localTokenBody: unknown = await tokenResponse.json();
+    expect(OAuthTokensSchema.safeParse(localTokenBody).success).toBe(true);
+    const localTokens = localTokenBody as {
+      access_token: string;
+      refresh_token: string;
+    };
+    expect(JSON.stringify(localTokens)).not.toContain("provider-access-secret");
+    expect(localTokens.access_token).not.toBe("provider-access-secret");
+
+    const authInfo = await binding.tokenVerifier.verifyAccessToken(
+      localTokens.access_token
+    );
+    expect(authInfo.token).toBe(localTokens.access_token);
+    expect(authInfo.resource).toEqual(resource);
+    const mapped = binding.mapAuthInfo(authInfo);
+    expect(mapped).toEqual({
+      user: { id: "user-1", email: "user@example.test" },
+      payload: {
+        sub: "user-1",
+        email: "user@example.test",
+        permissions: ["repository:read"],
+      },
+      permissions: ["repository:read"],
+      providerAccessToken: "provider-access-secret",
+    });
+    expect(upstreamRequests).toHaveLength(1);
+    expect(upstreamRequests[0]!.headers.get("Authorization")).toMatch(
+      /^Basic /u
+    );
+  });
+
+  it("uses an isolated private in-memory store for each omitted store", async () => {
+    const first = oauthProxy(proxyOptions()).bind(resource);
+    const second = oauthProxy(proxyOptions()).bind(resource);
+    const clientId = await register(first.middleware!);
+    const challenge = await s256(verifier);
+    const authorizeUrl = new URL(`${issuer}/authorize`);
+    authorizeUrl.search = new URLSearchParams({
+      response_type: "code",
+      client_id: clientId,
+      redirect_uri: redirectUri,
+      state: "downstream-state",
+      resource: resource.href,
+      scope: "read",
+      code_challenge: challenge,
+      code_challenge_method: "S256",
+    }).toString();
+
+    const response = await invoke(
+      second.middleware!,
+      new Request(authorizeUrl)
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "invalid_client" });
+  });
+});


### PR DESCRIPTION
## Summary

Exposes the v2 `oauthProxy()` public API from `mcp-use/oauth` and maps verified proxy sessions into normal MCP tool context.

## Review focus

- Familiar fixed-provider configuration with required explicit token-endpoint auth mode.
- Optional private in-memory store and optional encryption for zero-config development.
- Persistent plaintext storage is rejected; custom stores may declare that they encrypt secrets themselves.
- `ctx.auth.accessToken` remains the local opaque MCP bearer; only `ctx.auth.providerAccessToken` contains the upstream API token.
- Options are snapshotted, route overlap is rejected, and one proxy instance cannot bind to multiple resources.

## Validation

- Public API tests exercise DCR through consent, upstream callback, local token exchange, token separation, storage policy, and option isolation.
- Included in the full OAuth run: 13 test files, 137 tests.
- Server typecheck, build, ESLint, and Prettier pass.

PR 7 of 8. Based on #2344; next: #2346.
