### PR TITLE
docs(server): add OAuth proxy guide and GitHub example

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -338,6 +338,7 @@
                               "v2/typescript/server/authentication/providers/supabase",
                               "v2/typescript/server/authentication/providers/workos",
                               "v2/typescript/server/authentication/providers/scalekit",
+                              "v2/typescript/server/authentication/providers/oauth-proxy",
                               "v2/typescript/server/authentication/providers/custom"
                             ]
                           }

--- a/docs/v2/typescript/server/authentication/index.mdx
+++ b/docs/v2/typescript/server/authentication/index.mdx
@@ -8,7 +8,8 @@ Configure an OAuth provider when an MCP server must identify callers or authoriz
 
 ## Choose a provider
 
-mcp-use supports resource-server providers whose authorization server supports Dynamic Client Registration (DCR).
+mcp-use supports direct resource-server providers and an embedded OAuth Proxy
+for providers that require a fixed OAuth application.
 
 | Identity system                          | Provider                                                                  |
 | ---------------------------------------- | ------------------------------------------------------------------------- |
@@ -20,8 +21,11 @@ mcp-use supports resource-server providers whose authorization server supports D
 | WorkOS                                   | [WorkOS](/v2/typescript/server/authentication/providers/workos)           |
 | Scalekit                                 | [Scalekit](/v2/typescript/server/authentication/providers/scalekit)       |
 | Another DCR-capable authorization server | [Custom Provider](/v2/typescript/server/authentication/providers/custom)  |
+| Fixed OAuth application without DCR      | [OAuth Proxy](/v2/typescript/server/authentication/providers/oauth-proxy) |
 
-The MCP client registers and performs the authorization flow directly with the authorization server. Your MCP server does not handle authorization codes or exchange them for tokens.
+With a direct provider, the MCP client registers and performs authorization
+with the external authorization server. With OAuth Proxy, the MCP server runs a
+local authorization server and keeps the fixed upstream credentials private.
 
 ## Configure the server
 
@@ -97,6 +101,13 @@ When `oauth` is configured:
     href="/v2/typescript/server/authentication/providers/custom"
   >
     Integrate another DCR-capable authorization server.
+  </Card>
+  <Card
+    title="OAuth Proxy"
+    icon="shuffle"
+    href="/v2/typescript/server/authentication/providers/oauth-proxy"
+  >
+    Broker a fixed OAuth application for dynamically registered MCP clients.
   </Card>
   <Card
     title="Client Authentication"

--- a/docs/v2/typescript/server/authentication/providers/oauth-proxy.mdx
+++ b/docs/v2/typescript/server/authentication/providers/oauth-proxy.mdx
@@ -1,18 +1,250 @@
 ---
-title: "OAuth Proxy support boundary"
-description: "Understand the support boundary for fixed-client OAuth providers."
+title: "OAuth Proxy"
+description: "Broker a fixed OAuth application for MCP clients when the upstream provider does not support Dynamic Client Registration."
 icon: "shuffle"
 ---
 
-mcp-use does not provide a server-side OAuth proxy factory or implement authorization, callback, token-exchange, or fixed-client brokering routes. This page is intentionally excluded from navigation.
+Use `oauthProxy()` when an upstream provider requires you to create one OAuth
+application with a fixed client ID and secret. The proxy gives every MCP client
+its own local public registration, consent, authorization code, access token,
+and refresh token. Upstream credentials and tokens stay on the server.
 
-If your identity provider supports Dynamic Client Registration, use a [built-in provider](/v2/typescript/server/authentication/index) or [Custom Provider](/v2/typescript/server/authentication/providers/custom). The MCP client then registers directly with the authorization server, while mcp-use acts only as the protected resource server.
+If the provider supports Dynamic Client Registration, use a
+[built-in provider](/v2/typescript/server/authentication/index) or
+[Custom Provider](/v2/typescript/server/authentication/providers/custom)
+instead.
 
-If the provider gives you only a fixed `clientId` and `clientSecret`, deploy a standards-compliant external authorization server or broker that:
+## Configure the upstream application
 
-- publishes OAuth authorization-server metadata, including a registration endpoint;
-- registers MCP clients and enforces redirect URI and PKCE requirements;
-- performs the upstream authorization and token exchange without exposing the fixed secret;
-- issues or validates tokens bound to the MCP resource.
+Create an OAuth application in the provider dashboard and register this
+callback URL:
 
-Point a custom provider at that external authorization server and implement resource-bound token verification. mcp-use has no server-side fixed-client brokering equivalent.
+```text
+https://mcp.example.com/oauth/callback
+```
+
+For local development on the default port, use:
+
+```text
+http://localhost:3000/oauth/callback
+```
+
+The callback belongs to the MCP server, not to an individual MCP client. The
+server validates each MCP client's redirect URI separately after local Dynamic
+Client Registration.
+
+## Add the proxy
+
+Import `oauthProxy` from `mcp-use/oauth`. You must choose the upstream token
+endpoint authentication method explicitly. Use the method documented by the
+provider; mcp-use never guesses it.
+
+```typescript
+import { MCPServer } from "mcp-use";
+import { oauthProxy, type OAuthProxyJsonObject } from "mcp-use/oauth";
+
+const clientId = process.env.OAUTH_CLIENT_ID;
+const clientSecret = process.env.OAUTH_CLIENT_SECRET;
+if (!clientId || !clientSecret) {
+  throw new Error("OAUTH_CLIENT_ID and OAUTH_CLIENT_SECRET are required");
+}
+
+const server = new MCPServer({
+  name: "oauth-proxy-server",
+  version: "1.0.0",
+  oauth: oauthProxy({
+    authEndpoint: "https://provider.example.com/oauth/authorize",
+    tokenEndpoint: "https://provider.example.com/oauth/token",
+    issuer: "https://provider.example.com",
+    clientId,
+    clientSecret,
+    tokenEndpointAuthMethod: "client_secret_post",
+    scopes: ["profile", "email"],
+    async verifyToken(providerAccessToken) {
+      const response = await fetch("https://provider.example.com/userinfo", {
+        headers: { Authorization: `Bearer ${providerAccessToken}` },
+      });
+      if (!response.ok) throw new Error("Invalid provider access token");
+
+      const user = (await response.json()) as {
+        id: string;
+        email?: string;
+        name?: string;
+      };
+      const payload: OAuthProxyJsonObject = {
+        sub: user.id,
+        email: user.email ?? null,
+        name: user.name ?? null,
+      };
+      return { payload };
+    },
+  }),
+});
+
+export default server;
+```
+
+`verifyToken` must authenticate the upstream access token and return trusted,
+JSON-serializable identity data. The default user mapper requires a string
+`sub` claim and maps `email`, `name`, `preferred_username`, and `picture` when
+present. Pass `getUserInfo(payload)` to return an application-specific user
+type.
+
+## Use the correct access token
+
+OAuth Proxy maintains two token boundaries:
+
+- `ctx.auth.accessToken` is the local opaque bearer token presented by the MCP
+  client. Never send it to the upstream provider.
+- `ctx.auth.providerAccessToken` is the upstream access token. Send it only to
+  the configured provider's API.
+
+```typescript
+server.tool(
+  {
+    name: "get-provider-profile",
+    description: "Read the authenticated profile from the provider.",
+  },
+  async (_args, ctx) => {
+    const token = ctx.auth.providerAccessToken;
+    if (!token) throw new Error("Provider access token is unavailable");
+
+    const response = await fetch("https://provider.example.com/userinfo", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    return {
+      content: [{ type: "text", text: await response.text() }],
+    };
+  },
+);
+```
+
+The proxy never exposes the upstream refresh token or ID token. Revoking a
+local token immediately stops that local token or refresh family from reaching
+the MCP server. The initial release does not call the provider's revocation
+endpoint automatically.
+
+## Understand the authorization flow
+
+The proxy runs two bound authorization flows:
+
+1. The MCP client registers with the local `/oauth/register` endpoint.
+2. The local `/oauth/authorize` endpoint validates the registered redirect URI,
+   exact MCP resource, requested scopes, state, and S256 PKCE challenge.
+3. The user approves the MCP client on a server-owned consent page.
+4. The server starts a separate upstream authorization request with fresh
+   state and S256 PKCE values.
+5. The provider redirects to `/oauth/callback`. The server validates the
+   upstream transaction and exchanges the provider code.
+6. The server redirects a new local code to the MCP client's registered URI.
+7. The MCP client exchanges that code for local opaque access and refresh
+   tokens.
+
+Every local refresh token rotates after use. Replaying an old refresh token
+revokes its local token family. If an upstream refresh request has an ambiguous
+network result, the proxy fails closed and requires authorization again.
+
+## Configure provider-specific behavior
+
+`extraAuthorizeParams` adds fixed authorization parameters such as
+`prompt: "consent"`. Reserved protocol parameters—including `client_id`,
+`redirect_uri`, `state`, `scope`, PKCE fields, `nonce`, and `resource`—cannot be
+overridden.
+
+The downstream MCP `resource` is never forwarded upstream automatically. If a
+provider requires RFC 8707 resource indicators, map them explicitly:
+
+```typescript
+oauthProxy({
+  // ...required options
+  mapUpstreamResource({ phase }) {
+    return phase === "authorization"
+      ? "https://provider.example.com/api"
+      : undefined;
+  },
+});
+```
+
+Set `issuer` to the expected upstream RFC 9207 authorization-response issuer.
+Set `requireAuthorizationResponseIssuer: true` only when the provider always
+returns `iss`. This upstream value is separate from the local issuer published
+at `https://mcp.example.com/oauth`.
+
+Supply `verifyIdToken(idToken)` only when you verify its signature, issuer, and
+audience. Providing the hook enables an upstream OpenID Connect nonce and
+validates the nonce only against claims returned by that trusted hook.
+
+## Choose token storage
+
+Without `store`, each `oauthProxy()` call creates a private in-memory store. It
+needs no encryption key, but registrations and sessions disappear on restart
+and are not shared across server instances.
+
+For a persistent custom store, choose one of these protections:
+
+- configure SDK encryption with an AES-256-GCM keyring; or
+- declare `secretProtection: "store-encrypted"` when the custom store encrypts
+  every payload itself.
+
+A persistent store that declares `secretProtection: "none"` is rejected unless
+you configure SDK encryption. The SDK never derives an encryption key from the
+upstream client secret.
+
+Custom stores implement byte-oriented create, read, replace, consume, and
+multi-key transaction operations. Transactions must be serializable across all
+instances that share the store. Import `OAuthProxyStore` and
+`OAuthProxyEncryptionOptions` from `mcp-use/oauth` for the complete contracts.
+
+## Configuration reference
+
+| Option                               | Behavior                                                                 |
+| ------------------------------------ | ------------------------------------------------------------------------ |
+| `authEndpoint`                       | Required upstream authorization endpoint.                                |
+| `tokenEndpoint`                      | Required upstream token endpoint.                                        |
+| `issuer`                             | Optional expected upstream RFC 9207 authorization-response issuer.       |
+| `requireAuthorizationResponseIssuer` | Requires the upstream callback to return the configured `issuer`.        |
+| `clientId`                           | Required fixed upstream application client ID.                           |
+| `tokenEndpointAuthMethod`            | Required: `client_secret_basic`, `client_secret_post`, or `none`.        |
+| `clientSecret`                       | Required for secret methods and forbidden for `none`.                    |
+| `scopes`                             | Locally grantable scopes; defaults to `openid`, `email`, and `profile`.  |
+| `upstreamScopes`                     | Scopes requested upstream; defaults to `scopes`.                         |
+| `verifyToken`                        | Required upstream access-token verification and trusted payload mapping. |
+| `getUserInfo`                        | Optional synchronous application user mapper.                            |
+| `extraAuthorizeParams`               | Fixed non-reserved upstream authorization parameters.                    |
+| `verifyIdToken`                      | Trusted ID-token verifier that enables upstream nonce validation.        |
+| `mapUpstreamResource`                | Explicit provider-specific resource mapping for authorization/refresh.   |
+| `authorizationServerPath`            | Local route prefix; defaults to `/oauth`.                                |
+| `store` and `encryption`             | Optional state storage and SDK encryption configuration.                 |
+| `resource` / `requiredScopes`        | Canonical MCP resource override and scopes enforced by the bearer gate.  |
+| `resourceName`                       | Human-readable protected-resource metadata name.                         |
+| `serviceDocumentationUrl`            | Protected-resource documentation URL.                                    |
+| `fetch`                              | Optional Fetch implementation for upstream calls.                        |
+| `timeoutMs` / `maxResponseBytes`     | Bounds upstream requests and responses.                                  |
+| `maxBodyBytes`                       | Bounds local registration and form bodies.                               |
+
+## Test with GitHub
+
+The runnable
+[GitHub OAuth Proxy example](https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/auth/github-oauth-proxy)
+shows a provider that uses `client_secret_post`. It also demonstrates calling
+the GitHub API with `ctx.auth.providerAccessToken`.
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card
+    title="User Context"
+    icon="user"
+    href="/v2/typescript/server/authentication/user-context"
+  >
+    Authorize tools with the mapped user, scopes, permissions, and token
+    boundaries.
+  </Card>
+  <Card
+    title="GitHub example"
+    icon="github"
+    href="https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/auth/github-oauth-proxy"
+  >
+    Run a fixed-client OAuth Proxy locally.
+  </Card>
+</CardGroup>

--- a/docs/v2/typescript/server/authentication/user-context.mdx
+++ b/docs/v2/typescript/server/authentication/user-context.mdx
@@ -15,6 +15,7 @@ type OAuthAuth<TUser> = {
   user: TUser;
   payload: Record<string, unknown>;
   accessToken: string;
+  providerAccessToken?: string;
   scopes: string[];
   permissions: string[];
   clientId?: string;
@@ -25,7 +26,9 @@ type OAuthAuth<TUser> = {
 
 - `user` is the provider's normalized user type.
 - `payload` contains the verified token claims or introspection data.
-- `accessToken` is the verified bearer token. Forward it only when calling an upstream API on behalf of the user.
+- `accessToken` is the bearer token presented to the MCP server.
+- `providerAccessToken` is present only for OAuth Proxy. Send this token—not
+  `accessToken`—when calling the upstream provider on behalf of the user.
 - `scopes` are copied from the auth information returned by the token verifier.
 - `permissions` are produced by the provider's mapping.
 - `clientId` is present when the token has a client identifier.

--- a/docs/v2/typescript/server/migration.mdx
+++ b/docs/v2/typescript/server/migration.mdx
@@ -473,17 +473,26 @@ Move existing widget CSP domains to `view.csp`.
 
 ## Update authentication, proxies, and security
 
-Native v2 acts as an OAuth resource server backed by an external authorization
-server. Import provider adapters from `mcp-use/oauth/*`, supply their required
-locator options, and use the provider-specific `ctx.auth.user` type.
+Native v2 can act as an OAuth resource server backed by an external
+authorization server or run an embedded OAuth Proxy for a fixed upstream OAuth
+application. Import provider adapters from `mcp-use/oauth/*` and use the
+provider-specific `ctx.auth.user` type.
 
 Replace generic `userId` assumptions with the provider's mapped field, commonly
 `id`. Replace `getAuth`, `hasScope`, and `requireScope` with verified
 `ctx.auth`, scopes, permissions, and application authorization checks.
 
-OAuth proxy or authorization-server mode has no native v2 migration. Do not
-translate `oauthProxy`, `jwksVerifier`, or `mountOAuthProxy` as resource-server
-configuration.
+Migrate v1 `oauthProxy()` to the v2 factory from `mcp-use/oauth`. Configure
+`tokenEndpointAuthMethod` explicitly and provide a store when sessions must
+survive restarts or span instances. v2 issues local opaque tokens instead of
+passing provider tokens through: `ctx.auth.accessToken` is now the local MCP
+bearer, while `ctx.auth.providerAccessToken` is the token for upstream API
+calls. See [OAuth Proxy](/v2/typescript/server/authentication/providers/oauth-proxy)
+for the complete boundary.
+
+`mountOAuthProxy` is a browser-client BFF and is not the server authentication
+factory. Migrate custom JWT verification to the v2 verifier APIs or the
+`verifyToken` hook appropriate to the selected provider.
 
 v2 upstream composition accepts HTTP remotes or a ready compatible client
 connection. A v1 stdio child-process proxy requires an architecture change.
@@ -528,14 +537,11 @@ server.
 Move durable state to application storage keyed by verified user, tenant, or an
 explicit domain handle. Do not key business state to an MCP transport session.
 
-### OAuth, proxy, and OpenAPI
+### OAuth and OpenAPI
 
-- OAuth proxy and authorization-server mode are deferred. Direct
-  resource-server authentication is implemented.
 - Unsigned token bypasses such as `verifyJwt: false` are not supported.
-- Verify proxy requirements for upstream OAuth, templates, completions,
-  subscriptions, list synchronization, sampling, and elicitation before
-  migrating.
+- OAuth Proxy revokes local token families but does not call upstream provider
+  revocation endpoints automatically.
 - Verify OpenAPI servers that depend on external references, cookies, non-JSON
   request bodies, callbacks, webhooks, or automatic security-scheme discovery.
 

--- a/libraries/typescript/.changeset/bright-otters-proxy.md
+++ b/libraries/typescript/.changeset/bright-otters-proxy.md
@@ -1,0 +1,6 @@
+---
+"mcp-use": minor
+---
+
+Add an OAuth Proxy provider for upstream OAuth applications that do not support
+Dynamic Client Registration.

--- a/libraries/typescript/packages/server/examples/auth/README.md
+++ b/libraries/typescript/packages/server/examples/auth/README.md
@@ -1,6 +1,6 @@
-# Direct authentication examples
+# Authentication examples
 
-These examples use direct external authorization servers:
+These examples verify tokens from external authorization servers directly:
 
 - [Clerk](./clerk/)
 - [Auth0](./auth0/)
@@ -10,9 +10,15 @@ These examples use direct external authorization servers:
 - [Better Auth](./better-auth/)
 - [Mixed OAuth with Better Auth](./mixed-oauth/)
 
-Each server exposes only the `get-user-info` tool. It never issues, proxies, or
-forwards access tokens. For public deployments, set `MCP_URL` to the server
-origin (for example, `https://mcp.example.com`), not the `/mcp` endpoint.
+The [GitHub OAuth Proxy](./github-oauth-proxy/) example brokers one fixed
+GitHub OAuth App for MCP clients because GitHub does not provide Dynamic Client
+Registration for OAuth Apps.
+
+Each direct-provider example exposes only the `get-user-info` tool and never
+issues, proxies, or forwards access tokens. The GitHub proxy example instead
+uses the server-only upstream token to call GitHub. For public deployments, set
+`MCP_URL` to the server origin (for example, `https://mcp.example.com`), not the
+`/mcp` endpoint.
 
 OAuth protects the browser landing page at `/mcp` by default. These examples
 set `publicLandingPage: true` so people can open the HTML connection guide

--- a/libraries/typescript/packages/server/examples/auth/github-oauth-proxy/.env.example
+++ b/libraries/typescript/packages/server/examples/auth/github-oauth-proxy/.env.example
@@ -1,0 +1,6 @@
+# Create a GitHub OAuth App and copy its credentials here.
+GITHUB_CLIENT_ID=your-github-oauth-app-client-id
+GITHUB_CLIENT_SECRET=your-github-oauth-app-client-secret
+
+# Public origin only, with no path. Set this for tunnels and deployments.
+# MCP_URL=https://mcp.example.com

--- a/libraries/typescript/packages/server/examples/auth/github-oauth-proxy/README.md
+++ b/libraries/typescript/packages/server/examples/auth/github-oauth-proxy/README.md
@@ -1,0 +1,52 @@
+# GitHub OAuth Proxy example
+
+This server lets MCP clients authenticate through one GitHub OAuth App. The
+server performs the GitHub authorization flow, stores GitHub tokens privately,
+and issues separate opaque tokens to each MCP client.
+
+## Configure GitHub
+
+1. Create a GitHub OAuth App under **Settings → Developer settings → OAuth
+   Apps**. GitHub documents the endpoints, S256 PKCE fields, and code exchange
+   in [Authorizing OAuth apps](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps).
+2. Set **Homepage URL** to `http://localhost:3000`.
+3. Set **Authorization callback URL** to
+   `http://localhost:3000/oauth/callback`.
+4. Copy `.env.example` to `.env` and set `GITHUB_CLIENT_ID` and
+   `GITHUB_CLIENT_SECRET`.
+
+For a public deployment, use the public origin for the homepage and register
+`https://mcp.example.com/oauth/callback`. Set `MCP_URL` to that origin without a
+path.
+
+## Run
+
+From this directory:
+
+```sh
+pnpm dev
+```
+
+The script requests port 3000. If the CLI selects another available port,
+update the GitHub OAuth App callback URL to match the printed origin and restart
+the authorization flow.
+
+Connect an MCP client to `http://localhost:3000/mcp`. The server dynamically
+registers the MCP client locally and asks for consent before redirecting to
+GitHub.
+
+## Verify the token boundary
+
+Call the `get-github-user` tool after authorization. The tool uses
+`ctx.auth.providerAccessToken` to call GitHub. `ctx.auth.accessToken` is the
+separate opaque token presented by the MCP client and must not be sent to
+GitHub.
+
+The default store is process-local. Restarting the server clears client
+registrations, consent transactions, and token sessions.
+
+## Verify types
+
+```sh
+pnpm typecheck
+```

--- a/libraries/typescript/packages/server/examples/auth/github-oauth-proxy/package.json
+++ b/libraries/typescript/packages/server/examples/auth/github-oauth-proxy/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "mcp-use-example-auth-github-oauth-proxy",
+  "type": "module",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Example: mcp-use OAuth Proxy with a fixed GitHub OAuth App.",
+  "engines": {
+    "node": ">=22.22.2"
+  },
+  "scripts": {
+    "dev": "mcp-use dev --port 3000",
+    "build": "mcp-use build",
+    "start": "mcp-use start --port 3000",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "mcp-use": "workspace:*",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "^22.20.0",
+    "typescript": "^7.0.2"
+  }
+}

--- a/libraries/typescript/packages/server/examples/auth/github-oauth-proxy/src/index.ts
+++ b/libraries/typescript/packages/server/examples/auth/github-oauth-proxy/src/index.ts
@@ -1,0 +1,104 @@
+import { MCPServer } from "mcp-use";
+import { oauthProxy, type OAuthProxyJsonObject } from "mcp-use/oauth";
+import { z } from "zod";
+
+const githubUserSchema = z.object({
+  id: z.number().int().nonnegative(),
+  login: z.string(),
+  name: z.string().nullable(),
+  email: z.string().nullable(),
+  avatar_url: z.url(),
+  html_url: z.url(),
+});
+
+const githubUserOutputSchema = z.object({
+  id: z.string(),
+  login: z.string(),
+  name: z.string().nullable(),
+  email: z.string().nullable(),
+  avatarUrl: z.url(),
+  profileUrl: z.url(),
+});
+
+function requireEnv(name: string): string {
+  const value = process.env[name]?.trim();
+  if (value === undefined || value === "") {
+    throw new Error(`${name} must be set`);
+  }
+  return value;
+}
+
+async function fetchGitHubUser(providerAccessToken: string) {
+  const response = await fetch("https://api.github.com/user", {
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${providerAccessToken}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`GitHub user verification failed (${response.status})`);
+  }
+  return githubUserSchema.parse(await response.json());
+}
+
+const server = new MCPServer({
+  name: "github-oauth-proxy-example",
+  version: "1.0.0",
+  title: "GitHub OAuth Proxy example",
+  description:
+    "Brokers a fixed GitHub OAuth App for dynamically registered MCP clients.",
+  publicLandingPage: true,
+  oauth: oauthProxy({
+    authEndpoint: "https://github.com/login/oauth/authorize",
+    tokenEndpoint: "https://github.com/login/oauth/access_token",
+    clientId: requireEnv("GITHUB_CLIENT_ID"),
+    clientSecret: requireEnv("GITHUB_CLIENT_SECRET"),
+    tokenEndpointAuthMethod: "client_secret_post",
+    scopes: ["read:user"],
+    async verifyToken(providerAccessToken) {
+      const user = await fetchGitHubUser(providerAccessToken);
+      const payload: OAuthProxyJsonObject = {
+        sub: String(user.id),
+        preferred_username: user.login,
+        name: user.name,
+        email: user.email,
+        picture: user.avatar_url,
+        profile_url: user.html_url,
+      };
+      return { payload };
+    },
+  }),
+});
+
+server.tool(
+  {
+    name: "get-github-user",
+    title: "Get GitHub user",
+    description:
+      "Call GitHub with the authenticated user's provider access token.",
+    outputSchema: githubUserOutputSchema,
+    annotations: { readOnlyHint: true },
+  },
+  async (_args, ctx) => {
+    const providerAccessToken = ctx.auth.providerAccessToken;
+    if (providerAccessToken === undefined) {
+      throw new Error("GitHub provider access token is unavailable");
+    }
+    const user = await fetchGitHubUser(providerAccessToken);
+    const data = {
+      id: String(user.id),
+      login: user.login,
+      name: user.name,
+      email: user.email,
+      avatarUrl: user.avatar_url,
+      profileUrl: user.html_url,
+    };
+    return {
+      content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+      structuredContent: data,
+    };
+  }
+);
+
+export default server;

--- a/libraries/typescript/packages/server/examples/auth/github-oauth-proxy/tsconfig.json
+++ b/libraries/typescript/packages/server/examples/auth/github-oauth-proxy/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2024"],
+    "types": ["node"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -667,6 +667,22 @@ importers:
         specifier: ^7.0.2
         version: 7.0.2
 
+  packages/server/examples/auth/github-oauth-proxy:
+    dependencies:
+      mcp-use:
+        specifier: workspace:*
+        version: link:../../..
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@types/node':
+        specifier: ^22.20.0
+        version: 22.20.1
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
+
   packages/server/examples/auth/keycloak:
     dependencies:
       mcp-use:


### PR DESCRIPTION
## Summary

Documents OAuth Proxy v2 and adds a runnable GitHub OAuth App example. No GitHub or Google provider preset is introduced.

## Review focus

- Setup, two-token boundary, authorization flow, provider-specific hooks, and storage/encryption guide.
- Migration guidance from v1 OAuth Proxy semantics.
- GitHub example using `client_secret_post`, S256 PKCE, `/oauth/callback`, and `ctx.auth.providerAccessToken`.
- Minor changeset for `mcp-use`.

## Validation

- GitHub example typechecks and builds.
- Documentation JSON parses and all changed files pass Prettier.
- Changed TypeScript passes ESLint.
- Full OAuth run: 13 test files, 137 tests; server typecheck and build pass.

PR 8 of 8. Based on #2345. Stack starts at #2339.
