### PR TITLE
feat(client): support generic confidential OAuth clients

### DIFF
--- a/libraries/typescript/.changeset/fuzzy-cats-connect.md
+++ b/libraries/typescript/.changeset/fuzzy-cats-connect.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/client": minor
+---
+
+Support generic pre-registered confidential OAuth clients in `useMcp` with `oauth.clientSecret`. Browser flows require an OAuth proxy and complete the authorization-code exchange in the popup opener so client secrets remain in memory and are never persisted in callback state or localStorage.

--- a/libraries/typescript/packages/client/src/auth/browser.ts
+++ b/libraries/typescript/packages/client/src/auth/browser.ts
@@ -66,6 +66,8 @@ export interface BrowserOAuthOptions {
   /**
    * Pre-registered OAuth client information. When set, the SDK skips
    * Dynamic Client Registration and uses this client_id directly.
+   * Confidential clients require `oauthProxyUrl` and popup OAuth; their secret
+   * remains in opener memory and is omitted from persisted callback state.
    * Required for proxy-mode auth servers (e.g. Slack, WorkOS proxy)
    * that strip `registration_endpoint` from metadata.
    */
@@ -86,8 +88,10 @@ export interface BrowserOAuthOptions {
 export class BrowserOAuthClientProvider implements OAuthClientProvider {
   /** Protected MCP server URL associated with this provider. */
   readonly serverUrl: string;
-  /** Pre-registered public client information, when configured. */
+  /** Pre-registered client information, when configured. */
   readonly staticClientInfo?: OAuthClientInformation;
+  /** Whether the popup callback must return the code for an opener-owned exchange. */
+  readonly completeAuthorizationInOpener: boolean;
   private session: OAuthSessionStore;
   private readonly storage: LocalStorageKVStore;
 
@@ -112,9 +116,15 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
     | undefined;
 
   constructor(serverUrl: string, options: BrowserOAuthOptions = {}) {
-    if (options.staticClientInfo?.client_secret) {
+    const hasClientSecret = Boolean(options.staticClientInfo?.client_secret);
+    if (hasClientSecret && !options.oauthProxyUrl) {
       throw new Error(
-        "Browser OAuth clients must be public clients; staticClientInfo.client_secret is not allowed."
+        "Browser confidential OAuth clients require oauthProxyUrl so the client secret is never sent directly to the authorization server."
+      );
+    }
+    if (hasClientSecret && options.useRedirectFlow) {
+      throw new Error(
+        "Browser confidential OAuth clients require popup OAuth; redirect flow cannot keep the client secret in memory."
       );
     }
     this.serverUrl = serverUrl;
@@ -130,6 +140,7 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
     this.connectionUrl = options.connectionUrl;
     this.proxyOAuthRequests = options.proxyOAuthRequests ?? true;
     this.staticClientInfo = options.staticClientInfo;
+    this.completeAuthorizationInOpener = hasClientSecret;
     this.onPopupWindow = options.onPopupWindow;
   }
 
@@ -579,8 +590,7 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
   }
 
   /**
-   * Return the stored public OAuth client ID. Browser providers do not retain
-   * client secrets.
+   * Return the configured OAuth client ID without exposing its secret.
    */
   async getClientCredentials(): Promise<{
     /** Public OAuth client identifier. */
@@ -597,6 +607,11 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
    * use `redirectToAuthorization` for that.
    */
   async prepareAuthorizationUrl(authorizationUrl: URL): Promise<string> {
+    const publicStaticClientInfo = this.staticClientInfo
+      ? (({ client_secret: _secret, ...publicInfo }) => publicInfo)(
+          this.staticClientInfo
+        )
+      : undefined;
     const prepared = await this.session.storeAuthorizationState(
       authorizationUrl,
       {
@@ -605,11 +620,14 @@ export class BrowserOAuthClientProvider implements OAuthClientProvider {
           ...(this.clientMetadataUrl
             ? { clientMetadataUrl: this.clientMetadataUrl }
             : {}),
-          ...(this.staticClientInfo
-            ? { staticClientInfo: this.staticClientInfo }
+          ...(publicStaticClientInfo
+            ? { staticClientInfo: publicStaticClientInfo }
             : {}),
           ...(this.scope ? { scope: this.scope } : {}),
         },
+        ...(this.completeAuthorizationInOpener
+          ? { completeAuthorizationInOpener: true }
+          : {}),
         flowType: this.useRedirectFlow ? "redirect" : "popup",
         returnUrl:
           typeof window !== "undefined" ? window.location.href : undefined,

--- a/libraries/typescript/packages/client/src/auth/callback.ts
+++ b/libraries/typescript/packages/client/src/auth/callback.ts
@@ -11,6 +11,8 @@ import { LocalStorageKVStore } from "./storage.js";
 interface AuthCallbackMeta {
   state?: string | null;
   serverUrlHash?: string | null;
+  authorizationCode?: string | null;
+  issuer?: string | null;
 }
 
 let inFlightCallback: Promise<void> | null = null;
@@ -30,6 +32,10 @@ function buildCallbackPayload(
     ...(success ? {} : { error: error ?? "Unknown error" }),
     ...(meta.state ? { state: meta.state } : {}),
     ...(meta.serverUrlHash ? { serverUrlHash: meta.serverUrlHash } : {}),
+    ...(meta.authorizationCode
+      ? { authorizationCode: meta.authorizationCode }
+      : {}),
+    ...(meta.issuer ? { issuer: meta.issuer } : {}),
   };
 }
 
@@ -236,6 +242,28 @@ async function completeAuthorization(): Promise<void> {
 
     if (!storedState.providerOptions) {
       throw new Error("Stored OAuth state is missing provider options.");
+    }
+
+    if (storedState.completeAuthorizationInOpener) {
+      const oauthError = callbackParams.get("error");
+      if (oauthError) {
+        throw new Error(
+          callbackParams.get("error_description") ??
+            `OAuth authorization failed: ${oauthError}`
+        );
+      }
+      const authorizationCode = callbackParams.get("code");
+      if (!authorizationCode) {
+        throw new Error("OAuth callback is missing the authorization code.");
+      }
+      await stateStore.remove(stateKey);
+      signalResult(true, undefined, storedState, {
+        state,
+        serverUrlHash: storedState.serverUrlHash,
+        authorizationCode,
+        issuer: callbackParams.get("iss"),
+      });
+      return;
     }
 
     const { serverUrl, ...providerOptions } = storedState.providerOptions;

--- a/libraries/typescript/packages/client/src/auth/flow.ts
+++ b/libraries/typescript/packages/client/src/auth/flow.ts
@@ -146,13 +146,33 @@ export async function completeOAuthFlow(
     return;
   }
 
-  await waitForBrowserAuthComplete(flowProvider, timeoutMs);
+  const browserResult = await waitForBrowserAuthComplete(
+    flowProvider,
+    timeoutMs
+  );
+  if (browserResult?.authorizationCode) {
+    if (options.finishAuthorization) {
+      await options.finishAuthorization(
+        browserResult.authorizationCode,
+        browserResult.issuer
+      );
+    } else {
+      await auth(provider, {
+        serverUrl,
+        authorizationCode: browserResult.authorizationCode,
+        ...(browserResult.issuer !== undefined
+          ? { iss: browserResult.issuer }
+          : {}),
+        fetchFn,
+      });
+    }
+  }
 }
 
 async function waitForBrowserAuthComplete(
   provider: FlowProvider,
   timeoutMs: number
-): Promise<void> {
+): Promise<{ authorizationCode?: string; issuer?: string } | undefined> {
   if (typeof window === "undefined") {
     throw new Error(
       "OAuth redirect requires a browser environment or a provider with getAuthorizationCode()"
@@ -193,7 +213,12 @@ async function waitForBrowserAuthComplete(
 
     switch (result.kind) {
       case "success":
-        return;
+        return {
+          ...(result.authorizationCode
+            ? { authorizationCode: result.authorizationCode }
+            : {}),
+          ...(result.issuer ? { issuer: result.issuer } : {}),
+        };
       case "cancelled":
         throw new Error("OAuth authentication was cancelled.");
       case "timeout":

--- a/libraries/typescript/packages/client/src/auth/popup.ts
+++ b/libraries/typescript/packages/client/src/auth/popup.ts
@@ -40,11 +40,15 @@ export interface McpAuthCallbackMessage {
   state?: string;
   /** Hash of the server URL the flow authenticated against. */
   serverUrlHash?: string;
+  /** Authorization code returned for an opener-owned confidential-client exchange. */
+  authorizationCode?: string;
+  /** Authorization-server issuer returned with the authorization response. */
+  issuer?: string;
 }
 
 /** Terminal outcome of an opener-owned popup flow. */
 type AuthPopupResult =
-  | { kind: "success" }
+  | { kind: "success"; authorizationCode?: string; issuer?: string }
   | { kind: "error"; error: string }
   | { kind: "cancelled" }
   | { kind: "timeout" };
@@ -152,7 +156,13 @@ export function runAuthPopup({
       // without a `state` (older callback pages) are accepted for back-compat.
       if (payload.state && state && payload.state !== state) return;
       if (payload.success) {
-        settle({ kind: "success" });
+        settle({
+          kind: "success",
+          ...(payload.authorizationCode
+            ? { authorizationCode: payload.authorizationCode }
+            : {}),
+          ...(payload.issuer ? { issuer: payload.issuer } : {}),
+        });
       } else {
         settle({
           kind: "error",

--- a/libraries/typescript/packages/client/src/auth/session-store.ts
+++ b/libraries/typescript/packages/client/src/auth/session-store.ts
@@ -27,6 +27,8 @@ export interface StoredState {
     staticClientInfo?: OAuthClientInformation;
     scope?: string;
   };
+  /** Complete the code exchange in the opener so confidential credentials stay in memory. */
+  completeAuthorizationInOpener?: boolean;
   flowType?: "popup" | "redirect";
   returnUrl?: string;
 }
@@ -67,6 +69,7 @@ interface StoreAuthorizationStateOptions {
    * stored state so the callback handler can rebuild the provider.
    */
   extraProviderOptions?: Record<string, unknown>;
+  completeAuthorizationInOpener?: boolean;
   flowType?: "popup" | "redirect";
   returnUrl?: string;
 }
@@ -447,6 +450,9 @@ export class OAuthSessionStore {
           : {}),
         ...(opts.extraProviderOptions ?? {}),
       },
+      ...(opts.completeAuthorizationInOpener
+        ? { completeAuthorizationInOpener: true }
+        : {}),
       flowType: opts.flowType,
       returnUrl: opts.returnUrl,
     };

--- a/libraries/typescript/packages/client/src/core/config.ts
+++ b/libraries/typescript/packages/client/src/core/config.ts
@@ -167,7 +167,11 @@ export interface AutoOAuthOptions {
   clientMetadataUrl?: string;
   /** Space-delimited OAuth scopes to request. */
   scope?: string;
-  /** Pre-registered public client id (skips DCR). */
+  /**
+   * Pre-registered OAuth client information (skips DCR). Browser client
+   * secrets require an OAuth proxy and popup flow; Node providers may use
+   * confidential credentials directly.
+   */
   staticClientInfo?: OAuthClientInformation;
   /** Preferred Node loopback port. Defaults to `33418`. */
   preferredPort?: number;

--- a/libraries/typescript/packages/client/src/react/types.ts
+++ b/libraries/typescript/packages/client/src/react/types.ts
@@ -325,6 +325,7 @@ export type UseMcpOptions = {
    *   url: 'https://mcp.example.com',
    *   oauth: {
    *     clientId: 'my-preregistered-client-id',
+   *     clientSecret: 'kept-in-memory-until-token-exchange',
    *     clientMetadataUrl: 'https://app.example.com/oauth/client-metadata.json',
    *     scope: 'openid profile email',
    *   },
@@ -334,6 +335,12 @@ export type UseMcpOptions = {
   oauth?: {
     /** Pre-registered OAuth client_id. */
     clientId?: string;
+    /**
+     * Pre-registered confidential-client secret. Requires `clientId`, a
+     * configured `oauthProxyUrl`, and popup OAuth. The secret is kept in the
+     * opener's memory and is never written to callback state or localStorage.
+     */
+    clientSecret?: string;
     /**
      * Public HTTPS OAuth Client ID Metadata Document URL (CIMD).
      * The document must contain a matching client_id and redirect_uris.

--- a/libraries/typescript/packages/client/src/react/useMcp.ts
+++ b/libraries/typescript/packages/client/src/react/useMcp.ts
@@ -159,12 +159,19 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
   const requestedProxyAddress = proxyConfig?.proxyAddress;
 
   const oauthClientId = oauthOptions?.clientId?.trim() || undefined;
+  const oauthClientSecret = oauthOptions?.clientSecret?.trim() || undefined;
   const oauthClientMetadataUrl =
     oauthOptions?.clientMetadataUrl?.trim() || undefined;
   const oauthScope = oauthOptions?.scope?.trim() || undefined;
   const staticClientInfo = useMemo(
-    () => (oauthClientId ? { client_id: oauthClientId } : undefined),
-    [oauthClientId]
+    () =>
+      oauthClientId
+        ? {
+            client_id: oauthClientId,
+            ...(oauthClientSecret ? { client_secret: oauthClientSecret } : {}),
+          }
+        : undefined,
+    [oauthClientId, oauthClientSecret]
   );
 
   // Create a per-instance logger so multiple useMcp instances don't clobber each other's log level.
@@ -1749,6 +1756,14 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
 
         switch (result.kind) {
           case "success":
+            if (result.authorizationCode) {
+              await auth(freshAuthProvider, {
+                serverUrl: baseUrl,
+                authorizationCode: result.authorizationCode,
+                ...(result.issuer ? { iss: result.issuer } : {}),
+                fetchFn: freshAuthProvider.getProxyFetch?.(),
+              });
+            }
             addLog(
               "info",
               "Authentication succeeded; reconnecting to MCP server..."

--- a/libraries/typescript/packages/client/tests/unit/auth/browser-provider-static-client.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/auth/browser-provider-static-client.test.ts
@@ -249,7 +249,7 @@ describe("BrowserOAuthClientProvider — pre-registered client_id", () => {
     expect(stored.providerOptions.scope).toBe("openid profile");
   });
 
-  it("rejects a static browser client secret", () => {
+  it("requires an OAuth proxy for a static browser client secret", () => {
     expect(
       () =>
         new BrowserOAuthClientProvider(SERVER_URL, {
@@ -259,7 +259,54 @@ describe("BrowserOAuthClientProvider — pre-registered client_id", () => {
             client_secret: "shh-secret",
           },
         })
-    ).toThrow(/public clients/);
+    ).toThrow(/require oauthProxyUrl/);
+  });
+
+  it("rejects redirect flow for a static browser client secret", () => {
+    expect(
+      () =>
+        new BrowserOAuthClientProvider(SERVER_URL, {
+          callbackUrl: "https://app.example.com/oauth/callback",
+          oauthProxyUrl: "https://app.example.com/inspector/api/oauth",
+          useRedirectFlow: true,
+          staticClientInfo: {
+            client_id: "preregistered-abc",
+            client_secret: "shh-secret",
+          },
+        })
+    ).toThrow(/require popup OAuth/);
+  });
+
+  it("keeps a static client secret in opener memory and out of callback state", async () => {
+    const provider = new BrowserOAuthClientProvider(SERVER_URL, {
+      callbackUrl: "https://app.example.com/oauth/callback",
+      oauthProxyUrl: "https://app.example.com/inspector/api/oauth",
+      staticClientInfo: {
+        client_id: "preregistered-abc",
+        client_secret: "shh-secret",
+      },
+    });
+
+    expect(await provider.clientInformation()).toMatchObject({
+      client_id: "preregistered-abc",
+      client_secret: "shh-secret",
+    });
+    expect(provider.completeAuthorizationInOpener).toBe(true);
+
+    await provider.prepareAuthorizationUrl(
+      new URL("https://auth.example.com/authorize")
+    );
+    const stateKey = Object.keys(localStorage).find((key) =>
+      key.includes("_state_")
+    );
+    const serialized = await new LocalStorageKVStore().get(stateKey!);
+    expect(serialized).not.toContain("shh-secret");
+    expect(JSON.parse(serialized!)).toMatchObject({
+      completeAuthorizationInOpener: true,
+      providerOptions: {
+        staticClientInfo: { client_id: "preregistered-abc" },
+      },
+    });
   });
 
   it("validates and persists clientMetadataUrl for callback reconstruction", async () => {

--- a/libraries/typescript/packages/client/tests/unit/auth/callback.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/auth/callback.test.ts
@@ -185,6 +185,32 @@ describe("onMcpAuthorization", () => {
     expect(localStorage.getItem(stateKey)).toBeNull();
   });
 
+  it("returns the authorization response to the opener without exchanging it", async () => {
+    storeState({ completeAuthorizationInOpener: true });
+    setCallbackUrl(
+      `code=authorization-code&iss=https%3A%2F%2Fauth.example.com&state=${state}`
+    );
+    const { onMcpAuthorization } =
+      await import("../../../src/auth/callback.js");
+
+    await onMcpAuthorization();
+
+    expect(mocks.providerConstructor).not.toHaveBeenCalled();
+    expect(mocks.finishAuth).not.toHaveBeenCalled();
+    expect(postMessage).toHaveBeenCalledWith(
+      {
+        type: "mcp_auth_callback",
+        success: true,
+        state,
+        serverUrlHash: "server-hash",
+        authorizationCode: "authorization-code",
+        issuer: "https://auth.example.com",
+      },
+      window.location.origin
+    );
+    expect(localStorage.getItem(stateKey)).toBeNull();
+  });
+
   it("decrypts a persisted state record before completing the callback", async () => {
     const storedState: StoredState = {
       expiry: Date.now() + 60_000,

--- a/libraries/typescript/packages/client/tests/unit/auth/flow.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/auth/flow.test.ts
@@ -150,6 +150,32 @@ describe("completeOAuthFlow", () => {
     expect(markFlowComplete).toHaveBeenCalledOnce();
   });
 
+  it("exchanges a confidential-client callback code in the browser opener", async () => {
+    vi.mocked(runAuthPopup).mockResolvedValue({
+      kind: "success",
+      authorizationCode: "authorization-code",
+      issuer: "https://auth.example.com",
+    });
+    vi.mocked(auth).mockResolvedValue("AUTHORIZED");
+    const proxyFetch = vi.fn();
+    const provider = {
+      hasPendingFlow: true,
+      getKey: () => "mcp:auth_server_tokens",
+      getLastAttemptedAuthUrl: () =>
+        "https://auth.example.com/authorize?state=stored-state",
+      getProxyFetch: () => proxyFetch,
+    } as unknown as OAuthClientProvider;
+
+    await completeOAuthFlow(provider, "https://example.com/mcp");
+
+    expect(auth).toHaveBeenCalledWith(provider, {
+      serverUrl: "https://example.com/mcp",
+      authorizationCode: "authorization-code",
+      iss: "https://auth.example.com",
+      fetchFn: proxyFetch,
+    });
+  });
+
   it("launches a prepared browser flow after explicit authentication", async () => {
     vi.mocked(runAuthPopup).mockResolvedValue({ kind: "success" });
     const startAuthorization = vi.fn();

--- a/libraries/typescript/packages/client/tests/unit/auth/popup-runner.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/auth/popup-runner.test.ts
@@ -92,6 +92,28 @@ describe("runAuthPopup", () => {
     await expect(promise).resolves.toEqual({ kind: "success" });
   });
 
+  it("returns an authorization code and issuer for opener-owned exchange", async () => {
+    const promise = runAuthPopup({
+      popup: makePopupStub() as unknown as Window,
+      state: FLOW_STATE,
+      tokensKey: TOKENS_KEY,
+    });
+
+    postCallbackMessage({
+      type: MCP_AUTH_CALLBACK_MESSAGE_TYPE,
+      success: true,
+      state: FLOW_STATE,
+      authorizationCode: "authorization-code",
+      issuer: "https://auth.example.com",
+    });
+
+    await expect(promise).resolves.toEqual({
+      kind: "success",
+      authorizationCode: "authorization-code",
+      issuer: "https://auth.example.com",
+    });
+  });
+
   it("ignores result messages belonging to a different flow's state", async () => {
     const popup = makePopupStub();
     const promise = runAuthPopup({

--- a/libraries/typescript/packages/client/tests/unit/react/useMcp-auth-flow-error.test.tsx
+++ b/libraries/typescript/packages/client/tests/unit/react/useMcp-auth-flow-error.test.tsx
@@ -114,6 +114,43 @@ describe("useMcp manual authentication failures", () => {
     vi.clearAllMocks();
   });
 
+  it("forwards generic pre-registered client credentials to the browser provider", async () => {
+    function TestComponent() {
+      useMcp({
+        url: "https://mcp.example.com/mcp",
+        oauthProxyUrl: "https://app.example.com/inspector/api/oauth",
+        oauth: {
+          clientId: "pre-registered-client",
+          clientSecret: "confidential-secret",
+          scope: "read write",
+        },
+        autoReconnect: false,
+        autoRetry: false,
+        logLevel: "silent",
+      });
+      return null;
+    }
+
+    let renderer: ReturnType<typeof create>;
+    await act(async () => {
+      renderer = create(<TestComponent />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mocks.createBrowserOAuthProvider).toHaveBeenCalledWith(
+      expect.objectContaining({
+        staticClientInfo: {
+          client_id: "pre-registered-client",
+          client_secret: "confidential-secret",
+        },
+        scope: "read write",
+      })
+    );
+
+    await act(async () => renderer!.unmount());
+  });
+
   it("surfaces pre-redirect auth errors without starting the popup runner", async () => {
     let latest: ReturnType<typeof useMcp> | undefined;
 


### PR DESCRIPTION
## Summary

- add generic `oauth.clientSecret` support alongside `clientId` and `scope` in `useMcp`
- require browser confidential-client flows to use an OAuth proxy and popup flow
- complete the authorization-code exchange in the opener so the client secret remains in memory and is never written to callback state or localStorage
- preserve existing public-client DCR/CIMD and callback behavior
- add a minor changeset for `@mcp-use/client` so `pkg-pr-new` publishes a preview package

This is provider-agnostic: Slack, Google services, and any other pre-registered OAuth client use the same MCP/OAuth fields and flow.

## Validation

- `pnpm --filter @mcp-use/client exec tsc --noEmit`
- `pnpm --filter @mcp-use/client build`
- `pnpm --filter @mcp-use/client test:run` (56 files, 349 tests)
- `pnpm --filter @mcp-use/agent build`
- `pnpm --filter @mcp-use/inspector build`
- focused ESLint and Prettier checks
- `pnpm exec changeset status`
- `git diff --check`

## MochiPi preview test

Once the PR preview workflow publishes, install the emitted `@mcp-use/client` preview package in MochiPi and pass the generic `{ clientId, clientSecret, scope }` config with the existing same-origin `/inspector/api/oauth` proxy and popup callback.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds pre-registered confidential OAuth client support to `useMcp` via `oauth.clientSecret`, completing the token exchange in the popup opener so the secret stays in memory and is never persisted to callback state or localStorage. Browser flows previously rejected client secrets outright; now Slack, Google, and other pre-registered apps can use the existing OAuth proxy and popup flow, and public-client behavior is unchanged.

**Behavior**
- Confidential-client browser flows require `oauthProxyUrl` and popup OAuth; redirect flow now throws instead of exposing the secret.
- Callback pages pass the authorization code and issuer back to the opener, which performs the exchange.

<sup>Written for commit ddc34bb38954f63d40380dc49ac8de35038d05d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

