### PR TITLE
feat(inspector): show RPC latency in the timing column

### DIFF
--- a/libraries/typescript/.changeset/tidy-rpc-latency.md
+++ b/libraries/typescript/.changeset/tidy-rpc-latency.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Show RPC response latency in the traffic timing column instead of repeating it in the method label.

--- a/libraries/typescript/packages/inspector/src/client/components/logging/JsonRpcLoggerView.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/logging/JsonRpcLoggerView.tsx
@@ -424,11 +424,18 @@ function RpcLogRow({
         <Tooltip>
           <TooltipTrigger
             render={
-              <span className="shrink-0 cursor-default font-mono text-[10px] tabular-nums text-muted-foreground underline decoration-dotted underline-offset-2">
-                {responseLabel
-                  ? `${responseLabel.latencyMs} ms`
-                  : new Date(item.timestamp).toLocaleTimeString()}
-              </span>
+              responseLabel ? (
+                <span className="shrink-0 cursor-default font-mono text-[10px] tabular-nums text-muted-foreground underline decoration-dotted underline-offset-2">
+                  {responseLabel.latencyMs} ms
+                </span>
+              ) : (
+                <time
+                  dateTime={item.timestamp}
+                  className="shrink-0 cursor-default font-mono text-[10px] tabular-nums text-muted-foreground underline decoration-dotted underline-offset-2"
+                >
+                  {new Date(item.timestamp).toLocaleTimeString()}
+                </time>
+              )
             }
             nativeButton={false}
           />

--- a/libraries/typescript/packages/inspector/src/client/components/logging/JsonRpcLoggerView.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/logging/JsonRpcLoggerView.tsx
@@ -409,9 +409,6 @@ function RpcLogRow({
           {responseLabel ? (
             <>
               <span>{responseLabel.method}</span>
-              <span className="ml-1 text-[9px] tabular-nums text-muted-foreground/80">
-                · {responseLabel.latencyMs} ms
-              </span>
               {responseLabel.outcome === "error" ? (
                 <span className="text-muted-foreground"> · error</span>
               ) : null}
@@ -427,12 +424,11 @@ function RpcLogRow({
         <Tooltip>
           <TooltipTrigger
             render={
-              <time
-                dateTime={item.timestamp}
-                className="shrink-0 cursor-default font-mono text-[10px] tabular-nums text-muted-foreground underline decoration-dotted underline-offset-2"
-              >
-                {new Date(item.timestamp).toLocaleTimeString()}
-              </time>
+              <span className="shrink-0 cursor-default font-mono text-[10px] tabular-nums text-muted-foreground underline decoration-dotted underline-offset-2">
+                {responseLabel
+                  ? `${responseLabel.latencyMs} ms`
+                  : new Date(item.timestamp).toLocaleTimeString()}
+              </span>
             }
             nativeButton={false}
           />


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

Move correlated JSON-RPC response latency into the traffic row's right-hand timing column instead of appending it to the method label.

This follows the maintainer-requested follow-up in #2327: method names retain the available width, while the more useful response duration replaces the wall-clock timestamp for matched responses. Request rows and unmatched responses keep their existing timestamp, and the exact response timestamp remains available in the tooltip.

## Review Readiness

- [x] Scoped to #2327
- [x] Checked open PRs for the issue and equivalent wording; no duplicate found
- [x] Added the required Inspector changeset
- [x] Verified the affected Inspector package locally

## TypeScript Checklist

### Packages Modified

- [x] `inspector`

### Pre-commit Checklist

- [x] Formatting passes
- [x] Linting passes
- [x] Build passes
- [x] Changeset added
- [x] Existing correlation tests cover the latency value used by the row

## Testing

- `pnpm exec vitest run src/client/__tests__/rpc-traffic-correlation.test.ts` (5 passed)
- `pnpm exec vitest run --maxWorkers=1` (54 files, 261 tests passed)
- `pnpm type-check`
- `pnpm lint`
- `pnpm exec prettier --check packages/inspector/src/client/components/logging/JsonRpcLoggerView.tsx .changeset/tidy-rpc-latency.md`
- `pnpm build`

## Compatibility / Risk

Presentation-only change. RPC traffic capture, correlation, storage, search, copy, and download formats are unchanged. Rows without a correlated duration continue to display their timestamp.

Closes #2327

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves correlated JSON-RPC response latency into the traffic row's timing column so method names keep their full width.

- Matched responses now show latency in place of the wall-clock timestamp; request rows and unmatched responses keep the timestamp.
- The exact response timestamp remains available in the tooltip.

<sup>Written for commit 046e7d0261ba5ab5f87be452561a29dd2edb2448. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

