### PR TITLE
docs(cli): add a README so the npm page is not blank

### DIFF
--- a/libraries/typescript/packages/cli/README.md
+++ b/libraries/typescript/packages/cli/README.md
@@ -1,0 +1,43 @@
+# `@mcp-use/cli`
+
+Prebuilt CLI, development server, and build pipeline for
+[mcp-use](https://github.com/mcp-use/mcp-use).
+
+Most people never install this package directly. `mcp-use` depends on it and
+exposes the same `mcp-use` executable, so a project that installs the framework
+already has it:
+
+```bash
+npm install mcp-use
+npx mcp-use dev
+```
+
+## Commands
+
+```text
+mcp-use <command> [options]
+
+  dev          Start the dev server
+  build        Build the server into .mcp-use/build
+  typecheck    Refresh MCP types and run the project's TypeScript compiler
+  start        Serve the production build from .mcp-use/build
+  client       Connect to and invoke MCP servers
+  screenshot   Capture an MCP Apps view
+  deploy       Deploy from GitHub or upload local source
+  login/logout/whoami/org/servers/deployments
+               Manage Manufact Cloud sessions, servers, and deployments
+```
+
+`mcp-use dev` serves the MCP endpoint, watches views for HMR, and mounts the
+Inspector. `--tunnel` exposes either `dev` or `start` through the managed
+relay in [`@mcp-use/tunnel`](https://www.npmjs.com/package/@mcp-use/tunnel).
+
+Run `mcp-use --help` for the full option list.
+
+## Documentation
+
+The exhaustive command reference, including every flag and the CLI environment
+variables, lives at
+[CLI Reference](https://docs.mcp-use.com/v2/typescript/api-reference/cli-reference).
+New to the framework? Start with the
+[quickstart](https://docs.mcp-use.com/v2/typescript/getting-started/quickstart).

--- a/libraries/typescript/packages/cli/README.md
+++ b/libraries/typescript/packages/cli/README.md
@@ -1,15 +1,12 @@
 # `@mcp-use/cli`
 
-Prebuilt CLI, development server, and build pipeline for
+Prebuilt CLI, development server, build pipeline, and MCP client for
 [mcp-use](https://github.com/mcp-use/mcp-use).
 
-Most people never install this package directly. `mcp-use` depends on it and
-exposes the same `mcp-use` executable, so a project that installs the framework
-already has it:
-
 ```bash
-npm install mcp-use
 npx mcp-use dev
+npx mcp-use client connect demo https://example.com/mcp
+npx mcp-use client demo tools list
 ```
 
 ## Commands


### PR DESCRIPTION
## Why

`@mcp-use/cli` is the only published package in the family without a README, and the registry reflects it:

```
$ curl -s https://registry.npmjs.org/@mcp-use%2Fcli | jq -r .readme
""
```

So the npm page for the package that provides the `mcp-use` executable renders nothing at all. Every sibling has one:

| package | README |
|---|---|
| mcp-use | 380 lines |
| @mcp-use/inspector | 433 |
| create-mcp-use-app | 518 |
| @mcp-use/agent | 145 |
| @mcp-use/client | 127 |
| @mcp-use/tunnel | 22 |
| **@mcp-use/cli** | **none** |

## What it says

Deliberately short, closer to the `@mcp-use/tunnel` README than the `mcp-use` one, because this package is rarely installed directly. `mcp-use` depends on it and exposes the same `bin`, which both `package.json` and the existing CLI reference page state, so the README leads with that rather than pretending it is a standalone install.

Contents: what the package is, how it actually reaches users, the command list taken from `mcp-use --help`, and links onward. Nothing invented, and no flag table duplicated here that would drift from the docs site.

## Checks

Both links resolve directly, no redirect:

```
200  hops=0  https://docs.mcp-use.com/v2/typescript/api-reference/cli-reference
200  hops=0  https://docs.mcp-use.com/v2/typescript/getting-started/quickstart
```

`README.md` is not in this package's `files` array, and it does not need to be, since npm always includes it. Confirmed rather than assumed:

```
$ npm pack --dry-run
npm notice Tarball Contents
npm notice 1.5kB README.md
npm notice 895B THIRD_PARTY_NOTICES.md
npm notice 642B dist/bin.js
```

No changeset: content only, no behaviour change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a README to `@mcp-use/cli` so its npm page no longer renders blank.

- `@mcp-use/cli` was the only published package in the family without a README.
- The README is short, leads with the built-in MCP client, and lists the commands from `mcp-use --help`.
- It links to the CLI reference and quickstart docs; content only, so no changeset was added.

<sup>Written for commit f1fa0469e7f8db6ef8eff24c2c729592ed73061f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

