### PR TITLE
fix(dev): consolidate server request logs

### DIFF
--- a/libraries/typescript/.changeset/single-line-dev-logs.md
+++ b/libraries/typescript/.changeset/single-line-dev-logs.md
@@ -1,0 +1,7 @@
+---
+"mcp-use": patch
+"@mcp-use/cli": patch
+"@mcp-use/inspector": patch
+---
+
+Consolidate MCP request logging into one record and label colocated dev server and Inspector logs.

--- a/libraries/typescript/packages/cli/src/cli/dev.ts
+++ b/libraries/typescript/packages/cli/src/cli/dev.ts
@@ -113,6 +113,7 @@ function sameDiscoveredViews(
 interface ServerLike {
   fetch(request: Request): Response | Promise<Response>;
   __setEventBus(bus: ServerEventBus): void;
+  __setRequestLogPrefix(prefix: string | undefined): void;
   __mount(): void;
   /** URL path prefix the MCP endpoint is mounted at (default `"/mcp"`). */
   readonly basePath?: string;
@@ -580,22 +581,6 @@ export async function runDev(options: DevOptions): Promise<void> {
     }
   };
 
-  let currentHandler: WebHandler;
-  let basePath: string;
-  let currentSkillsDirectory: string | undefined;
-  try {
-    const { server, skillsDirectory } = await importServer(currentViews);
-    server.__setEventBus(eventBus);
-    server.__mount();
-    currentHandler = async (request) => server.fetch(request);
-    basePath = server.basePath ?? "/mcp";
-    currentSkillsDirectory = skillsDirectory;
-  } catch (error) {
-    await runner.close();
-    await vite.close();
-    throw error;
-  }
-
   let inspectorModule: ProjectInspectorModule | undefined;
   let inspectorHandler: DevInspectorHandler | undefined;
   let inspectorMountPath: string | undefined;
@@ -610,6 +595,7 @@ export async function runDev(options: DevOptions): Promise<void> {
       oauthProxyAllowLoopback: localhostBind || wildcardBind,
       devMode: true,
       manufactChatUrl: process.env["MANUFACT_CHAT_URL"],
+      logPrefix: "[inspector]",
     });
     if (typeof mounted !== "function") {
       throw new Error(
@@ -621,7 +607,13 @@ export async function runDev(options: DevOptions): Promise<void> {
     inspectorMountPath = nextBasePath;
   };
 
+  let currentHandler: WebHandler;
+  let basePath: string;
+  let currentSkillsDirectory: string | undefined;
   try {
+    const { server, skillsDirectory } = await importServer(currentViews);
+    server.__setEventBus(eventBus);
+    basePath = server.basePath ?? "/mcp";
     if (options.inspector !== false) {
       const loadedInspector = await loadProjectInspector(options.cwd);
       if (loadedInspector.installed) {
@@ -629,6 +621,12 @@ export async function runDev(options: DevOptions): Promise<void> {
         mountDevInspector(basePath);
       }
     }
+    server.__setRequestLogPrefix(
+      inspectorHandler === undefined ? undefined : "[server]"
+    );
+    server.__mount();
+    currentHandler = async (request) => server.fetch(request);
+    currentSkillsDirectory = skillsDirectory;
   } catch (error) {
     await runner.close();
     await vite.close();
@@ -658,6 +656,9 @@ export async function runDev(options: DevOptions): Promise<void> {
           runner.evaluatedModules.clear();
           const { server, skillsDirectory } = await importServer(viewsSnapshot);
           server.__setEventBus(eventBus);
+          server.__setRequestLogPrefix(
+            inspectorHandler === undefined ? undefined : "[server]"
+          );
           server.__mount();
 
           if (isAborted()) return;

--- a/libraries/typescript/packages/cli/src/cli/inspector.ts
+++ b/libraries/typescript/packages/cli/src/cli/inspector.ts
@@ -25,6 +25,8 @@ export interface DevInspectorMountOptions {
   devMode: true;
   /** Hosted chat endpoint injected into the Inspector shell, from `MANUFACT_CHAT_URL`. */
   manufactChatUrl?: string | undefined;
+  /** Source label for Inspector logs when it shares the dev server stdout. */
+  logPrefix?: string | undefined;
 }
 
 /** Structurally typed Inspector package entry loaded from the user's project. */

--- a/libraries/typescript/packages/cli/tests/cli/dev.test.ts
+++ b/libraries/typescript/packages/cli/tests/cli/dev.test.ts
@@ -173,7 +173,7 @@ function installFakeInspector(cwd: string): void {
     const url = new URL(request.url);
     const prefix = options.basePath + "/inspector";
     if (url.pathname === prefix + "/config.json") {
-      return Response.json({ autoConnectUrl: options.autoConnectUrl });
+      return Response.json({ autoConnectUrl: options.autoConnectUrl, logPrefix: options.logPrefix });
     }
     if (url.pathname === prefix || url.pathname.startsWith(prefix + "/")) {
       return new Response("mounted:" + options.basePath, {
@@ -459,8 +459,12 @@ describe("runDev", () => {
     expect(await shell.text()).toBe("mounted:/mcp");
     expect(
       await (await fetch(`${origin}/mcp/inspector/config.json`)).json()
-    ).toEqual({ autoConnectUrl: `${origin}/mcp` });
+    ).toEqual({ autoConnectUrl: `${origin}/mcp`, logPrefix: "[inspector]" });
     expect(dev.logs.some((line) => line.includes("➜ Inspector:"))).toBe(true);
+    await mcpRequest(dev.url, "tools/list");
+    expect(dev.logs.some((line) => line.includes("[server] tools/list"))).toBe(
+      true
+    );
 
     const entry = join(cwd, "src", "index.ts");
     writeFileSync(
@@ -478,7 +482,10 @@ describe("runDev", () => {
     expect((await fetch(`${origin}/mcp/inspector`)).status).toBe(404);
     expect(
       await (await fetch(`${origin}/api/mcp/inspector/config.json`)).json()
-    ).toEqual({ autoConnectUrl: `${origin}/api/mcp` });
+    ).toEqual({
+      autoConnectUrl: `${origin}/api/mcp`,
+      logPrefix: "[inspector]",
+    });
   });
 
   it("serves the built-in Inspector without a project dependency", async () => {

--- a/libraries/typescript/packages/inspector/src/server/middleware.ts
+++ b/libraries/typescript/packages/inspector/src/server/middleware.ts
@@ -30,6 +30,8 @@ export interface MountInspectorOptions {
   oauthProxyAllowedOrigins?: readonly string[];
   /** Allow OAuth and MCP proxy requests to loopback targets (default `true`). */
   oauthProxyAllowLoopback?: boolean;
+  /** Optional source label for logs when Inspector shares a dev server process. */
+  logPrefix?: string;
   /**
    * Server-wide MCP path prefix (default `/mcp`; `""` = root). The Inspector
    * is served from `${basePath}/inspector` and its API from
@@ -130,6 +132,7 @@ function registerInspectorRoutes(
     // where loopback proxying is SSRF into the host's own services. Default to
     // blocking loopback; local dev tooling opts in explicitly.
     oauthProxyAllowLoopback: options?.oauthProxyAllowLoopback ?? false,
+    logPrefix: options?.logPrefix,
   };
   if (options?.autoConnectUrl !== undefined) {
     routesConfig.autoConnectUrl = options.autoConnectUrl;

--- a/libraries/typescript/packages/inspector/src/server/proxy-routes.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy-routes.ts
@@ -15,6 +15,8 @@ export type InspectorProxyRoutesConfig = {
   oauthProxyAllowLoopback?: boolean;
   /** Mount OAuth BFF routes (default true). */
   oauth?: boolean;
+  /** Optional source label for logs when Inspector shares a dev server process. */
+  logPrefix?: string;
 };
 
 /**
@@ -46,6 +48,7 @@ export function registerInspectorProxyRoutes(
     path: p("/inspector/api/proxy"),
     allowLoopback,
     rateLimiter: apiRateLimiter,
+    logPrefix: config?.logPrefix,
   });
 
   if (mountOAuth) {
@@ -53,6 +56,7 @@ export function registerInspectorProxyRoutes(
       basePath: p("/inspector/api/oauth"),
       callbackPath: p("/inspector/oauth/callback"),
       enableLogging: true,
+      logPrefix: config?.logPrefix,
       allowedOrigins: config?.oauthProxyAllowedOrigins ?? [],
       allowLoopback,
       rateLimiter: apiRateLimiter,

--- a/libraries/typescript/packages/inspector/src/server/proxy/mcp-proxy.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy/mcp-proxy.ts
@@ -73,6 +73,8 @@ interface McpProxyOptions {
   enableLogging?: boolean;
   /** Shared process-local limiter for Inspector proxy and OAuth routes. */
   rateLimiter?: RateLimiterMemory;
+  /** Optional source label for logs when Inspector shares a dev server process. */
+  logPrefix?: string;
 }
 
 /** Whether an MCP response must remain streaming instead of being buffered. */
@@ -129,6 +131,7 @@ export function isOpenEndedSseResponse(
 export function mountMcpProxy(app: Hono, options: McpProxyOptions = {}): void {
   const basePath = options.path || "/mcp/proxy";
   const enableLogging = options.enableLogging !== false;
+  const logPrefix = options.logPrefix;
   const rateLimiter =
     options.rateLimiter ??
     new RateLimiterMemory({
@@ -171,7 +174,12 @@ export function mountMcpProxy(app: Hono, options: McpProxyOptions = {}): void {
 
   // Apply logger middleware to proxy routes
   if (enableLogging) {
-    app.use(`${basePath}/*`, logger());
+    app.use(
+      `${basePath}/*`,
+      logPrefix === undefined
+        ? logger()
+        : logger((message, ...args) => console.log(logPrefix, message, ...args))
+    );
   }
 
   app.use(`${basePath}/*`, rateLimit);

--- a/libraries/typescript/packages/inspector/src/server/proxy/oauth-proxy.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy/oauth-proxy.ts
@@ -70,6 +70,8 @@ interface OAuthProxyOptions {
   callbackPath?: string;
   /** @default true */
   enableLogging?: boolean;
+  /** Optional source label for logs when Inspector shares a dev server process. */
+  logPrefix?: string;
   /** Optional authentication applied before any outbound request. */
   authenticate?: (c: Context) => Promise<boolean> | boolean;
   /** Optional deployment policy applied after built-in URL and network checks. */
@@ -120,6 +122,7 @@ export function mountOAuthProxy(
     maxResponseBodyBytes = 1024 * 1024,
     callbackPath = "/oauth/callback",
     enableLogging = true,
+    logPrefix,
     authenticate,
     validateServerUrl,
     rateLimiter: configuredRateLimiter = new RateLimiterMemory({
@@ -205,7 +208,7 @@ export function mountOAuthProxy(
     }
 
     try {
-      log(enableLogging, `GET ${target}`);
+      log(enableLogging, logPrefix, `GET ${target}`);
       const upstream = await safeFetch(target, {
         method: "GET",
         headers: { Accept: "application/json" },
@@ -252,7 +255,7 @@ export function mountOAuthProxy(
           upstream.headers.get("content-type") ?? "application/json",
       });
     } catch (error) {
-      return proxyError(c, error, enableLogging);
+      return proxyError(c, error, enableLogging, logPrefix);
     }
   });
 
@@ -313,7 +316,7 @@ export function mountOAuthProxy(
         bindings.set(bindingKey, binding);
         pruneBindings(bindings);
       } catch (error) {
-        return proxyError(c, error, enableLogging);
+        return proxyError(c, error, enableLogging, logPrefix);
       }
     }
     const endpointKind = binding.endpoints.get(canonicalUrl(target));
@@ -350,7 +353,7 @@ export function mountOAuthProxy(
         return c.json({ error: "OAuth request body too large" }, 413);
       }
 
-      log(enableLogging, `POST ${endpointKind} ${target}`);
+      log(enableLogging, logPrefix, `POST ${endpointKind} ${target}`);
       const upstream = await safeFetch(target, {
         method: "POST",
         headers,
@@ -396,11 +399,15 @@ export function mountOAuthProxy(
         body: responseBody,
       });
     } catch (error) {
-      return proxyError(c, error, enableLogging);
+      return proxyError(c, error, enableLogging, logPrefix);
     }
   });
 
-  log(enableLogging, `Mounted at ${basePath}/metadata and ${basePath}/proxy`);
+  log(
+    enableLogging,
+    logPrefix,
+    `Mounted at ${basePath}/metadata and ${basePath}/proxy`
+  );
 }
 
 async function validateUrl(
@@ -1129,13 +1136,33 @@ function isPublicAddress(address: string): boolean {
   );
 }
 
-function log(enabled: boolean, message: string): void {
-  if (enabled) console.log(`[OAuth BFF] ${message}`);
+function log(
+  enabled: boolean,
+  prefix: string | undefined,
+  message: string
+): void {
+  if (enabled) {
+    console.log(
+      prefix === undefined
+        ? `[OAuth BFF] ${message}`
+        : `${prefix} [OAuth BFF] ${message}`
+    );
+  }
 }
 
-function proxyError(c: Context, error: unknown, logging: boolean): Response {
+function proxyError(
+  c: Context,
+  error: unknown,
+  logging: boolean,
+  prefix: string | undefined
+): Response {
   const message = error instanceof Error ? error.message : "Unknown error";
-  if (logging) console.error("[OAuth BFF]", message);
+  if (logging) {
+    console.error(
+      prefix === undefined ? "[OAuth BFF]" : `${prefix} [OAuth BFF]`,
+      message
+    );
+  }
   if (error instanceof BodyTooLargeError) {
     return c.json({ error: "Upstream response too large" }, 502);
   }

--- a/libraries/typescript/packages/inspector/tests/unit/mcp-proxy-security.test.ts
+++ b/libraries/typescript/packages/inspector/tests/unit/mcp-proxy-security.test.ts
@@ -9,6 +9,43 @@ afterEach(() => {
 });
 
 describe("Inspector MCP proxy request isolation", () => {
+  it("prefixes proxy logs only when sharing the dev server process", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () => new Response("ok"))
+    );
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const request = () =>
+      new Request(proxyUrl, {
+        headers: { "X-Target-URL": "https://93.184.216.34/mcp" },
+      });
+
+    const embedded = new Hono();
+    mountMcpProxy(embedded, {
+      path: "/inspector/api/proxy",
+      logPrefix: "[inspector]",
+    });
+    await embedded.fetch(request());
+    expect(logSpy.mock.calls).not.toHaveLength(0);
+    expect(
+      logSpy.mock.calls.every(([line]) =>
+        String(line).startsWith("[inspector]")
+      )
+    ).toBe(true);
+
+    logSpy.mockClear();
+    const standalone = new Hono();
+    mountMcpProxy(standalone, { path: "/inspector/api/proxy" });
+    await standalone.fetch(request());
+    expect(logSpy.mock.calls).not.toHaveLength(0);
+    expect(
+      logSpy.mock.calls.every(
+        ([line]) => !String(line).startsWith("[inspector]")
+      )
+    ).toBe(true);
+    logSpy.mockRestore();
+  });
+
   it("does not forward Inspector cookies or browser-origin headers", async () => {
     const fetchFn = vi.fn<typeof fetch>(async (_input, init) => {
       const headers = new Headers(init?.headers);

--- a/libraries/typescript/packages/server/src/index.ts
+++ b/libraries/typescript/packages/server/src/index.ts
@@ -22,7 +22,11 @@ export {
 export type { FetchHandler, FetchMiddleware, RequestBag } from "./fetch-app.js";
 export { registerViews } from "./views/index.js";
 export { requestLogger } from "./logging.js";
-export type { LoggingOptions, LogLevel } from "./logging.js";
+export type {
+  LoggingOptions,
+  LogLevel,
+  RequestLoggerOptions,
+} from "./logging.js";
 export type {
   LandingPageOptions,
   LandingPagePrompt,

--- a/libraries/typescript/packages/server/src/logging.ts
+++ b/libraries/typescript/packages/server/src/logging.ts
@@ -265,6 +265,60 @@ function methodStyle(method: string): Style {
   return blue;
 }
 
+interface RequestDescription {
+  /** HTTP method, MCP method, or a compact batch method list. */
+  method: string;
+  /** Client identity from MCP metadata, or `unknown`. */
+  client: string;
+  /** First MCP request, used for subject and debug details. */
+  mcpRequest: JSONRPCRequest | undefined;
+  /** Whether reading the response would consume an open-ended stream. */
+  streaming: boolean;
+}
+
+/** Classify one request before the handler runs. */
+function describeRequest(
+  httpMethod: string,
+  pathname: string,
+  mcpPath: string | undefined,
+  body: unknown
+): RequestDescription {
+  if (pathname !== mcpPath) {
+    return {
+      method: httpMethod,
+      client: "unknown",
+      mcpRequest: undefined,
+      streaming: false,
+    };
+  }
+
+  const requests = Array.isArray(body)
+    ? body.filter(isJSONRPCRequest)
+    : isJSONRPCRequest(body)
+      ? [body]
+      : [];
+  const mcpRequest = requests[0];
+  if (mcpRequest === undefined) {
+    return {
+      method: httpMethod,
+      client: "unknown",
+      mcpRequest: undefined,
+      streaming: false,
+    };
+  }
+
+  const method =
+    requests.length === 1
+      ? sanitize(mcpRequest.method)
+      : `batch(${requests.map((request) => sanitize(request.method)).join(",")})`;
+  return {
+    method,
+    client: formatMcpClient(mcpRequest) ?? "unknown",
+    mcpRequest,
+    streaming: mcpRequest.method === "subscriptions/listen",
+  };
+}
+
 /* ------------------------------------------------------------------------ *
  * Response outcome
  * ------------------------------------------------------------------------ */
@@ -493,6 +547,33 @@ function isNoisyRequest(httpMethod: string, pathname: string): boolean {
   return pathname.endsWith("/favicon.ico");
 }
 
+interface RequestLogLine {
+  timestamp: string;
+  prefix: string | undefined;
+  description: RequestDescription;
+  detail: McpDetail | undefined;
+  pathname: string;
+  status: number;
+  durationMs: number;
+  suffix: string[];
+}
+
+/** Render the stable single-line field order in one place. */
+function formatRequestLogLine(line: RequestLogLine): string {
+  const { description, detail } = line;
+  return [
+    dim(line.timestamp),
+    ...(line.prefix === undefined ? [] : [bold(line.prefix)]),
+    methodStyle(description.method)(description.method),
+    ...(detail?.subject === undefined ? [] : [bold(sanitize(detail.subject))]),
+    line.pathname,
+    styleStatus(line.status),
+    dim(`client=${sanitize(description.client)}`),
+    dim(`${line.durationMs}ms`),
+    ...line.suffix,
+  ].join(" ");
+}
+
 /**
  * Fetch middleware logging every request in the compact single-line format (see
  * the module docs). `MCPServer` registers it automatically unless
@@ -535,102 +616,79 @@ export function requestLogger(
       }
     }
 
-    const mcpRequests =
-      pathname === options.mcpPath
-        ? Array.isArray(requestBody)
-          ? requestBody.filter(isJSONRPCRequest)
-          : isJSONRPCRequest(requestBody)
-            ? [requestBody]
-            : []
-        : [];
-    const firstMcpRequest = mcpRequests[0];
-    const method =
-      mcpRequests.length === 0
-        ? httpMethod
-        : mcpRequests.length === 1
-          ? sanitize(firstMcpRequest!.method)
-          : `batch(${mcpRequests.map((message) => sanitize(message.method)).join(",")})`;
-    const client = firstMcpRequest
-      ? (formatMcpClient(firstMcpRequest) ?? "unknown")
-      : "unknown";
-    const isStreamingMethod =
-      firstMcpRequest?.method === "subscriptions/listen";
+    const description = describeRequest(
+      httpMethod,
+      pathname,
+      options.mcpPath,
+      requestBody
+    );
+    const logLine = (
+      status: number,
+      detail: McpDetail | undefined,
+      suffix: string[] = []
+    ): void => {
+      console.log(
+        formatRequestLogLine({
+          timestamp: new Date().toISOString().substring(11, 19),
+          prefix: options.prefix,
+          description,
+          detail,
+          pathname,
+          status,
+          durationMs: Date.now() - startedAt,
+          suffix,
+        })
+      );
+    };
 
     let response: Response;
     try {
       response = await next();
     } catch (error) {
-      const durationMs = Date.now() - startedAt;
-      const timestamp = new Date().toISOString().substring(11, 19);
-      console.log(
-        [
-          dim(timestamp),
-          ...(options.prefix === undefined ? [] : [bold(options.prefix)]),
-          methodStyle(method)(method),
-          pathname,
-          styleStatus(500),
-          dim(`client=${sanitize(client)}`),
-          dim(`${durationMs}ms`),
-          red(
-            `ERROR ${sanitize(error instanceof Error ? error.message : String(error))}`
-          ),
-        ].join(" ")
-      );
+      logLine(500, undefined, [
+        red(
+          `ERROR ${sanitize(error instanceof Error ? error.message : String(error))}`
+        ),
+      ]);
       throw error;
     }
 
-    const durationMs = Date.now() - startedAt;
-    const timestamp = new Date().toISOString().substring(11, 19);
-    const parts: string[] = [
-      dim(timestamp),
-      ...(options.prefix === undefined ? [] : [bold(options.prefix)]),
-      methodStyle(method)(method),
-    ];
-
-    if (firstMcpRequest !== undefined) {
-      const detail = formatDetail(firstMcpRequest);
-      if (detail.subject !== undefined)
-        parts.push(bold(sanitize(detail.subject)));
-    }
-    parts.push(
-      pathname,
-      styleStatus(response.status),
-      dim(`client=${sanitize(client)}`),
-      dim(`${durationMs}ms`)
-    );
-
-    if (firstMcpRequest !== undefined) {
-      const detail = formatDetail(firstMcpRequest);
+    const detail =
+      description.mcpRequest === undefined
+        ? undefined
+        : formatDetail(description.mcpRequest);
+    const suffix: string[] = [];
+    if (description.mcpRequest !== undefined && detail !== undefined) {
       const echoPayloads = level !== "info";
       if (echoPayloads && detail.input !== undefined) {
-        parts.push(inlineJson(detail.input));
+        suffix.push(inlineJson(detail.input));
       }
-      const outcome: ResponseOutcome = isStreamingMethod
+      const outcome: ResponseOutcome = description.streaming
         ? { errorMessage: null }
         : await extractResponseOutcome(response);
       if (
         echoPayloads &&
-        firstMcpRequest.method === "tools/call" &&
+        description.mcpRequest.method === "tools/call" &&
         outcome.errorMessage === null &&
         outcome.result !== undefined
       ) {
-        parts.push(dim("->"), inlineJson(compactToolResult(outcome.result)));
+        suffix.push(dim("->"), inlineJson(compactToolResult(outcome.result)));
       }
       if (outcome.errorMessage !== null) {
-        parts.push(red(`ERROR ${sanitize(outcome.errorMessage)}`));
+        suffix.push(red(`ERROR ${sanitize(outcome.errorMessage)}`));
       } else if (response.status >= 400) {
-        parts.push(red(`ERROR (HTTP ${response.status})`));
+        suffix.push(red(`ERROR (HTTP ${response.status})`));
       }
     }
 
-    console.log(parts.join(" "));
+    logLine(response.status, detail, suffix);
 
     if (level === "trace") {
       await printTraceDump(
         response,
         requestHeaders,
         requestBody,
-        !isStreamingMethod
+        !description.streaming
       );
     }
 

--- a/libraries/typescript/packages/server/src/logging.ts
+++ b/libraries/typescript/packages/server/src/logging.ts
@@ -1,18 +1,12 @@
 /**
  * Compact HTTP/MCP request logging.
  *
- * One summary line per HTTP request, plus an indented detail line for MCP
- * (JSON-RPC) requests naming the protocol method, its subject (tool name,
- * resource URI, prompt name), and the calling client:
+ * One summary line per HTTP request. MCP (JSON-RPC) requests use their
+ * protocol method instead of the transport method:
  *
  * ```text
- * 12:45:01 POST /mcp 200 in 12ms
- *   tools/call greet raw-request/0.0.0
+ * 12:45:01 tools/call greet /mcp 200 client=raw-request/0.0.0 12ms
  * ```
- *
- * Detail lines are plain two-space-indented ASCII (no box-drawing glyphs) so
- * log parsers and agents can tell the two apart mechanically: summary lines
- * start with a timestamp, detail lines start with whitespace.
  *
  * Three verbosity levels, resolved per request from the `MCP_USE_LOG_LEVEL`
  * environment variable (overriding any configured level):
@@ -115,6 +109,14 @@ interface McpDetail {
   subject?: string | undefined;
   /** Caller-provided input worth echoing inline (tool/prompt arguments). */
   input?: unknown;
+}
+
+/** Internal transport context supplied by {@link MCPServer}. */
+interface RequestLoggerContext {
+  /** MCP endpoint path. Only requests here may be labelled with an RPC method. */
+  mcpPath?: string;
+  /** Optional source label used when colocated dev services share stdout. */
+  prefix?: string | undefined;
 }
 
 /**
@@ -228,6 +230,20 @@ function formatClientIdentity(message: JSONRPCRequest): string | undefined {
     return undefined;
   }
   return formatClientInfo(info as Implementation);
+}
+
+/** Resolve a client identity, including the legacy initialize handshake. */
+function formatMcpClient(message: JSONRPCRequest): string | undefined {
+  const modern = formatClientIdentity(message);
+  if (modern !== undefined) return modern;
+  if (message.method !== "initialize") return undefined;
+  try {
+    return formatClientInfo(
+      (message.params as { clientInfo?: Implementation }).clientInfo
+    );
+  } catch {
+    return undefined;
+  }
 }
 
 /**
@@ -478,11 +494,13 @@ function isNoisyRequest(httpMethod: string, pathname: string): boolean {
 }
 
 /**
- * Fetch middleware logging every request in the compact two-line format (see
+ * Fetch middleware logging every request in the compact single-line format (see
  * the module docs). `MCPServer` registers it automatically unless
  * `config.logging.enabled` is `false`.
  */
-export function requestLogger(options: LoggingOptions = {}): FetchMiddleware {
+export function requestLogger(
+  options: LoggingOptions & RequestLoggerContext = {}
+): FetchMiddleware {
   if (options.enabled === false) {
     return (_request, next) => next();
   }
@@ -517,30 +535,72 @@ export function requestLogger(options: LoggingOptions = {}): FetchMiddleware {
       }
     }
 
-    const response = await next();
+    const mcpRequests =
+      pathname === options.mcpPath
+        ? Array.isArray(requestBody)
+          ? requestBody.filter(isJSONRPCRequest)
+          : isJSONRPCRequest(requestBody)
+            ? [requestBody]
+            : []
+        : [];
+    const firstMcpRequest = mcpRequests[0];
+    const method =
+      mcpRequests.length === 0
+        ? httpMethod
+        : mcpRequests.length === 1
+          ? sanitize(firstMcpRequest!.method)
+          : `batch(${mcpRequests.map((message) => sanitize(message.method)).join(",")})`;
+    const client = firstMcpRequest
+      ? (formatMcpClient(firstMcpRequest) ?? "unknown")
+      : "unknown";
+    const isStreamingMethod =
+      firstMcpRequest?.method === "subscriptions/listen";
+
+    let response: Response;
+    try {
+      response = await next();
+    } catch (error) {
+      const durationMs = Date.now() - startedAt;
+      const timestamp = new Date().toISOString().substring(11, 19);
+      console.log(
+        [
+          dim(timestamp),
+          ...(options.prefix === undefined ? [] : [bold(options.prefix)]),
+          methodStyle(method)(method),
+          pathname,
+          styleStatus(500),
+          dim(`client=${sanitize(client)}`),
+          dim(`${durationMs}ms`),
+          red(
+            `ERROR ${sanitize(error instanceof Error ? error.message : String(error))}`
+          ),
+        ].join(" ")
+      );
+      throw error;
+    }
 
     const durationMs = Date.now() - startedAt;
     const timestamp = new Date().toISOString().substring(11, 19);
-    const mcpRequest = isJSONRPCRequest(requestBody) ? requestBody : undefined;
-    const isStreamingMethod = mcpRequest?.method === "subscriptions/listen";
-
-    const lines: string[] = [
-      [
-        dim(timestamp),
-        bold(httpMethod),
-        pathname,
-        styleStatus(response.status),
-        dim(`in ${durationMs}ms`),
-      ].join(" "),
+    const parts: string[] = [
+      dim(timestamp),
+      ...(options.prefix === undefined ? [] : [bold(options.prefix)]),
+      methodStyle(method)(method),
     ];
 
-    if (mcpRequest !== undefined) {
-      const method = sanitize(mcpRequest.method);
-      const parts: string[] = [`  ${methodStyle(method)(method)}`];
-      const detail = formatDetail(mcpRequest);
-      if (detail.subject !== undefined) {
+    if (firstMcpRequest !== undefined) {
+      const detail = formatDetail(firstMcpRequest);
+      if (detail.subject !== undefined)
         parts.push(bold(sanitize(detail.subject)));
-      }
+    }
+    parts.push(
+      pathname,
+      styleStatus(response.status),
+      dim(`client=${sanitize(client)}`),
+      dim(`${durationMs}ms`)
+    );
+
+    if (firstMcpRequest !== undefined) {
+      const detail = formatDetail(firstMcpRequest);
       const echoPayloads = level !== "info";
       if (echoPayloads && detail.input !== undefined) {
         parts.push(inlineJson(detail.input));
@@ -550,25 +610,20 @@ export function requestLogger(options: LoggingOptions = {}): FetchMiddleware {
         : await extractResponseOutcome(response);
       if (
         echoPayloads &&
-        mcpRequest.method === "tools/call" &&
+        firstMcpRequest.method === "tools/call" &&
         outcome.errorMessage === null &&
         outcome.result !== undefined
       ) {
         parts.push(dim("->"), inlineJson(compactToolResult(outcome.result)));
-      }
-      if (mcpRequest.method !== "initialize") {
-        const client = formatClientIdentity(mcpRequest);
-        if (client !== undefined) parts.push(dim(sanitize(client)));
       }
       if (outcome.errorMessage !== null) {
         parts.push(red(`ERROR ${sanitize(outcome.errorMessage)}`));
       } else if (response.status >= 400) {
         parts.push(red(`ERROR (HTTP ${response.status})`));
       }
-      lines.push(parts.join(" "));
     }
 
-    console.log(lines.join("\n"));
+    console.log(parts.join(" "));
 
     if (level === "trace") {
       await printTraceDump(

--- a/libraries/typescript/packages/server/src/logging.ts
+++ b/libraries/typescript/packages/server/src/logging.ts
@@ -28,6 +28,10 @@ import {
   type RequestTypeMap,
 } from "@modelcontextprotocol/server";
 
+import {
+  isBufferedResponse,
+  trackBufferedResponse,
+} from "./buffered-response.js";
 import { getRequestBag, type FetchMiddleware } from "./fetch-app.js";
 
 /** Verbosity of the request logger. */
@@ -111,11 +115,14 @@ interface McpDetail {
   input?: unknown;
 }
 
-/** Internal transport context supplied by {@link MCPServer}. */
-interface RequestLoggerContext {
-  /** MCP endpoint path. Only requests here may be labelled with an RPC method. */
+/** Options for the standalone {@link requestLogger} middleware. */
+export interface RequestLoggerOptions extends LoggingOptions {
+  /**
+   * MCP endpoint path. Only requests to this exact path are labelled with
+   * their JSON-RPC method instead of their HTTP method.
+   */
   mcpPath?: string;
-  /** Optional source label used when colocated dev services share stdout. */
+  /** Source label used when colocated development services share stdout. */
   prefix?: string | undefined;
 }
 
@@ -131,7 +138,7 @@ type DetailFormatter<M extends RequestMethod> = (
 function formatClientInfo(
   info: Implementation | undefined
 ): string | undefined {
-  if (info === undefined) return undefined;
+  if (info === undefined || typeof info.name !== "string") return undefined;
   return typeof info.version === "string" && info.version !== ""
     ? `${info.name}/${info.version}`
     : info.name;
@@ -359,12 +366,20 @@ interface ResponseOutcome {
  * successful `result` payload. Handles both `application/json` and
  * `text/event-stream` bodies.
  */
-async function extractResponseOutcome(res: Response): Promise<ResponseOutcome> {
+async function extractResponseOutcome(
+  res: Response,
+  request: Request
+): Promise<ResponseOutcome> {
   if (!res.body) return { errorMessage: null };
 
   let text: string;
   try {
-    text = await res.clone().text();
+    const wasBuffered = isBufferedResponse(res, request);
+    const clone = res.clone();
+    // Cloning tees the body and changes its identity. Re-associate a
+    // framework-buffered response so downstream adapters can still trust it.
+    if (wasBuffered) trackBufferedResponse(request, res);
+    text = await clone.text();
   } catch {
     return { errorMessage: null };
   }
@@ -580,7 +595,7 @@ function formatRequestLogLine(line: RequestLogLine): string {
  * `config.logging.enabled` is `false`.
  */
 export function requestLogger(
-  options: LoggingOptions & RequestLoggerContext = {}
+  options: RequestLoggerOptions = {}
 ): FetchMiddleware {
   if (options.enabled === false) {
     return (_request, next) => next();
@@ -610,6 +625,13 @@ export function requestLogger(
       } else {
         try {
           requestBody = await request.clone().json();
+          if (
+            (request.headers.get("content-type") ?? "").includes(
+              "application/json"
+            )
+          ) {
+            getRequestBag(request).parsedBody = requestBody;
+          }
         } catch {
           // Non-JSON body — the summary line logs without MCP detail.
         }
@@ -664,7 +686,7 @@ export function requestLogger(
       }
       const outcome: ResponseOutcome = description.streaming
         ? { errorMessage: null }
-        : await extractResponseOutcome(response);
+        : await extractResponseOutcome(response, request);
       if (
         echoPayloads &&
         description.mcpRequest.method === "tools/call" &&

--- a/libraries/typescript/packages/server/src/logging.ts
+++ b/libraries/typescript/packages/server/src/logging.ts
@@ -268,8 +268,8 @@ function methodStyle(method: string): Style {
 interface RequestDescription {
   /** HTTP method, MCP method, or a compact batch method list. */
   method: string;
-  /** Client identity from MCP metadata, or `unknown`. */
-  client: string;
+  /** Client identity for MCP traffic; omitted for HTTP-formatted requests. */
+  client: string | undefined;
   /** First MCP request, used for subject and debug details. */
   mcpRequest: JSONRPCRequest | undefined;
   /** Whether reading the response would consume an open-ended stream. */
@@ -286,7 +286,7 @@ function describeRequest(
   if (pathname !== mcpPath) {
     return {
       method: httpMethod,
-      client: "unknown",
+      client: undefined,
       mcpRequest: undefined,
       streaming: false,
     };
@@ -301,7 +301,7 @@ function describeRequest(
   if (mcpRequest === undefined) {
     return {
       method: httpMethod,
-      client: "unknown",
+      client: undefined,
       mcpRequest: undefined,
       streaming: false,
     };
@@ -568,7 +568,9 @@ function formatRequestLogLine(line: RequestLogLine): string {
     ...(detail?.subject === undefined ? [] : [bold(sanitize(detail.subject))]),
     line.pathname,
     styleStatus(line.status),
-    dim(`client=${sanitize(description.client)}`),
+    ...(description.client === undefined
+      ? []
+      : [dim(`client=${sanitize(description.client)}`)]),
     dim(`${line.durationMs}ms`),
     ...line.suffix,
   ].join(" ");

--- a/libraries/typescript/packages/server/src/logging.ts
+++ b/libraries/typescript/packages/server/src/logging.ts
@@ -5,7 +5,7 @@
  * protocol method instead of the transport method:
  *
  * ```text
- * 12:45:01 tools/call greet /mcp 200 client=raw-request/0.0.0 12ms
+ * tools/call greet /mcp 200 client=raw-request/0.0.0 12ms
  * ```
  *
  * Three verbosity levels, resolved per request from the `MCP_USE_LOG_LEVEL`
@@ -548,7 +548,6 @@ function isNoisyRequest(httpMethod: string, pathname: string): boolean {
 }
 
 interface RequestLogLine {
-  timestamp: string;
   prefix: string | undefined;
   description: RequestDescription;
   detail: McpDetail | undefined;
@@ -562,7 +561,6 @@ interface RequestLogLine {
 function formatRequestLogLine(line: RequestLogLine): string {
   const { description, detail } = line;
   return [
-    dim(line.timestamp),
     ...(line.prefix === undefined ? [] : [bold(line.prefix)]),
     methodStyle(description.method)(description.method),
     ...(detail?.subject === undefined ? [] : [bold(sanitize(detail.subject))]),
@@ -631,7 +629,6 @@ export function requestLogger(
     ): void => {
       console.log(
         formatRequestLogLine({
-          timestamp: new Date().toISOString().substring(11, 19),
           prefix: options.prefix,
           description,
           detail,

--- a/libraries/typescript/packages/server/src/server.ts
+++ b/libraries/typescript/packages/server/src/server.ts
@@ -323,6 +323,8 @@ function registerFetchMiddleware<TEnv extends Env>(
  */
 export class MCPServer<TUser = never, TEnv extends Env = Env> {
   readonly #config: ServerConfig<TUser>;
+  /** Dev-only source label injected before mounting colocated Inspector routes. */
+  #requestLogPrefix: string | undefined;
   readonly #branding: ReturnType<typeof normalizeServerBranding>;
   readonly #tools = new Map<string, ToolEntry<TUser, TEnv>>();
   readonly #resources = new Map<string, ResourceEntry<TUser, TEnv>>();
@@ -901,6 +903,12 @@ export class MCPServer<TUser = never, TEnv extends Env = Env> {
     this.#eventBus = bus;
   }
 
+  /** Set a development-only label for request logs before the app is mounted. @internal */
+  __setRequestLogPrefix(prefix: string | undefined): void {
+    this.#assertNotStarted("request log prefix", "development");
+    this.#requestLogPrefix = prefix;
+  }
+
   /** Mount and validate the Hono/MCP application without serving a request. @internal */
   __mount(): void {
     if (!this.#skillsPrimed) {
@@ -1348,8 +1356,12 @@ export class MCPServer<TUser = never, TEnv extends Env = Env> {
       const nestedBasePath = basePath === "/" ? "" : basePath;
       const httpApp = new Hono<TEnv>();
       const middlewares = [
+        requestLogger({
+          ...this.#config.logging,
+          mcpPath: basePath,
+          prefix: this.#requestLogPrefix,
+        }),
         jsonBodyMiddleware(),
-        requestLogger(this.#config.logging),
       ];
 
       const corsConfig = this.#config.cors;

--- a/libraries/typescript/packages/server/tests/budgets/cli-budget.test.ts
+++ b/libraries/typescript/packages/server/tests/budgets/cli-budget.test.ts
@@ -107,12 +107,12 @@ describe("published CLI boundaries", () => {
     }
   });
 
-  it("keeps the edge entry under eighty KiB and its static graph under one hundred twenty-four KiB", async () => {
+  it("keeps the edge entry under one hundred thousand bytes and its static graph under one hundred twenty-four KiB", async () => {
     const entry = new URL("index.js", DIST);
     const graph = await buildStaticGraph(entry);
     const graphBytes = await sumFileBytes(graph.files.keys());
 
-    expect((await stat(entry)).size).toBeLessThanOrEqual(80 * 1024);
+    expect((await stat(entry)).size).toBeLessThanOrEqual(100_000);
     expect(graphBytes).toBeLessThanOrEqual(124 * 1024);
   });
 

--- a/libraries/typescript/packages/server/tests/logging.test.ts
+++ b/libraries/typescript/packages/server/tests/logging.test.ts
@@ -260,9 +260,7 @@ describe("requestLogger (via MCPServer.fetch)", () => {
     );
     const lines = loggedLines();
     expect(lines).toHaveLength(1);
-    expect(lines[0]).toMatch(
-      /^\d{2}:\d{2}:\d{2} GET \/health 404 client=unknown \d+ms$/
-    );
+    expect(lines[0]).toMatch(/^\d{2}:\d{2}:\d{2} GET \/health 404 \d+ms$/);
     await server.close();
   });
 
@@ -283,10 +281,10 @@ describe("requestLogger (via MCPServer.fetch)", () => {
       })
     );
     expect(loggedLines()[0]).toMatch(
-      /^\d{2}:\d{2}:\d{2} PATCH \/health 404 client=unknown \d+ms$/
+      /^\d{2}:\d{2}:\d{2} PATCH \/health 404 \d+ms$/
     );
     expect(loggedLines()[1]).toMatch(
-      /^\d{2}:\d{2}:\d{2} POST \/mcp 400 client=unknown \d+ms$/
+      /^\d{2}:\d{2}:\d{2} POST \/mcp 400 \d+ms$/
     );
     await server.close();
   });
@@ -348,7 +346,7 @@ describe("requestLogger (via MCPServer.fetch)", () => {
       )
     ).rejects.toThrow("socket closed");
     expect(loggedLines()[0]).toMatch(
-      /DELETE \/mcp 500 client=unknown \d+ms ERROR socket closed/
+      /DELETE \/mcp 500 \d+ms ERROR socket closed/
     );
   });
 
@@ -363,7 +361,7 @@ describe("requestLogger (via MCPServer.fetch)", () => {
     );
     expect(loggedLines()).toHaveLength(1);
     expect(loggedLines()[0]).toMatch(
-      /^\d{2}:\d{2}:\d{2} GET \/mcp\/inspector 404 client=unknown \d+ms$/
+      /^\d{2}:\d{2}:\d{2} GET \/mcp\/inspector 404 \d+ms$/
     );
     await server.close();
   });

--- a/libraries/typescript/packages/server/tests/logging.test.ts
+++ b/libraries/typescript/packages/server/tests/logging.test.ts
@@ -1,13 +1,12 @@
 /**
- * Request-logging tests: the compact two-line format (HTTP summary line plus
- * indented MCP detail line), error surfacing, level handling, and noise
+ * Request-logging tests: the compact single-line format, error surfacing, level handling, and noise
  * skipping — driven through `MCPServer.fetch` with synthetic
  * 2026-07-28 requests, capturing `console.log`.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 
-import { MCPServer } from "../src/index.js";
+import { MCPServer, requestLogger } from "../src/index.js";
 import type { ServerConfig } from "../src/index.js";
 
 /** The per-request `_meta` envelope every 2026-07-28 request carries. */
@@ -100,7 +99,7 @@ describe("requestLogger (via MCPServer.fetch)", () => {
       .flatMap((entry) => entry.split("\n"));
   }
 
-  it("logs a two-line summary + detail for tools/call", async () => {
+  it("logs one complete MCP record for tools/call", async () => {
     const server = buildServer();
     const response = await server.fetch(
       mcpRequest(
@@ -112,10 +111,10 @@ describe("requestLogger (via MCPServer.fetch)", () => {
     expect(response.status).toBe(200);
 
     const lines = loggedLines();
-    expect(lines).toHaveLength(2);
-    expect(lines[0]).toMatch(/^\d{2}:\d{2}:\d{2} POST \/mcp 200 in \d+ms$/);
-    // info level: no request/response payloads on the detail line.
-    expect(lines[1]).toBe("  tools/call greet raw-request/0.0.0");
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatch(
+      /^\d{2}:\d{2}:\d{2} tools\/call greet \/mcp 200 client=raw-request\/0\.0\.0 \d+ms$/
+    );
     await server.close();
   });
 
@@ -130,10 +129,11 @@ describe("requestLogger (via MCPServer.fetch)", () => {
     );
     const lines = loggedLines();
     // debug adds inline payloads but no trace dump.
-    expect(lines).toHaveLength(2);
-    expect(lines[1]).toBe(
-      '  tools/call greet {"who":"world"} -> "hi world" raw-request/0.0.0'
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain(
+      "tools/call greet /mcp 200 client=raw-request/0.0.0"
     );
+    expect(lines[0]).toContain('{"who":"world"} -> "hi world"');
     await server.close();
   });
 
@@ -146,11 +146,12 @@ describe("requestLogger (via MCPServer.fetch)", () => {
         { "mcp-name": "greet" }
       )
     );
-    const detail = loggedLines()[1] ?? "";
+    const detail = loggedLines()[0] ?? "";
     expect(detail).toContain('{"who":"xxx');
     expect(detail).toContain("...");
     // 80-char cap plus the ellipsis.
-    const inputSegment = detail.split(" ")[4] ?? "";
+    const inputSegment =
+      detail.split(" ").find((part) => part.startsWith('{"who"')) ?? "";
     expect(inputSegment.length).toBeLessThanOrEqual(83);
     await server.close();
   });
@@ -164,8 +165,8 @@ describe("requestLogger (via MCPServer.fetch)", () => {
         { "mcp-name": "config://settings" }
       )
     );
-    expect(loggedLines()[1]).toBe(
-      "  resources/read config://settings raw-request/0.0.0"
+    expect(loggedLines()[0]).toMatch(
+      /resources\/read config:\/\/settings \/mcp 200 client=raw-request\/0\.0\.0 \d+ms/
     );
     await server.close();
   });
@@ -179,14 +180,18 @@ describe("requestLogger (via MCPServer.fetch)", () => {
         { "mcp-name": "standup" }
       )
     );
-    expect(loggedLines()[1]).toBe("  prompts/get standup raw-request/0.0.0");
+    expect(loggedLines()[0]).toMatch(
+      /prompts\/get standup \/mcp 200 client=raw-request\/0\.0\.0 \d+ms/
+    );
     await server.close();
   });
 
   it("logs methods without a subject as the bare method name", async () => {
     const server = buildServer();
     await server.fetch(mcpRequest("tools/list", {}));
-    expect(loggedLines()[1]).toBe("  tools/list raw-request/0.0.0");
+    expect(loggedLines()[0]).toMatch(
+      /tools\/list \/mcp 200 client=raw-request\/0\.0\.0 \d+ms/
+    );
     await server.close();
   });
 
@@ -212,7 +217,9 @@ describe("requestLogger (via MCPServer.fetch)", () => {
         }),
       })
     );
-    expect(loggedLines()[1]).toBe("  initialize legacy-client/2.1.0");
+    expect(loggedLines()[0]).toMatch(
+      /initialize legacy-client\/2\.1\.0 \/mcp 200 client=legacy-client\/2\.1\.0 \d+ms/
+    );
     await server.close();
   });
 
@@ -225,8 +232,8 @@ describe("requestLogger (via MCPServer.fetch)", () => {
         { "mcp-name": "fail" }
       )
     );
-    expect(loggedLines()[1]).toBe(
-      "  tools/call fail raw-request/0.0.0 ERROR failed: on purpose"
+    expect(loggedLines()[0]).toMatch(
+      /tools\/call fail \/mcp 200 client=raw-request\/0\.0\.0 \d+ms ERROR failed: on purpose/
     );
     await server.close();
   });
@@ -240,8 +247,8 @@ describe("requestLogger (via MCPServer.fetch)", () => {
         { "mcp-name": "no-such-tool" }
       )
     );
-    const detail = loggedLines()[1];
-    expect(detail).toContain("  tools/call no-such-tool");
+    const detail = loggedLines()[0];
+    expect(detail).toContain("tools/call no-such-tool /mcp");
     expect(detail).toMatch(/ERROR .*no-such-tool/);
     await server.close();
   });
@@ -253,8 +260,96 @@ describe("requestLogger (via MCPServer.fetch)", () => {
     );
     const lines = loggedLines();
     expect(lines).toHaveLength(1);
-    expect(lines[0]).toMatch(/^\d{2}:\d{2}:\d{2} GET \/health 404 in \d+ms$/);
+    expect(lines[0]).toMatch(
+      /^\d{2}:\d{2}:\d{2} GET \/health 404 client=unknown \d+ms$/
+    );
     await server.close();
+  });
+
+  it("uses the HTTP method for malformed and non-MCP endpoint bodies", async () => {
+    const server = buildServer();
+    await server.fetch(
+      new Request("http://localhost/health", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", method: "tools/list" }),
+      })
+    );
+    await server.fetch(
+      new Request("http://localhost/mcp", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{not json",
+      })
+    );
+    expect(loggedLines()[0]).toMatch(
+      /^\d{2}:\d{2}:\d{2} PATCH \/health 404 client=unknown \d+ms$/
+    );
+    expect(loggedLines()[1]).toMatch(
+      /^\d{2}:\d{2}:\d{2} POST \/mcp 400 client=unknown \d+ms$/
+    );
+    await server.close();
+  });
+
+  it("labels JSON-RPC batches and missing client metadata without throwing", async () => {
+    const server = buildServer();
+    await server.fetch(
+      new Request("http://localhost/mcp", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify([
+          { jsonrpc: "2.0", id: 1, method: "tools/list", params: {} },
+          { jsonrpc: "2.0", id: 2, method: "prompts/list", params: {} },
+        ]),
+      })
+    );
+    expect(loggedLines()[0]).toMatch(
+      /batch\(tools\/list,prompts\/list\) \/mcp \d+ client=unknown \d+ms/
+    );
+    await server.close();
+  });
+
+  it("adds an explicit source prefix only when one is configured", async () => {
+    const body = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/list",
+      params: {},
+    });
+    await requestLogger({ mcpPath: "/mcp", prefix: "[server]" })(
+      new Request("http://localhost/mcp", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body,
+      }),
+      async () => new Response(null, { status: 204 })
+    );
+    await requestLogger({ mcpPath: "/mcp" })(
+      new Request("http://localhost/mcp", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body,
+      }),
+      async () => new Response(null, { status: 204 })
+    );
+    expect(loggedLines()[0]).toContain(
+      "[server] tools/list /mcp 204 client=unknown"
+    );
+    expect(loggedLines()[1]).not.toContain("[server]");
+  });
+
+  it("logs a 500 single-line record before rethrowing a handler failure", async () => {
+    await expect(
+      requestLogger({ mcpPath: "/mcp" })(
+        new Request("http://localhost/mcp", { method: "DELETE" }),
+        async () => {
+          throw new Error("socket closed");
+        }
+      )
+    ).rejects.toThrow("socket closed");
+    expect(loggedLines()[0]).toMatch(
+      /DELETE \/mcp 500 client=unknown \d+ms ERROR socket closed/
+    );
   });
 
   it("logs unknown inspector paths and skips favicon noise", async () => {
@@ -268,7 +363,7 @@ describe("requestLogger (via MCPServer.fetch)", () => {
     );
     expect(loggedLines()).toHaveLength(1);
     expect(loggedLines()[0]).toMatch(
-      /^\d{2}:\d{2}:\d{2} GET \/mcp\/inspector 404 in \d+ms$/
+      /^\d{2}:\d{2}:\d{2} GET \/mcp\/inspector 404 client=unknown \d+ms$/
     );
     await server.close();
   });
@@ -297,7 +392,10 @@ describe("requestLogger (via MCPServer.fetch)", () => {
     expect(output).toContain("Response Body:");
     expect(output).toContain('"who": "dump"');
     // Trace includes debug's inline echo too.
-    expect(output).toContain('  tools/call greet {"who":"dump"}');
+    expect(output).toContain(
+      "tools/call greet /mcp 200 client=raw-request/0.0.0"
+    );
+    expect(output).toContain('{"who":"dump"}');
     await server.close();
   });
 
@@ -327,10 +425,8 @@ describe("requestLogger (via MCPServer.fetch)", () => {
     );
     const lines = loggedLines();
     // The injected newline must not produce a third log line.
-    expect(lines).toHaveLength(2);
-    expect(lines[1]).toBe(
-      "  tools/call fail raw-request/0.0.0 ERROR failed: line1 FORGED 200 OK"
-    );
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain("ERROR failed: line1 FORGED 200 OK");
     await server.close();
   });
 
@@ -353,7 +449,9 @@ describe("requestLogger (via MCPServer.fetch)", () => {
         { "mcp-name": "greet", host: "api.example.com" }
       )
     );
-    expect(loggedLines()[1]).toBe("  tools/call greet raw-request/0.0.0");
+    expect(loggedLines()[0]).toMatch(
+      /tools\/call greet \/mcp 200 client=raw-request\/0\.0\.0 \d+ms/
+    );
     await server.close();
   });
 });

--- a/libraries/typescript/packages/server/tests/logging.test.ts
+++ b/libraries/typescript/packages/server/tests/logging.test.ts
@@ -6,6 +6,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 
+import { getRequestBag, jsonBodyMiddleware } from "../src/fetch-app.js";
 import { MCPServer, requestLogger } from "../src/index.js";
 import type { ServerConfig } from "../src/index.js";
 
@@ -223,6 +224,34 @@ describe("requestLogger (via MCPServer.fetch)", () => {
     await server.close();
   });
 
+  it("does not let a malformed legacy clientInfo name mask initialize errors", async () => {
+    const server = buildServer();
+    const response = await server.fetch(
+      new Request("http://localhost/mcp", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: "2025-06-18",
+            capabilities: {},
+            clientInfo: { name: 123, version: "2.1.0" },
+          },
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toContain('"error"');
+    expect(loggedLines()[0]).toMatch(/initialize \/mcp 200 client=unknown/);
+    await server.close();
+  });
+
   it("appends ERROR with the tool's message for isError results", async () => {
     const server = buildServer();
     await server.fetch(
@@ -330,6 +359,49 @@ describe("requestLogger (via MCPServer.fetch)", () => {
       "[server] tools/list /mcp 204 client=unknown"
     );
     expect(loggedLines()[1]).not.toContain("[server]");
+  });
+
+  it("stashes its parsed JSON body for jsonBodyMiddleware to reuse", async () => {
+    const body = { jsonrpc: "2.0", id: 1, method: "tools/list", params: {} };
+    const request = new Request("http://localhost/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    const parseSpy = vi.spyOn(JSON, "parse");
+    const terminal = vi.fn(async () => {
+      expect(getRequestBag(request).parsedBody).toEqual(body);
+      return new Response(null, { status: 204 });
+    });
+
+    try {
+      const response = await requestLogger({ mcpPath: "/mcp" })(request, () =>
+        jsonBodyMiddleware()(request, terminal)
+      );
+
+      expect(response.status).toBe(204);
+      expect(parseSpy).toHaveBeenCalledTimes(1);
+      expect(terminal).toHaveBeenCalledTimes(1);
+    } finally {
+      parseSpy.mockRestore();
+    }
+  });
+
+  it("leaves malformed JSON for jsonBodyMiddleware to reject", async () => {
+    const request = new Request("http://localhost/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{not json",
+    });
+    const terminal = vi.fn(async () => new Response(null, { status: 204 }));
+
+    const response = await requestLogger({ mcpPath: "/mcp" })(request, () =>
+      jsonBodyMiddleware()(request, terminal)
+    );
+
+    expect(response.status).toBe(400);
+    expect(getRequestBag(request).parsedBody).toBeUndefined();
+    expect(terminal).not.toHaveBeenCalled();
   });
 
   it("logs a 500 single-line record before rethrowing a handler failure", async () => {

--- a/libraries/typescript/packages/server/tests/logging.test.ts
+++ b/libraries/typescript/packages/server/tests/logging.test.ts
@@ -113,7 +113,7 @@ describe("requestLogger (via MCPServer.fetch)", () => {
     const lines = loggedLines();
     expect(lines).toHaveLength(1);
     expect(lines[0]).toMatch(
-      /^\d{2}:\d{2}:\d{2} tools\/call greet \/mcp 200 client=raw-request\/0\.0\.0 \d+ms$/
+      /^tools\/call greet \/mcp 200 client=raw-request\/0\.0\.0 \d+ms$/
     );
     await server.close();
   });
@@ -260,7 +260,7 @@ describe("requestLogger (via MCPServer.fetch)", () => {
     );
     const lines = loggedLines();
     expect(lines).toHaveLength(1);
-    expect(lines[0]).toMatch(/^\d{2}:\d{2}:\d{2} GET \/health 404 \d+ms$/);
+    expect(lines[0]).toMatch(/^GET \/health 404 \d+ms$/);
     await server.close();
   });
 
@@ -280,12 +280,8 @@ describe("requestLogger (via MCPServer.fetch)", () => {
         body: "{not json",
       })
     );
-    expect(loggedLines()[0]).toMatch(
-      /^\d{2}:\d{2}:\d{2} PATCH \/health 404 \d+ms$/
-    );
-    expect(loggedLines()[1]).toMatch(
-      /^\d{2}:\d{2}:\d{2} POST \/mcp 400 \d+ms$/
-    );
+    expect(loggedLines()[0]).toMatch(/^PATCH \/health 404 \d+ms$/);
+    expect(loggedLines()[1]).toMatch(/^POST \/mcp 400 \d+ms$/);
     await server.close();
   });
 
@@ -360,9 +356,7 @@ describe("requestLogger (via MCPServer.fetch)", () => {
       new Request("http://localhost/favicon.ico", { method: "GET" })
     );
     expect(loggedLines()).toHaveLength(1);
-    expect(loggedLines()[0]).toMatch(
-      /^\d{2}:\d{2}:\d{2} GET \/mcp\/inspector 404 \d+ms$/
-    );
+    expect(loggedLines()[0]).toMatch(/^GET \/mcp\/inspector 404 \d+ms$/);
     await server.close();
   });
 


### PR DESCRIPTION
## Summary
- emit one MCP/HTTP request record with method, status, client, and elapsed time
- label colocated dev server and Inspector logs while preserving standalone output
- cover malformed bodies, batches, missing metadata, errors, and prefix routing

## Verification
- `pnpm exec vitest run tests/logging.test.ts`
- `pnpm exec vitest run tests/cli/dev.test.ts`
- `pnpm exec vitest run tests/unit/mcp-proxy-security.test.ts`
- `pnpm --filter mcp-use build`
- `pnpm --filter @mcp-use/inspector build`
- `pnpm --filter @mcp-use/cli build`
- targeted ESLint and Prettier checks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates dev server request logging so every MCP/HTTP request emits one line instead of the previous two-line pair, and adds `[server]` / `[inspector]` source prefixes when the Inspector shares the dev server stdout. The new format logs MCP requests by RPC method rather than HTTP method and drops the timestamp; anything that parsed the old lines needs updating.

**Details**
- Shows `client=...` on MCP lines only, resolved from modern or legacy initialize handshakes with `unknown` fallback; HTTP lines omit it.
- Handles malformed bodies, JSON-RPC batches (`batch(a,b)`), and logs a single 500 line before rethrowing handler errors.
- Standalone Inspector and non-colocated dev server output keeps its prior labels.
- Enters canary prerelease mode with a patch changeset for `mcp-use`, `@mcp-use/cli`, and `@mcp-use/inspector`.

<sup>Written for commit abb745a0d8d928e977d02d09797ba20aa090640e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

