### PR TITLE
docs(client): put the sandbox subpath inside the coverage gate

### DIFF
--- a/libraries/typescript/packages/client/typedoc.json
+++ b/libraries/typescript/packages/client/typedoc.json
@@ -1,6 +1,11 @@
 {
   "$schema": "https://typedoc.org/schema.json",
-  "entryPoints": ["src/index.ts", "src/index-browser.ts", "src/react/index.ts"],
+  "entryPoints": [
+    "src/index.ts",
+    "src/index-browser.ts",
+    "src/react/index.ts",
+    "src/sandbox.ts"
+  ],
   "tsconfig": "tsconfig.json",
   "readme": "none",
   "validation": {


### PR DESCRIPTION
## Why

`@mcp-use/client` publishes three subpaths. Typedoc only inspects two of them:

```json
"exports":     [".", "./react", "./sandbox"]
"entryPoints": ["src/index.ts", "src/index-browser.ts", "src/react/index.ts"]
```

So everything exported from `src/sandbox.ts` sits outside the documentation gate that #2312 turned on.

## Proof it is a real hole, not a tidy-up

Appending an undocumented export to `src/sandbox.ts` and running `pnpm docs:api` both ways:

| entryPoints | result |
|---|---|
| without `src/sandbox.ts` | **exit 0**, no warnings |
| with it | **exit 3** |

```
sandbox.SandboxProbe (TypeAlias), defined in @mcp-use/client/src/sandbox.ts,
  does not have any documentation
sandbox.SandboxProbe.probe (Property), defined in @mcp-use/client/src/sandbox.ts,
  does not have any documentation
```

I checked it in both directions on purpose. The first run is the one that matters: today anything added to that file ships undocumented and CI stays green.

## Being straight about the current state

**Nothing is undocumented there right now.** The only export, `buildSandboxProxyBlobHtml`, has TSDoc and is also re-exported through `./react`, which is a listed entry point. That is exactly why the hole has gone unnoticed. This closes it before the next export lands, rather than fixing a live problem.

`pnpm docs:api` still exits 0 with the entry added, so this changes nothing about the current build.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the sandbox subpath to the TypeDoc coverage gate so undocumented exports from `src/sandbox.ts` now fail `pnpm docs:api` instead of passing silently.

Nothing exported from the sandbox file is undocumented today, so the build result is unchanged.

<sup>Written for commit c63a3dd4b664c70181bf9611e1730333bb2d23fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

