### PR TITLE
fix(inspector): expose upstream fetch failures

### DIFF
--- a/libraries/typescript/.changeset/pre.json
+++ b/libraries/typescript/.changeset/pre.json
@@ -1,0 +1,14 @@
+{
+  "mode": "pre",
+  "tag": "canary",
+  "initialVersions": {
+    "@mcp-use/agent": "2.0.10",
+    "@mcp-use/cli": "4.1.7",
+    "@mcp-use/client": "2.2.1",
+    "create-mcp-use-app": "2.0.5",
+    "@mcp-use/inspector": "20.3.2",
+    "mcp-use": "2.3.3",
+    "@mcp-use/tunnel": "0.2.0"
+  },
+  "changesets": []
+}

--- a/libraries/typescript/.changeset/safe-proxies-explain.md
+++ b/libraries/typescript/.changeset/safe-proxies-explain.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Return gateway-specific status codes for MCP upstream fetch failures and log safe structured network diagnostics without leaking target URL credentials or query parameters.

--- a/libraries/typescript/packages/cli/tests/cli/dev.test.ts
+++ b/libraries/typescript/packages/cli/tests/cli/dev.test.ts
@@ -62,18 +62,32 @@ beforeEach(() => {
 
 afterEach(async () => {
   tunnelState.url = null;
-  while (cleanups.length > 0) {
-    await cleanups.pop()?.();
+  const errors: unknown[] = [];
+  try {
+    while (cleanups.length > 0) {
+      try {
+        await cleanups.pop()?.();
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+  } finally {
+    if (originalMcpUrl === undefined) {
+      delete process.env["MCP_URL"];
+    } else {
+      process.env["MCP_URL"] = originalMcpUrl;
+    }
+    if (originalPort === undefined) {
+      delete process.env["PORT"];
+    } else {
+      process.env["PORT"] = originalPort;
+    }
   }
-  if (originalMcpUrl === undefined) {
-    delete process.env["MCP_URL"];
-  } else {
-    process.env["MCP_URL"] = originalMcpUrl;
+  if (errors.length === 1) {
+    throw errors[0];
   }
-  if (originalPort === undefined) {
-    delete process.env["PORT"];
-  } else {
-    process.env["PORT"] = originalPort;
+  if (errors.length > 1) {
+    throw new AggregateError(errors, "test cleanup failed");
   }
 });
 

--- a/libraries/typescript/packages/cli/tests/cli/helpers.ts
+++ b/libraries/typescript/packages/cli/tests/cli/helpers.ts
@@ -46,7 +46,16 @@ export function copyFixture(
 
 /** Remove a scratch dir, ignoring failures. */
 export function removeDir(dir: string): void {
-  rmSync(dir, { recursive: true, force: true });
+  try {
+    rmSync(dir, {
+      recursive: true,
+      force: true,
+      maxRetries: 5,
+      retryDelay: 100,
+    });
+  } catch {
+    // best effort: Vite may still be finishing optimizer temp cleanup.
+  }
 }
 
 /** Bind the basic fixture's add tool to a named view for CLI error tests. */

--- a/libraries/typescript/packages/inspector/src/server/proxy/mcp-proxy.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy/mcp-proxy.ts
@@ -20,6 +20,142 @@ import {
 import { isSafeProxyTarget } from "./oauth-proxy.js";
 
 const MAX_REDIRECTS = 3;
+const UPSTREAM_TIMEOUT_CODES = new Set([
+  "ETIMEDOUT",
+  "UND_ERR_BODY_TIMEOUT",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+]);
+
+type UpstreamFetchDiagnostic = {
+  code: string;
+  causeName?: string;
+  syscall?: string;
+  hostname?: string;
+  address?: string;
+  port?: string | number;
+};
+
+function errorCauseChain(error: unknown): Record<string, unknown>[] {
+  const chain: Record<string, unknown>[] = [];
+  const seen = new Set<unknown>();
+  const pending: unknown[] = [error];
+  while (pending.length > 0 && chain.length < 8) {
+    const current = pending.shift();
+    if (current === null || typeof current !== "object" || seen.has(current)) {
+      continue;
+    }
+    seen.add(current);
+    const record = current as Record<string, unknown>;
+    chain.push(record);
+    pending.push(record.cause);
+    if (Array.isArray(record.errors)) {
+      pending.push(...record.errors.slice(0, 4));
+    }
+  }
+  return chain;
+}
+
+function firstStringField(
+  chain: Record<string, unknown>[],
+  field: string
+): string | undefined {
+  for (const item of chain) {
+    const value = item[field];
+    if (typeof value === "string" && value.length > 0)
+      return value.slice(0, 200);
+  }
+  return undefined;
+}
+
+/** Extract bounded, non-secret network fields from a Node/Undici fetch error. */
+export function upstreamFetchDiagnostic(
+  error: unknown
+): UpstreamFetchDiagnostic {
+  const chain = errorCauseChain(error);
+  const cause = chain.at(1) ?? chain.at(0);
+  const syscall = firstStringField(chain, "syscall");
+  const hostname = firstStringField(chain, "hostname");
+  const address = firstStringField(chain, "address");
+  let port: string | number | undefined;
+  for (const item of chain) {
+    const value = item.port;
+    if (
+      typeof value === "string" ||
+      (typeof value === "number" && Number.isFinite(value))
+    ) {
+      port = typeof value === "string" ? value.slice(0, 20) : value;
+      break;
+    }
+  }
+
+  return {
+    code: firstStringField(chain, "code") ?? "UPSTREAM_FETCH_FAILED",
+    ...(typeof cause?.name === "string" && cause.name
+      ? { causeName: cause.name.slice(0, 100) }
+      : {}),
+    ...(syscall ? { syscall } : {}),
+    ...(hostname ? { hostname } : {}),
+    ...(address ? { address } : {}),
+    ...(port !== undefined ? { port } : {}),
+  };
+}
+
+/** Remove URL credentials, query parameters, and fragments before logging. */
+export function sanitizedProxyTarget(targetUrl: string | undefined): string {
+  if (!targetUrl) return "unknown";
+  try {
+    const parsed = new URL(targetUrl);
+    parsed.username = "";
+    parsed.password = "";
+    parsed.search = "";
+    parsed.hash = "";
+    return parsed.toString();
+  } catch {
+    return "invalid";
+  }
+}
+
+function isUpstreamTimeout(
+  error: unknown,
+  diagnostic: UpstreamFetchDiagnostic
+): boolean {
+  if (UPSTREAM_TIMEOUT_CODES.has(diagnostic.code)) return true;
+  return errorCauseChain(error).some(
+    (item) => item.name === "TimeoutError" || item.name === "AbortError"
+  );
+}
+
+function upstreamFetchErrorResponse(
+  c: Context,
+  error: unknown,
+  targetUrl: string
+): Response {
+  const diagnostic = upstreamFetchDiagnostic(error);
+  const timedOut = isUpstreamTimeout(error, diagnostic);
+  const status = timedOut ? 504 : 502;
+  const safeTargetUrl = sanitizedProxyTarget(targetUrl);
+
+  console.warn(
+    `[MCP Proxy] Upstream fetch failed ${JSON.stringify({
+      targetUrl: safeTargetUrl,
+      status,
+      ...diagnostic,
+    })}`
+  );
+
+  return c.json(
+    {
+      error: "Proxy request failed",
+      details: timedOut
+        ? "Upstream MCP server timed out"
+        : "Could not reach upstream MCP server",
+      code: diagnostic.code,
+      targetUrl: safeTargetUrl,
+    },
+    status
+  );
+}
 
 /**
  * Options for configuring the MCP proxy middleware
@@ -288,12 +424,17 @@ export function mountMcpProxy(app: Hono, options: McpProxyOptions = {}): void {
       // Follow a bounded redirect chain manually so every destination passes
       // the network policy and request bytes are never reused after detachment.
       for (let redirectCount = 0; ; redirectCount += 1) {
-        const response = await fetch(currentUrl, {
-          method: currentMethod,
-          headers,
-          body: currentBody,
-          redirect: "manual",
-        });
+        let response: Response;
+        try {
+          response = await fetch(currentUrl, {
+            method: currentMethod,
+            headers,
+            body: currentBody,
+            redirect: "manual",
+          });
+        } catch (error) {
+          return upstreamFetchErrorResponse(c, error, currentUrl);
+        }
         const location = response.headers.get("location");
         if (!(response.status >= 300 && response.status < 400 && location)) {
           return proxyResponse(response);
@@ -330,40 +471,19 @@ export function mountMcpProxy(app: Hono, options: McpProxyOptions = {}): void {
         currentUrl = redirectUrl.toString();
       }
     } catch (error) {
-      const message = error instanceof Error ? error.message : "Unknown error";
+      const targetUrl = sanitizedProxyTarget(c.req.header("X-Target-URL"));
 
-      // Get targetUrl for better error logging
-      const targetUrl = c.req.header("X-Target-URL");
-
-      // Check if this is a connection refused error (common when a stored server isn't running)
-      const isConnectionRefused =
-        error instanceof Error &&
-        (error.message.includes("ECONNREFUSED") ||
-          error.message.includes("fetch failed"));
-
-      if (isConnectionRefused) {
-        // This is expected when reconnecting to a stored server that's not running
-        // Log as a warning instead of error, without stack trace
-        console.warn(
-          `[MCP Proxy] Connection refused to ${targetUrl || "unknown target"} - server may not be running`
-        );
-      } else {
-        // Log other errors with full details
-        console.error(
-          "[MCP Proxy] Request failed:",
-          message,
-          "\nTarget URL:",
-          targetUrl || "unknown",
-          "\nError:",
-          error
-        );
-      }
+      console.error("[MCP Proxy] Internal request failure:", {
+        targetUrl,
+        errorName: error instanceof Error ? error.name : typeof error,
+      });
 
       return c.json(
         {
           error: "Proxy request failed",
-          details: message,
-          targetUrl: targetUrl || "unknown",
+          details: "The MCP proxy could not process the request",
+          code: "PROXY_INTERNAL_ERROR",
+          targetUrl,
         },
         500
       );

--- a/libraries/typescript/packages/inspector/tests/unit/mcp-proxy-security.test.ts
+++ b/libraries/typescript/packages/inspector/tests/unit/mcp-proxy-security.test.ts
@@ -6,6 +6,7 @@ const proxyUrl = "http://localhost/inspector/api/proxy";
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
 
 describe("Inspector MCP proxy request isolation", () => {
@@ -183,5 +184,109 @@ describe("Inspector MCP proxy request isolation", () => {
     expect(response.status).toBe(200);
     expect(response.headers.get("cache-control")).toBe("private, no-store");
     expect(response.headers.get("x-accel-buffering")).toBe("no");
+  });
+
+  it("returns a safe 502 with the underlying network error code", async () => {
+    const networkError = Object.assign(new Error("connect ECONNREFUSED"), {
+      code: "ECONNREFUSED",
+      syscall: "connect",
+      address: "93.184.216.34",
+      port: 443,
+    });
+    const cause = new AggregateError([networkError], "connection failed");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () => {
+        throw new TypeError("fetch failed", { cause });
+      })
+    );
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const app = new Hono();
+    mountMcpProxy(app, {
+      path: "/inspector/api/proxy",
+      enableLogging: false,
+    });
+
+    const response = await app.fetch(
+      new Request(proxyUrl, {
+        headers: {
+          "X-Target-URL":
+            "https://93.184.216.34/mcp?access_token=must-not-leak",
+        },
+      })
+    );
+    const body = await response.json();
+    const logged = warn.mock.calls.flat().join(" ");
+
+    expect(response.status).toBe(502);
+    expect(body).toEqual({
+      error: "Proxy request failed",
+      details: "Could not reach upstream MCP server",
+      code: "ECONNREFUSED",
+      targetUrl: "https://93.184.216.34/mcp",
+    });
+    expect(logged).toContain('"code":"ECONNREFUSED"');
+    expect(logged).toContain('"syscall":"connect"');
+    expect(logged).not.toContain("must-not-leak");
+  });
+
+  it("maps Undici connection timeouts to a 504", async () => {
+    const cause = Object.assign(new Error("connection timed out"), {
+      code: "UND_ERR_CONNECT_TIMEOUT",
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () => {
+        throw new TypeError("fetch failed", { cause });
+      })
+    );
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const app = new Hono();
+    mountMcpProxy(app, {
+      path: "/inspector/api/proxy",
+      enableLogging: false,
+    });
+
+    const response = await app.fetch(
+      new Request(proxyUrl, {
+        headers: {
+          "X-Target-URL": "https://93.184.216.34/mcp",
+        },
+      })
+    );
+
+    expect(response.status).toBe(504);
+    expect(await response.json()).toMatchObject({
+      details: "Upstream MCP server timed out",
+      code: "UND_ERR_CONNECT_TIMEOUT",
+    });
+  });
+
+  it("uses a stable fallback code when fetch has no structured cause", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () => {
+        throw new TypeError("fetch failed");
+      })
+    );
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const app = new Hono();
+    mountMcpProxy(app, {
+      path: "/inspector/api/proxy",
+      enableLogging: false,
+    });
+
+    const response = await app.fetch(
+      new Request(proxyUrl, {
+        headers: {
+          "X-Target-URL": "https://93.184.216.34/mcp",
+        },
+      })
+    );
+
+    expect(response.status).toBe(502);
+    expect(await response.json()).toMatchObject({
+      code: "UPSTREAM_FETCH_FAILED",
+    });
   });
 });


### PR DESCRIPTION
## Summary

- handle outbound MCP `fetch()` failures at the fetch boundary instead of treating every `fetch failed` as an internal 500 / connection refusal
- return 502 for upstream connection failures and 504 for timeout-class failures while preserving the existing `Proxy request failed` response label
- traverse bounded `cause` and `AggregateError.errors` chains to retain safe Node/Undici diagnostics such as code, syscall, hostname, address, and port
- strip URL credentials, query parameters, and fragments from logs and responses
- keep non-fetch proxy exceptions as internal 500s with a stable `PROXY_INTERNAL_ERROR` code
- add an Inspector patch changeset

## Root cause

The deployed proxy currently catches Node's top-level `TypeError: fetch failed`, discards `error.cause`, labels it as `Connection refused`, and returns HTTP 500. During the Manufact production incident that made intermittent proxy egress failures appear to the client as MCP version-negotiation failures and left Vercel with no underlying DNS/socket/Undici code.

This PR fixes that classification and observability boundary. The connection-amplification root cause is addressed separately in mcp-use/mcp-use-cloud#1582.

## Verification

- focused proxy suite: 8 passed
- full Inspector unit suite after building packaged app assets: 54 files, 264 tests passed
- `pnpm --filter @mcp-use/inspector type-check`
- `pnpm --filter @mcp-use/inspector build:server`
- targeted ESLint and Prettier
- changeset pre-commit validation
- `git diff --check`

## Compatibility

The JSON `error` string remains `Proxy request failed`; consumers can use the new stable `code` field and HTTP status to distinguish upstream connection, timeout, and internal proxy failures.

This is independent of #2260. Both touch the proxy implementation, but this PR does not depend on the rate-limit changes in that PR.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the MCP proxy so upstream fetch failures are classified and reported correctly instead of treating every `fetch failed` as an internal 500 connection refusal.

- Returns 502 for upstream connection failures and 504 for timeout-class failures, preserving the `Proxy request failed` error label.
- Extracts safe network diagnostics (error code, syscall, hostname, address, port) from bounded `cause` and `AggregateError.errors` chains.
- Strips URL credentials, query parameters, and fragments from logged and returned target URLs.
- Keeps non-fetch proxy exceptions at 500 with a stable `PROXY_INTERNAL_ERROR` code.
- Adds a patch changeset for `@mcp-use/inspector`.

<sup>Written for commit ec74fb0101156eaeffad6669ec1caff97132144a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

