### PR TITLE
fix(typescript): fail screenshot CLI on MCP App init failure

### DIFF
--- a/libraries/typescript/.changeset/late-times-exist.md
+++ b/libraries/typescript/.changeset/late-times-exist.md
@@ -1,0 +1,6 @@
+---
+"@mcp-use/inspector": patch
+"@mcp-use/cli": patch
+---
+
+`mcp-use screenshot` now fails with a stable `view_load_failed` code instead of writing a PNG when the MCP App itself fails to initialize (a bad resource, a sandbox connect failure, or an initialize-handshake failure). This is baseline behavior, not opt-in. `console.error` calls, uncaught errors, and unhandled rejections a widget logs after it has successfully initialized continue to be ignored, since those are frequently recoverable and treating them as failures would create false positives.

--- a/libraries/typescript/packages/cli/src/commands/screenshot.ts
+++ b/libraries/typescript/packages/cli/src/commands/screenshot.ts
@@ -472,6 +472,35 @@ async function waitForDocument(
   );
 }
 
+interface ReadyState {
+  ready?: boolean;
+  error?: string | null;
+  errorMessage?: string | null;
+  selector?: boolean;
+}
+
+/**
+ * Turn the Inspector preview's polled DOM state into a failure, or
+ * `undefined` when there is none yet.
+ *
+ * Only an explicit MCP App initialization failure (a bad resource, a
+ * sandbox connect failure, an initialize-handshake failure, or a missing
+ * screenshot bundle) fails the capture here — never a widget's own
+ * `console.error`, uncaught error, or unhandled rejection logged after it
+ * has successfully initialized. See ViewPreview.tsx in \@mcp-use/inspector.
+ */
+export function readyStateFailure(
+  state: ReadyState | undefined
+): CommandError | undefined {
+  if (state?.error !== "view_load_failed") return undefined;
+  return new CommandError(
+    "view_load_failed",
+    state.errorMessage
+      ? `MCP App failed to initialize: ${state.errorMessage}`
+      : "MCP App failed to initialize."
+  );
+}
+
 async function waitForReady(
   browser: BrowserHandle,
   selector: string | undefined,
@@ -482,23 +511,17 @@ async function waitForReady(
     const expression = `(() => ({
       ready: document.body?.dataset.viewReady === "true",
       error: document.body?.dataset.viewError || null,
+      errorMessage: document.body?.dataset.viewErrorMessage || null,
       selector: ${JSON.stringify(selector)} === undefined || !!document.querySelector(${JSON.stringify(selector ?? "")})
     }))()`;
     const response = (await browser.cdp.send(
       "Runtime.evaluate",
       { expression, returnByValue: true },
       browser.sessionId
-    )) as {
-      result?: {
-        value?: { ready?: boolean; error?: string | null; selector?: boolean };
-      };
-    };
+    )) as { result?: { value?: ReadyState } };
     const state = response.result?.value;
-    if (state?.error)
-      throw new CommandError(
-        "preview_failed",
-        `Inspector preview failed: ${state.error}`
-      );
+    const failure = readyStateFailure(state);
+    if (failure) throw failure;
     if (state?.ready === true && state.selector === true) return;
     await sleep(100);
   }

--- a/libraries/typescript/packages/cli/tests/commands/screenshot.test.ts
+++ b/libraries/typescript/packages/cli/tests/commands/screenshot.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { normalizeCaptureBounds } from "../../src/commands/screenshot.js";
+import {
+  normalizeCaptureBounds,
+  readyStateFailure,
+} from "../../src/commands/screenshot.js";
 
 describe("screenshot capture bounds", () => {
   it("pixel-aligns the rendered widget instead of retaining viewport space", () => {
@@ -28,5 +31,46 @@ describe("screenshot capture bounds", () => {
     expect(() => normalizeCaptureBounds(bounds)).toThrow(
       /widget bounds|invalid widget bounds/
     );
+  });
+});
+
+describe("screenshot readiness gate", () => {
+  it("has no failure while the view is still resolving", () => {
+    expect(readyStateFailure(undefined)).toBeUndefined();
+    expect(readyStateFailure({})).toBeUndefined();
+    expect(readyStateFailure({ ready: false, selector: true })).toBeUndefined();
+  });
+
+  it("has no failure once the view becomes ready", () => {
+    expect(readyStateFailure({ ready: true, selector: true })).toBeUndefined();
+  });
+
+  it("fails only on an explicit initialization failure", () => {
+    const failure = readyStateFailure({
+      error: "view_load_failed",
+      errorMessage: "Sandbox did not report ready.",
+    });
+    expect(failure?.code).toBe("view_load_failed");
+    expect(failure?.message).toContain("Sandbox did not report ready.");
+  });
+
+  it("falls back to a generic message when no detail is available", () => {
+    const failure = readyStateFailure({ error: "view_load_failed" });
+    expect(failure?.code).toBe("view_load_failed");
+    expect(failure?.message).toBe("MCP App failed to initialize.");
+  });
+
+  it("never fails on a widget's own runtime error after it has initialized", () => {
+    // A widget's console.error / uncaught error / unhandled rejection must
+    // not surface here — only the Inspector's explicit "view_load_failed"
+    // initialization-failure signal does. Any other value (including a
+    // widget-authored error string) is ignored.
+    expect(
+      readyStateFailure({
+        ready: true,
+        selector: true,
+        error: "runtime_error",
+      })
+    ).toBeUndefined();
   });
 });

--- a/libraries/typescript/packages/inspector/src/client/components/ViewPreview.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ViewPreview.tsx
@@ -17,10 +17,22 @@
  *
  * In both modes, `body[data-view-ready="true"]` is set once the renderer
  * signals readiness + fonts have loaded + two animation frames have elapsed.
+ *
+ * If the MCP App fails to *initialize* — a bad resource, a sandbox connect
+ * failure, an initialize-handshake failure, or (bundle mode only) a missing
+ * screenshot bundle — `body[data-view-error="view_load_failed"]` is set
+ * instead, with an optional `body[data-view-error-message]` detail. This
+ * never fires for a widget's own `console.error`, uncaught errors, or
+ * unhandled rejections logged after it has successfully initialized; see
+ * `markViewLoadFailed` below.
  */
 
-import { ViewRenderer, useMcpClient } from "@mcp-use/client/react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  ViewRenderer,
+  useMcpClient,
+  type ViewLifecycleEvent,
+} from "@mcp-use/client/react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams, useSearchParams } from "react-router";
 import { useViewHostProps } from "@/client/hooks/useViewHostProps";
 import { getBasePath } from "@/client/utils/basePath";
@@ -97,26 +109,51 @@ function usePreviewViewport(): void {
   }, []);
 }
 
-/** Expose non-secret preview failures to CDP callers. */
+/**
+ * Mark `body[data-view-error="view_load_failed"]` for the screenshot CLI to
+ * poll for. Reserved for explicit MCP App *initialization* failures — the
+ * widget never became ready to render — never for arbitrary `console.error`
+ * calls, uncaught errors, or unhandled rejections a widget logs after it has
+ * successfully initialized. Those are frequently recoverable and would
+ * otherwise turn a working screenshot into a false-positive failure.
+ */
+function markViewLoadFailed(message?: string): void {
+  document.body.dataset.viewError = "view_load_failed";
+  if (message) document.body.dataset.viewErrorMessage = message;
+  else delete document.body.dataset.viewErrorMessage;
+}
+
+function clearViewLoadFailed(): void {
+  delete document.body.dataset.viewError;
+  delete document.body.dataset.viewErrorMessage;
+}
+
+/** Surface a missing screenshot bundle as an initialization failure. */
 function usePreviewErrorSignal(
   bundleRequired: boolean,
   bundlePresent: boolean
 ): void {
   useEffect(() => {
-    const markRuntimeError = () => {
-      document.body.dataset.viewError = "runtime_error";
-    };
     if (bundleRequired && !bundlePresent) {
-      document.body.dataset.viewError = "invalid_payload";
+      markViewLoadFailed(
+        "Screenshot bundle was not injected before navigation."
+      );
     }
-    window.addEventListener("error", markRuntimeError);
-    window.addEventListener("unhandledrejection", markRuntimeError);
-    return () => {
-      window.removeEventListener("error", markRuntimeError);
-      window.removeEventListener("unhandledrejection", markRuntimeError);
-      delete document.body.dataset.viewError;
-    };
+    return () => clearViewLoadFailed();
   }, [bundleRequired, bundlePresent]);
+}
+
+/**
+ * Track {@link ViewRenderer}'s lifecycle and mark `view_load_failed` only for
+ * its `"error"` status — resource resolution failures, sandbox connect
+ * failures, and initialize-handshake failures. A later successful stage
+ * (e.g. a retried `"connecting"`) clears the mark.
+ */
+function useViewLifecycleErrorSignal(): (event: ViewLifecycleEvent) => void {
+  return useCallback((event: ViewLifecycleEvent) => {
+    if (event.status === "error") markViewLoadFailed(event.error);
+    else clearViewLoadFailed();
+  }, []);
 }
 
 /**
@@ -248,6 +285,7 @@ function ViewPreviewBundle({
   const containerRef = useRef<HTMLDivElement>(null);
   usePreviewViewport();
   useBundleReadinessSignal(rendererReady, containerRef);
+  const onLifecycleChange = useViewLifecycleErrorSignal();
 
   const readResource = useMemo(() => {
     return async (uri: string) => {
@@ -272,6 +310,7 @@ function ViewPreviewBundle({
         inlineMaxWidth={widthOverride}
         chromeless
         onReady={() => setRendererReady(true)}
+        onLifecycleChange={onLifecycleChange}
         source={{
           kind: "live",
           connection: {

--- a/libraries/typescript/packages/inspector/src/client/components/ViewPreview.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ViewPreview.tsx
@@ -153,15 +153,19 @@ function usePreviewErrorSignal(
  * re-initialization sync failure (e.g. the widget's own dev-mode HMR reload
  * failing to resynchronize) — see `installInitializedSync`'s `onLaterError`
  * in `@mcp-use/client`. That happens only after the view already initialized
- * once, so it must not retroactively fail an otherwise-successful capture;
- * once `"initialized"`/`"ready"` is seen, further `"error"` events are
- * ignored until a fresh `"resolving"` phase (a genuine new connect attempt)
- * re-arms the check.
+ * once, without ever emitting `"resolving"` or `"connecting"` again (the
+ * bridge is already connected), so it must not retroactively fail an
+ * otherwise-successful capture. Once `"initialized"`/`"ready"` is seen,
+ * further `"error"` events are ignored until a fresh `"resolving"` (a new
+ * resource resolve) or `"connecting"` (a bridge reconnect on the same
+ * resource — its effect has a dependency set disjoint from the resolve
+ * effect's, so it can re-run on its own) re-arms the check.
  */
 function useViewLifecycleErrorSignal(): (event: ViewLifecycleEvent) => void {
   const initializedRef = useRef(false);
   return useCallback((event: ViewLifecycleEvent) => {
-    if (event.status === "resolving") initializedRef.current = false;
+    if (event.status === "resolving" || event.status === "connecting")
+      initializedRef.current = false;
     else if (event.status === "initialized" || event.status === "ready")
       initializedRef.current = true;
 

--- a/libraries/typescript/packages/inspector/src/client/components/ViewPreview.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ViewPreview.tsx
@@ -145,14 +145,31 @@ function usePreviewErrorSignal(
 
 /**
  * Track {@link ViewRenderer}'s lifecycle and mark `view_load_failed` only for
- * its `"error"` status — resource resolution failures, sandbox connect
- * failures, and initialize-handshake failures. A later successful stage
- * (e.g. a retried `"connecting"`) clears the mark.
+ * an `"error"` status reached before the view first initializes — resource
+ * resolution failures, sandbox connect failures, and initialize-handshake
+ * failures.
+ *
+ * `ViewRenderer` also reports `"error"` for a *later* guest
+ * re-initialization sync failure (e.g. the widget's own dev-mode HMR reload
+ * failing to resynchronize) — see `installInitializedSync`'s `onLaterError`
+ * in `@mcp-use/client`. That happens only after the view already initialized
+ * once, so it must not retroactively fail an otherwise-successful capture;
+ * once `"initialized"`/`"ready"` is seen, further `"error"` events are
+ * ignored until a fresh `"resolving"` phase (a genuine new connect attempt)
+ * re-arms the check.
  */
 function useViewLifecycleErrorSignal(): (event: ViewLifecycleEvent) => void {
+  const initializedRef = useRef(false);
   return useCallback((event: ViewLifecycleEvent) => {
-    if (event.status === "error") markViewLoadFailed(event.error);
-    else clearViewLoadFailed();
+    if (event.status === "resolving") initializedRef.current = false;
+    else if (event.status === "initialized" || event.status === "ready")
+      initializedRef.current = true;
+
+    if (event.status === "error") {
+      if (!initializedRef.current) markViewLoadFailed(event.error);
+      return;
+    }
+    clearViewLoadFailed();
   }, []);
 }
 

--- a/libraries/typescript/packages/inspector/src/client/components/ViewPreview.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ViewPreview.tsx
@@ -160,20 +160,40 @@ function usePreviewErrorSignal(
  * resource resolve) or `"connecting"` (a bridge reconnect on the same
  * resource — its effect has a dependency set disjoint from the resolve
  * effect's, so it can re-run on its own) re-arms the check.
+ *
+ * The marker is cleared only for stages that positively belong to the active
+ * attempt (`"resolving"`/`"connecting"` starting one, `"initialized"`/
+ * `"ready"` completing one). `"tearing-down"` and `"closed"` are ignored:
+ * they can arrive late from a superseded bridge attempt, and a sequence such
+ * as connecting → error → (old) closed would otherwise erase the current
+ * attempt's failure and let the screenshot CLI time out or capture a broken
+ * view instead of failing.
  */
-function useViewLifecycleErrorSignal(): (event: ViewLifecycleEvent) => void {
+export function useViewLifecycleErrorSignal(): (
+  event: ViewLifecycleEvent
+) => void {
   const initializedRef = useRef(false);
   return useCallback((event: ViewLifecycleEvent) => {
-    if (event.status === "resolving" || event.status === "connecting")
+    if (event.status === "resolving" || event.status === "connecting") {
       initializedRef.current = false;
-    else if (event.status === "initialized" || event.status === "ready")
+      clearViewLoadFailed();
+      return;
+    }
+
+    if (event.status === "initialized" || event.status === "ready") {
       initializedRef.current = true;
+      clearViewLoadFailed();
+      return;
+    }
 
     if (event.status === "error") {
       if (!initializedRef.current) markViewLoadFailed(event.error);
       return;
     }
-    clearViewLoadFailed();
+
+    // "sandbox-loading" only follows a "resolving" that already cleared, and
+    // "tearing-down"/"closed" may belong to an older attempt — neither may
+    // erase the current attempt's marker.
   }, []);
 }
 

--- a/libraries/typescript/packages/inspector/src/client/components/__tests__/view-lifecycle-error-signal.test.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/__tests__/view-lifecycle-error-signal.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { ViewLifecycleEvent } from "@mcp-use/client/react";
+import { useViewLifecycleErrorSignal } from "../ViewPreview";
+
+/**
+ * Mount the hook alone and hand back its emit callback, so a lifecycle
+ * sequence can be replayed against the real `useRef` identity the component
+ * would give it.
+ */
+function mountSignal(): {
+  emit: (event: ViewLifecycleEvent) => void;
+  root: Root;
+} {
+  let onLifecycle!: (event: ViewLifecycleEvent) => void;
+
+  function Probe() {
+    onLifecycle = useViewLifecycleErrorSignal();
+    return null;
+  }
+
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(<Probe />);
+  });
+
+  return { emit: (event) => act(() => onLifecycle(event)), root };
+}
+
+describe("useViewLifecycleErrorSignal", () => {
+  let root: Root | undefined;
+  let emit: (event: ViewLifecycleEvent) => void;
+
+  beforeEach(() => {
+    ({ emit, root } = mountSignal());
+  });
+
+  afterEach(() => {
+    act(() => root?.unmount());
+    root = undefined;
+    document.body.innerHTML = "";
+    delete document.body.dataset.viewError;
+    delete document.body.dataset.viewErrorMessage;
+  });
+
+  it("keeps the failure marker when a superseded attempt's teardown arrives after the error", () => {
+    emit({ status: "connecting" });
+    emit({ status: "error", error: "sandbox connect failed" });
+
+    expect(document.body.dataset.viewError).toBe("view_load_failed");
+
+    // Late "closed" from the older bridge attempt — it must not erase the
+    // current attempt's failure.
+    emit({ status: "closed" });
+
+    expect(document.body.dataset.viewError).toBe("view_load_failed");
+    expect(document.body.dataset.viewErrorMessage).toBe(
+      "sandbox connect failed"
+    );
+  });
+
+  it("keeps the failure marker across a late tearing-down", () => {
+    emit({ status: "resolving" });
+    emit({ status: "error", error: "resource not found" });
+    emit({ status: "tearing-down" });
+
+    expect(document.body.dataset.viewError).toBe("view_load_failed");
+  });
+
+  it("ignores a post-initialization error", () => {
+    emit({ status: "connecting" });
+    emit({ status: "initialized" });
+    emit({ status: "error", error: "HMR re-sync failed" });
+
+    expect(document.body.dataset.viewError).toBeUndefined();
+  });
+
+  it("re-arms on a bridge reconnect after a successful initialization", () => {
+    emit({ status: "connecting" });
+    emit({ status: "ready" });
+    emit({ status: "connecting" });
+    emit({ status: "error", error: "reconnect handshake failed" });
+
+    expect(document.body.dataset.viewError).toBe("view_load_failed");
+  });
+
+  it("clears a previous failure once a fresh attempt starts and succeeds", () => {
+    emit({ status: "connecting" });
+    emit({ status: "error", error: "sandbox connect failed" });
+
+    emit({ status: "resolving" });
+    expect(document.body.dataset.viewError).toBeUndefined();
+
+    emit({ status: "sandbox-loading" });
+    emit({ status: "connecting" });
+    emit({ status: "ready" });
+
+    expect(document.body.dataset.viewError).toBeUndefined();
+    expect(document.body.dataset.viewErrorMessage).toBeUndefined();
+  });
+});


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

Check all that apply:
- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

`mcp-use screenshot` could write a PNG even when the MCP App itself failed to
initialize, weakening it as an automated CI/agent gate. This makes
initialization success the baseline requirement for a screenshot, not an
opt-in flag:

- Inspector's chromeless preview route now tracks `ViewRenderer`'s lifecycle
  and marks `body[data-view-error="view_load_failed"]` (plus an optional
  `data-view-error-message` detail) only for genuine initialization failures —
  a bad resource, a sandbox connect failure, an initialize-handshake failure,
  or (bundle mode) a missing screenshot bundle.
- It no longer listens for generic `window.onerror` / `unhandledrejection`
  events. Those previously marked *any* uncaught JS error as a failure,
  including a widget's own `console.error`-style issues logged well after it
  had successfully initialized — a false-positive source.
- The screenshot CLI's readiness poll now fails with a stable
  `view_load_failed` error code on that signal, instead of the previous
  generic `preview_failed`. `browser_timeout` is unchanged for the case where
  readiness is never reached and no specific reason is available.

## Review Readiness

Help maintainers review this quickly:

- [x] The PR is scoped to one issue or one clearly related change
- [x] The PR description explains the user-visible problem and the fix
- [x] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [x] I verified the affected package/docs path with the commands listed below
- [x] I checked for existing open PRs that already solve the same issue

## Implementation Details

1. `packages/inspector/src/client/components/ViewPreview.tsx`: replaced the
   window-level error listeners with `markViewLoadFailed` /
   `clearViewLoadFailed` helpers, wired through a new
   `useViewLifecycleErrorSignal` hook passed as `ViewRenderer`'s
   `onLifecycleChange` in bundle mode. The existing "bundle missing" check now
   reuses the same `view_load_failed` code instead of the old
   `invalid_payload`.
2. `packages/cli/src/commands/screenshot.ts`: extracted the DOM-state → error
   mapping into an exported, unit-testable `readyStateFailure()`, and updated
   `waitForReady` to use it. Only `error === "view_load_failed"` fails the
   capture now.
3. No new dependencies. No public API shape changes — only the CLI's
   machine-readable `error.code` value on failure (`view_load_failed` instead
   of `preview_failed`) and the JS-side lifecycle wiring inside
   `@mcp-use/inspector`'s preview route change.

---

## TypeScript Checklist

> Complete this section if your PR includes TypeScript changes

### Packages Modified

Check all packages that were modified:
- [ ] `docs`
- [ ] `tests`
- [x] `cli`
- [ ] `create-mcp-use-app`
- [ ] `mcp-use` (server)
- [ ] `mcp-use` (client)
- [x] `inspector`

### Pre-commit Checklist

Ensure all of the following have been completed:
- [x] Ran `pnpm lint:fix` to auto-fix linting issues
- [x] Ran `pnpm format` to format code with Prettier
- [x] Ran `pnpm build` and build succeeds without errors
- [x] Ran `pnpm changeset` to create a changeset (if this PR includes user-facing changes)
- [x] Added or updated tests if needed
- [ ] Updated documentation in `docs/` folder if needed

---

## Python Checklist

> Complete this section if your PR includes Python changes

N/A — TypeScript-only change.

---

## Example Usage (Before)

```bash
# A widget's MCP App fails during the initialize handshake (e.g. the sandbox
# never comes up, or the resource returns an invalid MIME type). Before this
# change, the screenshot command could still write a PNG despite the
# initialization failure.
mcp-use screenshot --server demo --tool show-app
# writes demo-show-app-....png, even though the View never actually initialized
```

## Example Usage (After)

```bash
mcp-use screenshot --server demo --tool show-app --json
# {"error":{"code":"view_load_failed","message":"MCP App failed to initialize: ..."}}
# exits 1, no PNG written
```

## Documentation Updates

None — `mcp-use screenshot --help`'s existing exit-code description
("MCP, tool, Inspector, browser, readiness, or write failure") already covers
this generically; no docs reference the specific `preview_failed` /
`view_load_failed` code names.

## Testing

- Unit tests added: `packages/cli/tests/commands/screenshot.test.ts` — new
  `screenshot readiness gate` suite covering `readyStateFailure()`: no
  failure while resolving, no failure once ready, failure with/without a
  detail message on `view_load_failed`, and — the key regression guard — no
  failure for an arbitrary post-init runtime error string.
- Ran full suites: `pnpm --filter @mcp-use/cli exec vitest run` (294/294
  passed) and `pnpm --filter @mcp-use/inspector exec vitest run tests/unit`
  (52/52 passed).
- Ran `tsc --noEmit` and `eslint` on both changed files — clean.
- Ran `pnpm --filter @mcp-use/cli --filter @mcp-use/inspector build` — both
  build successfully.
- No manual browser/CDP testing was performed against a live MCP App in this
  environment; behavior is covered by the extracted pure-function unit tests
  instead.

## Backwards Compatibility

The screenshot CLI's default behavior changes: a capture that previously
succeeded despite a genuine MCP App initialization failure will now fail with
`view_load_failed` (exit code 1, same as other operational failures). This is
a bug fix, not a new opt-in flag — no CLI flags, options, or output shape
change for the success path. `console.error` / uncaught-error / unhandled-
rejection based failures are intentionally *not* introduced by this change.

## Related Issues

Closes #2295