### PR TITLE
feat(inspector): make hosted proxy the unified MCP and OAuth relay

### DIFF
--- a/libraries/typescript/packages/inspector/README.md
+++ b/libraries/typescript/packages/inspector/README.md
@@ -357,13 +357,40 @@ services:
 
 ### Environment Variables
 
-All configuration is optional. The inspector works out of the box with sensible defaults.
+Local development works with in-memory OAuth state. A production deployment
+must provide a shared Redis store and encryption key because OAuth registration
+and token requests may land on different replicas.
 
 | Variable   | Default    | Description                  |
 | ---------- | ---------- | ---------------------------- |
 | `NODE_ENV` | production | Node.js environment          |
 | `PORT`     | 8080       | Port to run the inspector on |
 | `HOST`     | 0.0.0.0    | Host to bind to              |
+| `INSPECTOR_OAUTH_REDIS_URL` (or `REDIS_URL`) | — | Shared Redis URL required in production |
+| `INSPECTOR_OAUTH_ENCRYPTION_KEY` | — | Base64-encoded 32-byte AES key required in production |
+| `INSPECTOR_OAUTH_ALLOWED_ORIGINS` | — | Comma-separated exact browser origins allowed for OAuth |
+| `INSPECTOR_MCP_ALLOWED_ORIGINS` | OAuth origins | Comma-separated exact browser origins allowed for MCP |
+| `INSPECTOR_OAUTH_CONFIDENTIAL_CLIENTS_JSON` | — | Server-only JSON array of configured confidential clients |
+| `INSPECTOR_ALLOW_LOOPBACK` | `true` locally, `false` in production | Permit loopback upstream targets |
+
+`INSPECTOR_OAUTH_CONFIDENTIAL_CLIENTS_JSON` is intentionally read only by the
+server. Its shape is:
+
+```json
+[
+  {
+    "serverUrls": ["https://mcp.example.com/mcp"],
+    "clientId": "server-issued-client-id",
+    "clientSecret": "server-issued-client-secret",
+    "authMethod": "client_secret_post"
+  }
+]
+```
+
+Secrets are never included in browser responses or logs. Do not use `*` for
+OAuth origins; list every product origin explicitly. For a multi-replica
+deployment, configure these values in the secret manager (Infisical/Railway)
+before routing application OAuth traffic to the hosted Inspector.
 
 ---
 

--- a/libraries/typescript/packages/inspector/package.json
+++ b/libraries/typescript/packages/inspector/package.json
@@ -148,7 +148,9 @@
       "optional": true
     }
   },
-  "dependencies": {},
+  "dependencies": {
+    "redis": "^5.8.2"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/libraries/typescript/packages/inspector/package.json
+++ b/libraries/typescript/packages/inspector/package.json
@@ -148,9 +148,7 @@
       "optional": true
     }
   },
-  "dependencies": {
-    "redis": "^5.8.2"
-  },
+  "dependencies": {},
   "publishConfig": {
     "access": "public"
   },
@@ -180,6 +178,7 @@
     "react-router": "^8.3.0",
     "react-resizable-panels": "^4.6.4",
     "rate-limiter-flexible": "^11.2.0",
+    "redis": "^5.8.2",
     "rollup-plugin-visualizer": "^6.0.3",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",

--- a/libraries/typescript/packages/inspector/src/server/cli.ts
+++ b/libraries/typescript/packages/inspector/src/server/cli.ts
@@ -135,6 +135,13 @@ registerInspectorShell(app, {
   manufactChatUrl: process.env.MANUFACT_CHAT_URL,
 });
 
+process.once("SIGTERM", () => {
+  void oauthProxyStateStore.close?.();
+});
+process.once("SIGINT", () => {
+  void oauthProxyStateStore.close?.();
+});
+
 async function startServer() {
   try {
     const port = await findAvailablePort(startPort);

--- a/libraries/typescript/packages/inspector/src/server/cli.ts
+++ b/libraries/typescript/packages/inspector/src/server/cli.ts
@@ -99,8 +99,7 @@ const mcpAllowedOrigins = parseOrigins(
     process.env.INSPECTOR_OAUTH_ALLOWED_ORIGINS
 );
 const production = process.env.NODE_ENV === "production";
-const redisUrl =
-  process.env.INSPECTOR_OAUTH_REDIS_URL ?? process.env.REDIS_URL;
+const redisUrl = process.env.INSPECTOR_OAUTH_REDIS_URL ?? process.env.REDIS_URL;
 const encryptionKeyValue = process.env.INSPECTOR_OAUTH_ENCRYPTION_KEY;
 if (production && (!redisUrl || !encryptionKeyValue)) {
   throw new Error(
@@ -189,7 +188,9 @@ function createConfidentialClientResolver(
   try {
     parsed = JSON.parse(value);
   } catch {
-    throw new Error("INSPECTOR_OAUTH_CONFIDENTIAL_CLIENTS_JSON must be valid JSON");
+    throw new Error(
+      "INSPECTOR_OAUTH_CONFIDENTIAL_CLIENTS_JSON must be valid JSON"
+    );
   }
   if (!Array.isArray(parsed)) {
     throw new Error(
@@ -202,7 +203,9 @@ function createConfidentialClientResolver(
     }
     const record = entry as Record<string, unknown>;
     const serverUrls = Array.isArray(record.serverUrls)
-      ? record.serverUrls.filter((url): url is string => typeof url === "string")
+      ? record.serverUrls.filter(
+          (url): url is string => typeof url === "string"
+        )
       : [];
     const clientId = record.clientId;
     const clientSecret = record.clientSecret;
@@ -220,9 +223,7 @@ function createConfidentialClientResolver(
       serverUrls: serverUrls.map((url) => canonicalUrl(url)),
       clientId,
       clientSecret,
-      authMethod: authMethod as
-        | "client_secret_basic"
-        | "client_secret_post",
+      authMethod: authMethod as "client_secret_basic" | "client_secret_post",
     };
   });
   return ({ serverUrl, clientId }) => {

--- a/libraries/typescript/packages/inspector/src/server/cli.ts
+++ b/libraries/typescript/packages/inspector/src/server/cli.ts
@@ -2,10 +2,15 @@
 
 import { serve } from "@hono/node-server";
 import { Hono } from "hono";
-import { cors } from "hono/cors";
 import open from "open";
 import { registerInspectorShell } from "./inspector-shell.js";
 import { registerInspectorProxyRoutes } from "./proxy-routes.js";
+import {
+  createMemoryOAuthProxyStateStore,
+  createRedisOAuthProxyStateStore,
+  decodeOAuthProxyEncryptionKey,
+} from "./proxy/index.js";
+import type { OAuthProxyConfidentialClientResolver } from "./proxy/oauth-proxy.js";
 import {
   findAvailablePort,
   formatErrorDiagnostic,
@@ -77,14 +82,6 @@ Examples:
 }
 
 const app = new Hono();
-
-app.use(
-  "*",
-  cors({
-    origin: "*",
-    exposeHeaders: ["*"],
-  })
-);
 // The CLI is primarily local dev tooling, where proxying to localhost MCP
 // servers is the main use case — but the published Docker image runs this same
 // CLI with NODE_ENV=production on a public port, where loopback proxying is
@@ -94,10 +91,44 @@ const allowLoopback = process.env.INSPECTOR_ALLOW_LOOPBACK
   ? process.env.INSPECTOR_ALLOW_LOOPBACK === "true"
   : process.env.NODE_ENV !== "production";
 
+const oauthAllowedOrigins = parseOrigins(
+  process.env.INSPECTOR_OAUTH_ALLOWED_ORIGINS
+);
+const mcpAllowedOrigins = parseOrigins(
+  process.env.INSPECTOR_MCP_ALLOWED_ORIGINS ??
+    process.env.INSPECTOR_OAUTH_ALLOWED_ORIGINS
+);
+const production = process.env.NODE_ENV === "production";
+const redisUrl =
+  process.env.INSPECTOR_OAUTH_REDIS_URL ?? process.env.REDIS_URL;
+const encryptionKeyValue = process.env.INSPECTOR_OAUTH_ENCRYPTION_KEY;
+if (production && (!redisUrl || !encryptionKeyValue)) {
+  throw new Error(
+    "Production Inspector OAuth requires INSPECTOR_OAUTH_REDIS_URL (or REDIS_URL) and INSPECTOR_OAUTH_ENCRYPTION_KEY"
+  );
+}
+if (production && oauthAllowedOrigins.length === 0) {
+  throw new Error(
+    "Production Inspector OAuth requires INSPECTOR_OAUTH_ALLOWED_ORIGINS"
+  );
+}
+const oauthProxyStateStore = redisUrl
+  ? createRedisOAuthProxyStateStore({
+      url: redisUrl,
+      encryptionKey: decodeOAuthProxyEncryptionKey(encryptionKeyValue ?? ""),
+    })
+  : createMemoryOAuthProxyStateStore();
+const oauthProxyConfidentialClientResolver = createConfidentialClientResolver(
+  process.env.INSPECTOR_OAUTH_CONFIDENTIAL_CLIENTS_JSON
+);
+
 registerInspectorProxyRoutes(app, {
   autoConnectUrl: mcpUrl,
-  oauthProxyAllowedOrigins: [],
+  oauthProxyAllowedOrigins: oauthAllowedOrigins,
+  mcpProxyAllowedOrigins: mcpAllowedOrigins,
   oauthProxyAllowLoopback: allowLoopback,
+  oauthProxyStateStore,
+  oauthProxyConfidentialClientResolver,
 });
 
 registerInspectorShell(app, {
@@ -141,3 +172,82 @@ async function startServer() {
 }
 
 startServer();
+
+function parseOrigins(value: string | undefined): string[] {
+  if (!value) return [];
+  return value
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+}
+
+function createConfidentialClientResolver(
+  value: string | undefined
+): OAuthProxyConfidentialClientResolver | undefined {
+  if (!value) return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new Error("INSPECTOR_OAUTH_CONFIDENTIAL_CLIENTS_JSON must be valid JSON");
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error(
+      "INSPECTOR_OAUTH_CONFIDENTIAL_CLIENTS_JSON must be an array"
+    );
+  }
+  const clients = parsed.map((entry) => {
+    if (!entry || typeof entry !== "object") {
+      throw new Error("Invalid Inspector confidential client entry");
+    }
+    const record = entry as Record<string, unknown>;
+    const serverUrls = Array.isArray(record.serverUrls)
+      ? record.serverUrls.filter((url): url is string => typeof url === "string")
+      : [];
+    const clientId = record.clientId;
+    const clientSecret = record.clientSecret;
+    const authMethod = record.authMethod;
+    if (
+      serverUrls.length === 0 ||
+      typeof clientId !== "string" ||
+      typeof clientSecret !== "string" ||
+      (authMethod !== "client_secret_basic" &&
+        authMethod !== "client_secret_post")
+    ) {
+      throw new Error("Invalid Inspector confidential client entry");
+    }
+    return {
+      serverUrls: serverUrls.map((url) => canonicalUrl(url)),
+      clientId,
+      clientSecret,
+      authMethod: authMethod as
+        | "client_secret_basic"
+        | "client_secret_post",
+    };
+  });
+  return ({ serverUrl, clientId }) => {
+    const match = clients.find(
+      (client) =>
+        client.clientId === clientId &&
+        client.serverUrls.some((url) => url === canonicalUrl(serverUrl))
+    );
+    return match
+      ? {
+          clientSecret: match.clientSecret,
+          authMethod: match.authMethod,
+        }
+      : undefined;
+  };
+}
+
+function canonicalUrl(value: string): string {
+  const url = new URL(value);
+  url.hash = "";
+  if (
+    (url.protocol === "https:" && url.port === "443") ||
+    (url.protocol === "http:" && url.port === "80")
+  ) {
+    url.port = "";
+  }
+  return url.toString().replace(/\/$/, "");
+}

--- a/libraries/typescript/packages/inspector/src/server/index.ts
+++ b/libraries/typescript/packages/inspector/src/server/index.ts
@@ -14,3 +14,13 @@ export {
   registerInspectorProxyRoutes,
   type InspectorProxyRoutesConfig,
 } from "./proxy-routes.js";
+export {
+  createMemoryOAuthProxyStateStore,
+  createRedisOAuthProxyStateStore,
+  decodeOAuthProxyEncryptionKey,
+  type OAuthProxyStateStore,
+} from "./proxy/oauth-state-store.js";
+export type {
+  OAuthProxyConfidentialClient,
+  OAuthProxyConfidentialClientResolver,
+} from "./proxy/oauth-proxy.js";

--- a/libraries/typescript/packages/inspector/src/server/proxy-routes.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy-routes.ts
@@ -73,8 +73,7 @@ export function registerInspectorProxyRoutes(
       allowLoopback,
       rateLimiter: apiRateLimiter,
       stateStore: config?.oauthProxyStateStore,
-      resolveConfidentialClient:
-        config?.oauthProxyConfidentialClientResolver,
+      resolveConfidentialClient: config?.oauthProxyConfidentialClientResolver,
     });
   }
 

--- a/libraries/typescript/packages/inspector/src/server/proxy-routes.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy-routes.ts
@@ -1,6 +1,11 @@
 import type { Hono } from "hono";
 import { RateLimiterMemory } from "rate-limiter-flexible";
-import { mountMcpProxy, mountOAuthProxy } from "./proxy/index.js";
+import {
+  mountMcpProxy,
+  mountOAuthProxy,
+  type OAuthProxyConfidentialClientResolver,
+  type OAuthProxyStateStore,
+} from "./proxy/index.js";
 import {
   INSPECTOR_API_RATE_LIMIT,
   INSPECTOR_RATE_LIMIT_WINDOW_SECONDS,
@@ -11,10 +16,18 @@ export type InspectorProxyRoutesConfig = {
   autoConnectUrl?: string | null;
   /** Explicit cross-origin callers of the OAuth BFF. Same-origin is implicit. */
   oauthProxyAllowedOrigins?: readonly string[];
+  /** Explicit cross-origin callers of the MCP CORS proxy. */
+  mcpProxyAllowedOrigins?: readonly string[];
   /** Allow the OAuth BFF to reach loopback servers in local development. */
   oauthProxyAllowLoopback?: boolean;
   /** Mount OAuth BFF routes (default true). */
   oauth?: boolean;
+  /** Mount MCP CORS proxy routes (default true). */
+  mcp?: boolean;
+  /** Durable state shared by every OAuth proxy replica. */
+  oauthProxyStateStore?: OAuthProxyStateStore;
+  /** Server-side provider configuration for confidential OAuth clients. */
+  oauthProxyConfidentialClientResolver?: OAuthProxyConfidentialClientResolver;
 };
 
 /**
@@ -42,11 +55,14 @@ export function registerInspectorProxyRoutes(
     });
   });
 
-  mountMcpProxy(app, {
-    path: p("/inspector/api/proxy"),
-    allowLoopback,
-    rateLimiter: apiRateLimiter,
-  });
+  if (config?.mcp !== false) {
+    mountMcpProxy(app, {
+      path: p("/inspector/api/proxy"),
+      allowLoopback,
+      rateLimiter: apiRateLimiter,
+      allowedOrigins: config?.mcpProxyAllowedOrigins,
+    });
+  }
 
   if (mountOAuth) {
     mountOAuthProxy(app, {
@@ -56,6 +72,9 @@ export function registerInspectorProxyRoutes(
       allowedOrigins: config?.oauthProxyAllowedOrigins ?? [],
       allowLoopback,
       rateLimiter: apiRateLimiter,
+      stateStore: config?.oauthProxyStateStore,
+      resolveConfidentialClient:
+        config?.oauthProxyConfidentialClientResolver,
     });
   }
 

--- a/libraries/typescript/packages/inspector/src/server/proxy/index.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy/index.ts
@@ -1,8 +1,6 @@
 export { mountMcpProxy } from "./mcp-proxy.js";
 export { mountOAuthProxy } from "./oauth-proxy.js";
-export type {
-  OAuthProxyConfidentialClientResolver,
-} from "./oauth-proxy.js";
+export type { OAuthProxyConfidentialClientResolver } from "./oauth-proxy.js";
 export {
   createMemoryOAuthProxyStateStore,
   createRedisOAuthProxyStateStore,

--- a/libraries/typescript/packages/inspector/src/server/proxy/index.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy/index.ts
@@ -1,2 +1,11 @@
 export { mountMcpProxy } from "./mcp-proxy.js";
 export { mountOAuthProxy } from "./oauth-proxy.js";
+export type {
+  OAuthProxyConfidentialClientResolver,
+} from "./oauth-proxy.js";
+export {
+  createMemoryOAuthProxyStateStore,
+  createRedisOAuthProxyStateStore,
+  decodeOAuthProxyEncryptionKey,
+  type OAuthProxyStateStore,
+} from "./oauth-state-store.js";

--- a/libraries/typescript/packages/inspector/src/server/proxy/mcp-proxy.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy/mcp-proxy.ts
@@ -73,6 +73,8 @@ interface McpProxyOptions {
   enableLogging?: boolean;
   /** Shared process-local limiter for Inspector proxy and OAuth routes. */
   rateLimiter?: RateLimiterMemory;
+  /** Explicit browser origins; an empty list preserves the anonymous wildcard default. */
+  allowedOrigins?: readonly string[];
 }
 
 /** Whether an MCP response must remain streaming instead of being buffered. */
@@ -152,7 +154,7 @@ export function mountMcpProxy(app: Hono, options: McpProxyOptions = {}): void {
   app.use(
     `${basePath}/*`,
     cors({
-      origin: "*",
+      origin: createCorsOriginResolver(options.allowedOrigins ?? []),
       allowHeaders: [
         "Authorization",
         "Content-Type",
@@ -162,10 +164,21 @@ export function mountMcpProxy(app: Hono, options: McpProxyOptions = {}): void {
         "Mcp-Session-Id",
         "mcp-session-id",
         "mcp-protocol-version",
+        "Mcp-Protocol-Version",
+        "Mcp-Method",
+        "Mcp-Name",
+        "Last-Event-ID",
         "X-Server-Id",
         "X-Requested-With",
       ],
-      exposeHeaders: ["*"],
+      exposeHeaders: [
+        "Mcp-Session-Id",
+        "Mcp-Protocol-Version",
+        "WWW-Authenticate",
+        "Location",
+        "Retry-After",
+        "X-Accel-Buffering",
+      ],
     })
   );
 
@@ -369,6 +382,29 @@ export function mountMcpProxy(app: Hono, options: McpProxyOptions = {}): void {
       );
     }
   });
+}
+
+function createCorsOriginResolver(
+  allowedOrigins: readonly string[]
+): "*" | ((origin: string) => string) {
+  if (allowedOrigins.length === 0) return "*";
+  const origins = new Set(allowedOrigins.map(normalizeOrigin));
+  return (origin: string) => {
+    try {
+      const normalized = normalizeOrigin(origin);
+      return origins.has(normalized) ? normalized : "";
+    } catch {
+      return "";
+    }
+  };
+}
+
+function normalizeOrigin(origin: string): string {
+  const url = new URL(origin);
+  if (url.pathname !== "/" || url.search || url.hash) {
+    throw new Error(`MCP proxy allowed origin must be an origin: ${origin}`);
+  }
+  return url.origin;
 }
 
 function deleteHeader(headers: Record<string, string>, name: string): void {

--- a/libraries/typescript/packages/inspector/src/server/proxy/oauth-proxy.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy/oauth-proxy.ts
@@ -19,6 +19,10 @@ import {
   INSPECTOR_RATE_LIMIT_WINDOW_SECONDS,
   inspectorRateLimitResponse,
 } from "../rate-limit.js";
+import {
+  createMemoryOAuthProxyStateStore,
+  type OAuthProxyStateStore,
+} from "./oauth-state-store.js";
 
 type OAuthEndpointKind =
   | "registration"
@@ -44,6 +48,21 @@ type ConfidentialClient = {
   authMethod: "client_secret_basic" | "client_secret_post";
   expiresAt: number;
 };
+
+export type OAuthProxyConfidentialClient = {
+  clientSecret: string;
+  authMethod: "client_secret_basic" | "client_secret_post";
+  expiresAt?: number;
+};
+
+export type OAuthProxyConfidentialClientResolver = (options: {
+  serverUrl: string;
+  targetUrl: string;
+  clientId: string;
+}) =>
+  | OAuthProxyConfidentialClient
+  | undefined
+  | Promise<OAuthProxyConfidentialClient | undefined>;
 
 type ProxyRequest = {
   serverUrl?: unknown;
@@ -79,6 +98,10 @@ interface OAuthProxyOptions {
   ) => Promise<boolean> | boolean;
   /** Shared process-local limiter for Inspector proxy and OAuth routes. */
   rateLimiter?: RateLimiterMemory;
+  /** Durable store shared by every Inspector replica. */
+  stateStore?: OAuthProxyStateStore;
+  /** Server-side resolver for configured confidential clients (never browser-visible). */
+  resolveConfidentialClient?: OAuthProxyConfidentialClientResolver;
 }
 
 const SAFE_REQUEST_HEADERS = new Set([
@@ -126,7 +149,10 @@ export function mountOAuthProxy(
       points: INSPECTOR_API_RATE_LIMIT,
       duration: INSPECTOR_RATE_LIMIT_WINDOW_SECONDS,
     }),
+    stateStore,
+    resolveConfidentialClient,
   } = options;
+  const durableStateStore = stateStore ?? createMemoryOAuthProxyStateStore();
   const origins = new Set(allowedOrigins.map(normalizeOrigin));
   const bindings = new Map<string, Binding>();
   const confidentialClients = new Map<string, ConfidentialClient>();
@@ -180,7 +206,12 @@ export function mountOAuthProxy(
     }
     const target = targetResult.url;
     const key = canonicalUrl(serverUrl);
-    const binding = getBinding(bindings, key);
+    let binding: Binding;
+    try {
+      binding = await loadBinding(durableStateStore, bindings, key);
+    } catch (error) {
+      return proxyError(c, error, enableLogging);
+    }
     let metadataKind = classifyMetadataTarget(serverUrl, target, binding);
     if (!metadataKind && binding.authorizationServers.size === 0) {
       try {
@@ -191,9 +222,12 @@ export function mountOAuthProxy(
           timeoutMs,
           maxResponseBodyBytes
         );
-        bindings.set(key, binding);
+        await saveBinding(durableStateStore, bindings, key, binding);
         metadataKind = classifyMetadataTarget(serverUrl, target, binding);
-      } catch {
+      } catch (error) {
+        if (error instanceof OAuthProxyStateStoreError) {
+          return proxyError(c, error, enableLogging);
+        }
         // The requested target remains unauthorized below.
       }
     }
@@ -244,8 +278,7 @@ export function mountOAuthProxy(
         );
       }
       binding.updatedAt = Date.now();
-      bindings.set(key, binding);
-      pruneBindings(bindings);
+      await saveBinding(durableStateStore, bindings, key, binding);
 
       return c.body(raw, 200, {
         "Content-Type":
@@ -300,7 +333,12 @@ export function mountOAuthProxy(
     }
 
     const bindingKey = canonicalUrl(serverUrl);
-    const binding = getBinding(bindings, bindingKey);
+    let binding: Binding;
+    try {
+      binding = await loadBinding(durableStateStore, bindings, bindingKey);
+    } catch (error) {
+      return proxyError(c, error, enableLogging);
+    }
     if (binding.endpoints.size === 0) {
       try {
         await hydrateBinding(
@@ -310,8 +348,12 @@ export function mountOAuthProxy(
           timeoutMs,
           maxResponseBodyBytes
         );
-        bindings.set(bindingKey, binding);
-        pruneBindings(bindings);
+        await saveBinding(
+          durableStateStore,
+          bindings,
+          bindingKey,
+          binding
+        );
       } catch (error) {
         return proxyError(c, error, enableLogging);
       }
@@ -337,11 +379,15 @@ export function mountOAuthProxy(
           new URL(callbackPath, publicOrigin).toString()
         );
       } else {
-        body = applyConfidentialClientAuthentication({
+        body = await applyConfidentialClientAuthentication({
           body,
           headers,
           bindingKey,
           clients: confidentialClients,
+          stateStore: durableStateStore,
+          serverUrl: serverUrl.toString(),
+          targetUrl: target.toString(),
+          resolveConfidentialClient,
         });
       }
       if (
@@ -382,11 +428,12 @@ export function mountOAuthProxy(
         typeof responseBody === "object" &&
         !Array.isArray(responseBody)
       ) {
-        responseBody = retainConfidentialClient({
+        responseBody = await retainConfidentialClient({
           responseBody: responseBody as Record<string, unknown>,
           binding,
           bindingKey,
           clients: confidentialClients,
+          stateStore: durableStateStore,
         });
       }
       return c.json({
@@ -777,16 +824,17 @@ function serializeBody(body: unknown, headers: Headers): string | undefined {
 }
 
 function confidentialClientKey(bindingKey: string, clientId: string): string {
-  return `${bindingKey}\u0000${clientId}`;
+  return `client:${Buffer.from(`${bindingKey}\u0000${clientId}`, "utf8").toString("base64url")}`;
 }
 
-function retainConfidentialClient(options: {
+async function retainConfidentialClient(options: {
   responseBody: Record<string, unknown>;
   binding: Binding;
   bindingKey: string;
   clients: Map<string, ConfidentialClient>;
-}): Record<string, unknown> {
-  const { responseBody, binding, bindingKey, clients } = options;
+  stateStore: OAuthProxyStateStore;
+}): Promise<Record<string, unknown>> {
+  const { responseBody, binding, bindingKey, clients, stateStore } = options;
   const clientId = responseBody.client_id;
   const clientSecret = responseBody.client_secret;
   if (typeof clientId !== "string" || typeof clientSecret !== "string") {
@@ -804,21 +852,30 @@ function retainConfidentialClient(options: {
   const upstreamExpiry = responseBody.client_secret_expires_at;
   const expiresAt =
     upstreamExpiry === 0
-      ? Number.POSITIVE_INFINITY
+      ? Date.now() + CONFIDENTIAL_CLIENT_TTL_MS
       : typeof upstreamExpiry === "number" && upstreamExpiry > 0
         ? upstreamExpiry * 1000
         : Date.now() + CONFIDENTIAL_CLIENT_TTL_MS;
 
   pruneConfidentialClients(clients);
-  clients.set(confidentialClientKey(bindingKey, clientId), {
+  const client = {
     clientSecret,
     authMethod,
     expiresAt,
-  });
+  } satisfies ConfidentialClient;
+  const key = confidentialClientKey(bindingKey, clientId);
+  clients.set(key, client);
+  await storeSet(
+    stateStore,
+    key,
+    client,
+    Math.max(1, expiresAt - Date.now())
+  );
   while (clients.size > MAX_CONFIDENTIAL_CLIENTS) {
     const oldest = clients.keys().next().value as string | undefined;
     if (!oldest) break;
     clients.delete(oldest);
+    await storeDelete(stateStore, oldest);
   }
 
   const browserSafe = { ...responseBody };
@@ -828,13 +885,26 @@ function retainConfidentialClient(options: {
   return browserSafe;
 }
 
-function applyConfidentialClientAuthentication(options: {
+async function applyConfidentialClientAuthentication(options: {
   body: string | undefined;
   headers: Headers;
   bindingKey: string;
   clients: Map<string, ConfidentialClient>;
-}): string | undefined {
-  const { body, headers, bindingKey, clients } = options;
+  stateStore: OAuthProxyStateStore;
+  serverUrl: string;
+  targetUrl: string;
+  resolveConfidentialClient?: OAuthProxyConfidentialClientResolver;
+}): Promise<string | undefined> {
+  const {
+    body,
+    headers,
+    bindingKey,
+    clients,
+    stateStore,
+    serverUrl,
+    targetUrl,
+    resolveConfidentialClient,
+  } = options;
   if (
     !body ||
     !(headers.get("content-type") ?? "").includes(
@@ -849,10 +919,37 @@ function applyConfidentialClientAuthentication(options: {
   if (!clientId) return body;
 
   const key = confidentialClientKey(bindingKey, clientId);
-  const client = clients.get(key);
+  let client = clients.get(key);
+  if (client === undefined) {
+    client = await storeGet<ConfidentialClient>(stateStore, key);
+    if (client !== undefined) clients.set(key, client);
+  }
+  if (client === undefined && resolveConfidentialClient) {
+    const resolved = await resolveConfidentialClient({
+      serverUrl,
+      targetUrl,
+      clientId,
+    });
+    if (resolved) {
+      client = {
+        clientSecret: resolved.clientSecret,
+        authMethod: resolved.authMethod,
+        expiresAt:
+          resolved.expiresAt ?? Date.now() + CONFIDENTIAL_CLIENT_TTL_MS,
+      };
+      clients.set(key, client);
+      await storeSet(
+        stateStore,
+        key,
+        client,
+        Math.max(1, client.expiresAt - Date.now())
+      );
+    }
+  }
   if (!client) return body;
   if (client.expiresAt <= Date.now()) {
     clients.delete(key);
+    await storeDelete(stateStore, key);
     return body;
   }
 
@@ -947,18 +1044,83 @@ function parseObject(value: string): Record<string, unknown> {
   return parsed as Record<string, unknown>;
 }
 
-function getBinding(bindings: Map<string, Binding>, key: string): Binding {
+async function loadBinding(
+  stateStore: OAuthProxyStateStore,
+  bindings: Map<string, Binding>,
+  key: string
+): Promise<Binding> {
+  const persisted = await storeGet<SerializedBinding>(
+    stateStore,
+    bindingStoreKey(key)
+  );
+  if (persisted !== undefined) {
+    const binding = deserializeBinding(persisted);
+    if (Date.now() - binding.updatedAt <= BINDING_TTL_MS) {
+      bindings.set(key, binding);
+      return binding;
+    }
+    await storeDelete(stateStore, bindingStoreKey(key));
+  }
   const existing = bindings.get(key);
   if (existing && Date.now() - existing.updatedAt <= BINDING_TTL_MS) {
     return existing;
   }
   bindings.delete(key);
+  return emptyBinding();
+}
+
+async function saveBinding(
+  stateStore: OAuthProxyStateStore,
+  bindings: Map<string, Binding>,
+  key: string,
+  binding: Binding
+): Promise<void> {
+  bindings.set(key, binding);
+  await storeSet(
+    stateStore,
+    bindingStoreKey(key),
+    serializeBinding(binding),
+    BINDING_TTL_MS
+  );
+  pruneBindings(bindings);
+}
+
+function emptyBinding(): Binding {
   return {
     authorizationServers: new Set(),
     endpoints: new Map(),
     tokenEndpointAuthMethods: new Set(),
     updatedAt: Date.now(),
   };
+}
+
+type SerializedBinding = {
+  authorizationServers: string[];
+  endpoints: Array<[string, OAuthEndpointKind]>;
+  tokenEndpointAuthMethods: string[];
+  updatedAt: number;
+};
+
+function serializeBinding(binding: Binding): SerializedBinding {
+  return {
+    authorizationServers: [...binding.authorizationServers],
+    endpoints: [...binding.endpoints.entries()],
+    tokenEndpointAuthMethods: [...binding.tokenEndpointAuthMethods],
+    updatedAt: binding.updatedAt,
+  };
+}
+
+function deserializeBinding(value: SerializedBinding): Binding {
+  return {
+    authorizationServers: new Set(value.authorizationServers),
+    endpoints: new Map(value.endpoints),
+    tokenEndpointAuthMethods: new Set(value.tokenEndpointAuthMethods),
+    updatedAt: value.updatedAt,
+  };
+}
+
+function bindingStoreKey(key: string): string {
+  return `binding:${Buffer.from(key, "utf8").toString("base64url")}`;
 }
 
 function pruneBindings(bindings: Map<string, Binding>): void {
@@ -1136,6 +1298,9 @@ function log(enabled: boolean, message: string): void {
 function proxyError(c: Context, error: unknown, logging: boolean): Response {
   const message = error instanceof Error ? error.message : "Unknown error";
   if (logging) console.error("[OAuth BFF]", message);
+  if (error instanceof OAuthProxyStateStoreError) {
+    return c.json({ error: "OAuth proxy state store unavailable" }, 503);
+  }
   if (error instanceof BodyTooLargeError) {
     return c.json({ error: "Upstream response too large" }, 502);
   }
@@ -1150,3 +1315,47 @@ function proxyError(c: Context, error: unknown, logging: boolean): Response {
 
 class BodyTooLargeError extends Error {}
 class InvalidUpstreamError extends Error {}
+class OAuthProxyStateStoreError extends Error {}
+
+async function storeGet<T>(
+  store: OAuthProxyStateStore,
+  key: string
+): Promise<T | undefined> {
+  try {
+    return await store.get<T>(key);
+  } catch (error) {
+    throw new OAuthProxyStateStoreError(
+      error instanceof Error ? error.message : "OAuth proxy state read failed"
+    );
+  }
+}
+
+async function storeSet<T>(
+  store: OAuthProxyStateStore,
+  key: string,
+  value: T,
+  ttlMs: number
+): Promise<void> {
+  try {
+    await store.set(key, value, ttlMs);
+  } catch (error) {
+    throw new OAuthProxyStateStoreError(
+      error instanceof Error ? error.message : "OAuth proxy state write failed"
+    );
+  }
+}
+
+async function storeDelete(
+  store: OAuthProxyStateStore,
+  key: string
+): Promise<void> {
+  try {
+    await store.delete(key);
+  } catch (error) {
+    throw new OAuthProxyStateStoreError(
+      error instanceof Error
+        ? error.message
+        : "OAuth proxy state delete failed"
+    );
+  }
+}

--- a/libraries/typescript/packages/inspector/src/server/proxy/oauth-proxy.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy/oauth-proxy.ts
@@ -909,9 +909,14 @@ async function applyConfidentialClientAuthentication(options: {
   if (!clientId) return body;
 
   const key = confidentialClientKey(bindingKey, clientId);
-  let client = await storeGet<ConfidentialClient>(stateStore, key);
-  if (client !== undefined) clients.set(key, client);
-  else client = clients.get(key);
+  const persistedClient = await storeGet<unknown>(stateStore, key);
+  let client: ConfidentialClient | undefined;
+  if (isConfidentialClient(persistedClient)) {
+    client = persistedClient;
+    clients.set(key, persistedClient);
+  } else {
+    client = clients.get(key);
+  }
   if (client === undefined && resolveConfidentialClient) {
     const resolved = await resolveConfidentialClient({
       serverUrl,
@@ -967,6 +972,18 @@ function pruneConfidentialClients(
   for (const [key, client] of clients) {
     if (client.expiresAt <= now) clients.delete(key);
   }
+}
+
+function isConfidentialClient(value: unknown): value is ConfidentialClient {
+  return Boolean(
+    value &&
+    typeof value === "object" &&
+    typeof (value as ConfidentialClient).clientSecret === "string" &&
+    ((value as ConfidentialClient).authMethod === "client_secret_basic" ||
+      (value as ConfidentialClient).authMethod === "client_secret_post") &&
+    typeof (value as ConfidentialClient).expiresAt === "number" &&
+    Number.isFinite((value as ConfidentialClient).expiresAt)
+  );
 }
 
 async function readRequestCapped(
@@ -1099,6 +1116,14 @@ function serializeBinding(binding: Binding): SerializedBinding {
 }
 
 function deserializeBinding(value: SerializedBinding): Binding {
+  if (
+    !Array.isArray(value.authorizationServers) ||
+    !Array.isArray(value.endpoints) ||
+    !Array.isArray(value.tokenEndpointAuthMethods) ||
+    typeof value.updatedAt !== "number"
+  ) {
+    throw new InvalidUpstreamError("OAuth proxy state is invalid");
+  }
   return {
     authorizationServers: new Set(value.authorizationServers),
     endpoints: new Map(value.endpoints),

--- a/libraries/typescript/packages/inspector/src/server/proxy/oauth-proxy.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy/oauth-proxy.ts
@@ -348,12 +348,7 @@ export function mountOAuthProxy(
           timeoutMs,
           maxResponseBodyBytes
         );
-        await saveBinding(
-          durableStateStore,
-          bindings,
-          bindingKey,
-          binding
-        );
+        await saveBinding(durableStateStore, bindings, bindingKey, binding);
       } catch (error) {
         return proxyError(c, error, enableLogging);
       }
@@ -865,12 +860,7 @@ async function retainConfidentialClient(options: {
   } satisfies ConfidentialClient;
   const key = confidentialClientKey(bindingKey, clientId);
   clients.set(key, client);
-  await storeSet(
-    stateStore,
-    key,
-    client,
-    Math.max(1, expiresAt - Date.now())
-  );
+  await storeSet(stateStore, key, client, Math.max(1, expiresAt - Date.now()));
   while (clients.size > MAX_CONFIDENTIAL_CLIENTS) {
     const oldest = clients.keys().next().value as string | undefined;
     if (!oldest) break;
@@ -1353,9 +1343,7 @@ async function storeDelete(
     await store.delete(key);
   } catch (error) {
     throw new OAuthProxyStateStoreError(
-      error instanceof Error
-        ? error.message
-        : "OAuth proxy state delete failed"
+      error instanceof Error ? error.message : "OAuth proxy state delete failed"
     );
   }
 }

--- a/libraries/typescript/packages/inspector/src/server/proxy/oauth-proxy.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy/oauth-proxy.ts
@@ -909,11 +909,9 @@ async function applyConfidentialClientAuthentication(options: {
   if (!clientId) return body;
 
   const key = confidentialClientKey(bindingKey, clientId);
-  let client = clients.get(key);
-  if (client === undefined) {
-    client = await storeGet<ConfidentialClient>(stateStore, key);
-    if (client !== undefined) clients.set(key, client);
-  }
+  let client = await storeGet<ConfidentialClient>(stateStore, key);
+  if (client !== undefined) clients.set(key, client);
+  else client = clients.get(key);
   if (client === undefined && resolveConfidentialClient) {
     const resolved = await resolveConfidentialClient({
       serverUrl,

--- a/libraries/typescript/packages/inspector/src/server/proxy/oauth-state-store.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy/oauth-state-store.ts
@@ -77,7 +77,9 @@ export function createRedisOAuthProxyStateStore(options: {
     },
     async set<T>(key: string, value: T, ttlMs: number): Promise<void> {
       const encoded = await encrypt(value, options.encryptionKey);
-      await (await ready()).set(keyPrefix + key, encoded, {
+      await (
+        await ready()
+      ).set(keyPrefix + key, encoded, {
         PX: Math.max(1, Math.ceil(ttlMs)),
       });
     },

--- a/libraries/typescript/packages/inspector/src/server/proxy/oauth-state-store.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy/oauth-state-store.ts
@@ -1,0 +1,163 @@
+import { createClient } from "redis";
+
+/**
+ * Durable state boundary used by the hosted OAuth BFF.
+ *
+ * Implementations must apply the supplied TTL and must not log values. The
+ * proxy stores only metadata bindings and confidential-client credentials at
+ * this boundary; browser-visible OAuth responses are always sanitized before
+ * they leave the proxy.
+ */
+export interface OAuthProxyStateStore {
+  get<T>(key: string): Promise<T | undefined>;
+  set<T>(key: string, value: T, ttlMs: number): Promise<void>;
+  delete(key: string): Promise<void>;
+  close?(): Promise<void>;
+}
+
+/** Process-local fallback for local development and unit tests. */
+export function createMemoryOAuthProxyStateStore(): OAuthProxyStateStore {
+  const values = new Map<string, { value: unknown; expiresAt: number }>();
+  return {
+    async get<T>(key: string): Promise<T | undefined> {
+      const entry = values.get(key);
+      if (!entry || entry.expiresAt <= Date.now()) {
+        values.delete(key);
+        return undefined;
+      }
+      return structuredClone(entry.value) as T;
+    },
+    async set<T>(key: string, value: T, ttlMs: number): Promise<void> {
+      values.set(key, {
+        value: structuredClone(value),
+        expiresAt: Date.now() + Math.max(1, ttlMs),
+      });
+    },
+    async delete(key: string): Promise<void> {
+      values.delete(key);
+    },
+  };
+}
+
+/**
+ * Redis-backed store for Railway/production deployments.
+ *
+ * Values are encrypted with AES-256-GCM before persistence. The encryption key
+ * is supplied by the deployment secret manager and never returned to callers.
+ */
+export function createRedisOAuthProxyStateStore(options: {
+  url: string;
+  encryptionKey: Uint8Array;
+  keyPrefix?: string;
+}): OAuthProxyStateStore {
+  if (!options.url) throw new TypeError("Redis URL is required");
+  if (options.encryptionKey.byteLength !== 32) {
+    throw new TypeError("OAuth proxy encryption key must be 32 bytes");
+  }
+
+  const client = createClient({ url: options.url });
+  // Redis requires an error listener; keep diagnostics out of logs because
+  // connection URLs can contain credentials.
+  client.on("error", () => undefined);
+  const keyPrefix = options.keyPrefix ?? "mcp-use:inspector:oauth:";
+  let connecting: Promise<void> | undefined;
+  const ready = async () => {
+    if (!client.isReady) {
+      connecting ??= client.connect().then(() => undefined);
+      await connecting;
+    }
+    return client;
+  };
+
+  return {
+    async get<T>(key: string): Promise<T | undefined> {
+      const raw = await (await ready()).get(keyPrefix + key);
+      if (raw === null) return undefined;
+      return (await decrypt(raw, options.encryptionKey)) as T;
+    },
+    async set<T>(key: string, value: T, ttlMs: number): Promise<void> {
+      const encoded = await encrypt(value, options.encryptionKey);
+      await (await ready()).set(keyPrefix + key, encoded, {
+        PX: Math.max(1, Math.ceil(ttlMs)),
+      });
+    },
+    async delete(key: string): Promise<void> {
+      await (await ready()).del(keyPrefix + key);
+    },
+    async close(): Promise<void> {
+      if (client.isOpen) await client.quit();
+    },
+  };
+}
+
+export function decodeOAuthProxyEncryptionKey(value: string): Uint8Array {
+  const normalized = value.trim();
+  let decoded: Uint8Array;
+  try {
+    decoded = Uint8Array.from(Buffer.from(normalized, "base64"));
+  } catch {
+    throw new TypeError("OAuth proxy encryption key must be base64");
+  }
+  if (decoded.byteLength !== 32) {
+    throw new TypeError("OAuth proxy encryption key must decode to 32 bytes");
+  }
+  return decoded;
+}
+
+async function encrypt(value: unknown, key: Uint8Array): Promise<string> {
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const plaintext = new TextEncoder().encode(JSON.stringify(value));
+  const cryptoKey = await crypto.subtle.importKey(
+    "raw",
+    toArrayBuffer(key),
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["encrypt"]
+  );
+  const ciphertext = new Uint8Array(
+    await crypto.subtle.encrypt({ name: "AES-GCM", iv }, cryptoKey, plaintext)
+  );
+  return JSON.stringify({
+    v: 1,
+    iv: Buffer.from(iv).toString("base64url"),
+    ciphertext: Buffer.from(ciphertext).toString("base64url"),
+  });
+}
+
+async function decrypt(value: string, key: Uint8Array): Promise<unknown> {
+  try {
+    const envelope = JSON.parse(value) as {
+      v?: unknown;
+      iv?: unknown;
+      ciphertext?: unknown;
+    };
+    if (
+      envelope.v !== 1 ||
+      typeof envelope.iv !== "string" ||
+      typeof envelope.ciphertext !== "string"
+    ) {
+      throw new Error("Invalid OAuth proxy state envelope");
+    }
+    const cryptoKey = await crypto.subtle.importKey(
+      "raw",
+      toArrayBuffer(key),
+      { name: "AES-GCM", length: 256 },
+      false,
+      ["decrypt"]
+    );
+    const plaintext = await crypto.subtle.decrypt(
+      { name: "AES-GCM", iv: Buffer.from(envelope.iv, "base64url") },
+      cryptoKey,
+      Buffer.from(envelope.ciphertext, "base64url")
+    );
+    return JSON.parse(new TextDecoder().decode(plaintext));
+  } catch {
+    throw new Error("Unable to decrypt OAuth proxy state");
+  }
+}
+
+function toArrayBuffer(value: Uint8Array): ArrayBuffer {
+  const copy = new ArrayBuffer(value.byteLength);
+  new Uint8Array(copy).set(value);
+  return copy;
+}

--- a/libraries/typescript/packages/inspector/tests/unit/mcp-proxy-security.test.ts
+++ b/libraries/typescript/packages/inspector/tests/unit/mcp-proxy-security.test.ts
@@ -9,6 +9,43 @@ afterEach(() => {
 });
 
 describe("Inspector MCP proxy request isolation", () => {
+  it("allows only configured browser origins and MCP protocol headers", async () => {
+    const app = new Hono();
+    mountMcpProxy(app, {
+      path: "/inspector/api/proxy",
+      enableLogging: false,
+      allowedOrigins: ["https://manufact.com", "https://mochipi.dev"],
+    });
+
+    const allowed = await app.fetch(
+      new Request(proxyUrl, {
+        method: "OPTIONS",
+        headers: {
+          Origin: "https://mochipi.dev",
+          "Access-Control-Request-Method": "POST",
+          "Access-Control-Request-Headers": "mcp-method, x-target-url",
+        },
+      }),
+    );
+    expect(allowed.status).toBe(204);
+    expect(allowed.headers.get("access-control-allow-origin")).toBe(
+      "https://mochipi.dev",
+    );
+    expect(allowed.headers.get("access-control-allow-headers")).toContain(
+      "Mcp-Method",
+    );
+
+    const denied = await app.fetch(
+      new Request(proxyUrl, {
+        method: "OPTIONS",
+        headers: { Origin: "https://attacker.example" },
+      }),
+    );
+    expect(denied.headers.get("access-control-allow-origin")).not.toBe(
+      "https://attacker.example",
+    );
+  });
+
   it("does not forward Inspector cookies or browser-origin headers", async () => {
     const fetchFn = vi.fn<typeof fetch>(async (_input, init) => {
       const headers = new Headers(init?.headers);

--- a/libraries/typescript/packages/inspector/tests/unit/mcp-proxy-security.test.ts
+++ b/libraries/typescript/packages/inspector/tests/unit/mcp-proxy-security.test.ts
@@ -25,24 +25,24 @@ describe("Inspector MCP proxy request isolation", () => {
           "Access-Control-Request-Method": "POST",
           "Access-Control-Request-Headers": "mcp-method, x-target-url",
         },
-      }),
+      })
     );
     expect(allowed.status).toBe(204);
     expect(allowed.headers.get("access-control-allow-origin")).toBe(
-      "https://mochipi.dev",
+      "https://mochipi.dev"
     );
     expect(allowed.headers.get("access-control-allow-headers")).toContain(
-      "Mcp-Method",
+      "Mcp-Method"
     );
 
     const denied = await app.fetch(
       new Request(proxyUrl, {
         method: "OPTIONS",
         headers: { Origin: "https://attacker.example" },
-      }),
+      })
     );
     expect(denied.headers.get("access-control-allow-origin")).not.toBe(
-      "https://attacker.example",
+      "https://attacker.example"
     );
   });
 

--- a/libraries/typescript/packages/inspector/tests/unit/oauth-proxy-confidential.test.ts
+++ b/libraries/typescript/packages/inspector/tests/unit/oauth-proxy-confidential.test.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { mountOAuthProxy } from "../../src/server/proxy/oauth-proxy";
+import type { OAuthProxyStateStore } from "../../src/server/proxy/oauth-state-store";
 
 const inspectorOrigin = "https://inspector.example.com";
 const serverUrl = "https://93.184.216.34/mcp";
@@ -46,6 +47,21 @@ function proxyRequest(url: string, body: unknown): Request {
       body,
     }),
   });
+}
+
+function sharedStateStore(): OAuthProxyStateStore {
+  const values = new Map<string, unknown>();
+  return {
+    async get<T>(key: string) {
+      return values.get(key) as T | undefined;
+    },
+    async set<T>(key: string, value: T) {
+      values.set(key, structuredClone(value));
+    },
+    async delete(key: string) {
+      values.delete(key);
+    },
+  };
 }
 
 afterEach(() => {
@@ -153,6 +169,69 @@ describe("Inspector OAuth BFF confidential clients", () => {
     expect(await token.json()).toMatchObject({
       status: 200,
       body: { access_token: "redacted", token_type: "Bearer" },
+    });
+  });
+
+  it("shares bindings and DCR credentials across proxy replicas", async () => {
+    const fetchFn = vi.fn<typeof fetch>(async (input, init) => {
+      const url = input.toString();
+      if (url === resourceMetadataUrl) {
+        return jsonResponse({
+          resource: serverUrl,
+          authorization_servers: [issuer],
+        });
+      }
+      if (url === authorizationMetadataUrl) {
+        return jsonResponse({
+          issuer,
+          registration_endpoint: registrationUrl,
+          token_endpoint: tokenUrl,
+          token_endpoint_auth_methods_supported: ["client_secret_post"],
+        });
+      }
+      if (url === registrationUrl) {
+        return jsonResponse({
+          client_id: "shared-client",
+          client_secret: "shared-secret",
+          client_secret_expires_at: 0,
+          token_endpoint_auth_method: "client_secret_post",
+        });
+      }
+      if (url === tokenUrl) {
+        const params = new URLSearchParams(String(init?.body));
+        expect(params.get("client_secret")).toBe("shared-secret");
+        return jsonResponse({ access_token: "shared-token" });
+      }
+      return new Response("not found", { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchFn);
+
+    const stateStore = sharedStateStore();
+    const firstReplica = new Hono();
+    const secondReplica = new Hono();
+    mountOAuthProxy(firstReplica, { basePath: "/oauth", enableLogging: false, stateStore });
+    mountOAuthProxy(secondReplica, { basePath: "/oauth", enableLogging: false, stateStore });
+
+    expect((await firstReplica.fetch(metadataRequest(resourceMetadataUrl))).status).toBe(200);
+    expect((await firstReplica.fetch(metadataRequest(authorizationMetadataUrl))).status).toBe(200);
+
+    const registration = await firstReplica.fetch(
+      proxyRequest(registrationUrl, { client_name: "shared" }),
+    );
+    expect((await registration.json()).body).toMatchObject({
+      client_id: "shared-client",
+      token_endpoint_auth_method: "none",
+    });
+
+    const token = await secondReplica.fetch(
+      proxyRequest(tokenUrl, {
+        grant_type: "authorization_code",
+        client_id: "shared-client",
+      }),
+    );
+    expect(await token.json()).toMatchObject({
+      status: 200,
+      body: { access_token: "shared-token" },
     });
   });
 });

--- a/libraries/typescript/packages/inspector/tests/unit/oauth-proxy-confidential.test.ts
+++ b/libraries/typescript/packages/inspector/tests/unit/oauth-proxy-confidential.test.ts
@@ -209,14 +209,27 @@ describe("Inspector OAuth BFF confidential clients", () => {
     const stateStore = sharedStateStore();
     const firstReplica = new Hono();
     const secondReplica = new Hono();
-    mountOAuthProxy(firstReplica, { basePath: "/oauth", enableLogging: false, stateStore });
-    mountOAuthProxy(secondReplica, { basePath: "/oauth", enableLogging: false, stateStore });
+    mountOAuthProxy(firstReplica, {
+      basePath: "/oauth",
+      enableLogging: false,
+      stateStore,
+    });
+    mountOAuthProxy(secondReplica, {
+      basePath: "/oauth",
+      enableLogging: false,
+      stateStore,
+    });
 
-    expect((await firstReplica.fetch(metadataRequest(resourceMetadataUrl))).status).toBe(200);
-    expect((await firstReplica.fetch(metadataRequest(authorizationMetadataUrl))).status).toBe(200);
+    expect(
+      (await firstReplica.fetch(metadataRequest(resourceMetadataUrl))).status
+    ).toBe(200);
+    expect(
+      (await firstReplica.fetch(metadataRequest(authorizationMetadataUrl)))
+        .status
+    ).toBe(200);
 
     const registration = await firstReplica.fetch(
-      proxyRequest(registrationUrl, { client_name: "shared" }),
+      proxyRequest(registrationUrl, { client_name: "shared" })
     );
     expect((await registration.json()).body).toMatchObject({
       client_id: "shared-client",
@@ -227,7 +240,7 @@ describe("Inspector OAuth BFF confidential clients", () => {
       proxyRequest(tokenUrl, {
         grant_type: "authorization_code",
         client_id: "shared-client",
-      }),
+      })
     );
     expect(await token.json()).toMatchObject({
       status: 200,

--- a/libraries/typescript/packages/inspector/tsup.server.ts
+++ b/libraries/typescript/packages/inspector/tsup.server.ts
@@ -6,6 +6,7 @@ const bundledServerDependencies = [
   "@hono/node-server",
   "@mcp-use/client",
   "open",
+  "redis",
   "rate-limiter-flexible",
 ];
 const rateLimiterMemoryShim = fileURLToPath(

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -427,9 +427,6 @@ importers:
       mcp-use:
         specifier: workspace:*
         version: link:../server
-      redis:
-        specifier: ^5.8.2
-        version: 5.12.1(@opentelemetry/api@1.9.1)
     devDependencies:
       '@base-ui/react':
         specifier: ^1.6.0
@@ -503,6 +500,9 @@ importers:
       react-resizable-panels:
         specifier: ^4.6.4
         version: 4.6.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      redis:
+        specifier: ^5.8.2
+        version: 5.12.1(@opentelemetry/api@1.9.1)
       react-router:
         specifier: ^8.3.0
         version: 8.3.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -427,6 +427,9 @@ importers:
       mcp-use:
         specifier: workspace:*
         version: link:../server
+      redis:
+        specifier: ^5.8.2
+        version: 5.12.1(@opentelemetry/api@1.9.1)
     devDependencies:
       '@base-ui/react':
         specifier: ^1.6.0
@@ -4096,6 +4099,42 @@ packages:
   '@radix-ui/rect@1.1.3':
     resolution: {integrity: sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==}
 
+  '@redis/bloom@5.12.1':
+    resolution: {integrity: sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA==}
+    engines: {node: '>= 18.19.0'}
+    peerDependencies:
+      '@redis/client': ^5.12.1
+
+  '@redis/client@5.12.1':
+    resolution: {integrity: sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==}
+    engines: {node: '>= 18.19.0'}
+    peerDependencies:
+      '@node-rs/xxhash': ^1.1.0
+      '@opentelemetry/api': '>=1 <2'
+    peerDependenciesMeta:
+      '@node-rs/xxhash':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+
+  '@redis/json@5.12.1':
+    resolution: {integrity: sha512-eOze75esLve4vfqDel7aMX08CNaiLLQS2fV8mpRN9NxPe1rVR4vQyYiW/OgtGUysF6QOr9ANhfxABKNOJfXdKg==}
+    engines: {node: '>= 18.19.0'}
+    peerDependencies:
+      '@redis/client': ^5.12.1
+
+  '@redis/search@5.12.1':
+    resolution: {integrity: sha512-ItlxbxC9cKI6IU1TLWoczwJCRb6TdmkEpWv05UrPawqaAnWGRu3rcIqsc5vN483T2fSociuyV1UkWIL5I4//2w==}
+    engines: {node: '>= 18.19.0'}
+    peerDependencies:
+      '@redis/client': ^5.12.1
+
+  '@redis/time-series@5.12.1':
+    resolution: {integrity: sha512-c6JL6E3EcZJuNqKFz+KM+l9l5mpcQiKvTwgA3blt5glWJ8hjDk0yeHN3beE/MpqYIQ8UEX44ItQzgkE/gCBELQ==}
+    engines: {node: '>= 18.19.0'}
+    peerDependencies:
+      '@redis/client': ^5.12.1
+
   '@rolldown/binding-android-arm64@1.0.3':
     resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -5644,6 +5683,10 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -7977,6 +8020,10 @@ packages:
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  redis@5.12.1:
+    resolution: {integrity: sha512-LDsoVvb/CpoV9EN3FXvgvSHNJWuCIzl9MiO3ppOevuGLpSGJhwfQjpEwfFJcQvNSddHADDdZaWx0HnmMxRXG7g==}
+    engines: {node: '>= 18.19.0'}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -11430,6 +11477,28 @@ snapshots:
 
   '@radix-ui/rect@1.1.3': {}
 
+  '@redis/bloom@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
+
+  '@redis/client@5.12.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      cluster-key-slot: 1.1.2
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@redis/json@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
+
+  '@redis/search@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
+
+  '@redis/time-series@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
+
   '@rolldown/binding-android-arm64@1.0.3':
     optional: true
 
@@ -12821,6 +12890,8 @@ snapshots:
   clsx@1.1.1: {}
 
   clsx@2.1.1: {}
+
+  cluster-key-slot@1.1.2: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -15404,6 +15475,17 @@ snapshots:
       picomatch: 4.0.4
 
   readdirp@4.1.2: {}
+
+  redis@5.12.1(@opentelemetry/api@1.9.1):
+    dependencies:
+      '@redis/bloom': 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))
+      '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
+      '@redis/json': 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))
+      '@redis/search': 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))
+      '@redis/time-series': 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))
+    transitivePeerDependencies:
+      - '@node-rs/xxhash'
+      - '@opentelemetry/api'
 
   reflect.getprototypeof@1.0.10:
     dependencies:


### PR DESCRIPTION
## What changed

- make the hosted Inspector MCP proxy and OAuth BFF configurable through one route registration
- add exact-origin CORS configuration for MCP and OAuth, including the MCP protocol headers used by modern Streamable HTTP/subscriptions
- persist OAuth metadata bindings and confidential DCR credentials in a shared Redis store with AES-256-GCM value encryption
- fail closed in production when shared OAuth state or its encryption key is missing
- add a provider-neutral server-side confidential-client resolver for configured providers (for example Google Workspace); secrets never enter browser responses or logs
- keep local development and unit tests on an in-memory store

## Why

The browser-facing OAuth relay previously kept DCR state in process-local Maps, so a registration on one Railway replica could not be followed by a token exchange on another. The hosted MCP proxy also used a wildcard CORS policy with an incomplete MCP header set. This PR makes the hosted Inspector the single relay boundary while preserving SSRF, redirect, streaming, and secret-handling protections.

## Verification

- `git diff --check`
- server TypeScript check passes for the changed files; the workspace still reports the pre-existing missing `@mcp-use/client/sandbox` build artifact in `inspector-shell.ts`
- added unit coverage for exact MCP CORS and cross-replica DCR/token state sharing

## Deployment requirements

Before switching Cloud/MochiPi to hosted OAuth, configure the Inspector Railway service through the secret manager with:

- `INSPECTOR_OAUTH_REDIS_URL` (or `REDIS_URL`)
- `INSPECTOR_OAUTH_ENCRYPTION_KEY` (base64-encoded 32-byte key)
- `INSPECTOR_OAUTH_ALLOWED_ORIGINS` (exact Cloud/MochiPi origins)
- `INSPECTOR_MCP_ALLOWED_ORIGINS` (exact browser origins; defaults to OAuth origins)
- `INSPECTOR_OAUTH_CONFIDENTIAL_CLIENTS_JSON` for server-owned confidential providers

Do not merge the dependent Cloud PR until this version is deployed and the hosted OAuth callback has been browser-tested.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the hosted Inspector's process-local OAuth state with a shared Redis store and restricts MCP CORS to exact origins, making the hosted Inspector a single relay boundary for both MCP and OAuth. OAuth DCR and token exchanges now work across replicas, replicas re-read confidential-client credentials from the shared store when a local cache is empty, the Redis connection closes cleanly on shutdown, and production fails closed if Redis or the encryption key is missing.

**Migration**
- Set `INSPECTOR_OAUTH_REDIS_URL`, `INSPECTOR_OAUTH_ENCRYPTION_KEY`, and `INSPECTOR_OAUTH_ALLOWED_ORIGINS` before routing OAuth traffic to the hosted Inspector.
- Optionally set `INSPECTOR_MCP_ALLOWED_ORIGINS` (defaults to OAuth origins) and `INSPECTOR_OAUTH_CONFIDENTIAL_CLIENTS_JSON` for server-side confidential clients.

<sup>Written for commit 5e273c1bf938aaa39c102509ea3e5fbb016893b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

