### PR TITLE
fix(cli): use native file watching on Windows

### DIFF
--- a/libraries/typescript/.changeset/native-windows-watch.md
+++ b/libraries/typescript/.changeset/native-windows-watch.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/cli": patch
+---
+
+Use native Windows file watching in dev mode instead of forcing polling.

--- a/libraries/typescript/packages/cli/src/cli/dev.ts
+++ b/libraries/typescript/packages/cli/src/cli/dev.ts
@@ -468,12 +468,6 @@ export async function runDev(options: DevOptions): Promise<void> {
         // broadcast `full-reload` forever, so srcdoc view guests repeatedly
         // remount and surface a compiling spinner instead of Fast Refresh.
         ignored: "**/.dev-server-logs.txt",
-        // Windows file notifications can be coalesced or dropped while Vite
-        // is transforming the same module. Polling keeps dev reloads reliable.
-        ...(process.platform === "win32" && {
-          usePolling: true,
-          interval: 100,
-        }),
       },
       // A public/wildcard bind deliberately accepts hostnames that are only
       // known to the surrounding platform (for example a sandbox URL). Keep


### PR DESCRIPTION
## Summary

- stop forcing Chokidar polling for the CLI dev server on Windows
- let Vite use the native Windows watcher
- keep the existing dev-server log exclusion unchanged

## Why

This tests the Windows-specific hypothesis from #2273 directly. The current 100 ms polling override can establish its initial baseline after a test edits a watched file, causing the update to be missed permanently rather than merely delayed. Native watching removes that polling startup window.

## Validation

- `pnpm exec vitest run tests/cli/dev.test.ts` — 34 passed
- `pnpm run typecheck` — passed
- `pnpm exec eslint packages/cli/src/cli/dev.ts` — passed
- `pnpm exec prettier --check packages/cli/src/cli/dev.ts .changeset/native-windows-watch.md` — passed
- `pnpm run build` — passed

## Verification boundary

Local validation ran on macOS and proves the existing dev/HMR suite still passes there. The Windows Actions job is the intended verification for the watcher change, as requested in #2273; no timeout was increased and no test expectation was weakened.

Addresses the Windows watcher path in #2273.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Uses native Windows file watching for the CLI dev server instead of forcing Chokidar polling. The old 100 ms polling override could establish its baseline after a file edit and permanently miss the update, so native watching removes that startup window and addresses the Windows watcher path in #2273.

<sup>Written for commit 29778fe5be7e2e9133f9363fc6e4c87e06ede86d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

