### PR TITLE
docs(inspector): remove unsupported WebSocket and stdio transport claims

### DIFF
--- a/libraries/typescript/packages/inspector/README.md
+++ b/libraries/typescript/packages/inspector/README.md
@@ -145,7 +145,7 @@ The main dashboard is your central hub for managing MCP server connections:
 To connect to an MCP server:
 
 1. **Open Connect Panel**: Click the Connect panel on the right side of the dashboard
-2. **Configure Transport**: The Inspector connects over Streamable HTTP (SSE is supported for legacy servers; WebSocket and stdio are not supported)
+2. **Configure Transport**: The Inspector supports Streamable HTTP only.
 3. **Enter Server URL**: Input the MCP server endpoint (e.g., `https://mcp.linear.app/mcp`)
 4. **Configure Authentication** (if needed): Add OAuth credentials or API headers
 5. **Click Connect**: Establish the connection

--- a/libraries/typescript/packages/inspector/README.md
+++ b/libraries/typescript/packages/inspector/README.md
@@ -63,7 +63,7 @@ For detailed usage instructions and guides, visit [mcp-use.com/docs/inspector](h
 | **📁 Resource Browser**    | View and copy resource URIs with syntax highlighting                    |
 | **🧩 Skills Explorer**     | Browse, verify, and preview Skills over MCP files                        |
 | **💬 Prompt Manager**      | Test and manage prompts with argument templates                         |
-| **🌐 Universal Support**   | Works with HTTP/SSE and WebSocket connections                           |
+| **🌐 Universal Support**   | Works with HTTP/SSE server connections                               |
 | **🎨 Widget Support**      | Full support for MCP-UI and OpenAI Apps SDK widgets                     |
 | **🔑 BYOK Chat**           | Bring Your Own Key chat interface for testing conversational flows      |
 | **📚 Skill-aware Chat**    | Test progressive skill loading with removable per-chat context          |
@@ -145,10 +145,7 @@ The main dashboard is your central hub for managing MCP server connections:
 To connect to an MCP server:
 
 1. **Open Connect Panel**: Click the Connect panel on the right side of the dashboard
-2. **Configure Transport**:
-   - Select "Streamable HTTP" for SSE connections
-   - Select "WebSocket" for WS connections
-   - Configure "stdin/stdio" for local process connections
+2. **Configure Transport**: The Inspector connects over Streamable HTTP (SSE is supported for legacy servers; WebSocket and stdio are not supported)
 3. **Enter Server URL**: Input the MCP server endpoint (e.g., `https://mcp.linear.app/mcp`)
 4. **Configure Authentication** (if needed): Add OAuth credentials or API headers
 5. **Click Connect**: Establish the connection


### PR DESCRIPTION
## Description

Fixes #2361

The Inspector README advertised transports that are not implemented:

- **Key Features** claimed "Works with HTTP/SSE and WebSocket connections"
- **Adding an MCP Server** instructed users to select "WebSocket" and configure "stdin/stdio"

The client only supports Streamable HTTP, with SSE still accepted for legacy saved connections (see `ConnectionSettingsForm.tsx` — `transportType: "http", // HTTP only - SSE is deprecated`; the transport selector was removed from the connect form).

This PR updates both spots to describe only the supported options.

## Checklist

- [x] Documentation-only change (no code affected)
- [x] Verified no WebSocket/stdio transport plumbing exists in the Inspector client/server
- [x] Scoped to avoid overlap with #2357 (which touches other sections of this README)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes unsupported WebSocket and stdio transport claims from the Inspector README so docs match the Streamable HTTP-only client, fixing #2361.

- Updates the Key Features table and "Adding an MCP Server" steps to describe only Streamable HTTP.
- Notes that SSE remains supported for legacy servers.

<sup>Written for commit f9a32d0a8e5be2168a944b12170d833545e266bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

