### PR TITLE
feat(inspector): show request duration instead of timestamp in RPC logger

### DIFF
--- a/libraries/typescript/.changeset/rpc-logger-duration.md
+++ b/libraries/typescript/.changeset/rpc-logger-duration.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Inspector RPC logger: replace the per-row timestamp with the request duration in milliseconds

--- a/libraries/typescript/packages/inspector/src/client/components/logging/JsonRpcLoggerView.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/logging/JsonRpcLoggerView.tsx
@@ -421,28 +421,23 @@ function RpcLogRow({
           ) : null}
         </span>
 
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              responseLabel ? (
+        {responseLabel ? (
+          <Tooltip>
+            <TooltipTrigger
+              render={
                 <span className="shrink-0 cursor-default font-mono text-[10px] tabular-nums text-muted-foreground underline decoration-dotted underline-offset-2">
                   {responseLabel.latencyMs} ms
                 </span>
-              ) : (
-                <time
-                  dateTime={item.timestamp}
-                  className="shrink-0 cursor-default font-mono text-[10px] tabular-nums text-muted-foreground underline decoration-dotted underline-offset-2"
-                >
-                  {new Date(item.timestamp).toLocaleTimeString()}
-                </time>
-              )
-            }
-            nativeButton={false}
-          />
-          <TooltipContent side="left">
-            {new Date(item.timestamp).toLocaleString()}
-          </TooltipContent>
-        </Tooltip>
+              }
+              nativeButton={false}
+            />
+            <TooltipContent side="left">
+              {`Request took ${responseLabel.latencyMs} ms (${new Date(
+                item.timestamp
+              ).toLocaleString()})`}
+            </TooltipContent>
+          </Tooltip>
+        ) : null}
       </button>
 
       {expanded ? (
@@ -472,10 +467,7 @@ function getMethod(
   responseLabels: ReadonlyMap<string, RpcTrafficResponseLabel>
 ): string {
   const responseLabel = responseLabels.get(entry.id);
-  if (responseLabel) {
-    const errorSuffix = responseLabel.outcome === "error" ? " · error" : "";
-    return `${responseLabel.method} · ${responseLabel.latencyMs} ms${errorSuffix}`;
-  }
+  if (responseLabel) return responseLabel.method;
 
   const fromMessage = getRpcTrafficMethod(entry.message);
   if (fromMessage) return fromMessage;


### PR DESCRIPTION
## Description

Fixes #2327 (follow-up to #2303)

The RPC log rows rendered the wall-clock timestamp on the right of each row, while the request latency was squeezed into the truncated method label. Per the issue, the timestamp is rarely useful compared to how long the request actually took, and the inline latency contributed to text truncation.

This PR:

- Moves the latency (`42 ms`) into the right-side slot where the timestamp rendered, keeping the dotted-underline tooltip (now showing `Request took 42 ms (<wall-clock time>)`).
- Removes the inline `· 42 ms` from the truncated method label so longer method names are less likely to be cut off.
- Rows without a measured duration (notifications, pending requests) render no right-side time.
- Search matching and row `data-testid`s now use the bare method name instead of `method · 42 ms`.

No changes to the correlation layer were needed — `buildRpcTrafficResponseLabels` already computes per-pair latency client-side.

## Testing

- `pnpm vitest run` for `rpc-traffic-correlation` and `rpc-traffic-store` (11 tests, unchanged and passing)
- `pnpm type-check` (after building workspace deps)
- `eslint` on the changed file
- Manual: connect to a server in the inspector, observe durations on response rows

## Changeset

Added a `patch` changeset for `@mcp-use/inspector`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2327 by showing the request duration instead of the wall-clock timestamp in RPC log rows, so you can see latency at a glance.

- Moves the latency (e.g., `42 ms`) to the right-side slot where the timestamp rendered; the tooltip now shows both latency and the original wall-clock time.
- Removes the inline `· 42 ms` from the method label so longer method names are less likely to be truncated.
- Rows without a measured duration (notifications, pending requests) render no right-side time.
- Search matching and row `data-testid`s now use the bare method name instead of `method · 42 ms`.
- Adds a `patch` changeset for `@mcp-use/inspector`.

<sup>Written for commit 272f19205911dd222a40889c0a83e6683980b9a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

