### PR TITLE
feat(python): support Python 3.13 and 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ permissions:
 #
 # 2. Python Tests (runs if libraries/python/** changed)
 #    ├─ python-lint: Ruff linting and formatting checks
-#    ├─ python-unit-tests: Matrix [Python 3.11, 3.12]
+#    ├─ python-unit-tests: Matrix [Python 3.11, 3.12, 3.13, 3.14]
 #    ├─ python-transport-tests: Matrix [stdio, sse, streamable_http]
 #    │  └─ python-transport-tests-report: Posts PR comment with test results table
 #    ├─ python-primitive-tests: Matrix [7 MCP primitives]
@@ -203,8 +203,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
         deps: ["latest", "minimum"]
+        exclude:
+          # Minimum direct-dependency versions (e.g. pydantic 2.11 via
+          # pydantic-core 2.33, pillow 10.4 via fastembed 0.3) predate
+          # Python 3.14 and ship no wheels for it, so lowest-direct
+          # resolution cannot install. Minimum bounds stay covered on
+          # 3.11-3.13; 3.14 is tested with latest resolution.
+          - python-version: "3.14"
+            deps: "minimum"
     defaults:
       run:
         working-directory: libraries/python

--- a/libraries/python/DEPENDENCY_POLICY.md
+++ b/libraries/python/DEPENDENCY_POLICY.md
@@ -5,8 +5,8 @@ This document describes how mcp-use manages its dependencies for the Python SDK.
 ## Python Version Support
 
 - **Minimum supported**: Python 3.11
-- **Tested on CI**: Python 3.11, 3.12
-- **Policy**: We support the two most recent minor Python versions. When a new Python version is released, we add support within one release cycle and may drop the oldest supported version with a major version bump.
+- **Tested on CI**: Python 3.11, 3.12, 3.13, 3.14 (minimum direct-dependency resolution is tested on 3.11–3.13; the minimum versions of some transitive dependencies ship no Python 3.14 wheels, so 3.14 is tested with latest resolution)
+- **Policy**: We support Python 3.11 and newer. When a new minor Python version is released, we add classifiers and CI coverage within one release cycle; dropping the oldest supported version requires a major version bump.
 
 ## MCP SDK (`mcp` package)
 

--- a/libraries/python/pyproject.toml
+++ b/libraries/python/pyproject.toml
@@ -17,6 +17,8 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [


### PR DESCRIPTION
## Description

Fixes #1778

Python 3.13/3.14 users hit install failures and neither version is tested in CI. This PR adds both versions to the package classifiers and the CI unit-test matrix, with one deliberate exclusion: the **minimum**-resolution job on 3.14.

Why the exclusion: with lowest-direct resolution, some minimum transitive pins predate Python 3.14 and ship no wheels for it — `pydantic==2.11.0` pulls `pydantic-core==2.33.0` and `fastembed==0.3.0` pulls `pillow==10.4.0`, both failing to build from source on 3.14 (details in #1778). Bumping minimum bounds just for a new interpreter would restrict users on 3.11–3.13, so minimum bounds stay tested on 3.11–3.13 and 3.14 runs with latest resolution.

This reapplies the approach from #1856 (closed unmerged):

1. `libraries/python/pyproject.toml`: added `3.13` and `3.14` trove classifiers.
2. `.github/workflows/ci.yml`: `python-unit` matrix extended to `["3.11", "3.12", "3.13", "3.14"]` with an `exclude` for `3.14 × minimum`; header comment updated.
3. `libraries/python/DEPENDENCY_POLICY.md`: tested-versions statement updated to match.

No dependency bounds changed; `requires-python >= 3.11` unchanged.

## Testing

- Validated workflow YAML parses with the expected matrix and exclusion (js-yaml).
- Validated `pyproject.toml` parses with the new classifiers (tomllib).
- CI on this PR will exercise the new matrix entries (3.13/3.14 × latest, 3.13 × minimum).

## Related

- Closes #1778
- Reapplies #1856 (closed unmerged)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1778 by adding Python 3.13 and 3.14 support to the Python library, so installs no longer fail on those versions. The minimum-resolution CI job is excluded on 3.14 because some pinned minimum transitive versions ship no 3.14 wheels; minimum bounds stay tested on 3.11–3.13.

**Changes**
- Adds `3.13` and `3.14` trove classifiers to `pyproject.toml`.
- Extends the CI unit-test matrix to include 3.13 and 3.14.
- Updates `DEPENDENCY_POLICY.md` tested versions and changes support policy to Python 3.11 and newer.

<sup>Written for commit a257abfcf17bbd84b9a06629a405a4cb055033c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

