### PR TITLE
fix(client): stop OAuth retries after disconnect

### DIFF
--- a/libraries/typescript/.changeset/calm-clients-stop.md
+++ b/libraries/typescript/.changeset/calm-clients-stop.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/client": patch
+---
+
+Stop OAuth authorization retries after the client disconnects.

--- a/libraries/typescript/packages/client/src/transport/http.ts
+++ b/libraries/typescript/packages/client/src/transport/http.ts
@@ -318,6 +318,9 @@ export class HttpConnector extends BaseConnector {
         throw error;
       }
       await this.completeInteractiveAuthorization();
+      if (!this.connected || !this.client) {
+        throw new Error("MCP client is not connected");
+      }
       return operation();
     }
   }

--- a/libraries/typescript/packages/client/tests/unit/client/mixed-auth.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/client/mixed-auth.test.ts
@@ -174,6 +174,45 @@ describe("mixed OAuth authorization", () => {
     });
   });
 
+  it("does not retry a protected operation after disconnecting during OAuth", async () => {
+    let finishAuthorization!: () => void;
+    const authorization = new Promise<void>((resolve) => {
+      finishAuthorization = resolve;
+    });
+    const callTool = vi
+      .fn()
+      .mockRejectedValueOnce(new UnauthorizedError("Authentication required"));
+    const connector = new HttpConnector("https://mcp.example.com/mcp", {
+      authProvider: createProvider({
+        getAuthorizationResponse: vi.fn(async () => {
+          await authorization;
+          return {
+            code: "authorization-code",
+            iss: "https://auth.example.com",
+          };
+        }),
+      }),
+      detectMixedAuth: false,
+    });
+    attachConnectedClient(
+      connector,
+      { callTool, getProtocolEra: () => "modern" },
+      {
+        finishAuth: vi.fn(async () => {}),
+      }
+    );
+
+    const request = connector.callTool("build", {});
+    await vi.waitFor(() => {
+      expect(callTool).toHaveBeenCalledOnce();
+    });
+    await connector.disconnect();
+    finishAuthorization();
+
+    await expect(request).rejects.toThrow("MCP client is not connected");
+    expect(callTool).toHaveBeenCalledOnce();
+  });
+
   it("leaves a protected operation pending when automatic auth is disabled", async () => {
     const finishAuth = vi.fn(async () => {});
     const connector = new HttpConnector("https://mcp.example.com/mcp", {


### PR DESCRIPTION
## Summary

- re-check the HTTP connector state after interactive OAuth completes
- return the existing clean not-connected error when a disconnect wins the OAuth wait
- cover the race and verify that the protected operation is not retried

Fixes #2366.

## Validation

From `libraries/typescript/packages/client`:

- `./node_modules/.bin/vitest run tests/unit/client/mixed-auth.test.ts` — 7 passed
- `../../node_modules/.bin/rimraf dist && ../../node_modules/.bin/tsup && ../../node_modules/.bin/tsc --emitDeclarationOnly --declaration` — passed
- `./node_modules/.bin/vitest run` — 56 files, 344 tests passed

From `libraries/typescript`:

- `./node_modules/.bin/eslint packages/client/src/transport/http.ts packages/client/tests/unit/client/mixed-auth.test.ts` — passed
- `./node_modules/.bin/prettier --check packages/client/src/transport/http.ts packages/client/tests/unit/client/mixed-auth.test.ts` — passed

## Risk

The added guard runs only after an interactive OAuth wait and immediately before the retry. Connected retries are unchanged; a connector disconnected during the wait now rejects deterministically instead of invoking a closure whose client was cleared.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2366 by preventing a protected operation from retrying after interactive OAuth when the connector disconnected during the wait. The operation now rejects deterministically with "MCP client is not connected" instead of invoking a closure whose client was cleared.

- Adds a patch changeset for `@mcp-use/client`.

<sup>Written for commit f0dafa9f70a52b5d927b07ceaa61ef453551c4b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

