### PR TITLE
fix(python): surface SSE transport fallback

### DIFF
--- a/libraries/python/mcp_use/client/connectors/http.py
+++ b/libraries/python/mcp_use/client/connectors/http.py
@@ -254,14 +254,16 @@ class HttpConnector(BaseConnector):
         # Exception from the inner try is propagated here and in
         # the most cases is an McpError, so checking instances is useless
         except Exception as streamable_error:
-            logger.debug(f"Streamable HTTP failed: {streamable_error}")
+            logger.warning("Streamable HTTP connection failed (%s)", type(streamable_error).__name__)
+            logger.debug("Streamable HTTP failure details: %s", streamable_error)
 
             # Clean up the failed streamable HTTP connection manager
             if connection_manager:
                 try:
-                    await connection_manager.close()
-                except Exception:
-                    pass
+                    await connection_manager.stop()
+                except Exception as cleanup_error:
+                    logger.warning("Failed to stop streamable HTTP connection (%s)", type(cleanup_error).__name__)
+                    logger.debug("Streamable HTTP cleanup failure details: %s", cleanup_error)
 
             # It doesn't make sense to check error types. Because client
             # always return a McpError, if he can't reach the server
@@ -271,7 +273,7 @@ class HttpConnector(BaseConnector):
             if should_fallback:
                 try:
                     # Fall back to the old SSE transport
-                    logger.debug(f"Attempting SSE fallback connection to: {self.base_url}")
+                    logger.info("Falling back to SSE transport")
                     connection_manager = SseConnectionManager(
                         self.base_url,
                         self.headers,

--- a/libraries/python/tests/unit/test_http_connector.py
+++ b/libraries/python/tests/unit/test_http_connector.py
@@ -12,7 +12,7 @@ from mcp.types import EmptyResult, ErrorData, Prompt, Resource, Tool
 from mcp_use.client.auth.bearer import BearerAuth
 from mcp_use.client.connectors.http import HttpConnector
 from mcp_use.client.middleware.middleware import CallbackClientSession
-from mcp_use.client.task_managers import SseConnectionManager
+from mcp_use.client.task_managers import SseConnectionManager, StreamableHttpConnectionManager
 
 
 @patch("mcp_use.client.connectors.base.logger")
@@ -96,16 +96,24 @@ class TestHttpConnectorConnection(IsolatedAsyncioTestCase):
         self.mock_client_session = MagicMock()
         self.mock_client_session.__aenter__ = AsyncMock()
 
+    @patch("mcp_use.client.connectors.http.logger")
     @patch("mcp_use.client.connectors.http.SseConnectionManager")
     @patch("mcp_use.client.connectors.http.StreamableHttpConnectionManager")
     @patch("mcp_use.client.connectors.http.ClientSession")
-    async def test_connect_with_sse(self, mock_client_session_class, mock_streamable_cm_class, mock_sse_cm_class, _):
+    async def test_connect_with_sse(
+        self,
+        mock_client_session_class,
+        mock_streamable_cm_class,
+        mock_sse_cm_class,
+        mock_http_logger,
+        _,
+    ):
         """Test connecting to the MCP implementation using SSE fallback."""
         # Setup streamable HTTP to fail during initialization
-        mock_streamable_cm_instance = MagicMock()
+        mock_streamable_cm_instance = MagicMock(spec_set=StreamableHttpConnectionManager)
         mock_streamable_cm_instance.start = AsyncMock()
         mock_streamable_cm_instance.start.return_value = ("read_stream", "write_stream")
-        mock_streamable_cm_instance.close = AsyncMock()
+        mock_streamable_cm_instance.stop = AsyncMock()
         mock_streamable_cm_class.return_value = mock_streamable_cm_instance
 
         # Setup SSE to succeed
@@ -117,6 +125,8 @@ class TestHttpConnectorConnection(IsolatedAsyncioTestCase):
         # Setup client sessions
         call_count = 0
 
+        streamable_error = McpError(ErrorData(code=1, message="Connection closed"))
+
         def mock_client_session_factory(*args, **kwargs):
             nonlocal call_count
             call_count += 1
@@ -127,7 +137,7 @@ class TestHttpConnectorConnection(IsolatedAsyncioTestCase):
 
             if call_count == 1:
                 # First call (streamable HTTP) - initialization fails
-                mock_instance.initialize.side_effect = McpError(ErrorData(code=1, message="Connection closed"))
+                mock_instance.initialize.side_effect = streamable_error
             else:
                 # Second call (SSE) - succeeds
                 mock_init_result = MagicMock()
@@ -160,6 +170,11 @@ class TestHttpConnectorConnection(IsolatedAsyncioTestCase):
         self.assertEqual(self.connector._connection_manager, mock_sse_cm_instance)
         self.assertTrue(self.connector._connected)
         self.assertIsNotNone(self.connector.client_session)
+        mock_streamable_cm_instance.stop.assert_awaited_once_with()
+        mock_http_logger.warning.assert_called_once_with(
+            "Streamable HTTP connection failed (%s)", type(streamable_error).__name__
+        )
+        mock_http_logger.info.assert_called_once_with("Falling back to SSE transport")
 
     @patch("mcp_use.client.connectors.http.StreamableHttpConnectionManager")
     @patch("mcp_use.client.connectors.http.ClientSession")
@@ -236,15 +251,19 @@ class TestHttpConnectorConnection(IsolatedAsyncioTestCase):
         # Verify connection manager was not created or started
         mock_cm_class.assert_not_called()
 
+    @patch("mcp_use.client.connectors.http.logger")
     @patch("mcp_use.client.connectors.http.SseConnectionManager")
     @patch("mcp_use.client.connectors.http.StreamableHttpConnectionManager")
-    async def test_connect_failure(self, mock_streamable_cm_class, mock_sse_cm_class, _):
+    async def test_connect_failure(self, mock_streamable_cm_class, mock_sse_cm_class, mock_http_logger, _):
         """Test handling connection failures."""
         # Setup mocks for streamable HTTP failure
-        mock_streamable_cm_instance = MagicMock()
+        streamable_error = Exception("Streamable HTTP failed")
+        cleanup_error = Exception("Streamable HTTP cleanup failed")
+        mock_streamable_cm_instance = MagicMock(spec_set=StreamableHttpConnectionManager)
         mock_streamable_cm_instance.start = AsyncMock()
-        mock_streamable_cm_instance.close = AsyncMock()
-        mock_streamable_cm_instance.start.side_effect = Exception("Streamable HTTP failed")
+        mock_streamable_cm_instance.stop = AsyncMock()
+        mock_streamable_cm_instance.start.side_effect = streamable_error
+        mock_streamable_cm_instance.stop.side_effect = cleanup_error
         mock_streamable_cm_class.return_value = mock_streamable_cm_instance
 
         # Setup mocks for SSE failure (fallback)
@@ -269,6 +288,14 @@ class TestHttpConnectorConnection(IsolatedAsyncioTestCase):
         self.assertIsNone(self.connector.client_session)
         self.assertIsNone(self.connector._connection_manager)
         self.assertFalse(self.connector._connected)
+        mock_streamable_cm_instance.stop.assert_awaited_once_with()
+        mock_http_logger.warning.assert_has_calls(
+            [
+                call("Streamable HTTP connection failed (%s)", type(streamable_error).__name__),
+                call("Failed to stop streamable HTTP connection (%s)", type(cleanup_error).__name__),
+            ]
+        )
+        mock_http_logger.info.assert_called_once_with("Falling back to SSE transport")
 
     async def test_disconnect(self, _):
         """Test disconnecting from the MCP implementation."""


### PR DESCRIPTION
## Description

Fixes #2369.

When streamable HTTP failed, the transport change was only visible at debug level. The cleanup path also called `close()` even though `StreamableHttpConnectionManager` exposes `stop()`, and swallowed the resulting error.

This change:

- emits a warning with the failure category before fallback
- announces the SSE fallback at info level
- keeps detailed exception text at debug level and endpoint data out of default-visible logs
- stops the failed streamable HTTP manager through its supported lifecycle method
- tightens the fallback tests with spec-constrained mocks and cleanup assertions

## Testing

- `uv run --extra dev --extra e2b python -m pytest tests/unit -q` — 305 passed
- `ruff check .` — passed
- `ruff format --check .` — 228 files already formatted

## Backwards Compatibility

No public API changes. Successful streamable HTTP connections are unchanged; only failed-attempt cleanup and fallback visibility change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces the SSE transport fallback in logs so users can see when streamable HTTP fails and the client switches to SSE. Previously this was only visible at debug level, and cleanup called `close()` on a manager that exposes `stop()`, swallowing any cleanup errors.

- Emits a warning with the failure category before falling back and an info message when SSE takes over.
- Keeps detailed exception text and endpoint data at debug level.
- Stops the failed streamable HTTP manager via `stop()` and logs cleanup failures instead of swallowing them.
- Tightens fallback tests with spec-constrained mocks and cleanup assertions.

<sup>Written for commit 0803540b71cb783f3231fb3b0ee152ff65c982a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

